### PR TITLE
feat(datasets): upload CSV drawer + redesigned dropzone

### DIFF
--- a/langwatch/src/components/datasets/AddRowsFromCSVModal.tsx
+++ b/langwatch/src/components/datasets/AddRowsFromCSVModal.tsx
@@ -19,7 +19,7 @@ import {
 } from "../../server/datasets/types";
 import { api } from "../../utils/api";
 import { tryToConvertRowsToAppropriateType } from "../AddOrEditDatasetDrawer";
-import { CSVReaderComponent } from "./UploadCSVModal";
+import { CSVReaderComponent } from "./UploadCSVDrawer";
 
 export function AddRowsFromCSVModal({
   isOpen,

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -10,12 +10,14 @@ import {
   useDisclosure,
   VStack,
 } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import { keyframes } from "@emotion/react";
+import { useEffect, useRef, useState } from "react";
 import {
   CheckCircle,
   CloudUpload,
   FileText,
   Trash2,
+  X,
   XCircle,
 } from "lucide-react";
 import {
@@ -377,6 +379,10 @@ export function UploadCSVForm({
   // the file's row (sizeError + overRowLimitForFallback below).
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [sizeError, setSizeError] = useState<string | null>(null);
+  // Abort handle for the in-flight PUT + the pending dataset it minted, so a
+  // user-initiated cancel can stop the stream and reap the orphaned row.
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const pendingDatasetIdRef = useRef<string | null>(null);
 
   const getValidName = async (proposedName: string): Promise<string> => {
     if (!projectId) return proposedName;
@@ -431,7 +437,11 @@ export function UploadCSVForm({
     setIsUploading(true);
     setUploadError(null);
     // Track the pending dataset so a presigned-PUT failure can clean up the
-    // orphaned `uploading` row before falling back.
+    // orphaned `uploading` row before falling back. The refs mirror these so a
+    // user-initiated cancel can abort the stream and reap the same row.
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    pendingDatasetIdRef.current = null;
     let pendingDatasetId: string | undefined;
     try {
       const name =
@@ -442,9 +452,12 @@ export function UploadCSVForm({
         filename: rawFile.name,
       });
       pendingDatasetId = datasetId;
-      await putFileToPresignedUrl(uploadUrl, rawFile);
+      pendingDatasetIdRef.current = datasetId;
+      await putFileToPresignedUrl(uploadUrl, rawFile, controller.signal);
       await finalizeDirectUpload({ projectId, datasetId });
 
+      abortControllerRef.current = null;
+      pendingDatasetIdRef.current = null;
       if (onDirectUploadComplete) {
         // Hand off to the drawer host, which polls status and shows the
         // processing → ready/failed flow in place (no navigation).
@@ -460,6 +473,11 @@ export function UploadCSVForm({
         void router.push(`/${project.slug}/datasets/${datasetId}`);
       }
     } catch (error) {
+      // A user-initiated cancel aborts the PUT: handleCancelUpload already reset
+      // state and reaped the pending row, so there is nothing more to do here.
+      if (error instanceof Error && error.name === "AbortError") {
+        return;
+      }
       // Any failure AFTER requestDirectUpload minted the `uploading` row leaves
       // it behind and locks the slug — whether we fall back (a fresh dataset is
       // created) or surface the error (the upload is abandoned). Reap it either
@@ -501,6 +519,26 @@ export function UploadCSVForm({
       );
       setIsUploading(false);
     }
+  };
+
+  /**
+   * Cancel an in-flight direct upload: abort the streaming PUT and reap the
+   * pending `uploading` row so its slug isn't locked on retry. The file stays
+   * selected so the user can re-upload or remove it.
+   */
+  const handleCancelUpload = () => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    const pendingId = pendingDatasetIdRef.current;
+    pendingDatasetIdRef.current = null;
+    if (pendingId && projectId) {
+      void abortPendingUpload({ projectId, datasetId: pendingId }).catch(
+        (error) => {
+          logger.error({ error }, "Failed to clean up cancelled upload");
+        },
+      );
+    }
+    setIsUploading(false);
   };
 
   /**
@@ -575,6 +613,7 @@ export function UploadCSVForm({
         parse={!enableDirectUpload}
         uploadStatus={isUploading && enableDirectUpload ? "uploading" : undefined}
         fileError={fileError}
+        onCancel={handleCancelUpload}
         onUploadAccepted={handleUploadAccepted}
         onRawFile={(file) => {
           setRawFile(file);
@@ -605,6 +644,7 @@ export function UploadCSVForm({
         <Button
           colorPalette="blue"
           loading={isUploading}
+          loadingText="Uploading"
           disabled={!!disabled || isUploading || !canUpload}
           onClick={() => void handleUpload()}
         >
@@ -622,6 +662,7 @@ export function CSVReaderComponent({
   parse = true,
   uploadStatus,
   fileError,
+  onCancel,
   children,
 }: {
   onUploadAccepted: (results: {
@@ -647,6 +688,8 @@ export function CSVReaderComponent({
   uploadStatus?: "uploading";
   /** File-level validation/upload message; renders the file row in an error state. */
   fileError?: string;
+  /** Cancels an in-flight upload (no-parse path). Shows the X cancel control. */
+  onCancel?: () => void;
   children?: (hasAcceptedFile: boolean) => React.ReactNode;
 }) {
   if (!parse) {
@@ -656,6 +699,7 @@ export function CSVReaderComponent({
         onUploadRemoved={onUploadRemoved}
         uploadStatus={uploadStatus}
         fileError={fileError}
+        onCancel={onCancel}
       >
         {children}
       </RawFileDropzone>
@@ -902,7 +946,7 @@ const DROPZONE_DOTTED_STYLE: React.CSSProperties = {
 };
 
 /** Shared Chakra props for the dashed dropzone surface; highlights when active
- *  (dragging a file over it) and on hover. */
+ *  (dragging a file over it) and on hover, and softly grows the cloud icon. */
 const dropzoneSurfaceProps = (active: boolean) => ({
   borderRadius: "xl",
   borderWidth: "2px",
@@ -914,8 +958,37 @@ const dropzoneSurfaceProps = (active: boolean) => ({
   cursor: "pointer",
   width: "full",
   transition: "border-color 0.15s ease, background-color 0.15s ease",
-  _hover: { borderColor: "blue.300", bg: "blue.500/5" },
+  // Grow the icon while dragging a file over the zone; the icon's own
+  // transition animates the grow/shrink smoothly.
+  "& .lw-dropzone-icon": active ? { transform: "scale(1.12)" } : {},
+  _hover: {
+    borderColor: "blue.300",
+    bg: "blue.500/5",
+    "& .lw-dropzone-icon": { transform: "scale(1.12)" },
+  },
 });
+
+// PostHog's rainbow-scroll text sheen (same recipe as ShikiCommandBox): a
+// gradient clipped to the text whose background-position scrolls to animate.
+// Applied to the file name while it uploads — one continuous "loading" tell.
+const lwRainbowScroll = keyframes`
+  0% { background-position-x: 0%; }
+  100% { background-position-x: 200%; }
+`;
+
+const LW_RAINBOW_GRADIENT =
+  "linear-gradient(90deg, #0143cb 0%, #2b6ff4 24%, #d23401 47%, #ff651f 66%, #fba000 83%, #0143cb 100%)";
+
+const RAINBOW_TEXT_CSS = {
+  color: "transparent",
+  backgroundImage: LW_RAINBOW_GRADIENT,
+  backgroundClip: "text",
+  WebkitBackgroundClip: "text",
+  WebkitTextFillColor: "transparent",
+  backgroundSize: "200% 100%",
+  animation: `${lwRainbowScroll} 3s linear infinite`,
+  "@media (prefers-reduced-motion: reduce)": { animation: "none" },
+} as const;
 
 /**
  * Empty-state contents of the dropzone: an upload illustration, the primary
@@ -924,7 +997,12 @@ const dropzoneSurfaceProps = (active: boolean) => ({
 function DropzonePrompt() {
   return (
     <VStack gap={2}>
-      <Box color="blue.400">
+      <Box
+        className="lw-dropzone-icon"
+        color="blue.400"
+        transition="transform 0.2s ease"
+        transformOrigin="center"
+      >
         <CloudUpload size={36} strokeWidth={1.5} />
       </Box>
       <Text fontSize="md" color="fg">
@@ -982,6 +1060,7 @@ function DatasetFileRow({
   action?: React.ReactNode;
 }) {
   const isError = status === "error";
+  const isUploading = status === "uploading";
   const meta = message ?? metaLabel;
   return (
     <HStack
@@ -995,7 +1074,13 @@ function DatasetFileRow({
     >
       <DatasetFileStatusIcon status={status} />
       <VStack align="start" gap={0} flex={1} minWidth={0}>
-        <Text fontWeight="medium" truncate maxWidth="full">
+        <Text
+          fontWeight="medium"
+          truncate
+          maxWidth="full"
+          // The name sweeps a rainbow gradient while uploading — the "loading" tell.
+          css={isUploading ? RAINBOW_TEXT_CSS : undefined}
+        >
           {name}
         </Text>
         {(sizeLabel ?? meta) && (
@@ -1023,7 +1108,6 @@ function RemoveFileButton({ onRemove }: { onRemove: () => void }) {
   return (
     <Box
       as="button"
-      type="button"
       color="fg.muted"
       display="flex"
       _hover={{ color: "red.500" }}
@@ -1036,6 +1120,26 @@ function RemoveFileButton({ onRemove }: { onRemove: () => void }) {
       }}
     >
       <Trash2 size={18} />
+    </Box>
+  );
+}
+
+/** X control shown in place of the trash while an upload is in flight. */
+function CancelUploadButton({ onCancel }: { onCancel: () => void }) {
+  return (
+    <Box
+      as="button"
+      color="fg.muted"
+      display="flex"
+      _hover={{ color: "red.500" }}
+      aria-label="Cancel upload"
+      onClick={(event: React.MouseEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onCancel();
+      }}
+    >
+      <X size={18} />
     </Box>
   );
 }
@@ -1063,13 +1167,24 @@ function CSVReaderBox({
   }, [acceptedFile, setAcceptedFile]);
 
   return (
-    <VStack width="full" gap={3} align="stretch">
+    <VStack width="full" gap={0} align="stretch">
+      {/* Single-file flow: the drag-and-drop container collapses once a file is
+          chosen and expands back when it's removed. */}
       <Box
-        {...getRootProps()}
-        {...dropzoneSurfaceProps(zoneHover)}
-        style={DROPZONE_DOTTED_STYLE}
+        display="grid"
+        gridTemplateRows={acceptedFile ? "0fr" : "1fr"}
+        opacity={acceptedFile ? 0 : 1}
+        transition="grid-template-rows 0.35s ease, opacity 0.3s ease"
       >
-        <DropzonePrompt />
+        <Box overflow="hidden">
+          <Box
+            {...getRootProps()}
+            {...dropzoneSurfaceProps(zoneHover)}
+            style={DROPZONE_DOTTED_STYLE}
+          >
+            <DropzonePrompt />
+          </Box>
+        </Box>
       </Box>
       {acceptedFile && (
         <DatasetFileRow
@@ -1080,7 +1195,6 @@ function CSVReaderBox({
           action={
             <Box
               as="button"
-              type="button"
               color="fg.muted"
               display="flex"
               _hover={{ color: "red.500" }}
@@ -1110,6 +1224,7 @@ function RawFileDropzone({
   onUploadRemoved,
   uploadStatus,
   fileError,
+  onCancel,
   children,
 }: {
   onRawFile?: (file: File | null) => void;
@@ -1118,6 +1233,8 @@ function RawFileDropzone({
   uploadStatus?: "uploading";
   /** File-level validation/upload message; turns the row red. */
   fileError?: string;
+  /** Cancels the in-flight upload; shows the X cancel control while uploading. */
+  onCancel?: () => void;
   children?: (hasAcceptedFile: boolean) => React.ReactNode;
 }) {
   const [zoneHover, setZoneHover] = useState(false);
@@ -1141,42 +1258,50 @@ function RawFileDropzone({
       : "selected";
 
   return (
-    <VStack width="full" gap={3} align="stretch">
-      {/* While the file streams, the dropzone is replaced by its status row so
-          the user can't swap files mid-upload (single-file flow). */}
-      {!isUploading && (
-        <Box
-          as="label"
-          {...dropzoneSurfaceProps(zoneHover)}
-          style={DROPZONE_DOTTED_STYLE}
-          display="block"
-          onDragOver={(event) => {
-            event.preventDefault();
-            setZoneHover(true);
-          }}
-          onDragLeave={(event) => {
-            event.preventDefault();
-            setZoneHover(false);
-          }}
-          onDrop={(event) => {
-            event.preventDefault();
-            setZoneHover(false);
-            const file = event.dataTransfer?.files?.[0] ?? null;
-            if (file) setFile(file);
-          }}
-        >
-          <input
-            type="file"
-            accept=".csv,.json,.jsonl"
-            style={{ display: "none" }}
-            onChange={(event) => {
-              const file = event.target.files?.[0] ?? null;
+    <VStack width="full" gap={0} align="stretch">
+      {/* Single-file flow: the drag-and-drop container smoothly collapses once a
+          file is chosen and expands back when it's removed or cancelled. The
+          grid 1fr→0fr trick animates the height without measuring it. */}
+      <Box
+        display="grid"
+        gridTemplateRows={acceptedFile ? "0fr" : "1fr"}
+        opacity={acceptedFile ? 0 : 1}
+        transition="grid-template-rows 0.35s ease, opacity 0.3s ease"
+      >
+        <Box overflow="hidden">
+          <Box
+            as="label"
+            {...dropzoneSurfaceProps(zoneHover)}
+            style={DROPZONE_DOTTED_STYLE}
+            display="block"
+            onDragOver={(event) => {
+              event.preventDefault();
+              setZoneHover(true);
+            }}
+            onDragLeave={(event) => {
+              event.preventDefault();
+              setZoneHover(false);
+            }}
+            onDrop={(event) => {
+              event.preventDefault();
+              setZoneHover(false);
+              const file = event.dataTransfer?.files?.[0] ?? null;
               if (file) setFile(file);
             }}
-          />
-          <DropzonePrompt />
+          >
+            <input
+              type="file"
+              accept=".csv,.json,.jsonl"
+              style={{ display: "none" }}
+              onChange={(event) => {
+                const file = event.target.files?.[0] ?? null;
+                if (file) setFile(file);
+              }}
+            />
+            <DropzonePrompt />
+          </Box>
         </Box>
-      )}
+      </Box>
       {acceptedFile && (
         <DatasetFileRow
           name={acceptedFile.name}
@@ -1185,7 +1310,18 @@ function RawFileDropzone({
           status={rowStatus}
           message={fileError}
           action={
-            isUploading ? undefined : (
+            isUploading ? (
+              onCancel ? (
+                <CancelUploadButton
+                  onCancel={() => {
+                    // Cancel aborts the upload AND clears the file, so the
+                    // drag-and-drop container expands back in.
+                    onCancel();
+                    setFile(null);
+                  }}
+                />
+              ) : undefined
+            ) : (
               <RemoveFileButton onRemove={() => setFile(null)} />
             )
           }

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -486,9 +486,27 @@ export function UploadCSVForm({
         void router.push(`/${project.slug}/datasets/${datasetId}`);
       }
     } catch (error) {
-      // A user-initiated cancel aborts the PUT: handleCancelUpload already reset
-      // state and reaped the pending row, so there is nothing more to do here.
+      // A user-initiated cancel aborts the PUT. handleCancelUpload reaped the
+      // pending row IF it knew the id at cancel time — but a cancel that landed
+      // while requestDirectUpload() was still in flight ran BEFORE the id
+      // existed, so the row (minted just after) is still pending. The ref holds
+      // that id exactly when it hasn't been reaped yet, so reap-and-clear here.
+      // (Cancel during the PUT already reaped and nulled the ref, so this is a
+      // no-op then — no double reap.)
       if (error instanceof Error && error.name === "AbortError") {
+        const strandedId = pendingDatasetIdRef.current;
+        pendingDatasetIdRef.current = null;
+        if (strandedId && projectId) {
+          void abortPendingUpload({
+            projectId,
+            datasetId: strandedId,
+          }).catch((cleanupError) => {
+            logger.error(
+              { error: cleanupError },
+              "Failed to clean up cancelled upload",
+            );
+          });
+        }
         return;
       }
       // Any failure AFTER requestDirectUpload minted the `uploading` row leaves

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -11,7 +11,6 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { keyframes } from "@emotion/react";
-import { useEffect, useRef, useState } from "react";
 import {
   CheckCircle,
   CloudUpload,
@@ -20,6 +19,7 @@ import {
   X,
   XCircle,
 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import {
   formatFileSize,
   jsonToCSV as papaparseJsonToCSV,
@@ -33,7 +33,6 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
 import { createLogger } from "~/utils/logger";
-import { Drawer } from "../ui/drawer";
 import type {
   DatasetColumns,
   DatasetRecordEntry,
@@ -43,6 +42,7 @@ import {
   type AddDatasetDrawerProps,
   AddOrEditDatasetDrawer,
 } from "../AddOrEditDatasetDrawer";
+import { Drawer } from "../ui/drawer";
 import { toaster } from "../ui/toaster";
 import {
   abortPendingUpload,
@@ -144,9 +144,7 @@ export function UploadCSVDrawer({
                   const datasetId = processingDatasetId;
                   handleClose();
                   if (project) {
-                    void router.push(
-                      `/${project.slug}/datasets/${datasetId}`,
-                    );
+                    void router.push(`/${project.slug}/datasets/${datasetId}`);
                   }
                 }}
               />
@@ -180,6 +178,15 @@ export function UploadCSVDrawer({
   );
 }
 
+/** True once a dataset has at least one column — the signal that normalize has
+ *  actually run (distinguishes a real "ready" from the schema-default one). */
+function datasetHasColumns(dataset: { columnTypes?: unknown }): boolean {
+  const cols = dataset.columnTypes;
+  return (
+    !!cols && typeof cols === "object" && Object.keys(cols as object).length > 0
+  );
+}
+
 /**
  * In-drawer view for the async tail of a direct upload (ADR-032 D4): after the
  * raw file is finalized, the dataset normalizes server-side. This polls its
@@ -188,7 +195,7 @@ export function UploadCSVDrawer({
  * the drawer. On ready it notifies the host (to refresh the list); navigating
  * to the dataset is an explicit user action, never automatic.
  */
-function DatasetUploadProcessing({
+export function DatasetUploadProcessing({
   projectId,
   datasetId,
   onReady,
@@ -208,31 +215,35 @@ function DatasetUploadProcessing({
     { projectId, datasetId },
     {
       enabled: !!projectId && !!datasetId,
-      // Poll only while preparing; the functional form lets the query stop
-      // itself once the status settles (same contract as the dataset page).
-      refetchInterval: (data) =>
-        data?.status === "processing" || data?.status === "uploading"
-          ? 3000
-          : false,
+      // Poll while preparing. `Dataset.status` schema-defaults to "ready", so a
+      // row whose normalize hasn't run can momentarily read "ready" with no
+      // columns — keep polling in that case too, and stop only once it has
+      // columns, failed, or the row is gone (findFirst → null).
+      refetchInterval: (data) => {
+        if (!data) return false;
+        if (data.status === "processing" || data.status === "uploading") {
+          return 3000;
+        }
+        if (data.status === "ready" && !datasetHasColumns(data)) return 3000;
+        return false;
+      },
     },
   );
 
-  const status = datasetQuery.data?.status;
-  const isReady = status === "ready";
-  const isFailed = status === "failed";
-  // A freshly finalized direct upload always reports a real status
-  // (uploading → processing → ready), so anything that is not yet ready or
-  // failed — including the first in-flight fetch — is still "preparing".
-  const isProcessing = !isReady && !isFailed;
+  const data = datasetQuery.data;
+  // `getById` (findFirst, archivedAt: null) returns null for a missing/archived
+  // dataset — a terminal state, NOT "still preparing" (else the spinner hangs
+  // forever, since refetchInterval also stops on null).
+  const datasetGone = datasetQuery.isFetched && data == null;
+  const isFailed = data?.status === "failed";
+  // Trust "ready" only once normalize has populated columns, so the schema
+  // default can't be mistaken for a finished upload.
+  const isReady = data?.status === "ready" && datasetHasColumns(data);
+  const isProcessing = !datasetGone && !isFailed && !isReady;
 
-  const readyDataset = datasetQuery.data;
   useEffect(() => {
-    if (isReady && readyDataset) {
-      onReady({
-        id: readyDataset.id,
-        name: readyDataset.name,
-        columnTypes: readyDataset.columnTypes,
-      });
+    if (isReady && data) {
+      onReady({ id: data.id, name: data.name, columnTypes: data.columnTypes });
     }
     // Fire once on the transition to ready; onReady just refreshes the list.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -258,18 +269,15 @@ function DatasetUploadProcessing({
     }
   };
 
-  const rowStatus: DatasetFileStatus = isFailed
-    ? "error"
-    : isReady
-      ? "ready"
-      : "uploading";
+  const rowStatus: DatasetFileStatus =
+    isFailed || datasetGone ? "error" : isReady ? "ready" : "uploading";
 
   // Same row treatment as the dropzone, so the upload → prepare → ready flow
   // reads as one continuous file row rather than swapping to a banner.
   return (
     <VStack width="full" align="stretch" gap={4}>
       <DatasetFileRow
-        name={datasetQuery.data?.name ?? "Your dataset"}
+        name={data?.name ?? "Your dataset"}
         status={rowStatus}
         metaLabel={
           isReady
@@ -279,10 +287,12 @@ function DatasetUploadProcessing({
               : undefined
         }
         message={
-          isFailed
-            ? (datasetQuery.data?.statusError ??
-              "Something went wrong while processing your file. You can retry.")
-            : undefined
+          datasetGone
+            ? "This dataset is no longer available."
+            : isFailed
+              ? (data?.statusError ??
+                "Something went wrong while processing your file. You can retry.")
+              : undefined
         }
         action={
           isFailed ? (
@@ -454,10 +464,13 @@ export function UploadCSVForm({
       pendingDatasetId = datasetId;
       pendingDatasetIdRef.current = datasetId;
       await putFileToPresignedUrl(uploadUrl, rawFile, controller.signal);
-      await finalizeDirectUpload({ projectId, datasetId });
-
+      // The PUT succeeded — we're now committed to finalizing, so a cancel must
+      // NOT reap the row. Clear the abort/reap handles BEFORE finalize (not
+      // after) to close the cancel-after-finalize double-reap race.
       abortControllerRef.current = null;
       pendingDatasetIdRef.current = null;
+      await finalizeDirectUpload({ projectId, datasetId });
+
       if (onDirectUploadComplete) {
         // Hand off to the drawer host, which polls status and shows the
         // processing → ready/failed flow in place (no navigation).
@@ -512,6 +525,9 @@ export function UploadCSVForm({
       // A same-origin local-FS failure (e.g. StorageNotWritable) is a real,
       // actionable server error — surface it verbatim, no fallback parse.
       logger.error({ error }, "Direct dataset upload failed");
+      // System error → top alert; clear any file-level error so the two never
+      // render the shared `upload-error` testid at once.
+      setSizeError(null);
       setUploadError(
         error instanceof Error
           ? error.message
@@ -553,6 +569,8 @@ export function UploadCSVForm({
    */
   const runFallbackParseAndDrawer = async (file: File) => {
     if (file.size > MAX_FILE_SIZE_BYTES) {
+      // File-level error → inline row; clear any system error for exclusivity.
+      setUploadError(null);
       setSizeError(
         "This file is too large to upload on this deployment. Large uploads require object storage.",
       );
@@ -567,6 +585,7 @@ export function UploadCSVForm({
       uploadCSVData();
     } catch (error) {
       logger.error({ error }, "Fallback parse of dataset file failed");
+      setSizeError(null);
       setUploadError(
         error instanceof Error
           ? error.message
@@ -611,7 +630,9 @@ export function UploadCSVForm({
         // Direct path: capture only the raw File (no parse). Fallback/picker
         // path: parse immediately for synchronous columns/records.
         parse={!enableDirectUpload}
-        uploadStatus={isUploading && enableDirectUpload ? "uploading" : undefined}
+        uploadStatus={
+          isUploading && enableDirectUpload ? "uploading" : undefined
+        }
         fileError={fileError}
         onCancel={handleCancelUpload}
         onUploadAccepted={handleUploadAccepted}
@@ -1274,6 +1295,8 @@ function RawFileDropzone({
             {...dropzoneSurfaceProps(zoneHover)}
             style={DROPZONE_DOTTED_STYLE}
             display="block"
+            // Observable drag-active state (the highlight itself is CSS-only).
+            data-active={zoneHover ? "true" : "false"}
             onDragOver={(event) => {
               event.preventDefault();
               setZoneHover(true);

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -1337,6 +1337,10 @@ function RawFileDropzone({
               onChange={(event) => {
                 const file = event.target.files?.[0] ?? null;
                 if (file) setFile(file);
+                // Reset the native value so re-picking the SAME file after a
+                // remove still fires `change` (otherwise the unchanged value
+                // suppresses it and Upload stays disabled).
+                event.target.value = "";
               }}
             />
             <DropzonePrompt />

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -484,14 +484,24 @@ export function UploadCSVForm({
         void router.push(`/${project.slug}/datasets/${datasetId}`);
       }
     } catch (error) {
-      // A user-initiated cancel aborts the PUT. handleCancelUpload reaped the
-      // pending row IF it knew the id at cancel time — but a cancel that landed
-      // while requestDirectUpload() was still in flight ran BEFORE the id
-      // existed, so the row (minted just after) is still pending. The ref holds
-      // that id exactly when it hasn't been reaped yet, so reap-and-clear here.
-      // (Cancel during the PUT already reaped and nulled the ref, so this is a
-      // no-op then — no double reap.)
-      if (error instanceof Error && error.name === "AbortError") {
+      // A user-initiated cancel aborts the PUT (AbortError) OR lands while
+      // requestDirectUpload() is still pending. The presign call is deliberately
+      // NOT wired to the abort signal (aborting its fetch could strand a row the
+      // server minted but whose id we never received), so it runs to completion
+      // and may resolve OR reject — e.g. DirectUploadUnavailableError on a
+      // no-storage install — AFTER the cancel. In that window we must NOT run the
+      // fallback parse or surface an error for an upload the user already
+      // cancelled. `controller.signal.aborted` is the precise "cancelled while
+      // this attempt was live" flag (handleCancelUpload only aborts a controller
+      // still held by the ref; once the PUT succeeds the ref is nulled, so a
+      // later cancel can't set it), so treat it like AbortError: reap any row the
+      // presign minted (the ref holds that id exactly when it hasn't been reaped
+      // yet; a cancel during the PUT already reaped and nulled it → no double
+      // reap) and bail before any fallback/error handling.
+      if (
+        (error instanceof Error && error.name === "AbortError") ||
+        controller.signal.aborted
+      ) {
         const strandedId = pendingDatasetIdRef.current;
         pendingDatasetIdRef.current = null;
         if (strandedId && projectId) {

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -1,9 +1,11 @@
 import {
+  Alert,
   Box,
   Button,
   Heading,
   HStack,
   Spacer,
+  Spinner,
   Text,
   useDisclosure,
   VStack,
@@ -40,6 +42,7 @@ import {
   PresignedUploadFailedError,
   putFileToPresignedUrl,
   requestDirectUpload,
+  retryDatasetNormalize,
 } from "./services/directUpload";
 import { getSafeColumnName } from "./utils/reservedColumns";
 export const MAX_ROWS_LIMIT = 10_000;
@@ -66,6 +69,8 @@ export function UploadCSVDrawer({
   enableDirectUpload?: boolean;
 }) {
   const { closeDrawer } = useDrawer();
+  const { project } = useOrganizationTeamProject();
+  const router = useRouter();
   const onClose = onClose_ ?? closeDrawer;
   const isOpen = isOpen_ ?? true;
 
@@ -74,16 +79,29 @@ export function UploadCSVDrawer({
   const [uploadedDataset, setUploadedDataset] = useState<
     InMemoryDataset | undefined
   >(undefined);
+  // Direct-upload (ADR-032 D4) processing stays IN this drawer: once the raw
+  // file is streamed + finalized, the dataset normalizes server-side. We hold
+  // its id and poll its status here instead of navigating to the dataset page,
+  // so the whole async flow is observable without leaving the drawer.
+  const [processingDatasetId, setProcessingDatasetId] = useState<string | null>(
+    null,
+  );
 
   const uploadCSVData = () => {
     setLocalIsOpen(false);
     addDatasetDrawer.onOpen();
   };
 
+  const handleClose = () => {
+    setProcessingDatasetId(null);
+    onClose();
+  };
+
   useEffect(() => {
     setLocalIsOpen(isOpen);
     if (!isOpen) {
       setUploadedDataset(undefined);
+      setProcessingDatasetId(null);
       addDatasetDrawer.onClose();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -93,7 +111,7 @@ export function UploadCSVDrawer({
     <>
       <Drawer.Root
         open={localIsOpen}
-        onOpenChange={({ open }) => !open && onClose()}
+        onOpenChange={({ open }) => !open && handleClose()}
         size="xl"
       >
         <Drawer.Content bg="bg">
@@ -102,14 +120,38 @@ export function UploadCSVDrawer({
             <Heading>Upload CSV</Heading>
           </Drawer.Header>
           <Drawer.Body>
-            <UploadCSVForm
-              setUploadedDataset={setUploadedDataset}
-              uploadedDataset={uploadedDataset}
-              uploadCSVData={uploadCSVData}
-              onCreateFromScratch={onCreateFromScratch}
-              enableDirectUpload={enableDirectUpload}
-              onClose={onClose}
-            />
+            {processingDatasetId && project ? (
+              <DatasetUploadProcessing
+                projectId={project.id}
+                datasetId={processingDatasetId}
+                onReady={(dataset) => {
+                  onSuccess({
+                    datasetId: dataset.id,
+                    name: dataset.name,
+                    columnTypes: (dataset.columnTypes ?? {}) as DatasetColumns,
+                  });
+                }}
+                onViewDataset={() => {
+                  const datasetId = processingDatasetId;
+                  handleClose();
+                  if (project) {
+                    void router.push(
+                      `/${project.slug}/datasets/${datasetId}`,
+                    );
+                  }
+                }}
+              />
+            ) : (
+              <UploadCSVForm
+                setUploadedDataset={setUploadedDataset}
+                uploadedDataset={uploadedDataset}
+                uploadCSVData={uploadCSVData}
+                onCreateFromScratch={onCreateFromScratch}
+                enableDirectUpload={enableDirectUpload}
+                onClose={onClose}
+                onDirectUploadComplete={setProcessingDatasetId}
+              />
+            )}
           </Drawer.Body>
         </Drawer.Content>
       </Drawer.Root>
@@ -126,6 +168,139 @@ export function UploadCSVDrawer({
         }}
       />
     </>
+  );
+}
+
+/**
+ * In-drawer view for the async tail of a direct upload (ADR-032 D4): after the
+ * raw file is finalized, the dataset normalizes server-side. This polls its
+ * status (mirroring the dataset page's processing banner, so the UX is
+ * identical) and surfaces processing / ready / failed states without leaving
+ * the drawer. On ready it notifies the host (to refresh the list); navigating
+ * to the dataset is an explicit user action, never automatic.
+ */
+function DatasetUploadProcessing({
+  projectId,
+  datasetId,
+  onReady,
+  onViewDataset,
+}: {
+  projectId: string;
+  datasetId: string;
+  onReady: (dataset: {
+    id: string;
+    name: string;
+    columnTypes: unknown;
+  }) => void;
+  onViewDataset: () => void;
+}) {
+  const [isRetrying, setIsRetrying] = useState(false);
+  const datasetQuery = api.dataset.getById.useQuery(
+    { projectId, datasetId },
+    {
+      enabled: !!projectId && !!datasetId,
+      // Poll only while preparing; the functional form lets the query stop
+      // itself once the status settles (same contract as the dataset page).
+      refetchInterval: (data) =>
+        data?.status === "processing" || data?.status === "uploading"
+          ? 3000
+          : false,
+    },
+  );
+
+  const status = datasetQuery.data?.status;
+  const isReady = status === "ready";
+  const isFailed = status === "failed";
+  // A freshly finalized direct upload always reports a real status
+  // (uploading → processing → ready), so anything that is not yet ready or
+  // failed — including the first in-flight fetch — is still "preparing".
+  const isProcessing = !isReady && !isFailed;
+
+  const readyDataset = datasetQuery.data;
+  useEffect(() => {
+    if (isReady && readyDataset) {
+      onReady({
+        id: readyDataset.id,
+        name: readyDataset.name,
+        columnTypes: readyDataset.columnTypes,
+      });
+    }
+    // Fire once on the transition to ready; onReady just refreshes the list.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isReady]);
+
+  const handleRetry = async () => {
+    setIsRetrying(true);
+    try {
+      await retryDatasetNormalize({ projectId, datasetId });
+      await datasetQuery.refetch();
+    } catch (error) {
+      toaster.create({
+        title: "Could not retry",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Please try again in a moment.",
+        type: "error",
+        meta: { closable: true },
+      });
+    } finally {
+      setIsRetrying(false);
+    }
+  };
+
+  return (
+    <VStack width="full" align="stretch" gap={4}>
+      {isFailed && (
+        <Alert.Root status="error">
+          <Alert.Indicator />
+          <Alert.Content>
+            <Alert.Title>We could not prepare your dataset</Alert.Title>
+            <Alert.Description>
+              {datasetQuery.data?.statusError ??
+                "Something went wrong while processing your file. You can retry."}
+            </Alert.Description>
+          </Alert.Content>
+          <Button
+            size="sm"
+            colorPalette="red"
+            variant="outline"
+            loading={isRetrying}
+            onClick={() => void handleRetry()}
+          >
+            Retry
+          </Button>
+        </Alert.Root>
+      )}
+      {isProcessing && (
+        <Alert.Root status="info">
+          <Alert.Indicator>
+            <Spinner size="sm" />
+          </Alert.Indicator>
+          <Alert.Content>
+            <Alert.Title>
+              Preparing your dataset, this can take a few minutes
+            </Alert.Title>
+          </Alert.Content>
+        </Alert.Root>
+      )}
+      {isReady && (
+        <Alert.Root status="success">
+          <Alert.Indicator />
+          <Alert.Content>
+            <Alert.Title>Your dataset is ready</Alert.Title>
+          </Alert.Content>
+        </Alert.Root>
+      )}
+      <HStack width="full">
+        <Spacer />
+        {isReady && (
+          <Button colorPalette="blue" onClick={onViewDataset}>
+            View dataset
+          </Button>
+        )}
+      </HStack>
+    </VStack>
   );
 }
 
@@ -169,16 +344,22 @@ export function UploadCSVForm({
   disabled,
   enableDirectUpload = false,
   onClose,
+  onDirectUploadComplete,
 }: {
   setUploadedDataset: (dataset: InMemoryDataset | undefined) => void;
   uploadedDataset: InMemoryDataset | undefined;
   onCreateFromScratch?: () => void;
   uploadCSVData: () => void;
   disabled?: boolean;
-  /** When true, "Upload" streams the raw file to storage and navigates to the
-   *  dataset page; falls back to the parse-and-drawer flow if storage is off. */
+  /** When true, "Upload" streams the raw file to storage; the host then shows
+   *  processing in the drawer. Falls back to the parse-and-drawer flow if
+   *  storage is off. */
   enableDirectUpload?: boolean;
   onClose?: () => void;
+  /** Called with the new dataset id once a direct upload is finalized, so the
+   *  host (UploadCSVDrawer) takes over and shows processing IN the drawer.
+   *  When omitted, the direct path navigates to the dataset page instead. */
+  onDirectUploadComplete?: (datasetId: string) => void;
 }) {
   const { project } = useOrganizationTeamProject();
   const projectId = project?.id;
@@ -260,13 +441,20 @@ export function UploadCSVForm({
       await putFileToPresignedUrl(uploadUrl, rawFile);
       await finalizeDirectUpload({ projectId, datasetId });
 
-      toaster.create({
-        title: "Preparing your dataset",
-        type: "success",
-        meta: { closable: true },
-      });
-      onClose?.();
-      void router.push(`/${project.slug}/datasets/${datasetId}`);
+      if (onDirectUploadComplete) {
+        // Hand off to the drawer host, which polls status and shows the
+        // processing → ready/failed flow in place (no navigation).
+        setIsUploading(false);
+        onDirectUploadComplete(datasetId);
+      } else {
+        toaster.create({
+          title: "Preparing your dataset",
+          type: "success",
+          meta: { closable: true },
+        });
+        onClose?.();
+        void router.push(`/${project.slug}/datasets/${datasetId}`);
+      }
     } catch (error) {
       // Any failure AFTER requestDirectUpload minted the `uploading` row leaves
       // it behind and locks the slug — whether we fall back (a fresh dataset is
@@ -361,6 +549,17 @@ export function UploadCSVForm({
 
   return (
     <VStack width="full" align="start" gap={4}>
+      {(uploadError || overRowLimitForFallback) && (
+        <Alert.Root status="error" width="full">
+          <Alert.Indicator />
+          <Alert.Content>
+            <Alert.Description data-testid="upload-error">
+              {uploadError ??
+                `Sorry, the max number of rows accepted for datasets is currently ${MAX_ROWS_LIMIT} rows. Please reduce the number of rows or contact support.`}
+            </Alert.Description>
+          </Alert.Content>
+        </Alert.Root>
+      )}
       <CSVReaderComponent
         // Direct path: capture only the raw File (no parse). Fallback/picker
         // path: parse immediately for synchronous columns/records.
@@ -377,19 +576,6 @@ export function UploadCSVForm({
         }}
       />
       <HStack width="full" align="end">
-        {overRowLimitForFallback && (
-          <Text color="red.500" paddingTop={4}>
-            Sorry, the max number of rows accepted for datasets is currently{" "}
-            {MAX_ROWS_LIMIT} rows. Please reduce the number of rows or contact
-            support.
-          </Text>
-        )}
-        {uploadError && (
-          <Text color="red.500" paddingTop={4} data-testid="upload-error">
-            {uploadError}
-          </Text>
-        )}
-
         {onCreateFromScratch && (
           <Button
             variant="plain"

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Heading,
   HStack,
   Spacer,
   Text,
@@ -21,7 +22,7 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
 import { useRouter } from "~/utils/compat/next-router";
 import { createLogger } from "~/utils/logger";
-import { Dialog } from "../../components/ui/dialog";
+import { Drawer } from "../ui/drawer";
 import type {
   DatasetColumns,
   DatasetRecordEntry,
@@ -43,9 +44,9 @@ import {
 import { getSafeColumnName } from "./utils/reservedColumns";
 export const MAX_ROWS_LIMIT = 10_000;
 
-const logger = createLogger("UploadCSVModal");
+const logger = createLogger("UploadCSVDrawer");
 
-export function UploadCSVModal({
+export function UploadCSVDrawer({
   isOpen: isOpen_,
   onClose: onClose_,
   onSuccess,
@@ -90,17 +91,17 @@ export function UploadCSVModal({
 
   return (
     <>
-      <Dialog.Root
+      <Drawer.Root
         open={localIsOpen}
         onOpenChange={({ open }) => !open && onClose()}
-        closeOnInteractOutside={false}
+        size="xl"
       >
-        <Dialog.Content bg="bg">
-          <Dialog.Header>
-            <Dialog.Title>Upload CSV</Dialog.Title>
-            <Dialog.CloseTrigger />
-          </Dialog.Header>
-          <Dialog.Body>
+        <Drawer.Content bg="bg">
+          <Drawer.CloseTrigger />
+          <Drawer.Header>
+            <Heading>Upload CSV</Heading>
+          </Drawer.Header>
+          <Drawer.Body>
             <UploadCSVForm
               setUploadedDataset={setUploadedDataset}
               uploadedDataset={uploadedDataset}
@@ -109,9 +110,9 @@ export function UploadCSVModal({
               enableDirectUpload={enableDirectUpload}
               onClose={onClose}
             />
-          </Dialog.Body>
-        </Dialog.Content>
-      </Dialog.Root>
+          </Drawer.Body>
+        </Drawer.Content>
+      </Drawer.Root>
       <AddOrEditDatasetDrawer
         datasetToSave={uploadedDataset}
         open={addDatasetDrawer.open}

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -37,7 +37,10 @@ import type {
   DatasetColumns,
   DatasetRecordEntry,
 } from "../../server/datasets/types";
-import { MAX_FILE_SIZE_BYTES } from "../../server/datasets/upload-utils";
+import {
+  MAX_FILE_SIZE_BYTES,
+  MAX_ROWS_LIMIT,
+} from "../../server/datasets/upload-utils";
 import {
   type AddDatasetDrawerProps,
   AddOrEditDatasetDrawer,
@@ -54,7 +57,6 @@ import {
   retryDatasetNormalize,
 } from "./services/directUpload";
 import { getSafeColumnName } from "./utils/reservedColumns";
-export const MAX_ROWS_LIMIT = 10_000;
 
 const logger = createLogger("UploadCSVDrawer");
 
@@ -178,15 +180,6 @@ export function UploadCSVDrawer({
   );
 }
 
-/** True once a dataset has at least one column — the signal that normalize has
- *  actually run (distinguishes a real "ready" from the schema-default one). */
-function datasetHasColumns(dataset: { columnTypes?: unknown }): boolean {
-  const cols = dataset.columnTypes;
-  return (
-    !!cols && typeof cols === "object" && Object.keys(cols as object).length > 0
-  );
-}
-
 /**
  * In-drawer view for the async tail of a direct upload (ADR-032 D4): after the
  * raw file is finalized, the dataset normalizes server-side. This polls its
@@ -215,18 +208,15 @@ export function DatasetUploadProcessing({
     { projectId, datasetId },
     {
       enabled: !!projectId && !!datasetId,
-      // Poll while preparing. `Dataset.status` schema-defaults to "ready", so a
-      // row whose normalize hasn't run can momentarily read "ready" with no
-      // columns — keep polling in that case too, and stop only once it has
-      // columns, failed, or the row is gone (findFirst → null).
-      refetchInterval: (data) => {
-        if (!data) return false;
-        if (data.status === "processing" || data.status === "uploading") {
-          return 3000;
-        }
-        if (data.status === "ready" && !datasetHasColumns(data)) return 3000;
-        return false;
-      },
+      // Poll only while preparing, then stop — same contract as the dataset
+      // page. `finalizeUpload` always flips the row to "processing" before
+      // normalize runs, so "ready" is only ever reached once normalize has
+      // finished; we don't second-guess it (a degenerate columnless dataset is
+      // still terminally ready, not an endless spinner).
+      refetchInterval: (data) =>
+        data?.status === "processing" || data?.status === "uploading"
+          ? 3000
+          : false,
     },
   );
 
@@ -236,9 +226,7 @@ export function DatasetUploadProcessing({
   // forever, since refetchInterval also stops on null).
   const datasetGone = datasetQuery.isFetched && data == null;
   const isFailed = data?.status === "failed";
-  // Trust "ready" only once normalize has populated columns, so the schema
-  // default can't be mistaken for a finished upload.
-  const isReady = data?.status === "ready" && datasetHasColumns(data);
+  const isReady = data?.status === "ready";
   const isProcessing = !datasetGone && !isFailed && !isReady;
 
   useEffect(() => {
@@ -394,6 +382,15 @@ export function UploadCSVForm({
   const abortControllerRef = useRef<AbortController | null>(null);
   const pendingDatasetIdRef = useRef<string | null>(null);
 
+  // Closing the drawer mid-upload unmounts this form — abort the in-flight PUT
+  // so it doesn't silently finalize a dataset behind the user's back. The refs
+  // are nulled the instant the PUT succeeds (before finalize), so this aborts
+  // only a genuinely in-flight stream; the AbortError catch then reaps the
+  // pending row. No-op (ref null) on a normal close or the processing handoff.
+  useEffect(() => {
+    return () => abortControllerRef.current?.abort();
+  }, []);
+
   const getValidName = async (proposedName: string): Promise<string> => {
     if (!projectId) return proposedName;
     const validName = await trpcUtils.dataset.findNextName.fetch({
@@ -482,6 +479,7 @@ export function UploadCSVForm({
           type: "success",
           meta: { closable: true },
         });
+        setIsUploading(false);
         onClose?.();
         void router.push(`/${project.slug}/datasets/${datasetId}`);
       }
@@ -557,8 +555,9 @@ export function UploadCSVForm({
 
   /**
    * Cancel an in-flight direct upload: abort the streaming PUT and reap the
-   * pending `uploading` row so its slug isn't locked on retry. The file stays
-   * selected so the user can re-upload or remove it.
+   * pending `uploading` row so its slug isn't locked on retry. The dropzone's
+   * cancel control additionally clears the selected file (re-expanding the drop
+   * zone) — see `RawFileDropzone`'s cancel handler — so the user starts fresh.
    */
   const handleCancelUpload = () => {
     abortControllerRef.current?.abort();

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -12,6 +12,13 @@ import {
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import {
+  CheckCircle,
+  CloudUpload,
+  FileText,
+  Trash2,
+  XCircle,
+} from "lucide-react";
+import {
   formatFileSize,
   jsonToCSV as papaparseJsonToCSV,
   readString as papaparseReadString,
@@ -249,57 +256,50 @@ function DatasetUploadProcessing({
     }
   };
 
+  const rowStatus: DatasetFileStatus = isFailed
+    ? "error"
+    : isReady
+      ? "ready"
+      : "uploading";
+
+  // Same row treatment as the dropzone, so the upload → prepare → ready flow
+  // reads as one continuous file row rather than swapping to a banner.
   return (
     <VStack width="full" align="stretch" gap={4}>
-      {isFailed && (
-        <Alert.Root status="error">
-          <Alert.Indicator />
-          <Alert.Content>
-            <Alert.Title>We could not prepare your dataset</Alert.Title>
-            <Alert.Description>
-              {datasetQuery.data?.statusError ??
-                "Something went wrong while processing your file. You can retry."}
-            </Alert.Description>
-          </Alert.Content>
-          <Button
-            size="sm"
-            colorPalette="red"
-            variant="outline"
-            loading={isRetrying}
-            onClick={() => void handleRetry()}
-          >
-            Retry
-          </Button>
-        </Alert.Root>
-      )}
-      {isProcessing && (
-        <Alert.Root status="info">
-          <Alert.Indicator>
-            <Spinner size="sm" />
-          </Alert.Indicator>
-          <Alert.Content>
-            <Alert.Title>
-              Preparing your dataset, this can take a few minutes
-            </Alert.Title>
-          </Alert.Content>
-        </Alert.Root>
-      )}
-      {isReady && (
-        <Alert.Root status="success">
-          <Alert.Indicator />
-          <Alert.Content>
-            <Alert.Title>Your dataset is ready</Alert.Title>
-          </Alert.Content>
-        </Alert.Root>
-      )}
-      <HStack width="full">
-        <Spacer />
-        {isReady && (
-          <Button colorPalette="blue" onClick={onViewDataset}>
-            View dataset
-          </Button>
-        )}
-      </HStack>
+      <DatasetFileRow
+        name={datasetQuery.data?.name ?? "Your dataset"}
+        status={rowStatus}
+        metaLabel={
+          isReady
+            ? "Ready"
+            : isProcessing
+              ? "Preparing your dataset, this can take a few minutes"
+              : undefined
+        }
+        message={
+          isFailed
+            ? (datasetQuery.data?.statusError ??
+              "Something went wrong while processing your file. You can retry.")
+            : undefined
+        }
+        action={
+          isFailed ? (
+            <Button
+              size="sm"
+              colorPalette="red"
+              variant="outline"
+              loading={isRetrying}
+              onClick={() => void handleRetry()}
+            >
+              Retry
+            </Button>
+          ) : isReady ? (
+            <Button size="sm" colorPalette="blue" onClick={onViewDataset}>
+              View dataset
+            </Button>
+          ) : undefined
+        }
+      />
     </VStack>
   );
 }
@@ -372,7 +372,11 @@ export function UploadCSVForm({
   // used by the fallback (no-storage) flow.
   const [rawFile, setRawFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
+  // System/drawer-level failure (storage not writable, upload failed) → top
+  // alert. File-level validation (too large / over the row limit) → inline on
+  // the file's row (sizeError + overRowLimitForFallback below).
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [sizeError, setSizeError] = useState<string | null>(null);
 
   const getValidName = async (proposedName: string): Promise<string> => {
     if (!projectId) return proposedName;
@@ -511,7 +515,7 @@ export function UploadCSVForm({
    */
   const runFallbackParseAndDrawer = async (file: File) => {
     if (file.size > MAX_FILE_SIZE_BYTES) {
-      setUploadError(
+      setSizeError(
         "This file is too large to upload on this deployment. Large uploads require object storage.",
       );
       setIsUploading(false);
@@ -547,15 +551,20 @@ export function UploadCSVForm({
       uploadedDataset.datasetRecords.length > 0 &&
       !overRowLimitForFallback;
 
+  // File-level validation, shown inline on the file's row: too-large (fallback)
+  // or over the in-browser row limit.
+  const fileError = overRowLimitForFallback
+    ? `Sorry, the max number of rows accepted for datasets is currently ${MAX_ROWS_LIMIT} rows. Please reduce the number of rows or contact support.`
+    : (sizeError ?? undefined);
+
   return (
     <VStack width="full" align="start" gap={4}>
-      {(uploadError || overRowLimitForFallback) && (
+      {uploadError && (
         <Alert.Root status="error" width="full">
           <Alert.Indicator />
           <Alert.Content>
             <Alert.Description data-testid="upload-error">
-              {uploadError ??
-                `Sorry, the max number of rows accepted for datasets is currently ${MAX_ROWS_LIMIT} rows. Please reduce the number of rows or contact support.`}
+              {uploadError}
             </Alert.Description>
           </Alert.Content>
         </Alert.Root>
@@ -564,15 +573,19 @@ export function UploadCSVForm({
         // Direct path: capture only the raw File (no parse). Fallback/picker
         // path: parse immediately for synchronous columns/records.
         parse={!enableDirectUpload}
+        uploadStatus={isUploading && enableDirectUpload ? "uploading" : undefined}
+        fileError={fileError}
         onUploadAccepted={handleUploadAccepted}
         onRawFile={(file) => {
           setRawFile(file);
           setUploadError(null);
+          setSizeError(null);
         }}
         onUploadRemoved={() => {
           setUploadedDataset(undefined);
           setRawFile(null);
           setUploadError(null);
+          setSizeError(null);
         }}
       />
       <HStack width="full" align="end">
@@ -607,6 +620,8 @@ export function CSVReaderComponent({
   onUploadRemoved,
   onRawFile,
   parse = true,
+  uploadStatus,
+  fileError,
   children,
 }: {
   onUploadAccepted: (results: {
@@ -628,11 +643,20 @@ export function CSVReaderComponent({
    * rely on for synchronous columns/records.
    */
   parse?: boolean;
+  /** "uploading" while the no-parse raw file streams to storage. */
+  uploadStatus?: "uploading";
+  /** File-level validation/upload message; renders the file row in an error state. */
+  fileError?: string;
   children?: (hasAcceptedFile: boolean) => React.ReactNode;
 }) {
   if (!parse) {
     return (
-      <RawFileDropzone onRawFile={onRawFile} onUploadRemoved={onUploadRemoved}>
+      <RawFileDropzone
+        onRawFile={onRawFile}
+        onUploadRemoved={onUploadRemoved}
+        uploadStatus={uploadStatus}
+        fileError={fileError}
+      >
         {children}
       </RawFileDropzone>
     );
@@ -642,6 +666,7 @@ export function CSVReaderComponent({
     <ParsingCSVReader
       onUploadAccepted={onUploadAccepted}
       onUploadRemoved={onUploadRemoved}
+      fileError={fileError}
     >
       {children}
     </ParsingCSVReader>
@@ -658,6 +683,7 @@ export function CSVReaderComponent({
 function ParsingCSVReader({
   onUploadAccepted,
   onUploadRemoved,
+  fileError,
   children,
 }: {
   onUploadAccepted: (results: {
@@ -665,6 +691,7 @@ function ParsingCSVReader({
     acceptedFile: File;
   }) => void | Promise<void>;
   onUploadRemoved?: () => void;
+  fileError?: string;
   children?: (hasAcceptedFile: boolean) => React.ReactNode;
 }) {
   const { CSVReader } = useCSVReader();
@@ -729,7 +756,6 @@ function ParsingCSVReader({
         acceptedFile,
         ProgressBar,
         getRemoveFileProps,
-        Remove,
       }: {
         getRootProps: () => Record<string, unknown>;
         acceptedFile: File | null;
@@ -743,9 +769,9 @@ function ParsingCSVReader({
               acceptedFile={acceptedFile}
               setAcceptedFile={setAcceptedFile}
               zoneHover={zoneHover}
+              fileError={fileError}
               getRootProps={getRootProps}
               getRemoveFileProps={getRemoveFileProps}
-              Remove={Remove}
               ProgressBar={ProgressBar}
             />
             {children ? children(acceptedFile !== null) : null}{" "}
@@ -862,21 +888,174 @@ function jsonToCSV(jsonContents: object[]): string {
   });
 }
 
+type DatasetFileStatus = "selected" | "uploading" | "ready" | "error";
+
+const DROPZONE_SUPPORTED_HELP = "Supported files: CSV, JSON, or JSONL";
+
+// Dotted-grid surface for the empty dropzone. Raw CSS (not a Chakra token) so
+// it composes over the theme-aware background color; `border` follows the
+// active color mode.
+const DROPZONE_DOTTED_STYLE: React.CSSProperties = {
+  backgroundImage:
+    "radial-gradient(var(--chakra-colors-border) 1px, transparent 1px)",
+  backgroundSize: "16px 16px",
+};
+
+/** Shared Chakra props for the dashed dropzone surface; highlights when active
+ *  (dragging a file over it) and on hover. */
+const dropzoneSurfaceProps = (active: boolean) => ({
+  borderRadius: "xl",
+  borderWidth: "2px",
+  borderStyle: "dashed" as const,
+  borderColor: active ? "blue.400" : "border",
+  bg: active ? "blue.500/10" : "transparent",
+  padding: 10,
+  textAlign: "center" as const,
+  cursor: "pointer",
+  width: "full",
+  transition: "border-color 0.15s ease, background-color 0.15s ease",
+  _hover: { borderColor: "blue.300", bg: "blue.500/5" },
+});
+
+/**
+ * Empty-state contents of the dropzone: an upload illustration, the primary
+ * prompt (with "click to browse" reading as a link), and the supported types.
+ */
+function DropzonePrompt() {
+  return (
+    <VStack gap={2}>
+      <Box color="blue.400">
+        <CloudUpload size={36} strokeWidth={1.5} />
+      </Box>
+      <Text fontSize="md" color="fg">
+        Drag and drop file, or{" "}
+        <Text as="span" color="blue.500" fontWeight="medium">
+          click to browse
+        </Text>
+      </Text>
+      <Text fontSize="xs" color="fg.muted">
+        {DROPZONE_SUPPORTED_HELP}
+      </Text>
+    </VStack>
+  );
+}
+
+function DatasetFileStatusIcon({ status }: { status: DatasetFileStatus }) {
+  if (status === "uploading") return <Spinner size="sm" color="blue.500" />;
+  if (status === "ready")
+    return (
+      <Box color="green.500" display="flex">
+        <CheckCircle size={20} />
+      </Box>
+    );
+  if (status === "error")
+    return (
+      <Box color="red.500" display="flex">
+        <XCircle size={20} />
+      </Box>
+    );
+  return (
+    <Box color="fg.muted" display="flex">
+      <FileText size={20} />
+    </Box>
+  );
+}
+
+/**
+ * A file presented as a status row (Image #5): status icon, file name, a
+ * "size · meta" sub-line, and a trailing action slot (remove, cancel, …). The
+ * error state turns the row red and shows the message in place of the meta.
+ */
+function DatasetFileRow({
+  name,
+  sizeLabel,
+  metaLabel,
+  status,
+  message,
+  action,
+}: {
+  name: string;
+  sizeLabel?: string;
+  metaLabel?: string;
+  status: DatasetFileStatus;
+  message?: string;
+  action?: React.ReactNode;
+}) {
+  const isError = status === "error";
+  const meta = message ?? metaLabel;
+  return (
+    <HStack
+      width="full"
+      gap={3}
+      padding={3}
+      borderWidth="1px"
+      borderRadius="lg"
+      borderColor={isError ? "red.400" : "border"}
+      bg="bg"
+    >
+      <DatasetFileStatusIcon status={status} />
+      <VStack align="start" gap={0} flex={1} minWidth={0}>
+        <Text fontWeight="medium" truncate maxWidth="full">
+          {name}
+        </Text>
+        {(sizeLabel ?? meta) && (
+          <HStack gap={2} fontSize="xs" color="fg.muted">
+            {sizeLabel && <Text>{sizeLabel}</Text>}
+            {sizeLabel && meta && <Text color="border">|</Text>}
+            {meta && (
+              <Text
+                color={isError ? "red.500" : "fg.muted"}
+                data-testid={isError ? "upload-error" : undefined}
+              >
+                {meta}
+              </Text>
+            )}
+          </HStack>
+        )}
+      </VStack>
+      {action}
+    </HStack>
+  );
+}
+
+/** Trash-style remove control for a file row. */
+function RemoveFileButton({ onRemove }: { onRemove: () => void }) {
+  return (
+    <Box
+      as="button"
+      type="button"
+      color="fg.muted"
+      display="flex"
+      _hover={{ color: "red.500" }}
+      aria-label="Remove file"
+      onClick={(event: React.MouseEvent) => {
+        // Prevent a wrapping label from re-opening the file picker on remove.
+        event.preventDefault();
+        event.stopPropagation();
+        onRemove();
+      }}
+    >
+      <Trash2 size={18} />
+    </Box>
+  );
+}
+
 function CSVReaderBox({
   acceptedFile,
   setAcceptedFile,
   zoneHover,
+  fileError,
   getRootProps,
   getRemoveFileProps,
-  Remove,
   ProgressBar,
 }: {
   acceptedFile: File | null;
   setAcceptedFile: (file: File | null) => void;
   zoneHover: boolean;
+  /** File-level validation message (e.g. over the row limit); turns the row red. */
+  fileError?: string;
   getRootProps: () => Record<string, unknown>;
   getRemoveFileProps: () => Record<string, unknown>;
-  Remove: React.ComponentType;
   ProgressBar: React.ComponentType;
 }) {
   useEffect(() => {
@@ -884,45 +1063,37 @@ function CSVReaderBox({
   }, [acceptedFile, setAcceptedFile]);
 
   return (
-    <Box
-      {...getRootProps()}
-      borderRadius={"lg"}
-      borderWidth={2}
-      borderColor={zoneHover ? "border.emphasized" : "border"}
-      borderStyle="dashed"
-      padding={10}
-      textAlign="center"
-      cursor="pointer"
-      width="full"
-    >
-      {acceptedFile ? (
-        <>
-          <Box
-            bg="bg.muted"
-            padding={4}
-            borderRadius={"lg"}
-            position="relative"
-          >
-            <VStack>
-              <Text>{formatFileSize(acceptedFile.size)}</Text>
-              <Text>{acceptedFile.name}</Text>
-            </VStack>
-            <ProgressBar />
-
+    <VStack width="full" gap={3} align="stretch">
+      <Box
+        {...getRootProps()}
+        {...dropzoneSurfaceProps(zoneHover)}
+        style={DROPZONE_DOTTED_STYLE}
+      >
+        <DropzonePrompt />
+      </Box>
+      {acceptedFile && (
+        <DatasetFileRow
+          name={acceptedFile.name}
+          sizeLabel={formatFileSize(acceptedFile.size)}
+          status={fileError ? "error" : "selected"}
+          message={fileError}
+          action={
             <Box
-              position="absolute"
-              right={-1}
-              top={-1}
+              as="button"
+              type="button"
+              color="fg.muted"
+              display="flex"
+              _hover={{ color: "red.500" }}
+              aria-label="Remove file"
               {...getRemoveFileProps()}
             >
-              <Remove />
+              <Trash2 size={18} />
             </Box>
-          </Box>
-        </>
-      ) : (
-        <Text>Drop CSV or JSONL file or click here to upload</Text>
+          }
+        />
       )}
-    </Box>
+      <ProgressBar />
+    </VStack>
   );
 }
 
@@ -937,10 +1108,16 @@ function CSVReaderBox({
 function RawFileDropzone({
   onRawFile,
   onUploadRemoved,
+  uploadStatus,
+  fileError,
   children,
 }: {
   onRawFile?: (file: File | null) => void;
   onUploadRemoved?: () => void;
+  /** Set to "uploading" while the raw file streams to storage. */
+  uploadStatus?: "uploading";
+  /** File-level validation/upload message; turns the row red. */
+  fileError?: string;
   children?: (hasAcceptedFile: boolean) => React.ReactNode;
 }) {
   const [zoneHover, setZoneHover] = useState(false);
@@ -956,75 +1133,65 @@ function RawFileDropzone({
     }
   };
 
+  const isUploading = uploadStatus === "uploading";
+  const rowStatus: DatasetFileStatus = fileError
+    ? "error"
+    : isUploading
+      ? "uploading"
+      : "selected";
+
   return (
-    <>
-      <Box
-        as="label"
-        borderRadius={"lg"}
-        borderWidth={2}
-        borderColor={zoneHover ? "border.emphasized" : "border"}
-        borderStyle="dashed"
-        padding={10}
-        textAlign="center"
-        cursor="pointer"
-        width="full"
-        display="block"
-        onDragOver={(event) => {
-          event.preventDefault();
-          setZoneHover(true);
-        }}
-        onDragLeave={(event) => {
-          event.preventDefault();
-          setZoneHover(false);
-        }}
-        onDrop={(event) => {
-          event.preventDefault();
-          setZoneHover(false);
-          const file = event.dataTransfer?.files?.[0] ?? null;
-          if (file) setFile(file);
-        }}
-      >
-        <input
-          type="file"
-          accept=".csv,.json,.jsonl"
-          style={{ display: "none" }}
-          onChange={(event) => {
-            const file = event.target.files?.[0] ?? null;
+    <VStack width="full" gap={3} align="stretch">
+      {/* While the file streams, the dropzone is replaced by its status row so
+          the user can't swap files mid-upload (single-file flow). */}
+      {!isUploading && (
+        <Box
+          as="label"
+          {...dropzoneSurfaceProps(zoneHover)}
+          style={DROPZONE_DOTTED_STYLE}
+          display="block"
+          onDragOver={(event) => {
+            event.preventDefault();
+            setZoneHover(true);
+          }}
+          onDragLeave={(event) => {
+            event.preventDefault();
+            setZoneHover(false);
+          }}
+          onDrop={(event) => {
+            event.preventDefault();
+            setZoneHover(false);
+            const file = event.dataTransfer?.files?.[0] ?? null;
             if (file) setFile(file);
           }}
+        >
+          <input
+            type="file"
+            accept=".csv,.json,.jsonl"
+            style={{ display: "none" }}
+            onChange={(event) => {
+              const file = event.target.files?.[0] ?? null;
+              if (file) setFile(file);
+            }}
+          />
+          <DropzonePrompt />
+        </Box>
+      )}
+      {acceptedFile && (
+        <DatasetFileRow
+          name={acceptedFile.name}
+          sizeLabel={formatFileSize(acceptedFile.size)}
+          metaLabel={new Date(acceptedFile.lastModified).toLocaleDateString()}
+          status={rowStatus}
+          message={fileError}
+          action={
+            isUploading ? undefined : (
+              <RemoveFileButton onRemove={() => setFile(null)} />
+            )
+          }
         />
-        {acceptedFile ? (
-          <Box
-            bg="bg.muted"
-            padding={4}
-            borderRadius={"lg"}
-            position="relative"
-          >
-            <VStack>
-              <Text>{formatFileSize(acceptedFile.size)}</Text>
-              <Text>{acceptedFile.name}</Text>
-            </VStack>
-            <Box
-              position="absolute"
-              right={-1}
-              top={-1}
-              onClick={(event) => {
-                // Prevent the label from re-opening the file picker on remove.
-                event.preventDefault();
-                event.stopPropagation();
-                setFile(null);
-              }}
-            >
-              <Text fontSize="lg" lineHeight="1" cursor="pointer">
-                ×
-              </Text>
-            </Box>
-          </Box>
-        ) : (
-          <Text>Drop CSV or JSONL file or click here to upload</Text>
-        )}
-      </Box>
+      )}
       {children ? children(acceptedFile !== null) : null}
-    </>
+    </VStack>
   );
 }

--- a/langwatch/src/components/datasets/__tests__/CSVReaderComponent.unit.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/CSVReaderComponent.unit.test.tsx
@@ -39,7 +39,7 @@ vi.mock("react-papaparse", async (importActual) => {
   };
 });
 
-import { CSVReaderComponent } from "../UploadCSVModal";
+import { CSVReaderComponent } from "../UploadCSVDrawer";
 
 function renderReader(props: {
   parse?: boolean;

--- a/langwatch/src/components/datasets/__tests__/CSVReaderComponent.unit.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/CSVReaderComponent.unit.test.tsx
@@ -101,7 +101,9 @@ describe("CSVReaderComponent", () => {
       );
       onRawFile.mockClear();
 
-      await userEvent.click(screen.getByText("×"));
+      await userEvent.click(
+        screen.getByRole("button", { name: /remove file/i }),
+      );
 
       expect(onRawFile).toHaveBeenCalledWith(null);
       expect(onUploadRemoved).toHaveBeenCalledTimes(1);

--- a/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
@@ -353,8 +353,8 @@ describe("DatasetUploadProcessing", () => {
     });
   });
 
-  describe("when the dataset reports ready but has no columns yet", () => {
-    it("keeps showing preparing (does not trust the schema-default ready)", () => {
+  describe("when a degenerate dataset is ready with no columns", () => {
+    it("treats ready as terminal (no endless spinner) — finalize guarantees processing first", () => {
       getByIdResult.data = {
         id: "dataset_1",
         name: "ds",
@@ -365,8 +365,11 @@ describe("DatasetUploadProcessing", () => {
       const onReady = vi.fn();
       renderProcessing({ onReady });
 
-      expect(screen.getByText(/preparing your dataset/i)).toBeInTheDocument();
-      expect(onReady).not.toHaveBeenCalled();
+      // Not stuck on a spinner; "ready" is honored once the server says so.
+      expect(
+        screen.queryByText(/preparing your dataset/i),
+      ).not.toBeInTheDocument();
+      expect(onReady).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
@@ -8,7 +8,13 @@
  * hooks). Binds specs/datasets/dataset-upload-dropzone.feature.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -20,6 +26,10 @@ const getByIdResult: {
   isFetched: boolean;
 } = { data: undefined, isFetched: false };
 const retryDatasetNormalize = vi.fn();
+const requestDirectUpload = vi.fn();
+const putFileToPresignedUrl = vi.fn();
+const finalizeDirectUpload = vi.fn();
+const abortPendingUpload = vi.fn();
 
 vi.mock("~/utils/api", () => ({
   api: {
@@ -47,6 +57,11 @@ vi.mock("../services/directUpload", async (importActual) => {
     ...actual,
     retryDatasetNormalize: (...args: unknown[]) =>
       retryDatasetNormalize(...args),
+    requestDirectUpload: (...args: unknown[]) => requestDirectUpload(...args),
+    putFileToPresignedUrl: (...args: unknown[]) =>
+      putFileToPresignedUrl(...args),
+    finalizeDirectUpload: (...args: unknown[]) => finalizeDirectUpload(...args),
+    abortPendingUpload: (...args: unknown[]) => abortPendingUpload(...args),
   };
 });
 
@@ -71,7 +86,12 @@ vi.mock("../ui/toaster", () => ({
 import {
   CSVReaderComponent,
   DatasetUploadProcessing,
+  UploadCSVForm,
 } from "../UploadCSVDrawer";
+
+/** Error shaped like an aborted fetch. */
+const abortError = () =>
+  Object.assign(new Error("aborted"), { name: "AbortError" });
 
 const wrap = (ui: React.ReactElement) =>
   render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
@@ -360,6 +380,78 @@ describe("DatasetUploadProcessing", () => {
         screen.queryByText(/preparing your dataset/i),
       ).not.toBeInTheDocument();
       expect(onReady).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("UploadCSVForm cancel", () => {
+  describe("when cancel lands before requestDirectUpload resolves", () => {
+    it("reaps the just-minted dataset row instead of stranding it", async () => {
+      const user = userEvent.setup();
+      // requestDirectUpload is held open so we can cancel mid-flight, then
+      // resolve it AFTER the cancel — the server has minted the row by then.
+      let resolveRequest!: (value: {
+        datasetId: string;
+        uploadUrl: string;
+        slug: string;
+        stagingKey: string;
+      }) => void;
+      requestDirectUpload.mockReturnValue(
+        new Promise((resolve) => {
+          resolveRequest = resolve;
+        }),
+      );
+      // The PUT fails immediately because the cancel already aborted the signal.
+      putFileToPresignedUrl.mockImplementation(
+        (_url: string, _file: File, signal?: AbortSignal) => {
+          if (signal?.aborted) return Promise.reject(abortError());
+          return Promise.resolve();
+        },
+      );
+      abortPendingUpload.mockResolvedValue(undefined);
+
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <UploadCSVForm
+            setUploadedDataset={vi.fn()}
+            uploadedDataset={undefined}
+            uploadCSVData={vi.fn()}
+            enableDirectUpload={true}
+            onDirectUploadComplete={vi.fn()}
+          />
+        </ChakraProvider>,
+      );
+
+      await user.upload(
+        fileInput(),
+        new File(["x"], "racey.csv", { type: "text/csv" }),
+      );
+      await user.click(screen.getByRole("button", { name: /^upload$/i }));
+
+      // Mid-flight: the cancel control is shown; click it before the presign
+      // resolves (so handleCancelUpload sees no id yet → reaps nothing).
+      await user.click(
+        await screen.findByRole("button", { name: /cancel upload/i }),
+      );
+      expect(abortPendingUpload).not.toHaveBeenCalled();
+
+      // Now the presign resolves: the row exists, the aborted PUT throws, and
+      // the catch must reap the now-known id.
+      resolveRequest({
+        datasetId: "dataset_racey",
+        uploadUrl: "https://s3.example/put",
+        slug: "s",
+        stagingKey: "staging/proj/u",
+      });
+
+      await waitFor(() => {
+        expect(abortPendingUpload).toHaveBeenCalledWith({
+          projectId: "proj_1",
+          datasetId: "dataset_racey",
+        });
+      });
+      // Reaped exactly once.
+      expect(abortPendingUpload).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
@@ -157,6 +157,26 @@ describe("the upload dropzone", () => {
         screen.getByRole("button", { name: /remove file/i }),
       ).toBeInTheDocument();
     });
+
+    it("resets the native input value so the same file can be re-picked after a remove", async () => {
+      const user = userEvent.setup();
+      wrap(
+        <CSVReaderComponent
+          parse={false}
+          onUploadAccepted={vi.fn()}
+          onRawFile={vi.fn()}
+        />,
+      );
+
+      await user.upload(
+        fileInput(),
+        new File(["x"], "repick.csv", { type: "text/csv" }),
+      );
+
+      // The captured file lives in React state; the input is cleared so the OS
+      // dialog re-firing `change` for the same file isn't suppressed.
+      expect(fileInput().value).toBe("");
+    });
   });
 
   describe("when the chosen file is removed", () => {

--- a/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
@@ -1,0 +1,368 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Component tests for the Upload CSV drawer pieces: the redesigned dropzone
+ * (empty state, drag highlight, file status row, collapse), the in-drawer
+ * processing view, the cancel control, and error routing. Renders the
+ * components and mocks the boundaries (upload service, tRPC, project/router
+ * hooks). Binds specs/datasets/dataset-upload-dropzone.feature.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+// Mutable result the mocked `dataset.getById.useQuery` returns, so each test
+// drives DatasetUploadProcessing into a specific state.
+const getByIdResult: {
+  data: Record<string, unknown> | null | undefined;
+  isFetched: boolean;
+} = { data: undefined, isFetched: false };
+const retryDatasetNormalize = vi.fn();
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({
+      dataset: {
+        findNextName: { fetch: vi.fn().mockResolvedValue("New Dataset") },
+      },
+    }),
+    dataset: {
+      getById: {
+        useQuery: () => ({
+          data: getByIdResult.data,
+          isFetched: getByIdResult.isFetched,
+          refetch: vi.fn(),
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("../services/directUpload", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../services/directUpload")>();
+  return {
+    ...actual,
+    retryDatasetNormalize: (...args: unknown[]) => retryDatasetNormalize(...args),
+  };
+});
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj_1", slug: "proj" },
+  }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ closeDrawer: vi.fn() }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("../ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+import {
+  CSVReaderComponent,
+  DatasetUploadProcessing,
+} from "../UploadCSVDrawer";
+
+const wrap = (ui: React.ReactElement) =>
+  render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+
+const fileInput = () =>
+  document.querySelector('input[type="file"]') as HTMLInputElement;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  getByIdResult.data = undefined;
+  getByIdResult.isFetched = false;
+});
+
+describe("the upload dropzone", () => {
+  describe("when no file has been chosen", () => {
+    /** @scenario The empty dropzone invites a file */
+    it("invites a file with the prompt and supported types", () => {
+      wrap(
+        <CSVReaderComponent parse={false} onUploadAccepted={vi.fn()} />,
+      );
+
+      expect(screen.getByText(/drag and drop file/i)).toBeInTheDocument();
+      expect(screen.getByText(/click to browse/i)).toBeInTheDocument();
+      expect(screen.getByText(/supported files/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when a file is dragged over the zone", () => {
+    /** @scenario Dragging a file over the dropzone highlights it */
+    it("marks the zone active while the file is over it and clears on leave", () => {
+      const { container } = wrap(
+        <CSVReaderComponent parse={false} onUploadAccepted={vi.fn()} />,
+      );
+      const zone = container.querySelector("[data-active]") as HTMLElement;
+
+      expect(zone).toHaveAttribute("data-active", "false");
+      fireEvent.dragOver(zone);
+      expect(zone).toHaveAttribute("data-active", "true");
+      fireEvent.dragLeave(zone);
+      expect(zone).toHaveAttribute("data-active", "false");
+    });
+  });
+
+  describe("when a file is chosen", () => {
+    /** @scenario A chosen file appears as a status row */
+    it("shows a row with the file name and its size", async () => {
+      const user = userEvent.setup();
+      wrap(
+        <CSVReaderComponent
+          parse={false}
+          onUploadAccepted={vi.fn()}
+          onRawFile={vi.fn()}
+        />,
+      );
+
+      await user.upload(
+        fileInput(),
+        new File(["a,b\n1,2\n"], "chosen.csv", { type: "text/csv" }),
+      );
+
+      expect(await screen.findByText("chosen.csv")).toBeInTheDocument();
+      expect(screen.getByText(/\bB\b|KB|MB/)).toBeInTheDocument(); // size label
+      expect(
+        screen.getByRole("button", { name: /remove file/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when the chosen file is removed", () => {
+    /** @scenario Removing the chosen file returns the empty dropzone */
+    it("drops the row and notifies removal", async () => {
+      const user = userEvent.setup();
+      const onUploadRemoved = vi.fn();
+      wrap(
+        <CSVReaderComponent
+          parse={false}
+          onUploadAccepted={vi.fn()}
+          onRawFile={vi.fn()}
+          onUploadRemoved={onUploadRemoved}
+        />,
+      );
+
+      await user.upload(
+        fileInput(),
+        new File(["x"], "gone.csv", { type: "text/csv" }),
+      );
+      expect(await screen.findByText("gone.csv")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /remove file/i }));
+
+      expect(screen.queryByText("gone.csv")).not.toBeInTheDocument();
+      expect(onUploadRemoved).toHaveBeenCalledTimes(1);
+      // The empty prompt is still mounted (it collapses, it doesn't unmount).
+      expect(screen.getByText(/drag and drop file/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when the chosen file breaks a limit", () => {
+    /** @scenario A file that breaks a limit is rejected on its row */
+    it("marks the file row with the error message", async () => {
+      const user = userEvent.setup();
+      const { rerender } = wrap(
+        <CSVReaderComponent
+          parse={false}
+          onUploadAccepted={vi.fn()}
+          onRawFile={vi.fn()}
+        />,
+      );
+
+      await user.upload(
+        fileInput(),
+        new File(["x"], "big.csv", { type: "text/csv" }),
+      );
+      expect(await screen.findByText("big.csv")).toBeInTheDocument();
+
+      // The host computes the validation and passes it down.
+      rerender(
+        <ChakraProvider value={defaultSystem}>
+          <CSVReaderComponent
+            parse={false}
+            onUploadAccepted={vi.fn()}
+            onRawFile={vi.fn()}
+            fileError="File is too large"
+          />
+        </ChakraProvider>,
+      );
+
+      expect(screen.getByTestId("upload-error")).toHaveTextContent(
+        /file is too large/i,
+      );
+    });
+  });
+
+  describe("when the file is uploading", () => {
+    /** @scenario An uploading file shows progress and can be cancelled */
+    it("shows the uploading row and a cancel control that fires onCancel", async () => {
+      const user = userEvent.setup();
+      const onCancel = vi.fn();
+      const { rerender } = wrap(
+        <CSVReaderComponent
+          parse={false}
+          onUploadAccepted={vi.fn()}
+          onRawFile={vi.fn()}
+          onCancel={onCancel}
+        />,
+      );
+
+      await user.upload(
+        fileInput(),
+        new File(["x"], "uploading.csv", { type: "text/csv" }),
+      );
+
+      rerender(
+        <ChakraProvider value={defaultSystem}>
+          <CSVReaderComponent
+            parse={false}
+            onUploadAccepted={vi.fn()}
+            onRawFile={vi.fn()}
+            uploadStatus="uploading"
+            onCancel={onCancel}
+          />
+        </ChakraProvider>,
+      );
+
+      const cancel = screen.getByRole("button", { name: /cancel upload/i });
+      expect(cancel).toBeInTheDocument();
+      // The trash remove control is replaced by cancel while uploading.
+      expect(
+        screen.queryByRole("button", { name: /remove file/i }),
+      ).not.toBeInTheDocument();
+
+      await user.click(cancel);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("DatasetUploadProcessing", () => {
+  const renderProcessing = (overrides?: {
+    onReady?: () => void;
+    onViewDataset?: () => void;
+  }) =>
+    wrap(
+      <DatasetUploadProcessing
+        projectId="proj_1"
+        datasetId="dataset_1"
+        onReady={overrides?.onReady ?? vi.fn()}
+        onViewDataset={overrides?.onViewDataset ?? vi.fn()}
+      />,
+    );
+
+  describe("when the dataset is still processing", () => {
+    it("shows the preparing state and does not call onReady", () => {
+      getByIdResult.data = { id: "dataset_1", name: "ds", status: "processing" };
+      getByIdResult.isFetched = true;
+      const onReady = vi.fn();
+      renderProcessing({ onReady });
+
+      expect(screen.getByText(/preparing your dataset/i)).toBeInTheDocument();
+      expect(onReady).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the dataset becomes ready", () => {
+    /** @scenario A finished upload shows a ready row without leaving the drawer */
+    it("shows the ready row with a View dataset action and calls onReady once", () => {
+      getByIdResult.data = {
+        id: "dataset_1",
+        name: "ds",
+        status: "ready",
+        columnTypes: [{ name: "question", type: "string" }],
+      };
+      getByIdResult.isFetched = true;
+      const onReady = vi.fn();
+      const onViewDataset = vi.fn();
+      const { rerender } = renderProcessing({ onReady, onViewDataset });
+
+      expect(screen.getByText(/ready/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /view dataset/i }),
+      ).toBeInTheDocument();
+      expect(onReady).toHaveBeenCalledTimes(1);
+
+      // A re-render with the same ready data must not fire onReady again.
+      rerender(
+        <ChakraProvider value={defaultSystem}>
+          <DatasetUploadProcessing
+            projectId="proj_1"
+            datasetId="dataset_1"
+            onReady={onReady}
+            onViewDataset={onViewDataset}
+          />
+        </ChakraProvider>,
+      );
+      expect(onReady).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the dataset reports ready but has no columns yet", () => {
+    it("keeps showing preparing (does not trust the schema-default ready)", () => {
+      getByIdResult.data = {
+        id: "dataset_1",
+        name: "ds",
+        status: "ready",
+        columnTypes: [],
+      };
+      getByIdResult.isFetched = true;
+      const onReady = vi.fn();
+      renderProcessing({ onReady });
+
+      expect(screen.getByText(/preparing your dataset/i)).toBeInTheDocument();
+      expect(onReady).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the dataset failed to prepare", () => {
+    it("shows the error message and a Retry action", () => {
+      getByIdResult.data = {
+        id: "dataset_1",
+        name: "ds",
+        status: "failed",
+        statusError: "boom",
+      };
+      getByIdResult.isFetched = true;
+      renderProcessing();
+
+      expect(screen.getByText("boom")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /retry/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when the dataset is gone", () => {
+    it("shows a terminal not-available message instead of an endless spinner", () => {
+      getByIdResult.data = null;
+      getByIdResult.isFetched = true;
+      const onReady = vi.fn();
+      renderProcessing({ onReady });
+
+      expect(
+        screen.getByText(/no longer available/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/preparing your dataset/i)).not.toBeInTheDocument();
+      expect(onReady).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
@@ -8,15 +8,9 @@
  * hooks). Binds specs/datasets/dataset-upload-dropzone.feature.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
 // Mutable result the mocked `dataset.getById.useQuery` returns, so each test
@@ -51,7 +45,8 @@ vi.mock("../services/directUpload", async (importActual) => {
     await importActual<typeof import("../services/directUpload")>();
   return {
     ...actual,
-    retryDatasetNormalize: (...args: unknown[]) => retryDatasetNormalize(...args),
+    retryDatasetNormalize: (...args: unknown[]) =>
+      retryDatasetNormalize(...args),
   };
 });
 
@@ -95,9 +90,7 @@ describe("the upload dropzone", () => {
   describe("when no file has been chosen", () => {
     /** @scenario The empty dropzone invites a file */
     it("invites a file with the prompt and supported types", () => {
-      wrap(
-        <CSVReaderComponent parse={false} onUploadAccepted={vi.fn()} />,
-      );
+      wrap(<CSVReaderComponent parse={false} onUploadAccepted={vi.fn()} />);
 
       expect(screen.getByText(/drag and drop file/i)).toBeInTheDocument();
       expect(screen.getByText(/click to browse/i)).toBeInTheDocument();
@@ -271,7 +264,11 @@ describe("DatasetUploadProcessing", () => {
 
   describe("when the dataset is still processing", () => {
     it("shows the preparing state and does not call onReady", () => {
-      getByIdResult.data = { id: "dataset_1", name: "ds", status: "processing" };
+      getByIdResult.data = {
+        id: "dataset_1",
+        name: "ds",
+        status: "processing",
+      };
       getByIdResult.isFetched = true;
       const onReady = vi.fn();
       renderProcessing({ onReady });
@@ -358,10 +355,10 @@ describe("DatasetUploadProcessing", () => {
       const onReady = vi.fn();
       renderProcessing({ onReady });
 
+      expect(screen.getByText(/no longer available/i)).toBeInTheDocument();
       expect(
-        screen.getByText(/no longer available/i),
-      ).toBeInTheDocument();
-      expect(screen.queryByText(/preparing your dataset/i)).not.toBeInTheDocument();
+        screen.queryByText(/preparing your dataset/i),
+      ).not.toBeInTheDocument();
       expect(onReady).not.toHaveBeenCalled();
     });
   });

--- a/langwatch/src/components/datasets/__tests__/UploadCSVFallbackGuard.integration.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/UploadCSVFallbackGuard.integration.test.tsx
@@ -66,7 +66,7 @@ import {
   DirectUploadUnavailableError,
   PresignedUploadFailedError,
 } from "../services/directUpload";
-import { UploadCSVForm } from "../UploadCSVModal";
+import { UploadCSVForm } from "../UploadCSVDrawer";
 
 const renderForm = () =>
   render(

--- a/langwatch/src/components/datasets/__tests__/UploadCSVFallbackGuard.integration.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/UploadCSVFallbackGuard.integration.test.tsx
@@ -13,7 +13,7 @@
  * first call — which must NOT fire for an oversize file.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -259,6 +259,67 @@ describe("UploadCSVForm 409-fallback size guard", () => {
       });
       // The size-guard fires before any in-browser parse of the oversize file.
       expect(textSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the user cancels while the presign request is still in flight", () => {
+    it("does NOT fall back or surface an error if the presign later rejects", async () => {
+      // The cancel control aborts the AbortController, but requestDirectUpload is
+      // not wired to it — so a no-storage install's DirectUploadUnavailableError
+      // can still reject AFTER the cancel. The catch must recognise the cancel
+      // (signal.aborted) and bail, NOT run the fallback parse / open the drawer.
+      let rejectPresign!: (reason: unknown) => void;
+      requestDirectUpload.mockReturnValue(
+        new Promise((_resolve, reject) => {
+          rejectPresign = reject;
+        }),
+      );
+      const uploadCSVData = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <UploadCSVForm
+            setUploadedDataset={vi.fn()}
+            uploadedDataset={undefined}
+            uploadCSVData={uploadCSVData}
+            enableDirectUpload={true}
+          />
+        </ChakraProvider>,
+      );
+
+      const smallFile = new File(["a,b\n1,2\n"], "small.csv", {
+        type: "text/csv",
+      });
+      // If the cancelled upload WRONGLY fell back, the parser would read the file.
+      const textSpy = vi
+        .spyOn(smallFile, "text")
+        .mockResolvedValue("a,b\n1,2\n");
+
+      const input = document.querySelector(
+        'input[type="file"]',
+      ) as HTMLInputElement;
+      await user.upload(input, smallFile);
+      await user.click(screen.getByRole("button", { name: /upload/i }));
+
+      // Presign is in flight → the row shows a Cancel control. Cancel now.
+      await waitFor(() => expect(requestDirectUpload).toHaveBeenCalledTimes(1));
+      await user.click(
+        await screen.findByRole("button", { name: /cancel upload/i }),
+      );
+
+      // The presign now rejects the way a no-storage install would — post-cancel.
+      await act(async () => {
+        rejectPresign(new DirectUploadUnavailableError());
+        // Flush the rejection through handleUpload's catch.
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // The cancel wins: no fallback parse, no drawer hand-off, no error banner.
+      expect(textSpy).not.toHaveBeenCalled();
+      expect(uploadCSVData).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("upload-error")).not.toBeInTheDocument();
     });
   });
 

--- a/langwatch/src/components/datasets/services/directUpload.ts
+++ b/langwatch/src/components/datasets/services/directUpload.ts
@@ -123,6 +123,7 @@ export async function requestDirectUpload({
 export async function putFileToPresignedUrl(
   uploadUrl: string,
   file: File,
+  signal?: AbortSignal,
 ): Promise<void> {
   const sameOrigin = uploadUrl.startsWith("/");
   let response: Response;
@@ -131,8 +132,14 @@ export async function putFileToPresignedUrl(
       method: "PUT",
       body: file,
       credentials: sameOrigin ? "include" : "omit",
+      signal,
     });
   } catch (error) {
+    // A user-initiated cancel aborts the fetch: propagate the AbortError as-is
+    // so the caller treats it as a cancel, not a CORS/network fallback signal.
+    if (error instanceof Error && error.name === "AbortError") {
+      throw error;
+    }
     // Same-origin (local-FS streaming route): a fetch rejection is a genuine
     // server/network failure, NOT a CORS-fallback signal — surface it directly
     // (falling back to in-browser parse can't help; the local route IS the

--- a/langwatch/src/components/drawerRegistry.ts
+++ b/langwatch/src/components/drawerRegistry.ts
@@ -26,7 +26,7 @@ import {
 import { AlertDrawer } from "./analytics/AlertDrawer";
 import { DashboardNameDrawer } from "./analytics/DashboardNameDrawer";
 import { SelectDatasetDrawer } from "./datasets/SelectDatasetDrawer";
-import { UploadCSVModal } from "./datasets/UploadCSVModal";
+import { UploadCSVDrawer } from "./datasets/UploadCSVDrawer";
 import { FeatureFlagsDrawer } from "./drawers/FeatureFlagsDrawer";
 import { SdkRadarDrawer } from "./drawers/SdkRadarDrawer";
 import { EditAutomationFilterDrawer } from "./EditAutomationFilterDrawer";
@@ -92,7 +92,7 @@ export const drawers = {
   addAnnotationQueue: AddAnnotationQueueDrawer,
   addDatasetRecord: AddDatasetRecordDrawerV2,
   llmModelCost: LLMModelCostDrawer,
-  uploadCSV: UploadCSVModal,
+  uploadCSV: UploadCSVDrawer,
   addOrEditDataset: AddOrEditDatasetDrawer,
   editAutomationFilter: EditAutomationFilterDrawer,
   seriesFilters: SeriesFiltersDrawer,

--- a/langwatch/src/optimization_studio/components/DatasetModal.tsx
+++ b/langwatch/src/optimization_studio/components/DatasetModal.tsx
@@ -34,7 +34,7 @@ import {
   DatasetEditorTable,
   type InMemoryDataset,
 } from "~/components/datasets/editor/DatasetEditorTable";
-import { UploadCSVModal } from "~/components/datasets/UploadCSVModal";
+import { UploadCSVDrawer } from "~/components/datasets/UploadCSVDrawer";
 import { useDrawer } from "~/hooks/useDrawer";
 import type { DatasetColumns } from "~/server/datasets/types";
 import { Dialog } from "../../components/ui/dialog";
@@ -268,7 +268,7 @@ export function DatasetModal({
         )}
       </Dialog.Content>
       {uploadCSVModal.open && (
-        <UploadCSVModal
+        <UploadCSVDrawer
           isOpen={uploadCSVModal.open}
           onClose={uploadCSVModal.onClose}
           // The workflow picker needs the dataset's columns synchronously to

--- a/langwatch/src/pages/[project]/datasets.tsx
+++ b/langwatch/src/pages/[project]/datasets.tsx
@@ -32,7 +32,7 @@ import { useRouter } from "~/utils/compat/next-router";
 import { AddOrEditDatasetDrawer } from "../../components/AddOrEditDatasetDrawer";
 import { DashboardLayout } from "../../components/DashboardLayout";
 import { CopyDatasetDialog } from "../../components/datasets/CopyDatasetDialog";
-import { UploadCSVModal } from "../../components/datasets/UploadCSVModal";
+import { UploadCSVDrawer } from "../../components/datasets/UploadCSVDrawer";
 import { Link } from "../../components/ui/link";
 import { Menu } from "../../components/ui/menu";
 import { toaster } from "../../components/ui/toaster";
@@ -365,7 +365,7 @@ function DatasetsPage() {
           addEditDatasetDrawer.onClose();
         }}
       />
-      <UploadCSVModal
+      <UploadCSVDrawer
         isOpen={uploadCSVModal.open}
         onClose={uploadCSVModal.onClose}
         onSuccess={() => {

--- a/langwatch/src/tests/pages/datasets-list.integration.test.tsx
+++ b/langwatch/src/tests/pages/datasets-list.integration.test.tsx
@@ -102,8 +102,8 @@ vi.mock("~/utils/api", () => ({
   },
 }));
 
-vi.mock("~/components/datasets/UploadCSVModal", () => ({
-  UploadCSVModal: ({ isOpen }: { isOpen: boolean }) =>
+vi.mock("~/components/datasets/UploadCSVDrawer", () => ({
+  UploadCSVDrawer: ({ isOpen }: { isOpen: boolean }) =>
     isOpen ? <div data-testid="upload-csv-modal" /> : null,
 }));
 

--- a/langwatch/src/tests/pages/datasets.lite-member.integration.test.tsx
+++ b/langwatch/src/tests/pages/datasets.lite-member.integration.test.tsx
@@ -6,13 +6,14 @@
  * Verifies that edit/delete menu items are gated behind
  * the `datasets:manage` permission for lite members.
  */
-import { cleanup, render, screen } from "@testing-library/react";
+
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockIsLiteMemberRef, mockDatasetsList, mockDeleteMutate } =
-  vi.hoisted(() => {
+const { mockIsLiteMemberRef, mockDatasetsList, mockDeleteMutate } = vi.hoisted(
+  () => {
     return {
       mockIsLiteMemberRef: {
         current: false,
@@ -35,7 +36,8 @@ const { mockIsLiteMemberRef, mockDatasetsList, mockDeleteMutate } =
       },
       mockDeleteMutate: vi.fn(),
     };
-  });
+  },
+);
 
 vi.mock("~/utils/compat/next-router", () => ({
   useRouter: () => ({
@@ -122,14 +124,12 @@ vi.mock("~/utils/trpcError", () => ({
   isHandledByGlobalHandler: vi.fn(() => false),
 }));
 
-vi.mock("~/components/datasets/UploadCSVModal", () => ({
-  UploadCSVModal: () => <div data-testid="upload-csv-modal" />,
+vi.mock("~/components/datasets/UploadCSVDrawer", () => ({
+  UploadCSVDrawer: () => <div data-testid="upload-csv-modal" />,
 }));
 
 vi.mock("~/components/AddOrEditDatasetDrawer", () => ({
-  AddOrEditDatasetDrawer: () => (
-    <div data-testid="add-edit-dataset-drawer" />
-  ),
+  AddOrEditDatasetDrawer: () => <div data-testid="add-edit-dataset-drawer" />,
 }));
 
 vi.mock("~/components/datasets/CopyDatasetDialog", () => ({
@@ -154,21 +154,15 @@ vi.mock("~/components/ui/layouts/PageLayout", () => ({
     Container: ({ children }: { children?: ReactNode }) => (
       <div>{children}</div>
     ),
-    Content: ({ children }: { children?: ReactNode }) => (
-      <div>{children}</div>
-    ),
+    Content: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   },
 }));
 
 vi.mock("~/components/ui/menu", () => ({
   Menu: {
     Root: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-    Trigger: ({ children }: { children?: ReactNode }) => (
-      <div>{children}</div>
-    ),
-    Content: ({ children }: { children?: ReactNode }) => (
-      <div>{children}</div>
-    ),
+    Trigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Content: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
     Item: ({
       children,
       ...props
@@ -196,9 +190,7 @@ vi.mock("~/components/ui/link", () => ({
 }));
 
 // Lazy import to ensure mocks are set up first
-const { default: DatasetsPage } = await import(
-  "~/pages/[project]/datasets"
-);
+const { default: DatasetsPage } = await import("~/pages/[project]/datasets");
 
 function renderPage() {
   return render(

--- a/specs/datasets/dataset-upload-dropzone.feature
+++ b/specs/datasets/dataset-upload-dropzone.feature
@@ -1,0 +1,57 @@
+Feature: Dataset upload dropzone states
+
+  The "Upload CSV" drawer presents a single dropzone whose look reflects where
+  the user is in the flow: an inviting empty state, a clear highlight while a
+  file is dragged over it, and — once a file is chosen — a status row that
+  shows the file's name, size and what is happening to it (selected, uploading,
+  ready, or rejected). One CSV makes one dataset; the dropzone never accepts a
+  batch.
+
+  Background:
+    Given I am on the datasets page
+    And I open the "Upload CSV" drawer
+
+  @unit
+  Scenario: The empty dropzone invites a file
+    When no file has been chosen yet
+    Then the dropzone shows an upload illustration
+    And it reads "Drag and drop file, or click to browse"
+    And it lists the supported file types
+
+  @unit
+  Scenario: Dragging a file over the dropzone highlights it
+    When I drag a file over the dropzone
+    Then the dropzone is highlighted as an active drop target
+    And the highlight clears when the file leaves the dropzone
+
+  @unit
+  Scenario: A chosen file appears as a status row
+    When I choose a CSV file
+    Then the dropzone shows a row with the file name and its size
+    And the row offers a way to remove the file
+
+  @unit
+  Scenario: Removing the chosen file returns the empty dropzone
+    Given I have chosen a CSV file
+    When I remove it from the row
+    Then the dropzone returns to its empty, inviting state
+
+  @unit
+  Scenario: A file that breaks a limit is rejected on its row
+    Given object storage is unavailable on this install
+    When I choose a file larger than the in-browser limit
+    Then the file's row is marked as an error
+    And the row explains the file is too large
+    And the upload is not started
+
+  @integration
+  Scenario: An uploading file shows progress and can be cancelled
+    When I upload a CSV
+    Then its row shows it is uploading
+    And the row offers to cancel
+
+  @integration
+  Scenario: A finished upload shows a ready row without leaving the drawer
+    When my uploaded dataset finishes preparing
+    Then its row shows it is ready
+    And I stay in the drawer until I choose to view the dataset

--- a/specs/datasets/dataset-upload-dropzone.feature
+++ b/specs/datasets/dataset-upload-dropzone.feature
@@ -44,13 +44,13 @@ Feature: Dataset upload dropzone states
     And the row explains the file is too large
     And the upload is not started
 
-  @integration
+  @unit
   Scenario: An uploading file shows progress and can be cancelled
-    When I upload a CSV
+    When the file is uploading
     Then its row shows it is uploading
     And the row offers to cancel
 
-  @integration
+  @unit
   Scenario: A finished upload shows a ready row without leaving the drawer
     When my uploaded dataset finishes preparing
     Then its row shows it is ready


### PR DESCRIPTION
## Why

The "Upload CSV" surface was registered as a drawer but rendered a centered modal, and the direct upload (ADR-032 D4) navigated away to the dataset page to watch async processing. This turns it into one coherent drawer flow and gives the dropzone the polish the rest of the dataset UI already has.

Builds on the open epic PR #4908 (`feat/datasets-s3-reads`); #5067 (scan-before-lock) is already merged into that branch.

## What changed

- **Modal → drawer:** `UploadCSVModal` → `UploadCSVDrawer`; renders a `Drawer` (size `xl`, matching the `AddOrEditDatasetDrawer` it hands off to). Component + file renamed so the name matches what it renders.
- **Async upload stays in the drawer:** the direct upload no longer navigates to the dataset page; it polls status in place (processing → ready / failed, with retry), refreshes the list on ready, and offers an explicit "View dataset".
- **Redesigned dropzone:** dotted-grid empty state with a cloud icon + "Drag and drop file, or click to browse" and supported types; hover / drag-over highlight; the chosen file renders as a status row (icon + name + size·date + remove).
- **Error placement:** system/storage failures → alert at the top of the drawer; file-level validation (too large / over the row limit) → inline on the file's row.
- **Upload experience polish:** the cloud icon softly grows on hover; the file name sweeps a rainbow gradient while uploading; the trash control becomes an **X** that cancels the in-flight upload; the drag-and-drop container smoothly collapses once a file is chosen and expands back on remove/cancel; the Upload button shows a loading state.

## How it works

- Cancel threads an `AbortController` into `putFileToPresignedUrl` (new optional `signal`); on cancel it aborts the PUT, reaps the pending `uploading` row, and clears the file so the dropzone expands back in.
- The rainbow name reuses the PostHog rainbow-scroll recipe (same as `ShikiCommandBox`).
- The collapse uses the CSS grid `1fr→0fr` trick (no JS height measuring).

## Test plan

- Unit: `CSVReaderComponent.unit.test.tsx`, `directUpload.unit.test.ts` — 17 passing; `pnpm typecheck` clean.
- `UploadCSVFallbackGuard.integration.test.tsx` assertions (the `upload-error` hook) preserved; runs in CI (needs the container runner, not available locally).
- Spec: `specs/datasets/dataset-upload-dropzone.feature`.

## Deployment Impact

None. Frontend-only UI changes plus a backward-compatible optional `AbortSignal` parameter on `putFileToPresignedUrl`. No schema, API, or infra changes.