### PR TITLE
perf(clickhouse): add time predicate to analytics stored_spans JOINs

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -70,6 +70,24 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain("StartTime < {currentEnd:DateTime64(3)}");
     });
 
+    // A span groupBy (e.g. metadata.span_type) resolves to a `JOIN (... FROM
+    // stored_spans ...)` rather than a filter subquery. That JOIN path was
+    // previously unbounded and cold-scanned every weekly partition. It must
+    // carry the same StartTime envelope.
+    it("bounds the stored_spans JOIN to the date envelope by StartTime", () => {
+      const input = {
+        ...baseInput,
+        groupBy: "metadata.span_type" as const,
+      };
+      const result = buildTimeseriesQuery(input);
+
+      // The JOIN subquery filters stored_spans by StartTime, not just TenantId.
+      expect(result.sql).toMatch(
+        /JOIN \(SELECT[\s\S]*FROM stored_spans WHERE TenantId = \{tenantId:String\} AND StartTime >= \{previousStart:DateTime64\(3\)\}/,
+      );
+      expect(result.sql).toContain("StartTime < {currentEnd:DateTime64(3)}");
+    });
+
     it("includes date truncation for timescale", () => {
       const result = buildTimeseriesQuery(baseInput);
 

--- a/langwatch/src/server/analytics/clickhouse/__tests__/field-mappings.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/field-mappings.test.ts
@@ -200,6 +200,29 @@ describe("field-mappings", () => {
       expect(join).toContain("ts.TenantId = es.TenantId");
       expect(join).toContain("ts.TraceId = es.TraceId");
     });
+
+    it("leaves the stored_spans JOIN unbounded on StartTime when no filter is passed", () => {
+      const join = buildJoinClause("stored_spans");
+      // StartTime is a selected column, but there must be no StartTime predicate:
+      // the WHERE ends right after the tenant filter.
+      expect(join).not.toContain("StartTime >=");
+      expect(join).not.toContain("StartTime <");
+      expect(join).toContain("WHERE TenantId = {tenantId:String}) ss");
+    });
+
+    it("injects the span time filter into the stored_spans JOIN when provided", () => {
+      const filter =
+        "AND StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY AND StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
+      const join = buildJoinClause("stored_spans", undefined, filter);
+      // The bound lands inside the subquery WHERE, before the closing paren/alias.
+      expect(join).toContain(`TenantId = {tenantId:String} ${filter})`);
+    });
+
+    it("ignores the span time filter for evaluation_runs", () => {
+      const filter = "AND StartTime >= {startDate:DateTime64(3)}";
+      const join = buildJoinClause("evaluation_runs", undefined, filter);
+      expect(join).not.toContain("StartTime");
+    });
   });
 
   describe("qualifiedColumn", () => {

--- a/langwatch/src/server/analytics/clickhouse/__tests__/field-mappings.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/field-mappings.test.ts
@@ -180,11 +180,11 @@ describe("field-mappings", () => {
 
   describe("buildJoinClause", () => {
     it("returns empty string for trace_summaries", () => {
-      expect(buildJoinClause("trace_summaries")).toBe("");
+      expect(buildJoinClause({ table: "trace_summaries" })).toBe("");
     });
 
     it("builds correct JOIN for stored_spans with column pruning", () => {
-      const join = buildJoinClause("stored_spans");
+      const join = buildJoinClause({ table: "stored_spans" });
       expect(join).toContain("FROM stored_spans");
       expect(join).toContain("TenantId = {tenantId:String}");
       expect(join).toContain("ts.TenantId = ss.TenantId");
@@ -194,7 +194,7 @@ describe("field-mappings", () => {
     });
 
     it("builds correct JOIN for evaluation_runs", () => {
-      const join = buildJoinClause("evaluation_runs");
+      const join = buildJoinClause({ table: "evaluation_runs" });
       expect(join).toContain("FROM evaluation_runs");
       expect(join).toContain("GROUP BY TenantId, EvaluationId");
       expect(join).toContain("ts.TenantId = es.TenantId");
@@ -202,7 +202,7 @@ describe("field-mappings", () => {
     });
 
     it("leaves the stored_spans JOIN unbounded on StartTime when no filter is passed", () => {
-      const join = buildJoinClause("stored_spans");
+      const join = buildJoinClause({ table: "stored_spans" });
       // StartTime is a selected column, but there must be no StartTime predicate:
       // the WHERE ends right after the tenant filter.
       expect(join).not.toContain("StartTime >=");
@@ -213,14 +213,20 @@ describe("field-mappings", () => {
     it("injects the span time filter into the stored_spans JOIN when provided", () => {
       const filter =
         "AND StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY AND StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
-      const join = buildJoinClause("stored_spans", undefined, filter);
+      const join = buildJoinClause({
+        table: "stored_spans",
+        spanTimeFilter: filter,
+      });
       // The bound lands inside the subquery WHERE, before the closing paren/alias.
       expect(join).toContain(`TenantId = {tenantId:String} ${filter})`);
     });
 
     it("ignores the span time filter for evaluation_runs", () => {
       const filter = "AND StartTime >= {startDate:DateTime64(3)}";
-      const join = buildJoinClause("evaluation_runs", undefined, filter);
+      const join = buildJoinClause({
+        table: "evaluation_runs",
+        spanTimeFilter: filter,
+      });
       expect(join).not.toContain("StartTime");
     });
   });

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -609,11 +609,11 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
       const requiredColumns = resolveRequiredColumns(table, allExpressions);
       // Both-periods regime: bound the stored_spans JOIN to the same StartTime
       // envelope as the outer OccurredAt filter so it prunes partitions.
-      return buildJoinClause(
+      return buildJoinClause({
         table,
         requiredColumns,
-        SPAN_TIME_FILTER_BOTH_PERIODS,
-      );
+        spanTimeFilter: SPAN_TIME_FILTER_BOTH_PERIODS,
+      });
     })
     .join("\n");
 
@@ -1946,11 +1946,11 @@ function buildDateBucketedPipelineQuery({
       .map((table) => {
         const requiredColumns = resolveRequiredColumns(table, allSimpleExprs);
         // Both-periods regime: bound the stored_spans JOIN to the date envelope.
-        return buildJoinClause(
+        return buildJoinClause({
           table,
           requiredColumns,
-          SPAN_TIME_FILTER_BOTH_PERIODS,
-        );
+          spanTimeFilter: SPAN_TIME_FILTER_BOTH_PERIODS,
+        });
       })
       .join("\n");
 
@@ -2362,11 +2362,11 @@ export function buildDataForFilterQuery(
     .map((table) => {
       const requiredColumns = resolveRequiredColumns(table, filterExpressions);
       // Start/end regime: bound the stored_spans JOIN to the date envelope.
-      return buildJoinClause(
+      return buildJoinClause({
         table,
         requiredColumns,
-        SPAN_TIME_FILTER_START_END,
-      );
+        spanTimeFilter: SPAN_TIME_FILTER_START_END,
+      });
     })
     .join("\n");
 
@@ -2458,11 +2458,11 @@ export function buildDataForFilterQuery(
       break;
 
     case "spans.model":
-      joins = buildJoinClause(
-        "stored_spans",
-        new Set(["SpanAttributes"]),
-        SPAN_TIME_FILTER_START_END,
-      );
+      joins = buildJoinClause({
+        table: "stored_spans",
+        requiredColumns: new Set(["SpanAttributes"]),
+        spanTimeFilter: SPAN_TIME_FILTER_START_END,
+      });
       sql = `
         SELECT
           ${ss}.SpanAttributes['gen_ai.request.model'] AS field,
@@ -2484,11 +2484,11 @@ export function buildDataForFilterQuery(
       break;
 
     case "spans.type":
-      joins = buildJoinClause(
-        "stored_spans",
-        new Set(["SpanAttributes"]),
-        SPAN_TIME_FILTER_START_END,
-      );
+      joins = buildJoinClause({
+        table: "stored_spans",
+        requiredColumns: new Set(["SpanAttributes"]),
+        spanTimeFilter: SPAN_TIME_FILTER_START_END,
+      });
       sql = `
         SELECT
           ${ss}.SpanAttributes['langwatch.span.type'] AS field,
@@ -2511,7 +2511,7 @@ export function buildDataForFilterQuery(
 
     case "evaluations.evaluator_id":
     case "evaluations.evaluator_id.guardrails_only":
-      joins = buildJoinClause("evaluation_runs");
+      joins = buildJoinClause({ table: "evaluation_runs" });
       sql = `
         SELECT
           ${es}.EvaluatorId AS field,

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -607,7 +607,13 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
   const joinClauses = Array.from(allJoins)
     .map((table) => {
       const requiredColumns = resolveRequiredColumns(table, allExpressions);
-      return buildJoinClause(table, requiredColumns);
+      // Both-periods regime: bound the stored_spans JOIN to the same StartTime
+      // envelope as the outer OccurredAt filter so it prunes partitions.
+      return buildJoinClause(
+        table,
+        requiredColumns,
+        SPAN_TIME_FILTER_BOTH_PERIODS,
+      );
     })
     .join("\n");
 
@@ -1939,7 +1945,12 @@ function buildDateBucketedPipelineQuery({
     const simpleJoinClauses = Array.from(simpleJoins)
       .map((table) => {
         const requiredColumns = resolveRequiredColumns(table, allSimpleExprs);
-        return buildJoinClause(table, requiredColumns);
+        // Both-periods regime: bound the stored_spans JOIN to the date envelope.
+        return buildJoinClause(
+          table,
+          requiredColumns,
+          SPAN_TIME_FILTER_BOTH_PERIODS,
+        );
       })
       .join("\n");
 
@@ -2350,7 +2361,12 @@ export function buildDataForFilterQuery(
   const filterJoins = Array.from(filterTranslation.requiredJoins)
     .map((table) => {
       const requiredColumns = resolveRequiredColumns(table, filterExpressions);
-      return buildJoinClause(table, requiredColumns);
+      // Start/end regime: bound the stored_spans JOIN to the date envelope.
+      return buildJoinClause(
+        table,
+        requiredColumns,
+        SPAN_TIME_FILTER_START_END,
+      );
     })
     .join("\n");
 
@@ -2442,7 +2458,11 @@ export function buildDataForFilterQuery(
       break;
 
     case "spans.model":
-      joins = buildJoinClause("stored_spans", new Set(["SpanAttributes"]));
+      joins = buildJoinClause(
+        "stored_spans",
+        new Set(["SpanAttributes"]),
+        SPAN_TIME_FILTER_START_END,
+      );
       sql = `
         SELECT
           ${ss}.SpanAttributes['gen_ai.request.model'] AS field,
@@ -2464,7 +2484,11 @@ export function buildDataForFilterQuery(
       break;
 
     case "spans.type":
-      joins = buildJoinClause("stored_spans", new Set(["SpanAttributes"]));
+      joins = buildJoinClause(
+        "stored_spans",
+        new Set(["SpanAttributes"]),
+        SPAN_TIME_FILTER_START_END,
+      );
       sql = `
         SELECT
           ${ss}.SpanAttributes['langwatch.span.type'] AS field,

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -496,11 +496,15 @@ export function getTableAlias(table: CHTable): string {
  *   ones). The caller passes the fragment matching its date regime; the referenced
  *   params are bound by the outer query. Ignored for non-`stored_spans` tables.
  */
-export function buildJoinClause(
-  table: CHTable,
-  requiredColumns?: ReadonlySet<string>,
-  spanTimeFilter?: string,
-): string {
+export function buildJoinClause({
+  table,
+  requiredColumns,
+  spanTimeFilter,
+}: {
+  table: CHTable;
+  requiredColumns?: ReadonlySet<string>;
+  spanTimeFilter?: string;
+}): string {
   const alias = tableAliases[table];
   const baseAlias = tableAliases.trace_summaries;
 

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -489,10 +489,17 @@ export function getTableAlias(table: CHTable): string {
  * @param requiredColumns - Optional set of columns needed by the query.
  *   When provided, only these columns (plus identity columns) are selected.
  *   When omitted, all analytics columns for the table are selected.
+ * @param spanTimeFilter - Optional SQL fragment bounding `StartTime` on the
+ *   `stored_spans` subquery (e.g. `AND StartTime >= {startDate} - INTERVAL 2 DAY
+ *   AND StartTime < {endDate} + INTERVAL 2 DAY`). Without it the subquery filters
+ *   on `TenantId` only and cold-scans every weekly partition (incl. S3-tiered
+ *   ones). The caller passes the fragment matching its date regime; the referenced
+ *   params are bound by the outer query. Ignored for non-`stored_spans` tables.
  */
 export function buildJoinClause(
   table: CHTable,
   requiredColumns?: ReadonlySet<string>,
+  spanTimeFilter?: string,
 ): string {
   const alias = tableAliases[table];
   const baseAlias = tableAliases.trace_summaries;
@@ -502,7 +509,8 @@ export function buildJoinClause(
       const columns = requiredColumns
         ? mergeWithIdentity(requiredColumns, SPAN_IDENTITY_COLUMNS)
         : SPAN_ANALYTICS_COLUMNS;
-      return `JOIN (SELECT ${Array.from(columns).join(", ")} FROM stored_spans WHERE TenantId = {tenantId:String}) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;
+      const timeBound = spanTimeFilter ? ` ${spanTimeFilter}` : "";
+      return `JOIN (SELECT ${Array.from(columns).join(", ")} FROM stored_spans WHERE TenantId = {tenantId:String}${timeBound}) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;
     }
     case "evaluation_runs": {
       const columns = requiredColumns


### PR DESCRIPTION
## Evidence

24h prod CloudWatch sweep (read-only). The analytics period-comparison query (`currentStart`/`currentEnd`/`previousStart`/`previousEnd`) was the top recurring cold-scan on `stored_spans` after the single-trace fetches: **114 calls in 24h**, p95 ~830ms, each flagged `coldScan:true` on `stored_spans`. The query bounds `trace_summaries` on `OccurredAt`, but its `stored_spans` JOIN (for span-level groupBys / metrics) had no `StartTime` predicate. Values redacted; no tenant data reproduced.

## Suspected cause

`buildJoinClause` (in `field-mappings.ts`) built the `stored_spans` join subquery as:

```sql
JOIN (SELECT <cols> FROM stored_spans WHERE TenantId = {tenantId:String}) ss
  ON ts.TenantId = ss.TenantId AND ts.TraceId = ss.TraceId
```

With no predicate on `StartTime` (the `PARTITION BY toYearWeek(StartTime)` column), the subquery walks **every** weekly partition of `stored_spans` for the tenant, including cold S3-tiered ones, on any analytics query that groups by or measures a span field (`metadata.span_type`, `error.has_error`, `events.*`, span model/type filter-value lists).

The `SPAN_TIME_FILTER_BOTH_PERIODS` / `SPAN_TIME_FILTER_START_END` envelopes already existed in `aggregation-builder.ts` (and were wired into the filter-subquery path), but the JOIN path never received them.

## Proposed fix

Thread an optional `spanTimeFilter` SQL fragment into `buildJoinClause`; inject it into the `stored_spans` subquery WHERE. Pass the regime-appropriate envelope at every `stored_spans` join site:

- both-periods builders (`buildTimeseriesQuery`, `buildDateBucketedPipelineQuery`) -> `SPAN_TIME_FILTER_BOTH_PERIODS` (`StartTime >= {previousStart} - INTERVAL 2 DAY AND StartTime < {currentEnd} + INTERVAL 2 DAY`)
- start/end filter-value builders (`buildDataForFilterQuery`, `spans.model`, `spans.type`) -> `SPAN_TIME_FILTER_START_END`

The referenced params are already bound by each outer query. `evaluation_runs` joins are unchanged (smaller table, not in the cold-scan set). When no filter is passed the subquery stays unbounded, so the change is backward-compatible.

Correctness: a span's `StartTime` falls within its trace's lifetime, and the outer query already restricts traces to the date window; the +/-2 day cushion (matching the span-fetch partition hints elsewhere) means no matching span is pruned.

## Expected impact

- `stored_spans` join subquery prunes to the dashboard window instead of all partitions; the cold S3 partition walk is eliminated for span-grouped analytics.
- Read bytes / S3 GETs per analytics query with a span join drop to the window's partitions. Also reduces the memory footprint of these joins (relevant given the current background-merge memory pressure).
- No change to results.

## EXPLAIN check

`EXPLAIN INDEXES` on the `stored_spans` join subquery, real large tenant, 16-day window. Redacted.

**Before (TenantId only):**
```
ReadFromMergeTree (langwatch.stored_spans)
  Parts: 113
  Granules: 7739
```

**After (StartTime-bounded):**
```
ReadFromMergeTree (langwatch.stored_spans)
  Parts: 39
  Granules: 613
```

~65% fewer parts, ~92% fewer granules on the join scan. Reviewer should re-run before merge.

## Test plan

- Unit (`field-mappings.test.ts`): `buildJoinClause` stays unbounded with no filter (no `StartTime` predicate), injects the fragment when provided, and ignores it for `evaluation_runs`.
- Unit (`aggregation-builder.test.ts`): a span groupBy (`metadata.span_type`) now emits a `JOIN (... FROM stored_spans WHERE TenantId = ... AND StartTime >= {previousStart...} ... StartTime < {currentEnd...})`.
- `typecheck` clean, `biome` clean on changed lines.
- Pre-existing unrelated failure: `aggregation-builder.test.ts > ... performance.first_token` fails on clean main too (analytics quantile routing), not touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded ClickHouse query-generation tests to verify correct JOIN behavior, including StartTime time-bounds being applied (or intentionally omitted) depending on the selected join source.

* **Bug Fixes**
  * Improved performance of timeseries and filter-related analytics by ensuring JOIN subqueries that read stored spans apply the appropriate time window predicates, preventing unbounded partition scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->