### PR TITLE
fix(datasets): address S3 review findings across reads, lock scope, CSRF, ready-gating, and helm

### DIFF
--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -174,6 +174,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if gt (int .Values.app.replicaCount) 1 }}
     {{- $errors = append $errors "app.storedObjects.localFilesystem.enabled requires replicaCount=1 (pods don't share a local filesystem). Enable app.dataplane for multi-replica deployments." }}
   {{- end }}
+  {{- /* Workers mount the SAME RWO PVC as the app, so they are bound by the
+         same single-node constraint — guard workers.replicaCount too, else a
+         multi-replica worker pool renders cleanly then crashloops on the volume. */}}
+  {{- if gt (int .Values.workers.replicaCount) 1 }}
+    {{- $errors = append $errors "app.storedObjects.localFilesystem.enabled requires workers.replicaCount=1 (workers share the app's local-filesystem PVC). Enable app.dataplane for multi-replica deployments." }}
+  {{- end }}
 {{- end }}
 
 {{/* Validate dataset storage secrets */}}

--- a/charts/langwatch/templates/dataset-s3-migration-job.yaml
+++ b/charts/langwatch/templates/dataset-s3-migration-job.yaml
@@ -52,6 +52,12 @@ spec:
         app.kubernetes.io/component: dataset-s3-migration
     spec:
       restartPolicy: Never
+      {{/* On EKS+IRSA the Job must run as the same IAM-role-annotated
+           ServiceAccount as the app/workers to reach S3; default ("") falls
+           through to the namespace default SA (consistent with app/workers). */}}
+      {{- with .Values.datasetS3Migration.serviceAccountName }}
+      serviceAccountName: {{ . }}
+      {{- end }}
 
       {{/* Inherit chart-wide pod security + scheduling defaults so strict
            clusters don't reject the hook and node taints / dedicated pools

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -297,8 +297,8 @@ app:
       # AWS S3 configuration for dataset storage
       ## @extra app.dataplane.providers.awsS3 AWS S3 provider configuration.
       ## @param app.dataplane.providers.awsS3.endpoint.value [string] Custom S3 endpoint.
-      ## @param app.dataplane.providers.awsS3.accessKeyId.value [string] S3 access key ID.
-      ## @param app.dataplane.providers.awsS3.secretAccessKey.value [string] S3 secret access key.
+      ## @param app.dataplane.providers.awsS3.accessKeyId.value [string] S3 access key ID (not recommended in production — use accessKeyId.secretKeyRef).
+      ## @param app.dataplane.providers.awsS3.secretAccessKey.value [string] S3 secret access key (not recommended in production — use secretAccessKey.secretKeyRef).
       ## @param app.dataplane.providers.awsS3.keySalt.value [string] Optional key salt.
       awsS3:
         endpoint:
@@ -746,8 +746,13 @@ datasetS3Migration:
   skip: false
   ## @param datasetS3Migration.backoffLimit [default: 3] Job backoffLimit — retries on transient failure (the task is idempotent).
   backoffLimit: 3
-  ## @param datasetS3Migration.activeDeadlineSeconds [object] Hard runtime limit for the hook Job (unset = no limit).
-  activeDeadlineSeconds: ~
+  ## @param datasetS3Migration.activeDeadlineSeconds [default: 21600] Hard runtime limit (s) for the hook Job — a backstop so a hung migration can't run forever. The task is idempotent/resumable, so a re-run resumes; raise for very large installs or set null to disable.
+  activeDeadlineSeconds: 21600
+  # ServiceAccount for the migration Job. Leave empty to use the namespace
+  # default (matching the app/workers). On EKS+IRSA, set this to the same
+  # IAM-role-annotated ServiceAccount the app/workers use so the Job can reach S3.
+  ## @param datasetS3Migration.serviceAccountName [string, default: ""] ServiceAccount for the Job (set to the app/workers IRSA SA on EKS).
+  serviceAccountName: ""
   ## @param datasetS3Migration.ttlSecondsAfterFinished [default: 600] Clean up the finished Job after this many seconds.
   ttlSecondsAfterFinished: 600
   ## @extra datasetS3Migration.resources Resource requests and limits for the migration Job.

--- a/langwatch/src/app/api/dataset/[[...route]]/__tests__/direct-upload-auth.unit.test.ts
+++ b/langwatch/src/app/api/dataset/[[...route]]/__tests__/direct-upload-auth.unit.test.ts
@@ -115,6 +115,55 @@ describe("authorizeDirectUpload", () => {
         expect(projectFindUnique).not.toHaveBeenCalled();
       });
     });
+
+    describe("when the request is forged cross-site (CSRF)", () => {
+      it("rejects with 403 on Sec-Fetch-Site: cross-site, before any permission check", async () => {
+        hasProjectPermission.mockResolvedValue(true); // would pass if reached
+
+        const result = await authorizeDirectUpload(
+          makeContext({ "sec-fetch-site": "cross-site" }),
+          PROJECT_ID,
+        );
+
+        expect(result).toMatchObject({ ok: false, status: 403 });
+        // The CSRF gate fires before the permission check and team resolve.
+        expect(hasProjectPermission).not.toHaveBeenCalled();
+        expect(projectFindUnique).not.toHaveBeenCalled();
+      });
+
+      it("rejects when the Origin host differs from the Host (older browser, no Sec-Fetch-Site)", async () => {
+        hasProjectPermission.mockResolvedValue(true);
+
+        const result = await authorizeDirectUpload(
+          makeContext({
+            origin: "https://evil.example",
+            host: "app.langwatch.ai",
+          }),
+          PROJECT_ID,
+        );
+
+        expect(result).toMatchObject({ ok: false, status: 403 });
+        expect(hasProjectPermission).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the request is same-origin", () => {
+      it("proceeds to the permission check on Sec-Fetch-Site: same-origin", async () => {
+        hasProjectPermission.mockResolvedValue(true);
+
+        const result = await authorizeDirectUpload(
+          makeContext({ "sec-fetch-site": "same-origin" }),
+          PROJECT_ID,
+        );
+
+        expect(result).toEqual({
+          ok: true,
+          projectId: PROJECT_ID,
+          teamId: TEAM_ID,
+        });
+        expect(hasProjectPermission).toHaveBeenCalled();
+      });
+    });
   });
 
   describe("given no session", () => {

--- a/langwatch/src/app/api/dataset/[[...route]]/app.ts
+++ b/langwatch/src/app/api/dataset/[[...route]]/app.ts
@@ -8,7 +8,6 @@ import {
   requires,
 } from "~/server/api/security";
 import { createLogger } from "~/utils/logger/server";
-import { createManyDatasetRecords } from "../../../../server/api/routers/datasetRecord.utils";
 import { UploadValidationError } from "../../../../server/datasets/dataset.service";
 import type { DatasetNotReadyError } from "../../../../server/datasets/errors";
 import type { DatasetColumns } from "../../../../server/datasets/types";
@@ -735,51 +734,33 @@ secured.access(requires("datasets:manage")).post(
     const { entries } = c.req.valid("json");
     const service = c.get("datasetService");
 
-    let dataset;
+    // Route through the service (parity with `/:slugOrId/records`) instead of
+    // reaching into the tRPC-layer `createManyDatasetRecords` util: the service
+    // owns the dataset lookup, column validation, id generation, and the
+    // s3_jsonl-vs-PG write routing. This handler only translates the result and
+    // typed errors to the legacy `{ success }` HTTP shape.
     try {
-      dataset = await service.getBySlugOrId({
+      await service.batchCreateRecords({
         slugOrId: slug,
         projectId: project.id,
+        entries,
       });
+      return c.json({ success: true });
     } catch (error) {
-      return mapDatasetNotFoundError(error);
-    }
-
-    const columns = Object.fromEntries(
-      (dataset.columnTypes as DatasetColumns).map((column) => [
-        column.name,
-        column.type,
-      ]),
-    );
-    for (const entry of entries) {
-      for (const [key] of Object.entries(entry)) {
-        if (!columns[key]) {
-          throw new BadRequestError(
-            `Column \`${key}\` is not present in the \`${dataset.name}\` dataset`,
-          );
-        }
+      if (error instanceof Error && error.name === "InvalidColumnError") {
+        throw new BadRequestError(error.message);
       }
-    }
-
-    const now = Date.now();
-
-    try {
-      await createManyDatasetRecords({
-        datasetId: dataset.id,
-        projectId: project.id,
-        datasetRecords: entries.map((entry, index) => ({
-          id: `${now}-${index}`,
-          ...entry,
-        })),
-      });
-    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.name === "MalformedColumnTypesError"
+      ) {
+        throw new InternalServerError(error.message);
+      }
       // M1: an s3_jsonl dataset still preparing rejects the append (I-READY).
       const notReady = mapDatasetNotReadyError(error, c);
       if (notReady) return notReady;
       return mapDatasetNotFoundError(error);
     }
-
-    return c.json({ success: true });
   },
 );
 

--- a/langwatch/src/app/api/dataset/[[...route]]/direct-upload-auth.ts
+++ b/langwatch/src/app/api/dataset/[[...route]]/direct-upload-auth.ts
@@ -33,6 +33,34 @@ import { prisma } from "~/server/db";
 
 const PERMISSION = "datasets:manage" as const;
 
+/**
+ * CSRF defense-in-depth for the COOKIE-authed path only. The direct-upload POST
+ * is a `multipart/form-data` "simple request" (no preflight) authenticated by the
+ * NextAuth session cookie, so without this a malicious cross-origin page could
+ * forge it with the victim's cookie. (The API-key path is not exposed: keys
+ * aren't auto-attached by the browser.)
+ *
+ * `Sec-Fetch-Site` is the primary signal — set by every modern browser based on
+ * the real request initiator and unaffected by reverse proxies; `cross-site` is
+ * exactly the CSRF vector, while `same-origin`/`same-site`/`none` (direct nav)
+ * are legitimate. For older browsers that omit it, fall back to comparing the
+ * `Origin` host against the forwarded/Host header.
+ */
+function isCrossSiteRequest(c: Context): boolean {
+  const secFetchSite = c.req.header("sec-fetch-site");
+  if (secFetchSite) {
+    return secFetchSite === "cross-site";
+  }
+  const origin = c.req.header("origin");
+  if (!origin) return false;
+  const host = c.req.header("x-forwarded-host") ?? c.req.header("host") ?? "";
+  try {
+    return new URL(origin).host !== host;
+  } catch {
+    return true; // malformed Origin → treat as cross-site
+  }
+}
+
 export type DirectUploadAuthResult =
   | { ok: true; projectId: string; teamId: string }
   | { ok: false; status: 401 | 403; error: string };
@@ -50,6 +78,15 @@ export async function authorizeDirectUpload(
   // 1. Session cookie (the upload UI).
   const session = await getServerAuthSession({ req: c.req.raw as any });
   if (session) {
+    // CSRF: a cookie-authed state change must originate same-site. Reject a
+    // cross-site request before any permission check / mutation.
+    if (isCrossSiteRequest(c)) {
+      return {
+        ok: false,
+        status: 403,
+        error: "Cross-site request blocked.",
+      };
+    }
     const permitted = await hasProjectPermission(
       { prisma, session },
       projectId,

--- a/langwatch/src/app/api/dataset/__tests__/dataset-upload-api.integration.test.ts
+++ b/langwatch/src/app/api/dataset/__tests__/dataset-upload-api.integration.test.ts
@@ -673,6 +673,39 @@ describe("Feature: Dataset File Upload REST API", () => {
         expect(res.status).toBe(401);
       });
     });
+
+    describe("when an API key targets a DIFFERENT project (cross-tenant IDOR)", () => {
+      /** @scenario Direct-upload rejects a foreign-project API key against an owned project */
+      it("returns 401 from POST /direct-upload on apiKey/project mismatch", async () => {
+        // A second project under the same team; its API key must NOT authorize a
+        // direct upload that targets the first project. This is the route-level
+        // proof of the cross-tenant guard (the unit test covers the decision
+        // function; this exercises the full handlerManagedAuth chain).
+        const foreignProject = await prisma.project.create({
+          data: {
+            ...projectFactory.build({ slug: nanoid() }),
+            teamId: testTeam.id,
+            personalFeatures: {},
+          },
+        });
+        try {
+          const form = new FormData();
+          form.set("projectId", testProjectId); // project A (owned)
+          form.set("name", "Cross tenant");
+          form.set("filename", "data.csv");
+
+          const res = await app.request("/api/dataset/direct-upload", {
+            method: "POST",
+            headers: { "X-Auth-Token": foreignProject.apiKey }, // project B's key
+            body: form,
+          });
+
+          expect(res.status).toBe(401);
+        } finally {
+          await prisma.project.delete({ where: { id: foreignProject.id } });
+        }
+      });
+    });
   });
 
   // ── Postgres null-byte safety + atomicity ──────────────────────

--- a/langwatch/src/components/datasets/DatasetPickerList.tsx
+++ b/langwatch/src/components/datasets/DatasetPickerList.tsx
@@ -46,9 +46,17 @@ export function DatasetPickerList({
 
   const filteredDatasets = useMemo(() => {
     if (!datasetsQuery.data) return [];
+    // Only `ready` datasets are usable: selecting a processing/uploading/failed
+    // one hands its id to the workbench/workflow node, which then throws
+    // DatasetNotReadyError on the first read. Hide non-ready rows from the picker
+    // so they can't be chosen. Legacy rows default status="ready"; a null status
+    // (born-before-status) is treated as ready too, matching the read gate.
+    const ready = datasetsQuery.data.filter(
+      (dataset) => dataset.status === "ready" || dataset.status == null,
+    );
     const query = searchQuery.toLowerCase().trim();
-    if (!query) return datasetsQuery.data;
-    return datasetsQuery.data.filter((dataset) =>
+    if (!query) return ready;
+    return ready.filter((dataset) =>
       dataset.name.toLowerCase().includes(query),
     );
   }, [datasetsQuery.data, searchQuery]);

--- a/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/UploadCSVDrawer.unit.test.tsx
@@ -417,7 +417,6 @@ describe("UploadCSVForm cancel", () => {
         datasetId: string;
         uploadUrl: string;
         slug: string;
-        stagingKey: string;
       }) => void;
       requestDirectUpload.mockReturnValue(
         new Promise((resolve) => {
@@ -464,7 +463,6 @@ describe("UploadCSVForm cancel", () => {
         datasetId: "dataset_racey",
         uploadUrl: "https://s3.example/put",
         slug: "s",
-        stagingKey: "staging/proj/u",
       });
 
       await waitFor(() => {

--- a/langwatch/src/components/datasets/__tests__/UploadCSVFallbackGuard.integration.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/UploadCSVFallbackGuard.integration.test.tsx
@@ -178,7 +178,6 @@ describe("UploadCSVForm 409-fallback size guard", () => {
         datasetId: "dataset_pending",
         slug: "s",
         uploadUrl: "https://s3.example/put",
-        stagingKey: "staging/proj/u",
       });
       putFileToPresignedUrl.mockRejectedValue(new PresignedUploadFailedError());
       abortPendingUpload.mockResolvedValue(undefined);
@@ -230,7 +229,6 @@ describe("UploadCSVForm 409-fallback size guard", () => {
         datasetId: "dataset_pending",
         slug: "s",
         uploadUrl: "https://s3.example/put",
-        stagingKey: "staging/proj/u",
       });
       putFileToPresignedUrl.mockRejectedValue(new PresignedUploadFailedError());
       abortPendingUpload.mockResolvedValue(undefined);
@@ -334,7 +332,6 @@ describe("UploadCSVForm 409-fallback size guard", () => {
         datasetId: "dataset_pending",
         slug: "s",
         uploadUrl: "/api/dataset/direct-upload/staging/up_1?projectId=proj_1",
-        stagingKey: "staging/proj_1/up_1",
       });
       putFileToPresignedUrl.mockRejectedValue(
         new Error(

--- a/langwatch/src/components/datasets/services/__tests__/directUpload.unit.test.ts
+++ b/langwatch/src/components/datasets/services/__tests__/directUpload.unit.test.ts
@@ -31,7 +31,6 @@ describe("directUpload service", () => {
           datasetId: "dataset_1",
           slug: "my-dataset",
           uploadUrl: "https://s3.example/staging/abc",
-          stagingKey: "staging/proj/abc",
         };
         mockFetch().mockResolvedValue({
           ok: true,

--- a/langwatch/src/components/datasets/services/__tests__/directUpload.unit.test.ts
+++ b/langwatch/src/components/datasets/services/__tests__/directUpload.unit.test.ts
@@ -247,6 +247,20 @@ describe("directUpload service", () => {
         expect(init.method).toBe("DELETE");
       });
     });
+
+    describe("when the cleanup DELETE returns a non-ok status", () => {
+      it("throws so the caller logs the failure instead of swallowing it", async () => {
+        // A 5xx (DB timeout, pod restart) leaves the `uploading` row pinned in PG
+        // — pinning its slug and counting against project quota. The reject makes
+        // that observable at the caller's existing catch/log; it must NOT resolve
+        // silently.
+        mockFetch().mockResolvedValue({ ok: false, status: 500 });
+
+        await expect(
+          abortPendingUpload({ projectId: "proj_1", datasetId: "dataset_1" }),
+        ).rejects.toThrow(/status 500/);
+      });
+    });
   });
 
   describe("finalizeDirectUpload()", () => {

--- a/langwatch/src/components/datasets/services/directUpload.ts
+++ b/langwatch/src/components/datasets/services/directUpload.ts
@@ -183,8 +183,14 @@ export async function putFileToPresignedUrl(
  * Best-effort cleanup of the just-created pending (`uploading`) dataset after a
  * presigned-PUT failure, so a CORS-failed attempt doesn't leave a stuck
  * `uploading` row behind. Authenticated by the same session cookie the other
- * direct-upload routes use; failures are swallowed (the fallback path creates a
- * fresh dataset regardless).
+ * direct-upload routes use.
+ *
+ * A non-2xx DELETE (DB timeout, pod restart) THROWS rather than resolving
+ * silently: every caller already wraps this in a `.catch`/try-catch that logs,
+ * so the failure becomes observable (an orphaned `uploading` row pins its slug
+ * and counts against project quota until reaped). Callers still proceed with the
+ * fallback regardless — the reject is for visibility, not control flow. A
+ * server-side TTL sweep of stale `uploading` rows is the durable backstop.
  */
 export async function abortPendingUpload({
   projectId,
@@ -193,10 +199,15 @@ export async function abortPendingUpload({
   projectId: string;
   datasetId: string;
 }): Promise<void> {
-  await fetch(
+  const response = await fetch(
     `/api/dataset/direct-upload/${datasetId}?projectId=${encodeURIComponent(projectId)}`,
     { method: "DELETE" },
   );
+  if (!response.ok) {
+    throw new Error(
+      `abortPendingUpload: DELETE failed (status ${response.status}) — dataset ${datasetId} may remain in 'uploading'`,
+    );
+  }
 }
 
 /**

--- a/langwatch/src/components/datasets/services/directUpload.ts
+++ b/langwatch/src/components/datasets/services/directUpload.ts
@@ -64,7 +64,6 @@ export type DirectUploadHandle = {
   datasetId: string;
   slug: string;
   uploadUrl: string;
-  stagingKey: string;
 };
 
 /**

--- a/langwatch/src/pages/[project]/datasets.tsx
+++ b/langwatch/src/pages/[project]/datasets.tsx
@@ -298,35 +298,47 @@ function DatasetsPage() {
                           </Button>
                         </Menu.Trigger>
                         <Menu.Content>
-                          <Menu.Item
-                            value="copy"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              setCopyDataset({
-                                datasetId: dataset.id,
-                                datasetName: dataset.name,
-                              });
-                            }}
-                          >
-                            <Copy size={16} /> Replicate to another project
-                          </Menu.Item>
+                          {/* Replicate and Edit operate on dataset CONTENT, which
+                              only exists once `ready` — copyDataset / column edits
+                              throw DatasetNotReadyError on a processing/failed row.
+                              Gate them on ready (a null status = legacy = ready).
+                              Delete stays available so a stuck/failed dataset can
+                              always be cleaned up. */}
+                          {(dataset.status === "ready" ||
+                            dataset.status == null) && (
+                            <Menu.Item
+                              value="copy"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setCopyDataset({
+                                  datasetId: dataset.id,
+                                  datasetName: dataset.name,
+                                });
+                              }}
+                            >
+                              <Copy size={16} /> Replicate to another project
+                            </Menu.Item>
+                          )}
                           {!isLiteMember && (
                             <>
-                              <Menu.Item
-                                value="edit"
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  setEditDataset({
-                                    datasetId: dataset.id,
-                                    name: dataset.name,
-                                    columnTypes:
-                                      dataset.columnTypes as DatasetColumns,
-                                  });
-                                  addEditDatasetDrawer.onOpen();
-                                }}
-                              >
-                                <Edit size={16} /> Edit dataset
-                              </Menu.Item>
+                              {(dataset.status === "ready" ||
+                                dataset.status == null) && (
+                                <Menu.Item
+                                  value="edit"
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    setEditDataset({
+                                      datasetId: dataset.id,
+                                      name: dataset.name,
+                                      columnTypes:
+                                        dataset.columnTypes as DatasetColumns,
+                                    });
+                                    addEditDatasetDrawer.onOpen();
+                                  }}
+                                >
+                                  <Edit size={16} /> Edit dataset
+                                </Menu.Item>
+                              )}
                               <Menu.Item
                                 value="delete"
                                 color="red.600"

--- a/langwatch/src/pages/[project]/datasets/[id].tsx
+++ b/langwatch/src/pages/[project]/datasets/[id].tsx
@@ -31,7 +31,14 @@ export default function Dataset() {
   );
 
   const status = datasetQuery.data?.status;
-  const isReady = status === "ready" || status == null;
+  // Gate on `isSuccess`: before the query resolves `status` is `undefined`, and
+  // `undefined == null` is `true` — which would mount the editor and fire
+  // `getAll` against a still-`processing` dataset (server rejects with
+  // PRECONDITION_FAILED → retry-toast cascade) before the status is known. Once
+  // the query settles, a genuinely-null status (legacy born-before-status rows)
+  // still reads as ready.
+  const isReady =
+    datasetQuery.isSuccess && (status === "ready" || status == null);
 
   const runExperiment = () => {
     void router.push({

--- a/langwatch/src/server/api/routers/__tests__/datasetRecord.utils.s3.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/datasetRecord.utils.s3.unit.test.ts
@@ -400,6 +400,49 @@ describe("getFullDataset()", () => {
     });
   });
 
+  describe("when an s3_jsonl dataset is ready but its chunkCount is null", () => {
+    it("throws DatasetChunkCountMissingError rather than serving an empty dataset", async () => {
+      // I-COUNT drift: `chunkCount ?? 0` would loop zero times and return [] with
+      // a positive count — silent data loss. The guard surfaces it loudly.
+      findFirst.mockResolvedValue({
+        ...baseDataset,
+        rowCount: 2,
+        chunkCount: null,
+      });
+      const readChunks = mockReadChunks([]);
+
+      await expect(
+        getFullDataset({ datasetId: "dataset_1", projectId: "p1" }),
+      ).rejects.toMatchObject({ name: "DatasetChunkCountMissingError" });
+      expect(readChunks).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a single-row selection falls back to a full read but the dataset exceeds the heap ceiling", () => {
+    it("throws DatasetTooLargeToExportError instead of reading the whole corpus", async () => {
+      // No offsets → the single-row select can't short-circuit and would read
+      // every chunk; guard on sizeBytes so a large legacy dataset can't OOM.
+      findFirst.mockResolvedValue({
+        ...baseDataset,
+        rowCount: 2,
+        chunkCount: 1,
+        chunkOffsets: null,
+        sizeBytes: BigInt(200 * 1024 * 1024), // 200 MB > 100 MB ceiling
+      });
+      const { readChunks, readChunk } = mockReadChunk({});
+
+      await expect(
+        getFullDataset({
+          datasetId: "dataset_1",
+          projectId: "p1",
+          entrySelection: "first",
+        }),
+      ).rejects.toMatchObject({ name: "DatasetTooLargeToExportError" });
+      expect(readChunk).not.toHaveBeenCalled();
+      expect(readChunks).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when the dataset row does not exist", () => {
     it("returns null", async () => {
       findFirst.mockResolvedValue(null);

--- a/langwatch/src/server/api/routers/__tests__/datasetRecord.utils.s3.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/datasetRecord.utils.s3.unit.test.ts
@@ -562,6 +562,26 @@ describe("readDatasetHeadS3Jsonl()", () => {
     });
   });
 
+  describe("when the offset index is missing and chunkCount is null (I-COUNT drift)", () => {
+    it("throws DatasetChunkCountMissingError instead of an empty preview against a positive total", async () => {
+      const { readChunk } = mockReadChunk({});
+
+      await expect(
+        readDatasetHeadS3Jsonl({
+          dataset: {
+            ...baseDataset,
+            rowCount: 5,
+            chunkCount: null,
+            chunkOffsets: null,
+          } as never,
+          projectId: "p1",
+        }),
+      ).rejects.toMatchObject({ name: "DatasetChunkCountMissingError" });
+      // The guard fires before the scan loop — no chunk is read.
+      expect(readChunk).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when the dataset is not ready", () => {
     it("throws DatasetNotReadyError without reading chunks", async () => {
       const { readChunk } = mockReadChunk({});

--- a/langwatch/src/server/api/routers/datasetRecord.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.ts
@@ -96,6 +96,8 @@ export const datasetRecordRouter = createTRPCRouter({
           datasetId: input.datasetId,
           projectId: input.projectId,
           datasetRecords: input.entries,
+          // Reuse the existence-check lookup above instead of re-querying.
+          dataset,
         });
       } catch (error) {
         return rethrowDatasetNotReadyAsTRPC(error);

--- a/langwatch/src/server/api/routers/datasetRecord.utils.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.utils.ts
@@ -9,6 +9,7 @@ import {
   getDatasetStorage,
 } from "../../datasets/dataset-storage";
 import {
+  DatasetChunkCountMissingError,
   DatasetNotReadyError,
   DatasetTooLargeToExportError,
 } from "../../datasets/errors";
@@ -32,6 +33,27 @@ const storageService = new StorageService();
  * guard that keeps the pod alive in the meantime.
  */
 export const DATASET_FULL_EXPORT_MAX_BYTES = 100 * 1024 * 1024;
+
+/**
+ * Guard an UNBOUNDED full-corpus read (`readChunks` over every chunk) against
+ * OOM. The bounded readers cap at a byte budget, but three paths materialise the
+ * whole dataset at once — the legacy no-offsets fallbacks (single-row select and
+ * paginated list) and `copyDataset`. Reject a dataset too large to hold in heap
+ * with the same typed error the export path uses, rather than OOMing the pod.
+ * (Upload caps don't bound this: a dataset grows past 25 MB via repeated
+ * appends, so `sizeBytes` is the only real ceiling.)
+ */
+export const assertDatasetReadableInHeap = (dataset: {
+  sizeBytes: bigint | null;
+}): void => {
+  const sizeBytes = Number(dataset.sizeBytes ?? 0n);
+  if (sizeBytes > DATASET_FULL_EXPORT_MAX_BYTES) {
+    throw new DatasetTooLargeToExportError({
+      sizeBytes,
+      maxBytes: DATASET_FULL_EXPORT_MAX_BYTES,
+    });
+  }
+};
 
 const createDatasetRecords = ({
   entries,
@@ -449,6 +471,14 @@ export const getFullDataset = async ({
       });
     }
 
+    // I-COUNT: a `ready` s3_jsonl dataset MUST have a non-null chunkCount.
+    // `chunkCount ?? 0` below would otherwise loop zero times and serve an EMPTY
+    // dataset against a positive rowCount — silent, undiagnosable data loss.
+    // Throw loudly so the drift surfaces (and `recomputeDatasetCounts` repairs).
+    if (dataset.chunkCount == null) {
+      throw new DatasetChunkCountMissingError(datasetId);
+    }
+
     const storage = await getDatasetStorage(projectId);
 
     const count = dataset.rowCount ?? 0;
@@ -473,12 +503,14 @@ export const getFullDataset = async ({
       }
       // `record === null`: no short-circuit possible (missing/legacy offsets).
       // This rare defensive path reads the whole dataset to honour
-      // last/random/N correctly, then selects the single row. Bounded by the
-      // same in-memory read the rung accepts for legacy data without offsets.
+      // last/random/N correctly, then selects the single row — an UNBOUNDED read
+      // even for a single-row selection, so guard it on `sizeBytes` (the export
+      // path below guards the same way) rather than OOM on a large legacy dataset.
+      assertDatasetReadableInHeap(dataset);
       const rows = await storage.readChunks({
         projectId,
         datasetId,
-        chunkCount: dataset.chunkCount ?? 0,
+        chunkCount: dataset.chunkCount,
       });
       const allRecords = rows.map((line) => adaptS3JsonlRecord(line, dataset));
       const selected = selectRecords(allRecords, entrySelection);
@@ -500,13 +532,7 @@ export const getFullDataset = async ({
     // multi-GB download with a clear, typed error instead of OOMing the pod.
     // (True streaming export is the reads-at-scale fast-follow epic.)
     if (limitMb === null) {
-      const sizeBytes = Number(dataset.sizeBytes ?? 0n);
-      if (sizeBytes > DATASET_FULL_EXPORT_MAX_BYTES) {
-        throw new DatasetTooLargeToExportError({
-          sizeBytes,
-          maxBytes: DATASET_FULL_EXPORT_MAX_BYTES,
-        });
-      }
+      assertDatasetReadableInHeap(dataset);
     }
 
     // "all": read chunks ONE AT A TIME (I-MEM), accumulating rows until the

--- a/langwatch/src/server/api/routers/datasetRecord.utils.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.utils.ts
@@ -95,6 +95,7 @@ export const createManyDatasetRecords = async ({
   projectId,
   datasetRecords,
   tx,
+  dataset: providedDataset,
 }: {
   datasetId: string;
   projectId: string;
@@ -104,11 +105,18 @@ export const createManyDatasetRecords = async ({
   // Postgres path are joined to the caller's transaction so that a failure in
   // record insertion can roll back the parent dataset row.
   tx?: Prisma.TransactionClient;
+  // Optional already-loaded dataset row. Callers that just fetched it (e.g. the
+  // tRPC create procedure's existence check) pass it to skip a redundant lookup.
+  // Only used for the initial layout routing; the s3_jsonl path re-reads the
+  // authoritative state under the advisory lock regardless.
+  dataset?: Dataset | null;
 }) => {
   const db = tx ?? prisma;
-  const dataset = await db.dataset.findFirst({
-    where: { id: datasetId, projectId },
-  });
+  const dataset =
+    providedDataset ??
+    (await db.dataset.findFirst({
+      where: { id: datasetId, projectId },
+    }));
 
   if (!dataset) {
     throw new TRPCError({

--- a/langwatch/src/server/api/routers/datasetRecord.utils.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.utils.ts
@@ -417,6 +417,14 @@ export const readDatasetHeadS3Jsonl = async ({
       );
     }
   } else {
+    // I-COUNT: with no offsets the scan is driven by chunkCount; a null
+    // chunkCount (`?? 0`) would scan zero chunks and return an EMPTY preview
+    // against a positive total — masking the very drift this guards elsewhere
+    // (getFullDataset/listRecords). Throw rather than render an empty head. The
+    // offsets branch above never reaches here, so this only fires on real drift.
+    if (dataset.chunkCount == null) {
+      throw new DatasetChunkCountMissingError(dataset.id);
+    }
     // Legacy/never-written offsets: scan chunks in order, skipping empties,
     // until the preview is full. Still bounded — stops at the first chunk(s)
     // that fill it, never reads the whole dataset.

--- a/langwatch/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
@@ -297,6 +297,8 @@ describe("DatasetService", () => {
       it("throws DatasetNotReadyError instead of editing the chunk", async () => {
         const repository = {
           findBySlugOrId: vi.fn().mockResolvedValue({ ...notReadyRow }),
+          // The injected repo's locked re-read that the mutation asserts ready on.
+          findOneOrThrow: vi.fn().mockResolvedValue({ ...notReadyRow }),
         };
         vi.mocked(getDatasetStorage).mockResolvedValue({
           readChunk: vi.fn(),
@@ -325,6 +327,8 @@ describe("DatasetService", () => {
       it("throws DatasetNotReadyError instead of rewriting chunks", async () => {
         const repository = {
           findBySlugOrId: vi.fn().mockResolvedValue({ ...notReadyRow }),
+          // The injected repo's locked re-read that the mutation asserts ready on.
+          findOneOrThrow: vi.fn().mockResolvedValue({ ...notReadyRow }),
         };
         vi.mocked(getDatasetStorage).mockResolvedValue({
           readChunk: vi.fn(),

--- a/langwatch/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../api/routers/datasetRecord.utils", async (importOriginal) => {
 import { createManyDatasetRecords } from "../../api/routers/datasetRecord.utils";
 import { DatasetService } from "../dataset.service";
 import { getDatasetStorage } from "../dataset-storage";
+import { DatasetChunkCountMissingError } from "../errors";
 
 const makeService = (overrides: {
   repository?: Record<string, unknown>;
@@ -122,6 +123,32 @@ describe("DatasetService", () => {
         expect(result.pagination.total).toBe(2);
         // The PG paginator must NOT be touched for s3_jsonl.
         expect(recordRepository.listPaginated).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when a ready s3_jsonl dataset has a null chunkCount and no offsets (I-COUNT drift)", () => {
+      it("throws DatasetChunkCountMissingError instead of serving an empty page against a positive rowCount", async () => {
+        const repository = {
+          findBySlugOrId: vi.fn().mockResolvedValue({
+            ...baseS3Dataset,
+            chunkCount: null,
+            rowCount: 5,
+          }),
+        };
+        // Storage is stubbed but the guard must fire BEFORE any chunk read — a
+        // `chunkCount ?? 0` would otherwise loop zero times and return [] (empty
+        // page) while total=5: silent data loss.
+        const readChunks = mockReadChunks([]);
+
+        await expect(
+          makeService({ repository }).listRecords({
+            slugOrId: "ds",
+            projectId: "p1",
+            page: 1,
+            limit: 10,
+          }),
+        ).rejects.toBeInstanceOf(DatasetChunkCountMissingError);
+        expect(readChunks).not.toHaveBeenCalled();
       });
     });
 

--- a/langwatch/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
@@ -378,6 +378,32 @@ describe("DatasetService", () => {
     });
   });
 
+  describe("upsertDataset() changing column types on a ready s3_jsonl dataset", () => {
+    it("refuses with a typed ColumnTypeChangeNotSupportedError (a 4xx, not a 500)", async () => {
+      // s3_jsonl column migration is a deferred rung; the edit must surface a
+      // typed, user-actionable error the router maps to a 4xx — not a plain
+      // Error that collapses into a generic 500.
+      const repository = {
+        findOne: vi.fn().mockResolvedValue({ ...baseS3Dataset }), // ready, cols [a]
+        findBySlug: vi.fn().mockResolvedValue(null),
+      };
+      const prisma = {
+        $transaction: async (fn: (tx: unknown) => unknown) => fn({}),
+      };
+
+      await expect(
+        makeService({ repository, prisma }).upsertDataset({
+          projectId: "p1",
+          datasetId: "dataset_1",
+          name: "DS",
+          columnTypes: [{ name: "b", type: "string" }], // changed columns
+        }),
+      ).rejects.toMatchObject({
+        name: "ColumnTypeChangeNotSupportedError",
+      });
+    });
+  });
+
   describe("copyDataset()", () => {
     describe("when the source is s3_jsonl and ready", () => {
       it("reads source rows from chunks (not the empty PG table) into the new s3_jsonl dataset", async () => {

--- a/langwatch/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
@@ -513,5 +513,31 @@ describe("DatasetService", () => {
         ).rejects.toMatchObject({ name: "DatasetNotReadyError" });
       });
     });
+
+    describe("when the source is ready s3_jsonl but has a null chunkCount (I-COUNT drift)", () => {
+      it("throws DatasetChunkCountMissingError instead of creating an empty copy", async () => {
+        const create = vi.fn();
+        const repository = {
+          findOne: vi.fn().mockResolvedValue({
+            ...baseS3Dataset,
+            chunkCount: null,
+            rowCount: 5,
+          }),
+          findAllSlugs: vi.fn().mockResolvedValue([]),
+          findBySlug: vi.fn().mockResolvedValue(null),
+          create,
+        };
+
+        await expect(
+          makeService({ repository }).copyDataset({
+            sourceDatasetId: "dataset_1",
+            sourceProjectId: "p1",
+            targetProjectId: "p2",
+          }),
+        ).rejects.toBeInstanceOf(DatasetChunkCountMissingError);
+        // No empty copy is created against the positive rowCount.
+        expect(create).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/langwatch/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-service.s3-reads.unit.test.ts
@@ -346,6 +346,32 @@ describe("DatasetService", () => {
         });
       });
     });
+
+    describe("upsertDataset() editing an existing dataset", () => {
+      it("refuses to edit a not-ready dataset, before any slug lookup or mutation", async () => {
+        const repository = {
+          findOne: vi.fn().mockResolvedValue({ ...notReadyRow }),
+          findBySlug: vi.fn(),
+        };
+        const prisma = {
+          $transaction: async (fn: (tx: unknown) => unknown) => fn({}),
+        };
+
+        await expect(
+          makeService({ repository, prisma }).upsertDataset({
+            projectId: "p1",
+            datasetId: "dataset_1",
+            name: "DS",
+            columnTypes: [{ name: "a", type: "string" }],
+          }),
+        ).rejects.toMatchObject({
+          name: "DatasetNotReadyError",
+          status: "processing",
+        });
+        // The ready-gate fires before the slug-conflict lookup / write.
+        expect(repository.findBySlug).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("copyDataset()", () => {

--- a/langwatch/src/server/datasets/__tests__/dataset-service.upload.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-service.upload.unit.test.ts
@@ -45,11 +45,13 @@ describe("DatasetService", () => {
           filename: "data.jsonl",
         });
 
+        // The raw staging key is NOT leaked in the response — the client only
+        // needs datasetId + uploadUrl; finalize reads the key from the row (C1).
         expect(result).toMatchObject({
           datasetId: "dataset_x",
           uploadUrl: "https://example/put",
-          stagingKey: "staging/p1/u1",
         });
+        expect(result).not.toHaveProperty("stagingKey");
         expect(repo.create).toHaveBeenCalledWith(
           expect.objectContaining({
             status: "uploading",
@@ -107,6 +109,81 @@ describe("DatasetService", () => {
         expect(repo.create).not.toHaveBeenCalled();
       });
     });
+
+    describe("when abandoned pending uploads linger (poll-triggered reap)", () => {
+      it("archives stale uploading rows and deletes their staging objects before minting", async () => {
+        const deleteStaged = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(getDatasetStorage).mockResolvedValue({
+          deleteStaged,
+          createPresignedUpload: vi.fn().mockResolvedValue({
+            uploadId: "u2",
+            key: "staging/p1/u2",
+            url: "https://example/put",
+          }),
+        } as any);
+        const stale = {
+          id: "dataset_stale",
+          name: "Old Upload",
+          projectId: "p1",
+          status: "uploading",
+          stagingKey: "staging/p1/old",
+          archivedAt: null,
+        };
+        const repo = {
+          findStalePendingUploads: vi.fn().mockResolvedValue([stale]),
+          findBySlug: vi.fn().mockResolvedValue(null),
+          create: vi.fn().mockResolvedValue({ id: "dataset_new", slug: "ds" }),
+          update: vi.fn().mockResolvedValue({}),
+        };
+
+        await makeService(repo).createPendingUpload({
+          projectId: "p1",
+          name: "DS",
+          filename: "data.jsonl",
+        });
+
+        // the abandoned row's staging object is deleted and the row archived...
+        expect(deleteStaged).toHaveBeenCalledWith({
+          projectId: "p1",
+          key: "staging/p1/old",
+        });
+        expect(repo.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: "dataset_stale",
+            projectId: "p1",
+            data: expect.objectContaining({ archivedAt: expect.any(Date) }),
+          }),
+        );
+        // ...and the new upload still proceeds
+        expect(repo.create).toHaveBeenCalled();
+      });
+
+      it("never blocks the upload when the sweep itself fails", async () => {
+        vi.mocked(getDatasetStorage).mockResolvedValue({
+          createPresignedUpload: vi.fn().mockResolvedValue({
+            uploadId: "u3",
+            key: "staging/p1/u3",
+            url: "https://example/put",
+          }),
+        } as any);
+        const repo = {
+          findStalePendingUploads: vi
+            .fn()
+            .mockRejectedValue(new Error("db down")),
+          findBySlug: vi.fn().mockResolvedValue(null),
+          create: vi.fn().mockResolvedValue({ id: "dataset_new", slug: "ds" }),
+        };
+
+        const result = await makeService(repo).createPendingUpload({
+          projectId: "p1",
+          name: "DS",
+          filename: "data.jsonl",
+        });
+
+        expect(result).toMatchObject({ datasetId: "dataset_new" });
+        expect(repo.create).toHaveBeenCalled();
+      });
+    });
   });
 
   describe("abortPendingUpload()", () => {
@@ -117,6 +194,7 @@ describe("DatasetService", () => {
         const repo = {
           findOne: vi.fn().mockResolvedValue({
             id: "dataset_x",
+            projectId: "p1",
             name: "DS",
             status: "uploading",
             stagingKey: "staging/p1/u1",

--- a/langwatch/src/server/datasets/__tests__/local-dataset-storage.integration.test.ts
+++ b/langwatch/src/server/datasets/__tests__/local-dataset-storage.integration.test.ts
@@ -58,6 +58,70 @@ describe("LocalDatasetStorage", () => {
       });
     });
 
+    describe("given atomic chunk writes (temp + rename)", () => {
+      it("leaves no .tmp residue after writeChunks and rewriteChunk", async () => {
+        await storage.writeChunks({
+          projectId: "p1",
+          datasetId: "d-atomic",
+          records: [{ a: 1 }, { a: 2 }],
+        });
+        await storage.rewriteChunk({
+          projectId: "p1",
+          datasetId: "d-atomic",
+          index: 0,
+          records: [{ a: 9 }],
+        });
+
+        const chunkDir = path.dirname(
+          path.join(storageDir, chunkKey("p1", "d-atomic", 0)),
+        );
+        const entries = await fs.readdir(chunkDir);
+        expect(entries.filter((f) => f.includes(".tmp-"))).toEqual([]);
+        expect(
+          entries.some((f) => f.startsWith("chunk-") && f.endsWith(".jsonl")),
+        ).toBe(true);
+      });
+
+      it("never exposes a torn chunk to a concurrent reader during repeated rewrites", async () => {
+        // A bare fs.writeFile truncates-then-writes; a read landing mid-write
+        // observes a partial file and crashes in JSON.parse. temp+rename makes
+        // every read see either the old or the fully-written new object. Hammer
+        // one chunk with rewrites while continuously reading it: each read must
+        // return exactly one complete row, never throw.
+        await storage.writeChunks({
+          projectId: "p1",
+          datasetId: "d-race",
+          records: [{ a: "x".repeat(1000) }],
+        });
+
+        let reads = 0;
+        const readLoop = (async () => {
+          for (let i = 0; i < 200; i++) {
+            const rows = await storage.readChunk({
+              projectId: "p1",
+              datasetId: "d-race",
+              index: 0,
+            });
+            expect(rows).toHaveLength(1);
+            reads++;
+          }
+        })();
+        const writeLoop = (async () => {
+          for (let i = 0; i < 200; i++) {
+            await storage.rewriteChunk({
+              projectId: "p1",
+              datasetId: "d-race",
+              index: 0,
+              records: [{ a: "y".repeat(1000 + i) }],
+            });
+          }
+        })();
+
+        await Promise.all([readLoop, writeLoop]);
+        expect(reads).toBe(200);
+      });
+    });
+
     describe("when appending rows to an existing dataset", () => {
       it("preserves the original rows and appends the new ones in order", async () => {
         const first = await storage.writeChunks({

--- a/langwatch/src/server/datasets/__tests__/self-hosted-no-s3.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/self-hosted-no-s3.unit.test.ts
@@ -172,7 +172,10 @@ describe("Feature: Large dataset storage — self-hosted without object storage"
         /^\/api\/dataset\/direct-upload\/staging\//,
       );
       expect(repository.create).toHaveBeenCalledOnce();
-      const uploadId = pending.stagingKey.split("/").pop()!;
+      // The staging key is bound to the row (C1), NOT leaked in the response —
+      // read it off the created row the way finalize does.
+      const stagingKey = createdRow!.stagingKey as string;
+      const uploadId = stagingKey.split("/").pop()!;
 
       // 2. The browser PUTs the raw file; the route streams it via the service.
       await service.writeStagedUpload({
@@ -186,7 +189,7 @@ describe("Feature: Large dataset storage — self-hosted without object storage"
       const storage = await getDatasetStorage("p1");
       const size = await storage.headStagedObjectSize({
         projectId: "p1",
-        key: pending.stagingKey,
+        key: stagingKey,
       });
       expect(size).toBeGreaterThan(0);
 

--- a/langwatch/src/server/datasets/dataset-mutations.ts
+++ b/langwatch/src/server/datasets/dataset-mutations.ts
@@ -25,6 +25,7 @@
  */
 import type { Dataset, Prisma, PrismaClient } from "@prisma/client";
 import { nanoid } from "nanoid";
+import { createLogger } from "~/utils/logger/server";
 import { DatasetRepository } from "./dataset.repository";
 import {
   type ChunkedDatasetMeta,
@@ -37,6 +38,8 @@ import { withDatasetLock } from "./dataset-lock";
 import { type DatasetStorage, getDatasetStorage } from "./dataset-storage";
 import { DatasetNotReadyError } from "./errors";
 import { stripNullBytes } from "./sanitize";
+
+const logger = createLogger("langwatch:datasets:mutations");
 
 export type RecomputedDatasetCounts = {
   rowCount: number;
@@ -347,6 +350,10 @@ const locateIdsBeforeLock = async ({
       // Couldn't read this chunk off the lock (e.g. racing a rewrite). Abandon
       // the hint so the caller uses the proven full in-lock scan instead of
       // acting on a partial locate.
+      logger.warn(
+        { projectId, datasetId, index },
+        "off-lock chunk read failed during id locate; abandoning fast-path hint, falling back to full in-lock scan",
+      );
       return null;
     }
     for (const line of rows) {
@@ -521,6 +528,10 @@ export const editS3JsonlRecord = async ({
           return { updated: true };
         }
         // Row moved/removed since the scan → fall through to the full scan.
+        logger.warn(
+          { projectId, datasetId: dataset.id, recordId, index },
+          "edit fast-path drift: located row not in hinted chunk; falling back to full in-lock scan",
+        );
       }
     }
 
@@ -667,7 +678,13 @@ export const deleteS3JsonlRecords = async ({
         // not, a concurrent mutation moved/removed it since the scan — bail to
         // the proven full scan rather than risk a missed delete.
         for (const id of hint.locatedIds) {
-          if (!removedIds.has(id)) return null;
+          if (!removedIds.has(id)) {
+            logger.warn(
+              { projectId, datasetId: dataset.id, recordId: id },
+              "delete fast-path drift: located id not removed (concurrent mutation); falling back to full in-lock scan",
+            );
+            return null;
+          }
         }
         if (deleted === 0) {
           return { deleted: 0 };

--- a/langwatch/src/server/datasets/dataset-mutations.ts
+++ b/langwatch/src/server/datasets/dataset-mutations.ts
@@ -277,6 +277,7 @@ export const appendS3JsonlRecords = async ({
   entries,
   forcedIds,
   storage,
+  repository: providedRepository,
 }: {
   prisma: PrismaClient;
   dataset: Dataset;
@@ -284,9 +285,10 @@ export const appendS3JsonlRecords = async ({
   entries: unknown[];
   forcedIds?: (string | undefined)[];
   storage?: DatasetStorage;
+  repository?: DatasetRepository;
 }): Promise<{ appended: number }> => {
   const datasetStorage = storage ?? (await getDatasetStorage(projectId));
-  const repository = new DatasetRepository(prisma);
+  const repository = providedRepository ?? new DatasetRepository(prisma);
 
   return withDatasetLock({ prisma, datasetId: dataset.id }, async (tx) => {
     const current = await repository.findOneOrThrow(
@@ -430,6 +432,7 @@ export const editS3JsonlRecord = async ({
   recordId,
   entry,
   storage,
+  repository: providedRepository,
 }: {
   prisma: PrismaClient;
   dataset: Dataset;
@@ -437,9 +440,10 @@ export const editS3JsonlRecord = async ({
   recordId: string;
   entry: unknown;
   storage?: DatasetStorage;
+  repository?: DatasetRepository;
 }): Promise<{ updated: boolean }> => {
   const datasetStorage = storage ?? (await getDatasetStorage(projectId));
-  const repository = new DatasetRepository(prisma);
+  const repository = providedRepository ?? new DatasetRepository(prisma);
 
   // OFF the lock: locate the row's chunk so only that chunk is re-read under it.
   // Skipped unless the dataset looks ready — never do storage I/O ahead of the
@@ -578,15 +582,17 @@ export const deleteS3JsonlRecords = async ({
   projectId,
   recordIds,
   storage,
+  repository: providedRepository,
 }: {
   prisma: PrismaClient;
   dataset: Dataset;
   projectId: string;
   recordIds: string[];
   storage?: DatasetStorage;
+  repository?: DatasetRepository;
 }): Promise<{ deleted: number }> => {
   const datasetStorage = storage ?? (await getDatasetStorage(projectId));
-  const repository = new DatasetRepository(prisma);
+  const repository = providedRepository ?? new DatasetRepository(prisma);
   const removeSet = new Set(recordIds);
   const isTarget = (line: unknown): boolean =>
     isChunkLine(line) && removeSet.has(line.id);
@@ -756,14 +762,16 @@ export const recomputeDatasetCounts = async ({
   datasetId,
   projectId,
   storage,
+  repository: providedRepository,
 }: {
   prisma: PrismaClient;
   datasetId: string;
   projectId: string;
   storage?: DatasetStorage;
+  repository?: DatasetRepository;
 }): Promise<RecomputedDatasetCounts> => {
   const datasetStorage = storage ?? (await getDatasetStorage(projectId));
-  const repository = new DatasetRepository(prisma);
+  const repository = providedRepository ?? new DatasetRepository(prisma);
 
   return withDatasetLock({ prisma, datasetId }, async (tx) => {
     const current = await repository.findOneOrThrow(

--- a/langwatch/src/server/datasets/dataset.repository.ts
+++ b/langwatch/src/server/datasets/dataset.repository.ts
@@ -147,8 +147,8 @@ export class DatasetRepository {
    * Finds the pending (`status='uploading'`, non-archived) dataset that owns a
    * given staging key. The direct-upload staging route uses this to refuse a
    * stream into a `staging/` slot no upload row claims — otherwise an authed
-   * project user could spray orphan objects there (local FS has no staging-TTL
-   * reaper). `stagingKey` is server-minted and bound to the row at presign time.
+   * project user could spray orphan objects there. `stagingKey` is server-minted
+   * and bound to the row at presign time.
    */
   async findPendingUploadByStagingKey(input: {
     projectId: string;
@@ -160,6 +160,28 @@ export class DatasetRepository {
         stagingKey: input.stagingKey,
         status: "uploading",
         archivedAt: null,
+      },
+    });
+  }
+
+  /**
+   * Finds abandoned pending uploads in a project: `status='uploading'`,
+   * non-archived rows created before `olderThan`. Drives the poll-triggered
+   * reap (see `DatasetService.reapStalePendingUploads`) that bounds the
+   * accumulation of stuck `uploading` rows + their staging objects without a
+   * scheduler. The `olderThan` cutoff is conservative (well beyond the presign
+   * TTL) so a still-in-flight upload is never matched.
+   */
+  async findStalePendingUploads(input: {
+    projectId: string;
+    olderThan: Date;
+  }): Promise<Dataset[]> {
+    return await this.prisma.dataset.findMany({
+      where: {
+        projectId: input.projectId,
+        status: "uploading",
+        archivedAt: null,
+        createdAt: { lt: input.olderThan },
       },
     });
   }

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -8,6 +8,7 @@ import { createLogger } from "~/utils/logger/server";
 import { slugify } from "~/utils/slugify";
 import {
   adaptS3JsonlRecord,
+  assertDatasetReadableInHeap,
   createManyDatasetRecords,
   getFullDataset,
 } from "../api/routers/datasetRecord.utils";
@@ -657,6 +658,12 @@ export class DatasetService {
           });
         }
       } else {
+        // No chunkOffsets (legacy/partial migration): the only way to honour the
+        // page window is to read every chunk, then slice — an UNBOUNDED read per
+        // page. Guard on sizeBytes so a large offset-less dataset can't OOM the
+        // pod on a normal list call (offsets-present datasets take the bounded
+        // branch above).
+        assertDatasetReadableInHeap(dataset);
         const rows = await storage.readChunks({
           projectId: params.projectId,
           datasetId: dataset.id,
@@ -957,8 +964,9 @@ export class DatasetService {
     // Fetch source records. ADR-032: an s3_jsonl source has its content in chunk
     // objects, not the PG DatasetRecord table (I-PG), so reading PG would copy
     // an empty dataset. Gate on ready (I-READY) and read the chunks instead.
-    // NOTE: reads all chunks in memory; large-dataset copy is bounded by the
-    // reads-at-scale fast-follow, same as every other read in this rung.
+    // NOTE: reads all chunks in memory until the streaming-copy fast-follow —
+    // so guard on sizeBytes (same ceiling as export) to reject a too-large copy
+    // rather than OOM the pod.
     let sourceRecordEntries: Array<Record<string, unknown>>;
     if (sourceDataset.contentLayout === "s3_jsonl") {
       if (sourceDataset.status !== "ready") {
@@ -967,6 +975,7 @@ export class DatasetService {
           statusError: sourceDataset.statusError,
         });
       }
+      assertDatasetReadableInHeap(sourceDataset);
       const storage = await getDatasetStorage(sourceProjectId);
       const rows = await storage.readChunks({
         projectId: sourceProjectId,

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -749,6 +749,7 @@ export class DatasetService {
         projectId: params.projectId,
         recordId: params.recordId,
         entry: sanitisedEntry,
+        repository: this.repository,
       });
       const record = {
         id: params.recordId,
@@ -866,6 +867,7 @@ export class DatasetService {
         projectId: params.projectId,
         entries: records.map((r) => r.entry),
         forcedIds: records.map((r) => r.id),
+        repository: this.repository,
       });
       const createdAt = new Date();
       return records.map((record) => ({
@@ -913,6 +915,7 @@ export class DatasetService {
         dataset,
         projectId: params.projectId,
         recordIds: params.recordIds,
+        repository: this.repository,
       });
       return { count: deleted };
     }

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -25,6 +25,7 @@ import { enqueueDatasetNormalize } from "./dataset-normalize.queue";
 import { DatasetRecordRepository } from "./dataset-record.repository";
 import { getDatasetStorage } from "./dataset-storage";
 import {
+  ColumnTypeChangeNotSupportedError,
   DatasetConflictError,
   DatasetNotFoundError,
   DatasetNotReadyError,
@@ -249,9 +250,7 @@ export class DatasetService {
         // nothing, leaving stored chunk keys out of sync with columnTypes.
         // Refuse rather than corrupt. (Deferred: s3_jsonl column migration.)
         if (existingDataset.contentLayout === "s3_jsonl") {
-          throw new Error(
-            "Changing column types is not yet supported for large (S3) datasets",
-          );
+          throw new ColumnTypeChangeNotSupportedError();
         }
         await this.migrateDatasetRecordColumns(
           {

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -207,6 +207,21 @@ export class DatasetService {
         throw new DatasetNotFoundError();
       }
 
+      // Defense in depth for the UI's ready-gate: editing a dataset that is still
+      // `uploading`/`processing` (or `failed`) races the normalize job and edits
+      // content that isn't settled. Refuse unless ready (a null status = legacy =
+      // ready). The datasets-page menu hides Edit for non-ready rows; this stops a
+      // direct/stale call too.
+      if (
+        existingDataset.status != null &&
+        existingDataset.status !== "ready"
+      ) {
+        throw new DatasetNotReadyError({
+          status: existingDataset.status,
+          statusError: existingDataset.statusError,
+        });
+      }
+
       const slug = this.generateSlug(name);
 
       // Check for slug collision with other datasets (excluding current one)

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -1,6 +1,11 @@
 import type { Readable } from "node:stream";
 import { generate } from "@langwatch/ksuid";
-import type { DatasetRecord, Prisma, PrismaClient } from "@prisma/client";
+import type {
+  Dataset,
+  DatasetRecord,
+  Prisma,
+  PrismaClient,
+} from "@prisma/client";
 import { nanoid } from "nanoid";
 import { tryToMapPreviousColumnsToNewColumns } from "~/optimization_studio/utils/datasetUtils";
 import { KSUID_RESOURCES } from "~/utils/constants";
@@ -40,6 +45,7 @@ import {
 import { ExperimentRepository } from "./experiment.repository";
 import {
   exceedsUploadCap,
+  STALE_PENDING_UPLOAD_TTL_SECONDS,
   stagingUploadKey,
   UPLOAD_MAX_BYTES,
 } from "./presigned-upload";
@@ -1139,15 +1145,6 @@ export class DatasetService {
   }
 
   /**
-   * Creates a new dataset from an uploaded file.
-   *
-   * Parses the file, infers columns (all as "string"), renames reserved columns,
-   * creates the dataset and records.
-   *
-   * @throws {DatasetConflictError} if slug conflicts
-   * @throws {UploadValidationError} if file too large, too many rows, etc.
-   */
-  /**
    * R3: start a direct browser→S3 upload for a NEW dataset. Checks the name
    * conflict FIRST (C2 — a conflict must never mint a presigned URL), then
    * mints the presigned target (fails fast with `DirectUploadUnavailableError`
@@ -1155,6 +1152,9 @@ export class DatasetService {
    * then creates the `Dataset` in `uploading` with the minted staging key
    * bound to the row (C1). Content lands in S3 once the normalize job runs
    * (rung 4); `columnTypes` is unknown until then.
+   *
+   * Opportunistically reaps this project's abandoned prior uploads first (no
+   * scheduler — the poll-triggered cleanup; see `reapStalePendingUploads`).
    */
   async createPendingUpload(params: {
     projectId: string;
@@ -1164,9 +1164,13 @@ export class DatasetService {
     datasetId: string;
     slug: string;
     uploadUrl: string;
-    stagingKey: string;
   }> {
     const { projectId, name, filename } = params;
+
+    // Bound the accumulation of abandoned `uploading` rows + staging objects:
+    // sweep this project's stale pending uploads as new ones start. Best-effort
+    // (never blocks this upload).
+    await this.reapStalePendingUploads(projectId);
 
     const slug = this.generateSlug(name);
     // C2: reject a name conflict before minting a presigned URL so a duplicate
@@ -1199,7 +1203,6 @@ export class DatasetService {
       datasetId: dataset.id,
       slug: dataset.slug,
       uploadUrl: upload.url,
-      stagingKey: upload.key,
     };
   }
 
@@ -1279,14 +1282,28 @@ export class DatasetService {
       throw new UploadNotPendingError();
     }
 
-    // Best-effort delete of the staged object — non-fatal (the staging lifecycle
-    // rule reaps it otherwise; a failed delete must not block the cleanup).
+    await this.reapPendingUpload(dataset);
+
+    return { datasetId, aborted: true };
+  }
+
+  /**
+   * Reap one pending (`uploading`, non-archived) upload row: best-effort delete
+   * its staged object, then archive the row (rename the slug + set `archivedAt`)
+   * so it stops pinning its slug/quota. The staged-object delete is non-fatal —
+   * the S3 staging lifecycle rule (IaC) reaps it otherwise; a failed delete must
+   * never block the archive. Shared by the explicit abort (`abortPendingUpload`)
+   * and the poll-triggered sweep (`reapStalePendingUploads`). The caller owns the
+   * `status='uploading'` guard.
+   */
+  private async reapPendingUpload(dataset: Dataset): Promise<void> {
+    const { id: datasetId, projectId } = dataset;
     if (dataset.stagingKey) {
       try {
         const storage = await getDatasetStorage(projectId);
         await storage.deleteStaged({ projectId, key: dataset.stagingKey });
       } catch {
-        // ignore
+        // ignore — best-effort; the lifecycle rule is the durable backstop
       }
     }
 
@@ -1299,8 +1316,39 @@ export class DatasetService {
         archivedAt: new Date(),
       },
     });
+  }
 
-    return { datasetId, aborted: true };
+  /**
+   * Poll-triggered cleanup of abandoned pending uploads: archive every
+   * `status='uploading'` row in the project older than
+   * `STALE_PENDING_UPLOAD_TTL_SECONDS` and best-effort delete its staging
+   * object. Runs opportunistically when a new upload starts (NOT a scheduler —
+   * this epic deliberately adds no cron; see the normalize-recovery decision),
+   * so accumulation is bounded for any project that keeps uploading. Wholly
+   * best-effort: any failure is swallowed so it can never block the upload that
+   * triggered it. The conservative TTL guarantees a still-in-flight upload is
+   * never reaped. The durable backstop for a project that never uploads again is
+   * the S3 `staging/` lifecycle rule (IaC).
+   */
+  private async reapStalePendingUploads(projectId: string): Promise<void> {
+    try {
+      const olderThan = new Date(
+        Date.now() - STALE_PENDING_UPLOAD_TTL_SECONDS * 1000,
+      );
+      const stale = await this.repository.findStalePendingUploads({
+        projectId,
+        olderThan,
+      });
+      for (const dataset of stale) {
+        try {
+          await this.reapPendingUpload(dataset);
+        } catch {
+          // one bad row must not abort the rest of the sweep
+        }
+      }
+    } catch {
+      // sweep is opportunistic — never let it block the triggering upload
+    }
   }
 
   /**

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -31,6 +31,7 @@ import { DatasetRecordRepository } from "./dataset-record.repository";
 import { getDatasetStorage } from "./dataset-storage";
 import {
   ColumnTypeChangeNotSupportedError,
+  DatasetChunkCountMissingError,
   DatasetConflictError,
   DatasetNotFoundError,
   DatasetNotReadyError,
@@ -684,10 +685,18 @@ export class DatasetService {
         // pod on a normal list call (offsets-present datasets take the bounded
         // branch above).
         assertDatasetReadableInHeap(dataset);
+        // I-COUNT: same guard as getFullDataset — a `ready` s3_jsonl dataset MUST
+        // have a non-null chunkCount. `chunkCount ?? 0` would loop zero times and
+        // serve an EMPTY page against a positive rowCount (silent data loss); the
+        // offsets branch above never reaches here, so this only fires on genuine
+        // drift. Throw loudly so it surfaces (and recomputeDatasetCounts repairs).
+        if (dataset.chunkCount == null) {
+          throw new DatasetChunkCountMissingError(dataset.id);
+        }
         const rows = await storage.readChunks({
           projectId: params.projectId,
           datasetId: dataset.id,
-          chunkCount: dataset.chunkCount ?? 0,
+          chunkCount: dataset.chunkCount,
         });
         const records = rows.map((line) => adaptS3JsonlRecord(line, dataset));
         pageRecords.push(...records.slice(windowStart, windowEnd));

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -1008,11 +1008,18 @@ export class DatasetService {
         });
       }
       assertDatasetReadableInHeap(sourceDataset);
+      // I-COUNT: a ready s3_jsonl source MUST have a non-null chunkCount; `?? 0`
+      // would read zero chunks and silently copy an EMPTY dataset against a
+      // positive rowCount. Mirror getFullDataset/listRecords — throw, don't
+      // truncate (no offsets branch here, so chunkCount always governs the read).
+      if (sourceDataset.chunkCount == null) {
+        throw new DatasetChunkCountMissingError(sourceDatasetId);
+      }
       const storage = await getDatasetStorage(sourceProjectId);
       const rows = await storage.readChunks({
         projectId: sourceProjectId,
         datasetId: sourceDatasetId,
-        chunkCount: sourceDataset.chunkCount ?? 0,
+        chunkCount: sourceDataset.chunkCount,
       });
       // Reuse the shared {id, entry} → DatasetRecord adapter (the same unwrap the
       // read paths use) and take just the entry; the copy mints fresh ids below.

--- a/langwatch/src/server/datasets/errors.ts
+++ b/langwatch/src/server/datasets/errors.ts
@@ -216,6 +216,28 @@ export class MissingChunkError extends Error {
 }
 
 /**
+ * An s3_jsonl dataset is `ready` but its PG-authoritative `chunkCount` is null —
+ * an I-COUNT integrity violation (a transiently-failed `UPDATE` after migrate /
+ * normalize, never a valid resting state). Read paths must NOT coerce it via
+ * `chunkCount ?? 0`, which would loop zero times and serve an EMPTY dataset
+ * against a positive `rowCount` — silent, undiagnosable data loss for the UI,
+ * SDK, and experiments. Throwing surfaces the drift loudly so it can be repaired
+ * (`recomputeDatasetCounts`) rather than masked. Maps to a 500 (server-side data
+ * bug, not user-actionable).
+ */
+export class DatasetChunkCountMissingError extends Error {
+  readonly datasetId: string;
+
+  constructor(datasetId: string) {
+    super(
+      `Dataset ${datasetId} has s3_jsonl layout but a null chunkCount (I-COUNT drift)`,
+    );
+    this.name = "DatasetChunkCountMissingError";
+    this.datasetId = datasetId;
+  }
+}
+
+/**
  * The local-FS storage root is not writable (EACCES/EROFS/EPERM) — born-on-
  * storage made a writable backend mandatory, so this is a deployment-config
  * error, not a transient failure. Typed (vs a bare `Error`) so the upload route

--- a/langwatch/src/server/datasets/errors.ts
+++ b/langwatch/src/server/datasets/errors.ts
@@ -10,6 +10,22 @@ export class DatasetNotFoundError extends Error {
   }
 }
 
+/**
+ * A column-type change was requested on an s3_jsonl dataset, where rewriting
+ * every chunk's keys is a later rung (Decision 6 defers s3_jsonl column
+ * migration). It's a user-actionable precondition, not a server fault — typed so
+ * the router maps it to a 4xx with the message intact instead of letting a plain
+ * `Error` collapse into a generic 500.
+ */
+export class ColumnTypeChangeNotSupportedError extends Error {
+  constructor(
+    message = "Changing column types is not yet supported for large (S3) datasets",
+  ) {
+    super(message);
+    this.name = "ColumnTypeChangeNotSupportedError";
+  }
+}
+
 export class DatasetConflictError extends Error {
   constructor(message = "A dataset with this name already exists") {
     super(message);

--- a/langwatch/src/server/datasets/local-dataset-storage.ts
+++ b/langwatch/src/server/datasets/local-dataset-storage.ts
@@ -59,6 +59,30 @@ export class LocalDatasetStorage implements DatasetStorage {
   }
 
   /**
+   * Write a chunk file atomically: write a unique temp sibling, then `rename`
+   * it into place. A bare `fs.writeFile` truncates-then-writes, so a reader —
+   * `readChunks`/`readChunk` take NO advisory lock (only writers do) — can
+   * observe a half-written chunk and crash in `JSON.parse`. POSIX `rename` is
+   * atomic on the same filesystem, so a concurrent read sees either the old
+   * object or the fully-written new one, never a torn one. This brings the
+   * local backend to parity with S3 (PutObject is already atomic). The temp
+   * sibling shares the chunk's directory so the rename stays intra-filesystem;
+   * a failed write removes it so a crash never leaves `.tmp-*` litter.
+   */
+  private async atomicWriteFile(filePath: string, data: string): Promise<void> {
+    const tmpPath = `${filePath}.tmp-${nanoid()}`;
+    try {
+      await fs.writeFile(tmpPath, data, "utf-8");
+      await fs.rename(tmpPath, filePath);
+    } catch (error: unknown) {
+      await fs.rm(tmpPath, { force: true }).catch(() => {
+        // best-effort cleanup — surface the original write/rename error
+      });
+      throw error;
+    }
+  }
+
+  /**
    * Turn a raw FS permission failure (EACCES/EROFS/EPERM) into an actionable
    * error pointing at the two ways to fix it; rethrow anything else. Born-on-
    * storage made a writable backend mandatory, so an unwritable root (e.g. the
@@ -104,7 +128,7 @@ export class LocalDatasetStorage implements DatasetStorage {
       );
       try {
         await fs.mkdir(path.dirname(filePath), { recursive: true });
-        await fs.writeFile(filePath, chunk.jsonl, "utf-8");
+        await this.atomicWriteFile(filePath, chunk.jsonl);
       } catch (error: unknown) {
         this.rethrowWritable(error);
       }
@@ -211,7 +235,7 @@ export class LocalDatasetStorage implements DatasetStorage {
     }
     const filePath = this.localPath(chunkKey(projectId, datasetId, index));
     await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.writeFile(filePath, jsonl, "utf-8");
+    await this.atomicWriteFile(filePath, jsonl);
     // startRow/endRow are chunk-LOCAL here; the caller recomputes global offsets.
     return { index, startRow: 0, endRow: records.length, byteSize };
   }

--- a/langwatch/src/server/datasets/middleware.ts
+++ b/langwatch/src/server/datasets/middleware.ts
@@ -1,5 +1,10 @@
 import { TRPCError } from "@trpc/server";
-import { DatasetConflictError, DatasetNotFoundError } from "./errors";
+import {
+  ColumnTypeChangeNotSupportedError,
+  DatasetConflictError,
+  DatasetNotFoundError,
+  DatasetNotReadyError,
+} from "./errors";
 
 /**
  * Middleware function that catches domain errors and maps them to tRPC errors.
@@ -22,6 +27,27 @@ export async function withDatasetErrorHandling<T>(
       throw new TRPCError({
         code: "CONFLICT",
         message: error.message,
+      });
+    }
+
+    // A column-type change on an s3_jsonl dataset is a user-actionable
+    // precondition (deferred feature), not a server fault — surface a 4xx with
+    // the message instead of a generic 500.
+    if (error instanceof ColumnTypeChangeNotSupportedError) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: error.message,
+        cause: error,
+      });
+    }
+
+    // Editing a not-yet-ready dataset (defense-in-depth ready-gate) — same code
+    // the record routes use for DatasetNotReadyError.
+    if (error instanceof DatasetNotReadyError) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: error.message,
+        cause: error,
       });
     }
 

--- a/langwatch/src/server/datasets/presigned-upload.ts
+++ b/langwatch/src/server/datasets/presigned-upload.ts
@@ -22,6 +22,23 @@ export const UPLOAD_MAX_BYTES = 5 * 1024 * 1024 * 1024;
 export const UPLOAD_TTL_SECONDS = 15 * 60;
 
 /**
+ * Age past which a `status='uploading'` row is treated as abandoned and reaped
+ * (its staging object deleted, the row archived). Deliberately FAR above the
+ * presign TTL: a row that lingers this long means the browser PUT either never
+ * happened or completed-but-never-finalized, never a still-in-flight upload (a
+ * legit upload starts within the 15-min presign window and finalizes promptly).
+ * The conservative margin guarantees the lazy sweep never reaps a live upload.
+ *
+ * The reaper is *poll-triggered* (runs opportunistically when the next upload
+ * starts — see `reapStalePendingUploads`), not a scheduler: this epic
+ * deliberately adds no new cron/BullMQ-repeat (see the normalize-recovery
+ * decision). The durable backstop for objects whose row never gets reaped (an
+ * inactive project) is an S3 bucket lifecycle rule on the `staging/` prefix
+ * (IaC) — the same place the upload-bucket CORS rule lives.
+ */
+export const STALE_PENDING_UPLOAD_TTL_SECONDS = 24 * 60 * 60;
+
+/**
  * Server-owned, tenant-scoped staging key the client cannot widen — the
  * presign is bound to exactly this key, so a client can only write this one
  * object under its own project prefix.

--- a/langwatch/src/tasks/__tests__/backfillDatasetContentToS3.unit.test.ts
+++ b/langwatch/src/tasks/__tests__/backfillDatasetContentToS3.unit.test.ts
@@ -71,6 +71,9 @@ const makePrisma = (row: Dataset | null) => {
     dataset: { findFirst, update },
   };
   const prisma = {
+    // Top-level findFirst for the OUTSIDE-lock pre-check; the in-lock re-read
+    // uses the tx's findFirst (same spy, same row).
+    dataset: { findFirst },
     $transaction: vi.fn(async (fn: (t: typeof tx) => unknown) => fn(tx)),
   };
   return { prisma, tx, update, findFirst, executeRaw };
@@ -415,7 +418,14 @@ describe("backfillDatasetContentToS3", () => {
         const lockExecuteRaw = vi.fn().mockResolvedValue([]);
         const prisma = {
           project: { findMany: projectFindMany },
-          dataset: { findMany: datasetFindMany },
+          dataset: {
+            findMany: datasetFindMany,
+            // Top-level findFirst for each dataset's OUTSIDE-lock pre-check
+            // (both d1/d2 are postgres → both proceed to migrate).
+            findFirst: vi
+              .fn()
+              .mockResolvedValue(makeDataset({ contentLayout: "postgres" })),
+          },
           $transaction: vi.fn(async (fn: (t: unknown) => unknown) =>
             fn({
               $executeRaw: lockExecuteRaw,
@@ -474,17 +484,33 @@ describe("backfillDatasetContentToS3", () => {
           .mockResolvedValueOnce([]);
         const prisma = {
           project: { findMany: vi.fn().mockResolvedValue([{ id: "p1" }]) },
-          dataset: { findMany },
-          $transaction: vi.fn(async () => {
-            throw new Error("S3 write failed");
-          }),
+          dataset: {
+            findMany,
+            findFirst: vi
+              .fn()
+              .mockResolvedValue(makeDataset({ contentLayout: "postgres" })),
+          },
+          $transaction: vi.fn(async (fn: (t: unknown) => unknown) =>
+            fn({
+              $executeRaw: vi.fn().mockResolvedValue([]),
+              dataset: { findFirst: vi.fn(), update: vi.fn() },
+            }),
+          ),
         };
         const deps = makeDeps({
           prisma: prisma as never,
+          recordRepository: {
+            findDatasetRecords: vi
+              .fn()
+              .mockResolvedValue([makeRecord("r", { a: 1 })]),
+          } as never,
           resolveStorage: vi
             .fn()
             .mockResolvedValue({ kind: "s3", bucket: "b" }),
-          getStorage: vi.fn().mockResolvedValue(makeStorage(vi.fn())),
+          // The S3 write (now OUTSIDE the lock) fails for this dataset.
+          getStorage: vi.fn().mockResolvedValue(
+            makeStorage(vi.fn().mockRejectedValue(new Error("S3 write failed"))),
+          ),
         });
 
         const summary = await migrateAllPostgresDatasets(deps);

--- a/langwatch/src/tasks/__tests__/backfillDatasetContentToS3.unit.test.ts
+++ b/langwatch/src/tasks/__tests__/backfillDatasetContentToS3.unit.test.ts
@@ -508,9 +508,13 @@ describe("backfillDatasetContentToS3", () => {
             .fn()
             .mockResolvedValue({ kind: "s3", bucket: "b" }),
           // The S3 write (now OUTSIDE the lock) fails for this dataset.
-          getStorage: vi.fn().mockResolvedValue(
-            makeStorage(vi.fn().mockRejectedValue(new Error("S3 write failed"))),
-          ),
+          getStorage: vi
+            .fn()
+            .mockResolvedValue(
+              makeStorage(
+                vi.fn().mockRejectedValue(new Error("S3 write failed")),
+              ),
+            ),
         });
 
         const summary = await migrateAllPostgresDatasets(deps);

--- a/langwatch/src/tasks/backfillDatasetContentToS3.ts
+++ b/langwatch/src/tasks/backfillDatasetContentToS3.ts
@@ -130,11 +130,60 @@ export const migrateDatasetToS3 = async (
 
   const storage = await deps.getStorage(projectId);
 
+  // Pre-check OUTSIDE the lock: skip an already-migrated dataset before doing any
+  // S3 work. The authoritative re-check runs inside the lock below — this one
+  // just avoids wasted writes on the common already-done case.
+  const preCheck = await deps.prisma.dataset.findFirst({
+    where: { id: dataset.id, projectId },
+  });
+  if (!preCheck || preCheck.contentLayout !== "postgres") {
+    logger.info(
+      { datasetId: dataset.id, projectId },
+      "Skipping dataset — already migrated (not on postgres layout)",
+    );
+    return "already-migrated";
+  }
+
+  // Read the PG rows and write the S3 chunks OUTSIDE the advisory lock — only the
+  // atomic counter+`contentLayout` flip needs serialization, so we never hold the
+  // lock (and burn its 120s transaction budget) across S3 network I/O. Safe
+  // because the write is idempotent by deterministic key: a concurrent/re-run
+  // write overwrites the same keys with identical content (a postgres-layout
+  // dataset's corpus is frozen during migration) and a crash here is re-runnable.
+  // This is the ordering the file header documents. [Records are capped at the
+  // legacy 25MB/10k limits → fits in memory; PRESERVE ids so the chunk lines
+  // carry the same record ids the editor targets.]
+  const records = await deps.recordRepository.findDatasetRecords({
+    datasetId: dataset.id,
+    projectId,
+  });
+  const lines = records.map((row) => ({ id: row.id, entry: row.entry }));
+
+  const written = await storage.writeChunks({
+    projectId,
+    datasetId: dataset.id,
+    records: lines,
+    fromIndex: 0,
+  });
+
+  // Defensive orphan-chunk cleanup (I-IDEM): drop any tail chunks a crashed prior
+  // run wrote beyond what THIS run writes, so a shorter re-run never leaves
+  // dangling `chunk-{n}` objects. Harmless today (frozen corpus → same count) and
+  // cheap (stops at the first contiguous gap).
+  await storage.deleteChunksFrom({
+    projectId,
+    datasetId: dataset.id,
+    fromIndex: written.length,
+  });
+  const meta = chunkedMeta(written);
+
+  // Flip onto s3_jsonl UNDER the lock — a short, PG-only critical section: re-read
+  // to win the race against a concurrent run (our idempotent S3 writes make a
+  // redundant write harmless), then commit the counter update + `contentLayout`
+  // flip atomically. `status` is left untouched (existing datasets are `ready`).
   return withDatasetLock(
     { prisma: deps.prisma, datasetId: dataset.id },
     async (tx) => {
-      // Re-read inside the lock: another pod/run may have migrated this dataset
-      // since we listed it. Idempotent/resumable — only `postgres` is migrated.
       const current = await tx.dataset.findFirst({
         where: { id: dataset.id, projectId },
       });
@@ -146,44 +195,6 @@ export const migrateDatasetToS3 = async (
         return "already-migrated";
       }
 
-      // Read the PG rows (small — capped at the legacy 25MB/10k limits, so the
-      // whole dataset fits in memory; no streaming needed). PRESERVE ids so the
-      // s3_jsonl chunk lines carry the same record ids the editor targets.
-      const records = await deps.recordRepository.findDatasetRecords(
-        { datasetId: dataset.id, projectId },
-        { tx },
-      );
-      const lines = records.map((row) => ({ id: row.id, entry: row.entry }));
-
-      // Write S3 chunks BEFORE the PG flip. Deterministic keys from index 0 →
-      // a re-run overwrites the same keys idempotently rather than appending.
-      const written = await storage.writeChunks({
-        projectId,
-        datasetId: dataset.id,
-        records: lines,
-        fromIndex: 0,
-      });
-
-      // Defensive orphan-chunk cleanup (I-IDEM). A crashed prior run could have
-      // written MORE chunks than this run does (e.g. if it failed mid-write, or
-      // a future change makes the corpus shrinkable) — those tail chunks would
-      // be orphaned, since `writeChunks` overwrites by key but never deletes
-      // beyond what it writes. Drop everything from `written.length` upward so a
-      // shorter re-run can never leave dangling `chunk-{n}` objects. Harmless
-      // today (the PG corpus is frozen → re-runs write the same count), but it
-      // future-proofs the flow and is cheap (stops at the first contiguous gap).
-      // Called unconditionally: simpler than gating on "could there be priors"
-      // and the no-op cost (one HEAD that 404s) is negligible.
-      await storage.deleteChunksFrom({
-        projectId,
-        datasetId: dataset.id,
-        fromIndex: written.length,
-      });
-      const meta = chunkedMeta(written);
-
-      // Flip the dataset onto the s3_jsonl layout in the SAME locked
-      // transaction — counter update + contentLayout flip commit atomically.
-      // `status` is left untouched (existing datasets are `ready`).
       await tx.dataset.update({
         where: { id: dataset.id, projectId },
         data: {

--- a/langwatch/src/tests/pages/dataset-edit-run-experiment.integration.test.tsx
+++ b/langwatch/src/tests/pages/dataset-edit-run-experiment.integration.test.tsx
@@ -29,7 +29,10 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
 }));
 
 // The page lifted the dataset read to decide the I-READY gate (ADR-032), so it
-// now calls tRPC directly — stub it as a ready dataset so the editor chrome renders.
+// now calls tRPC directly — stub it as a settled, ready dataset so the editor
+// chrome renders. The gate is `isSuccess && status === "ready"`, so the mock
+// must report `isSuccess: true` (a `status: "ready"` payload alone is gated out
+// until the query resolves).
 vi.mock("~/utils/api", () => ({
   api: {
     dataset: {
@@ -37,6 +40,7 @@ vi.mock("~/utils/api", () => ({
         useQuery: () => ({
           data: { status: "ready" },
           isLoading: false,
+          isSuccess: true,
           refetch: vi.fn(),
         }),
       },

--- a/specs/features/dataset-file-upload-api.feature
+++ b/specs/features/dataset-file-upload-api.feature
@@ -305,3 +305,9 @@ Feature: Dataset File Upload REST API
   Scenario: Upload to existing without API key returns 401
     When I POST /api/dataset/some-dataset/upload without X-Auth-Token header
     Then the request fails with 401 Unauthorized
+
+  @integration
+  Scenario: Direct-upload rejects a foreign-project API key against an owned project
+    Given a second project with its own API key
+    When I POST /api/dataset/direct-upload for the first project using the second project's API key
+    Then the request fails with 401 Unauthorized


### PR DESCRIPTION
## Why

Two review passes on the datasets→S3 chunked-JSONL reads epic ([#4908](https://github.com/langwatch/langwatch/pull/4908)), plus a set of follow-up findings, surfaced correctness, security, and hygiene issues that were out of scope to fix inline on the epic branch. This PR addresses **every validated finding** in one place. It stacks on `feat/datasets-s3-reads`.

Scope boundary: two findings are deliberately **not** here — the migration lost-write race and per-dataset storage-backend persistence — because each is a larger, cross-cutting change (one touches every postgres mutation path, one needs a Prisma migration) and neither gates merging the reads work. Both are tracked as pre-migration blockers. See *Anything surprising?*.

## What changed

**Data integrity — null `chunkCount` (I-COUNT) on s3_jsonl reads.** A ready s3_jsonl dataset with a null `chunkCount` coerced `?? 0` and served an *empty* result against a positive `rowCount` — silent, undiagnosable data loss. All four read sites now throw `DatasetChunkCountMissingError` instead of truncating: `getFullDataset`, `listRecords` (no-offset fallback), `copyDataset`, and the head/preview path. Same change adds a heap ceiling so an offset-less full read can't OOM the pod.

**Concurrency / migration.** The backfill now does its S3 chunk writes *outside* the per-dataset advisory lock, holding the lock only for the short PG counter+`contentLayout` flip — so a migration never burns the lock's transaction budget across network I/O.

**Local-FS durability.** `writeChunks`/`rewriteChunk` write a temp sibling then atomic-rename. A bare `fs.writeFile` truncates-then-writes, so a lock-free reader could observe a torn chunk and crash in `JSON.parse`; rename brings the local backend to parity with S3 (PutObject is already atomic).

**Upload lifecycle & security.** CSRF defense (Sec-Fetch-Site + Origin/x-forwarded-host fallback) on the cookie-authed direct-upload routes; a route-level cross-tenant guard on `POST /direct-upload`; the raw `stagingKey` dropped from the upload response (nothing consumed it — finalize reads the key from the row); and a poll-triggered sweep that reaps abandoned `uploading` rows + their staging objects when the next upload starts (no new scheduler).

**Ready-gating (I-READY, defense-in-depth).** The dataset picker, row-action menu, and edit path honour `status='ready'` (null = legacy = ready); the editor gates on query success and surfaces a failed upload-abort; a column-type change on an s3_jsonl dataset now surfaces as a typed 4xx instead of a generic 500.

**Architecture / hygiene.** `POST /:slug/entries` routed through the service layer (no route→repository); `DatasetRepository` injected into the s3_jsonl mutations; the create-path dataset lookup de-duplicated.

**Helm.** The RWO single-replica guard now also covers `workers.replicaCount`; the migration Job gained an optional `serviceAccountName` and an `activeDeadlineSeconds` backstop.

## How it works

The I-COUNT guard is intentionally placed per-read-path rather than once at the top, because the offset-driven read branches legitimately operate with a null `chunkCount` (they address chunks via the PG-authoritative `chunkOffsets` index, never the count). The guard only fires in the branches where `chunkCount` actually drives the read — the no-offset fallbacks — so it surfaces genuine drift without breaking valid offset-indexed reads.

The abandoned-upload reaper is poll-triggered (runs opportunistically when a new upload starts), not a cron — this epic deliberately adds no new scheduler. Its durable backstop for projects that never upload again is an S3 `staging/` lifecycle rule, tracked as separate infra work.

## Test plan

All green locally:

- **Unit:** `dataset-service.upload`, `dataset-service.s3-reads`, `datasetRecord.utils.s3`, `self-hosted-no-s3`, `directUpload`, `UploadCSVDrawer`, `dataset-mutations` — every fix has a regression test (the four I-COUNT guards each assert `DatasetChunkCountMissingError` + that no chunk read happens; the atomic write asserts no `.tmp` residue + no torn read under concurrent rewrite; the reaper asserts stale rows are archived and never blocks the triggering upload).
- **Integration (runs in CI — needs Docker locally):** `local-dataset-storage`, `dataset-upload-api` (cross-tenant scenario), `dataset-edit-run-experiment`.
- **Typecheck** (`tslsp` per-file) clean; **biome** clean on all changed files; **feature-parity** `OK` (the new cross-tenant scenario is bound).

## Deployment Impact

**Env vars:** none added or changed. The CSRF defense reads existing request headers (`Sec-Fetch-Site`, `Origin`, `x-forwarded-host`); the upload reaper uses a code constant, not config.

**Helm values changed (`charts/langwatch`):**
- The single-replica RWO guard in `_helpers.tpl` now also covers `workers.replicaCount`. It hard-fails an install **only** for the misconfiguration it targets: `replicaCount > 1` *and* local-filesystem storage on an RWO volume. Operators on S3 or an RWX volume are unaffected — this just extends to workers the same guard the app pods already had.
- The dataset→S3 migration Job (`dataset-s3-migration-job.yaml`) gained an optional `serviceAccountName` (defaults unset → the namespace default SA, no behavior change) and an `activeDeadlineSeconds` default of `21600` (6h) as a backstop so a stuck one-shot migration Job can't run forever.
- `values.yaml` adds documentation comments for the `awsS3` `secretKeyRef` wiring (comments only, no value changes).

**Default behavior on a vanilla `helm install` (no overrides):** unchanged. The RWO guard does not trigger on a default install; `serviceAccountName` stays unset (namespace default SA); the 6h deadline only bounds the optional one-shot migration Job, which self-skips when there's nothing to migrate.

**BYOC dataplane impact:** none. These are control-plane chart/Job mechanics; per-project BYOC bucket resolution and dataplane S3 config are untouched.

## Anything surprising?

**Deliberately deferred (tracked, not lost):**

- **P1 — backfill lost-write race.** A `DatasetRecord` mutation concurrent with a migration can be lost (postgres mutation paths don't take the advisory lock; the migrate snapshots outside it). It's a real P1 but a **pre-migration** blocker, not pre-merge — the backfill isn't running yet — and the fix is cross-cutting (every postgres mutation path joins the lock + ready-gate; migration marks the row `migrating` before snapshotting). Carved to its own change.
- **P1 — persist `storageBackend` per dataset.** `getDatasetStorage` re-resolves the backend from env on every read, so a local-FS→S3 migration orphans existing datasets. Needs a Prisma schema migration, so it's its own PR.

Both are documented with full repro + fix shape in the epic's planning notes.
