### PR TITLE
fix(langevals): report unknown ragas cost as None instead of $0

### DIFF
--- a/langevals/evaluators/ragas/langevals_ragas/factual_correctness.py
+++ b/langevals/evaluators/ragas/langevals_ragas/factual_correctness.py
@@ -132,6 +132,6 @@ class RagasFactualCorrectnessEvaluator(
 
         return RagasResult(
             score=score,
-            cost=cost,
+            cost=cost.money,
             details=details if details else None,
         )

--- a/langevals/evaluators/ragas/langevals_ragas/faithfulness.py
+++ b/langevals/evaluators/ragas/langevals_ragas/faithfulness.py
@@ -149,6 +149,6 @@ class RagasFaithfulnessEvaluator(
 
         return RagasResult(
             score=score,
-            cost=cost,
+            cost=cost.money,
             details=details,
         )

--- a/langevals/evaluators/ragas/langevals_ragas/lib/common.py
+++ b/langevals/evaluators/ragas/langevals_ragas/lib/common.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from dataclasses import dataclass
 import os
 from typing import List, Optional
 from langevals_core.base_evaluator import (
@@ -103,11 +104,24 @@ def check_max_tokens(
     return None
 
 
+@dataclass
+class CapturedCost:
+    """Mutable holder for the cost captured by :func:`capture_cost`.
+
+    The cost can only be computed on teardown — after the ``with`` block has run
+    the evaluation and the token usage is known — so callers read ``.money``
+    *after* the block. ``money`` is ``None`` when the model's price is unknown
+    (see :func:`capture_cost`).
+    """
+
+    money: Optional[Money]
+
+
 @contextmanager
 def capture_cost(llm: LangchainLLMWrapper):
     with get_openai_callback() as cb:
-        money = Money(amount=0, currency="USD")
-        yield money
+        captured = CapturedCost(money=Money(amount=0, currency="USD"))
+        yield captured
 
         prompt_tokens = cb.prompt_tokens
         completion_tokens = cb.completion_tokens
@@ -118,13 +132,14 @@ def capture_cost(llm: LangchainLLMWrapper):
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
             )
-            money.amount = prompt_cost + completion_cost
+            captured.money = Money(amount=prompt_cost + completion_cost, currency="USD")
         except Exception as e:
             if "This model isn't mapped yet" in str(e):
-                # TODO: we need to pass in user cost mapping here
-                # TODO: actually yield None somehow here, because we don't want to store this value as 0
-                return None
+                # litellm has no price for this model, so the cost is genuinely
+                # unknown. Report it as None rather than a misleading $0, which
+                # would understate evaluation spend in cost dashboards.
+                # TODO: pass in a user-provided cost mapping here to price
+                # otherwise-unmapped models.
+                captured.money = None
             else:
                 raise e
-
-        return money

--- a/langevals/evaluators/ragas/langevals_ragas/response_context_precision.py
+++ b/langevals/evaluators/ragas/langevals_ragas/response_context_precision.py
@@ -97,6 +97,6 @@ class RagasResponseContextPrecisionEvaluator(
 
         return RagasResult(
             score=score,
-            cost=cost,
+            cost=cost.money,
             details=None,
         )

--- a/langevals/evaluators/ragas/langevals_ragas/response_context_recall.py
+++ b/langevals/evaluators/ragas/langevals_ragas/response_context_recall.py
@@ -98,6 +98,6 @@ class RagasResponseContextRecallEvaluator(
 
         return RagasResult(
             score=score,
-            cost=cost,
+            cost=cost.money,
             details=details,
         )

--- a/langevals/evaluators/ragas/langevals_ragas/response_relevancy.py
+++ b/langevals/evaluators/ragas/langevals_ragas/response_relevancy.py
@@ -110,6 +110,6 @@ class RagasResponseRelevancyEvaluator(
 
         return RagasResult(
             score=score,
-            cost=cost,
+            cost=cost.money,
             details=f"Questions generated from output:\n\n{generated_questions}\n\nSimilarity to original question: {breakdown['similarity']}\nEvasive answer: {any_noncommittal}",
         )

--- a/langevals/evaluators/ragas/langevals_ragas/rubrics_based_scoring.py
+++ b/langevals/evaluators/ragas/langevals_ragas/rubrics_based_scoring.py
@@ -117,6 +117,6 @@ class RagasRubricsBasedScoringEvaluator(
 
         return RagasResult(
             score=score,
-            cost=cost,
+            cost=cost.money,
             details=breakdown.feedback if breakdown else None,
         )

--- a/langevals/evaluators/ragas/langevals_ragas/sql_query_equivalence.py
+++ b/langevals/evaluators/ragas/langevals_ragas/sql_query_equivalence.py
@@ -85,7 +85,7 @@ class RagasSQLQueryEquivalenceEvaluator(
 
         return RagasSQLQueryEquivalenceResult(
             passed=score >= 0.5,
-            cost=cost,
+            cost=cost.money,
             details=(
                 f"Response query explaination: {breakdown.response_query_explaination}\nReference query explaination: {breakdown.reference_query_explaination}\nEquivalence: {breakdown.equivalence}"
                 if breakdown

--- a/langevals/evaluators/ragas/langevals_ragas/summarization_score.py
+++ b/langevals/evaluators/ragas/langevals_ragas/summarization_score.py
@@ -90,6 +90,6 @@ class RagasSummarizationScoreEvaluator(
 
         return RagasResult(
             score=score,
-            cost=cost,
+            cost=cost.money,
             details=details,
         )

--- a/langevals/evaluators/ragas/tests/test_ragas.py
+++ b/langevals/evaluators/ragas/tests/test_ragas.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import dotenv
 import pytest
 
-from langevals_core.base_evaluator import EvaluatorSettings
+from langevals_core.base_evaluator import EvaluatorSettings, Money
 from langevals_ragas.bleu_score import RagasBLEUScoreEntry, RagasBLEUScoreEvaluator
 from langevals_ragas.context_f1 import (
     RagasContextF1Entry,
@@ -198,6 +198,65 @@ def test_faithfulness_supports_ragas_0_3_statement_generator_output():
     assert result.status == "processed"
     assert result.score == 0.5
     assert result.details and 'The capital of France is Paris.' in result.details
+
+
+def test_cost_is_reported_as_unknown_when_model_is_not_priced():
+    """When litellm cannot price the judge model (it raises "This model isn't
+    mapped yet"), the cost is genuinely unknown and must be reported as ``None``
+    — not a misleading ``$0``, which silently understates evaluation spend in
+    cost dashboards. Regression for ``capture_cost`` swallowing the
+    unmapped-model case in ``langevals_ragas/lib/common.py``."""
+    with patch(
+        "langevals_ragas.faithfulness.Faithfulness", _FakeFaithfulness
+    ), patch(
+        "langevals_ragas.faithfulness.prepare_llm", return_value=(_DummyLLM(), None)
+    ), patch(
+        "langevals_ragas.faithfulness.check_max_tokens", return_value=None
+    ), patch(
+        "langevals_ragas.lib.common.cost_per_token",
+        side_effect=Exception("This model isn't mapped yet."),
+    ):
+        evaluator = RagasFaithfulnessEvaluator(
+            settings=RagasFaithfulnessSettings(autodetect_dont_know=False)
+        )
+        result = evaluator.evaluate(
+            RagasFaithfulnessEntry(
+                output="The capital of France is Paris.",
+                contexts=["Paris is the capital of France."],
+            )
+        )
+
+    assert result.status == "processed"
+    assert result.cost is None
+
+
+def test_cost_is_reported_as_money_when_model_is_priced():
+    """When litellm can price the model, the cost must be reported as a ``Money``
+    (even ``$0`` for a zero-token run) — never ``None``. Guards the
+    ``capture_cost`` success path against the unmapped-model fix."""
+    with patch(
+        "langevals_ragas.faithfulness.Faithfulness", _FakeFaithfulness
+    ), patch(
+        "langevals_ragas.faithfulness.prepare_llm", return_value=(_DummyLLM(), None)
+    ), patch(
+        "langevals_ragas.faithfulness.check_max_tokens", return_value=None
+    ), patch(
+        "langevals_ragas.lib.common.cost_per_token",
+        return_value=(0.001, 0.002),
+    ):
+        evaluator = RagasFaithfulnessEvaluator(
+            settings=RagasFaithfulnessSettings(autodetect_dont_know=False)
+        )
+        result = evaluator.evaluate(
+            RagasFaithfulnessEntry(
+                output="The capital of France is Paris.",
+                contexts=["Paris is the capital of France."],
+            )
+        )
+
+    assert result.status == "processed"
+    assert isinstance(result.cost, Money)
+    assert result.cost.amount == pytest.approx(0.003)
 
 
 def test_response_relevancy():


### PR DESCRIPTION
## What

When litellm can't price the judge model (`This model isn't mapped yet`), the ragas evaluators reported a cost of **$0** instead of *unknown*, silently understating evaluation spend in cost dashboards. This affected all 8 LLM-based ragas evaluators.

## Why

`capture_cost` is a `@contextmanager`, so the `return None` after its `yield` was dead code. On the unmapped-model branch the cost was left at the initial `Money(amount=0)`.

## Fix

`capture_cost` now yields a small mutable `CapturedCost` holder and sets `.money = None` for unmapped models (`EvaluationResult.cost` is already `Optional[Money]`). The 8 call sites read `cost.money`.

## Tests

Adds two network-free regression tests (no API key needed):

- unmapped model → `result.cost is None`
- priced model → `result.cost` is a `Money` with the expected amount

All ragas unit tests pass locally; the only failures are the pre-existing network tests that require `OPENAI_API_KEY`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cost capture and reporting across evaluators to properly track monetary values.
  * Improved handling when model pricing is unknown—now gracefully reports null cost instead of errors.

* **Tests**
  * Added regression tests verifying cost reporting accuracy for both priced and unpriced models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->