### PR TITLE
fix(traces-v2): make trace ID copy toast dismissible

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -123,6 +123,7 @@ function TraceIdChip({ traceId }: { traceId: string }) {
           description: traceId,
           type: "success",
           duration: 2500,
+          meta: { closable: true },
         });
         return;
       }
@@ -134,6 +135,7 @@ function TraceIdChip({ traceId }: { traceId: string }) {
           "Clipboard access is restricted. This can happen on non-HTTPS domains. Copy the ID manually from the URL.",
         type: "error",
         duration: 6000,
+        meta: { closable: true },
       });
     }
   };


### PR DESCRIPTION
## What

The "Trace ID copied" toast (and its "Couldn't copy trace ID" error sibling) in the trace drawer header had no way to dismiss it — you had to wait for the auto-timeout. Other toasts in the app already render a close button. This adds one.

## Why

The shared toaster (`components/ui/toaster.tsx`) already conditionally renders `<Toast.CloseTrigger />` when a toast sets `meta.closable`. The two copy toasts in `TraceIdChip` just never set it. Two-line fix — reuses existing infra, no new component.

## Change

`DrawerHeader.tsx`: add `meta: { closable: true }` to both the success and error copy toasts.

## Proof

Verified in a real browser (Trace Explorer, `/traces` drawer):
- Close button renders: `data-part="close-trigger"`, `aria-label="Dismiss notification"`.
- Clicking it dismisses the toast (1 → 0 toasts in the notifications region).
- 0 console errors/warnings.

| Claim | Status |
|-------|--------|
| Copy toast renders a close button | PASS |
| Clicking close dismisses it | PASS |
| Error toast also closable | PASS |
| No regressions | PASS |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trace ID copy notifications can now be manually dismissed, providing better control over notification display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->