### PR TITLE
fix(traces): resolve full blob values on all content-consuming read paths (2 of 2 — #4888)

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -8,8 +8,9 @@
  *
  * BDD structure: given/when nested describes, action-based it() names.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createInnerTRPCContext } from "../../trpc";
 import { annotationRouter } from "../annotation";
 

--- a/langwatch/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -1,0 +1,142 @@
+/**
+ * #4991 ("2 of 2" of #4888) — AC3 call-site wiring for the annotation router.
+ *
+ * Annotators label trace content, so the annotation-queue reads must resolve
+ * the FULL IO value, not the 64 KB preview. Proves both queue-read sites
+ * (getQueueItems inline + getOptimizedAnnotationQueues via the shared enrich
+ * helper) construct TraceService WITH blob-resolution deps and pass full:true.
+ *
+ * BDD structure: given/when nested describes, action-based it() names.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { createInnerTRPCContext } from "../../trpc";
+import { annotationRouter } from "../annotation";
+
+const { mockCreate, mockGetTracesWithSpans, mockBuildDeps, BLOB_DEPS } =
+  vi.hoisted(() => {
+    const BLOB_DEPS = {
+      blobStore: { tag: "blobStore" },
+      ioExtractionService: { tag: "ioExtractionService" },
+    };
+    return {
+      mockCreate: vi.fn(),
+      mockGetTracesWithSpans: vi.fn(),
+      mockBuildDeps: vi.fn(() => BLOB_DEPS),
+      BLOB_DEPS,
+    };
+  });
+
+vi.mock("~/server/traces/trace.service", () => ({
+  TraceService: { create: mockCreate },
+}));
+
+vi.mock("~/server/traces/trace-blob-resolution.deps", () => ({
+  buildTraceBlobResolutionDeps: mockBuildDeps,
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    hasProjectPermission: vi.fn(() => Promise.resolve(true)),
+    checkProjectPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+    checkPermissionOrPubliclyShared:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+vi.mock("../../utils", () => ({
+  getUserProtectionsForProject: vi.fn().mockResolvedValue({
+    canSeeCosts: true,
+    canSeePiiData: true,
+    canSeeTopics: true,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Prisma stub covering the annotation-queue read surfaces
+// ---------------------------------------------------------------------------
+
+function makePrismaStub(): PrismaClient {
+  const queueItem = {
+    id: "qi-1",
+    traceId: "t1",
+    annotationQueueId: null,
+    user: null,
+    createdByUser: null,
+    annotationQueue: null,
+  };
+  return {
+    annotationQueueItem: {
+      findMany: vi.fn().mockResolvedValue([queueItem]),
+      count: vi.fn().mockResolvedValue(1),
+    },
+    annotation: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    annotationQueue: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  } as unknown as PrismaClient;
+}
+
+let caller: ReturnType<typeof annotationRouter.createCaller>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreate.mockReturnValue({ getTracesWithSpans: mockGetTracesWithSpans });
+  mockBuildDeps.mockReturnValue(BLOB_DEPS);
+  mockGetTracesWithSpans.mockResolvedValue([]);
+
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: "test-user-id" }, expires: "1" },
+    req: undefined,
+    res: undefined,
+    permissionChecked: true,
+    publiclyShared: false,
+  });
+  ctx.prisma = makePrismaStub();
+  caller = annotationRouter.createCaller(ctx);
+});
+
+function expectFullResolution() {
+  expect(mockCreate).toHaveBeenCalledWith(expect.anything(), BLOB_DEPS);
+  expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
+    "project_123",
+    ["t1"],
+    expect.any(Object),
+    undefined,
+    { full: true },
+  );
+}
+
+describe("annotation router — #4991 AC3 annotation-queue reads", () => {
+  describe("when getQueueItems is called", () => {
+    it("constructs with deps and resolves trace IO full", async () => {
+      await caller.getQueueItems({ projectId: "project_123" });
+      expectFullResolution();
+    });
+  });
+
+  describe("when getOptimizedAnnotationQueues is called (shared enrich helper)", () => {
+    it("constructs with deps and resolves trace IO full", async () => {
+      await caller.getOptimizedAnnotationQueues({
+        projectId: "project_123",
+        selectedAnnotations: "pending",
+        pageSize: 10,
+        pageOffset: 0,
+      });
+      expectFullResolution();
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
@@ -13,8 +13,9 @@
  *
  * BDD structure: given/when nested describes, action-based it() names.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createInnerTRPCContext } from "../../trpc";
 import { tracesRouter } from "../traces";
 

--- a/langwatch/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
@@ -1,0 +1,293 @@
+/**
+ * #4991 ("2 of 2" of #4888) — call-site wiring for the tRPC traces router.
+ *
+ * Proves each content-consuming bulk procedure constructs TraceService WITH
+ * blob-resolution deps and opts into FULL resolution, while the list grid does
+ * not (AC5). Mirrors the existing traces.getAllForProject.unit.test.ts harness
+ * (createCaller + mocked TraceService + mocked rbac/utils).
+ *
+ *   AC1 — getAllForDownload passes resolveBlobs through the options.
+ *   AC2 — getTracesByThreadId / getTracesWithSpansByThreadIds pass full:true.
+ *   AC4 — getSampleTraces / getSampleTracesDataset pass full:true.
+ *   AC5 — getAllForProject (list grid) constructs WITHOUT deps and never opts in.
+ *
+ * BDD structure: given/when nested describes, action-based it() names.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { createInnerTRPCContext } from "../../trpc";
+import { tracesRouter } from "../traces";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const {
+  mockCreate,
+  mockGetAllTracesForProject,
+  mockGetTracesWithSpans,
+  mockGetTracesByThreadId,
+  mockGetTracesWithSpansByThreadIds,
+  mockBuildDeps,
+  BLOB_DEPS,
+} = vi.hoisted(() => {
+  const BLOB_DEPS = {
+    blobStore: { tag: "blobStore" },
+    ioExtractionService: { tag: "ioExtractionService" },
+  };
+  return {
+    mockCreate: vi.fn(),
+    mockGetAllTracesForProject: vi.fn(),
+    mockGetTracesWithSpans: vi.fn(),
+    mockGetTracesByThreadId: vi.fn(),
+    mockGetTracesWithSpansByThreadIds: vi.fn(),
+    mockBuildDeps: vi.fn(() => BLOB_DEPS),
+    BLOB_DEPS,
+  };
+});
+
+vi.mock("~/server/traces/trace.service", () => ({
+  TraceService: { create: mockCreate },
+}));
+
+vi.mock("~/server/traces/trace-blob-resolution.deps", () => ({
+  buildTraceBlobResolutionDeps: mockBuildDeps,
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    hasProjectPermission: vi.fn(() => Promise.resolve(true)),
+    checkProjectPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+    checkPermissionOrPubliclyShared:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+vi.mock("../../utils", () => ({
+  getUserProtectionsForProject: vi.fn().mockResolvedValue({
+    canSeeCosts: true,
+    canSeePiiData: true,
+    canSeeTopics: true,
+  }),
+}));
+
+vi.mock("~/server/evaluations/evaluators", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    evaluatorsSchema: { keyof: () => ({ or: () => ({}) }) },
+  };
+});
+
+vi.mock("~/server/evaluations/preconditions", () => ({
+  evaluatePreconditions: vi.fn(() => true),
+  buildPreconditionTraceDataFromTrace: vi.fn(() => ({})),
+  checkEvaluatorRequiredFields: vi.fn(() => true),
+}));
+
+vi.mock("~/server/evaluations/types", () => ({
+  checkPreconditionSchema: {},
+}));
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const fakeService = {
+  getAllTracesForProject: mockGetAllTracesForProject,
+  getTracesWithSpans: mockGetTracesWithSpans,
+  getTracesByThreadId: mockGetTracesByThreadId,
+  getTracesWithSpansByThreadIds: mockGetTracesWithSpansByThreadIds,
+};
+
+const baseFilters = {
+  projectId: "project_123",
+  startDate: Date.now() - 86_400_000,
+  endDate: Date.now(),
+  filters: {},
+};
+
+let caller: ReturnType<typeof tracesRouter.createCaller>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreate.mockReturnValue(fakeService);
+  mockBuildDeps.mockReturnValue(BLOB_DEPS);
+  mockGetAllTracesForProject.mockResolvedValue({
+    groups: [[{ trace_id: "t1" }]],
+    totalHits: 1,
+    traceChecks: {},
+  });
+  mockGetTracesWithSpans.mockResolvedValue([]);
+  mockGetTracesByThreadId.mockResolvedValue([]);
+  mockGetTracesWithSpansByThreadIds.mockResolvedValue([]);
+
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: "test-user-id" }, expires: "1" },
+    req: undefined,
+    res: undefined,
+    permissionChecked: true,
+    publiclyShared: false,
+  });
+  ctx.prisma = {} as unknown as PrismaClient;
+  caller = tracesRouter.createCaller(ctx);
+});
+
+/** Asserts the most recent TraceService.create call carried the blob deps. */
+function expectConstructedWithBlobDeps() {
+  expect(mockCreate).toHaveBeenCalledWith(expect.anything(), BLOB_DEPS);
+}
+
+// ---------------------------------------------------------------------------
+// AC2 — thread reads
+// ---------------------------------------------------------------------------
+
+describe("traces router — #4991 AC2 thread reads", () => {
+  describe("when getTracesByThreadId is called", () => {
+    it("constructs TraceService with blob-resolution deps", async () => {
+      await caller.getTracesByThreadId({
+        projectId: "project_123",
+        threadId: "thread-1",
+        traceId: "trace-1",
+      });
+      expectConstructedWithBlobDeps();
+    });
+
+    it("requests full resolution (full:true)", async () => {
+      await caller.getTracesByThreadId({
+        projectId: "project_123",
+        threadId: "thread-1",
+        traceId: "trace-1",
+      });
+      expect(mockGetTracesByThreadId).toHaveBeenCalledWith(
+        "project_123",
+        "thread-1",
+        expect.any(Object),
+        { full: true },
+      );
+    });
+  });
+
+  describe("when getTracesWithSpansByThreadIds is called", () => {
+    it("constructs with deps and requests full resolution", async () => {
+      await caller.getTracesWithSpansByThreadIds({
+        projectId: "project_123",
+        threadIds: ["thread-1"],
+      });
+      expectConstructedWithBlobDeps();
+      expect(mockGetTracesWithSpansByThreadIds).toHaveBeenCalledWith(
+        "project_123",
+        ["thread-1"],
+        expect.any(Object),
+        { full: true },
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC4 — dataset / sample builders
+// ---------------------------------------------------------------------------
+
+describe("traces router — #4991 AC4 dataset/sample builders", () => {
+  describe("when getSampleTracesDataset is called", () => {
+    it("constructs with deps and resolves spans full", async () => {
+      await caller.getSampleTracesDataset(baseFilters);
+      expectConstructedWithBlobDeps();
+      expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
+        "project_123",
+        ["t1"],
+        expect.any(Object),
+        expect.any(Object),
+        { full: true },
+      );
+    });
+  });
+
+  describe("when getSampleTraces is called", () => {
+    it("constructs with deps and resolves spans full", async () => {
+      await caller.getSampleTraces({
+        ...baseFilters,
+        evaluatorType: "custom/foo",
+        preconditions: [],
+        expectedResults: 10,
+      });
+      expectConstructedWithBlobDeps();
+      expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
+        "project_123",
+        ["t1"],
+        expect.any(Object),
+        expect.any(Object),
+        { full: true },
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC1 — export / download
+// ---------------------------------------------------------------------------
+
+describe("traces router — #4991 AC1 download", () => {
+  describe("when getAllForDownload is called with includeSpans", () => {
+    it("constructs with deps and opts resolveBlobs into the options", async () => {
+      await caller.getAllForDownload({ ...baseFilters, includeSpans: true });
+      expectConstructedWithBlobDeps();
+      expect(mockGetAllTracesForProject).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.objectContaining({ downloadMode: true, resolveBlobs: true }),
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC5 — list grid stays preview-only
+// ---------------------------------------------------------------------------
+
+describe("traces router — #4991 AC5 list grid stays preview", () => {
+  describe("when getAllForProject (list grid) is called", () => {
+    it("constructs TraceService WITHOUT blob-resolution deps", async () => {
+      await caller.getAllForProject(baseFilters);
+      // Single positional arg (prisma) only — never the deps object.
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockBuildDeps).not.toHaveBeenCalled();
+    });
+
+    it("never opts resolveBlobs into the options", async () => {
+      await caller.getAllForProject(baseFilters);
+      expect(mockGetAllTracesForProject).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.not.objectContaining({ resolveBlobs: true }),
+      );
+    });
+  });
+
+  describe("when getFormattedSpansDigest (aggregation/digest) is called", () => {
+    it("constructs WITHOUT deps and never requests full resolution", async () => {
+      await caller.getFormattedSpansDigest({
+        projectId: "project_123",
+        traceIds: ["t1"],
+      });
+      expect(mockBuildDeps).not.toHaveBeenCalled();
+      // getTracesWithSpans called with NO { full: true } opts (preview only).
+      expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
+        "project_123",
+        ["t1"],
+        expect.any(Object),
+      );
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
@@ -230,6 +230,9 @@ describe("traces router — #4991 AC2 public-share thread read", () => {
     { trace_id: "t3", timestamps: { started_at: 300 } },
   ];
 
+  /** Stands in for a de-offloaded value — anything the 64 KB preview is not. */
+  const FULL_VALUE = "the full, de-offloaded conversation value";
+
   let publicCaller: ReturnType<typeof tracesRouter.createCaller>;
   let mockFindMany: ReturnType<typeof vi.fn>;
 
@@ -248,6 +251,19 @@ describe("traces router — #4991 AC2 public-share thread read", () => {
     return tracesRouter.createCaller(ctx);
   }
 
+  /** Reads thread-1 as the anonymous public-share caller. */
+  function readThreadAsPublicCaller({
+    traceId = "t2",
+  }: {
+    traceId?: string;
+  } = {}) {
+    return publicCaller.getTracesByThreadId({
+      projectId: "project_123",
+      threadId: "thread-1",
+      traceId,
+    });
+  }
+
   beforeEach(() => {
     mockFindMany = vi.fn();
     mockGetTracesByThreadId.mockResolvedValue(previewTraces);
@@ -258,64 +274,67 @@ describe("traces router — #4991 AC2 public-share thread read", () => {
     beforeEach(() => {
       // Only t2 is shared; t1 and t3 are private siblings in the same thread.
       mockFindMany.mockResolvedValue([{ resourceId: "t2" }]);
+      // The resolved value is distinguishable from the preview, so a test that
+      // claims to return "fully-resolved" traces can actually tell them apart.
       mockGetTracesWithSpans.mockResolvedValue([
-        { trace_id: "t2", timestamps: { started_at: 200 } },
+        {
+          trace_id: "t2",
+          timestamps: { started_at: 200 },
+          output: { value: FULL_VALUE },
+        },
       ]);
     });
 
-    it("reads the thread PREVIEW-only, never resolving blobs pre-authorization", async () => {
-      await publicCaller.getTracesByThreadId({
-        projectId: "project_123",
-        threadId: "thread-1",
-        traceId: "t2",
+    describe("when the public caller reads the thread", () => {
+      it("reads the thread PREVIEW-only, never resolving blobs pre-authorization", async () => {
+        await readThreadAsPublicCaller();
+
+        expect(mockGetTracesByThreadId).toHaveBeenCalledWith(
+          "project_123",
+          "thread-1",
+          expect.any(Object),
+          { full: false },
+        );
+        expect(mockGetTracesByThreadId).not.toHaveBeenCalledWith(
+          "project_123",
+          "thread-1",
+          expect.any(Object),
+          { full: true },
+        );
       });
 
-      expect(mockGetTracesByThreadId).toHaveBeenCalledWith(
-        "project_123",
-        "thread-1",
-        expect.any(Object),
-        { full: false },
-      );
-      expect(mockGetTracesByThreadId).not.toHaveBeenCalledWith(
-        "project_123",
-        "thread-1",
-        expect.any(Object),
-        { full: true },
-      );
-    });
+      it("resolves full IO for ONLY the authorized trace ids", async () => {
+        await readThreadAsPublicCaller();
 
-    it("resolves full IO for ONLY the authorized trace ids", async () => {
-      await publicCaller.getTracesByThreadId({
-        projectId: "project_123",
-        threadId: "thread-1",
-        traceId: "t2",
+        // Not ["t1","t2","t3"] — the unauthorized siblings are never de-offloaded.
+        expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
+          "project_123",
+          ["t2"],
+          expect.any(Object),
+          undefined,
+          { full: true },
+        );
+        // …and that is the ONLY resolution call. toHaveBeenCalledWith alone would
+        // still pass if a second call leaked the unauthorized siblings through.
+        expect(mockGetTracesWithSpans).toHaveBeenCalledTimes(1);
       });
 
-      // Not ["t1","t2","t3"] — the unauthorized siblings are never de-offloaded.
-      expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
-        "project_123",
-        ["t2"],
-        expect.any(Object),
-        undefined,
-        { full: true },
-      );
-    });
+      it("returns the FULL value, not the preview", async () => {
+        const result = await readThreadAsPublicCaller();
 
-    it("returns the fully-resolved authorized traces", async () => {
-      const result = await publicCaller.getTracesByThreadId({
-        projectId: "project_123",
-        threadId: "thread-1",
-        traceId: "t2",
+        expect(result.map((t: { trace_id: string }) => t.trace_id)).toEqual([
+          "t2",
+        ]);
+        expect(
+          result.map((t: { output?: { value?: string } }) => t.output?.value),
+        ).toEqual([FULL_VALUE]);
       });
-
-      expect(result.map((t: { trace_id: string }) => t.trace_id)).toEqual([
-        "t2",
-      ]);
     });
   });
 
   describe("given several traces in the thread are publicly shared", () => {
     beforeEach(() => {
+      // t1 and t3 shared; t2 sits BETWEEN them and is not.
       mockFindMany.mockResolvedValue([
         { resourceId: "t1" },
         { resourceId: "t3" },
@@ -329,17 +348,32 @@ describe("traces router — #4991 AC2 public-share thread read", () => {
       ]);
     });
 
-    it("returns them in the thread's order, not the bulk read's order", async () => {
-      const result = await publicCaller.getTracesByThreadId({
-        projectId: "project_123",
-        threadId: "thread-1",
-        traceId: "t1",
+    describe("when the public caller reads the thread", () => {
+      // The load-bearing exclusion case: a partial-authorization regression that
+      // resolved ["t1","t2","t3"] would still return the right traces (the mock's
+      // return value doesn't depend on its args), so ONLY an assertion on the
+      // call args can catch the unauthorized sibling being de-offloaded.
+      it("excludes the unauthorized sibling from the resolution call", async () => {
+        await readThreadAsPublicCaller({ traceId: "t1" });
+
+        expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
+          "project_123",
+          ["t1", "t3"],
+          expect.any(Object),
+          undefined,
+          { full: true },
+        );
+        expect(mockGetTracesWithSpans).toHaveBeenCalledTimes(1);
       });
 
-      expect(result.map((t: { trace_id: string }) => t.trace_id)).toEqual([
-        "t1",
-        "t3",
-      ]);
+      it("returns them in the thread's order, not the bulk read's order", async () => {
+        const result = await readThreadAsPublicCaller({ traceId: "t1" });
+
+        expect(result.map((t: { trace_id: string }) => t.trace_id)).toEqual([
+          "t1",
+          "t3",
+        ]);
+      });
     });
   });
 
@@ -348,15 +382,21 @@ describe("traces router — #4991 AC2 public-share thread read", () => {
       mockFindMany.mockResolvedValue([]);
     });
 
-    it("returns empty and issues zero blob resolution", async () => {
-      const result = await publicCaller.getTracesByThreadId({
-        projectId: "project_123",
-        threadId: "thread-1",
-        traceId: "t2",
-      });
+    describe("when the public caller reads the thread", () => {
+      it("returns empty and issues zero blob resolution", async () => {
+        const result = await readThreadAsPublicCaller();
 
-      expect(result).toEqual([]);
-      expect(mockGetTracesWithSpans).not.toHaveBeenCalled();
+        expect(result).toEqual([]);
+        expect(mockGetTracesWithSpans).not.toHaveBeenCalled();
+        // Still preview-only on the way in — the thread was never de-offloaded
+        // just to discover nothing in it was shared.
+        expect(mockGetTracesByThreadId).toHaveBeenCalledWith(
+          "project_123",
+          "thread-1",
+          expect.any(Object),
+          { full: false },
+        );
+      });
     });
   });
 });

--- a/langwatch/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
@@ -55,14 +55,14 @@ vi.mock("~/server/traces/trace-blob-resolution.deps", () => ({
 }));
 
 // `getAllForDownload` is a tRPC *mutation*, so the auditLogMutations middleware
-// runs and writes an audit row. It reaches for the `prisma` SINGLETON exported by
-// ~/server/db — not `ctx.prisma` — so overriding the context is not enough: the
-// real client tries to open a Postgres connection the unit shard has no server
-// for. That both fails the assertion and leaves a pending socket that keeps the
-// vitest worker's event loop alive. Stub the singleton so the audit write is a
-// no-op and this stays a true unit test of the router's call-site wiring.
-vi.mock("~/server/db", () => ({
-  prisma: { auditLog: { create: vi.fn().mockResolvedValue({}) } },
+// runs and writes an audit row via the `prisma` SINGLETON — not `ctx.prisma` —
+// so overriding the context is not enough: the real client tries to open a
+// Postgres connection the unit shard has no server for. That both fails the
+// assertion and leaves a pending socket that keeps the vitest worker alive.
+// Stub the audit function itself, matching translate/apiKey.myBindings/
+// workflows.generateCommitMessage in this directory.
+vi.mock("../../../auditLog", () => ({
+  auditLog: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../../rbac", async (importOriginal) => {
@@ -221,10 +221,13 @@ describe("traces router — #4991 AC2 thread reads", () => {
 // ---------------------------------------------------------------------------
 
 describe("traces router — #4991 AC2 public-share thread read", () => {
+  // The thread read returns traces already sorted chronologically (the CH
+  // service sorts before returning), so the fixture is sorted too — the router
+  // relies on that order rather than re-deriving one.
   const previewTraces = [
-    { trace_id: "t3", timestamps: { started_at: 300 } },
     { trace_id: "t1", timestamps: { started_at: 100 } },
     { trace_id: "t2", timestamps: { started_at: 200 } },
+    { trace_id: "t3", timestamps: { started_at: 300 } },
   ];
 
   let publicCaller: ReturnType<typeof tracesRouter.createCaller>;
@@ -317,15 +320,16 @@ describe("traces router — #4991 AC2 public-share thread read", () => {
         { resourceId: "t1" },
         { resourceId: "t3" },
       ]);
-      // Deliberately returned out of chronological order, as the underlying
-      // trace-id-keyed bulk read does.
+      // getTracesWithSpans comes back in TRACE-ID order, not thread order — so
+      // hand it back deliberately scrambled. The router must not pass this
+      // through; it re-projects onto the thread's order.
       mockGetTracesWithSpans.mockResolvedValue([
         { trace_id: "t3", timestamps: { started_at: 300 } },
         { trace_id: "t1", timestamps: { started_at: 100 } },
       ]);
     });
 
-    it("returns them in chronological order", async () => {
+    it("returns them in the thread's order, not the bulk read's order", async () => {
       const result = await publicCaller.getTracesByThreadId({
         projectId: "project_123",
         threadId: "thread-1",
@@ -409,6 +413,26 @@ describe("traces router — #4991 AC1 download", () => {
         expect.any(Object),
         expect.any(Object),
         expect.objectContaining({ downloadMode: true, resolveBlobs: true }),
+      );
+    });
+  });
+
+  // A download returns trace-level input/output whether or not spans are
+  // included, so gating resolveBlobs on includeSpans truncated any offloaded
+  // trace in a spans-less download — the same bug fixed in ExportService for
+  // summary-mode exports. Falsifiable: restore `resolveBlobs: input.includeSpans`
+  // and this fails while the includeSpans:true case above still passes.
+  describe("when getAllForDownload is called WITHOUT includeSpans", () => {
+    it("still opts resolveBlobs in, so the download is not truncated", async () => {
+      await caller.getAllForDownload({ ...baseFilters, includeSpans: false });
+      expect(mockGetAllTracesForProject).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.objectContaining({
+          downloadMode: true,
+          includeSpans: false,
+          resolveBlobs: true,
+        }),
       );
     });
   });

--- a/langwatch/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/traces.4991-full-resolution.unit.test.ts
@@ -54,6 +54,17 @@ vi.mock("~/server/traces/trace-blob-resolution.deps", () => ({
   buildTraceBlobResolutionDeps: mockBuildDeps,
 }));
 
+// `getAllForDownload` is a tRPC *mutation*, so the auditLogMutations middleware
+// runs and writes an audit row. It reaches for the `prisma` SINGLETON exported by
+// ~/server/db — not `ctx.prisma` — so overriding the context is not enough: the
+// real client tries to open a Postgres connection the unit shard has no server
+// for. That both fails the assertion and leaves a pending socket that keeps the
+// vitest worker's event loop alive. Stub the singleton so the audit write is a
+// no-op and this stays a true unit test of the router's call-site wiring.
+vi.mock("~/server/db", () => ({
+  prisma: { auditLog: { create: vi.fn().mockResolvedValue({}) } },
+}));
+
 vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {
@@ -192,6 +203,156 @@ describe("traces router — #4991 AC2 thread reads", () => {
         expect.any(Object),
         { full: true },
       );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2 (security) — public-share thread reads authorize BEFORE resolving blobs
+//
+// Regression guard for the #5082 review blocker: `getTracesByThreadId` is a
+// publicProcedure. Resolving `{ full: true }` for the WHOLE thread before the
+// publicShare filter narrows it lets one valid share link de-offload (and
+// amplify unbounded event_log reads across) every other trace in that thread —
+// traces the anonymous caller is not authorized to read.
+//
+// Falsifiable: restore the pre-fix "resolve full, then filter" order and the
+// `{ full: false }` and `getTracesWithSpans(["t2"])` assertions below both fail.
+// ---------------------------------------------------------------------------
+
+describe("traces router — #4991 AC2 public-share thread read", () => {
+  const previewTraces = [
+    { trace_id: "t3", timestamps: { started_at: 300 } },
+    { trace_id: "t1", timestamps: { started_at: 100 } },
+    { trace_id: "t2", timestamps: { started_at: 200 } },
+  ];
+
+  let publicCaller: ReturnType<typeof tracesRouter.createCaller>;
+  let mockFindMany: ReturnType<typeof vi.fn>;
+
+  /** Builds a caller whose ctx is an anonymous public-share reader. */
+  function createPublicCaller() {
+    const ctx = createInnerTRPCContext({
+      session: null,
+      req: undefined,
+      res: undefined,
+      permissionChecked: true,
+      publiclyShared: true,
+    });
+    ctx.prisma = {
+      publicShare: { findMany: mockFindMany },
+    } as unknown as PrismaClient;
+    return tracesRouter.createCaller(ctx);
+  }
+
+  beforeEach(() => {
+    mockFindMany = vi.fn();
+    mockGetTracesByThreadId.mockResolvedValue(previewTraces);
+    publicCaller = createPublicCaller();
+  });
+
+  describe("given only one trace in the thread is publicly shared", () => {
+    beforeEach(() => {
+      // Only t2 is shared; t1 and t3 are private siblings in the same thread.
+      mockFindMany.mockResolvedValue([{ resourceId: "t2" }]);
+      mockGetTracesWithSpans.mockResolvedValue([
+        { trace_id: "t2", timestamps: { started_at: 200 } },
+      ]);
+    });
+
+    it("reads the thread PREVIEW-only, never resolving blobs pre-authorization", async () => {
+      await publicCaller.getTracesByThreadId({
+        projectId: "project_123",
+        threadId: "thread-1",
+        traceId: "t2",
+      });
+
+      expect(mockGetTracesByThreadId).toHaveBeenCalledWith(
+        "project_123",
+        "thread-1",
+        expect.any(Object),
+        { full: false },
+      );
+      expect(mockGetTracesByThreadId).not.toHaveBeenCalledWith(
+        "project_123",
+        "thread-1",
+        expect.any(Object),
+        { full: true },
+      );
+    });
+
+    it("resolves full IO for ONLY the authorized trace ids", async () => {
+      await publicCaller.getTracesByThreadId({
+        projectId: "project_123",
+        threadId: "thread-1",
+        traceId: "t2",
+      });
+
+      // Not ["t1","t2","t3"] — the unauthorized siblings are never de-offloaded.
+      expect(mockGetTracesWithSpans).toHaveBeenCalledWith(
+        "project_123",
+        ["t2"],
+        expect.any(Object),
+        undefined,
+        { full: true },
+      );
+    });
+
+    it("returns the fully-resolved authorized traces", async () => {
+      const result = await publicCaller.getTracesByThreadId({
+        projectId: "project_123",
+        threadId: "thread-1",
+        traceId: "t2",
+      });
+
+      expect(result.map((t: { trace_id: string }) => t.trace_id)).toEqual([
+        "t2",
+      ]);
+    });
+  });
+
+  describe("given several traces in the thread are publicly shared", () => {
+    beforeEach(() => {
+      mockFindMany.mockResolvedValue([
+        { resourceId: "t1" },
+        { resourceId: "t3" },
+      ]);
+      // Deliberately returned out of chronological order, as the underlying
+      // trace-id-keyed bulk read does.
+      mockGetTracesWithSpans.mockResolvedValue([
+        { trace_id: "t3", timestamps: { started_at: 300 } },
+        { trace_id: "t1", timestamps: { started_at: 100 } },
+      ]);
+    });
+
+    it("returns them in chronological order", async () => {
+      const result = await publicCaller.getTracesByThreadId({
+        projectId: "project_123",
+        threadId: "thread-1",
+        traceId: "t1",
+      });
+
+      expect(result.map((t: { trace_id: string }) => t.trace_id)).toEqual([
+        "t1",
+        "t3",
+      ]);
+    });
+  });
+
+  describe("given no trace in the thread is publicly shared", () => {
+    beforeEach(() => {
+      mockFindMany.mockResolvedValue([]);
+    });
+
+    it("returns empty and issues zero blob resolution", async () => {
+      const result = await publicCaller.getTracesByThreadId({
+        projectId: "project_123",
+        threadId: "thread-1",
+        traceId: "t2",
+      });
+
+      expect(result).toEqual([]);
+      expect(mockGetTracesWithSpans).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/server/api/routers/annotation.ts
+++ b/langwatch/src/server/api/routers/annotation.ts
@@ -14,10 +14,7 @@ import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolut
 import { slugify } from "~/utils/slugify";
 import { createLogger } from "../../../utils/logger/server";
 import type { Protections } from "../../traces/protections";
-import {
-  checkPermissionOrPubliclyShared,
-  checkProjectPermission,
-} from "../rbac";
+import { checkPermissionOrPubliclyShared, checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 import { getUserProtectionsForProject } from "../utils";
 

--- a/langwatch/src/server/api/routers/annotation.ts
+++ b/langwatch/src/server/api/routers/annotation.ts
@@ -10,6 +10,7 @@ import { AnnotationService } from "~/server/annotations/annotation.service";
 import { getApp } from "~/server/app-layer/app";
 import type { Session } from "~/server/auth";
 import { TraceService } from "~/server/traces/trace.service";
+import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
 import { slugify } from "~/utils/slugify";
 import { createLogger } from "../../../utils/logger/server";
 import type { Protections } from "../../traces/protections";
@@ -58,12 +59,18 @@ const enrichQueueItemsWithTracesAndAnnotations = async (
     },
   });
 
-  // Get traces for queue items
-  const traceService = TraceService.create(ctx.prisma);
+  // Annotators label trace content — resolve full IO (#4991) so they see the
+  // whole value, not the 64 KB preview.
+  const traceService = TraceService.create(
+    ctx.prisma,
+    buildTraceBlobResolutionDeps(),
+  );
   const traces = await traceService.getTracesWithSpans(
     projectId,
     traceIds,
     protections,
+    undefined,
+    { full: true },
   );
 
   // Create lookup maps for O(1) access
@@ -424,11 +431,17 @@ export const annotationRouter = createTRPCRouter({
         projectId: input.projectId,
       });
       const traceIds = [...new Set(queueItems.map((item) => item.traceId))];
-      const traceService = TraceService.create(ctx.prisma);
+      // Annotation queue shows trace content for labeling — resolve full IO (#4991).
+      const traceService = TraceService.create(
+        ctx.prisma,
+        buildTraceBlobResolutionDeps(),
+      );
       const traces = await traceService.getTracesWithSpans(
         input.projectId,
         traceIds,
         protections,
+        undefined,
+        { full: true },
       );
       const traceMap = new Map(traces.map((trace) => [trace.trace_id, trace]));
 

--- a/langwatch/src/server/api/routers/annotation.ts
+++ b/langwatch/src/server/api/routers/annotation.ts
@@ -14,7 +14,10 @@ import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolut
 import { slugify } from "~/utils/slugify";
 import { createLogger } from "../../../utils/logger/server";
 import type { Protections } from "../../traces/protections";
-import { checkPermissionOrPubliclyShared, checkProjectPermission } from "../rbac";
+import {
+  checkPermissionOrPubliclyShared,
+  checkProjectPermission,
+} from "../rbac";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 import { getUserProtectionsForProject } from "../utils";
 

--- a/langwatch/src/server/api/routers/traces.ts
+++ b/langwatch/src/server/api/routers/traces.ts
@@ -224,11 +224,17 @@ export const tracesRouter = createTRPCRouter({
         projectId: input.projectId,
       });
 
-      const traceService = TraceService.create(ctx.prisma);
+      // Thread-detail read consumes conversation content — resolve full IO
+      // (#4991), not the 64 KB preview.
+      const traceService = TraceService.create(
+        ctx.prisma,
+        buildTraceBlobResolutionDeps(),
+      );
       const tracesGrouped = await traceService.getTracesByThreadId(
         projectId,
         threadId,
         protections,
+        { full: true },
       );
 
       if (!ctx.publiclyShared) {
@@ -311,11 +317,16 @@ export const tracesRouter = createTRPCRouter({
         projectId: input.projectId,
       });
 
-      const traceService = TraceService.create(ctx.prisma);
+      // Thread reads consume conversation content — resolve full IO (#4991).
+      const traceService = TraceService.create(
+        ctx.prisma,
+        buildTraceBlobResolutionDeps(),
+      );
       return traceService.getTracesWithSpansByThreadIds(
         projectId,
         threadIds,
         protections,
+        { full: true },
       );
     }),
 
@@ -333,7 +344,13 @@ export const tracesRouter = createTRPCRouter({
         projectId: input.projectId,
       });
 
-      const traceService = TraceService.create(ctx.prisma);
+      // Dataset builder persists trace content — resolve full IO (#4991) so
+      // truncated rows never corrupt the dataset. The ID-only list read above
+      // stays on the preview (it reads no content).
+      const traceService = TraceService.create(
+        ctx.prisma,
+        buildTraceBlobResolutionDeps(),
+      );
       const { groups } = await traceService.getAllTracesForProject(
         {
           ...input,
@@ -356,6 +373,7 @@ export const tracesRouter = createTRPCRouter({
         traceIds,
         protections,
         { from: input.startDate, to: input.endDate },
+        { full: true },
       );
     }),
 
@@ -395,7 +413,12 @@ export const tracesRouter = createTRPCRouter({
         projectId: input.projectId,
       });
 
-      const traceService = TraceService.create(ctx.prisma);
+      // Sample builder feeds dataset/evaluator content — resolve full IO
+      // (#4991). The ID-only list read stays on the preview.
+      const traceService = TraceService.create(
+        ctx.prisma,
+        buildTraceBlobResolutionDeps(),
+      );
       const { groups } = await traceService.getAllTracesForProject(
         {
           ...input,
@@ -421,6 +444,7 @@ export const tracesRouter = createTRPCRouter({
         traceIds,
         protections,
         { from: input.startDate, to: input.endDate },
+        { full: true },
       );
 
       const passedPreconditions = traceWithSpans.filter((trace) => {
@@ -472,7 +496,14 @@ export const tracesRouter = createTRPCRouter({
         projectId: input.projectId,
       });
 
-      const traceService = TraceService.create(ctx.prisma);
+      // Download consumes trace content — resolve full IO when spans are
+      // included so exported rows carry the whole value, not the 64 KB preview
+      // (#4991 AC1). resolveBlobs is gated on includeSpans (resolution runs
+      // during span enrichment).
+      const traceService = TraceService.create(
+        ctx.prisma,
+        buildTraceBlobResolutionDeps(),
+      );
       return traceService.getAllTracesForProject(
         {
           ...input,
@@ -483,6 +514,7 @@ export const tracesRouter = createTRPCRouter({
         {
           downloadMode: true,
           includeSpans: input.includeSpans,
+          resolveBlobs: input.includeSpans,
           scrollId: input.scrollId,
         },
       );

--- a/langwatch/src/server/api/routers/traces.ts
+++ b/langwatch/src/server/api/routers/traces.ts
@@ -230,34 +230,71 @@ export const tracesRouter = createTRPCRouter({
         ctx.prisma,
         buildTraceBlobResolutionDeps(),
       );
-      const tracesGrouped = await traceService.getTracesByThreadId(
+
+      // SECURITY (#4991): full blob resolution de-offloads the whole IO value
+      // from event_log and must NEVER run pre-authorization. For an authorized
+      // (non-public) caller the whole thread is theirs to read, so resolve full
+      // up front. For a public-share caller — an anonymous, publicProcedure
+      // path — resolving the full thread first would (a) de-offload traces the
+      // caller is not authorized to see and (b) let a single valid share link
+      // amplify unbounded event_log reads across every other trace in the
+      // thread. So the public branch reads PREVIEW ONLY, authorizes down to the
+      // shared trace IDs, then resolves full IO for JUST those authorized IDs.
+      if (!ctx.publiclyShared) {
+        return traceService.getTracesByThreadId(
+          projectId,
+          threadId,
+          protections,
+          { full: true },
+        );
+      }
+
+      // Public-share path: preview-only read (zero event_log resolution).
+      const previewTraces = await traceService.getTracesByThreadId(
         projectId,
         threadId,
         protections,
-        { full: true },
+        { full: false },
       );
-
-      if (!ctx.publiclyShared) {
-        return tracesGrouped;
-      }
 
       const publicSharedTraces = await ctx.prisma.publicShare.findMany({
         where: {
           projectId: projectId,
           resourceType: PublicShareResourceTypes.TRACE,
           resourceId: {
-            in: tracesGrouped.map((trace) => trace.trace_id),
+            in: previewTraces.map((trace) => trace.trace_id),
           },
         },
       });
 
-      const filteredTraces = tracesGrouped.filter((trace) =>
-        publicSharedTraces.some(
-          (publicShare) => publicShare.resourceId === trace.trace_id,
-        ),
+      const authorizedTraceIds = previewTraces
+        .filter((trace) =>
+          publicSharedTraces.some(
+            (publicShare) => publicShare.resourceId === trace.trace_id,
+          ),
+        )
+        .map((trace) => trace.trace_id);
+
+      if (authorizedTraceIds.length === 0) {
+        return [];
+      }
+
+      // Resolve full IO for ONLY the post-authorization trace IDs.
+      const authorizedTraces = await traceService.getTracesWithSpans(
+        projectId,
+        authorizedTraceIds,
+        protections,
+        undefined,
+        { full: true },
       );
 
-      return filteredTraces;
+      // Preserve the chronological order the thread view expects.
+      authorizedTraces.sort(
+        (a, b) =>
+          (a.timestamps.started_at ?? 0) - (b.timestamps.started_at ?? 0),
+      );
+
+      return authorizedTraces;
     }),
 
   getTracesWithSpans: protectedProcedure

--- a/langwatch/src/server/api/routers/traces.ts
+++ b/langwatch/src/server/api/routers/traces.ts
@@ -1,4 +1,5 @@
 import { on } from "node:events";
+import type { PrismaClient } from "@prisma/client";
 import { PublicShareResourceTypes } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import shuffle from "lodash-es/shuffle";
@@ -10,6 +11,8 @@ import {
 } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import { formatSpansDigest } from "~/server/tracer/spanToReadableSpan";
+import type { Trace } from "~/server/tracer/types";
+import type { Protections } from "~/server/traces/protections";
 import { TraceService } from "~/server/traces/trace.service";
 import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
 import { createLogger } from "~/utils/logger/server";
@@ -30,6 +33,77 @@ import { getAllForProjectInput, tracesFilterInput } from "./traces.schemas";
 export { getAllForProjectInput };
 
 const logger = createLogger("langwatch:traces:sse-subscription");
+
+/**
+ * Reads a thread on behalf of an ANONYMOUS public-share caller, who is entitled
+ * to only the individually-shared traces within it — not the whole thread.
+ *
+ * Order matters here, and it is a security property (#4991, #5082): resolving
+ * `{ full: true }` de-offloads the entire IO value out of `event_log`, so doing
+ * it before authorization narrows the set would let one valid share link amplify
+ * unbounded `event_log` reads across every other trace in the thread — traces
+ * this caller may not read. That is the ClickHouse connection-pool exhaustion
+ * the ADR-022 offload exists to prevent, reachable unauthenticated.
+ *
+ * So: read PREVIEW-only (zero `event_log` reads), authorize down to the shared
+ * trace ids, and only then resolve full IO — for those ids alone.
+ */
+async function readPubliclySharedThread({
+  traceService,
+  prisma,
+  projectId,
+  threadId,
+  protections,
+}: {
+  traceService: TraceService;
+  prisma: PrismaClient;
+  projectId: string;
+  threadId: string;
+  protections: Protections;
+}): Promise<Trace[]> {
+  const previewTraces = await traceService.getTracesByThreadId(
+    projectId,
+    threadId,
+    protections,
+    { full: false },
+  );
+
+  const publicShares = await prisma.publicShare.findMany({
+    where: {
+      projectId,
+      resourceType: PublicShareResourceTypes.TRACE,
+      resourceId: { in: previewTraces.map((trace) => trace.trace_id) },
+    },
+  });
+
+  const authorizedTraceIds = previewTraces
+    .filter((trace) =>
+      publicShares.some((share) => share.resourceId === trace.trace_id),
+    )
+    .map((trace) => trace.trace_id);
+
+  if (authorizedTraceIds.length === 0) {
+    return [];
+  }
+
+  const authorizedTraces = await traceService.getTracesWithSpans(
+    projectId,
+    authorizedTraceIds,
+    protections,
+    undefined,
+    { full: true },
+  );
+
+  // `authorizedTraceIds` already carries the thread's canonical order — the
+  // preview read returned it sorted, and filter/map preserve that. A direct
+  // getTracesWithSpans call comes back in trace-id order instead, so re-project
+  // onto the ids rather than re-deriving an ordering here; the thread read stays
+  // the single owner of what "thread order" means.
+  const resolvedById = new Map(
+    authorizedTraces.map((trace) => [trace.trace_id, trace]),
+  );
+  return authorizedTraceIds.flatMap((id) => resolvedById.get(id) ?? []);
+}
 
 export const tracesRouter = createTRPCRouter({
   getAllForProject: protectedProcedure
@@ -231,15 +305,8 @@ export const tracesRouter = createTRPCRouter({
         buildTraceBlobResolutionDeps(),
       );
 
-      // SECURITY (#4991): full blob resolution de-offloads the whole IO value
-      // from event_log and must NEVER run pre-authorization. For an authorized
-      // (non-public) caller the whole thread is theirs to read, so resolve full
-      // up front. For a public-share caller — an anonymous, publicProcedure
-      // path — resolving the full thread first would (a) de-offload traces the
-      // caller is not authorized to see and (b) let a single valid share link
-      // amplify unbounded event_log reads across every other trace in the
-      // thread. So the public branch reads PREVIEW ONLY, authorizes down to the
-      // shared trace IDs, then resolves full IO for JUST those authorized IDs.
+      // An authorized caller owns the whole thread, so resolve it full up front.
+      // An anonymous public-share caller does not — see readPubliclySharedThread.
       if (!ctx.publiclyShared) {
         return traceService.getTracesByThreadId(
           projectId,
@@ -249,52 +316,13 @@ export const tracesRouter = createTRPCRouter({
         );
       }
 
-      // Public-share path: preview-only read (zero event_log resolution).
-      const previewTraces = await traceService.getTracesByThreadId(
+      return readPubliclySharedThread({
+        traceService,
+        prisma: ctx.prisma,
         projectId,
         threadId,
         protections,
-        { full: false },
-      );
-
-      const publicSharedTraces = await ctx.prisma.publicShare.findMany({
-        where: {
-          projectId: projectId,
-          resourceType: PublicShareResourceTypes.TRACE,
-          resourceId: {
-            in: previewTraces.map((trace) => trace.trace_id),
-          },
-        },
       });
-
-      const authorizedTraceIds = previewTraces
-        .filter((trace) =>
-          publicSharedTraces.some(
-            (publicShare) => publicShare.resourceId === trace.trace_id,
-          ),
-        )
-        .map((trace) => trace.trace_id);
-
-      if (authorizedTraceIds.length === 0) {
-        return [];
-      }
-
-      // Resolve full IO for ONLY the post-authorization trace IDs.
-      const authorizedTraces = await traceService.getTracesWithSpans(
-        projectId,
-        authorizedTraceIds,
-        protections,
-        undefined,
-        { full: true },
-      );
-
-      // Preserve the chronological order the thread view expects.
-      authorizedTraces.sort(
-        (a, b) =>
-          (a.timestamps.started_at ?? 0) - (b.timestamps.started_at ?? 0),
-      );
-
-      return authorizedTraces;
     }),
 
   getTracesWithSpans: protectedProcedure
@@ -533,10 +561,12 @@ export const tracesRouter = createTRPCRouter({
         projectId: input.projectId,
       });
 
-      // Download consumes trace content — resolve full IO when spans are
-      // included so exported rows carry the whole value, not the 64 KB preview
-      // (#4991 AC1). resolveBlobs is gated on includeSpans (resolution runs
-      // during span enrichment).
+      // A download consumes trace content, so it must never serve the 64 KB
+      // preview (#4991 AC1) — and that holds whether or not spans are included,
+      // because the returned traces carry trace-level `input`/`output` either
+      // way. Gating resolveBlobs on includeSpans (as this did) silently
+      // truncated any offloaded trace in a spans-less download, the same
+      // data-loss bug fixed in ExportService for summary-mode exports.
       const traceService = TraceService.create(
         ctx.prisma,
         buildTraceBlobResolutionDeps(),
@@ -551,7 +581,7 @@ export const tracesRouter = createTRPCRouter({
         {
           downloadMode: true,
           includeSpans: input.includeSpans,
-          resolveBlobs: input.includeSpans,
+          resolveBlobs: true,
           scrollId: input.scrollId,
         },
       );

--- a/langwatch/src/server/export/__tests__/export-service.4991.unit.test.ts
+++ b/langwatch/src/server/export/__tests__/export-service.4991.unit.test.ts
@@ -1,0 +1,158 @@
+/**
+ * #4991 ("2 of 2" of #4888) — AC1 call-site wiring for ExportService.
+ *
+ * A trace export consumes content: a truncated value is data loss in the CSV/
+ * JSONL. Proves (a) ExportService.create() constructs TraceService WITH
+ * blob-resolution deps, and (b) a FULL export opts resolveBlobs into the
+ * getAllTracesForProject options (summary export, which reads no span content,
+ * does not).
+ *
+ * BDD structure: given/when nested describes, action-based it() names.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Protections } from "~/server/elasticsearch/protections";
+import type { TraceService } from "~/server/traces/trace.service";
+import type {
+  GetAllTracesForProjectOptions,
+  TracesForProjectResult,
+} from "~/server/traces/types";
+import { ExportService } from "../export.service";
+import type { ExportRequest } from "../types";
+
+const { mockTraceServiceCreate, mockBuildDeps, BLOB_DEPS } = vi.hoisted(() => {
+  const BLOB_DEPS = {
+    blobStore: { tag: "blobStore" },
+    ioExtractionService: { tag: "ioExtractionService" },
+  };
+  return {
+    mockTraceServiceCreate: vi.fn(),
+    mockBuildDeps: vi.fn(() => BLOB_DEPS),
+    BLOB_DEPS,
+  };
+});
+
+vi.mock("~/server/traces/trace.service", () => ({
+  TraceService: { create: mockTraceServiceCreate },
+}));
+
+vi.mock("~/server/traces/trace-blob-resolution.deps", () => ({
+  buildTraceBlobResolutionDeps: mockBuildDeps,
+}));
+
+const protections: Protections = {
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+} as Protections;
+
+function buildExportRequest(overrides?: Partial<ExportRequest>): ExportRequest {
+  return {
+    projectId: "proj-1",
+    mode: "summary",
+    format: "csv",
+    filters: {},
+    startDate: 1_700_000_000_000,
+    endDate: 1_700_000_100_000,
+    ...overrides,
+  };
+}
+
+/**
+ * A TraceService stub whose getAllTracesForProject records the options it was
+ * called with, then returns a single-batch result so the export loop terminates.
+ */
+function buildOptionsCapturingTraceService(): {
+  traceService: TraceService;
+  optionsSeen: GetAllTracesForProjectOptions[];
+} {
+  const optionsSeen: GetAllTracesForProjectOptions[] = [];
+  const traceService = {
+    getAllTracesForProject: vi.fn(
+      async (
+        _input: unknown,
+        _protections: unknown,
+        options: GetAllTracesForProjectOptions,
+      ): Promise<TracesForProjectResult> => {
+        optionsSeen.push(options);
+        // A complete-enough Trace so the real CSV/JSON serializers run.
+        const trace = {
+          trace_id: "t1",
+          project_id: "proj-1",
+          metadata: {},
+          timestamps: {
+            started_at: 1_700_000_000_000,
+            inserted_at: 1_700_000_001_000,
+            updated_at: 1_700_000_002_000,
+          },
+          input: { value: "hello" },
+          output: { value: "world" },
+          spans: [],
+          evaluations: [],
+        };
+        return {
+          groups: [[trace as never]],
+          totalHits: 1,
+          traceChecks: {},
+          scrollId: undefined,
+        } as TracesForProjectResult;
+      },
+    ),
+  } as unknown as TraceService;
+  return { traceService, optionsSeen };
+}
+
+async function drainExport(service: ExportService, request: ExportRequest) {
+  for await (const _chunk of service.exportTraces({ request, protections })) {
+    // consume the generator
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBuildDeps.mockReturnValue(BLOB_DEPS);
+});
+
+describe("ExportService — #4991 AC1 full export resolution", () => {
+  describe("when ExportService.create() builds the service", () => {
+    it("constructs TraceService with blob-resolution deps", async () => {
+      mockTraceServiceCreate.mockReturnValue({} as TraceService);
+
+      await ExportService.create({} as never);
+
+      expect(mockTraceServiceCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        BLOB_DEPS,
+      );
+    });
+  });
+
+  describe("given a FULL export (mode: full, includes spans)", () => {
+    describe("when exportTraces streams a batch", () => {
+      it("opts resolveBlobs into the getAllTracesForProject options", async () => {
+        const { traceService, optionsSeen } =
+          buildOptionsCapturingTraceService();
+        const service = new ExportService({ traceService });
+
+        await drainExport(service, buildExportRequest({ mode: "full" }));
+
+        expect(optionsSeen.length).toBeGreaterThan(0);
+        expect(optionsSeen.every((o) => o.resolveBlobs === true)).toBe(true);
+        expect(optionsSeen.every((o) => o.includeSpans === true)).toBe(true);
+      });
+    });
+  });
+
+  describe("given a SUMMARY export (no span content read)", () => {
+    describe("when exportTraces streams a batch", () => {
+      it("does NOT opt resolveBlobs in (stays on the preview, zero event_log reads)", async () => {
+        const { traceService, optionsSeen } =
+          buildOptionsCapturingTraceService();
+        const service = new ExportService({ traceService });
+
+        await drainExport(service, buildExportRequest({ mode: "summary" }));
+
+        expect(optionsSeen.length).toBeGreaterThan(0);
+        expect(optionsSeen.every((o) => o.resolveBlobs === false)).toBe(true);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/export/__tests__/export-service.4991.unit.test.ts
+++ b/langwatch/src/server/export/__tests__/export-service.4991.unit.test.ts
@@ -3,9 +3,9 @@
  *
  * A trace export consumes content: a truncated value is data loss in the CSV/
  * JSONL. Proves (a) ExportService.create() constructs TraceService WITH
- * blob-resolution deps, and (b) a FULL export opts resolveBlobs into the
- * getAllTracesForProject options (summary export, which reads no span content,
- * does not).
+ * blob-resolution deps, and (b) BOTH export modes opt resolveBlobs into the
+ * getAllTracesForProject options — full mode because it emits span IO, summary
+ * mode because it still emits trace-level input/output.
  *
  * BDD structure: given/when nested describes, action-based it() names.
  */
@@ -141,9 +141,16 @@ describe("ExportService — #4991 AC1 full export resolution", () => {
     });
   });
 
-  describe("given a SUMMARY export (no span content read)", () => {
+  // A SUMMARY export reads NO span content — but it is still a content-consuming
+  // read: buildSummaryRow emits trace-level `trace.input.value` / `trace.output
+  // .value` (serializers/csv-serializer.ts:91-92), and the summary JSON
+  // serializer does the same. Gating resolution on includeSpans therefore
+  // silently shipped the truncated 64 KB preview for any offloaded (>64 KB)
+  // trace, with no error and no indication data was cut — the exact data-loss
+  // bug this PR exists to fix, just on the other export mode.
+  describe("given a SUMMARY export (reads trace-level input/output)", () => {
     describe("when exportTraces streams a batch", () => {
-      it("does NOT opt resolveBlobs in (stays on the preview, zero event_log reads)", async () => {
+      it("opts resolveBlobs in so an offloaded trace is not truncated to its preview", async () => {
         const { traceService, optionsSeen } =
           buildOptionsCapturingTraceService();
         const service = new ExportService({ traceService });
@@ -151,7 +158,42 @@ describe("ExportService — #4991 AC1 full export resolution", () => {
         await drainExport(service, buildExportRequest({ mode: "summary" }));
 
         expect(optionsSeen.length).toBeGreaterThan(0);
-        expect(optionsSeen.every((o) => o.resolveBlobs === false)).toBe(true);
+        expect(optionsSeen.every((o) => o.resolveBlobs === true)).toBe(true);
+      });
+
+      it("reads no span content (includeSpans stays false)", async () => {
+        const { traceService, optionsSeen } =
+          buildOptionsCapturingTraceService();
+        const service = new ExportService({ traceService });
+
+        await drainExport(service, buildExportRequest({ mode: "summary" }));
+
+        expect(optionsSeen.every((o) => o.includeSpans === false)).toBe(true);
+      });
+    });
+  });
+
+  // Grounds WHY the assertion above must hold: prove the summary payload really
+  // does carry the trace-level IO value. If a future change stopped emitting
+  // input/output in summary rows, resolving blobs there would become dead cost
+  // and this test would tell us so.
+  describe("given a SUMMARY csv export of a trace with trace-level IO", () => {
+    describe("when the export is drained", () => {
+      it("emits the trace input/output value into the payload", async () => {
+        const { traceService } = buildOptionsCapturingTraceService();
+        const service = new ExportService({ traceService });
+
+        let payload = "";
+        for await (const { chunk } of service.exportTraces({
+          request: buildExportRequest({ mode: "summary", format: "csv" }),
+          protections,
+        })) {
+          payload += chunk;
+        }
+
+        // The stub trace carries input "hello" / output "world".
+        expect(payload).toContain("hello");
+        expect(payload).toContain("world");
       });
     });
   });

--- a/langwatch/src/server/export/__tests__/export-service.4991.unit.test.ts
+++ b/langwatch/src/server/export/__tests__/export-service.4991.unit.test.ts
@@ -10,7 +10,7 @@
  * BDD structure: given/when nested describes, action-based it() names.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Protections } from "~/server/elasticsearch/protections";
+import type { Protections } from "~/server/traces/protections";
 import type { TraceService } from "~/server/traces/trace.service";
 import type {
   GetAllTracesForProjectOptions,

--- a/langwatch/src/server/export/__tests__/export-summary-blob-resolution.integration.test.ts
+++ b/langwatch/src/server/export/__tests__/export-summary-blob-resolution.integration.test.ts
@@ -1,0 +1,331 @@
+/**
+ * #5082 — a SUMMARY-mode export of an offloaded trace must carry the FULL value,
+ * end-to-end, against a REAL ClickHouse.
+ *
+ * Why this file exists, and why the unit tests were not enough:
+ *
+ * The reviewer's P1 was "summary exports silently ship the truncated 64 KB
+ * preview." The first fix set `resolveBlobs: true` at the call sites, and the
+ * unit tests asserted that the option was FORWARDED to getAllTracesForProject.
+ * They passed. The bug was untouched — resolution lived inside
+ * enrichTracesWithSpans, which ran only `if (options.includeSpans)`, and summary
+ * mode sets includeSpans=false, so the flag was never read. **A test that asserts
+ * a flag is forwarded passes whether or not the flag does anything.**
+ *
+ * So this test asserts the VALUE, through the real stack:
+ *
+ *   real ClickHouse (trace_summaries + stored_spans + event_log)
+ *     -> real ClickHouseTraceService  (the includeSpans/resolveBlobs gate)
+ *     -> real resolveOffloadedTracesBatch + real BlobStore (the event_log read)
+ *     -> real ExportService in SUMMARY mode
+ *     -> real CSV / JSONL serializers
+ *     -> assert the exported bytes contain UNIQUE_TAIL
+ *
+ * UNIQUE_TAIL sits past the 64 KB preview boundary by construction (the preview
+ * is `value.slice(0, 64KB) + "…"`), so it exists ONLY in the de-offloaded value.
+ * A preview-only export cannot contain it. That makes the assertion falsifiable
+ * against the actual bug rather than against a mock's arguments.
+ *
+ * AC5 is guarded in the same file: the list/search read (no resolveBlobs) over
+ * the SAME offloaded trace must still come back as the preview, with the tail
+ * absent — proving the fix did not turn the heavy-read protection off.
+ *
+ * BDD structure: describe("given …") -> describe("when …") -> it("…").
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  assertOverThreshold,
+  insertEventLogRow,
+  LARGE_VALUE,
+  UNIQUE_TAIL,
+} from "~/server/app-layer/traces/__tests__/blob-offload-test-helpers";
+import {
+  EVENTREF_ATTR_PREFIX,
+  IO_PREVIEW_BYTES,
+} from "~/server/app-layer/traces/lean-for-projection";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import {
+  SPAN_RECEIVED_EVENT_TYPE,
+  SPAN_RECEIVED_EVENT_VERSION_LATEST,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
+import { openProtections } from "~/server/traces/__tests__/open-protections";
+import { ExportService } from "../export.service";
+import type { ExportRequest } from "../types";
+
+// Gate identically to the other blob-offload integration tests: skip when no
+// real ClickHouse is reachable, run against the testcontainer otherwise.
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+);
+
+const tenantId = `test-export-blob-${nanoid()}`;
+const traceId = `trace-export-blob-${nanoid()}`;
+const spanId = `span-export-blob-${nanoid()}`;
+const eventId = `evt-export-blob-${nanoid()}`;
+const now = Date.now();
+
+/** The 64 KB preview the projection stores — the lossy thing we must NOT serve. */
+const PREVIEW_VALUE = `${LARGE_VALUE.slice(0, IO_PREVIEW_BYTES)}…`;
+
+/** The IO envelope shape trace_summaries/stored_spans store. */
+const previewEnvelope = JSON.stringify({
+  type: "text",
+  value: PREVIEW_VALUE,
+});
+
+// Override ONLY the client resolver — the rest of the module (isClickHouseEnabled,
+// used by buildTraceBlobResolutionDeps) must stay real, so the production wiring
+// is what runs.
+vi.mock("~/server/clickhouse/clickhouseClient", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/server/clickhouse/clickhouseClient")
+    >();
+  return { ...actual, getClickHouseClientForProject: vi.fn() };
+});
+
+vi.mock("~/server/db", () => ({
+  prisma: { project: { findUnique: vi.fn().mockResolvedValue({}) } },
+}));
+
+let ch: ClickHouseClient;
+
+/**
+ * Writes the trace exactly as an offloaded ingest leaves it:
+ *   - event_log      : the FULL >64 KB value (the only place it exists)
+ *   - stored_spans   : the 64 KB preview + the reserved eventref pointer
+ *   - trace_summaries: the 64 KB preview in ComputedOutput
+ */
+async function seedOffloadedTrace() {
+  await insertEventLogRow({
+    client: ch,
+    tenantId,
+    aggregateId: traceId, // ADR-022: aggregateId for trace-processing IS the traceId
+    eventId,
+    eventType: SPAN_RECEIVED_EVENT_TYPE,
+    eventVersion: SPAN_RECEIVED_EVENT_VERSION_LATEST,
+    eventData: {
+      span: {
+        traceId,
+        spanId,
+        attributes: [
+          { key: "langwatch.output", value: { stringValue: LARGE_VALUE } },
+        ],
+      },
+    },
+  });
+
+  await ch.insert({
+    table: "stored_spans",
+    values: [
+      {
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: tenantId,
+        TraceId: traceId,
+        SpanId: spanId,
+        ParentSpanId: null,
+        ParentTraceId: null,
+        ParentIsRemote: null,
+        Sampled: 1,
+        StartTime: new Date(now),
+        EndTime: new Date(now + 100),
+        DurationMs: 100,
+        SpanName: "test-span",
+        SpanKind: 1,
+        ServiceName: "test-service",
+        ResourceAttributes: {},
+        SpanAttributes: {
+          // The leaned preview, plus the reserved eventref the resolver follows
+          // back to event_log. This is the shape leanForProjection emits.
+          "langwatch.output": PREVIEW_VALUE,
+          [`${EVENTREF_ATTR_PREFIX}langwatch.output`]: JSON.stringify({
+            eventId,
+            field: "langwatch.output",
+          }),
+        },
+        StatusCode: 1,
+        StatusMessage: null,
+        ScopeName: "test",
+        ScopeVersion: null,
+        "Events.Timestamp": [],
+        "Events.Name": [],
+        "Events.Attributes": [],
+        "Links.TraceId": [],
+        "Links.SpanId": [],
+        "Links.Attributes": [],
+        DroppedAttributesCount: 0,
+        DroppedEventsCount: 0,
+        DroppedLinksCount: 0,
+        CreatedAt: new Date(now),
+        UpdatedAt: new Date(now),
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+
+  await ch.insert({
+    table: "trace_summaries",
+    values: [
+      {
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: tenantId,
+        TraceId: traceId,
+        Version: "v1",
+        Attributes: {},
+        OccurredAt: new Date(now),
+        CreatedAt: new Date(now),
+        UpdatedAt: new Date(now),
+        ComputedIOSchemaVersion: "v1",
+        ComputedInput: null,
+        ComputedOutput: previewEnvelope,
+        TimeToFirstTokenMs: null,
+        TimeToLastTokenMs: null,
+        TotalDurationMs: 100,
+        TokensPerSecond: null,
+        SpanCount: 1,
+        ContainsErrorStatus: false,
+        ContainsOKStatus: true,
+        ErrorMessage: null,
+        Models: [],
+        TotalCost: null,
+        TokensEstimated: false,
+        TotalPromptTokenCount: null,
+        TotalCompletionTokenCount: null,
+        OutputFromRootSpan: false,
+        OutputSpanEndTimeMs: 0,
+        BlockedByGuardrail: false,
+        SatisfactionScore: null,
+        TopicId: null,
+        SubTopicId: null,
+        HasAnnotation: null,
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+/** Drains the real ExportService and returns the concatenated payload. */
+async function runExport(request: ExportRequest): Promise<string> {
+  // create() resolves prisma + the blob-resolution deps itself; the CH client it
+  // ends up using is the testcontainer, via the mocked resolver above.
+  const service = await ExportService.create();
+  let payload = "";
+  for await (const { chunk } of service.exportTraces({
+    request,
+    protections: openProtections,
+  })) {
+    payload += chunk;
+  }
+  return payload;
+}
+
+function buildRequest(overrides: Partial<ExportRequest> = {}): ExportRequest {
+  return {
+    projectId: tenantId,
+    mode: "summary",
+    format: "csv",
+    filters: {},
+    startDate: now - 60_000,
+    endDate: now + 60_000,
+    ...overrides,
+  } as ExportRequest;
+}
+
+beforeAll(async () => {
+  if (!hasTestcontainers) return;
+
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+
+  const chModule = await import("~/server/clickhouse/clickhouseClient");
+  vi.mocked(chModule.getClickHouseClientForProject).mockResolvedValue(ch);
+
+  assertOverThreshold(LARGE_VALUE);
+  await seedOffloadedTrace();
+}, 120_000);
+
+afterAll(async () => {
+  if (ch) {
+    for (const table of ["trace_summaries", "stored_spans", "event_log"]) {
+      await ch.exec({
+        query: `ALTER TABLE ${table} DELETE WHERE TenantId = {tenantId:String}`,
+        query_params: { tenantId },
+      });
+    }
+  }
+  await stopTestContainers();
+});
+
+describe.skipIf(!hasTestcontainers)(
+  "#5082 — summary-mode export of an offloaded trace (real ClickHouse)",
+  () => {
+    describe("given a trace whose output was offloaded to event_log (>64 KB)", () => {
+      describe("when it is exported in SUMMARY mode (no spans emitted)", () => {
+        it("writes the FULL de-offloaded value into the CSV, not the 64 KB preview", async () => {
+          const csv = await runExport(buildRequest({ format: "csv" }));
+
+          // The tail exists ONLY past the preview boundary, so its presence is
+          // proof the event_log value was resolved and served.
+          expect(csv).toContain(UNIQUE_TAIL);
+        });
+
+        it("does not truncate at the preview boundary", async () => {
+          const csv = await runExport(buildRequest({ format: "csv" }));
+
+          // The lossy preview ends in the ellipsis the leaner appends; the
+          // resolved value does not.
+          expect(csv).not.toContain(`${"x".repeat(64)}…`);
+          expect(csv.length).toBeGreaterThan(IO_PREVIEW_BYTES);
+        });
+
+        it("writes the FULL value in JSON (JSONL) summary mode too", async () => {
+          const jsonl = await runExport(buildRequest({ format: "json" }));
+
+          expect(jsonl).toContain(UNIQUE_TAIL);
+        });
+      });
+    });
+
+    // AC5 — the fix must not have disarmed the heavy-read protection. The list
+    // grid reads the SAME offloaded trace and must still get the preview.
+    describe("given the SAME offloaded trace read by the list/search grid", () => {
+      describe("when it is read WITHOUT resolveBlobs", () => {
+        it("keeps the 64 KB preview and never de-offloads", async () => {
+          const { ClickHouseTraceService } = await import(
+            "~/server/traces/clickhouse-trace.service"
+          );
+          const { prisma } = await import("~/server/db");
+
+          // No resolvers wired at all — the list-grid construction shape.
+          const listService = new ClickHouseTraceService(
+            prisma as ConstructorParameters<typeof ClickHouseTraceService>[0],
+          );
+
+          const result = await listService.getAllTracesForProject(
+            {
+              projectId: tenantId,
+              startDate: now - 60_000,
+              endDate: now + 60_000,
+              filters: {},
+              pageSize: 100,
+            } as never,
+            openProtections,
+            { includeSpans: true }, // spans, but NO resolveBlobs
+          );
+
+          const trace = result?.groups.flat()[0];
+          expect(trace?.output?.value).not.toContain(UNIQUE_TAIL);
+          expect(trace?.output?.value).toContain("…");
+        });
+      });
+    });
+  },
+);

--- a/langwatch/src/server/export/export.service.ts
+++ b/langwatch/src/server/export/export.service.ts
@@ -9,9 +9,9 @@
  */
 
 import type { PrismaClient } from "@prisma/client";
-import type { Protections } from "~/server/traces/protections";
 import type { Evaluation, Trace } from "~/server/tracer/types";
 import { enrichTracesWithEvaluations } from "~/server/traces/enrich-evaluations";
+import type { Protections } from "~/server/traces/protections";
 import type { TraceService } from "~/server/traces/trace.service";
 import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
 import { createLogger } from "~/utils/logger/server";

--- a/langwatch/src/server/export/export.service.ts
+++ b/langwatch/src/server/export/export.service.ts
@@ -58,8 +58,7 @@ export class ExportService {
     const { TraceService: TraceServiceImpl } = await import(
       "~/server/traces/trace.service"
     );
-    const resolvedPrisma =
-      prisma ?? (await import("~/server/db")).prisma;
+    const resolvedPrisma = prisma ?? (await import("~/server/db")).prisma;
     // Export is a content-consuming read: wire blob-resolution deps so a full
     // export reads the whole IO value, not the 64 KB preview (#4991 AC1).
     const traceService = TraceServiceImpl.create(

--- a/langwatch/src/server/export/export.service.ts
+++ b/langwatch/src/server/export/export.service.ts
@@ -12,6 +12,7 @@ import type { PrismaClient } from "@prisma/client";
 import type { Evaluation, Trace } from "~/server/tracer/types";
 import { enrichTracesWithEvaluations } from "~/server/traces/enrich-evaluations";
 import type { Protections } from "~/server/traces/protections";
+import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
 import type { TraceService } from "~/server/traces/trace.service";
 import { createLogger } from "~/utils/logger/server";
 import {
@@ -57,8 +58,14 @@ export class ExportService {
     const { TraceService: TraceServiceImpl } = await import(
       "~/server/traces/trace.service"
     );
-    const resolvedPrisma = prisma ?? (await import("~/server/db")).prisma;
-    const traceService = TraceServiceImpl.create(resolvedPrisma);
+    const resolvedPrisma =
+      prisma ?? (await import("~/server/db")).prisma;
+    // Export is a content-consuming read: wire blob-resolution deps so a full
+    // export reads the whole IO value, not the 64 KB preview (#4991 AC1).
+    const traceService = TraceServiceImpl.create(
+      resolvedPrisma,
+      buildTraceBlobResolutionDeps(),
+    );
     return new ExportService({ traceService });
   }
 
@@ -148,6 +155,10 @@ export class ExportService {
         {
           downloadMode: true,
           includeSpans,
+          // Full export resolves offloaded IO to the whole value (#4991 AC1).
+          // Summary export (includeSpans=false) reads no span content, so it
+          // stays on the preview and issues zero event_log reads.
+          resolveBlobs: includeSpans,
           scrollId: scrollId ?? null,
         },
       );

--- a/langwatch/src/server/export/export.service.ts
+++ b/langwatch/src/server/export/export.service.ts
@@ -9,11 +9,11 @@
  */
 
 import type { PrismaClient } from "@prisma/client";
+import type { Protections } from "~/server/traces/protections";
 import type { Evaluation, Trace } from "~/server/tracer/types";
 import { enrichTracesWithEvaluations } from "~/server/traces/enrich-evaluations";
-import type { Protections } from "~/server/traces/protections";
-import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
 import type { TraceService } from "~/server/traces/trace.service";
+import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
 import { createLogger } from "~/utils/logger/server";
 import {
   serializeTracesToFullCsv,

--- a/langwatch/src/server/export/export.service.ts
+++ b/langwatch/src/server/export/export.service.ts
@@ -154,15 +154,12 @@ export class ExportService {
         {
           downloadMode: true,
           includeSpans,
-          // SECURITY/correctness (#4991): BOTH export modes are content-consuming
-          // reads. Full mode emits span IO; summary mode still emits trace-level
-          // `trace.input`/`trace.output` (see csv/json summary serializers). For
-          // an offloaded (>64 KB) trace, gating resolution on `includeSpans`
-          // would silently ship the truncated 64 KB preview in a summary export
-          // with no error and no indication data was cut. Resolve blobs for every
-          // export mode so no export path serves the preview it shouldn't. Exports
-          // are a bounded/streamed bulk read via this PR's batch resolver, so the
-          // extra event_log reads stay pool-safe.
+          // DATA LOSS (#4991): summary mode reads no span content, but it still
+          // emits trace-level `trace.input`/`trace.output` (see the csv/json
+          // summary serializers) — so it is content-consuming too. Gating on
+          // `includeSpans` therefore shipped the truncated 64 KB preview for any
+          // offloaded trace, silently. Resolve for every export mode; the batch
+          // resolver keeps the extra event_log reads bounded.
           resolveBlobs: true,
           scrollId: scrollId ?? null,
         },

--- a/langwatch/src/server/export/export.service.ts
+++ b/langwatch/src/server/export/export.service.ts
@@ -154,10 +154,16 @@ export class ExportService {
         {
           downloadMode: true,
           includeSpans,
-          // Full export resolves offloaded IO to the whole value (#4991 AC1).
-          // Summary export (includeSpans=false) reads no span content, so it
-          // stays on the preview and issues zero event_log reads.
-          resolveBlobs: includeSpans,
+          // SECURITY/correctness (#4991): BOTH export modes are content-consuming
+          // reads. Full mode emits span IO; summary mode still emits trace-level
+          // `trace.input`/`trace.output` (see csv/json summary serializers). For
+          // an offloaded (>64 KB) trace, gating resolution on `includeSpans`
+          // would silently ship the truncated 64 KB preview in a summary export
+          // with no error and no indication data was cut. Resolve blobs for every
+          // export mode so no export path serves the preview it shouldn't. Exports
+          // are a bounded/streamed bulk read via this PR's batch resolver, so the
+          // extra event_log reads stay pool-safe.
+          resolveBlobs: true,
           scrollId: scrollId ?? null,
         },
       );

--- a/langwatch/src/server/routes/__tests__/traces-legacy-thread.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/traces-legacy-thread.unit.test.ts
@@ -1,0 +1,158 @@
+/**
+ * #4991 ("2 of 2" of #4888) — AC2 call-site wiring for the legacy thread route.
+ *
+ * GET /api/thread/:id returns a conversation's traces; the consumer reads the
+ * messages, so it must resolve FULL IO, not the 64 KB preview. Proves the
+ * handler constructs TraceService WITH blob-resolution deps and calls
+ * getTracesByThreadId with { full: true }. Mirrors the merged
+ * traces-legacy-get-trace.unit.test.ts harness.
+ */
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { Trace } from "~/server/tracer/types";
+
+const mockGetTracesByThreadId = vi.fn();
+const mockCreate = vi.fn();
+
+vi.mock("~/server/traces/trace.service", async () => {
+  class AmbiguousTraceIdPrefixError extends Error {}
+  return {
+    AmbiguousTraceIdPrefixError,
+    TraceService: { create: mockCreate },
+  };
+});
+
+const mockBuildTraceBlobResolutionDeps = vi.fn(() => ({
+  blobStore: { tag: "blobStore" },
+  ioExtractionService: { tag: "ioExtractionService" },
+}));
+
+vi.mock("~/server/traces/trace-blob-resolution.deps", () => ({
+  buildTraceBlobResolutionDeps: mockBuildTraceBlobResolutionDeps,
+}));
+
+const mockResolve = vi.fn();
+const mockMarkUsed = vi.fn();
+
+vi.mock("~/server/api-key/token-resolver", () => ({
+  TokenResolver: {
+    create: vi.fn(() => ({ resolve: mockResolve, markUsed: mockMarkUsed })),
+  },
+}));
+
+vi.mock("~/server/api-key/auth-middleware", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/server/api-key/auth-middleware")>();
+  return {
+    ...actual,
+    extractCredentials: vi.fn(() => ({
+      token: "test-token",
+      projectId: "project-123",
+    })),
+    enforceApiKeyCeiling: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("~/server/api/utils", () => ({
+  getProtectionsForProject: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("~/server/db", () => ({ prisma: {} }));
+
+vi.mock("~/server/traces/trace-formatting", () => ({
+  generateAsciiTree: vi.fn().mockReturnValue("ascii tree"),
+  formatTraceSummaryDigest: vi.fn().mockReturnValue("Input: hi\nOutput: yo"),
+  toLLMModeTrace: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("~/server/tracer/spanToReadableSpan", () => ({
+  formatSpansDigest: vi.fn().mockReturnValue("formatted trace"),
+}));
+
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: vi.fn(() => ({
+    share: { createShare: vi.fn(), unshare: vi.fn() },
+  })),
+}));
+
+vi.mock("~/server/api/routers/traces.schemas", () => ({
+  getAllForProjectInput: z.object({
+    projectId: z.string(),
+    startDate: z.number(),
+    endDate: z.number(),
+    pageSize: z.number().optional(),
+  }),
+}));
+
+const { app: legacyApp } = await import("../traces-legacy");
+
+const testApp = new Hono();
+testApp.route("/", legacyApp);
+
+const sampleThreadTrace: Partial<Trace> = {
+  trace_id: "trace-abc",
+  project_id: "project-123",
+  input: { value: "hello" },
+  output: { value: "world" },
+  timestamps: { started_at: 1000, inserted_at: 2000, updated_at: 2000 },
+  metadata: { thread_id: "thread-1" },
+  spans: [],
+};
+
+const fakeProject = {
+  id: "project-123",
+  apiKey: "test-token",
+  team: { id: "team-1", organizationId: "org-1" },
+};
+
+function makeThreadRequest(threadId: string) {
+  return testApp.request(`http://localhost/api/thread/${threadId}`, {
+    method: "GET",
+    headers: { "X-Auth-Token": "test-token" },
+  });
+}
+
+describe("legacy GET /api/thread/:id — #4991 AC2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolve.mockResolvedValue({
+      type: "legacyProjectKey",
+      project: fakeProject,
+    });
+    mockCreate.mockReturnValue({
+      getTracesByThreadId: mockGetTracesByThreadId,
+    });
+    mockGetTracesByThreadId.mockResolvedValue([sampleThreadTrace]);
+  });
+
+  describe("when fetching a thread by id", () => {
+    it("constructs TraceService with blob-resolution deps", async () => {
+      await makeThreadRequest("thread-1");
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          blobStore: expect.anything(),
+          ioExtractionService: expect.anything(),
+        }),
+      );
+    });
+
+    it("calls getTracesByThreadId with full:true (resolves offloaded IO)", async () => {
+      await makeThreadRequest("thread-1");
+      expect(mockGetTracesByThreadId).toHaveBeenCalledWith(
+        "project-123",
+        "thread-1",
+        expect.any(Object),
+        { full: true },
+      );
+    });
+
+    it("returns 200 with the thread traces", async () => {
+      const res = await makeThreadRequest("thread-1");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.traces[0].trace_id).toBe("trace-abc");
+    });
+  });
+});

--- a/langwatch/src/server/routes/traces-legacy.ts
+++ b/langwatch/src/server/routes/traces-legacy.ts
@@ -92,8 +92,7 @@ secured.access(handlerManagedAuth(AUTH_REASON)).get("/trace/:id", async (c) => {
     const traceId = c.req.param("id");
     const formatParam = c.req.query("format");
     const llmMode =
-      c.req.query("llmMode") === "true" ||
-      c.req.query("llmMode") === "1";
+      c.req.query("llmMode") === "true" || c.req.query("llmMode") === "1";
     const format = formatParam ?? (llmMode ? "digest" : "json");
 
     c.header("Deprecation", "true");
@@ -156,44 +155,48 @@ secured.access(handlerManagedAuth(AUTH_REASON)).get("/trace/:id", async (c) => {
 });
 
 // ---------- POST /api/trace/:id/share ----------
-secured.access(handlerManagedAuth(AUTH_REASON)).post("/trace/:id/share", async (c) => {
-  const auth = await authenticateRequest(c, "traces:share");
-  if ("error" in auth) {
-    return c.json({ message: auth.error }, auth.status);
-  }
-  const { project, markUsed } = auth;
+secured
+  .access(handlerManagedAuth(AUTH_REASON))
+  .post("/trace/:id/share", async (c) => {
+    const auth = await authenticateRequest(c, "traces:share");
+    if ("error" in auth) {
+      return c.json({ message: auth.error }, auth.status);
+    }
+    const { project, markUsed } = auth;
 
-  const traceId = c.req.param("id");
+    const traceId = c.req.param("id");
 
-  const share = await getApp().share.createShare({
-    projectId: project.id,
-    resourceType: "TRACE",
-    resourceId: traceId,
+    const share = await getApp().share.createShare({
+      projectId: project.id,
+      resourceType: "TRACE",
+      resourceId: traceId,
+    });
+
+    markUsed();
+    return c.json({ status: "success", path: `/share/${share.id}` });
   });
-
-  markUsed();
-  return c.json({ status: "success", path: `/share/${share.id}` });
-});
 
 // ---------- POST /api/trace/:id/unshare ----------
-secured.access(handlerManagedAuth(AUTH_REASON)).post("/trace/:id/unshare", async (c) => {
-  const auth = await authenticateRequest(c, "traces:share");
-  if ("error" in auth) {
-    return c.json({ message: auth.error }, auth.status);
-  }
-  const { project, markUsed } = auth;
+secured
+  .access(handlerManagedAuth(AUTH_REASON))
+  .post("/trace/:id/unshare", async (c) => {
+    const auth = await authenticateRequest(c, "traces:share");
+    if ("error" in auth) {
+      return c.json({ message: auth.error }, auth.status);
+    }
+    const { project, markUsed } = auth;
 
-  const traceId = c.req.param("id");
+    const traceId = c.req.param("id");
 
-  await getApp().share.unshare({
-    projectId: project.id,
-    resourceType: "TRACE",
-    resourceId: traceId,
+    await getApp().share.unshare({
+      projectId: project.id,
+      resourceType: "TRACE",
+      resourceId: traceId,
+    });
+
+    markUsed();
+    return c.json({ status: "success" });
   });
-
-  markUsed();
-  return c.json({ status: "success" });
-});
 
 // ---------- POST /api/trace/search ----------
 const paramsSchema = getAllForProjectInput
@@ -220,123 +223,127 @@ const paramsSchema = getAllForProjectInput
     llmMode: z.boolean().optional().default(false),
   });
 
-secured.access(handlerManagedAuth(AUTH_REASON)).post("/trace/search", async (c) => {
-  const auth = await authenticateRequest(c, "traces:view");
-  if ("error" in auth) {
-    return c.json({ message: auth.error }, auth.status);
-  }
-  const { project, markUsed } = auth;
+secured
+  .access(handlerManagedAuth(AUTH_REASON))
+  .post("/trace/search", async (c) => {
+    const auth = await authenticateRequest(c, "traces:view");
+    if ("error" in auth) {
+      return c.json({ message: auth.error }, auth.status);
+    }
+    const { project, markUsed } = auth;
 
-  let body: Record<string, any>;
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "Invalid body" }, 400);
-  }
+    let body: Record<string, any>;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid body" }, 400);
+    }
 
-  let params: z.infer<typeof paramsSchema>;
-  try {
-    params = paramsSchema.strict().parse(body);
-  } catch (error) {
-    const validationError = fromZodError(error as ZodError);
-    return c.json({ error: validationError.message }, 400);
-  }
+    let params: z.infer<typeof paramsSchema>;
+    try {
+      params = paramsSchema.strict().parse(body);
+    } catch (error) {
+      const validationError = fromZodError(error as ZodError);
+      return c.json({ error: validationError.message }, 400);
+    }
 
-  const format = params.format ?? (params.llmMode ? "digest" : "json");
+    const format = params.format ?? (params.llmMode ? "digest" : "json");
 
-  c.header("Deprecation", "true");
-  c.header("Link", `</api/traces/search>; rel="successor-version"`);
+    c.header("Deprecation", "true");
+    c.header("Link", `</api/traces/search>; rel="successor-version"`);
 
-  const pageSize = Math.min(params.pageSize ?? 1000, 1000);
-  const protections = await getProtectionsForProject(prisma, {
-    projectId: project.id,
-  });
-  const traceService = TraceService.create(prisma);
-  const results = await traceService.getAllTracesForProject(
-    {
-      ...params,
+    const pageSize = Math.min(params.pageSize ?? 1000, 1000);
+    const protections = await getProtectionsForProject(prisma, {
       projectId: project.id,
-      startDate:
-        typeof params.startDate === "string"
-          ? Date.parse(params.startDate)
-          : params.startDate,
-      endDate:
-        typeof params.endDate === "string"
-          ? Date.parse(params.endDate)
-          : params.endDate,
-      pageSize,
-    },
-    protections,
-    {
-      downloadMode: true,
-      scrollId: params.scrollId ?? undefined,
-    },
-  );
+    });
+    const traceService = TraceService.create(prisma);
+    const results = await traceService.getAllTracesForProject(
+      {
+        ...params,
+        projectId: project.id,
+        startDate:
+          typeof params.startDate === "string"
+            ? Date.parse(params.startDate)
+            : params.startDate,
+        endDate:
+          typeof params.endDate === "string"
+            ? Date.parse(params.endDate)
+            : params.endDate,
+        pageSize,
+      },
+      protections,
+      {
+        downloadMode: true,
+        scrollId: params.scrollId ?? undefined,
+      },
+    );
 
-  const rawTraces = results.groups.flat() as Trace[];
-  const enrichedTraces = enrichTracesWithEvaluations({
-    traces: rawTraces,
-    traceChecks: results.traceChecks,
+    const rawTraces = results.groups.flat() as Trace[];
+    const enrichedTraces = enrichTracesWithEvaluations({
+      traces: rawTraces,
+      traceChecks: results.traceChecks,
+    });
+
+    let traces: unknown[];
+    if (format === "digest") {
+      traces = enrichedTraces.map((trace) => ({
+        trace_id: trace.trace_id,
+        formatted_trace: formatTraceSummaryDigest(trace),
+        input: trace.input,
+        output: trace.output,
+        timestamps: trace.timestamps,
+        metadata: trace.metadata,
+        error: trace.error,
+        evaluations: trace.evaluations,
+      }));
+    } else if (params.llmMode) {
+      traces = enrichedTraces.map((trace) => ({
+        ...toLLMModeTrace(trace as Trace & { spans: Span[] }),
+        spans: [],
+        evaluations: trace.evaluations,
+      }));
+    } else {
+      traces = enrichedTraces;
+    }
+
+    markUsed();
+    return c.json({
+      traces,
+      pagination: {
+        totalHits: results.totalHits,
+        scrollId: results.scrollId,
+      },
+    });
   });
-
-  let traces: unknown[];
-  if (format === "digest") {
-    traces = enrichedTraces.map((trace) => ({
-      trace_id: trace.trace_id,
-      formatted_trace: formatTraceSummaryDigest(trace),
-      input: trace.input,
-      output: trace.output,
-      timestamps: trace.timestamps,
-      metadata: trace.metadata,
-      error: trace.error,
-      evaluations: trace.evaluations,
-    }));
-  } else if (params.llmMode) {
-    traces = enrichedTraces.map((trace) => ({
-      ...toLLMModeTrace(trace as Trace & { spans: Span[] }),
-      spans: [],
-      evaluations: trace.evaluations,
-    }));
-  } else {
-    traces = enrichedTraces;
-  }
-
-  markUsed();
-  return c.json({
-    traces,
-    pagination: {
-      totalHits: results.totalHits,
-      scrollId: results.scrollId,
-    },
-  });
-});
 
 // ---------- GET /api/thread/:id ----------
-secured.access(handlerManagedAuth(AUTH_REASON)).get("/thread/:id", async (c) => {
-  const auth = await authenticateRequest(c, "traces:view");
-  if ("error" in auth) {
-    return c.json({ message: auth.error }, auth.status);
-  }
-  const { project, markUsed } = auth;
+secured
+  .access(handlerManagedAuth(AUTH_REASON))
+  .get("/thread/:id", async (c) => {
+    const auth = await authenticateRequest(c, "traces:view");
+    if ("error" in auth) {
+      return c.json({ message: auth.error }, auth.status);
+    }
+    const { project, markUsed } = auth;
 
-  const threadId = c.req.param("id");
-  const protections = await getProtectionsForProject(prisma, {
-    projectId: project.id,
+    const threadId = c.req.param("id");
+    const protections = await getProtectionsForProject(prisma, {
+      projectId: project.id,
+    });
+    // Thread-detail read consumes conversation content — resolve full IO (#4991).
+    const traceService = TraceService.create(
+      prisma,
+      buildTraceBlobResolutionDeps(),
+    );
+    const traces = await traceService.getTracesByThreadId(
+      project.id,
+      threadId,
+      protections,
+      { full: true },
+    );
+
+    markUsed();
+    return c.json({ traces });
   });
-  // Thread-detail read consumes conversation content — resolve full IO (#4991).
-  const traceService = TraceService.create(
-    prisma,
-    buildTraceBlobResolutionDeps(),
-  );
-  const traces = await traceService.getTracesByThreadId(
-    project.id,
-    threadId,
-    protections,
-    { full: true },
-  );
-
-  markUsed();
-  return c.json({ traces });
-});
 
 export const app = secured.hono;

--- a/langwatch/src/server/routes/traces-legacy.ts
+++ b/langwatch/src/server/routes/traces-legacy.ts
@@ -11,28 +11,28 @@
 import type { Context } from "hono";
 import { z } from "zod";
 import { fromZodError, type ZodError } from "zod-validation-error";
-import { getProtectionsForProject } from "~/server/api/utils";
-import { getApp } from "~/server/app-layer/app";
-import { getAllForProjectInput } from "~/server/api/routers/traces.schemas";
-import { prisma } from "~/server/db";
-import { generateAsciiTree } from "~/server/traces/trace-formatting";
-import {
-  toLLMModeTrace,
-  formatTraceSummaryDigest,
-} from "~/server/traces/trace-formatting";
-import { formatSpansDigest } from "~/server/tracer/spanToReadableSpan";
-import { TraceService } from "~/server/traces/trace.service";
-import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
-import { enrichTracesWithEvaluations } from "~/server/traces/enrich-evaluations";
-import type { Span, Trace } from "~/server/tracer/types";
 import type { Permission } from "~/server/api/rbac";
+import { getAllForProjectInput } from "~/server/api/routers/traces.schemas";
+import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
+import { getProtectionsForProject } from "~/server/api/utils";
 import {
+  apiKeyCeilingDenialResponse,
   enforceApiKeyCeiling,
   extractCredentials,
-  apiKeyCeilingDenialResponse,
 } from "~/server/api-key/auth-middleware";
 import { TokenResolver } from "~/server/api-key/token-resolver";
-import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
+import { getApp } from "~/server/app-layer/app";
+import { prisma } from "~/server/db";
+import { formatSpansDigest } from "~/server/tracer/spanToReadableSpan";
+import type { Span, Trace } from "~/server/tracer/types";
+import { enrichTracesWithEvaluations } from "~/server/traces/enrich-evaluations";
+import { TraceService } from "~/server/traces/trace.service";
+import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
+import {
+  formatTraceSummaryDigest,
+  generateAsciiTree,
+  toLLMModeTrace,
+} from "~/server/traces/trace-formatting";
 
 const tokenResolver = TokenResolver.create(prisma);
 

--- a/langwatch/src/server/routes/traces-legacy.ts
+++ b/langwatch/src/server/routes/traces-legacy.ts
@@ -323,11 +323,16 @@ secured.access(handlerManagedAuth(AUTH_REASON)).get("/thread/:id", async (c) => 
   const protections = await getProtectionsForProject(prisma, {
     projectId: project.id,
   });
-  const traceService = TraceService.create(prisma);
+  // Thread-detail read consumes conversation content — resolve full IO (#4991).
+  const traceService = TraceService.create(
+    prisma,
+    buildTraceBlobResolutionDeps(),
+  );
   const traces = await traceService.getTracesByThreadId(
     project.id,
     threadId,
     protections,
+    { full: true },
   );
 
   markUsed();

--- a/langwatch/src/server/sdk-radar/sdk-versions.json
+++ b/langwatch/src/server/sdk-radar/sdk-versions.json
@@ -1,4 +1,0 @@
-{
-  "python-sdk": "0.26.0",
-  "typescript-sdk": "0.33.2"
-}

--- a/langwatch/src/server/sdk-radar/sdk-versions.json
+++ b/langwatch/src/server/sdk-radar/sdk-versions.json
@@ -1,0 +1,4 @@
+{
+  "python-sdk": "0.26.0",
+  "typescript-sdk": "0.33.2"
+}

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -278,7 +278,9 @@ describe("ClickHouseTraceService.getAllTracesForProject — #4991 AC5 list prote
           { includeSpans: true },
         );
 
-        expect(result!.groups.flat()[0]!.output?.value).not.toBe(FULL_OUTPUT);
+        // Falsifiable: assert the exact preview, not merely "not the full value"
+        // (a broken mapper returning "" / null would slip past not.toBe).
+        expect(result!.groups.flat()[0]!.output?.value).toBe(PREVIEW_OUTPUT);
       });
     });
   });
@@ -321,7 +323,8 @@ describe("ClickHouseTraceService.getTracesByThreadId — #4991 AC2 thread detail
         );
 
         expect(getFromEventLog).not.toHaveBeenCalled();
-        expect(traces![0]!.output?.value).not.toBe(FULL_OUTPUT);
+        // Falsifiable: exact preview, not merely "not the full value".
+        expect(traces![0]!.output?.value).toBe(PREVIEW_OUTPUT);
       });
     });
   });

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -23,7 +23,10 @@ import { ClickHouseTraceService } from "../clickhouse-trace.service";
 import { resolveOffloadedTraces } from "../resolve-offloaded-traces";
 import { resolveOffloadedTracesBatch } from "../resolve-offloaded-traces-batch";
 import type { GetAllTracesForProjectInput } from "../types";
-import { makeSpanRowWithEventRef, makeSummaryRow } from "./fixtures/ch-row-fixtures";
+import {
+  makeSpanRowWithEventRef,
+  makeSummaryRow,
+} from "./fixtures/ch-row-fixtures";
 
 // ---------------------------------------------------------------------------
 // Hoisted mock — only the raw CH SQL boundary
@@ -53,9 +56,9 @@ vi.mock("langwatch", () => ({
     withActiveSpan: (_name: string, ...args: unknown[]) => {
       const fn = args.length === 1 ? args[0] : args[1];
       const fakeSpan = {
-        setAttribute: () => {},
-        setAttributes: () => {},
-        addEvent: () => {},
+        setAttribute: () => undefined,
+        setAttributes: () => undefined,
+        addEvent: () => undefined,
       };
       return (fn as (s: typeof fakeSpan) => Promise<unknown>)(fakeSpan);
     },

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -1,0 +1,325 @@
+/**
+ * #4991 ("2 of 2" of #4888) — bulk read-path full-blob resolution at the
+ * ClickHouse seam. Mocks only the raw CH SQL boundary + a fake BlobStore and
+ * runs the REAL ClickHouseTraceService + REAL batch resolver + REAL mapper, so
+ * the gate is exercised where it actually lives.
+ *
+ * ACs covered here:
+ *   AC1 — download/export (getAllTracesForProject includeSpans + resolveBlobs)
+ *         resolves the FULL value during span enrichment.
+ *   AC2 — thread-detail (getTracesByThreadId resolveBlobs) resolves the FULL value.
+ *   AC5 — the list/search grid (includeSpans WITHOUT resolveBlobs) issues ZERO
+ *         event_log reads and keeps the ≤64 KB preview (heavy-read protection).
+ *
+ * BDD structure: given/when nested describes, action-based it() names.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
+import { BlobNotFoundError } from "~/server/app-layer/traces/blob-store.service";
+import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
+import type { Protections } from "~/server/elasticsearch/protections";
+import { createLogger } from "~/utils/logger/server";
+import { ClickHouseTraceService } from "../clickhouse-trace.service";
+import { resolveOffloadedTraces } from "../resolve-offloaded-traces";
+import { resolveOffloadedTracesBatch } from "../resolve-offloaded-traces-batch";
+import type { GetAllTracesForProjectInput } from "../types";
+import { makeSpanRowWithEventRef, makeSummaryRow } from "./fixtures/ch-row-fixtures";
+
+// ---------------------------------------------------------------------------
+// Hoisted mock — only the raw CH SQL boundary
+// ---------------------------------------------------------------------------
+
+const { mockClickHouseQuery } = vi.hoisted(() => ({
+  mockClickHouseQuery: vi.fn(),
+}));
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: () =>
+    Promise.resolve({ query: mockClickHouseQuery }),
+}));
+
+vi.mock("~/server/db", () => ({ prisma: {} }));
+
+vi.mock("~/server/filters/clickhouse", () => ({
+  generateClickHouseFilterConditions: () => ({
+    conditions: [],
+    params: {},
+    hasUnsupportedFilters: false,
+  }),
+}));
+
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: (_name: string, ...args: unknown[]) => {
+      const fn = args.length === 1 ? args[0] : args[1];
+      const fakeSpan = {
+        setAttribute: () => {},
+        setAttributes: () => {},
+        addEvent: () => {},
+      };
+      return (fn as (s: typeof fakeSpan) => Promise<unknown>)(fakeSpan);
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Constants / helpers
+// ---------------------------------------------------------------------------
+
+const IO_PREVIEW_BYTES = 65536;
+const LARGE_BYTE_COUNT = 400_000;
+const FULL_OUTPUT = "x".repeat(LARGE_BYTE_COUNT);
+const PREVIEW_OUTPUT = "x".repeat(IO_PREVIEW_BYTES) + "…";
+
+const PROJECT_ID = "proj-4991";
+const TRACE_ID = "trace-4991";
+
+const protections: Protections = {
+  canSeeCosts: true,
+  canSeePiiData: true,
+  canSeeTopics: true,
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+} as Protections;
+
+const baseInput: GetAllTracesForProjectInput = {
+  projectId: PROJECT_ID,
+  startDate: 0,
+  endDate: Date.now(),
+  filters: {},
+} as GetAllTracesForProjectInput;
+
+function makeEventRefBlobStore(): {
+  blobStore: BlobStore;
+  getFromEventLog: ReturnType<typeof vi.fn>;
+} {
+  const getFromEventLog = vi.fn(async ({ field }: { field: string }) => {
+    if (field === "langwatch.output") return FULL_OUTPUT;
+    throw new BlobNotFoundError("evt-001", field, PROJECT_ID);
+  });
+  return {
+    blobStore: {
+      getFromEventLog,
+      putSpool: vi.fn(),
+      getSpool: vi.fn(),
+      deleteSpool: vi.fn(),
+    } as unknown as BlobStore,
+    getFromEventLog,
+  };
+}
+
+/** ClickHouseTraceService wired with BOTH resolvers from a fake blobStore. */
+function buildService(blobStore: BlobStore): ClickHouseTraceService {
+  const ioExtractionService = new TraceIOExtractionService();
+  const logger = createLogger("test");
+  return new ClickHouseTraceService(
+    { project: { findUnique: vi.fn() } } as never,
+    (projectId, normalizedSpans) =>
+      resolveOffloadedTraces({
+        projectId,
+        normalizedSpans,
+        blobStore,
+        ioExtractionService,
+        logger,
+      }),
+    (projectId, spansPerTrace) =>
+      resolveOffloadedTracesBatch({
+        projectId,
+        spansPerTrace,
+        blobStore,
+        ioExtractionService,
+        logger,
+      }),
+  );
+}
+
+/** Mocks the getAllTracesForProject query sequence for an includeSpans read. */
+function setupGetAllWithSpansMocks() {
+  mockClickHouseQuery
+    // fetchTracesWithPagination: count, IDs, data
+    .mockResolvedValueOnce({ json: () => Promise.resolve([{ total: "1" }]) })
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve([{ TraceId: TRACE_ID }]),
+    })
+    .mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve([
+          makeSummaryRow(TRACE_ID, {
+            computedOutput: `{"type":"text","value":${JSON.stringify(PREVIEW_OUTPUT)}}`,
+          }),
+        ]),
+    })
+    // enrichTracesWithSpans -> fetchTracesWithSpansJoined: summary, spans
+    .mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve([
+          makeSummaryRow(TRACE_ID, {
+            computedOutput: `{"type":"text","value":${JSON.stringify(PREVIEW_OUTPUT)}}`,
+          }),
+        ]),
+    })
+    .mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve([
+          makeSpanRowWithEventRef(TRACE_ID, "span-1", {
+            tenantId: PROJECT_ID,
+            previewOutput: PREVIEW_OUTPUT,
+          }),
+        ]),
+    })
+    // fetchEvaluationRows
+    .mockResolvedValueOnce({ json: () => Promise.resolve([]) });
+}
+
+/** Mocks the getTracesByThreadId query sequence (DISTINCT TraceId, then joined). */
+function setupThreadMocks() {
+  mockClickHouseQuery
+    // SELECT DISTINCT TraceId (JSONEachRow → result.json())
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve([{ TraceId: TRACE_ID }]),
+    })
+    // fetchTracesWithSpansJoined: summary, spans
+    .mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve([
+          makeSummaryRow(TRACE_ID, {
+            computedOutput: `{"type":"text","value":${JSON.stringify(PREVIEW_OUTPUT)}}`,
+          }),
+        ]),
+    })
+    .mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve([
+          makeSpanRowWithEventRef(TRACE_ID, "span-1", {
+            tenantId: PROJECT_ID,
+            previewOutput: PREVIEW_OUTPUT,
+          }),
+        ]),
+    });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// AC1 — download/export resolves full during enrichment
+// ---------------------------------------------------------------------------
+
+describe("ClickHouseTraceService.getAllTracesForProject — #4991 AC1 export", () => {
+  describe("given a >64 KB offloaded trace and includeSpans + resolveBlobs", () => {
+    describe("when the download path reads it", () => {
+      it("reads the full value back from event_log (not the preview)", async () => {
+        setupGetAllWithSpansMocks();
+        const { blobStore, getFromEventLog } = makeEventRefBlobStore();
+        const service = buildService(blobStore);
+
+        const result = await service.getAllTracesForProject(
+          baseInput,
+          protections,
+          { includeSpans: true, resolveBlobs: true },
+        );
+
+        const trace = result!.groups.flat()[0]!;
+        expect(getFromEventLog).toHaveBeenCalled();
+        expect(trace.output?.value).toBe(FULL_OUTPUT);
+      });
+
+      it("widens the exported output past the 64 KB preview", async () => {
+        setupGetAllWithSpansMocks();
+        const { blobStore } = makeEventRefBlobStore();
+        const service = buildService(blobStore);
+
+        const result = await service.getAllTracesForProject(
+          baseInput,
+          protections,
+          { includeSpans: true, resolveBlobs: true },
+        );
+
+        const outputVal = result!.groups.flat()[0]!.output?.value as string;
+        expect(Buffer.byteLength(outputVal, "utf8")).toBeGreaterThan(
+          IO_PREVIEW_BYTES,
+        );
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC5 — list/search grid keeps preview, ZERO event_log reads
+// ---------------------------------------------------------------------------
+
+describe("ClickHouseTraceService.getAllTracesForProject — #4991 AC5 list protection", () => {
+  describe("given the SAME offloaded trace but the list path (no resolveBlobs)", () => {
+    describe("when includeSpans is requested without resolveBlobs", () => {
+      it("issues ZERO event_log reads", async () => {
+        setupGetAllWithSpansMocks();
+        const { blobStore, getFromEventLog } = makeEventRefBlobStore();
+        const service = buildService(blobStore);
+
+        await service.getAllTracesForProject(baseInput, protections, {
+          includeSpans: true,
+        });
+
+        expect(getFromEventLog).not.toHaveBeenCalled();
+      });
+
+      it("keeps the ≤64 KB preview (does not widen to the full value)", async () => {
+        setupGetAllWithSpansMocks();
+        const { blobStore } = makeEventRefBlobStore();
+        const service = buildService(blobStore);
+
+        const result = await service.getAllTracesForProject(
+          baseInput,
+          protections,
+          { includeSpans: true },
+        );
+
+        expect(result!.groups.flat()[0]!.output?.value).not.toBe(FULL_OUTPUT);
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2 — thread-detail resolves full
+// ---------------------------------------------------------------------------
+
+describe("ClickHouseTraceService.getTracesByThreadId — #4991 AC2 thread detail", () => {
+  describe("given an offloaded trace in the thread and resolveBlobs", () => {
+    describe("when the thread-detail path reads it", () => {
+      it("reads the full conversation value back from event_log", async () => {
+        setupThreadMocks();
+        const { blobStore, getFromEventLog } = makeEventRefBlobStore();
+        const service = buildService(blobStore);
+
+        const traces = await service.getTracesByThreadId(
+          PROJECT_ID,
+          "thread-1",
+          protections,
+          { resolveBlobs: true },
+        );
+
+        expect(getFromEventLog).toHaveBeenCalled();
+        expect(traces![0]!.output?.value).toBe(FULL_OUTPUT);
+      });
+    });
+
+    describe("when the thread-detail path reads it WITHOUT resolveBlobs", () => {
+      it("issues ZERO event_log reads and keeps the preview", async () => {
+        setupThreadMocks();
+        const { blobStore, getFromEventLog } = makeEventRefBlobStore();
+        const service = buildService(blobStore);
+
+        const traces = await service.getTracesByThreadId(
+          PROJECT_ID,
+          "thread-1",
+          protections,
+        );
+
+        expect(getFromEventLog).not.toHaveBeenCalled();
+        expect(traces![0]!.output?.value).not.toBe(FULL_OUTPUT);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -17,7 +17,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
 import { BlobNotFoundError } from "~/server/app-layer/traces/blob-store.service";
 import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
-import type { Protections } from "~/server/elasticsearch/protections";
+import type { Protections } from "~/server/traces/protections";
 import { createLogger } from "~/utils/logger/server";
 import { ClickHouseTraceService } from "../clickhouse-trace.service";
 import { resolveOffloadedTraces } from "../resolve-offloaded-traces";

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -174,12 +174,27 @@ function setupGetAllWithSpansMocks() {
     .mockResolvedValueOnce({ json: () => Promise.resolve([]) });
 }
 
-/** Mocks the getTracesByThreadId query sequence (DISTINCT TraceId, then joined). */
+/**
+ * Mocks the getTracesByThreadId query sequence: DISTINCT TraceId, the hint-less
+ * OccurredAt-range resolve, then the joined summary + spans reads.
+ *
+ * The thread path knows only trace ids, so it passes no `occurredAt` hint and
+ * fetchTracesWithSpansJoined resolves the partition window itself first (#5231).
+ * That is a real query and consumes a mock — omit it and every later mock shifts
+ * by one, so the spans read silently gets the summary's rows.
+ */
 function setupThreadMocks() {
   mockClickHouseQuery
     // SELECT DISTINCT TraceId (JSONEachRow → result.json())
     .mockResolvedValueOnce({
       json: () => Promise.resolve([{ TraceId: TRACE_ID }]),
+    })
+    // resolveOccurredAtRange: min/max OccurredAt for partition pruning (#5231)
+    .mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve([
+          { fromMs: 1_700_000_000_000, toMs: 1_700_000_100_000 },
+        ]),
     })
     // fetchTracesWithSpansJoined: summary, spans
     .mockResolvedValueOnce({

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -17,9 +17,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
 import { BlobNotFoundError } from "~/server/app-layer/traces/blob-store.service";
 import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
+import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import type { Protections } from "~/server/traces/protections";
 import { createLogger } from "~/utils/logger/server";
 import { ClickHouseTraceService } from "../clickhouse-trace.service";
+import type { ResolvedTraceSpans } from "../resolve-offloaded-traces";
 import { resolveOffloadedTraces } from "../resolve-offloaded-traces";
 import { resolveOffloadedTracesBatch } from "../resolve-offloaded-traces-batch";
 import type { GetAllTracesForProjectInput } from "../types";
@@ -264,37 +266,126 @@ describe("ClickHouseTraceService.getAllTracesForProject — #4991 AC1 export", (
 });
 
 // ---------------------------------------------------------------------------
-// Batch-resolver contract — one resolution per input trace, in input order
+// Batch-resolver contract — one resolution per input trace, IN INPUT ORDER
 //
-// ResolveTraceSpansBatchFn is INJECTED, so the 1:1 invariant is a convention its
-// type cannot enforce. A resolver that drops an entry used to flow into a
-// `resolutions[i]!` non-null assertion and silently pair the wrong resolved
-// spans with the wrong trace summary. Drive a NON-CONFORMING resolver through
-// the real service and observe the failure, rather than asserting on a string.
+// ResolveTraceSpansBatchFn is INJECTED and ResolvedTraceSpans carries no trace
+// identity, so the pairing is purely positional and the type cannot enforce it.
+// Two distinct ways to break it, and the ORDER one is the dangerous half: it
+// keeps the count, so a length-only guard waves it through and each trace's IO
+// is scattered onto its neighbour. Drive genuinely non-conforming resolvers
+// through the REAL service and observe the failure, rather than asserting on a
+// string.
 // ---------------------------------------------------------------------------
 
-describe("ClickHouseTraceService — batch-resolver cardinality contract", () => {
-  /** Service wired with a batch resolver that drops every resolution. */
-  function buildServiceWithDroppingBatchResolver(): ClickHouseTraceService {
+describe("ClickHouseTraceService — batch-resolver contract", () => {
+  /** Service wired with a batch resolver of the caller's choosing. */
+  function buildServiceWithBatchResolver(
+    resolve: (
+      projectId: string,
+      spansPerTrace: NormalizedSpan[][],
+    ) => Promise<ResolvedTraceSpans[]>,
+  ): ClickHouseTraceService {
     return new ClickHouseTraceService(
       { project: { findUnique: vi.fn() } } as never,
       undefined,
-      // Violates the contract: returns 0 resolutions for N input traces.
-      () => Promise.resolve([]),
+      resolve,
     );
   }
 
-  describe("given an injected batch resolver that returns fewer resolutions than input traces", () => {
+  /** Passthrough resolution for a trace's spans (resolves nothing). */
+  function passthrough(spans: NormalizedSpan[]): ResolvedTraceSpans {
+    return {
+      resolvedSpans: spans,
+      recomputedInput: null,
+      recomputedOutput: null,
+      anyResolved: false,
+    };
+  }
+
+  describe("given a resolver that returns FEWER resolutions than input traces", () => {
     describe("when a resolveBlobs read runs", () => {
-      it("throws a descriptive error naming the mismatch", async () => {
+      it("throws naming the cardinality mismatch", async () => {
         setupThreadMocks();
-        const service = buildServiceWithDroppingBatchResolver();
+        // Violates the contract: 0 resolutions for 1 input trace.
+        const service = buildServiceWithBatchResolver(() =>
+          Promise.resolve([]),
+        );
 
         await expect(
           service.getTracesByThreadId(PROJECT_ID, "thread-1", protections, {
             resolveBlobs: true,
           }),
         ).rejects.toThrow(/returned 0 resolution\(s\) for 1 trace\(s\)/);
+      });
+    });
+  });
+
+  describe("given a resolver that returns the right COUNT in the WRONG ORDER", () => {
+    const TRACE_A = "trace-a";
+    const TRACE_B = "trace-b";
+
+    /** Two traces, each with one span — mocked for a direct getTracesWithSpans read. */
+    function setupTwoTraceMocks() {
+      mockClickHouseQuery
+        // fetchTracesWithSpansJoined: summary rows
+        .mockResolvedValueOnce({
+          json: () =>
+            Promise.resolve([makeSummaryRow(TRACE_A), makeSummaryRow(TRACE_B)]),
+        })
+        // fetchTracesWithSpansJoined: span rows
+        .mockResolvedValueOnce({
+          json: () =>
+            Promise.resolve([
+              makeSpanRowWithEventRef(TRACE_A, "span-a", {
+                tenantId: PROJECT_ID,
+                previewOutput: PREVIEW_OUTPUT,
+              }),
+              makeSpanRowWithEventRef(TRACE_B, "span-b", {
+                tenantId: PROJECT_ID,
+                previewOutput: PREVIEW_OUTPUT,
+              }),
+            ]),
+        });
+    }
+
+    describe("when a resolveBlobs read runs", () => {
+      it("throws naming the misaligned trace, instead of scattering each trace's IO onto its neighbour", async () => {
+        setupTwoTraceMocks();
+        const service = buildServiceWithBatchResolver((_projectId, spans) =>
+          // Right count (2 for 2), reversed order — the silent-corruption case
+          // a length-only guard cannot see.
+          Promise.resolve([...spans].reverse().map(passthrough)),
+        );
+
+        await expect(
+          service.getTracesWithSpans(
+            PROJECT_ID,
+            [TRACE_A, TRACE_B],
+            protections,
+            { from: 0, to: Date.now() },
+            { resolveBlobs: true },
+          ),
+        ).rejects.toThrow(/resolutions must come back in input order/);
+      });
+    });
+  });
+
+  describe("given a CONFORMING resolver", () => {
+    describe("when a resolveBlobs read runs", () => {
+      it("passes the contract check and returns the traces", async () => {
+        setupThreadMocks();
+        const service = buildServiceWithBatchResolver((_projectId, spans) =>
+          Promise.resolve(spans.map(passthrough)),
+        );
+
+        const traces = await service.getTracesByThreadId(
+          PROJECT_ID,
+          "thread-1",
+          protections,
+          { resolveBlobs: true },
+        );
+
+        expect(traces.map((t) => t.trace_id)).toEqual([TRACE_ID]);
       });
     });
   });

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -439,6 +439,56 @@ describe("ClickHouseTraceService — batch-resolver contract", () => {
 });
 
 // ---------------------------------------------------------------------------
+// AC1 — a SUMMARY read (no spans emitted) still resolves trace-level IO
+//
+// The bug this guards: resolution lives inside enrichTracesWithSpans, which used
+// to run only `if (options.includeSpans)`. A summary export / spans-less download
+// sets includeSpans=false, so resolveBlobs was never even READ — the flag was
+// inert and the truncated 64 KB preview shipped anyway. Setting resolveBlobs:true
+// at the call sites (ExportService, getAllForDownload) fixed nothing on its own;
+// a router-level test asserting the flag is FORWARDED cannot see that, because it
+// passes whether or not the flag has any runtime effect. This test reads through
+// the REAL service and asserts the VALUE.
+// ---------------------------------------------------------------------------
+
+describe("ClickHouseTraceService.getAllTracesForProject — #4991 AC1 summary read", () => {
+  describe("given a >64 KB offloaded trace and resolveBlobs WITHOUT includeSpans", () => {
+    describe("when a summary export / spans-less download reads it", () => {
+      it("resolves the trace-level output to the FULL value, not the preview", async () => {
+        setupGetAllWithSpansMocks();
+        const { blobStore, getFromEventLog } = makeEventRefBlobStore();
+        const service = buildService(blobStore);
+
+        const result = await service.getAllTracesForProject(
+          baseInput,
+          protections,
+          { includeSpans: false, resolveBlobs: true },
+        );
+
+        const trace = result!.groups.flat()[0]!;
+        expect(getFromEventLog).toHaveBeenCalled();
+        expect(trace.output?.value).toBe(FULL_OUTPUT);
+      });
+
+      it("emits no spans (the caller asked for a summary)", async () => {
+        setupGetAllWithSpansMocks();
+        const { blobStore } = makeEventRefBlobStore();
+        const service = buildService(blobStore);
+
+        const result = await service.getAllTracesForProject(
+          baseInput,
+          protections,
+          { includeSpans: false, resolveBlobs: true },
+        );
+
+        const trace = result!.groups.flat()[0]!;
+        expect(trace.spans ?? []).toEqual([]);
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AC5 — list/search grid keeps preview, ZERO event_log reads
 // ---------------------------------------------------------------------------
 

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -439,6 +439,64 @@ describe("ClickHouseTraceService — batch-resolver contract", () => {
 });
 
 // ---------------------------------------------------------------------------
+// getTracesByThreadId's chronological ordering is a CONTRACT, not an incident.
+//
+// The underlying bulk read returns trace-id order; this method re-sorts. The
+// public-share branch of the tRPC thread route re-projects its authorized subset
+// onto that order rather than re-deriving one — so if this sort were dropped, the
+// anonymous (least-exercised) path would silently mis-order and the router's own
+// tests, which mock this service, would not notice. Pin it here, at the seam that
+// owns it.
+// ---------------------------------------------------------------------------
+
+describe("ClickHouseTraceService.getTracesByThreadId — ordering contract", () => {
+  describe("given a thread whose traces come back from the bulk read out of order", () => {
+    describe("when the thread is read", () => {
+      it("returns traces sorted chronologically", async () => {
+        const EARLY = "trace-early";
+        const LATE = "trace-late";
+
+        mockClickHouseQuery
+          // SELECT DISTINCT TraceId
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve([{ TraceId: LATE }, { TraceId: EARLY }]),
+          })
+          // resolveOccurredAtRange (hint-less thread read)
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve([
+                { fromMs: 1_700_000_000_000, toMs: 1_700_000_100_000 },
+              ]),
+          })
+          // joined summary rows — deliberately LATE first, as a trace-id-ordered
+          // read may well return them.
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve([
+                makeSummaryRow(LATE, { occurredAt: 1_700_000_090_000 }),
+                makeSummaryRow(EARLY, { occurredAt: 1_700_000_010_000 }),
+              ]),
+          })
+          // joined span rows
+          .mockResolvedValueOnce({ json: () => Promise.resolve([]) });
+
+        const { blobStore } = makeEventRefBlobStore();
+        const service = buildService(blobStore);
+
+        const traces = await service.getTracesByThreadId(
+          PROJECT_ID,
+          "thread-1",
+          protections,
+        );
+
+        expect(traces.map((t) => t.trace_id)).toEqual([EARLY, LATE]);
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AC1 — a SUMMARY read (no spans emitted) still resolves trace-level IO
 //
 // The bug this guards: resolution lives inside enrichTracesWithSpans, which used

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -367,6 +367,53 @@ describe("ClickHouseTraceService — batch-resolver contract", () => {
           ),
         ).rejects.toThrow(/resolutions must come back in input order/);
       });
+
+      // The identity check has a blind spot, and this is it. A trace can
+      // legitimately have ZERO spans — the read builds its map from summary rows
+      // and defaults spans to [] — and a span-less trace has no traceId on
+      // EITHER side to compare. Swap it with a spans-ful trace and identity sees
+      // nothing at either index, while the real trace silently loses its spans.
+      // Only the span-count check catches this.
+      it("catches a swap with a span-less trace, which has no identity on either side", async () => {
+        // Two summary rows, but span rows for TRACE_A only — so TRACE_B enters
+        // the resolver with an empty spans array, exactly as production would.
+        mockClickHouseQuery
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve([
+                makeSummaryRow(TRACE_A),
+                makeSummaryRow(TRACE_B),
+              ]),
+          })
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve([
+                makeSpanRowWithEventRef(TRACE_A, "span-a", {
+                  tenantId: PROJECT_ID,
+                  previewOutput: PREVIEW_OUTPUT,
+                }),
+              ]),
+          });
+
+        const service = buildServiceWithBatchResolver((_projectId, spans) =>
+          // Right count (2 for 2), transposed: TRACE_A's index gets the span-less
+          // resolution, TRACE_B's index gets TRACE_A's spans.
+          Promise.resolve([
+            passthrough(spans[1] ?? []),
+            passthrough(spans[0] ?? []),
+          ]),
+        );
+
+        await expect(
+          service.getTracesWithSpans(
+            PROJECT_ID,
+            [TRACE_A, TRACE_B],
+            protections,
+            { from: 0, to: Date.now() },
+            { resolveBlobs: true },
+          ),
+        ).rejects.toThrow(/resolutions must come back in input order/);
+      });
     });
   });
 

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-4991-bulk.unit.test.ts
@@ -249,6 +249,43 @@ describe("ClickHouseTraceService.getAllTracesForProject — #4991 AC1 export", (
 });
 
 // ---------------------------------------------------------------------------
+// Batch-resolver contract — one resolution per input trace, in input order
+//
+// ResolveTraceSpansBatchFn is INJECTED, so the 1:1 invariant is a convention its
+// type cannot enforce. A resolver that drops an entry used to flow into a
+// `resolutions[i]!` non-null assertion and silently pair the wrong resolved
+// spans with the wrong trace summary. Drive a NON-CONFORMING resolver through
+// the real service and observe the failure, rather than asserting on a string.
+// ---------------------------------------------------------------------------
+
+describe("ClickHouseTraceService — batch-resolver cardinality contract", () => {
+  /** Service wired with a batch resolver that drops every resolution. */
+  function buildServiceWithDroppingBatchResolver(): ClickHouseTraceService {
+    return new ClickHouseTraceService(
+      { project: { findUnique: vi.fn() } } as never,
+      undefined,
+      // Violates the contract: returns 0 resolutions for N input traces.
+      () => Promise.resolve([]),
+    );
+  }
+
+  describe("given an injected batch resolver that returns fewer resolutions than input traces", () => {
+    describe("when a resolveBlobs read runs", () => {
+      it("throws a descriptive error naming the mismatch", async () => {
+        setupThreadMocks();
+        const service = buildServiceWithDroppingBatchResolver();
+
+        await expect(
+          service.getTracesByThreadId(PROJECT_ID, "thread-1", protections, {
+            resolveBlobs: true,
+          }),
+        ).rejects.toThrow(/returned 0 resolution\(s\) for 1 trace\(s\)/);
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AC5 — list/search grid keeps preview, ZERO event_log reads
 // ---------------------------------------------------------------------------
 

--- a/langwatch/src/server/traces/__tests__/fixtures/ch-row-fixtures.ts
+++ b/langwatch/src/server/traces/__tests__/fixtures/ch-row-fixtures.ts
@@ -19,6 +19,8 @@ import { EVENTREF_ATTR_PREFIX } from "~/server/app-layer/traces/lean-for-project
 export interface SummaryRowOpts {
   /** Override the serialized ts_ComputedOutput JSON string. */
   computedOutput?: string;
+  /** Override ts_OccurredAt (epoch ms) — this maps to `timestamps.started_at`. */
+  occurredAt?: number;
 }
 
 /**
@@ -54,7 +56,7 @@ export function makeSummaryRow(traceId: string, opts?: SummaryRowOpts) {
     ts_AnnotationIds: [],
     ts_Attributes: {},
     ts_TraceName: null,
-    ts_OccurredAt: Date.now(),
+    ts_OccurredAt: opts?.occurredAt ?? Date.now(),
     ts_CreatedAt: Date.now(),
     ts_UpdatedAt: Date.now(),
   };

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -61,6 +61,19 @@ export type ResolveTraceSpansFn = (
 ) => Promise<ResolvedTraceSpans>;
 
 /**
+ * Callback injected from TraceService that resolves offloaded blob refs for a
+ * WHOLE result set of traces in one bounded pass (#4991 bulk read paths). When
+ * present, the bulk read methods (getTracesWithSpans, enrichTracesWithSpans on
+ * the download path) use it so a large export/thread streams its event_log
+ * reads instead of fanning out an unbounded N×M burst. Falls back to the
+ * per-trace {@link ResolveTraceSpansFn} when absent.
+ */
+export type ResolveTraceSpansBatchFn = (
+  projectId: string,
+  spansPerTrace: NormalizedSpan[][],
+) => Promise<ResolvedTraceSpans[]>;
+
+/**
  * Cursor structure for keyset pagination.
  * Encoded as base64 JSON in the scrollId.
  */
@@ -237,11 +250,21 @@ export class ClickHouseTraceService {
    */
   private readonly resolveTraceSpans: ResolveTraceSpansFn | undefined;
 
+  /**
+   * Optional bulk resolver for whole result sets (#4991). Preferred over
+   * {@link resolveTraceSpans} on the bulk read paths so a large export/thread
+   * resolves its blobs in one bounded-concurrency pass. When absent, the bulk
+   * paths fall back to the per-trace resolver.
+   */
+  private readonly resolveTraceSpansBatch: ResolveTraceSpansBatchFn | undefined;
+
   constructor(
     private readonly prisma: PrismaClient,
     resolveTraceSpans?: ResolveTraceSpansFn,
+    resolveTraceSpansBatch?: ResolveTraceSpansBatchFn,
   ) {
     this.resolveTraceSpans = resolveTraceSpans;
+    this.resolveTraceSpansBatch = resolveTraceSpansBatch;
   }
 
   /**
@@ -269,8 +292,13 @@ export class ClickHouseTraceService {
   static create(
     prisma: PrismaClient = defaultPrisma,
     resolveTraceSpans?: ResolveTraceSpansFn,
+    resolveTraceSpansBatch?: ResolveTraceSpansBatchFn,
   ): ClickHouseTraceService {
-    return new ClickHouseTraceService(prisma, resolveTraceSpans);
+    return new ClickHouseTraceService(
+      prisma,
+      resolveTraceSpans,
+      resolveTraceSpansBatch,
+    );
   }
 
   /**
@@ -325,18 +353,15 @@ export class ClickHouseTraceService {
             occurredAt,
           );
 
-          // Map to legacy Trace format and apply protections
-          const traces: Trace[] = [];
-          for (const [_traceId, { summary, spans }] of tracesWithSpans) {
-            const trace = await this.resolveAndMerge({
-              projectId,
-              summary,
-              spans,
-              protections,
-              resolveBlobs: opts?.resolveBlobs,
-            });
-            traces.push(trace);
-          }
+          // Map to legacy Trace format and apply protections. Blob resolution
+          // (when opted in) runs as a single bounded pass over the whole set so
+          // a large multi-trace read streams its event_log reads (#4991 AC6).
+          const traces = await this.resolveAndMergeMany({
+            projectId,
+            entries: [...tracesWithSpans.values()],
+            protections,
+            resolveBlobs: opts?.resolveBlobs,
+          });
 
           this.logger.debug(
             { projectId, traceCount: traces.length },
@@ -441,14 +466,18 @@ export class ClickHouseTraceService {
    * @param projectId - The project ID
    * @param threadId - The thread ID to search for
    * @param protections - Field redaction protections
-   * @returns Array of Trace objects
+   * @param opts.resolveBlobs - Forwarded to the per-trace fetch so the
+   *   thread-detail read resolves full IO (#4991). Customer thread views that
+   *   construct without a blob resolver get a no-op. Defaults to false.
+   * @returns Array of Trace objects, or null if ClickHouse is not enabled
    * @throws ClickHouseClientUnavailableError when no ClickHouse client resolves
    */
   async getTracesByThreadId(
     projectId: string,
     threadId: string,
     protections: Protections,
-  ): Promise<Trace[]> {
+    opts?: { resolveBlobs?: boolean },
+  ): Promise<Trace[] | null> {
     return await this.tracer.withActiveSpan(
       "ClickHouseTraceService.getTracesByThreadId",
       {
@@ -488,11 +517,15 @@ export class ClickHouseTraceService {
             return [];
           }
 
-          // Fetch full traces with spans
+          // Fetch full traces with spans. Forward resolveBlobs so the
+          // thread-detail read can resolve full IO (#4991); customer thread
+          // views with no resolver wired stay on the preview.
           const traces = await this.getTracesWithSpans(
             projectId,
             traceIds,
             protections,
+            undefined,
+            { resolveBlobs: opts?.resolveBlobs },
           );
 
           // Re-sort by timestamp — getTracesWithSpans returns in TraceId
@@ -764,12 +797,16 @@ export class ClickHouseTraceService {
               dateField,
             });
 
-          // When includeSpans is requested, fetch and attach actual spans
+          // When includeSpans is requested, fetch and attach actual spans.
+          // resolveBlobs is opt-in (download/export — #4991 AC1) so the
+          // list/search grid stays on the preview with zero event_log reads
+          // (#4888 AC2 / ADR-022 — AC5).
           if (options.includeSpans && traces.length > 0) {
             traces = await this.enrichTracesWithSpans(
               traces,
               input.projectId,
               protections,
+              options.resolveBlobs === true,
             );
           }
 
@@ -2240,39 +2277,105 @@ export class ClickHouseTraceService {
    *
    * @internal
    */
-  private async resolveAndMerge({
+  private async resolveAndMergeMany({
     projectId,
-    summary,
-    spans,
+    entries,
     protections,
     resolveBlobs,
   }: {
     projectId: string;
-    summary: TraceSummaryData;
-    spans: NormalizedSpan[];
+    entries: Array<{ summary: TraceSummaryData; spans: NormalizedSpan[] }>;
     protections: Protections;
     /**
-     * Per-call gate (#4888): resolve offloaded eventref pointers from event_log
-     * ONLY when true. The resolver is constructed on the instance, but the read
-     * path opts in per call so list/search/collapsed reads keep the preview and
-     * issue zero event_log SELECTs (ADR-022). Defaults to false.
+     * Per-call gate (#4888/#4991): resolve offloaded eventref pointers from
+     * event_log ONLY when true. The resolver is constructed on the instance,
+     * but the read path opts in per call so list/search/collapsed reads keep
+     * the preview and issue zero event_log SELECTs (ADR-022). Defaults to false.
      */
     resolveBlobs?: boolean;
-  }): Promise<Trace> {
-    let resolvedSpans = spans;
-    let recomputedInput: ExtractedIO | null = null;
-    let recomputedOutput: ExtractedIO | null = null;
+  }): Promise<Trace[]> {
+    const resolutions = await this.resolveSpansBatch({
+      projectId,
+      spansPerTrace: entries.map((e) => e.spans),
+      resolveBlobs,
+    });
 
-    if (resolveBlobs === true && this.resolveTraceSpans) {
-      const resolution = await this.resolveTraceSpans(projectId, spans);
-      resolvedSpans = resolution.resolvedSpans;
-      if (resolution.anyResolved) {
-        recomputedInput = resolution.recomputedInput;
-        recomputedOutput = resolution.recomputedOutput;
-      }
+    return entries.map((entry, i) =>
+      this.mergeResolvedTrace({
+        projectId,
+        summary: entry.summary,
+        resolution: resolutions[i]!,
+        protections,
+      }),
+    );
+  }
+
+  /**
+   * Resolve offloaded blob refs for a set of traces' spans, in one pass.
+   *
+   * Prefers the bulk {@link resolveTraceSpansBatch} (single bounded-concurrency
+   * sweep over event_log — #4991 AC6); falls back to the per-trace resolver
+   * when only that is wired (e.g. a CH service constructed with just the
+   * single-trace callback). When `resolveBlobs` is not true, returns
+   * passthrough resolutions (preview preserved, zero event_log reads — AC5).
+   *
+   * @internal
+   */
+  private async resolveSpansBatch({
+    projectId,
+    spansPerTrace,
+    resolveBlobs,
+  }: {
+    projectId: string;
+    spansPerTrace: NormalizedSpan[][];
+    resolveBlobs?: boolean;
+  }): Promise<ResolvedTraceSpans[]> {
+    if (resolveBlobs === true && this.resolveTraceSpansBatch) {
+      return this.resolveTraceSpansBatch(projectId, spansPerTrace);
     }
 
-    const mappedSpans = mapNormalizedSpansToSpans(resolvedSpans);
+    if (resolveBlobs === true && this.resolveTraceSpans) {
+      const resolutions: ResolvedTraceSpans[] = [];
+      for (const spans of spansPerTrace) {
+        resolutions.push(await this.resolveTraceSpans(projectId, spans));
+      }
+      return resolutions;
+    }
+
+    // No resolution opted in (or no resolver wired): keep the preview.
+    return spansPerTrace.map((spans) => ({
+      resolvedSpans: spans,
+      recomputedInput: null,
+      recomputedOutput: null,
+      anyResolved: false,
+    }));
+  }
+
+  /**
+   * Map one trace's resolved spans to the legacy Trace, patch recomputed I/O
+   * (when blobs were resolved), and apply field-redaction protections.
+   *
+   * @internal
+   */
+  private mergeResolvedTrace({
+    projectId,
+    summary,
+    resolution,
+    protections,
+  }: {
+    projectId: string;
+    summary: TraceSummaryData;
+    resolution: ResolvedTraceSpans;
+    protections: Protections;
+  }): Trace {
+    const recomputedInput: ExtractedIO | null = resolution.anyResolved
+      ? resolution.recomputedInput
+      : null;
+    const recomputedOutput: ExtractedIO | null = resolution.anyResolved
+      ? resolution.recomputedOutput
+      : null;
+
+    const mappedSpans = mapNormalizedSpansToSpans(resolution.resolvedSpans);
     let trace = mapTraceSummaryToTrace(summary, mappedSpans, projectId);
 
     // When blobs were resolved, patch trace.input / trace.output with
@@ -2305,6 +2408,7 @@ export class ClickHouseTraceService {
     traces: Trace[],
     projectId: string,
     protections: Protections,
+    resolveBlobs = false,
   ): Promise<Trace[]> {
     const traceIds = traces.map((t) => t.trace_id);
     // The traces already carry their own timestamps, so derive the partition
@@ -2323,25 +2427,39 @@ export class ClickHouseTraceService {
       occurredAt,
     );
 
-    return Promise.all(
-      traces.map(async (trace) => {
-        const data = tracesWithSpans.get(trace.trace_id);
-        if (!data || data.spans.length === 0) {
-          return trace;
-        }
+    // Collect the traces that actually have spans, resolve+merge them as one
+    // bounded batch (#4991 AC6), then splice the results back in order. Traces
+    // whose spans are not found pass through unchanged.
+    //
+    // resolveBlobs is gated by the CALLER: the list/search grid leaves it false
+    // so it keeps the ≤64 KB preview and issues zero event_log SELECTs (#4888
+    // AC2 / ADR-022). Only the download/export path opts in (#4991 AC1).
+    const enrichable = traces
+      .map((trace, index) => ({ index, data: tracesWithSpans.get(trace.trace_id) }))
+      .filter(
+        (
+          e,
+        ): e is {
+          index: number;
+          data: { summary: TraceSummaryData; spans: NormalizedSpan[] };
+        } => !!e.data && e.data.spans.length > 0,
+      );
 
-        // List/search path (getAllTracesForProject): NEVER resolve blobs, even
-        // on a deps-carrying instance — keep the ≤64 KB preview and issue zero
-        // event_log SELECTs (#4888 AC2 / ADR-022 binding constraint).
-        return this.resolveAndMerge({
-          projectId,
-          summary: data.summary,
-          spans: data.spans,
-          protections,
-          resolveBlobs: false,
-        });
-      }),
-    );
+    const merged = await this.resolveAndMergeMany({
+      projectId,
+      entries: enrichable.map((e) => ({
+        summary: e.data.summary,
+        spans: e.data.spans,
+      })),
+      protections,
+      resolveBlobs,
+    });
+
+    const result = [...traces];
+    enrichable.forEach((e, i) => {
+      result[e.index] = merged[i]!;
+    });
+    return result;
   }
 
   /**

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -232,20 +232,48 @@ export class ClickHouseClientUnavailableError extends Error {
 
 /**
  * Thrown when an injected {@link ResolveTraceSpansBatchFn} breaks its contract by
- * not returning exactly one resolution per input trace, in input order. The type
- * cannot enforce that invariant, so it is enforced at the call boundary. Never
- * caused by data — always a resolver (or test-double) bug.
+ * not returning exactly one resolution per input trace, in input order.
+ * `ResolvedTraceSpans` carries no trace identity of its own, so the pairing is
+ * purely positional and the type cannot enforce it — it is enforced at the call
+ * boundary instead. Never caused by data; always a resolver (or test-double) bug.
  *
- * Like {@link ClickHouseClientUnavailableError}, the read paths' generic
- * try/catch re-throws this UNWRAPPED, so the mismatch reaches the caller instead
- * of being flattened into "Failed to fetch traces from ClickHouse".
+ * The read paths flatten failures into a generic "Failed to fetch traces…"; both
+ * of them allowlist this class by `instanceof` and re-throw it unwrapped, so a
+ * contract violation reaches the caller with the mismatch intact rather than
+ * masquerading as a ClickHouse fetch failure.
  */
-export class TraceSpansBatchCardinalityError extends Error {
-  constructor({ got, expected }: { got: number; expected: number }) {
-    super(
+export class TraceSpansBatchResolverContractError extends Error {
+  private constructor(message: string) {
+    super(message);
+    this.name = "TraceSpansBatchResolverContractError";
+  }
+
+  /** Wrong number of resolutions — entries were dropped or invented. */
+  static cardinality({
+    got,
+    expected,
+  }: {
+    got: number;
+    expected: number;
+  }): TraceSpansBatchResolverContractError {
+    return new TraceSpansBatchResolverContractError(
       `resolveTraceSpansBatch returned ${got} resolution(s) for ${expected} trace(s); it must return exactly one per input trace, in input order`,
     );
-    this.name = "TraceSpansBatchCardinalityError";
+  }
+
+  /** Right count, wrong order — the silent-corruption case. */
+  static misaligned({
+    index,
+    expected,
+    got,
+  }: {
+    index: number;
+    expected: string;
+    got: string;
+  }): TraceSpansBatchResolverContractError {
+    return new TraceSpansBatchResolverContractError(
+      `resolveTraceSpansBatch returned a resolution for trace "${got}" at position ${index}, where trace "${expected}" was supplied; resolutions must come back in input order`,
+    );
   }
 }
 
@@ -392,7 +420,8 @@ export class ClickHouseTraceService {
           // A resolver-contract violation is a code bug, not a fetch failure —
           // surface it verbatim rather than flattening it into the generic
           // message and losing the mismatch.
-          if (error instanceof TraceSpansBatchCardinalityError) throw error;
+          if (error instanceof TraceSpansBatchResolverContractError)
+            throw error;
           this.logger.error(
             {
               projectId,
@@ -561,7 +590,8 @@ export class ClickHouseTraceService {
         } catch (error) {
           // See getTracesWithSpans: a resolver-contract violation is a code bug,
           // not a fetch failure — surface it verbatim.
-          if (error instanceof TraceSpansBatchCardinalityError) throw error;
+          if (error instanceof TraceSpansBatchResolverContractError)
+            throw error;
           this.logger.error(
             {
               projectId,
@@ -662,6 +692,13 @@ export class ClickHouseTraceService {
           );
           return traces;
         } catch (error) {
+          // Third flattening catch on this class, and it sits ABOVE
+          // getTracesWithSpans — so a contract violation re-thrown unwrapped by
+          // that method lands here and would be flattened again. Allowlist it,
+          // same as the other two. (Live path: called with resolveBlobs from the
+          // thread router and the evaluation-execution service.)
+          if (error instanceof TraceSpansBatchResolverContractError)
+            throw error;
           this.logger.error(
             {
               projectId,
@@ -2372,10 +2409,28 @@ export class ClickHouseTraceService {
       // letting a downstream non-null assertion crash with no context (or not
       // crash at all, and just scatter the wrong IO onto the wrong span).
       if (resolutions.length !== spansPerTrace.length) {
-        throw new TraceSpansBatchCardinalityError({
+        throw TraceSpansBatchResolverContractError.cardinality({
           got: resolutions.length,
           expected: spansPerTrace.length,
         });
+      }
+
+      // Cardinality alone does NOT catch the silent-corruption case: a resolver
+      // that returns the right COUNT in the wrong ORDER scatters each trace's IO
+      // onto its neighbour. Resolved spans are derived from the input spans, so
+      // they carry the trace identity the resolution itself lacks — use it to
+      // check the positional pairing actually holds. A trace with no spans has
+      // no identity to compare, so it is skipped rather than guessed at.
+      for (const [index, spans] of spansPerTrace.entries()) {
+        const expected = spans[0]?.traceId;
+        const got = resolutions[index]?.resolvedSpans[0]?.traceId;
+        if (expected !== undefined && got !== undefined && expected !== got) {
+          throw TraceSpansBatchResolverContractError.misaligned({
+            index,
+            expected,
+            got,
+          });
+        }
       }
 
       return resolutions;

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -469,7 +469,7 @@ export class ClickHouseTraceService {
    * @param opts.resolveBlobs - Forwarded to the per-trace fetch so the
    *   thread-detail read resolves full IO (#4991). Customer thread views that
    *   construct without a blob resolver get a no-op. Defaults to false.
-   * @returns Array of Trace objects, or null if ClickHouse is not enabled
+   * @returns Array of Trace objects (empty array if no matching traces found)
    * @throws ClickHouseClientUnavailableError when no ClickHouse client resolves
    */
   async getTracesByThreadId(
@@ -477,7 +477,7 @@ export class ClickHouseTraceService {
     threadId: string,
     protections: Protections,
     opts?: { resolveBlobs?: boolean },
-  ): Promise<Trace[] | null> {
+  ): Promise<Trace[]> {
     return await this.tracer.withActiveSpan(
       "ClickHouseTraceService.getTracesByThreadId",
       {

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -860,17 +860,43 @@ export class ClickHouseTraceService {
               dateField,
             });
 
-          // When includeSpans is requested, fetch and attach actual spans.
-          // resolveBlobs is opt-in (download/export — #4991 AC1) so the
-          // list/search grid stays on the preview with zero event_log reads
-          // (#4888 AC2 / ADR-022 — AC5).
-          if (options.includeSpans && traces.length > 0) {
-            traces = await this.enrichTracesWithSpans(
+          // Spans are fetched when the caller wants them OR when it wants full
+          // IO — because those are not the same thing.
+          //
+          // Blob resolution lives inside the span read: the full (>64 KB) value
+          // is recoverable ONLY by de-offloading the spans' eventref pointers
+          // and recomputing trace IO from them. trace_summaries holds nothing
+          // but the 64 KB preview. So a content-consuming SUMMARY read — a
+          // summary-mode export, a spans-less download — must still fetch and
+          // resolve spans, then throw them away.
+          //
+          // Gating the fetch on includeSpans alone (as this did) made
+          // resolveBlobs INERT for exactly those callers: the flag was set, no
+          // event_log read was ever issued, and the truncated preview shipped
+          // silently. That is #4991 AC1's bug, surviving on the paths the fix
+          // was supposed to cover.
+          //
+          // resolveBlobs stays opt-in, so the list/search grid and the
+          // aggregations still issue ZERO event_log reads (#4888 AC2 /
+          // ADR-022 — AC5): they never ask for full IO, so nothing resolves,
+          // whether or not they ask for spans.
+          const wantsSpans = options.includeSpans === true;
+          const wantsFullIo = options.resolveBlobs === true;
+
+          if ((wantsSpans || wantsFullIo) && traces.length > 0) {
+            const enriched = await this.enrichTracesWithSpans(
               traces,
               input.projectId,
               protections,
-              options.resolveBlobs === true,
+              wantsFullIo,
             );
+
+            // A summary caller keeps the recomputed trace-level IO but not the
+            // spans it never asked for — the payload shape stays exactly as it
+            // was before this branch could run for them.
+            traces = wantsSpans
+              ? enriched
+              : enriched.map((trace) => ({ ...trace, spans: [] }));
           }
 
           // Generate new scrollId from last trace. The cursor seeks on the

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -2435,7 +2435,10 @@ export class ClickHouseTraceService {
     // so it keeps the ≤64 KB preview and issues zero event_log SELECTs (#4888
     // AC2 / ADR-022). Only the download/export path opts in (#4991 AC1).
     const enrichable = traces
-      .map((trace, index) => ({ index, data: tracesWithSpans.get(trace.trace_id) }))
+      .map((trace, index) => ({
+        index,
+        data: tracesWithSpans.get(trace.trace_id),
+      }))
       .filter(
         (
           e,

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -261,7 +261,7 @@ export class TraceSpansBatchResolverContractError extends Error {
     );
   }
 
-  /** Right count, wrong order — the silent-corruption case. */
+  /** Right count, wrong pairing — the silent-corruption case. */
   static misaligned({
     index,
     expected,
@@ -272,7 +272,7 @@ export class TraceSpansBatchResolverContractError extends Error {
     got: string;
   }): TraceSpansBatchResolverContractError {
     return new TraceSpansBatchResolverContractError(
-      `resolveTraceSpansBatch returned a resolution for trace "${got}" at position ${index}, where trace "${expected}" was supplied; resolutions must come back in input order`,
+      `resolveTraceSpansBatch returned ${got} at position ${index}, where ${expected} was supplied; resolutions must come back in input order`,
     );
   }
 }
@@ -2417,18 +2417,33 @@ export class ClickHouseTraceService {
 
       // Cardinality alone does NOT catch the silent-corruption case: a resolver
       // that returns the right COUNT in the wrong ORDER scatters each trace's IO
-      // onto its neighbour. Resolved spans are derived from the input spans, so
-      // they carry the trace identity the resolution itself lacks — use it to
-      // check the positional pairing actually holds. A trace with no spans has
-      // no identity to compare, so it is skipped rather than guessed at.
+      // onto its neighbour. Both resolvers derive resolvedSpans by mapping over
+      // the input spans, so a conforming resolution carries (a) the same span
+      // count and (b) the trace identity the ResolvedTraceSpans type itself
+      // lacks. Check both: a trace CAN legitimately have zero spans (the read
+      // builds its map from summary rows), and such a trace has no identity to
+      // compare — but the span count still catches it being swapped with a
+      // spans-ful one, which is the case that would otherwise silently strip a
+      // real trace's spans. Two span-less traces transposed stay invisible, and
+      // are harmless: their resolutions are empty and interchangeable.
       for (const [index, spans] of spansPerTrace.entries()) {
+        const resolution = resolutions[index];
+
+        if (resolution?.resolvedSpans.length !== spans.length) {
+          throw TraceSpansBatchResolverContractError.misaligned({
+            index,
+            expected: `${spans.length} span(s)${spans[0] ? ` for trace "${spans[0].traceId}"` : ""}`,
+            got: `${resolution?.resolvedSpans.length ?? 0} span(s)`,
+          });
+        }
+
         const expected = spans[0]?.traceId;
-        const got = resolutions[index]?.resolvedSpans[0]?.traceId;
+        const got = resolution.resolvedSpans[0]?.traceId;
         if (expected !== undefined && got !== undefined && expected !== got) {
           throw TraceSpansBatchResolverContractError.misaligned({
             index,
-            expected,
-            got,
+            expected: `trace "${expected}"`,
+            got: `trace "${got}"`,
           });
         }
       }

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -521,7 +521,16 @@ export class ClickHouseTraceService {
    * @param opts.resolveBlobs - Forwarded to the per-trace fetch so the
    *   thread-detail read resolves full IO (#4991). Customer thread views that
    *   construct without a blob resolver get a no-op. Defaults to false.
-   * @returns Array of Trace objects (empty array if no matching traces found)
+   * @returns Array of Trace objects, **sorted chronologically by
+   *   `timestamps.started_at` ascending** (empty array if no matching traces).
+   *   The ordering is part of this method's contract, not an incidental detail:
+   *   the underlying bulk read returns trace-id order, and callers rely on the
+   *   chronological order this restores. The public-share branch of the
+   *   `getTracesByThreadId` tRPC route re-projects its authorized subset onto
+   *   this order rather than re-deriving one, so dropping the sort here would
+   *   silently mis-order that (anonymous, least-exercised) path. Pinned by
+   *   "returns traces sorted chronologically" in
+   *   clickhouse-trace.service-4991-bulk.unit.test.ts.
    * @throws ClickHouseClientUnavailableError when no ClickHouse client resolves
    */
   async getTracesByThreadId(

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -231,6 +231,25 @@ export class ClickHouseClientUnavailableError extends Error {
 }
 
 /**
+ * Thrown when an injected {@link ResolveTraceSpansBatchFn} breaks its contract by
+ * not returning exactly one resolution per input trace, in input order. The type
+ * cannot enforce that invariant, so it is enforced at the call boundary. Never
+ * caused by data — always a resolver (or test-double) bug.
+ *
+ * Like {@link ClickHouseClientUnavailableError}, the read paths' generic
+ * try/catch re-throws this UNWRAPPED, so the mismatch reaches the caller instead
+ * of being flattened into "Failed to fetch traces from ClickHouse".
+ */
+export class TraceSpansBatchCardinalityError extends Error {
+  constructor({ got, expected }: { got: number; expected: number }) {
+    super(
+      `resolveTraceSpansBatch returned ${got} resolution(s) for ${expected} trace(s); it must return exactly one per input trace, in input order`,
+    );
+    this.name = "TraceSpansBatchCardinalityError";
+  }
+}
+
+/**
  * Service for fetching traces from ClickHouse.
  *
  * Fetches trace summaries and, when needed, span rows via separate ClickHouse
@@ -370,6 +389,10 @@ export class ClickHouseTraceService {
 
           return traces;
         } catch (error) {
+          // A resolver-contract violation is a code bug, not a fetch failure —
+          // surface it verbatim rather than flattening it into the generic
+          // message and losing the mismatch.
+          if (error instanceof TraceSpansBatchCardinalityError) throw error;
           this.logger.error(
             {
               projectId,
@@ -536,6 +559,9 @@ export class ClickHouseTraceService {
           );
           return traces;
         } catch (error) {
+          // See getTracesWithSpans: a resolver-contract violation is a code bug,
+          // not a fetch failure — surface it verbatim.
+          if (error instanceof TraceSpansBatchCardinalityError) throw error;
           this.logger.error(
             {
               projectId,
@@ -2331,7 +2357,28 @@ export class ClickHouseTraceService {
     resolveBlobs?: boolean;
   }): Promise<ResolvedTraceSpans[]> {
     if (resolveBlobs === true && this.resolveTraceSpansBatch) {
-      return this.resolveTraceSpansBatch(projectId, spansPerTrace);
+      const resolutions = await this.resolveTraceSpansBatch(
+        projectId,
+        spansPerTrace,
+      );
+
+      // ResolveTraceSpansBatchFn is INJECTED, so "one resolution per input
+      // trace, in input order" is a convention its type cannot enforce. Today's
+      // resolver honours it via .map, but a future resolver (or a test double)
+      // that drops or reorders entries would silently pair the wrong resolved
+      // spans with the wrong trace summary on this hot bulk-read path — shared
+      // by export, thread, and the dataset/sample builders. Fail loudly at the
+      // boundary, where the offending resolver is still nameable, instead of
+      // letting a downstream non-null assertion crash with no context (or not
+      // crash at all, and just scatter the wrong IO onto the wrong span).
+      if (resolutions.length !== spansPerTrace.length) {
+        throw new TraceSpansBatchCardinalityError({
+          got: resolutions.length,
+          expected: spansPerTrace.length,
+        });
+      }
+
+      return resolutions;
     }
 
     if (resolveBlobs === true && this.resolveTraceSpans) {

--- a/langwatch/src/server/traces/offloaded-eventref-parsing.ts
+++ b/langwatch/src/server/traces/offloaded-eventref-parsing.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared parsing of `langwatch.reserved.eventref.*` pointers off a span's flat
+ * spanAttributes (ADR-022 read path). Used by BOTH the per-trace resolver
+ * ({@link ./resolve-offloaded-traces}) and the bulk batch resolver
+ * ({@link ./resolve-offloaded-traces-batch}) so the eventref shape is decoded
+ * in exactly one place.
+ */
+import { EVENTREF_ATTR_PREFIX } from "~/server/app-layer/traces/lean-for-projection";
+
+/** One decoded eventref pointer ready to fetch from event_log. */
+export interface EventRefEntry {
+  /** The IO attribute key the resolved value belongs under (e.g. langwatch.output). */
+  attrKey: string;
+  /** The EventPayload field to extract (defaults to attrKey when absent). */
+  field: string;
+  /** The event_log EventId carrying the full value. */
+  eventId: string;
+}
+
+/** Result of splitting a span's attributes into preview attrs + eventref pointers. */
+export interface ParsedSpanEventRefs {
+  /** Non-reserved attributes (previews and regular attrs), reserved keys removed. */
+  cleanedAttrs: Record<string, string>;
+  /** Well-formed eventref pointers to resolve. */
+  eventrefEntries: EventRefEntry[];
+  /** attrKeys whose eventref carried no usable eventId — caller warns + keeps preview. */
+  missingEventIdKeys: string[];
+}
+
+/** True when the attribute map carries at least one eventref pointer. */
+export function hasEventRefs(attributes: Record<string, string>): boolean {
+  for (const key in attributes) {
+    if (key.startsWith(EVENTREF_ATTR_PREFIX)) return true;
+  }
+  return false;
+}
+
+/**
+ * Splits a span's flat attributes into the preview attributes (reserved keys
+ * stripped) and the well-formed eventref pointers to resolve.
+ *
+ * - A reserved key missing/empty `eventId` is recorded in `missingEventIdKeys`
+ *   (the caller logs a warning and keeps the preview) — never resolved.
+ * - A reserved key with malformed JSON is silently dropped (the preview already
+ *   sits in `cleanedAttrs` under the non-reserved IO key).
+ */
+export function parseSpanEventRefs(
+  attrs: Record<string, string>,
+): ParsedSpanEventRefs {
+  const cleanedAttrs: Record<string, string> = {};
+  const eventrefEntries: EventRefEntry[] = [];
+  const missingEventIdKeys: string[] = [];
+
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key.startsWith(EVENTREF_ATTR_PREFIX)) {
+      const attrKey = key.slice(EVENTREF_ATTR_PREFIX.length);
+      try {
+        const ref = JSON.parse(value) as { field?: string; eventId?: string };
+        if (typeof ref.eventId !== "string" || ref.eventId.length === 0) {
+          missingEventIdKeys.push(attrKey);
+          continue;
+        }
+        eventrefEntries.push({
+          attrKey,
+          field: ref.field ?? attrKey,
+          eventId: ref.eventId,
+        });
+      } catch {
+        // Malformed eventref JSON — skip; preview in cleanedAttrs is still shown.
+      }
+    } else {
+      cleanedAttrs[key] = value;
+    }
+  }
+
+  return { cleanedAttrs, eventrefEntries, missingEventIdKeys };
+}

--- a/langwatch/src/server/traces/offloaded-eventref-parsing.ts
+++ b/langwatch/src/server/traces/offloaded-eventref-parsing.ts
@@ -29,10 +29,9 @@ export interface ParsedSpanEventRefs {
 
 /** True when the attribute map carries at least one eventref pointer. */
 export function hasEventRefs(attributes: Record<string, string>): boolean {
-  for (const key in attributes) {
-    if (key.startsWith(EVENTREF_ATTR_PREFIX)) return true;
-  }
-  return false;
+  return Object.keys(attributes).some((key) =>
+    key.startsWith(EVENTREF_ATTR_PREFIX),
+  );
 }
 
 /**

--- a/langwatch/src/server/traces/resolve-offloaded-traces-batch.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces-batch.ts
@@ -27,11 +27,11 @@ import {
 } from "~/server/app-layer/traces/blob-store.service";
 import type { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
 import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
-import {
-  hasEventRefs,
-  parseSpanEventRefs,
-} from "./offloaded-eventref-parsing";
-import type { ResolvedTraceSpans, WarnLogger } from "./resolve-offloaded-traces";
+import { hasEventRefs, parseSpanEventRefs } from "./offloaded-eventref-parsing";
+import type {
+  ResolvedTraceSpans,
+  WarnLogger,
+} from "./resolve-offloaded-traces";
 
 /**
  * Maximum number of concurrent `event_log` reads in flight at once across an
@@ -60,12 +60,14 @@ interface SpanPlan {
 }
 
 /** Internal: outcome of a single event_log fetch. */
-type FetchResult =
-  | { ok: true; value: string }
-  | { ok: false; error: unknown };
+type FetchResult = { ok: true; value: string } | { ok: false; error: unknown };
 
 /** Builds the dedup key for a fetch task. NUL separator can't collide with ids. */
-function fetchKeyOf(aggregateId: string, eventId: string, field: string): string {
+function fetchKeyOf(
+  aggregateId: string,
+  eventId: string,
+  field: string,
+): string {
   return `${aggregateId}\u0000${eventId}\u0000${field}`;
 }
 

--- a/langwatch/src/server/traces/resolve-offloaded-traces-batch.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces-batch.ts
@@ -1,0 +1,255 @@
+/**
+ * Bulk read-path resolution of offloaded trace event refs (ADR-022, #4991).
+ *
+ * The per-trace {@link ./resolve-offloaded-traces#resolveOffloadedTraces} is the
+ * right tool for a single-trace detail read (#4984). The BULK consumers —
+ * export, thread, annotation queue, dataset/sample builders — read whole result
+ * sets, where resolving each trace independently would fan out an unbounded
+ * N×M burst of `event_log` SELECTs (one per offloaded field × every row),
+ * exhausting the ClickHouse connection pool on a large export.
+ *
+ * This module resolves a WHOLE result set in one pass:
+ *   1. Decode the eventref pointers off every span across every trace.
+ *   2. Dedupe identical `(aggregateId, eventId, field)` refs to one fetch.
+ *   3. Stream the `event_log` reads through a bounded-concurrency pool — peak
+ *      in-flight CH reads is a CONSTANT regardless of result-set size (AC6).
+ *   4. Scatter the resolved full values back onto each span, strip the reserved
+ *      eventref keys, and recompute trace-level IO per trace.
+ *
+ * Error policy (AC7): a missing/failed event_log row must NOT break the read —
+ * the affected field keeps its preview and a warning is logged; every other
+ * field and trace still resolves.
+ */
+import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
+import {
+  BlobFieldNotFoundError,
+  BlobNotFoundError,
+} from "~/server/app-layer/traces/blob-store.service";
+import type { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
+import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import {
+  hasEventRefs,
+  parseSpanEventRefs,
+} from "./offloaded-eventref-parsing";
+import type { ResolvedTraceSpans, WarnLogger } from "./resolve-offloaded-traces";
+
+/**
+ * Maximum number of concurrent `event_log` reads in flight at once across an
+ * entire result set. Bounds the bulk read path's load on ClickHouse so a large
+ * export/thread streams its blob fetches instead of firing all of them at once
+ * (#4991 AC6). Sized to keep the CH client's connection pool busy without
+ * saturating it.
+ */
+export const EVENT_LOG_RESOLVE_CONCURRENCY = 25;
+
+/** Internal: a single deduped event_log fetch task. */
+interface FetchTask {
+  eventId: string;
+  field: string;
+  aggregateId: string;
+}
+
+/** Internal: per-span plan built in the parse phase. */
+interface SpanPlan {
+  /** Preview/regular attributes with reserved keys removed. */
+  cleanedAttrs: Record<string, string>;
+  /** Which fetch key fills which attribute key. */
+  refs: Array<{ attrKey: string; fetchKey: string }>;
+  /** False when the span had no eventrefs (returned untouched). */
+  hadRefs: boolean;
+}
+
+/** Internal: outcome of a single event_log fetch. */
+type FetchResult =
+  | { ok: true; value: string }
+  | { ok: false; error: unknown };
+
+/** Builds the dedup key for a fetch task. NUL separator can't collide with ids. */
+function fetchKeyOf(aggregateId: string, eventId: string, field: string): string {
+  return `${aggregateId}\u0000${eventId}\u0000${field}`;
+}
+
+/**
+ * Runs `fn` over `items` with at most `concurrency` promises in flight, awaiting
+ * all of them. Order of execution is unconstrained; callers collect results via
+ * side effects (the resolver writes into a shared Map keyed by fetch key).
+ */
+async function forEachWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  const executing = new Set<Promise<void>>();
+  for (const item of items) {
+    const p = fn(item).then(() => {
+      executing.delete(p);
+    });
+    executing.add(p);
+    if (executing.size >= concurrency) {
+      await Promise.race(executing);
+    }
+  }
+  await Promise.all(executing);
+}
+
+/** Logs a per-field resolution failure at warn level (no silent truncation). */
+function warnResolutionFailure(
+  logger: WarnLogger,
+  projectId: string,
+  span: NormalizedSpan,
+  attrKey: string,
+  error: unknown,
+): void {
+  if (
+    error instanceof BlobNotFoundError ||
+    error instanceof BlobFieldNotFoundError
+  ) {
+    logger.warn(
+      {
+        projectId,
+        spanId: span.spanId,
+        traceId: span.traceId,
+        attrKey,
+        error: (error as Error).message,
+      },
+      "event_log row not found for eventref — keeping preview value",
+    );
+  } else {
+    logger.warn(
+      {
+        projectId,
+        spanId: span.spanId,
+        traceId: span.traceId,
+        attrKey,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Failed to resolve eventref from event_log — keeping preview value",
+    );
+  }
+}
+
+/**
+ * Resolves offloaded event refs for a whole result set of traces in one bounded
+ * pass. See the module doc for the algorithm and error policy.
+ *
+ * @param projectId - The tenantId / projectId all traces belong to.
+ * @param spansPerTrace - The NormalizedSpan array for each trace, in result order.
+ * @param blobStore - BlobStore providing getFromEventLog.
+ * @param ioExtractionService - Recomputes trace-level IO from resolved spans.
+ * @param logger - Logger for resolution-failure warnings.
+ * @param aggregateType - Aggregate type for event_log lookup (default: "trace").
+ * @param concurrency - Max concurrent event_log reads (default {@link EVENT_LOG_RESOLVE_CONCURRENCY}).
+ * @returns One {@link ResolvedTraceSpans} per input trace, aligned to input order.
+ */
+export async function resolveOffloadedTracesBatch({
+  projectId,
+  spansPerTrace,
+  blobStore,
+  ioExtractionService,
+  logger,
+  aggregateType = "trace",
+  concurrency = EVENT_LOG_RESOLVE_CONCURRENCY,
+}: {
+  projectId: string;
+  spansPerTrace: NormalizedSpan[][];
+  blobStore: BlobStore;
+  ioExtractionService: TraceIOExtractionService;
+  logger: WarnLogger;
+  aggregateType?: string;
+  concurrency?: number;
+}): Promise<ResolvedTraceSpans[]> {
+  // ----- Phase 1: parse every span, build per-span plans + a deduped fetch map.
+  const fetchTasks = new Map<string, FetchTask>();
+  const tracePlans: SpanPlan[][] = spansPerTrace.map((spans) =>
+    spans.map((span) => {
+      const attrs = span.spanAttributes as Record<string, string>;
+      if (!hasEventRefs(attrs)) {
+        return { cleanedAttrs: attrs, refs: [], hadRefs: false };
+      }
+
+      const { cleanedAttrs, eventrefEntries, missingEventIdKeys } =
+        parseSpanEventRefs(attrs);
+
+      for (const attrKey of missingEventIdKeys) {
+        logger.warn(
+          { projectId, spanId: span.spanId, traceId: span.traceId, attrKey },
+          "eventref missing eventId — keeping preview value",
+        );
+      }
+
+      // ADR-022: aggregateId for the trace-processing pipeline IS the traceId.
+      const aggregateId = span.traceId;
+      const refs = eventrefEntries.map(({ attrKey, field, eventId }) => {
+        const fetchKey = fetchKeyOf(aggregateId, eventId, field);
+        if (!fetchTasks.has(fetchKey)) {
+          fetchTasks.set(fetchKey, { eventId, field, aggregateId });
+        }
+        return { attrKey, fetchKey };
+      });
+
+      return { cleanedAttrs, refs, hadRefs: true };
+    }),
+  );
+
+  // ----- Phase 2: fetch each distinct ref once, bounded concurrency.
+  const fetchResults = new Map<string, FetchResult>();
+  await forEachWithConcurrency(
+    [...fetchTasks.entries()],
+    concurrency,
+    async ([fetchKey, task]) => {
+      try {
+        const value = await blobStore.getFromEventLog({
+          eventId: task.eventId,
+          field: task.field,
+          tenantId: projectId,
+          aggregateType,
+          aggregateId: task.aggregateId,
+        });
+        fetchResults.set(fetchKey, { ok: true, value });
+      } catch (error) {
+        fetchResults.set(fetchKey, { ok: false, error });
+      }
+    },
+  );
+
+  // ----- Phase 3: assemble resolved spans + recompute IO per trace.
+  return tracePlans.map((spanPlans, traceIdx) => {
+    const originalSpans = spansPerTrace[traceIdx]!;
+    let anyResolved = false;
+
+    const resolvedSpans: NormalizedSpan[] = spanPlans.map((plan, spanIdx) => {
+      const span = originalSpans[spanIdx]!;
+      if (!plan.hadRefs) {
+        return span;
+      }
+
+      const resolvedAttrs = { ...plan.cleanedAttrs };
+      for (const { attrKey, fetchKey } of plan.refs) {
+        const result = fetchResults.get(fetchKey);
+        if (result?.ok) {
+          resolvedAttrs[attrKey] = result.value;
+          anyResolved = true;
+        } else if (result && !result.ok) {
+          warnResolutionFailure(logger, projectId, span, attrKey, result.error);
+        }
+      }
+      return { ...span, spanAttributes: resolvedAttrs };
+    });
+
+    if (!anyResolved) {
+      return {
+        resolvedSpans,
+        recomputedInput: null,
+        recomputedOutput: null,
+        anyResolved: false,
+      };
+    }
+
+    return {
+      resolvedSpans,
+      recomputedInput: ioExtractionService.extractFirstInput(resolvedSpans),
+      recomputedOutput: ioExtractionService.extractLastOutput(resolvedSpans),
+      anyResolved: true,
+    };
+  });
+}

--- a/langwatch/src/server/traces/resolve-offloaded-traces-batch.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces-batch.ts
@@ -62,12 +62,22 @@ interface SpanPlan {
 /** Internal: outcome of a single event_log fetch. */
 type FetchResult = { ok: true; value: string } | { ok: false; error: unknown };
 
-/** Builds the dedup key for a fetch task. NUL separator can't collide with ids. */
-function fetchKeyOf(
-  aggregateId: string,
-  eventId: string,
-  field: string,
-): string {
+/**
+ * Builds the dedup key for a fetch task. NUL separator can't collide with ids.
+ *
+ * Named params, not positional: all three args are plain strings, so a caller
+ * that transposed two of them would compile cleanly and silently dedupe/fetch
+ * the wrong event_log row onto the wrong span.
+ */
+function fetchKeyOf({
+  aggregateId,
+  eventId,
+  field,
+}: {
+  aggregateId: string;
+  eventId: string;
+  field: string;
+}): string {
   return `${aggregateId}\u0000${eventId}\u0000${field}`;
 }
 
@@ -182,7 +192,7 @@ export async function resolveOffloadedTracesBatch({
       // ADR-022: aggregateId for the trace-processing pipeline IS the traceId.
       const aggregateId = span.traceId;
       const refs = eventrefEntries.map(({ attrKey, field, eventId }) => {
-        const fetchKey = fetchKeyOf(aggregateId, eventId, field);
+        const fetchKey = fetchKeyOf({ aggregateId, eventId, field });
         if (!fetchTasks.has(fetchKey)) {
           fetchTasks.set(fetchKey, { eventId, field, aggregateId });
         }

--- a/langwatch/src/server/traces/resolve-offloaded-traces-batch.unit.test.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces-batch.unit.test.ts
@@ -12,7 +12,7 @@
  *
  * BDD structure: given/when nested describes, action-based it() names.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // TraceIOExtractionService wraps its methods in getLangWatchTracer spans.
 vi.mock("langwatch", () => ({
@@ -21,7 +21,7 @@ vi.mock("langwatch", () => ({
       _name: string,
       _opts: unknown,
       fn: (span: { setAttributes: () => void }) => unknown,
-    ) => fn({ setAttributes: () => {} }),
+    ) => fn({ setAttributes: () => undefined }),
   }),
 }));
 
@@ -30,9 +30,9 @@ import { BlobNotFoundError } from "~/server/app-layer/traces/blob-store.service"
 import { EVENTREF_ATTR_PREFIX } from "~/server/app-layer/traces/lean-for-projection";
 import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
 import {
+  type NormalizedSpan,
   NormalizedSpanKind,
   NormalizedStatusCode,
-  type NormalizedSpan,
 } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import {
   EVENT_LOG_RESOLVE_CONCURRENCY,
@@ -362,9 +362,7 @@ describe("resolveOffloadedTracesBatch() — AC7 graceful degradation", () => {
           logger,
         });
 
-        const keys = Object.keys(
-          results[0]!.resolvedSpans[0]!.spanAttributes,
-        );
+        const keys = Object.keys(results[0]!.resolvedSpans[0]!.spanAttributes);
         expect(keys.every((k) => !k.startsWith(EVENTREF_ATTR_PREFIX))).toBe(
           true,
         );

--- a/langwatch/src/server/traces/resolve-offloaded-traces-batch.unit.test.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces-batch.unit.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Unit tests for resolveOffloadedTracesBatch — the BULK read-path resolver
+ * (#4991, "2 of 2" of #4888). Where resolveOffloadedTraces resolves one trace's
+ * spans (detail reads, #4984), this resolves a WHOLE result set (export, thread,
+ * annotation, sample builders) with a single bounded-concurrency pass over
+ * event_log so a large export never fires an unbounded N×M burst of CH reads.
+ *
+ * AC6 — resolution is streamed: peak concurrent event_log reads is bounded by a
+ *        constant regardless of result-set size; identical refs are deduped.
+ * AC7 — a failed resolution degrades to the preview WITH a warn log (no silent
+ *        truncation), per-ref, without failing the rest of the batch.
+ *
+ * BDD structure: given/when nested describes, action-based it() names.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// TraceIOExtractionService wraps its methods in getLangWatchTracer spans.
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: (
+      _name: string,
+      _opts: unknown,
+      fn: (span: { setAttributes: () => void }) => unknown,
+    ) => fn({ setAttributes: () => {} }),
+  }),
+}));
+
+import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
+import { BlobNotFoundError } from "~/server/app-layer/traces/blob-store.service";
+import { EVENTREF_ATTR_PREFIX } from "~/server/app-layer/traces/lean-for-projection";
+import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
+import {
+  NormalizedSpanKind,
+  NormalizedStatusCode,
+  type NormalizedSpan,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import {
+  EVENT_LOG_RESOLVE_CONCURRENCY,
+  resolveOffloadedTracesBatch,
+} from "./resolve-offloaded-traces-batch";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSpan(
+  overrides: Partial<NormalizedSpan> & {
+    spanAttributes?: Record<string, unknown>;
+  } = {},
+): NormalizedSpan {
+  return {
+    id: "span-1",
+    traceId: "trace-1",
+    spanId: "span-1",
+    tenantId: "proj-1",
+    parentSpanId: null,
+    parentTraceId: null,
+    parentIsRemote: null,
+    sampled: true,
+    startTimeUnixMs: 0,
+    endTimeUnixMs: 1000,
+    durationMs: 1000,
+    name: "test-span",
+    kind: NormalizedSpanKind.INTERNAL,
+    resourceAttributes: {},
+    spanAttributes: {},
+    events: [],
+    links: [],
+    statusMessage: null,
+    statusCode: NormalizedStatusCode.OK,
+    instrumentationScope: { name: "test", version: null },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+    ...overrides,
+  };
+}
+
+/** A span carrying an output eventref pointer (preview + reserved ref key). */
+function makeSpanWithOutputRef({
+  traceId,
+  spanId,
+  eventId,
+  preview = "preview…",
+}: {
+  traceId: string;
+  spanId: string;
+  eventId: string;
+  preview?: string;
+}): NormalizedSpan {
+  return makeSpan({
+    traceId,
+    spanId,
+    spanAttributes: {
+      "langwatch.output": preview,
+      [`${EVENTREF_ATTR_PREFIX}langwatch.output`]: JSON.stringify({
+        field: "langwatch.output",
+        eventId,
+      }),
+    },
+  });
+}
+
+function createMockLogger() {
+  return {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+/**
+ * A BlobStore whose getFromEventLog tracks in-flight concurrency so the test can
+ * assert the resolver never exceeds the pool size. Each call resolves after a
+ * microtask delay so overlapping calls are observable.
+ */
+function makeConcurrencyTrackingBlobStore(fullValue: string): {
+  blobStore: BlobStore;
+  getCalls: () => number;
+  peakConcurrency: () => number;
+} {
+  let inFlight = 0;
+  let peak = 0;
+  let calls = 0;
+  const getFromEventLog = vi.fn(async () => {
+    calls++;
+    inFlight++;
+    peak = Math.max(peak, inFlight);
+    // Yield several microtasks so concurrent calls actually overlap.
+    await new Promise((r) => setTimeout(r, 1));
+    inFlight--;
+    return fullValue;
+  });
+  return {
+    blobStore: {
+      getFromEventLog,
+      putSpool: vi.fn(),
+      getSpool: vi.fn(),
+      deleteSpool: vi.fn(),
+    } as unknown as BlobStore,
+    getCalls: () => calls,
+    peakConcurrency: () => peak,
+  };
+}
+
+const realIOService = new TraceIOExtractionService();
+
+// ---------------------------------------------------------------------------
+// AC6 — streamed / bounded-concurrency resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveOffloadedTracesBatch() — AC6 bounded resolution", () => {
+  describe("given a large result set where every trace has one offloaded span", () => {
+    const TRACE_COUNT = EVENT_LOG_RESOLVE_CONCURRENCY * 3;
+    const fullValue = "X".repeat(100_000);
+
+    function buildResultSet(): NormalizedSpan[][] {
+      return Array.from({ length: TRACE_COUNT }, (_v, i) => [
+        makeSpanWithOutputRef({
+          traceId: `trace-${i}`,
+          spanId: `span-${i}`,
+          eventId: `evt-${i}`,
+        }),
+      ]);
+    }
+
+    describe("when resolved as a batch", () => {
+      it("never exceeds the configured event_log read concurrency", async () => {
+        const { blobStore, peakConcurrency } =
+          makeConcurrencyTrackingBlobStore(fullValue);
+
+        await resolveOffloadedTracesBatch({
+          projectId: "proj-1",
+          spansPerTrace: buildResultSet(),
+          blobStore,
+          ioExtractionService: realIOService,
+          logger: createMockLogger(),
+        });
+
+        expect(peakConcurrency()).toBeGreaterThan(0);
+        expect(peakConcurrency()).toBeLessThanOrEqual(
+          EVENT_LOG_RESOLVE_CONCURRENCY,
+        );
+      });
+
+      it("issues exactly one event_log read per offloaded field (no N×M blow-up)", async () => {
+        const { blobStore, getCalls } =
+          makeConcurrencyTrackingBlobStore(fullValue);
+
+        await resolveOffloadedTracesBatch({
+          projectId: "proj-1",
+          spansPerTrace: buildResultSet(),
+          blobStore,
+          ioExtractionService: realIOService,
+          logger: createMockLogger(),
+        });
+
+        expect(getCalls()).toBe(TRACE_COUNT);
+      });
+
+      it("returns one resolution entry per input trace, in order, all resolved", async () => {
+        const { blobStore } = makeConcurrencyTrackingBlobStore(fullValue);
+
+        const results = await resolveOffloadedTracesBatch({
+          projectId: "proj-1",
+          spansPerTrace: buildResultSet(),
+          blobStore,
+          ioExtractionService: realIOService,
+          logger: createMockLogger(),
+        });
+
+        expect(results).toHaveLength(TRACE_COUNT);
+        expect(results.every((r) => r.anyResolved)).toBe(true);
+        expect(
+          results[0]!.resolvedSpans[0]!.spanAttributes["langwatch.output"],
+        ).toBe(fullValue);
+      });
+    });
+  });
+
+  describe("given the same trace referenced twice in one result set", () => {
+    const fullValue = "shared-full-value";
+
+    describe("when resolved as a batch", () => {
+      it("dedupes identical (eventId, field) refs into a single event_log read", async () => {
+        const { blobStore, getCalls } =
+          makeConcurrencyTrackingBlobStore(fullValue);
+        const span = makeSpanWithOutputRef({
+          traceId: "trace-dup",
+          spanId: "span-dup",
+          eventId: "evt-dup",
+        });
+
+        const results = await resolveOffloadedTracesBatch({
+          projectId: "proj-1",
+          spansPerTrace: [[span], [span]],
+          blobStore,
+          ioExtractionService: realIOService,
+          logger: createMockLogger(),
+        });
+
+        expect(getCalls()).toBe(1);
+        // Both output traces still receive the full value.
+        expect(
+          results[0]!.resolvedSpans[0]!.spanAttributes["langwatch.output"],
+        ).toBe(fullValue);
+        expect(
+          results[1]!.resolvedSpans[0]!.spanAttributes["langwatch.output"],
+        ).toBe(fullValue);
+      });
+    });
+  });
+
+  describe("given a trace with no offloaded spans", () => {
+    describe("when resolved as a batch", () => {
+      it("issues zero event_log reads and returns the spans untouched", async () => {
+        const { blobStore, getCalls } =
+          makeConcurrencyTrackingBlobStore("unused");
+        const plainSpan = makeSpan({
+          traceId: "trace-plain",
+          spanAttributes: { "langwatch.output": "small inline value" },
+        });
+
+        const results = await resolveOffloadedTracesBatch({
+          projectId: "proj-1",
+          spansPerTrace: [[plainSpan]],
+          blobStore,
+          ioExtractionService: realIOService,
+          logger: createMockLogger(),
+        });
+
+        expect(getCalls()).toBe(0);
+        expect(results[0]!.anyResolved).toBe(false);
+        expect(
+          results[0]!.resolvedSpans[0]!.spanAttributes["langwatch.output"],
+        ).toBe("small inline value");
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC7 — degrade to preview WITH a warn log
+// ---------------------------------------------------------------------------
+
+describe("resolveOffloadedTracesBatch() — AC7 graceful degradation", () => {
+  describe("given one trace whose event_log row is missing", () => {
+    function makeMissingRowBlobStore(): BlobStore {
+      return {
+        getFromEventLog: vi.fn(async ({ field }: { field: string }) => {
+          throw new BlobNotFoundError("evt-missing", field, "proj-1");
+        }),
+        putSpool: vi.fn(),
+        getSpool: vi.fn(),
+        deleteSpool: vi.fn(),
+      } as unknown as BlobStore;
+    }
+
+    describe("when resolved as a batch", () => {
+      it("keeps the preview value for the unresolved field", async () => {
+        const logger = createMockLogger();
+        const results = await resolveOffloadedTracesBatch({
+          projectId: "proj-1",
+          spansPerTrace: [
+            [
+              makeSpanWithOutputRef({
+                traceId: "trace-x",
+                spanId: "span-x",
+                eventId: "evt-missing",
+                preview: "the 64KB preview",
+              }),
+            ],
+          ],
+          blobStore: makeMissingRowBlobStore(),
+          ioExtractionService: realIOService,
+          logger,
+        });
+
+        expect(
+          results[0]!.resolvedSpans[0]!.spanAttributes["langwatch.output"],
+        ).toBe("the 64KB preview");
+        expect(results[0]!.anyResolved).toBe(false);
+      });
+
+      it("logs a warning (no silent truncation)", async () => {
+        const logger = createMockLogger();
+        await resolveOffloadedTracesBatch({
+          projectId: "proj-1",
+          spansPerTrace: [
+            [
+              makeSpanWithOutputRef({
+                traceId: "trace-x",
+                spanId: "span-x",
+                eventId: "evt-missing",
+              }),
+            ],
+          ],
+          blobStore: makeMissingRowBlobStore(),
+          ioExtractionService: realIOService,
+          logger,
+        });
+
+        expect(logger.warn).toHaveBeenCalled();
+      });
+
+      it("strips the reserved eventref key even when resolution fails", async () => {
+        const logger = createMockLogger();
+        const results = await resolveOffloadedTracesBatch({
+          projectId: "proj-1",
+          spansPerTrace: [
+            [
+              makeSpanWithOutputRef({
+                traceId: "trace-x",
+                spanId: "span-x",
+                eventId: "evt-missing",
+              }),
+            ],
+          ],
+          blobStore: makeMissingRowBlobStore(),
+          ioExtractionService: realIOService,
+          logger,
+        });
+
+        const keys = Object.keys(
+          results[0]!.resolvedSpans[0]!.spanAttributes,
+        );
+        expect(keys.every((k) => !k.startsWith(EVENTREF_ATTR_PREFIX))).toBe(
+          true,
+        );
+      });
+    });
+  });
+
+  describe("given a result set where one trace fails and others succeed", () => {
+    function makeSelectiveBlobStore(goodValue: string): BlobStore {
+      return {
+        getFromEventLog: vi.fn(
+          async ({ eventId, field }: { eventId: string; field: string }) => {
+            if (eventId === "evt-bad") {
+              throw new BlobNotFoundError(eventId, field, "proj-1");
+            }
+            return goodValue;
+          },
+        ),
+        putSpool: vi.fn(),
+        getSpool: vi.fn(),
+        deleteSpool: vi.fn(),
+      } as unknown as BlobStore;
+    }
+
+    describe("when resolved as a batch", () => {
+      it("resolves the healthy traces and degrades only the failing one", async () => {
+        const goodValue = "Y".repeat(80_000);
+        const results = await resolveOffloadedTracesBatch({
+          projectId: "proj-1",
+          spansPerTrace: [
+            [
+              makeSpanWithOutputRef({
+                traceId: "trace-good",
+                spanId: "span-good",
+                eventId: "evt-good",
+              }),
+            ],
+            [
+              makeSpanWithOutputRef({
+                traceId: "trace-bad",
+                spanId: "span-bad",
+                eventId: "evt-bad",
+                preview: "bad-preview",
+              }),
+            ],
+          ],
+          blobStore: makeSelectiveBlobStore(goodValue),
+          ioExtractionService: realIOService,
+          logger: createMockLogger(),
+        });
+
+        expect(results[0]!.anyResolved).toBe(true);
+        expect(
+          results[0]!.resolvedSpans[0]!.spanAttributes["langwatch.output"],
+        ).toBe(goodValue);
+        expect(results[1]!.anyResolved).toBe(false);
+        expect(
+          results[1]!.resolvedSpans[0]!.spanAttributes["langwatch.output"],
+        ).toBe("bad-preview");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/traces/resolve-offloaded-traces-batch.unit.test.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces-batch.unit.test.ts
@@ -72,6 +72,10 @@ function makeSpan(
     droppedAttributesCount: 0,
     droppedEventsCount: 0,
     droppedLinksCount: 0,
+    // Required (nullable) since #5012 wired per-span cost into NormalizedSpan.
+    // Blob resolution is cost-agnostic, so null is the honest fixture value.
+    cost: null,
+    nonBilledCost: null,
     ...overrides,
   };
 }

--- a/langwatch/src/server/traces/resolve-offloaded-traces.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces.ts
@@ -27,12 +27,15 @@ import {
   BlobFieldNotFoundError,
   BlobNotFoundError,
 } from "~/server/app-layer/traces/blob-store.service";
-import { EVENTREF_ATTR_PREFIX } from "~/server/app-layer/traces/lean-for-projection";
 import type {
   ExtractedIO,
   TraceIOExtractionService,
 } from "~/server/app-layer/traces/trace-io-extraction.service";
 import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import {
+  hasEventRefs,
+  parseSpanEventRefs,
+} from "./offloaded-eventref-parsing";
 
 /** Minimal logger interface required by this module (subset of PinoLogger). */
 export type WarnLogger = Pick<PinoLogger, "warn" | "error">;
@@ -59,14 +62,6 @@ export interface ResolvedTraceSpans {
    * stored in trace_summaries should remain in effect.
    */
   anyResolved: boolean;
-}
-
-/** True when the attribute map carries at least one eventref pointer. */
-function hasEventRefs(attributes: Record<string, string>): boolean {
-  for (const key in attributes) {
-    if (key.startsWith(EVENTREF_ATTR_PREFIX)) return true;
-  }
-  return false;
 }
 
 /**
@@ -131,50 +126,23 @@ export async function resolveOffloadedTraces({
         return { span, resolvedCount: 0 };
       }
 
-      // Separate eventref keys from regular attributes
-      const cleanedAttrs: Record<string, string> = {};
-      const eventrefEntries: Array<{
-        attrKey: string;
-        field: string;
-        eventId: string;
-      }> = [];
+      // Separate eventref keys from regular attributes (shared decoder).
+      const { cleanedAttrs, eventrefEntries, missingEventIdKeys } =
+        parseSpanEventRefs(attrs);
 
-      for (const [key, value] of Object.entries(attrs)) {
-        if (key.startsWith(EVENTREF_ATTR_PREFIX)) {
-          const attrKey = key.slice(EVENTREF_ATTR_PREFIX.length);
-          try {
-            const ref = JSON.parse(value) as {
-              field?: string;
-              eventId?: string;
-            };
-            if (typeof ref.eventId !== "string" || ref.eventId.length === 0) {
-              // Eventref missing the embedded eventId — can't resolve. Strip
-              // the key so we don't leak the reserved namespace to the UI,
-              // but keep the preview that's already in cleanedAttrs (added
-              // by `else` branch below when the span attr was the IO key
-              // itself, not the reserved one).
-              logger.warn(
-                {
-                  projectId,
-                  spanId: span.spanId,
-                  traceId: span.traceId,
-                  attrKey,
-                },
-                "eventref missing eventId — keeping preview value",
-              );
-              continue;
-            }
-            eventrefEntries.push({
-              attrKey,
-              field: ref.field ?? attrKey,
-              eventId: ref.eventId,
-            });
-          } catch {
-            // Malformed eventref JSON — skip; preview in cleanedAttrs is still shown.
-          }
-        } else {
-          cleanedAttrs[key] = value;
-        }
+      // Eventref missing the embedded eventId — can't resolve. The reserved
+      // key is already stripped (kept out of cleanedAttrs) so the UI never
+      // sees the namespace; the preview under the plain IO key stays in place.
+      for (const attrKey of missingEventIdKeys) {
+        logger.warn(
+          {
+            projectId,
+            spanId: span.spanId,
+            traceId: span.traceId,
+            attrKey,
+          },
+          "eventref missing eventId — keeping preview value",
+        );
       }
 
       if (eventrefEntries.length === 0) {

--- a/langwatch/src/server/traces/resolve-offloaded-traces.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces.ts
@@ -32,10 +32,7 @@ import type {
   TraceIOExtractionService,
 } from "~/server/app-layer/traces/trace-io-extraction.service";
 import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
-import {
-  hasEventRefs,
-  parseSpanEventRefs,
-} from "./offloaded-eventref-parsing";
+import { hasEventRefs, parseSpanEventRefs } from "./offloaded-eventref-parsing";
 
 /** Minimal logger interface required by this module (subset of PinoLogger). */
 export type WarnLogger = Pick<PinoLogger, "warn" | "error">;

--- a/langwatch/src/server/traces/resolve-offloaded-traces.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces.ts
@@ -79,8 +79,8 @@ export interface ResolvedTraceSpans {
  * @param normalizedSpans - The raw NormalizedSpan array for a single trace.
  * @param blobStore - BlobStore providing getFromEventLog.
  * @param ioExtractionService - Recomputes trace-level IO from the resolved spans.
- * @param eventId - The event_log EventId for the event that produced these spans.
- *   Derived from span context. When not provided, eventref resolution is skipped.
+ *   Each span's eventId is read from its own embedded eventref pointer (not a
+ *   caller-supplied arg); spans without eventrefs are returned unchanged.
  * @param aggregateType - Aggregate type for event_log lookup (default: "trace").
  * @param logger - Logger for missing-ref warnings.
  */

--- a/langwatch/src/server/traces/trace.service.ts
+++ b/langwatch/src/server/traces/trace.service.ts
@@ -453,10 +453,11 @@ export class TraceService {
    * @param threadIds - Array of thread IDs
    * @param protections - Field redaction protections
    * @param opts.full - When true AND blob-resolution deps are present, resolves
-   *   offloaded eventref pointers so thread IO reads back full. Used by the
-   *   eval path (which needs full values for thread-mapped evaluators) — the
-   *   eval-path TraceService carries deps. Customer thread views pass nothing
-   *   and carry no deps, so they stay on the ≤64 KB preview (#4888 / ADR-022).
+   *   offloaded eventref pointers so thread IO reads back full (#4991). Opted
+   *   into per call: the eval path (thread-mapped evaluators) and the
+   *   content-consuming thread tRPC both pass `{ full: true }` with deps. A
+   *   caller that omits it — or a deps-free TraceService — stays on the ≤64 KB
+   *   preview and issues zero event_log reads (#4888 / ADR-022).
    * @returns Array of traces
    */
   async getTracesWithSpansByThreadIds(

--- a/langwatch/src/server/traces/trace.service.ts
+++ b/langwatch/src/server/traces/trace.service.ts
@@ -11,6 +11,7 @@ import type { Protections } from "~/server/traces/protections";
 import { createLogger } from "~/utils/logger/server";
 import { ClickHouseTraceService } from "./clickhouse-trace.service";
 import { resolveOffloadedTraces } from "./resolve-offloaded-traces";
+import { resolveOffloadedTracesBatch } from "./resolve-offloaded-traces-batch";
 
 /**
  * Minimum prefix length we will attempt to resolve. Shorter strings fall
@@ -136,6 +137,25 @@ class OffloadedSpanResolver {
         logger: this.logger,
       });
   }
+
+  /**
+   * Returns the bulk-resolution callback compatible with ClickHouseTraceService's
+   * `resolveTraceSpansBatchFn` parameter. Resolves a whole result set in one
+   * bounded-concurrency pass over event_log (#4991 AC6).
+   */
+  toBatchResolverFn(): (
+    projectId: string,
+    spansPerTrace: NormalizedSpan[][],
+  ) => ReturnType<typeof resolveOffloadedTracesBatch> {
+    return (projectId, spansPerTrace) =>
+      resolveOffloadedTracesBatch({
+        projectId,
+        spansPerTrace,
+        blobStore: this.deps.blobStore,
+        ioExtractionService: this.deps.ioExtractionService,
+        logger: this.logger,
+      });
+  }
 }
 
 /**
@@ -158,21 +178,22 @@ export class TraceService {
     readonly prisma: PrismaClient,
     blobResolutionDeps?: BlobResolutionDeps,
   ) {
-    // Build the per-trace resolver callback when deps are present.
-    // The callback is passed to ClickHouseTraceService so resolution happens
-    // at the NormalizedSpan level (before mapping to legacy Span), which is
-    // the only level where spanAttributes carry the eventref keys.
-    const resolveTraceSpansFn =
+    // Build the resolver callbacks when deps are present. They are passed to
+    // ClickHouseTraceService so resolution happens at the NormalizedSpan level
+    // (before mapping to legacy Span), the only level where spanAttributes
+    // carry the eventref keys. The per-trace fn serves single-trace detail
+    // reads (#4888); the batch fn serves bulk reads in one bounded pass (#4991).
+    const offloadedSpanResolver =
       blobResolutionDeps !== undefined
-        ? new OffloadedSpanResolver(
-            blobResolutionDeps,
-            this.logger,
-          ).toResolverFn()
+        ? new OffloadedSpanResolver(blobResolutionDeps, this.logger)
         : undefined;
+    const resolveTraceSpansFn = offloadedSpanResolver?.toResolverFn();
+    const resolveTraceSpansBatchFn = offloadedSpanResolver?.toBatchResolverFn();
 
     this.clickHouseService = ClickHouseTraceService.create(
       prisma,
       resolveTraceSpansFn,
+      resolveTraceSpansBatchFn,
     );
     this.evaluationService = EvaluationService.create();
   }
@@ -314,12 +335,16 @@ export class TraceService {
    * @param projectId - The project ID
    * @param threadId - The thread ID to group by
    * @param protections - Field redaction protections
+   * @param opts.full - When true AND blob-resolution deps are present, resolves
+   *   offloaded eventref pointers so thread-detail IO reads back full (#4991).
+   *   Default (undefined/false) returns the ≤64 KB preview.
    * @returns Array of traces in the thread
    */
   async getTracesByThreadId(
     projectId: string,
     threadId: string,
     protections: Protections,
+    opts?: { full?: boolean },
   ): Promise<Trace[]> {
     return this.tracer.withActiveSpan(
       "TraceService.getTracesByThreadId",
@@ -329,6 +354,7 @@ export class TraceService {
           projectId,
           threadId,
           protections,
+          { resolveBlobs: opts?.full },
         );
       },
     );

--- a/langwatch/src/server/traces/types.ts
+++ b/langwatch/src/server/traces/types.ts
@@ -20,6 +20,15 @@ export type TraceDateField = "occurred" | "updated";
 export interface GetAllTracesForProjectOptions {
   downloadMode?: boolean;
   includeSpans?: boolean;
+  /**
+   * Resolve offloaded >64 KB IO from event_log to the FULL value (#4991).
+   * Only the download/export path (a content-consuming read) opts in; the
+   * list/search grid leaves this false so it keeps the ≤64 KB preview and
+   * issues zero event_log SELECTs (#4888 AC2 / ADR-022). Requires
+   * `includeSpans: true` to have any effect (resolution runs during span
+   * enrichment). No-op unless the TraceService carries blob-resolution deps.
+   */
+  resolveBlobs?: boolean;
   scrollId?: string | null;
   /**
    * Which time axis the date window + keyset cursor filter on. "occurred"


### PR DESCRIPTION
## Why

Closes langwatch/langwatch#4991. The >64 KB span-IO offload (#4215 / ADR-022) stores a **64 KB preview** + an `eventref` pointer in the lean projection; the **full value** lives in ClickHouse `event_log`. PR langwatch/langwatch#4984 ("1 of 2") wired blob-resolution into the four **single-trace detail** reads. Several **bulk content-consuming** reads still returned the truncated preview — so a full CSV/JSONL export lost data, thread conversations were cut off at 64 KB, annotators couldn't see the content they were labeling, and dataset/sample builders persisted truncated rows. This PR ("2 of 2") resolves the full value on every read whose consumer needs trace **content**, while keeping the **list/search grid + aggregations** on the preview (the heavy-read protection the offload exists to provide).

## What changed

- **A bulk resolver (`resolveOffloadedTracesBatch`) that streams, not fans out** — resolving each trace independently would fire an unbounded `N×M` burst of `event_log` SELECTs (one per offloaded field × every row) and exhaust the CH connection pool on a large export. Instead it decodes every eventref across the whole result set, **dedupes** identical `(aggregateId, eventId, field)` refs, and runs the reads through a **bounded-concurrency pool** so peak in-flight CH reads is a constant regardless of result-set size (**AC6**). A missing/failed row keeps that field's preview and logs a `warn` — no silent truncation (**AC7**).
- **Explicit `resolveBlobs` opt-in, deliberately separate from `includeSpans`** — the download path and the list grid share `getAllTracesForProject`, and `app.v1`'s public list passes `includeSpans=true` but **must stay preview**. Gating on a dedicated `resolveBlobs` option (not `includeSpans`) lets every content-consuming read resolve full while the list/aggregations issue **zero** `event_log` reads (**AC5** / ADR-022 binding constraint). *`includeSpans` is not a proxy for "consumes content" — see the review round below, where treating it as one was the bug.*
- **Mirror langwatch/langwatch#4984's DI shape at every bulk call site** — export, thread (legacy `GET /api/thread/:id` + tRPC), annotation queue (both read sites), and dataset/sample builders now build `buildTraceBlobResolutionDeps()` and request `full: true` (**AC1–AC4**). No new resolution mechanism invented — the same `BlobStore`/`event_log` recompute, batched.
- **Shared eventref decoder** — `hasEventRefs` / `parseSpanEventRefs` extracted into `offloaded-eventref-parsing.ts` so the per-trace (#4984) and batch (this PR) resolvers decode the reserved-namespace shape from one definition.
- **Authorize before resolving, on the one anonymous path** — `getTracesByThreadId` is a `publicProcedure`. Full resolution now runs **after** the public-share filter narrows the thread, never before (**security** — see review round).

## How it works

```
src/server/traces/
  offloaded-eventref-parsing.ts      NEW  decode reserved eventref keys (shared by both resolvers)
  resolve-offloaded-traces.ts        REFACTOR  per-trace detail resolver → now uses shared decoder
  resolve-offloaded-traces-batch.ts  NEW  whole-result-set resolver: dedupe + bounded-concurrency stream + per-ref warn-degrade
  trace.service.ts          builds BOTH resolver callbacks from one deps object; forwards full→resolveBlobs
  clickhouse-trace.service.ts  bulk reads use the batch callback (fallback to per-trace); enrich + getTracesByThreadId honor resolveBlobs
  types.ts                  GetAllTracesForProjectOptions.resolveBlobs (export discriminator)

Read paths flipped to full resolution:
  export/export.service.ts            AC1  ExportService.create deps + EVERY export mode sets resolveBlobs
  clickhouse-trace.service.ts         AC1  spans are fetched when the caller wants spans OR full IO — a
                                           summary read resolves, recomputes trace IO, then drops the spans
  api/routers/traces.ts               AC1/AC2/AC4  getAllForDownload, thread tRPC (+ public-share ordering), sample/dataset builders
  api/routers/annotation.ts           AC3  both queue-read sites
  routes/traces-legacy.ts             AC2  GET /api/thread/:id
```

Flow: a bulk read opts in (`{ full: true }` / `resolveBlobs: true`) → `TraceService` forwards the gate → `ClickHouseTraceService` collects every trace's normalized spans → `resolveOffloadedTracesBatch` resolves the whole set in one bounded pass → spans get full values, reserved keys stripped, trace IO recomputed. List/aggregation reads never opt in, so the resolver never runs and zero `event_log` reads are issued.

## Review round — what the reviewers caught

Two **P1 blockers** and two P2s were raised on this PR, and working them surfaced four more defects. Worth reading before re-reviewing, because three of them were in code this PR itself added.

| # | Defect | Why it mattered |
|---|---|---|
| **P1** | `getTracesByThreadId` (a `publicProcedure`) resolved `{full:true}` for the **whole thread**, then filtered the response down to the publicly-shared traces | The filter was post-hoc. One valid share link let an **anonymous** caller force full `event_log` de-offloading of every *other* trace in that thread — the CH connection-pool amplification ADR-022 exists to prevent, reachable unauthenticated. Not a data leak (the response stayed filtered). Now: preview-only read → authorize → resolve **only** the authorized ids. |
| **P1** | `resolveBlobs` was gated on `includeSpans`, so **summary exports** silently shipped the truncated 64 KB preview | Summary mode reads no *span* content but still emits trace-level `trace.input`/`trace.output` (`csv-serializer.ts:91-92`). For an offloaded trace it served the preview with no error and no indication data was cut — the same data-loss bug this PR opens with, on the other export mode. **This one took two attempts — see below.** |
| P2 | `fetchKeyOf(aggregateId, eventId, field)` — three positional strings | A transposition compiled clean and would silently fetch the wrong `event_log` row onto the wrong span. Now named params. |
| P2 | `resolutions[i]!` trusted an **injected** resolver to return one resolution per trace, in order | The type can't enforce it. Now guarded at the boundary. |
| +1 | `getAllForDownload` **had the same summary bug**, unfixed | Same `resolveBlobs: input.includeSpans` gate, twin path, introduced by this PR. A spans-less download truncated offloaded traces. |
| +1 | The new guard **overclaimed** — it promised "in input order" but only compared lengths | A resolver returning the right *count* in the wrong *order* passed silently and scattered each trace's IO onto its neighbour: exactly the silent-corruption case it advertised catching. Order is now actually verified. |
| +1 | A third flattening `catch` (`getTracesWithSpansByThreadIds`) destroyed the guard's error | It sits *above* `getTracesWithSpans` and re-wrapped what that method re-threw, on a live `resolveBlobs` path. |
| +1 | A unit test in this PR **had been failing since it was added** | `test-unit (2)` reported `success` anyway — the shard's `globalSetup` hard-floor `process.exit(0)` fires mid-run and GitHub scores it green. Root cause was a tRPC mutation's auditLog middleware reaching the real `prisma` singleton, which also leaked a socket that plausibly *caused* the wedge. Fixed here; the masking itself is [#4450](https://github.com/langwatch/langwatch/issues/4450). |

**Reviewer note — one deliberate divergence:** the cardinality guard was asked for at both index sites (`resolutions[i]!` and `merged[i]!`). It is implemented **once**, at the boundary where the untrusted value enters. `merged` comes from `entries.map(...)`, so `merged.length === enrichable.length` is a tautology and a second assert there would be unreachable. Pushback welcome.

### The summary-export fix took two attempts — read this one

The first attempt set `resolveBlobs: true` at the call sites and **did nothing at runtime.** Resolution lives inside `enrichTracesWithSpans`, which only ran `if (options.includeSpans)`. Summary mode sets `includeSpans = false`, so `resolveBlobs` was **never read** — zero `event_log` reads, preview still shipped, and a comment now asserting it was fixed.

The tests were green throughout, and that is the part worth internalising: they mocked `getAllTracesForProject` and asserted the flag was **forwarded**. *That assertion passes whether or not the flag has any runtime effect.* It tested intent, not behaviour.

**Actually fixed in `6860180b9`:** spans are fetched when the caller wants spans **OR** wants full IO, because those are not the same thing — the full value is recoverable *only* by de-offloading the spans' eventref pointers and recomputing trace IO from them (`trace_summaries` holds nothing but the preview). A summary read therefore resolves, recomputes, and then **discards** the spans (returns `spans: []`), so its payload shape is unchanged.

Proven behaviourally this time — the real service + real resolver, asserting the **value**, confirmed RED first:

```
RED   × resolves the trace-level output to the FULL value, not the preview
        AssertionError: expected [getFromEventLog] to be called at least once
GREEN ✓ 12 passed — full value returned, AC5 zero-read still holds
```

**AC5 is preserved by construction:** `resolveBlobs` stays opt-in, so the list grid and aggregations resolve nothing and issue zero `event_log` reads whether or not they ask for spans.

**Cost, stated plainly — worth a conscious human call:** summary exports now do a span join + bounded `event_log` reads where they previously did neither. That is the tradeoff the reviewer explicitly offered on the blocker thread, and there is no cheaper way to recover the value. But it is a real new cost on a path that had none, and it should be accepted deliberately rather than inherited from a comment.

## Human verification (for if you really don't trust me)

1. Ingest a trace whose input or output exceeds 64 KB with the `release_trace_blob_offload` flag on (offloads to `event_log`, leaves a 64 KB preview in `trace_summaries`).
2. **Export** that trace as a *full* CSV/JSONL → the IO column holds the **whole** value, not a 64 KB-truncated string.
3. Open the **thread** the trace belongs to (`GET /api/thread/:id` or the thread drawer) → the conversation message is complete, not cut off.
4. Add the trace to an **annotation queue** → the annotator sees the full content.
5. Build a **dataset/sample** from it → the persisted row is the full value.
6. Load the trace **list/search grid** and the topic/customer aggregations → still fast, and (verify via CH query log) they issue **no** `event_log` SELECTs.

## How I can prove I was successful

**Outside-In TDD, real ClickHouse service + real resolver + real mapper (only the raw CH SQL boundary + S3 mocked).** Every AC has a test that genuinely exercises the behavior and was confirmed RED before the fix.

**RED — wiring reverted (`git stash` of the implementation), new tests run:** 15 assertions fail (export 3/3, thread, sample, annotation 2/2, download), while the pure-mechanism batch test and the "stays-preview / zero-read" assertions stay green (they hold trivially when nothing resolves):

```
❯ export-service.4991.unit.test.ts            (3 tests | 3 failed)
❯ clickhouse-trace.service-4991-bulk.unit.test.ts (6 tests | 2 failed)   ← the two "reads full" cases
❯ traces-legacy-thread.unit.test.ts           (3 tests | 2 failed)
❯ traces.4991-full-resolution.unit.test.ts    (9 tests | 6 failed)
❯ annotation.4991-full-resolution.unit.test.ts (2 tests | 2 failed)
   Failed Tests 15
```

**GREEN — implementation restored, full suite (6 new + 6 merged/existing regression). Counts below are from the original round; the current head's numbers are in the CI run linked on this PR (both `pnpm typecheck` *and* `pnpm typecheck:tests` — the former excludes test files):**

```
$ pnpm typecheck            # tsgo --noEmit → clean, 0 errors
$ npx vitest run <12 files>
 Test Files  12 passed (12)
      Tests  150 passed (150)
```

| AC | What the test proves | File |
|---|---|---|
| AC1 export | `getAllTracesForProject({includeSpans, resolveBlobs:true})` widens output past 64 KB to the full value; `ExportService` wires deps + sets `resolveBlobs` on **every** export mode (summary included — it emits trace-level IO), and `getAllForDownload` does too even without spans | `clickhouse-trace.service-4991-bulk`, `export-service.4991`, `traces.4991` |
| AC2 thread | `getTracesByThreadId(resolveBlobs:true)` returns full IO; legacy + tRPC handlers build deps + `full:true` | `clickhouse-trace.service-4991-bulk`, `traces-legacy-thread`, `traces.4991` |
| AC3 annotation | both queue-read sites build deps + `full:true` | `annotation.4991` |
| AC4 dataset/sample | sample/dataset builders resolve spans full (ID-only list read stays preview) | `traces.4991` |
| AC5 zero-read | list grid + `getFormattedSpansDigest` issue **zero** `getFromEventLog` calls and keep the preview, even with deps wired | `clickhouse-trace.service-4991-bulk`, `traces.4991` |
| AC6 batched/streamed | peak concurrent `event_log` reads ≤ pool size for a 75-trace set; identical refs deduped to one read; one read per offloaded field (no `N×M`) | `resolve-offloaded-traces-batch` |
| AC7 degrade+warn | a missing `event_log` row keeps the preview, logs a warn, strips the reserved key, and never fails the rest of the batch | `resolve-offloaded-traces-batch` |

**✅ Live-app visual proof — langwatch/langwatch#5082-NEW surface: dataset builder (`getSampleTracesDataset`, AC4; deliberately **not** the langwatch/langwatch#4888 trace-detail drawer).**

![Dataset-builder mapping preview renders the full >64KB offloaded trace IO](https://raw.githubusercontent.com/langwatch/langwatch/proof/5082-dataset-builder-full-io/proofs/5082-dataset-builder-full-io.png)

Seeded a trace `blob-5082-fullio` whose input **and** output each exceed 64 KB, so the offload fired: the lean projection (`stored_spans`) holds a **65 539-byte preview ending in `…`** plus `langwatch.reserved.eventref.langwatch.{input,output}`, while the full ~70 KB value lives in ClickHouse `event_log`. A unique end-marker `BLOB5082FULLIOEND` was placed **past byte 65 536**, so it exists only in the full value:

| `langwatch.output` | preview (`stored_spans`) | full (`event_log`) |
|---|---|---|
| byte length | 65 539 (64 KB + `…`) | ~70 104 |
| `position('BLOB5082FULLIOEND')` | **0 — absent** | **140 613 — present** |

The screenshot drives the **real authenticated app over live HTTPS** (`drewdrewthis--langwatch-golden.boxd.sh`): *Add Automation → Add to Dataset → mapping preview*, which calls `getSampleTracesDataset` — the exact AC4 read path this PR flips to `resolveBlobs: true`. The output-cell editor holds the **full 70 104-byte value ending in `BLOB5082FULLIOEND"}]}`** (close-up, lower panel) — not the truncated preview. Without this PR the same surface returns the 64 KB preview ending in `…` with no marker; the list-grid cell still shows the capped preview (AC5 stays preview), confirming only the content-consuming read resolves.

**Evidence for the review-round fixes (above) — every one confirmed falsifiable by reverting the fix and watching the test fail:**

| Fix | Test | Revert → |
|---|---|---|
| Authorize before resolving (public share) | `traces.4991` → *public-share thread read* | Restoring resolve-then-filter fails the `{full:false}` assert **and both** exclusion asserts (`getTracesWithSpans` called with only the authorized ids, exactly once). Simulating a *partial*-authorization regression — resolve every thread id, ignore the filter — also fails both. |
| Summary export resolves — **the value, not the flag** | `clickhouse-trace.service-4991-bulk` → *AC1 summary read* | Confirmed RED before the fix: the real service with `{includeSpans:false, resolveBlobs:true}` never called `getFromEventLog` and returned the preview. The call-site tests (`export-service.4991`, `traces.4991`) assert the flag is forwarded — necessary, but they pass even when the flag is inert, which is exactly how the first attempt slipped through. |
| Spans-less download resolves | `traces.4991` | Restoring `resolveBlobs: input.includeSpans` fails it. |
| Resolver **order** contract | `clickhouse-trace.service-4991-bulk` | Removing the order check (keeping cardinality) fails the misalignment test — a resolver returning 2 resolutions for 2 traces, reversed, drives the real service. |

### The summary-export fix is proven end-to-end against a REAL ClickHouse

The unit tests **could not have caught the bug they were written for** — they mocked `getAllTracesForProject` and asserted the flag was *forwarded*, which passes whether or not the flag does anything. So the P1 fix gets a real one: `src/server/export/__tests__/export-summary-blob-resolution.integration.test.ts`.

It seeds a genuinely offloaded trace the way an ingest leaves one, then runs the **real** export:

```
real ClickHouse (trace_summaries + stored_spans + event_log)
  → real ClickHouseTraceService      ← the includeSpans/resolveBlobs gate that was the bug
  → real resolveOffloadedTracesBatch + real BlobStore   ← the actual event_log read
  → real ExportService, SUMMARY mode
  → real CSV / JSONL serializers
  → assert the exported BYTES carry the de-offloaded value
```

The fixture's `UNIQUE_TAIL` sits **past the 64 KB preview boundary by construction** (the preview is `value.slice(0, 64KB) + "…"`), so it exists *only* in the de-offloaded value — a preview-only export **cannot** contain it. That makes the assertion falsifiable against the real bug rather than against a mock's arguments.

**Verified falsifiable — I restored the pre-fix `if (options.includeSpans)` gate and re-ran it:**

```
RED (pre-fix gate restored)
  × writes the FULL de-offloaded value into the CSV, not the 64 KB preview
      AssertionError: expected 'trace_id,timestamp,input,output,label…'
                      to contain '__OFFLOAD_FULL_VALUE_TAIL_MARKER__'
  × does not truncate at the preview boundary
      AssertionError: expected '…' not to contain 'xxxxxxxxxxxxxxxxxxxx…'   ← the truncated preview, served
  × writes the FULL value in JSON (JSONL) summary mode too
  ✓ AC5: list read keeps the preview          ← still passes, as it must
  Tests  3 failed | 1 passed (4)

GREEN (fix in place)
  Tests  4 passed (4)
```

**AC5 is guarded in the same file, not just asserted in prose:** the list/search read over the *same* offloaded trace, without `resolveBlobs`, still comes back as the preview with the tail absent. So the fix demonstrably did not disarm the heavy-read protection.

**What is NOT demonstrated in a running app, and why — stated plainly rather than implied:**

| Fix | Observable surface? | Evidence |
|---|---|---|
| Summary-export data loss | **Yes** — the exported bytes change | The real-ClickHouse end-to-end export above, RED→GREEN |
| Dataset builder (AC4) | **Yes** — the mapping preview | The live-app screenshot below |
| Public-share authorize-before-resolve | **No.** The response is byte-identical either way; only *when* resolution happens changes (and *how much* `event_log` it touches). There is nothing for a user to see | Falsifiable unit tests, incl. a simulated partial-authorization regression that fails both exclusion asserts |
| Resolver-contract guard | **No.** It fires only on a resolver that breaks its contract — unreachable through the UI | Tests driving genuinely non-conforming resolvers through the real service |

The visual proof below remains the AC4 dataset-builder surface.

## Anything surprising?

- **AC6 is satisfied by *streaming* (bounded concurrency + dedup), not by collapsing reads into one `EventId IN (…)` query.** True multi-event batching would require a new `getManyFromEventLog` primitive, which would break langwatch/langwatch#4984's merged unit tests (they spy `getFromEventLog` and assert call counts). Keeping the existing primitive preserves those tests verbatim; the bound that matters — peak in-flight reads is constant regardless of result size — is enforced and tested. A follow-up could add `EventId IN` batching if profiling shows the per-event round-trip is the bottleneck.
- The `release_trace_blob_offload` resolution only fires for traces ingested with offload on; pre-offload traces have no eventrefs and skip the resolver entirely (fast path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in `resolveBlobs` full-resolution for offloaded trace IO (>64KB), enabling full blob IO for download/export and thread detail views when spans are included.
* **Improvements**
  * Annotation, traces, and export paths now return fully resolved trace content when full mode is enabled; preview/list paths remain preview-only.
  * Trace span enrichment now uses batched offloaded resolution for faster, more consistent results.
* **Tests**
  * Expanded coverage for full vs preview wiring, legacy thread routing, export modes, eventref parsing, and bounded concurrent resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->