### PR TITLE
feat(charts): datasets-S3 deploy support — worker PVC + migration Job (ADR-032)

### DIFF
--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -135,23 +135,35 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 
 ### Global configuration
 
-| Name                              | Description                                                                  | Value        |
-| --------------------------------- | ---------------------------------------------------------------------------- | ------------ |
-| `global.env`                      | Deployment environment for all components.                                   | `production` |
-| `global.podSecurityContext`       | Default pod security context (applied cluster-wide unless overridden).       | `{}`         |
-| `global.containerSecurityContext` | Default container security context (applied cluster-wide unless overridden). | `{}`         |
-| `global.automountServiceAccountToken` | Mount the ServiceAccount token into first-party workload pods. Defaults to false. | `false`  |
-| `global.scheduling`               | Global scheduling defaults for all pods.                                     |              |
-| `global.scheduling.nodeSelector`  | Node selector labels for all pods.                                           | `{}`         |
-| `global.scheduling.affinity`      | Affinity rules for all pods.                                                 | `{}`         |
-| `global.scheduling.tolerations`   | Tolerations applied to all pods.                                             | `[]`         |
+| Name                                  | Description                                                                                                                                                                                                                                                                                                                   | Value        |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `global.env`                          | Deployment environment for all components.                                                                                                                                                                                                                                                                                    | `production` |
+| `global.podSecurityContext`           | Default pod security context (applied cluster-wide unless overridden).                                                                                                                                                                                                                                                        | `{}`         |
+| `global.containerSecurityContext`     | Default container security context (applied cluster-wide unless overridden).                                                                                                                                                                                                                                                  | `{}`         |
+| `global.automountServiceAccountToken` | Mount the ServiceAccount token into first-party workload pods (app, workers, nlp, langevals, cronjobs, postgresql, redis, dataset-s3-migration Job). Defaults to false — none of these call the Kubernetes API, and many clusters deny pods that automount the token. Set true only if a sidecar needs in-cluster API access. | `false`      |
+| `global.scheduling`                   | Global scheduling defaults for all pods.                                                                                                                                                                                                                                                                                      |              |
+| `global.scheduling.nodeSelector`      | Node selector labels for all pods.                                                                                                                                                                                                                                                                                            | `{}`         |
+| `global.scheduling.affinity`          | Affinity rules for all pods.                                                                                                                                                                                                                                                                                                  | `{}`         |
+| `global.scheduling.tolerations`       | Tolerations applied to all pods.                                                                                                                                                                                                                                                                                              | `[]`         |
 
 ### Auto-generation
 
-| Name                      | Description                                                      | Value   |
-| ------------------------- | ---------------------------------------------------------------- | ------- |
-| `autogen.enabled`         | Enable automatic secret generation (development only).           | `false` |
-| `autogen.secretNames.app` | Secret name for the main LangWatch app (autogenerated if empty). | `""`    |
+
+### Preflight
+
+| Name                                 | Description                                                            | Value               |
+| ------------------------------------ | ---------------------------------------------------------------------- | ------------------- |
+| `preflight.enabled`                  | Run the pre-upgrade Secret-keys check.                                 | `true`              |
+| `preflight.image`                    | Container image for the preflight Job (needs sh + kubectl).            | `alpine/k8s:1.30.0` |
+| `preflight.imagePullPolicy`          | Pull policy for the preflight image.                                   | `IfNotPresent`      |
+| `preflight.activeDeadlineSeconds`    | Hard limit on hook runtime — beats helm hook timeout for clearer logs. | `60`                |
+| `preflight.podSecurityContext`       | Pod security context override for the preflight hook.                  | `{}`                |
+| `preflight.containerSecurityContext` | Container security context override for the preflight container.       | `{}`                |
+| `preflight.nodeSelector`             | Node selector override for the preflight hook.                         | `{}`                |
+| `preflight.tolerations`              | Tolerations override for the preflight hook.                           | `[]`                |
+| `preflight.affinity`                 | Affinity override for the preflight hook.                              | `{}`                |
+| `autogen.enabled`                    | Enable automatic secret generation (development only).                 | `false`             |
+| `autogen.secretNames.app`            | Secret name for the main LangWatch app (autogenerated if empty).       | `""`                |
 
 ### Secrets
 
@@ -161,143 +173,153 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `secrets.secretKeys.credentialsEncryptionKey` | Key name for credentials encryption.                 | `""`  |
 | `secrets.secretKeys.cronApiKey`               | Key name for cron API key.                           | `""`  |
 | `secrets.secretKeys.nextAuthSecret`           | Key name for NextAuth secret.                        | `""`  |
+| `secrets.secretKeys.virtualKeyPepper`         | Key name for AI Gateway virtual-key pepper.          | `""`  |
 
 ### Container images
 
-| Name                              | Description                  | Value |
-| --------------------------------- | ---------------------------- | ----- |
-| `images.app.repository`           | App image repository.        | `""`  |
-| `images.app.tag`                  | App image tag.               | `""`  |
-| `images.app.pullPolicy`           | App image pull policy.       | `""`  |
-| `images.langwatch_nlp.repository` | NLP image repository.        | `""`  |
-| `images.langwatch_nlp.tag`        | NLP image tag.               | `""`  |
-| `images.langwatch_nlp.pullPolicy` | NLP image pull policy.       | `""`  |
-| `images.langevals.repository`     | Langevals image repository.  | `""`  |
-| `images.langevals.tag`            | Langevals image tag.         | `""`  |
-| `images.langevals.pullPolicy`     | Langevals image pull policy. | `""`  |
+| Name                              | Description                                                         | Value |
+| --------------------------------- | ------------------------------------------------------------------- | ----- |
+| `images.app.repository`           | App image repository.                                               | `""`  |
+| `images.app.tag`                  | App image tag.                                                      | `""`  |
+| `images.app.pullPolicy`           | App image pull policy.                                              | `""`  |
+| `images.langwatch_nlp.repository` | NLP image repository (Go nlpgo binary, published as langwatch_nlp). | `""`  |
+| `images.langwatch_nlp.tag`        | NLP image tag.                                                      | `""`  |
+| `images.langwatch_nlp.pullPolicy` | NLP image pull policy.                                              | `""`  |
+| `images.langevals.repository`     | Langevals image repository.                                         | `""`  |
+| `images.langevals.tag`            | Langevals image tag.                                                | `""`  |
+| `images.langevals.pullPolicy`     | Langevals image pull policy.                                        | `""`  |
 
 ### LangWatch app
 
-| Name                                                                    | Description                                                                               | Value                   |
-| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------- |
-| `app.replicaCount`                                                      | Number of application replicas.                                                           | `1`                     |
-| `app.service`                                                           | Service configuration for the app.                                                        |                         |
-| `app.service.type`                                                      | Service type.                                                                             | `ClusterIP`             |
-| `app.service.port`                                                      | Service port.                                                                             | `5560`                  |
-| `app.resources`                                                         | Resource requests and limits for the app.                                                 |                         |
-| `app.resources.requests.cpu`                                            | Requested CPU.                                                                            | `250m`                  |
-| `app.resources.requests.memory`                                         | Requested memory.                                                                         | `2Gi`                   |
-| `app.resources.limits.cpu`                                              | CPU limit.                                                                                | `1000m`                 |
-| `app.resources.limits.memory`                                           | Memory limit.                                                                             | `4Gi`                   |
-| `app.nodeEnv`                                                           | Node.js environment override (falls back to global.env if empty).                         | `""`                    |
-| `app.credentialsEncryptionKey`                                          | Configuration for credentials encryption.                                                 |                         |
-| `app.credentialsEncryptionKey.value`                                    | Encryption key value (not recommended in production).                                     | `""`                    |
-| `app.credentialsEncryptionKey.secretKeyRef`                             | Reference to a secret holding the encryption key.                                         | `{}`                    |
-| `app.cronApiKey`                                                        | API key used by cron jobs for authentication.                                             |                         |
-| `app.cronApiKey.value`                                                  | Cron API key value.                                                                       | `""`                    |
-| `app.cronApiKey.secretKeyRef`                                           | Reference to a secret holding the cron API key.                                           | `{}`                    |
-| `app.http`                                                              | HTTP configuration for base/public URLs.                                                  |                         |
-| `app.http.baseHost`                                                     | Internal base URL.                                                                        | `http://localhost:5560` |
-| `app.http.publicUrl`                                                    | Public URL for users.                                                                     | `http://localhost:5560` |
-| `app.features`                                                          | Feature flags for the app.                                                                |                         |
-| `app.features.skipEnvValidation`                                        | Skip env var validation (dev only).                                                       | `false`                 |
-| `app.features.disableStrictPiiRedaction`                                | Skip the strict PII redaction pass (Presidio analysis service).                           | `false`                 |
-| `app.upstreams`                                                         | Upstream connections from app to internal services.                                       |                         |
-| `app.upstreams.nlp.scheme`                                              | Scheme for NLP upstream.                                                                  | `http`                  |
-| `app.upstreams.nlp.name`                                                | Service name for NLP upstream. If empty, defaults to {{ .Release.Name }}-langwatch-nlp.   | `""`                    |
-| `app.upstreams.nlp.port`                                                | Port for NLP upstream.                                                                    | `5561`                  |
-| `app.upstreams.langevals.scheme`                                        | Scheme for Langevals upstream.                                                            | `http`                  |
-| `app.upstreams.langevals.name`                                          | Service name for Langevals upstream. If empty, defaults to {{ .Release.Name }}-langevals. | `""`                    |
-| `app.upstreams.langevals.port`                                          | Port for Langevals upstream.                                                              | `5562`                  |
-| `app.evaluators`                                                        | Evaluator providers configuration.                                                        |                         |
-| `app.evaluators.azureOpenAI`                                            | Azure OpenAI evaluator configuration.                                                     |                         |
-| `app.evaluators.azureOpenAI.enabled`                                    | Enable Azure OpenAI evaluator.                                                            | `false`                 |
-| `app.evaluators.azureOpenAI.endpoint.value`                             | Azure OpenAI endpoint.                                                                    | `""`                    |
-| `app.evaluators.azureOpenAI.apiKey.value`                               | Azure OpenAI API key.                                                                     | `""`                    |
-| `app.evaluators.azureOpenAI.endpoint.secretKeyRef`                      | Secret ref for Azure OpenAI endpoint.                                                     | `{}`                    |
-| `app.evaluators.azureOpenAI.apiKey.secretKeyRef`                        | Secret ref for Azure OpenAI API key.                                                      | `{}`                    |
-| `app.evaluators.google`                                                 | Google evaluator configuration.                                                           |                         |
-| `app.evaluators.google.enabled`                                         | Enable Google evaluator.                                                                  | `false`                 |
-| `app.evaluators.google.credentials.value`                               | Google credentials JSON (base64 or inline).                                               | `""`                    |
-| `app.evaluators.google.credentials.secretKeyRef`                        | Secret ref for Google credentials JSON.                                                   | `{}`                    |
-| `app.dataplane`                                              | Object storage configuration for datasets.                                                |                         |
-| `app.dataplane.enabled`                                      | Enable dataset object storage.                                                            | `false`                 |
-| `app.dataplane.provider`                                     | Object storage provider.                                                                  | `awsS3`                 |
-| `app.dataplane.bucket`                                       | Bucket name for datasets.                                                                 | `langwatch-dataset`     |
-| `app.dataplane.providers.awsS3`                              | AWS S3 provider configuration.                                                            |                         |
-| `app.dataplane.providers.awsS3.endpoint.value`               | Custom S3 endpoint.                                                                       | `""`                    |
-| `app.dataplane.providers.awsS3.accessKeyId.value`            | S3 access key ID.                                                                         | `""`                    |
-| `app.dataplane.providers.awsS3.secretAccessKey.value`        | S3 secret access key.                                                                     | `""`                    |
-| `app.dataplane.providers.awsS3.keySalt.value`                | Optional key salt.                                                                        | `""`                    |
-| `app.dataplane.providers.awsS3.endpoint.secretKeyRef`        | Secret ref for custom S3 endpoint.                                                        | `{}`                    |
-| `app.dataplane.providers.awsS3.accessKeyId.secretKeyRef`     | Secret ref for S3 access key ID.                                                          | `{}`                    |
-| `app.dataplane.providers.awsS3.secretAccessKey.secretKeyRef` | Secret ref for S3 secret access key.                                                      | `{}`                    |
-| `app.dataplane.providers.awsS3.keySalt.secretKeyRef`         | Secret ref for optional key salt.                                                         | `{}`                    |
-| `app.email`                                                             | Email provider configuration.                                                             |                         |
-| `app.email.enabled`                                                     | Enable email notifications.                                                               | `false`                 |
-| `app.email.defaultFrom`                                                 | Default "from" address.                                                                   | `""`                    |
-| `app.email.provider`                                                    | Email provider.                                                                           | `sendgrid`              |
-| `app.email.providers.sendgrid`                                          | Sendgrid provider configuration.                                                          |                         |
-| `app.email.providers.sendgrid.apiKey.value`                             | Sendgrid API key.                                                                         | `""`                    |
-| `app.email.providers.sendgrid.apiKey.secretKeyRef`                      | Secret ref for SendGrid API key.                                                          | `{}`                    |
-| `app.nextAuth`                                                          | NextAuth configuration and providers.                                                     |                         |
-| `app.nextAuth.provider`                                                 | Default auth provider.                                                                    | `email`                 |
-| `app.nextAuth.secret.value`                                             | NextAuth secret value (not recommended inline for production).                            | `""`                    |
-| `app.nextAuth.secret.secretKeyRef`                                      | Secret ref for NextAuth secret.                                                           | `{}`                    |
-| `app.nextAuth.providers`                                                | OAuth providers configuration.                                                            |                         |
-| `app.nextAuth.providers.auth0`                                          | Auth0 OAuth configuration.                                                                |                         |
-| `app.nextAuth.providers.auth0.clientId.value`                           | Auth0 client ID.                                                                          | `""`                    |
-| `app.nextAuth.providers.auth0.clientSecret.value`                       | Auth0 client secret.                                                                      | `""`                    |
-| `app.nextAuth.providers.auth0.issuer.value`                             | Auth0 issuer URL.                                                                         | `""`                    |
-| `app.nextAuth.providers.auth0.clientId.value`                           | Auth0 client ID.                                                                          | `""`                    |
-| `app.nextAuth.providers.auth0.clientId.secretKeyRef`                    | Secret ref for Auth0 client ID.                                                           | `{}`                    |
-| `app.nextAuth.providers.auth0.clientSecret.value`                       | Auth0 client secret.                                                                      | `""`                    |
-| `app.nextAuth.providers.auth0.clientSecret.secretKeyRef`                | Secret ref for Auth0 client secret.                                                       | `{}`                    |
-| `app.nextAuth.providers.auth0.issuer.value`                             | Auth0 issuer URL.                                                                         | `""`                    |
-| `app.nextAuth.providers.auth0.issuer.secretKeyRef`                      | Secret ref for Auth0 issuer URL.                                                          | `{}`                    |
-| `app.nextAuth.providers.azureAd`                                        | Azure AD OAuth configuration.                                                             |                         |
-| `app.nextAuth.providers.azureAd.clientId.value`                         | Azure AD client ID.                                                                       | `""`                    |
-| `app.nextAuth.providers.azureAd.clientId.secretKeyRef`                  | Secret ref for Azure AD client ID.                                                        | `{}`                    |
-| `app.nextAuth.providers.azureAd.clientSecret.value`                     | Azure AD client secret.                                                                   | `""`                    |
-| `app.nextAuth.providers.azureAd.clientSecret.secretKeyRef`              | Secret ref for Azure AD client secret.                                                    | `{}`                    |
-| `app.nextAuth.providers.azureAd.tenantId.value`                         | Azure AD tenant ID.                                                                       | `""`                    |
-| `app.nextAuth.providers.azureAd.tenantId.secretKeyRef`                  | Secret ref for Azure AD tenant ID.                                                        | `{}`                    |
-| `app.nextAuth.providers.cognito`                                        | AWS Cognito OAuth configuration.                                                          |                         |
-| `app.nextAuth.providers.cognito.clientId.value`                         | Cognito client ID.                                                                        | `""`                    |
-| `app.nextAuth.providers.cognito.clientId.secretKeyRef`                  | Secret ref for Cognito client ID.                                                         | `{}`                    |
-| `app.nextAuth.providers.cognito.clientSecret.value`                     | Cognito client secret.                                                                    | `""`                    |
-| `app.nextAuth.providers.cognito.clientSecret.secretKeyRef`              | Secret ref for Cognito client secret.                                                     | `{}`                    |
-| `app.nextAuth.providers.cognito.issuer.value`                           | Cognito issuer URL.                                                                       | `""`                    |
-| `app.nextAuth.providers.cognito.issuer.secretKeyRef`                    | Secret ref for Cognito issuer URL.                                                        | `{}`                    |
-| `app.nextAuth.providers.github`                                         | GitHub OAuth configuration.                                                               |                         |
-| `app.nextAuth.providers.github.clientId.value`                          | GitHub client ID.                                                                         | `""`                    |
-| `app.nextAuth.providers.github.clientId.secretKeyRef`                   | Secret ref for GitHub client ID.                                                          | `{}`                    |
-| `app.nextAuth.providers.github.clientSecret.value`                      | GitHub client secret.                                                                     | `""`                    |
-| `app.nextAuth.providers.github.clientSecret.secretKeyRef`               | Secret ref for GitHub client secret.                                                      | `{}`                    |
-| `app.nextAuth.providers.gitlab`                                         | GitLab OAuth configuration.                                                               |                         |
-| `app.nextAuth.providers.gitlab.clientId.value`                          | GitLab client ID.                                                                         | `""`                    |
-| `app.nextAuth.providers.gitlab.clientId.secretKeyRef`                   | Secret ref for GitLab client ID.                                                          | `{}`                    |
-| `app.nextAuth.providers.gitlab.clientSecret.value`                      | GitLab client secret.                                                                     | `""`                    |
-| `app.nextAuth.providers.gitlab.clientSecret.secretKeyRef`               | Secret ref for GitLab client secret.                                                      | `{}`                    |
-| `app.nextAuth.providers.google`                                         | Google OAuth configuration.                                                               |                         |
-| `app.nextAuth.providers.google.clientId.value`                          | Google client ID.                                                                         | `""`                    |
-| `app.nextAuth.providers.google.clientId.secretKeyRef`                   | Secret ref for Google client ID.                                                          | `{}`                    |
-| `app.nextAuth.providers.google.clientSecret.value`                      | Google client secret.                                                                     | `""`                    |
-| `app.nextAuth.providers.google.clientSecret.secretKeyRef`               | Secret ref for Google client secret.                                                      | `{}`                    |
-| `app.nextAuth.providers.okta`                                           | Okta OAuth configuration.                                                                 |                         |
-| `app.nextAuth.providers.okta.clientId.value`                            | Okta client ID.                                                                           | `""`                    |
-| `app.nextAuth.providers.okta.clientId.secretKeyRef`                     | Secret ref for Okta client ID.                                                            | `{}`                    |
-| `app.nextAuth.providers.okta.clientSecret.value`                        | Okta client secret.                                                                       | `""`                    |
-| `app.nextAuth.providers.okta.clientSecret.secretKeyRef`                 | Secret ref for Okta client secret.                                                        | `{}`                    |
-| `app.nextAuth.providers.okta.issuer.value`                              | Okta issuer URL.                                                                          | `""`                    |
-| `app.nextAuth.providers.okta.issuer.secretKeyRef`                       | Secret ref for Okta issuer URL.                                                           | `{}`                    |
-| `app.telemetry`                                                         | Telemetry configuration.                                                                  |                         |
-| `app.telemetry.usage`                                                   | Usage analytics.                                                                          |                         |
-| `app.telemetry.usage.enabled`                                           | Enable anonymous usage analytics.                                                         | `true`                  |
-| `app.telemetry.metrics`                                                 | Metrics configuration.                                                                    |                         |
-| `app.telemetry.metrics.enabled`                                         | Enable metrics collection.                                                                | `false`                 |
-| `app.telemetry.metrics.apiKey.value`                                    | Metrics API key.                                                                          | `""`                    |
-| `app.telemetry.metrics.apiKey.secretKeyRef`                             | Secret ref for metrics API key.                                                           | `{}`                    |
+| Name                                                         | Description                                                                                                           | Value                        |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `app.replicaCount`                                           | Number of application replicas.                                                                                       | `1`                          |
+| `app.service`                                                | Service configuration for the app.                                                                                    |                              |
+| `app.service.type`                                           | Service type.                                                                                                         | `ClusterIP`                  |
+| `app.service.port`                                           | Service port.                                                                                                         | `5560`                       |
+| `app.resources`                                              | Resource requests and limits for the app.                                                                             |                              |
+| `app.resources.requests.cpu`                                 | Requested CPU.                                                                                                        | `250m`                       |
+| `app.resources.requests.memory`                              | Requested memory.                                                                                                     | `2Gi`                        |
+| `app.resources.limits.cpu`                                   | CPU limit.                                                                                                            | `1000m`                      |
+| `app.resources.limits.memory`                                | Memory limit.                                                                                                         | `4Gi`                        |
+| `app.nodeEnv`                                                | Node.js environment override (falls back to global.env if empty).                                                     | `""`                         |
+| `app.credentialsEncryptionKey`                               | Configuration for credentials encryption.                                                                             |                              |
+| `app.credentialsEncryptionKey.value`                         | Encryption key value (not recommended in production).                                                                 | `""`                         |
+| `app.credentialsEncryptionKey.secretKeyRef`                  | Reference to a secret holding the encryption key.                                                                     | `{}`                         |
+| `app.cronApiKey`                                             | API key used by cron jobs for authentication.                                                                         |                              |
+| `app.cronApiKey.value`                                       | Cron API key value.                                                                                                   | `""`                         |
+| `app.cronApiKey.secretKeyRef`                                | Reference to a secret holding the cron API key.                                                                       | `{}`                         |
+| `app.virtualKeyPepper`                                       | Pepper for hashing AI Gateway virtual-key secrets.                                                                    |                              |
+| `app.virtualKeyPepper.value`                                 | Pepper value (not recommended inline for production).                                                                 | `""`                         |
+| `app.virtualKeyPepper.secretKeyRef`                          | Reference to a secret holding the pepper.                                                                             | `{}`                         |
+| `app.http`                                                   | HTTP configuration for base/public URLs.                                                                              |                              |
+| `app.http.baseHost`                                          | Internal base URL.                                                                                                    | `http://localhost:5560`      |
+| `app.http.publicUrl`                                         | Public URL for users.                                                                                                 | `http://localhost:5560`      |
+| `app.features`                                               | Feature flags for the app.                                                                                            |                              |
+| `app.features.skipEnvValidation`                             | Skip env var validation (dev only).                                                                                   | `false`                      |
+| `app.features.disableStrictPiiRedaction`                     | Skip the strict PII redaction pass (Presidio analysis service). Native secrets and essential PII redaction still run. | `false`                      |
+| `app.features.topicClustering`                               | Enable automatic topic clustering.                                                                                    | `true`                       |
+| `app.upstreams`                                              | Upstream connections from app to internal services.                                                                   |                              |
+| `app.upstreams.nlp.scheme`                                   | Scheme for NLP upstream.                                                                                              | `http`                       |
+| `app.upstreams.nlp.name`                                     | Service name for NLP upstream. If empty, defaults to {{ .Release.Name }}-langwatch-nlp.                               | `""`                         |
+| `app.upstreams.nlp.port`                                     | Port for NLP upstream.                                                                                                | `5561`                       |
+| `app.upstreams.langevals.scheme`                             | Scheme for Langevals upstream.                                                                                        | `http`                       |
+| `app.upstreams.langevals.name`                               | Service name for Langevals upstream. If empty, defaults to {{ .Release.Name }}-langevals.                             | `""`                         |
+| `app.upstreams.langevals.port`                               | Port for Langevals upstream.                                                                                          | `5562`                       |
+| `app.evaluators`                                             | Evaluator providers configuration.                                                                                    |                              |
+| `app.evaluators.azureOpenAI`                                 | Azure OpenAI evaluator configuration.                                                                                 |                              |
+| `app.evaluators.azureOpenAI.enabled`                         | Enable Azure OpenAI evaluator.                                                                                        | `false`                      |
+| `app.evaluators.azureOpenAI.endpoint.value`                  | Azure OpenAI endpoint.                                                                                                | `""`                         |
+| `app.evaluators.azureOpenAI.apiKey.value`                    | Azure OpenAI API key.                                                                                                 | `""`                         |
+| `app.evaluators.azureOpenAI.endpoint.secretKeyRef`           | Secret ref for Azure OpenAI endpoint.                                                                                 | `{}`                         |
+| `app.evaluators.azureOpenAI.apiKey.secretKeyRef`             | Secret ref for Azure OpenAI API key.                                                                                  | `{}`                         |
+| `app.evaluators.google`                                      | Google evaluator configuration.                                                                                       |                              |
+| `app.evaluators.google.enabled`                              | Enable Google evaluator.                                                                                              | `false`                      |
+| `app.evaluators.google.credentials.value`                    | Google credentials JSON (base64 or inline).                                                                           | `""`                         |
+| `app.evaluators.google.credentials.secretKeyRef`             | Secret ref for Google credentials JSON.                                                                               | `{}`                         |
+| `app.dataplane`                                              | Object storage configuration for datasets.                                                                            |                              |
+| `app.dataplane.enabled`                                      | Enable dataset object storage.                                                                                        | `false`                      |
+| `app.dataplane.provider`                                     | Object storage provider.                                                                                              | `awsS3`                      |
+| `app.dataplane.bucket`                                       | Bucket name for datasets.                                                                                             | `langwatch-dataset`          |
+| `app.dataplane.providers.awsS3`                              | AWS S3 provider configuration.                                                                                        |                              |
+| `app.dataplane.providers.awsS3.endpoint.value`               | Custom S3 endpoint.                                                                                                   | `""`                         |
+| `app.dataplane.providers.awsS3.accessKeyId.value`            | S3 access key ID (not recommended in production — use accessKeyId.secretKeyRef).                                      | `""`                         |
+| `app.dataplane.providers.awsS3.secretAccessKey.value`        | S3 secret access key (not recommended in production — use secretAccessKey.secretKeyRef).                              | `""`                         |
+| `app.dataplane.providers.awsS3.keySalt.value`                | Optional key salt.                                                                                                    | `""`                         |
+| `app.dataplane.providers.awsS3.endpoint.secretKeyRef`        | Secret ref for custom S3 endpoint.                                                                                    | `{}`                         |
+| `app.dataplane.providers.awsS3.accessKeyId.secretKeyRef`     | Secret ref for S3 access key ID.                                                                                      | `{}`                         |
+| `app.dataplane.providers.awsS3.secretAccessKey.secretKeyRef` | Secret ref for S3 secret access key.                                                                                  | `{}`                         |
+| `app.dataplane.providers.awsS3.keySalt.secretKeyRef`         | Secret ref for optional key salt.                                                                                     | `{}`                         |
+| `app.storedObjects`                                          | Stored-objects configuration.                                                                                         |                              |
+| `app.storedObjects.localFilesystem.enabled`                  | Use a local-FS path for stored-objects bytes. Disable when using app.dataplane (S3) instead.                          | `true`                       |
+| `app.storedObjects.localFilesystem.path`                     | Mount point that the LocalFilesystemDriver writes under.                                                              | `/var/lib/langwatch/objects` |
+| `app.storedObjects.localFilesystem.size`                     | PVC size for the stored-objects volume.                                                                               | `10Gi`                       |
+| `app.storedObjects.localFilesystem.storageClassName`         | PVC storageClassName (cluster default if empty).                                                                      | `""`                         |
+| `app.email`                                                  | Email provider configuration.                                                                                         |                              |
+| `app.email.enabled`                                          | Enable email notifications.                                                                                           | `false`                      |
+| `app.email.defaultFrom`                                      | Default "from" address.                                                                                               | `""`                         |
+| `app.email.provider`                                         | Email provider.                                                                                                       | `sendgrid`                   |
+| `app.email.providers.sendgrid`                               | Sendgrid provider configuration.                                                                                      |                              |
+| `app.email.providers.sendgrid.apiKey.value`                  | Sendgrid API key.                                                                                                     | `""`                         |
+| `app.email.providers.sendgrid.apiKey.secretKeyRef`           | Secret ref for SendGrid API key.                                                                                      | `{}`                         |
+| `app.nextAuth`                                               | NextAuth configuration and providers.                                                                                 |                              |
+| `app.nextAuth.provider`                                      | Default auth provider.                                                                                                | `email`                      |
+| `app.nextAuth.secret.value`                                  | NextAuth secret value (not recommended inline for production).                                                        | `""`                         |
+| `app.nextAuth.secret.secretKeyRef`                           | Secret ref for NextAuth secret.                                                                                       | `{}`                         |
+| `app.nextAuth.providers`                                     | OAuth providers configuration.                                                                                        |                              |
+| `app.nextAuth.providers.auth0`                               | Auth0 OAuth configuration.                                                                                            |                              |
+| `app.nextAuth.providers.auth0.clientId.value`                | Auth0 client ID.                                                                                                      | `""`                         |
+| `app.nextAuth.providers.auth0.clientSecret.value`            | Auth0 client secret.                                                                                                  | `""`                         |
+| `app.nextAuth.providers.auth0.issuer.value`                  | Auth0 issuer URL.                                                                                                     | `""`                         |
+| `app.nextAuth.providers.auth0.clientId.value`                | Auth0 client ID.                                                                                                      | `""`                         |
+| `app.nextAuth.providers.auth0.clientId.secretKeyRef`         | Secret ref for Auth0 client ID.                                                                                       | `{}`                         |
+| `app.nextAuth.providers.auth0.clientSecret.value`            | Auth0 client secret.                                                                                                  | `""`                         |
+| `app.nextAuth.providers.auth0.clientSecret.secretKeyRef`     | Secret ref for Auth0 client secret.                                                                                   | `{}`                         |
+| `app.nextAuth.providers.auth0.issuer.value`                  | Auth0 issuer URL.                                                                                                     | `""`                         |
+| `app.nextAuth.providers.auth0.issuer.secretKeyRef`           | Secret ref for Auth0 issuer URL.                                                                                      | `{}`                         |
+| `app.nextAuth.providers.azureAd`                             | Azure AD OAuth configuration.                                                                                         |                              |
+| `app.nextAuth.providers.azureAd.clientId.value`              | Azure AD client ID.                                                                                                   | `""`                         |
+| `app.nextAuth.providers.azureAd.clientId.secretKeyRef`       | Secret ref for Azure AD client ID.                                                                                    | `{}`                         |
+| `app.nextAuth.providers.azureAd.clientSecret.value`          | Azure AD client secret.                                                                                               | `""`                         |
+| `app.nextAuth.providers.azureAd.clientSecret.secretKeyRef`   | Secret ref for Azure AD client secret.                                                                                | `{}`                         |
+| `app.nextAuth.providers.azureAd.tenantId.value`              | Azure AD tenant ID.                                                                                                   | `""`                         |
+| `app.nextAuth.providers.azureAd.tenantId.secretKeyRef`       | Secret ref for Azure AD tenant ID.                                                                                    | `{}`                         |
+| `app.nextAuth.providers.cognito`                             | AWS Cognito OAuth configuration.                                                                                      |                              |
+| `app.nextAuth.providers.cognito.clientId.value`              | Cognito client ID.                                                                                                    | `""`                         |
+| `app.nextAuth.providers.cognito.clientId.secretKeyRef`       | Secret ref for Cognito client ID.                                                                                     | `{}`                         |
+| `app.nextAuth.providers.cognito.clientSecret.value`          | Cognito client secret.                                                                                                | `""`                         |
+| `app.nextAuth.providers.cognito.clientSecret.secretKeyRef`   | Secret ref for Cognito client secret.                                                                                 | `{}`                         |
+| `app.nextAuth.providers.cognito.issuer.value`                | Cognito issuer URL.                                                                                                   | `""`                         |
+| `app.nextAuth.providers.cognito.issuer.secretKeyRef`         | Secret ref for Cognito issuer URL.                                                                                    | `{}`                         |
+| `app.nextAuth.providers.github`                              | GitHub OAuth configuration.                                                                                           |                              |
+| `app.nextAuth.providers.github.clientId.value`               | GitHub client ID.                                                                                                     | `""`                         |
+| `app.nextAuth.providers.github.clientId.secretKeyRef`        | Secret ref for GitHub client ID.                                                                                      | `{}`                         |
+| `app.nextAuth.providers.github.clientSecret.value`           | GitHub client secret.                                                                                                 | `""`                         |
+| `app.nextAuth.providers.github.clientSecret.secretKeyRef`    | Secret ref for GitHub client secret.                                                                                  | `{}`                         |
+| `app.nextAuth.providers.gitlab`                              | GitLab OAuth configuration.                                                                                           |                              |
+| `app.nextAuth.providers.gitlab.clientId.value`               | GitLab client ID.                                                                                                     | `""`                         |
+| `app.nextAuth.providers.gitlab.clientId.secretKeyRef`        | Secret ref for GitLab client ID.                                                                                      | `{}`                         |
+| `app.nextAuth.providers.gitlab.clientSecret.value`           | GitLab client secret.                                                                                                 | `""`                         |
+| `app.nextAuth.providers.gitlab.clientSecret.secretKeyRef`    | Secret ref for GitLab client secret.                                                                                  | `{}`                         |
+| `app.nextAuth.providers.google`                              | Google OAuth configuration.                                                                                           |                              |
+| `app.nextAuth.providers.google.clientId.value`               | Google client ID.                                                                                                     | `""`                         |
+| `app.nextAuth.providers.google.clientId.secretKeyRef`        | Secret ref for Google client ID.                                                                                      | `{}`                         |
+| `app.nextAuth.providers.google.clientSecret.value`           | Google client secret.                                                                                                 | `""`                         |
+| `app.nextAuth.providers.google.clientSecret.secretKeyRef`    | Secret ref for Google client secret.                                                                                  | `{}`                         |
+| `app.nextAuth.providers.okta`                                | Okta OAuth configuration.                                                                                             |                              |
+| `app.nextAuth.providers.okta.clientId.value`                 | Okta client ID.                                                                                                       | `""`                         |
+| `app.nextAuth.providers.okta.clientId.secretKeyRef`          | Secret ref for Okta client ID.                                                                                        | `{}`                         |
+| `app.nextAuth.providers.okta.clientSecret.value`             | Okta client secret.                                                                                                   | `""`                         |
+| `app.nextAuth.providers.okta.clientSecret.secretKeyRef`      | Secret ref for Okta client secret.                                                                                    | `{}`                         |
+| `app.nextAuth.providers.okta.issuer.value`                   | Okta issuer URL.                                                                                                      | `""`                         |
+| `app.nextAuth.providers.okta.issuer.secretKeyRef`            | Secret ref for Okta issuer URL.                                                                                       | `{}`                         |
+| `app.telemetry`                                              | Telemetry configuration.                                                                                              |                              |
+| `app.telemetry.usage`                                        | Usage analytics.                                                                                                      |                              |
+| `app.telemetry.usage.enabled`                                | Enable anonymous usage analytics.                                                                                     | `true`                       |
+| `app.telemetry.metrics`                                      | Metrics configuration.                                                                                                |                              |
+| `app.telemetry.metrics.enabled`                              | Enable metrics collection.                                                                                            | `false`                      |
+| `app.telemetry.metrics.apiKey.value`                         | Metrics API key.                                                                                                      | `""`                         |
+| `app.telemetry.metrics.apiKey.secretKeyRef`                  | Secret ref for metrics API key.                                                                                       | `{}`                         |
 
 ### CronJobs Kubernetes overrides
 
@@ -332,37 +354,67 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `app.extraVolumes`                    | Additional pod volumes.                             | `[]`  |
 | `app.extraInitContainers`             | Additional init containers.                         | `[]`  |
 | `app.extraLifecycle`                  | Additional lifecycle hooks for app container.       | `{}`  |
-| `app.extraVolumeMounts`              | Additional volume mounts for app container.         | `[]`  |
+| `app.extraVolumeMounts`               | Additional volume mounts for app container.         | `[]`  |
 
 ### Workers
 
-| Name                                      | Description                                     | Value   |
-| ----------------------------------------- | ----------------------------------------------- | ------- |
-| `workers.replicaCount`                    | Number of worker replicas.                      | `1`     |
-| `workers.resources`                       | Resource requests and limits for workers.       |         |
-| `workers.resources.requests.cpu`          | Requested CPU.                                  | `250m`  |
-| `workers.resources.requests.memory`       | Requested memory.                               | `2Gi`   |
-| `workers.resources.limits.cpu`            | CPU limit.                                      | `1000m` |
-| `workers.resources.limits.memory`         | Memory limit.                                   | `4Gi`   |
-| `workers.podSecurityContext`              | Pod security context overrides.                 | `{}`    |
-| `workers.containerSecurityContext`        | Container security context overrides.           | `{}`    |
-| `workers.podDisruptionBudget`             | PodDisruptionBudget spec overrides.             | `{}`    |
-| `workers.nodeSelector`                    | Node selector overrides.                        | `{}`    |
-| `workers.tolerations`                     | Tolerations overrides.                          | `[]`    |
-| `workers.affinity`                        | Affinity overrides.                             | `{}`    |
-| `workers.pod`                             | Pod-level metadata.                             |         |
-| `workers.pod.annotations`                 | Additional pod annotations.                     | `{}`    |
-| `workers.pod.labels`                      | Additional pod labels.                          | `{}`    |
-| `workers.deployment`                      | Deployment-level metadata and strategy.         |         |
-| `workers.deployment.annotations`          | Additional deployment annotations.              | `{}`    |
-| `workers.deployment.labels`               | Additional deployment labels.                   | `{}`    |
-| `workers.deployment.strategy`             | Deployment strategy overrides.                  | `{}`    |
-| `workers.deployment.revisionHistoryLimit` | Number of old replicasets to retain.            | `10`    |
-| `workers.extraEnvs`                       | Additional environment variables.               | `[]`    |
-| `workers.extraContainers`                 | Additional sidecar containers.                  | `[]`    |
-| `workers.extraVolumes`                    | Additional pod volumes.                         | `[]`    |
-| `workers.extraInitContainers`             | Additional init containers.                     | `[]`    |
-| `workers.extraVolumeMounts`               | Additional volume mounts for workers container. | `[]`    |
+| Name                                      | Description                                     | Value           |
+| ----------------------------------------- | ----------------------------------------------- | --------------- |
+| `workers.enabled`                         | Deploy the workers Deployment + PDB.            | `true`          |
+| `workers.replicaCount`                    | Number of worker replicas.                      | `1`             |
+| `workers.resources`                       | Resource requests and limits for workers.       |                 |
+| `workers.resources.requests.cpu`          | Requested CPU.                                  | `250m`          |
+| `workers.resources.requests.memory`       | Requested memory.                               | `2Gi`           |
+| `workers.resources.limits.cpu`            | CPU limit.                                      | `1000m`         |
+| `workers.resources.limits.memory`         | Memory limit.                                   | `4Gi`           |
+| `workers.upstreams`                       | Upstream to app (callbacks, etc.).              |                 |
+| `workers.upstreams.langwatch.scheme`      | Scheme to app.                                  | `http`          |
+| `workers.upstreams.langwatch.name`        | Service name for app.                           | `langwatch-app` |
+| `workers.upstreams.langwatch.port`        | Port to app.                                    | `5560`          |
+| `workers.podSecurityContext`              | Pod security context overrides.                 | `{}`            |
+| `workers.containerSecurityContext`        | Container security context overrides.           | `{}`            |
+| `workers.podDisruptionBudget`             | PodDisruptionBudget spec overrides.             | `{}`            |
+| `workers.nodeSelector`                    | Node selector overrides.                        | `{}`            |
+| `workers.tolerations`                     | Tolerations overrides.                          | `[]`            |
+| `workers.affinity`                        | Affinity overrides.                             | `{}`            |
+| `workers.topologySpreadConstraints`       | Topology spread constraints overrides.          | `[]`            |
+| `workers.pod`                             | Pod-level metadata.                             |                 |
+| `workers.pod.annotations`                 | Additional pod annotations.                     | `{}`            |
+| `workers.pod.labels`                      | Additional pod labels.                          | `{}`            |
+| `workers.deployment`                      | Deployment-level metadata and strategy.         |                 |
+| `workers.deployment.annotations`          | Additional deployment annotations.              | `{}`            |
+| `workers.deployment.labels`               | Additional deployment labels.                   | `{}`            |
+| `workers.deployment.strategy`             | Deployment strategy overrides.                  | `{}`            |
+| `workers.deployment.revisionHistoryLimit` | Number of old replicasets to retain.            | `10`            |
+| `workers.extraEnvs`                       | Additional environment variables.               | `[]`            |
+| `workers.extraContainers`                 | Additional sidecar containers.                  | `[]`            |
+| `workers.extraVolumes`                    | Additional pod volumes.                         | `[]`            |
+| `workers.extraInitContainers`             | Additional init containers.                     | `[]`            |
+| `workers.extraVolumeMounts`               | Additional volume mounts for workers container. | `[]`            |
+
+### Dataset S3 migration
+
+| Name                                           | Description                                                                                                                                                                                              | Value   |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `datasetS3Migration.enabled`                   | Render the post-install/post-upgrade migration hook Job.                                                                                                                                                 | `true`  |
+| `datasetS3Migration.skip`                      | Disable the dataset PG→S3 backfill migration entirely.                                                                                                                                                   | `false` |
+| `datasetS3Migration.backoffLimit`              | Job backoffLimit — retries on transient failure (the task is idempotent).                                                                                                                                | `3`     |
+| `datasetS3Migration.activeDeadlineSeconds`     | Hard runtime limit (s) for the hook Job — a backstop so a hung migration can't run forever. The task is idempotent/resumable, so a re-run resumes; raise for very large installs or set null to disable. | `21600` |
+| `datasetS3Migration.serviceAccountName`        | ServiceAccount for the Job (set to the app/workers IRSA SA on EKS).                                                                                                                                      | `""`    |
+| `datasetS3Migration.ttlSecondsAfterFinished`   | Clean up the finished Job after this many seconds.                                                                                                                                                       | `600`   |
+| `datasetS3Migration.resources`                 | Resource requests and limits for the migration Job.                                                                                                                                                      |         |
+| `datasetS3Migration.resources.requests.cpu`    | Requested CPU.                                                                                                                                                                                           | `100m`  |
+| `datasetS3Migration.resources.requests.memory` | Requested memory.                                                                                                                                                                                        | `512Mi` |
+| `datasetS3Migration.resources.limits.cpu`      | CPU limit.                                                                                                                                                                                               | `1000m` |
+| `datasetS3Migration.resources.limits.memory`   | Memory limit.                                                                                                                                                                                            | `2Gi`   |
+| `datasetS3Migration.podSecurityContext`        | Pod security context override.                                                                                                                                                                           | `{}`    |
+| `datasetS3Migration.containerSecurityContext`  | Container security context override.                                                                                                                                                                     | `{}`    |
+| `datasetS3Migration.nodeSelector`              | Node selector override.                                                                                                                                                                                  | `{}`    |
+| `datasetS3Migration.tolerations`               | Tolerations override.                                                                                                                                                                                    | `[]`    |
+| `datasetS3Migration.affinity`                  | Affinity override.                                                                                                                                                                                       | `{}`    |
+| `datasetS3Migration.extraEnvs`                 | Additional environment variables for the migration Job.                                                                                                                                                  | `[]`    |
+| `datasetS3Migration.extraVolumes`              | Additional pod volumes.                                                                                                                                                                                  | `[]`    |
+| `datasetS3Migration.extraVolumeMounts`         | Additional volume mounts.                                                                                                                                                                                | `[]`    |
 
 ### NLP service
 
@@ -435,54 +487,54 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `langevals.extraContainers`                 | Additional sidecar containers.          | `[]`        |
 | `langevals.extraVolumes`                    | Additional pod volumes.                 | `[]`        |
 | `langevals.extraInitContainers`             | Additional init containers.             | `[]`        |
-| `langevals.extraLifecycle`                 | Additional lifecycle hooks.             | `{}`        |
-| `langevals.extraVolumeMounts`              | Additional volume mounts.               | `[]`        |
+| `langevals.extraLifecycle`                  | Additional lifecycle hooks.             | `{}`        |
+| `langevals.extraVolumeMounts`               | Additional volume mounts.               | `[]`        |
 
 ### CronJobs
 
-| Name                                            | Description                                        | Value                                       |
-| ----------------------------------------------- | -------------------------------------------------- | ------------------------------------------- |
-| `cronjobs.enabled`                              | Enable all cron jobs.                              | `true`                                      |
-| `cronjobs.labels`                               | Additional labels for CronJob resources.           | `{}`                                        |
-| `cronjobs.image`                                | Cron job image.                                    |                                             |
-| `cronjobs.image.repository`                     | Image repository.                                  | `curlimages/curl`                           |
-| `cronjobs.image.tag`                            | Image tag.                                         | `8.12.1`                                    |
-| `cronjobs.image.pullPolicy`                     | Image pull policy.                                 | `IfNotPresent`                              |
-| `cronjobs.resources`                            | Resource requests and limits for jobs.             |                                             |
-| `cronjobs.resources.requests.cpu`               | Requested CPU.                                     | `100m`                                      |
-| `cronjobs.resources.requests.memory`            | Requested memory.                                  | `64Mi`                                      |
-| `cronjobs.resources.limits.cpu`                 | CPU limit.                                         | `100m`                                      |
-| `cronjobs.resources.limits.memory`              | Memory limit.                                      | `64Mi`                                      |
-| `cronjobs.jobs`                                 | Individual cron job endpoints and schedules.       |                                             |
-| `cronjobs.jobs.topicClustering`                 | Topic clustering job.                              |                                             |
-| `cronjobs.jobs.topicClustering.enabled`         | Enable topic clustering job.                       | `true`                                      |
-| `cronjobs.jobs.topicClustering.schedule`        | Cron schedule.                                     | `0 0 * * *`                                 |
-| `cronjobs.jobs.topicClustering.endpoint`        | Endpoint path.                                     | `/api/cron/schedule_topic_clustering`       |
-| `cronjobs.jobs.alertTriggers`                   | Alert triggers job.                                |                                             |
-| `cronjobs.jobs.alertTriggers.enabled`           | Enable alert triggers job.                         | `true`                                      |
-| `cronjobs.jobs.alertTriggers.schedule`          | Cron schedule.                                     | `*/3 * * * *`                               |
-| `cronjobs.jobs.alertTriggers.endpoint`          | Endpoint path.                                     | `/api/cron/triggers`                        |
-| `cronjobs.podSecurityContext`                   | Pod security context overrides.                    | `{}`                                        |
-| `cronjobs.containerSecurityContext`             | Container security context overrides.              | `{}`                                        |
-| `cronjobs.nodeSelector`                         | Node selector overrides.                           | `{}`                                        |
-| `cronjobs.tolerations`                          | Tolerations overrides.                             | `[]`                                        |
-| `cronjobs.affinity`                             | Affinity overrides.                                | `{}`                                        |
-| `cronjobs.topologySpreadConstraints`            | Topology spread constraints.                       | `[]`                                        |
-| `cronjobs.cronjob`                              | CronJob-level metadata.                            |                                             |
-| `cronjobs.cronjob.annotations`                  | CronJob annotations.                               | `{}`                                        |
-| `cronjobs.cronjob.labels`                       | CronJob labels.                                    | `{}`                                        |
-| `cronjobs.job`                                  | Job-level metadata.                                |                                             |
-| `cronjobs.job.annotations`                      | Job annotations.                                   | `{}`                                        |
-| `cronjobs.job.labels`                           | Job labels.                                        | `{}`                                        |
-| `cronjobs.pod`                                  | Pod-level metadata.                                |                                             |
-| `cronjobs.pod.annotations`                      | Pod annotations.                                   | `{}`                                        |
-| `cronjobs.pod.labels`                           | Pod labels.                                        | `{}`                                        |
-| `cronjobs.extraEnvs`                            | Additional environment variables.                  | `[]`                                        |
-| `cronjobs.extraContainers`                      | Additional containers.                             | `[]`                                        |
-| `cronjobs.extraVolumes`                         | Additional volumes.                                | `[]`                                        |
-| `cronjobs.extraInitContainers`                  | Additional init containers.                        | `[]`                                        |
-| `cronjobs.extraLifecycle`                       | Additional lifecycle hooks for cron job container. | `{}`                                        |
-| `cronjobs.extraVolumeMounts`                    | Additional volume mounts for cron job container.   | `[]`                                        |
+| Name                                     | Description                                        | Value                                 |
+| ---------------------------------------- | -------------------------------------------------- | ------------------------------------- |
+| `cronjobs.enabled`                       | Enable all cron jobs.                              | `true`                                |
+| `cronjobs.labels`                        | Additional labels for CronJob resources.           | `{}`                                  |
+| `cronjobs.image`                         | Cron job image.                                    |                                       |
+| `cronjobs.image.repository`              | Image repository.                                  | `curlimages/curl`                     |
+| `cronjobs.image.tag`                     | Image tag.                                         | `8.12.1`                              |
+| `cronjobs.image.pullPolicy`              | Image pull policy.                                 | `IfNotPresent`                        |
+| `cronjobs.resources`                     | Resource requests and limits for jobs.             |                                       |
+| `cronjobs.resources.requests.cpu`        | Requested CPU.                                     | `100m`                                |
+| `cronjobs.resources.requests.memory`     | Requested memory.                                  | `64Mi`                                |
+| `cronjobs.resources.limits.cpu`          | CPU limit.                                         | `100m`                                |
+| `cronjobs.resources.limits.memory`       | Memory limit.                                      | `64Mi`                                |
+| `cronjobs.jobs`                          | Individual cron job endpoints and schedules.       |                                       |
+| `cronjobs.jobs.topicClustering`          | Topic clustering job.                              |                                       |
+| `cronjobs.jobs.topicClustering.enabled`  | Enable topic clustering job.                       | `true`                                |
+| `cronjobs.jobs.topicClustering.schedule` | Cron schedule.                                     | `0 0 * * *`                           |
+| `cronjobs.jobs.topicClustering.endpoint` | Endpoint path.                                     | `/api/cron/schedule_topic_clustering` |
+| `cronjobs.jobs.alertTriggers`            | Alert triggers job.                                |                                       |
+| `cronjobs.jobs.alertTriggers.enabled`    | Enable alert triggers job.                         | `true`                                |
+| `cronjobs.jobs.alertTriggers.schedule`   | Cron schedule.                                     | `*/3 * * * *`                         |
+| `cronjobs.jobs.alertTriggers.endpoint`   | Endpoint path.                                     | `/api/cron/triggers`                  |
+| `cronjobs.podSecurityContext`            | Pod security context overrides.                    | `{}`                                  |
+| `cronjobs.containerSecurityContext`      | Container security context overrides.              | `{}`                                  |
+| `cronjobs.nodeSelector`                  | Node selector overrides.                           | `{}`                                  |
+| `cronjobs.tolerations`                   | Tolerations overrides.                             | `[]`                                  |
+| `cronjobs.affinity`                      | Affinity overrides.                                | `{}`                                  |
+| `cronjobs.topologySpreadConstraints`     | Topology spread constraints.                       | `[]`                                  |
+| `cronjobs.cronjob`                       | CronJob-level metadata.                            |                                       |
+| `cronjobs.cronjob.annotations`           | CronJob annotations.                               | `{}`                                  |
+| `cronjobs.cronjob.labels`                | CronJob labels.                                    | `{}`                                  |
+| `cronjobs.job`                           | Job-level metadata.                                |                                       |
+| `cronjobs.job.annotations`               | Job annotations.                                   | `{}`                                  |
+| `cronjobs.job.labels`                    | Job labels.                                        | `{}`                                  |
+| `cronjobs.pod`                           | Pod-level metadata.                                |                                       |
+| `cronjobs.pod.annotations`               | Pod annotations.                                   | `{}`                                  |
+| `cronjobs.pod.labels`                    | Pod labels.                                        | `{}`                                  |
+| `cronjobs.extraEnvs`                     | Additional environment variables.                  | `[]`                                  |
+| `cronjobs.extraContainers`               | Additional containers.                             | `[]`                                  |
+| `cronjobs.extraVolumes`                  | Additional volumes.                                | `[]`                                  |
+| `cronjobs.extraInitContainers`           | Additional init containers.                        | `[]`                                  |
+| `cronjobs.extraLifecycle`                | Additional lifecycle hooks for cron job container. | `{}`                                  |
+| `cronjobs.extraVolumeMounts`             | Additional volume mounts for cron job container.   | `[]`                                  |
 
 ### Ingress
 
@@ -513,7 +565,7 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `prometheus.rbac.create`                          | Create RBAC resources.                     | `true`                          |
 | `prometheus.serviceAccounts.server`               | ServiceAccount settings.                   |                                 |
 | `prometheus.serviceAccounts.server.create`        | Create a dedicated ServiceAccount.         | `true`                          |
-| `prometheus.server.configMapOverrideName`         | Override ConfigMap name for scrape config. | `prometheus-config`             |
+| `prometheus.server.configMapOverrideName`         | Override ConfigMap name for scrape config. | `""`                            |
 | `prometheus.server.image`                         | Image configuration.                       |                                 |
 | `prometheus.server.image.repository`              | Image repository.                          | `quay.io/prometheus/prometheus` |
 | `prometheus.server.image.tag`                     | Image tag.                                 | `v3.2.1`                        |
@@ -556,7 +608,7 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `postgresql.auth.secretKeys.databaseKey`            | Database key.                                        | `database`          |
 | `postgresql.image`                                  | PostgreSQL container image.                          |                     |
 | `postgresql.image.repository`                       | Image repository.                                    | `postgres`          |
-| `postgresql.image.tag`                              | Image tag.                                           | `"17"`              |
+| `postgresql.image.tag`                              | Image tag.                                           | `"17.5"`            |
 | `postgresql.image.pullPolicy`                       | Image pull policy.                                   | `IfNotPresent`      |
 | `postgresql.primary.persistence`                    | Persistent volume for primary.                       |                     |
 | `postgresql.primary.persistence.size`               | PVC size.                                            | `20Gi`              |
@@ -569,46 +621,52 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 
 ### ClickHouse
 
-| Name                                        | Description                                                                                   | Value   |
-| ------------------------------------------- | --------------------------------------------------------------------------------------------- | ------- |
-| `clickhouse.chartManaged`                   | Manage ClickHouse via this chart using the clickhouse-serverless subchart (false = external). | `true`  |
-| `clickhouse.external.url`                   | ClickHouse connection URL.                                                                    |         |
-| `clickhouse.external.url.value`             | Full ClickHouse URL (http://user:pass@host:8123/database).                                    | `""`    |
-| `clickhouse.external.url.secretKeyRef.name` | Secret name for URL.                                                                          | `""`    |
-| `clickhouse.external.url.secretKeyRef.key`  | Secret key for URL.                                                                           | `""`    |
-| `clickhouse.external.cluster`               | Cluster name for ON CLUSTER DDL (omit for non-replicated).                                    | `""`    |
-
-### ClickHouse (chart-managed subchart options)
-
-| Name                                                       | Description                                                                                                   | Value            |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `clickhouse.replicas`                                      | ClickHouse replicas. 1 = standalone MergeTree. 3+ = Keeper + ReplicatedMergeTree (must be odd).               | `1`              |
-| `clickhouse.memory`                                        | Memory limit per ClickHouse pod. Image auto-tunes MAX_SERVER_MEMORY_USAGE (85%), per-query limits (20%), etc. | `4Gi`            |
-| `clickhouse.cpu`                                           | CPU limit per ClickHouse pod. Image auto-tunes merge pool size, insert threads, etc.                          | `2`              |
-| `clickhouse.storage`                                       | Hot storage configuration.                                                                                    |                  |
-| `clickhouse.storage.size`                                  | PVC size for hot data.                                                                                        | `50Gi`           |
-| `clickhouse.storage.storageClass`                          | Storage class (empty = cluster default).                                                                      | `""`             |
-| `clickhouse.objectStorage.bucket`                          | S3 bucket name (shared by cold storage and backups).                                                          | `""`             |
-| `clickhouse.objectStorage.region`                          | S3 region.                                                                                                    | `""`             |
-| `clickhouse.objectStorage.endpoint`                        | S3-compatible endpoint URL.                                                                                   | `""`             |
-| `clickhouse.objectStorage.useEnvironmentCredentials`       | Use IRSA / workload identity.                                                                                 | `true`           |
-| `clickhouse.objectStorage.credentials.secretKeyRef.name`   | Secret name containing S3 access keys.                                                                        | `""`             |
-| `clickhouse.cold.enabled`                                  | Enable tiered hot→cold storage to S3.                                                                         | `false`          |
-| `clickhouse.cold.defaultTtlDays`                           | TTL days before data moves to cold (must be divisible by 7).                                                  | `49`             |
-| `clickhouse.backup.enabled`                                | Enable automated native ClickHouse backups.                                                                   | `false`          |
-| `clickhouse.backup.database`                               | Database to back up.                                                                                          | `langwatch`      |
-| `clickhouse.backup.full.schedule`                          | Cron schedule for full backups.                                                                               | `"0 */12 * * *"` |
-| `clickhouse.backup.incremental.schedule`                   | Cron schedule for incremental backups.                                                                        | `"0 * * * *"`    |
-| `clickhouse.auth`                                          | Authentication configuration.                                                                                 |                  |
-| `clickhouse.auth.password`                                 | ClickHouse password (auto-generated when empty).                                                              | `""`             |
-| `clickhouse.auth.existingSecret`                           | Name of existing secret containing the password.                                                              | `""`             |
-| `clickhouse.auth.secretKeys`                               | Key mappings for existing secret.                                                                             |                  |
-| `clickhouse.auth.secretKeys.passwordKey`                   | Key name in the existing secret.                                                                              | `password`       |
-| `clickhouse.env`                                           | Advanced: override any computed ClickHouse env var (applied last).                                            | `{}`             |
-| `clickhouse.scheduling`                                    | Scheduling constraints for ClickHouse pods.                                                                   |                  |
-| `clickhouse.scheduling.nodeSelector`                       | Node selector for ClickHouse pods.                                                                            | `{}`             |
-| `clickhouse.scheduling.affinity`                           | Affinity rules for ClickHouse pods.                                                                           | `{}`             |
-| `clickhouse.scheduling.tolerations`                        | Tolerations for ClickHouse pods.                                                                              | `[]`             |
+| Name                                                                | Description                                                                                                   | Value            |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `clickhouse.chartManaged`                                           | Manage ClickHouse via this chart using the clickhouse-serverless subchart (false = external).                 | `true`           |
+| `clickhouse.external.url`                                           | ClickHouse connection URL.                                                                                    |                  |
+| `clickhouse.external.url.value`                                     | Full ClickHouse URL (http://user:pass@host:8123/database).                                                    | `""`             |
+| `clickhouse.external.url.secretKeyRef.name`                         | Secret name for URL.                                                                                          | `""`             |
+| `clickhouse.external.url.secretKeyRef.key`                          | Secret key for URL.                                                                                           | `""`             |
+| `clickhouse.external.cluster`                                       | Cluster name for ON CLUSTER DDL (omit for non-replicated).                                                    | `""`             |
+| `clickhouse.replicas`                                               | ClickHouse replicas. 1 = standalone MergeTree. 3+ = Keeper + ReplicatedMergeTree (must be odd).               | `1`              |
+| `clickhouse.memory`                                                 | Memory limit per ClickHouse pod. Image auto-tunes MAX_SERVER_MEMORY_USAGE (85%), per-query limits (20%), etc. | `4Gi`            |
+| `clickhouse.cpu`                                                    | CPU limit per ClickHouse pod. Image auto-tunes merge pool size, insert threads, etc.                          | `2`              |
+| `clickhouse.storage`                                                | Hot storage configuration.                                                                                    |                  |
+| `clickhouse.storage.size`                                           | PVC size for hot data.                                                                                        | `50Gi`           |
+| `clickhouse.storage.storageClass`                                   | Storage class (empty = cluster default).                                                                      | `""`             |
+| `clickhouse.objectStorage`                                          | S3-compatible object storage (shared by cold storage and backups).                                            |                  |
+| `clickhouse.objectStorage.bucket`                                   | S3 bucket name.                                                                                               | `""`             |
+| `clickhouse.objectStorage.region`                                   | S3 region.                                                                                                    | `""`             |
+| `clickhouse.objectStorage.endpoint`                                 | S3-compatible endpoint URL (e.g. https://s3.us-east-1.amazonaws.com/bucket/).                                 | `""`             |
+| `clickhouse.objectStorage.useEnvironmentCredentials`                | Use IRSA / workload identity instead of static keys.                                                          | `true`           |
+| `clickhouse.objectStorage.credentials`                              | Static S3 credentials (only when useEnvironmentCredentials is false).                                         |                  |
+| `clickhouse.objectStorage.credentials.secretKeyRef.name`            | Secret name containing S3 access keys.                                                                        | `""`             |
+| `clickhouse.objectStorage.credentials.secretKeyRef.accessKeyId`     | Key for access key ID in secret.                                                                              | `accessKey`      |
+| `clickhouse.objectStorage.credentials.secretKeyRef.secretAccessKey` | Key for secret access key in secret.                                                                          | `secretKey`      |
+| `clickhouse.cold`                                                   | Cold storage: tiered hot→cold data movement (requires objectStorage).                                         |                  |
+| `clickhouse.cold.enabled`                                           | Enable tiered storage to S3.                                                                                  | `false`          |
+| `clickhouse.cold.defaultTtlDays`                                    | Default TTL days before moving data to cold storage (must be divisible by 7).                                 | `49`             |
+| `clickhouse.backup`                                                 | Native ClickHouse BACKUP/RESTORE to S3 (requires objectStorage).                                              |                  |
+| `clickhouse.backup.enabled`                                         | Enable automated native ClickHouse backups.                                                                   | `false`          |
+| `clickhouse.backup.database`                                        | Database to back up.                                                                                          | `langwatch`      |
+| `clickhouse.backup.full`                                            | Full backup schedule.                                                                                         |                  |
+| `clickhouse.backup.full.schedule`                                   | Cron schedule for full backups.                                                                               | `"0 */12 * * *"` |
+| `clickhouse.backup.incremental`                                     | Incremental backup schedule.                                                                                  |                  |
+| `clickhouse.backup.incremental.schedule`                            | Cron schedule for incremental backups.                                                                        | `"0 * * * *"`    |
+| `clickhouse.preflight`                                              | Subchart preflight Job override.                                                                              |                  |
+| `clickhouse.preflight.enabled`                                      | Disable subchart preflight under umbrella install.                                                            | `false`          |
+| `clickhouse.auth`                                                   | Authentication configuration.                                                                                 |                  |
+| `clickhouse.auth.password`                                          | ClickHouse password (auto-generated when empty).                                                              | `""`             |
+| `clickhouse.auth.existingSecret`                                    | Name of existing secret containing the password. Supports tpl expressions.                                    | `""`             |
+| `clickhouse.auth.secretKeys`                                        | Key mappings for existing secret.                                                                             |                  |
+| `clickhouse.auth.secretKeys.passwordKey`                            | Key name in the existing secret.                                                                              | `password`       |
+| `clickhouse.auth.secretKeys.clusterSecretKey`                       | Key name for cluster secret.                                                                                  | `clusterSecret`  |
+| `clickhouse.env`                                                    | Advanced: override any computed ClickHouse env var (applied last).                                            | `{}`             |
+| `clickhouse.scheduling`                                             | Scheduling constraints for ClickHouse pods.                                                                   |                  |
+| `clickhouse.scheduling.nodeSelector`                                | Node selector for ClickHouse pods.                                                                            | `{}`             |
+| `clickhouse.scheduling.affinity`                                    | Affinity rules for ClickHouse pods.                                                                           | `{}`             |
+| `clickhouse.scheduling.tolerations`                                 | Tolerations for ClickHouse pods.                                                                              | `[]`             |
 
 ### Redis
 
@@ -620,14 +678,13 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `redis.external.connectionString.secretKeyRef` | Secret ref for connection string.                           | `{}`           |
 | `redis.image`                                  | Redis container image.                                      |                |
 | `redis.image.repository`                       | Image repository.                                           | `redis`        |
-| `redis.image.tag`                              | Image tag.                                                  | `"8"`          |
+| `redis.image.tag`                              | Image tag.                                                  | `"8.0"`        |
 | `redis.image.pullPolicy`                       | Image pull policy.                                          | `IfNotPresent` |
 | `redis.auth.enabled`                           | Enable Redis AUTH.                                          | `true`         |
 | `redis.auth.password`                          | Redis password (autogenerated if empty when chart-managed). | `""`           |
 | `redis.auth.existingSecret`                    | Existing secret for Redis password.                         | `""`           |
 | `redis.auth.secretKeys.passwordKey`            | Password key name.                                          | `password`     |
 | `redis.master.persistence`                     | Persistent volume for master.                               |                |
-| `redis.master.persistence.enabled`             | Enable persistence.                                         | `true`         |
 | `redis.master.persistence.size`                | PVC size.                                                   | `10Gi`         |
 | `redis.master.persistence.storageClass`        | Storage class.                                              | `""`           |
 | `redis.master.resources`                       | Resource requests and limits.                               |                |
@@ -635,6 +692,22 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `redis.master.resources.requests.memory`       | Requested memory.                                           | `256Mi`        |
 | `redis.master.resources.limits.cpu`            | CPU limit.                                                  | `500m`         |
 | `redis.master.resources.limits.memory`         | Memory limit.                                               | `512Mi`        |
+
+### AI Gateway
+
+| Name                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Value                             |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `gateway.chartManaged`                   | Lift the AI gateway pod as part of this chart (false = external or off).                                                                                                                                                                                                                                                                                                                                                                                                                  | `true`                            |
+| `gateway.publicUrl`                      | Externally-reachable URL of the AI Gateway (e.g. https://gateway.your-corp.com). The control plane hands this to CLI users (langwatch claude/codex/cursor) at login. REQUIRED for self-hosted CLI/agentic use: without it the CLI falls back to http://localhost:5563, which a developer laptop cannot reach against a remote cluster. Leave empty to auto-derive from gateway.ingress.host when you set your own host. Set LANGWATCH_GATEWAY_URL on the client to override per-user.     | `""`                              |
+| `gateway.controlPlane.baseUrl`           | URL the gateway uses to reach langwatch-app. Defaults assume release name `langwatch`.                                                                                                                                                                                                                                                                                                                                                                                                    | `http://langwatch-app:5560`       |
+| `gateway.secrets.existingSecretName`     | Name of the Secret the gateway pod mounts for LW_GATEWAY_INTERNAL_SECRET + LW_GATEWAY_JWT_SECRET. this release collapsed gateway-auth into the umbrella's app Secret so both langwatch-app and the gateway pod mount the SAME Secret. Default matches the autogen app-secret name when release name is `langwatch`. If you override the release name OR set `autogen.secretNames.app` / `secrets.existingSecret`, set this to the same Secret name so the gateway subchart bridges to it. | `langwatch-app-secrets`           |
+| `gateway.otel.endpoint`                  | OTLP/HTTP ingest URL the gateway exports spans to. Empty disables trace export entirely. Point at langwatch-app:5560/api/otel (with authExistingSecretName) or an external collector.                                                                                                                                                                                                                                                                                                     | `""`                              |
+| `gateway.otel.authExistingSecretName`    | Name of a Secret carrying the X-Auth-Token attached to every OTLP span export. Required when endpoint points at /api/otel; the ingest rejects unauthenticated spans with 401.                                                                                                                                                                                                                                                                                                             | `""`                              |
+| `gateway.otel.authSecretKey`             | Key inside `otel.authExistingSecretName` holding the token.                                                                                                                                                                                                                                                                                                                                                                                                                               | `token`                           |
+| `langy-agent.chartManaged`               | Lift the Langy agent pod as part of this chart. Default off so existing upgrades aren't broken by the absent shared Secret; opt in once the LANGY_INTERNAL_SECRET secret is created out-of-band.                                                                                                                                                                                                                                                                                          | `false`                           |
+| `langy-agent.controlPlane.agentUrl`      | URL the app uses to reach the agent Service. Leave empty to auto-derive from the release name.                                                                                                                                                                                                                                                                                                                                                                                            | `http://<release>-langy-agent:80` |
+| `langy-agent.secrets.existingSecretName` | Secret carrying LANGY_INTERNAL_SECRET, shared between the app and the agent pod. Created out-of-band (terraform / external-secrets); the umbrella chart does NOT materialise it.                                                                                                                                                                                                                                                                                                          | `langwatch-langy-agent-auth`      |
+| `langy-agent.secrets.internalSecretKey`  | Key inside the existing Secret that holds the shared internal secret.                                                                                                                                                                                                                                                                                                                                                                                                                     | `LANGY_INTERNAL_SECRET`           |
 
 _This section will be replaced by the generator._
 

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -95,7 +95,47 @@ docs/ai-gateway/self-hosting/helm.
 {{- end }}
 
 ──────────────────────────────────────────────────────────────────────
-6. Required Secrets — check before upgrading
+6. Dataset object storage
+──────────────────────────────────────────────────────────────────────
+Datasets store their content as chunked JSONL in object storage, and a
+WRITABLE backend is REQUIRED: every dataset create writes to it, with no
+database fallback (ADR-032 "born-on-storage"). The chart configures a
+backend for you:
+
+  • Default (no S3): a local-filesystem PVC is provisioned
+    ({{ .Values.app.storedObjects.localFilesystem.path }},
+    {{ .Values.app.storedObjects.localFilesystem.size | default "10Gi" }})
+    and mounted into the app, the worker (which runs dataset
+    normalization), and the dataset-migration Job — they all read and write
+    the SAME chunks (LANGWATCH_LOCAL_STORAGE_PATH), so a fresh install works
+    without S3. Because these separate pods share one ReadWriteOnce volume,
+    every dataset pod must run on a SINGLE NODE: the chart refuses
+    replicaCount > 1, and on a multi-node cluster the worker / migration Job
+    can fail to schedule against the app's volume. Fine for a hobby /
+    single-node install; bytes survive pod restarts. For anything bigger,
+    enable app.dataplane (S3).
+
+  • Production / multi-pod: enable app.dataplane (S3 / MinIO / Azure).
+    Then configure these on the bucket and deployment, or uploads and
+    large datasets will not work:
+
+      • Bucket CORS: allow PUT from the app origin. The browser uploads
+        files straight to the bucket via a presigned PUT, so a missing
+        CORS rule fails the direct upload (small files fall back to a
+        backend upload; large files cannot).
+
+      • Lifecycle TTL on the staging/ prefix: expire un-finalized uploads
+        (e.g. 1-7 days) so abandoned uploads are reaped automatically.
+
+      • Worker + Redis (event sourcing): dataset normalization runs
+        off-request on the worker via the Redis-backed queue. Without a
+        worker and Redis, normalization falls back to running in the
+        request — fine for a single small pod, but a multi-pod S3
+        deployment must run the worker so uploads are processed
+        off-request.
+
+──────────────────────────────────────────────────────────────────────
+7. Required Secrets — check before upgrading
 ──────────────────────────────────────────────────────────────────────
 Each chart bump may introduce new required keys on the umbrella's app
 Secret. When upgrading, verify these are present in the Secret the app

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -110,10 +110,26 @@ backend for you:
     the SAME chunks (LANGWATCH_LOCAL_STORAGE_PATH), so a fresh install works
     without S3. Because these separate pods share one ReadWriteOnce volume,
     every dataset pod must run on a SINGLE NODE: the chart refuses
-    replicaCount > 1, and on a multi-node cluster the worker / migration Job
-    can fail to schedule against the app's volume. Fine for a hobby /
-    single-node install; bytes survive pod restarts. For anything bigger,
-    enable app.dataplane (S3).
+    replicaCount > 1 and co-locates the worker / migration Job with the app
+    pod via a default podAffinity. Fine for a hobby / single-node install;
+    bytes survive pod restarts. For anything bigger, enable
+    app.dataplane (S3).
+
+    Operational notes for this mode:
+      • The PVC uses the cluster's DEFAULT StorageClass (or
+        app.storedObjects.localFilesystem.storageClassName). On bare-metal
+        clusters with no default StorageClass the PVC — and every pod
+        mounting it — stays Pending: install a provisioner (e.g.
+        local-path-provisioner) or set storageClassName explicitly.
+      • App and worker Deployments default to strategy: Recreate so
+        upgrades release the shared volume before new pods schedule (a
+        surged pod wedges Pending on an RWO multi-attach error on
+        multi-node clusters). Expect a brief downtime per upgrade; set
+        app/workers deployment.strategy explicitly to override.
+      • GitOps (ArgoCD / Flux): the dataset-migration hook maps to a
+        PostSync hook, which already waits for the rollout to be healthy;
+        plain Helm should upgrade with --wait when crossing the ADR-032
+        boundary (see the migration Job template header).
 
   • Production / multi-pod: enable app.dataplane (S3 / MinIO / Azure).
     Then configure these on the bucket and deployment, or uploads and

--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -121,11 +121,13 @@ backend for you:
         clusters with no default StorageClass the PVC — and every pod
         mounting it — stays Pending: install a provisioner (e.g.
         local-path-provisioner) or set storageClassName explicitly.
-      • App and worker Deployments default to strategy: Recreate so
-        upgrades release the shared volume before new pods schedule (a
-        surged pod wedges Pending on an RWO multi-attach error on
-        multi-node clusters). Expect a brief downtime per upgrade; set
-        app/workers deployment.strategy explicitly to override.
+      • App and worker Deployments default to a kill-then-start rollout
+        (RollingUpdate with maxSurge=0/maxUnavailable=1) so upgrades
+        release the shared volume before new pods schedule (a surged pod
+        wedges Pending on an RWO multi-attach error on multi-node
+        clusters). Expect a brief downtime per upgrade; set app/workers
+        deployment.strategy explicitly to override. Zero-downtime
+        upgrades require S3-backed stored objects instead of local-FS.
       • GitOps (ArgoCD / Flux): the dataset-migration hook maps to a
         PostSync hook, which already waits for the rollout to be healthy;
         plain Helm should upgrade with --wait when crossing the ADR-032

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -174,6 +174,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if gt (int .Values.app.replicaCount) 1 }}
     {{- $errors = append $errors "app.storedObjects.localFilesystem.enabled requires replicaCount=1 (pods don't share a local filesystem). Enable app.dataplane for multi-replica deployments." }}
   {{- end }}
+  {{- /* Workers mount the SAME RWO PVC as the app, so they are bound by the
+         same single-node constraint — guard workers.replicaCount too, else a
+         multi-replica worker pool renders cleanly then crashloops on the volume. */}}
+  {{- if gt (int .Values.workers.replicaCount) 1 }}
+    {{- $errors = append $errors "app.storedObjects.localFilesystem.enabled requires workers.replicaCount=1 (workers share the app's local-filesystem PVC). Enable app.dataplane for multi-replica deployments." }}
+  {{- end }}
 {{- end }}
 
 {{/* Validate dataset storage secrets */}}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -176,8 +176,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- end }}
   {{- /* Workers mount the SAME RWO PVC as the app, so they are bound by the
          same single-node constraint — guard workers.replicaCount too, else a
-         multi-replica worker pool renders cleanly then crashloops on the volume. */}}
-  {{- if gt (int .Values.workers.replicaCount) 1 }}
+         multi-replica worker pool renders cleanly then crashloops on the volume.
+         Only when workers are actually deployed: a disabled worker pool's
+         leftover replicaCount must not fail the render. */}}
+  {{- if and .Values.workers.enabled (gt (int .Values.workers.replicaCount) 1) }}
     {{- $errors = append $errors "app.storedObjects.localFilesystem.enabled requires workers.replicaCount=1 (workers share the app's local-filesystem PVC). Enable app.dataplane for multi-replica deployments." }}
   {{- end }}
 {{- end }}
@@ -688,6 +690,28 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and .Values.app.storedObjects.localFilesystem.enabled (not .Values.app.dataplane.enabled) -}}
 true
 {{- end -}}
+{{- end -}}
+
+{{/*
+  Default podAffinity co-locating a pod with the app pod, for consumers of the
+  app's RWO stored-objects PVC (workers Deployment, dataset-s3-migration Job).
+  An RWO volume attaches to ONE node, so a consumer scheduled on any other node
+  sits Pending on a multi-attach error — and local-FS is the chart DEFAULT, so
+  a vanilla install on a multi-node cluster would wedge without this. Required
+  (not preferred) because landing off-node is never functional. Trivially
+  satisfied on the documented single-node/hobby topology. Consumers render it
+  only when local-FS is active AND no explicit affinity is set — an operator's
+  own workers/datasetS3Migration/global affinity overrides it wholesale (they
+  own scheduling then, same override semantics as the coalesce chain).
+*/}}
+{{- define "langwatch.storedObjects.colocationAffinity" -}}
+podAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ .Release.Name }}-app
+          app.kubernetes.io/instance: {{ .Release.Name }}
+      topologyKey: kubernetes.io/hostname
 {{- end -}}
 
 {{/* ClickHouse: Cluster name for the app (only when replicas > 1 or external.cluster set) */}}

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -600,6 +600,33 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 - name: LANGWATCH_LOCAL_STORAGE_PATH
   value: {{ .Values.app.storedObjects.localFilesystem.path | quote }}
 {{- end }}
+
+# NextAuth secret. Lives in sharedEnv (not just the app Deployment) because
+# BetterAuth initializes eagerly at import time across every consumer of the
+# app image — workers and the dataset-s3-migration hook Job both pull in the
+# same module graph, so any of them can crash with "You are using the default
+# secret" if this is missing, regardless of whether that consumer's own logic
+# ever touches auth. Same secretKeyRef precedence everywhere (explicit
+# override -> existingSecret -> autogen).
+{{- if .Values.app.nextAuth.secret.secretKeyRef.name }}
+- name: NEXTAUTH_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.app.nextAuth.secret.secretKeyRef.name }}
+      key: {{ .Values.app.nextAuth.secret.secretKeyRef.key }}
+{{- else if .Values.secrets.existingSecret }}
+- name: NEXTAUTH_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.existingSecret }}
+      key: {{ .Values.secrets.secretKeys.nextAuthSecret | default "nextAuthSecret" }}
+{{- else if .Values.autogen.enabled }}
+- name: NEXTAUTH_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "langwatch.appSecretName" . }}
+      key: nextAuthSecret
+{{- end }}
 {{- end }}
 
 {{/* ============================================================ */}}

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -17,8 +17,19 @@ metadata:
 spec:
   replicas: {{ .Values.app.replicaCount }}
   {{- if .Values.app.deployment.strategy }}
-  strategy: 
+  strategy:
     {{- toYaml .Values.app.deployment.strategy | nindent 8 }}
+  {{- else if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
+  {{/* Default Recreate under local-FS: the pod holds the RWO stored-objects
+       PVC, and the k8s default RollingUpdate surges the new pod BEFORE the old
+       one releases the volume — on a multi-node cluster the new pod can land
+       on another node and wedge Pending on a multi-attach error (the scheduler
+       does not avoid RWO conflicts for CSI volumes). Recreate tears down every
+       volume consumer first, so upgrades detach cleanly at the cost of a brief
+       downtime — honest for the single-replica local-FS tier. An explicit
+       app.deployment.strategy overrides this. */}}
+  strategy:
+    type: Recreate
   {{- end }}
   {{- if hasKey (default (dict) .Values.app.deployment) "revisionHistoryLimit" }}
   revisionHistoryLimit: {{ .Values.app.deployment.revisionHistoryLimit }}

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -20,16 +20,31 @@ spec:
   strategy:
     {{- toYaml .Values.app.deployment.strategy | nindent 8 }}
   {{- else if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
-  {{/* Default Recreate under local-FS: the pod holds the RWO stored-objects
-       PVC, and the k8s default RollingUpdate surges the new pod BEFORE the old
-       one releases the volume — on a multi-node cluster the new pod can land
-       on another node and wedge Pending on a multi-attach error (the scheduler
-       does not avoid RWO conflicts for CSI volumes). Recreate tears down every
-       volume consumer first, so upgrades detach cleanly at the cost of a brief
-       downtime — honest for the single-replica local-FS tier. An explicit
-       app.deployment.strategy overrides this. */}}
+  {{/* Default kill-then-start under local-FS: the pod holds the RWO
+       stored-objects PVC, and the k8s default RollingUpdate (25% surge) starts
+       the new pod BEFORE the old one releases the volume — on a multi-node
+       cluster the new pod can land on another node and wedge Pending on a
+       multi-attach error (the scheduler does not avoid RWO conflicts for CSI
+       volumes). maxSurge=0/maxUnavailable=1 at replicas=1 behaves exactly like
+       Recreate (old pod terminates and releases the volume before the new one
+       schedules), at the cost of a brief downtime — honest for the
+       single-replica local-FS tier.
+
+       Deliberately NOT `type: Recreate`: switching a live Deployment from the
+       k8s-defaulted RollingUpdate to Recreate requires DELETING the live
+       `rollingUpdate` struct, and Helm's 3-way merge cannot emit that deletion
+       when the previous release's manifest never had a `strategy` key (the
+       pre-#5083 chart) — the API then rejects the patch with
+       "spec.strategy.rollingUpdate: Forbidden: may not be specified when
+       strategy `type` is 'Recreate'", failing every upgrade across this
+       boundary. Setting maxSurge/maxUnavailable only UPDATES existing fields,
+       which the merge applies cleanly. An explicit app.deployment.strategy
+       overrides this. */}}
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   {{- end }}
   {{- if hasKey (default (dict) .Values.app.deployment) "revisionHistoryLimit" }}
   revisionHistoryLimit: {{ .Values.app.deployment.revisionHistoryLimit }}

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -254,30 +254,10 @@ spec:
               value: {{ $gwPublic | quote }}
             {{- end }}
 
-            # NextAuth configuration
+            # NextAuth configuration (NEXTAUTH_SECRET lives in sharedEnv —
+            # every app-image consumer needs it, see _helpers.tpl)
             - name: NEXTAUTH_PROVIDER
               value: {{ .Values.app.nextAuth.provider | quote }}
-
-            # NextAuth secret
-            {{- if .Values.app.nextAuth.secret.secretKeyRef.name }}
-            - name: NEXTAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.app.nextAuth.secret.secretKeyRef.name }}
-                  key: {{ .Values.app.nextAuth.secret.secretKeyRef.key }}
-            {{- else if .Values.secrets.existingSecret }}
-            - name: NEXTAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.existingSecret }}
-                  key: {{ .Values.secrets.secretKeys.nextAuthSecret | default "nextAuthSecret" }}
-            {{- else if .Values.autogen.enabled }}
-            - name: NEXTAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langwatch.appSecretName" . }}
-                  key: nextAuthSecret
-            {{- end }}
 
             # NextAuth - SSO OAuth providers (auth0, azureAd, cognito, github, gitlab, google, okta)
             {{- $oauthProviders := list

--- a/charts/langwatch/templates/dataset-s3-migration-job.yaml
+++ b/charts/langwatch/templates/dataset-s3-migration-job.yaml
@@ -1,0 +1,135 @@
+{{/*
+  ADR-032 Decision 7 (rung 5): the PG→S3 dataset backfill, as a Helm
+  post-install,post-upgrade hook Job.
+
+  Runs the `backfillDatasetContentToS3` task (`pnpm run task ...`) which flips
+  existing datasets whose content still lives in Postgres onto the chunked-JSONL
+  S3 layout. Three properties make this safe to fire on every upgrade:
+
+    - OFF THE BOOT PATH: it's a hook Job that runs AFTER the deploy completes —
+      never on the `set -e` app boot — so a migration hiccup can't block pods
+      from starting, and the flip is rollout-gated (no old-image pod is present
+      when a dataset flips).
+    - IDEMPOTENT + SELF-SKIPPING: the task self-skips when no `postgres`-layout
+      datasets remain or when storage isn't S3-configured, and re-runs are no-ops
+      (already-`s3_jsonl` datasets are skipped under the per-dataset advisory
+      lock). So running it on every `helm upgrade` is harmless.
+    - OPT-OUT: `SKIP_DATASET_S3_MIGRATE` (wired from
+      `.Values.datasetS3Migration.skip`) lets an operator disable it entirely.
+
+  Hook semantics mirror the preflight-secrets hook: `hook-weight` runs it after
+  the app/workers roll (a higher weight than preflight's negative weights), and
+  `hook-delete-policy: before-hook-creation` deletes a prior run's Job before
+  re-creating it so reruns are clean. Image + env mirror the workers Deployment
+  (same app image, same `langwatch.sharedEnv` — DATABASE_URL, S3 config, etc.).
+*/}}
+{{- if and .Values.datasetS3Migration.enabled (not .Values.datasetS3Migration.skip) }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-dataset-s3-migration
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-dataset-s3-migration
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: dataset-s3-migration
+    {{- include "langwatch.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  backoffLimit: {{ .Values.datasetS3Migration.backoffLimit | default 3 }}
+  {{- with .Values.datasetS3Migration.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
+  ttlSecondsAfterFinished: {{ .Values.datasetS3Migration.ttlSecondsAfterFinished | default 600 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-dataset-s3-migration
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: dataset-s3-migration
+    spec:
+      restartPolicy: Never
+      {{/* On EKS+IRSA the Job must run as the same IAM-role-annotated
+           ServiceAccount as the app/workers to reach S3; default ("") falls
+           through to the namespace default SA (consistent with app/workers). */}}
+      {{- with .Values.datasetS3Migration.serviceAccountName }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+
+      {{/* Inherit chart-wide pod security + scheduling defaults so strict
+           clusters don't reject the hook and node taints / dedicated pools
+           still apply — the same coalesce pattern the workers / app / preflight
+           templates use. */}}
+      {{- with (coalesce .Values.datasetS3Migration.podSecurityContext .Values.global.podSecurityContext) }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.datasetS3Migration.nodeSelector .Values.global.scheduling.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.datasetS3Migration.tolerations .Values.global.scheduling.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (coalesce .Values.datasetS3Migration.affinity .Values.global.scheduling.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      containers:
+        - name: {{ .Release.Name }}-dataset-s3-migration
+          {{- with (coalesce .Values.datasetS3Migration.containerSecurityContext .Values.global.containerSecurityContext) }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.images.app.repository }}:{{ .Values.images.app.tag }}"
+          imagePullPolicy: "{{ .Values.images.app.pullPolicy }}"
+          workingDir: /app/langwatch
+          command: ['pnpm']
+          args: ['run', 'task', 'backfillDatasetContentToS3']
+          env:
+            {{- include "langwatch.sharedEnv" . | nindent 12 }}
+
+            {{/* No SKIP_DATASET_S3_MIGRATE env here: the outer guard above
+                 (`and .enabled (not .skip)`) already excludes skip=true, so this
+                 Job only renders when the migration is meant to run. Setting
+                 skip=true omits the Job entirely rather than running it with the
+                 opt-out flag. */}}
+            {{- with .Values.datasetS3Migration.extraEnvs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.datasetS3Migration.resources | nindent 12 }}
+          volumeMounts:
+            {{- with .Values.datasetS3Migration.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            - name: tmp-dir
+              mountPath: /tmp
+            {{- if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
+            # Stored-objects local-FS mount. When migrating to local FS (no S3),
+            # the backfill writes the migrated dataset chunks here, so the Job
+            # MUST mount the SAME PVC the app reads from — otherwise the chunks
+            # land on the Job's ephemeral FS and the flipped `s3_jsonl` rows point
+            # at content that doesn't exist (broken reads / data loss). Renders
+            # only when local-FS is the active backend; shares the app's RWO PVC →
+            # single-node topology (use app.dataplane S3 otherwise).
+            - name: stored-objects-data
+              mountPath: {{ .Values.app.storedObjects.localFilesystem.path }}
+            {{- end }}
+      volumes:
+        {{- with .Values.datasetS3Migration.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: tmp-dir
+          emptyDir: {}
+        {{- if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
+        - name: stored-objects-data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-stored-objects
+        {{- end }}
+{{- end }}

--- a/charts/langwatch/templates/dataset-s3-migration-job.yaml
+++ b/charts/langwatch/templates/dataset-s3-migration-job.yaml
@@ -75,9 +75,17 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (coalesce .Values.datasetS3Migration.affinity .Values.global.scheduling.affinity) }}
+      {{- if (coalesce .Values.datasetS3Migration.affinity .Values.global.scheduling.affinity) }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml (coalesce .Values.datasetS3Migration.affinity .Values.global.scheduling.affinity) | nindent 8 }}
+      {{- else if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
+      {{/* Default co-location with the app pod: on local-FS the Job writes
+           migrated chunks to the app's RWO stored-objects PVC (mounted below),
+           so off-node scheduling means a multi-attach Pending wedge. The app
+           pod is guaranteed up when this post-install/post-upgrade hook fires.
+           See langwatch.storedObjects.colocationAffinity. */}}
+      affinity:
+        {{- include "langwatch.storedObjects.colocationAffinity" . | nindent 8 }}
       {{- end }}
 
       containers:

--- a/charts/langwatch/templates/dataset-s3-migration-job.yaml
+++ b/charts/langwatch/templates/dataset-s3-migration-job.yaml
@@ -6,10 +6,17 @@
   existing datasets whose content still lives in Postgres onto the chunked-JSONL
   S3 layout. Three properties make this safe to fire on every upgrade:
 
-    - OFF THE BOOT PATH: it's a hook Job that runs AFTER the deploy completes —
-      never on the `set -e` app boot — so a migration hiccup can't block pods
-      from starting, and the flip is rollout-gated (no old-image pod is present
-      when a dataset flips).
+    - OFF THE BOOT PATH: it's a hook Job, never on the `set -e` app boot, so a
+      migration hiccup can't block pods from starting. NOTE: post-upgrade hooks
+      fire after resources are SUBMITTED, not after the Deployment rollout
+      completes (hook-weight only orders hooks among themselves) — the flip is
+      rollout-gated only when the release waits on rollout (`helm upgrade
+      --wait` / `--atomic`, Argo, Flux). Without that, upgrading from a
+      pre-ADR-032 image can flip a dataset while an old-image pod still serves:
+      reads stay fine (the PG rows are retained), but an old pod's dataset
+      WRITE after the flip lands only in the PG rows and is invisible to the
+      new layout. Use --wait (or pause dataset writes) when upgrading across
+      the ADR-032 boundary.
     - IDEMPOTENT + SELF-SKIPPING: the task self-skips when no `postgres`-layout
       datasets remain, and re-runs are no-ops (already-`s3_jsonl` datasets are
       skipped under the per-dataset advisory lock). So running it on every

--- a/charts/langwatch/templates/dataset-s3-migration-job.yaml
+++ b/charts/langwatch/templates/dataset-s3-migration-job.yaml
@@ -11,9 +11,11 @@
       from starting, and the flip is rollout-gated (no old-image pod is present
       when a dataset flips).
     - IDEMPOTENT + SELF-SKIPPING: the task self-skips when no `postgres`-layout
-      datasets remain or when storage isn't S3-configured, and re-runs are no-ops
-      (already-`s3_jsonl` datasets are skipped under the per-dataset advisory
-      lock). So running it on every `helm upgrade` is harmless.
+      datasets remain, and re-runs are no-ops (already-`s3_jsonl` datasets are
+      skipped under the per-dataset advisory lock). So running it on every
+      `helm upgrade` is harmless. There is NO "no S3" skip: each dataset
+      migrates to whatever backend the resolver provides — S3 when configured,
+      else the local filesystem (hence the stored-objects PVC mount below).
     - OPT-OUT: `SKIP_DATASET_S3_MIGRATE` (wired from
       `.Values.datasetS3Migration.skip`) lets an operator disable it entirely.
 

--- a/charts/langwatch/templates/dataset-s3-migration-job.yaml
+++ b/charts/langwatch/templates/dataset-s3-migration-job.yaml
@@ -61,6 +61,12 @@ spec:
         app.kubernetes.io/component: dataset-s3-migration
     spec:
       restartPolicy: Never
+      {{/* Same parity as app/workers: the task talks to Postgres/object
+           storage only, never the Kubernetes API, so don't mount the SA token
+           (chart default false). IRSA is unaffected — the EKS pod-identity
+           webhook injects its own projected web-identity token independent of
+           this flag. (Preflight deliberately differs: it calls kubectl.) */}}
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       {{/* On EKS+IRSA the Job must run as the same IAM-role-annotated
            ServiceAccount as the app/workers to reach S3; default ("") falls
            through to the namespace default SA (consistent with app/workers). */}}
@@ -84,9 +90,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (coalesce .Values.datasetS3Migration.affinity .Values.global.scheduling.affinity) }}
+      {{- $affinity := coalesce .Values.datasetS3Migration.affinity .Values.global.scheduling.affinity }}
+      {{- if $affinity }}
       affinity:
-        {{- toYaml (coalesce .Values.datasetS3Migration.affinity .Values.global.scheduling.affinity) | nindent 8 }}
+        {{- toYaml $affinity | nindent 8 }}
       {{- else if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
       {{/* Default co-location with the app pod: on local-FS the Job writes
            migrated chunks to the app's RWO stored-objects PVC (mounted below),

--- a/charts/langwatch/templates/dataset-s3-migration-job.yaml
+++ b/charts/langwatch/templates/dataset-s3-migration-job.yaml
@@ -118,6 +118,35 @@ spec:
           env:
             {{- include "langwatch.sharedEnv" . | nindent 12 }}
 
+            {{/* NEXTAUTH_SECRET: not part of sharedEnv (app-only today), but
+                 the task's module graph eagerly initializes the BetterAuth
+                 client at import time regardless of what the task itself
+                 does. Without this, better-auth falls through to its own
+                 default-secret detection, finds nothing, and throws
+                 "You are using the default secret" — crashing the Job on
+                 every attempt. Same secretKeyRef precedence as
+                 app/deployment.yaml (explicit override -> existingSecret ->
+                 autogen). */}}
+            {{- if .Values.app.nextAuth.secret.secretKeyRef.name }}
+            - name: NEXTAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.nextAuth.secret.secretKeyRef.name }}
+                  key: {{ .Values.app.nextAuth.secret.secretKeyRef.key }}
+            {{- else if .Values.secrets.existingSecret }}
+            - name: NEXTAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.existingSecret }}
+                  key: {{ .Values.secrets.secretKeys.nextAuthSecret | default "nextAuthSecret" }}
+            {{- else if .Values.autogen.enabled }}
+            - name: NEXTAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "langwatch.appSecretName" . }}
+                  key: nextAuthSecret
+            {{- end }}
+
             {{/* No SKIP_DATASET_S3_MIGRATE env here: the outer guard above
                  (`and .enabled (not .skip)`) already excludes skip=true, so this
                  Job only renders when the migration is meant to run. Setting

--- a/charts/langwatch/templates/dataset-s3-migration-job.yaml
+++ b/charts/langwatch/templates/dataset-s3-migration-job.yaml
@@ -118,35 +118,6 @@ spec:
           env:
             {{- include "langwatch.sharedEnv" . | nindent 12 }}
 
-            {{/* NEXTAUTH_SECRET: not part of sharedEnv (app-only today), but
-                 the task's module graph eagerly initializes the BetterAuth
-                 client at import time regardless of what the task itself
-                 does. Without this, better-auth falls through to its own
-                 default-secret detection, finds nothing, and throws
-                 "You are using the default secret" — crashing the Job on
-                 every attempt. Same secretKeyRef precedence as
-                 app/deployment.yaml (explicit override -> existingSecret ->
-                 autogen). */}}
-            {{- if .Values.app.nextAuth.secret.secretKeyRef.name }}
-            - name: NEXTAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.app.nextAuth.secret.secretKeyRef.name }}
-                  key: {{ .Values.app.nextAuth.secret.secretKeyRef.key }}
-            {{- else if .Values.secrets.existingSecret }}
-            - name: NEXTAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.existingSecret }}
-                  key: {{ .Values.secrets.secretKeys.nextAuthSecret | default "nextAuthSecret" }}
-            {{- else if .Values.autogen.enabled }}
-            - name: NEXTAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "langwatch.appSecretName" . }}
-                  key: nextAuthSecret
-            {{- end }}
-
             {{/* No SKIP_DATASET_S3_MIGRATE env here: the outer guard above
                  (`and .enabled (not .skip)`) already excludes skip=true, so this
                  Job only renders when the migration is meant to run. Setting

--- a/charts/langwatch/templates/preflight-secrets-job.yaml
+++ b/charts/langwatch/templates/preflight-secrets-job.yaml
@@ -163,7 +163,7 @@ spec:
                 printf 'Each missing key blocks the upgrade. Either add it to the existing Secret\n' >&2
                 printf 'or switch to chart-managed via autogen.enabled=true (chart materialises\n' >&2
                 printf 'both app-secrets and gateway-auth on first install). See NOTES.txt\n' >&2
-                printf 'section 6 for the kubectl create / annotate commands.\n' >&2
+                printf 'section 7 for the kubectl create / annotate commands.\n' >&2
                 exit 1
               fi
               printf 'preflight: all required Secret keys present in namespace %s\n' "$ns"

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -20,6 +20,16 @@ spec:
   {{- if .Values.workers.deployment.strategy }}
   strategy:
     {{- toYaml .Values.workers.deployment.strategy | nindent 8 }}
+  {{- else if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
+  {{/* Default Recreate under local-FS, same rationale as the app Deployment:
+       workers mount the app's RWO stored-objects PVC, and a surged worker pod
+       keeps the volume attached to the old node during an upgrade — which can
+       wedge the app's own replacement pod on a multi-attach error. Recreate on
+       BOTH deployments releases the volume before new pods schedule; the
+       co-location affinity then reunites them on one node. An explicit
+       workers.deployment.strategy overrides this. */}}
+  strategy:
+    type: Recreate
   {{- end }}
   {{- if hasKey (default (dict) .Values.workers.deployment) "revisionHistoryLimit" }}
   revisionHistoryLimit: {{ .Values.workers.deployment.revisionHistoryLimit }}

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -59,9 +59,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with (coalesce .Values.workers.affinity .Values.global.scheduling.affinity)}}
+      {{- if (coalesce .Values.workers.affinity .Values.global.scheduling.affinity) }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml (coalesce .Values.workers.affinity .Values.global.scheduling.affinity) | nindent 8 }}
+      {{- else if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
+      {{/* Default co-location with the app pod: workers mount the app's RWO
+           stored-objects PVC below, so off-node scheduling means a multi-attach
+           Pending wedge. See langwatch.storedObjects.colocationAffinity. */}}
+      affinity:
+        {{- include "langwatch.storedObjects.colocationAffinity" . | nindent 8 }}
       {{- end }}
 
       {{- with (coalesce .Values.workers.topologySpreadConstraints .Values.global.scheduling.topologySpreadConstraints)}}

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -114,6 +114,20 @@ spec:
             {{- end }}
             - name: tmp-dir
               mountPath: /tmp
+            {{- if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
+            # Stored-objects local-FS mount. The off-request normalize job runs
+            # HERE (on the worker), so it must read the app's staged upload and
+            # write dataset chunks to the SAME PVC the app mounts — not the
+            # worker's own ephemeral FS (where `LANGWATCH_LOCAL_STORAGE_PATH`
+            # from sharedEnv would otherwise point, and normalize would fail to
+            # find the staged file / lose its chunk writes). Renders only when
+            # local-FS is the active backend; app + workers share this one RWO
+            # PVC, which requires them co-located on a single node — the
+            # documented single-replica/hobby topology. Use app.dataplane (S3)
+            # for any multi-node deployment.
+            - name: stored-objects-data
+              mountPath: {{ .Values.app.storedObjects.localFilesystem.path }}
+            {{- end }}
 
       volumes:
         {{- with .Values.workers.extraVolumes}}
@@ -121,4 +135,9 @@ spec:
         {{- end }}
         - name: tmp-dir
           emptyDir: {}
+        {{- if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
+        - name: stored-objects-data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-stored-objects
+        {{- end }}
 {{- end }}

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -21,15 +21,31 @@ spec:
   strategy:
     {{- toYaml .Values.workers.deployment.strategy | nindent 8 }}
   {{- else if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
-  {{/* Default Recreate under local-FS, same rationale as the app Deployment:
-       workers mount the app's RWO stored-objects PVC, and a surged worker pod
-       keeps the volume attached to the old node during an upgrade — which can
-       wedge the app's own replacement pod on a multi-attach error. Recreate on
-       BOTH deployments releases the volume before new pods schedule; the
-       co-location affinity then reunites them on one node. An explicit
-       workers.deployment.strategy overrides this. */}}
+  {{/* Default kill-then-start under local-FS, same rationale as the app
+       Deployment: workers mount the app's RWO stored-objects PVC, and the k8s default RollingUpdate (25% surge) starts
+       the new pod BEFORE the old one releases the volume — on a multi-node
+       cluster the new pod can land on another node and wedge Pending on a
+       multi-attach error (the scheduler does not avoid RWO conflicts for CSI
+       volumes). maxSurge=0/maxUnavailable=1 at replicas=1 behaves exactly like
+       Recreate (old pod terminates and releases the volume before the new one
+       schedules), at the cost of a brief downtime — honest for the
+       single-replica local-FS tier.
+
+       Deliberately NOT `type: Recreate`: switching a live Deployment from the
+       k8s-defaulted RollingUpdate to Recreate requires DELETING the live
+       `rollingUpdate` struct, and Helm's 3-way merge cannot emit that deletion
+       when the previous release's manifest never had a `strategy` key (the
+       pre-#5083 chart) — the API then rejects the patch with
+       "spec.strategy.rollingUpdate: Forbidden: may not be specified when
+       strategy `type` is 'Recreate'", failing every upgrade across this
+       boundary. Setting maxSurge/maxUnavailable only UPDATES existing fields,
+       which the merge applies cleanly. An explicit workers.deployment.strategy
+       overrides this. */}}
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   {{- end }}
   {{- if hasKey (default (dict) .Values.workers.deployment) "revisionHistoryLimit" }}
   revisionHistoryLimit: {{ .Values.workers.deployment.revisionHistoryLimit }}

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -69,9 +69,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- if (coalesce .Values.workers.affinity .Values.global.scheduling.affinity) }}
+      {{- $affinity := coalesce .Values.workers.affinity .Values.global.scheduling.affinity }}
+      {{- if $affinity }}
       affinity:
-        {{- toYaml (coalesce .Values.workers.affinity .Values.global.scheduling.affinity) | nindent 8 }}
+        {{- toYaml $affinity | nindent 8 }}
       {{- else if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
       {{/* Default co-location with the app pod: workers mount the app's RWO
            stored-objects PVC below, so off-node scheduling means a multi-attach

--- a/charts/langwatch/tests/e2e.sh
+++ b/charts/langwatch/tests/e2e.sh
@@ -409,8 +409,16 @@ test_dataset_s3_migration_upgrade() {
   # Minimal org/team/project/dataset graph, inserted directly (no auth flow
   # needed — this is disposable seed data, not an auth-path test). IDs are
   # explicit because Prisma's @default(nanoid()) is applied client-side, not
-  # a DB default.
+  # a DB default. Delete-before-insert makes this safe to re-run against a
+  # reused cluster (KEEP_CLUSTER=true local dev loop) — CI always starts from
+  # a fresh Kind cluster, but a local rerun without this would hit a
+  # duplicate-key error on the second pass.
   pg_exec <<'SQL' >/dev/null
+DELETE FROM "DatasetRecord" WHERE "projectId" = 'e2e_project';
+DELETE FROM "Dataset" WHERE "projectId" = 'e2e_project';
+DELETE FROM "Project" WHERE id = 'e2e_project';
+DELETE FROM "Team" WHERE id = 'e2e_team';
+DELETE FROM "Organization" WHERE id = 'e2e_org';
 INSERT INTO "Organization" (id, name, slug) VALUES ('e2e_org', 'E2E Org', 'e2e-org');
 INSERT INTO "Team" (id, name, slug, "organizationId") VALUES ('e2e_team', 'E2E Team', 'e2e-team', 'e2e_org');
 INSERT INTO "Project" (id, name, slug, "apiKey", "teamId", language, framework) VALUES ('e2e_project', 'E2E Project', 'e2e-project', 'e2e_api_key', 'e2e_team', 'other', 'other');

--- a/charts/langwatch/tests/e2e.sh
+++ b/charts/langwatch/tests/e2e.sh
@@ -26,6 +26,10 @@ source "$(cd "$(dirname "$0")/../../lib" && pwd)/test-helpers.sh"
 trap cleanup_cluster EXIT
 
 # ─── PostgreSQL helper ───────────────────────────────────────────────────────
+# Argv-embedded query — only safe for simple queries with no double quotes or
+# single-quoted literals (its only call site is `SELECT 1`). Suites needing
+# real SQL (double-quoted Prisma identifiers, string literals) use a local
+# stdin-based variant instead — see pg_exec in test_dataset_s3_migration_upgrade.
 pg_query() {
   local pod="$1" query="$2"
   kc exec "$pod" -- \

--- a/charts/langwatch/tests/e2e.sh
+++ b/charts/langwatch/tests/e2e.sh
@@ -382,6 +382,92 @@ test_workers() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# SUITE: dataset S3 migration — real upgrade across the ADR-032 boundary
+#
+# Reproduces the actual customer upgrade path: app/workers are already
+# running from test_app/test_workers with NO strategy key rendered (the
+# pre-#5083 chart never set one, so the live Deployments carry only the
+# k8s-API-server-defaulted RollingUpdate). This suite seeds a legacy
+# `contentLayout=postgres` dataset directly via SQL — the app's own UI/API
+# can no longer create postgres-layout rows (read-only migration source
+# since #4895) — then upgrades with local-FS + the migration hook enabled
+# for the FIRST time, which is exactly when the Deployment strategy flips
+# to the kill-then-start RollingUpdate override. A regression here means
+# `helm upgrade` breaks for every existing self-hosted install.
+# ─────────────────────────────────────────────────────────────────────────────
+test_dataset_s3_migration_upgrade() {
+  sep; info "Suite: dataset S3 migration upgrade"
+
+  local pg_pod="${RELEASE}-postgresql-0"
+
+  # psql over stdin (no `-c "<sql>"` argv layer) so double-quoted identifiers
+  # need no shell escaping at all.
+  pg_exec() {
+    kc exec -i "$pg_pod" -- env PGPASSWORD=e2etest psql -U postgres -d langwatch -v ON_ERROR_STOP=1 "$@"
+  }
+
+  # Minimal org/team/project/dataset graph, inserted directly (no auth flow
+  # needed — this is disposable seed data, not an auth-path test). IDs are
+  # explicit because Prisma's @default(nanoid()) is applied client-side, not
+  # a DB default.
+  pg_exec <<'SQL' >/dev/null
+INSERT INTO "Organization" (id, name, slug) VALUES ('e2e_org', 'E2E Org', 'e2e-org');
+INSERT INTO "Team" (id, name, slug, "organizationId") VALUES ('e2e_team', 'E2E Team', 'e2e-team', 'e2e_org');
+INSERT INTO "Project" (id, name, slug, "apiKey", "teamId", language, framework) VALUES ('e2e_project', 'E2E Project', 'e2e-project', 'e2e_api_key', 'e2e_team', 'other', 'other');
+INSERT INTO "Dataset" (id, "projectId", name, slug, "columnTypes", "contentLayout", status) VALUES ('e2e_legacy_ds', 'e2e_project', 'Legacy Dataset', 'legacy-dataset', '[{"name":"input","type":"string"}]', 'postgres', 'ready');
+INSERT INTO "DatasetRecord" (id, "datasetId", "projectId", entry)
+  SELECT 'e2e_rec_' || g, 'e2e_legacy_ds', 'e2e_project', jsonb_build_object('input', 'row ' || g)
+  FROM generate_series(1,5) g;
+SQL
+  pass "Seeded legacy contentLayout=postgres dataset (5 records)"
+
+  # The actual regression test: this upgrade is the first to render a
+  # Deployment strategy at all. On the pre-fix chart (`type: Recreate` +
+  # `rollingUpdate: null`) this failed with "spec.strategy.rollingUpdate:
+  # Forbidden" because Helm's 3-way merge can't delete a live
+  # k8s-defaulted field the previous release's manifest never mentioned.
+  hc upgrade "$RELEASE" "$CHART_DIR" \
+    -f "$CHART_DIR/tests/values-e2e.yaml" \
+    --set app.replicaCount=1 \
+    --set workers.enabled=true \
+    --set workers.replicaCount=1 \
+    --set app.storedObjects.localFilesystem.enabled=true \
+    --set datasetS3Migration.enabled=true \
+    --wait --timeout "${TIMEOUT}s"
+  pass "helm upgrade succeeds across the strategy boundary"
+
+  local strategy
+  strategy=$(kc get deploy "${RELEASE}-app" -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}')
+  assert_eq "app Deployment strategy is kill-then-start (maxSurge=0)" "$strategy" "0"
+
+  wait_pod_ready "app.kubernetes.io/name=${RELEASE}-app" 180
+  wait_pod_ready "app.kubernetes.io/name=${RELEASE}-workers" 180
+
+  local job_status
+  job_status=$(kc get job "${RELEASE}-dataset-s3-migration" \
+    -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')
+  assert_eq "migration Job completed" "$job_status" "True"
+
+  local layout row_count
+  layout=$(pg_exec -tA <<'SQL'
+SELECT "contentLayout" FROM "Dataset" WHERE id='e2e_legacy_ds';
+SQL
+  )
+  row_count=$(pg_exec -tA <<'SQL'
+SELECT "rowCount" FROM "Dataset" WHERE id='e2e_legacy_ds';
+SQL
+  )
+  assert_eq "dataset flipped to s3_jsonl" "$layout" "s3_jsonl"
+  assert_eq "migrated rowCount matches seeded records" "$row_count" "5"
+
+  local app_pod chunk_lines
+  app_pod=$(kc get pod -l "app.kubernetes.io/name=${RELEASE}-app" -o jsonpath='{.items[0].metadata.name}')
+  chunk_lines=$(kc exec "$app_pod" -- sh -c \
+    "wc -l < /var/lib/langwatch/objects/datasets/e2e_project/e2e_legacy_ds/chunk-00000.jsonl" | tr -d ' ')
+  assert_eq "PVC chunk file has all 5 migrated rows" "$chunk_lines" "5"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # SUITE: cold storage + backup (deploys RustFS as S3, verifies actual I/O)
 # ─────────────────────────────────────────────────────────────────────────────
 test_cold_storage_and_backup() {
@@ -557,6 +643,7 @@ main() {
   test_resources
   test_app
   test_workers
+  test_dataset_s3_migration_upgrade
   test_upgrade
   test_external_clickhouse
   test_cold_storage_and_backup

--- a/charts/langwatch/tests/values-e2e-full.yaml
+++ b/charts/langwatch/tests/values-e2e-full.yaml
@@ -25,6 +25,13 @@ images:
 # ── App (1 replica) ─────────────────────────────────────────────────────────
 app:
   replicaCount: 1
+  # Local-FS stored objects requires workers.replicaCount=1 (single-node RWO
+  # PVC shared with the app) — this suite deliberately runs 2 workers to
+  # validate the multi-replica tier, so disable local-FS (multi-replica
+  # customers use S3/dataplane). See the _helpers.tpl guard.
+  storedObjects:
+    localFilesystem:
+      enabled: false
   features:
     skipEnvValidation: true
   service:
@@ -44,6 +51,12 @@ workers:
   resources:
     requests: { cpu: 100m, memory: 1Gi }
     limits:   { cpu: 1000m, memory: 2Gi }
+
+# No writable stored-objects backend above → the dataset backfill hook has
+# nowhere to migrate to; keep it out of the full-stack run (covered by the
+# local-FS upgrade path instead).
+datasetS3Migration:
+  enabled: false
 
 # ── NLP ──────────────────────────────────────────────────────────────────────
 langwatch_nlp:

--- a/charts/langwatch/tests/values-e2e.yaml
+++ b/charts/langwatch/tests/values-e2e.yaml
@@ -48,6 +48,14 @@ workers:
   # (validates the gate added in c74fb13a3).
   enabled: false
 
+# ── Dataset PG→S3 migration hook (ADR-032) — needs the private app image ──────
+# It's a BLOCKING post-install hook, so unlike the 0-replica app/workers/nlp
+# Deployments (which helm doesn't --wait on), a failed hook fails the whole
+# release. The app image is never loaded into this infra-only cluster, so the
+# hook would ErrImageNeverPull under pullPolicy: Never. Disable it here.
+datasetS3Migration:
+  enabled: false
+
 langwatch_nlp:
   replicaCount: 0
 

--- a/charts/langwatch/tests/values-e2e.yaml
+++ b/charts/langwatch/tests/values-e2e.yaml
@@ -51,8 +51,10 @@ workers:
 # ── Dataset PG→S3 migration hook (ADR-032) — needs the private app image ──────
 # It's a BLOCKING post-install hook, so unlike the 0-replica app/workers/nlp
 # Deployments (which helm doesn't --wait on), a failed hook fails the whole
-# release. The app image is never loaded into this infra-only cluster, so the
-# hook would ErrImageNeverPull under pullPolicy: Never. Disable it here.
+# release. At `helm install` time (this baseline) the app image isn't loaded
+# yet, so the hook would ErrImageNeverPull under pullPolicy: Never — disable
+# it here. test_dataset_s3_migration_upgrade re-enables it later in the same
+# job, once test_app has proven the image is loaded and running.
 datasetS3Migration:
   enabled: false
 

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -728,8 +728,9 @@ workers:
 # `backfillDatasetContentToS3` task — flipping existing datasets whose content
 # still lives in Postgres onto the chunked-JSONL S3 layout. It runs OFF the boot
 # path (after the deploy completes), is idempotent, advisory-locked and
-# self-skipping (no-op when no postgres-layout datasets remain or storage isn't
-# S3-configured), so it is safe to fire on every `helm upgrade`. Image + env
+# self-skipping (no-op when no postgres-layout datasets remain; each dataset
+# migrates to S3 when configured, else to the local-filesystem stored-objects
+# volume), so it is safe to fire on every `helm upgrade`. Image + env
 # mirror the workers Deployment (same app image, same shared env). See
 # templates/dataset-s3-migration-job.yaml.
 #

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -308,8 +308,8 @@ app:
       # AWS S3 configuration for dataset storage
       ## @extra app.dataplane.providers.awsS3 AWS S3 provider configuration.
       ## @param app.dataplane.providers.awsS3.endpoint.value [string] Custom S3 endpoint.
-      ## @param app.dataplane.providers.awsS3.accessKeyId.value [string] S3 access key ID.
-      ## @param app.dataplane.providers.awsS3.secretAccessKey.value [string] S3 secret access key.
+      ## @param app.dataplane.providers.awsS3.accessKeyId.value [string] S3 access key ID (not recommended in production — use accessKeyId.secretKeyRef).
+      ## @param app.dataplane.providers.awsS3.secretAccessKey.value [string] S3 secret access key (not recommended in production — use secretAccessKey.secretKeyRef).
       ## @param app.dataplane.providers.awsS3.keySalt.value [string] Optional key salt.
       awsS3:
         endpoint:
@@ -719,6 +719,78 @@ workers:
   ## @param workers.extraInitContainers [array] Additional init containers.
   extraInitContainers: []
   ## @param workers.extraVolumeMounts [array] Additional volume mounts for workers container.
+  extraVolumeMounts: []
+
+# =============================================================================
+# Dataset PG→S3 backfill migration (ADR-032 Decision 7, rung 5)
+# =============================================================================
+# A post-install,post-upgrade hook Job that runs the
+# `backfillDatasetContentToS3` task — flipping existing datasets whose content
+# still lives in Postgres onto the chunked-JSONL S3 layout. It runs OFF the boot
+# path (after the deploy completes), is idempotent, advisory-locked and
+# self-skipping (no-op when no postgres-layout datasets remain or storage isn't
+# S3-configured), so it is safe to fire on every `helm upgrade`. Image + env
+# mirror the workers Deployment (same app image, same shared env). See
+# templates/dataset-s3-migration-job.yaml.
+#
+# RELEASE-FAILURE SEMANTICS: this is a post-install,post-upgrade hook, so a
+# CATASTROPHIC, top-level task failure (DB unreachable, storage hard-down — NOT
+# a per-dataset error, which is caught and logged so the run continues) fails
+# the Helm release. This is deliberate: the task throws on such failures so the
+# problem stays visible rather than being silently swallowed. Recovery is
+# low-risk because the run is IDEMPOTENT and SELF-RESUMING — already-migrated
+# datasets are skipped under the advisory lock and a half-written dataset is
+# re-driven (overwrite-by-key + atomic flip), so simply re-running the upgrade
+# after fixing the underlying outage completes the migration. To unblock a
+# deploy WITHOUT waiting on the migration, set `datasetS3Migration.skip: true`
+# (below): the hook Job is not rendered and the release proceeds; datasets stay
+# on the `postgres` layout (and keep reading from PG) until a later upgrade with
+# `skip: false` migrates them.
+## @section Dataset S3 migration
+datasetS3Migration:
+  ## @param datasetS3Migration.enabled [default: true] Render the post-install/post-upgrade migration hook Job.
+  enabled: true
+  # Operator opt-out for the migration (ADR-032 SKIP_DATASET_S3_MIGRATE). When
+  # true the hook Job is not rendered at all; the task additionally self-skips
+  # at runtime if it ever runs with this env set.
+  ## @param datasetS3Migration.skip [default: false] Disable the dataset PG→S3 backfill migration entirely.
+  skip: false
+  ## @param datasetS3Migration.backoffLimit [default: 3] Job backoffLimit — retries on transient failure (the task is idempotent).
+  backoffLimit: 3
+  ## @param datasetS3Migration.activeDeadlineSeconds [default: 21600] Hard runtime limit (s) for the hook Job — a backstop so a hung migration can't run forever. The task is idempotent/resumable, so a re-run resumes; raise for very large installs or set null to disable.
+  activeDeadlineSeconds: 21600
+  # ServiceAccount for the migration Job. Leave empty to use the namespace
+  # default (matching the app/workers). On EKS+IRSA, set this to the same
+  # IAM-role-annotated ServiceAccount the app/workers use so the Job can reach S3.
+  ## @param datasetS3Migration.serviceAccountName [string, default: ""] ServiceAccount for the Job (set to the app/workers IRSA SA on EKS).
+  serviceAccountName: ""
+  ## @param datasetS3Migration.ttlSecondsAfterFinished [default: 600] Clean up the finished Job after this many seconds.
+  ttlSecondsAfterFinished: 600
+  ## @extra datasetS3Migration.resources Resource requests and limits for the migration Job.
+  ## @param datasetS3Migration.resources.requests.cpu [string, default: 100m] Requested CPU.
+  ## @param datasetS3Migration.resources.requests.memory [string, default: 512Mi] Requested memory.
+  ## @param datasetS3Migration.resources.limits.cpu [string, default: 1000m] CPU limit.
+  ## @param datasetS3Migration.resources.limits.memory [string, default: 2Gi] Memory limit.
+  resources:
+    requests: { cpu: 100m, memory: 512Mi }
+    limits: { cpu: 1000m, memory: 2Gi }
+  # Per-hook overrides; empty defaults fall through to global.* via the
+  # coalesce chain in the template (same convention as workers / preflight).
+  ## @param datasetS3Migration.podSecurityContext [object] Pod security context override.
+  podSecurityContext: {}
+  ## @param datasetS3Migration.containerSecurityContext [object] Container security context override.
+  containerSecurityContext: {}
+  ## @param datasetS3Migration.nodeSelector [object] Node selector override.
+  nodeSelector: {}
+  ## @param datasetS3Migration.tolerations [array] Tolerations override.
+  tolerations: []
+  ## @param datasetS3Migration.affinity [object] Affinity override.
+  affinity: {}
+  ## @param datasetS3Migration.extraEnvs [array] Additional environment variables for the migration Job.
+  extraEnvs: []
+  ## @param datasetS3Migration.extraVolumes [array] Additional pod volumes.
+  extraVolumes: []
+  ## @param datasetS3Migration.extraVolumeMounts [array] Additional volume mounts.
   extraVolumeMounts: []
 
 # =============================================================================

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -33,7 +33,7 @@ global:
       drop:
         - ALL
     readOnlyRootFilesystem: true
-  ## @param global.automountServiceAccountToken [default: false] Mount the ServiceAccount token into first-party workload pods (app, workers, nlp, langevals, cronjobs, postgresql, redis). Defaults to false — none of these call the Kubernetes API, and many clusters deny pods that automount the token. Set true only if a sidecar needs in-cluster API access.
+  ## @param global.automountServiceAccountToken [default: false] Mount the ServiceAccount token into first-party workload pods (app, workers, nlp, langevals, cronjobs, postgresql, redis, dataset-s3-migration Job). Defaults to false — none of these call the Kubernetes API, and many clusters deny pods that automount the token. Set true only if a sidecar needs in-cluster API access.
   automountServiceAccountToken: false
   ## @extra global.scheduling Global scheduling defaults for all pods.
   ## @param global.scheduling.nodeSelector [object] Node selector labels for all pods.
@@ -1735,6 +1735,7 @@ langy-agent:
     agentUrl: ""
 
   ## @param langy-agent.secrets.existingSecretName [string, default: langwatch-langy-agent-auth] Secret carrying LANGY_INTERNAL_SECRET, shared between the app and the agent pod. Created out-of-band (terraform / external-secrets); the umbrella chart does NOT materialise it.
+  ## @param langy-agent.secrets.internalSecretKey [string, default: LANGY_INTERNAL_SECRET] Key inside the existing Secret that holds the shared internal secret.
   secrets:
     existingSecretName: langwatch-langy-agent-auth
     internalSecretKey: LANGY_INTERNAL_SECRET


### PR DESCRIPTION
## What

Carves the Helm chart changes for the datasets→S3 chunked-JSONL epic (ADR-032) out of the feature PR (#4895) into their own release artifact.

The TS feature is **born-on-storage + dual-read** — it merged (#4895) and runs without any chart change. This PR carries only the deploy-layer plumbing, so the auto-running backfill Job lives here, on the chart's own timeline, instead of on the feature's critical path.

## Changes

- **`workers/deployment.yaml`** — mount the app's stored-objects RWO PVC on the worker. The off-request normalize job runs on the worker, so on a local-filesystem backend it must read staged uploads / write chunks to the *same* volume the app mounts (else it loses writes). Renders only when local-FS is the active backend.
- **`_helpers.tpl`** — guard `workers.replicaCount=1` under local-FS (workers share the app's single-node RWO PVC), matching the existing app-replica guard. The guard only fires when `workers.enabled=true` — a disabled pool's leftover replicaCount doesn't fail the render.
- **Default kill-then-start rollout under local-FS** — the k8s default RollingUpdate surges the replacement pod before the old one releases the RWO PVC, wedging upgrades Pending on multi-attach on multi-node clusters (a surged worker anchors the volume even if the app alone rolls kill-then-start). Both app and workers default to `RollingUpdate` with `maxSurge: 0 / maxUnavailable: 1` when local-FS is active — behaviorally identical to `Recreate` at replicas=1 (old pod releases the volume before the new one schedules), but deliberately NOT `type: Recreate`: Helm's 3-way merge cannot delete the live k8s-defaulted `rollingUpdate` struct when the previous release never rendered a `strategy` key, so a Recreate default fails every upgrade from a pre-existing install with `spec.strategy.rollingUpdate: Forbidden` (found by live-upgrade testing, see below). An explicit `deployment.strategy` overrides. Brief downtime per upgrade — honest for the single-replica tier; zero-downtime needs S3.
- **Default co-location affinity (review fix)** — workers and the migration Job share the app's RWO PVC, which attaches to ONE node; on a multi-node cluster an off-node consumer sits Pending on a multi-attach error. When local-FS is active and no explicit affinity is set, both default to a required `podAffinity` on the app pod (`langwatch.storedObjects.colocationAffinity`). An operator-set `workers.*`/`datasetS3Migration.*`/`global.scheduling` affinity overrides it wholesale.
- **`dataset-s3-migration-job.yaml` + `values.datasetS3Migration`** — the one-time PG→S3 backfill as a `post-install,post-upgrade` hook Job. Idempotent, advisory-locked, self-skipping; `skip: true` opts out.
- **`values.yaml` storedObjects + `NOTES.txt`** — storage-backend config and operator guidance.

## Release ordering (the one coupling)

The worker PVC mount is **required** for normalize on self-hosted **local-filesystem** deployments. So this chart must release **with-or-before** the app image carrying the feature. Cloud / S3-dataplane deployments don't use that mount and are unaffected.

When upgrading across the ADR-032 boundary, run `helm upgrade --wait` (or an Argo/Flux-style sync that waits on rollout): post-upgrade hooks fire after resources are *submitted*, not after the rollout *completes*, so without a wait the backfill can flip a dataset while a pre-feature pod still serves — reads stay fine (PG rows are retained), but that pod's dataset writes after the flip land only in PG and are invisible to the new layout. Documented in the Job template header.

## Migration default — race resolved

An earlier revision of this PR flagged a lost-write race in `backfillDatasetContentToS3` as an open blocker for the default-on hook. That race guard shipped inside #4895 (merged): the task snapshots `(count, max(updatedAt))` before streaming, re-checks both under the per-dataset advisory lock just before the flip, and **skips the flip on any mismatch** — the dataset stays fully readable on the `postgres` layout and re-migrates on the next run (`skipped-concurrent-write`). ADR-032 v18 records the blocker as resolved, so `datasetS3Migration.enabled: true` stands as the default. Fresh / cloud installs are born-on-storage and self-skip → unaffected.

## Deployment Impact

- **Env vars:** none added or changed. The hook Job reuses `langwatch.sharedEnv` (DATABASE_URL, S3 config) plus `NEXTAUTH_SECRET` with the same secretKeyRef precedence as the app Deployment — the task's module graph eagerly initializes BetterAuth at import time and crash-loops without it (found by live-upgrade testing, see below); `SKIP_DATASET_S3_MIGRATE` (pre-existing, from #4895) is wired from `datasetS3Migration.skip`.
- **Helm values added:** `datasetS3Migration.*` (enabled/skip/backoffLimit/activeDeadlineSeconds/serviceAccountName/ttlSecondsAfterFinished/resources/scheduling overrides) and `app.storedObjects.localFilesystem.*` (enabled/path/size/storageClassName).
- **Vanilla `helm install`, no overrides:** local-FS is the active stored-objects backend → a 10Gi RWO PVC renders, app+workers+migration Job all mount it and are co-located on one node via default podAffinity; app and worker replicas are validated to 1. App and worker Deployments default to a kill-then-start rollout (`maxSurge: 0 / maxUnavailable: 1`) so upgrades release the shared RWO volume before rescheduling (needs a default StorageClass — bare-metal clusters without one get Pending PVCs; see NOTES). The post-install/post-upgrade hook Job runs the backfill; on fresh installs it self-skips (no `postgres`-layout datasets). Upgrades with existing datasets backfill them to the configured storage; opt out with `datasetS3Migration.skip=true`.
- **BYOC / S3 dataplane:** with `app.dataplane.enabled=true` no PVC, mounts, or co-location affinity render; the Job talks to S3 with the same credentials/SA as the app (set `datasetS3Migration.serviceAccountName` to the IRSA SA on EKS).

## Verified by live upgrade test (minikube)

Reproduced the real customer path end-to-end: `helm install` from the **main** chart (pre-this-PR) with main images, seeded two legacy `contentLayout='postgres'` datasets via SQL, then `helm upgrade` to this branch. This surfaced and fixed two upgrade-blocking bugs no CI test covers (the e2e values file disables all new paths):

1. **`strategy: Recreate` broke every upgrade** from a pre-existing release (`spec.strategy.rollingUpdate: Forbidden`) — replaced with the maxSurge=0 rollout above; upgrade now succeeds unattended, no manual step, no hook RBAC.
2. **Migration Job crash-looped** (`BetterAuthError: You are using the default secret`) — fixed by wiring `NEXTAUTH_SECRET` into the Job.

Post-fix verification: upgrade `deployed` unattended; migration Job `Complete` — both seeded datasets flipped to `s3_jsonl` with chunk files on the PVC matching DB `sizeBytes`/`rowCount` exactly, PG rows retained; re-run self-skips (`migrated: 0, failed: 0`); a real 100MB/80-row UI upload landed as 13 chunk files on the PVC with zero rows in Postgres.

Epic / feature: #4895 · ADR-032


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable dataset object storage guidance and support for local filesystem and S3-compatible backends, including clearer writable-backend requirements.
  * Introduced an optional post-install/post-upgrade dataset backfill hook job (`datasetS3Migration`).
  * When using local filesystem storage, workers are co-scheduled with the app and mount the shared dataset volume.
* **Bug Fixes**
  * Improved Helm validation to block incompatible settings (shared local-filesystem storage with worker replicas > 1).
* **Documentation**
  * Expanded storage NOTES (CORS/lifecycle/TTL) and updated AWS credential guidance; updated required secrets step numbering.
* **Tests**
  * Updated e2e values to disable the migration hook during infra-only installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
