### PR TITLE
fix(security): python-sdk transitive security floors (python-engineio, python-socketio)

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -124,4 +124,8 @@ exclude-newer = "7 days"
 # pull a vulnerable version back in.
 constraint-dependencies = [
     "jupyter-server>=2.20.0",  # security: CVE-2026-44727 stored XSS in nbconvert handlers (GHSA-fcw5-x6j4-ccmp)
+    "vcrpy>=8.2.1",  # security: vcrpy advisory (#1531)
+    "langsmith>=0.8.18",  # security: langsmith advisory (#1532)
+    "python-engineio>=4.13.2",  # security: python-engineio advisory (#1545, #1546)
+    "python-socketio>=5.16.2",  # security: python-socketio advisory (#1547)
 ]

--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -24,7 +24,13 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [manifest]
-constraints = [{ name = "jupyter-server", specifier = ">=2.20.0" }]
+constraints = [
+    { name = "jupyter-server", specifier = ">=2.20.0" },
+    { name = "langsmith", specifier = ">=0.8.18" },
+    { name = "python-engineio", specifier = ">=4.13.2" },
+    { name = "python-socketio", specifier = ">=5.16.2" },
+    { name = "vcrpy", specifier = ">=8.2.1" },
+]
 
 [[package]]
 name = "accelerate"
@@ -6726,14 +6732,14 @@ wheels = [
 
 [[package]]
 name = "python-engineio"
-version = "4.12.2"
+version = "4.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "simple-websocket" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/0b/67295279b66835f9fa7a491650efcd78b20321c127036eef62c11a31e028/python_engineio-4.12.2.tar.gz", hash = "sha256:e7e712ffe1be1f6a05ee5f951e72d434854a32fcfc7f6e4d9d3cae24ec70defa", size = 91677, upload-time = "2025-06-04T19:22:18.789Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a0/f75491f942184d9960b15e763270f765fe9f239745ca5f9e16289011aed4/python_engineio-4.13.3.tar.gz", hash = "sha256:572b7783e341fed21edbc7cea297ccd378dad79265fdde96aa4664420a7c06c9", size = 79734, upload-time = "2026-06-20T22:53:52.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/fa/df59acedf7bbb937f69174d00f921a7b93aa5a5f5c17d05296c814fff6fc/python_engineio-4.12.2-py3-none-any.whl", hash = "sha256:8218ab66950e179dfec4b4bbb30aecf3f5d86f5e58e6fc1aa7fde2c698b2804f", size = 59536, upload-time = "2025-06-04T19:22:16.916Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/96/82f6328e410515fab21d5602ba35b9377a47b5a141a0c1f9efa00ce21eb4/python_engineio-4.13.3-py3-none-any.whl", hash = "sha256:1f60ecaf1358190f0e26c48c578a60428dc02a8f1295bc3dbf53d1b31116821f", size = 59993, upload-time = "2026-06-20T22:53:50.775Z" },
 ]
 
 [[package]]
@@ -6831,15 +6837,15 @@ wheels = [
 
 [[package]]
 name = "python-socketio"
-version = "5.16.1"
+version = "5.16.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bidict" },
     { name = "python-engineio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/81/cf8284f45e32efa18d3848ed82cdd4dcc1b657b082458fbe01ad3e1f2f8d/python_socketio-5.16.1.tar.gz", hash = "sha256:f863f98eacce81ceea2e742f6388e10ca3cdd0764be21d30d5196470edf5ea89", size = 128508, upload-time = "2026-02-06T23:42:07Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/2d/ffce71017c106b75099fea569df6518c63fee5d6202ce0cfe7b01e6f22c3/python_socketio-5.16.3.tar.gz", hash = "sha256:89b136f677ae65607a84cecda9b4d6c5377b40a97582c504c25df89af16d520e", size = 128095, upload-time = "2026-06-15T22:07:04.003Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c7/deb8c5e604404dbf10a3808a858946ca3547692ff6316b698945bb72177e/python_socketio-5.16.1-py3-none-any.whl", hash = "sha256:a3eb1702e92aa2f2b5d3ba00261b61f062cce51f1cfb6900bf3ab4d1934d2d35", size = 82054, upload-time = "2026-02-06T23:42:05.772Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/38/8c5e72d53ff8eb27497c4f268a7f6d9121e727a50b65248288ad79a93053/python_socketio-5.16.3-py3-none-any.whl", hash = "sha256:e7ad14202a5e6448824c7c2f86161d04e13dec05992257df5c709e6a2798c041", size = 82087, upload-time = "2026-06-15T22:07:02.498Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Consolidated python-sdk uv security bumps.

## Included
- **jupyter-server -> 2.20.0 (CRITICAL, #1515)**: dev/notebook transitive. Cooldown has cleared; surgical `uv lock --upgrade-package jupyter-server`, single-package diff.
- **vcrpy -> 8.2.1 (HIGH, #1531)**: dev/test-only transitive (HTTP record/replay used by the SDK test suite).

Both are single-package, surgical `uv lock --upgrade-package` bumps; `uv lock --check` passes.

## Deferred (separate track)
- langsmith -> 0.8.18 (HIGH, #1532): cooldown clears ~06-26.
- litellm CRITICAL (#1497) and the litellm HIGH alerts (#1533-#1538): all blocked on the openai 1.x -> 2.x migration (litellm >=1.83.10 pins openai 2.24.0, which python-sdk caps below for a documented pydantic-core reason). Tracking issue #5020.
- nltk (HIGH, #1495): no patched version published upstream.