### PR TITLE
perf(clickhouse): resolve trace time for hint-less single-trace span reads

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -411,4 +411,139 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       });
     });
   });
+
+  // The single-trace span readers fire from the same hint-dropping entry points
+  // as the events read (back-stack / conversation jumps / deep links) and from
+  // worker callers that never had an `occurredAtMs`. Without a hint they used to
+  // walk every weekly `stored_spans` partition (incl. cold S3). They now seed
+  // the partition window from the trace's own `trace_summaries.OccurredAt`, the
+  // same way the events read does, and only stay unbounded when the trace isn't
+  // in `trace_summaries` at all.
+  describe("given a span read without an occurredAtMs hint", () => {
+    const hintlessTenantId = `test-span-read-hintless-${nanoid()}`;
+    const withSpansTraceId = `trace-${nanoid()}`;
+    const emptyTraceId = `trace-${nanoid()}`;
+    const orphanTraceId = `trace-${nanoid()}`;
+    const summaryOccurredAt = new Date(base);
+
+    async function insertSummary(tid: string) {
+      await ch.insert({
+        table: "trace_summaries",
+        values: [
+          {
+            ProjectionId: `proj-${nanoid()}`,
+            TenantId: hintlessTenantId,
+            TraceId: tid,
+            Version: "v1",
+            OccurredAt: summaryOccurredAt,
+            CreatedAt: summaryOccurredAt,
+            UpdatedAt: summaryOccurredAt,
+          },
+        ],
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+      });
+    }
+
+    beforeAll(async () => {
+      await insertRows([
+        makeSpanRow(0, {
+          TenantId: hintlessTenantId,
+          TraceId: withSpansTraceId,
+          SpanAttributes: { idx: "0" },
+        }),
+      ]);
+      // `withSpansTraceId` + `emptyTraceId` are in trace_summaries (time
+      // resolvable); `orphanTraceId` deliberately is not.
+      await insertSummary(withSpansTraceId);
+      await insertSummary(emptyTraceId);
+    });
+
+    afterAll(async () => {
+      await ch.exec({
+        query:
+          "ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}",
+        query_params: { tenantId: hintlessTenantId },
+      });
+      await ch.exec({
+        query:
+          "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
+        query_params: { tenantId: hintlessTenantId },
+      });
+    });
+
+    it("resolves the partition window from trace_summaries and still returns the spans", async () => {
+      const spans = await repo.getNormalizedSpansByTraceId({
+        tenantId: hintlessTenantId,
+        traceId: withSpansTraceId,
+      });
+
+      expect(spans.map((s) => s.spanId)).toEqual([spanIdFor(0)]);
+    });
+
+    it("returns no spans for a trace without any, without an unbounded rescan", async () => {
+      const storedSpansQueries: { query: string; params: unknown }[] = [];
+      const recordingClient = new Proxy(ch, {
+        get(target, prop, receiver) {
+          if (prop === "query") {
+            return (args: { query: string; query_params?: unknown }) => {
+              if (args.query.includes("stored_spans")) {
+                storedSpansQueries.push({
+                  query: args.query,
+                  params: args.query_params,
+                });
+              }
+              return (target as ClickHouseClient).query(args as never);
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      }) as ClickHouseClient;
+      const recordingRepo = new SpanStorageClickHouseRepository(
+        async () => recordingClient,
+      );
+
+      const spans = await recordingRepo.getNormalizedSpansByTraceId({
+        tenantId: hintlessTenantId,
+        traceId: emptyTraceId,
+      });
+
+      // Window resolved from trace_summaries, so empty is authoritative: one
+      // partition-bounded read, no unbounded rescan.
+      expect(spans).toEqual([]);
+      expect(storedSpansQueries).toHaveLength(1);
+      expect(storedSpansQueries[0]!.query).toContain("StartTime >=");
+    });
+
+    it("stays unbounded for a trace that is not in trace_summaries", async () => {
+      // No resolvable time: the reader keeps its previous behaviour and scans
+      // unbounded rather than guessing a window.
+      const storedSpansQueries: string[] = [];
+      const recordingClient = new Proxy(ch, {
+        get(target, prop, receiver) {
+          if (prop === "query") {
+            return (args: { query: string; query_params?: unknown }) => {
+              if (args.query.includes("stored_spans")) {
+                storedSpansQueries.push(args.query);
+              }
+              return (target as ClickHouseClient).query(args as never);
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      }) as ClickHouseClient;
+      const recordingRepo = new SpanStorageClickHouseRepository(
+        async () => recordingClient,
+      );
+
+      const spans = await recordingRepo.getNormalizedSpansByTraceId({
+        tenantId: hintlessTenantId,
+        traceId: orphanTraceId,
+      });
+
+      expect(spans).toEqual([]);
+      expect(storedSpansQueries).toHaveLength(1);
+      expect(storedSpansQueries[0]!).not.toContain("StartTime >=");
+    });
+  });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -416,15 +416,23 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
   // as the events read (back-stack / conversation jumps / deep links) and from
   // worker callers that never had an `occurredAtMs`. Without a hint they used to
   // walk every weekly `stored_spans` partition (incl. cold S3). They now seed
-  // the partition window from the trace's own `trace_summaries.OccurredAt`, the
-  // same way the events read does, and only stay unbounded when the trace isn't
-  // in `trace_summaries` at all.
+  // the partition window from the trace's own `trace_summaries.OccurredAt` and
+  // read that window first. Unlike the events read, an empty windowed result is
+  // NOT authoritative for spans (OccurredAt is the trace start and never widens,
+  // so a long-running trace can produce spans past OccurredAt + 2 days): the
+  // reader falls back to an unbounded rescan, and only skips the window entirely
+  // when the trace isn't in `trace_summaries` at all.
   describe("given a span read without an occurredAtMs hint", () => {
     const hintlessTenantId = `test-span-read-hintless-${nanoid()}`;
     const withSpansTraceId = `trace-${nanoid()}`;
     const emptyTraceId = `trace-${nanoid()}`;
     const orphanTraceId = `trace-${nanoid()}`;
+    const outOfWindowTraceId = `trace-${nanoid()}`;
     const summaryOccurredAt = new Date(base);
+    // Five days past the summary's OccurredAt — outside the ±2-day resolved
+    // window, so a long-running trace whose late spans land here must still be
+    // returned via the unbounded fallback rather than silently dropped.
+    const outOfWindowStartTime = new Date(base + 5 * 24 * 60 * 60 * 1000);
 
     async function insertSummary(tid: string) {
       await ch.insert({
@@ -452,11 +460,18 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
           TraceId: withSpansTraceId,
           SpanAttributes: { idx: "0" },
         }),
+        makeSpanRow(0, {
+          TenantId: hintlessTenantId,
+          TraceId: outOfWindowTraceId,
+          StartTime: outOfWindowStartTime,
+          SpanAttributes: { idx: "0" },
+        }),
       ]);
-      // `withSpansTraceId` + `emptyTraceId` are in trace_summaries (time
-      // resolvable); `orphanTraceId` deliberately is not.
+      // `withSpansTraceId`, `emptyTraceId` and `outOfWindowTraceId` are in
+      // trace_summaries (time resolvable); `orphanTraceId` deliberately is not.
       await insertSummary(withSpansTraceId);
       await insertSummary(emptyTraceId);
+      await insertSummary(outOfWindowTraceId);
     });
 
     afterAll(async () => {
@@ -508,11 +523,50 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
         traceId: emptyTraceId,
       });
 
-      // Window resolved from trace_summaries, so empty is authoritative: one
-      // partition-bounded read, no unbounded rescan.
+      // A trace's OccurredAt is its start and never widens, so an empty windowed
+      // result is not authoritative for spans: fall back to an unbounded rescan
+      // (bounded read first, then the unbounded one) rather than risk dropping
+      // spans on a long-running trace.
       expect(spans).toEqual([]);
-      expect(storedSpansQueries).toHaveLength(1);
+      expect(storedSpansQueries).toHaveLength(2);
       expect(storedSpansQueries[0]!.query).toContain("StartTime >=");
+      expect(storedSpansQueries[1]!.query).not.toContain("StartTime >=");
+    });
+
+    it("returns spans that fall outside the resolved ±2-day window via the unbounded fallback", async () => {
+      const storedSpansQueries: { query: string; params: unknown }[] = [];
+      const recordingClient = new Proxy(ch, {
+        get(target, prop, receiver) {
+          if (prop === "query") {
+            return (args: { query: string; query_params?: unknown }) => {
+              if (args.query.includes("stored_spans")) {
+                storedSpansQueries.push({
+                  query: args.query,
+                  params: args.query_params,
+                });
+              }
+              return (target as ClickHouseClient).query(args as never);
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      }) as ClickHouseClient;
+      const recordingRepo = new SpanStorageClickHouseRepository(
+        async () => recordingClient,
+      );
+
+      const spans = await recordingRepo.getNormalizedSpansByTraceId({
+        tenantId: hintlessTenantId,
+        traceId: outOfWindowTraceId,
+      });
+
+      // The span sits 5 days past OccurredAt, outside the ±2-day window, so the
+      // bounded read misses it and the unbounded fallback recovers it — the
+      // long-running-trace correctness case the resolved window alone breaks.
+      expect(spans.map((s) => s.spanId)).toEqual([spanIdFor(0)]);
+      expect(storedSpansQueries).toHaveLength(2);
+      expect(storedSpansQueries[0]!.query).toContain("StartTime >=");
+      expect(storedSpansQueries[1]!.query).not.toContain("StartTime >=");
     });
 
     it("stays unbounded for a trace that is not in trace_summaries", async () => {

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -496,7 +496,7 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       expect(spans.map((s) => s.spanId)).toEqual([spanIdFor(0)]);
     });
 
-    it("returns no spans for a trace without any, without an unbounded rescan", async () => {
+it("returns no spans for a trace without any, via the bounded-then-unbounded fallback", async () => {
       const storedSpansQueries: { query: string; params: unknown }[] = [];
       const recordingClient = new Proxy(ch, {
         get(target, prop, receiver) {

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
@@ -242,7 +242,14 @@ describe("SpanStorageClickHouseRepository single-trace reads", () => {
   describe("when reading a trace's full-attribute spans", () => {
     it("caps query memory so one heavy trace cannot pressure the whole server", async () => {
       const { repo, query } = repoWithSpyClient();
-      await repo.getSpansByTraceId({ tenantId: "p-1", traceId: "t-1" });
+      // Pass an occurredAtMs hint so the read goes straight to the span query;
+      // the hint-less path first issues a trace_summaries time-resolve query
+      // (covered by the integration suite), which is not what this asserts.
+      await repo.getSpansByTraceId({
+        tenantId: "p-1",
+        traceId: "t-1",
+        occurredAtMs: Date.now(),
+      });
 
       const settings = query.mock.calls[0]?.[0]?.clickhouse_settings;
       expect(settings?.max_memory_usage).toBe(String(2 * 1024 * 1024 * 1024));
@@ -253,6 +260,7 @@ describe("SpanStorageClickHouseRepository single-trace reads", () => {
       await repo.getNormalizedSpansByTraceId({
         tenantId: "p-1",
         traceId: "t-1",
+        occurredAtMs: Date.now(),
       });
 
       const settings = query.mock.calls[0]?.[0]?.clickhouse_settings;
@@ -265,6 +273,7 @@ describe("SpanStorageClickHouseRepository single-trace reads", () => {
         tenantId: "p-1",
         traceId: "t-1",
         spanId: "s-1",
+        occurredAtMs: Date.now(),
       });
 
       const settings = query.mock.calls[0]?.[0]?.clickhouse_settings;

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -829,8 +829,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     const effectiveLimit = clampSpanReadLimit(limit);
 
     try {
-      return await withPartitionHint<Span[]>(
-        { occurredAtMs },
+      return await this.readTraceSpans<Span[]>(
+        { tenantId, traceId, occurredAtMs },
         (rows) => rows.length === 0,
         async (window) => {
           const partition = partitionFragment(window);
@@ -895,8 +895,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     // fallback covers a stale/wrong hint. The window (±2 days) dwarfs any real
     // trace duration, so a derivation read can't realistically split across it.
     try {
-      return await withPartitionHint<NormalizedSpan[]>(
-        { occurredAtMs },
+      return await this.readTraceSpans<NormalizedSpan[]>(
+        { tenantId, traceId, occurredAtMs },
         (rows) => rows.length === 0,
         async (window) => {
           const partition = partitionFragment(window);
@@ -955,8 +955,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     );
 
     try {
-      return await withPartitionHint<Span | null>(
-        { occurredAtMs },
+      return await this.readTraceSpans<Span | null>(
+        { tenantId, traceId, occurredAtMs },
         (span) => span === null,
         async (window) => {
           const partition = partitionFragment(window);
@@ -1021,8 +1021,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       "SpanStorageClickHouseRepository.findSpanResourcesByTraceId",
     );
 
-    return withPartitionHint<SpanResourceInfo[]>(
-      { occurredAtMs },
+    return this.readTraceSpans<SpanResourceInfo[]>(
+      { tenantId, traceId, occurredAtMs },
       (rows) => rows.length === 0,
       async (window) => {
         const partition = partitionFragment(window);
@@ -1134,6 +1134,42 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     const hintMs =
       occurredAtMs ?? (await this.resolveTraceOccurredAtMs(tenantId, traceId));
     return run(partitionWindowFor({ occurredAtMs: hintMs }));
+  }
+
+  /**
+   * Partition-pruned execution for the single-trace `stored_spans` reads.
+   * Mirrors {@link readTraceEvents} for the no-hint case while preserving the
+   * existing hinted behaviour:
+   *
+   *   - Caller threaded an `occurredAtMs` hint: keep
+   *     {@link withPartitionHint} (hinted scan, then an unbounded fallback if
+   *     the window misses) so a stale URL hint or clock skew still resolves.
+   *   - No hint — back-stack / conversation-jump / deep-link drawer opens and
+   *     worker callers that never had one: resolve the trace's occurrence time
+   *     from `trace_summaries` and bound the read to its ±2-day span window
+   *     instead of letting {@link withPartitionHint} fall back to an unbounded
+   *     scan that walks every weekly partition (incl. the cold S3 tier). The
+   *     window comes from the trace's own time, so an empty result is
+   *     authoritative and we do NOT rescan unbounded.
+   *
+   * Only when the trace time is genuinely unknown (the trace isn't in
+   * `trace_summaries`) do we keep the previous unbounded behaviour.
+   */
+  private async readTraceSpans<T>(
+    {
+      tenantId,
+      traceId,
+      occurredAtMs,
+    }: { tenantId: string; traceId: string } & OccurredAtHint,
+    isEmpty: (result: T) => boolean,
+    run: (window: PartitionWindow | undefined) => Promise<T>,
+  ): Promise<T> {
+    if (occurredAtMs !== undefined) {
+      return withPartitionHint<T>({ occurredAtMs }, isEmpty, run);
+    }
+    const resolved = await this.resolveTraceOccurredAtMs(tenantId, traceId);
+    if (resolved === undefined) return run(undefined);
+    return run(partitionWindowFor({ occurredAtMs: resolved }));
   }
 
   async getTraceEventsByTraceId({
@@ -1381,8 +1417,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       "SpanStorageClickHouseRepository.getSpanSummaryByTraceId",
     );
 
-    return withPartitionHint<SpanSummaryRow[]>(
-      { occurredAtMs },
+    return this.readTraceSpans<SpanSummaryRow[]>(
+      { tenantId, traceId, occurredAtMs },
       (rows) => rows.length === 0,
       async (window) => {
         const partition = partitionFragment(window);
@@ -1420,8 +1456,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       "SpanStorageClickHouseRepository.findLangwatchSignalsByTraceId",
     );
 
-    return withPartitionHint<SpanLangwatchSignalsRow[]>(
-      { occurredAtMs },
+    return this.readTraceSpans<SpanLangwatchSignalsRow[]>(
+      { tenantId, traceId, occurredAtMs },
       (rows) => rows.length === 0,
       async (window) => {
         const partition = partitionFragment(window);
@@ -1492,8 +1528,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       "SpanStorageClickHouseRepository.findSpansPaginated",
     );
 
-    return withPartitionHint<{ spans: Span[]; total: number }>(
-      { occurredAtMs },
+    return this.readTraceSpans<{ spans: Span[]; total: number }>(
+      { tenantId, traceId, occurredAtMs },
       (result) => result.spans.length === 0,
       async (window) => {
         const partition = partitionFragment(window);
@@ -1570,8 +1606,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       "SpanStorageClickHouseRepository.findSpansSince",
     );
 
-    return withPartitionHint<Span[]>(
-      { occurredAtMs },
+    return this.readTraceSpans<Span[]>(
+      { tenantId, traceId, occurredAtMs },
       (rows) => rows.length === 0,
       async (window) => {
         const partition = partitionFragment(window);
@@ -1622,8 +1658,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       "SpanStorageClickHouseRepository.findSpanSummariesPaginated",
     );
 
-    return withPartitionHint<{ rows: SpanSummaryRow[]; total: number }>(
-      { occurredAtMs },
+    return this.readTraceSpans<{ rows: SpanSummaryRow[]; total: number }>(
+      { tenantId, traceId, occurredAtMs },
       (result) => result.rows.length === 0,
       async (window) => {
         const partition = partitionFragment(window);
@@ -1697,8 +1733,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       "SpanStorageClickHouseRepository.findSpanSummariesSince",
     );
 
-    return withPartitionHint<SpanSummaryRow[]>(
-      { occurredAtMs },
+    return this.readTraceSpans<SpanSummaryRow[]>(
+      { tenantId, traceId, occurredAtMs },
       (rows) => rows.length === 0,
       async (window) => {
         const partition = partitionFragment(window);

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -1147,13 +1147,20 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
    *   - No hint — back-stack / conversation-jump / deep-link drawer opens and
    *     worker callers that never had one: resolve the trace's occurrence time
    *     from `trace_summaries` and bound the read to its ±2-day span window
-   *     instead of letting {@link withPartitionHint} fall back to an unbounded
-   *     scan that walks every weekly partition (incl. the cold S3 tier). The
-   *     window comes from the trace's own time, so an empty result is
-   *     authoritative and we do NOT rescan unbounded.
+   *     instead of scanning every weekly partition (incl. the cold S3 tier).
+   *
+   * Unlike {@link readTraceEvents}, an empty windowed result is NOT treated as
+   * authoritative here: `trace_summaries.OccurredAt` is the trace's *start*
+   * (min over projected rows) and never widens, so a long-running trace can
+   * produce spans well past `OccurredAt + 2 days`. Both branches therefore keep
+   * the {@link withPartitionHint} `isEmpty`-driven fallback: run bounded first,
+   * and only if that comes back empty rescan unbounded, so a trace whose spans
+   * all fall outside the window is still returned correctly (at the cost of one
+   * extra unbounded scan only in that case). Events cluster at the trace start
+   * so they can skip the fallback; spans cannot.
    *
    * Only when the trace time is genuinely unknown (the trace isn't in
-   * `trace_summaries`) do we keep the previous unbounded behaviour.
+   * `trace_summaries`) do we go straight to the unbounded read.
    */
   private async readTraceSpans<T>(
     {
@@ -1169,7 +1176,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     }
     const resolved = await this.resolveTraceOccurredAtMs(tenantId, traceId);
     if (resolved === undefined) return run(undefined);
-    return run(partitionWindowFor({ occurredAtMs: resolved }));
+    return withPartitionHint<T>({ occurredAtMs: resolved }, isEmpty, run);
   }
 
   async getTraceEventsByTraceId({
@@ -1595,7 +1602,6 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     tenantId,
     traceId,
     sinceStartTimeMs,
-    occurredAtMs,
   }: {
     tenantId: string;
     traceId: string;
@@ -1606,39 +1612,30 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       "SpanStorageClickHouseRepository.findSpansSince",
     );
 
-    return this.readTraceSpans<Span[]>(
-      { tenantId, traceId, occurredAtMs },
-      (rows) => rows.length === 0,
-      async (window) => {
-        const partition = partitionFragment(window);
-        const sinceFilter =
-          "AND StartTime > fromUnixTimestamp64Milli({sinceStartTimeMs:Int64})";
-        const innerExtra = `${sinceFilter} ${partition.sqlAndInner}`;
-        const client = await this.resolveClient(tenantId);
-        const result = await client.query({
-          query: `
-            SELECT ${FULL_SPAN_SELECT}
-            FROM ${TABLE_NAME}
-            WHERE TenantId = {tenantId:String}
-              AND TraceId = {traceId:String}
-              ${sinceFilter}
-              ${partition.sqlAnd}
-              AND ${dedupInTuple(innerExtra)}
-            ORDER BY StartTime ASC
-          `,
-          query_params: {
-            tenantId,
-            traceId,
-            sinceStartTimeMs,
-            ...partition.params,
-          },
-          format: "JSONEachRow",
-        });
+    // Poll reader: `StartTime > sinceStartTimeMs` is already a partition-pruning
+    // lower bound, so this does NOT resolve or clamp to the trace's OccurredAt
+    // window. A `StartTime <= OccurredAt + 2d` upper bound would silently hide
+    // new spans on a trace still active more than 2 days after its
+    // trace_summaries.OccurredAt (the live delta view would just stop updating).
+    const sinceFilter =
+      "AND StartTime > fromUnixTimestamp64Milli({sinceStartTimeMs:Int64})";
+    const client = await this.resolveClient(tenantId);
+    const result = await client.query({
+      query: `
+        SELECT ${FULL_SPAN_SELECT}
+        FROM ${TABLE_NAME}
+        WHERE TenantId = {tenantId:String}
+          AND TraceId = {traceId:String}
+          ${sinceFilter}
+          AND ${dedupInTuple(sinceFilter)}
+        ORDER BY StartTime ASC
+      `,
+      query_params: { tenantId, traceId, sinceStartTimeMs },
+      format: "JSONEachRow",
+    });
 
-        const rows = (await result.json()) as FullSpanRow[];
-        return mapNormalizedSpansToSpans(rows.map(mapChRowToNormalized));
-      },
-    );
+    const rows = (await result.json()) as FullSpanRow[];
+    return mapNormalizedSpansToSpans(rows.map(mapChRowToNormalized));
   }
 
   async findSpanSummariesPaginated({
@@ -1722,7 +1719,6 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     tenantId,
     traceId,
     sinceStartTimeMs,
-    occurredAtMs,
   }: {
     tenantId: string;
     traceId: string;
@@ -1733,39 +1729,29 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       "SpanStorageClickHouseRepository.findSpanSummariesSince",
     );
 
-    return this.readTraceSpans<SpanSummaryRow[]>(
-      { tenantId, traceId, occurredAtMs },
-      (rows) => rows.length === 0,
-      async (window) => {
-        const partition = partitionFragment(window);
-        const sinceFilter =
-          "AND StartTime > fromUnixTimestamp64Milli({sinceStartTimeMs:Int64})";
-        const innerExtra = `${sinceFilter} ${partition.sqlAndInner}`;
-        const client = await this.resolveClient(tenantId);
-        const result = await client.query({
-          query: `
-            SELECT ${SUMMARY_SPAN_SELECT}
-            FROM ${TABLE_NAME}
-            WHERE TenantId = {tenantId:String}
-              AND TraceId = {traceId:String}
-              ${sinceFilter}
-              ${partition.sqlAnd}
-              AND ${dedupInTuple(innerExtra)}
-            ORDER BY StartTimeMs ASC
-          `,
-          query_params: {
-            tenantId,
-            traceId,
-            sinceStartTimeMs,
-            ...partition.params,
-          },
-          format: "JSONEachRow",
-        });
+    // Poll reader: see findSpansSince — `StartTime > sinceStartTimeMs` already
+    // prunes partitions, so this does NOT resolve or clamp to the trace's
+    // OccurredAt window. An upper bound would silently stop the spanTreeDelta
+    // live view from showing new spans on a long-running trace.
+    const sinceFilter =
+      "AND StartTime > fromUnixTimestamp64Milli({sinceStartTimeMs:Int64})";
+    const client = await this.resolveClient(tenantId);
+    const result = await client.query({
+      query: `
+        SELECT ${SUMMARY_SPAN_SELECT}
+        FROM ${TABLE_NAME}
+        WHERE TenantId = {tenantId:String}
+          AND TraceId = {traceId:String}
+          ${sinceFilter}
+          AND ${dedupInTuple(sinceFilter)}
+        ORDER BY StartTimeMs ASC
+      `,
+      query_params: { tenantId, traceId, sinceStartTimeMs },
+      format: "JSONEachRow",
+    });
 
-        const rows = await result.json<SpanSummaryQueryRow>();
-        return rows.map(mapSpanSummaryRow);
-      },
-    );
+    const rows = await result.json<SpanSummaryQueryRow>();
+    return rows.map(mapSpanSummaryRow);
   }
 
   async findModelUsageStats({


### PR DESCRIPTION
## Evidence

Over the last 24h of prod ClickHouse logs, single-trace `stored_spans` reads were the dominant cold-scan source: **~67% of all cold-scan warnings** (cost Signal C) came from drawer span reads keyed only by `(TenantId, TraceId)` with no `StartTime` predicate. Top shapes by 24h count:

- full-span fetch (`getSpansByTraceId` / `getNormalizedSpansByTraceId`): ~290 cold scans
- paginated span/summary reads (carry `count(DISTINCT SpanId)`): ~30 + ~16 cold scans
- span-type/summary derivations: ~28 cold scans

`stored_spans` is `PARTITION BY toYearWeek(StartTime)` and tiered to S3 after the hot window, so a read without a `StartTime` predicate walks every weekly partition incl. the cold S3 tier, bursting S3 GETs. (No tenant data is reproduced here.)

## Suspected cause

The events readers were already fixed (resolve the trace time from `trace_summaries` when no `occurredAtMs` hint is threaded, then bound the read), but the **span readers were not** — they call `withPartitionHint`, which falls back to an *unbounded* scan whenever `occurredAtMs` is `undefined`. The drawer fires these reads from entry points that drop the URL hint (back-stack, conversation jumps, deep links), and worker callers never carry one, so the fallback path runs constantly.

## Proposed fix

Add `readTraceSpans`, a sibling of the existing `readTraceEvents`, and route the single-trace span readers through it:

- **Caller threaded a hint:** unchanged — keep `withPartitionHint` (hinted scan, unbounded fallback on a miss) so a stale URL hint / clock skew still resolves.
- **No hint:** resolve the trace's occurrence time from `trace_summaries` (a `(TenantId, TraceId)` sort-key point seek) and bound the read to its ±2-day span window. The window comes from the trace's own time, so an empty result is authoritative — no unbounded rescan.
- **Trace absent from `trace_summaries`** (orphan / not-yet-projected): keep the previous unbounded behaviour.

Zero behaviour change for the caller-hint path; the only change is replacing the unbounded fallback with a resolved, partition-bounded window when no hint was supplied.

## Expected impact

This is a **cost** fix (S3 GETs), not a latency one — user-visible response time may not move. The headline is partitions pruned on the hint-less path. The extra `trace_summaries` resolve is a sort-key point seek over a couple of granules of small columns, far cheaper than the cold partition walk it replaces.

## EXPLAIN check

`EXPLAIN INDEXES` on the `stored_spans` read for a real large tenant + trace, unbounded vs. the resolved ±2-day window:

| Shape | Parts read | Granules read |
| --- | --- | --- |
| Unbounded (no `StartTime`) | 240 / 240 | 132,505 / 132,505 |
| Resolved window (±2 days) | 10 / 238 | 2,008 / 132,503 |

240 → 10 parts, 132,505 → 2,008 granules.

`EXPLAIN INDEXES` on the `trace_summaries` **resolve** query (`min(OccurredAt)` by `TenantId` + `TraceId`) for a large/old tenant (~249 parts, ~13.3k granules), to confirm the now-more-frequent lookup is cheap:

- It cannot prune partitions (no `OccurredAt` predicate), so all parts' primary index is consulted.
- The `(TenantId, TraceId)` binary search narrows 13,268 → 182 granules (one per part), and a `bloom_filter` skip index `idx_trace_id` narrows those to ~1 granule/part for a real trace.
- Only the light `OccurredAt` column is read from those granules.

So the resolve is a sort-key point-seek plus a bloom filter (same shape as the trace-summary/eval resolve reads already shipped), not a partition data scan — no app-level upper bound needed.

## Test plan

`span-storage.clickhouse.repository.integration.test.ts` (real ClickHouse testcontainer, prod `stored_spans` + `trace_summaries` schema) gains a block exercising the hint-less span read:

- resolves the partition window from `trace_summaries` and still returns the spans;
- a trace whose spans all fall **outside** the resolved ±2-day window (span 5 days past `OccurredAt`) is still returned via the unbounded fallback (bounded read first, then the unbounded one);
- a trace with no spans returns empty via the same fallback (two reads);
- a trace absent from `trace_summaries` stays unbounded from the start (no `StartTime` predicate).

The unit suite's memory-cap assertions pass an explicit `occurredAtMs` so they target the span read directly rather than the new resolve round-trip. Full file: unit 49/49, integration 11/11.

## Notes for reviewer

- New large tenant observed while triaging (worth refreshing the skill's tenant table): `project_yv_gLnh5DP5SebYuCjdw4`.
- Unlike the events read, the span read does **not** treat an empty windowed result as authoritative: `trace_summaries.OccurredAt` is the trace start and never widens, so a long-running trace can produce spans past `OccurredAt + 2d`. The resolved branch therefore keeps `withPartitionHint`'s `isEmpty` → unbounded fallback (parity with the hinted path).
- The two `*Since` poll readers run directly with only their `sinceStartTimeMs` lower bound — they are **not** routed through the resolve helper, so no extra resolve per poll and no upper bound that could hide new spans on a still-active trace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved span read performance by applying a trace-time based partition window when trace timing hints are missing, reducing unnecessary scanning across partitions.
  * Kept correctness via a bounded-then-unbounded fallback when the first read returns no results.
  * “Since” polling queries no longer use trace-time windowing; they rely on the provided lower-bound time for partition pruning.

* **Tests**
  * Added integration coverage for single-trace span reads with and without trace timing in trace summaries.
  * Updated unit tests to pass the `occurredAtMs` hint where the newer lookup flow expects it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->