### PR TITLE
perf(clickhouse): bound key-discovery facet memory so it spills instead of OOMing

### DIFF
--- a/langwatch/src/server/app-layer/traces/facet-registry.ts
+++ b/langwatch/src/server/app-layer/traces/facet-registry.ts
@@ -30,6 +30,12 @@ export interface FacetQueryContext {
 export interface FacetQuery {
   sql: string;
   params: Record<string, unknown>;
+  /**
+   * Optional per-query ClickHouse settings (e.g. a memory ceiling / external
+   * GROUP BY threshold for the unbounded key-discovery facets). Passed straight
+   * through as `clickhouse_settings` when the query runs.
+   */
+  settings?: Record<string, string>;
 }
 
 interface BaseFacetDef {

--- a/langwatch/src/server/app-layer/traces/facets/__tests__/span-attribute-keys.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/facets/__tests__/span-attribute-keys.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { FACET_REGISTRY } from "../../facet-registry";
+import { KEY_DISCOVERY_SETTINGS } from "../helpers";
 import {
   SPAN_ATTRIBUTE_KEYS_FACET,
   buildSpanAttributeKeysFacetQuery,
@@ -48,6 +49,15 @@ describe("buildSpanAttributeKeysFacetQuery", () => {
       // S3 cold storage). See the ClickHouse mistakes table in CLAUDE.md.
       expect(query.sql).toContain("StartTime >=");
       expect(query.sql).toContain("StartTime <=");
+    });
+
+    it("carries the key-discovery memory guard", () => {
+      // High-cardinality attribute keys make this arrayJoin/GROUP BY a memory
+      // hog; the guard spills the aggregation and caps the read so a
+      // pathological tenant fails its own facet rather than the whole server.
+      expect(query.settings).toBe(KEY_DISCOVERY_SETTINGS);
+      expect(query.settings?.max_memory_usage).toBeDefined();
+      expect(query.settings?.max_bytes_before_external_group_by).toBeDefined();
     });
 
     it("reads the keys subcolumn directly via `.keys`, never the values side", () => {

--- a/langwatch/src/server/app-layer/traces/facets/event-attribute-keys.ts
+++ b/langwatch/src/server/app-layer/traces/facets/event-attribute-keys.ts
@@ -3,7 +3,7 @@ import type {
   FacetQuery,
   FacetQueryContext,
 } from "../facet-registry";
-import { baseParams, buildTimeWhere } from "./helpers";
+import { baseParams, buildTimeWhere, KEY_DISCOVERY_SETTINGS } from "./helpers";
 
 /**
  * Discover query for event attribute keys: every distinct key seen across
@@ -51,6 +51,7 @@ export function buildEventAttributeKeysFacetQuery(
       ...baseParams(ctx),
       ...(ctx.prefix ? { prefix: ctx.prefix } : {}),
     },
+    settings: KEY_DISCOVERY_SETTINGS,
   };
 }
 

--- a/langwatch/src/server/app-layer/traces/facets/helpers.ts
+++ b/langwatch/src/server/app-layer/traces/facets/helpers.ts
@@ -24,6 +24,30 @@ export function buildTimeWhere(timeColumn: string): string {
 }
 
 /**
+ * Per-query memory guard for the unbounded key-discovery facets
+ * (`metadata-keys`, `span-attribute-keys`, `event-attribute-keys`). Each
+ * flattens an attribute-map's keys with `arrayJoin` and groups by key over the
+ * whole time window. A tenant that stuffs high-cardinality data into key names
+ * (per-user / UUID keys) turns the GROUP BY into millions of groups, and the
+ * read of the keys subcolumn can allocate gigabytes — observed tripping
+ * `MEMORY_LIMIT_EXCEEDED` in prod.
+ *
+ * `max_bytes_before_external_group_by` spills that aggregation to disk so the
+ * facet completes instead of OOMing, and `max_memory_usage` caps the read so a
+ * pathological tenant fails its own discovery query rather than allocating
+ * against the server total — where the OvercommitTracker resolves the pressure
+ * by killing whichever query is allocating, degrading unrelated requests. Same
+ * rationale as the span repo's `SINGLE_TRACE_READ_SETTINGS`. The ceiling sits
+ * above any normal facet read and below the global per-query limit, so it only
+ * trips on the pathological tail.
+ */
+export const KEY_DISCOVERY_SETTINGS: Record<string, string> = {
+  // ClickHouse settings are string-typed over the wire.
+  max_bytes_before_external_group_by: String(512 * 1024 * 1024), // 512 MiB
+  max_memory_usage: String(2 * 1024 * 1024 * 1024), // 2 GiB
+};
+
+/**
  * The bound-parameter tuple every facet query relies on. Helpers that need
  * `prefix` add it on top, since not every builder supports key/value
  * prefix-filtering.

--- a/langwatch/src/server/app-layer/traces/facets/metadata-keys.ts
+++ b/langwatch/src/server/app-layer/traces/facets/metadata-keys.ts
@@ -3,7 +3,7 @@ import type {
   FacetQuery,
   FacetQueryContext,
 } from "../facet-registry";
-import { baseParams, buildTimeWhere } from "./helpers";
+import { baseParams, buildTimeWhere, KEY_DISCOVERY_SETTINGS } from "./helpers";
 
 /**
  * Discover query for trace metadata attribute keys: every distinct
@@ -50,6 +50,7 @@ export function buildMetadataKeysFacetQuery(
       ...baseParams(ctx),
       ...(ctx.prefix ? { prefix: ctx.prefix } : {}),
     },
+    settings: KEY_DISCOVERY_SETTINGS,
   };
 }
 

--- a/langwatch/src/server/app-layer/traces/facets/span-attribute-keys.ts
+++ b/langwatch/src/server/app-layer/traces/facets/span-attribute-keys.ts
@@ -3,7 +3,7 @@ import type {
   FacetQuery,
   FacetQueryContext,
 } from "../facet-registry";
-import { baseParams, buildTimeWhere } from "./helpers";
+import { baseParams, buildTimeWhere, KEY_DISCOVERY_SETTINGS } from "./helpers";
 
 /**
  * Discover query for span attribute keys: every distinct `SpanAttributes`
@@ -61,6 +61,7 @@ export function buildSpanAttributeKeysFacetQuery(
       ...baseParams(ctx),
       ...(ctx.prefix ? { prefix: ctx.prefix } : {}),
     },
+    settings: KEY_DISCOVERY_SETTINGS,
   };
 }
 

--- a/langwatch/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
@@ -1,5 +1,6 @@
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
+import type { FacetQuery } from "../facet-registry";
 import type { TraceSummaryData } from "../types";
 import type { TraceSummaryFieldsBase } from "./_summary-fields.types";
 import type {
@@ -621,11 +622,7 @@ export class TraceListClickHouseRepository implements TraceListRepository {
 
   async findCategoricalFacetRaw(params: {
     tenantId: string;
-    query: {
-      sql: string;
-      params: Record<string, unknown>;
-      settings?: Record<string, string>;
-    };
+    query: FacetQuery;
   }): Promise<CategoricalFacetResult> {
     EventUtils.validateTenantId(
       { tenantId: params.tenantId },

--- a/langwatch/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
@@ -621,7 +621,11 @@ export class TraceListClickHouseRepository implements TraceListRepository {
 
   async findCategoricalFacetRaw(params: {
     tenantId: string;
-    query: { sql: string; params: Record<string, unknown> };
+    query: {
+      sql: string;
+      params: Record<string, unknown>;
+      settings?: Record<string, string>;
+    };
   }): Promise<CategoricalFacetResult> {
     EventUtils.validateTenantId(
       { tenantId: params.tenantId },
@@ -632,6 +636,11 @@ export class TraceListClickHouseRepository implements TraceListRepository {
     const result = await client.query({
       query: params.query.sql,
       query_params: params.query.params,
+      // Per-query guard (e.g. the key-discovery facets' memory ceiling); absent
+      // for facets that don't set one.
+      ...(params.query.settings
+        ? { clickhouse_settings: params.query.settings }
+        : {}),
       format: "JSONEachRow",
     });
 


### PR DESCRIPTION
## Evidence

Over the last 24h of prod ClickHouse logs, the per-query `MEMORY_LIMIT_EXCEEDED` (Code 241) SELECTs that are genuine query targets (vs. INSERT/ingestion pressure) concentrated on the **metadata-keys discovery facet** — the sidebar's "what attribute keys exist" dropdown — at **~12 GiB** per failed attempt, killed by the OvercommitTracker. (No tenant data reproduced here.)

The facet runs three sibling builders with the same shape — `metadata-keys` (trace_summaries `Attributes`), `span-attribute-keys` (stored_spans `SpanAttributes`), `event-attribute-keys` (stored_spans `Events.Attributes`, a double `arrayJoin`):

```
SELECT key, count() AS cnt, count() OVER () AS total_distinct
FROM (SELECT arrayJoin(<Map>.keys) AS key FROM <table> WHERE <tenant+time>)
GROUP BY key ORDER BY cnt DESC LIMIT n OFFSET m
```

## Suspected cause

The query is **already partition-pruned** (it carries the tenant + time predicate), so this is not a cold scan — the cost is memory. A tenant that stuffs high-cardinality data into attribute **key names** (per-user keys, UUIDs) turns the `GROUP BY key` into millions of groups; the keys-subcolumn read plus the `count() OVER ()` window buffer then allocates gigabytes. Because nothing caps it, that allocation lands against the server's **total** memory limit, where the OvercommitTracker resolves the pressure by killing whichever query is allocating — so one pathological tenant's facet can degrade unrelated requests.

## Proposed fix

Add a shared `KEY_DISCOVERY_SETTINGS` guard and attach it to the three key-discovery builders, threaded through the facet executor as `clickhouse_settings`:

- `max_bytes_before_external_group_by` (512 MiB) — spills the high-cardinality aggregation to disk so the facet **completes** instead of OOMing.
- `max_memory_usage` (2 GiB) — caps the read so a pathological tenant fails its **own** discovery query rather than allocating against the server total.

This mirrors the existing `SINGLE_TRACE_READ_SETTINGS` precedent already used by the single-trace span readers in this codebase. No query-shape change; results are identical (spilling is exact). Per-query SETTINGS only — no DB/table config touched.

## Expected impact

The pathological facet either spills to disk and returns correct results, or fails its own query with a clean facet error, instead of pushing server RSS into OvercommitTracker territory and degrading unrelated requests. Normal-tenant facet reads (p95 well under the ceiling) are unaffected.

## EXPLAIN check

`EXPLAIN INDEXES` on the metadata-keys facet for the tenant that OOMed confirms the query already prunes partitions — the lever is memory, not scan width:

```
Parts:    38 / 274
Granules: 1257 / 12961
```

`EXPLAIN PIPELINE` shows the `WindowTransform` (`count() OVER ()`) feeding the sort/limit on top of the aggregation — the buffer that, with millions of groups, drives the allocation. The memory guard is a runtime setting EXPLAIN cannot reflect; it is exercised by the integration test below against a real ClickHouse.

## Test plan

- `span-attribute-keys.unit.test.ts` asserts the builder carries the `KEY_DISCOVERY_SETTINGS` guard (memory ceiling + external GROUP BY), so a refactor can't silently drop it.
- `span-attribute-keys.integration.test.ts` (real ClickHouse testcontainer) continues to pass with the settings threaded through the executor, confirming the pass-through executes.
- Facet unit suite 153/153; typecheck clean.

## Notes for reviewer

- Tune `KEY_DISCOVERY_SETTINGS` in `facets/helpers.ts` if legitimate large tenants start failing — the ceiling is set above any normal facet read and below the global per-query limit.
- A follow-on structural option (not in this PR): the discovery facet only needs the top-N keys; the `count() OVER ()` total could be derived more cheaply, but the GROUP BY over all distinct keys is unavoidable for frequency ranking, so the spill guard is the load-bearing fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for per-query ClickHouse settings in trace facet lookups.
  * Key-discovery facets (attribute/metadata keys) now apply guarded default settings to reduce memory usage on large requests.
* **Bug Fixes**
  * Trace facet query execution now consistently forwards provided settings to ClickHouse, preserving existing behavior when none are provided.
* **Tests**
  * Added assertions to verify key-discovery queries include the expected settings values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->