### PR TITLE
fix(datasets): observable direct-upload PUT failures + stop ghost rows

### DIFF
--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -534,18 +534,30 @@ export function UploadCSVForm({
           );
         }
       }
-      // "No browser-reachable storage" and "presigned PUT failed"
-      // (CORS/network/non-ok) mean: fall back to the backend upload path. The
-      // fallback is size-guarded, so a small file + missing CORS still works, and
-      // a large file + missing CORS shows the clear "large uploads require object
-      // storage" error. Either way, no dead end.
-      if (
-        error instanceof DirectUploadUnavailableError ||
-        error instanceof PresignedUploadFailedError
-      ) {
+      // No browser-reachable storage at all (DirectUploadUnavailable): the
+      // install simply has no S3 → fall back to the in-browser parse path. A
+      // large file there hits the size guard with the accurate "requires object
+      // storage" message.
+      if (error instanceof DirectUploadUnavailableError) {
         // Parse the already-captured file NOW (the first and only in-browser
         // parse on this path) and hand off to the existing parse-and-drawer flow.
-        await runFallbackParseAndDrawer(rawFile);
+        await runFallbackParseAndDrawer(rawFile, "no-storage");
+        return;
+      }
+      // Storage IS configured but the cross-origin presigned PUT was rejected —
+      // almost always a missing/incorrect bucket CORS rule (an opaque fetch
+      // TypeError carries no status). This silently degrades the headline
+      // direct-upload path to the legacy in-browser one, so log it LOUDLY for
+      // operators — the UI can't (and per copywriting.md shouldn't) explain CORS
+      // to an end user. Then fall back for small files (resilience) but show an
+      // accurate error for large ones — never the false "requires object storage"
+      // when storage is in fact configured.
+      if (error instanceof PresignedUploadFailedError) {
+        logger.error(
+          { error, fileSizeBytes: rawFile.size, projectId },
+          "Direct-to-storage upload failed: presigned PUT rejected (likely a missing bucket CORS rule or storage connectivity). Falling back to in-browser parse.",
+        );
+        await runFallbackParseAndDrawer(rawFile, "presign-failed");
         return;
       }
       // A same-origin local-FS failure (e.g. StorageNotWritable) is a real,
@@ -594,12 +606,21 @@ export function UploadCSVForm({
    * OOM the browser (the exact failure direct upload avoids). Over the limit we
    * abort with a clear message instead of parsing.
    */
-  const runFallbackParseAndDrawer = async (file: File) => {
+  const runFallbackParseAndDrawer = async (
+    file: File,
+    reason: "no-storage" | "presign-failed",
+  ) => {
     if (file.size > MAX_FILE_SIZE_BYTES) {
       // File-level error → inline row; clear any system error for exclusivity.
       setUploadError(null);
       setSizeError(
-        "This file is too large to upload on this deployment. Large uploads require object storage.",
+        reason === "presign-failed"
+          ? // Storage IS configured — the direct upload to it failed. Do NOT
+            // claim the deployment lacks object storage (the misleading message
+            // a real user hit). Operator-facing CORS/connectivity detail is in
+            // the log; the UI stays jargon-free (copywriting.md).
+            "We couldn't upload your file to storage. Please try again, or contact your administrator if the problem persists."
+          : "This file is too large to upload on this deployment. Large uploads require object storage.",
       );
       setIsUploading(false);
       return;

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -611,17 +611,23 @@ export function UploadCSVForm({
     reason: "no-storage" | "presign-failed",
   ) => {
     if (file.size > MAX_FILE_SIZE_BYTES) {
+      // Exhaustive map (not a ternary): widening the `reason` union surfaces a
+      // compile error here instead of silently defaulting to one message.
+      //  - presign-failed: storage IS configured, the direct upload to it
+      //    failed — do NOT claim the deployment lacks object storage (the
+      //    misleading message a real user hit). Operator-facing CORS/
+      //    connectivity detail is in the log; the UI stays jargon-free
+      //    (copywriting.md).
+      //  - no-storage: the deployment genuinely has no object storage.
+      const oversizeMessage: Record<typeof reason, string> = {
+        "presign-failed":
+          "We couldn't upload your file to storage. Please try again, or contact your administrator if the problem persists.",
+        "no-storage":
+          "This file is too large to upload on this deployment. Large uploads require object storage.",
+      };
       // File-level error → inline row; clear any system error for exclusivity.
       setUploadError(null);
-      setSizeError(
-        reason === "presign-failed"
-          ? // Storage IS configured — the direct upload to it failed. Do NOT
-            // claim the deployment lacks object storage (the misleading message
-            // a real user hit). Operator-facing CORS/connectivity detail is in
-            // the log; the UI stays jargon-free (copywriting.md).
-            "We couldn't upload your file to storage. Please try again, or contact your administrator if the problem persists."
-          : "This file is too large to upload on this deployment. Large uploads require object storage.",
-      );
+      setSizeError(oversizeMessage[reason]);
       setIsUploading(false);
       return;
     }

--- a/langwatch/src/components/datasets/__tests__/UploadCSVFallbackGuard.integration.test.tsx
+++ b/langwatch/src/components/datasets/__tests__/UploadCSVFallbackGuard.integration.test.tsx
@@ -224,7 +224,7 @@ describe("UploadCSVForm 409-fallback size guard", () => {
   });
 
   describe("when the presigned PUT fails (CORS/network) and the file exceeds the size limit", () => {
-    it("shows the too-large error and does NOT parse the oversize file", async () => {
+    it("shows a storage-upload-failed error (NOT the misleading 'requires object storage') and does NOT parse the oversize file", async () => {
       requestDirectUpload.mockResolvedValue({
         datasetId: "dataset_pending",
         slug: "s",
@@ -250,11 +250,18 @@ describe("UploadCSVForm 409-fallback size guard", () => {
       await user.upload(input, oversize);
       await user.click(screen.getByRole("button", { name: /upload/i }));
 
+      // Storage IS configured (the PUT failed, not the presign mint), so the
+      // error must NOT claim the deployment lacks object storage — that was the
+      // real bug a 100 MB upload hit. Surface an accurate "couldn't upload"
+      // message instead.
       await waitFor(() => {
         expect(screen.getByTestId("upload-error")).toHaveTextContent(
-          /too large to upload on this deployment/i,
+          /couldn't upload your file to storage/i,
         );
       });
+      expect(screen.getByTestId("upload-error")).not.toHaveTextContent(
+        /requires object storage/i,
+      );
       // The size-guard fires before any in-browser parse of the oversize file.
       expect(textSpy).not.toHaveBeenCalled();
     });

--- a/langwatch/src/server/__tests__/buildStorageConnectSrc.unit.test.ts
+++ b/langwatch/src/server/__tests__/buildStorageConnectSrc.unit.test.ts
@@ -33,13 +33,38 @@ describe("buildStorageConnectSrc", () => {
     });
   });
 
-  describe("when neither endpoint nor region is set", () => {
-    it("falls back to a broad AWS S3 wildcard", () => {
-      expect(buildStorageConnectSrc({})).toEqual(["https://*.amazonaws.com"]);
+  describe("when AWS is in use without endpoint or region (bucket/AWS_REGION only)", () => {
+    it("derives the region from AWS_REGION", () => {
+      expect(buildStorageConnectSrc({ AWS_REGION: "us-west-2" })).toEqual([
+        "https://s3.us-west-2.amazonaws.com",
+        "https://*.s3.us-west-2.amazonaws.com",
+      ]);
+    });
+
+    it("falls back to the broad AWS wildcard when only a bucket name is set", () => {
+      expect(buildStorageConnectSrc({ S3_BUCKET_NAME: "my-bucket" })).toEqual([
+        "https://*.amazonaws.com",
+      ]);
     });
   });
 
-  describe("when Azure blob storage is configured", () => {
+  describe("when no storage env is set at all (local-FS deployment)", () => {
+    it("emits no storage origin — nothing to allow", () => {
+      expect(buildStorageConnectSrc({})).toEqual([]);
+    });
+  });
+
+  describe("when only Azure is configured (no AWS env)", () => {
+    it("emits ONLY the Azure origin — no gratuitous amazonaws wildcard", () => {
+      expect(
+        buildStorageConnectSrc({
+          AZURE_BLOB_ENDPOINT: "https://acct.blob.core.windows.net",
+        }),
+      ).toEqual(["https://acct.blob.core.windows.net"]);
+    });
+  });
+
+  describe("when both S3 and Azure are configured", () => {
     it("adds the Azure endpoint origin alongside the S3 origin", () => {
       expect(
         buildStorageConnectSrc({
@@ -49,6 +74,32 @@ describe("buildStorageConnectSrc", () => {
       ).toEqual([
         "https://s3.eu-central-1.amazonaws.com",
         "https://acct.blob.core.windows.net",
+      ]);
+    });
+  });
+
+  describe("when S3_REGION carries an injected CSP directive (security)", () => {
+    it("rejects the non-region value and falls back to the wildcard rather than injecting", () => {
+      const result = buildStorageConnectSrc({
+        S3_REGION: "us-east-1; frame-src *",
+      });
+      expect(result).toEqual(["https://*.amazonaws.com"]);
+      expect(result.join(" ")).not.toContain(";");
+      expect(result.join(" ")).not.toContain(" frame-src");
+    });
+  });
+
+  describe("when the endpoint is an opaque-origin scheme (file://)", () => {
+    it("rejects it instead of emitting the string 'null' into the CSP", () => {
+      const result = buildStorageConnectSrc({
+        S3_ENDPOINT: "file:///mnt/storage",
+        S3_REGION: "eu-west-1",
+      });
+      expect(result).not.toContain("null");
+      // Falls through to the region-derived AWS origins.
+      expect(result).toEqual([
+        "https://s3.eu-west-1.amazonaws.com",
+        "https://*.s3.eu-west-1.amazonaws.com",
       ]);
     });
   });

--- a/langwatch/src/server/__tests__/buildStorageConnectSrc.unit.test.ts
+++ b/langwatch/src/server/__tests__/buildStorageConnectSrc.unit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildStorageConnectSrc } from "../buildStorageConnectSrc";
+
+describe("buildStorageConnectSrc", () => {
+  describe("when an explicit S3_ENDPOINT is set (prod / R2 / MinIO)", () => {
+    it("returns exactly that endpoint's origin", () => {
+      expect(
+        buildStorageConnectSrc({
+          S3_ENDPOINT:
+            "https://langwatch-storage-prod.s3.eu-central-1.amazonaws.com",
+          S3_REGION: "eu-central-1",
+        }),
+      ).toEqual([
+        "https://langwatch-storage-prod.s3.eu-central-1.amazonaws.com",
+      ]);
+    });
+
+    it("drops any path/query, keeping only the origin", () => {
+      expect(
+        buildStorageConnectSrc({
+          S3_ENDPOINT: "https://s3.example.com/bucket?x=1",
+        }),
+      ).toEqual(["https://s3.example.com"]);
+    });
+  });
+
+  describe("when no endpoint is set but a region is (plain AWS / IRSA)", () => {
+    it("allows both path-style and virtual-hosted AWS forms for the region", () => {
+      expect(buildStorageConnectSrc({ S3_REGION: "us-east-1" })).toEqual([
+        "https://s3.us-east-1.amazonaws.com",
+        "https://*.s3.us-east-1.amazonaws.com",
+      ]);
+    });
+  });
+
+  describe("when neither endpoint nor region is set", () => {
+    it("falls back to a broad AWS S3 wildcard", () => {
+      expect(buildStorageConnectSrc({})).toEqual(["https://*.amazonaws.com"]);
+    });
+  });
+
+  describe("when Azure blob storage is configured", () => {
+    it("adds the Azure endpoint origin alongside the S3 origin", () => {
+      expect(
+        buildStorageConnectSrc({
+          S3_ENDPOINT: "https://s3.eu-central-1.amazonaws.com",
+          AZURE_BLOB_ENDPOINT: "https://acct.blob.core.windows.net",
+        }),
+      ).toEqual([
+        "https://s3.eu-central-1.amazonaws.com",
+        "https://acct.blob.core.windows.net",
+      ]);
+    });
+  });
+
+  describe("when the endpoint is malformed", () => {
+    it("ignores it and falls back rather than throwing", () => {
+      expect(
+        buildStorageConnectSrc({
+          S3_ENDPOINT: "not a url",
+          S3_REGION: "eu-west-1",
+        }),
+      ).toEqual([
+        "https://s3.eu-west-1.amazonaws.com",
+        "https://*.s3.eu-west-1.amazonaws.com",
+      ]);
+    });
+  });
+});

--- a/langwatch/src/server/buildStorageConnectSrc.ts
+++ b/langwatch/src/server/buildStorageConnectSrc.ts
@@ -10,23 +10,41 @@
  * The allowed origin(s) are derived from the SAME env the S3 client
  * (`createS3Client`) uses, so the CSP always tracks the configured
  * bucket/region/endpoint instead of drifting from a hardcoded list.
+ *
+ * SECURITY: every value here is interpolated into a security header, so it is
+ * validated/sanitised before emission — an env value containing `;`, whitespace,
+ * or an opaque origin must never inject extra CSP directives or source tokens.
  */
 
 type StorageEnv = {
   S3_ENDPOINT?: string;
   S3_REGION?: string;
+  S3_BUCKET_NAME?: string;
+  AWS_REGION?: string;
   AZURE_BLOB_ENDPOINT?: string;
 };
 
+/**
+ * Resolve a URL to its origin, or null if unusable. `new URL("file:///x")` (and
+ * other opaque-origin schemes) does NOT throw — it returns the *string* `"null"`,
+ * which if emitted into `connect-src` becomes an unquoted `null` source that
+ * matches null-origin documents (sandboxed iframes, `data:` URIs) and silently
+ * weakens the policy. Reject it explicitly.
+ */
 const safeOrigin = (url: string | undefined): string | null => {
   if (!url) return null;
   try {
-    return new URL(url).origin;
+    const origin = new URL(url).origin;
+    return origin === "null" ? null : origin;
   } catch {
     // A malformed endpoint must never break header construction.
     return null;
   }
 };
+
+/** AWS region tokens are `[a-z0-9-]` only — anything else can't be a real region
+ * and, interpolated into the header, would inject CSP directives/tokens. */
+const AWS_REGION_RE = /^[a-z0-9-]+$/;
 
 /**
  * The object-storage origins to add to the CSP `connect-src` directive.
@@ -34,10 +52,12 @@ const safeOrigin = (url: string | undefined): string | null => {
  * - An explicit `S3_ENDPOINT` (R2 / MinIO / custom, or the bucket-scoped AWS
  *   endpoint prod uses) — the presigned URL's origin is exactly this, and the
  *   S3 client runs `forcePathStyle`, so the host never gets a bucket subdomain.
- * - No endpoint (plain AWS, e.g. IRSA): the SDK targets
- *   `s3.<region>.amazonaws.com` (path-style) or `<bucket>.s3.<region>…`
- *   (virtual-hosted), so allow both forms for the configured region; fall back
- *   to a broad AWS S3 wildcard only when even the region is unknown.
+ * - No endpoint but AWS is in use (region / bucket / `AWS_REGION` set, e.g.
+ *   IRSA): the SDK targets `s3.<region>.amazonaws.com` (path-style) or
+ *   `<bucket>.s3.<region>…` (virtual-hosted), so allow both forms for the
+ *   validated region; fall back to a broad AWS S3 wildcard only when the region
+ *   is unknown/invalid. The AWS branch is gated on an AWS signal so a pure-Azure
+ *   or local-FS deployment never gets a gratuitous `amazonaws.com` source.
  * - `AZURE_BLOB_ENDPOINT` for the Azure alternative.
  *
  * BYOC per-org endpoints are intentionally NOT covered here — a static CSP
@@ -50,9 +70,16 @@ export const buildStorageConnectSrc = (env: StorageEnv): string[] => {
   const endpointOrigin = safeOrigin(env.S3_ENDPOINT);
   if (endpointOrigin) {
     origins.add(endpointOrigin);
-  } else {
-    const region = env.S3_REGION?.trim();
-    if (region) {
+  } else if (
+    env.S3_ENDPOINT ||
+    env.S3_REGION ||
+    env.S3_BUCKET_NAME ||
+    env.AWS_REGION
+  ) {
+    // AWS S3 is plausibly the backend (some AWS/S3 env present) but no usable
+    // explicit endpoint — emit the AWS origin(s) for the configured region.
+    const region = (env.S3_REGION ?? env.AWS_REGION)?.trim();
+    if (region && AWS_REGION_RE.test(region)) {
       origins.add(`https://s3.${region}.amazonaws.com`);
       origins.add(`https://*.s3.${region}.amazonaws.com`);
     } else {

--- a/langwatch/src/server/buildStorageConnectSrc.ts
+++ b/langwatch/src/server/buildStorageConnectSrc.ts
@@ -1,0 +1,67 @@
+/**
+ * ADR-032 R3: the browser uploads a dataset file straight to object storage via
+ * a presigned PUT. In production the app sends a Content-Security-Policy, and
+ * its `connect-src` directive must allow the storage origin — otherwise the
+ * browser refuses the `fetch` BEFORE it leaves the page. That surfaces as an
+ * opaque `TypeError` (looks like a CORS failure, but the bucket CORS is fine),
+ * the drawer falls back to the in-browser parse path, and large uploads dead-end
+ * with the misleading "requires object storage" error.
+ *
+ * The allowed origin(s) are derived from the SAME env the S3 client
+ * (`createS3Client`) uses, so the CSP always tracks the configured
+ * bucket/region/endpoint instead of drifting from a hardcoded list.
+ */
+
+type StorageEnv = {
+  S3_ENDPOINT?: string;
+  S3_REGION?: string;
+  AZURE_BLOB_ENDPOINT?: string;
+};
+
+const safeOrigin = (url: string | undefined): string | null => {
+  if (!url) return null;
+  try {
+    return new URL(url).origin;
+  } catch {
+    // A malformed endpoint must never break header construction.
+    return null;
+  }
+};
+
+/**
+ * The object-storage origins to add to the CSP `connect-src` directive.
+ *
+ * - An explicit `S3_ENDPOINT` (R2 / MinIO / custom, or the bucket-scoped AWS
+ *   endpoint prod uses) — the presigned URL's origin is exactly this, and the
+ *   S3 client runs `forcePathStyle`, so the host never gets a bucket subdomain.
+ * - No endpoint (plain AWS, e.g. IRSA): the SDK targets
+ *   `s3.<region>.amazonaws.com` (path-style) or `<bucket>.s3.<region>…`
+ *   (virtual-hosted), so allow both forms for the configured region; fall back
+ *   to a broad AWS S3 wildcard only when even the region is unknown.
+ * - `AZURE_BLOB_ENDPOINT` for the Azure alternative.
+ *
+ * BYOC per-org endpoints are intentionally NOT covered here — a static CSP
+ * can't enumerate dynamic per-tenant buckets; that ships with the deferred
+ * per-org upload route.
+ */
+export const buildStorageConnectSrc = (env: StorageEnv): string[] => {
+  const origins = new Set<string>();
+
+  const endpointOrigin = safeOrigin(env.S3_ENDPOINT);
+  if (endpointOrigin) {
+    origins.add(endpointOrigin);
+  } else {
+    const region = env.S3_REGION?.trim();
+    if (region) {
+      origins.add(`https://s3.${region}.amazonaws.com`);
+      origins.add(`https://*.s3.${region}.amazonaws.com`);
+    } else {
+      origins.add("https://*.amazonaws.com");
+    }
+  }
+
+  const azureOrigin = safeOrigin(env.AZURE_BLOB_ENDPOINT);
+  if (azureOrigin) origins.add(azureOrigin);
+
+  return [...origins];
+};

--- a/langwatch/src/server/datasets/__tests__/dataset-service.upload.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-service.upload.unit.test.ts
@@ -111,7 +111,7 @@ describe("DatasetService", () => {
     });
 
     describe("when abandoned pending uploads linger (poll-triggered reap)", () => {
-      it("archives stale uploading rows and deletes their staging objects before minting", async () => {
+      it("hard-deletes stale uploading rows and their staging objects before minting", async () => {
         const deleteStaged = vi.fn().mockResolvedValue(undefined);
         vi.mocked(getDatasetStorage).mockResolvedValue({
           deleteStaged,
@@ -133,7 +133,7 @@ describe("DatasetService", () => {
           findStalePendingUploads: vi.fn().mockResolvedValue([stale]),
           findBySlug: vi.fn().mockResolvedValue(null),
           create: vi.fn().mockResolvedValue({ id: "dataset_new", slug: "ds" }),
-          update: vi.fn().mockResolvedValue({}),
+          deletePendingUpload: vi.fn().mockResolvedValue(1),
         };
 
         await makeService(repo).createPendingUpload({
@@ -142,18 +142,16 @@ describe("DatasetService", () => {
           filename: "data.jsonl",
         });
 
-        // the abandoned row's staging object is deleted and the row archived...
+        // the abandoned row's staging object is deleted and the content-less
+        // placeholder row hard-deleted (not archived — no ghost left behind)...
         expect(deleteStaged).toHaveBeenCalledWith({
           projectId: "p1",
           key: "staging/p1/old",
         });
-        expect(repo.update).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: "dataset_stale",
-            projectId: "p1",
-            data: expect.objectContaining({ archivedAt: expect.any(Date) }),
-          }),
-        );
+        expect(repo.deletePendingUpload).toHaveBeenCalledWith({
+          id: "dataset_stale",
+          projectId: "p1",
+        });
         // ...and the new upload still proceeds
         expect(repo.create).toHaveBeenCalled();
       });
@@ -341,7 +339,7 @@ describe("DatasetService", () => {
 
   describe("abortPendingUpload()", () => {
     describe("when aborting a still-pending upload", () => {
-      it("deletes the staged object and archives the uploading row", async () => {
+      it("deletes the staged object and hard-deletes the uploading row", async () => {
         const deleteStaged = vi.fn().mockResolvedValue(undefined);
         vi.mocked(getDatasetStorage).mockResolvedValue({ deleteStaged } as any);
         const repo = {
@@ -353,7 +351,7 @@ describe("DatasetService", () => {
             stagingKey: "staging/p1/u1",
             archivedAt: null,
           }),
-          update: vi.fn().mockResolvedValue({}),
+          deletePendingUpload: vi.fn().mockResolvedValue(1),
         };
 
         const result = await makeService(repo).abortPendingUpload({
@@ -366,14 +364,12 @@ describe("DatasetService", () => {
           projectId: "p1",
           key: "staging/p1/u1",
         });
-        // Archived (soft-deleted), not hard-deleted.
-        expect(repo.update).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: "dataset_x",
-            projectId: "p1",
-            data: expect.objectContaining({ archivedAt: expect.any(Date) }),
-          }),
-        );
+        // A content-less placeholder is discarded, not soft-archived — no ghost
+        // row (the "double rows in PG") left behind.
+        expect(repo.deletePendingUpload).toHaveBeenCalledWith({
+          id: "dataset_x",
+          projectId: "p1",
+        });
       });
     });
 
@@ -389,7 +385,7 @@ describe("DatasetService", () => {
             status: "ready",
             archivedAt: null,
           }),
-          update: vi.fn(),
+          deletePendingUpload: vi.fn(),
         };
 
         await expect(
@@ -398,7 +394,7 @@ describe("DatasetService", () => {
             datasetId: "dataset_x",
           }),
         ).rejects.toThrow(/not pending/i);
-        expect(repo.update).not.toHaveBeenCalled();
+        expect(repo.deletePendingUpload).not.toHaveBeenCalled();
       });
     });
 
@@ -406,7 +402,7 @@ describe("DatasetService", () => {
       it("rejects with DatasetNotFoundError", async () => {
         const repo = {
           findOne: vi.fn().mockResolvedValue(null),
-          update: vi.fn(),
+          deletePendingUpload: vi.fn(),
         };
 
         await expect(
@@ -415,7 +411,7 @@ describe("DatasetService", () => {
             datasetId: "missing",
           }),
         ).rejects.toThrow();
-        expect(repo.update).not.toHaveBeenCalled();
+        expect(repo.deletePendingUpload).not.toHaveBeenCalled();
       });
     });
   });

--- a/langwatch/src/server/datasets/__tests__/dataset.repository.integration.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset.repository.integration.test.ts
@@ -1,0 +1,119 @@
+import type { Organization, Project, Team } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { projectFactory } from "~/factories/project.factory";
+import { prisma } from "~/server/db";
+import { DatasetRepository } from "../dataset.repository";
+
+/**
+ * Integration coverage for `DatasetRepository.deletePendingUpload` against a
+ * real Postgres. This is the FIRST hard-delete of a `Dataset` in the codebase
+ * (every other removal soft-archives), so the unit/service tests — which mock
+ * the repo — can't prove the actual `deleteMany` succeeds under
+ * `relationMode="prisma"` (where `DatasetRecord`/`BatchEvaluation` default to
+ * `onDelete: Restrict`). These exercise the real Prisma path: a childless
+ * placeholder deletes cleanly, the `status='uploading'` guard protects a row a
+ * finalize raced to `processing`, and the predicate is tenancy-scoped.
+ */
+describe("DatasetRepository.deletePendingUpload (integration)", () => {
+  let repository: DatasetRepository;
+  let organization: Organization;
+  let team: Team;
+  let project: Project;
+
+  beforeEach(async () => {
+    repository = new DatasetRepository(prisma);
+    organization = await prisma.organization.create({
+      data: { name: "Test Org", slug: `test-org-${nanoid()}` },
+    });
+    team = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `test-team-${nanoid()}`,
+        organizationId: organization.id,
+      },
+    });
+    project = await prisma.project.create({
+      data: {
+        ...projectFactory.build({ slug: nanoid() }),
+        teamId: team.id,
+        personalFeatures: {},
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.dataset.deleteMany({ where: { projectId: project.id } });
+    await prisma.project.delete({ where: { id: project.id } });
+    await prisma.team.delete({ where: { id: team.id } });
+    await prisma.organization.delete({ where: { id: organization.id } });
+  });
+
+  const createUploadingRow = (status: string) =>
+    prisma.dataset.create({
+      data: {
+        id: `dataset_${nanoid()}`,
+        name: "Pending Upload",
+        slug: `pending-${nanoid()}`,
+        projectId: project.id,
+        columnTypes: [],
+        contentLayout: "s3_jsonl",
+        status,
+        stagingKey: `staging/${project.id}/${nanoid()}`,
+      },
+    });
+
+  describe("given a content-less uploading placeholder", () => {
+    describe("when deleting it", () => {
+      it("removes the row and returns count 1", async () => {
+        const row = await createUploadingRow("uploading");
+
+        const count = await repository.deletePendingUpload({
+          id: row.id,
+          projectId: project.id,
+        });
+
+        expect(count).toBe(1);
+        expect(
+          await prisma.dataset.findFirst({ where: { id: row.id } }),
+        ).toBeNull();
+      });
+    });
+  });
+
+  describe("given a row a finalize raced to 'processing'", () => {
+    describe("when deleting it", () => {
+      it("is a no-op (count 0) and leaves the now-live dataset intact", async () => {
+        const row = await createUploadingRow("processing");
+
+        const count = await repository.deletePendingUpload({
+          id: row.id,
+          projectId: project.id,
+        });
+
+        expect(count).toBe(0);
+        expect(
+          await prisma.dataset.findFirst({ where: { id: row.id } }),
+        ).not.toBeNull();
+      });
+    });
+  });
+
+  describe("given a pending row in another project", () => {
+    describe("when deleting with a mismatched projectId", () => {
+      it("does not cross the tenancy boundary", async () => {
+        const row = await createUploadingRow("uploading");
+
+        const count = await repository.deletePendingUpload({
+          id: row.id,
+          projectId: `project_${nanoid()}`,
+        });
+
+        expect(count).toBe(0);
+        expect(
+          await prisma.dataset.findFirst({ where: { id: row.id } }),
+        ).not.toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/datasets/__tests__/dataset.repository.integration.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset.repository.integration.test.ts
@@ -75,7 +75,9 @@ describe("DatasetRepository.deletePendingUpload (integration)", () => {
 
         expect(count).toBe(1);
         expect(
-          await prisma.dataset.findFirst({ where: { id: row.id } }),
+          await prisma.dataset.findFirst({
+            where: { id: row.id, projectId: project.id },
+          }),
         ).toBeNull();
       });
     });
@@ -93,7 +95,9 @@ describe("DatasetRepository.deletePendingUpload (integration)", () => {
 
         expect(count).toBe(0);
         expect(
-          await prisma.dataset.findFirst({ where: { id: row.id } }),
+          await prisma.dataset.findFirst({
+            where: { id: row.id, projectId: project.id },
+          }),
         ).not.toBeNull();
       });
     });
@@ -111,7 +115,9 @@ describe("DatasetRepository.deletePendingUpload (integration)", () => {
 
         expect(count).toBe(0);
         expect(
-          await prisma.dataset.findFirst({ where: { id: row.id } }),
+          await prisma.dataset.findFirst({
+            where: { id: row.id, projectId: project.id },
+          }),
         ).not.toBeNull();
       });
     });

--- a/langwatch/src/server/datasets/__tests__/dataset.repository.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset.repository.test.ts
@@ -50,12 +50,7 @@ describe("DatasetRepository", () => {
     it.todo("returns all slugs for project");
   });
 
-  describe("deletePendingUpload", () => {
-    // Status-guarded hard delete of a content-less upload placeholder.
-    it.todo("deletes the row while status='uploading' and returns count 1");
-    it.todo(
-      "is a no-op (count 0) when a finalize raced it to 'processing' — never destroys a now-live dataset",
-    );
-    it.todo("scopes deletion to id + projectId (tenancy guard)");
-  });
+  // deletePendingUpload's real-PG behavior (status guard, tenancy scope, and
+  // that the first-ever Dataset hard-delete succeeds under relationMode="prisma")
+  // is covered in dataset.repository.integration.test.ts.
 });

--- a/langwatch/src/server/datasets/__tests__/dataset.repository.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset.repository.test.ts
@@ -49,4 +49,13 @@ describe("DatasetRepository", () => {
   describe("findAllSlugs", () => {
     it.todo("returns all slugs for project");
   });
+
+  describe("deletePendingUpload", () => {
+    // Status-guarded hard delete of a content-less upload placeholder.
+    it.todo("deletes the row while status='uploading' and returns count 1");
+    it.todo(
+      "is a no-op (count 0) when a finalize raced it to 'processing' — never destroys a now-live dataset",
+    );
+    it.todo("scopes deletion to id + projectId (tenancy guard)");
+  });
 });

--- a/langwatch/src/server/datasets/dataset.repository.ts
+++ b/langwatch/src/server/datasets/dataset.repository.ts
@@ -144,6 +144,37 @@ export class DatasetRepository {
   }
 
   /**
+   * Hard-delete a still-pending upload row. Guarded on `status='uploading'`
+   * (a `deleteMany`, not `delete`) so a finalize that raced in between the
+   * caller's status check and this call — flipping the row to `processing` — is
+   * never destroyed: the predicate then matches 0 rows and the now-live dataset
+   * survives. A pending upload never held content (no records, no committed
+   * chunks), so it is detritus to discard, not a dataset to archive; deleting it
+   * frees the slug naturally and leaves no content-less ghost behind. The
+   * id+projectId predicate is the tenancy guard. Returns the count deleted
+   * (0 = already reaped, or no longer pending).
+   */
+  async deletePendingUpload(
+    input: {
+      id: string;
+      projectId: string;
+    },
+    options?: {
+      tx?: Prisma.TransactionClient;
+    },
+  ): Promise<number> {
+    const client = options?.tx ?? this.prisma;
+    const { count } = await client.dataset.deleteMany({
+      where: {
+        id: input.id,
+        projectId: input.projectId,
+        status: "uploading",
+      },
+    });
+    return count;
+  }
+
+  /**
    * Conditionally flip a dataset to `failed` ONLY while it is still
    * `processing`. The normalize enqueue catch uses this: when the enqueue
    * rejects synchronously no job is in flight, so the row's `processing` is a

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -1336,11 +1336,19 @@ export class DatasetService {
 
   /**
    * Reap one pending (`uploading`, non-archived) upload row: best-effort delete
-   * its staged object, then archive the row (rename the slug + set `archivedAt`)
-   * so it stops pinning its slug/quota. The staged-object delete is non-fatal —
-   * the S3 staging lifecycle rule (IaC) reaps it otherwise; a failed delete must
-   * never block the archive. Shared by the explicit abort (`abortPendingUpload`)
-   * and the poll-triggered sweep (`reapStalePendingUploads`). The caller owns the
+   * its staged object, then HARD-DELETE the row. A pending upload never received
+   * content — the browser PUT failed/was abandoned, or finalize never ran — so
+   * there is nothing to retain. Earlier this *archived* the row (rename slug +
+   * `archivedAt`), which left a content-less ghost per failed direct upload: in a
+   * bucket-CORS outage the drawer silently falls back for small files yet still
+   * mints+orphans a row each time, so they accumulated unbounded (the "double
+   * rows in PG" — the archived placeholder alongside the fallback's real
+   * dataset). Deleting frees the slug naturally and leaves nothing behind; the
+   * repo guards the delete on `status='uploading'` so a finalize racing this call
+   * is never destroyed. The staged-object delete is non-fatal — the S3 staging
+   * lifecycle rule (IaC) reaps it otherwise; a failed delete must never block the
+   * row delete. Shared by the explicit abort (`abortPendingUpload`) and the
+   * poll-triggered sweep (`reapStalePendingUploads`). The caller owns the
    * `status='uploading'` guard.
    */
   private async reapPendingUpload(dataset: Dataset): Promise<void> {
@@ -1354,15 +1362,7 @@ export class DatasetService {
       }
     }
 
-    const slug = this.generateSlug(dataset.name);
-    await this.repository.update({
-      id: datasetId,
-      projectId,
-      data: {
-        slug: `${slug}-archived-${nanoid()}`,
-        archivedAt: new Date(),
-      },
-    });
+    await this.repository.deletePendingUpload({ id: datasetId, projectId });
   }
 
   /**

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -1329,7 +1329,19 @@ export class DatasetService {
       throw new UploadNotPendingError();
     }
 
-    await this.reapPendingUpload(dataset);
+    const deleted = await this.reapPendingUpload(dataset);
+    if (deleted === 0) {
+      // TOCTOU: a finalize raced between the `status==='uploading'` read above
+      // and the status-guarded delete, flipping the row to `processing`. The
+      // status guard correctly spared the now-live dataset, so we do NOT throw
+      // (the user's cancel simply lost the race) — but log it so this rare
+      // false-"aborted" (the UI thinks it cancelled while the dataset finishes
+      // processing) is observable instead of silent.
+      logger.warn(
+        { projectId, datasetId },
+        "abortPendingUpload deleted no row — a finalize likely won the race; dataset is no longer pending",
+      );
+    }
 
     return { datasetId, aborted: true };
   }
@@ -1351,7 +1363,7 @@ export class DatasetService {
    * poll-triggered sweep (`reapStalePendingUploads`). The caller owns the
    * `status='uploading'` guard.
    */
-  private async reapPendingUpload(dataset: Dataset): Promise<void> {
+  private async reapPendingUpload(dataset: Dataset): Promise<number> {
     const { id: datasetId, projectId } = dataset;
     if (dataset.stagingKey) {
       try {
@@ -1362,7 +1374,12 @@ export class DatasetService {
       }
     }
 
-    await this.repository.deletePendingUpload({ id: datasetId, projectId });
+    // Returns the rows deleted (0 = a finalize raced and the status guard
+    // spared the now-live row); the explicit-abort caller logs that case.
+    return await this.repository.deletePendingUpload({
+      id: datasetId,
+      projectId,
+    });
   }
 
   /**

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import promBundle from "express-prom-bundle";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
 import { createSecureServer } from "http2";
 import path from "path";
@@ -37,45 +37,42 @@ async function loadDevHttpsCredentials(
   }
 
   const { generate } = await import("selfsigned");
-  const pems = generate(
-    [{ name: "commonName", value: "localhost" }],
-    {
-      days: 825, // Apple's max accepted lifetime for trusted certs.
-      keySize: 2048,
-      extensions: [
-        {
-          name: "subjectAltName",
-          altNames: [
-            { type: 2, value: "localhost" },
-            { type: 2, value: "*.localhost" },
-            { type: 7, ip: "127.0.0.1" },
-            { type: 7, ip: "::1" },
-          ],
-        },
-      ],
-    },
-  );
+  const pems = generate([{ name: "commonName", value: "localhost" }], {
+    days: 825, // Apple's max accepted lifetime for trusted certs.
+    keySize: 2048,
+    extensions: [
+      {
+        name: "subjectAltName",
+        altNames: [
+          { type: 2, value: "localhost" },
+          { type: 2, value: "*.localhost" },
+          { type: 7, ip: "127.0.0.1" },
+          { type: 7, ip: "::1" },
+        ],
+      },
+    ],
+  });
 
   mkdirSync(cacheDir, { recursive: true });
   writeFileSync(certPath, pems.cert);
   writeFileSync(keyPath, pems.private);
   return { cert: Buffer.from(pems.cert), key: Buffer.from(pems.private) };
 }
-import { register } from "prom-client";
-import { buildStorageConnectSrc } from "./server/buildStorageConnectSrc";
-import { getApp } from "./server/app-layer/app";
-import { initializeWebApp } from "./server/app-layer/presets";
-import { getWorkerMetricsPort } from "./server/background/config";
-import { createMcpHandler } from "./mcp/handler";
-import { shutdownPostHog } from "./server/posthog";
-import { verifyRedisReady } from "./server/redis";
-import { createLogger } from "./utils/logger/server";
 
 // Hono — unified API router
 import type { Hono } from "hono";
+import { register } from "prom-client";
+import { createMcpHandler } from "./mcp/handler";
 import { createApiRouter } from "./server/api-router";
+import { getApp } from "./server/app-layer/app";
+import { initializeWebApp } from "./server/app-layer/presets";
+import { getWorkerMetricsPort } from "./server/background/config";
+import { buildStorageConnectSrc } from "./server/buildStorageConnectSrc";
+import { shutdownPostHog } from "./server/posthog";
+import { verifyRedisReady } from "./server/redis";
 import { serveStaticOrFallback } from "./server/static-handler";
 import { setupTRPCWebSocket } from "./server/websockets/trpc-ws";
+import { createLogger } from "./utils/logger/server";
 
 const logger = createLogger("langwatch:start");
 
@@ -174,7 +171,13 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
     // ADR-032: allow the browser's presigned PUT to object storage (derived
     // from the same env the S3 client uses) — without it the CSP blocks the
     // upload before it leaves the page and the drawer silently falls back.
-    `connect-src 'self' ${buildStorageConnectSrc(process.env).join(" ")} https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev`,
+    `connect-src 'self' ${buildStorageConnectSrc({
+      S3_ENDPOINT: process.env.S3_ENDPOINT,
+      S3_REGION: process.env.S3_REGION,
+      AZURE_BLOB_ENDPOINT: process.env.AZURE_BLOB_ENDPOINT,
+    }).join(
+      " ",
+    )} https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev`,
     "frame-src 'self' https://*.posthog.com https://*.pendo.io https://www.youtube.com https://get.langwatch.ai https://*.googletagmanager.com https://www.google.com https://*.reo.dev",
   ].join("; ");
 
@@ -183,7 +186,9 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
     "X-Content-Type-Options": "nosniff",
     // CSP only in production — dev needs inline scripts for Vite HMR
     ...(!dev ? { "Content-Security-Policy": cspHeader } : {}),
-    ...(!dev ? { "Strict-Transport-Security": "max-age=31536000; includeSubDomains" } : {}),
+    ...(!dev
+      ? { "Strict-Transport-Security": "max-age=31536000; includeSubDomains" }
+      : {}),
   };
 
   // Optional HTTPS + HTTP/2 path for local dev. Set
@@ -203,7 +208,10 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
     try {
       // Collapse runs of slashes so paths like `//authorize` resolve to `/authorize`
       // instead of failing the absolute-path guard on the SPA fallback below.
-      const pathname = ((req.url ?? "/").split("?")[0] ?? "/").replace(/\/{2,}/g, "/");
+      const pathname = ((req.url ?? "/").split("?")[0] ?? "/").replace(
+        /\/{2,}/g,
+        "/",
+      );
 
       // Apply security headers to all responses
       for (const [key, value] of Object.entries(securityHeaders)) {
@@ -228,7 +236,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
           res.end(await register.metrics());
         } else {
           const workersMetricsRes = await fetch(
-            `http://0.0.0.0:${getWorkerMetricsPort()}/metrics`
+            `http://0.0.0.0:${getWorkerMetricsPort()}/metrics`,
           );
           res.setHeader("Content-Type", register.contentType);
           res.end(await workersMetricsRes.text());
@@ -243,7 +251,13 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
 
       // ---- API Routes (all go through Hono) ----
       if (pathname.startsWith("/api/")) {
-        const handled = await routeThroughHono(honoApp, req, res, hostname, port);
+        const handled = await routeThroughHono(
+          honoApp,
+          req,
+          res,
+          hostname,
+          port,
+        );
         if (handled) return;
 
         res.statusCode = 404;
@@ -261,13 +275,18 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
       res.statusCode = 404;
       res.end("Not Found");
     } catch (err) {
-      logger.error({ url: req.url, error: err }, "error occurred handling request");
+      logger.error(
+        { url: req.url, error: err },
+        "error occurred handling request",
+      );
       res.statusCode = 500;
       res.end("internal server error");
     }
   };
 
-  let server: ReturnType<typeof createServer> | ReturnType<typeof createSecureServer>;
+  let server:
+    | ReturnType<typeof createServer>
+    | ReturnType<typeof createSecureServer>;
   if (useHttp2) {
     const { cert, key } = await loadDevHttpsCredentials(dir);
     // Node's http2 compat-API hands us the same IncomingMessage /
@@ -287,7 +306,9 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
   // Bind the tRPC router to a WebSocket transport on the same HTTP server.
   // Lets high-frequency procedures (presence cursor today) escape the
   // browser's 6-connection HTTP cap by riding a single long-lived socket.
-  const wsHandle = setupTRPCWebSocket(server as ReturnType<typeof createServer>);
+  const wsHandle = setupTRPCWebSocket(
+    server as ReturnType<typeof createServer>,
+  );
 
   server.once("error", (err) => {
     logger.error({ error: err }, "error occurred on server");
@@ -315,7 +336,9 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
         hostname,
         port,
         fullUrl: `${useHttp2 ? "https" : "http"}://${hostname === "0.0.0.0" ? "localhost" : hostname}:${port}`,
-        mode: dev ? `development (API only — Vite on :${basePort})` : "production",
+        mode: dev
+          ? `development (API only — Vite on :${basePort})`
+          : "production",
       },
       "langwatch listening",
     );
@@ -360,7 +383,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
   process.on("unhandledRejection", (reason, promise) => {
     logger.fatal(
       { reason: reason instanceof Error ? reason : { value: reason }, promise },
-      "unhandled rejection detected"
+      "unhandled rejection detected",
     );
   });
 };
@@ -370,7 +393,7 @@ async function routeThroughHono(
   req: IncomingMessage,
   res: ServerResponse,
   hostname: string,
-  port: number
+  port: number,
 ): Promise<boolean> {
   const body =
     req.method !== "GET" && req.method !== "HEAD"

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -62,6 +62,7 @@ async function loadDevHttpsCredentials(
   return { cert: Buffer.from(pems.cert), key: Buffer.from(pems.private) };
 }
 import { register } from "prom-client";
+import { buildStorageConnectSrc } from "./server/buildStorageConnectSrc";
 import { getApp } from "./server/app-layer/app";
 import { initializeWebApp } from "./server/app-layer/presets";
 import { getWorkerMetricsPort } from "./server/background/config";
@@ -170,7 +171,10 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
     "frame-ancestors 'none'",
     ...(!dev ? ["upgrade-insecure-requests"] : []),
     "worker-src 'self' blob:",
-    "connect-src 'self' https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev",
+    // ADR-032: allow the browser's presigned PUT to object storage (derived
+    // from the same env the S3 client uses) — without it the CSP blocks the
+    // upload before it leaves the page and the drawer silently falls back.
+    `connect-src 'self' ${buildStorageConnectSrc(process.env).join(" ")} https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev`,
     "frame-src 'self' https://*.posthog.com https://*.pendo.io https://www.youtube.com https://get.langwatch.ai https://*.googletagmanager.com https://www.google.com https://*.reo.dev",
   ].join("; ");
 

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -37,21 +37,24 @@ async function loadDevHttpsCredentials(
   }
 
   const { generate } = await import("selfsigned");
-  const pems = generate([{ name: "commonName", value: "localhost" }], {
-    days: 825, // Apple's max accepted lifetime for trusted certs.
-    keySize: 2048,
-    extensions: [
-      {
-        name: "subjectAltName",
-        altNames: [
-          { type: 2, value: "localhost" },
-          { type: 2, value: "*.localhost" },
-          { type: 7, ip: "127.0.0.1" },
-          { type: 7, ip: "::1" },
-        ],
-      },
-    ],
-  });
+  const pems = generate(
+    [{ name: "commonName", value: "localhost" }],
+    {
+      days: 825, // Apple's max accepted lifetime for trusted certs.
+      keySize: 2048,
+      extensions: [
+        {
+          name: "subjectAltName",
+          altNames: [
+            { type: 2, value: "localhost" },
+            { type: 2, value: "*.localhost" },
+            { type: 7, ip: "127.0.0.1" },
+            { type: 7, ip: "::1" },
+          ],
+        },
+      ],
+    },
+  );
 
   mkdirSync(cacheDir, { recursive: true });
   writeFileSync(certPath, pems.cert);
@@ -186,9 +189,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
     "X-Content-Type-Options": "nosniff",
     // CSP only in production — dev needs inline scripts for Vite HMR
     ...(!dev ? { "Content-Security-Policy": cspHeader } : {}),
-    ...(!dev
-      ? { "Strict-Transport-Security": "max-age=31536000; includeSubDomains" }
-      : {}),
+    ...(!dev ? { "Strict-Transport-Security": "max-age=31536000; includeSubDomains" } : {}),
   };
 
   // Optional HTTPS + HTTP/2 path for local dev. Set
@@ -208,10 +209,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
     try {
       // Collapse runs of slashes so paths like `//authorize` resolve to `/authorize`
       // instead of failing the absolute-path guard on the SPA fallback below.
-      const pathname = ((req.url ?? "/").split("?")[0] ?? "/").replace(
-        /\/{2,}/g,
-        "/",
-      );
+      const pathname = ((req.url ?? "/").split("?")[0] ?? "/").replace(/\/{2,}/g, "/");
 
       // Apply security headers to all responses
       for (const [key, value] of Object.entries(securityHeaders)) {
@@ -236,7 +234,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
           res.end(await register.metrics());
         } else {
           const workersMetricsRes = await fetch(
-            `http://0.0.0.0:${getWorkerMetricsPort()}/metrics`,
+            `http://0.0.0.0:${getWorkerMetricsPort()}/metrics`
           );
           res.setHeader("Content-Type", register.contentType);
           res.end(await workersMetricsRes.text());
@@ -251,13 +249,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
 
       // ---- API Routes (all go through Hono) ----
       if (pathname.startsWith("/api/")) {
-        const handled = await routeThroughHono(
-          honoApp,
-          req,
-          res,
-          hostname,
-          port,
-        );
+        const handled = await routeThroughHono(honoApp, req, res, hostname, port);
         if (handled) return;
 
         res.statusCode = 404;
@@ -275,18 +267,13 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
       res.statusCode = 404;
       res.end("Not Found");
     } catch (err) {
-      logger.error(
-        { url: req.url, error: err },
-        "error occurred handling request",
-      );
+      logger.error({ url: req.url, error: err }, "error occurred handling request");
       res.statusCode = 500;
       res.end("internal server error");
     }
   };
 
-  let server:
-    | ReturnType<typeof createServer>
-    | ReturnType<typeof createSecureServer>;
+  let server: ReturnType<typeof createServer> | ReturnType<typeof createSecureServer>;
   if (useHttp2) {
     const { cert, key } = await loadDevHttpsCredentials(dir);
     // Node's http2 compat-API hands us the same IncomingMessage /
@@ -306,9 +293,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
   // Bind the tRPC router to a WebSocket transport on the same HTTP server.
   // Lets high-frequency procedures (presence cursor today) escape the
   // browser's 6-connection HTTP cap by riding a single long-lived socket.
-  const wsHandle = setupTRPCWebSocket(
-    server as ReturnType<typeof createServer>,
-  );
+  const wsHandle = setupTRPCWebSocket(server as ReturnType<typeof createServer>);
 
   server.once("error", (err) => {
     logger.error({ error: err }, "error occurred on server");
@@ -336,9 +321,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
         hostname,
         port,
         fullUrl: `${useHttp2 ? "https" : "http"}://${hostname === "0.0.0.0" ? "localhost" : hostname}:${port}`,
-        mode: dev
-          ? `development (API only — Vite on :${basePort})`
-          : "production",
+        mode: dev ? `development (API only — Vite on :${basePort})` : "production",
       },
       "langwatch listening",
     );
@@ -383,7 +366,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
   process.on("unhandledRejection", (reason, promise) => {
     logger.fatal(
       { reason: reason instanceof Error ? reason : { value: reason }, promise },
-      "unhandled rejection detected",
+      "unhandled rejection detected"
     );
   });
 };
@@ -393,7 +376,7 @@ async function routeThroughHono(
   req: IncomingMessage,
   res: ServerResponse,
   hostname: string,
-  port: number,
+  port: number
 ): Promise<boolean> {
   const body =
     req.method !== "GET" && req.method !== "HEAD"

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -177,6 +177,8 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
     `connect-src 'self' ${buildStorageConnectSrc({
       S3_ENDPOINT: process.env.S3_ENDPOINT,
       S3_REGION: process.env.S3_REGION,
+      S3_BUCKET_NAME: process.env.S3_BUCKET_NAME,
+      AWS_REGION: process.env.AWS_REGION,
       AZURE_BLOB_ENDPOINT: process.env.AZURE_BLOB_ENDPOINT,
     }).join(
       " ",


### PR DESCRIPTION
> **Root cause correction (updated):** The real blocker is the app **Content-Security-Policy**, not bucket CORS. Prod bucket CORS on `langwatch-storage-prod` is live and correct (`get-bucket-cors`: `PUT/GET/HEAD`, `https://*.langwatch.ai`). The presigned PUT was refused by the production CSP because `connect-src` did not list the object-storage origin (CSP is production-only, which is why local dev masked it). Fixed by deriving the storage origin from env into `connect-src` (`buildStorageConnectSrc`). The observability + hard-delete-on-abort changes remain as hardening/safety-net.

---

Closes #5088.

## What

Hardens the browser → object-storage **direct dataset upload** path so a failed presigned `PUT` (typically a missing/ineffective bucket CORS rule) is no longer an invisible, misleading, ghost-row-spawning degradation.

## Why

Today a `PresignedUploadFailedError` (storage configured, PUT failed) is handled identically to `DirectUploadUnavailableError` (no storage). Result:

1. **Invisible** — no log/telemetry, so a fully-broken direct-upload path looks healthy because small files silently keep working via the in-browser-parse fallback.
2. **Misleading** — a file over the 25 MB fallback cap shows *"requires object storage"* even though storage IS configured and it's the upload to it that failed.
3. **Ghost rows** — the pending `uploading` placeholder is archived (slug renamed + `archivedAt`) and the fallback creates a *separate* `ready` dataset → two rows per upload, accumulating unbounded during a CORS outage.

## Changes

- **Observability** — `PresignedUploadFailedError` now logs loudly with an operator-facing CORS/connectivity hint, distinct from the no-storage case (`UploadCSVDrawer.tsx`).
- **Accurate error** — over-cap files, when storage is configured, get an accurate "couldn't upload your file to storage" message instead of the false "requires object storage". The CORS specifics stay in the log; the UI stays jargon-free (`copywriting.md`).
- **No ghost rows** — content-less pending placeholders are hard-deleted instead of archived, via a new **status-guarded** `DatasetRepository.deletePendingUpload` (`deleteMany where status='uploading'`), so a finalize racing the abort is never destroyed. Shared by the explicit abort and the poll-triggered stale sweep.

## Scope / not in scope

This is app-side hardening so the failure is **observable and honest**. It does **not** replace the actual unblock — applying the bucket CORS rule (tracked in IaC) so the browser preflight succeeds and direct upload works end-to-end. Verify with `aws s3api get-bucket-cors` on the target bucket before closing out the incident.

## Tests

- `dataset-service.upload.unit.test.ts` — abort + poll-sweep now assert hard-delete (`deletePendingUpload`) instead of archive. **29 pass.**
- `UploadCSVFallbackGuard.integration.test.tsx` — over-cap + presign-failed now asserts the accurate message and that it does **not** say "requires object storage". **6 pass.**
- `dataset.repository.test.ts` — `deletePendingUpload` contract documented (status-guard, tenancy scope) matching the file's `it.todo` convention.
- typecheck + biome clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV upload fallback handling by distinguishing “no browser-reachable storage” from “presigned PUT rejected,” with clearer user messaging and more detailed presign-failure logging.
  * Oversized-file errors now show “couldn’t upload your file to storage” when the presigned PUT is rejected.
  * Pending CSV uploads are cleaned up more reliably by hard-deleting still-`uploading` placeholders during reaping/abort flows.
* **Security**
  * Updated CSP `connect-src` to dynamically allow storage-relevant upload origins (S3/Azure) based on runtime configuration.
* **Tests**
  * Added/updated unit and integration tests for the revised fallback messaging and hard-delete behavior, plus coverage for dynamic CSP origin derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->