### PR TITLE
chore(ui): migrate destructive window.confirm() to ConfirmDialog (#4141)

### DIFF
--- a/langwatch/src/components/analytics/CustomDashboardsSection.tsx
+++ b/langwatch/src/components/analytics/CustomDashboardsSection.tsx
@@ -10,6 +10,7 @@ import {
 import { useRouter } from "~/utils/compat/next-router";
 import { useEffect, useRef, useState } from "react";
 import { MenuLink } from "~/components/MenuLink";
+import { ConfirmDialog } from "~/components/gateway/ConfirmDialog";
 import { Menu } from "~/components/ui/menu";
 import { toaster } from "~/components/ui/toaster";
 import { useDrawer } from "~/hooks/useDrawer";
@@ -34,6 +35,9 @@ export function CustomDashboardsSection({
     null,
   );
   const [editingName, setEditingName] = useState("");
+  const [dashboardToDelete, setDashboardToDelete] = useState<string | null>(
+    null,
+  );
   const inputRef = useRef<HTMLInputElement>(null);
 
   const dashboardsQuery = api.dashboards.getAll.useQuery(
@@ -139,39 +143,7 @@ export function CustomDashboardsSection({
       return;
     }
 
-    const confirmed = window.confirm(
-      "Are you sure you want to delete this dashboard? All graphs on this dashboard will be deleted.",
-    );
-    if (!confirmed) return;
-
-    deleteDashboard.mutate(
-      { projectId, dashboardId },
-      {
-        onSuccess: () => {
-          void dashboardsQuery.refetch();
-          void queryClient.licenseEnforcement.checkLimit.invalidate();
-          // If we deleted the current dashboard, redirect to the first dashboard
-          if (currentDashboardId === dashboardId) {
-            const remainingDashboards = dashboards.filter(
-              (d) => d.id !== dashboardId,
-            );
-            if (remainingDashboards[0]) {
-              void router.push(
-                `/${projectSlug}/analytics/reports?dashboard=${remainingDashboards[0].id}`,
-              );
-            }
-          }
-        },
-        onError: () => {
-          toaster.create({
-            title: "Error deleting dashboard",
-            type: "error",
-            duration: 3000,
-            meta: { closable: true },
-          });
-        },
-      },
-    );
+    setDashboardToDelete(dashboardId);
   };
 
   if (dashboardsQuery.isLoading) {
@@ -187,6 +159,50 @@ export function CustomDashboardsSection({
 
   return (
     <>
+      <ConfirmDialog
+        open={!!dashboardToDelete}
+        onOpenChange={(open) => {
+          if (!open) setDashboardToDelete(null);
+        }}
+        title="Delete dashboard"
+        message="Are you sure you want to delete this dashboard? All graphs on this dashboard will be deleted."
+        confirmLabel="Delete"
+        tone="danger"
+        loading={deleteDashboard.isLoading}
+        onConfirm={() => {
+          if (!dashboardToDelete) return;
+          const dashboardId = dashboardToDelete;
+          deleteDashboard.mutate(
+            { projectId, dashboardId },
+            {
+              onSuccess: () => {
+                void dashboardsQuery.refetch();
+                void queryClient.licenseEnforcement.checkLimit.invalidate();
+                // If we deleted the current dashboard, redirect to the first dashboard
+                if (currentDashboardId === dashboardId) {
+                  const remainingDashboards = dashboards.filter(
+                    (d) => d.id !== dashboardId,
+                  );
+                  if (remainingDashboards[0]) {
+                    void router.push(
+                      `/${projectSlug}/analytics/reports?dashboard=${remainingDashboards[0].id}`,
+                    );
+                  }
+                }
+              },
+              onError: () => {
+                toaster.create({
+                  title: "Error deleting dashboard",
+                  type: "error",
+                  duration: 3000,
+                  meta: { closable: true },
+                });
+              },
+              onSettled: () => setDashboardToDelete(null),
+            },
+          );
+        }}
+      />
       {dashboards.map((dashboard, index) => {
         const isSelected = selectedDashboardId === dashboard.id;
         const isEditing = editingDashboardId === dashboard.id;

--- a/langwatch/src/components/analytics/CustomDashboardsSection.tsx
+++ b/langwatch/src/components/analytics/CustomDashboardsSection.tsx
@@ -161,8 +161,8 @@ export function CustomDashboardsSection({
     <>
       <ConfirmDialog
         open={!!dashboardToDelete}
-        onOpenChange={(open) => {
-          if (!open) setDashboardToDelete(null);
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setDashboardToDelete(null);
         }}
         title="Delete dashboard"
         message="Are you sure you want to delete this dashboard? All graphs on this dashboard will be deleted."

--- a/langwatch/src/components/evaluations/MonitorsSection.tsx
+++ b/langwatch/src/components/evaluations/MonitorsSection.tsx
@@ -33,6 +33,7 @@ import type { AppRouter } from "../../server/api/root";
 import { getEvaluatorDefinitions } from "../../server/evaluations/getEvaluator";
 import { api } from "../../utils/api";
 import { CustomGraph } from "../analytics/CustomGraph";
+import { ConfirmDialog } from "../gateway/ConfirmDialog";
 import { Link } from "../ui/link";
 import { toaster } from "../ui/toaster";
 import { CopyMonitorDialog } from "./CopyMonitorDialog";
@@ -52,6 +53,9 @@ export const MonitorsSection = ({ title, monitors }: MonitorsSectionProps) => {
     monitorId: string;
     monitorName: string;
   } | null>(null);
+  const [monitorToDelete, setMonitorToDelete] = useState<{ id: string } | null>(
+    null,
+  );
 
   const { project } = useOrganizationTeamProject();
   const router = useRouter();
@@ -240,18 +244,7 @@ export const MonitorsSection = ({ title, monitors }: MonitorsSectionProps) => {
                           color="red.fg"
                           onClick={() => {
                             if (!project) return;
-
-                            if (
-                              !confirm(
-                                "Are you sure you want to delete this monitor?",
-                              )
-                            )
-                              return;
-
-                            void deleteMonitorMutation.mutate({
-                              id: monitor.id,
-                              projectId: project.id,
-                            });
+                            setMonitorToDelete({ id: monitor.id });
                           }}
                         >
                           <LuTrash size={16} />
@@ -298,6 +291,24 @@ export const MonitorsSection = ({ title, monitors }: MonitorsSectionProps) => {
           monitorName={copyDialogState.monitorName}
         />
       )}
+      <ConfirmDialog
+        open={!!monitorToDelete}
+        onOpenChange={(open) => {
+          if (!open) setMonitorToDelete(null);
+        }}
+        title="Delete monitor"
+        message="Are you sure you want to delete this monitor?"
+        confirmLabel="Delete"
+        tone="danger"
+        loading={deleteMonitorMutation.isLoading}
+        onConfirm={() => {
+          if (!project || !monitorToDelete) return;
+          deleteMonitorMutation.mutate(
+            { id: monitorToDelete.id, projectId: project.id },
+            { onSettled: () => setMonitorToDelete(null) },
+          );
+        }}
+      />
     </Card.Root>
   );
 };

--- a/langwatch/src/components/evaluations/MonitorsSection.tsx
+++ b/langwatch/src/components/evaluations/MonitorsSection.tsx
@@ -293,8 +293,8 @@ export const MonitorsSection = ({ title, monitors }: MonitorsSectionProps) => {
       )}
       <ConfirmDialog
         open={!!monitorToDelete}
-        onOpenChange={(open) => {
-          if (!open) setMonitorToDelete(null);
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setMonitorToDelete(null);
         }}
         title="Delete monitor"
         message="Are you sure you want to delete this monitor?"

--- a/langwatch/src/components/evaluators/EvaluatorListDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorListDrawer.tsx
@@ -189,8 +189,8 @@ export function EvaluatorListDrawer(props: EvaluatorListDrawerProps) {
 
       <ConfirmDialog
         open={!!evaluatorToDelete}
-        onOpenChange={(open) => {
-          if (!open) setEvaluatorToDelete(null);
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setEvaluatorToDelete(null);
         }}
         title="Delete evaluator"
         message={`Are you sure you want to delete "${

--- a/langwatch/src/components/evaluators/EvaluatorListDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorListDrawer.tsx
@@ -26,6 +26,7 @@ import {
 import type { EvaluatorWithFields } from "~/server/evaluators/evaluator.service";
 import { api } from "~/utils/api";
 import { evaluatorTempNameMap } from "../checks/EvaluatorSelection";
+import { ConfirmDialog } from "../gateway/ConfirmDialog";
 import { Menu } from "../ui/menu";
 import { EvaluatorApiUsageDialog } from "./EvaluatorApiUsageDialog";
 
@@ -99,18 +100,13 @@ export function EvaluatorListDrawer(props: EvaluatorListDrawerProps) {
   };
 
   const handleDeleteEvaluator = (evaluator: EvaluatorWithFields) => {
-    if (
-      window.confirm(`Are you sure you want to delete "${evaluator.name}"?`)
-    ) {
-      deleteMutation.mutate({
-        id: evaluator.id,
-        projectId: project?.id ?? "",
-      });
-    }
+    setEvaluatorToDelete(evaluator);
   };
 
   // State for API usage dialog
   const [apiDialogEvaluator, setApiDialogEvaluator] =
+    useState<EvaluatorWithFields | null>(null);
+  const [evaluatorToDelete, setEvaluatorToDelete] =
     useState<EvaluatorWithFields | null>(null);
 
   const handleUseFromApi = (evaluator: EvaluatorWithFields) => {
@@ -189,6 +185,27 @@ export function EvaluatorListDrawer(props: EvaluatorListDrawerProps) {
         evaluator={apiDialogEvaluator}
         open={!!apiDialogEvaluator}
         onClose={() => setApiDialogEvaluator(null)}
+      />
+
+      <ConfirmDialog
+        open={!!evaluatorToDelete}
+        onOpenChange={(open) => {
+          if (!open) setEvaluatorToDelete(null);
+        }}
+        title="Delete evaluator"
+        message={`Are you sure you want to delete "${
+          evaluatorToDelete?.name ?? ""
+        }"?`}
+        confirmLabel="Delete"
+        tone="danger"
+        loading={deleteMutation.isLoading}
+        onConfirm={() => {
+          if (!evaluatorToDelete) return;
+          deleteMutation.mutate(
+            { id: evaluatorToDelete.id, projectId: project?.id ?? "" },
+            { onSettled: () => setEvaluatorToDelete(null) },
+          );
+        }}
       />
     </Drawer.Root>
   );

--- a/langwatch/src/components/evaluators/__tests__/EvaluatorListDrawer.integration.test.tsx
+++ b/langwatch/src/components/evaluators/__tests__/EvaluatorListDrawer.integration.test.tsx
@@ -2,13 +2,20 @@
  * @vitest-environment jsdom
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EvaluatorWithFields } from "~/server/evaluators/evaluator.service";
 import { EvaluatorListDrawer } from "../EvaluatorListDrawer";
 
-const { mockEvaluator } = vi.hoisted(() => ({
+const { mockEvaluator, deleteMutate } = vi.hoisted(() => ({
   mockEvaluator: {
     id: "evaluator_1",
     name: "Exactness",
@@ -16,6 +23,7 @@ const { mockEvaluator } = vi.hoisted(() => ({
     config: {},
     updatedAt: "2026-01-01T00:00:00.000Z",
   },
+  deleteMutate: vi.fn(),
 }));
 
 vi.mock("~/utils/api", () => ({
@@ -28,7 +36,7 @@ vi.mock("~/utils/api", () => ({
         useQuery: () => ({ isLoading: false, data: [mockEvaluator] }),
       },
       delete: {
-        useMutation: () => ({ mutate: vi.fn() }),
+        useMutation: () => ({ mutate: deleteMutate, isLoading: false }),
       },
     },
   },
@@ -103,6 +111,65 @@ describe("EvaluatorListDrawer", () => {
       expect(onSelect).toHaveBeenCalledWith(
         mockEvaluator as unknown as EvaluatorWithFields,
       );
+    });
+  });
+
+  describe("when deleting an evaluator", () => {
+    it("confirms via the modal dialog instead of window.confirm and deletes on confirm", async () => {
+      const user = userEvent.setup();
+      const confirmSpy = vi.spyOn(window, "confirm");
+      // The component closes the dialog when the mutation settles.
+      deleteMutate.mockImplementation(
+        (_vars: unknown, opts?: { onSettled?: () => void }) =>
+          opts?.onSettled?.(),
+      );
+      renderDrawer();
+
+      await user.click(
+        await screen.findByTestId(`evaluator-menu-${mockEvaluator.id}`),
+      );
+      await user.click(
+        await screen.findByTestId(`evaluator-delete-${mockEvaluator.id}`),
+      );
+
+      // The reusable modal is shown, not the native confirm dialog.
+      await waitFor(() => {
+        expect(screen.getByText("Delete evaluator")).toBeInTheDocument();
+        expect(
+          screen.getByText(`Are you sure you want to delete "Exactness"?`),
+        ).toBeInTheDocument();
+      });
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(deleteMutate).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole("button", { name: "Delete" }));
+
+      expect(deleteMutate).toHaveBeenCalledWith(
+        { id: mockEvaluator.id, projectId: "project-1" },
+        expect.objectContaining({ onSettled: expect.any(Function) }),
+      );
+      // Once the mutation settles the confirmation modal is dismissed.
+      await waitFor(() => {
+        expect(screen.queryByText("Delete evaluator")).not.toBeInTheDocument();
+      });
+
+      confirmSpy.mockRestore();
+    });
+
+    it("does not delete when the modal is cancelled", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.click(
+        await screen.findByTestId(`evaluator-menu-${mockEvaluator.id}`),
+      );
+      await user.click(
+        await screen.findByTestId(`evaluator-delete-${mockEvaluator.id}`),
+      );
+
+      await user.click(await screen.findByRole("button", { name: "Cancel" }));
+
+      expect(deleteMutate).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/components/gateway/__tests__/ConfirmDialog.integration.test.tsx
+++ b/langwatch/src/components/gateway/__tests__/ConfirmDialog.integration.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the reusable ConfirmDialog component that replaces window.confirm
+ * across the app (see #4141). Covers the contract its call sites rely on:
+ * open/close visibility, confirm/cancel callbacks, custom labels, and the
+ * loading state that guards against double-submits during a mutation.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ConfirmDialog } from "../ConfirmDialog";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("ConfirmDialog", () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    title: "Delete saved view",
+    message: 'Delete "My View" saved view?',
+    onConfirm: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when open", () => {
+    it("renders the title and message", async () => {
+      render(<ConfirmDialog {...defaultProps} />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Delete saved view")).toBeInTheDocument();
+        expect(
+          screen.getByText('Delete "My View" saved view?'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("uses the default confirm label when none is provided", async () => {
+      render(<ConfirmDialog {...defaultProps} />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Confirm" }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("renders a custom confirm label", async () => {
+      render(<ConfirmDialog {...defaultProps} confirmLabel="Delete" />, {
+        wrapper: Wrapper,
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Delete" }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("when closed", () => {
+    it("does not render the message", () => {
+      render(<ConfirmDialog {...defaultProps} open={false} />, {
+        wrapper: Wrapper,
+      });
+
+      expect(
+        screen.queryByText('Delete "My View" saved view?'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when the confirm button is clicked", () => {
+    it("calls onConfirm", async () => {
+      const user = userEvent.setup();
+      const onConfirm = vi.fn();
+
+      render(
+        <ConfirmDialog
+          {...defaultProps}
+          confirmLabel="Delete"
+          onConfirm={onConfirm}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await user.click(await screen.findByRole("button", { name: "Delete" }));
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the cancel button is clicked", () => {
+    it("requests close via onOpenChange(false) without confirming", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      const onConfirm = vi.fn();
+
+      render(
+        <ConfirmDialog
+          {...defaultProps}
+          onOpenChange={onOpenChange}
+          onConfirm={onConfirm}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await user.click(await screen.findByRole("button", { name: "Cancel" }));
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when loading", () => {
+    it("disables the cancel button so the action cannot be aborted mid-flight", async () => {
+      render(<ConfirmDialog {...defaultProps} loading={true} />, {
+        wrapper: Wrapper,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/gateway/__tests__/ConfirmDialog.integration.test.tsx
+++ b/langwatch/src/components/gateway/__tests__/ConfirmDialog.integration.test.tsx
@@ -17,7 +17,7 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
 );
 
-describe("ConfirmDialog", () => {
+describe("given a ConfirmDialog", () => {
   const defaultProps = {
     open: true,
     onOpenChange: vi.fn(),

--- a/langwatch/src/components/messages/SavedViewsBar.tsx
+++ b/langwatch/src/components/messages/SavedViewsBar.tsx
@@ -41,6 +41,7 @@ import { useSavedViews } from "../../hooks/useSavedViews";
 import { getOriginColor } from "../../utils/originColors";
 import { getColorForString } from "../../utils/rotatingColors";
 import { MENU_WIDTH_COMPACT, MENU_WIDTH_EXPANDED } from "../MainMenu";
+import { ConfirmDialog } from "../gateway/ConfirmDialog";
 import { Menu } from "../ui/menu";
 
 /**
@@ -246,6 +247,7 @@ function ViewBadge({
 }) {
   const [isRenaming, setIsRenaming] = useState(false);
   const [editName, setEditName] = useState(name);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleDoubleClick = useCallback(() => {
@@ -361,9 +363,7 @@ function ViewBadge({
             height="14px"
             onClick={(e) => {
               e.stopPropagation();
-              if (window.confirm(`Delete "${name}" saved view?`)) {
-                onDelete?.();
-              }
+              setConfirmDeleteOpen(true);
             }}
             data-testid={`delete-view-${id}`}
           >
@@ -371,6 +371,18 @@ function ViewBadge({
           </IconButton>
         )}
       </HStack>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onOpenChange={setConfirmDeleteOpen}
+        title="Delete saved view"
+        message={`Delete "${name}" saved view?`}
+        confirmLabel="Delete"
+        tone="danger"
+        onConfirm={() => {
+          setConfirmDeleteOpen(false);
+          onDelete?.();
+        }}
+      />
     </Badge>
   );
 }

--- a/langwatch/src/components/messages/SavedViewsBar.tsx
+++ b/langwatch/src/components/messages/SavedViewsBar.tsx
@@ -247,7 +247,7 @@ function ViewBadge({
 }) {
   const [isRenaming, setIsRenaming] = useState(false);
   const [editName, setEditName] = useState(name);
-  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleDoubleClick = useCallback(() => {
@@ -363,7 +363,7 @@ function ViewBadge({
             height="14px"
             onClick={(e) => {
               e.stopPropagation();
-              setConfirmDeleteOpen(true);
+              setIsConfirmDeleteOpen(true);
             }}
             data-testid={`delete-view-${id}`}
           >
@@ -372,14 +372,14 @@ function ViewBadge({
         )}
       </HStack>
       <ConfirmDialog
-        open={confirmDeleteOpen}
-        onOpenChange={setConfirmDeleteOpen}
+        open={isConfirmDeleteOpen}
+        onOpenChange={setIsConfirmDeleteOpen}
         title="Delete saved view"
         message={`Delete "${name}" saved view?`}
         confirmLabel="Delete"
         tone="danger"
         onConfirm={() => {
-          setConfirmDeleteOpen(false);
+          setIsConfirmDeleteOpen(false);
           onDelete?.();
         }}
       />

--- a/langwatch/src/components/messages/SavedViewsBar.tsx
+++ b/langwatch/src/components/messages/SavedViewsBar.tsx
@@ -40,8 +40,8 @@ import type { SavedView } from "../../hooks/useSavedViews";
 import { useSavedViews } from "../../hooks/useSavedViews";
 import { getOriginColor } from "../../utils/originColors";
 import { getColorForString } from "../../utils/rotatingColors";
-import { MENU_WIDTH_COMPACT, MENU_WIDTH_EXPANDED } from "../MainMenu";
 import { ConfirmDialog } from "../gateway/ConfirmDialog";
+import { MENU_WIDTH_COMPACT, MENU_WIDTH_EXPANDED } from "../MainMenu";
 import { Menu } from "../ui/menu";
 
 /**

--- a/langwatch/src/pages/[project]/evaluations.tsx
+++ b/langwatch/src/pages/[project]/evaluations.tsx
@@ -545,8 +545,8 @@ function EvaluationsV2() {
       )}
       <ConfirmDialog
         open={!!experimentToDelete}
-        onOpenChange={(open) => {
-          if (!open) setExperimentToDelete(null);
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setExperimentToDelete(null);
         }}
         title="Delete evaluation"
         message={`Are you sure you want to delete the evaluation "${

--- a/langwatch/src/pages/[project]/evaluations.tsx
+++ b/langwatch/src/pages/[project]/evaluations.tsx
@@ -27,6 +27,7 @@ import {
 } from "react-icons/lu";
 import { NewEvaluationMenu } from "~/components/evaluations/NewEvaluationMenu";
 import { NoDataInfoBlock } from "~/components/NoDataInfoBlock";
+import { ConfirmDialog } from "~/components/gateway/ConfirmDialog";
 import { ListTable } from "~/components/ui/ListTable";
 import { Link } from "~/components/ui/link";
 import { useRouter } from "~/utils/compat/next-router";
@@ -57,6 +58,10 @@ function EvaluationsV2() {
     evaluationName: string;
   } | null>(null);
   const [newEvaluationMenuOpen, setNewEvaluationMenuOpen] = useState(false);
+  const [experimentToDelete, setExperimentToDelete] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
 
   const navigationFooter = useNavigationFooter();
 
@@ -115,16 +120,7 @@ function EvaluationsV2() {
     experimentId: string,
     experimentName: string,
   ) => {
-    if (
-      confirm(
-        `Are you sure you want to delete the evaluation "${experimentName}"? This will also delete the workflow, monitor, and prompts associated with it. Datasets will be kept.`,
-      )
-    ) {
-      deleteExperimentMutation.mutate({
-        projectId: project?.id ?? "",
-        experimentId,
-      });
-    }
+    setExperimentToDelete({ id: experimentId, name: experimentName });
   };
 
   if (!project) return null;
@@ -547,6 +543,29 @@ function EvaluationsV2() {
           evaluationName={copyDialogState.evaluationName}
         />
       )}
+      <ConfirmDialog
+        open={!!experimentToDelete}
+        onOpenChange={(open) => {
+          if (!open) setExperimentToDelete(null);
+        }}
+        title="Delete evaluation"
+        message={`Are you sure you want to delete the evaluation "${
+          experimentToDelete?.name ?? ""
+        }"? This will also delete the workflow, monitor, and prompts associated with it. Datasets will be kept.`}
+        confirmLabel="Delete"
+        tone="danger"
+        loading={deleteExperimentMutation.isLoading}
+        onConfirm={() => {
+          if (!experimentToDelete) return;
+          deleteExperimentMutation.mutate(
+            {
+              projectId: project?.id ?? "",
+              experimentId: experimentToDelete.id,
+            },
+            { onSettled: () => setExperimentToDelete(null) },
+          );
+        }}
+      />
     </DashboardLayout>
   );
 }

--- a/langwatch/src/pages/[project]/evaluations/[id]/edit.tsx
+++ b/langwatch/src/pages/[project]/evaluations/[id]/edit.tsx
@@ -10,11 +10,13 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { useRouter } from "~/utils/compat/next-router";
+import { useState } from "react";
 import { MoreVertical } from "react-feather";
 import CheckConfigForm, {
   type CheckConfigFormData,
 } from "../../../../components/checks/CheckConfigForm";
 import { DashboardLayout } from "../../../../components/DashboardLayout";
+import { ConfirmDialog } from "../../../../components/gateway/ConfirmDialog";
 import { Menu } from "../../../../components/ui/menu";
 import { toaster } from "../../../../components/ui/toaster";
 import { useOrganizationTeamProject } from "../../../../hooks/useOrganizationTeamProject";
@@ -31,6 +33,7 @@ export default function EditTraceCheck() {
   );
   const updateCheck = api.monitors.update.useMutation();
   const deleteCheck = api.monitors.delete.useMutation();
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const onSubmit = async (data: CheckConfigFormData) => {
     if (!project || !data.checkType) return;
@@ -65,34 +68,7 @@ export default function EditTraceCheck() {
 
   const handleDeleteCheck = () => {
     if (!project) return;
-
-    if (window.confirm("Are you sure you want to delete this check?")) {
-      deleteCheck.mutate(
-        { id: checkId, projectId: project.id },
-        {
-          onSuccess: () => {
-            toaster.create({
-              title: "Check deleted successfully",
-              type: "success",
-              meta: {
-                closable: true,
-              },
-            });
-            void router.push(`/${project.slug}/evaluations`);
-          },
-          onError: () => {
-            toaster.create({
-              title: "Failed to delete check",
-              description: "Please try again",
-              type: "error",
-              meta: {
-                closable: true,
-              },
-            });
-          },
-        },
-      );
-    }
+    setConfirmDeleteOpen(true);
   };
 
   const defaultValues = check.data
@@ -108,6 +84,44 @@ export default function EditTraceCheck() {
 
   return (
     <DashboardLayout>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onOpenChange={setConfirmDeleteOpen}
+        title="Delete check"
+        message="Are you sure you want to delete this check?"
+        confirmLabel="Delete"
+        tone="danger"
+        loading={deleteCheck.isLoading}
+        onConfirm={() => {
+          if (!project) return;
+          deleteCheck.mutate(
+            { id: checkId, projectId: project.id },
+            {
+              onSuccess: () => {
+                toaster.create({
+                  title: "Check deleted successfully",
+                  type: "success",
+                  meta: {
+                    closable: true,
+                  },
+                });
+                void router.push(`/${project.slug}/evaluations`);
+              },
+              onError: () => {
+                toaster.create({
+                  title: "Failed to delete check",
+                  description: "Please try again",
+                  type: "error",
+                  meta: {
+                    closable: true,
+                  },
+                });
+              },
+              onSettled: () => setConfirmDeleteOpen(false),
+            },
+          );
+        }}
+      />
       <Container maxWidth="1200" padding={6}>
         <VStack align="start" gap={4}>
           <HStack align="end" width="full">

--- a/langwatch/src/pages/[project]/evaluations/[id]/edit.tsx
+++ b/langwatch/src/pages/[project]/evaluations/[id]/edit.tsx
@@ -33,7 +33,7 @@ export default function EditTraceCheck() {
   );
   const updateCheck = api.monitors.update.useMutation();
   const deleteCheck = api.monitors.delete.useMutation();
-  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
 
   const onSubmit = async (data: CheckConfigFormData) => {
     if (!project || !data.checkType) return;
@@ -68,7 +68,7 @@ export default function EditTraceCheck() {
 
   const handleDeleteCheck = () => {
     if (!project) return;
-    setConfirmDeleteOpen(true);
+    setIsConfirmDeleteOpen(true);
   };
 
   const defaultValues = check.data
@@ -85,8 +85,8 @@ export default function EditTraceCheck() {
   return (
     <DashboardLayout>
       <ConfirmDialog
-        open={confirmDeleteOpen}
-        onOpenChange={setConfirmDeleteOpen}
+        open={isConfirmDeleteOpen}
+        onOpenChange={setIsConfirmDeleteOpen}
         title="Delete check"
         message="Are you sure you want to delete this check?"
         confirmLabel="Delete"
@@ -117,7 +117,7 @@ export default function EditTraceCheck() {
                   },
                 });
               },
-              onSettled: () => setConfirmDeleteOpen(false),
+              onSettled: () => setIsConfirmDeleteOpen(false),
             },
           );
         }}

--- a/langwatch/src/pages/settings/roles.tsx
+++ b/langwatch/src/pages/settings/roles.tsx
@@ -403,9 +403,7 @@ function RolesManagement({
               description={role.description ?? ""}
               permissionCount={`${role.permissions.length} permissions`}
               hasPermission={hasPermission}
-              onDelete={() =>
-                setRoleToDelete({ id: role.id, name: role.name })
-              }
+              onDelete={() => setRoleToDelete({ id: role.id, name: role.name })}
               onEdit={() => {
                 void handleEditRole(role.id);
               }}

--- a/langwatch/src/pages/settings/roles.tsx
+++ b/langwatch/src/pages/settings/roles.tsx
@@ -449,8 +449,8 @@ function RolesManagement({
 
       <ConfirmDialog
         open={!!roleToDelete}
-        onOpenChange={(open) => {
-          if (!open) setRoleToDelete(null);
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setRoleToDelete(null);
         }}
         title="Delete role"
         message={`Are you sure you want to delete the role "${

--- a/langwatch/src/pages/settings/roles.tsx
+++ b/langwatch/src/pages/settings/roles.tsx
@@ -16,6 +16,7 @@ import { ShieldUser } from "lucide-react";
 
 import { useState } from "react";
 import { Eye, Plus, Shield, Users } from "react-feather";
+import { ConfirmDialog } from "~/components/gateway/ConfirmDialog";
 import { PageLayout } from "~/components/ui/layouts/PageLayout";
 import SettingsLayout from "../../components/SettingsLayout";
 import { ContactSalesBlock } from "../../components/subscription/ContactSalesBlock";
@@ -134,6 +135,10 @@ function RolesManagement({
     name: string;
     description: string;
     permissions: Permission[];
+  } | null>(null);
+  const [roleToDelete, setRoleToDelete] = useState<{
+    id: string;
+    name: string;
   } | null>(null);
   const apiContext = api.useContext();
   // Fetch custom roles
@@ -398,15 +403,9 @@ function RolesManagement({
               description={role.description ?? ""}
               permissionCount={`${role.permissions.length} permissions`}
               hasPermission={hasPermission}
-              onDelete={() => {
-                if (
-                  confirm(
-                    `Are you sure you want to delete the role "${role.name}"?`,
-                  )
-                ) {
-                  deleteRole.mutate({ roleId: role.id });
-                }
-              }}
+              onDelete={() =>
+                setRoleToDelete({ id: role.id, name: role.name })
+              }
               onEdit={() => {
                 void handleEditRole(role.id);
               }}
@@ -448,6 +447,27 @@ function RolesManagement({
         title="Edit Role"
         submitLabel="Update Role"
         isSubmitting={updateRole.isLoading}
+      />
+
+      <ConfirmDialog
+        open={!!roleToDelete}
+        onOpenChange={(open) => {
+          if (!open) setRoleToDelete(null);
+        }}
+        title="Delete role"
+        message={`Are you sure you want to delete the role "${
+          roleToDelete?.name ?? ""
+        }"?`}
+        confirmLabel="Delete"
+        tone="danger"
+        loading={deleteRole.isLoading}
+        onConfirm={() => {
+          if (!roleToDelete) return;
+          deleteRole.mutate(
+            { roleId: roleToDelete.id },
+            { onSettled: () => setRoleToDelete(null) },
+          );
+        }}
       />
 
       {/* View Permissions Dialog */}


### PR DESCRIPTION
## Ticket

Part of #4141 (this PR covers the delete/destructive-confirmation batch; remaining call sites tracked below).

The codebase still had ~22 `window.confirm()` / `confirm()` calls for destructive and guard actions. These are a11y-hostile, unthemed, and untestable. This PR migrates the **delete/destructive** confirmations to the existing reusable `ConfirmDialog` (`~/components/gateway/ConfirmDialog`) for consistent UX, theming, keyboard accessibility, and a loading state during the mutation.

## G-START verdict: PROCEED

Re-validated against current `main` (`cbc48c1b`): the issue is open, the smell still exists (22 real call sites confirmed by grep; #4136 migrated 2 of the original set), no superseding PR, and the premise still holds. Scoped to a coherent batch to keep the PR reviewable.

## Change

Migrated 7 destructive-confirmation call sites from native `confirm()` to `ConfirmDialog`, following the established in-repo pattern (`TeamForm.tsx`, #4136): stash the target in component state, render one `<ConfirmDialog>`, fire the existing mutation in `onConfirm`. Existing `onSuccess`/`onError` mutation callbacks (toasts, refetch, redirect) are preserved verbatim.

For the six mutation-backed surfaces the dialog stays open during the request and is dismissed in the mutation's `onSettled` (fires on both success and error). This makes the `loading` prop meaningful (spinner + disabled confirm guards against double-submitting a destructive delete, notably the cascade evaluation delete) and ensures the modal closes on a failed delete instead of getting stuck open. `SavedViewsBar` is the one exception: the badge receives an `onDelete` callback and does not own the delete mutation, so there is no `isLoading` to wire; it closes synchronously, matching the original `window.confirm` flow.

- `components/messages/SavedViewsBar.tsx` — delete saved view
- `components/evaluations/MonitorsSection.tsx` — delete monitor
- `components/evaluators/EvaluatorListDrawer.tsx` — delete evaluator
- `components/analytics/CustomDashboardsSection.tsx` — delete dashboard (the "last dashboard" guard stays at click time)
- `pages/settings/roles.tsx` — delete custom role
- `pages/[project]/evaluations.tsx` — delete evaluation
- `pages/[project]/evaluations/[id]/edit.tsx` — delete check

Scope is intentionally limited to delete/destructive confirmations. The "unsaved changes" close-guards (agent/prompt editor drawers, History, etc.) and action confirmations (Optimize/Evaluate) convert synchronous guards into async modals, are higher-risk, and are left for follow-up PRs.

## Evidence

- **New `components/gateway/__tests__/ConfirmDialog.test.tsx`** (the shared component had no test): 7 cases — renders title/message when open, hides when closed, default + custom confirm label, `onConfirm` on confirm, `onOpenChange(false)` on cancel without confirming, `loading` disables Cancel. `7 passed`.
- **Extended `EvaluatorListDrawer.integration.test.tsx`**: drives the real rendered flow — open actions menu → click Delete → asserts the `ConfirmDialog` modal appears (and `window.confirm` is **not** called) → click Confirm → asserts the `delete` mutation is called with the right vars and that the modal is dismissed once the mutation settles; plus a cancel path asserting no deletion. `4 passed` (2 new + 2 existing).

A workflow-backed self-review (`/code-review`) ran over the diff; its confirmed findings (modal staying open on a failed delete, inert `loading` wiring, test naming) were addressed in this PR via the `onSettled` pattern above and by naming the new test `.integration.test.tsx`.
- **`pnpm typecheck`**: 0 errors.
- **grep**: 0 `window.confirm`/`confirm(` remaining in the 7 files.

QA note: `ConfirmDialog` is an already-shipped component used in ~18 places; the integration test exercises it through the real `EvaluatorListDrawer` render, so behavior is covered without a full multi-flow app boot.

## Advisory note

Advisory PR from the tech-debt-fixer bot — opened for human review, not to be merged by the bot. The human makes the merge call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent, in-app confirmation dialogs for deleting dashboards, monitors, evaluators, saved views, experiments, checks, and custom roles, with clearer warnings, danger styling, and in-dialog loading states.
* **Bug Fixes**
  * Replaced browser `confirm()` prompts with React-controlled dialogs for a smoother, more reliable deletion flow.
* **Tests**
  * Added integration coverage for the reusable confirmation dialog and updated tests for the evaluator deletion confirmation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->