### PR TITLE
fix(datasets): surface read-truncation in the dataset editor

### DIFF
--- a/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -602,19 +602,18 @@ export function DatasetEditorTable({
         )}
         {isTruncatedRead ? (
           <Tooltip
-            content={`This dataset is too large to display in full here — showing the first ${rowCount.toLocaleString()} of ${totalRecordCount.toLocaleString()} rows. Editing a visible row saves just that row; use Download as CSV for the complete dataset.`}
+            content={`This dataset is too large to display in full here — showing ${rowCount.toLocaleString()} out of ${totalRecordCount.toLocaleString()} rows. Editing a visible row saves just that row; use Download as CSV for the complete dataset.`}
           >
-            <HStack
-              gap={1}
-              color="orange.600"
-              cursor="help"
-              data-testid="dataset-row-count"
-            >
-              <AlertTriangle size={13} />
-              <Text fontSize="13px">
-                Showing {rowCount.toLocaleString()} of{" "}
+            <HStack gap={1} cursor="help" data-testid="dataset-row-count">
+              <Text fontSize="13px" color="fg.muted">
+                {rowCount.toLocaleString()} out of{" "}
                 {totalRecordCount.toLocaleString()} records
               </Text>
+              {/* Icon trails the count and carries the warning color; the text
+                  stays neutral. */}
+              <Box color="orange.500" display="flex">
+                <AlertTriangle size={13} />
+              </Box>
             </HStack>
           </Tooltip>
         ) : (

--- a/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -40,7 +40,16 @@ import {
   useRef,
   useState,
 } from "react";
-import { Check, Download, Edit2, Plus, Trash2, Upload, X } from "react-feather";
+import {
+  AlertTriangle,
+  Check,
+  Download,
+  Edit2,
+  Plus,
+  Trash2,
+  Upload,
+  X,
+} from "react-feather";
 import { useStore } from "zustand";
 
 import { AddOrEditDatasetDrawer } from "~/components/AddOrEditDatasetDrawer";
@@ -335,6 +344,18 @@ export function DatasetEditorTable({
   // Always include one trailing phantom row (Excel-style "click to add")
   const displayRowCount = Math.max(rowCount + 1, 3);
 
+  // Large-dataset read truncation (ADR-032): saved datasets load via
+  // `getFullDataset`, which stops accumulating rows once it crosses a byte
+  // budget and returns the PG-authoritative total in `count` + a `truncated`
+  // flag. Without surfacing it the chrome shows only the loaded rows (e.g. "3
+  // records") for a 1640-row dataset — misleading. `count` is the source of
+  // truth for the total; `rowCount` is what's actually rendered.
+  const serverRecordCount = datasetId ? databaseDataset.data?.count : undefined;
+  const isTruncatedRead = datasetId
+    ? databaseDataset.data?.truncated === true
+    : false;
+  const totalRecordCount = serverRecordCount ?? rowCount;
+
   const rowData = useMemo((): DatasetTableRowData[] => {
     return Array.from({ length: displayRowCount }, (_, index) => {
       const record = records[index];
@@ -579,9 +600,33 @@ export function DatasetEditorTable({
         ) : (
           title
         )}
-        <Text fontSize="13px" color="fg.muted" data-testid="dataset-row-count">
-          {rowCount} {rowCount === 1 ? "record" : "records"}
-        </Text>
+        {isTruncatedRead ? (
+          <Tooltip
+            content={`This dataset is too large to display in full here — showing the first ${rowCount.toLocaleString()} of ${totalRecordCount.toLocaleString()} rows. Editing a visible row saves just that row; use Download as CSV for the complete dataset.`}
+          >
+            <HStack
+              gap={1}
+              color="orange.600"
+              cursor="help"
+              data-testid="dataset-row-count"
+            >
+              <AlertTriangle size={13} />
+              <Text fontSize="13px">
+                Showing {rowCount.toLocaleString()} of{" "}
+                {totalRecordCount.toLocaleString()} records
+              </Text>
+            </HStack>
+          </Tooltip>
+        ) : (
+          <Text
+            fontSize="13px"
+            color="fg.muted"
+            data-testid="dataset-row-count"
+          >
+            {totalRecordCount.toLocaleString()}{" "}
+            {totalRecordCount === 1 ? "record" : "records"}
+          </Text>
+        )}
         {datasetId && (
           <SaveStatusChip state={autosave.state} error={autosave.error} />
         )}

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -427,7 +427,7 @@ describe("given a large saved dataset whose read is truncated", () => {
       // rows — and flags that the view is partial.
       await waitFor(() =>
         expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
-          "Showing 3 of 1,640 records",
+          "3 out of 1,640 records",
         ),
       );
     });
@@ -453,7 +453,7 @@ describe("given a large saved dataset whose read is truncated", () => {
         ),
       );
       expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
-        "Showing",
+        "out of",
       );
     });
   });

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -397,3 +397,64 @@ describe("given a saved dataset", () => {
     });
   });
 });
+
+// ── Large-dataset read truncation (ADR-032) ──────────────────────────
+
+describe("given a large saved dataset whose read is truncated", () => {
+  const renderSaved = (data: Record<string, unknown>) => {
+    getAllQuery.mockReturnValue({ data, isLoading: false, refetch: vi.fn() });
+    return render(<DatasetEditorTable datasetId="dataset_big" />, {
+      wrapper: Wrapper,
+    });
+  };
+
+  describe("when the read is truncated", () => {
+    it("shows the true total with a truncation notice, not just the loaded rows", async () => {
+      renderSaved({
+        id: "dataset_big",
+        name: "dataset-images-2gb",
+        columnTypes,
+        count: 1640,
+        truncated: true,
+        datasetRecords: [
+          { id: "r1", input: "a", expected_output: "x" },
+          { id: "r2", input: "b", expected_output: "y" },
+          { id: "r3", input: "c", expected_output: "z" },
+        ],
+      });
+
+      // The count reflects the PG-authoritative total (1,640), NOT the 3 loaded
+      // rows — and flags that the view is partial.
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+          "Showing 3 of 1,640 records",
+        ),
+      );
+    });
+  });
+
+  describe("when the read is not truncated", () => {
+    it("shows the plain total with no truncation notice", async () => {
+      renderSaved({
+        id: "dataset_small",
+        name: "small",
+        columnTypes,
+        count: 2,
+        truncated: false,
+        datasetRecords: [
+          { id: "r1", input: "a", expected_output: "x" },
+          { id: "r2", input: "b", expected_output: "y" },
+        ],
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+          "2 records",
+        ),
+      );
+      expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
+        "Showing",
+      );
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/datasetRecord.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.ts
@@ -20,6 +20,7 @@ import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import {
   createManyDatasetRecords,
+  DATASET_EDITOR_READ_LIMIT_MB,
   getFullDataset,
   readDatasetHeadS3Jsonl,
 } from "./datasetRecord.utils";
@@ -160,6 +161,9 @@ export const datasetRecordRouter = createTRPCRouter({
         return await getFullDataset({
           datasetId: input.datasetId,
           projectId: input.projectId,
+          // Editor view loads into the browser; give heavy-row datasets a useful
+          // window instead of the 5 MB default (~3 rows of base64 images).
+          limitMb: DATASET_EDITOR_READ_LIMIT_MB,
         });
       } catch (error) {
         // Defense: a not-ready read surfaces as PRECONDITION_FAILED instead of

--- a/langwatch/src/server/api/routers/datasetRecord.utils.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.utils.ts
@@ -445,6 +445,18 @@ export const readDatasetHeadS3Jsonl = async ({
   };
 };
 
+/**
+ * Byte budget for the dataset editor's read (`datasetRecord.getAll`). The editor
+ * loads rows into the browser, so this caps how much it pulls — for datasets
+ * with heavy cells (e.g. base64 images ~1.25 MB/row) it's what decides how many
+ * rows are visible. Raised from the 5 MB default so heavy-row datasets show a
+ * useful window (~10 rows at 1.25 MB/row) instead of ~3. Browsing the full set
+ * of a multi-GB dataset is the separate paginated/streaming-reads epic (ADR-032);
+ * this is just a bigger window, not a cap removal. Run/export paths keep their
+ * own budgets (the function default / `null`).
+ */
+export const DATASET_EDITOR_READ_LIMIT_MB = 13;
+
 export const getFullDataset = async ({
   datasetId,
   projectId,


### PR DESCRIPTION
## What

A large `s3_jsonl` dataset showed a misleading row count in the editor — the detail view of a 1640-row dataset displayed **"3 records"**, reading like data loss when nothing is lost.

**Root cause:** the editor loads via `datasetRecord.getAll` → `getFullDataset`, which accumulates rows only until it crosses a byte budget, then stops. The default was **5 MB**; for image datasets (~1.25 MB/row — two base64 images each) that's ~3 rows, and the chrome rendered `records.length` while ignoring the PG-authoritative total (`count`) and the `truncated` flag the read already returns.

## Changes

1. **Honest count** — when the read is truncated the chrome shows the true total with a notice (`⚠ Showing 3 of 1,640 records` + tooltip explaining it's too large to display fully and that Download as CSV gives the complete data). Not truncated → unchanged `1,640 records`.
2. **Bigger editor window** — raised the editor read to a named **`DATASET_EDITOR_READ_LIMIT_MB = 13`** (from the 5 MB default), so heavy-row datasets show a useful window (~10 rows at 1.25 MB/row) instead of ~3. Scoped to the **editor read (`getAll`)** only — run/export paths keep their own budgets.

No data-integrity risk: saved-mode autosave is a **per-record-id delta** (`update` one row / `deleteMany` by ids), so editing a visible row persists only that row — the rest is untouched. Verified `getFullDataset` returns the real `count` on all layouts (s3_jsonl, legacy single-blob, Postgres).

## Scope

This makes the editor honest and gives a bigger window. It is **not** full browsing of multi-GB datasets — that's the separate batched/streaming-reads fast-follow (ADR-032 "Scope honesty"; the editable grid loads all rows into an in-memory store, and even Download is heap-guarded with a typed 413 for multi-GB). 13 MB is a bigger window, not a cap removal — the 2 GB set will still show a partial window with the notice.

## Tests
- Truncated read → count shows `Showing 3 of 1,640 records`.
- Non-truncated read → plain `2 records`, no notice.
- Existing editor tests unchanged (10 → 12).

Branched off latest `main` (includes #5108). Typecheck + biome clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the dataset editor table header for large saved datasets, including a warning indicator when results are truncated.
  * Updated the row-count UI to clearly show loaded rows versus the total available records.
* **Bug Fixes**
  * Adjusted the dataset editor “getAll” read path to use a larger editor-focused read limit for better visibility on heavy datasets.
* **Tests**
  * Added integration coverage for large-dataset truncation behavior, including both truncated and non-truncated states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->