### PR TITLE
fix(datasets): pin editor truncation tooltip copy + keyboard a11y

### DIFF
--- a/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -71,6 +71,7 @@ import {
   DatasetTableProvider,
   type DatasetTableRowData,
 } from "./DatasetTableContext";
+import { truncatedReadTooltip } from "./datasetEditorCopy";
 import { datasetTableCss } from "./datasetTableStyles";
 import {
   createDatasetEditorStore,
@@ -602,15 +603,29 @@ export function DatasetEditorTable({
         )}
         {isTruncatedRead ? (
           <Tooltip
-            content={`This dataset is too large to display in full here — showing ${rowCount.toLocaleString()} out of ${totalRecordCount.toLocaleString()} rows. Editing a visible row saves just that row; use Download as CSV for the complete dataset.`}
+            content={truncatedReadTooltip({
+              shown: rowCount,
+              total: totalRecordCount,
+            })}
           >
-            <HStack gap={1} cursor="help" data-testid="dataset-row-count">
+            <HStack
+              gap={1}
+              cursor="help"
+              // Keyboard-reachable: the explanation is otherwise hover-only, so
+              // make the chip focusable (Tooltip opens on focus too) and expose
+              // the full text to assistive tech via aria-label.
+              tabIndex={0}
+              role="note"
+              aria-label={truncatedReadTooltip({
+                shown: rowCount,
+                total: totalRecordCount,
+              })}
+              data-testid="dataset-row-count"
+            >
               <Text fontSize="13px" color="fg.muted">
                 {rowCount.toLocaleString()} out of{" "}
                 {totalRecordCount.toLocaleString()} records
               </Text>
-              {/* Icon trails the count and carries the warning color; the text
-                  stays neutral. */}
               <Box color="orange.500" display="flex">
                 <AlertTriangle size={13} />
               </Box>

--- a/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -71,7 +71,7 @@ import {
   DatasetTableProvider,
   type DatasetTableRowData,
 } from "./DatasetTableContext";
-import { truncatedReadTooltip } from "./datasetEditorCopy";
+import { formatRecordCount, truncatedReadTooltip } from "./datasetEditorCopy";
 import { datasetTableCss } from "./datasetTableStyles";
 import {
   createDatasetEditorStore,
@@ -623,8 +623,8 @@ export function DatasetEditorTable({
               data-testid="dataset-row-count"
             >
               <Text fontSize="13px" color="fg.muted">
-                {rowCount.toLocaleString()} out of{" "}
-                {totalRecordCount.toLocaleString()} records
+                {formatRecordCount(rowCount)} out of{" "}
+                {formatRecordCount(totalRecordCount)} records
               </Text>
               <Box color="orange.500" display="flex">
                 <AlertTriangle size={13} />
@@ -637,7 +637,7 @@ export function DatasetEditorTable({
             color="fg.muted"
             data-testid="dataset-row-count"
           >
-            {totalRecordCount.toLocaleString()}{" "}
+            {formatRecordCount(totalRecordCount)}{" "}
             {totalRecordCount === 1 ? "record" : "records"}
           </Text>
         )}

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -430,6 +430,14 @@ describe("given a large saved dataset whose read is truncated", () => {
           "3 out of 1,640 records",
         ),
       );
+      // The explanation is keyboard/SR-reachable: the chip is focusable and
+      // exposes the full tooltip copy via aria-label (not hover-only).
+      const chip = screen.getByTestId("dataset-row-count");
+      expect(chip).toHaveAttribute("tabindex", "0");
+      expect(chip).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("too large to display in full"),
+      );
     });
   });
 

--- a/langwatch/src/components/datasets/editor/__tests__/datasetEditorCopy.unit.test.ts
+++ b/langwatch/src/components/datasets/editor/__tests__/datasetEditorCopy.unit.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { truncatedReadTooltip } from "../datasetEditorCopy";
+
+describe("truncatedReadTooltip", () => {
+  describe("when a large dataset's editor read is truncated", () => {
+    it("states what is shown vs the total and how to get the full data", () => {
+      const copy = truncatedReadTooltip({ shown: 3, total: 1640 });
+
+      // Pin the customer-facing message so it can't silently drift.
+      expect(copy).toBe(
+        "This dataset is too large to display in full here — showing 3 out of 1,640 rows. Editing a visible row saves just that row; use Download as CSV for the complete dataset.",
+      );
+    });
+
+    it("formats both counts with thousands separators", () => {
+      const copy = truncatedReadTooltip({ shown: 10, total: 1000000 });
+      expect(copy).toContain("showing 10 out of 1,000,000 rows");
+    });
+  });
+});

--- a/langwatch/src/components/datasets/editor/__tests__/datasetEditorCopy.unit.test.ts
+++ b/langwatch/src/components/datasets/editor/__tests__/datasetEditorCopy.unit.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { truncatedReadTooltip } from "../datasetEditorCopy";
 
-describe("truncatedReadTooltip", () => {
-  describe("when a large dataset's editor read is truncated", () => {
+describe("given a dataset whose editor read is truncated", () => {
+  describe("when building the count tooltip", () => {
     it("states what is shown vs the total and how to get the full data", () => {
       const copy = truncatedReadTooltip({ shown: 3, total: 1640 });
 
@@ -12,7 +12,7 @@ describe("truncatedReadTooltip", () => {
       );
     });
 
-    it("formats both counts with thousands separators", () => {
+    it("formats both counts with a fixed en-US thousands separator (locale-independent)", () => {
       const copy = truncatedReadTooltip({ shown: 10, total: 1000000 });
       expect(copy).toContain("showing 10 out of 1,000,000 rows");
     });

--- a/langwatch/src/components/datasets/editor/datasetEditorCopy.ts
+++ b/langwatch/src/components/datasets/editor/datasetEditorCopy.ts
@@ -1,0 +1,20 @@
+/**
+ * User-facing copy for the dataset editor, kept as pure builders so the strings
+ * are pinned by tests and can't silently drift (copywriting.md: copy hidden
+ * behind a `(?)` tooltip is pinned to the code by a test).
+ */
+
+/**
+ * Tooltip shown on the truncated-read count chip. A large dataset is loaded into
+ * the editor up to a byte budget, so only the first rows are shown; this
+ * explains that nothing is lost, that editing a visible row is safe, and how to
+ * get the complete data.
+ */
+export const truncatedReadTooltip = ({
+  shown,
+  total,
+}: {
+  shown: number;
+  total: number;
+}): string =>
+  `This dataset is too large to display in full here — showing ${shown.toLocaleString()} out of ${total.toLocaleString()} rows. Editing a visible row saves just that row; use Download as CSV for the complete dataset.`;

--- a/langwatch/src/components/datasets/editor/datasetEditorCopy.ts
+++ b/langwatch/src/components/datasets/editor/datasetEditorCopy.ts
@@ -5,6 +5,18 @@
  */
 
 /**
+ * Fixed `en-US` separator (1,640) for record counts. Pinned rather than
+ * `toLocaleString()` (runtime locale) so the copy is deterministic — the tooltip
+ * text and visible count stay identical across browsers/CI, and the pinned-copy
+ * test doesn't break under a non-en locale (`1.640` / `1 640`).
+ */
+const recordCountFormatter = new Intl.NumberFormat("en-US");
+
+/** Format a record count with the editor's fixed thousands separator. */
+export const formatRecordCount = (count: number): string =>
+  recordCountFormatter.format(count);
+
+/**
  * Tooltip shown on the truncated-read count chip. A large dataset is loaded into
  * the editor up to a byte budget, so only the first rows are shown; this
  * explains that nothing is lost, that editing a visible row is safe, and how to
@@ -17,4 +29,4 @@ export const truncatedReadTooltip = ({
   shown: number;
   total: number;
 }): string =>
-  `This dataset is too large to display in full here — showing ${shown.toLocaleString()} out of ${total.toLocaleString()} rows. Editing a visible row saves just that row; use Download as CSV for the complete dataset.`;
+  `This dataset is too large to display in full here — showing ${formatRecordCount(shown)} out of ${formatRecordCount(total)} rows. Editing a visible row saves just that row; use Download as CSV for the complete dataset.`;


### PR DESCRIPTION
## What

Follow-up to **#5109** (merged) addressing CodeRabbit's review on it. Targets `main`.

Applies the **3 valid** CodeRabbit findings from #5109:

1. **Pin the tooltip copy with a test** — extracted the truncated-read tooltip into a pure builder `truncatedReadTooltip({ shown, total })` (`datasetEditorCopy.ts`) and pinned the exact customer-facing string with a unit test. Pure-string test by design: asserting the Chakra `Tooltip`'s rendered content would mean hovering + waiting on a portal (flaky); pinning the builder is stable and covers the same intent.
2. **Make the truncation help keyboard-reachable** — the chip was hover-only. It's now focusable (`tabIndex={0}`, `role="note"`) so the Tooltip opens on focus, and the full explanation is exposed to assistive tech via `aria-label` (integration test asserts the wiring).
3. **Remove a redundant what-comment** on the icon.

## Tests
- `datasetEditorCopy.unit.test.ts` (2 cases) pins the copy.
- Editor integration test asserts the chip is focusable + carries the aria-label (12 pass).
- Typecheck + biome clean.

No behavior change beyond a11y + a refactor of the copy into a tested builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the dataset editor’s truncation warning with more precise “shown vs total” messaging, including consistent record-count formatting.
  * Improved accessibility for the truncation indicator by making it keyboard-focusable and exposing an accurate explanation via an assistive-tech label.
* **Tests**
  * Expanded unit and integration tests to validate the tooltip copy, locale-independent number formatting, and the focus/ARIA behavior of the row-count warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->