### PR TITLE
feat(datasets): bulk dataset upload

### DIFF
--- a/langwatch/src/components/datasets/DatasetSelector.tsx
+++ b/langwatch/src/components/datasets/DatasetSelector.tsx
@@ -1,6 +1,6 @@
 import { Button, createListCollection, Field } from "@chakra-ui/react";
 import type { Dataset } from "@prisma/client";
-import { useEffect, useState, type ReactNode } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import type {
   FieldErrors,
   Path,
@@ -35,7 +35,7 @@ export function DatasetSelector<T extends { datasetId: string }>({
   });
 
   const [selectedValue, setSelectedValue] = useState<string[]>(
-    localStorageDatasetId ? [localStorageDatasetId] : []
+    localStorageDatasetId ? [localStorageDatasetId] : [],
   );
 
   useEffect(() => {

--- a/langwatch/src/components/datasets/UploadCSVDrawer.tsx
+++ b/langwatch/src/components/datasets/UploadCSVDrawer.tsx
@@ -10,15 +10,7 @@ import {
   useDisclosure,
   VStack,
 } from "@chakra-ui/react";
-import { keyframes } from "@emotion/react";
-import {
-  CheckCircle,
-  CloudUpload,
-  FileText,
-  Trash2,
-  X,
-  XCircle,
-} from "lucide-react";
+import { CheckCircle, FileText, Trash2, X, XCircle } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import {
   formatFileSize,
@@ -47,6 +39,12 @@ import {
 } from "../AddOrEditDatasetDrawer";
 import { Drawer } from "../ui/drawer";
 import { toaster } from "../ui/toaster";
+import {
+  DROPZONE_DOTTED_STYLE,
+  DropzonePrompt,
+  dropzoneSurfaceProps,
+  RAINBOW_TEXT_CSS,
+} from "./datasetDropzoneStyles";
 import {
   abortPendingUpload,
   DirectUploadUnavailableError,
@@ -1149,90 +1147,6 @@ function jsonToCSV(jsonContents: object[]): string {
 }
 
 type DatasetFileStatus = "selected" | "uploading" | "ready" | "error";
-
-const DROPZONE_SUPPORTED_HELP = "Supported files: CSV, JSON, or JSONL";
-
-// Dotted-grid surface for the empty dropzone. Raw CSS (not a Chakra token) so
-// it composes over the theme-aware background color; `border` follows the
-// active color mode.
-const DROPZONE_DOTTED_STYLE: React.CSSProperties = {
-  backgroundImage:
-    "radial-gradient(var(--chakra-colors-border) 1px, transparent 1px)",
-  backgroundSize: "16px 16px",
-};
-
-/** Shared Chakra props for the dashed dropzone surface; highlights when active
- *  (dragging a file over it) and on hover, and softly grows the cloud icon. */
-const dropzoneSurfaceProps = (active: boolean) => ({
-  borderRadius: "xl",
-  borderWidth: "2px",
-  borderStyle: "dashed" as const,
-  borderColor: active ? "blue.400" : "border",
-  bg: active ? "blue.500/10" : "transparent",
-  padding: 10,
-  textAlign: "center" as const,
-  cursor: "pointer",
-  width: "full",
-  transition: "border-color 0.15s ease, background-color 0.15s ease",
-  // Grow the icon while dragging a file over the zone; the icon's own
-  // transition animates the grow/shrink smoothly.
-  "& .lw-dropzone-icon": active ? { transform: "scale(1.12)" } : {},
-  _hover: {
-    borderColor: "blue.300",
-    bg: "blue.500/5",
-    "& .lw-dropzone-icon": { transform: "scale(1.12)" },
-  },
-});
-
-// PostHog's rainbow-scroll text sheen (same recipe as ShikiCommandBox): a
-// gradient clipped to the text whose background-position scrolls to animate.
-// Applied to the file name while it uploads — one continuous "loading" tell.
-const lwRainbowScroll = keyframes`
-  0% { background-position-x: 0%; }
-  100% { background-position-x: 200%; }
-`;
-
-const LW_RAINBOW_GRADIENT =
-  "linear-gradient(90deg, #0143cb 0%, #2b6ff4 24%, #d23401 47%, #ff651f 66%, #fba000 83%, #0143cb 100%)";
-
-const RAINBOW_TEXT_CSS = {
-  color: "transparent",
-  backgroundImage: LW_RAINBOW_GRADIENT,
-  backgroundClip: "text",
-  WebkitBackgroundClip: "text",
-  WebkitTextFillColor: "transparent",
-  backgroundSize: "200% 100%",
-  animation: `${lwRainbowScroll} 3s linear infinite`,
-  "@media (prefers-reduced-motion: reduce)": { animation: "none" },
-} as const;
-
-/**
- * Empty-state contents of the dropzone: an upload illustration, the primary
- * prompt (with "click to browse" reading as a link), and the supported types.
- */
-function DropzonePrompt() {
-  return (
-    <VStack gap={2}>
-      <Box
-        className="lw-dropzone-icon"
-        color="blue.400"
-        transition="transform 0.2s ease"
-        transformOrigin="center"
-      >
-        <CloudUpload size={36} strokeWidth={1.5} />
-      </Box>
-      <Text fontSize="md" color="fg">
-        Drag and drop file, or{" "}
-        <Text as="span" color="blue.500" fontWeight="medium">
-          click to browse
-        </Text>
-      </Text>
-      <Text fontSize="xs" color="fg.muted">
-        {DROPZONE_SUPPORTED_HELP}
-      </Text>
-    </VStack>
-  );
-}
 
 function DatasetFileStatusIcon({ status }: { status: DatasetFileStatus }) {
   if (status === "uploading") return <Spinner size="sm" color="blue.500" />;

--- a/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
@@ -110,6 +110,71 @@ function BulkColumnFields({
   );
 }
 
+/** Click-to-edit dataset name (like the prompt variable-name field): a label
+ *  that becomes a focused, text-selected input on click and commits on blur or
+ *  Enter (Escape cancels). Editable only before the upload starts. */
+function EditableName({
+  value,
+  editable,
+  onCommit,
+}: {
+  value: string;
+  editable: boolean;
+  onCommit: (next: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  useEffect(() => {
+    if (!editing) setDraft(value);
+  }, [value, editing]);
+
+  if (!editable) {
+    return (
+      <Text fontWeight="medium" truncate maxW="full">
+        {value}
+      </Text>
+    );
+  }
+  if (editing) {
+    const commit = () => {
+      onCommit(draft);
+      setEditing(false);
+    };
+    return (
+      <Input
+        size="sm"
+        autoFocus
+        value={draft}
+        fontWeight="medium"
+        aria-label="Dataset name"
+        onChange={(e) => setDraft(e.target.value)}
+        onFocus={(e) => e.currentTarget.select()}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          if (e.key === "Escape") {
+            setDraft(value);
+            setEditing(false);
+          }
+        }}
+      />
+    );
+  }
+  return (
+    <Text
+      fontWeight="medium"
+      truncate
+      maxW="full"
+      cursor="text"
+      title="Click to rename"
+      _hover={{ textDecoration: "underline dotted" }}
+      onClick={() => setEditing(true)}
+    >
+      {value}
+    </Text>
+  );
+}
+
 /** The right-aligned slot of a row: the confirm-types toggle while pending,
  *  otherwise an inline status tracker (preparing/uploading rainbow → ready). */
 function RowTrailing({
@@ -146,15 +211,21 @@ function RowTrailing({
       );
     case "uploading":
       return (
-        <Text fontSize="13px" fontWeight="medium" css={RAINBOW_TEXT_CSS}>
-          Uploading…
-        </Text>
+        <HStack gap={1.5}>
+          <Spinner size="xs" color="blue.500" />
+          <Text fontSize="13px" fontWeight="medium" css={RAINBOW_TEXT_CSS}>
+            Uploading…
+          </Text>
+        </HStack>
       );
     case "processing":
       return (
-        <Text fontSize="13px" fontWeight="medium" css={RAINBOW_TEXT_CSS}>
-          Preparing…
-        </Text>
+        <HStack gap={1.5}>
+          <Spinner size="xs" color="blue.500" />
+          <Text fontSize="13px" fontWeight="medium" css={RAINBOW_TEXT_CSS}>
+            Preparing…
+          </Text>
+        </HStack>
       );
     case "ready":
       return (
@@ -192,6 +263,7 @@ function BulkFileRow({
   onCancel,
   onRetry,
   onColumns,
+  onName,
   onReady,
   onFailed,
 }: {
@@ -201,6 +273,7 @@ function BulkFileRow({
   onCancel: () => void;
   onRetry: () => void;
   onColumns: (next: DatasetColumns) => void;
+  onName: (next: string) => void;
   onReady: () => void;
   onFailed: (error?: string) => void;
 }) {
@@ -252,14 +325,11 @@ function BulkFileRow({
     >
       <HStack gap={3} width="full" align="center">
         <VStack align="start" gap={0} flex={1} minW={0}>
-          <Text
-            fontWeight="medium"
-            truncate
-            maxW="full"
-            css={isActive ? RAINBOW_TEXT_CSS : undefined}
-          >
-            {file.name}
-          </Text>
+          <EditableName
+            value={file.name}
+            editable={file.status === "pending"}
+            onCommit={onName}
+          />
           <Text fontSize="xs" color="fg.muted">
             {formatFileSize(file.file.size)}
           </Text>
@@ -412,6 +482,7 @@ export function BulkUploadDrawer({
                   onCancel={() => bulk.cancelFile(file.id)}
                   onRetry={() => void bulk.retryFile(file.id)}
                   onColumns={(next) => bulk.setColumnTypes(file.id, next)}
+                  onName={(next) => bulk.setName(file.id, next)}
                   onReady={() => {
                     bulk.markReady(file.id);
                     onUploaded?.();

--- a/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
@@ -1,0 +1,387 @@
+/**
+ * Bulk upload (D1/D2/D4/D6-9 UI): a dedicated drawer to drop several files at
+ * once. Each file is its own row with an inline collapsed column-type confirm;
+ * "Upload all" prepares them in the background, independently. Reuses the
+ * single-flow's `DatasetUploadProcessing` poller for each row's processing tail.
+ */
+import {
+  Box,
+  Button,
+  Collapsible,
+  Heading,
+  HStack,
+  Input,
+  NativeSelect,
+  Spacer,
+  Spinner,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import {
+  AlertTriangle,
+  CheckCircle,
+  ChevronDown,
+  RefreshCw,
+  X,
+  XCircle,
+} from "react-feather";
+import { formatFileSize } from "react-papaparse";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import type { DatasetColumns } from "~/server/datasets/types";
+import { Drawer } from "../../ui/drawer";
+import { DatasetUploadProcessing } from "../UploadCSVDrawer";
+import { type BulkFile, useBulkUpload } from "./useBulkUpload";
+
+const COLUMN_TYPE_OPTIONS = [
+  "string",
+  "number",
+  "boolean",
+  "date",
+  "list",
+  "json",
+  "image",
+] as const;
+
+/** Inline, compact column-type list for one file: rename + retype only (the
+ *  confirmed columns must stay positionally 1:1 with the file's headers — no
+ *  add/remove). */
+function BulkColumnFields({
+  columnTypes,
+  onChange,
+}: {
+  columnTypes: DatasetColumns;
+  onChange: (next: DatasetColumns) => void;
+}) {
+  const setAt = (index: number, patch: Partial<DatasetColumns[number]>) =>
+    onChange(columnTypes.map((c, i) => (i === index ? { ...c, ...patch } : c)));
+
+  return (
+    <VStack align="stretch" gap={2} width="full">
+      {columnTypes.map((col, index) => (
+        <HStack key={index} gap={2} width="full">
+          <Input
+            size="sm"
+            value={col.name}
+            aria-label={`Column ${index + 1} name`}
+            onChange={(e) => setAt(index, { name: e.target.value })}
+          />
+          <NativeSelect.Root size="sm" width="40">
+            <NativeSelect.Field
+              value={col.type}
+              aria-label={`Column ${index + 1} type`}
+              onChange={(e) =>
+                setAt(index, {
+                  type: e.target.value as DatasetColumns[number]["type"],
+                })
+              }
+            >
+              {COLUMN_TYPE_OPTIONS.map((t) => (
+                <option key={t} value={t}>
+                  {t === "image" ? "image (URL)" : t}
+                </option>
+              ))}
+            </NativeSelect.Field>
+            <NativeSelect.Indicator />
+          </NativeSelect.Root>
+        </HStack>
+      ))}
+    </VStack>
+  );
+}
+
+function StatusChip({ file }: { file: BulkFile }) {
+  switch (file.status) {
+    case "ready":
+      return (
+        <HStack gap={1} color="green.600" fontSize="13px">
+          <CheckCircle size={14} /> <Text>Ready</Text>
+        </HStack>
+      );
+    case "failed":
+    case "rejected":
+      return (
+        <HStack gap={1} color="red.500" fontSize="13px">
+          <XCircle size={14} />
+          <Text>
+            {file.rejectedReason === "unsupported"
+              ? "Unsupported file"
+              : file.rejectedReason === "too-large"
+                ? "Too large"
+                : (file.error ?? "Failed")}
+          </Text>
+        </HStack>
+      );
+    case "queued":
+      return (
+        <Text fontSize="13px" color="fg.muted">
+          Queued
+        </Text>
+      );
+    case "uploading":
+    case "processing":
+      return (
+        <HStack gap={1} color="blue.500" fontSize="13px">
+          <Spinner size="xs" /> <Text>Preparing…</Text>
+        </HStack>
+      );
+    case "cancelled":
+      return (
+        <Text fontSize="13px" color="fg.muted">
+          Cancelled
+        </Text>
+      );
+    default:
+      return null;
+  }
+}
+
+function BulkFileRow({
+  file,
+  projectId,
+  onRemove,
+  onCancel,
+  onRetry,
+  onColumns,
+  onReady,
+}: {
+  file: BulkFile;
+  projectId: string;
+  onRemove: () => void;
+  onCancel: () => void;
+  onRetry: () => void;
+  onColumns: (next: DatasetColumns) => void;
+  onReady: () => void;
+}) {
+  const canConfirm =
+    file.status === "pending" &&
+    file.columnTypes &&
+    file.columnTypes.length > 0;
+  const isActive = file.status === "uploading" || file.status === "processing";
+
+  return (
+    <VStack
+      align="stretch"
+      gap={2}
+      padding={3}
+      borderWidth="1px"
+      borderRadius="lg"
+      borderColor={
+        file.status === "failed" || file.status === "rejected"
+          ? "red.300"
+          : "border"
+      }
+      bg="bg"
+    >
+      <HStack gap={3} width="full">
+        <VStack align="start" gap={0} flex={1} minW={0}>
+          <Text fontWeight="medium" truncate maxW="full">
+            {file.name}
+          </Text>
+          <Text fontSize="xs" color="fg.muted">
+            {formatFileSize(file.file.size)}
+          </Text>
+        </VStack>
+        <StatusChip file={file} />
+        {file.status === "failed" && (
+          <Button size="xs" variant="outline" onClick={onRetry}>
+            <RefreshCw size={12} /> Retry
+          </Button>
+        )}
+        {isActive ? (
+          <Box
+            as="button"
+            aria-label="Cancel upload"
+            color="fg.muted"
+            _hover={{ color: "red.500" }}
+            onClick={onCancel}
+          >
+            <X size={16} />
+          </Box>
+        ) : (
+          <Box
+            as="button"
+            aria-label="Remove file"
+            color="fg.muted"
+            _hover={{ color: "red.500" }}
+            onClick={onRemove}
+          >
+            <X size={16} />
+          </Box>
+        )}
+      </HStack>
+
+      {canConfirm && file.columnTypes && (
+        <Collapsible.Root>
+          <Collapsible.Trigger
+            asChild
+            aria-label={`Confirm columns for ${file.name}`}
+          >
+            <HStack
+              as="button"
+              gap={1}
+              fontSize="13px"
+              color="blue.600"
+              cursor="pointer"
+            >
+              <ChevronDown size={14} />
+              <Text>{file.columnTypes.length} columns — confirm types</Text>
+            </HStack>
+          </Collapsible.Trigger>
+          <Collapsible.Content>
+            <Box paddingTop={2}>
+              <BulkColumnFields
+                columnTypes={file.columnTypes}
+                onChange={onColumns}
+              />
+            </Box>
+          </Collapsible.Content>
+        </Collapsible.Root>
+      )}
+
+      {file.status === "processing" && file.datasetId && (
+        <DatasetUploadProcessing
+          projectId={projectId}
+          datasetId={file.datasetId}
+          onReady={onReady}
+          onViewDataset={onReady}
+        />
+      )}
+    </VStack>
+  );
+}
+
+export function BulkUploadDrawer({
+  open,
+  onClose,
+  onUploaded,
+}: {
+  open: boolean;
+  onClose: () => void;
+  /** Called as files reach `ready` so the host can refresh the datasets list. */
+  onUploaded?: () => void;
+}) {
+  const { project } = useOrganizationTeamProject();
+  const projectId = project?.id;
+  const bulk = useBulkUpload(projectId);
+
+  const onDropFiles = (fileList: FileList | null) => {
+    if (fileList && fileList.length > 0) {
+      void bulk.addFiles(Array.from(fileList));
+    }
+  };
+
+  return (
+    <Drawer.Root
+      open={open}
+      onOpenChange={({ open: o }) => !o && onClose()}
+      size="xl"
+    >
+      <Drawer.Content bg="bg">
+        <Drawer.CloseTrigger />
+        <Drawer.Header>
+          <Heading>Bulk upload</Heading>
+        </Drawer.Header>
+        <Drawer.Body>
+          <VStack align="stretch" gap={4} width="full">
+            <Box
+              as="label"
+              borderWidth="2px"
+              borderStyle="dashed"
+              borderColor="border"
+              borderRadius="xl"
+              padding={8}
+              textAlign="center"
+              cursor="pointer"
+              _hover={{ borderColor: "blue.300", bg: "blue.500/5" }}
+              onDragOver={(e: React.DragEvent) => e.preventDefault()}
+              onDrop={(e: React.DragEvent) => {
+                e.preventDefault();
+                onDropFiles(e.dataTransfer?.files ?? null);
+              }}
+            >
+              <input
+                type="file"
+                multiple
+                accept=".csv,.json,.jsonl"
+                style={{ display: "none" }}
+                onChange={(e) => {
+                  onDropFiles(e.target.files);
+                  e.target.value = "";
+                }}
+              />
+              <Text color="fg" fontSize="md">
+                Drag and drop files, or{" "}
+                <Text as="span" color="blue.500" fontWeight="medium">
+                  click to browse
+                </Text>
+              </Text>
+              <Text fontSize="xs" color="fg.muted">
+                Supported files: CSV, JSON, or JSONL — one dataset per file
+              </Text>
+            </Box>
+
+            {bulk.counts.total > 0 && (
+              <HStack
+                fontSize="13px"
+                color="fg.muted"
+                gap={3}
+                data-testid="bulk-summary"
+              >
+                <Text>{bulk.counts.total} files</Text>
+                {bulk.counts.ready > 0 && (
+                  <Text color="green.600">{bulk.counts.ready} ready</Text>
+                )}
+                {bulk.counts.preparing > 0 && (
+                  <Text color="blue.500">
+                    {bulk.counts.preparing} preparing
+                  </Text>
+                )}
+                {bulk.counts.queued > 0 && (
+                  <Text>{bulk.counts.queued} queued</Text>
+                )}
+                {bulk.counts.failed > 0 && (
+                  <HStack gap={1} color="red.500">
+                    <AlertTriangle size={13} />
+                    <Text>{bulk.counts.failed} failed</Text>
+                  </HStack>
+                )}
+              </HStack>
+            )}
+
+            <VStack align="stretch" gap={2} width="full">
+              {bulk.files.map((file) => (
+                <BulkFileRow
+                  key={file.id}
+                  file={file}
+                  projectId={projectId ?? ""}
+                  onRemove={() => bulk.removeFile(file.id)}
+                  onCancel={() => bulk.cancelFile(file.id)}
+                  onRetry={() => void bulk.retryFile(file.id)}
+                  onColumns={(next) => bulk.setColumnTypes(file.id, next)}
+                  onReady={() => {
+                    bulk.markReady(file.id);
+                    onUploaded?.();
+                  }}
+                />
+              ))}
+            </VStack>
+
+            <HStack width="full">
+              <Spacer />
+              <Button variant="ghost" onClick={onClose}>
+                Close
+              </Button>
+              <Button
+                colorPalette="blue"
+                disabled={!bulk.hasUploadable || !projectId}
+                onClick={() => bulk.start()}
+              >
+                Upload all
+              </Button>
+            </HStack>
+          </VStack>
+        </Drawer.Body>
+      </Drawer.Content>
+    </Drawer.Root>
+  );
+}

--- a/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
@@ -303,7 +303,20 @@ export function BulkUploadDrawer({
                 type="file"
                 multiple
                 accept=".csv,.json,.jsonl"
-                style={{ display: "none" }}
+                aria-label="Add files for bulk upload"
+                // Visually hidden but kept in the tab order (not display:none) so
+                // the picker is reachable + operable by keyboard.
+                style={{
+                  position: "absolute",
+                  width: 1,
+                  height: 1,
+                  padding: 0,
+                  margin: -1,
+                  overflow: "hidden",
+                  clip: "rect(0 0 0 0)",
+                  whiteSpace: "nowrap",
+                  border: 0,
+                }}
                 onChange={(e) => {
                   onDropFiles(e.target.files);
                   e.target.value = "";

--- a/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
@@ -1,13 +1,13 @@
 /**
  * Bulk upload (D1/D2/D4/D6-9 UI): a dedicated drawer to drop several files at
  * once. Each file is its own row with an inline collapsed column-type confirm;
- * "Upload all" prepares them in the background, independently. Reuses the
- * single-flow's `DatasetUploadProcessing` poller for each row's processing tail.
+ * "Upload all" prepares them in the background, independently. Shares the
+ * single-file dropzone visuals (dotted grid + growing cloud + rainbow) so the
+ * two flows look identical.
  */
 import {
   Box,
   Button,
-  Collapsible,
   Heading,
   HStack,
   Input,
@@ -17,19 +17,26 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
 import {
   AlertTriangle,
   CheckCircle,
   ChevronDown,
+  ChevronUp,
   RefreshCw,
   X,
-  XCircle,
 } from "react-feather";
 import { formatFileSize } from "react-papaparse";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { DatasetColumns } from "~/server/datasets/types";
+import { api } from "~/utils/api";
 import { Drawer } from "../../ui/drawer";
-import { DatasetUploadProcessing } from "../UploadCSVDrawer";
+import {
+  DROPZONE_DOTTED_STYLE,
+  DropzonePrompt,
+  dropzoneSurfaceProps,
+  RAINBOW_TEXT_CSS,
+} from "../datasetDropzoneStyles";
 import { type BulkFile, useBulkUpload } from "./useBulkUpload";
 
 const COLUMN_TYPE_OPTIONS = [
@@ -41,6 +48,20 @@ const COLUMN_TYPE_OPTIONS = [
   "json",
   "image",
 ] as const;
+
+// Visually hidden but kept in the tab order (not display:none) so the picker is
+// reachable + operable by keyboard.
+const SR_ONLY_INPUT: React.CSSProperties = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0 0 0 0)",
+  whiteSpace: "nowrap",
+  border: 0,
+};
 
 /** Inline, compact column-type list for one file: rename + retype only (the
  *  confirmed columns must stay positionally 1:1 with the file's headers — no
@@ -56,7 +77,7 @@ function BulkColumnFields({
     onChange(columnTypes.map((c, i) => (i === index ? { ...c, ...patch } : c)));
 
   return (
-    <VStack align="stretch" gap={2} width="full">
+    <VStack align="stretch" gap={2} width="full" paddingTop={2}>
       {columnTypes.map((col, index) => (
         <HStack key={index} gap={2} width="full">
           <Input
@@ -89,26 +110,32 @@ function BulkColumnFields({
   );
 }
 
-function StatusChip({ file }: { file: BulkFile }) {
+/** The right-aligned slot of a row: the confirm-types toggle while pending,
+ *  otherwise an inline status tracker (preparing/uploading rainbow → ready). */
+function RowTrailing({
+  file,
+  isOpen,
+  onToggle,
+}: {
+  file: BulkFile;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
   switch (file.status) {
-    case "ready":
+    case "pending":
+      if (!file.columnTypes || file.columnTypes.length === 0) return null;
       return (
-        <HStack gap={1} color="green.600" fontSize="13px">
-          <CheckCircle size={14} /> <Text>Ready</Text>
-        </HStack>
-      );
-    case "failed":
-    case "rejected":
-      return (
-        <HStack gap={1} color="red.500" fontSize="13px">
-          <XCircle size={14} />
-          <Text>
-            {file.rejectedReason === "unsupported"
-              ? "Unsupported file"
-              : file.rejectedReason === "too-large"
-                ? "Too large"
-                : (file.error ?? "Failed")}
-          </Text>
+        <HStack
+          as="button"
+          gap={1}
+          fontSize="13px"
+          color="blue.600"
+          cursor="pointer"
+          aria-label={`Confirm columns for ${file.name}`}
+          onClick={onToggle}
+        >
+          <Text>{file.columnTypes.length} columns — confirm types</Text>
+          {isOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
         </HStack>
       );
     case "queued":
@@ -118,11 +145,34 @@ function StatusChip({ file }: { file: BulkFile }) {
         </Text>
       );
     case "uploading":
+      return (
+        <Text fontSize="13px" fontWeight="medium" css={RAINBOW_TEXT_CSS}>
+          Uploading…
+        </Text>
+      );
     case "processing":
       return (
-        <HStack gap={1} color="blue.500" fontSize="13px">
-          <Spinner size="xs" /> <Text>Preparing…</Text>
+        <Text fontSize="13px" fontWeight="medium" css={RAINBOW_TEXT_CSS}>
+          Preparing…
+        </Text>
+      );
+    case "ready":
+      return (
+        <HStack gap={1} color="green.600" fontSize="13px">
+          <CheckCircle size={14} />
+          <Text>Ready</Text>
         </HStack>
+      );
+    case "failed":
+    case "rejected":
+      return (
+        <Text fontSize="13px" color="red.500">
+          {file.rejectedReason === "unsupported"
+            ? "Unsupported file"
+            : file.rejectedReason === "too-large"
+              ? "Too large"
+              : (file.error ?? "Failed")}
+        </Text>
       );
     case "cancelled":
       return (
@@ -143,6 +193,7 @@ function BulkFileRow({
   onRetry,
   onColumns,
   onReady,
+  onFailed,
 }: {
   file: BulkFile;
   projectId: string;
@@ -151,17 +202,44 @@ function BulkFileRow({
   onRetry: () => void;
   onColumns: (next: DatasetColumns) => void;
   onReady: () => void;
+  onFailed: (error?: string) => void;
 }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const isActive = file.status === "uploading" || file.status === "processing";
   const canConfirm =
     file.status === "pending" &&
-    file.columnTypes &&
+    !!file.columnTypes &&
     file.columnTypes.length > 0;
-  const isActive = file.status === "uploading" || file.status === "processing";
+
+  // Poll the dataset status inline once finalized (no nested container). The
+  // server normalizes off-thread; the row reports ready/failed in place.
+  const isPolling = file.status === "processing" && !!file.datasetId;
+  const statusQuery = api.dataset.getById.useQuery(
+    { projectId, datasetId: file.datasetId ?? "" },
+    {
+      enabled: isPolling,
+      refetchOnWindowFocus: false,
+      refetchInterval: (data: { status?: string } | null | undefined) =>
+        data?.status === "processing" ? 3000 : false,
+    },
+  );
+  const polledStatus = statusQuery.data?.status;
+  useEffect(() => {
+    if (!isPolling) return;
+    if (polledStatus === "ready") onReady();
+    else if (polledStatus === "failed") {
+      onFailed(
+        (statusQuery.data as { statusError?: string } | undefined)
+          ?.statusError ?? undefined,
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPolling, polledStatus]);
 
   return (
     <VStack
       align="stretch"
-      gap={2}
+      gap={0}
       padding={3}
       borderWidth="1px"
       borderRadius="lg"
@@ -172,16 +250,26 @@ function BulkFileRow({
       }
       bg="bg"
     >
-      <HStack gap={3} width="full">
+      <HStack gap={3} width="full" align="center">
         <VStack align="start" gap={0} flex={1} minW={0}>
-          <Text fontWeight="medium" truncate maxW="full">
+          <Text
+            fontWeight="medium"
+            truncate
+            maxW="full"
+            css={isActive ? RAINBOW_TEXT_CSS : undefined}
+          >
             {file.name}
           </Text>
           <Text fontSize="xs" color="fg.muted">
             {formatFileSize(file.file.size)}
           </Text>
         </VStack>
-        <StatusChip file={file} />
+        <Spacer />
+        <RowTrailing
+          file={file}
+          isOpen={isOpen}
+          onToggle={() => setIsOpen((o) => !o)}
+        />
         {file.status === "failed" && (
           <Button size="xs" variant="outline" onClick={onRetry}>
             <RefreshCw size={12} /> Retry
@@ -192,6 +280,7 @@ function BulkFileRow({
             as="button"
             aria-label="Cancel upload"
             color="fg.muted"
+            display="flex"
             _hover={{ color: "red.500" }}
             onClick={onCancel}
           >
@@ -202,6 +291,7 @@ function BulkFileRow({
             as="button"
             aria-label="Remove file"
             color="fg.muted"
+            display="flex"
             _hover={{ color: "red.500" }}
             onClick={onRemove}
           >
@@ -210,41 +300,8 @@ function BulkFileRow({
         )}
       </HStack>
 
-      {canConfirm && file.columnTypes && (
-        <Collapsible.Root>
-          <Collapsible.Trigger
-            asChild
-            aria-label={`Confirm columns for ${file.name}`}
-          >
-            <HStack
-              as="button"
-              gap={1}
-              fontSize="13px"
-              color="blue.600"
-              cursor="pointer"
-            >
-              <ChevronDown size={14} />
-              <Text>{file.columnTypes.length} columns — confirm types</Text>
-            </HStack>
-          </Collapsible.Trigger>
-          <Collapsible.Content>
-            <Box paddingTop={2}>
-              <BulkColumnFields
-                columnTypes={file.columnTypes}
-                onChange={onColumns}
-              />
-            </Box>
-          </Collapsible.Content>
-        </Collapsible.Root>
-      )}
-
-      {file.status === "processing" && file.datasetId && (
-        <DatasetUploadProcessing
-          projectId={projectId}
-          datasetId={file.datasetId}
-          onReady={onReady}
-          onViewDataset={onReady}
-        />
+      {isOpen && canConfirm && file.columnTypes && (
+        <BulkColumnFields columnTypes={file.columnTypes} onChange={onColumns} />
       )}
     </VStack>
   );
@@ -263,6 +320,7 @@ export function BulkUploadDrawer({
   const { project } = useOrganizationTeamProject();
   const projectId = project?.id;
   const bulk = useBulkUpload(projectId);
+  const [zoneHover, setZoneHover] = useState(false);
 
   const onDropFiles = (fileList: FileList | null) => {
     if (fileList && fileList.length > 0) {
@@ -279,23 +337,26 @@ export function BulkUploadDrawer({
       <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
-          <Heading>Bulk upload</Heading>
+          <Heading>Upload datasets</Heading>
         </Drawer.Header>
         <Drawer.Body>
           <VStack align="stretch" gap={4} width="full">
             <Box
               as="label"
-              borderWidth="2px"
-              borderStyle="dashed"
-              borderColor="border"
-              borderRadius="xl"
-              padding={8}
-              textAlign="center"
-              cursor="pointer"
-              _hover={{ borderColor: "blue.300", bg: "blue.500/5" }}
-              onDragOver={(e: React.DragEvent) => e.preventDefault()}
+              {...dropzoneSurfaceProps(zoneHover)}
+              style={DROPZONE_DOTTED_STYLE}
+              display="block"
+              onDragOver={(e: React.DragEvent) => {
+                e.preventDefault();
+                setZoneHover(true);
+              }}
+              onDragLeave={(e: React.DragEvent) => {
+                e.preventDefault();
+                setZoneHover(false);
+              }}
               onDrop={(e: React.DragEvent) => {
                 e.preventDefault();
+                setZoneHover(false);
                 onDropFiles(e.dataTransfer?.files ?? null);
               }}
             >
@@ -304,33 +365,13 @@ export function BulkUploadDrawer({
                 multiple
                 accept=".csv,.json,.jsonl"
                 aria-label="Add files for bulk upload"
-                // Visually hidden but kept in the tab order (not display:none) so
-                // the picker is reachable + operable by keyboard.
-                style={{
-                  position: "absolute",
-                  width: 1,
-                  height: 1,
-                  padding: 0,
-                  margin: -1,
-                  overflow: "hidden",
-                  clip: "rect(0 0 0 0)",
-                  whiteSpace: "nowrap",
-                  border: 0,
-                }}
+                style={SR_ONLY_INPUT}
                 onChange={(e) => {
                   onDropFiles(e.target.files);
                   e.target.value = "";
                 }}
               />
-              <Text color="fg" fontSize="md">
-                Drag and drop files, or{" "}
-                <Text as="span" color="blue.500" fontWeight="medium">
-                  click to browse
-                </Text>
-              </Text>
-              <Text fontSize="xs" color="fg.muted">
-                Supported files: CSV, JSON, or JSONL — one dataset per file
-              </Text>
+              <DropzonePrompt multiple />
             </Box>
 
             {bulk.counts.total > 0 && (
@@ -375,6 +416,7 @@ export function BulkUploadDrawer({
                     bulk.markReady(file.id);
                     onUploaded?.();
                   }}
+                  onFailed={(error) => bulk.markFailed(file.id, error)}
                 />
               ))}
             </VStack>

--- a/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
@@ -161,17 +161,23 @@ function EditableName({
     );
   }
   return (
-    <Text
-      fontWeight="medium"
-      truncate
+    <Button
+      type="button"
+      variant="plain"
+      size="sm"
+      height="auto"
+      minW={0}
       maxW="full"
-      cursor="text"
-      title="Click to rename"
+      paddingX={0}
+      justifyContent="flex-start"
+      title="Rename dataset"
       _hover={{ textDecoration: "underline dotted" }}
       onClick={() => setEditing(true)}
     >
-      {value}
-    </Text>
+      <Text as="span" fontWeight="medium" truncate maxW="full">
+        {value}
+      </Text>
+    </Button>
   );
 }
 
@@ -278,7 +284,10 @@ function BulkFileRow({
   onFailed: (error?: string) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
-  const isActive = file.status === "uploading" || file.status === "processing";
+  // Only an in-flight PUT is cancellable; a `processing` row is already
+  // finalized (its dataset exists) so it offers neither cancel nor remove.
+  const canCancel = file.status === "uploading";
+  const isProcessing = file.status === "processing";
   const canConfirm =
     file.status === "pending" &&
     !!file.columnTypes &&
@@ -345,7 +354,7 @@ function BulkFileRow({
             <RefreshCw size={12} /> Retry
           </Button>
         )}
-        {isActive ? (
+        {canCancel ? (
           <Box
             as="button"
             aria-label="Cancel upload"
@@ -356,7 +365,7 @@ function BulkFileRow({
           >
             <X size={16} />
           </Box>
-        ) : (
+        ) : isProcessing ? null : (
           <Box
             as="button"
             aria-label="Remove file"
@@ -482,7 +491,7 @@ export function BulkUploadDrawer({
                   onCancel={() => bulk.cancelFile(file.id)}
                   onRetry={() => void bulk.retryFile(file.id)}
                   onColumns={(next) => bulk.setColumnTypes(file.id, next)}
-                  onName={(next) => bulk.setName(file.id, next)}
+                  onName={(next) => bulk.setName({ id: file.id, name: next })}
                   onReady={() => {
                     bulk.markReady(file.id);
                     onUploaded?.();

--- a/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
@@ -219,7 +219,6 @@ describe("given the bulk upload drawer", () => {
       await user.upload(fileInput(), [csv("data.csv")]);
       await waitFor(() => expect(screen.getByText("data")).toBeInTheDocument());
 
-      // Click the name → it becomes a focused input; replace it.
       await user.click(screen.getByText("data"));
       const nameField = await screen.findByLabelText("Dataset name");
       await user.clear(nameField);

--- a/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
@@ -198,8 +198,8 @@ describe("given the bulk upload drawer", () => {
         ).toBeInTheDocument(),
       );
 
-      // Collapsed: the column inputs are not visible until expanded.
-      expect(screen.queryByLabelText("Column 1 name")).not.toBeVisible?.();
+      // Collapsed: the column inputs are not rendered until expanded.
+      expect(screen.queryByLabelText("Column 1 name")).not.toBeInTheDocument();
       await user.click(screen.getByText(/2 columns — confirm types/i));
 
       const nameInput = await screen.findByLabelText("Column 1 name");

--- a/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
@@ -352,6 +352,12 @@ describe("given the bulk upload drawer", () => {
     it("labels the file picker, remove, and column controls", async () => {
       const user = userEvent.setup();
       render_();
+      // The file picker is keyboard-reachable: a labelled input in the tab order
+      // (not display:none), so it can be opened without a mouse.
+      const picker = screen.getByLabelText(/add files for bulk upload/i);
+      expect(picker).toBeInTheDocument();
+      expect((picker as HTMLElement).style.display).not.toBe("none");
+
       await user.upload(fileInput(), [csv("data.csv")]);
       await waitFor(() => expect(screen.getByText("data")).toBeInTheDocument());
 

--- a/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the Bulk upload drawer: render the drawer with the
+ * directUpload service, the header parser, the per-row poller's tRPC query, and
+ * the project/router hooks mocked. Asserts the user-visible behaviour of the
+ * spec scenarios (rows, inline confirm, independent prep, failure/retry, cancel).
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import type { DatasetColumns } from "~/server/datasets/types";
+
+const requestDirectUpload = vi.fn();
+const putFileToPresignedUrl = vi.fn();
+const finalizeDirectUpload = vi.fn();
+const abortPendingUpload = vi.fn();
+const retryDatasetNormalize = vi.fn();
+vi.mock("../../services/directUpload", async (orig) => {
+  const actual = await orig<typeof import("../../services/directUpload")>();
+  return {
+    ...actual,
+    requestDirectUpload: (...a: unknown[]) => requestDirectUpload(...a),
+    putFileToPresignedUrl: (...a: unknown[]) => putFileToPresignedUrl(...a),
+    finalizeDirectUpload: (...a: unknown[]) => finalizeDirectUpload(...a),
+    abortPendingUpload: (...a: unknown[]) => abortPendingUpload(...a),
+    retryDatasetNormalize: (...a: unknown[]) => retryDatasetNormalize(...a),
+  };
+});
+
+const parseHeaderColumns = vi.fn();
+vi.mock("../../utils/parseHeaderColumns", () => ({
+  HEADER_PARSE_MAX_BYTES: 262144,
+  parseHeaderColumns: (...a: unknown[]) => parseHeaderColumns(...a),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj_1", slug: "proj" },
+  }),
+}));
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ closeDrawer: vi.fn() }),
+}));
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+// DatasetUploadProcessing (reused per row) polls dataset.getById — resolve ready.
+const getByIdQuery = vi.fn(() => ({
+  data: { id: "dataset_x", name: "n", status: "ready", columnTypes: [] },
+  isFetched: true,
+  refetch: vi.fn(),
+}));
+vi.mock("~/utils/api", () => ({
+  api: {
+    dataset: { getById: { useQuery: () => getByIdQuery() } },
+    useContext: () => ({}),
+  },
+}));
+
+import { BulkUploadDrawer } from "../BulkUploadDrawer";
+
+const twoCols: DatasetColumns = [
+  { name: "a", type: "string" },
+  { name: "b", type: "string" },
+];
+
+const csv = (name: string) =>
+  new File(["a,b\n1,2\n"], name, { type: "text/csv" });
+
+const render_ = (onUploaded = vi.fn()) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <BulkUploadDrawer open onClose={vi.fn()} onUploaded={onUploaded} />
+    </ChakraProvider>,
+  );
+
+const fileInput = () =>
+  document.querySelector('input[type="file"]') as HTMLInputElement;
+
+const uploadButton = () => screen.getByRole("button", { name: /upload all/i });
+
+beforeEach(() => {
+  requestDirectUpload.mockReset().mockResolvedValue({
+    datasetId: "dataset_1",
+    slug: "data",
+    uploadUrl: "https://s3.example/put",
+  });
+  putFileToPresignedUrl.mockReset().mockResolvedValue(undefined);
+  finalizeDirectUpload.mockReset().mockResolvedValue({ status: "processing" });
+  abortPendingUpload.mockReset().mockResolvedValue(undefined);
+  retryDatasetNormalize.mockReset().mockResolvedValue(undefined);
+  parseHeaderColumns.mockReset().mockResolvedValue(twoCols);
+});
+afterEach(() => cleanup());
+
+describe("given the bulk upload drawer", () => {
+  describe("when several files are dropped", () => {
+    /** @scenario Dropping several files lists one row per file */
+    it("lists one row per file with its name and size, and enables upload", async () => {
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [
+        csv("one.csv"),
+        csv("two.csv"),
+        csv("three.csv"),
+      ]);
+
+      await waitFor(() => {
+        expect(screen.getByText("one")).toBeInTheDocument();
+      });
+      expect(screen.getByText("two")).toBeInTheDocument();
+      expect(screen.getByText("three")).toBeInTheDocument();
+      expect(uploadButton()).toBeEnabled();
+    });
+  });
+
+  describe("when more files are added after the first drop", () => {
+    /** @scenario Adding more files appends to the list */
+    it("appends without replacing the earlier rows", async () => {
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("one.csv"), csv("two.csv")]);
+      await waitFor(() => expect(screen.getByText("one")).toBeInTheDocument());
+      await user.upload(fileInput(), [csv("three.csv"), csv("four.csv")]);
+
+      await waitFor(() => expect(screen.getByText("four")).toBeInTheDocument());
+      expect(screen.getByText("one")).toBeInTheDocument();
+      expect(screen.getByText("three")).toBeInTheDocument();
+    });
+  });
+
+  describe("when the same file is dropped twice", () => {
+    /** @scenario The same file dropped twice becomes two rows */
+    it("creates two independently-named rows", async () => {
+      const user = userEvent.setup();
+      render_();
+      const f = csv("dup.csv");
+      await user.upload(fileInput(), [f]);
+      await waitFor(() => expect(screen.getByText("dup")).toBeInTheDocument());
+      await user.upload(fileInput(), [csv("dup.csv")]);
+
+      // Two rows: "dup" and the deduped "dup (1)".
+      await waitFor(() =>
+        expect(screen.getByText("dup (1)")).toBeInTheDocument(),
+      );
+      expect(screen.getByText("dup")).toBeInTheDocument();
+    });
+  });
+
+  describe("when a file is removed before uploading", () => {
+    /** @scenario Removing a not-yet-started file drops only that row */
+    it("drops only that row", async () => {
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("keep.csv"), csv("drop.csv")]);
+      await waitFor(() => expect(screen.getByText("drop")).toBeInTheDocument());
+
+      // Two rows → two remove buttons in order; the second is the "drop" row.
+      await user.click(screen.getAllByLabelText(/remove file/i)[1]!);
+
+      await waitFor(() =>
+        expect(screen.queryByText("drop")).not.toBeInTheDocument(),
+      );
+      expect(screen.getByText("keep")).toBeInTheDocument();
+    });
+  });
+
+  describe("when the last file is removed", () => {
+    /** @scenario Removing the last file disables the upload action */
+    it("disables the upload action", async () => {
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("only.csv")]);
+      await waitFor(() => expect(screen.getByText("only")).toBeInTheDocument());
+
+      await user.click(screen.getByLabelText(/remove file/i));
+      await waitFor(() =>
+        expect(screen.queryByText("only")).not.toBeInTheDocument(),
+      );
+      expect(uploadButton()).toBeDisabled();
+    });
+  });
+
+  describe("when a file's columns are detected", () => {
+    /** @scenario Each file's columns are detected and shown collapsed */
+    /** @scenario Confirming columns never opens a separate drawer */
+    it("shows a collapsed confirm with text defaults, editable in place", async () => {
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("data.csv")]);
+      await waitFor(() =>
+        expect(
+          screen.getByText(/2 columns — confirm types/i),
+        ).toBeInTheDocument(),
+      );
+
+      // Collapsed: the column inputs are not visible until expanded.
+      expect(screen.queryByLabelText("Column 1 name")).not.toBeVisible?.();
+      await user.click(screen.getByText(/2 columns — confirm types/i));
+
+      const nameInput = await screen.findByLabelText("Column 1 name");
+      expect(nameInput).toHaveValue("a");
+      expect(screen.getByLabelText("Column 1 type")).toHaveValue("string");
+      // Editing happens in place — no separate dialog/drawer with a Save button.
+      expect(
+        screen.queryByRole("button", { name: /^save$/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when files are uploaded", () => {
+    /** @scenario Uploading prepares every file independently in the background */
+    it("prepares every file and each becomes ready on its own", async () => {
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("one.csv"), csv("two.csv")]);
+      await waitFor(() => expect(screen.getByText("one")).toBeInTheDocument());
+
+      await user.click(uploadButton());
+
+      await waitFor(() =>
+        expect(screen.getAllByText(/ready/i).length).toBeGreaterThanOrEqual(2),
+      );
+      expect(requestDirectUpload).toHaveBeenCalledTimes(2);
+    });
+
+    /** @scenario The types I confirmed are applied to that file's dataset */
+    it("sends the confirmed column types for that file", async () => {
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("data.csv")]);
+      await waitFor(() =>
+        expect(screen.getByText(/confirm types/i)).toBeInTheDocument(),
+      );
+      await user.click(screen.getByText(/confirm types/i));
+      await user.selectOptions(
+        await screen.findByLabelText("Column 1 type"),
+        "number",
+      );
+      await user.click(uploadButton());
+
+      await waitFor(() => expect(requestDirectUpload).toHaveBeenCalled());
+      expect(requestDirectUpload.mock.calls[0]![0].columnTypes).toEqual([
+        { name: "a", type: "number" },
+        { name: "b", type: "string" },
+      ]);
+    });
+
+    /** @scenario Files that share a name become distinct datasets */
+    it("uploads same-named files under distinct names", async () => {
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("data.csv")]);
+      await waitFor(() => expect(screen.getByText("data")).toBeInTheDocument());
+      await user.upload(fileInput(), [csv("data.csv")]);
+      await waitFor(() =>
+        expect(screen.getByText("data (1)")).toBeInTheDocument(),
+      );
+
+      await user.click(uploadButton());
+      await waitFor(() => expect(requestDirectUpload).toHaveBeenCalledTimes(2));
+      const names = requestDirectUpload.mock.calls.map((c) => c[0].name).sort();
+      expect(names).toEqual(["data", "data (1)"]);
+    });
+  });
+
+  describe("when one file fails", () => {
+    /** @scenario One file failing does not stop the others */
+    it("fails that row but the others still become ready", async () => {
+      requestDirectUpload
+        .mockResolvedValueOnce({
+          datasetId: "dataset_ok",
+          slug: "ok",
+          uploadUrl: "https://s3.example/put",
+        })
+        .mockRejectedValueOnce(new Error("boom"));
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("ok.csv"), csv("bad.csv")]);
+      await waitFor(() => expect(screen.getByText("ok")).toBeInTheDocument());
+
+      await user.click(uploadButton());
+
+      await waitFor(() =>
+        expect(screen.getByText(/boom/i)).toBeInTheDocument(),
+      );
+      expect(
+        screen.getByRole("button", { name: /retry/i }),
+      ).toBeInTheDocument();
+    });
+
+    /** @scenario Retrying a failed file re-runs only that file and creates no duplicate */
+    it("re-runs only the failed file on retry", async () => {
+      requestDirectUpload
+        .mockResolvedValueOnce({
+          datasetId: "dataset_ok",
+          slug: "ok",
+          uploadUrl: "https://s3.example/put",
+        })
+        .mockRejectedValueOnce(new Error("boom"))
+        .mockResolvedValueOnce({
+          datasetId: "dataset_retry",
+          slug: "bad",
+          uploadUrl: "https://s3.example/put",
+        });
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("ok.csv"), csv("bad.csv")]);
+      await waitFor(() => expect(screen.getByText("ok")).toBeInTheDocument());
+      await user.click(uploadButton());
+      await waitFor(() =>
+        expect(screen.getByText(/boom/i)).toBeInTheDocument(),
+      );
+
+      const before = requestDirectUpload.mock.calls.length;
+      await user.click(screen.getByRole("button", { name: /retry/i }));
+      await waitFor(() =>
+        expect(requestDirectUpload.mock.calls.length).toBe(before + 1),
+      );
+      // Only one more create — no duplicate for the already-succeeded file.
+    });
+  });
+
+  describe("when a batch exceeds the dataset allowance", () => {
+    /** @scenario A batch larger than my remaining dataset allowance */
+    it("fails the over-allowance files with a clear message, keeps the rest", async () => {
+      requestDirectUpload
+        .mockResolvedValueOnce({
+          datasetId: "d1",
+          slug: "a",
+          uploadUrl: "https://s3.example/put",
+        })
+        .mockRejectedValueOnce(new Error("dataset limit reached"));
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("a.csv"), csv("b.csv")]);
+      await waitFor(() => expect(screen.getByText("a")).toBeInTheDocument());
+      await user.click(uploadButton());
+
+      await waitFor(() =>
+        expect(screen.getByText(/limit reached/i)).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("accessibility", () => {
+    /** @scenario The bulk upload flow is operable by keyboard and screen reader */
+    it("labels the file picker, remove, and column controls", async () => {
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("data.csv")]);
+      await waitFor(() => expect(screen.getByText("data")).toBeInTheDocument());
+
+      expect(screen.getByLabelText(/remove file/i)).toBeInTheDocument();
+      await user.click(screen.getByText(/confirm types/i));
+      expect(await screen.findByLabelText("Column 1 name")).toBeInTheDocument();
+      expect(screen.getByLabelText("Column 1 type")).toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
@@ -212,6 +212,29 @@ describe("given the bulk upload drawer", () => {
     });
   });
 
+  describe("when a file's name is edited", () => {
+    it("renames the dataset in place and uploads under the new name", async () => {
+      const user = userEvent.setup();
+      render_();
+      await user.upload(fileInput(), [csv("data.csv")]);
+      await waitFor(() => expect(screen.getByText("data")).toBeInTheDocument());
+
+      // Click the name → it becomes a focused input; replace it.
+      await user.click(screen.getByText("data"));
+      const nameField = await screen.findByLabelText("Dataset name");
+      await user.clear(nameField);
+      await user.type(nameField, "renamed{Enter}");
+
+      await waitFor(() =>
+        expect(screen.getByText("renamed")).toBeInTheDocument(),
+      );
+
+      await user.click(uploadButton());
+      await waitFor(() => expect(requestDirectUpload).toHaveBeenCalled());
+      expect(requestDirectUpload.mock.calls[0]![0].name).toBe("renamed");
+    });
+  });
+
   describe("when files are uploaded", () => {
     /** @scenario Uploading prepares every file independently in the background */
     it("prepares every file and each becomes ready on its own", async () => {

--- a/langwatch/src/components/datasets/bulkUpload/__tests__/batchNameDedup.unit.test.ts
+++ b/langwatch/src/components/datasets/bulkUpload/__tests__/batchNameDedup.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { baseNameFromFilename, batchDedupeNames } from "../batchNameDedup";
+
+describe("baseNameFromFilename", () => {
+  describe("when the filename has an extension", () => {
+    it("strips the extension", () => {
+      expect(baseNameFromFilename("products.csv")).toBe("products");
+      expect(baseNameFromFilename("a.b.jsonl")).toBe("a.b");
+    });
+  });
+
+  describe("when the filename has no usable stem", () => {
+    it("falls back to a default name", () => {
+      expect(baseNameFromFilename(".csv")).toBe("New Dataset");
+      expect(baseNameFromFilename("   ")).toBe("New Dataset");
+    });
+  });
+});
+
+describe("batchDedupeNames", () => {
+  describe("given files that share a name", () => {
+    it("keeps the first and suffixes the rest distinctly", () => {
+      expect(batchDedupeNames(["data", "data", "other", "data"])).toEqual([
+        "data",
+        "data (1)",
+        "other",
+        "data (2)",
+      ]);
+    });
+
+    it("never collides a bumped name with a literal input of that suffix", () => {
+      expect(batchDedupeNames(["a", "a", "a (1)"])).toEqual([
+        "a",
+        "a (1)",
+        "a (1) (1)",
+      ]);
+    });
+  });
+
+  describe("given all-distinct names", () => {
+    it("returns them unchanged", () => {
+      expect(batchDedupeNames(["x", "y", "z"])).toEqual(["x", "y", "z"]);
+    });
+  });
+});

--- a/langwatch/src/components/datasets/bulkUpload/__tests__/bulkUploadOrchestrator.unit.test.ts
+++ b/langwatch/src/components/datasets/bulkUpload/__tests__/bulkUploadOrchestrator.unit.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from "vitest";
+import { DatasetNameConflictError } from "../../services/directUpload";
+import {
+  runWithConcurrency,
+  type UploadSingleFileDeps,
+  uploadSingleFile,
+} from "../bulkUploadOrchestrator";
+
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+};
+
+describe("runWithConcurrency", () => {
+  describe("given more items than the cap", () => {
+    it("never runs more than the cap at once and completes every item", async () => {
+      let active = 0;
+      let maxActive = 0;
+      const done: number[] = [];
+      await runWithConcurrency([0, 1, 2, 3, 4], 2, async (n) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await Promise.resolve();
+        await Promise.resolve();
+        done.push(n);
+        active -= 1;
+      });
+      expect(maxActive).toBe(2);
+      expect([...done].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it("starts a queued item as soon as a slot frees", async () => {
+      const gates = [deferred(), deferred(), deferred()];
+      const started: number[] = [];
+      const all = runWithConcurrency([0, 1, 2], 1, async (n) => {
+        started.push(n);
+        await gates[n]!.promise;
+      });
+
+      // cap 1 → only the first item runs; the rest are queued.
+      await Promise.resolve();
+      expect(started).toEqual([0]);
+
+      // Finishing item 0 frees the lane → item 1 starts.
+      gates[0]!.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(started).toEqual([0, 1]);
+
+      gates[1]!.resolve();
+      gates[2]!.resolve();
+      await all;
+      expect(started).toEqual([0, 1, 2]);
+    });
+  });
+});
+
+const file = (name = "data.csv") => new File(["a,b\n1,2\n"], name);
+
+const makeDeps = (
+  overrides: Partial<UploadSingleFileDeps> = {},
+): UploadSingleFileDeps => ({
+  requestDirectUpload: vi.fn().mockResolvedValue({
+    datasetId: "dataset_1",
+    slug: "data",
+    uploadUrl: "https://s3.example/put",
+  }),
+  putFileToPresignedUrl: vi.fn().mockResolvedValue(undefined),
+  finalizeDirectUpload: vi.fn().mockResolvedValue({
+    datasetId: "dataset_1",
+    status: "processing",
+  }),
+  abortPendingUpload: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+describe("uploadSingleFile", () => {
+  const bump = (current: string) => `${current} (1)`;
+
+  describe("given the happy path", () => {
+    it("creates, uploads, and finalizes, returning the dataset id", async () => {
+      const deps = makeDeps();
+      const result = await uploadSingleFile(
+        { projectId: "p1", name: "data", file: file(), nextName: bump },
+        deps,
+      );
+      expect(result).toEqual({ datasetId: "dataset_1", finalName: "data" });
+      expect(deps.putFileToPresignedUrl).toHaveBeenCalledTimes(1);
+      expect(deps.finalizeDirectUpload).toHaveBeenCalledWith({
+        projectId: "p1",
+        datasetId: "dataset_1",
+      });
+      expect(deps.abortPendingUpload).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the name conflicts (the batch-name race)", () => {
+    it("bumps the name and retries the create without reaping anything", async () => {
+      const requestDirectUpload = vi
+        .fn()
+        .mockRejectedValueOnce(new DatasetNameConflictError())
+        .mockResolvedValueOnce({
+          datasetId: "dataset_2",
+          slug: "data-1",
+          uploadUrl: "https://s3.example/put",
+        });
+      const deps = makeDeps({ requestDirectUpload });
+
+      const result = await uploadSingleFile(
+        { projectId: "p1", name: "data", file: file(), nextName: bump },
+        deps,
+      );
+
+      expect(result.finalName).toBe("data (1)");
+      expect(requestDirectUpload).toHaveBeenCalledTimes(2);
+      expect(requestDirectUpload.mock.calls[1]![0]).toMatchObject({
+        name: "data (1)",
+      });
+      // A conflict means no row was created, so nothing to reap.
+      expect(deps.abortPendingUpload).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the upload fails after the row was created", () => {
+    it("reaps the pending row and rethrows", async () => {
+      const putFileToPresignedUrl = vi
+        .fn()
+        .mockRejectedValue(new Error("CORS"));
+      const deps = makeDeps({ putFileToPresignedUrl });
+
+      await expect(
+        uploadSingleFile(
+          { projectId: "p1", name: "data", file: file(), nextName: bump },
+          deps,
+        ),
+      ).rejects.toThrow("CORS");
+
+      expect(deps.abortPendingUpload).toHaveBeenCalledWith({
+        projectId: "p1",
+        datasetId: "dataset_1",
+      });
+      expect(deps.finalizeDirectUpload).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the upload is cancelled mid-flight", () => {
+    it("reaps the pending row and rethrows the abort", async () => {
+      const abortError = new Error("aborted");
+      abortError.name = "AbortError";
+      const putFileToPresignedUrl = vi.fn().mockRejectedValue(abortError);
+      const deps = makeDeps({ putFileToPresignedUrl });
+
+      await expect(
+        uploadSingleFile(
+          { projectId: "p1", name: "data", file: file(), nextName: bump },
+          deps,
+        ),
+      ).rejects.toThrow("aborted");
+      expect(deps.abortPendingUpload).toHaveBeenCalledWith({
+        projectId: "p1",
+        datasetId: "dataset_1",
+      });
+    });
+  });
+});

--- a/langwatch/src/components/datasets/bulkUpload/__tests__/bulkUploadOrchestrator.unit.test.ts
+++ b/langwatch/src/components/datasets/bulkUpload/__tests__/bulkUploadOrchestrator.unit.test.ts
@@ -32,6 +32,7 @@ describe("runWithConcurrency", () => {
       expect([...done].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
     });
 
+    /** @scenario A large batch starts a few files and queues the rest */
     it("starts a queued item as soon as a slot frees", async () => {
       const gates = [deferred(), deferred(), deferred()];
       const started: number[] = [];
@@ -81,14 +82,22 @@ describe("uploadSingleFile", () => {
   const bump = (current: string) => `${current} (1)`;
 
   describe("given the happy path", () => {
-    it("creates, uploads, and finalizes, returning the dataset id", async () => {
+    /** @scenario Large files do not freeze the app while uploading */
+    it("creates, uploads, and finalizes, streaming the raw File (never read into memory)", async () => {
       const deps = makeDeps();
+      const theFile = file();
       const result = await uploadSingleFile(
-        { projectId: "p1", name: "data", file: file(), nextName: bump },
+        { projectId: "p1", name: "data", file: theFile, nextName: bump },
         deps,
       );
       expect(result).toEqual({ datasetId: "dataset_1", finalName: "data" });
+      // The raw File is handed to the PUT as-is — never read into an ArrayBuffer
+      // first — so a multi-GB file streams without freezing the tab.
       expect(deps.putFileToPresignedUrl).toHaveBeenCalledTimes(1);
+      const putCall = (deps.putFileToPresignedUrl as ReturnType<typeof vi.fn>)
+        .mock.calls[0]!;
+      expect(putCall[0]).toBe("https://s3.example/put");
+      expect(putCall[1]).toBe(theFile);
       expect(deps.finalizeDirectUpload).toHaveBeenCalledWith({
         projectId: "p1",
         datasetId: "dataset_1",

--- a/langwatch/src/components/datasets/bulkUpload/batchNameDedup.ts
+++ b/langwatch/src/components/datasets/bulkUpload/batchNameDedup.ts
@@ -22,6 +22,18 @@ export const baseNameFromFilename = (filename: string): string => {
   return trimmed === "" ? "New Dataset" : trimmed;
 };
 
+/**
+ * Increment a name's `" (k)"` suffix (or add `" (1)"`). Used by the orchestrator
+ * to pick the next candidate after a server slug 409 (a DB collision that the
+ * within-batch dedupe couldn't see — e.g. a name already taken by an existing
+ * dataset, or a concurrent create in another tab).
+ */
+export const bumpName = (name: string): string => {
+  const match = name.match(/^(.*) \((\d+)\)$/);
+  if (match) return `${match[1]} (${Number(match[2]) + 1})`;
+  return `${name} (1)`;
+};
+
 /** The next unused `"<name> (k)"` for k ≥ 1, given the names already taken. */
 const nextSuffixed = (name: string, taken: Set<string>): string => {
   let k = 1;

--- a/langwatch/src/components/datasets/bulkUpload/batchNameDedup.ts
+++ b/langwatch/src/components/datasets/bulkUpload/batchNameDedup.ts
@@ -1,0 +1,49 @@
+/**
+ * Bulk upload (D5): make the proposed dataset names within ONE batch distinct
+ * before any upload starts.
+ *
+ * The server's `findNextName` checks the DB, not the not-yet-created siblings in
+ * the same drop, so dropping two `data.csv` would propose "data" for both and the
+ * second `requestDirectUpload` would 409 on the slug. We dedupe within the batch
+ * up front ("data", "data (1)", …); a DB collision that survives this (a name
+ * already taken by an existing dataset, or a concurrent create) is handled
+ * separately by retrying the create with the next suffix (the orchestrator's
+ * 409 auto-retry).
+ */
+
+/** Strip the extension from a filename to seed the dataset name (matches the
+ *  single-upload flow's `proposeValidName`). Falls back to the whole name. */
+export const baseNameFromFilename = (filename: string): string => {
+  const dot = filename.lastIndexOf(".");
+  // dot > 0 → strip the extension; dot === 0 → a dotfile (no stem) → empty;
+  // dot < 0 → no extension, keep as-is.
+  const stem = dot > 0 ? filename.slice(0, dot) : dot === 0 ? "" : filename;
+  const trimmed = stem.trim();
+  return trimmed === "" ? "New Dataset" : trimmed;
+};
+
+/** The next unused `"<name> (k)"` for k ≥ 1, given the names already taken. */
+const nextSuffixed = (name: string, taken: Set<string>): string => {
+  let k = 1;
+  let candidate = `${name} (${k})`;
+  while (taken.has(candidate)) {
+    k += 1;
+    candidate = `${name} (${k})`;
+  }
+  return candidate;
+};
+
+/**
+ * Return one distinct name per input, preserving order. The first occurrence
+ * keeps its name; later collisions get `"<name> (1)"`, `"<name> (2)"`, … A
+ * literal input that equals an already-emitted suffix keeps bumping, so
+ * `["a","a","a (1)"]` → `["a","a (1)","a (1) (1)"]` — never a duplicate.
+ */
+export const batchDedupeNames = (names: string[]): string[] => {
+  const taken = new Set<string>();
+  return names.map((name) => {
+    const chosen = taken.has(name) ? nextSuffixed(name, taken) : name;
+    taken.add(chosen);
+    return chosen;
+  });
+};

--- a/langwatch/src/components/datasets/bulkUpload/bulkUploadOrchestrator.ts
+++ b/langwatch/src/components/datasets/bulkUpload/bulkUploadOrchestrator.ts
@@ -1,0 +1,135 @@
+/**
+ * Bulk upload (D3): the storage-agnostic orchestration core, decoupled from
+ * React so the hard parts are unit-testable.
+ *
+ *  - `runWithConcurrency` runs N items through at most `cap` workers at once; the
+ *    rest queue and start as slots free (the "queues the rest" behaviour).
+ *  - `uploadSingleFile` is one file's pipeline: requestDirectUpload → PUT →
+ *    finalize, reusing the single-upload primitives so S3-vs-local-vs-no-storage
+ *    stays abstracted by URL shape. It retries the CREATE under a fresh name on a
+ *    slug conflict (the batch-name race), and reaps the `uploading` row on any
+ *    post-create failure or cancel (single-flow parity — nothing half-created).
+ *
+ * Both take their collaborators as injected deps so tests drive them with fakes.
+ */
+
+import type { DatasetColumns } from "~/server/datasets/types";
+import {
+  abortPendingUpload,
+  DatasetNameConflictError,
+  finalizeDirectUpload,
+  putFileToPresignedUrl,
+  requestDirectUpload,
+} from "../services/directUpload";
+
+/** Max times we re-attempt the CREATE under a bumped name on a slug conflict
+ *  before giving up (a pathological run where every candidate is taken). */
+export const MAX_NAME_CONFLICT_RETRIES = 25;
+
+/**
+ * Run `items` through `worker` with at most `cap` in flight. `worker` MUST NOT
+ * throw — each item owns its own success/failure (per-file independence); a
+ * throwing worker would reject the whole pool. Resolves when every item is done.
+ */
+export async function runWithConcurrency<T>(
+  items: readonly T[],
+  cap: number,
+  worker: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const pump = async (): Promise<void> => {
+    const index = cursor++;
+    if (index >= items.length) return;
+    await worker(items[index]!, index);
+    return pump();
+  };
+  const lanes = Array.from(
+    { length: Math.max(1, Math.min(cap, items.length)) },
+    () => pump(),
+  );
+  await Promise.all(lanes);
+}
+
+export type UploadSingleFileDeps = {
+  requestDirectUpload: typeof requestDirectUpload;
+  putFileToPresignedUrl: typeof putFileToPresignedUrl;
+  finalizeDirectUpload: typeof finalizeDirectUpload;
+  abortPendingUpload: typeof abortPendingUpload;
+};
+
+const defaultDeps: UploadSingleFileDeps = {
+  requestDirectUpload,
+  putFileToPresignedUrl,
+  finalizeDirectUpload,
+  abortPendingUpload,
+};
+
+export type UploadSingleFileResult = {
+  datasetId: string;
+  /** The name actually used (may differ from the requested one after a conflict
+   *  retry) so the UI can reflect it. */
+  finalName: string;
+};
+
+/**
+ * Upload one file end to end. On a slug conflict (the within-batch / concurrent
+ * name race) it bumps the name via `nextName` and retries the CREATE — no row
+ * exists yet on a conflict (the server rejects the name BEFORE minting one), so
+ * the retry is clean. After the row IS created, any PUT/finalize failure OR a
+ * caller cancel (AbortError) reaps the `uploading` row before rethrowing, so a
+ * failed/cancelled file never leaves a half-created dataset behind.
+ */
+export async function uploadSingleFile(
+  params: {
+    projectId: string;
+    name: string;
+    file: File;
+    columnTypes?: DatasetColumns;
+    signal?: AbortSignal;
+    /** Produce the next candidate name when the current one conflicts. */
+    nextName: (current: string) => string;
+  },
+  deps: UploadSingleFileDeps = defaultDeps,
+): Promise<UploadSingleFileResult> {
+  const { projectId, file, columnTypes, signal, nextName } = params;
+  let name = params.name;
+
+  for (let attempt = 0; attempt < MAX_NAME_CONFLICT_RETRIES; attempt++) {
+    let datasetId: string;
+    let uploadUrl: string;
+    try {
+      const handle = await deps.requestDirectUpload({
+        projectId,
+        name,
+        filename: file.name,
+        columnTypes,
+      });
+      datasetId = handle.datasetId;
+      uploadUrl = handle.uploadUrl;
+    } catch (error) {
+      // Conflict = the name (slug) is taken — no row was created, so just bump
+      // the name and retry the create cleanly.
+      if (error instanceof DatasetNameConflictError) {
+        name = nextName(name);
+        continue;
+      }
+      throw error;
+    }
+
+    // The row now exists. Any failure past here must reap it (single-flow parity).
+    try {
+      await deps.putFileToPresignedUrl(uploadUrl, file, signal);
+      await deps.finalizeDirectUpload({ projectId, datasetId });
+      return { datasetId, finalName: name };
+    } catch (error) {
+      await deps
+        .abortPendingUpload({ projectId, datasetId })
+        .catch(() => undefined);
+      throw error;
+    }
+  }
+
+  throw new DatasetNameConflictError(
+    `Could not find an available name for "${file.name}"`,
+  );
+}

--- a/langwatch/src/components/datasets/bulkUpload/bulkUploadOrchestrator.ts
+++ b/langwatch/src/components/datasets/bulkUpload/bulkUploadOrchestrator.ts
@@ -116,17 +116,24 @@ export async function uploadSingleFile(
       throw error;
     }
 
-    // The row now exists. Any failure past here must reap it (single-flow parity).
+    // The row now exists. Reap ONLY on a PUT failure/cancel — at that point no
+    // bytes finalized, so the `uploading` row is genuinely orphaned.
     try {
       await deps.putFileToPresignedUrl(uploadUrl, file, signal);
-      await deps.finalizeDirectUpload({ projectId, datasetId });
-      return { datasetId, finalName: name };
     } catch (error) {
       await deps
         .abortPendingUpload({ projectId, datasetId })
         .catch(() => undefined);
       throw error;
     }
+
+    // PUT succeeded → committed to finalizing. A finalize failure must NOT reap:
+    // finalize may have already committed server-side (a transport blip on the
+    // response would otherwise delete a real dataset), and the reap is
+    // status-guarded to `uploading` anyway — a still-`uploading` row is left to
+    // the server's stale-upload TTL sweep, not blindly deleted here.
+    await deps.finalizeDirectUpload({ projectId, datasetId });
+    return { datasetId, finalName: name };
   }
 
   throw new DatasetNameConflictError(

--- a/langwatch/src/components/datasets/bulkUpload/useBulkUpload.ts
+++ b/langwatch/src/components/datasets/bulkUpload/useBulkUpload.ts
@@ -1,0 +1,297 @@
+/**
+ * Bulk upload (D3 React wrapper, + D5/D7/D8 wiring): owns the per-file rows and
+ * drives the orchestration core.
+ *
+ * The orchestrator is fire-and-forget — `start()` kicks `runWithConcurrency` as a
+ * detached promise chain, NOT a React effect — so closing the drawer (unmounting
+ * the hook) does not abort in-flight or queued files: they keep preparing and
+ * surface in the datasets list (the "close keeps preparing" behaviour). Status
+ * setters that fire after unmount are harmless no-ops.
+ */
+import { nanoid } from "nanoid";
+import { useCallback, useRef, useState } from "react";
+import type { DatasetColumns } from "~/server/datasets/types";
+import { detectFileFormat } from "~/server/datasets/upload-utils";
+import { retryDatasetNormalize } from "../services/directUpload";
+import { parseHeaderColumns } from "../utils/parseHeaderColumns";
+import {
+  baseNameFromFilename,
+  batchDedupeNames,
+  bumpName,
+} from "./batchNameDedup";
+import { runWithConcurrency, uploadSingleFile } from "./bulkUploadOrchestrator";
+
+/** Files prepared at once; the rest queue (the "queues the rest" behaviour). */
+export const BULK_UPLOAD_CONCURRENCY = 3;
+/** Client-side reject above this; mirrors the server `UPLOAD_MAX_BYTES` (5 GiB)
+ *  so an oversized file fails on its row before consuming a dataset slot. */
+export const BULK_MAX_UPLOAD_BYTES = 5 * 1024 * 1024 * 1024;
+/** Bounded headers read in parallel when files are added, so a big drop doesn't
+ *  jank the UI thread. */
+const HEADER_PARSE_BATCH = 4;
+
+export type BulkFileStatus =
+  | "pending" // accepted, ready to upload
+  | "rejected" // unsupported type / too large — never uploaded
+  | "queued" // accepted, waiting for an upload slot
+  | "uploading" // requestDirectUpload → PUT → finalize in flight
+  | "processing" // finalized; server is normalizing (poll for ready/failed)
+  | "ready"
+  | "failed"
+  | "cancelled";
+
+export type BulkFile = {
+  id: string;
+  file: File;
+  /** Proposed dataset name (deduped within the batch). */
+  name: string;
+  /** Parsed header columns; null = header unreadable → columns derived server-side. */
+  columns: DatasetColumns | null;
+  /** Confirmed columns (defaults to `columns`); sent to the server's normalize. */
+  columnTypes: DatasetColumns | null;
+  status: BulkFileStatus;
+  datasetId?: string;
+  error?: string;
+  rejectedReason?: "unsupported" | "too-large";
+};
+
+export type BulkUploadCounts = {
+  total: number;
+  ready: number;
+  preparing: number; // uploading + processing
+  queued: number;
+  failed: number;
+};
+
+const isSupportedType = (file: File): boolean => {
+  try {
+    detectFileFormat(file.name);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Parse `files` headers with a small concurrency so a large drop stays smooth. */
+const parseHeaders = async (
+  files: File[],
+): Promise<(DatasetColumns | null)[]> => {
+  const results: (DatasetColumns | null)[] = new Array(files.length).fill(null);
+  let cursor = 0;
+  const lane = async (): Promise<void> => {
+    const i = cursor++;
+    if (i >= files.length) return;
+    try {
+      results[i] = await parseHeaderColumns(files[i]!);
+    } catch {
+      results[i] = null;
+    }
+    return lane();
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(HEADER_PARSE_BATCH, files.length) }, lane),
+  );
+  return results;
+};
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error
+    ? error.message
+    : "Something went wrong preparing this file.";
+
+export function useBulkUpload(projectId: string | undefined) {
+  const [files, setFiles] = useState<BulkFile[]>([]);
+  // Mirror state for the detached orchestrator + actions to read without stale
+  // closures (the fire-and-forget loop must see the latest rows).
+  const filesRef = useRef<BulkFile[]>([]);
+  filesRef.current = files;
+  const controllersRef = useRef<Map<string, AbortController>>(new Map());
+
+  const update = useCallback((id: string, patch: Partial<BulkFile>) => {
+    setFiles((prev) => prev.map((f) => (f.id === id ? { ...f, ...patch } : f)));
+  }, []);
+
+  /** Add files: reject unsupported/oversized on their own rows, parse headers,
+   *  and dedupe names across the WHOLE current list (existing + new). */
+  const addFiles = useCallback(async (incoming: File[]) => {
+    if (incoming.length === 0) return;
+    const columnsList = await parseHeaders(incoming);
+    setFiles((prev) => {
+      const additions: BulkFile[] = incoming.map((file, i) => {
+        const columns = columnsList[i] ?? null;
+        if (!isSupportedType(file)) {
+          return makeRejected(file, columns, "unsupported");
+        }
+        if (file.size > BULK_MAX_UPLOAD_BYTES) {
+          return makeRejected(file, columns, "too-large");
+        }
+        return {
+          id: nanoid(),
+          file,
+          name: baseNameFromFilename(file.name),
+          columns,
+          columnTypes: columns,
+          status: "pending" as const,
+        };
+      });
+      // Dedupe names across uploadable rows only (rejected rows never create).
+      const merged = [...prev, ...additions];
+      const uploadable = merged.filter((f) => f.status !== "rejected");
+      const deduped = batchDedupeNames(uploadable.map((f) => f.name));
+      let k = 0;
+      return merged.map((f) =>
+        f.status === "rejected" ? f : { ...f, name: deduped[k++]! },
+      );
+    });
+  }, []);
+
+  const removeFile = useCallback((id: string) => {
+    controllersRef.current.get(id)?.abort();
+    controllersRef.current.delete(id);
+    setFiles((prev) => prev.filter((f) => f.id !== id));
+  }, []);
+
+  const setColumnTypes = useCallback(
+    (id: string, columnTypes: DatasetColumns) => update(id, { columnTypes }),
+    [update],
+  );
+
+  /** Run one file's pipeline, updating its status. Never throws (per-file
+   *  independence). */
+  const runOne = useCallback(
+    async (id: string) => {
+      if (!projectId) return;
+      const f = filesRef.current.find((x) => x.id === id);
+      if (!f) return;
+      const controller = new AbortController();
+      controllersRef.current.set(id, controller);
+      update(id, { status: "uploading", error: undefined });
+      try {
+        const { datasetId } = await uploadSingleFile({
+          projectId,
+          name: f.name,
+          file: f.file,
+          columnTypes: f.columnTypes ?? undefined,
+          signal: controller.signal,
+          nextName: bumpName,
+        });
+        // Finalized → server is normalizing; the row polls for ready/failed.
+        update(id, { status: "processing", datasetId });
+      } catch (error) {
+        if (
+          controller.signal.aborted ||
+          (error instanceof Error && error.name === "AbortError")
+        ) {
+          update(id, { status: "cancelled" });
+        } else {
+          update(id, { status: "failed", error: errorMessage(error) });
+        }
+      } finally {
+        controllersRef.current.delete(id);
+      }
+    },
+    [projectId, update],
+  );
+
+  /** Start the batch: queue every pending file, then drive the detached pool. */
+  const start = useCallback(() => {
+    const pending = filesRef.current.filter((f) => f.status === "pending");
+    if (pending.length === 0) return;
+    setFiles((prev) =>
+      prev.map((f) =>
+        f.status === "pending" ? { ...f, status: "queued" } : f,
+      ),
+    );
+    // Fire-and-forget (NOT an effect) → survives drawer close.
+    void runWithConcurrency(pending, BULK_UPLOAD_CONCURRENCY, (f) =>
+      runOne(f.id),
+    );
+  }, [runOne]);
+
+  /** Cancel an in-flight (or queued) file; reaps its row, leaves others alone. */
+  const cancelFile = useCallback(
+    (id: string) => {
+      const controller = controllersRef.current.get(id);
+      if (controller) {
+        controller.abort(); // runOne's catch reaps the row + marks cancelled
+      } else {
+        update(id, { status: "cancelled" });
+      }
+    },
+    [update],
+  );
+
+  /** Retry a failed file. Two modes (no duplicate dataset): if it already has a
+   *  dataset (finalized but preparation failed) re-drive normalize; otherwise it
+   *  never created a row (reaped on failure) so re-upload cleanly. */
+  const retryFile = useCallback(
+    async (id: string) => {
+      if (!projectId) return;
+      const f = filesRef.current.find((x) => x.id === id);
+      if (!f) return;
+      if (f.datasetId) {
+        update(id, { status: "processing", error: undefined });
+        try {
+          await retryDatasetNormalize({ projectId, datasetId: f.datasetId });
+        } catch (error) {
+          update(id, { status: "failed", error: errorMessage(error) });
+        }
+        return;
+      }
+      await runOne(id);
+    },
+    [projectId, runOne, update],
+  );
+
+  /** A row's poller reports the terminal server state. */
+  const markReady = useCallback(
+    (id: string) => update(id, { status: "ready" }),
+    [update],
+  );
+  const markFailed = useCallback(
+    (id: string, error?: string) => update(id, { status: "failed", error }),
+    [update],
+  );
+
+  const counts: BulkUploadCounts = {
+    total: files.length,
+    ready: files.filter((f) => f.status === "ready").length,
+    preparing: files.filter(
+      (f) => f.status === "uploading" || f.status === "processing",
+    ).length,
+    queued: files.filter((f) => f.status === "queued").length,
+    failed: files.filter(
+      (f) => f.status === "failed" || f.status === "rejected",
+    ).length,
+  };
+
+  const hasUploadable = files.some((f) => f.status === "pending");
+
+  return {
+    files,
+    counts,
+    hasUploadable,
+    addFiles,
+    removeFile,
+    setColumnTypes,
+    start,
+    cancelFile,
+    retryFile,
+    markReady,
+    markFailed,
+  };
+}
+
+const makeRejected = (
+  file: File,
+  columns: DatasetColumns | null,
+  reason: "unsupported" | "too-large",
+): BulkFile => ({
+  id: nanoid(),
+  file,
+  name: baseNameFromFilename(file.name),
+  columns,
+  columnTypes: columns,
+  status: "rejected",
+  rejectedReason: reason,
+});

--- a/langwatch/src/components/datasets/bulkUpload/useBulkUpload.ts
+++ b/langwatch/src/components/datasets/bulkUpload/useBulkUpload.ts
@@ -156,6 +156,17 @@ export function useBulkUpload(projectId: string | undefined) {
     [update],
   );
 
+  /** Rename a not-yet-uploaded file's dataset. A blank name is ignored (keeps the
+   *  current one); a within-batch collision is resolved at upload by the
+   *  orchestrator's 409 bump, so no re-dedupe is needed here. */
+  const setName = useCallback(
+    (id: string, name: string) => {
+      const trimmed = name.trim();
+      if (trimmed !== "") update(id, { name: trimmed });
+    },
+    [update],
+  );
+
   /** Run one file's pipeline, updating its status. Never throws (per-file
    *  independence). */
   const runOne = useCallback(
@@ -284,6 +295,7 @@ export function useBulkUpload(projectId: string | undefined) {
     addFiles,
     removeFile,
     setColumnTypes,
+    setName,
     start,
     cancelFile,
     retryFile,

--- a/langwatch/src/components/datasets/bulkUpload/useBulkUpload.ts
+++ b/langwatch/src/components/datasets/bulkUpload/useBulkUpload.ts
@@ -162,7 +162,11 @@ export function useBulkUpload(projectId: string | undefined) {
     async (id: string) => {
       if (!projectId) return;
       const f = filesRef.current.find((x) => x.id === id);
-      if (!f) return;
+      // Skip rows cancelled/removed while queued — runWithConcurrency captured
+      // them at start(), but a cancel before their turn must NOT create a
+      // dataset. (Status may still read "pending" here if the queue re-render
+      // hasn't flushed; only an explicit cancel/removal blocks the run.)
+      if (!f || f.status === "cancelled") return;
       const controller = new AbortController();
       controllersRef.current.set(id, controller);
       update(id, { status: "uploading", error: undefined });
@@ -213,8 +217,14 @@ export function useBulkUpload(projectId: string | undefined) {
     (id: string) => {
       const controller = controllersRef.current.get(id);
       if (controller) {
-        controller.abort(); // runOne's catch reaps the row + marks cancelled
-      } else {
+        controller.abort(); // uploading → abort the PUT; runOne reaps the row
+        return;
+      }
+      // No in-flight PUT: only a not-yet-started row can be cancelled. A
+      // `processing` row is already finalized (its dataset exists) and can't be
+      // un-created here, so leave it.
+      const f = filesRef.current.find((x) => x.id === id);
+      if (f && (f.status === "queued" || f.status === "pending")) {
         update(id, { status: "cancelled" });
       }
     },

--- a/langwatch/src/components/datasets/bulkUpload/useBulkUpload.ts
+++ b/langwatch/src/components/datasets/bulkUpload/useBulkUpload.ts
@@ -156,13 +156,17 @@ export function useBulkUpload(projectId: string | undefined) {
     [update],
   );
 
-  /** Rename a not-yet-uploaded file's dataset. A blank name is ignored (keeps the
-   *  current one); a within-batch collision is resolved at upload by the
-   *  orchestrator's 409 bump, so no re-dedupe is needed here. */
+  /** Rename a not-yet-uploaded file's dataset. Only `pending` rows can be renamed
+   *  (once queued/uploading the name is committed server-side); a blank name is
+   *  ignored (keeps the current one); a within-batch collision is resolved at
+   *  upload by the orchestrator's 409 bump, so no re-dedupe is needed here. */
   const setName = useCallback(
-    (id: string, name: string) => {
+    ({ id, name }: { id: string; name: string }) => {
       const trimmed = name.trim();
-      if (trimmed !== "") update(id, { name: trimmed });
+      if (trimmed === "") return;
+      const file = filesRef.current.find((f) => f.id === id);
+      if (file?.status !== "pending") return;
+      update(id, { name: trimmed });
     },
     [update],
   );

--- a/langwatch/src/components/datasets/datasetDropzoneStyles.tsx
+++ b/langwatch/src/components/datasets/datasetDropzoneStyles.tsx
@@ -1,0 +1,93 @@
+/**
+ * Shared dropzone visuals for the dataset upload flows (single-file
+ * `UploadCSVDrawer` and `BulkUploadDrawer`) so both look identical: the
+ * dotted-grid dashed surface, the cloud illustration that grows on hover/drag,
+ * and the rainbow "loading" text sheen used while a file prepares.
+ */
+import { Box, Text, VStack } from "@chakra-ui/react";
+import { keyframes } from "@emotion/react";
+import { CloudUpload } from "lucide-react";
+
+// Dotted-grid surface for the empty dropzone. Raw CSS (not a Chakra token) so
+// it composes over the theme-aware background color; `border` follows the
+// active color mode.
+export const DROPZONE_DOTTED_STYLE: React.CSSProperties = {
+  backgroundImage:
+    "radial-gradient(var(--chakra-colors-border) 1px, transparent 1px)",
+  backgroundSize: "16px 16px",
+};
+
+/** Shared Chakra props for the dashed dropzone surface; highlights when active
+ *  (dragging a file over it) and on hover, and softly grows the cloud icon. */
+export const dropzoneSurfaceProps = (active: boolean) => ({
+  borderRadius: "xl",
+  borderWidth: "2px",
+  borderStyle: "dashed" as const,
+  borderColor: active ? "blue.400" : "border",
+  bg: active ? "blue.500/10" : "transparent",
+  padding: 10,
+  textAlign: "center" as const,
+  cursor: "pointer",
+  width: "full",
+  transition: "border-color 0.15s ease, background-color 0.15s ease",
+  // Grow the icon while dragging a file over the zone; the icon's own
+  // transition animates the grow/shrink smoothly.
+  "& .lw-dropzone-icon": active ? { transform: "scale(1.12)" } : {},
+  _hover: {
+    borderColor: "blue.300",
+    bg: "blue.500/5",
+    "& .lw-dropzone-icon": { transform: "scale(1.12)" },
+  },
+});
+
+// PostHog's rainbow-scroll text sheen (same recipe as ShikiCommandBox): a
+// gradient clipped to the text whose background-position scrolls to animate.
+// Applied to a name/status while it uploads — one continuous "loading" tell.
+const lwRainbowScroll = keyframes`
+  0% { background-position-x: 0%; }
+  100% { background-position-x: 200%; }
+`;
+
+const LW_RAINBOW_GRADIENT =
+  "linear-gradient(90deg, #0143cb 0%, #2b6ff4 24%, #d23401 47%, #ff651f 66%, #fba000 83%, #0143cb 100%)";
+
+export const RAINBOW_TEXT_CSS = {
+  color: "transparent",
+  backgroundImage: LW_RAINBOW_GRADIENT,
+  backgroundClip: "text",
+  WebkitBackgroundClip: "text",
+  WebkitTextFillColor: "transparent",
+  backgroundSize: "200% 100%",
+  animation: `${lwRainbowScroll} 3s linear infinite`,
+  "@media (prefers-reduced-motion: reduce)": { animation: "none" },
+} as const;
+
+/**
+ * Empty-state contents of the dropzone: an upload illustration, the primary
+ * prompt (with "click to browse" reading as a link), and the supported types.
+ * `multiple` switches the copy to the plural (bulk) form.
+ */
+export function DropzonePrompt({ multiple = false }: { multiple?: boolean }) {
+  return (
+    <VStack gap={2}>
+      <Box
+        className="lw-dropzone-icon"
+        color="blue.400"
+        transition="transform 0.2s ease"
+        transformOrigin="center"
+      >
+        <CloudUpload size={36} strokeWidth={1.5} />
+      </Box>
+      <Text fontSize="md" color="fg">
+        {multiple ? "Drag and drop files, or " : "Drag and drop file, or "}
+        <Text as="span" color="blue.500" fontWeight="medium">
+          click to browse
+        </Text>
+      </Text>
+      <Text fontSize="xs" color="fg.muted">
+        Supported files: CSV, JSON, or JSONL
+        {multiple ? " — one dataset per file" : ""}
+      </Text>
+    </VStack>
+  );
+}

--- a/langwatch/src/components/datasets/datasetDropzoneStyles.tsx
+++ b/langwatch/src/components/datasets/datasetDropzoneStyles.tsx
@@ -19,12 +19,12 @@ export const DROPZONE_DOTTED_STYLE: React.CSSProperties = {
 
 /** Shared Chakra props for the dashed dropzone surface; highlights when active
  *  (dragging a file over it) and on hover, and softly grows the cloud icon. */
-export const dropzoneSurfaceProps = (active: boolean) => ({
+export const dropzoneSurfaceProps = (isActive: boolean) => ({
   borderRadius: "xl",
   borderWidth: "2px",
   borderStyle: "dashed" as const,
-  borderColor: active ? "blue.400" : "border",
-  bg: active ? "blue.500/10" : "transparent",
+  borderColor: isActive ? "blue.400" : "border",
+  bg: isActive ? "blue.500/10" : "transparent",
   padding: 10,
   textAlign: "center" as const,
   cursor: "pointer",
@@ -32,7 +32,7 @@ export const dropzoneSurfaceProps = (active: boolean) => ({
   transition: "border-color 0.15s ease, background-color 0.15s ease",
   // Grow the icon while dragging a file over the zone; the icon's own
   // transition animates the grow/shrink smoothly.
-  "& .lw-dropzone-icon": active ? { transform: "scale(1.12)" } : {},
+  "& .lw-dropzone-icon": isActive ? { transform: "scale(1.12)" } : {},
   _hover: {
     borderColor: "blue.300",
     bg: "blue.500/5",

--- a/langwatch/src/pages/[project]/datasets.tsx
+++ b/langwatch/src/pages/[project]/datasets.tsx
@@ -31,6 +31,7 @@ import { useDeleteDatasetConfirmation } from "~/hooks/useDeleteDatasetConfirmati
 import { useRouter } from "~/utils/compat/next-router";
 import { AddOrEditDatasetDrawer } from "../../components/AddOrEditDatasetDrawer";
 import { DashboardLayout } from "../../components/DashboardLayout";
+import { BulkUploadDrawer } from "../../components/datasets/bulkUpload/BulkUploadDrawer";
 import { CopyDatasetDialog } from "../../components/datasets/CopyDatasetDialog";
 import { UploadCSVDrawer } from "../../components/datasets/UploadCSVDrawer";
 import { Link } from "../../components/ui/link";
@@ -47,6 +48,7 @@ import { isHandledByGlobalHandler } from "../../utils/trpcError";
 function DatasetsPage() {
   const addEditDatasetDrawer = useDisclosure();
   const uploadCSVModal = useDisclosure();
+  const bulkUploadModal = useDisclosure();
   const { project } = useOrganizationTeamProject();
   const { isLiteMember } = useLiteMemberGuard();
   const router = useRouter();
@@ -180,6 +182,12 @@ function DatasetsPage() {
             onChange={(e) => setSearch(e.target.value)}
           />
         </InputGroup>
+        <PageLayout.HeaderButton
+          data-testid="bulk-upload-datasets"
+          onClick={() => bulkUploadModal.onOpen()}
+        >
+          <Upload height={17} width={17} strokeWidth={2.5} /> Bulk upload
+        </PageLayout.HeaderButton>
         <PageLayout.HeaderButton onClick={() => uploadCSVModal.onOpen()}>
           <Upload height={17} width={17} strokeWidth={2.5} /> Upload or Create
           Dataset
@@ -388,6 +396,13 @@ function DatasetsPage() {
           setTimeout(() => {
             addEditDatasetDrawer.onOpen();
           }, 100);
+        }}
+      />
+      <BulkUploadDrawer
+        open={bulkUploadModal.open}
+        onClose={bulkUploadModal.onClose}
+        onUploaded={() => {
+          void datasets.refetch();
         }}
       />
       <DeleteDialog />

--- a/specs/datasets/bulk-dataset-upload.feature
+++ b/specs/datasets/bulk-dataset-upload.feature
@@ -1,0 +1,203 @@
+Feature: Bulk dataset upload
+
+  Uploading datasets one at a time is slow when you have several. The "Bulk
+  upload" drawer lets you drop multiple files at once and turns each into its
+  own dataset, prepared in the background. Every file appears as its own row so
+  you can see — and fix — each one independently: the columns detected from the
+  file are shown collapsed with sensible defaults, and you only expand a row if
+  you want to rename a column or change its type before uploading. One file
+  failing never blocks the others, and you can retry just that one.
+
+  This is a separate surface from the single-file "Upload CSV" flow, which is
+  unchanged. The same file types are accepted as the single-file flow (CSV,
+  JSON, JSONL). Each row moves through its own states: ready-to-upload →
+  queued → preparing → ready, or → failed (with retry).
+
+  Background:
+    Given I am on the datasets page
+    And I open the "Bulk upload" drawer
+
+  # ── Adding files ────────────────────────────────────────────────────
+
+  @integration
+  Scenario: Dropping several files lists one row per file
+    When I drop three supported files onto the drawer
+    Then I see three rows, one per file
+    And each row shows the file's name and size
+    And the upload action is enabled
+
+  @integration
+  Scenario: Adding more files appends to the list
+    Given I have already added two files
+    When I add two more
+    Then the list shows four rows
+    And no earlier row is replaced
+
+  @integration
+  Scenario: The same file dropped twice becomes two rows
+    Given I have added a file
+    When I add the very same file again
+    Then there are two rows for it
+    And each row is tracked independently
+
+  @integration
+  Scenario: A file of an unsupported type is rejected on its own row
+    When I add a supported file and an unsupported file together
+    Then the unsupported file's row shows it was not accepted
+    And the supported file's row is still ready to upload
+    And the upload action uploads only the accepted file
+
+  @integration
+  Scenario: A file too large to upload is rejected on its own row
+    When I add a file larger than the maximum upload size
+    Then that file's row shows it is too large
+    And it is not uploaded
+    And it never counts against my dataset allowance
+
+  @integration
+  Scenario: Removing a not-yet-started file drops only that row
+    Given I have added three files
+    When I remove one of them
+    Then only that row is gone
+    And the other two remain ready to upload
+
+  @integration
+  Scenario: Removing the last file disables the upload action
+    Given I have added one file
+    When I remove it
+    Then the drawer returns to its empty, inviting state
+    And the upload action is disabled
+
+  # ── Confirming columns inline ───────────────────────────────────────
+
+  @integration
+  Scenario: Each file's columns are detected and shown collapsed
+    When I add a file
+    Then its detected columns are shown collapsed
+    And every column defaults to text
+    And I can expand the row to rename a column or change its type
+    And I cannot add or remove columns for that file
+
+  @integration
+  Scenario: Confirming columns never opens a separate drawer
+    When I add a file and expand its columns
+    Then I edit the column names and types in place on that row
+    And no extra drawer or dialog opens
+
+  @integration
+  Scenario: A file whose columns cannot be detected still uploads
+    Given I have added a file whose header cannot be read
+    When I start the upload
+    Then that file is still uploaded
+    And its columns are determined while it is prepared
+
+  # ── Uploading independently ─────────────────────────────────────────
+
+  @integration
+  Scenario: Uploading prepares every file independently in the background
+    Given I have added three files
+    When I start the upload
+    Then all three are accepted without me waiting on each one in turn
+    And each row reports its own progress
+    And each becomes ready on its own
+
+  @unit
+  Scenario: A large batch starts a few files and queues the rest
+    Given I have added more files than prepare at once
+    When I start the upload
+    Then some files begin preparing immediately
+    And the remaining files are shown as queued, not stuck
+    And a queued file starts as soon as an earlier one finishes
+
+  @integration
+  Scenario: The drawer summarises overall batch progress
+    Given I have started an upload of several files
+    Then I see how many are ready, preparing, queued, and failed
+    And the summary updates as each file changes state
+
+  @integration
+  Scenario: The types I confirmed are applied to that file's dataset
+    Given I have added a file and changed one column to a number
+    When I start the upload and it finishes preparing
+    Then that dataset reports the column as a number
+    And the other files are unaffected by my change
+
+  @integration
+  Scenario: Files that share a name become distinct datasets
+    Given I have added several files that all share the same name
+    When I start the upload
+    Then each becomes its own dataset with a distinct name
+    And none overwrites another
+
+  # ── Quota ───────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: A batch larger than my remaining dataset allowance
+    Given my project has room for fewer datasets than I have added
+    When I start the upload
+    Then the files that fit my allowance become ready
+    And the files beyond it fail with a clear "limit reached" message
+    And only the datasets actually created count against my allowance
+
+  # ── Per-file failure and recovery ───────────────────────────────────
+
+  @integration
+  Scenario: One file failing does not stop the others
+    Given I have added three files and one of them cannot be prepared
+    When I start the upload
+    Then the two good files still become ready
+    And the failed file shows an error with the option to retry
+
+  @integration
+  Scenario: An empty file fails on its own row instead of hanging
+    Given I have added an empty file alongside a good one
+    When I start the upload
+    Then the empty file's row shows it failed, not a stuck spinner
+    And the good file still becomes ready
+
+  @integration
+  Scenario: Retrying a failed file re-runs only that file and creates no duplicate
+    Given I have started an upload and one file has failed
+    When I retry that file
+    Then only that file is re-run
+    And it does not create a second dataset for the same file
+    And the files that already succeeded are not touched
+
+  @integration
+  Scenario: Cancelling one in-flight file leaves the others alone
+    Given I have started an upload of three files
+    When I cancel one file while it is still uploading
+    Then that file stops and leaves nothing half-created behind
+    And the other two continue preparing
+
+  @integration
+  Scenario: Closing the drawer mid-upload keeps the files preparing
+    Given I have started an upload of several files
+    When I close the drawer before they finish
+    Then the files keep preparing in the background
+    And I follow their progress in my datasets list as they become ready
+
+  # ── Storage-agnostic + large files ──────────────────────────────────
+
+  @unit
+  Scenario: Large files do not freeze the app while uploading
+    Given I have added a very large file
+    When I start the upload
+    Then the app stays responsive
+    And the file is sent without being read into the browser first
+
+  @integration
+  Scenario: Bulk upload works on a self-hosted install without object storage
+    Given a self-hosted install without object storage
+    When I bulk upload several files
+    Then each file is still accepted and prepared
+    And each dataset becomes ready
+
+  # ── Accessibility ───────────────────────────────────────────────────
+
+  @integration
+  Scenario: The bulk upload flow is operable by keyboard and screen reader
+    When I add files using the keyboard
+    Then I can add, expand, and remove a file without a mouse
+    And each row's status change is announced to assistive technology
+    And the expand control and the remove and retry actions are labelled

--- a/specs/datasets/bulk-dataset-upload.feature
+++ b/specs/datasets/bulk-dataset-upload.feature
@@ -40,14 +40,14 @@ Feature: Bulk dataset upload
     Then there are two rows for it
     And each row is tracked independently
 
-  @integration
+  @integration @unimplemented
   Scenario: A file of an unsupported type is rejected on its own row
     When I add a supported file and an unsupported file together
     Then the unsupported file's row shows it was not accepted
     And the supported file's row is still ready to upload
     And the upload action uploads only the accepted file
 
-  @integration
+  @integration @unimplemented
   Scenario: A file too large to upload is rejected on its own row
     When I add a file larger than the maximum upload size
     Then that file's row shows it is too large
@@ -84,7 +84,7 @@ Feature: Bulk dataset upload
     Then I edit the column names and types in place on that row
     And no extra drawer or dialog opens
 
-  @integration
+  @integration @unimplemented
   Scenario: A file whose columns cannot be detected still uploads
     Given I have added a file whose header cannot be read
     When I start the upload
@@ -109,7 +109,7 @@ Feature: Bulk dataset upload
     And the remaining files are shown as queued, not stuck
     And a queued file starts as soon as an earlier one finishes
 
-  @integration
+  @integration @unimplemented
   Scenario: The drawer summarises overall batch progress
     Given I have started an upload of several files
     Then I see how many are ready, preparing, queued, and failed
@@ -148,7 +148,7 @@ Feature: Bulk dataset upload
     Then the two good files still become ready
     And the failed file shows an error with the option to retry
 
-  @integration
+  @integration @unimplemented
   Scenario: An empty file fails on its own row instead of hanging
     Given I have added an empty file alongside a good one
     When I start the upload
@@ -163,14 +163,14 @@ Feature: Bulk dataset upload
     And it does not create a second dataset for the same file
     And the files that already succeeded are not touched
 
-  @integration
+  @integration @unimplemented
   Scenario: Cancelling one in-flight file leaves the others alone
     Given I have started an upload of three files
     When I cancel one file while it is still uploading
     Then that file stops and leaves nothing half-created behind
     And the other two continue preparing
 
-  @integration
+  @integration @unimplemented
   Scenario: Closing the drawer mid-upload keeps the files preparing
     Given I have started an upload of several files
     When I close the drawer before they finish
@@ -186,7 +186,7 @@ Feature: Bulk dataset upload
     Then the app stays responsive
     And the file is sent without being read into the browser first
 
-  @integration
+  @integration @unimplemented
   Scenario: Bulk upload works on a self-hosted install without object storage
     Given a self-hosted install without object storage
     When I bulk upload several files


### PR DESCRIPTION
## What

Bulk dataset upload — a dedicated drawer to drop several files at once; each becomes its own dataset, prepared in the background, with inline collapsed per-file column-type confirm and independent per-file failures. Validated spec: `specs/datasets/bulk-dataset-upload.feature` (planned via plan-work: challenged + test-tier reviewed).

## How

- **Storage-agnostic core** (`bulkUploadOrchestrator.ts`) — `runWithConcurrency` (cap 3 in-flight, queue the rest) + `uploadSingleFile` (per-file `requestDirectUpload → PUT → finalize`, reusing the single-flow primitives so **S3 / local-FS / no-storage stays abstracted by URL shape**). Retries the create under a bumped name on a slug 409 (the within-batch name race the server can't see); reaps the `uploading` row on any post-create failure or cancel.
- **Batch name dedup** (`batchNameDedup.ts`) — distinct names within one drop.
- **`useBulkUpload` hook** — per-file state machine; **fire-and-forget** `start()` (not a React effect) so closing the drawer doesn't kill in-flight/queued files; two-mode retry (re-upload vs re-normalize, no duplicate); bounded header parsing; aggregate counts.
- **`BulkUploadDrawer`** — multi-file dropzone, per-file rows, inline **collapsed** column confirm (rename/retype only, positionally 1:1 with the file), status chips, cancel/retry/remove, aggregate summary; reuses `DatasetUploadProcessing` per row for the processing tail.
- **Entry point** — "Bulk upload" button on the datasets page. Single-file flow untouched.

## Tests

- Orchestrator unit (11): cap/queue, 409 name-retry, reap-on-failure, reap-on-cancel, large-file streamed, name dedup.
- Drawer integration (13): rows, append, same-file-twice, remove/remove-last-disables, collapsed inline confirm (no separate drawer), independent prep → ready, confirmed types applied, distinct names, one-fails-others-survive, retry-only-that-file, quota limit message, a11y labels.
- **16/24 scenarios bound**; 8 `@unimplemented` (tracked gaps): unsupported/too-large row rejection, undetected-header upload, aggregate-summary, empty-file fail, cancel-while-in-flight, close-keeps-preparing, no-storage parity. The *logic* for several exists; their test harness is server-coupled or file-picker-finicky — follow-up.

Typecheck + biome clean; feature-parity green. No server changes (server already runs concurrent multi-dataset uploads + normalize).

## Deployment Impact

None. Client-only feature; no migrations, env, or infra. Reuses existing upload/normalize endpoints and the per-project storage resolution. Single-file upload flow is unchanged. Safe rolling deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Bulk Upload drawer on the datasets page with drag-and-drop or keyboard-accessible multi-file selection.
  * Added per-file rows showing upload status, file sizing, inline column type confirmation (when detected), and actions (retry/cancel/remove).
  * Added batch progress tracking with concurrency-limited processing and automatic in-batch dataset name deduplication.
* **Bug Fixes**
  * Improved resilience for duplicate filenames, per-file failures, retries, and cancellations so other files can continue unaffected.
  * Added clearer “limit reached” handling when allowance is exceeded.
* **Tests**
  * Added integration/unit coverage for the bulk upload UI flow, concurrency orchestration, deduplication, and the bulk upload feature spec.
* **Refactor**
  * Updated dataset upload dropzone visuals via shared, reusable styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->