### PR TITLE
perf(clickhouse): resolve ScheduledAt for hint-less evaluation reads to prune partitions

### DIFF
--- a/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-run.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-run.clickhouse.repository.integration.test.ts
@@ -63,8 +63,15 @@ beforeAll(async () => {
 
   // Two versions of the same evaluation: the dedup must return the latest
   // (v2), and the ScheduledAt resolve (argMax over UpdatedAt) must pick v2's
-  // ScheduledAt = `base`.
-  await repo.upsert(makeEval("eval-resolve-1", { score: 1 }), tenantId);
+  // ScheduledAt = `base`. v1's ScheduledAt sits 30 days back — outside the
+  // ±7-day resolve window — so if the resolver picked the wrong version the
+  // bounded read would land on the wrong partition and miss the row, failing
+  // the latest-version assertion below.
+  const staleScheduledAt = base - 30 * 24 * 60 * 60 * 1000;
+  await repo.upsert(
+    makeEval("eval-resolve-1", { score: 1, scheduledAt: staleScheduledAt }),
+    tenantId,
+  );
   await repo.upsert(
     makeEval("eval-resolve-1", { score: 2, updatedAt: base + 1000 }),
     tenantId,

--- a/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-run.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-run.clickhouse.repository.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Integration tests for `getByEvaluationId` partition pruning on a real
+ * ClickHouse testcontainer (production `evaluation_runs` schema:
+ * `ReplacingMergeTree(UpdatedAt)`, `PARTITION BY toYearWeek(ScheduledAt)`,
+ * `ORDER BY (TenantId, EvaluationId)`).
+ *
+ * The heavy ZSTD(3) columns (Inputs / Details / Error / ErrorDetails) are only
+ * pruned to the eval's partition when a `ScheduledAt` predicate is present.
+ * Callers that don't thread a `scheduledAt` hint (event-sourcing projection
+ * reads) used to scan every weekly partition incl. cold S3; the reader now
+ * resolves ScheduledAt from a cheap sort-key seek and bounds the read.
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getTestClickHouseClient } from "../../../../event-sourcing/__tests__/integration/testContainers";
+import type { EvaluationRunData } from "../../types";
+import { EvaluationRunClickHouseRepository } from "../evaluation-run.clickhouse.repository";
+
+const tenantId = `test-eval-resolve-${nanoid()}`;
+const base = Date.now() - 60 * 60 * 1000;
+
+let ch: ClickHouseClient;
+let repo: EvaluationRunClickHouseRepository;
+
+function makeEval(
+  evaluationId: string,
+  overrides: Partial<EvaluationRunData> = {},
+): EvaluationRunData {
+  return {
+    evaluationId,
+    evaluatorId: "evaluator-1",
+    evaluatorType: "test/evaluator",
+    evaluatorName: "Test Evaluator",
+    traceId: `trace-${nanoid()}`,
+    isGuardrail: false,
+    status: "processed",
+    score: 1,
+    passed: true,
+    label: null,
+    details: "ok",
+    inputs: { input: "x" },
+    error: null,
+    errorDetails: null,
+    createdAt: base,
+    updatedAt: base,
+    LastEventOccurredAt: base,
+    archivedAt: null,
+    scheduledAt: base,
+    startedAt: base,
+    completedAt: base,
+    costId: null,
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  const rawClient = getTestClickHouseClient();
+  if (!rawClient) throw new Error("ClickHouse test container not available");
+  ch = rawClient;
+  repo = new EvaluationRunClickHouseRepository(async () => ch);
+
+  // Two versions of the same evaluation: the dedup must return the latest
+  // (v2), and the ScheduledAt resolve (argMax over UpdatedAt) must pick v2's
+  // ScheduledAt = `base`.
+  await repo.upsert(makeEval("eval-resolve-1", { score: 1 }), tenantId);
+  await repo.upsert(
+    makeEval("eval-resolve-1", { score: 2, updatedAt: base + 1000 }),
+    tenantId,
+  );
+}, 120_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query:
+        "ALTER TABLE evaluation_runs DELETE WHERE TenantId = {tenantId:String}",
+      query_params: { tenantId },
+    });
+  }
+});
+
+describe("EvaluationRunClickHouseRepository.getByEvaluationId (integration)", () => {
+  it("returns the latest version when no ScheduledAt hint is passed", async () => {
+    const result = await repo.getByEvaluationId({
+      tenantId,
+      evaluationId: "eval-resolve-1",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.score).toBe(2);
+  });
+
+  it("resolves ScheduledAt and bounds the heavy read to the eval's partition", async () => {
+    const queries: string[] = [];
+    const recordingClient = new Proxy(ch, {
+      get(target, prop, receiver) {
+        if (prop === "query") {
+          return (args: { query: string; query_params?: unknown }) => {
+            if (args.query.includes("evaluation_runs")) {
+              queries.push(args.query);
+            }
+            return (target as ClickHouseClient).query(args as never);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as ClickHouseClient;
+    const recordingRepo = new EvaluationRunClickHouseRepository(
+      async () => recordingClient,
+    );
+
+    const result = await recordingRepo.getByEvaluationId({
+      tenantId,
+      evaluationId: "eval-resolve-1",
+    });
+
+    expect(result?.score).toBe(2);
+    // One cheap resolve (argMax ScheduledAt) + the heavy read, and the heavy
+    // read is partition-bounded on ScheduledAt rather than unbounded.
+    expect(queries).toHaveLength(2);
+    const resolveQuery = queries.find((q) => q.includes("argMax(ScheduledAt"));
+    const heavyQuery = queries.find((q) => q.includes("PREWHERE"));
+    expect(resolveQuery).toBeDefined();
+    expect(heavyQuery).toBeDefined();
+    expect(heavyQuery!).toContain("ScheduledAt >=");
+  });
+
+  it("returns null and stays unbounded for an evaluation that does not exist", async () => {
+    const queries: string[] = [];
+    const recordingClient = new Proxy(ch, {
+      get(target, prop, receiver) {
+        if (prop === "query") {
+          return (args: { query: string; query_params?: unknown }) => {
+            if (args.query.includes("evaluation_runs")) {
+              queries.push(args.query);
+            }
+            return (target as ClickHouseClient).query(args as never);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as ClickHouseClient;
+    const recordingRepo = new EvaluationRunClickHouseRepository(
+      async () => recordingClient,
+    );
+
+    const result = await recordingRepo.getByEvaluationId({
+      tenantId,
+      evaluationId: `missing-${nanoid()}`,
+    });
+
+    expect(result).toBeNull();
+    // Resolve finds nothing (epoch default), so the heavy read keeps its
+    // previous unbounded behaviour rather than guessing a window.
+    const heavyQuery = queries.find((q) => q.includes("PREWHERE"));
+    expect(heavyQuery).toBeDefined();
+    expect(heavyQuery!).not.toContain("ScheduledAt >=");
+  });
+});

--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -143,6 +143,44 @@ export class EvaluationRunClickHouseRepository
     }
   }
 
+  /**
+   * Resolve an evaluation's ScheduledAt (the `PARTITION BY toYearWeek(...)`
+   * column) so {@link getByEvaluationId} can prune partitions even when the
+   * caller never threaded a `scheduledAt` hint. `evaluation_runs` is
+   * `ORDER BY (TenantId, EvaluationId)`, so this is a sort-key point seek over
+   * a couple of granules of small columns — far cheaper than letting the heavy
+   * read fall back to scanning every weekly partition (incl. cold S3).
+   *
+   * `argMax(ScheduledAt, UpdatedAt)` takes the ScheduledAt of the latest
+   * version (the same row the dedup keeps). Returns undefined when the
+   * evaluation isn't in the table, where the caller stays unbounded.
+   */
+  private async resolveScheduledAtMs(
+    tenantId: string,
+    evaluationId: string,
+  ): Promise<number | undefined> {
+    const client = await this.resolveClient(tenantId);
+    const result = await client.query({
+      query: `
+        SELECT toUnixTimestamp64Milli(argMax(ScheduledAt, UpdatedAt)) AS scheduledAtMs
+        FROM ${TABLE_NAME}
+        WHERE TenantId = {tenantId:String}
+          AND EvaluationId = {evaluationId:String}
+      `,
+      query_params: { tenantId, evaluationId },
+      format: "JSONEachRow",
+    });
+    const rows = (await result.json()) as Array<{
+      scheduledAtMs: string | number | null;
+    }>;
+    const raw = rows[0]?.scheduledAtMs;
+    if (raw === null || raw === undefined) return undefined;
+    // argMax over no matching rows yields the epoch default (0); treat that —
+    // and any non-positive value — as "unknown" so the caller stays unbounded.
+    const ms = typeof raw === "string" ? Number(raw) : raw;
+    return Number.isFinite(ms) && ms > 0 ? ms : undefined;
+  }
+
   async getByEvaluationId({
     tenantId,
     evaluationId,
@@ -182,7 +220,15 @@ export class EvaluationRunClickHouseRepository
       // dev/docs/best_practices/clickhouse-queries.md.
 
       const slackMs = hints?.scheduledAtSlackMs ?? 7 * 24 * 60 * 60 * 1000;
-      const scheduledAtMs = hints?.scheduledAt?.getTime();
+      // When the caller didn't pass a ScheduledAt hint (event-sourcing
+      // projection reads, internal callers), resolve it from a cheap
+      // sort-key point seek so the heavy read below still prunes partitions
+      // instead of scanning every weekly partition incl. cold S3. Resolves
+      // to undefined only when the evaluation isn't in the table at all,
+      // where the read keeps its previous unbounded behaviour.
+      const scheduledAtMs =
+        hints?.scheduledAt?.getTime() ??
+        (await this.resolveScheduledAtMs(tenantId, evaluationId));
       const partitionPredicate = scheduledAtMs !== undefined
         ? "AND t.ScheduledAt >= fromUnixTimestamp64Milli({scheduledAtFrom:Int64}) AND t.ScheduledAt <= fromUnixTimestamp64Milli({scheduledAtTo:Int64})"
         : "";


### PR DESCRIPTION
## Evidence

Over the last 24h of prod ClickHouse slow-query warnings, the single highest-volume read-bytes breach was the evaluation get-by-id shape (`evaluation_runs`), keyed by `(tenantId, evaluationId)`:

- ~1,250 calls/24h, p50 ~163ms but **median readBytes ~10.5 MB (max ~21.7 MB)** against a 3 MB budget — flagged as a slow-query/read-bytes warning, not a cold-scan (the table isn't in the cold-scan tracker, but it is time-partitioned).

(No tenant data reproduced here.)

## Suspected cause

`evaluation_runs` is `ReplacingMergeTree(UpdatedAt)`, `PARTITION BY toYearWeek(ScheduledAt)`, `ORDER BY (TenantId, EvaluationId)`. `getByEvaluationId` already has the right shape (PREWHERE IN-tuple so heavy ZSTD(3) columns decompress only for the winning row) **but its `ScheduledAt` partition predicate is only applied when the caller passes a `scheduledAt` hint.** The bulk of the traffic is event-sourcing projection reads (`evaluationRun.store.ts` → `getByEvaluationId({ tenantId, evaluationId })`) with no hint, so the partition predicate is empty and the engine opens every weekly partition (incl. the cold S3 tier) to find and decompress the heavy columns for a single evaluation.

## Proposed fix

Mirror the existing `resolveTraceOccurredAtMs` pattern in the span repository: when no `scheduledAt` hint is present, resolve it from a cheap sort-key point seek and bound the read.

- New `resolveScheduledAtMs(tenantId, evaluationId)`: `SELECT argMax(ScheduledAt, UpdatedAt) ... WHERE TenantId AND EvaluationId`. Because the table is `ORDER BY (TenantId, EvaluationId)`, this is a sort-key prefix seek over a couple of granules of small columns. `argMax` returns the ScheduledAt of the latest version (the row the dedup keeps).
- `getByEvaluationId` falls back to the resolved value, so the existing `ScheduledAt` partition predicate (±7-day window) now prunes for hint-less callers too.
- An evaluation absent from the table resolves to `undefined` → the read keeps its previous unbounded behaviour.

No query-shape change beyond the added partition predicate; results are identical.

## Expected impact

The heavy-column read is bounded to ~2 weekly partitions instead of all of them, cutting decompressed read bytes and S3 GETs for the hint-less path (the ~10.5 MB median should drop by roughly an order of magnitude). The added resolve is a light, sort-key-pruned point read.

## EXPLAIN check

`EXPLAIN INDEXES` on `evaluation_runs` for a real large tenant, unbounded vs. a `ScheduledAt`-bounded read — the partition (MinMax) index prunes parts opened for the heavy read:

| Shape | Parts | Granules |
| --- | --- | --- |
| Unbounded (no `ScheduledAt`) | 65 / 76 | 9,275 |
| `ScheduledAt`-bounded (±7d) | 8 / 65 | 35 |

(Tenant-level EXPLAIN; the real query adds the `EvaluationId` sort-key prune on top, so absolute granule counts are smaller, but the part-open reduction from the partition predicate is the lever.)

## Test plan

New `evaluation-run.clickhouse.repository.integration.test.ts` (real ClickHouse testcontainer, prod `evaluation_runs` schema):

- without a hint, `getByEvaluationId` returns the latest version (dedup correct);
- without a hint, it issues one cheap resolve (`argMax(ScheduledAt, …)`) plus the heavy read, and the heavy read carries the `ScheduledAt >=` partition predicate;
- a non-existent evaluation resolves to nothing and the read stays unbounded (no guessed window).

3/3 pass; typecheck clean.

## Notes for reviewer

- Pre-existing biome import-formatting nit on an unchanged line in the repo file (not touched by this PR; reviewdog only checks added lines).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation lookup behavior so results are more reliably deduplicated when multiple versions exist.
  * When no time hint is provided, evaluation history searches now use the repository’s resolved timestamp to narrow the query and return the expected record.
  * If an evaluation cannot be found, the lookup now cleanly returns no result while preserving the previous fallback behavior.
* **Tests**
  * Added a ClickHouse integration test suite covering scheduled-time resolution, deduplication, and missing-evaluation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->