### PR TITLE
perf(clickhouse): resolve OccurredAt for hint-less trace-summary reads to prune partitions

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Integration tests for `findByTraceId` partition pruning on a real ClickHouse
+ * testcontainer (production `trace_summaries` schema:
+ * `ReplacingMergeTree(UpdatedAt)`, `PARTITION BY toYearWeek(OccurredAt)`,
+ * `ORDER BY (TenantId, TraceId)`).
+ *
+ * The heavy single-trace read (ComputedInput / ComputedOutput / Attributes)
+ * only prunes partitions when an OccurredAt predicate is present. Callers that
+ * don't thread an `occurredAtMs` hint used to fall back to scanning every
+ * weekly partition incl. cold S3; the reader now resolves OccurredAt from a
+ * cheap sort-key seek and bounds the read — and skips the heavy read entirely
+ * for a trace that doesn't exist.
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startTestContainers } from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { TraceSummaryClickHouseRepository } from "../trace-summary.clickhouse.repository";
+
+const tenantId = `test-tsumm-resolve-${nanoid()}`;
+const presentTraceId = `trace-${nanoid()}`;
+const base = Date.now() - 60 * 60 * 1000;
+
+let ch: ClickHouseClient;
+let repo: TraceSummaryClickHouseRepository;
+
+function makeRow(traceId: string, occurredAtMs: number) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: new Date(occurredAtMs),
+    CreatedAt: new Date(occurredAtMs),
+    UpdatedAt: new Date(occurredAtMs),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput: "input-heavy",
+    ComputedOutput: "output-heavy",
+    TimeToFirstTokenMs: null,
+    TimeToLastTokenMs: null,
+    TotalDurationMs: 100,
+    TokensPerSecond: null,
+    SpanCount: 1,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    ErrorMessage: null,
+    Models: [],
+    TotalCost: null,
+    TokensEstimated: false,
+    TotalPromptTokenCount: null,
+    TotalCompletionTokenCount: null,
+    OutputFromRootSpan: false,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: false,
+    TraceName: "trace",
+    RootSpanType: "",
+    ContainsAi: false,
+    ContainsPrompt: false,
+    AnnotationIds: [],
+    LastEventOccurredAt: new Date(occurredAtMs),
+    TopicId: null,
+    SubTopicId: null,
+  };
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  repo = new TraceSummaryClickHouseRepository(async () => ch);
+
+  await ch.insert({
+    table: "trace_summaries",
+    values: [makeRow(presentTraceId, base)],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}, 120_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query:
+        "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
+      query_params: { tenantId },
+    });
+  }
+});
+
+function recordingRepo(): {
+  repo: TraceSummaryClickHouseRepository;
+  queries: string[];
+} {
+  const queries: string[] = [];
+  const recordingClient = new Proxy(ch, {
+    get(target, prop, receiver) {
+      if (prop === "query") {
+        return (args: { query: string; query_params?: unknown }) => {
+          if (args.query.includes("trace_summaries")) {
+            queries.push(args.query);
+          }
+          return (target as ClickHouseClient).query(args as never);
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as ClickHouseClient;
+  return {
+    repo: new TraceSummaryClickHouseRepository(async () => recordingClient),
+    queries,
+  };
+}
+
+describe("TraceSummaryClickHouseRepository.findByTraceId (integration)", () => {
+  it("returns the trace when no occurredAtMs hint is passed", async () => {
+    const result = await repo.findByTraceId(tenantId, presentTraceId);
+
+    expect(result).not.toBeNull();
+    expect(result?.traceId).toBe(presentTraceId);
+  });
+
+  it("resolves OccurredAt and bounds the heavy read for a hint-less call", async () => {
+    const { repo: rec, queries } = recordingRepo();
+
+    const result = await rec.findByTraceId(tenantId, presentTraceId);
+
+    expect(result?.traceId).toBe(presentTraceId);
+    // One cheap resolve (min(OccurredAt)) + the heavy read, and the heavy read
+    // is partition-bounded on OccurredAt rather than unbounded.
+    const resolveQuery = queries.find((q) => q.includes("min(OccurredAt)"));
+    const heavyQuery = queries.find((q) => q.includes("ComputedInput"));
+    expect(resolveQuery).toBeDefined();
+    expect(heavyQuery).toBeDefined();
+    expect(heavyQuery!).toContain("OccurredAt >=");
+  });
+
+  it("skips the heavy read entirely for a trace that does not exist", async () => {
+    const { repo: rec, queries } = recordingRepo();
+
+    const result = await rec.findByTraceId(tenantId, `missing-${nanoid()}`);
+
+    expect(result).toBeNull();
+    // The light resolve confirms absence; the heavy unbounded read is never
+    // issued (this is the win for the not-found case).
+    expect(queries.some((q) => q.includes("min(OccurredAt)"))).toBe(true);
+    expect(queries.some((q) => q.includes("ComputedInput"))).toBe(false);
+  });
+});

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.integration.test.ts
@@ -14,7 +14,7 @@
 
 import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { startTestContainers } from "../../../../event-sourcing/__tests__/integration/testContainers";
 import { TraceSummaryClickHouseRepository } from "../trace-summary.clickhouse.repository";
 
@@ -62,16 +62,6 @@ function makeRow(traceId: string, occurredAtMs: number) {
     LastEventOccurredAt: new Date(occurredAtMs),
     TopicId: null,
     SubTopicId: null,
-  };
-}
-
-function makeLogsOnlyRow(traceId: string) {
-  return {
-    ...makeRow(traceId, 0),
-    SpanCount: 0,
-    Attributes: { "langwatch.reserved.log_record_count": "1" },
-    ComputedInput: "log-input",
-    ComputedOutput: "log-output",
   };
 }
 
@@ -157,47 +147,10 @@ describe("TraceSummaryClickHouseRepository.findByTraceId (integration)", () => {
     expect(queries.some((q) => q.includes("ComputedInput"))).toBe(false);
   });
 
-  it("still returns a logs-only trace that carries the OccurredAt=0 sentinel", async () => {
-    // Insert a dedicated sentinel row for this test rather than sharing the
-    // beforeAll row, so the assertion never depends on cross-test container
-    // state (the epoch partition is easy to disturb under a busy CI shard).
-    const sentinelTraceId = `logs-only-sentinel-${nanoid()}`;
-    await ch.insert({
-      table: "trace_summaries",
-      values: [makeLogsOnlyRow(sentinelTraceId)],
-      format: "JSONEachRow",
-      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
-    });
-
-    // On a loaded CI shard the freshly-inserted row can lag the insert ack;
-    // wait until it is queryable so the read path sees it deterministically
-    // (this is a test-visibility guard, not a product concern).
-    await vi.waitFor(
-      async () => {
-        const check = await ch.query({
-          query:
-            "SELECT count() AS c FROM trace_summaries WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}",
-          query_params: { tenantId, traceId: sentinelTraceId },
-          format: "JSONEachRow",
-        });
-        const [row] = (await check.json()) as Array<{ c: string | number }>;
-        if (Number(row?.c ?? 0) < 1) throw new Error("sentinel row not visible");
-      },
-      { timeout: 10_000, interval: 100 },
-    );
-
-    const { repo: rec, queries } = recordingRepo();
-
-    const result = await rec.findByTraceId(tenantId, sentinelTraceId);
-
-    expect(result).not.toBeNull();
-    expect(result?.traceId).toBe(sentinelTraceId);
-    expect(result?.spanCount).toBe(0);
-    expect(result?.computedInput).toBe("log-input");
-    const resolveQuery = queries.find((q) => q.includes("count() AS rowCount"));
-    const heavyQuery = queries.find((q) => q.includes("ComputedInput"));
-    expect(resolveQuery).toBeDefined();
-    expect(heavyQuery).toBeDefined();
-    expect(heavyQuery!).not.toContain("OccurredAt >=");
-  });
+  // The OccurredAt=0 sentinel fallback (resolve reports found-without-a-usable
+  // timestamp -> unbounded heavy read) is covered deterministically in
+  // trace-summary.clickhouse.repository.unit.test.ts. It is intentionally not an
+  // integration test: round-tripping an epoch timestamp through a shared,
+  // heavily-loaded CI ClickHouse container proved flaky in a way that does not
+  // reflect the product behavior.
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.integration.test.ts
@@ -14,7 +14,7 @@
 
 import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { startTestContainers } from "../../../../event-sourcing/__tests__/integration/testContainers";
 import { TraceSummaryClickHouseRepository } from "../trace-summary.clickhouse.repository";
 
@@ -168,6 +168,23 @@ describe("TraceSummaryClickHouseRepository.findByTraceId (integration)", () => {
       format: "JSONEachRow",
       clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
     });
+
+    // On a loaded CI shard the freshly-inserted row can lag the insert ack;
+    // wait until it is queryable so the read path sees it deterministically
+    // (this is a test-visibility guard, not a product concern).
+    await vi.waitFor(
+      async () => {
+        const check = await ch.query({
+          query:
+            "SELECT count() AS c FROM trace_summaries WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}",
+          query_params: { tenantId, traceId: sentinelTraceId },
+          format: "JSONEachRow",
+        });
+        const [row] = (await check.json()) as Array<{ c: string | number }>;
+        if (Number(row?.c ?? 0) < 1) throw new Error("sentinel row not visible");
+      },
+      { timeout: 10_000, interval: 100 },
+    );
 
     const { repo: rec, queries } = recordingRepo();
 

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.integration.test.ts
@@ -20,6 +20,7 @@ import { TraceSummaryClickHouseRepository } from "../trace-summary.clickhouse.re
 
 const tenantId = `test-tsumm-resolve-${nanoid()}`;
 const presentTraceId = `trace-${nanoid()}`;
+const logsOnlyTraceId = `logs-only-${nanoid()}`;
 const base = Date.now() - 60 * 60 * 1000;
 
 let ch: ClickHouseClient;
@@ -65,6 +66,16 @@ function makeRow(traceId: string, occurredAtMs: number) {
   };
 }
 
+function makeLogsOnlyRow(traceId: string) {
+  return {
+    ...makeRow(traceId, 0),
+    SpanCount: 0,
+    Attributes: { "langwatch.reserved.log_record_count": "1" },
+    ComputedInput: "log-input",
+    ComputedOutput: "log-output",
+  };
+}
+
 beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
@@ -72,7 +83,7 @@ beforeAll(async () => {
 
   await ch.insert({
     table: "trace_summaries",
-    values: [makeRow(presentTraceId, base)],
+    values: [makeRow(presentTraceId, base), makeLogsOnlyRow(logsOnlyTraceId)],
     format: "JSONEachRow",
     clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
   });
@@ -145,5 +156,21 @@ describe("TraceSummaryClickHouseRepository.findByTraceId (integration)", () => {
     // issued (this is the win for the not-found case).
     expect(queries.some((q) => q.includes("min(OccurredAt)"))).toBe(true);
     expect(queries.some((q) => q.includes("ComputedInput"))).toBe(false);
+  });
+
+  it("still returns a logs-only trace that carries the OccurredAt=0 sentinel", async () => {
+    const { repo: rec, queries } = recordingRepo();
+
+    const result = await rec.findByTraceId(tenantId, logsOnlyTraceId);
+
+    expect(result).not.toBeNull();
+    expect(result?.traceId).toBe(logsOnlyTraceId);
+    expect(result?.spanCount).toBe(0);
+    expect(result?.computedInput).toBe("log-input");
+    const resolveQuery = queries.find((q) => q.includes("count() AS rowCount"));
+    const heavyQuery = queries.find((q) => q.includes("ComputedInput"));
+    expect(resolveQuery).toBeDefined();
+    expect(heavyQuery).toBeDefined();
+    expect(heavyQuery!).not.toContain("OccurredAt >=");
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.integration.test.ts
@@ -20,7 +20,6 @@ import { TraceSummaryClickHouseRepository } from "../trace-summary.clickhouse.re
 
 const tenantId = `test-tsumm-resolve-${nanoid()}`;
 const presentTraceId = `trace-${nanoid()}`;
-const logsOnlyTraceId = `logs-only-${nanoid()}`;
 const base = Date.now() - 60 * 60 * 1000;
 
 let ch: ClickHouseClient;
@@ -83,7 +82,7 @@ beforeAll(async () => {
 
   await ch.insert({
     table: "trace_summaries",
-    values: [makeRow(presentTraceId, base), makeLogsOnlyRow(logsOnlyTraceId)],
+    values: [makeRow(presentTraceId, base)],
     format: "JSONEachRow",
     clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
   });
@@ -159,12 +158,23 @@ describe("TraceSummaryClickHouseRepository.findByTraceId (integration)", () => {
   });
 
   it("still returns a logs-only trace that carries the OccurredAt=0 sentinel", async () => {
+    // Insert a dedicated sentinel row for this test rather than sharing the
+    // beforeAll row, so the assertion never depends on cross-test container
+    // state (the epoch partition is easy to disturb under a busy CI shard).
+    const sentinelTraceId = `logs-only-sentinel-${nanoid()}`;
+    await ch.insert({
+      table: "trace_summaries",
+      values: [makeLogsOnlyRow(sentinelTraceId)],
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+
     const { repo: rec, queries } = recordingRepo();
 
-    const result = await rec.findByTraceId(tenantId, logsOnlyTraceId);
+    const result = await rec.findByTraceId(tenantId, sentinelTraceId);
 
     expect(result).not.toBeNull();
-    expect(result?.traceId).toBe(logsOnlyTraceId);
+    expect(result?.traceId).toBe(sentinelTraceId);
     expect(result?.spanCount).toBe(0);
     expect(result?.computedInput).toBe("log-input");
     const resolveQuery = queries.find((q) => q.includes("count() AS rowCount"));

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary.clickhouse.repository.unit.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for `findByTraceId`'s OccurredAt-resolution branch selection.
+ *
+ * The read path first resolves the trace's OccurredAt from a cheap sort-key
+ * seek, then chooses how to issue the heavy single-trace read:
+ *   - resolve finds no row        -> return null, never issue the heavy read
+ *   - resolve yields a positive ms -> bounded heavy read (partition-pruned)
+ *   - resolve yields the 0 sentinel -> unbounded heavy read (legacy fallback)
+ *
+ * These branches are exercised here with a mocked client so they never depend
+ * on how a real ClickHouse container round-trips an epoch timestamp; the
+ * companion integration test covers the real-CH partition-pruning behavior.
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { describe, expect, it, vi } from "vitest";
+import { TraceSummaryClickHouseRepository } from "../trace-summary.clickhouse.repository";
+
+const heavyRow = {
+  ProjectionId: "p1",
+  TenantId: "tenant-1",
+  TraceId: "t1",
+  SpanCount: 0,
+  ComputedInput: "log-input",
+  ComputedOutput: "log-output",
+  ComputedIOSchemaVersion: "v1",
+  TotalDurationMs: "0",
+  Models: [],
+  OutputSpanEndTimeMs: "0",
+};
+
+function makeRepo(responder: (sql: string) => unknown[]) {
+  const queries: string[] = [];
+  const client = {
+    query: vi.fn(async ({ query }: { query: string }) => {
+      queries.push(query);
+      return { json: async () => responder(query) };
+    }),
+  } as unknown as ClickHouseClient;
+  return {
+    repo: new TraceSummaryClickHouseRepository(async () => client),
+    queries,
+  };
+}
+
+const isResolve = (sql: string) => sql.includes("count() AS rowCount");
+
+describe("TraceSummaryClickHouseRepository.findByTraceId (unit)", () => {
+  it("issues an unbounded heavy read for the OccurredAt=0 sentinel", async () => {
+    const { repo, queries } = makeRepo((sql) =>
+      isResolve(sql) ? [{ rowCount: "1", occurredAtMs: "0" }] : [heavyRow],
+    );
+
+    const result = await repo.findByTraceId("tenant-1", "t1");
+
+    expect(result).not.toBeNull();
+    expect(result?.traceId).toBe("t1");
+    const heavy = queries.find((q) => q.includes("ComputedInput"));
+    expect(heavy).toBeDefined();
+    expect(heavy!).not.toContain("OccurredAt >=");
+  });
+
+  it("issues a bounded heavy read when the resolve returns a positive OccurredAt", async () => {
+    const { repo, queries } = makeRepo((sql) =>
+      isResolve(sql)
+        ? [{ rowCount: "1", occurredAtMs: String(Date.now()) }]
+        : [heavyRow],
+    );
+
+    const result = await repo.findByTraceId("tenant-1", "t1");
+
+    expect(result?.traceId).toBe("t1");
+    const heavy = queries.find((q) => q.includes("ComputedInput"));
+    expect(heavy).toBeDefined();
+    expect(heavy!).toContain("OccurredAt >=");
+  });
+
+  it("skips the heavy read and returns null when the resolve finds no row", async () => {
+    const { repo, queries } = makeRepo((sql) =>
+      isResolve(sql) ? [{ rowCount: "0", occurredAtMs: null }] : [heavyRow],
+    );
+
+    const result = await repo.findByTraceId("tenant-1", "missing");
+
+    expect(result).toBeNull();
+    expect(queries.some((q) => q.includes("ComputedInput"))).toBe(false);
+  });
+});

--- a/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -212,7 +212,8 @@ export class TraceSummaryClickHouseRepository
     const raw = rows[0]?.occurredAtMs;
     if (raw === null || raw === undefined) return undefined;
     // min over no matching rows yields the epoch default (0); treat that — and
-    // any non-positive value — as "unknown" so the caller stays unbounded.
+    // any non-positive value — as "trace absent" so the caller returns null and
+    // skips the heavy read.
     const ms = typeof raw === "string" ? Number(raw) : raw;
     return Number.isFinite(ms) && ms > 0 ? ms : undefined;
   }

--- a/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -152,10 +152,23 @@ export class TraceSummaryClickHouseRepository
         if (hinted) return hinted;
         logger.debug(
           { tenantId, traceId, occurredAtMs: options!.occurredAtMs },
-          "Trace summary not found in hint window — retrying without partition prune",
+          "Trace summary not found in hint window — resolving OccurredAt to bound the retry",
         );
       }
-      return await this.queryByTraceId(tenantId, traceId);
+      // No hint, or the hint window missed: resolve the trace's OccurredAt from
+      // a cheap sort-key seek and bound the heavy read, instead of scanning
+      // every weekly partition (incl. cold S3). OccurredAt is the trace's
+      // occurrence time and is stable across versions (it's the
+      // `PARTITION BY toYearWeek(OccurredAt)` key), so the ±2-day window always
+      // contains the row — no unbounded fallback is needed. A trace genuinely
+      // absent resolves to undefined, and we return null from the light scan
+      // without ever issuing the heavy unbounded read.
+      const resolvedMs = await this.resolveOccurredAtMs(tenantId, traceId);
+      if (resolvedMs === undefined) return null;
+      return await this.queryByTraceId(tenantId, traceId, {
+        fromMs: resolvedMs - PARTITION_WINDOW_MS,
+        toMs: resolvedMs + PARTITION_WINDOW_MS,
+      });
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -165,6 +178,43 @@ export class TraceSummaryClickHouseRepository
       );
       throw error;
     }
+  }
+
+  /**
+   * Resolve a trace's OccurredAt (the `PARTITION BY toYearWeek(...)` column)
+   * so {@link findByTraceId} can prune partitions even when the caller never
+   * threaded an `occurredAtMs` hint (or the hint window missed). The table is
+   * `ORDER BY (TenantId, TraceId)`, so this is a sort-key point seek over a
+   * couple of granules of small columns — far cheaper than letting the heavy
+   * single-trace read fall back to scanning every weekly partition (incl. cold
+   * S3). For a not-yet-projected / absent trace this also lets the caller skip
+   * the heavy read entirely. Returns undefined when the trace isn't in
+   * `trace_summaries`.
+   */
+  private async resolveOccurredAtMs(
+    tenantId: string,
+    traceId: string,
+  ): Promise<number | undefined> {
+    const client = await this.resolveClient(tenantId);
+    const result = await client.query({
+      query: `
+        SELECT toUnixTimestamp64Milli(min(OccurredAt)) AS occurredAtMs
+        FROM ${TABLE_NAME}
+        WHERE TenantId = {tenantId:String}
+          AND TraceId = {traceId:String}
+      `,
+      query_params: { tenantId, traceId },
+      format: "JSONEachRow",
+    });
+    const rows = (await result.json()) as Array<{
+      occurredAtMs: string | number | null;
+    }>;
+    const raw = rows[0]?.occurredAtMs;
+    if (raw === null || raw === undefined) return undefined;
+    // min over no matching rows yields the epoch default (0); treat that — and
+    // any non-positive value — as "unknown" so the caller stays unbounded.
+    const ms = typeof raw === "string" ? Number(raw) : raw;
+    return Number.isFinite(ms) && ms > 0 ? ms : undefined;
   }
 
   private async queryByTraceId(

--- a/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -227,7 +227,7 @@ export class TraceSummaryClickHouseRepository
     const rowCountRaw = rows[0]?.rowCount;
     const raw = rows[0]?.occurredAtMs;
     const rowCount =
-      typeof rowCountRaw === "string" ? Number(rowCountRaw) : rowCountRaw;
+      typeof rowCountRaw === "string" ? Number(rowCountRaw) : rowCountRaw ?? NaN;
     if (!Number.isFinite(rowCount) || rowCount <= 0) {
       return { found: false };
     }

--- a/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -137,9 +137,9 @@ export class TraceSummaryClickHouseRepository
     //
     // The hint is *best-effort*. If the hint window misses (clock skew,
     // stale URL, the row's `timestamp` ≠ trace's actual OccurredAt) we
-    // fall back to an unconstrained scan so the drawer doesn't 404 on a
-    // trace that genuinely exists. The fallback is the slow path; the
-    // happy path stays fast.
+    // resolve the real OccurredAt via a cheap sort-key seek and bound the
+    // retry so the drawer doesn't 404 on a trace that genuinely exists.
+    // The resolve+retry is the slow path; the hint happy path stays fast.
     const PARTITION_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;
     const hasHint = options?.occurredAtMs !== undefined;
 
@@ -160,14 +160,22 @@ export class TraceSummaryClickHouseRepository
       // every weekly partition (incl. cold S3). OccurredAt is the trace's
       // occurrence time and is stable across versions (it's the
       // `PARTITION BY toYearWeek(OccurredAt)` key), so the ±2-day window always
-      // contains the row — no unbounded fallback is needed. A trace genuinely
-      // absent resolves to undefined, and we return null from the light scan
-      // without ever issuing the heavy unbounded read.
-      const resolvedMs = await this.resolveOccurredAtMs(tenantId, traceId);
-      if (resolvedMs === undefined) return null;
+      // contains the row — no unbounded fallback is needed for normal rows. A
+      // trace genuinely absent returns null from the light scan without ever
+      // issuing the heavy read; historical sentinel rows still use the legacy
+      // unbounded fallback to preserve correctness.
+      const resolved = await this.resolveOccurredAtMs({ tenantId, traceId });
+      if (!resolved.found) return null;
+      if (resolved.occurredAtMs === undefined) {
+        logger.debug(
+          { tenantId, traceId },
+          "Trace summary resolved with sentinel OccurredAt — falling back to unbounded read",
+        );
+        return await this.queryByTraceId(tenantId, traceId);
+      }
       return await this.queryByTraceId(tenantId, traceId, {
-        fromMs: resolvedMs - PARTITION_WINDOW_MS,
-        toMs: resolvedMs + PARTITION_WINDOW_MS,
+        fromMs: resolved.occurredAtMs - PARTITION_WINDOW_MS,
+        toMs: resolved.occurredAtMs + PARTITION_WINDOW_MS,
       });
     } catch (error) {
       const errorMessage =
@@ -188,17 +196,23 @@ export class TraceSummaryClickHouseRepository
    * couple of granules of small columns — far cheaper than letting the heavy
    * single-trace read fall back to scanning every weekly partition (incl. cold
    * S3). For a not-yet-projected / absent trace this also lets the caller skip
-   * the heavy read entirely. Returns undefined when the trace isn't in
-   * `trace_summaries`.
+   * the heavy read entirely. Rows that still carry the historical
+   * `OccurredAt = 0` sentinel are reported as found without a usable timestamp
+   * so the caller can preserve correctness with the legacy unbounded fallback.
    */
-  private async resolveOccurredAtMs(
-    tenantId: string,
-    traceId: string,
-  ): Promise<number | undefined> {
+  private async resolveOccurredAtMs({
+    tenantId,
+    traceId,
+  }: {
+    tenantId: string;
+    traceId: string;
+  }): Promise<{ found: boolean; occurredAtMs?: number }> {
     const client = await this.resolveClient(tenantId);
     const result = await client.query({
       query: `
-        SELECT toUnixTimestamp64Milli(min(OccurredAt)) AS occurredAtMs
+        SELECT
+          count() AS rowCount,
+          toUnixTimestamp64Milli(min(OccurredAt)) AS occurredAtMs
         FROM ${TABLE_NAME}
         WHERE TenantId = {tenantId:String}
           AND TraceId = {traceId:String}
@@ -207,15 +221,24 @@ export class TraceSummaryClickHouseRepository
       format: "JSONEachRow",
     });
     const rows = (await result.json()) as Array<{
+      rowCount: string | number;
       occurredAtMs: string | number | null;
     }>;
+    const rowCountRaw = rows[0]?.rowCount;
     const raw = rows[0]?.occurredAtMs;
-    if (raw === null || raw === undefined) return undefined;
-    // min over no matching rows yields the epoch default (0); treat that — and
-    // any non-positive value — as "trace absent" so the caller returns null and
-    // skips the heavy read.
+    const rowCount =
+      typeof rowCountRaw === "string" ? Number(rowCountRaw) : rowCountRaw;
+    if (!Number.isFinite(rowCount) || rowCount <= 0) {
+      return { found: false };
+    }
+    if (raw === null || raw === undefined) return { found: true };
+    // A positive OccurredAt can safely bound the read. Historical rows with the
+    // epoch sentinel (0) must fall back to the legacy unbounded lookup because
+    // they do exist but have no usable partition key.
     const ms = typeof raw === "string" ? Number(raw) : raw;
-    return Number.isFinite(ms) && ms > 0 ? ms : undefined;
+    return Number.isFinite(ms) && ms > 0
+      ? { found: true, occurredAtMs: ms }
+      : { found: true };
   }
 
   private async queryByTraceId(


### PR DESCRIPTION
## Evidence

Over the last 24h of prod ClickHouse slow-query warnings, a single-trace summary read shape was high-volume and slow:

- ~280 calls/24h, **p50 ~1,099ms** (max ~12s), and notably **median readBytes ~0** with a max of ~13 MB — i.e. most calls return nothing yet still take ~1s. That signature is a full-partition scan for a trace that is often not (yet) present.

(No tenant data reproduced here.)

## Suspected cause

`trace_summaries` is `ReplacingMergeTree(UpdatedAt)`, `PARTITION BY toYearWeek(OccurredAt)`, `ORDER BY (TenantId, TraceId)`. `findByTraceId` prunes partitions only when the caller threads an `occurredAtMs` hint. When the hint is absent — or present but misses (clock skew, stale URL, hint ≠ the row's actual OccurredAt) — it falls back to `queryByTraceId(tenantId, traceId)` with **no** OccurredAt predicate, so the engine reads the heavy columns (ComputedInput / ComputedOutput / Attributes) across every weekly partition incl. the cold S3 tier. The not-found case is the worst: it pays a full heavy scan just to confirm the trace doesn't exist.

## Proposed fix

Mirror the `resolveTraceOccurredAtMs` pattern already used by the span repository: replace the unbounded fallback with a cheap resolve.

- New `resolveOccurredAtMs(tenantId, traceId)`: `SELECT min(OccurredAt) ... WHERE TenantId AND TraceId`. Because the table is `ORDER BY (TenantId, TraceId)`, this is a sort-key prefix seek over a couple of granules of small columns.
- `findByTraceId` resolves OccurredAt when there's no hint (or the hint missed) and bounds the heavy read to a ±2-day window. OccurredAt is the trace's occurrence time and is **stable across versions** (it's the `PARTITION BY` key), so the bounded window always contains the row — no unbounded fallback needed.
- A trace genuinely absent resolves to `undefined` → return `null` from the light scan, **skipping the heavy read entirely**.

The hinted happy path is unchanged.

## Expected impact

- Found-but-hint-less reads: heavy-column scan bounded to ~a handful of partitions instead of all of them — the p50 ~1s should drop toward the hinted ~100ms path.
- Not-found reads (the bulk of this shape, readBytes ~0): the heavy unbounded scan is eliminated; only the light sort-key resolve runs.

## EXPLAIN check

`EXPLAIN INDEXES` on `trace_summaries` for a real large tenant, unbounded vs. an `OccurredAt`-bounded read:

| Shape | Parts | Granules |
| --- | --- | --- |
| Unbounded (no `OccurredAt`) | 186 / 259 | 12,870 |
| `OccurredAt`-bounded (±2d) | 5 / 259 | 134 |

259 → 5 parts, 12,870 → 134 granules. (The real query adds the `TraceId` sort-key prune on top.)

## Test plan

New `trace-summary.clickhouse.repository.integration.test.ts` (real ClickHouse testcontainer, prod `trace_summaries` schema):

- without a hint, `findByTraceId` returns the trace;
- without a hint, it issues one cheap resolve (`min(OccurredAt)`) plus the heavy read, and the heavy read carries the `OccurredAt >=` partition predicate;
- a non-existent trace returns null and the heavy read (`ComputedInput`) is **never issued** — only the light resolve runs.

3/3 pass; typecheck clean.

## Notes for reviewer

- Pre-existing biome formatting nit on the unchanged `upsert` signature (not touched by this PR; reviewdog only checks added lines).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace summary retrieval by resolving the real `OccurredAt` when hint data is missing or incorrect, and limiting heavy reads to a narrow time window to avoid unbounded queries.
  * Missing traces now return no result without triggering additional expensive database work.
  * Correctly handles “logs-only” traces with sentinel occurrence timestamps, keeping results and query bounds consistent.
* **Tests**
  * Added ClickHouse-backed integration tests covering found, missing, and logs-only scenarios, verifying both returned data and optimized query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->