### PR TITLE
fix(tests): de-flake data privacy drawer Escape-close integration test

### DIFF
--- a/langwatch/src/pages/settings/__tests__/dataPrivacyDrawerUrl.integration.test.tsx
+++ b/langwatch/src/pages/settings/__tests__/dataPrivacyDrawerUrl.integration.test.tsx
@@ -9,7 +9,7 @@
  * mirroring DrawerNavigation.integration.test.tsx.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 import type React from "react";
@@ -173,9 +173,17 @@ describe("Privacy rule drawer URL routing", () => {
         />,
       );
 
+      // The drawer is modal={false}, so Ark UI attaches its Escape listener on
+      // the document only after the portaled content mounts. Wait for the
+      // drawer to be on screen before pressing Escape, otherwise the keypress
+      // can land before the listener exists (the CI flake).
+      await screen.findByText("Edit privacy rule");
+
       await user.keyboard("{Escape}");
 
-      expect(mockCloseDrawer).toHaveBeenCalled();
+      // onOpenChange -> onClose resolves a tick later, so poll rather than
+      // asserting synchronously.
+      await waitFor(() => expect(mockCloseDrawer).toHaveBeenCalled());
     });
   });
 });


### PR DESCRIPTION
## What

De-flakes `dataPrivacyDrawerUrl.integration.test.tsx` > "clears the drawer from the URL", which intermittently failed in CI with:

```
AssertionError: expected "vi.fn()" to be called at least once
  expect(mockCloseDrawer).toHaveBeenCalled();
```

## Root cause — timing race, not bad logic

The test fired `user.keyboard("{Escape}")` immediately after `render` and asserted `mockCloseDrawer` synchronously. Two things made it racy on loaded CI runners:

1. **Escape listener attached late.** The drawer is `modal={false}` (`components/ui/drawer.tsx`), so focus is *not* trapped into the dialog on open. Ark UI/Chakra attaches the Escape `keydown` handler on the document via an effect that runs only **after** the portaled content mounts. The keypress could land before that → `onClose` never fired.
2. **`onOpenChange → onClose` is async.** Even when Escape lands, the close callback resolves a tick later than the synchronous `expect`.

Fast machines win the race; CI under load loses it.

## Fix

- Await `screen.findByText("Edit privacy rule")` before pressing Escape — guarantees the drawer (and its listener) is mounted.
- Wrap the assertion in `waitFor(...)` to poll instead of asserting on the same tick.

Test-only change; component behavior is correct.

## Verification

15/15 consecutive local runs green (non-deterministic before).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for the settings privacy drawer, reducing timing-related flakiness in keyboard-dismissal coverage.
  * Added asynchronous assertion handling to better match real-world drawer close behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->