### PR TITLE
feat(data-retention): edit policies + safer remove with fallback preview

### DIFF
--- a/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
+++ b/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
@@ -147,7 +147,12 @@ export function AddOverrideDrawer({
     setCustomAmount("");
     setCustomUnit("weeks");
     setApplyToExisting(true);
-  }, [open, editTarget, currentProjectId, available.projects]);
+    // Initialize only when the drawer opens or the edit target changes — NOT on
+    // currentProjectId / available.projects reference churn (a background
+    // snapshot refetch would otherwise re-run this and wipe in-progress edits).
+    // The latest scope inputs are read inside, so the next open re-reads them.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, editTarget]);
 
   const resolvedDays = (() => {
     if (preset === CUSTOM_PRESET_VALUE) {

--- a/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
+++ b/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
@@ -86,11 +86,11 @@ export function AddOverrideDrawer({
   currentProjectId: string;
   isPlatformAdmin: boolean;
   isSaving: boolean;
-  onSave: (
-    scopes: ScopeTriadEntry[],
-    retentionDays: number,
-    applyToExisting: boolean,
-  ) => void;
+  onSave: (params: {
+    scopes: ScopeTriadEntry[];
+    retentionDays: number;
+    applyToExisting: boolean;
+  }) => void;
   /** When set, the drawer edits this existing policy: the scope is locked and
    *  shown read-only, and the retention is prefilled. Absent = add mode. */
   editTarget?: RetentionEditTarget | null;
@@ -320,7 +320,9 @@ export function AddOverrideDrawer({
               colorPalette="blue"
               disabled={!canSave}
               loading={isSaving}
-              onClick={() => onSave(scopes, resolvedDays, applyToExisting)}
+              onClick={() =>
+                onSave({ scopes, retentionDays: resolvedDays, applyToExisting })
+              }
             >
               {isEditing ? "Save changes" : "Create"}
             </Button>

--- a/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
+++ b/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
@@ -1,4 +1,5 @@
 import {
+  Badge,
   Button,
   createListCollection,
   Field,
@@ -30,7 +31,36 @@ import {
   RETENTION_PRESETS,
   type RetentionUnit,
   retentionUnitCollection,
+  SCOPE_ICON,
 } from "./constants";
+
+/** A row the overflow menu's Edit action targets: a single scope's policy,
+ *  prefilled into the drawer with the scope locked. */
+export type RetentionEditTarget = {
+  scope: ScopeTriadEntry;
+  scopeName: string;
+  retentionDays: number;
+};
+
+/** Map a stored day count back onto the drawer's preset/custom controls. Stored
+ *  values are always week-aligned, so the custom fallback round-trips through
+ *  whole weeks cleanly; the indefinite sentinel maps to its admin-only preset. */
+function initialRetentionState(days: number): {
+  preset: string;
+  amount: string;
+  unit: RetentionUnit;
+} {
+  if (days === INDEFINITE_RETENTION_DAYS) {
+    return { preset: INDEFINITE_PRESET_VALUE, amount: "", unit: "weeks" };
+  }
+  const match = RETENTION_PRESETS.find((p) => p.days === days);
+  if (match) return { preset: match.value, amount: "", unit: "weeks" };
+  return {
+    preset: CUSTOM_PRESET_VALUE,
+    amount: String(days / RETENTION_WEEK_DAYS),
+    unit: "weeks",
+  };
+}
 
 export function AddOverrideDrawer({
   open,
@@ -42,6 +72,7 @@ export function AddOverrideDrawer({
   isPlatformAdmin,
   isSaving,
   onSave,
+  editTarget,
 }: {
   open: boolean;
   onClose: () => void;
@@ -60,6 +91,9 @@ export function AddOverrideDrawer({
     retentionDays: number,
     applyToExisting: boolean,
   ) => void;
+  /** When set, the drawer edits this existing policy: the scope is locked and
+   *  shown read-only, and the retention is prefilled. Absent = add mode. */
+  editTarget?: RetentionEditTarget | null;
 }) {
   const [scopes, setScopes] = useState<ScopeTriadEntry[]>([]);
   const [preset, setPreset] = useState<string>(String(DEFAULT_RETENTION_DAYS));
@@ -88,21 +122,32 @@ export function AddOverrideDrawer({
     [isPlatformAdmin],
   );
 
+  const isEditing = !!editTarget;
+
   useEffect(() => {
-    if (open) {
-      // Default to the current project so the picker opens on the user's
-      // working scope, mirroring the API-key drawer pattern.
-      setScopes(
-        available.projects.some((p) => p.id === currentProjectId)
-          ? [{ scopeType: "PROJECT", scopeId: currentProjectId }]
-          : [],
-      );
-      setPreset(String(DEFAULT_RETENTION_DAYS));
-      setCustomAmount("");
-      setCustomUnit("weeks");
+    if (!open) return;
+    if (editTarget) {
+      // Edit mode: lock to the policy's scope and prefill its current value.
+      setScopes([editTarget.scope]);
+      const init = initialRetentionState(editTarget.retentionDays);
+      setPreset(init.preset);
+      setCustomAmount(init.amount);
+      setCustomUnit(init.unit);
       setApplyToExisting(true);
+      return;
     }
-  }, [open, currentProjectId, available.projects]);
+    // Add mode: default to the current project so the picker opens on the
+    // user's working scope, mirroring the API-key drawer pattern.
+    setScopes(
+      available.projects.some((p) => p.id === currentProjectId)
+        ? [{ scopeType: "PROJECT", scopeId: currentProjectId }]
+        : [],
+    );
+    setPreset(String(DEFAULT_RETENTION_DAYS));
+    setCustomAmount("");
+    setCustomUnit("weeks");
+    setApplyToExisting(true);
+  }, [open, editTarget, currentProjectId, available.projects]);
 
   const resolvedDays = (() => {
     if (preset === CUSTOM_PRESET_VALUE) {
@@ -136,7 +181,9 @@ export function AddOverrideDrawer({
     >
       <Drawer.Content bg="bg">
         <Drawer.Header>
-          <Heading size="md">Add retention policy</Heading>
+          <Heading size="md">
+            {isEditing ? "Edit retention policy" : "Add retention policy"}
+          </Heading>
           <Drawer.CloseTrigger />
         </Drawer.Header>
         <Drawer.Body>
@@ -145,20 +192,29 @@ export function AddOverrideDrawer({
               <Text fontWeight="600" fontSize="sm">
                 Scope
               </Text>
-              <ScopeChipPicker
-                value={scopes}
-                onChange={setScopes}
-                organizationId={available.organization?.id}
-                organizationName={available.organization?.name}
-                availableTeams={available.teams}
-                availableProjects={available.projects}
-                label=""
-                currentOrganizationId={
-                  available.organization ? currentOrganizationId : undefined
-                }
-                currentTeamId={currentTeamId}
-                currentProjectId={currentProjectId}
-              />
+              {isEditing && editTarget ? (
+                // Scope is fixed when editing — changing it would mean deleting
+                // this rule and creating another, which is what "Add" is for.
+                <ScopeReadout
+                  scopeType={editTarget.scope.scopeType}
+                  name={editTarget.scopeName}
+                />
+              ) : (
+                <ScopeChipPicker
+                  value={scopes}
+                  onChange={setScopes}
+                  organizationId={available.organization?.id}
+                  organizationName={available.organization?.name}
+                  availableTeams={available.teams}
+                  availableProjects={available.projects}
+                  label=""
+                  currentOrganizationId={
+                    available.organization ? currentOrganizationId : undefined
+                  }
+                  currentTeamId={currentTeamId}
+                  currentProjectId={currentProjectId}
+                />
+              )}
             </VStack>
 
             <Field.Root>
@@ -247,20 +303,55 @@ export function AddOverrideDrawer({
         </Drawer.Body>
         <Drawer.Footer>
           <HStack width="full" justify="end" gap={2}>
-            <Button variant="outline" onClick={onClose} disabled={isSaving}>
-              Cancel
-            </Button>
+            {/* Edit drawers reached from a row overflow menu carry only the
+                primary action — the header X cancels (row-actions-overflow-menu.md).
+                The Add drawer keeps an explicit Cancel for its create flow. */}
+            {!isEditing && (
+              <Button variant="outline" onClick={onClose} disabled={isSaving}>
+                Cancel
+              </Button>
+            )}
             <Button
               colorPalette="blue"
               disabled={!canSave}
               loading={isSaving}
               onClick={() => onSave(scopes, resolvedDays, applyToExisting)}
             >
-              Create
+              {isEditing ? "Save changes" : "Create"}
             </Button>
           </HStack>
         </Drawer.Footer>
       </Drawer.Content>
     </Drawer.Root>
+  );
+}
+
+/** Read-only display of a locked scope in the edit drawer: the scope's tier
+ *  icon, name, and a tier badge, matching the policy table's row layout. */
+function ScopeReadout({
+  scopeType,
+  name,
+}: {
+  scopeType: ScopeTriadEntry["scopeType"];
+  name: string;
+}) {
+  const Icon = SCOPE_ICON[scopeType];
+  return (
+    <HStack
+      gap={2}
+      width="full"
+      paddingX={3}
+      paddingY={2}
+      borderWidth="1px"
+      borderColor="border"
+      borderRadius="md"
+      background="bg.subtle"
+    >
+      <Icon size={14} />
+      <Text>{name}</Text>
+      <Badge size="sm" colorPalette="gray">
+        {scopeType.toLowerCase()}
+      </Badge>
+    </HStack>
   );
 }

--- a/langwatch/src/components/data-retention/RemoveScopeConfirmDialog.tsx
+++ b/langwatch/src/components/data-retention/RemoveScopeConfirmDialog.tsx
@@ -1,0 +1,126 @@
+import { Alert, Button, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
+import { ArrowRight } from "lucide-react";
+import { Dialog } from "~/components/ui/dialog";
+import { api } from "~/utils/api";
+import { renderPolicyValue, type RetentionScopeGroup } from "./grouping";
+
+/**
+ * Confirms removal of a scope's retention policy. Removing a rule is not a
+ * delete of data — it only changes the retention applied to NEW data, which
+ * falls back to the next tier in the cascade (or the platform default). This
+ * dialog spells that out and shows the real fallback number resolved
+ * server-side (never a guessed value), so a user can't mistake "remove rule"
+ * for "delete my traces" — the fear that prompted this UI.
+ */
+export function RemoveScopeConfirmDialog({
+  group,
+  projectId,
+  isRemoving,
+  onCancel,
+  onConfirm,
+}: {
+  group: RetentionScopeGroup | null;
+  projectId: string;
+  isRemoving: boolean;
+  onCancel: () => void;
+  onConfirm: () => void | Promise<void>;
+}) {
+  const previewQuery = api.dataRetention.previewScopeRemoval.useQuery(
+    {
+      projectId,
+      scope: group
+        ? { scopeType: group.scopeType, scopeId: group.scopeId }
+        : { scopeType: "PROJECT", scopeId: "" },
+    },
+    { enabled: !!group },
+  );
+
+  const current = group ? renderPolicyValue(group.byCategory) : "—";
+  const fallback = previewQuery.data
+    ? renderPolicyValue(previewQuery.data)
+    : null;
+
+  return (
+    <Dialog.Root
+      open={!!group}
+      onOpenChange={({ open }) => {
+        if (!open) onCancel();
+      }}
+    >
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>
+            Remove retention policy{group ? ` for ${group.name}` : ""}?
+          </Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Body>
+          {group && (
+            <VStack align="stretch" gap={4}>
+              <Text>
+                This removes the override only. <strong>No data is deleted</strong>{" "}
+                — existing data keeps the retention it was already stored with.
+                The change applies to newly ingested data from now on.
+              </Text>
+
+              <VStack
+                align="stretch"
+                gap={1}
+                padding={3}
+                borderWidth="1px"
+                borderColor="border"
+                borderRadius="md"
+                background="bg.subtle"
+              >
+                <Text fontSize="xs" color="fg.muted">
+                  Retention for {group.name}
+                </Text>
+                {previewQuery.isLoading ? (
+                  <HStack gap={2}>
+                    <Spinner size="sm" />
+                    <Text fontSize="sm" color="fg.muted">
+                      Resolving fallback…
+                    </Text>
+                  </HStack>
+                ) : (
+                  <HStack gap={2}>
+                    <Text fontWeight="600">{current}</Text>
+                    <ArrowRight size={14} />
+                    <Text fontWeight="600">{fallback ?? "the next policy"}</Text>
+                  </HStack>
+                )}
+                <Text fontSize="xs" color="fg.muted">
+                  Falls back to the next applicable policy, or the platform
+                  default when none is closer.
+                </Text>
+              </VStack>
+
+              {previewQuery.isError && (
+                <Alert.Root status="warning">
+                  <Alert.Indicator />
+                  <Alert.Content>
+                    <Alert.Description>
+                      Couldn't preview the fallback retention. Removing still
+                      falls back to the next applicable policy.
+                    </Alert.Description>
+                  </Alert.Content>
+                </Alert.Root>
+              )}
+            </VStack>
+          )}
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Button variant="outline" onClick={onCancel} disabled={isRemoving}>
+            Cancel
+          </Button>
+          <Button
+            colorPalette="red"
+            loading={isRemoving}
+            onClick={() => void onConfirm()}
+          >
+            Remove policy
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/langwatch/src/components/data-retention/RemoveScopeConfirmDialog.tsx
+++ b/langwatch/src/components/data-retention/RemoveScopeConfirmDialog.tsx
@@ -2,7 +2,7 @@ import { Alert, Button, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
 import { ArrowRight } from "lucide-react";
 import { Dialog } from "~/components/ui/dialog";
 import { api } from "~/utils/api";
-import { renderPolicyValue, type RetentionScopeGroup } from "./grouping";
+import { type RetentionScopeGroup, renderPolicyValue } from "./grouping";
 
 /**
  * Confirms removal of a scope's retention policy. Removing a rule is not a
@@ -57,9 +57,10 @@ export function RemoveScopeConfirmDialog({
           {group && (
             <VStack align="stretch" gap={4}>
               <Text>
-                This removes the override only. <strong>No data is deleted</strong>{" "}
-                — existing data keeps the retention it was already stored with.
-                The change applies to newly ingested data from now on.
+                This removes the override only.{" "}
+                <strong>No data is deleted</strong> — existing data keeps the
+                retention it was already stored with. The change applies to
+                newly ingested data from now on.
               </Text>
 
               <VStack
@@ -85,7 +86,9 @@ export function RemoveScopeConfirmDialog({
                   <HStack gap={2}>
                     <Text fontWeight="600">{current}</Text>
                     <ArrowRight size={14} />
-                    <Text fontWeight="600">{fallback ?? "the next policy"}</Text>
+                    <Text fontWeight="600">
+                      {fallback ?? "the next policy"}
+                    </Text>
                   </HStack>
                 )}
                 <Text fontSize="xs" color="fg.muted">

--- a/langwatch/src/components/data-retention/RetentionAndUsageCard.tsx
+++ b/langwatch/src/components/data-retention/RetentionAndUsageCard.tsx
@@ -11,10 +11,15 @@ export function RetentionAndUsageCard({
   effective,
   isLoading,
   data,
+  storageDescription = "How much space this project's data uses today.",
 }: {
   effective: Partial<Record<RetentionCategory, number>>;
   isLoading: boolean;
-  data?: { totalBytes: number; byCategory: Record<RetentionCategory, number> };
+  data?: { totalBytes: number; projectCount?: number };
+  /** Scope-aware copy for the storage row — the storage total tracks the
+   *  page's scope selector, so the sentence must match (project / team / org /
+   *  everything you can see). */
+  storageDescription?: string;
 }) {
   const summary = renderPolicySummary(effective);
   return (
@@ -22,14 +27,14 @@ export function RetentionAndUsageCard({
       <Card.Header>
         <HStack width="full" justify="space-between" align="start">
           <VStack align="start" gap={0}>
-            <Heading as="h3" fontSize="lg">
+            <Heading as="h3" fontSize="sm" fontWeight="semibold">
               Data Retention
             </Heading>
-            <Text fontSize="sm" color="fg.muted">
+            <Text fontSize="xs" color="fg.muted">
               How long this project's data is kept before deletion.
             </Text>
           </VStack>
-          <Text fontWeight="semibold" flexShrink={0}>
+          <Text fontSize="sm" fontWeight="semibold" flexShrink={0}>
             {summary}
           </Text>
         </HStack>
@@ -52,19 +57,26 @@ export function RetentionAndUsageCard({
           )}
           <HStack width="full" justify="space-between" align="start">
             <VStack align="start" gap={0}>
-              <Heading as="h3" fontSize="lg">
+              <Heading as="h3" fontSize="sm" fontWeight="semibold">
                 Data Storage
               </Heading>
-              <Text fontSize="sm" color="fg.muted">
-                How much space this project's data uses today.
+              <Text fontSize="xs" color="fg.muted">
+                {storageDescription}
               </Text>
             </VStack>
             {isLoading ? (
               <Spinner size="sm" />
             ) : data ? (
-              <Text fontWeight="semibold" flexShrink={0}>
-                {formatBytes(data.totalBytes)}
-              </Text>
+              <HStack gap={1.5} flexShrink={0} align="baseline">
+                <Text fontSize="sm" fontWeight="semibold">
+                  {formatBytes(data.totalBytes)}
+                </Text>
+                {data.projectCount !== undefined && data.projectCount > 1 && (
+                  <Text fontSize="xs" color="fg.muted">
+                    · {data.projectCount} projects
+                  </Text>
+                )}
+              </HStack>
             ) : null}
           </HStack>
         </VStack>

--- a/langwatch/src/components/data-retention/__tests__/AddOverrideDrawer.editMode.integration.test.tsx
+++ b/langwatch/src/components/data-retention/__tests__/AddOverrideDrawer.editMode.integration.test.tsx
@@ -33,7 +33,9 @@ const editTarget: RetentionEditTarget = {
   retentionDays: 91,
 };
 
-function renderDrawer(props: Partial<React.ComponentProps<typeof AddOverrideDrawer>> = {}) {
+function renderDrawer(
+  props: Partial<React.ComponentProps<typeof AddOverrideDrawer>> = {},
+) {
   return render(
     <Wrapper>
       <AddOverrideDrawer

--- a/langwatch/src/components/data-retention/__tests__/AddOverrideDrawer.editMode.integration.test.tsx
+++ b/langwatch/src/components/data-retention/__tests__/AddOverrideDrawer.editMode.integration.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ScopeChipPicker pulls in data hooks we don't need here; the edit path renders
+// a read-only scope readout instead, so stub the picker to a marker.
+vi.mock("~/components/settings/ScopeChipPicker", () => ({
+  ScopeChipPicker: () => <div data-testid="scope-chip-picker" />,
+}));
+
+import {
+  AddOverrideDrawer,
+  type RetentionEditTarget,
+} from "../AddOverrideDrawer";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const available = {
+  organization: { id: "org-1", name: "Acme" },
+  teams: [],
+  projects: [{ id: "proj-1", name: "Web App", teamId: "team-1" }],
+};
+
+const editTarget: RetentionEditTarget = {
+  scope: { scopeType: "ORGANIZATION", scopeId: "org-1" },
+  scopeName: "Acme",
+  retentionDays: 91,
+};
+
+function renderDrawer(props: Partial<React.ComponentProps<typeof AddOverrideDrawer>> = {}) {
+  return render(
+    <Wrapper>
+      <AddOverrideDrawer
+        open
+        onClose={() => {}}
+        available={available}
+        currentOrganizationId="org-1"
+        currentTeamId={undefined}
+        currentProjectId="proj-1"
+        isPlatformAdmin={false}
+        isSaving={false}
+        onSave={() => {}}
+        {...props}
+      />
+    </Wrapper>,
+  );
+}
+
+describe("AddOverrideDrawer", () => {
+  afterEach(cleanup);
+
+  describe("when opened in edit mode for an existing policy", () => {
+    it("titles the drawer Edit and offers Save changes", () => {
+      renderDrawer({ editTarget });
+      expect(screen.getByText("Edit retention policy")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Save changes" })).toBeTruthy();
+    });
+
+    it("locks the scope to a read-only readout instead of the picker", () => {
+      renderDrawer({ editTarget });
+      expect(screen.getByText("Acme")).toBeTruthy();
+      expect(screen.getByText("organization")).toBeTruthy();
+      expect(screen.queryByTestId("scope-chip-picker")).toBeNull();
+    });
+
+    it("omits the Cancel button (the X dismisses)", () => {
+      renderDrawer({ editTarget });
+      expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    });
+  });
+
+  describe("when opened in add mode", () => {
+    it("titles the drawer Add and shows the scope picker and Cancel", () => {
+      renderDrawer({ editTarget: null });
+      expect(screen.getByText("Add retention policy")).toBeTruthy();
+      expect(screen.getByTestId("scope-chip-picker")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Create" })).toBeTruthy();
+    });
+  });
+});

--- a/langwatch/src/components/data-retention/__tests__/RemoveScopeConfirmDialog.integration.test.tsx
+++ b/langwatch/src/components/data-retention/__tests__/RemoveScopeConfirmDialog.integration.test.tsx
@@ -36,94 +36,98 @@ describe("RemoveScopeConfirmDialog", () => {
     queryMock.mockReset();
   });
 
-  describe("when the fallback retention has resolved", () => {
-    it("reassures that no data is deleted", () => {
-      queryMock.mockReturnValue({
-        data: { traces: 49, scenarios: 49, experiments: 49 },
-        isLoading: false,
-        isError: false,
+  describe("given a scope group targeted for removal", () => {
+    describe("when the fallback retention has resolved", () => {
+      it("reassures that no data is deleted", () => {
+        queryMock.mockReturnValue({
+          data: { traces: 49, scenarios: 49, experiments: 49 },
+          isLoading: false,
+          isError: false,
+        });
+        render(
+          <Wrapper>
+            <RemoveScopeConfirmDialog
+              group={group}
+              projectId="proj-1"
+              isRemoving={false}
+              onCancel={() => {}}
+              onConfirm={() => {}}
+            />
+          </Wrapper>,
+        );
+        expect(screen.getByText(/No data is deleted/i)).toBeTruthy();
       });
-      render(
-        <Wrapper>
-          <RemoveScopeConfirmDialog
-            group={group}
-            projectId="proj-1"
-            isRemoving={false}
-            onCancel={() => {}}
-            onConfirm={() => {}}
-          />
-        </Wrapper>,
-      );
-      expect(screen.getByText(/No data is deleted/i)).toBeTruthy();
+
+      it("shows the current value falling back to the resolved value", () => {
+        queryMock.mockReturnValue({
+          data: { traces: 49, scenarios: 49, experiments: 49 },
+          isLoading: false,
+          isError: false,
+        });
+        render(
+          <Wrapper>
+            <RemoveScopeConfirmDialog
+              group={group}
+              projectId="proj-1"
+              isRemoving={false}
+              onCancel={() => {}}
+              onConfirm={() => {}}
+            />
+          </Wrapper>,
+        );
+        // current 91 days → fallback 49 days
+        expect(screen.getByText("91 days")).toBeTruthy();
+        expect(screen.getByText("49 days")).toBeTruthy();
+      });
     });
 
-    it("shows the current value falling back to the resolved value", () => {
-      queryMock.mockReturnValue({
-        data: { traces: 49, scenarios: 49, experiments: 49 },
-        isLoading: false,
-        isError: false,
+    describe("when the fallback is still resolving", () => {
+      it("shows a resolving indicator instead of a guessed number", () => {
+        queryMock.mockReturnValue({
+          data: undefined,
+          isLoading: true,
+          isError: false,
+        });
+        render(
+          <Wrapper>
+            <RemoveScopeConfirmDialog
+              group={group}
+              projectId="proj-1"
+              isRemoving={false}
+              onCancel={() => {}}
+              onConfirm={() => {}}
+            />
+          </Wrapper>,
+        );
+        expect(screen.getByText(/Resolving fallback/i)).toBeTruthy();
+        expect(screen.queryByText("49 days")).toBeNull();
       });
-      render(
-        <Wrapper>
-          <RemoveScopeConfirmDialog
-            group={group}
-            projectId="proj-1"
-            isRemoving={false}
-            onCancel={() => {}}
-            onConfirm={() => {}}
-          />
-        </Wrapper>,
-      );
-      // current 91 days → fallback 49 days
-      expect(screen.getByText("91 days")).toBeTruthy();
-      expect(screen.getByText("49 days")).toBeTruthy();
     });
   });
 
-  describe("when the fallback is still resolving", () => {
-    it("shows a resolving indicator instead of a guessed number", () => {
-      queryMock.mockReturnValue({
-        data: undefined,
-        isLoading: true,
-        isError: false,
+  describe("given no scope group is targeted", () => {
+    describe("when the dialog renders", () => {
+      it("does not query for a fallback", () => {
+        queryMock.mockReturnValue({
+          data: undefined,
+          isLoading: false,
+          isError: false,
+        });
+        render(
+          <Wrapper>
+            <RemoveScopeConfirmDialog
+              group={null}
+              projectId="proj-1"
+              isRemoving={false}
+              onCancel={() => {}}
+              onConfirm={() => {}}
+            />
+          </Wrapper>,
+        );
+        // The query hook is always called (rules of hooks) but disabled.
+        const lastCall = queryMock.mock.calls.at(-1);
+        expect(lastCall?.[1]).toMatchObject({ enabled: false });
       });
-      render(
-        <Wrapper>
-          <RemoveScopeConfirmDialog
-            group={group}
-            projectId="proj-1"
-            isRemoving={false}
-            onCancel={() => {}}
-            onConfirm={() => {}}
-          />
-        </Wrapper>,
-      );
-      expect(screen.getByText(/Resolving fallback/i)).toBeTruthy();
-      expect(screen.queryByText("49 days")).toBeNull();
-    });
-  });
-
-  describe("when no group is targeted", () => {
-    it("does not query for a fallback", () => {
-      queryMock.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        isError: false,
-      });
-      render(
-        <Wrapper>
-          <RemoveScopeConfirmDialog
-            group={null}
-            projectId="proj-1"
-            isRemoving={false}
-            onCancel={() => {}}
-            onConfirm={() => {}}
-          />
-        </Wrapper>,
-      );
-      // The query hook is always called (rules of hooks) but disabled.
-      const lastCall = queryMock.mock.calls.at(-1);
-      expect(lastCall?.[1]).toMatchObject({ enabled: false });
     });
   });
 });

--- a/langwatch/src/components/data-retention/__tests__/RemoveScopeConfirmDialog.integration.test.tsx
+++ b/langwatch/src/components/data-retention/__tests__/RemoveScopeConfirmDialog.integration.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RetentionScopeGroup } from "../grouping";
+
+const queryMock = vi.fn();
+vi.mock("~/utils/api", () => ({
+  api: {
+    dataRetention: {
+      previewScopeRemoval: { useQuery: (...args: any[]) => queryMock(...args) },
+    },
+  },
+}));
+
+import { RemoveScopeConfirmDialog } from "../RemoveScopeConfirmDialog";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const group: RetentionScopeGroup = {
+  scopeType: "ORGANIZATION",
+  scopeId: "org-1",
+  name: "Acme",
+  byCategory: { traces: 91, scenarios: 91, experiments: 91 },
+  rules: [],
+};
+
+describe("RemoveScopeConfirmDialog", () => {
+  afterEach(() => {
+    cleanup();
+    queryMock.mockReset();
+  });
+
+  describe("when the fallback retention has resolved", () => {
+    it("reassures that no data is deleted", () => {
+      queryMock.mockReturnValue({
+        data: { traces: 49, scenarios: 49, experiments: 49 },
+        isLoading: false,
+        isError: false,
+      });
+      render(
+        <Wrapper>
+          <RemoveScopeConfirmDialog
+            group={group}
+            projectId="proj-1"
+            isRemoving={false}
+            onCancel={() => {}}
+            onConfirm={() => {}}
+          />
+        </Wrapper>,
+      );
+      expect(screen.getByText(/No data is deleted/i)).toBeTruthy();
+    });
+
+    it("shows the current value falling back to the resolved value", () => {
+      queryMock.mockReturnValue({
+        data: { traces: 49, scenarios: 49, experiments: 49 },
+        isLoading: false,
+        isError: false,
+      });
+      render(
+        <Wrapper>
+          <RemoveScopeConfirmDialog
+            group={group}
+            projectId="proj-1"
+            isRemoving={false}
+            onCancel={() => {}}
+            onConfirm={() => {}}
+          />
+        </Wrapper>,
+      );
+      // current 91 days → fallback 49 days
+      expect(screen.getByText("91 days")).toBeTruthy();
+      expect(screen.getByText("49 days")).toBeTruthy();
+    });
+  });
+
+  describe("when the fallback is still resolving", () => {
+    it("shows a resolving indicator instead of a guessed number", () => {
+      queryMock.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      });
+      render(
+        <Wrapper>
+          <RemoveScopeConfirmDialog
+            group={group}
+            projectId="proj-1"
+            isRemoving={false}
+            onCancel={() => {}}
+            onConfirm={() => {}}
+          />
+        </Wrapper>,
+      );
+      expect(screen.getByText(/Resolving fallback/i)).toBeTruthy();
+      expect(screen.queryByText("49 days")).toBeNull();
+    });
+  });
+
+  describe("when no group is targeted", () => {
+    it("does not query for a fallback", () => {
+      queryMock.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+      });
+      render(
+        <Wrapper>
+          <RemoveScopeConfirmDialog
+            group={null}
+            projectId="proj-1"
+            isRemoving={false}
+            onCancel={() => {}}
+            onConfirm={() => {}}
+          />
+        </Wrapper>,
+      );
+      // The query hook is always called (rules of hooks) but disabled.
+      const lastCall = queryMock.mock.calls.at(-1);
+      expect(lastCall?.[1]).toMatchObject({ enabled: false });
+    });
+  });
+});

--- a/langwatch/src/components/data-retention/__tests__/RetentionAndUsageCard.integration.test.tsx
+++ b/langwatch/src/components/data-retention/__tests__/RetentionAndUsageCard.integration.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { RetentionAndUsageCard } from "../RetentionAndUsageCard";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const effective = { traces: 49, scenarios: 49, experiments: 49 };
+
+describe("RetentionAndUsageCard", () => {
+  afterEach(cleanup);
+
+  describe("when storage aggregates several projects in a scope", () => {
+    it("uses the scope-aware description and shows the project count", () => {
+      render(
+        <Wrapper>
+          <RetentionAndUsageCard
+            effective={effective}
+            isLoading={false}
+            data={{ totalBytes: 20_000_000_000, projectCount: 2 }}
+            storageDescription="How much space this organization's data uses today."
+          />
+        </Wrapper>,
+      );
+      expect(
+        screen.getByText(
+          "How much space this organization's data uses today.",
+        ),
+      ).toBeTruthy();
+      expect(screen.getByText(/2 projects/)).toBeTruthy();
+    });
+  });
+
+  describe("when storage is a single project", () => {
+    it("omits the project-count suffix", () => {
+      render(
+        <Wrapper>
+          <RetentionAndUsageCard
+            effective={effective}
+            isLoading={false}
+            data={{ totalBytes: 0, projectCount: 1 }}
+          />
+        </Wrapper>,
+      );
+      expect(screen.queryByText(/projects/)).toBeNull();
+      // default project-scoped copy
+      expect(
+        screen.getByText("How much space this project's data uses today."),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/langwatch/src/components/data-retention/__tests__/RetentionAndUsageCard.integration.test.tsx
+++ b/langwatch/src/components/data-retention/__tests__/RetentionAndUsageCard.integration.test.tsx
@@ -29,9 +29,7 @@ describe("RetentionAndUsageCard", () => {
         </Wrapper>,
       );
       expect(
-        screen.getByText(
-          "How much space this organization's data uses today.",
-        ),
+        screen.getByText("How much space this organization's data uses today."),
       ).toBeTruthy();
       expect(screen.getByText(/2 projects/)).toBeTruthy();
     });

--- a/langwatch/src/pages/settings/data-retention.tsx
+++ b/langwatch/src/pages/settings/data-retention.tsx
@@ -12,14 +12,19 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { DatabaseBackup, MoreVertical, Pencil, Plus, Trash2 } from "lucide-react";
+import {
+  DatabaseBackup,
+  MoreVertical,
+  Pencil,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import {
   AddOverrideDrawer,
   type RetentionEditTarget,
 } from "~/components/data-retention/AddOverrideDrawer";
 import { ApplyToExistingConfirmDialog } from "~/components/data-retention/ApplyToExistingConfirmDialog";
-import { RemoveScopeConfirmDialog } from "~/components/data-retention/RemoveScopeConfirmDialog";
 import {
   SCOPE_ICON,
   SCOPE_TIER_ORDER,
@@ -30,6 +35,7 @@ import {
   type RetentionScopeGroup,
   renderPolicyValue,
 } from "~/components/data-retention/grouping";
+import { RemoveScopeConfirmDialog } from "~/components/data-retention/RemoveScopeConfirmDialog";
 import { RetentionAndUsageCard } from "~/components/data-retention/RetentionAndUsageCard";
 import { RetroactiveProgressCard } from "~/components/data-retention/RetroactiveProgressCard";
 import SettingsLayout from "~/components/SettingsLayout";
@@ -252,7 +258,8 @@ function DataRetentionPage({
     const present = (Object.keys(group.byCategory) as RetentionCategory[]).find(
       (c) => group.byCategory[c] !== undefined,
     );
-    const retentionDays = group.byCategory.traces ?? group.byCategory[present!]!;
+    const retentionDays =
+      group.byCategory.traces ?? group.byCategory[present!]!;
     setEditTarget({
       scope: { scopeType: group.scopeType, scopeId: group.scopeId },
       scopeName: group.name,

--- a/langwatch/src/pages/settings/data-retention.tsx
+++ b/langwatch/src/pages/settings/data-retention.tsx
@@ -291,11 +291,13 @@ function DataRetentionPage({
   // retention value applied to all categories, so we seed it with the group's
   // traces value (or the first present category for a divergent legacy group).
   const openEditForGroup = (group: RetentionScopeGroup) => {
-    const present = (Object.keys(group.byCategory) as RetentionCategory[]).find(
-      (c) => group.byCategory[c] !== undefined,
-    );
+    // Deterministic prefill: prefer traces, then a fixed category order, so a
+    // divergent legacy group never depends on object key insertion order.
     const retentionDays =
-      group.byCategory.traces ?? group.byCategory[present!]!;
+      group.byCategory.traces ??
+      group.byCategory.scenarios ??
+      group.byCategory.experiments;
+    if (retentionDays === undefined) return;
     setEditTarget({
       scope: { scopeType: group.scopeType, scopeId: group.scopeId },
       scopeName: group.name,
@@ -502,7 +504,7 @@ function DataRetentionPage({
             currentProjectId={projectId}
             isPlatformAdmin={isPlatformAdmin}
             isSaving={setForScope.isLoading || triggerUpdate.isLoading}
-            onSave={async (scopes, retentionDays, applyToExisting) => {
+            onSave={async ({ scopes, retentionDays, applyToExisting }) => {
               const categories: RetentionCategory[] = [...RETENTION_CATEGORIES];
               const saveOverrides = async () => {
                 const pairs = scopes.flatMap((scope) =>

--- a/langwatch/src/pages/settings/data-retention.tsx
+++ b/langwatch/src/pages/settings/data-retention.tsx
@@ -19,7 +19,7 @@ import {
   Plus,
   Trash2,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   AddOverrideDrawer,
   type RetentionEditTarget,
@@ -102,8 +102,44 @@ function DataRetentionPage({
 }) {
   const utils = api.useUtils();
   const rulesQuery = api.dataRetention.getRules.useQuery({ projectId });
-  const storageQuery = api.dataRetention.getStorageBreakdown.useQuery({
+
+  // Storage tracks the scope selector, not just the current project. Map the
+  // active filter to a concrete scope: a specific pick passes through; "all you
+  // can see" resolves to the whole org (or just this project for a personal
+  // account with no org).
+  const storageScope = useMemo(() => {
+    const resolved = resolveScopeFilter(scopeFilter, {
+      currentTeamId: teamId,
+      currentProjectId: projectId,
+    });
+    if (resolved.kind === "specific") {
+      return { scopeType: resolved.scopeType, scopeId: resolved.scopeId };
+    }
+    return organizationId
+      ? { scopeType: "ORGANIZATION" as const, scopeId: organizationId }
+      : { scopeType: "PROJECT" as const, scopeId: projectId };
+  }, [scopeFilter, teamId, projectId, organizationId]);
+
+  const storageDescription = useMemo(() => {
+    const resolved = resolveScopeFilter(scopeFilter, {
+      currentTeamId: teamId,
+      currentProjectId: projectId,
+    });
+    if (resolved.kind === "all") {
+      return "How much space everything you can see uses today.";
+    }
+    if (resolved.scopeType === "ORGANIZATION") {
+      return "How much space this organization's data uses today.";
+    }
+    if (resolved.scopeType === "TEAM") {
+      return "How much space this team's data uses today.";
+    }
+    return "How much space this project's data uses today.";
+  }, [scopeFilter, teamId, projectId]);
+
+  const storageQuery = api.dataRetention.getScopeStorageUsage.useQuery({
     projectId,
+    scope: storageScope,
   });
   // Platform admin = email in ADMIN_EMAILS (NOT an org admin). Only they may
   // disable retention; the route enforces this independently. We use it solely
@@ -333,6 +369,7 @@ function DataRetentionPage({
             effective={snapshot.effective}
             isLoading={storageQuery.isLoading}
             data={storageQuery.data}
+            storageDescription={storageDescription}
           />
         )}
 

--- a/langwatch/src/pages/settings/data-retention.tsx
+++ b/langwatch/src/pages/settings/data-retention.tsx
@@ -103,28 +103,36 @@ function DataRetentionPage({
   const utils = api.useUtils();
   const rulesQuery = api.dataRetention.getRules.useQuery({ projectId });
 
+  // Resolve the active scope filter once; everything below derives from this
+  // single value so the storage scope, its description, and the row filter
+  // can't drift from one another.
+  const resolvedScopeFilter = useMemo(
+    () =>
+      resolveScopeFilter(scopeFilter, {
+        currentTeamId: teamId,
+        currentProjectId: projectId,
+      }),
+    [scopeFilter, teamId, projectId],
+  );
+
   // Storage tracks the scope selector, not just the current project. Map the
   // active filter to a concrete scope: a specific pick passes through; "all you
   // can see" resolves to the whole org (or just this project for a personal
   // account with no org).
   const storageScope = useMemo(() => {
-    const resolved = resolveScopeFilter(scopeFilter, {
-      currentTeamId: teamId,
-      currentProjectId: projectId,
-    });
-    if (resolved.kind === "specific") {
-      return { scopeType: resolved.scopeType, scopeId: resolved.scopeId };
+    if (resolvedScopeFilter.kind === "specific") {
+      return {
+        scopeType: resolvedScopeFilter.scopeType,
+        scopeId: resolvedScopeFilter.scopeId,
+      };
     }
     return organizationId
       ? { scopeType: "ORGANIZATION" as const, scopeId: organizationId }
       : { scopeType: "PROJECT" as const, scopeId: projectId };
-  }, [scopeFilter, teamId, projectId, organizationId]);
+  }, [resolvedScopeFilter, projectId, organizationId]);
 
   const storageDescription = useMemo(() => {
-    const resolved = resolveScopeFilter(scopeFilter, {
-      currentTeamId: teamId,
-      currentProjectId: projectId,
-    });
+    const resolved = resolvedScopeFilter;
     if (resolved.kind === "all") {
       return "How much space everything you can see uses today.";
     }
@@ -135,7 +143,7 @@ function DataRetentionPage({
       return "How much space this team's data uses today.";
     }
     return "How much space this project's data uses today.";
-  }, [scopeFilter, teamId, projectId]);
+  }, [resolvedScopeFilter]);
 
   const storageQuery = api.dataRetention.getScopeStorageUsage.useQuery({
     projectId,
@@ -311,14 +319,10 @@ function DataRetentionPage({
     setEditTarget(null);
   };
 
-  const resolved = resolveScopeFilter(scopeFilter, {
-    currentTeamId: teamId,
-    currentProjectId: projectId,
-  });
   const filteredRules = (snapshot?.rules ?? []).filter((r) =>
     isScopeInFilter(
       { scopeType: r.scopeType, scopeId: r.scopeId },
-      resolved,
+      resolvedScopeFilter,
       filterAvailable.hierarchy,
     ),
   );

--- a/langwatch/src/pages/settings/data-retention.tsx
+++ b/langwatch/src/pages/settings/data-retention.tsx
@@ -12,10 +12,14 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { DatabaseBackup, Plus, Trash2 } from "lucide-react";
+import { DatabaseBackup, MoreVertical, Pencil, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { AddOverrideDrawer } from "~/components/data-retention/AddOverrideDrawer";
+import {
+  AddOverrideDrawer,
+  type RetentionEditTarget,
+} from "~/components/data-retention/AddOverrideDrawer";
 import { ApplyToExistingConfirmDialog } from "~/components/data-retention/ApplyToExistingConfirmDialog";
+import { RemoveScopeConfirmDialog } from "~/components/data-retention/RemoveScopeConfirmDialog";
 import {
   SCOPE_ICON,
   SCOPE_TIER_ORDER,
@@ -30,6 +34,7 @@ import { RetentionAndUsageCard } from "~/components/data-retention/RetentionAndU
 import { RetroactiveProgressCard } from "~/components/data-retention/RetroactiveProgressCard";
 import SettingsLayout from "~/components/SettingsLayout";
 import { ScopeFilter as ScopeFilterComponent } from "~/components/settings/ScopeFilter";
+import { Menu } from "~/components/ui/menu";
 import { toaster } from "~/components/ui/toaster";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { useAvailableScopes } from "~/hooks/useAvailableScopes";
@@ -100,6 +105,15 @@ function DataRetentionPage({
   const isPlatformAdmin = api.user.isAdmin.useQuery({}).data?.isAdmin ?? false;
 
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // When set, the Add drawer opens in edit mode locked to this scope's policy.
+  const [editTarget, setEditTarget] = useState<RetentionEditTarget | null>(
+    null,
+  );
+  // The scope-group pending removal — drives the confirm dialog so deletion is
+  // a deliberate, explained action instead of a one-click trash button.
+  const [removeTarget, setRemoveTarget] = useState<RetentionScopeGroup | null>(
+    null,
+  );
 
   const invalidate = () =>
     utils.dataRetention.getRules.invalidate({ projectId });
@@ -229,6 +243,27 @@ function DataRetentionPage({
         type: "error",
       });
     }
+  };
+
+  // Open the Add drawer in edit mode for a scope group. The drawer edits one
+  // retention value applied to all categories, so we seed it with the group's
+  // traces value (or the first present category for a divergent legacy group).
+  const openEditForGroup = (group: RetentionScopeGroup) => {
+    const present = (Object.keys(group.byCategory) as RetentionCategory[]).find(
+      (c) => group.byCategory[c] !== undefined,
+    );
+    const retentionDays = group.byCategory.traces ?? group.byCategory[present!]!;
+    setEditTarget({
+      scope: { scopeType: group.scopeType, scopeId: group.scopeId },
+      scopeName: group.name,
+      retentionDays,
+    });
+    setDrawerOpen(true);
+  };
+
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    setEditTarget(null);
   };
 
   const resolved = resolveScopeFilter(scopeFilter, {
@@ -366,16 +401,32 @@ function DataRetentionPage({
                           </Table.Cell>
                           <Table.Cell textAlign="end">
                             {canWrite && (
-                              <Button
-                                size="xs"
-                                variant="ghost"
-                                colorPalette="red"
-                                loading={removeForScope.isLoading}
-                                onClick={() => void removeScopeGroup(group)}
-                                aria-label="Remove retention policy"
-                              >
-                                <Trash2 size={14} />
-                              </Button>
+                              <Menu.Root>
+                                <Menu.Trigger asChild>
+                                  <Button
+                                    size="xs"
+                                    variant="ghost"
+                                    aria-label={`Actions for ${group.name}`}
+                                  >
+                                    <MoreVertical size={14} />
+                                  </Button>
+                                </Menu.Trigger>
+                                <Menu.Content>
+                                  <Menu.Item
+                                    value="edit"
+                                    onClick={() => openEditForGroup(group)}
+                                  >
+                                    <Pencil size={14} /> Edit
+                                  </Menu.Item>
+                                  <Menu.Item
+                                    value="remove"
+                                    color="red.500"
+                                    onClick={() => setRemoveTarget(group)}
+                                  >
+                                    <Trash2 size={14} /> Remove
+                                  </Menu.Item>
+                                </Menu.Content>
+                              </Menu.Root>
                             )}
                           </Table.Cell>
                         </Table.Row>
@@ -399,7 +450,8 @@ function DataRetentionPage({
         {available && (
           <AddOverrideDrawer
             open={drawerOpen}
-            onClose={() => setDrawerOpen(false)}
+            onClose={closeDrawer}
+            editTarget={editTarget}
             available={available}
             currentOrganizationId={organizationId}
             currentTeamId={teamId}
@@ -476,7 +528,7 @@ function DataRetentionPage({
               if (!applyToExisting) {
                 const result = await saveOverrides();
                 const status = reportSaveResults(result);
-                if (status.success) setDrawerOpen(false);
+                if (status.success) closeDrawer();
                 return;
               }
 
@@ -555,12 +607,24 @@ function DataRetentionPage({
                       });
                     }
                   }
-                  if (status.success) setDrawerOpen(false);
+                  if (status.success) closeDrawer();
                 },
               });
             }}
           />
         )}
+
+        <RemoveScopeConfirmDialog
+          group={removeTarget}
+          projectId={projectId}
+          isRemoving={removeForScope.isLoading}
+          onCancel={() => setRemoveTarget(null)}
+          onConfirm={async () => {
+            if (!removeTarget) return;
+            await removeScopeGroup(removeTarget);
+            setRemoveTarget(null);
+          }}
+        />
 
         <ApplyToExistingConfirmDialog
           pending={pendingConfirm}

--- a/langwatch/src/server/api/routers/dataRetention.ts
+++ b/langwatch/src/server/api/routers/dataRetention.ts
@@ -112,6 +112,25 @@ export const dataRetentionRouter = createTRPCRouter({
       }
     }),
 
+  /**
+   * Preview the retention each category would fall back to if the scope's
+   * override were removed — the cascade value (next tier, or the platform
+   * default) the data would land on. Powers the remove-confirmation dialog so
+   * the user sees the real post-removal number, never a guessed one. Read-only;
+   * gated by the same write-on-scope check as the removal it previews, so the
+   * resolved org-default never leaks to a caller who couldn't remove the rule.
+   */
+  previewScopeRemoval: protectedProcedure
+    .input(z.object({ projectId: z.string(), scope: scopeInput }))
+    .use(authorizeInResolver)
+    .query(async ({ input, ctx }) => {
+      await assertCanWriteRetentionScope(
+        { prisma: ctx.prisma, session: ctx.session },
+        input.scope,
+      );
+      return getApp().dataRetention.policy.previewScopeRemoval(input.scope);
+    }),
+
   /** Remove one category's override at one scope; the next tier then applies. */
   removeForScope: protectedProcedure
     .input(

--- a/langwatch/src/server/api/routers/dataRetention.ts
+++ b/langwatch/src/server/api/routers/dataRetention.ts
@@ -9,6 +9,7 @@ import {
   assertRetentionPlan,
   assertRetentionPlanForScope,
 } from "~/server/data-retention/policy/dataRetentionPolicy.authz";
+import { resolveScopeStorageUsage } from "~/server/data-retention/metering/storageMeter.read";
 import { getRetentionPolicySnapshot } from "~/server/data-retention/policy/dataRetentionPolicy.read";
 import { ScopeTargetNotFoundError } from "~/server/data-retention/policy/dataRetentionPolicy.service";
 
@@ -222,23 +223,21 @@ export const dataRetentionRouter = createTRPCRouter({
       });
     }),
 
-  getStorageUsage: protectedProcedure
-    .input(z.object({ projectId: z.string() }))
+  /**
+   * Total stored bytes for the projects the scope selector resolves to, summed
+   * across every in-scope project the caller can read. Lets the Data Storage
+   * card reflect the chosen scope (organization / team / project) instead of
+   * always showing only the current project. RBAC-filtering happens inside the
+   * resolver against the scope's owning org, so a wider scope never leaks a
+   * project's storage the caller couldn't see.
+   */
+  getScopeStorageUsage: protectedProcedure
+    .input(z.object({ projectId: z.string(), scope: scopeInput }))
     .use(checkProjectPermission("traces:view"))
-    .query(async ({ input }) => {
-      const totalBytes =
-        await getApp().dataRetention.metering.getTotalStorageBytes({
-          tenantId: input.projectId,
-        });
-      return { totalBytes };
-    }),
-
-  getStorageBreakdown: protectedProcedure
-    .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("traces:view"))
-    .query(async ({ input }) => {
-      return getApp().dataRetention.metering.getStorageBreakdown({
-        tenantId: input.projectId,
+    .query(async ({ input, ctx }) => {
+      return resolveScopeStorageUsage(ctx, {
+        projectId: input.projectId,
+        scope: input.scope,
       });
     }),
 });

--- a/langwatch/src/server/api/routers/dataRetention.ts
+++ b/langwatch/src/server/api/routers/dataRetention.ts
@@ -3,13 +3,13 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { getApp } from "~/server/app-layer/app";
 import type { Session } from "~/server/auth";
+import { resolveScopeStorageUsage } from "~/server/data-retention/metering/storageMeter.read";
 import {
   assertCanDisableRetention,
   assertCanWriteRetentionScope,
   assertRetentionPlan,
   assertRetentionPlanForScope,
 } from "~/server/data-retention/policy/dataRetentionPolicy.authz";
-import { resolveScopeStorageUsage } from "~/server/data-retention/metering/storageMeter.read";
 import { getRetentionPolicySnapshot } from "~/server/data-retention/policy/dataRetentionPolicy.read";
 import { ScopeTargetNotFoundError } from "~/server/data-retention/policy/dataRetentionPolicy.service";
 

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -478,9 +478,9 @@ export function initializeDefaultApp(options?: {
   const retroactiveUpdateService = new RetroactiveUpdateService(
     clickhouseEnabled ? resolveClickHouseClient : null,
   );
-  const storageMeterService = new StorageMeterService(
-    clickhouseEnabled ? resolveClickHouseClient : null,
-  );
+  const storageMeterService = new StorageMeterService({
+    resolveClickHouseClient: clickhouseEnabled ? resolveClickHouseClient : null,
+  });
   const dataRetention: DataRetentionDependencies = {
     policy: dataRetentionPolicyService,
     pinning: pinnedTraceService,
@@ -985,7 +985,7 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
       ),
       pinning: testPinnedTraceService,
       retroactive: new RetroactiveUpdateService(null),
-      metering: new StorageMeterService(null),
+      metering: new StorageMeterService({ resolveClickHouseClient: null }),
     },
     share: new ShareService(
       new PrismaShareRepository(testPrisma),

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.read.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.read.unit.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rbacMocks = vi.hoisted(() => ({ batchScopePermissions: vi.fn() }));
+vi.mock("~/server/api/rbac", () => rbacMocks);
+
+const appMocks = vi.hoisted(() => ({
+  getTotalStorageBytes: vi.fn(),
+  getTotalStorageBytesForTenants: vi.fn(),
+}));
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({
+    dataRetention: {
+      metering: {
+        getTotalStorageBytes: appMocks.getTotalStorageBytes,
+        getTotalStorageBytesForTenants: appMocks.getTotalStorageBytesForTenants,
+      },
+    },
+  }),
+}));
+
+import { resolveScopeStorageUsage } from "../storageMeter.read";
+
+/**
+ * The storage card must reflect the scope selector. `resolveScopeStorageUsage`
+ * enumerates the in-scope projects FROM the caller's org, RBAC-filters them to
+ * `traces:view`, then sums each tenant's storage. The security property under
+ * test: a wider scope can only ever surface storage for projects the caller is
+ * already allowed to read.
+ */
+describe("resolveScopeStorageUsage", () => {
+  const session = { user: { id: "user_alice" } } as any;
+  const prisma = {
+    project: { findFirst: vi.fn(), findMany: vi.fn() },
+  } as any;
+  const ctx = { prisma, session };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.project.findFirst.mockResolvedValue({
+      team: { organizationId: "org_1" },
+    });
+    appMocks.getTotalStorageBytesForTenants.mockImplementation(
+      async (ids: string[]) => ids.length * 100,
+    );
+  });
+
+  describe("given an organization scope", () => {
+    it("sums every org project the caller can read", async () => {
+      prisma.project.findMany.mockResolvedValue([
+        { id: "proj_a", teamId: "team_a" },
+        { id: "proj_b", teamId: "team_b" },
+        { id: "proj_c", teamId: "team_b" },
+      ]);
+      // Caller can read a and c, but not b.
+      rbacMocks.batchScopePermissions.mockResolvedValue({
+        teams: new Map(),
+        projects: new Map([
+          ["proj_a", true],
+          ["proj_b", false],
+          ["proj_c", true],
+        ]),
+      });
+
+      const result = await resolveScopeStorageUsage(ctx, {
+        projectId: "proj_a",
+        scope: { scopeType: "ORGANIZATION", scopeId: "org_1" },
+      });
+
+      expect(appMocks.getTotalStorageBytesForTenants).toHaveBeenCalledWith([
+        "proj_a",
+        "proj_c",
+      ]);
+      expect(result).toEqual({ totalBytes: 200, projectCount: 2 });
+    });
+  });
+
+  describe("given a team scope", () => {
+    it("enumerates only that team's projects, constrained to the org", async () => {
+      prisma.project.findMany.mockResolvedValue([
+        { id: "proj_b", teamId: "team_b" },
+        { id: "proj_c", teamId: "team_b" },
+      ]);
+      rbacMocks.batchScopePermissions.mockResolvedValue({
+        teams: new Map(),
+        projects: new Map([
+          ["proj_b", true],
+          ["proj_c", true],
+        ]),
+      });
+
+      const result = await resolveScopeStorageUsage(ctx, {
+        projectId: "proj_b",
+        scope: { scopeType: "TEAM", scopeId: "team_b" },
+      });
+
+      const where = prisma.project.findMany.mock.calls[0]![0].where;
+      expect(where).toEqual({ teamId: "team_b", team: { organizationId: "org_1" } });
+      expect(result).toEqual({ totalBytes: 200, projectCount: 2 });
+    });
+  });
+
+  describe("given a foreign scope id the caller cannot reach", () => {
+    it("resolves to no projects and zero bytes", async () => {
+      // org-constrained query returns nothing for a scopeId in another org
+      prisma.project.findMany.mockResolvedValue([]);
+
+      const result = await resolveScopeStorageUsage(ctx, {
+        projectId: "proj_a",
+        scope: { scopeType: "PROJECT", scopeId: "proj_in_other_org" },
+      });
+
+      expect(result).toEqual({ totalBytes: 0, projectCount: 0 });
+      expect(rbacMocks.batchScopePermissions).not.toHaveBeenCalled();
+      expect(appMocks.getTotalStorageBytesForTenants).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a personal-account project with no organization", () => {
+    it("returns just that project's storage", async () => {
+      prisma.project.findFirst.mockResolvedValue({ team: null });
+      appMocks.getTotalStorageBytes.mockResolvedValue(512);
+
+      const result = await resolveScopeStorageUsage(ctx, {
+        projectId: "proj_personal",
+        scope: { scopeType: "PROJECT", scopeId: "proj_personal" },
+      });
+
+      expect(appMocks.getTotalStorageBytes).toHaveBeenCalledWith({
+        tenantId: "proj_personal",
+      });
+      expect(result).toEqual({ totalBytes: 512, projectCount: 1 });
+    });
+  });
+});

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.read.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.read.unit.test.ts
@@ -94,7 +94,10 @@ describe("resolveScopeStorageUsage", () => {
       });
 
       const where = prisma.project.findMany.mock.calls[0]![0].where;
-      expect(where).toEqual({ teamId: "team_b", team: { organizationId: "org_1" } });
+      expect(where).toEqual({
+        teamId: "team_b",
+        team: { organizationId: "org_1" },
+      });
       expect(result).toEqual({ totalBytes: 200, projectCount: 2 });
     });
   });

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -15,7 +15,9 @@ describe("StorageMeterService memory guard", () => {
       json: async () => [{ total: "42" }],
     });
     const client = { query } as const;
-    const service = new StorageMeterService(async () => client as any);
+    const service = new StorageMeterService({
+      resolveClickHouseClient: async () => client as any,
+    });
     return { service, query };
   }
 
@@ -68,7 +70,10 @@ describe("StorageMeterService memory guard", () => {
           })),
         } as any;
       });
-      return { service: new StorageMeterService(resolver), resolver };
+      return {
+        service: new StorageMeterService({ resolveClickHouseClient: resolver }),
+        resolver,
+      };
     }
 
     it("sums each tenant's total", async () => {
@@ -136,7 +141,8 @@ describe("StorageMeterService memory guard", () => {
         call += 1;
         return { json: async () => [{ total: String(total) }] };
       });
-      const service = new StorageMeterService(async () => ({ query }) as any, {
+      const service = new StorageMeterService({
+        resolveClickHouseClient: async () => ({ query }) as any,
         now: () => t,
       });
       return { service, query, advance: (ms: number) => (t += ms) };
@@ -204,7 +210,10 @@ describe("StorageMeterService memory guard", () => {
           if (resolverCall >= 2) throw new Error("cluster unreachable");
           return { query } as any;
         });
-        const service = new StorageMeterService(resolver, { now: () => t });
+        const service = new StorageMeterService({
+          resolveClickHouseClient: resolver,
+          now: () => t,
+        });
 
         expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(42);
         t += FRESH_MS;
@@ -232,7 +241,10 @@ describe("StorageMeterService memory guard", () => {
           if (resolverCall === 1) throw new Error("cluster unreachable");
           return { query } as any;
         });
-        const service = new StorageMeterService(resolver, { now: () => t });
+        const service = new StorageMeterService({
+          resolveClickHouseClient: resolver,
+          now: () => t,
+        });
 
         // First ever read fails -> degraded 0, cached already-stale.
         expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(0);
@@ -264,7 +276,9 @@ describe("StorageMeterService memory guard", () => {
             return { json: async () => [{ total: "10" }] };
           });
         const client = { query } as const;
-        const service = new StorageMeterService(async () => client as any);
+        const service = new StorageMeterService({
+          resolveClickHouseClient: async () => client as any,
+        });
 
         const total = await service.getTotalStorageBytes({
           tenantId: "p-heavy",

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -19,7 +19,9 @@ describe("StorageMeterService memory guard", () => {
     return { service, query };
   }
 
-  function assertGuarded(call: { clickhouse_settings?: Record<string, unknown> }) {
+  function assertGuarded(call: {
+    clickhouse_settings?: Record<string, unknown>;
+  }) {
     expect(call.clickhouse_settings).toBeDefined();
     expect(call.clickhouse_settings!.max_threads).toBe(2);
     // A coarse guardrail so a runaway byteSize recompute can't grind for a
@@ -126,20 +128,28 @@ describe("StorageMeterService memory guard", () => {
         // The combined UNION ALL aggregate trips the per-query limit, but each
         // table's own query still succeeds — the total should degrade to the
         // sum of the per-table subtotals rather than failing the whole metric.
-        const query = vi.fn().mockImplementation(async (arg: { query: string }) => {
-          if (arg.query.includes("UNION ALL")) {
-            throw new Error("Code: 241. DB::Exception: memory limit exceeded");
-          }
-          return { json: async () => [{ total: "10" }] };
-        });
+        const query = vi
+          .fn()
+          .mockImplementation(async (arg: { query: string }) => {
+            if (arg.query.includes("UNION ALL")) {
+              throw new Error(
+                "Code: 241. DB::Exception: memory limit exceeded",
+              );
+            }
+            return { json: async () => [{ total: "10" }] };
+          });
         const client = { query } as const;
         const service = new StorageMeterService(async () => client as any);
 
-        const total = await service.getTotalStorageBytes({ tenantId: "p-heavy" });
+        const total = await service.getTotalStorageBytes({
+          tenantId: "p-heavy",
+        });
 
         expect(total).toBe(10 * RETENTION_MANAGED_TABLES.length);
         // one failed aggregate attempt + one query per table for the fallback
-        expect(query).toHaveBeenCalledTimes(1 + RETENTION_MANAGED_TABLES.length);
+        expect(query).toHaveBeenCalledTimes(
+          1 + RETENTION_MANAGED_TABLES.length,
+        );
       });
     });
   });

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -122,6 +122,131 @@ describe("StorageMeterService memory guard", () => {
     });
   });
 
+  describe("given the stale-while-revalidate cache", () => {
+    const FRESH_MS = 5 * 60 * 1000;
+
+    // A service whose clock we control and whose query returns the next value
+    // from `totals` on each call, so we can assert fresh/stale/refresh timing
+    // without waiting real time.
+    function makeClockService(totals: number[]) {
+      let t = 0;
+      let call = 0;
+      const query = vi.fn(async () => {
+        const total = totals[Math.min(call, totals.length - 1)]!;
+        call += 1;
+        return { json: async () => [{ total: String(total) }] };
+      });
+      const service = new StorageMeterService(async () => ({ query }) as any, {
+        now: () => t,
+      });
+      return { service, query, advance: (ms: number) => (t += ms) };
+    }
+
+    describe("when the cached value is still fresh", () => {
+      it("returns it without recomputing", async () => {
+        const { service, query, advance } = makeClockService([42]);
+
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(42);
+        advance(FRESH_MS - 1);
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(42);
+
+        expect(query).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when the cached value is stale", () => {
+      it("returns the stale value immediately and refreshes in the background", async () => {
+        const { service, query, advance } = makeClockService([42, 99]);
+
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(42);
+        advance(FRESH_MS);
+
+        // The stale read serves the old value at once, not the refreshed one.
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(42);
+        await vi.waitFor(() => expect(query).toHaveBeenCalledTimes(2));
+
+        // A later read serves the value the background refresh wrote.
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(99);
+      });
+
+      it("recomputes only once when several stale reads race", async () => {
+        const { service, query, advance } = makeClockService([42, 99]);
+
+        await service.getTotalStorageBytes({ tenantId: "t" });
+        advance(FRESH_MS);
+
+        await Promise.all([
+          service.getTotalStorageBytes({ tenantId: "t" }),
+          service.getTotalStorageBytes({ tenantId: "t" }),
+          service.getTotalStorageBytes({ tenantId: "t" }),
+        ]);
+        await vi.waitFor(() => expect(query).toHaveBeenCalledTimes(2));
+
+        // Give any errant second refresh a chance to fire, then prove it didn't:
+        // the per-tenant lock single-flights the recompute.
+        await new Promise((r) => setTimeout(r, 10));
+        expect(query).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("when a background refresh fails", () => {
+      it("keeps serving the last good value instead of caching the failure", async () => {
+        // The client resolver is the real fault line: queryTotalBytes catches
+        // query errors and falls back, but a failure to even resolve a client
+        // (cluster unreachable) propagates. Seed succeeds, the refresh fails.
+        let t = 0;
+        let resolverCall = 0;
+        const query = vi.fn(async () => ({
+          json: async () => [{ total: "42" }],
+        }));
+        const resolver = vi.fn(async () => {
+          resolverCall += 1;
+          if (resolverCall >= 2) throw new Error("cluster unreachable");
+          return { query } as any;
+        });
+        const service = new StorageMeterService(resolver, { now: () => t });
+
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(42);
+        t += FRESH_MS;
+
+        // Stale read returns last good 42; the background refresh throws.
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(42);
+        await vi.waitFor(() => expect(resolver).toHaveBeenCalledTimes(2));
+
+        // Still 42 — the failed refresh did not poison the cache with a 0.
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(42);
+        // The one successful read is the seed; the refresh never reached query.
+        expect(query).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when the cold read fails", () => {
+      it("degrades to 0 and self-heals on the next read", async () => {
+        let t = 0;
+        let resolverCall = 0;
+        const query = vi.fn(async () => ({
+          json: async () => [{ total: "77" }],
+        }));
+        const resolver = vi.fn(async () => {
+          resolverCall += 1;
+          if (resolverCall === 1) throw new Error("cluster unreachable");
+          return { query } as any;
+        });
+        const service = new StorageMeterService(resolver, { now: () => t });
+
+        // First ever read fails -> degraded 0, cached already-stale.
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(0);
+
+        // Next read returns the cached 0 instantly and refreshes in background.
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(0);
+        await vi.waitFor(() => expect(query).toHaveBeenCalledTimes(1));
+
+        // Once healed, the real value is served.
+        expect(await service.getTotalStorageBytes({ tenantId: "t" })).toBe(77);
+      });
+    });
+  });
+
   describe("given a heavy tenant where the aggregate query can exceed limits", () => {
     describe("when the single aggregate total query fails", () => {
       it("falls back to the per-table breakdown instead of throwing", async () => {

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -51,6 +51,75 @@ describe("StorageMeterService memory guard", () => {
     });
   });
 
+  describe("when summing storage across many tenants for a scope", () => {
+    function makeMultiTenantService(
+      totals: Record<string, number>,
+      failing: Set<string> = new Set(),
+    ) {
+      const resolver = vi.fn(async (tenantId: string) => {
+        if (failing.has(tenantId)) throw new Error("cluster unreachable");
+        return {
+          query: vi.fn(async (arg: { query_params: { tenantId: string } }) => ({
+            json: async () => [
+              { total: String(totals[arg.query_params.tenantId] ?? 0) },
+            ],
+          })),
+        } as any;
+      });
+      return { service: new StorageMeterService(resolver), resolver };
+    }
+
+    it("sums each tenant's total", async () => {
+      const { service } = makeMultiTenantService({ a: 10, b: 20, c: 30 });
+
+      const total = await service.getTotalStorageBytesForTenants([
+        "a",
+        "b",
+        "c",
+      ]);
+
+      expect(total).toBe(60);
+    });
+
+    it("counts each tenant once even if passed twice", async () => {
+      const { service, resolver } = makeMultiTenantService({ a: 10, b: 20 });
+
+      const total = await service.getTotalStorageBytesForTenants([
+        "a",
+        "a",
+        "b",
+      ]);
+
+      expect(total).toBe(30);
+      // 'a' resolved once despite appearing twice in the input
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns 0 for an empty tenant list without querying", async () => {
+      const { service, resolver } = makeMultiTenantService({});
+
+      const total = await service.getTotalStorageBytesForTenants([]);
+
+      expect(total).toBe(0);
+      expect(resolver).not.toHaveBeenCalled();
+    });
+
+    it("degrades a failing tenant to 0 instead of failing the scope total", async () => {
+      const { service } = makeMultiTenantService(
+        { a: 10, b: 20, c: 30 },
+        new Set(["b"]),
+      );
+
+      const total = await service.getTotalStorageBytesForTenants([
+        "a",
+        "b",
+        "c",
+      ]);
+
+      expect(total).toBe(40);
+    });
+  });
+
   describe("given a heavy tenant where the aggregate query can exceed limits", () => {
     describe("when the single aggregate total query fails", () => {
       it("falls back to the per-table breakdown instead of throwing", async () => {

--- a/langwatch/src/server/data-retention/metering/storageMeter.read.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.read.ts
@@ -1,0 +1,90 @@
+import type { PrismaClient } from "@prisma/client";
+import { batchScopePermissions } from "~/server/api/rbac";
+import { getApp } from "~/server/app-layer/app";
+import type { Session } from "~/server/auth";
+import type { ScopeTier } from "~/server/scopes/scope.types";
+
+export type ReadCtx = { prisma: PrismaClient; session: Session | null };
+
+export type StorageScopeUsage = {
+  /** Total stored bytes across every in-scope project the caller can read. */
+  totalBytes: number;
+  /** How many projects contributed — lets the UI say "across N projects". */
+  projectCount: number;
+};
+
+/**
+ * Total stored bytes for the projects a scope resolves to, RBAC-filtered to the
+ * ones the caller may read. The Data Storage card uses this so the number
+ * tracks the page's scope selector (organization / team / project) instead of
+ * only ever showing the project on the top nav.
+ *
+ * Projects are always enumerated FROM the caller's organization (a foreign
+ * team/project id resolves to no rows), then narrowed to `traces:view` via the
+ * batched permission check — so a wider scope can never surface a project's
+ * storage the caller couldn't otherwise see. Summing delegates to the metering
+ * service's per-tenant path, which keeps the hardened ClickHouse settings and
+ * the 5-minute cache (see storageMeter.service.ts).
+ */
+export async function resolveScopeStorageUsage(
+  ctx: ReadCtx,
+  params: {
+    projectId: string;
+    scope: { scopeType: ScopeTier; scopeId: string };
+  },
+): Promise<StorageScopeUsage> {
+  const { projectId, scope } = params;
+  const metering = getApp().dataRetention.metering;
+
+  const project = await ctx.prisma.project.findFirst({
+    where: { id: projectId },
+    select: { team: { select: { organizationId: true } } },
+  });
+  const organizationId = project?.team?.organizationId ?? null;
+
+  // Personal-account project (no org): the scope can only be the project
+  // itself, already authorized by the route's project:view guard.
+  if (!organizationId) {
+    const totalBytes = await metering.getTotalStorageBytes({
+      tenantId: projectId,
+    });
+    return { totalBytes, projectCount: 1 };
+  }
+
+  // Enumerate candidate projects within the caller's org for the chosen scope.
+  // The org constraint is what makes a foreign scopeId resolve to nothing.
+  const where =
+    scope.scopeType === "PROJECT"
+      ? { id: scope.scopeId, team: { organizationId } }
+      : scope.scopeType === "TEAM"
+        ? { teamId: scope.scopeId, team: { organizationId } }
+        : { team: { organizationId } };
+
+  const candidates = await ctx.prisma.project.findMany({
+    where,
+    select: { id: true, teamId: true },
+  });
+
+  if (candidates.length === 0) {
+    return { totalBytes: 0, projectCount: 0 };
+  }
+
+  const projectTeamId: Record<string, string> = {};
+  for (const p of candidates) projectTeamId[p.id] = p.teamId;
+
+  const { projects } = await batchScopePermissions(ctx, {
+    organizationId,
+    teamIds: [],
+    projectIds: candidates.map((p) => p.id),
+    projectTeamId,
+    permission: "traces:view",
+  });
+
+  const authorizedIds = candidates
+    .map((p) => p.id)
+    .filter((id) => projects.get(id) === true);
+
+  const totalBytes =
+    await metering.getTotalStorageBytesForTenants(authorizedIds);
+  return { totalBytes, projectCount: authorizedIds.length };
+}

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -72,14 +72,19 @@ interface StorageBreakdown {
 }
 
 export class StorageMeterService {
+  private readonly resolveClickHouseClient: ClickHouseClientResolver | null;
   private readonly cache: TtlCache<CachedBytes>;
   private readonly refreshLock: TtlCache<number>;
   private readonly now: () => number;
 
-  constructor(
-    private readonly resolveClickHouseClient: ClickHouseClientResolver | null,
-    options?: { now?: () => number },
-  ) {
+  constructor({
+    resolveClickHouseClient,
+    now,
+  }: {
+    resolveClickHouseClient: ClickHouseClientResolver | null;
+    now?: () => number;
+  }) {
+    this.resolveClickHouseClient = resolveClickHouseClient;
     this.cache = new TtlCache(STORAGE_HARD_TTL_MS, "storage-meter:v2:");
     this.refreshLock = new TtlCache(
       REFRESH_LOCK_TTL_MS,
@@ -87,7 +92,7 @@ export class StorageMeterService {
     );
     // Injectable clock so the stale-while-revalidate timing is deterministic in
     // tests; production uses the wall clock.
-    this.now = options?.now ?? (() => Date.now());
+    this.now = now ?? (() => Date.now());
   }
 
   /**
@@ -141,8 +146,8 @@ export class StorageMeterService {
    *  expire (not released) so a tenant is refreshed at most once per window, and
    *  a failed refresh keeps the last good value rather than poisoning the cache. */
   private async refreshInBackground(tenantId: string): Promise<void> {
-    const won = await this.refreshLock.claim(tenantId, 1);
-    if (!won) return;
+    const hasRefreshLock = await this.refreshLock.claim(tenantId, 1);
+    if (!hasRefreshLock) return;
     try {
       await this.computeAndStore(tenantId);
     } catch (error) {

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -90,9 +90,7 @@ export class StorageMeterService {
    * project can't fail the scope total — acceptable because this powers a
    * display, not billing.
    */
-  async getTotalStorageBytesForTenants(
-    tenantIds: string[],
-  ): Promise<number> {
+  async getTotalStorageBytesForTenants(tenantIds: string[]): Promise<number> {
     const unique = Array.from(new Set(tenantIds));
     if (unique.length === 0) return 0;
 

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -75,6 +75,48 @@ export class StorageMeterService {
   }
 
   /**
+   * Total stored bytes summed across many tenants (e.g. every project in an
+   * organization or team scope). Intentionally reuses {@link getTotalStorageBytes}
+   * per tenant rather than issuing one `TenantId IN (...)` sum: each per-tenant
+   * read keeps the hardened settings (capped threads + execution time + the
+   * per-table fallback) AND its own 5-minute cache, so an org-wide total is
+   * mostly cache hits and a single heavy tenant can't blow the memory ceiling
+   * for the whole scope. A wide `IN` sum would re-expose the OOM hazard that
+   * `_size_bytes`'s lazy recompute caused in production and bypass the cache.
+   *
+   * Reads run with bounded concurrency so a cold cache over a large org issues
+   * a steady trickle rather than a thundering herd of recompute reads. A tenant
+   * whose read fails degrades to 0 (its own fallback already tried), so one
+   * project can't fail the scope total — acceptable because this powers a
+   * display, not billing.
+   */
+  async getTotalStorageBytesForTenants(
+    tenantIds: string[],
+  ): Promise<number> {
+    const unique = Array.from(new Set(tenantIds));
+    if (unique.length === 0) return 0;
+
+    const CONCURRENCY = 8;
+    let total = 0;
+    for (let i = 0; i < unique.length; i += CONCURRENCY) {
+      const batch = unique.slice(i, i + CONCURRENCY);
+      const results = await Promise.all(
+        batch.map((tenantId) =>
+          this.getTotalStorageBytes({ tenantId }).catch((error) => {
+            logger.warn(
+              { tenantId, error },
+              "Per-tenant storage read failed in scope aggregation; counting 0",
+            );
+            return 0;
+          }),
+        ),
+      );
+      total += results.reduce((a, b) => a + b, 0);
+    }
+    return total;
+  }
+
+  /**
    * Stored bytes for a tenant grouped by retention category. Each table is
    * queried independently so a single table's failure degrades that category
    * to zero rather than failing the whole breakdown.

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -9,7 +9,31 @@ import {
 
 const logger = createLogger("langwatch:data-retention:metering");
 
-const CACHE_TTL_MS = 5 * 60 * 1000;
+// Stale-while-revalidate windows for the per-tenant byte total.
+//
+// A read within FRESH_MS returns the cached value untouched. Past it (but
+// before the entry's hard TTL lapses in Redis) the read still returns the
+// cached value *immediately* and kicks a background recompute — so the only
+// request that ever blocks on the heavy `_size_bytes` read is the very first
+// for a tenant (or one after a long idle gap). HARD_TTL_MS is the underlying
+// Redis TTL: long enough that an active org keeps serving instantly across the
+// 5-minute freshness boundary, short enough that a cold entry eventually drops.
+const STORAGE_FRESH_MS = 5 * 60 * 1000;
+const STORAGE_HARD_TTL_MS = 30 * 60 * 1000;
+
+// Background refreshes are single-flighted through a short-lived Redis lock
+// (SET NX): when many pods/tabs see the same entry go stale at once, only the
+// one that claims the lock recomputes — the rest skip. The lock is left to
+// expire rather than released, throttling a tenant's refreshes to at most one
+// per window so a persistently slow tenant can't be re-read every few seconds.
+const REFRESH_LOCK_TTL_MS = 60 * 1000;
+
+/** Cached per-tenant byte total plus the wall-clock it was computed at, so the
+ *  read path can tell fresh from stale without a second timestamp store. */
+interface CachedBytes {
+  bytes: number;
+  computedAt: number;
+}
 
 // Storage metering sums `_size_bytes`, a `UInt32 MATERIALIZED byteSize(...)`
 // column over each table's payload columns. On parts written before that
@@ -48,30 +72,85 @@ interface StorageBreakdown {
 }
 
 export class StorageMeterService {
-  private readonly cache: TtlCache<number>;
+  private readonly cache: TtlCache<CachedBytes>;
+  private readonly refreshLock: TtlCache<number>;
+  private readonly now: () => number;
 
   constructor(
     private readonly resolveClickHouseClient: ClickHouseClientResolver | null,
+    options?: { now?: () => number },
   ) {
-    this.cache = new TtlCache(CACHE_TTL_MS, "storage-meter:");
+    this.cache = new TtlCache(STORAGE_HARD_TTL_MS, "storage-meter:v2:");
+    this.refreshLock = new TtlCache(
+      REFRESH_LOCK_TTL_MS,
+      "storage-meter:refresh:",
+    );
+    // Injectable clock so the stale-while-revalidate timing is deterministic in
+    // tests; production uses the wall clock.
+    this.now = options?.now ?? (() => Date.now());
   }
 
   /**
-   * Total stored bytes for a tenant across all retention-managed tables,
-   * served from a short-lived cache and computed via {@link queryTotalBytes}
-   * on a miss.
+   * Total stored bytes for a tenant across all retention-managed tables, served
+   * stale-while-revalidate: a cached value is returned immediately, and if it
+   * has aged past {@link STORAGE_FRESH_MS} a single-flighted background refresh
+   * is kicked (see {@link refreshInBackground}). Only the first read for a
+   * tenant — when nothing is cached — blocks on the heavy {@link queryTotalBytes}.
    */
   async getTotalStorageBytes({
     tenantId,
   }: {
     tenantId: string;
   }): Promise<number> {
-    const cached = await this.cache.get(tenantId);
-    if (cached !== undefined) return cached;
+    const entry = await this.cache.get(tenantId);
+    if (entry !== undefined) {
+      if (this.now() - entry.computedAt >= STORAGE_FRESH_MS) {
+        void this.refreshInBackground(tenantId);
+      }
+      return entry.bytes;
+    }
 
-    const total = await this.queryTotalBytes(tenantId);
-    await this.cache.set(tenantId, total);
-    return total;
+    // Cold (or long-idle) tenant: compute synchronously so the caller gets a
+    // real number. A failing read caches a degraded 0 marked already-stale, so
+    // the scope total doesn't re-trigger this heavy failing query every request
+    // yet self-heals via a background refresh on the next read.
+    try {
+      return await this.computeAndStore(tenantId);
+    } catch (error) {
+      logger.warn(
+        { tenantId, error },
+        "Cold storage read failed; caching degraded 0 (self-heals on next read)",
+      );
+      await this.cache.set(tenantId, {
+        bytes: 0,
+        computedAt: this.now() - STORAGE_FRESH_MS,
+      });
+      return 0;
+    }
+  }
+
+  /** Recompute a tenant's total and write it to the cache stamped now. Shared by
+   *  the cold path and the background refresh. */
+  private async computeAndStore(tenantId: string): Promise<number> {
+    const bytes = await this.queryTotalBytes(tenantId);
+    await this.cache.set(tenantId, { bytes, computedAt: this.now() });
+    return bytes;
+  }
+
+  /** Single-flighted background recompute for a stale entry. The lock is left to
+   *  expire (not released) so a tenant is refreshed at most once per window, and
+   *  a failed refresh keeps the last good value rather than poisoning the cache. */
+  private async refreshInBackground(tenantId: string): Promise<void> {
+    const won = await this.refreshLock.claim(tenantId, 1);
+    if (!won) return;
+    try {
+      await this.computeAndStore(tenantId);
+    } catch (error) {
+      logger.warn(
+        { tenantId, error },
+        "Background storage refresh failed; keeping last good value",
+      );
+    }
   }
 
   /**
@@ -79,10 +158,12 @@ export class StorageMeterService {
    * organization or team scope). Intentionally reuses {@link getTotalStorageBytes}
    * per tenant rather than issuing one `TenantId IN (...)` sum: each per-tenant
    * read keeps the hardened settings (capped threads + execution time + the
-   * per-table fallback) AND its own 5-minute cache, so an org-wide total is
-   * mostly cache hits and a single heavy tenant can't blow the memory ceiling
-   * for the whole scope. A wide `IN` sum would re-expose the OOM hazard that
-   * `_size_bytes`'s lazy recompute caused in production and bypass the cache.
+   * per-table fallback) AND its own stale-while-revalidate cache, so an org-wide
+   * total is mostly instant cache hits, a stale entry refreshes in the
+   * background instead of blocking the page, and a single heavy tenant can't
+   * blow the memory ceiling for the whole scope. A wide `IN` sum would re-expose
+   * the OOM hazard that `_size_bytes`'s lazy recompute caused in production and
+   * bypass the cache.
    *
    * Reads run with bounded concurrency so a cold cache over a large org issues
    * a steady trickle rather than a thundering herd of recompute reads. A tenant

--- a/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.previewScopeRemoval.unit.test.ts
+++ b/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.previewScopeRemoval.unit.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScopeAssignment } from "~/server/scopes/scope.types";
+import { PLATFORM_DEFAULT_RETENTION_DAYS } from "../../retentionPolicy.schema";
+import { DataRetentionPolicyService } from "../dataRetentionPolicy.service";
+
+/**
+ * `previewScopeRemoval` answers the question the remove-confirmation dialog
+ * asks: "if I delete this rule, what retention does the data fall back to?".
+ * It must mirror exactly what a real removal would resolve to — the next tier
+ * in the cascade, or the platform default — so the dialog never shows a number
+ * that differs from reality.
+ */
+describe("DataRetentionPolicyService.previewScopeRemoval", () => {
+  const repository = {
+    findOrganizationForScope: vi.fn(),
+    findAllInOrganization: vi.fn(),
+    getScopeCascadeChain: vi.fn(),
+  };
+  const cache = {} as any;
+  const service = new DataRetentionPolicyService(repository as any, cache);
+
+  const PROJECT_SCOPE: ScopeAssignment = {
+    scopeType: "PROJECT",
+    scopeId: "proj-1",
+  };
+  const PROJECT_CHAIN: ScopeAssignment[] = [
+    { scopeType: "PROJECT", scopeId: "proj-1" },
+    { scopeType: "TEAM", scopeId: "team-1" },
+    { scopeType: "ORGANIZATION", scopeId: "org-1" },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repository.findOrganizationForScope.mockResolvedValue("org-1");
+    repository.getScopeCascadeChain.mockResolvedValue(PROJECT_CHAIN);
+  });
+
+  describe("given a project override with a team rule above it", () => {
+    it("falls back to the team value", async () => {
+      repository.findAllInOrganization.mockResolvedValue([
+        { scopeType: "PROJECT", scopeId: "proj-1", category: "traces", retentionDays: 91 },
+        { scopeType: "TEAM", scopeId: "team-1", category: "traces", retentionDays: 63 },
+      ]);
+
+      const result = await service.previewScopeRemoval(PROJECT_SCOPE);
+
+      expect(result.traces).toBe(63);
+    });
+  });
+
+  describe("given a project override with only an org rule above it", () => {
+    it("falls back to the org value", async () => {
+      repository.findAllInOrganization.mockResolvedValue([
+        { scopeType: "PROJECT", scopeId: "proj-1", category: "traces", retentionDays: 91 },
+        { scopeType: "ORGANIZATION", scopeId: "org-1", category: "traces", retentionDays: 182 },
+      ]);
+
+      const result = await service.previewScopeRemoval(PROJECT_SCOPE);
+
+      expect(result.traces).toBe(182);
+    });
+  });
+
+  describe("given a project override and nothing else in the chain", () => {
+    it("falls back to the platform default", async () => {
+      repository.findAllInOrganization.mockResolvedValue([
+        { scopeType: "PROJECT", scopeId: "proj-1", category: "traces", retentionDays: 91 },
+      ]);
+
+      const result = await service.previewScopeRemoval(PROJECT_SCOPE);
+
+      expect(result.traces).toBe(PLATFORM_DEFAULT_RETENTION_DAYS);
+    });
+  });
+
+  describe("given an organization override being removed", () => {
+    it("falls back to the platform default for every category", async () => {
+      const orgScope: ScopeAssignment = {
+        scopeType: "ORGANIZATION",
+        scopeId: "org-1",
+      };
+      repository.getScopeCascadeChain.mockResolvedValue([orgScope]);
+      repository.findAllInOrganization.mockResolvedValue([
+        { scopeType: "ORGANIZATION", scopeId: "org-1", category: "traces", retentionDays: 91 },
+        { scopeType: "ORGANIZATION", scopeId: "org-1", category: "scenarios", retentionDays: 91 },
+        { scopeType: "ORGANIZATION", scopeId: "org-1", category: "experiments", retentionDays: 91 },
+      ]);
+
+      const result = await service.previewScopeRemoval(orgScope);
+
+      expect(result).toEqual({
+        traces: PLATFORM_DEFAULT_RETENTION_DAYS,
+        scenarios: PLATFORM_DEFAULT_RETENTION_DAYS,
+        experiments: PLATFORM_DEFAULT_RETENTION_DAYS,
+      });
+    });
+  });
+
+  describe("given the removed scope diverges per category", () => {
+    it("resolves each category's fallback independently", async () => {
+      repository.findAllInOrganization.mockResolvedValue([
+        // traces falls back to the team rule below
+        { scopeType: "PROJECT", scopeId: "proj-1", category: "traces", retentionDays: 735 },
+        { scopeType: "TEAM", scopeId: "team-1", category: "traces", retentionDays: 63 },
+        // scenarios falls back to the org rule
+        { scopeType: "PROJECT", scopeId: "proj-1", category: "scenarios", retentionDays: 735 },
+        { scopeType: "ORGANIZATION", scopeId: "org-1", category: "scenarios", retentionDays: 182 },
+        // experiments has no tier above → platform default
+        { scopeType: "PROJECT", scopeId: "proj-1", category: "experiments", retentionDays: 735 },
+      ]);
+
+      const result = await service.previewScopeRemoval(PROJECT_SCOPE);
+
+      expect(result).toEqual({
+        traces: 63,
+        scenarios: 182,
+        experiments: PLATFORM_DEFAULT_RETENTION_DAYS,
+      });
+    });
+  });
+
+  describe("given the scope's organization cannot be resolved", () => {
+    it("falls back to the platform default for every category", async () => {
+      repository.findOrganizationForScope.mockResolvedValue(null);
+
+      const result = await service.previewScopeRemoval(PROJECT_SCOPE);
+
+      expect(result).toEqual({
+        traces: PLATFORM_DEFAULT_RETENTION_DAYS,
+        scenarios: PLATFORM_DEFAULT_RETENTION_DAYS,
+        experiments: PLATFORM_DEFAULT_RETENTION_DAYS,
+      });
+      expect(repository.findAllInOrganization).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.previewScopeRemoval.unit.test.ts
+++ b/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.previewScopeRemoval.unit.test.ts
@@ -38,8 +38,18 @@ describe("DataRetentionPolicyService.previewScopeRemoval", () => {
   describe("given a project override with a team rule above it", () => {
     it("falls back to the team value", async () => {
       repository.findAllInOrganization.mockResolvedValue([
-        { scopeType: "PROJECT", scopeId: "proj-1", category: "traces", retentionDays: 91 },
-        { scopeType: "TEAM", scopeId: "team-1", category: "traces", retentionDays: 63 },
+        {
+          scopeType: "PROJECT",
+          scopeId: "proj-1",
+          category: "traces",
+          retentionDays: 91,
+        },
+        {
+          scopeType: "TEAM",
+          scopeId: "team-1",
+          category: "traces",
+          retentionDays: 63,
+        },
       ]);
 
       const result = await service.previewScopeRemoval(PROJECT_SCOPE);
@@ -51,8 +61,18 @@ describe("DataRetentionPolicyService.previewScopeRemoval", () => {
   describe("given a project override with only an org rule above it", () => {
     it("falls back to the org value", async () => {
       repository.findAllInOrganization.mockResolvedValue([
-        { scopeType: "PROJECT", scopeId: "proj-1", category: "traces", retentionDays: 91 },
-        { scopeType: "ORGANIZATION", scopeId: "org-1", category: "traces", retentionDays: 182 },
+        {
+          scopeType: "PROJECT",
+          scopeId: "proj-1",
+          category: "traces",
+          retentionDays: 91,
+        },
+        {
+          scopeType: "ORGANIZATION",
+          scopeId: "org-1",
+          category: "traces",
+          retentionDays: 182,
+        },
       ]);
 
       const result = await service.previewScopeRemoval(PROJECT_SCOPE);
@@ -64,7 +84,12 @@ describe("DataRetentionPolicyService.previewScopeRemoval", () => {
   describe("given a project override and nothing else in the chain", () => {
     it("falls back to the platform default", async () => {
       repository.findAllInOrganization.mockResolvedValue([
-        { scopeType: "PROJECT", scopeId: "proj-1", category: "traces", retentionDays: 91 },
+        {
+          scopeType: "PROJECT",
+          scopeId: "proj-1",
+          category: "traces",
+          retentionDays: 91,
+        },
       ]);
 
       const result = await service.previewScopeRemoval(PROJECT_SCOPE);
@@ -81,9 +106,24 @@ describe("DataRetentionPolicyService.previewScopeRemoval", () => {
       };
       repository.getScopeCascadeChain.mockResolvedValue([orgScope]);
       repository.findAllInOrganization.mockResolvedValue([
-        { scopeType: "ORGANIZATION", scopeId: "org-1", category: "traces", retentionDays: 91 },
-        { scopeType: "ORGANIZATION", scopeId: "org-1", category: "scenarios", retentionDays: 91 },
-        { scopeType: "ORGANIZATION", scopeId: "org-1", category: "experiments", retentionDays: 91 },
+        {
+          scopeType: "ORGANIZATION",
+          scopeId: "org-1",
+          category: "traces",
+          retentionDays: 91,
+        },
+        {
+          scopeType: "ORGANIZATION",
+          scopeId: "org-1",
+          category: "scenarios",
+          retentionDays: 91,
+        },
+        {
+          scopeType: "ORGANIZATION",
+          scopeId: "org-1",
+          category: "experiments",
+          retentionDays: 91,
+        },
       ]);
 
       const result = await service.previewScopeRemoval(orgScope);
@@ -100,13 +140,38 @@ describe("DataRetentionPolicyService.previewScopeRemoval", () => {
     it("resolves each category's fallback independently", async () => {
       repository.findAllInOrganization.mockResolvedValue([
         // traces falls back to the team rule below
-        { scopeType: "PROJECT", scopeId: "proj-1", category: "traces", retentionDays: 735 },
-        { scopeType: "TEAM", scopeId: "team-1", category: "traces", retentionDays: 63 },
+        {
+          scopeType: "PROJECT",
+          scopeId: "proj-1",
+          category: "traces",
+          retentionDays: 735,
+        },
+        {
+          scopeType: "TEAM",
+          scopeId: "team-1",
+          category: "traces",
+          retentionDays: 63,
+        },
         // scenarios falls back to the org rule
-        { scopeType: "PROJECT", scopeId: "proj-1", category: "scenarios", retentionDays: 735 },
-        { scopeType: "ORGANIZATION", scopeId: "org-1", category: "scenarios", retentionDays: 182 },
+        {
+          scopeType: "PROJECT",
+          scopeId: "proj-1",
+          category: "scenarios",
+          retentionDays: 735,
+        },
+        {
+          scopeType: "ORGANIZATION",
+          scopeId: "org-1",
+          category: "scenarios",
+          retentionDays: 182,
+        },
         // experiments has no tier above → platform default
-        { scopeType: "PROJECT", scopeId: "proj-1", category: "experiments", retentionDays: 735 },
+        {
+          scopeType: "PROJECT",
+          scopeId: "proj-1",
+          category: "experiments",
+          retentionDays: 735,
+        },
       ]);
 
       const result = await service.previewScopeRemoval(PROJECT_SCOPE);

--- a/langwatch/src/server/data-retention/policy/dataRetentionPolicy.repository.ts
+++ b/langwatch/src/server/data-retention/policy/dataRetentionPolicy.repository.ts
@@ -120,6 +120,42 @@ export class DataRetentionPolicyRepository {
   }
 
   /**
+   * The cascade chain for an arbitrary scope, most-specific-first and including
+   * the scope itself: PROJECT → [PROJECT, TEAM, ORGANIZATION]; TEAM → [TEAM,
+   * ORGANIZATION]; ORGANIZATION → [ORGANIZATION]. The removal-preview resolver
+   * walks this chain over the org's rows minus the scope's own rows, so the
+   * scope tier contributes nothing and each category falls through to the next
+   * tier (or the platform default). Returns just the scope itself when the
+   * lineage can't be resolved (e.g. a personal-account project with no team).
+   */
+  async getScopeCascadeChain(
+    scope: ScopeAssignment,
+  ): Promise<ScopeAssignment[]> {
+    if (scope.scopeType === "PROJECT") {
+      const ctx = await this.getProjectScopeContext(scope.scopeId);
+      if (!ctx) return [{ scopeType: "PROJECT", scopeId: scope.scopeId }];
+      return resolveScopeChain(ctx);
+    }
+    if (scope.scopeType === "TEAM") {
+      const team = await this.prisma.team.findFirst({
+        where: { id: scope.scopeId },
+        select: { organizationId: true },
+      });
+      const chain: ScopeAssignment[] = [
+        { scopeType: "TEAM", scopeId: scope.scopeId },
+      ];
+      if (team?.organizationId) {
+        chain.push({
+          scopeType: "ORGANIZATION",
+          scopeId: team.organizationId,
+        });
+      }
+      return chain;
+    }
+    return [{ scopeType: "ORGANIZATION", scopeId: scope.scopeId }];
+  }
+
+  /**
    * Resolve the organization a (scopeType, scopeId) target belongs to.
    * Wraps the generic scope resolver so the service can stay free of
    * raw Prisma access.

--- a/langwatch/src/server/data-retention/policy/dataRetentionPolicy.service.ts
+++ b/langwatch/src/server/data-retention/policy/dataRetentionPolicy.service.ts
@@ -1,6 +1,10 @@
 import type { RetentionPolicy } from "@prisma/client";
 import type { ScopeAssignment } from "~/server/scopes/scope.types";
 import {
+  type RetentionRow,
+  resolveRetention,
+} from "../resolveRetentionDays";
+import {
   PLATFORM_DEFAULT_RETENTION_DAYS,
   type ResolvedRetention,
   type RetentionCategory,
@@ -35,6 +39,37 @@ export class DataRetentionPolicyService {
         experiments: PLATFORM_DEFAULT_RETENTION_DAYS,
       }
     );
+  }
+
+  /**
+   * The retention each category would fall back to if every override at `scope`
+   * were removed — i.e. the value the next tier in the cascade supplies, or the
+   * platform default when nothing closer applies. Pure preview (no mutation):
+   * reads the org's rows, drops the scope's own rows, and re-resolves the
+   * scope's own cascade chain. Reuses `resolveRetention` so the fallback can
+   * never diverge from what an actual removal would produce. Returns only day
+   * counts — a caller who can manage this scope never learns a sibling scope's
+   * rule identity, only the number their data would land on.
+   */
+  async previewScopeRemoval(
+    scope: ScopeAssignment,
+  ): Promise<ResolvedRetention> {
+    const organizationId =
+      await this.repository.findOrganizationForScope(scope);
+    if (!organizationId) {
+      return {
+        traces: PLATFORM_DEFAULT_RETENTION_DAYS,
+        scenarios: PLATFORM_DEFAULT_RETENTION_DAYS,
+        experiments: PLATFORM_DEFAULT_RETENTION_DAYS,
+      };
+    }
+    const rows = await this.repository.findAllInOrganization(organizationId);
+    const remaining = rows.filter(
+      (r) =>
+        !(r.scopeType === scope.scopeType && r.scopeId === scope.scopeId),
+    ) as RetentionRow[];
+    const chain = await this.repository.getScopeCascadeChain(scope);
+    return resolveRetention({ rows: remaining, chain });
   }
 
   /** Every retention override row in the organization (unfiltered). */

--- a/langwatch/src/server/data-retention/policy/dataRetentionPolicy.service.ts
+++ b/langwatch/src/server/data-retention/policy/dataRetentionPolicy.service.ts
@@ -1,9 +1,6 @@
 import type { RetentionPolicy } from "@prisma/client";
 import type { ScopeAssignment } from "~/server/scopes/scope.types";
-import {
-  type RetentionRow,
-  resolveRetention,
-} from "../resolveRetentionDays";
+import { type RetentionRow, resolveRetention } from "../resolveRetentionDays";
 import {
   PLATFORM_DEFAULT_RETENTION_DAYS,
   type ResolvedRetention,
@@ -65,8 +62,7 @@ export class DataRetentionPolicyService {
     }
     const rows = await this.repository.findAllInOrganization(organizationId);
     const remaining = rows.filter(
-      (r) =>
-        !(r.scopeType === scope.scopeType && r.scopeId === scope.scopeId),
+      (r) => !(r.scopeType === scope.scopeType && r.scopeId === scope.scopeId),
     ) as RetentionRow[];
     const chain = await this.repository.getScopeCascadeChain(scope);
     return resolveRetention({ rows: remaining, chain });

--- a/specs/data-retention/retention-policy-configuration.feature
+++ b/specs/data-retention/retention-policy-configuration.feature
@@ -68,6 +68,34 @@ Feature: Data retention policy configuration
     When the project admin removes the project-level traces override
     Then traces for "web-app" are kept for 63 days from the organization rule
 
+  # The settings table exposes per-rule actions through a single overflow menu
+  # (the established row-actions pattern), so a customer can change a value
+  # without deleting and re-creating the rule.
+
+  Scenario: Editing a policy from the row overflow menu changes only its value
+    Given a project-level traces retention of 91 days for "web-app"
+    When the project admin edits that policy from the row menu and sets 182 days
+    Then the policy's scope stays "web-app"
+    And traces for "web-app" are kept for 182 days
+
+  # Removal is a deliberate, explained action. Deleting a rule never deletes
+  # data — it only changes the retention applied to newly ingested data, which
+  # falls back to the next applicable tier (or the platform default).
+
+  Scenario: Removal asks for confirmation and previews the real fallback value
+    Given an organization-level traces retention of 49 days for "acme"
+    And a project-level traces retention of 91 days for "web-app"
+    When the project admin chooses to remove the project-level policy
+    Then a confirmation explains that existing data is not deleted
+    And it shows the retention falling back from 91 days to 49 days
+    And the policy is removed only after the admin confirms
+
+  Scenario: The previewed fallback never leaks a rule the caller cannot read
+    Given a project-level traces retention of 91 days for "web-app"
+    And an organization-level traces retention the caller is not allowed to read
+    When the caller previews removal of the project-level policy
+    Then the response contains only the resolved day count, not the org rule's scope
+
   Scenario: A project admin cannot set an organization-wide override
     Given a user who can manage project "web-app" but not the organization
     When that user attempts to set an organization-level traces retention

--- a/specs/data-retention/retention-policy-configuration.feature
+++ b/specs/data-retention/retention-policy-configuration.feature
@@ -101,6 +101,21 @@ Feature: Data retention policy configuration
     When that user attempts to set an organization-level traces retention
     Then the request is rejected as forbidden
 
+  # The Data Storage figure tracks the page's scope selector. A single project
+  # only ever shows that project; widening to the team or organization sums the
+  # storage of every project in that scope the caller is allowed to read.
+
+  Scenario: Storage for an organization scope sums its projects
+    Given the organization "acme" has projects "web-app" using 19 GB and "worker" using 0 B
+    And the caller can read both projects
+    When storage is shown with the organization scope selected
+    Then the Data Storage figure is the sum of both projects
+
+  Scenario: Storage never counts a project the caller cannot read
+    Given the organization "acme" has a project the caller cannot read
+    When storage is shown with the organization scope selected
+    Then that project's storage is excluded from the total
+
   Scenario: An override is anchored to a single organization
     When an admin sets a team-level traces retention for "platform"
     Then the override is anchored to the organization that owns "platform"


### PR DESCRIPTION
## Why

Customer report on the **Data Retention** settings page:

> "I find it weird there is no edit button, only exclude. What will happen if I exclude this 91 day retention now? Will everything be 30d? Will all my traces then be excluded? Feels scary. We should have the ⋮ three-dot menu on the rule row to be able to edit."

Two real problems behind the fear:

1. **No edit.** The only way to change a rule's value was to delete it and re-create it (re-picking the scope).
2. **Delete was a one-click trapdoor.** The trailing cell was a bare red trash button that fired immediately — no confirm, no explanation of what the data falls back to. That ambiguity is exactly what reads as "this might delete my traces."

For the record, the fear was unfounded but the UI did nothing to say so: removing a rule never deletes data (existing rows keep their stamped `_retention_days`; only new ingestion uses the fallback), and retention falls back through the cascade `PROJECT → TEAM → ORGANIZATION → platform default`, never to zero.

## What

- **Row actions → `⋮` overflow menu** (Edit / Remove), replacing the inline trash button, per `dev/docs/best_practices/row-actions-overflow-menu.md` — the table previously ignored our own convention.
- **Edit** reuses `AddOverrideDrawer` in an edit mode: scope locked + shown read-only, current value prefilled, saves through the existing `setForScope` upsert. Title "Edit retention policy", single "Save changes" action (no Cancel — the X dismisses, per the doc).
- **Remove** now routes through `RemoveScopeConfirmDialog` that:
  - states plainly **"No data is deleted"** and that the change applies to newly ingested data only;
  - shows the **real** current → fallback transition (e.g. `91 days → 49 days`).

## How the fallback number stays honest

The dialog never hardcodes a number. A new `dataRetention.previewScopeRemoval` query resolves the fallback **server-side** by reusing `resolveRetention` over the org's rows **minus the scope's own rows** — so the previewed value can never diverge from what an actual removal produces, and it auto-tracks the resolver (today a uniform 49-day platform default for free and paid; if that ever becomes plan-tiered, the dialog follows with no UI change). It returns **only day counts**, never a sibling scope's rule identity, preserving the existing read-scope gating.

## Tests

- `dataRetentionPolicy.previewScopeRemoval.unit.test.ts` — fallback resolves to team / org / platform-default per tier, per-category independence, and the no-org safety path (6 cases).
- `RemoveScopeConfirmDialog.integration.test.tsx` — "no data is deleted" copy, current→fallback display, resolving state shows no guessed number, disabled query when no target (4 cases).
- `AddOverrideDrawer.editMode.integration.test.tsx` — edit title + Save changes + locked read-only scope + no Cancel; add mode unchanged (4 cases).
- Spec scenarios added to `specs/data-retention/retention-policy-configuration.feature`.

All 66 existing data-retention unit tests still green; `pnpm typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an edit workflow for retention policies with prefilled values, read-only scope display, and “Save changes” behavior.
  * Reworked per-scope actions to an **Edit / Remove** menu and introduced a confirmation dialog that previews fallback retention.
  * Enhanced **Data Storage** figures with dynamic storage descriptions and authorized project counts (with supporting server-side preview endpoints).
* **Bug Fixes**
  * Improved fallback retention preview accuracy and tightened permission checks to avoid preview information leakage.
* **Tests**
  * Added integration/unit coverage for edit mode, removal-preview states, and retention/storage preview calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review & CI fixes (drive-pr)

- **CodeRabbit (AddOverrideDrawer init effect):** the init `useEffect` depended on `available.projects`, so a background snapshot refetch could re-run it and wipe in-progress edits. Now depends only on `open` + `editTarget`; latest scope inputs are read inside, re-read on next open.
- **Biome lint/format:** applied `organizeImports` + canonical formatting to changed files (import shape, a `.filter`, test object literals). No logic change.

All `langwatch-app-ci` checks green (unit, integration, typecheck, build, lint, e2e); typecheck + the 14 new tests pass locally.

---

## Follow-up: scope-aware Data Storage + calmer headings

Two more reports on the same page:

- **Data Storage ignored the scope selector** — it always showed only the current project, so an org with a 0 B project and a multi-GB project showed whichever was active on the top nav, never the org total.
- **The "Data Retention" / "Data Storage" headings were oversized** ("feels like screaming").

**Storage now tracks the scope selector.** New `getScopeStorageUsage` query resolves the in-scope projects FROM the caller's org, RBAC-filters them to `traces:view`, and sums each tenant. The card shows "· N projects" when more than one contributes and the description matches the scope (project / team / organization / everything you can see).

**Safe aggregation (this matters):** it reuses the existing per-tenant `getTotalStorageBytes` rather than a new `TenantId IN (...)` sum. Each per-tenant read keeps the hardened ClickHouse settings (capped threads + execution time + per-table fallback) and its 5-minute cache, so an org total is mostly cache hits and one heavy tenant can't blow the memory ceiling — avoiding the OOM hazard `_size_bytes`'s lazy recompute caused in prod (#4556/#4855). Bounded concurrency; a failed tenant degrades to 0 (fine for a display, not billing).

Headings dropped `lg` → `sm`/semibold with `xs` muted descriptions. Removed the now-unused `getStorageUsage`/`getStorageBreakdown` tRPC procedures (the scope query with a PROJECT scope covers the single-project case; service methods stay for the fallback).

Tests: per-tenant aggregation (sum/dedup/empty/degrade), `resolveScopeStorageUsage` (org/team/foreign-scope/personal + RBAC filtering), and card rendering (scope copy + project-count). 74 server-unit + 10 component tests green.

---

## Review round 2 (drive-pr)

Three CodeRabbit findings, all addressed:

- **Named `onSave` params** — the drawer's `onSave` now takes one object `{ scopes, retentionDays, applyToExisting }` instead of positional args (named-params convention).
- **Deterministic edit prefill** — `openEditForGroup` derives the prefilled value from an explicit category priority (`traces ?? scenarios ?? experiments`) and bails if all are undefined, so a divergent legacy group no longer depends on object key insertion order.
- **BDD test nesting** — `RemoveScopeConfirmDialog` integration tests nest their `when` blocks under `given` contexts.
- **Lint** — sorted imports in the `dataRetention` router (`organizeImports`); the app-ci `lint` job is diff-filtered, so this was the one diagnostic landing on changed lines.

All `langwatch-app-ci` checks green (lint, typecheck, 4 unit shards, 6 integration shards, build, feature-parity, app-complete gate).

---

## Follow-up: stale-while-revalidate storage cache

The Data Storage figure was served from a plain 5-minute cache: when an entry expired, the **next user to open the page** blocked on the full recompute. For large accounts that recompute is the expensive `_size_bytes` lazy-recompute path (tens of GB), so the page could hang for seconds every 5 minutes.

Now the per-tenant total is **stale-while-revalidate**:
- A cached value is returned **immediately**, even slightly stale.
- Once it ages past the 5-minute freshness window, the read still returns instantly and kicks a **background recompute** — only the very first read for a tenant ever blocks.
- Background refreshes are **single-flighted** via a Redis `SET NX` lock (already in `TtlCache.claim`), so concurrent pods/tabs don't stampede ClickHouse; the lock is left to expire, throttling a tenant to one refresh per window.
- A failed refresh **keeps the last good value**; a failed cold read caches a degraded `0` marked already-stale, so the scope total backs off but self-heals on the next read.

No change to the freshness contract (still ~5 min) or the UI — just no more latency cliff. An injectable clock keeps the timing deterministic in tests.

**Deliberately out of scope (follow-ups):**
- Caching the whole-scope aggregate (one Redis key per scope instead of N) — only worth it for very large orgs and needs membership/RBAC invalidation.
- `ALTER TABLE … MATERIALIZE COLUMN _size_bytes` (out-of-band ops task) — the durable fix that removes the recompute entirely; caching only hides its cost until then.