### PR TITLE
fix(billing): wire evaluation runs to billable events meter

### DIFF
--- a/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
@@ -9,7 +9,6 @@ vi.mock("~/server/metrics", async (importOriginal) => {
     incrementEsReactorTotal: vi.fn(),
   };
 });
-import type { QueueManager } from "../../services/queues/queueManager";
 import type { Event } from "../../domain/types";
 import type { ReactorDefinition } from "../../reactors/reactor.types";
 import {
@@ -17,29 +16,11 @@ import {
   createMockFoldProjectionStore,
   createMockMapProjectionDefinition,
   createMockAppendStore,
+  createMockQueueManager,
   createTestEvent,
   createTestTenantId,
   TEST_CONSTANTS,
 } from "../../services/__tests__/testHelpers";
-
-function createMockQueueManager(overrides?: {
-  hasReactorQueues?: boolean;
-  getReactorQueue?: ReturnType<typeof vi.fn>;
-}): QueueManager<Event> {
-  return {
-    hasProjectionQueues: vi.fn().mockReturnValue(false),
-    hasHandlerQueues: vi.fn().mockReturnValue(false),
-    hasReactorQueues: vi.fn().mockReturnValue(overrides?.hasReactorQueues ?? false),
-    getProjectionQueue: vi.fn().mockReturnValue(undefined),
-    getHandlerQueue: vi.fn().mockReturnValue(undefined),
-    getReactorQueue: overrides?.getReactorQueue ?? vi.fn().mockReturnValue(undefined),
-    close: vi.fn().mockResolvedValue(void 0),
-    waitUntilReady: vi.fn().mockResolvedValue(void 0),
-    initializeProjectionQueues: vi.fn(),
-    initializeHandlerQueues: vi.fn(),
-    initializeReactorQueues: vi.fn(),
-  } as unknown as QueueManager<Event>;
-}
 
 describe("ProjectionRouter", () => {
   const tenantId = createTestTenantId();

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/orgBillableEventsMeter.evaluation.regression.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/orgBillableEventsMeter.evaluation.regression.test.ts
@@ -41,7 +41,10 @@ function createMeterRouterWithSpyStore() {
   );
   router.registerMapProjection({
     ...orgBillableEventsMeterProjection,
-    store: { ...createMockAppendStore<BillableEventRecord>(), append: appendSpy },
+    store: {
+      ...createMockAppendStore<BillableEventRecord>(),
+      append: appendSpy,
+    },
   });
   return { router, appendSpy };
 }
@@ -66,75 +69,77 @@ function createReportedEvent(
 }
 
 describe("orgBillableEventsMeter — evaluation billing (issue #5124)", () => {
-  describe("when an evaluation reported event is dispatched", () => {
-    it("records exactly one billable row keyed on the evaluation", async () => {
-      const tenantId = createTestTenantId();
-      const evaluationId = "eval-abc";
-      const { router, appendSpy } = createMeterRouterWithSpyStore();
+  describe("given the real meter projection registered on a router", () => {
+    describe("when an evaluation reported event is dispatched", () => {
+      it("records exactly one billable row keyed on the evaluation", async () => {
+        const tenantId = createTestTenantId();
+        const evaluationId = "eval-abc";
+        const { router, appendSpy } = createMeterRouterWithSpyStore();
 
-      await router.dispatch([createReportedEvent(tenantId, evaluationId)], {
-        tenantId,
+        await router.dispatch([createReportedEvent(tenantId, evaluationId)], {
+          tenantId,
+        });
+
+        expect(appendSpy).toHaveBeenCalledTimes(1);
+        const record = appendSpy.mock.calls[0]![0] as BillableEventRecord;
+        expect(record).toEqual(
+          expect.objectContaining({
+            tenantId: String(tenantId),
+            eventType: EVALUATION_EVENT_TYPES.REPORTED,
+            deduplicationKey: `${tenantId}:${evaluationId}:reported`,
+          }),
+        );
       });
-
-      expect(appendSpy).toHaveBeenCalledTimes(1);
-      const record = appendSpy.mock.calls[0]![0] as BillableEventRecord;
-      expect(record).toEqual(
-        expect.objectContaining({
-          tenantId: String(tenantId),
-          eventType: EVALUATION_EVENT_TYPES.REPORTED,
-          deduplicationKey: `${tenantId}:${evaluationId}:reported`,
-        }),
-      );
     });
-  });
 
-  describe("when the same evaluation is reported twice (retry/replay)", () => {
-    it("produces the same dedup key so it collapses to one billable unit", async () => {
-      const tenantId = createTestTenantId();
-      const evaluationId = "eval-retry";
-      const { router, appendSpy } = createMeterRouterWithSpyStore();
+    describe("when the same evaluation is reported twice (retry/replay)", () => {
+      it("produces the same dedup key so it collapses to one billable unit", async () => {
+        const tenantId = createTestTenantId();
+        const evaluationId = "eval-retry";
+        const { router, appendSpy } = createMeterRouterWithSpyStore();
 
-      await router.dispatch(
-        [
-          createReportedEvent(tenantId, evaluationId),
-          createReportedEvent(tenantId, evaluationId),
-        ],
-        { tenantId },
-      );
+        await router.dispatch(
+          [
+            createReportedEvent(tenantId, evaluationId),
+            createReportedEvent(tenantId, evaluationId),
+          ],
+          { tenantId },
+        );
 
-      expect(appendSpy).toHaveBeenCalledTimes(2);
-      const keys = appendSpy.mock.calls.map(
-        (call) => (call[0] as BillableEventRecord).deduplicationKey,
-      );
-      expect(new Set(keys).size).toBe(1);
-      expect(keys[0]).toBe(`${tenantId}:${evaluationId}:reported`);
+        expect(appendSpy).toHaveBeenCalledTimes(2);
+        const keys = appendSpy.mock.calls.map(
+          (call) => (call[0] as BillableEventRecord).deduplicationKey,
+        );
+        expect(new Set(keys).size).toBe(1);
+        expect(keys[0]).toBe(`${tenantId}:${evaluationId}:reported`);
+      });
     });
-  });
 
-  describe("when never-emitted evaluation event types are dispatched", () => {
-    it("ignores lw.evaluation.scheduled and lw.evaluation.started since production never emits them", async () => {
-      const tenantId = createTestTenantId();
-      const { router, appendSpy } = createMeterRouterWithSpyStore();
+    describe("when never-emitted evaluation event types are dispatched", () => {
+      it("ignores lw.evaluation.scheduled and lw.evaluation.started since production never emits them", async () => {
+        const tenantId = createTestTenantId();
+        const { router, appendSpy } = createMeterRouterWithSpyStore();
 
-      await router.dispatch(
-        [
-          createTestEvent(
-            "eval-1",
-            TEST_CONSTANTS.AGGREGATE_TYPE,
-            tenantId,
-            EVALUATION_EVENT_TYPES.SCHEDULED,
-          ),
-          createTestEvent(
-            "eval-2",
-            TEST_CONSTANTS.AGGREGATE_TYPE,
-            tenantId,
-            EVALUATION_EVENT_TYPES.STARTED,
-          ),
-        ],
-        { tenantId },
-      );
+        await router.dispatch(
+          [
+            createTestEvent(
+              "eval-1",
+              TEST_CONSTANTS.AGGREGATE_TYPE,
+              tenantId,
+              EVALUATION_EVENT_TYPES.SCHEDULED,
+            ),
+            createTestEvent(
+              "eval-2",
+              TEST_CONSTANTS.AGGREGATE_TYPE,
+              tenantId,
+              EVALUATION_EVENT_TYPES.STARTED,
+            ),
+          ],
+          { tenantId },
+        );
 
-      expect(appendSpy).not.toHaveBeenCalled();
+        expect(appendSpy).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/orgBillableEventsMeter.evaluation.regression.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/orgBillableEventsMeter.evaluation.regression.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression test for issue #5124 — evaluation runs emit no billable events.
+ *
+ * The billable-events meter (orgBillableEventsMeterProjection) used to subscribe
+ * to `lw.evaluation.scheduled` / `lw.evaluation.started`, neither of which is ever
+ * produced in production. The real evaluation event is `lw.evaluation.reported`
+ * (emitted by reportEvaluation / ReportEvaluationCommand / ExecuteEvaluationCommand),
+ * so evaluations contributed ZERO billable rows.
+ *
+ * This drives the actual runtime path — the ProjectionRouter's eventType filter
+ * (the bug site) + the real projection `map()` + a capturing store — and asserts a
+ * billable record is produced. It is NOT a shape assertion on the eventTypes array:
+ * if `reported` is dropped from the subscription, the router filters the event out
+ * and the store is never called, failing the test.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { Event } from "../../../domain/types";
+import { EVALUATION_EVENT_TYPES } from "../../../pipelines/evaluation-processing/schemas/constants";
+import {
+  createMockAppendStore,
+  createMockQueueManager,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../../services/__tests__/testHelpers";
+import { ProjectionRouter } from "../../projectionRouter";
+import { orgBillableEventsMeterProjection } from "../orgBillableEventsMeter.mapProjection";
+import type { BillableEventRecord } from "../orgBillableEventsMeter.store";
+
+/**
+ * Registers the REAL meter projection (its real eventTypes + real map) onto an
+ * inline router, swapping only the store boundary for a capturing spy.
+ */
+function createMeterRouterWithSpyStore() {
+  const appendSpy = vi.fn().mockResolvedValue(void 0);
+  const router = new ProjectionRouter(
+    TEST_CONSTANTS.AGGREGATE_TYPE,
+    TEST_CONSTANTS.PIPELINE_NAME,
+    createMockQueueManager(),
+  );
+  router.registerMapProjection({
+    ...orgBillableEventsMeterProjection,
+    store: { ...createMockAppendStore<BillableEventRecord>(), append: appendSpy },
+  });
+  return { router, appendSpy };
+}
+
+/**
+ * Builds a `lw.evaluation.reported` event with the production idempotencyKey
+ * (`${tenantId}:${evaluationId}:reported`, per ReportEvaluationCommand).
+ */
+function createReportedEvent(
+  tenantId: ReturnType<typeof createTestTenantId>,
+  evaluationId: string,
+): Event {
+  return {
+    ...createTestEvent(
+      evaluationId,
+      TEST_CONSTANTS.AGGREGATE_TYPE,
+      tenantId,
+      EVALUATION_EVENT_TYPES.REPORTED,
+    ),
+    idempotencyKey: `${tenantId}:${evaluationId}:reported`,
+  };
+}
+
+describe("orgBillableEventsMeter — evaluation billing (issue #5124)", () => {
+  describe("when an evaluation reported event is dispatched", () => {
+    it("records exactly one billable row keyed on the evaluation", async () => {
+      const tenantId = createTestTenantId();
+      const evaluationId = "eval-abc";
+      const { router, appendSpy } = createMeterRouterWithSpyStore();
+
+      await router.dispatch([createReportedEvent(tenantId, evaluationId)], {
+        tenantId,
+      });
+
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+      const record = appendSpy.mock.calls[0]![0] as BillableEventRecord;
+      expect(record).toEqual(
+        expect.objectContaining({
+          tenantId: String(tenantId),
+          eventType: EVALUATION_EVENT_TYPES.REPORTED,
+          deduplicationKey: `${tenantId}:${evaluationId}:reported`,
+        }),
+      );
+    });
+  });
+
+  describe("when the same evaluation is reported twice (retry/replay)", () => {
+    it("produces the same dedup key so it collapses to one billable unit", async () => {
+      const tenantId = createTestTenantId();
+      const evaluationId = "eval-retry";
+      const { router, appendSpy } = createMeterRouterWithSpyStore();
+
+      await router.dispatch(
+        [
+          createReportedEvent(tenantId, evaluationId),
+          createReportedEvent(tenantId, evaluationId),
+        ],
+        { tenantId },
+      );
+
+      expect(appendSpy).toHaveBeenCalledTimes(2);
+      const keys = appendSpy.mock.calls.map(
+        (call) => (call[0] as BillableEventRecord).deduplicationKey,
+      );
+      expect(new Set(keys).size).toBe(1);
+      expect(keys[0]).toBe(`${tenantId}:${evaluationId}:reported`);
+    });
+  });
+
+  describe("when never-emitted evaluation event types are dispatched", () => {
+    it("ignores lw.evaluation.scheduled and lw.evaluation.started since production never emits them", async () => {
+      const tenantId = createTestTenantId();
+      const { router, appendSpy } = createMeterRouterWithSpyStore();
+
+      await router.dispatch(
+        [
+          createTestEvent(
+            "eval-1",
+            TEST_CONSTANTS.AGGREGATE_TYPE,
+            tenantId,
+            EVALUATION_EVENT_TYPES.SCHEDULED,
+          ),
+          createTestEvent(
+            "eval-2",
+            TEST_CONSTANTS.AGGREGATE_TYPE,
+            tenantId,
+            EVALUATION_EVENT_TYPES.STARTED,
+          ),
+        ],
+        { tenantId },
+      );
+
+      expect(appendSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/orgBillableEventsMeter.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/orgBillableEventsMeter.unit.test.ts
@@ -166,14 +166,14 @@ describe("orgBillableEventsMeterProjection.map", () => {
         makeEvent({
           id: "evt-1",
           idempotencyKey: "idem-key-abc",
-          type: "lw.evaluation.started",
+          type: "lw.evaluation.reported",
         }),
       );
 
       expect(result).toEqual(
         expect.objectContaining({
           deduplicationKey: "idem-key-abc",
-          eventType: "lw.evaluation.started",
+          eventType: "lw.evaluation.reported",
         }),
       );
     });

--- a/langwatch/src/server/event-sourcing/projections/global/orgBillableEventsMeter.mapProjection.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/orgBillableEventsMeter.mapProjection.ts
@@ -33,8 +33,13 @@ export const orgBillableEventsMeterProjection: MapProjectionDefinition<
   eventTypes: [
     SPAN_RECEIVED_EVENT_TYPE,
 
-    EVALUATION_EVENT_TYPES.SCHEDULED,
-    EVALUATION_EVENT_TYPES.STARTED,
+    // `reported` is the only evaluation event production ever emits (via
+    // reportEvaluation / ReportEvaluationCommand / ExecuteEvaluationCommand).
+    // Its idempotencyKey is `${tenantId}:${evaluationId}:reported`, so retries and
+    // replays collapse to exactly one billable unit per evaluation. The previously
+    // listed `scheduled`/`started` types are never produced outside test presets
+    // (see issue #5124) and are intentionally not subscribed.
+    EVALUATION_EVENT_TYPES.REPORTED,
 
     EXPERIMENT_RUN_EVENT_TYPES.STARTED,
     EXPERIMENT_RUN_EVENT_TYPES.EVALUATOR_RESULT,

--- a/langwatch/src/server/event-sourcing/services/__tests__/testHelpers.ts
+++ b/langwatch/src/server/event-sourcing/services/__tests__/testHelpers.ts
@@ -18,6 +18,33 @@ import type {
   EventStore,
   EventStoreReadContext,
 } from "../../stores/eventStore.types";
+import type { QueueManager } from "../queues/queueManager";
+
+/**
+ * Creates a mock QueueManager. Defaults to the inline (no-queue) configuration
+ * so routers process projections/reactors synchronously without Redis/BullMQ.
+ */
+export function createMockQueueManager(overrides?: {
+  hasReactorQueues?: boolean;
+  getReactorQueue?: ReturnType<typeof vi.fn>;
+}): QueueManager<Event> {
+  return {
+    hasProjectionQueues: vi.fn().mockReturnValue(false),
+    hasHandlerQueues: vi.fn().mockReturnValue(false),
+    hasReactorQueues: vi
+      .fn()
+      .mockReturnValue(overrides?.hasReactorQueues ?? false),
+    getProjectionQueue: vi.fn().mockReturnValue(undefined),
+    getHandlerQueue: vi.fn().mockReturnValue(undefined),
+    getReactorQueue:
+      overrides?.getReactorQueue ?? vi.fn().mockReturnValue(undefined),
+    close: vi.fn().mockResolvedValue(void 0),
+    waitUntilReady: vi.fn().mockResolvedValue(void 0),
+    initializeProjectionQueues: vi.fn(),
+    initializeHandlerQueues: vi.fn(),
+    initializeReactorQueues: vi.fn(),
+  } as unknown as QueueManager<Event>;
+}
 
 /**
  * Creates a mock EventStore with default implementations.


### PR DESCRIPTION
# Related Issue

- Resolves #5124

## Why

Closes #5124

Evaluation executions are tracked in `evaluation_runs` but contributed **zero** rows to the `billable_events` meter — evaluation usage was effectively un-billed in production. The meter projection subscribed to `lw.evaluation.scheduled` and `lw.evaluation.started`, but no production code path ever emits either type. The live pipeline only emits `lw.evaluation.reported` (via `reportEvaluation` / `ReportEvaluationCommand` / `ExecuteEvaluationCommand`), which the meter wasn't listening for. Net effect: the meter watched for event types that are never produced.

## What changed

Subscribed the billable-events meter to the event production actually emits (`lw.evaluation.reported`) and removed the two dead subscriptions (`scheduled` / `started`), reconciling the meter's `eventTypes` with what the evaluation pipeline really produces. Each evaluation execution now yields exactly one billable event.

## How it works

The `reported` event carries a stable `idempotencyKey` of `${tenantId}:${evaluationId}:reported`. The meter derives its ClickHouse dedup key from that, so retries and replays of the same evaluation collapse to a single billable unit — no double counting. The 6 production emitters each generate a fresh `evaluationId` per evaluation, giving the desired one-billable-event-per-evaluation granularity.

The `scheduled`/`started` event schemas, type guards, and `StartEvaluationCommand` remain in place (still pipeline-registered) — they are out of scope for this billing fix and only the meter subscription changed.

## Test plan

Added `orgBillableEventsMeter.evaluation.regression.test.ts`, which drives the **real** `ProjectionRouter` eventType filter + the real projection `map()` + a capturing store (not a shape assertion on the `eventTypes` array):

- A `lw.evaluation.reported` event records exactly one billable row keyed `${tenantId}:${evaluationId}:reported`.
- Two reports of the same `evaluationId` (retry/replay) produce the same dedup key → collapse to one billable unit.
- `lw.evaluation.scheduled` / `lw.evaluation.started` are ignored (guards against re-adding dead subscriptions).

Confirmed all three **fail on the pre-fix code** (reported filtered out; scheduled/started still recorded) and pass after. Full suite for the touched areas green (60 tests), `pnpm typecheck` clean.

Also extracted the duplicated `createMockQueueManager` test factory into shared `testHelpers` (was copy-pasted in `projectionRouter.test.ts`).

## Anything surprising?

- Out of scope, pre-existing: the meter's `map()` stamps `eventTimestamp` from `event.createdAt` (ingestion time) rather than the `reported` event's `occurredAt` (evaluation time). If billing windows are time-bucketed this may warrant a separate look.
- Separate from the billable-events historical reconstruction script (`src/tasks/billableEventsReconstruction.ts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Billable evaluation tracking now processes only `reported` events, avoiding billable entries from `scheduled` or `started`.
  * Deduplication for evaluation reporting is enforced so replayed or retried events don’t double-count.

* **Tests**
  * Added a new regression test suite validating billable-meter output, deduplication stability, and filtering of non-billable event types.
  * Updated unit test expectations to align with the `reported` event flow.

* **Chores**
  * Improved test setup by reusing a shared mock queue manager helper across projection router tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->