### PR TITLE
fix(evaluators): truncate long evaluator names on card to stop layout overflow

### DIFF
--- a/langwatch/src/components/evaluators/EvaluatorCard.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorCard.tsx
@@ -4,6 +4,7 @@ import { ArrowUp, CheckSquare, Clock, Code, Copy, MoreVertical, RefreshCw, Workf
 import { useState } from "react";
 import { LuPencil, LuTrash2 } from "react-icons/lu";
 import { formatTimeAgo } from "~/utils/formatTimeAgo";
+import { OverflownTextWithTooltip } from "../OverflownText";
 import { Menu } from "../ui/menu";
 import { EvaluatorApiUsageDialog } from "./EvaluatorApiUsageDialog";
 
@@ -179,12 +180,19 @@ export function EvaluatorCard({
             <Spacer />
 
             {/* Name */}
-            <Text color="fg" fontSize="sm" fontWeight={500}>
+            <OverflownTextWithTooltip
+              color="fg"
+              fontSize="sm"
+              fontWeight={500}
+              lineClamp={2}
+              width="full"
+              wordBreak="break-word"
+            >
               {evaluator.name}
-            </Text>
+            </OverflownTextWithTooltip>
 
             {/* Metadata */}
-            <Text color="fg.subtle" fontSize="12px">
+            <Text color="fg.subtle" fontSize="12px" lineClamp={1} width="full">
               {typeLabel}
               {evaluatorType && ` • ${evaluatorType}`} •{" "}
               {formatTimeAgo(new Date(evaluator.updatedAt).getTime())}


### PR DESCRIPTION
## Summary
- Long evaluator names — e.g. `langy-hallucination-eval-1779722670246-updated-1779807421213-updated-...` produced by repeated rename/update flows — wrapped over 3+ lines and broke the fixed-height (`142px`) evaluator card on the Evaluators page.
- Swap the name `<Text>` for `<OverflownTextWithTooltip lineClamp={2} wordBreak="break-word">`, matching the truncation pattern already used elsewhere (e.g. `MessageCard`, `TopicsSelector`). Full name is still discoverable on hover.
- Also clamp the metadata row (`typeLabel • evaluatorType • updatedAt`) to a single line so it never wraps either.

## Repro (before)
A card whose `evaluator.name` is longer than ~40 characters renders three or more wrapped lines, pushing the metadata line below the card edge. (Screenshot in the originating bug report.)

## After
- Short names render unchanged (one line, identical styling).
- Long names truncate after two lines with `…`, full name shown via the existing `OverflownTextWithTooltip` hover tooltip.
- Card height stays at `142px`; the grid layout no longer drifts.

## Test plan
- [x] Visit `/[project]/evaluations` with a project containing an evaluator with a very long name; card layout stays put, ellipsis appears, full name shows on hover.
- [x] Card with a short name looks visually identical to before.
- [x] `pnpm typecheck` clean in `langwatch/`.

cc @aryansharma28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated evaluator names to truncate gracefully and show the full text in a tooltip when needed.
  * Improved readability for long names while keeping the existing card layout and metadata unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->