### PR TITLE
fix(evaluations): match page heading to sidebar/breadcrumb label

### DIFF
--- a/langwatch/src/pages/[project]/evaluations.tsx
+++ b/langwatch/src/pages/[project]/evaluations.tsx
@@ -147,7 +147,7 @@ function EvaluationsV2() {
   return (
     <DashboardLayout>
       <PageLayout.Header>
-        <PageLayout.Heading>Experiments</PageLayout.Heading>
+        <PageLayout.Heading>Evaluations</PageLayout.Heading>
         <Spacer />
         <HStack gap={2}>
           <NewEvaluationMenu
@@ -210,9 +210,9 @@ function EvaluationsV2() {
             )}
 
             <VStack align="start" gap={1}>
-              <Heading as="h1">Experiments</Heading>
+              <Heading as="h1">Evaluations</Heading>
               <Text color="fg.muted">
-                View and analyze your experiment results
+                View and analyze your evaluation results
               </Text>
             </VStack>
 


### PR DESCRIPTION
## Summary
- Sidebar nav item and breadcrumb both read **"Evaluations"**, but the page H1 rendered **"Experiments"** — a visible discrepancy on the same viewport.
- Rename the `PageLayout.Heading` (top header) and the inner `<Heading as="h1">` (above the experiments table) to `Evaluations`, and the inner description from `View and analyze your experiment results` → `View and analyze your evaluation results`.
- UI-copy only: file name (`evaluations.tsx`), route, type badges (`Experiment (UI)` / `Experiment (SDK)`), and `ExperimentType` enums untouched. That's the deeper rename; intentionally out of scope.

## Before
```
Breadcrumb:  test  >  Dashboard  >  Evaluations
Page H1:                            Experiments    ← mismatch
```

## After
```
Breadcrumb:  test  >  Dashboard  >  Evaluations
Page H1:                            Evaluations    ← matches
```

## Test plan
- [ ] Click sidebar "Evaluations" → page H1 reads "Evaluations" (not "Experiments").
- [ ] Scroll past the Online Evaluations section → inner section heading reads "Evaluations" and the subtext reads "View and analyze your evaluation results".
- [ ] No regressions on the experiments table, NoDataInfoBlock, or NewEvaluationMenu.

cc @aryansharma28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Renamed the page from “Experiments” to “Evaluations” in the main heading and supporting text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->