### PR TITLE
fix(model-providers): pin modern Azure api-version + honour deploymentMapping inline

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/prepareLitellmParams.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/prepareLitellmParams.unit.test.ts
@@ -17,7 +17,10 @@ vi.mock("~/server/modelProviders/modelProvider.service", () => ({
   },
 }));
 
-import { prepareLitellmParams } from "../modelProviders.utils";
+import {
+  DEFAULT_AZURE_API_VERSION,
+  prepareLitellmParams,
+} from "../modelProviders.utils";
 
 const baseAzureProvider = {
   provider: "azure" as const,
@@ -139,6 +142,75 @@ describe("prepareLitellmParams", () => {
       expect(params.api_base).toBe("https://gateway.example.com/azure");
       expect(params.use_azure_gateway).toBe("true");
       expect(params.api_version).toBe("2024-09-01");
+    });
+
+    describe("when no api-version is configured (direct mode)", () => {
+      it("pins a modern default so newer deployments don't 404 'Resource not found'", async () => {
+        // Regression: without an explicit api-version the downstream gateway
+        // (Bifrost) falls back to a stale 2024-10-21 default that 404s
+        // gpt-5-class Azure deployments. We must always send a modern version.
+        const params = await prepareLitellmParams({
+          model: "azure/gpt-5.4",
+          modelProvider: baseAzureProvider,
+          projectId: "project-123",
+        });
+
+        expect(params.api_version).toBe(DEFAULT_AZURE_API_VERSION);
+      });
+    });
+
+    describe("when AZURE_OPENAI_API_VERSION is configured (direct mode)", () => {
+      it("uses the provider override instead of the default", async () => {
+        const providerWithVersion = {
+          ...baseAzureProvider,
+          customKeys: {
+            ...baseAzureProvider.customKeys,
+            AZURE_OPENAI_API_VERSION: "2025-01-01-preview",
+          },
+        };
+
+        const params = await prepareLitellmParams({
+          model: "azure/gpt-5.4",
+          modelProvider: providerWithVersion,
+          projectId: "project-123",
+        });
+
+        expect(params.api_version).toBe("2025-01-01-preview");
+      });
+    });
+
+    describe("when the provider defines a deploymentMapping", () => {
+      it("maps the model id to its Azure deployment name", async () => {
+        // The deployment name need not equal the model id; honour the
+        // explicit mapping instead of assuming model id == deployment name.
+        const providerWithMapping = {
+          ...baseAzureProvider,
+          deploymentMapping: { "gpt-5.4": "my-gpt5-deployment" },
+        };
+
+        const params = await prepareLitellmParams({
+          model: "azure/gpt-5.4",
+          modelProvider: providerWithMapping,
+          projectId: "project-123",
+        });
+
+        expect(params.deployment).toBe("my-gpt5-deployment");
+      });
+
+      it("leaves deployment unset when the model is not in the mapping", async () => {
+        const providerWithMapping = {
+          ...baseAzureProvider,
+          deploymentMapping: { "gpt-4o": "my-gpt4o-deployment" },
+        };
+
+        const params = await prepareLitellmParams({
+          model: "azure/gpt-5.4",
+          modelProvider: providerWithMapping,
+          projectId: "project-123",
+        });
+
+        expect(params.deployment).toBeUndefined();
+      });
     });
   });
 });

--- a/langwatch/src/server/api/routers/__tests__/prepareLitellmParams.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/prepareLitellmParams.unit.test.ts
@@ -197,6 +197,24 @@ describe("prepareLitellmParams", () => {
         expect(params.deployment).toBe("my-gpt5-deployment");
       });
 
+      it("resolves a full-key mapping via the normalized model when given the mp-id wire format", async () => {
+        // The incoming model can be the canonical `mp_.../...` wire format;
+        // the full-key fallback must use the normalized `azure/...` form, not
+        // the raw mp-id, or a "azure/gpt-5.4" mapping would miss.
+        const providerWithMapping = {
+          ...baseAzureProvider,
+          deploymentMapping: { "azure/gpt-5.4": "my-gpt5-deployment" },
+        };
+
+        const params = await prepareLitellmParams({
+          model: "mp_abc_123/gpt-5.4",
+          modelProvider: providerWithMapping,
+          projectId: "project-123",
+        });
+
+        expect(params.deployment).toBe("my-gpt5-deployment");
+      });
+
       it("leaves deployment unset when the model is not in the mapping", async () => {
         const providerWithMapping = {
           ...baseAzureProvider,

--- a/langwatch/src/server/api/routers/modelProviders.utils.ts
+++ b/langwatch/src/server/api/routers/modelProviders.utils.ts
@@ -364,7 +364,7 @@ export const prepareLitellmParams = async ({
 
     // Map the model id to its Azure deployment name when the provider defines
     // an explicit deploymentMapping (the deployment name need not equal the
-    // model id). The gateway/control-plane path already honours this field
+    // model id). The gateway/control-plane path already honors this field
     // (config.materialiser); mirror it here so the in-process Studio /
     // playground path agrees instead of assuming model id == deployment name.
     const deploymentMap = modelProvider.deploymentMapping as Record<

--- a/langwatch/src/server/api/routers/modelProviders.utils.ts
+++ b/langwatch/src/server/api/routers/modelProviders.utils.ts
@@ -184,9 +184,8 @@ export const listProjectModelProvidersForFrontend = async (
   projectId: string,
 ) => {
   const service = ModelProviderService.create(prisma);
-  const providers = await service.listProjectModelProvidersForFrontend(
-    projectId,
-  );
+  const providers =
+    await service.listProjectModelProvidersForFrontend(projectId);
 
   const registryMetadata = getModelMetadataForFrontend();
   const providersAsRecord = Object.fromEntries(
@@ -373,8 +372,12 @@ export const prepareLitellmParams = async ({
       string
     > | null;
     if (deploymentMap) {
+      // params.model is already normalized to `provider/model` (the incoming
+      // `model` may still be the canonical `mp_.../...` wire format), so key
+      // the lookups off it for both the bare and full-key forms.
       const bareModel = params.model.split("/").slice(1).join("/");
-      const deployment = deploymentMap[bareModel] ?? deploymentMap[model];
+      const deployment =
+        deploymentMap[bareModel] ?? deploymentMap[params.model];
       if (deployment) {
         params.deployment = deployment;
       }

--- a/langwatch/src/server/api/routers/modelProviders.utils.ts
+++ b/langwatch/src/server/api/routers/modelProviders.utils.ts
@@ -273,6 +273,15 @@ export const prepareEnvKeys = (modelProvider: MaybeStoredModelProvider) => {
   );
 };
 
+/**
+ * Modern Azure OpenAI api-version used for direct (non-gateway) calls.
+ * Without an explicit version the downstream gateway (Bifrost) falls back
+ * to a stale GA default (2024-10-21) that returns "Resource not found" for
+ * newer (gpt-5-class) Azure deployments — even when the deployment name is
+ * correct. Overridable per provider via the AZURE_OPENAI_API_VERSION key.
+ */
+export const DEFAULT_AZURE_API_VERSION = "2025-04-01-preview";
+
 export const prepareLitellmParams = async ({
   model,
   modelProvider,
@@ -331,21 +340,44 @@ export const prepareLitellmParams = async ({
       getModelOrDefaultEnvKey(modelProvider, "AWS_REGION_NAME") ?? "invalid";
   }
 
-  // Handle Azure API Gateway configuration
+  // Azure: resolve api-version and deployment so the downstream gateway
+  // (Bifrost) targets the right Azure surface.
   if (modelProvider.provider === "azure") {
     const gatewayBaseUrl = getModelOrDefaultEnvKey(
       modelProvider,
       "AZURE_API_GATEWAY_BASE_URL",
     );
-    const gatewayVersion =
-      getModelOrDefaultEnvKey(modelProvider, "AZURE_API_GATEWAY_VERSION") ??
-      "2024-05-01-preview";
 
-    // If API Gateway is configured, route through the gateway endpoint
     if (gatewayBaseUrl) {
+      // API Gateway mode: route through the customer's gateway endpoint with
+      // its own pinned api-version (the gateway/APIM owns version policy).
       params.api_base = gatewayBaseUrl;
       params.use_azure_gateway = "true";
-      params.api_version = gatewayVersion;
+      params.api_version =
+        getModelOrDefaultEnvKey(modelProvider, "AZURE_API_GATEWAY_VERSION") ??
+        "2024-05-01-preview";
+    } else {
+      // Direct mode: pin a modern api-version (see DEFAULT_AZURE_API_VERSION).
+      params.api_version =
+        getModelOrDefaultEnvKey(modelProvider, "AZURE_OPENAI_API_VERSION") ??
+        DEFAULT_AZURE_API_VERSION;
+    }
+
+    // Map the model id to its Azure deployment name when the provider defines
+    // an explicit deploymentMapping (the deployment name need not equal the
+    // model id). The gateway/control-plane path already honours this field
+    // (config.materialiser); mirror it here so the in-process Studio /
+    // playground path agrees instead of assuming model id == deployment name.
+    const deploymentMap = modelProvider.deploymentMapping as Record<
+      string,
+      string
+    > | null;
+    if (deploymentMap) {
+      const bareModel = params.model.split("/").slice(1).join("/");
+      const deployment = deploymentMap[bareModel] ?? deploymentMap[model];
+      if (deployment) {
+        params.deployment = deployment;
+      }
     }
 
     // Pass through all extra headers
@@ -359,8 +391,6 @@ export const prepareLitellmParams = async ({
       );
     }
   }
-
-  // TODO: add azure deployment as params.model as azure/<deployment-name>
 
   return await buildManagedBedrockLitellmParams({
     params,

--- a/langwatch/src/server/modelProviders/registry.ts
+++ b/langwatch/src/server/modelProviders/registry.ts
@@ -303,13 +303,16 @@ export const modelProviders = {
       .object({
         AZURE_OPENAI_API_KEY: z.string().nullable().optional(),
         AZURE_OPENAI_ENDPOINT: z.string().nullable().optional(),
+        AZURE_OPENAI_API_VERSION: z.string().nullable().optional(),
         AZURE_API_GATEWAY_BASE_URL: z.string().nullable().optional(),
         AZURE_API_GATEWAY_VERSION: z.string().nullable().optional(),
       })
       .passthrough(),
-    // Direct-mode and gateway-mode each need both of their two fields;
+    // Direct-mode and gateway-mode each need both of their required fields;
     // the useApiGateway toggle in the UI swaps which pair is visible.
-    optionalKeys: [],
+    // AZURE_OPENAI_API_VERSION is optional — it falls back to a modern
+    // default (DEFAULT_AZURE_API_VERSION) when left blank.
+    optionalKeys: ["AZURE_OPENAI_API_VERSION"],
     enabledSince: new Date("2023-01-01"),
   },
   bedrock: {

--- a/langwatch/src/server/modelProviders/registry.ts
+++ b/langwatch/src/server/modelProviders/registry.ts
@@ -308,11 +308,12 @@ export const modelProviders = {
         AZURE_API_GATEWAY_VERSION: z.string().nullable().optional(),
       })
       .passthrough(),
-    // Direct-mode and gateway-mode each need both of their required fields;
-    // the useApiGateway toggle in the UI swaps which pair is visible.
-    // AZURE_OPENAI_API_VERSION is optional — it falls back to a modern
-    // default (DEFAULT_AZURE_API_VERSION) when left blank.
-    optionalKeys: ["AZURE_OPENAI_API_VERSION"],
+    // Direct-mode and gateway-mode each require their endpoint/base-url +
+    // api-key; the useApiGateway toggle in the UI swaps which set is visible.
+    // The api-version fields are optional — prepareLitellmParams falls back to
+    // a sensible default for each (DEFAULT_AZURE_API_VERSION for direct mode,
+    // 2024-05-01-preview for the gateway) when left blank.
+    optionalKeys: ["AZURE_OPENAI_API_VERSION", "AZURE_API_GATEWAY_VERSION"],
     enabledSince: new Date("2023-01-01"),
   },
   bedrock: {
@@ -425,9 +426,9 @@ export function getParameterConstraints(
   const provider = modelId.split("/")[0];
   if (!provider) return undefined;
 
-  const providerDef = modelProviders[
-    provider as keyof typeof modelProviders
-  ] as ModelProviderDefinition | undefined;
+  const providerDef = modelProviders[provider as keyof typeof modelProviders] as
+    | ModelProviderDefinition
+    | undefined;
   return providerDef?.parameterConstraints;
 }
 

--- a/langwatch/src/utils/__tests__/modelProviderHelpers.unit.test.ts
+++ b/langwatch/src/utils/__tests__/modelProviderHelpers.unit.test.ts
@@ -81,6 +81,7 @@ describe("modelProviderHelpers", () => {
     const schemaShape = {
       AZURE_OPENAI_API_KEY: {},
       AZURE_OPENAI_ENDPOINT: {},
+      AZURE_OPENAI_API_VERSION: {},
       AZURE_API_GATEWAY_BASE_URL: {},
       AZURE_API_GATEWAY_VERSION: {},
       OPENAI_API_KEY: {},
@@ -95,11 +96,12 @@ describe("modelProviderHelpers", () => {
       });
     });
 
-    it("returns standard keys for Azure with API Gateway disabled", () => {
+    it("returns standard keys (incl. api-version override) for Azure with API Gateway disabled", () => {
       const result = getDisplayKeysForProvider("azure", false, schemaShape);
       expect(result).toEqual({
         AZURE_OPENAI_API_KEY: {},
         AZURE_OPENAI_ENDPOINT: {},
+        AZURE_OPENAI_API_VERSION: {},
       });
     });
 

--- a/langwatch/src/utils/modelProviderHelpers.ts
+++ b/langwatch/src/utils/modelProviderHelpers.ts
@@ -53,6 +53,7 @@ export function getDisplayKeysForProvider(
     return {
       AZURE_OPENAI_API_KEY: schemaShape.AZURE_OPENAI_API_KEY,
       AZURE_OPENAI_ENDPOINT: schemaShape.AZURE_OPENAI_ENDPOINT,
+      AZURE_OPENAI_API_VERSION: schemaShape.AZURE_OPENAI_API_VERSION,
     };
   }
 

--- a/services/nlpgo/adapters/dispatcheradapter/adapter.go
+++ b/services/nlpgo/adapters/dispatcheradapter/adapter.go
@@ -321,13 +321,16 @@ func geminiCred(m map[string]string) domain.Credential {
 	}
 }
 
-// withDeploymentMap adds a self-deployment entry on Azure / Bedrock /
-// Vertex credentials so Bifrost's per-key-config readers ("deployments
-// not set" otherwise) accept the call. In the Studio shape the model
-// id IS the deployment name (azure/gpt-5-mini → deployment "gpt-5-mini").
-// Bifrost's deployment lookup is keyed by model so a {model: model}
-// self-map suffices for inline-credential customers; aigateway HTTP
-// callers populate richer maps at the control plane layer.
+// withDeploymentMap adds a deployment entry on Azure / Bedrock / Vertex
+// credentials so Bifrost's per-key-config readers ("deployments not set"
+// otherwise) accept the call. By default the model id IS the deployment
+// name (azure/gpt-5-mini → deployment "gpt-5-mini"), so a {model: model}
+// self-map suffices. When the provider defines an explicit deployment
+// (the model id need not equal the deployment name, e.g. an Azure
+// deployment named differently from the model), the control plane forwards
+// it as Extra["deployment"]; honour it so the model id maps to the real
+// deployment. aigateway HTTP callers populate richer maps at the control
+// plane layer.
 func withDeploymentMap(cred domain.Credential, bareModel string) domain.Credential {
 	if bareModel == "" {
 		return cred
@@ -341,7 +344,11 @@ func withDeploymentMap(cred domain.Credential, bareModel string) domain.Credenti
 		cred.DeploymentMap = map[string]string{}
 	}
 	if _, present := cred.DeploymentMap[bareModel]; !present {
-		cred.DeploymentMap[bareModel] = bareModel
+		deployment := bareModel
+		if explicit := cred.Extra["deployment"]; explicit != "" {
+			deployment = explicit
+		}
+		cred.DeploymentMap[bareModel] = deployment
 	}
 	return cred
 }

--- a/services/nlpgo/adapters/dispatcheradapter/adapter.go
+++ b/services/nlpgo/adapters/dispatcheradapter/adapter.go
@@ -328,7 +328,7 @@ func geminiCred(m map[string]string) domain.Credential {
 // self-map suffices. When the provider defines an explicit deployment
 // (the model id need not equal the deployment name, e.g. an Azure
 // deployment named differently from the model), the control plane forwards
-// it as Extra["deployment"]; honour it so the model id maps to the real
+// it as Extra["deployment"]; honor it so the model id maps to the real
 // deployment. aigateway HTTP callers populate richer maps at the control
 // plane layer.
 func withDeploymentMap(cred domain.Credential, bareModel string) domain.Credential {

--- a/services/nlpgo/adapters/dispatcheradapter/adapter_test.go
+++ b/services/nlpgo/adapters/dispatcheradapter/adapter_test.go
@@ -254,7 +254,7 @@ func TestWithDeploymentMap_SelfMapsByDefault(t *testing.T) {
 	}
 }
 
-func TestWithDeploymentMap_HonoursExplicitDeployment(t *testing.T) {
+func TestWithDeploymentMap_HonorsExplicitDeployment(t *testing.T) {
 	// When the model id differs from the Azure deployment name, the control
 	// plane forwards the real deployment as Extra["deployment"]; the model
 	// id must map to it rather than to itself.

--- a/services/nlpgo/adapters/dispatcheradapter/adapter_test.go
+++ b/services/nlpgo/adapters/dispatcheradapter/adapter_test.go
@@ -245,3 +245,33 @@ func TestCredentialFromHeaders_UnsupportedProvider(t *testing.T) {
 		t.Fatalf("expected unsupported-provider error, got %v", err)
 	}
 }
+
+func TestWithDeploymentMap_SelfMapsByDefault(t *testing.T) {
+	cred := domain.Credential{ProviderID: domain.ProviderAzure}
+	cred = withDeploymentMap(cred, "gpt-5-mini")
+	if got := cred.DeploymentMap["gpt-5-mini"]; got != "gpt-5-mini" {
+		t.Errorf("expected self-map, got %q", got)
+	}
+}
+
+func TestWithDeploymentMap_HonoursExplicitDeployment(t *testing.T) {
+	// When the model id differs from the Azure deployment name, the control
+	// plane forwards the real deployment as Extra["deployment"]; the model
+	// id must map to it rather than to itself.
+	cred := domain.Credential{
+		ProviderID: domain.ProviderAzure,
+		Extra:      map[string]string{"deployment": "my-gpt5-deployment"},
+	}
+	cred = withDeploymentMap(cred, "gpt-5.4")
+	if got := cred.DeploymentMap["gpt-5.4"]; got != "my-gpt5-deployment" {
+		t.Errorf("expected explicit deployment, got %q", got)
+	}
+}
+
+func TestWithDeploymentMap_IgnoresNonMappedProviders(t *testing.T) {
+	cred := domain.Credential{ProviderID: domain.ProviderOpenAI}
+	cred = withDeploymentMap(cred, "gpt-5-mini")
+	if cred.DeploymentMap != nil {
+		t.Errorf("expected no deployment map for OpenAI, got %v", cred.DeploymentMap)
+	}
+}

--- a/services/nlpgo/adapters/litellm/translator.go
+++ b/services/nlpgo/adapters/litellm/translator.go
@@ -60,7 +60,7 @@ func FromLiteLLMParams(provider string, params map[string]any) (InlineCredential
 			Provider: "azure",
 			Azure: pickAny(params,
 				"api_key", "api_base", "api_version",
-				"use_azure_gateway", "extra_headers",
+				"deployment", "use_azure_gateway", "extra_headers",
 			),
 		}, nil
 	case "bedrock":

--- a/services/nlpgo/adapters/litellm/translator_test.go
+++ b/services/nlpgo/adapters/litellm/translator_test.go
@@ -359,6 +359,24 @@ func TestFromLiteLLMParams_Azure_PreservesNestedExtraHeaders(t *testing.T) {
 	}
 }
 
+func TestFromLiteLLMParams_Azure_ForwardsDeployment(t *testing.T) {
+	// prepareLitellmParams sets `deployment` when the provider defines an
+	// explicit deploymentMapping (model id != Azure deployment name). It must
+	// survive into the inline credentials so withDeploymentMap can use it.
+	ic, err := FromLiteLLMParams("azure", map[string]any{
+		"api_key":     "azk",
+		"api_base":    "https://acme.openai.azure.com",
+		"api_version": "2025-04-01-preview",
+		"deployment":  "my-gpt5-deployment",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ic.Azure["deployment"] != "my-gpt5-deployment" {
+		t.Errorf("expected deployment to be forwarded, got %v", ic.Azure["deployment"])
+	}
+}
+
 func TestFromLiteLLMParams_Bedrock(t *testing.T) {
 	ic, err := FromLiteLLMParams("bedrock", map[string]any{
 		"aws_access_key_id":     "AKIA",


### PR DESCRIPTION
## Problem

A customer reported `azure: Resource not found` (HTTP 404) when running a prompt configured with Azure OpenAI in the prompt playground — for a modern (gpt-5-class) model.

The error is **Azure's own 404**, surfaced raw. Investigation found two independent, individually-sufficient causes:

### 1. Stale, un-overridable Azure api-version (primary)

The prompt-studio chat executes entirely in Go: CopilotKit → `studioBackendPostEvent` → nlpgo → in-process Bifrost. In **direct (non-gateway) mode the TS layer set no `api_version`**, so Bifrost fell back to its GA default `2024-10-21`. That version predates the gpt-5 family, so Azure returns **`Resource not found` even when the deployment name is correct**. The only way to override it was to enable the optional API Gateway — direct Azure users were stuck on the stale default.

### 2. No model→deployment mapping on the inline path (secondary)

The model id was passed to Azure verbatim as the deployment name. The `deploymentMapping` field already exists and is honoured by the gateway/control-plane path (`config.materialiser`), but the in-process Studio/playground path ignored it — assuming model id == deployment name.

## Fix

- **`prepareLitellmParams` always sets `api_version` for Azure.** Direct mode defaults to a modern `DEFAULT_AZURE_API_VERSION` (`2025-04-01-preview`), **overridable per provider** via a new optional `AZURE_OPENAI_API_VERSION` credential key (surfaced as an optional field in the direct-mode provider settings form).
- **`prepareLitellmParams` resolves the deployment** from `deploymentMapping` and forwards it as `params.deployment`. The nlpgo translator allowlists it and `withDeploymentMap` maps `model id → real deployment`, falling back to the prior self-map when absent. This closes the inconsistency where the gateway path honoured `deploymentMapping` but the inline path didn't.

Both playground surfaces benefit from the api-version fix (the foundry `/api/playground` proxy path already forwards `x-litellm-api_version`). Deployment mapping is wired on the verified Studio/dispatcher path.

## Why these defaults

- `2025-04-01-preview` is a modern Azure api-version that resolves current model families and is backward-compatible for older deployments (preview versions are supersets of GA). It's overridable, so anyone needing to pin a specific version still can.
- Reusing the existing `deploymentMapping` field (rather than a new schema) keeps both routing paths consistent.

## Tests

- `prepareLitellmParams.unit.test.ts`: direct-mode api-version default, `AZURE_OPENAI_API_VERSION` override, deployment-mapping resolution, and the not-mapped fallthrough.
- `modelProviderHelpers.unit.test.ts`: api-version field appears in the direct-mode Azure key set.
- Go `translator_test.go`: `deployment` is forwarded into the inline Azure credentials.
- Go `adapter_test.go`: `withDeploymentMap` self-maps by default and honours an explicit deployment; non-Azure providers untouched.

All green; `pnpm typecheck` clean; `go build ./...` + `go vet` clean.

## Follow-ups (out of scope, noted)

- The foundry `/api/playground` proxy path does not apply any deployment map (no `withDeploymentMap`), and writes `cred.Extra["api_base"]` where Bifrost reads `endpoint`. Pre-existing; separate from the reported Studio bug.
- Friendlier surfacing of provider 404s in the playground UI (currently the raw `azure: Resource not found` leaks through).
- No UI yet to edit per-model `deploymentMapping` (API-settable only).



**Review round (CodeRabbit):**
- Azure `deploymentMapping` full-key fallback now keys off the normalized `params.model` (not the raw `mp_.../...` wire value) so `azure/<model>` mappings resolve. Added a regression test for the mp-id input.
- `AZURE_API_GATEWAY_VERSION` added to `optionalKeys` (it has a runtime default, so the form must not mark it required).

## Deployment Impact

No migrations, no chart/env changes, no new secrets — backward compatible.

- **Behavioral change (Azure direct mode):** existing Azure providers without an explicit api-version now send `2025-04-01-preview` instead of the downstream gateway's stale `2024-10-21` default. This fixes gpt-5-class deployments and is backward compatible for older deployments (preview api-versions are supersets of GA). To pin a specific version, set the new optional `AZURE_OPENAI_API_VERSION` field.
- **New optional credential key** `AZURE_OPENAI_API_VERSION` (direct mode) — additive; the Azure `keysSchema` is `.passthrough()` so no migration is needed.
- **Services touched:** `services/nlpgo` (litellm translator + dispatcher) ships in the normal app/worker image; no standalone deploy step. No `services/aigateway` behavior change.
- **Rollback:** revert the PR; no data migration to undo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure connections now support optional API version overrides, including support for API Gateway routing vs direct Azure calls with sensible defaults.
  * Azure model routing can use configured deployment mappings to select the correct deployment.

* **Bug Fixes**
  * Azure inline credentials now correctly preserve and forward an explicit deployment value.
  * Azure deployment mapping now honors explicit deployment overrides when provided, while non-Azure providers remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->