### PR TITLE
fix(dev): start Redis in make quickstart frontend-only

### DIFF
--- a/scripts/__tests__/dev-overrides.unit.bats
+++ b/scripts/__tests__/dev-overrides.unit.bats
@@ -148,13 +148,17 @@ teardown() {
 
 # --- frontend-only ---
 
-# @scenario "frontend-only mode starts no compose containers"
-@test "frontend-only writes only NEXTAUTH_PROVIDER (no compose, no URL overrides)" {
+# @scenario "frontend-only pins host-side Redis for in-process workers, no other compose"
+@test "frontend-only pins host-side REDIS_URL but no DB/CH/NLP overrides" {
+  # frontend-only runs no app/DB/CH compose, but `pnpm dev` runs the BullMQ
+  # workers in-process and the dev.sh launcher brings up a local redis for
+  # them. REDIS_URL must be the host-side localhost (pnpm dev runs on the
+  # host, not in the docker network). DB / CH / NLP still come from .env.
   write_dev_overrides frontend-only "$OUT"
   result=$(cat "$OUT")
   [[ "$result" == *"NEXTAUTH_PROVIDER=email"* ]]
+  [[ "$result" == *"REDIS_URL=redis://localhost:6379"* ]]
   [[ "$result" != *"DATABASE_URL"* ]]
-  [[ "$result" != *"REDIS_URL"* ]]
   [[ "$result" != *"CLICKHOUSE_URL"* ]]
   [[ "$result" != *"LANGWATCH_NLP_SERVICE"* ]]
 }

--- a/scripts/__tests__/dev-redis-detection.unit.bats
+++ b/scripts/__tests__/dev-redis-detection.unit.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# Unit tests for the host-Redis detection logic in scripts/dev.sh —
+# redis_listener_is_usable() and the frontend-only reuse/start/error branch
+# in run_frontend_only().
+#
+# Why this exists: redis_port_in_use() only proves *something* owns host port
+# 6379. Reusing that as Redis (REDIS_URL=redis://localhost:6379, skipping
+# `$COMPOSE up -d redis`) silently breaks the in-process BullMQ workers when
+# the listener is a non-Redis process or a Redis that needs auth/TLS. The fix
+# verifies the listener with `redis-cli ... ping` (PONG) before reuse, errors
+# out when 6379 is occupied by something unverifiable, and only starts its own
+# container when the port is free. (CodeRabbit review 4579126710, #5143.)
+#
+# dev.sh runs no app/compose when sourced: the `BASH_SOURCE != $0` guard near
+# the bottom returns after the function definitions. We source it inside a
+# `bash -c` whose argv0 is a single token so dev.sh's
+# `. "$(dirname "$0")/lib/write-dev-overrides.sh"` resolves relative to the
+# scripts/ working directory.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+
+  # Workdir whose langwatch/ subdir lets run_frontend_only's trailing
+  # `(cd langwatch && ... pnpm dev)` succeed without a real checkout.
+  WORKDIR="$TEST_DIR/work"
+  mkdir -p "$WORKDIR/langwatch"
+
+  # redis-cli stub that answers PING with PONG (a real, usable local Redis).
+  STUB_PONG="$TEST_DIR/bin-pong"
+  mkdir -p "$STUB_PONG"
+  printf '%s\n' '#!/usr/bin/env bash' 'echo PONG' > "$STUB_PONG/redis-cli"
+
+  # redis-cli stub that answers with a non-PONG reply (a listener that is not
+  # a usable Redis — e.g. another service, or a Redis demanding auth).
+  STUB_BAD="$TEST_DIR/bin-bad"
+  mkdir -p "$STUB_BAD"
+  printf '%s\n' '#!/usr/bin/env bash' 'echo WRONGREPLY' > "$STUB_BAD/redis-cli"
+
+  # Empty dir used as the entire PATH to simulate redis-cli being absent.
+  EMPTY_DIR="$TEST_DIR/empty"
+  mkdir -p "$EMPTY_DIR"
+
+  # pnpm stub so run_frontend_only's `pnpm dev` tail is a no-op in tests.
+  STUB_PNPM="$TEST_DIR/bin-pnpm"
+  mkdir -p "$STUB_PNPM"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$STUB_PNPM/pnpm"
+
+  chmod +x "$STUB_PONG/redis-cli" "$STUB_BAD/redis-cli" "$STUB_PNPM/pnpm"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- redis_listener_is_usable() ---
+
+# @scenario "redis-cli PONG reply means the listener is a usable local Redis"
+@test "redis_listener_is_usable: PONG reply -> usable" {
+  run bash -c '
+    scripts_dir="$1"; stub_bin="$2"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    PATH="$stub_bin:$PATH"
+    redis_listener_is_usable
+  ' _ "$SCRIPT_DIR" "$STUB_PONG"
+  [ "$status" -eq 0 ]
+}
+
+# @scenario "a listener that does not reply PONG is not a usable Redis"
+@test "redis_listener_is_usable: non-PONG reply -> not usable" {
+  run bash -c '
+    scripts_dir="$1"; stub_bin="$2"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    PATH="$stub_bin:$PATH"
+    redis_listener_is_usable
+  ' _ "$SCRIPT_DIR" "$STUB_BAD"
+  [ "$status" -ne 0 ]
+}
+
+# @scenario "absent redis-cli degrades gracefully to not-usable (no crash)"
+@test "redis_listener_is_usable: redis-cli absent -> not usable" {
+  run bash -c '
+    scripts_dir="$1"; empty_dir="$2"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    PATH="$empty_dir"
+    redis_listener_is_usable
+  ' _ "$SCRIPT_DIR" "$EMPTY_DIR"
+  [ "$status" -ne 0 ]
+}
+
+# --- run_frontend_only() redis branch ---
+
+# @scenario "frontend-only reuses a verified usable Redis without starting a container"
+@test "run_frontend_only: usable redis on 6379 -> reuse, no container start" {
+  run bash -c '
+    scripts_dir="$1"; workdir="$2"; stub_pnpm="$3"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    redis_port_in_use() { return 0; }
+    redis_listener_is_usable() { return 0; }
+    write_overrides() { :; }
+    COMPOSE="echo __COMPOSE_CALLED__"
+    PATH="$stub_pnpm:$PATH"
+    cd "$workdir" || exit 91
+    run_frontend_only
+  ' _ "$SCRIPT_DIR" "$WORKDIR" "$STUB_PNPM"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"reusing it for in-process workers"* ]]
+  [[ "$output" != *"__COMPOSE_CALLED__"* ]]
+  [[ "$output" != *"Starting: redis compose service"* ]]
+}
+
+# @scenario "frontend-only errors out when 6379 is occupied by an unusable listener"
+@test "run_frontend_only: non-usable listener on 6379 -> error + non-zero exit, no container start" {
+  run bash -c '
+    scripts_dir="$1"; workdir="$2"; stub_pnpm="$3"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    redis_port_in_use() { return 0; }
+    redis_listener_is_usable() { return 1; }
+    write_overrides() { :; }
+    COMPOSE="echo __COMPOSE_CALLED__"
+    PATH="$stub_pnpm:$PATH"
+    cd "$workdir" || exit 91
+    run_frontend_only
+  ' _ "$SCRIPT_DIR" "$WORKDIR" "$STUB_PNPM"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not be verified as a usable"* ]]
+  [[ "$output" != *"__COMPOSE_CALLED__"* ]]
+}
+
+# @scenario "frontend-only starts its own redis container when 6379 is free"
+@test "run_frontend_only: port 6379 free -> starts redis container" {
+  run bash -c '
+    scripts_dir="$1"; workdir="$2"; stub_pnpm="$3"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    redis_port_in_use() { return 1; }
+    redis_listener_is_usable() { return 1; }
+    write_overrides() { :; }
+    COMPOSE="echo __COMPOSE_CALLED__"
+    PATH="$stub_pnpm:$PATH"
+    cd "$workdir" || exit 91
+    run_frontend_only
+  ' _ "$SCRIPT_DIR" "$WORKDIR" "$STUB_PNPM"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Starting: redis compose service"* ]]
+  [[ "$output" == *"__COMPOSE_CALLED__ up -d redis"* ]]
+}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -155,6 +155,20 @@ EOF
   done
 }
 
+# Predicate: is something already listening on host port 6379? Used by
+# frontend-only to decide whether to start its own redis container or reuse
+# an existing host redis. Mirrors check_host_redis_collision's detection but
+# returns a status instead of exiting.
+redis_port_in_use() {
+  if command -v lsof >/dev/null 2>&1; then
+    [ -n "$(lsof -iTCP:6379 -sTCP:LISTEN -t 2>/dev/null | head -n1)" ]
+  elif command -v ss >/dev/null 2>&1; then
+    ss -ltnH "sport = :6379" 2>/dev/null | grep -q ":6379"
+  else
+    return 1
+  fi
+}
+
 # Detect a host-side process holding port 6379 before redis tries to bind.
 check_host_redis_collision() {
   [ "${SKIP_HOST_REDIS_CHECK:-0}" = "1" ] && return 0
@@ -349,11 +363,30 @@ EOF
 }
 
 run_frontend_only() {
+  # frontend-only runs no app/DB/CH compose — DB, ClickHouse, NLP and S3 all
+  # come from the operator's .env (shared dev). BUT `pnpm dev` starts the
+  # BullMQ workers in-process by default (set START_WORKERS=false for pure
+  # Vite), and those workers need Redis. Bring up only the lightweight `redis`
+  # compose service locally — sharing dev Redis would collide with other
+  # developers' jobs (same reason dev-infra runs Redis locally). The overlay
+  # pins REDIS_URL=redis://localhost:6379 so the host-side `pnpm dev` reaches it.
+  #
+  # If a host process already owns 6379 (e.g. the operator runs their own
+  # redis), reuse it rather than failing — our container would just collide.
   write_overrides frontend-only
-  echo "Preset: frontend-only — no compose. Run 'pnpm dev' from langwatch/ to start."
+  if redis_port_in_use; then
+    echo "Port 6379 already has a listener — reusing it for in-process workers (not starting a redis container)."
+  else
+    echo "Starting: redis compose service (preset=frontend-only)"
+    $COMPOSE up -d redis
+    echo "Redis is running detached on localhost:6379 (for in-process workers)."
+  fi
+  echo "Preset: frontend-only — no app compose. Run 'pnpm dev' from langwatch/ to start."
   echo ""
   echo "Tip: pure UI / design / static iteration. URLs come from langwatch/.env."
   echo "     For services on top: switch to all-local, all-local-nlp, or full-local."
+  echo "     Pure Vite with no background processing: START_WORKERS=false pnpm dev."
+  echo "     Stop redis with: scripts/dev.sh down"
   # Skip flags must be on the shell env of the pnpm dev subprocess, NOT in
   # .env.dev-up: start:prepare:db runs the migrations before the app boots
   # dotenv, so it reads the shell environment, not the overlay file. Frontend-only

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -169,6 +169,17 @@ redis_port_in_use() {
   fi
 }
 
+# Predicate: is the listener on host port 6379 actually a usable local Redis?
+# redis_port_in_use only proves *something* owns the port; this confirms it
+# speaks the Redis protocol with no auth/TLS gate by issuing PING and checking
+# for a PONG reply. If redis-cli is unavailable we cannot verify it, so we
+# degrade to "not usable" and the caller refuses to reuse an unverifiable
+# listener (rather than silently breaking the in-process BullMQ workers).
+redis_listener_is_usable() {
+  command -v redis-cli >/dev/null 2>&1 || return 1
+  redis-cli -u redis://localhost:6379 ping 2>/dev/null | grep -qx 'PONG'
+}
+
 # Detect a host-side process holding port 6379 before redis tries to bind.
 check_host_redis_collision() {
   [ "${SKIP_HOST_REDIS_CHECK:-0}" = "1" ] && return 0
@@ -372,10 +383,27 @@ run_frontend_only() {
   # pins REDIS_URL=redis://localhost:6379 so the host-side `pnpm dev` reaches it.
   #
   # If a host process already owns 6379 (e.g. the operator runs their own
-  # redis), reuse it rather than failing — our container would just collide.
+  # redis), reuse it ONLY when it answers PING with PONG — i.e. a real,
+  # auth-free local Redis. A non-Redis listener, or a Redis that requires
+  # auth/TLS, would let `pnpm dev` start but silently break the in-process
+  # BullMQ workers later, so fail loudly instead of reusing it. If 6379 is
+  # free, bring up our own lightweight redis container.
   write_overrides frontend-only
-  if redis_port_in_use; then
-    echo "Port 6379 already has a listener — reusing it for in-process workers (not starting a redis container)."
+  if redis_port_in_use && redis_listener_is_usable; then
+    echo "Port 6379 already has a usable Redis — reusing it for in-process workers (not starting a redis container)."
+  elif redis_port_in_use; then
+    cat >&2 <<'EOF'
+ERROR: Port 6379 has a listener, but it could not be verified as a usable
+       local Redis (redis-cli PING did not return PONG, or redis-cli is not
+       installed). frontend-only points the in-process BullMQ workers at
+       redis://localhost:6379, so reusing a non-Redis process — or a Redis
+       that needs auth/TLS — would silently break job processing. Fix one of:
+         - install redis-cli so the launcher can verify the listener, or
+         - stop whatever owns 6379 / repoint it at a plain local Redis, or
+         - free port 6379 so this launcher can start its own redis container.
+       Pure Vite with no workers: START_WORKERS=false pnpm dev.
+EOF
+    exit 1
   else
     echo "Starting: redis compose service (preset=frontend-only)"
     $COMPOSE up -d redis

--- a/scripts/lib/write-dev-overrides.sh
+++ b/scripts/lib/write-dev-overrides.sh
@@ -59,7 +59,16 @@ write_dev_overrides() {
 
   case "$preset" in
     frontend-only)
-      # No compose. Operator's .env points at dev infra; no overrides needed.
+      # No app/DB/CH compose — DB / CH / NLP / S3 all come from the operator's
+      # .env (shared dev). The one exception is Redis: `pnpm dev` runs the
+      # BullMQ workers in-process by default, and the dev.sh launcher brings up
+      # a local `redis` compose service for them (sharing dev Redis would
+      # collide with other developers' jobs — same reasoning as dev-infra).
+      # Pin REDIS_URL to host-side localhost because `pnpm dev` runs on the
+      # HOST, not inside the docker network.
+      cat >> "$out" <<'EOF'
+REDIS_URL=redis://localhost:6379
+EOF
       return 0
       ;;
     migration)


### PR DESCRIPTION
## What was broken

`make quickstart frontend-only` (→ `./scripts/dev.sh frontend-only`) did **not** start Redis.

frontend-only deliberately runs no app/DB/ClickHouse compose — those come from the operator's `langwatch/.env` (shared dev). But `pnpm dev` starts the **BullMQ workers in-process by default** (the preset's own help says so; `START_WORKERS=false` opts out), and those workers need a Redis broker. The preset:

- started **no** Redis container, and
- pinned **no** `REDIS_URL` in `langwatch/.env.dev-up`.

So the in-process workers had nothing to connect to. Every other workers-running preset (`all-local`, `dev-storage`, `dev-infra`, `full-local`) brings Redis up first.

## The fix

Mirror exactly what `dev-infra` already does for Redis:

1. **`scripts/dev.sh` → `run_frontend_only`** — bring up only the lightweight `redis` compose service (`docker compose -f compose.dev.yml up -d redis`) before `pnpm dev`. If a host process already owns port `6379` (e.g. the operator runs their own redis), **reuse it** rather than failing — added a small `redis_port_in_use` predicate (reuses the existing `check_host_redis_collision` detection logic) so this is non-disruptive.
2. **`scripts/lib/write-dev-overrides.sh` → frontend-only branch** — pin `REDIS_URL=redis://localhost:6379` (host-side localhost, because `pnpm dev` runs on the host, not in the docker network — same as `dev-infra`).
3. **`scripts/__tests__/dev-overrides.unit.bats`** — updated the frontend-only test to assert the new host-side `REDIS_URL` (it previously asserted *no* `REDIS_URL`); DB/CH/NLP are still asserted absent.

Local — not shared dev — Redis, deliberately: sharing dev Redis collides with other developers' BullMQ jobs (this is the documented `dev-infra` rationale).

Scope is intentionally minimal: 3 files, +51/-5. No app/DB/CH compose added; the preset stays "no app compose, fast."

## Human verification

To confirm the bug is fixed on your machine:

```bash
make quickstart frontend-only
# Expect, before pnpm dev starts:
#   Starting: redis compose service (preset=frontend-only)
#   Redis is running detached on localhost:6379 (for in-process workers)
docker compose -f compose.dev.yml ps redis     # -> redis container Up
redis-cli -h localhost -p 6379 ping            # -> PONG
cat langwatch/.env.dev-up                       # -> contains REDIS_URL=redis://localhost:6379
```

If you already run a host redis on 6379, expect instead:
`Port 6379 already has a listener — reusing it ...` (no second container, no failure).

## How I can prove I was successful

backend-only / dev-tooling change — no UI surface, so no screenshot.

1. **Unit tests pass (18/18)** including the updated frontend-only assertion and the cross-preset credential-leak invariant:
   ```
   $ bats scripts/__tests__/dev-overrides.unit.bats
   ...
   ok 13 frontend-only pins host-side REDIS_URL but no DB/CH/NLP overrides
   ok 18 no preset writes any credential-shaped env var to the overlay
   1..18  (all ok)
   ```
2. **Overlay now emits Redis** — `write_dev_overrides frontend-only` produces:
   ```
   NEXTAUTH_PROVIDER=email
   REDIS_URL=redis://localhost:6379
   ```
3. **Launcher code path proven** — traced `run_frontend_only` with `docker`/`pnpm` stubbed:
   - port 6379 free → `docker compose -f compose.dev.yml up -d redis` runs **before** `pnpm dev`.
   - port 6379 in use → reuse message, **no** redis container started, `pnpm dev` still runs.
4. **`bash -n`** clean on both `scripts/dev.sh` and `scripts/lib/write-dev-overrides.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `frontend-only` development setup to safely reuse an existing Redis on port `6379` when it’s a usable, unauthenticated Redis.
  * If something is listening on `6379` but isn’t safe to reuse, the setup now fails with an error instead of starting a new Redis container.
  * Updated `frontend-only` environment overrides to pin `REDIS_URL=redis://localhost:6379` and avoid setting a database URL.
* **Tests**
  * Updated and added unit tests to validate Redis detection and the revised override expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backend-only — no UI surface

This PR changes `scripts/dev.sh` (local dev-tooling for `make quickstart frontend-only`) and its bats test only — there is **no user-facing UI surface**, so live-app visual proof is N/A. Verification = the new bats suite (6 tests) + existing bats (18) + `bash -n` syntax check. <!-- no-ui-surface -->
