### PR TITLE
fix(compose): isolate mcp-server node_modules in a named volume (#5144)

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -6,7 +6,8 @@
 # **Use `make quickstart` — not direct compose.** ADR-004 (2026-05, #3860)
 # established `make quickstart` as the single entry point for local dev. It
 # sets VOLUME_PREFIX via scripts/dev.sh so per-worktree volumes (goose_bin,
-# app_modules, bullboard_modules, see line ~360) get isolated names; running
+# app_modules, bullboard_modules, mcp_server_modules, see the volumes block)
+# get isolated names; running
 # `docker compose -f compose.dev.yml up` directly collapses every worktree
 # onto the same volumes.
 #
@@ -145,6 +146,7 @@ services:
       - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
       - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
+      - mcp_server_modules:/mcp-server/node_modules
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro
       - ./python-sdk:/python-sdk:ro
@@ -187,6 +189,7 @@ services:
       - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
       - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
+      - mcp_server_modules:/mcp-server/node_modules
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro
       - ./python-sdk:/python-sdk:ro
@@ -255,6 +258,7 @@ services:
       - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
       - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
+      - mcp_server_modules:/mcp-server/node_modules
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro
       - ./python-sdk:/python-sdk:ro
@@ -357,6 +361,7 @@ services:
       - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
       - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
+      - mcp_server_modules:/mcp-server/node_modules
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro
       - ./python-sdk:/python-sdk:ro
@@ -403,6 +408,13 @@ volumes:
     name: ${VOLUME_PREFIX:-langwatch}-app-modules
   bullboard_modules:
     name: ${VOLUME_PREFIX:-langwatch}-bullboard-modules
+  # mcp-server is a standalone pnpm workspace whose install + build run in the
+  # `init` container against the `./mcp-server` bind mount. Without isolation
+  # the container install writes container-shaped pnpm symlinks into the host
+  # tree, which then dangle and break a host-side build (#5144). Isolating
+  # node_modules in a named volume keeps the host tree untouched.
+  mcp_server_modules:
+    name: ${VOLUME_PREFIX:-langwatch}-mcp-server-modules
   # Always shared (cache only).
   pnpm_store:
     name: langwatch-pnpm-store


### PR DESCRIPTION
## Ticket

Closes #5144. `make quickstart full-local` (any compose `init` build) poisons the host `mcp-server/node_modules`: the container `pnpm install` writes container-shaped pnpm symlinks into the host bind mount, which dangle on the host and break a host-side build with `Cannot find module '.../mcp-server/node_modules/tsup/dist/cli-default.js'`.

## G-START verdict

PROCEED. Re-verified on current `origin/main` (`8decd8873`): the `init` service still runs `(cd /mcp-server && pnpm install --ignore-scripts && pnpm run build)` against the `./mcp-server` bind mount, and `mcp-server` is the only bind-mounted workspace whose `node_modules` is not isolated in a named volume (`app` uses `app_modules`, `bullboard` uses `bullboard_modules`). The premise holds; no existing PR.

## Change

Add a `mcp_server_modules` named volume mounted at `/mcp-server/node_modules` on every service that bind-mounts `./mcp-server` (`init`, `app`, `workers`, `ai-server`), following the existing `app_modules` / `bullboard_modules` pattern (same `${VOLUME_PREFIX:-langwatch}-…` per-worktree naming from ADR-004). The named volume shadows the host `node_modules`, so the container install writes into the volume and the host tree is left untouched. Header comment updated to keep the volume inventory honest.

This is exactly the fix the issue's "Expected behavior" calls for; no command changes, no behavior change for the in-container build.

## Evidence

**Structural (YAML + wiring):** all four services that bind-mount `./mcp-server` now isolate `node_modules`; volume declared once; target consistent.
```
services bind-mounting ./mcp-server and whether isolated:
  [('init', True), ('app', True), ('workers', True), ('ai-server', True)]
OK: all 4 mcp-server services isolate node_modules; YAML valid
```

**Functional (reproduced the mount topology with `docker run`):**

Negative control = current main (bind mount only) reproduces the bug:
```
AFTER (no named volume): HOST node_modules
  CONTAINER_MARKER
  HOST_SENTINEL
  tsup
host tsup symlink target: ../../app/node_modules/.pnpm/tsup/dist/cli-default.js   <- dangling host path = #5144
```

With this PR's topology (bind mount + `mcp_server_modules:/mcp-server/node_modules`) the host tree is shielded:
```
BEFORE: host node_modules -> HOST_SENTINEL
container writes CONTAINER_MARKER + tsup symlink into /mcp-server/node_modules
AFTER: HOST node_modules -> HOST_SENTINEL   (only)
readlink host tsup -> no tsup symlink on host  ✓
```
The container's install writes land in the named volume, never on the host bind mount.

## Advisory note

Advisory PR from the tech-debt-fixer bot, opened for human review, not to be merged by the bot. The human makes the merge call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local development container setup so workspace dependencies are kept isolated, reducing build and install issues caused by shared volume paths.
  * Helped prevent broken dependency links when running the app with Compose directly.

* **Documentation**
  * Clarified the development Compose notes to better explain the volume setup and local workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->