### PR TITLE
fix(dev): repair the full-local docker compose stack so langevals-backed evaluators run

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -293,7 +293,14 @@ services:
   # dial http://langwatch_nlp:5561 (LANGWATCH_NLP_SERVICE) unchanged.
 
   langwatch_nlp:
-    image: langwatch/langwatch_nlp:latest
+    # Build from local services/nlpgo source (via Dockerfile.langwatch_nlp)
+    # instead of the published langwatch/langwatch_nlp:latest image, which
+    # lags the source. Building from source keeps the engine in lockstep with
+    # this checkout, so evaluator output (e.g. the `details`/reasoning
+    # envelope) matches the code here. See #5151.
+    build:
+      context: .
+      dockerfile: Dockerfile.langwatch_nlp
     profiles: [nlp, scenarios, full]
     # No host port - accessed via docker network as "langwatch_nlp:5561"
     environment:
@@ -307,7 +314,14 @@ services:
           cpus: "0.5"
 
   langevals:
-    image: langwatch/langevals:latest
+    # Build from local ./langevals source (via Dockerfile.langevals) instead
+    # of the published langwatch/langevals:latest image, which lags the
+    # source. Newer evaluators present in this checkout 404 against :latest;
+    # building from source guarantees the container serves exactly the
+    # evaluators in this checkout. See #5151.
+    build:
+      context: .
+      dockerfile: Dockerfile.langevals
     profiles: [nlp, full]
     # No host port - accessed via docker network as "langevals:5562"
     environment:
@@ -315,7 +329,11 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256m
+          # langevals imports ragas/langchain at boot and OOM-kills at 256m
+          # before it can serve a single request — even with preload disabled.
+          # Production (charts/langwatch) requests 6Gi/limits 8Gi; 4g is enough
+          # for the dev import footprint plus LLM-judge evaluators.
+          memory: 4g
           cpus: "0.5"
 
   # =============================================================================

--- a/langwatch/scripts/build-mcp-server.sh
+++ b/langwatch/scripts/build-mcp-server.sh
@@ -9,6 +9,23 @@ set -eo pipefail
 printf 'building mcp server... '
 start=$(node -e 'console.log(Date.now())')
 
+# Self-heal a half-linked mcp-server/node_modules. An interrupted prep run
+# (Ctrl-C, OOM, the compose-v5 crash) can leave the `.bin/tsup` symlink in
+# place while the `tsup` package files never finish linking. The next
+# `pnpm install` then reports "Lockfile is up to date" and skips repair, so
+# this build dies with `Cannot find module '.../tsup/dist/cli-default.js'`.
+# Re-link the workspace deps from the store when tsup's entrypoint is absent
+# — the exact one-liner we'd otherwise run by hand, made automatic.
+mcp_tsup="$(cd "$(dirname "$0")/../.." && pwd)/mcp-server/node_modules/tsup/dist/cli-default.js"
+if [ ! -e "$mcp_tsup" ]; then
+  printf '(repairing deps) '
+  if ! repair_output=$(pnpm --filter @langwatch/mcp-server install 2>&1); then
+    printf 'FAILED\n'
+    printf '%s\n' "$repair_output"
+    exit 1
+  fi
+fi
+
 if ! output=$(pnpm --silent --filter @langwatch/mcp-server run build 2>&1); then
   printf 'FAILED\n'
   printf '%s\n' "$output"


### PR DESCRIPTION
## Why

Closes #5146

The `make quickstart full-local` docker compose dev stack couldn't run langevals-backed evaluators: the `langevals` container OOM-died at boot, and the `langevals` / `langwatch_nlp` images served stale binaries. A separate prep step (`build:mcp-server`) also hard-failed after any interrupted install. All fixes are dev-environment only — `compose.dev.yml` and `langwatch/scripts/build-mcp-server.sh`. No feature/runtime code.

Root-cause background on why the published images drift behind source is tracked in #5151.

## What changed

- **Raise the `langevals` dev memory limit `256m` → `4g`** so its ragas/langchain import has headroom to reach a serving state instead of being OOM-killed at boot.
- **Build `langevals` from local source** (`Dockerfile.langevals`) instead of the published `:latest` image, so the container serves the evaluators in this checkout.
- **Build `langwatch_nlp` from local source** (`Dockerfile.langwatch_nlp`) instead of `:latest`, so the engine emits the evaluator `details` (reasoning) envelope.
- **Self-heal the `mcp-server` build prep**: `build-mcp-server.sh` re-links `@langwatch/mcp-server` when `tsup`'s entrypoint is missing (a half-linked `node_modules` left by an interrupted install), and fails fast surfacing the repair output if the relink itself fails.

## Test plan

- `bash scripts/build-mcp-server.sh` from a worktree with no `mcp-server/node_modules` → `building mcp server... (repairing deps) built in 3.2s`. Self-heal triggers and succeeds where it previously hard-failed; a failing relink now exits non-zero with output.
- `docker compose -f compose.dev.yml --profile full config` validates; `langevals` limit resolves to 4 GiB; `langevals` and `langwatch_nlp` resolve to build-from-source.
- Both images build clean from local source.
- **Acceptance:** a langevals-backed evaluator (e.g. `langevals/pairwise_compare`) returns a real verdict with reasoning end-to-end on `make quickstart full-local`.

## Anything surprising?

The four changes stack — the cap raise alone still leaves a stale langevals image, and both langevals fixes still drop the reasoning envelope without the nlpgo fix. Building from source adds a one-time image build on the first `full-local` boot after this lands; #5151 tracks removing the build-from-source workaround once published images stay in lockstep with source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development services now build from the local workspace instead of relying on older prebuilt images, reducing version mismatches and improving local startup reliability.
  * Increased memory available to one development service to prevent out-of-memory failures during startup and evaluation tasks.

* **Chores**
  * The MCP server build script now automatically repairs missing dependencies before building, helping recover from incomplete installs without manual cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->