### PR TITLE
fix(scenario-events): accept input_audio in MESSAGE_SNAPSHOT validator

### DIFF
--- a/langwatch/src/server/scenarios/schemas/__tests__/event-schemas.unit.test.ts
+++ b/langwatch/src/server/scenarios/schemas/__tests__/event-schemas.unit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the scenario event WIRE validator (`scenarioEventSchema`) —
+ * the exact schema the `/api/scenario-events` route hands to
+ * `zValidator("json", scenarioEventSchema)`. A `safeParse` success here is a
+ * faithful, DB-free proxy for "the route returns 201, not 400": the route only
+ * 400s when this parse fails.
+ *
+ * Regression guard for #5149 (the missing WIRE leg of #4138): a
+ * SCENARIO_MESSAGE_SNAPSHOT carrying a voice turn
+ * (`[text, {type:"input_audio", input_audio:{data}}]`) was rejected here with a
+ * Zod `invalid_union` 400 BEFORE `extractInlineMediaFromEvent` ever ran, so
+ * voice audio never reached the externalizer the UI render leg (#4138) depends
+ * on. These tests pin that the validator now ACCEPTS `input_audio` while still
+ * accepting every previously-valid shape.
+ */
+import { describe, expect, it } from "vitest";
+import { ScenarioEventType } from "~/server/scenarios/scenario-event.enums";
+import {
+  scenarioEventSchema,
+  scenarioMessageSnapshotSchema,
+} from "~/server/scenarios/schemas";
+
+const WAV_BASE64 = Buffer.from("fake-wav-bytes").toString("base64");
+
+/** A MESSAGE_SNAPSHOT wire event whose `messages` carry `content` parts. */
+function makeSnapshotEvent(content: unknown) {
+  return {
+    type: ScenarioEventType.MESSAGE_SNAPSHOT,
+    timestamp: Date.now(),
+    batchRunId: "batch-1",
+    scenarioId: "scenario-1",
+    scenarioRunId: "run-1",
+    scenarioSetId: "default",
+    messages: [{ id: "msg-1", role: "assistant", content }],
+  };
+}
+
+describe("scenarioMessageSnapshotSchema — input_audio wire acceptance (#5149)", () => {
+  it("ACCEPTS a voice turn: [text, input_audio] mixed content (was 400 before the fix)", () => {
+    const event = makeSnapshotEvent([
+      { type: "text", text: "Here is your audio reply" },
+      { type: "input_audio", input_audio: { data: WAV_BASE64, format: "wav" } },
+    ]);
+
+    // scenarioEventSchema is the discriminated union the route validator uses.
+    const result = scenarioEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("preserves the input_audio bytes through validation so the extractor can externalize them", () => {
+    const event = makeSnapshotEvent([
+      { type: "text", text: "Here is your audio reply" },
+      { type: "input_audio", input_audio: { data: WAV_BASE64, format: "wav" } },
+    ]);
+
+    const result = scenarioMessageSnapshotSchema.safeParse(event);
+    expect(result.success).toBe(true);
+
+    // The audio part — and crucially its base64 `data` — must survive the parse
+    // unchanged; `extractInlineMediaFromEvent` reads exactly this to decode and
+    // store the bytes. If validation stripped it, the extractor would no-op.
+    const audioPart = (result.success ? result.data.messages[0] : undefined) as
+      | {
+          content: Array<{
+            type: string;
+            input_audio?: { data?: string; format?: string };
+          }>;
+        }
+      | undefined;
+    const part = audioPart?.content.find((p) => p.type === "input_audio");
+    expect(part?.input_audio?.data).toBe(WAV_BASE64);
+    expect(part?.input_audio?.format).toBe("wav");
+  });
+
+  it("ACCEPTS an audio-only turn: [input_audio] with no text part", () => {
+    const event = makeSnapshotEvent([
+      { type: "input_audio", input_audio: { data: WAV_BASE64, format: "wav" } },
+    ]);
+
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  it("ACCEPTS the post-extraction rewrite shape: input_audio:{url, mimeType} with no data", () => {
+    const event = makeSnapshotEvent([
+      { type: "text", text: "Here is your audio reply" },
+      {
+        type: "input_audio",
+        input_audio: { url: "/api/files/proj/abc123", mimeType: "audio/wav" },
+      },
+    ]);
+
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+});
+
+describe("scenarioMessageSnapshotSchema — regression: previously-valid shapes still validate (#5149 AC4)", () => {
+  it("ACCEPTS plain string content", () => {
+    const event = makeSnapshotEvent("just text");
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  it("ACCEPTS a text content part", () => {
+    const event = makeSnapshotEvent([{ type: "text", text: "hello" }]);
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  it("ACCEPTS an image_url content part (existing tracer chatMessageSchema member)", () => {
+    const event = makeSnapshotEvent([
+      { type: "image_url", image_url: { url: "https://example.com/cat.png" } },
+    ]);
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+});

--- a/langwatch/src/server/scenarios/schemas/event-schemas.ts
+++ b/langwatch/src/server/scenarios/schemas/event-schemas.ts
@@ -103,6 +103,55 @@ export const scenarioRunFinishedSchema = baseScenarioEventSchema.extend({
 });
 
 /**
+ * Voice scenario `input_audio` content part — the missing WIRE leg of #4138
+ * (tracked as #5149).
+ *
+ * Voice turns arrive as a mixed content array, e.g.
+ *   `[ { type: "text", text }, { type: "input_audio", input_audio: { data, format } } ]`
+ * — the shape the langwatch python-sdk emits, and the shape the typescript-sdk's
+ * `convert-core-messages-to-agui-messages` translates AI-SDK audio parts to.
+ *
+ * Neither the AG-UI `MessageSchema` nor the tracer `chatMessageSchema` content
+ * unions accept an `input_audio` part, so a voice MESSAGE_SNAPSHOT was
+ * 400-rejected at the route validator (`zValidator("json", scenarioEventSchema)`
+ * in `app/api/scenario-events/[[...route]]/app.ts`) BEFORE
+ * `extractInlineMediaFromEvent` — which already externalizes `input_audio`
+ * (`server/stored-objects/content-extractor.ts` `inputAudio`) — ever ran.
+ * Accepting it here lets the payload reach that extractor so the UI render leg
+ * shipped in #4138 finally has data to paint.
+ *
+ * Every `input_audio` field is optional so this validates BOTH the inbound
+ * pre-extraction shape (`{ data, format }`) and the post-extraction rewrite
+ * (`{ url, mimeType, data: undefined }`).
+ */
+const inputAudioContentPartSchema = z.object({
+  type: z.literal("input_audio"),
+  input_audio: z.object({
+    data: z.string().optional(),
+    format: z.string().optional(),
+    mimeType: z.string().optional(),
+    url: z.string().optional(),
+    id: z.string().optional(),
+  }),
+});
+
+/**
+ * A message whose `content` array mixes plain text with `input_audio` parts.
+ * Added as a third member of the message union below so existing text / image /
+ * tool / binary messages keep validating via `MessageSchema` / `chatMessageSchema`
+ * — this is purely additive and rejects no previously-accepted shape.
+ */
+const scenarioAudioMessageSchema = z.object({
+  role: z.string().optional(),
+  content: z.array(
+    z.union([
+      z.object({ type: z.literal("text"), text: z.string() }),
+      inputAudioContentPartSchema,
+    ]),
+  ),
+});
+
+/**
  * Scenario Message Snapshot Event Schema
  * Captures the conversation state at a specific point during scenario execution.
  * Includes searchable_content and payload for full message functionality.
@@ -112,7 +161,7 @@ export const scenarioMessageSnapshotSchema = MessagesSnapshotEventSchema.merge(
     type: z.literal(ScenarioEventType.MESSAGE_SNAPSHOT),
     messages: z.array(
       z.intersection(
-        z.union([MessageSchema, chatMessageSchema]),
+        z.union([MessageSchema, chatMessageSchema, scenarioAudioMessageSchema]),
         z.object({
           id: z.string().optional(),
           trace_id: z.string().optional(),

--- a/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
@@ -219,6 +219,42 @@ function makeEventWithInlineImage(scenarioRunId: string) {
   };
 }
 
+/**
+ * A SCENARIO_MESSAGE_SNAPSHOT whose message content is a voice turn:
+ * `[text, {type:"input_audio", input_audio:{data, format}}]` — the shape the
+ * python-sdk emits and the ts-sdk's convert-core-messages translates to.
+ *
+ * Unlike TEXT_MESSAGE_END (whose `message` field is `z.record(z.unknown())` and
+ * bypasses content validation), this payload is validated by the STRICT
+ * `scenarioMessageSnapshotSchema` messages union — the exact gate that
+ * 400-rejected voice audio before #5149. This is the end-to-end wire test the
+ * isolated extractor/renderer tests were missing.
+ */
+function makeMessageSnapshotWithInputAudio(scenarioRunId: string) {
+  const audioBase64 = Buffer.from("fake-wav-bytes").toString("base64");
+  return {
+    type: ScenarioEventType.MESSAGE_SNAPSHOT,
+    timestamp: Date.now(),
+    batchRunId: `batch-${nanoid(6)}`,
+    scenarioId: `scenario-${nanoid(6)}`,
+    scenarioRunId,
+    scenarioSetId: "default",
+    messages: [
+      {
+        id: `msg-${nanoid(6)}`,
+        role: "assistant",
+        content: [
+          { type: "text", text: "Here is your audio reply" },
+          {
+            type: "input_audio",
+            input_audio: { data: audioBase64, format: "wav" },
+          },
+        ],
+      },
+    ],
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
@@ -380,6 +416,46 @@ describe("POST /api/scenario-events (ingest)", () => {
         expect.objectContaining({
           projectId: testProjectId,
           mediaType: "image/png",
+          purpose: "scenario_event",
+        }),
+      );
+    });
+  });
+
+  describe("when a MESSAGE_SNAPSHOT carries a voice input_audio turn (#5149 — missing wire leg of #4138)", () => {
+    /** @scenario "Voice MESSAGE_SNAPSHOT with input_audio is accepted (201) and the audio is externalized" */
+    it("returns 201 (not 400) and externalizes the input_audio bytes via storeFromBytes", async () => {
+      const extractedId = `stored-${nanoid(8)}`;
+      mockStoreFromBytes.mockResolvedValueOnce({
+        id: extractedId,
+        mediaType: "audio/wav",
+        isDuplicate: false,
+      });
+
+      const scenarioRunId = `run-${nanoid(6)}`;
+      const body = makeMessageSnapshotWithInputAudio(scenarioRunId);
+
+      const res = await app.request("/api/scenario-events", {
+        method: "POST",
+        headers: {
+          "X-Auth-Token": testApiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      // Before the wire-leg fix this returned 400 — the scenarioEventSchema
+      // message union (event-schemas.ts) had no `input_audio` member, so
+      // zValidator rejected the snapshot before extraction ever ran.
+      expect(res.status).toBe(201);
+
+      // The audio survived validation and reached extractInlineMediaFromEvent,
+      // which decoded the base64 and externalized it as a stored object. The
+      // wav format resolves to the audio/wav media type.
+      expect(mockStoreFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: testProjectId,
+          mediaType: "audio/wav",
           purpose: "scenario_event",
         }),
       );

--- a/specs/features/scenarios/externalize-event-byte-content.feature
+++ b/specs/features/scenarios/externalize-event-byte-content.feature
@@ -360,6 +360,19 @@ Feature: Externalize event byte content to stored_objects
     And the event payload remains a valid MESSAGE_SNAPSHOT shape
 
   @integration
+  Scenario: Voice MESSAGE_SNAPSHOT with input_audio is accepted (201) and the audio is externalized
+    # The WIRE leg of voice-scenario audio: #5149, the missing half of #4138
+    # (which fixed only the UI render leg). The route validator
+    # (scenarioEventSchema) must accept an input_audio content part so the
+    # snapshot reaches the extractor — otherwise it is 400-rejected at the
+    # zValidator before any externalization can run, and the run shows zero
+    # turns. The SDK emits voice turns as [text, input_audio].
+    Given a MESSAGE_SNAPSHOT whose message content is a voice turn [text, {type:"input_audio", input_audio:{data, format:"wav"}}]
+    When the event is POSTed to /api/scenario-events
+    Then the request is accepted with 201 rather than 400 from schema validation
+    And the inline audio bytes are decoded and externalized to a stored_objects row with media type audio/wav
+
+  @integration
   Scenario: Content parts with an unrecognised shape cause the message to pass through unchanged
     Given a message whose content array contains a part with an unrecognized type
     When the extractor walks the part list


### PR DESCRIPTION
## Why

Closes #5149

Voice scenario audio **never renders** in the simulations UI. Every `SCENARIO_MESSAGE_SNAPSHOT` POST to `/api/scenario-events` that carries audio is **400-rejected by Zod validation before the inline-media extractor runs**, so the run row appears (RUN_STARTED/RUN_FINISHED = 201) but with **zero turns**. This affects **all** voice scenarios (python + ts SDK).

This is the missing **wire leg** of #4138. That issue fixed only the UI render leg, on the (false) premise that the wire already accepted `input_audio` — it never did.

## What changed

- **Widened the `MESSAGE_SNAPSHOT` message-content union to accept `input_audio`** — `scenarioMessageSnapshotSchema` validated each message against `z.union([MessageSchema, chatMessageSchema])`; neither AG-UI `MessageSchema` (`text | image | audio | video | document | binary`) nor tracer `chatMessageSchema` (`text | image_url | tool_call | tool_result | binary`) has an `input_audio` part, so a voice turn `[text, {type:"input_audio", input_audio:{data}}]` failed `invalid_union` → 400.
- **Additive, scoped to the wire-leg validator** — chose a third union member (`scenarioAudioMessageSchema`) over editing the shared `chatRichContentSchema` in `tracer/types.ts`: smallest blast radius, no change to trace validation, and it rejects **no** previously-accepted shape.
- **Every `input_audio` field is optional** — validates both the inbound pre-extraction shape (`{data, format}`) and the post-extraction rewrite (`{url, mimeType, data: undefined}`) the extractor emits.
- **Added the end-to-end wire test that was missing** — existing tests exercised the extractor/renderer with fixtures, *bypassing validation*; that gap is exactly what hid the bug.
- **Bound the new test to feature-file parity** — added the matching `@integration` scenario to `specs/features/scenarios/externalize-event-byte-content.feature` (the spec that already governs the sibling scenario-events ingest tests), so the `feature-parity` CI job stays green.

## How it works

```
src/server/scenarios/schemas/event-schemas.ts        ← the fix (wire validation)
  ├─ inputAudioContentPartSchema   (new)  {type:"input_audio", input_audio:{data?,format?,mimeType?,url?,id?}}
  ├─ scenarioAudioMessageSchema    (new)  {role?, content:[ text | input_audio ]}
  └─ scenarioMessageSnapshotSchema (edit) messages union → [MessageSchema, chatMessageSchema, scenarioAudioMessageSchema]

src/app/api/scenario-events/[[...route]]/app.ts       (unchanged)
  zValidator("json", scenarioEventSchema)   ← was 400 here; now passes
    → extractInlineMediaFromEvent(...)       ← already handles input_audio

src/server/stored-objects/content-extractor.ts        (unchanged)
  inputAudio()  decodes base64 → storeFromBytes → rewrites to {url, mimeType}

src/components/simulations/MediaPart.tsx              (unchanged — UI leg shipped in #4138)
  renders {type:"input_audio", input_audio:{url, mimeType}} as <audio controls>
```

The validator was the only broken link: every layer downstream of it already handled `input_audio` and was dead code until the POST was accepted.

## How I can prove I was successful

**Falsifiability — the targeted tests fail without the fix and pass with it** (no user-observable surface is bootable in this env — no DB/app; the UI render leg was already verified in #4138, so the proof here is the wire validator going red→green).

Commits are split so a reviewer can reproduce red directly: `git checkout d36d3f9ad` (tests) → red; `git checkout f161e333e` (fix) → green. A third commit (`503ac1543`) binds the new test's `@scenario` annotation to a feature scenario so `check:feature-parity` passes (exit 0, locally verified).

RED — fix reverted (`git stash` of `event-schemas.ts`), validator back to `z.union([MessageSchema, chatMessageSchema])`:

```
❯ src/server/scenarios/schemas/__tests__/event-schemas.unit.test.ts (7 tests | 4 failed)
   × ACCEPTS a voice turn: [text, input_audio] mixed content (was 400 before the fix)
   × preserves the input_audio bytes through validation so the extractor can externalize them
   × ACCEPTS an audio-only turn: [input_audio] with no text part
   × ACCEPTS the post-extraction rewrite shape: input_audio:{url, mimeType} with no data
 Test Files  1 failed (1)
      Tests  4 failed | 3 passed (7)
```

GREEN — fix applied:

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

The 3 tests that pass in both runs are the regression guards (string / text / image_url content) — proof the change is purely additive.

`pnpm typecheck` (tsgo) passes (exit 0); biome is clean on the changed lines.

The integration test (`scenario-events-ingest.integration.test.ts`) drives a real POST through the route validator and asserts **201 + `storeFromBytes` externalization** — it runs against a real Postgres in CI (`test-integration`), the end-to-end wire proof this PR is about. CI status linked on this PR.

## Human verification

For a skeptic who wants to confirm independently:

1. `cd langwatch && pnpm install`
2. `git checkout d36d3f9ad` (tests-only commit) then
   `pnpm exec vitest run src/server/scenarios/schemas/__tests__/event-schemas.unit.test.ts`
   → 4 `input_audio` tests **fail** (the validator rejects the voice turn).
3. `git checkout f161e333e` (the fix) and re-run the same command → **7 pass**.
4. End-to-end: POST a `SCENARIO_MESSAGE_SNAPSHOT` to `/api/scenario-events` whose `messages[].content` is
   `[{type:"text",text:"hi"},{type:"input_audio",input_audio:{data:"<wav-base64>",format:"wav"}}]`.
   Before: `400` (`ZodError invalid_union` at `messages.0.content.0.type`). After: `201`, and the audio is externalized to `/api/files/...` and renders as an `<audio>` bubble (UI leg from #4138).

## Anything surprising?

- **Not a regression.** `input_audio` appears in no committed source; #4651 (the zod single-source refactor) removed nothing here — the validator simply never accepted it.
- **No SDK change needed** — `@langwatch/scenario` already emits `input_audio` on the wire (verified in the issue); the fix is purely this server-side validator.
- The cleaner long-term shape (add `input_audio` to the shared `chatRichContentSchema` so traces can carry realtime audio too) is deliberately **out of scope** here to keep blast radius on the wire-leg fix — maintainers' call for a follow-up.


## Live-app visual — waived (Drew msg 637)

This is the **wire leg** (server Zod validator). The UI render leg (audio player) shipped and was proven in **#4138**; this PR only opens the wire so that already-built renderer receives data. The wire is proven here by the **real-Postgres integration test** (voice `MESSAGE_SNAPSHOT` POST → **201**, audio decoded + externalized as `audio/wav` via `storeFromBytes`). Drew **waived** the redundant end-to-end golden-VM voice-scenario visual for this wire-only change. <!-- no-ui-surface -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voice messages with inline audio are now accepted in scenario event ingest instead of being rejected during validation.
  * Mixed content turns with text and audio, as well as audio-only turns, are supported.
  * Audio content is preserved through validation so it can be processed and stored correctly.
  * Externalized audio now keeps the expected media type and is saved successfully for later use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->