### PR TITLE
fix(parity): reconcile quickstart redis scenarios to restore feature-parity on main

### DIFF
--- a/specs/setup/quickstart-entry-point.feature
+++ b/specs/setup/quickstart-entry-point.feature
@@ -49,16 +49,60 @@ Feature: make quickstart is the single dev environment entry point with intent-b
   # --- Default = fastest path (#3860 AC#3) ---
 
   @unit
-  Scenario: frontend-only mode starts no compose containers
+  Scenario: frontend-only pins host-side Redis for in-process workers, no other compose
     When I run "make quickstart frontend-only"
-    Then no compose services are brought up
-    And langwatch/.env.dev-up contains only NEXTAUTH_PROVIDER=email
-    And no infrastructure URLs are overridden
+    Then langwatch/.env.dev-up pins REDIS_URL=redis://localhost:6379
+    And it sets NEXTAUTH_PROVIDER=email
+    And no DATABASE_URL, CLICKHOUSE_URL, or LANGWATCH_NLP_SERVICE override is written
 
   @integration @unimplemented
   Scenario: frontend-only mode is fast — under 5 seconds to ready hint
     When I run "make quickstart frontend-only"
     Then the command completes in under 5 seconds with a hint to run "pnpm dev"
+
+  # frontend-only runs the BullMQ workers in-process via `pnpm dev`, so it needs
+  # a broker. dev.sh verifies host port 6379 is a *usable* Redis (redis-cli PING
+  # -> PONG) before reusing it, errors out when the port is held by something
+  # unverifiable, and only starts its own redis compose container when free.
+  Rule: frontend-only verifies host Redis is usable before reuse
+
+    @unit
+    Scenario: redis-cli PONG reply means the listener is a usable local Redis
+      Given redis-cli answers PING with "PONG"
+      When redis_listener_is_usable runs
+      Then it reports the listener as a usable Redis
+
+    @unit
+    Scenario: a listener that does not reply PONG is not a usable Redis
+      Given redis-cli answers PING with a non-PONG reply
+      When redis_listener_is_usable runs
+      Then it reports the listener as not usable
+
+    @unit
+    Scenario: absent redis-cli degrades gracefully to not-usable (no crash)
+      Given redis-cli is not on PATH
+      When redis_listener_is_usable runs
+      Then it reports the listener as not usable without crashing
+
+    @unit
+    Scenario: frontend-only reuses a verified usable Redis without starting a container
+      Given host port 6379 is in use by a verified usable Redis
+      When I run "make quickstart frontend-only"
+      Then it reuses the existing Redis for the in-process workers
+      And it does not start a redis compose container
+
+    @unit
+    Scenario: frontend-only errors out when 6379 is occupied by an unusable listener
+      Given host port 6379 is in use by a listener that is not a usable Redis
+      When I run "make quickstart frontend-only"
+      Then it fails with an actionable error and a non-zero exit
+      And it does not start a redis compose container
+
+    @unit
+    Scenario: frontend-only starts its own redis container when 6379 is free
+      Given host port 6379 is free
+      When I run "make quickstart frontend-only"
+      Then it starts the redis compose service
 
   # --- URL rewrite per mode (#3860 AC#6) ---
 

--- a/specs/setup/quickstart-entry-point.feature
+++ b/specs/setup/quickstart-entry-point.feature
@@ -145,7 +145,7 @@ Feature: make quickstart is the single dev environment entry point with intent-b
     Given a previous run wrote all-local overrides
     When write_overrides runs again with mode=frontend-only
     Then langwatch/.env.dev-up no longer contains DATABASE_URL
-    And only the frontend-only override (NEXTAUTH_PROVIDER) remains
+    And it contains only the frontend-only overrides (NEXTAUTH_PROVIDER and REDIS_URL)
 
   # --- Stateful volume sharing (#3860 AC#4) ---
 


### PR DESCRIPTION
## What

The `feature-parity` CI gate is **red on main** (1 unbound enforced scenario + 7 annotations referencing unknown scenarios). This restores it to green.

## Root cause

The breakage is in the quickstart dev-setup area, introduced by #5143 (start Redis in frontend-only). That PR:
- renamed a `# @scenario` binding in `scripts/__tests__/dev-overrides.unit.bats` (orphaning the `frontend-only mode starts no compose containers` scenario at `quickstart-entry-point.feature:52`), and
- added 6 new redis-detection bindings in `scripts/__tests__/dev-redis-detection.unit.bats` without adding the matching Gherkin scenarios.

The `feature-parity` job only runs when `specs/**` or `langwatch/**` change, so the breakage stayed latent on main until the next `specs/**` change (#5148) triggered a run. It was never my #5148 diff — that feature is fully bound; #5148 was just the first run to surface the pre-existing breakage.

## Fix

Reconcile `specs/setup/quickstart-entry-point.feature` with the behavior #5143 actually shipped:
- Retitle the orphaned scenario to `frontend-only pins host-side Redis for in-process workers, no other compose` and update its body (frontend-only now pins `REDIS_URL=redis://localhost:6379` and starts/reuses a local Redis). Binds the renamed annotation, clears the unbound scenario.
- Add a `frontend-only verifies host Redis is usable before reuse` rule with the 6 redis-detection scenarios. Titles match the bats annotations exactly; bodies are derived from the bats cases (PONG/non-PONG/absent usability, and the reuse / error / start-container branches).

No script or test behavior changes — this only adds/aligns the Gherkin the bats tests already point at.

## Evidence

`pnpm check:feature-parity`:
```
before: FAIL: 1 unbound scenario(s) in enforced files, 7 unknown annotation(s).
after:  OK: 2226 enforced scenario(s) bound across 681 file(s).   (exit 0)
        specs/setup/quickstart-entry-point.feature  12/12 scenarios bound  ✓
```

## Advisory note

Advisory PR from the tech-debt-fixer bot, opened for human review, not to be merged by the bot. Given this unblocks main, prioritising review is reasonable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced quickstart “frontend-only” setup with explicit local Redis configuration (`REDIS_URL=redis://localhost:6379`) and default email authentication settings.
  * Improved startup behavior to reuse an already-running, usable Redis on port 6379 instead of starting containers unnecessarily.

* **Bug Fixes**
  * Prevents incorrect assumptions about Redis availability when port 6379 is occupied by an unusable listener.
  * Provides a clearer, actionable failure message and starts a local Redis service when the port is free.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->