### PR TITLE
ci(feature-parity): trigger the gate on every binding-source root

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -36,9 +36,25 @@ jobs:
               - '.github/workflows/langwatch-app-ci.yml'
               - '.github/.release-please-manifest.json'
               - '.github/scripts/**'
+            # The parity scanner binds @scenario annotations from test files
+            # across many roots, not just specs/ and langwatch/. This list MUST
+            # cover every root the scanner reads (DEFAULT_TEST_ROOTS,
+            # DEFAULT_GO_TEST_ROOTS, DEFAULT_PYTHON_TEST_ROOTS,
+            # DEFAULT_BATS_TEST_ROOTS in langwatch/scripts/check-feature-parity.ts),
+            # otherwise a binding change in an unlisted root merges without the
+            # gate ever running and silently breaks parity on main (e.g. #5143
+            # edited only scripts/__tests__/*.bats and slipped through).
             feature-parity:
-              - 'langwatch/**'
               - 'specs/**'
+              - 'langwatch/**'
+              - 'mcp-server/**'
+              - 'typescript-sdk/**'
+              - 'python-sdk/**'
+              - 'services/**'
+              - 'pkg/**'
+              - 'langevals/**'
+              - 'langwatch_server/**'
+              - 'scripts/**'
               - '.github/workflows/langwatch-app-ci.yml'
 
   typecheck:


### PR DESCRIPTION
## The real problem: how did broken parity reach main?

The `feature-parity` CI job is gated by a `detect-changes` filter (`langwatch-app-ci.yml`) that only matched:

```
feature-parity:
  - 'langwatch/**'
  - 'specs/**'
```

But the scanner (`langwatch/scripts/check-feature-parity.ts`) binds `@scenario` annotations from **many** roots beyond those two:

| Kind | Roots (from the scanner's constants) | In old filter? |
|------|--------------------------------------|----------------|
| TS | `langwatch/src`, `langwatch/ee`, `langwatch/scripts`, `mcp-server/src`, `typescript-sdk/src`, `python-sdk/src` | only the `langwatch/*` ones |
| Go | `services/nlpgo`, `services/aigateway`, `pkg` | ❌ |
| Python | `langevals`, `langwatch_server` | ❌ |
| bats | `scripts/__tests__`, `langwatch/scripts/__tests__` | only the `langwatch/*` one |

So a binding change in any unlisted root (Go test, mcp-server/typescript-sdk/python-sdk TS test, a Python test, or a top-level `scripts/__tests__/*.bats`) **merges without the parity gate ever running**, and the breakage only surfaces later when an unrelated `specs/**` PR finally triggers a run.

That is precisely what happened: **#5143** edited only `scripts/__tests__/*.bats` (+ `dev.sh`), renamed a `@scenario` binding, and added 6 annotations with no matching scenarios. The gate didn't run on it, so it shipped red; the failure only appeared on the next `specs/**` PR. (#5152 then fixed the bindings; this PR fixes the hole that let it through.)

## Fix

Expand the `feature-parity` filter to cover **every** root the scanner reads, with a comment tying it to the scanner's root constants (`DEFAULT_TEST_ROOTS` / `DEFAULT_GO_TEST_ROOTS` / `DEFAULT_PYTHON_TEST_ROOTS` / `DEFAULT_BATS_TEST_ROOTS`) so the two stay in sync.

## Evidence

```
feature-parity globs: ['specs/**','langwatch/**','mcp-server/**','typescript-sdk/**',
  'python-sdk/**','services/**','pkg/**','langevals/**','langwatch_server/**','scripts/**',
  '.github/workflows/langwatch-app-ci.yml']
scanner roots covered: True | missing: none
YAML valid
```

A change like #5143's (touching `scripts/**`) now matches the filter, so the gate runs and would have caught the broken bindings before merge.

## Advisory note

Advisory PR from the tech-debt-fixer bot, opened for human review, not to be merged by the bot. The human makes the merge call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated change detection so more repository areas trigger the feature-parity check.
  * Improved consistency between repository updates and the validation that runs in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->