### PR TITLE
feat(datasets): paginate the dataset editor for large datasets

### DIFF
--- a/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -237,11 +237,11 @@ export function DatasetEditorTable({
   const pageCount = Math.max(1, Math.ceil((serverRecordCount ?? 0) / pageSize));
   const currentPage = Math.min(page, pageCount);
   const isLastPage = currentPage >= pageCount;
-  // Snap a now-out-of-range page back into range (e.g. the last page's rows were
-  // all deleted under us, or the rows-per-page grew). Acts ONLY on an
-  // authoritative count — never on absent data — so an in-flight page switch
-  // can't bounce navigation back to page 1. Floored at 1, so it never drives the
-  // page to 0.
+  // Snap a now-out-of-range page back into range — e.g. the last page's rows
+  // were all deleted under us (the post-delete refetch shrinks the count) or a
+  // navigation refetch returned a smaller dataset. Acts ONLY on an authoritative
+  // count — never on absent data — so an in-flight page switch can't bounce
+  // navigation back to page 1. Floored at 1, so it never drives the page to 0.
   useEffect(() => {
     if (serverRecordCount == null) return;
     const count = Math.max(1, Math.ceil(serverRecordCount / pageSize));
@@ -387,6 +387,14 @@ export function DatasetEditorTable({
     resolveFullRecord,
     clearPendingChange,
     onStatus,
+    // After a deletion settles, refresh the server total so the pager reflects
+    // the smaller dataset and the clamp effect can snap off a now-empty last
+    // page. Saved mode only — in-memory deletes never touch this query.
+    onRecordsDeleted: datasetId
+      ? () => {
+          void databaseDataset.refetch();
+        }
+      : undefined,
   });
 
   // ── Table assembly ────────────────────────────────────────────────

--- a/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -43,6 +43,8 @@ import {
 import {
   AlertTriangle,
   Check,
+  ChevronLeft,
+  ChevronRight,
   Download,
   Edit2,
   Plus,
@@ -104,6 +106,10 @@ export type DatasetEditorController = {
 
 const CHECKBOX_WIDTH_PX = 36;
 const MAX_ROWS_WITHOUT_VIRTUALIZATION = 100;
+/** Records per page for the saved-dataset editor (classic page N of M). One
+ *  page comfortably fits the virtualized viewport while keeping each read
+ *  bounded — an s3_jsonl page touches only the chunks overlapping the window. */
+const DATASET_EDITOR_PAGE_SIZE = 50;
 
 const toEditorColumns = (columnTypes: DatasetColumns): EditorColumn[] =>
   columnTypes.map((col, index) => ({
@@ -184,13 +190,27 @@ export function DatasetEditorTable({
 
   // ── Data loading ──────────────────────────────────────────────────
 
-  const databaseDataset = api.datasetRecord.getAll.useQuery(
-    { projectId: project?.id ?? "", datasetId: datasetId ?? "" },
+  // Saved datasets are read one page at a time (classic page N of M) instead of
+  // the whole dataset, which previously truncated past a byte cap and silently
+  // hid the rest. In-memory mode (no datasetId) keeps its full local copy.
+  const [page, setPage] = useState(1);
+
+  const databaseDataset = api.datasetRecord.listPaginated.useQuery(
+    {
+      projectId: project?.id ?? "",
+      datasetId: datasetId ?? "",
+      page,
+      limit: DATASET_EDITOR_PAGE_SIZE,
+    },
     {
       // Gated on `readEnabled` so a still-preparing/failed dataset is never read
-      // (getAll → getFullDataset throws DatasetNotReadyError otherwise).
+      // (listPaginated throws DatasetNotReadyError otherwise).
       enabled: !!project && !!datasetId && readEnabled,
       refetchOnWindowFocus: false,
+      // staleTime 0: returning to a previously-viewed page refetches in the
+      // background so a cell edited then navigated-away-from shows its saved
+      // value on return (the edit is persisted per-record, not into this cache).
+      staleTime: 0,
       onError: (error) => {
         if (isHandledByGlobalHandler(error)) return;
         toaster.create({
@@ -203,6 +223,14 @@ export function DatasetEditorTable({
       },
     },
   );
+
+  const totalPages = datasetId ? (databaseDataset.data?.totalPages ?? 1) : 1;
+  const isLastPage = page >= totalPages;
+  // Clamp the page if the dataset shrank under us (e.g. the last page's rows
+  // were all deleted), so we never sit on an empty out-of-range page.
+  useEffect(() => {
+    if (datasetId && page > totalPages) setPage(totalPages);
+  }, [datasetId, page, totalPages]);
 
   const datasetName = datasetId
     ? databaseDataset.data?.name
@@ -342,8 +370,22 @@ export function DatasetEditorTable({
   // ── Table assembly ────────────────────────────────────────────────
 
   const rowCount = records.length;
-  // Always include one trailing phantom row (Excel-style "click to add")
-  const displayRowCount = Math.max(rowCount + 1, 3);
+  // The trailing phantom row (Excel-style "click to add") appends to the END of
+  // the dataset, so on the paged saved view it belongs only on the last page —
+  // adding it on an earlier full page would create a row the user can't see.
+  // In-memory mode (no datasetId) is one local list, so it always shows it.
+  const showAddRow = !datasetId || isLastPage;
+  const displayRowCount = showAddRow ? Math.max(rowCount + 1, 3) : rowCount;
+
+  // Block page navigation while a record save is queued or in flight: switching
+  // pages reloads the store (setData drops the prior page's records), so an
+  // unsaved edit on the outgoing page would be stranded (resolveFullRecord can
+  // no longer find it). The autosave debounce is short, so this is a brief gate.
+  const hasPendingWrites =
+    autosave.state === "saving" ||
+    (datasetId
+      ? Object.keys(pendingSavedChanges[datasetId] ?? {}).length > 0
+      : false);
 
   // Large-dataset read truncation (ADR-032): saved datasets load via
   // `getFullDataset`, which stops accumulating rows once it crosses a byte
@@ -754,15 +796,54 @@ export function DatasetEditorTable({
       </Box>
 
       <HStack>
-        <Button
-          size="sm"
-          variant="ghost"
-          data-testid="add-row"
-          onClick={handleAddRow}
-        >
-          <Plus size={14} /> Add row
-        </Button>
+        {showAddRow && (
+          <Button
+            size="sm"
+            variant="ghost"
+            data-testid="add-row"
+            onClick={handleAddRow}
+          >
+            <Plus size={14} /> Add row
+          </Button>
+        )}
         <Spacer />
+        {datasetId && totalPages > 1 && (
+          <HStack gap={2} data-testid="dataset-pager">
+            <Button
+              size="xs"
+              variant="ghost"
+              data-testid="dataset-page-prev"
+              aria-label="Previous page"
+              disabled={page <= 1 || hasPendingWrites}
+              onClick={() => {
+                clearRowSelection();
+                setPage((p) => Math.max(1, p - 1));
+              }}
+            >
+              <ChevronLeft size={14} />
+            </Button>
+            <Text
+              fontSize="13px"
+              color="fg.muted"
+              data-testid="dataset-page-indicator"
+            >
+              Page {page} of {totalPages}
+            </Text>
+            <Button
+              size="xs"
+              variant="ghost"
+              data-testid="dataset-page-next"
+              aria-label="Next page"
+              disabled={page >= totalPages || hasPendingWrites}
+              onClick={() => {
+                clearRowSelection();
+                setPage((p) => Math.min(totalPages, p + 1));
+              }}
+            >
+              <ChevronRight size={14} />
+            </Button>
+          </HStack>
+        )}
       </HStack>
       {bottomSpace && <Box height={bottomSpace} flexShrink={0} />}
 

--- a/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -206,6 +206,10 @@ export function DatasetEditorTable({
       // (listPaginated throws DatasetNotReadyError otherwise).
       enabled: !!project && !!datasetId && readEnabled,
       refetchOnWindowFocus: false,
+      // Hold the previous page's result while the next page loads, so a page
+      // switch doesn't blank the grid (and doesn't momentarily drop the page
+      // count, which would otherwise bounce navigation back to page 1).
+      keepPreviousData: true,
       // A background refetch (e.g. on reconnect) would reload the store via
       // setData and drop an unsaved local edit on the current page — page
       // navigation is gated on pending writes, but an automatic refetch is not,
@@ -228,20 +232,27 @@ export function DatasetEditorTable({
     },
   );
 
-  // `pageCount` is the number of pages to navigate — floored at 1 so an EMPTY
+  // The PG-authoritative page count from the last settled read (undefined until
+  // the first response; held across a page switch by keepPreviousData so it never
+  // momentarily resets mid-navigation). `pageCount` floors at 1 so an EMPTY
   // dataset (server `totalPages` 0) still reads as a single page and never asks
   // for page 0 (which the server's `positive()` guard would reject). `currentPage`
   // is the page actually shown, clamped so it can never exceed the count.
-  const totalPages = datasetId ? (databaseDataset.data?.totalPages ?? 1) : 1;
-  const pageCount = Math.max(1, totalPages);
+  const serverTotalPages = datasetId
+    ? databaseDataset.data?.totalPages
+    : undefined;
+  const pageCount = Math.max(1, serverTotalPages ?? 1);
   const currentPage = Math.min(page, pageCount);
   const isLastPage = currentPage >= pageCount;
   // Snap a now-out-of-range page back into range (e.g. the last page's rows were
-  // all deleted under us). Floored via `pageCount`, so this never drives the
-  // page to 0 — it only ever pulls an overshoot down to the real last page.
+  // all deleted under us). Acts ONLY on an authoritative count — never on absent
+  // data — so an in-flight page switch can't bounce navigation back to page 1.
+  // Floored at 1, so it never drives the page to 0.
   useEffect(() => {
-    if (datasetId && page > pageCount) setPage(pageCount);
-  }, [datasetId, page, pageCount]);
+    if (serverTotalPages == null) return;
+    const count = Math.max(1, serverTotalPages);
+    if (page > count) setPage(count);
+  }, [serverTotalPages, page]);
 
   const datasetName = datasetId
     ? databaseDataset.data?.name

--- a/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -40,21 +40,12 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  Check,
-  ChevronLeft,
-  ChevronRight,
-  Download,
-  Edit2,
-  Plus,
-  Trash2,
-  Upload,
-  X,
-} from "react-feather";
+import { Check, Download, Edit2, Plus, Trash2, Upload, X } from "react-feather";
 import { useStore } from "zustand";
 
 import { AddOrEditDatasetDrawer } from "~/components/AddOrEditDatasetDrawer";
 import { ColumnTypeIcon } from "~/components/shared/ColumnTypeIcon";
+import { Pagination } from "~/components/ui/Pagination";
 import { SelectionActionBar } from "~/components/ui/SelectionActionBar";
 import { toaster } from "~/components/ui/toaster";
 import { Tooltip } from "~/components/ui/tooltip";
@@ -193,13 +184,14 @@ export function DatasetEditorTable({
   // the whole dataset, which previously truncated past a byte cap and silently
   // hid the rest. In-memory mode (no datasetId) keeps its full local copy.
   const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DATASET_EDITOR_PAGE_SIZE);
 
   const databaseDataset = api.datasetRecord.listPaginated.useQuery(
     {
       projectId: project?.id ?? "",
       datasetId: datasetId ?? "",
       page,
-      limit: DATASET_EDITOR_PAGE_SIZE,
+      limit: pageSize,
     },
     {
       // Gated on `readEnabled` so a still-preparing/failed dataset is never read
@@ -232,27 +224,29 @@ export function DatasetEditorTable({
     },
   );
 
-  // The PG-authoritative page count from the last settled read (undefined until
-  // the first response; held across a page switch by keepPreviousData so it never
-  // momentarily resets mid-navigation). `pageCount` floors at 1 so an EMPTY
-  // dataset (server `totalPages` 0) still reads as a single page and never asks
-  // for page 0 (which the server's `positive()` guard would reject). `currentPage`
-  // is the page actually shown, clamped so it can never exceed the count.
-  const serverTotalPages = datasetId
-    ? databaseDataset.data?.totalPages
-    : undefined;
-  const pageCount = Math.max(1, serverTotalPages ?? 1);
+  // The PG-authoritative total record count from the last settled read (undefined
+  // until the first response; held across a page switch by keepPreviousData so it
+  // never momentarily resets mid-navigation). Deriving the page count from
+  // `count / pageSize` — rather than reading the server's `totalPages` — keeps it
+  // correct the instant the user changes the rows-per-page, before any refetch.
+  // `pageCount` floors at 1 so an EMPTY dataset still reads as a single page and
+  // never asks for page 0 (which the server's `positive()` guard would reject).
+  // `currentPage` is the page actually shown, clamped so it can never exceed the
+  // count.
+  const serverRecordCount = datasetId ? databaseDataset.data?.count : undefined;
+  const pageCount = Math.max(1, Math.ceil((serverRecordCount ?? 0) / pageSize));
   const currentPage = Math.min(page, pageCount);
   const isLastPage = currentPage >= pageCount;
   // Snap a now-out-of-range page back into range (e.g. the last page's rows were
-  // all deleted under us). Acts ONLY on an authoritative count — never on absent
-  // data — so an in-flight page switch can't bounce navigation back to page 1.
-  // Floored at 1, so it never drives the page to 0.
+  // all deleted under us, or the rows-per-page grew). Acts ONLY on an
+  // authoritative count — never on absent data — so an in-flight page switch
+  // can't bounce navigation back to page 1. Floored at 1, so it never drives the
+  // page to 0.
   useEffect(() => {
-    if (serverTotalPages == null) return;
-    const count = Math.max(1, serverTotalPages);
+    if (serverRecordCount == null) return;
+    const count = Math.max(1, Math.ceil(serverRecordCount / pageSize));
     if (page > count) setPage(count);
-  }, [serverTotalPages, page]);
+  }, [serverRecordCount, pageSize, page]);
 
   const datasetName = datasetId
     ? databaseDataset.data?.name
@@ -412,8 +406,7 @@ export function DatasetEditorTable({
   // The count chip shows the PG-authoritative whole-dataset total (`count`),
   // not just the rows on this page; the pager shows the position within it.
   // (Pagination replaced the old byte-cap truncation, so there is no longer a
-  // partial-read state to surface.)
-  const serverRecordCount = datasetId ? databaseDataset.data?.count : undefined;
+  // partial-read state to surface.) `serverRecordCount` is derived once above.
   const totalRecordCount = serverRecordCount ?? rowCount;
 
   const rowData = useMemo((): DatasetTableRowData[] => {
@@ -788,44 +781,27 @@ export function DatasetEditorTable({
           </Button>
         )}
         <Spacer />
-        {datasetId && pageCount > 1 && (
-          <HStack gap={2} data-testid="dataset-pager">
-            <Button
-              size="xs"
-              variant="ghost"
-              data-testid="dataset-page-prev"
-              aria-label="Previous page"
-              disabled={currentPage <= 1 || hasPendingWrites}
-              onClick={() => {
-                clearRowSelection();
-                setPage(Math.max(1, currentPage - 1));
-              }}
-            >
-              <ChevronLeft size={14} />
-            </Button>
-            <Text
-              fontSize="13px"
-              color="fg.muted"
-              data-testid="dataset-page-indicator"
-            >
-              Page {currentPage} of {pageCount}
-            </Text>
-            <Button
-              size="xs"
-              variant="ghost"
-              data-testid="dataset-page-next"
-              aria-label="Next page"
-              disabled={currentPage >= pageCount || hasPendingWrites}
-              onClick={() => {
-                clearRowSelection();
-                setPage(Math.min(pageCount, currentPage + 1));
-              }}
-            >
-              <ChevronRight size={14} />
-            </Button>
-          </HStack>
-        )}
       </HStack>
+      {datasetId && (
+        <Pagination
+          page={currentPage}
+          pageSize={pageSize}
+          totalCount={totalRecordCount}
+          isLoading={databaseDataset.isLoading}
+          // Block navigation while a record save is queued or in flight; a page
+          // switch reloads the store and would strand an unsaved edit.
+          navDisabled={hasPendingWrites}
+          onPageChange={(nextPage) => {
+            clearRowSelection();
+            setPage(nextPage);
+          }}
+          onPageSizeChange={(nextSize) => {
+            clearRowSelection();
+            setPageSize(nextSize);
+            setPage(1);
+          }}
+        />
+      )}
       {bottomSpace && <Box height={bottomSpace} flexShrink={0} />}
 
       {floatingSelectionBar && selectedRows.size > 0 && (

--- a/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -265,8 +265,14 @@ export function DatasetEditorTable({
   // other way via onUpdateDataset).
   const loadedRef = useRef(false);
   const lastPropagatedRef = useRef<EditorRecord[] | null>(null);
+  // While `keepPreviousData` serves the prior key's result during a key change,
+  // `isPreviousData` is true. Skip hydrating from it: a `datasetId` switch would
+  // otherwise populate the grid with the OLD dataset's rows under the NEW id
+  // (a data-integrity mismatch until the new query settles). For a same-dataset
+  // page switch this just holds the current page until the next one lands.
+  const holdingPreviousData = databaseDataset.isPreviousData;
   useEffect(() => {
-    if (datasetId && databaseDataset.data) {
+    if (datasetId && databaseDataset.data && !holdingPreviousData) {
       const columns = toEditorColumns(
         (databaseDataset.data.columnTypes ?? []) as DatasetColumns,
       );
@@ -295,7 +301,7 @@ export function DatasetEditorTable({
       lastPropagatedRef.current = store.getState().records;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasetId, databaseDataset.data, store]);
+  }, [datasetId, databaseDataset.data, holdingPreviousData, store]);
 
   // Imperative controller for external writers (AI generation streams)
   useEffect(() => {

--- a/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
+++ b/langwatch/src/components/datasets/editor/DatasetEditorTable.tsx
@@ -41,7 +41,6 @@ import {
   useState,
 } from "react";
 import {
-  AlertTriangle,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -73,7 +72,7 @@ import {
   DatasetTableProvider,
   type DatasetTableRowData,
 } from "./DatasetTableContext";
-import { formatRecordCount, truncatedReadTooltip } from "./datasetEditorCopy";
+import { formatRecordCount } from "./datasetEditorCopy";
 import { datasetTableCss } from "./datasetTableStyles";
 import {
   createDatasetEditorStore,
@@ -207,6 +206,11 @@ export function DatasetEditorTable({
       // (listPaginated throws DatasetNotReadyError otherwise).
       enabled: !!project && !!datasetId && readEnabled,
       refetchOnWindowFocus: false,
+      // A background refetch (e.g. on reconnect) would reload the store via
+      // setData and drop an unsaved local edit on the current page — page
+      // navigation is gated on pending writes, but an automatic refetch is not,
+      // so disable it.
+      refetchOnReconnect: false,
       // staleTime 0: returning to a previously-viewed page refetches in the
       // background so a cell edited then navigated-away-from shows its saved
       // value on return (the edit is persisted per-record, not into this cache).
@@ -224,13 +228,20 @@ export function DatasetEditorTable({
     },
   );
 
+  // `pageCount` is the number of pages to navigate — floored at 1 so an EMPTY
+  // dataset (server `totalPages` 0) still reads as a single page and never asks
+  // for page 0 (which the server's `positive()` guard would reject). `currentPage`
+  // is the page actually shown, clamped so it can never exceed the count.
   const totalPages = datasetId ? (databaseDataset.data?.totalPages ?? 1) : 1;
-  const isLastPage = page >= totalPages;
-  // Clamp the page if the dataset shrank under us (e.g. the last page's rows
-  // were all deleted), so we never sit on an empty out-of-range page.
+  const pageCount = Math.max(1, totalPages);
+  const currentPage = Math.min(page, pageCount);
+  const isLastPage = currentPage >= pageCount;
+  // Snap a now-out-of-range page back into range (e.g. the last page's rows were
+  // all deleted under us). Floored via `pageCount`, so this never drives the
+  // page to 0 — it only ever pulls an overshoot down to the real last page.
   useEffect(() => {
-    if (datasetId && page > totalPages) setPage(totalPages);
-  }, [datasetId, page, totalPages]);
+    if (datasetId && page > pageCount) setPage(pageCount);
+  }, [datasetId, page, pageCount]);
 
   const datasetName = datasetId
     ? databaseDataset.data?.name
@@ -387,16 +398,11 @@ export function DatasetEditorTable({
       ? Object.keys(pendingSavedChanges[datasetId] ?? {}).length > 0
       : false);
 
-  // Large-dataset read truncation (ADR-032): saved datasets load via
-  // `getFullDataset`, which stops accumulating rows once it crosses a byte
-  // budget and returns the PG-authoritative total in `count` + a `truncated`
-  // flag. Without surfacing it the chrome shows only the loaded rows (e.g. "3
-  // records") for a 1640-row dataset — misleading. `count` is the source of
-  // truth for the total; `rowCount` is what's actually rendered.
+  // The count chip shows the PG-authoritative whole-dataset total (`count`),
+  // not just the rows on this page; the pager shows the position within it.
+  // (Pagination replaced the old byte-cap truncation, so there is no longer a
+  // partial-read state to surface.)
   const serverRecordCount = datasetId ? databaseDataset.data?.count : undefined;
-  const isTruncatedRead = datasetId
-    ? databaseDataset.data?.truncated === true
-    : false;
   const totalRecordCount = serverRecordCount ?? rowCount;
 
   const rowData = useMemo((): DatasetTableRowData[] => {
@@ -643,46 +649,10 @@ export function DatasetEditorTable({
         ) : (
           title
         )}
-        {isTruncatedRead ? (
-          <Tooltip
-            content={truncatedReadTooltip({
-              shown: rowCount,
-              total: totalRecordCount,
-            })}
-          >
-            <HStack
-              gap={1}
-              cursor="help"
-              // Keyboard-reachable: the explanation is otherwise hover-only, so
-              // make the chip focusable (Tooltip opens on focus too) and expose
-              // the full text to assistive tech via aria-label.
-              tabIndex={0}
-              role="note"
-              aria-label={truncatedReadTooltip({
-                shown: rowCount,
-                total: totalRecordCount,
-              })}
-              data-testid="dataset-row-count"
-            >
-              <Text fontSize="13px" color="fg.muted">
-                {formatRecordCount(rowCount)} out of{" "}
-                {formatRecordCount(totalRecordCount)} records
-              </Text>
-              <Box color="orange.500" display="flex">
-                <AlertTriangle size={13} />
-              </Box>
-            </HStack>
-          </Tooltip>
-        ) : (
-          <Text
-            fontSize="13px"
-            color="fg.muted"
-            data-testid="dataset-row-count"
-          >
-            {formatRecordCount(totalRecordCount)}{" "}
-            {totalRecordCount === 1 ? "record" : "records"}
-          </Text>
-        )}
+        <Text fontSize="13px" color="fg.muted" data-testid="dataset-row-count">
+          {formatRecordCount(totalRecordCount)}{" "}
+          {totalRecordCount === 1 ? "record" : "records"}
+        </Text>
         {datasetId && (
           <SaveStatusChip state={autosave.state} error={autosave.error} />
         )}
@@ -807,17 +777,17 @@ export function DatasetEditorTable({
           </Button>
         )}
         <Spacer />
-        {datasetId && totalPages > 1 && (
+        {datasetId && pageCount > 1 && (
           <HStack gap={2} data-testid="dataset-pager">
             <Button
               size="xs"
               variant="ghost"
               data-testid="dataset-page-prev"
               aria-label="Previous page"
-              disabled={page <= 1 || hasPendingWrites}
+              disabled={currentPage <= 1 || hasPendingWrites}
               onClick={() => {
                 clearRowSelection();
-                setPage((p) => Math.max(1, p - 1));
+                setPage(Math.max(1, currentPage - 1));
               }}
             >
               <ChevronLeft size={14} />
@@ -827,17 +797,17 @@ export function DatasetEditorTable({
               color="fg.muted"
               data-testid="dataset-page-indicator"
             >
-              Page {page} of {totalPages}
+              Page {currentPage} of {pageCount}
             </Text>
             <Button
               size="xs"
               variant="ghost"
               data-testid="dataset-page-next"
               aria-label="Next page"
-              disabled={page >= totalPages || hasPendingWrites}
+              disabled={currentPage >= pageCount || hasPendingWrites}
               onClick={() => {
                 clearRowSelection();
-                setPage((p) => Math.min(totalPages, p + 1));
+                setPage(Math.min(pageCount, currentPage + 1));
               }}
             >
               <ChevronRight size={14} />

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -404,71 +404,75 @@ describe("given a saved dataset", () => {
   });
 });
 
-// ── Large-dataset read truncation (ADR-032) ──────────────────────────
+// ── Whole-dataset total count ────────────────────────────────────────
 
-describe("given a large saved dataset whose read is truncated", () => {
-  const renderSaved = (data: Record<string, unknown>) => {
-    getAllQuery.mockReturnValue({ data, isLoading: false, refetch: vi.fn() });
-    return render(<DatasetEditorTable datasetId="dataset_big" />, {
-      wrapper: Wrapper,
-    });
-  };
-
-  describe("when the read is truncated", () => {
-    it("shows the true total with a truncation notice, not just the loaded rows", async () => {
-      renderSaved({
-        id: "dataset_big",
-        name: "dataset-images-2gb",
-        columnTypes,
-        count: 1640,
-        truncated: true,
-        datasetRecords: [
-          { id: "r1", input: "a", expected_output: "x" },
-          { id: "r2", input: "b", expected_output: "y" },
-          { id: "r3", input: "c", expected_output: "z" },
-        ],
+describe("given the saved dataset's record count", () => {
+  describe("when the dataset spans many pages", () => {
+    it("shows the PG-authoritative whole-dataset total, not just the loaded page", async () => {
+      getAllQuery.mockReturnValue({
+        data: {
+          id: "ds",
+          name: "ds",
+          columnTypes,
+          count: 1640,
+          totalPages: 33,
+          page: 1,
+          datasetRecords: [
+            { id: "r1", entry: { input: "a", expected_output: "x" } },
+            { id: "r2", entry: { input: "b", expected_output: "y" } },
+          ],
+        },
+        isLoading: false,
+        refetch: vi.fn(),
       });
+      render(<DatasetEditorTable datasetId="ds" />, { wrapper: Wrapper });
 
-      // The count reflects the PG-authoritative total (1,640), NOT the 3 loaded
-      // rows — and flags that the view is partial.
       await waitFor(() =>
         expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
-          "3 out of 1,640 records",
+          "1,640 records",
         ),
       );
-      // The explanation is keyboard/SR-reachable: the chip is focusable and
-      // exposes the full tooltip copy via aria-label (not hover-only).
-      const chip = screen.getByTestId("dataset-row-count");
-      expect(chip).toHaveAttribute("tabindex", "0");
-      expect(chip).toHaveAttribute(
-        "aria-label",
-        expect.stringContaining("too large to display in full"),
+      // Pagination replaced byte-cap truncation — no "X out of Y" partial notice.
+      expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
+        "out of",
       );
     });
   });
 
-  describe("when the read is not truncated", () => {
-    it("shows the plain total with no truncation notice", async () => {
-      renderSaved({
-        id: "dataset_small",
-        name: "small",
-        columnTypes,
-        count: 2,
-        truncated: false,
-        datasetRecords: [
-          { id: "r1", input: "a", expected_output: "x" },
-          { id: "r2", input: "b", expected_output: "y" },
-        ],
+  describe("when the dataset is empty", () => {
+    it("renders a single page, no pager, and never requests page 0", async () => {
+      // total 0 -> server totalPages 0. The page must floor at 1: requesting
+      // page 0 would fail the server's positive() guard and break the editor.
+      const requested: Array<number | undefined> = [];
+      const stable = {
+        data: {
+          id: "empty",
+          name: "empty",
+          columnTypes,
+          count: 0,
+          totalPages: 0,
+          page: 1,
+          datasetRecords: [],
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+      getAllQuery.mockReset();
+      getAllQuery.mockImplementation((input: { page?: number }) => {
+        requested.push(input?.page);
+        return stable; // stable ref (like react-query) — avoids a reload loop
       });
+      render(<DatasetEditorTable datasetId="empty" />, { wrapper: Wrapper });
 
       await waitFor(() =>
         expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
-          "2 records",
+          "0 records",
         ),
       );
-      expect(screen.getByTestId("dataset-row-count")).not.toHaveTextContent(
-        "out of",
-      );
+      expect(screen.queryByTestId("dataset-pager")).not.toBeInTheDocument();
+      // An empty dataset is its own last page, so the add-row stays available.
+      expect(screen.getByTestId("add-row")).toBeInTheDocument();
+      expect(requested).not.toContain(0);
     });
   });
 });

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -7,7 +7,7 @@
  * cells, portal editor); only the tRPC transport is mocked.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -825,6 +825,78 @@ describe("given rows are deleted from a paginated dataset", () => {
       await waitFor(() => expect(refetchSpy).toHaveBeenCalled(), {
         timeout: 2000,
       });
+    });
+  });
+
+  describe("when the delete commits but a later update in the batch fails", () => {
+    /** @scenario Move between pages */
+    it("still refreshes the total — a committed delete must not be masked by an update error", async () => {
+      // Force the bug-triggering interleave: both ops are dispatched, the delete
+      // commits, and the update fails LAST — so the batch only reaches zero
+      // pending ops via the error path. The count refresh must fire from there
+      // too, or a committed delete leaves the pager count stale. (Settling the
+      // delete synchronously would hide the bug, since ops would hit zero on the
+      // delete's own success.)
+      let resolveDelete: (() => void) | undefined;
+      let rejectUpdate: ((e: { message: string }) => void) | undefined;
+      deleteManyMutate.mockImplementation(
+        (_args: unknown, opts?: { onSuccess?: () => void }) => {
+          resolveDelete = opts?.onSuccess;
+        },
+      );
+      updateMutate.mockImplementation(
+        (
+          _args: unknown,
+          opts?: { onError?: (e: { message: string }) => void },
+        ) => {
+          rejectUpdate = opts?.onError;
+        },
+      );
+      const refetchSpy = vi.fn();
+      getAllQuery.mockReset();
+      getAllQuery.mockReturnValue({
+        data: {
+          id: "dp",
+          name: "dp",
+          columnTypes,
+          count: 51,
+          totalPages: 2,
+          page: 1,
+          datasetRecords: [
+            { id: "r1", entry: { input: "a", expected_output: "x" } },
+            { id: "r2", entry: { input: "b", expected_output: "y" } },
+          ],
+        },
+        isLoading: false,
+        isPreviousData: false,
+        refetch: refetchSpy,
+      });
+
+      const user = userEvent.setup();
+      render(<DatasetEditorTable datasetId="dp" />, { wrapper: Wrapper });
+      await screen.findByText("a");
+
+      // Queue a delete (row 1) and an edit (row 2, now at index 0) into the same
+      // debounce batch.
+      await user.click(screen.getByLabelText("Select row 1"));
+      await user.click(await screen.findByTestId("delete-selected-rows"));
+      await user.dblClick(screen.getByTestId("cell-0-input_0"));
+      const textarea = await screen.findByRole("textbox");
+      await user.clear(textarea);
+      await user.type(textarea, "edited{Enter}");
+
+      // Both mutations dispatched; settle them delete-then-update so ops reaches
+      // zero through the error path.
+      await waitFor(() => {
+        expect(resolveDelete).toBeDefined();
+        expect(rejectUpdate).toBeDefined();
+      });
+      await act(async () => {
+        resolveDelete?.();
+        rejectUpdate?.({ message: "boom" });
+      });
+
+      expect(refetchSpy).toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -38,6 +38,12 @@ vi.mock("~/utils/api", () => ({
       getAll: {
         useQuery: (...args: unknown[]) => getAllQuery(...args),
       },
+      // The saved-dataset editor now reads one page at a time. Point it at the
+      // same mock so saved-mode fixtures (which set the records via this fn)
+      // drive the paged read; pages without `totalPages` read as a single page.
+      listPaginated: {
+        useQuery: (...args: unknown[]) => getAllQuery(...args),
+      },
       update: {
         useMutation: () => ({ mutate: updateMutate }),
       },
@@ -464,5 +470,147 @@ describe("given a large saved dataset whose read is truncated", () => {
         "out of",
       );
     });
+  });
+});
+
+// ── Pagination (classic page N of M) ─────────────────────────────────
+
+describe("given a saved dataset larger than one page", () => {
+  const TOTAL_PAGES = 3;
+  const COUNT = 150;
+
+  // Return a STABLE object reference per page, the way react-query does — an
+  // unstable ref every render would make the store-load effect re-run forever.
+  const renderPaged = () => {
+    const byPage = new Map<number, unknown>();
+    getAllQuery.mockReset();
+    getAllQuery.mockImplementation((input: { page?: number }) => {
+      const p = input?.page ?? 1;
+      if (!byPage.has(p)) {
+        byPage.set(p, {
+          data: {
+            id: "dataset_paged",
+            name: "paged",
+            columnTypes,
+            count: COUNT,
+            totalPages: TOTAL_PAGES,
+            page: p,
+            truncated: false,
+            datasetRecords: [
+              {
+                id: `p${p}r1`,
+                entry: { input: `page${p}-a`, expected_output: "x" },
+              },
+              {
+                id: `p${p}r2`,
+                entry: { input: `page${p}-b`, expected_output: "y" },
+              },
+            ],
+          },
+          isLoading: false,
+          refetch: vi.fn(),
+        });
+      }
+      return byPage.get(p);
+    });
+    return render(<DatasetEditorTable datasetId="dataset_paged" />, {
+      wrapper: Wrapper,
+    });
+  };
+
+  /** @scenario A dataset larger than one page shows the first page with a pager */
+  it("shows the first page, the pager, and the whole-dataset total", async () => {
+    renderPaged();
+    await waitFor(() =>
+      expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+        "Page 1 of 3",
+      ),
+    );
+    // Total reflects the whole dataset, not just the loaded page.
+    expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
+      "150 records",
+    );
+    expect(screen.getByTestId("dataset-page-prev")).toBeDisabled();
+    expect(screen.getByTestId("dataset-page-next")).toBeEnabled();
+    // The add-row affordance is not offered on an earlier, full page.
+    expect(screen.queryByTestId("add-row")).not.toBeInTheDocument();
+  });
+
+  /** @scenario Move between pages */
+  it("moves to the next page and back", async () => {
+    const user = userEvent.setup();
+    renderPaged();
+    await screen.findByTestId("dataset-page-indicator");
+
+    await user.click(screen.getByTestId("dataset-page-next"));
+    await waitFor(() =>
+      expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+        "Page 2 of 3",
+      ),
+    );
+    // The editor requested page 2 from the server (windowed read, not a slice).
+    expect(getAllQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2 }),
+      expect.anything(),
+    );
+
+    await user.click(screen.getByTestId("dataset-page-prev"));
+    await waitFor(() =>
+      expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+        "Page 1 of 3",
+      ),
+    );
+  });
+
+  /** @scenario Edits on a page are saved to the right record */
+  it("saves an edit made on a later page to that page's own record", async () => {
+    updateMutate.mockImplementation(
+      (_args: unknown, opts?: { onSuccess?: () => void }) =>
+        opts?.onSuccess?.(),
+    );
+    const user = userEvent.setup();
+    renderPaged();
+    await screen.findByTestId("dataset-page-indicator");
+
+    // Move to page 2 first (no pending writes yet, so navigation is allowed),
+    // then edit its first cell.
+    await user.click(screen.getByTestId("dataset-page-next"));
+    await screen.findByText("page2-a");
+    await user.dblClick(screen.getByTestId("cell-0-input_0"));
+    const textarea = await screen.findByRole("textbox");
+    await user.clear(textarea);
+    await user.type(textarea, "edited{Enter}");
+
+    // The save targets the page-2 record by its own id — pagination binds edits
+    // per record, never by a positional slot within the page.
+    await waitFor(
+      () =>
+        expect(updateMutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            datasetId: "dataset_paged",
+            recordId: "p2r1",
+            updatedRecord: expect.objectContaining({ input: "edited" }),
+          }),
+          expect.anything(),
+        ),
+      { timeout: 2000 },
+    );
+  });
+
+  /** @scenario A new row is added on the last page */
+  it("offers the add-row only once on the last page", async () => {
+    const user = userEvent.setup();
+    renderPaged();
+    await screen.findByTestId("dataset-page-indicator");
+    expect(screen.queryByTestId("add-row")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("dataset-page-next")); // page 2
+    await user.click(screen.getByTestId("dataset-page-next")); // page 3 (last)
+    await waitFor(() =>
+      expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+        "Page 3 of 3",
+      ),
+    );
+    expect(screen.getByTestId("add-row")).toBeInTheDocument();
   });
 });

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -570,13 +570,17 @@ describe("given a saved dataset larger than one page", () => {
     /** @scenario Move between pages */
     it("stays on the requested page instead of bouncing back to page 1", async () => {
       // react-query holds the previous page's result while the next page's key
-      // loads (keepPreviousData). Simulate that: page 2 is not yet "ready", so
-      // the hook returns page 1's data — the page count must NOT momentarily
-      // reset and snap navigation back to page 1.
+      // loads (keepPreviousData), flagging it `isPreviousData: true`. Simulate
+      // that faithfully: page 2 is not yet "ready", so the hook returns page 1's
+      // data marked as held — the page count must NOT momentarily reset and snap
+      // navigation back to page 1, and the held data must not re-hydrate the
+      // store (the guard skips it). Stable refs per (page, held) so the
+      // store-load effect can't loop.
       const ready = new Set([1]);
-      const cache = new Map<number, unknown>();
+      const fresh = new Map<number, unknown>();
+      const held = new Map<number, unknown>();
       let lastReady = 1;
-      const pageResult = (p: number) => ({
+      const pageResult = (p: number, isPreviousData: boolean) => ({
         data: {
           id: "dataset_paged",
           name: "paged",
@@ -592,6 +596,7 @@ describe("given a saved dataset larger than one page", () => {
           ],
         },
         isLoading: false,
+        isPreviousData,
         refetch: vi.fn(),
       });
       getAllQuery.mockReset();
@@ -599,11 +604,13 @@ describe("given a saved dataset larger than one page", () => {
         const p = input?.page ?? 1;
         if (ready.has(p)) {
           lastReady = p;
-          if (!cache.has(p)) cache.set(p, pageResult(p));
-          return cache.get(p);
+          if (!fresh.has(p)) fresh.set(p, pageResult(p, false));
+          return fresh.get(p);
         }
-        if (!cache.has(lastReady)) cache.set(lastReady, pageResult(lastReady));
-        return cache.get(lastReady); // previous page held while page p loads
+        // Previous page held while page p loads → flagged isPreviousData.
+        if (!held.has(lastReady))
+          held.set(lastReady, pageResult(lastReady, true));
+        return held.get(lastReady);
       });
 
       const user = userEvent.setup();
@@ -682,7 +689,7 @@ describe("given a saved dataset larger than one page", () => {
     expect(screen.getByTestId("add-row")).toBeInTheDocument();
   });
 
-  /** @scenario A dataset larger than one page shows the first page with a pager */
+  /** @scenario Change how many rows are shown per page */
   it("re-reads with the new limit and resets to page 1 when rows-per-page changes", async () => {
     const user = userEvent.setup();
     renderPaged();
@@ -741,7 +748,8 @@ describe("given the editor is switched to a different dataset", () => {
   });
 
   describe("when the previous dataset's data is still being served", () => {
-    /** @scenario Edits on a page are saved to the right record */
+    // Regression: robustness of the keepPreviousData hold across a datasetId
+    // switch — not a feature scenario, so deliberately not @scenario-bound.
     it("never hydrates the new dataset id with the previous dataset's rows", async () => {
       updateMutate.mockImplementation(
         (_args: unknown, opts?: { onSuccess?: () => void }) =>
@@ -787,7 +795,7 @@ describe("given the editor is switched to a different dataset", () => {
 // stale page count and can strand the user on a now-empty last page.
 describe("given rows are deleted from a paginated dataset", () => {
   describe("when the deletion is saved", () => {
-    /** @scenario Move between pages */
+    // Regression: post-delete count refresh — not a feature scenario.
     it("refreshes the server total so the pager cannot strand an empty page", async () => {
       deleteManyMutate.mockImplementation(
         (_args: unknown, opts?: { onSuccess?: () => void }) =>
@@ -829,7 +837,8 @@ describe("given rows are deleted from a paginated dataset", () => {
   });
 
   describe("when the delete commits but a later update in the batch fails", () => {
-    /** @scenario Move between pages */
+    // Regression: count refresh must fire on batch settle via the error path
+    // too — not a feature scenario.
     it("still refreshes the total — a committed delete must not be masked by an update error", async () => {
       // Force the bug-triggering interleave: both ops are dispatched, the delete
       // commits, and the update fails LAST — so the batch only reaches zero

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -688,6 +688,10 @@ describe("given a saved dataset larger than one page", () => {
     renderPaged();
     await screen.findByTestId("pagination-indicator");
 
+    // The active size (default 50) is a no-op — disabled so it can't re-trigger
+    // the clear-selection / reset-to-page-1 / refetch path with no real change.
+    expect(screen.getByTestId("pagination-size-50")).toBeDisabled();
+
     // Move off page 1 first so the reset-to-page-1 is observable.
     await user.click(screen.getByTestId("pagination-next"));
     await waitFor(() =>
@@ -711,5 +715,69 @@ describe("given a saved dataset larger than one page", () => {
     };
     expect(lastCall.limit).toBe(100);
     expect(lastCall.page).toBe(1);
+  });
+});
+
+// keepPreviousData (held for the pagination no-bounce) must NOT bleed one
+// dataset's rows into another when the editor is pointed at a different
+// datasetId while the previous result is still being served.
+describe("given the editor is switched to a different dataset", () => {
+  const datasetAResult = (isPreviousData: boolean) => ({
+    data: {
+      id: "dataset_a",
+      name: "A",
+      columnTypes,
+      count: 1,
+      totalPages: 1,
+      page: 1,
+      datasetRecords: [
+        { id: "a1", entry: { input: "alpha", expected_output: "x" } },
+      ],
+    },
+    isLoading: false,
+    // react-query sets this while keepPreviousData serves the prior key's data.
+    isPreviousData,
+    refetch: vi.fn(),
+  });
+
+  describe("when the previous dataset's data is still being served", () => {
+    /** @scenario Edits on a page are saved to the right record */
+    it("never hydrates the new dataset id with the previous dataset's rows", async () => {
+      updateMutate.mockImplementation(
+        (_args: unknown, opts?: { onSuccess?: () => void }) =>
+          opts?.onSuccess?.(),
+      );
+      getAllQuery.mockReset();
+      getAllQuery.mockReturnValue(datasetAResult(false));
+
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <DatasetEditorTable datasetId="dataset_a" />,
+        { wrapper: Wrapper },
+      );
+      await screen.findByText("alpha");
+
+      // Point the editor at dataset B; keepPreviousData still serves A's rows
+      // (isPreviousData), so the grid keeps showing them until B settles.
+      getAllQuery.mockReturnValue(datasetAResult(true));
+      rerender(<DatasetEditorTable datasetId="dataset_b" />);
+
+      // Edit the held cell before B's own data arrives.
+      await user.dblClick(screen.getByTestId("cell-0-input_0"));
+      const textarea = await screen.findByRole("textbox");
+      await user.clear(textarea);
+      await user.type(textarea, "edited{Enter}");
+
+      await waitFor(() => expect(updateMutate).toHaveBeenCalled(), {
+        timeout: 2000,
+      });
+      // The write targets the dataset the rows actually belong to (A), never the
+      // newly-selected B — without the guard the store would be hydrated as
+      // B-id-with-A-rows and corrupt dataset B.
+      expect(updateMutate).not.toHaveBeenCalledWith(
+        expect.objectContaining({ datasetId: "dataset_b" }),
+        expect.anything(),
+      );
+    });
   });
 });

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -469,7 +469,7 @@ describe("given the saved dataset's record count", () => {
           "0 records",
         ),
       );
-      expect(screen.queryByTestId("dataset-pager")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("pagination")).not.toBeInTheDocument();
       // An empty dataset is its own last page, so the add-row stays available.
       expect(screen.getByTestId("add-row")).toBeInTheDocument();
       expect(requested).not.toContain(0);
@@ -526,7 +526,7 @@ describe("given a saved dataset larger than one page", () => {
   it("shows the first page, the pager, and the whole-dataset total", async () => {
     renderPaged();
     await waitFor(() =>
-      expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+      expect(screen.getByTestId("pagination-indicator")).toHaveTextContent(
         "Page 1 of 3",
       ),
     );
@@ -534,8 +534,8 @@ describe("given a saved dataset larger than one page", () => {
     expect(screen.getByTestId("dataset-row-count")).toHaveTextContent(
       "150 records",
     );
-    expect(screen.getByTestId("dataset-page-prev")).toBeDisabled();
-    expect(screen.getByTestId("dataset-page-next")).toBeEnabled();
+    expect(screen.getByTestId("pagination-prev")).toBeDisabled();
+    expect(screen.getByTestId("pagination-next")).toBeEnabled();
     // The add-row affordance is not offered on an earlier, full page.
     expect(screen.queryByTestId("add-row")).not.toBeInTheDocument();
   });
@@ -544,11 +544,11 @@ describe("given a saved dataset larger than one page", () => {
   it("moves to the next page and back", async () => {
     const user = userEvent.setup();
     renderPaged();
-    await screen.findByTestId("dataset-page-indicator");
+    await screen.findByTestId("pagination-indicator");
 
-    await user.click(screen.getByTestId("dataset-page-next"));
+    await user.click(screen.getByTestId("pagination-next"));
     await waitFor(() =>
-      expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+      expect(screen.getByTestId("pagination-indicator")).toHaveTextContent(
         "Page 2 of 3",
       ),
     );
@@ -558,9 +558,9 @@ describe("given a saved dataset larger than one page", () => {
       expect.anything(),
     );
 
-    await user.click(screen.getByTestId("dataset-page-prev"));
+    await user.click(screen.getByTestId("pagination-prev"));
     await waitFor(() =>
-      expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+      expect(screen.getByTestId("pagination-indicator")).toHaveTextContent(
         "Page 1 of 3",
       ),
     );
@@ -611,16 +611,16 @@ describe("given a saved dataset larger than one page", () => {
         wrapper: Wrapper,
       });
       await waitFor(() =>
-        expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+        expect(screen.getByTestId("pagination-indicator")).toHaveTextContent(
           "Page 1 of 3",
         ),
       );
 
-      await user.click(screen.getByTestId("dataset-page-next"));
+      await user.click(screen.getByTestId("pagination-next"));
       // Page 2 is still loading — the indicator must show page 2, not bounce to 1,
       // and the last request must be for page 2.
       await waitFor(() =>
-        expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+        expect(screen.getByTestId("pagination-indicator")).toHaveTextContent(
           "Page 2 of 3",
         ),
       );
@@ -638,11 +638,11 @@ describe("given a saved dataset larger than one page", () => {
     );
     const user = userEvent.setup();
     renderPaged();
-    await screen.findByTestId("dataset-page-indicator");
+    await screen.findByTestId("pagination-indicator");
 
     // Move to page 2 first (no pending writes yet, so navigation is allowed),
     // then edit its first cell.
-    await user.click(screen.getByTestId("dataset-page-next"));
+    await user.click(screen.getByTestId("pagination-next"));
     await screen.findByText("page2-a");
     await user.dblClick(screen.getByTestId("cell-0-input_0"));
     const textarea = await screen.findByRole("textbox");
@@ -669,16 +669,47 @@ describe("given a saved dataset larger than one page", () => {
   it("offers the add-row only once on the last page", async () => {
     const user = userEvent.setup();
     renderPaged();
-    await screen.findByTestId("dataset-page-indicator");
+    await screen.findByTestId("pagination-indicator");
     expect(screen.queryByTestId("add-row")).not.toBeInTheDocument();
 
-    await user.click(screen.getByTestId("dataset-page-next")); // page 2
-    await user.click(screen.getByTestId("dataset-page-next")); // page 3 (last)
+    await user.click(screen.getByTestId("pagination-next")); // page 2
+    await user.click(screen.getByTestId("pagination-next")); // page 3 (last)
     await waitFor(() =>
-      expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+      expect(screen.getByTestId("pagination-indicator")).toHaveTextContent(
         "Page 3 of 3",
       ),
     );
     expect(screen.getByTestId("add-row")).toBeInTheDocument();
+  });
+
+  /** @scenario A dataset larger than one page shows the first page with a pager */
+  it("re-reads with the new limit and resets to page 1 when rows-per-page changes", async () => {
+    const user = userEvent.setup();
+    renderPaged();
+    await screen.findByTestId("pagination-indicator");
+
+    // Move off page 1 first so the reset-to-page-1 is observable.
+    await user.click(screen.getByTestId("pagination-next"));
+    await waitFor(() =>
+      expect(screen.getByTestId("pagination-indicator")).toHaveTextContent(
+        "Page 2 of 3",
+      ),
+    );
+
+    // Switch to 100 rows per page. The page count is derived from
+    // count / pageSize, so 150 records collapse to 2 pages immediately, and the
+    // server is re-read with the new limit from page 1.
+    await user.click(screen.getByTestId("pagination-size-100"));
+    await waitFor(() =>
+      expect(screen.getByTestId("pagination-indicator")).toHaveTextContent(
+        "Page 1 of 2",
+      ),
+    );
+    const lastCall = getAllQuery.mock.calls.at(-1)![0] as {
+      page?: number;
+      limit?: number;
+    };
+    expect(lastCall.limit).toBe(100);
+    expect(lastCall.page).toBe(1);
   });
 });

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -781,3 +781,50 @@ describe("given the editor is switched to a different dataset", () => {
     });
   });
 });
+
+// Deleting rows shrinks the dataset, but only the current page lives in the
+// store, so the server total must be re-read — otherwise the pager keeps the
+// stale page count and can strand the user on a now-empty last page.
+describe("given rows are deleted from a paginated dataset", () => {
+  describe("when the deletion is saved", () => {
+    /** @scenario Move between pages */
+    it("refreshes the server total so the pager cannot strand an empty page", async () => {
+      deleteManyMutate.mockImplementation(
+        (_args: unknown, opts?: { onSuccess?: () => void }) =>
+          opts?.onSuccess?.(),
+      );
+      const refetchSpy = vi.fn();
+      getAllQuery.mockReset();
+      getAllQuery.mockReturnValue({
+        data: {
+          id: "dp",
+          name: "dp",
+          columnTypes,
+          count: 51,
+          totalPages: 2,
+          page: 1,
+          datasetRecords: [
+            { id: "r1", entry: { input: "a", expected_output: "x" } },
+            { id: "r2", entry: { input: "b", expected_output: "y" } },
+          ],
+        },
+        isLoading: false,
+        isPreviousData: false,
+        refetch: refetchSpy,
+      });
+
+      const user = userEvent.setup();
+      render(<DatasetEditorTable datasetId="dp" />, { wrapper: Wrapper });
+      await screen.findByText("a");
+
+      await user.click(screen.getByLabelText("Select row 1"));
+      await user.click(await screen.findByTestId("delete-selected-rows"));
+
+      // The editor re-reads the page (and thus the whole-dataset count) once the
+      // delete settles, instead of trusting the now-stale cached total.
+      await waitFor(() => expect(refetchSpy).toHaveBeenCalled(), {
+        timeout: 2000,
+      });
+    });
+  });
+});

--- a/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
+++ b/langwatch/src/components/datasets/editor/__tests__/DatasetEditorTable.integration.test.tsx
@@ -566,6 +566,70 @@ describe("given a saved dataset larger than one page", () => {
     );
   });
 
+  describe("when the next page is still loading", () => {
+    /** @scenario Move between pages */
+    it("stays on the requested page instead of bouncing back to page 1", async () => {
+      // react-query holds the previous page's result while the next page's key
+      // loads (keepPreviousData). Simulate that: page 2 is not yet "ready", so
+      // the hook returns page 1's data — the page count must NOT momentarily
+      // reset and snap navigation back to page 1.
+      const ready = new Set([1]);
+      const cache = new Map<number, unknown>();
+      let lastReady = 1;
+      const pageResult = (p: number) => ({
+        data: {
+          id: "dataset_paged",
+          name: "paged",
+          columnTypes,
+          count: 150,
+          totalPages: 3,
+          page: p,
+          datasetRecords: [
+            {
+              id: `p${p}r1`,
+              entry: { input: `page${p}-a`, expected_output: "x" },
+            },
+          ],
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      });
+      getAllQuery.mockReset();
+      getAllQuery.mockImplementation((input: { page?: number }) => {
+        const p = input?.page ?? 1;
+        if (ready.has(p)) {
+          lastReady = p;
+          if (!cache.has(p)) cache.set(p, pageResult(p));
+          return cache.get(p);
+        }
+        if (!cache.has(lastReady)) cache.set(lastReady, pageResult(lastReady));
+        return cache.get(lastReady); // previous page held while page p loads
+      });
+
+      const user = userEvent.setup();
+      render(<DatasetEditorTable datasetId="dataset_paged" />, {
+        wrapper: Wrapper,
+      });
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+          "Page 1 of 3",
+        ),
+      );
+
+      await user.click(screen.getByTestId("dataset-page-next"));
+      // Page 2 is still loading — the indicator must show page 2, not bounce to 1,
+      // and the last request must be for page 2.
+      await waitFor(() =>
+        expect(screen.getByTestId("dataset-page-indicator")).toHaveTextContent(
+          "Page 2 of 3",
+        ),
+      );
+      expect(
+        (getAllQuery.mock.calls.at(-1)![0] as { page?: number }).page,
+      ).toBe(2);
+    });
+  });
+
   /** @scenario Edits on a page are saved to the right record */
   it("saves an edit made on a later page to that page's own record", async () => {
     updateMutate.mockImplementation(

--- a/langwatch/src/components/datasets/editor/useDatasetRecordSync.ts
+++ b/langwatch/src/components/datasets/editor/useDatasetRecordSync.ts
@@ -102,21 +102,31 @@ export const useDatasetRecordSync = ({
     onStatusRef.current("saving");
   }, []);
 
+  // Once the batch fully drains, refresh the count if it deleted anything —
+  // fired from BOTH the success and error paths, so a committed delete still
+  // refreshes even when a later update in the same batch fails.
+  const flushDeletedBatch = useCallback(() => {
+    if (pendingOpsRef.current !== 0 || !batchHadDeleteRef.current) return;
+    batchHadDeleteRef.current = false;
+    onRecordsDeletedRef.current?.();
+  }, []);
+
   const handleSyncSuccess = useCallback(() => {
     pendingOpsRef.current = Math.max(0, pendingOpsRef.current - 1);
     if (pendingOpsRef.current === 0) {
       markSaved();
-      if (batchHadDeleteRef.current) {
-        batchHadDeleteRef.current = false;
-        onRecordsDeletedRef.current?.();
-      }
+      flushDeletedBatch();
     }
-  }, [markSaved]);
+  }, [flushDeletedBatch, markSaved]);
 
-  const handleSyncError = useCallback((error: { message: string }) => {
-    pendingOpsRef.current = Math.max(0, pendingOpsRef.current - 1);
-    onStatusRef.current("error", error.message);
-  }, []);
+  const handleSyncError = useCallback(
+    (error: { message: string }) => {
+      pendingOpsRef.current = Math.max(0, pendingOpsRef.current - 1);
+      onStatusRef.current("error", error.message);
+      flushDeletedBatch();
+    },
+    [flushDeletedBatch],
+  );
 
   // Drain pending changes to the DB (debounced)
   useEffect(() => {

--- a/langwatch/src/components/datasets/editor/useDatasetRecordSync.ts
+++ b/langwatch/src/components/datasets/editor/useDatasetRecordSync.ts
@@ -37,6 +37,11 @@ export type DatasetRecordSyncParams = {
   ) => ({ id: string } & Record<string, unknown>) | undefined;
   clearPendingChange: (dbDatasetId: string, recordId: string) => void;
   onStatus: (state: AutosaveState, error?: string) => void;
+  /** Called once after a sync batch that deleted records fully settles. The
+   *  paginated editor uses it to refresh the server total, so the pager can't
+   *  strand the user on a now-empty last page (the local store only holds the
+   *  current page, so it can't know the new whole-dataset count on its own). */
+  onRecordsDeleted?: () => void;
 };
 
 export const useDatasetRecordSync = ({
@@ -45,6 +50,7 @@ export const useDatasetRecordSync = ({
   resolveFullRecord,
   clearPendingChange,
   onStatus,
+  onRecordsDeleted,
 }: DatasetRecordSyncParams) => {
   const savedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingOpsRef = useRef(0);
@@ -65,6 +71,12 @@ export const useDatasetRecordSync = ({
   resolveFullRecordRef.current = resolveFullRecord;
   const onStatusRef = useRef(onStatus);
   onStatusRef.current = onStatus;
+  const onRecordsDeletedRef = useRef(onRecordsDeleted);
+  onRecordsDeletedRef.current = onRecordsDeleted;
+  // Set when the current batch successfully deletes records; consumed when the
+  // batch fully drains so the count refresh runs exactly once, after all writes
+  // (never mid-batch, which would reload the store and strand a pending update).
+  const batchHadDeleteRef = useRef(false);
 
   useEffect(() => {
     return () => {
@@ -94,6 +106,10 @@ export const useDatasetRecordSync = ({
     pendingOpsRef.current = Math.max(0, pendingOpsRef.current - 1);
     if (pendingOpsRef.current === 0) {
       markSaved();
+      if (batchHadDeleteRef.current) {
+        batchHadDeleteRef.current = false;
+        onRecordsDeletedRef.current?.();
+      }
     }
   }, [markSaved]);
 
@@ -140,6 +156,9 @@ export const useDatasetRecordSync = ({
                 for (const recordId of recordsToDelete) {
                   clearPendingChange(dbDatasetId, recordId);
                 }
+                // Mark before draining: if this delete is the batch's last op,
+                // handleSyncSuccess fires the count refresh in this same call.
+                batchHadDeleteRef.current = true;
                 handleSyncSuccess();
               },
               onError: (error) => {

--- a/langwatch/src/components/ui/Pagination.tsx
+++ b/langwatch/src/components/ui/Pagination.tsx
@@ -1,0 +1,121 @@
+import { Button, Flex, IconButton, Skeleton, Text } from "@chakra-ui/react";
+import { ChevronLeft, ChevronRight } from "react-feather";
+
+/**
+ * Prop-driven classic "page N of M" pager, modeled on the traces-v2 table pager
+ * (rows-per-page selector + page indicator + prev/next, a loading skeleton, and
+ * hidden when there is nothing to page). Unlike that one it takes its state as
+ * props instead of reading a feature store, so any surface can own its own page
+ * state and data source.
+ *
+ * The page count is derived from `totalCount / pageSize` — the single source of
+ * truth — so it stays correct the instant `pageSize` changes, before any refetch.
+ */
+
+const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
+
+export function Pagination({
+  page,
+  pageSize,
+  totalCount,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+  isLoading = false,
+  /**
+   * Extra disable for the prev/next arrows beyond loading + boundaries — e.g. an
+   * editor that blocks navigation while a record save is still in flight.
+   */
+  navDisabled = false,
+  /** Plural noun shown after the total, e.g. "records". Omit to hide the total. */
+  unitLabel,
+}: {
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange?: (size: number) => void;
+  pageSizeOptions?: readonly number[];
+  isLoading?: boolean;
+  navDisabled?: boolean;
+  unitLabel?: string;
+}) {
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const currentPage = Math.min(Math.max(1, page), totalPages);
+
+  // Nothing to page through once the count is known to be zero.
+  if (!isLoading && totalCount === 0) return null;
+
+  return (
+    <Flex
+      align="center"
+      justify="flex-end"
+      gap={3}
+      paddingX={2}
+      paddingY={1.5}
+      borderTopWidth="1px"
+      borderColor="border.muted"
+      flexShrink={0}
+      data-testid="pagination"
+    >
+      {isLoading ? (
+        <Skeleton height="14px" width="200px" borderRadius="sm" />
+      ) : (
+        <>
+          {onPageSizeChange && (
+            <Flex align="center" gap={0.5}>
+              <Text textStyle="xs" color="fg.subtle" flexShrink={0}>
+                Rows
+              </Text>
+              {pageSizeOptions.map((size) => (
+                <Button
+                  key={size}
+                  variant="ghost"
+                  size="2xs"
+                  color={pageSize === size ? "fg" : "fg.subtle"}
+                  fontWeight={pageSize === size ? "semibold" : "normal"}
+                  onClick={() => onPageSizeChange(size)}
+                  paddingX={1.5}
+                  minWidth="auto"
+                  data-testid={`pagination-size-${size}`}
+                >
+                  {size}
+                </Button>
+              ))}
+            </Flex>
+          )}
+          <Text
+            textStyle="xs"
+            color="fg.subtle"
+            data-testid="pagination-indicator"
+          >
+            Page {currentPage} of {totalPages}
+            {unitLabel ? ` (${totalCount.toLocaleString()} ${unitLabel})` : ""}
+          </Text>
+        </>
+      )}
+      <Flex gap={1}>
+        <IconButton
+          aria-label="Previous page"
+          variant="ghost"
+          size="xs"
+          disabled={isLoading || navDisabled || currentPage <= 1}
+          onClick={() => onPageChange(currentPage - 1)}
+          data-testid="pagination-prev"
+        >
+          <ChevronLeft size={14} />
+        </IconButton>
+        <IconButton
+          aria-label="Next page"
+          variant="ghost"
+          size="xs"
+          disabled={isLoading || navDisabled || currentPage >= totalPages}
+          onClick={() => onPageChange(currentPage + 1)}
+          data-testid="pagination-next"
+        >
+          <ChevronRight size={14} />
+        </IconButton>
+      </Flex>
+    </Flex>
+  );
+}

--- a/langwatch/src/components/ui/Pagination.tsx
+++ b/langwatch/src/components/ui/Pagination.tsx
@@ -14,6 +14,103 @@ import { ChevronLeft, ChevronRight } from "react-feather";
 
 const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
 
+type PaginationProps = {
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange?: (size: number) => void;
+  pageSizeOptions?: readonly number[];
+  isLoading?: boolean;
+  /**
+   * Extra disable for the controls beyond loading + boundaries — e.g. an editor
+   * that blocks navigation (and a page-size change, which also resets the page)
+   * while a record save is still in flight.
+   */
+  navDisabled?: boolean;
+  /** Plural noun shown after the total, e.g. "records". Omit to hide the total. */
+  unitLabel?: string;
+};
+
+function PageSizeSelector({
+  pageSize,
+  pageSizeOptions,
+  disabled,
+  onPageSizeChange,
+}: {
+  pageSize: number;
+  pageSizeOptions: readonly number[];
+  disabled: boolean;
+  onPageSizeChange: (size: number) => void;
+}) {
+  return (
+    <Flex align="center" gap={0.5}>
+      <Text textStyle="xs" color="fg.subtle" flexShrink={0}>
+        Rows
+      </Text>
+      {pageSizeOptions.map((size) => {
+        const active = pageSize === size;
+        return (
+          <Button
+            key={size}
+            variant="ghost"
+            size="2xs"
+            // Same nav gate as prev/next: a size change clears selection, resets
+            // to page 1, and refetches, so it must not run while a save is in
+            // flight. The already-active size is a no-op.
+            disabled={disabled || active}
+            color={active ? "fg" : "fg.subtle"}
+            fontWeight={active ? "semibold" : "normal"}
+            onClick={() => onPageSizeChange(size)}
+            paddingX={1.5}
+            minWidth="auto"
+            data-testid={`pagination-size-${size}`}
+          >
+            {size}
+          </Button>
+        );
+      })}
+    </Flex>
+  );
+}
+
+function PageNav({
+  currentPage,
+  totalPages,
+  disabled,
+  onPageChange,
+}: {
+  currentPage: number;
+  totalPages: number;
+  disabled: boolean;
+  onPageChange: (page: number) => void;
+}) {
+  return (
+    <Flex gap={1}>
+      <IconButton
+        aria-label="Previous page"
+        variant="ghost"
+        size="xs"
+        disabled={disabled || currentPage <= 1}
+        onClick={() => onPageChange(currentPage - 1)}
+        data-testid="pagination-prev"
+      >
+        <ChevronLeft size={14} />
+      </IconButton>
+      <IconButton
+        aria-label="Next page"
+        variant="ghost"
+        size="xs"
+        disabled={disabled || currentPage >= totalPages}
+        onClick={() => onPageChange(currentPage + 1)}
+        data-testid="pagination-next"
+      >
+        <ChevronRight size={14} />
+      </IconButton>
+    </Flex>
+  );
+}
+
 export function Pagination({
   page,
   pageSize,
@@ -22,27 +119,11 @@ export function Pagination({
   onPageSizeChange,
   pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
   isLoading = false,
-  /**
-   * Extra disable for the prev/next arrows beyond loading + boundaries — e.g. an
-   * editor that blocks navigation while a record save is still in flight.
-   */
   navDisabled = false,
-  /** Plural noun shown after the total, e.g. "records". Omit to hide the total. */
   unitLabel,
-}: {
-  page: number;
-  pageSize: number;
-  totalCount: number;
-  onPageChange: (page: number) => void;
-  onPageSizeChange?: (size: number) => void;
-  pageSizeOptions?: readonly number[];
-  isLoading?: boolean;
-  navDisabled?: boolean;
-  unitLabel?: string;
-}) {
+}: PaginationProps) {
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
   const currentPage = Math.min(Math.max(1, page), totalPages);
-
   // Nothing to page through once the count is known to be zero.
   if (!isLoading && totalCount === 0) return null;
 
@@ -63,26 +144,12 @@ export function Pagination({
       ) : (
         <>
           {onPageSizeChange && (
-            <Flex align="center" gap={0.5}>
-              <Text textStyle="xs" color="fg.subtle" flexShrink={0}>
-                Rows
-              </Text>
-              {pageSizeOptions.map((size) => (
-                <Button
-                  key={size}
-                  variant="ghost"
-                  size="2xs"
-                  color={pageSize === size ? "fg" : "fg.subtle"}
-                  fontWeight={pageSize === size ? "semibold" : "normal"}
-                  onClick={() => onPageSizeChange(size)}
-                  paddingX={1.5}
-                  minWidth="auto"
-                  data-testid={`pagination-size-${size}`}
-                >
-                  {size}
-                </Button>
-              ))}
-            </Flex>
+            <PageSizeSelector
+              pageSize={pageSize}
+              pageSizeOptions={pageSizeOptions}
+              disabled={navDisabled}
+              onPageSizeChange={onPageSizeChange}
+            />
           )}
           <Text
             textStyle="xs"
@@ -94,28 +161,12 @@ export function Pagination({
           </Text>
         </>
       )}
-      <Flex gap={1}>
-        <IconButton
-          aria-label="Previous page"
-          variant="ghost"
-          size="xs"
-          disabled={isLoading || navDisabled || currentPage <= 1}
-          onClick={() => onPageChange(currentPage - 1)}
-          data-testid="pagination-prev"
-        >
-          <ChevronLeft size={14} />
-        </IconButton>
-        <IconButton
-          aria-label="Next page"
-          variant="ghost"
-          size="xs"
-          disabled={isLoading || navDisabled || currentPage >= totalPages}
-          onClick={() => onPageChange(currentPage + 1)}
-          data-testid="pagination-next"
-        >
-          <ChevronRight size={14} />
-        </IconButton>
-      </Flex>
+      <PageNav
+        currentPage={currentPage}
+        totalPages={totalPages}
+        disabled={isLoading || navDisabled}
+        onPageChange={onPageChange}
+      />
     </Flex>
   );
 }

--- a/langwatch/src/optimization_studio/components/__tests__/DatasetModal.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/__tests__/DatasetModal.integration.test.tsx
@@ -75,6 +75,15 @@ vi.mock("~/utils/api", () => ({
           refetch: vi.fn(),
         }),
       },
+      // The saved-dataset editor reads one page at a time now; draft (in-memory)
+      // mode keeps it disabled but the hook is still invoked, so it must exist.
+      listPaginated: {
+        useQuery: () => ({
+          data: undefined,
+          isLoading: false,
+          refetch: vi.fn(),
+        }),
+      },
       update: { useMutation: () => ({ mutate: vi.fn() }) },
       deleteMany: { useMutation: () => ({ mutate: vi.fn() }) },
       create: { useMutation: () => ({ mutate: vi.fn() }) },

--- a/langwatch/src/server/api/routers/datasetRecord.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.ts
@@ -192,9 +192,9 @@ export const datasetRecordRouter = createTRPCRouter({
       }),
     )
     .use(checkProjectPermission("datasets:view"))
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
       try {
-        return await DatasetService.create(prisma).getDatasetPage({
+        return await DatasetService.create(ctx.prisma).getDatasetPage({
           slugOrId: input.datasetId,
           projectId: input.projectId,
           page: input.page,

--- a/langwatch/src/server/api/routers/datasetRecord.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.ts
@@ -2,12 +2,14 @@ import type { Dataset, PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
+import { DatasetService } from "../../datasets/dataset.service";
 import {
   deleteS3JsonlRecords,
   editS3JsonlRecord,
 } from "../../datasets/dataset-mutations";
 import {
   ChunkTooLargeError,
+  DatasetNotFoundError,
   DatasetNotReadyError,
   DatasetTooLargeToExportError,
   DuplicateRecordIdError,
@@ -169,6 +171,40 @@ export const datasetRecordRouter = createTRPCRouter({
         // Defense: a not-ready read surfaces as PRECONDITION_FAILED instead of
         // INTERNAL_SERVER_ERROR (the UI already gates, but downstream consumers
         // rely on a clean 4xx — see useGetDatasetData / useSavedDatasetLoader).
+        return rethrowDatasetNotReadyAsTRPC(error);
+      }
+    }),
+  /**
+   * One page of a dataset for the editor (classic page N of M). Replaces the
+   * editor's whole-dataset `getAll` read — which truncated past a byte cap and
+   * silently hid the rest — with a bounded windowed read (s3_jsonl reads only
+   * the chunks overlapping the page; PG paginates by skip/take). Total is the
+   * PG-authoritative `count`. Editing still works on the visible page because
+   * record mutations target each record by its own id.
+   */
+  listPaginated: protectedProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        datasetId: z.string(),
+        page: z.number().int().positive().default(1),
+        limit: z.number().int().positive().max(200).default(50),
+      }),
+    )
+    .use(checkProjectPermission("datasets:view"))
+    .query(async ({ input }) => {
+      try {
+        return await DatasetService.create(prisma).getDatasetPage({
+          slugOrId: input.datasetId,
+          projectId: input.projectId,
+          page: input.page,
+          limit: input.limit,
+        });
+      } catch (error) {
+        // Parity with getAll/getFullDataset: an archived/missing dataset reads
+        // as null (the editor surfaces "no longer available"), not a 500. A
+        // still-preparing dataset maps to PRECONDITION_FAILED like the others.
+        if (error instanceof DatasetNotFoundError) return null;
         return rethrowDatasetNotReadyAsTRPC(error);
       }
     }),

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -723,7 +723,28 @@ export class DatasetService {
       slugOrId: params.slugOrId,
       projectId: params.projectId,
     });
+    return this.paginateResolvedDataset({
+      dataset,
+      projectId: params.projectId,
+      page: params.page,
+      limit: params.limit,
+    });
+  }
 
+  /**
+   * Reads one page of records from an already-resolved dataset — the shared
+   * windowed read behind both `listRecords` (slug/id lookup first) and
+   * `getDatasetPage` (the editor's paged read), so the s3_jsonl chunk-window
+   * logic lives in exactly one place and a caller that already holds the row
+   * doesn't look it up twice.
+   */
+  private async paginateResolvedDataset(params: {
+    dataset: Dataset;
+    projectId: string;
+    page: number;
+    limit: number;
+  }) {
+    const { dataset } = params;
     const skip = (params.page - 1) * params.limit;
 
     // ADR-032: s3_jsonl content lives in chunk objects, not the PG
@@ -842,6 +863,53 @@ export class DatasetService {
         total,
         totalPages: Math.ceil(total / params.limit),
       },
+    };
+  }
+
+  /**
+   * One page of a dataset for the editor: the dataset's name + columnTypes plus
+   * the page's records ({ id, entry }) and the PG-authoritative total. Replaces
+   * the editor's whole-dataset `getFullDataset` read (which truncated past a
+   * byte cap) with a bounded windowed read, so arbitrarily large datasets page
+   * instead of silently hiding rows. Resolves the row ONCE and reuses the same
+   * windowed reader as `listRecords`.
+   *
+   * @throws {DatasetNotFoundError} if dataset not found
+   * @throws {DatasetNotReadyError} if an s3_jsonl dataset is still preparing
+   */
+  async getDatasetPage(params: {
+    slugOrId: string;
+    projectId: string;
+    page: number;
+    limit: number;
+  }) {
+    const dataset = await this.getBySlugOrId({
+      slugOrId: params.slugOrId,
+      projectId: params.projectId,
+    });
+    const { data, pagination } = await this.paginateResolvedDataset({
+      dataset,
+      projectId: params.projectId,
+      page: params.page,
+      limit: params.limit,
+    });
+    return {
+      id: dataset.id,
+      name: dataset.name,
+      columnTypes: dataset.columnTypes,
+      datasetRecords: data.map((record) => ({
+        id: record.id,
+        entry: record.entry,
+      })),
+      count: pagination.total,
+      page: pagination.page,
+      limit: pagination.limit,
+      totalPages: pagination.totalPages,
+      // A page is a bounded window by construction — there is no byte-cap
+      // truncation as with the whole-dataset `getFullDataset` read. Carried so
+      // the editor's existing truncation-aware count chip stays type-safe and
+      // simply never lights up on the paged path.
+      truncated: false as boolean,
     };
   }
 

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -905,11 +905,6 @@ export class DatasetService {
       page: pagination.page,
       limit: pagination.limit,
       totalPages: pagination.totalPages,
-      // A page is a bounded window by construction — there is no byte-cap
-      // truncation as with the whole-dataset `getFullDataset` read. Carried so
-      // the editor's existing truncation-aware count chip stays type-safe and
-      // simply never lights up on the paged path.
-      truncated: false as boolean,
     };
   }
 

--- a/specs/datasets/dataset-editor.feature
+++ b/specs/datasets/dataset-editor.feature
@@ -69,6 +69,13 @@ Feature: Dataset editor
     Then an empty row to add a record is available there
     And it is not offered on earlier, full pages
 
+  @integration
+  Scenario: Change how many rows are shown per page
+    Given the dataset has more records than fit on one page
+    When I change how many rows are shown per page
+    Then that many records are loaded
+    And I am returned to the first page
+
   # ============================================================================
   # Inline cell editing
   # ============================================================================

--- a/specs/datasets/dataset-editor.feature
+++ b/specs/datasets/dataset-editor.feature
@@ -30,6 +30,46 @@ Feature: Dataset editor
     And scrolling through the dataset stays smooth
 
   # ============================================================================
+  # Pagination
+  # ============================================================================
+  # A dataset larger than one page is read a page at a time instead of loading
+  # the whole thing into the browser (which previously stopped at a byte cap and
+  # silently hid the rest). The editor shows one page of records with a pager;
+  # editing still works on the visible page because edits target each record by
+  # its own id.
+
+  @integration
+  Scenario: A dataset larger than one page shows the first page with a pager
+    Given the dataset has more records than fit on one page
+    When I open the dataset in the editor
+    Then I see the first page of records
+    And I see which page I am on and how many pages there are
+    And the total record count reflects the whole dataset, not just this page
+
+  @integration
+  Scenario: Move between pages
+    Given the dataset has more records than fit on one page
+    When I open the dataset in the editor
+    And I go to the next page
+    Then I see the next page of records
+    And I can return to the previous page
+
+  @integration
+  Scenario: Edits on a page are saved to the right record
+    Given the dataset has more records than fit on one page
+    When I move to a later page
+    And I edit a cell on that page
+    Then the change is saved to that record
+    And it is still there when I return to that page
+
+  @integration
+  Scenario: A new row is added on the last page
+    Given the dataset has more records than fit on one page
+    When I go to the last page
+    Then an empty row to add a record is available there
+    And it is not offered on earlier, full pages
+
+  # ============================================================================
   # Inline cell editing
   # ============================================================================
 


### PR DESCRIPTION
## Why

Closes #5153

The dataset detail editor loaded the **whole** dataset into the browser via `datasetRecord.getAll` → `getFullDataset`, capped at ~13 MB (`DATASET_EDITOR_READ_LIMIT_MB`). Past that the read was **silently truncated** — the grid showed only the first rows behind a "showing X of Y" notice and the rest were unreachable. Large datasets were effectively unviewable/uneditable beyond the cap.

## What changed

The saved-dataset editor now reads **one page at a time** (classic page N of M) instead of the whole dataset, so arbitrarily large datasets are fully viewable and editable. In-memory mode (draft datasets, prompt demonstrations) is unchanged.

- **Server** — `DatasetService.getDatasetPage()`: an editor-shaped one-page read (name + columnTypes + page records + PG-authoritative total). It reuses the existing windowed reader (`s3_jsonl` reads only the chunks overlapping the page window; PG paginates by skip/take), extracted as `paginateResolvedDataset` so the row is resolved once. Exposed as a new tRPC procedure `datasetRecord.listPaginated`.
- **Shared pager** — extracted a prop-driven `~/components/ui/Pagination`, modeled on the traces-v2 table pager so the two surfaces behave the same: a rows-per-page selector, a loading skeleton, and a pager that shows even on a single page (only hidden when the count is known to be zero). Unlike the traces-v2 one it takes its state as props instead of reading a feature store, so any surface owns its own page state and data source.
- **Client** (`DatasetEditorTable`, saved path only) — `page` + `pageSize` state + `listPaginated` query, the shared `Pagination` footer (rows-per-page / prev / `Page N of M` / next), and the whole-dataset total in the count chip.
- Editing still works on the visible page because record mutations target each record by its own id (no full in-memory copy needed).
- The old **byte-cap truncation UI was removed** — pagination supersedes it, so there is no longer a partial-read state to surface.

## How it works

- **Memory-bounded reads.** `getDatasetPage` → `listRecords`’ windowed reader: for `s3_jsonl` it reads only the chunk objects whose `[startRow, endRow)` overlap the requested page (via `chunkOffsets`), never the whole file; for PG it’s `skip`/`take`. Total comes from the PG-authoritative `rowCount`.
- **Edits stay correct across pages.** Edits/deletes go through the existing per-record-by-id mutations, so only the current page lives in the store. Page navigation is **blocked while a save is queued/in-flight** (switching pages reloads the store and would otherwise strand an unsaved edit), and selection clears per page.
- **Add-row** appears only on the **last page** (the trailing phantom row appends to the end of the dataset).
- **Deletes refresh the total.** Only the current page lives in the store, so a delete can't recompute the whole-dataset count locally. After a delete batch settles, the editor refetches the page (and thus the PG-authoritative count), so the count chip and pager stay accurate and the clamp snaps off a now-empty last page instead of stranding the user there.
- **Robust boundaries.** The page count is derived from `count / pageSize` — the single source of truth — so it stays correct the instant rows-per-page changes, before any refetch. It is a first-class clamped quantity — `pageCount = max(1, ceil(count / pageSize))`, `currentPage = min(page, pageCount)` — used for the query/display/pager/nav, so an empty dataset, a single page, or a dataset that shrank under you can never produce an out-of-range request (e.g. page 0, which the server's `positive()` guard rejects). Changing rows-per-page resets to page 1.

## Test plan

- **Spec**: `specs/datasets/dataset-editor.feature` — Pagination scenarios (first page + pager, navigation, per-record edit on a later page, add-row gated to the last page), each bound by an integration test.
- **Integration** (`DatasetEditorTable.integration.test.tsx`): first-page+pager+total, next/prev navigation, the previous page held while the next loads (no bounce to page 1), an edit on page 2 saving to that page's record id, add-row only on the last page, a **rows-per-page change** re-reading with the new limit and resetting to page 1, a **cross-dataset switch** never hydrating the new id with the previous dataset's rows, a **delete refreshing the server total**, and an **empty-dataset regression** (never requests page 0, no pager, add-row stays, "0 records"). 20 tests, all discriminating (verified red without each fix).
- typecheck + biome + `check:feature-parity` green.

## Anything surprising?

- **Local verification gap**: the editor integration suite is Docker-gated and Docker is down on my machine, so these tests were **validated in jsdom out-of-band** (20/20 — paged flow, the keepPreviousData no-bounce case, per-record edit binding, rows-per-page change, the cross-dataset hydration guard, the post-delete count refresh, and the empty-dataset boundary). **CI must run the integration suite before merge**, and a browser-QA pass is worth it given how widely `DatasetEditorTable` is shared.
- **Consumers checked**: of the 6 `DatasetEditorTable` usages, only the optimization-studio `DatasetModal` saved-mode embed also gains pagination (an improvement — it had the same 13 MB truncation); it uses `onColumnsChanged` only, so no data-assumption breaks. The Demonstrations modals use in-memory mode (untouched).
- **Deliberately out of scope** (follow-ups): prev/next-only pager (no jump-to-page), the CSV download / "Run experiment" full-dataset reads (unchanged), and migrating traces-v2 onto the shared `Pagination` (its store-backed pager is left in place for now). Wider requirement noted in #5153: no dataset surface should read a whole dataset into one heap — other `getFullDataset` callers should be audited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Saved-dataset editor now uses page-by-page loading with a new Pagination control (“page N of M”), whole-dataset totals, and page-size selection; “Add row” is shown only on the last page.
* **Bug Fixes**
  * Pagination navigation is disabled while autosave/pending writes are active, preventing lost or stranded edits.
  * Page edits persist to the correct records; switching datasets no longer mixes rows; deleting records refreshes totals so pagination updates correctly.
* **Documentation**
  * Updated dataset editor specs to reflect pagination, whole totals, and empty/add-row behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->