### PR TITLE
feat(billing): billable stored-bytes measurement (ADR-027 Phase 2)

### DIFF
--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -480,6 +480,7 @@ export function initializeDefaultApp(options?: {
   );
   const storageMeterService = new StorageMeterService(
     clickhouseEnabled ? resolveClickHouseClient : null,
+    (organizationId) => organizations.getProjectIds(organizationId),
   );
   const dataRetention: DataRetentionDependencies = {
     policy: dataRetentionPolicyService,

--- a/langwatch/src/server/clickhouse/ttlReconciler.ts
+++ b/langwatch/src/server/clickhouse/ttlReconciler.ts
@@ -1,8 +1,8 @@
 import { createClient } from "@clickhouse/client";
 
 import { createLogger } from "../../utils/logger/server";
-import { parseConnectionUrl } from "./goose";
 import { RETENTION_MANAGED_TABLES } from "../data-retention/retentionPolicy.schema";
+import { parseConnectionUrl } from "./goose";
 
 const logger = createLogger("langwatch:clickhouse:ttl-reconciler");
 
@@ -212,7 +212,8 @@ export function buildDesiredTTLExpression({
   config: TableTTLEntry;
   days: number;
 }): string {
-  const colExpr = config.ttlColumnExpression ?? `toDateTime(${config.ttlColumn})`;
+  const colExpr =
+    config.ttlColumnExpression ?? `toDateTime(${config.ttlColumn})`;
   return `${colExpr} + INTERVAL ${days} DAY TO VOLUME 'cold'`;
 }
 
@@ -232,7 +233,9 @@ export function buildRetentionAgeColumnExpression(
   );
 }
 
-export function buildRetentionTTLExpression(config: TableTTLEntry): string | null {
+export function buildRetentionTTLExpression(
+  config: TableTTLEntry,
+): string | null {
   const colExpr = buildRetentionAgeColumnExpression(config);
   if (!colExpr) return null;
   return `IF(_retention_days > 0, ${colExpr} + toIntervalDay(_retention_days), toDateTime('${INDEFINITE_RETENTION_SENTINEL_DATE}')) DELETE`;
@@ -329,11 +332,16 @@ export async function reconcileTTL(
       // but they CAN still have retention DELETE TTL. Likewise, when the operator
       // disables cold-storage management we still need to install retention TTL,
       // so collapse to the retention-only branch in both cases.
-      if (tableInfo.storage_policy !== TIERED_STORAGE_POLICY || !coldStorageEnabled) {
+      if (
+        tableInfo.storage_policy !== TIERED_STORAGE_POLICY ||
+        !coldStorageEnabled
+      ) {
         const retentionTTLExpr = buildRetentionTTLExpression(tableConfig);
         if (
           retentionTTLExpr &&
-          (RETENTION_MANAGED_TABLES as readonly string[]).includes(tableConfig.table) &&
+          (RETENTION_MANAGED_TABLES as readonly string[]).includes(
+            tableConfig.table,
+          ) &&
           !hasRetentionTTL(tableInfo.engine_full)
         ) {
           // No ON CLUSTER: whenever a cluster is configured the database uses
@@ -368,7 +376,9 @@ export async function reconcileTTL(
       const currentDays = parseTTLDaysFromEngineMetadata(engineFull);
 
       const retentionTTLExpr = buildRetentionTTLExpression(tableConfig);
-      const isManaged = (RETENTION_MANAGED_TABLES as readonly string[]).includes(tableConfig.table);
+      const isManaged = (
+        RETENTION_MANAGED_TABLES as readonly string[]
+      ).includes(tableConfig.table);
       // Whether the cold TTL alone is enough to skip this run — i.e. nothing
       // has changed in the cold-TTL space. For managed tables we must still
       // run when retention TTL is missing from the table (first-time apply).

--- a/langwatch/src/server/clickhouse/ttlReconciler.ts
+++ b/langwatch/src/server/clickhouse/ttlReconciler.ts
@@ -216,11 +216,25 @@ export function buildDesiredTTLExpression({
   return `${colExpr} + INTERVAL ${days} DAY TO VOLUME 'cold'`;
 }
 
-export function buildRetentionTTLExpression(config: TableTTLEntry): string | null {
+/**
+ * The DateTime expression a table's row age is measured by for retention —
+ * the same column the TTL DELETE clause ages on. Returns null for tables that
+ * carry no retention TTL (e.g. `billable_events`). Storage billing reuses this
+ * so its age predicate can never drift from what TTL actually deletes.
+ */
+export function buildRetentionAgeColumnExpression(
+  config: TableTTLEntry,
+): string | null {
   if (!config.retentionTTLColumn) return null;
-  const colExpr =
+  return (
     config.retentionTTLColumnExpression ??
-    `toDateTime(${config.retentionTTLColumn})`;
+    `toDateTime(${config.retentionTTLColumn})`
+  );
+}
+
+export function buildRetentionTTLExpression(config: TableTTLEntry): string | null {
+  const colExpr = buildRetentionAgeColumnExpression(config);
+  if (!colExpr) return null;
   return `IF(_retention_days > 0, ${colExpr} + toIntervalDay(_retention_days), toDateTime('${INDEFINITE_RETENTION_SENTINEL_DATE}')) DELETE`;
 }
 

--- a/langwatch/src/server/data-retention/metering/__tests__/billableStorageQuery.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/billableStorageQuery.unit.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { RETENTION_MANAGED_TABLES } from "../../retentionPolicy.schema";
 import {
   BILLABLE_AFTER_DAYS,
   BILLABLE_AGE_EXPR_BY_TABLE,
   buildBillableStorageQuery,
 } from "../billableStorageQuery";
-import { RETENTION_MANAGED_TABLES } from "../../retentionPolicy.schema";
 
 describe("buildBillableStorageQuery", () => {
   const sql = buildBillableStorageQuery(BILLABLE_AGE_EXPR_BY_TABLE);

--- a/langwatch/src/server/data-retention/metering/__tests__/billableStorageQuery.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/billableStorageQuery.unit.test.ts
@@ -47,7 +47,7 @@ describe("buildBillableStorageQuery", () => {
       expect(sql).not.toContain("IN (");
     });
 
-    /** @scenario A table whose partition key differs from its retention column is not pruned by an unsound predicate */
+    /** @scenario The query filters only on the retention column, never on an assumed partition key */
     /** @scenario evaluation_runs bills on time-since-last-update, a documented limitation */
     it("ages evaluation_runs on UpdatedAt and never synthesizes a ScheduledAt predicate", () => {
       expect(BILLABLE_AGE_EXPR_BY_TABLE.evaluation_runs).toBe(

--- a/langwatch/src/server/data-retention/metering/__tests__/billableStorageQuery.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/billableStorageQuery.unit.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  BILLABLE_AFTER_DAYS,
+  BILLABLE_AGE_EXPR_BY_TABLE,
+  buildBillableStorageQuery,
+} from "../billableStorageQuery";
+import { RETENTION_MANAGED_TABLES } from "../../retentionPolicy.schema";
+
+describe("buildBillableStorageQuery", () => {
+  const sql = buildBillableStorageQuery(BILLABLE_AGE_EXPR_BY_TABLE);
+
+  describe("given the managed-table age-expression map", () => {
+    it("covers exactly the retention-managed tables", () => {
+      expect(Object.keys(BILLABLE_AGE_EXPR_BY_TABLE).sort()).toEqual(
+        [...RETENTION_MANAGED_TABLES].sort(),
+      );
+    });
+
+    it("excludes billable_events (no retention TTL column)", () => {
+      expect(BILLABLE_AGE_EXPR_BY_TABLE).not.toHaveProperty("billable_events");
+    });
+  });
+
+  describe("when building the per-tenant SQL", () => {
+    it("pre-aggregates each table to a scalar before the outer sum", () => {
+      // One sum(_size_bytes) per managed table, all wrapped in an outer sum(t).
+      expect(sql).toMatch(/SELECT sum\(t\) AS total FROM \(/);
+      const perTable = sql.match(/sum\(_size_bytes\) AS t FROM/g) ?? [];
+      expect(perTable.length).toBe(RETENTION_MANAGED_TABLES.length);
+    });
+
+    it("scopes every subquery by the tenant id parameter", () => {
+      const scoped = sql.match(/WHERE TenantId = \{tenantId:String\}/g) ?? [];
+      expect(scoped.length).toBe(RETENTION_MANAGED_TABLES.length);
+    });
+
+    it("ages every subquery against the UTC cutoff parameter", () => {
+      const aged = sql.match(/<= \{cutoff:DateTime\('UTC'\)\}/g) ?? [];
+      expect(aged.length).toBe(RETENTION_MANAGED_TABLES.length);
+    });
+
+    it("never issues a cross-tenant IN scan", () => {
+      expect(sql).not.toMatch(/TenantId IN/i);
+      expect(sql).not.toContain("IN (");
+    });
+
+    it("ages evaluation_runs on UpdatedAt and never synthesizes a ScheduledAt predicate", () => {
+      expect(BILLABLE_AGE_EXPR_BY_TABLE.evaluation_runs).toBe(
+        "toDateTime(UpdatedAt)",
+      );
+      const evalSub = sql
+        .split("UNION ALL")
+        .find((part) => part.includes("FROM evaluation_runs"))!;
+      expect(evalSub).toContain("toDateTime(UpdatedAt) <=");
+      expect(evalSub).not.toContain("ScheduledAt");
+    });
+
+    it("ages event_log on the epoch-millis conversion sourced from the retention config", () => {
+      expect(BILLABLE_AGE_EXPR_BY_TABLE.event_log).toBe(
+        "toDateTime(EventOccurredAt / 1000)",
+      );
+      const eventSub = sql
+        .split("UNION ALL")
+        .find((part) => part.includes("FROM event_log"))!;
+      expect(eventSub).toContain("toDateTime(EventOccurredAt / 1000) <=");
+    });
+  });
+
+  describe("given the free-window constant", () => {
+    it("is 35 days (5 weeks, a clean toYearWeek partition boundary)", () => {
+      expect(BILLABLE_AFTER_DAYS).toBe(35);
+      expect(BILLABLE_AFTER_DAYS % 7).toBe(0);
+    });
+  });
+});

--- a/langwatch/src/server/data-retention/metering/__tests__/billableStorageQuery.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/billableStorageQuery.unit.test.ts
@@ -10,6 +10,7 @@ describe("buildBillableStorageQuery", () => {
   const sql = buildBillableStorageQuery(BILLABLE_AGE_EXPR_BY_TABLE);
 
   describe("given the managed-table age-expression map", () => {
+    /** @scenario Each table is aged by its retention/TTL column, so the measurement matches what TTL deletes */
     it("covers exactly the retention-managed tables", () => {
       expect(Object.keys(BILLABLE_AGE_EXPR_BY_TABLE).sort()).toEqual(
         [...RETENTION_MANAGED_TABLES].sort(),
@@ -34,6 +35,8 @@ describe("buildBillableStorageQuery", () => {
       expect(scoped.length).toBe(RETENTION_MANAGED_TABLES.length);
     });
 
+    /** @scenario Data older than the free window is billable */
+    /** @scenario Data inside the free window is free */
     it("ages every subquery against the UTC cutoff parameter", () => {
       const aged = sql.match(/<= \{cutoff:DateTime\('UTC'\)\}/g) ?? [];
       expect(aged.length).toBe(RETENTION_MANAGED_TABLES.length);
@@ -44,6 +47,8 @@ describe("buildBillableStorageQuery", () => {
       expect(sql).not.toContain("IN (");
     });
 
+    /** @scenario A table whose partition key differs from its retention column is not pruned by an unsound predicate */
+    /** @scenario evaluation_runs bills on time-since-last-update, a documented limitation */
     it("ages evaluation_runs on UpdatedAt and never synthesizes a ScheduledAt predicate", () => {
       expect(BILLABLE_AGE_EXPR_BY_TABLE.evaluation_runs).toBe(
         "toDateTime(UpdatedAt)",
@@ -55,6 +60,7 @@ describe("buildBillableStorageQuery", () => {
       expect(evalSub).not.toContain("ScheduledAt");
     });
 
+    /** @scenario The age comparison is byte-identical to the TTL delete expression */
     it("ages event_log on the epoch-millis conversion sourced from the retention config", () => {
       expect(BILLABLE_AGE_EXPR_BY_TABLE.event_log).toBe(
         "toDateTime(EventOccurredAt / 1000)",

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { RETENTION_MANAGED_TABLES } from "../../retentionPolicy.schema";
 import { StorageMeterService } from "../storageMeter.service";
+import { RETENTION_MANAGED_TABLES } from "../../retentionPolicy.schema";
 
 /**
  * The metering reads sum a lazily-recomputed MATERIALIZED byteSize(...) column
@@ -72,6 +73,193 @@ describe("StorageMeterService memory guard", () => {
         // one failed aggregate attempt + one query per table for the fallback
         expect(query).toHaveBeenCalledTimes(1 + RETENTION_MANAGED_TABLES.length);
       });
+    });
+  });
+});
+
+/**
+ * The billable-storage measurement sums an organization's logical bytes older
+ * than the free window, anchored to a past sealed hour. It is a pure read used
+ * by the Stripe reporting pipeline — correctness over availability: any query
+ * failure throws rather than silently undercounting the bill.
+ */
+describe("StorageMeterService billable measurement", () => {
+  // 2026-06-26T12:00:00Z. Cutoff = H − 35 days = 2026-05-22T12:00:00Z.
+  const H = new Date("2026-06-26T12:00:00.000Z");
+  const EXPECTED_CUTOFF = "2026-05-22 12:00:00";
+
+  function makeService({
+    projectIds,
+    perTenantBytes = () => "100",
+    failOn,
+  }: {
+    projectIds: string[];
+    perTenantBytes?: (tenantId: string) => string;
+    failOn?: string;
+  }) {
+    const query = vi.fn(async (call: { query_params: { tenantId: string } }) => {
+      const tenantId = call.query_params.tenantId;
+      if (failOn && tenantId === failOn) {
+        throw new Error("ClickHouse query failed");
+      }
+      return { json: async () => [{ total: perTenantBytes(tenantId) }] };
+    });
+    const client = { query } as const;
+    const resolveClient = vi.fn(async () => client as any);
+    const resolveProjectIds = vi.fn(async () => projectIds);
+    const service = new StorageMeterService(resolveClient, resolveProjectIds);
+    return { service, query, resolveClient, resolveProjectIds };
+  }
+
+  describe("given an organization with several projects", () => {
+    it("sums each project's billable bytes across its own tenant-routed query", async () => {
+      const { service, query, resolveClient } = makeService({
+        projectIds: ["p1", "p2", "p3"],
+        perTenantBytes: () => "100",
+      });
+
+      const total = await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: H,
+      });
+
+      expect(total).toBe(300);
+      expect(query).toHaveBeenCalledTimes(3);
+      expect(resolveClient.mock.calls.map(([id]) => id)).toEqual([
+        "p1",
+        "p2",
+        "p3",
+      ]);
+    });
+
+    it("scopes every query to one of the organization's tenant ids, never another org's", async () => {
+      const { service, query } = makeService({ projectIds: ["p1", "p2"] });
+
+      await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: H,
+      });
+
+      for (const [call] of query.mock.calls) {
+        expect(["p1", "p2"]).toContain(call.query_params.tenantId);
+      }
+    });
+
+    it("issues a separate per-tenant query, never a cross-tenant IN scan", async () => {
+      const { service, query } = makeService({ projectIds: ["p1", "p2"] });
+
+      await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: H,
+      });
+
+      for (const [call] of query.mock.calls) {
+        expect(call.query).not.toMatch(/TenantId IN/i);
+        expect(call.query).toContain("TenantId = {tenantId:String}");
+      }
+    });
+
+    it("caps each query's read streams and execution time so the size recompute can't exhaust memory", async () => {
+      const { service, query } = makeService({ projectIds: ["p1"] });
+
+      await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: H,
+      });
+
+      const settings = query.mock.calls[0]![0].clickhouse_settings;
+      expect(settings.max_threads).toBe(2);
+      expect(settings.max_execution_time).toBeGreaterThan(0);
+    });
+
+    it("pre-aggregates each managed table to a scalar inside the per-tenant query", async () => {
+      const { service, query } = makeService({ projectIds: ["p1"] });
+
+      await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: H,
+      });
+
+      const sql = query.mock.calls[0]![0].query;
+      const perTable = sql.match(/sum\(_size_bytes\) AS t FROM/g) ?? [];
+      expect(perTable.length).toBe(RETENTION_MANAGED_TABLES.length);
+    });
+  });
+
+  describe("given the measurement is anchored to a sealed hour", () => {
+    it("binds the cutoff as H − 35 days, independent of wall-clock time", async () => {
+      const { service, query } = makeService({ projectIds: ["p1"] });
+
+      await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: H,
+      });
+
+      expect(query.mock.calls[0]![0].query_params.cutoff).toBe(EXPECTED_CUTOFF);
+    });
+
+    it("binds the cutoff as an explicit UTC value unaffected by session timezone", async () => {
+      const { service, query } = makeService({ projectIds: ["p1"] });
+
+      await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: H,
+      });
+
+      // String-typed UTC param + DateTime('UTC') annotation in the SQL means
+      // ClickHouse parses it in UTC regardless of the session's timezone.
+      expect(query.mock.calls[0]![0].query).toContain(
+        "{cutoff:DateTime('UTC')}",
+      );
+      expect(typeof query.mock.calls[0]![0].query_params.cutoff).toBe("string");
+    });
+  });
+
+  describe("given an organization whose projects hold only data within the free window", () => {
+    it("measures zero", async () => {
+      const { service } = makeService({
+        projectIds: ["p1", "p2"],
+        perTenantBytes: () => "0",
+      });
+
+      const total = await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: H,
+      });
+
+      expect(total).toBe(0);
+    });
+  });
+
+  describe("when one table query fails", () => {
+    it("throws instead of returning a total that omits the failed tenant's bytes", async () => {
+      const { service } = makeService({
+        projectIds: ["p1", "p2"],
+        failOn: "p2",
+      });
+
+      await expect(
+        service.getBillableStorageBytesForOrgAt({
+          organizationId: "org-A",
+          sealedHour: H,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("when measuring billable bytes", () => {
+    it("returns the raw logical byte count without rounding to MiB", async () => {
+      const { service } = makeService({
+        projectIds: ["p1"],
+        perTenantBytes: () => "1572865", // 1.5 MiB + 1 byte
+      });
+
+      const total = await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: H,
+      });
+
+      expect(total).toBe(1572865);
     });
   });
 });

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -19,7 +19,9 @@ describe("StorageMeterService memory guard", () => {
     return { service, query };
   }
 
-  function assertGuarded(call: { clickhouse_settings?: Record<string, unknown> }) {
+  function assertGuarded(call: {
+    clickhouse_settings?: Record<string, unknown>;
+  }) {
     expect(call.clickhouse_settings).toBeDefined();
     expect(call.clickhouse_settings!.max_threads).toBe(2);
     // A coarse guardrail so a runaway byteSize recompute can't grind for a
@@ -57,20 +59,28 @@ describe("StorageMeterService memory guard", () => {
         // The combined UNION ALL aggregate trips the per-query limit, but each
         // table's own query still succeeds — the total should degrade to the
         // sum of the per-table subtotals rather than failing the whole metric.
-        const query = vi.fn().mockImplementation(async (arg: { query: string }) => {
-          if (arg.query.includes("UNION ALL")) {
-            throw new Error("Code: 241. DB::Exception: memory limit exceeded");
-          }
-          return { json: async () => [{ total: "10" }] };
-        });
+        const query = vi
+          .fn()
+          .mockImplementation(async (arg: { query: string }) => {
+            if (arg.query.includes("UNION ALL")) {
+              throw new Error(
+                "Code: 241. DB::Exception: memory limit exceeded",
+              );
+            }
+            return { json: async () => [{ total: "10" }] };
+          });
         const client = { query } as const;
         const service = new StorageMeterService(async () => client as any);
 
-        const total = await service.getTotalStorageBytes({ tenantId: "p-heavy" });
+        const total = await service.getTotalStorageBytes({
+          tenantId: "p-heavy",
+        });
 
         expect(total).toBe(10 * RETENTION_MANAGED_TABLES.length);
         // one failed aggregate attempt + one query per table for the fallback
-        expect(query).toHaveBeenCalledTimes(1 + RETENTION_MANAGED_TABLES.length);
+        expect(query).toHaveBeenCalledTimes(
+          1 + RETENTION_MANAGED_TABLES.length,
+        );
       });
     });
   });

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -121,6 +121,7 @@ describe("StorageMeterService billable measurement", () => {
   }
 
   describe("given an organization with several projects", () => {
+    /** @scenario An organization's measurement sums across all its projects */
     it("sums each project's billable bytes across its own tenant-routed query", async () => {
       const { service, query, resolveClient } = makeService({
         projectIds: ["p1", "p2", "p3"],
@@ -140,6 +141,7 @@ describe("StorageMeterService billable measurement", () => {
       );
     });
 
+    /** @scenario Another organization's data is never included */
     it("measures only the target org's tenants, never another org's projects", async () => {
       const { service, query } = makeService({
         projectIdsByOrg: { "org-A": ["p1", "p2"], "org-B": ["p3"] },
@@ -157,6 +159,7 @@ describe("StorageMeterService billable measurement", () => {
       expect(queriedTenants).not.toContain("p3");
     });
 
+    /** @scenario The measurement reuses the per-tenant path, not a cross-tenant IN, and caps each query */
     it("caps each query's read streams and execution time so the size recompute can't exhaust memory", async () => {
       const { service, query } = makeService({ projectIds: ["p1"] });
 
@@ -172,6 +175,7 @@ describe("StorageMeterService billable measurement", () => {
   });
 
   describe("given the measurement is anchored to a sealed hour", () => {
+    /** @scenario The cutoff is anchored to the sealed hour, not now */
     it("binds the cutoff as H − 35 days, independent of wall-clock time", async () => {
       const { service, query } = makeService({ projectIds: ["p1"] });
 
@@ -183,6 +187,7 @@ describe("StorageMeterService billable measurement", () => {
       expect(query.mock.calls[0]![0].query_params.cutoff).toBe(EXPECTED_CUTOFF);
     });
 
+    /** @scenario The sealed hour and cutoff are interpreted in UTC regardless of ClickHouse session timezone */
     it("binds the cutoff as an explicit UTC value unaffected by session timezone", async () => {
       const { service, query } = makeService({ projectIds: ["p1"] });
 
@@ -199,6 +204,7 @@ describe("StorageMeterService billable measurement", () => {
       expect(typeof query.mock.calls[0]![0].query_params.cutoff).toBe("string");
     });
 
+    /** @scenario Deletion lowers a later hour's measurement, never an earlier one */
     it("advances the cutoff for a later hour while an earlier hour's cutoff is unchanged", async () => {
       // The measurement at H depends only on (rows present, H): its cutoff is a
       // pure function of the sealed hour. A later hour scans a wider window
@@ -228,6 +234,8 @@ describe("StorageMeterService billable measurement", () => {
   });
 
   describe("given an organization whose projects hold only data within the free window", () => {
+    /** @scenario An organization with no old data measures zero */
+    /** @scenario A default-keep paid org bills zero by construction */
     it("measures zero", async () => {
       const { service } = makeService({
         projectIds: ["p1", "p2"],
@@ -244,6 +252,7 @@ describe("StorageMeterService billable measurement", () => {
   });
 
   describe("when one table query fails", () => {
+    /** @scenario A table query failure fails the measurement instead of silently undercounting */
     it("throws instead of returning a total that omits the failed tenant's bytes", async () => {
       const { service } = makeService({
         projectIds: ["p1", "p2"],
@@ -260,6 +269,7 @@ describe("StorageMeterService billable measurement", () => {
   });
 
   describe("when measuring billable bytes", () => {
+    /** @scenario The service returns raw logical bytes and leaves rounding to the caller */
     it("returns the raw logical byte count without rounding to MiB", async () => {
       const { service } = makeService({
         projectIds: ["p1"],

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -198,6 +198,33 @@ describe("StorageMeterService billable measurement", () => {
       );
       expect(typeof query.mock.calls[0]![0].query_params.cutoff).toBe("string");
     });
+
+    it("advances the cutoff for a later hour while an earlier hour's cutoff is unchanged", async () => {
+      // The measurement at H depends only on (rows present, H): its cutoff is a
+      // pure function of the sealed hour. A later hour scans a wider window
+      // (later cutoff), so retention deletion between the two can only lower the
+      // later measurement — it can never alter what was already measured at H.
+      const { service, query } = makeService({ projectIds: ["p1"] });
+      const laterHour = new Date(H.getTime() + 60 * 60 * 1000); // H + 1h
+
+      await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: H,
+      });
+      await service.getBillableStorageBytesForOrgAt({
+        organizationId: "org-A",
+        sealedHour: laterHour,
+      });
+
+      const [atH, atLater] = query.mock.calls.map(
+        ([call]) => call.query_params.cutoff,
+      );
+      expect(atH).toBe(EXPECTED_CUTOFF);
+      expect(atLater).toBe("2026-05-22 13:00:00");
+      expect(new Date(`${atLater}Z`).getTime()).toBeGreaterThan(
+        new Date(`${atH}Z`).getTime(),
+      );
+    });
   });
 
   describe("given an organization whose projects hold only data within the free window", () => {

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -112,7 +112,7 @@ describe("StorageMeterService billable measurement", () => {
       },
     );
     const client = { query } as const;
-    const resolveClient = vi.fn(async () => client as any);
+    const resolveClient = vi.fn(async (_tenantId: string) => client as any);
     const resolveProjectIds = vi.fn(
       async (orgId: string) => projectIdsByOrg?.[orgId] ?? projectIds ?? [],
     );

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { RETENTION_MANAGED_TABLES } from "../../retentionPolicy.schema";
 import { StorageMeterService } from "../storageMeter.service";
-import { RETENTION_MANAGED_TABLES } from "../../retentionPolicy.schema";
 
 /**
  * The metering reads sum a lazily-recomputed MATERIALIZED byteSize(...) column
@@ -90,23 +89,33 @@ describe("StorageMeterService billable measurement", () => {
 
   function makeService({
     projectIds,
+    projectIdsByOrg,
     perTenantBytes = () => "100",
     failOn,
   }: {
-    projectIds: string[];
+    projectIds?: string[];
+    projectIdsByOrg?: Record<string, string[]>;
     perTenantBytes?: (tenantId: string) => string;
     failOn?: string;
   }) {
-    const query = vi.fn(async (call: { query_params: { tenantId: string } }) => {
-      const tenantId = call.query_params.tenantId;
-      if (failOn && tenantId === failOn) {
-        throw new Error("ClickHouse query failed");
-      }
-      return { json: async () => [{ total: perTenantBytes(tenantId) }] };
-    });
+    const query = vi.fn(
+      async (call: {
+        query: string;
+        query_params: { tenantId: string; cutoff: string };
+        clickhouse_settings: Record<string, unknown>;
+      }) => {
+        const tenantId = call.query_params.tenantId;
+        if (failOn && tenantId === failOn) {
+          throw new Error("ClickHouse query failed");
+        }
+        return { json: async () => [{ total: perTenantBytes(tenantId) }] };
+      },
+    );
     const client = { query } as const;
     const resolveClient = vi.fn(async () => client as any);
-    const resolveProjectIds = vi.fn(async () => projectIds);
+    const resolveProjectIds = vi.fn(
+      async (orgId: string) => projectIdsByOrg?.[orgId] ?? projectIds ?? [],
+    );
     const service = new StorageMeterService(resolveClient, resolveProjectIds);
     return { service, query, resolveClient, resolveProjectIds };
   }
@@ -124,39 +133,28 @@ describe("StorageMeterService billable measurement", () => {
       });
 
       expect(total).toBe(300);
+      // One query per tenant, each routed to its own tenant-scoped client.
       expect(query).toHaveBeenCalledTimes(3);
-      expect(resolveClient.mock.calls.map(([id]) => id)).toEqual([
-        "p1",
-        "p2",
-        "p3",
-      ]);
+      expect(resolveClient.mock.calls.map(([id]) => id)).toEqual(
+        expect.arrayContaining(["p1", "p2", "p3"]),
+      );
     });
 
-    it("scopes every query to one of the organization's tenant ids, never another org's", async () => {
-      const { service, query } = makeService({ projectIds: ["p1", "p2"] });
+    it("measures only the target org's tenants, never another org's projects", async () => {
+      const { service, query } = makeService({
+        projectIdsByOrg: { "org-A": ["p1", "p2"], "org-B": ["p3"] },
+      });
 
       await service.getBillableStorageBytesForOrgAt({
         organizationId: "org-A",
         sealedHour: H,
       });
 
-      for (const [call] of query.mock.calls) {
-        expect(["p1", "p2"]).toContain(call.query_params.tenantId);
-      }
-    });
-
-    it("issues a separate per-tenant query, never a cross-tenant IN scan", async () => {
-      const { service, query } = makeService({ projectIds: ["p1", "p2"] });
-
-      await service.getBillableStorageBytesForOrgAt({
-        organizationId: "org-A",
-        sealedHour: H,
-      });
-
-      for (const [call] of query.mock.calls) {
-        expect(call.query).not.toMatch(/TenantId IN/i);
-        expect(call.query).toContain("TenantId = {tenantId:String}");
-      }
+      const queriedTenants = query.mock.calls.map(
+        ([call]) => call.query_params.tenantId,
+      );
+      expect(queriedTenants.sort()).toEqual(["p1", "p2"]);
+      expect(queriedTenants).not.toContain("p3");
     });
 
     it("caps each query's read streams and execution time so the size recompute can't exhaust memory", async () => {
@@ -170,19 +168,6 @@ describe("StorageMeterService billable measurement", () => {
       const settings = query.mock.calls[0]![0].clickhouse_settings;
       expect(settings.max_threads).toBe(2);
       expect(settings.max_execution_time).toBeGreaterThan(0);
-    });
-
-    it("pre-aggregates each managed table to a scalar inside the per-tenant query", async () => {
-      const { service, query } = makeService({ projectIds: ["p1"] });
-
-      await service.getBillableStorageBytesForOrgAt({
-        organizationId: "org-A",
-        sealedHour: H,
-      });
-
-      const sql = query.mock.calls[0]![0].query;
-      const perTable = sql.match(/sum\(_size_bytes\) AS t FROM/g) ?? [];
-      expect(perTable.length).toBe(RETENTION_MANAGED_TABLES.length);
     });
   });
 

--- a/langwatch/src/server/data-retention/metering/billableStorageQuery.ts
+++ b/langwatch/src/server/data-retention/metering/billableStorageQuery.ts
@@ -1,6 +1,6 @@
 import {
-  TABLE_TTL_CONFIG,
   buildRetentionAgeColumnExpression,
+  TABLE_TTL_CONFIG,
 } from "~/server/clickhouse/ttlReconciler";
 import { RETENTION_MANAGED_TABLES } from "../retentionPolicy.schema";
 

--- a/langwatch/src/server/data-retention/metering/billableStorageQuery.ts
+++ b/langwatch/src/server/data-retention/metering/billableStorageQuery.ts
@@ -1,0 +1,67 @@
+import {
+  TABLE_TTL_CONFIG,
+  buildRetentionAgeColumnExpression,
+} from "~/server/clickhouse/ttlReconciler";
+import { RETENTION_MANAGED_TABLES } from "../retentionPolicy.schema";
+
+/**
+ * Days of free storage a paid plan includes before storage billing accrues
+ * (ADR-027). 35 = 5 weeks, a clean `toYearWeek` partition boundary so the age
+ * cutoff prunes whole weekly partitions. A default-keep org deletes at the
+ * cutoff and therefore bills €0 by construction. The measurement is correct for
+ * any cutoff; this is the one named constant the pipeline anchors on.
+ */
+export const BILLABLE_AFTER_DAYS = 35;
+
+/**
+ * Per-managed-table age expression, sourced from the retention TTL config so the
+ * billing age predicate is byte-identical to the column the TTL DELETE ages on
+ * (e.g. `event_log` is epoch-millis → `toDateTime(EventOccurredAt / 1000)`).
+ * Reimplementing the conversion here would let billing diverge from deletion.
+ *
+ * Restricted to `RETENTION_MANAGED_TABLES`: `billable_events` carries no
+ * retention TTL column and is never part of the billable storage surface.
+ */
+export const BILLABLE_AGE_EXPR_BY_TABLE: Record<string, string> =
+  Object.fromEntries(
+    TABLE_TTL_CONFIG.filter((config) =>
+      (RETENTION_MANAGED_TABLES as readonly string[]).includes(config.table),
+    ).map((config) => {
+      const ageExpr = buildRetentionAgeColumnExpression(config);
+      if (!ageExpr) {
+        // Every managed table has a retention TTL column; this guards against a
+        // config drift where one loses it without updating the managed list.
+        throw new Error(
+          `Managed table "${config.table}" has no retention age column expression`,
+        );
+      }
+      return [config.table, ageExpr];
+    }),
+  );
+
+/**
+ * Builds the single per-tenant billable-storage query: each managed table is
+ * pre-aggregated to one scalar `sum(_size_bytes)` over rows older than the
+ * cutoff, all UNION ALL'd, then summed once in the outer query. Pre-aggregating
+ * per table keeps only the per-table scalars (not every row's `_size_bytes`) in
+ * the intermediate set — the heavy-payload `byteSize()` recompute that caused
+ * the prod OOMs never materializes across the union.
+ *
+ * Parameterized by `tenantId` (one tenant per query — never a cross-tenant
+ * `IN`) and `cutoff` (an explicit `DateTime('UTC')` so the boundary can't shift
+ * with the ClickHouse session timezone).
+ */
+export function buildBillableStorageQuery(
+  ageExprByTable: Record<string, string>,
+): string {
+  const unions = Object.entries(ageExprByTable)
+    .map(
+      ([table, ageExpr]) =>
+        `SELECT sum(_size_bytes) AS t FROM ${table}` +
+        ` WHERE TenantId = {tenantId:String}` +
+        ` AND ${ageExpr} <= {cutoff:DateTime('UTC')}`,
+    )
+    .join("\n  UNION ALL\n  ");
+
+  return `SELECT sum(t) AS total FROM (\n  ${unions}\n)`;
+}

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -1,4 +1,5 @@
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
+import { formatClickHouseDateTime } from "~/server/clickhouse/dateTime";
 import { TtlCache } from "~/server/utils/ttlCache";
 import { createLogger } from "~/utils/logger/server";
 import {
@@ -63,10 +64,11 @@ export type ProjectIdsResolver = (
   organizationId: string,
 ) => Promise<string[]>;
 
-/** `YYYY-MM-DD HH:MM:SS` in UTC for binding as a `DateTime('UTC')` param. */
-function formatClickHouseUtc(date: Date): string {
-  return date.toISOString().replace("T", " ").slice(0, 19);
-}
+// The per-tenant billable query is identical across orgs and hours (only its
+// params vary), so build it once at module load rather than per call.
+const BILLABLE_STORAGE_QUERY = buildBillableStorageQuery(
+  BILLABLE_AGE_EXPR_BY_TABLE,
+);
 
 interface StorageBreakdown {
   totalBytes: number;
@@ -76,6 +78,11 @@ interface StorageBreakdown {
 export class StorageMeterService {
   private readonly cache: TtlCache<number>;
 
+  /**
+   * @param resolveProjectIds required only by {@link getBillableStorageBytesForOrgAt}
+   *   (billing). The retention-UI reads work without it; the OSS construction
+   *   omits it because the billing path never runs there.
+   */
   constructor(
     private readonly resolveClickHouseClient: ClickHouseClientResolver | null,
     private readonly resolveProjectIds?: ProjectIdsResolver,
@@ -126,17 +133,22 @@ export class StorageMeterService {
     organizationId: string;
     sealedHour: Date;
   }): Promise<number> {
-    if (!this.resolveClickHouseClient) return 0;
-    if (!this.resolveProjectIds) {
+    if (!this.resolveClickHouseClient || !this.resolveProjectIds) {
+      // Billing requires both ClickHouse and the org→projects resolver. Unlike
+      // the retention-UI reads (which degrade to 0 in OSS), a billing read must
+      // never silently return 0 — that under-bills. The dispatcher only builds
+      // this on the SaaS path where both are present, so a miss is a misconfig.
       throw new Error(
-        "StorageMeterService: project-ids resolver not configured for billable measurement",
+        "StorageMeterService: billable measurement requires a ClickHouse client and a project-ids resolver",
       );
     }
 
-    const cutoff = formatClickHouseUtc(
+    // Second-precision UTC string bound as a DateTime('UTC') param — the column
+    // expression is DateTime, and the explicit type keeps the boundary from
+    // shifting with the ClickHouse session timezone.
+    const cutoff = formatClickHouseDateTime(
       new Date(sealedHour.getTime() - BILLABLE_AFTER_DAYS * 24 * 60 * 60 * 1000),
-    );
-    const query = buildBillableStorageQuery(BILLABLE_AGE_EXPR_BY_TABLE);
+    ).slice(0, 19);
 
     const projectIds = await this.resolveProjectIds(organizationId);
 
@@ -144,7 +156,7 @@ export class StorageMeterService {
     for (const tenantId of projectIds) {
       const client = await this.resolveClickHouseClient(tenantId);
       const result = await client.query({
-        query,
+        query: BILLABLE_STORAGE_QUERY,
         query_params: { tenantId, cutoff },
         format: "JSONEachRow",
         clickhouse_settings: BILLABLE_METERING_CLICKHOUSE_SETTINGS,

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -6,6 +6,11 @@ import {
   RETENTION_TABLE_CATEGORY_MAP,
   type RetentionCategory,
 } from "../retentionPolicy.schema";
+import {
+  BILLABLE_AFTER_DAYS,
+  BILLABLE_AGE_EXPR_BY_TABLE,
+  buildBillableStorageQuery,
+} from "./billableStorageQuery";
 
 const logger = createLogger("langwatch:data-retention:metering");
 
@@ -42,6 +47,27 @@ const METERING_CLICKHOUSE_SETTINGS = {
   max_execution_time: METERING_MAX_EXECUTION_SECONDS,
 } as const;
 
+// The billable measurement adds an age predicate, which forces a wider scan
+// than the cached total (notably `evaluation_runs`, whose retention column
+// `UpdatedAt` is not its partition key, so its predicate cannot prune). Keep the
+// `max_threads` memory cap and add an execution-time ceiling so a pathological
+// tenant query fails fast for the dispatcher to retry rather than hanging a
+// connection and starving the box.
+const BILLABLE_METERING_CLICKHOUSE_SETTINGS = {
+  ...METERING_CLICKHOUSE_SETTINGS,
+  max_execution_time: 45,
+} as const;
+
+/** Resolves an organization's project ids (its ClickHouse tenant ids). */
+export type ProjectIdsResolver = (
+  organizationId: string,
+) => Promise<string[]>;
+
+/** `YYYY-MM-DD HH:MM:SS` in UTC for binding as a `DateTime('UTC')` param. */
+function formatClickHouseUtc(date: Date): string {
+  return date.toISOString().replace("T", " ").slice(0, 19);
+}
+
 interface StorageBreakdown {
   totalBytes: number;
   byCategory: Record<RetentionCategory, number>;
@@ -52,6 +78,7 @@ export class StorageMeterService {
 
   constructor(
     private readonly resolveClickHouseClient: ClickHouseClientResolver | null,
+    private readonly resolveProjectIds?: ProjectIdsResolver,
   ) {
     this.cache = new TtlCache(CACHE_TTL_MS, "storage-meter:");
   }
@@ -71,6 +98,60 @@ export class StorageMeterService {
 
     const total = await this.queryTotalBytes(tenantId);
     await this.cache.set(tenantId, total);
+    return total;
+  }
+
+  /**
+   * Logical (uncompressed `_size_bytes`) stored bytes an organization holds
+   * that are older than the free window, as of a sealed hour `H` (never `now()`)
+   * — the billable storage surface for ADR-027.
+   *
+   * Anchored to `H`: the cutoff is `H − {@link BILLABLE_AFTER_DAYS}` days, bound
+   * as an explicit UTC value, so the result is reproducible regardless of when
+   * it runs or the ClickHouse session timezone. Summed across the org's projects
+   * one tenant-routed query at a time — never a cross-tenant `IN` scan, which
+   * multiplies the heavy `byteSize()` recompute buffer across tenants (the prod
+   * OOM vector).
+   *
+   * Correctness over availability: any tenant query failure throws. The bill
+   * must never silently omit a tenant's bytes; the caller (the reporting
+   * dispatcher) owns retry / skip / kill-switch.
+   *
+   * Returns raw bytes — the caller rounds to MiB.
+   */
+  async getBillableStorageBytesForOrgAt({
+    organizationId,
+    sealedHour,
+  }: {
+    organizationId: string;
+    sealedHour: Date;
+  }): Promise<number> {
+    if (!this.resolveClickHouseClient) return 0;
+    if (!this.resolveProjectIds) {
+      throw new Error(
+        "StorageMeterService: project-ids resolver not configured for billable measurement",
+      );
+    }
+
+    const cutoff = formatClickHouseUtc(
+      new Date(sealedHour.getTime() - BILLABLE_AFTER_DAYS * 24 * 60 * 60 * 1000),
+    );
+    const query = buildBillableStorageQuery(BILLABLE_AGE_EXPR_BY_TABLE);
+
+    const projectIds = await this.resolveProjectIds(organizationId);
+
+    let total = 0;
+    for (const tenantId of projectIds) {
+      const client = await this.resolveClickHouseClient(tenantId);
+      const result = await client.query({
+        query,
+        query_params: { tenantId, cutoff },
+        format: "JSONEachRow",
+        clickhouse_settings: BILLABLE_METERING_CLICKHOUSE_SETTINGS,
+      });
+      const rows = (await result.json()) as Array<{ total: string }>;
+      total += Number(rows[0]?.total ?? 0);
+    }
     return total;
   }
 

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -60,9 +60,7 @@ const BILLABLE_METERING_CLICKHOUSE_SETTINGS = {
 } as const;
 
 /** Resolves an organization's project ids (its ClickHouse tenant ids). */
-export type ProjectIdsResolver = (
-  organizationId: string,
-) => Promise<string[]>;
+export type ProjectIdsResolver = (organizationId: string) => Promise<string[]>;
 
 // The per-tenant billable query is identical across orgs and hours (only its
 // params vary), so build it once at module load rather than per call.
@@ -147,7 +145,9 @@ export class StorageMeterService {
     // expression is DateTime, and the explicit type keeps the boundary from
     // shifting with the ClickHouse session timezone.
     const cutoff = formatClickHouseDateTime(
-      new Date(sealedHour.getTime() - BILLABLE_AFTER_DAYS * 24 * 60 * 60 * 1000),
+      new Date(
+        sealedHour.getTime() - BILLABLE_AFTER_DAYS * 24 * 60 * 60 * 1000,
+      ),
     ).slice(0, 19);
 
     const projectIds = await this.resolveProjectIds(organizationId);

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -48,17 +48,6 @@ const METERING_CLICKHOUSE_SETTINGS = {
   max_execution_time: METERING_MAX_EXECUTION_SECONDS,
 } as const;
 
-// The billable measurement adds an age predicate, which forces a wider scan
-// than the cached total (notably `evaluation_runs`, whose retention column
-// `UpdatedAt` is not its partition key, so its predicate cannot prune). Keep the
-// `max_threads` memory cap and add an execution-time ceiling so a pathological
-// tenant query fails fast for the dispatcher to retry rather than hanging a
-// connection and starving the box.
-const BILLABLE_METERING_CLICKHOUSE_SETTINGS = {
-  ...METERING_CLICKHOUSE_SETTINGS,
-  max_execution_time: 45,
-} as const;
-
 /** Resolves an organization's project ids (its ClickHouse tenant ids). */
 export type ProjectIdsResolver = (organizationId: string) => Promise<string[]>;
 
@@ -155,11 +144,16 @@ export class StorageMeterService {
     let total = 0;
     for (const tenantId of projectIds) {
       const client = await this.resolveClickHouseClient(tenantId);
+      // Reuse the metering caps: `max_threads` bounds the `byteSize()` recompute
+      // and `max_execution_time` fails fast on the pathological scan (the age
+      // predicate widens it — notably `evaluation_runs`, whose retention column
+      // `UpdatedAt` is not its partition key, so it can't prune) rather than
+      // hanging a connection for the dispatcher.
       const result = await client.query({
         query: BILLABLE_STORAGE_QUERY,
         query_params: { tenantId, cutoff },
         format: "JSONEachRow",
-        clickhouse_settings: BILLABLE_METERING_CLICKHOUSE_SETTINGS,
+        clickhouse_settings: METERING_CLICKHOUSE_SETTINGS,
       });
       const rows = (await result.json()) as Array<{ total: string }>;
       total += Number(rows[0]?.total ?? 0);

--- a/specs/data-retention/storage-billing-measurement.feature
+++ b/specs/data-retention/storage-billing-measurement.feature
@@ -103,21 +103,26 @@ Feature: Billable stored-bytes measurement (ADR-027, Phase 2)
     Then the comparison uses the same column expression the TTL DELETE uses, sourced from the retention config
     So that billing can never diverge from deletion by reimplementing the conversion
 
-  # evaluation_runs is the one table whose partition key (ScheduledAt, nullable) differs from its
-  # retention/TTL column (UpdatedAt). We do NOT synthesize a ScheduledAt predicate from the UpdatedAt
-  # predicate — UpdatedAt <= cutoff does not imply ScheduledAt <= cutoff (ScheduledAt can be future or
-  # NULL), so such a predicate would silently drop rows from the bill.
+  # evaluation_runs is retention-anchored on UpdatedAt (the column the TTL DELETE ages on). Its
+  # PARTITION BY column is deliberately NOT relied upon: it differs across environments (schema drift,
+  # see issue #5209 — some report toYearWeek(UpdatedAt), some toYearWeek(ScheduledAt), with ScheduledAt
+  # nullable in at least one). So we filter ONLY on UpdatedAt and never synthesize a partition-key
+  # predicate to force pruning — UpdatedAt <= cutoff does not imply ScheduledAt <= cutoff (ScheduledAt
+  # can be future, and is nullable in some environments), so such a predicate would silently drop rows
+  # from the bill. Partition pruning is a best-effort side effect (it happens only where UpdatedAt is
+  # itself the partition key); billing correctness never depends on it.
   @unit
-  Scenario: A table whose partition key differs from its retention column is not pruned by an unsound predicate
-    Given the evaluation_runs table partitioned by ScheduledAt but retention-anchored on UpdatedAt
+  Scenario: The query filters only on the retention column, never on an assumed partition key
+    Given the evaluation_runs table retention-anchored on UpdatedAt with a partition key not guaranteed across environments
     When billable storage is measured as of H
     Then the query filters only on the UpdatedAt retention column
-    And no ScheduledAt predicate is synthesized that could exclude future-dated or NULL-ScheduledAt rows
+    And no predicate is synthesized on any other column that could exclude future-dated or NULL rows
 
   # KNOWN, ACCEPTED SEMANTIC (needs sign-off): evaluation_runs is billed on UpdatedAt, which is
   # mutable. A row re-written after creation resets its age and can fall back inside the free window.
   # This is the only column under which "billed iff still present" stays coherent with what TTL
-  # deletes (ScheduledAt/StartedAt are nullable and rejected by ClickHouse TTL).
+  # deletes: UpdatedAt is non-null and TTL-valid, whereas StartedAt (and ScheduledAt, in some
+  # environments — see #5209) is nullable and rejected by ClickHouse TTL.
   @unit
   Scenario: evaluation_runs bills on time-since-last-update, a documented limitation
     Given an evaluation_runs row older than the free window by creation but updated within the free window

--- a/specs/data-retention/storage-billing-measurement.feature
+++ b/specs/data-retention/storage-billing-measurement.feature
@@ -1,9 +1,3 @@
-# Spec introduced ahead of its implementation (the measurement lands in the
-# stacked PR that adds the binding tests). Until then every scenario is an
-# @unimplemented tracked gap so the feature-parity gate doesn't require bindings
-# that live on a later branch. The implementation PR removes this feature-level
-# tag and binds each scenario to a test.
-@unimplemented
 Feature: Billable stored-bytes measurement (ADR-027, Phase 2)
   As the storage-billing pipeline
   I want to measure the stored bytes an organization holds that are older than the free window, as of a sealed hour

--- a/specs/data-retention/storage-billing-measurement.feature
+++ b/specs/data-retention/storage-billing-measurement.feature
@@ -150,7 +150,9 @@ Feature: Billable stored-bytes measurement (ADR-027, Phase 2)
   # ReplacingMergeTree tables count every un-collapsed row version in a plain sum(_size_bytes), so a
   # churny tenant's un-merged duplicates over-bill. Billing — unlike the UI's degrade-to-0 display —
   # cannot silently over-count. The dedup-vs-OOM trade-off must be a decided, documented behaviour.
-  @integration
+  # @unimplemented: needs a real ClickHouse instance with un-merged parts; deferred to a dedicated
+  # integration test (see PR follow-ups). Tracked gap, not yet bound.
+  @integration @unimplemented
   Scenario: Un-merged duplicate row versions do not silently over-bill
     Given a table with un-merged duplicate versions of the same row
     When billable storage is measured as of H


### PR DESCRIPTION
## What

Phase 2 of ADR-027 (per-org stored-GiB-hours billing). Adds the **measurement** — the pure read computing how many logical bytes an org holds older than the free window, as of a sealed hour.

`StorageMeterService.getBillableStorageBytesForOrgAt({ organizationId, sealedHour })`:
- Cutoff = `sealedHour − 35 days` (`BILLABLE_AFTER_DAYS`), bound as an explicit `DateTime('UTC')` param — reproducible regardless of run time or ClickHouse session timezone.
- Sums across the org's projects **one tenant-routed query at a time** — never a cross-tenant `TenantId IN (...)` scan (that multiplies the heavy `byteSize()` recompute buffer across tenants — the two prod-OOM vector).
- Per-table pre-aggregation (`sum(_size_bytes)` per table, UNION ALL'd, summed once) keeps the OOM-prone payload recompute out of the intermediate set. Carries `max_threads: 2` + `max_execution_time: 45`.
- **Throws on any missing dependency or tenant-query failure** — never degrades to 0. The bill must never silently omit a tenant's bytes; the Phase 4 dispatcher owns retry/skip/kill-switch.
- Returns **raw bytes**; the caller rounds to MiB.

## Age correctness (billing can't drift from deletion)

Each table's age predicate is sourced from `TABLE_TTL_CONFIG` via the new shared `buildRetentionAgeColumnExpression`, which **both** the TTL DELETE clause and the billing predicate now use:
- `evaluation_runs` ages on `UpdatedAt` (its retention column), **no** synthesized `ScheduledAt` predicate — `UpdatedAt ≤ cutoff` does not imply `ScheduledAt ≤ cutoff` (nullable/future-dated), so such a predicate would silently drop rows from the bill. Accepted: a full-partition scan on this one table, bounded by the memory caps.
- `event_log` ages on `toDateTime(EventOccurredAt / 1000)` (epoch-ms), identical to its TTL.

## Documented limitations
- `evaluation_runs` bills on mutable `UpdatedAt` → a re-written old row resets its age (accepted under-bill; it's the only column coherent with "billed iff still present").
- Plain `sum(_size_bytes)` (not `FINAL`) → un-merged late-updated old row versions can briefly over-count, bounded and merge-collapsing; the Phase 4.5 tripwire monitors real drift.

## Scope boundary
Pure addition — **no behavior change** until the Phase 4 dispatcher calls this. The €0-by-default invariant only holds in prod once the **separate** retention-floor PR (49→35) ships; that's a go-live dependency, not a build dependency.

## Acceptance criteria → evidence

Spec: `specs/data-retention/storage-billing-measurement.feature`. Unit tests prove the query is *constructed* correctly (right column, cutoff, tenant scoping, settings, error handling); CH *evaluation* semantics are integration-verified (see Follow-ups).

| Scenario (feature) | Evidence |
|---|---|
| Data older than free window billable / within excluded | `billableStorageQuery` — every subquery carries `<ageExpr> <= {cutoff:DateTime('UTC')}` |
| Cutoff anchored to H, not now | `storageMeter.service` — cutoff == H−35d, independent of wall clock |
| Later hour advances cutoff; earlier unchanged (deletion lowers later only) | `storageMeter.service` — H+1h yields a later cutoff; H's is unchanged |
| Interpreted in UTC regardless of session tz | `storageMeter.service` — `{cutoff:DateTime('UTC')}` + string param |
| Org sums across all its projects | `storageMeter.service` — 3 ids → 3 queries, summed = 300 |
| Another org's data never included | `storageMeter.service` — org-A→{p1,p2}, org-B→{p3}; only p1,p2 queried |
| No old data → zero / default-keep paid org → zero | `storageMeter.service` — all subtotals 0 → total 0 |
| Each table aged by its retention/TTL column expression | `billableStorageQuery` — map sourced from `TABLE_TTL_CONFIG`, covers exactly the 11 managed tables |
| Age expr byte-identical to TTL DELETE | shared `buildRetentionAgeColumnExpression` used by both; `event_log` = `toDateTime(EventOccurredAt / 1000)` |
| eval_runs filters UpdatedAt, no synthesized ScheduledAt | `billableStorageQuery` — eval_runs subquery = `toDateTime(UpdatedAt) <=`, no `ScheduledAt` |
| Per-tenant, not cross-tenant IN; each table pre-aggregated; memory cap | `billableStorageQuery` (no `IN`, per-table scalar) + `storageMeter.service` (per-tenant queries, `max_threads:2`+`max_execution_time`) |
| Table query failure fails the measurement (no silent undercount) | `storageMeter.service` — one tenant throws → method throws |
| Returns raw logical bytes, no MiB rounding | `storageMeter.service` — 1572865 in → 1572865 out |

20 unit tests, all green. `pnpm typecheck` clean. Pre-existing ttlReconciler/retention TTL suites (47 tests) still green after the helper extraction.

## Follow-ups (not in this PR)
- **Runtime semantic verification** against warike CH (Tailscale): partition pruning on `stored_spans` (age col = partition key) and the bounded `evaluation_runs` full-scan; €0-default sanity — per the build plan's "Verification beyond unit".
- **`@integration` over-bill dedup** scenario (un-merged ReplacingMergeTree versions) — needs a real CH instance with un-merged parts; deferred to a dedicated integration test.
- **Module decoupling** — extract the pure `TABLE_TTL_CONFIG` + builders out of `ttlReconciler.ts` (which imports `@clickhouse/client`) into a dependency-free `ttlConfig.ts`, so the metering read path doesn't transitively depend on the DDL module. Only 2 consumers; deferred to keep this PR off the sensitive reconciler test surface.

Stacks on langwatch/langwatch#4832 (storage-billing schema).