### PR TITLE
fix(scenarios): require only the minimal input mapping to run

### DIFF
--- a/langwatch/src/components/agents/AgentCodeEditorDrawer.tsx
+++ b/langwatch/src/components/agents/AgentCodeEditorDrawer.tsx
@@ -18,7 +18,12 @@ import {
   OutputsSection,
   type OutputType,
 } from "~/components/outputs/OutputsSection";
+import {
+  isScenarioMappingValid,
+  ScenarioInputMappingSection,
+} from "~/components/suites/ScenarioInputMappingSection";
 import { Drawer } from "~/components/ui/drawer";
+import { toaster } from "~/components/ui/toaster";
 import {
   type AvailableSource,
   type FieldMapping,
@@ -33,7 +38,6 @@ import {
 } from "~/hooks/useDrawer";
 import { useLicenseEnforcement } from "~/hooks/useLicenseEnforcement";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import { toaster } from "~/components/ui/toaster";
 import { CodeEditorModal } from "~/optimization_studio/components/code/CodeEditorModal";
 import type {
   CodeComponentConfig,
@@ -43,10 +47,9 @@ import type {
   AgentComponentConfig,
   TypedAgent,
 } from "~/server/agents/agent.repository";
+import { computeBestMatchMappings } from "~/server/scenarios/execution/resolve-field-mappings";
 import { api } from "~/utils/api";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
-import { ScenarioInputMappingSection, isScenarioMappingValid } from "~/components/suites/ScenarioInputMappingSection";
-import { computeBestMatchMappings } from "~/server/scenarios/execution/resolve-field-mappings";
 
 const DEFAULT_CODE = `class Code:
     def __call__(self, input: str):
@@ -106,7 +109,8 @@ const buildCodeConfig = (
   ],
   inputs: inputs as CodeComponentConfig["inputs"],
   outputs: outputs as CodeComponentConfig["outputs"],
-  scenarioMappings: Object.keys(scenarioMappings).length > 0 ? scenarioMappings : undefined,
+  scenarioMappings:
+    Object.keys(scenarioMappings).length > 0 ? scenarioMappings : undefined,
   scenarioOutputField,
 });
 
@@ -171,8 +175,12 @@ export function AgentCodeEditorDrawer(props: AgentCodeEditorDrawerProps) {
   const [code, setCode] = useState(DEFAULT_CODE);
   const [inputs, setInputs] = useState<DSLField[]>(DEFAULT_INPUTS);
   const [outputs, setOutputs] = useState<DSLField[]>(DEFAULT_OUTPUTS);
-  const [scenarioMappings, setScenarioMappings] = useState<Record<string, FieldMapping>>({});
-  const [scenarioOutputField, setScenarioOutputField] = useState<string | undefined>(undefined);
+  const [scenarioMappings, setScenarioMappings] = useState<
+    Record<string, FieldMapping>
+  >({});
+  const [scenarioOutputField, setScenarioOutputField] = useState<
+    string | undefined
+  >(undefined);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
   // Track when code modal is open - we hide the drawer to avoid focus conflicts
@@ -195,16 +203,22 @@ export function AgentCodeEditorDrawer(props: AgentCodeEditorDrawerProps) {
       const agentInputs = getInputsFromConfig(agentQuery.data.config);
       setInputs(agentInputs);
       setOutputs(getOutputsFromConfig(agentQuery.data.config));
-      const existingMappings = (agentQuery.data.config as CodeComponentConfig).scenarioMappings ?? {};
+      const existingMappings =
+        (agentQuery.data.config as CodeComponentConfig).scenarioMappings ?? {};
       // If no saved mappings, compute best-match defaults from input names
-      const effectiveInputs = agentInputs.length > 0
-        ? agentInputs
-        : [{ identifier: "input", type: "str" }];
-      const mappings = Object.keys(existingMappings).length > 0
-        ? existingMappings
-        : computeBestMatchMappings({ inputs: effectiveInputs });
+      const effectiveInputs =
+        agentInputs.length > 0
+          ? agentInputs
+          : [{ identifier: "input", type: "str" }];
+      const mappings =
+        Object.keys(existingMappings).length > 0
+          ? existingMappings
+          : computeBestMatchMappings({ inputs: effectiveInputs });
       setScenarioMappings(mappings);
-      setScenarioOutputField((agentQuery.data.config as CodeComponentConfig).scenarioOutputField ?? undefined);
+      setScenarioOutputField(
+        (agentQuery.data.config as CodeComponentConfig).scenarioOutputField ??
+          undefined,
+      );
       setHasUnsavedChanges(false);
     } else if (!agentId) {
       // Reset form for new agent — compute best-match from default inputs
@@ -248,13 +262,21 @@ export function AgentCodeEditorDrawer(props: AgentCodeEditorDrawerProps) {
   });
 
   const isSaving = createMutation.isPending || updateMutation.isPending;
-  const isValid = name.trim().length > 0 && isScenarioMappingValid({ mappings: scenarioMappings });
+  const isValid =
+    name.trim().length > 0 &&
+    isScenarioMappingValid({ mappings: scenarioMappings });
 
   const handleSave = useCallback(() => {
     if (!project?.id || !isValid) return;
 
     // Build DSL-compatible config with current inputs/outputs/scenarioMappings/scenarioOutputField
-    const config = buildCodeConfig(code, inputs, outputs, scenarioMappings, scenarioOutputField);
+    const config = buildCodeConfig(
+      code,
+      inputs,
+      outputs,
+      scenarioMappings,
+      scenarioOutputField,
+    );
 
     if (agentId) {
       // Editing existing agent - no limit check needed
@@ -309,9 +331,10 @@ export function AgentCodeEditorDrawer(props: AgentCodeEditorDrawerProps) {
     setInputs(newInputs);
     // Recompute best-match for any new inputs that don't already have a mapping
     setScenarioMappings((prev) => {
-      const effectiveInputs = newInputs.length > 0
-        ? newInputs
-        : [{ identifier: "input", type: "str" }];
+      const effectiveInputs =
+        newInputs.length > 0
+          ? newInputs
+          : [{ identifier: "input", type: "str" }];
       const bestMatch = computeBestMatchMappings({ inputs: effectiveInputs });
       const merged = { ...prev };
       for (const inp of effectiveInputs) {
@@ -385,9 +408,10 @@ export function AgentCodeEditorDrawer(props: AgentCodeEditorDrawerProps) {
 
   // For scenario mappings, mirror the backend's implicit input fallback
   // (code-agent.adapter.ts synthesizes { identifier: "input", type: "str" } when inputs is empty)
-  const scenarioInputsForUI: Variable[] = variablesForUI.length > 0
-    ? variablesForUI
-    : [{ identifier: "input", type: "str" }];
+  const scenarioInputsForUI: Variable[] =
+    variablesForUI.length > 0
+      ? variablesForUI
+      : [{ identifier: "input", type: "str" }];
 
   // Convert DSL outputs to Output[] for OutputsSection
   const outputsForUI: Output[] = outputs.map((output) => ({

--- a/langwatch/src/components/agents/AgentCodeEditorDrawer.tsx
+++ b/langwatch/src/components/agents/AgentCodeEditorDrawer.tsx
@@ -248,7 +248,7 @@ export function AgentCodeEditorDrawer(props: AgentCodeEditorDrawerProps) {
   });
 
   const isSaving = createMutation.isPending || updateMutation.isPending;
-  const isValid = name.trim().length > 0 && isScenarioMappingValid({ mappings: scenarioMappings, outputs, outputField: scenarioOutputField });
+  const isValid = name.trim().length > 0 && isScenarioMappingValid({ mappings: scenarioMappings });
 
   const handleSave = useCallback(() => {
     if (!project?.id || !isValid) return;

--- a/langwatch/src/components/agents/AgentHttpEditorDrawer.tsx
+++ b/langwatch/src/components/agents/AgentHttpEditorDrawer.tsx
@@ -369,20 +369,11 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
   });
 
   const isSaving = createMutation.isPending || updateMutation.isPending;
-  // For HTTP agents the scenario output is always the HTTP response body,
-  // so we synthesize a single virtual "output" field and skip the output-field
-  // picker. The ScenarioInputMappingSection still renders its read-only row.
-  const httpScenarioOutputs: Variable[] = useMemo(
-    () => [{ identifier: "output", type: "str" }],
-    [],
-  );
   const isValid =
     (name?.trim().length ?? 0) > 0 &&
     (url?.trim().length ?? 0) > 0 &&
     isScenarioMappingValid({
       mappings: scenarioMappings,
-      outputs: httpScenarioOutputs,
-      outputField: undefined,
     });
 
   const handleSave = useCallback(() => {

--- a/langwatch/src/components/agents/AgentWorkflowEditorDrawer.tsx
+++ b/langwatch/src/components/agents/AgentWorkflowEditorDrawer.tsx
@@ -218,8 +218,6 @@ export function AgentWorkflowEditorDrawer(
     workflowOutputs.length > 0 &&
     isScenarioMappingValid({
       mappings: scenarioMappings,
-      outputs: workflowOutputs,
-      outputField: scenarioOutputField,
     });
 
   const handleSave = useCallback(() => {

--- a/langwatch/src/components/agents/__tests__/AgentCodeEditorDrawer.save-gate.integration.test.tsx
+++ b/langwatch/src/components/agents/__tests__/AgentCodeEditorDrawer.save-gate.integration.test.tsx
@@ -26,12 +26,13 @@
  *
  * @see specs/features/scenarios/minimal-input-mapping.feature
  */
-import type React from "react";
+
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AgentCodeEditorDrawer } from "../AgentCodeEditorDrawer";
 import type { ScenarioInputMappingSectionProps } from "~/components/suites/ScenarioInputMappingSection";
+import { AgentCodeEditorDrawer } from "../AgentCodeEditorDrawer";
 
 // ── Hoisted mock state ────────────────────────────────────────────────────────
 
@@ -194,7 +195,8 @@ const CODE_AGENT_INPUT_MAPPED_OUTPUT_CLEARED = {
       {
         identifier: "code",
         type: "code",
-        value: "class Code:\n    def __call__(self, userQuery: str):\n        return {'response': userQuery}",
+        value:
+          "class Code:\n    def __call__(self, userQuery: str):\n        return {'response': userQuery}",
       },
     ],
     inputs: [{ identifier: "userQuery", type: "str" }],
@@ -230,7 +232,8 @@ const CODE_AGENT_NO_INPUT_MAPPING = {
       {
         identifier: "code",
         type: "code",
-        value: "class Code:\n    def __call__(self, sessionId: str):\n        return {'response': sessionId}",
+        value:
+          "class Code:\n    def __call__(self, sessionId: str):\n        return {'response': sessionId}",
       },
     ],
     inputs: [{ identifier: "sessionId", type: "str" }],
@@ -257,10 +260,9 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 function renderDrawer(agentId: string) {
-  return render(
-    <AgentCodeEditorDrawer open={true} agentId={agentId} />,
-    { wrapper: Wrapper },
-  );
+  return render(<AgentCodeEditorDrawer open={true} agentId={agentId} />, {
+    wrapper: Wrapper,
+  });
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -276,26 +278,12 @@ describe("AgentCodeEditorDrawer save gate", () => {
     });
 
     describe("when the drawer renders with the pre-saved config", () => {
-      /**
-       * @scenario Save code agent when output mapping is cleared but input mapping present
-       *
-       * FAILS current code:
-       *   isScenarioMappingValid checks hasOutputMapping = hasOutputs && outputField !== ""
-       *   outputs = [{ identifier: "response" }] → hasOutputs = true
-       *   outputField = "" → "" !== "" = false → hasOutputMapping = false
-       *   isValid = false → button disabled
-       *
-       * After fix (isScenarioMappingValid drops && hasOutputMapping):
-       *   isScenarioMappingValid returns hasScenarioInputMapping(mappings) = true
-       *   isValid = true → button enabled
-       */
+      /** @scenario Save code agent when output mapping is cleared but input mapping present */
       it("enables the Save Changes button", async () => {
         renderDrawer("code-agent-cleared");
 
         await waitFor(() => {
-          expect(
-            screen.getByTestId("save-agent-button"),
-          ).not.toBeDisabled();
+          expect(screen.getByTestId("save-agent-button")).not.toBeDisabled();
         });
       });
     });
@@ -308,11 +296,7 @@ describe("AgentCodeEditorDrawer save gate", () => {
     });
 
     describe("when the drawer renders with threadId-only mapping", () => {
-      /**
-       * No "input" or "messages" source mapping → hasScenarioInputMapping = false
-       * → isScenarioMappingValid = false → Save disabled.
-       * Green both before and after the fix — fail-closed preserved.
-       */
+      /** @scenario Save code agent stays blocked when no input mapping is configured */
       it("keeps the Save Changes button disabled", async () => {
         renderDrawer("code-agent-no-input");
 

--- a/langwatch/src/components/agents/__tests__/AgentCodeEditorDrawer.save-gate.integration.test.tsx
+++ b/langwatch/src/components/agents/__tests__/AgentCodeEditorDrawer.save-gate.integration.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for AgentCodeEditorDrawer Save gate — Issue #3412
+ *
+ * AgentCodeEditorDrawer.tsx:251 computes:
+ *   isValid = name.trim().length > 0 &&
+ *             isScenarioMappingValid({ mappings, outputs, outputField })
+ *
+ * There is NO structural workflowOutputs.length guard here — the code agent
+ * always has its own outputs declared in state (DEFAULT_OUTPUTS or loaded from
+ * config). The only gate is isScenarioMappingValid.
+ *
+ * After the fix (isScenarioMappingValid drops && hasOutputMapping), a code agent
+ * with a valid input mapping must be saveable even when the user has explicitly
+ * cleared the output-field selection (scenarioOutputField = "").
+ *
+ * Test matrix:
+ *   (a) RED→GREEN  — valid input mapping + outputs present + outputField
+ *                    explicitly cleared ("") → Save ENABLED after fix
+ *   (b) FAIL-CLOSED — only threadId mapped (no input/messages) → Save stays
+ *                    DISABLED (fail-closed preserved)
+ *
+ * Uses the real isScenarioMappingValid / hasScenarioInputMapping via
+ * importOriginal so the tests actually exercise the predicate change.
+ *
+ * @see specs/features/scenarios/minimal-input-mapping.feature
+ */
+import type React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentCodeEditorDrawer } from "../AgentCodeEditorDrawer";
+import type { ScenarioInputMappingSectionProps } from "~/components/suites/ScenarioInputMappingSection";
+
+// ── Hoisted mock state ────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  agentData: null as Record<string, unknown> | null,
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    query: { project: "test-project" },
+    asPath: "/test",
+  }),
+}));
+
+vi.mock("~/utils/auth-client", () => ({
+  useSession: () => ({
+    data: { user: { id: "test-user" } },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "test-project", slug: "test-project" },
+    organization: { id: "test-org" },
+    team: null,
+  }),
+}));
+
+vi.mock("~/hooks/useLicenseEnforcement", () => ({
+  useLicenseEnforcement: () => ({
+    checkAndProceed: (callback: () => void) => callback(),
+    isLoading: false,
+    isAllowed: true,
+    limitInfo: { allowed: true, current: 0, max: 10 },
+  }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: vi.fn(),
+    openDrawer: vi.fn(),
+    drawerOpen: vi.fn(() => false),
+    canGoBack: false,
+    goBack: vi.fn(),
+  }),
+  useDrawerParams: () => ({}),
+  getComplexProps: () => ({}),
+  getFlowCallbacks: () => ({}),
+}));
+
+vi.mock("~/optimization_studio/components/code/CodeEditorModal", () => ({
+  CodeEditor: () => null,
+  CodeEditorModal: () => null,
+}));
+
+vi.mock("~/components/blocks/CodeBlockEditor", () => ({
+  CodeBlockEditor: ({
+    code,
+    onChange,
+  }: {
+    code: string;
+    onChange: (code: string) => void;
+  }) => (
+    <div data-testid="code-editor">
+      <textarea
+        data-testid="code-textarea"
+        value={code}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  ),
+}));
+
+// Partial mock: stub the heavy React component but keep the real
+// isScenarioMappingValid / hasScenarioInputMapping so the save-gate tests
+// exercise the actual predicate, not a mock.
+vi.mock(
+  "~/components/suites/ScenarioInputMappingSection",
+  async (importOriginal) => {
+    const mod =
+      await importOriginal<
+        typeof import("~/components/suites/ScenarioInputMappingSection")
+      >();
+    return {
+      ...mod,
+      ScenarioInputMappingSection: ({
+        inputs,
+      }: ScenarioInputMappingSectionProps) => (
+        <div data-testid="scenario-mapping-section">
+          {inputs.map((i) => (
+            <div
+              key={i.identifier}
+              data-testid={`scenario-mapping-input-${i.identifier}`}
+            >
+              {i.identifier}
+            </div>
+          ))}
+        </div>
+      ),
+    };
+  },
+);
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    agents: {
+      getById: {
+        useQuery: (_input: unknown, options?: { enabled?: boolean }) => {
+          if (options?.enabled === false) {
+            return { data: undefined, isLoading: false, error: null };
+          }
+          return { data: mocks.agentData, isLoading: false, error: null };
+        },
+      },
+      create: {
+        useMutation: () => ({
+          mutateAsync: vi.fn().mockResolvedValue({ id: "new-agent-id" }),
+          isPending: false,
+        }),
+      },
+      update: {
+        useMutation: () => ({
+          mutateAsync: vi.fn().mockResolvedValue({}),
+          isPending: false,
+        }),
+      },
+    },
+    useContext: () => ({
+      agents: {
+        getAll: { invalidate: vi.fn() },
+        getById: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+// ── Agent fixtures ────────────────────────────────────────────────────────────
+
+/**
+ * Code agent with a valid input mapping (userQuery → input), outputs present,
+ * but scenarioOutputField explicitly cleared ("").
+ *
+ * RED case: isScenarioMappingValid returns false now because
+ *   hasOutputMapping = (outputs.length > 0) && "" !== "" = false
+ * After fix: returns hasScenarioInputMapping(mappings) = true → Save enabled.
+ */
+const CODE_AGENT_INPUT_MAPPED_OUTPUT_CLEARED = {
+  id: "code-agent-cleared",
+  name: "Code Agent Cleared Output",
+  type: "code" as const,
+  projectId: "test-project",
+  config: {
+    name: "Code",
+    description: "Python code block",
+    parameters: [
+      {
+        identifier: "code",
+        type: "code",
+        value: "class Code:\n    def __call__(self, userQuery: str):\n        return {'response': userQuery}",
+      },
+    ],
+    inputs: [{ identifier: "userQuery", type: "str" }],
+    outputs: [{ identifier: "response", type: "str" }],
+    scenarioMappings: {
+      userQuery: {
+        type: "source" as const,
+        sourceId: "scenario",
+        path: ["input"],
+      },
+    },
+    scenarioOutputField: "", // explicitly cleared by user
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  description: null,
+  copiedFromAgentId: null,
+};
+
+/**
+ * Code agent where the mapping does NOT wire "input" or "messages" — only
+ * threadId. hasScenarioInputMapping returns false for this config.
+ */
+const CODE_AGENT_NO_INPUT_MAPPING = {
+  id: "code-agent-no-input",
+  name: "Code Agent No Input Mapping",
+  type: "code" as const,
+  projectId: "test-project",
+  config: {
+    name: "Code",
+    description: "Python code block",
+    parameters: [
+      {
+        identifier: "code",
+        type: "code",
+        value: "class Code:\n    def __call__(self, sessionId: str):\n        return {'response': sessionId}",
+      },
+    ],
+    inputs: [{ identifier: "sessionId", type: "str" }],
+    outputs: [{ identifier: "response", type: "str" }],
+    scenarioMappings: {
+      sessionId: {
+        type: "source" as const,
+        sourceId: "scenario",
+        path: ["threadId"], // threadId only — not "input" or "messages"
+      },
+    },
+    scenarioOutputField: "response",
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  description: null,
+  copiedFromAgentId: null,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function renderDrawer(agentId: string) {
+  return render(
+    <AgentCodeEditorDrawer open={true} agentId={agentId} />,
+    { wrapper: Wrapper },
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("AgentCodeEditorDrawer save gate", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(cleanup);
+
+  // (a) RED → GREEN ────────────────────────────────────────────────────────────
+  describe("given a code agent with a valid input mapping but outputField explicitly cleared", () => {
+    beforeEach(() => {
+      mocks.agentData = CODE_AGENT_INPUT_MAPPED_OUTPUT_CLEARED;
+    });
+
+    describe("when the drawer renders with the pre-saved config", () => {
+      /**
+       * @scenario Save code agent when output mapping is cleared but input mapping present
+       *
+       * FAILS current code:
+       *   isScenarioMappingValid checks hasOutputMapping = hasOutputs && outputField !== ""
+       *   outputs = [{ identifier: "response" }] → hasOutputs = true
+       *   outputField = "" → "" !== "" = false → hasOutputMapping = false
+       *   isValid = false → button disabled
+       *
+       * After fix (isScenarioMappingValid drops && hasOutputMapping):
+       *   isScenarioMappingValid returns hasScenarioInputMapping(mappings) = true
+       *   isValid = true → button enabled
+       */
+      it("enables the Save Changes button", async () => {
+        renderDrawer("code-agent-cleared");
+
+        await waitFor(() => {
+          expect(
+            screen.getByTestId("save-agent-button"),
+          ).not.toBeDisabled();
+        });
+      });
+    });
+  });
+
+  // (b) FAIL-CLOSED ─────────────────────────────────────────────────────────────
+  describe("given a code agent with no input-field mapping", () => {
+    beforeEach(() => {
+      mocks.agentData = CODE_AGENT_NO_INPUT_MAPPING;
+    });
+
+    describe("when the drawer renders with threadId-only mapping", () => {
+      /**
+       * No "input" or "messages" source mapping → hasScenarioInputMapping = false
+       * → isScenarioMappingValid = false → Save disabled.
+       * Green both before and after the fix — fail-closed preserved.
+       */
+      it("keeps the Save Changes button disabled", async () => {
+        renderDrawer("code-agent-no-input");
+
+        await waitFor(() => {
+          expect(screen.getByTestId("save-agent-button")).toBeDisabled();
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/components/agents/__tests__/AgentCodeEditorDrawer.save-gate.integration.test.tsx
+++ b/langwatch/src/components/agents/__tests__/AgentCodeEditorDrawer.save-gate.integration.test.tsx
@@ -3,9 +3,9 @@
  *
  * Integration tests for AgentCodeEditorDrawer Save gate — Issue #3412
  *
- * AgentCodeEditorDrawer.tsx:251 computes:
+ * AgentCodeEditorDrawer.tsx computes:
  *   isValid = name.trim().length > 0 &&
- *             isScenarioMappingValid({ mappings, outputs, outputField })
+ *             isScenarioMappingValid({ mappings: scenarioMappings })
  *
  * There is NO structural workflowOutputs.length guard here — the code agent
  * always has its own outputs declared in state (DEFAULT_OUTPUTS or loaded from

--- a/langwatch/src/components/agents/__tests__/AgentWorkflowEditorDrawer.save-gate.integration.test.tsx
+++ b/langwatch/src/components/agents/__tests__/AgentWorkflowEditorDrawer.save-gate.integration.test.tsx
@@ -1,0 +1,448 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for AgentWorkflowEditorDrawer Save gate — Issue #3412
+ *
+ * The ONLY source change is in isScenarioMappingValid: the `&& hasOutputMapping`
+ * conjunction is dropped so the function returns true whenever a valid input
+ * mapping is present, regardless of whether an output mapping has been selected.
+ *
+ * The structural guards `workflowInputs.length > 0` and
+ * `workflowOutputs.length > 0` in AgentWorkflowEditorDrawer.tsx:215-223 STAY.
+ * `workflowOutputs` derives from the published workflow's end-node inputs
+ * (extractVariables). Length === 0 means the workflow structurally emits
+ * nothing; enabling Save there would start a run judged on "{}". That gate is
+ * load-bearing and must remain.
+ *
+ * Test matrix:
+ *   (a) RED→GREEN  — workflow WITH end outputs + input mapping + outputField
+ *                    explicitly cleared ("") → Save ENABLED after fix
+ *   (b) REGRESSION — workflow WITHOUT end outputs + input mapping → Save stays
+ *                    DISABLED (structural guard must not be relaxed)
+ *   (c) FAIL-CLOSED — workflow WITH outputs + no input/messages mapping
+ *                    → Save stays DISABLED (fail-closed preserved)
+ *
+ * Uses the real isScenarioMappingValid / hasScenarioInputMapping via
+ * importOriginal so the tests actually exercise the predicate change.
+ *
+ * @see specs/features/scenarios/minimal-input-mapping.feature
+ */
+import type React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentWorkflowEditorDrawer } from "../AgentWorkflowEditorDrawer";
+import type { ScenarioInputMappingSectionProps } from "~/components/suites/ScenarioInputMappingSection";
+
+// ── Hoisted mock state ────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  agentData: null as Record<string, unknown> | null,
+  workflowData: null as Record<string, unknown> | null,
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    query: { project: "test-project" },
+    asPath: "/test",
+  }),
+}));
+
+vi.mock("~/utils/auth-client", () => ({
+  useSession: () => ({
+    data: { user: { id: "test-user" } },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "test-project", slug: "test-project" },
+    organization: { id: "test-org" },
+    team: null,
+  }),
+}));
+
+vi.mock("~/hooks/useLicenseEnforcement", () => ({
+  useLicenseEnforcement: () => ({
+    checkAndProceed: (callback: () => void) => callback(),
+    isLoading: false,
+    isAllowed: true,
+    limitInfo: { allowed: true, current: 0, max: 10 },
+  }),
+}));
+
+vi.mock("~/utils/compat/next-link", () => ({
+  default: ({
+    href,
+    children,
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: vi.fn(),
+    openDrawer: vi.fn(),
+    drawerOpen: vi.fn(() => false),
+    canGoBack: false,
+    goBack: vi.fn(),
+  }),
+  useDrawerParams: () => ({}),
+  getComplexProps: () => ({}),
+  getFlowCallbacks: () => ({}),
+}));
+
+// Partial mock: stub the heavy React component but keep the real
+// isScenarioMappingValid / hasScenarioInputMapping so the save-gate tests
+// exercise the actual predicate, not a mock.
+vi.mock(
+  "~/components/suites/ScenarioInputMappingSection",
+  async (importOriginal) => {
+    const mod =
+      await importOriginal<
+        typeof import("~/components/suites/ScenarioInputMappingSection")
+      >();
+    return {
+      ...mod,
+      ScenarioInputMappingSection: ({
+        inputs,
+      }: ScenarioInputMappingSectionProps) => (
+        <div data-testid="scenario-mapping-section">
+          {inputs.map((i) => (
+            <div
+              key={i.identifier}
+              data-testid={`scenario-mapping-input-${i.identifier}`}
+            >
+              {i.identifier}
+            </div>
+          ))}
+        </div>
+      ),
+    };
+  },
+);
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    agents: {
+      getById: {
+        useQuery: (_input: unknown, options?: { enabled?: boolean }) => {
+          if (options?.enabled === false) {
+            return { data: undefined, isLoading: false, error: null };
+          }
+          return { data: mocks.agentData, isLoading: false, error: null };
+        },
+      },
+      update: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          isPending: false,
+        }),
+      },
+    },
+    workflow: {
+      getById: {
+        useQuery: (_input: unknown, options?: { enabled?: boolean }) => {
+          if (options?.enabled === false) {
+            return { data: undefined, isLoading: false, error: null };
+          }
+          return { data: mocks.workflowData, isLoading: false, error: null };
+        },
+      },
+    },
+    useContext: () => ({
+      agents: {
+        getAll: { invalidate: vi.fn() },
+        getById: { invalidate: vi.fn() },
+      },
+      workflow: {
+        getById: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+// ── DSL fixtures ──────────────────────────────────────────────────────────────
+
+/**
+ * Workflow with one entry output and one end-node input.
+ * getMappingSurfaceInputs → [{identifier:"userMessage"}]
+ * workflowOutputs → [{identifier:"response"}]  (structural guard passes)
+ */
+const DSL_WITH_OUTPUTS = {
+  spec_version: "1.4" as const,
+  name: "Full Workflow",
+  icon: "🔧",
+  description: "",
+  version: "1",
+  default_llm: { model: "openai/gpt-5-mini", temperature: 0 },
+  template_adapter: "default" as const,
+  enable_tracing: false,
+  state: {},
+  nodes: [
+    {
+      id: "entry",
+      type: "entry",
+      position: { x: 0, y: 0 },
+      data: {
+        name: "Entry",
+        outputs: [{ identifier: "userMessage", type: "str" }],
+      },
+    },
+    {
+      id: "end",
+      type: "end",
+      position: { x: 400, y: 0 },
+      data: {
+        name: "End",
+        inputs: [{ identifier: "response", type: "str" }],
+      },
+    },
+  ],
+  edges: [],
+};
+
+/**
+ * Workflow with one entry output and NO end-node inputs.
+ * workflowOutputs → []  (structural guard blocks Save regardless of mapping)
+ */
+const DSL_INPUTS_NO_OUTPUTS = {
+  spec_version: "1.4" as const,
+  name: "Inputs-Only Workflow",
+  icon: "🔧",
+  description: "",
+  version: "1",
+  default_llm: { model: "openai/gpt-5-mini", temperature: 0 },
+  template_adapter: "default" as const,
+  enable_tracing: false,
+  state: {},
+  nodes: [
+    {
+      id: "entry",
+      type: "entry",
+      position: { x: 0, y: 0 },
+      data: {
+        name: "Entry",
+        outputs: [{ identifier: "userMessage", type: "str" }],
+      },
+    },
+    {
+      id: "end",
+      type: "end",
+      position: { x: 400, y: 0 },
+      data: {
+        name: "End",
+        inputs: [], // no workflow outputs
+      },
+    },
+  ],
+  edges: [],
+};
+
+// ── Agent fixtures ────────────────────────────────────────────────────────────
+
+/**
+ * Valid input mapping (userMessage → input) but scenarioOutputField is
+ * explicitly cleared (""). The structural guard passes (workflow HAS outputs).
+ *
+ * RED case: isScenarioMappingValid returns false now because
+ *   hasOutputMapping = (outputs.length > 0) && "" !== "" = false
+ * After fix: returns hasScenarioInputMapping(mappings) = true → Save enabled.
+ */
+const AGENT_INPUT_MAPPING_CLEARED_OUTPUT = {
+  id: "agent-cleared-output",
+  name: "Cleared Output Agent",
+  type: "workflow" as const,
+  projectId: "test-project",
+  workflowId: "workflow-with-outputs",
+  config: {
+    workflow_id: "workflow-with-outputs",
+    scenarioMappings: {
+      userMessage: {
+        type: "source" as const,
+        sourceId: "scenario",
+        path: ["input"],
+      },
+    },
+    scenarioOutputField: "", // explicitly cleared by user
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  description: null,
+  copiedFromAgentId: null,
+};
+
+/**
+ * Valid input mapping but the workflow has no end-node outputs.
+ * workflowOutputs = [] → structural guard blocks Save.
+ * Must remain DISABLED after the fix.
+ */
+const AGENT_INPUT_MAPPING_NO_WORKFLOW_OUTPUTS = {
+  id: "agent-no-wf-outputs",
+  name: "No Workflow Outputs Agent",
+  type: "workflow" as const,
+  projectId: "test-project",
+  workflowId: "workflow-no-outputs",
+  config: {
+    workflow_id: "workflow-no-outputs",
+    scenarioMappings: {
+      userMessage: {
+        type: "source" as const,
+        sourceId: "scenario",
+        path: ["input"],
+      },
+    },
+    // No scenarioOutputField
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  description: null,
+  copiedFromAgentId: null,
+};
+
+/**
+ * Only threadId mapped — hasScenarioInputMapping returns false.
+ * Workflow has outputs (structural guard passes), but input gate blocks Save.
+ */
+const AGENT_NO_INPUT_MAPPING = {
+  id: "agent-no-input",
+  name: "ThreadId-Only Agent",
+  type: "workflow" as const,
+  projectId: "test-project",
+  workflowId: "workflow-with-outputs",
+  config: {
+    workflow_id: "workflow-with-outputs",
+    scenarioMappings: {
+      sessionId: {
+        type: "source" as const,
+        sourceId: "scenario",
+        path: ["threadId"], // threadId only — not "input" or "messages"
+      },
+    },
+    scenarioOutputField: "response",
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  description: null,
+  copiedFromAgentId: null,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function renderDrawer(agentId: string) {
+  return render(
+    <AgentWorkflowEditorDrawer open={true} agentId={agentId} />,
+    { wrapper: Wrapper },
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("AgentWorkflowEditorDrawer save gate", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(cleanup);
+
+  // (a) RED → GREEN ────────────────────────────────────────────────────────────
+  describe("given a workflow with outputs and a valid input mapping but outputField explicitly cleared", () => {
+    beforeEach(() => {
+      mocks.agentData = AGENT_INPUT_MAPPING_CLEARED_OUTPUT;
+      mocks.workflowData = {
+        id: "workflow-with-outputs",
+        name: "Full Workflow",
+        projectId: "test-project",
+        currentVersion: { id: "v1", dsl: DSL_WITH_OUTPUTS },
+      };
+    });
+
+    describe("when the drawer renders with the pre-saved config", () => {
+      /**
+       * @scenario Save workflow agent when output mapping is cleared but input mapping present
+       *
+       * FAILS current code:
+       *   isScenarioMappingValid checks hasOutputMapping = hasOutputs && outputField !== ""
+       *   outputField = "" → hasOutputMapping = false → isValid = false → button disabled
+       *
+       * After fix (isScenarioMappingValid drops && hasOutputMapping):
+       *   isScenarioMappingValid returns hasScenarioInputMapping(mappings) = true
+       *   workflowOutputs.length > 0 = true (structural guard passes)
+       *   isValid = true → button enabled
+       */
+      it("enables the Save Changes button", async () => {
+        renderDrawer("agent-cleared-output");
+
+        await waitFor(() => {
+          expect(
+            screen.getByTestId("save-agent-button"),
+          ).not.toBeDisabled();
+        });
+      });
+    });
+  });
+
+  // (b) REGRESSION GUARD ───────────────────────────────────────────────────────
+  describe("given a workflow with no end outputs and a valid input mapping", () => {
+    beforeEach(() => {
+      mocks.agentData = AGENT_INPUT_MAPPING_NO_WORKFLOW_OUTPUTS;
+      mocks.workflowData = {
+        id: "workflow-no-outputs",
+        name: "Inputs-Only Workflow",
+        projectId: "test-project",
+        currentVersion: { id: "v2", dsl: DSL_INPUTS_NO_OUTPUTS },
+      };
+    });
+
+    describe("when the drawer renders with the pre-saved config", () => {
+      /**
+       * The structural guard workflowOutputs.length > 0 must stay in place.
+       * A workflow that publishes no end-node outputs cannot produce a
+       * scorable response. Save must stay blocked here.
+       * Green both before and after the fix — regression protection.
+       */
+      it("keeps the Save Changes button disabled", async () => {
+        renderDrawer("agent-no-wf-outputs");
+
+        await waitFor(() => {
+          expect(screen.getByTestId("save-agent-button")).toBeDisabled();
+        });
+      });
+    });
+  });
+
+  // (c) FAIL-CLOSED ─────────────────────────────────────────────────────────────
+  describe("given a workflow with outputs but no input-field mapping", () => {
+    beforeEach(() => {
+      mocks.agentData = AGENT_NO_INPUT_MAPPING;
+      mocks.workflowData = {
+        id: "workflow-with-outputs",
+        name: "Full Workflow",
+        projectId: "test-project",
+        currentVersion: { id: "v3", dsl: DSL_WITH_OUTPUTS },
+      };
+    });
+
+    describe("when the drawer renders with threadId-only mapping", () => {
+      /**
+       * No "input" or "messages" source mapping → hasScenarioInputMapping = false
+       * → isScenarioMappingValid = false → Save disabled.
+       * Green both before and after the fix — fail-closed preserved.
+       */
+      it("keeps the Save Changes button disabled", async () => {
+        renderDrawer("agent-no-input");
+
+        await waitFor(() => {
+          expect(screen.getByTestId("save-agent-button")).toBeDisabled();
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/components/agents/__tests__/AgentWorkflowEditorDrawer.save-gate.integration.test.tsx
+++ b/langwatch/src/components/agents/__tests__/AgentWorkflowEditorDrawer.save-gate.integration.test.tsx
@@ -27,12 +27,13 @@
  *
  * @see specs/features/scenarios/minimal-input-mapping.feature
  */
-import type React from "react";
+
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AgentWorkflowEditorDrawer } from "../AgentWorkflowEditorDrawer";
 import type { ScenarioInputMappingSectionProps } from "~/components/suites/ScenarioInputMappingSection";
+import { AgentWorkflowEditorDrawer } from "../AgentWorkflowEditorDrawer";
 
 // ── Hoisted mock state ────────────────────────────────────────────────────────
 
@@ -340,10 +341,9 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 function renderDrawer(agentId: string) {
-  return render(
-    <AgentWorkflowEditorDrawer open={true} agentId={agentId} />,
-    { wrapper: Wrapper },
-  );
+  return render(<AgentWorkflowEditorDrawer open={true} agentId={agentId} />, {
+    wrapper: Wrapper,
+  });
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -365,25 +365,12 @@ describe("AgentWorkflowEditorDrawer save gate", () => {
     });
 
     describe("when the drawer renders with the pre-saved config", () => {
-      /**
-       * @scenario Save workflow agent when output mapping is cleared but input mapping present
-       *
-       * FAILS current code:
-       *   isScenarioMappingValid checks hasOutputMapping = hasOutputs && outputField !== ""
-       *   outputField = "" → hasOutputMapping = false → isValid = false → button disabled
-       *
-       * After fix (isScenarioMappingValid drops && hasOutputMapping):
-       *   isScenarioMappingValid returns hasScenarioInputMapping(mappings) = true
-       *   workflowOutputs.length > 0 = true (structural guard passes)
-       *   isValid = true → button enabled
-       */
+      /** @scenario Save workflow agent when output mapping is cleared but input mapping present */
       it("enables the Save Changes button", async () => {
         renderDrawer("agent-cleared-output");
 
         await waitFor(() => {
-          expect(
-            screen.getByTestId("save-agent-button"),
-          ).not.toBeDisabled();
+          expect(screen.getByTestId("save-agent-button")).not.toBeDisabled();
         });
       });
     });
@@ -402,12 +389,7 @@ describe("AgentWorkflowEditorDrawer save gate", () => {
     });
 
     describe("when the drawer renders with the pre-saved config", () => {
-      /**
-       * The structural guard workflowOutputs.length > 0 must stay in place.
-       * A workflow that publishes no end-node outputs cannot produce a
-       * scorable response. Save must stay blocked here.
-       * Green both before and after the fix — regression protection.
-       */
+      /** @scenario Save workflow agent stays blocked when the workflow has no published outputs */
       it("keeps the Save Changes button disabled", async () => {
         renderDrawer("agent-no-wf-outputs");
 
@@ -431,11 +413,7 @@ describe("AgentWorkflowEditorDrawer save gate", () => {
     });
 
     describe("when the drawer renders with threadId-only mapping", () => {
-      /**
-       * No "input" or "messages" source mapping → hasScenarioInputMapping = false
-       * → isScenarioMappingValid = false → Save disabled.
-       * Green both before and after the fix — fail-closed preserved.
-       */
+      /** @scenario Save workflow agent stays blocked when no input mapping is configured */
       it("keeps the Save Changes button disabled", async () => {
         renderDrawer("agent-no-input");
 

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -278,9 +278,11 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
           if (agent) {
             const config = agent.config as CustomComponentConfig;
             const mappings = config.scenarioMappings ?? {};
-            // We don't have workflow outputs here — server-side pre-run check
-            // covers output validation. Share the input half of the rule with
-            // the editor drawer via hasScenarioInputMapping.
+            // Run gate is input-only by design (#3412): a scenario needs only one
+            // input ("input" or "messages") mapped to be runnable; output mapping
+            // is optional (auto-populates to first output, or graceful stringify
+            // fallback). Uses shared hasScenarioInputMapping SSOT so the run gate
+            // and editor Save gate agree on the same input rule.
             if (!hasScenarioInputMapping(mappings)) {
               // Fallback affordance (#3411): even if the auto-open below races,
               // is dismissed, or fails, the toast itself links back to the editor.

--- a/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
@@ -431,4 +431,65 @@ describe("<ScenarioFormDrawer /> mapping gate", () => {
       );
     });
   });
+
+  // ── Issue #3412 — minimal input mapping ─────────────────────────────────────
+  // The run gate in handleSaveAndRun already uses hasScenarioInputMapping (input
+  // mapping only, no output required). This block documents that contract so a
+  // future regression that adds output checks to the run gate is caught early.
+
+  describe("when target is a workflow agent with a valid input mapping and no outputField", () => {
+    beforeEach(() => {
+      // Agent has scenarioMappings that satisfies hasScenarioInputMapping
+      // but has NO scenarioOutputField configured.
+      mocks.mockAgentsGetByIdFetch.mockResolvedValue({
+        id: "workflow-agent-input-only",
+        type: "workflow",
+        name: "Input-Only Workflow Agent",
+        config: {
+          workflow_id: "wf-input-only",
+          scenarioMappings: {
+            userMessage: {
+              type: "source",
+              sourceId: "scenario",
+              path: ["input"],
+            },
+          },
+          // No scenarioOutputField — the user never configured an output
+        },
+      });
+    });
+
+    /** @scenario Run gate passes for workflow agent with input-only mapping */
+    it("proceeds with the run without opening the mapping drawer", async () => {
+      const user = userEvent.setup();
+      renderWithTarget({ type: "workflow", id: "workflow-agent-input-only" });
+
+      await user.click(screen.getByTestId("save-and-run-button"));
+
+      await waitFor(() => {
+        expect(mocks.mockRunScenario).toHaveBeenCalled();
+      });
+
+      expect(mocks.mockOpenDrawer).not.toHaveBeenCalledWith(
+        "agentWorkflowEditor",
+        expect.anything(),
+      );
+    });
+
+    /** @scenario Run gate emits no mapping warning when input is mapped */
+    it("does not show a mapping warning toast", async () => {
+      const user = userEvent.setup();
+      renderWithTarget({ type: "workflow", id: "workflow-agent-input-only" });
+
+      await user.click(screen.getByTestId("save-and-run-button"));
+
+      await waitFor(() => {
+        expect(mocks.mockRunScenario).toHaveBeenCalled();
+      });
+
+      expect(mockToasterCreate).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Configure scenario mappings" }),
+      );
+    });
+  });
 });

--- a/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
@@ -432,11 +432,7 @@ describe("<ScenarioFormDrawer /> mapping gate", () => {
     });
   });
 
-  // ── Issue #3412 — minimal input mapping ─────────────────────────────────────
-  // The run gate in handleSaveAndRun already uses hasScenarioInputMapping (input
-  // mapping only, no output required). This block documents that contract so a
-  // future regression that adds output checks to the run gate is caught early.
-
+  // These guard the PRE-EXISTING input-only run-gate contract (this PR only corrected a comment in ScenarioFormDrawer.tsx, not its logic).
   describe("when target is a workflow agent with a valid input mapping and no outputField", () => {
     beforeEach(() => {
       // Agent has scenarioMappings that satisfies hasScenarioInputMapping

--- a/langwatch/src/components/suites/ScenarioInputMappingSection.tsx
+++ b/langwatch/src/components/suites/ScenarioInputMappingSection.tsx
@@ -129,24 +129,18 @@ export function hasScenarioInputMapping(
 }
 
 /**
- * Checks whether the scenario mappings are valid (i.e. enough to save and run).
+ * Whether the scenario mappings are sufficient to save and run an agent.
  *
- * Minimum required: a single source mapping whose path is "input" or "messages".
- * `hasScenarioInputMapping` is the single source of truth for this rule and is
- * shared by the editor Save gate and the Save-&-Run drawer gate.
- *
- * Output mapping is optional: when omitted the run auto-populates to the first
- * output, or gracefully stringifies the full result. Callers still pass
- * `outputs` and `outputField` for UI display purposes; they do not gate saving.
+ * Minimum (and only) requirement: a single source mapping whose path is
+ * "input" or "messages". An output mapping is optional — when omitted the run
+ * auto-populates the first output or gracefully stringifies the full result.
+ * Shared by the editor Save gate and the Save-&-Run drawer gate via
+ * hasScenarioInputMapping (the single source of truth).
  */
 export function isScenarioMappingValid({
   mappings,
-  outputs: _outputs,
-  outputField: _outputField,
 }: {
   mappings: Record<string, FieldMapping>;
-  outputs?: Variable[];
-  outputField?: string;
 }): boolean {
   return hasScenarioInputMapping(mappings);
 }

--- a/langwatch/src/components/suites/ScenarioInputMappingSection.tsx
+++ b/langwatch/src/components/suites/ScenarioInputMappingSection.tsx
@@ -129,23 +129,26 @@ export function hasScenarioInputMapping(
 }
 
 /**
- * Checks whether the scenario mappings are valid.
- * - At least one of input or messages must be mapped.
- * - An output must be selected (not cleared).
+ * Checks whether the scenario mappings are valid (i.e. enough to save and run).
+ *
+ * Minimum required: a single source mapping whose path is "input" or "messages".
+ * `hasScenarioInputMapping` is the single source of truth for this rule and is
+ * shared by the editor Save gate and the Save-&-Run drawer gate.
+ *
+ * Output mapping is optional: when omitted the run auto-populates to the first
+ * output, or gracefully stringifies the full result. Callers still pass
+ * `outputs` and `outputField` for UI display purposes; they do not gate saving.
  */
 export function isScenarioMappingValid({
   mappings,
-  outputs,
-  outputField,
+  outputs: _outputs,
+  outputField: _outputField,
 }: {
   mappings: Record<string, FieldMapping>;
   outputs?: Variable[];
   outputField?: string;
 }): boolean {
-  const hasOutputs = (outputs ?? []).length > 0;
-  // outputField === "" means explicitly cleared; undefined means auto-populate
-  const hasOutputMapping = hasOutputs && outputField !== "";
-  return hasScenarioInputMapping(mappings) && hasOutputMapping;
+  return hasScenarioInputMapping(mappings);
 }
 
 export function ScenarioInputMappingSection({

--- a/langwatch/src/components/suites/__tests__/ScenarioInputMappingSection.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/ScenarioInputMappingSection.unit.test.ts
@@ -8,8 +8,8 @@
  * @see specs/scenarios/minimal-input-mapping.feature
  */
 import { describe, expect, it } from "vitest";
-import { isScenarioMappingValid } from "../ScenarioInputMappingSection";
 import type { FieldMapping } from "~/components/variables/VariableMappingInput";
+import { isScenarioMappingValid } from "../ScenarioInputMappingSection";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -40,6 +40,7 @@ describe("isScenarioMappingValid", () => {
 
   describe("given a valid 'input' mapping", () => {
     describe("when no output is configured", () => {
+      /** @scenario Input mapping alone passes the predicate */
       it("returns true", () => {
         expect(
           isScenarioMappingValid({
@@ -52,6 +53,7 @@ describe("isScenarioMappingValid", () => {
 
   describe("given a valid 'messages' mapping", () => {
     describe("when no output is configured", () => {
+      /** @scenario Messages mapping alone passes the predicate */
       it("returns true", () => {
         expect(
           isScenarioMappingValid({
@@ -68,6 +70,7 @@ describe("isScenarioMappingValid", () => {
 
   describe("given no input-field mapping (fail-closed)", () => {
     describe("when threadId-only mapping is present", () => {
+      /** @scenario ThreadId-only mapping fails the predicate */
       it("returns false", () => {
         expect(
           isScenarioMappingValid({
@@ -78,6 +81,7 @@ describe("isScenarioMappingValid", () => {
     });
 
     describe("when only a static value mapping is present", () => {
+      /** @scenario Static value mapping fails the predicate */
       it("returns false", () => {
         expect(
           isScenarioMappingValid({
@@ -88,6 +92,7 @@ describe("isScenarioMappingValid", () => {
     });
 
     describe("when mappings are empty", () => {
+      /** @scenario Empty mappings fail the predicate */
       it("returns false", () => {
         expect(
           isScenarioMappingValid({

--- a/langwatch/src/components/suites/__tests__/ScenarioInputMappingSection.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/ScenarioInputMappingSection.unit.test.ts
@@ -5,7 +5,7 @@
  * The function returns true whenever a source mapping wires to "input" or
  * "messages", and false (fail-closed) when no such mapping is present.
  *
- * @see specs/scenarios/minimal-input-mapping.feature
+ * @see specs/features/scenarios/minimal-input-mapping.feature
  */
 import { describe, expect, it } from "vitest";
 import type { FieldMapping } from "~/components/variables/VariableMappingInput";

--- a/langwatch/src/components/suites/__tests__/ScenarioInputMappingSection.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/ScenarioInputMappingSection.unit.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for isScenarioMappingValid — Issue #3412
+ *
+ * The function currently requires BOTH an input mapping AND an output mapping
+ * before it returns true. This blocks users from saving an agent that has only
+ * an input mapping configured, because the output-mapping check is over-strict.
+ *
+ * After the fix, isScenarioMappingValid must return true whenever a valid
+ * input mapping is present, regardless of whether any output is configured.
+ * The function must still return false (fail-closed) when no input mapping is
+ * present, with or without outputs.
+ *
+ * @see specs/scenarios/minimal-input-mapping.feature
+ */
+import { describe, expect, it } from "vitest";
+import { isScenarioMappingValid } from "../ScenarioInputMappingSection";
+import type { FieldMapping } from "~/components/variables/VariableMappingInput";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+/** Valid input mapping: one agent input wired to the scenario "input" field. */
+const INPUT_MAPPED: Record<string, FieldMapping> = {
+  userMessage: { type: "source", sourceId: "scenario", path: ["input"] },
+};
+
+/** Valid messages mapping: one agent input wired to the scenario "messages" field. */
+const MESSAGES_MAPPED: Record<string, FieldMapping> = {
+  history: { type: "source", sourceId: "scenario", path: ["messages"] },
+};
+
+/** No input/messages mapping — only threadId (not sufficient on its own). */
+const THREAD_ID_ONLY: Record<string, FieldMapping> = {
+  sessionId: { type: "source", sourceId: "scenario", path: ["threadId"] },
+};
+
+/** Static value mapping — no source path at all. */
+const VALUE_ONLY: Record<string, FieldMapping> = {
+  context: { type: "value", value: "hardcoded" },
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("isScenarioMappingValid", () => {
+  // ── Happy-path: input mapping only (the fix target) ────────────────────────
+  // Each of these currently returns false because the function requires an
+  // output mapping. After the fix, input mapping alone is sufficient.
+
+  describe("given a valid 'input' mapping and no outputs configured", () => {
+    describe("when outputs is an empty array", () => {
+      // FAILS current code: hasOutputs = false → hasOutputMapping = false → returns false
+      it("returns true", () => {
+        expect(
+          isScenarioMappingValid({
+            mappings: INPUT_MAPPED,
+            outputs: [],
+            outputField: undefined,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("when outputs is undefined", () => {
+      // FAILS current code: (outputs ?? []).length = 0 → hasOutputs = false → returns false
+      it("returns true", () => {
+        expect(
+          isScenarioMappingValid({
+            mappings: INPUT_MAPPED,
+            outputs: undefined,
+            outputField: undefined,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("when outputs exist but outputField is explicitly cleared", () => {
+      // FAILS current code: outputField === "" → hasOutputMapping = false → returns false
+      it("returns true", () => {
+        expect(
+          isScenarioMappingValid({
+            mappings: INPUT_MAPPED,
+            outputs: [{ identifier: "response", type: "str" }],
+            outputField: "",
+          }),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe("given a valid 'messages' mapping and no outputs", () => {
+    describe("when outputs is an empty array", () => {
+      // FAILS current code: same hasOutputs = false path
+      it("returns true", () => {
+        expect(
+          isScenarioMappingValid({
+            mappings: MESSAGES_MAPPED,
+            outputs: [],
+            outputField: undefined,
+          }),
+        ).toBe(true);
+      });
+    });
+  });
+
+  // ── Fail-closed: no input/messages mapping → always false ──────────────────
+  // These must stay false after the fix — the function must not become
+  // a no-op that accepts any configuration.
+
+  describe("given no input-field mapping (fail-closed)", () => {
+    describe("when threadId-only mapping is present and outputs are fully configured", () => {
+      it("returns false", () => {
+        expect(
+          isScenarioMappingValid({
+            mappings: THREAD_ID_ONLY,
+            outputs: [{ identifier: "response", type: "str" }],
+            outputField: "response",
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe("when only a static value mapping is present and outputs are configured", () => {
+      it("returns false", () => {
+        expect(
+          isScenarioMappingValid({
+            mappings: VALUE_ONLY,
+            outputs: [{ identifier: "response", type: "str" }],
+            outputField: "response",
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe("when mappings are empty", () => {
+      it("returns false", () => {
+        expect(
+          isScenarioMappingValid({
+            mappings: {},
+            outputs: [],
+            outputField: undefined,
+          }),
+        ).toBe(false);
+      });
+    });
+  });
+});

--- a/langwatch/src/components/suites/__tests__/ScenarioInputMappingSection.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/ScenarioInputMappingSection.unit.test.ts
@@ -1,14 +1,9 @@
 /**
  * Unit tests for isScenarioMappingValid — Issue #3412
  *
- * The function currently requires BOTH an input mapping AND an output mapping
- * before it returns true. This blocks users from saving an agent that has only
- * an input mapping configured, because the output-mapping check is over-strict.
- *
- * After the fix, isScenarioMappingValid must return true whenever a valid
- * input mapping is present, regardless of whether any output is configured.
- * The function must still return false (fail-closed) when no input mapping is
- * present, with or without outputs.
+ * A valid input mapping alone is sufficient; output mapping is not required.
+ * The function returns true whenever a source mapping wires to "input" or
+ * "messages", and false (fail-closed) when no such mapping is present.
  *
  * @see specs/scenarios/minimal-input-mapping.feature
  */
@@ -41,60 +36,26 @@ const VALUE_ONLY: Record<string, FieldMapping> = {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("isScenarioMappingValid", () => {
-  // ── Happy-path: input mapping only (the fix target) ────────────────────────
-  // Each of these currently returns false because the function requires an
-  // output mapping. After the fix, input mapping alone is sufficient.
+  // ── Happy-path: input mapping alone is sufficient ──────────────────────────
 
-  describe("given a valid 'input' mapping and no outputs configured", () => {
-    describe("when outputs is an empty array", () => {
-      // FAILS current code: hasOutputs = false → hasOutputMapping = false → returns false
+  describe("given a valid 'input' mapping", () => {
+    describe("when no output is configured", () => {
       it("returns true", () => {
         expect(
           isScenarioMappingValid({
             mappings: INPUT_MAPPED,
-            outputs: [],
-            outputField: undefined,
-          }),
-        ).toBe(true);
-      });
-    });
-
-    describe("when outputs is undefined", () => {
-      // FAILS current code: (outputs ?? []).length = 0 → hasOutputs = false → returns false
-      it("returns true", () => {
-        expect(
-          isScenarioMappingValid({
-            mappings: INPUT_MAPPED,
-            outputs: undefined,
-            outputField: undefined,
-          }),
-        ).toBe(true);
-      });
-    });
-
-    describe("when outputs exist but outputField is explicitly cleared", () => {
-      // FAILS current code: outputField === "" → hasOutputMapping = false → returns false
-      it("returns true", () => {
-        expect(
-          isScenarioMappingValid({
-            mappings: INPUT_MAPPED,
-            outputs: [{ identifier: "response", type: "str" }],
-            outputField: "",
           }),
         ).toBe(true);
       });
     });
   });
 
-  describe("given a valid 'messages' mapping and no outputs", () => {
-    describe("when outputs is an empty array", () => {
-      // FAILS current code: same hasOutputs = false path
+  describe("given a valid 'messages' mapping", () => {
+    describe("when no output is configured", () => {
       it("returns true", () => {
         expect(
           isScenarioMappingValid({
             mappings: MESSAGES_MAPPED,
-            outputs: [],
-            outputField: undefined,
           }),
         ).toBe(true);
       });
@@ -102,29 +63,25 @@ describe("isScenarioMappingValid", () => {
   });
 
   // ── Fail-closed: no input/messages mapping → always false ──────────────────
-  // These must stay false after the fix — the function must not become
+  // These must stay false — the function must not become
   // a no-op that accepts any configuration.
 
   describe("given no input-field mapping (fail-closed)", () => {
-    describe("when threadId-only mapping is present and outputs are fully configured", () => {
+    describe("when threadId-only mapping is present", () => {
       it("returns false", () => {
         expect(
           isScenarioMappingValid({
             mappings: THREAD_ID_ONLY,
-            outputs: [{ identifier: "response", type: "str" }],
-            outputField: "response",
           }),
         ).toBe(false);
       });
     });
 
-    describe("when only a static value mapping is present and outputs are configured", () => {
+    describe("when only a static value mapping is present", () => {
       it("returns false", () => {
         expect(
           isScenarioMappingValid({
             mappings: VALUE_ONLY,
-            outputs: [{ identifier: "response", type: "str" }],
-            outputField: "response",
           }),
         ).toBe(false);
       });
@@ -135,8 +92,6 @@ describe("isScenarioMappingValid", () => {
         expect(
           isScenarioMappingValid({
             mappings: {},
-            outputs: [],
-            outputField: undefined,
           }),
         ).toBe(false);
       });

--- a/specs/features/scenarios/minimal-input-mapping.feature
+++ b/specs/features/scenarios/minimal-input-mapping.feature
@@ -22,31 +22,32 @@ Feature: Scenario agent needs only a single input mapping to save and run
   # ── Core predicate ────────────────────────────────────────────────────────
 
   @unit
-  Scenario: Valid input mapping with no outputs configured passes the predicate
+  Scenario: Input mapping alone passes the predicate
     Given an agent configuration with a source mapping for the "input" scenario field
-    And no outputs are declared
     When the mapping validity is evaluated
     Then the result is valid
 
   @unit
-  Scenario: Valid input mapping with outputField explicitly cleared passes the predicate
-    Given an agent configuration with a source mapping for the "input" scenario field
-    And outputs are declared
-    But the output-field selection has been explicitly cleared
-    When the mapping validity is evaluated
-    Then the result is valid
-
-  @unit
-  Scenario: Valid messages mapping with no outputs configured passes the predicate
+  Scenario: Messages mapping alone passes the predicate
     Given an agent configuration with a source mapping for the "messages" scenario field
-    And no outputs are declared
     When the mapping validity is evaluated
     Then the result is valid
 
   @unit
-  Scenario: No input or messages mapping fails the predicate regardless of outputs
-    Given an agent configuration with no source mapping for "input" or "messages"
-    And outputs are fully configured
+  Scenario: ThreadId-only mapping fails the predicate
+    Given an agent configuration with only a "threadId" source mapping
+    When the mapping validity is evaluated
+    Then the result is invalid
+
+  @unit
+  Scenario: Static value mapping fails the predicate
+    Given an agent configuration with only a static value mapping
+    When the mapping validity is evaluated
+    Then the result is invalid
+
+  @unit
+  Scenario: Empty mappings fail the predicate
+    Given an agent configuration with no mappings at all
     When the mapping validity is evaluated
     Then the result is invalid
 
@@ -91,13 +92,30 @@ Feature: Scenario agent needs only a single input mapping to save and run
     When the agent editor drawer renders
     Then the Save Changes button is disabled
 
+  # ── Save & Run gate ───────────────────────────────────────────────────────
+  # A scenario must be runnable with only the input mapping (issue AC1). The
+  # run gate already used the input-only rule; these guard that contract.
+
+  @integration
+  Scenario: Run gate passes for workflow agent with input-only mapping
+    Given a workflow agent with a valid input mapping and no output mapping
+    When the user clicks Save and run
+    Then the scenario run starts without opening the mapping editor
+
+  @integration
+  Scenario: Run gate emits no mapping warning when input is mapped
+    Given a workflow agent with a valid input mapping and no output mapping
+    When the user clicks Save and run
+    Then no mapping-required warning is shown
+
   # ── AC Coverage Map ───────────────────────────────────────────────────────
   # "isScenarioMappingValid returns true for input-only mapping" →
-  #   "Valid input mapping with no outputs configured passes the predicate"
-  #   "Valid input mapping with outputField explicitly cleared passes the predicate"
-  #   "Valid messages mapping with no outputs configured passes the predicate"
+  #   "Input mapping alone passes the predicate"
+  #   "Messages mapping alone passes the predicate"
   # "isScenarioMappingValid is fail-closed" →
-  #   "No input or messages mapping fails the predicate regardless of outputs"
+  #   "ThreadId-only mapping fails the predicate"
+  #   "Static value mapping fails the predicate"
+  #   "Empty mappings fail the predicate"
   # "Workflow drawer Save gate passes for input-only mapping" →
   #   "Save workflow agent when output mapping is cleared but input mapping present"
   # "Structural workflow-output guard is preserved" →

--- a/specs/features/scenarios/minimal-input-mapping.feature
+++ b/specs/features/scenarios/minimal-input-mapping.feature
@@ -1,0 +1,110 @@
+Feature: Scenario agent needs only a single input mapping to save and run
+  As a scenario author
+  I want to save a workflow or code agent configuration that only has an input mapping
+  So that I can run scenarios without being forced to configure an output-field selection upfront
+
+  # Background: the scenario framework auto-populates the output if a single
+  # output is declared; users should not be blocked from saving or running
+  # just because they cleared the output-field picker or haven't touched it.
+  #
+  # The output-MAPPING requirement (hasOutputMapping) is relaxed in
+  # isScenarioMappingValid. The structural guard on published workflow
+  # outputs (workflowOutputs.length > 0 in AgentWorkflowEditorDrawer.isValid)
+  # STAYS — a workflow with no end-node outputs cannot produce a scorable
+  # response, so Save must remain blocked there.
+  #
+  # Scope of this feature:
+  #   - isScenarioMappingValid predicate (unit)
+  #   - AgentWorkflowEditorDrawer Save gate (integration)
+  #   - AgentCodeEditorDrawer Save gate (integration)
+  # Out of scope: the structural workflowOutputs.length guard (unchanged).
+
+  # ── Core predicate ────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: Valid input mapping with no outputs configured passes the predicate
+    Given an agent configuration with a source mapping for the "input" scenario field
+    And no outputs are declared
+    When the mapping validity is evaluated
+    Then the result is valid
+
+  @unit
+  Scenario: Valid input mapping with outputField explicitly cleared passes the predicate
+    Given an agent configuration with a source mapping for the "input" scenario field
+    And outputs are declared
+    But the output-field selection has been explicitly cleared
+    When the mapping validity is evaluated
+    Then the result is valid
+
+  @unit
+  Scenario: Valid messages mapping with no outputs configured passes the predicate
+    Given an agent configuration with a source mapping for the "messages" scenario field
+    And no outputs are declared
+    When the mapping validity is evaluated
+    Then the result is valid
+
+  @unit
+  Scenario: No input or messages mapping fails the predicate regardless of outputs
+    Given an agent configuration with no source mapping for "input" or "messages"
+    And outputs are fully configured
+    When the mapping validity is evaluated
+    Then the result is invalid
+
+  # ── Workflow editor drawer ─────────────────────────────────────────────────
+
+  @integration
+  Scenario: Save workflow agent when output mapping is cleared but input mapping present
+    Given a workflow agent with a valid input mapping for the "input" scenario field
+    And the linked workflow publishes at least one end-node output
+    And the user has explicitly cleared the output-field selection
+    When the agent editor drawer renders
+    Then the Save Changes button is enabled
+
+  @integration
+  Scenario: Save workflow agent stays blocked when the workflow has no published outputs
+    Given a workflow agent with a valid input mapping for the "input" scenario field
+    And the linked workflow publishes no end-node outputs
+    When the agent editor drawer renders
+    Then the Save Changes button is disabled
+
+  @integration
+  Scenario: Save workflow agent stays blocked when no input mapping is configured
+    Given a workflow agent with only a "threadId" source mapping
+    And the linked workflow publishes at least one end-node output
+    When the agent editor drawer renders
+    Then the Save Changes button is disabled
+
+  # ── Code editor drawer ────────────────────────────────────────────────────
+
+  @integration
+  Scenario: Save code agent when output mapping is cleared but input mapping present
+    Given a code agent with a valid input mapping for the "input" scenario field
+    And the agent declares at least one output
+    And the user has explicitly cleared the output-field selection
+    When the agent editor drawer renders
+    Then the Save Changes button is enabled
+
+  @integration
+  Scenario: Save code agent stays blocked when no input mapping is configured
+    Given a code agent with only a "threadId" source mapping
+    And the agent declares at least one output
+    When the agent editor drawer renders
+    Then the Save Changes button is disabled
+
+  # ── AC Coverage Map ───────────────────────────────────────────────────────
+  # "isScenarioMappingValid returns true for input-only mapping" →
+  #   "Valid input mapping with no outputs configured passes the predicate"
+  #   "Valid input mapping with outputField explicitly cleared passes the predicate"
+  #   "Valid messages mapping with no outputs configured passes the predicate"
+  # "isScenarioMappingValid is fail-closed" →
+  #   "No input or messages mapping fails the predicate regardless of outputs"
+  # "Workflow drawer Save gate passes for input-only mapping" →
+  #   "Save workflow agent when output mapping is cleared but input mapping present"
+  # "Structural workflow-output guard is preserved" →
+  #   "Save workflow agent stays blocked when the workflow has no published outputs"
+  # "Workflow drawer fail-closed" →
+  #   "Save workflow agent stays blocked when no input mapping is configured"
+  # "Code drawer Save gate passes for input-only mapping" →
+  #   "Save code agent when output mapping is cleared but input mapping present"
+  # "Code drawer fail-closed" →
+  #   "Save code agent stays blocked when no input mapping is configured"


### PR DESCRIPTION
# Related Issue

- Resolves #3412

## Why

Closes #3412 (sub-issue of mini-epic #3441 — broken mappings across eval-v3, workflows, agents, scenarios).

A scenario run should require only the **single input mapping** — not an output mapping. The editor Save gate was over-strict: `isScenarioMappingValid` required an output mapping in addition to the input, so a scenario author who cleared the output-field picker (or used a code agent with no declared output) could not save the agent config and therefore could not run the scenario.

## What changed

- **`isScenarioMappingValid` is now input-only** — drops the `&& hasOutputMapping` conjunction and defers to `hasScenarioInputMapping` as the single source of truth shared by the editor Save gate and the Save-and-Run drawer gate (issue AC4). An explicit output mapping is optional: it auto-populates to the first output, or the run gracefully stringifies the full result.
- **Structural guards preserved (deliberately)** — `AgentWorkflowEditorDrawer.isValid` keeps `workflowInputs.length > 0 && workflowOutputs.length > 0`. A workflow with no *published* end outputs structurally returns nothing; relaxing that would let a scenario be judged on `"{}"` — the exact silently-wrong run epic #3441 exists to kill. Only the output-MAPPING requirement is relaxed, not the requirement that a workflow HAVE outputs.
- **Corrected a misleading comment** in `ScenarioFormDrawer` that claimed the server-side pre-run check validates outputs. It does not — `validate-workflow-mappings.ts` only rejects multi-input workflow agents that have zero mappings.

## How it works

```
suites/ScenarioInputMappingSection.tsx
  hasScenarioInputMapping(mappings)   -> SSOT: at least one source mapping on "input"|"messages" (unchanged)
  isScenarioMappingValid(...)         -> now returns hasScenarioInputMapping(mappings) only
agents/AgentWorkflowEditorDrawer.tsx  -> consumer; structural workflowInputs/workflowOutputs guards UNTOUCHED
agents/AgentCodeEditorDrawer.tsx      -> consumer; benefits (no separate output guard)
agents/AgentHttpEditorDrawer.tsx      -> consumer; already exempt (synthesizes a virtual output)
scenarios/ScenarioFormDrawer.tsx      -> Save-and-Run gate already used hasScenarioInputMapping; comment corrected
```

## Human verification

For a skeptical reviewer who wants to re-confirm independently:

1. Open a scenario suite and edit a **workflow agent** whose linked workflow publishes at least one end output.
2. Map a scenario input (`input` or `messages`) to an agent input. Clear the output-field picker.
3. Confirm the **Save Changes** button is **enabled** (before this PR it was disabled with the output cleared).
4. Save and run — the scenario runs with only the input mapping.
5. Negative checks: a workflow with **no published end outputs** still shows "publish an end output" and Save stays **disabled** (structural guard intact); a config with **no input mapped** still blocks (fail-closed).

## How I can prove I was successful

**Falsifiable test pair (strongest proof).** New tests are RED against the pre-fix code and GREEN after the one-line relaxation.

Before the fix — `isScenarioMappingValid` rejects an input-only mapping:
```
FAIL  ScenarioInputMappingSection.unit > given a valid 'input' mapping and no outputs configured > when outputs is an empty array > returns true
  AssertionError: expected false to be true
Tests  4 failed | 3 passed (7)
```

After the fix — all 20 new/changed tests green, including the structural-guard regression test (no-output workflow -> Save still disabled):
```
ScenarioInputMappingSection.unit.test.ts ............ 7 passed (7)
AgentWorkflowEditorDrawer.save-gate.integration ..... \
AgentCodeEditorDrawer.save-gate.integration ......... 13 passed (3 files)
ScenarioFormDrawer.mapping-gate.integration ......... /
pnpm typecheck ...................................... clean (tsgo, 0 errors)
```

**Live-app proof (real running app, authenticated dogfood session on the golden fork).** A Code agent with `input` mapped and the output mapping **explicitly cleared** ("Required"). Same state, two code versions:

| Before (current code) — Save **disabled** | After (this PR) — Save **enabled** |
|---|---|
| ![Save Changes disabled when output mapping cleared](https://raw.githubusercontent.com/langwatch/langwatch/proof/3412-minimal-input-mapping/proofs/3412-before-save-disabled.png) | ![Save Changes enabled with input-only mapping](https://raw.githubusercontent.com/langwatch/langwatch/proof/3412-minimal-input-mapping/proofs/3412-after-save-enabled.png) |

The only difference between the two captures is `isScenarioMappingValid` (loaded via the dev server). Input stays mapped in both; clearing the output mapping disables Save on the current code and leaves it enabled with this PR.

## Acceptance Criteria

| # | AC (from #3412) | Evidence | Status |
|---|-----------------|----------|--------|
| 1 | Scenario runs with only one input mapping; no output required | Save-and-run run gate uses `hasScenarioInputMapping`; integration test "run proceeds input-only" | ✅ |
| 2 | Pre-run validation relaxed to input-only; output validation not blocking | `isScenarioMappingValid` input-only; server `validate-workflow-mappings` never gated outputs (comment corrected) | ✅ |
| 3 | Minimum required mappings documented | doc comment on `isScenarioMappingValid`/`hasScenarioInputMapping`; `specs/features/scenarios/minimal-input-mapping.feature` | ✅ |
| 4 | `hasScenarioInputMapping` is the single source of truth; client + server agree | Client Save + Run gates both use it; server note below | ✅ (client) |
| 5 | Tests cover minimal-mapping case (one input, no outputs) | unit + 2 save-gate integration suites | ✅ |
| 6 | No regression to missing-input validation (fail-closed) | fail-closed cases green in unit + both drawers | ✅ |

## Anything surprising?

- The issue's premise — "the server-side pre-run check validates outputs, blocking minimal runs" — was inaccurate. The server validator only guards multi-input zero-mapping agents; the real over-strict gate was the **client Save button**. The common run case (output-field left at its default `undefined`) already passed input-only on main; this PR closes the remaining edges (explicitly-cleared output field; code agents with no output) and makes input-only the **documented** single source of truth.
- On AC4: the **client** SSOT is now `hasScenarioInputMapping` for both Save and Run. The server validator is intentionally a coarser, independent safety net (rejects only multi-input agents with zero mappings) and does not mirror the client predicate; making it a byte-for-byte mirror is not needed for this change and would risk multi-input flows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for input-only scenario mappings, allowing “Save” and “Save and Run” to proceed without requiring an output field in affected agent editors.

* **Bug Fixes**
  * Updated Save button validation across code, HTTP, and workflow agent drawers to depend on input mappings instead of output-field/outputs presence.
  * Prevented unnecessary configuration warnings when input mappings are already correctly set.

* **Tests**
  * Added/expanded integration and unit tests covering save/run gating and minimal input-mapping scenarios.

* **Documentation**
  * Updated scenario mapping guidance and added a feature spec for minimal input mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->