### PR TITLE
fix(traces): server-side facet value search beyond the preloaded top-50

### DIFF
--- a/langwatch/src/features/traces-v2/components/FilterSidebar/FacetSection.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/FacetSection.tsx
@@ -1,7 +1,16 @@
-import { Box, Button, HStack, Input, Text, VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  HStack,
+  Input,
+  Spinner,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
 import type React from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Kbd } from "~/components/ops/shared/Kbd";
+import { useFacetSearch } from "../../hooks/useFacetSearch";
 import { useFacetLensStore } from "../../stores/facetLensStore";
 import {
   AUTO_EXPAND_THRESHOLD,
@@ -42,6 +51,16 @@ interface FacetSectionProps {
     mode: "range" | "discrete";
     onToggle: () => void;
   };
+  /**
+   * When true, the per-facet value search runs SERVER-SIDE: typing queries
+   * `facetValues` with the text as a `prefix`, matching against ALL of this
+   * facet's distinct values (not just the preloaded `items`). Set only by
+   * the categorical render branch — `facetValues` throws for range facets,
+   * so the discrete-range branch leaves it unset and the search stays the
+   * client-side filter over `items`. The Enter-to-filter fallback is kept in
+   * both modes for arbitrary / not-yet-ingested values.
+   */
+  supportsValueSearch?: boolean;
   /**
    * Optional per-row extras renderer. Invoked for any row whose value
    * is currently active (i.e. surfaced via `pinnedContent`). The
@@ -100,6 +119,7 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
   renderInactiveRowExtras,
   synthetic,
   modeToggleProps,
+  supportsValueSearch,
 }) => {
   const [expandedInactiveRows, setExpandedInactiveRows] = useState<Set<string>>(
     () => new Set(),
@@ -169,9 +189,42 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
   // in the list for one-click filtering; the badge just stops tallying them.
   const presentValueCount = useMemo(() => countPresentValues(items), [items]);
 
+  // Server-side value search. When the per-facet search is open with a
+  // non-empty query, query `facetValues` with that text as a `prefix` so the
+  // match runs against ALL of this facet's distinct values — not just the
+  // preloaded top-N `items`. Gated on `supportsValueSearch` because
+  // `facetValues` throws for range facets (SectionRenderer sets the prop only
+  // on the categorical render branch). The hook is always called (hooks can't
+  // be conditional) but stays disabled until the gate opens.
+  const serverSearchActive =
+    !!supportsValueSearch && searchOpen && searchQuery.trim().length > 0;
+  const serverSearch = useFacetSearch({
+    facetKey: field,
+    prefix: searchQuery,
+    enabled: serverSearchActive,
+  });
+  const serverItems = useMemo<FacetItem[]>(
+    () =>
+      serverSearch.values.map((v) => ({
+        value: v.value,
+        label: v.label ?? v.value,
+        count: v.count,
+      })),
+    [serverSearch.values],
+  );
+
+  // While server search is active the server has already matched the prefix
+  // against every value, so feed those into the pipeline instead of the
+  // preloaded top-N. Skip the client-side substring narrowing (pass an empty
+  // query to the sorter) — the server is the source of truth for what matches.
+  const baseItems = serverSearchActive ? serverItems : items;
   const filtered = useMemo(
-    () => filterAndSortItems({ items, searchQuery }),
-    [items, searchQuery],
+    () =>
+      filterAndSortItems({
+        items: baseItems,
+        searchQuery: serverSearchActive ? "" : searchQuery,
+      }),
+    [baseItems, serverSearchActive, searchQuery],
   );
 
   // Active rows = currently-filtered values (same-field OR values are
@@ -434,7 +487,21 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
                 }}
                 textStyle="xs"
               />
+              {serverSearchActive && serverSearch.isLoading && (
+                <HStack
+                  data-testid="facet-search-spinner"
+                  gap={2}
+                  paddingX={1}
+                  paddingY={1}
+                >
+                  <Spinner size="xs" />
+                  <Text textStyle="2xs" color="fg.subtle">
+                    Searching all values…
+                  </Text>
+                </HStack>
+              )}
               {searchQuery.trim() &&
+                !(serverSearchActive && serverSearch.isLoading) &&
                 layout.facetWindow.visible.length === 0 && (
                   <Text textStyle="2xs" color="fg.muted" paddingX={1}>
                     No match. Press <Kbd>Enter</Kbd> to filter by "

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/FacetSection.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/FacetSection.tsx
@@ -196,11 +196,17 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
   // preloaded top-N `items`. The typed text is debounced before it hits the
   // server: a per-keystroke prefix scan over a high-cardinality facet is a real
   // ClickHouse round-trip. Gated on `serverValueSearch` — see useFacetSearch
-  // (server search is categorical-only). The hook is always called (hooks can't
-  // be conditional) but stays disabled until the gate opens.
+  // (server search is categorical-only) — AND on BOTH the live and debounced
+  // query: the debounced value drives the fetch (wait for typing to settle),
+  // while the live value disables it the instant the input is cleared so a
+  // stale prefix can't keep firing for the debounce window. The hook is always
+  // called (hooks can't be conditional) but stays disabled until the gate opens.
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 300);
   const serverSearchActive =
-    !!serverValueSearch && searchOpen && debouncedSearchQuery.trim().length > 0;
+    !!serverValueSearch &&
+    searchOpen &&
+    searchQuery.trim().length > 0 &&
+    debouncedSearchQuery.trim().length > 0;
   const serverSearch = useFacetSearch({
     facetKey: field,
     prefix: debouncedSearchQuery,
@@ -494,7 +500,7 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
                 }}
                 textStyle="xs"
               />
-              {serverSearchActive && serverSearch.isLoading && (
+              {serverSearchActive && serverSearch.isFetching && (
                 <HStack
                   data-testid="facet-search-spinner"
                   gap={2}
@@ -508,7 +514,7 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
                 </HStack>
               )}
               {searchQuery.trim() &&
-                !(serverSearchActive && serverSearch.isLoading) &&
+                !(serverSearchActive && serverSearch.isFetching) &&
                 layout.facetWindow.visible.length === 0 && (
                   <Text textStyle="2xs" color="fg.muted" paddingX={1}>
                     No match. Press <Kbd>Enter</Kbd> to filter by "

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/FacetSection.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/FacetSection.tsx
@@ -10,8 +10,10 @@ import {
 import type React from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Kbd } from "~/components/ops/shared/Kbd";
+import { useDebouncedValue } from "../../hooks/useDebouncedValue";
 import { useFacetSearch } from "../../hooks/useFacetSearch";
 import { useFacetLensStore } from "../../stores/facetLensStore";
+import { dedupeByValue } from "../../utils/dedupeByValue";
 import {
   AUTO_EXPAND_THRESHOLD,
   MAX_EXPANDED_FACETS,
@@ -52,15 +54,14 @@ interface FacetSectionProps {
     onToggle: () => void;
   };
   /**
-   * When true, the per-facet value search runs SERVER-SIDE: typing queries
-   * `facetValues` with the text as a `prefix`, matching against ALL of this
-   * facet's distinct values (not just the preloaded `items`). Set only by
-   * the categorical render branch — `facetValues` throws for range facets,
-   * so the discrete-range branch leaves it unset and the search stays the
-   * client-side filter over `items`. The Enter-to-filter fallback is kept in
-   * both modes for arbitrary / not-yet-ingested values.
+   * When true, the per-facet value search ALSO reaches the SERVER (queries
+   * `facetValues` with the typed text as a `prefix`) to SUPPLEMENT — not
+   * replace — the client-side filter over `items`, so values beyond the
+   * preloaded top-N surface too. Set only by the categorical render branch;
+   * see {@link useFacetSearch} — server search is categorical-only. The
+   * Enter-to-filter fallback is kept regardless for not-yet-ingested values.
    */
-  supportsValueSearch?: boolean;
+  serverValueSearch?: boolean;
   /**
    * Optional per-row extras renderer. Invoked for any row whose value
    * is currently active (i.e. surfaced via `pinnedContent`). The
@@ -119,7 +120,7 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
   renderInactiveRowExtras,
   synthetic,
   modeToggleProps,
-  supportsValueSearch,
+  serverValueSearch,
 }) => {
   const [expandedInactiveRows, setExpandedInactiveRows] = useState<Set<string>>(
     () => new Set(),
@@ -190,17 +191,19 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
   const presentValueCount = useMemo(() => countPresentValues(items), [items]);
 
   // Server-side value search. When the per-facet search is open with a
-  // non-empty query, query `facetValues` with that text as a `prefix` so the
-  // match runs against ALL of this facet's distinct values — not just the
-  // preloaded top-N `items`. Gated on `supportsValueSearch` because
-  // `facetValues` throws for range facets (SectionRenderer sets the prop only
-  // on the categorical render branch). The hook is always called (hooks can't
+  // non-empty query, ALSO query `facetValues` with that text as a `prefix` so
+  // the match reaches ALL of this facet's distinct values — not just the
+  // preloaded top-N `items`. The typed text is debounced before it hits the
+  // server: a per-keystroke prefix scan over a high-cardinality facet is a real
+  // ClickHouse round-trip. Gated on `serverValueSearch` — see useFacetSearch
+  // (server search is categorical-only). The hook is always called (hooks can't
   // be conditional) but stays disabled until the gate opens.
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, 300);
   const serverSearchActive =
-    !!supportsValueSearch && searchOpen && searchQuery.trim().length > 0;
+    !!serverValueSearch && searchOpen && debouncedSearchQuery.trim().length > 0;
   const serverSearch = useFacetSearch({
     facetKey: field,
-    prefix: searchQuery,
+    prefix: debouncedSearchQuery,
     enabled: serverSearchActive,
   });
   const serverItems = useMemo<FacetItem[]>(
@@ -213,18 +216,22 @@ const FacetSectionInner: React.FC<FacetSectionProps> = ({
     [serverSearch.values],
   );
 
-  // While server search is active the server has already matched the prefix
-  // against every value, so feed those into the pipeline instead of the
-  // preloaded top-N. Skip the client-side substring narrowing (pass an empty
-  // query to the sorter) — the server is the source of truth for what matches.
-  const baseItems = serverSearchActive ? serverItems : items;
-  const filtered = useMemo(
+  // SUPPLEMENT, don't replace: while server search is active, feed the UNION of
+  // the preloaded items and the server prefix results (preloaded first so it
+  // wins on a shared value, keeping its dotColor / aggregates). The client-side
+  // substring filter still runs over that union on the LIVE query every
+  // keystroke — a server prefix hit is also a substring match, so it survives,
+  // while a substring living WITHIN a preloaded value (e.g. "gpt-4o" inside
+  // "openai/gpt-4o-mini", which the server's anchored prefix match misses) is
+  // still found locally.
+  const baseItems = useMemo(
     () =>
-      filterAndSortItems({
-        items: baseItems,
-        searchQuery: serverSearchActive ? "" : searchQuery,
-      }),
-    [baseItems, serverSearchActive, searchQuery],
+      serverSearchActive ? dedupeByValue([...items, ...serverItems]) : items,
+    [serverSearchActive, items, serverItems],
+  );
+  const filtered = useMemo(
+    () => filterAndSortItems({ items: baseItems, searchQuery }),
+    [baseItems, searchQuery],
   );
 
   // Active rows = currently-filtered values (same-field OR values are

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/SectionRenderer.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/SectionRenderer.tsx
@@ -233,12 +233,10 @@ const SectionRendererInner: React.FC<SectionRendererProps> = ({
         renderActiveRowExtras={renderActiveRowExtras}
         renderInactiveRowExtras={renderInactiveRowExtras}
         synthetic={section.synthetic}
-        // Categorical facets support server-side value search — `facetValues`
-        // accepts them. Range facets do NOT (it throws for a range key, e.g.
-        // promptVersion), so the discrete-range branch below deliberately
-        // omits this prop. The discriminator is the render BRANCH, not the
-        // `field` (a discrete-range key can read like a categorical one).
-        supportsValueSearch
+        // Categorical facets get server-side value search; the discrete-range
+        // branch below omits it (the discriminator is the render BRANCH, not
+        // the `field`). See useFacetSearch — server search is categorical-only.
+        serverValueSearch
       />
     );
 

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/SectionRenderer.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/SectionRenderer.tsx
@@ -233,6 +233,12 @@ const SectionRendererInner: React.FC<SectionRendererProps> = ({
         renderActiveRowExtras={renderActiveRowExtras}
         renderInactiveRowExtras={renderInactiveRowExtras}
         synthetic={section.synthetic}
+        // Categorical facets support server-side value search — `facetValues`
+        // accepts them. Range facets do NOT (it throws for a range key, e.g.
+        // promptVersion), so the discrete-range branch below deliberately
+        // omits this prop. The discriminator is the render BRANCH, not the
+        // `field` (a discrete-range key can read like a categorical one).
+        supportsValueSearch
       />
     );
 

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.anyOf.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.anyOf.integration.test.tsx
@@ -14,6 +14,14 @@ import { Activity } from "lucide-react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
+// FacetSection now calls useFacetSearch (server-side value search) at the top
+// level. This suite renders FacetSection without a tRPC provider, so stub the
+// hook out — server search has its own suite
+// (FacetSection.serverSearch.integration.test.tsx).
+vi.mock("../../../hooks/useFacetSearch", () => ({
+  useFacetSearch: () => ({ values: [], totalDistinct: 0, isLoading: false }),
+}));
+
 import { FacetSection } from "../FacetSection";
 import type { FacetItem, FacetValueState } from "../types";
 

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.modeToggle.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.modeToggle.integration.test.tsx
@@ -14,6 +14,14 @@ import { Compass } from "lucide-react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
+// FacetSection now calls useFacetSearch (server-side value search) at the top
+// level. This suite renders FacetSection without a tRPC provider, so stub the
+// hook out — server search has its own dedicated suite
+// (FacetSection.serverSearch.integration.test.tsx).
+vi.mock("../../../hooks/useFacetSearch", () => ({
+  useFacetSearch: () => ({ values: [], totalDistinct: 0, isLoading: false }),
+}));
+
 import { FacetSection } from "../FacetSection";
 import type { FacetItem, FacetValueState } from "../types";
 

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.reorder.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.reorder.integration.test.tsx
@@ -13,6 +13,14 @@ import { Compass } from "lucide-react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
+// FacetSection now calls useFacetSearch (server-side value search) at the top
+// level. This suite renders FacetSection without a tRPC provider, so stub the
+// hook out — server search has its own dedicated suite
+// (FacetSection.serverSearch.integration.test.tsx).
+vi.mock("../../../hooks/useFacetSearch", () => ({
+  useFacetSearch: () => ({ values: [], totalDistinct: 0, isLoading: false }),
+}));
+
 import { FacetSection } from "../FacetSection";
 import type { FacetItem, FacetValueState } from "../types";
 

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.serverSearch.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.serverSearch.integration.test.tsx
@@ -53,18 +53,21 @@ const PRELOADED: FacetItem[] = [
 
 const neutral = (): FacetValueState => "neutral";
 
-function renderSection(props?: { supportsValueSearch?: boolean }) {
+function renderSection(props?: {
+  serverValueSearch?: boolean;
+  items?: FacetItem[];
+}) {
   return render(
     <ChakraProvider value={defaultSystem}>
       <FacetSection
         title="SERVICE"
         icon={Server}
         field="service"
-        items={PRELOADED}
+        items={props?.items ?? PRELOADED}
         getValueState={neutral}
         onToggle={vi.fn()}
         onExclude={vi.fn()}
-        supportsValueSearch={props?.supportsValueSearch}
+        serverValueSearch={props?.serverValueSearch}
       />
     </ChakraProvider>,
   );
@@ -111,25 +114,71 @@ describe("<FacetSection /> server-side value search", () => {
         },
       );
 
-      renderSection({ supportsValueSearch: true });
+      renderSection({ serverValueSearch: true });
       openSearchAndType("finance");
 
-      // The query reached past the preloaded five with a server-side prefix.
-      expect(apiMock.useQuery).toHaveBeenCalledWith(
-        expect.objectContaining({
-          facetKey: "service",
-          prefix: expect.stringContaining("finance"),
-        }),
-        expect.objectContaining({ enabled: true }),
+      // The query reached past the preloaded five with a server-side prefix
+      // (the typed text is debounced before it fires, hence waitFor).
+      await waitFor(() =>
+        expect(apiMock.useQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            facetKey: "service",
+            prefix: expect.stringContaining("finance"),
+          }),
+          expect.objectContaining({ enabled: true }),
+        ),
       );
       // And the server-only value renders as a row.
       expect(await screen.findByText("finance-team-42")).toBeInTheDocument();
     });
   });
 
+  describe("given a substring match lives within a preloaded value", () => {
+    // The server does a PREFIX match anchored at the start, so "gpt-4o" misses
+    // the namespaced "openai/gpt-4o-mini" and returns nothing. Pre-fix the code
+    // REPLACED the preloaded list with the (empty) server result and blanked
+    // the client query, so the row vanished. The SUPPLEMENT fix unions
+    // preloaded + server and keeps the live client substring filter, so a value
+    // beyond the server's anchored match is still found locally.
+    it("still finds a substring match within the preloaded items while the server search is active", async () => {
+      apiMock.useQuery.mockImplementation(
+        (_input: { prefix?: string }, opts: { enabled?: boolean }) =>
+          opts?.enabled
+            ? { data: { values: [], totalDistinct: 0 }, isLoading: false }
+            : { data: undefined, isLoading: false },
+      );
+
+      renderSection({
+        serverValueSearch: true,
+        items: [
+          ...PRELOADED,
+          {
+            value: "openai/gpt-4o-mini",
+            label: "openai/gpt-4o-mini",
+            count: 5,
+          },
+        ],
+      });
+      openSearchAndType("gpt-4o");
+
+      // Server search goes active (debounced) and prefix-misses → empty result…
+      await waitFor(() =>
+        expect(apiMock.useQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            prefix: expect.stringContaining("gpt-4o"),
+          }),
+          expect.objectContaining({ enabled: true }),
+        ),
+      );
+      // …yet the client substring filter over the preloaded∪server union still
+      // surfaces it.
+      expect(await screen.findByText("openai/gpt-4o-mini")).toBeInTheDocument();
+    });
+  });
+
   describe("given a facet that does NOT support value search (range/discrete)", () => {
     it("never enables the server query", () => {
-      renderSection({ supportsValueSearch: false });
+      renderSection({ serverValueSearch: false });
       openSearchAndType("finance");
 
       expect(apiMock.useQuery).not.toHaveBeenCalledWith(
@@ -154,7 +203,7 @@ describe("<FacetSection /> server-side value search", () => {
             : { data: undefined, isLoading: false },
       );
 
-      renderSection({ supportsValueSearch: true });
+      renderSection({ serverValueSearch: true });
       const input = openSearchAndType("finance");
       expect(await screen.findByText("finance-team-42")).toBeInTheDocument();
 
@@ -165,14 +214,18 @@ describe("<FacetSection /> server-side value search", () => {
         expect(screen.queryByText("finance-team-42")).not.toBeInTheDocument(),
       );
       expect(screen.getByText("checkout")).toBeInTheDocument();
-      // The most recent facetValues call is disabled.
-      const lastCall = apiMock.useQuery.mock.calls.at(-1);
-      expect(lastCall?.[1]?.enabled).toBe(false);
+      // The server query disables once the debounce settles to "" — the
+      // debounced prefix lingers ~300ms after the input is cleared, so poll
+      // until the latest facetValues call is disabled (the live client filter
+      // already restored the preloaded items synchronously, above).
+      await waitFor(() =>
+        expect(apiMock.useQuery.mock.calls.at(-1)?.[1]?.enabled).toBe(false),
+      );
     });
   });
 
-  describe("while the server search is loading", () => {
-    it("shows a spinner row", () => {
+  describe("when the server search is loading", () => {
+    it("shows a spinner row", async () => {
       apiMock.useQuery.mockImplementation(
         (_input: { prefix?: string }, opts: { enabled?: boolean }) =>
           opts?.enabled
@@ -180,10 +233,13 @@ describe("<FacetSection /> server-side value search", () => {
             : { data: undefined, isLoading: false },
       );
 
-      renderSection({ supportsValueSearch: true });
+      renderSection({ serverValueSearch: true });
       openSearchAndType("finance");
 
-      expect(screen.getByTestId("facet-search-spinner")).toBeInTheDocument();
+      // Debounced: the spinner appears once the server query actually fires.
+      expect(
+        await screen.findByTestId("facet-search-spinner"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.serverSearch.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.serverSearch.integration.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Server-side facet value search. Typing in a categorical facet's value
+ * search queries `tracesV2.facetValues` with a `prefix`, matching against ALL
+ * distinct values — so a high-cardinality facet (models, users, services,
+ * trace names, labels) can surface a value beyond the preloaded top-50.
+ * See specs/traces-v2/search.feature, rule "Very high-cardinality facets".
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { Server } from "lucide-react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+// useFacetSearch (exercised for real here) reads project + time range and
+// fires the tracesV2.facetValues query. Mock those three boundaries so the
+// hook runs against a controllable server response.
+const apiMock = vi.hoisted(() => ({ useQuery: vi.fn() }));
+
+vi.mock("~/utils/api", () => ({
+  api: { tracesV2: { facetValues: { useQuery: apiMock.useQuery } } },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { id: "proj-1" } }),
+}));
+
+vi.mock("../../../stores/filterStore", () => ({
+  useFilterStore: (selector: (s: unknown) => unknown) =>
+    selector({ debouncedTimeRange: { from: 1, to: 2, label: undefined } }),
+}));
+
+import { FacetSection } from "../FacetSection";
+import type { FacetItem, FacetValueState } from "../types";
+
+// Five preloaded service values — the top-N the discover payload shipped.
+// "finance-team-42" is deliberately NOT among them: it lives only server-side.
+const PRELOADED: FacetItem[] = [
+  { value: "checkout", label: "checkout", count: 50 },
+  { value: "billing", label: "billing", count: 40 },
+  { value: "auth", label: "auth", count: 30 },
+  { value: "search", label: "search", count: 20 },
+  { value: "inventory", label: "inventory", count: 10 },
+];
+
+const neutral = (): FacetValueState => "neutral";
+
+function renderSection(props?: { supportsValueSearch?: boolean }) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <FacetSection
+        title="SERVICE"
+        icon={Server}
+        field="service"
+        items={PRELOADED}
+        getValueState={neutral}
+        onToggle={vi.fn()}
+        onExclude={vi.fn()}
+        supportsValueSearch={props?.supportsValueSearch}
+      />
+    </ChakraProvider>,
+  );
+}
+
+const openSearchAndType = (text: string) => {
+  fireEvent.click(
+    screen.getByRole("button", { name: "Search SERVICE values" }),
+  );
+  const input = screen.getByPlaceholderText(/Search or press Enter/i);
+  fireEvent.change(input, { target: { value: text } });
+  return input as HTMLInputElement;
+};
+
+beforeEach(() => {
+  apiMock.useQuery.mockReset();
+  // Default: a settled, empty server response.
+  apiMock.useQuery.mockImplementation(() => ({
+    data: { values: [], totalDistinct: 0 },
+    isLoading: false,
+  }));
+});
+
+afterEach(() => cleanup());
+
+describe("<FacetSection /> server-side value search", () => {
+  describe("given a categorical facet that supports value search", () => {
+    /** @scenario "Facet search matches against all values" */
+    it("queries facetValues with a prefix and surfaces a value beyond the preloaded top-N", async () => {
+      apiMock.useQuery.mockImplementation(
+        (input: { prefix?: string }, opts: { enabled?: boolean }) => {
+          if (!opts?.enabled) return { data: undefined, isLoading: false };
+          const prefix = String(input.prefix ?? "").toLowerCase();
+          if (prefix.includes("finance")) {
+            return {
+              data: {
+                values: [{ value: "finance-team-42", count: 3 }],
+                totalDistinct: 1,
+              },
+              isLoading: false,
+            };
+          }
+          return { data: { values: [], totalDistinct: 0 }, isLoading: false };
+        },
+      );
+
+      renderSection({ supportsValueSearch: true });
+      openSearchAndType("finance");
+
+      // The query reached past the preloaded five with a server-side prefix.
+      expect(apiMock.useQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          facetKey: "service",
+          prefix: expect.stringContaining("finance"),
+        }),
+        expect.objectContaining({ enabled: true }),
+      );
+      // And the server-only value renders as a row.
+      expect(await screen.findByText("finance-team-42")).toBeInTheDocument();
+    });
+  });
+
+  describe("given a facet that does NOT support value search (range/discrete)", () => {
+    it("never enables the server query", () => {
+      renderSection({ supportsValueSearch: false });
+      openSearchAndType("finance");
+
+      expect(apiMock.useQuery).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
+  });
+
+  describe("when the search is cleared", () => {
+    it("restores the preloaded items and disables the server query", async () => {
+      apiMock.useQuery.mockImplementation(
+        (_input: { prefix?: string }, opts: { enabled?: boolean }) =>
+          opts?.enabled
+            ? {
+                data: {
+                  values: [{ value: "finance-team-42", count: 3 }],
+                  totalDistinct: 1,
+                },
+                isLoading: false,
+              }
+            : { data: undefined, isLoading: false },
+      );
+
+      renderSection({ supportsValueSearch: true });
+      const input = openSearchAndType("finance");
+      expect(await screen.findByText("finance-team-42")).toBeInTheDocument();
+
+      fireEvent.change(input, { target: { value: "" } });
+
+      // The preloaded list is back; the server-only value is gone.
+      await waitFor(() =>
+        expect(screen.queryByText("finance-team-42")).not.toBeInTheDocument(),
+      );
+      expect(screen.getByText("checkout")).toBeInTheDocument();
+      // The most recent facetValues call is disabled.
+      const lastCall = apiMock.useQuery.mock.calls.at(-1);
+      expect(lastCall?.[1]?.enabled).toBe(false);
+    });
+  });
+
+  describe("while the server search is loading", () => {
+    it("shows a spinner row", () => {
+      apiMock.useQuery.mockImplementation(
+        (_input: { prefix?: string }, opts: { enabled?: boolean }) =>
+          opts?.enabled
+            ? { data: undefined, isLoading: true }
+            : { data: undefined, isLoading: false },
+      );
+
+      renderSection({ supportsValueSearch: true });
+      openSearchAndType("finance");
+
+      expect(screen.getByTestId("facet-search-spinner")).toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.serverSearch.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/FacetSection.serverSearch.integration.test.tsx
@@ -209,28 +209,25 @@ describe("<FacetSection /> server-side value search", () => {
 
       fireEvent.change(input, { target: { value: "" } });
 
-      // The preloaded list is back; the server-only value is gone.
-      await waitFor(() =>
-        expect(screen.queryByText("finance-team-42")).not.toBeInTheDocument(),
-      );
+      // The live-input gate disables the server query SYNCHRONOUSLY on clear —
+      // no 300ms stale window where the debounced prefix would keep firing.
+      expect(apiMock.useQuery.mock.calls.at(-1)?.[1]?.enabled).toBe(false);
+      // The preloaded list is back and the server-only value is gone.
       expect(screen.getByText("checkout")).toBeInTheDocument();
-      // The server query disables once the debounce settles to "" — the
-      // debounced prefix lingers ~300ms after the input is cleared, so poll
-      // until the latest facetValues call is disabled (the live client filter
-      // already restored the preloaded items synchronously, above).
-      await waitFor(() =>
-        expect(apiMock.useQuery.mock.calls.at(-1)?.[1]?.enabled).toBe(false),
-      );
+      expect(screen.queryByText("finance-team-42")).not.toBeInTheDocument();
     });
   });
 
   describe("when the server search is loading", () => {
     it("shows a spinner row", async () => {
+      // keepPreviousData means a refinement refetch reports isLoading:false but
+      // isFetching:true — the spinner must follow isFetching, not isLoading
+      // (see useFacetSearch). Revert the gate to isLoading and this fails.
       apiMock.useQuery.mockImplementation(
         (_input: { prefix?: string }, opts: { enabled?: boolean }) =>
           opts?.enabled
-            ? { data: undefined, isLoading: true }
-            : { data: undefined, isLoading: false },
+            ? { data: undefined, isLoading: false, isFetching: true }
+            : { data: undefined, isLoading: false, isFetching: false },
       );
 
       renderSection({ serverValueSearch: true });

--- a/langwatch/src/features/traces-v2/components/SearchBar/TokenValuePicker.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/TokenValuePicker.tsx
@@ -130,10 +130,14 @@ export const TokenValuePicker: React.FC<TokenValuePickerProps> = ({
     debouncedFilter.trim().toLowerCase() ===
       anchor.currentValue.trim().toLowerCase();
 
+  // Gated on BOTH the live `pristine` and the debounced `serverPristine`: the
+  // debounced gate waits for typing to settle before fetching, the live gate
+  // disables the query the instant the text returns to the chip's value so a
+  // stale prefix can't keep firing for the debounce window.
   const serverSearch = useFacetSearch({
     facetKey: anchor?.field ?? "",
     prefix: debouncedFilter,
-    enabled: !!cat && !serverPristine,
+    enabled: !!cat && !pristine && !serverPristine,
   });
 
   const values = useMemo(() => {

--- a/langwatch/src/features/traces-v2/components/SearchBar/TokenValuePicker.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/TokenValuePicker.tsx
@@ -12,10 +12,12 @@ import { BookOpen, Check, Plus, Search } from "lucide-react";
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useDebouncedValue } from "../../hooks/useDebouncedValue";
 import { useFacetSearch } from "../../hooks/useFacetSearch";
 import { useTraceFacets } from "../../hooks/useTraceFacets";
 import { useFilterStore } from "../../stores/filterStore";
 import { useUIStore } from "../../stores/uiStore";
+import { dedupeByValue } from "../../utils/dedupeByValue";
 
 const MAX_VALUES_PER_PAGE = 60;
 const POPOVER_WIDTH = 320;
@@ -114,27 +116,50 @@ export const TokenValuePicker: React.FC<TokenValuePickerProps> = ({
     filter.trim() === "" ||
     filter.trim().toLowerCase() === anchor.currentValue.trim().toLowerCase();
 
+  // Debounce the typed text before it hits the server — a per-keystroke
+  // `facetValues` prefix scan over a high-cardinality facet is a real
+  // ClickHouse round-trip. The client-side substring filter in the `values`
+  // memo below stays on the live `filter` for instant local narrowing; only
+  // this server query reads the debounced value. `serverPristine` mirrors
+  // `pristine` on the debounced text so the query doesn't fire until typing
+  // settles.
+  const debouncedFilter = useDebouncedValue(filter, 300);
+  const serverPristine =
+    !anchor ||
+    debouncedFilter.trim() === "" ||
+    debouncedFilter.trim().toLowerCase() ===
+      anchor.currentValue.trim().toLowerCase();
+
   const serverSearch = useFacetSearch({
     facetKey: anchor?.field ?? "",
-    prefix: filter,
-    enabled: !!cat && !pristine,
+    prefix: debouncedFilter,
+    enabled: !!cat && !serverPristine,
   });
 
-  const values = useMemo<
-    { value: string; label?: string; count: number }[]
-  >(() => {
+  const values = useMemo(() => {
     if (!anchor || !cat) return [];
-    // Pristine → the preloaded alternatives. Edited → server-side prefix
-    // results matched against ALL values (the server matches value AND label),
-    // not just the preloaded top-N. Annotated to the common shape so `.map`
-    // resolves over the two source arrays without a union-of-arrays call error.
+    // Pristine → the preloaded alternatives, shown unfiltered as a dropdown.
+    // Edited → SUPPLEMENT the preloaded top-N with the server prefix results
+    // (union, preloaded first so it wins on a shared value), then narrow by the
+    // live (undebounced) substring filter: a server prefix hit is also a
+    // substring match so it survives, while a substring living WITHIN a
+    // preloaded value (which the server's anchored prefix match misses) is
+    // still found locally. Annotated to the common shape so `.map` resolves
+    // over the two source arrays without a union-of-arrays call error.
     const source: { value: string; label?: string; count: number }[] = pristine
       ? cat.topValues
-      : serverSearch.values;
+      : dedupeByValue([...cat.topValues, ...serverSearch.values]);
+    const q = pristine ? "" : filter.trim().toLowerCase();
     return source
+      .filter(
+        (v) =>
+          !q ||
+          v.value.toLowerCase().includes(q) ||
+          (v.label?.toLowerCase().includes(q) ?? false),
+      )
       .map((v) => ({ value: v.value, label: v.label, count: v.count }))
       .slice(0, MAX_VALUES_PER_PAGE);
-  }, [anchor, cat, pristine, serverSearch.values]);
+  }, [anchor, cat, pristine, serverSearch.values, filter]);
 
   // On open, move the highlight onto the current value's row so ↑↓ starts
   // from where the user is and a bare Enter re-commits the current value (a

--- a/langwatch/src/features/traces-v2/components/SearchBar/TokenValuePicker.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/TokenValuePicker.tsx
@@ -62,6 +62,11 @@ export const TokenValuePicker: React.FC<TokenValuePickerProps> = ({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const seededOpenKey = useRef<string | null>(null);
+  // Anchor (`field:start`) the `filter` has been (re)seeded for. Gates the
+  // server query so a direct chip-to-chip switch can't fire for the new field
+  // carrying the previous chip's text — `anchor` changes one render before the
+  // reseed effect below resets `filter`. Same keyed-ref idiom as seededOpenKey.
+  const filterSeededAnchorKey = useRef<string | null>(null);
 
   // Prefill the input with the chip's current value so the user can edit it
   // as text (not just filter the list) — clicking a chip should let you tweak
@@ -70,6 +75,9 @@ export const TokenValuePicker: React.FC<TokenValuePickerProps> = ({
   useEffect(() => {
     setFilter(anchor?.currentValue ?? "");
     setActiveIndex(0);
+    filterSeededAnchorKey.current = anchor
+      ? `${anchor.field}:${anchor.location.start}`
+      : null;
   }, [anchor?.field, anchor?.location.start, anchor?.currentValue]);
 
   // Focus the search input when the picker OPENS — deferred to the next
@@ -133,11 +141,19 @@ export const TokenValuePicker: React.FC<TokenValuePickerProps> = ({
   // Gated on BOTH the live `pristine` and the debounced `serverPristine`: the
   // debounced gate waits for typing to settle before fetching, the live gate
   // disables the query the instant the text returns to the chip's value so a
-  // stale prefix can't keep firing for the debounce window.
+  // stale prefix can't keep firing for the debounce window. Also gated on the
+  // filter having been (re)seeded for the CURRENT anchor — a chip-to-chip switch
+  // changes `anchor.field` one render before the reseed effect resets `filter`,
+  // so without this the query would fire for the new field with the old text.
   const serverSearch = useFacetSearch({
     facetKey: anchor?.field ?? "",
     prefix: debouncedFilter,
-    enabled: !!cat && !pristine && !serverPristine,
+    enabled:
+      !!cat &&
+      !pristine &&
+      !serverPristine &&
+      filterSeededAnchorKey.current ===
+        (anchor ? `${anchor.field}:${anchor.location.start}` : null),
   });
 
   const values = useMemo(() => {

--- a/langwatch/src/features/traces-v2/components/SearchBar/TokenValuePicker.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/TokenValuePicker.tsx
@@ -12,6 +12,7 @@ import { BookOpen, Check, Plus, Search } from "lucide-react";
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useFacetSearch } from "../../hooks/useFacetSearch";
 import { useTraceFacets } from "../../hooks/useTraceFacets";
 import { useFilterStore } from "../../stores/filterStore";
 import { useUIStore } from "../../stores/uiStore";
@@ -91,29 +92,49 @@ export const TokenValuePicker: React.FC<TokenValuePickerProps> = ({
     return () => cancelAnimationFrame(raf);
   }, [anchor?.field, anchor?.location.start]);
 
-  const values = useMemo(() => {
-    if (!anchor) return [];
-    const cat = facets.find(
+  // Resolve this chip's field to a categorical descriptor. Lifted above the
+  // value memo so the server-search hook's `enabled` can depend on it.
+  // `facetValues` only accepts categorical facets, so a non-categorical /
+  // unknown field leaves `cat` undefined and the picker shows nothing.
+  const cat = useMemo(() => {
+    if (!anchor) return undefined;
+    const found = facets.find(
       (d) => d.kind === "categorical" && d.key === anchor.field,
     );
-    if (!cat || cat.kind !== "categorical") return [];
-    const q = filter.trim().toLowerCase();
-    // While the input still holds the unedited current value (or is empty),
-    // show the FULL list so the picker still reads as a dropdown of
-    // alternatives — only narrow once the user actually edits the text.
-    // Match against value AND label so typing the friendly name (e.g.
-    // "Faithfulness") finds the id-keyed row ("ragas/faithfulness") —
-    // mirrors the sidebar facet section's search behaviour.
-    const pristine = q === "" || q === anchor.currentValue.trim().toLowerCase();
-    const filtered = pristine
+    return found && found.kind === "categorical" ? found : undefined;
+  }, [facets, anchor]);
+
+  // "Pristine" = the input still holds the chip's unedited value (or is
+  // empty). While pristine the picker reads as a dropdown of alternatives —
+  // show the full preloaded top-N and DON'T hit the server. Once the user
+  // edits the text we switch to a server-side prefix search so a value beyond
+  // the preloaded top-N can be found and picked.
+  const pristine =
+    !anchor ||
+    filter.trim() === "" ||
+    filter.trim().toLowerCase() === anchor.currentValue.trim().toLowerCase();
+
+  const serverSearch = useFacetSearch({
+    facetKey: anchor?.field ?? "",
+    prefix: filter,
+    enabled: !!cat && !pristine,
+  });
+
+  const values = useMemo<
+    { value: string; label?: string; count: number }[]
+  >(() => {
+    if (!anchor || !cat) return [];
+    // Pristine → the preloaded alternatives. Edited → server-side prefix
+    // results matched against ALL values (the server matches value AND label),
+    // not just the preloaded top-N. Annotated to the common shape so `.map`
+    // resolves over the two source arrays without a union-of-arrays call error.
+    const source: { value: string; label?: string; count: number }[] = pristine
       ? cat.topValues
-      : cat.topValues.filter(
-          (v) =>
-            v.value.toLowerCase().includes(q) ||
-            (v.label?.toLowerCase().includes(q) ?? false),
-        );
-    return filtered.slice(0, MAX_VALUES_PER_PAGE);
-  }, [facets, anchor, filter]);
+      : serverSearch.values;
+    return source
+      .map((v) => ({ value: v.value, label: v.label, count: v.count }))
+      .slice(0, MAX_VALUES_PER_PAGE);
+  }, [anchor, cat, pristine, serverSearch.values]);
 
   // On open, move the highlight onto the current value's row so ↑↓ starts
   // from where the user is and a bare Enter re-commits the current value (a

--- a/langwatch/src/features/traces-v2/components/SearchBar/__tests__/SearchBar.browser.test.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/__tests__/SearchBar.browser.test.tsx
@@ -17,6 +17,13 @@ vi.mock("../../../hooks/useTraceFacets", () => ({
   useTraceFacets: () => ({ data: [], isLoading: false }),
 }));
 
+// SearchBar mounts TokenValuePicker, which now calls useFacetSearch (a tRPC
+// query) at the top level. This suite renders SearchBar without a tRPC
+// provider, so stub the hook out — server search has its own dedicated suite.
+vi.mock("../../../hooks/useFacetSearch", () => ({
+  useFacetSearch: () => ({ values: [], totalDistinct: 0, isLoading: false }),
+}));
+
 import { useFilterStore } from "../../../stores/filterStore";
 import { SearchBar } from "../SearchBar";
 

--- a/langwatch/src/features/traces-v2/components/SearchBar/__tests__/SearchBar.errorBanner.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/__tests__/SearchBar.errorBanner.integration.test.tsx
@@ -37,6 +37,13 @@ vi.mock("../../../hooks/useTraceFacets", () => ({
   useTraceFacets: () => ({ data: [], isLoading: false }),
 }));
 
+// SearchBar mounts TokenValuePicker, which now calls useFacetSearch at the
+// top level. These tests don't wrap with a tRPC provider, so stub the hook
+// out — server search is covered by its own dedicated suite.
+vi.mock("../../../hooks/useFacetSearch", () => ({
+  useFacetSearch: () => ({ values: [], totalDistinct: 0, isLoading: false }),
+}));
+
 vi.mock("@paper-design/shaders-react", () => ({
   MeshGradient: () => null,
 }));
@@ -112,7 +119,8 @@ describe("<SearchBar /> unified error banner", () => {
   describe("given an AI error with structured details in the store", () => {
     const aiError: AiActionError = {
       code: "provider_error",
-      message: "Failed after 2 attempts. Last error: Cannot connect to provider.",
+      message:
+        "Failed after 2 attempts. Last error: Cannot connect to provider.",
       details: {
         provider: "openai",
         model: "gpt-5-mini",
@@ -228,9 +236,7 @@ describe("<SearchBar /> unified error banner", () => {
   describe("given no errors in the store", () => {
     it("does not render the banner", () => {
       renderSearchBar();
-      expect(
-        screen.queryByLabelText(/dismiss error/i),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/dismiss error/i)).not.toBeInTheDocument();
     });
   });
 

--- a/langwatch/src/features/traces-v2/components/SearchBar/__tests__/SearchBar.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/__tests__/SearchBar.integration.test.tsx
@@ -44,6 +44,14 @@ vi.mock("../../../hooks/useTraceFacets", () => ({
   useTraceFacets: () => ({ data: [], isLoading: false }),
 }));
 
+// SearchBar mounts TokenValuePicker, which now calls useFacetSearch at the
+// top level. These smoke tests don't wrap with a tRPC provider, so stub the
+// hook out — its server search is covered by
+// TokenValuePicker.serverSearch.integration.test.tsx.
+vi.mock("../../../hooks/useFacetSearch", () => ({
+  useFacetSearch: () => ({ values: [], totalDistinct: 0, isLoading: false }),
+}));
+
 // @paper-design/shaders-react requires WebGL, which jsdom does not provide.
 // The shader backdrop is decorative; rendering nothing keeps the SearchBar
 // mountable without crashing on an unhandled WebGL constructor rejection.

--- a/langwatch/src/features/traces-v2/components/SearchBar/__tests__/TokenValuePicker.serverSearch.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/__tests__/TokenValuePicker.serverSearch.integration.test.tsx
@@ -8,7 +8,13 @@
  */
 
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -100,12 +106,16 @@ describe("<TokenValuePicker /> server-side search", () => {
       const input = screen.getByPlaceholderText(/Filter service values/i);
       fireEvent.change(input, { target: { value: "finance" } });
 
-      expect(apiMock.useQuery).toHaveBeenCalledWith(
-        expect.objectContaining({
-          facetKey: "service",
-          prefix: expect.stringContaining("finance"),
-        }),
-        expect.objectContaining({ enabled: true }),
+      // The typed text is debounced before the server query fires, hence
+      // waitFor rather than a synchronous assertion.
+      await waitFor(() =>
+        expect(apiMock.useQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            facetKey: "service",
+            prefix: expect.stringContaining("finance"),
+          }),
+          expect.objectContaining({ enabled: true }),
+        ),
       );
       expect(await screen.findByText("finance-prod-99")).toBeInTheDocument();
     });

--- a/langwatch/src/features/traces-v2/components/SearchBar/__tests__/TokenValuePicker.serverSearch.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/__tests__/TokenValuePicker.serverSearch.integration.test.tsx
@@ -29,8 +29,10 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
 }));
 
 // The picker resolves its field's categorical descriptor from useTraceFacets.
-// Its top values are only "checkout" / "billing" — "finance-prod-99" exists
-// only server-side, so finding it proves the search reached past the top-N.
+// Preloaded top values: "checkout" / "billing" (so a server-only value like
+// "finance-prod-99" proves the search reached past the top-N), plus the
+// namespaced "openai/gpt-4o-mini" — the server's ANCHORED prefix "gpt-4o"
+// misses it, so it exercises the supplement (preloaded ∪ server) regression.
 vi.mock("../../../hooks/useTraceFacets", () => ({
   useTraceFacets: () => ({
     data: [
@@ -41,6 +43,7 @@ vi.mock("../../../hooks/useTraceFacets", () => ({
         topValues: [
           { value: "checkout", count: 50 },
           { value: "billing", count: 40 },
+          { value: "openai/gpt-4o-mini", count: 5 },
         ],
       },
     ],
@@ -94,7 +97,6 @@ afterEach(() => cleanup());
 
 describe("<TokenValuePicker /> server-side search", () => {
   describe("given the user edits a categorical chip's value", () => {
-    /** @scenario "Editing a search-bar value chip searches all values, not just the preloaded set" */
     it("queries facetValues with a prefix and surfaces a value beyond the preloaded top-N", async () => {
       render(
         <ChakraProvider value={defaultSystem}>
@@ -133,6 +135,49 @@ describe("<TokenValuePicker /> server-side search", () => {
         expect.anything(),
         expect.objectContaining({ enabled: true }),
       );
+    });
+  });
+
+  describe("given a substring match lives within a preloaded value", () => {
+    // The server does a PREFIX match anchored at the start, so "gpt-4o" misses
+    // the namespaced "openai/gpt-4o-mini" and returns nothing. A replace-regression
+    // (the empty server result REPLACING the preloaded list) would drop the row;
+    // the SUPPLEMENT contract unions preloaded + server and keeps the live client
+    // substring filter, so the preloaded value — a substring match — stays shown.
+    // Mirrors FacetSection.serverSearch's preloaded-survival regression.
+    /** @scenario "Editing a search-bar value chip searches all values, not just the preloaded set" */
+    it("keeps a matching preloaded value when the server prefix search misses it (supplement, not replace)", async () => {
+      apiMock.useQuery.mockImplementation(
+        (_input: { prefix?: string }, opts: { enabled?: boolean }) =>
+          opts?.enabled
+            ? { data: { values: [], totalDistinct: 0 }, isLoading: false }
+            : { data: undefined, isLoading: false },
+      );
+
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <TokenValuePicker anchor={anchor} onClose={vi.fn()} />
+        </ChakraProvider>,
+      );
+
+      // Editing "checkout" → "gpt-4o" flips to a server-side search whose
+      // anchored prefix misses the namespaced preloaded value.
+      const input = screen.getByPlaceholderText(/Filter service values/i);
+      fireEvent.change(input, { target: { value: "gpt-4o" } });
+
+      // Server search goes active (debounced) and prefix-misses → empty result…
+      await waitFor(() =>
+        expect(apiMock.useQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            facetKey: "service",
+            prefix: expect.stringContaining("gpt-4o"),
+          }),
+          expect.objectContaining({ enabled: true }),
+        ),
+      );
+      // …yet the preloaded value, a substring match over the preloaded∪server
+      // union, is still shown. Under a replace-regression it would vanish.
+      expect(await screen.findByText("openai/gpt-4o-mini")).toBeInTheDocument();
     });
   });
 });

--- a/langwatch/src/features/traces-v2/components/SearchBar/__tests__/TokenValuePicker.serverSearch.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/__tests__/TokenValuePicker.serverSearch.integration.test.tsx
@@ -94,6 +94,7 @@ afterEach(() => cleanup());
 
 describe("<TokenValuePicker /> server-side search", () => {
   describe("given the user edits a categorical chip's value", () => {
+    /** @scenario "Editing a search-bar value chip searches all values, not just the preloaded set" */
     it("queries facetValues with a prefix and surfaces a value beyond the preloaded top-N", async () => {
       render(
         <ChakraProvider value={defaultSystem}>

--- a/langwatch/src/features/traces-v2/components/SearchBar/__tests__/TokenValuePicker.serverSearch.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/__tests__/TokenValuePicker.serverSearch.integration.test.tsx
@@ -145,39 +145,41 @@ describe("<TokenValuePicker /> server-side search", () => {
     // the SUPPLEMENT contract unions preloaded + server and keeps the live client
     // substring filter, so the preloaded value — a substring match — stays shown.
     // Mirrors FacetSection.serverSearch's preloaded-survival regression.
-    /** @scenario "Editing a search-bar value chip searches all values, not just the preloaded set" */
-    it("keeps a matching preloaded value when the server prefix search misses it (supplement, not replace)", async () => {
-      apiMock.useQuery.mockImplementation(
-        (_input: { prefix?: string }, opts: { enabled?: boolean }) =>
-          opts?.enabled
-            ? { data: { values: [], totalDistinct: 0 }, isLoading: false }
-            : { data: undefined, isLoading: false },
-      );
+    describe("when the user edits the chip to a value the server prefix-search misses", () => {
+      /** @scenario "Editing a search-bar value chip searches all values, not just the preloaded set" */
+      it("keeps a matching preloaded value when the server prefix search misses it (supplement, not replace)", async () => {
+        apiMock.useQuery.mockImplementation(
+          (_input: { prefix?: string }, opts: { enabled?: boolean }) =>
+            opts?.enabled
+              ? { data: { values: [], totalDistinct: 0 }, isLoading: false }
+              : { data: undefined, isLoading: false },
+        );
 
-      render(
-        <ChakraProvider value={defaultSystem}>
-          <TokenValuePicker anchor={anchor} onClose={vi.fn()} />
-        </ChakraProvider>,
-      );
+        render(
+          <ChakraProvider value={defaultSystem}>
+            <TokenValuePicker anchor={anchor} onClose={vi.fn()} />
+          </ChakraProvider>,
+        );
 
-      // Editing "checkout" → "gpt-4o" flips to a server-side search whose
-      // anchored prefix misses the namespaced preloaded value.
-      const input = screen.getByPlaceholderText(/Filter service values/i);
-      fireEvent.change(input, { target: { value: "gpt-4o" } });
+        const input = screen.getByPlaceholderText(/Filter service values/i);
+        fireEvent.change(input, { target: { value: "gpt-4o" } });
 
-      // Server search goes active (debounced) and prefix-misses → empty result…
-      await waitFor(() =>
-        expect(apiMock.useQuery).toHaveBeenCalledWith(
-          expect.objectContaining({
-            facetKey: "service",
-            prefix: expect.stringContaining("gpt-4o"),
-          }),
-          expect.objectContaining({ enabled: true }),
-        ),
-      );
-      // …yet the preloaded value, a substring match over the preloaded∪server
-      // union, is still shown. Under a replace-regression it would vanish.
-      expect(await screen.findByText("openai/gpt-4o-mini")).toBeInTheDocument();
+        // Server search goes active (debounced) and prefix-misses → empty result…
+        await waitFor(() =>
+          expect(apiMock.useQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+              facetKey: "service",
+              prefix: expect.stringContaining("gpt-4o"),
+            }),
+            expect.objectContaining({ enabled: true }),
+          ),
+        );
+        // …yet the preloaded value, a substring match over the preloaded∪server
+        // union, is still shown. Under a replace-regression it would vanish.
+        expect(
+          await screen.findByText("openai/gpt-4o-mini"),
+        ).toBeInTheDocument();
+      });
     });
   });
 });

--- a/langwatch/src/features/traces-v2/components/SearchBar/__tests__/TokenValuePicker.serverSearch.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/__tests__/TokenValuePicker.serverSearch.integration.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Server-side search inside the search-bar value picker. Once the user edits
+ * a categorical chip's value the picker queries `tracesV2.facetValues` with a
+ * `prefix`, so a value beyond the preloaded top-N can be found and picked.
+ * See specs/traces-v2/search.feature, rule "Very high-cardinality facets".
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const apiMock = vi.hoisted(() => ({ useQuery: vi.fn() }));
+
+vi.mock("~/utils/api", () => ({
+  api: { tracesV2: { facetValues: { useQuery: apiMock.useQuery } } },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { id: "proj-1" } }),
+}));
+
+// The picker resolves its field's categorical descriptor from useTraceFacets.
+// Its top values are only "checkout" / "billing" — "finance-prod-99" exists
+// only server-side, so finding it proves the search reached past the top-N.
+vi.mock("../../../hooks/useTraceFacets", () => ({
+  useTraceFacets: () => ({
+    data: [
+      {
+        kind: "categorical",
+        key: "service",
+        label: "Service",
+        topValues: [
+          { value: "checkout", count: 50 },
+          { value: "billing", count: 40 },
+        ],
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+vi.mock("../../../stores/filterStore", () => ({
+  useFilterStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      setFacetValueAt: vi.fn(),
+      debouncedTimeRange: { from: 1, to: 2, label: undefined },
+    }),
+}));
+
+vi.mock("../../../stores/uiStore", () => ({
+  useUIStore: (selector: (s: unknown) => unknown) =>
+    selector({ setSyntaxHelpOpen: vi.fn() }),
+}));
+
+import { TokenValuePicker } from "../TokenValuePicker";
+
+const anchor = {
+  rect: { bottom: 100, left: 100, top: 80, right: 220 } as DOMRect,
+  field: "service",
+  currentValue: "checkout",
+  location: { start: 0, end: 16 },
+};
+
+beforeEach(() => {
+  apiMock.useQuery.mockReset();
+  apiMock.useQuery.mockImplementation(
+    (input: { prefix?: string }, opts: { enabled?: boolean }) => {
+      if (!opts?.enabled) return { data: undefined, isLoading: false };
+      const prefix = String(input.prefix ?? "").toLowerCase();
+      if (prefix.includes("finance")) {
+        return {
+          data: {
+            values: [{ value: "finance-prod-99", count: 7 }],
+            totalDistinct: 1,
+          },
+          isLoading: false,
+        };
+      }
+      return { data: { values: [], totalDistinct: 0 }, isLoading: false };
+    },
+  );
+});
+
+afterEach(() => cleanup());
+
+describe("<TokenValuePicker /> server-side search", () => {
+  describe("given the user edits a categorical chip's value", () => {
+    it("queries facetValues with a prefix and surfaces a value beyond the preloaded top-N", async () => {
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <TokenValuePicker anchor={anchor} onClose={vi.fn()} />
+        </ChakraProvider>,
+      );
+
+      // Prefilled with the chip's current value ("checkout") — pristine, no
+      // server hit. Editing it to "finance" flips to a server-side search.
+      const input = screen.getByPlaceholderText(/Filter service values/i);
+      fireEvent.change(input, { target: { value: "finance" } });
+
+      expect(apiMock.useQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          facetKey: "service",
+          prefix: expect.stringContaining("finance"),
+        }),
+        expect.objectContaining({ enabled: true }),
+      );
+      expect(await screen.findByText("finance-prod-99")).toBeInTheDocument();
+    });
+
+    it("does not hit the server while the input still holds the unedited value", () => {
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <TokenValuePicker anchor={anchor} onClose={vi.fn()} />
+        </ChakraProvider>,
+      );
+
+      // Pristine (input === currentValue) → every call stays disabled.
+      expect(apiMock.useQuery).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useFacetSearch.integration.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useFacetSearch.integration.test.ts
@@ -97,7 +97,7 @@ describe("useFacetSearch", () => {
   // AttributeKeyRow has always relied on — an attribute-prefixed key, limit
   // 30, a 5-minute staleTime, and crucially NO prefix (it lazy-loads the top
   // values, it does not search them).
-  describe("useAttributeValues (delegates to useFacetSearch)", () => {
+  describe("given useAttributeValues delegates to useFacetSearch", () => {
     it("queries facetValues with the attribute-prefixed key, limit 30, no prefix", () => {
       renderHook(() => useAttributeValues("langwatch.user_id", true));
 
@@ -106,6 +106,15 @@ describe("useFacetSearch", () => {
       expect(call?.[0]?.limit).toBe(30);
       expect(call?.[0]?.prefix).toBeUndefined();
       expect(call?.[1]?.staleTime).toBe(5 * 60_000);
+    });
+
+    // The prefixed facetKey ("attribute.") is truthy even for an empty key, so
+    // useFacetSearch's own `!!facetKey` guard would not catch it —
+    // useAttributeValues must additionally gate on a non-empty attribute key.
+    it("disables the query when the attribute key is empty", () => {
+      renderHook(() => useAttributeValues("", true));
+
+      expect(lastOpts()?.enabled).toBe(false);
     });
   });
 });

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useFacetSearch.integration.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useFacetSearch.integration.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useFacetSearch wires the per-facet value search to tracesV2.facetValues:
+ * it forwards the typed `prefix`, gates the query on a project + a facetKey,
+ * and is the shared engine behind useAttributeValues (which delegates to it
+ * with no prefix and limit 30). See specs/traces-v2/search.feature.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+  projectId: { value: "proj-1" as string | undefined },
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: { tracesV2: { facetValues: { useQuery: harness.useQuery } } },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: harness.projectId.value
+      ? { id: harness.projectId.value }
+      : undefined,
+  }),
+}));
+
+vi.mock("../../stores/filterStore", () => ({
+  useFilterStore: (selector: (s: unknown) => unknown) =>
+    selector({ debouncedTimeRange: { from: 10, to: 20, label: undefined } }),
+}));
+
+import { useAttributeValues } from "../useAttributeValues";
+import { useFacetSearch } from "../useFacetSearch";
+
+const lastInput = () => harness.useQuery.mock.calls.at(-1)?.[0];
+const lastOpts = () => harness.useQuery.mock.calls.at(-1)?.[1];
+const callFor = (facetKey: string) =>
+  harness.useQuery.mock.calls.find((c) => c[0]?.facetKey === facetKey);
+
+beforeEach(() => {
+  harness.useQuery.mockReset();
+  harness.useQuery.mockImplementation(() => ({
+    data: undefined,
+    isLoading: false,
+  }));
+  harness.projectId.value = "proj-1";
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("useFacetSearch", () => {
+  describe("when enabled with a project and a facetKey", () => {
+    it("forwards the typed prefix to facetValues", () => {
+      renderHook(() =>
+        useFacetSearch({ facetKey: "service", prefix: "fin", enabled: true }),
+      );
+
+      expect(lastInput()?.facetKey).toBe("service");
+      expect(lastInput()?.prefix).toBe("fin");
+      expect(lastOpts()?.enabled).toBe(true);
+    });
+
+    it("omits an all-whitespace prefix (sends undefined, not a blank string)", () => {
+      renderHook(() =>
+        useFacetSearch({ facetKey: "service", prefix: "   ", enabled: true }),
+      );
+
+      expect(lastInput()?.prefix).toBeUndefined();
+    });
+  });
+
+  describe("when there is no project", () => {
+    it("disables the query", () => {
+      harness.projectId.value = undefined;
+      renderHook(() =>
+        useFacetSearch({ facetKey: "service", prefix: "fin", enabled: true }),
+      );
+
+      expect(lastOpts()?.enabled).toBe(false);
+    });
+  });
+
+  describe("when the facetKey is empty", () => {
+    it("disables the query", () => {
+      renderHook(() =>
+        useFacetSearch({ facetKey: "", prefix: "fin", enabled: true }),
+      );
+
+      expect(lastOpts()?.enabled).toBe(false);
+    });
+  });
+
+  // Regression: useAttributeValues must keep delegating with the same shape
+  // AttributeKeyRow has always relied on — an attribute-prefixed key, limit
+  // 30, a 5-minute staleTime, and crucially NO prefix (it lazy-loads the top
+  // values, it does not search them).
+  describe("useAttributeValues (delegates to useFacetSearch)", () => {
+    it("queries facetValues with the attribute-prefixed key, limit 30, no prefix", () => {
+      renderHook(() => useAttributeValues("langwatch.user_id", true));
+
+      const call = callFor("attribute.langwatch.user_id");
+      expect(call).toBeDefined();
+      expect(call?.[0]?.limit).toBe(30);
+      expect(call?.[0]?.prefix).toBeUndefined();
+      expect(call?.[1]?.staleTime).toBe(5 * 60_000);
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/hooks/useAttributeValues.ts
+++ b/langwatch/src/features/traces-v2/hooks/useAttributeValues.ts
@@ -10,12 +10,17 @@ import { useFacetSearch } from "./useFacetSearch";
  * values, it does not search them — and the long staleTime keeps an expanded
  * section from refetching every time the rolling time range ticks (SSE
  * invalidates on real changes).
+ *
+ * The `attrKey.length > 0` guard matters because the prefixed `facetKey`
+ * (`attribute.`) is truthy even for an empty key, so useFacetSearch's own
+ * `!!facetKey` guard would NOT catch it — without this the query would fire
+ * for a bare `attribute.` key.
  */
 export function useAttributeValues(attrKey: string, enabled: boolean) {
   return useFacetSearch({
     facetKey: `attribute.${attrKey}`,
     prefix: "",
-    enabled,
+    enabled: enabled && attrKey.length > 0,
     limit: 30,
     staleTimeMs: 5 * 60_000,
   });

--- a/langwatch/src/features/traces-v2/hooks/useAttributeValues.ts
+++ b/langwatch/src/features/traces-v2/hooks/useAttributeValues.ts
@@ -1,42 +1,22 @@
-import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import { api } from "~/utils/api";
-import { useFilterStore } from "../stores/filterStore";
-
-const EMPTY: { value: string; label?: string; count: number }[] = [];
+import { useFacetSearch } from "./useFacetSearch";
 
 /**
- * Lazy-loads top distinct values for a single attribute key (e.g. "langwatch.user_id").
- * Fetches only when `enabled` is true so collapsed sections stay free.
+ * Lazy-loads top distinct values for a single attribute key (e.g.
+ * "langwatch.user_id"). Fetches only when `enabled` is true so collapsed
+ * sections stay free.
+ *
+ * Thin delegation to {@link useFacetSearch}: an attribute key is just an
+ * `attribute.`-prefixed facet. No prefix is passed — this surfaces the top
+ * values, it does not search them — and the long staleTime keeps an expanded
+ * section from refetching every time the rolling time range ticks (SSE
+ * invalidates on real changes).
  */
 export function useAttributeValues(attrKey: string, enabled: boolean) {
-  const { project } = useOrganizationTeamProject();
-  const timeRange = useFilterStore((s) => s.debouncedTimeRange);
-
-  const query = api.tracesV2.facetValues.useQuery(
-    {
-      projectId: project?.id ?? "",
-      timeRange: {
-        from: timeRange.from,
-        to: timeRange.to,
-        live: !!timeRange.label,
-      },
-      facetKey: `attribute.${attrKey}`,
-      limit: 30,
-      offset: 0,
-    },
-    {
-      enabled: enabled && !!project?.id && !!attrKey,
-      // Distinct attribute values turn over slowly; SSE invalidates on
-      // real changes, so a long staleTime keeps expanded sections from
-      // refetching every time the rolling time range ticks.
-      staleTime: 5 * 60_000,
-      keepPreviousData: true,
-    },
-  );
-
-  return {
-    values: query.data?.values ?? EMPTY,
-    totalDistinct: query.data?.totalDistinct ?? 0,
-    isLoading: query.isLoading && enabled,
-  };
+  return useFacetSearch({
+    facetKey: `attribute.${attrKey}`,
+    prefix: "",
+    enabled,
+    limit: 30,
+    staleTimeMs: 5 * 60_000,
+  });
 }

--- a/langwatch/src/features/traces-v2/hooks/useDebouncedValue.ts
+++ b/langwatch/src/features/traces-v2/hooks/useDebouncedValue.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delayMs` of
+ * quiet. Used to throttle the server-side facet search: a per-keystroke
+ * `facetValues` prefix scan over a high-cardinality facet is a real ClickHouse
+ * round-trip, so the network query reads this debounced value while the
+ * client-side substring filter stays on the live value for instant local
+ * feedback.
+ *
+ * No generic value-debounce hook existed under `src/` (only the purpose-built
+ * `useDebouncedFilterCommit` / `useDebouncedTextarea`), so this is the small
+ * shared primitive for "debounce an already-controlled value".
+ */
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/langwatch/src/features/traces-v2/hooks/useFacetSearch.ts
+++ b/langwatch/src/features/traces-v2/hooks/useFacetSearch.ts
@@ -70,5 +70,11 @@ export function useFacetSearch({
     values: query.data?.values ?? EMPTY,
     totalDistinct: query.data?.totalDistinct ?? 0,
     isLoading: query.isLoading && enabled,
+    // `keepPreviousData` keeps `isLoading` true only on the COLD first fetch, so
+    // refinement keystrokes (which refetch while prior values stay on screen)
+    // need `isFetching` to drive the "Searching all values…" spinner. Exposed
+    // ALONGSIDE `isLoading` — useAttributeValues / AttributeKeyRow rely on the
+    // latter, so it stays.
+    isFetching: (query.isFetching ?? false) && enabled,
   };
 }

--- a/langwatch/src/features/traces-v2/hooks/useFacetSearch.ts
+++ b/langwatch/src/features/traces-v2/hooks/useFacetSearch.ts
@@ -1,0 +1,72 @@
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { api } from "~/utils/api";
+import { useFilterStore } from "../stores/filterStore";
+
+const EMPTY: { value: string; label?: string; count: number }[] = [];
+
+/**
+ * Server-side search over a single facet's distinct values.
+ *
+ * Queries `tracesV2.facetValues` with the typed `prefix` so a value can be
+ * found among ALL of a facet's distinct values — not just the preloaded
+ * top-N the discover payload shipped. This is what lets a high-cardinality
+ * facet (models, users, services, trace names, labels) surface a value
+ * beyond #50.
+ *
+ * Only valid for CATEGORICAL facets (and `attribute.*`) — `facetValues`
+ * throws for range facets. Callers therefore gate `enabled`: the sidebar
+ * passes it only from the categorical render branch; the value picker only
+ * once the resolved descriptor is categorical.
+ *
+ * Also the shared engine behind {@link useAttributeValues}, which delegates
+ * here with no prefix to lazy-load an attribute's top values.
+ */
+export function useFacetSearch({
+  facetKey,
+  prefix,
+  enabled,
+  limit = 100,
+  staleTimeMs = 60_000,
+}: {
+  /** Facet to search — identity-mapped to the server's `facetKey`. */
+  facetKey: string;
+  /** Raw search text; trimmed, and omitted entirely when blank. */
+  prefix: string;
+  /** Caller's gate (e.g. search open + non-empty query). ANDed with the
+   *  project + facetKey guards below. */
+  enabled: boolean;
+  /** Max distinct values to return (the server caps at 1000). */
+  limit?: number;
+  /** How long results stay fresh — distinct values turn over slowly, and SSE
+   *  invalidates on real changes. */
+  staleTimeMs?: number;
+}) {
+  const { project } = useOrganizationTeamProject();
+  const timeRange = useFilterStore((s) => s.debouncedTimeRange);
+
+  const query = api.tracesV2.facetValues.useQuery(
+    {
+      projectId: project?.id ?? "",
+      timeRange: {
+        from: timeRange.from,
+        to: timeRange.to,
+        live: !!timeRange.label,
+      },
+      facetKey,
+      prefix: prefix.trim() || undefined,
+      limit,
+      offset: 0,
+    },
+    {
+      enabled: enabled && !!project?.id && !!facetKey,
+      staleTime: staleTimeMs,
+      keepPreviousData: true,
+    },
+  );
+
+  return {
+    values: query.data?.values ?? EMPTY,
+    totalDistinct: query.data?.totalDistinct ?? 0,
+    isLoading: query.isLoading && enabled,
+  };
+}

--- a/langwatch/src/features/traces-v2/hooks/useFacetSearch.ts
+++ b/langwatch/src/features/traces-v2/hooks/useFacetSearch.ts
@@ -13,10 +13,12 @@ const EMPTY: { value: string; label?: string; count: number }[] = [];
  * facet (models, users, services, trace names, labels) surface a value
  * beyond #50.
  *
- * Only valid for CATEGORICAL facets (and `attribute.*`) — `facetValues`
- * throws for range facets. Callers therefore gate `enabled`: the sidebar
- * passes it only from the categorical render branch; the value picker only
- * once the resolved descriptor is categorical.
+ * Server search is categorical-only (this is the canonical statement of that
+ * rule — callers just point here): valid for CATEGORICAL facets (and
+ * `attribute.*`), because `facetValues` throws for range facets. Callers
+ * therefore gate `enabled` — the sidebar passes it only from the categorical
+ * render branch (`serverValueSearch`); the value picker only once the resolved
+ * descriptor is categorical.
  *
  * Also the shared engine behind {@link useAttributeValues}, which delegates
  * here with no prefix to lazy-load an attribute's top values.

--- a/langwatch/src/features/traces-v2/utils/__tests__/dedupeByValue.unit.test.ts
+++ b/langwatch/src/features/traces-v2/utils/__tests__/dedupeByValue.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { dedupeByValue } from "../dedupeByValue";
+
+// Backs the SUPPLEMENT (not replace) merge of preloaded facet items with
+// server prefix-search results: the same value can appear in both lists, and
+// the preloaded entry — which carries the richer payload — must win.
+
+describe("dedupeByValue", () => {
+  describe("given two lists that share a value", () => {
+    it("keeps the first occurrence so the preloaded entry's payload survives", () => {
+      const preloaded = [
+        { value: "gpt-4o", count: 50, dotColor: "blue" },
+        { value: "claude", count: 40, dotColor: "purple" },
+      ];
+      const server = [
+        { value: "gpt-4o", count: 1 },
+        { value: "gpt-4o-mini", count: 2 },
+      ];
+
+      expect(dedupeByValue([...preloaded, ...server])).toEqual([
+        { value: "gpt-4o", count: 50, dotColor: "blue" },
+        { value: "claude", count: 40, dotColor: "purple" },
+        { value: "gpt-4o-mini", count: 2 },
+      ]);
+    });
+  });
+
+  describe("given no duplicates", () => {
+    it("returns the items unchanged and in order", () => {
+      const items = [{ value: "a" }, { value: "b" }, { value: "c" }];
+      expect(dedupeByValue(items)).toEqual(items);
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/utils/dedupeByValue.ts
+++ b/langwatch/src/features/traces-v2/utils/dedupeByValue.ts
@@ -1,0 +1,18 @@
+/**
+ * Dedupe a list of `{ value }` items by `value`, keeping the FIRST occurrence.
+ *
+ * Used to SUPPLEMENT a preloaded facet list with server prefix-search results
+ * without double-listing a value that appears in both. Passing the preloaded
+ * items first means their richer payload (count, dotColor, aggregates) wins
+ * over the leaner server row for the same value.
+ */
+export function dedupeByValue<T extends { value: string }>(items: T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const item of items) {
+    if (seen.has(item.value)) continue;
+    seen.add(item.value);
+    out.push(item);
+  }
+  return out;
+}

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1101,8 +1101,9 @@ Rule: Very high-cardinality facets
   @integration
   Scenario: Editing a search-bar value chip searches all values, not just the preloaded set
     Given the user has a "service:" filter chip in the search bar
-    When the user clicks the chip and edits the value to a prefix matching a service beyond the preloaded top set
-    Then the matching service value beyond the preloaded set appears in the picker
+    When the user clicks the chip and edits the value to a prefix
+    Then the matching preloaded values and any matching values beyond the preloaded set both appear in the picker
+    And they supplement the preloaded set rather than replacing it
 
   Scenario: Clearing facet search returns to top-5 view
     Given the user is searching in the Service facet

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1102,7 +1102,7 @@ Rule: Very high-cardinality facets
   Scenario: Editing a search-bar value chip searches all values, not just the preloaded set
     Given the user has a "service:" filter chip in the search bar
     When the user clicks the chip and edits the value to a prefix matching a service beyond the preloaded top set
-    Then the picker queries the server with that prefix and shows the matching value
+    Then the matching service value beyond the preloaded set appears in the picker
 
   Scenario: Clearing facet search returns to top-5 view
     Given the user is searching in the Service facet

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1096,7 +1096,13 @@ Rule: Very high-cardinality facets
   Scenario: Facet search matches against all values
     When the user types "finance" in the Service facet search
     Then values matching "finance" from all 60 services are shown inline
-    And the top-5 list is temporarily replaced with search results
+    And they supplement the preloaded top-5 rather than replacing it
+
+  @integration
+  Scenario: Editing a search-bar value chip searches all values, not just the preloaded set
+    Given the user has a "service:" filter chip in the search bar
+    When the user clicks the chip and edits the value to a prefix matching a service beyond the preloaded top set
+    Then the picker queries the server with that prefix and shows the matching value
 
   Scenario: Clearing facet search returns to top-5 view
     Given the user is searching in the Service facet

--- a/specs/traces-v2/search.feature
+++ b/specs/traces-v2/search.feature
@@ -1092,6 +1092,7 @@ Rule: Very high-cardinality facets
     Then 30 total values are visible
     And a message reads "And 30 more — use search to filter"
 
+  @integration
   Scenario: Facet search matches against all values
     When the user types "finance" in the Service facet search
     Then values matching "finance" from all 60 services are shown inline


### PR DESCRIPTION
## Why

Closes #4239

The trace filter sidebar's per-facet **Search…** input and the search-bar **value picker** only filtered *client-side within the preloaded top values*. The discover payload caps each facet at 50 values (`TOP_N`), so for a high-cardinality facet — **models, users, trace names, labels** — a value ranked beyond #50 could never be found, no matter what you typed. The sidebar's own spec already promised the correct behavior (`specs/traces-v2/search.feature` → *"Facet search matches against all values"* → *"values matching 'finance' from all 60 services are shown inline"*); the implementation didn't honor it.

> `TOP_N` was already bumped 10→50 by #4230 just before this issue was filed. **Bumping the cap is not the fix** (the issue's own "Alternatives" says so) — a customer with 100+ values still hits the wall. This PR does the real work: server-side search.

## What changed

- **New shared `useFacetSearch` hook** — queries the existing `tracesV2.facetValues` endpoint with the typed text as a `prefix`, so the match runs server-side against **all** of a facet's distinct values, not just the preloaded top-50. `useAttributeValues` now delegates to it (an attribute key is just an `attribute.`-prefixed facet), removing a near-duplicate.
- **`FacetSection` gains a `serverValueSearch` prop** — when the per-facet search is open, the typed text (debounced) queries `facetValues`, and the results **supplement** (union, not replace) the preloaded list; the live client substring filter still narrows that union. This keeps substring matches *within* the preloaded set (the server does an anchored `prefix%` match, so `gpt-4o` would miss `openai/gpt-4o-mini` on its own) **and** surfaces prefix matches beyond the top-50. **Set only on the categorical render branch** in `SectionRenderer`: `facetValues` *throws* for range facets (e.g. `promptVersion`, which reads categorical but is a range key), so the discriminator is the render branch, not the field string.
- **`TokenValuePicker` does the same** — once the user edits a chip's value (non-"pristine"), it unions the preloaded `topValues` with the debounced server prefix results and applies the live substring filter.
- **Debounced** — the per-keystroke prefix is debounced (300 ms) before it hits ClickHouse; the client substring filter stays on the live value for instant local feedback.
- **`TOP_N` is untouched** — no magic-number bump.

## How it works

```
useFacetSearch.ts (new)         shared engine: facetValues({facetKey, prefix}) — project+facetKey gated, tenant-scoped
  └─ useAttributeValues.ts       now a thin delegate (attribute.<key>, no prefix, limit 30, 5-min stale) — behavior identical
useDebouncedValue.ts (new)      generic 300 ms value debounce — only the server query reads it; client filter stays live
dedupeByValue.ts (new)          first-occurrence-wins union helper (preloaded payload wins over the leaner server row)
FacetSection.tsx                 serverValueSearch prop → dedupeByValue([preloaded, …serverResults]) feeds the existing filter/computeWindow pipeline; spinner while loading; Enter-to-filter fallback preserved
  └─ SectionRenderer.tsx         passes serverValueSearch ONLY on the section.kind==="cat" branch (range branch left untouched → never calls facetValues)
TokenValuePicker.tsx             cat/pristine lifted above the hook; edited → union(preloaded, debounced server) + live substring filter; pristine → preloaded topValues
specs/traces-v2/search.feature   "Facet search matches against all values" now tagged @integration and bound to a test
```

`facetValues` is double tenant-gated (`checkProjectPermission("traces:view")` + `tenantId` → `WHERE TenantId`), so the new hook adds no multitenancy surface. `field` maps to the server `facetKey` by identity (verified against the facet registry — `model`/`user`/`traceName`/`label` are all `kind: "categorical"`).

## Human verification

A skeptical reviewer can re-confirm independently:

1. Open **Observe** (traces) on a project whose **Model** (or **User** / **Trace name** / **Label**) facet has more than 50 distinct values.
2. In the left sidebar, open that facet section, click the **funnel/search** icon, and type a prefix that matches a value ranked **beyond the top 50** (one not shown in the default list).
3. **Confirm the value now appears** in the list. On `main` it does not — the search only filters the 50 preloaded values. (Network tab: a `tracesV2.facetValues` request fires with your `prefix`.)
4. In the **search bar**, click an existing `field:value` chip to open the value picker, edit the value text to a beyond-top-50 prefix, and confirm matching values appear.

## How I can prove I was successful

**1 — Real-app BEFORE (the bug, captured live).** On the running dogfood app, opening the **Model** facet search and typing `gpt` fires **no** `tracesV2.facetValues` request — the filter is purely client-side over the preloaded values. That is the bug: anything beyond the preloaded set is unreachable.

![Real-app BEFORE: Model facet search, client-side only](https://raw.githubusercontent.com/langwatch/langwatch/proof/4239-facet-server-search/proofs/4239-before-model-search.png)

Network while typing `gpt` in that search — only discover/list, **no `facetValues`**:
```
GET /api/trpc/tracesV2.discover?...            => 200
GET /api/trpc/...tracesV2.newCount,tracesV2.list?... => 200
(no tracesV2.facetValues request is made)
```

**2 — The fix toggles the suite RED → GREEN on the *real* production component.** The scenario-bound `FacetSection.serverSearch.integration.test.tsx` renders the real `FacetSection` with a mocked `facetValues` that returns `finance-team-42` (a value **not** in the preloaded items) only when queried with a `prefix`. Reverting **only** `FacetSection.tsx` to `origin/main` (no wiring) makes 3/4 fail — `facetValues` never called, the value never appears, spinner absent; this PR's wiring turns them green.

![Falsifiability: RED→GREEN on real FacetSection](https://raw.githubusercontent.com/langwatch/langwatch/proof/4239-facet-server-search/proofs/4239-after-redgreen.png)

**3 — Full validation.** 15 files · **94 integration tests pass** (testcontainers ClickHouse+Redis), `pnpm typecheck` clean, feature-parity **2228 scenarios bound** (incl. the newly-bound scenario), CI on this PR green.

**Scope note (honest).** The full live-app *AFTER* (the spinner + `facetValues(prefix)` call screenshotted in the running app) was **not** captured: the shared `drewdrewthis--langwatch-golden` runs a branch **192 files behind main**, so a clean overlay of this main-based change broke its page, and a throwaway fork switched to this branch hit boxd dev-stack restart fragility. The AFTER behavior is proven instead by the red→green falsifiability on the real component (#2) plus the live BEFORE (#1). Happy to re-capture on a main-based env if you want it.

## Anything surprising?

- `TokenValuePicker` is mounted unconditionally by `SearchBar`, and three `FacetSection` suites render the component without a tRPC provider. Because the new hook is always called (hooks can't be conditional), those 6 existing suites would crash with "No QueryClient". Fixed minimally by stubbing `useFacetSearch` (one `vi.mock` each) — their concerns (any-of hint, mode toggle, reorder, error banner) are unrelated to server search.
- Range facets are deliberately excluded — `facetValues` throws for them. The discriminator lives on the render branch (`SectionRenderer`), not the field string, because a discrete-range key (`promptVersion`) reads as categorical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Facet filters and value pickers now support server-assisted prefix searching for categorical facets.
  * Server results now **supplement** the initial values list (they don’t replace it), with a debounced search flow.
  * While server searching, the UI shows a dedicated loading row and suppresses the “no match” empty state until results arrive.
* **Bug Fixes**
  * Overlapping values from preloaded and server results are deduplicated, with preloaded values taking precedence.
* **Tests**
  * Added/updated integration tests for server-backed facet search (including new hook mocks) and adjusted the high-cardinality facet search spec to verify supplement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->