### PR TITLE
fix(traces): bisect single-batch OOM + DRY retry loops + typed orderDirection

### DIFF
--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-oom-bisect.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-oom-bisect.integration.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Integration tests for the OOM batch-retry / bisection fallback.
+ *
+ * The unit tests around this path mock the rejection, so they can only prove
+ * the helper reacts to an error SHAPE we hand it. These exercise the real
+ * chain end to end against a testcontainers ClickHouse:
+ *
+ *   real ClickHouse MEMORY_LIMIT_EXCEEDED
+ *     -> the driver's own error
+ *     -> translateClickHouseQueryError / QueryMemoryExceededError
+ *     -> isClickHouseMemoryLimitError
+ *     -> retryInBatchesWithBisect
+ *
+ * so a regression anywhere in that chain — a changed error class, a detector
+ * that stops unwrapping, a swallowed rejection — fails here even though every
+ * mock-based test stays green.
+ *
+ * How the OOM is triggered: a proxy client injects `max_memory_usage` into the
+ * heavy summary read, tightly for large batches and generously for small ones.
+ * The ceiling is chosen per batch size deliberately, so the test is
+ * deterministic rather than dependent on how much memory a given ClickHouse
+ * build happens to allocate. Everything downstream of the trigger — the error,
+ * its translation, the detection, the recovery, the returned rows — is real.
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { ClickHouseTraceService } from "../clickhouse-trace.service";
+import type { GetAllTracesForProjectInput } from "../types";
+import { openProtections } from "./open-protections";
+
+const tenantId = `test-oom-bisect-${nanoid()}`;
+const now = Date.now();
+
+/** Big enough that a 25-row read genuinely needs room, small enough to insert fast. */
+const PAYLOAD = JSON.stringify({
+  type: "text",
+  value: "x".repeat(200_000),
+});
+
+const TRACE_COUNT = 30;
+const traceIds = Array.from(
+  { length: TRACE_COUNT },
+  (_, i) => `trace-oom-${String(i).padStart(3, "0")}-${nanoid()}`,
+);
+
+function makeTraceSummaryRow(traceId: string, index: number) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    Version: "v1",
+    Attributes: {},
+    // Spread across a minute so the page has a deterministic sort order.
+    OccurredAt: new Date(now - index * 1000),
+    CreatedAt: new Date(now - index * 1000),
+    UpdatedAt: new Date(now - index * 1000),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput: PAYLOAD,
+    ComputedOutput: PAYLOAD,
+    TimeToFirstTokenMs: null,
+    TimeToLastTokenMs: null,
+    TotalDurationMs: 100,
+    TokensPerSecond: null,
+    SpanCount: 1,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    ErrorMessage: null,
+    Models: [],
+    TotalCost: null,
+    TokensEstimated: false,
+    TotalPromptTokenCount: null,
+    TotalCompletionTokenCount: null,
+    OutputFromRootSpan: false,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: false,
+    SatisfactionScore: null,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+  };
+}
+
+function makeQueryInput(
+  overrides: Partial<GetAllTracesForProjectInput> = {},
+): GetAllTracesForProjectInput {
+  return {
+    projectId: tenantId,
+    startDate: now - 600_000,
+    endDate: now + 600_000,
+    filters: {},
+    pageSize: TRACE_COUNT,
+    ...overrides,
+  };
+}
+
+/**
+ * Wrap the real client so the heavy summary read runs under a memory ceiling.
+ *
+ * `limitFor` receives the batch's id count and returns the `max_memory_usage`
+ * bytes for that query, or null to leave it unbounded. Only the heavy read is
+ * touched — the count and id queries must still succeed for the page to get as
+ * far as the summary read at all.
+ */
+function memoryCappedClient(
+  base: ClickHouseClient,
+  limitFor: (batchSize: number) => number | null,
+): { client: ClickHouseClient; batchSizes: number[] } {
+  const batchSizes: number[] = [];
+  const client = new Proxy(base, {
+    get(target, prop, receiver) {
+      if (prop !== "query") return Reflect.get(target, prop, receiver);
+      return (args: {
+        query: string;
+        query_params?: Record<string, unknown>;
+        clickhouse_settings?: Record<string, unknown>;
+      }) => {
+        const ids = args.query_params?.pageTraceIds;
+        const isHeavySummaryRead =
+          typeof args.query === "string" &&
+          args.query.includes("ts_ComputedInput") &&
+          Array.isArray(ids);
+
+        if (!isHeavySummaryRead) {
+          return (target as ClickHouseClient).query(args as never);
+        }
+
+        batchSizes.push((ids as string[]).length);
+        const limit = limitFor((ids as string[]).length);
+        return (target as ClickHouseClient).query({
+          ...args,
+          clickhouse_settings: {
+            ...(args.clickhouse_settings ?? {}),
+            ...(limit === null ? {} : { max_memory_usage: String(limit) }),
+          },
+        } as never);
+      };
+    },
+  }) as ClickHouseClient;
+  return { client, batchSizes };
+}
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: { project: { findUnique: vi.fn().mockResolvedValue({}) } },
+}));
+
+let ch: ClickHouseClient;
+let service: ClickHouseTraceService;
+let getClickHouseClientForProject: ReturnType<typeof vi.fn>;
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+
+  const chModule = await import("~/server/clickhouse/clickhouseClient");
+  getClickHouseClientForProject = vi.mocked(
+    chModule.getClickHouseClientForProject,
+  );
+  getClickHouseClientForProject.mockResolvedValue(ch);
+
+  const { prisma } = await import("~/server/db");
+  service = new ClickHouseTraceService(
+    prisma as ConstructorParameters<typeof ClickHouseTraceService>[0],
+  );
+
+  await ch.insert({
+    table: "trace_summaries",
+    values: traceIds.map((id, i) => makeTraceSummaryRow(id, i)),
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}, 120_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("ClickHouse OOM bisection (integration)", () => {
+  describe("getAllTracesForProject()", () => {
+    describe("given a real MEMORY_LIMIT_EXCEEDED on the full-list summary read", () => {
+      it("recovers the whole page by bisecting until the batches fit", async () => {
+        // Tight for anything over 12 ids, generous below — so the full list of
+        // 30 OOMs, the 25-id batch OOMs, and the bisected halves succeed.
+        const { client, batchSizes } = memoryCappedClient(ch, (size) =>
+          size > 12 ? 1_000_000 : null,
+        );
+        getClickHouseClientForProject.mockResolvedValue(client);
+        try {
+          const result = await service.getAllTracesForProject(
+            makeQueryInput(),
+            openProtections,
+          );
+
+          // Every trace still comes back: the recovery is lossless, not
+          // best-effort.
+          expect(result).not.toBeNull();
+          expect(result!.groups.flat()).toHaveLength(TRACE_COUNT);
+        } finally {
+          getClickHouseClientForProject.mockResolvedValue(ch);
+        }
+
+        // The shape of the descent, from the real run: the full list, then
+        // fixed-size batching, then a bisected pair that fits.
+        expect(batchSizes[0]).toBe(TRACE_COUNT);
+        expect(batchSizes).toContain(25);
+        expect(batchSizes.some((n) => n <= 12 && n > 0)).toBe(true);
+      }, 120_000);
+
+      it("returns rows identical to the same read without any memory pressure", async () => {
+        const unpressured = await service.getAllTracesForProject(
+          makeQueryInput(),
+          openProtections,
+        );
+
+        const { client } = memoryCappedClient(ch, (size) =>
+          size > 12 ? 1_000_000 : null,
+        );
+        getClickHouseClientForProject.mockResolvedValue(client);
+        let bisected: Awaited<
+          ReturnType<typeof service.getAllTracesForProject>
+        >;
+        try {
+          bisected = await service.getAllTracesForProject(
+            makeQueryInput(),
+            openProtections,
+          );
+        } finally {
+          getClickHouseClientForProject.mockResolvedValue(ch);
+        }
+
+        // The point of the re-sort in the caller: batches come back in chunk
+        // order, so without it the recovered page would be ordered differently
+        // from the happy path. Ids AND order must match exactly.
+        const idsOf = (
+          r: Awaited<ReturnType<typeof service.getAllTracesForProject>>,
+        ) => r!.groups.flat().map((t) => t.trace_id);
+        expect(idsOf(bisected)).toEqual(idsOf(unpressured));
+      }, 120_000);
+    });
+
+    describe("given every batch size still OOMs", () => {
+      it("gives up instead of grinding, and surfaces the memory error", async () => {
+        // A ceiling nothing can satisfy: the descent reaches a single id,
+        // which cannot be split further, so the error propagates.
+        const { client, batchSizes } = memoryCappedClient(ch, () => 1);
+        getClickHouseClientForProject.mockResolvedValue(client);
+        try {
+          await expect(
+            service.getAllTracesForProject(makeQueryInput(), openProtections),
+          ).rejects.toThrow();
+        } finally {
+          getClickHouseClientForProject.mockResolvedValue(ch);
+        }
+
+        // Bounded work, not a runaway: the fan-out stays far below the
+        // ceil(30/25) + MAX_BISECT_RETRIES ceiling rather than exploring the
+        // whole tree before failing.
+        expect(batchSizes.length).toBeLessThanOrEqual(2 + 100);
+        expect(batchSizes).toContain(1);
+      }, 120_000);
+    });
+  });
+});

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-oom-bisect.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-oom-bisect.integration.test.ts
@@ -193,6 +193,7 @@ afterAll(async () => {
 describe("ClickHouse OOM bisection (integration)", () => {
   describe("getAllTracesForProject()", () => {
     describe("given a real MEMORY_LIMIT_EXCEEDED on the full-list summary read", () => {
+      /** @scenario A page still loads when the database runs out of memory */
       it("recovers the whole page by bisecting until the batches fit", async () => {
         // Tight for anything over 12 ids, generous below — so the full list of
         // 30 OOMs, the 25-id batch OOMs, and the bisected halves succeed.
@@ -221,6 +222,7 @@ describe("ClickHouse OOM bisection (integration)", () => {
         expect(batchSizes.some((n) => n <= 12 && n > 0)).toBe(true);
       }, 120_000);
 
+      /** @scenario A page recovered from a memory limit matches an unaffected read */
       it("returns rows identical to the same read without any memory pressure", async () => {
         const unpressured = await service.getAllTracesForProject(
           makeQueryInput(),
@@ -254,6 +256,7 @@ describe("ClickHouse OOM bisection (integration)", () => {
     });
 
     describe("given every batch size still OOMs", () => {
+      /** @scenario A trace that cannot be read alone fails the page instead of retrying forever */
       it("gives up instead of grinding, and surfaces the memory error", async () => {
         // A ceiling nothing can satisfy: the descent reaches a single id,
         // which cannot be split further, so the error propagates.

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -761,6 +761,99 @@ describe("ClickHouseTraceService", () => {
           service.getAllTracesForProject(baseInput, protections),
         ).rejects.toThrow("SYNTAX_ERROR");
       });
+
+      it("bisects a 25-ID batch that still OOMs and resolves both halves", async () => {
+        const traceIds = Array.from({ length: 30 }, (_, i) => `trace-${i}`);
+        const summaryRows = traceIds.map((id, i) => ({
+          ...makeSummaryRow(id),
+          ts_OccurredAt: Date.now() - i * 1000,
+        }));
+        const idRows = traceIds.map((id) => ({ TraceId: id }));
+
+        mockClickHouseQuery
+          // count
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          // IDs
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(idRows),
+          })
+          // summary full list — OOM, drops to fixed-size batches
+          .mockRejectedValueOnce(new Error("MEMORY_LIMIT_EXCEEDED"))
+          // first 25-ID batch — STILL OOMs, triggers recursive bisection
+          .mockRejectedValueOnce(new Error("MEMORY_LIMIT_EXCEEDED"))
+          // bisected lower half (ids 0-11)
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows.slice(0, 12)),
+          })
+          // bisected upper half (ids 12-24)
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows.slice(12, 25)),
+          })
+          // second fixed-size batch (ids 25-29)
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows.slice(25)),
+          })
+          // evaluations
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([]),
+          });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          { ...baseInput, pageSize: 30 } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.groups.flat()).toHaveLength(30);
+        // calls: 0=count, 1=IDs, 2=full OOM, 3=25-ID batch OOM, 4 & 5 = halves
+        expect(
+          mockClickHouseQuery.mock.calls[3]![0].query_params.pageTraceIds,
+        ).toHaveLength(25);
+        expect(
+          mockClickHouseQuery.mock.calls[4]![0].query_params.pageTraceIds,
+        ).toHaveLength(12);
+        expect(
+          mockClickHouseQuery.mock.calls[5]![0].query_params.pageTraceIds,
+        ).toHaveLength(13);
+      });
+
+      it("rethrows when a single-ID summary batch still OOMs after bisecting", async () => {
+        const traceIds = ["trace-0", "trace-1"];
+        const idRows = traceIds.map((id) => ({ TraceId: id }));
+
+        mockClickHouseQuery
+          // count
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          // IDs
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(idRows),
+          })
+          // every summary read OOMs: full list, the batch, then the bisected
+          // single id — which can no longer be split, so it propagates.
+          .mockRejectedValue(new Error("MEMORY_LIMIT_EXCEEDED"));
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await expect(
+          service.getAllTracesForProject(
+            { ...baseInput, pageSize: 2 } as GetAllTracesForProjectInput,
+            protections,
+          ),
+        ).rejects.toThrow("MEMORY_LIMIT_EXCEEDED");
+        // count, IDs, full-list OOM, 2-ID batch OOM, then the bisected 1-ID OOM
+        // — proof the helper descended to a single id before giving up.
+        expect(mockClickHouseQuery).toHaveBeenCalledTimes(5);
+      });
     });
 
     describe("when ClickHouse MEMORY_LIMIT_EXCEEDED on evaluations query", () => {
@@ -801,6 +894,96 @@ describe("ClickHouseTraceService", () => {
 
         expect(result).not.toBeNull();
         expect(result!.groups.flat()).toHaveLength(1);
+      });
+
+      it("bisects a 25-ID evaluations batch that still OOMs and resolves both halves", async () => {
+        const traceIds = Array.from({ length: 30 }, (_, i) => `trace-${i}`);
+        const summaryRows = traceIds.map((id) => makeSummaryRow(id));
+        const idRows = traceIds.map((id) => ({ TraceId: id }));
+
+        mockClickHouseQuery
+          // count
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          // IDs
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(idRows),
+          })
+          // summary — succeeds in one read
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows),
+          })
+          // evaluations full list — OOM, drops to fixed-size batches
+          .mockRejectedValueOnce(new Error("MEMORY_LIMIT_EXCEEDED"))
+          // first 25-ID eval batch — STILL OOMs, triggers recursive bisection
+          .mockRejectedValueOnce(new Error("MEMORY_LIMIT_EXCEEDED"))
+          // bisected lower half (12 ids)
+          .mockResolvedValueOnce({ json: () => Promise.resolve([]) })
+          // bisected upper half (13 ids)
+          .mockResolvedValueOnce({ json: () => Promise.resolve([]) })
+          // second fixed-size eval batch (5 ids)
+          .mockResolvedValueOnce({ json: () => Promise.resolve([]) });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          { ...baseInput, pageSize: 30 } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.groups.flat()).toHaveLength(30);
+        // calls: 0=count, 1=IDs, 2=summary, 3=full eval OOM, 4=25-ID OOM, 5 & 6 = halves
+        expect(
+          mockClickHouseQuery.mock.calls[4]![0].query_params.traceIds,
+        ).toHaveLength(25);
+        expect(
+          mockClickHouseQuery.mock.calls[5]![0].query_params.traceIds,
+        ).toHaveLength(12);
+        expect(
+          mockClickHouseQuery.mock.calls[6]![0].query_params.traceIds,
+        ).toHaveLength(13);
+      });
+
+      it("rethrows when a single-ID evaluations batch still OOMs after bisecting", async () => {
+        const summaryRows = [
+          makeSummaryRow("trace-0"),
+          makeSummaryRow("trace-1"),
+        ];
+        const idRows = [{ TraceId: "trace-0" }, { TraceId: "trace-1" }];
+
+        mockClickHouseQuery
+          // count
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: "2" }]),
+          })
+          // IDs
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(idRows),
+          })
+          // summary — succeeds
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows),
+          })
+          // every evaluations read OOMs, down to the single-id batch which can
+          // no longer be split — so it propagates.
+          .mockRejectedValue(new Error("MEMORY_LIMIT_EXCEEDED"));
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await expect(
+          service.getAllTracesForProject(
+            { ...baseInput, pageSize: 2 } as GetAllTracesForProjectInput,
+            protections,
+          ),
+        ).rejects.toThrow("MEMORY_LIMIT_EXCEEDED");
+        // count, IDs, summary, full eval OOM, 2-ID batch OOM, bisected 1-ID OOM
+        expect(mockClickHouseQuery).toHaveBeenCalledTimes(6);
       });
     });
 
@@ -971,6 +1154,71 @@ describe("ClickHouseTraceService", () => {
         // The resolve fails open (call 1), then the summary's non-OOM error
         // propagates without per-batch retries (call 2) — no retry loop.
         expect(mockClickHouseQuery).toHaveBeenCalledTimes(2);
+      });
+
+      it("bisects a 25-trace join batch that still OOMs and resolves both halves", async () => {
+        const traceIds = Array.from({ length: 30 }, (_, i) => `trace-${i}`);
+
+        mockClickHouseQuery
+          // full-list summary — OOM, drops to fixed-size batches
+          .mockRejectedValueOnce(new Error("MEMORY_LIMIT_EXCEEDED"))
+          // first 25-trace batch summary — STILL OOMs, triggers bisection
+          .mockRejectedValueOnce(new Error("MEMORY_LIMIT_EXCEEDED"))
+          // bisected lower half (12): summary then spans
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve(
+                traceIds.slice(0, 12).map((id) => makeSummaryRow(id)),
+              ),
+          })
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve(
+                traceIds.slice(0, 12).map((id) => makeSpanRow(id, `${id}-s`)),
+              ),
+          })
+          // bisected upper half (13): summary then spans
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve(
+                traceIds.slice(12, 25).map((id) => makeSummaryRow(id)),
+              ),
+          })
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve(
+                traceIds.slice(12, 25).map((id) => makeSpanRow(id, `${id}-s`)),
+              ),
+          })
+          // second fixed-size batch (5): summary then spans
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve(
+                traceIds.slice(25).map((id) => makeSummaryRow(id)),
+              ),
+          })
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve(
+                traceIds.slice(25).map((id) => makeSpanRow(id, `${id}-s`)),
+              ),
+          });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const traces = await service.getTracesWithSpans(
+          "proj_123",
+          traceIds,
+          protections,
+        );
+
+        expect(traces).not.toBeNull();
+        expect(traces).toHaveLength(30);
+        for (const trace of traces!) {
+          expect(trace.spans).toHaveLength(1);
+        }
       });
     });
 

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -863,7 +863,8 @@ describe("ClickHouseTraceService", () => {
             json: () => Promise.resolve([{ total: String(traceIds.length) }]),
           })
           .mockResolvedValueOnce({
-            json: () => Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
+            json: () =>
+              Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
           })
           // Every read of more than one id OOMs; single ids succeed. The helper
           // must therefore walk 25 -> 12 -> 6 -> 3 -> 1 rather than giving up at
@@ -876,7 +877,8 @@ describe("ClickHouseTraceService", () => {
                 return Promise.reject(new Error("MEMORY_LIMIT_EXCEEDED"));
               }
               return Promise.resolve({
-                json: () => Promise.resolve(ids.map((id) => makeSummaryRow(id))),
+                json: () =>
+                  Promise.resolve(ids.map((id) => makeSummaryRow(id))),
               });
             },
           );
@@ -918,7 +920,8 @@ describe("ClickHouseTraceService", () => {
             json: () => Promise.resolve([{ total: String(traceIds.length) }]),
           })
           .mockResolvedValueOnce({
-            json: () => Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
+            json: () =>
+              Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
           })
           .mockImplementation(
             (args: { query_params?: { pageTraceIds?: string[] } }) => {
@@ -927,7 +930,8 @@ describe("ClickHouseTraceService", () => {
                 return Promise.reject(new Error("MEMORY_LIMIT_EXCEEDED"));
               }
               return Promise.resolve({
-                json: () => Promise.resolve(ids.map((id) => makeSummaryRow(id))),
+                json: () =>
+                  Promise.resolve(ids.map((id) => makeSummaryRow(id))),
               });
             },
           );
@@ -965,7 +969,8 @@ describe("ClickHouseTraceService", () => {
             json: () => Promise.resolve([{ total: String(traceIds.length) }]),
           })
           .mockResolvedValueOnce({
-            json: () => Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
+            json: () =>
+              Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
           })
           .mockImplementation(
             async (args: { query_params?: { pageTraceIds?: string[] } }) => {
@@ -1012,7 +1017,8 @@ describe("ClickHouseTraceService", () => {
             json: () => Promise.resolve([{ total: String(traceIds.length) }]),
           })
           .mockResolvedValueOnce({
-            json: () => Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
+            json: () =>
+              Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
           })
           // full list OOMs, the 25-id chunk OOMs, then the bisected lower half
           // fails for an unrelated reason — the guard's non-OOM arm in the
@@ -1048,7 +1054,8 @@ describe("ClickHouseTraceService", () => {
             json: () => Promise.resolve([{ total: String(traceIds.length) }]),
           })
           .mockResolvedValueOnce({
-            json: () => Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
+            json: () =>
+              Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
           })
           // Production never surfaces a raw Error carrying the ClickHouse
           // fragment any more: every read path runs through

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -1160,6 +1160,11 @@ describe("ClickHouseTraceService", () => {
         const traceIds = Array.from({ length: 30 }, (_, i) => `trace-${i}`);
 
         mockClickHouseQuery
+          // OccurredAt sort-key resolve (light seek that bounds the reads below)
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve([{ fromMs: 1_000_000, toMs: 2_000_000 }]),
+          })
           // full-list summary — OOM, drops to fixed-size batches
           .mockRejectedValueOnce(new Error("MEMORY_LIMIT_EXCEEDED"))
           // first 25-trace batch summary — STILL OOMs, triggers bisection

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -762,6 +762,7 @@ describe("ClickHouseTraceService", () => {
         ).rejects.toThrow("SYNTAX_ERROR");
       });
 
+      /** @scenario A batch that still exceeds the memory limit is split and retried */
       it("bisects a 25-ID batch that still OOMs and resolves both halves", async () => {
         const traceIds = Array.from({ length: 30 }, (_, i) => `trace-${i}`);
         const summaryRows = traceIds.map((id, i) => ({
@@ -855,6 +856,7 @@ describe("ClickHouseTraceService", () => {
         expect(mockClickHouseQuery).toHaveBeenCalledTimes(5);
       });
 
+      /** @scenario Splitting continues until a batch holds a single trace */
       it("descends all the way to single ids when every larger chunk OOMs", async () => {
         const traceIds = Array.from({ length: 30 }, (_, i) => `trace-${i}`);
 
@@ -908,6 +910,7 @@ describe("ClickHouseTraceService", () => {
         expect(chunkSizes).toContain(3);
       });
 
+      /** @scenario Recovery stops once its work budget is spent */
       it("stops bisecting once the work budget is spent instead of grinding every chunk", async () => {
         // The regime the budget exists for: server-wide memory pressure, where
         // a chunk fails at 25 but succeeds once small. Nothing aborts early, so
@@ -959,6 +962,7 @@ describe("ClickHouseTraceService", () => {
         );
       });
 
+      /** @scenario Retries of a split batch run one at a time */
       it("runs the two halves sequentially so a retry never doubles memory pressure", async () => {
         const traceIds = Array.from({ length: 25 }, (_, i) => `trace-${i}`);
         let inFlight = 0;
@@ -1009,6 +1013,7 @@ describe("ClickHouseTraceService", () => {
         expect(maxInFlight).toBe(1);
       });
 
+      /** @scenario A failure unrelated to memory is surfaced immediately */
       it("re-throws a non-OOM error raised inside the bisection, without descending further", async () => {
         const traceIds = Array.from({ length: 25 }, (_, i) => `trace-${i}`);
 
@@ -1471,6 +1476,7 @@ describe("ClickHouseTraceService", () => {
         }
       });
 
+      /** @scenario Splitting a batch does not narrow the span search window */
       it("keeps the span scan window identical across every bisected chunk", async () => {
         const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000;
         // Deliberately far from the summary rows' own OccurredAt (Date.now()):

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -854,6 +854,244 @@ describe("ClickHouseTraceService", () => {
         // — proof the helper descended to a single id before giving up.
         expect(mockClickHouseQuery).toHaveBeenCalledTimes(5);
       });
+
+      it("descends all the way to single ids when every larger chunk OOMs", async () => {
+        const traceIds = Array.from({ length: 30 }, (_, i) => `trace-${i}`);
+
+        mockClickHouseQuery
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
+          })
+          // Every read of more than one id OOMs; single ids succeed. The helper
+          // must therefore walk 25 -> 12 -> 6 -> 3 -> 1 rather than giving up at
+          // the first split, which is the "down to a single id" claim the doc
+          // comment makes and the one-level tests above never exercise.
+          .mockImplementation(
+            (args: { query_params?: { pageTraceIds?: string[] } }) => {
+              const ids = args.query_params?.pageTraceIds ?? [];
+              if (ids.length > 1) {
+                return Promise.reject(new Error("MEMORY_LIMIT_EXCEEDED"));
+              }
+              return Promise.resolve({
+                json: () => Promise.resolve(ids.map((id) => makeSummaryRow(id))),
+              });
+            },
+          );
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          { ...baseInput, pageSize: 30 } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.groups.flat()).toHaveLength(30);
+
+        const chunkSizes = mockClickHouseQuery.mock.calls
+          .map((call) => call[0].query_params?.pageTraceIds?.length)
+          .filter((n): n is number => typeof n === "number");
+        // The descent bottomed out at 1, and every id was served by exactly one
+        // single-id read (25 from the first chunk, 5 from the second).
+        expect(chunkSizes).toContain(1);
+        expect(chunkSizes.filter((n) => n === 1)).toHaveLength(30);
+        // Intermediate levels really were visited, not skipped.
+        expect(chunkSizes).toContain(12);
+        expect(chunkSizes).toContain(6);
+        expect(chunkSizes).toContain(3);
+      });
+
+      it("stops bisecting once the work budget is spent instead of grinding every chunk", async () => {
+        // The regime the budget exists for: server-wide memory pressure, where
+        // a chunk fails at 25 but succeeds once small. Nothing aborts early, so
+        // every chunk pays a full recursion tree — 12 chunks x 17 runs = 204
+        // sequential queries at an instance that just reported it was OOM.
+        const traceIds = Array.from({ length: 300 }, (_, i) => `trace-${i}`);
+
+        mockClickHouseQuery
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
+          })
+          .mockImplementation(
+            (args: { query_params?: { pageTraceIds?: string[] } }) => {
+              const ids = args.query_params?.pageTraceIds ?? [];
+              if (ids.length > 3) {
+                return Promise.reject(new Error("MEMORY_LIMIT_EXCEEDED"));
+              }
+              return Promise.resolve({
+                json: () => Promise.resolve(ids.map((id) => makeSummaryRow(id))),
+              });
+            },
+          );
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        // Uncapped this call SUCCEEDS after grinding all 300 ids. The budget is
+        // what turns it back into the fast failure that protected the instance
+        // before bisection existed — so `rejects` here IS the fix, and it flips
+        // to a resolved page the moment the cap is removed.
+        await expect(
+          service.getAllTracesForProject(
+            { ...baseInput, pageSize: 300 } as GetAllTracesForProjectInput,
+            protections,
+          ),
+        ).rejects.toThrow("MEMORY_LIMIT_EXCEEDED");
+
+        // Total work stays under the documented ceiling:
+        //   ceil(300/25) baseline chunks + MAX_BISECT_RETRIES + count + IDs.
+        // Uncapped this is 206, so the bound fails without the budget.
+        expect(mockClickHouseQuery.mock.calls.length).toBeLessThanOrEqual(
+          12 + 100 + 2,
+        );
+      });
+
+      it("runs the two halves sequentially so a retry never doubles memory pressure", async () => {
+        const traceIds = Array.from({ length: 25 }, (_, i) => `trace-${i}`);
+        let inFlight = 0;
+        let maxInFlight = 0;
+
+        mockClickHouseQuery
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
+          })
+          .mockImplementation(
+            async (args: { query_params?: { pageTraceIds?: string[] } }) => {
+              const ids = args.query_params?.pageTraceIds ?? [];
+              inFlight += 1;
+              maxInFlight = Math.max(maxInFlight, inFlight);
+              try {
+                // Yield the microtask queue so overlapping calls would actually
+                // observe each other; a Promise.all refactor lands here at 2.
+                await new Promise((resolve) => setTimeout(resolve, 0));
+                if (ids.length > 12) {
+                  throw new Error("MEMORY_LIMIT_EXCEEDED");
+                }
+                return {
+                  json: () =>
+                    Promise.resolve(ids.map((id) => makeSummaryRow(id))),
+                };
+              } finally {
+                inFlight -= 1;
+              }
+            },
+          );
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          { ...baseInput, pageSize: 25 } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        // Load-bearing safety property, called out in the helper's comment and
+        // otherwise untested: a Promise.all refactor would stay green without it.
+        expect(maxInFlight).toBe(1);
+      });
+
+      it("re-throws a non-OOM error raised inside the bisection, without descending further", async () => {
+        const traceIds = Array.from({ length: 25 }, (_, i) => `trace-${i}`);
+
+        mockClickHouseQuery
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
+          })
+          // full list OOMs, the 25-id chunk OOMs, then the bisected lower half
+          // fails for an unrelated reason — the guard's non-OOM arm in the
+          // RECURSIVE position, which the top-level test can't reach.
+          .mockRejectedValueOnce(new Error("MEMORY_LIMIT_EXCEEDED"))
+          .mockRejectedValueOnce(new Error("MEMORY_LIMIT_EXCEEDED"))
+          .mockRejectedValueOnce(new Error("SYNTAX_ERROR"));
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await expect(
+          service.getAllTracesForProject(
+            { ...baseInput, pageSize: 25 } as GetAllTracesForProjectInput,
+            protections,
+          ),
+        ).rejects.toThrow("SYNTAX_ERROR");
+        // count, IDs, full-list OOM, chunk OOM, lower-half SYNTAX_ERROR — and
+        // nothing after it: the upper half is never attempted.
+        expect(mockClickHouseQuery).toHaveBeenCalledTimes(5);
+      });
+
+      it("bisects on the translated query_memory_exceeded the resilient client actually raises", async () => {
+        const { QueryMemoryExceededError } = await import(
+          "~/server/app-layer/traces/errors"
+        );
+        const traceIds = Array.from({ length: 25 }, (_, i) => `trace-${i}`);
+        const summaryRows = traceIds.map((id) => makeSummaryRow(id));
+
+        mockClickHouseQuery
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(traceIds.map((id) => ({ TraceId: id }))),
+          })
+          // Production never surfaces a raw Error carrying the ClickHouse
+          // fragment any more: every read path runs through
+          // translateClickHouseQueryError, which hands back this handled error
+          // with the driver detail buried in `reasons`. The other bisection
+          // tests reach the fallback via the legacy string-match arm, so this
+          // is the only one that proves the feature fires in prod.
+          .mockRejectedValueOnce(
+            new QueryMemoryExceededError({
+              reasons: [new Error("Code: 241. DB::Exception: ...")],
+            }),
+          )
+          .mockRejectedValueOnce(
+            new QueryMemoryExceededError({
+              reasons: [new Error("Code: 241. DB::Exception: ...")],
+            }),
+          )
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows.slice(0, 12)),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows.slice(12)),
+          })
+          .mockResolvedValueOnce({ json: () => Promise.resolve([]) });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          { ...baseInput, pageSize: 25 } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.groups.flat()).toHaveLength(25);
+        expect(
+          mockClickHouseQuery.mock.calls[4]![0].query_params.pageTraceIds,
+        ).toHaveLength(12);
+        expect(
+          mockClickHouseQuery.mock.calls[5]![0].query_params.pageTraceIds,
+        ).toHaveLength(13);
+      });
     });
 
     describe("when ClickHouse MEMORY_LIMIT_EXCEEDED on evaluations query", () => {
@@ -1223,6 +1461,75 @@ describe("ClickHouseTraceService", () => {
         expect(traces).toHaveLength(30);
         for (const trace of traces!) {
           expect(trace.spans).toHaveLength(1);
+        }
+      });
+
+      it("keeps the span scan window identical across every bisected chunk", async () => {
+        const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000;
+        // Deliberately far from the summary rows' own OccurredAt (Date.now()):
+        // if the window were still derived from a chunk's matched rows, the
+        // span reads would land near now instead of on this list-wide range.
+        const RESOLVED_FROM_MS = 1_000_000;
+        const RESOLVED_TO_MS = 2_000_000;
+        const traceIds = Array.from({ length: 30 }, (_, i) => `trace-${i}`);
+
+        mockClickHouseQuery
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve([
+                { fromMs: RESOLVED_FROM_MS, toMs: RESOLVED_TO_MS },
+              ]),
+          })
+          .mockImplementation(
+            (args: {
+              query: string;
+              query_params?: { traceIds?: string[] };
+            }) => {
+              const ids = args.query_params?.traceIds ?? [];
+              const isSpanRead = args.query.includes("stored_spans");
+              // Chunks above 12 OOM, so the 25-id chunk bisects; the halves
+              // then run their own span reads. Pre-fix each of those derived a
+              // window from its own summary rows.
+              if (!isSpanRead && ids.length > 12) {
+                return Promise.reject(new Error("MEMORY_LIMIT_EXCEEDED"));
+              }
+              return Promise.resolve({
+                json: () =>
+                  Promise.resolve(
+                    isSpanRead
+                      ? ids.map((id) => makeSpanRow(id, `${id}-s`))
+                      : ids.map((id) => makeSummaryRow(id)),
+                  ),
+              });
+            },
+          );
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const traces = await service.getTracesWithSpans(
+          "proj_123",
+          traceIds,
+          protections,
+        );
+
+        expect(traces).toHaveLength(30);
+
+        const spanCalls = mockClickHouseQuery.mock.calls
+          .map((call) => call[0])
+          .filter((args) => args.query.includes("stored_spans"));
+        // More than one chunk ran, so "identical" is a real constraint here.
+        expect(spanCalls.length).toBeGreaterThan(1);
+        for (const spanCall of spanCalls) {
+          // Chunk-INVARIANT: bisecting changes how many span reads happen,
+          // never which rows they are allowed to see. Derived per chunk, the
+          // narrowest of these would have collapsed toward a single trace's
+          // OccurredAt and silently dropped spans outside it.
+          expect(spanCall.query_params.fromMs).toBe(
+            RESOLVED_FROM_MS - TWO_DAYS_MS,
+          );
+          expect(spanCall.query_params.toMs).toBe(RESOLVED_TO_MS + TWO_DAYS_MS);
         }
       });
     });

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1895,6 +1895,26 @@ export class ClickHouseTraceService {
   private static readonly SUMMARY_BATCH_SIZE = 25;
 
   /**
+   * Ceiling on the EXTRA chunk-runs one call may spend on bisection, on top of
+   * its `ceil(ids.length / batchSize)` baseline chunks.
+   *
+   * Bisection generates unbounded work by construction: a chunk of 25 driven
+   * all the way down costs 49 runs instead of 1, and the download path hands
+   * this helper up to `pageSize ?? 10_000` ids (`api/routers/traces.ts`) — 400
+   * chunks — so an uncapped descent can issue ~20k sequential queries (~40k
+   * round trips on the join path, which runs two per chunk) against an
+   * instance that has *already told us it is out of memory*. The dangerous
+   * regime is server-wide memory pressure, where chunks fail at 25 and succeed
+   * small: every chunk bisects and nothing aborts early.
+   *
+   * Fast-fail IS the backpressure that protected that instance before
+   * bisection existed, so this budget restores it. Once spent, the next
+   * chunk-level OOM propagates instead of descending, capping one call at
+   * `ceil(ids.length / batchSize) + MAX_BISECT_RETRIES` runs.
+   */
+  private static readonly MAX_BISECT_RETRIES = 100;
+
+  /**
    * Run `runQuery` over `ids` in fixed-size chunks of `batchSize`, returning the
    * concatenated rows. This is the shared OOM fallback the trace reads use after
    * a full-list query trips ClickHouse's per-query memory cap.
@@ -1904,42 +1924,70 @@ export class ClickHouseTraceService {
    * heavy trace can no longer fail the whole page. The two halves run
    * SEQUENTIALLY (not in parallel) so a retry never compounds memory pressure on
    * an instance that just OOMed. A single-id batch that still OOMs — or any
-   * non-OOM error — is rethrown.
+   * non-OOM error — is rethrown, as is any OOM once `maxBisectRetries` is spent.
    */
-  private async retryInBatchesWithBisect<T>(
-    runQuery: (ids: string[]) => Promise<T[]>,
-    ids: string[],
-    batchSize: number,
-  ): Promise<T[]> {
+  private async retryInBatchesWithBisect<T>({
+    runQuery,
+    ids,
+    batchSize,
+    projectId,
+    maxBisectRetries = ClickHouseTraceService.MAX_BISECT_RETRIES,
+  }: {
+    runQuery: (ids: string[]) => Promise<T[]>;
+    ids: string[];
+    batchSize: number;
+    projectId: string;
+    maxBisectRetries?: number;
+  }): Promise<T[]> {
     if (batchSize <= 0) {
+      // Guards an infinite `for` below rather than a live caller (all three
+      // pass SUMMARY_BATCH_SIZE); a hung read is a worse failure than the
+      // three lines this costs.
       throw new Error("retryInBatchesWithBisect: batchSize must be > 0");
     }
-    const runChunk = async (chunk: string[]): Promise<T[]> => {
+    // Closed over the WHOLE call, not per chunk: the fan-out that has to be
+    // bounded is the request's total, because 400 chunks each bisecting a
+    // little hammers the instance exactly as hard as one chunk bisecting a lot.
+    let bisectRetriesSpent = 0;
+
+    const runChunk = async (chunk: string[], depth: number): Promise<T[]> => {
       try {
         return await runQuery(chunk);
       } catch (error) {
         if (chunk.length <= 1 || !isClickHouseMemoryLimitError(error)) {
           throw error;
         }
+        // Each bisection costs exactly two more chunk-runs; charge them up
+        // front so the budget bounds work issued, not work completed.
+        if (bisectRetriesSpent + 2 > maxBisectRetries) {
+          this.logger.warn(
+            { projectId, chunkSize: chunk.length, depth, maxBisectRetries },
+            "ClickHouse bisect budget exhausted; failing fast instead of descending further",
+          );
+          throw error;
+        }
+        bisectRetriesSpent += 2;
+
         const mid = Math.floor(chunk.length / 2);
         // Only the initial full-list OOM logs at the call site; this is the
         // sole signal that a page descended into per-batch bisection — and it
         // fires only under memory stress, exactly when the signal matters.
+        // Bounded by the budget above, so it cannot flood the log.
         this.logger.warn(
-          { batchSize: chunk.length, mid },
+          { projectId, chunkSize: chunk.length, mid, depth },
           "ClickHouse batch still OOMed; bisecting",
         );
         // Sequential, not parallel: running both halves at once would
         // re-pressure the same instance that just OOMed.
-        const lowerHalf = await runChunk(chunk.slice(0, mid));
-        const upperHalf = await runChunk(chunk.slice(mid));
+        const lowerHalf = await runChunk(chunk.slice(0, mid), depth + 1);
+        const upperHalf = await runChunk(chunk.slice(mid), depth + 1);
         return [...lowerHalf, ...upperHalf];
       }
     };
 
     const rows: T[] = [];
     for (let i = 0; i < ids.length; i += batchSize) {
-      rows.push(...(await runChunk(ids.slice(i, i + batchSize))));
+      rows.push(...(await runChunk(ids.slice(i, i + batchSize), 0)));
     }
     return rows;
   }
@@ -2065,11 +2113,12 @@ export class ClickHouseTraceService {
         `Summary query OOM for ${traceIds.length} traces, retrying in batches of ${ClickHouseTraceService.SUMMARY_BATCH_SIZE}`,
       );
 
-      const allRows = await this.retryInBatchesWithBisect(
+      const allRows = await this.retryInBatchesWithBisect({
         runQuery,
-        traceIds,
-        ClickHouseTraceService.SUMMARY_BATCH_SIZE,
-      );
+        ids: traceIds,
+        batchSize: ClickHouseTraceService.SUMMARY_BATCH_SIZE,
+        projectId,
+      });
 
       // Batches come back in chunk order, not the page's global sort order —
       // re-impose the ORDER BY (date axis, then TraceId) across the merged set.
@@ -2317,11 +2366,12 @@ export class ClickHouseTraceService {
         `Evaluations query OOM for ${traceIds.length} traces, retrying in batches of ${ClickHouseTraceService.SUMMARY_BATCH_SIZE}`,
       );
 
-      return await this.retryInBatchesWithBisect(
+      return await this.retryInBatchesWithBisect({
         runQuery,
-        traceIds,
-        ClickHouseTraceService.SUMMARY_BATCH_SIZE,
-      );
+        ids: traceIds,
+        batchSize: ClickHouseTraceService.SUMMARY_BATCH_SIZE,
+        projectId,
+      });
     }
   }
 
@@ -2766,40 +2816,45 @@ export class ClickHouseTraceService {
         // MEMORY_LIMIT_EXCEEDED. Run the list as one query on the happy path, and
         // on OOM retry in fixed-size batches (same fallback as fetchTraceSummaryRows
         // / fetchEvaluationRows) so peak memory is bounded without dropping data.
+        // When the caller knows the traces' approximate time, bound the
+        // summary read to those weekly partitions. trace_summaries is
+        // partitioned on OccurredAt, so a TraceId-only filter cannot prune
+        // partitions and scans every part (incl. cold S3) to locate the rows.
+        // A ±2-day margin around the caller's range is safe headroom; without
+        // a hint we keep the original unbounded read.
+        //
+        // resolveOccurredAtRange yields a RANGE (min/max OccurredAt), not a
+        // point, so map it onto queryWindowed's centre+half-width form: centre
+        // on the range midpoint and grow the half-width to cover half the range
+        // PLUS the ±2-day margin. The emitted fragment's bounds then land on
+        // exactly [from - 2d, to + 2d] — the same predicate the old local
+        // constant produced. Fallback "none": a resolve failure already left
+        // effectiveOccurredAt undefined (hint null -> unbounded read, warn
+        // logged at the resolve site), and a hinted-but-empty summary read is
+        // never widened here — an empty result is authoritative and the caller
+        // below skips the span scan.
+        //
+        // Computed ONCE for the whole trace-id list, deliberately outside
+        // runBatch: it derives from the caller's / the resolve's range over ALL
+        // ids, so every chunk — including a bisected one — reads through the
+        // same window. See the span window below for why that matters.
+        const hasSummaryWindow =
+          effectiveOccurredAt !== undefined &&
+          effectiveOccurredAt.from > 0 &&
+          effectiveOccurredAt.to > 0;
+        const summaryHintMs = hasSummaryWindow
+          ? (effectiveOccurredAt.from + effectiveOccurredAt.to) / 2
+          : null;
+        const summaryWindowMs = hasSummaryWindow
+          ? (effectiveOccurredAt.to - effectiveOccurredAt.from) / 2 +
+            DEFAULT_PARTITION_WINDOW_MS
+          : DEFAULT_PARTITION_WINDOW_MS;
+
         const runBatch = async (
           batchTraceIds: string[],
         ): Promise<
           Map<string, { summary: TraceSummaryData; spans: NormalizedSpan[] }>
         > => {
-          // When the caller knows the traces' approximate time, bound the
-          // summary read to those weekly partitions. trace_summaries is
-          // partitioned on OccurredAt, so a TraceId-only filter cannot prune
-          // partitions and scans every part (incl. cold S3) to locate the rows.
-          // A ±2-day margin around the caller's range is safe headroom; without
-          // a hint we keep the original unbounded read.
-          //
-          // resolveOccurredAtRange yields a RANGE (min/max OccurredAt), not a
-          // point, so map it onto queryWindowed's centre+half-width form: centre
-          // on the range midpoint and grow the half-width to cover half the range
-          // PLUS the ±2-day margin. The emitted fragment's bounds then land on
-          // exactly [from - 2d, to + 2d] — the same predicate the old local
-          // constant produced. Fallback "none": a resolve failure already left
-          // effectiveOccurredAt undefined (hint null -> unbounded read, warn
-          // logged at the resolve site), and a hinted-but-empty summary read is
-          // never widened here — an empty result is authoritative and the caller
-          // below skips the span scan.
-          const hasSummaryWindow =
-            effectiveOccurredAt !== undefined &&
-            effectiveOccurredAt.from > 0 &&
-            effectiveOccurredAt.to > 0;
-          const summaryHintMs = hasSummaryWindow
-            ? (effectiveOccurredAt.from + effectiveOccurredAt.to) / 2
-            : null;
-          const summaryWindowMs = hasSummaryWindow
-            ? (effectiveOccurredAt.to - effectiveOccurredAt.from) / 2 +
-              DEFAULT_PARTITION_WINDOW_MS
-            : DEFAULT_PARTITION_WINDOW_MS;
-
           // Summaries first (light, one row per trace): they carry OccurredAt,
           // which bounds the heavy stored_spans scan below to the traces' weekly
           // partitions instead of cold-scanning every partition on S3. A span's
@@ -2910,24 +2965,26 @@ export class ClickHouseTraceService {
             Links_Attributes: Record<string, unknown>[];
           };
 
-          // Bound the stored_spans scan to the weeks the matched traces occurred
-          // in (the cold-scan cost driver). Same range->window mapping as the
-          // summary read above: centre on the matched summaries' OccurredAt
-          // midpoint, half-width = half that range + the ±2-day margin, so the
-          // fragment lands on exactly [min - 2d, max + 2d]. Fallback "none": no
-          // matched OccurredAts -> hint null -> unbounded scan (the old
-          // hasWindow=false branch); a hinted-but-empty span read is
-          // authoritative and never widened.
-          const occurredAts = summaryRows
-            .map((r) => r.ts_OccurredAt)
-            .filter((t): t is number => typeof t === "number" && t > 0);
-          const hasWindow = occurredAts.length > 0;
-          const spanMinMs = hasWindow ? Math.min(...occurredAts) : 0;
-          const spanMaxMs = hasWindow ? Math.max(...occurredAts) : 0;
-          const spanHintMs = hasWindow ? (spanMinMs + spanMaxMs) / 2 : null;
-          const spanWindowMs = hasWindow
-            ? (spanMaxMs - spanMinMs) / 2 + DEFAULT_PARTITION_WINDOW_MS
-            : DEFAULT_PARTITION_WINDOW_MS;
+          // Bound the stored_spans scan to the weeks the traces occurred in
+          // (the cold-scan cost driver), reusing the list-wide window computed
+          // above rather than deriving one from THIS chunk's summary rows.
+          //
+          // Deriving per chunk is what the OOM fallback makes unsafe: the
+          // window would narrow monotonically as bisection halves the chunk,
+          // and at length 1 it collapses to a single trace's OccurredAt ±2d.
+          // Any span outside that — long-running sessions, replays, clock skew
+          // — would then be dropped with no error and no warning, so the same
+          // trace would come back with fewer spans purely because the read hit
+          // memory pressure. Keying off the list-wide range instead makes the
+          // window chunk-INVARIANT: bisecting changes how many queries we run,
+          // never which rows they can see.
+          //
+          // Fallback "none": no list-wide range (caller passed none and the
+          // sort-key resolve failed open) -> hint null -> unbounded scan, the
+          // same slow-but-correct branch the summary read above takes. A
+          // hinted-but-empty span read is authoritative and never widened.
+          const spanHintMs = summaryHintMs;
+          const spanWindowMs = summaryWindowMs;
 
           const spanRows = await queryWindowed<SpanRow[]>({
             table: "stored_spans",
@@ -3050,13 +3107,17 @@ export class ClickHouseTraceService {
 
           // runBatch returns a Map keyed by TraceId; flatten each batch's
           // entries so the shared bisecting helper can concatenate them, then
-          // rebuild the Map. Per-batch id sets are disjoint, so no entry is lost
-          // when reconstructing.
-          const mergedEntries = await this.retryInBatchesWithBisect(
-            async (ids) => [...(await runBatch(ids))],
-            traceIds,
-            ClickHouseTraceService.SUMMARY_BATCH_SIZE,
-          );
+          // rebuild the Map. The helper partitions by INDEX, not by value, so
+          // this assumes callers do not pass a duplicated trace id — if one
+          // did, it would land in two chunks and the later entry would win the
+          // rebuild. Equivalent to the happy path's `tracesMap.set`, which
+          // collapses duplicates the same way.
+          const mergedEntries = await this.retryInBatchesWithBisect({
+            runQuery: async (ids) => [...(await runBatch(ids))],
+            ids: traceIds,
+            batchSize: ClickHouseTraceService.SUMMARY_BATCH_SIZE,
+            projectId,
+          });
           return new Map(mergedEntries);
         }
       },

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1906,11 +1906,14 @@ export class ClickHouseTraceService {
    * an instance that just OOMed. A single-id batch that still OOMs — or any
    * non-OOM error — is rethrown.
    */
-  private static async retryInBatchesWithBisect<T>(
+  private async retryInBatchesWithBisect<T>(
     runQuery: (ids: string[]) => Promise<T[]>,
     ids: string[],
     batchSize: number,
   ): Promise<T[]> {
+    if (batchSize <= 0) {
+      throw new Error("retryInBatchesWithBisect: batchSize must be > 0");
+    }
     const runChunk = async (chunk: string[]): Promise<T[]> => {
       try {
         return await runQuery(chunk);
@@ -1919,6 +1922,13 @@ export class ClickHouseTraceService {
           throw error;
         }
         const mid = Math.floor(chunk.length / 2);
+        // Only the initial full-list OOM logs at the call site; this is the
+        // sole signal that a page descended into per-batch bisection — and it
+        // fires only under memory stress, exactly when the signal matters.
+        this.logger.warn(
+          { batchSize: chunk.length, mid },
+          "ClickHouse batch still OOMed; bisecting",
+        );
         // Sequential, not parallel: running both halves at once would
         // re-pressure the same instance that just OOMed.
         const lowerHalf = await runChunk(chunk.slice(0, mid));
@@ -2055,7 +2065,7 @@ export class ClickHouseTraceService {
         `Summary query OOM for ${traceIds.length} traces, retrying in batches of ${ClickHouseTraceService.SUMMARY_BATCH_SIZE}`,
       );
 
-      const allRows = await ClickHouseTraceService.retryInBatchesWithBisect(
+      const allRows = await this.retryInBatchesWithBisect(
         runQuery,
         traceIds,
         ClickHouseTraceService.SUMMARY_BATCH_SIZE,
@@ -2307,7 +2317,7 @@ export class ClickHouseTraceService {
         `Evaluations query OOM for ${traceIds.length} traces, retrying in batches of ${ClickHouseTraceService.SUMMARY_BATCH_SIZE}`,
       );
 
-      return await ClickHouseTraceService.retryInBatchesWithBisect(
+      return await this.retryInBatchesWithBisect(
         runQuery,
         traceIds,
         ClickHouseTraceService.SUMMARY_BATCH_SIZE,
@@ -3042,12 +3052,11 @@ export class ClickHouseTraceService {
           // entries so the shared bisecting helper can concatenate them, then
           // rebuild the Map. Per-batch id sets are disjoint, so no entry is lost
           // when reconstructing.
-          const mergedEntries =
-            await ClickHouseTraceService.retryInBatchesWithBisect(
-              async (ids) => [...(await runBatch(ids))],
-              traceIds,
-              ClickHouseTraceService.SUMMARY_BATCH_SIZE,
-            );
+          const mergedEntries = await this.retryInBatchesWithBisect(
+            async (ids) => [...(await runBatch(ids))],
+            traceIds,
+            ClickHouseTraceService.SUMMARY_BATCH_SIZE,
+          );
           return new Map(mergedEntries);
         }
       },

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -2321,6 +2321,22 @@ export class ClickHouseTraceService {
   /**
    * Fetch evaluation rows for a set of trace IDs.
    * Same OOM-resilient pattern as fetchTraceSummaryRows.
+   *
+   * ⚠ Partition-safety of the OOM fallback rests on an invariant the schema
+   * does NOT enforce. The dedup below groups on `(TenantId, EvaluationId)`
+   * while the batching splits on `TraceId`, and `evaluation_runs` is
+   * `ORDER BY (TenantId, EvaluationId)` with `TraceId` merely a nullable
+   * column — so nothing structurally stops two versions of one EvaluationId
+   * from carrying different TraceIds. If that happened and the two landed in
+   * different batches, each would compute its own local `max(UpdatedAt)` and
+   * the concatenation would resurrect the stale version alongside the current
+   * one. (The trace-summary read has no such exposure: it groups on
+   * `(TenantId, TraceId)`, which CONTAINS the split key.)
+   *
+   * This is safe only while TraceId never changes across versions of an
+   * EvaluationId. No writer does that today; bisection multiplies the number
+   * of partitions, so if one ever starts, the damage shows up only on the OOM
+   * path and is effectively unreproducible.
    */
   private async fetchEvaluationRows({
     clickHouseClient,

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1895,10 +1895,51 @@ export class ClickHouseTraceService {
   private static readonly SUMMARY_BATCH_SIZE = 25;
 
   /**
+   * Run `runQuery` over `ids` in fixed-size chunks of `batchSize`, returning the
+   * concatenated rows. This is the shared OOM fallback the trace reads use after
+   * a full-list query trips ClickHouse's per-query memory cap.
+   *
+   * If a chunk itself OOMs (MEMORY_LIMIT_EXCEEDED) the chunk is recursively
+   * BISECTED — halve, retry each half — down to a single id, so one unusually
+   * heavy trace can no longer fail the whole page. The two halves run
+   * SEQUENTIALLY (not in parallel) so a retry never compounds memory pressure on
+   * an instance that just OOMed. A single-id batch that still OOMs — or any
+   * non-OOM error — is rethrown.
+   */
+  private static async retryInBatchesWithBisect<T>(
+    runQuery: (ids: string[]) => Promise<T[]>,
+    ids: string[],
+    batchSize: number,
+  ): Promise<T[]> {
+    const runChunk = async (chunk: string[]): Promise<T[]> => {
+      try {
+        return await runQuery(chunk);
+      } catch (error) {
+        if (chunk.length <= 1 || !isClickHouseMemoryLimitError(error)) {
+          throw error;
+        }
+        const mid = Math.floor(chunk.length / 2);
+        // Sequential, not parallel: running both halves at once would
+        // re-pressure the same instance that just OOMed.
+        const lowerHalf = await runChunk(chunk.slice(0, mid));
+        const upperHalf = await runChunk(chunk.slice(mid));
+        return [...lowerHalf, ...upperHalf];
+      }
+    };
+
+    const rows: T[] = [];
+    for (let i = 0; i < ids.length; i += batchSize) {
+      rows.push(...(await runChunk(ids.slice(i, i + batchSize))));
+    }
+    return rows;
+  }
+
+  /**
    * Fetch full trace summary rows for a set of trace IDs.
-   * On ClickHouse MEMORY_LIMIT_EXCEEDED, retries in smaller batches
-   * so that heavy ComputedInput/ComputedOutput columns don't blow the
-   * per-query memory cap. If a single batch still OOMs the error propagates.
+   * On ClickHouse MEMORY_LIMIT_EXCEEDED, retries in smaller batches —
+   * bisecting any batch that still OOMs down to a single id — so heavy
+   * ComputedInput/ComputedOutput columns don't blow the per-query memory cap.
+   * Only a single-id batch that still OOMs propagates.
    */
   private async fetchTraceSummaryRows({
     clickHouseClient,
@@ -1916,7 +1957,7 @@ export class ClickHouseTraceService {
     startDate: number;
     endDate: number;
     traceIds: string[];
-    orderDirection: string;
+    orderDirection: "ASC" | "DESC";
     /** Fetch the heavy Computed* columns independently. False reads '' instead —
      * the row shape is unchanged but ClickHouse never materializes that column. */
     fetchInput?: boolean;
@@ -2014,20 +2055,14 @@ export class ClickHouseTraceService {
         `Summary query OOM for ${traceIds.length} traces, retrying in batches of ${ClickHouseTraceService.SUMMARY_BATCH_SIZE}`,
       );
 
-      const allRows: TraceSummaryRow[] = [];
-      for (
-        let i = 0;
-        i < traceIds.length;
-        i += ClickHouseTraceService.SUMMARY_BATCH_SIZE
-      ) {
-        const batch = traceIds.slice(
-          i,
-          i + ClickHouseTraceService.SUMMARY_BATCH_SIZE,
-        );
-        const batchRows = await runQuery(batch);
-        allRows.push(...batchRows);
-      }
+      const allRows = await ClickHouseTraceService.retryInBatchesWithBisect(
+        runQuery,
+        traceIds,
+        ClickHouseTraceService.SUMMARY_BATCH_SIZE,
+      );
 
+      // Batches come back in chunk order, not the page's global sort order —
+      // re-impose the ORDER BY (date axis, then TraceId) across the merged set.
       const dir = orderDirection === "DESC" ? -1 : 1;
       allRows.sort((a, b) => {
         const timeDiff = a[sortColumn] - b[sortColumn];
@@ -2272,21 +2307,11 @@ export class ClickHouseTraceService {
         `Evaluations query OOM for ${traceIds.length} traces, retrying in batches of ${ClickHouseTraceService.SUMMARY_BATCH_SIZE}`,
       );
 
-      const allRows: ClickHouseEvaluationRunRow[] = [];
-      for (
-        let i = 0;
-        i < traceIds.length;
-        i += ClickHouseTraceService.SUMMARY_BATCH_SIZE
-      ) {
-        const batch = traceIds.slice(
-          i,
-          i + ClickHouseTraceService.SUMMARY_BATCH_SIZE,
-        );
-        const batchRows = await runQuery(batch);
-        allRows.push(...batchRows);
-      }
-
-      return allRows;
+      return await ClickHouseTraceService.retryInBatchesWithBisect(
+        runQuery,
+        traceIds,
+        ClickHouseTraceService.SUMMARY_BATCH_SIZE,
+      );
     }
   }
 
@@ -3013,25 +3038,17 @@ export class ClickHouseTraceService {
             `Traces-with-spans join OOM for ${traceIds.length} traces, retrying in batches of ${ClickHouseTraceService.SUMMARY_BATCH_SIZE}`,
           );
 
-          const merged = new Map<
-            string,
-            { summary: TraceSummaryData; spans: NormalizedSpan[] }
-          >();
-          for (
-            let i = 0;
-            i < traceIds.length;
-            i += ClickHouseTraceService.SUMMARY_BATCH_SIZE
-          ) {
-            const batch = traceIds.slice(
-              i,
-              i + ClickHouseTraceService.SUMMARY_BATCH_SIZE,
+          // runBatch returns a Map keyed by TraceId; flatten each batch's
+          // entries so the shared bisecting helper can concatenate them, then
+          // rebuild the Map. Per-batch id sets are disjoint, so no entry is lost
+          // when reconstructing.
+          const mergedEntries =
+            await ClickHouseTraceService.retryInBatchesWithBisect(
+              async (ids) => [...(await runBatch(ids))],
+              traceIds,
+              ClickHouseTraceService.SUMMARY_BATCH_SIZE,
             );
-            const batchMap = await runBatch(batch);
-            for (const [traceId, value] of batchMap) {
-              merged.set(traceId, value);
-            }
-          }
-          return merged;
+          return new Map(mergedEntries);
         }
       },
     );

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -2999,6 +2999,15 @@ export class ClickHouseTraceService {
           // sort-key resolve failed open) -> hint null -> unbounded scan, the
           // same slow-but-correct branch the summary read above takes. A
           // hinted-but-empty span read is authoritative and never widened.
+          //
+          // Cost, accepted knowingly: callers that pass a broad occurredAt
+          // (the trace-list routes forward the user's whole date filter) now
+          // scan spans over that range rather than the matched traces' own
+          // times — more weekly partitions, though the summary read in the
+          // same call already scans exactly this window. Keeping the tight
+          // per-chunk window only when the batch covers the whole id list
+          // would recover that, at the price of a branch whose invariance
+          // argument is far longer than this one's.
           const spanHintMs = summaryHintMs;
           const spanWindowMs = summaryWindowMs;
 

--- a/specs/traces/clickhouse-oom-batch-recovery.feature
+++ b/specs/traces/clickhouse-oom-batch-recovery.feature
@@ -1,0 +1,92 @@
+Feature: Trace reads survive a ClickHouse memory limit
+
+  Reading a page of traces pulls wide columns (ComputedInput/ComputedOutput,
+  span attributes) for every trace on the page, so a large or unusually heavy
+  page can exceed ClickHouse's per-query memory limit and fail the whole
+  request. When that happens the read retries the page in smaller batches, and
+  splits any batch that still fails, so one heavy trace no longer costs the
+  user every other trace on the page.
+
+  The recovery runs against a database that has just reported it is out of
+  memory, so it is bounded on purpose: it must never turn one failed read into
+  a sustained flood of queries at a struggling instance, and it must never
+  quietly return fewer rows than the same read would have returned without
+  memory pressure.
+
+  Two test layers, matching specs/analytics/clickhouse-memory-safety.feature:
+  1. Recovery behaviour and its bounds (unit, mocked failures)
+  2. End-to-end recovery under a real memory limit (integration, real ClickHouse)
+
+  Background:
+    Given a project with traces stored in ClickHouse
+
+  # ---------------------------------------------------------------------------
+  # Layer 1: recovery behaviour and its bounds (unit)
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A batch that still exceeds the memory limit is split and retried
+    Given a page of traces whose full read exceeds the memory limit
+    And the first smaller batch also exceeds the memory limit
+    When the page is read
+    Then that batch is split and each part is retried
+    And every trace on the page is returned
+
+  @unit
+  Scenario: Splitting continues until a batch holds a single trace
+    Given a page of traces where only a single-trace read fits in memory
+    When the page is read
+    Then the batches are split repeatedly until each holds one trace
+    And every trace on the page is returned
+
+  @unit
+  Scenario: Recovery stops once its work budget is spent
+    Given sustained memory pressure where large batches fail and small ones succeed
+    When a page large enough to exhaust the recovery budget is read
+    Then the read fails instead of continuing to retry
+    And the total number of queries stays within the budget
+
+  @unit
+  Scenario: Retries of a split batch run one at a time
+    Given a batch that is split after exceeding the memory limit
+    When its parts are retried
+    Then no two of those retries run at the same time
+
+  @unit
+  Scenario: A failure unrelated to memory is surfaced immediately
+    Given a batch that is split after exceeding the memory limit
+    And one part fails for a reason other than memory
+    When the page is read
+    Then that failure is reported without retrying the remaining parts
+
+  @unit
+  Scenario: Splitting a batch does not narrow the span search window
+    Given a page read that is split into smaller batches
+    When the spans for each batch are read
+    Then every batch searches the same time window as the unsplit read
+
+  # ---------------------------------------------------------------------------
+  # Layer 2: end-to-end under a real memory limit (real ClickHouse)
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: A page still loads when the database runs out of memory
+    Given a running ClickHouse test container with schema applied
+    And traces heavy enough that reading the whole page exceeds a set memory limit
+    When the page is read
+    Then every trace on the page is returned
+
+  @integration
+  Scenario: A page recovered from a memory limit matches an unaffected read
+    Given a running ClickHouse test container with schema applied
+    And traces heavy enough that reading the whole page exceeds a set memory limit
+    When the page is read under that limit and again without it
+    Then both reads return the same traces in the same order
+
+  @integration
+  Scenario: A trace that cannot be read alone fails the page instead of retrying forever
+    Given a running ClickHouse test container with schema applied
+    And a memory limit no batch size can satisfy
+    When the page is read
+    Then the memory error is reported
+    And the number of queries issued stays within the recovery budget


### PR DESCRIPTION
# Related Issue

- Refs #4202
- Follow-up filed: #6277

## Reviewer cockpit

- **Scariest thing** — this code only ever runs against a ClickHouse instance that has *already* reported it is out of memory. Get the bound wrong and a single trace-list read fires thousands of sequential queries at a struggling instance, turning a fast 500 into a multi-minute outage amplifier. The second-scariest is silent: a span-scan window that narrows as the retry bisects would return **fewer spans for the same trace** with no error at all.
- **Start here** — `retryInBatchesWithBisect` in `langwatch/src/server/traces/clickhouse-trace.service.ts`. The whole PR is that one helper plus its three call sites; the budget check is the ~6 lines that decide whether this is a safety feature or a load generator.

## Why

Refs #4202. PR #4201 made `/api/traces/search` retry a memory-blown ClickHouse read in batches of 25. A **single 25-id batch that itself OOMs** still propagated uncaught, failing the whole request.

This PR bisects that batch instead — and, per review, **bounds** the bisection so the recovery cannot itself become the incident.

## What changed

- **Cumulative work budget (`MAX_BISECT_RETRIES = 100`)** → *alternative: a 2-level depth cap* → a depth cap bounds one chunk but not the request: the download path passes `pageSize ?? 10_000`, so 400 chunks each bisecting "only a little" still costs thousands of queries. The budget is closed over the whole call, so it bounds the axis that actually matters, capping a call at `ceil(ids/25) + 100` runs instead of ~19,600 (~39,200 on the join path). **Cost if this call is wrong:** a page that *could* have been recovered by grinding now 500s — deliberately, because that is the pre-bisection behaviour and the backpressure a memory-pressured instance depends on.
- **Chunk-invariant span window** → *alternative: widen the per-chunk margin and log when it narrows* → widening only shrinks the odds of silently dropping spans; it does not remove them. The window is now computed once for the whole id list, so bisecting changes how many queries run, never which rows they can see. **Two real costs, both deliberate:** (1) the two `traces.ts` callers that pass `{from: startDate, to: endDate}` now scan spans over the *user's* date range ±2d instead of the matched traces' own times — for a 30-day filter that is ~5 weekly partitions instead of ~1. The summary read in the same call already paid exactly this, so it is a widening to match, not a new class of scan. (2) When no list-wide range exists at all (caller passed none *and* the sort-key resolve failed open), the span scan is unbounded rather than narrowly-and-wrongly bounded — in a branch that already took the same fallback for its summary read. **I picked correctness over both.** A tighter variant exists — keep the summary-derived window when the batch covers the whole id list, use the list-wide one only for subsets — and I left it out because the extra branch needs a paragraph to justify while this needs a sentence. Say the word if you'd rather have the perf.
- **Recursive single-batch bisection (issue item #5, partial)** — a failing batch is halved and each half retried, **sequentially**, down to a single id. This fixes the *aggregate* case (25 mid-size traces summing over the cap). It does **not** fix one trace heavy enough to OOM alone: bisection locates it and then rethrows, same failed page. Tracked as #6277 — see *Anything surprising?*.
- **DRY the three retry loops (issue item #3)** — `fetchTraceSummaryRows`, `fetchEvaluationRows` and the spans-join each carried a copy of the batch-retry loop; they now share one helper (the join via a Map↔entries adapter). **Typed `orderDirection` (item #6)** — `string` → `"ASC" | "DESC"`.
- **`specs/traces/clickhouse-oom-batch-recovery.feature`** — nine scenarios, every one bound to a test that already passes. Mirrors `specs/analytics/clickhouse-memory-safety.feature`, which covers the same class of problem for the analytics service in the same two layers. See *Anything surprising?* for why it arrived late.

## How it works

```
clickhouse-trace.service.ts
  MAX_BISECT_RETRIES = 100            NEW  cumulative ceiling on bisection-induced runs
  retryInBatchesWithBisect<T>({runQuery, ids, batchSize, projectId})   shared helper
    └ runChunk(chunk, depth)
        try runQuery(chunk)
        on error → rethrow if len<=1, non-OOM, OR budget spent   ← the bound
                 → else charge 2, bisect SEQUENTIALLY, concat
  fetchTraceSummaryRows       ── on OOM → retryInBatchesWithBisect  (re-sort kept in caller)
  fetchEvaluationRows         ── on OOM → retryInBatchesWithBisect
  fetchTracesWithSpansJoined  ── on OOM → retryInBatchesWithBisect  (Map↔entries adapter)
    └ summary + span windows now computed ONCE, above runBatch      ← chunk-invariant
```

The OOM detector (`isClickHouseMemoryLimitError`) and the 25-id `SUMMARY_BATCH_SIZE` are unchanged. The recursion strictly shrinks the chunk toward a length-1 base case, so it terminates on the chunk axis; the budget terminates it on the request axis.

## Human verification

A skeptical reviewer can re-confirm each claim independently:

1. **The budget actually bounds work.** Open `retryInBatchesWithBisect` and replace `if (bisectRetriesSpent + 2 > maxBisectRetries)` with `if (false)`. Run `pnpm test:unit src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts` → *"stops bisecting once the work budget is spent"* fails with **"promise resolved instead of rejecting"** — i.e. uncapped, the read grinds all 300 ids and succeeds. Restore → passes.
2. **The span window is chunk-invariant.** Restore the per-chunk derivation (`Math.min(...occurredAts)` from `summaryRows`) in place of `const spanHintMs = summaryHintMs`. Re-run → *"keeps the span scan window identical across every bisected chunk"* fails, showing the window drifted to `Date.now()` instead of the list-wide range.
3. **The halves really are sequential.** Change the two `await runChunk(...)` lines to a `Promise.all([...])`. Re-run → **7** tests fail, including the dedicated concurrency test.
4. **It works against a real database, not a mock.** `pnpm test:integration src/server/traces/__tests__/clickhouse-trace-oom-bisect.integration.test.ts` (needs Docker — spins up ClickHouse via testcontainers). Then change `chunk.length <= 1` to `chunk.length <= 99999` in `retryInBatchesWithBisect` to disable bisection and re-run → all 3 fail.
5. **The spec is really bound, not decorative.** `npx tsx langwatch/scripts/check-feature-parity.ts` exits 0 ("all bound"). Delete any one `/** @scenario ... */` line and re-run → exit 1, naming that scenario.
6. **The branch is not stale.** `git merge-base --is-ancestor origin/main HEAD` exits 0.

## How I can prove I was successful

**Exercised against a real ClickHouse, not only mocks** — *proven*:

![#4202 real-ClickHouse OOM + red→green falsifiability](https://raw.githubusercontent.com/langwatch/langwatch/proof/4202-oom-bisection/proofs/4202-redgreen-v3.png)

Every pre-existing test on this path *mocks the rejection*, so it can only prove the helper reacts to an error shape we hand it — which is exactly the gap the review named. New `clickhouse-trace-oom-bisect.integration.test.ts` runs the whole chain against a testcontainers ClickHouse:

```
real MEMORY_LIMIT_EXCEEDED -> driver error -> translateClickHouseQueryError
  -> QueryMemoryExceededError -> isClickHouseMemoryLimitError -> bisection
```

The error the service actually caught, from that run:

> `Query memory limit exceeded: would use 643.31 KiB (attempt to allocate chunk of 0.00 B), maximum: 1.00 B: While executing AggregatingTransform.`
> `at parseError (@clickhouse/client/dist/common/error/error.js:42:16)`

| Claim | Status | Evidence |
|---|---|---|
| The fix works against a **real** ClickHouse OOM | **proven** | 3/3 integration green: page recovers in full; recovered page is identical in ids **and order** to the unpressured read; and when nothing fits it gives up bounded. Disabling the bisection turns **all three red** against real ClickHouse |
| Bisection fires on the **prod** error path | **proven** | the integration run above never constructs an error — ClickHouse raises it. Plus a unit test rejecting with `QueryMemoryExceededError` (`code: "query_memory_exceeded"`); every pre-existing bisection test reached the fallback only via the legacy string-match arm |
| Rebased onto current main (was 565 behind) | **proven** | rebased onto `3d3fb6b802`; `merge-base --is-ancestor` clean |
| Proof re-run on today's code, not the stale base | **proven** | control run: pristine `origin/main`, same `node_modules`, **34/34 green** — so every failure below is attributable to this PR, not inherited |
| The budget cap is load-bearing | **proven** | disabled → the read **resolves** instead of rejecting (RED 1/3) |
| The span window fix is load-bearing | **proven** | reverted → window drifts to `Date.now()` (RED 2/3) |
| Sequential halves are enforced | **proven** | `Promise.all` → 7 tests red (RED 3/3) |
| Suite + types green | **proven** | **45/45** on the unit file, **404/404** across all 25 `src/server/traces` unit files, `pnpm typecheck` and `pnpm typecheck:tests` both exit 0 |

On determinism: the integration test picks the `max_memory_usage` ceiling per batch size, so the *trigger* is deterministic rather than dependent on how much memory a given ClickHouse build allocates. Everything downstream of the trigger — the error, its translation, the detection, the recovery, the returned rows — is real.

**The rebase was not a formality — it caught a real regression.** On the stale base the suite was green. Rebased, 4 tests failed, and the control run proves they were this PR's: main's join path now issues an `OccurredAt` sort-key resolve before the summary read, which shifted the query sequence the join bisect test is index-coupled to; that one stale test was consuming the following tests' queued mocks. Fixed, and the index-coupling the review flagged is exactly why it broke.

<!-- no-ui-surface --> This is a backend-only change to the ClickHouse read path — no user-facing UI surface. The gating surface is the trace-list read under genuine ClickHouse memory pressure, and it is exercised as such: real database, real `MEMORY_LIMIT_EXCEEDED`, through the service's real public entry point (`getAllTracesForProject`). Reaching this code path in the running app requires inducing a real OOM, which is what the integration test does — a browser walk of the trace list would exercise the happy path only and prove nothing about this change.

## Anything surprising?

- **This PR does not close #4202 item #5.** For the case that item literally describes — *one* trace heavy enough to OOM alone — behaviour is unchanged: bisection locates the offending id, then rethrows, and the page still fails. What it genuinely fixes is the aggregate case. The graceful path (routing that id into the streaming response's existing `skipped` count) is filed as **#6277**; the reviewer preferred doing it here, but it is a new user-visible contract rather than a bound on this recursion, so it is tracked rather than smuggled in. The body says `Refs #4202`, not `Closes`.
- **The budget makes a previously-recoverable page fail.** Under sustained pressure a read that would have succeeded after ~200 queries now 500s after ~110. That is intended — the reviewer's point is that fast-fail *is* the backpressure — but it is a real behaviour change, not just a safety net.
- **The feature file arrived last, not first.** `CLAUDE.md` says specs come before code and I did not check `specs/` until a late sweep — by which point `specs/analytics/clickhouse-memory-safety.feature` turned out to cover this exact class of problem for a sibling service, in the same two layers this PR had independently converged on. The file now documents delivered behaviour rather than having driven it. Worth saying plainly: it is a spec written after the fact, and it is only as good as the tests it is bound to.
- **CI's `evaluate` job is red for reasons unrelated to this PR.** The "Auto-approve for validated Low-Risk or Firefighting" workflow calls OpenAI and the key is returning `insufficient_quota`; it is failing simultaneously on unrelated branches (`worktree-fix+langy-5741-retro`, `issue3439/python-error-surface`). It is **not** one of `main`'s required checks (`validate title`, `typecheck`, `build`), so it does not gate this PR — but it will keep showing red until the billing side is sorted.
- **Two pre-existing formatting violations were left alone.** `biome@2.4.14` (the version `biome.json`'s schema declares; the lockfile installs 2.5.1) flags 3 spots in this test file, all on lines that predate this PR. Only the lines this PR adds were formatted, to keep the diff reviewable.
