### PR TITLE
fix(monitors): stop per-trace evaluations running twice (survivesDispatch dedup)

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -430,10 +430,10 @@ describe("evaluationTrigger reactor", () => {
 
       // The reactor can fire a second time after the command was already
       // dispatched (a late span, then the deferred OriginResolvedEvent). The
-      // dedup key outlives dispatch (6-min TTL), so survivesDispatch must be set
+      // dedup key outlives dispatch (6-min TTL), so shouldSurviveDispatch must be set
       // for that second dispatch to be squashed instead of re-run as a duplicate.
       const [_payload, options] = vi.mocked(deps.evaluation).mock.calls[0]!;
-      expect(options!.deduplication!.survivesDispatch).toBe(true);
+      expect(options!.deduplication!.shouldSurviveDispatch).toBe(true);
     });
   });
 
@@ -465,7 +465,7 @@ describe("evaluationTrigger reactor", () => {
       const [_payload, options] = vi.mocked(deps.evaluation).mock.calls[0]!;
       // delay == threadIdleTimeout * 1000 confirms the thread-level branch was taken.
       expect(options!.delay).toBe(300 * 1000);
-      expect(options!.deduplication!.survivesDispatch).toBe(true);
+      expect(options!.deduplication!.shouldSurviveDispatch).toBe(true);
     });
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import { TRACK_EVENT_SPAN_NAME } from "~/server/tracer/constants";
 import type { ReactorContext } from "../../../../reactors/reactor.types";
+import { MAX_PROCESSED_SPANS } from "../../projections/traceSummary.foldProjection";
 import type { TraceProcessingEvent } from "../../schemas/events";
 import {
   createEvaluationTriggerReactor,
@@ -8,8 +10,6 @@ import {
   type EvaluationTriggerReactorDeps,
 } from "../evaluationTrigger.reactor";
 import { DEFERRED_CHECK_DELAY_MS } from "../originGate.reactor";
-import { TRACK_EVENT_SPAN_NAME } from "~/server/tracer/constants";
-import { MAX_PROCESSED_SPANS } from "../../projections/traceSummary.foldProjection";
 
 function createFoldState(
   overrides: Partial<TraceSummaryData> = {},
@@ -135,7 +135,12 @@ function createDeps(
   return {
     monitors: {
       getEnabledOnMessageMonitors: vi.fn().mockResolvedValue([
-        { id: "mon-1", checkType: "llm/boolean", name: "Test Monitor", evaluator: null },
+        {
+          id: "mon-1",
+          checkType: "llm/boolean",
+          name: "Test Monitor",
+          evaluator: null,
+        },
       ]),
     } as unknown as EvaluationTriggerReactorDeps["monitors"],
     evaluation: vi.fn().mockResolvedValue(undefined),
@@ -175,7 +180,10 @@ describe("detectCausalityLoop (pure)", () => {
   it("accepts depth as a string-valued OTLP attribute", () => {
     const reason = detectCausalityLoop({
       spanAttributes: [
-        { key: "langwatch.reserved.causality_depth", value: { stringValue: "2" } },
+        {
+          key: "langwatch.reserved.causality_depth",
+          value: { stringValue: "2" },
+        },
       ],
     });
     expect(reason).toBe("depth_direct");
@@ -184,7 +192,10 @@ describe("detectCausalityLoop (pure)", () => {
   it("ignores malformed depth values", () => {
     const reason = detectCausalityLoop({
       spanAttributes: [
-        { key: "langwatch.reserved.causality_depth", value: { stringValue: "abc" } },
+        {
+          key: "langwatch.reserved.causality_depth",
+          value: { stringValue: "abc" },
+        },
       ],
     });
     expect(reason).toBeNull();
@@ -212,7 +223,9 @@ describe("evaluationTrigger reactor", () => {
 
       await reactor.handle(createOriginEvent(), createContext(state));
 
-      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
+      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith(
+        "tenant-1",
+      );
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
     });
   });
@@ -307,7 +320,10 @@ describe("evaluationTrigger reactor", () => {
         attributes: { "langwatch.origin": "evaluation" },
       });
 
-      await reactor.handle(createOriginEvent("evaluation"), createContext(state));
+      await reactor.handle(
+        createOriginEvent("evaluation"),
+        createContext(state),
+      );
 
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
     });
@@ -397,7 +413,9 @@ describe("evaluationTrigger reactor", () => {
       const [_payload, options] = vi.mocked(deps.evaluation).mock.calls[0]!;
       expect(options).toBeDefined();
       expect(options!.deduplication).toBeDefined();
-      expect(options!.deduplication!.ttlMs).toBe(DEFERRED_CHECK_DELAY_MS + 60_000);
+      expect(options!.deduplication!.ttlMs).toBe(
+        DEFERRED_CHECK_DELAY_MS + 60_000,
+      );
       expect(options!.delay).toBeUndefined();
     });
 
@@ -415,6 +433,38 @@ describe("evaluationTrigger reactor", () => {
       // dedup key outlives dispatch (6-min TTL), so survivesDispatch must be set
       // for that second dispatch to be squashed instead of re-run as a duplicate.
       const [_payload, options] = vi.mocked(deps.evaluation).mock.calls[0]!;
+      expect(options!.deduplication!.survivesDispatch).toBe(true);
+    });
+  });
+
+  describe("when thread-level eval is dispatched", () => {
+    it("also marks the dedup as surviving dispatch (#3912)", async () => {
+      const deps = createDeps({
+        monitors: {
+          getEnabledOnMessageMonitors: vi.fn().mockResolvedValue([
+            {
+              id: "mon-1",
+              checkType: "llm/boolean",
+              name: "Test Monitor",
+              evaluator: null,
+              threadIdleTimeout: 300,
+            },
+          ]),
+        } as unknown as EvaluationTriggerReactorDeps["monitors"],
+      });
+      const reactor = createEvaluationTriggerReactor(deps);
+      const state = createFoldState({
+        attributes: {
+          "langwatch.origin": "application",
+          "gen_ai.conversation.id": "thread-1",
+        },
+      });
+
+      await reactor.handle(createOriginEvent(), createContext(state));
+
+      const [_payload, options] = vi.mocked(deps.evaluation).mock.calls[0]!;
+      // delay == threadIdleTimeout * 1000 confirms the thread-level branch was taken.
+      expect(options!.delay).toBe(300 * 1000);
       expect(options!.deduplication!.survivesDispatch).toBe(true);
     });
   });
@@ -474,7 +524,9 @@ describe("evaluationTrigger reactor", () => {
 
       await reactor.handle(event, createContext(state));
 
-      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
+      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith(
+        "tenant-1",
+      );
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
     });
   });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -400,6 +400,23 @@ describe("evaluationTrigger reactor", () => {
       expect(options!.deduplication!.ttlMs).toBe(DEFERRED_CHECK_DELAY_MS + 60_000);
       expect(options!.delay).toBeUndefined();
     });
+
+    it("marks the dedup as surviving dispatch so a re-trigger after dispatch is squashed (#3912)", async () => {
+      const deps = createDeps();
+      const reactor = createEvaluationTriggerReactor(deps);
+      const state = createFoldState({
+        attributes: { "langwatch.origin": "application" },
+      });
+
+      await reactor.handle(createOriginEvent(), createContext(state));
+
+      // The reactor can fire a second time after the command was already
+      // dispatched (a late span, then the deferred OriginResolvedEvent). The
+      // dedup key outlives dispatch (6-min TTL), so survivesDispatch must be set
+      // for that second dispatch to be squashed instead of re-run as a duplicate.
+      const [_payload, options] = vi.mocked(deps.evaluation).mock.calls[0]!;
+      expect(options!.deduplication!.survivesDispatch).toBe(true);
+    });
   });
 
   describe("when trace is blocked by guardrail with no output", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -1,21 +1,24 @@
 import { generate } from "@langwatch/ksuid";
-import { evaluatorLoopBlockedCounter } from "../../../../metrics";
 import type { MonitorService } from "~/server/app-layer/monitors/monitor.service";
-import type { QueueSendOptions } from "../../../queues";
-import { ExecuteEvaluationCommand } from "../../evaluation-processing/commands/executeEvaluation.command";
-import type { ExecuteEvaluationCommandData } from "../../evaluation-processing/schemas/commands";
+import { SYNTHETIC_SPAN_NAMES } from "~/server/tracer/constants";
 import { KSUID_RESOURCES } from "../../../../../utils/constants";
 import { createLogger } from "../../../../../utils/logger/server";
+import { featureFlagService } from "../../../../featureFlag";
+import { evaluatorLoopBlockedCounter } from "../../../../metrics";
+import type { QueueSendOptions } from "../../../queues";
 import type { ReactorDefinition } from "../../../reactors/reactor.types";
+import { ExecuteEvaluationCommand } from "../../evaluation-processing/commands/executeEvaluation.command";
+import type { ExecuteEvaluationCommandData } from "../../evaluation-processing/schemas/commands";
 import {
   MAX_PROCESSED_SPANS,
   type TraceSummaryData,
 } from "../projections/traceSummary.foldProjection";
-import { isSpanReceivedEvent, type TraceProcessingEvent } from "../schemas/events";
+import {
+  isSpanReceivedEvent,
+  type TraceProcessingEvent,
+} from "../schemas/events";
 import { defineOriginGuardedTraceReactor } from "./_originGuardedReactor";
-import { SYNTHETIC_SPAN_NAMES } from "~/server/tracer/constants";
 import { DEFERRED_CHECK_DELAY_MS } from "./originGate.reactor";
-import { featureFlagService } from "../../../../featureFlag";
 
 const CAUSALITY_LOOP_GUARD_DISABLED_FLAG =
   "ops_es_causality_loop_guard_disabled";
@@ -26,7 +29,10 @@ const logger = createLogger(
 
 export interface EvaluationTriggerReactorDeps {
   monitors: MonitorService;
-  evaluation: (data: ExecuteEvaluationCommandData, options?: QueueSendOptions<ExecuteEvaluationCommandData>) => Promise<void>;
+  evaluation: (
+    data: ExecuteEvaluationCommandData,
+    options?: QueueSendOptions<ExecuteEvaluationCommandData>,
+  ) => Promise<void>;
 }
 
 /**
@@ -48,7 +54,10 @@ export function createEvaluationTriggerReactor(
       // do not contribute to fold IO and must not re-trigger ON_MESSAGE evaluator runs. We
       // share `SYNTHETIC_SPAN_NAMES` with the trace-summary fold (foldProjection.ts:88) so a
       // future synthetic name updates both sites at once.
-      if (isSpanReceivedEvent(event) && SYNTHETIC_SPAN_NAMES.has(event.data.span.name)) {
+      if (
+        isSpanReceivedEvent(event) &&
+        SYNTHETIC_SPAN_NAMES.has(event.data.span.name)
+      ) {
         return;
       }
       const { tenantId, aggregateId: traceId, foldState } = context;
@@ -259,36 +268,37 @@ async function dispatchEvaluations({
       };
 
       const isThreadLevel =
-        monitor.threadIdleTimeout &&
-        monitor.threadIdleTimeout > 0 &&
-        threadId;
+        monitor.threadIdleTimeout && monitor.threadIdleTimeout > 0 && threadId;
 
-      const sendOptions: QueueSendOptions<ExecuteEvaluationCommandData> | undefined =
-        isThreadLevel
-          ? {
-              delay: monitor.threadIdleTimeout! * 1000,
-              deduplication: {
-                makeId: ExecuteEvaluationCommand.makeJobId,
-                ttlMs: monitor.threadIdleTimeout! * 1000,
-                // Squash a re-trigger that lands after the command was dispatched
-                // (within the TTL) instead of re-running it (#3912).
-                survivesDispatch: true,
-              },
-            }
-          : {
-              deduplication: {
-                makeId: ExecuteEvaluationCommand.makeJobId,
-                // 6 min — outlasts the 5-min deferred origin resolution window
-                // so that if the reactor fires twice (once from a late span,
-                // once from the deferred OriginResolvedEvent), the second
-                // dispatch is squashed by the dedup key.
-                ttlMs: DEFERRED_CHECK_DELAY_MS + 60_000,
-                // Honor the still-alive dedup key even after the first command was
-                // dispatched, so the second trigger is squashed rather than
-                // DEL+restaged into a duplicate evaluation run (#3912).
-                survivesDispatch: true,
-              },
-            };
+      const sendOptions:
+        | QueueSendOptions<ExecuteEvaluationCommandData>
+        | undefined = isThreadLevel
+        ? {
+            delay: monitor.threadIdleTimeout! * 1000,
+            deduplication: {
+              makeId: ExecuteEvaluationCommand.makeJobId,
+              ttlMs: monitor.threadIdleTimeout! * 1000,
+              // Defensive on this branch: the thread dedup TTL roughly equals the
+              // dispatch delay (both = threadIdleTimeout), so the post-dispatch
+              // squash window is ~0. The load-bearing fix is the trace-level
+              // deferred branch below (6-min TTL >> dispatch latency) (#3912).
+              survivesDispatch: true,
+            },
+          }
+        : {
+            deduplication: {
+              makeId: ExecuteEvaluationCommand.makeJobId,
+              // 6 min — outlasts the 5-min deferred origin resolution window
+              // so that if the reactor fires twice (once from a late span,
+              // once from the deferred OriginResolvedEvent), the second
+              // dispatch is squashed by the dedup key.
+              ttlMs: DEFERRED_CHECK_DELAY_MS + 60_000,
+              // Honor the still-alive dedup key even after the first command was
+              // dispatched, so the second trigger is squashed rather than
+              // DEL+restaged into a duplicate evaluation run (#3912).
+              survivesDispatch: true,
+            },
+          };
 
       await deps.evaluation(payload, sendOptions);
     } catch (error) {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -282,7 +282,7 @@ async function dispatchEvaluations({
               // dispatch delay (both = threadIdleTimeout), so the post-dispatch
               // squash window is ~0. The load-bearing fix is the trace-level
               // deferred branch below (6-min TTL >> dispatch latency) (#3912).
-              survivesDispatch: true,
+              shouldSurviveDispatch: true,
             },
           }
         : {
@@ -296,7 +296,7 @@ async function dispatchEvaluations({
               // Honor the still-alive dedup key even after the first command was
               // dispatched, so the second trigger is squashed rather than
               // DEL+restaged into a duplicate evaluation run (#3912).
-              survivesDispatch: true,
+              shouldSurviveDispatch: true,
             },
           };
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -270,6 +270,9 @@ async function dispatchEvaluations({
               deduplication: {
                 makeId: ExecuteEvaluationCommand.makeJobId,
                 ttlMs: monitor.threadIdleTimeout! * 1000,
+                // Squash a re-trigger that lands after the command was dispatched
+                // (within the TTL) instead of re-running it (#3912).
+                survivesDispatch: true,
               },
             }
           : {
@@ -280,6 +283,10 @@ async function dispatchEvaluations({
                 // once from the deferred OriginResolvedEvent), the second
                 // dispatch is squashed by the dedup key.
                 ttlMs: DEFERRED_CHECK_DELAY_MS + 60_000,
+                // Honor the still-alive dedup key even after the first command was
+                // dispatched, so the second trigger is squashed rather than
+                // DEL+restaged into a duplicate evaluation run (#3912).
+                survivesDispatch: true,
               },
             };
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -344,6 +344,51 @@ describe("GroupStagingScripts", () => {
       });
     });
 
+    describe("when survivesDispatch is set and the job was already dispatched", () => {
+      it("squashes the new job instead of re-staging it (no re-run after dispatch)", async () => {
+        // Stage j1 with a dedup key configured to survive dispatch, then dispatch
+        // it so it leaves staging while the dedup key's TTL is still alive.
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dedupId: "survive-1",
+            dedupTtlMs: 60000,
+            dispatchAfterMs: 0,
+            survivesDispatch: true,
+          }),
+        );
+
+        const dispatched = await scripts.dispatch({
+          nowMs: Date.now(),
+          activeTtlSec: 300,
+        });
+        expect(dispatched).not.toBeNull();
+        expect(dispatched!.stagedJobId).toBe("j1");
+        expect(await inspectGroupJobs("group-a")).toEqual([]);
+
+        // A late re-trigger stages the same dedup id AFTER dispatch. With
+        // survivesDispatch the still-alive TTL is HONORED: the new job is squashed
+        // (isNew=false) rather than DEL+restaged as the default TOCTOU path does.
+        const { isNew } = await scripts.stage(
+          makeJob({
+            stagedJobId: "j2",
+            dedupId: "survive-1",
+            dedupTtlMs: 60000,
+            dispatchAfterMs: 5000,
+            survivesDispatch: true,
+          }),
+        );
+
+        expect(isNew).toBe(false);
+        // No new job staged for the group — the duplicate is squashed.
+        expect(await inspectGroupJobs("group-a")).toEqual([]);
+        // The dedup key is preserved (still the dispatched job), not deleted.
+        expect(await inspectDedupKey("survive-1")).toBe("j1");
+        // The originally dispatched job stays active and untouched.
+        expect(await inspectActiveKey("group-a")).toBe("j1");
+      });
+    });
+
     describe("extend/replace flags", () => {
       it("updates score when extend is true", async () => {
         await scripts.stage(
@@ -936,6 +981,60 @@ describe("GroupStagingScripts", () => {
 
         const data = await inspectDataHash("group-a");
         expect(data["j0"]).toBe(JSON.stringify({ from: "j2" }));
+      });
+    });
+
+    describe("when survivesDispatch is set and a batch dedup was already dispatched", () => {
+      it("squashes the dispatched-dedup job instead of staging it as new", async () => {
+        // j0 staged with a survives-dispatch dedup, then dispatched (left staging
+        // while its dedup key TTL is still alive).
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j0",
+            groupId: "group-x",
+            dedupId: "batch-survive",
+            dedupTtlMs: 60000,
+            dispatchAfterMs: 0,
+            survivesDispatch: true,
+          }),
+        );
+        await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: 300 });
+
+        // Batch: j1 re-triggers the same (already-dispatched) dedup with
+        // survivesDispatch, j2 has no dedup. Only j2 is new; j1 is squashed by the
+        // surviving dedup key rather than DEL+restaged as the default race path does.
+        const { newStagedCount, orphanedValues } = await scripts.stageBatch([
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "group-x",
+            dedupId: "batch-survive",
+            dedupTtlMs: 60000,
+            dispatchAfterMs: 5000,
+            survivesDispatch: true,
+            jobDataJson: JSON.stringify({ from: "j1" }),
+          }),
+          makeJob({
+            stagedJobId: "j2",
+            groupId: "group-y",
+            dispatchAfterMs: 1000,
+          }),
+        ]);
+
+        // Only j2 is new; j1 was squashed by the surviving dedup key.
+        expect(newStagedCount).toBe(1);
+        // j1's payload is reported as the orphaned value (index-aligned with the
+        // batch); j2 displaced nothing.
+        expect(orphanedValues).toEqual([JSON.stringify({ from: "j1" }), ""]);
+
+        const jobsX = await inspectGroupJobs("group-x");
+        expect(jobsX).not.toContain("j1");
+        expect(jobsX).not.toContain("j0");
+
+        const jobsY = await inspectGroupJobs("group-y");
+        expect(jobsY).toContain("j2");
+
+        // The dedup key is preserved (still the dispatched job), not deleted.
+        expect(await inspectDedupKey("batch-survive")).toBe("j0");
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -360,7 +360,7 @@ describe("GroupStagingScripts", () => {
       });
     });
 
-    describe("when survivesDispatch is set and the job was already dispatched", () => {
+    describe("when shouldSurviveDispatch is set and the job was already dispatched", () => {
       it("squashes the new job instead of re-staging it (no re-run after dispatch)", async () => {
         // Stage j1 with a dedup key configured to survive dispatch, then dispatch
         // it so it leaves staging while the dedup key's TTL is still alive.
@@ -370,7 +370,7 @@ describe("GroupStagingScripts", () => {
             dedupId: "survive-1",
             dedupTtlMs: 60000,
             dispatchAfterMs: 0,
-            survivesDispatch: true,
+            shouldSurviveDispatch: true,
           }),
         );
 
@@ -383,7 +383,7 @@ describe("GroupStagingScripts", () => {
         expect(await inspectGroupJobs("group-a")).toEqual([]);
 
         // A late re-trigger stages the same dedup id AFTER dispatch. With
-        // survivesDispatch the still-alive TTL is HONORED: the new job is squashed
+        // shouldSurviveDispatch the still-alive TTL is HONORED: the new job is squashed
         // (isNew=false) rather than DEL+restaged as the default TOCTOU path does.
         const { isNew } = await scripts.stage(
           makeJob({
@@ -391,7 +391,7 @@ describe("GroupStagingScripts", () => {
             dedupId: "survive-1",
             dedupTtlMs: 60000,
             dispatchAfterMs: 5000,
-            survivesDispatch: true,
+            shouldSurviveDispatch: true,
           }),
         );
 
@@ -1023,7 +1023,7 @@ describe("GroupStagingScripts", () => {
       });
     });
 
-    describe("when survivesDispatch is set and a batch dedup was already dispatched", () => {
+    describe("when shouldSurviveDispatch is set and a batch dedup was already dispatched", () => {
       it("squashes the dispatched-dedup job instead of staging it as new", async () => {
         // j0 staged with a survives-dispatch dedup, then dispatched (left staging
         // while its dedup key TTL is still alive).
@@ -1034,13 +1034,13 @@ describe("GroupStagingScripts", () => {
             dedupId: "batch-survive",
             dedupTtlMs: 60000,
             dispatchAfterMs: 0,
-            survivesDispatch: true,
+            shouldSurviveDispatch: true,
           }),
         );
         await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: 300 });
 
         // Batch: j1 re-triggers the same (already-dispatched) dedup with
-        // survivesDispatch, j2 has no dedup. Only j2 is new; j1 is squashed by the
+        // shouldSurviveDispatch, j2 has no dedup. Only j2 is new; j1 is squashed by the
         // surviving dedup key rather than DEL+restaged as the default race path does.
         const { newStagedCount, orphanedValues } = await scripts.stageBatch([
           makeJob({
@@ -1049,7 +1049,7 @@ describe("GroupStagingScripts", () => {
             dedupId: "batch-survive",
             dedupTtlMs: 60000,
             dispatchAfterMs: 5000,
-            survivesDispatch: true,
+            shouldSurviveDispatch: true,
             jobDataJson: JSON.stringify({ from: "j1" }),
           }),
           makeJob({
@@ -1074,6 +1074,58 @@ describe("GroupStagingScripts", () => {
 
         // The dedup key is preserved (still the dispatched job), not deleted.
         expect(await inspectDedupKey("batch-survive")).toBe("j0");
+      });
+    });
+
+    describe("when a shouldSurviveDispatch batch squash targets an already-drained group", () => {
+      it("does not resurrect the drained group into the ready set", async () => {
+        // Stage j0 under a survives-dispatch dedup, dispatch it, then COMPLETE it
+        // so the group fully drains: it leaves staging AND the ready set while the
+        // dedup key's TTL is still alive.
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j0",
+            groupId: "group-drain",
+            dedupId: "drained-survive",
+            dedupTtlMs: 60000,
+            dispatchAfterMs: 0,
+            shouldSurviveDispatch: true,
+          }),
+        );
+        await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: 300 });
+        await scripts.complete({ groupId: "group-drain", stagedJobId: "j0" });
+
+        // Precondition: the group is drained — gone from ready and from staging.
+        expect(
+          await redis.zscore(`${keyPrefix()}ready`, "group-drain"),
+        ).toBeNull();
+        expect(await inspectGroupJobs("group-drain")).toEqual([]);
+
+        // A late re-trigger batches ONLY the same (already-dispatched) dedup with
+        // shouldSurviveDispatch. It is squashed (stages no job), so the group must
+        // NOT be re-added to ready — doing so would resurrect a drained, empty
+        // group into the dispatch scan after the loop.
+        const { newStagedCount } = await scripts.stageBatch([
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "group-drain",
+            dedupId: "drained-survive",
+            dedupTtlMs: 60000,
+            dispatchAfterMs: 5000,
+            shouldSurviveDispatch: true,
+          }),
+        ]);
+
+        // The squash staged nothing...
+        expect(newStagedCount).toBe(0);
+        // ...and did NOT resurrect the drained group into ready.
+        expect(
+          await redis.zscore(`${keyPrefix()}ready`, "group-drain"),
+        ).toBeNull();
+        expect(await inspectReadySet()).toEqual([]);
+        // Still drained from staging; the dedup key is preserved, not re-staged.
+        expect(await inspectGroupJobs("group-drain")).toEqual([]);
+        expect(await inspectDedupKey("drained-survive")).toBe("j0");
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1,19 +1,28 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Redis } from "ioredis";
 import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { QueueRedisRepository } from "../../../../app-layer/ops/repositories/queue.redis.repository";
+import {
+  getTestRedisConnection,
   startTestContainers,
   stopTestContainers,
-  getTestRedisConnection,
 } from "../../../__tests__/integration/testContainers";
+import { encodeJobEnvelope } from "../jobEnvelope";
 import {
-  GroupStagingScripts,
+  type DispatchResult,
   GROUP_KEY_TTL_MS,
   GROUP_QUEUE_REGISTRY_KEY,
+  GroupStagingScripts,
   PARK_RECONCILE_MAX_DRAIN,
-  type DispatchResult,
 } from "../scripts";
-import { QueueRedisRepository } from "../../../../app-layer/ops/repositories/queue.redis.repository";
-import { encodeJobEnvelope } from "../jobEnvelope";
 
 let redis: Redis;
 let scripts: GroupStagingScripts;
@@ -88,7 +97,9 @@ describe("GroupStagingScripts", () => {
   describe("stage", () => {
     describe("when staging a new job", () => {
       it("adds job to group sorted set with correct score", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 5000 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 5000 }),
+        );
 
         const jobs = await inspectGroupJobs("group-a");
         expect(jobs).toEqual(["j1", "5000"]);
@@ -96,7 +107,9 @@ describe("GroupStagingScripts", () => {
 
       it("stores payload in data hash", async () => {
         const payload = JSON.stringify({ key: "value" });
-        await scripts.stage(makeJob({ stagedJobId: "j1", jobDataJson: payload }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", jobDataJson: payload }),
+        );
 
         const data = await inspectDataHash("group-a");
         expect(data).toEqual({ j1: payload });
@@ -151,8 +164,8 @@ describe("GroupStagingScripts", () => {
 
           // Data updated to j2's payload, keyed under j1
           const data = await inspectDataHash("group-a");
-          expect(data["j1"]).toBe(JSON.stringify({ version: 2 }));
-          expect(data["j2"]).toBeUndefined();
+          expect(data.j1).toBe(JSON.stringify({ version: 2 }));
+          expect(data.j2).toBeUndefined();
         });
       });
 
@@ -215,8 +228,8 @@ describe("GroupStagingScripts", () => {
         expect(jobs).toEqual(["j1", "2000"]);
 
         const data = await inspectDataHash("group-a");
-        expect(data["j1"]).toBe(JSON.stringify({ version: 2 }));
-        expect(data["j2"]).toBeUndefined();
+        expect(data.j1).toBe(JSON.stringify({ version: 2 }));
+        expect(data.j2).toBeUndefined();
 
         const dedupValue = await inspectDedupKey("squash-1");
         expect(dedupValue).toBe("j1");
@@ -255,7 +268,7 @@ describe("GroupStagingScripts", () => {
         expect(jobs).toEqual(["j1", "3000"]);
 
         const data = await inspectDataHash("group-a");
-        expect(data["j1"]).toBe(JSON.stringify({ v: 3 }));
+        expect(data.j1).toBe(JSON.stringify({ v: 3 }));
 
         const dedupValue = await inspectDedupKey("triple-1");
         expect(dedupValue).toBe("j1");
@@ -273,7 +286,10 @@ describe("GroupStagingScripts", () => {
           }),
         );
 
-        const dispatched = await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: 300 });
+        const dispatched = await scripts.dispatch({
+          nowMs: Date.now(),
+          activeTtlSec: 300,
+        });
         expect(dispatched).not.toBeNull();
         expect(dispatched!.stagedJobId).toBe("j1");
 
@@ -463,7 +479,7 @@ describe("GroupStagingScripts", () => {
         );
 
         const data = await inspectDataHash("group-a");
-        expect(data["j1"]).toBe(JSON.stringify({ original: true }));
+        expect(data.j1).toBe(JSON.stringify({ original: true }));
       });
 
       it("updates data when replace is true", async () => {
@@ -487,7 +503,7 @@ describe("GroupStagingScripts", () => {
         );
 
         const data = await inspectDataHash("group-a");
-        expect(data["j1"]).toBe(JSON.stringify({ v: 2 }));
+        expect(data.j1).toBe(JSON.stringify({ v: 2 }));
       });
 
       it("keeps both score and data unchanged with extend:false + replace:false", async () => {
@@ -521,7 +537,7 @@ describe("GroupStagingScripts", () => {
         expect(jobs).toEqual(["j1", "5000"]);
 
         const data = await inspectDataHash("group-a");
-        expect(data["j1"]).toBe(JSON.stringify({ first: true }));
+        expect(data.j1).toBe(JSON.stringify({ first: true }));
 
         const dedupValue = await inspectDedupKey("both-false");
         expect(dedupValue).toBe("j1");
@@ -555,7 +571,7 @@ describe("GroupStagingScripts", () => {
         expect(jobs).toEqual(["j1", "1000"]);
 
         const data = await inspectDataHash("group-a");
-        expect(data["j1"]).toBe(JSON.stringify({ v: 2 }));
+        expect(data.j1).toBe(JSON.stringify({ v: 2 }));
       });
     });
 
@@ -751,7 +767,10 @@ describe("GroupStagingScripts", () => {
           }),
         );
 
-        const dispatched = await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: 300 });
+        const dispatched = await scripts.dispatch({
+          nowMs: Date.now(),
+          activeTtlSec: 300,
+        });
         expect(dispatched).not.toBeNull();
         expect(dispatched!.stagedJobId).toBe("j1");
         expect(dispatched!.jobDataJson).toBe(JSON.stringify({ v: 2 }));
@@ -780,22 +799,26 @@ describe("GroupStagingScripts", () => {
         );
 
         const data = await inspectDataHash("group-a");
-        expect(data["j2"]).toBeDefined();
-        expect(data["j1"]).toBeUndefined();
+        expect(data.j2).toBeDefined();
+        expect(data.j1).toBeUndefined();
       });
     });
 
     describe("when group is currently active", () => {
       it("does not lower ready score below the active-until window", async () => {
         // Seed an active job and an active-until ready score
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
         const nowMs = 200;
         const activeTtlSec = 60;
         const activeUntil = nowMs + activeTtlSec * 1000;
         await scripts.dispatch({ nowMs, activeTtlSec });
 
         // Stage another job for the same group while it is processing
-        await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 150 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j2", dispatchAfterMs: 150 }),
+        );
 
         // Ready score must remain at activeUntil so dispatch doesn't re-pick the group
         const ready = await inspectReadySet();
@@ -803,10 +826,14 @@ describe("GroupStagingScripts", () => {
       });
 
       it("still stores the new job in the group jobs zset", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
 
-        await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 150 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j2", dispatchAfterMs: 150 }),
+        );
 
         const jobs = await inspectGroupJobs("group-a");
         expect(jobs).toContain("j2");
@@ -815,7 +842,9 @@ describe("GroupStagingScripts", () => {
 
     describe("when group is blocked", () => {
       it("does not re-add a blocked group to the ready set", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
         await scripts.restageAndBlock({
           groupId: "group-a",
@@ -829,7 +858,9 @@ describe("GroupStagingScripts", () => {
         expect(await inspectReadySet()).toEqual([]);
 
         // Stage a new job for the blocked group — should not reinsert it
-        await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 150 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j2", dispatchAfterMs: 150 }),
+        );
 
         expect(await inspectReadySet()).toEqual([]);
       });
@@ -840,8 +871,16 @@ describe("GroupStagingScripts", () => {
     describe("when staging for different groups", () => {
       it("creates entries per group and pushes signal", async () => {
         const jobs = [
-          makeJob({ stagedJobId: "j1", groupId: "group-x", dispatchAfterMs: 100 }),
-          makeJob({ stagedJobId: "j2", groupId: "group-y", dispatchAfterMs: 200 }),
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "group-x",
+            dispatchAfterMs: 100,
+          }),
+          makeJob({
+            stagedJobId: "j2",
+            groupId: "group-y",
+            dispatchAfterMs: 200,
+          }),
         ];
 
         await scripts.stageBatch(jobs);
@@ -980,7 +1019,7 @@ describe("GroupStagingScripts", () => {
         expect(jobs).toContain("j3");
 
         const data = await inspectDataHash("group-a");
-        expect(data["j0"]).toBe(JSON.stringify({ from: "j2" }));
+        expect(data.j0).toBe(JSON.stringify({ from: "j2" }));
       });
     });
 
@@ -1042,8 +1081,12 @@ describe("GroupStagingScripts", () => {
   describe("dispatch", () => {
     describe("when group has eligible jobs", () => {
       it("returns oldest job (lowest score <= nowMs)", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
-        await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
+        await scripts.stage(
+          makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }),
+        );
 
         const result = await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 });
 
@@ -1053,7 +1096,9 @@ describe("GroupStagingScripts", () => {
       });
 
       it("sets active key with TTL", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
 
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
 
@@ -1066,7 +1111,9 @@ describe("GroupStagingScripts", () => {
       });
 
       it("removes job from sorted set", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
 
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
 
@@ -1075,8 +1122,12 @@ describe("GroupStagingScripts", () => {
       });
 
       it("re-scores ready set with future activeUntil after dispatch", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
-        await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
+        await scripts.stage(
+          makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }),
+        );
 
         const nowMs = 300;
         const activeTtlSec = 60;
@@ -1088,7 +1139,9 @@ describe("GroupStagingScripts", () => {
       });
 
       it("keeps group in ready with future activeUntil score after dispatch (no pending left)", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
 
         const nowMs = 200;
         const activeTtlSec = 60;
@@ -1102,7 +1155,11 @@ describe("GroupStagingScripts", () => {
       it("returns jobDataJson from data hash", async () => {
         const payload = JSON.stringify({ test: "data" });
         await scripts.stage(
-          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100, jobDataJson: payload }),
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: payload,
+          }),
         );
 
         const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
@@ -1110,15 +1167,27 @@ describe("GroupStagingScripts", () => {
 
         // Data should be cleaned up
         const data = await inspectDataHash("group-a");
-        expect(data["j1"]).toBeUndefined();
+        expect(data.j1).toBeUndefined();
       });
     });
 
     describe("when group has active key", () => {
       it("skips group, tries next", async () => {
         // Stage jobs in two groups
-        await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "group-a", dispatchAfterMs: 100 }));
-        await scripts.stage(makeJob({ stagedJobId: "j2", groupId: "group-b", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "group-a",
+            dispatchAfterMs: 100,
+          }),
+        );
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j2",
+            groupId: "group-b",
+            dispatchAfterMs: 100,
+          }),
+        );
 
         // Dispatch picks groups by ZRANGEBYSCORE (lowest dispatchAfter first); both groups have the same score.
         const first = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
@@ -1133,7 +1202,9 @@ describe("GroupStagingScripts", () => {
 
     describe("when group is blocked", () => {
       it("skips group", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
 
         // Manually block the group
         await redis.sadd(`${keyPrefix()}blocked`, "group-a");
@@ -1145,7 +1216,9 @@ describe("GroupStagingScripts", () => {
 
     describe("when no jobs eligible (future dispatchAfterMs)", () => {
       it("returns null", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 99999 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 99999 }),
+        );
 
         const result = await scripts.dispatch({ nowMs: 100, activeTtlSec: 60 });
         expect(result).toBeNull();
@@ -1154,7 +1227,10 @@ describe("GroupStagingScripts", () => {
 
     describe("when ready set empty", () => {
       it("returns null", async () => {
-        const result = await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: 60 });
+        const result = await scripts.dispatch({
+          nowMs: Date.now(),
+          activeTtlSec: 60,
+        });
         expect(result).toBeNull();
       });
     });
@@ -1188,10 +1264,17 @@ describe("GroupStagingScripts", () => {
       });
 
       it("recalculates ready score from earliest pending job after completion", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
-        await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
+        await scripts.stage(
+          makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }),
+        );
 
-        const dispatched = (await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 }))!;
+        const dispatched = (await scripts.dispatch({
+          nowMs: 300,
+          activeTtlSec: 60,
+        }))!;
         await scripts.complete({
           groupId: dispatched.groupId,
           stagedJobId: dispatched.stagedJobId,
@@ -1234,7 +1317,9 @@ describe("GroupStagingScripts", () => {
 
         expect(ok).toBe(false);
         // Active key should still have the other job
-        expect(await inspectActiveKey(dispatched.groupId)).toBe("some-other-job");
+        expect(await inspectActiveKey(dispatched.groupId)).toBe(
+          "some-other-job",
+        );
       });
     });
   });
@@ -1242,7 +1327,9 @@ describe("GroupStagingScripts", () => {
   describe("refreshActiveKey", () => {
     describe("when active key matches", () => {
       it("refreshes TTL, returns true", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 10 });
 
         const ok = await scripts.refreshActiveKey({
@@ -1273,7 +1360,9 @@ describe("GroupStagingScripts", () => {
     describe("when group was removed from ready (e.g. after blocking)", () => {
       it("does not re-add the group to the ready set", async () => {
         // Set up: group is processing a job, then gets blocked mid-flight
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
         await scripts.restageAndBlock({
           groupId: "group-a",
@@ -1305,7 +1394,9 @@ describe("GroupStagingScripts", () => {
 
     describe("when active and in ready", () => {
       it("refreshes ready score to nowMs + activeTtlSec*1000", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }),
+        );
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
 
         // ZADD with smaller score to simulate score drift; heartbeat should push it forward.
@@ -1416,10 +1507,18 @@ describe("GroupStagingScripts", () => {
 
     it("2 groups: dispatches in parallel", async () => {
       await scripts.stage(
-        makeJob({ stagedJobId: "a1", groupId: "group-a", dispatchAfterMs: 100 }),
+        makeJob({
+          stagedJobId: "a1",
+          groupId: "group-a",
+          dispatchAfterMs: 100,
+        }),
       );
       await scripts.stage(
-        makeJob({ stagedJobId: "b1", groupId: "group-b", dispatchAfterMs: 100 }),
+        makeJob({
+          stagedJobId: "b1",
+          groupId: "group-b",
+          dispatchAfterMs: 100,
+        }),
       );
 
       const r1 = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
@@ -1437,7 +1536,10 @@ describe("GroupStagingScripts", () => {
     it("blocks group, next dispatch skips it", async () => {
       await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
 
-      const dispatched = (await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 }))!;
+      const dispatched = (await scripts.dispatch({
+        nowMs: 200,
+        activeTtlSec: 60,
+      }))!;
       expect(dispatched.stagedJobId).toBe("j1");
 
       // Simulate exhausted retries — restage and block
@@ -1457,7 +1559,10 @@ describe("GroupStagingScripts", () => {
     it("after manual SREM unblock, group dispatchable again", async () => {
       await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
 
-      const dispatched = (await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 }))!;
+      const dispatched = (await scripts.dispatch({
+        nowMs: 200,
+        activeTtlSec: 60,
+      }))!;
 
       await scripts.restageAndBlock({
         groupId: "group-a",
@@ -1481,484 +1586,501 @@ describe("GroupStagingScripts", () => {
 
   describe("dispatch", () => {
     describe("when head-of-line job is paused", () => {
-    function makePausedJobData(overrides: Record<string, unknown> = {}): string {
-      return JSON.stringify({
-        __pipelineName: "ingestion",
-        __jobType: "projection",
-        __jobName: "traceProjection",
-        hello: "world",
-        ...overrides,
-      });
-    }
-
-    it("skips group whose head job matches a paused pipeline", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: makePausedJobData(),
-        }),
-      );
-      await scripts.addPauseKey("ingestion");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).toBeNull();
-    });
-
-    it("skips group when paused at jobType level", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: makePausedJobData(),
-        }),
-      );
-      await scripts.addPauseKey("ingestion/projection");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).toBeNull();
-    });
-
-    it("skips group when paused at jobType/jobName level", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: makePausedJobData(),
-        }),
-      );
-      await scripts.addPauseKey("ingestion/projection/traceProjection");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).toBeNull();
-    });
-
-    it("dispatches non-paused groups while paused group is skipped", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          groupId: "group-paused",
-          dispatchAfterMs: 100,
-          jobDataJson: makePausedJobData(),
-        }),
-      );
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j2",
-          groupId: "group-ok",
-          dispatchAfterMs: 100,
-          jobDataJson: JSON.stringify({ hello: "world" }),
-        }),
-      );
-      await scripts.addPauseKey("ingestion");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).not.toBeNull();
-      expect(result!.groupId).toBe("group-ok");
-      expect(result!.stagedJobId).toBe("j2");
-    });
-
-    it("does not dequeue paused job (preserves FIFO)", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: makePausedJobData(),
-        }),
-      );
-      await scripts.addPauseKey("ingestion");
-
-      await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-
-      // Job should still be in the group's job queue
-      const jobs = await inspectGroupJobs("group-a");
-      expect(jobs).toContain("j1");
-
-      // No active key should be set
-      const active = await inspectActiveKey("group-a");
-      expect(active).toBeNull();
-
-      // Data hash should still have the job
-      const data = await inspectDataHash("group-a");
-      expect(data["j1"]).toBeDefined();
-    });
-
-    it("resumes dispatch immediately after pause key is removed", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: makePausedJobData(),
-        }),
-      );
-      await scripts.addPauseKey("ingestion");
-
-      const blocked = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(blocked).toBeNull();
-
-      await scripts.removePauseKey("ingestion");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).not.toBeNull();
-      expect(result!.stagedJobId).toBe("j1");
-    });
-
-    it("does not pause when job has no __pipelineName", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: JSON.stringify({ hello: "world" }),
-        }),
-      );
-      await scripts.addPauseKey("ingestion");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).not.toBeNull();
-      expect(result!.stagedJobId).toBe("j1");
-    });
-
-    it("different jobType is not paused", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: makePausedJobData(),
-        }),
-      );
-      await scripts.addPauseKey("ingestion/reactor");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).not.toBeNull();
-      expect(result!.stagedJobId).toBe("j1");
-    });
-  });
-
-  // ADR-026: staged values are GQ1 envelopes whose routing fields live in a
-  // tiny header so the Lua pause-check never decodes the (gzipped) body.
-  describe("when head-of-line job is envelope-encoded", () => {
-    beforeEach(() => {
-      vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
-    });
-
-    afterEach(() => {
-      vi.unstubAllEnvs();
-    });
-
-    async function makeEnvelopeJobData(
-      overrides: Record<string, unknown> = {},
-    ): Promise<string> {
-      // >1 KiB so the body is gzip+base64 — proves Lua reads the header only.
-      return await encodeJobEnvelope({
-        jobData: {
+      function makePausedJobData(
+        overrides: Record<string, unknown> = {},
+      ): string {
+        return JSON.stringify({
           __pipelineName: "ingestion",
           __jobType: "projection",
           __jobName: "traceProjection",
-          bulk: "x".repeat(4096),
+          hello: "world",
           ...overrides,
-        },
-      });
-    }
+        });
+      }
 
-    it("skips group whose envelope header matches a paused pipeline", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: await makeEnvelopeJobData(),
-        }),
-      );
-      await scripts.addPauseKey("ingestion");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).toBeNull();
-    });
-
-    it("skips group when paused at jobType level via the header", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: await makeEnvelopeJobData(),
-        }),
-      );
-      await scripts.addPauseKey("ingestion/projection");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).toBeNull();
-    });
-
-    it("skips group when paused at jobType/jobName level via the header", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: await makeEnvelopeJobData(),
-        }),
-      );
-      await scripts.addPauseKey("ingestion/projection/traceProjection");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).toBeNull();
-    });
-
-    it("dispatches the envelope intact when nothing is paused", async () => {
-      const jobDataJson = await makeEnvelopeJobData();
-      await scripts.stage(
-        makeJob({ stagedJobId: "j1", dispatchAfterMs: 100, jobDataJson }),
-      );
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).not.toBeNull();
-      expect(result!.jobDataJson).toBe(jobDataJson);
-    });
-
-    it("increments the per-job-name failed counter from the envelope header", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          dispatchAfterMs: 100,
-          jobDataJson: await makeEnvelopeJobData(),
-        }),
-      );
-      const dispatched = (await scripts.dispatch({
-        nowMs: 200,
-        activeTtlSec: 60,
-      }))!;
-
-      await scripts.restageAndBlock({
-        groupId: "group-a",
-        newStagedJobId: "j1/r/1",
-        score: 100,
-        jobDataJson: dispatched.jobDataJson,
-      });
-
-      const perJobName = await redis.get(
-        `${keyPrefix()}stats:failed:traceProjection`,
-      );
-      expect(perJobName).toBe("1");
-    });
-  });
-
-  // Tenant-level pause via "tenant:<tenantId>" entries in the same
-  // paused-jobs SET. Added post-2026-05-11 incident — see
-  // specs/queue-pausing/queue-pausing.feature.
-  describe("when head-of-line group's tenant is paused", () => {
-    function makeBenignJobData(overrides: Record<string, unknown> = {}): string {
-      return JSON.stringify({
-        __pipelineName: "ingestion",
-        __jobType: "projection",
-        __jobName: "traceProjection",
-        ...overrides,
-      });
-    }
-
-    /** @scenario Pausing a tenant halts dispatch for that tenant only */
-    it("parks a paused tenant's group OUT of ready (not skip-in-place) and returns null", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          groupId: "project_A/command/recordSpan/trace:xyz",
-          dispatchAfterMs: 100,
-          jobDataJson: makeBenignJobData(),
-        }),
-      );
-      await scripts.addPauseKey("tenant:project_A");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).toBeNull();
-
-      // The group is moved OUT of the ready scan into the tenant's parked set, so a
-      // large paused backlog can never plug the bounded scan and starve other tenants.
-      const ready = await inspectReadySet();
-      expect(ready).not.toContain("project_A/command/recordSpan/trace:xyz");
-      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
-      expect(
-        await redis.sismember(`${keyPrefix()}parked-tenants`, "project_A"),
-      ).toBe(1);
-    });
-
-    /** @scenario A paused tenant's backlog does not block other tenants */
-    it("dispatches another tenant even when a paused tenant fills the front of ready", async () => {
-      // Paused tenant has several due groups at the FRONT of ready (lowest scores).
-      for (let i = 0; i < 5; i++) {
+      it("skips group whose head job matches a paused pipeline", async () => {
         await scripts.stage(
           makeJob({
-            stagedJobId: `bad${i}`,
-            groupId: `project_A/command/recordSpan/trace:${i}`,
-            dispatchAfterMs: 100 + i,
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: makePausedJobData(),
+          }),
+        );
+        await scripts.addPauseKey("ingestion");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).toBeNull();
+      });
+
+      it("skips group when paused at jobType level", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: makePausedJobData(),
+          }),
+        );
+        await scripts.addPauseKey("ingestion/projection");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).toBeNull();
+      });
+
+      it("skips group when paused at jobType/jobName level", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: makePausedJobData(),
+          }),
+        );
+        await scripts.addPauseKey("ingestion/projection/traceProjection");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).toBeNull();
+      });
+
+      it("dispatches non-paused groups while paused group is skipped", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "group-paused",
+            dispatchAfterMs: 100,
+            jobDataJson: makePausedJobData(),
+          }),
+        );
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j2",
+            groupId: "group-ok",
+            dispatchAfterMs: 100,
+            jobDataJson: JSON.stringify({ hello: "world" }),
+          }),
+        );
+        await scripts.addPauseKey("ingestion");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).not.toBeNull();
+        expect(result!.groupId).toBe("group-ok");
+        expect(result!.stagedJobId).toBe("j2");
+      });
+
+      it("does not dequeue paused job (preserves FIFO)", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: makePausedJobData(),
+          }),
+        );
+        await scripts.addPauseKey("ingestion");
+
+        await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+
+        // Job should still be in the group's job queue
+        const jobs = await inspectGroupJobs("group-a");
+        expect(jobs).toContain("j1");
+
+        // No active key should be set
+        const active = await inspectActiveKey("group-a");
+        expect(active).toBeNull();
+
+        // Data hash should still have the job
+        const data = await inspectDataHash("group-a");
+        expect(data.j1).toBeDefined();
+      });
+
+      it("resumes dispatch immediately after pause key is removed", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: makePausedJobData(),
+          }),
+        );
+        await scripts.addPauseKey("ingestion");
+
+        const blocked = await scripts.dispatch({
+          nowMs: 200,
+          activeTtlSec: 60,
+        });
+        expect(blocked).toBeNull();
+
+        await scripts.removePauseKey("ingestion");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).not.toBeNull();
+        expect(result!.stagedJobId).toBe("j1");
+      });
+
+      it("does not pause when job has no __pipelineName", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: JSON.stringify({ hello: "world" }),
+          }),
+        );
+        await scripts.addPauseKey("ingestion");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).not.toBeNull();
+        expect(result!.stagedJobId).toBe("j1");
+      });
+
+      it("different jobType is not paused", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: makePausedJobData(),
+          }),
+        );
+        await scripts.addPauseKey("ingestion/reactor");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).not.toBeNull();
+        expect(result!.stagedJobId).toBe("j1");
+      });
+    });
+
+    // ADR-026: staged values are GQ1 envelopes whose routing fields live in a
+    // tiny header so the Lua pause-check never decodes the (gzipped) body.
+    describe("when head-of-line job is envelope-encoded", () => {
+      beforeEach(() => {
+        vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
+      });
+
+      afterEach(() => {
+        vi.unstubAllEnvs();
+      });
+
+      async function makeEnvelopeJobData(
+        overrides: Record<string, unknown> = {},
+      ): Promise<string> {
+        // >1 KiB so the body is gzip+base64 — proves Lua reads the header only.
+        return await encodeJobEnvelope({
+          jobData: {
+            __pipelineName: "ingestion",
+            __jobType: "projection",
+            __jobName: "traceProjection",
+            bulk: "x".repeat(4096),
+            ...overrides,
+          },
+        });
+      }
+
+      it("skips group whose envelope header matches a paused pipeline", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: await makeEnvelopeJobData(),
+          }),
+        );
+        await scripts.addPauseKey("ingestion");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).toBeNull();
+      });
+
+      it("skips group when paused at jobType level via the header", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: await makeEnvelopeJobData(),
+          }),
+        );
+        await scripts.addPauseKey("ingestion/projection");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).toBeNull();
+      });
+
+      it("skips group when paused at jobType/jobName level via the header", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: await makeEnvelopeJobData(),
+          }),
+        );
+        await scripts.addPauseKey("ingestion/projection/traceProjection");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).toBeNull();
+      });
+
+      it("dispatches the envelope intact when nothing is paused", async () => {
+        const jobDataJson = await makeEnvelopeJobData();
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", dispatchAfterMs: 100, jobDataJson }),
+        );
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).not.toBeNull();
+        expect(result!.jobDataJson).toBe(jobDataJson);
+      });
+
+      it("increments the per-job-name failed counter from the envelope header", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dispatchAfterMs: 100,
+            jobDataJson: await makeEnvelopeJobData(),
+          }),
+        );
+        const dispatched = (await scripts.dispatch({
+          nowMs: 200,
+          activeTtlSec: 60,
+        }))!;
+
+        await scripts.restageAndBlock({
+          groupId: "group-a",
+          newStagedJobId: "j1/r/1",
+          score: 100,
+          jobDataJson: dispatched.jobDataJson,
+        });
+
+        const perJobName = await redis.get(
+          `${keyPrefix()}stats:failed:traceProjection`,
+        );
+        expect(perJobName).toBe("1");
+      });
+    });
+
+    // Tenant-level pause via "tenant:<tenantId>" entries in the same
+    // paused-jobs SET. Added post-2026-05-11 incident — see
+    // specs/queue-pausing/queue-pausing.feature.
+    describe("when head-of-line group's tenant is paused", () => {
+      function makeBenignJobData(
+        overrides: Record<string, unknown> = {},
+      ): string {
+        return JSON.stringify({
+          __pipelineName: "ingestion",
+          __jobType: "projection",
+          __jobName: "traceProjection",
+          ...overrides,
+        });
+      }
+
+      /** @scenario Pausing a tenant halts dispatch for that tenant only */
+      it("parks a paused tenant's group OUT of ready (not skip-in-place) and returns null", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "project_A/command/recordSpan/trace:xyz",
+            dispatchAfterMs: 100,
             jobDataJson: makeBenignJobData(),
           }),
         );
-      }
-      // Another tenant's group is staged later (higher score = behind the paused ones).
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "good",
-          groupId: "project_B/command/recordSpan/trace:b",
-          dispatchAfterMs: 200,
-          jobDataJson: makeBenignJobData(),
-        }),
-      );
-      await scripts.addPauseKey("tenant:project_A");
+        await scripts.addPauseKey("tenant:project_A");
 
-      // Dispatch reaches project_B because project_A's groups are parked OUT of the
-      // scan as it walks past them, rather than re-skipped in place every poll.
-      const result = await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 });
-      expect(result).not.toBeNull();
-      expect(result!.groupId).toBe("project_B/command/recordSpan/trace:b");
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).toBeNull();
 
-      // All 5 paused groups were moved out of ready into parked.
-      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(5);
+        // The group is moved OUT of the ready scan into the tenant's parked set, so a
+        // large paused backlog can never plug the bounded scan and starve other tenants.
+        const ready = await inspectReadySet();
+        expect(ready).not.toContain("project_A/command/recordSpan/trace:xyz");
+        expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
+        expect(
+          await redis.sismember(`${keyPrefix()}parked-tenants`, "project_A"),
+        ).toBe(1);
+      });
+
+      /** @scenario A paused tenant's backlog does not block other tenants */
+      it("dispatches another tenant even when a paused tenant fills the front of ready", async () => {
+        // Paused tenant has several due groups at the FRONT of ready (lowest scores).
+        for (let i = 0; i < 5; i++) {
+          await scripts.stage(
+            makeJob({
+              stagedJobId: `bad${i}`,
+              groupId: `project_A/command/recordSpan/trace:${i}`,
+              dispatchAfterMs: 100 + i,
+              jobDataJson: makeBenignJobData(),
+            }),
+          );
+        }
+        // Another tenant's group is staged later (higher score = behind the paused ones).
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "good",
+            groupId: "project_B/command/recordSpan/trace:b",
+            dispatchAfterMs: 200,
+            jobDataJson: makeBenignJobData(),
+          }),
+        );
+        await scripts.addPauseKey("tenant:project_A");
+
+        // Dispatch reaches project_B because project_A's groups are parked OUT of the
+        // scan as it walks past them, rather than re-skipped in place every poll.
+        const result = await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 });
+        expect(result).not.toBeNull();
+        expect(result!.groupId).toBe("project_B/command/recordSpan/trace:b");
+
+        // All 5 paused groups were moved out of ready into parked.
+        expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(5);
+      });
+
+      /** @scenario A still-paused tenant is not restored by the reconcile */
+      it("keeps groups parked across the reconcile while the tenant stays paused", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "project_A/command/recordSpan/trace:xyz",
+            dispatchAfterMs: 100,
+            jobDataJson: makeBenignJobData(),
+          }),
+        );
+        await scripts.addPauseKey("tenant:project_A");
+
+        // First poll parks it.
+        expect(
+          await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 }),
+        ).toBeNull();
+        expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
+
+        // A later poll runs the reconcile (past the 2s gate), but the tenant is still
+        // paused so unparkUpTo refuses to restore: it stays parked, dispatch null.
+        expect(
+          await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 }),
+        ).toBeNull();
+        expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
+      });
+
+      it("dispatches groups for non-paused tenants while paused tenant is skipped", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j-bad",
+            groupId: "project_A/command/recordSpan/trace:aaa",
+            dispatchAfterMs: 100,
+            jobDataJson: makeBenignJobData(),
+          }),
+        );
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j-ok",
+            groupId: "project_B/command/recordSpan/trace:bbb",
+            dispatchAfterMs: 100,
+            jobDataJson: makeBenignJobData(),
+          }),
+        );
+        await scripts.addPauseKey("tenant:project_A");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).not.toBeNull();
+        expect(result!.groupId).toBe("project_B/command/recordSpan/trace:bbb");
+        expect(result!.stagedJobId).toBe("j-ok");
+      });
+
+      /** @scenario Unpausing a tenant resumes dispatch immediately */
+      it("restores the parked group and resumes dispatch after the tenant pause key is removed", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "project_A/command/recordSpan/trace:xyz",
+            dispatchAfterMs: 100,
+            jobDataJson: makeBenignJobData(),
+          }),
+        );
+        await scripts.addPauseKey("tenant:project_A");
+
+        const blocked = await scripts.dispatch({
+          nowMs: 200,
+          activeTtlSec: 60,
+        });
+        expect(blocked).toBeNull();
+        // Parked out of the ready scan while paused.
+        expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
+
+        await scripts.removePauseKey("tenant:project_A");
+
+        // Unpausing restores the parked group via the dispatch reconcile (time-gated
+        // ~2s): advance the clock past the gate so the next poll reconciles the
+        // now-unpaused tenant back into ready and dispatches it in the same call.
+        const result = await scripts.dispatch({
+          nowMs: 2300,
+          activeTtlSec: 60,
+        });
+        expect(result).not.toBeNull();
+        expect(result!.stagedJobId).toBe("j1");
+        expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(0);
+      });
+
+      it("does not pause an unrelated tenant whose id is a prefix of the paused one", async () => {
+        // SISMEMBER on the full string "tenant:project_A" must NOT match
+        // a group for tenantId "project_AA". This guards against accidental
+        // prefix-substring matches in the Lua extraction.
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "project_AA/command/recordSpan/trace:xyz",
+            dispatchAfterMs: 100,
+            jobDataJson: makeBenignJobData(),
+          }),
+        );
+        await scripts.addPauseKey("tenant:project_A");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).not.toBeNull();
+        expect(result!.stagedJobId).toBe("j1");
+      });
+
+      it("tenant pause works alongside pipeline pause without interference", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "project_A/command/recordSpan/trace:xyz",
+            dispatchAfterMs: 100,
+            jobDataJson: makeBenignJobData(),
+          }),
+        );
+        // Pause BOTH the tenant AND a pipeline; the group should remain blocked
+        // even if one of the pauses is later removed.
+        await scripts.addPauseKey("tenant:project_A");
+        await scripts.addPauseKey("ingestion");
+
+        let result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).toBeNull();
+
+        // Remove pipeline pause — tenant pause still blocks
+        await scripts.removePauseKey("ingestion");
+        result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).toBeNull();
+
+        // Remove tenant pause — the tenant-paused group was parked out of the scan,
+        // so resumption is via the dispatch reconcile (time-gated ~2s): advance the
+        // clock past the gate so the next poll restores and dispatches it.
+        await scripts.removePauseKey("tenant:project_A");
+        result = await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 });
+        expect(result).not.toBeNull();
+        expect(result!.stagedJobId).toBe("j1");
+      });
+
+      it("parks a paused single-segment groupId (whole id is the tenant)", async () => {
+        // Defensive: a groupId without "/" means the whole string is the tenant.
+        // This shouldn't happen in production but the Lua must not error, and a
+        // paused single-segment tenant must still be parked out of the scan (via
+        // parkTenantOf), not left to skip-in-place.
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "single_segment_group",
+            dispatchAfterMs: 100,
+            jobDataJson: makeBenignJobData(),
+          }),
+        );
+        await scripts.addPauseKey("tenant:single_segment_group");
+
+        const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(result).toBeNull();
+        expect(
+          await redis.zcard(`${keyPrefix()}parked:single_segment_group`),
+        ).toBe(1);
+      });
     });
-
-    /** @scenario A still-paused tenant is not restored by the reconcile */
-    it("keeps groups parked across the reconcile while the tenant stays paused", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          groupId: "project_A/command/recordSpan/trace:xyz",
-          dispatchAfterMs: 100,
-          jobDataJson: makeBenignJobData(),
-        }),
-      );
-      await scripts.addPauseKey("tenant:project_A");
-
-      // First poll parks it.
-      expect(await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 })).toBeNull();
-      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
-
-      // A later poll runs the reconcile (past the 2s gate), but the tenant is still
-      // paused so unparkUpTo refuses to restore: it stays parked, dispatch null.
-      expect(await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 })).toBeNull();
-      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
-    });
-
-    it("dispatches groups for non-paused tenants while paused tenant is skipped", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j-bad",
-          groupId: "project_A/command/recordSpan/trace:aaa",
-          dispatchAfterMs: 100,
-          jobDataJson: makeBenignJobData(),
-        }),
-      );
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j-ok",
-          groupId: "project_B/command/recordSpan/trace:bbb",
-          dispatchAfterMs: 100,
-          jobDataJson: makeBenignJobData(),
-        }),
-      );
-      await scripts.addPauseKey("tenant:project_A");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).not.toBeNull();
-      expect(result!.groupId).toBe("project_B/command/recordSpan/trace:bbb");
-      expect(result!.stagedJobId).toBe("j-ok");
-    });
-
-    /** @scenario Unpausing a tenant resumes dispatch immediately */
-    it("restores the parked group and resumes dispatch after the tenant pause key is removed", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          groupId: "project_A/command/recordSpan/trace:xyz",
-          dispatchAfterMs: 100,
-          jobDataJson: makeBenignJobData(),
-        }),
-      );
-      await scripts.addPauseKey("tenant:project_A");
-
-      const blocked = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(blocked).toBeNull();
-      // Parked out of the ready scan while paused.
-      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
-
-      await scripts.removePauseKey("tenant:project_A");
-
-      // Unpausing restores the parked group via the dispatch reconcile (time-gated
-      // ~2s): advance the clock past the gate so the next poll reconciles the
-      // now-unpaused tenant back into ready and dispatches it in the same call.
-      const result = await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 });
-      expect(result).not.toBeNull();
-      expect(result!.stagedJobId).toBe("j1");
-      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(0);
-    });
-
-    it("does not pause an unrelated tenant whose id is a prefix of the paused one", async () => {
-      // SISMEMBER on the full string "tenant:project_A" must NOT match
-      // a group for tenantId "project_AA". This guards against accidental
-      // prefix-substring matches in the Lua extraction.
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          groupId: "project_AA/command/recordSpan/trace:xyz",
-          dispatchAfterMs: 100,
-          jobDataJson: makeBenignJobData(),
-        }),
-      );
-      await scripts.addPauseKey("tenant:project_A");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).not.toBeNull();
-      expect(result!.stagedJobId).toBe("j1");
-    });
-
-    it("tenant pause works alongside pipeline pause without interference", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          groupId: "project_A/command/recordSpan/trace:xyz",
-          dispatchAfterMs: 100,
-          jobDataJson: makeBenignJobData(),
-        }),
-      );
-      // Pause BOTH the tenant AND a pipeline; the group should remain blocked
-      // even if one of the pauses is later removed.
-      await scripts.addPauseKey("tenant:project_A");
-      await scripts.addPauseKey("ingestion");
-
-      let result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).toBeNull();
-
-      // Remove pipeline pause — tenant pause still blocks
-      await scripts.removePauseKey("ingestion");
-      result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).toBeNull();
-
-      // Remove tenant pause — the tenant-paused group was parked out of the scan,
-      // so resumption is via the dispatch reconcile (time-gated ~2s): advance the
-      // clock past the gate so the next poll restores and dispatches it.
-      await scripts.removePauseKey("tenant:project_A");
-      result = await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 });
-      expect(result).not.toBeNull();
-      expect(result!.stagedJobId).toBe("j1");
-    });
-
-    it("parks a paused single-segment groupId (whole id is the tenant)", async () => {
-      // Defensive: a groupId without "/" means the whole string is the tenant.
-      // This shouldn't happen in production but the Lua must not error, and a
-      // paused single-segment tenant must still be parked out of the scan (via
-      // parkTenantOf), not left to skip-in-place.
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          groupId: "single_segment_group",
-          dispatchAfterMs: 100,
-          jobDataJson: makeBenignJobData(),
-        }),
-      );
-      await scripts.addPauseKey("tenant:single_segment_group");
-
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-      expect(result).toBeNull();
-      expect(
-        await redis.zcard(`${keyPrefix()}parked:single_segment_group`),
-      ).toBe(1);
-    });
-  });
   });
 
   describe("dispatchBatch", () => {
@@ -2009,10 +2131,18 @@ describe("GroupStagingScripts", () => {
       it("does not dispatch from the same group twice in one call", async () => {
         // Stage two jobs in the same group
         await scripts.stage(
-          makeJob({ stagedJobId: "j1", groupId: "group-a", dispatchAfterMs: 100 }),
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "group-a",
+            dispatchAfterMs: 100,
+          }),
         );
         await scripts.stage(
-          makeJob({ stagedJobId: "j2", groupId: "group-a", dispatchAfterMs: 200 }),
+          makeJob({
+            stagedJobId: "j2",
+            groupId: "group-a",
+            dispatchAfterMs: 200,
+          }),
         );
 
         // dispatchBatch should only dispatch j1 (per-group FIFO: active key blocks j2)
@@ -2028,266 +2158,270 @@ describe("GroupStagingScripts", () => {
     });
 
     describe("when paused jobs exist", () => {
-    it("skips paused groups and returns only non-paused", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          groupId: "group-paused",
-          dispatchAfterMs: 100,
-          jobDataJson: JSON.stringify({
-            __pipelineName: "ingestion",
-            __jobType: "projection",
-            hello: "world",
-          }),
-        }),
-      );
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j2",
-          groupId: "group-ok",
-          dispatchAfterMs: 100,
-          jobDataJson: JSON.stringify({ hello: "world" }),
-        }),
-      );
-      await scripts.addPauseKey("ingestion");
-
-      const results = await scripts.dispatchBatch({
-        nowMs: 200,
-        activeTtlSec: 60,
-        maxJobs: 10,
-      });
-
-      expect(results).toHaveLength(1);
-      expect(results[0]!.groupId).toBe("group-ok");
-      expect(results[0]!.stagedJobId).toBe("j2");
-
-      // Paused job should still be in its queue
-      const jobs = await inspectGroupJobs("group-paused");
-      expect(jobs).toContain("j1");
-    });
-
-    // Mirror of dispatch() tenant-pause coverage. dispatchBatch shares the
-    // same pause-check Lua block but iterates multiple jobs per call, so a
-    // separate test guards against the second branch drifting from the first.
-    it("skips groups whose tenantId is paused and returns only other tenants", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j-bad",
-          groupId: "project_A/command/recordSpan/trace:a",
-          dispatchAfterMs: 100,
-          jobDataJson: JSON.stringify({}),
-        }),
-      );
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j-ok",
-          groupId: "project_B/command/recordSpan/trace:b",
-          dispatchAfterMs: 100,
-          jobDataJson: JSON.stringify({}),
-        }),
-      );
-      await scripts.addPauseKey("tenant:project_A");
-
-      const results = await scripts.dispatchBatch({
-        nowMs: 200,
-        activeTtlSec: 60,
-        maxJobs: 10,
-      });
-
-      expect(results).toHaveLength(1);
-      expect(results[0]!.groupId).toBe("project_B/command/recordSpan/trace:b");
-    });
-
-    it("a non-paused tenant whose id is a prefix of a paused one still dispatches", async () => {
-      await scripts.stage(
-        makeJob({
-          stagedJobId: "j1",
-          groupId: "project_AA/command/recordSpan/trace:x",
-          dispatchAfterMs: 100,
-          jobDataJson: JSON.stringify({}),
-        }),
-      );
-      await scripts.addPauseKey("tenant:project_A");
-
-      const results = await scripts.dispatchBatch({
-        nowMs: 200,
-        activeTtlSec: 60,
-        maxJobs: 10,
-      });
-
-      expect(results).toHaveLength(1);
-      expect(results[0]!.stagedJobId).toBe("j1");
-    });
-
-    // Parity with specs/event-sourcing/tenant-soft-cap.feature
-    // @integration @tenant-cap @batch scenarios
-    describe("when tenant cap interacts with dispatchBatch", () => {
-      const TENANT_CAP_ENV = "LANGWATCH_DISPATCH_TENANT_CAP";
-      let originalEnv: string | undefined;
-
-      beforeEach(() => {
-        originalEnv = process.env[TENANT_CAP_ENV];
-      });
-
-      afterEach(() => {
-        if (originalEnv === undefined) {
-          delete process.env[TENANT_CAP_ENV];
-        } else {
-          process.env[TENANT_CAP_ENV] = originalEnv;
-        }
-      });
-
-      /** @scenario DISPATCH_BATCH skips over-cap groups and dispatches under-cap groups in one call */
-      it("over-cap tenant groups are skipped, under-cap tenant groups dispatch", async () => {
-        process.env[TENANT_CAP_ENV] = "1";
-
-        for (let i = 0; i < 5; i++) {
-          await scripts.stage(
-            makeJob({
-              stagedJobId: `noisy-j${i}`,
-              groupId: `proj_noisy/g${i}`,
-              dispatchAfterMs: 1000,
-            }),
-          );
-        }
-        await scripts.stage(
-          makeJob({
-            stagedJobId: "quiet-j1",
-            groupId: "proj_quiet/g1",
-            dispatchAfterMs: 1001,
-          }),
-        );
-
-        const results = await scripts.dispatchBatch({
-          nowMs: 2000,
-          activeTtlSec: 60,
-          maxJobs: 10,
-        });
-
-        const dispatched = results.map((r) => r.groupId);
-        expect(dispatched).toContain("proj_noisy/g0");
-        expect(dispatched).toContain("proj_quiet/g1");
-        expect(dispatched).toHaveLength(2);
-      });
-
-      /** @scenario Over-cap tenant with a blocked group does not affect other tenants */
-      it("over-cap tenant blocked group is skipped without SISMEMBER affecting dispatch", async () => {
-        process.env[TENANT_CAP_ENV] = "2";
-
+      it("skips paused groups and returns only non-paused", async () => {
         await scripts.stage(
           makeJob({
             stagedJobId: "j1",
-            groupId: "proj_noisy/g1",
-            dispatchAfterMs: 1000,
+            groupId: "group-paused",
+            dispatchAfterMs: 100,
+            jobDataJson: JSON.stringify({
+              __pipelineName: "ingestion",
+              __jobType: "projection",
+              hello: "world",
+            }),
           }),
         );
         await scripts.stage(
           makeJob({
             stagedJobId: "j2",
-            groupId: "proj_noisy/g2",
-            dispatchAfterMs: 1000,
+            groupId: "group-ok",
+            dispatchAfterMs: 100,
+            jobDataJson: JSON.stringify({ hello: "world" }),
           }),
         );
-        await scripts.stage(
-          makeJob({
-            stagedJobId: "j3",
-            groupId: "proj_noisy/g3",
-            dispatchAfterMs: 1000,
-          }),
-        );
-        await scripts.stage(
-          makeJob({
-            stagedJobId: "quiet-j1",
-            groupId: "proj_quiet/g1",
-            dispatchAfterMs: 1001,
-          }),
-        );
+        await scripts.addPauseKey("ingestion");
 
-        const first = await scripts.dispatchBatch({
-          nowMs: 2000,
-          activeTtlSec: 60,
-          maxJobs: 10,
-        });
-        expect(first.map((r) => r.groupId)).toContain("proj_noisy/g1");
-        expect(first.map((r) => r.groupId)).toContain("proj_noisy/g2");
-        expect(first.map((r) => r.groupId)).not.toContain("proj_noisy/g3");
-        expect(first.map((r) => r.groupId)).toContain("proj_quiet/g1");
-
-        // restageAndBlock frees g1's slot (counter 2→1). g2 still active
-        // so proj_noisy counter = 1. Complete proj_quiet/g1 so it frees
-        // its slot (counter 0). Now lower cap to 1: proj_noisy (counter=1)
-        // is at cap, proj_quiet (counter=0) is under cap.
-        await scripts.restageAndBlock({
-          groupId: "proj_noisy/g1",
-          newStagedJobId: "j1-retry",
-          score: 5000,
-          jobDataJson: first.find((r) => r.groupId === "proj_noisy/g1")!.jobDataJson,
-          errorMessage: "test",
-        });
-        await scripts.complete({
-          groupId: "proj_quiet/g1",
-          stagedJobId: first.find((r) => r.groupId === "proj_quiet/g1")!.stagedJobId,
-        });
-        process.env[TENANT_CAP_ENV] = "1";
-
-        await scripts.stage(
-          makeJob({
-            stagedJobId: "quiet-j2",
-            groupId: "proj_quiet/g2",
-            dispatchAfterMs: 3001,
-          }),
-        );
-
-        const second = await scripts.dispatchBatch({
-          nowMs: 4000,
+        const results = await scripts.dispatchBatch({
+          nowMs: 200,
           activeTtlSec: 60,
           maxJobs: 10,
         });
 
-        expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g1");
-        expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g3");
-        expect(second.map((r) => r.groupId)).toContain("proj_quiet/g2");
+        expect(results).toHaveLength(1);
+        expect(results[0]!.groupId).toBe("group-ok");
+        expect(results[0]!.stagedJobId).toBe("j2");
+
+        // Paused job should still be in its queue
+        const jobs = await inspectGroupJobs("group-paused");
+        expect(jobs).toContain("j1");
       });
 
-      /** @scenario Drift cleanup runs for under-cap tenants in batch dispatch */
-      it("drift cleanup still runs for under-cap tenants with empty job ZSETs", async () => {
-        process.env[TENANT_CAP_ENV] = "10";
+      // Mirror of dispatch() tenant-pause coverage. dispatchBatch shares the
+      // same pause-check Lua block but iterates multiple jobs per call, so a
+      // separate test guards against the second branch drifting from the first.
+      it("skips groups whose tenantId is paused and returns only other tenants", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j-bad",
+            groupId: "project_A/command/recordSpan/trace:a",
+            dispatchAfterMs: 100,
+            jobDataJson: JSON.stringify({}),
+          }),
+        );
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j-ok",
+            groupId: "project_B/command/recordSpan/trace:b",
+            dispatchAfterMs: 100,
+            jobDataJson: JSON.stringify({}),
+          }),
+        );
+        await scripts.addPauseKey("tenant:project_A");
 
+        const results = await scripts.dispatchBatch({
+          nowMs: 200,
+          activeTtlSec: 60,
+          maxJobs: 10,
+        });
+
+        expect(results).toHaveLength(1);
+        expect(results[0]!.groupId).toBe(
+          "project_B/command/recordSpan/trace:b",
+        );
+      });
+
+      it("a non-paused tenant whose id is a prefix of a paused one still dispatches", async () => {
         await scripts.stage(
           makeJob({
             stagedJobId: "j1",
-            groupId: "proj_acme/g1",
-            dispatchAfterMs: 1000,
+            groupId: "project_AA/command/recordSpan/trace:x",
+            dispatchAfterMs: 100,
+            jobDataJson: JSON.stringify({}),
           }),
         );
+        await scripts.addPauseKey("tenant:project_A");
 
-        const batch1 = await scripts.dispatchBatch({
-          nowMs: 2000,
-          activeTtlSec: 60,
-          maxJobs: 10,
-        });
-        expect(batch1).toHaveLength(1);
-
-        await scripts.complete({
-          groupId: "proj_acme/g1",
-          stagedJobId: batch1[0]!.stagedJobId,
-        });
-
-        await redis.zadd(`${keyPrefix()}ready`, 2500, "proj_acme/g-zombie");
-        const readyBefore = await inspectReadySet();
-        expect(readyBefore).toContain("proj_acme/g-zombie");
-
-        await scripts.dispatchBatch({
-          nowMs: 3000,
+        const results = await scripts.dispatchBatch({
+          nowMs: 200,
           activeTtlSec: 60,
           maxJobs: 10,
         });
 
-        const readyAfter = await inspectReadySet();
-        expect(readyAfter).not.toContain("proj_acme/g-zombie");
+        expect(results).toHaveLength(1);
+        expect(results[0]!.stagedJobId).toBe("j1");
+      });
+
+      // Parity with specs/event-sourcing/tenant-soft-cap.feature
+      // @integration @tenant-cap @batch scenarios
+      describe("when tenant cap interacts with dispatchBatch", () => {
+        const TENANT_CAP_ENV = "LANGWATCH_DISPATCH_TENANT_CAP";
+        let originalEnv: string | undefined;
+
+        beforeEach(() => {
+          originalEnv = process.env[TENANT_CAP_ENV];
+        });
+
+        afterEach(() => {
+          if (originalEnv === undefined) {
+            delete process.env[TENANT_CAP_ENV];
+          } else {
+            process.env[TENANT_CAP_ENV] = originalEnv;
+          }
+        });
+
+        /** @scenario DISPATCH_BATCH skips over-cap groups and dispatches under-cap groups in one call */
+        it("over-cap tenant groups are skipped, under-cap tenant groups dispatch", async () => {
+          process.env[TENANT_CAP_ENV] = "1";
+
+          for (let i = 0; i < 5; i++) {
+            await scripts.stage(
+              makeJob({
+                stagedJobId: `noisy-j${i}`,
+                groupId: `proj_noisy/g${i}`,
+                dispatchAfterMs: 1000,
+              }),
+            );
+          }
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "quiet-j1",
+              groupId: "proj_quiet/g1",
+              dispatchAfterMs: 1001,
+            }),
+          );
+
+          const results = await scripts.dispatchBatch({
+            nowMs: 2000,
+            activeTtlSec: 60,
+            maxJobs: 10,
+          });
+
+          const dispatched = results.map((r) => r.groupId);
+          expect(dispatched).toContain("proj_noisy/g0");
+          expect(dispatched).toContain("proj_quiet/g1");
+          expect(dispatched).toHaveLength(2);
+        });
+
+        /** @scenario Over-cap tenant with a blocked group does not affect other tenants */
+        it("over-cap tenant blocked group is skipped without SISMEMBER affecting dispatch", async () => {
+          process.env[TENANT_CAP_ENV] = "2";
+
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              groupId: "proj_noisy/g1",
+              dispatchAfterMs: 1000,
+            }),
+          );
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j2",
+              groupId: "proj_noisy/g2",
+              dispatchAfterMs: 1000,
+            }),
+          );
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j3",
+              groupId: "proj_noisy/g3",
+              dispatchAfterMs: 1000,
+            }),
+          );
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "quiet-j1",
+              groupId: "proj_quiet/g1",
+              dispatchAfterMs: 1001,
+            }),
+          );
+
+          const first = await scripts.dispatchBatch({
+            nowMs: 2000,
+            activeTtlSec: 60,
+            maxJobs: 10,
+          });
+          expect(first.map((r) => r.groupId)).toContain("proj_noisy/g1");
+          expect(first.map((r) => r.groupId)).toContain("proj_noisy/g2");
+          expect(first.map((r) => r.groupId)).not.toContain("proj_noisy/g3");
+          expect(first.map((r) => r.groupId)).toContain("proj_quiet/g1");
+
+          // restageAndBlock frees g1's slot (counter 2→1). g2 still active
+          // so proj_noisy counter = 1. Complete proj_quiet/g1 so it frees
+          // its slot (counter 0). Now lower cap to 1: proj_noisy (counter=1)
+          // is at cap, proj_quiet (counter=0) is under cap.
+          await scripts.restageAndBlock({
+            groupId: "proj_noisy/g1",
+            newStagedJobId: "j1-retry",
+            score: 5000,
+            jobDataJson: first.find((r) => r.groupId === "proj_noisy/g1")!
+              .jobDataJson,
+            errorMessage: "test",
+          });
+          await scripts.complete({
+            groupId: "proj_quiet/g1",
+            stagedJobId: first.find((r) => r.groupId === "proj_quiet/g1")!
+              .stagedJobId,
+          });
+          process.env[TENANT_CAP_ENV] = "1";
+
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "quiet-j2",
+              groupId: "proj_quiet/g2",
+              dispatchAfterMs: 3001,
+            }),
+          );
+
+          const second = await scripts.dispatchBatch({
+            nowMs: 4000,
+            activeTtlSec: 60,
+            maxJobs: 10,
+          });
+
+          expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g1");
+          expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g3");
+          expect(second.map((r) => r.groupId)).toContain("proj_quiet/g2");
+        });
+
+        /** @scenario Drift cleanup runs for under-cap tenants in batch dispatch */
+        it("drift cleanup still runs for under-cap tenants with empty job ZSETs", async () => {
+          process.env[TENANT_CAP_ENV] = "10";
+
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              groupId: "proj_acme/g1",
+              dispatchAfterMs: 1000,
+            }),
+          );
+
+          const batch1 = await scripts.dispatchBatch({
+            nowMs: 2000,
+            activeTtlSec: 60,
+            maxJobs: 10,
+          });
+          expect(batch1).toHaveLength(1);
+
+          await scripts.complete({
+            groupId: "proj_acme/g1",
+            stagedJobId: batch1[0]!.stagedJobId,
+          });
+
+          await redis.zadd(`${keyPrefix()}ready`, 2500, "proj_acme/g-zombie");
+          const readyBefore = await inspectReadySet();
+          expect(readyBefore).toContain("proj_acme/g-zombie");
+
+          await scripts.dispatchBatch({
+            nowMs: 3000,
+            activeTtlSec: 60,
+            maxJobs: 10,
+          });
+
+          const readyAfter = await inspectReadySet();
+          expect(readyAfter).not.toContain("proj_acme/g-zombie");
+        });
       });
     });
-  });
   });
 
   // ============================================================================
@@ -2309,9 +2443,15 @@ describe("GroupStagingScripts", () => {
     describe("when the happy path completes normally", () => {
       /** @scenario Counter tracks jobs in :jobs ZSETs through happy path */
       it("total-pending returns to 0 after stage → dispatch → complete", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g1", dispatchAfterMs: 100 }));
-        await scripts.stage(makeJob({ stagedJobId: "j2", groupId: "g2", dispatchAfterMs: 100 }));
-        await scripts.stage(makeJob({ stagedJobId: "j3", groupId: "g3", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", groupId: "g1", dispatchAfterMs: 100 }),
+        );
+        await scripts.stage(
+          makeJob({ stagedJobId: "j2", groupId: "g2", dispatchAfterMs: 100 }),
+        );
+        await scripts.stage(
+          makeJob({ stagedJobId: "j3", groupId: "g3", dispatchAfterMs: 100 }),
+        );
 
         expect(await inspectTotalPending()).toBe(3);
 
@@ -2319,9 +2459,18 @@ describe("GroupStagingScripts", () => {
         const d2 = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
         const d3 = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
 
-        await scripts.complete({ groupId: d1!.groupId, stagedJobId: d1!.stagedJobId });
-        await scripts.complete({ groupId: d2!.groupId, stagedJobId: d2!.stagedJobId });
-        await scripts.complete({ groupId: d3!.groupId, stagedJobId: d3!.stagedJobId });
+        await scripts.complete({
+          groupId: d1!.groupId,
+          stagedJobId: d1!.stagedJobId,
+        });
+        await scripts.complete({
+          groupId: d2!.groupId,
+          stagedJobId: d2!.stagedJobId,
+        });
+        await scripts.complete({
+          groupId: d3!.groupId,
+          stagedJobId: d3!.stagedJobId,
+        });
 
         expect(await inspectTotalPending()).toBe(0);
       });
@@ -2330,7 +2479,13 @@ describe("GroupStagingScripts", () => {
     describe("when active key expires before COMPLETE", () => {
       /** @scenario Counter stays accurate when activeKey expires before COMPLETE */
       it("counter stays accurate — DECR happened at dispatch, not complete", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-leak", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "g-leak",
+            dispatchAfterMs: 100,
+          }),
+        );
         expect(await inspectTotalPending()).toBe(1);
 
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
@@ -2340,7 +2495,10 @@ describe("GroupStagingScripts", () => {
         // Simulate active key expiry (Redis TTL fires or saturation delays heartbeat)
         await redis.del(`${keyPrefix()}group:g-leak:active`);
 
-        const completed = await scripts.complete({ groupId: "g-leak", stagedJobId: "j1" });
+        const completed = await scripts.complete({
+          groupId: "g-leak",
+          stagedJobId: "j1",
+        });
         expect(completed).toBe(false);
 
         // FIX: counter is 0 — DECR already happened at dispatch time.
@@ -2354,7 +2512,13 @@ describe("GroupStagingScripts", () => {
     describe("when a job is retried via retryRestage", () => {
       /** @scenario Counter tracks retry restage as a new pending job */
       it("total-pending returns to 0 after stage → dispatch → retryRestage → dispatch → complete", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-retry", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "g-retry",
+            dispatchAfterMs: 100,
+          }),
+        );
         expect(await inspectTotalPending()).toBe(1);
 
         const d1 = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
@@ -2389,7 +2553,13 @@ describe("GroupStagingScripts", () => {
     describe("when a job exhausts retries via restageAndBlock", () => {
       /** @scenario Counter tracks restage-and-block as a new pending job */
       it("total-pending returns to 0 after stage → dispatch → restageAndBlock → unblock → dispatch → complete", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-block", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "g-block",
+            dispatchAfterMs: 100,
+          }),
+        );
         expect(await inspectTotalPending()).toBe(1);
 
         const d1 = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
@@ -2407,7 +2577,10 @@ describe("GroupStagingScripts", () => {
         expect(await inspectTotalPending()).toBe(1);
 
         // Operator unblocks the group via UNBLOCK_LUA
-        const { wasBlocked } = await repo.unblockGroup({ queueName: QUEUE_NAME, groupId: "g-block" });
+        const { wasBlocked } = await repo.unblockGroup({
+          queueName: QUEUE_NAME,
+          groupId: "g-block",
+        });
         expect(wasBlocked).toBe(true);
 
         // Dispatch the restaged job
@@ -2416,7 +2589,10 @@ describe("GroupStagingScripts", () => {
         expect(d2!.stagedJobId).toBe("j1/r/final");
 
         // Job succeeds this time
-        await scripts.complete({ groupId: "g-block", stagedJobId: "j1/r/final" });
+        await scripts.complete({
+          groupId: "g-block",
+          stagedJobId: "j1/r/final",
+        });
 
         expect(await inspectTotalPending()).toBe(0);
       });
@@ -2424,7 +2600,13 @@ describe("GroupStagingScripts", () => {
 
     describe("when a job is retried multiple times before succeeding", () => {
       it("total-pending returns to 0 after 3 retries then success", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-multi", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "g-multi",
+            dispatchAfterMs: 100,
+          }),
+        );
         expect(await inspectTotalPending()).toBe(1);
 
         // Attempt 1: dispatch → fail → retryRestage
@@ -2482,7 +2664,13 @@ describe("GroupStagingScripts", () => {
         // retryRestage/restageAndBlock. No manual counter manipulation needed.
 
         // Stage: INCR → counter = 1
-        await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-balanced", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "g-balanced",
+            dispatchAfterMs: 100,
+          }),
+        );
         expect(await inspectTotalPending()).toBe(1);
 
         // Dispatch: DECR at ZREM → counter = 0
@@ -2506,7 +2694,10 @@ describe("GroupStagingScripts", () => {
         expect(await inspectTotalPending()).toBe(0);
 
         // Complete: no counter change → counter = 0
-        await scripts.complete({ groupId: "g-balanced", stagedJobId: "j1/r/1" });
+        await scripts.complete({
+          groupId: "g-balanced",
+          stagedJobId: "j1/r/1",
+        });
         expect(await inspectTotalPending()).toBe(0);
       });
     });
@@ -2514,11 +2705,41 @@ describe("GroupStagingScripts", () => {
     describe("counter reconciliation invariant", () => {
       /** @scenario Counter equals sum of all :jobs ZSET cardinalities */
       it("total-pending equals sum of ZCARD(:jobs) across all groups", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "a1", groupId: "g-recon-a", dispatchAfterMs: 100 }));
-        await scripts.stage(makeJob({ stagedJobId: "a2", groupId: "g-recon-a", dispatchAfterMs: 200 }));
-        await scripts.stage(makeJob({ stagedJobId: "b1", groupId: "g-recon-b", dispatchAfterMs: 100 }));
-        await scripts.stage(makeJob({ stagedJobId: "c1", groupId: "g-recon-c", dispatchAfterMs: 100 }));
-        await scripts.stage(makeJob({ stagedJobId: "c2", groupId: "g-recon-c", dispatchAfterMs: 200 }));
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "a1",
+            groupId: "g-recon-a",
+            dispatchAfterMs: 100,
+          }),
+        );
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "a2",
+            groupId: "g-recon-a",
+            dispatchAfterMs: 200,
+          }),
+        );
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "b1",
+            groupId: "g-recon-b",
+            dispatchAfterMs: 100,
+          }),
+        );
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "c1",
+            groupId: "g-recon-c",
+            dispatchAfterMs: 100,
+          }),
+        );
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "c2",
+            groupId: "g-recon-c",
+            dispatchAfterMs: 200,
+          }),
+        );
 
         // Dispatch some — creates mixed state (some staged, some active)
         await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 });
@@ -2537,7 +2758,13 @@ describe("GroupStagingScripts", () => {
       });
 
       it("retryRestage preserves the invariant — retry INCRs when job re-enters :jobs", async () => {
-        await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-recon-retry", dispatchAfterMs: 100 }));
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "g-recon-retry",
+            dispatchAfterMs: 100,
+          }),
+        );
         expect(await inspectTotalPending()).toBe(1);
 
         // Dispatch: DECR → counter = 0
@@ -2556,7 +2783,9 @@ describe("GroupStagingScripts", () => {
 
         // retryRestage ZADD'd a new job AND INCR'd the counter.
         // ZCARD(:jobs) = 1 (retry job), counter = 1. Invariant holds.
-        const jobCount = await redis.zcard(`${keyPrefix()}group:g-recon-retry:jobs`);
+        const jobCount = await redis.zcard(
+          `${keyPrefix()}group:g-recon-retry:jobs`,
+        );
         expect(jobCount).toBe(1);
         expect(await inspectTotalPending()).toBe(1);
         expect(await inspectTotalPending()).toBe(jobCount);
@@ -2578,17 +2807,42 @@ describe("GroupStagingScripts", () => {
 
     /** @scenario drainTenant decrements stats:total-pending atomically per group */
     it("decrements stats:total-pending by the count of staged jobs dropped", async () => {
-      await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-drain", dispatchAfterMs: 1000 }));
-      await scripts.stage(makeJob({ stagedJobId: "j2", groupId: "g-drain", dispatchAfterMs: 2000 }));
-      await scripts.stage(makeJob({ stagedJobId: "j3", groupId: "g-drain", dispatchAfterMs: 3000 }));
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          groupId: "g-drain",
+          dispatchAfterMs: 1000,
+        }),
+      );
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j2",
+          groupId: "g-drain",
+          dispatchAfterMs: 2000,
+        }),
+      );
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j3",
+          groupId: "g-drain",
+          dispatchAfterMs: 3000,
+        }),
+      );
 
-      const before = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      const before = Number(
+        await redis.get(`${keyPrefix()}stats:total-pending`),
+      );
       expect(before).toBe(3);
 
-      const result = await repo.drainGroup({ queueName: QUEUE_NAME, groupId: "g-drain" });
+      const result = await repo.drainGroup({
+        queueName: QUEUE_NAME,
+        groupId: "g-drain",
+      });
       expect(result.jobsRemoved).toBe(3);
 
-      const after = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      const after = Number(
+        await redis.get(`${keyPrefix()}stats:total-pending`),
+      );
       expect(after).toBe(0);
     });
 
@@ -2597,42 +2851,79 @@ describe("GroupStagingScripts", () => {
       // should be 1 (just j2 in :jobs). j1's INCR was already compensated
       // by DECR at dispatch time. Drain must NOT count the active job
       // again or the counter goes negative.
-      await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-active", dispatchAfterMs: 100 }));
-      await scripts.stage(makeJob({ stagedJobId: "j2", groupId: "g-active", dispatchAfterMs: 200 }));
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          groupId: "g-active",
+          dispatchAfterMs: 100,
+        }),
+      );
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j2",
+          groupId: "g-active",
+          dispatchAfterMs: 200,
+        }),
+      );
 
-      const afterStage = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      const afterStage = Number(
+        await redis.get(`${keyPrefix()}stats:total-pending`),
+      );
       expect(afterStage).toBe(2);
 
       // Move j1 from staged → active (DECR at dispatch → counter = 1)
-      const dispatched = await scripts.dispatch({ nowMs: 150, activeTtlSec: 60 });
+      const dispatched = await scripts.dispatch({
+        nowMs: 150,
+        activeTtlSec: 60,
+      });
       expect(dispatched).not.toBeNull();
       expect(dispatched!.stagedJobId).toBe("j1");
       expect(await inspectActiveKey("g-active")).toBe("j1");
 
-      const afterDispatch = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      const afterDispatch = Number(
+        await redis.get(`${keyPrefix()}stats:total-pending`),
+      );
       expect(afterDispatch).toBe(1); // j2 still in :jobs
 
-      const result = await repo.drainGroup({ queueName: QUEUE_NAME, groupId: "g-active" });
+      const result = await repo.drainGroup({
+        queueName: QUEUE_NAME,
+        groupId: "g-active",
+      });
       expect(result.jobsRemoved).toBe(1); // only j2 (staged), not j1 (active)
 
-      const after = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      const after = Number(
+        await redis.get(`${keyPrefix()}stats:total-pending`),
+      );
       expect(after).toBe(0);
     });
 
     it("drain on a fully-dispatched group drops 0 jobs", async () => {
       // Edge case: ZCARD=0 because the only job was dispatched (DECRed).
       // activeKey exists but drain must NOT count it — already DECRed.
-      await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-only-active", dispatchAfterMs: 100 }));
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          groupId: "g-only-active",
+          dispatchAfterMs: 100,
+        }),
+      );
       await scripts.dispatch({ nowMs: 150, activeTtlSec: 60 });
       expect(await inspectActiveKey("g-only-active")).toBe("j1");
 
-      const before = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      const before = Number(
+        await redis.get(`${keyPrefix()}stats:total-pending`),
+      );
       expect(before).toBe(0); // dispatch already DECRed
 
-      const result = await repo.drainGroup({ queueName: QUEUE_NAME, groupId: "g-only-active" });
+      const result = await repo.drainGroup({
+        queueName: QUEUE_NAME,
+        groupId: "g-only-active",
+      });
       expect(result.jobsRemoved).toBe(0); // no staged jobs to drop
 
-      const after = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      const after = Number(
+        await redis.get(`${keyPrefix()}stats:total-pending`),
+      );
       expect(after).toBe(0);
     });
 
@@ -2640,10 +2931,15 @@ describe("GroupStagingScripts", () => {
       // Defensive: drain on a never-existed group should not push counter negative.
       await redis.set(`${keyPrefix()}stats:total-pending`, "5");
 
-      const result = await repo.drainGroup({ queueName: QUEUE_NAME, groupId: "never-existed" });
+      const result = await repo.drainGroup({
+        queueName: QUEUE_NAME,
+        groupId: "never-existed",
+      });
       expect(result.jobsRemoved).toBe(0);
 
-      const after = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      const after = Number(
+        await redis.get(`${keyPrefix()}stats:total-pending`),
+      );
       expect(after).toBe(5);
     });
   });
@@ -2701,10 +2997,16 @@ describe("GroupStagingScripts", () => {
       expect(result.jobsDrained).toBe(2);
 
       // Untouched groups still hold their jobs
-      const cmdJobs = await inspectGroupJobs("project_X/command/recordSpan/trace:t1");
+      const cmdJobs = await inspectGroupJobs(
+        "project_X/command/recordSpan/trace:t1",
+      );
       expect(cmdJobs.filter((s) => !s.match(/^\d+$/))).toContain("cmd-c");
-      const otherTenantJobs = await inspectGroupJobs("project_Y/fold/projectDailySdkUsage/key-1");
-      expect(otherTenantJobs.filter((s) => !s.match(/^\d+$/))).toContain("other-tenant");
+      const otherTenantJobs = await inspectGroupJobs(
+        "project_Y/fold/projectDailySdkUsage/key-1",
+      );
+      expect(otherTenantJobs.filter((s) => !s.match(/^\d+$/))).toContain(
+        "other-tenant",
+      );
     });
 
     it("without groupIdContains, drains every group for the tenant", async () => {
@@ -2753,8 +3055,12 @@ describe("GroupStagingScripts", () => {
       expect(result.groupsDrained).toBe(0);
       expect(result.jobsDrained).toBe(0);
 
-      const survivors = await inspectGroupJobs("project_Z/fold/somethingShared/key-1");
-      expect(survivors.filter((s) => !s.match(/^\d+$/))).toContain("wrong-tenant");
+      const survivors = await inspectGroupJobs(
+        "project_Z/fold/somethingShared/key-1",
+      );
+      expect(survivors.filter((s) => !s.match(/^\d+$/))).toContain(
+        "wrong-tenant",
+      );
     });
   });
 
@@ -2820,9 +3126,7 @@ describe("GroupStagingScripts", () => {
       dispatchAfterMs?: number;
     }) {
       const groupId = `${tenantId}/${groupSuffix}`;
-      await scripts.stage(
-        makeJob({ groupId, stagedJobId, dispatchAfterMs }),
-      );
+      await scripts.stage(makeJob({ groupId, stagedJobId, dispatchAfterMs }));
       return groupId;
     }
 
@@ -2844,7 +3148,9 @@ describe("GroupStagingScripts", () => {
       // One live slot after first dispatch, scored at the slot's expiry
       // (nowMs + activeTtlSec*1000 = 2000 + 60000 = 62000).
       expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(1);
-      expect(await redis.zscore(tenantActiveZKey("proj_acme"), groupId)).toBe("62000");
+      expect(await redis.zscore(tenantActiveZKey("proj_acme"), groupId)).toBe(
+        "62000",
+      );
 
       // Live-count boundary: a slot is live only while strictly in the future
       // (score > nowMs). One ms before its 62000 expiry it counts; AT exactly
@@ -2893,8 +3199,12 @@ describe("GroupStagingScripts", () => {
       });
       expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(1);
       // The remaining slot belongs to the still-active group.
-      expect(await redis.zscore(tenantActiveZKey("proj_acme"), d2!.groupId)).not.toBeNull();
-      expect(await redis.zscore(tenantActiveZKey("proj_acme"), d1!.groupId)).toBeNull();
+      expect(
+        await redis.zscore(tenantActiveZKey("proj_acme"), d2!.groupId),
+      ).not.toBeNull();
+      expect(
+        await redis.zscore(tenantActiveZKey("proj_acme"), d1!.groupId),
+      ).toBeNull();
     });
 
     /** @scenario RESTAGE_AND_BLOCK removes the in-flight slot on exhausted retries */
@@ -2932,7 +3242,9 @@ describe("GroupStagingScripts", () => {
       });
 
       // Initial slot score = dispatch nowMs (2000) + 60000 = 62000.
-      expect(await redis.zscore(tenantActiveZKey("proj_acme"), groupId)).toBe("62000");
+      expect(await redis.zscore(tenantActiveZKey("proj_acme"), groupId)).toBe(
+        "62000",
+      );
 
       // refreshActiveKey uses Date.now() internally, so the bumped score is a
       // real wall-clock expiry far past the initial 62000 placeholder.
@@ -2942,7 +3254,9 @@ describe("GroupStagingScripts", () => {
         activeTtlSec: 60,
       });
 
-      const score = Number(await redis.zscore(tenantActiveZKey("proj_acme"), groupId));
+      const score = Number(
+        await redis.zscore(tenantActiveZKey("proj_acme"), groupId),
+      );
       const expectedExpiry = Date.now() + 60 * 1000;
       expect(score).toBeGreaterThan(62000);
       // Slot expiry tracks the activeKey heartbeat (Date.now() + ttl), within a
@@ -2957,7 +3271,10 @@ describe("GroupStagingScripts", () => {
         groupSuffix: "g1",
         stagedJobId: "j1",
       });
-      const dispatched = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
+      const dispatched = await scripts.dispatch({
+        nowMs: 2000,
+        activeTtlSec: 60,
+      });
 
       // Free the slot out from under an in-flight heartbeat (as COMPLETE would).
       await redis.zrem(tenantActiveZKey("proj_acme"), groupId);
@@ -2968,7 +3285,9 @@ describe("GroupStagingScripts", () => {
         stagedJobId: dispatched!.stagedJobId,
         activeTtlSec: 60,
       });
-      expect(await redis.zscore(tenantActiveZKey("proj_acme"), groupId)).toBeNull();
+      expect(
+        await redis.zscore(tenantActiveZKey("proj_acme"), groupId),
+      ).toBeNull();
     });
 
     /** @scenario RETRY_RESTAGE bumps the in-flight slot expiry to the retry window */
@@ -2995,7 +3314,9 @@ describe("GroupStagingScripts", () => {
 
       // retryRestage sets the slot expiry to Date.now() + retryTtlSec*1000,
       // retryTtlSec = ceil(backoffMs/1000)+2 = 32s.
-      const score = Number(await redis.zscore(tenantActiveZKey("proj_acme"), groupId));
+      const score = Number(
+        await redis.zscore(tenantActiveZKey("proj_acme"), groupId),
+      );
       const expectedExpiry = Date.now() + 32 * 1000;
       expect(score).toBeGreaterThan(0);
       expect(Math.abs(score - expectedExpiry)).toBeLessThanOrEqual(2000);
@@ -3022,8 +3343,12 @@ describe("GroupStagingScripts", () => {
       });
 
       // First two dispatches OK
-      expect(await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 })).not.toBeNull();
-      expect(await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 })).not.toBeNull();
+      expect(
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }),
+      ).not.toBeNull();
+      expect(
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }),
+      ).not.toBeNull();
       expect(await redis.zcard(tenantActiveZKey("proj_noisy"))).toBe(2);
 
       // Third dispatch must be refused: tenant is at cap=2
@@ -3145,13 +3470,23 @@ describe("GroupStagingScripts", () => {
       });
 
       // Batch dispatch: gets 1 noisy + 1 quiet (cap=1 each)
-      const batch = await scripts.dispatchBatch({ nowMs: 2000, activeTtlSec: 60, maxJobs: 10 });
+      const batch = await scripts.dispatchBatch({
+        nowMs: 2000,
+        activeTtlSec: 60,
+        maxJobs: 10,
+      });
       const groupIds = batch.map((r) => r.groupId);
       expect(groupIds).toContain("proj_quiet/only");
-      expect(groupIds.filter((g) => g.startsWith("proj_noisy/"))).toHaveLength(1);
+      expect(groupIds.filter((g) => g.startsWith("proj_noisy/"))).toHaveLength(
+        1,
+      );
 
       // Second batch: both tenants at cap, nothing left to dispatch
-      const batch2 = await scripts.dispatchBatch({ nowMs: 2000, activeTtlSec: 60, maxJobs: 10 });
+      const batch2 = await scripts.dispatchBatch({
+        nowMs: 2000,
+        activeTtlSec: 60,
+        maxJobs: 10,
+      });
       expect(batch2).toHaveLength(0);
 
       // The 19 remaining noisy groups were parked out of ready, not re-deferred
@@ -3176,7 +3511,9 @@ describe("GroupStagingScripts", () => {
       expect(dispatched).not.toBeNull();
 
       // Scan for any tenant_active_z:* keys: must be none.
-      const keysAfterDispatch = await redis.keys(`${keyPrefix()}tenant_active_z:*`);
+      const keysAfterDispatch = await redis.keys(
+        `${keyPrefix()}tenant_active_z:*`,
+      );
       expect(keysAfterDispatch).toEqual([]);
 
       // Round-trip a full lifecycle to confirm no key is created at any
@@ -3186,7 +3523,9 @@ describe("GroupStagingScripts", () => {
         groupId,
         stagedJobId: dispatched!.stagedJobId,
       });
-      const keysAfterComplete = await redis.keys(`${keyPrefix()}tenant_active_z:*`);
+      const keysAfterComplete = await redis.keys(
+        `${keyPrefix()}tenant_active_z:*`,
+      );
       expect(keysAfterComplete).toEqual([]);
 
       // restageAndBlock path too: re-stage a fresh group and walk the
@@ -3248,20 +3587,26 @@ describe("GroupStagingScripts", () => {
         const d1 = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
         expect(d1!.groupId).toBe("proj_acme/g1");
         // Second poll parks g2 (tenant at cap=1) at its original score.
-        expect(await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 })).toBeNull();
-        expect(await redis.zrange(parkedKey("proj_acme"), 0, -1, "WITHSCORES")).toEqual([
-          "proj_acme/g2",
-          "1500",
-        ]);
+        expect(
+          await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }),
+        ).toBeNull();
+        expect(
+          await redis.zrange(parkedKey("proj_acme"), 0, -1, "WITHSCORES"),
+        ).toEqual(["proj_acme/g2", "1500"]);
 
         // Completing g1 frees the slot → COMPLETE unparks g2 back into ready
         // at its preserved score, and clears the now-empty registry entry.
-        await scripts.complete({ groupId: d1!.groupId, stagedJobId: d1!.stagedJobId });
+        await scripts.complete({
+          groupId: d1!.groupId,
+          stagedJobId: d1!.stagedJobId,
+        });
         expect(await redis.zcard(parkedKey("proj_acme"))).toBe(0);
         expect(
           await redis.sismember(`${keyPrefix()}parked-tenants`, "proj_acme"),
         ).toBe(0);
-        expect(await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2")).toBe("1500");
+        expect(await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2")).toBe(
+          "1500",
+        );
 
         // g2 is now dispatchable.
         const d2 = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
@@ -3289,7 +3634,9 @@ describe("GroupStagingScripts", () => {
         const d1 = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 5 });
         await scripts.dispatch({ nowMs: 2000, activeTtlSec: 5 }); // parks g2
         expect(await redis.zcard(parkedKey("proj_crash"))).toBe(1);
-        expect(await redis.zscore(tenantActiveZKey("proj_crash"), d1!.groupId)).toBe("7000");
+        expect(
+          await redis.zscore(tenantActiveZKey("proj_crash"), d1!.groupId),
+        ).toBe("7000");
 
         // Simulate the worker dying ungracefully: no COMPLETE, no heartbeat. The
         // active key expires on its own; we drop it here to mirror that. The
@@ -3301,11 +3648,16 @@ describe("GroupStagingScripts", () => {
         // A later poll whose nowMs (8000) is past the lapsed slot score (7000):
         // tenantActiveCount GCs the stale member, reads 0 (under cap), and the
         // reconcile restores g2 with NO manual counter reset.
-        const recovered = await scripts.dispatch({ nowMs: 8000, activeTtlSec: 5 });
+        const recovered = await scripts.dispatch({
+          nowMs: 8000,
+          activeTtlSec: 5,
+        });
         expect(recovered!.groupId).toBe("proj_crash/g2");
         expect(await redis.zcard(parkedKey("proj_crash"))).toBe(0);
         // The lapsed slot was garbage-collected out of the ZSET.
-        expect(await redis.zscore(tenantActiveZKey("proj_crash"), d1!.groupId)).toBeNull();
+        expect(
+          await redis.zscore(tenantActiveZKey("proj_crash"), d1!.groupId),
+        ).toBeNull();
       });
 
       /** @scenario Disabling the cap restores all parked groups */
@@ -3342,7 +3694,8 @@ describe("GroupStagingScripts", () => {
         // whole set (the May-27 442K-scale single-thread block this fix avoids).
         const total = PARK_RECONCILE_MAX_DRAIN + 50;
         const members: (string | number)[] = [];
-        for (let i = 0; i < total; i++) members.push(1000 + i, `proj_big/g${i}`);
+        for (let i = 0; i < total; i++)
+          members.push(1000 + i, `proj_big/g${i}`);
         await redis.zadd(`${keyPrefix()}parked:proj_big`, ...members);
         await redis.sadd(`${keyPrefix()}parked-tenants`, "proj_big");
         expect(await redis.zcard(parkedKey("proj_big"))).toBe(total);
@@ -3384,15 +3737,22 @@ describe("GroupStagingScripts", () => {
         await scripts.dispatch({ nowMs: now, activeTtlSec: 60 });
         expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(2);
         // Next poll parks the remaining 3 (tenant at cap=2).
-        expect(await scripts.dispatch({ nowMs: now, activeTtlSec: 60 })).toBeNull();
+        expect(
+          await scripts.dispatch({ nowMs: now, activeTtlSec: 60 }),
+        ).toBeNull();
         expect(await redis.zcard(parkedKey("proj_acme"))).toBe(3);
 
         // Completing ONE frees exactly one slot → exactly ONE group unparks.
-        await scripts.complete({ groupId: d1!.groupId, stagedJobId: d1!.stagedJobId });
+        await scripts.complete({
+          groupId: d1!.groupId,
+          stagedJobId: d1!.stagedJobId,
+        });
         expect(await redis.zcard(parkedKey("proj_acme"))).toBe(2);
         // The single restored group is the only one due in ready (its preserved
         // score is the small staged dispatchAfter, well under the active scores).
-        expect(await redis.zcount(`${keyPrefix()}ready`, "-inf", "3000")).toBe(1);
+        expect(await redis.zcount(`${keyPrefix()}ready`, "-inf", "3000")).toBe(
+          1,
+        );
       });
 
       /** @scenario Staging a new job for a parked group keeps it parked */
@@ -3416,16 +3776,21 @@ describe("GroupStagingScripts", () => {
 
         // Stage a lower-score job into the already-parked g2.
         await scripts.stage(
-          makeJob({ groupId: "proj_acme/g2", stagedJobId: "j2b", dispatchAfterMs: 900 }),
+          makeJob({
+            groupId: "proj_acme/g2",
+            stagedJobId: "j2b",
+            dispatchAfterMs: 900,
+          }),
         );
 
         // g2 must stay parked (absorbing the lower score there via LT), NOT
         // reappear in the ready scan.
-        expect(await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2")).toBeNull();
-        expect(await redis.zrange(parkedKey("proj_acme"), 0, -1, "WITHSCORES")).toEqual([
-          "proj_acme/g2",
-          "900",
-        ]);
+        expect(
+          await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2"),
+        ).toBeNull();
+        expect(
+          await redis.zrange(parkedKey("proj_acme"), 0, -1, "WITHSCORES"),
+        ).toEqual(["proj_acme/g2", "900"]);
       });
 
       // The remaining ready-writers (STAGE_BATCH, RETRY_RESTAGE, ops UNBLOCK and
@@ -3451,11 +3816,19 @@ describe("GroupStagingScripts", () => {
         expect(await redis.zcard(parkedKey("proj_acme"))).toBe(1);
 
         await scripts.stageBatch([
-          makeJob({ groupId: "proj_acme/g2", stagedJobId: "j2b", dispatchAfterMs: 900 }),
+          makeJob({
+            groupId: "proj_acme/g2",
+            stagedJobId: "j2b",
+            dispatchAfterMs: 900,
+          }),
         ]);
 
-        expect(await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2")).toBeNull();
-        expect(await redis.zscore(parkedKey("proj_acme"), "proj_acme/g2")).toBe("900");
+        expect(
+          await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2"),
+        ).toBeNull();
+        expect(await redis.zscore(parkedKey("proj_acme"), "proj_acme/g2")).toBe(
+          "900",
+        );
       });
 
       it("keeps a parked group parked when it is unblocked via the ops repo", async () => {
@@ -3480,9 +3853,14 @@ describe("GroupStagingScripts", () => {
         // then unblock it: UNBLOCK must route through the parked-aware write so
         // it does not clobber g2 back into ready.
         await redis.sadd(`${keyPrefix()}blocked`, "proj_acme/g2");
-        await repo.unblockGroup({ queueName: QUEUE_NAME, groupId: "proj_acme/g2" });
+        await repo.unblockGroup({
+          queueName: QUEUE_NAME,
+          groupId: "proj_acme/g2",
+        });
 
-        expect(await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2")).toBeNull();
+        expect(
+          await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2"),
+        ).toBeNull();
         expect(await redis.zcard(parkedKey("proj_acme"))).toBe(1);
       });
 
@@ -3532,7 +3910,10 @@ describe("GroupStagingScripts", () => {
         // A poll past the lapsed scores GCs the dead slots, reads the tenant as
         // under cap, and the reconcile restores the parked group: dispatch
         // resumes for the live tenant with NO manual counter reset.
-        const recovered = await scripts.dispatch({ nowMs: 8000, activeTtlSec: 5 });
+        const recovered = await scripts.dispatch({
+          nowMs: 8000,
+          activeTtlSec: 5,
+        });
         expect(recovered).not.toBeNull();
         expect(recovered!.groupId).toBe("proj_dead/g4");
         expect(await redis.zcard(parkedKey("proj_dead"))).toBe(0);
@@ -3565,7 +3946,9 @@ describe("GroupStagingScripts", () => {
       await pipeline.exec();
 
       // Now stage one more to trigger LTRIM
-      await scripts.stage(makeJob({ stagedJobId: "trigger", dispatchAfterMs: 100 }));
+      await scripts.stage(
+        makeJob({ stagedJobId: "trigger", dispatchAfterMs: 100 }),
+      );
 
       const signals = await inspectSignalList();
       expect(signals.length).toBeLessThanOrEqual(1000);
@@ -3580,9 +3963,27 @@ async function inspectTotalPending() {
 describe("GroupStagingScripts.drainGroupReady", () => {
   describe("when a group has several due jobs", () => {
     it("drains up to maxJobs in ascending score order with their data", async () => {
-      await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100, jobDataJson: '{"n":1}' }));
-      await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200, jobDataJson: '{"n":2}' }));
-      await scripts.stage(makeJob({ stagedJobId: "j3", dispatchAfterMs: 300, jobDataJson: '{"n":3}' }));
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          dispatchAfterMs: 100,
+          jobDataJson: '{"n":1}',
+        }),
+      );
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j2",
+          dispatchAfterMs: 200,
+          jobDataJson: '{"n":2}',
+        }),
+      );
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j3",
+          dispatchAfterMs: 300,
+          jobDataJson: '{"n":3}',
+        }),
+      );
 
       const drained = await scripts.drainGroupReady({
         groupId: "group-a",
@@ -3600,7 +4001,11 @@ describe("GroupStagingScripts.drainGroupReady", () => {
       await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }));
       await scripts.stage(makeJob({ stagedJobId: "j3", dispatchAfterMs: 300 }));
 
-      await scripts.drainGroupReady({ groupId: "group-a", nowMs: 10_000, maxJobs: 2 });
+      await scripts.drainGroupReady({
+        groupId: "group-a",
+        nowMs: 10_000,
+        maxJobs: 2,
+      });
 
       const jobs = await inspectGroupJobs("group-a");
       expect(jobs).toEqual(["j3", "300"]);
@@ -3615,7 +4020,11 @@ describe("GroupStagingScripts.drainGroupReady", () => {
       await scripts.stage(makeJob({ stagedJobId: "j3", dispatchAfterMs: 300 }));
       expect(await inspectTotalPending()).toBe("3");
 
-      await scripts.drainGroupReady({ groupId: "group-a", nowMs: 10_000, maxJobs: 2 });
+      await scripts.drainGroupReady({
+        groupId: "group-a",
+        nowMs: 10_000,
+        maxJobs: 2,
+      });
 
       expect(await inspectTotalPending()).toBe("1");
     });
@@ -3629,7 +4038,11 @@ describe("GroupStagingScripts.drainGroupReady", () => {
       await redis.set(`${keyPrefix()}group:group-a:active`, "dispatched-job");
       const readyBefore = await inspectReadySet();
 
-      await scripts.drainGroupReady({ groupId: "group-a", nowMs: 10_000, maxJobs: 5 });
+      await scripts.drainGroupReady({
+        groupId: "group-a",
+        nowMs: 10_000,
+        maxJobs: 5,
+      });
 
       expect(await inspectActiveKey("group-a")).toBe("dispatched-job");
       expect(await inspectReadySet()).toEqual(readyBefore);
@@ -3639,9 +4052,15 @@ describe("GroupStagingScripts.drainGroupReady", () => {
 
   describe("when some jobs are future-scheduled", () => {
     it("drains only the jobs due at nowMs", async () => {
-      await scripts.stage(makeJob({ stagedJobId: "due1", dispatchAfterMs: 100 }));
-      await scripts.stage(makeJob({ stagedJobId: "due2", dispatchAfterMs: 200 }));
-      await scripts.stage(makeJob({ stagedJobId: "future", dispatchAfterMs: 9_999 }));
+      await scripts.stage(
+        makeJob({ stagedJobId: "due1", dispatchAfterMs: 100 }),
+      );
+      await scripts.stage(
+        makeJob({ stagedJobId: "due2", dispatchAfterMs: 200 }),
+      );
+      await scripts.stage(
+        makeJob({ stagedJobId: "future", dispatchAfterMs: 9_999 }),
+      );
 
       const drained = await scripts.drainGroupReady({
         groupId: "group-a",
@@ -3659,7 +4078,13 @@ describe("GroupStagingScripts.drainGroupReady", () => {
     it("returns empty without touching the group", async () => {
       await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
 
-      expect(await scripts.drainGroupReady({ groupId: "group-a", nowMs: 10_000, maxJobs: 0 })).toEqual([]);
+      expect(
+        await scripts.drainGroupReady({
+          groupId: "group-a",
+          nowMs: 10_000,
+          maxJobs: 0,
+        }),
+      ).toEqual([]);
 
       const jobs = await inspectGroupJobs("group-a");
       expect(jobs).toEqual(["j1", "100"]);
@@ -3669,7 +4094,13 @@ describe("GroupStagingScripts.drainGroupReady", () => {
 
   describe("when the group is empty", () => {
     it("returns empty", async () => {
-      expect(await scripts.drainGroupReady({ groupId: "nonexistent", nowMs: 10_000, maxJobs: 5 })).toEqual([]);
+      expect(
+        await scripts.drainGroupReady({
+          groupId: "nonexistent",
+          nowMs: 10_000,
+          maxJobs: 5,
+        }),
+      ).toEqual([]);
     });
   });
 });
@@ -3778,8 +4209,12 @@ describe("group-key TTL safety net", () => {
 
   describe("when an active job heartbeats with pending siblings", () => {
     it("refreshes the pending-sibling jobs/data TTL", async () => {
-      await scripts.stage(makeJob({ stagedJobId: "active", dispatchAfterMs: 100 }));
-      await scripts.stage(makeJob({ stagedJobId: "sibling", dispatchAfterMs: 200 }));
+      await scripts.stage(
+        makeJob({ stagedJobId: "active", dispatchAfterMs: 100 }),
+      );
+      await scripts.stage(
+        makeJob({ stagedJobId: "sibling", dispatchAfterMs: 200 }),
+      );
       await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 }); // claims "active"
 
       // Age the sibling keys' TTL well below the window; the heartbeat must
@@ -3842,7 +4277,9 @@ describe("queue discovery via registry", () => {
     it("discovers it from the registry set", async () => {
       await scripts.registerQueue();
 
-      expect(await redis.smembers(GROUP_QUEUE_REGISTRY_KEY)).toContain(QUEUE_NAME);
+      expect(await redis.smembers(GROUP_QUEUE_REGISTRY_KEY)).toContain(
+        QUEUE_NAME,
+      );
       expect(await repo.discoverQueueNames()).toContain(QUEUE_NAME);
     });
   });
@@ -3855,7 +4292,9 @@ describe("queue discovery via registry", () => {
       const names = await repo.discoverQueueNames();
 
       expect(names).toContain(QUEUE_NAME);
-      expect(await redis.smembers(GROUP_QUEUE_REGISTRY_KEY)).toContain(QUEUE_NAME);
+      expect(await redis.smembers(GROUP_QUEUE_REGISTRY_KEY)).toContain(
+        QUEUE_NAME,
+      );
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -2,8 +2,8 @@ import { performance } from "node:perf_hooks";
 import {
   context as otelContext,
   SpanKind,
-  trace,
   TraceFlags,
+  trace,
 } from "@opentelemetry/api";
 import fastq from "fastq";
 import { Cluster, Redis as IORedis } from "ioredis";
@@ -11,18 +11,17 @@ import { getLangWatchTracer } from "langwatch";
 import type { SemConvAttributes } from "langwatch/observability";
 import { createLogger } from "../../../../utils/logger/server";
 import {
+  createContextFromJobData,
   getJobContextMetadata,
   type JobContextMetadata,
-  createContextFromJobData,
   runWithContext,
 } from "../../../context/asyncContext";
-import { connection } from "../../../redis";
+import { featureFlagService } from "../../../featureFlag";
 import {
-  decodeJobEnvelope,
-  encodeJobEnvelope,
-  readEnvelopeBlobId,
-} from "./jobEnvelope";
-import { RedisJobBlobStore } from "./redisJobBlobStore";
+  TenantRateTracker,
+  tenantIdFromGroupId,
+} from "../../../observability/tenantRateTracker";
+import { connection } from "../../../redis";
 import type {
   DeduplicationConfig,
   EventSourcedQueueDefinition,
@@ -30,38 +29,39 @@ import type {
   QueueSendOptions,
 } from "../../queues";
 import {
-  categorizeError,
   ConfigurationError,
+  categorizeError,
   ErrorCategory,
   QueueError,
 } from "../../services/errorHandling";
-import { JOB_RETRY_CONFIG, getBackoffMs } from "../shared";
+import { getBackoffMs, JOB_RETRY_CONFIG } from "../shared";
 import { GroupQueueDispatcher } from "./dispatcher";
 import {
+  decodeJobEnvelope,
+  encodeJobEnvelope,
+  readEnvelopeBlobId,
+} from "./jobEnvelope";
+import {
   gqGroupsBlockedTotal,
+  gqJobDelayMilliseconds,
+  gqJobDurationMilliseconds,
   gqJobsCompletedTotal,
   gqJobsDedupedTotal,
-  gqJobsExhaustedTotal,
-  gqJobsRetriedTotal,
-  gqJobsNonRetryableTotal,
-  gqJobsStagedTotal,
   gqJobsDelayedTotal,
-  gqJobDelayMilliseconds,
+  gqJobsExhaustedTotal,
+  gqJobsNonRetryableTotal,
+  gqJobsRetriedTotal,
+  gqJobsStagedTotal,
   gqRetryAttempt,
   gqRetryBackoffMilliseconds,
-  gqJobDurationMilliseconds,
 } from "./metrics";
 import { GroupQueueMetricsCollector } from "./metricsCollector";
+import { RedisJobBlobStore } from "./redisJobBlobStore";
 import {
   type DispatchResult,
   type DrainedJob,
   GroupStagingScripts,
 } from "./scripts";
-import {
-  TenantRateTracker,
-  tenantIdFromGroupId,
-} from "../../../observability/tenantRateTracker";
-import { featureFlagService } from "../../../featureFlag";
 
 /**
  * Configuration for the group queue.

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -305,11 +305,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     let dedupTtlMs = 0;
     let shouldExtend = true;
     let shouldReplace = true;
+    let survivesDispatch = false;
     if (dedup) {
       dedupId = dedup.makeId(payload).replaceAll(":", ".");
       dedupTtlMs = dedup.ttlMs ?? DEFAULT_DEDUPLICATION_TTL_MS;
       shouldExtend = dedup.extend !== false;
       shouldReplace = dedup.replace !== false;
+      survivesDispatch = dedup.survivesDispatch === true;
     }
 
     // Attach context metadata to the payload
@@ -340,6 +342,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       }),
       shouldExtend,
       shouldReplace,
+      survivesDispatch,
     });
 
     // A dedup squash displaced a staged payload; reclaim its offloaded blob so
@@ -402,6 +405,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
     const shouldExtend = dedup ? dedup.extend !== false : true;
     const shouldReplace = dedup ? dedup.replace !== false : true;
+    const survivesDispatch = dedup ? dedup.survivesDispatch === true : false;
 
     const jobsToStage = await Promise.all(
       payloads.map(async (payload, index) => {
@@ -435,6 +439,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           }),
           shouldExtend,
           shouldReplace,
+          survivesDispatch,
         };
       }),
     );

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -305,13 +305,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     let dedupTtlMs = 0;
     let shouldExtend = true;
     let shouldReplace = true;
-    let survivesDispatch = false;
+    let shouldSurviveDispatch = false;
     if (dedup) {
       dedupId = dedup.makeId(payload).replaceAll(":", ".");
       dedupTtlMs = dedup.ttlMs ?? DEFAULT_DEDUPLICATION_TTL_MS;
       shouldExtend = dedup.extend !== false;
       shouldReplace = dedup.replace !== false;
-      survivesDispatch = dedup.survivesDispatch === true;
+      shouldSurviveDispatch = dedup.shouldSurviveDispatch === true;
     }
 
     // Attach context metadata to the payload
@@ -342,7 +342,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       }),
       shouldExtend,
       shouldReplace,
-      survivesDispatch,
+      shouldSurviveDispatch,
     });
 
     // A dedup squash displaced a staged payload; reclaim its offloaded blob so
@@ -405,7 +405,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
     const shouldExtend = dedup ? dedup.extend !== false : true;
     const shouldReplace = dedup ? dedup.replace !== false : true;
-    const survivesDispatch = dedup ? dedup.survivesDispatch === true : false;
+    const shouldSurviveDispatch = dedup
+      ? dedup.shouldSurviveDispatch === true
+      : false;
 
     const jobsToStage = await Promise.all(
       payloads.map(async (payload, index) => {
@@ -439,7 +441,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           }),
           shouldExtend,
           shouldReplace,
-          survivesDispatch,
+          shouldSurviveDispatch,
         };
       }),
     );

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -477,7 +477,7 @@ if dedupId ~= "" and dedupTtlMs > 0 then
       return {0, orphanedValue}
     end
     -- Already dispatched. Default: the dedup key is stale, clean it up and let a
-    -- new job stage (the historical TOCTOU behavior). When survivesDispatch is
+    -- new job stage (the historical TOCTOU behavior). When shouldSurviveDispatch is
     -- set, HONOR the still-alive TTL instead — squash the new job and report its
     -- payload as the orphaned value (same {0, orphanedValue} shape the in-staging
     -- squash returns) so a late re-trigger after dispatch cannot re-run it (#3912).
@@ -557,6 +557,10 @@ for i = 1, count do
 
   local isDeduped = false
   local orphanedValue = ""
+  -- True only for the post-dispatch squash (already-dispatched dedup honored):
+  -- that item stages no job AND the deduped job is already gone, so it must NOT
+  -- contribute this group to the post-loop ready bookkeeping (see below).
+  local squashedPostDispatch = false
   if dedupId ~= "" and dedupTtlMs > 0 then
     local existingJobId = redis.call("GET", dedupKey)
     if existingJobId then
@@ -577,13 +581,14 @@ for i = 1, count do
         isDeduped = true
       else
         -- Already dispatched. Default: the dedup key is stale, clean it up and let
-        -- a new job stage (the historical TOCTOU behavior). When survivesDispatch
+        -- a new job stage (the historical TOCTOU behavior). When shouldSurviveDispatch
         -- is set, HONOR the still-alive TTL instead — squash the new job (mark it
         -- deduped and report its payload as orphaned, mirroring the in-staging
         -- squash above) so a late re-trigger after dispatch cannot re-run it (#3912).
         if shouldSurviveDispatch == 1 then
           orphanedValue = jobDataJson
           isDeduped = true
+          squashedPostDispatch = true
         else
           redis.call("DEL", dedupKey)
         end
@@ -603,10 +608,16 @@ for i = 1, count do
 
   refreshGroupKeyTtl(groupJobsKey, dataKey, nowMs)
 
-  -- Track minimum dispatchAfter per affected group
-  local existingMin = affectedGroups[groupId]
-  if existingMin == nil or dispatchAfter < existingMin then
-    affectedGroups[groupId] = dispatchAfter
+  -- Track minimum dispatchAfter per affected group. A post-dispatch squash is
+  -- skipped: it staged no job and the deduped job already left staging, so
+  -- adding the group here would reinsert a drained (empty) group into ready /
+  -- demanding-tenants after the loop. A normal stage and an in-staging squash
+  -- (rank found — that job IS staged) still register, so the group stays ready.
+  if not squashedPostDispatch then
+    local existingMin = affectedGroups[groupId]
+    if existingMin == nil or dispatchAfter < existingMin then
+      affectedGroups[groupId] = dispatchAfter
+    end
   end
 end
 
@@ -1544,7 +1555,7 @@ export class GroupStagingScripts {
     jobDataJson,
     shouldExtend = true,
     shouldReplace = true,
-    survivesDispatch = false,
+    shouldSurviveDispatch = false,
   }: {
     stagedJobId: string;
     groupId: string;
@@ -1554,7 +1565,7 @@ export class GroupStagingScripts {
     jobDataJson: string;
     shouldExtend?: boolean;
     shouldReplace?: boolean;
-    survivesDispatch?: boolean;
+    shouldSurviveDispatch?: boolean;
   }): Promise<{ isNew: boolean; orphanedValue: string }> {
     const groupJobsKey = `${this.keyPrefix}group:${groupId}:jobs`;
     const readyKey = `${this.keyPrefix}ready`;
@@ -1591,7 +1602,7 @@ export class GroupStagingScripts {
       String(Date.now()),
       String(readGlobalBudget()),
       // ARGV[11] — appended after globalBudget so no existing index shifts.
-      String(survivesDispatch ? 1 : 0),
+      String(shouldSurviveDispatch ? 1 : 0),
     );
 
     // STAGE_LUA returns [code, orphanedValue]. Tolerate a bare integer reply
@@ -1622,7 +1633,7 @@ export class GroupStagingScripts {
       jobDataJson: string;
       shouldExtend?: boolean;
       shouldReplace?: boolean;
-      survivesDispatch?: boolean;
+      shouldSurviveDispatch?: boolean;
     }>,
   ): Promise<{ newStagedCount: number; orphanedValues: string[] }> {
     if (jobs.length === 0) return { newStagedCount: 0, orphanedValues: [] };
@@ -1645,7 +1656,7 @@ export class GroupStagingScripts {
         // 9th per-job arg (offset + 9 in the Lua). Kept in the per-job block,
         // alongside the other dedup flags, so the trailing nowMs/globalBudget
         // remain end-relative (ARGV[#ARGV-1]/ARGV[#ARGV]).
-        String((job.survivesDispatch ?? false) ? 1 : 0),
+        String((job.shouldSurviveDispatch ?? false) ? 1 : 0),
       );
     }
     // Appended after all per-job args: nowMs then globalBudget last, so the Lua

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -431,6 +431,11 @@ local globalBudget   = tonumber(ARGV[10]) or 0
 if globalBudget > 0 then
   redis.call("ZADD", parkKeyPrefixOf(readyKey) .. "demanding-tenants", nowMs, parkTenantOf(groupId))
 end
+-- Opt-in (default 0 = unchanged behavior). When 1, a dedup key whose job has
+-- already been DISPATCHED but whose TTL is still alive HONORS the dispatch and
+-- squashes the new job instead of DEL+restaging, so a late re-trigger after
+-- dispatch cannot re-run the command (fixes #3912 double evaluations).
+local shouldSurviveDispatch = tonumber(ARGV[11]) or 0
 
 -- Skip ready-score updates while the group is processing (active key set) or
 -- blocked. In those states the ready score is owned by REFRESH_LUA / COMPLETE_LUA
@@ -471,7 +476,14 @@ if dedupId ~= "" and dedupTtlMs > 0 then
       redis.call("LTRIM", signalKey, 0, 999)
       return {0, orphanedValue}
     end
-    -- Already dispatched: dedup key is stale, clean it up
+    -- Already dispatched. Default: the dedup key is stale, clean it up and let a
+    -- new job stage (the historical TOCTOU behavior). When survivesDispatch is
+    -- set, HONOR the still-alive TTL instead — squash the new job and report its
+    -- payload as the orphaned value (same {0, orphanedValue} shape the in-staging
+    -- squash returns) so a late re-trigger after dispatch cannot re-run it (#3912).
+    if shouldSurviveDispatch == 1 then
+      return {0, jobDataJson}
+    end
     redis.call("DEL", dedupKey)
   end
 end
@@ -523,7 +535,10 @@ local affectedGroups = {}
 local orphanedValues = {}
 
 for i = 1, count do
-  local offset = 2 + (i - 1) * 8
+  -- Per-job stride is 9: stagedJobId..shouldReplace (8) + shouldSurviveDispatch
+  -- (1). nowMs/globalBudget stay appended once AFTER the loop and are read
+  -- end-relative (ARGV[#ARGV-1]/ARGV[#ARGV]), so they are unaffected by the stride.
+  local offset = 2 + (i - 1) * 9
   local stagedJobId   = ARGV[offset + 1]
   local groupId       = ARGV[offset + 2]
   local dispatchAfter = tonumber(ARGV[offset + 3])
@@ -532,6 +547,9 @@ for i = 1, count do
   local jobDataJson   = ARGV[offset + 6]
   local shouldExtend  = tonumber(ARGV[offset + 7])
   local shouldReplace = tonumber(ARGV[offset + 8])
+  -- Opt-in (default 0 = unchanged). See STAGE_LUA: when 1, a dispatched-but-TTL-
+  -- alive dedup key squashes the new job instead of being cleaned up (#3912).
+  local shouldSurviveDispatch = tonumber(ARGV[offset + 9]) or 0
 
   local groupJobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
   local dataKey      = keyPrefix .. "group:" .. groupId .. ":data"
@@ -558,8 +576,17 @@ for i = 1, count do
         redis.call("SET", dedupKey, existingJobId, "PX", dedupTtlMs)
         isDeduped = true
       else
-        -- Already dispatched: dedup key is stale, clean it up
-        redis.call("DEL", dedupKey)
+        -- Already dispatched. Default: the dedup key is stale, clean it up and let
+        -- a new job stage (the historical TOCTOU behavior). When survivesDispatch
+        -- is set, HONOR the still-alive TTL instead — squash the new job (mark it
+        -- deduped and report its payload as orphaned, mirroring the in-staging
+        -- squash above) so a late re-trigger after dispatch cannot re-run it (#3912).
+        if shouldSurviveDispatch == 1 then
+          orphanedValue = jobDataJson
+          isDeduped = true
+        else
+          redis.call("DEL", dedupKey)
+        end
       end
     end
   end
@@ -1517,6 +1544,7 @@ export class GroupStagingScripts {
     jobDataJson,
     shouldExtend = true,
     shouldReplace = true,
+    survivesDispatch = false,
   }: {
     stagedJobId: string;
     groupId: string;
@@ -1526,6 +1554,7 @@ export class GroupStagingScripts {
     jobDataJson: string;
     shouldExtend?: boolean;
     shouldReplace?: boolean;
+    survivesDispatch?: boolean;
   }): Promise<{ isNew: boolean; orphanedValue: string }> {
     const groupJobsKey = `${this.keyPrefix}group:${groupId}:jobs`;
     const readyKey = `${this.keyPrefix}ready`;
@@ -1561,6 +1590,8 @@ export class GroupStagingScripts {
       String(shouldReplace ? 1 : 0),
       String(Date.now()),
       String(readGlobalBudget()),
+      // ARGV[11] — appended after globalBudget so no existing index shifts.
+      String(survivesDispatch ? 1 : 0),
     );
 
     // STAGE_LUA returns [code, orphanedValue]. Tolerate a bare integer reply
@@ -1591,6 +1622,7 @@ export class GroupStagingScripts {
       jobDataJson: string;
       shouldExtend?: boolean;
       shouldReplace?: boolean;
+      survivesDispatch?: boolean;
     }>,
   ): Promise<{ newStagedCount: number; orphanedValues: string[] }> {
     if (jobs.length === 0) return { newStagedCount: 0, orphanedValues: [] };
@@ -1610,6 +1642,10 @@ export class GroupStagingScripts {
         job.jobDataJson,
         String((job.shouldExtend ?? true) ? 1 : 0),
         String((job.shouldReplace ?? true) ? 1 : 0),
+        // 9th per-job arg (offset + 9 in the Lua). Kept in the per-job block,
+        // alongside the other dedup flags, so the trailing nowMs/globalBudget
+        // remain end-relative (ARGV[#ARGV-1]/ARGV[#ARGV]).
+        String((job.survivesDispatch ?? false) ? 1 : 0),
       );
     }
     // Appended after all per-job args: nowMs then globalBudget last, so the Lua

--- a/langwatch/src/server/event-sourcing/queues/queue.types.ts
+++ b/langwatch/src/server/event-sourcing/queues/queue.types.ts
@@ -103,7 +103,9 @@ export function resolveDeduplicationStrategy<Payload>(
   return strategy;
 }
 
-export interface EventSourcedQueueDefinition<Payload extends Record<string, unknown>> {
+export interface EventSourcedQueueDefinition<
+  Payload extends Record<string, unknown>,
+> {
   /**
    * Base name for the queue and job.
    * Queue name will be derived as `{name}` (with braces).
@@ -183,9 +185,14 @@ export interface QueueSendOptions<Payload> {
   deduplication?: DeduplicationConfig<Payload>;
 }
 
-export interface EventSourcedQueueProcessor<Payload extends Record<string, unknown>> {
+export interface EventSourcedQueueProcessor<
+  Payload extends Record<string, unknown>,
+> {
   send(payload: Payload, options?: QueueSendOptions<Payload>): Promise<void>;
-  sendBatch(payloads: Payload[], options?: QueueSendOptions<Payload>): Promise<void>;
+  sendBatch(
+    payloads: Payload[],
+    options?: QueueSendOptions<Payload>,
+  ): Promise<void>;
   /**
    * Gracefully closes the queue processor, waiting for in-flight jobs to complete.
    * Should be called during application shutdown.

--- a/langwatch/src/server/event-sourcing/queues/queue.types.ts
+++ b/langwatch/src/server/event-sourcing/queues/queue.types.ts
@@ -37,6 +37,21 @@ export interface DeduplicationConfig<Payload> {
    * @default true
    */
   replace?: boolean;
+  /**
+   * Whether a dedup key whose job has already been DISPATCHED (removed from
+   * staging) but whose TTL is still alive should SQUASH a new job rather than be
+   * treated as stale and cleaned up.
+   *
+   * Default (`false`): the historical behavior — once the deduplicated job is
+   * dispatched, the dedup key is considered stale, deleted, and a new job stages
+   * (so a late re-trigger re-runs the command). When `true`, the still-alive TTL
+   * is HONORED: the new job is squashed for the remainder of the TTL window, so a
+   * late re-trigger arriving after dispatch cannot re-run the command. Use it
+   * when the dedup TTL is sized to span the whole window in which duplicate
+   * triggers may arrive (fixes per-trace evaluations running twice, #3912).
+   * @default false
+   */
+  survivesDispatch?: boolean;
 }
 
 /**

--- a/langwatch/src/server/event-sourcing/queues/queue.types.ts
+++ b/langwatch/src/server/event-sourcing/queues/queue.types.ts
@@ -51,7 +51,7 @@ export interface DeduplicationConfig<Payload> {
    * triggers may arrive (fixes per-trace evaluations running twice, #3912).
    * @default false
    */
-  survivesDispatch?: boolean;
+  shouldSurviveDispatch?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Why

Closes #3912

Customers saw every per-trace online evaluation run **twice** (6 evaluators → 12 runs). Root cause (confirmed in the issue): the groupQueue dedup only prevents duplicate **staging**. Once a job is **dispatched** (removed from the staging sorted set), `STAGE_LUA` treats the still-alive dedup key as stale — it `DEL`s the key and stages a **new** job. So a late span arriving after the `evaluationTrigger` reactor's debounce window fires re-stages the reactor → re-dispatches → a second set of evaluations.

## What changed

- **New opt-in `shouldSurviveDispatch` flag on `DeduplicationConfig`.** When set, `STAGE_LUA` **honors** a dispatched-but-TTL-alive dedup key — it squashes the new job instead of `DEL`+restage. **Default-off ⇒ byte-identical existing behavior** (this is why the change is safe: every other queue caller is unaffected at the bit level).
- **Both `STAGE_LUA` copies patched** (single-stage and batch-stage) — the bug lived in both.
- **Post-dispatch squash skips ready bookkeeping** (CodeRabbit-caught): in the batch path a post-dispatch squash sets a per-item `squashedPostDispatch` flag so it does **not** feed its group into the post-loop `ready`/`demanding-tenants` bookkeeping — otherwise a fully-drained (completed) group could be resurrected into `ready`. The single-stage path already returns early. Covered by a new regression test.
- **`evaluationTrigger` reactor opts in** (`shouldSurviveDispatch: true` on the evaluation command's dedup), so a post-dispatch re-trigger can no longer re-run the command within the dedup TTL.

## How it works

```
queue.types.ts            DeduplicationConfig gains shouldSurviveDispatch?: boolean (default-off, documented)
groupQueue.ts             reads dedup.shouldSurviveDispatch; threads it into both stage paths as a named param
scripts.ts (STAGE_LUA)    single-stage: on "already dispatched", if shouldSurviveDispatch → return {0, jobDataJson} (squash) else DEL+restage
                          batch-stage:  on "already dispatched", if shouldSurviveDispatch → isDeduped=true (skip staging) else DEL+restage
evaluationTrigger.reactor.ts  shouldSurviveDispatch: true on the ExecuteEvaluation dedup config
```

**ARGV is append-only** (the load-bearing safety property — a shifted index would corrupt every queue op):
- single-stage: new flag is `ARGV[11]`, appended **after** `globalBudget` (`ARGV[10]`); no existing index moves.
- batch-stage: the per-job stride goes `8 → 9` (the flag is the 9th per-job arg, read at `ARGV[offset + 9]`), in lockstep between the JS builder and the Lua reader; the trailing `nowMs`/`globalBudget` are read **end-relative** (`ARGV[#ARGV-1]`/`ARGV[#ARGV]`), so they're unaffected.

## Human verification

1. Read `STAGE_LUA` (both copies) in `scripts.ts`: confirm the `else` branch (dedup key exists but `ZRANK` is nil = already dispatched) now squashes when `shouldSurviveDispatch == 1` and only `DEL`s otherwise.
2. `src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts` — the existing TOCTOU/batch-race tests (flag unset) still assert the old DEL+restage behavior (proving default is unchanged); the new tests assert that with `shouldSurviveDispatch: true` a dispatched-but-TTL-alive key squashes the re-stage.
3. Falsifiability: `git checkout origin/main -- <the 4 impl files>`, run the two test files → the shouldSurviveDispatch tests fail (default → duplicate stages); restore → pass.

## How I can prove I was successful

**Falsifiability (the floor for a backend change).** Reverting **only** the implementation (the 4 non-test files) to `origin/main` makes the shouldSurviveDispatch tests fail — a duplicate stages, exactly the #3912 bug; restoring this PR's flag-honoring Lua + reactor opt-in turns them green.

![#3912 red→green falsifiability](https://raw.githubusercontent.com/langwatch/langwatch/proof/3912-eval-dedup/proofs/3912-redgreen.png)

- **RED** (impl reverted): the shouldSurviveDispatch single + batch tests and the reactor-config test fail.
- **GREEN** (this PR): `scripts.integration.test.ts` **144/144**, reactor **24/24**, `pnpm typecheck` clean. Existing TOCTOU/batch-race tests stay green (default behavior unchanged).

<!-- no-ui-surface --> Backend-only change to the Redis groupQueue + the evaluation reactor — no user-facing UI surface. CI re-runs the full suites (with the full env, including `groupQueue.integration.test.ts`, which needs env vars absent from the isolated local worktree).

## Anything surprising?

- **Memory-queue parity gap (flagged, out of scope):** the in-memory `groupQueue` impl (`memory.ts`, used in some unit contexts) does not honor `shouldSurviveDispatch` — the optional field is simply ignored there. Production uses the Redis path, which this PR fixes. Worth a follow-up if the in-memory path ever backs eval dedup.
- The fix is deliberately **opt-in**: rather than change the global dedup semantics (risky for every queue caller), only the evaluation command turns it on. The issue's alternative (an application-level SETNX in the reactor) was rejected — it needs a compensating `DEL` on send-failure, the right key dimension for thread-evals, and Redis wiring the reactor lacks; the Lua flag is contained and correct for both trace- and thread-level evals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deduplication option (`shouldSurviveDispatch`) to keep dedup keys effective even after the original queued job has already been dispatched, reducing duplicate re-triggers within the TTL window.
  * Evaluation dispatch now applies this deduplication behavior consistently across thread-level and delayed dispatch paths.
* **Bug Fixes**
  * Improved queue/group staging so late-arriving items can be squashed correctly without removing stale dedup state, and adjusted group re-scoring behavior to match.
* **Tests**
  * Extended reactor unit coverage for the new dispatch-survival deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->