### PR TITLE
feat(experiments-v3): pairwise UX improvements — auto-wire, dedicated column, sidebar fix

### DIFF
--- a/langwatch/src/components/datasets/editor/TableCell.tsx
+++ b/langwatch/src/components/datasets/editor/TableCell.tsx
@@ -14,7 +14,7 @@ import { EditableCell } from "./EditableCell";
  * editable via EditableCell; "checkbox" toggles row selection; anything else
  * (e.g. the workbench's "target" columns) renders through flexRender.
  */
-export type ColumnType = "checkbox" | "dataset" | "target";
+export type ColumnType = "checkbox" | "dataset" | "target" | "pairwise";
 
 type ColumnMeta = {
   columnType: ColumnType;

--- a/langwatch/src/components/targets/TargetTypeSelectorDrawer.tsx
+++ b/langwatch/src/components/targets/TargetTypeSelectorDrawer.tsx
@@ -3,7 +3,7 @@ import { Bot, CheckCircle, FileText, Swords } from "lucide-react";
 import { LuArrowLeft } from "react-icons/lu";
 
 import { Drawer } from "~/components/ui/drawer";
-import type { TargetType } from "~/experiments-v3/types";
+import type { PairwiseEvaluatorConfig, TargetConfig, TargetType } from "~/experiments-v3/types";
 import { getComplexProps, useDrawer } from "~/hooks/useDrawer";
 
 // Re-export for backward compatibility
@@ -18,6 +18,12 @@ export type TargetTypeSelectorDrawerProps = {
   open?: boolean;
   onClose?: () => void;
   onSelect?: (type: TargetType) => void;
+  /** Passed through to evaluatorEditor when "Pairwise Compare" is selected. */
+  pairwiseContext?: {
+    initialPairwise?: PairwiseEvaluatorConfig;
+    targets: TargetConfig[];
+    datasetColumns: { id: string; name: string }[];
+  };
 };
 
 const targetTypes: Array<{
@@ -71,12 +77,15 @@ export function TargetTypeSelectorDrawer(props: TargetTypeSelectorDrawerProps) {
     // Pairwise is a UI shortcut: skip the category/type picker and jump
     // straight into the pairwise_compare evaluator config. The save flow
     // (set up by handleAddTarget) creates the column as an evaluator-target.
+    // Forward pairwiseContext from handleAddTarget so the creation form shows
+    // Variant A / Variant B / Golden field immediately (matching edit-mode UX).
     if (type === "pairwise") {
       openDrawer(
         "evaluatorEditor",
         {
           evaluatorType: "langevals/pairwise_compare",
           category: "llm_judge",
+          pairwiseContext: complexProps.pairwiseContext as TargetTypeSelectorDrawerProps["pairwiseContext"],
         },
         { replace: true },
       );

--- a/langwatch/src/components/targets/TargetTypeSelectorDrawer.tsx
+++ b/langwatch/src/components/targets/TargetTypeSelectorDrawer.tsx
@@ -1,9 +1,21 @@
-import { Box, Button, Heading, HStack, Separator, Text, VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Heading,
+  HStack,
+  Separator,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
 import { Bot, CheckCircle, FileText, Swords } from "lucide-react";
 import { LuArrowLeft } from "react-icons/lu";
 
 import { Drawer } from "~/components/ui/drawer";
-import type { PairwiseEvaluatorConfig, TargetConfig, TargetType } from "~/experiments-v3/types";
+import type {
+  PairwiseEvaluatorConfig,
+  TargetConfig,
+  TargetType,
+} from "~/experiments-v3/types";
 import { getComplexProps, useDrawer } from "~/hooks/useDrawer";
 
 // Re-export for backward compatibility
@@ -85,7 +97,8 @@ export function TargetTypeSelectorDrawer(props: TargetTypeSelectorDrawerProps) {
         {
           evaluatorType: "langevals/pairwise_compare",
           category: "llm_judge",
-          pairwiseContext: complexProps.pairwiseContext as TargetTypeSelectorDrawerProps["pairwiseContext"],
+          pairwiseContext:
+            complexProps.pairwiseContext as TargetTypeSelectorDrawerProps["pairwiseContext"],
         },
         { replace: true },
       );

--- a/langwatch/src/components/targets/TargetTypeSelectorDrawer.tsx
+++ b/langwatch/src/components/targets/TargetTypeSelectorDrawer.tsx
@@ -97,8 +97,8 @@ export function TargetTypeSelectorDrawer(props: TargetTypeSelectorDrawerProps) {
         {
           evaluatorType: "langevals/pairwise_compare",
           category: "llm_judge",
-          pairwiseContext:
-            complexProps.pairwiseContext as TargetTypeSelectorDrawerProps["pairwiseContext"],
+          pairwiseContext: (complexProps.pairwiseContext ??
+            props.pairwiseContext) as TargetTypeSelectorDrawerProps["pairwiseContext"],
         },
         { replace: true },
       );

--- a/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
+++ b/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
@@ -287,6 +287,15 @@ export function EvaluationsV3Table({
   // Track pending mappings for new prompts (before they become targets)
   const pendingMappingsRef = useRef<Record<string, UIFieldMapping>>({});
 
+  // Track pairwise variant selections made inside the creation evaluatorEditor
+  // so handleSelectEvaluatorAsTarget can apply them on save instead of empty defaults.
+  const pendingPairwiseRef = useRef<{
+    variantA: string;
+    variantB: string;
+    goldenField: string;
+    includeMetrics: ("cost" | "duration")[];
+  } | null>(null);
+
   // Track target being switched (null when adding new, target ID when switching)
   const switchingTargetIdRef = useRef<string | null>(null);
 
@@ -397,7 +406,7 @@ export function EvaluationsV3Table({
         outputs,
         mappings: {},
         ...(isPairwiseEvaluator && {
-          pairwise: {
+          pairwise: pendingPairwiseRef.current ?? {
             variantA: "",
             variantB: "",
             goldenField: "",
@@ -405,10 +414,20 @@ export function EvaluationsV3Table({
           },
         }),
       };
+      pendingPairwiseRef.current = null;
       addOrReplaceTarget(targetConfig);
-      closeDrawer();
+      // For pairwise-as-target, open the PairwiseConfigForm immediately so the
+      // user can configure Variant A / Variant B / Golden field without having
+      // to find and click the target chip again.
+      if (isPairwiseEvaluator) {
+        // openTargetEditor reads fresh store state, so the target we just added
+        // is visible when the drawer opens.
+        void openTargetEditor(targetConfig);
+      } else {
+        closeDrawer();
+      }
     },
-    [addOrReplaceTarget, closeDrawer],
+    [addOrReplaceTarget, closeDrawer, openTargetEditor],
   );
 
   // Handler for when a prompt is selected from the drawer
@@ -794,6 +813,21 @@ export function EvaluationsV3Table({
     setFlowCallbacks("evaluatorList", {
       onSelect: handleSelectEvaluatorAsTarget,
     });
+    // Build pairwiseContext so TargetTypeSelectorDrawer can pass it to
+    // evaluatorEditor when "Pairwise Compare" is selected — this makes the
+    // creation form show Variant A / Variant B / Golden field immediately,
+    // matching the edit-mode experience (see #5195).
+    pendingPairwiseRef.current = null;
+    const state = useEvaluationsV3Store.getState();
+    const variantOptions = state.targets.filter((t) => t.type !== "evaluator");
+    const activeDs = state.datasets.find((d) => d.id === state.activeDatasetId);
+    const pairwiseContext = {
+      initialPairwise: undefined,
+      targets: variantOptions,
+      datasetColumns:
+        activeDs?.columns.map((c) => ({ id: c.id, name: c.name })) ?? [],
+    };
+
     // Set up flow callback for when a NEW evaluator is created during the target flow
     // This handles: add comparison > evaluator > create new > category > fill form > create
     setFlowCallbacks(
@@ -815,9 +849,12 @@ export function EvaluationsV3Table({
           handleSelectEvaluatorAsTarget(evaluator);
           return true; // Indicate navigation was handled to prevent default back behavior
         },
+        onPairwiseChange: (next) => {
+          pendingPairwiseRef.current = next;
+        },
       }),
     );
-    openDrawer("targetTypeSelector");
+    openDrawer("targetTypeSelector", { pairwiseContext });
   }, [
     buildAvailableSources,
     openDrawer,
@@ -1351,9 +1388,7 @@ export function EvaluationsV3Table({
           {
             id: `pairwise.${evaluatorId}`,
             header: (context) => {
-              const meta = context.table.options.meta as
-                | TableMeta
-                | undefined;
+              const meta = context.table.options.meta as TableMeta | undefined;
               const evaluator = meta?.evaluatorsMap.get(evaluatorId);
               return (
                 <HStack gap={1}>
@@ -1365,9 +1400,7 @@ export function EvaluationsV3Table({
             },
             cell: (info) => {
               if (info.row.original.isEmpty) return null;
-              const meta = info.table.options.meta as
-                | TableMeta
-                | undefined;
+              const meta = info.table.options.meta as TableMeta | undefined;
               const variantATarget = meta?.targetsMap.get(variantAId);
               const variantBTarget = meta?.targetsMap.get(variantBId);
               const rowData = info.row.original.targets[variantAId];

--- a/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
+++ b/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
@@ -1190,9 +1190,10 @@ export function EvaluationsV3Table({
       (e) =>
         e.evaluatorType === "langevals/pairwise_compare" &&
         e.pairwise?.variantA &&
-        e.pairwise?.variantB,
+        e.pairwise?.variantB &&
+        e.pairwise?.goldenField,
     )
-    .map((e) => e.id)
+    .map((e) => `${e.id}:${e.pairwise?.variantA}:${e.pairwise?.variantB}`)
     .join(",");
   const stablePairwiseEvaluators = useMemo(
     () =>
@@ -1200,7 +1201,8 @@ export function EvaluationsV3Table({
         (e) =>
           e.evaluatorType === "langevals/pairwise_compare" &&
           e.pairwise?.variantA &&
-          e.pairwise?.variantB,
+          e.pairwise?.variantB &&
+          e.pairwise?.goldenField,
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [pairwiseEvaluatorsKey],

--- a/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
+++ b/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
@@ -68,6 +68,7 @@ import { createPromptEditorCallbacks } from "../utils/promptEditorCallbacks";
 import { ColumnTypeIcon } from "./ColumnTypeIcon";
 import { DatasetSuperHeader } from "./DatasetSuperHeader";
 import { EvaluationsV3DatasetTableProvider } from "./EvaluationsV3DatasetTableProvider";
+import { PairwiseCompareCell } from "./PairwiseCompareCell";
 import { SelectionToolbar } from "./SelectionToolbar";
 import {
   CheckboxCellFromMeta,
@@ -552,9 +553,40 @@ export function EvaluationsV3Table({
       // The first target provides the mapping context for the drawer.
       const firstTarget = state.targets[0];
 
+      if (!addedId || !added) {
+        closeDrawer();
+        return;
+      }
+
+      // Pairwise evaluators always open their dedicated target-picker form
+      // (PairwiseConfigForm), regardless of whether targets exist yet.
+      // useOpenEvaluatorEditor routes pairwise_compare to PairwiseConfigForm
+      // and ignores the `target` / `targetName` params, so we pass a stub
+      // when no real target exists yet.
+      if (added.evaluatorType === "langevals/pairwise_compare") {
+        const stubTarget: TargetConfig = firstTarget ?? {
+          id: "",
+          type: "prompt",
+          inputs: [],
+          outputs: [],
+          mappings: {},
+        };
+        openEvaluatorEditor({
+          evaluator: added,
+          target: stubTarget,
+          targetName: firstTarget
+            ? (resolveTargetNameFromCache({
+                target: firstTarget,
+                utils: trpcUtils,
+                projectId: project?.id,
+              }) ?? "")
+            : "",
+          isCodeEvaluator: false,
+        });
+        return;
+      }
+
       if (
-        addedId &&
-        added &&
         firstTarget &&
         evaluatorHasMissingMappings(
           added,
@@ -1093,6 +1125,29 @@ export function EvaluationsV3Table({
     [datasetColumnsKey],
   );
 
+  // Stabilize pairwise evaluators — only those with both variants configured.
+  // Only recreate columns when the set of configured pairwise evaluators changes.
+  const pairwiseEvaluatorsKey = evaluators
+    .filter(
+      (e) =>
+        e.evaluatorType === "langevals/pairwise_compare" &&
+        e.pairwise?.variantA &&
+        e.pairwise?.variantB,
+    )
+    .map((e) => e.id)
+    .join(",");
+  const stablePairwiseEvaluators = useMemo(
+    () =>
+      evaluators.filter(
+        (e) =>
+          e.evaluatorType === "langevals/pairwise_compare" &&
+          e.pairwise?.variantA &&
+          e.pairwise?.variantB,
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pairwiseEvaluatorsKey],
+  );
+
   // Build table meta for passing dynamic data to headers/cells
   // This allows column definitions to stay stable while data changes
   const targetsMap = useMemo(
@@ -1283,12 +1338,66 @@ export function EvaluationsV3Table({
       );
     }
 
+    // Dedicated pairwise result columns — one per fully-configured pairwise
+    // evaluator, rendered AFTER all target columns (Target A, Target B, Pairwise).
+    // The orchestrator anchors Phase-2 results on variantA's cell.
+    for (const pwEval of stablePairwiseEvaluators) {
+      const evaluatorId = pwEval.id;
+      const variantAId = pwEval.pairwise!.variantA;
+      const variantBId = pwEval.pairwise!.variantB;
+      cols.push(
+        columnHelper.accessor(
+          (row) => row.targets[variantAId]?.evaluators[evaluatorId],
+          {
+            id: `pairwise.${evaluatorId}`,
+            header: (context) => {
+              const meta = context.table.options.meta as
+                | TableMeta
+                | undefined;
+              const evaluator = meta?.evaluatorsMap.get(evaluatorId);
+              return (
+                <HStack gap={1}>
+                  <Text fontSize="13px" fontWeight="medium">
+                    🏆 {evaluator?.localEvaluatorConfig?.name ?? "Pairwise"}
+                  </Text>
+                </HStack>
+              );
+            },
+            cell: (info) => {
+              if (info.row.original.isEmpty) return null;
+              const meta = info.table.options.meta as
+                | TableMeta
+                | undefined;
+              const variantATarget = meta?.targetsMap.get(variantAId);
+              const variantBTarget = meta?.targetsMap.get(variantBId);
+              const rowData = info.row.original.targets[variantAId];
+              return (
+                <PairwiseCompareCell
+                  result={info.getValue()}
+                  isLoading={rowData?.isLoading}
+                  variantATarget={variantATarget}
+                  variantBTarget={variantBTarget}
+                />
+              );
+            },
+            size: TARGET_COL_DEFAULT_PCT,
+            minSize: 10,
+            meta: {
+              columnType: "pairwise" as ColumnType,
+              columnId: `pairwise.${evaluatorId}`,
+            },
+          },
+        ) as ColumnDef<TableRowData>,
+      );
+    }
+
     return cols;
   }, [
     // ONLY structural dependencies - columns should almost never change
     // All dynamic data goes through tableMeta
     targetIds,
     stableDatasetColumns,
+    stablePairwiseEvaluators,
     columnHelper,
   ]);
 

--- a/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
+++ b/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
@@ -1148,10 +1148,31 @@ export function EvaluationsV3Table({
   // Build columns - columnHelper is stable (useMemo to prevent recreating)
   const columnHelper = useMemo(() => createColumnHelper<TableRowData>(), []);
 
-  // Extract target IDs for stable column structure
-  // Only recreate when the actual IDs change, not when target data changes
-  const targetIdsKey = targets.map((r) => r.id).join(",");
-  const targetIds = useMemo(() => targets.map((r) => r.id), [targetIdsKey]);
+  // Extract target IDs for stable column structure.
+  // Sort so non-evaluator targets (prompts/agents) always precede evaluator
+  // targets (pairwise, custom evals) — giving the logical left-to-right order:
+  // Target A | Target B | Pairwise.
+  const targetIdsKey = targets
+    .slice()
+    .sort((a, b) => {
+      if (a.type === "evaluator" && b.type !== "evaluator") return 1;
+      if (a.type !== "evaluator" && b.type === "evaluator") return -1;
+      return 0;
+    })
+    .map((r) => r.id)
+    .join(",");
+  const targetIds = useMemo(
+    () =>
+      targets
+        .slice()
+        .sort((a, b) => {
+          if (a.type === "evaluator" && b.type !== "evaluator") return 1;
+          if (a.type !== "evaluator" && b.type === "evaluator") return -1;
+          return 0;
+        })
+        .map((r) => r.id),
+    [targetIdsKey],
+  );
 
   // Similarly stabilize dataset columns - include type in key so icon updates when type changes
   const datasetColumnsKey = datasetColumns

--- a/langwatch/src/experiments-v3/hooks/useEvaluationsV3Store.ts
+++ b/langwatch/src/experiments-v3/hooks/useEvaluationsV3Store.ts
@@ -560,6 +560,7 @@ const storeImpl: StateCreator<EvaluationsV3Store> = (set, get) => ({
       };
 
       // Also auto-map evaluator inputs for this new target
+      const newTargets = [...state.targets, targetWithMappings];
       const evaluatorsWithNewMappings = state.evaluators.map((evaluator) => {
         const newMappings = inferAllEvaluatorMappings(
           evaluator,
@@ -574,11 +575,32 @@ const storeImpl: StateCreator<EvaluationsV3Store> = (set, get) => ({
           }
           Object.assign(mergedMappings[datasetId]!, targetMappings);
         }
+
+        // Auto-wire pairwise variants when going from 1 → 2 targets.
+        // Guard: only fires at exactly 2 targets (3+ is ambiguous).
+        if (
+          evaluator.evaluatorType === "langevals/pairwise_compare" &&
+          evaluator.pairwise &&
+          newTargets.length === 2 &&
+          !evaluator.pairwise.variantA &&
+          !evaluator.pairwise.variantB
+        ) {
+          return {
+            ...evaluator,
+            mappings: mergedMappings,
+            pairwise: {
+              ...evaluator.pairwise,
+              variantA: state.targets[0]!.id,
+              variantB: targetWithMappings.id,
+            },
+          };
+        }
+
         return { ...evaluator, mappings: mergedMappings };
       });
 
       return {
-        targets: [...state.targets, targetWithMappings],
+        targets: newTargets,
         evaluators: evaluatorsWithNewMappings,
       };
     });
@@ -766,13 +788,33 @@ const storeImpl: StateCreator<EvaluationsV3Store> = (set, get) => ({
         state.datasets,
         state.targets,
       );
-      const evaluatorWithMappings = {
+      let evaluatorWithMappings = {
         ...evaluator,
         mappings: {
           ...evaluator.mappings,
           ...autoMappings,
         },
       };
+
+      // Auto-wire pairwise variants when exactly 2 targets already exist.
+      // Guard: only fires at exactly 2 targets (3+ is ambiguous, user configures manually).
+      if (
+        evaluatorWithMappings.evaluatorType === "langevals/pairwise_compare" &&
+        evaluatorWithMappings.pairwise &&
+        state.targets.length === 2 &&
+        !evaluatorWithMappings.pairwise.variantA &&
+        !evaluatorWithMappings.pairwise.variantB
+      ) {
+        evaluatorWithMappings = {
+          ...evaluatorWithMappings,
+          pairwise: {
+            ...evaluatorWithMappings.pairwise,
+            variantA: state.targets[0]!.id,
+            variantB: state.targets[1]!.id,
+          },
+        };
+      }
+
       return {
         evaluators: [...state.evaluators, evaluatorWithMappings],
       };


### PR DESCRIPTION
## Summary

Three pairwise UX fixes for the experiments-v3 workbench:

1. **Auto-wire variantA/variantB** — when there are exactly 2 non-evaluator targets in the workbench, the pairwise evaluator config is pre-populated with those targets so the user doesn't have to pick them manually.

2. **Dedicated 🏆 Pairwise column** — pairwise evaluators get their own column header (after target columns), separate from regular per-target evaluator chips.

3. **Same drawer for create and edit** — clicking "Add Comparison" → "Pairwise Compare" now shows the Variant A / Variant B / Golden field pickers in the creation drawer, identical to the edit experience. Previously the creation flow skipped the `PairwiseConfigForm` entirely.

## Screenshots

**Type selector — "Add Comparison" drawer:**
![type-selector](https://i.img402.dev/pkpydzvmvp.png)

**Creation drawer opens directly into Pairwise Compare with Variant A / Variant B / Golden field pickers:**
![pairwise-creation-drawer](https://i.img402.dev/qz2681v9a9.png)

**PairwiseConfigForm in creation drawer (scrolled):**
![pairwise-config-form](https://i.img402.dev/wvnoty4t8m.png)

## Implementation

- `EvaluationsV3Table.tsx` — `handleAddTarget` builds `pairwiseContext` (targets + datasetColumns) and passes it to `targetTypeSelector` via `complexProps`; `handleSelectEvaluatorAsTarget` uses `pendingPairwiseRef` to track pairwise config during creation and calls `openTargetEditor` (edit mode) after save so the full form is shown
- `TargetTypeSelectorDrawer.tsx` — forwards `pairwiseContext` from `complexProps` to `evaluatorEditor` when "Pairwise Compare" is selected
- `EvaluatorEditorShared.tsx` — already renders `PairwiseConfigForm` when `pairwiseContext` is set; no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for pairwise-compare evaluators, including guided setup that opens the pairwise configuration immediately after creation and preserves variant selections through target creation.
  * Pairwise results now render in dedicated table columns after normal target columns.
* **Bug Fixes**
  * Auto-linking for pairwise variantA/variantB now works reliably when targets are added in either order.
  * Improved V3 table stability by keeping consistent ordering so pairwise and non-pairwise views remain predictable.
  * Prevented misconfiguration by removing the unsupported “pairwise” column type from the dataset editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->