### PR TITLE
fix(translate): surface typed model errors instead of generic masking

### DIFF
--- a/langwatch/src/components/messages/MessageHoverActions.tsx
+++ b/langwatch/src/components/messages/MessageHoverActions.tsx
@@ -12,7 +12,9 @@ import type { Trace } from "../../server/tracer/types";
 import { api } from "../../utils/api";
 import { getExtractedInput } from "../../utils/traceExtraction";
 
+import { toaster } from "../ui/toaster";
 import { Tooltip } from "../ui/tooltip";
+import { shouldShowGenericTranslateError } from "./translationError";
 
 export const useTranslationState = () => {
   const [translatedTextInput, setTranslatedTextInput] = useState<string | null>(
@@ -107,13 +109,23 @@ export const MessageHoverActions = ({
         setTranslatedTextInput(inputData.translation);
         setTranslatedTextOutput(outputData.translation);
       })
-      .catch(() => {
-        // Revert the optimistic toggle. We deliberately don't raise a
-        // toast here: the typed-error toasts (missing model / provider
-        // disabled / AI call failed) are raised by the global tRPC error
-        // handler in utils/api.tsx. A generic "please try again" toast at
-        // this layer would shadow that actionable message.
+      .catch((error: unknown) => {
+        // Revert the optimistic toggle. The typed-error toasts (missing
+        // model / provider disabled / AI call failed) are raised by the
+        // global tRPC error handler in utils/api.tsx, so we only fall back
+        // to a generic toast when none of those matched — otherwise a
+        // non-typed failure (e.g. "Project not found", a DB error) would
+        // leave the user with no feedback at all.
         setTranslationActive(false);
+        if (shouldShowGenericTranslateError(error)) {
+          toaster.create({
+            title: "Error translating",
+            description:
+              "There was an error translating the message, please try again.",
+            type: "error",
+            meta: { closable: true },
+          });
+        }
       });
   };
 

--- a/langwatch/src/components/messages/MessageHoverActions.tsx
+++ b/langwatch/src/components/messages/MessageHoverActions.tsx
@@ -12,7 +12,6 @@ import type { Trace } from "../../server/tracer/types";
 import { api } from "../../utils/api";
 import { getExtractedInput } from "../../utils/traceExtraction";
 
-import { toaster } from "../ui/toaster";
 import { Tooltip } from "../ui/tooltip";
 
 export const useTranslationState = () => {
@@ -109,15 +108,12 @@ export const MessageHoverActions = ({
         setTranslatedTextOutput(outputData.translation);
       })
       .catch(() => {
-        toaster.create({
-          title: "Error translating",
-          description:
-            "There was an error translating the message, please try again.",
-          type: "error",
-          meta: {
-            closable: true,
-          },
-        });
+        // Revert the optimistic toggle. We deliberately don't raise a
+        // toast here: the typed-error toasts (missing model / provider
+        // disabled / AI call failed) are raised by the global tRPC error
+        // handler in utils/api.tsx. A generic "please try again" toast at
+        // this layer would shadow that actionable message.
+        setTranslationActive(false);
       });
   };
 

--- a/langwatch/src/components/messages/__tests__/translationError.unit.test.ts
+++ b/langwatch/src/components/messages/__tests__/translationError.unit.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  extractAiCallFailedInfo,
+  extractMissingModelInfo,
+  extractProviderDisabledInfo,
+} from "../../../utils/trpcError";
+import { shouldShowGenericTranslateError } from "../translationError";
+
+// The gating logic is what we own here; the extractors are a boundary
+// (tested in utils/trpcError). Mock them so we can prove the fallback fires
+// only when none matched.
+vi.mock("../../../utils/trpcError", () => ({
+  extractMissingModelInfo: vi.fn(),
+  extractAiCallFailedInfo: vi.fn(),
+  extractProviderDisabledInfo: vi.fn(),
+}));
+
+const allReturnNull = () => {
+  vi.mocked(extractMissingModelInfo).mockReturnValue(null);
+  vi.mocked(extractAiCallFailedInfo).mockReturnValue(null);
+  vi.mocked(extractProviderDisabledInfo).mockReturnValue(null);
+};
+
+describe("shouldShowGenericTranslateError()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allReturnNull();
+  });
+
+  describe("when no typed model-error handler matches", () => {
+    it("returns true so the caller shows a generic fallback toast", () => {
+      expect(
+        shouldShowGenericTranslateError(new Error("Project not found")),
+      ).toBe(true);
+    });
+  });
+
+  describe("when the missing-model handler already surfaces the failure", () => {
+    it("returns false so the toast is not duplicated", () => {
+      vi.mocked(extractMissingModelInfo).mockReturnValue({
+        featureKey: "translate.text",
+        featureDisplayName: "Inline translation",
+        role: "FAST",
+      });
+
+      expect(shouldShowGenericTranslateError({})).toBe(false);
+    });
+  });
+
+  describe("when the AI-call-failed handler already surfaces the failure", () => {
+    it("returns false so the toast is not duplicated", () => {
+      vi.mocked(extractAiCallFailedInfo).mockReturnValue({
+        featureKey: "translate.text",
+        featureDisplayName: "Inline translation",
+        role: "FAST",
+        errorMessage: "Invalid API key",
+      });
+
+      expect(shouldShowGenericTranslateError({})).toBe(false);
+    });
+  });
+
+  describe("when the provider-disabled handler already surfaces the failure", () => {
+    it("returns false so the toast is not duplicated", () => {
+      vi.mocked(extractProviderDisabledInfo).mockReturnValue({
+        featureKey: "translate.text",
+        featureDisplayName: "Inline translation",
+        role: "FAST",
+        projectId: "project_abc123",
+        resolvedScope: "project",
+        resolvedModel: "openai/gpt-5-mini",
+        providerKey: "openai",
+        alternate: null,
+      });
+
+      expect(shouldShowGenericTranslateError({})).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/components/messages/translationError.ts
+++ b/langwatch/src/components/messages/translationError.ts
@@ -1,0 +1,23 @@
+import {
+  extractAiCallFailedInfo,
+  extractMissingModelInfo,
+  extractProviderDisabledInfo,
+} from "../../utils/trpcError";
+
+/**
+ * Whether the inline-translation failure handler should raise its own
+ * generic fallback toast.
+ *
+ * The global tRPC error handler (utils/api.tsx) already raises an
+ * actionable toast for the typed model errors — missing model, provider
+ * disabled, AI call failed — so we must NOT add a second generic toast on
+ * top of those. But a non-typed failure (e.g. "Project not found", a DB
+ * error during model resolution) carries none of those causes, and the
+ * global handler stays silent — so without a fallback the user would click
+ * Translate and get no feedback at all. Return true only when none of the
+ * typed extractors matched.
+ */
+export const shouldShowGenericTranslateError = (error: unknown): boolean =>
+  !extractMissingModelInfo(error) &&
+  !extractAiCallFailedInfo(error) &&
+  !extractProviderDisabledInfo(error);

--- a/langwatch/src/server/api/routers/__tests__/translate.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/translate.unit.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PrismaClient } from "@prisma/client";
-import { translateRouter } from "../translate";
-import { createInnerTRPCContext } from "../../trpc";
-import { AiCallFailedError } from "../../../modelProviders/aiCallFailedError";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ModelNotConfiguredError } from "../../../modelProviders/modelNotConfiguredError";
+import { createInnerTRPCContext, errorFormatterForTesting } from "../../trpc";
+import { translateRouter } from "../translate";
 
 // Regression: translate previously hardcoded openai("gpt-4-turbo"), ignoring project model config
 // Regression: translate previously rewrapped every failure in a generic
@@ -121,38 +120,31 @@ describe("translateRouter.translate()", () => {
   });
 
   describe("when the model call fails", () => {
-    it("re-raises as BAD_REQUEST carrying a typed AI_CALL_FAILED cause so the frontend shows the actionable toast", async () => {
+    it("re-raises as BAD_REQUEST and serialises a typed AI_CALL_FAILED cause the toast can read", async () => {
       mockGenerateText.mockRejectedValue(
         new Error("Invalid API key: FAKE_KEY_FOR_TESTING"),
       );
 
-      await expect(
-        caller.translate({
-          projectId: "project_abc123",
-          textToTranslate: "Hola",
-        }),
-      ).rejects.toMatchObject({
-        code: "BAD_REQUEST",
-        cause: {
-          cause: "AI_CALL_FAILED",
-          featureKey: "translate.text",
-          // The provider message is surfaced (truncated) so the failure
-          // is diagnosable — the whole point of the fix.
-          originalErrorMessage:
-            expect.stringContaining("FAKE_KEY_FOR_TESTING"),
-        },
-      });
-    });
+      const error = await caller
+        .translate({ projectId: "project_abc123", textToTranslate: "Hola" })
+        .then(() => null)
+        .catch((e: unknown) => e);
 
-    it("wraps generateText failures in AiCallFailedError before the middleware re-raises them", () => {
-      // Guard the discriminator the wire contract above depends on.
-      const err = new AiCallFailedError(
-        "translate.text",
-        "FAST",
-        "Inline translation",
-        "boom",
-      );
-      expect(err.cause).toBe("AI_CALL_FAILED");
+      expect(error).toMatchObject({ code: "BAD_REQUEST" });
+
+      // Assert the *serialised* wire shape (error.data.cause) the frontend
+      // extractor in utils/trpcError.ts::extractAiCallFailedInfo reads — not
+      // the raw class property — so this fails if the formatter stops
+      // emitting the field the toast consumes.
+      const wire = errorFormatterForTesting({
+        shape: { data: {} },
+        error: error as { cause?: unknown },
+      });
+      expect(wire.data.cause).toMatchObject({
+        code: "AI_CALL_FAILED",
+        featureKey: "translate.text",
+        errorMessage: expect.stringContaining("FAKE_KEY_FOR_TESTING"),
+      });
     });
   });
 

--- a/langwatch/src/server/api/routers/__tests__/translate.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/translate.unit.test.ts
@@ -2,8 +2,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PrismaClient } from "@prisma/client";
 import { translateRouter } from "../translate";
 import { createInnerTRPCContext } from "../../trpc";
+import { AiCallFailedError } from "../../../modelProviders/aiCallFailedError";
+import { ModelNotConfiguredError } from "../../../modelProviders/modelNotConfiguredError";
 
 // Regression: translate previously hardcoded openai("gpt-4-turbo"), ignoring project model config
+// Regression: translate previously rewrapped every failure in a generic
+// INTERNAL_SERVER_ERROR ("Check model provider configuration"), stripping
+// the typed cause so the frontend could only show "please try again". It
+// must now surface typed model errors so the global tRPC handler raises the
+// actionable toast (missing model / provider disabled / AI call failed).
 
 const mockGetVercelAIModel = vi.fn();
 vi.mock("../../../modelProviders/utils", () => ({
@@ -114,9 +121,10 @@ describe("translateRouter.translate()", () => {
   });
 
   describe("when the model call fails", () => {
-    it("throws a TRPCError with a generic message that hides upstream details", async () => {
-      const underlyingError = new Error("Invalid API key: FAKE_KEY_FOR_TESTING");
-      mockGenerateText.mockRejectedValue(underlyingError);
+    it("re-raises as BAD_REQUEST carrying a typed AI_CALL_FAILED cause so the frontend shows the actionable toast", async () => {
+      mockGenerateText.mockRejectedValue(
+        new Error("Invalid API key: FAKE_KEY_FOR_TESTING"),
+      );
 
       await expect(
         caller.translate({
@@ -124,45 +132,37 @@ describe("translateRouter.translate()", () => {
           textToTranslate: "Hola",
         }),
       ).rejects.toMatchObject({
-        code: "INTERNAL_SERVER_ERROR",
-        message:
-          "Failed to get translation. Check model provider configuration.",
+        code: "BAD_REQUEST",
+        cause: {
+          cause: "AI_CALL_FAILED",
+          featureKey: "translate.text",
+          // The provider message is surfaced (truncated) so the failure
+          // is diagnosable — the whole point of the fix.
+          originalErrorMessage:
+            expect.stringContaining("FAKE_KEY_FOR_TESTING"),
+        },
       });
     });
 
-    it("does not leak the upstream error message to the client", async () => {
-      const underlyingError = new Error("Invalid API key: FAKE_KEY_FOR_TESTING");
-      mockGenerateText.mockRejectedValue(underlyingError);
-
-      await expect(
-        caller.translate({
-          projectId: "project_abc123",
-          textToTranslate: "Hola",
-        }),
-      ).rejects.toMatchObject({
-        message: expect.not.stringContaining("FAKE_KEY_FOR_TESTING"),
-      });
-    });
-
-    it("includes the original error as cause for server-side debugging", async () => {
-      const underlyingError = new Error("Rate limit exceeded");
-      mockGenerateText.mockRejectedValue(underlyingError);
-
-      await expect(
-        caller.translate({
-          projectId: "project_abc123",
-          textToTranslate: "Hola",
-        }),
-      ).rejects.toMatchObject({
-        cause: underlyingError,
-      });
+    it("wraps generateText failures in AiCallFailedError before the middleware re-raises them", () => {
+      // Guard the discriminator the wire contract above depends on.
+      const err = new AiCallFailedError(
+        "translate.text",
+        "FAST",
+        "Inline translation",
+        "boom",
+      );
+      expect(err.cause).toBe("AI_CALL_FAILED");
     });
   });
 
-  describe("when getVercelAIModel fails", () => {
-    it("throws a TRPCError with a generic message and preserves cause", async () => {
-      const modelError = new Error(
-        "Model provider openai not configured or disabled for project",
+  describe("when the model cannot be resolved", () => {
+    it("propagates a typed MODEL_NOT_CONFIGURED cause to its own toast surface", async () => {
+      const modelError = new ModelNotConfiguredError(
+        "translate.text",
+        "FAST",
+        "Inline translation",
+        "project_abc123",
       );
       mockGetVercelAIModel.mockRejectedValue(modelError);
 
@@ -172,10 +172,11 @@ describe("translateRouter.translate()", () => {
           textToTranslate: "Hola",
         }),
       ).rejects.toMatchObject({
-        code: "INTERNAL_SERVER_ERROR",
-        message:
-          "Failed to get translation. Check model provider configuration.",
-        cause: modelError,
+        code: "BAD_REQUEST",
+        cause: {
+          cause: "MODEL_NOT_CONFIGURED",
+          featureKey: "translate.text",
+        },
       });
     });
   });

--- a/langwatch/src/server/api/routers/__tests__/translate.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/translate.unit.test.ts
@@ -1,6 +1,7 @@
 import type { PrismaClient } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ModelNotConfiguredError } from "../../../modelProviders/modelNotConfiguredError";
+import { ModelProviderDisabledError } from "../../../modelProviders/modelProviderDisabledError";
 import { createInnerTRPCContext, errorFormatterForTesting } from "../../trpc";
 import { translateRouter } from "../translate";
 
@@ -169,6 +170,41 @@ describe("translateRouter.translate()", () => {
           cause: "MODEL_NOT_CONFIGURED",
           featureKey: "translate.text",
         },
+      });
+    });
+
+    it("propagates a typed MODEL_PROVIDER_DISABLED cause to its own toast surface", async () => {
+      const modelError = new ModelProviderDisabledError(
+        "translate.text",
+        "Inline translation",
+        "FAST",
+        "project_abc123",
+        "project",
+        "openai/gpt-5-mini",
+        "openai",
+        null,
+      );
+      mockGetVercelAIModel.mockRejectedValue(modelError);
+
+      const error = await caller
+        .translate({ projectId: "project_abc123", textToTranslate: "Hola" })
+        .then(() => null)
+        .catch((e: unknown) => e);
+
+      expect(error).toMatchObject({ code: "BAD_REQUEST" });
+
+      // Serialised wire shape the frontend extractor reads — proves the
+      // typed error reaches domainErrorMiddleware untouched (the claim the
+      // translate.ts comment makes) instead of being mis-tagged as an
+      // AI_CALL_FAILED or flattened to a generic 500.
+      const wire = errorFormatterForTesting({
+        shape: { data: {} },
+        error: error as { cause?: unknown },
+      });
+      expect(wire.data.cause).toMatchObject({
+        code: "MODEL_PROVIDER_DISABLED",
+        featureKey: "translate.text",
+        providerKey: "openai",
       });
     });
   });

--- a/langwatch/src/server/api/routers/translate.ts
+++ b/langwatch/src/server/api/routers/translate.ts
@@ -1,11 +1,14 @@
 import { TRPCError } from "@trpc/server";
 import { generateText } from "ai";
 import { z } from "zod";
+import { createLogger } from "~/utils/logger/server";
 import { wrapAiCall } from "../../modelProviders/aiCallFailedError";
 import { featureByKey } from "../../modelProviders/featureRegistry";
 import { getVercelAIModel } from "../../modelProviders/utils";
 import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+const logger = createLogger("langwatch:translate");
 
 const TRANSLATE_FEATURE_KEY = "translate.text";
 
@@ -44,13 +47,24 @@ export const translateRouter = createTRPCRouter({
 
       // Any provider/SDK failure during the call surfaces as a typed
       // AiCallFailedError → "double-check your model configuration" toast
-      // carrying the real (truncated) provider error message.
-      const { text } = await wrapAiCall(feature, async () =>
-        generateText({
-          model,
-          prompt: `Translate the following text to English only reply with the translated text, do not include any other text: ${input.textToTranslate}`,
-        }),
-      );
+      // carrying the real (truncated) provider error message. wrapAiCall
+      // truncates that message to the first line for the client, so log the
+      // FULL underlying error server-side first — the later lines (provider
+      // status bodies, gateway 404 detail) are what we need for prod triage.
+      const { text } = await wrapAiCall(feature, async () => {
+        try {
+          return await generateText({
+            model,
+            prompt: `Translate the following text to English only reply with the translated text, do not include any other text: ${input.textToTranslate}`,
+          });
+        } catch (error) {
+          logger.error(
+            { error, projectId: input.projectId },
+            "Translation model call failed",
+          );
+          throw error;
+        }
+      });
 
       return { translation: text };
     }),

--- a/langwatch/src/server/api/routers/translate.ts
+++ b/langwatch/src/server/api/routers/translate.ts
@@ -29,12 +29,14 @@ export const translateRouter = createTRPCRouter({
 
       // Don't wrap everything in a generic INTERNAL_SERVER_ERROR — that
       // strips the typed `cause` the frontend needs and the user only ever
-      // sees "please try again". Resolve the model OUTSIDE wrapAiCall so
-      // model-resolution failures (ModelNotConfiguredError /
-      // ModelProviderDisabledError) propagate untouched to their own toast
-      // surfaces via domainErrorMiddleware — wrapAiCall only passes
-      // ModelNotConfiguredError through, so wrapping resolution too would
-      // mis-tag a disabled provider as an AI_CALL_FAILED.
+      // sees "please try again". Resolve the model OUTSIDE wrapAiCall: the
+      // cascade resolver (resolveModelForFeature) throws the typed
+      // ModelNotConfiguredError when nothing is set and
+      // ModelProviderDisabledError when the resolved FAST model's provider
+      // is disabled, and both must reach domainErrorMiddleware untouched to
+      // open their own toasts. wrapAiCall only passes ModelNotConfiguredError
+      // through, so resolving inside it would mis-tag a disabled provider as
+      // an AI_CALL_FAILED.
       const model = await getVercelAIModel({
         projectId: input.projectId,
         featureKey: TRANSLATE_FEATURE_KEY,

--- a/langwatch/src/server/api/routers/translate.ts
+++ b/langwatch/src/server/api/routers/translate.ts
@@ -1,12 +1,13 @@
 import { TRPCError } from "@trpc/server";
 import { generateText } from "ai";
 import { z } from "zod";
+import { wrapAiCall } from "../../modelProviders/aiCallFailedError";
+import { featureByKey } from "../../modelProviders/featureRegistry";
 import { getVercelAIModel } from "../../modelProviders/utils";
-import { createLogger } from "~/utils/logger/server";
 import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
-const logger = createLogger("langwatch:translate");
+const TRANSLATE_FEATURE_KEY = "translate.text";
 
 export const translateRouter = createTRPCRouter({
   translate: protectedProcedure
@@ -18,25 +19,37 @@ export const translateRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("triggers:view"))
     .mutation(async ({ input }) => {
-      try {
-        const model = await getVercelAIModel({ projectId: input.projectId, featureKey: "translate.text" });
-        const response: { text: string } = await generateText({
-          model,
-          prompt: `Translate the following text to English only reply with the translated text, do not include any other text: ${input.textToTranslate}`,
-        });
-        const { text } = response;
-        return { translation: text };
-      } catch (error) {
-        logger.error(
-          { error, projectId: input.projectId },
-          "Failed to get translation",
-        );
+      const feature = featureByKey(TRANSLATE_FEATURE_KEY);
+      if (!feature) {
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
-          message:
-            "Failed to get translation. Check model provider configuration.",
-          cause: error,
+          message: `${TRANSLATE_FEATURE_KEY} feature is not registered`,
         });
       }
+
+      // Don't wrap everything in a generic INTERNAL_SERVER_ERROR — that
+      // strips the typed `cause` the frontend needs and the user only ever
+      // sees "please try again". Resolve the model OUTSIDE wrapAiCall so
+      // model-resolution failures (ModelNotConfiguredError /
+      // ModelProviderDisabledError) propagate untouched to their own toast
+      // surfaces via domainErrorMiddleware — wrapAiCall only passes
+      // ModelNotConfiguredError through, so wrapping resolution too would
+      // mis-tag a disabled provider as an AI_CALL_FAILED.
+      const model = await getVercelAIModel({
+        projectId: input.projectId,
+        featureKey: TRANSLATE_FEATURE_KEY,
+      });
+
+      // Any provider/SDK failure during the call surfaces as a typed
+      // AiCallFailedError → "double-check your model configuration" toast
+      // carrying the real (truncated) provider error message.
+      const { text } = await wrapAiCall(feature, async () =>
+        generateText({
+          model,
+          prompt: `Translate the following text to English only reply with the translated text, do not include any other text: ${input.textToTranslate}`,
+        }),
+      );
+
+      return { translation: text };
     }),
 });


### PR DESCRIPTION
## What

Inline **Translate** (Trace Details → message hover) failed with a generic *"There was an error translating the message, please try again."* and **no actionable detail** — even though the platform already has typed-error toasts (missing model / provider disabled / AI call failed) that every other AI feature uses.

Closes #5197.

## Root cause — double error-masking

The translate path bypassed the typed model-error system at two layers:

1. **Backend** (`translate.ts`) — a `try/catch` rewrapped *every* error into a generic `INTERNAL_SERVER_ERROR`, discarding the typed `cause`.
2. **Frontend** (`MessageHoverActions.tsx`) — a bare `.catch()` threw away even that and showed a hardcoded toast, so the global tRPC handler in `utils/api.tsx` never fired.

Confirmed from a customer report: the wire payload had `cause: null, domainError: null, code: INTERNAL_SERVER_ERROR`.

## Fix

Route translate through the existing typed-error infra (mirrors `workflows.commit_message`):

- Resolve the model **outside** `wrapAiCall` so `ModelNotConfiguredError` / `ModelProviderDisabledError` propagate untouched to their own toast surfaces via `domainErrorMiddleware` (`wrapAiCall` only passes `ModelNotConfiguredError` through, so wrapping resolution would mis-tag a disabled provider as `AI_CALL_FAILED`).
- Wrap **only** the `generateText` call so provider/SDK failures surface as a typed `AiCallFailedError` carrying the real (truncated) provider message → "double-check your model configuration" toast.
- Drop the frontend bare-catch toast; just revert the optimistic toggle and let the global handler raise the actionable toast.

## Scope / what this does NOT do

This is a **visibility** fix. It makes the *real* provider failure diagnosable in the UI; it does **not** cure the underlying provider error itself. For the reporting project the model resolved and the provider call failed (~6.2s elapsed → not a config-missing fast-fail) — likely a bad/expired key, disabled provider, or gateway `api-version` 404. Post-deploy the correct toast will name it; we follow up from there.

## Tests

`translate.unit.test.ts` rewritten to assert the new contract:
- model-call failure → `BAD_REQUEST` with typed `AI_CALL_FAILED` cause + the truncated provider message surfaced
- `ModelNotConfiguredError` → `BAD_REQUEST` with typed `MODEL_NOT_CONFIGURED` cause
- success path unchanged

All 5 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Translation failures now surface clearer, typed error details to the client instead of generic messaging.
  * Translation UI no longer shows duplicate/over-eager fallback toasts; it only displays a generic error when a typed handler doesn’t apply.
  * If translation fails, the optimistic “translated” state is now reliably reverted.
  * Translation model/provider issues are reported with more specific, user-facing error causes.
* **Tests**
  * Updated translation mutation unit tests to validate typed error causes and messages.
  * Added unit tests for the generic-translate-error fallback decision logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->