### PR TITLE
test(typescript-sdk): narrow spanProcessors shutdown catch to expected export error

### DIFF
--- a/typescript-sdk/src/observability-sdk/setup/node/__tests__/integration/setup-config-options.integration.test.ts
+++ b/typescript-sdk/src/observability-sdk/setup/node/__tests__/integration/setup-config-options.integration.test.ts
@@ -165,8 +165,20 @@ describe('setupObservability Integration - Configuration Options', () => {
     span.end();
     await new Promise(resolve => setTimeout(resolve, 50));
     expect(onEndSpy).toHaveBeenCalled();
-    // Shutdown may throw network errors from the LangWatch exporter — ignore them.
-    await handle.shutdown().catch((_e) => undefined);
+    // Shutdown flushes the ended span through the default LangWatch exporter,
+    // which fails to reach the fake endpoint. Tolerate only that expected
+    // export/network failure — anything else (e.g. a broken spanProcessors
+    // teardown path) must still fail the test.
+    await handle.shutdown().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        !/export failed|otlp|enotfound|econnrefused|getaddrinfo|fetch failed|network/i.test(
+          message,
+        )
+      ) {
+        throw error;
+      }
+    });
   });
 
   // For options that cannot be directly inspected, keep logger or side-effect checks


### PR DESCRIPTION
## What this does

Narrows the `spanProcessors` integration test's shutdown error handling so it only swallows the **expected** export/network failure, not every error.

## Why

`setup-config-options.integration.test.ts > should use spanProcessors if provided` ends a real span, so `handle.shutdown()` flushes it through the default LangWatch exporter and throws reaching the fake endpoint. The existing handling swallowed *any* shutdown error, which would also mask a genuine regression in the `spanProcessors` teardown path (flagged by CodeRabbit). Now it rethrows anything that isn't an export/network failure.

## Scope note

This PR originally bundled fixes for all three pre-existing `sdk-javascript-ci` failures on `main` (the `@ai-sdk/openai@4.x` peer-deps canary, the OTLP flake, and the e2e `StorageNotWritable` storage path). **Those all landed independently on `main` via the 3.5.0 release** — after rebasing, git dropped the peer-deps/lockfile/e2e commits as already-upstream. What remains is this single test-quality improvement, which supersedes main's broader `.catch(() => undefined)` on the same test.

## Tests

`setup-config-options.integration.test.ts` green locally (30 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the integration test shutdown handling to ignore expected export/network-related failures while still surfacing unexpected teardown issues.
  * This makes the test more reliable without hiding genuine problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->