### PR TITLE
fix(batch-eval): guard runs query until experiment resolves

### DIFF
--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
@@ -211,7 +211,7 @@ export function BatchEvaluationResults({
       runId: selectedRunId ?? "",
     },
     {
-      enabled: !!selectedRunId,
+      enabled: !!project && !!experiment && !!selectedRunId,
       refetchInterval: runDataRefetchInterval,
     },
   );

--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
@@ -18,13 +18,14 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { type Experiment, ExperimentType, type Project } from "@prisma/client";
-import { useRouter } from "~/utils/compat/next-router";
+import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { BarChart2, Download, ExternalLink } from "react-feather";
 
 import { Link } from "~/components/ui/link";
 import { useLiteMemberGuard } from "~/hooks/useLiteMemberGuard";
 import { api } from "~/utils/api";
+import { useRouter } from "~/utils/compat/next-router";
 import { PageLayout } from "../ui/layouts/PageLayout";
 import {
   BatchEvaluationResultsTable,
@@ -35,18 +36,14 @@ import { type BatchRunSummary, BatchRunsSidebar } from "./BatchRunsSidebar";
 import { ComparisonCharts, type XAxisOption } from "./ComparisonCharts";
 import { downloadCsv } from "./csvExport";
 import { getRunDisplayName } from "./getRunDisplayName";
+import { isRunFinished } from "./isRunFinished";
 import { TableSkeleton } from "./TableSkeleton";
 import {
   type BatchEvaluationData,
   transformBatchEvaluationData,
 } from "./types";
 import { useComparisonMode } from "./useComparisonMode";
-import { isRunFinished } from "./isRunFinished";
-import {
-  RUN_COLORS,
-  useMultiRunData,
-} from "./useMultiRunData";
-import React from "react";
+import { RUN_COLORS, useMultiRunData } from "./useMultiRunData";
 
 type BatchEvaluationResultsProps = {
   project?: Project;
@@ -102,6 +99,7 @@ export function BatchEvaluationResults({
       experimentId: experiment?.id ?? "",
     },
     {
+      enabled: !!project && !!experiment,
       refetchInterval: isSomeRunning ? 3000 : 10000,
     },
   );
@@ -408,9 +406,7 @@ export function BatchEvaluationResults({
   const runColors = stableRunColorMap;
 
   // Find sidebar run for selected
-  const sidebarSelectedRun = sidebarRuns.find(
-    (r) => r.runId === selectedRunId,
-  );
+  const sidebarSelectedRun = sidebarRuns.find((r) => r.runId === selectedRunId);
 
   // CSV download - using the new V3 export that properly handles multi-target data
   const handleDownloadCSV = useCallback(() => {
@@ -457,20 +453,35 @@ export function BatchEvaluationResults({
       </Box>
 
       {/* Main content - flex column that fills available space */}
-      <VStack flex={1} minWidth={0} height="full" gap={0} align="stretch" overflow="auto">
+      <VStack
+        flex={1}
+        minWidth={0}
+        height="full"
+        gap={0}
+        align="stretch"
+        overflow="auto"
+      >
         {/* Header - fixed height */}
         <PageLayout.Header paddingX={2} withBorder={false} flexShrink={0}>
           <HStack gap={1} minWidth={0} overflow="hidden" flexShrink={1}>
             <Heading whiteSpace="nowrap" flexShrink={0}>
               {experiment ? (
-                experiment.name ?? experiment.slug
+                (experiment.name ?? experiment.slug)
               ) : (
                 <Skeleton width="200px" height="28px" />
               )}
             </Heading>
             {experiment && sidebarSelectedRun && (
-              <Text textStyle={"xs"} color={"fg.muted"} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis" flexShrink={1} minWidth={0}>
-                {'// '}
+              <Text
+                textStyle={"xs"}
+                color={"fg.muted"}
+                whiteSpace="nowrap"
+                overflow="hidden"
+                textOverflow="ellipsis"
+                flexShrink={1}
+                minWidth={0}
+              >
+                {"// "}
                 {sidebarSelectedRun.runId}
               </Text>
             )}

--- a/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResults.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResults.test.tsx
@@ -19,7 +19,6 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Component, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExperimentRunWithItems } from "~/server/experiments-v3/services/types";
 import { BatchEvaluationResults } from "../BatchEvaluationResults";
@@ -902,42 +901,31 @@ describe.skip("BatchEvaluationResults Integration", () => {
 /**
  * Regression guard for issue #5196.
  *
- * The runs query (api.experiments.getExperimentBatchEvaluationRuns.useQuery)
- * must NOT fire until both `project` and `experiment` are resolved. Without an
- * `enabled` guard the query fires with an empty experimentId before the
- * experiment loads, and the backend returns 404 NOT_FOUND
- * ("Experiment not found: "). Two sibling call-sites already guard this the
- * same way (BatchEvaluationV2.tsx and experiments-v3 HistoryButton.tsx).
+ * Both batch-evaluation queries must NOT fire until `project` and `experiment`
+ * are resolved. Without an `enabled` guard they fire with an empty
+ * experimentId before the experiment loads, and the backend returns 404
+ * NOT_FOUND ("Experiment not found: "). Two sibling call-sites already guard
+ * the runs query the same way (BatchEvaluationV2.tsx and experiments-v3
+ * HistoryButton.tsx).
  *
- * These tests assert on the OPTIONS argument the component passes to useQuery
- * rather than on rendered output: the runs query is invoked early in render
- * (before any child renders), so its recorded call args are available even
- * though the full integration suite above is skipped due to an unrelated jsdom
- * render crash. The few hooks that run ahead of it (useLiteMemberGuard, the
- * router, useMultiRunData) are mocked above so render reaches the query; an
- * error boundary then guards against any later crash masking the assertion.
+ *   - getExperimentBatchEvaluationRuns (plural, "runs query"): guarded by
+ *     `!!project && !!experiment`.
+ *   - getExperimentBatchEvaluationRun (singular, "run-data query"): on a
+ *     deep-link (?runId=X) the selected run id resolves from the router/prop
+ *     BEFORE `experiment` loads, so `!!selectedRunId` alone is not enough — it
+ *     must also require `!!project && !!experiment`.
+ *
+ * These tests assert on the OPTIONS argument each query receives rather than on
+ * rendered output: both queries are invoked early in render (before any child
+ * renders), so their recorded call args are available even though the full
+ * integration suite above is skipped due to an unrelated jsdom render crash.
+ * The hooks that run ahead of them (useLiteMemberGuard, the router,
+ * useMultiRunData) are mocked above so render reaches both query call-sites.
  */
-class RenderBoundary extends Component<
-  { children: ReactNode },
-  { hasError: boolean }
-> {
-  state = { hasError: false };
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-  componentDidCatch() {
-    // Swallow: the runs-query hook has already been invoked by the time any
-    // downstream render error is thrown. We only care about its call args.
-  }
-  render() {
-    return this.state.hasError ? null : this.props.children;
-  }
-}
-
-describe("BatchEvaluationResults runs-query enabled guard (#5196)", () => {
+describe("given the BatchEvaluationResults batch-evaluation queries (#5196)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Benign loading state so the component does not depend on runs data.
+    // Benign loading state so the component does not depend on query data.
     vi.mocked(
       api.experiments.getExperimentBatchEvaluationRuns.useQuery,
     ).mockReturnValue({
@@ -962,7 +950,7 @@ describe("BatchEvaluationResults runs-query enabled guard (#5196)", () => {
     cleanup();
   });
 
-  /** Options object passed to the runs query on its first invocation. */
+  /** Options object passed to the runs (plural) query on its first invocation. */
   const runsQueryOptions = () => {
     const mock = vi.mocked(
       api.experiments.getExperimentBatchEvaluationRuns.useQuery,
@@ -971,42 +959,90 @@ describe("BatchEvaluationResults runs-query enabled guard (#5196)", () => {
     return mock.mock.calls[0]?.[1] as { enabled?: boolean } | undefined;
   };
 
-  it("disables the runs query when experiment is undefined", () => {
-    render(
-      <RenderBoundary>
-        <BatchEvaluationResults project={mockProject} experiment={undefined} />
-      </RenderBoundary>,
-      { wrapper: Wrapper },
+  /** Options object passed to the run-data (singular) query on first invocation. */
+  const runDataQueryOptions = () => {
+    const mock = vi.mocked(
+      api.experiments.getExperimentBatchEvaluationRun.useQuery,
     );
+    expect(mock).toHaveBeenCalled();
+    return mock.mock.calls[0]?.[1] as { enabled?: boolean } | undefined;
+  };
 
-    expect(runsQueryOptions()?.enabled).toBeFalsy();
+  describe("the runs query (getExperimentBatchEvaluationRuns, plural)", () => {
+    describe("when experiment is undefined", () => {
+      it("is disabled", () => {
+        render(
+          <BatchEvaluationResults
+            project={mockProject}
+            experiment={undefined}
+          />,
+          { wrapper: Wrapper },
+        );
+
+        expect(runsQueryOptions()?.enabled).toBeFalsy();
+      });
+    });
+
+    describe("when project is undefined", () => {
+      it("is disabled", () => {
+        render(
+          <BatchEvaluationResults
+            project={undefined}
+            experiment={mockExperiment}
+          />,
+          { wrapper: Wrapper },
+        );
+
+        expect(runsQueryOptions()?.enabled).toBeFalsy();
+      });
+    });
+
+    describe("when both project and experiment are set", () => {
+      it("is enabled", () => {
+        render(
+          <BatchEvaluationResults
+            project={mockProject}
+            experiment={mockExperiment}
+          />,
+          { wrapper: Wrapper },
+        );
+
+        expect(runsQueryOptions()?.enabled).toBe(true);
+      });
+    });
   });
 
-  it("disables the runs query when project is undefined", () => {
-    render(
-      <RenderBoundary>
-        <BatchEvaluationResults
-          project={undefined}
-          experiment={mockExperiment}
-        />
-      </RenderBoundary>,
-      { wrapper: Wrapper },
-    );
+  describe("the run-data query (getExperimentBatchEvaluationRun, singular)", () => {
+    describe("when deep-linked to a run before the experiment loads (experiment undefined, selectedRunId present)", () => {
+      it("is disabled", () => {
+        // Simulate ?runId=X resolving via the external prop before `experiment`
+        // is available: selectedRunId is truthy yet experiment is undefined.
+        render(
+          <BatchEvaluationResults
+            project={mockProject}
+            experiment={undefined}
+            selectedRunId="deep-linked-run"
+          />,
+          { wrapper: Wrapper },
+        );
 
-    expect(runsQueryOptions()?.enabled).toBeFalsy();
-  });
+        expect(runDataQueryOptions()?.enabled).toBeFalsy();
+      });
+    });
 
-  it("enables the runs query when both project and experiment are set", () => {
-    render(
-      <RenderBoundary>
-        <BatchEvaluationResults
-          project={mockProject}
-          experiment={mockExperiment}
-        />
-      </RenderBoundary>,
-      { wrapper: Wrapper },
-    );
+    describe("when project, experiment, and a selected run are all set", () => {
+      it("is enabled", () => {
+        render(
+          <BatchEvaluationResults
+            project={mockProject}
+            experiment={mockExperiment}
+            selectedRunId="swift-bright-fox"
+          />,
+          { wrapper: Wrapper },
+        );
 
-    expect(runsQueryOptions()?.enabled).toBe(true);
+        expect(runDataQueryOptions()?.enabled).toBe(true);
+      });
+    });
   });
 });

--- a/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResults.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResults.test.tsx
@@ -19,6 +19,7 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Component, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExperimentRunWithItems } from "~/server/experiments-v3/services/types";
 import { BatchEvaluationResults } from "../BatchEvaluationResults";
@@ -60,6 +61,24 @@ vi.mock("~/utils/compat/next-router", () => ({
     push: vi.fn(),
     replace: vi.fn(),
   }),
+}));
+
+// Mock the multi-run comparison hook so the focused query-guard tests below can
+// render the component far enough to invoke its useQuery hooks without pulling in
+// the comparison data-fetching machinery.
+vi.mock("../useMultiRunData", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../useMultiRunData")>();
+  return {
+    ...actual,
+    useMultiRunData: vi.fn().mockReturnValue({ runs: [] }),
+  };
+});
+
+// Mock the lite-member guard. It runs (via useOrganizationTeamProject) before the
+// runs query and would otherwise call an unmocked tRPC hook, crashing render
+// before the query under test is ever invoked.
+vi.mock("~/hooks/useLiteMemberGuard", () => ({
+  useLiteMemberGuard: vi.fn().mockReturnValue({ isLiteMember: false }),
 }));
 
 // Import the mocked api
@@ -877,5 +896,117 @@ describe.skip("BatchEvaluationResults Integration", () => {
         expect(screen.getByTestId("exit-compare-button")).toBeInTheDocument();
       });
     });
+  });
+});
+
+/**
+ * Regression guard for issue #5196.
+ *
+ * The runs query (api.experiments.getExperimentBatchEvaluationRuns.useQuery)
+ * must NOT fire until both `project` and `experiment` are resolved. Without an
+ * `enabled` guard the query fires with an empty experimentId before the
+ * experiment loads, and the backend returns 404 NOT_FOUND
+ * ("Experiment not found: "). Two sibling call-sites already guard this the
+ * same way (BatchEvaluationV2.tsx and experiments-v3 HistoryButton.tsx).
+ *
+ * These tests assert on the OPTIONS argument the component passes to useQuery
+ * rather than on rendered output: the runs query is invoked early in render
+ * (before any child renders), so its recorded call args are available even
+ * though the full integration suite above is skipped due to an unrelated jsdom
+ * render crash. The few hooks that run ahead of it (useLiteMemberGuard, the
+ * router, useMultiRunData) are mocked above so render reaches the query; an
+ * error boundary then guards against any later crash masking the assertion.
+ */
+class RenderBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  componentDidCatch() {
+    // Swallow: the runs-query hook has already been invoked by the time any
+    // downstream render error is thrown. We only care about its call args.
+  }
+  render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
+describe("BatchEvaluationResults runs-query enabled guard (#5196)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Benign loading state so the component does not depend on runs data.
+    vi.mocked(
+      api.experiments.getExperimentBatchEvaluationRuns.useQuery,
+    ).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as unknown as ReturnType<
+      typeof api.experiments.getExperimentBatchEvaluationRuns.useQuery
+    >);
+    vi.mocked(
+      api.experiments.getExperimentBatchEvaluationRun.useQuery,
+    ).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<
+      typeof api.experiments.getExperimentBatchEvaluationRun.useQuery
+    >);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  /** Options object passed to the runs query on its first invocation. */
+  const runsQueryOptions = () => {
+    const mock = vi.mocked(
+      api.experiments.getExperimentBatchEvaluationRuns.useQuery,
+    );
+    expect(mock).toHaveBeenCalled();
+    return mock.mock.calls[0]?.[1] as { enabled?: boolean } | undefined;
+  };
+
+  it("disables the runs query when experiment is undefined", () => {
+    render(
+      <RenderBoundary>
+        <BatchEvaluationResults project={mockProject} experiment={undefined} />
+      </RenderBoundary>,
+      { wrapper: Wrapper },
+    );
+
+    expect(runsQueryOptions()?.enabled).toBeFalsy();
+  });
+
+  it("disables the runs query when project is undefined", () => {
+    render(
+      <RenderBoundary>
+        <BatchEvaluationResults
+          project={undefined}
+          experiment={mockExperiment}
+        />
+      </RenderBoundary>,
+      { wrapper: Wrapper },
+    );
+
+    expect(runsQueryOptions()?.enabled).toBeFalsy();
+  });
+
+  it("enables the runs query when both project and experiment are set", () => {
+    render(
+      <RenderBoundary>
+        <BatchEvaluationResults
+          project={mockProject}
+          experiment={mockExperiment}
+        />
+      </RenderBoundary>,
+      { wrapper: Wrapper },
+    );
+
+    expect(runsQueryOptions()?.enabled).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

`BatchEvaluationResults` fired `experiments.getExperimentBatchEvaluationRuns.useQuery` with an **empty `experimentId`** before the experiment resolved (page-load / navigation race), so the backend returned `404 NOT_FOUND` — surfacing `TRPCClientError: "Experiment not found: "` (trailing space = the empty id interpolated literally). Two sibling call-sites already guard this; this one was missing it.

Closes #5196

## What changed

- **Add `enabled: !!project && !!experiment` to the runs `useQuery` options** — mirrors the existing guard at `BatchEvaluationV2.tsx:195` and `experiments-v3/HistoryButton.tsx`; no request fires until both ids resolve. Chosen over defaulting the id or swallowing the 404 because the sibling guard is the established convention and keeps the query honest.
- **Falsifiability test on the query options** — asserts the runs query is disabled when `project`/`experiment` are unresolved and enabled when both are set.

## How it works

`BatchEvaluationResults.tsx:99-107` — the `useQuery` call already coalesced `experimentId` to `""`; the new `enabled` line short-circuits the query (TanStack Query skips disabled queries) until `project` **and** `experiment` are both truthy. No other behavior changes; `refetchInterval` is untouched.

## Human verification

1. Open a batch-evaluation results page via a navigation where the experiment id resolves after mount (deep-link / refresh on an experiment results page).
2. **Before:** the network tab shows a `getExperimentBatchEvaluationRuns` call with an empty `experimentId` returning 404, plus a `"Experiment not found: "` tRPC error.
3. **After:** no such call fires until both project and experiment resolve; the 404 is gone.

Or run the unit guard below.

## How I can prove I was successful

This is a **query-gating logic fix with no rendered-UI delta** (it suppresses a spurious background request on an unresolved-id race), so the proof is a **red→green falsifiability test** on the `useQuery` options the component passes — not a visual diff (backend-only: no user-visible rendering changes).

Scoped test: `node_modules/.bin/vitest run src/components/batch-evaluation-results/__tests__/BatchEvaluationResults.test.tsx`

**RED — guard absent** (the bug-catching case fails):
```
× enables the runs query when both project and experiment are set
AssertionError: expected undefined to be true // Object.is equality
- Expected: true
+ Received: undefined
  expect(runsQueryOptions()?.enabled).toBe(true);
Tests  1 failed | 2 passed | 19 skipped (22)
```

**GREEN — with the fix** (re-run on HEAD `53ae1746e`):
```
 Test Files  1 passed (1)
      Tests  3 passed | 19 skipped (22)
   Duration  5.73s
```

Typecheck clean (`tsgo --noEmit --project ./tsconfig.tsgo.json`, exit 0, nothing in `batch-evaluation-results`).

## Anything surprising?

The pre-existing `BatchEvaluationResults Integration` suite is `describe.skip` (unrelated jsdom mount crash predating this PR). The new guard test is a **separate non-skipped block** asserting on the `useQuery` options argument (available before child render) rather than rendered DOM — runs green without un-skipping the broken suite. The two "disables" cases pass vacuously on broken code (absent `enabled` is falsy); the **"enables when both set"** case is the real regression guard (the red→green case above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented batch evaluation results from loading until both the project and experiment are available, avoiding unnecessary requests and related errors.
  * Ensured the selected run’s details query only runs when a valid run ID is present along with the project and experiment.
* **Tests**
  * Added regression coverage to verify query enablement rules for both runs and selected run data.
* **Style**
  * Cleaned up import and layout formatting without changing the visible behavior of the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- no-ui-surface -->

