### PR TITLE
feat(api): add GET /api/me/usage — REST endpoint for personal spend/usage

### DIFF
--- a/langwatch/src/app/api/me/[[...route]]/app.ts
+++ b/langwatch/src/app/api/me/[[...route]]/app.ts
@@ -1,7 +1,7 @@
+import { PersonalUsageService } from "@ee/governance/services/personalUsage.service";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "hono-openapi";
 import { resolver, validator as zValidator } from "hono-openapi/zod";
-import { PersonalUsageService } from "@ee/governance/services/personalUsage.service";
 import {
   createProjectApp,
   requires,

--- a/langwatch/src/app/api/me/[[...route]]/app.ts
+++ b/langwatch/src/app/api/me/[[...route]]/app.ts
@@ -1,0 +1,96 @@
+import { HTTPException } from "hono/http-exception";
+import { describeRoute } from "hono-openapi";
+import { resolver, validator as zValidator } from "hono-openapi/zod";
+import { PersonalUsageService } from "@ee/governance/services/personalUsage.service";
+import {
+  createProjectApp,
+  requires,
+  type SecuredApp,
+} from "~/server/api/security";
+import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
+
+import type { AuthMiddlewareVariables } from "../../middleware/auth";
+import { baseResponses } from "../../shared/base-responses";
+import { meUsageQuerySchema, meUsageResponseSchema } from "./schemas";
+
+patchZodOpenapi();
+
+/**
+ * Hono app for /api/me — the personal-developer surface. Today it
+ * exposes a single read: GET /api/me/usage, the same spend / usage /
+ * model-breakdown payload the /me dashboard renders via the
+ * `api.user.personalUsage` tRPC procedure. Both entrypoints call the
+ * shared PersonalUsageService so the numbers stay identical across the
+ * web dashboard and any external client (desktop widget, CLI, CI).
+ *
+ * Auth: a project API key whose project is the caller's personal
+ * project (Project.isPersonal=true). The owner is resolved from
+ * Project.ownerUserId; usage is keyed by (personalProjectId, ownerUserId)
+ * exactly as the tRPC procedure keys it, so ingestion-source ledger
+ * traffic (Claude Code OTLP, etc.) is unioned in the same way.
+ */
+const secured = createProjectApp({ basePath: "/api/me" });
+
+registerMeRoutes(secured);
+
+export function registerMeRoutes(
+  secured: SecuredApp<{ Variables: AuthMiddlewareVariables }>,
+): void {
+  secured.access(requires("project:view")).get(
+    "/usage",
+    describeRoute({
+      description:
+        "Personal AI usage for the current month (or an explicit window): spend, billed spend, request + token counts, per-day buckets, and per-model breakdown. Requires a personal-project API key.",
+      responses: {
+        ...baseResponses,
+        200: {
+          description: "Success",
+          content: {
+            "application/json": {
+              schema: resolver(meUsageResponseSchema),
+            },
+          },
+        },
+      },
+    }),
+    zValidator("query", meUsageQuerySchema),
+    async (c) => {
+      const project = c.get("project");
+
+      // /api/me/usage is principal-scoped: it only makes sense for a
+      // personal project, where ownerUserId identifies whose usage to
+      // roll up. A shared/team project key has no single owner, so we
+      // reject it rather than guess.
+      if (!project.isPersonal || !project.ownerUserId) {
+        throw new HTTPException(400, {
+          message:
+            "GET /api/me/usage requires a personal-project API key (Project.isPersonal must be true). Use the API key from your personal workspace.",
+        });
+      }
+
+      const { windowStartMs, windowEndMs } = c.req.valid("query");
+      const window =
+        windowStartMs !== undefined && windowEndMs !== undefined
+          ? { start: new Date(windowStartMs), end: new Date(windowEndMs) }
+          : undefined;
+
+      const usage = new PersonalUsageService();
+      const input = {
+        personalProjectId: project.id,
+        userId: project.ownerUserId,
+        window,
+      };
+
+      // Independent rollups — CH multiplexes them happily.
+      const [summary, dailyBuckets, breakdownByModel] = await Promise.all([
+        usage.summary(input),
+        usage.dailyBuckets(input),
+        usage.breakdownByModel(input),
+      ]);
+
+      return c.json({ summary, dailyBuckets, breakdownByModel });
+    },
+  );
+}
+
+export const app = secured.hono;

--- a/langwatch/src/app/api/me/[[...route]]/schemas.ts
+++ b/langwatch/src/app/api/me/[[...route]]/schemas.ts
@@ -7,12 +7,18 @@ import { z } from "zod";
  * match that existing surface so the two entrypoints don't drift.
  */
 
+// Max absolute epoch-ms representable by a JS `Date` (ECMA-262); anything
+// beyond becomes `Invalid Date`, so bound the inputs before they reach
+// `new Date(...)` in the route handler.
+const MAX_DATE_MS = 8_640_000_000_000_000;
+const epochMs = z.coerce.number().int().min(-MAX_DATE_MS).max(MAX_DATE_MS);
+
 export const meUsageQuerySchema = z
   .object({
     /** Inclusive window start in epoch ms. Defaults to start-of-month. */
-    windowStartMs: z.coerce.number().int().optional(),
+    windowStartMs: epochMs.optional(),
     /** Exclusive window end in epoch ms. Defaults to now. */
-    windowEndMs: z.coerce.number().int().optional(),
+    windowEndMs: epochMs.optional(),
   })
   // A half-specified window is ambiguous — require both bounds or neither,
   // rather than silently dropping a lone bound and returning the default month.

--- a/langwatch/src/app/api/me/[[...route]]/schemas.ts
+++ b/langwatch/src/app/api/me/[[...route]]/schemas.ts
@@ -7,12 +7,29 @@ import { z } from "zod";
  * match that existing surface so the two entrypoints don't drift.
  */
 
-export const meUsageQuerySchema = z.object({
-  /** Inclusive window start in epoch ms. Defaults to start-of-month. */
-  windowStartMs: z.coerce.number().int().optional(),
-  /** Exclusive window end in epoch ms. Defaults to now. */
-  windowEndMs: z.coerce.number().int().optional(),
-});
+export const meUsageQuerySchema = z
+  .object({
+    /** Inclusive window start in epoch ms. Defaults to start-of-month. */
+    windowStartMs: z.coerce.number().int().optional(),
+    /** Exclusive window end in epoch ms. Defaults to now. */
+    windowEndMs: z.coerce.number().int().optional(),
+  })
+  // A half-specified window is ambiguous — require both bounds or neither,
+  // rather than silently dropping a lone bound and returning the default month.
+  .refine(
+    (q) => (q.windowStartMs === undefined) === (q.windowEndMs === undefined),
+    {
+      message:
+        "windowStartMs and windowEndMs must be provided together (or both omitted for the current month).",
+    },
+  )
+  .refine(
+    (q) =>
+      q.windowStartMs === undefined ||
+      q.windowEndMs === undefined ||
+      q.windowStartMs < q.windowEndMs,
+    { message: "windowStartMs must be before windowEndMs." },
+  );
 
 const mostUsedModelSchema = z
   .object({ name: z.string(), usagePct: z.number() })

--- a/langwatch/src/app/api/me/[[...route]]/schemas.ts
+++ b/langwatch/src/app/api/me/[[...route]]/schemas.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+/**
+ * Wire schemas for GET /api/me/usage. Fields mirror the
+ * PersonalUsageService output (and the `api.user.personalUsage` tRPC
+ * payload the /me dashboard consumes) one-to-one, kept camelCase to
+ * match that existing surface so the two entrypoints don't drift.
+ */
+
+export const meUsageQuerySchema = z.object({
+  /** Inclusive window start in epoch ms. Defaults to start-of-month. */
+  windowStartMs: z.coerce.number().int().optional(),
+  /** Exclusive window end in epoch ms. Defaults to now. */
+  windowEndMs: z.coerce.number().int().optional(),
+});
+
+const mostUsedModelSchema = z
+  .object({ name: z.string(), usagePct: z.number() })
+  .nullable();
+
+const summarySchema = z.object({
+  spentUsd: z.number(),
+  billedUsd: z.number(),
+  requests: z.number(),
+  promptTokens: z.number(),
+  completionTokens: z.number(),
+  mostUsedModel: mostUsedModelSchema,
+});
+
+const bucketSchema = z.object({
+  day: z.string(),
+  spentUsd: z.number(),
+  billedUsd: z.number(),
+  requests: z.number(),
+});
+
+const breakdownSchema = z.object({
+  label: z.string(),
+  spentUsd: z.number(),
+  billedUsd: z.number(),
+  requests: z.number(),
+});
+
+export const meUsageResponseSchema = z.object({
+  summary: summarySchema,
+  dailyBuckets: z.array(bucketSchema),
+  breakdownByModel: z.array(breakdownSchema),
+});

--- a/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
+++ b/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
@@ -1,54 +1,115 @@
+import type { ClickHouseClient } from "@clickhouse/client";
 import {
-  OrganizationUserRole,
-  RoleBindingScopeType,
-  TeamUserRole,
   type Organization,
+  OrganizationUserRole,
   type Team,
+  TeamUserRole,
 } from "@prisma/client";
-import { generate } from "@langwatch/ksuid";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { KSUID_RESOURCES } from "~/utils/constants";
 import { prisma } from "~/server/db";
-import { ApiKeyService } from "~/server/api-key/api-key.service";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
 import { app } from "../[[...route]]/app";
+
+/** Minimal trace_summaries seed — mirrors the PersonalUsageService test helper. */
+async function insertTrace(
+  ch: ClickHouseClient,
+  tenantId: string,
+  t: { traceId: string; occurredAt: Date; totalCost: number; models: string[] },
+): Promise<void> {
+  await ch.insert({
+    table: "trace_summaries",
+    values: [
+      {
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: tenantId,
+        TraceId: t.traceId,
+        Version: "v1",
+        Attributes: {},
+        OccurredAt: t.occurredAt,
+        CreatedAt: t.occurredAt,
+        UpdatedAt: t.occurredAt,
+        ComputedIOSchemaVersion: "",
+        ComputedInput: null,
+        ComputedOutput: null,
+        TimeToFirstTokenMs: null,
+        TimeToLastTokenMs: null,
+        TotalDurationMs: 100,
+        TokensPerSecond: null,
+        SpanCount: 1,
+        ContainsErrorStatus: 0,
+        ContainsOKStatus: 1,
+        ErrorMessage: null,
+        Models: t.models,
+        TotalCost: t.totalCost,
+        NonBilledCost: 0,
+        TokensEstimated: false,
+        TotalPromptTokenCount: 10,
+        TotalCompletionTokenCount: 5,
+        OutputFromRootSpan: 0,
+        OutputSpanEndTimeMs: 0,
+        BlockedByGuardrail: 0,
+        TopicId: null,
+        SubTopicId: null,
+        HasAnnotation: null,
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
 
 describe("Feature: Personal usage REST API", () => {
   const ns = `me-usage-api-${nanoid(8)}`;
 
   let testOrganization: Organization;
   let testTeam: Team;
-  let personalProjectId: string;
-  let sharedProjectId: string;
-  let personalToken: string;
-  let sharedToken: string;
   let userId: string;
+  let ch: ClickHouseClient | null = null;
 
-  const authHeaders = (token: string, projectId: string) => ({
-    Authorization: `Bearer ${token}`,
+  // A personal project with seeded usage, a personal project with none, and a
+  // shared (non-personal) project — each authenticated by its OWN api key so
+  // the personal-vs-shared contract is exercised at the credential layer.
+  let seededProject: { id: string; apiKey: string };
+  let emptyProject: { id: string; apiKey: string };
+  let sharedProject: { id: string; apiKey: string };
+
+  // Deterministic window around the seeded in-window trace.
+  const inWindow = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
+  const outOfWindow = new Date(Date.UTC(2025, 11, 15, 12, 0, 0));
+  const windowStartMs = Date.UTC(2026, 0, 1);
+  const windowEndMs = Date.UTC(2026, 0, 31);
+
+  const authHeaders = (apiKey: string, projectId: string) => ({
+    Authorization: `Bearer ${apiKey}`,
     "X-Project-Id": projectId,
     "Content-Type": "application/json",
   });
 
-  const mintToken = async () =>
-    (
-      await ApiKeyService.create(prisma).create({
-        name: `me-usage-bootstrap-${nanoid(6)}`,
-        userId,
-        createdByUserId: userId,
-        organizationId: testOrganization.id,
-        permissionMode: "all",
-        bindings: [
-          {
-            role: TeamUserRole.ADMIN,
-            scopeType: RoleBindingScopeType.ORGANIZATION,
-            scopeId: testOrganization.id,
-          },
-        ],
-      })
-    ).token;
+  const makeProject = async (name: string, isPersonal: boolean) => {
+    const apiKey = `sk-lw-${nanoid(48)}`;
+    const project = await prisma.project.create({
+      data: {
+        id: `project_${nanoid()}`,
+        name,
+        slug: `--test-${nanoid(8)}`,
+        language: "typescript",
+        framework: "other",
+        apiKey,
+        teamId: testTeam.id,
+        isPersonal,
+        ownerUserId: isPersonal ? userId : null,
+      },
+    });
+    return { id: project.id, apiKey };
+  };
 
   beforeAll(async () => {
+    ch = getTestClickHouseClient();
+
     testOrganization = await prisma.organization.create({
       data: { name: "Me Usage Test Org", slug: `--test-org-${ns}` },
     });
@@ -73,55 +134,33 @@ describe("Feature: Personal usage REST API", () => {
     await prisma.teamUser.create({
       data: { userId, teamId: testTeam.id, role: TeamUserRole.ADMIN },
     });
-    await prisma.roleBinding.create({
-      data: {
-        id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
-        organizationId: testOrganization.id,
-        userId,
-        role: TeamUserRole.ADMIN,
-        scopeType: RoleBindingScopeType.ORGANIZATION,
-        scopeId: testOrganization.id,
-      },
-    });
 
-    const personalProject = await prisma.project.create({
-      data: {
-        id: `project_${nanoid()}`,
-        name: "Personal Workspace",
-        slug: `--test-personal-${ns}`,
-        language: "typescript",
-        framework: "other",
-        apiKey: `sk-lw-${nanoid(48)}`,
-        teamId: testTeam.id,
-        isPersonal: true,
-        ownerUserId: userId,
-      },
-    });
-    personalProjectId = personalProject.id;
+    seededProject = await makeProject("Personal Workspace", true);
+    emptyProject = await makeProject("Empty Personal Workspace", true);
+    sharedProject = await makeProject("Shared Project", false);
 
-    const sharedProject = await prisma.project.create({
-      data: {
-        id: `project_${nanoid()}`,
-        name: "Shared Project",
-        slug: `--test-shared-${ns}`,
-        language: "typescript",
-        framework: "other",
-        apiKey: `sk-lw-${nanoid(48)}`,
-        teamId: testTeam.id,
-        isPersonal: false,
-      },
-    });
-    sharedProjectId = sharedProject.id;
-
-    personalToken = await mintToken();
-    sharedToken = await mintToken();
+    if (ch) {
+      // One trace inside the window, one outside — the window test proves the
+      // out-of-window trace is excluded.
+      await insertTrace(ch, seededProject.id, {
+        traceId: `t-in-${nanoid(6)}`,
+        occurredAt: inWindow,
+        totalCost: 0.5,
+        models: ["gpt-4o"],
+      });
+      await insertTrace(ch, seededProject.id, {
+        traceId: `t-out-${nanoid(6)}`,
+        occurredAt: outOfWindow,
+        totalCost: 2.0,
+        models: ["claude-opus-4-8"],
+      });
+    }
   });
 
   afterAll(async () => {
-    await prisma.roleBinding
-      .deleteMany({ where: { organizationId: testOrganization.id } })
-      .catch(() => {});
-    await prisma.apiKey.deleteMany({ where: { userId } }).catch(() => {});
+    if (ch) {
+      await cleanupTestData(seededProject.id).catch(() => {});
+    }
     await prisma.project
       .deleteMany({ where: { teamId: testTeam.id } })
       .catch(() => {});
@@ -138,57 +177,94 @@ describe("Feature: Personal usage REST API", () => {
       .catch(() => {});
   });
 
-  describe("when no auth header is provided", () => {
-    it("returns 401", async () => {
-      const headers = new Headers();
-      headers.set("X-Project-Id", personalProjectId);
-      const res = await app.request("/api/me/usage", { headers });
-      expect(res.status).toBe(401);
+  describe("given no authentication", () => {
+    describe("when reading usage", () => {
+      it("returns 401", async () => {
+        const headers = new Headers();
+        headers.set("X-Project-Id", seededProject.id);
+        const res = await app.request("/api/me/usage", { headers });
+        expect(res.status).toBe(401);
+      });
     });
   });
 
-  describe("when the project key is a personal-project key", () => {
-    it("returns the personal-usage envelope (empty-state safe)", async () => {
-      const res = await app.request("/api/me/usage", {
-        headers: authHeaders(personalToken, personalProjectId),
-      });
-      expect(res.status).toBe(200);
-      const body = await res.json();
+  describe("given a personal-workspace API key", () => {
+    describe("when reading usage for an explicit window", () => {
+      it("rolls up only usage inside the window", async () => {
+        const res = await app.request(
+          `/api/me/usage?windowStartMs=${windowStartMs}&windowEndMs=${windowEndMs}`,
+          { headers: authHeaders(seededProject.apiKey, seededProject.id) },
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
 
-      expect(body.summary).toMatchObject({
-        spentUsd: 0,
-        billedUsd: 0,
-        requests: 0,
-        promptTokens: 0,
-        completionTokens: 0,
-        mostUsedModel: null,
+        // Only the in-window trace ($0.50, 1 request) counts; the $2.00
+        // out-of-window trace is excluded.
+        expect(body.summary.spentUsd).toBeCloseTo(0.5, 5);
+        expect(body.summary.requests).toBe(1);
+        expect(body.dailyBuckets.length).toBeGreaterThanOrEqual(1);
+        const total = body.dailyBuckets.reduce(
+          (sum: number, b: { spentUsd: number }) => sum + b.spentUsd,
+          0,
+        );
+        expect(total).toBeCloseTo(0.5, 5);
+        expect(
+          body.breakdownByModel.map((m: { label: string }) => m.label),
+        ).toContain("gpt-4o");
       });
-      expect(Array.isArray(body.dailyBuckets)).toBe(true);
-      expect(Array.isArray(body.breakdownByModel)).toBe(true);
-      expect(body.breakdownByModel).toEqual([]);
     });
 
-    it("accepts an explicit window via query params", async () => {
-      const end = 1_700_000_000_000;
-      const start = end - 7 * 24 * 60 * 60 * 1000;
-      const res = await app.request(
-        `/api/me/usage?windowStartMs=${start}&windowEndMs=${end}`,
-        { headers: authHeaders(personalToken, personalProjectId) },
-      );
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body.summary.spentUsd).toBe(0);
+    describe("when a half-specified window is provided", () => {
+      it("returns 400", async () => {
+        const res = await app.request(
+          `/api/me/usage?windowStartMs=${windowStartMs}`,
+          { headers: authHeaders(seededProject.apiKey, seededProject.id) },
+        );
+        expect(res.status).toBe(400);
+      });
+    });
+
+    describe("when the workspace has no usage in the window", () => {
+      it("returns the empty-state envelope", async () => {
+        const res = await app.request("/api/me/usage", {
+          headers: authHeaders(emptyProject.apiKey, emptyProject.id),
+        });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+
+        expect(body.summary).toMatchObject({
+          spentUsd: 0,
+          billedUsd: 0,
+          requests: 0,
+          promptTokens: 0,
+          completionTokens: 0,
+          mostUsedModel: null,
+        });
+        // dailyBuckets is dense (one zero-filled bucket per day in the
+        // window via fillEmptyBuckets), so empty-state means every bucket is
+        // zero — not an empty array.
+        expect(body.dailyBuckets.length).toBeGreaterThan(0);
+        expect(
+          body.dailyBuckets.every(
+            (b: { spentUsd: number; requests: number }) =>
+              b.spentUsd === 0 && b.requests === 0,
+          ),
+        ).toBe(true);
+        expect(body.breakdownByModel).toEqual([]);
+      });
     });
   });
 
-  describe("when the project key is a shared (non-personal) project key", () => {
-    it("returns 400 explaining a personal-project key is required", async () => {
-      const res = await app.request("/api/me/usage", {
-        headers: authHeaders(sharedToken, sharedProjectId),
+  describe("given a shared (non-personal) workspace API key", () => {
+    describe("when reading usage", () => {
+      it("returns 400 explaining a personal-workspace key is required", async () => {
+        const res = await app.request("/api/me/usage", {
+          headers: authHeaders(sharedProject.apiKey, sharedProject.id),
+        });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(JSON.stringify(body)).toContain("personal-project");
       });
-      expect(res.status).toBe(400);
-      const body = await res.json();
-      expect(JSON.stringify(body)).toContain("personal-project");
     });
   });
 });

--- a/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
+++ b/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
@@ -15,23 +15,33 @@ import {
 import { app } from "../[[...route]]/app";
 
 /** Minimal trace_summaries seed — mirrors the PersonalUsageService test helper. */
-async function insertTrace(
-  ch: ClickHouseClient,
-  tenantId: string,
-  t: { traceId: string; occurredAt: Date; totalCost: number; models: string[] },
-): Promise<void> {
+async function insertTrace({
+  ch,
+  tenantId,
+  traceId,
+  occurredAt,
+  totalCost,
+  models,
+}: {
+  ch: ClickHouseClient;
+  tenantId: string;
+  traceId: string;
+  occurredAt: Date;
+  totalCost: number;
+  models: string[];
+}): Promise<void> {
   await ch.insert({
     table: "trace_summaries",
     values: [
       {
         ProjectionId: `proj-${nanoid()}`,
         TenantId: tenantId,
-        TraceId: t.traceId,
+        TraceId: traceId,
         Version: "v1",
         Attributes: {},
-        OccurredAt: t.occurredAt,
-        CreatedAt: t.occurredAt,
-        UpdatedAt: t.occurredAt,
+        OccurredAt: occurredAt,
+        CreatedAt: occurredAt,
+        UpdatedAt: occurredAt,
         ComputedIOSchemaVersion: "",
         ComputedInput: null,
         ComputedOutput: null,
@@ -43,8 +53,8 @@ async function insertTrace(
         ContainsErrorStatus: 0,
         ContainsOKStatus: 1,
         ErrorMessage: null,
-        Models: t.models,
-        TotalCost: t.totalCost,
+        Models: models,
+        TotalCost: totalCost,
         NonBilledCost: 0,
         TokensEstimated: false,
         TotalPromptTokenCount: 10,
@@ -83,13 +93,25 @@ describe("Feature: Personal usage REST API", () => {
   const windowStartMs = Date.UTC(2026, 0, 1);
   const windowEndMs = Date.UTC(2026, 0, 31);
 
-  const authHeaders = (apiKey: string, projectId: string) => ({
+  const authHeaders = ({
+    apiKey,
+    projectId,
+  }: {
+    apiKey: string;
+    projectId: string;
+  }) => ({
     Authorization: `Bearer ${apiKey}`,
     "X-Project-Id": projectId,
     "Content-Type": "application/json",
   });
 
-  const makeProject = async (name: string, isPersonal: boolean) => {
+  const makeProject = async ({
+    name,
+    isPersonal,
+  }: {
+    name: string;
+    isPersonal: boolean;
+  }) => {
     const apiKey = `sk-lw-${nanoid(48)}`;
     const project = await prisma.project.create({
       data: {
@@ -135,20 +157,33 @@ describe("Feature: Personal usage REST API", () => {
       data: { userId, teamId: testTeam.id, role: TeamUserRole.ADMIN },
     });
 
-    seededProject = await makeProject("Personal Workspace", true);
-    emptyProject = await makeProject("Empty Personal Workspace", true);
-    sharedProject = await makeProject("Shared Project", false);
+    seededProject = await makeProject({
+      name: "Personal Workspace",
+      isPersonal: true,
+    });
+    emptyProject = await makeProject({
+      name: "Empty Personal Workspace",
+      isPersonal: true,
+    });
+    sharedProject = await makeProject({
+      name: "Shared Project",
+      isPersonal: false,
+    });
 
     if (ch) {
       // One trace inside the window, one outside — the window test proves the
       // out-of-window trace is excluded.
-      await insertTrace(ch, seededProject.id, {
+      await insertTrace({
+        ch,
+        tenantId: seededProject.id,
         traceId: `t-in-${nanoid(6)}`,
         occurredAt: inWindow,
         totalCost: 0.5,
         models: ["gpt-4o"],
       });
-      await insertTrace(ch, seededProject.id, {
+      await insertTrace({
+        ch,
+        tenantId: seededProject.id,
         traceId: `t-out-${nanoid(6)}`,
         occurredAt: outOfWindow,
         totalCost: 2.0,
@@ -179,6 +214,7 @@ describe("Feature: Personal usage REST API", () => {
 
   describe("given no authentication", () => {
     describe("when reading usage", () => {
+      /** @scenario "Unauthenticated requests are rejected" */
       it("returns 401", async () => {
         const headers = new Headers();
         headers.set("X-Project-Id", seededProject.id);
@@ -189,11 +225,38 @@ describe("Feature: Personal usage REST API", () => {
   });
 
   describe("given a personal-workspace API key", () => {
+    describe("when reading usage for the current month (default window)", () => {
+      /** @scenario "Reading personal usage for the current month" */
+      it("returns the usage envelope", async () => {
+        const res = await app.request("/api/me/usage", {
+          headers: authHeaders({
+            apiKey: seededProject.apiKey,
+            projectId: seededProject.id,
+          }),
+        });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+
+        expect(body.summary).toHaveProperty("spentUsd");
+        expect(body.summary).toHaveProperty("billedUsd");
+        expect(body.summary).toHaveProperty("requests");
+        expect(body.summary).toHaveProperty("mostUsedModel");
+        expect(Array.isArray(body.dailyBuckets)).toBe(true);
+        expect(Array.isArray(body.breakdownByModel)).toBe(true);
+      });
+    });
+
     describe("when reading usage for an explicit window", () => {
+      /** @scenario "Reading personal usage for an explicit window" */
       it("rolls up only usage inside the window", async () => {
         const res = await app.request(
           `/api/me/usage?windowStartMs=${windowStartMs}&windowEndMs=${windowEndMs}`,
-          { headers: authHeaders(seededProject.apiKey, seededProject.id) },
+          {
+            headers: authHeaders({
+              apiKey: seededProject.apiKey,
+              projectId: seededProject.id,
+            }),
+          },
         );
         expect(res.status).toBe(200);
         const body = await res.json();
@@ -215,19 +278,49 @@ describe("Feature: Personal usage REST API", () => {
     });
 
     describe("when a half-specified window is provided", () => {
-      it("returns 400", async () => {
+      /** @scenario "A half-specified window is rejected" */
+      it("returns 400 explaining both bounds are required", async () => {
         const res = await app.request(
           `/api/me/usage?windowStartMs=${windowStartMs}`,
-          { headers: authHeaders(seededProject.apiKey, seededProject.id) },
+          {
+            headers: authHeaders({
+              apiKey: seededProject.apiKey,
+              projectId: seededProject.id,
+            }),
+          },
         );
         expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(JSON.stringify(body)).toContain("provided together");
+      });
+    });
+
+    describe("when an inverted window is provided", () => {
+      /** @scenario "An inverted window is rejected" */
+      it("returns 400 explaining start must be before end", async () => {
+        const res = await app.request(
+          `/api/me/usage?windowStartMs=${windowEndMs}&windowEndMs=${windowStartMs}`,
+          {
+            headers: authHeaders({
+              apiKey: seededProject.apiKey,
+              projectId: seededProject.id,
+            }),
+          },
+        );
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(JSON.stringify(body)).toContain("before");
       });
     });
 
     describe("when the workspace has no usage in the window", () => {
+      /** @scenario "Empty state is safe" */
       it("returns the empty-state envelope", async () => {
         const res = await app.request("/api/me/usage", {
-          headers: authHeaders(emptyProject.apiKey, emptyProject.id),
+          headers: authHeaders({
+            apiKey: emptyProject.apiKey,
+            projectId: emptyProject.id,
+          }),
         });
         expect(res.status).toBe(200);
         const body = await res.json();
@@ -257,9 +350,13 @@ describe("Feature: Personal usage REST API", () => {
 
   describe("given a shared (non-personal) workspace API key", () => {
     describe("when reading usage", () => {
+      /** @scenario "A shared-workspace API key is rejected" */
       it("returns 400 explaining a personal-workspace key is required", async () => {
         const res = await app.request("/api/me/usage", {
-          headers: authHeaders(sharedProject.apiKey, sharedProject.id),
+          headers: authHeaders({
+            apiKey: sharedProject.apiKey,
+            projectId: sharedProject.id,
+          }),
         });
         expect(res.status).toBe(400);
         const body = await res.json();

--- a/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
+++ b/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
@@ -1,0 +1,194 @@
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+  type Organization,
+  type Team,
+} from "@prisma/client";
+import { generate } from "@langwatch/ksuid";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { KSUID_RESOURCES } from "~/utils/constants";
+import { prisma } from "~/server/db";
+import { ApiKeyService } from "~/server/api-key/api-key.service";
+import { app } from "../[[...route]]/app";
+
+describe("Feature: Personal usage REST API", () => {
+  const ns = `me-usage-api-${nanoid(8)}`;
+
+  let testOrganization: Organization;
+  let testTeam: Team;
+  let personalProjectId: string;
+  let sharedProjectId: string;
+  let personalToken: string;
+  let sharedToken: string;
+  let userId: string;
+
+  const authHeaders = (token: string, projectId: string) => ({
+    Authorization: `Bearer ${token}`,
+    "X-Project-Id": projectId,
+    "Content-Type": "application/json",
+  });
+
+  const mintToken = async () =>
+    (
+      await ApiKeyService.create(prisma).create({
+        name: `me-usage-bootstrap-${nanoid(6)}`,
+        userId,
+        createdByUserId: userId,
+        organizationId: testOrganization.id,
+        permissionMode: "all",
+        bindings: [
+          {
+            role: TeamUserRole.ADMIN,
+            scopeType: RoleBindingScopeType.ORGANIZATION,
+            scopeId: testOrganization.id,
+          },
+        ],
+      })
+    ).token;
+
+  beforeAll(async () => {
+    testOrganization = await prisma.organization.create({
+      data: { name: "Me Usage Test Org", slug: `--test-org-${ns}` },
+    });
+    testTeam = await prisma.team.create({
+      data: {
+        name: "Me Usage Test Team",
+        slug: `--test-team-${ns}`,
+        organizationId: testOrganization.id,
+      },
+    });
+    const user = await prisma.user.create({
+      data: { name: "Test User", email: `test-${ns}@example.com` },
+    });
+    userId = user.id;
+    await prisma.organizationUser.create({
+      data: {
+        userId,
+        organizationId: testOrganization.id,
+        role: OrganizationUserRole.ADMIN,
+      },
+    });
+    await prisma.teamUser.create({
+      data: { userId, teamId: testTeam.id, role: TeamUserRole.ADMIN },
+    });
+    await prisma.roleBinding.create({
+      data: {
+        id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+        organizationId: testOrganization.id,
+        userId,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: testOrganization.id,
+      },
+    });
+
+    const personalProject = await prisma.project.create({
+      data: {
+        id: `project_${nanoid()}`,
+        name: "Personal Workspace",
+        slug: `--test-personal-${ns}`,
+        language: "typescript",
+        framework: "other",
+        apiKey: `sk-lw-${nanoid(48)}`,
+        teamId: testTeam.id,
+        isPersonal: true,
+        ownerUserId: userId,
+      },
+    });
+    personalProjectId = personalProject.id;
+
+    const sharedProject = await prisma.project.create({
+      data: {
+        id: `project_${nanoid()}`,
+        name: "Shared Project",
+        slug: `--test-shared-${ns}`,
+        language: "typescript",
+        framework: "other",
+        apiKey: `sk-lw-${nanoid(48)}`,
+        teamId: testTeam.id,
+        isPersonal: false,
+      },
+    });
+    sharedProjectId = sharedProject.id;
+
+    personalToken = await mintToken();
+    sharedToken = await mintToken();
+  });
+
+  afterAll(async () => {
+    await prisma.roleBinding
+      .deleteMany({ where: { organizationId: testOrganization.id } })
+      .catch(() => {});
+    await prisma.apiKey.deleteMany({ where: { userId } }).catch(() => {});
+    await prisma.project
+      .deleteMany({ where: { teamId: testTeam.id } })
+      .catch(() => {});
+    await prisma.teamUser
+      .deleteMany({ where: { teamId: testTeam.id } })
+      .catch(() => {});
+    await prisma.organizationUser
+      .deleteMany({ where: { organizationId: testOrganization.id } })
+      .catch(() => {});
+    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+    await prisma.team.delete({ where: { id: testTeam.id } }).catch(() => {});
+    await prisma.organization
+      .delete({ where: { id: testOrganization.id } })
+      .catch(() => {});
+  });
+
+  describe("when no auth header is provided", () => {
+    it("returns 401", async () => {
+      const headers = new Headers();
+      headers.set("X-Project-Id", personalProjectId);
+      const res = await app.request("/api/me/usage", { headers });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("when the project key is a personal-project key", () => {
+    it("returns the personal-usage envelope (empty-state safe)", async () => {
+      const res = await app.request("/api/me/usage", {
+        headers: authHeaders(personalToken, personalProjectId),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.summary).toMatchObject({
+        spentUsd: 0,
+        billedUsd: 0,
+        requests: 0,
+        promptTokens: 0,
+        completionTokens: 0,
+        mostUsedModel: null,
+      });
+      expect(Array.isArray(body.dailyBuckets)).toBe(true);
+      expect(Array.isArray(body.breakdownByModel)).toBe(true);
+      expect(body.breakdownByModel).toEqual([]);
+    });
+
+    it("accepts an explicit window via query params", async () => {
+      const end = 1_700_000_000_000;
+      const start = end - 7 * 24 * 60 * 60 * 1000;
+      const res = await app.request(
+        `/api/me/usage?windowStartMs=${start}&windowEndMs=${end}`,
+        { headers: authHeaders(personalToken, personalProjectId) },
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.summary.spentUsd).toBe(0);
+    });
+  });
+
+  describe("when the project key is a shared (non-personal) project key", () => {
+    it("returns 400 explaining a personal-project key is required", async () => {
+      const res = await app.request("/api/me/usage", {
+        headers: authHeaders(sharedToken, sharedProjectId),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(JSON.stringify(body)).toContain("personal-project");
+    });
+  });
+});

--- a/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
+++ b/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
@@ -296,21 +296,38 @@ describe("Feature: Personal usage REST API", () => {
     });
 
     describe("when an inverted window is provided", () => {
-      /** @scenario "An inverted window is rejected" */
-      it("returns 400 explaining start must be before end", async () => {
-        const res = await app.request(
-          `/api/me/usage?windowStartMs=${windowEndMs}&windowEndMs=${windowStartMs}`,
-          {
-            headers: authHeaders({
-              apiKey: seededProject.apiKey,
-              projectId: seededProject.id,
-            }),
-          },
-        );
-        expect(res.status).toBe(400);
-        const body = await res.json();
-        expect(JSON.stringify(body)).toContain("before");
-      });
+      // "at or after the end time" — cover both start > end and start === end
+      // so a regression from `<` to `<=` in the schema check can't slip through.
+      const invertedCases: Array<{
+        label: string;
+        start: number;
+        end: number;
+      }> = [
+        { label: "start after end", start: windowEndMs, end: windowStartMs },
+        {
+          label: "start equal to end",
+          start: windowStartMs,
+          end: windowStartMs,
+        },
+      ];
+
+      for (const { label, start, end } of invertedCases) {
+        /** @scenario "An inverted window is rejected" */
+        it(`returns 400 explaining start must be before end (${label})`, async () => {
+          const res = await app.request(
+            `/api/me/usage?windowStartMs=${start}&windowEndMs=${end}`,
+            {
+              headers: authHeaders({
+                apiKey: seededProject.apiKey,
+                projectId: seededProject.id,
+              }),
+            },
+          );
+          expect(res.status).toBe(400);
+          const body = await res.json();
+          expect(JSON.stringify(body)).toContain("before");
+        });
+      }
     });
 
     describe("when the workspace has no usage in the window", () => {

--- a/langwatch/src/server/api-router.ts
+++ b/langwatch/src/server/api-router.ts
@@ -2,18 +2,21 @@
  * Unified Hono API router — all /api/* routes mounted here.
  * Each sub-app sets its own basePath (e.g. "/api/traces").
  */
-import { Hono, type Context } from "hono";
+import { type Context, Hono } from "hono";
 
 import { createServiceApp, publicEndpoint } from "~/server/api/security";
-
+import { app as adminApp } from "../../ee/admin/routes/admin";
 import { app as agentsApp } from "../app/api/agents/[[...route]]/app";
 import { app as analyticsApp } from "../app/api/analytics/[...route]/app";
+import { app as apiKeysApp } from "../app/api/api-keys/[[...route]]/app";
 import { app as copilotKitApp } from "../app/api/copilotkit/[[...route]]/app";
 import { app as dashboardsApp } from "../app/api/dashboards/[[...route]]/app";
 import { app as datasetApp } from "../app/api/dataset/[[...route]]/app";
 import { app as evaluatorsApp } from "../app/api/evaluators/[[...route]]/app";
+import { app as eventsApp } from "../app/api/events/[[...route]]/app";
 import { app as experimentsApp } from "../app/api/experiments/[[...route]]/app";
 import { app as exportTracesApp } from "../app/api/export/traces/[[...route]]/app";
+import { app as filesApp } from "../app/api/files/[[...route]]/app";
 import { app as gatewayPlatformApp } from "../app/api/gateway-platform/[[...route]]/app";
 import { app as governanceApp } from "../app/api/governance/[[...route]]/app";
 import { app as graphsApp } from "../app/api/graphs/[[...route]]/app";
@@ -21,10 +24,8 @@ import { app as meApp } from "../app/api/me/[[...route]]/app";
 import { app as modelDefaultsApp } from "../app/api/model-defaults/[[...route]]/app";
 import { app as modelProvidersApp } from "../app/api/model-providers/[[...route]]/app";
 import { app as monitorsApp } from "../app/api/monitors/[[...route]]/app";
-import { app as apiKeysApp } from "../app/api/api-keys/[[...route]]/app";
 import { app as projectsApp } from "../app/api/projects/[[...route]]/app";
 import { app as promptsApp } from "../app/api/prompts/[[...route]]/app";
-import { app as filesApp } from "../app/api/files/[[...route]]/app";
 import { app as scenarioEventsApp } from "../app/api/scenario-events/[[...route]]/app";
 import { app as scenariosApp } from "../app/api/scenarios/[[...route]]/app";
 import { app as secretsApp } from "../app/api/secrets/[[...route]]/app";
@@ -32,35 +33,34 @@ import { app as simulationRunsApp } from "../app/api/simulation-runs/[[...route]
 import { app as suitesApp } from "../app/api/suites/[[...route]]/app";
 import { app as teamsApp } from "../app/api/teams/[[...route]]/app";
 import { app as tracesApp } from "../app/api/traces/[[...route]]/app";
-import { app as eventsApp } from "../app/api/events/[[...route]]/app";
 import { app as triggersApp } from "../app/api/triggers/[[...route]]/app";
 import { app as workflowsCrudApp } from "../app/api/workflows/[[...route]]/app";
-
-import { app as datasetGenerateApp } from "./routes/dataset-generate";
-import { app as experimentsV3App, legacyAliasApp as experimentsV3LegacyAliasApp } from "./routes/experiments-v3";
-import { app as gatewayInternalApp } from "./routes/gateway-internal";
-import { app as healthChecksApp } from "./routes/health-checks";
-import { app as otelApp } from "./routes/otel";
-import { app as playgroundApp } from "./routes/playground";
-import { app as scenarioGenerateApp } from "./routes/scenario-generate";
-import { app as scimApp } from "./routes/scim";
-import { app as webhooksApp } from "./routes/webhooks";
-import { app as workflowsApp } from "./routes/workflows";
-
-import { app as adminApp } from "../../ee/admin/routes/admin";
 import { app as annotationsApp } from "./routes/annotations";
 import { app as authApp } from "./routes/auth";
 import { app as authCliApp } from "./routes/auth-cli";
 import { app as collectorApp } from "./routes/collector";
-import { app as ingestionRoutesApp } from "./routes/ingest/ingestionRoutes";
 import { app as cronApp } from "./routes/cron";
+import { app as datasetGenerateApp } from "./routes/dataset-generate";
 import { app as evaluationsLegacyApp } from "./routes/evaluations-legacy";
+import {
+  app as experimentsV3App,
+  legacyAliasApp as experimentsV3LegacyAliasApp,
+} from "./routes/experiments-v3";
+import { app as gatewayInternalApp } from "./routes/gateway-internal";
 import { app as healthApp } from "./routes/health";
+import { app as healthChecksApp } from "./routes/health-checks";
+import { app as ingestionRoutesApp } from "./routes/ingest/ingestionRoutes";
 import { app as miscApp } from "./routes/misc";
 import { app as opsApp } from "./routes/ops";
+import { app as otelApp } from "./routes/otel";
+import { app as playgroundApp } from "./routes/playground";
+import { app as scenarioGenerateApp } from "./routes/scenario-generate";
+import { app as scimApp } from "./routes/scim";
 import { app as sseApp } from "./routes/sse";
 import { app as tracesLegacyApp } from "./routes/traces-legacy";
 import { app as trpcApp } from "./routes/trpc";
+import { app as webhooksApp } from "./routes/webhooks";
+import { app as workflowsApp } from "./routes/workflows";
 
 export function createApiRouter() {
   const api = new Hono();
@@ -94,9 +94,9 @@ export function createApiRouter() {
   api.route("/", legacyOAuthCallbacks.hono);
 
   // ORDERING: specific paths before catch-all siblings with same basePath
-  api.route("/", datasetGenerateApp);    // /api/dataset/generate (before datasetApp's /:slugOrId)
-  api.route("/", workflowsApp);          // /api/workflows/code-completion, /post_event
-  api.route("/", healthChecksApp);       // /api/health/collector, /evaluations, etc.
+  api.route("/", datasetGenerateApp); // /api/dataset/generate (before datasetApp's /:slugOrId)
+  api.route("/", workflowsApp); // /api/workflows/code-completion, /post_event
+  api.route("/", healthChecksApp); // /api/health/collector, /evaluations, etc.
 
   api.route("/", agentsApp);
   api.route("/", analyticsApp);
@@ -114,14 +114,14 @@ export function createApiRouter() {
   // SecuredApp builder (no namespace-wide guard), so this ordering is
   // belt-and-suspenders; the experiments-route-auth regression test pins it.
   api.route("/", experimentsV3App);
-  api.route("/", experimentsV3LegacyAliasApp);  // /api/evaluations/v3/... → /api/experiments/...
+  api.route("/", experimentsV3LegacyAliasApp); // /api/evaluations/v3/... → /api/experiments/...
   api.route("/", experimentsApp);
   api.route("/", filesApp);
   api.route("/", exportTracesApp);
   api.route("/", gatewayPlatformApp);
   api.route("/", governanceApp);
   api.route("/", graphsApp);
-  api.route("/", meApp);                  // /api/me/usage — personal spend/usage
+  api.route("/", meApp); // /api/me/usage — personal spend/usage
   api.route("/", modelDefaultsApp);
   api.route("/", modelProvidersApp);
   api.route("/", monitorsApp);
@@ -136,7 +136,7 @@ export function createApiRouter() {
   api.route("/", teamsApp);
   api.route("/", tracesApp);
   api.route("/", triggersApp);
-  api.route("/", workflowsCrudApp);      // CRUD — complements workflowsApp (code-completion, post_event)
+  api.route("/", workflowsCrudApp); // CRUD — complements workflowsApp (code-completion, post_event)
 
   api.route("/", gatewayInternalApp);
   api.route("/", otelApp);
@@ -151,7 +151,7 @@ export function createApiRouter() {
   // authApp owns the BetterAuth catch-all (`/auth/*`), which would
   // otherwise swallow `/auth/cli/*` and return 404 from BetterAuth.
   // Register the more-specific basePath first so Hono routes match it.
-  api.route("/", authCliApp);  // /api/auth/cli/* — RFC 8628 device-flow for CLI
+  api.route("/", authCliApp); // /api/auth/cli/* — RFC 8628 device-flow for CLI
   api.route("/", authApp);
   api.route("/", collectorApp);
   api.route("/", ingestionRoutesApp); // /api/ingest/* — Activity Monitor receivers

--- a/langwatch/src/server/api-router.ts
+++ b/langwatch/src/server/api-router.ts
@@ -17,6 +17,7 @@ import { app as exportTracesApp } from "../app/api/export/traces/[[...route]]/ap
 import { app as gatewayPlatformApp } from "../app/api/gateway-platform/[[...route]]/app";
 import { app as governanceApp } from "../app/api/governance/[[...route]]/app";
 import { app as graphsApp } from "../app/api/graphs/[[...route]]/app";
+import { app as meApp } from "../app/api/me/[[...route]]/app";
 import { app as modelDefaultsApp } from "../app/api/model-defaults/[[...route]]/app";
 import { app as modelProvidersApp } from "../app/api/model-providers/[[...route]]/app";
 import { app as monitorsApp } from "../app/api/monitors/[[...route]]/app";
@@ -120,6 +121,7 @@ export function createApiRouter() {
   api.route("/", gatewayPlatformApp);
   api.route("/", governanceApp);
   api.route("/", graphsApp);
+  api.route("/", meApp);                  // /api/me/usage — personal spend/usage
   api.route("/", modelDefaultsApp);
   api.route("/", modelProvidersApp);
   api.route("/", monitorsApp);

--- a/langwatch/src/tasks/generateOpenAPISpec.ts
+++ b/langwatch/src/tasks/generateOpenAPISpec.ts
@@ -13,18 +13,18 @@ import { app as gatewayPlatformApp } from "../app/api/gateway-platform/[[...rout
 import { app as governanceApp } from "../app/api/governance/[[...route]]/app";
 import { app as graphsApp } from "../app/api/graphs/[[...route]]/app";
 import { app as meApp } from "../app/api/me/[[...route]]/app";
+import { app as modelDefaultsApp } from "../app/api/model-defaults/[[...route]]/app";
+import { app as modelProvidersApp } from "../app/api/model-providers/[[...route]]/app";
+import { app as monitorsApp } from "../app/api/monitors/[[...route]]/app";
 import currentSpec from "../app/api/openapiLangWatch.json";
 import { app as llmConfigsApp } from "../app/api/prompts/[[...route]]/app";
 import { app as scenarioEventsApp } from "../app/api/scenario-events/[[...route]]/app";
 import { app as scenariosApp } from "../app/api/scenarios/[[...route]]/app";
-import { app as modelDefaultsApp } from "../app/api/model-defaults/[[...route]]/app";
-import { app as modelProvidersApp } from "../app/api/model-providers/[[...route]]/app";
-import { app as tracesApp } from "../app/api/traces/[[...route]]/app";
-import { app as triggersApp } from "../app/api/triggers/[[...route]]/app";
+import { app as secretsApp } from "../app/api/secrets/[[...route]]/app";
 import { app as simulationRunsApp } from "../app/api/simulation-runs/[[...route]]/app";
 import { app as suitesApp } from "../app/api/suites/[[...route]]/app";
-import { app as monitorsApp } from "../app/api/monitors/[[...route]]/app";
-import { app as secretsApp } from "../app/api/secrets/[[...route]]/app";
+import { app as tracesApp } from "../app/api/traces/[[...route]]/app";
+import { app as triggersApp } from "../app/api/triggers/[[...route]]/app";
 import { app as workflowsApp } from "../app/api/workflows/[[...route]]/app";
 
 const overwriteMerge = (_destinationArray: any[], sourceArray: any[]) =>

--- a/langwatch/src/tasks/generateOpenAPISpec.ts
+++ b/langwatch/src/tasks/generateOpenAPISpec.ts
@@ -12,6 +12,7 @@ import { app as eventsApp } from "../app/api/events/[[...route]]/app";
 import { app as gatewayPlatformApp } from "../app/api/gateway-platform/[[...route]]/app";
 import { app as governanceApp } from "../app/api/governance/[[...route]]/app";
 import { app as graphsApp } from "../app/api/graphs/[[...route]]/app";
+import { app as meApp } from "../app/api/me/[[...route]]/app";
 import currentSpec from "../app/api/openapiLangWatch.json";
 import { app as llmConfigsApp } from "../app/api/prompts/[[...route]]/app";
 import { app as scenarioEventsApp } from "../app/api/scenario-events/[[...route]]/app";
@@ -65,6 +66,8 @@ export default async function execute() {
   const governanceSpec = await generateSpecs(governanceApp);
   console.log("Building graphs spec...");
   const graphsSpec = await generateSpecs(graphsApp);
+  console.log("Building me spec...");
+  const meSpec = await generateSpecs(meApp);
   console.log("Building llm configs spec...");
   const llmConfigsSpec = await generateSpecs(llmConfigsApp);
   console.log("Building scenario events spec...");
@@ -103,6 +106,7 @@ export default async function execute() {
       gatewayPlatformSpec,
       governanceSpec,
       graphsSpec,
+      meSpec,
       llmConfigsSpec,
       modelDefaultsSpec,
       modelProvidersSpec,
@@ -131,6 +135,7 @@ export default async function execute() {
           key.includes("/api/gateway/v1") ||
           key.includes("/api/governance") ||
           key.includes("/api/graphs") ||
+          key.includes("/api/me") ||
           key.includes("/api/prompts") ||
           key.includes("/api/dataset") ||
           key.includes("/api/model-providers") ||

--- a/specs/ai-gateway/governance/me-usage-rest-api.feature
+++ b/specs/ai-gateway/governance/me-usage-rest-api.feature
@@ -1,0 +1,38 @@
+Feature: Personal usage REST API
+  As a developer (or a desktop/menu-bar widget acting on my behalf)
+  I want a stable REST endpoint that returns my personal AI spend and usage
+  So that I can read the same numbers the /me dashboard shows without scraping tRPC
+
+  Background:
+    Given a personal project authenticated by its project API key
+    And the project has isPersonal=true with an ownerUserId
+
+  Scenario: Reading personal usage for the current month
+    When I GET /api/me/usage
+    Then the response status is 200
+    And the body has a "summary" object with spentUsd, billedUsd, requests, promptTokens, completionTokens and mostUsedModel
+    And the body has a "dailyBuckets" array of { day, spentUsd, billedUsd, requests }
+    And the body has a "breakdownByModel" array of { label, spentUsd, billedUsd, requests }
+
+  Scenario: Reading personal usage for an explicit window
+    When I GET /api/me/usage with windowStartMs and windowEndMs query params
+    Then the response status is 200
+    And the rollups cover only the requested window
+
+  Scenario: Empty state is safe
+    Given the personal project has no usage in the window
+    When I GET /api/me/usage
+    Then the response status is 200
+    And summary.spentUsd is 0 and mostUsedModel is null
+    And dailyBuckets and breakdownByModel are empty arrays
+
+  Scenario: A non-personal project key is rejected
+    Given the API key belongs to a project where isPersonal is false
+    When I GET /api/me/usage
+    Then the response status is 400
+    And the error explains a personal-project API key is required
+
+  Scenario: Unauthenticated requests are rejected
+    Given no Authorization header
+    When I GET /api/me/usage
+    Then the response status is 401

--- a/specs/ai-gateway/governance/me-usage-rest-api.feature
+++ b/specs/ai-gateway/governance/me-usage-rest-api.feature
@@ -4,35 +4,39 @@ Feature: Personal usage REST API
   So that I can read the same numbers the /me dashboard shows without scraping tRPC
 
   Background:
-    Given a personal project authenticated by its project API key
-    And the project has isPersonal=true with an ownerUserId
+    Given I authenticate with an API key from my personal workspace
 
   Scenario: Reading personal usage for the current month
     When I GET /api/me/usage
     Then the response status is 200
-    And the body has a "summary" object with spentUsd, billedUsd, requests, promptTokens, completionTokens and mostUsedModel
-    And the body has a "dailyBuckets" array of { day, spentUsd, billedUsd, requests }
-    And the body has a "breakdownByModel" array of { label, spentUsd, billedUsd, requests }
+    And the body has a "summary" object with spend, billed spend, request and token counts, and the most-used model
+    And the body has a "dailyBuckets" array of per-day spend and request counts
+    And the body has a "breakdownByModel" array of per-model spend and request counts
 
   Scenario: Reading personal usage for an explicit window
-    When I GET /api/me/usage with windowStartMs and windowEndMs query params
+    When I GET /api/me/usage with a start and end time
     Then the response status is 200
-    And the rollups cover only the requested window
+    And the rollups cover only usage that falls inside the requested window
+
+  Scenario: A half-specified window is rejected
+    When I GET /api/me/usage with only a start time (or only an end time)
+    Then the response status is 400
+    And the error explains both bounds must be provided together
 
   Scenario: Empty state is safe
-    Given the personal project has no usage in the window
+    Given my personal workspace has no usage in the window
     When I GET /api/me/usage
     Then the response status is 200
-    And summary.spentUsd is 0 and mostUsedModel is null
-    And dailyBuckets and breakdownByModel are empty arrays
+    And the spend is 0 and there is no most-used model
+    And every daily bucket shows zero spend and the per-model breakdown is empty
 
-  Scenario: A non-personal project key is rejected
-    Given the API key belongs to a project where isPersonal is false
+  Scenario: A shared-workspace API key is rejected
+    Given I authenticate with an API key from a shared (non-personal) workspace
     When I GET /api/me/usage
     Then the response status is 400
-    And the error explains a personal-project API key is required
+    And the error explains a personal-workspace API key is required
 
   Scenario: Unauthenticated requests are rejected
-    Given no Authorization header
+    Given I provide no API key
     When I GET /api/me/usage
     Then the response status is 401

--- a/specs/ai-gateway/governance/me-usage-rest-api.feature
+++ b/specs/ai-gateway/governance/me-usage-rest-api.feature
@@ -23,6 +23,11 @@ Feature: Personal usage REST API
     Then the response status is 400
     And the error explains both bounds must be provided together
 
+  Scenario: An inverted window is rejected
+    When I GET /api/me/usage with a start time at or after the end time
+    Then the response status is 400
+    And the error explains the start must be before the end
+
   Scenario: Empty state is safe
     Given my personal workspace has no usage in the window
     When I GET /api/me/usage


### PR DESCRIPTION
## What

Adds `GET /api/me/usage` — a stable REST endpoint that returns a developer's personal AI spend/usage: the same payload the `/me` dashboard renders today (spend, billed spend, request + token counts, per-day buckets, per-model breakdown).

## Why

The personal-usage numbers were only reachable via the `api.user.personalUsage` **tRPC** procedure — session-authed and an unstable wire contract. There was no way for an external client (a desktop/menu-bar widget, the CLI, or CI) to read "my spend this month" against a documented API. This endpoint closes that gap.

It reuses `PersonalUsageService` (the exact service the tRPC procedure calls), so the web dashboard and REST clients return identical numbers — no business-logic duplication.

## Contract

```
GET /api/me/usage?windowStartMs=<ms>&windowEndMs=<ms>
Authorization: Bearer <personal-project API key>
```

- **Auth**: a personal-project API key. The owner is resolved from `Project.ownerUserId`; usage is keyed by `(personalProjectId, ownerUserId)` exactly as the tRPC procedure keys it, so ingestion-source ledger traffic (Claude Code OTLP, etc.) is unioned in the same way.
- **Window**: optional; defaults to start-of-month → now.
- **Response** (camelCase, mirrors the tRPC payload one-to-one):
  ```json
  {
    "summary": { "spentUsd", "billedUsd", "requests", "promptTokens", "completionTokens", "mostUsedModel": { "name", "usagePct" } | null },
    "dailyBuckets": [ { "day", "spentUsd", "billedUsd", "requests" } ],
    "breakdownByModel": [ { "label", "spentUsd", "billedUsd", "requests" } ]
  }
  ```
- **Errors**: `400` if the key's project is not a personal project; `401` if unauthenticated.

## Layering

Route → existing `PersonalUsageService`. No new repository or Prisma access; the route only reads `c.get("project")` from the established project-API-key middleware (same pattern as `/api/model-defaults`).

## Tests

`src/app/api/me/__tests__/me-usage-api.integration.test.ts` — 4 scenarios against **real Postgres + ClickHouse** (no mocks): 401 unauth, 200 personal-key empty-state envelope, 200 explicit window, 400 shared-project-key rejection. All green locally.

Spec: `specs/ai-gateway/governance/me-usage-rest-api.feature`.

## Notes

Part of a broader effort to make governance/usage data consumable by external clients. Registered in both the runtime API router and the OpenAPI spec generator, so it lands in `openapiLangWatch.json` (and the generated SDKs) on the next regen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **My Account** endpoint **GET /api/me/usage** for personal usage (overall summary, daily rollups, and per-model breakdown).
  * Supports optional time-window filtering via `windowStartMs`/`windowEndMs`.
* **Bug Fixes**
  * Enforces personal-workspace API keys only, with clear 400/401 responses; validates both window bounds and rejects inverted ranges.
  * Returns a consistent empty-state payload (zeroed summary/buckets and `mostUsedModel: null`) when no usage exists.
* **Tests**
  * Added integration tests covering auth, window validation, empty/non-personal scenarios.
* **Documentation**
  * Added OpenAPI spec generation and a behavior feature definition for the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->