### PR TITLE
fix(security): bump jupyter-server to 2.20.0 (CVE-2026-44727 critical XSS)

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -118,3 +118,10 @@ tests = [
 
 [tool.uv]
 exclude-newer = "7 days"
+
+# Transitive-dependency security pins. Keep these even when the importing
+# package isn't a direct dependency, so a future re-resolution can't silently
+# pull a vulnerable version back in.
+constraint-dependencies = [
+    "jupyter-server>=2.20.0",  # security: CVE-2026-44727 stored XSS in nbconvert handlers (GHSA-fcw5-x6j4-ccmp)
+]

--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -20,8 +20,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-23T06:11:08.493859Z"
 exclude-newer-span = "P7D"
+
+[manifest]
+constraints = [{ name = "jupyter-server", specifier = ">=2.20.0" }]
 
 [[package]]
 name = "accelerate"
@@ -2793,7 +2796,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-server"
-version = "2.18.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2816,9 +2819,9 @@ dependencies = [
     { name = "traitlets" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/15/1eacb0fcb79ef86e8a0a79a708e6ad7435f6f223097dd29a4ce861fabc44/jupyter_server-2.18.2.tar.gz", hash = "sha256:06b4f40d8a7a00bb39d5216859c81374a0e7cfefe6d8a5a7facc5a5c37c679a7", size = 753177, upload-time = "2026-05-06T07:04:36.274Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/dc/db3a582633170186f8c8b31298d7eb26ad0eb031a1f53476c258b64eed05/jupyter_server-2.20.0.tar.gz", hash = "sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14", size = 756523, upload-time = "2026-06-17T12:09:09.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/50/ecf4f70d65bdb7519b28a33d1b2fee8a4b4ba1ae1a92f15d97e877c5de21/jupyter_server-2.18.2-py3-none-any.whl", hash = "sha256:fa5e46539ded65791838035a2b6001f13e54d5f64b8b3752eb1e91fdd641a5b8", size = 391907, upload-time = "2026-05-06T07:04:34.014Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl", hash = "sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc", size = 393143, upload-time = "2026-06-17T12:09:07.234Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps `jupyter-server` **2.18.2 → 2.20.0** in `python-sdk/uv.lock` to resolve [Dependabot alert #1515](https://github.com/langwatch/langwatch/security/dependabot/1515).

## Why

**CVE-2026-44727 / GHSA-fcw5-x6j4-ccmp — critical (CVSS 4.0: 9.3), stored XSS.**

`jupyter_server`'s `NbconvertFileHandler` / `NbconvertPostHandler` render user-authored notebook HTML under the Jupyter origin **without a `sandbox` directive in their CSP**. Combined with `nbconvert.HTMLExporter`'s default non-sanitizing behavior, a notebook carrying an HTML payload in a `display_data` output triggers stored XSS — an authenticated victim who opens `/nbconvert/html/<path>` can have their session token exfiltrated, gaining full `/api/*` authority and kernel RCE. Patched upstream in 2.20.0 ([6cbee8d](https://github.com/jupyter-server/jupyter_server/commit/6cbee8d65e71abac851c4492fea987ad080580bd)).

## Scope

- Transitive dependency (via `jupyter` / `jupyterlab`), runtime scope, in the **python-sdk** only.
- Lockfile diff is surgical — `jupyter-server` is the only package whose version changes (2.18.2 → 2.20.0). The `exclude-newer` metadata line updates as a normal side-effect of `uv lock` resolving the relative `P7D` span to an absolute snapshot.
- Added a `constraint-dependencies` pin (`jupyter-server>=2.20.0`) in `pyproject.toml` so a future re-resolution can't silently pull a vulnerable version back in, matching the existing security-pin convention used for `jupyterlab`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a dependency constraint to keep a security-related package version pinned during future dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->