### PR TITLE
fix(dev): don't fail make quickstart when our own redis is already running

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -85,10 +85,12 @@ services:
   # own. Compose treats this as belonging to the first project that brings it
   # up; subsequent `quickstart`s detect the running container and reuse it.
   #
-  # Prerequisite: no host-side redis-server may be holding 6379. `make
-  # quickstart` calls `check_host_redis_collision` (scripts/dev.sh) which
-  # detects this case and prints a clear hint. On macOS:
-  # `brew services stop redis`. On Linux: `sudo systemctl stop redis-server`.
+  # Prerequisite: no NON-Docker process (e.g. a host redis-server) may be
+  # holding 6379. `make quickstart` calls `check_host_redis_collision`
+  # (scripts/dev.sh), which exempts this project's own already-running redis
+  # container (idempotent reuse) and only errors on a foreign listener it cannot
+  # rebind over. To free a host redis — macOS: `brew services stop redis`;
+  # Linux: `sudo systemctl stop redis-server`.
   redis:
     image: redis:alpine
     ports:

--- a/scripts/__tests__/dev-redis-detection.unit.bats
+++ b/scripts/__tests__/dev-redis-detection.unit.bats
@@ -157,3 +157,152 @@ teardown() {
   [[ "$output" == *"Starting: redis compose service"* ]]
   [[ "$output" == *"__COMPOSE_CALLED__ up -d redis"* ]]
 }
+
+# --- check_host_redis_collision() (container-preset pre-flight guard) ---
+#
+# Why these exist: check_host_redis_collision used to hard-fail whenever
+# *anything* held host port 6379. That false-positives on the common case of
+# re-running quickstart against an already-up stack — the compose `redis`
+# service binds 6379:6379, so our own running container owns the port even
+# though `docker compose up` would idempotently reuse it. The guard now exempts
+# this project's own redis container and only errors on a foreign listener.
+
+# @scenario "an explicit SKIP flag short-circuits the guard"
+@test "check_host_redis_collision: SKIP_HOST_REDIS_CHECK=1 -> returns 0" {
+  run bash -c '
+    scripts_dir="$1"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    redis_port_in_use() { return 0; }
+    redis_6379_owned_by_this_project() { return 1; }
+    SKIP_HOST_REDIS_CHECK=1 check_host_redis_collision
+  ' _ "$SCRIPT_DIR"
+  [ "$status" -eq 0 ]
+}
+
+# @scenario "port 6379 free -> guard passes (own redis container will start)"
+@test "check_host_redis_collision: 6379 free -> returns 0" {
+  run bash -c '
+    scripts_dir="$1"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    redis_port_in_use() { return 1; }
+    redis_6379_owned_by_this_project() { return 1; }
+    check_host_redis_collision
+  ' _ "$SCRIPT_DIR"
+  [ "$status" -eq 0 ]
+}
+
+# @scenario "this project's own running redis on 6379 is reused, not rejected"
+@test "check_host_redis_collision: own redis container on 6379 -> returns 0, no error" {
+  run bash -c '
+    scripts_dir="$1"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    redis_port_in_use() { return 0; }
+    redis_6379_owned_by_this_project() { return 0; }
+    check_host_redis_collision
+  ' _ "$SCRIPT_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"already listening on host port 6379"* ]]
+}
+
+# @scenario "a foreign (non-Docker) listener on 6379 still fails loudly"
+@test "check_host_redis_collision: foreign listener on 6379 -> error + exit 1" {
+  run bash -c '
+    scripts_dir="$1"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    redis_port_in_use() { return 0; }
+    redis_6379_owned_by_this_project() { return 1; }
+    check_host_redis_collision
+  ' _ "$SCRIPT_DIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not"*"this dev stack"*"own redis container"* ]]
+  [[ "$output" == *"SKIP_HOST_REDIS_CHECK=1"* ]]
+}
+
+# --- redis_6379_owned_by_this_project() ---
+
+# @scenario "absent docker degrades to not-owned (no crash, falls through to guard)"
+@test "redis_6379_owned_by_this_project: docker absent -> not owned" {
+  run bash -c '
+    scripts_dir="$1"; empty_dir="$2"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    PATH="$empty_dir"
+    redis_6379_owned_by_this_project
+  ' _ "$SCRIPT_DIR" "$EMPTY_DIR"
+  [ "$status" -ne 0 ]
+}
+
+# @scenario "a container publishing host 6379 under THIS compose project is owned"
+@test "redis_6379_owned_by_this_project: matching compose project -> owned" {
+  STUB_DOCKER="$TEST_DIR/bin-docker-match"
+  mkdir -p "$STUB_DOCKER"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'case "$*" in' \
+    '  *"ps -q --filter publish=6379"*) echo cidA ;;' \
+    '  *"inspect"*"compose.project"*) echo my-worktree ;;' \
+    '  *) ;;' \
+    'esac' > "$STUB_DOCKER/docker"
+  chmod +x "$STUB_DOCKER/docker"
+  run bash -c '
+    scripts_dir="$1"; stub="$2"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    PATH="$stub:$PATH"
+    COMPOSE_PROJECT_NAME=my-worktree redis_6379_owned_by_this_project
+  ' _ "$SCRIPT_DIR" "$STUB_DOCKER"
+  [ "$status" -eq 0 ]
+}
+
+# @scenario "a container publishing host 6379 under ANOTHER project is not owned"
+@test "redis_6379_owned_by_this_project: foreign compose project -> not owned" {
+  STUB_DOCKER="$TEST_DIR/bin-docker-foreign"
+  mkdir -p "$STUB_DOCKER"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'case "$*" in' \
+    '  *"ps -q --filter publish=6379"*) echo cidA ;;' \
+    '  *"inspect"*"compose.project"*) echo some-other-app ;;' \
+    '  *) ;;' \
+    'esac' > "$STUB_DOCKER/docker"
+  chmod +x "$STUB_DOCKER/docker"
+  run bash -c '
+    scripts_dir="$1"; stub="$2"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    PATH="$stub:$PATH"
+    COMPOSE_PROJECT_NAME=my-worktree redis_6379_owned_by_this_project
+  ' _ "$SCRIPT_DIR" "$STUB_DOCKER"
+  [ "$status" -ne 0 ]
+}
+
+# @scenario "nothing publishing host 6379 -> not owned (e.g. stray redis on another host port)"
+@test "redis_6379_owned_by_this_project: no publisher on 6379 -> not owned" {
+  STUB_DOCKER="$TEST_DIR/bin-docker-none"
+  mkdir -p "$STUB_DOCKER"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    '# ps returns nothing; any inspect returns nothing' \
+    'exit 0' > "$STUB_DOCKER/docker"
+  chmod +x "$STUB_DOCKER/docker"
+  run bash -c '
+    scripts_dir="$1"; stub="$2"
+    set --
+    cd "$scripts_dir" || exit 90
+    source ./dev.sh
+    PATH="$stub:$PATH"
+    COMPOSE_PROJECT_NAME=my-worktree redis_6379_owned_by_this_project
+  ' _ "$SCRIPT_DIR" "$STUB_DOCKER"
+  [ "$status" -ne 0 ]
+}

--- a/scripts/__tests__/dev-redis-detection.unit.bats
+++ b/scripts/__tests__/dev-redis-detection.unit.bats
@@ -167,7 +167,7 @@ teardown() {
 # though `docker compose up` would idempotently reuse it. The guard now exempts
 # this project's own redis container and only errors on a foreign listener.
 
-# @scenario "an explicit SKIP flag short-circuits the guard"
+# @scenario "the host-redis collision check is skipped when SKIP_HOST_REDIS_CHECK is set"
 @test "check_host_redis_collision: SKIP_HOST_REDIS_CHECK=1 -> returns 0" {
   run bash -c '
     scripts_dir="$1"
@@ -181,7 +181,7 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
-# @scenario "port 6379 free -> guard passes (own redis container will start)"
+# @scenario "container presets pass the host-redis check when 6379 is free"
 @test "check_host_redis_collision: 6379 free -> returns 0" {
   run bash -c '
     scripts_dir="$1"
@@ -210,7 +210,7 @@ teardown() {
   [[ "$output" != *"already listening on host port 6379"* ]]
 }
 
-# @scenario "a foreign (non-Docker) listener on 6379 still fails loudly"
+# @scenario "a foreign listener on 6379 fails the host-redis check loudly"
 @test "check_host_redis_collision: foreign listener on 6379 -> error + exit 1" {
   run bash -c '
     scripts_dir="$1"
@@ -228,7 +228,7 @@ teardown() {
 
 # --- redis_6379_owned_by_this_project() ---
 
-# @scenario "absent docker degrades to not-owned (no crash, falls through to guard)"
+# @scenario "redis ownership degrades to not-ours when docker is unavailable"
 @test "redis_6379_owned_by_this_project: docker absent -> not owned" {
   run bash -c '
     scripts_dir="$1"; empty_dir="$2"
@@ -241,7 +241,7 @@ teardown() {
   [ "$status" -ne 0 ]
 }
 
-# @scenario "a container publishing host 6379 under THIS compose project is owned"
+# @scenario "a redis on host 6379 from this same project counts as ours"
 @test "redis_6379_owned_by_this_project: matching compose project -> owned" {
   STUB_DOCKER="$TEST_DIR/bin-docker-match"
   mkdir -p "$STUB_DOCKER"
@@ -264,7 +264,7 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
-# @scenario "a container publishing host 6379 under ANOTHER project is not owned"
+# @scenario "a redis on host 6379 from another project does not count as ours"
 @test "redis_6379_owned_by_this_project: foreign compose project -> not owned" {
   STUB_DOCKER="$TEST_DIR/bin-docker-foreign"
   mkdir -p "$STUB_DOCKER"
@@ -287,7 +287,7 @@ teardown() {
   [ "$status" -ne 0 ]
 }
 
-# @scenario "nothing publishing host 6379 -> not owned (e.g. stray redis on another host port)"
+# @scenario "a redis mapped to a different host port does not count as ours"
 @test "redis_6379_owned_by_this_project: no publisher on 6379 -> not owned" {
   STUB_DOCKER="$TEST_DIR/bin-docker-none"
   mkdir -p "$STUB_DOCKER"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -155,10 +155,9 @@ EOF
   done
 }
 
-# Predicate: is something already listening on host port 6379? Used by
-# frontend-only to decide whether to start its own redis container or reuse
-# an existing host redis. Mirrors check_host_redis_collision's detection but
-# returns a status instead of exiting.
+# Predicate: is something already listening on host port 6379? Shared by
+# check_host_redis_collision (the pre-flight guard for container presets) and
+# frontend-only's reuse/start branch. Returns a status; never exits.
 redis_port_in_use() {
   if command -v lsof >/dev/null 2>&1; then
     [ -n "$(lsof -iTCP:6379 -sTCP:LISTEN -t 2>/dev/null | head -n1)" ]
@@ -180,22 +179,38 @@ redis_listener_is_usable() {
   redis-cli -u redis://localhost:6379 ping 2>/dev/null | grep -qx 'PONG'
 }
 
-# Detect a host-side process holding port 6379 before redis tries to bind.
+# Predicate: is host port 6379 published by THIS compose project's own redis
+# container? The compose `redis` service binds 6379:6379, so when our own stack
+# is already up (a prior `make quickstart` left it running), `docker compose up`
+# idempotently reuses that container — re-running quickstart must NOT treat it as
+# a port collision. `--filter publish=6379` matches by the *host* published port,
+# so a stray redis mapped to some other host port (e.g. 55002->6379) is correctly
+# ignored. Another worktree's redis is rejected earlier by
+# check_stateful_collision with a clearer, volume-scoped message, so only our own
+# project's container reaches this exemption.
+redis_6379_owned_by_this_project() {
+  command -v docker >/dev/null 2>&1 || return 1
+  local me="${COMPOSE_PROJECT_NAME:-langwatch}" cid project
+  for cid in $(docker ps -q --filter "publish=6379" 2>/dev/null); do
+    project=$(docker inspect -f '{{index .Config.Labels "com.docker.compose.project"}}' "$cid" 2>/dev/null || true)
+    [ "$project" = "$me" ] && return 0
+  done
+  return 1
+}
+
+# Detect a host-side process holding port 6379 before the compose redis service
+# tries to bind it. Our own already-running redis container is exempt: docker
+# compose reuses it, so re-running quickstart on an up stack must not fail.
 check_host_redis_collision() {
   [ "${SKIP_HOST_REDIS_CHECK:-0}" = "1" ] && return 0
-  local pid=""
-  if command -v lsof >/dev/null 2>&1; then
-    pid=$(lsof -iTCP:6379 -sTCP:LISTEN -t 2>/dev/null | head -n1)
-  elif command -v ss >/dev/null 2>&1; then
-    ss -ltnH "sport = :6379" 2>/dev/null | grep -q ":6379" && pid="<unknown>"
-  fi
-  [ -z "$pid" ] && return 0
+  redis_port_in_use || return 0
+  redis_6379_owned_by_this_project && return 0
   cat >&2 <<EOF
-ERROR: A process is already listening on host port 6379 (redis).
-       The dev-stack redis container needs that port to bind. Stop the
-       host-side redis first (e.g. 'brew services stop redis' on macOS,
-       'sudo systemctl stop redis-server' on Linux), or set
-       SKIP_HOST_REDIS_CHECK=1 if you've intentionally repointed the dev
+ERROR: A process is already listening on host port 6379 (redis), and it is not
+       this dev stack's own redis container. The compose redis service needs
+       that port to bind. Stop the host-side redis first (e.g. 'brew services
+       stop redis' on macOS, 'sudo systemctl stop redis-server' on Linux), or
+       set SKIP_HOST_REDIS_CHECK=1 if you've intentionally repointed the dev
        stack at a host redis.
 EOF
   exit 1

--- a/specs/setup/quickstart-entry-point.feature
+++ b/specs/setup/quickstart-entry-point.feature
@@ -107,6 +107,62 @@ Feature: make quickstart is the single dev environment entry point with intent-b
     When run_frontend_only runs
     Then it starts its own redis compose container for the in-process workers
 
+  # --- Container presets reuse their own running redis (#5213) ---
+  # Container presets (all-local, all-local-nlp, dev-storage, full-local) start a
+  # redis container bound to host :6379. A blunt "anything on :6379 fails" check
+  # false-positives when this same project's redis is already running from a prior
+  # run — docker compose would simply reuse it. The check now exempts this
+  # project's own redis container and only fails on a foreign listener it cannot
+  # bind over. Bound to `scripts/__tests__/dev-redis-detection.unit.bats`.
+
+  @unit
+  Scenario: the host-redis collision check is skipped when SKIP_HOST_REDIS_CHECK is set
+    Given SKIP_HOST_REDIS_CHECK is set to 1
+    When check_host_redis_collision runs
+    Then it returns success without inspecting the port
+
+  @unit
+  Scenario: container presets pass the host-redis check when 6379 is free
+    Given host port 6379 is free
+    When check_host_redis_collision runs
+    Then it returns success so the preset can start its own redis container
+
+  @unit
+  Scenario: this project's own running redis on 6379 is reused, not rejected
+    Given this project's own redis container already holds host port 6379
+    When check_host_redis_collision runs
+    Then it returns success and prints no collision error
+
+  @unit
+  Scenario: a foreign listener on 6379 fails the host-redis check loudly
+    Given host port 6379 is held by a process that is not this project's redis
+    When check_host_redis_collision runs
+    Then it exits non-zero with a message explaining how to free the port or skip the check
+
+  @unit
+  Scenario: redis ownership degrades to not-ours when docker is unavailable
+    Given docker is not on PATH
+    When redis_6379_owned_by_this_project runs
+    Then it reports the port is not owned by this project without crashing
+
+  @unit
+  Scenario: a redis on host 6379 from this same project counts as ours
+    Given a container from this compose project publishes host port 6379
+    When redis_6379_owned_by_this_project runs
+    Then it reports the port is owned by this project
+
+  @unit
+  Scenario: a redis on host 6379 from another project does not count as ours
+    Given a container from a different compose project publishes host port 6379
+    When redis_6379_owned_by_this_project runs
+    Then it reports the port is not owned by this project
+
+  @unit
+  Scenario: a redis mapped to a different host port does not count as ours
+    Given no container publishes host port 6379
+    When redis_6379_owned_by_this_project runs
+    Then it reports the port is not owned by this project
+
   # --- URL rewrite per mode (#3860 AC#6) ---
 
   @unit


### PR DESCRIPTION
## Why

Closes #5213

`make quickstart` (every container preset: `all-local`, `all-local-nlp`, `dev-storage`, `full-local`) hard-failed with `ERROR: A process is already listening on host port 6379 (redis)` **even when the listener was this dev stack's own redis container** from a prior run. `docker compose up` would idempotently reuse that container, so the failure was a false-positive that forced a `make down` (or `SKIP_HOST_REDIS_CHECK=1`) before every re-run.

## What changed

`check_host_redis_collision()` (`scripts/dev.sh`) used a blunt rule: *anything* on host `:6379` → `exit 1`. It couldn't tell our own reusable redis apart from a foreign listener that genuinely blocks the bind.

The guard now **exempts this compose project's own redis container** before erroring. A foreign / non-Docker listener still fails loudly with the same hint, and `SKIP_HOST_REDIS_CHECK=1` still bypasses it. Cross-worktree redis is already rejected upstream by `check_stateful_collision` with a clearer, volume-scoped message, so it never reaches this exemption.

Also folds the duplicated `lsof`/`ss` detection onto the existing `redis_port_in_use` predicate (the same one `frontend-only` uses), and updates the stale prerequisite comment in `compose.dev.yml`.

## How it works

New predicate `redis_6379_owned_by_this_project()`:

- `docker ps -q --filter publish=6379` lists containers publishing the **host** port 6379 (so a stray redis mapped to another host port like `55002->6379` is correctly ignored).
- For each, compare its `com.docker.compose.project` label to `${COMPOSE_PROJECT_NAME:-langwatch}`. A match = our own stack already up → reuse, return 0.

`check_host_redis_collision()` becomes: `SKIP` flag → `port free` → `owned by us` → else error.

## Test plan

- `scripts/__tests__/dev-redis-detection.unit.bats` — added 8 scenarios covering the guard (SKIP flag, port free, own container reused, foreign listener still fails) and the new ownership predicate (docker absent, matching project, foreign project, no publisher). All 14 tests in the file pass (`bats scripts/__tests__/dev-redis-detection.unit.bats`).
- `bash -n scripts/dev.sh` clean; `shellcheck` introduces no new warnings (only pre-existing SC2155 on unrelated `find_free_port` lines).
- The foreign-listener regression test fails against the old blanket logic and passes with the exemption.

## Anything surprising?

- For container presets a *host* (non-Docker) redis is still a genuine conflict — the compose `redis` service can't rebind `6379:6379` over it — so we keep failing there rather than silently rerouting. Reusing a host redis only makes sense for `frontend-only` (host `pnpm dev`), which already does it via `redis_listener_is_usable`.
- bats files aren't run by a dedicated CI job today; verified locally with upstream bats-core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host Redis port `6379` collision detection when starting the local development stack, avoiding false failures when this project’s own Redis is already running.
  * Updated failure messaging to better explain when `6379` is occupied by another process and guidance to resolve it; collision checks can still be skipped via `SKIP_HOST_REDIS_CHECK=1`.
* **Documentation**
  * Refined quickstart guidance with clearer prerequisites and OS-specific steps to free the host Redis listener.
* **Tests**
  * Added coverage for the updated Redis collision and “ownership” detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->