### PR TITLE
fix(governance): scope /me/usage ingestion-ledger queries to the org's governance tenant

### DIFF
--- a/langwatch/ee/governance/services/governanceProject.service.ts
+++ b/langwatch/ee/governance/services/governanceProject.service.ts
@@ -42,6 +42,27 @@ export const PROJECT_KIND = {
 export type ProjectKind = (typeof PROJECT_KIND)[keyof typeof PROJECT_KIND];
 
 /**
+ * Read-only lookup of the org's hidden Governance Project. Unlike
+ * `ensureHiddenGovernanceProject`, this NEVER creates — read paths (e.g.
+ * the personal-usage rollups powering /me) must not provision a
+ * Governance Project as a side effect of a GET. Returns null when the org
+ * has never minted an ingestion source, in which case there is no
+ * ingestion-ledger traffic to union in.
+ */
+export async function findHiddenGovernanceProject(
+  prisma: PrismaClient,
+  organizationId: string,
+): Promise<Project | null> {
+  return prisma.project.findFirst({
+    where: {
+      kind: PROJECT_KIND.INTERNAL_GOVERNANCE,
+      team: { organizationId },
+      archivedAt: null,
+    },
+  });
+}
+
+/**
  * Resolve the org's hidden Governance Project, creating one on first
  * call. Idempotent — concurrent callers may briefly race; the
  * org-scoped composite-unique guard on (teamId, kind) collapses the
@@ -56,13 +77,7 @@ export async function ensureHiddenGovernanceProject(
   prisma: PrismaClient,
   organizationId: string,
 ): Promise<Project> {
-  const existing = await prisma.project.findFirst({
-    where: {
-      kind: PROJECT_KIND.INTERNAL_GOVERNANCE,
-      team: { organizationId },
-      archivedAt: null,
-    },
-  });
+  const existing = await findHiddenGovernanceProject(prisma, organizationId);
   if (existing) return existing;
 
   const team = await prisma.team.findFirst({

--- a/langwatch/ee/governance/services/governanceProject.service.ts
+++ b/langwatch/ee/governance/services/governanceProject.service.ts
@@ -49,10 +49,13 @@ export type ProjectKind = (typeof PROJECT_KIND)[keyof typeof PROJECT_KIND];
  * has never minted an ingestion source, in which case there is no
  * ingestion-ledger traffic to union in.
  */
-export async function findHiddenGovernanceProject(
-  prisma: PrismaClient,
-  organizationId: string,
-): Promise<Project | null> {
+export async function findHiddenGovernanceProject({
+  prisma,
+  organizationId,
+}: {
+  prisma: PrismaClient;
+  organizationId: string;
+}): Promise<Project | null> {
   return prisma.project.findFirst({
     where: {
       kind: PROJECT_KIND.INTERNAL_GOVERNANCE,
@@ -77,7 +80,10 @@ export async function ensureHiddenGovernanceProject(
   prisma: PrismaClient,
   organizationId: string,
 ): Promise<Project> {
-  const existing = await findHiddenGovernanceProject(prisma, organizationId);
+  const existing = await findHiddenGovernanceProject({
+    prisma,
+    organizationId,
+  });
   if (existing) return existing;
 
   const team = await prisma.team.findFirst({

--- a/langwatch/ee/governance/services/personalUsage.service.ts
+++ b/langwatch/ee/governance/services/personalUsage.service.ts
@@ -27,12 +27,11 @@
  * render "no usage yet" cards without special-case branching.
  */
 import type { ClickHouseClient } from "@clickhouse/client";
-
+import { ANALYTICS_CLICKHOUSE_SETTINGS } from "~/server/analytics/clickhouse/clickhouse-analytics.service";
 import {
   getClickHouseClientForProject,
   isClickHouseEnabled,
 } from "~/server/clickhouse/clickhouseClient";
-import { ANALYTICS_CLICKHOUSE_SETTINGS } from "~/server/analytics/clickhouse/clickhouse-analytics.service";
 
 export interface PersonalUsageWindow {
   /** Inclusive UTC start of the rollup window. */
@@ -84,14 +83,32 @@ export interface PersonalUsageQueryInput {
   /** Defaults to start-of-current-month → now if omitted. */
   window?: PersonalUsageWindow;
   /**
-   * Owner's userId. When supplied, the service unions in any
-   * gateway_budget_ledger_events written under PRINCIPAL scope for
-   * this user — picks up Claude Code OTLP / other ingestion-source
-   * traffic that lands under the hidden Governance Project tenant
-   * rather than the user's personal-project tenant. Without it,
-   * summaries / buckets / breakdowns reflect only gateway-VK traffic.
+   * Owner's userId. When supplied alongside `ingestionTenantId`, the
+   * service unions in any gateway_budget_ledger_events written under
+   * PRINCIPAL scope for this user — picks up Claude Code OTLP / other
+   * ingestion-source traffic that lands under the hidden Governance
+   * Project tenant rather than the user's personal-project tenant.
+   * Without it, summaries / buckets / breakdowns reflect only gateway-VK
+   * traffic.
    */
   userId?: string;
+  /**
+   * The org's hidden Governance Project tenant id. Ingestion-source
+   * ledger rows are written under THIS tenant (ingestionRoutes.ts writes
+   * `TenantId: govProject.id`), never the personal project. It is the
+   * mandatory tenant scope for the PRINCIPAL-ledger union:
+   *   - Correctness: a user in multiple orgs has PRINCIPAL rows under
+   *     each org's governance tenant. Filtering on this org's tenant
+   *     keeps /me scoped to the right org instead of summing the user's
+   *     spend across every org they belong to.
+   *   - Performance: `TenantId` is the leading ORDER BY key on
+   *     gateway_budget_ledger_events, so this lets ClickHouse prune to
+   *     the tenant's parts instead of scanning every tenant's ledger.
+   * Omitted → the union is skipped entirely (an org with no Governance
+   * Project has no ingestion traffic, and an unbounded cross-tenant scan
+   * is never the right fallback).
+   */
+  ingestionTenantId?: string;
 }
 
 /**
@@ -110,13 +127,16 @@ export interface PersonalUsageQueryInput {
  *             PRINCIPAL the User.id).
  *   AmountUSD, TokensInput, TokensOutput, Model, OccurredAt, etc.
  *
- * Personal-usage queries pin Scope='principal' (lowercase, matching
- * `scopeToClickHouse` in budget.clickhouse.repository.ts:539) AND
- * ScopeId=userId so
- * we get exactly the per-user ledger rows. Multi-budget events show
- * up multiple times across scope rows (one row per applicable budget),
- * but the Scope/ScopeId pair narrows to the user's principal slice
- * cleanly.
+ * Personal-usage queries pin TenantId=<org's hidden Governance Project>
+ * AND Scope='principal' (lowercase, matching `scopeToClickHouse` in
+ * budget.clickhouse.repository.ts:539) AND ScopeId=userId so we get
+ * exactly the per-user ledger rows for THIS org. The TenantId pin both
+ * prunes partitions (it is the leading ORDER BY key) and scopes a
+ * multi-org user to the current org — without it the query would sum the
+ * user's principal spend across every org they belong to. Multi-budget
+ * events show up multiple times across scope rows (one row per applicable
+ * budget), but the Scope/ScopeId pair narrows to the user's principal
+ * slice cleanly.
  */
 
 export class PersonalUsageService {
@@ -124,9 +144,7 @@ export class PersonalUsageService {
    * Returns aggregated spend + token + model summary for the window.
    * Empty state safe — returns zeros + null model if no traces.
    */
-  async summary(
-    input: PersonalUsageQueryInput,
-  ): Promise<PersonalUsageSummary> {
+  async summary(input: PersonalUsageQueryInput): Promise<PersonalUsageSummary> {
     const window = input.window ?? defaultMonthWindow();
     const client = await getClickHouseClientForProject(input.personalProjectId);
     if (!client) return emptySummary();
@@ -144,12 +162,14 @@ export class PersonalUsageService {
     // hidden governance project tenant, NOT the user's personal
     // project — so the trace_summaries query above misses them. Pull
     // per-principal ledger rows and merge.
-    const ingestion = input.userId
-      ? await this.queryIngestionPrincipalSummary(client, {
-          userId: input.userId,
-          window,
-        })
-      : null;
+    const ingestion =
+      input.userId && input.ingestionTenantId
+        ? await this.queryIngestionPrincipalSummary(client, {
+            tenantId: input.ingestionTenantId,
+            userId: input.userId,
+            window,
+          })
+        : null;
 
     const totalCost = summaryRow.totalCost + (ingestion?.totalCost ?? 0);
     // The gateway ledger records real per-token spend (virtual-key traffic the
@@ -174,8 +194,7 @@ export class PersonalUsageService {
     }
     if (
       ingestion?.topModel &&
-      (!mergedTopModel ||
-        ingestion.topModel.requests > mergedTopModel.requests)
+      (!mergedTopModel || ingestion.topModel.requests > mergedTopModel.requests)
     ) {
       mergedTopModel = ingestion.topModel;
     }
@@ -202,7 +221,9 @@ export class PersonalUsageService {
    * Daily spend buckets across the window. UTC day boundaries.
    * Empty buckets are filled with zeros so the chart line connects.
    */
-  async dailyBuckets(input: PersonalUsageQueryInput): Promise<PersonalUsageBucket[]> {
+  async dailyBuckets(
+    input: PersonalUsageQueryInput,
+  ): Promise<PersonalUsageBucket[]> {
     const window = input.window ?? defaultLast14DaysWindow();
     const client = await getClickHouseClientForProject(input.personalProjectId);
     if (!client) return fillEmptyBuckets(window);
@@ -264,8 +285,9 @@ export class PersonalUsageService {
 
     // Ingestion-source ledger union: per-day spend for the user's
     // PRINCIPAL-scope rows, merged into the same byDay map.
-    if (input.userId) {
+    if (input.userId && input.ingestionTenantId) {
       const ledgerBuckets = await this.queryIngestionPrincipalBuckets(client, {
+        tenantId: input.ingestionTenantId,
         userId: input.userId,
         window,
       });
@@ -287,7 +309,7 @@ export class PersonalUsageService {
 
   private async queryIngestionPrincipalBuckets(
     client: ClickHouseClient,
-    params: { userId: string; window: PersonalUsageWindow },
+    params: { tenantId: string; userId: string; window: PersonalUsageWindow },
   ): Promise<PersonalUsageBucket[]> {
     if (!isClickHouseEnabled()) return [];
     try {
@@ -298,7 +320,8 @@ export class PersonalUsageService {
             sum(AmountUSD)     AS SpentUsd,
             countDistinct(GatewayRequestId) AS Requests
           FROM gateway_budget_ledger_events
-          WHERE Scope = 'principal'
+          WHERE TenantId = {tenantId:String}
+            AND Scope = 'principal'
             AND ScopeId = {userId:String}
             AND OccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})
             AND OccurredAt <  fromUnixTimestamp64Milli({toMs:Int64})
@@ -307,6 +330,7 @@ export class PersonalUsageService {
           SETTINGS ${formatSettings(ANALYTICS_CLICKHOUSE_SETTINGS)}
         `,
         query_params: {
+          tenantId: params.tenantId,
           userId: params.userId,
           fromMs: params.window.start.getTime(),
           toMs: params.window.end.getTime(),
@@ -412,10 +436,10 @@ export class PersonalUsageService {
 
     // Ingestion-source ledger union: per-model spend for the user's
     // PRINCIPAL-scope rows, merged into the same map.
-    if (input.userId) {
+    if (input.userId && input.ingestionTenantId) {
       const ledgerBreakdown = await this.queryIngestionPrincipalBreakdown(
         client,
-        { userId: input.userId, window },
+        { tenantId: input.ingestionTenantId, userId: input.userId, window },
       );
       for (const r of ledgerBreakdown) {
         const existing = aggregated.get(r.label) ?? {
@@ -438,7 +462,7 @@ export class PersonalUsageService {
 
   private async queryIngestionPrincipalBreakdown(
     client: ClickHouseClient,
-    params: { userId: string; window: PersonalUsageWindow },
+    params: { tenantId: string; userId: string; window: PersonalUsageWindow },
   ): Promise<PersonalUsageBreakdown[]> {
     if (!isClickHouseEnabled()) return [];
     try {
@@ -449,7 +473,8 @@ export class PersonalUsageService {
             sum(AmountUSD)             AS SpentUsd,
             countDistinct(GatewayRequestId) AS Requests
           FROM gateway_budget_ledger_events
-          WHERE Scope = 'principal'
+          WHERE TenantId = {tenantId:String}
+            AND Scope = 'principal'
             AND ScopeId = {userId:String}
             AND OccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})
             AND OccurredAt <  fromUnixTimestamp64Milli({toMs:Int64})
@@ -458,6 +483,7 @@ export class PersonalUsageService {
           SETTINGS ${formatSettings(ANALYTICS_CLICKHOUSE_SETTINGS)}
         `,
         query_params: {
+          tenantId: params.tenantId,
           userId: params.userId,
           fromMs: params.window.start.getTime(),
           toMs: params.window.end.getTime(),
@@ -572,7 +598,7 @@ export class PersonalUsageService {
    */
   private async queryIngestionPrincipalSummary(
     client: ClickHouseClient,
-    params: { userId: string; window: PersonalUsageWindow },
+    params: { tenantId: string; userId: string; window: PersonalUsageWindow },
   ): Promise<{
     totalCost: number;
     requestCount: number;
@@ -590,13 +616,15 @@ export class PersonalUsageService {
             sum(TokensInput)          AS PromptTokens,
             sum(TokensOutput)         AS CompletionTokens
           FROM gateway_budget_ledger_events
-          WHERE Scope = 'principal'
+          WHERE TenantId = {tenantId:String}
+            AND Scope = 'principal'
             AND ScopeId = {userId:String}
             AND OccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})
             AND OccurredAt <  fromUnixTimestamp64Milli({toMs:Int64})
           SETTINGS ${formatSettings(ANALYTICS_CLICKHOUSE_SETTINGS)}
         `,
         query_params: {
+          tenantId: params.tenantId,
           userId: params.userId,
           fromMs: params.window.start.getTime(),
           toMs: params.window.end.getTime(),
@@ -619,7 +647,8 @@ export class PersonalUsageService {
             Model AS Name,
             countDistinct(GatewayRequestId) AS Requests
           FROM gateway_budget_ledger_events
-          WHERE Scope = 'principal'
+          WHERE TenantId = {tenantId:String}
+            AND Scope = 'principal'
             AND ScopeId = {userId:String}
             AND OccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})
             AND OccurredAt <  fromUnixTimestamp64Milli({toMs:Int64})
@@ -629,6 +658,7 @@ export class PersonalUsageService {
           SETTINGS ${formatSettings(ANALYTICS_CLICKHOUSE_SETTINGS)}
         `,
         query_params: {
+          tenantId: params.tenantId,
           userId: params.userId,
           fromMs: params.window.start.getTime(),
           toMs: params.window.end.getTime(),

--- a/langwatch/src/app/api/me/[[...route]]/app.ts
+++ b/langwatch/src/app/api/me/[[...route]]/app.ts
@@ -99,7 +99,10 @@ export function registerMeRoutes(
         select: { organizationId: true },
       });
       const governanceProject = team
-        ? await findHiddenGovernanceProject(prisma, team.organizationId)
+        ? await findHiddenGovernanceProject({
+            prisma,
+            organizationId: team.organizationId,
+          })
         : null;
 
       const usage = new PersonalUsageService();

--- a/langwatch/src/app/api/me/[[...route]]/app.ts
+++ b/langwatch/src/app/api/me/[[...route]]/app.ts
@@ -1,3 +1,4 @@
+import { findHiddenGovernanceProject } from "@ee/governance/services/governanceProject.service";
 import { PersonalUsageService } from "@ee/governance/services/personalUsage.service";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "hono-openapi";
@@ -7,6 +8,7 @@ import {
   requires,
   type SecuredApp,
 } from "~/server/api/security";
+import { prisma } from "~/server/db";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
 
 import type { AuthMiddlewareVariables } from "../../middleware/auth";
@@ -85,10 +87,26 @@ export function registerMeRoutes(
           ? { start: new Date(windowStartMs), end: new Date(windowEndMs) }
           : undefined;
 
+      // Ingestion-source ledger rows (Claude Code OTLP, etc.) land under
+      // the org's hidden Governance Project tenant, not the personal
+      // project. Resolve it read-only (never provision on a GET) so the
+      // usage union is scoped to THIS org's tenant — both to prune
+      // ClickHouse partitions and to avoid summing a multi-org user's
+      // spend across every org. Absent when the org never minted an
+      // ingestion source, in which case there is no ledger traffic.
+      const team = await prisma.team.findUnique({
+        where: { id: project.teamId },
+        select: { organizationId: true },
+      });
+      const governanceProject = team
+        ? await findHiddenGovernanceProject(prisma, team.organizationId)
+        : null;
+
       const usage = new PersonalUsageService();
       const input = {
         personalProjectId: project.id,
         userId: project.ownerUserId,
+        ingestionTenantId: governanceProject?.id,
         window,
       };
 

--- a/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
+++ b/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
@@ -76,6 +76,57 @@ async function insertTrace({
   });
 }
 
+/**
+ * Minimal gateway_budget_ledger_events seed — mirrors the columns
+ * insertDebit writes (budget.clickhouse.repository.ts). PRINCIPAL-scope
+ * rows are how ingestion sources (Claude Code OTLP) land per-user spend,
+ * written under the org's hidden Governance Project tenant.
+ */
+async function insertLedgerRow({
+  ch,
+  tenantId,
+  scopeId,
+  amountUsd,
+  model,
+  occurredAt,
+}: {
+  ch: ClickHouseClient;
+  tenantId: string;
+  scopeId: string;
+  amountUsd: number;
+  model: string;
+  occurredAt: Date;
+}): Promise<void> {
+  await ch.insert({
+    table: "gateway_budget_ledger_events",
+    values: [
+      {
+        TenantId: tenantId,
+        BudgetId: `budget-${nanoid(6)}`,
+        Scope: "principal",
+        ScopeId: scopeId,
+        Window: "MONTH",
+        VirtualKeyId: "",
+        ProviderCredentialId: "",
+        GatewayRequestId: `req-${nanoid(8)}`,
+        AmountUSD: amountUsd,
+        TokensInput: 10,
+        TokensOutput: 5,
+        TokensCacheRead: 0,
+        TokensCacheWrite: 0,
+        Model: model,
+        ProviderSlot: "",
+        DurationMS: 0,
+        Status: "success",
+        OccurredAt: occurredAt.getTime(),
+        EventTimestamp: occurredAt.getTime(),
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
 describe("Feature: Personal usage REST API", () => {
   const ns = `me-usage-api-${nanoid(8)}`;
 
@@ -94,6 +145,14 @@ describe("Feature: Personal usage REST API", () => {
   // to prove the ownership guard (caller must own the project it targets).
   let otherUsersPersonalProjectId: string;
   let callerUserToken: string;
+
+  // Ingestion-source fixtures: a hidden Governance Project (where PRINCIPAL
+  // ledger rows land), plus a dedicated user + personal project so the
+  // ledger seed doesn't perturb the seededProject assertions above.
+  let governanceProjectId: string;
+  let ingestionProject: { id: string; apiKey: string };
+  let ingestionUserId: string;
+  const foreignGovTenantId = `project_foreign_gov_${nanoid(8)}`;
 
   // Deterministic window around the seeded in-window trace.
   const inWindow = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
@@ -233,6 +292,53 @@ describe("Feature: Personal usage REST API", () => {
       })
     ).token;
 
+    // Hidden Governance Project for the org — ingestion-source PRINCIPAL
+    // ledger rows are written under this tenant (ingestionRoutes.ts).
+    const governanceProject = await prisma.project.create({
+      data: {
+        id: `project_${nanoid()}`,
+        name: "Governance (internal)",
+        slug: `governance-${testOrganization.id}`,
+        language: "internal",
+        framework: "governance",
+        apiKey: `sk-lw-${nanoid(48)}`,
+        teamId: testTeam.id,
+        kind: "internal_governance",
+        isPersonal: false,
+        ownerUserId: null,
+      },
+    });
+    governanceProjectId = governanceProject.id;
+
+    // Dedicated ingestion user + personal project (keeps the seededProject
+    // assertions above untouched).
+    const ingestionUser = await prisma.user.create({
+      data: { name: "Ingestion User", email: `ingest-${ns}@example.com` },
+    });
+    ingestionUserId = ingestionUser.id;
+    await prisma.organizationUser.create({
+      data: {
+        userId: ingestionUserId,
+        organizationId: testOrganization.id,
+        role: OrganizationUserRole.MEMBER,
+      },
+    });
+    const ingestionApiKey = `sk-lw-${nanoid(48)}`;
+    const ingestionProj = await prisma.project.create({
+      data: {
+        id: `project_${nanoid()}`,
+        name: "Ingestion Personal Workspace",
+        slug: `--test-ingest-${nanoid(8)}`,
+        language: "typescript",
+        framework: "other",
+        apiKey: ingestionApiKey,
+        teamId: testTeam.id,
+        isPersonal: true,
+        ownerUserId: ingestionUserId,
+      },
+    });
+    ingestionProject = { id: ingestionProj.id, apiKey: ingestionApiKey };
+
     if (ch) {
       // One trace inside the window, one outside — the window test proves the
       // out-of-window trace is excluded.
@@ -252,12 +358,51 @@ describe("Feature: Personal usage REST API", () => {
         totalCost: 2.0,
         models: ["claude-opus-4-8"],
       });
+
+      // Ingestion ledger for ingestionUser: one row under THIS org's
+      // governance tenant (must count), one under a FOREIGN tenant (must be
+      // excluded by the TenantId scope — the multi-org-leak guard), and one
+      // under the right tenant but OUT of window (must be excluded by time).
+      await insertLedgerRow({
+        ch,
+        tenantId: governanceProjectId,
+        scopeId: ingestionUserId,
+        amountUsd: 0.3,
+        model: "claude-sonnet-4-6",
+        occurredAt: inWindow,
+      });
+      await insertLedgerRow({
+        ch,
+        tenantId: foreignGovTenantId,
+        scopeId: ingestionUserId,
+        amountUsd: 99.0,
+        model: "gpt-4o",
+        occurredAt: inWindow,
+      });
+      await insertLedgerRow({
+        ch,
+        tenantId: governanceProjectId,
+        scopeId: ingestionUserId,
+        amountUsd: 7.0,
+        model: "claude-sonnet-4-6",
+        occurredAt: outOfWindow,
+      });
     }
   });
 
   afterAll(async () => {
     if (ch) {
       await cleanupTestData(seededProject.id).catch(() => {});
+      // gateway_budget_ledger_events isn't covered by cleanupTestData.
+      // Best-effort delete the rows this suite seeded (unique ScopeId per
+      // run, so a lagging async mutation can't collide with other suites).
+      await ch
+        .command({
+          query:
+            "ALTER TABLE gateway_budget_ledger_events DELETE WHERE ScopeId = {scopeId:String}",
+          query_params: { scopeId: ingestionUserId },
+        })
+        .catch(() => {});
     }
     await prisma.apiKey
       .deleteMany({ where: { organizationId: testOrganization.id } })
@@ -466,6 +611,37 @@ describe("Feature: Personal usage REST API", () => {
           }),
         });
         expect(res.status).toBe(200);
+      });
+    });
+  });
+
+  describe("given ingestion-source spend in the org's governance tenant", () => {
+    describe("when reading usage for the explicit window", () => {
+      /** @scenario "Ingestion ledger spend is unioned, scoped to this org's tenant" */
+      it("unions only this org's governance-tenant rows, excluding foreign tenants", async () => {
+        const res = await app.request(
+          `/api/me/usage?windowStartMs=${windowStartMs}&windowEndMs=${windowEndMs}`,
+          {
+            headers: authHeaders({
+              apiKey: ingestionProject.apiKey,
+              projectId: ingestionProject.id,
+            }),
+          },
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+
+        // Only the in-org, in-window ledger row ($0.30, 1 request) counts.
+        // The $99 foreign-tenant row is excluded by the TenantId scope (the
+        // multi-org leak guard) and the $7 out-of-window row by time.
+        expect(body.summary.spentUsd).toBeCloseTo(0.3, 5);
+        expect(body.summary.requests).toBe(1);
+        const labels = body.breakdownByModel.map(
+          (m: { label: string }) => m.label,
+        );
+        expect(labels).toContain("claude-sonnet-4-6");
+        // gpt-4o only appears on the foreign-tenant row — proves exclusion.
+        expect(labels).not.toContain("gpt-4o");
       });
     });
   });

--- a/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
+++ b/langwatch/src/app/api/me/__tests__/me-usage-api.integration.test.ts
@@ -617,7 +617,7 @@ describe("Feature: Personal usage REST API", () => {
 
   describe("given ingestion-source spend in the org's governance tenant", () => {
     describe("when reading usage for the explicit window", () => {
-      /** @scenario "Ingestion ledger spend is unioned, scoped to this org's tenant" */
+      /** @scenario "Ingestion-source spend is included and scoped to this organization" */
       it("unions only this org's governance-tenant rows, excluding foreign tenants", async () => {
         const res = await app.request(
           `/api/me/usage?windowStartMs=${windowStartMs}&windowEndMs=${windowEndMs}`,

--- a/langwatch/src/server/api/routers/user.ts
+++ b/langwatch/src/server/api/routers/user.ts
@@ -567,10 +567,10 @@ export const userRouter = createTRPCRouter({
       // Ingestion-source ledger rows (Claude Code OTLP, etc.) land under
       // the org's hidden Governance Project tenant. Resolve it read-only
       // so the PRINCIPAL-ledger union is scoped to this org's tenant.
-      const governanceProject = await findHiddenGovernanceProject(
-        ctx.prisma,
-        input.organizationId,
-      );
+      const governanceProject = await findHiddenGovernanceProject({
+        prisma: ctx.prisma,
+        organizationId: input.organizationId,
+      });
 
       // Run the rollup queries in parallel — they're independent and the
       // CH server happily multiplexes. userId + ingestionTenantId are

--- a/langwatch/src/server/api/routers/user.ts
+++ b/langwatch/src/server/api/routers/user.ts
@@ -1,4 +1,5 @@
 import { CliBootstrapService } from "@ee/governance/services/cliBootstrap.service";
+import { findHiddenGovernanceProject } from "@ee/governance/services/governanceProject.service";
 import { PersonalUsageService } from "@ee/governance/services/personalUsage.service";
 import { PersonalVirtualKeyService } from "@ee/governance/services/personalVirtualKey.service";
 import { PersonalWorkspaceService } from "@ee/governance/services/personalWorkspace.service";
@@ -563,29 +564,42 @@ export const userRouter = createTRPCRouter({
 
       const usage = new PersonalUsageService();
 
+      // Ingestion-source ledger rows (Claude Code OTLP, etc.) land under
+      // the org's hidden Governance Project tenant. Resolve it read-only
+      // so the PRINCIPAL-ledger union is scoped to this org's tenant.
+      const governanceProject = await findHiddenGovernanceProject(
+        ctx.prisma,
+        input.organizationId,
+      );
+
       // Run the rollup queries in parallel — they're independent and the
-      // CH server happily multiplexes. userId is threaded so
-      // PersonalUsageService can union ingestion-source ledger rows
-      // (Claude Code OTLP, etc.) keyed on PRINCIPAL-scope budgets where
-      // ScopeId=userId. Without it, the /me dashboard misses third-party
-      // traffic landing in the hidden governance project tenant. Recent
-      // activity itself is read directly from the personal project tenant
-      // by the /me table (tracesV2.list), so it isn't fetched here.
+      // CH server happily multiplexes. userId + ingestionTenantId are
+      // threaded so PersonalUsageService can union ingestion-source ledger
+      // rows keyed on PRINCIPAL-scope budgets where ScopeId=userId, scoped
+      // to this org's governance tenant. Without them, the /me dashboard
+      // misses third-party traffic landing in the hidden governance
+      // project tenant. Recent activity itself is read directly from the
+      // personal project tenant by the /me table (tracesV2.list), so it
+      // isn't fetched here.
+      const ingestionTenantId = governanceProject?.id;
       const [summary, dailyBuckets, breakdownByModel] = await Promise.all([
         usage.summary({
           personalProjectId: workspace.project.id,
           window,
           userId,
+          ingestionTenantId,
         }),
         usage.dailyBuckets({
           personalProjectId: workspace.project.id,
           window,
           userId,
+          ingestionTenantId,
         }),
         usage.breakdownByModel({
           personalProjectId: workspace.project.id,
           window,
           userId,
+          ingestionTenantId,
         }),
       ]);
 

--- a/specs/ai-gateway/governance/me-usage-rest-api.feature
+++ b/specs/ai-gateway/governance/me-usage-rest-api.feature
@@ -18,6 +18,14 @@ Feature: Personal usage REST API
     Then the response status is 200
     And the rollups cover only usage that falls inside the requested window
 
+  Scenario: Ingestion-source spend is included and scoped to this organization
+    Given my account has ingestion-source spend (e.g. Claude Code) in this organization
+    And my account also has ingestion-source spend in another organization
+    When I GET /api/me/usage
+    Then the response status is 200
+    And the rollups include this organization's ingestion-source spend
+    And the rollups exclude ingestion-source spend from other organizations
+
   Scenario: A half-specified window is rejected
     When I GET /api/me/usage with only a start time (or only an end time)
     Then the response status is 400


### PR DESCRIPTION
Follow-up to #5222 (which fixed the cross-user ownership leak on `GET /api/me/usage`). While reviewing that fix, the **ingestion-source ledger union** in `PersonalUsageService` was found to query `gateway_budget_ledger_events` filtered only by `Scope='principal' AND ScopeId=userId` — **with no `TenantId` predicate**, violating the repo's "always filter TenantId first" rule.

## Why it matters

This union runs on every `/api/me/usage` call (REST) and every `/me` dashboard load (tRPC), so both paths were affected.

- **Correctness (multi-org over-count):** ingestion-source PRINCIPAL rows (Claude Code OTLP, etc.) are written under the **org's hidden Governance Project tenant** (`ingestionRoutes.ts` writes `TenantId: govProject.id`). A user who belongs to multiple orgs has PRINCIPAL rows under *each* org's governance tenant. Without a `TenantId` filter, the single-org `/me` view summed the user's spend **across every org they belong to**.
- **Performance:** `TenantId` is the leading `ORDER BY` key on the ledger table. The unfiltered query scanned every tenant's ledger rows instead of pruning to one — the same unbounded-scan class that has caused CH OOM incidents.

> Not a cross-**user** leak — `ScopeId` is the globally-unique `User.id`, so a caller only ever saw their own spend. This is org-scoping correctness + partition pruning, which is why it's a follow-up rather than part of the #5222 hotfix.

## The fix

- Add a **read-only** `findHiddenGovernanceProject(prisma, organizationId)` alongside `ensureHiddenGovernanceProject` — read paths (a GET) must never provision a Governance Project as a side effect.
- Thread `ingestionTenantId` into `PersonalUsageQueryInput`; every `gateway_budget_ledger_events` query now pins `TenantId = {ingestionTenantId}` first. The union is **skipped entirely** when the org has no governance project (no ingestion traffic) — never an unbounded fallback scan.
- Both callers resolve the org's governance tenant and pass it: the REST `/api/me/usage` route and the `personalUsage` tRPC procedure.

## Tests

Extended the `/api/me/usage` integration test: seeds ledger rows under (a) this org's governance tenant, in-window, (b) a **foreign** tenant, in-window, and (c) the right tenant but **out-of-window**, then asserts only (a) is unioned — proving both the new `TenantId` scope (the multi-org guard) and the existing time filter. Unit/format/typecheck verified locally; the integration test requires Docker (testcontainers) and runs in CI.

## Follow-up not included
`ANALYTICS_CLICKHOUSE_SETTINGS` still lacks `max_execution_time` / `max_threads` scan-safety caps on these `sum()` queries; the `TenantId` pin removes the unbounded-scan hazard, so the caps are a separate hardening item rather than a blocker here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage reports now optionally include ingestion-related spend scoped to the organization’s hidden governance tenant, when available.
  * Personal usage summaries and breakdowns can now combine personal activity with eligible ingestion-source activity.
* **Bug Fixes**
  * Corrected usage totals and model breakdowns to include only organization-scoped ingestion data and exclude records outside the selected time window.
  * When no governance tenant project is available, usage falls back to personal activity only.
* **Tests**
  * Added/extended integration and BDD coverage to validate tenant-scoped ingestion inclusion/exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->