### PR TITLE
feat(billing): reportStorageForHourCommand — additive hourly Stripe reporting (ADR-027 Phase 3)

### DIFF
--- a/langwatch/src/server/app-layer/billing/storageBillingCheckpoint.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingCheckpoint.service.ts
@@ -57,6 +57,25 @@ export interface StorageBillingCheckpointService {
     pendingReportedTotal: bigint;
     consecutiveFailures: number;
   }): Promise<void>;
+
+  /**
+   * Breaker-only failure record (ADR-027 Phase 3). Storage reporting is
+   * per-hour and idempotent via the `StorageUsageHourly.reportedAt` cursor, so
+   * it does not use the lastReportedTotal/pendingReportedTotal accumulator —
+   * only the consecutive-failure counter that trips the circuit breaker. Upsert
+   * so the first failure on a fresh (org, month) creates the row.
+   */
+  recordFailure(params: {
+    organizationId: string;
+    billingMonth: string;
+    consecutiveFailures: number;
+  }): Promise<void>;
+
+  /** Clears the consecutive-failure counter after a successful report. */
+  recordSuccess(params: {
+    organizationId: string;
+    billingMonth: string;
+  }): Promise<void>;
 }
 
 /**
@@ -181,6 +200,51 @@ export class PrismaStorageBillingCheckpointService
       },
       update: {
         consecutiveFailures: params.consecutiveFailures,
+      },
+    });
+  }
+
+  async recordFailure(params: {
+    organizationId: string;
+    billingMonth: string;
+    consecutiveFailures: number;
+  }): Promise<void> {
+    await this.prisma.storageBillingCheckpoint.upsert({
+      where: {
+        organizationId_billingMonth: {
+          organizationId: params.organizationId,
+          billingMonth: params.billingMonth,
+        },
+      },
+      create: {
+        organizationId: params.organizationId,
+        billingMonth: params.billingMonth,
+        consecutiveFailures: params.consecutiveFailures,
+      },
+      update: {
+        consecutiveFailures: params.consecutiveFailures,
+      },
+    });
+  }
+
+  async recordSuccess(params: {
+    organizationId: string;
+    billingMonth: string;
+  }): Promise<void> {
+    await this.prisma.storageBillingCheckpoint.upsert({
+      where: {
+        organizationId_billingMonth: {
+          organizationId: params.organizationId,
+          billingMonth: params.billingMonth,
+        },
+      },
+      create: {
+        organizationId: params.organizationId,
+        billingMonth: params.billingMonth,
+        consecutiveFailures: 0,
+      },
+      update: {
+        consecutiveFailures: 0,
       },
     });
   }

--- a/langwatch/src/server/app-layer/billing/storageUsageHourly.repository.ts
+++ b/langwatch/src/server/app-layer/billing/storageUsageHourly.repository.ts
@@ -1,0 +1,65 @@
+import type { PrismaClient } from "@prisma/client";
+
+/** A measured storage hour, as needed by the reporting command. */
+export interface StorageUsageHour {
+  megabytes: number;
+  /** The durable per-hour idempotency cursor — null until reported to Stripe. */
+  reportedAt: Date | null;
+}
+
+/**
+ * Read/stamp access to the durable `StorageUsageHourly` measurement rows
+ * (ADR-027). The reporting command reads one hour to decide whether to report
+ * it, and stamps `reportedAt` once Stripe has accepted it — the stamp is the
+ * cursor that guarantees each hour is billed exactly once.
+ */
+export interface StorageUsageHourlyRepository {
+  findHour(params: {
+    organizationId: string;
+    sealedHour: Date;
+  }): Promise<StorageUsageHour | null>;
+
+  markReported(params: {
+    organizationId: string;
+    sealedHour: Date;
+    reportedAt: Date;
+  }): Promise<void>;
+}
+
+export class PrismaStorageUsageHourlyRepository
+  implements StorageUsageHourlyRepository
+{
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findHour(params: {
+    organizationId: string;
+    sealedHour: Date;
+  }): Promise<StorageUsageHour | null> {
+    const row = await this.prisma.storageUsageHourly.findUnique({
+      where: {
+        organizationId_sealedHour: {
+          organizationId: params.organizationId,
+          sealedHour: params.sealedHour,
+        },
+      },
+      select: { megabytes: true, reportedAt: true },
+    });
+    return row ?? null;
+  }
+
+  async markReported(params: {
+    organizationId: string;
+    sealedHour: Date;
+    reportedAt: Date;
+  }): Promise<void> {
+    await this.prisma.storageUsageHourly.update({
+      where: {
+        organizationId_sealedHour: {
+          organizationId: params.organizationId,
+          sealedHour: params.sealedHour,
+        },
+      },
+      data: { reportedAt: params.reportedAt },
+    });
+  }
+}

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -73,6 +73,8 @@ import { TraceUsageService } from "../traces/trace-usage.service";
 import { runEvaluationWorkflow } from "../workflows/runWorkflow";
 import { App, getApp, globalForApp, initializeApp } from "./app";
 import { PrismaBillingCheckpointService } from "./billing/billingCheckpoint.service";
+import { PrismaStorageBillingCheckpointService } from "./billing/storageBillingCheckpoint.service";
+import { PrismaStorageUsageHourlyRepository } from "./billing/storageUsageHourly.repository";
 import { BroadcastService } from "./broadcast/broadcast.service";
 import { createClickHouseClientFromConfig } from "./clients/clickhouse.factory";
 import { NullLangevalsClient } from "./clients/langevals/langevals.client";
@@ -568,6 +570,10 @@ export function initializeDefaultApp(options?: {
     esSync: { esClient, traceIndex: TRACE_INDEX, traceIndexId, prisma },
     costRecorder: new PrismaEvaluationCostRecorder(prisma),
     billingCheckpoints: new PrismaBillingCheckpointService(prisma),
+    storageBillingCheckpoints: new PrismaStorageBillingCheckpointService(
+      prisma,
+    ),
+    storageUsageHourly: new PrismaStorageUsageHourlyRepository(prisma),
     usageReportingService,
     gatewayBudgetSync,
     // ADR-022: Inject BlobStore into the pipeline registry so RecordSpanCommand
@@ -964,6 +970,7 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
       } as AppCommands["suiteRuns"],
       billing: {
         reportUsageForMonth: noop,
+        reportStorageForHour: noop,
       } as AppCommands["billing"],
       scenarioExecutionHandle: {
         reactor: {

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -28,6 +28,8 @@ import { createLogger } from "~/utils/logger/server";
 import { queryBillableEventsTotal } from "../../../ee/billing/services/billableEventsQuery";
 import type { UsageReportingService } from "../../../ee/billing/services/usageReportingService";
 import type { BillingCheckpointService } from "../app-layer/billing/billingCheckpoint.service";
+import type { StorageBillingCheckpointService } from "../app-layer/billing/storageBillingCheckpoint.service";
+import type { StorageUsageHourlyRepository } from "../app-layer/billing/storageUsageHourly.repository";
 import type { BroadcastService } from "../app-layer/broadcast/broadcast.service";
 import { getAzureSafetyEnvFromProject } from "../app-layer/evaluations/azure-safety-env.server";
 import type { EvaluationCostRecorder } from "../app-layer/evaluations/evaluation-cost.recorder";
@@ -50,6 +52,7 @@ import { createElasticsearchBatchEvaluationRepository } from "../experiments-v3/
 import { type CommandDispatcher, Deferred } from "./deferred";
 import type { EventSourcing } from "./eventSourcing";
 import { mapCommands } from "./mapCommands";
+import { ReportStorageForHourCommand } from "./pipelines/billing-reporting/commands/reportStorageForHour.command";
 import { ReportUsageForMonthCommand } from "./pipelines/billing-reporting/commands/reportUsageForMonth.command";
 import {
   BILLING_REPORTING_PIPELINE_NAME,
@@ -204,6 +207,8 @@ export interface PipelineRegistryDeps {
   esSync: EvaluationEsSyncReactorDeps;
   costRecorder: EvaluationCostRecorder;
   billingCheckpoints: BillingCheckpointService;
+  storageBillingCheckpoints: StorageBillingCheckpointService;
+  storageUsageHourly: StorageUsageHourlyRepository;
   usageReportingService?: UsageReportingService;
   gatewayBudgetSync?: GatewayBudgetSyncReactorDeps;
   /**
@@ -747,9 +752,23 @@ export class PipelineRegistry {
       },
     });
 
+    const reportStorageForHourCommand = new ReportStorageForHourCommand({
+      organizations: this.deps.organizations,
+      storageBillingCheckpoints: this.deps.storageBillingCheckpoints,
+      storageUsageHourly: this.deps.storageUsageHourly,
+      getUsageReportingService: () => this.deps.usageReportingService,
+      selfDispatch: (data) => {
+        const pipeline = this.deps.eventSourcing.getPipeline(
+          BILLING_REPORTING_PIPELINE_NAME,
+        );
+        return pipeline.commands.reportStorageForHour.send(data);
+      },
+    });
+
     return this.deps.eventSourcing.register(
       createBillingReportingPipeline({
         reportUsageForMonthCommand,
+        reportStorageForHourCommand,
       }),
     );
   }

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportStorageForHour.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportStorageForHour.command.unit.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Unit tests for the reportStorageForHour command handler.
+ *
+ * Mocks boundaries: OrganizationService, StorageBillingCheckpointService,
+ * StorageUsageHourlyRepository, Stripe (UsageReportingService), selfDispatch,
+ * and error capture.
+ *
+ * @see specs/data-retention/storage-billing-hour-reporting.feature
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Command } from "../../../../";
+import { createTenantId } from "../../../../domain/tenantId";
+import type { ReportStorageForHourCommandData } from "../../schemas/commands";
+
+const {
+  mockOrganizations,
+  mockStorageBillingCheckpoints,
+  mockStorageUsageHourly,
+  mockReportUsageDelta,
+  mockSelfDispatch,
+  mockCaptureException,
+  createMockLogger,
+} = vi.hoisted(() => {
+  const mockReportUsageDelta = vi.fn();
+  const mockSelfDispatch = vi.fn();
+  const mockCaptureException = vi.fn();
+
+  const createMockLogger = () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => createMockLogger()),
+  });
+
+  return {
+    mockOrganizations: { getOrganizationForBilling: vi.fn() },
+    mockStorageBillingCheckpoints: {
+      getCheckpoint: vi.fn(),
+      recordFailure: vi.fn(),
+      recordSuccess: vi.fn(),
+    },
+    mockStorageUsageHourly: { findHour: vi.fn(), markReported: vi.fn() },
+    mockReportUsageDelta,
+    mockSelfDispatch,
+    mockCaptureException,
+    createMockLogger,
+  };
+});
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: vi.fn(() => createMockLogger()),
+}));
+
+// Disable the org-level TtlCache so tests don't share cached org data.
+vi.mock("~/server/utils/ttlCache", () => ({
+  TtlCache: class {
+    async get() {
+      return undefined;
+    }
+    async set() {
+      return;
+    }
+    async delete() {
+      return;
+    }
+  },
+}));
+
+vi.mock("~/utils/posthogErrorCapture", () => ({
+  captureException: mockCaptureException,
+  toError: vi.fn((e) => (e instanceof Error ? e : new Error(String(e)))),
+  withScope: vi.fn((cb: (scope: Record<string, unknown>) => void) => {
+    cb({ setTag: vi.fn(), setExtra: vi.fn() });
+  }),
+}));
+
+const SEALED_HOUR = "2026-02-15T12:00:00.000Z";
+const EXPECTED_IDENTIFIER = "storage_mb:org-1:2026-02-15T12";
+const EXPECTED_MONTH = "2026-02";
+
+function makeCommand(
+  organizationId = "org-1",
+  sealedHour = SEALED_HOUR,
+): Command<ReportStorageForHourCommandData> {
+  return {
+    tenantId: createTenantId(organizationId),
+    aggregateId: organizationId,
+    type: "lw.billing_report.report_storage_for_hour" as any,
+    data: {
+      organizationId,
+      sealedHour,
+      tenantId: organizationId,
+      occurredAt: Date.now(),
+    },
+  };
+}
+
+function makeOrg({
+  id = "org-1",
+  stripeCustomerId = "cus_123" as string | null,
+  hasSubscription = true,
+} = {}) {
+  return {
+    id,
+    stripeCustomerId,
+    subscriptions: hasSubscription ? [{ id: "sub-1" }] : [],
+  };
+}
+
+async function createHandler() {
+  const { ReportStorageForHourCommand } = await import(
+    "../reportStorageForHour.command"
+  );
+  return new ReportStorageForHourCommand({
+    organizations: mockOrganizations as any,
+    storageBillingCheckpoints: mockStorageBillingCheckpoints as any,
+    storageUsageHourly: mockStorageUsageHourly as any,
+    getUsageReportingService: () => ({
+      reportUsageDelta: mockReportUsageDelta,
+      reportUsageSet: vi.fn(),
+      getUsageSummary: vi.fn(),
+    }),
+    selfDispatch: mockSelfDispatch,
+  });
+}
+
+describe("ReportStorageForHourCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+    mockStorageBillingCheckpoints.getCheckpoint.mockResolvedValue(null);
+  });
+
+  describe("given an unreported measured hour", () => {
+    /** @scenario An unreported hour is reported additively and marked reported */
+    it("sends one additive meter event for the hour and stamps the cursor", async () => {
+      mockStorageUsageHourly.findHour.mockResolvedValue({
+        megabytes: 42,
+        reportedAt: null,
+      });
+      mockReportUsageDelta.mockResolvedValue([{ reported: true }]);
+      const handler = await createHandler();
+
+      const result = await handler.handle(makeCommand());
+
+      expect(result).toEqual([]);
+      expect(mockReportUsageDelta).toHaveBeenCalledTimes(1);
+      expect(mockReportUsageDelta).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stripeCustomerId: "cus_123",
+          events: [
+            expect.objectContaining({
+              eventName: "langwatch_storage_megabytes_hourly",
+              identifier: EXPECTED_IDENTIFIER,
+              value: 42,
+              timestamp: Math.floor(new Date(SEALED_HOUR).getTime() / 1000),
+            }),
+          ],
+        }),
+      );
+      expect(mockStorageUsageHourly.markReported).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: "org-1",
+          sealedHour: new Date(SEALED_HOUR),
+        }),
+      );
+      // Success on a clean breaker: no checkpoint write, no self-dispatch.
+      expect(
+        mockStorageBillingCheckpoints.recordSuccess,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockStorageBillingCheckpoints.recordFailure,
+      ).not.toHaveBeenCalled();
+      expect(mockSelfDispatch).not.toHaveBeenCalled();
+    });
+
+    /** @scenario The reported value is the hour's integer megabytes */
+    it("sends the raw integer megabytes with no conversion", async () => {
+      mockStorageUsageHourly.findHour.mockResolvedValue({
+        megabytes: 12345,
+        reportedAt: null,
+      });
+      mockReportUsageDelta.mockResolvedValue([{ reported: true }]);
+      const handler = await createHandler();
+
+      await handler.handle(makeCommand());
+
+      const sentValue = mockReportUsageDelta.mock.calls[0]![0].events[0].value;
+      expect(sentValue).toBe(12345);
+      expect(Number.isInteger(sentValue)).toBe(true);
+    });
+
+    /** @scenario The billing identifier is deterministic per organization and hour */
+    it("builds a deterministic identifier from organization and hour", async () => {
+      mockStorageUsageHourly.findHour.mockResolvedValue({
+        megabytes: 1,
+        reportedAt: null,
+      });
+      mockReportUsageDelta.mockResolvedValue([{ reported: true }]);
+
+      await (await createHandler()).handle(makeCommand());
+      await (await createHandler()).handle(makeCommand());
+
+      const ids = mockReportUsageDelta.mock.calls.map(
+        ([arg]) => arg.events[0].identifier,
+      );
+      expect(ids).toEqual([EXPECTED_IDENTIFIER, EXPECTED_IDENTIFIER]);
+    });
+  });
+
+  describe("given the hour is already reported", () => {
+    /** @scenario An hour already marked reported is not reported again */
+    it("sends nothing and leaves the cursor unchanged", async () => {
+      mockStorageUsageHourly.findHour.mockResolvedValue({
+        megabytes: 42,
+        reportedAt: new Date("2026-02-15T13:00:00.000Z"),
+      });
+      const handler = await createHandler();
+
+      const result = await handler.handle(makeCommand());
+
+      expect(result).toEqual([]);
+      expect(mockReportUsageDelta).not.toHaveBeenCalled();
+      expect(mockStorageUsageHourly.markReported).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the meter event already exists on Stripe", () => {
+    /** @scenario A Stripe duplicate is treated as already reported */
+    it("treats the duplicate as reported and stamps the cursor without a failure", async () => {
+      mockStorageUsageHourly.findHour.mockResolvedValue({
+        megabytes: 42,
+        reportedAt: null,
+      });
+      // The usage service maps resource_already_exists to reported: true.
+      mockReportUsageDelta.mockResolvedValue([{ reported: true }]);
+      const handler = await createHandler();
+
+      await handler.handle(makeCommand());
+
+      expect(mockStorageUsageHourly.markReported).toHaveBeenCalledTimes(1);
+      expect(
+        mockStorageBillingCheckpoints.recordFailure,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when Stripe permanently rejects the event", () => {
+    /** @scenario A permanent rejection does not mark the hour reported */
+    it("leaves the hour unreported, increments failures, and does not self-dispatch", async () => {
+      mockStorageUsageHourly.findHour.mockResolvedValue({
+        megabytes: 42,
+        reportedAt: null,
+      });
+      mockReportUsageDelta.mockResolvedValue([
+        { reported: false, error: "invalid_request" },
+      ]);
+      const handler = await createHandler();
+
+      const result = await handler.handle(makeCommand());
+
+      expect(result).toEqual([]);
+      expect(mockStorageUsageHourly.markReported).not.toHaveBeenCalled();
+      expect(mockStorageBillingCheckpoints.recordFailure).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        billingMonth: EXPECTED_MONTH,
+        consecutiveFailures: 1,
+      });
+      expect(mockSelfDispatch).not.toHaveBeenCalled();
+      expect(mockCaptureException).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the report hits a transient error", () => {
+    /** @scenario A transient error increases the failure count and retries */
+    it("increments failures, self-dispatches a retry, and does not throw", async () => {
+      mockStorageUsageHourly.findHour.mockResolvedValue({
+        megabytes: 42,
+        reportedAt: null,
+      });
+      mockReportUsageDelta.mockRejectedValue(new Error("rate limited"));
+      const handler = await createHandler();
+
+      const result = await handler.handle(makeCommand());
+
+      expect(result).toEqual([]);
+      expect(mockStorageBillingCheckpoints.recordFailure).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        billingMonth: EXPECTED_MONTH,
+        consecutiveFailures: 1,
+      });
+      expect(mockStorageUsageHourly.markReported).not.toHaveBeenCalled();
+      expect(mockSelfDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: "org-1",
+          sealedHour: SEALED_HOUR,
+        }),
+      );
+    });
+  });
+
+  describe("given the breaker is at the failure threshold", () => {
+    /** @scenario The breaker stops reporting after too many consecutive failures */
+    it("does not read the hour, report, or self-dispatch", async () => {
+      mockStorageBillingCheckpoints.getCheckpoint.mockResolvedValue({
+        lastReportedTotal: 0,
+        pendingReportedTotal: null,
+        consecutiveFailures: 5,
+      });
+      const handler = await createHandler();
+
+      const result = await handler.handle(makeCommand());
+
+      expect(result).toEqual([]);
+      expect(mockStorageUsageHourly.findHour).not.toHaveBeenCalled();
+      expect(mockReportUsageDelta).not.toHaveBeenCalled();
+      expect(mockSelfDispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given prior failures below the threshold then a success", () => {
+    /** @scenario A success below the breaker threshold clears the failure count */
+    it("clears the failure count on success", async () => {
+      mockStorageBillingCheckpoints.getCheckpoint.mockResolvedValue({
+        lastReportedTotal: 0,
+        pendingReportedTotal: null,
+        consecutiveFailures: 3,
+      });
+      mockStorageUsageHourly.findHour.mockResolvedValue({
+        megabytes: 42,
+        reportedAt: null,
+      });
+      mockReportUsageDelta.mockResolvedValue([{ reported: true }]);
+      const handler = await createHandler();
+
+      await handler.handle(makeCommand());
+
+      expect(mockStorageUsageHourly.markReported).toHaveBeenCalledTimes(1);
+      expect(mockStorageBillingCheckpoints.recordSuccess).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        billingMonth: EXPECTED_MONTH,
+      });
+      expect(
+        mockStorageBillingCheckpoints.recordFailure,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given an organization that cannot be billed", () => {
+    /** @scenario Reporting is skipped for an organization that cannot be billed */
+    it("sends nothing when there is no Stripe customer", async () => {
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(
+        makeOrg({ stripeCustomerId: null }),
+      );
+      const handler = await createHandler();
+
+      const result = await handler.handle(makeCommand());
+
+      expect(result).toEqual([]);
+      expect(mockReportUsageDelta).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given no measured row for the requested hour", () => {
+    /** @scenario Reporting is a no-op when no measured hour exists */
+    it("sends nothing and stamps nothing", async () => {
+      mockStorageUsageHourly.findHour.mockResolvedValue(null);
+      const handler = await createHandler();
+
+      const result = await handler.handle(makeCommand());
+
+      expect(result).toEqual([]);
+      expect(mockReportUsageDelta).not.toHaveBeenCalled();
+      expect(mockStorageUsageHourly.markReported).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("static metadata", () => {
+    it("exposes the command type, aggregate id, and span attributes", async () => {
+      const { ReportStorageForHourCommand } = await import(
+        "../reportStorageForHour.command"
+      );
+      expect(ReportStorageForHourCommand.schema.type).toBe(
+        "lw.billing_report.report_storage_for_hour",
+      );
+      expect(
+        ReportStorageForHourCommand.getAggregateId(makeCommand().data),
+      ).toBe("org-1");
+      expect(
+        ReportStorageForHourCommand.getSpanAttributes(makeCommand().data),
+      ).toMatchObject({ "payload.organizationId": "org-1" });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportStorageForHour.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportStorageForHour.command.ts
@@ -1,0 +1,309 @@
+import { TtlCache } from "~/server/utils/ttlCache";
+import { createLogger } from "~/utils/logger/server";
+import {
+  captureException,
+  toError,
+  withScope,
+} from "~/utils/posthogErrorCapture";
+import type { UsageReportingService } from "../../../../../../ee/billing/services/usageReportingService";
+import type { StorageBillingCheckpointService } from "../../../../app-layer/billing/storageBillingCheckpoint.service";
+import type { StorageUsageHourlyRepository } from "../../../../app-layer/billing/storageUsageHourly.repository";
+import type { OrganizationService } from "../../../../app-layer/organizations/organization.service";
+import type { Command, CommandHandler } from "../../../";
+import { defineCommandSchema } from "../../../";
+import type { Event } from "../../../domain/types";
+import type { ReportStorageForHourCommandData } from "../schemas/commands";
+import { reportStorageForHourCommandDataSchema } from "../schemas/commands";
+import { BILLING_REPORT_COMMAND_TYPES } from "../schemas/constants";
+
+const logger = createLogger(
+  "langwatch:billing-reporting:report-storage-for-hour",
+);
+
+/** Stripe meter event name for additive hourly storage (MiB). */
+const STORAGE_MEGABYTES_EVENT_NAME = "langwatch_storage_megabytes_hourly";
+
+/** Maximum consecutive failures before the circuit-breaker trips. */
+const MAX_CONSECUTIVE_FAILURES = 5;
+
+const ONE_MINUTE_MS = 60 * 1000;
+
+type CachedOrgData = {
+  id: string;
+  stripeCustomerId: string | null;
+  subscriptions: { id: string }[];
+};
+
+const orgCache = new TtlCache<CachedOrgData>(
+  ONE_MINUTE_MS,
+  "ttlcache:storage-billing:orgData:",
+);
+
+export interface ReportStorageForHourCommandDeps {
+  organizations: OrganizationService;
+  storageBillingCheckpoints: StorageBillingCheckpointService;
+  storageUsageHourly: StorageUsageHourlyRepository;
+  getUsageReportingService: () => UsageReportingService | undefined;
+  selfDispatch: (data: ReportStorageForHourCommandData) => Promise<void>;
+}
+
+const SCHEMA = defineCommandSchema(
+  BILLING_REPORT_COMMAND_TYPES.REPORT_STORAGE_FOR_HOUR,
+  reportStorageForHourCommandDataSchema,
+  "Command to report one measured storage hour to Stripe, additively",
+);
+
+/** The UTC billing month ("YYYY-MM") a sealed hour belongs to. */
+function billingMonthOf(sealedHour: Date): string {
+  return sealedHour.toISOString().slice(0, 7);
+}
+
+/**
+ * Deterministic Stripe idempotency key for a sealed hour. Hour-precision ISO so
+ * the same (org, hour) always produces the same identifier — Stripe dedups a
+ * re-send within its window, billing the hour once.
+ */
+function buildIdentifier(organizationId: string, sealedHour: Date): string {
+  return `storage_mb:${organizationId}:${sealedHour.toISOString().slice(0, 13)}`;
+}
+
+/**
+ * Command handler for reporting one measured storage hour to Stripe.
+ *
+ * Additive, not delta: the hour's raw megabytes are sent once into a `sum`
+ * meter (never a last-value set). Idempotency is the durable
+ * `StorageUsageHourly.reportedAt` cursor plus the deterministic Stripe
+ * identifier; the per-month checkpoint carries ONLY the circuit breaker
+ * (consecutive failures) — it cannot disambiguate which hour was in flight, so
+ * crash-recovery is the cursor, not a checkpoint accumulator (ADR-027 Phase 3).
+ *
+ * Error handling never propagates to the framework: every job is "successful";
+ * the handler owns retry (self-dispatch on transient, breaker on repeated
+ * failure). Uses constructor DI — pass the instance via `.withCommandInstance()`.
+ */
+export class ReportStorageForHourCommand
+  implements CommandHandler<Command<ReportStorageForHourCommandData>, Event>
+{
+  static readonly schema = SCHEMA;
+
+  constructor(private readonly deps: ReportStorageForHourCommandDeps) {}
+
+  static getAggregateId(payload: ReportStorageForHourCommandData): string {
+    return payload.organizationId;
+  }
+
+  static getSpanAttributes(
+    payload: ReportStorageForHourCommandData,
+  ): Record<string, string | number | boolean> {
+    return {
+      "payload.organizationId": payload.organizationId,
+      "payload.sealedHour": payload.sealedHour,
+    };
+  }
+
+  async handle(
+    command: Command<ReportStorageForHourCommandData>,
+  ): Promise<Event[]> {
+    const { organizationId, sealedHour, tenantId } = command.data;
+
+    let shouldSelfDispatch = false;
+    try {
+      let org = (await orgCache.get(organizationId)) ?? null;
+      if (!org) {
+        org =
+          await this.deps.organizations.getOrganizationForBilling(
+            organizationId,
+          );
+        if (org) {
+          await orgCache.set(organizationId, org);
+        }
+      }
+
+      if (!org) {
+        logger.warn({ organizationId }, "organization not billable, skipping");
+        return [];
+      }
+      if (!org.stripeCustomerId) {
+        logger.debug({ organizationId }, "no Stripe customer ID, skipping");
+        return [];
+      }
+      if (org.subscriptions.length === 0) {
+        logger.debug({ organizationId }, "no active subscription, skipping");
+        return [];
+      }
+
+      shouldSelfDispatch = await this.reportHour({
+        organizationId,
+        sealedHour,
+        stripeCustomerId: org.stripeCustomerId,
+      });
+    } catch (error) {
+      // Never propagate to framework — log and return empty events.
+      logger.error(
+        { organizationId, sealedHour, error },
+        "unexpected error in storage reporting command handler",
+      );
+      await withScope(async (scope) => {
+        scope.setTag?.("handler", "reportStorageForHour");
+        scope.setExtra?.("organizationId", organizationId);
+        scope.setExtra?.("sealedHour", sealedHour);
+        captureException(toError(error));
+      });
+      return [];
+    }
+
+    // Self-dispatch (transient retry) outside try/catch so failures propagate.
+    if (shouldSelfDispatch) {
+      await this.deps.selfDispatch({
+        organizationId,
+        sealedHour,
+        tenantId,
+        occurredAt: Date.now(),
+      });
+    }
+
+    return [];
+  }
+
+  /**
+   * Reports one sealed hour. Returns true only when a transient error means the
+   * same hour should be retried via self-dispatch; false on success, skip,
+   * permanent rejection, or a tripped breaker.
+   */
+  private async reportHour({
+    organizationId,
+    sealedHour,
+    stripeCustomerId,
+  }: {
+    organizationId: string;
+    sealedHour: string;
+    stripeCustomerId: string;
+  }): Promise<boolean> {
+    const sealedHourDate = new Date(sealedHour);
+    const billingMonth = billingMonthOf(sealedHourDate);
+
+    const checkpoint = await this.deps.storageBillingCheckpoints.getCheckpoint({
+      organizationId,
+      billingMonth,
+    });
+    const consecutiveFailures = checkpoint?.consecutiveFailures ?? 0;
+
+    if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      logger.error(
+        { organizationId, billingMonth, consecutiveFailures },
+        "ALARM: storage-billing circuit-breaker tripped — consecutive failures " +
+          "exceeded threshold, stopping. Manual investigation required.",
+      );
+      return false;
+    }
+
+    const hour = await this.deps.storageUsageHourly.findHour({
+      organizationId,
+      sealedHour: sealedHourDate,
+    });
+    if (!hour) {
+      logger.debug(
+        { organizationId, sealedHour },
+        "no measured storage hour, skipping",
+      );
+      return false;
+    }
+    if (hour.reportedAt != null) {
+      logger.debug(
+        { organizationId, sealedHour },
+        "hour already reported, skipping",
+      );
+      return false;
+    }
+
+    const usageReportingService = this.deps.getUsageReportingService();
+    if (!usageReportingService) {
+      logger.error(
+        { organizationId, sealedHour },
+        "usageReportingService not available — billing requires isSaas, this is a configuration error",
+      );
+      return false;
+    }
+
+    const identifier = buildIdentifier(organizationId, sealedHourDate);
+
+    try {
+      const results = await usageReportingService.reportUsageDelta({
+        stripeCustomerId,
+        organizationId,
+        events: [
+          {
+            eventName: STORAGE_MEGABYTES_EVENT_NAME,
+            identifier,
+            timestamp: Math.floor(sealedHourDate.getTime() / 1000),
+            value: hour.megabytes,
+          },
+        ],
+      });
+
+      const result = results[0];
+
+      if (!result?.reported) {
+        // Permanent rejection: leave the hour unreported (cursor stays null) so
+        // a later run can retry; bump the breaker; do NOT self-dispatch.
+        logger.error(
+          { organizationId, sealedHour, identifier, error: result?.error },
+          "Stripe permanently rejected storage meter event, hour left unreported",
+        );
+        await withScope(async (scope) => {
+          scope.setTag?.("handler", "reportStorageForHour");
+          scope.setExtra?.("organizationId", organizationId);
+          scope.setExtra?.("identifier", identifier);
+          scope.setExtra?.("stripeError", result?.error);
+          captureException(
+            new Error(
+              `Stripe rejected storage meter event: ${result?.error ?? "unknown"}`,
+            ),
+          );
+        });
+        await this.deps.storageBillingCheckpoints.recordFailure({
+          organizationId,
+          billingMonth,
+          consecutiveFailures: consecutiveFailures + 1,
+        });
+        return false;
+      }
+
+      // Success (including resource_already_exists, treated as reported by the
+      // usage service). Stamp the cursor so the hour is never sent again.
+      await this.deps.storageUsageHourly.markReported({
+        organizationId,
+        sealedHour: sealedHourDate,
+        reportedAt: new Date(),
+      });
+
+      // Clear the breaker only if it had tripped partway — avoids a checkpoint
+      // write on the clean happy path.
+      if (consecutiveFailures > 0) {
+        await this.deps.storageBillingCheckpoints.recordSuccess({
+          organizationId,
+          billingMonth,
+        });
+      }
+
+      logger.debug(
+        { organizationId, sealedHour, identifier, value: hour.megabytes },
+        "storage hour reported and marked reported",
+      );
+      return false;
+    } catch (error) {
+      // Transient error (rate limit, network, transient DB): bump the breaker
+      // and self-dispatch to retry the same hour.
+      logger.warn(
+        { organizationId, sealedHour, error },
+        "transient error reporting storage hour, will retry via self-dispatch",
+      );
+      await this.deps.storageBillingCheckpoints.recordFailure({
+        organizationId,
+        billingMonth,
+        consecutiveFailures: consecutiveFailures + 1,
+      });
+      return true;
+    }
+  }
+}

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/pipeline.ts
@@ -1,11 +1,13 @@
 import { definePipeline } from "../../";
 import type { Event } from "../../domain/types";
+import { ReportStorageForHourCommand } from "./commands/reportStorageForHour.command";
 import { ReportUsageForMonthCommand } from "./commands/reportUsageForMonth.command";
 
 export const BILLING_REPORTING_PIPELINE_NAME = "billing_reporting" as const;
 
 export interface BillingReportingPipelineDeps {
   reportUsageForMonthCommand: ReportUsageForMonthCommand;
+  reportStorageForHourCommand: ReportStorageForHourCommand;
 }
 
 /**
@@ -21,13 +23,33 @@ export function createBillingReportingPipeline(
   return definePipeline<Event>()
     .withName(BILLING_REPORTING_PIPELINE_NAME)
     .withAggregateType("billing_report")
-    .withCommandInstance("reportUsageForMonth", ReportUsageForMonthCommand, deps.reportUsageForMonthCommand, {
-      delay: 300_000, // 5 min delay (initial + re-trigger)
-      deduplication: {
-        makeId: (p: { organizationId: string; billingMonth: string }) =>
-          `${p.organizationId}:${p.billingMonth}`,
-        ttlMs: 310_000, // 310s > 300s delay — prevents thundering herd, self-dispatch still works via replace logic
+    .withCommandInstance(
+      "reportUsageForMonth",
+      ReportUsageForMonthCommand,
+      deps.reportUsageForMonthCommand,
+      {
+        delay: 300_000, // 5 min delay (initial + re-trigger)
+        deduplication: {
+          makeId: (p: { organizationId: string; billingMonth: string }) =>
+            `${p.organizationId}:${p.billingMonth}`,
+          ttlMs: 310_000, // 310s > 300s delay — prevents thundering herd, self-dispatch still works via replace logic
+        },
       },
-    })
+    )
+    .withCommandInstance(
+      "reportStorageForHour",
+      ReportStorageForHourCommand,
+      deps.reportStorageForHourCommand,
+      {
+        delay: 300_000, // 5 min backoff between a transient failure and its self-dispatched retry
+        deduplication: {
+          // Per (org, hour): each sealed hour is reported independently, and a
+          // replay-driven re-dispatch of the same hour coalesces.
+          makeId: (p: { organizationId: string; sealedHour: string }) =>
+            `${p.organizationId}:${p.sealedHour}`,
+          ttlMs: 310_000, // 310s > 300s delay — same sizing as the month command
+        },
+      },
+    )
     .build();
 }

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/schemas/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/schemas/commands.ts
@@ -18,3 +18,25 @@ export const reportUsageForMonthCommandDataSchema = z.object({
 export type ReportUsageForMonthCommandData = z.infer<
   typeof reportUsageForMonthCommandDataSchema
 >;
+
+/**
+ * Command data for reporting one measured storage hour to Stripe.
+ * Dispatched by the storage-reporting dispatcher (Phase 4) once a sealed hour
+ * has been measured and persisted to StorageUsageHourly.
+ *
+ * `sealedHour` is the UTC hour boundary as an ISO-8601 string (the same instant
+ * the measurement was anchored to). Like the month command, organizationId is
+ * reused as tenantId — the framework only uses tenantId for groupKey
+ * construction (${tenantId}:${aggregateType}:${aggregateId}), and storage
+ * billing is an org-level concern.
+ */
+export const reportStorageForHourCommandDataSchema = z.object({
+  organizationId: z.string(),
+  sealedHour: z.string().datetime(),
+  tenantId: z.string(),
+  occurredAt: z.number(),
+});
+
+export type ReportStorageForHourCommandData = z.infer<
+  typeof reportStorageForHourCommandDataSchema
+>;

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/schemas/constants.ts
@@ -4,10 +4,12 @@
 
 export const BILLING_REPORT_COMMAND_TYPES = {
   REPORT_USAGE_FOR_MONTH: "lw.billing_report.report_usage_for_month",
+  REPORT_STORAGE_FOR_HOUR: "lw.billing_report.report_storage_for_hour",
 } as const;
 
 export const BILLING_REPORTING_COMMAND_TYPES = [
   BILLING_REPORT_COMMAND_TYPES.REPORT_USAGE_FOR_MONTH,
+  BILLING_REPORT_COMMAND_TYPES.REPORT_STORAGE_FOR_HOUR,
 ] as const;
 
 export type BillingReportingCommandType =

--- a/specs/data-retention/storage-billing-hour-reporting.feature
+++ b/specs/data-retention/storage-billing-hour-reporting.feature
@@ -1,0 +1,106 @@
+Feature: Storage billing — report a sealed hour to Stripe (ADR-027, Phase 3)
+  As the storage-billing pipeline
+  I want to report each measured hour's storage to Stripe exactly once, additively
+  So that an organization's invoice reflects MiB-hours of data kept beyond the free window
+
+  # A measured hour (organization + sealed UTC hour + integer megabytes) is reported as one
+  # additive meter event into a `sum` meter — the raw hourly value IS the integral, sent once and
+  # never recomputed (NOT a gauge / last-value set, which would telescope and be gameable by deleting
+  # late in the period). Idempotency is the hour's own "reported" marker (the durable cursor) plus a
+  # deterministic Stripe identifier; a separate per-month checkpoint carries ONLY the circuit breaker.
+  # Decision (2026-06-30): the checkpoint is breaker-only — the (org, month) row cannot disambiguate
+  # which hour was in flight, so crash-recovery is the per-hour cursor, not a checkpoint accumulator.
+
+  # ---------------------------------------------------------------------------
+  # Happy path + additive contract
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: An unreported hour is reported additively and marked reported
+    Given an organization with a Stripe customer and an active subscription
+    And a measured hour that has not yet been reported
+    When the hour is reported
+    Then exactly one additive meter event is sent for that hour's megabytes
+    And the hour is marked reported so it is never sent again
+
+  @unit
+  Scenario: The reported value is the hour's integer megabytes
+    Given a measured hour of a known integer megabyte size
+    When the hour is reported
+    Then the value sent to billing equals that integer megabyte count
+    And no gigabyte conversion or fractional value is applied on our side
+
+  @unit
+  Scenario: The billing identifier is deterministic per organization and hour
+    Given the same organization and sealed hour reported twice
+    When each report builds its billing identifier
+    Then both produce the same identifier so billing counts the hour once
+
+  # ---------------------------------------------------------------------------
+  # Idempotency (the reported cursor)
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: An hour already marked reported is not reported again
+    Given a measured hour that is already marked reported
+    When the hour is reported
+    Then no meter event is sent
+    And the hour's reported state is left unchanged
+
+  @unit
+  Scenario: A Stripe duplicate is treated as already reported
+    Given a measured hour whose meter event already exists on Stripe
+    When the hour is reported
+    Then the duplicate is treated as a successful report
+    And the hour is marked reported without raising a failure
+
+  # ---------------------------------------------------------------------------
+  # Failure handling + circuit breaker
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A permanent rejection does not mark the hour reported
+    Given a measured hour that Stripe permanently rejects
+    When the hour is reported
+    Then the hour is left unreported so a later run can retry
+    And the consecutive-failure count is increased
+    And no retry is self-dispatched for a permanent rejection
+
+  @unit
+  Scenario: A transient error increases the failure count and retries
+    Given a measured hour whose report hits a transient billing error
+    When the hour is reported
+    Then the consecutive-failure count is increased
+    And a retry of the same hour is self-dispatched
+    And the error is not propagated to the queue framework
+
+  @unit
+  Scenario: The breaker stops reporting after too many consecutive failures
+    Given an organization whose consecutive-failure count is at the breaker threshold
+    When an hour is reported
+    Then no meter event is sent
+    And no retry is self-dispatched until the failure is investigated
+
+  @unit
+  Scenario: A success below the breaker threshold clears the failure count
+    Given an organization with some prior consecutive failures below the threshold
+    And a measured hour that has not yet been reported
+    When the hour is reported successfully
+    Then the consecutive-failure count is cleared
+
+  # ---------------------------------------------------------------------------
+  # Skip conditions
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Reporting is skipped for an organization that cannot be billed
+    Given an organization with no Stripe customer or no active subscription
+    When an hour is reported
+    Then no meter event is sent
+
+  @unit
+  Scenario: Reporting is a no-op when no measured hour exists
+    Given an organization with no measured row for the requested hour
+    When the hour is reported
+    Then no meter event is sent
+    And nothing is marked reported


### PR DESCRIPTION
## What

Phase 3 of ADR-027. Adds **`ReportStorageForHourCommand`** — reports one measured storage hour to Stripe as a single **additive** meter event (raw MiB into a `sum` meter, never a last-value `set`, which would telescope and be gameable by deleting late in the period).

Clones the *structure* of `reportUsageForMonth` (skip conditions, two-phase, failure handling, circuit breaker) but **not** its delta-on-monthly-accumulator semantics — storage is additive per immutable hour.

## Key design decision (resolved during build)

The monthly command recovers crashes via `pendingReportedTotal` because there's exactly **one** unit of work per `(org, month)`. Storage has **many hours** per `(org, month)` sharing one checkpoint row, so `pendingReportedTotal` can't tell which hour was in flight. Decision:

- **Per-hour idempotency = `StorageUsageHourly.reportedAt` cursor** + deterministic Stripe identifier `storage_mb:<org>:<isoHour>`. Skip if already stamped; Stripe dedups a re-send.
- **The `(org, month)` checkpoint carries ONLY the circuit breaker** (`consecutiveFailures`). Crash-recovery is the cursor, not an accumulator.
- Monthly reconciliation total is derived (`SUM(megabytes WHERE reportedAt IS NOT NULL)`), always consistent.

→ PR1's `lastReportedTotal` / `pendingReportedTotal` columns are now **unused for storage** (over-cloned from the monthly checkpoint). Harmless; flagged to trim or repurpose for the Phase 4.5 tripwire's reconciliation snapshot.

## Behavior

- **Skip:** org not billable (no Stripe customer / no active subscription), or no measured row for the hour.
- **Success** (incl. Stripe `resource_already_exists`): stamp `reportedAt`; clear the breaker only if it had tripped partway; no self-dispatch (the hour is one-and-done).
- **Permanent rejection:** leave the hour unreported (cursor stays null) so a later run retries; bump the breaker; capture; no self-dispatch.
- **Transient error:** bump the breaker; self-dispatch a retry of the same hour; never propagate to the queue framework.
- **Breaker** trips at 5 consecutive failures → stops before reading the hour or calling Stripe; manual investigation.

## Files

- `commands/reportStorageForHour.command.ts` — the handler.
- `schemas/commands.ts` + `schemas/constants.ts` — `reportStorageForHourCommandDataSchema` + `REPORT_STORAGE_FOR_HOUR` type.
- `storageBillingCheckpoint.service.ts` — breaker-only `recordFailure` / `recordSuccess`.
- `storageUsageHourly.repository.ts` (new) — `findHour` / `markReported`.
- `pipeline.ts` — registered with per-`(org, hour)` dedup (`310s > 300s`, same sizing as the month command).
- `pipelineRegistry.ts` + `presets.ts` — instantiation + DI wiring.

The command is **registered and inert** — the dispatcher that sends it is Phase 4. No real Stripe call happens until the `STORAGE_GB` meter exists (Phase 5).

## Tests

- `specs/data-retention/storage-billing-hour-reporting.feature` — 11 `@unit` scenarios, all bound.
- `reportStorageForHour.command.unit.test.ts` — 12 tests: additive happy path, integer-MiB value, deterministic identifier, already-reported skip, Stripe duplicate, permanent rejection, transient retry, breaker tripped, breaker reset, skip-not-billable, no-row no-op, static metadata.

`pnpm typecheck` clean, 26 billing-reporting unit tests green (no regression to `reportUsageForMonth`), feature-parity OK.

Stacks on langwatch/langwatch#5158 (measurement).
