### PR TITLE
feat(datasets): live processing progress for large uploads (ADR-034)

### DIFF
--- a/dev/docs/adr/034-dataset-processing-progress.md
+++ b/dev/docs/adr/034-dataset-processing-progress.md
@@ -148,7 +148,7 @@ Client: tenant-scoped `onDatasetProgress.useSubscription` (filter by watched `da
 
 ## Open questions
 
-- **ADR-032 amendment for the `runInline` large-file hazard** (Decision 10): a setup-time "configure a worker/Redis for large uploads" error, framed as event-loop starvation, narrowing I-SELFHOST as a formal ADR-032 revision. **Owner: TBD — separate ADR, not blocking 033.**
+- **ADR-032 amendment for the `runInline` large-file hazard** (Decision 10): a setup-time "configure a worker/Redis for large uploads" error, framed as event-loop starvation, narrowing I-SELFHOST as a formal ADR-032 revision. **Owner: TBD — a separate ADR-032 amendment, not blocking this ADR (034).**
 - **`DATASET_PROGRESS_BROADCAST_MIN_INTERVAL_MS`** (1000) and **`DATASET_PROGRESS_STALE_RECONCILE_MS`** (5000) — tune against perceived smoothness vs Redis/refetch load once measured.
 - **Durable line-number failures** — revisit if support sees users stuck on opaque "failed" (deferred).
 

--- a/dev/docs/adr/034-dataset-processing-progress.md
+++ b/dev/docs/adr/034-dataset-processing-progress.md
@@ -1,0 +1,158 @@
+# ADR-034: Live dataset-processing progress is broadcast-only over the export SSE spine, with getById as the terminal authority
+
+**Date:** 2026-06-30
+
+**Status:** Accepted
+
+> **One-line:** A large dataset's normalize job **broadcasts ephemeral progress** (input-`bytesRead` / `totalBytes` / `rows` / `phase`) over the **existing export `BroadcastService` → tRPC SSE** spine on a producer-side throttle; the client renders a **bytes-%, live-row-count, client-computed-ETA bar with a phase stepper**, takes the **%** purely from SSE but treats **`getById` as the durable terminal authority** (re-fetched on connect / on `done` / on SSE-gap), **writes no progress to Postgres**, and **adds no schema** — so the bar can never hang and never overshoot, at the deliberate cost that the exact in-flight % does not survive a refresh.
+
+## Context
+
+A customer onboarding a multi-GB dataset hits a **multi-minute "Processing"** with zero feedback (`BulkUploadDrawer` "Preparing…" spinner; `[id].tsx` "Preparing your dataset" alert). It reads as hung. **Forcing function:** large-dataset onboarding friction — the silent wait is the felt pain.
+
+**Blast radius: data-path adjacent.** The progress producer is the normalize worker, so this ADR carries invariants + a mandatory red-team (folded as v2), even though it ships no migration.
+
+This builds directly on **ADR-032** (`dev/docs/adr/032-datasets-s3-jsonl.md`, Accepted), which provides everything durable we need and which this ADR does **not** revise:
+
+- Normalize runs **off-request as a standalone GroupQueue job** (`registerJob`, concurrency 1, streaming, memory-bounded), reading the staged upload and producing ~16 MB JSONL chunks via `StreamingChunkWriter`.
+- The `Dataset` row carries durable **terminal** state: `status` (`uploading → processing → ready / failed`), `statusError`, and **on success** `rowCount` / `sizeBytes` / `chunkCount` / `chunkOffsets`. The staged object is HEAD'd for its **raw input size** at finalize.
+- Every read consumer gates on `status='ready'` (I-READY); a wedged `processing` row is re-driven by the poll-triggered `reapStaleProcessing` (ADR-032 v17).
+
+And on the **export progress** spine, reused in shape — with its real limits now understood (see v2):
+
+- `BroadcastService.broadcastToTenant` / `broadcastToTenantRateLimited` / `getTenantEmitter` — Redis pub/sub, multi-pod-safe (`src/server/app-layer/broadcast/broadcast.service.ts`). The rate limiter (`tenant-rate-limiter.ts:75`) is a **token bucket that DROPS** over-budget events — it does **not** coalesce — and a subscriber-side bucket gates **every** inbound message (`broadcast.service.ts:89`). Subscriptions relay **live** emitter events only; **there is no replay/last-value cache**.
+- `exportRouter.onExportProgress` — a tRPC SSE `subscription` filtered by id, terminating on `done`/`error` (`src/server/api/routers/export.ts`). The template for `onDatasetProgress`. Export survives the no-replay/drop gaps **only because its subscription is welded to the HTTP streaming response**; ADR-034 decouples the worker job from the subscription, so it must reconcile terminals itself.
+
+**What is missing** is only the *signal*: GroupQueue is a fire-and-forget FIFO one-shot (`queueManager.ts:678`) with **no `updateProgress`, no durable, queryable job-progress store**.
+
+**Prior ADRs / rules.** ADR-019 + `CLAUDE.md`: route → service → repository, `projectId` on every query. ADR-007/023/026: GroupQueue is the substrate (no BullMQ). Reuse over parallel-build — honored by extending the export spine.
+
+## Decision
+
+1. **In-flight progress is broadcast-only and ephemeral — never written to Postgres.** The normalize job emits a progress event over the existing `BroadcastService`; nothing about the running % touches the `Dataset` row. **Rejects** persisting progress to new `Dataset` columns or a `DatasetProcessing` table (~128 `UPDATE`s per 2 GB file — write-amplification on the heaviest path, for durability we trade away in Decision 6) and "reuse a GroupQueue progress store" (none exists).
+
+2. **The denominator is input bytes; rows and ETA are derived.** `% = bytesRead / totalBytes`, where **`bytesRead` is bytes consumed from the staged input stream** and **`totalBytes` is the staged-object HEAD size captured at job start** — both measured on the **input** side, deliberately *not* the output `sizeBytes` column (which is normalized-chunk bytes written only on success, and would make the bar overshoot/undershoot — see I-BYTES). `rows` is an **unbounded live count**, no denominator. **ETA/throughput are computed client-side** from successive SSE deltas (Δbytes / Δt), shown only after ≥2 deltas. Determinate from the first tick, **single pass**. **Rejects** a row-count denominator via line-count pre-pass (doubles I/O, violates ADR-032's streaming contract) and an indeterminate-only bar.
+
+3. **Transport reuses the export spine as a single tenant-scoped `onDatasetProgress` tRPC SSE subscription, client-filtered by a watched `datasetId` set.** One subscription per project; the detail page watches one id, the bulk drawer watches N — one code path, scales to bulk on a single emitter listener. `datasets:view` RBAC, server-side tenant scoping, terminates when no watched id remains active. **Rejects** a per-dataset subscription (N concurrent uploads = N listeners against the per-tenant emitter's shared 50-listener ceiling — `broadcast.service.ts:258` — `MaxListenersExceeded` + leak on a 50-file drop) and keeping the 3 s `getById` poll as the primary channel.
+
+4. **The client takes the % purely from SSE but treats `getById` as the durable terminal authority.** `getById` is re-fetched/invalidated on **subscription connect**, on **receipt of `done`/`error`**, and on **any SSE gap > `DATASET_PROGRESS_STALE_RECONCILE_MS` while `processing`**. A durable `ready`/`failed` from `getById` drives the bar terminal **regardless of whether the terminal SSE event ever arrived**. This is **not** the rejected 3 s poll — it is event-driven refetch plus one safety timer. **Rejects** a one-shot `getById` mount-seed with no reconciliation (the common subscribe-after-done race — fast job finishes before the component subscribes — leaves the bar hung forever).
+
+5. **The terminal `done`/`error` is sent via plain `broadcastToTenant` (never the rate-limited path) and only *after* the durable terminal commit.** The rate limiter drops; the terminal event must not be droppable, and committing `status` before broadcasting prevents a `done`-triggered `getById` refetch from racing back to `processing`. Even so, delivery is best-effort — Decision 4's reconciliation is the guarantee; this just makes the happy path instant. **Rejects** routing the terminal through `broadcastToTenantRateLimited` (could be dropped under tenant bucket pressure, stranding the bar at 99%).
+
+6. **On refresh / SSE-drop mid-job the bar is indeterminate and self-heals; terminal correctness is guaranteed by Decision 4, not by "the next delta."** `getById='processing'` → indeterminate "Processing…"; the next throttled broadcast refills the exact % while the worker is alive; a dead/wedged worker stays **honestly indeterminate** (the UI never invents a %) until `getById` reconciliation or ADR-032's `reapStaleProcessing` resolves it. **Rejects** subscribe-triggered worker re-emit (extra machinery for a sub-second gain) and a blank/0 % hold.
+
+7. **The Phase-1 "durable / refresh-proof" constraint is consciously downgraded — for the % only.** Only **terminal** state (`status` / `statusError` / final counts — already durable per ADR-032) survives a refresh; the **intermediate %** does not. This is the price of Decision 1, accepted because (a) the bar self-heals within one throttle interval while the worker is alive and (b) Decision 4 guarantees the terminal is always reached.
+
+8. **A rich phase stepper rides inside the SSE payload — no new column.** `Uploading → Processing (%) → Finalizing → Ready/Failed`; the fine `phase` travels in the event, the coarse refresh-seed uses ADR-032's `status`. **Rejects** a persisted `phase` column and a single bar with no stepper.
+
+9. **Failures surface generically via ADR-032's durable `statusError` — no line/row location.** `status='failed'` + a generic message, durable on the row, read by the `getById` reconciliation (Decision 4), shown with Retry. **Rejects** enriching `statusError` with the offending line (deferred — minimal v1) and streaming the error only over SSE (a refresh after failure would lose it).
+
+10. **The `runInline` (no-worker) large-file hazard is out of scope for this ADR.** It is an ADR-032 concern (its Accepted I-SELFHOST promises no-worker installs onboard multi-GB datasets inline) and the real hazard is **event-loop starvation**, not heap OOM (ADR-032's streaming contract already bounds memory). Handling it correctly — a **setup-time** "configure a worker/Redis for large uploads" error rather than a per-upload ambush — requires amending ADR-032, tracked as an Open Question. **Rejects** folding a per-upload inline byte-reject into ADR-034 (would bury a regression of an Accepted invariant inside a UX ADR, mis-frame the hazard as OOM, and collide numerically with `LARGE_JSON_MAX_BYTES`).
+
+## Constants
+
+| Name | Value | Purpose |
+|---|---|---|
+| Broadcast event type | `"dataset_progress"` | Tenant-emitter event name; **must** be added to `BroadcastEventType` + `ALL_EVENT_TYPES` (`broadcast.service.ts:22`) or delivery is silently same-pod-only (I-XPOD). |
+| `phase` values | `uploading` \| `processing` \| `finalizing` \| `ready` \| `failed` | Fine stepper state in the SSE event (ephemeral); coarse refresh-seed maps from `Dataset.status`. |
+| Event `type` values | `progress` \| `done` \| `error` | Mirrors `exportProgressEventSchema`; subscription drops a watched id on its `done`/`error`. |
+| `DATASET_PROGRESS_BROADCAST_MIN_INTERVAL_MS` | 1000 (proposed, tunable) | **Producer-side** min-interval throttle (last-sent timestamp) — the token-bucket limiter does **not** enforce an interval (S5), so the producer must. `progress` events are throttled; **terminal events bypass it.** |
+| `DATASET_PROGRESS_STALE_RECONCILE_MS` | 5000 (proposed, tunable) | SSE-gap after which the client re-fetches `getById` while `processing` (Decision 4 safety timer). |
+| Subscription RBAC | `datasets:view` | Gate on `onDatasetProgress` (mirrors export's `traces:view`). |
+| `bytesRead` / `totalBytes` | input stream offset / staging HEAD at job start | Both input-side; never the output `sizeBytes` column (B2 / I-BYTES). |
+
+## Invariants
+
+| ID | Invariant | Test anchor |
+|---|---|---|
+| I-NOWRITE | The progress path performs **zero** `Dataset` writes during normalize; the only writes are ADR-032's claim (`processing`) and the single terminal update (`ready`/`failed`). | Normalize a large file → assert no `Dataset` UPDATE between claim and finalize beyond the terminal one. |
+| I-TERMINAL-REACHED | The bar **always** reaches a terminal state even if **every** SSE event is dropped or the subscription starts after the job finished — `getById` reconciliation (connect / `done` / gap) flips it. | Subscribe after the job already emitted `done`; drop all SSE → `getById` refetch flips bar to ready/failed, no hang. |
+| I-BYTES | The bar is monotonic in [0, 100] and reaches 100 only at finalize — numerator and denominator are both input-side. | Normalize an expanding CSV (JSONL ≫ raw) and a compressing one → never exceeds 100% early, never teleports. |
+| I-ORDER | Terminal `status` is committed **before** the terminal broadcast; a `done`-triggered `getById` refetch never observes `processing`. | Broadcast-after-commit ordering test; `done` → refetch returns `ready`. |
+| I-XPOD | With the worker on pod A and the subscription on pod B, progress crosses pods (event type registered in `ALL_EVENT_TYPES`). | Publish on A, subscribe on B → event received. |
+| I-TENANT | Progress is tenant-scoped and client-filtered by `datasetId`; a subscriber never receives another project's progress; gated by `datasets:view`. | Cross-project subscribe → zero leak. |
+| I-RATE | Producer emits at most one `progress` event per `DATASET_PROGRESS_BROADCAST_MIN_INTERVAL_MS` regardless of chunk count; terminal events are exempt. | Normalize a 2 GB file → `progress` event count ≈ duration/interval, not one-per-chunk; exactly one terminal. |
+| I-TERMINAL-DURABLE | `ready`/`failed` + final counts + `statusError` survive a refresh (inherits ADR-032 I-READY). | Fail a normalize → refresh → still `failed` + message + Retry. |
+
+## Schema
+
+**No migration. Intentionally.** Every durable field already exists on `Dataset` from ADR-032. The only new declared shape is the SSE event, parallel to `exportProgressEventSchema`:
+
+```ts
+// src/server/api/routers/dataset.ts (new subscription, mirrors export.ts)
+export const datasetProgressEventSchema = z.object({
+  datasetId: z.string(),
+  type: z.enum(["progress", "done", "error"]),
+  phase: z
+    .enum(["uploading", "processing", "finalizing", "ready", "failed"])
+    .optional(),
+  bytesRead: z.number().optional(),  // input stream offset (numerator)
+  totalBytes: z.number().optional(), // staging-object HEAD size @ job start (NOT Dataset.sizeBytes)
+  rows: z.number().optional(),       // unbounded live count, no denominator
+  message: z.string().optional(),    // generic failure message (Decision 9)
+});
+```
+
+Producer wiring (no new persistence):
+
+```
+dataset-normalize.job.ts
+  ├─ at job start: totalBytes = HEAD(stagingKey)           // raw input size
+  ├─ parse loop tracks bytesRead from the staged input stream
+  ├─ producer throttle (last-sent ts ≥ MIN_INTERVAL_MS):
+  │     broadcast.broadcastToTenantRateLimited(projectId,
+  │       { datasetId, type:"progress", phase, bytesRead, totalBytes, rows },
+  │       "dataset_progress")
+  └─ on finalize/catch:
+        repository.update(status: ready|failed, ...)        // COMMIT FIRST (I-ORDER)
+        broadcast.broadcastToTenant(projectId,              // PLAIN broadcast, after commit (Decision 5)
+          { datasetId, type: "done"|"error", phase, message? }, "dataset_progress")
+```
+
+Client: tenant-scoped `onDatasetProgress.useSubscription` (filter by watched `datasetId` set) for the % / rows / phase; `api.dataset.getById` invalidated on connect / `done` / SSE-gap for the durable terminal (Decision 4).
+
+## Rejected alternatives
+
+- **Generic job-progress platform** — over-built; datasets is the only consumer.
+- **Minimal bar, no ETA/phase** — fails the rich-bar intent.
+- **Row-count denominator via pre-pass** — doubles I/O, breaks ADR-032's streaming contract.
+- **Output `sizeBytes` as denominator** — doesn't exist mid-job; output/raw mismatch overshoots (B2).
+- **Persist progress to columns / a table** — write-amplification; durability traded away.
+- **GroupQueue progress store** — none exists; FIFO one-shot only.
+- **One-shot `getById` seed, no reconciliation** — subscribe-after-done hangs the bar (B1).
+- **Terminal via the rate-limited path** — droppable; strands the bar at 99% (B1).
+- **Retained-last-event cache in BroadcastService** — adds stateful TTL/eviction to a shared service export doesn't need; `getById` reconciliation is cheaper and already durable.
+- **Per-dataset subscription** — 50-listener ceiling breaks the bulk drop (S3).
+- **Keep the 3 s poll primary / poll fallback** — underuses SSE; bulk N-poll cost.
+- **Subscribe-triggered worker re-emit** — machinery for a sub-second gain.
+- **Durable line-number failure detail** — deferred; generic `failed`.
+- **Inline byte-reject inside ADR-034** — wrong ADR, wrong hazard model, number collision (S4 → Decision 10).
+
+## Consequences
+
+**Positive**
+- **Zero new schema, zero migration** — additive: one SSE event type + one throttled broadcast + one client component.
+- **No DB write-amplification** on the heaviest path.
+- **The bar can neither hang nor overshoot** — `getById` reconciliation (I-TERMINAL-REACHED) + input-side bytes (I-BYTES) close the two red-team blockers.
+- **Real-time bytes-%, live rows, ETA, phase stepper**; cross-pod by construction; one transport shape scales detail → bulk.
+
+**Negative**
+- **Exact in-flight % does not survive a refresh / SSE-drop** — brief indeterminate flash, self-heals only while the worker is alive (Decision 7, conscious).
+- **A small `getById` reconciliation cost** returns — event-driven refetch on connect/`done`/gap (not a periodic poll), a deliberate concession to close B1.
+- **A wedged/dead worker is indistinguishable from "slow"** until reconciliation / `reapStaleProcessing`.
+- **Generic failure message** — a malformed line in a 2 GB file gives no location.
+- **The no-worker large-file hazard is left unfixed here** — deferred to an ADR-032 amendment (Open Questions).
+
+**Neutral**
+- ETA is a client-side byte-rate estimate (shown after ≥2 deltas); the **rows/sec** display is jumpy on base64-heavy data, the ETA itself is defensible (normalize wall-time tracks bytes-I/O).
+
+## Open questions
+
+- **ADR-032 amendment for the `runInline` large-file hazard** (Decision 10): a setup-time "configure a worker/Redis for large uploads" error, framed as event-loop starvation, narrowing I-SELFHOST as a formal ADR-032 revision. **Owner: TBD — separate ADR, not blocking 033.**
+- **`DATASET_PROGRESS_BROADCAST_MIN_INTERVAL_MS`** (1000) and **`DATASET_PROGRESS_STALE_RECONCILE_MS`** (5000) — tune against perceived smoothness vs Redis/refetch load once measured.
+- **Durable line-number failures** — revisit if support sees users stuck on opaque "failed" (deferred).
+
+## Revisions
+
+- **v1 (2026-06-30):** Initial. Phase-1: decision = dataset-only progress UX, forcing = large-dataset onboarding, blast = data-path adjacent, locked = reuse SSE spine · durable/refresh-proof. Phase-3 r1: bytes denominator; inline minimal-guard; GroupQueue-job-only (no PG); pure-SSE transport. r2: indeterminate-self-heal; rich broadcast-only phases; generic-failed; per-dataset subscription. **"durable/refresh-proof" consciously downgraded** to ephemeral-%/durable-terminal.
+- **v2 (2026-06-30) — red-team folded:** **B1** the terminal SSE event is droppable (token-bucket drops, no replay) and subscribe-after-done hangs the bar → **`getById` becomes the event-driven terminal authority** (connect / `done` / gap) + terminal sent via **plain** `broadcastToTenant` after commit (Decisions 4, 5; I-TERMINAL-REACHED). **B2** denominator conflated output `sizeBytes` with raw input → **both numerator and denominator are input-side**, staging HEAD at job start (Decision 2; I-BYTES). **S1** commit `status` before terminal broadcast (I-ORDER). **S2** register `dataset_progress` in `ALL_EVENT_TYPES` or it's same-pod-only (I-XPOD). **S3** per-dataset subscription breaks the 50-listener bulk ceiling → **single tenant-scoped, client-filtered subscription** (Decision 3, supersedes r2 per-dataset keying). **S4** the inline guard regressed Accepted I-SELFHOST and mis-framed the hazard → **removed from 033**, deferred to an ADR-032 amendment (Decision 10). **S5** the limiter is a token bucket, not a min-interval throttle → **producer-side throttle**, terminal exempt (I-RATE).

--- a/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
@@ -13,6 +13,7 @@ import {
   HStack,
   Icon,
   Input,
+  Progress,
   Spacer,
   Spinner,
   Text,
@@ -58,6 +59,8 @@ import {
   ColumnTypeSelect,
 } from "../../shared/ColumnTypeSelect";
 import { Drawer } from "../../ui/drawer";
+import type { DatasetProgressLive } from "../processing/datasetProgressView";
+import { useDatasetProgressMap } from "../processing/useDatasetProgressMap";
 import {
   DROPZONE_DOTTED_STYLE,
   DropzonePrompt,
@@ -436,10 +439,13 @@ function RowTrailing({
   file,
   isOpen,
   onToggle,
+  live,
 }: {
   file: BulkFile;
   isOpen: boolean;
   onToggle: () => void;
+  /** ADR-034: latest ephemeral progress tick for this row's dataset, if any. */
+  live?: DatasetProgressLive;
 }) {
   switch (file.status) {
     case "pending":
@@ -473,15 +479,40 @@ function RowTrailing({
           </Text>
         </HStack>
       );
-    case "processing":
+    case "processing": {
+      // ADR-034: a determinate bar once a live tick with a total has arrived;
+      // an honest "Preparing…" until then (or if the worker is silent).
+      const percent =
+        live && live.totalBytes && live.totalBytes > 0
+          ? Math.min(100, Math.round(((live.bytesRead ?? 0) / live.totalBytes) * 100))
+          : null;
       return (
-        <HStack gap={1.5}>
-          <Spinner size="xs" color="blue.500" />
-          <Text fontSize="13px" fontWeight="medium" css={RAINBOW_TEXT_CSS}>
-            Preparing…
-          </Text>
-        </HStack>
+        <VStack align="end" gap={1} minW="150px">
+          <HStack gap={1.5}>
+            <Spinner size="xs" color="blue.500" />
+            <Text fontSize="13px" fontWeight="medium" css={RAINBOW_TEXT_CSS}>
+              {percent == null
+                ? "Preparing…"
+                : `${percent}%${
+                    live?.rows != null
+                      ? ` · ${live.rows.toLocaleString()} rows`
+                      : ""
+                  }`}
+            </Text>
+          </HStack>
+          <Progress.Root
+            value={percent}
+            colorPalette="blue"
+            size="xs"
+            width="150px"
+          >
+            <Progress.Track>
+              <Progress.Range />
+            </Progress.Track>
+          </Progress.Root>
+        </VStack>
       );
+    }
     case "ready":
       return (
         <HStack gap={1} color="green.600" fontSize="13px">
@@ -514,6 +545,7 @@ function RowTrailing({
 function BulkFileRow({
   file,
   projectId,
+  live,
   onRemove,
   onCancel,
   onRetry,
@@ -524,6 +556,9 @@ function BulkFileRow({
 }: {
   file: BulkFile;
   projectId: string;
+  /** ADR-034: latest ephemeral progress tick for this dataset (from the drawer's
+   *  single lifted subscription), or undefined before the first tick. */
+  live?: DatasetProgressLive;
   onRemove: () => void;
   onCancel: () => void;
   onRetry: () => void;
@@ -597,6 +632,7 @@ function BulkFileRow({
           file={file}
           isOpen={isOpen}
           onToggle={() => setIsOpen((o) => !o)}
+          live={live}
         />
         {file.status === "failed" && (
           <Button size="xs" variant="outline" onClick={onRetry}>
@@ -670,6 +706,17 @@ export function BulkUploadDrawer({
   const projectId = project?.id;
   const bulk = useBulkUpload(projectId);
   const [zoneHover, setZoneHover] = useState(false);
+
+  // ADR-034: ONE project-wide progress subscription for the whole drawer (not
+  // one per row — that would hit the 50-listener emitter ceiling). Enabled only
+  // while something is in flight; rows read their live tick by datasetId.
+  const anyActive = bulk.files.some(
+    (file) => file.status === "processing" || file.status === "uploading",
+  );
+  const progressMap = useDatasetProgressMap({
+    projectId: projectId ?? "",
+    enabled: anyActive,
+  });
 
   // Block the upload while any pending file has a blank or duplicated column
   // name — normalize would drop/collide those values (see invalidColumnNameKeys).
@@ -772,6 +819,7 @@ export function BulkUploadDrawer({
                   key={file.id}
                   file={file}
                   projectId={projectId ?? ""}
+                  live={file.datasetId ? progressMap[file.datasetId] : undefined}
                   onRemove={() => bulk.removeFile(file.id)}
                   onCancel={() => bulk.cancelFile(file.id)}
                   onRetry={() => void bulk.retryFile(file.id)}

--- a/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
@@ -59,14 +59,14 @@ import {
   ColumnTypeSelect,
 } from "../../shared/ColumnTypeSelect";
 import { Drawer } from "../../ui/drawer";
-import type { DatasetProgressLive } from "../processing/datasetProgressView";
-import { useDatasetProgressMap } from "../processing/useDatasetProgressMap";
 import {
   DROPZONE_DOTTED_STYLE,
   DropzonePrompt,
   dropzoneSurfaceProps,
   RAINBOW_TEXT_CSS,
 } from "../datasetDropzoneStyles";
+import type { DatasetProgressLive } from "../processing/datasetProgressView";
+import { useDatasetProgressMap } from "../processing/useDatasetProgressMap";
 import { reorderColumnsBySourceHeader } from "./columnReorder";
 import { invalidColumnNameKeys } from "./columnValidation";
 import { type BulkFile, useBulkUpload } from "./useBulkUpload";

--- a/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/BulkUploadDrawer.tsx
@@ -484,7 +484,10 @@ function RowTrailing({
       // an honest "Preparing…" until then (or if the worker is silent).
       const percent =
         live && live.totalBytes && live.totalBytes > 0
-          ? Math.min(100, Math.round(((live.bytesRead ?? 0) / live.totalBytes) * 100))
+          ? Math.min(
+              100,
+              Math.round(((live.bytesRead ?? 0) / live.totalBytes) * 100),
+            )
           : null;
       return (
         <VStack align="end" gap={1} minW="150px">
@@ -819,7 +822,9 @@ export function BulkUploadDrawer({
                   key={file.id}
                   file={file}
                   projectId={projectId ?? ""}
-                  live={file.datasetId ? progressMap[file.datasetId] : undefined}
+                  live={
+                    file.datasetId ? progressMap[file.datasetId] : undefined
+                  }
                   onRemove={() => bulk.removeFile(file.id)}
                   onCancel={() => bulk.cancelFile(file.id)}
                   onRetry={() => void bulk.retryFile(file.id)}

--- a/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
+++ b/langwatch/src/components/datasets/bulkUpload/__tests__/BulkUploadDrawer.integration.test.tsx
@@ -56,7 +56,13 @@ const getByIdQuery = vi.fn(() => ({
 }));
 vi.mock("~/utils/api", () => ({
   api: {
-    dataset: { getById: { useQuery: () => getByIdQuery() } },
+    dataset: {
+      getById: { useQuery: () => getByIdQuery() },
+      // ADR-034: the drawer opens one lifted progress subscription; the test
+      // drives no live events, so a no-op stub keeps the rows on their getById
+      // status poll (which resolves ready above).
+      onDatasetProgress: { useSubscription: () => undefined },
+    },
     useContext: () => ({}),
   },
 }));

--- a/langwatch/src/components/datasets/processing/DatasetProcessingProgress.tsx
+++ b/langwatch/src/components/datasets/processing/DatasetProcessingProgress.tsx
@@ -1,0 +1,144 @@
+/**
+ * ADR-034: the live dataset-processing bar — percent (input bytes), a running
+ * row count, a client-computed ETA, and a phase stepper. Renders nothing once
+ * the dataset is ready (the editor takes over) and an actionable failed state
+ * with Retry. The terminal authority is the caller's `getById`; this component
+ * just reflects the view the hook derives.
+ */
+import {
+  Alert,
+  Box,
+  Button,
+  HStack,
+  Progress,
+  Spinner,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import type {
+  DatasetProgressPhase,
+  DatasetStatusLike,
+} from "./datasetProgressView";
+import { useDatasetProcessingProgress } from "./useDatasetProcessingProgress";
+
+const PHASES: { key: DatasetProgressPhase; label: string }[] = [
+  { key: "uploading", label: "Uploading" },
+  { key: "processing", label: "Processing" },
+  { key: "finalizing", label: "Finalizing" },
+  { key: "ready", label: "Ready" },
+];
+
+const formatEta = (seconds?: number): string | null => {
+  if (seconds == null) return null;
+  if (seconds < 60) return `~${seconds}s left`;
+  return `~${Math.round(seconds / 60)} min left`;
+};
+
+function PhaseStepper({ current }: { current: DatasetProgressPhase }) {
+  const activeIdx = PHASES.findIndex((p) => p.key === current);
+  return (
+    <HStack gap={1} flexShrink={0}>
+      {PHASES.map((p, i) => (
+        <HStack key={p.key} gap={1}>
+          <Text
+            textStyle="xs"
+            color={i <= activeIdx ? "fg" : "fg.subtle"}
+            fontWeight={i === activeIdx ? "semibold" : "normal"}
+          >
+            {p.label}
+          </Text>
+          {i < PHASES.length - 1 && (
+            <Text textStyle="xs" color="fg.subtle">
+              →
+            </Text>
+          )}
+        </HStack>
+      ))}
+    </HStack>
+  );
+}
+
+export function DatasetProcessingProgress(props: {
+  projectId: string;
+  datasetId: string;
+  status: DatasetStatusLike;
+  statusError?: string | null;
+  onReconcile?: () => void;
+  onRetry?: () => void;
+  isRetrying?: boolean;
+}) {
+  const view = useDatasetProcessingProgress(props);
+
+  if (view.kind === "hidden") return null;
+
+  if (view.kind === "failed") {
+    return (
+      <Alert.Root status="error" data-testid="dataset-processing-failed">
+        <Alert.Indicator />
+        <Alert.Content>
+          <Alert.Title>We could not prepare your dataset</Alert.Title>
+          <Alert.Description>
+            {view.message ??
+              "Something went wrong while processing your file. You can retry."}
+          </Alert.Description>
+        </Alert.Content>
+        {props.onRetry && (
+          <Button
+            size="sm"
+            colorPalette="red"
+            variant="outline"
+            loading={props.isRetrying}
+            onClick={props.onRetry}
+          >
+            Retry
+          </Button>
+        )}
+      </Alert.Root>
+    );
+  }
+
+  const indeterminate = view.kind === "indeterminate";
+  const eta = indeterminate ? null : formatEta(view.etaSeconds);
+
+  return (
+    <Box
+      padding={3}
+      borderRadius="lg"
+      borderWidth="1px"
+      borderColor="border.muted"
+      bg="bg.panel"
+      data-testid="dataset-processing-progress"
+    >
+      <VStack align="stretch" gap={2}>
+        <HStack justify="space-between" gap={3}>
+          <HStack gap={2} minWidth={0}>
+            <Spinner size="xs" color="fg.muted" />
+            <Text textStyle="sm" color="fg" truncate>
+              {indeterminate ? (
+                "Preparing your dataset…"
+              ) : (
+                <>
+                  {view.percent}% prepared
+                  {view.rows != null
+                    ? ` · ${view.rows.toLocaleString()} rows`
+                    : ""}
+                  {eta ? ` · ${eta}` : ""}
+                </>
+              )}
+            </Text>
+          </HStack>
+          <PhaseStepper current={view.phase} />
+        </HStack>
+        <Progress.Root
+          value={indeterminate ? null : view.percent}
+          colorPalette="blue"
+          size="xs"
+        >
+          <Progress.Track>
+            <Progress.Range css={{ transition: "width 0.5s ease-in-out" }} />
+          </Progress.Track>
+        </Progress.Root>
+      </VStack>
+    </Box>
+  );
+}

--- a/langwatch/src/components/datasets/processing/DatasetProcessingProgress.tsx
+++ b/langwatch/src/components/datasets/processing/DatasetProcessingProgress.tsx
@@ -17,6 +17,7 @@ import {
 } from "@chakra-ui/react";
 import type {
   DatasetProgressPhase,
+  DatasetProgressView,
   DatasetStatusLike,
 } from "./datasetProgressView";
 import { useDatasetProcessingProgress } from "./useDatasetProcessingProgress";
@@ -58,48 +59,50 @@ function PhaseStepper({ current }: { current: DatasetProgressPhase }) {
   );
 }
 
-export function DatasetProcessingProgress(props: {
-  projectId: string;
-  datasetId: string;
-  status: DatasetStatusLike;
-  statusError?: string | null;
-  onReconcile?: () => void;
+/** Durable-failure state: message + optional Retry (from the caller's getById). */
+function ProcessingFailedAlert({
+  message,
+  onRetry,
+  isRetrying,
+}: {
+  message?: string;
   onRetry?: () => void;
   isRetrying?: boolean;
 }) {
-  const view = useDatasetProcessingProgress(props);
+  return (
+    <Alert.Root status="error" data-testid="dataset-processing-failed">
+      <Alert.Indicator />
+      <Alert.Content>
+        <Alert.Title>We could not prepare your dataset</Alert.Title>
+        <Alert.Description>
+          {message ??
+            "Something went wrong while processing your file. You can retry."}
+        </Alert.Description>
+      </Alert.Content>
+      {onRetry && (
+        <Button
+          size="sm"
+          colorPalette="red"
+          variant="outline"
+          loading={isRetrying}
+          onClick={onRetry}
+        >
+          Retry
+        </Button>
+      )}
+    </Alert.Root>
+  );
+}
 
-  if (view.kind === "hidden") return null;
+type ActiveView = Extract<
+  DatasetProgressView,
+  { kind: "indeterminate" | "determinate" }
+>;
 
-  if (view.kind === "failed") {
-    return (
-      <Alert.Root status="error" data-testid="dataset-processing-failed">
-        <Alert.Indicator />
-        <Alert.Content>
-          <Alert.Title>We could not prepare your dataset</Alert.Title>
-          <Alert.Description>
-            {view.message ??
-              "Something went wrong while processing your file. You can retry."}
-          </Alert.Description>
-        </Alert.Content>
-        {props.onRetry && (
-          <Button
-            size="sm"
-            colorPalette="red"
-            variant="outline"
-            loading={props.isRetrying}
-            onClick={props.onRetry}
-          >
-            Retry
-          </Button>
-        )}
-      </Alert.Root>
-    );
-  }
-
+/** The live bar itself: label (percent · rows · ETA) + stepper + progress. */
+function ProcessingBar({ view }: { view: ActiveView }) {
   const indeterminate = view.kind === "indeterminate";
   const eta = indeterminate ? null : formatEta(view.etaSeconds);
-
   return (
     <Box
       padding={3}
@@ -141,4 +144,28 @@ export function DatasetProcessingProgress(props: {
       </VStack>
     </Box>
   );
+}
+
+export function DatasetProcessingProgress(props: {
+  projectId: string;
+  datasetId: string;
+  status: DatasetStatusLike;
+  statusError?: string | null;
+  onReconcile?: () => void;
+  onRetry?: () => void;
+  isRetrying?: boolean;
+}) {
+  const view = useDatasetProcessingProgress(props);
+
+  if (view.kind === "hidden") return null;
+  if (view.kind === "failed") {
+    return (
+      <ProcessingFailedAlert
+        message={view.message}
+        onRetry={props.onRetry}
+        isRetrying={props.isRetrying}
+      />
+    );
+  }
+  return <ProcessingBar view={view} />;
 }

--- a/langwatch/src/components/datasets/processing/__tests__/datasetProgressView.unit.test.ts
+++ b/langwatch/src/components/datasets/processing/__tests__/datasetProgressView.unit.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveDatasetProgressView,
+  estimateEtaSeconds,
+} from "../datasetProgressView";
+
+describe("deriveDatasetProgressView", () => {
+  describe("when getById is terminal (the durable authority)", () => {
+    // I-TERMINAL-REACHED: the durable status overrides any stale ephemeral tick —
+    // this is what makes the bar un-hangable. A 45% 'processing' tick that was
+    // the last thing the SSE stream delivered must NOT survive a getById=ready.
+    it("hides the bar on ready even with a stale processing tick still in hand", () => {
+      const view = deriveDatasetProgressView({
+        status: "ready",
+        live: { bytesRead: 450, totalBytes: 1000, rows: 12, phase: "processing" },
+      });
+      expect(view).toEqual({ kind: "hidden" });
+    });
+
+    it("shows failed with the durable statusError regardless of the live tick", () => {
+      const view = deriveDatasetProgressView({
+        status: "failed",
+        statusError: "Uploaded file is empty",
+        live: { bytesRead: 999, totalBytes: 1000, phase: "processing" },
+      });
+      expect(view).toEqual({
+        kind: "failed",
+        message: "Uploaded file is empty",
+      });
+    });
+  });
+
+  describe("when still processing", () => {
+    it("is determinate from input bytes once a live tick with a total arrives", () => {
+      const view = deriveDatasetProgressView({
+        status: "processing",
+        live: { bytesRead: 250, totalBytes: 1000, rows: 30, phase: "processing" },
+        etaSeconds: 12,
+      });
+      expect(view).toEqual({
+        kind: "determinate",
+        percent: 25,
+        rows: 30,
+        etaSeconds: 12,
+        phase: "processing",
+      });
+    });
+
+    it("is honestly indeterminate with no live tick yet (refresh / dead worker)", () => {
+      const view = deriveDatasetProgressView({ status: "processing", live: null });
+      expect(view).toEqual({ kind: "indeterminate", phase: "processing" });
+    });
+
+    it("never exceeds 100% even if input bytes overshoot the total", () => {
+      const view = deriveDatasetProgressView({
+        status: "processing",
+        live: { bytesRead: 1200, totalBytes: 1000, phase: "finalizing" },
+      });
+      expect(view).toMatchObject({ kind: "determinate", percent: 100 });
+    });
+  });
+
+  describe("when not yet resolved", () => {
+    it("hides while status is undefined (query loading)", () => {
+      expect(
+        deriveDatasetProgressView({ status: undefined, live: null }),
+      ).toEqual({ kind: "hidden" });
+    });
+  });
+});
+
+describe("estimateEtaSeconds", () => {
+  it("returns undefined before two samples", () => {
+    expect(estimateEtaSeconds([{ t: 0, bytes: 0 }], 1000, 0)).toBeUndefined();
+  });
+
+  it("derives remaining seconds from the byte-rate over the window", () => {
+    // 500 bytes over 5s = 100 B/s; 500 remaining → 5s.
+    const eta = estimateEtaSeconds(
+      [
+        { t: 0, bytes: 0 },
+        { t: 5000, bytes: 500 },
+      ],
+      1000,
+      500,
+    );
+    expect(eta).toBe(5);
+  });
+
+  it("returns undefined on a non-positive rate", () => {
+    expect(
+      estimateEtaSeconds(
+        [
+          { t: 0, bytes: 500 },
+          { t: 5000, bytes: 500 },
+        ],
+        1000,
+        500,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/langwatch/src/components/datasets/processing/__tests__/datasetProgressView.unit.test.ts
+++ b/langwatch/src/components/datasets/processing/__tests__/datasetProgressView.unit.test.ts
@@ -12,7 +12,12 @@ describe("deriveDatasetProgressView", () => {
     it("hides the bar on ready even with a stale processing tick still in hand", () => {
       const view = deriveDatasetProgressView({
         status: "ready",
-        live: { bytesRead: 450, totalBytes: 1000, rows: 12, phase: "processing" },
+        live: {
+          bytesRead: 450,
+          totalBytes: 1000,
+          rows: 12,
+          phase: "processing",
+        },
       });
       expect(view).toEqual({ kind: "hidden" });
     });
@@ -34,7 +39,12 @@ describe("deriveDatasetProgressView", () => {
     it("is determinate from input bytes once a live tick with a total arrives", () => {
       const view = deriveDatasetProgressView({
         status: "processing",
-        live: { bytesRead: 250, totalBytes: 1000, rows: 30, phase: "processing" },
+        live: {
+          bytesRead: 250,
+          totalBytes: 1000,
+          rows: 30,
+          phase: "processing",
+        },
         etaSeconds: 12,
       });
       expect(view).toEqual({
@@ -46,8 +56,19 @@ describe("deriveDatasetProgressView", () => {
       });
     });
 
+    it("falls back to the uploading status, not processing, when a tick has no phase", () => {
+      const view = deriveDatasetProgressView({
+        status: "uploading",
+        live: { bytesRead: 100, totalBytes: 1000 },
+      });
+      expect(view).toMatchObject({ kind: "determinate", phase: "uploading" });
+    });
+
     it("is honestly indeterminate with no live tick yet (refresh / dead worker)", () => {
-      const view = deriveDatasetProgressView({ status: "processing", live: null });
+      const view = deriveDatasetProgressView({
+        status: "processing",
+        live: null,
+      });
       expect(view).toEqual({ kind: "indeterminate", phase: "processing" });
     });
 

--- a/langwatch/src/components/datasets/processing/__tests__/useDatasetProcessingProgress.unit.test.ts
+++ b/langwatch/src/components/datasets/processing/__tests__/useDatasetProcessingProgress.unit.test.ts
@@ -34,7 +34,11 @@ const { useDatasetProcessingProgress } = await import(
   "../useDatasetProcessingProgress"
 );
 
-const base = { projectId: "p1", datasetId: "d1", status: "processing" as const };
+const base = {
+  projectId: "p1",
+  datasetId: "d1",
+  status: "processing" as const,
+};
 
 beforeEach(() => {
   capturedOnData = undefined;
@@ -70,9 +74,7 @@ describe("useDatasetProcessingProgress", () => {
 
   describe("when a progress tick for this dataset arrives", () => {
     it("becomes determinate from the input bytes", () => {
-      const { result } = renderHook(() =>
-        useDatasetProcessingProgress(base),
-      );
+      const { result } = renderHook(() => useDatasetProcessingProgress(base));
       act(() =>
         capturedOnData?.({
           datasetId: "d1",
@@ -94,9 +96,7 @@ describe("useDatasetProcessingProgress", () => {
   describe("when a terminal done event arrives", () => {
     it("reconciles the durable status via getById", () => {
       const onReconcile = vi.fn();
-      renderHook(() =>
-        useDatasetProcessingProgress({ ...base, onReconcile }),
-      );
+      renderHook(() => useDatasetProcessingProgress({ ...base, onReconcile }));
       act(() =>
         capturedOnData?.({ datasetId: "d1", type: "done", phase: "ready" }),
       );
@@ -108,9 +108,7 @@ describe("useDatasetProcessingProgress", () => {
     it("reconciles via getById on the gap timer", () => {
       vi.useFakeTimers();
       const onReconcile = vi.fn();
-      renderHook(() =>
-        useDatasetProcessingProgress({ ...base, onReconcile }),
-      );
+      renderHook(() => useDatasetProcessingProgress({ ...base, onReconcile }));
       act(() => {
         vi.advanceTimersByTime(2 * DATASET_PROGRESS_STALE_RECONCILE_MS + 100);
       });

--- a/langwatch/src/components/datasets/processing/__tests__/useDatasetProcessingProgress.unit.test.ts
+++ b/langwatch/src/components/datasets/processing/__tests__/useDatasetProcessingProgress.unit.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DATASET_PROGRESS_STALE_RECONCILE_MS } from "~/server/datasets/dataset-progress";
+
+/**
+ * ADR-034: the reconciliation glue the pure view test can't reach — the SSE
+ * onData filter, the terminal/gap → getById reconcile, and the enabled gate.
+ * The tRPC subscription is mocked to capture its callbacks so the test can drive
+ * events and the gap timer directly.
+ */
+
+let capturedOnData: ((event: unknown) => void) | undefined;
+let capturedEnabled: boolean | undefined;
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    dataset: {
+      onDatasetProgress: {
+        useSubscription: (
+          _input: unknown,
+          opts: { enabled?: boolean; onData?: (event: unknown) => void },
+        ) => {
+          capturedOnData = opts.onData;
+          capturedEnabled = opts.enabled;
+        },
+      },
+    },
+  },
+}));
+
+// Imported after the mock is registered.
+const { useDatasetProcessingProgress } = await import(
+  "../useDatasetProcessingProgress"
+);
+
+const base = { projectId: "p1", datasetId: "d1", status: "processing" as const };
+
+beforeEach(() => {
+  capturedOnData = undefined;
+  capturedEnabled = undefined;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useDatasetProcessingProgress", () => {
+  describe("when a tick targets a different dataset", () => {
+    it("ignores it — no reconcile, no live update", () => {
+      const onReconcile = vi.fn();
+      const { result } = renderHook(() =>
+        useDatasetProcessingProgress({ ...base, onReconcile }),
+      );
+      act(() =>
+        capturedOnData?.({
+          datasetId: "other",
+          type: "progress",
+          bytesRead: 5,
+          totalBytes: 10,
+        }),
+      );
+      expect(onReconcile).not.toHaveBeenCalled();
+      expect(result.current).toEqual({
+        kind: "indeterminate",
+        phase: "processing",
+      });
+    });
+  });
+
+  describe("when a progress tick for this dataset arrives", () => {
+    it("becomes determinate from the input bytes", () => {
+      const { result } = renderHook(() =>
+        useDatasetProcessingProgress(base),
+      );
+      act(() =>
+        capturedOnData?.({
+          datasetId: "d1",
+          type: "progress",
+          phase: "processing",
+          bytesRead: 250,
+          totalBytes: 1000,
+          rows: 4,
+        }),
+      );
+      expect(result.current).toMatchObject({
+        kind: "determinate",
+        percent: 25,
+        rows: 4,
+      });
+    });
+  });
+
+  describe("when a terminal done event arrives", () => {
+    it("reconciles the durable status via getById", () => {
+      const onReconcile = vi.fn();
+      renderHook(() =>
+        useDatasetProcessingProgress({ ...base, onReconcile }),
+      );
+      act(() =>
+        capturedOnData?.({ datasetId: "d1", type: "done", phase: "ready" }),
+      );
+      expect(onReconcile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when no tick arrives for the stale window", () => {
+    it("reconciles via getById on the gap timer", () => {
+      vi.useFakeTimers();
+      const onReconcile = vi.fn();
+      renderHook(() =>
+        useDatasetProcessingProgress({ ...base, onReconcile }),
+      );
+      act(() => {
+        vi.advanceTimersByTime(2 * DATASET_PROGRESS_STALE_RECONCILE_MS + 100);
+      });
+      expect(onReconcile).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the dataset is already settled", () => {
+    it("does not subscribe", () => {
+      renderHook(() =>
+        useDatasetProcessingProgress({ ...base, status: "ready" }),
+      );
+      expect(capturedEnabled).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/components/datasets/processing/__tests__/useDatasetProgressMap.unit.test.ts
+++ b/langwatch/src/components/datasets/processing/__tests__/useDatasetProgressMap.unit.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * ADR-034: the bulk-drawer progress map. The tRPC subscription is mocked to
+ * capture its onData so the test can drive events directly. The load-bearing
+ * behaviour: a terminal event drops the cached tick so a retry of the same
+ * datasetId doesn't reuse a stale percent.
+ */
+
+let capturedOnData: ((event: unknown) => void) | undefined;
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    dataset: {
+      onDatasetProgress: {
+        useSubscription: (
+          _input: unknown,
+          opts: { enabled?: boolean; onData?: (event: unknown) => void },
+        ) => {
+          capturedOnData = opts.onData;
+        },
+      },
+    },
+  },
+}));
+
+const { useDatasetProgressMap } = await import("../useDatasetProgressMap");
+
+beforeEach(() => {
+  capturedOnData = undefined;
+});
+
+describe("useDatasetProgressMap", () => {
+  describe("when a progress tick arrives", () => {
+    it("records the latest tick under its datasetId", () => {
+      const { result } = renderHook(() =>
+        useDatasetProgressMap({ projectId: "p1", enabled: true }),
+      );
+      act(() =>
+        capturedOnData?.({
+          datasetId: "d1",
+          type: "progress",
+          bytesRead: 250,
+          totalBytes: 1000,
+          rows: 4,
+        }),
+      );
+      expect(result.current.d1).toMatchObject({ bytesRead: 250, rows: 4 });
+    });
+  });
+
+  describe("when a terminal event arrives for a cached dataset", () => {
+    it("drops the cached tick so a retry starts indeterminate", () => {
+      const { result } = renderHook(() =>
+        useDatasetProgressMap({ projectId: "p1", enabled: true }),
+      );
+      act(() =>
+        capturedOnData?.({
+          datasetId: "d1",
+          type: "progress",
+          bytesRead: 900,
+          totalBytes: 1000,
+        }),
+      );
+      expect(result.current.d1).toBeDefined();
+
+      act(() => capturedOnData?.({ datasetId: "d1", type: "done" }));
+      expect(result.current.d1).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/components/datasets/processing/datasetProgressView.ts
+++ b/langwatch/src/components/datasets/processing/datasetProgressView.ts
@@ -1,0 +1,107 @@
+/**
+ * ADR-034: the pure view-model for the dataset-processing bar — no React, no
+ * tRPC, so the load-bearing rule is directly testable: the durable `getById`
+ * status is the terminal authority and ALWAYS overrides whatever the last
+ * (ephemeral) SSE tick said. That is what makes the bar un-hangable
+ * (I-TERMINAL-REACHED): a stale `processing` 45% tick can never survive a
+ * `getById` that reads `ready`/`failed`.
+ */
+
+export type DatasetProgressPhase =
+  | "uploading"
+  | "processing"
+  | "finalizing"
+  | "ready"
+  | "failed";
+
+/** Latest ephemeral progress tick for one dataset (from the SSE stream). */
+export type DatasetProgressLive = {
+  bytesRead?: number;
+  totalBytes?: number;
+  rows?: number;
+  phase?: DatasetProgressPhase;
+};
+
+/** A (timestamp, input-bytes) sample used to estimate throughput → ETA. */
+export type EtaSample = { t: number; bytes: number };
+
+export type DatasetProgressView =
+  | { kind: "hidden" }
+  | { kind: "failed"; message?: string }
+  | { kind: "indeterminate"; phase: DatasetProgressPhase }
+  | {
+      kind: "determinate";
+      percent: number;
+      rows?: number;
+      etaSeconds?: number;
+      phase: DatasetProgressPhase;
+    };
+
+/** Coarse durable status as returned by `dataset.getById` (ADR-032). */
+export type DatasetStatusLike =
+  | "uploading"
+  | "processing"
+  | "ready"
+  | "failed"
+  | null
+  | undefined;
+
+const clampPercent = (value: number): number =>
+  Math.max(0, Math.min(100, Math.round(value)));
+
+/**
+ * Estimate seconds remaining from input-byte throughput over the sample window.
+ * Returns undefined until there are ≥2 samples and a positive rate — the ADR
+ * deliberately does not show an ETA before it can be meaningful.
+ */
+export const estimateEtaSeconds = (
+  samples: EtaSample[],
+  totalBytes: number | undefined,
+  currentBytes: number | undefined,
+): number | undefined => {
+  if (!totalBytes || currentBytes == null || samples.length < 2) return undefined;
+  const first = samples[0]!;
+  const last = samples[samples.length - 1]!;
+  const elapsedSec = (last.t - first.t) / 1000;
+  const bytesDelta = last.bytes - first.bytes;
+  if (elapsedSec <= 0 || bytesDelta <= 0) return undefined;
+  const rate = bytesDelta / elapsedSec; // bytes/sec
+  const remaining = Math.max(0, totalBytes - currentBytes);
+  return Math.ceil(remaining / rate);
+};
+
+/**
+ * Map the durable status + the latest ephemeral tick to what the bar shows.
+ *
+ * Terminal `getById` status wins over any `live`:
+ *  - failed  → failed (durable `statusError`), even if the last tick was 45%.
+ *  - ready / null (legacy) / undefined (loading) → hidden (the editor takes over).
+ *  - uploading / processing → determinate when a live tick with a total exists,
+ *    otherwise an honest indeterminate "Processing…" (refresh / no tick yet).
+ */
+export const deriveDatasetProgressView = (input: {
+  status: DatasetStatusLike;
+  statusError?: string | null;
+  live: DatasetProgressLive | null;
+  etaSeconds?: number;
+}): DatasetProgressView => {
+  const { status, statusError, live, etaSeconds } = input;
+
+  if (status === "failed") {
+    return { kind: "failed", message: statusError ?? undefined };
+  }
+  if (status === "uploading" || status === "processing") {
+    if (live && live.totalBytes && live.totalBytes > 0 && live.bytesRead != null) {
+      return {
+        kind: "determinate",
+        percent: clampPercent((live.bytesRead / live.totalBytes) * 100),
+        rows: live.rows,
+        etaSeconds,
+        phase: live.phase ?? "processing",
+      };
+    }
+    return { kind: "indeterminate", phase: live?.phase ?? status };
+  }
+  // ready, legacy-null, or not-yet-resolved → nothing to show.
+  return { kind: "hidden" };
+};

--- a/langwatch/src/components/datasets/processing/datasetProgressView.ts
+++ b/langwatch/src/components/datasets/processing/datasetProgressView.ts
@@ -59,7 +59,8 @@ export const estimateEtaSeconds = (
   totalBytes: number | undefined,
   currentBytes: number | undefined,
 ): number | undefined => {
-  if (!totalBytes || currentBytes == null || samples.length < 2) return undefined;
+  if (!totalBytes || currentBytes == null || samples.length < 2)
+    return undefined;
   const first = samples[0]!;
   const last = samples[samples.length - 1]!;
   const elapsedSec = (last.t - first.t) / 1000;
@@ -91,13 +92,21 @@ export const deriveDatasetProgressView = (input: {
     return { kind: "failed", message: statusError ?? undefined };
   }
   if (status === "uploading" || status === "processing") {
-    if (live && live.totalBytes && live.totalBytes > 0 && live.bytesRead != null) {
+    if (
+      live &&
+      live.totalBytes &&
+      live.totalBytes > 0 &&
+      live.bytesRead != null
+    ) {
       return {
         kind: "determinate",
         percent: clampPercent((live.bytesRead / live.totalBytes) * 100),
         rows: live.rows,
         etaSeconds,
-        phase: live.phase ?? "processing",
+        // Fall back to the durable status (uploading/processing), not a hardcoded
+        // "processing" — an uploading dataset that emits bytes before `phase` is
+        // set must not jump the stepper straight to Processing.
+        phase: live.phase ?? status,
       };
     }
     return { kind: "indeterminate", phase: live?.phase ?? status };

--- a/langwatch/src/components/datasets/processing/useDatasetProcessingProgress.ts
+++ b/langwatch/src/components/datasets/processing/useDatasetProcessingProgress.ts
@@ -9,7 +9,7 @@
  * even if every progress event is dropped (I-TERMINAL-REACHED). Returns a view
  * model, never JSX.
  */
-import { useEffect, useRef, useState } from "react";
+import { type MutableRefObject, useEffect, useRef, useState } from "react";
 import {
   DATASET_PROGRESS_STALE_RECONCILE_MS,
   type DatasetProgressEvent,
@@ -19,24 +19,43 @@ import {
   type DatasetProgressLive,
   type DatasetProgressView,
   type DatasetStatusLike,
-  type EtaSample,
   deriveDatasetProgressView,
+  type EtaSample,
   estimateEtaSeconds,
 } from "./datasetProgressView";
 
 const MAX_ETA_SAMPLES = 8;
 
-export function useDatasetProcessingProgress(params: {
+/** Reconcile via getById when no SSE tick arrives within the stale window
+ *  (a dropped terminal event or a dead worker). */
+function useStaleGapReconcile(
+  isActive: boolean,
+  lastEventAt: MutableRefObject<number>,
+  reconcile: MutableRefObject<(() => void) | undefined>,
+) {
+  useEffect(() => {
+    if (!isActive) return;
+    const id = setInterval(() => {
+      if (
+        Date.now() - lastEventAt.current >
+        DATASET_PROGRESS_STALE_RECONCILE_MS
+      ) {
+        reconcile.current?.();
+      }
+    }, DATASET_PROGRESS_STALE_RECONCILE_MS);
+    return () => clearInterval(id);
+  }, [isActive]);
+}
+
+/** The ephemeral side: SSE subscription → latest tick + ETA samples, plus the
+ *  terminal/gap reconcile nudge. Not exported — the public hook composes it. */
+function useLiveProgress(params: {
   projectId: string;
   datasetId: string;
-  status: DatasetStatusLike;
-  statusError?: string | null;
-  /** Refetch the durable `getById` — fired on a terminal SSE event and on a gap. */
+  isActive: boolean;
   onReconcile?: () => void;
-}): DatasetProgressView {
-  const { projectId, datasetId, status, statusError, onReconcile } = params;
-  const isActive = status === "processing" || status === "uploading";
-
+}): { live: DatasetProgressLive | null; etaSeconds?: number } {
+  const { projectId, datasetId, isActive, onReconcile } = params;
   const [live, setLive] = useState<DatasetProgressLive | null>(null);
   const samples = useRef<EtaSample[]>([]);
   const lastEventAt = useRef<number>(Date.now());
@@ -52,41 +71,28 @@ export function useDatasetProcessingProgress(params: {
         // for datasets this mount isn't watching.
         if (event.datasetId !== datasetId) return;
         lastEventAt.current = Date.now();
-        if (event.type === "progress") {
-          setLive({
-            bytesRead: event.bytesRead,
-            totalBytes: event.totalBytes,
-            rows: event.rows,
-            phase: event.phase,
-          });
-          if (event.bytesRead != null) {
-            samples.current = [
-              ...samples.current,
-              { t: Date.now(), bytes: event.bytesRead },
-            ].slice(-MAX_ETA_SAMPLES);
-          }
-        } else {
+        if (event.type !== "progress") {
           // done | error: pull the durable terminal status now.
           reconcileRef.current?.();
+          return;
+        }
+        setLive({
+          bytesRead: event.bytesRead,
+          totalBytes: event.totalBytes,
+          rows: event.rows,
+          phase: event.phase,
+        });
+        if (event.bytesRead != null) {
+          samples.current = [
+            ...samples.current,
+            { t: Date.now(), bytes: event.bytesRead },
+          ].slice(-MAX_ETA_SAMPLES);
         }
       },
     },
   );
 
-  // Gap safety: still `processing` but no tick for a while → reconcile via
-  // getById (catches a dropped terminal event or a dead worker).
-  useEffect(() => {
-    if (!isActive) return;
-    const id = setInterval(() => {
-      if (
-        Date.now() - lastEventAt.current >
-        DATASET_PROGRESS_STALE_RECONCILE_MS
-      ) {
-        reconcileRef.current?.();
-      }
-    }, DATASET_PROGRESS_STALE_RECONCILE_MS);
-    return () => clearInterval(id);
-  }, [isActive]);
+  useStaleGapReconcile(isActive, lastEventAt, reconcileRef);
 
   // Clear ephemeral state once the dataset settles so a later re-entry is clean.
   useEffect(() => {
@@ -101,6 +107,24 @@ export function useDatasetProcessingProgress(params: {
     live?.totalBytes,
     live?.bytesRead,
   );
+  return { live, etaSeconds };
+}
 
+export function useDatasetProcessingProgress(params: {
+  projectId: string;
+  datasetId: string;
+  status: DatasetStatusLike;
+  statusError?: string | null;
+  /** Refetch the durable `getById` — fired on a terminal SSE event and on a gap. */
+  onReconcile?: () => void;
+}): DatasetProgressView {
+  const { projectId, datasetId, status, statusError, onReconcile } = params;
+  const isActive = status === "processing" || status === "uploading";
+  const { live, etaSeconds } = useLiveProgress({
+    projectId,
+    datasetId,
+    isActive,
+    onReconcile,
+  });
   return deriveDatasetProgressView({ status, statusError, live, etaSeconds });
 }

--- a/langwatch/src/components/datasets/processing/useDatasetProcessingProgress.ts
+++ b/langwatch/src/components/datasets/processing/useDatasetProcessingProgress.ts
@@ -1,0 +1,106 @@
+/**
+ * ADR-034: live dataset-processing progress hook.
+ *
+ * Owns the ephemeral side — the per-project SSE subscription (filtered to this
+ * datasetId), the latest tick, and the ETA samples. The DURABLE terminal state
+ * is owned by the caller's `getById` (passed in as `status`/`statusError`); this
+ * hook only nudges it: it calls `onReconcile` on a terminal SSE event and on an
+ * SSE gap while still `processing`, so the bar always reaches a definite outcome
+ * even if every progress event is dropped (I-TERMINAL-REACHED). Returns a view
+ * model, never JSX.
+ */
+import { useEffect, useRef, useState } from "react";
+import {
+  DATASET_PROGRESS_STALE_RECONCILE_MS,
+  type DatasetProgressEvent,
+} from "~/server/datasets/dataset-progress";
+import { api } from "~/utils/api";
+import {
+  type DatasetProgressLive,
+  type DatasetProgressView,
+  type DatasetStatusLike,
+  type EtaSample,
+  deriveDatasetProgressView,
+  estimateEtaSeconds,
+} from "./datasetProgressView";
+
+const MAX_ETA_SAMPLES = 8;
+
+export function useDatasetProcessingProgress(params: {
+  projectId: string;
+  datasetId: string;
+  status: DatasetStatusLike;
+  statusError?: string | null;
+  /** Refetch the durable `getById` — fired on a terminal SSE event and on a gap. */
+  onReconcile?: () => void;
+}): DatasetProgressView {
+  const { projectId, datasetId, status, statusError, onReconcile } = params;
+  const isActive = status === "processing" || status === "uploading";
+
+  const [live, setLive] = useState<DatasetProgressLive | null>(null);
+  const samples = useRef<EtaSample[]>([]);
+  const lastEventAt = useRef<number>(Date.now());
+  const reconcileRef = useRef(onReconcile);
+  reconcileRef.current = onReconcile;
+
+  api.dataset.onDatasetProgress.useSubscription(
+    { projectId },
+    {
+      enabled: isActive && !!projectId,
+      onData: (event: DatasetProgressEvent) => {
+        // One project-wide subscription multiplexes every dataset; ignore ticks
+        // for datasets this mount isn't watching.
+        if (event.datasetId !== datasetId) return;
+        lastEventAt.current = Date.now();
+        if (event.type === "progress") {
+          setLive({
+            bytesRead: event.bytesRead,
+            totalBytes: event.totalBytes,
+            rows: event.rows,
+            phase: event.phase,
+          });
+          if (event.bytesRead != null) {
+            samples.current = [
+              ...samples.current,
+              { t: Date.now(), bytes: event.bytesRead },
+            ].slice(-MAX_ETA_SAMPLES);
+          }
+        } else {
+          // done | error: pull the durable terminal status now.
+          reconcileRef.current?.();
+        }
+      },
+    },
+  );
+
+  // Gap safety: still `processing` but no tick for a while → reconcile via
+  // getById (catches a dropped terminal event or a dead worker).
+  useEffect(() => {
+    if (!isActive) return;
+    const id = setInterval(() => {
+      if (
+        Date.now() - lastEventAt.current >
+        DATASET_PROGRESS_STALE_RECONCILE_MS
+      ) {
+        reconcileRef.current?.();
+      }
+    }, DATASET_PROGRESS_STALE_RECONCILE_MS);
+    return () => clearInterval(id);
+  }, [isActive]);
+
+  // Clear ephemeral state once the dataset settles so a later re-entry is clean.
+  useEffect(() => {
+    if (!isActive) {
+      setLive(null);
+      samples.current = [];
+    }
+  }, [isActive]);
+
+  const etaSeconds = estimateEtaSeconds(
+    samples.current,
+    live?.totalBytes,
+    live?.bytesRead,
+  );
+
+  return deriveDatasetProgressView({ status, statusError, live, etaSeconds });
+}

--- a/langwatch/src/components/datasets/processing/useDatasetProgressMap.ts
+++ b/langwatch/src/components/datasets/processing/useDatasetProgressMap.ts
@@ -1,0 +1,48 @@
+/**
+ * ADR-034: the bulk-drawer companion to {@link useDatasetProcessingProgress}.
+ *
+ * The bulk drawer can have many datasets preparing at once. Mounting the
+ * single-dataset hook per row would open N subscriptions against the per-tenant
+ * emitter and hit its 50-listener ceiling (the per-dataset trap the ADR rejects
+ * in Decision 3). Instead the drawer mounts THIS once: a single project-wide
+ * subscription accumulating the latest live tick per datasetId, which rows read
+ * presentationally. Terminal state stays each row's own `getById` poll (the
+ * durable authority), so a dropped progress event never strands a row.
+ */
+import { useState } from "react";
+import type { DatasetProgressEvent } from "~/server/datasets/dataset-progress";
+import { api } from "~/utils/api";
+import type { DatasetProgressLive } from "./datasetProgressView";
+
+export function useDatasetProgressMap({
+  projectId,
+  enabled,
+}: {
+  projectId: string;
+  enabled: boolean;
+}): Record<string, DatasetProgressLive> {
+  const [map, setMap] = useState<Record<string, DatasetProgressLive>>({});
+
+  api.dataset.onDatasetProgress.useSubscription(
+    { projectId },
+    {
+      enabled: enabled && !!projectId,
+      onData: (event: DatasetProgressEvent) => {
+        // Only live ticks update the map; terminal done/error is reconciled by
+        // each row's getById poll, so the last live tick can stay until then.
+        if (event.type !== "progress") return;
+        setMap((prev) => ({
+          ...prev,
+          [event.datasetId]: {
+            bytesRead: event.bytesRead,
+            totalBytes: event.totalBytes,
+            rows: event.rows,
+            phase: event.phase,
+          },
+        }));
+      },
+    },
+  );
+
+  return map;
+}

--- a/langwatch/src/components/datasets/processing/useDatasetProgressMap.ts
+++ b/langwatch/src/components/datasets/processing/useDatasetProgressMap.ts
@@ -28,9 +28,18 @@ export function useDatasetProgressMap({
     {
       enabled: enabled && !!projectId,
       onData: (event: DatasetProgressEvent) => {
-        // Only live ticks update the map; terminal done/error is reconciled by
-        // each row's getById poll, so the last live tick can stay until then.
-        if (event.type !== "progress") return;
+        // On terminal (done/error) drop the cached tick so a later retry of the
+        // same datasetId starts from an honest indeterminate state rather than
+        // reusing a stale percent until the first fresh tick arrives.
+        if (event.type !== "progress") {
+          setMap((prev) => {
+            if (!(event.datasetId in prev)) return prev;
+            const next = { ...prev };
+            delete next[event.datasetId];
+            return next;
+          });
+          return;
+        }
         setMap((prev) => ({
           ...prev,
           [event.datasetId]: {

--- a/langwatch/src/pages/[project]/datasets/[id].tsx
+++ b/langwatch/src/pages/[project]/datasets/[id].tsx
@@ -1,8 +1,9 @@
-import { Alert, Box, Button, HStack, Spinner, Text } from "@chakra-ui/react";
+import { Box, Button, Text } from "@chakra-ui/react";
 import { FlaskConical } from "lucide-react";
 import { useState } from "react";
 import { DashboardLayout } from "~/components/DashboardLayout";
 import { DatasetEditorTable } from "~/components/datasets/editor/DatasetEditorTable";
+import { DatasetProcessingProgress } from "~/components/datasets/processing/DatasetProcessingProgress";
 import { retryDatasetNormalize } from "~/components/datasets/services/directUpload";
 import { toaster } from "~/components/ui/toaster";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -77,38 +78,20 @@ export default function Dataset() {
   return (
     <DashboardLayout>
       <Box width="full" paddingX={6} paddingY={6}>
-        {(status === "uploading" || status === "processing") && (
-          <Alert.Root status="info" marginBottom={4}>
-            <Alert.Indicator>
-              <Spinner size="sm" />
-            </Alert.Indicator>
-            <Alert.Content>
-              <Alert.Title>
-                Preparing your dataset, this can take a few minutes
-              </Alert.Title>
-            </Alert.Content>
-          </Alert.Root>
-        )}
-        {status === "failed" && (
-          <Alert.Root status="error" marginBottom={4}>
-            <Alert.Indicator />
-            <Alert.Content>
-              <Alert.Title>We could not prepare your dataset</Alert.Title>
-              <Alert.Description>
-                {datasetQuery.data?.statusError ??
-                  "Something went wrong while processing your file. You can retry."}
-              </Alert.Description>
-            </Alert.Content>
-            <Button
-              size="sm"
-              colorPalette="red"
-              variant="outline"
-              loading={isRetrying}
-              onClick={() => void handleRetry()}
-            >
-              Retry
-            </Button>
-          </Alert.Root>
+        {(status === "uploading" ||
+          status === "processing" ||
+          status === "failed") && (
+          <Box marginBottom={4}>
+            <DatasetProcessingProgress
+              projectId={project?.id ?? ""}
+              datasetId={datasetId}
+              status={status}
+              statusError={datasetQuery.data?.statusError}
+              onReconcile={() => void datasetQuery.refetch()}
+              onRetry={() => void handleRetry()}
+              isRetrying={isRetrying}
+            />
+          </Box>
         )}
         {datasetGone && (
           <Text color="fg.muted">This dataset is no longer available.</Text>

--- a/langwatch/src/server/api/routers/dataset.ts
+++ b/langwatch/src/server/api/routers/dataset.ts
@@ -1,7 +1,10 @@
+import { on } from "node:events";
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import { getApp } from "~/server/app-layer/app";
 import { slugify } from "~/utils/slugify";
+import { datasetProgressEventSchema } from "../../datasets/dataset-progress";
 import { DatasetService } from "../../datasets/dataset.service";
 import { datasetErrorHandler } from "../../datasets/middleware";
 import {
@@ -131,6 +134,38 @@ export const datasetRouter = createTRPCRouter({
       });
 
       return dataset;
+    }),
+  /**
+   * ADR-034: subscribe to live dataset-processing progress for the project.
+   *
+   * One multiplexed subscription per project — it yields every `dataset_progress`
+   * event for the tenant and the client filters by the datasetId(s) it is
+   * watching (detail page = 1, bulk drawer = N) on a single emitter listener,
+   * sidestepping the 50-listener-per-tenant ceiling. Progress is ephemeral; the
+   * durable terminal state is reconciled by the client via `getById`
+   * (I-TERMINAL-REACHED), so this never needs replay and never breaks on a single
+   * dataset's terminal event — it lives until the client unsubscribes.
+   */
+  onDatasetProgress: protectedProcedure
+    .input(z.object({ projectId: z.string() }))
+    .use(checkProjectPermission("datasets:view"))
+    .subscription(async function* (opts) {
+      const { projectId } = opts.input;
+      const emitter = getApp().broadcast.getTenantEmitter(projectId);
+      for await (const eventArgs of on(emitter, "dataset_progress", {
+        // @ts-expect-error - signal is not typed on the Node EventEmitter overload
+        signal: opts.signal,
+      })) {
+        const raw = eventArgs[0] as { event: string; timestamp: number };
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(raw.event);
+        } catch {
+          continue;
+        }
+        const result = datasetProgressEventSchema.safeParse(parsed);
+        if (result.success) yield result.data;
+      }
     }),
   deleteById: protectedProcedure
     .input(

--- a/langwatch/src/server/api/routers/dataset.ts
+++ b/langwatch/src/server/api/routers/dataset.ts
@@ -4,8 +4,11 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import { getApp } from "~/server/app-layer/app";
 import { slugify } from "~/utils/slugify";
-import { datasetProgressEventSchema } from "../../datasets/dataset-progress";
 import { DatasetService } from "../../datasets/dataset.service";
+import {
+  DATASET_PROGRESS_EVENT,
+  datasetProgressEventSchema,
+} from "../../datasets/dataset-progress";
 import { datasetErrorHandler } from "../../datasets/middleware";
 import {
   datasetRecordFormSchema,
@@ -152,8 +155,9 @@ export const datasetRouter = createTRPCRouter({
     .subscription(async function* (opts) {
       const { projectId } = opts.input;
       const emitter = getApp().broadcast.getTenantEmitter(projectId);
-      for await (const eventArgs of on(emitter, "dataset_progress", {
-        // @ts-expect-error - signal is not typed on the Node EventEmitter overload
+      for await (const eventArgs of on(emitter, DATASET_PROGRESS_EVENT, {
+        // @ts-expect-error - tRPC's ResolveOptions doesn't expose `signal`, but
+        // the subscription runtime provides it for teardown (mirrors export.ts).
         signal: opts.signal,
       })) {
         const raw = eventArgs[0] as { event: string; timestamp: number };

--- a/langwatch/src/server/app-layer/broadcast/broadcast.service.ts
+++ b/langwatch/src/server/app-layer/broadcast/broadcast.service.ts
@@ -54,7 +54,7 @@ export class BroadcastService {
   private cleanupInterval: NodeJS.Timeout | null = null;
   private readonly EMITTER_CLEANUP_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
   private emitterEmptyTimes = new Map<string, number>(); // tenantId -> timestamp when emitter became empty
-  private active: boolean = false;
+  private active = false;
   private readonly senderRateLimiter = new TenantRateLimiter();
   private readonly subscriberRateLimiter = new TenantRateLimiter();
 
@@ -74,10 +74,16 @@ export class BroadcastService {
     const channels = ALL_EVENT_TYPES.map(redisChannel);
     this.subscriber.subscribe(...channels, (err, count) => {
       if (err) {
-        this.logger.error({ error: err }, "Failed to subscribe to SSE channels");
+        this.logger.error(
+          { error: err },
+          "Failed to subscribe to SSE channels",
+        );
         return;
       }
-      this.logger.debug({ subscriberCount: count, channels }, "Subscribed to SSE channels");
+      this.logger.debug(
+        { subscriberCount: count, channels },
+        "Subscribed to SSE channels",
+      );
     });
 
     this.subscriber.on("message", (channel, message) => {
@@ -296,7 +302,9 @@ export class BroadcastService {
     this.active = false;
 
     // Allow in-flight Redis publishes to drain
-    await new Promise((resolve) => setTimeout(resolve, BroadcastService.DRAIN_DELAY_MS));
+    await new Promise((resolve) =>
+      setTimeout(resolve, BroadcastService.DRAIN_DELAY_MS),
+    );
 
     if (!this.subscriber) return;
 

--- a/langwatch/src/server/app-layer/broadcast/broadcast.service.ts
+++ b/langwatch/src/server/app-layer/broadcast/broadcast.service.ts
@@ -9,6 +9,12 @@ export type BroadcastEventType =
   | "trace_updated"
   | "simulation_updated"
   | "export_progress"
+  // ADR-034: ephemeral live progress for an async dataset-normalize job
+  // (bytes / rows / phase). Registered here AND in ALL_EVENT_TYPES below so the
+  // Redis subscriber actually subscribes to its channel — otherwise progress is
+  // silently delivered only when the worker and the SSE subscriber share a pod
+  // (I-XPOD). Multiplexed per project; the client filters by datasetId.
+  | "dataset_progress"
   | "presence_updated"
   | "presence_cursor"
   // Fires when a tenant's facet `discover` payload finishes background
@@ -23,6 +29,7 @@ const ALL_EVENT_TYPES: BroadcastEventType[] = [
   "trace_updated",
   "simulation_updated",
   "export_progress",
+  "dataset_progress",
   "presence_updated",
   "presence_cursor",
   "discover_updated",

--- a/langwatch/src/server/datasets/__tests__/dataset-normalize.job.progress.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-normalize.job.progress.unit.test.ts
@@ -139,6 +139,34 @@ describe("dataset-normalize progress", () => {
         expect.objectContaining({ fromIndex: 0 }),
       );
     });
+
+    it("still commits ready when the emit rejects asynchronously", async () => {
+      const storage = makeStorage(Readable.from(['{"a":"1"}\n']));
+      const repo = {
+        findOne: vi.fn().mockResolvedValue({ id: "d1", status: "processing" }),
+        update: vi.fn().mockResolvedValue({}),
+      };
+      const handler = createDatasetNormalizeHandler({
+        repository: repo as any,
+        getStorage: async () => storage as any,
+        // An async emitter that rejects must be swallowed, not surface as an
+        // unhandled rejection or fail the normalize.
+        emitProgress: async () => {
+          throw new Error("broadcast down (async)");
+        },
+      });
+
+      await expect(handler(basePayload)).resolves.toBeUndefined();
+
+      const statuses = repo.update.mock.calls.map(
+        (c) => (c[0] as { data: { status: string } }).data.status,
+      );
+      expect(statuses).toContain("ready");
+      expect(statuses).not.toContain("failed");
+      expect(storage.deleteChunksFrom).not.toHaveBeenCalledWith(
+        expect.objectContaining({ fromIndex: 0 }),
+      );
+    });
   });
 
   describe("when the file is malformed", () => {

--- a/langwatch/src/server/datasets/__tests__/dataset-normalize.job.progress.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-normalize.job.progress.unit.test.ts
@@ -1,0 +1,125 @@
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toJsonlChunks } from "../dataset-chunking";
+import { createDatasetNormalizeHandler } from "../dataset-normalize.job";
+import type { DatasetProgressEvent } from "../dataset-progress";
+
+/**
+ * ADR-034: the producer contract for live progress. Unit-tests the normalize
+ * handler's emit seam at its boundary (a spy `emitProgress`), with the real
+ * streaming parse + chunk writer underneath.
+ *
+ * The load-bearing guarantees (the ones the red-team caught as ship-breakers):
+ *  - I-ORDER: the terminal event is emitted ONLY AFTER the durable status commit
+ *    — so a `done`-triggered `getById` refetch can never race back to processing.
+ *  - I-BYTES: the denominator is the input-side HEAD size, and the bar reaches
+ *    100% (bytesRead === totalBytes) exactly at done.
+ *  - a normalize failure commits `failed` THEN emits a terminal error.
+ */
+
+const STAGED_SIZE = 1024;
+
+const makeStorage = (stream: Readable) => ({
+  writeChunks: vi.fn(
+    async ({
+      records,
+      fromIndex = 0,
+    }: {
+      records: unknown[];
+      fromIndex?: number;
+    }) => toJsonlChunks(records).map((c) => ({ ...c, index: c.index + fromIndex })),
+  ),
+  deleteStaged: vi.fn().mockResolvedValue(undefined),
+  deleteChunksFrom: vi.fn().mockResolvedValue(undefined),
+  headStagedObjectSize: vi.fn().mockResolvedValue(STAGED_SIZE),
+  streamStaged: vi.fn().mockResolvedValue(stream),
+  readChunks: vi.fn(),
+  createPresignedUpload: vi.fn(),
+});
+
+const basePayload = {
+  id: "d1",
+  tenantId: "p1",
+  projectId: "p1",
+  datasetId: "d1",
+  stagingKey: "staging/p1/u1",
+  filename: "data.jsonl",
+};
+
+/**
+ * Drive the handler recording a single interleaved sequence of repository
+ * commits and progress emits, so ordering invariants are directly assertable.
+ */
+const run = async (stream: Readable) => {
+  const sequence: string[] = [];
+  const emitted: DatasetProgressEvent[] = [];
+  const repo = {
+    findOne: vi.fn().mockResolvedValue({ id: "d1", status: "processing" }),
+    update: vi.fn(async ({ data }: { data: { status: string } }) => {
+      sequence.push(`commit:${data.status}`);
+      return {};
+    }),
+  };
+  const emitProgress = vi.fn((_projectId: string, e: DatasetProgressEvent) => {
+    sequence.push(`emit:${e.type}`);
+    emitted.push(e);
+  });
+  const handler = createDatasetNormalizeHandler({
+    repository: repo as any,
+    getStorage: async () => makeStorage(stream) as any,
+    emitProgress,
+  });
+  const result = await handler(basePayload).then(
+    () => ({ ok: true as const }),
+    (error: unknown) => ({ ok: false as const, error }),
+  );
+  return { sequence, emitted, result };
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("dataset-normalize progress", () => {
+  describe("when a dataset normalizes successfully", () => {
+    it("emits live progress with the input-side total then a terminal done", async () => {
+      const { emitted } = await run(
+        Readable.from(['{"a":"1"}\n{"a":"2"}\n']),
+      );
+
+      const progress = emitted.find((e) => e.type === "progress");
+      expect(progress).toBeDefined();
+      expect(progress!.totalBytes).toBe(STAGED_SIZE);
+
+      const done = emitted.find((e) => e.type === "done");
+      expect(done).toMatchObject({
+        phase: "ready",
+        totalBytes: STAGED_SIZE,
+        bytesRead: STAGED_SIZE,
+        rows: 2,
+      });
+    });
+
+    it("emits the terminal done strictly after the durable ready commit (I-ORDER)", async () => {
+      const { sequence } = await run(Readable.from(['{"a":"1"}\n']));
+
+      const readyIdx = sequence.indexOf("commit:ready");
+      const doneIdx = sequence.indexOf("emit:done");
+      expect(readyIdx).toBeGreaterThanOrEqual(0);
+      expect(doneIdx).toBeGreaterThan(readyIdx);
+    });
+  });
+
+  describe("when the file is malformed", () => {
+    it("commits failed then emits a terminal error", async () => {
+      const { sequence, emitted, result } = await run(
+        Readable.from(["{not valid json\n"]),
+      );
+
+      expect(result.ok).toBe(false);
+      const failedIdx = sequence.indexOf("commit:failed");
+      const errorIdx = sequence.indexOf("emit:error");
+      expect(failedIdx).toBeGreaterThanOrEqual(0);
+      expect(errorIdx).toBeGreaterThan(failedIdx);
+      expect(emitted.at(-1)).toMatchObject({ type: "error", phase: "failed" });
+    });
+  });
+});

--- a/langwatch/src/server/datasets/__tests__/dataset-normalize.job.progress.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-normalize.job.progress.unit.test.ts
@@ -27,7 +27,8 @@ const makeStorage = (stream: Readable) => ({
     }: {
       records: unknown[];
       fromIndex?: number;
-    }) => toJsonlChunks(records).map((c) => ({ ...c, index: c.index + fromIndex })),
+    }) =>
+      toJsonlChunks(records).map((c) => ({ ...c, index: c.index + fromIndex })),
   ),
   deleteStaged: vi.fn().mockResolvedValue(undefined),
   deleteChunksFrom: vi.fn().mockResolvedValue(undefined),
@@ -81,9 +82,7 @@ beforeEach(() => vi.clearAllMocks());
 describe("dataset-normalize progress", () => {
   describe("when a dataset normalizes successfully", () => {
     it("emits live progress with the input-side total then a terminal done", async () => {
-      const { emitted } = await run(
-        Readable.from(['{"a":"1"}\n{"a":"2"}\n']),
-      );
+      const { emitted } = await run(Readable.from(['{"a":"1"}\n{"a":"2"}\n']));
 
       const progress = emitted.find((e) => e.type === "progress");
       expect(progress).toBeDefined();
@@ -105,6 +104,40 @@ describe("dataset-normalize progress", () => {
       const doneIdx = sequence.indexOf("emit:done");
       expect(readyIdx).toBeGreaterThanOrEqual(0);
       expect(doneIdx).toBeGreaterThan(readyIdx);
+    });
+  });
+
+  describe("when the progress emit throws", () => {
+    // Regression: the terminal `done` emit runs AFTER the ready commit, inside
+    // the try whose catch deletes every chunk (fromIndex 0). A throwing emit
+    // there must NOT flip ready→failed nor wipe the processed dataset.
+    it("still commits ready and never deletes the processed chunks", async () => {
+      const storage = makeStorage(Readable.from(['{"a":"1"}\n']));
+      const repo = {
+        findOne: vi.fn().mockResolvedValue({ id: "d1", status: "processing" }),
+        update: vi.fn().mockResolvedValue({}),
+      };
+      const handler = createDatasetNormalizeHandler({
+        repository: repo as any,
+        getStorage: async () => storage as any,
+        emitProgress: () => {
+          throw new Error("broadcast down");
+        },
+      });
+
+      await expect(handler(basePayload)).resolves.toBeUndefined();
+
+      const statuses = repo.update.mock.calls.map(
+        (c) => (c[0] as { data: { status: string } }).data.status,
+      );
+      expect(statuses).toContain("ready");
+      expect(statuses).not.toContain("failed");
+      // The catch's chunk reap is `fromIndex: 0` (wipe); the success path trims
+      // orphans at `fromIndex: chunkCount`. A throwing emit must never trigger
+      // the former.
+      expect(storage.deleteChunksFrom).not.toHaveBeenCalledWith(
+        expect.objectContaining({ fromIndex: 0 }),
+      );
     });
   });
 

--- a/langwatch/src/server/datasets/__tests__/dataset-progress.unit.test.ts
+++ b/langwatch/src/server/datasets/__tests__/dataset-progress.unit.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { BroadcastService } from "../../app-layer/broadcast/broadcast.service";
+import {
+  DATASET_PROGRESS_EVENT,
+  datasetProgressEventSchema,
+  makeEmitDatasetProgress,
+} from "../dataset-progress";
+
+/**
+ * ADR-034: the progress broadcast wire, end to end through a REAL
+ * `BroadcastService` (no Redis → local emit). Proves the three things a browser
+ * pass would otherwise have to: the event-type name matches what the emitter
+ * delivers, the payload round-trips through JSON, and `datasetProgressEventSchema`
+ * accepts it — for both the rate-limited progress path and the plain terminal
+ * path (Decision 5).
+ */
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+let broadcast: BroadcastService;
+
+afterEach(async () => {
+  await broadcast.close();
+});
+
+describe("dataset progress broadcast wire", () => {
+  const collect = (projectId: string) => {
+    const received: { event: string }[] = [];
+    broadcast
+      .getTenantEmitter(projectId)
+      .on(DATASET_PROGRESS_EVENT, (data: { event: string }) =>
+        received.push(data),
+      );
+    return received;
+  };
+
+  describe("when a progress tick is emitted", () => {
+    it("delivers a schema-valid event to the project's tenant emitter", async () => {
+      broadcast = new BroadcastService(null);
+      const received = collect("project_p1");
+      const emit = makeEmitDatasetProgress(broadcast);
+
+      emit("project_p1", {
+        datasetId: "d1",
+        type: "progress",
+        phase: "processing",
+        bytesRead: 512,
+        totalBytes: 1024,
+        rows: 7,
+      });
+      await flush();
+
+      expect(received).toHaveLength(1);
+      const parsed = datasetProgressEventSchema.parse(
+        JSON.parse(received[0]!.event),
+      );
+      expect(parsed).toMatchObject({
+        datasetId: "d1",
+        type: "progress",
+        bytesRead: 512,
+        totalBytes: 1024,
+        rows: 7,
+      });
+    });
+  });
+
+  describe("when a terminal event is emitted", () => {
+    it("delivers the done event (plain path) to the tenant emitter", async () => {
+      broadcast = new BroadcastService(null);
+      const received = collect("project_p1");
+      const emit = makeEmitDatasetProgress(broadcast);
+
+      emit("project_p1", { datasetId: "d1", type: "done", phase: "ready" });
+      await flush();
+
+      const parsed = datasetProgressEventSchema.parse(
+        JSON.parse(received.at(-1)!.event),
+      );
+      expect(parsed).toMatchObject({ datasetId: "d1", type: "done" });
+    });
+  });
+
+  describe("when a tick targets another project", () => {
+    it("is not delivered to this project's emitter (tenant isolation)", async () => {
+      broadcast = new BroadcastService(null);
+      const mine = collect("project_p1");
+      const emit = makeEmitDatasetProgress(broadcast);
+
+      emit("project_p2", { datasetId: "dX", type: "progress", bytesRead: 1 });
+      await flush();
+
+      expect(mine).toHaveLength(0);
+    });
+  });
+});

--- a/langwatch/src/server/datasets/dataset-chunk-writer.ts
+++ b/langwatch/src/server/datasets/dataset-chunk-writer.ts
@@ -57,6 +57,13 @@ export class StreamingChunkWriter {
       storage: DatasetStorage;
       projectId: string;
       datasetId: string;
+      /**
+       * ADR-034: fired once per chunk flush with the running cumulative row
+       * count. The natural ~16 MB throttle point for live progress — the
+       * normalize job reads input bytes separately and combines the two. Optional
+       * so the backfill producer and tests need not wire it.
+       */
+      onProgress?: (rowsWritten: number) => void;
     },
   ) {}
 
@@ -103,6 +110,8 @@ export class StreamingChunkWriter {
     this.nextIndex += written.length;
     this.buffer = [];
     this.bufferBytes = 0;
+    // ADR-034: report cumulative rows after each flush (throttled downstream).
+    this.deps.onProgress?.(this.nextStartRow);
   }
 
   /**

--- a/langwatch/src/server/datasets/dataset-normalize.job.ts
+++ b/langwatch/src/server/datasets/dataset-normalize.job.ts
@@ -33,6 +33,7 @@ import type { DatasetRepository } from "./dataset.repository";
 import { StreamingChunkWriter } from "./dataset-chunk-writer";
 import {
   DATASET_PROGRESS_BROADCAST_MIN_INTERVAL_MS,
+  type DatasetProgressEvent,
   type EmitDatasetProgress,
 } from "./dataset-progress";
 import type { DatasetStorage } from "./dataset-storage";
@@ -476,6 +477,19 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
 
     const storage = await deps.getStorage(projectId);
 
+    // ADR-034: progress is best-effort telemetry. This wrapper guarantees an
+    // emit can NEVER affect the job's outcome — critically, a throw from the
+    // terminal `done` emit runs AFTER the `ready` commit, and the catch below
+    // deletes every chunk (fromIndex 0); an unguarded throw there would destroy
+    // a fully-processed dataset. Swallow everything, sync and async.
+    const safeEmit = (event: DatasetProgressEvent): void => {
+      try {
+        deps.emitProgress?.(projectId, event);
+      } catch {
+        // never let a progress broadcast fail (or delete) a normalize
+      }
+    };
+
     try {
       // Defense-in-depth fast reject (I-MEM): finalize already capped this, but
       // never start streaming an over-cap object.
@@ -509,7 +523,7 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
           return;
         }
         lastEmitAt = now;
-        deps.emitProgress(projectId, {
+        safeEmit({
           datasetId,
           type: "progress",
           phase: "processing",
@@ -566,19 +580,17 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
       // ADR-034: the input stream is drained; the remaining flush + DB write are
       // the "finalizing" phase. Forced (bypasses the throttle) so the stepper
       // always shows it even on a fast job.
-      if (deps.emitProgress) {
-        deps.emitProgress(projectId, {
-          datasetId,
-          type: "progress",
-          phase: "finalizing",
-          bytesRead,
-          totalBytes,
-          rows: rowsWritten,
-        });
-        // Claim the throttle window so finalize()'s own flush doesn't emit a
-        // late `processing` tick after this — which would flick the stepper back.
-        lastEmitAt = Date.now();
-      }
+      safeEmit({
+        datasetId,
+        type: "progress",
+        phase: "finalizing",
+        bytesRead,
+        totalBytes,
+        rows: rowsWritten,
+      });
+      // Claim the throttle window so finalize()'s own flush doesn't emit a late
+      // `processing` tick after this — which would flick the stepper back.
+      lastEmitAt = Date.now();
       // I-MEM: finalize returns the aggregated meta built from per-chunk
       // metadata only — the chunk `jsonl` payloads were released at each flush,
       // so the whole normalized file is never accumulated in heap.
@@ -618,7 +630,7 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
       // `ready` commit above, via emitProgress's PLAIN (non-rate-limited) path
       // so the limiter can't strand the bar at 99%. Best-effort — `getById`
       // reconciliation is the actual guarantee (I-TERMINAL-REACHED).
-      deps.emitProgress?.(projectId, {
+      safeEmit({
         datasetId,
         type: "done",
         phase: "ready",
@@ -659,7 +671,7 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
       });
       // ADR-034: terminal `error` after the durable `failed` commit. The client
       // shows generic-failed; the durable `statusError` survives a refresh.
-      deps.emitProgress?.(projectId, {
+      safeEmit({
         datasetId,
         type: "error",
         phase: "failed",

--- a/langwatch/src/server/datasets/dataset-normalize.job.ts
+++ b/langwatch/src/server/datasets/dataset-normalize.job.ts
@@ -575,6 +575,9 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
           totalBytes,
           rows: rowsWritten,
         });
+        // Claim the throttle window so finalize()'s own flush doesn't emit a
+        // late `processing` tick after this — which would flick the stepper back.
+        lastEmitAt = Date.now();
       }
       // I-MEM: finalize returns the aggregated meta built from per-chunk
       // metadata only — the chunk `jsonl` payloads were released at each flush,

--- a/langwatch/src/server/datasets/dataset-normalize.job.ts
+++ b/langwatch/src/server/datasets/dataset-normalize.job.ts
@@ -27,10 +27,14 @@
  */
 
 import readline from "node:readline";
-import type { Readable } from "node:stream";
+import { type Readable, Transform } from "node:stream";
 import Papa from "papaparse";
 import type { DatasetRepository } from "./dataset.repository";
 import { StreamingChunkWriter } from "./dataset-chunk-writer";
+import {
+  DATASET_PROGRESS_BROADCAST_MIN_INTERVAL_MS,
+  type EmitDatasetProgress,
+} from "./dataset-progress";
 import type { DatasetStorage } from "./dataset-storage";
 import { UPLOAD_MAX_BYTES } from "./presigned-upload";
 import type { DatasetColumns, DatasetConfirmColumns } from "./types";
@@ -97,6 +101,13 @@ export type DatasetNormalizePayload = {
 export type DatasetNormalizeDeps = {
   repository: DatasetRepository;
   getStorage: (projectId: string) => Promise<DatasetStorage>;
+  /**
+   * ADR-034: optional emit seam for live progress. Wired to `BroadcastService`
+   * in `pipelineRegistry`; omitted by tests and anywhere progress isn't wanted.
+   * Progress is ephemeral and never persisted — the dataset's durable `status`
+   * is the terminal authority the client reconciles against.
+   */
+  emitProgress?: EmitDatasetProgress;
 };
 
 /**
@@ -477,11 +488,66 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
       }
 
       const format = detectFileFormat(filename);
-      const stream = await storage.streamStaged({ projectId, key: stagingKey });
+
+      // ADR-034: live progress scaffolding. `totalBytes` is the input-side HEAD
+      // size (denominator); `bytesRead` counts bytes consumed from the staged
+      // stream (numerator); `rowsWritten` is the running row count. All
+      // ephemeral — broadcast only, never persisted.
+      const totalBytes = sizeBytes;
+      let bytesRead = 0;
+      let rowsWritten = 0;
+      let lastEmitAt = 0;
+      const emitProcessing = (force = false): void => {
+        if (!deps.emitProgress) return;
+        const now = Date.now();
+        // Producer-side min-interval throttle (I-RATE) — the shared limiter is a
+        // token bucket, not an interval throttle, so the floor lives here.
+        if (
+          !force &&
+          now - lastEmitAt < DATASET_PROGRESS_BROADCAST_MIN_INTERVAL_MS
+        ) {
+          return;
+        }
+        lastEmitAt = now;
+        deps.emitProgress(projectId, {
+          datasetId,
+          type: "progress",
+          phase: "processing",
+          bytesRead,
+          totalBytes,
+          rows: rowsWritten,
+        });
+      };
+
+      const rawStream = await storage.streamStaged({
+        projectId,
+        key: stagingKey,
+      });
+      // Count INPUT bytes through a passthrough the parser reads from — keeps
+      // backpressure intact (the parser pulls, the counter forwards). `pipe`
+      // does not forward 'error', so forward it explicitly or a source read
+      // failure would hang the parser instead of failing the dataset.
+      const countingStream = new Transform({
+        transform(chunk: Buffer | string, _enc, cb) {
+          bytesRead +=
+            typeof chunk === "string"
+              ? Buffer.byteLength(chunk, "utf8")
+              : chunk.length;
+          cb(null, chunk);
+        },
+      });
+      rawStream.on("error", (err) => countingStream.destroy(err));
+      rawStream.pipe(countingStream);
+
       const writer = new StreamingChunkWriter({
         storage,
         projectId,
         datasetId,
+        // Throttled per-flush tick combining the latest input bytes + row count.
+        onProgress: (rows) => {
+          rowsWritten = rows;
+          emitProcessing();
+        },
       });
 
       // ADR-032 v19: the upload's confirm step persists the user-chosen columns
@@ -491,12 +557,25 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
       // all-`string` below, exactly as before.
       const confirmedColumns = (dataset.columnTypes as DatasetColumns) ?? [];
       const { headers, appliedColumnTypes } = await parseInto({
-        stream,
+        stream: countingStream,
         format,
         writer,
         sizeBytes,
         targetColumns: confirmedColumns.length > 0 ? confirmedColumns : null,
       });
+      // ADR-034: the input stream is drained; the remaining flush + DB write are
+      // the "finalizing" phase. Forced (bypasses the throttle) so the stepper
+      // always shows it even on a fast job.
+      if (deps.emitProgress) {
+        deps.emitProgress(projectId, {
+          datasetId,
+          type: "progress",
+          phase: "finalizing",
+          bytesRead,
+          totalBytes,
+          rows: rowsWritten,
+        });
+      }
       // I-MEM: finalize returns the aggregated meta built from per-chunk
       // metadata only — the chunk `jsonl` payloads were released at each flush,
       // so the whole normalized file is never accumulated in heap.
@@ -532,6 +611,19 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
         },
       });
 
+      // ADR-034 Decision 5 / I-ORDER: terminal `done` only AFTER the durable
+      // `ready` commit above, via emitProgress's PLAIN (non-rate-limited) path
+      // so the limiter can't strand the bar at 99%. Best-effort — `getById`
+      // reconciliation is the actual guarantee (I-TERMINAL-REACHED).
+      deps.emitProgress?.(projectId, {
+        datasetId,
+        type: "done",
+        phase: "ready",
+        bytesRead: totalBytes,
+        totalBytes,
+        rows: meta.rowCount,
+      });
+
       // Best-effort staging cleanup — non-fatal (the lifecycle rule reaps it
       // otherwise; a failed delete must not fail a successful normalize).
       try {
@@ -561,6 +653,14 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
         id: datasetId,
         projectId,
         data: { status: "failed", statusError },
+      });
+      // ADR-034: terminal `error` after the durable `failed` commit. The client
+      // shows generic-failed; the durable `statusError` survives a refresh.
+      deps.emitProgress?.(projectId, {
+        datasetId,
+        type: "error",
+        phase: "failed",
+        message: statusError,
       });
       throw error;
     }

--- a/langwatch/src/server/datasets/dataset-normalize.job.ts
+++ b/langwatch/src/server/datasets/dataset-normalize.job.ts
@@ -484,7 +484,18 @@ export const createDatasetNormalizeHandler = (deps: DatasetNormalizeDeps) => {
     // a fully-processed dataset. Swallow everything, sync and async.
     const safeEmit = (event: DatasetProgressEvent): void => {
       try {
-        deps.emitProgress?.(projectId, event);
+        const result = deps.emitProgress?.(
+          projectId,
+          event,
+        ) as void | PromiseLike<void>;
+        // An injected emitter may be async; swallow a rejected promise too so it
+        // never surfaces as an unhandled rejection.
+        if (
+          result &&
+          typeof (result as PromiseLike<void>).then === "function"
+        ) {
+          void Promise.resolve(result).catch(() => undefined);
+        }
       } catch {
         // never let a progress broadcast fail (or delete) a normalize
       }

--- a/langwatch/src/server/datasets/dataset-progress.ts
+++ b/langwatch/src/server/datasets/dataset-progress.ts
@@ -75,7 +75,11 @@ export const makeEmitDatasetProgress =
     const payload = JSON.stringify(event);
     if (event.type === "progress") {
       void broadcast
-        .broadcastToTenantRateLimited(projectId, payload, DATASET_PROGRESS_EVENT)
+        .broadcastToTenantRateLimited(
+          projectId,
+          payload,
+          DATASET_PROGRESS_EVENT,
+        )
         .catch(() => undefined);
     } else {
       void broadcast

--- a/langwatch/src/server/datasets/dataset-progress.ts
+++ b/langwatch/src/server/datasets/dataset-progress.ts
@@ -1,0 +1,85 @@
+/**
+ * ADR-034: live dataset-processing progress — the shared event shape + the two
+ * broadcast seams, kept out of both the normalize job (so it stays decoupled
+ * from `BroadcastService`/tRPC and unit-testable at its boundaries) and the
+ * tRPC router (so the router stays a thin relay).
+ *
+ * Progress is **ephemeral**: it is broadcast over the existing export SSE spine
+ * and never persisted. Durability of the *terminal* outcome is ADR-032's
+ * `Dataset.status`; the client reconciles it via `getById` (the bar can never
+ * hang — I-TERMINAL-REACHED). These helpers only carry the live ticks + a
+ * best-effort terminal nudge.
+ */
+import { z } from "zod";
+import type { BroadcastService } from "../app-layer/broadcast/broadcast.service";
+
+/** The tenant-emitter / Redis channel event name (see `BroadcastEventType`). */
+export const DATASET_PROGRESS_EVENT = "dataset_progress" as const;
+
+/**
+ * Producer-side minimum interval between throttled `progress` broadcasts
+ * (ADR-034 I-RATE). The shared rate limiter is a token bucket (200/s sustained),
+ * NOT a min-interval throttle, so a 2 GB file's ~128 chunk flushes would all
+ * sail through unsmoothed — the producer enforces the floor itself via a
+ * last-sent timestamp. Terminal events bypass this entirely.
+ */
+export const DATASET_PROGRESS_BROADCAST_MIN_INTERVAL_MS = 1000;
+
+/**
+ * Client-side gap (no SSE event while `processing`) after which the client
+ * re-fetches `getById` to reconcile the terminal state (ADR-034 Decision 4
+ * safety timer). Exported for the client hook; lives here so the two intervals
+ * sit together.
+ */
+export const DATASET_PROGRESS_STALE_RECONCILE_MS = 5000;
+
+export const datasetProgressEventSchema = z.object({
+  datasetId: z.string(),
+  type: z.enum(["progress", "done", "error"]),
+  phase: z
+    .enum(["uploading", "processing", "finalizing", "ready", "failed"])
+    .optional(),
+  /** Bytes read from the staged INPUT stream (numerator). */
+  bytesRead: z.number().optional(),
+  /** Staged-object HEAD size at job start (denominator) — NOT the output `sizeBytes`. */
+  totalBytes: z.number().optional(),
+  /** Unbounded live row count (no denominator). */
+  rows: z.number().optional(),
+  /** Generic failure message on `type: "error"`. */
+  message: z.string().optional(),
+});
+
+export type DatasetProgressEvent = z.infer<typeof datasetProgressEventSchema>;
+
+/**
+ * The emit seam the normalize job is handed (kept narrow so the job never sees
+ * `BroadcastService`). `progress` ticks may be dropped under load; the terminal
+ * event is the only one that matters for correctness, and even it is only a
+ * best-effort nudge — `getById` reconciliation is the guarantee.
+ */
+export type EmitDatasetProgress = (
+  projectId: string,
+  event: DatasetProgressEvent,
+) => void;
+
+/**
+ * Build the emit seam over a `BroadcastService`. `progress` goes through the
+ * rate-limited path (safe to drop — the next tick recovers); terminal
+ * `done`/`error` goes through the PLAIN path so the limiter can't strand the bar
+ * at 99% (ADR-034 Decision 5). Both are fire-and-forget — a publish failure must
+ * never fail a normalize.
+ */
+export const makeEmitDatasetProgress =
+  (broadcast: BroadcastService): EmitDatasetProgress =>
+  (projectId, event) => {
+    const payload = JSON.stringify(event);
+    if (event.type === "progress") {
+      void broadcast
+        .broadcastToTenantRateLimited(projectId, payload, DATASET_PROGRESS_EVENT)
+        .catch(() => undefined);
+    } else {
+      void broadcast
+        .broadcastToTenant(projectId, payload, DATASET_PROGRESS_EVENT)
+        .catch(() => undefined);
+    }
+  };

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -22,6 +22,7 @@ import {
   type DatasetNormalizePayload,
 } from "~/server/datasets/dataset-normalize.job";
 import { registerDatasetNormalizeEnqueue } from "~/server/datasets/dataset-normalize.queue";
+import { makeEmitDatasetProgress } from "~/server/datasets/dataset-progress";
 import { getDatasetStorage } from "~/server/datasets/dataset-storage";
 import { TraceService } from "~/server/traces/trace.service";
 import { createLogger } from "~/utils/logger/server";
@@ -552,6 +553,11 @@ export class PipelineRegistry {
     const datasetNormalizeHandler = createDatasetNormalizeHandler({
       repository: new DatasetRepository(this.deps.prisma),
       getStorage: getDatasetStorage,
+      // ADR-034: broadcast live progress over the export SSE spine. Resolved
+      // lazily so `getApp()` is read at job-execution time (app fully up), and
+      // works cross-pod via Redis pub/sub (I-XPOD).
+      emitProgress: (projectId, event) =>
+        makeEmitDatasetProgress(getApp().broadcast)(projectId, event),
     });
     const datasetNormalizeQueue =
       tracePipeline.service.registerJob<DatasetNormalizePayload>({

--- a/specs/datasets/dataset-processing-progress.feature
+++ b/specs/datasets/dataset-processing-progress.feature
@@ -8,6 +8,11 @@ Feature: Live dataset-processing progress
 
   # Behaviour derived from ADR-034 (dev/docs/adr/034-dataset-processing-progress.md).
   # Progress while running is real-time but ephemeral; the final outcome is durable.
+  #
+  # Scenarios are @unimplemented until a scenario test binds each one: the v1 PR
+  # covers the pieces at the unit level (producer ordering + denominator, the
+  # terminal-authority view logic, and the broadcast wire) but not these
+  # end-to-end flows. Drop @unimplemented on a scenario as its binding test lands.
 
   Background:
     Given I am logged in
@@ -17,7 +22,7 @@ Feature: Live dataset-processing progress
   # Live progress
   # ============================================================================
 
-  @integration
+  @integration @unimplemented
   Scenario: A large dataset shows live progress while it is prepared
     Given I have uploaded a large dataset that is being prepared
     When I watch its progress
@@ -26,7 +31,7 @@ Feature: Live dataset-processing progress
     And I see an estimate of the time remaining
     And the percent never exceeds 100 and only reaches 100 when preparation finishes
 
-  @integration
+  @integration @unimplemented
   Scenario: The progress stepper shows which phase preparation is in
     Given a dataset that is being prepared
     When I watch its progress
@@ -37,14 +42,14 @@ Feature: Live dataset-processing progress
   # The bar always reaches a definite outcome (I-TERMINAL-REACHED)
   # ============================================================================
 
-  @integration
+  @integration @unimplemented
   Scenario: A dataset that finished preparing before I opened it shows ready, not a stuck bar
     Given a dataset whose preparation already finished
     When I open it after preparation has finished
     Then it shows as ready
     And I never see a progress bar stuck partway
 
-  @integration
+  @integration @unimplemented
   Scenario: Preparation that fails is shown as failed with a way to retry
     Given a dataset whose preparation failed
     When I open it
@@ -56,14 +61,14 @@ Feature: Live dataset-processing progress
   # Resilience
   # ============================================================================
 
-  @integration
+  @integration @unimplemented
   Scenario: Refreshing mid-preparation shows progress again
     Given a dataset that is being prepared
     When I refresh the page while it is still preparing
     Then I see it is still preparing
     And the live percent reappears as preparation continues
 
-  @integration
+  @integration @unimplemented
   Scenario: Progress for one project's dataset is never shown to another project
     Given a dataset being prepared in my project
     When another project subscribes to progress
@@ -73,7 +78,7 @@ Feature: Live dataset-processing progress
   # Bulk
   # ============================================================================
 
-  @integration
+  @integration @unimplemented
   Scenario: Several datasets uploaded together each show their own live progress
     Given I have uploaded several large datasets together
     When I watch the upload drawer

--- a/specs/datasets/dataset-processing-progress.feature
+++ b/specs/datasets/dataset-processing-progress.feature
@@ -1,0 +1,81 @@
+Feature: Live dataset-processing progress
+
+  When a large dataset is uploaded it is prepared in the background, which for a
+  multi-GB file takes minutes. Instead of a silent "Processing", the user sees a
+  live bar — percent complete, bytes processed of the total, a running row count,
+  an estimated time remaining, and which phase the preparation is in — and it
+  always settles on a definite outcome, even if they look away and come back.
+
+  # Behaviour derived from ADR-034 (dev/docs/adr/034-dataset-processing-progress.md).
+  # Progress while running is real-time but ephemeral; the final outcome is durable.
+
+  Background:
+    Given I am logged in
+    And I have access to a project
+
+  # ============================================================================
+  # Live progress
+  # ============================================================================
+
+  @integration
+  Scenario: A large dataset shows live progress while it is prepared
+    Given I have uploaded a large dataset that is being prepared
+    When I watch its progress
+    Then I see the percent complete advancing
+    And I see how many rows have been processed so far
+    And I see an estimate of the time remaining
+    And the percent never exceeds 100 and only reaches 100 when preparation finishes
+
+  @integration
+  Scenario: The progress stepper shows which phase preparation is in
+    Given a dataset that is being prepared
+    When I watch its progress
+    Then I see it move through uploading, processing, and finalizing
+    And it settles on ready when preparation finishes
+
+  # ============================================================================
+  # The bar always reaches a definite outcome (I-TERMINAL-REACHED)
+  # ============================================================================
+
+  @integration
+  Scenario: A dataset that finished preparing before I opened it shows ready, not a stuck bar
+    Given a dataset whose preparation already finished
+    When I open it after preparation has finished
+    Then it shows as ready
+    And I never see a progress bar stuck partway
+
+  @integration
+  Scenario: Preparation that fails is shown as failed with a way to retry
+    Given a dataset whose preparation failed
+    When I open it
+    Then it shows as failed
+    And I am offered a way to retry preparation
+    And the failure is still shown after I refresh the page
+
+  # ============================================================================
+  # Resilience
+  # ============================================================================
+
+  @integration
+  Scenario: Refreshing mid-preparation shows progress again
+    Given a dataset that is being prepared
+    When I refresh the page while it is still preparing
+    Then I see it is still preparing
+    And the live percent reappears as preparation continues
+
+  @integration
+  Scenario: Progress for one project's dataset is never shown to another project
+    Given a dataset being prepared in my project
+    When another project subscribes to progress
+    Then it receives no progress for my dataset
+
+  # ============================================================================
+  # Bulk
+  # ============================================================================
+
+  @integration
+  Scenario: Several datasets uploaded together each show their own live progress
+    Given I have uploaded several large datasets together
+    When I watch the upload drawer
+    Then each one shows its own percent, row count, and phase
+    And one finishing does not disturb the others


### PR DESCRIPTION
## What

Replaces the silent multi-minute **"Processing"** a large dataset shows while it's prepared with a **live bar** — bytes percent, a running row count, a client-computed **ETA**, and a phase stepper (Uploading → Processing → Finalizing → Ready). Wired on the dataset **detail page** and in the **bulk upload drawer**.

## Why

A customer onboarding a multi-GB dataset waits minutes on a spinner with no feedback — it reads as hung. The upload itself is already robust (presigned S3, ADR-032); this makes the *preparation* legible.

## Design — see `dev/docs/adr/034-dataset-processing-progress.md`

Locked via an ADR (with a red-team pass folded in as v2). Load-bearing decisions:

- **Broadcast-only, never persisted.** The normalize job emits progress over the existing **export SSE spine** (`BroadcastService` → tRPC subscription) — **zero new schema, zero migration**. No per-flush DB writes on the heaviest path.
- **`getById` is the terminal authority.** The durable `Dataset.status` (ADR-032) reconciles the bar on subscription connect / `done` / SSE-gap, so the bar **can never hang** even if a progress event is dropped — and never overshoots (bytes measured input-side).
- **One subscription per project, client-filtered** by the watched `datasetId` set (detail = 1, drawer = N) — sidesteps the per-tenant 50-listener ceiling.
- The `runInline` no-worker large-file hazard is explicitly **out of scope** here (a separate ADR-032 amendment) rather than buried in this UX change.

### Red-team-caught fixes (folded before this PR)
- Terminal `done`/`error` goes through the **plain** broadcast path (not the dropping rate limiter) and only **after** the durable commit (I-ORDER) — otherwise the bar could strand at 99%.
- Denominator is the **input** HEAD size, not the output `sizeBytes` column (which doesn't exist mid-job) — otherwise the bar overshoots on an expanding CSV.
- `dataset_progress` registered in `ALL_EVENT_TYPES` or delivery is silently same-pod-only.

## Testing

- **Producer** (`dataset-normalize.job.progress`): terminal emitted strictly after the `ready` commit; input-side denominator; failure commits `failed` then emits terminal error.
- **View logic** (`datasetProgressView`): durable status overrides a stale tick (un-hangable); never exceeds 100%; ETA from byte-rate.
- **Broadcast wire** (`dataset-progress`): real `BroadcastService` round-trip, schema parse, both paths, tenant isolation.
- `pnpm typecheck` clean; existing normalize / chunk-writer / broadcast suites unbroken (70/70 across the touched suites).

## Not in this PR
- **Live browser pass** with a real multi-GB upload — needs a running dev stack + valid dev S3 creds; the SSE wire is proven deterministically by the integration test. Best run via `/prove-them-wrong` against this PR once the stack is up.
- Surfacing the failing line number on `failed` (deferred — generic message for v1).

## Spec
`specs/datasets/dataset-processing-progress.feature`


## Deployment Impact

None. No database migration, no new environment variables, no charts/services/infra changes.

- **Schema:** none — progress is broadcast-only and reuses the existing `Dataset` columns from ADR-032.
- **Runtime:** adds one Redis pub/sub event type (`dataset_progress`) on the existing `BroadcastService` channel set and one tRPC SSE subscription (`dataset.onDatasetProgress`). No new services or workers.
- **Self-hosted:** unaffected — progress is best-effort and degrades cleanly with or without Redis; the durable dataset status stays the source of truth.
- **Docs:** adds ADR-034 (which is why this check flagged the PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live dataset-processing progress (determinate percent clamped to 100%, rows, ETA, and phase stepper), with indeterminate mode when totals are unknown.
  * Bulk upload drawer now shows independent per-dataset progress during uploading/processing.
  * Dataset pages now use a unified processing/status panel with retry support for failures.
* **Bug Fixes**
  * Ensured terminal outcomes are authoritative (no stuck/incorrect completion), and progress reconciles safely after refresh or missed updates.
* **Tests**
  * Added unit/integration coverage for progress views, ETA, reconciliation, and multi-dataset isolation.
* **Documentation**
  * Added ADR-034 and an end-to-end feature spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Closes #6561
