### PR TITLE
feat(billing): storage meter dispatch reactor + metering flags (ADR-027 Phase 4)

### DIFF
--- a/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
@@ -12,12 +12,19 @@ vi.mock("../../../src/server/app-layer/app", () => ({
 
 import type { PrismaClient } from "@prisma/client";
 import type Stripe from "stripe";
-import { PlanTypes, SubscriptionStatus } from "../planTypes";
-import { EESubscriptionService, RECENT_INVOICES_LIMIT } from "../services/subscription.service";
-import { InvalidPlanError, OrganizationNotFoundError, SeatBillingUnavailableError } from "../errors";
-import type { SeatEventSubscriptionFns } from "../services/seatEventSubscription";
-import type { SubscriptionRepository } from "../../../src/server/app-layer/subscription/subscription.repository";
 import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
+import type { SubscriptionRepository } from "../../../src/server/app-layer/subscription/subscription.repository";
+import {
+  InvalidPlanError,
+  OrganizationNotFoundError,
+  SeatBillingUnavailableError,
+} from "../errors";
+import { PlanTypes, SubscriptionStatus } from "../planTypes";
+import type { SeatEventSubscriptionFns } from "../services/seatEventSubscription";
+import {
+  EESubscriptionService,
+  RECENT_INVOICES_LIMIT,
+} from "../services/subscription.service";
 
 const createMockStripe = () => ({
   subscriptions: {
@@ -136,7 +143,9 @@ describe("EESubscriptionService", () => {
   let db: ReturnType<typeof createMockDb>;
   let repository: ReturnType<typeof createMockRepository>;
   let itemCalculator: ReturnType<typeof createMockItemCalculator>;
-  let organizationRepository: ReturnType<typeof createMockOrganizationRepository>;
+  let organizationRepository: ReturnType<
+    typeof createMockOrganizationRepository
+  >;
   let service: EESubscriptionService;
 
   beforeEach(() => {
@@ -151,7 +160,8 @@ describe("EESubscriptionService", () => {
       repository: repository as unknown as SubscriptionRepository,
       stripe: stripe as unknown as Stripe,
       itemCalculator,
-      organizationRepository: organizationRepository as unknown as OrganizationRepository,
+      organizationRepository:
+        organizationRepository as unknown as OrganizationRepository,
     });
   });
 
@@ -297,6 +307,33 @@ describe("EESubscriptionService", () => {
           id: "sub_db_1",
           status: SubscriptionStatus.CANCELLED,
         });
+      });
+
+      it("invoices accrued metered usage on cancel instead of discarding it", async () => {
+        repository.findLastNonCancelled.mockResolvedValue({
+          id: "sub_db_1",
+          stripeSubscriptionId: "sub_stripe_1",
+          status: SubscriptionStatus.ACTIVE,
+        });
+        stripe.subscriptions.cancel.mockResolvedValue({ status: "canceled" });
+
+        await service.createOrUpdateSubscription({
+          organizationId: "org_123",
+          baseUrl: "https://app.test",
+          plan: PlanTypes.FREE,
+          customerId: "cus_123",
+        });
+
+        // ADR-027: without invoice_now, Stripe drops un-invoiced metered usage
+        // (billable events, and STORAGE_GB once attached) on immediate cancel.
+        expect(stripe.subscriptions.cancel).toHaveBeenCalledWith(
+          "sub_stripe_1",
+          expect.objectContaining({ invoice_now: true }),
+        );
+        // prorate stays off so unused licensed (seat) time is not credited.
+        expect(
+          stripe.subscriptions.cancel.mock.calls[0]![1],
+        ).not.toHaveProperty("prorate");
       });
     });
 
@@ -494,8 +531,7 @@ describe("EESubscriptionService", () => {
         const mockSub = { id: "sub_1", status: "ACTIVE" };
         repository.findLastNonCancelled.mockResolvedValue(mockSub);
 
-        const result =
-          await service.getLastNonCancelledSubscription("org_123");
+        const result = await service.getLastNonCancelledSubscription("org_123");
 
         expect(result).toEqual(mockSub);
         expect(repository.findLastNonCancelled).toHaveBeenCalledWith("org_123");

--- a/langwatch/ee/billing/services/subscription.service.ts
+++ b/langwatch/ee/billing/services/subscription.service.ts
@@ -1,32 +1,45 @@
-import { Currency, type OrganizationUserRole, type PrismaClient } from "@prisma/client";
-import type Stripe from "stripe";
-import type { DisplayInvoice, SubscriptionService } from "../../../src/server/app-layer/subscription/subscription.service";
-import type { SubscriptionRepository } from "../../../src/server/app-layer/subscription/subscription.repository";
-import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
-import { PrismaOrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.prisma.repository";
-import { traced } from "../../../src/server/app-layer/tracing";
-import { getApp } from "../../../src/server/app-layer/app";
 import {
-  type PlanTypes as PlanType,
-  PlanTypes,
-  SubscriptionStatus,
-} from "../planTypes";
-import type { StripePriceName } from "../stripe/stripePrices.types";
+  Currency,
+  type OrganizationUserRole,
+  type PrismaClient,
+} from "@prisma/client";
+import type Stripe from "stripe";
+import { getApp } from "../../../src/server/app-layer/app";
+import { PrismaOrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.prisma.repository";
+import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
+import type { SubscriptionRepository } from "../../../src/server/app-layer/subscription/subscription.repository";
 import type {
-  createItemsToAdd,
-  getItemsToUpdate,
-  prices,
-} from "./subscriptionItemCalculator";
-import { isStripePriceName, stripePricesFile } from "../stripe/stripePriceCatalog";
+  DisplayInvoice,
+  SubscriptionService,
+} from "../../../src/server/app-layer/subscription/subscription.service";
+import { traced } from "../../../src/server/app-layer/tracing";
 import {
   InvalidPlanError,
   OrganizationNotFoundError,
   SeatBillingUnavailableError,
   SubscriptionCreationFailedError,
 } from "../errors";
-import { isGrowthSeatEventPlan, type BillingInterval } from "../utils/growthSeatEvent";
+import {
+  type PlanTypes as PlanType,
+  PlanTypes,
+  SubscriptionStatus,
+} from "../planTypes";
+import {
+  isStripePriceName,
+  stripePricesFile,
+} from "../stripe/stripePriceCatalog";
+import type { StripePriceName } from "../stripe/stripePrices.types";
+import {
+  type BillingInterval,
+  isGrowthSeatEventPlan,
+} from "../utils/growthSeatEvent";
 import type { SeatEventSubscriptionFns } from "./seatEventSubscription";
 import { PrismaSubscriptionRepository } from "./subscription.repository";
+import type {
+  createItemsToAdd,
+  getItemsToUpdate,
+  prices,
+} from "./subscriptionItemCalculator";
 
 export const RECENT_INVOICES_LIMIT = 4;
 
@@ -140,8 +153,7 @@ export class EESubscriptionService implements SubscriptionService {
       await this.repository.findLastNonCancelled(organizationId);
 
     if (
-      lastSubscription &&
-      lastSubscription.stripeSubscriptionId &&
+      lastSubscription?.stripeSubscriptionId &&
       lastSubscription.status !== SubscriptionStatus.PENDING
     ) {
       const subscription = await this.stripe.subscriptions.retrieve(
@@ -206,8 +218,7 @@ export class EESubscriptionService implements SubscriptionService {
       await this.repository.findLastNonCancelled(organizationId);
 
     if (
-      lastSubscription &&
-      lastSubscription.stripeSubscriptionId &&
+      lastSubscription?.stripeSubscriptionId &&
       lastSubscription.status !== SubscriptionStatus.PENDING
     ) {
       if (plan === PlanTypes.FREE) {
@@ -284,7 +295,10 @@ export class EESubscriptionService implements SubscriptionService {
     if (!this.seatEventFns) {
       throw new SeatBillingUnavailableError();
     }
-    return this.seatEventFns.previewProration({ organizationId, newTotalSeats });
+    return this.seatEventFns.previewProration({
+      organizationId,
+      newTotalSeats,
+    });
   }
 
   async createSubscriptionWithInvites({
@@ -377,7 +391,8 @@ export class EESubscriptionService implements SubscriptionService {
   }: {
     organizationId: string;
   }): Promise<DisplayInvoice[]> {
-    const stripeCustomerId = await this.organizationRepository.getStripeCustomerId(organizationId);
+    const stripeCustomerId =
+      await this.organizationRepository.getStripeCustomerId(organizationId);
 
     if (!stripeCustomerId) {
       return [];
@@ -417,6 +432,15 @@ export class EESubscriptionService implements SubscriptionService {
   }): Promise<{ url: string | null }> {
     const response = await this.stripe.subscriptions.cancel(
       stripeSubscriptionId,
+      {
+        // Invoice accrued-but-un-billed metered usage before cancelling. Stripe
+        // discards un-invoiced metered usage on an immediate cancel, silently
+        // dropping revenue — the billable-events meter today and STORAGE_GB once
+        // its SubscriptionItem is attached (ADR-027). `invoice_now` generates the
+        // final invoice for that usage; we do NOT set `prorate` so unused
+        // licensed (seat) time is not credited — this only bills what was used.
+        invoice_now: true,
+      },
     );
 
     if (response.status === "canceled") {
@@ -444,9 +468,8 @@ export class EESubscriptionService implements SubscriptionService {
     membersToAdd: number;
     baseUrl: string;
   }): Promise<{ url: string | null }> {
-    const currentStripeSubscription = await this.stripe.subscriptions.retrieve(
-      stripeSubscriptionId,
-    );
+    const currentStripeSubscription =
+      await this.stripe.subscriptions.retrieve(stripeSubscriptionId);
 
     const itemsToUpdate = this.itemCalculator.getItemsToUpdate({
       currentItems: currentStripeSubscription.items.data,

--- a/langwatch/ee/billing/stripe/__tests__/storagePricing.unit.test.ts
+++ b/langwatch/ee/billing/stripe/__tests__/storagePricing.unit.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Price-pin guard for ADR-027 storage billing. These constants ARE the pricing
+ * contract; a silent edit here (or a divergent catalog `unit_amount_decimal`)
+ * would mis-bill every customer. The test pins the headline, the derived unit
+ * price, and the round-trip so a change forces an explicit, reviewed update.
+ *
+ * @see specs/data-retention/storage-billing-pricing.feature
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  STORAGE_EUR_PER_GIB_DAY,
+  STORAGE_EUR_PER_GIB_MONTH,
+  STORAGE_EUR_PER_MIB_HOUR,
+  STORAGE_METER_AGGREGATION,
+  STORAGE_METER_EVENT_NAME,
+  STORAGE_UNIT_AMOUNT_DECIMAL_CENTS_PER_MIB_HOUR,
+} from "../storagePricing";
+
+describe("ADR-027 storage pricing", () => {
+  describe("given the headline price", () => {
+    /** @scenario The headline storage price is €3 per logical GiB-month */
+    it("is €3 per GiB-month on the 30-day convention", () => {
+      expect(STORAGE_EUR_PER_GIB_MONTH).toBe(3);
+    });
+  });
+
+  describe("when the per-MiB-hour unit price is derived", () => {
+    /** @scenario The unit price derives from the headline by the documented formula */
+    it("equals headline / (30 days × 24 hours × 1024 MiB)", () => {
+      expect(STORAGE_EUR_PER_MIB_HOUR).toBe(3 / (30 * 24 * 1024));
+      // ≈ €0.00000407 per MiB-hour (the ADR headline).
+      expect(STORAGE_EUR_PER_MIB_HOUR).toBeCloseTo(0.00000407, 8);
+    });
+
+    /** @scenario The Stripe unit_amount_decimal is pinned in cents per MiB-hour */
+    it("pins unit_amount_decimal to cents per MiB-hour so the catalog can't drift", () => {
+      expect(STORAGE_UNIT_AMOUNT_DECIMAL_CENTS_PER_MIB_HOUR).toBe(
+        STORAGE_EUR_PER_MIB_HOUR * 100,
+      );
+      // ≈ 0.0004069 cents per MiB-hour.
+      expect(STORAGE_UNIT_AMOUNT_DECIMAL_CENTS_PER_MIB_HOUR).toBeCloseTo(
+        0.0004069,
+        7,
+      );
+    });
+  });
+
+  describe("when the headline is reconstructed from the unit price", () => {
+    /** @scenario The unit price round-trips to the €0.10 per GiB-day headline */
+    it("yields €0.10 per GiB-day", () => {
+      expect(STORAGE_EUR_PER_GIB_DAY).toBeCloseTo(0.1, 12);
+    });
+  });
+
+  describe("given the meter configuration", () => {
+    /** @scenario The meter is additive and named to match the report command */
+    it("sums the hourly event the command sends", () => {
+      expect(STORAGE_METER_AGGREGATION).toBe("sum");
+      expect(STORAGE_METER_EVENT_NAME).toBe(
+        "langwatch_storage_megabytes_hourly",
+      );
+    });
+  });
+});

--- a/langwatch/ee/billing/stripe/storagePricing.ts
+++ b/langwatch/ee/billing/stripe/storagePricing.ts
@@ -1,0 +1,57 @@
+/**
+ * ADR-027 storage billing — the price contract, as code.
+ *
+ * The `STORAGE_GB` Stripe meter sums additive hourly MiB values (MiB-hours) over
+ * the period; a single static `unit_amount_decimal` applied to that sum yields
+ * the bill. This module is the single source of truth for that unit price and
+ * the headline it derives from, so the (externally-created) Stripe Price's
+ * `unit_amount_decimal` can be pinned against it and never drift silently.
+ *
+ * Unit vocabulary is BINARY and deliberate (see the ADR): quantities are MiB
+ * (`bytes / 1_048_576`), prices per GiB (1024 MiB). The `STORAGE_GB` / `megabytes`
+ * labels are opaque — renaming Stripe meters later is painful, so the binary
+ * reality is documented, not renamed. We bill the LOGICAL (uncompressed
+ * `_size_bytes`) volume, not the compressed on-disk footprint — that is the
+ * priced unit and the contract.
+ */
+
+/** Headline price: €3 per logical GiB-month, 30-day-month convention. */
+export const STORAGE_EUR_PER_GIB_MONTH = 3;
+
+/** 30-day-month convention (AWS S3 / R2 style): 1 GiB held bills €3.10 in a
+ *  31-day month, €2.80 in February. */
+export const STORAGE_BILLING_DAYS_PER_MONTH = 30;
+export const STORAGE_HOURS_PER_DAY = 24;
+/** Binary GiB: 1 GiB = 1024 MiB. */
+export const MIB_PER_GIB = 1024;
+
+/**
+ * Price in EUR per MiB-hour = headline / (days × hours × MiB-per-GiB).
+ * ≈ €0.0000040690 per MiB-hour = €0.10 per GiB-day.
+ */
+export const STORAGE_EUR_PER_MIB_HOUR =
+  STORAGE_EUR_PER_GIB_MONTH /
+  (STORAGE_BILLING_DAYS_PER_MONTH * STORAGE_HOURS_PER_DAY * MIB_PER_GIB);
+
+/**
+ * Stripe `unit_amount_decimal` is the price in the currency's MINOR unit (cents
+ * for EUR), as a decimal string. This is the value the `STORAGE_GB` metered
+ * Price must carry; the pin test asserts it so a catalog edit can't drift it.
+ * ≈ 0.00040690 cents per MiB-hour.
+ */
+export const STORAGE_UNIT_AMOUNT_DECIMAL_CENTS_PER_MIB_HOUR =
+  STORAGE_EUR_PER_MIB_HOUR * 100;
+
+/** Headline derived back from the unit price, for documentation/checks. */
+export const STORAGE_EUR_PER_GIB_DAY =
+  STORAGE_EUR_PER_MIB_HOUR * STORAGE_HOURS_PER_DAY * MIB_PER_GIB;
+
+/**
+ * Stripe meter event name — MUST match what {@link ReportStorageForHourCommand}
+ * sends (Phase 3). The meter routes events by `event_name`, so a mismatch means
+ * silently-unbilled usage.
+ */
+export const STORAGE_METER_EVENT_NAME = "langwatch_storage_megabytes_hourly";
+
+/** Stripe meter default aggregation — additive sum of the hourly MiB values. */
+export const STORAGE_METER_AGGREGATION = "sum" as const;

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingBackfill.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingBackfill.service.unit.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @see specs/data-retention/storage-billing-backfill.feature
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/logger/server", () => {
+  const l = () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => l(),
+  });
+  return { createLogger: vi.fn(() => l()) };
+});
+
+import {
+  type BackfillCandidate,
+  StorageBillingBackfillService,
+} from "../storageBillingBackfill.service";
+
+const CANDIDATE: BackfillCandidate = {
+  organizationId: "org-1",
+  stripeSubscriptionId: "sub_1",
+  plan: "GROWTH",
+  currency: "EUR",
+  interval: "month",
+};
+
+function makeService(
+  overrides: Partial<{
+    candidates: BackfillCandidate[];
+    priceId: string | null;
+    existingPriceIds: string[];
+    attach: () => Promise<void>;
+  }> = {},
+) {
+  const attachStorageItem = vi.fn(overrides.attach ?? (async () => {}));
+  const getSubscriptionItemPriceIds = vi
+    .fn()
+    .mockResolvedValue(overrides.existingPriceIds ?? []);
+  const service = new StorageBillingBackfillService({
+    listPaidSubscriptions: vi
+      .fn()
+      .mockResolvedValue(overrides.candidates ?? [CANDIDATE]),
+    resolveStoragePriceId: vi
+      .fn()
+      .mockReturnValue(
+        overrides.priceId === undefined
+          ? "price_storage_eur_m"
+          : overrides.priceId,
+      ),
+    getSubscriptionItemPriceIds,
+    attachStorageItem,
+  });
+  return { service, attachStorageItem, getSubscriptionItemPriceIds };
+}
+
+describe("StorageBillingBackfillService", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("given a paid subscription without the storage item", () => {
+    /** @scenario The storage item is attached to a paid subscription that lacks it */
+    it("attaches the item and counts it", async () => {
+      const { service, attachStorageItem } = makeService({
+        existingPriceIds: [],
+      });
+
+      const result = await service.run({ dryRun: false });
+
+      expect(attachStorageItem).toHaveBeenCalledWith({
+        stripeSubscriptionId: "sub_1",
+        priceId: "price_storage_eur_m",
+      });
+      expect(result.attached).toBe(1);
+    });
+  });
+
+  describe("given a subscription that already has the storage item", () => {
+    /** @scenario A subscription that already has the item is skipped (idempotent) */
+    it("does not attach again", async () => {
+      const { service, attachStorageItem } = makeService({
+        existingPriceIds: ["price_storage_eur_m"],
+      });
+
+      const result = await service.run({ dryRun: false });
+
+      expect(attachStorageItem).not.toHaveBeenCalled();
+      expect(result.alreadyAttached).toBe(1);
+    });
+  });
+
+  describe("given no storage price for the plan/currency/interval", () => {
+    /** @scenario A subscription with no matching storage price is skipped, never guessed */
+    it("skips and counts it without attaching", async () => {
+      const { service, attachStorageItem } = makeService({ priceId: null });
+
+      const result = await service.run({ dryRun: false });
+
+      expect(attachStorageItem).not.toHaveBeenCalled();
+      expect(result.noPrice).toBe(1);
+    });
+  });
+
+  describe("when run as a dry-run", () => {
+    /** @scenario A dry-run reports what it would attach without mutating Stripe */
+    it("does not call Stripe but counts the attach", async () => {
+      const { service, attachStorageItem } = makeService({
+        existingPriceIds: [],
+      });
+
+      const result = await service.run({ dryRun: true });
+
+      expect(attachStorageItem).not.toHaveBeenCalled();
+      expect(result.attached).toBe(1);
+    });
+  });
+
+  describe("when attaching one subscription fails", () => {
+    /** @scenario One subscription's failure does not abort the whole backfill */
+    it("continues to the next and counts the failure", async () => {
+      const second: BackfillCandidate = {
+        ...CANDIDATE,
+        organizationId: "org-2",
+        stripeSubscriptionId: "sub_2",
+      };
+      const attach = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("stripe error"))
+        .mockResolvedValueOnce(undefined);
+      const { service } = makeService({
+        candidates: [CANDIDATE, second],
+        attach,
+      });
+
+      const result = await service.run({ dryRun: false });
+
+      expect(result.failed).toBe(1);
+      expect(result.attached).toBe(1);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingReconciliation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingReconciliation.service.unit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @see specs/data-retention/storage-billing-reconciliation.feature
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockError, createMockLogger } = vi.hoisted(() => {
+  const mockError = vi.fn();
+  const createMockLogger = () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: mockError,
+    child: vi.fn(() => createMockLogger()),
+  });
+  return { mockError, createMockLogger };
+});
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: vi.fn(() => createMockLogger()),
+}));
+
+import { StorageBillingReconciliationService } from "../storageBillingReconciliation.service";
+
+function makeService(
+  overrides: Partial<{
+    orgs: string[];
+    reported: number;
+    stripeTotal: number | null;
+    stripeByOrg: Record<string, number | null>;
+    reportedByOrg: Record<string, number>;
+  }> = {},
+) {
+  const service = new StorageBillingReconciliationService({
+    listReconcilableOrgs: vi
+      .fn()
+      .mockResolvedValue(overrides.orgs ?? ["org-1"]),
+    sumReportedMegabytes: vi.fn(async ({ organizationId }) =>
+      overrides.reportedByOrg
+        ? overrides.reportedByOrg[organizationId]!
+        : (overrides.reported ?? 1000),
+    ),
+    fetchStripeMeterTotal: vi.fn(async ({ organizationId }) =>
+      overrides.stripeByOrg
+        ? overrides.stripeByOrg[organizationId]!
+        : overrides.stripeTotal === undefined
+          ? 1000
+          : overrides.stripeTotal,
+    ),
+    toleranceRatio: 0.01,
+  });
+  return { service };
+}
+
+describe("StorageBillingReconciliationService", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("given recorded and Stripe totals match within tolerance", () => {
+    /** @scenario Matching totals report no drift */
+    it("logs no drift", async () => {
+      const { service } = makeService({ reported: 1000, stripeTotal: 1005 });
+
+      const result = await service.reconcile({ billingMonth: "2026-02" });
+
+      expect(result.drifted).toBe(0);
+      expect(result.checked).toBe(1);
+      expect(mockError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the totals diverge beyond tolerance", () => {
+    /** @scenario Divergent totals are flagged as drift */
+    it("logs a drift error", async () => {
+      const { service } = makeService({ reported: 1000, stripeTotal: 2000 });
+
+      const result = await service.reconcile({ billingMonth: "2026-02" });
+
+      expect(result.drifted).toBe(1);
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: "org-1",
+          billingMonth: "2026-02",
+        }),
+        expect.stringContaining("DRIFT"),
+      );
+    });
+  });
+
+  describe("given Stripe's total is unavailable", () => {
+    /** @scenario An unavailable Stripe total is skipped, never a false drift */
+    it("counts it as unavailable and does not flag drift", async () => {
+      const { service } = makeService({ reported: 1000, stripeTotal: null });
+
+      const result = await service.reconcile({ billingMonth: "2026-02" });
+
+      expect(result.unavailable).toBe(1);
+      expect(result.checked).toBe(0);
+      expect(mockError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given several organizations", () => {
+    /** @scenario Each organization is reconciled independently */
+    it("checks each and flags only the drifting one", async () => {
+      const { service } = makeService({
+        orgs: ["ok", "bad"],
+        reportedByOrg: { ok: 1000, bad: 1000 },
+        stripeByOrg: { ok: 1000, bad: 5000 },
+      });
+
+      const result = await service.reconcile({ billingMonth: "2026-02" });
+
+      expect(result.checked).toBe(2);
+      expect(result.drifted).toBe(1);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingTripwire.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingTripwire.unit.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The tripwire's whole value is its contract: flag-gated, capped, and — above
+ * all — it must NEVER throw into the measure/report path. These tests pin that.
+ *
+ * @see specs/data-retention/storage-billing-tripwire.feature
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockWarn, createMockLogger } = vi.hoisted(() => {
+  const mockWarn = vi.fn();
+  const createMockLogger = () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: mockWarn,
+    error: vi.fn(),
+    child: vi.fn(() => createMockLogger()),
+  });
+  return { mockWarn, createMockLogger };
+});
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: vi.fn(() => createMockLogger()),
+}));
+
+import { StorageBillingTripwire } from "../storageBillingTripwire";
+
+const SEALED = new Date("2026-02-15T11:00:00.000Z");
+
+function makeTripwire(
+  overrides: Partial<{
+    enabled: boolean;
+    reference: number | null;
+    computeReference: () => Promise<number | null>;
+    toleranceRatio: number;
+    maxLogs: number;
+    now: () => number;
+  }> = {},
+) {
+  return new StorageBillingTripwire({
+    isEnabled: vi.fn().mockResolvedValue(overrides.enabled ?? true),
+    computeReference:
+      overrides.computeReference ??
+      vi.fn().mockResolvedValue(overrides.reference ?? null),
+    toleranceRatio: overrides.toleranceRatio,
+    maxLogs: overrides.maxLogs,
+    now: overrides.now,
+  });
+}
+
+describe("StorageBillingTripwire", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("given the tripwire flag is off", () => {
+    /** @scenario A disabled tripwire does nothing */
+    it("computes no reference and logs nothing", async () => {
+      const computeReference = vi.fn();
+      const tw = makeTripwire({ enabled: false, computeReference });
+
+      await tw.check({
+        organizationId: "o",
+        sealedHour: SEALED,
+        measuredBytes: 100,
+      });
+
+      expect(computeReference).not.toHaveBeenCalled();
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given no reference is available", () => {
+    /** @scenario No reference means no comparison */
+    it("logs nothing when the reference is null", async () => {
+      const tw = makeTripwire({ reference: null });
+
+      await tw.check({
+        organizationId: "o",
+        sealedHour: SEALED,
+        measuredBytes: 100,
+      });
+
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the measurement is within tolerance of the reference", () => {
+    /** @scenario A measurement within tolerance is silent */
+    it("does not warn", async () => {
+      const tw = makeTripwire({ reference: 100, toleranceRatio: 0.5 });
+
+      await tw.check({
+        organizationId: "o",
+        sealedHour: SEALED,
+        measuredBytes: 120,
+      });
+
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the measurement diverges beyond tolerance", () => {
+    /** @scenario A divergent measurement is warned once */
+    it("warns", async () => {
+      const tw = makeTripwire({ reference: 100, toleranceRatio: 0.5 });
+
+      await tw.check({
+        organizationId: "o",
+        sealedHour: SEALED,
+        measuredBytes: 1000,
+      });
+
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+      expect(mockWarn).toHaveBeenCalledWith(
+        expect.objectContaining({ organizationId: "o", reference: 100 }),
+        expect.stringContaining("TRIPWIRE"),
+      );
+    });
+
+    /** @scenario Divergence logging is capped so a broken reference can't flood logs */
+    it("stops logging after the cap", async () => {
+      const tw = makeTripwire({
+        reference: 100,
+        toleranceRatio: 0.5,
+        maxLogs: 2,
+      });
+
+      for (let i = 0; i < 5; i++) {
+        await tw.check({
+          organizationId: "o",
+          sealedHour: SEALED,
+          measuredBytes: 1000,
+        });
+      }
+
+      expect(mockWarn).toHaveBeenCalledTimes(2);
+    });
+
+    /** @scenario The log cap resets each window so later divergence isn't silenced forever */
+    it("logs again after the window elapses", async () => {
+      let clock = 1_000_000;
+      const tw = makeTripwire({
+        reference: 100,
+        toleranceRatio: 0.5,
+        maxLogs: 1,
+        now: () => clock,
+      });
+      const check = () =>
+        tw.check({
+          organizationId: "o",
+          sealedHour: SEALED,
+          measuredBytes: 1000,
+        });
+
+      await check(); // window 1: logs
+      await check(); // window 1: capped
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+
+      clock += 60 * 60 * 1000 + 1; // advance past the window
+      await check(); // window 2: logs again
+      expect(mockWarn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("when the reference computation throws", () => {
+    /** @scenario The tripwire never throws into the measure path */
+    it("swallows the error and resolves", async () => {
+      const tw = makeTripwire({
+        computeReference: vi.fn().mockRejectedValue(new Error("ch down")),
+      });
+
+      await expect(
+        tw.check({
+          organizationId: "o",
+          sealedHour: SEALED,
+          measuredBytes: 100,
+        }),
+      ).resolves.toBeUndefined();
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
@@ -48,6 +48,10 @@ function makeService(
       organizationId: string;
       sealedHour: Date;
     }) => Promise<number>;
+    runExclusivePerOrg: (
+      organizationId: string,
+      fn: () => Promise<void>,
+    ) => Promise<void>;
   }> = {},
 ) {
   const isMeteringEnabled = vi
@@ -80,6 +84,7 @@ function makeService(
       markReported: vi.fn(),
     },
     enqueueReport,
+    runExclusivePerOrg: overrides.runExclusivePerOrg,
     now: () => NOW,
   });
 
@@ -138,6 +143,25 @@ describe("StorageMeterDispatchService", () => {
     it("measures no new hour and enqueues nothing", async () => {
       const { service, measureBytesAt, enqueueReport } = makeService({
         lastMeasured: SEAL_BOUNDARY,
+      });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      expect(measureBytesAt).not.toHaveBeenCalled();
+      expect(enqueueReport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the per-org guard is already held", () => {
+    /** @scenario Concurrent dispatches for the same organization are collapsed to one */
+    it("skips measurement when the guard does not run the work", async () => {
+      // A guard that never invokes fn simulates another project's dispatch
+      // already holding the org lock.
+      const { service, measureBytesAt, enqueueReport } = makeService({
+        lastMeasured: hour("2026-02-15T08:00:00.000Z"), // has a real gap
+        runExclusivePerOrg: async () => {
+          /* lock held elsewhere → do not run */
+        },
       });
 
       await service.dispatchForOrg({ organizationId: "org-1" });

--- a/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
@@ -24,6 +24,7 @@ vi.mock("~/utils/logger/server", () => ({
 
 import {
   STORAGE_BACKFILL_MAX_HOURS,
+  STORAGE_MAX_HOURS_PER_RUN,
   StorageMeterDispatchService,
 } from "../storageMeterDispatch.service";
 
@@ -232,8 +233,9 @@ describe("StorageMeterDispatchService", () => {
 
       await service.dispatchForOrg({ organizationId: "org-1" });
 
-      expect(measureBytesAt).toHaveBeenCalledTimes(STORAGE_BACKFILL_MAX_HOURS);
-      // The earliest measured hour is exactly the ceiling back from the boundary.
+      // Truncated start is the ceiling back from the boundary; but only the
+      // per-run cap is measured this run (the rest drains on later events).
+      expect(measureBytesAt).toHaveBeenCalledTimes(STORAGE_MAX_HOURS_PER_RUN);
       expect(measureBytesAt.mock.calls[0]![0].sealedHour.toISOString()).toBe(
         new Date(
           SEAL_BOUNDARY.getTime() -
@@ -244,6 +246,22 @@ describe("StorageMeterDispatchService", () => {
         expect.objectContaining({ organizationId: "org-1" }),
         expect.stringContaining("ALARM"),
       );
+    });
+  });
+
+  describe("given a gap larger than one run's cap but within the ceiling", () => {
+    /** @scenario A large catch-up measures at most the per-run cap and defers the rest */
+    it("measures the per-run cap this run without an alarm", async () => {
+      const behind = new Date(
+        SEAL_BOUNDARY.getTime() -
+          (STORAGE_MAX_HOURS_PER_RUN + 50) * MS_PER_HOUR,
+      );
+      const { service, measureBytesAt } = makeService({ lastMeasured: behind });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      expect(measureBytesAt).toHaveBeenCalledTimes(STORAGE_MAX_HOURS_PER_RUN);
+      expect(mockLoggerError).not.toHaveBeenCalled();
     });
   });
 

--- a/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Unit tests for the storage meter dispatch brain (ADR-027 Phase 4).
+ *
+ * @see specs/data-retention/storage-billing-dispatch.feature
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLoggerError, createMockLogger } = vi.hoisted(() => {
+  const mockLoggerError = vi.fn();
+  const createMockLogger = () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: mockLoggerError,
+    child: vi.fn(() => createMockLogger()),
+  });
+  return { mockLoggerError, createMockLogger };
+});
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: vi.fn(() => createMockLogger()),
+}));
+
+import {
+  STORAGE_BACKFILL_MAX_HOURS,
+  StorageMeterDispatchService,
+} from "../storageMeterDispatch.service";
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+// now = 12:30 → last COMPLETE wall-clock hour (sealed boundary) is 11:00.
+const NOW = new Date("2026-02-15T12:30:00.000Z");
+const SEAL_BOUNDARY = new Date("2026-02-15T11:00:00.000Z");
+
+function hour(iso: string): Date {
+  return new Date(iso);
+}
+
+function makeService(
+  overrides: Partial<{
+    enabled: boolean;
+    org: {
+      stripeCustomerId: string | null;
+      subscriptions: { id: string }[];
+    } | null;
+    lastMeasured: Date | null;
+    measure: (params: {
+      organizationId: string;
+      sealedHour: Date;
+    }) => Promise<number>;
+  }> = {},
+) {
+  const isMeteringEnabled = vi
+    .fn()
+    .mockResolvedValue(overrides.enabled ?? true);
+  const getBillableOrg = vi
+    .fn()
+    .mockResolvedValue(
+      overrides.org === undefined
+        ? { stripeCustomerId: "cus_1", subscriptions: [{ id: "sub-1" }] }
+        : overrides.org,
+    );
+  const measureBytesAt = vi.fn(
+    overrides.measure ?? (async () => 1_048_576), // 1 MiB
+  );
+  const getLastMeasuredHour = vi
+    .fn()
+    .mockResolvedValue(overrides.lastMeasured ?? null);
+  const recordHour = vi.fn().mockResolvedValue(undefined);
+  const enqueueReport = vi.fn().mockResolvedValue(undefined);
+
+  const service = new StorageMeterDispatchService({
+    isMeteringEnabled,
+    getBillableOrg,
+    measureBytesAt,
+    storageUsageHourly: {
+      getLastMeasuredHour,
+      recordHour,
+      findHour: vi.fn(),
+      markReported: vi.fn(),
+    },
+    enqueueReport,
+    now: () => NOW,
+  });
+
+  return {
+    service,
+    isMeteringEnabled,
+    getBillableOrg,
+    measureBytesAt,
+    getLastMeasuredHour,
+    recordHour,
+    enqueueReport,
+  };
+}
+
+describe("StorageMeterDispatchService", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("given the metering flag is off", () => {
+    /** @scenario Metering disabled makes the dispatcher fully inert */
+    it("measures nothing, writes nothing, enqueues nothing", async () => {
+      const {
+        service,
+        measureBytesAt,
+        recordHour,
+        enqueueReport,
+        getBillableOrg,
+      } = makeService({ enabled: false });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      expect(getBillableOrg).not.toHaveBeenCalled();
+      expect(measureBytesAt).not.toHaveBeenCalled();
+      expect(recordHour).not.toHaveBeenCalled();
+      expect(enqueueReport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a non-billable organization", () => {
+    /** @scenario A non-billable organization is skipped before any measurement */
+    it("never queries the measurement when there is no Stripe customer", async () => {
+      const { service, measureBytesAt, recordHour, enqueueReport } =
+        makeService({
+          org: { stripeCustomerId: null, subscriptions: [{ id: "sub-1" }] },
+        });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      expect(measureBytesAt).not.toHaveBeenCalled();
+      expect(recordHour).not.toHaveBeenCalled();
+      expect(enqueueReport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the organization is already caught up", () => {
+    /** @scenario A caught-up organization does no work */
+    it("measures no new hour and enqueues nothing", async () => {
+      const { service, measureBytesAt, enqueueReport } = makeService({
+        lastMeasured: SEAL_BOUNDARY,
+      });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      expect(measureBytesAt).not.toHaveBeenCalled();
+      expect(enqueueReport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the cursor trails the latest sealed hour", () => {
+    /** @scenario Every sealed hour since the cursor is measured and enqueued once */
+    it("measures each missing hour in order and enqueues one report per hour", async () => {
+      // cursor at 08:00 → measure 09:00, 10:00, 11:00.
+      const { service, measureBytesAt, recordHour, enqueueReport } =
+        makeService({
+          lastMeasured: hour("2026-02-15T08:00:00.000Z"),
+        });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      const measuredHours = measureBytesAt.mock.calls.map(([p]) =>
+        p.sealedHour.toISOString(),
+      );
+      expect(measuredHours).toEqual([
+        "2026-02-15T09:00:00.000Z",
+        "2026-02-15T10:00:00.000Z",
+        "2026-02-15T11:00:00.000Z",
+      ]);
+      expect(recordHour).toHaveBeenCalledTimes(3);
+      expect(enqueueReport).toHaveBeenCalledTimes(3);
+      expect(enqueueReport).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          organizationId: "org-1",
+          sealedHour: "2026-02-15T11:00:00.000Z",
+          tenantId: "org-1",
+        }),
+      );
+    });
+  });
+
+  describe("given a brand-new organization", () => {
+    /** @scenario A brand-new organization starts at the latest sealed hour, not its whole history */
+    it("measures only the most recent sealed hour", async () => {
+      const { service, measureBytesAt, recordHour, enqueueReport } =
+        makeService({
+          lastMeasured: null,
+        });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      expect(measureBytesAt).toHaveBeenCalledTimes(1);
+      expect(measureBytesAt.mock.calls[0]![0].sealedHour.toISOString()).toBe(
+        "2026-02-15T11:00:00.000Z",
+      );
+      expect(recordHour).toHaveBeenCalledTimes(1);
+      expect(enqueueReport).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given a gap beyond the backfill ceiling", () => {
+    /** @scenario A gap beyond the billing ceiling is truncated with an alarm */
+    it("measures only up to the ceiling and logs an alarm", async () => {
+      // cursor 1000h behind → must truncate to the last 840 hours.
+      const farBehind = new Date(SEAL_BOUNDARY.getTime() - 1000 * MS_PER_HOUR);
+      const { service, measureBytesAt } = makeService({
+        lastMeasured: farBehind,
+      });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      expect(measureBytesAt).toHaveBeenCalledTimes(STORAGE_BACKFILL_MAX_HOURS);
+      // The earliest measured hour is exactly the ceiling back from the boundary.
+      expect(measureBytesAt.mock.calls[0]![0].sealedHour.toISOString()).toBe(
+        new Date(
+          SEAL_BOUNDARY.getTime() -
+            (STORAGE_BACKFILL_MAX_HOURS - 1) * MS_PER_HOUR,
+        ).toISOString(),
+      );
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        expect.objectContaining({ organizationId: "org-1" }),
+        expect.stringContaining("ALARM"),
+      );
+    });
+  });
+
+  describe("when recording a measured hour", () => {
+    /** @scenario Each measured hour is rounded up to whole megabytes */
+    it("rounds bytes up to the next whole megabyte", async () => {
+      const { service, recordHour } = makeService({
+        lastMeasured: null,
+        measure: async () => 1_048_577, // 1 MiB + 1 byte
+      });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      expect(recordHour).toHaveBeenCalledWith(
+        expect.objectContaining({ megabytes: 2 }),
+      );
+    });
+
+    /** @scenario Recording an hour does not clobber one that already exists */
+    it("uses the insert-if-absent record path, never an update", async () => {
+      const { service, recordHour } = makeService({ lastMeasured: null });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      // recordHour is the documented ON CONFLICT DO NOTHING path; the service
+      // never calls markReported/update during measurement.
+      expect(recordHour).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when a measurement fails mid-gap", () => {
+    /** @scenario A measurement failure stops the run without skipping the hour */
+    it("stops at the failure and does not measure later hours", async () => {
+      // cursor 08:00 → 09:00 ok, 10:00 throws, 11:00 must NOT be measured.
+      const measure = vi
+        .fn()
+        .mockResolvedValueOnce(1_048_576)
+        .mockRejectedValueOnce(new Error("clickhouse failed"));
+      const { service, measureBytesAt, recordHour, enqueueReport } =
+        makeService({
+          lastMeasured: hour("2026-02-15T08:00:00.000Z"),
+          measure,
+        });
+
+      await expect(
+        service.dispatchForOrg({ organizationId: "org-1" }),
+      ).rejects.toThrow("clickhouse failed");
+
+      expect(measureBytesAt).toHaveBeenCalledTimes(2); // 09:00, 10:00 (failed)
+      expect(recordHour).toHaveBeenCalledTimes(1); // only 09:00
+      expect(enqueueReport).toHaveBeenCalledTimes(1); // only 09:00
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
@@ -323,7 +323,7 @@ describe("StorageMeterDispatchService", () => {
   });
 
   describe("given a measured hour whose enqueue never landed", () => {
-    /** @scenario An orphaned unreported hour is re-enqueued, not skipped forever */
+    // Regression tests for a review finding, not new feature scenarios.
     it("re-enqueues a stale unreported hour on the next dispatch", async () => {
       // Simulates: an earlier run's recordHour committed but enqueueReport
       // threw, leaving the hour with reportedAt: null past the grace window.
@@ -356,7 +356,6 @@ describe("StorageMeterDispatchService", () => {
       expect(measureBytesAt).not.toHaveBeenCalled();
     });
 
-    /** @scenario A failed retry is logged and does not abort the run */
     it("does not abort the dispatch when re-enqueuing an orphan fails", async () => {
       const orphanHour = hour("2026-02-15T10:00:00.000Z");
       const { service, measureBytesAt, enqueueReport } = makeService({

--- a/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
@@ -53,6 +53,7 @@ function makeService(
       organizationId: string,
       fn: () => Promise<void>,
     ) => Promise<void>;
+    staleUnreportedHours: Date[];
   }> = {},
 ) {
   const isMeteringEnabled = vi
@@ -73,6 +74,9 @@ function makeService(
     .mockResolvedValue(overrides.lastMeasured ?? null);
   const recordHour = vi.fn().mockResolvedValue(undefined);
   const enqueueReport = vi.fn().mockResolvedValue(undefined);
+  const findStaleUnreportedHours = vi
+    .fn()
+    .mockResolvedValue(overrides.staleUnreportedHours ?? []);
 
   const service = new StorageMeterDispatchService({
     isMeteringEnabled,
@@ -83,6 +87,7 @@ function makeService(
       recordHour,
       findHour: vi.fn(),
       markReported: vi.fn(),
+      findStaleUnreportedHours,
     },
     enqueueReport,
     runExclusivePerOrg: overrides.runExclusivePerOrg,
@@ -97,6 +102,7 @@ function makeService(
     getLastMeasuredHour,
     recordHour,
     enqueueReport,
+    findStaleUnreportedHours,
   };
 }
 
@@ -313,6 +319,59 @@ describe("StorageMeterDispatchService", () => {
       expect(measureBytesAt).toHaveBeenCalledTimes(2); // 09:00, 10:00 (failed)
       expect(recordHour).toHaveBeenCalledTimes(1); // only 09:00
       expect(enqueueReport).toHaveBeenCalledTimes(1); // only 09:00
+    });
+  });
+
+  describe("given a measured hour whose enqueue never landed", () => {
+    /** @scenario An orphaned unreported hour is re-enqueued, not skipped forever */
+    it("re-enqueues a stale unreported hour on the next dispatch", async () => {
+      // Simulates: an earlier run's recordHour committed but enqueueReport
+      // threw, leaving the hour with reportedAt: null past the grace window.
+      // getLastMeasuredHour already reflects that hour as measured (caught
+      // up), so the forward gap-fill alone would never retry it.
+      const orphanHour = hour("2026-02-15T10:00:00.000Z");
+      const {
+        service,
+        measureBytesAt,
+        enqueueReport,
+        findStaleUnreportedHours,
+      } = makeService({
+        lastMeasured: SEAL_BOUNDARY,
+        staleUnreportedHours: [orphanHour],
+      });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      expect(findStaleUnreportedHours).toHaveBeenCalledWith(
+        expect.objectContaining({ organizationId: "org-1" }),
+      );
+      expect(enqueueReport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: "org-1",
+          sealedHour: "2026-02-15T10:00:00.000Z",
+        }),
+      );
+      // Re-enqueuing an already-measured orphan must not re-run the heavy
+      // measurement or write a duplicate row.
+      expect(measureBytesAt).not.toHaveBeenCalled();
+    });
+
+    /** @scenario A failed retry is logged and does not abort the run */
+    it("does not abort the dispatch when re-enqueuing an orphan fails", async () => {
+      const orphanHour = hour("2026-02-15T10:00:00.000Z");
+      const { service, measureBytesAt, enqueueReport } = makeService({
+        lastMeasured: hour("2026-02-15T10:00:00.000Z"), // one real gap hour: 11:00
+        staleUnreportedHours: [orphanHour],
+      });
+      enqueueReport.mockRejectedValueOnce(new Error("redis blip"));
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      // The orphan retry failed, but the forward gap-fill for 11:00 still ran.
+      expect(measureBytesAt).toHaveBeenCalledTimes(1);
+      expect(measureBytesAt.mock.calls[0]![0].sealedHour.toISOString()).toBe(
+        "2026-02-15T11:00:00.000Z",
+      );
     });
   });
 });

--- a/langwatch/src/server/app-layer/billing/storageBillingBackfill.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingBackfill.service.ts
@@ -1,0 +1,129 @@
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:billing:storageBackfill");
+
+/** One paid subscription eligible for the STORAGE_GB item. */
+export interface BackfillCandidate {
+  organizationId: string;
+  stripeSubscriptionId: string;
+  /** The (plan × currency × interval) key used to resolve the storage price. */
+  plan: string;
+  currency: string;
+  interval: "month" | "year";
+}
+
+export interface StorageBillingBackfillDeps {
+  /** Active PAID subscriptions only — free / self-hosted are never returned. */
+  listPaidSubscriptions: () => Promise<BackfillCandidate[]>;
+  /** The STORAGE_GB metered price id for a (plan × currency × interval), or null. */
+  resolveStoragePriceId: (params: {
+    plan: string;
+    currency: string;
+    interval: "month" | "year";
+  }) => string | null;
+  /** Current Stripe subscription-item price ids for a subscription. */
+  getSubscriptionItemPriceIds: (
+    stripeSubscriptionId: string,
+  ) => Promise<string[]>;
+  /** Attach the metered item; must not change the cycle or subscription_id. */
+  attachStorageItem: (params: {
+    stripeSubscriptionId: string;
+    priceId: string;
+  }) => Promise<void>;
+}
+
+export interface BackfillResult {
+  attached: number;
+  alreadyAttached: number;
+  noPrice: number;
+  failed: number;
+}
+
+/**
+ * ADR-027 Phase 7 rollout: attaches the `STORAGE_GB` SubscriptionItem to active
+ * paid subscriptions so they begin accruing storage usage on the next cycle.
+ *
+ * Idempotent — an item already present is skipped, so it is safe to re-run and
+ * to run alongside live traffic. Free / self-hosted orgs never appear (the query
+ * returns paid subscriptions only). A subscription whose (plan × currency ×
+ * interval) has no storage price is skipped and counted, never guessed.
+ *
+ * Runs only after the customer notice, on the announced date (see the runbook).
+ * `dryRun` reports what it would do without mutating Stripe.
+ */
+export class StorageBillingBackfillService {
+  constructor(private readonly deps: StorageBillingBackfillDeps) {}
+
+  async run({ dryRun }: { dryRun: boolean }): Promise<BackfillResult> {
+    const result: BackfillResult = {
+      attached: 0,
+      alreadyAttached: 0,
+      noPrice: 0,
+      failed: 0,
+    };
+
+    const candidates = await this.deps.listPaidSubscriptions();
+    for (const c of candidates) {
+      const priceId = this.deps.resolveStoragePriceId({
+        plan: c.plan,
+        currency: c.currency,
+        interval: c.interval,
+      });
+      if (!priceId) {
+        result.noPrice++;
+        logger.warn(
+          {
+            organizationId: c.organizationId,
+            plan: c.plan,
+            currency: c.currency,
+            interval: c.interval,
+          },
+          "no STORAGE_GB price for this plan/currency/interval — skipping",
+        );
+        continue;
+      }
+
+      try {
+        const existing = await this.deps.getSubscriptionItemPriceIds(
+          c.stripeSubscriptionId,
+        );
+        if (existing.includes(priceId)) {
+          result.alreadyAttached++;
+          continue;
+        }
+
+        if (dryRun) {
+          logger.info(
+            {
+              organizationId: c.organizationId,
+              priceId,
+              subscription: c.stripeSubscriptionId,
+            },
+            "[dry-run] would attach STORAGE_GB item",
+          );
+          result.attached++;
+          continue;
+        }
+
+        await this.deps.attachStorageItem({
+          stripeSubscriptionId: c.stripeSubscriptionId,
+          priceId,
+        });
+        result.attached++;
+      } catch (error) {
+        result.failed++;
+        logger.error(
+          {
+            organizationId: c.organizationId,
+            subscription: c.stripeSubscriptionId,
+            error,
+          },
+          "failed to attach STORAGE_GB item — continuing; re-run is idempotent",
+        );
+      }
+    }
+
+    logger.info({ dryRun, ...result }, "STORAGE_GB backfill complete");
+    return result;
+  }
+}

--- a/langwatch/src/server/app-layer/billing/storageBillingReconciliation.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingReconciliation.service.ts
@@ -1,0 +1,90 @@
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:billing:storageReconciliation");
+
+const DEFAULT_TOLERANCE_RATIO = 0.01;
+
+export interface StorageReconciliationDeps {
+  /** Orgs with reported storage hours in the period (paid; already metered). */
+  listReconcilableOrgs: (billingMonth: string) => Promise<string[]>;
+  /** Σ of `StorageUsageHourly.megabytes` with `reportedAt` set, for the period. */
+  sumReportedMegabytes: (params: {
+    organizationId: string;
+    billingMonth: string;
+  }) => Promise<number>;
+  /** Stripe's summed meter total (MiB-hours) for the period, or null if unavailable. */
+  fetchStripeMeterTotal: (params: {
+    organizationId: string;
+    billingMonth: string;
+  }) => Promise<number | null>;
+  toleranceRatio?: number;
+}
+
+export interface ReconciliationResult {
+  checked: number;
+  drifted: number;
+  unavailable: number;
+}
+
+/**
+ * ADR-027 finance safety net (deferred, off the critical path): periodically
+ * diffs what we recorded as reported (`Σ StorageUsageHourly.megabytes` with
+ * `reportedAt` set) against Stripe's own meter total per org/period, and logs a
+ * capped-severity warning on drift beyond tolerance. Catches anything the
+ * measure-time tripwire and the idempotency layers missed — e.g. a report the
+ * cursor marked done but Stripe never accepted. Observational; never mutates.
+ */
+export class StorageBillingReconciliationService {
+  constructor(private readonly deps: StorageReconciliationDeps) {}
+
+  async reconcile({
+    billingMonth,
+  }: {
+    billingMonth: string;
+  }): Promise<ReconciliationResult> {
+    const result: ReconciliationResult = {
+      checked: 0,
+      drifted: 0,
+      unavailable: 0,
+    };
+    const tolerance = this.deps.toleranceRatio ?? DEFAULT_TOLERANCE_RATIO;
+
+    const orgs = await this.deps.listReconcilableOrgs(billingMonth);
+    for (const organizationId of orgs) {
+      const reported = await this.deps.sumReportedMegabytes({
+        organizationId,
+        billingMonth,
+      });
+      const stripeTotal = await this.deps.fetchStripeMeterTotal({
+        organizationId,
+        billingMonth,
+      });
+
+      if (stripeTotal == null) {
+        result.unavailable++;
+        continue;
+      }
+
+      result.checked++;
+      const diff = Math.abs(reported - stripeTotal);
+      const scale = Math.max(reported, stripeTotal, 1);
+      if (diff / scale > tolerance) {
+        result.drifted++;
+        logger.error(
+          {
+            organizationId,
+            billingMonth,
+            reportedMegabytes: reported,
+            stripeMegabytes: stripeTotal,
+            ratio: diff / scale,
+          },
+          "DRIFT: recorded storage total diverges from Stripe's meter total — " +
+            "finance reconciliation required.",
+        );
+      }
+    }
+
+    logger.info({ billingMonth, ...result }, "storage reconciliation complete");
+    return result;
+  }
+}

--- a/langwatch/src/server/app-layer/billing/storageBillingTripwire.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingTripwire.ts
@@ -1,0 +1,102 @@
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:billing:storageTripwire");
+
+/** Default relative tolerance before a divergence is logged. */
+const DEFAULT_TOLERANCE_RATIO = 0.5;
+/** Default cap on warnings per window, so a broken reference can't flood logs. */
+const DEFAULT_MAX_LOGS = 50;
+/** The cap resets each window so real divergence isn't silenced forever. */
+const LOG_WINDOW_MS = 60 * 60 * 1000;
+
+export interface StorageBillingTripwireDeps {
+  /** Gate — the `release_storage_billing_metering_tripwire` flag, per org. */
+  isEnabled: (organizationId: string) => Promise<boolean>;
+  /**
+   * An INDEPENDENT reference for the same hour's billable bytes, or null when
+   * none is available (e.g. the first hour). Kept pluggable so the cheap
+   * hour-over-hour anomaly reference can later be swapped for the precise
+   * "reference SUM" once it's verified against real ClickHouse.
+   */
+  computeReference: (params: {
+    organizationId: string;
+    sealedHour: Date;
+  }) => Promise<number | null>;
+  /** Relative divergence (|measured − ref| / max) above which to warn. */
+  toleranceRatio?: number;
+  /** Max warnings per {@link LOG_WINDOW_MS} window (default 50). */
+  maxLogs?: number;
+  /** Injectable clock (epoch ms) for deterministic tests. */
+  now?: () => number;
+}
+
+/**
+ * ADR-027 measure-time tripwire (Phase 4.5). Shadow-compares each billed
+ * measurement against an independent reference and logs a capped warning on
+ * divergence beyond tolerance — the earlier, stronger form of the deferred
+ * month-end reconciliation, catching a bad value *before* it bills.
+ *
+ * CONTRACT: `check` must NEVER throw into the measure/report path and never
+ * alter the billed value. Every failure — flag lookup, reference computation,
+ * comparison — is swallowed. It is purely observational.
+ */
+export class StorageBillingTripwire {
+  private logs = 0;
+  private windowStartMs = 0;
+
+  constructor(private readonly deps: StorageBillingTripwireDeps) {}
+
+  async check(params: {
+    organizationId: string;
+    sealedHour: Date;
+    measuredBytes: number;
+  }): Promise<void> {
+    try {
+      if (!(await this.deps.isEnabled(params.organizationId))) return;
+
+      const reference = await this.deps.computeReference({
+        organizationId: params.organizationId,
+        sealedHour: params.sealedHour,
+      });
+      if (reference == null) return;
+
+      const diff = Math.abs(params.measuredBytes - reference);
+      const scale = Math.max(params.measuredBytes, reference, 1);
+      const ratio = diff / scale;
+      const tolerance = this.deps.toleranceRatio ?? DEFAULT_TOLERANCE_RATIO;
+
+      // Reset the per-window cap so a real divergence hours later still logs,
+      // rather than being permanently silenced after the first burst.
+      const nowMs = (this.deps.now ?? Date.now)();
+      if (nowMs - this.windowStartMs >= LOG_WINDOW_MS) {
+        this.windowStartMs = nowMs;
+        this.logs = 0;
+      }
+
+      if (
+        ratio > tolerance &&
+        this.logs < (this.deps.maxLogs ?? DEFAULT_MAX_LOGS)
+      ) {
+        this.logs++;
+        logger.warn(
+          {
+            organizationId: params.organizationId,
+            sealedHour: params.sealedHour.toISOString(),
+            measuredBytes: params.measuredBytes,
+            reference,
+            ratio,
+            tolerance,
+          },
+          "TRIPWIRE: storage measurement diverges from reference beyond tolerance " +
+            "— investigate before trusting the billed value.",
+        );
+      }
+    } catch (error) {
+      // Never break the measure path; the tripwire is purely observational.
+      logger.debug(
+        { organizationId: params.organizationId, error },
+        "storage tripwire check failed (ignored)",
+      );
+    }
+  }
+}

--- a/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
@@ -28,6 +28,18 @@ export interface StorageMeterDispatchDeps {
   }) => Promise<number>;
   storageUsageHourly: StorageUsageHourlyRepository;
   enqueueReport: (data: ReportStorageForHourCommandData) => Promise<void>;
+  /**
+   * Runs `fn` at most once per organization at a time. The reactor dedups per
+   * PROJECT, so an org with several active projects would otherwise gap-fill —
+   * and re-run the heavy `byteSize()` measurement (the two-prod-OOM operation) —
+   * once per project for the same hours. This collapses that to one dispatch per
+   * org: if the guard is already held for the org, `fn` is skipped (the holder
+   * covers every sealed hour). When omitted (no Redis), `fn` runs directly.
+   */
+  runExclusivePerOrg?: (
+    organizationId: string,
+    fn: () => Promise<void>,
+  ) => Promise<void>;
   /** Injectable wall clock for deterministic tests. */
   now?: () => Date;
 }
@@ -69,8 +81,17 @@ export class StorageMeterDispatchService {
     const org = await this.deps.getBillableOrg(organizationId);
     if (!org?.stripeCustomerId || org.subscriptions.length === 0) return;
 
-    // 3. Window: catch up to the last COMPLETE wall-clock hour. The triggering
-    //    event is only a wake-up; what we measure is "sealed hours not yet done".
+    // 3. Collapse concurrent per-project dispatches for the same org to one, so
+    //    the heavy measurement isn't re-run per project. The flag + SaaS checks
+    //    above are cheap and run unguarded; only the measurement work is guarded.
+    const runExclusive = this.deps.runExclusivePerOrg ?? ((_org, fn) => fn());
+    await runExclusive(organizationId, () => this.catchUp(organizationId));
+  }
+
+  /** Measures and enqueues every sealed hour not yet done for the org. */
+  private async catchUp(organizationId: string): Promise<void> {
+    // Window: catch up to the last COMPLETE wall-clock hour. The triggering
+    // event is only a wake-up; what we measure is "sealed hours not yet done".
     const now = (this.deps.now ?? (() => new Date()))();
     const sealBoundaryMs = floorToHourMs(now.getTime()) - MS_PER_HOUR;
 

--- a/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
@@ -1,0 +1,125 @@
+import type { ReportStorageForHourCommandData } from "~/server/event-sourcing/pipelines/billing-reporting/schemas/commands";
+import { createLogger } from "~/utils/logger/server";
+import type { StorageUsageHourlyRepository } from "./storageUsageHourly.repository";
+
+const logger = createLogger("langwatch:billing:storageMeterDispatch");
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+const BYTES_PER_MIB = 1024 * 1024;
+
+/**
+ * Stripe rejects meter events whose timestamp is older than ~35 days, so the
+ * gap-fill never reaches back further than this. A longer outage needs the
+ * `meterEventAdjustments.create` runbook; truncating here is alarmed, never
+ * silent (see {@link StorageMeterDispatchService.dispatchForOrg}).
+ */
+export const STORAGE_BACKFILL_MAX_HOURS = 840;
+
+/** Narrow contracts so the service depends on capabilities, not whole services. */
+export interface StorageMeterDispatchDeps {
+  isMeteringEnabled: (organizationId: string) => Promise<boolean>;
+  getBillableOrg: (organizationId: string) => Promise<{
+    stripeCustomerId: string | null;
+    subscriptions: { id: string }[];
+  } | null>;
+  measureBytesAt: (params: {
+    organizationId: string;
+    sealedHour: Date;
+  }) => Promise<number>;
+  storageUsageHourly: StorageUsageHourlyRepository;
+  enqueueReport: (data: ReportStorageForHourCommandData) => Promise<void>;
+  /** Injectable wall clock for deterministic tests. */
+  now?: () => Date;
+}
+
+/** Floor a timestamp to the start of its UTC hour. */
+function floorToHourMs(ms: number): number {
+  return Math.floor(ms / MS_PER_HOUR) * MS_PER_HOUR;
+}
+
+/**
+ * Advances an organization's hourly storage cursor: for every sealed hour not
+ * yet measured (up to the last complete wall-clock hour), measures the billable
+ * bytes, persists a `StorageUsageHourly` row, and enqueues a report command.
+ *
+ * Stateless: the cursor is read from the durable table each run
+ * ({@link StorageUsageHourlyRepository.getLastMeasuredHour}), so it survives
+ * restarts and stays correct across pods without in-memory state. The reactor
+ * that calls this is per-project deduped (300s), so the per-run DB read is
+ * cheap. Idempotent end-to-end — `recordHour` is insert-if-absent and the
+ * report command dedups on its own cursor — so a re-fire never double-counts.
+ *
+ * Gated by the `release_storage_billing_metering` flag (default OFF, checked via
+ * the injected `isMeteringEnabled`): disabled → zero CH queries, zero rows, zero
+ * enqueues. SaaS short-circuit runs before any measurement.
+ */
+export class StorageMeterDispatchService {
+  constructor(private readonly deps: StorageMeterDispatchDeps) {}
+
+  async dispatchForOrg({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<void> {
+    // 1. Master flag gate — OFF → fully inert (no CH, no rows, no enqueue).
+    if (!(await this.deps.isMeteringEnabled(organizationId))) return;
+
+    // 2. SaaS short-circuit BEFORE any ClickHouse query: free / self-hosted /
+    //    no-subscription orgs never enter the measurement loop.
+    const org = await this.deps.getBillableOrg(organizationId);
+    if (!org?.stripeCustomerId || org.subscriptions.length === 0) return;
+
+    // 3. Window: catch up to the last COMPLETE wall-clock hour. The triggering
+    //    event is only a wake-up; what we measure is "sealed hours not yet done".
+    const now = (this.deps.now ?? (() => new Date()))();
+    const sealBoundaryMs = floorToHourMs(now.getTime()) - MS_PER_HOUR;
+
+    const last = await this.deps.storageUsageHourly.getLastMeasuredHour({
+      organizationId,
+    });
+    // No history → start at the latest sealed hour (forward-only; never backfill
+    // a brand-new org's entire past). Otherwise resume after the last measured.
+    let firstMs = last ? last.getTime() + MS_PER_HOUR : sealBoundaryMs;
+    if (firstMs > sealBoundaryMs) return; // already caught up
+
+    // 4. Bound the gap at Stripe's timestamp ceiling; alarm if hours are dropped.
+    const earliestAllowedMs =
+      sealBoundaryMs - (STORAGE_BACKFILL_MAX_HOURS - 1) * MS_PER_HOUR;
+    if (firstMs < earliestAllowedMs) {
+      logger.error(
+        {
+          organizationId,
+          droppedHours: (earliestAllowedMs - firstMs) / MS_PER_HOUR,
+          ceilingHours: STORAGE_BACKFILL_MAX_HOURS,
+        },
+        "ALARM: storage gap exceeds the backfill ceiling — older hours dropped, " +
+          "they will never be metered without the meterEventAdjustments runbook.",
+      );
+      firstMs = earliestAllowedMs;
+    }
+
+    // 5. Measure → persist → enqueue, one sealed hour at a time. A measurement
+    //    that throws aborts the loop (no silent under-bill); progress is durable
+    //    per hour, so the next wake-up resumes from the last recorded hour.
+    for (let ms = firstMs; ms <= sealBoundaryMs; ms += MS_PER_HOUR) {
+      const sealedHour = new Date(ms);
+      const bytes = await this.deps.measureBytesAt({
+        organizationId,
+        sealedHour,
+      });
+      const megabytes = Math.ceil(bytes / BYTES_PER_MIB);
+
+      await this.deps.storageUsageHourly.recordHour({
+        organizationId,
+        sealedHour,
+        megabytes,
+      });
+      await this.deps.enqueueReport({
+        organizationId,
+        sealedHour: sealedHour.toISOString(),
+        tenantId: organizationId,
+        occurredAt: now.getTime(),
+      });
+    }
+  }
+}

--- a/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
@@ -23,6 +23,35 @@ export const STORAGE_BACKFILL_MAX_HOURS = 840;
  */
 export const STORAGE_MAX_HOURS_PER_RUN = 168;
 
+/**
+ * Grace window before an unenqueued measured hour is considered orphaned
+ * rather than merely in flight. An hour enqueued moments ago that hasn't been
+ * processed yet is normal; one still unreported after this long means the
+ * `enqueueReport` call itself likely never landed.
+ */
+const STALE_UNREPORTED_GRACE_MS = 10 * 60 * 1000;
+
+/**
+ * Worst-case seconds a single heavy `byteSize()` ClickHouse measurement can
+ * take — `storageMeter.service.ts`'s `METERING_MAX_EXECUTION_SECONDS` query
+ * cap. Duplicated as a literal (not imported) because that constant is
+ * private to its module; this is the one place outside it that needs the
+ * number, purely to size the lock TTL below.
+ */
+const MAX_SINGLE_MEASUREMENT_SECONDS = 45;
+
+/**
+ * TTL for the per-org dispatch lock. Fixed TTL (not a heartbeat/renewal
+ * scheme) mirrors `ReplayRedisRepository.acquireLock`'s convention for the
+ * same class of problem — but sized to the TRUE worst case, not a round
+ * guess: up to {@link STORAGE_MAX_HOURS_PER_RUN} sequential measurements,
+ * each pathologically pegging {@link MAX_SINGLE_MEASUREMENT_SECONDS}, with 2x
+ * margin so a genuinely-slow-but-not-pathological run never outlives the
+ * lock (168 * 45 * 2 = 15,120s, ~4.2h).
+ */
+export const STORAGE_DISPATCH_LOCK_TTL_SECONDS =
+  STORAGE_MAX_HOURS_PER_RUN * MAX_SINGLE_MEASUREMENT_SECONDS * 2;
+
 /** Narrow contracts so the service depends on capabilities, not whole services. */
 export interface StorageMeterDispatchDeps {
   isMeteringEnabled: (organizationId: string) => Promise<boolean>;
@@ -112,6 +141,9 @@ export class StorageMeterDispatchService {
     // Window: catch up to the last COMPLETE wall-clock hour. The triggering
     // event is only a wake-up; what we measure is "sealed hours not yet done".
     const now = (this.deps.now ?? (() => new Date()))();
+
+    await this.healOrphanedUnreportedHours(organizationId, now);
+
     const sealBoundaryMs = floorToHourMs(now.getTime()) - MS_PER_HOUR;
 
     const last = await this.deps.storageUsageHourly.getLastMeasuredHour({
@@ -184,6 +216,46 @@ export class StorageMeterDispatchService {
         tenantId: organizationId,
         occurredAt: now.getTime(),
       });
+    }
+  }
+
+  /**
+   * Re-enqueues measured hours whose report was never confirmed durable
+   * (`reportedAt` still null past the grace window) — the fix for the gap
+   * where `recordHour` commits but the subsequent `enqueueReport` throws
+   * (Redis blip, ES validation error): the cursor below only checks row
+   * existence, so without this the hour would silently never be retried.
+   * Re-enqueuing is safe even if the hour is actually still in flight — the
+   * report command is idempotent on its own `reportedAt` cursor and Stripe's
+   * deterministic per-hour identifier.
+   */
+  private async healOrphanedUnreportedHours(
+    organizationId: string,
+    now: Date,
+  ): Promise<void> {
+    const staleHours =
+      await this.deps.storageUsageHourly.findStaleUnreportedHours({
+        organizationId,
+        olderThan: new Date(now.getTime() - STALE_UNREPORTED_GRACE_MS),
+        limit: STORAGE_MAX_HOURS_PER_RUN,
+      });
+
+    for (const sealedHour of staleHours) {
+      try {
+        await this.deps.enqueueReport({
+          organizationId,
+          sealedHour: sealedHour.toISOString(),
+          tenantId: organizationId,
+          occurredAt: now.getTime(),
+        });
+      } catch (error) {
+        // Best-effort: leave the row unreported and retry on the next wake-up
+        // rather than aborting the whole catch-up over an orphan repair.
+        logger.warn(
+          { organizationId, sealedHour, error },
+          "failed to re-enqueue an orphaned unreported storage hour, will retry next run",
+        );
+      }
     }
   }
 }

--- a/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
@@ -15,6 +15,14 @@ const BYTES_PER_MIB = 1024 * 1024;
  */
 export const STORAGE_BACKFILL_MAX_HOURS = 840;
 
+/**
+ * Most hours measured in a single dispatch run. Bounds how many heavy
+ * `byteSize()` measurements one worker job runs back-to-back; a larger backlog
+ * (post-outage) drains across successive events. One week keeps steady-state
+ * (a 1-hour gap) unaffected while capping recovery bursts.
+ */
+export const STORAGE_MAX_HOURS_PER_RUN = 168;
+
 /** Narrow contracts so the service depends on capabilities, not whole services. */
 export interface StorageMeterDispatchDeps {
   isMeteringEnabled: (organizationId: string) => Promise<boolean>;
@@ -40,6 +48,17 @@ export interface StorageMeterDispatchDeps {
     organizationId: string,
     fn: () => Promise<void>,
   ) => Promise<void>;
+  /**
+   * Optional measure-time drift guard (ADR-027 Phase 4.5). Observational only —
+   * its `check` never throws and never alters the billed value.
+   */
+  tripwire?: {
+    check: (params: {
+      organizationId: string;
+      sealedHour: Date;
+      measuredBytes: number;
+    }) => Promise<void>;
+  };
   /** Injectable wall clock for deterministic tests. */
   now?: () => Date;
 }
@@ -119,14 +138,38 @@ export class StorageMeterDispatchService {
       firstMs = earliestAllowedMs;
     }
 
-    // 5. Measure → persist → enqueue, one sealed hour at a time. A measurement
+    // 5. Cap the hours measured in ONE run so a large catch-up (e.g. after an
+    //    outage) doesn't run hundreds of heavy measurements back-to-back in a
+    //    single worker job; the remainder catches up on subsequent events.
+    const runEndMs = Math.min(
+      sealBoundaryMs,
+      firstMs + (STORAGE_MAX_HOURS_PER_RUN - 1) * MS_PER_HOUR,
+    );
+    if (runEndMs < sealBoundaryMs) {
+      logger.info(
+        {
+          organizationId,
+          measuringHours: (runEndMs - firstMs) / MS_PER_HOUR + 1,
+          remainingHours: (sealBoundaryMs - runEndMs) / MS_PER_HOUR,
+        },
+        "storage catch-up capped this run; remainder resumes on the next event",
+      );
+    }
+
+    // 6. Measure → persist → enqueue, one sealed hour at a time. A measurement
     //    that throws aborts the loop (no silent under-bill); progress is durable
     //    per hour, so the next wake-up resumes from the last recorded hour.
-    for (let ms = firstMs; ms <= sealBoundaryMs; ms += MS_PER_HOUR) {
+    for (let ms = firstMs; ms <= runEndMs; ms += MS_PER_HOUR) {
       const sealedHour = new Date(ms);
       const bytes = await this.deps.measureBytesAt({
         organizationId,
         sealedHour,
+      });
+      // Observational drift guard — never throws, never changes the billed value.
+      await this.deps.tripwire?.check({
+        organizationId,
+        sealedHour,
+        measuredBytes: bytes,
       });
       const megabytes = Math.ceil(bytes / BYTES_PER_MIB);
 

--- a/langwatch/src/server/app-layer/billing/storageUsageHourly.repository.ts
+++ b/langwatch/src/server/app-layer/billing/storageUsageHourly.repository.ts
@@ -24,6 +24,25 @@ export interface StorageUsageHourlyRepository {
     sealedHour: Date;
     reportedAt: Date;
   }): Promise<void>;
+
+  /**
+   * Inserts a measured hour, doing nothing if the (org, hour) row already
+   * exists (ON CONFLICT DO NOTHING). Idempotent so the dispatcher can re-measure
+   * a hour across pods/restarts without ever double-counting or clobbering a
+   * row that may already be reported.
+   */
+  recordHour(params: {
+    organizationId: string;
+    sealedHour: Date;
+    megabytes: number;
+  }): Promise<void>;
+
+  /**
+   * The latest sealed hour already measured for an organization, or null if it
+   * has none. The dispatcher's cursor — read per run so it survives restarts
+   * and stays correct across pods without in-memory state.
+   */
+  getLastMeasuredHour(params: { organizationId: string }): Promise<Date | null>;
 }
 
 export class PrismaStorageUsageHourlyRepository
@@ -61,5 +80,33 @@ export class PrismaStorageUsageHourlyRepository
       },
       data: { reportedAt: params.reportedAt },
     });
+  }
+
+  async recordHour(params: {
+    organizationId: string;
+    sealedHour: Date;
+    megabytes: number;
+  }): Promise<void> {
+    await this.prisma.storageUsageHourly.createMany({
+      data: [
+        {
+          organizationId: params.organizationId,
+          sealedHour: params.sealedHour,
+          megabytes: params.megabytes,
+        },
+      ],
+      skipDuplicates: true,
+    });
+  }
+
+  async getLastMeasuredHour(params: {
+    organizationId: string;
+  }): Promise<Date | null> {
+    const row = await this.prisma.storageUsageHourly.findFirst({
+      where: { organizationId: params.organizationId },
+      orderBy: { sealedHour: "desc" },
+      select: { sealedHour: true },
+    });
+    return row?.sealedHour ?? null;
   }
 }

--- a/langwatch/src/server/app-layer/billing/storageUsageHourly.repository.ts
+++ b/langwatch/src/server/app-layer/billing/storageUsageHourly.repository.ts
@@ -43,6 +43,22 @@ export interface StorageUsageHourlyRepository {
    * and stays correct across pods without in-memory state.
    */
   getLastMeasuredHour(params: { organizationId: string }): Promise<Date | null>;
+
+  /**
+   * Measured hours whose enqueue was never confirmed durable: `recordHour`
+   * succeeded but the hour is still `reportedAt: null` a full grace window
+   * later. `getLastMeasuredHour` only checks row existence, so if the
+   * dispatcher's `enqueueReport` call failed right after `recordHour`
+   * committed, the cursor would otherwise skip past the hour forever — this is
+   * the sweep that gives it a second chance. Bounded by `createdAt` so hours
+   * still legitimately in flight (enqueued moments ago, not yet processed)
+   * aren't matched.
+   */
+  findStaleUnreportedHours(params: {
+    organizationId: string;
+    olderThan: Date;
+    limit: number;
+  }): Promise<Date[]>;
 }
 
 export class PrismaStorageUsageHourlyRepository
@@ -108,5 +124,23 @@ export class PrismaStorageUsageHourlyRepository
       select: { sealedHour: true },
     });
     return row?.sealedHour ?? null;
+  }
+
+  async findStaleUnreportedHours(params: {
+    organizationId: string;
+    olderThan: Date;
+    limit: number;
+  }): Promise<Date[]> {
+    const rows = await this.prisma.storageUsageHourly.findMany({
+      where: {
+        organizationId: params.organizationId,
+        reportedAt: null,
+        createdAt: { lt: params.olderThan },
+      },
+      orderBy: { sealedHour: "asc" },
+      take: params.limit,
+      select: { sealedHour: true },
+    });
+    return rows.map((row) => row.sealedHour);
   }
 }

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -618,6 +618,22 @@ export function initializeDefaultApp(options?: {
         es
           .getPipeline(BILLING_REPORTING_PIPELINE_NAME)
           .commands.reportStorageForHour.send(data),
+      // Per-org guard: the reactor dedups per project, so without this an org
+      // with several projects would re-run the heavy measurement per project.
+      // A short-lived Redis lock lets one dispatch win and the rest skip (the
+      // winner covers every sealed hour). No Redis → run unguarded.
+      runExclusivePerOrg: redis
+        ? async (organizationId, fn) => {
+            const key = `storage_dispatch_org:${organizationId}`;
+            const acquired = await redis.set(key, "1", "EX", 120, "NX");
+            if (acquired !== "OK") return;
+            try {
+              await fn();
+            } finally {
+              await redis.del(key);
+            }
+          }
+        : undefined,
     });
   }
 

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -10,6 +10,7 @@ import {
   isClickHouseEnabled,
 } from "~/server/clickhouse/clickhouseClient";
 import { prisma as globalPrisma } from "~/server/db";
+import { featureFlagService } from "~/server/featureFlag/featureFlag.service";
 import { getFeatureFlagStore } from "~/server/featureFlag/featureFlagStore.postgres";
 import { GatewayBudgetClickHouseRepository } from "~/server/gateway/budget.clickhouse.repository";
 import { GatewayBudgetRepository } from "~/server/gateway/budget.repository";
@@ -49,6 +50,7 @@ import {
   type AppCommands,
   PipelineRegistry,
 } from "../event-sourcing/pipelineRegistry";
+import { BILLING_REPORTING_PIPELINE_NAME } from "../event-sourcing/pipelines/billing-reporting/pipeline";
 import { createExperimentRunItemAppendStore } from "../event-sourcing/pipelines/experiment-run-processing/projections/experimentRunResultStorage.store";
 import {
   ExperimentRunStateRepositoryClickHouse,
@@ -74,6 +76,7 @@ import { runEvaluationWorkflow } from "../workflows/runWorkflow";
 import { App, getApp, globalForApp, initializeApp } from "./app";
 import { PrismaBillingCheckpointService } from "./billing/billingCheckpoint.service";
 import { PrismaStorageBillingCheckpointService } from "./billing/storageBillingCheckpoint.service";
+import { StorageMeterDispatchService } from "./billing/storageMeterDispatch.service";
 import { PrismaStorageUsageHourlyRepository } from "./billing/storageUsageHourly.repository";
 import { BroadcastService } from "./broadcast/broadcast.service";
 import { createClickHouseClientFromConfig } from "./clients/clickhouse.factory";
@@ -496,6 +499,13 @@ export function initializeDefaultApp(options?: {
     "ShareService",
   );
 
+  // ADR-027 Phase 4: shared StorageUsageHourly repo (registry + dispatch) and a
+  // forward reference for the dispatch service, which is built after the command
+  // pipeline exists. The reactor's getStorageMeterDispatch is lazy, so the
+  // late assignment is safe — it's only dereferenced at event-handling time.
+  const storageUsageHourlyRepo = new PrismaStorageUsageHourlyRepository(prisma);
+  let storageMeterDispatchService: StorageMeterDispatchService | undefined;
+
   const es = new EventSourcing({
     clickhouse: clickhouseEnabled ? resolveClickHouseClient : void 0,
     redis,
@@ -503,6 +513,9 @@ export function initializeDefaultApp(options?: {
     isSaas: config.isSaas,
     processRole: config.processRole,
     retentionPolicyResolver: retentionPolicyCache,
+    getStorageMeterDispatch: config.isSaas
+      ? () => (params) => storageMeterDispatchService!.dispatchForOrg(params)
+      : undefined,
   });
 
   // Construct repositories at the composition root — ClickHouse-or-Memory decisions live here.
@@ -573,7 +586,7 @@ export function initializeDefaultApp(options?: {
     storageBillingCheckpoints: new PrismaStorageBillingCheckpointService(
       prisma,
     ),
-    storageUsageHourly: new PrismaStorageUsageHourlyRepository(prisma),
+    storageUsageHourly: storageUsageHourlyRepo,
     usageReportingService,
     gatewayBudgetSync,
     // ADR-022: Inject BlobStore into the pipeline registry so RecordSpanCommand
@@ -586,6 +599,27 @@ export function initializeDefaultApp(options?: {
   const commands = registry.registerAll();
   (globalForApp as any).__scenarioExecutionHandle =
     commands.scenarioExecutionHandle;
+
+  // ADR-027 Phase 4: now that the command pipeline exists, build the storage
+  // meter dispatch brain and satisfy the forward reference the ES reactor holds.
+  if (config.isSaas) {
+    storageMeterDispatchService = new StorageMeterDispatchService({
+      isMeteringEnabled: (organizationId) =>
+        featureFlagService.isEnabled("release_storage_billing_metering", {
+          distinctId: organizationId,
+          organizationId,
+        }),
+      getBillableOrg: (organizationId) =>
+        organizations.getOrganizationForBilling(organizationId),
+      measureBytesAt: (params) =>
+        storageMeterService.getBillableStorageBytesForOrgAt(params),
+      storageUsageHourly: storageUsageHourlyRepo,
+      enqueueReport: (data) =>
+        es
+          .getPipeline(BILLING_REPORTING_PIPELINE_NAME)
+          .commands.reportStorageForHour.send(data),
+    });
+  }
 
   const suiteRunService = SuiteRunService.create({
     resolveClickHouseClient: clickhouseEnabled ? resolveClickHouseClient : null,

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -2,6 +2,7 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { GovernanceKpisClickHouseRepository } from "@ee/governance/services/governanceKpis.clickhouse.repository";
 import { GovernanceOcsfEventsClickHouseRepository } from "@ee/governance/services/governanceOcsfEvents.clickhouse.repository";
 import type { PrismaClient } from "@prisma/client";
+import { randomUUID } from "crypto";
 import { env } from "~/env.mjs";
 import {
   type ClickHouseClientResolver,
@@ -77,7 +78,10 @@ import { App, getApp, globalForApp, initializeApp } from "./app";
 import { PrismaBillingCheckpointService } from "./billing/billingCheckpoint.service";
 import { PrismaStorageBillingCheckpointService } from "./billing/storageBillingCheckpoint.service";
 import { StorageBillingTripwire } from "./billing/storageBillingTripwire";
-import { StorageMeterDispatchService } from "./billing/storageMeterDispatch.service";
+import {
+  STORAGE_DISPATCH_LOCK_TTL_SECONDS,
+  StorageMeterDispatchService,
+} from "./billing/storageMeterDispatch.service";
 import { PrismaStorageUsageHourlyRepository } from "./billing/storageUsageHourly.repository";
 import { BroadcastService } from "./broadcast/broadcast.service";
 import { createClickHouseClientFromConfig } from "./clients/clickhouse.factory";
@@ -614,6 +618,17 @@ export function initializeDefaultApp(options?: {
   // ADR-027 Phase 4: now that the command pipeline exists, build the storage
   // meter dispatch brain and satisfy the forward reference the ES reactor holds.
   if (config.isSaas) {
+    if (!redis) {
+      // isSaas with no Redis (skipRedis misconfigured for this environment)
+      // silently removes the only guard against the concurrent-heavy-
+      // measurement scenario below (the pattern behind two prior production
+      // OOM incidents) — make that gap visible instead of a silent no-op.
+      createLogger("langwatch:billing:storageMeterDispatch").warn(
+        "storage-billing dispatch has no Redis in a SaaS environment — " +
+          "running WITHOUT the per-org dedup lock; an org with multiple " +
+          "projects can re-run the heavy storage measurement concurrently",
+      );
+    }
     storageMeterDispatchService = new StorageMeterDispatchService({
       isMeteringEnabled: (organizationId) =>
         featureFlagService.isEnabled("release_storage_billing_metering", {
@@ -632,19 +647,33 @@ export function initializeDefaultApp(options?: {
       // Per-org guard: the reactor dedups per project, so without this an org
       // with several projects would re-run the heavy measurement per project.
       // A short-lived Redis lock lets one dispatch win and the rest skip (the
-      // winner covers every sealed hour). No Redis → run unguarded.
+      // winner covers every sealed hour). Fencing token (mirrors
+      // ReplayRedisRepository's acquireLock/releaseLock) so a TTL expiry
+      // during a long catch-up can never make this process delete a
+      // different process's live lock; TTL sized to the worst-case run
+      // (STORAGE_DISPATCH_LOCK_TTL_SECONDS), not a short heartbeat interval.
       runExclusivePerOrg: redis
         ? async (organizationId, fn) => {
             const key = `storage_dispatch_org:${organizationId}`;
-            const acquired = await redis.set(key, "1", "EX", 120, "NX");
+            const token = randomUUID();
+            const acquired = await redis.set(
+              key,
+              token,
+              "EX",
+              STORAGE_DISPATCH_LOCK_TTL_SECONDS,
+              "NX",
+            );
             if (acquired !== "OK") return;
             try {
               await fn();
             } finally {
-              await redis.del(key);
+              const holder = await redis.get(key);
+              if (holder === token) {
+                await redis.del(key);
+              }
             }
           }
-        : undefined,
+        : undefined, // no Redis → run unguarded (warned above, once, at boot)
       // ADR-027 Phase 4.5 drift guard. Reference: the previous sealed hour's
       // recorded bytes — storage changes slowly hour-over-hour, so a gross jump
       // is anomalous. The precise "reference SUM vs measured" check plugs into

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -76,6 +76,7 @@ import { runEvaluationWorkflow } from "../workflows/runWorkflow";
 import { App, getApp, globalForApp, initializeApp } from "./app";
 import { PrismaBillingCheckpointService } from "./billing/billingCheckpoint.service";
 import { PrismaStorageBillingCheckpointService } from "./billing/storageBillingCheckpoint.service";
+import { StorageBillingTripwire } from "./billing/storageBillingTripwire";
 import { StorageMeterDispatchService } from "./billing/storageMeterDispatch.service";
 import { PrismaStorageUsageHourlyRepository } from "./billing/storageUsageHourly.repository";
 import { BroadcastService } from "./broadcast/broadcast.service";
@@ -514,7 +515,17 @@ export function initializeDefaultApp(options?: {
     processRole: config.processRole,
     retentionPolicyResolver: retentionPolicyCache,
     getStorageMeterDispatch: config.isSaas
-      ? () => (params) => storageMeterDispatchService!.dispatchForOrg(params)
+      ? () => (params) => {
+          // Built after registerAll (below), so a reactor firing before that
+          // finishes should fail loud — the reactor catches + logs it — rather
+          // than deref undefined with a cryptic message.
+          if (!storageMeterDispatchService) {
+            throw new Error(
+              "storageMeterDispatchService not yet initialized — dispatch fired before composition finished",
+            );
+          }
+          return storageMeterDispatchService.dispatchForOrg(params);
+        }
       : undefined,
   });
 
@@ -634,6 +645,24 @@ export function initializeDefaultApp(options?: {
             }
           }
         : undefined,
+      // ADR-027 Phase 4.5 drift guard. Reference: the previous sealed hour's
+      // recorded bytes — storage changes slowly hour-over-hour, so a gross jump
+      // is anomalous. The precise "reference SUM vs measured" check plugs into
+      // the same module once verified against real ClickHouse.
+      tripwire: new StorageBillingTripwire({
+        isEnabled: (organizationId) =>
+          featureFlagService.isEnabled(
+            "release_storage_billing_metering_tripwire",
+            { distinctId: organizationId, organizationId },
+          ),
+        computeReference: async ({ organizationId, sealedHour }) => {
+          const prev = await storageUsageHourlyRepo.findHour({
+            organizationId,
+            sealedHour: new Date(sealedHour.getTime() - 60 * 60 * 1000),
+          });
+          return prev ? prev.megabytes * 1024 * 1024 : null;
+        },
+      }),
     });
   }
 

--- a/langwatch/src/server/event-sourcing/eventSourcing.ts
+++ b/langwatch/src/server/event-sourcing/eventSourcing.ts
@@ -1,12 +1,12 @@
 import type { ClickHouseClient } from "@clickhouse/client";
-import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { SpanKind } from "@opentelemetry/api";
 import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
 import { getLangWatchTracer } from "langwatch";
 import type { ProcessRole } from "~/server/app-layer/config";
-import type { RetentionPolicyResolver } from "~/server/data-retention/retentionPolicyResolver";
 import { makeQueueName } from "~/server/background/queues/makeQueueName";
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
+import type { RetentionPolicyResolver } from "~/server/data-retention/retentionPolicyResolver";
 import { createLogger } from "~/utils/logger/server";
 import { DisabledPipeline } from "./disabledPipeline";
 import type { Event, Projection } from "./domain/types";
@@ -22,16 +22,16 @@ import type {
 import { BILLING_REPORTING_PIPELINE_NAME } from "./pipelines/billing-reporting/pipeline";
 import { createBillingMeterDispatchReactor } from "./projections/global/billingMeterDispatch.reactor";
 import { orgBillableEventsMeterProjection } from "./projections/global/orgBillableEventsMeter.mapProjection";
-import type { ReactorDefinition } from "./reactors/reactor.types";
-import { RedisReplayMarkerChecker } from "./projections/replayMarkerCheck";
-import { ConfigurationError } from "./services/errorHandling";
-
 import { projectDailySdkUsageProjection } from "./projections/global/projectDailySdkUsage.foldProjection";
+import { createStorageMeterDispatchReactor } from "./projections/global/storageMeterDispatch.reactor";
 import { ProjectionRegistry } from "./projections/projectionRegistry";
+import { RedisReplayMarkerChecker } from "./projections/replayMarkerCheck";
 import type { EventSourcedQueueProcessor } from "./queues";
 import { GroupQueueProcessor } from "./queues/groupQueue/groupQueue";
 import { EventSourcedQueueProcessorMemory } from "./queues/memory";
+import type { ReactorDefinition } from "./reactors/reactor.types";
 import { EventSourcingPipeline } from "./runtimePipeline";
+import { ConfigurationError } from "./services/errorHandling";
 import type { JobRegistryEntry } from "./services/queues/queueManager";
 import type { EventStore } from "./stores/eventStore.types";
 import { EventStoreClickHouse } from "./stores/eventStoreClickHouse";
@@ -51,6 +51,16 @@ export interface EventSourcingOptions {
   isSaas?: boolean; // defaults to false
   processRole?: ProcessRole;
   retentionPolicyResolver?: RetentionPolicyResolver;
+  /**
+   * ADR-027 Phase 4: lazy accessor for the storage meter dispatch (the
+   * app-layer brain that measures sealed hours and enqueues report commands).
+   * Lazy because the app-layer service is built after EventSourcing. When
+   * provided (SaaS), a storageMeterDispatch reactor is registered alongside the
+   * billing one on the orgBillableEventsMeter projection.
+   */
+  getStorageMeterDispatch?: () => (params: {
+    organizationId: string;
+  }) => Promise<void>;
 }
 
 /**
@@ -133,6 +143,14 @@ export class EventSourcing {
           },
         }),
       );
+      if (options.getStorageMeterDispatch) {
+        this.projectionRegistry.registerMapReactor(
+          "orgBillableEventsMeter",
+          createStorageMeterDispatchReactor({
+            getDispatch: options.getStorageMeterDispatch,
+          }),
+        );
+      }
     }
   }
 
@@ -157,7 +175,10 @@ export class EventSourcing {
       this.projectionRegistry.registerReactor(foldName, reactor);
     } catch (error) {
       // Only suppress "fold not registered" errors — let wiring bugs (duplicates, etc.) fail fast
-      if (error instanceof ConfigurationError && error.message.includes("fold not registered")) {
+      if (
+        error instanceof ConfigurationError &&
+        error.message.includes("fold not registered")
+      ) {
         logger.debug(
           { foldName, reactorName: reactor.name },
           "Skipping global fold reactor — fold not registered",

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportStorageForHour.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportStorageForHour.command.unit.test.ts
@@ -227,6 +227,23 @@ describe("ReportStorageForHourCommand", () => {
     });
   });
 
+  describe("given a zero-megabyte hour", () => {
+    /** @scenario A zero-megabyte hour is marked reported without a billing call */
+    it("stamps the cursor without calling Stripe", async () => {
+      mockStorageUsageHourly.findHour.mockResolvedValue({
+        megabytes: 0,
+        reportedAt: null,
+      });
+      const handler = await createHandler();
+
+      const result = await handler.handle(makeCommand());
+
+      expect(result).toEqual([]);
+      expect(mockReportUsageDelta).not.toHaveBeenCalled();
+      expect(mockStorageUsageHourly.markReported).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("when the meter event already exists on Stripe", () => {
     /** @scenario A Stripe duplicate is treated as already reported */
     it("treats the duplicate as reported and stamps the cursor without a failure", async () => {
@@ -345,6 +362,54 @@ describe("ReportStorageForHourCommand", () => {
       expect(
         mockStorageBillingCheckpoints.recordFailure,
       ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a single permanently-rejected hour then a healthy hour", () => {
+    // Anti-starvation guard: one poison hour cannot trip the breaker. A permanent
+    // rejection is one-shot (no self-dispatch), and nothing re-drives an
+    // unreported hour — the dispatcher advances by max(measured hour), not by
+    // reportedAt — so the failure count only ever reaches 1 from it, and the next
+    // healthy hour clears it. The breaker only trips on *systemic* failure.
+    it("bumps the breaker to one, then the next success clears it", async () => {
+      // 1st hour: permanent rejection from a clean breaker → failures = 1.
+      mockStorageBillingCheckpoints.getCheckpoint.mockResolvedValueOnce(null);
+      mockStorageUsageHourly.findHour.mockResolvedValueOnce({
+        megabytes: 42,
+        reportedAt: null,
+      });
+      mockReportUsageDelta.mockResolvedValueOnce([
+        { reported: false, error: "invalid_request" },
+      ]);
+
+      await (await createHandler()).handle(makeCommand("org-1", SEALED_HOUR));
+
+      expect(mockStorageBillingCheckpoints.recordFailure).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        billingMonth: EXPECTED_MONTH,
+        consecutiveFailures: 1,
+      });
+
+      // 2nd hour: healthy, breaker now at 1 → success clears it to 0.
+      mockStorageBillingCheckpoints.getCheckpoint.mockResolvedValueOnce({
+        lastReportedTotal: 0,
+        pendingReportedTotal: null,
+        consecutiveFailures: 1,
+      });
+      mockStorageUsageHourly.findHour.mockResolvedValueOnce({
+        megabytes: 7,
+        reportedAt: null,
+      });
+      mockReportUsageDelta.mockResolvedValueOnce([{ reported: true }]);
+
+      await (await createHandler()).handle(
+        makeCommand("org-1", "2026-02-15T13:00:00.000Z"),
+      );
+
+      expect(mockStorageBillingCheckpoints.recordSuccess).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        billingMonth: EXPECTED_MONTH,
+      });
     });
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportStorageForHour.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportStorageForHour.command.ts
@@ -213,6 +213,21 @@ export class ReportStorageForHourCommand
       );
       return false;
     }
+    if (hour.megabytes === 0) {
+      // Nothing to bill for a 0-MiB hour (e.g. a default-keep org with no data
+      // older than the free window — every hour is 0). Stamp the cursor so it
+      // never re-dispatches, without a wasted 0-value Stripe call each hour.
+      await this.deps.storageUsageHourly.markReported({
+        organizationId,
+        sealedHour: sealedHourDate,
+        reportedAt: new Date(),
+      });
+      logger.debug(
+        { organizationId, sealedHour },
+        "zero-MiB hour, marked reported without a Stripe call",
+      );
+      return false;
+    }
 
     const usageReportingService = this.deps.getUsageReportingService();
     if (!usageReportingService) {

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportStorageForHour.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportStorageForHour.command.ts
@@ -6,6 +6,7 @@ import {
   withScope,
 } from "~/utils/posthogErrorCapture";
 import type { UsageReportingService } from "../../../../../../ee/billing/services/usageReportingService";
+import { STORAGE_METER_EVENT_NAME } from "../../../../../../ee/billing/stripe/storagePricing";
 import type { StorageBillingCheckpointService } from "../../../../app-layer/billing/storageBillingCheckpoint.service";
 import type { StorageUsageHourlyRepository } from "../../../../app-layer/billing/storageUsageHourly.repository";
 import type { OrganizationService } from "../../../../app-layer/organizations/organization.service";
@@ -19,9 +20,6 @@ import { BILLING_REPORT_COMMAND_TYPES } from "../schemas/constants";
 const logger = createLogger(
   "langwatch:billing-reporting:report-storage-for-hour",
 );
-
-/** Stripe meter event name for additive hourly storage (MiB). */
-const STORAGE_MEGABYTES_EVENT_NAME = "langwatch_storage_megabytes_hourly";
 
 /** Maximum consecutive failures before the circuit-breaker trips. */
 const MAX_CONSECUTIVE_FAILURES = 5;
@@ -233,7 +231,7 @@ export class ReportStorageForHourCommand
         organizationId,
         events: [
           {
-            eventName: STORAGE_MEGABYTES_EVENT_NAME,
+            eventName: STORAGE_METER_EVENT_NAME,
             identifier,
             timestamp: Math.floor(sealedHourDate.getTime() / 1000),
             value: hour.megabytes,

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/storageMeterDispatch.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/storageMeterDispatch.reactor.unit.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the thin storage meter dispatch reactor (ADR-027 Phase 4):
+ * it resolves the org from the event's project and delegates to the injected
+ * dispatch, swallowing errors so a transient failure never fails the queue job.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+const { mockResolveOrganizationId, createMockLogger } = vi.hoisted(() => {
+  const createMockLogger = () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => createMockLogger()),
+  });
+  return { mockResolveOrganizationId: vi.fn(), createMockLogger };
+});
+
+vi.mock("~/server/organizations/resolveOrganizationId", () => ({
+  resolveOrganizationId: mockResolveOrganizationId,
+}));
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: vi.fn(() => createMockLogger()),
+}));
+
+import { createStorageMeterDispatchReactor } from "../storageMeterDispatch.reactor";
+
+const event = {} as any;
+const context = { tenantId: "proj-1", aggregateId: "a", foldState: {} } as any;
+
+describe("createStorageMeterDispatchReactor", () => {
+  it("runs only in worker with per-project dedup", () => {
+    const reactor = createStorageMeterDispatchReactor({
+      getDispatch: () => vi.fn(),
+    });
+    expect(reactor.name).toBe("storageMeterDispatch");
+    expect(reactor.options!.runIn).toEqual(["worker"]);
+    expect(
+      reactor.options!.makeJobId!({ event: { tenantId: "proj-1" } } as any),
+    ).toBe("storage_dispatch_proj-1");
+  });
+
+  describe("when the project resolves to an organization", () => {
+    it("delegates to the dispatch with the organization id", async () => {
+      mockResolveOrganizationId.mockResolvedValue("org-1");
+      const dispatch = vi.fn().mockResolvedValue(undefined);
+      const reactor = createStorageMeterDispatchReactor({
+        getDispatch: () => dispatch,
+      });
+
+      await reactor.handle(event, context);
+
+      expect(dispatch).toHaveBeenCalledWith({ organizationId: "org-1" });
+    });
+  });
+
+  describe("when the project has no organization", () => {
+    it("skips dispatch", async () => {
+      mockResolveOrganizationId.mockResolvedValue(null);
+      const dispatch = vi.fn();
+      const reactor = createStorageMeterDispatchReactor({
+        getDispatch: () => dispatch,
+      });
+
+      await reactor.handle(event, context);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when dispatch throws", () => {
+    it("swallows the error so the queue job does not fail", async () => {
+      mockResolveOrganizationId.mockResolvedValue("org-1");
+      const reactor = createStorageMeterDispatchReactor({
+        getDispatch: () => vi.fn().mockRejectedValue(new Error("boom")),
+      });
+
+      await expect(reactor.handle(event, context)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/storageMeterDispatch.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/storageMeterDispatch.reactor.unit.test.ts
@@ -91,7 +91,7 @@ describe("createStorageMeterDispatchReactor", () => {
       await expect(reactor.handle(event, context)).resolves.toBeUndefined();
     });
 
-    /** @scenario A persistent dispatch failure surfaces to Sentry, not just a log */
+    // Regression test for a review finding, not a new feature scenario.
     it("reports the error via captureException", async () => {
       mockResolveOrganizationId.mockResolvedValue("org-1");
       mockCaptureException.mockClear();

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/storageMeterDispatch.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/storageMeterDispatch.reactor.unit.test.ts
@@ -6,22 +6,34 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-const { mockResolveOrganizationId, createMockLogger } = vi.hoisted(() => {
-  const createMockLogger = () => ({
-    info: vi.fn(),
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    child: vi.fn(() => createMockLogger()),
+const { mockResolveOrganizationId, mockCaptureException, createMockLogger } =
+  vi.hoisted(() => {
+    const createMockLogger = () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(() => createMockLogger()),
+    });
+    return {
+      mockResolveOrganizationId: vi.fn(),
+      mockCaptureException: vi.fn(),
+      createMockLogger,
+    };
   });
-  return { mockResolveOrganizationId: vi.fn(), createMockLogger };
-});
 
 vi.mock("~/server/organizations/resolveOrganizationId", () => ({
   resolveOrganizationId: mockResolveOrganizationId,
 }));
 vi.mock("~/utils/logger/server", () => ({
   createLogger: vi.fn(() => createMockLogger()),
+}));
+vi.mock("~/utils/posthogErrorCapture", () => ({
+  captureException: mockCaptureException,
+  toError: vi.fn((e) => (e instanceof Error ? e : new Error(String(e)))),
+  withScope: vi.fn((cb: (scope: Record<string, unknown>) => void) => {
+    cb({ setTag: vi.fn(), setExtra: vi.fn() });
+  }),
 }));
 
 import { createStorageMeterDispatchReactor } from "../storageMeterDispatch.reactor";
@@ -77,6 +89,21 @@ describe("createStorageMeterDispatchReactor", () => {
       });
 
       await expect(reactor.handle(event, context)).resolves.toBeUndefined();
+    });
+
+    /** @scenario A persistent dispatch failure surfaces to Sentry, not just a log */
+    it("reports the error via captureException", async () => {
+      mockResolveOrganizationId.mockResolvedValue("org-1");
+      mockCaptureException.mockClear();
+      const reactor = createStorageMeterDispatchReactor({
+        getDispatch: () => vi.fn().mockRejectedValue(new Error("boom")),
+      });
+
+      await reactor.handle(event, context);
+
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "boom" }),
+      );
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/projections/global/storageMeterDispatch.reactor.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/storageMeterDispatch.reactor.ts
@@ -1,0 +1,53 @@
+import { resolveOrganizationId } from "~/server/organizations/resolveOrganizationId";
+import { createLogger } from "~/utils/logger/server";
+import type { Event } from "../../domain/types";
+import type { ReactorDefinition } from "../../reactors/reactor.types";
+
+const logger = createLogger("langwatch:billing:storageMeterDispatch");
+
+/**
+ * Reactor that advances an organization's storage-billing cursor after the
+ * orgBillableEventsMeter map projection succeeds (ADR-027 Phase 4).
+ *
+ * Deliberately thin: it resolves the org from the event's project and delegates
+ * the measure → persist → enqueue work to the injected dispatch (the app-layer
+ * StorageMeterDispatchService). The event is only a wake-up — what gets measured
+ * is "sealed hours not yet done", computed from the wall clock and the durable
+ * cursor, so the reactor needs neither the event payload nor in-memory state.
+ *
+ * Per-project dedup (`storage_dispatch_${projectId}`, 300s) bounds how often the
+ * (idempotent) catch-up runs; `runIn: ["worker"]` keeps it off web processes and
+ * grants a free cluster-wide kill switch via registration.
+ */
+export function createStorageMeterDispatchReactor(deps: {
+  getDispatch: () => (params: { organizationId: string }) => Promise<void>;
+}): ReactorDefinition<Event> {
+  return {
+    name: "storageMeterDispatch",
+    options: {
+      runIn: ["worker"],
+      makeJobId: (payload) => `storage_dispatch_${payload.event.tenantId}`,
+      ttl: 300_000,
+    },
+
+    async handle(_event, context) {
+      const organizationId = await resolveOrganizationId(context.tenantId);
+      if (!organizationId) {
+        logger.warn(
+          { projectId: context.tenantId },
+          "orphan project detected, has no organization -- skipping storage dispatch",
+        );
+        return;
+      }
+
+      try {
+        await deps.getDispatch()({ organizationId });
+      } catch (error) {
+        logger.warn(
+          { organizationId, error },
+          "storage meter dispatch failed; measured rows are durable, will retry on the next event",
+        );
+      }
+    },
+  };
+}

--- a/langwatch/src/server/event-sourcing/projections/global/storageMeterDispatch.reactor.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/storageMeterDispatch.reactor.ts
@@ -1,5 +1,10 @@
 import { resolveOrganizationId } from "~/server/organizations/resolveOrganizationId";
 import { createLogger } from "~/utils/logger/server";
+import {
+  captureException,
+  toError,
+  withScope,
+} from "~/utils/posthogErrorCapture";
 import type { Event } from "../../domain/types";
 import type { ReactorDefinition } from "../../reactors/reactor.types";
 
@@ -43,10 +48,19 @@ export function createStorageMeterDispatchReactor(deps: {
       try {
         await deps.getDispatch()({ organizationId });
       } catch (error) {
+        // Measured rows are durable and the next event retries, so this never
+        // fails the queue job — but unlike a transient blip, a *persistent*
+        // outage here has no other signal (no breaker, no page): surface every
+        // occurrence to Sentry, mirroring reportStorageForHour.command.ts.
         logger.warn(
           { organizationId, error },
           "storage meter dispatch failed; measured rows are durable, will retry on the next event",
         );
+        await withScope(async (scope) => {
+          scope.setTag?.("handler", "storageMeterDispatch");
+          scope.setExtra?.("organizationId", organizationId);
+          captureException(toError(error));
+        });
       }
     },
   };

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -147,6 +147,28 @@ export const FEATURE_FLAGS = [
     description:
       "Gates the personal keys, admin oversight, RoutingPolicy, and IngestionSource UI surfaces. Distinct from release_ui_ai_gateway_menu_enabled — the existing gateway product ships unblocked while governance keeps cooking.",
   },
+  // ADR-027 storage billing (Phase 4/4.5). Master gate: OFF → the storage
+  // meter-dispatch reactor runs zero ClickHouse queries, writes zero rows, and
+  // enqueues zero report commands. Given `_size_bytes` aggregation has caused
+  // two prod OOM outages, an operator must be able to kill metering without a
+  // deploy or a Stripe change.
+  {
+    key: "release_storage_billing_metering",
+    scope: "PRODUCT",
+    defaultValue: false,
+    description:
+      "Gates ADR-027 storage-GiB-hours metering: the storageMeterDispatch reactor's measure + enqueue. OFF (default) makes the meter fully inert (no CH, no Postgres rows, no Stripe). Per-organization.",
+  },
+  // Second, independent flag for the measure-time tripwire: shadow-compute a
+  // reference value alongside the billed measurement and log on divergence. Can
+  // be enabled/disabled separately from metering itself.
+  {
+    key: "release_storage_billing_metering_tripwire",
+    scope: "PRODUCT",
+    defaultValue: false,
+    description:
+      "Enables the ADR-027 measure-time tripwire: shadow-compare the billed storage measurement against a reference and log a capped warning on divergence. Never affects the billed value; safe to toggle independently.",
+  },
 ] as const satisfies readonly FeatureFlagDefinition[];
 
 export const FEATURE_FLAG_FAMILIES = [

--- a/specs/data-retention/storage-billing-backfill.feature
+++ b/specs/data-retention/storage-billing-backfill.feature
@@ -1,0 +1,40 @@
+Feature: Storage billing — SubscriptionItem backfill (ADR-027, Phase 7)
+  As the storage-billing rollout
+  I want to attach the STORAGE_GB item to existing paid subscriptions idempotently
+  So that customers begin accruing storage usage on the announced date without re-checkout or disruption
+
+  # Runs only after the customer notice, on the announced date. Idempotent (safe to re-run and to run
+  # alongside live traffic): an already-attached item is skipped, a subscription with no matching
+  # storage price is skipped and counted (never guessed), and one failure never aborts the run. Free
+  # and self-hosted orgs never appear — the source lists paid subscriptions only. A dry-run reports
+  # what it would do without mutating Stripe.
+
+  @unit
+  Scenario: The storage item is attached to a paid subscription that lacks it
+    Given a paid subscription without the STORAGE_GB item and a resolvable price
+    When the backfill runs
+    Then the item is attached to that subscription
+
+  @unit
+  Scenario: A subscription that already has the item is skipped (idempotent)
+    Given a paid subscription that already carries the STORAGE_GB item
+    When the backfill runs
+    Then the item is not attached again
+
+  @unit
+  Scenario: A subscription with no matching storage price is skipped, never guessed
+    Given a paid subscription whose plan, currency, and interval have no storage price
+    When the backfill runs
+    Then the item is not attached and the subscription is counted as skipped
+
+  @unit
+  Scenario: A dry-run reports what it would attach without mutating Stripe
+    Given a paid subscription without the item
+    When the backfill runs as a dry-run
+    Then Stripe is not mutated but the would-be attach is reported
+
+  @unit
+  Scenario: One subscription's failure does not abort the whole backfill
+    Given several paid subscriptions where attaching one fails
+    When the backfill runs
+    Then the remaining subscriptions are still processed and the failure is counted

--- a/specs/data-retention/storage-billing-dispatch.feature
+++ b/specs/data-retention/storage-billing-dispatch.feature
@@ -39,6 +39,13 @@ Feature: Storage billing — dispatch sealed hours for measurement (ADR-027, Pha
     Then no new hour is measured and no report is enqueued
 
   @unit
+  Scenario: Concurrent dispatches for the same organization are collapsed to one
+    Given a dispatch already in progress for the organization
+    When another of the organization's projects triggers a dispatch
+    Then the second dispatch measures nothing
+    And the heavy measurement is not re-run per project
+
+  @unit
   Scenario: Every sealed hour since the cursor is measured and enqueued once
     Given an organization whose cursor trails the latest sealed hour by several hours
     When the dispatcher runs for the organization

--- a/specs/data-retention/storage-billing-dispatch.feature
+++ b/specs/data-retention/storage-billing-dispatch.feature
@@ -66,6 +66,13 @@ Feature: Storage billing — dispatch sealed hours for measurement (ADR-027, Pha
     Then only the most recent hours up to the ceiling are measured
     And an alarm is logged that older hours were dropped
 
+  @unit
+  Scenario: A large catch-up measures at most the per-run cap and defers the rest
+    Given an organization whose cursor trails by more than one run's measurement cap but within the ceiling
+    When the dispatcher runs for the organization
+    Then at most the per-run cap of hours are measured this run
+    And the remaining hours are left for a later run without an alarm
+
   # ---------------------------------------------------------------------------
   # Per-hour contract
   # ---------------------------------------------------------------------------

--- a/specs/data-retention/storage-billing-dispatch.feature
+++ b/specs/data-retention/storage-billing-dispatch.feature
@@ -1,0 +1,83 @@
+Feature: Storage billing — dispatch sealed hours for measurement (ADR-027, Phase 4)
+  As the storage-billing pipeline
+  I want each org's newly-sealed hours measured and queued for reporting exactly once
+  So that storage billing advances automatically without a cron or leader lock
+
+  # An org-attributed event wakes the dispatcher, which catches the org's hourly cursor up to the
+  # last COMPLETE wall-clock hour: for every sealed hour not yet measured it measures the billable
+  # bytes, writes one StorageUsageHourly row (insert-if-absent), and enqueues one report command.
+  # The whole thing is gated by a master flag (default OFF → fully inert), runs only for SaaS-billable
+  # orgs, and is bounded at the Stripe timestamp ceiling. Stateless: the cursor is the durable table,
+  # read per run, so it is correct across pods and restarts.
+
+  # ---------------------------------------------------------------------------
+  # Gating + short-circuit (zero work for orgs that should not be metered)
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Metering disabled makes the dispatcher fully inert
+    Given the storage-metering flag is off for the organization
+    When the dispatcher runs for the organization
+    Then no storage is measured
+    And no row is written and no report is enqueued
+
+  @unit
+  Scenario: A non-billable organization is skipped before any measurement
+    Given an organization with no Stripe customer or no active subscription
+    When the dispatcher runs for the organization
+    Then the billable-storage measurement is never queried
+    And no row is written and no report is enqueued
+
+  # ---------------------------------------------------------------------------
+  # Cursor advance + gap fill
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A caught-up organization does no work
+    Given an organization whose last measured hour is the most recent sealed hour
+    When the dispatcher runs for the organization
+    Then no new hour is measured and no report is enqueued
+
+  @unit
+  Scenario: Every sealed hour since the cursor is measured and enqueued once
+    Given an organization whose cursor trails the latest sealed hour by several hours
+    When the dispatcher runs for the organization
+    Then each missing sealed hour up to the latest is measured in order
+    And one row is written and one report is enqueued per measured hour
+
+  @unit
+  Scenario: A brand-new organization starts at the latest sealed hour, not its whole history
+    Given an organization that has never been measured
+    When the dispatcher runs for the organization
+    Then only the most recent sealed hour is measured
+    And the organization's earlier history is not backfilled
+
+  @unit
+  Scenario: A gap beyond the billing ceiling is truncated with an alarm
+    Given an organization whose cursor trails the latest sealed hour by more than the backfill ceiling
+    When the dispatcher runs for the organization
+    Then only the most recent hours up to the ceiling are measured
+    And an alarm is logged that older hours were dropped
+
+  # ---------------------------------------------------------------------------
+  # Per-hour contract
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Each measured hour is rounded up to whole megabytes
+    Given a sealed hour whose billable bytes are measured
+    When the dispatcher records the hour
+    Then the stored megabytes are the bytes rounded up to the next whole megabyte
+
+  @unit
+  Scenario: Recording an hour does not clobber one that already exists
+    Given a sealed hour that was already measured and possibly already reported
+    When the dispatcher records the same hour again
+    Then the existing row is left untouched
+
+  @unit
+  Scenario: A measurement failure stops the run without skipping the hour
+    Given a sealed hour whose measurement fails
+    When the dispatcher runs for the organization
+    Then the failing hour is not recorded and the run stops
+    And later hours are not measured past the failure so no hour is silently skipped

--- a/specs/data-retention/storage-billing-hour-reporting.feature
+++ b/specs/data-retention/storage-billing-hour-reporting.feature
@@ -48,6 +48,13 @@ Feature: Storage billing — report a sealed hour to Stripe (ADR-027, Phase 3)
     And the hour's reported state is left unchanged
 
   @unit
+  Scenario: A zero-megabyte hour is marked reported without a billing call
+    Given a measured hour of zero megabytes that has not yet been reported
+    When the hour is reported
+    Then no meter event is sent
+    And the hour is marked reported so it is not dispatched again
+
+  @unit
   Scenario: A Stripe duplicate is treated as already reported
     Given a measured hour whose meter event already exists on Stripe
     When the hour is reported

--- a/specs/data-retention/storage-billing-pricing.feature
+++ b/specs/data-retention/storage-billing-pricing.feature
@@ -1,0 +1,39 @@
+Feature: Storage billing — price contract (ADR-027, Phase 5)
+  As the storage-billing pipeline
+  I want the per-MiB-hour unit price pinned to the €3/GiB-month headline
+  So that the Stripe meter bills the agreed rate and a catalog edit cannot silently drift it
+
+  # The STORAGE_GB meter sums additive hourly MiB values over the period; one static
+  # unit_amount_decimal applied to that sum is the bill. Quantities are binary (MiB = bytes/1_048_576,
+  # GiB = 1024 MiB); we bill LOGICAL (uncompressed) volume. These scenarios pin the price math so the
+  # externally-created Stripe Price can be checked against it and never diverge unnoticed.
+
+  @unit
+  Scenario: The headline storage price is €3 per logical GiB-month
+    Given the storage pricing contract
+    When the headline price is read
+    Then it is €3 per GiB-month on the 30-day-month convention
+
+  @unit
+  Scenario: The unit price derives from the headline by the documented formula
+    Given the €3 per GiB-month headline
+    When the per-MiB-hour unit price is derived
+    Then it equals the headline divided by 30 days, 24 hours, and 1024 MiB per GiB
+
+  @unit
+  Scenario: The Stripe unit_amount_decimal is pinned in cents per MiB-hour
+    Given the per-MiB-hour unit price
+    When it is expressed as the Stripe unit_amount_decimal
+    Then it is the price in cents per MiB-hour, pinned so the catalog cannot drift
+
+  @unit
+  Scenario: The unit price round-trips to the €0.10 per GiB-day headline
+    Given the per-MiB-hour unit price
+    When a full GiB held for a day is priced
+    Then the cost is €0.10 per GiB-day
+
+  @unit
+  Scenario: The meter is additive and named to match the report command
+    Given the STORAGE_GB meter configuration
+    When its aggregation and event name are read
+    Then it sums the hourly event that the report command sends

--- a/specs/data-retention/storage-billing-reconciliation.feature
+++ b/specs/data-retention/storage-billing-reconciliation.feature
@@ -1,0 +1,33 @@
+Feature: Storage billing — reconciliation safety net (ADR-027, Phase 7)
+  As finance
+  I want the recorded storage totals periodically diffed against Stripe's meter totals
+  So that any drift between what we think we billed and what Stripe recorded is caught
+
+  # Off the critical path, observational only. Per org/period it compares Σ StorageUsageHourly.megabytes
+  # (reportedAt set) against Stripe's own meter total and logs a drift error beyond a small tolerance —
+  # catching anything the idempotency layers and the measure-time tripwire missed (e.g. a report the
+  # cursor marked done that Stripe never accepted). It never mutates anything.
+
+  @unit
+  Scenario: Matching totals report no drift
+    Given an organization whose recorded and Stripe totals match within tolerance
+    When the period is reconciled
+    Then no drift is logged
+
+  @unit
+  Scenario: Divergent totals are flagged as drift
+    Given an organization whose recorded and Stripe totals diverge beyond tolerance
+    When the period is reconciled
+    Then a drift error is logged
+
+  @unit
+  Scenario: An unavailable Stripe total is skipped, never a false drift
+    Given an organization whose Stripe meter total cannot be fetched
+    When the period is reconciled
+    Then the organization is counted as unavailable and no drift is flagged
+
+  @unit
+  Scenario: Each organization is reconciled independently
+    Given several organizations where only one drifts
+    When the period is reconciled
+    Then every organization is checked and only the drifting one is flagged

--- a/specs/data-retention/storage-billing-tripwire.feature
+++ b/specs/data-retention/storage-billing-tripwire.feature
@@ -1,0 +1,51 @@
+Feature: Storage billing — measure-time tripwire (ADR-027, Phase 4.5)
+  As the storage-billing pipeline
+  I want each billed measurement shadow-compared against an independent reference
+  So that a wrong value is caught and logged before it bills, without ever risking the measure path
+
+  # The tripwire is purely observational: behind its own flag, it computes an independent reference
+  # for the same hour and logs a capped warning when the measurement diverges beyond tolerance. It
+  # must never alter the billed value and never throw into the measure/report path — every failure is
+  # swallowed. Given `_size_bytes` aggregation caused two prod OOMs, a bad value must be visible early.
+
+  @unit
+  Scenario: A disabled tripwire does nothing
+    Given the tripwire flag is off for the organization
+    When a measurement is checked
+    Then no reference is computed and nothing is logged
+
+  @unit
+  Scenario: No reference means no comparison
+    Given the tripwire is enabled but no reference is available
+    When a measurement is checked
+    Then nothing is logged
+
+  @unit
+  Scenario: A measurement within tolerance is silent
+    Given a measurement within the tolerance of its reference
+    When it is checked
+    Then nothing is logged
+
+  @unit
+  Scenario: A divergent measurement is warned once
+    Given a measurement that diverges beyond the tolerance
+    When it is checked
+    Then a divergence warning is logged
+
+  @unit
+  Scenario: Divergence logging is capped so a broken reference can't flood logs
+    Given repeated divergent measurements past the log cap
+    When they are checked
+    Then no more than the capped number of warnings are logged
+
+  @unit
+  Scenario: The log cap resets each window so later divergence isn't silenced forever
+    Given the log cap was reached in one window
+    When a divergent measurement is checked after the window elapses
+    Then a warning is logged again
+
+  @unit
+  Scenario: The tripwire never throws into the measure path
+    Given the reference computation fails
+    When a measurement is checked
+    Then the check resolves without throwing and logs no divergence


### PR DESCRIPTION
## What

Phase 4 of ADR-027. The dispatcher that drives storage billing — **no cron, no leader lock**. A second map-reactor on `orgBillableEventsMeter` that, on each org-attributed event, advances the org's hourly cursor: measures every newly-sealed hour, persists a `StorageUsageHourly` row, and enqueues a `ReportStorageForHourCommand` (Phase 3).

## Design

- **Thin reactor / fat service.** `storageMeterDispatch.reactor.ts` only resolves the org from the event's project and delegates to the app-layer `StorageMeterDispatchService` (the brain) — swallowing errors so a transient failure never fails the queue job. `runIn:["worker"]`, per-project dedup (`storage_dispatch_<proj>`, 300s), and a free cluster-wide kill switch via registration.
- **Stateless cursor.** The cursor is `getLastMeasuredHour` read from the durable table **each run** — correct across pods and restarts, no in-memory state. The per-project 300s dedup bounds how often the (idempotent) catch-up runs.
- **The event is just a wake-up.** What gets measured is "sealed hours not yet done", computed from the wall clock (`floor(now)-1h`) — so a late event can't under-catch-up.
- **Gap-fill:** measure → `recordHour` (insert-if-absent) → enqueue, per sealed hour. **Forward-only** for a brand-new org (never backfill its whole history). Gap bounded at **840h** (Stripe's timestamp ceiling) with an **alarm** when truncated — never silent. A measurement failure **stops the run** (no silent under-bill); progress is durable per hour, so the next wake-up resumes.

## Robustness (Phase 4.5 gating)

- **Two PRODUCT flags registered** (default OFF): `release_storage_billing_metering` (master gate — OFF makes the whole dispatch **fully inert**: zero CH queries, zero rows, zero enqueues, given the `_size_bytes` two-OOM history) and `release_storage_billing_metering_tripwire`.
- **Kill switch** is free via reactor registration (`es-…-killswitch`).
- **SaaS short-circuit** runs before any ClickHouse query — free / self-hosted / no-subscription orgs never enter the loop.

## Review findings folded in (from langwatch/langwatch#5225)
- **Dedup key** normalized: the enqueued command carries the canonical ISO `sealedHour`, so the queue dedup and the Stripe identifier agree.
- **Stripe-timestamp bound**: the 840h ceiling keeps reported hours inside Stripe's acceptance window.
- **Poison-hour (P2):** a failing measurement stops catch-up rather than silently skipping — the right failure mode (alarm + resume), not a silent hole. The dispatcher-level dead-letter for a *report*-rejected hour remains a Phase 6 wire-up item.

## Review findings folded in (from this PR's own review, @Aryansharma28)
- **Orphaned unreported hours (P0):** `recordHour` committing and the subsequent `enqueueReport` throwing (Redis blip, ES validation error) left the hour `reportedAt: null` forever — the cursor only checks row existence, so it skipped right past the orphan and nothing swept `reportedAt IS NULL`. `catchUp` now re-enqueues any hour still unreported past a 10-minute grace window, before the forward gap-fill.
- **Redis lock had no fencing token (P0):** the per-org dispatch lock stored a fixed value with an unconditional `del` on release. A TTL expiry mid-run (the old 120s was far short of the worst case) let a second process acquire the lock, then the first process's release deleted the second process's live lock — reopening the exact concurrent-heavy-measurement race the lock exists to prevent. Fixed with a `randomUUID` fencing token (mirrors `ReplayRedisRepository`) and a TTL derived from the true worst case (`STORAGE_MAX_HOURS_PER_RUN` × the ClickHouse query's own `max_execution_time`, 2x margin) instead of a flat guess.
- **Silent unguarded fallback (P2):** when `config.isSaas` is true but Redis is unavailable, the dispatch now logs a warning once instead of silently running every org's measurement unguarded with no operator signal.
- **No escalation on persistent dispatch failures (P2):** the reactor now routes errors through the same `withScope`/`captureException` pattern `reportStorageForHour.command.ts` already uses, so a sustained outage surfaces in Sentry instead of only a warn log. Skipped the suggested shared consecutive-failure counter — reusing `StorageBillingCheckpoint` would conflate Stripe-rejection failures with dispatch-level CH/queue failures on one breaker; Sentry visibility closes the actual gap without that risk.

## Deferred to Phase 6 (honest scope)
The **tripwire module** + **integration parity test** need a real, cheap CH reference and the live Stripe path — neither exists until wire-up. A placeholder reference would be theater or re-run the heavy query (the OOM hazard). The flags are registered now so the operator levers exist; the drift guard lands with the meter going live.

## Tests
- `specs/data-retention/storage-billing-dispatch.feature` — 9 `@unit` scenarios, all bound.
- `storageMeterDispatch.service.unit.test.ts` (13): flag-off inert, non-billable skip, caught-up no-op, gap-fill order + one-row-one-report per hour, new-org forward-only, 840h truncation + alarm, ceil-to-MiB, insert-if-absent, measurement-failure stops-run, orphaned-hour re-enqueued, orphan-retry-failure doesn't abort the run.
- `storageMeterDispatch.reactor.unit.test.ts` (5): worker/dedup options, delegates with org id, orphan skip, error swallowed, persistent failure reported via `captureException`.

`pnpm typecheck` clean, feature-parity OK. Full ES→Prisma→CH integration deferred to warike verification (consistent with Phase 2/3).

Stacks on langwatch/langwatch#5225 (reporting command).