### PR TITLE
feat(billing): storage price contract + pin guard (ADR-027 Phase 5, code side)

### DIFF
--- a/langwatch/ee/billing/stripe/__tests__/storagePricing.unit.test.ts
+++ b/langwatch/ee/billing/stripe/__tests__/storagePricing.unit.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Price-pin guard for ADR-027 storage billing. These constants ARE the pricing
+ * contract; a silent edit here (or a divergent catalog `unit_amount_decimal`)
+ * would mis-bill every customer. The test pins the headline, the derived unit
+ * price, and the round-trip so a change forces an explicit, reviewed update.
+ *
+ * @see specs/data-retention/storage-billing-pricing.feature
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  STORAGE_EUR_PER_GIB_DAY,
+  STORAGE_EUR_PER_GIB_MONTH,
+  STORAGE_EUR_PER_MIB_HOUR,
+  STORAGE_METER_AGGREGATION,
+  STORAGE_METER_EVENT_NAME,
+  STORAGE_UNIT_AMOUNT_DECIMAL_CENTS_PER_MIB_HOUR,
+} from "../storagePricing";
+
+describe("ADR-027 storage pricing", () => {
+  describe("given the headline price", () => {
+    /** @scenario The headline storage price is €3 per logical GiB-month */
+    it("is €3 per GiB-month on the 30-day convention", () => {
+      expect(STORAGE_EUR_PER_GIB_MONTH).toBe(3);
+    });
+  });
+
+  describe("when the per-MiB-hour unit price is derived", () => {
+    /** @scenario The unit price derives from the headline by the documented formula */
+    it("equals headline / (30 days × 24 hours × 1024 MiB)", () => {
+      expect(STORAGE_EUR_PER_MIB_HOUR).toBe(3 / (30 * 24 * 1024));
+      // ≈ €0.00000407 per MiB-hour (the ADR headline).
+      expect(STORAGE_EUR_PER_MIB_HOUR).toBeCloseTo(0.00000407, 8);
+    });
+
+    /** @scenario The Stripe unit_amount_decimal is pinned in cents per MiB-hour */
+    it("pins unit_amount_decimal to cents per MiB-hour so the catalog can't drift", () => {
+      expect(STORAGE_UNIT_AMOUNT_DECIMAL_CENTS_PER_MIB_HOUR).toBe(
+        STORAGE_EUR_PER_MIB_HOUR * 100,
+      );
+      // ≈ 0.0004069 cents per MiB-hour.
+      expect(STORAGE_UNIT_AMOUNT_DECIMAL_CENTS_PER_MIB_HOUR).toBeCloseTo(
+        0.0004069,
+        7,
+      );
+    });
+  });
+
+  describe("when the headline is reconstructed from the unit price", () => {
+    /** @scenario The unit price round-trips to the €0.10 per GiB-day headline */
+    it("yields €0.10 per GiB-day", () => {
+      expect(STORAGE_EUR_PER_GIB_DAY).toBeCloseTo(0.1, 12);
+    });
+  });
+
+  describe("given the meter configuration", () => {
+    /** @scenario The meter is additive and named to match the report command */
+    it("sums the hourly event the command sends", () => {
+      expect(STORAGE_METER_AGGREGATION).toBe("sum");
+      expect(STORAGE_METER_EVENT_NAME).toBe(
+        "langwatch_storage_megabytes_hourly",
+      );
+    });
+  });
+});

--- a/langwatch/ee/billing/stripe/storagePricing.ts
+++ b/langwatch/ee/billing/stripe/storagePricing.ts
@@ -1,0 +1,57 @@
+/**
+ * ADR-027 storage billing — the price contract, as code.
+ *
+ * The `STORAGE_GB` Stripe meter sums additive hourly MiB values (MiB-hours) over
+ * the period; a single static `unit_amount_decimal` applied to that sum yields
+ * the bill. This module is the single source of truth for that unit price and
+ * the headline it derives from, so the (externally-created) Stripe Price's
+ * `unit_amount_decimal` can be pinned against it and never drift silently.
+ *
+ * Unit vocabulary is BINARY and deliberate (see the ADR): quantities are MiB
+ * (`bytes / 1_048_576`), prices per GiB (1024 MiB). The `STORAGE_GB` / `megabytes`
+ * labels are opaque — renaming Stripe meters later is painful, so the binary
+ * reality is documented, not renamed. We bill the LOGICAL (uncompressed
+ * `_size_bytes`) volume, not the compressed on-disk footprint — that is the
+ * priced unit and the contract.
+ */
+
+/** Headline price: €3 per logical GiB-month, 30-day-month convention. */
+export const STORAGE_EUR_PER_GIB_MONTH = 3;
+
+/** 30-day-month convention (AWS S3 / R2 style): 1 GiB held bills €3.10 in a
+ *  31-day month, €2.80 in February. */
+export const STORAGE_BILLING_DAYS_PER_MONTH = 30;
+export const STORAGE_HOURS_PER_DAY = 24;
+/** Binary GiB: 1 GiB = 1024 MiB. */
+export const MIB_PER_GIB = 1024;
+
+/**
+ * Price in EUR per MiB-hour = headline / (days × hours × MiB-per-GiB).
+ * ≈ €0.0000040690 per MiB-hour = €0.10 per GiB-day.
+ */
+export const STORAGE_EUR_PER_MIB_HOUR =
+  STORAGE_EUR_PER_GIB_MONTH /
+  (STORAGE_BILLING_DAYS_PER_MONTH * STORAGE_HOURS_PER_DAY * MIB_PER_GIB);
+
+/**
+ * Stripe `unit_amount_decimal` is the price in the currency's MINOR unit (cents
+ * for EUR), as a decimal string. This is the value the `STORAGE_GB` metered
+ * Price must carry; the pin test asserts it so a catalog edit can't drift it.
+ * ≈ 0.00040690 cents per MiB-hour.
+ */
+export const STORAGE_UNIT_AMOUNT_DECIMAL_CENTS_PER_MIB_HOUR =
+  STORAGE_EUR_PER_MIB_HOUR * 100;
+
+/** Headline derived back from the unit price, for documentation/checks. */
+export const STORAGE_EUR_PER_GIB_DAY =
+  STORAGE_EUR_PER_MIB_HOUR * STORAGE_HOURS_PER_DAY * MIB_PER_GIB;
+
+/**
+ * Stripe meter event name — MUST match what {@link ReportStorageForHourCommand}
+ * sends (Phase 3). The meter routes events by `event_name`, so a mismatch means
+ * silently-unbilled usage.
+ */
+export const STORAGE_METER_EVENT_NAME = "langwatch_storage_megabytes_hourly";
+
+/** Stripe meter default aggregation — additive sum of the hourly MiB values. */
+export const STORAGE_METER_AGGREGATION = "sum" as const;

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportStorageForHour.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportStorageForHour.command.ts
@@ -6,6 +6,7 @@ import {
   withScope,
 } from "~/utils/posthogErrorCapture";
 import type { UsageReportingService } from "../../../../../../ee/billing/services/usageReportingService";
+import { STORAGE_METER_EVENT_NAME } from "../../../../../../ee/billing/stripe/storagePricing";
 import type { StorageBillingCheckpointService } from "../../../../app-layer/billing/storageBillingCheckpoint.service";
 import type { StorageUsageHourlyRepository } from "../../../../app-layer/billing/storageUsageHourly.repository";
 import type { OrganizationService } from "../../../../app-layer/organizations/organization.service";
@@ -19,9 +20,6 @@ import { BILLING_REPORT_COMMAND_TYPES } from "../schemas/constants";
 const logger = createLogger(
   "langwatch:billing-reporting:report-storage-for-hour",
 );
-
-/** Stripe meter event name for additive hourly storage (MiB). */
-const STORAGE_MEGABYTES_EVENT_NAME = "langwatch_storage_megabytes_hourly";
 
 /** Maximum consecutive failures before the circuit-breaker trips. */
 const MAX_CONSECUTIVE_FAILURES = 5;
@@ -233,7 +231,7 @@ export class ReportStorageForHourCommand
         organizationId,
         events: [
           {
-            eventName: STORAGE_MEGABYTES_EVENT_NAME,
+            eventName: STORAGE_METER_EVENT_NAME,
             identifier,
             timestamp: Math.floor(sealedHourDate.getTime() / 1000),
             value: hour.megabytes,

--- a/specs/data-retention/storage-billing-pricing.feature
+++ b/specs/data-retention/storage-billing-pricing.feature
@@ -1,0 +1,39 @@
+Feature: Storage billing — price contract (ADR-027, Phase 5)
+  As the storage-billing pipeline
+  I want the per-MiB-hour unit price pinned to the €3/GiB-month headline
+  So that the Stripe meter bills the agreed rate and a catalog edit cannot silently drift it
+
+  # The STORAGE_GB meter sums additive hourly MiB values over the period; one static
+  # unit_amount_decimal applied to that sum is the bill. Quantities are binary (MiB = bytes/1_048_576,
+  # GiB = 1024 MiB); we bill LOGICAL (uncompressed) volume. These scenarios pin the price math so the
+  # externally-created Stripe Price can be checked against it and never diverge unnoticed.
+
+  @unit
+  Scenario: The headline storage price is €3 per logical GiB-month
+    Given the storage pricing contract
+    When the headline price is read
+    Then it is €3 per GiB-month on the 30-day-month convention
+
+  @unit
+  Scenario: The unit price derives from the headline by the documented formula
+    Given the €3 per GiB-month headline
+    When the per-MiB-hour unit price is derived
+    Then it equals the headline divided by 30 days, 24 hours, and 1024 MiB per GiB
+
+  @unit
+  Scenario: The Stripe unit_amount_decimal is pinned in cents per MiB-hour
+    Given the per-MiB-hour unit price
+    When it is expressed as the Stripe unit_amount_decimal
+    Then it is the price in cents per MiB-hour, pinned so the catalog cannot drift
+
+  @unit
+  Scenario: The unit price round-trips to the €0.10 per GiB-day headline
+    Given the per-MiB-hour unit price
+    When a full GiB held for a day is priced
+    Then the cost is €0.10 per GiB-day
+
+  @unit
+  Scenario: The meter is additive and named to match the report command
+    Given the STORAGE_GB meter configuration
+    When its aggregation and event name are read
+    Then it sums the hourly event that the report command sends


### PR DESCRIPTION
Code-side of Phase 5: the price math as a single source of truth + a pin test, and single-sourcing the meter event name into the report command.

**What's here (code):** `storagePricing.ts` — €3/logical-GiB-month headline, derived per-MiB-hour unit price (≈ €0.0000040690), Stripe `unit_amount_decimal` in cents, €0.10/GiB-day round-trip, `sum` aggregation, and the meter event name (now imported by the report command, so they can't drift). 5 bound `@unit` scenarios pin the math so a future edit can't silently mis-bill.

**What's external (NOT code — gated on humans/Stripe):**
- Create the `STORAGE_GB` meter + metered prices in Stripe (test then live).
- Wire their real ids into `stripeCatalog.json` + `STRIPE_METER_NAMES` / `STRIPE_PRICE_NAMES` (per plan×currency×interval).
- €3/GiB pricing-owner sign-off (ADR open question).

The pin guard is ready for the catalog price's `unit_amount_decimal` to be checked against it.

Stacks on #5227 (dispatcher).