### PR TITLE
perf(clickhouse): resolve trace time for hint-less batch trace reads

### DIFF
--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-dedup.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-dedup.integration.test.ts
@@ -509,6 +509,80 @@ describe("ClickHouse trace dedup (integration)", () => {
           expect(trace.spans[0]!.name).toBe("latest-span-version");
         });
       });
+
+      describe("when no occurredAt window is supplied (thread-view path)", () => {
+        function recordingClient(): {
+          client: ClickHouseClient;
+          queries: string[];
+        } {
+          const queries: string[] = [];
+          const client = new Proxy(ch, {
+            get(target, prop, receiver) {
+              if (prop === "query") {
+                return (args: { query: string; query_params?: unknown }) => {
+                  if (
+                    typeof args?.query === "string" &&
+                    args.query.includes("trace_summaries")
+                  ) {
+                    queries.push(args.query);
+                  }
+                  return (target as ClickHouseClient).query(args as never);
+                };
+              }
+              return Reflect.get(target, prop, receiver);
+            },
+          }) as ClickHouseClient;
+          return { client, queries };
+        }
+
+        it("resolves the OccurredAt span and bounds the heavy summary read", async () => {
+          const { client, queries } = recordingClient();
+          getClickHouseClientForProject.mockResolvedValue(client);
+          try {
+            const traces = await service.getTracesWithSpans(
+              tenantId,
+              [traceId],
+              openProtections,
+            );
+            // Correctness is unchanged: still the latest summary + span version.
+            expect(traces).toHaveLength(1);
+            expect(traces![0]!.trace_id).toBe(traceId);
+            expect(traces![0]!.metrics?.total_time_ms).toBe(300);
+          } finally {
+            getClickHouseClientForProject.mockResolvedValue(ch);
+          }
+
+          // A cheap resolve (min/max OccurredAt) runs, then the heavy summary
+          // read (ts_ComputedInput columns) is partition-bounded on OccurredAt
+          // instead of scanning every weekly part.
+          const resolveQuery = queries.find((q) => q.includes("min(OccurredAt)"));
+          const heavyQuery = queries.find((q) => q.includes("ts_ComputedInput"));
+          expect(resolveQuery).toBeDefined();
+          expect(heavyQuery).toBeDefined();
+          expect(heavyQuery!).toContain("OccurredAt >=");
+        });
+
+        it("stays unbounded when the trace ids resolve to no rows", async () => {
+          const { client, queries } = recordingClient();
+          getClickHouseClientForProject.mockResolvedValue(client);
+          try {
+            const traces = await service.getTracesWithSpans(
+              tenantId,
+              [`missing-${nanoid()}`],
+              openProtections,
+            );
+            expect(traces ?? []).toHaveLength(0);
+          } finally {
+            getClickHouseClientForProject.mockResolvedValue(ch);
+          }
+
+          // Resolve found nothing (epoch default), so the heavy summary read
+          // keeps its previous unbounded behaviour rather than guessing.
+          const heavyQuery = queries.find((q) => q.includes("ts_ComputedInput"));
+          expect(heavyQuery).toBeDefined();
+          expect(heavyQuery!).not.toContain("OccurredAt >=");
+        });
+      });
     });
 
     describe("when multiple traces each have multiple span versions", () => {

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-dedup.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-dedup.integration.test.ts
@@ -555,8 +555,12 @@ describe("ClickHouse trace dedup (integration)", () => {
           // A cheap resolve (min/max OccurredAt) runs, then the heavy summary
           // read (ts_ComputedInput columns) is partition-bounded on OccurredAt
           // instead of scanning every weekly part.
-          const resolveQuery = queries.find((q) => q.includes("min(OccurredAt)"));
-          const heavyQuery = queries.find((q) => q.includes("ts_ComputedInput"));
+          const resolveQuery = queries.find((q) =>
+            q.includes("min(OccurredAt)"),
+          );
+          const heavyQuery = queries.find((q) =>
+            q.includes("ts_ComputedInput"),
+          );
           expect(resolveQuery).toBeDefined();
           expect(heavyQuery).toBeDefined();
           expect(heavyQuery!).toContain("OccurredAt >=");
@@ -578,7 +582,9 @@ describe("ClickHouse trace dedup (integration)", () => {
 
           // Resolve found nothing (epoch default), so the heavy summary read
           // keeps its previous unbounded behaviour rather than guessing.
-          const heavyQuery = queries.find((q) => q.includes("ts_ComputedInput"));
+          const heavyQuery = queries.find((q) =>
+            q.includes("ts_ComputedInput"),
+          );
           expect(heavyQuery).toBeDefined();
           expect(heavyQuery!).not.toContain("OccurredAt >=");
         });

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service-resolution.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service-resolution.unit.test.ts
@@ -160,8 +160,14 @@ function makeEventRefBlobStore(contents: Record<string, string>): BlobStore {
   } as unknown as BlobStore;
 }
 
-/** Set up the two CH queries fetchTracesWithSpansJoined fires in parallel. */
+/**
+ * Set up the CH queries fetchTracesWithSpansJoined fires: a light resolve
+ * (min/max OccurredAt) for the hint-less path, then the summary and span reads.
+ */
 function setupGetTracesWithSpansMocks(traceId: string, spanId: string) {
+  const resolveResult = {
+    json: () => Promise.resolve([{ fromMs: 1_000_000, toMs: 2_000_000 }]),
+  };
   const summaryResult = {
     json: () => Promise.resolve([makeSummaryRow(traceId)]),
   };
@@ -169,6 +175,7 @@ function setupGetTracesWithSpansMocks(traceId: string, spanId: string) {
     json: () => Promise.resolve([makeSpanRowWithEventRef(traceId, spanId)]),
   };
   mockClickHouseQuery
+    .mockResolvedValueOnce(resolveResult)
     .mockResolvedValueOnce(summaryResult)
     .mockResolvedValueOnce(spansResult);
 }

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -1044,7 +1044,9 @@ describe("ClickHouseTraceService", () => {
           summaryCall.query.match(/OccurredAt >= fromUnixTimestamp64Milli/g) ??
             [],
         ).toHaveLength(2);
-        expect(summaryCall.query_params.sumFromMs).toBe(1_000_000 - TWO_DAYS_MS);
+        expect(summaryCall.query_params.sumFromMs).toBe(
+          1_000_000 - TWO_DAYS_MS,
+        );
         expect(summaryCall.query_params.sumToMs).toBe(2_000_000 + TWO_DAYS_MS);
       });
 

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -968,8 +968,9 @@ describe("ClickHouseTraceService", () => {
         await expect(
           service.getTracesWithSpans("proj_123", ["trace-0"], protections),
         ).rejects.toThrow();
-        // The single failed query is not followed by per-batch retries.
-        expect(mockClickHouseQuery).toHaveBeenCalledTimes(1);
+        // The resolve fails open (call 1), then the summary's non-OOM error
+        // propagates without per-batch retries (call 2) — no retry loop.
+        expect(mockClickHouseQuery).toHaveBeenCalledTimes(2);
       });
     });
 
@@ -1075,6 +1076,35 @@ describe("ClickHouseTraceService", () => {
         expect(summaryCall.query).not.toContain("OccurredAt <=");
         expect(summaryCall.query_params.sumFromMs).toBeUndefined();
         expect(summaryCall.query_params.sumToMs).toBeUndefined();
+      });
+
+      it("fails open to the unbounded read when the resolve query errors", async () => {
+        mockClickHouseQuery
+          // resolve errors (transient ClickHouse failure)
+          .mockRejectedValueOnce(new Error("resolve boom"))
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([makeSummaryRow("trace-0")]),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([makeSpanRow("trace-0", "trace-0-s")]),
+          });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const traces = await service.getTracesWithSpans(
+          "proj_123",
+          ["trace-0"],
+          protections,
+        );
+
+        // The read still succeeds; the summary just stays unbounded (the
+        // pre-optimization behaviour) rather than propagating the resolve error.
+        expect(traces).toHaveLength(1);
+        const summaryCall = mockClickHouseQuery.mock.calls[1]![0];
+        expect(summaryCall.query).not.toContain("OccurredAt >=");
+        expect(summaryCall.query_params.sumFromMs).toBeUndefined();
       });
     });
   });

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -860,6 +860,11 @@ describe("ClickHouseTraceService", () => {
         const traceIds = ["trace-0", "trace-1"];
 
         mockClickHouseQuery
+          // resolve: min/max OccurredAt for the ids (no occurredAt passed)
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve([{ fromMs: 1_000_000, toMs: 2_000_000 }]),
+          })
           // summary query for the full list — OOM
           .mockRejectedValueOnce(
             new Error(
@@ -898,6 +903,11 @@ describe("ClickHouseTraceService", () => {
         const traceIds = Array.from({ length: 30 }, (_, i) => `trace-${i}`);
 
         mockClickHouseQuery
+          // resolve: min/max OccurredAt for the ids (no occurredAt passed)
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve([{ fromMs: 1_000_000, toMs: 2_000_000 }]),
+          })
           // full-list summary — OOM
           .mockRejectedValueOnce(new Error("MEMORY_LIMIT_EXCEEDED"))
           // batch 1: summary (0-24) then spans
@@ -938,9 +948,10 @@ describe("ClickHouseTraceService", () => {
         );
 
         expect(traces).toHaveLength(30);
-        // call 0 = OOM, 1 = summary batch1, 2 = spans batch1, 3 = summary batch2
-        const batch1Summary = mockClickHouseQuery.mock.calls[1]![0];
-        const batch2Summary = mockClickHouseQuery.mock.calls[3]![0];
+        // call 0 = resolve, 1 = OOM full summary, 2 = summary batch1,
+        // 3 = spans batch1, 4 = summary batch2, 5 = spans batch2
+        const batch1Summary = mockClickHouseQuery.mock.calls[2]![0];
+        const batch2Summary = mockClickHouseQuery.mock.calls[4]![0];
         expect(batch1Summary.query_params.traceIds).toHaveLength(25);
         expect(batch2Summary.query_params.traceIds).toHaveLength(5);
       });
@@ -1002,8 +1013,14 @@ describe("ClickHouseTraceService", () => {
     });
 
     describe("when no occurredAt range is supplied", () => {
-      it("omits the OccurredAt window and keeps the unbounded summary read", async () => {
+      it("resolves the OccurredAt window from a sort-key seek and bounds the summary read", async () => {
+        const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000;
         mockClickHouseQuery
+          // resolve: min/max OccurredAt for the trace ids (light sort-key seek)
+          .mockResolvedValueOnce({
+            json: () =>
+              Promise.resolve([{ fromMs: 1_000_000, toMs: 2_000_000 }]),
+          })
           .mockResolvedValueOnce({
             json: () => Promise.resolve([makeSummaryRow("trace-0")]),
           })
@@ -1017,11 +1034,43 @@ describe("ClickHouseTraceService", () => {
 
         await service.getTracesWithSpans("proj_123", ["trace-0"], protections);
 
-        const summaryCall = mockClickHouseQuery.mock.calls[0]![0];
+        const resolveCall = mockClickHouseQuery.mock.calls[0]![0];
+        expect(resolveCall.query).toContain("min(OccurredAt)");
+        expect(resolveCall.query).toContain("max(OccurredAt)");
+
+        const summaryCall = mockClickHouseQuery.mock.calls[1]![0];
+        // Bounded to the resolved window (±2 days) in outer scan and inner dedup.
+        expect(
+          summaryCall.query.match(/OccurredAt >= fromUnixTimestamp64Milli/g) ??
+            [],
+        ).toHaveLength(2);
+        expect(summaryCall.query_params.sumFromMs).toBe(1_000_000 - TWO_DAYS_MS);
+        expect(summaryCall.query_params.sumToMs).toBe(2_000_000 + TWO_DAYS_MS);
+      });
+
+      it("keeps the summary read unbounded when the ids resolve to no rows", async () => {
+        mockClickHouseQuery
+          // resolve finds nothing -> min/max default to epoch (0) = "no window"
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ fromMs: 0, toMs: 0 }]),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([makeSummaryRow("trace-0")]),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([makeSpanRow("trace-0", "trace-0-s")]),
+          });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await service.getTracesWithSpans("proj_123", ["trace-0"], protections);
+
+        const summaryCall = mockClickHouseQuery.mock.calls[1]![0];
         // No OccurredAt predicate inlined at all, and no window params.
         expect(summaryCall.query).not.toContain("OccurredAt >=");
         expect(summaryCall.query).not.toContain("OccurredAt <=");
-        expect(summaryCall.query).not.toContain("sumFromMs");
         expect(summaryCall.query_params.sumFromMs).toBeUndefined();
         expect(summaryCall.query_params.sumToMs).toBeUndefined();
       });

--- a/langwatch/src/server/traces/__tests__/trace-service-4888-full-flag.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace-service-4888-full-flag.unit.test.ts
@@ -129,9 +129,15 @@ const PREVIEW_OUTPUT = "x".repeat(IO_PREVIEW_BYTES) + "…";
 // Mock setup helper
 // ---------------------------------------------------------------------------
 
-/** Set up the two CH queries fetchTracesWithSpansJoined fires (summary, spans). */
+/**
+ * Set up the CH queries fetchTracesWithSpansJoined fires: a light resolve
+ * (min/max OccurredAt) for the hint-less path, then the summary and span reads.
+ */
 function setupGetTracesWithSpansMocks(tenantId = PROJECT_ID_A) {
   mockClickHouseQuery
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve([{ fromMs: 1_000_000, toMs: 2_000_000 }]),
+    })
     .mockResolvedValueOnce({
       json: () =>
         Promise.resolve([
@@ -515,6 +521,10 @@ describe("ClickHouseTraceService — #4888 full resolution crosses the mapper", 
 
   function setupJoinedFetch() {
     mockClickHouseQuery
+      // resolve (min/max OccurredAt) for the hint-less path
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve([{ fromMs: 1_000_000, toMs: 2_000_000 }]),
+      })
       .mockResolvedValueOnce({
         json: () =>
           Promise.resolve([

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -2377,11 +2377,15 @@ export class ClickHouseTraceService {
    *
    * @internal
    */
-  private async resolveOccurredAtRange(
-    client: ClickHouseClient,
-    projectId: string,
-    traceIds: string[],
-  ): Promise<OccurredAtRange | undefined> {
+  private async resolveOccurredAtRange({
+    client,
+    projectId,
+    traceIds,
+  }: {
+    client: ClickHouseClient;
+    projectId: string;
+    traceIds: string[];
+  }): Promise<OccurredAtRange | undefined> {
     if (traceIds.length === 0) {
       return undefined;
     }
@@ -2445,11 +2449,23 @@ export class ClickHouseTraceService {
         // sort-key shape as the single-trace read in the trace-summary repo.
         const effectiveOccurredAt =
           occurredAt ??
-          (await this.resolveOccurredAtRange(
-            clickHouseClient,
+          (await this.resolveOccurredAtRange({
+            client: clickHouseClient,
             projectId,
             traceIds,
-          ));
+          }).catch((error) => {
+            // Fail open: the resolve is a pure optimization, so a transient
+            // failure must not break a read that previously succeeded. Fall
+            // back to the unbounded (slower but correct) summary read.
+            this.logger.warn(
+              {
+                projectId,
+                error: error instanceof Error ? error.message : error,
+              },
+              "OccurredAt resolve for batch trace read failed; falling back to unbounded summary read",
+            );
+            return undefined;
+          }));
 
         // The summary + span reads pull heavy columns (ComputedInput/Output,
         // Attributes, SpanAttributes/Events/Links) for the whole trace list, so a

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -2481,7 +2481,8 @@ export class ClickHouseTraceService {
             : "";
           const summaryTimeParams = hasSummaryWindow
             ? {
-                sumFromMs: effectiveOccurredAt.from - SUMMARY_PARTITION_WINDOW_MS,
+                sumFromMs:
+                  effectiveOccurredAt.from - SUMMARY_PARTITION_WINDOW_MS,
                 sumToMs: effectiveOccurredAt.to + SUMMARY_PARTITION_WINDOW_MS,
               }
             : {};

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -2366,6 +2366,49 @@ export class ClickHouseTraceService {
   }
 
   /**
+   * Resolve the OccurredAt span of a set of traces from a cheap sort-key seek.
+   *
+   * trace_summaries is ORDER BY (TenantId, TraceId), so filtering on those two
+   * columns and reading only OccurredAt (a light column) lets ClickHouse answer
+   * min/max from the sort-key index without decoding heavy payload columns. The
+   * returned range then bounds the heavy summary read to the traces' weekly
+   * partitions. Returns undefined when no rows match (min/max default to epoch),
+   * so the caller keeps its previous unbounded behaviour rather than guessing.
+   *
+   * @internal
+   */
+  private async resolveOccurredAtRange(
+    client: ClickHouseClient,
+    projectId: string,
+    traceIds: string[],
+  ): Promise<OccurredAtRange | undefined> {
+    if (traceIds.length === 0) {
+      return undefined;
+    }
+    const result = await client.query({
+      query: `
+        SELECT
+          toUnixTimestamp64Milli(min(OccurredAt)) AS fromMs,
+          toUnixTimestamp64Milli(max(OccurredAt)) AS toMs
+        FROM trace_summaries
+        WHERE TenantId = {tenantId:String}
+          AND TraceId IN ({traceIds:Array(String)})
+      `,
+      query_params: { tenantId: projectId, traceIds },
+      format: "JSONEachRow",
+    });
+    const rows = (await result.json()) as Array<{
+      fromMs: number | null;
+      toMs: number | null;
+    }>;
+    const row = rows[0];
+    if (!row || !(Number(row.fromMs) > 0) || !(Number(row.toMs) > 0)) {
+      return undefined;
+    }
+    return { from: Number(row.fromMs), to: Number(row.toMs) };
+  }
+
+  /**
    * Fetch trace summaries with their spans using a JOIN query.
    * This is more efficient than two separate queries.
    *
@@ -2392,6 +2435,22 @@ export class ClickHouseTraceService {
           throw new Error("ClickHouse client not available");
         }
 
+        // Callers that already know the traces' time pass `occurredAt`; the
+        // thread-view paths (getTracesByThreadId / getTracesWithSpansByThreadIds)
+        // only have trace ids. Without a window the summary read below filters on
+        // TraceId alone, which cannot prune partitions (trace_summaries is
+        // partitioned on OccurredAt) and so opens every weekly part incl. cold
+        // S3. Resolve the OccurredAt span from a cheap sort-key seek (light
+        // column only) and reuse it to bound the heavy read. Same resolve-from-
+        // sort-key shape as the single-trace read in the trace-summary repo.
+        const effectiveOccurredAt =
+          occurredAt ??
+          (await this.resolveOccurredAtRange(
+            clickHouseClient,
+            projectId,
+            traceIds,
+          ));
+
         // The summary + span reads pull heavy columns (ComputedInput/Output,
         // Attributes, SpanAttributes/Events/Links) for the whole trace list, so a
         // large list can exceed the per-query memory cap and fail with
@@ -2411,9 +2470,9 @@ export class ClickHouseTraceService {
           // a hint we keep the original unbounded read.
           const SUMMARY_PARTITION_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;
           const hasSummaryWindow =
-            occurredAt !== undefined &&
-            occurredAt.from > 0 &&
-            occurredAt.to > 0;
+            effectiveOccurredAt !== undefined &&
+            effectiveOccurredAt.from > 0 &&
+            effectiveOccurredAt.to > 0;
           const summaryTimeFilterOuter = hasSummaryWindow
             ? "AND t.OccurredAt >= fromUnixTimestamp64Milli({sumFromMs:Int64}) AND t.OccurredAt <= fromUnixTimestamp64Milli({sumToMs:Int64})"
             : "";
@@ -2422,8 +2481,8 @@ export class ClickHouseTraceService {
             : "";
           const summaryTimeParams = hasSummaryWindow
             ? {
-                sumFromMs: occurredAt.from - SUMMARY_PARTITION_WINDOW_MS,
-                sumToMs: occurredAt.to + SUMMARY_PARTITION_WINDOW_MS,
+                sumFromMs: effectiveOccurredAt.from - SUMMARY_PARTITION_WINDOW_MS,
+                sumToMs: effectiveOccurredAt.to + SUMMARY_PARTITION_WINDOW_MS,
               }
             : {};
 


### PR DESCRIPTION
## Evidence

From the last 24h of prod slow-query warnings, the batch trace-summary read is the highest-volume genuinely-slow shape that is not already covered by an open PR:

- Shape: `SELECT TraceId AS ts_TraceId, SpanCount AS ts_SpanCount, ... , Attributes AS ts_Attributes, ... FROM trace_summaries WHERE TenantId = ? AND TraceId IN (?) AND (dedup IN-tuple)` (params: `tenantId`, `traceIds` only, no time window).
- ~965 calls/24h, p50 ~1.35 s, max ~4.9 s, ~10 MB read per call.
- The read bytes are small but the latency is dominated by opening every weekly partition (many cold on S3) because a `TraceId`-only filter cannot prune a table partitioned on `OccurredAt`.

No raw tenant data is included here.

## Suspected cause

`fetchTracesWithSpansJoined` (reached via `getTracesWithSpans`) already accepts an optional `occurredAt` window and bounds the summary read when present. The list/search caller derives that window from the traces' own timestamps, but the thread-view callers (`getTracesByThreadId` / `getTracesWithSpansByThreadIds`) only have trace ids, so they call in with no window and fall to the unbounded path. The existing code comment on that path notes it keeps the original unbounded read when no hint is supplied.

## Proposed fix

When no `occurredAt` is supplied, resolve the traces' `OccurredAt` span from a cheap sort-key seek before the heavy read:

```sql
SELECT toUnixTimestamp64Milli(min(OccurredAt)) AS fromMs,
       toUnixTimestamp64Milli(max(OccurredAt)) AS toMs
FROM trace_summaries
WHERE TenantId = {tenantId:String} AND TraceId IN ({traceIds:Array(String)})
```

`trace_summaries` is `ORDER BY (TenantId, TraceId)`, so this reads only the light `OccurredAt` column over the ordered prefix. The resolved range then feeds the existing `occurredAt` window logic (a plus/minus 2-day margin is safe headroom, matching the existing span-window code), pruning the heavy summary read to the traces' weekly partitions.

This is the same resolve-from-sort-key shape already shipped for the single-trace read in the trace-summary repository. Only the no-hint path changes:

- Callers that pass `occurredAt` are untouched (zero regression).
- When the ids resolve to no rows (min/max default to epoch), the read stays unbounded rather than guessing a window.

## Expected impact

- Heavy summary read partitions pruned from all parts to a small handful; the light resolve replaces one heavy all-partition scan with one light all-partition scan plus a bounded heavy read.
- Fewer cold-partition part-opens on S3 for the thread-view fetch; the headline is partitions pruned rather than a fixed latency delta.
- Result correctness is unchanged (dedup and returned rows identical).

## EXPLAIN check (real large tenant, redacted; ids elided)

Heavy summary read, unbounded (current no-hint path):

```
ReadFromMergeTree (trace_summaries)
Parts: 265/265
```

Heavy summary read, bounded to the resolved plus/minus 2-day window:

```
ReadFromMergeTree (trace_summaries)
Parts: 3/268
```

Resolve query (light `OccurredAt`-only seek) reads only the `OccurredAt` column across parts, no heavy payload columns.

## Test plan

- `clickhouse-trace-dedup.integration.test.ts` (real ClickHouse testcontainer): added a "when no occurredAt window is supplied (thread-view path)" block asserting the resolve runs, the heavy summary read is bounded (`OccurredAt >=`), correctness (latest summary + span version) is unchanged, and that ids resolving to no rows keep the read unbounded.
- `clickhouse-trace.service.unit.test.ts`: updated the no-window and OOM batch-retry cases to account for the resolve query, and added a case asserting the resolve-and-bound behaviour.
- Full file: 11 integration + 30 unit tests pass; typecheck clean on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace loading for thread-view scenarios when no time window is provided by deriving an effective occurred-at range from available trace data.
  * Added a lightweight min/max occurred-at resolution step so summary reads are bounded when possible, including the existing safety margin behavior.
  * If resolution fails, the system now safely falls back to the previous unbounded behavior while still returning spans; unresolved trace IDs return empty results.
* **Tests**
  * Updated and expanded unit/integration coverage and ClickHouse mocking to match the new resolve-then-read query sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->