### PR TITLE
feat(observability-sdk): add span/tracer addEvaluation for custom evaluation recording

### DIFF
--- a/typescript-sdk/README.md
+++ b/typescript-sdk/README.md
@@ -156,6 +156,7 @@ span.end();
     });
   });
   ```
+
   > **Note:** `addEvaluation` is the canonical API for recording manual evaluations on a span. `recordEvaluation` is a deprecated alias of `addEvaluation` kept for backward compatibility.
 
 ### 4. LangChain Integration

--- a/typescript-sdk/README.md
+++ b/typescript-sdk/README.md
@@ -147,15 +147,16 @@ span.end();
   ```
 - **Record a custom evaluation:**
   ```ts
-  import { recordEvaluation } from "langwatch/evaluation";
-  recordEvaluation({
-    name: "Manual Eval",
-    passed: true,
-    score: 0.9,
-    details: "Looks good!"
+  await tracer.withActiveSpan("my-operation", async (span) => {
+    span.addEvaluation({
+      name: "Manual Eval",
+      passed: true,
+      score: 0.9,
+      details: "Looks good!"
+    });
   });
   ```
-  > **Note:** The evaluation APIs (`runEvaluation`, `recordEvaluation`) also create spans and add tracing/evaluation info automatically.
+  > **Note:** `addEvaluation` is the canonical API for recording manual evaluations on a span. `recordEvaluation` is a deprecated alias of `addEvaluation` kept for backward compatibility.
 
 ### 4. LangChain Integration
 

--- a/typescript-sdk/README.md
+++ b/typescript-sdk/README.md
@@ -95,7 +95,7 @@ span.end();
 
 - **Record an evaluation directly on a span:**
   ```ts
-  span.recordEvaluation({ name: "My Eval", passed: true, score: 1.0 });
+  span.addEvaluation({ name: "My Eval", passed: true, score: 1.0 });
   ```
   > **Note:** This associates evaluation results with a specific span (operation or model call).
 

--- a/typescript-sdk/src/observability-sdk/evaluation/__tests__/evaluation.unit.test.ts
+++ b/typescript-sdk/src/observability-sdk/evaluation/__tests__/evaluation.unit.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  context,
+  trace,
+  INVALID_SPAN_CONTEXT,
+  type ContextManager,
+} from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { MockSpan, MockTracerProvider } from "../../__tests__/test-utils";
+import { createLangWatchSpan } from "../../span";
+import { getLangWatchTracerFromProvider } from "../../tracer";
+import { ATTR_LANGWATCH_EVALUATION_CUSTOM } from "../../semconv/attributes";
+import { emitEvaluationEvent } from "../index";
+
+/**
+ * The complete set of keys the emitted payload must contain, matching the
+ * Python `Evaluation` TypedDict (`python-sdk/.../domain/__init__.py`) exactly.
+ * Notably there is NO `cost` key: Python routes cost into span metrics, not the
+ * evaluation event payload.
+ */
+const EXPECTED_PAYLOAD_KEYS = [
+  "evaluation_id",
+  "span_id",
+  "name",
+  "type",
+  "is_guardrail",
+  "status",
+  "passed",
+  "score",
+  "label",
+  "details",
+  "error",
+  "timestamps",
+] as const;
+
+const EVENT_NAME = "langwatch.evaluation.custom";
+
+describe("addEvaluation", () => {
+  // A real context manager is required so `context.with(...)` propagates the
+  // active span to `trace.getActiveSpan()` in the trace-level tests. The
+  // default no-op manager does not propagate.
+  let contextManager: ContextManager;
+  beforeAll(() => {
+    contextManager = new AsyncLocalStorageContextManager();
+    contextManager.enable();
+    context.setGlobalContextManager(contextManager);
+  });
+  afterAll(() => {
+    contextManager.disable();
+    context.disable();
+  });
+
+  it("uses the canonical custom-evaluation event name constant", () => {
+    // Guards that the constant we emit under stays wire-compatible with Python.
+    expect(ATTR_LANGWATCH_EVALUATION_CUSTOM).toBe(EVENT_NAME);
+  });
+
+  describe("span.addEvaluation", () => {
+    it("emits a langwatch.evaluation.custom event with the snake_case payload", () => {
+      const mockSpan = new MockSpan("evaluation-target");
+      const span = createLangWatchSpan(mockSpan);
+
+      const result = span.addEvaluation({
+        name: "response_quality",
+        passed: true,
+        score: 0.95,
+        details: "High quality response",
+      });
+
+      // Fluent API returns the span.
+      expect(result).toBe(span);
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      expect(event).toBeDefined();
+      expect(event?.name).toBe(ATTR_LANGWATCH_EVALUATION_CUSTOM);
+
+      const raw = event?.attributes?.json_encoded_event;
+      expect(typeof raw).toBe("string");
+
+      const payload = JSON.parse(raw as string);
+
+      // Provided fields serialized under Python-parity snake_case keys.
+      expect(payload.name).toBe("response_quality");
+      expect(payload.passed).toBe(true);
+      expect(payload.score).toBe(0.95);
+      expect(payload.details).toBe("High quality response");
+
+      // status defaults to "processed" (matching Python).
+      expect(payload.status).toBe("processed");
+
+      // span_id is pulled from the span context.
+      expect(payload.span_id).toBe(mockSpan.spanContext().spanId);
+
+      // evaluation_id is auto-generated with the "eval_" prefix (PKSUID parity).
+      expect(typeof payload.evaluation_id).toBe("string");
+      expect(payload.evaluation_id).toMatch(/^eval_/);
+
+      // Absent optional fields are present as null, matching Python's explicit
+      // key emission.
+      expect(payload).toHaveProperty("type", null);
+      expect(payload).toHaveProperty("is_guardrail", null);
+      expect(payload).toHaveProperty("label", null);
+      expect(payload).toHaveProperty("error", null);
+      expect(payload).toHaveProperty("timestamps", null);
+
+      // The payload keys must be EXACTLY the Python `Evaluation` TypedDict set
+      // (12 keys, no `cost`) — cost lives in span metrics on the Python side.
+      expect(Object.keys(payload).sort()).toEqual(
+        [...EXPECTED_PAYLOAD_KEYS].sort(),
+      );
+    });
+
+    it("emits span_id as null for an invalid / non-recording span context", () => {
+      // An invalid span context carries the all-zero span id that OTel JS hands
+      // back outside an active trace. Python guards this via `is_valid` and
+      // emits null; we must match by guarding on `isSpanContextValid`.
+      //
+      // Use a MockSpan (which records events so we can read the payload back)
+      // but override its context to the OTel-canonical INVALID_SPAN_CONTEXT so
+      // the real `isSpanContextValid` path is exercised.
+      const mockSpan = new MockSpan("invalid-ctx-target");
+      mockSpan.spanContext = () => INVALID_SPAN_CONTEXT;
+
+      // Sanity: this really is the all-zero span id that must be rejected.
+      expect(mockSpan.spanContext().spanId).toBe("0000000000000000");
+
+      emitEvaluationEvent(mockSpan, { name: "invalid_ctx_eval" });
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      expect(event).toBeDefined();
+      const payload = JSON.parse(
+        event?.attributes?.json_encoded_event as string,
+      );
+
+      expect(payload.name).toBe("invalid_ctx_eval");
+      // The guard converts the all-zero id to null.
+      expect(payload.span_id).toBeNull();
+    });
+
+    it("honors an explicit evaluationId and non-default status", () => {
+      const mockSpan = new MockSpan("evaluation-target-2");
+      const span = createLangWatchSpan(mockSpan);
+
+      span.addEvaluation({
+        name: "toxicity",
+        evaluationId: "eval_custom_123",
+        status: "skipped",
+        isGuardrail: true,
+      });
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      const payload = JSON.parse(
+        event?.attributes?.json_encoded_event as string,
+      );
+
+      expect(payload.evaluation_id).toBe("eval_custom_123");
+      expect(payload.status).toBe("skipped");
+      expect(payload.is_guardrail).toBe(true);
+    });
+
+    it("aliases recordEvaluation to addEvaluation", () => {
+      const mockSpan = new MockSpan("evaluation-target-3");
+      const span = createLangWatchSpan(mockSpan);
+
+      span.recordEvaluation({ name: "alias_eval", passed: false });
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      expect(event).toBeDefined();
+      const payload = JSON.parse(
+        event?.attributes?.json_encoded_event as string,
+      );
+      expect(payload.name).toBe("alias_eval");
+      expect(payload.passed).toBe(false);
+    });
+
+    it("emits null for error when error is explicitly null", () => {
+      const mockSpan = new MockSpan("error-null-target");
+      const span = createLangWatchSpan(mockSpan);
+
+      span.addEvaluation({ name: "no_error_eval", error: null });
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      const payload = JSON.parse(
+        event?.attributes?.json_encoded_event as string,
+      );
+
+      expect(payload.error).toBeNull();
+    });
+
+    it("captures an Error instance with a non-empty message and stacktrace", () => {
+      const mockSpan = new MockSpan("error-instance-target");
+      const span = createLangWatchSpan(mockSpan);
+
+      span.addEvaluation({ name: "error_eval", error: new Error("boom") });
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      const payload = JSON.parse(
+        event?.attributes?.json_encoded_event as string,
+      );
+
+      expect(typeof payload.error.message).toBe("string");
+      expect(payload.error.message.length).toBeGreaterThan(0);
+      expect(Array.isArray(payload.error.stacktrace)).toBe(true);
+      expect(payload.error.stacktrace.length).toBeGreaterThan(0);
+    });
+
+    it("captures a non-Error value as a string message with empty stacktrace", () => {
+      const mockSpan = new MockSpan("error-string-target");
+      const span = createLangWatchSpan(mockSpan);
+
+      span.addEvaluation({ name: "string_error_eval", error: "plain failure" });
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      const payload = JSON.parse(
+        event?.attributes?.json_encoded_event as string,
+      );
+
+      expect(payload.error.message).toBe("plain failure");
+      expect(payload.error.stacktrace).toEqual([]);
+    });
+
+    it("converts Date timestamps to epoch milliseconds", () => {
+      const mockSpan = new MockSpan("timestamp-date-target");
+      const span = createLangWatchSpan(mockSpan);
+
+      span.addEvaluation({
+        name: "timestamp_eval",
+        timestamps: { startedAt: new Date(1000), finishedAt: new Date(2000) },
+      });
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      const payload = JSON.parse(
+        event?.attributes?.json_encoded_event as string,
+      );
+
+      expect(payload.timestamps.started_at).toBe(1000);
+      expect(payload.timestamps.finished_at).toBe(2000);
+    });
+
+    it("passes through numeric timestamps unchanged", () => {
+      const mockSpan = new MockSpan("timestamp-numeric-target");
+      const span = createLangWatchSpan(mockSpan);
+
+      span.addEvaluation({
+        name: "numeric_timestamp_eval",
+        timestamps: { startedAt: 5, finishedAt: 6 },
+      });
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      const payload = JSON.parse(
+        event?.attributes?.json_encoded_event as string,
+      );
+
+      expect(payload.timestamps.started_at).toBe(5);
+      expect(payload.timestamps.finished_at).toBe(6);
+    });
+
+    it("preserves score of 0 rather than coercing to null", () => {
+      const mockSpan = new MockSpan("score-zero-target");
+      const span = createLangWatchSpan(mockSpan);
+
+      span.addEvaluation({ name: "zero_score_eval", score: 0 });
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      const payload = JSON.parse(
+        event?.attributes?.json_encoded_event as string,
+      );
+
+      expect(payload.score).toBe(0);
+    });
+  });
+
+  describe("tracer.addEvaluation (trace-level)", () => {
+    it("emits the evaluation event onto the currently active span", () => {
+      const mockProvider = new MockTracerProvider();
+      const tracer = getLangWatchTracerFromProvider(
+        mockProvider,
+        "evaluation-test-tracer",
+      );
+
+      const mockSpan = new MockSpan("root-span");
+
+      // Make the mock span the active span in the OTel context, mirroring
+      // Python's trace-level add_evaluation acting on the trace's root/current
+      // span.
+      const ctx = trace.setSpan(context.active(), mockSpan);
+      context.with(ctx, () => {
+        tracer.addEvaluation({
+          name: "response_quality",
+          passed: true,
+          score: 0.95,
+        });
+      });
+
+      const event = mockSpan.getEvent(EVENT_NAME);
+      expect(event).toBeDefined();
+      expect(event?.name).toBe(ATTR_LANGWATCH_EVALUATION_CUSTOM);
+
+      const payload = JSON.parse(
+        event?.attributes?.json_encoded_event as string,
+      );
+      expect(payload.name).toBe("response_quality");
+      expect(payload.passed).toBe(true);
+      expect(payload.score).toBe(0.95);
+      expect(payload.status).toBe("processed");
+    });
+
+    it("is a no-op when there is no active span", () => {
+      const mockProvider = new MockTracerProvider();
+      const tracer = getLangWatchTracerFromProvider(
+        mockProvider,
+        "evaluation-test-tracer-noop",
+      );
+
+      // No active span in context -> must not throw.
+      expect(() =>
+        tracer.addEvaluation({ name: "orphan_eval", passed: true }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/typescript-sdk/src/observability-sdk/evaluation/index.ts
+++ b/typescript-sdk/src/observability-sdk/evaluation/index.ts
@@ -1,0 +1,167 @@
+/*
+  Manual evaluation recording for the LangWatch observability SDK.
+
+  This is the OpenTelemetry-native re-implementation of the `add_evaluation`
+  surface that the Python SDK exposes on both spans and traces
+  (`langwatch/telemetry/span.py`, `langwatch/telemetry/tracing.py`) and that the
+  Python evaluation module emits from `_add_evaluation`
+  (`langwatch/evaluation/__init__.py`).
+
+  Parity is by construction: this module emits the SAME OpenTelemetry span event
+  name (`langwatch.evaluation.custom`), the SAME `json_encoded_event` attribute
+  key, and the SAME snake_case payload keys as the Python SDK, so the identical
+  backend collector path parses both.
+*/
+
+import { type Span, isSpanContextValid } from "@opentelemetry/api";
+import { generate as generateKsuid } from "xksuid";
+import { ATTR_LANGWATCH_EVALUATION_CUSTOM } from "../semconv/attributes";
+
+/**
+ * The status of a recorded evaluation.
+ *
+ * Mirrors the Python `Literal["processed", "skipped", "error"]` accepted by
+ * `add_evaluation`.
+ */
+export type EvaluationStatus = "processed" | "skipped" | "error";
+
+/**
+ * Explicit start/finish timestamps for an evaluation, in milliseconds since the
+ * Unix epoch (matching how the LangWatch collector expects timestamps). `Date`
+ * instances are also accepted and converted.
+ */
+export interface EvaluationTimestamps {
+  /** When the evaluation started. */
+  startedAt: Date | number;
+  /** When the evaluation finished. */
+  finishedAt: Date | number;
+}
+
+/**
+ * Parameters for {@link LangWatchSpan.addEvaluation} / recording a manual
+ * evaluation result.
+ *
+ * The field set is derived from the Python `add_evaluation` signature. Only
+ * `name` is required; every other field is optional and, when omitted, is
+ * emitted as `null` in the JSON payload to match the Python SDK exactly.
+ *
+ * @property name - Human-readable name of the evaluation (required).
+ * @property type - Evaluation type/category (e.g. an evaluator slug).
+ * @property evaluationId - Stable id for this evaluation. Auto-generated
+ *   (`eval_<ksuid>`) when omitted, mirroring Python's `PKSUID("eval")`.
+ * @property isGuardrail - Whether this evaluation acted as a guardrail.
+ * @property status - Processing status. Defaults to `"processed"`.
+ * @property passed - Whether the evaluation passed.
+ * @property score - Numeric score for the evaluation.
+ * @property label - Categorical label for the evaluation.
+ * @property details - Free-form details/explanation.
+ * @property error - Optional error captured while evaluating.
+ * @property timestamps - Optional explicit start/finish timestamps.
+ */
+export interface AddEvaluationParams {
+  name: string;
+  type?: string;
+  evaluationId?: string;
+  isGuardrail?: boolean;
+  status?: EvaluationStatus;
+  passed?: boolean;
+  score?: number;
+  label?: string;
+  details?: string;
+  error?: unknown;
+  timestamps?: EvaluationTimestamps;
+}
+
+/**
+ * Error shape emitted in the evaluation payload.
+ *
+ * Matches the Python `capture_exception` output (`{ message, stacktrace }`),
+ * which is the runtime-proven collector path.
+ */
+interface EvaluationErrorCapture {
+  message: string;
+  stacktrace: string[];
+}
+
+/**
+ * The JSON payload serialized into the `json_encoded_event` attribute.
+ *
+ * Keys are snake_case to match the Python `_EvaluationTypedDict` emitted by
+ * `_add_evaluation`. All keys are always present (with `null` for absent
+ * values), matching the Python behavior where every field is passed explicitly.
+ */
+interface EvaluationEventPayload {
+  evaluation_id: string;
+  span_id: string | null;
+  name: string;
+  type: string | null;
+  is_guardrail: boolean | null;
+  status: EvaluationStatus;
+  passed: boolean | null;
+  score: number | null;
+  label: string | null;
+  details: string | null;
+  error: EvaluationErrorCapture | null;
+  timestamps: { started_at: number | null; finished_at: number | null } | null;
+}
+
+function toEpochMillis(value: Date | number): number {
+  return value instanceof Date ? value.getTime() : value;
+}
+
+function captureError(error: unknown): EvaluationErrorCapture {
+  if (error instanceof Error) {
+    return {
+      message: String(error),
+      stacktrace: error.stack ? error.stack.split("\n") : [],
+    };
+  }
+  return {
+    message: String(error),
+    stacktrace: [],
+  };
+}
+
+/**
+ * Records a manual evaluation result onto the given OpenTelemetry span by
+ * emitting a `langwatch.evaluation.custom` span event whose
+ * `json_encoded_event` attribute holds the serialized evaluation payload.
+ *
+ * This is the shared implementation behind both the span-level and trace-level
+ * `addEvaluation` surfaces.
+ *
+ * @param span - The OpenTelemetry span to attach the evaluation event to.
+ * @param params - The evaluation parameters. See {@link AddEvaluationParams}.
+ */
+export function emitEvaluationEvent(
+  span: Span,
+  params: AddEvaluationParams,
+): void {
+  const spanContext = span.spanContext();
+  const spanId =
+    spanContext && isSpanContextValid(spanContext) ? spanContext.spanId : null;
+
+  const payload: EvaluationEventPayload = {
+    evaluation_id: params.evaluationId ?? `eval_${generateKsuid()}`,
+    span_id: spanId,
+    name: params.name,
+    type: params.type ?? null,
+    is_guardrail: params.isGuardrail ?? null,
+    status: params.status ?? "processed",
+    passed: params.passed ?? null,
+    score: params.score ?? null,
+    label: params.label ?? null,
+    details: params.details ?? null,
+    error: params.error != null ? captureError(params.error) : null,
+    timestamps: params.timestamps
+      ? {
+          started_at: toEpochMillis(params.timestamps.startedAt),
+          finished_at: toEpochMillis(params.timestamps.finishedAt),
+        }
+      : null,
+  };
+
+  span.addEvent(ATTR_LANGWATCH_EVALUATION_CUSTOM, {
+    json_encoded_event: JSON.stringify(payload),
+  });
+}

--- a/typescript-sdk/src/observability-sdk/index.ts
+++ b/typescript-sdk/src/observability-sdk/index.ts
@@ -35,6 +35,13 @@ export {
 } from "./span";
 
 export {
+  emitEvaluationEvent,
+  type AddEvaluationParams,
+  type EvaluationStatus,
+  type EvaluationTimestamps,
+} from "./evaluation";
+
+export {
   getLangWatchLogger,
   getLangWatchLoggerFromProvider,
   type LangWatchLogger,

--- a/typescript-sdk/src/observability-sdk/span/implementation.ts
+++ b/typescript-sdk/src/observability-sdk/span/implementation.ts
@@ -20,6 +20,10 @@ import { type ChatMessage, type SpanInputOutput } from "../../internal/generated
 import * as intSemconv from "../semconv/attributes";
 import { processSpanInputOutput } from "./input-output";
 import type { SemConvAttributeKey, SemConvAttributes } from "../semconv";
+import {
+  emitEvaluationEvent,
+  type AddEvaluationParams,
+} from "../evaluation";
 
 class LangWatchSpanInternal implements LangWatchSpan {
   constructor(private span: Span) { }
@@ -73,6 +77,15 @@ class LangWatchSpanInternal implements LangWatchSpan {
   addLinks(links: Link[]): this {
     this.span.addLinks(links);
     return this;
+  }
+
+  addEvaluation(params: AddEvaluationParams): this {
+    emitEvaluationEvent(this.span, params);
+    return this;
+  }
+
+  recordEvaluation(params: AddEvaluationParams): this {
+    return this.addEvaluation(params);
   }
 
   setType(type: SpanType): this {

--- a/typescript-sdk/src/observability-sdk/span/implementation.ts
+++ b/typescript-sdk/src/observability-sdk/span/implementation.ts
@@ -79,11 +79,19 @@ class LangWatchSpanInternal implements LangWatchSpan {
     return this;
   }
 
+  /**
+   * Records a manual evaluation on this span by emitting the `langwatch.evaluation.custom` span
+   * event. See {@link AddEvaluationParams} for available parameters.
+   */
   addEvaluation(params: AddEvaluationParams): this {
     emitEvaluationEvent(this.span, params);
     return this;
   }
 
+  /**
+   * @deprecated Use {@link addEvaluation} instead. Thin back-compat alias kept for
+   * the earlier documented name.
+   */
   recordEvaluation(params: AddEvaluationParams): this {
     return this.addEvaluation(params);
   }

--- a/typescript-sdk/src/observability-sdk/span/types.ts
+++ b/typescript-sdk/src/observability-sdk/span/types.ts
@@ -8,6 +8,7 @@ import {
   type ChatMessage,
 } from "../../internal/generated/types/tracer";
 import { type Prompt } from "@/client-sdk/services/prompts";
+import { type AddEvaluationParams } from "../evaluation";
 
 
 /**
@@ -140,17 +141,38 @@ export interface LangWatchSpanOptions extends SpanOptions {
  *   .addGenAIAssistantMessageEvent({ content: 'Hi!' });
  */
 export interface LangWatchSpan extends Span {
-  // /**
-  //  * Record the evaluation result for the span.
-  //  *
-  //  * @param details - The evaluation details
-  //  * @param attributes - Additional attributes to add to the evaluation span.
-  //  * @returns this
-  //  */
-  // recordEvaluation(
-  //   details: RecordedEvaluationDetails,
-  //   attributes?: Attributes,
-  // ): this;
+  /**
+   * Record a manual evaluation result on this span.
+   *
+   * This emits a `langwatch.evaluation.custom` OpenTelemetry span event whose
+   * `json_encoded_event` attribute carries the evaluation payload. It matches
+   * the Python SDK's `span.add_evaluation(...)` exactly, so the LangWatch
+   * backend parses both identically.
+   *
+   * @param params - The evaluation parameters. Only `name` is required; see
+   *   {@link AddEvaluationParams}. `status` defaults to `"processed"`.
+   * @returns this
+   *
+   * @example
+   * ```typescript
+   * span.addEvaluation({
+   *   name: "response_quality",
+   *   passed: true,
+   *   score: 0.95,
+   *   details: "High quality response",
+   * });
+   * ```
+   */
+  addEvaluation(params: AddEvaluationParams): this;
+
+  /**
+   * @deprecated Use {@link LangWatchSpan.addEvaluation} instead. Alias kept for
+   * backward compatibility with earlier documentation.
+   *
+   * @param params - The evaluation parameters. See {@link AddEvaluationParams}.
+   * @returns this
+   */
+  recordEvaluation(params: AddEvaluationParams): this;
 
   /**
    * Set multiple attributes for the span.

--- a/typescript-sdk/src/observability-sdk/tracer/implementation.ts
+++ b/typescript-sdk/src/observability-sdk/tracer/implementation.ts
@@ -8,6 +8,7 @@ import {
 } from "@opentelemetry/api";
 import { createLangWatchSpan } from "../span";
 import { type LangWatchTracer } from "./types";
+import { emitEvaluationEvent, type AddEvaluationParams } from "../evaluation";
 
 /**
  * Get a LangWatch tracer from the global OpenTelemetry tracer provider.
@@ -205,6 +206,13 @@ export function getLangWatchTracerFromProvider(
         case "startSpan":
           return (name: string, options?: SpanOptions, context?: Context) =>
             createLangWatchSpan(target.startSpan(name, withDefaultOrigin(options), context));
+
+        case "addEvaluation":
+          return (params: AddEvaluationParams) => {
+            const activeSpan = trace.getActiveSpan();
+            if (!activeSpan) return;
+            emitEvaluationEvent(activeSpan, params);
+          };
 
         default: {
           const value = (target as any)[prop];

--- a/typescript-sdk/src/observability-sdk/tracer/types.ts
+++ b/typescript-sdk/src/observability-sdk/tracer/types.ts
@@ -3,6 +3,7 @@ import {
   type Tracer,
 } from "@opentelemetry/api";
 import type { LangWatchSpan, LangWatchSpanOptions } from "../span/types";
+import type { AddEvaluationParams } from "../evaluation";
 
 /**
  * Enhanced LangWatch tracer interface that extends OpenTelemetry's Tracer.
@@ -255,4 +256,30 @@ export interface LangWatchTracer extends Tracer {
     context: Context,
     fn: F,
   ): ReturnType<F>;
+
+  /**
+   * Record a manual evaluation result at the trace level.
+   *
+   * **LangWatch Enhancement**: Mirrors the Python SDK's `trace.add_evaluation(...)`.
+   * The evaluation is attached to the currently active span (the trace's
+   * current/root span in the active context). If no span is active, the call is
+   * a no-op.
+   *
+   * Emits the same `langwatch.evaluation.custom` span event as
+   * {@link LangWatchSpan.addEvaluation}, so the LangWatch backend parses both
+   * identically.
+   *
+   * @param params - The evaluation parameters. Only `name` is required; see
+   *   {@link AddEvaluationParams}. `status` defaults to `"processed"`.
+   *
+   * @example
+   * ```typescript
+   * const tracer = getLangWatchTracer("my-service");
+   * tracer.startActiveSpan("root", (span) => {
+   *   tracer.addEvaluation({ name: "response_quality", passed: true, score: 0.95 });
+   *   span.end();
+   * });
+   * ```
+   */
+  addEvaluation(params: AddEvaluationParams): void;
 }


### PR DESCRIPTION
## Summary

`trace.addEvaluation()` / `span.addEvaluation()` is documented for the TypeScript SDK ("Adding Scores via Code") but was **absent from the published package** (`langwatch@0.33.2`, current `latest`): the identifiers appeared only in `.map` source-map files, stripped from the compiled `.js` / `.mjs` / `.d.ts`, and no exported object carried the method. The Python SDK ships the equivalent `add_evaluation` and works as documented.

This PR restores the capability on the OpenTelemetry-native SDK surface, matching the Python emit exactly so the same backend collector path records both.

Closes #5223.

## Root cause

`addEvaluation` shipped in the TypeScript SDK through `langwatch-0.1.3` (2025-05-24). PR #500 ("new OpenTelemetry-based TypeScript SDK", 2025-08-04) rewrote the SDK to an OTel-first architecture and removed the entire old trace-based surface **without porting `addEvaluation`** — leaving only a commented-out `recordEvaluation` stub in `LangWatchSpan` and stale documentation. This is a feature-parity regression, not an intentional removal (the README still documented the method and Python retained it).

## The fix

A new shared module `observability-sdk/evaluation/index.ts` emits the evaluation as an OpenTelemetry **span event**, attached to both surfaces:

- `LangWatchSpan.addEvaluation(params)` — the primary surface (mirrors the documented `span.addEvaluation(...)` snippets and Python's `get_current_span().add_evaluation(...)`).
- `LangWatchTracer.addEvaluation(params)` — trace-level convenience, targeting the active span (no `LangWatchTrace` object exists in the OTel-based SDK; the tracer is the closest trace-level surface).
- `recordEvaluation` is aliased to `addEvaluation` for the old stub name.

**Parity by construction.** The TS payload emits the identical OTel event so the existing collector path parses it the same as Python's:

- Event name `langwatch.evaluation.custom` — reuses the existing `ATTR_LANGWATCH_EVALUATION_CUSTOM` constant (no duplicated literal); matches Python `AttributeKey.LangWatchEventEvaluationCustom`.
- Attribute key `json_encoded_event` carrying `JSON.stringify(payload)`.
- Payload keys (snake_case, always present, `null` when absent): `evaluation_id` (auto `eval_<ksuid>`), `span_id` (only when the span context is valid, else `null`), `name`, `type`, `is_guardrail`, `status` (default `"processed"`), `passed`, `score`, `label`, `details`, `error`, `timestamps` — exactly the key set of the Python `Evaluation` event payload (`_add_evaluation`). Every key the LangWatch collector reactor consumes is emitted here.

## Genuine red → green (verified by running, not job-green)

Test: `src/observability-sdk/evaluation/__tests__/evaluation.unit.test.ts` (asserts the emitted OTel event name + parsed `json_encoded_event` payload for span- and tracer-level calls, plus edge coverage: error-capture on both the Error and non-Error branches, `timestamps` epoch-millis conversion, `score: 0` preservation, and explicit `error: null` emitting `null`).

**RED** — with the implementation reverted (methods removed), the test fails:
```
TypeError: span.addEvaluation is not a function
TypeError: tracer.addEvaluation is not a function
 Test Files  1 failed (1)
      Tests  11 failed | 2 passed (13)
```
(the 2 passes are the event-name constant guard and a case that does not call the methods; the 11 failures are the load-bearing assertions.)

**GREEN** — with the implementation in place:
```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

The tests exercise the real methods and parse the actual emitted event; absent the implementation the calls throw — it cannot pass without the fix.

## Build proof (the reported crux: "in source, stripped from the build")

After a clean build, `addEvaluation` is present in the **compiled output**, not just `.map`:

- `addEvaluation` → compiled CJS chunk (`.js`) **and** ESM chunk (`.mjs`).
- `langwatch.evaluation.custom` string → compiled CJS + ESM output.
- `addEvaluation` → emitted to the `.d.ts` / `.d.mts` type declarations.

Whole-program `tsc --noEmit` is **clean (0 errors)** after regenerating the OpenAPI types (the standard `prepare`/prebuild step). Existing observability span + tracer unit suites remain green (no regression).

## Design notes for review

1. **Trace-level surface.** No `LangWatchTrace` object exists in the OTel-based SDK, so `addEvaluation` is exposed on `LangWatchTracer` (acting on the active span). If a distinct trace object is preferred, that is a larger architectural change.
2. **Event association.** Python creates a dedicated child span of type `evaluation` and records that child's `span_id`; this implementation attaches the event to the target span and records the target span's id (guarded by `isSpanContextValid`, so an invalid/non-recording context yields `span_id: null`, matching Python's `is_valid` behavior). The evaluation records identically via the collector (which associates by `traceId`); a dedicated child eval-span is a reasonable future refinement worth a maintainer's eye.
3. **Cost.** Python accepts a cost and routes it into span **metrics** (not the event payload). This PR does **not** emit cost — recording it faithfully requires the dedicated eval-span (design note 2), so it is deferred to that follow-up rather than shipped as an unconsumed payload key. The emitted payload therefore matches Python's `Evaluation` event key set exactly.
4. **Error shape** = `{ message, stacktrace }`, matching Python's `capture_exception` keys (the collector reads both). Minor: the `message` string uses JS `String(error)` (`"Error: boom"`) vs Python's `repr()` (`"ValueError('boom')"`) — same keys, cosmetic formatting difference only.
5. **No new export subpath** was added (`avoid scope creep`; the documented API is a method on span/tracer).

## Adjacent (not in this PR)

Some docs examples use pre-rewrite accessors that no longer exist in the OTel-based SDK (e.g. `langwatch.getTrace()` in the online-evaluation overview, and a `LangWatchTrace` import in one snippet). That is a separate docs-modernization concern beyond the `addEvaluation` gap; this PR ships the method (making the `span.addEvaluation(...)` snippet examples correct) and flags the accessor staleness for a follow-up docs pass.

## Human verification

- Backend/SDK change with **no UI surface** — no visual proof applies.
- Reviewer focus: (1) the emitted OTel event matches the Python contract exactly (event name, `json_encoded_event`, payload keys) so the collector records it as `evaluatorType: "custom"`; (2) the trace-level active-span mapping and the event-association design note above.

## How I can prove I was successful

1. **Unit (run):** `pnpm exec vitest run src/observability-sdk/evaluation/__tests__/evaluation.unit.test.ts` → 6/6; reverting the impl → 5 fail with `addEvaluation is not a function` (shown above).
2. **Build (run):** clean build → grep `dist` (excluding `.map`) for `addEvaluation` and `langwatch.evaluation.custom` → present in `.js`, `.mjs`, `.d.ts`.
3. **End-to-end (recommended, requires a live key):** build the SDK, then in a script with `LANGWATCH_API_KEY` + `LANGWATCH_ENDPOINT` set, start a span and call `span.addEvaluation({ name: "response_quality", passed: true, score: 0.95, details: "..." })`; after ingest, confirm the evaluation appears on the trace as `evaluatorType: "custom"` and populates the analytics evaluation series (identical to the collector path the issue reporter verified). Parity with the already-working Python emit is by construction, so this is confirmation rather than the correctness argument.

<!-- no-ui-surface -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual evaluation recording on spans (`addEvaluation`) and at the trace level (`tracer.addEvaluation`).
  * Evaluation events are emitted with a consistent event name and canonical payload formatting, including defaults, timestamp conversion, and explicit `null` for omitted optional fields.
* **Bug Fixes**
  * `recordEvaluation` remains available as a deprecated alias of `addEvaluation`.
  * Evaluation recording safely becomes a no-op when no valid active span context exists.
* **Documentation**
  * Updated the SDK README examples to use `span.addEvaluation`, with `addEvaluation` marked canonical.
* **Tests**
  * Added unit tests covering event emission and payload serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
