### PR TITLE
chore(tests): adopt nested given/when BDD structure in 4 prompt test files (#4949)

### DIFF
--- a/langwatch/src/prompts/hooks/__tests__/usePromptConfigForm.systemPromptRequired.integration.test.tsx
+++ b/langwatch/src/prompts/hooks/__tests__/usePromptConfigForm.systemPromptRequired.integration.test.tsx
@@ -111,69 +111,71 @@ describe("usePromptConfigForm — system-prompt-required save flow (Issue #3196)
     cleanup();
   });
 
-  describe("when the system message is empty on initial render", () => {
-    /** @scenario "Save is disabled when the workflow prompt's system message is empty" */
-    it("disables the Save button, renders the inline required-field error, and blocks the mutation", async () => {
-      const calls: MutationCall[] = [];
-      render(
-        <PromptSaveHarness
-          initialMessages={[
-            { role: "system", content: "" },
-            { role: "user", content: "{{input}}" },
-          ]}
-          onMutationFire={(call) => calls.push(call)}
-        />,
-      );
+  describe("given a form rendered with an empty system message", () => {
+    describe("when the system message is empty on initial render", () => {
+      /** @scenario "Save is disabled when the workflow prompt's system message is empty" */
+      it("disables the Save button, renders the inline required-field error, and blocks the mutation", async () => {
+        const calls: MutationCall[] = [];
+        render(
+          <PromptSaveHarness
+            initialMessages={[
+              { role: "system", content: "" },
+              { role: "user", content: "{{input}}" },
+            ]}
+            onMutationFire={(call) => calls.push(call)}
+          />,
+        );
 
-      const saveButton = screen.getByRole("button", { name: "Save" });
-      await waitFor(() => expect(saveButton).toBeDisabled());
+        const saveButton = screen.getByRole("button", { name: "Save" });
+        await waitFor(() => expect(saveButton).toBeDisabled());
 
-      const alert = await screen.findByRole("alert");
-      expect(alert.textContent).toMatch(/system prompt is required/i);
+        const alert = await screen.findByRole("alert");
+        expect(alert.textContent).toMatch(/system prompt is required/i);
 
-      // Even if the disabled attribute is bypassed (e.g. via the keyboard or
-      // a programmatic submit), the click handler must still bail on the
-      // failed `methods.trigger()` — no mutation should fire.
-      await act(async () => {
-        saveButton.removeAttribute("disabled");
-        saveButton.click();
+        // Even if the disabled attribute is bypassed (e.g. via the keyboard or
+        // a programmatic submit), the click handler must still bail on the
+        // failed `methods.trigger()` — no mutation should fire.
+        await act(async () => {
+          saveButton.removeAttribute("disabled");
+          saveButton.click();
+        });
+        expect(calls).toHaveLength(0);
       });
-      expect(calls).toHaveLength(0);
     });
-  });
 
-  describe("when the user types a non-empty system message into the empty form", () => {
-    // The @e2e happy-path binding covers AC 4 at integration scope —
-    // the save handler firing with the supplied system content is
-    // the regression surface.  Browser-level e2e queued as follow-up.
-    /** @scenario "Save becomes enabled once the user fills in a system prompt" */
-    /** @scenario "Workflow with a valid system prompt saves successfully (happy-path regression)" */
-    it("clears the inline error, re-enables Save, and fires the mutation with the typed content", async () => {
-      const calls: MutationCall[] = [];
-      const user = userEvent.setup();
-      render(
-        <PromptSaveHarness
-          initialMessages={[
-            { role: "system", content: "" },
-            { role: "user", content: "{{input}}" },
-          ]}
-          onMutationFire={(call) => calls.push(call)}
-        />,
-      );
+    describe("when the user types a non-empty system message into the empty form", () => {
+      // The @e2e happy-path binding covers AC 4 at integration scope —
+      // the save handler firing with the supplied system content is
+      // the regression surface.  Browser-level e2e queued as follow-up.
+      /** @scenario "Save becomes enabled once the user fills in a system prompt" */
+      /** @scenario "Workflow with a valid system prompt saves successfully (happy-path regression)" */
+      it("clears the inline error, re-enables Save, and fires the mutation with the typed content", async () => {
+        const calls: MutationCall[] = [];
+        const user = userEvent.setup();
+        render(
+          <PromptSaveHarness
+            initialMessages={[
+              { role: "system", content: "" },
+              { role: "user", content: "{{input}}" },
+            ]}
+            onMutationFire={(call) => calls.push(call)}
+          />,
+        );
 
-      const saveButton = screen.getByRole("button", { name: "Save" });
-      await waitFor(() => expect(saveButton).toBeDisabled());
-      await screen.findByRole("alert");
+        const saveButton = screen.getByRole("button", { name: "Save" });
+        await waitFor(() => expect(saveButton).toBeDisabled());
+        await screen.findByRole("alert");
 
-      const textarea = screen.getByLabelText("system-content");
-      await user.type(textarea, "You are a helpful assistant.");
+        const textarea = screen.getByLabelText("system-content");
+        await user.type(textarea, "You are a helpful assistant.");
 
-      await waitFor(() => expect(saveButton).not.toBeDisabled());
-      expect(screen.queryByRole("alert")).toBeNull();
+        await waitFor(() => expect(saveButton).not.toBeDisabled());
+        expect(screen.queryByRole("alert")).toBeNull();
 
-      await user.click(saveButton);
-      await waitFor(() => expect(calls).toHaveLength(1));
-      expect(calls[0]?.systemContent).toBe("You are a helpful assistant.");
+        await user.click(saveButton);
+        await waitFor(() => expect(calls).toHaveLength(1));
+        expect(calls[0]?.systemContent).toBe("You are a helpful assistant.");
+      });
     });
   });
 });

--- a/langwatch/src/prompts/schemas/__tests__/form-schema.test.ts
+++ b/langwatch/src/prompts/schemas/__tests__/form-schema.test.ts
@@ -27,72 +27,74 @@ describe("formSchemaForSave — system prompt required refinement (Issue #3196)"
     };
   }
 
-  describe("when the messages array has no system message", () => {
-    /** @scenario "Prompt form schema rejects messages with no system content" */
-    it("reports a system-prompt-required error on the messages path", () => {
-      const result = formSchemaForSave.safeParse(
-        valuesWithMessages([{ role: "user", content: "{{input}}" }]),
-      );
+  describe("given a prompt form", () => {
+    describe("when the messages array has no system message", () => {
+      /** @scenario "Prompt form schema rejects messages with no system content" */
+      it("reports a system-prompt-required error on the messages path", () => {
+        const result = formSchemaForSave.safeParse(
+          valuesWithMessages([{ role: "user", content: "{{input}}" }]),
+        );
 
-      expect(result.success).toBe(false);
-      if (result.success) return;
-      const messagesPath = result.error.issues.find(
-        (issue) =>
-          issue.path[0] === "version" &&
-          issue.path[1] === "configData" &&
-          issue.path[2] === "messages",
-      );
-      expect(messagesPath).toBeDefined();
-      expect(messagesPath?.message).toMatch(/system prompt is required/i);
-    });
-  });
-
-  describe("when the system message exists but is empty / whitespace only", () => {
-    /** @scenario "Prompt form schema rejects messages with no system content" */
-    it("rejects an empty-string system message", () => {
-      const result = formSchemaForSave.safeParse(
-        valuesWithMessages([
-          { role: "system", content: "" },
-          { role: "user", content: "{{input}}" },
-        ]),
-      );
-
-      expect(result.success).toBe(false);
-      if (result.success) return;
-      const messagesPath = result.error.issues.find(
-        (issue) => issue.path[2] === "messages",
-      );
-      expect(messagesPath?.message).toMatch(/system prompt is required/i);
+        expect(result.success).toBe(false);
+        if (result.success) return;
+        const messagesPath = result.error.issues.find(
+          (issue) =>
+            issue.path[0] === "version" &&
+            issue.path[1] === "configData" &&
+            issue.path[2] === "messages",
+        );
+        expect(messagesPath).toBeDefined();
+        expect(messagesPath?.message).toMatch(/system prompt is required/i);
+      });
     });
 
-    /** @scenario "Prompt form schema rejects messages with no system content" */
-    it("rejects a whitespace-only system message", () => {
-      const result = formSchemaForSave.safeParse(
-        valuesWithMessages([
-          { role: "system", content: "   \n\t  " },
-          { role: "user", content: "{{input}}" },
-        ]),
-      );
+    describe("when the system message exists but is empty / whitespace only", () => {
+      /** @scenario "Prompt form schema rejects messages with no system content" */
+      it("rejects an empty-string system message", () => {
+        const result = formSchemaForSave.safeParse(
+          valuesWithMessages([
+            { role: "system", content: "" },
+            { role: "user", content: "{{input}}" },
+          ]),
+        );
 
-      expect(result.success).toBe(false);
-      if (result.success) return;
-      const messagesPath = result.error.issues.find(
-        (issue) => issue.path[2] === "messages",
-      );
-      expect(messagesPath?.message).toMatch(/system prompt is required/i);
+        expect(result.success).toBe(false);
+        if (result.success) return;
+        const messagesPath = result.error.issues.find(
+          (issue) => issue.path[2] === "messages",
+        );
+        expect(messagesPath?.message).toMatch(/system prompt is required/i);
+      });
+
+      /** @scenario "Prompt form schema rejects messages with no system content" */
+      it("rejects a whitespace-only system message", () => {
+        const result = formSchemaForSave.safeParse(
+          valuesWithMessages([
+            { role: "system", content: "   \n\t  " },
+            { role: "user", content: "{{input}}" },
+          ]),
+        );
+
+        expect(result.success).toBe(false);
+        if (result.success) return;
+        const messagesPath = result.error.issues.find(
+          (issue) => issue.path[2] === "messages",
+        );
+        expect(messagesPath?.message).toMatch(/system prompt is required/i);
+      });
     });
-  });
 
-  describe("when the system message has non-empty content", () => {
-    it("passes validation (happy path / no regression on AC 4)", () => {
-      const result = formSchemaForSave.safeParse(
-        valuesWithMessages([
-          { role: "system", content: "You are a helpful assistant." },
-          { role: "user", content: "{{input}}" },
-        ]),
-      );
+    describe("when the system message has non-empty content", () => {
+      it("passes validation (happy path / no regression on AC 4)", () => {
+        const result = formSchemaForSave.safeParse(
+          valuesWithMessages([
+            { role: "system", content: "You are a helpful assistant." },
+            { role: "user", content: "{{input}}" },
+          ]),
+        );
 
-      expect(result.success).toBe(true);
+        expect(result.success).toBe(true);
+      });
     });
   });
 });

--- a/langwatch/src/prompts/utils/__tests__/llmPromptConfigUtils.test.ts
+++ b/langwatch/src/prompts/utils/__tests__/llmPromptConfigUtils.test.ts
@@ -885,53 +885,57 @@ describe("formSchema runtime parameters validation", () => {
  * a unit test — the shape is small and stable.
  */
 describe("nodeDataToLocalPromptConfig — workflow scaffold round-trip (Issue #3196)", () => {
-  // Binds the @e2e scenario at integration scope — the round-trip
-  // through the bridge is the bug surface (Bug 1).  Browser-level
-  // e2e is queued as a follow-up.
-  /** @scenario "New workflow's default prompt node is scaffolded with the default system prompt" */
-  it("preserves the registry's default system message when converting the scaffolded signature node to LocalPromptConfig", () => {
-    const scaffoldedNodeData = {
-      inputs: [{ identifier: "input", type: "str" as const }],
-      outputs: [{ identifier: "output", type: "str" as const }],
-      parameters: [
-        {
-          identifier: "llm",
-          type: "llm" as const,
-          value: {
-            model: "openai/gpt-5-mini",
-            temperature: 0,
-            max_tokens: 2048,
-          },
-        },
-        {
-          identifier: "prompting_technique",
-          type: "prompting_technique" as const,
-          value: undefined,
-        },
-        {
-          identifier: "instructions",
-          type: "str" as const,
-          value: "You are a helpful assistant.",
-        },
-        {
-          identifier: "messages",
-          type: "chat_messages" as const,
-          value: [{ role: "user" as const, content: "{{input}}" }],
-        },
-        {
-          identifier: "demonstrations",
-          type: "dataset" as const,
-          value: undefined,
-        },
-      ],
-    } as any;
+  describe("given a scaffolded signature node carrying the registry's default system message", () => {
+    describe("when converting the node data to LocalPromptConfig", () => {
+      // Binds the @e2e scenario at integration scope — the round-trip
+      // through the bridge is the bug surface (Bug 1).  Browser-level
+      // e2e is queued as a follow-up.
+      /** @scenario "New workflow's default prompt node is scaffolded with the default system prompt" */
+      it("preserves the default system message in the messages array", () => {
+        const scaffoldedNodeData = {
+          inputs: [{ identifier: "input", type: "str" as const }],
+          outputs: [{ identifier: "output", type: "str" as const }],
+          parameters: [
+            {
+              identifier: "llm",
+              type: "llm" as const,
+              value: {
+                model: "openai/gpt-5-mini",
+                temperature: 0,
+                max_tokens: 2048,
+              },
+            },
+            {
+              identifier: "prompting_technique",
+              type: "prompting_technique" as const,
+              value: undefined,
+            },
+            {
+              identifier: "instructions",
+              type: "str" as const,
+              value: "You are a helpful assistant.",
+            },
+            {
+              identifier: "messages",
+              type: "chat_messages" as const,
+              value: [{ role: "user" as const, content: "{{input}}" }],
+            },
+            {
+              identifier: "demonstrations",
+              type: "dataset" as const,
+              value: undefined,
+            },
+          ],
+        } as any;
 
-    const result = nodeDataToLocalPromptConfig(scaffoldedNodeData);
+        const result = nodeDataToLocalPromptConfig(scaffoldedNodeData);
 
-    expect(result).not.toBeUndefined();
-    expect(result!.messages).toEqual([
-      { role: "system", content: "You are a helpful assistant." },
-      { role: "user", content: "{{input}}" },
-    ]);
+        expect(result).not.toBeUndefined();
+        expect(result!.messages).toEqual([
+          { role: "system", content: "You are a helpful assistant." },
+          { role: "user", content: "{{input}}" },
+        ]);
+      });
+    });
   });
 });

--- a/langwatch/src/server/prompt-config/__tests__/system-prompt-required.unit.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/system-prompt-required.unit.test.ts
@@ -28,61 +28,71 @@ import { PromptVersionService } from "~/server/prompt-config/prompt-version.serv
 vi.mock("~/server/prompt-config/repositories");
 
 describe("PromptService.createPrompt — missing system prompt (Issue #3196 regression)", () => {
-  /** @scenario "prompts.create returns 400 BAD_REQUEST when both prompt and system message are missing" */
-  it("throws a DomainError with httpStatus 400 and kind 'system_prompt_required' when no prompt and no system message are supplied", async () => {
-    const service = new PromptService({} as any);
-    (service as any).repository = {
-      createConfigWithInitialVersion: vi.fn(),
-    };
-    (service as any).versionService = {
-      assertNoSystemPromptConflict: vi.fn(),
-    };
-    (service as any).getOrganizationIdFromProjectId = vi
-      .fn()
-      .mockResolvedValue("org-1");
+  describe("given a PromptService", () => {
+    describe("when creating a prompt with neither a prompt nor a system message", () => {
+      /** @scenario "prompts.create returns 400 BAD_REQUEST when both prompt and system message are missing" */
+      it("throws a DomainError with httpStatus 400 and kind 'system_prompt_required' when no prompt and no system message are supplied", async () => {
+        const service = new PromptService({} as any);
+        (service as any).repository = {
+          createConfigWithInitialVersion: vi.fn(),
+        };
+        (service as any).versionService = {
+          assertNoSystemPromptConflict: vi.fn(),
+        };
+        (service as any).getOrganizationIdFromProjectId = vi
+          .fn()
+          .mockResolvedValue("org-1");
 
-    const error = await captureError(() =>
-      service.createPrompt({
-        projectId: "project-1",
-        handle: "missing-system-prompt",
-        messages: [{ role: "user", content: "{{input}}" }],
-      }),
-    );
+        const error = await captureError(() =>
+          service.createPrompt({
+            projectId: "project-1",
+            handle: "missing-system-prompt",
+            messages: [{ role: "user", content: "{{input}}" }],
+          }),
+        );
 
-    expect(error).toBeInstanceOf(DomainError);
-    expect((error as DomainError).kind).toBe("system_prompt_required");
-    expect((error as DomainError).httpStatus).toBe(400);
-    expect((error as Error).message).toMatch(/system prompt is required/i);
-    expect((error as Error).message).not.toMatch(/SystemPromptConflictError/);
-  });
+        expect(error).toBeInstanceOf(DomainError);
+        expect((error as DomainError).kind).toBe("system_prompt_required");
+        expect((error as DomainError).httpStatus).toBe(400);
+        expect((error as Error).message).toMatch(/system prompt is required/i);
+        expect((error as Error).message).not.toMatch(
+          /SystemPromptConflictError/,
+        );
+      });
+    });
 
-  /** @scenario "prompts.create still rejects when both prompt and a system message are provided (existing conflict preserved)" */
-  it("still throws a DomainError with httpStatus 409 when both prompt and a system message are provided (no regression on AC 5)", async () => {
-    const service = new PromptService({} as any);
-    (service as any).repository = {
-      createConfigWithInitialVersion: vi.fn(),
-    };
-    // Use the real PromptVersionService so we exercise the real conflict
-    // error class, not a synthetic mock. This guards against regression on
-    // AC 5 — both prompt + system message together must still throw the
-    // existing 409 conflict error.
-    (service as any).versionService = new PromptVersionService({} as any);
-    (service as any).getOrganizationIdFromProjectId = vi
-      .fn()
-      .mockResolvedValue("org-1");
+    describe("when creating a prompt with both a prompt and a system message", () => {
+      /** @scenario "prompts.create still rejects when both prompt and a system message are provided (existing conflict preserved)" */
+      it("still throws a DomainError with httpStatus 409 when both prompt and a system message are provided (no regression on AC 5)", async () => {
+        const service = new PromptService({} as any);
+        (service as any).repository = {
+          createConfigWithInitialVersion: vi.fn(),
+        };
+        // Use the real PromptVersionService so we exercise the real conflict
+        // error class, not a synthetic mock. This guards against regression on
+        // AC 5 — both prompt + system message together must still throw the
+        // existing 409 conflict error.
+        (service as any).versionService = new PromptVersionService({} as any);
+        (service as any).getOrganizationIdFromProjectId = vi
+          .fn()
+          .mockResolvedValue("org-1");
 
-    const error = await captureError(() =>
-      service.createPrompt({
-        projectId: "project-1",
-        handle: "conflicting-prompt",
-        prompt: "You are a helpful assistant.",
-        messages: [{ role: "system", content: "You are a helpful assistant." }],
-      }),
-    );
+        const error = await captureError(() =>
+          service.createPrompt({
+            projectId: "project-1",
+            handle: "conflicting-prompt",
+            prompt: "You are a helpful assistant.",
+            messages: [
+              { role: "system", content: "You are a helpful assistant." },
+            ],
+          }),
+        );
 
-    expect(error).toBeInstanceOf(DomainError);
-    expect((error as DomainError).kind).toBe("system_prompt_conflict");
-    expect((error as DomainError).httpStatus).toBe(409);
+        expect(error).toBeInstanceOf(DomainError);
+        expect((error as DomainError).kind).toBe("system_prompt_conflict");
+        expect((error as DomainError).httpStatus).toBe(409);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Ticket

Closes #4949. Four test files touched by #3977 use a flat or `when`-only structure instead of the repo-required nested `describe('given X')` → `describe('when Y')` → `it(...)` BDD structure (CLAUDE.md: *"Use nested `describe('given X')` and `describe('when Y')` blocks for BDD structure in test files, not flat test structures with GWT comments."*). CodeRabbit flagged these as "⚡ Quick win" nitpicks on #3977.

## G-START verdict

PROCEED. Re-verified on current main: all four files exist and each has **0** `describe('given …')` blocks (the missing layer), no open PR, no production-code involvement. Premise still holds — mechanical structure-only cleanup.

## Change

Wrap the existing assertions and fixtures **unchanged** in the missing `given`/`when` layers. No behavior change, no production-code change; the `@scenario` parity annotations stay glued to their `it()` calls.

| File | Change |
|------|--------|
| `llmPromptConfigUtils.test.ts` | scaffold round-trip block → `given(a scaffolded signature node)` → `when(converting to LocalPromptConfig)` |
| `system-prompt-required.unit.test.ts` | two flat `it`s → `given(a PromptService)` → `when(neither prompt nor system message)` / `when(both provided)` |
| `form-schema.test.ts` | the `when`-only blocks → parent `given(a prompt form)` |
| `usePromptConfigForm.systemPromptRequired.integration.test.tsx` | two `when` blocks → parent `given(a form rendered with an empty system message)` |

## Evidence

**AC: each file uses given → when → it nesting** — verified: `given`-block count is now 1 in every file (was 0).

**AC: all existing assertions/fixtures preserved; touched tests still pass** — no production code changed; ran the touched slice:
```
pnpm test:unit  (3 files)  → Test Files 3 passed (3), Tests 50 passed (50)
pnpm test:integration (1)  → Test Files 1 passed (1), Tests  2 passed (2)
```

**AC: no parity regression** — `@scenario` annotations kept adjacent to their `it()`:
```
pnpm check:feature-parity → OK: 2265 enforced scenario(s) bound across 689 file(s)
```

Biome-clean on all changed lines (the one remaining Biome notice is a pre-existing import-order deviation on unchanged lines in `llmPromptConfigUtils.test.ts`, out of scope).

## Advisory note

Advisory PR from the tech-debt-fixer bot, opened for human review, not to be merged by the bot. The human makes the merge call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized several prompt configuration and validation tests for clearer scenario grouping.
  * Kept coverage for required system prompt behavior, including empty and whitespace-only cases.
  * Preserved regression coverage for prompt round-trip handling and service error responses when system prompts are missing or conflicting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->