### PR TITLE
feat(billing): harden storage billing — cancel correctness, tripwire, backfill, reconciliation

### DIFF
--- a/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
@@ -298,6 +298,33 @@ describe("EESubscriptionService", () => {
           status: SubscriptionStatus.CANCELLED,
         });
       });
+
+      it("invoices accrued metered usage on cancel instead of discarding it", async () => {
+        repository.findLastNonCancelled.mockResolvedValue({
+          id: "sub_db_1",
+          stripeSubscriptionId: "sub_stripe_1",
+          status: SubscriptionStatus.ACTIVE,
+        });
+        stripe.subscriptions.cancel.mockResolvedValue({ status: "canceled" });
+
+        await service.createOrUpdateSubscription({
+          organizationId: "org_123",
+          baseUrl: "https://app.test",
+          plan: PlanTypes.FREE,
+          customerId: "cus_123",
+        });
+
+        // ADR-027: without invoice_now, Stripe drops un-invoiced metered usage
+        // (billable events, and STORAGE_GB once attached) on immediate cancel.
+        expect(stripe.subscriptions.cancel).toHaveBeenCalledWith(
+          "sub_stripe_1",
+          expect.objectContaining({ invoice_now: true }),
+        );
+        // prorate stays off so unused licensed (seat) time is not credited.
+        expect(stripe.subscriptions.cancel.mock.calls[0]![1]).not.toHaveProperty(
+          "prorate",
+        );
+      });
     });
 
     describe("when upgrading existing subscription", () => {

--- a/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
@@ -12,12 +12,19 @@ vi.mock("../../../src/server/app-layer/app", () => ({
 
 import type { PrismaClient } from "@prisma/client";
 import type Stripe from "stripe";
-import { PlanTypes, SubscriptionStatus } from "../planTypes";
-import { EESubscriptionService, RECENT_INVOICES_LIMIT } from "../services/subscription.service";
-import { InvalidPlanError, OrganizationNotFoundError, SeatBillingUnavailableError } from "../errors";
-import type { SeatEventSubscriptionFns } from "../services/seatEventSubscription";
-import type { SubscriptionRepository } from "../../../src/server/app-layer/subscription/subscription.repository";
 import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
+import type { SubscriptionRepository } from "../../../src/server/app-layer/subscription/subscription.repository";
+import {
+  InvalidPlanError,
+  OrganizationNotFoundError,
+  SeatBillingUnavailableError,
+} from "../errors";
+import { PlanTypes, SubscriptionStatus } from "../planTypes";
+import type { SeatEventSubscriptionFns } from "../services/seatEventSubscription";
+import {
+  EESubscriptionService,
+  RECENT_INVOICES_LIMIT,
+} from "../services/subscription.service";
 
 const createMockStripe = () => ({
   subscriptions: {
@@ -136,7 +143,9 @@ describe("EESubscriptionService", () => {
   let db: ReturnType<typeof createMockDb>;
   let repository: ReturnType<typeof createMockRepository>;
   let itemCalculator: ReturnType<typeof createMockItemCalculator>;
-  let organizationRepository: ReturnType<typeof createMockOrganizationRepository>;
+  let organizationRepository: ReturnType<
+    typeof createMockOrganizationRepository
+  >;
   let service: EESubscriptionService;
 
   beforeEach(() => {
@@ -151,7 +160,8 @@ describe("EESubscriptionService", () => {
       repository: repository as unknown as SubscriptionRepository,
       stripe: stripe as unknown as Stripe,
       itemCalculator,
-      organizationRepository: organizationRepository as unknown as OrganizationRepository,
+      organizationRepository:
+        organizationRepository as unknown as OrganizationRepository,
     });
   });
 
@@ -321,9 +331,9 @@ describe("EESubscriptionService", () => {
           expect.objectContaining({ invoice_now: true }),
         );
         // prorate stays off so unused licensed (seat) time is not credited.
-        expect(stripe.subscriptions.cancel.mock.calls[0]![1]).not.toHaveProperty(
-          "prorate",
-        );
+        expect(
+          stripe.subscriptions.cancel.mock.calls[0]![1],
+        ).not.toHaveProperty("prorate");
       });
     });
 
@@ -521,8 +531,7 @@ describe("EESubscriptionService", () => {
         const mockSub = { id: "sub_1", status: "ACTIVE" };
         repository.findLastNonCancelled.mockResolvedValue(mockSub);
 
-        const result =
-          await service.getLastNonCancelledSubscription("org_123");
+        const result = await service.getLastNonCancelledSubscription("org_123");
 
         expect(result).toEqual(mockSub);
         expect(repository.findLastNonCancelled).toHaveBeenCalledWith("org_123");

--- a/langwatch/ee/billing/services/subscription.service.ts
+++ b/langwatch/ee/billing/services/subscription.service.ts
@@ -417,6 +417,15 @@ export class EESubscriptionService implements SubscriptionService {
   }): Promise<{ url: string | null }> {
     const response = await this.stripe.subscriptions.cancel(
       stripeSubscriptionId,
+      {
+        // Invoice accrued-but-un-billed metered usage before cancelling. Stripe
+        // discards un-invoiced metered usage on an immediate cancel, silently
+        // dropping revenue — the billable-events meter today and STORAGE_GB once
+        // its SubscriptionItem is attached (ADR-027). `invoice_now` generates the
+        // final invoice for that usage; we do NOT set `prorate` so unused
+        // licensed (seat) time is not credited — this only bills what was used.
+        invoice_now: true,
+      },
     );
 
     if (response.status === "canceled") {

--- a/langwatch/ee/billing/services/subscription.service.ts
+++ b/langwatch/ee/billing/services/subscription.service.ts
@@ -1,32 +1,45 @@
-import { Currency, type OrganizationUserRole, type PrismaClient } from "@prisma/client";
-import type Stripe from "stripe";
-import type { DisplayInvoice, SubscriptionService } from "../../../src/server/app-layer/subscription/subscription.service";
-import type { SubscriptionRepository } from "../../../src/server/app-layer/subscription/subscription.repository";
-import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
-import { PrismaOrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.prisma.repository";
-import { traced } from "../../../src/server/app-layer/tracing";
-import { getApp } from "../../../src/server/app-layer/app";
 import {
-  type PlanTypes as PlanType,
-  PlanTypes,
-  SubscriptionStatus,
-} from "../planTypes";
-import type { StripePriceName } from "../stripe/stripePrices.types";
+  Currency,
+  type OrganizationUserRole,
+  type PrismaClient,
+} from "@prisma/client";
+import type Stripe from "stripe";
+import { getApp } from "../../../src/server/app-layer/app";
+import { PrismaOrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.prisma.repository";
+import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
+import type { SubscriptionRepository } from "../../../src/server/app-layer/subscription/subscription.repository";
 import type {
-  createItemsToAdd,
-  getItemsToUpdate,
-  prices,
-} from "./subscriptionItemCalculator";
-import { isStripePriceName, stripePricesFile } from "../stripe/stripePriceCatalog";
+  DisplayInvoice,
+  SubscriptionService,
+} from "../../../src/server/app-layer/subscription/subscription.service";
+import { traced } from "../../../src/server/app-layer/tracing";
 import {
   InvalidPlanError,
   OrganizationNotFoundError,
   SeatBillingUnavailableError,
   SubscriptionCreationFailedError,
 } from "../errors";
-import { isGrowthSeatEventPlan, type BillingInterval } from "../utils/growthSeatEvent";
+import {
+  type PlanTypes as PlanType,
+  PlanTypes,
+  SubscriptionStatus,
+} from "../planTypes";
+import {
+  isStripePriceName,
+  stripePricesFile,
+} from "../stripe/stripePriceCatalog";
+import type { StripePriceName } from "../stripe/stripePrices.types";
+import {
+  type BillingInterval,
+  isGrowthSeatEventPlan,
+} from "../utils/growthSeatEvent";
 import type { SeatEventSubscriptionFns } from "./seatEventSubscription";
 import { PrismaSubscriptionRepository } from "./subscription.repository";
+import type {
+  createItemsToAdd,
+  getItemsToUpdate,
+  prices,
+} from "./subscriptionItemCalculator";
 
 export const RECENT_INVOICES_LIMIT = 4;
 
@@ -140,8 +153,7 @@ export class EESubscriptionService implements SubscriptionService {
       await this.repository.findLastNonCancelled(organizationId);
 
     if (
-      lastSubscription &&
-      lastSubscription.stripeSubscriptionId &&
+      lastSubscription?.stripeSubscriptionId &&
       lastSubscription.status !== SubscriptionStatus.PENDING
     ) {
       const subscription = await this.stripe.subscriptions.retrieve(
@@ -206,8 +218,7 @@ export class EESubscriptionService implements SubscriptionService {
       await this.repository.findLastNonCancelled(organizationId);
 
     if (
-      lastSubscription &&
-      lastSubscription.stripeSubscriptionId &&
+      lastSubscription?.stripeSubscriptionId &&
       lastSubscription.status !== SubscriptionStatus.PENDING
     ) {
       if (plan === PlanTypes.FREE) {
@@ -284,7 +295,10 @@ export class EESubscriptionService implements SubscriptionService {
     if (!this.seatEventFns) {
       throw new SeatBillingUnavailableError();
     }
-    return this.seatEventFns.previewProration({ organizationId, newTotalSeats });
+    return this.seatEventFns.previewProration({
+      organizationId,
+      newTotalSeats,
+    });
   }
 
   async createSubscriptionWithInvites({
@@ -377,7 +391,8 @@ export class EESubscriptionService implements SubscriptionService {
   }: {
     organizationId: string;
   }): Promise<DisplayInvoice[]> {
-    const stripeCustomerId = await this.organizationRepository.getStripeCustomerId(organizationId);
+    const stripeCustomerId =
+      await this.organizationRepository.getStripeCustomerId(organizationId);
 
     if (!stripeCustomerId) {
       return [];
@@ -453,9 +468,8 @@ export class EESubscriptionService implements SubscriptionService {
     membersToAdd: number;
     baseUrl: string;
   }): Promise<{ url: string | null }> {
-    const currentStripeSubscription = await this.stripe.subscriptions.retrieve(
-      stripeSubscriptionId,
-    );
+    const currentStripeSubscription =
+      await this.stripe.subscriptions.retrieve(stripeSubscriptionId);
 
     const itemsToUpdate = this.itemCalculator.getItemsToUpdate({
       currentItems: currentStripeSubscription.items.data,

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingBackfill.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingBackfill.service.unit.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @see specs/data-retention/storage-billing-backfill.feature
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/logger/server", () => {
+  const l = () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => l(),
+  });
+  return { createLogger: vi.fn(() => l()) };
+});
+
+import {
+  type BackfillCandidate,
+  StorageBillingBackfillService,
+} from "../storageBillingBackfill.service";
+
+const CANDIDATE: BackfillCandidate = {
+  organizationId: "org-1",
+  stripeSubscriptionId: "sub_1",
+  plan: "GROWTH",
+  currency: "EUR",
+  interval: "month",
+};
+
+function makeService(
+  overrides: Partial<{
+    candidates: BackfillCandidate[];
+    priceId: string | null;
+    existingPriceIds: string[];
+    attach: () => Promise<void>;
+  }> = {},
+) {
+  const attachStorageItem = vi.fn(overrides.attach ?? (async () => {}));
+  const getSubscriptionItemPriceIds = vi
+    .fn()
+    .mockResolvedValue(overrides.existingPriceIds ?? []);
+  const service = new StorageBillingBackfillService({
+    listPaidSubscriptions: vi
+      .fn()
+      .mockResolvedValue(overrides.candidates ?? [CANDIDATE]),
+    resolveStoragePriceId: vi
+      .fn()
+      .mockReturnValue(
+        overrides.priceId === undefined ? "price_storage_eur_m" : overrides.priceId,
+      ),
+    getSubscriptionItemPriceIds,
+    attachStorageItem,
+  });
+  return { service, attachStorageItem, getSubscriptionItemPriceIds };
+}
+
+describe("StorageBillingBackfillService", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("given a paid subscription without the storage item", () => {
+    /** @scenario The storage item is attached to a paid subscription that lacks it */
+    it("attaches the item and counts it", async () => {
+      const { service, attachStorageItem } = makeService({ existingPriceIds: [] });
+
+      const result = await service.run({ dryRun: false });
+
+      expect(attachStorageItem).toHaveBeenCalledWith({
+        stripeSubscriptionId: "sub_1",
+        priceId: "price_storage_eur_m",
+      });
+      expect(result.attached).toBe(1);
+    });
+  });
+
+  describe("given a subscription that already has the storage item", () => {
+    /** @scenario A subscription that already has the item is skipped (idempotent) */
+    it("does not attach again", async () => {
+      const { service, attachStorageItem } = makeService({
+        existingPriceIds: ["price_storage_eur_m"],
+      });
+
+      const result = await service.run({ dryRun: false });
+
+      expect(attachStorageItem).not.toHaveBeenCalled();
+      expect(result.alreadyAttached).toBe(1);
+    });
+  });
+
+  describe("given no storage price for the plan/currency/interval", () => {
+    /** @scenario A subscription with no matching storage price is skipped, never guessed */
+    it("skips and counts it without attaching", async () => {
+      const { service, attachStorageItem } = makeService({ priceId: null });
+
+      const result = await service.run({ dryRun: false });
+
+      expect(attachStorageItem).not.toHaveBeenCalled();
+      expect(result.noPrice).toBe(1);
+    });
+  });
+
+  describe("when run as a dry-run", () => {
+    /** @scenario A dry-run reports what it would attach without mutating Stripe */
+    it("does not call Stripe but counts the attach", async () => {
+      const { service, attachStorageItem } = makeService({ existingPriceIds: [] });
+
+      const result = await service.run({ dryRun: true });
+
+      expect(attachStorageItem).not.toHaveBeenCalled();
+      expect(result.attached).toBe(1);
+    });
+  });
+
+  describe("when attaching one subscription fails", () => {
+    /** @scenario One subscription's failure does not abort the whole backfill */
+    it("continues to the next and counts the failure", async () => {
+      const second: BackfillCandidate = {
+        ...CANDIDATE,
+        organizationId: "org-2",
+        stripeSubscriptionId: "sub_2",
+      };
+      const attach = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("stripe error"))
+        .mockResolvedValueOnce(undefined);
+      const { service } = makeService({
+        candidates: [CANDIDATE, second],
+        attach,
+      });
+
+      const result = await service.run({ dryRun: false });
+
+      expect(result.failed).toBe(1);
+      expect(result.attached).toBe(1);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingBackfill.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingBackfill.service.unit.test.ts
@@ -47,7 +47,9 @@ function makeService(
     resolveStoragePriceId: vi
       .fn()
       .mockReturnValue(
-        overrides.priceId === undefined ? "price_storage_eur_m" : overrides.priceId,
+        overrides.priceId === undefined
+          ? "price_storage_eur_m"
+          : overrides.priceId,
       ),
     getSubscriptionItemPriceIds,
     attachStorageItem,
@@ -61,7 +63,9 @@ describe("StorageBillingBackfillService", () => {
   describe("given a paid subscription without the storage item", () => {
     /** @scenario The storage item is attached to a paid subscription that lacks it */
     it("attaches the item and counts it", async () => {
-      const { service, attachStorageItem } = makeService({ existingPriceIds: [] });
+      const { service, attachStorageItem } = makeService({
+        existingPriceIds: [],
+      });
 
       const result = await service.run({ dryRun: false });
 
@@ -102,7 +106,9 @@ describe("StorageBillingBackfillService", () => {
   describe("when run as a dry-run", () => {
     /** @scenario A dry-run reports what it would attach without mutating Stripe */
     it("does not call Stripe but counts the attach", async () => {
-      const { service, attachStorageItem } = makeService({ existingPriceIds: [] });
+      const { service, attachStorageItem } = makeService({
+        existingPriceIds: [],
+      });
 
       const result = await service.run({ dryRun: true });
 

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingReconciliation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingReconciliation.service.unit.test.ts
@@ -32,7 +32,9 @@ function makeService(
   }> = {},
 ) {
   const service = new StorageBillingReconciliationService({
-    listReconcilableOrgs: vi.fn().mockResolvedValue(overrides.orgs ?? ["org-1"]),
+    listReconcilableOrgs: vi
+      .fn()
+      .mockResolvedValue(overrides.orgs ?? ["org-1"]),
     sumReportedMegabytes: vi.fn(async ({ organizationId }) =>
       overrides.reportedByOrg
         ? overrides.reportedByOrg[organizationId]!
@@ -75,7 +77,10 @@ describe("StorageBillingReconciliationService", () => {
 
       expect(result.drifted).toBe(1);
       expect(mockError).toHaveBeenCalledWith(
-        expect.objectContaining({ organizationId: "org-1", billingMonth: "2026-02" }),
+        expect.objectContaining({
+          organizationId: "org-1",
+          billingMonth: "2026-02",
+        }),
         expect.stringContaining("DRIFT"),
       );
     });

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingReconciliation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingReconciliation.service.unit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @see specs/data-retention/storage-billing-reconciliation.feature
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockError, createMockLogger } = vi.hoisted(() => {
+  const mockError = vi.fn();
+  const createMockLogger = () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: mockError,
+    child: vi.fn(() => createMockLogger()),
+  });
+  return { mockError, createMockLogger };
+});
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: vi.fn(() => createMockLogger()),
+}));
+
+import { StorageBillingReconciliationService } from "../storageBillingReconciliation.service";
+
+function makeService(
+  overrides: Partial<{
+    orgs: string[];
+    reported: number;
+    stripeTotal: number | null;
+    stripeByOrg: Record<string, number | null>;
+    reportedByOrg: Record<string, number>;
+  }> = {},
+) {
+  const service = new StorageBillingReconciliationService({
+    listReconcilableOrgs: vi.fn().mockResolvedValue(overrides.orgs ?? ["org-1"]),
+    sumReportedMegabytes: vi.fn(async ({ organizationId }) =>
+      overrides.reportedByOrg
+        ? overrides.reportedByOrg[organizationId]!
+        : (overrides.reported ?? 1000),
+    ),
+    fetchStripeMeterTotal: vi.fn(async ({ organizationId }) =>
+      overrides.stripeByOrg
+        ? overrides.stripeByOrg[organizationId]!
+        : overrides.stripeTotal === undefined
+          ? 1000
+          : overrides.stripeTotal,
+    ),
+    toleranceRatio: 0.01,
+  });
+  return { service };
+}
+
+describe("StorageBillingReconciliationService", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("given recorded and Stripe totals match within tolerance", () => {
+    /** @scenario Matching totals report no drift */
+    it("logs no drift", async () => {
+      const { service } = makeService({ reported: 1000, stripeTotal: 1005 });
+
+      const result = await service.reconcile({ billingMonth: "2026-02" });
+
+      expect(result.drifted).toBe(0);
+      expect(result.checked).toBe(1);
+      expect(mockError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the totals diverge beyond tolerance", () => {
+    /** @scenario Divergent totals are flagged as drift */
+    it("logs a drift error", async () => {
+      const { service } = makeService({ reported: 1000, stripeTotal: 2000 });
+
+      const result = await service.reconcile({ billingMonth: "2026-02" });
+
+      expect(result.drifted).toBe(1);
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({ organizationId: "org-1", billingMonth: "2026-02" }),
+        expect.stringContaining("DRIFT"),
+      );
+    });
+  });
+
+  describe("given Stripe's total is unavailable", () => {
+    /** @scenario An unavailable Stripe total is skipped, never a false drift */
+    it("counts it as unavailable and does not flag drift", async () => {
+      const { service } = makeService({ reported: 1000, stripeTotal: null });
+
+      const result = await service.reconcile({ billingMonth: "2026-02" });
+
+      expect(result.unavailable).toBe(1);
+      expect(result.checked).toBe(0);
+      expect(mockError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given several organizations", () => {
+    /** @scenario Each organization is reconciled independently */
+    it("checks each and flags only the drifting one", async () => {
+      const { service } = makeService({
+        orgs: ["ok", "bad"],
+        reportedByOrg: { ok: 1000, bad: 1000 },
+        stripeByOrg: { ok: 1000, bad: 5000 },
+      });
+
+      const result = await service.reconcile({ billingMonth: "2026-02" });
+
+      expect(result.checked).toBe(2);
+      expect(result.drifted).toBe(1);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingTripwire.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingTripwire.unit.test.ts
@@ -55,7 +55,11 @@ describe("StorageBillingTripwire", () => {
       const computeReference = vi.fn();
       const tw = makeTripwire({ enabled: false, computeReference });
 
-      await tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 100 });
+      await tw.check({
+        organizationId: "o",
+        sealedHour: SEALED,
+        measuredBytes: 100,
+      });
 
       expect(computeReference).not.toHaveBeenCalled();
       expect(mockWarn).not.toHaveBeenCalled();
@@ -67,7 +71,11 @@ describe("StorageBillingTripwire", () => {
     it("logs nothing when the reference is null", async () => {
       const tw = makeTripwire({ reference: null });
 
-      await tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 100 });
+      await tw.check({
+        organizationId: "o",
+        sealedHour: SEALED,
+        measuredBytes: 100,
+      });
 
       expect(mockWarn).not.toHaveBeenCalled();
     });
@@ -78,7 +86,11 @@ describe("StorageBillingTripwire", () => {
     it("does not warn", async () => {
       const tw = makeTripwire({ reference: 100, toleranceRatio: 0.5 });
 
-      await tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 120 });
+      await tw.check({
+        organizationId: "o",
+        sealedHour: SEALED,
+        measuredBytes: 120,
+      });
 
       expect(mockWarn).not.toHaveBeenCalled();
     });
@@ -89,7 +101,11 @@ describe("StorageBillingTripwire", () => {
     it("warns", async () => {
       const tw = makeTripwire({ reference: 100, toleranceRatio: 0.5 });
 
-      await tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 1000 });
+      await tw.check({
+        organizationId: "o",
+        sealedHour: SEALED,
+        measuredBytes: 1000,
+      });
 
       expect(mockWarn).toHaveBeenCalledTimes(1);
       expect(mockWarn).toHaveBeenCalledWith(
@@ -100,10 +116,18 @@ describe("StorageBillingTripwire", () => {
 
     /** @scenario Divergence logging is capped so a broken reference can't flood logs */
     it("stops logging after the cap", async () => {
-      const tw = makeTripwire({ reference: 100, toleranceRatio: 0.5, maxLogs: 2 });
+      const tw = makeTripwire({
+        reference: 100,
+        toleranceRatio: 0.5,
+        maxLogs: 2,
+      });
 
       for (let i = 0; i < 5; i++) {
-        await tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 1000 });
+        await tw.check({
+          organizationId: "o",
+          sealedHour: SEALED,
+          measuredBytes: 1000,
+        });
       }
 
       expect(mockWarn).toHaveBeenCalledTimes(2);
@@ -118,7 +142,11 @@ describe("StorageBillingTripwire", () => {
       });
 
       await expect(
-        tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 100 }),
+        tw.check({
+          organizationId: "o",
+          sealedHour: SEALED,
+          measuredBytes: 100,
+        }),
       ).resolves.toBeUndefined();
       expect(mockWarn).not.toHaveBeenCalled();
     });

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingTripwire.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingTripwire.unit.test.ts
@@ -34,6 +34,7 @@ function makeTripwire(
     computeReference: () => Promise<number | null>;
     toleranceRatio: number;
     maxLogs: number;
+    now: () => number;
   }> = {},
 ) {
   return new StorageBillingTripwire({
@@ -43,6 +44,7 @@ function makeTripwire(
       vi.fn().mockResolvedValue(overrides.reference ?? null),
     toleranceRatio: overrides.toleranceRatio,
     maxLogs: overrides.maxLogs,
+    now: overrides.now,
   });
 }
 
@@ -130,6 +132,27 @@ describe("StorageBillingTripwire", () => {
         });
       }
 
+      expect(mockWarn).toHaveBeenCalledTimes(2);
+    });
+
+    /** @scenario The log cap resets each window so later divergence isn't silenced forever */
+    it("logs again after the window elapses", async () => {
+      let clock = 1_000_000;
+      const tw = makeTripwire({
+        reference: 100,
+        toleranceRatio: 0.5,
+        maxLogs: 1,
+        now: () => clock,
+      });
+      const check = () =>
+        tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 1000 });
+
+      await check(); // window 1: logs
+      await check(); // window 1: capped
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+
+      clock += 60 * 60 * 1000 + 1; // advance past the window
+      await check(); // window 2: logs again
       expect(mockWarn).toHaveBeenCalledTimes(2);
     });
   });

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingTripwire.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingTripwire.unit.test.ts
@@ -145,7 +145,11 @@ describe("StorageBillingTripwire", () => {
         now: () => clock,
       });
       const check = () =>
-        tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 1000 });
+        tw.check({
+          organizationId: "o",
+          sealedHour: SEALED,
+          measuredBytes: 1000,
+        });
 
       await check(); // window 1: logs
       await check(); // window 1: capped

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingTripwire.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingTripwire.unit.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The tripwire's whole value is its contract: flag-gated, capped, and — above
+ * all — it must NEVER throw into the measure/report path. These tests pin that.
+ *
+ * @see specs/data-retention/storage-billing-tripwire.feature
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockWarn, createMockLogger } = vi.hoisted(() => {
+  const mockWarn = vi.fn();
+  const createMockLogger = () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: mockWarn,
+    error: vi.fn(),
+    child: vi.fn(() => createMockLogger()),
+  });
+  return { mockWarn, createMockLogger };
+});
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: vi.fn(() => createMockLogger()),
+}));
+
+import { StorageBillingTripwire } from "../storageBillingTripwire";
+
+const SEALED = new Date("2026-02-15T11:00:00.000Z");
+
+function makeTripwire(
+  overrides: Partial<{
+    enabled: boolean;
+    reference: number | null;
+    computeReference: () => Promise<number | null>;
+    toleranceRatio: number;
+    maxLogs: number;
+  }> = {},
+) {
+  return new StorageBillingTripwire({
+    isEnabled: vi.fn().mockResolvedValue(overrides.enabled ?? true),
+    computeReference:
+      overrides.computeReference ??
+      vi.fn().mockResolvedValue(overrides.reference ?? null),
+    toleranceRatio: overrides.toleranceRatio,
+    maxLogs: overrides.maxLogs,
+  });
+}
+
+describe("StorageBillingTripwire", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("given the tripwire flag is off", () => {
+    /** @scenario A disabled tripwire does nothing */
+    it("computes no reference and logs nothing", async () => {
+      const computeReference = vi.fn();
+      const tw = makeTripwire({ enabled: false, computeReference });
+
+      await tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 100 });
+
+      expect(computeReference).not.toHaveBeenCalled();
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given no reference is available", () => {
+    /** @scenario No reference means no comparison */
+    it("logs nothing when the reference is null", async () => {
+      const tw = makeTripwire({ reference: null });
+
+      await tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 100 });
+
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the measurement is within tolerance of the reference", () => {
+    /** @scenario A measurement within tolerance is silent */
+    it("does not warn", async () => {
+      const tw = makeTripwire({ reference: 100, toleranceRatio: 0.5 });
+
+      await tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 120 });
+
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the measurement diverges beyond tolerance", () => {
+    /** @scenario A divergent measurement is warned once */
+    it("warns", async () => {
+      const tw = makeTripwire({ reference: 100, toleranceRatio: 0.5 });
+
+      await tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 1000 });
+
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+      expect(mockWarn).toHaveBeenCalledWith(
+        expect.objectContaining({ organizationId: "o", reference: 100 }),
+        expect.stringContaining("TRIPWIRE"),
+      );
+    });
+
+    /** @scenario Divergence logging is capped so a broken reference can't flood logs */
+    it("stops logging after the cap", async () => {
+      const tw = makeTripwire({ reference: 100, toleranceRatio: 0.5, maxLogs: 2 });
+
+      for (let i = 0; i < 5; i++) {
+        await tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 1000 });
+      }
+
+      expect(mockWarn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("when the reference computation throws", () => {
+    /** @scenario The tripwire never throws into the measure path */
+    it("swallows the error and resolves", async () => {
+      const tw = makeTripwire({
+        computeReference: vi.fn().mockRejectedValue(new Error("ch down")),
+      });
+
+      await expect(
+        tw.check({ organizationId: "o", sealedHour: SEALED, measuredBytes: 100 }),
+      ).resolves.toBeUndefined();
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageMeterDispatch.service.unit.test.ts
@@ -24,6 +24,7 @@ vi.mock("~/utils/logger/server", () => ({
 
 import {
   STORAGE_BACKFILL_MAX_HOURS,
+  STORAGE_MAX_HOURS_PER_RUN,
   StorageMeterDispatchService,
 } from "../storageMeterDispatch.service";
 
@@ -232,8 +233,9 @@ describe("StorageMeterDispatchService", () => {
 
       await service.dispatchForOrg({ organizationId: "org-1" });
 
-      expect(measureBytesAt).toHaveBeenCalledTimes(STORAGE_BACKFILL_MAX_HOURS);
-      // The earliest measured hour is exactly the ceiling back from the boundary.
+      // Truncated start is the ceiling back from the boundary; but only the
+      // per-run cap is measured this run (the rest drains on later events).
+      expect(measureBytesAt).toHaveBeenCalledTimes(STORAGE_MAX_HOURS_PER_RUN);
       expect(measureBytesAt.mock.calls[0]![0].sealedHour.toISOString()).toBe(
         new Date(
           SEAL_BOUNDARY.getTime() -
@@ -244,6 +246,22 @@ describe("StorageMeterDispatchService", () => {
         expect.objectContaining({ organizationId: "org-1" }),
         expect.stringContaining("ALARM"),
       );
+    });
+  });
+
+  describe("given a gap larger than one run's cap but within the ceiling", () => {
+    /** @scenario A large catch-up measures at most the per-run cap and defers the rest */
+    it("measures the per-run cap this run without an alarm", async () => {
+      const behind = new Date(
+        SEAL_BOUNDARY.getTime() -
+          (STORAGE_MAX_HOURS_PER_RUN + 50) * MS_PER_HOUR,
+      );
+      const { service, measureBytesAt } = makeService({ lastMeasured: behind });
+
+      await service.dispatchForOrg({ organizationId: "org-1" });
+
+      expect(measureBytesAt).toHaveBeenCalledTimes(STORAGE_MAX_HOURS_PER_RUN);
+      expect(mockLoggerError).not.toHaveBeenCalled();
     });
   });
 

--- a/langwatch/src/server/app-layer/billing/storageBillingBackfill.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingBackfill.service.ts
@@ -72,7 +72,12 @@ export class StorageBillingBackfillService {
       if (!priceId) {
         result.noPrice++;
         logger.warn(
-          { organizationId: c.organizationId, plan: c.plan, currency: c.currency, interval: c.interval },
+          {
+            organizationId: c.organizationId,
+            plan: c.plan,
+            currency: c.currency,
+            interval: c.interval,
+          },
           "no STORAGE_GB price for this plan/currency/interval — skipping",
         );
         continue;
@@ -89,7 +94,11 @@ export class StorageBillingBackfillService {
 
         if (dryRun) {
           logger.info(
-            { organizationId: c.organizationId, priceId, subscription: c.stripeSubscriptionId },
+            {
+              organizationId: c.organizationId,
+              priceId,
+              subscription: c.stripeSubscriptionId,
+            },
             "[dry-run] would attach STORAGE_GB item",
           );
           result.attached++;
@@ -104,7 +113,11 @@ export class StorageBillingBackfillService {
       } catch (error) {
         result.failed++;
         logger.error(
-          { organizationId: c.organizationId, subscription: c.stripeSubscriptionId, error },
+          {
+            organizationId: c.organizationId,
+            subscription: c.stripeSubscriptionId,
+            error,
+          },
           "failed to attach STORAGE_GB item — continuing; re-run is idempotent",
         );
       }

--- a/langwatch/src/server/app-layer/billing/storageBillingBackfill.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingBackfill.service.ts
@@ -1,0 +1,116 @@
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:billing:storageBackfill");
+
+/** One paid subscription eligible for the STORAGE_GB item. */
+export interface BackfillCandidate {
+  organizationId: string;
+  stripeSubscriptionId: string;
+  /** The (plan × currency × interval) key used to resolve the storage price. */
+  plan: string;
+  currency: string;
+  interval: "month" | "year";
+}
+
+export interface StorageBillingBackfillDeps {
+  /** Active PAID subscriptions only — free / self-hosted are never returned. */
+  listPaidSubscriptions: () => Promise<BackfillCandidate[]>;
+  /** The STORAGE_GB metered price id for a (plan × currency × interval), or null. */
+  resolveStoragePriceId: (params: {
+    plan: string;
+    currency: string;
+    interval: "month" | "year";
+  }) => string | null;
+  /** Current Stripe subscription-item price ids for a subscription. */
+  getSubscriptionItemPriceIds: (
+    stripeSubscriptionId: string,
+  ) => Promise<string[]>;
+  /** Attach the metered item; must not change the cycle or subscription_id. */
+  attachStorageItem: (params: {
+    stripeSubscriptionId: string;
+    priceId: string;
+  }) => Promise<void>;
+}
+
+export interface BackfillResult {
+  attached: number;
+  alreadyAttached: number;
+  noPrice: number;
+  failed: number;
+}
+
+/**
+ * ADR-027 Phase 7 rollout: attaches the `STORAGE_GB` SubscriptionItem to active
+ * paid subscriptions so they begin accruing storage usage on the next cycle.
+ *
+ * Idempotent — an item already present is skipped, so it is safe to re-run and
+ * to run alongside live traffic. Free / self-hosted orgs never appear (the query
+ * returns paid subscriptions only). A subscription whose (plan × currency ×
+ * interval) has no storage price is skipped and counted, never guessed.
+ *
+ * Runs only after the customer notice, on the announced date (see the runbook).
+ * `dryRun` reports what it would do without mutating Stripe.
+ */
+export class StorageBillingBackfillService {
+  constructor(private readonly deps: StorageBillingBackfillDeps) {}
+
+  async run({ dryRun }: { dryRun: boolean }): Promise<BackfillResult> {
+    const result: BackfillResult = {
+      attached: 0,
+      alreadyAttached: 0,
+      noPrice: 0,
+      failed: 0,
+    };
+
+    const candidates = await this.deps.listPaidSubscriptions();
+    for (const c of candidates) {
+      const priceId = this.deps.resolveStoragePriceId({
+        plan: c.plan,
+        currency: c.currency,
+        interval: c.interval,
+      });
+      if (!priceId) {
+        result.noPrice++;
+        logger.warn(
+          { organizationId: c.organizationId, plan: c.plan, currency: c.currency, interval: c.interval },
+          "no STORAGE_GB price for this plan/currency/interval — skipping",
+        );
+        continue;
+      }
+
+      try {
+        const existing = await this.deps.getSubscriptionItemPriceIds(
+          c.stripeSubscriptionId,
+        );
+        if (existing.includes(priceId)) {
+          result.alreadyAttached++;
+          continue;
+        }
+
+        if (dryRun) {
+          logger.info(
+            { organizationId: c.organizationId, priceId, subscription: c.stripeSubscriptionId },
+            "[dry-run] would attach STORAGE_GB item",
+          );
+          result.attached++;
+          continue;
+        }
+
+        await this.deps.attachStorageItem({
+          stripeSubscriptionId: c.stripeSubscriptionId,
+          priceId,
+        });
+        result.attached++;
+      } catch (error) {
+        result.failed++;
+        logger.error(
+          { organizationId: c.organizationId, subscription: c.stripeSubscriptionId, error },
+          "failed to attach STORAGE_GB item — continuing; re-run is idempotent",
+        );
+      }
+    }
+
+    logger.info({ dryRun, ...result }, "STORAGE_GB backfill complete");
+    return result;
+  }
+}

--- a/langwatch/src/server/app-layer/billing/storageBillingReconciliation.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingReconciliation.service.ts
@@ -1,0 +1,90 @@
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:billing:storageReconciliation");
+
+const DEFAULT_TOLERANCE_RATIO = 0.01;
+
+export interface StorageReconciliationDeps {
+  /** Orgs with reported storage hours in the period (paid; already metered). */
+  listReconcilableOrgs: (billingMonth: string) => Promise<string[]>;
+  /** Σ of `StorageUsageHourly.megabytes` with `reportedAt` set, for the period. */
+  sumReportedMegabytes: (params: {
+    organizationId: string;
+    billingMonth: string;
+  }) => Promise<number>;
+  /** Stripe's summed meter total (MiB-hours) for the period, or null if unavailable. */
+  fetchStripeMeterTotal: (params: {
+    organizationId: string;
+    billingMonth: string;
+  }) => Promise<number | null>;
+  toleranceRatio?: number;
+}
+
+export interface ReconciliationResult {
+  checked: number;
+  drifted: number;
+  unavailable: number;
+}
+
+/**
+ * ADR-027 finance safety net (deferred, off the critical path): periodically
+ * diffs what we recorded as reported (`Σ StorageUsageHourly.megabytes` with
+ * `reportedAt` set) against Stripe's own meter total per org/period, and logs a
+ * capped-severity warning on drift beyond tolerance. Catches anything the
+ * measure-time tripwire and the idempotency layers missed — e.g. a report the
+ * cursor marked done but Stripe never accepted. Observational; never mutates.
+ */
+export class StorageBillingReconciliationService {
+  constructor(private readonly deps: StorageReconciliationDeps) {}
+
+  async reconcile({
+    billingMonth,
+  }: {
+    billingMonth: string;
+  }): Promise<ReconciliationResult> {
+    const result: ReconciliationResult = {
+      checked: 0,
+      drifted: 0,
+      unavailable: 0,
+    };
+    const tolerance = this.deps.toleranceRatio ?? DEFAULT_TOLERANCE_RATIO;
+
+    const orgs = await this.deps.listReconcilableOrgs(billingMonth);
+    for (const organizationId of orgs) {
+      const reported = await this.deps.sumReportedMegabytes({
+        organizationId,
+        billingMonth,
+      });
+      const stripeTotal = await this.deps.fetchStripeMeterTotal({
+        organizationId,
+        billingMonth,
+      });
+
+      if (stripeTotal == null) {
+        result.unavailable++;
+        continue;
+      }
+
+      result.checked++;
+      const diff = Math.abs(reported - stripeTotal);
+      const scale = Math.max(reported, stripeTotal, 1);
+      if (diff / scale > tolerance) {
+        result.drifted++;
+        logger.error(
+          {
+            organizationId,
+            billingMonth,
+            reportedMegabytes: reported,
+            stripeMegabytes: stripeTotal,
+            ratio: diff / scale,
+          },
+          "DRIFT: recorded storage total diverges from Stripe's meter total — " +
+            "finance reconciliation required.",
+        );
+      }
+    }
+
+    logger.info({ billingMonth, ...result }, "storage reconciliation complete");
+    return result;
+  }
+}

--- a/langwatch/src/server/app-layer/billing/storageBillingTripwire.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingTripwire.ts
@@ -59,7 +59,10 @@ export class StorageBillingTripwire {
       const ratio = diff / scale;
       const tolerance = this.deps.toleranceRatio ?? DEFAULT_TOLERANCE_RATIO;
 
-      if (ratio > tolerance && this.logs < (this.deps.maxLogs ?? DEFAULT_MAX_LOGS)) {
+      if (
+        ratio > tolerance &&
+        this.logs < (this.deps.maxLogs ?? DEFAULT_MAX_LOGS)
+      ) {
         this.logs++;
         logger.warn(
           {

--- a/langwatch/src/server/app-layer/billing/storageBillingTripwire.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingTripwire.ts
@@ -1,0 +1,85 @@
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:billing:storageTripwire");
+
+/** Default relative tolerance before a divergence is logged. */
+const DEFAULT_TOLERANCE_RATIO = 0.5;
+/** Default cap on warnings per process, so a broken reference can't flood logs. */
+const DEFAULT_MAX_LOGS = 50;
+
+export interface StorageBillingTripwireDeps {
+  /** Gate — the `release_storage_billing_metering_tripwire` flag, per org. */
+  isEnabled: (organizationId: string) => Promise<boolean>;
+  /**
+   * An INDEPENDENT reference for the same hour's billable bytes, or null when
+   * none is available (e.g. the first hour). Kept pluggable so the cheap
+   * hour-over-hour anomaly reference can later be swapped for the precise
+   * "reference SUM" once it's verified against real ClickHouse.
+   */
+  computeReference: (params: {
+    organizationId: string;
+    sealedHour: Date;
+  }) => Promise<number | null>;
+  /** Relative divergence (|measured − ref| / max) above which to warn. */
+  toleranceRatio?: number;
+  maxLogs?: number;
+}
+
+/**
+ * ADR-027 measure-time tripwire (Phase 4.5). Shadow-compares each billed
+ * measurement against an independent reference and logs a capped warning on
+ * divergence beyond tolerance — the earlier, stronger form of the deferred
+ * month-end reconciliation, catching a bad value *before* it bills.
+ *
+ * CONTRACT: `check` must NEVER throw into the measure/report path and never
+ * alter the billed value. Every failure — flag lookup, reference computation,
+ * comparison — is swallowed. It is purely observational.
+ */
+export class StorageBillingTripwire {
+  private logs = 0;
+
+  constructor(private readonly deps: StorageBillingTripwireDeps) {}
+
+  async check(params: {
+    organizationId: string;
+    sealedHour: Date;
+    measuredBytes: number;
+  }): Promise<void> {
+    try {
+      if (!(await this.deps.isEnabled(params.organizationId))) return;
+
+      const reference = await this.deps.computeReference({
+        organizationId: params.organizationId,
+        sealedHour: params.sealedHour,
+      });
+      if (reference == null) return;
+
+      const diff = Math.abs(params.measuredBytes - reference);
+      const scale = Math.max(params.measuredBytes, reference, 1);
+      const ratio = diff / scale;
+      const tolerance = this.deps.toleranceRatio ?? DEFAULT_TOLERANCE_RATIO;
+
+      if (ratio > tolerance && this.logs < (this.deps.maxLogs ?? DEFAULT_MAX_LOGS)) {
+        this.logs++;
+        logger.warn(
+          {
+            organizationId: params.organizationId,
+            sealedHour: params.sealedHour.toISOString(),
+            measuredBytes: params.measuredBytes,
+            reference,
+            ratio,
+            tolerance,
+          },
+          "TRIPWIRE: storage measurement diverges from reference beyond tolerance " +
+            "— investigate before trusting the billed value.",
+        );
+      }
+    } catch (error) {
+      // Never break the measure path; the tripwire is purely observational.
+      logger.debug(
+        { organizationId: params.organizationId, error },
+        "storage tripwire check failed (ignored)",
+      );
+    }
+  }
+}

--- a/langwatch/src/server/app-layer/billing/storageBillingTripwire.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingTripwire.ts
@@ -4,8 +4,10 @@ const logger = createLogger("langwatch:billing:storageTripwire");
 
 /** Default relative tolerance before a divergence is logged. */
 const DEFAULT_TOLERANCE_RATIO = 0.5;
-/** Default cap on warnings per process, so a broken reference can't flood logs. */
+/** Default cap on warnings per window, so a broken reference can't flood logs. */
 const DEFAULT_MAX_LOGS = 50;
+/** The cap resets each window so real divergence isn't silenced forever. */
+const LOG_WINDOW_MS = 60 * 60 * 1000;
 
 export interface StorageBillingTripwireDeps {
   /** Gate — the `release_storage_billing_metering_tripwire` flag, per org. */
@@ -22,7 +24,10 @@ export interface StorageBillingTripwireDeps {
   }) => Promise<number | null>;
   /** Relative divergence (|measured − ref| / max) above which to warn. */
   toleranceRatio?: number;
+  /** Max warnings per {@link LOG_WINDOW_MS} window (default 50). */
   maxLogs?: number;
+  /** Injectable clock (epoch ms) for deterministic tests. */
+  now?: () => number;
 }
 
 /**
@@ -37,6 +42,7 @@ export interface StorageBillingTripwireDeps {
  */
 export class StorageBillingTripwire {
   private logs = 0;
+  private windowStartMs = 0;
 
   constructor(private readonly deps: StorageBillingTripwireDeps) {}
 
@@ -58,6 +64,14 @@ export class StorageBillingTripwire {
       const scale = Math.max(params.measuredBytes, reference, 1);
       const ratio = diff / scale;
       const tolerance = this.deps.toleranceRatio ?? DEFAULT_TOLERANCE_RATIO;
+
+      // Reset the per-window cap so a real divergence hours later still logs,
+      // rather than being permanently silenced after the first burst.
+      const nowMs = (this.deps.now ?? Date.now)();
+      if (nowMs - this.windowStartMs >= LOG_WINDOW_MS) {
+        this.windowStartMs = nowMs;
+        this.logs = 0;
+      }
 
       if (
         ratio > tolerance &&

--- a/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
@@ -15,6 +15,14 @@ const BYTES_PER_MIB = 1024 * 1024;
  */
 export const STORAGE_BACKFILL_MAX_HOURS = 840;
 
+/**
+ * Most hours measured in a single dispatch run. Bounds how many heavy
+ * `byteSize()` measurements one worker job runs back-to-back; a larger backlog
+ * (post-outage) drains across successive events. One week keeps steady-state
+ * (a 1-hour gap) unaffected while capping recovery bursts.
+ */
+export const STORAGE_MAX_HOURS_PER_RUN = 168;
+
 /** Narrow contracts so the service depends on capabilities, not whole services. */
 export interface StorageMeterDispatchDeps {
   isMeteringEnabled: (organizationId: string) => Promise<boolean>;
@@ -130,10 +138,28 @@ export class StorageMeterDispatchService {
       firstMs = earliestAllowedMs;
     }
 
-    // 5. Measure → persist → enqueue, one sealed hour at a time. A measurement
+    // 5. Cap the hours measured in ONE run so a large catch-up (e.g. after an
+    //    outage) doesn't run hundreds of heavy measurements back-to-back in a
+    //    single worker job; the remainder catches up on subsequent events.
+    const runEndMs = Math.min(
+      sealBoundaryMs,
+      firstMs + (STORAGE_MAX_HOURS_PER_RUN - 1) * MS_PER_HOUR,
+    );
+    if (runEndMs < sealBoundaryMs) {
+      logger.info(
+        {
+          organizationId,
+          measuringHours: (runEndMs - firstMs) / MS_PER_HOUR + 1,
+          remainingHours: (sealBoundaryMs - runEndMs) / MS_PER_HOUR,
+        },
+        "storage catch-up capped this run; remainder resumes on the next event",
+      );
+    }
+
+    // 6. Measure → persist → enqueue, one sealed hour at a time. A measurement
     //    that throws aborts the loop (no silent under-bill); progress is durable
     //    per hour, so the next wake-up resumes from the last recorded hour.
-    for (let ms = firstMs; ms <= sealBoundaryMs; ms += MS_PER_HOUR) {
+    for (let ms = firstMs; ms <= runEndMs; ms += MS_PER_HOUR) {
       const sealedHour = new Date(ms);
       const bytes = await this.deps.measureBytesAt({
         organizationId,

--- a/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageMeterDispatch.service.ts
@@ -40,6 +40,17 @@ export interface StorageMeterDispatchDeps {
     organizationId: string,
     fn: () => Promise<void>,
   ) => Promise<void>;
+  /**
+   * Optional measure-time drift guard (ADR-027 Phase 4.5). Observational only —
+   * its `check` never throws and never alters the billed value.
+   */
+  tripwire?: {
+    check: (params: {
+      organizationId: string;
+      sealedHour: Date;
+      measuredBytes: number;
+    }) => Promise<void>;
+  };
   /** Injectable wall clock for deterministic tests. */
   now?: () => Date;
 }
@@ -127,6 +138,12 @@ export class StorageMeterDispatchService {
       const bytes = await this.deps.measureBytesAt({
         organizationId,
         sealedHour,
+      });
+      // Observational drift guard — never throws, never changes the billed value.
+      await this.deps.tripwire?.check({
+        organizationId,
+        sealedHour,
+        measuredBytes: bytes,
       });
       const megabytes = Math.ceil(bytes / BYTES_PER_MIB);
 

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -76,6 +76,7 @@ import { runEvaluationWorkflow } from "../workflows/runWorkflow";
 import { App, getApp, globalForApp, initializeApp } from "./app";
 import { PrismaBillingCheckpointService } from "./billing/billingCheckpoint.service";
 import { PrismaStorageBillingCheckpointService } from "./billing/storageBillingCheckpoint.service";
+import { StorageBillingTripwire } from "./billing/storageBillingTripwire";
 import { StorageMeterDispatchService } from "./billing/storageMeterDispatch.service";
 import { PrismaStorageUsageHourlyRepository } from "./billing/storageUsageHourly.repository";
 import { BroadcastService } from "./broadcast/broadcast.service";
@@ -634,6 +635,24 @@ export function initializeDefaultApp(options?: {
             }
           }
         : undefined,
+      // ADR-027 Phase 4.5 drift guard. Reference: the previous sealed hour's
+      // recorded bytes — storage changes slowly hour-over-hour, so a gross jump
+      // is anomalous. The precise "reference SUM vs measured" check plugs into
+      // the same module once verified against real ClickHouse.
+      tripwire: new StorageBillingTripwire({
+        isEnabled: (organizationId) =>
+          featureFlagService.isEnabled(
+            "release_storage_billing_metering_tripwire",
+            { distinctId: organizationId, organizationId },
+          ),
+        computeReference: async ({ organizationId, sealedHour }) => {
+          const prev = await storageUsageHourlyRepo.findHour({
+            organizationId,
+            sealedHour: new Date(sealedHour.getTime() - 60 * 60 * 1000),
+          });
+          return prev ? prev.megabytes * 1024 * 1024 : null;
+        },
+      }),
     });
   }
 

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -515,7 +515,17 @@ export function initializeDefaultApp(options?: {
     processRole: config.processRole,
     retentionPolicyResolver: retentionPolicyCache,
     getStorageMeterDispatch: config.isSaas
-      ? () => (params) => storageMeterDispatchService!.dispatchForOrg(params)
+      ? () => (params) => {
+          // Built after registerAll (below), so a reactor firing before that
+          // finishes should fail loud — the reactor catches + logs it — rather
+          // than deref undefined with a cryptic message.
+          if (!storageMeterDispatchService) {
+            throw new Error(
+              "storageMeterDispatchService not yet initialized — dispatch fired before composition finished",
+            );
+          }
+          return storageMeterDispatchService.dispatchForOrg(params);
+        }
       : undefined,
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportStorageForHour.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportStorageForHour.command.unit.test.ts
@@ -227,6 +227,23 @@ describe("ReportStorageForHourCommand", () => {
     });
   });
 
+  describe("given a zero-megabyte hour", () => {
+    /** @scenario A zero-megabyte hour is marked reported without a billing call */
+    it("stamps the cursor without calling Stripe", async () => {
+      mockStorageUsageHourly.findHour.mockResolvedValue({
+        megabytes: 0,
+        reportedAt: null,
+      });
+      const handler = await createHandler();
+
+      const result = await handler.handle(makeCommand());
+
+      expect(result).toEqual([]);
+      expect(mockReportUsageDelta).not.toHaveBeenCalled();
+      expect(mockStorageUsageHourly.markReported).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("when the meter event already exists on Stripe", () => {
     /** @scenario A Stripe duplicate is treated as already reported */
     it("treats the duplicate as reported and stamps the cursor without a failure", async () => {

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportStorageForHour.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportStorageForHour.command.unit.test.ts
@@ -348,6 +348,54 @@ describe("ReportStorageForHourCommand", () => {
     });
   });
 
+  describe("given a single permanently-rejected hour then a healthy hour", () => {
+    // Anti-starvation guard: one poison hour cannot trip the breaker. A permanent
+    // rejection is one-shot (no self-dispatch), and nothing re-drives an
+    // unreported hour — the dispatcher advances by max(measured hour), not by
+    // reportedAt — so the failure count only ever reaches 1 from it, and the next
+    // healthy hour clears it. The breaker only trips on *systemic* failure.
+    it("bumps the breaker to one, then the next success clears it", async () => {
+      // 1st hour: permanent rejection from a clean breaker → failures = 1.
+      mockStorageBillingCheckpoints.getCheckpoint.mockResolvedValueOnce(null);
+      mockStorageUsageHourly.findHour.mockResolvedValueOnce({
+        megabytes: 42,
+        reportedAt: null,
+      });
+      mockReportUsageDelta.mockResolvedValueOnce([
+        { reported: false, error: "invalid_request" },
+      ]);
+
+      await (await createHandler()).handle(makeCommand("org-1", SEALED_HOUR));
+
+      expect(mockStorageBillingCheckpoints.recordFailure).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        billingMonth: EXPECTED_MONTH,
+        consecutiveFailures: 1,
+      });
+
+      // 2nd hour: healthy, breaker now at 1 → success clears it to 0.
+      mockStorageBillingCheckpoints.getCheckpoint.mockResolvedValueOnce({
+        lastReportedTotal: 0,
+        pendingReportedTotal: null,
+        consecutiveFailures: 1,
+      });
+      mockStorageUsageHourly.findHour.mockResolvedValueOnce({
+        megabytes: 7,
+        reportedAt: null,
+      });
+      mockReportUsageDelta.mockResolvedValueOnce([{ reported: true }]);
+
+      await (await createHandler()).handle(
+        makeCommand("org-1", "2026-02-15T13:00:00.000Z"),
+      );
+
+      expect(mockStorageBillingCheckpoints.recordSuccess).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        billingMonth: EXPECTED_MONTH,
+      });
+    });
+  });
+
   describe("given an organization that cannot be billed", () => {
     /** @scenario Reporting is skipped for an organization that cannot be billed */
     it("sends nothing when there is no Stripe customer", async () => {

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportStorageForHour.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportStorageForHour.command.ts
@@ -213,6 +213,21 @@ export class ReportStorageForHourCommand
       );
       return false;
     }
+    if (hour.megabytes === 0) {
+      // Nothing to bill for a 0-MiB hour (e.g. a default-keep org with no data
+      // older than the free window — every hour is 0). Stamp the cursor so it
+      // never re-dispatches, without a wasted 0-value Stripe call each hour.
+      await this.deps.storageUsageHourly.markReported({
+        organizationId,
+        sealedHour: sealedHourDate,
+        reportedAt: new Date(),
+      });
+      logger.debug(
+        { organizationId, sealedHour },
+        "zero-MiB hour, marked reported without a Stripe call",
+      );
+      return false;
+    }
 
     const usageReportingService = this.deps.getUsageReportingService();
     if (!usageReportingService) {

--- a/specs/data-retention/storage-billing-backfill.feature
+++ b/specs/data-retention/storage-billing-backfill.feature
@@ -1,0 +1,40 @@
+Feature: Storage billing — SubscriptionItem backfill (ADR-027, Phase 7)
+  As the storage-billing rollout
+  I want to attach the STORAGE_GB item to existing paid subscriptions idempotently
+  So that customers begin accruing storage usage on the announced date without re-checkout or disruption
+
+  # Runs only after the customer notice, on the announced date. Idempotent (safe to re-run and to run
+  # alongside live traffic): an already-attached item is skipped, a subscription with no matching
+  # storage price is skipped and counted (never guessed), and one failure never aborts the run. Free
+  # and self-hosted orgs never appear — the source lists paid subscriptions only. A dry-run reports
+  # what it would do without mutating Stripe.
+
+  @unit
+  Scenario: The storage item is attached to a paid subscription that lacks it
+    Given a paid subscription without the STORAGE_GB item and a resolvable price
+    When the backfill runs
+    Then the item is attached to that subscription
+
+  @unit
+  Scenario: A subscription that already has the item is skipped (idempotent)
+    Given a paid subscription that already carries the STORAGE_GB item
+    When the backfill runs
+    Then the item is not attached again
+
+  @unit
+  Scenario: A subscription with no matching storage price is skipped, never guessed
+    Given a paid subscription whose plan, currency, and interval have no storage price
+    When the backfill runs
+    Then the item is not attached and the subscription is counted as skipped
+
+  @unit
+  Scenario: A dry-run reports what it would attach without mutating Stripe
+    Given a paid subscription without the item
+    When the backfill runs as a dry-run
+    Then Stripe is not mutated but the would-be attach is reported
+
+  @unit
+  Scenario: One subscription's failure does not abort the whole backfill
+    Given several paid subscriptions where attaching one fails
+    When the backfill runs
+    Then the remaining subscriptions are still processed and the failure is counted

--- a/specs/data-retention/storage-billing-dispatch.feature
+++ b/specs/data-retention/storage-billing-dispatch.feature
@@ -66,6 +66,13 @@ Feature: Storage billing — dispatch sealed hours for measurement (ADR-027, Pha
     Then only the most recent hours up to the ceiling are measured
     And an alarm is logged that older hours were dropped
 
+  @unit
+  Scenario: A large catch-up measures at most the per-run cap and defers the rest
+    Given an organization whose cursor trails by more than one run's measurement cap but within the ceiling
+    When the dispatcher runs for the organization
+    Then at most the per-run cap of hours are measured this run
+    And the remaining hours are left for a later run without an alarm
+
   # ---------------------------------------------------------------------------
   # Per-hour contract
   # ---------------------------------------------------------------------------

--- a/specs/data-retention/storage-billing-hour-reporting.feature
+++ b/specs/data-retention/storage-billing-hour-reporting.feature
@@ -48,6 +48,13 @@ Feature: Storage billing — report a sealed hour to Stripe (ADR-027, Phase 3)
     And the hour's reported state is left unchanged
 
   @unit
+  Scenario: A zero-megabyte hour is marked reported without a billing call
+    Given a measured hour of zero megabytes that has not yet been reported
+    When the hour is reported
+    Then no meter event is sent
+    And the hour is marked reported so it is not dispatched again
+
+  @unit
   Scenario: A Stripe duplicate is treated as already reported
     Given a measured hour whose meter event already exists on Stripe
     When the hour is reported

--- a/specs/data-retention/storage-billing-reconciliation.feature
+++ b/specs/data-retention/storage-billing-reconciliation.feature
@@ -1,0 +1,33 @@
+Feature: Storage billing — reconciliation safety net (ADR-027, Phase 7)
+  As finance
+  I want the recorded storage totals periodically diffed against Stripe's meter totals
+  So that any drift between what we think we billed and what Stripe recorded is caught
+
+  # Off the critical path, observational only. Per org/period it compares Σ StorageUsageHourly.megabytes
+  # (reportedAt set) against Stripe's own meter total and logs a drift error beyond a small tolerance —
+  # catching anything the idempotency layers and the measure-time tripwire missed (e.g. a report the
+  # cursor marked done that Stripe never accepted). It never mutates anything.
+
+  @unit
+  Scenario: Matching totals report no drift
+    Given an organization whose recorded and Stripe totals match within tolerance
+    When the period is reconciled
+    Then no drift is logged
+
+  @unit
+  Scenario: Divergent totals are flagged as drift
+    Given an organization whose recorded and Stripe totals diverge beyond tolerance
+    When the period is reconciled
+    Then a drift error is logged
+
+  @unit
+  Scenario: An unavailable Stripe total is skipped, never a false drift
+    Given an organization whose Stripe meter total cannot be fetched
+    When the period is reconciled
+    Then the organization is counted as unavailable and no drift is flagged
+
+  @unit
+  Scenario: Each organization is reconciled independently
+    Given several organizations where only one drifts
+    When the period is reconciled
+    Then every organization is checked and only the drifting one is flagged

--- a/specs/data-retention/storage-billing-tripwire.feature
+++ b/specs/data-retention/storage-billing-tripwire.feature
@@ -39,6 +39,12 @@ Feature: Storage billing — measure-time tripwire (ADR-027, Phase 4.5)
     Then no more than the capped number of warnings are logged
 
   @unit
+  Scenario: The log cap resets each window so later divergence isn't silenced forever
+    Given the log cap was reached in one window
+    When a divergent measurement is checked after the window elapses
+    Then a warning is logged again
+
+  @unit
   Scenario: The tripwire never throws into the measure path
     Given the reference computation fails
     When a measurement is checked

--- a/specs/data-retention/storage-billing-tripwire.feature
+++ b/specs/data-retention/storage-billing-tripwire.feature
@@ -1,0 +1,45 @@
+Feature: Storage billing — measure-time tripwire (ADR-027, Phase 4.5)
+  As the storage-billing pipeline
+  I want each billed measurement shadow-compared against an independent reference
+  So that a wrong value is caught and logged before it bills, without ever risking the measure path
+
+  # The tripwire is purely observational: behind its own flag, it computes an independent reference
+  # for the same hour and logs a capped warning when the measurement diverges beyond tolerance. It
+  # must never alter the billed value and never throw into the measure/report path — every failure is
+  # swallowed. Given `_size_bytes` aggregation caused two prod OOMs, a bad value must be visible early.
+
+  @unit
+  Scenario: A disabled tripwire does nothing
+    Given the tripwire flag is off for the organization
+    When a measurement is checked
+    Then no reference is computed and nothing is logged
+
+  @unit
+  Scenario: No reference means no comparison
+    Given the tripwire is enabled but no reference is available
+    When a measurement is checked
+    Then nothing is logged
+
+  @unit
+  Scenario: A measurement within tolerance is silent
+    Given a measurement within the tolerance of its reference
+    When it is checked
+    Then nothing is logged
+
+  @unit
+  Scenario: A divergent measurement is warned once
+    Given a measurement that diverges beyond the tolerance
+    When it is checked
+    Then a divergence warning is logged
+
+  @unit
+  Scenario: Divergence logging is capped so a broken reference can't flood logs
+    Given repeated divergent measurements past the log cap
+    When they are checked
+    Then no more than the capped number of warnings are logged
+
+  @unit
+  Scenario: The tripwire never throws into the measure path
+    Given the reference computation fails
+    When a measurement is checked
+    Then the check resolves without throwing and logs no divergence


### PR DESCRIPTION
## What

ADR-027 "Bucket A" — the remaining code-completable hardening for Phases 6/7 + 4.5, in one PR. Five items, each tests-first.

### 1. Cancel invoices accrued metered usage (Phase 6 — real revenue bug)
`cancelSubscription` called `stripe.subscriptions.cancel(id)` with no `invoice_now`, so Stripe **silently discarded un-invoiced metered usage** on immediate cancel — dropping revenue for the billable-events meter *today*, and `STORAGE_GB` once attached. Now passes `invoice_now: true` (bills accrued usage); `prorate` stays off so unused seat time isn't credited. *(Downgrade-removes-`STORAGE_GB` is deferred until that item is actually attached — can't be exercised until it exists.)*

### 2. Poison-hour anti-starvation (corrects my #5225 review)
My #5225 review flagged a poison hour starving the org breaker **on a wrong assumption** — that the dispatcher re-drives unreported hours. It does **not**: the cursor advances by `max(measured hour)`, not `reportedAt`. So a permanent rejection is one-shot (breaker→1, no self-dispatch, nothing re-enqueues it) and the next healthy hour clears it. The breaker only trips on *systemic* failure — correct. Added a combined regression test locking the property; permanently-unreported hours are caught by item 5.

### 3. Measure-time tripwire (Phase 4.5)
`storageBillingTripwire.ts` — shadow-compares each billed measurement against an independent reference, logs a capped warning on divergence. **Contract (tested):** flag-gated, capped, and it **never throws into the measure path** or alters the billed value. Wired into the dispatcher (post-measure) behind `release_storage_billing_metering_tripwire` with a cheap hour-over-hour reference (storage changes slowly → a gross jump is anomalous). The precise "reference SUM" check plugs into the same module once warike-verified.

### 4. STORAGE_GB backfill service (Phase 7)
`storageBillingBackfill.service.ts` — idempotent attach of the `STORAGE_GB` item to active paid subscriptions: skips already-attached, skips (counts) subs with no matching price (never guessed), one failure never aborts the run, `dryRun` reports without mutating Stripe. Free/self-hosted never appear (paid-only source).

### 5. Reconciliation safety net (Phase 7, deferred item)
`storageBillingReconciliation.service.ts` — per org/period, diffs `Σ StorageUsageHourly.megabytes (reportedAt set)` vs Stripe's meter total, logs drift beyond a 1% tolerance; unavailable Stripe total is skipped (no false drift). Observational, never mutates.

## Tests
**79 unit tests** across 8 files; typecheck clean; feature-parity green (4 new bound feature files: tripwire, backfill, reconciliation, + a dispatch scenario). Items 4 & 5 are logic-complete + fully unit-tested with mocked Stripe; they **run** once the external `STORAGE_GB` meter/prices exist (Phase 5). The tripwire runs now; cancel-fix is live.

## Still external / not in this PR
Create the Stripe `STORAGE_GB` meter + prices → wire catalog ids; €3/GiB sign-off; retention floor 49→35 (product decision); customer notice + backfill execution + flag flip.

Stacks on #5227.


## Post-review follow-ups (added same-PR after review)
- **Tripwire log cap resets each hour window** — was a process-lifetime cap that went permanently silent after 50 warnings, even for genuinely new divergence.
- **Zero-MiB hours skip the Stripe call** — a default-keep org bills 0 every hour; stamp the cursor without a wasted 0-value meter event.
- **Cap measurements per dispatch run (168h)** — a large post-outage catch-up no longer runs hundreds of heavy `byteSize()` measurements back-to-back in one worker job; the remainder drains on later events.
- **Harden the dispatch forward-ref** in the composition root — fail loud if a reactor fires before composition finishes, instead of a cryptic undefined deref.

Remaining follow-ups that genuinely need external inputs (create the Stripe meter, ClickHouse verification, go-live wiring, retention-floor product decision) are **not** in this PR — see the review thread.