### PR TITLE
feat(data-retention): plan-gate the retention menu (paid fixed pair, enterprise full + custom)

### DIFF
--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -23,14 +23,17 @@ vi.mock("../../../src/server/app-layer/app", () => ({
   }),
 }));
 
-import { SubscriptionStatus } from "../planTypes";
+import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
+import type {
+  SubscriptionRepository,
+  SubscriptionWithOrg,
+} from "../../../src/server/app-layer/subscription/subscription.repository";
 import {
   PLATFORM_DEFAULT_RETENTION_DAYS,
   RETENTION_CATEGORIES,
 } from "../../../src/server/data-retention/retentionPolicy.schema";
+import { SubscriptionStatus } from "../planTypes";
 import { EEWebhookService } from "../services/webhookService";
-import type { SubscriptionRepository, SubscriptionWithOrg } from "../../../src/server/app-layer/subscription/subscription.repository";
-import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
 
 const createMockSubscriptionRepository = () => ({
   findLastNonCancelled: vi.fn(),
@@ -86,10 +89,14 @@ const createMockItemCalculator = () => ({
     GROWTH_EVENTS_EUR_ANNUAL: "price_growth_events_eur_annual",
     GROWTH_EVENTS_USD_MONTHLY: "price_growth_events_usd_monthly",
     GROWTH_EVENTS_USD_ANNUAL: "price_growth_events_usd_annual",
-    GROWTH_EVENTS_EUR_MONTHLY_UNTIL_MAR_2026: "price_growth_events_eur_monthly_until_mar_2026",
-    GROWTH_EVENTS_EUR_ANNUAL_UNTIL_MAR_2026: "price_growth_events_eur_annual_until_mar_2026",
-    GROWTH_EVENTS_USD_MONTHLY_UNTIL_MAR_2026: "price_growth_events_usd_monthly_until_mar_2026",
-    GROWTH_EVENTS_USD_ANNUAL_UNTIL_MAR_2026: "price_growth_events_usd_annual_until_mar_2026",
+    GROWTH_EVENTS_EUR_MONTHLY_UNTIL_MAR_2026:
+      "price_growth_events_eur_monthly_until_mar_2026",
+    GROWTH_EVENTS_EUR_ANNUAL_UNTIL_MAR_2026:
+      "price_growth_events_eur_annual_until_mar_2026",
+    GROWTH_EVENTS_USD_MONTHLY_UNTIL_MAR_2026:
+      "price_growth_events_usd_monthly_until_mar_2026",
+    GROWTH_EVENTS_USD_ANNUAL_UNTIL_MAR_2026:
+      "price_growth_events_usd_annual_until_mar_2026",
   },
 });
 
@@ -107,17 +114,25 @@ const makeSubscription = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-const makeSubscriptionWithOrg = (overrides: Record<string, unknown> = {}): SubscriptionWithOrg => {
+const makeSubscriptionWithOrg = (
+  overrides: Record<string, unknown> = {},
+): SubscriptionWithOrg => {
   const { organization, ...subscriptionOverrides } = overrides;
   return {
     ...makeSubscription(subscriptionOverrides),
-    organization: { name: "Acme", license: null, ...(organization as Record<string, unknown>) },
+    organization: {
+      name: "Acme",
+      license: null,
+      ...(organization as Record<string, unknown>),
+    },
   } as unknown as SubscriptionWithOrg;
 };
 
 const createMockStripe = (overrides: Record<string, unknown> = {}) => ({
   subscriptions: {
-    retrieve: vi.fn().mockResolvedValue({ id: "sub_stripe_1", status: "active" }),
+    retrieve: vi
+      .fn()
+      .mockResolvedValue({ id: "sub_stripe_1", status: "active" }),
     cancel: vi.fn().mockResolvedValue({}),
   },
   ...overrides,
@@ -210,7 +225,9 @@ describe("webhookService", () => {
           id: "sub_db_1",
           previousStatus: SubscriptionStatus.PENDING,
         });
-        expect(subRepo.cancelTrialSubscriptions).toHaveBeenCalledWith("org_123");
+        expect(subRepo.cancelTrialSubscriptions).toHaveBeenCalledWith(
+          "org_123",
+        );
       });
 
       /** @scenario Checkout fails when no subscription matches the reference */
@@ -246,13 +263,17 @@ describe("webhookService", () => {
         await promise;
 
         expect(subRepo.activate).toHaveBeenCalled();
-        expect(subRepo.cancelTrialSubscriptions).toHaveBeenCalledWith("org_123");
+        expect(subRepo.cancelTrialSubscriptions).toHaveBeenCalledWith(
+          "org_123",
+        );
       });
 
       /** @scenario Checkout succeeds even when invite approval fails */
       it("continues when invite approval fails", async () => {
         const mockInviteApprover = {
-          approvePaymentPendingInvites: vi.fn().mockRejectedValue(new Error("invite error")),
+          approvePaymentPendingInvites: vi
+            .fn()
+            .mockRejectedValue(new Error("invite error")),
         };
         service = new EEWebhookService({
           subscriptionRepository: subRepo as unknown as SubscriptionRepository,
@@ -279,7 +300,9 @@ describe("webhookService", () => {
         await promise;
 
         expect(subRepo.activate).toHaveBeenCalled();
-        expect(subRepo.cancelTrialSubscriptions).toHaveBeenCalledWith("org_123");
+        expect(subRepo.cancelTrialSubscriptions).toHaveBeenCalledWith(
+          "org_123",
+        );
       });
 
       /** @scenario Checkout succeeds without an invite approval mechanism */
@@ -394,10 +417,16 @@ describe("webhookService", () => {
         });
 
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.PENDING,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.activate.mockResolvedValue(
-          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.migrateToSeatEvent.mockResolvedValue([
           { stripeSubscriptionId: "sub_old_1" },
@@ -415,13 +444,21 @@ describe("webhookService", () => {
           organizationId: "org_123",
           excludeSubscriptionId: "sub_db_1",
         });
-        expect(localStripe.subscriptions.cancel).toHaveBeenCalledWith("sub_old_1", { prorate: true });
-        expect(localStripe.subscriptions.cancel).toHaveBeenCalledWith("sub_old_2", { prorate: true });
+        expect(localStripe.subscriptions.cancel).toHaveBeenCalledWith(
+          "sub_old_1",
+          { prorate: true },
+        );
+        expect(localStripe.subscriptions.cancel).toHaveBeenCalledWith(
+          "sub_old_2",
+          { prorate: true },
+        );
       });
 
       it("logs but does not fail when Stripe cancellation fails", async () => {
         const localStripe = createMockStripe();
-        localStripe.subscriptions.cancel.mockRejectedValue(new Error("Stripe error"));
+        localStripe.subscriptions.cancel.mockRejectedValue(
+          new Error("Stripe error"),
+        );
         service = new EEWebhookService({
           subscriptionRepository: subRepo as unknown as SubscriptionRepository,
           organizationRepository: orgRepo as unknown as OrganizationRepository,
@@ -430,10 +467,16 @@ describe("webhookService", () => {
         });
 
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.PENDING,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.activate.mockResolvedValue(
-          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.migrateToSeatEvent.mockResolvedValue([
           { stripeSubscriptionId: "sub_old_1" },
@@ -453,10 +496,16 @@ describe("webhookService", () => {
       /** @scenario A first paid Growth Seat activation provisions the organization policies */
       it("provisions an organization-scoped retention policy for every category at the platform default", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.PENDING,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.activate.mockResolvedValue(
-          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.migrateToSeatEvent.mockResolvedValue([]);
 
@@ -474,16 +523,24 @@ describe("webhookService", () => {
             retentionDays: PLATFORM_DEFAULT_RETENTION_DAYS,
           });
         }
-        expect(mockSetForScope).toHaveBeenCalledTimes(RETENTION_CATEGORIES.length);
+        expect(mockSetForScope).toHaveBeenCalledTimes(
+          RETENTION_CATEGORIES.length,
+        );
       });
 
-      /** @scenario A grandfathered org-level policy survives a seat event (INV-6) */
+      /** @scenario A billing event never overwrites an existing retention policy */
       it("never overwrites an existing org-level policy — only fills missing categories", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.PENDING,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.activate.mockResolvedValue(
-          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.migrateToSeatEvent.mockResolvedValue([]);
         // The org already tuned traces retention high; a billing event must NOT
@@ -504,11 +561,9 @@ describe("webhookService", () => {
         await vi.advanceTimersByTimeAsync(2000);
         await promise;
 
-        // traces is left untouched…
         expect(mockSetForScope).not.toHaveBeenCalledWith(
           expect.objectContaining({ category: "traces" }),
         );
-        // …while the remaining categories are still provisioned.
         expect(mockSetForScope).toHaveBeenCalledTimes(
           RETENTION_CATEGORIES.length - 1,
         );
@@ -517,13 +572,21 @@ describe("webhookService", () => {
       /** @scenario A retention failure never fails the billing webhook */
       it("still activates and notifies when retention provisioning throws", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.PENDING,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.activate.mockResolvedValue(
-          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.migrateToSeatEvent.mockResolvedValue([]);
-        mockSetForScope.mockRejectedValueOnce(new Error("retention store down"));
+        mockSetForScope.mockRejectedValueOnce(
+          new Error("retention store down"),
+        );
 
         const promise = service.handleInvoicePaymentSucceeded({
           subscriptionId: "sub_stripe_1",
@@ -534,7 +597,10 @@ describe("webhookService", () => {
         await promise;
 
         expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
-          expect.objectContaining({ type: "confirmed", organizationId: "org_123" }),
+          expect.objectContaining({
+            type: "confirmed",
+            organizationId: "org_123",
+          }),
         );
       });
     });
@@ -543,10 +609,16 @@ describe("webhookService", () => {
       /** @scenario A non-seat plan does not provision a policy */
       it("does not provision a retention policy on first activation", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "LAUNCH" }),
+          makeSubscription({
+            status: SubscriptionStatus.PENDING,
+            plan: "LAUNCH",
+          }),
         );
         subRepo.activate.mockResolvedValue(
-          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "LAUNCH" }),
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "LAUNCH",
+          }),
         );
 
         const promise = service.handleInvoicePaymentSucceeded({
@@ -564,10 +636,16 @@ describe("webhookService", () => {
       /** @scenario A renewal does not re-provision the policy */
       it("does not re-provision the retention policy", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.activate.mockResolvedValue(
-          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
 
         const promise = service.handleInvoicePaymentSucceeded({
@@ -851,7 +929,10 @@ describe("webhookService", () => {
     describe("when subscription is active and gets cancelled", () => {
       it("sends a cancelled Slack notification", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
 
@@ -875,7 +956,10 @@ describe("webhookService", () => {
 
       it("sends notification with cancellation date", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
 
@@ -896,7 +980,10 @@ describe("webhookService", () => {
 
       it("still cancels and notifies even when org name lookup fails", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         orgRepo.findNameById.mockResolvedValue(null);
 
@@ -918,7 +1005,10 @@ describe("webhookService", () => {
 
       it("completes cancellation even when notification throws", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         orgRepo.findNameById.mockRejectedValue(new Error("DB connection lost"));
 
@@ -940,7 +1030,10 @@ describe("webhookService", () => {
       /** @scenario Cancelling a subscription leaves the retention policies in place */
       it("does not remove the organization retention policies (removal deactivated)", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.findLastNonCancelled.mockResolvedValue(null);
 
@@ -1053,7 +1146,10 @@ describe("webhookService", () => {
       /** @scenario Active subscription update clears a trial license */
       it("recalculates quantities and updates", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "LAUNCH" }),
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "LAUNCH",
+          }),
         );
         itemCalculator.calculateQuantityForPrice
           .mockReturnValueOnce(5) // users
@@ -1094,7 +1190,10 @@ describe("webhookService", () => {
       /** @scenario Transition to active triggers a notification */
       it("notifies when transitioning from non-active to active", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "LAUNCH" }),
+          makeSubscription({
+            status: SubscriptionStatus.PENDING,
+            plan: "LAUNCH",
+          }),
         );
         subRepo.updateQuantities.mockResolvedValue(
           makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE }),
@@ -1124,7 +1223,10 @@ describe("webhookService", () => {
       /** @scenario Already-active subscription does not re-notify */
       it("skips notification when already active", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "LAUNCH" }),
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "LAUNCH",
+          }),
         );
         subRepo.updateQuantities.mockResolvedValue(
           makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE }),
@@ -1153,7 +1255,10 @@ describe("webhookService", () => {
       /** @scenario Cancelling a subscription leaves the retention policies in place */
       it("does not remove the organization retention policies (removal deactivated)", async () => {
         subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "GROWTH_SEAT_EUR_MONTHLY",
+          }),
         );
         subRepo.findLastNonCancelled.mockResolvedValue(null);
 

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockSendSlackSubscriptionEvent = vi.fn().mockResolvedValue(undefined);
 const mockSetForScope = vi.fn().mockResolvedValue(undefined);
 const mockRemoveForScope = vi.fn().mockResolvedValue(undefined);
+// Seat provisioning is create-if-absent: it reads the org's current rules and
+// only fills the gaps. Default to "no existing rules" so the base case
+// provisions everything.
+const mockListOrganizationRules = vi.fn().mockResolvedValue([]);
 
 vi.mock("../../../src/server/app-layer/app", () => ({
   getApp: () => ({
@@ -13,6 +17,7 @@ vi.mock("../../../src/server/app-layer/app", () => ({
       policy: {
         setForScope: mockSetForScope,
         removeForScope: mockRemoveForScope,
+        listOrganizationRules: mockListOrganizationRules,
       },
     },
   }),
@@ -470,6 +475,43 @@ describe("webhookService", () => {
           });
         }
         expect(mockSetForScope).toHaveBeenCalledTimes(RETENTION_CATEGORIES.length);
+      });
+
+      /** @scenario A grandfathered org-level policy survives a seat event (INV-6) */
+      it("never overwrites an existing org-level policy — only fills missing categories", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.migrateToSeatEvent.mockResolvedValue([]);
+        // The org already tuned traces retention high; a billing event must NOT
+        // clobber it back to the platform default (that would shorten the
+        // window and delete data). Only the uncovered categories are filled.
+        mockListOrganizationRules.mockResolvedValueOnce([
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: "org_123",
+            category: "traces",
+            retentionDays: 1827,
+          },
+        ]);
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        // traces is left untouched…
+        expect(mockSetForScope).not.toHaveBeenCalledWith(
+          expect.objectContaining({ category: "traces" }),
+        );
+        // …while the remaining categories are still provisioned.
+        expect(mockSetForScope).toHaveBeenCalledTimes(
+          RETENTION_CATEGORIES.length - 1,
+        );
       });
 
       /** @scenario A retention failure never fails the billing webhook */

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -1,25 +1,32 @@
 import { Currency, type PrismaClient } from "@prisma/client";
-import type Stripe from "stripe";
 import type { PostHog } from "posthog-node";
-import { createLogger } from "../../../src/utils/logger";
+import type Stripe from "stripe";
 import { getApp } from "../../../src/server/app-layer/app";
+import { PrismaOrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.prisma.repository";
+import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
 import type {
   SubscriptionRepository,
   SubscriptionWithOrg,
 } from "../../../src/server/app-layer/subscription/subscription.repository";
-import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
-import { PrismaOrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.prisma.repository";
-import { PrismaSubscriptionRepository } from "./subscription.repository";
-import { SubscriptionStatus } from "../planTypes";
-import type { calculateQuantityForPrice, prices } from "./subscriptionItemCalculator";
-import { isGrowthEventsPrice, isGrowthSeatEventPlan, isGrowthSeatPrice } from "../utils/growthSeatEvent";
-import { SubscriptionRecordNotFoundError } from "../errors";
 import { traced } from "../../../src/server/app-layer/tracing";
-import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
 import {
   PLATFORM_DEFAULT_RETENTION_DAYS,
   RETENTION_CATEGORIES,
 } from "../../../src/server/data-retention/retentionPolicy.schema";
+import { createLogger } from "../../../src/utils/logger";
+import { SubscriptionRecordNotFoundError } from "../errors";
+import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
+import { SubscriptionStatus } from "../planTypes";
+import {
+  isGrowthEventsPrice,
+  isGrowthSeatEventPlan,
+  isGrowthSeatPrice,
+} from "../utils/growthSeatEvent";
+import { PrismaSubscriptionRepository } from "./subscription.repository";
+import type {
+  calculateQuantityForPrice,
+  prices,
+} from "./subscriptionItemCalculator";
 
 const logger = createLogger("langwatch:billing:webhookService");
 
@@ -59,7 +66,9 @@ export type HandleEventResult =
 const STRIPE_EVENTUAL_CONSISTENCY_DELAY_MS = 2000;
 // TECH-DEBT: This fixed delay should become a retry loop with backoff.
 const waitForStripeConsistency = () =>
-  new Promise((resolve) => setTimeout(resolve, STRIPE_EVENTUAL_CONSISTENCY_DELAY_MS));
+  new Promise((resolve) =>
+    setTimeout(resolve, STRIPE_EVENTUAL_CONSISTENCY_DELAY_MS),
+  );
 
 export type WebhookService = {
   /**
@@ -90,9 +99,7 @@ export type WebhookService = {
     throwOnMissing?: boolean;
   }): Promise<void>;
 
-  handleInvoicePaymentFailed(params: {
-    subscriptionId: string;
-  }): Promise<void>;
+  handleInvoicePaymentFailed(params: { subscriptionId: string }): Promise<void>;
 
   handleSubscriptionDeleted(params: {
     stripeSubscriptionId: string;
@@ -479,9 +486,7 @@ export class EEWebhookService implements WebhookService {
         { subscriptionClientReferenceId },
         "[stripeWebhook] No subscription found for checkout",
       );
-      throw new SubscriptionRecordNotFoundError(
-        subscriptionClientReferenceId,
-      );
+      throw new SubscriptionRecordNotFoundError(subscriptionClientReferenceId);
     }
 
     await this.syncInvoicePaymentSuccess({
@@ -489,7 +494,8 @@ export class EEWebhookService implements WebhookService {
       throwOnMissing: true,
     });
 
-    const subscriptionRecord = await this.subscriptionRepository.findByStripeId(subscriptionId);
+    const subscriptionRecord =
+      await this.subscriptionRepository.findByStripeId(subscriptionId);
 
     const normalizedCurrency = this.normalizeSelectedCurrency(selectedCurrency);
     if (normalizedCurrency && subscriptionRecord) {
@@ -614,9 +620,10 @@ export class EEWebhookService implements WebhookService {
       );
     }
 
-    const remainingActive = await this.subscriptionRepository.findLastNonCancelled(
-      existingSubscription.organizationId,
-    );
+    const remainingActive =
+      await this.subscriptionRepository.findLastNonCancelled(
+        existingSubscription.organizationId,
+      );
     fireSubscriptionSyncNurturing({
       organizationId: existingSubscription.organizationId,
       hasSubscription: !!remainingActive,
@@ -644,10 +651,7 @@ export class EEWebhookService implements WebhookService {
       return;
     }
 
-    if (
-      subscription.status !== "active" ||
-      subscription.ended_at
-    ) {
+    if (subscription.status !== "active" || subscription.ended_at) {
       // Truly cancelled or ended — mark as CANCELLED in DB.
       // Note: canceled_at alone means "scheduled for cancellation at period end"
       // — the sub is still active until then, so we don't cancel in DB yet.
@@ -655,9 +659,10 @@ export class EEWebhookService implements WebhookService {
       // which is handled by handleSubscriptionDeleted.
       await this.subscriptionRepository.cancel({ id: existingSubForUpdate.id });
 
-      const remainingActive = await this.subscriptionRepository.findLastNonCancelled(
-        existingSubForUpdate.organizationId,
-      );
+      const remainingActive =
+        await this.subscriptionRepository.findLastNonCancelled(
+          existingSubForUpdate.organizationId,
+        );
       fireSubscriptionSyncNurturing({
         organizationId: existingSubForUpdate.organizationId,
         hasSubscription: !!remainingActive,
@@ -681,8 +686,7 @@ export class EEWebhookService implements WebhookService {
           item.price.id === this.itemCalculator.prices.LAUNCH_USERS ||
           item.price.id === this.itemCalculator.prices.ACCELERATE_USERS ||
           item.price.id === this.itemCalculator.prices.LAUNCH_ANNUAL_USERS ||
-          item.price.id ===
-            this.itemCalculator.prices.ACCELERATE_ANNUAL_USERS
+          item.price.id === this.itemCalculator.prices.ACCELERATE_ANNUAL_USERS
         ) {
           const calculateQuantity =
             this.itemCalculator.calculateQuantityForPrice({
@@ -692,8 +696,7 @@ export class EEWebhookService implements WebhookService {
             });
           usersQuantity = calculateQuantity;
         } else if (
-          item.price.id ===
-            this.itemCalculator.prices.ACCELERATE_TRACES_100K ||
+          item.price.id === this.itemCalculator.prices.ACCELERATE_TRACES_100K ||
           item.price.id === this.itemCalculator.prices.LAUNCH_TRACES_10K ||
           item.price.id ===
             this.itemCalculator.prices.LAUNCH_ANNUAL_TRACES_10K ||
@@ -710,17 +713,21 @@ export class EEWebhookService implements WebhookService {
         }
       }
 
-      const updatedSubscription = await this.subscriptionRepository.updateQuantities({
-        id: existingSubForUpdate.id,
-        maxMembers: usersQuantity,
-        maxMessagesPerMonth: tracesQuantity,
-      });
+      const updatedSubscription =
+        await this.subscriptionRepository.updateQuantities({
+          id: existingSubForUpdate.id,
+          maxMembers: usersQuantity,
+          maxMessagesPerMonth: tracesQuantity,
+        });
 
       if (!updatedSubscription) {
         return;
       }
 
-      await this.clearTrialLicenseIfPresent(updatedSubscription, "subscription updated to active");
+      await this.clearTrialLicenseIfPresent(
+        updatedSubscription,
+        "subscription updated to active",
+      );
 
       if (shouldNotify) {
         await getApp().notifications.sendSlackSubscriptionEvent({
@@ -802,21 +809,28 @@ export class EEWebhookService implements WebhookService {
     }
 
     if (previousSubscription.status !== SubscriptionStatus.ACTIVE) {
-      await this.clearTrialLicenseIfPresent(updatedSubscription, "subscription activated");
+      await this.clearTrialLicenseIfPresent(
+        updatedSubscription,
+        "subscription activated",
+      );
 
       if (isGrowthSeatEventPlan(updatedSubscription.plan)) {
-        const oldSubscriptions = await this.subscriptionRepository.migrateToSeatEvent({
-          organizationId: updatedSubscription.organizationId,
-          excludeSubscriptionId: updatedSubscription.id,
-        });
+        const oldSubscriptions =
+          await this.subscriptionRepository.migrateToSeatEvent({
+            organizationId: updatedSubscription.organizationId,
+            excludeSubscriptionId: updatedSubscription.id,
+          });
 
         // Cancel in Stripe after DB is consistent (outside transaction)
         for (const oldSub of oldSubscriptions) {
           if (oldSub.stripeSubscriptionId) {
             try {
-              await this.stripe.subscriptions.cancel(oldSub.stripeSubscriptionId, {
-                prorate: true,
-              });
+              await this.stripe.subscriptions.cancel(
+                oldSub.stripeSubscriptionId,
+                {
+                  prorate: true,
+                },
+              );
             } catch (err) {
               logger.error(
                 { stripeSubscriptionId: oldSub.stripeSubscriptionId, err },
@@ -862,13 +876,18 @@ export class EEWebhookService implements WebhookService {
    * deletion windows — free-tier content blurs after 14d but stays recoverable
    * until the 49d policy deletes it. TODO(#4745): the blur layer.
    *
-   * Each category is upserted independently (idempotent on scope + category)
-   * and best-effort: a retention failure must never fail the Stripe webhook —
-   * that would leave the subscription stuck PENDING and trigger Stripe retries —
-   * so we log and continue to the next category, mirroring the surrounding
-   * notification side effects.
+   * Create-if-absent, per category: an org that already has a category's
+   * org-level policy keeps it (never clobbered back to the default — that would
+   * shorten a grandfathered window and delete data). Only missing categories
+   * are provisioned. Best-effort throughout: a retention failure must never fail
+   * the Stripe webhook — that would leave the subscription stuck PENDING and
+   * trigger Stripe retries — so if the current rules can't be read we skip
+   * provisioning entirely, and a per-category write failure is logged and
+   * skipped, mirroring the surrounding notification side effects.
    */
-  private async applySeatRetentionPolicy(organizationId: string): Promise<void> {
+  private async applySeatRetentionPolicy(
+    organizationId: string,
+  ): Promise<void> {
     // Create-if-absent, NOT upsert: a seat/subscription event must never
     // overwrite an existing org-level override. Unconditionally writing the
     // platform default here would clobber a grandfathered high policy (e.g.

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -869,7 +869,40 @@ export class EEWebhookService implements WebhookService {
    * notification side effects.
    */
   private async applySeatRetentionPolicy(organizationId: string): Promise<void> {
+    // Create-if-absent, NOT upsert: a seat/subscription event must never
+    // overwrite an existing org-level override. Unconditionally writing the
+    // platform default here would clobber a grandfathered high policy (e.g.
+    // ORG-traces = 1827d) down to 49d on any billing event — silently
+    // shortening the retention window and DELETING data the customer never
+    // opted to lose. Mirrors licenseHandler.provisionMissingRetentionPolicies.
+    let covered: Set<string>;
+    try {
+      const existing =
+        await getApp().dataRetention.policy.listOrganizationRules(
+          organizationId,
+        );
+      covered = new Set(
+        existing
+          .filter(
+            (row) =>
+              row.scopeType === "ORGANIZATION" &&
+              row.scopeId === organizationId,
+          )
+          .map((row) => row.category),
+      );
+    } catch (err) {
+      // If we can't read the current rules we can't prove a category is absent,
+      // so skip provisioning rather than risk a clobber. Ingestion still stamps
+      // PLATFORM_DEFAULT_RETENTION_DAYS via the cascade fallback.
+      logger.error(
+        { organizationId, err },
+        "[stripeWebhook] Failed to read retention rules; skipping seat provisioning",
+      );
+      return;
+    }
+
     for (const category of RETENTION_CATEGORIES) {
+      if (covered.has(category)) continue;
       try {
         await getApp().dataRetention.policy.setForScope({
           scope: { scopeType: "ORGANIZATION", scopeId: organizationId },

--- a/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
+++ b/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
@@ -18,18 +18,20 @@ import { Drawer } from "~/components/ui/drawer";
 import { Select } from "~/components/ui/select";
 import { Switch } from "~/components/ui/switch";
 import {
-  DEFAULT_RETENTION_DAYS,
+  ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS,
   INDEFINITE_RETENTION_DAYS,
   MAX_RETENTION_DAYS,
-  MIN_RETENTION_DAYS,
   RETENTION_WEEK_DAYS,
 } from "~/server/data-retention/retentionPolicy.schema";
 import {
+  buildRetentionMenuItems,
   CUSTOM_PRESET_VALUE,
   DAYS_PER_UNIT,
   INDEFINITE_PRESET_VALUE,
-  RETENTION_PRESETS,
+  LEGACY_PRESET_VALUE,
+  type RetentionPreset,
   type RetentionUnit,
+  retentionPresetsForTier,
   retentionUnitCollection,
   SCOPE_ICON,
 } from "./constants";
@@ -42,24 +44,47 @@ export type RetentionEditTarget = {
   retentionDays: number;
 };
 
-/** Map a stored day count back onto the drawer's preset/custom controls. Stored
- *  values are always week-aligned, so the custom fallback round-trips through
- *  whole weeks cleanly; the indefinite sentinel maps to its admin-only preset. */
-function initialRetentionState(days: number): {
+/** Map a stored day count back onto the drawer's controls, given what the
+ *  org's plan can represent. Stored values are always week-aligned, so the
+ *  custom fallback round-trips through whole weeks cleanly. A value the current
+ *  plan can't offer (a grandfathered high paid value, or indefinite for a
+ *  non-admin) maps to the read-only legacy option rather than being coerced. */
+function initialRetentionState({
+  days,
+  presets,
+  isEnterprise,
+  isPlatformAdmin,
+}: {
+  days: number;
+  presets: RetentionPreset[];
+  isEnterprise: boolean;
+  isPlatformAdmin: boolean;
+}): {
   preset: string;
   amount: string;
   unit: RetentionUnit;
 } {
   if (days === INDEFINITE_RETENTION_DAYS) {
-    return { preset: INDEFINITE_PRESET_VALUE, amount: "", unit: "weeks" };
+    return isPlatformAdmin
+      ? { preset: INDEFINITE_PRESET_VALUE, amount: "", unit: "weeks" }
+      : { preset: LEGACY_PRESET_VALUE, amount: "", unit: "weeks" };
   }
-  const match = RETENTION_PRESETS.find((p) => p.days === days);
+  const match = presets.find((p) => p.days === days);
   if (match) return { preset: match.value, amount: "", unit: "weeks" };
-  return {
-    preset: CUSTOM_PRESET_VALUE,
-    amount: String(days / RETENTION_WEEK_DAYS),
-    unit: "weeks",
-  };
+  // Only enterprise/self-hosted has a custom field, and only for values that
+  // clear its floor and align to whole weeks. Anything else is grandfathered.
+  const customEligible =
+    isEnterprise &&
+    days >= ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS &&
+    days % RETENTION_WEEK_DAYS === 0;
+  if (customEligible) {
+    return {
+      preset: CUSTOM_PRESET_VALUE,
+      amount: String(days / RETENTION_WEEK_DAYS),
+      unit: "weeks",
+    };
+  }
+  return { preset: LEGACY_PRESET_VALUE, amount: "", unit: "weeks" };
 }
 
 export function AddOverrideDrawer({
@@ -70,6 +95,7 @@ export function AddOverrideDrawer({
   currentTeamId,
   currentProjectId,
   isPlatformAdmin,
+  isEnterprise,
   isSaving,
   onSave,
   editTarget,
@@ -85,6 +111,9 @@ export function AddOverrideDrawer({
   currentTeamId: string | undefined;
   currentProjectId: string;
   isPlatformAdmin: boolean;
+  /** True for enterprise (and self-hosted, which resolves to enterprise). Paid
+   *  non-enterprise orgs get the fixed short menu with no custom field. */
+  isEnterprise: boolean;
   isSaving: boolean;
   onSave: (params: {
     scopes: ScopeTriadEntry[];
@@ -95,45 +124,73 @@ export function AddOverrideDrawer({
    *  shown read-only, and the retention is prefilled. Absent = add mode. */
   editTarget?: RetentionEditTarget | null;
 }) {
+  // The retention menu is plan-gated: paid orgs get a fixed short pair, while
+  // enterprise/self-hosted get the full list plus a custom field.
+  const presets = useMemo(
+    () => retentionPresetsForTier(isEnterprise),
+    [isEnterprise],
+  );
+  const defaultPreset = presets[0]?.value ?? CUSTOM_PRESET_VALUE;
+
   const [scopes, setScopes] = useState<ScopeTriadEntry[]>([]);
-  const [preset, setPreset] = useState<string>(String(DEFAULT_RETENTION_DAYS));
+  const [preset, setPreset] = useState<string>(defaultPreset);
   const [customAmount, setCustomAmount] = useState<string>("");
   const [customUnit, setCustomUnit] = useState<RetentionUnit>("weeks");
-  const [applyToExisting, setApplyToExisting] = useState<boolean>(true);
+  // Default OFF: a new/edited policy applies to future ingestion only unless the
+  // user explicitly opts in. Applying to existing data triggers a ClickHouse
+  // ALTER … UPDATE rewrite across all of the scope's parts — an expensive,
+  // hard-to-undo operation — so it must be a deliberate choice, not the default.
+  const [applyToExisting, setApplyToExisting] = useState<boolean>(false);
 
-  // Platform admins get an extra "No retention (keep forever)" option. The 0
-  // sentinel is structurally valid input; the route authorizes it admin-only.
+  const isEditing = !!editTarget;
+
+  // When editing a policy whose stored value the current plan can't offer
+  // (a grandfathered paid value, or indefinite for a non-admin), surface it as
+  // a read-only legacy option so the user sees the truth and isn't forced to
+  // coerce it. Absent from Add mode — new policies only pick allowed values.
+  const legacyDays =
+    isEditing &&
+    editTarget &&
+    initialRetentionState({
+      days: editTarget.retentionDays,
+      presets,
+      isEnterprise,
+      isPlatformAdmin,
+    }).preset === LEGACY_PRESET_VALUE
+      ? editTarget.retentionDays
+      : null;
+
+  // Menu = [legacy?] + plan presets + [keep-forever (admin)] + [custom
+  // (enterprise/self-hosted only)]. Paid orgs get neither custom nor
+  // keep-forever, so their entire menu is the fixed short pair. Built by a pure
+  // helper (unit-tested) so the plan gating doesn't depend on rendering.
   const presetCollection = useMemo(
     () =>
       createListCollection({
-        items: [
-          ...RETENTION_PRESETS.map((p) => ({ value: p.value, label: p.label })),
-          ...(isPlatformAdmin
-            ? [
-                {
-                  value: INDEFINITE_PRESET_VALUE,
-                  label: "No retention (keep forever)",
-                },
-              ]
-            : []),
-          { value: CUSTOM_PRESET_VALUE, label: "Custom…" },
-        ],
+        items: buildRetentionMenuItems({
+          isEnterprise,
+          isPlatformAdmin,
+          legacyDays,
+        }),
       }),
-    [isPlatformAdmin],
+    [isEnterprise, isPlatformAdmin, legacyDays],
   );
-
-  const isEditing = !!editTarget;
 
   useEffect(() => {
     if (!open) return;
     if (editTarget) {
       // Edit mode: lock to the policy's scope and prefill its current value.
       setScopes([editTarget.scope]);
-      const init = initialRetentionState(editTarget.retentionDays);
+      const init = initialRetentionState({
+        days: editTarget.retentionDays,
+        presets,
+        isEnterprise,
+        isPlatformAdmin,
+      });
       setPreset(init.preset);
       setCustomAmount(init.amount);
       setCustomUnit(init.unit);
-      setApplyToExisting(true);
+      setApplyToExisting(false);
       return;
     }
     // Add mode: default to the current project so the picker opens on the
@@ -143,10 +200,10 @@ export function AddOverrideDrawer({
         ? [{ scopeType: "PROJECT", scopeId: currentProjectId }]
         : [],
     );
-    setPreset(String(DEFAULT_RETENTION_DAYS));
+    setPreset(defaultPreset);
     setCustomAmount("");
     setCustomUnit("weeks");
-    setApplyToExisting(true);
+    setApplyToExisting(false);
     // Initialize only when the drawer opens or the edit target changes — NOT on
     // currentProjectId / available.projects reference churn (a background
     // snapshot refetch would otherwise re-run this and wipe in-progress edits).
@@ -155,6 +212,9 @@ export function AddOverrideDrawer({
   }, [open, editTarget]);
 
   const resolvedDays = (() => {
+    // The legacy option is read-only: it can't be saved, only replaced by
+    // picking a real option, so it resolves to no valid value.
+    if (preset === LEGACY_PRESET_VALUE) return NaN;
     if (preset === CUSTOM_PRESET_VALUE) {
       const n = Number(customAmount);
       if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) return NaN;
@@ -167,9 +227,14 @@ export function AddOverrideDrawer({
     // Indefinite (0) is only reachable via the admin-only preset; the route
     // re-checks the capability, so the UI just needs to treat it as valid.
     resolvedDays === INDEFINITE_RETENTION_DAYS ||
-    (Number.isFinite(resolvedDays) &&
+    // Any curated preset (the plan menu) is a pre-vetted allowed value — no
+    // range check needed; that's the point of the fixed menu. Only the custom
+    // field (enterprise/self-hosted) needs the ≥49 floor + week alignment.
+    (preset !== CUSTOM_PRESET_VALUE && preset !== LEGACY_PRESET_VALUE) ||
+    (preset === CUSTOM_PRESET_VALUE &&
+      Number.isFinite(resolvedDays) &&
       Number.isInteger(resolvedDays) &&
-      resolvedDays >= MIN_RETENTION_DAYS &&
+      resolvedDays >= ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS &&
       resolvedDays <= MAX_RETENTION_DAYS &&
       resolvedDays % RETENTION_WEEK_DAYS === 0);
 
@@ -277,13 +342,19 @@ export function AddOverrideDrawer({
               <Field.HelperText>
                 {preset === INDEFINITE_PRESET_VALUE
                   ? "Data will be kept indefinitely — exempt from automatic deletion."
-                  : preset === CUSTOM_PRESET_VALUE && customAmount && daysValid
-                    ? `Stored as ${resolvedDays} days.`
+                  : preset === LEGACY_PRESET_VALUE
+                    ? "This length isn't available on your plan. Pick an option above to change it — leaving it keeps the current value."
                     : preset === CUSTOM_PRESET_VALUE &&
                         customAmount &&
-                        !daysValid
-                      ? `Must be between ${MIN_RETENTION_DAYS} and ${MAX_RETENTION_DAYS} days.`
-                      : `Minimum ${MIN_RETENTION_DAYS} days (7 weeks). Retention is partition-aligned and rounded to whole weeks under the hood.`}
+                        daysValid
+                      ? `Stored as ${resolvedDays} days.`
+                      : preset === CUSTOM_PRESET_VALUE &&
+                          customAmount &&
+                          !daysValid
+                        ? `Must be between ${ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS} and ${MAX_RETENTION_DAYS} days, in whole weeks.`
+                        : isEnterprise
+                          ? `Custom values start at ${ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS} days (7 weeks) and round to whole weeks.`
+                          : "Retention length is set by your plan."}
               </Field.HelperText>
             </Field.Root>
 

--- a/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
+++ b/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
@@ -204,12 +204,15 @@ export function AddOverrideDrawer({
     setCustomAmount("");
     setCustomUnit("weeks");
     setApplyToExisting(false);
-    // Initialize only when the drawer opens or the edit target changes — NOT on
-    // currentProjectId / available.projects reference churn (a background
-    // snapshot refetch would otherwise re-run this and wipe in-progress edits).
-    // The latest scope inputs are read inside, so the next open re-reads them.
+    // Initialize when the drawer opens, the edit target changes, or the plan
+    // tier resolves. `isEnterprise` starts false while `useActivePlan` loads and
+    // flips once when it settles; without it here, opening the drawer on a cold
+    // plan load would strand an enterprise value in the read-only "legacy" state
+    // (paid can't represent it). It's a stable boolean, so it re-inits at most
+    // once. Deliberately NOT keyed on currentProjectId / available.projects
+    // reference churn — a background snapshot refetch would wipe in-progress edits.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, editTarget]);
+  }, [open, editTarget, isEnterprise]);
 
   const resolvedDays = (() => {
     // The legacy option is read-only: it can't be saved, only replaced by

--- a/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
+++ b/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
@@ -73,11 +73,11 @@ function initialRetentionState({
   if (match) return { preset: match.value, amount: "", unit: "weeks" };
   // Only enterprise/self-hosted has a custom field, and only for values that
   // clear its floor and align to whole weeks. Anything else is grandfathered.
-  const customEligible =
+  const isCustomEligible =
     isEnterprise &&
     days >= ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS &&
     days % RETENTION_WEEK_DAYS === 0;
-  if (customEligible) {
+  if (isCustomEligible) {
     return {
       preset: CUSTOM_PRESET_VALUE,
       amount: String(days / RETENTION_WEEK_DAYS),
@@ -204,15 +204,17 @@ export function AddOverrideDrawer({
     setCustomAmount("");
     setCustomUnit("weeks");
     setApplyToExisting(false);
-    // Initialize when the drawer opens, the edit target changes, or the plan
-    // tier resolves. `isEnterprise` starts false while `useActivePlan` loads and
-    // flips once when it settles; without it here, opening the drawer on a cold
-    // plan load would strand an enterprise value in the read-only "legacy" state
-    // (paid can't represent it). It's a stable boolean, so it re-inits at most
-    // once. Deliberately NOT keyed on currentProjectId / available.projects
-    // reference churn — a background snapshot refetch would wipe in-progress edits.
+    // Initialize when the drawer opens, the edit target changes, or a plan/admin
+    // flag resolves. `isEnterprise` and `isPlatformAdmin` both start false while
+    // their queries load and flip once when they settle; without them here,
+    // opening the drawer on a cold load would strand a value the not-yet-loaded
+    // tier can't represent in the read-only "legacy" state (an enterprise value
+    // under paid, or a keep-forever value under non-admin). Both are stable
+    // booleans, so this re-inits at most once each. Deliberately NOT keyed on
+    // currentProjectId / available.projects reference churn — a background
+    // snapshot refetch would wipe in-progress edits.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, editTarget, isEnterprise]);
+  }, [open, editTarget, isEnterprise, isPlatformAdmin]);
 
   const resolvedDays = (() => {
     // The legacy option is read-only: it can't be saved, only replaced by

--- a/langwatch/src/components/data-retention/__tests__/AddOverrideDrawer.editMode.integration.test.tsx
+++ b/langwatch/src/components/data-retention/__tests__/AddOverrideDrawer.editMode.integration.test.tsx
@@ -46,6 +46,7 @@ function renderDrawer(
         currentTeamId={undefined}
         currentProjectId="proj-1"
         isPlatformAdmin={false}
+        isEnterprise={true}
         isSaving={false}
         onSave={() => {}}
         {...props}

--- a/langwatch/src/components/data-retention/__tests__/AddOverrideDrawer.planGating.integration.test.tsx
+++ b/langwatch/src/components/data-retention/__tests__/AddOverrideDrawer.planGating.integration.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/components/settings/ScopeChipPicker", () => ({
+  ScopeChipPicker: () => <div data-testid="scope-chip-picker" />,
+}));
+
+import {
+  AddOverrideDrawer,
+  type RetentionEditTarget,
+} from "../AddOverrideDrawer";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const available = {
+  organization: { id: "org-1", name: "Acme" },
+  teams: [],
+  projects: [{ id: "proj-1", name: "Web App", teamId: "team-1" }],
+};
+
+function renderDrawer(
+  props: Partial<React.ComponentProps<typeof AddOverrideDrawer>>,
+) {
+  return render(
+    <Wrapper>
+      <AddOverrideDrawer
+        open
+        onClose={() => {}}
+        available={available}
+        currentOrganizationId="org-1"
+        currentTeamId={undefined}
+        currentProjectId="proj-1"
+        isPlatformAdmin={false}
+        isEnterprise={false}
+        isSaving={false}
+        onSave={() => {}}
+        {...props}
+      />
+    </Wrapper>,
+  );
+}
+
+// Menu-content gating is covered exhaustively by the pure buildRetentionMenuItems
+// unit test; these cases lock the drawer-level behaviors that only exist once
+// rendered (default switch state, grandfather Save-guard).
+describe("AddOverrideDrawer plan-gated behavior", () => {
+  afterEach(cleanup);
+
+  describe("the apply-to-existing toggle", () => {
+    it("defaults OFF, so saving a new policy never triggers a rewrite unasked", () => {
+      const onSave = vi.fn();
+      // Add mode defaults the scope to the current project and the retention to
+      // the first plan preset, so Create is enabled without further input.
+      renderDrawer({ isEnterprise: true, onSave });
+
+      fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+      expect(onSave).toHaveBeenCalledTimes(1);
+      expect(onSave.mock.calls[0]?.[0]).toMatchObject({
+        applyToExisting: false,
+      });
+    });
+  });
+
+  describe("when a paid org edits a grandfathered out-of-menu value", () => {
+    const legacyTarget: RetentionEditTarget = {
+      scope: { scopeType: "ORGANIZATION", scopeId: "org-1" },
+      scopeName: "Acme",
+      retentionDays: 371, // enterprise-only value, not on the paid menu
+    };
+
+    it("surfaces it as read-only 'current (legacy)' and disables Save until changed", () => {
+      renderDrawer({ isEnterprise: false, editTarget: legacyTarget });
+      // The label shows in both the selected-value readout and the option list,
+      // so assert at least one occurrence rather than a unique match.
+      expect(
+        screen.getAllByText("Current: 371 days (legacy)").length,
+      ).toBeGreaterThan(0);
+      // Grandfathering: never coerce or silently shorten — Save stays disabled
+      // while the read-only legacy value is selected.
+      const save = screen.getByRole("button", {
+        name: "Save changes",
+      }) as HTMLButtonElement;
+      expect(save.disabled).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/components/data-retention/__tests__/retentionMenu.unit.test.ts
+++ b/langwatch/src/components/data-retention/__tests__/retentionMenu.unit.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRetentionMenuItems,
+  CUSTOM_PRESET_VALUE,
+  INDEFINITE_PRESET_VALUE,
+  LEGACY_PRESET_VALUE,
+} from "../constants";
+
+const labels = (items: { label: string }[]) => items.map((i) => i.label);
+const values = (items: { value: string }[]) => items.map((i) => i.value);
+
+describe("buildRetentionMenuItems", () => {
+  describe("given a paid (non-enterprise) org", () => {
+    const items = buildRetentionMenuItems({
+      isEnterprise: false,
+      isPlatformAdmin: false,
+      legacyDays: null,
+    });
+
+    it("offers exactly the two fixed presets, in order", () => {
+      expect(labels(items)).toEqual(["1 month", "2 months"]);
+    });
+
+    it("offers no custom option", () => {
+      expect(values(items)).not.toContain(CUSTOM_PRESET_VALUE);
+    });
+
+    it("offers no keep-forever option", () => {
+      expect(values(items)).not.toContain(INDEFINITE_PRESET_VALUE);
+    });
+  });
+
+  describe("given an enterprise org", () => {
+    const items = buildRetentionMenuItems({
+      isEnterprise: true,
+      isPlatformAdmin: false,
+      legacyDays: null,
+    });
+
+    it("offers the full preset list plus custom", () => {
+      expect(labels(items)).toEqual([
+        "1 month",
+        "2 months",
+        "3 months",
+        "1 year",
+        "5 years",
+        "Custom…",
+      ]);
+    });
+
+    it("does not offer keep-forever to a non-admin", () => {
+      expect(values(items)).not.toContain(INDEFINITE_PRESET_VALUE);
+    });
+  });
+
+  describe("given a platform admin", () => {
+    it("adds keep-forever before the custom option", () => {
+      const items = buildRetentionMenuItems({
+        isEnterprise: true,
+        isPlatformAdmin: true,
+        legacyDays: null,
+      });
+      expect(values(items)).toContain(INDEFINITE_PRESET_VALUE);
+      // Custom stays last so keep-forever doesn't hide beneath it.
+      expect(values(items).at(-1)).toBe(CUSTOM_PRESET_VALUE);
+    });
+  });
+
+  describe("given a grandfathered out-of-menu value being edited", () => {
+    it("prepends a read-only 'current (legacy)' entry showing the stored days", () => {
+      const items = buildRetentionMenuItems({
+        isEnterprise: false,
+        isPlatformAdmin: false,
+        legacyDays: 371,
+      });
+      expect(items[0]).toEqual({
+        value: LEGACY_PRESET_VALUE,
+        label: "Current: 371 days (legacy)",
+      });
+      // The real plan options still follow.
+      expect(labels(items).slice(1)).toEqual(["1 month", "2 months"]);
+    });
+
+    it("labels an indefinite legacy value as keep-forever", () => {
+      const items = buildRetentionMenuItems({
+        isEnterprise: false,
+        isPlatformAdmin: false,
+        legacyDays: 0,
+      });
+      expect(items[0]?.label).toBe("Current: keep forever (legacy)");
+    });
+  });
+});

--- a/langwatch/src/components/data-retention/constants.ts
+++ b/langwatch/src/components/data-retention/constants.ts
@@ -39,21 +39,94 @@ export const retentionUnitCollection = createListCollection({
   })),
 });
 
+export type RetentionPreset = { value: string; label: string; days: number };
+
 // Presets round UP relative to the human label so the selection covers the
-// full period plus a small buffer (e.g. "1 year" = 371d, not 364d). Avoids
-// underselling: a user who picks "1 year" expects at least a full year.
-export const RETENTION_PRESETS: Array<{
-  value: string;
-  label: string;
-  days: number;
-}> = [
-  { value: "49", label: "7 weeks", days: 49 },
+// full period plus a small buffer (e.g. "1 year" = 371d ≈ 53wk, "1 month" =
+// 35d = 5wk). Avoids underselling: a user who picks "1 year" expects at least a
+// full year, and "1 month" covers a month plus a recovery buffer.
+//
+// Which list a customer sees is plan-gated (see the plan-gated-menu ADR):
+//   - PAID (non-enterprise SaaS): the fixed pair {35, 63}, no custom.
+//   - ENTERPRISE / self-hosted:   the full list below + a custom field (≥49d).
+// The server re-enforces this at the mutation boundary
+// (`assertRetentionValueAllowedForPlan`); these lists only shape the UI.
+
+/** Paid (non-enterprise) menu: "~1 month" / "~2 months" only. */
+export const PAID_RETENTION_PRESETS: RetentionPreset[] = [
+  { value: "35", label: "1 month", days: 35 },
+  { value: "63", label: "2 months", days: 63 },
+];
+
+/** Enterprise / self-hosted menu: the paid short options plus longer windows. */
+export const ENTERPRISE_RETENTION_PRESETS: RetentionPreset[] = [
+  { value: "35", label: "1 month", days: 35 },
+  { value: "63", label: "2 months", days: 63 },
   { value: "91", label: "3 months", days: 91 },
-  { value: "182", label: "6 months", days: 182 },
   { value: "371", label: "1 year", days: 371 },
-  { value: "735", label: "2 years", days: 735 },
   { value: "1827", label: "5 years", days: 1827 },
 ];
+
+/** The preset list a plan tier may pick from. Enterprise (and self-hosted,
+ *  which resolves to enterprise) additionally gets a custom field. */
+export function retentionPresetsForTier(
+  isEnterprise: boolean,
+): RetentionPreset[] {
+  return isEnterprise ? ENTERPRISE_RETENTION_PRESETS : PAID_RETENTION_PRESETS;
+}
+
+/** Select value for a grandfathered policy whose stored retention isn't offered
+ *  on the org's current plan. Rendered read-only so editing never silently
+ *  coerces (or shortens → deletes) an out-of-menu value. */
+export const LEGACY_PRESET_VALUE = "legacy";
+
+/** Human label for the read-only legacy option. */
+export function legacyLabel(days: number): string {
+  return days === INDEFINITE_RETENTION_DAYS
+    ? "Current: keep forever (legacy)"
+    : `Current: ${days} days (legacy)`;
+}
+
+export type RetentionMenuItem = { value: string; label: string };
+
+/**
+ * The exact option list the retention drawer shows, in order. Plan-gated:
+ *   - legacy entry first, only when editing an out-of-menu stored value;
+ *   - the tier's presets (paid → {35,63}; enterprise → full list);
+ *   - keep-forever, platform admins only;
+ *   - Custom…, enterprise / self-hosted only.
+ * Pure so the gating is unit-testable without rendering the drawer. The server
+ * (`assertRetentionValueAllowedForPlan`) is the real enforcement; this only
+ * shapes the UI.
+ */
+export function buildRetentionMenuItems({
+  isEnterprise,
+  isPlatformAdmin,
+  legacyDays,
+}: {
+  isEnterprise: boolean;
+  isPlatformAdmin: boolean;
+  legacyDays: number | null;
+}): RetentionMenuItem[] {
+  return [
+    ...(legacyDays !== null
+      ? [{ value: LEGACY_PRESET_VALUE, label: legacyLabel(legacyDays) }]
+      : []),
+    ...retentionPresetsForTier(isEnterprise).map((p) => ({
+      value: p.value,
+      label: p.label,
+    })),
+    ...(isPlatformAdmin
+      ? [
+          {
+            value: INDEFINITE_PRESET_VALUE,
+            label: "No retention (keep forever)",
+          },
+        ]
+      : []),
+    ...(isEnterprise ? [{ value: CUSTOM_PRESET_VALUE, label: "Custom…" }] : []),
+  ];
+}
 
 export const CUSTOM_PRESET_VALUE = "custom";
 

--- a/langwatch/src/components/data-retention/constants.ts
+++ b/langwatch/src/components/data-retention/constants.ts
@@ -50,7 +50,7 @@ export type RetentionPreset = { value: string; label: string; days: number };
 //   - PAID (non-enterprise SaaS): the fixed pair {35, 63}, no custom.
 //   - ENTERPRISE / self-hosted:   the full list below + a custom field (≥49d).
 // The server re-enforces this at the mutation boundary
-// (`assertRetentionValueAllowedForPlan`); these lists only shape the UI.
+// (`assertPlanAllowsRetentionValue`); these lists only shape the UI.
 
 /** Paid (non-enterprise) menu: "~1 month" / "~2 months" only. */
 export const PAID_RETENTION_PRESETS: RetentionPreset[] = [
@@ -96,7 +96,7 @@ export type RetentionMenuItem = { value: string; label: string };
  *   - keep-forever, platform admins only;
  *   - Custom…, enterprise / self-hosted only.
  * Pure so the gating is unit-testable without rendering the drawer. The server
- * (`assertRetentionValueAllowedForPlan`) is the real enforcement; this only
+ * (`assertPlanAllowsRetentionValue`) is the real enforcement; this only
  * shapes the UI.
  */
 export function buildRetentionMenuItems({

--- a/langwatch/src/pages/settings/data-retention.tsx
+++ b/langwatch/src/pages/settings/data-retention.tsx
@@ -43,6 +43,7 @@ import { ScopeFilter as ScopeFilterComponent } from "~/components/settings/Scope
 import { Menu } from "~/components/ui/menu";
 import { toaster } from "~/components/ui/toaster";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
+import { useActivePlan } from "~/hooks/useActivePlan";
 import { useAvailableScopes } from "~/hooks/useAvailableScopes";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useUrlScopeFilter } from "~/hooks/useUrlScopeFilter";
@@ -153,6 +154,9 @@ function DataRetentionPage({
   // disable retention; the route enforces this independently. We use it solely
   // to decide whether to surface the "No retention" option in the drawer.
   const isPlatformAdmin = api.user.isAdmin.useQuery({}).data?.isAdmin ?? false;
+  // Enterprise (and self-hosted, which resolves to enterprise) gets the full
+  // retention menu + custom; paid non-enterprise gets the fixed short pair.
+  const { isEnterprise } = useActivePlan();
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   // When set, the Add drawer opens in edit mode locked to this scope's policy.
@@ -507,6 +511,7 @@ function DataRetentionPage({
             currentTeamId={teamId}
             currentProjectId={projectId}
             isPlatformAdmin={isPlatformAdmin}
+            isEnterprise={isEnterprise}
             isSaving={setForScope.isLoading || triggerUpdate.isLoading}
             onSave={async ({ scopes, retentionDays, applyToExisting }) => {
               const categories: RetentionCategory[] = [...RETENTION_CATEGORIES];

--- a/langwatch/src/pages/settings/data-retention.tsx
+++ b/langwatch/src/pages/settings/data-retention.tsx
@@ -48,7 +48,7 @@ import { useAvailableScopes } from "~/hooks/useAvailableScopes";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useUrlScopeFilter } from "~/hooks/useUrlScopeFilter";
 import {
-  DEFAULT_RETENTION_DAYS,
+  PLATFORM_DEFAULT_RETENTION_DAYS,
   RETENTION_CATEGORIES,
   type RetentionCategory,
 } from "~/server/data-retention/retentionPolicy.schema";
@@ -396,7 +396,7 @@ function DataRetentionPage({
                       <EmptyState.Title>No retention policies</EmptyState.Title>
                       <EmptyState.Description>
                         Add a retention policy to override the platform default
-                        of {DEFAULT_RETENTION_DAYS} days.
+                        of {PLATFORM_DEFAULT_RETENTION_DAYS} days.
                       </EmptyState.Description>
                     </VStack>
                     {canWrite && (

--- a/langwatch/src/server/api/routers/dataRetention.ts
+++ b/langwatch/src/server/api/routers/dataRetention.ts
@@ -9,6 +9,7 @@ import {
   assertCanWriteRetentionScope,
   assertRetentionPlan,
   assertRetentionPlanForScope,
+  assertRetentionValueAllowedForPlan,
 } from "~/server/data-retention/policy/dataRetentionPolicy.authz";
 import { getRetentionPolicySnapshot } from "~/server/data-retention/policy/dataRetentionPolicy.read";
 import { ScopeTargetNotFoundError } from "~/server/data-retention/policy/dataRetentionPolicy.service";
@@ -92,6 +93,15 @@ export const dataRetentionRouter = createTRPCRouter({
       await assertRetentionPlanForScope(
         { prisma: ctx.prisma, session: ctx.session },
         input.scope,
+      );
+      // Value-gate: paid plans may persist only their fixed presets; enterprise/
+      // self-hosted keep the full range + custom (≥49). No-ops on the indefinite
+      // sentinel so the platform-admin check below still runs. This is the
+      // write-path prevention — the UI menu is a mirror, not the enforcement.
+      await assertRetentionValueAllowedForPlan(
+        { prisma: ctx.prisma, session: ctx.session },
+        input.scope,
+        input.retentionDays,
       );
       // Disabling retention (indefinite/keep-forever) is platform-admin only.
       // The schema accepts the 0 sentinel structurally; this is where the

--- a/langwatch/src/server/api/routers/dataRetention.ts
+++ b/langwatch/src/server/api/routers/dataRetention.ts
@@ -9,7 +9,7 @@ import {
   assertCanWriteRetentionScope,
   assertRetentionPlan,
   assertRetentionPlanForScope,
-  assertRetentionValueAllowedForPlan,
+  assertRetentionWriteAllowed,
 } from "~/server/data-retention/policy/dataRetentionPolicy.authz";
 import { getRetentionPolicySnapshot } from "~/server/data-retention/policy/dataRetentionPolicy.read";
 import { ScopeTargetNotFoundError } from "~/server/data-retention/policy/dataRetentionPolicy.service";
@@ -89,16 +89,13 @@ export const dataRetentionRouter = createTRPCRouter({
         input.scope,
       );
       // Plan-gate against the scope's owning org, not the caller-supplied
-      // projectId. The two can belong to different organizations.
-      await assertRetentionPlanForScope(
-        { prisma: ctx.prisma, session: ctx.session },
-        input.scope,
-      );
-      // Value-gate: paid plans may persist only their fixed presets; enterprise/
-      // self-hosted keep the full range + custom (≥49). No-ops on the indefinite
-      // sentinel so the platform-admin check below still runs. This is the
-      // write-path prevention — the UI menu is a mirror, not the enforcement.
-      await assertRetentionValueAllowedForPlan(
+      // projectId (the two can belong to different orgs). Resolves the org +
+      // plan once, then applies the free gate AND the value gate: paid plans
+      // may persist only their fixed presets; enterprise/self-hosted keep the
+      // full range + custom (≥49). No-ops on the indefinite sentinel so the
+      // platform-admin check below still runs. The write-path prevention — the
+      // UI menu is a mirror, not the enforcement.
+      await assertRetentionWriteAllowed(
         { prisma: ctx.prisma, session: ctx.session },
         input.scope,
         input.retentionDays,

--- a/langwatch/src/server/data-retention/__tests__/retentionPolicy.schema.unit.test.ts
+++ b/langwatch/src/server/data-retention/__tests__/retentionPolicy.schema.unit.test.ts
@@ -65,6 +65,25 @@ describe("retentionDaysSchema", () => {
     });
   });
 
+  describe("when the value is below the enterprise floor but not a paid preset", () => {
+    // Defense-in-depth: the absolute floor is 35 (paid's short option), but the
+    // ONLY sub-49 value the schema accepts is a fixed paid preset. An arbitrary
+    // 7-aligned value between 35 and 49 (e.g. 42) must not slip through the type
+    // boundary even if a caller skips the plan gate.
+    it("rejects 42 (7-aligned, ≥ floor, but not a paid preset)", () => {
+      expect(retentionDaysSchema.safeParse(42).success).toBe(false);
+    });
+
+    it("still accepts the paid short preset 35", () => {
+      expect(retentionDaysSchema.safeParse(35).success).toBe(true);
+    });
+
+    it("accepts any whole-week value at or above the enterprise floor", () => {
+      expect(retentionDaysSchema.safeParse(49).success).toBe(true);
+      expect(retentionDaysSchema.safeParse(63).success).toBe(true);
+    });
+  });
+
   describe("when the value is not an integer", () => {
     it("rejects it", () => {
       expect(retentionDaysSchema.safeParse(49.5).success).toBe(false);

--- a/langwatch/src/server/data-retention/__tests__/retentionPolicy.schema.unit.test.ts
+++ b/langwatch/src/server/data-retention/__tests__/retentionPolicy.schema.unit.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS,
   INDEFINITE_RETENTION_DAYS,
   MAX_RETENTION_DAYS,
   MIN_RETENTION_DAYS,
+  PAID_RETENTION_PRESET_DAYS,
   PLATFORM_DEFAULT_RETENTION_DAYS,
   RETENTION_WEEK_DAYS,
   retentionDaysInputSchema,
@@ -11,7 +13,8 @@ import {
 
 describe("retentionDaysSchema", () => {
   describe("given a whole-week value within the allowed range", () => {
-    it("accepts the minimum (7 weeks)", () => {
+    it("accepts the absolute minimum (35 days / 5 weeks, the paid floor)", () => {
+      expect(MIN_RETENTION_DAYS).toBe(35);
       expect(retentionDaysSchema.safeParse(MIN_RETENTION_DAYS).success).toBe(
         true,
       );
@@ -102,6 +105,34 @@ describe("retentionDaysInputSchema", () => {
     it("still rejects a value that isn't a whole number of weeks", () => {
       expect(retentionDaysInputSchema.safeParse(50).success).toBe(false);
     });
+  });
+});
+
+describe("plan-tier retention constants", () => {
+  // The paid menu sits below the 49-day recovery floor free/enterprise keep, so
+  // the absolute schema floor had to drop to 35 (the gate re-enforces 49 for
+  // non-paid custom values). Guard the ordering so the two floors don't drift.
+  it("keeps the absolute floor below the enterprise custom floor", () => {
+    expect(MIN_RETENTION_DAYS).toBeLessThan(
+      ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS,
+    );
+    expect(ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS).toBe(49);
+  });
+
+  it("has both paid presets whole-week aligned and persistable by the schema", () => {
+    expect(PAID_RETENTION_PRESET_DAYS).toEqual([35, 63]);
+    for (const days of PAID_RETENTION_PRESET_DAYS) {
+      expect(days % RETENTION_WEEK_DAYS).toBe(0);
+      expect(retentionDaysSchema.safeParse(days).success).toBe(true);
+    }
+  });
+
+  it("keeps the shorter paid preset below the enterprise custom floor", () => {
+    // This is the whole point of dropping the schema floor: 35 must be a legal
+    // stored value even though it is under the 49-day recovery floor.
+    expect(PAID_RETENTION_PRESET_DAYS[0]).toBeLessThan(
+      ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS,
+    );
   });
 });
 

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.read.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.read.unit.test.ts
@@ -72,6 +72,28 @@ describe("resolveScopeStorageUsage", () => {
       ]);
       expect(result).toEqual({ totalBytes: 200, projectCount: 2 });
     });
+
+    it("excludes archived projects from the enumeration", async () => {
+      prisma.project.findMany.mockResolvedValue([]);
+      rbacMocks.batchScopePermissions.mockResolvedValue({
+        teams: new Map(),
+        projects: new Map(),
+      });
+
+      await resolveScopeStorageUsage(ctx, {
+        projectId: "proj_a",
+        scope: { scopeType: "ORGANIZATION", scopeId: "org_1" },
+      });
+
+      // The projectCount the storage card shows must match what the user sees
+      // in the nav — archived projects are filtered out at the query, so they
+      // never inflate the count.
+      const where = prisma.project.findMany.mock.calls[0]![0].where;
+      expect(where).toEqual({
+        team: { organizationId: "org_1" },
+        archivedAt: null,
+      });
+    });
   });
 
   describe("given a team scope", () => {
@@ -97,6 +119,8 @@ describe("resolveScopeStorageUsage", () => {
       expect(where).toEqual({
         teamId: "team_b",
         team: { organizationId: "org_1" },
+        // Archived projects are excluded — they're hidden everywhere else.
+        archivedAt: null,
       });
       expect(result).toEqual({ totalBytes: 200, projectCount: 2 });
     });

--- a/langwatch/src/server/data-retention/metering/storageMeter.read.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.read.ts
@@ -53,12 +53,15 @@ export async function resolveScopeStorageUsage(
 
   // Enumerate candidate projects within the caller's org for the chosen scope.
   // The org constraint is what makes a foreign scopeId resolve to nothing.
+  // `archivedAt: null` excludes archived projects — they're hidden from the nav
+  // and every other project listing, so counting them here would inflate the
+  // "N projects" the storage card reports beyond what the user can actually see.
   const where =
     scope.scopeType === "PROJECT"
-      ? { id: scope.scopeId, team: { organizationId } }
+      ? { id: scope.scopeId, team: { organizationId }, archivedAt: null }
       : scope.scopeType === "TEAM"
-        ? { teamId: scope.scopeId, team: { organizationId } }
-        : { team: { organizationId } };
+        ? { teamId: scope.scopeId, team: { organizationId }, archivedAt: null }
+        : { team: { organizationId }, archivedAt: null };
 
   const candidates = await ctx.prisma.project.findMany({
     where,

--- a/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.read.unit.test.ts
+++ b/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.read.unit.test.ts
@@ -190,5 +190,35 @@ describe("getRetentionPolicySnapshot — scope visibility", () => {
         "project_a",
       ]);
     });
+
+    it("omits an archived project from `available` even when writable", async () => {
+      // A writable but archived project must not be offered as a scope to
+      // attach a new retention policy — it's hidden from the nav everywhere.
+      prisma.project.findMany.mockResolvedValueOnce([
+        { id: "project_a", name: "Project A", teamId: "team_a" },
+        {
+          id: "project_arch",
+          name: "Archived",
+          teamId: "team_a",
+          archivedAt: new Date("2026-01-01"),
+        },
+      ]);
+      rbacMocks.batchScopePermissions.mockResolvedValueOnce({
+        teams: new Map(),
+        projects: new Map([
+          ["project_a", true],
+          ["project_arch", true],
+        ]),
+      });
+
+      const snapshot = await getRetentionPolicySnapshot(
+        { prisma, session },
+        { projectId: "project_a" },
+      );
+
+      expect(snapshot.available.projects.map((p) => p.id)).toEqual([
+        "project_a",
+      ]);
+    });
   });
 });

--- a/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.valueGate.unit.test.ts
+++ b/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.valueGate.unit.test.ts
@@ -90,7 +90,7 @@ describe("assertRetentionValueAllowedForPlan", () => {
 
     it.each([
       35, 63, 91, 371, 1827,
-    ])("allows the enterprise preset %id", async (days) => {
+    ])("allows the enterprise preset of %i days", async (days) => {
       await expect(
         assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, days),
       ).resolves.toBeUndefined();

--- a/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.valueGate.unit.test.ts
+++ b/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.valueGate.unit.test.ts
@@ -1,3 +1,4 @@
+import type { PlanInfo } from "@ee/licensing/planInfo";
 import { TRPCError } from "@trpc/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,140 +18,138 @@ vi.mock("~/server/app-layer/app", () => ({
   }),
 }));
 
-import { assertRetentionValueAllowedForPlan } from "../dataRetentionPolicy.authz";
+import {
+  assertPlanAllowsRetentionValue,
+  assertRetentionWriteAllowed,
+} from "../dataRetentionPolicy.authz";
 
-const ORG_SCOPE = { scopeType: "ORGANIZATION" as const, scopeId: "org_1" };
+const paidPlan = { free: false, type: "GROWTH_SEAT_EUR_MONTHLY" } as PlanInfo;
+const enterprisePlan = { free: false, type: "ENTERPRISE" } as PlanInfo;
+const freePlan = { free: true, type: "FREE" } as PlanInfo;
 
-/** ctx whose prisma resolves the org scope to org_1 (so the gate reaches the
- *  plan lookup). Session carries a user for the plan-provider call. */
-function makeCtx() {
-  return {
-    session: { user: { id: "user_1" } },
-    prisma: {
-      organization: { findUnique: vi.fn().mockResolvedValue({ id: "org_1" }) },
-    },
-  } as any;
-}
+const expectForbidden = (fn: () => void) => {
+  expect(fn).toThrow(TRPCError);
+  expect(fn).toThrow(expect.objectContaining({ code: "FORBIDDEN" }));
+};
 
-function mockPlan(plan: { free: boolean; type: string }) {
-  planMocks.getActivePlan.mockResolvedValue(plan);
-}
-
-async function expectForbidden(promise: Promise<unknown>) {
-  await expect(promise).rejects.toBeInstanceOf(TRPCError);
-  await expect(promise).rejects.toMatchObject({ code: "FORBIDDEN" });
-}
-
-describe("assertRetentionValueAllowedForPlan", () => {
+describe("assertPlanAllowsRetentionValue", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     envMock.IS_SAAS = true;
   });
 
-  describe("given a paid (non-enterprise) SaaS org", () => {
-    beforeEach(() => {
-      mockPlan({ free: false, type: "GROWTH_SEAT_EUR_MONTHLY" });
+  describe("given a paid (non-enterprise) SaaS plan", () => {
+    it.each([35, 63])("allows the fixed preset of %i days", (days) => {
+      expect(() =>
+        assertPlanAllowsRetentionValue(paidPlan, days),
+      ).not.toThrow();
     });
 
-    it("allows the fixed 1-month preset (35d)", async () => {
-      await expect(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 35),
-      ).resolves.toBeUndefined();
+    it("rejects an arbitrary off-menu value (e.g. 364d)", () => {
+      expectForbidden(() => assertPlanAllowsRetentionValue(paidPlan, 364));
     });
 
-    it("allows the fixed 2-month preset (63d)", async () => {
-      await expect(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 63),
-      ).resolves.toBeUndefined();
+    it("rejects an enterprise preset like 1 year (371d)", () => {
+      expectForbidden(() => assertPlanAllowsRetentionValue(paidPlan, 371));
     });
 
-    it("rejects an arbitrary off-menu value (e.g. 364d)", async () => {
-      await expectForbidden(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 364),
-      );
-    });
-
-    it("rejects an enterprise preset like 1 year (371d)", async () => {
-      await expectForbidden(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 371),
-      );
-    });
-
-    it("no-ops on the indefinite sentinel so the admin gate runs downstream", async () => {
-      await expect(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 0),
-      ).resolves.toBeUndefined();
+    it("no-ops on the indefinite sentinel so the admin gate runs downstream", () => {
+      expect(() => assertPlanAllowsRetentionValue(paidPlan, 0)).not.toThrow();
     });
   });
 
-  describe("given an enterprise SaaS org", () => {
-    beforeEach(() => {
-      mockPlan({ free: false, type: "ENTERPRISE" });
-    });
-
+  describe("given an enterprise SaaS plan", () => {
     it.each([
       35, 63, 91, 371, 1827,
-    ])("allows the enterprise preset of %i days", async (days) => {
-      await expect(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, days),
-      ).resolves.toBeUndefined();
+    ])("allows the enterprise preset of %i days", (days) => {
+      expect(() =>
+        assertPlanAllowsRetentionValue(enterprisePlan, days),
+      ).not.toThrow();
     });
 
-    it("allows a custom value at or above the 49d floor", async () => {
-      await expect(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 56),
-      ).resolves.toBeUndefined();
+    it("allows a custom value at or above the 49d floor", () => {
+      expect(() =>
+        assertPlanAllowsRetentionValue(enterprisePlan, 56),
+      ).not.toThrow();
     });
 
-    it("rejects a custom value below the 49d floor that isn't a paid preset", async () => {
+    it("rejects a custom value below the 49d floor that isn't a paid preset", () => {
       // 42d is 7-aligned but below the enterprise floor and not 35/63.
-      await expectForbidden(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 42),
-      );
+      expectForbidden(() => assertPlanAllowsRetentionValue(enterprisePlan, 42));
     });
   });
 
   describe("given a self-hosted deployment (IS_SAAS unset)", () => {
     beforeEach(() => {
       envMock.IS_SAAS = undefined;
-      // A self-hosted plan may report any type; the gate must not cap it.
-      mockPlan({ free: false, type: "GROWTH_SEAT_EUR_MONTHLY" });
     });
 
-    it("allows a long custom window (2 years)", async () => {
-      await expect(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 735),
-      ).resolves.toBeUndefined();
+    it("allows a long custom window (2 years) even on a non-enterprise plan type", () => {
+      expect(() => assertPlanAllowsRetentionValue(paidPlan, 735)).not.toThrow();
     });
 
-    it("still enforces the 49d floor for sub-floor non-preset values", async () => {
-      await expectForbidden(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 42),
-      );
+    it("still enforces the 49d floor for sub-floor non-preset values", () => {
+      expectForbidden(() => assertPlanAllowsRetentionValue(paidPlan, 42));
     });
   });
 
-  describe("given a free org (blocked upstream by the free gate)", () => {
-    it("does not additionally reject on the value rule", async () => {
-      mockPlan({ free: true, type: "FREE" });
-      await expect(
-        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 371),
-      ).resolves.toBeUndefined();
+  describe("given a free plan (blocked upstream by the free gate)", () => {
+    it("does not additionally reject on the value rule", () => {
+      expect(() => assertPlanAllowsRetentionValue(freePlan, 371)).not.toThrow();
     });
   });
+});
 
-  describe("given a scope that resolves to no organization", () => {
-    it("throws NOT_FOUND before consulting the plan", async () => {
-      const ctx = {
-        session: { user: { id: "user_1" } },
-        prisma: {
-          organization: { findUnique: vi.fn().mockResolvedValue(null) },
+describe("assertRetentionWriteAllowed", () => {
+  const ORG_SCOPE = { scopeType: "ORGANIZATION" as const, scopeId: "org_1" };
+
+  function makeCtx() {
+    return {
+      session: { user: { id: "user_1" } },
+      prisma: {
+        organization: {
+          findUnique: vi.fn().mockResolvedValue({ id: "org_1" }),
         },
-      } as any;
-      await expect(
-        assertRetentionValueAllowedForPlan(ctx, ORG_SCOPE, 35),
-      ).rejects.toMatchObject({ code: "NOT_FOUND" });
-      expect(planMocks.getActivePlan).not.toHaveBeenCalled();
-    });
+      },
+    } as any;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envMock.IS_SAAS = true;
+  });
+
+  it("resolves the org and plan exactly once for the whole gate", async () => {
+    planMocks.getActivePlan.mockResolvedValue(paidPlan);
+    const ctx = makeCtx();
+    await assertRetentionWriteAllowed(ctx, ORG_SCOPE, 35);
+    expect(ctx.prisma.organization.findUnique).toHaveBeenCalledTimes(1);
+    expect(planMocks.getActivePlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a paid org's off-menu value end-to-end", async () => {
+    planMocks.getActivePlan.mockResolvedValue(paidPlan);
+    await expect(
+      assertRetentionWriteAllowed(makeCtx(), ORG_SCOPE, 371),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("blocks a free org via the free gate before the value rule", async () => {
+    planMocks.getActivePlan.mockResolvedValue(freePlan);
+    await expect(
+      assertRetentionWriteAllowed(makeCtx(), ORG_SCOPE, 35),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("throws NOT_FOUND when the scope resolves to no organization", async () => {
+    const ctx = {
+      session: { user: { id: "user_1" } },
+      prisma: {
+        organization: { findUnique: vi.fn().mockResolvedValue(null) },
+      },
+    } as any;
+    await expect(
+      assertRetentionWriteAllowed(ctx, ORG_SCOPE, 35),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(planMocks.getActivePlan).not.toHaveBeenCalled();
   });
 });

--- a/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.valueGate.unit.test.ts
+++ b/langwatch/src/server/data-retention/policy/__tests__/dataRetentionPolicy.valueGate.unit.test.ts
@@ -1,0 +1,156 @@
+import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// env.IS_SAAS decides whether the value gate caps at all: self-hosted (!IS_SAAS)
+// resolves to enterprise and is never capped. Mutable so each test picks a tier.
+const envMock = vi.hoisted(() => ({
+  IS_SAAS: true as boolean | undefined,
+}));
+vi.mock("~/env.mjs", () => ({ env: envMock }));
+
+const planMocks = vi.hoisted(() => ({
+  getActivePlan: vi.fn(),
+}));
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({
+    planProvider: { getActivePlan: planMocks.getActivePlan },
+  }),
+}));
+
+import { assertRetentionValueAllowedForPlan } from "../dataRetentionPolicy.authz";
+
+const ORG_SCOPE = { scopeType: "ORGANIZATION" as const, scopeId: "org_1" };
+
+/** ctx whose prisma resolves the org scope to org_1 (so the gate reaches the
+ *  plan lookup). Session carries a user for the plan-provider call. */
+function makeCtx() {
+  return {
+    session: { user: { id: "user_1" } },
+    prisma: {
+      organization: { findUnique: vi.fn().mockResolvedValue({ id: "org_1" }) },
+    },
+  } as any;
+}
+
+function mockPlan(plan: { free: boolean; type: string }) {
+  planMocks.getActivePlan.mockResolvedValue(plan);
+}
+
+async function expectForbidden(promise: Promise<unknown>) {
+  await expect(promise).rejects.toBeInstanceOf(TRPCError);
+  await expect(promise).rejects.toMatchObject({ code: "FORBIDDEN" });
+}
+
+describe("assertRetentionValueAllowedForPlan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envMock.IS_SAAS = true;
+  });
+
+  describe("given a paid (non-enterprise) SaaS org", () => {
+    beforeEach(() => {
+      mockPlan({ free: false, type: "GROWTH_SEAT_EUR_MONTHLY" });
+    });
+
+    it("allows the fixed 1-month preset (35d)", async () => {
+      await expect(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 35),
+      ).resolves.toBeUndefined();
+    });
+
+    it("allows the fixed 2-month preset (63d)", async () => {
+      await expect(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 63),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects an arbitrary off-menu value (e.g. 364d)", async () => {
+      await expectForbidden(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 364),
+      );
+    });
+
+    it("rejects an enterprise preset like 1 year (371d)", async () => {
+      await expectForbidden(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 371),
+      );
+    });
+
+    it("no-ops on the indefinite sentinel so the admin gate runs downstream", async () => {
+      await expect(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 0),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("given an enterprise SaaS org", () => {
+    beforeEach(() => {
+      mockPlan({ free: false, type: "ENTERPRISE" });
+    });
+
+    it.each([
+      35, 63, 91, 371, 1827,
+    ])("allows the enterprise preset %id", async (days) => {
+      await expect(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, days),
+      ).resolves.toBeUndefined();
+    });
+
+    it("allows a custom value at or above the 49d floor", async () => {
+      await expect(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 56),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects a custom value below the 49d floor that isn't a paid preset", async () => {
+      // 42d is 7-aligned but below the enterprise floor and not 35/63.
+      await expectForbidden(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 42),
+      );
+    });
+  });
+
+  describe("given a self-hosted deployment (IS_SAAS unset)", () => {
+    beforeEach(() => {
+      envMock.IS_SAAS = undefined;
+      // A self-hosted plan may report any type; the gate must not cap it.
+      mockPlan({ free: false, type: "GROWTH_SEAT_EUR_MONTHLY" });
+    });
+
+    it("allows a long custom window (2 years)", async () => {
+      await expect(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 735),
+      ).resolves.toBeUndefined();
+    });
+
+    it("still enforces the 49d floor for sub-floor non-preset values", async () => {
+      await expectForbidden(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 42),
+      );
+    });
+  });
+
+  describe("given a free org (blocked upstream by the free gate)", () => {
+    it("does not additionally reject on the value rule", async () => {
+      mockPlan({ free: true, type: "FREE" });
+      await expect(
+        assertRetentionValueAllowedForPlan(makeCtx(), ORG_SCOPE, 371),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("given a scope that resolves to no organization", () => {
+    it("throws NOT_FOUND before consulting the plan", async () => {
+      const ctx = {
+        session: { user: { id: "user_1" } },
+        prisma: {
+          organization: { findUnique: vi.fn().mockResolvedValue(null) },
+        },
+      } as any;
+      await expect(
+        assertRetentionValueAllowedForPlan(ctx, ORG_SCOPE, 35),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      expect(planMocks.getActivePlan).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/data-retention/policy/dataRetentionPolicy.authz.ts
+++ b/langwatch/src/server/data-retention/policy/dataRetentionPolicy.authz.ts
@@ -197,10 +197,16 @@ export async function assertRetentionPlanForScope(
  * Which retention values a plan tier may persist. Deliberately a standalone
  * map inside the retention module rather than a field on `PlanInfo` /
  * `PLAN_LIMITS` / the signed license: retention packaging owns its own tiering
- * and stays decoupled from billing/license plumbing. Because it reads only
- * existing `PlanInfo` fields (`free`, `type`), a license-resolved org can never
- * crash on a missing field — the gate fails OPEN (uncapped) for any tier it
- * doesn't recognise.
+ * and stays decoupled from billing/license plumbing. It reads only existing
+ * `PlanInfo` fields (`free`, `type`), so a license-resolved org can never crash
+ * on a missing field.
+ *
+ * Tiering is by exclusion: enterprise (`isEnterpriseTier`) and self-hosted
+ * (`!IS_SAAS`) are uncapped; every other non-free SaaS plan is "paid". An
+ * unrecognised SaaS tier therefore fails CLOSED to the restrictive paid menu —
+ * the data-loss-safe default (a mis-tiered org can't set an arbitrary window),
+ * not fail-open. If a new enterprise-like tier is added, extend
+ * `isEnterpriseTier` (the app-wide enterprise check) so it resolves to uncapped.
  *
  * - `fixed`   → paid (non-enterprise SaaS): only the listed presets, no custom.
  * - `uncapped`→ enterprise / self-hosted: any whole-week value ≥ `customMin`,

--- a/langwatch/src/server/data-retention/policy/dataRetentionPolicy.authz.ts
+++ b/langwatch/src/server/data-retention/policy/dataRetentionPolicy.authz.ts
@@ -121,6 +121,21 @@ export async function canConfigureRetention(
 }
 
 /**
+ * Throws FORBIDDEN if the plan is free. Pure — the single source of the
+ * free-tier gate, over an already-resolved plan, so a caller that has the plan
+ * in hand doesn't refetch it.
+ */
+export function assertPlanConfigurable(plan: PlanInfo): void {
+  if (!plan.free) return;
+  throw new TRPCError({
+    code: "FORBIDDEN",
+    message:
+      "Configuring data retention is a paid-plan feature. " +
+      "All projects use the platform default until the organization upgrades.",
+  });
+}
+
+/**
  * Throws FORBIDDEN if the org is on a free plan. Retention overrides and
  * retroactive mutations are paid-tier features; free plans use the platform
  * default uniformly. Called from every mutation that writes retention state.
@@ -129,15 +144,11 @@ export async function assertRetentionPlan(
   ctx: RBACContext,
   organizationId: string,
 ): Promise<void> {
-  if (await canConfigureRetention(organizationId, ctx.session?.user ?? null)) {
-    return;
-  }
-  throw new TRPCError({
-    code: "FORBIDDEN",
-    message:
-      "Configuring data retention is a paid-plan feature. " +
-      "All projects use the platform default until the organization upgrades.",
+  const plan = await getApp().planProvider.getActivePlan({
+    organizationId,
+    user: ctx.session?.user ?? undefined,
   });
+  assertPlanConfigurable(plan);
 }
 
 /**
@@ -168,6 +179,31 @@ export async function resolveScopeOrganizationId(
     select: { team: { select: { organizationId: true } } },
   });
   return project?.team?.organizationId ?? null;
+}
+
+/**
+ * Resolve a scope to its owning org's active plan in a single pass — the one
+ * place that touches the DB + plan provider for a scope-targeted write. Both
+ * the free gate and the value gate then operate on this already-resolved plan,
+ * so `setForScope` never resolves the org or fetches the plan twice.
+ * Throws NOT_FOUND if the scope doesn't resolve to an org.
+ */
+export async function resolveScopePlan(
+  ctx: RBACContext,
+  scope: RetentionScope,
+): Promise<{ organizationId: string; plan: PlanInfo }> {
+  const organizationId = await resolveScopeOrganizationId(ctx, scope);
+  if (!organizationId) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: `${scope.scopeType.toLowerCase()} ${scope.scopeId} was not found.`,
+    });
+  }
+  const plan = await getApp().planProvider.getActivePlan({
+    organizationId,
+    user: ctx.session?.user ?? undefined,
+  });
+  return { organizationId, plan };
 }
 
 /**
@@ -230,42 +266,20 @@ function ruleForPlan(plan: PlanInfo): RetentionRule {
 }
 
 /**
- * Throws FORBIDDEN if the plan of the scope's owning org may not persist the
- * requested retention value. This is the write-path prevention that stops a
- * paid org from setting an arbitrary (e.g. custom multi-year) window through
+ * Throws FORBIDDEN if `plan` may not persist `retentionDays`. Pure — operates
+ * on an already-resolved plan and reads only the tier rule, so it is trivially
+ * unit-testable and does no I/O. This is the write-path prevention that stops a
+ * paid org from persisting an arbitrary (e.g. custom multi-year) window through
  * the tRPC surface, independent of what the UI offers.
  *
- * Order matters at the call site: run AFTER the free gate
- * (`assertRetentionPlanForScope`) and it no-ops on the indefinite sentinel so
- * the platform-admin `assertCanDisableRetention` check still runs downstream.
- * Only `setForScope` (the one place a NEW value is chosen) calls this;
- * retroactive apply replays an already-stored value and is NOT value-gated.
+ * No-ops on the indefinite sentinel (keep-forever is authorized separately, by
+ * `assertCanDisableRetention`) and on free plans (blocked by the free gate).
  */
-export async function assertRetentionValueAllowedForPlan(
-  ctx: RBACContext,
-  scope: RetentionScope,
+export function assertPlanAllowsRetentionValue(
+  plan: PlanInfo,
   retentionDays: number,
-): Promise<void> {
-  // Keep-forever (0) is authorized separately (platform-admin only). Returning
-  // here lets that gate run and keeps the value rule from rejecting the
-  // sentinel as "not a preset".
+): void {
   if (retentionDays === INDEFINITE_RETENTION_DAYS) return;
-
-  const organizationId = await resolveScopeOrganizationId(ctx, scope);
-  if (!organizationId) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: `${scope.scopeType.toLowerCase()} ${scope.scopeId} was not found.`,
-    });
-  }
-
-  const plan = await getApp().planProvider.getActivePlan({
-    organizationId,
-    user: ctx.session?.user ?? undefined,
-  });
-
-  // Free orgs are blocked upstream by the free gate; don't double-enforce the
-  // value rule (which would otherwise reject their platform-default resolution).
   if (plan.free) return;
 
   const rule = ruleForPlan(plan);
@@ -296,4 +310,22 @@ export async function assertRetentionValueAllowedForPlan(
         "Choose one of the offered options, or contact us to unlock more.",
     });
   }
+}
+
+/**
+ * The full write gate for `setForScope`: resolve the scope's owning-org plan
+ * ONCE, then apply the free gate and the value gate to it. Replaces calling
+ * `assertRetentionPlanForScope` + a separate value gate, which each re-resolved
+ * the org and refetched the plan. Only `setForScope` (the one place a NEW value
+ * is chosen) uses this; retroactive apply replays an already-stored value and
+ * is deliberately NOT value-gated (it still runs the free gate elsewhere).
+ */
+export async function assertRetentionWriteAllowed(
+  ctx: RBACContext,
+  scope: RetentionScope,
+  retentionDays: number,
+): Promise<void> {
+  const { plan } = await resolveScopePlan(ctx, scope);
+  assertPlanConfigurable(plan);
+  assertPlanAllowsRetentionValue(plan, retentionDays);
 }

--- a/langwatch/src/server/data-retention/policy/dataRetentionPolicy.authz.ts
+++ b/langwatch/src/server/data-retention/policy/dataRetentionPolicy.authz.ts
@@ -1,6 +1,9 @@
 import { isAdmin } from "@ee/admin/isAdmin";
+import type { PlanInfo } from "@ee/licensing/planInfo";
 import type { PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
+import { env } from "~/env.mjs";
+import { isEnterpriseTier } from "~/server/api/enterprise";
 import {
   hasOrganizationPermission,
   hasProjectPermission,
@@ -8,6 +11,11 @@ import {
 } from "~/server/api/rbac";
 import { getApp } from "~/server/app-layer/app";
 import type { Session } from "~/server/auth";
+import {
+  ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS,
+  INDEFINITE_RETENTION_DAYS,
+  PAID_RETENTION_PRESET_DAYS,
+} from "~/server/data-retention/retentionPolicy.schema";
 import type { ScopeTier } from "~/server/scopes/scope.types";
 
 type RBACContext = { prisma: PrismaClient; session: Session | null };
@@ -183,4 +191,103 @@ export async function assertRetentionPlanForScope(
     });
   }
   await assertRetentionPlan(ctx, organizationId);
+}
+
+/**
+ * Which retention values a plan tier may persist. Deliberately a standalone
+ * map inside the retention module rather than a field on `PlanInfo` /
+ * `PLAN_LIMITS` / the signed license: retention packaging owns its own tiering
+ * and stays decoupled from billing/license plumbing. Because it reads only
+ * existing `PlanInfo` fields (`free`, `type`), a license-resolved org can never
+ * crash on a missing field — the gate fails OPEN (uncapped) for any tier it
+ * doesn't recognise.
+ *
+ * - `fixed`   → paid (non-enterprise SaaS): only the listed presets, no custom.
+ * - `uncapped`→ enterprise / self-hosted: any whole-week value ≥ `customMin`,
+ *               plus the paid short presets (35/63) as the sole sub-floor
+ *               exceptions.
+ */
+type RetentionRule =
+  | { kind: "fixed"; presetDays: readonly number[] }
+  | { kind: "uncapped"; customMin: number };
+
+function ruleForPlan(plan: PlanInfo): RetentionRule {
+  // Self-hosted / OSS short-circuits to ENTERPRISE upstream, but guard on
+  // IS_SAAS too so a mis-resolved plan on a self-hosted deploy is never capped.
+  if (env.IS_SAAS !== true || isEnterpriseTier(plan.type)) {
+    return {
+      kind: "uncapped",
+      customMin: ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS,
+    };
+  }
+  return { kind: "fixed", presetDays: PAID_RETENTION_PRESET_DAYS };
+}
+
+/**
+ * Throws FORBIDDEN if the plan of the scope's owning org may not persist the
+ * requested retention value. This is the write-path prevention that stops a
+ * paid org from setting an arbitrary (e.g. custom multi-year) window through
+ * the tRPC surface, independent of what the UI offers.
+ *
+ * Order matters at the call site: run AFTER the free gate
+ * (`assertRetentionPlanForScope`) and it no-ops on the indefinite sentinel so
+ * the platform-admin `assertCanDisableRetention` check still runs downstream.
+ * Only `setForScope` (the one place a NEW value is chosen) calls this;
+ * retroactive apply replays an already-stored value and is NOT value-gated.
+ */
+export async function assertRetentionValueAllowedForPlan(
+  ctx: RBACContext,
+  scope: RetentionScope,
+  retentionDays: number,
+): Promise<void> {
+  // Keep-forever (0) is authorized separately (platform-admin only). Returning
+  // here lets that gate run and keeps the value rule from rejecting the
+  // sentinel as "not a preset".
+  if (retentionDays === INDEFINITE_RETENTION_DAYS) return;
+
+  const organizationId = await resolveScopeOrganizationId(ctx, scope);
+  if (!organizationId) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: `${scope.scopeType.toLowerCase()} ${scope.scopeId} was not found.`,
+    });
+  }
+
+  const plan = await getApp().planProvider.getActivePlan({
+    organizationId,
+    user: ctx.session?.user ?? undefined,
+  });
+
+  // Free orgs are blocked upstream by the free gate; don't double-enforce the
+  // value rule (which would otherwise reject their platform-default resolution).
+  if (plan.free) return;
+
+  const rule = ruleForPlan(plan);
+
+  if (rule.kind === "uncapped") {
+    // The paid short presets (35/63) are the only values allowed below the
+    // enterprise custom floor. Everything else must clear the floor; whole-week
+    // alignment is already enforced by `retentionDaysSchema`.
+    if (
+      (PAID_RETENTION_PRESET_DAYS as readonly number[]).includes(retentionDays)
+    ) {
+      return;
+    }
+    if (retentionDays < rule.customMin) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: `Retention must be at least ${rule.customMin} days on your plan.`,
+      });
+    }
+    return;
+  }
+
+  if (!rule.presetDays.includes(retentionDays)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message:
+        "That retention length isn't available on your plan. " +
+        "Choose one of the offered options, or contact us to unlock more.",
+    });
+  }
 }

--- a/langwatch/src/server/data-retention/policy/dataRetentionPolicy.read.ts
+++ b/langwatch/src/server/data-retention/policy/dataRetentionPolicy.read.ts
@@ -6,12 +6,12 @@ import {
 } from "~/server/api/rbac";
 import { getApp } from "~/server/app-layer/app";
 import type { Session } from "~/server/auth";
-import { canConfigureRetention } from "./dataRetentionPolicy.authz";
 import type { ScopeTier } from "~/server/scopes/scope.types";
 import type {
   ResolvedRetention,
   RetentionCategory,
 } from "../retentionPolicy.schema";
+import { canConfigureRetention } from "./dataRetentionPolicy.authz";
 
 export type ReadCtx = { prisma: PrismaClient; session: Session | null };
 
@@ -124,7 +124,10 @@ export async function getRetentionPolicySnapshot(
       }),
       ctx.prisma.project.findMany({
         where: { team: { organizationId } },
-        select: { id: true, name: true, teamId: true },
+        // `archivedAt` is selected (not filtered in the query) so the name
+        // lookup below still resolves a rule that targets a since-archived
+        // project; the archived ones are dropped only from the scope PICKER.
+        select: { id: true, name: true, teamId: true, archivedAt: true },
         orderBy: { name: "asc" },
       }),
       app.dataRetention.policy.listOrganizationRules(organizationId),
@@ -198,7 +201,9 @@ export async function getRetentionPolicySnapshot(
       .filter((t) => teamManage.teams.get(t.id))
       .map(({ id, name }) => ({ id, name })),
     projects: orgProjects
-      .filter((p) => projectUpdate.projects.get(p.id))
+      // Archived projects are hidden from the nav and can't be navigated to, so
+      // they must not be offered as a scope to attach a new retention policy.
+      .filter((p) => !p.archivedAt && projectUpdate.projects.get(p.id))
       .map(({ id, name, teamId }) => ({ id, name, teamId })),
   };
 

--- a/langwatch/src/server/data-retention/retentionPolicy.schema.ts
+++ b/langwatch/src/server/data-retention/retentionPolicy.schema.ts
@@ -12,10 +12,38 @@ import { z } from "zod";
 export const RETENTION_WEEK_DAYS = 7;
 
 /**
- * The minimum retention any override may set: 7 weeks. Below this, ClickHouse
- * TTL churn stops being worth the storage saved.
+ * The absolute minimum retention any override may persist: 5 weeks (35 days).
+ *
+ * This is the paid tier's short option ("~1 month"). It is deliberately BELOW
+ * the 49-day recovery floor that free and enterprise keep: paid retention is a
+ * packaging lever, and a paid org opts into a shorter (35d) window than free
+ * (49d) — an inverted-recovery trade-off locked in the plan-gated-menu ADR
+ * (v4). The schema alone therefore no longer guarantees ≥49; the 49-day floor
+ * for non-paid (enterprise / self-hosted) CUSTOM values is re-enforced in the
+ * plan gate (`assertRetentionValueAllowedForPlan`), not here. See
+ * `ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS`.
  */
-export const MIN_RETENTION_DAYS = 49;
+export const MIN_RETENTION_DAYS = 35;
+
+/**
+ * The floor for any CUSTOM (free-form) retention value on the enterprise /
+ * self-hosted tiers, and the recovery floor free/enterprise data keeps. Paid's
+ * sub-floor options (`PAID_RETENTION_PRESET_DAYS`) are the only values allowed
+ * below this, and only as fixed presets — never as custom input. Gate-enforced,
+ * not schema-enforced (the schema floor is `MIN_RETENTION_DAYS = 35`).
+ */
+export const ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS = 49;
+
+/**
+ * The fixed retention menu for PAID (non-enterprise SaaS) organizations:
+ * "~1 month" and "~2 months", snapped UP to whole weeks (30→35 = 5wk,
+ * 60→63 = 9wk) so both align to the weekly ClickHouse partition key. Paid orgs
+ * may pick ONLY these two values — no custom, no other presets. Enterprise also
+ * offers these two as its short options, but reaches longer windows via its
+ * full preset list plus custom (≥49). The gate treats membership in this list
+ * as the sole exception to the enterprise 49-day custom floor.
+ */
+export const PAID_RETENTION_PRESET_DAYS = [35, 63] as const;
 
 /**
  * The maximum retention any override may set. Retention is persisted to the
@@ -29,10 +57,11 @@ export const MIN_RETENTION_DAYS = 49;
 export const MAX_RETENTION_DAYS = 65534;
 
 /**
- * The default retention proposed when creating an override: 7 weeks, the same
- * as the minimum. This is only the suggested starting value in the UI; the
- * value actually stamped when no override exists is PLATFORM_DEFAULT_RETENTION_DAYS
- * (see below), not indefinite.
+ * Fallback starting value for the override drawer when a tier-specific default
+ * can't be derived. The drawer itself defaults to the first preset of the
+ * caller's plan menu (paid → 35, enterprise → 35); this constant is only the
+ * floor-aligned backstop. The value actually stamped when no override exists is
+ * PLATFORM_DEFAULT_RETENTION_DAYS (see below), not this.
  */
 export const DEFAULT_RETENTION_DAYS = MIN_RETENTION_DAYS;
 

--- a/langwatch/src/server/data-retention/retentionPolicy.schema.ts
+++ b/langwatch/src/server/data-retention/retentionPolicy.schema.ts
@@ -20,7 +20,7 @@ export const RETENTION_WEEK_DAYS = 7;
  * (49d) — an inverted-recovery trade-off locked in the plan-gated-menu ADR
  * (v4). The schema alone therefore no longer guarantees ≥49; the 49-day floor
  * for non-paid (enterprise / self-hosted) CUSTOM values is re-enforced in the
- * plan gate (`assertRetentionValueAllowedForPlan`), not here. See
+ * plan gate (`assertPlanAllowsRetentionValue`), not here. See
  * `ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS`.
  */
 export const MIN_RETENTION_DAYS = 35;
@@ -101,7 +101,23 @@ export const retentionDaysSchema = z
   .max(MAX_RETENTION_DAYS)
   .refine((days) => days % RETENTION_WEEK_DAYS === 0, {
     message: `Retention must be a whole number of weeks (a multiple of ${RETENTION_WEEK_DAYS} days), to align with weekly ClickHouse partitions.`,
-  });
+  })
+  // Defense-in-depth for the tier-dependent floor: the only value the schema
+  // accepts below ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS is a fixed paid preset.
+  // The plan gate still owns the per-tier rule (a paid preset isn't valid for
+  // *every* tier), but this stops any path — now or a future ungated caller —
+  // from persisting an arbitrary sub-floor value like 42. Without it, dropping
+  // MIN to 35 would let 35–48 through the type boundary unchecked.
+  .refine(
+    (days) =>
+      (PAID_RETENTION_PRESET_DAYS as readonly number[]).includes(days) ||
+      days >= ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS,
+    {
+      message: `Retention under ${ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS} days is only available as a fixed plan option (${PAID_RETENTION_PRESET_DAYS.join(
+        " or ",
+      )} days).`,
+    },
+  );
 
 /**
  * The sentinel day-count meaning "keep data indefinitely" — exempt from TTL
@@ -115,10 +131,11 @@ export const retentionDaysSchema = z
 export const INDEFINITE_RETENTION_DAYS = 0;
 
 /**
- * Accepted input for setting an override: either a finite retention (≥ 49 days,
- * whole weeks) or the indefinite sentinel (0 = keep forever). Allowing 0 here
- * is structural only — authorization for the indefinite case is enforced
- * separately in the route (platform admins only), never by this schema.
+ * Accepted input for setting an override: either a finite retention (a paid
+ * preset, or ≥ 49 days, always whole weeks — see `retentionDaysSchema`) or the
+ * indefinite sentinel (0 = keep forever). Allowing 0 here is structural only —
+ * authorization for the indefinite case is enforced separately in the route
+ * (platform admins only), never by this schema.
  */
 export const retentionDaysInputSchema = z.union([
   z.literal(INDEFINITE_RETENTION_DAYS),

--- a/specs/data-retention/plan-gated-retention-menu.feature
+++ b/specs/data-retention/plan-gated-retention-menu.feature
@@ -1,0 +1,59 @@
+Feature: Plan-gated data-retention menu
+  As LangWatch
+  I restrict which retention lengths each plan tier can choose
+  So that retention is a clear paid→enterprise packaging lever and no one can
+  set an arbitrary window that is expensive or risky to apply
+
+  # Retention length is gated by plan:
+  #   - Free      cannot configure retention at all (unchanged).
+  #   - Paid      may pick only "1 month" or "2 months" — a fixed pair, no custom.
+  #   - Enterprise (and self-hosted) get the full menu plus a custom value.
+  # The server enforces the rule at the write boundary; the menu only mirrors it.
+  # Existing out-of-menu values are grandfathered — never auto-changed or deleted.
+
+  Scenario: A paid organization sees only the two fixed options
+    Given an organization on a paid, non-enterprise plan
+    When a manager opens the retention policy editor
+    Then the only retention choices are "1 month" and "2 months"
+    And there is no custom option
+    And there is no keep-forever option
+
+  Scenario: A paid organization cannot save an off-menu retention value
+    Given an organization on a paid, non-enterprise plan
+    When a manager attempts to set a retention of one year
+    Then the change is rejected as not available on their plan
+    And the retention is left unchanged
+
+  Scenario: An enterprise organization gets the full menu and a custom value
+    Given an organization on an enterprise plan
+    When a manager opens the retention policy editor
+    Then the choices include "1 month", "2 months", "3 months", "1 year", and "5 years"
+    And a custom value is available
+    When the manager enters a custom retention shorter than the recovery floor
+    Then the change is rejected as below the minimum for their plan
+
+  Scenario: Keep-forever stays a platform-admin capability on every plan
+    Given an organization on an enterprise plan
+    And the acting user is not a platform administrator
+    When the manager opens the retention policy editor
+    Then keep-forever is not offered
+    And attempting to set keep-forever is rejected
+
+  Scenario: A grandfathered value is shown but never silently changed
+    Given a paid organization whose traces retention was previously set to one year
+    When a manager opens the retention policy editor for that scope
+    Then the current value is shown as a read-only "legacy" entry
+    And saving is disabled until the manager picks an available option
+    And the stored retention is never shortened on its own
+
+  Scenario: Applying a change to existing data is opt-in, not automatic
+    Given a manager is setting a new retention policy
+    When the editor opens
+    Then "apply this change to existing data" is off by default
+    So that saving a policy never rewrites existing data unless explicitly chosen
+
+  Scenario: A billing event never overwrites an existing retention policy
+    Given an organization whose org-level traces retention is set to five years
+    When a seat/subscription billing event is processed for that organization
+    Then the five-year traces policy is left unchanged
+    And only retention categories that had no policy are provisioned to the default


### PR DESCRIPTION
## Why

Retention length is meant to be a paid→enterprise packaging lever, but today every non-free org (paid *and* enterprise) gets the identical full preset menu **plus an unbounded Custom field**. That let a paid customer (via a customer report) pick an arbitrary retention value, which fired a large retroactive `ALTER … UPDATE` rewrite across ClickHouse and stressed S3-tiered storage. This PR restricts *which* retention values each plan tier can choose and makes the retroactive rewrite opt-in.

Implements the locked plan-gated-retention-menu ADR (v4).

## What changed

- **Plan-gated menu**, enforced server-side and mirrored in the UI:
  - **Free** — cannot configure (unchanged).
  - **Paid** (non-enterprise SaaS) — a fixed pair only: **1 month (35d)** and **2 months (63d)**. No custom, no keep-forever.
  - **Enterprise / self-hosted** — **1 month, 2 months, 3 months, 1 year, 5 years** + **Custom** (≥49d, whole weeks). Keep-forever stays platform-admin only.
- **Server value gate** (`assertRetentionValueAllowedForPlan`) on the `setForScope` mutation — the real enforcement; the menu is just a mirror. Not applied to retroactive apply (it replays an already-stored value).
- **"Apply this change to existing data" now defaults OFF.** The retroactive rewrite is the expensive/hard-to-undo operation, so it's now a deliberate opt-in.
- **Grandfathering** — a stored value that isn't on the org's current menu shows as a read-only "current (legacy)" entry; it is never coerced or auto-shortened, and Save stays disabled until a valid option is picked.
- **Webhook create-if-absent (INV-6)** — a seat/subscription billing event no longer overwrites an existing org-level retention policy down to the default (a pre-existing latent data-loss path).

## How it works

- The tier→rule map lives in the retention module and reads only the already-resolved `PlanInfo` (`free`, `type` via `isEnterpriseTier`) — **no coupling to `PLAN_LIMITS`/license**. It **fails closed** to the restrictive paid menu for any unmapped SaaS tier (the data-loss-safe default); self-hosted (`!IS_SAAS`) and enterprise are uncapped.
- The absolute schema floor drops **49→35** so paid's short option is persistable; the 49d floor for non-paid **custom** input is re-enforced in the gate (`ENTERPRISE_CUSTOM_MIN_RETENTION_DAYS`). The two paid presets are the only sub-49 values any non-free tier can select.
- The menu is built by a pure `buildRetentionMenuItems` helper so the gating is unit-testable without rendering.

## Test plan

- **Unit** — `assertRetentionValueAllowedForPlan` (paid rejects off-menu/enterprise values, allows {35,63}; enterprise allows presets + custom ≥49, rejects sub-floor; self-hosted uncapped; free no-op; NOT_FOUND); schema floor + paid-preset constants; pure `buildRetentionMenuItems` matrix; webhook create-if-absent regression.
- **Integration (jsdom)** — drawer defaults apply-to-existing OFF (asserted via the `onSave` payload); paid grandfathered value renders read-only and disables Save.
- `pnpm typecheck` clean; all touched suites green (needs Docker for the ClickHouse-backed integration project in CI).

## Anything surprising?

- **Overrides ADR INV-7.** The locked design made 35d paid-only ("35 is unreachable by enterprise"). Per owner decision, enterprise now also offers 1 month/2 months (35/63) for consistent labels across tiers — documented as **v4** in the ADR. Enterprise *custom* input still floors at 49; the two short presets are the only sub-49 selectable values.
- Paid recovery window (35d) is intentionally **shorter than free** (49d) — the inverted-recovery trade-off the ADR already accepted; flag for support/comms.
- Freshly-provisioned paid orgs sit at the 49d default (off the paid menu) until they edit — grandfather-safe (49 ≥ 35, lengthening only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan-tier aware data-retention UI, including enterprise-only custom options.
  * Legacy/grandfathered retention values now display as read-only, with saving disabled until a valid option is selected.
* **Bug Fixes**
  * Seat/billing webhook provisioning now applies retention rules with create-if-absent per category, avoiding overwriting existing org rules.
  * Server-side retention writes are now enforced by plan tier, with updated retention floors and allowed presets.
  * Archived projects are excluded from retention scope availability and storage totals/counts.
* **Tests**
  * Added/updated coverage for plan-gated menus, legacy behavior, schema validation, billing provisioning, and archived-project handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Also in this PR (adjacent fixes found while testing the page)
- **Storage card counted archived projects.** The Data Storage line showed an inflated project count (archived projects are hidden everywhere else). `resolveScopeStorageUsage` and the retention scope picker now filter `archivedAt: null`, so the count/bytes and the assignable-scope list match what the user actually sees.