### PR TITLE
fix(experiments-v3): stop body rows bleeding through sticky header gap on vertical scroll

### DIFF
--- a/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
+++ b/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
@@ -8,7 +8,14 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { nanoid } from "nanoid";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useShallow } from "zustand/react/shallow";
 import { AddOrEditDatasetDrawer } from "~/components/AddOrEditDatasetDrawer";
 import { datasetTableCss } from "~/components/datasets/editor/datasetTableStyles";
@@ -1613,8 +1620,24 @@ export function EvaluationsV3Table({
   // +1 for the spacer column that's always present
   const targetsColSpan = targets.length + 2;
 
-  // Height of the super header row (Dataset/Agents row)
-  const SUPER_HEADER_HEIGHT = 51;
+  // Measure the super header row's actual rendered height so the column
+  // header row's sticky `top` offset matches. A hardcoded constant drifts
+  // from the true <th> box-model height (content + padding + border) in a
+  // border-collapse:separate table, leaving a gap through which body rows
+  // bleed during vertical scroll.
+  const superHeaderRowRef = useRef<HTMLTableRowElement>(null);
+  const [superHeaderHeight, setSuperHeaderHeight] = useState(51);
+  useLayoutEffect(() => {
+    const row = superHeaderRowRef.current;
+    if (!row) return;
+    const measure = () => {
+      setSuperHeaderHeight(row.getBoundingClientRect().height);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(row);
+    return () => observer.disconnect();
+  }, []);
   const MENU_PLUS_PADDING = 56 + 16;
 
   // Calculate total percentage for all resizable columns
@@ -1684,7 +1707,7 @@ export function EvaluationsV3Table({
         // Column header row (second row in thead)
         "& thead tr:nth-of-type(2) th": {
           position: "sticky",
-          top: `${SUPER_HEADER_HEIGHT}px`,
+          top: `${superHeaderHeight}px`,
           zIndex: 10,
           backgroundColor: "var(--chakra-colors-bg-panel)",
         },
@@ -1747,7 +1770,7 @@ export function EvaluationsV3Table({
           <col style={{ width: DRAWER_WIDTH }} />
         </colgroup>
         <thead>
-          <tr>
+          <tr ref={superHeaderRowRef}>
             <DatasetSuperHeader
               colSpan={datasetColSpan}
               activeDataset={activeDataset}


### PR DESCRIPTION
## Summary

When scrolling the experiments workbench vertically, body row content was visible in the space between the "Prompts or Agents" super header and the "category_classifier / Score" column header row — appearing as faint text bleeding through.

## Root cause

`EvaluationsV3Table.tsx` renders two sticky rows in the `<thead>`:
- Super header row — `top: 0`
- Column header row — `top: SUPER_HEADER_HEIGHT` where `SUPER_HEADER_HEIGHT = 51`

The super header's `<th>` has `height: 48px` + `padding: 12px 12px` + `border-bottom: 1px` in a `border-collapse: separate` table. The browser's box-model interpretation of `height` on a `<th>` in this configuration (content-box + separate spacing) renders the row at approximately **73px** in Chrome — not 51px.

The column header row was told to stick at `top: 51px`, which is ~22px shy of where the super header actually ends. That gap is where body rows scroll through and become visible.

## Fix

Replace the hardcoded constant with a **runtime measurement** of the super header row's actual rendered height:

- `useRef<HTMLTableRowElement>` on the super header `<tr>`
- `useLayoutEffect` calls `getBoundingClientRect().height` once on mount to seed the sticky offset before the first paint
- `ResizeObserver` tracks size changes (loading state → loaded state adds/removes the `+ Add Comparison` button; window resize can change content wrapping)

The column header now sticks flush against the super header's actual bottom edge regardless of future padding/border changes.

## Diff

+19 / −3 lines, one file (`langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx`).

## Why not just update `SUPER_HEADER_HEIGHT = 73`?

Two reasons:
1. **Fragile.** Any future change to super header padding, font size, or border thickness re-opens the bug. Dynamic measurement is self-correcting.
2. **Cross-browser drift.** The exact rendered height varies subtly across Chromium/Firefox/Safari for `<th>` box-model. A hardcoded value is browser-specific.

## Test plan

- [ ] Local dev: open experiments workbench, scroll vertically — no faint body row text above column headers
- [ ] Loading state → loaded state transition: sticky offset re-measures correctly when the `+ Add Comparison` button appears
- [ ] Window resize during scroll: no gap opens
- [ ] Existing integration tests still pass (`CellValidationNumber.integration.test.tsx`, `CellEditingRows.integration.test.tsx` — both mock `TargetSuperHeader` and are unaffected by the sticky-offset internal)

## Screenshot (before)

Body row text visible between "Prompts or Agents" and "category_classifier" column header — as attached in the reporting thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table header alignment so sticky column headers stay correctly positioned as the top header row changes height.
  * Made the second header row’s sticky offset adapt automatically to the rendered layout, reducing visual overlap and spacing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->