### PR TITLE
feat(python-sdk): support custom CA bundle and SSL verify bypass

### DIFF
--- a/python-sdk/src/langwatch/client.py
+++ b/python-sdk/src/langwatch/client.py
@@ -2,7 +2,7 @@ import atexit
 import os
 import logging
 import threading
-from typing import List, Optional, Sequence, ClassVar
+from typing import List, Optional, Sequence, ClassVar, Union
 
 from langwatch.__version__ import __version__
 from langwatch.attributes import AttributeKey
@@ -70,6 +70,7 @@ class Client(LangWatchClientProtocol):
         dict[opentelemetry.trace.TracerProvider, set[BaseInstrumentor]]
     ] = {}
     _prompts_path: ClassVar[Optional[str]] = None
+    _ssl_config_warned: ClassVar[bool] = False
 
     # Regular attributes for protocol compatibility
     base_attributes: BaseAttributes
@@ -399,6 +400,7 @@ class Client(LangWatchClientProtocol):
         cls._rest_api_client = None
         cls._prompts_path = None
         cls._registered_instrumentors.clear()
+        cls._ssl_config_warned = False
 
     @classmethod
     def reset_for_testing(cls) -> None:
@@ -713,11 +715,21 @@ class Client(LangWatchClientProtocol):
                 f"Configuring OTLP exporter with endpoint: {Client._endpoint_url}/api/otel/v1/traces"
             )
 
-        otlp_exporter = OTLPSpanExporter(
-            endpoint=f"{Client._endpoint_url}/api/otel/v1/traces",
-            headers=headers,
-            timeout=int(os.getenv("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", 30)),
-        )
+        ssl_verify_value = Client._get_ssl_config()
+        exporter_kwargs = {
+            "endpoint": f"{Client._endpoint_url}/api/otel/v1/traces",
+            "headers": headers,
+            "timeout": int(os.getenv("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", 30)),
+        }
+
+        if ssl_verify_value is not None:
+            # NOTE: Passing certificate_file=False requires
+            # opentelemetry-exporter-otlp-proto-http with the fix from
+            # https://github.com/open-telemetry/opentelemetry-python/pull/5379
+            # Without it, False is falsy and silently ignored by the exporter.
+            exporter_kwargs["certificate_file"] = ssl_verify_value  # type: ignore[assignment]
+
+        otlp_exporter = OTLPSpanExporter(**exporter_kwargs)
 
         # Wrap the exporter with conditional logic
         conditional_exporter = ConditionalSpanExporter(
@@ -750,6 +762,51 @@ class Client(LangWatchClientProtocol):
         )
 
         return Client._rest_api_client
+
+    @staticmethod
+    def _get_ssl_config() -> Optional[Union[bool, str]]:
+        """
+        Returns the value to pass as certificate_file to OTLPSpanExporter.
+
+        Reads from environment variables:
+        - LANGWATCH_SSL_VERIFY: set to 'false'/'0'/'no'/'disable' to skip verification
+        - LANGWATCH_CA_BUNDLE: path to a .pem/.crt CA bundle file
+
+        Returns:
+        - False: disables SSL verification
+        - str: path to custom CA bundle
+        - None: use default behavior (let OTEL exporter decide)
+
+        When LANGWATCH_CA_BUNDLE is set, it takes precedence over the native
+        OTEL variables (OTEL_EXPORTER_OTLP_CERTIFICATE /
+        OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE).
+
+        NOTE: certificate_file=False requires opentelemetry-exporter-otlp-proto-http
+        with the fix from https://github.com/open-telemetry/opentelemetry-python/pull/5379
+        """
+        ssl_verify = os.getenv("LANGWATCH_SSL_VERIFY", "true").lower()
+        ca_bundle = os.getenv("LANGWATCH_CA_BUNDLE", "")
+
+        if ssl_verify in ("false", "0", "no", "disable"):
+            if not Client._ssl_config_warned:
+                Client._ssl_config_warned = True
+                logger.info(
+                    "LANGWATCH_SSL_VERIFY is disabled. SSL certificate "
+                    "verification will be skipped."
+                )
+            return False  # type: ignore[return-value]  # OTEL exporter passes this as verify= to requests
+
+        if ca_bundle:
+            if os.path.isfile(ca_bundle):
+                logger.info(f"Using custom CA bundle: {ca_bundle}")
+                return ca_bundle
+            else:
+                logger.warning(
+                    f"LANGWATCH_CA_BUNDLE={ca_bundle} was set but the file "
+                    "does not exist. Falling back to default SSL behavior."
+                )
+
+        return None
 
 
 class ConditionalSpanExporter(SpanExporter):

--- a/python-sdk/tests/test_ssl_config.py
+++ b/python-sdk/tests/test_ssl_config.py
@@ -98,7 +98,6 @@ class TestGetSslConfigLogging:
             Client._get_ssl_config()
         assert caplog.text.count("SSL certificate") == 1
 
-        # Reset and call again — should warn again
         Client.reset_for_testing()
         caplog.clear()
         with caplog.at_level(logging.INFO):

--- a/python-sdk/tests/test_ssl_config.py
+++ b/python-sdk/tests/test_ssl_config.py
@@ -1,0 +1,115 @@
+"""
+Tests for Client._get_ssl_config() — SSL verification configuration via environment variables.
+"""
+
+import logging
+
+import pytest
+
+from langwatch.client import Client
+
+
+@pytest.fixture(autouse=True)
+def reset_client():
+    """Ensure each test starts with a clean Client state."""
+    Client.reset_for_testing()
+    yield
+    Client.reset_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Remove SSL-related env vars so tests are isolated."""
+    monkeypatch.delenv("LANGWATCH_SSL_VERIFY", raising=False)
+    monkeypatch.delenv("LANGWATCH_CA_BUNDLE", raising=False)
+
+
+class TestGetSslConfigDefault:
+    def test_returns_none_when_no_env_vars_set(self):
+        assert Client._get_ssl_config() is None
+
+    def test_returns_none_when_ssl_verify_is_true(self, monkeypatch):
+        monkeypatch.setenv("LANGWATCH_SSL_VERIFY", "true")
+        assert Client._get_ssl_config() is None
+
+
+class TestGetSslConfigDisableVerify:
+    @pytest.mark.parametrize(
+        "value",
+        ["false", "False", "FALSE", "0", "no", "No", "disable", "DISABLE"],
+    )
+    def test_returns_false_for_disable_values(self, monkeypatch, value):
+        monkeypatch.setenv("LANGWATCH_SSL_VERIFY", value)
+        assert Client._get_ssl_config() is False
+
+    def test_ssl_verify_false_takes_precedence_over_ca_bundle(
+        self, monkeypatch, tmp_path
+    ):
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("fake cert content")
+        monkeypatch.setenv("LANGWATCH_SSL_VERIFY", "false")
+        monkeypatch.setenv("LANGWATCH_CA_BUNDLE", str(ca_file))
+        assert Client._get_ssl_config() is False
+
+
+class TestGetSslConfigCaBundle:
+    def test_returns_path_when_file_exists(self, monkeypatch, tmp_path):
+        ca_file = tmp_path / "corporate-ca.pem"
+        ca_file.write_text("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----")
+        monkeypatch.setenv("LANGWATCH_CA_BUNDLE", str(ca_file))
+        assert Client._get_ssl_config() == str(ca_file)
+
+    def test_returns_none_when_file_does_not_exist(self, monkeypatch):
+        monkeypatch.setenv("LANGWATCH_CA_BUNDLE", "/nonexistent/path/ca.pem")
+        assert Client._get_ssl_config() is None
+
+    def test_returns_none_when_ca_bundle_is_empty_string(self, monkeypatch):
+        monkeypatch.setenv("LANGWATCH_CA_BUNDLE", "")
+        assert Client._get_ssl_config() is None
+
+
+class TestGetSslConfigLogging:
+    def test_logs_warning_when_ca_file_missing(self, monkeypatch, caplog):
+        monkeypatch.setenv("LANGWATCH_CA_BUNDLE", "/no/such/file.pem")
+        with caplog.at_level(logging.WARNING):
+            Client._get_ssl_config()
+        assert "does not exist" in caplog.text
+        assert "/no/such/file.pem" in caplog.text
+
+    def test_logs_info_when_ssl_verify_disabled(self, monkeypatch, caplog):
+        monkeypatch.setenv("LANGWATCH_SSL_VERIFY", "false")
+        with caplog.at_level(logging.INFO):
+            Client._get_ssl_config()
+        assert "SSL certificate" in caplog.text
+
+    def test_ssl_disabled_warning_emitted_only_once(self, monkeypatch, caplog):
+        monkeypatch.setenv("LANGWATCH_SSL_VERIFY", "false")
+        with caplog.at_level(logging.INFO):
+            Client._get_ssl_config()
+            Client._get_ssl_config()
+            Client._get_ssl_config()
+        assert caplog.text.count("SSL certificate") == 1
+
+    def test_ssl_disabled_warning_resets_after_reset_for_testing(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("LANGWATCH_SSL_VERIFY", "false")
+        with caplog.at_level(logging.INFO):
+            Client._get_ssl_config()
+        assert caplog.text.count("SSL certificate") == 1
+
+        # Reset and call again — should warn again
+        Client.reset_for_testing()
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            Client._get_ssl_config()
+        assert caplog.text.count("SSL certificate") == 1
+
+    def test_logs_info_when_using_custom_ca_bundle(self, monkeypatch, tmp_path, caplog):
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("fake cert")
+        monkeypatch.setenv("LANGWATCH_CA_BUNDLE", str(ca_file))
+        with caplog.at_level(logging.INFO):
+            Client._get_ssl_config()
+        assert "Using custom CA bundle" in caplog.text
+        assert str(ca_file) in caplog.text


### PR DESCRIPTION
## Why

In corporate environments using private certificate authorities (internal PKI), TLS verification often fails because the corporate root CA isn't present in Python's default trust store.

The LangWatch SDK currently doesn't provide a straightforward way to configure TLS verification for the OpenTelemetry OTLP HTTP exporter, making integration with these environments unnecessarily difficult.

Closes #

## What changed

Added support for two LangWatch-specific environment variables:

- **`LANGWATCH_SSL_VERIFY`** — set to `false`/`0`/`no`/`disable` to disable TLS certificate verification
- **`LANGWATCH_CA_BUNDLE`** — path to a `.pem`/`.crt` file containing a custom CA bundle

A new static method, `Client._get_ssl_config()`, reads these variables and returns the appropriate value to pass as `certificate_file` when constructing the `OTLPSpanExporter`.

When neither variable is set, the SDK preserves the existing OpenTelemetry behavior.

Added **19 unit tests** covering all code paths.

## How it works

The OpenTelemetry OTLP HTTP exporter forwards its `certificate_file` argument to the underlying `requests` client as the `verify` parameter.

Depending on the environment variables, the SDK now passes one of the following values:

- `False` → disable TLS certificate verification
- `"/path/to/ca.pem"` → use a custom CA bundle
- `None` (omit the argument) → preserve the exporter's default behavior

`LANGWATCH_SSL_VERIFY=false` takes precedence over `LANGWATCH_CA_BUNDLE`.

Both variables override the native OpenTelemetry certificate configuration (`OTEL_EXPORTER_OTLP_CERTIFICATE` / `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE`). When neither LangWatch variable is defined, the exporter falls back to the standard OpenTelemetry behavior.

> **Note:** support for `LANGWATCH_SSL_VERIFY=false` depends on an upstream OpenTelemetry fix (PR #5379). Without that fix, explicitly passing `certificate_file=False` is ignored because the exporter currently initializes the value using `certificate_file or environ.get(...)`. Support for custom CA bundles (`LANGWATCH_CA_BUNDLE`) works independently.

## Test plan

Added `tests/test_ssl_config.py` with **19 parametrized unit tests** covering:

- Default behavior (no environment variables) → returns `None`
- All supported `LANGWATCH_SSL_VERIFY` disable values (`false`, `0`, `no`, `disable`, case-insensitive) → returns `False`
- Valid `LANGWATCH_CA_BUNDLE` → returns the configured path
- Invalid CA bundle path → returns `None` and emits a warning
- `LANGWATCH_SSL_VERIFY=false` takes precedence over `LANGWATCH_CA_BUNDLE`
- Info log is emitted only once (dedup guard)
- Guard state resets correctly via `reset_for_testing()`

```bash
LANGWATCH_API_KEY="testkey" \
PYTHONPATH="$PYTHONPATH:tests:." \
uv run python -m pytest tests/test_ssl_config.py -v

# 19 passed ✅
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable TLS/SSL verification for OTLP span exporting, including support for custom CA bundles via environment settings.
* **Bug Fixes**
  * Improved exporter setup so SSL-related options are applied consistently and warnings are reduced to a single occurrence.
* **Tests**
  * Added automated coverage for SSL configuration behavior, including defaults, enabled/disabled settings, CA bundle handling, and warning/log behavior reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->