### PR TITLE
test(infra): register global afterEach(cleanup) so portaled dialogs stop leaking (#4469)

### DIFF
--- a/langwatch/src/components/shared/__tests__/global-dialog-cleanup.regression.test.tsx
+++ b/langwatch/src/components/shared/__tests__/global-dialog-cleanup.regression.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression guard for #4469: proves the global `afterEach(cleanup)` registered
+ * in `test-setup.ts` unmounts portaled content between tests, so role-based
+ * queries stay deterministic in CI.
+ *
+ * This file deliberately does NOT register its own `afterEach(cleanup)`. The
+ * only unmount between its two tests comes from the shared setup file, so the
+ * second test can see exactly one dialog only if the global hook ran. Remove
+ * that global hook and the second test sees two leaked dialogs and fails, which
+ * is the exact accumulation that made `getByRole`/`getAllByRole` flake.
+ */
+import { render, screen } from "@testing-library/react";
+import { createPortal } from "react-dom";
+import { describe, expect, it } from "vitest";
+
+// Mirrors how Chakra dialogs mount: React content is portaled straight into
+// document.body rather than into the render container.
+const PortaledDialog = () =>
+  createPortal(<div role="dialog">portaled dialog content</div>, document.body);
+
+describe("given the global afterEach(cleanup) from test-setup", () => {
+  describe("when a portaled dialog is rendered across consecutive tests", () => {
+    it("mounts exactly one dialog on the first render", () => {
+      render(<PortaledDialog />);
+      expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    });
+
+    it("still sees exactly one dialog on the next render, proving no accumulation", () => {
+      render(<PortaledDialog />);
+      expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    });
+  });
+});

--- a/langwatch/test-setup.ts
+++ b/langwatch/test-setup.ts
@@ -1,11 +1,25 @@
 import os from "node:os";
 import path from "node:path";
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
 import dotenv from "dotenv";
-import { afterAll, vi } from "vitest";
+import { afterAll, afterEach, vi } from "vitest";
 import { TEST_PUBLIC_KEY } from "./ee/licensing/__tests__/fixtures/testKeys";
 
 dotenv.config({ path: ".env" });
+
+// Register React Testing Library's per-test unmount globally. vitest.config.ts
+// runs without `globals: true`, so RTL's automatic afterEach(cleanup) never
+// self-registers; component tests that render portaled Chakra dialogs/modals
+// then leak every render into document.body, where accumulated dialogs get
+// marked aria-hidden by focus management and make role-based queries
+// (getByRole/getAllByRole) flake in CI. Registering cleanup once here fixes the
+// whole class (current and future test files) at the root instead of per file
+// (#4469, the CI-only flake first seen in #4467). cleanup() no-ops when a test
+// rendered nothing, so node-environment (non-jsdom) tests are unaffected.
+afterEach(() => {
+  cleanup();
+});
 
 // Born-on-storage (ADR-032): every dataset create writes chunk objects to the
 // resolved storage backend. Tests run without S3, so the resolver falls back to


### PR DESCRIPTION
## Ticket

Closes #4469. Dialog/modal component tests leak portaled dialogs into `document.body` because there is no per-test unmount, causing CI-only `getByRole`/`getAllByRole` flakes.

## Premise re-check (still holds on current main)

Verified against `origin/main` (`27b6c0c`): `langwatch/vitest.config.ts` still runs without `globals: true`, and `langwatch/test-setup.ts` still registers no `afterEach(cleanup)`, so React Testing Library's automatic per-test cleanup never registers. `ScenarioCreateModal.test.tsx` still has no `cleanup()`. No open PR addresses this. PROCEED.

## Change

Root-cause fix instead of per-file patching. Register `afterEach(cleanup)` once in the shared `setupFile` (`langwatch/test-setup.ts`), so every current and future dialog/modal test is cleaned up between tests. `cleanup()` no-ops when a test rendered nothing, so node-environment (non-jsdom) tests are unaffected.

This eliminates the whole class of leak-driven flakes at the source. The alternative in the issue, a per-file `afterEach(cleanup)` on each affected file (the pattern used in #4468 for `AICreateModal`), is lower blast radius but leaves the root cause in place, so new test files keep reintroducing the leak.

Scope is kept tight: existing per-file `afterEach(cleanup)` calls are left in place (calling cleanup twice is idempotent). Removing them and the redundant `getDialogContent()` "last dialog" heuristic is a safe follow-up simplification, not bundled here.

## Evidence

- **Regression guard (new):** `global-dialog-cleanup.regression.test.tsx` renders a portaled dialog across two consecutive tests and declares **no** local `afterEach(cleanup)`. Run in isolation it passes (`Test Files 1 passed, Tests 2 passed`); the second test can see exactly one dialog only if the global hook unmounted the first. Remove the hook and that test sees two leaked dialogs and fails. This executes the code path (not a string assertion), per the repo's regression-test rule.
- **Dialog family still green:** `AICreateModal.test.tsx` + `ScenarioCreateModal.test.tsx` pass with the global hook added (idempotent alongside their own cleanup).
- **Node-env safety:** node-environment unit tests (`githubPrLinks.unit.test.ts`, `githubOauthState.unit.test.ts`) pass, confirming the RTL import and `cleanup()` no-op are safe without a DOM (`25 passed`).
- **Blast radius:** the full component unit slice `pnpm test:unit src/components` passes: `Test Files 126 passed | 8 skipped`, `Tests 1646 passed | 129 skipped | 23 todo`, `0 failed`. No test relied on cross-test DOM accumulation.
- **Typecheck:** `pnpm typecheck` clean.

## Advisory note

Advisory PR from the tech-debt-fixer bot, opened for human review, not to be merged by the bot. The human makes the merge call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test stability by ensuring rendered dialogs are cleaned up between test runs.
  * Added coverage to prevent dialogs from persisting across consecutive tests, reducing flaky results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->