### PR TITLE
refactor(tests): consolidate duplicated blob-offload integration fixtures into shared helpers (#4987)

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/blob-offload-test-helpers.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/blob-offload-test-helpers.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared fixture helpers for the large-trace blob-offload integration tests
+ * (#4888 / #4215 / ADR-022). These constants and functions are identical across
+ * the blob-offload read-path tests, so they live here once instead of being
+ * copy-pasted per file (avoids schema/shape drift across the family).
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { expect } from "vitest";
+import { IO_PREVIEW_BYTES } from "~/server/app-layer/traces/lean-for-projection";
+import type { Event } from "~/server/event-sourcing";
+
+export const AGGREGATE_TYPE = "trace";
+
+/**
+ * A 200 KB deterministic payload whose final bytes only exist past the 64 KB
+ * preview boundary. The preview is `value.slice(0, 64KB) + "…"`, so it can NEVER
+ * contain UNIQUE_TAIL, so a preview-only read fails the tail assertion.
+ */
+export const UNIQUE_TAIL = "__OFFLOAD_FULL_VALUE_TAIL_MARKER__";
+export const LARGE_VALUE = "x".repeat(200_000) + UNIQUE_TAIL;
+
+/** Sanity: the payload genuinely exceeds the offload threshold. */
+export function assertOverThreshold(value: string): void {
+  expect(Buffer.byteLength(value, "utf-8")).toBeGreaterThan(IO_PREVIEW_BYTES);
+}
+
+/**
+ * Inserts ONE full event_log row, exactly as the production write path stores it
+ * (`EventPayload` IS `event.data`). Mirrors the canonical event_log test idiom
+ * (JSONEachRow with a stringified payload) and stamps `_retention_days: 0`
+ * (never-expire sentinel, test-only) so a merge-cycle TTL can't evict the fixture
+ * mid-run.
+ */
+export async function insertEventLogRow({
+  client,
+  tenantId,
+  aggregateId,
+  eventId,
+  eventType,
+  eventVersion,
+  eventData,
+}: {
+  client: ClickHouseClient;
+  tenantId: string;
+  aggregateId: string;
+  eventId: string;
+  eventType: string;
+  eventVersion: string;
+  eventData: unknown;
+}): Promise<void> {
+  const ts = Date.now();
+  await client.insert({
+    table: "event_log",
+    values: [
+      {
+        TenantId: tenantId,
+        AggregateType: AGGREGATE_TYPE,
+        AggregateId: aggregateId,
+        EventId: eventId,
+        EventType: eventType,
+        EventVersion: eventVersion,
+        EventTimestamp: ts,
+        EventOccurredAt: ts,
+        EventPayload: JSON.stringify(eventData),
+        IdempotencyKey: eventId,
+        _retention_days: 0,
+      },
+    ],
+    format: "JSONEachRow",
+    // Sync insert so the read-back in the same test sees the row immediately.
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+/** Reads span attributes out of a leaned SpanReceived event into a string map. */
+export function extractSpanAttrs(event: Event): Record<string, string> {
+  const data = event.data as {
+    span?: {
+      attributes?: Array<{ key: string; value: { stringValue?: string } }>;
+    };
+  };
+  const attrs: Record<string, string> = {};
+  for (const attr of data?.span?.attributes ?? []) {
+    if (typeof attr.value.stringValue === "string") {
+      attrs[attr.key] = attr.value.stringValue;
+    }
+  }
+  return attrs;
+}

--- a/langwatch/src/server/app-layer/traces/__tests__/large-trace-blob-offload-readpath.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/large-trace-blob-offload-readpath.integration.test.ts
@@ -47,10 +47,17 @@
 
 import type { ClickHouseClient } from "@clickhouse/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  AGGREGATE_TYPE,
+  assertOverThreshold,
+  extractSpanAttrs,
+  insertEventLogRow,
+  LARGE_VALUE,
+  UNIQUE_TAIL,
+} from "~/server/app-layer/traces/__tests__/blob-offload-test-helpers";
 import { BlobStore } from "~/server/app-layer/traces/blob-store.service";
 import {
   EVENTREF_ATTR_PREFIX,
-  IO_PREVIEW_BYTES,
   leanForProjection,
 } from "~/server/app-layer/traces/lean-for-projection";
 import { NullSpanStorageRepository } from "~/server/app-layer/traces/repositories/span-storage.repository";
@@ -84,72 +91,6 @@ import {
 const hasTestcontainers = !!(
   process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
 );
-
-const AGGREGATE_TYPE = "trace";
-
-/**
- * A 200 KB deterministic payload whose final bytes only exist past the 64 KB
- * preview boundary. The preview is `value.slice(0, 64KB) + "…"`, so it can NEVER
- * contain UNIQUE_TAIL — a preview-only read fails the tail assertion.
- */
-const UNIQUE_TAIL = "__OFFLOAD_FULL_VALUE_TAIL_MARKER__";
-const LARGE_VALUE = "x".repeat(200_000) + UNIQUE_TAIL;
-
-/** Sanity: the payload genuinely exceeds the offload threshold. */
-function assertOverThreshold(value: string): void {
-  expect(Buffer.byteLength(value, "utf-8")).toBeGreaterThan(IO_PREVIEW_BYTES);
-}
-
-/**
- * Inserts ONE full event_log row, exactly as the production write path stores
- * it (`EventPayload` IS `event.data`). Mirrors the
- * eventLogDurability.integration.test.ts idiom — JSONEachRow with a stringified
- * payload — and stamps `_retention_days: 0` (never-expire sentinel, test-only)
- * so a merge-cycle TTL can never evict the fixture mid-run.
- */
-async function insertEventLogRow({
-  client,
-  tenantId,
-  aggregateId,
-  eventId,
-  eventType,
-  eventVersion,
-  eventData,
-}: {
-  client: ClickHouseClient;
-  tenantId: string;
-  aggregateId: string;
-  eventId: string;
-  eventType: string;
-  eventVersion: string;
-  eventData: unknown;
-}): Promise<void> {
-  const ts = Date.now();
-  await client.insert({
-    table: "event_log",
-    values: [
-      {
-        TenantId: tenantId,
-        AggregateType: AGGREGATE_TYPE,
-        AggregateId: aggregateId,
-        EventId: eventId,
-        EventType: eventType,
-        EventVersion: eventVersion,
-        EventTimestamp: ts,
-        EventOccurredAt: ts,
-        // Production stores event.data as the EventPayload; the CH client
-        // serializes it to the `EventPayload String` column. We stringify here
-        // to match the canonical event_log test idiom byte-for-byte.
-        EventPayload: JSON.stringify(eventData),
-        IdempotencyKey: eventId,
-        _retention_days: 0,
-      },
-    ],
-    format: "JSONEachRow",
-    // Sync insert so the read-back in the same test sees the row immediately.
-    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
-  });
-}
 
 /**
  * Builds a SpanReceived domain Event whose `langwatch.input` carries `value`.
@@ -242,22 +183,6 @@ function makeLogRecordReceivedEvent({
       attributes: {},
     },
   } as unknown as Event;
-}
-
-/** Reads span attributes out of a leaned SpanReceived event into a string map. */
-function extractSpanAttrs(event: Event): Record<string, string> {
-  const data = event.data as {
-    span?: {
-      attributes?: Array<{ key: string; value: { stringValue?: string } }>;
-    };
-  };
-  const attrs: Record<string, string> = {};
-  for (const attr of data?.span?.attributes ?? []) {
-    if (typeof attr.value.stringValue === "string") {
-      attrs[attr.key] = attr.value.stringValue;
-    }
-  }
-  return attrs;
 }
 
 /** Builds a NormalizedSpan carrying the supplied (leaned) attribute map. */

--- a/langwatch/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts
@@ -24,13 +24,20 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
+  AGGREGATE_TYPE,
+  assertOverThreshold,
+  extractSpanAttrs,
+  insertEventLogRow,
+  LARGE_VALUE,
+  UNIQUE_TAIL,
+} from "~/server/app-layer/traces/__tests__/blob-offload-test-helpers";
+import {
   EVENTREF_ATTR_PREFIX,
   IO_PREVIEW_BYTES,
   leanForProjection,
 } from "~/server/app-layer/traces/lean-for-projection";
 import * as clickhouseClientModule from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
-import type { Protections } from "~/server/elasticsearch/protections";
 import type { Event } from "~/server/event-sourcing";
 import {
   startTestContainers,
@@ -42,6 +49,7 @@ import {
   SPAN_RECEIVED_EVENT_VERSION_LATEST,
 } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
 import type { Span, Trace } from "~/server/tracer/types";
+import { openProtections } from "~/server/traces/__tests__/open-protections";
 import { TraceService } from "~/server/traces/trace.service";
 import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
 
@@ -67,36 +75,9 @@ vi.mock("~/server/clickhouse/clickhouseClient", async (importOriginal) => ({
   isClickHouseEnabled: () => true,
 }));
 
-const AGGREGATE_TYPE = "trace";
-
 /** The IO fields the matrix covers; each is leaned + offloaded independently. */
 const IO_FIELDS = ["langwatch.input", "langwatch.output"] as const;
 type IoField = (typeof IO_FIELDS)[number];
-
-/**
- * A 200 KB deterministic payload whose final bytes only exist past the 64 KB
- * preview boundary. The preview is `value.slice(0, 64KB) + "…"`, so it can NEVER
- * contain UNIQUE_TAIL — a preview-only read fails the tail assertion.
- */
-const UNIQUE_TAIL = "__OFFLOAD_FULL_VALUE_TAIL_MARKER__";
-const LARGE_VALUE = "x".repeat(200_000) + UNIQUE_TAIL;
-
-/**
- * Permissive protections that allow all content categories to be visible, so the
- * read mappers never redact the IO value out from under the assertions. Mirrors
- * `openProtections` in clickhouse-trace-dedup.integration.test.ts; the shape is
- * verified against the current `Protections` type (all fields optional).
- */
-const openProtections: Protections = {
-  canSeeCosts: true,
-  canSeeCapturedInput: true,
-  canSeeCapturedOutput: true,
-};
-
-/** Sanity: the payload genuinely exceeds the offload threshold. */
-function assertOverThreshold(value: string): void {
-  expect(Buffer.byteLength(value, "utf-8")).toBeGreaterThan(IO_PREVIEW_BYTES);
-}
 
 /**
  * Builds a SpanReceived domain Event whose IO field (`langwatch.input` or
@@ -162,70 +143,6 @@ function makeSpanReceivedEvent({
       instrumentationScope: { name: "test" },
     },
   } as unknown as Event;
-}
-
-/** Reads span attributes out of a leaned SpanReceived event into a string map. */
-function extractSpanAttrs(event: Event): Record<string, string> {
-  const data = event.data as {
-    span?: {
-      attributes?: Array<{ key: string; value: { stringValue?: string } }>;
-    };
-  };
-  const attrs: Record<string, string> = {};
-  for (const attr of data?.span?.attributes ?? []) {
-    if (typeof attr.value.stringValue === "string") {
-      attrs[attr.key] = attr.value.stringValue;
-    }
-  }
-  return attrs;
-}
-
-/**
- * Inserts ONE full event_log row, exactly as the production write path stores it
- * (`EventPayload` IS `event.data`). Mirrors the canonical event_log test idiom —
- * JSONEachRow with a stringified payload — and stamps `_retention_days: 0`
- * (never-expire sentinel, test-only) so a merge-cycle TTL can't evict the fixture
- * mid-run.
- */
-async function insertEventLogRow({
-  client,
-  tenantId,
-  aggregateId,
-  eventId,
-  eventType,
-  eventVersion,
-  eventData,
-}: {
-  client: ClickHouseClient;
-  tenantId: string;
-  aggregateId: string;
-  eventId: string;
-  eventType: string;
-  eventVersion: string;
-  eventData: unknown;
-}): Promise<void> {
-  const ts = Date.now();
-  await client.insert({
-    table: "event_log",
-    values: [
-      {
-        TenantId: tenantId,
-        AggregateType: AGGREGATE_TYPE,
-        AggregateId: aggregateId,
-        EventId: eventId,
-        EventType: eventType,
-        EventVersion: eventVersion,
-        EventTimestamp: ts,
-        EventOccurredAt: ts,
-        EventPayload: JSON.stringify(eventData),
-        IdempotencyKey: eventId,
-        _retention_days: 0,
-      },
-    ],
-    format: "JSONEachRow",
-    // Sync insert so the read-back in the same test sees the row immediately.
-    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
-  });
 }
 
 /**

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-dedup.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-dedup.integration.test.ts
@@ -15,8 +15,8 @@ import {
   stopTestContainers,
 } from "../../event-sourcing/__tests__/integration/testContainers";
 import { ClickHouseTraceService } from "../clickhouse-trace.service";
-import type { Protections } from "../../elasticsearch/protections";
 import type { GetAllTracesForProjectInput } from "../types";
+import { openProtections } from "./open-protections";
 
 const tenantId = `test-trace-dedup-${nanoid()}`;
 const now = Date.now();
@@ -125,15 +125,6 @@ async function insertSpan(
     clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
   });
 }
-
-/**
- * Permissive protections that allow all fields to be visible.
- */
-const openProtections: Protections = {
-  canSeeCosts: true,
-  canSeeCapturedInput: true,
-  canSeeCapturedOutput: true,
-};
 
 /**
  * Helper to build a valid GetAllTracesForProjectInput with defaults.

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-field-names.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-field-names.integration.test.ts
@@ -17,7 +17,7 @@ import {
   stopTestContainers,
 } from "../../event-sourcing/__tests__/integration/testContainers";
 import { ClickHouseTraceService } from "../clickhouse-trace.service";
-import type { Protections } from "../../elasticsearch/protections";
+import { openProtections } from "./open-protections";
 
 const tenantId = `test-field-names-${nanoid()}`;
 const now = Date.now();
@@ -151,12 +151,6 @@ async function insertEvaluationRuns(
     clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
   });
 }
-
-const openProtections: Protections = {
-  canSeeCosts: true,
-  canSeeCapturedInput: true,
-  canSeeCapturedOutput: true,
-};
 
 // A list large enough to blow past the historical 1000 / 200 caps.
 const LARGE_NAME_COUNT = 1500;

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-updated-axis.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-updated-axis.integration.test.ts
@@ -22,7 +22,6 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
 import { prisma } from "~/server/db";
-import type { Protections } from "../../elasticsearch/protections";
 import {
   startTestContainers,
   stopTestContainers,
@@ -32,6 +31,7 @@ import type {
   GetAllTracesForProjectInput,
   TracesForProjectResult,
 } from "../types";
+import { openProtections } from "./open-protections";
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
   getClickHouseClientForProject: vi.fn(),
@@ -48,12 +48,6 @@ const tenantId = `test-updated-axis-${nanoid()}`;
 const now = Date.now();
 const SECOND = 1000;
 const ONE_DAY = 24 * 60 * 60 * 1000;
-
-const openProtections: Protections = {
-  canSeeCosts: true,
-  canSeeCapturedInput: true,
-  canSeeCapturedOutput: true,
-};
 
 // Distinct traces, each inserted as MULTIPLE versions (same TraceId, same
 // OccurredAt, increasing UpdatedAt) — exactly what re-ingestion / late

--- a/langwatch/src/server/traces/__tests__/open-protections.ts
+++ b/langwatch/src/server/traces/__tests__/open-protections.ts
@@ -1,0 +1,12 @@
+import type { Protections } from "~/server/elasticsearch/protections";
+
+/**
+ * Permissive protections that allow all content categories to be visible, so the
+ * read mappers never redact IO values out from under the assertions in the
+ * ClickHouse trace read-path tests.
+ */
+export const openProtections: Protections = {
+  canSeeCosts: true,
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+};

--- a/langwatch/src/server/traces/__tests__/projection-search.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/projection-search.integration.test.ts
@@ -34,6 +34,7 @@ import {
   type ProjectionFrom,
 } from "../projection";
 import type { GetAllTracesForProjectInput } from "../types";
+import { openProtections } from "./open-protections";
 
 const tenantId = `test-projection-${nanoid()}`;
 const traceId = `trace-projection-${nanoid()}`;
@@ -42,12 +43,6 @@ const traceId = `trace-projection-${nanoid()}`;
 const lateTraceId = `trace-late-${nanoid()}`;
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const now = Date.now();
-
-const openProtections: Protections = {
-  canSeeCosts: true,
-  canSeeCapturedInput: true,
-  canSeeCapturedOutput: true,
-};
 
 function makeTraceSummaryRow(overrides: Record<string, unknown> = {}) {
   return {


### PR DESCRIPTION
## Ticket

Closes #4987. Blob-offload trace read-path tests duplicate fixture helpers verbatim across files, so the ClickHouse row/event shapes live in several places and a schema change must be applied N times (violates the repo's reuse-first rule).

## Premise re-check (still holds on current main)

Verified against `origin/main` (`27b6c0c`): the duplication is still present. No open PR addresses it. PROCEED.

## Change

Behavior-preserving, test-only consolidation, scoped to what is provably safe:

- **New `blob-offload-test-helpers.ts`** exports the six helpers that are byte-identical across the two primary files (`trace-detail-blob-recall-endpoint` and `large-trace-blob-offload-readpath`): `AGGREGATE_TYPE`, `UNIQUE_TAIL`, `LARGE_VALUE`, `assertOverThreshold`, `insertEventLogRow`, `extractSpanAttrs`. Both files now import them and drop their local copies.
- **New `open-protections.ts`** exports the `openProtections` constant, verified byte-identical across all five sites (recall, `clickhouse-trace-dedup`, `clickhouse-trace-updated-axis`, `clickhouse-trace-field-names`, `projection-search`); all five now import it.

### Deliberately left un-consolidated (to avoid silent behavior drift)

- `makeSpanReceivedEvent` diverges by file (the recall version parameterizes the IO field via `{ ioField, ioValue }`; the readpath version hardcodes `langwatch.input` via `{ inputValue }`; two other files have their own simpler variants and a different `LARGE_VALUE` size). Merging these would change fixture semantics, so each stays local.
- The `insertTraceSummary`/`insertSpan`/`makeTraceSummaryRow`/`makeSpanRow` family overlaps cross-directory (`src/server/traces/__tests__`) with real ClickHouse-row-shape drift risk; not forced into this PR.

Only helpers proven identical were merged; nothing else was touched.

## Evidence

- **Integration slice (all 6 rewired files, one run):** `Test Files 6 passed (6)`, `Tests 39 passed (39)`, ~10.6s (testcontainers spin up ClickHouse + Redis). The WARN lines are the expected AC5 "event_log row absent" path, not failures. Passing behavior-sensitive integration tests after the rewire is the proof the extraction is behavior-preserving.
- **Typecheck:** `pnpm typecheck` clean.
- **Biome:** the new/changed files check clean (no fixes applied), so reviewdog will not flag the changed lines.

## Advisory note

Advisory PR from the tech-debt-fixer bot, opened for human review, not to be merged by the bot. The human makes the merge call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared test setup for trace-related scenarios, reducing repeated logic across the codebase.
  * Standardized a common permissive trace-visibility configuration for several test paths.
  * Improved consistency in how large trace payloads and span attributes are prepared for integration coverage.

* **Tests**
  * Updated trace integration tests to use shared helpers, making them easier to maintain and more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->