### PR TITLE
fix(experiments-v3): 500 on repeated workflow evaluate calls

### DIFF
--- a/langwatch/src/app/api/workflows/__tests__/workflows-api.integration.test.ts
+++ b/langwatch/src/app/api/workflows/__tests__/workflows-api.integration.test.ts
@@ -408,7 +408,6 @@ describe("Workflows REST API", () => {
         expect(body.run_url).toContain(`/experiments/${experiment!.slug}`);
       });
 
-      /** @scenario "Evaluating the same workflow twice reuses the existing experiment" */
       it("succeeds on a second evaluate call against the same workflow", async () => {
         await createVersion("1", entryDsl());
 

--- a/langwatch/src/app/api/workflows/__tests__/workflows-api.integration.test.ts
+++ b/langwatch/src/app/api/workflows/__tests__/workflows-api.integration.test.ts
@@ -408,6 +408,31 @@ describe("Workflows REST API", () => {
         expect(body.run_url).toContain(`/experiments/${experiment!.slug}`);
       });
 
+      /** @scenario "Evaluating the same workflow twice reuses the existing experiment" */
+      it("succeeds on a second evaluate call against the same workflow", async () => {
+        await createVersion("1", entryDsl());
+
+        const first = await postEvaluate(
+          `/api/workflows/${workflow.id}/evaluate`,
+        );
+        const firstBody = await expectRunResponse(first);
+
+        const second = await postEvaluate(
+          `/api/workflows/${workflow.id}/evaluate`,
+        );
+        const secondBody = await expectRunResponse(second);
+
+        expect(secondBody.run_id).not.toBe(firstBody.run_id);
+        const experiments = await prisma.experiment.findMany({
+          where: {
+            projectId: testProjectId,
+            workflowId: workflow.id,
+            type: "EVALUATIONS_V3",
+          },
+        });
+        expect(experiments).toHaveLength(1);
+      });
+
       /** @scenario "The response stays backward compatible" */
       it("still returns the evaluated version id and version", async () => {
         const version = await createVersion("1", entryDsl());

--- a/langwatch/src/server/experiments/experiment.repository.ts
+++ b/langwatch/src/server/experiments/experiment.repository.ts
@@ -182,25 +182,6 @@ export class ExperimentRepository {
     );
   }
 
-  async upsert(
-    input: {
-      id: string;
-      projectId: string;
-      data: Prisma.ExperimentUpdateInput;
-    },
-    options?: { tx?: Prisma.TransactionClient },
-  ): Promise<Experiment> {
-    const client = options?.tx ?? this.prisma;
-    return await client.experiment.upsert({
-      where: { id: input.id, projectId: input.projectId },
-      update: input.data,
-      create: {
-        ...(input.data as Prisma.ExperimentUncheckedCreateInput),
-        id: input.id,
-      },
-    });
-  }
-
   async upsertById(
     input: {
       id: string;

--- a/langwatch/src/server/experiments/experiment.service.ts
+++ b/langwatch/src/server/experiments/experiment.service.ts
@@ -157,7 +157,7 @@ export class ExperimentService {
     });
 
     if (existing) {
-      await this.repository.upsert({
+      await this.repository.updateById({
         id: existing.id,
         projectId,
         data: { workbenchState: workbenchStateJson },


### PR DESCRIPTION
## Summary
- `POST /api/workflows/:id/evaluate` 500s with `PrismaClientValidationError: Argument type is missing` on every evaluate call after the first for a given workflow.
- Root cause: `ExperimentService.findOrCreateForWorkflow`'s "existing experiment" branch called the generic `ExperimentRepository.upsert` with only `{ workbenchState }`. That method builds Prisma's `create:` object from the same partial data via an unsafe type cast, so `create:` ends up missing required fields (`type`, `projectId`, `name`, `slug`). Prisma validates the entire upsert call — including the unused `create` branch — before executing, so the call fails structurally regardless of which branch would actually run.
- The row is already confirmed to exist at that point, so this was always meant to be an update. Swapped to `updateById`. That was the last caller of the generic `upsert`, so deleted it too — its unsafe cast is a footgun for the next caller.
- Regression from #4946 (unify workflow evaluation onto the evaluations-v3 pipeline), shipped without a test that re-evaluates the same workflow twice.

## Test plan
- [x] Added a regression test (`succeeds on a second evaluate call against the same workflow`) that reproduces the crash: confirmed it fails with the reported 500/Prisma error against the old code, passes after the fix
- [x] `pnpm test:integration` — full `workflows-api.integration.test.ts` suite (19/19) and `experiment-slug-deduplication.integration.test.ts` (5/5) pass
- [x] `pnpm typecheck` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-evaluating the same workflow now keeps a single evaluation experiment per workflow/project, preventing duplicate experiment records.
  * Each evaluation still produces a new `run_id` while reusing the existing experiment entry.

* **Tests**
  * Added an integration test for `POST /api/workflows/:id/evaluate` to verify repeated evaluations succeed, return different `run_id`s, and result in only one `EVALUATIONS_V3` experiment record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->