### PR TITLE
fix(drawers): flushSync drawer navigations so they actually render

### DIFF
--- a/langwatch/src/components/CurrentDrawer.tsx
+++ b/langwatch/src/components/CurrentDrawer.tsx
@@ -61,7 +61,9 @@ export function CurrentDrawer({ marginTop }: { marginTop?: number }) {
       .getState()
       .openLiteMemberRestriction({ resource: restrictedResource });
 
-    // Clear drawer from URL so it doesn't persist in browser history
+    // Clear drawer from URL so it doesn't persist in browser history.
+    // flushSync: see useDrawer.ts closeDrawer for why plain push can leave
+    // this update uncommitted.
     void router.push(
       "?" +
         qs.stringify(
@@ -72,7 +74,7 @@ export function CurrentDrawer({ marginTop }: { marginTop?: number }) {
           ),
         ),
       undefined,
-      { shallow: true },
+      { shallow: true, flushSync: true },
     );
   }, [isRestricted]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -131,7 +133,7 @@ export function CurrentDrawer({ marginTop }: { marginTop?: number }) {
                 ),
               ),
             undefined,
-            { shallow: true },
+            { shallow: true, flushSync: true },
           );
         }}
       >

--- a/langwatch/src/hooks/__tests__/useDrawer.test.tsx
+++ b/langwatch/src/hooks/__tests__/useDrawer.test.tsx
@@ -101,6 +101,24 @@ describe("useDrawer", () => {
       expect(mockPush).not.toHaveBeenCalled();
     });
 
+    it("navigates with flushSync so a first-time-lazy drawer actually renders", () => {
+      // Drawers are React.lazy() behind a single Suspense boundary
+      // (CurrentDrawer.tsx). Without flushSync, React Router's default
+      // startTransition wrap hides a first-time suspend behind the
+      // previously committed UI — the URL changes but nothing renders.
+      const { result } = renderHook(() => useDrawer());
+
+      act(() => {
+        result.current.openDrawer("promptList");
+      });
+
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.any(String),
+        undefined,
+        expect.objectContaining({ flushSync: true }),
+      );
+    });
+
     it("builds drawer stack on navigation", () => {
       mockQuery = { "drawer.open": "targetTypeSelector" };
       const { result } = renderHook(() => useDrawer());
@@ -143,6 +161,21 @@ describe("useDrawer", () => {
       expect(mockPush).toHaveBeenCalled();
       const pushCall = mockPush.mock.calls[0]?.[0] as string;
       expect(pushCall).not.toContain("drawer");
+    });
+
+    it("navigates with flushSync so the closed state actually commits", () => {
+      mockQuery = { "drawer.open": "promptList" };
+      const { result } = renderHook(() => useDrawer());
+
+      act(() => {
+        result.current.closeDrawer();
+      });
+
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.any(String),
+        undefined,
+        expect.objectContaining({ flushSync: true }),
+      );
     });
 
     it("clears the drawer stack", () => {

--- a/langwatch/src/hooks/useDrawer.ts
+++ b/langwatch/src/hooks/useDrawer.ts
@@ -347,10 +347,16 @@ export const useDrawer = () => {
         },
       );
 
+      // flushSync: drawers are React.lazy() (see drawerRegistry.ts) and this
+      // update mounts one for the first time in the session more often than
+      // not. Left under React Router's default startTransition wrap, a
+      // first-time Suspense would keep the previously committed UI on
+      // screen instead of showing the fallback — the URL changes but the
+      // drawer never appears until something else forces a re-render.
       void router[options.replace ? "replace" : "push"](
         buildUrl(path, newQuery, hash),
         undefined,
-        { shallow: true },
+        { shallow: true, flushSync: true },
       );
     },
     [router],
@@ -494,8 +500,11 @@ export const useDrawer = () => {
       allowEmptyArrays: true,
     });
 
+    // flushSync: see updateDrawerUrl above — same startTransition/Suspense
+    // interaction can leave the closed-drawer state uncommitted.
     void router.push(buildUrl(path, newQueryString, hash), undefined, {
       shallow: true,
+      flushSync: true,
     });
   }, [router]);
 

--- a/langwatch/src/hooks/useDrawer.ts
+++ b/langwatch/src/hooks/useDrawer.ts
@@ -133,10 +133,13 @@ export const navigateToDrawer = (
     "drawer.open": drawer,
   };
 
+  // flushSync: same startTransition/Suspense interaction as updateDrawerUrl
+  // in useDrawer() below — this is the module-level equivalent, used to open
+  // a drawer from code that isn't necessarily mounted (flow callbacks).
   void Router.push(
     "?" + qs.stringify(newQuery, { allowDots: true, arrayFormat: "comma" }),
     undefined,
-    { shallow: true },
+    { shallow: true, flushSync: true },
   );
 };
 
@@ -187,7 +190,15 @@ export const useUpdateDrawerParams = () => {
         allowEmptyArrays: true,
       });
       const url = buildUrl(path, newQs, hash);
-      void router[push ? "push" : "replace"](url, undefined, { shallow: true });
+      // flushSync: same startTransition/Suspense interaction as
+      // updateDrawerUrl — this doesn't usually mount a new lazy drawer
+      // (drawer.open is untouched), but keep it consistent with the rest
+      // of the drawer navigation surface rather than leave a third,
+      // differently-behaved push/replace pattern in this file.
+      void router[push ? "push" : "replace"](url, undefined, {
+        shallow: true,
+        flushSync: true,
+      });
     },
     [router],
   );

--- a/langwatch/src/main.tsx
+++ b/langwatch/src/main.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import { RouterProvider } from "react-router";
+import { RouterProvider } from "react-router/dom";
 import { router } from "./routes";
 import { OuterProviders } from "./AppProviders";
 import { setRouterInstance } from "./utils/compat/next-router";

--- a/langwatch/src/utils/compat/next-router.ts
+++ b/langwatch/src/utils/compat/next-router.ts
@@ -293,12 +293,19 @@ export function buildUrl(
  * Mimics Next.js `Router` default export.
  * Must be kept in sync with the current URL state.
  */
+type ImperativeRouter = {
+  navigate: (
+    to: string,
+    opts?: { replace?: boolean; flushSync?: boolean },
+  ) => void;
+};
+
 /**
  * Set by main.tsx after router is created. Enables imperative navigation
  * from module-level code (e.g. navigateToDrawer in useDrawer.ts).
  */
-let _routerInstance: { navigate: (to: string) => void } | null = null;
-export function setRouterInstance(r: { navigate: (to: string) => void }) {
+let _routerInstance: ImperativeRouter | null = null;
+export function setRouterInstance(r: ImperativeRouter) {
   _routerInstance = r;
 }
 
@@ -340,7 +347,10 @@ class RouterSingleton {
   ): Promise<boolean> {
     const target = _as ?? buildUrl(url);
     if (_routerInstance) {
-      _routerInstance.navigate(target);
+      _routerInstance.navigate(target, {
+        replace: false,
+        flushSync: options?.flushSync,
+      });
     } else {
       window.history.pushState({}, "", target);
       window.dispatchEvent(new PopStateEvent("popstate"));
@@ -358,7 +368,10 @@ class RouterSingleton {
   ): Promise<boolean> {
     const target = _as ?? buildUrl(url);
     if (_routerInstance) {
-      _routerInstance.navigate(target);
+      _routerInstance.navigate(target, {
+        replace: true,
+        flushSync: options?.flushSync,
+      });
     } else {
       window.history.replaceState({}, "", target);
       window.dispatchEvent(new PopStateEvent("popstate"));

--- a/langwatch/src/utils/compat/next-router.ts
+++ b/langwatch/src/utils/compat/next-router.ts
@@ -128,6 +128,13 @@ interface NextRouterOptions {
   shallow?: boolean;
   scroll?: boolean;
   locale?: string;
+  // Forces the navigation's state update through ReactDOM.flushSync instead
+  // of React Router's default startTransition wrap. Needed for navigations
+  // that mount a first-time React.lazy() component (e.g. opening a drawer):
+  // under startTransition, a Suspense boundary suspending for the first time
+  // keeps the previously committed UI on screen instead of showing the
+  // fallback, so the update appears to silently do nothing.
+  flushSync?: boolean;
 }
 
 type EventHandler = (...args: any[]) => void;
@@ -455,7 +462,7 @@ export function useRouter(): CompatRouter {
         // The `as` string is the actual browser URL; `url` is the internal route
         // descriptor which may contain [param] placeholders.
         const target = _as ?? buildUrl(url, routeParamKeys, location.pathname);
-        navigate(target, { replace: false });
+        navigate(target, { replace: false, flushSync: options?.flushSync });
         if (options?.scroll !== false) {
           window.scrollTo(0, 0);
         }
@@ -463,7 +470,7 @@ export function useRouter(): CompatRouter {
       },
       replace: (url, _as?, options?) => {
         const target = _as ?? buildUrl(url, routeParamKeys, location.pathname);
-        navigate(target, { replace: true });
+        navigate(target, { replace: true, flushSync: options?.flushSync });
         if (options?.scroll !== false) {
           window.scrollTo(0, 0);
         }


### PR DESCRIPTION
## Summary
- Opening a drawer (e.g. "+ Add" on Prompts or Agents, or navigating between drawers such as clicking "Evaluator" inside "Add to Evaluation") updated the URL but the drawer never visually appeared — until something else forced a re-render. A hard refresh "fixed" it (until the next fresh drawer type).
- Closing had the mirror-image symptom: Cancel/X updated the URL to strip `drawer.open`, but the drawer stayed open on screen.
- Root cause: every drawer is `React.lazy()` (#3243, "perf: lazy-load drawer registry, 4.3MB → 232KB") rendered inside one `Suspense` boundary in `CurrentDrawer`. React Router v7's `RouterProvider` wraps every navigation's state update in `React.startTransition` by default. Under React 18 semantics, when a transition-wrapped update causes a Suspense boundary to suspend for the *first time*, React keeps the previously committed UI on screen instead of showing the fallback — so the first-time-this-session mount (or unmount) of a lazy drawer silently does nothing until an unrelated re-render happens to resolve it.
- Fix: thread `flushSync` through drawer navigations (open, close, and the two URL-cleanup paths in `CurrentDrawer`), forcing `ReactDOM.flushSync` instead of `startTransition` for these specific updates. `flushSync` requires `RouterProvider` from `"react-router/dom"` (it's a documented no-op otherwise) — swapped in `main.tsx`.

## Test plan
- [x] `pnpm typecheck` clean
- [x] Verified live in dev: "+ Add" on Prompts or Agents now opens "Add to Evaluation" immediately (no refresh needed); clicking "Evaluator" inside it navigates to the evaluator list drawer immediately; Cancel/X now closes the drawer immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drawer open/close reliability by ensuring immediate UI commitment after URL updates (including lazy-loaded drawer content).
  * Cleared drawer-related URL state more consistently for restricted users and error fallbacks to prevent stale drawer views.
* **New Features**
  * Added a `flushSync` navigation option to the Next.js compatibility layer and forwarded it through router navigations.
* **Tests**
  * Added assertions verifying drawer navigation calls include `flushSync: true`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->