### PR TITLE
fix(langy): temporarily restrict prod access to aryan@langwatch.ai

### DIFF
--- a/langwatch/src/utils/isLangwatchStaff.ts
+++ b/langwatch/src/utils/isLangwatchStaff.ts
@@ -9,7 +9,18 @@
  * feature flag. SSO/OAuth providers (Google, Auth0, GitHub, ...) assert
  * verification on the user's behalf, so `emailVerified` is already true
  * before the session is minted.
+ *
+ * In production, Langy is temporarily further restricted to a single
+ * allowlisted email while the feature is being hardened (see
+ * LANGY_PROD_ALLOWLIST) — non-production environments (dev, staging,
+ * self-hosted) keep the full @langwatch.ai staff bypass so the team can
+ * keep testing locally.
  */
+
+// Temporary production lockdown while Langy is being hardened. Widen or
+// remove once the feature is stable enough for the whole team again.
+const LANGY_PROD_ALLOWLIST = new Set(["aryan@langwatch.ai"]);
+
 export function isLangwatchStaff(
   user:
     | {
@@ -21,5 +32,9 @@ export function isLangwatchStaff(
 ): boolean {
   if (!user?.email) return false;
   if (!user.emailVerified) return false;
-  return user.email.trim().toLowerCase().endsWith("@langwatch.ai");
+  const email = user.email.trim().toLowerCase();
+  if (process.env.NODE_ENV === "production") {
+    return LANGY_PROD_ALLOWLIST.has(email);
+  }
+  return email.endsWith("@langwatch.ai");
 }


### PR DESCRIPTION
## Summary
- Langy's production gate — `isLangwatchStaff()` — currently lets in *any* `@langwatch.ai` account. It's the sole bypass used by both the client gate (`ProjectLangyLayout.tsx`) and the server gate (`routes/langy.ts`, `routes/github-langy.ts`), so it's a single, low-blast-radius choke point.
- While investigating the "Add Comparison" bug in the experiments workbench today, found a separate real bug: an infinite render loop caused by how the workbench registers its Langy proposal handlers (fix coming in a follow-up PR). Until that's landed and Langy's had a bit more soak time, narrow production access to a single allowlisted email (`aryan@langwatch.ai`) so nobody else runs into in-progress issues.
- Non-production environments (dev, staging, self-hosted) are untouched — the full `@langwatch.ai` staff bypass still applies there, so the team can keep testing locally.
- This is intended to be temporary; widen or remove `LANGY_PROD_ALLOWLIST` once Langy is stable enough for the whole team again.

## Test plan
- [x] `pnpm typecheck` clean
- [x] Confirmed `isLangwatchStaff` has no other call sites besides the three Langy files (`langy.ts`, `github-langy.ts`, `ProjectLangyLayout.tsx`) and one doc-comment reference in the feature-flag registry — safe to narrow its production behavior directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened staff access checks in production to only allow approved email addresses.
  * Standardized email handling by trimming spaces and ignoring letter case before validation.
  * Kept non-production behavior unchanged for verified company email addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->