### PR TITLE
fix(langy): stop proposal-handler registration from looping the workbench

### DIFF
--- a/langwatch/src/components/langy/LangyContext.tsx
+++ b/langwatch/src/components/langy/LangyContext.tsx
@@ -1,10 +1,12 @@
 import {
   createContext,
   type ReactNode,
+  type RefObject,
   useCallback,
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import type { ProposalHandlers } from "./MessageContent";
@@ -12,7 +14,12 @@ import type { ProposalHandlers } from "./MessageContent";
 interface LangyContextValue {
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
-  proposalHandlers: ProposalHandlers;
+  // A ref, not state: pages re-derive their handlers object on most
+  // renders (see useRegisterLangyHandlers), and Langy only ever needs the
+  // latest value at proposal-click time, never during render. Storing it
+  // as state fed registration straight back into a render loop — register
+  // -> setState -> re-render -> new handlers object -> register -> ...
+  proposalHandlersRef: RefObject<ProposalHandlers>;
   experimentSlug: string | undefined;
   registerHandlers: (
     handlers: ProposalHandlers,
@@ -25,21 +32,19 @@ const LangyContext = createContext<LangyContextValue | null>(null);
 
 export function LangyProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
-  const [proposalHandlers, setProposalHandlers] = useState<ProposalHandlers>(
-    {},
-  );
+  const proposalHandlersRef = useRef<ProposalHandlers>({});
   const [experimentSlug, setExperimentSlug] = useState<string | undefined>();
 
   const registerHandlers = useCallback(
     (handlers: ProposalHandlers, opts?: { experimentSlug?: string }) => {
-      setProposalHandlers(handlers);
+      proposalHandlersRef.current = handlers;
       setExperimentSlug(opts?.experimentSlug);
     },
     [],
   );
 
   const clearHandlers = useCallback(() => {
-    setProposalHandlers({});
+    proposalHandlersRef.current = {};
     setExperimentSlug(undefined);
   }, []);
 
@@ -47,12 +52,12 @@ export function LangyProvider({ children }: { children: ReactNode }) {
     () => ({
       isOpen,
       setIsOpen,
-      proposalHandlers,
+      proposalHandlersRef,
       experimentSlug,
       registerHandlers,
       clearHandlers,
     }),
-    [isOpen, proposalHandlers, experimentSlug, registerHandlers, clearHandlers],
+    [isOpen, experimentSlug, registerHandlers, clearHandlers],
   );
 
   return (

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -10,7 +10,14 @@ import {
 } from "@chakra-ui/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
 import { ChevronsRight, Plus, Sparkles, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { isLangyManagedVk } from "~/components/gateway/langyVk";
 import { allModelOptions } from "~/components/ModelSelector";
 import { Kbd } from "~/components/ops/shared/Kbd";
@@ -65,14 +72,14 @@ export const LANGY_DOCKED_OFFSET = PANEL_WIDTH;
 export const LANGY_TRANSITION = "240ms cubic-bezier(0.32, 0.72, 0, 1)";
 
 interface LangyDrawerProps {
-  proposalHandlers?: ProposalHandlers;
+  proposalHandlersRef?: RefObject<ProposalHandlers>;
   experimentSlug?: string;
   isOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
 
 export function LangyDrawer({
-  proposalHandlers,
+  proposalHandlersRef,
   experimentSlug,
   isOpen: isOpenProp,
   onOpenChange,
@@ -97,7 +104,7 @@ export function LangyDrawer({
       <LangyPanel
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
-        proposalHandlers={proposalHandlers}
+        proposalHandlersRef={proposalHandlersRef}
         experimentSlug={experimentSlug}
       />
     </>
@@ -197,12 +204,12 @@ function LangyHandle({
 function LangyPanel({
   isOpen,
   onClose,
-  proposalHandlers,
+  proposalHandlersRef,
   experimentSlug,
 }: {
   isOpen: boolean;
   onClose: () => void;
-  proposalHandlers?: ProposalHandlers;
+  proposalHandlersRef?: RefObject<ProposalHandlers>;
   experimentSlug?: string;
 }) {
   const { organization, project } = useOrganizationTeamProject();
@@ -448,7 +455,7 @@ function LangyPanel({
     if (applyingProposals.has(proposalId)) return;
     if (proposalId in appliedOutcomes) return;
     if (discardedProposals.has(proposalId)) return;
-    const handler = proposalHandlers?.[proposal.kind];
+    const handler = proposalHandlersRef?.current?.[proposal.kind];
     if (!handler) {
       toaster.create({
         title: "Cannot apply",

--- a/langwatch/src/components/langy/ProjectLangyLayout.tsx
+++ b/langwatch/src/components/langy/ProjectLangyLayout.tsx
@@ -118,12 +118,12 @@ function LangyShiftedRoot({
 }
 
 function LangyDrawerConnected() {
-  const { isOpen, setIsOpen, proposalHandlers, experimentSlug } = useLangy();
+  const { isOpen, setIsOpen, proposalHandlersRef, experimentSlug } = useLangy();
   return (
     <LangyDrawer
       isOpen={isOpen}
       onOpenChange={setIsOpen}
-      proposalHandlers={proposalHandlers}
+      proposalHandlersRef={proposalHandlersRef}
       experimentSlug={experimentSlug}
     />
   );


### PR DESCRIPTION
## Summary
- Found while investigating the "Add Comparison" bug in the experiments workbench (see #5277): visiting any experiments workbench page and adding a target triggers an infinite render loop — the console repeats `Maximum update depth exceeded` forever after the autosave (`experiments.saveEvaluationsV3`) resolves.
- Root cause: `workbench/[slug].tsx` builds a `proposalHandlers` object (its Langy action menu) via `useMemo` with several tRPC mutation/utils objects as dependencies that don't have stable identity across renders, so the object is effectively new on most renders. `useRegisterLangyHandlers` has `handlers` in its effect's dependency array, so it fires every time and calls `registerHandlers` → `setProposalHandlers` (React **state**) inside `LangyProvider`. That state update re-renders the whole subtree under the provider — including the workbench page itself — which produces a new `proposalHandlers` object again. Loop.
- This isn't gated by Langy access — `LangyProvider` always wraps page content regardless of who can see the panel (only the visible chat UI is conditionally rendered), so this fires for **every** user on the workbench page, not just Langy users.
- Fix: `proposalHandlers` never needed to be React state — every consumer (`LangySidebar`'s `applyProposal`) only reads it at proposal-click time, never during render. Store it in a `ref` instead. Registering a new handlers object no longer triggers a re-render, so the loop can't start. `experimentSlug` stays as state since it *is* rendered (the "On: `<slug>`" panel subtitle).

## Test plan
- [x] `pnpm typecheck` clean
- [x] Verified live: navigated to a fresh experiments workbench, added two prompt targets (triggering the autosave mutation twice), watched the browser console for 6+ seconds after each save — 0 errors, vs. the repeating `Maximum update depth exceeded` before this fix.
- [x] Confirmed the Langy proposal-apply flow (`applyProposal` reading `proposalHandlersRef.current`) still type-checks correctly through `LangyDrawer` → `LangyPanel`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proposal handling in the Langy sidebar by switching to a ref-based handler flow, improving reliability when opening and applying suggestions.
  * Fixed cases where “no handler” behavior could be triggered incorrectly, helping proposals apply more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->