### PR TITLE
fix(langy): preflight health check before reserving a PR permit

### DIFF
--- a/langwatch/src/server/routes/__tests__/langy-connect-card.test.ts
+++ b/langwatch/src/server/routes/__tests__/langy-connect-card.test.ts
@@ -246,12 +246,15 @@ describe("POST /api/langy/chat — unconnected user asks for a PR", () => {
     expect(res.status).toBe(200);
 
     // (a) The credentials forwarded to the agent carry NO github token. Read
-    // the actual body the route POSTed to the agent /chat endpoint.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [agentUrl, agentInit] = fetchMock.mock.calls[0] as [
-      string,
-      { body: string },
-    ];
+    // the actual body the route POSTed to the agent /chat endpoint. The route
+    // also preflights a GET to /health before this — same mock, since it
+    // returns 200 for any URL — so pick out the /chat call specifically
+    // rather than assuming call order.
+    const chatCall = fetchMock.mock.calls.find(
+      ([url]) => url === "http://agent.test/chat",
+    ) as [string, { body: string }] | undefined;
+    expect(chatCall).toBeDefined();
+    const [agentUrl, agentInit] = chatCall!;
     expect(agentUrl).toBe("http://agent.test/chat");
     const forwarded = JSON.parse(agentInit.body) as {
       credentials: Record<string, unknown>;

--- a/langwatch/src/server/routes/__tests__/langy-github-prs.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/langy-github-prs.integration.test.ts
@@ -532,7 +532,7 @@ describe("Feature: Langy chat opens PRs as the requesting user", () => {
     });
 
     describe("when the agent deliberately rejects the request", () => {
-      /** @scenario "Langy does not retry when the agent rejects the request" */
+      /** `@scenario` "Langy does not retry when the agent rejects the request" */
       it("does not retry a 4xx response from the agent", async () => {
         let chatAttempts = 0;
         fetchMock = vi.fn(async (url: string) => {

--- a/langwatch/src/server/routes/__tests__/langy-github-prs.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/langy-github-prs.integration.test.ts
@@ -513,38 +513,6 @@ describe("Feature: Langy chat opens PRs as the requesting user", () => {
       });
     });
 
-    describe("when the agent backend hiccups once before responding", () => {
-      /** @scenario "Langy recovers from a brief agent hiccup" */
-      it("retries automatically and still opens the PR", async () => {
-        const opened = "acme/service-x#42";
-        let chatAttempts = 0;
-        fetchMock = vi.fn(async (url: string) => {
-          if (url === "http://agent.test/health") {
-            return new Response(null, { status: 200 });
-          }
-          chatAttempts += 1;
-          if (chatAttempts === 1) {
-            throw new Error("ECONNRESET");
-          }
-          return agentStreamResponse(
-            `[langy:progress:opened:${opened}]\n\n` +
-              `Opened https://github.com/acme/service-x/pull/42`,
-          );
-        });
-        vi.stubGlobal("fetch", fetchMock);
-
-        const res = await postChat("Open a PR on acme/service-x");
-        expect(res.status).toBe(200);
-        await drain(res);
-
-        expect(chatAttempts).toBe(2);
-        const persisted = persistedAssistantText();
-        expect(persisted).toContain(
-          "https://github.com/acme/service-x/pull/42",
-        );
-      });
-    });
-
     describe("when the agent is completely unreachable", () => {
       /** @scenario "Langy fails fast when the agent is completely unreachable" */
       it("fails fast with a clear message and never reserves a PR permit", async () => {
@@ -714,12 +682,15 @@ describe("Feature: Langy chat opens PRs as the requesting user", () => {
       /** @scenario "Permit must be released on every non-PR exit" */
       it("releases the permit when the agent fetch transport fails", async () => {
         // /health must pass (preflight runs BEFORE permit reservation) so this
-        // test exercises the /chat transport failure specifically. The /chat
-        // call fails on every attempt, so it exhausts the one bounded retry too.
+        // test exercises the /chat transport failure specifically. No retry:
+        // the agent has no idempotency key, so a single failed attempt must
+        // surface immediately rather than replaying the prompt.
+        let chatAttempts = 0;
         fetchMock = vi.fn(async (url: string) => {
           if (url === "http://agent.test/health") {
             return new Response(null, { status: 200 });
           }
+          chatAttempts += 1;
           throw new Error("ECONNREFUSED");
         });
         vi.stubGlobal("fetch", fetchMock);
@@ -727,16 +698,22 @@ describe("Feature: Langy chat opens PRs as the requesting user", () => {
         const res = await postChat("Open a PR on acme/service-x");
         expect(res.status).toBe(502);
 
+        expect(chatAttempts).toBe(1);
         expect(reserveLangyGithubPrPermit).toHaveBeenCalledTimes(1);
         expect(releaseLangyGithubPrPermit).toHaveBeenCalledTimes(1);
       });
 
       /** @scenario "Permit must be released on every non-PR exit" */
       it("releases the permit when the agent answers with a non-OK status", async () => {
+        // No retry on the 5xx either — same reasoning as above, and the
+        // agent may have already started acting on the prompt before
+        // returning the error.
+        let chatAttempts = 0;
         fetchMock = vi.fn(async (url: string) => {
           if (url === "http://agent.test/health") {
             return new Response(null, { status: 200 });
           }
+          chatAttempts += 1;
           return new Response("upstream blew up", {
             status: 502,
             headers: { "Content-Type": "text/plain" },
@@ -747,6 +724,7 @@ describe("Feature: Langy chat opens PRs as the requesting user", () => {
         const res = await postChat("Open a PR on acme/service-x");
         expect(res.status).toBe(502);
 
+        expect(chatAttempts).toBe(1);
         expect(reserveLangyGithubPrPermit).toHaveBeenCalledTimes(1);
         expect(releaseLangyGithubPrPermit).toHaveBeenCalledTimes(1);
       });

--- a/langwatch/src/server/routes/__tests__/langy-github-prs.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/langy-github-prs.integration.test.ts
@@ -532,7 +532,7 @@ describe("Feature: Langy chat opens PRs as the requesting user", () => {
     });
 
     describe("when the agent deliberately rejects the request", () => {
-      /** `@scenario` "Langy does not retry when the agent rejects the request" */
+      /** @scenario "Langy does not retry when the agent rejects the request" */
       it("does not retry a 4xx response from the agent", async () => {
         let chatAttempts = 0;
         fetchMock = vi.fn(async (url: string) => {

--- a/langwatch/src/server/routes/__tests__/langy-github-prs.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/langy-github-prs.integration.test.ts
@@ -556,20 +556,15 @@ describe("Feature: Langy chat opens PRs as the requesting user", () => {
         });
         vi.stubGlobal("fetch", fetchMock);
 
-        const start = Date.now();
         const res = await postChat("Open a PR on acme/service-x");
-        const elapsedMs = Date.now() - start;
 
         expect(res.status).toBe(503);
-        // Well under the 120s chat budget — the preflight uses a 3s timeout,
-        // not the full chat timeout, so this fails fast.
-        expect(elapsedMs).toBeLessThan(5_000);
         expect(reserveLangyGithubPrPermit).not.toHaveBeenCalled();
       });
     });
 
     describe("when the agent deliberately rejects the request", () => {
-      /** @scenario "Langy recovers from a brief agent hiccup" */
+      /** @scenario "Langy does not retry when the agent rejects the request" */
       it("does not retry a 4xx response from the agent", async () => {
         let chatAttempts = 0;
         fetchMock = vi.fn(async (url: string) => {

--- a/langwatch/src/server/routes/__tests__/langy-github-prs.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/langy-github-prs.integration.test.ts
@@ -513,6 +513,80 @@ describe("Feature: Langy chat opens PRs as the requesting user", () => {
       });
     });
 
+    describe("when the agent backend hiccups once before responding", () => {
+      /** @scenario "Langy recovers from a brief agent hiccup" */
+      it("retries automatically and still opens the PR", async () => {
+        const opened = "acme/service-x#42";
+        let chatAttempts = 0;
+        fetchMock = vi.fn(async (url: string) => {
+          if (url === "http://agent.test/health") {
+            return new Response(null, { status: 200 });
+          }
+          chatAttempts += 1;
+          if (chatAttempts === 1) {
+            throw new Error("ECONNRESET");
+          }
+          return agentStreamResponse(
+            `[langy:progress:opened:${opened}]\n\n` +
+              `Opened https://github.com/acme/service-x/pull/42`,
+          );
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const res = await postChat("Open a PR on acme/service-x");
+        expect(res.status).toBe(200);
+        await drain(res);
+
+        expect(chatAttempts).toBe(2);
+        const persisted = persistedAssistantText();
+        expect(persisted).toContain(
+          "https://github.com/acme/service-x/pull/42",
+        );
+      });
+    });
+
+    describe("when the agent is completely unreachable", () => {
+      /** @scenario "Langy fails fast when the agent is completely unreachable" */
+      it("fails fast with a clear message and never reserves a PR permit", async () => {
+        fetchMock = vi.fn(async (url: string) => {
+          if (url === "http://agent.test/health") {
+            throw new Error("ECONNREFUSED");
+          }
+          throw new Error(`unexpected fetch: ${url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const start = Date.now();
+        const res = await postChat("Open a PR on acme/service-x");
+        const elapsedMs = Date.now() - start;
+
+        expect(res.status).toBe(503);
+        // Well under the 120s chat budget — the preflight uses a 3s timeout,
+        // not the full chat timeout, so this fails fast.
+        expect(elapsedMs).toBeLessThan(5_000);
+        expect(reserveLangyGithubPrPermit).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the agent deliberately rejects the request", () => {
+      /** @scenario "Langy recovers from a brief agent hiccup" */
+      it("does not retry a 4xx response from the agent", async () => {
+        let chatAttempts = 0;
+        fetchMock = vi.fn(async (url: string) => {
+          if (url === "http://agent.test/health") {
+            return new Response(null, { status: 200 });
+          }
+          chatAttempts += 1;
+          return new Response("bad request", { status: 400 });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const res = await postChat("Open a PR on acme/service-x");
+        expect(res.status).toBe(502);
+        expect(chatAttempts).toBe(1);
+      });
+    });
+
     describe("when the worker is asked for a repo the App is NOT installed on", () => {
       /*
        * Installation scoping is enforced inside the agent's github.md skill —
@@ -644,7 +718,13 @@ describe("Feature: Langy chat opens PRs as the requesting user", () => {
     describe("when a pre-stream error happens after the permit was reserved", () => {
       /** @scenario "Permit must be released on every non-PR exit" */
       it("releases the permit when the agent fetch transport fails", async () => {
-        fetchMock = vi.fn(async () => {
+        // /health must pass (preflight runs BEFORE permit reservation) so this
+        // test exercises the /chat transport failure specifically. The /chat
+        // call fails on every attempt, so it exhausts the one bounded retry too.
+        fetchMock = vi.fn(async (url: string) => {
+          if (url === "http://agent.test/health") {
+            return new Response(null, { status: 200 });
+          }
           throw new Error("ECONNREFUSED");
         });
         vi.stubGlobal("fetch", fetchMock);
@@ -658,13 +738,15 @@ describe("Feature: Langy chat opens PRs as the requesting user", () => {
 
       /** @scenario "Permit must be released on every non-PR exit" */
       it("releases the permit when the agent answers with a non-OK status", async () => {
-        fetchMock = vi.fn(
-          async () =>
-            new Response("upstream blew up", {
-              status: 502,
-              headers: { "Content-Type": "text/plain" },
-            }),
-        );
+        fetchMock = vi.fn(async (url: string) => {
+          if (url === "http://agent.test/health") {
+            return new Response(null, { status: 200 });
+          }
+          return new Response("upstream blew up", {
+            status: 502,
+            headers: { "Content-Type": "text/plain" },
+          });
+        });
         vi.stubGlobal("fetch", fetchMock);
 
         const res = await postChat("Open a PR on acme/service-x");

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -247,6 +247,7 @@ async function fetchAgentChatWithRetry(opts: {
   try {
     const response = await attempt(AGENT_CHAT_TIMEOUT_MS);
     if (response.ok || response.status < 500) return response;
+    void response.body?.cancel();
     return await attempt(AGENT_CHAT_RETRY_TIMEOUT_MS);
   } catch (error) {
     if (isAbortTimeoutError(error)) throw error;

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -507,7 +507,9 @@ langyRoute().post("/langy/chat", async (c) => {
 
   if (!agentResponse.ok) {
     // The agent answered, but with a non-2xx — same shape: no PR was
-    // opened so the permit must come back.
+    // opened so the permit must come back. Cancel the body so the
+    // connection doesn't stay held open (mirrors isAgentHealthy above).
+    void agentResponse.body?.cancel();
     await releasePermitIfUnused();
     logger.error(
       { status: agentResponse.status },

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -199,11 +199,18 @@ const langyRoute = () =>
 
 const AGENT_HEALTH_CHECK_TIMEOUT_MS = 3_000;
 const AGENT_CHAT_TIMEOUT_MS = 120_000;
-const AGENT_CHAT_RETRY_TIMEOUT_MS = 15_000;
 
 // Preflight before reserving a PR permit or calling /chat: a 3s timeout
 // instead of the 120s chat budget, so a fully-down agent fails in seconds
 // and never burns a daily PR permit on a dead backend.
+//
+// Deliberately no retry on the /chat call itself: the agent's worker has
+// no idempotency key, and a POST /chat that fails after the agent already
+// started acting on the prompt (5xx or a reset mid-stream) would, on
+// retry, get replayed as a second independent turn against the same
+// worker — risking a duplicate PR. Fixing that properly needs an
+// idempotency mechanism on the agent side; until then, a mid-task failure
+// surfaces to the user instead of being silently retried.
 async function isAgentHealthy(agentUrl: string): Promise<boolean> {
   try {
     const response = await fetch(`${agentUrl}/health`, {
@@ -213,45 +220,6 @@ async function isAgentHealthy(agentUrl: string): Promise<boolean> {
     return response.ok;
   } catch {
     return false;
-  }
-}
-
-function isAbortTimeoutError(error: unknown): boolean {
-  return error instanceof Error && error.name === "TimeoutError";
-}
-
-// One bounded retry for the actual chat call. Only retries transport
-// failures that fail FAST (connection refused/reset/DNS) or a 5xx from the
-// agent — never a 4xx (the agent is up and deliberately rejected the
-// request; retrying gets the same answer) and never a full-duration
-// timeout (we already waited the whole 120s budget once; doubling that
-// wait is worse than just failing). The retry itself uses a much shorter
-// timeout — if the agent doesn't come back quickly, further waiting won't
-// help either.
-async function fetchAgentChatWithRetry(opts: {
-  agentUrl: string;
-  internalSecret: string;
-  body: unknown;
-}): Promise<Response> {
-  const attempt = (timeoutMs: number) =>
-    fetch(`${opts.agentUrl}/chat`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${opts.internalSecret}`,
-      },
-      body: JSON.stringify(opts.body),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-
-  try {
-    const response = await attempt(AGENT_CHAT_TIMEOUT_MS);
-    if (response.ok || response.status < 500) return response;
-    void response.body?.cancel();
-    return await attempt(AGENT_CHAT_RETRY_TIMEOUT_MS);
-  } catch (error) {
-    if (isAbortTimeoutError(error)) throw error;
-    return await attempt(AGENT_CHAT_RETRY_TIMEOUT_MS);
   }
 }
 
@@ -505,10 +473,13 @@ langyRoute().post("/langy/chat", async (c) => {
 
   let agentResponse: Response;
   try {
-    agentResponse = await fetchAgentChatWithRetry({
-      agentUrl,
-      internalSecret,
-      body: {
+    agentResponse = await fetch(`${agentUrl}/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${internalSecret}`,
+      },
+      body: JSON.stringify({
         conversationId: conversation.id,
         prompt: userText,
         system: capReachedNote
@@ -520,12 +491,15 @@ langyRoute().post("/langy/chat", async (c) => {
         // unrecognized fields, so this is effectively a wire-up that doesn't
         // change behavior — but the user's picker choice rides through.
         ...(modelOverride ? { modelOverride } : {}),
-      },
+      }),
+      signal: AbortSignal.timeout(AGENT_CHAT_TIMEOUT_MS),
     });
   } catch (error) {
-    // Transport failure that survived the retry (DNS, connection refused,
-    // or a full-duration timeout). The agent never accepted the work, so
-    // the permit must be released before we surface the 502.
+    // Transport failure (DNS, connection refused, timeout). The agent
+    // never accepted the work — no idempotency mechanism exists on its
+    // side, so this is deliberately NOT retried (see isAgentHealthy's
+    // comment above). The permit must be released before we surface the
+    // 502.
     await releasePermitIfUnused();
     logger.error({ error }, "opencode agent request transport failure");
     return c.json({ error: "Agent request failed" }, { status: 502 });

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -197,6 +197,63 @@ secured.hono.use("/langy/*", async (c, next) => {
 const langyRoute = () =>
   secured.access(handlerManagedAuth(LANGY_HANDLER_AUTH_REASON));
 
+const AGENT_HEALTH_CHECK_TIMEOUT_MS = 3_000;
+const AGENT_CHAT_TIMEOUT_MS = 120_000;
+const AGENT_CHAT_RETRY_TIMEOUT_MS = 15_000;
+
+// Preflight before reserving a PR permit or calling /chat: a 3s timeout
+// instead of the 120s chat budget, so a fully-down agent fails in seconds
+// and never burns a daily PR permit on a dead backend.
+async function isAgentHealthy(agentUrl: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${agentUrl}/health`, {
+      signal: AbortSignal.timeout(AGENT_HEALTH_CHECK_TIMEOUT_MS),
+    });
+    void response.body?.cancel();
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function isAbortTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === "TimeoutError";
+}
+
+// One bounded retry for the actual chat call. Only retries transport
+// failures that fail FAST (connection refused/reset/DNS) or a 5xx from the
+// agent — never a 4xx (the agent is up and deliberately rejected the
+// request; retrying gets the same answer) and never a full-duration
+// timeout (we already waited the whole 120s budget once; doubling that
+// wait is worse than just failing). The retry itself uses a much shorter
+// timeout — if the agent doesn't come back quickly, further waiting won't
+// help either.
+async function fetchAgentChatWithRetry(opts: {
+  agentUrl: string;
+  internalSecret: string;
+  body: unknown;
+}): Promise<Response> {
+  const attempt = (timeoutMs: number) =>
+    fetch(`${opts.agentUrl}/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${opts.internalSecret}`,
+      },
+      body: JSON.stringify(opts.body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+  try {
+    const response = await attempt(AGENT_CHAT_TIMEOUT_MS);
+    if (response.ok || response.status < 500) return response;
+    return await attempt(AGENT_CHAT_RETRY_TIMEOUT_MS);
+  } catch (error) {
+    if (isAbortTimeoutError(error)) throw error;
+    return await attempt(AGENT_CHAT_RETRY_TIMEOUT_MS);
+  }
+}
+
 langyRoute().post("/langy/chat", async (c) => {
   const session = await getServerAuthSession({
     req: c.req.raw as NextRequestShim,
@@ -382,6 +439,14 @@ langyRoute().post("/langy/chat", async (c) => {
     }
   }
 
+  if (!(await isAgentHealthy(agentUrl))) {
+    logger.error({ agentUrl }, "opencode agent failed preflight health check");
+    return c.json(
+      { error: "Agent is currently unavailable. Please try again shortly." },
+      { status: 503 },
+    );
+  }
+
   // Per-user daily PR cap, enforced by atomic permit reservation BEFORE we
   // hand the worker a GitHub token. If we're over cap, we strip the token
   // from `credentials` below so the worker physically cannot `gh pr create`
@@ -439,13 +504,10 @@ langyRoute().post("/langy/chat", async (c) => {
 
   let agentResponse: Response;
   try {
-    agentResponse = await fetch(`${agentUrl}/chat`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${internalSecret}`,
-      },
-      body: JSON.stringify({
+    agentResponse = await fetchAgentChatWithRetry({
+      agentUrl,
+      internalSecret,
+      body: {
         conversationId: conversation.id,
         prompt: userText,
         system: capReachedNote
@@ -457,13 +519,12 @@ langyRoute().post("/langy/chat", async (c) => {
         // unrecognized fields, so this is effectively a wire-up that doesn't
         // change behavior — but the user's picker choice rides through.
         ...(modelOverride ? { modelOverride } : {}),
-      }),
-      signal: AbortSignal.timeout(120_000),
+      },
     });
   } catch (error) {
-    // Transport failure (DNS, connection refused, timeout from
-    // AbortSignal.timeout). The agent never accepted the work, so the
-    // permit must be released before we surface the 502.
+    // Transport failure that survived the retry (DNS, connection refused,
+    // or a full-duration timeout). The agent never accepted the work, so
+    // the permit must be released before we surface the 502.
     await releasePermitIfUnused();
     logger.error({ error }, "opencode agent request transport failure");
     return c.json({ error: "Agent request failed" }, { status: 502 });

--- a/specs/langy/langy-github-prs.feature
+++ b/specs/langy/langy-github-prs.feature
@@ -41,14 +41,6 @@ Feature: Langy opens GitHub PRs as the requesting user
     And Langy renders the PR as a card in chat
 
   @integration
-  Scenario: Langy recovers from a brief agent hiccup
-    Given I have connected my GitHub account
-    And the agent backend fails once before responding
-    When I ask Langy to open a PR on "acme/service-x"
-    Then Langy retries automatically
-    And a pull request is created on "acme/service-x"
-
-  @integration
   Scenario: Langy fails fast when the agent is completely unreachable
     Given I have connected my GitHub account
     And the agent backend is completely unreachable

--- a/specs/langy/langy-github-prs.feature
+++ b/specs/langy/langy-github-prs.feature
@@ -40,6 +40,22 @@ Feature: Langy opens GitHub PRs as the requesting user
     And the branch commits are attributed to my GitHub login
     And Langy renders the PR as a card in chat
 
+  @integration
+  Scenario: Langy recovers from a brief agent hiccup
+    Given I have connected my GitHub account
+    And the agent backend fails once before responding
+    When I ask Langy to open a PR on "acme/service-x"
+    Then Langy retries automatically
+    And a pull request is created on "acme/service-x"
+
+  @integration
+  Scenario: Langy fails fast when the agent is completely unreachable
+    Given I have connected my GitHub account
+    And the agent backend is completely unreachable
+    When I ask Langy to open a PR on "acme/service-x"
+    Then Langy tells me it is temporarily unavailable within a few seconds
+    And no daily PR permit is consumed
+
   @integration @e2e
   Scenario: Tokens never persist in the worker or repo clone
     Given I have connected my GitHub account

--- a/specs/langy/langy-github-prs.feature
+++ b/specs/langy/langy-github-prs.feature
@@ -56,6 +56,14 @@ Feature: Langy opens GitHub PRs as the requesting user
     Then Langy tells me it is temporarily unavailable within a few seconds
     And no daily PR permit is consumed
 
+  @integration
+  Scenario: Langy does not retry when the agent rejects the request
+    Given I have connected my GitHub account
+    And the agent backend rejects the request with a 4xx response
+    When I ask Langy to open a PR on "acme/service-x"
+    Then Langy does not retry the request
+    And Langy reports the failure
+
   @integration @e2e
   Scenario: Tokens never persist in the worker or repo clone
     Given I have connected my GitHub account


### PR DESCRIPTION
## Summary
- Langy's call to the agent backend (`/langy/chat` → agent `/chat`) reserved a daily PR permit and made a single 120s-timeout fetch with no way to tell "agent is completely dead" apart from "agent is up but failed mid-task" — a fully-down agent could burn up to 2 minutes and a permit before the user saw an error.
- Adds a 3s `/health` preflight **before** the permit is reserved. A fully-down agent now fails in ~3s and never touches the permit system at all.
- Originally this PR also added a bounded retry on `/chat` itself, but that was dropped after a CodeRabbit review (verified independently against the reference agent implementation) found it could duplicate side effects: the agent's per-conversation worker has no idempotency key, so retrying after a 5xx/reset could replay the same prompt as an independent second turn on a worker that already accepted and started the work — risking a duplicate PR. Fixing that safely needs an idempotency mechanism on the agent side, out of scope here. A mid-task failure now surfaces to the user immediately, same as before, just distinguished cleanly from the "agent never got the request at all" case.

## Test plan
- [x] `specs/langy/langy-github-prs.feature` — scenario: fails fast when the agent is completely unreachable (no daily permit consumed)
- [x] `langy-github-prs.integration.test.ts` — 14/14 passing, including permit-release regression tests updated to assert single-attempt (no retry) behavior
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bounded agent availability pre-check before handling chat, with clear “temporarily unavailable” messaging when the agent can’t be reached.

* **Bug Fixes**
  * Improved GitHub PR opening reliability: fails fast when the agent is unreachable (no permit consumed) and returns correct errors when the agent rejects or errors (no retry, single `/chat` attempt, permits released correctly).

* **Tests**
  * Strengthened unit and integration test coverage for health preflight, timeouts, and exact request/permit-call behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->