### PR TITLE
fix(billing): resolve plan once per usage limit check to avoid snapshot race

### DIFF
--- a/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -280,6 +280,7 @@ describe("UsageService", () => {
         expect(mockPlanResolver).toHaveBeenCalledWith("org-123");
       });
 
+      /** @scenario Limit checks decide from one active plan snapshot */
       it("uses one active plan snapshot for counting and threshold comparison", async () => {
         const firstPlan = {
           ...FREE_PLAN,

--- a/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -279,6 +279,26 @@ describe("UsageService", () => {
 
         expect(mockPlanResolver).toHaveBeenCalledWith("org-123");
       });
+
+      it("uses one active plan snapshot for counting and threshold comparison", async () => {
+        const firstPlan = {
+          ...FREE_PLAN,
+          maxMessagesPerMonth: 1000,
+        };
+        const laterPlan = {
+          ...FREE_PLAN,
+          maxMessagesPerMonth: 2000,
+        };
+        (mockPlanResolver as ReturnType<typeof vi.fn>)
+          .mockResolvedValue(laterPlan)
+          .mockResolvedValueOnce(firstPlan);
+
+        const result = await service.checkLimit({ teamId: "team-123" });
+
+        expect(result.exceeded).toBe(true);
+        expect(result.maxMessagesPerMonth).toBe(1000);
+        expect(mockPlanResolver).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe("when count < maxMessagesPerMonth", () => {

--- a/langwatch/src/server/app-layer/usage/usage.service.ts
+++ b/langwatch/src/server/app-layer/usage/usage.service.ts
@@ -1,4 +1,5 @@
 import { UNLIMITED_MESSAGES } from "../../../../ee/billing/planLimits";
+import type { PlanInfo } from "../../../../ee/licensing/planInfo";
 import type { OrganizationRepository } from "../../repositories/organization.repository";
 import type { EventUsageService } from "../../traces/event-usage.service";
 import type { TraceUsageService } from "../../traces/trace-usage.service";
@@ -72,10 +73,8 @@ export class UsageService {
       throw new OrganizationNotFoundForTeamError(teamId);
     }
 
-    const [count, plan] = await Promise.all([
-      this.getCurrentMonthCount({ organizationId }),
-      this.planResolver(organizationId),
-    ]);
+    const plan = await this.planResolver(organizationId);
+    const count = await this.getCurrentMonthCount({ organizationId, plan });
 
     if (count === "unlimited") {
       return { exceeded: false };
@@ -83,7 +82,7 @@ export class UsageService {
 
     if (count >= plan.maxMessagesPerMonth) {
       // getCurrentMonthCount already warmed the decision cache, so this is a map lookup
-      const decision = await this.getCachedMeterDecision(organizationId);
+      const decision = await this.getCachedMeterDecision(organizationId, plan);
       return {
         exceeded: true,
         message: buildLimitMessage({
@@ -182,20 +181,22 @@ export class UsageService {
 
   async getCurrentMonthCount({
     organizationId,
+    plan,
   }: {
     organizationId: string;
+    plan?: PlanInfo;
   }): Promise<number | "unlimited"> {
     // Skip the heavy ClickHouse query for unlimited plans (e.g. seat-based pricing).
     // The count would never exceed the limit, so querying is wasted work for
     // ENFORCEMENT. Returns "unlimited" so callers can distinguish from actual 0
     // usage. Display callers that need the real volume regardless of the cap use
     // getCurrentMonthCountForDisplay instead.
-    const plan = await this.planResolver(organizationId);
-    if (plan.maxMessagesPerMonth >= UNLIMITED_MESSAGES) {
+    const activePlan = plan ?? (await this.planResolver(organizationId));
+    if (activePlan.maxMessagesPerMonth >= UNLIMITED_MESSAGES) {
       return "unlimited";
     }
 
-    return this.computeCurrentMonthCount({ organizationId });
+    return this.computeCurrentMonthCount({ organizationId, plan: activePlan });
   }
 
   /**
@@ -218,10 +219,12 @@ export class UsageService {
 
   private async computeCurrentMonthCount({
     organizationId,
+    plan,
   }: {
     organizationId: string;
+    plan?: PlanInfo;
   }): Promise<number> {
-    const decision = await this.getCachedMeterDecision(organizationId);
+    const decision = await this.getCachedMeterDecision(organizationId, plan);
     const cacheKey = `${organizationId}:${decision.usageUnit}`;
 
     const cached = await this.countCache.get(cacheKey);
@@ -286,22 +289,24 @@ export class UsageService {
 
   private async getCachedMeterDecision(
     organizationId: string,
+    plan?: PlanInfo,
   ): Promise<MeterDecision> {
     const cached = await this.decisionCache.get(organizationId);
     if (cached) return cached;
 
-    const decision = await this.resolveMeterDecision(organizationId);
+    const decision = await this.resolveMeterDecision(organizationId, plan);
     await this.decisionCache.set(organizationId, decision);
     return decision;
   }
 
   private async resolveMeterDecision(
     organizationId: string,
+    resolvedPlan?: PlanInfo,
   ): Promise<MeterDecision> {
     const pricingModel =
       (await this.organizationRepository?.getPricingModel(organizationId)) ??
       null;
-    const plan = await this.planResolver(organizationId);
+    const plan = resolvedPlan ?? (await this.planResolver(organizationId));
     const hasValidLicenseOverride = plan.planSource === "license";
 
     const decision = resolveUsageMeter({

--- a/specs/licensing/usage-enforcement-plan-resolution.feature
+++ b/specs/licensing/usage-enforcement-plan-resolution.feature
@@ -1,0 +1,15 @@
+Feature: Usage enforcement plan resolution
+  As the usage enforcement service
+  I want to reuse the active plan already resolved for a limit check
+  So that enforcement compares usage and thresholds from the same plan snapshot
+
+  @unit
+  Scenario: Limit checks decide from one active plan snapshot
+    Given an organization belongs to team "team-123"
+    And the active plan allows 1000 monthly events
+    And a later active plan lookup would allow 2000 monthly events
+    And the organization has 1000 events this month
+    When I check the monthly usage limit for team "team-123"
+    Then the limit check reports that usage is exceeded
+    And the result uses the 1000-event threshold from the first active plan snapshot
+    And the later active plan value is not used during the same check


### PR DESCRIPTION
## Summary
- Fixes #5309
- `UsageService.checkLimit` resolved the org's plan twice for a single enforcement decision — once for the count/limit comparison, once again independently inside `resolveMeterDecision` for `usageUnit`/license-override. If the plan changed between those two calls, the limit check and the metering decision could disagree.
- Threads a single resolved `PlanInfo` through `getCurrentMonthCount` -> `computeCurrentMonthCount` -> `getCachedMeterDecision` -> `resolveMeterDecision`, falling back to a fresh resolve only when no snapshot is passed in, so other callers of these methods are unaffected.

## Test plan
- [x] `usage.service.unit.test.ts`: new case mocks the resolver to return a smaller-limit plan then a larger-limit plan, asserts the limit decision uses the first snapshot and the resolver is called only once per `checkLimit`.
- [x] Full test file passes (22/22).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage limit checks now reuse the initially resolved active plan snapshot for the entire monthly evaluation, ensuring consistent thresholds even if plan details change mid-check.
  * Meter-decision and month-count calculations now align with the same plan context used for enforcement.
* **Tests**
  * Added unit and feature coverage to verify plan-snapshot reuse during usage enforcement plan resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->