### PR TITLE
test(billing): cover usageUnit/license-override half of the plan-snapshot fix

### DIFF
--- a/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -306,7 +306,9 @@ describe("UsageService", () => {
         expect(result.maxMessagesPerMonth).toBe(1000);
         // "Monthly"/"events" only come from firstPlan (free: false, license
         // override with usageUnit "events"); laterPlan would render "Free"/"traces".
-        expect(result.message).toContain("Monthly limit of 1000 events reached");
+        expect(result.message).toContain(
+          "Monthly limit of 1000 events reached",
+        );
         expect(mockPlanResolver).toHaveBeenCalledTimes(1);
       });
     });

--- a/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -281,14 +281,20 @@ describe("UsageService", () => {
       });
 
       /** @scenario Limit checks decide from one active plan snapshot */
-      it("uses one active plan snapshot for counting and threshold comparison", async () => {
-        const firstPlan = {
+      it("uses one active plan snapshot for counting, threshold, and message wording", async () => {
+        const firstPlan: PlanInfo = {
           ...FREE_PLAN,
+          planSource: "license",
+          free: false,
           maxMessagesPerMonth: 1000,
+          usageUnit: "events",
         };
-        const laterPlan = {
+        const laterPlan: PlanInfo = {
           ...FREE_PLAN,
+          planSource: "subscription",
+          free: false,
           maxMessagesPerMonth: 2000,
+          usageUnit: "traces",
         };
         (mockPlanResolver as ReturnType<typeof vi.fn>)
           .mockResolvedValue(laterPlan)
@@ -298,6 +304,9 @@ describe("UsageService", () => {
 
         expect(result.exceeded).toBe(true);
         expect(result.maxMessagesPerMonth).toBe(1000);
+        // "Monthly"/"events" only come from firstPlan (free: false, license
+        // override with usageUnit "events"); laterPlan would render "Free"/"traces".
+        expect(result.message).toContain("Monthly limit of 1000 events reached");
         expect(mockPlanResolver).toHaveBeenCalledTimes(1);
       });
     });


### PR DESCRIPTION
## Summary
Follow-up to #5310. CodeRabbit flagged that the regression test added there only proved the numeric threshold (`maxMessagesPerMonth`) and resolver call-count came from one plan snapshot — it didn't cover the other half of that bug: `resolveMeterDecision` also derives `usageUnit` and the license-override flag (`plan.planSource === "license"`) from the passed-in plan, and an independent second resolve there was part of the original inconsistency.

- `firstPlan` now uses `planSource: "license"`, `usageUnit: "events"`, `free: false`.
- `laterPlan` now uses `planSource: "subscription"`, `usageUnit: "traces"`, `free: false`.
- New assertion: `result.message` contains `"Monthly limit of 1000 events reached"` — only reachable if `firstPlan` fed both the count/threshold path and the meter-decision path; if the code regressed to resolve twice, the message would render from `laterPlan` instead (`"traces"`, and the threshold check would already fail at 1000 >= 2000).

Verified the added assertion actually catches the regression by reverting `usage.service.ts` to the pre-#5310 double-resolve locally and confirming this test fails there (then restored).

## Test plan
- [x] `usage.service.unit.test.ts` — 22/22 pass
- [x] Confirmed the new assertion fails against the pre-fix double-resolve implementation, confirming it's not a vacuous check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated unit test coverage for plan-limit behavior to use explicit plan snapshot data, including usage unit details.
  * Strengthened assertions to ensure the limit-reached message uses the active plan snapshot (the “first” plan) for consistent monthly event limit wording, even when a later plan would differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->