### PR TITLE
feat(cost-intelligence): cost breakdown by category on /me usage + activity monitor

### DIFF
--- a/langwatch/ee/billing/services/__tests__/categoryBillingBoundary.integration.test.ts
+++ b/langwatch/ee/billing/services/__tests__/categoryBillingBoundary.integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment node
+ *
+ * ADR-033 invariant "Never feeds billing", behavioural half: the executable
+ * billing usage count (`queryTraceSummariesTotalUniq`, the trace-count path
+ * that reads trace_summaries for plan-limit checking) must return the SAME
+ * number whether or not the trace summaries carry `blockcat` category
+ * attributes. Two tenants with byte-identical traces — one classified, one not
+ * — must meter identically. Pairs with categoryBillingBoundary.unit.test.ts
+ * (static import check).
+ *
+ * Spec: specs/ai-gateway/governance/cost-breakdown-dashboard.feature
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  blockCategoryCostAttr,
+  blockCategoryTokensAttr,
+} from "~/server/app-layer/traces/block-classification/categories";
+import { prisma } from "~/server/db";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { queryTraceSummariesTotalUniq } from "../billableEventsQuery";
+
+// Fixed instant inside a stable billing month (matches queryTraceSummariesTotalUniq's
+// CreatedAt filter, which uses the billing-month range).
+const CREATED_AT = new Date(Date.UTC(2026, 2, 15, 12, 0, 0));
+const BILLING_MONTH = "2026-03";
+
+async function insertTrace(
+  ch: ClickHouseClient,
+  tenantId: string,
+  attrs: Record<string, string>,
+): Promise<void> {
+  await ch.insert({
+    table: "trace_summaries",
+    values: [
+      {
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: tenantId,
+        TraceId: `t-${nanoid()}`,
+        Version: "v1",
+        Attributes: attrs,
+        OccurredAt: CREATED_AT,
+        CreatedAt: CREATED_AT,
+        UpdatedAt: CREATED_AT,
+        ComputedIOSchemaVersion: "",
+        ComputedInput: null,
+        ComputedOutput: null,
+        TimeToFirstTokenMs: null,
+        TimeToLastTokenMs: null,
+        TotalDurationMs: 100,
+        TokensPerSecond: null,
+        SpanCount: 1,
+        ContainsErrorStatus: 0,
+        ContainsOKStatus: 1,
+        ErrorMessage: null,
+        Models: ["claude-opus-4-8"],
+        TotalCost: 1.0,
+        NonBilledCost: 0,
+        TokensEstimated: false,
+        TotalPromptTokenCount: 10,
+        TotalCompletionTokenCount: 5,
+        OutputFromRootSpan: 0,
+        OutputSpanEndTimeMs: 0,
+        BlockedByGuardrail: 0,
+        TopicId: null,
+        SubTopicId: null,
+        HasAnnotation: null,
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+describe("ADR-033 billing boundary: usage count ignores category attributes", () => {
+  const ns = `cbb-${nanoid(8)}`;
+  let ch: ClickHouseClient | null = null;
+  let orgId = "";
+  let classifiedProjectId = "";
+  let plainProjectId = "";
+
+  beforeAll(async () => {
+    const maybe = getTestClickHouseClient();
+    if (!maybe) return;
+    ch = maybe;
+
+    const org = await prisma.organization.create({
+      data: { name: ns, slug: `org-${ns}` },
+    });
+    orgId = org.id;
+    const team = await prisma.team.create({
+      data: { name: `team-${ns}`, slug: `team-${ns}`, organizationId: org.id },
+    });
+    const classified = await prisma.project.create({
+      data: {
+        name: `classified-${ns}`,
+        slug: `classified-${ns}`,
+        teamId: team.id,
+        language: "en",
+        framework: "openai",
+        apiKey: `key-c-${ns}`,
+      },
+    });
+    const plain = await prisma.project.create({
+      data: {
+        name: `plain-${ns}`,
+        slug: `plain-${ns}`,
+        teamId: team.id,
+        language: "en",
+        framework: "openai",
+        apiKey: `key-p-${ns}`,
+      },
+    });
+    classifiedProjectId = classified.id;
+    plainProjectId = plain.id;
+
+    // Three traces per tenant. The classified tenant carries category attrs;
+    // the plain tenant carries none. Everything else is identical.
+    for (let i = 0; i < 3; i++) {
+      if (!ch) break;
+      await insertTrace(ch, classifiedProjectId, {
+        [blockCategoryCostAttr("system_prompt")]: "0.4",
+        [blockCategoryTokensAttr("system_prompt")]: "400",
+        [blockCategoryCostAttr("thinking")]: "0.1",
+        [blockCategoryTokensAttr("thinking")]: "100",
+      });
+      await insertTrace(ch, plainProjectId, {});
+    }
+  });
+
+  afterAll(async () => {
+    if (!ch) return;
+    await cleanupTestData(classifiedProjectId);
+    await cleanupTestData(plainProjectId);
+    await prisma.project
+      .deleteMany({ where: { team: { organizationId: orgId } } })
+      .catch(() => undefined);
+    await prisma.team
+      .deleteMany({ where: { organizationId: orgId } })
+      .catch(() => undefined);
+    await prisma.organization
+      .deleteMany({ where: { id: orgId } })
+      .catch(() => undefined);
+  });
+
+  describe("given one project with blockcat attrs and one without, otherwise identical", () => {
+    it("meters the same billable trace count for both", async () => {
+      if (!ch) return;
+      const classifiedCount = await queryTraceSummariesTotalUniq({
+        projectIds: [classifiedProjectId],
+        billingMonth: BILLING_MONTH,
+      });
+      const plainCount = await queryTraceSummariesTotalUniq({
+        projectIds: [plainProjectId],
+        billingMonth: BILLING_MONTH,
+      });
+      expect(classifiedCount).toBe(3);
+      expect(plainCount).toBe(3);
+      expect(classifiedCount).toBe(plainCount);
+    });
+  });
+});

--- a/langwatch/ee/billing/services/__tests__/categoryBillingBoundary.unit.test.ts
+++ b/langwatch/ee/billing/services/__tests__/categoryBillingBoundary.unit.test.ts
@@ -1,10 +1,16 @@
 /**
- * ADR-033 invariant "Never feeds billing": no billing or plan-limit code path
- * may read category classification data. This static check walks the billing
- * (`ee/billing`) and plan-limit (`src/server/license-enforcement`) source trees
- * and asserts none of them import the block-classification module or reference
- * the reserved `blockcat` category attributes. A behavioural companion lives in
+ * ADR-033 invariant "Never feeds billing": no billing, licensing, plan-limit,
+ * or budget-enforcement code path may read category classification data. This
+ * static check walks those source trees and asserts none of them import the
+ * block-classification module or reference the reserved `blockcat` category
+ * attributes. A behavioural companion lives in
  * categoryBillingBoundary.integration.test.ts.
+ *
+ * `ee/governance` is scanned too — its budget/anomaly enforcement lives there —
+ * but the two DASHBOARD read paths (personalUsage, activity-monitor) plus their
+ * routers/tests are allowlisted: they are the analytics display surface the
+ * ADR explicitly permits, and allowlisting by exact path keeps any NEW
+ * governance file that touches blockcat failing this test by default.
  *
  * Grep-based rather than a full import-graph walk (no such util exists in the
  * repo, ADR anchor permits it): direct imports are what a reviewer would add by
@@ -15,15 +21,31 @@
  * Spec: specs/ai-gateway/governance/cost-breakdown-dashboard.feature
  */
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { describe, expect, it } from "vitest";
 
 // Repo-relative roots. __dirname is <repo>/langwatch/ee/billing/services/__tests__.
 const REPO_LANGWATCH = join(__dirname, "..", "..", "..", "..");
 const SCAN_ROOTS = [
   join(REPO_LANGWATCH, "ee", "billing"),
+  join(REPO_LANGWATCH, "ee", "licensing"),
+  join(REPO_LANGWATCH, "ee", "saas"),
+  join(REPO_LANGWATCH, "ee", "governance"),
   join(REPO_LANGWATCH, "src", "server", "license-enforcement"),
 ];
+
+// The permitted analytics display surface (ADR-033 Decision 9) — exact paths.
+const ALLOWLISTED_READ_PATHS = [
+  join("ee", "governance", "services", "personalUsage.service.ts"),
+  join(
+    "ee",
+    "governance",
+    "services",
+    "activity-monitor",
+    "activityMonitor.service.ts",
+  ),
+  join("ee", "governance", "routers", "activityMonitor.ts"),
+].map((p) => sep + p);
 
 // Anything that would tie billing to the category classifier.
 const FORBIDDEN = ["block-classification", "blockcat", "blockClassifier"];
@@ -38,8 +60,11 @@ function collectSourceFiles(dir: string): string[] {
       continue;
     }
     if (!/\.(ts|tsx)$/.test(entry)) continue;
-    // The boundary tests themselves reference the forbidden tokens on purpose.
+    // The boundary tests themselves reference the forbidden tokens on purpose,
+    // and governance __tests__ fixtures exercise the dashboard read paths.
     if (/categoryBillingBoundary\./.test(entry)) continue;
+    if (full.includes(`${sep}__tests__${sep}`)) continue;
+    if (ALLOWLISTED_READ_PATHS.some((p) => full.endsWith(p))) continue;
     out.push(full);
   }
   return out;

--- a/langwatch/ee/billing/services/__tests__/categoryBillingBoundary.unit.test.ts
+++ b/langwatch/ee/billing/services/__tests__/categoryBillingBoundary.unit.test.ts
@@ -1,0 +1,66 @@
+/**
+ * ADR-033 invariant "Never feeds billing": no billing or plan-limit code path
+ * may read category classification data. This static check walks the billing
+ * (`ee/billing`) and plan-limit (`src/server/license-enforcement`) source trees
+ * and asserts none of them import the block-classification module or reference
+ * the reserved `blockcat` category attributes. A behavioural companion lives in
+ * categoryBillingBoundary.integration.test.ts.
+ *
+ * Grep-based rather than a full import-graph walk (no such util exists in the
+ * repo, ADR anchor permits it): direct imports are what a reviewer would add by
+ * accident, and the classifier lives entirely under `block-classification`, so
+ * any path into its outputs shows up as that path segment or the `blockcat`
+ * attribute prefix.
+ *
+ * Spec: specs/ai-gateway/governance/cost-breakdown-dashboard.feature
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Repo-relative roots. __dirname is <repo>/langwatch/ee/billing/services/__tests__.
+const REPO_LANGWATCH = join(__dirname, "..", "..", "..", "..");
+const SCAN_ROOTS = [
+  join(REPO_LANGWATCH, "ee", "billing"),
+  join(REPO_LANGWATCH, "src", "server", "license-enforcement"),
+];
+
+// Anything that would tie billing to the category classifier.
+const FORBIDDEN = ["block-classification", "blockcat", "blockClassifier"];
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "node_modules") continue;
+      out.push(...collectSourceFiles(full));
+      continue;
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue;
+    // The boundary tests themselves reference the forbidden tokens on purpose.
+    if (/categoryBillingBoundary\./.test(entry)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+describe("ADR-033 billing boundary: category data never reaches billing", () => {
+  describe("given the billing and plan-limit source trees", () => {
+    /** @scenario "Category totals never affect billing or plan limits" */
+    it("contains no import or reference into the block-classification module", () => {
+      const offenders: Array<{ file: string; token: string }> = [];
+      for (const root of SCAN_ROOTS) {
+        for (const file of collectSourceFiles(root)) {
+          const src = readFileSync(file, "utf8");
+          for (const token of FORBIDDEN) {
+            if (src.includes(token)) {
+              offenders.push({ file: file.replace(REPO_LANGWATCH, ""), token });
+            }
+          }
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+  });
+});

--- a/langwatch/ee/governance/routers/activityMonitor.ts
+++ b/langwatch/ee/governance/routers/activityMonitor.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 
-import { ActivityMonitorService } from "@ee/governance/services/activity-monitor/activityMonitor.service";
 /**
  * tRPC router for the Activity Monitor read-side queries that power
  * the /governance admin dashboard. Replaces Alexis's MOCK_* fixtures
@@ -16,6 +15,8 @@ import { ActivityMonitorService } from "@ee/governance/services/activity-monitor
  * Spec: specs/ai-gateway/governance/activity-monitor.feature
  */
 import { z } from "zod";
+
+import { ActivityMonitorService } from "@ee/governance/services/activity-monitor/activityMonitor.service";
 
 import {
   ENTERPRISE_FEATURE_ERRORS,
@@ -64,7 +65,9 @@ export const activityMonitorRouter = createTRPCRouter({
         windowDays: z.number().int().min(1).max(365).default(30),
         limit: z.number().int().min(1).max(500).default(50),
         offset: z.number().int().min(0).default(0),
-        sortBy: z.enum(["spend", "requests", "lastActivity"]).default("spend"),
+        sortBy: z
+          .enum(["spend", "requests", "lastActivity"])
+          .default("spend"),
         sortDir: z.enum(["asc", "desc"]).default("desc"),
       }),
     )
@@ -97,7 +100,9 @@ export const activityMonitorRouter = createTRPCRouter({
         windowDays: z.number().int().min(1).max(365).default(30),
         limit: z.number().int().min(1).max(500).default(50),
         offset: z.number().int().min(0).default(0),
-        sortBy: z.enum(["spend", "requests", "lastActivity"]).default("spend"),
+        sortBy: z
+          .enum(["spend", "requests", "lastActivity"])
+          .default("spend"),
         sortDir: z.enum(["asc", "desc"]).default("desc"),
       }),
     )

--- a/langwatch/ee/governance/routers/activityMonitor.ts
+++ b/langwatch/ee/governance/routers/activityMonitor.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 
+import { ActivityMonitorService } from "@ee/governance/services/activity-monitor/activityMonitor.service";
 /**
  * tRPC router for the Activity Monitor read-side queries that power
  * the /governance admin dashboard. Replaces Alexis's MOCK_* fixtures
@@ -15,8 +16,6 @@
  * Spec: specs/ai-gateway/governance/activity-monitor.feature
  */
 import { z } from "zod";
-
-import { ActivityMonitorService } from "@ee/governance/services/activity-monitor/activityMonitor.service";
 
 import {
   ENTERPRISE_FEATURE_ERRORS,
@@ -65,9 +64,7 @@ export const activityMonitorRouter = createTRPCRouter({
         windowDays: z.number().int().min(1).max(365).default(30),
         limit: z.number().int().min(1).max(500).default(50),
         offset: z.number().int().min(0).default(0),
-        sortBy: z
-          .enum(["spend", "requests", "lastActivity"])
-          .default("spend"),
+        sortBy: z.enum(["spend", "requests", "lastActivity"]).default("spend"),
         sortDir: z.enum(["asc", "desc"]).default("desc"),
       }),
     )
@@ -100,9 +97,7 @@ export const activityMonitorRouter = createTRPCRouter({
         windowDays: z.number().int().min(1).max(365).default(30),
         limit: z.number().int().min(1).max(500).default(50),
         offset: z.number().int().min(0).default(0),
-        sortBy: z
-          .enum(["spend", "requests", "lastActivity"])
-          .default("spend"),
+        sortBy: z.enum(["spend", "requests", "lastActivity"]).default("spend"),
         sortDir: z.enum(["asc", "desc"]).default("desc"),
       }),
     )
@@ -171,6 +166,28 @@ export const activityMonitorRouter = createTRPCRouter({
         organizationId: input.organizationId,
         windowDays: input.windowDays,
         groupBy: input.groupBy,
+      });
+    }),
+
+  /**
+   * Aggregate cost breakdown by content category (ADR-033 PR D) across the
+   * org's governance-origin coding-agent traffic. Same RBAC + enterprise gate
+   * as the rest of the Activity Monitor — analytics only, never billing.
+   */
+  categoryBreakdown: protectedProcedure
+    .input(
+      z.object({
+        organizationId: z.string(),
+        windowDays: z.number().int().min(1).max(365).default(30),
+      }),
+    )
+    .use(checkOrganizationPermission("activityMonitor:view"))
+    .use(enterpriseGate)
+    .query(async ({ ctx, input }) => {
+      const service = ActivityMonitorService.create(ctx.prisma);
+      return await service.categoryBreakdown({
+        organizationId: input.organizationId,
+        windowDays: input.windowDays,
       });
     }),
 

--- a/langwatch/ee/governance/services/__tests__/activityMonitorCategoryBreakdown.service.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/activityMonitorCategoryBreakdown.service.integration.test.ts
@@ -1,0 +1,240 @@
+/**
+ * @vitest-environment node
+ *
+ * ActivityMonitorService.categoryBreakdown — ADR-033 PR D.
+ *
+ * The org Activity Monitor aggregates the coding-agent cost split by content
+ * category across every user's governance-origin traffic. Category totals ride
+ * the reserved `langwatch.reserved.blockcat.<category>.{cost_usd,tokens}`
+ * attributes the trace fold accumulates onto trace_summaries. This test seeds
+ * governance-origin rows directly and exercises the read query against real
+ * ClickHouse — TenantId isolation and origin filtering must hold exactly as
+ * they do for spendByUser.
+ *
+ * Spec: specs/ai-gateway/governance/cost-breakdown-dashboard.feature
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import type { Organization, Project } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  blockCategoryCostAttr,
+  blockCategoryTokensAttr,
+} from "~/server/app-layer/traces/block-classification/categories";
+import { prisma } from "~/server/db";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { ActivityMonitorService } from "../activity-monitor/activityMonitor.service";
+import { ensureHiddenGovernanceProject } from "../governanceProject.service";
+
+const ORIGIN_KEY = "langwatch.origin.kind";
+const ORIGIN_VALUE = "ingestion_source";
+const USER_KEY = "langwatch.user_id";
+
+async function insertTraceSummary(
+  ch: ClickHouseClient,
+  tenantId: string,
+  t: {
+    traceId: string;
+    occurredAt: Date;
+    totalCost: number;
+    attrs: Record<string, string>;
+  },
+): Promise<void> {
+  await ch.insert({
+    table: "trace_summaries",
+    values: [
+      {
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: tenantId,
+        TraceId: t.traceId,
+        Version: "v1",
+        Attributes: t.attrs,
+        OccurredAt: t.occurredAt,
+        CreatedAt: t.occurredAt,
+        UpdatedAt: t.occurredAt,
+        ComputedIOSchemaVersion: "",
+        ComputedInput: null,
+        ComputedOutput: null,
+        TimeToFirstTokenMs: null,
+        TimeToLastTokenMs: null,
+        TotalDurationMs: 100,
+        TokensPerSecond: null,
+        SpanCount: 1,
+        ContainsErrorStatus: 0,
+        ContainsOKStatus: 1,
+        ErrorMessage: null,
+        Models: ["claude-sonnet-4"],
+        TotalCost: t.totalCost,
+        TokensEstimated: false,
+        TotalPromptTokenCount: 10,
+        TotalCompletionTokenCount: 5,
+        OutputFromRootSpan: 0,
+        OutputSpanEndTimeMs: 0,
+        BlockedByGuardrail: 0,
+        TopicId: null,
+        SubTopicId: null,
+        HasAnnotation: null,
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+describe("ActivityMonitorService.categoryBreakdown", () => {
+  const namespace = `amcb-${nanoid(8)}`;
+  let ch: ClickHouseClient;
+  let primaryOrg: Organization;
+  let primaryGovProject: Project;
+  let crossOrg: Organization;
+  let crossGovProject: Project;
+
+  beforeAll(async () => {
+    const maybeCh = getTestClickHouseClient();
+    if (!maybeCh) throw new Error("ClickHouse test container not available");
+    ch = maybeCh;
+
+    primaryOrg = await prisma.organization.create({
+      data: { name: `Primary ${namespace}`, slug: `primary-${namespace}` },
+    });
+    await prisma.team.create({
+      data: {
+        name: `Primary Team ${namespace}`,
+        slug: `primary-team-${namespace}`,
+        organizationId: primaryOrg.id,
+      },
+    });
+    crossOrg = await prisma.organization.create({
+      data: { name: `Cross ${namespace}`, slug: `cross-${namespace}` },
+    });
+    await prisma.team.create({
+      data: {
+        name: `Cross Team ${namespace}`,
+        slug: `cross-team-${namespace}`,
+        organizationId: crossOrg.id,
+      },
+    });
+    primaryGovProject = await ensureHiddenGovernanceProject(
+      prisma,
+      primaryOrg.id,
+    );
+    crossGovProject = await ensureHiddenGovernanceProject(prisma, crossOrg.id);
+
+    const inWindow = new Date(Date.now() - 12 * 60 * 60 * 1000);
+
+    // Alice: system_prompt 0.5 / mcp_tool_definitions 0.2
+    await insertTraceSummary(ch, primaryGovProject.id, {
+      traceId: `tr-a-${nanoid()}`,
+      occurredAt: inWindow,
+      totalCost: 0.7,
+      attrs: {
+        [ORIGIN_KEY]: ORIGIN_VALUE,
+        [USER_KEY]: "alice@example.com",
+        [blockCategoryCostAttr("system_prompt")]: "0.5",
+        [blockCategoryTokensAttr("system_prompt")]: "500",
+        [blockCategoryCostAttr("mcp_tool_definitions")]: "0.2",
+        [blockCategoryTokensAttr("mcp_tool_definitions")]: "200",
+      },
+    });
+    // Bob: system_prompt 0.3 / thinking 0.4 — aggregates across users
+    await insertTraceSummary(ch, primaryGovProject.id, {
+      traceId: `tr-b-${nanoid()}`,
+      occurredAt: inWindow,
+      totalCost: 0.7,
+      attrs: {
+        [ORIGIN_KEY]: ORIGIN_VALUE,
+        [USER_KEY]: "bob@example.com",
+        [blockCategoryCostAttr("system_prompt")]: "0.3",
+        [blockCategoryTokensAttr("system_prompt")]: "300",
+        [blockCategoryCostAttr("thinking")]: "0.4",
+        [blockCategoryTokensAttr("thinking")]: "400",
+      },
+    });
+    // Non-governance-origin app trace — must be excluded.
+    await insertTraceSummary(ch, primaryGovProject.id, {
+      traceId: `tr-app-${nanoid()}`,
+      occurredAt: inWindow,
+      totalCost: 99,
+      attrs: {
+        [blockCategoryCostAttr("system_prompt")]: "99",
+        [blockCategoryTokensAttr("system_prompt")]: "99000",
+      },
+    });
+    // Cross-org governance trace — must be excluded by TenantId isolation.
+    await insertTraceSummary(ch, crossGovProject.id, {
+      traceId: `tr-cross-${nanoid()}`,
+      occurredAt: inWindow,
+      totalCost: 50,
+      attrs: {
+        [ORIGIN_KEY]: ORIGIN_VALUE,
+        [USER_KEY]: "eve@cross.example.com",
+        [blockCategoryCostAttr("system_prompt")]: "50",
+        [blockCategoryTokensAttr("system_prompt")]: "50000",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.project
+      .deleteMany({
+        where: { id: { in: [primaryGovProject.id, crossGovProject.id] } },
+      })
+      .catch(() => undefined);
+    await prisma.team
+      .deleteMany({
+        where: { organizationId: { in: [primaryOrg.id, crossOrg.id] } },
+      })
+      .catch(() => undefined);
+    await prisma.organization
+      .deleteMany({ where: { id: { in: [primaryOrg.id, crossOrg.id] } } })
+      .catch(() => undefined);
+    await cleanupTestData(primaryGovProject.id);
+    await cleanupTestData(crossGovProject.id);
+  });
+
+  describe("given an organization with classified coding-agent traffic from several users", () => {
+    /** @scenario "The org activity monitor aggregates category totals across users" */
+    it("sums per-category cost + tokens across users, excluding app + cross-org traffic", async () => {
+      const service = ActivityMonitorService.create(prisma);
+      const rows = await service.categoryBreakdown({
+        organizationId: primaryOrg.id,
+        windowDays: 7,
+      });
+
+      const byCat = new Map(rows.map((r) => [r.category, r]));
+      // system_prompt: alice 0.5 + bob 0.3 = 0.8 (app 99 + cross 50 excluded)
+      expect(byCat.get("system_prompt")?.costUsd).toBeCloseTo(0.8, 5);
+      expect(byCat.get("system_prompt")?.tokens).toBeCloseTo(800, 5);
+      expect(byCat.get("mcp_tool_definitions")?.costUsd).toBeCloseTo(0.2, 5);
+      expect(byCat.get("thinking")?.costUsd).toBeCloseTo(0.4, 5);
+      // Sorted by cost desc.
+      expect(rows[0]?.category).toBe("system_prompt");
+      // No cross-org / app leakage: total bounded well below the excluded $149.
+      const total = rows.reduce((s, r) => s + r.costUsd, 0);
+      expect(total).toBeLessThan(2);
+    });
+  });
+
+  describe("given an org with no hidden Governance Project", () => {
+    it("returns [] without touching ClickHouse", async () => {
+      const orphan = await prisma.organization.create({
+        data: { name: `Orphan ${nanoid(6)}`, slug: `orphan-${nanoid(6)}` },
+      });
+      try {
+        const service = ActivityMonitorService.create(prisma);
+        const rows = await service.categoryBreakdown({
+          organizationId: orphan.id,
+          windowDays: 7,
+        });
+        expect(rows).toEqual([]);
+      } finally {
+        await prisma.organization
+          .delete({ where: { id: orphan.id } })
+          .catch(() => undefined);
+      }
+    });
+  });
+});

--- a/langwatch/ee/governance/services/__tests__/personalUsageCategoryBreakdown.service.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/personalUsageCategoryBreakdown.service.integration.test.ts
@@ -1,0 +1,224 @@
+/**
+ * @vitest-environment node
+ *
+ * PersonalUsageService.breakdownByCategory — ADR-033 PR D.
+ *
+ * The /me personal-usage view surfaces the user's coding-agent cost split by
+ * content category (system prompt / MCP tool defs / thinking / ...). Category
+ * totals ride the reserved `langwatch.reserved.blockcat.<category>.{cost_usd,
+ * tokens}` attributes the trace fold accumulates onto trace_summaries. This
+ * test executes the real query against ClickHouse against seeded trace
+ * summaries so a query regression surfaces as a throw or a wrong number, not a
+ * silent string diff.
+ *
+ * Spec: specs/ai-gateway/governance/cost-breakdown-dashboard.feature
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  blockCategoryCostAttr,
+  blockCategoryTokensAttr,
+} from "~/server/app-layer/traces/block-classification/categories";
+import { prisma } from "~/server/db";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { PersonalUsageService } from "../personalUsage.service";
+
+async function insertTrace(
+  ch: ClickHouseClient,
+  tenantId: string,
+  t: {
+    traceId: string;
+    occurredAt: Date;
+    totalCost: number;
+    attrs: Record<string, string>;
+  },
+): Promise<void> {
+  await ch.insert({
+    table: "trace_summaries",
+    values: [
+      {
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: tenantId,
+        TraceId: t.traceId,
+        Version: "v1",
+        Attributes: t.attrs,
+        OccurredAt: t.occurredAt,
+        CreatedAt: t.occurredAt,
+        UpdatedAt: t.occurredAt,
+        ComputedIOSchemaVersion: "",
+        ComputedInput: null,
+        ComputedOutput: null,
+        TimeToFirstTokenMs: null,
+        TimeToLastTokenMs: null,
+        TotalDurationMs: 100,
+        TokensPerSecond: null,
+        SpanCount: 1,
+        ContainsErrorStatus: 0,
+        ContainsOKStatus: 1,
+        ErrorMessage: null,
+        Models: ["claude-opus-4-8"],
+        TotalCost: t.totalCost,
+        NonBilledCost: 0,
+        TokensEstimated: false,
+        TotalPromptTokenCount: 10,
+        TotalCompletionTokenCount: 5,
+        OutputFromRootSpan: 0,
+        OutputSpanEndTimeMs: 0,
+        BlockedByGuardrail: 0,
+        TopicId: null,
+        SubTopicId: null,
+        HasAnnotation: null,
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+describe("PersonalUsageService.breakdownByCategory", () => {
+  const ns = `pucb-${nanoid(8)}`;
+  const occurredAt = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
+  const window = {
+    start: new Date(Date.UTC(2026, 0, 1)),
+    end: new Date(Date.UTC(2026, 0, 31)),
+  };
+  let ch: ClickHouseClient | null = null;
+  let orgId = "";
+  let tenantId = "";
+
+  beforeAll(async () => {
+    const maybe = getTestClickHouseClient();
+    if (!maybe) return;
+    ch = maybe;
+
+    const org = await prisma.organization.create({
+      data: { name: ns, slug: `org-${ns}` },
+    });
+    orgId = org.id;
+    const team = await prisma.team.create({
+      data: { name: `team-${ns}`, slug: `team-${ns}`, organizationId: org.id },
+    });
+    const project = await prisma.project.create({
+      data: {
+        name: `personal-${ns}`,
+        slug: `personal-${ns}`,
+        teamId: team.id,
+        language: "en",
+        framework: "openai",
+        apiKey: `key-${ns}`,
+      },
+    });
+    tenantId = project.id;
+
+    // Two classified traces. system_prompt and mcp_tool_definitions accumulate
+    // across both; thinking appears on one only.
+    await insertTrace(ch, tenantId, {
+      traceId: `t-1-${nanoid(6)}`,
+      occurredAt,
+      totalCost: 1.0,
+      attrs: {
+        [blockCategoryCostAttr("system_prompt")]: "0.6",
+        [blockCategoryTokensAttr("system_prompt")]: "600",
+        [blockCategoryCostAttr("mcp_tool_definitions")]: "0.3",
+        [blockCategoryTokensAttr("mcp_tool_definitions")]: "300",
+        [blockCategoryCostAttr("thinking")]: "0.1",
+        [blockCategoryTokensAttr("thinking")]: "100",
+      },
+    });
+    await insertTrace(ch, tenantId, {
+      traceId: `t-2-${nanoid(6)}`,
+      occurredAt,
+      totalCost: 0.5,
+      attrs: {
+        [blockCategoryCostAttr("system_prompt")]: "0.2",
+        [blockCategoryTokensAttr("system_prompt")]: "200",
+        [blockCategoryCostAttr("mcp_tool_definitions")]: "0.3",
+        [blockCategoryTokensAttr("mcp_tool_definitions")]: "300",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    if (!ch) return;
+    await cleanupTestData(tenantId);
+    await prisma.project
+      .deleteMany({ where: { team: { organizationId: orgId } } })
+      .catch(() => undefined);
+    await prisma.team
+      .deleteMany({ where: { organizationId: orgId } })
+      .catch(() => undefined);
+    await prisma.organization
+      .deleteMany({ where: { id: orgId } })
+      .catch(() => undefined);
+  });
+
+  describe("given a user whose coding-agent traffic produced classified category totals", () => {
+    /** @scenario "The personal usage view shows the user's cost breakdown by category" */
+    it("returns per-category cost + token totals summed across the window, sorted by cost desc", async () => {
+      if (!ch) return;
+      const rows = await new PersonalUsageService().breakdownByCategory({
+        personalProjectId: tenantId,
+        window,
+      });
+
+      const byCat = new Map(rows.map((r) => [r.category, r]));
+      // system_prompt: 0.6 + 0.2 = 0.8 ; mcp_tool_definitions: 0.3 + 0.3 = 0.6
+      expect(byCat.get("system_prompt")?.costUsd).toBeCloseTo(0.8, 5);
+      expect(byCat.get("system_prompt")?.tokens).toBeCloseTo(800, 5);
+      expect(byCat.get("mcp_tool_definitions")?.costUsd).toBeCloseTo(0.6, 5);
+      expect(byCat.get("thinking")?.costUsd).toBeCloseTo(0.1, 5);
+      // Sorted by cost desc: system_prompt first.
+      expect(rows[0]?.category).toBe("system_prompt");
+      // Categories with no attributes never surface.
+      expect(byCat.has("image")).toBe(false);
+    });
+  });
+
+  describe("given a user whose traffic produced no category totals", () => {
+    it("returns an empty array so the UI can render the enablement hint", async () => {
+      if (!ch) return;
+      const emptyOrg = await prisma.organization.create({
+        data: { name: `${ns}-empty`, slug: `org-${ns}-empty` },
+      });
+      const emptyTeam = await prisma.team.create({
+        data: {
+          name: `team-${ns}-empty`,
+          slug: `team-${ns}-empty`,
+          organizationId: emptyOrg.id,
+        },
+      });
+      const emptyProject = await prisma.project.create({
+        data: {
+          name: `personal-${ns}-empty`,
+          slug: `personal-${ns}-empty`,
+          teamId: emptyTeam.id,
+          language: "en",
+          framework: "openai",
+          apiKey: `key-${ns}-empty`,
+        },
+      });
+      try {
+        const rows = await new PersonalUsageService().breakdownByCategory({
+          personalProjectId: emptyProject.id,
+          window,
+        });
+        expect(rows).toEqual([]);
+      } finally {
+        await cleanupTestData(emptyProject.id);
+        await prisma.project
+          .deleteMany({ where: { team: { organizationId: emptyOrg.id } } })
+          .catch(() => undefined);
+        await prisma.team
+          .deleteMany({ where: { organizationId: emptyOrg.id } })
+          .catch(() => undefined);
+        await prisma.organization
+          .deleteMany({ where: { id: emptyOrg.id } })
+          .catch(() => undefined);
+      }
+    });
+  });
+});

--- a/langwatch/ee/governance/services/__tests__/personalUsageCategoryBreakdown.service.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/personalUsageCategoryBreakdown.service.integration.test.ts
@@ -25,6 +25,7 @@ import {
   cleanupTestData,
   getTestClickHouseClient,
 } from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { GOVERNANCE_ATTR } from "../governanceAttributeKeys";
 import { PersonalUsageService } from "../personalUsage.service";
 
 async function insertTrace(
@@ -175,6 +176,115 @@ describe("PersonalUsageService.breakdownByCategory", () => {
       expect(rows[0]?.category).toBe("system_prompt");
       // Categories with no attributes never surface.
       expect(byCat.has("image")).toBe(false);
+    });
+  });
+
+  describe("given ingestion-source category traffic on the org's governance tenant", () => {
+    // The gov tenant carries coding-agent traffic that never lands in the
+    // personal project. Its trace summaries hold both the blockcat attrs and
+    // the acting principal on Attributes['langwatch.user_id'] (an email).
+    const principalEmail = `owner-${ns}@example.com`;
+    const otherEmail = `other-${ns}@example.com`;
+    let govOrgId = "";
+    let govTenantId = "";
+
+    beforeAll(async () => {
+      if (!ch) return;
+      const govOrg = await prisma.organization.create({
+        data: { name: `${ns}-gov`, slug: `org-${ns}-gov` },
+      });
+      govOrgId = govOrg.id;
+      const govTeam = await prisma.team.create({
+        data: {
+          name: `team-${ns}-gov`,
+          slug: `team-${ns}-gov`,
+          organizationId: govOrg.id,
+        },
+      });
+      const govProject = await prisma.project.create({
+        data: {
+          name: `gov-${ns}`,
+          slug: `gov-${ns}`,
+          teamId: govTeam.id,
+          language: "en",
+          framework: "openai",
+          apiKey: `key-${ns}-gov`,
+        },
+      });
+      govTenantId = govProject.id;
+
+      // This principal's ingestion row: system_prompt 0.5 / 500.
+      await insertTrace(ch, govTenantId, {
+        traceId: `g-mine-${nanoid(6)}`,
+        occurredAt,
+        totalCost: 0.5,
+        attrs: {
+          [GOVERNANCE_ATTR.USER_ID]: principalEmail,
+          [blockCategoryCostAttr("system_prompt")]: "0.5",
+          [blockCategoryTokensAttr("system_prompt")]: "500",
+        },
+      });
+      // Another user's ingestion row under the SAME gov tenant — must be
+      // excluded by the principal-email filter, never summed into /me.
+      await insertTrace(ch, govTenantId, {
+        traceId: `g-other-${nanoid(6)}`,
+        occurredAt,
+        totalCost: 9.0,
+        attrs: {
+          [GOVERNANCE_ATTR.USER_ID]: otherEmail,
+          [blockCategoryCostAttr("system_prompt")]: "9.0",
+          [blockCategoryTokensAttr("system_prompt")]: "9000",
+        },
+      });
+    });
+
+    afterAll(async () => {
+      if (!ch) return;
+      await cleanupTestData(govTenantId);
+      await prisma.project
+        .deleteMany({ where: { team: { organizationId: govOrgId } } })
+        .catch(() => undefined);
+      await prisma.team
+        .deleteMany({ where: { organizationId: govOrgId } })
+        .catch(() => undefined);
+      await prisma.organization
+        .deleteMany({ where: { id: govOrgId } })
+        .catch(() => undefined);
+    });
+
+    describe("when userEmail + ingestionTenantId are supplied", () => {
+      it("unions the principal's gov-tenant category totals into the personal rows", async () => {
+        if (!ch) return;
+        const rows = await new PersonalUsageService().breakdownByCategory({
+          personalProjectId: tenantId,
+          ingestionTenantId: govTenantId,
+          userEmail: principalEmail,
+          window,
+        });
+
+        const byCat = new Map(rows.map((r) => [r.category, r]));
+        // system_prompt: personal 0.8 + this principal's gov 0.5 = 1.3.
+        // The other user's 9.0 is filtered out by the user_id predicate.
+        expect(byCat.get("system_prompt")?.costUsd).toBeCloseTo(1.3, 5);
+        expect(byCat.get("system_prompt")?.tokens).toBeCloseTo(1300, 5);
+        // mcp_tool_definitions is personal-only (0.6) — untouched by the union.
+        expect(byCat.get("mcp_tool_definitions")?.costUsd).toBeCloseTo(0.6, 5);
+      });
+    });
+
+    describe("when userEmail / ingestionTenantId are absent", () => {
+      it("returns personal-tenant rows only — no gov-tenant union", async () => {
+        if (!ch) return;
+        const rows = await new PersonalUsageService().breakdownByCategory({
+          personalProjectId: tenantId,
+          window,
+        });
+
+        const byCat = new Map(rows.map((r) => [r.category, r]));
+        // Personal-only: system_prompt stays 0.8 (gov 0.5 NOT merged).
+        expect(byCat.get("system_prompt")?.costUsd).toBeCloseTo(0.8, 5);
+        expect(byCat.get("system_prompt")?.tokens).toBeCloseTo(800, 5);
+      });
     });
   });
 

--- a/langwatch/ee/governance/services/__tests__/personalUsageCategoryBreakdown.union.test.ts
+++ b/langwatch/ee/governance/services/__tests__/personalUsageCategoryBreakdown.union.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment node
+ *
+ * PersonalUsageService.breakdownByCategory — ingestion-source union control
+ * flow (ADR-033 PR D). These are unit tests over a mocked ClickHouse client:
+ * they assert WHEN the second (gov-tenant) query fires, that its results merge
+ * into the personal rows, and that a union failure degrades to personal-only
+ * rather than blanking the view. The real query shape is covered end-to-end by
+ * personalUsageCategoryBreakdown.service.integration.test.ts.
+ *
+ * Spec: specs/ai-gateway/governance/cost-breakdown-dashboard.feature
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CATEGORIES,
+  type Category,
+} from "~/server/app-layer/traces/block-classification/categories";
+
+const { queryMock } = vi.hoisted(() => ({ queryMock: vi.fn() }));
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: vi.fn(async () => ({ query: queryMock })),
+  isClickHouseEnabled: () => true,
+}));
+
+import { PersonalUsageService } from "../personalUsage.service";
+
+const window = {
+  start: new Date(Date.UTC(2026, 0, 1)),
+  end: new Date(Date.UTC(2026, 0, 31)),
+};
+
+/** Build the single aggregate row the outer query returns for the given cats. */
+function rowFor(
+  entries: Partial<Record<Category, { cost: number; tokens: number }>>,
+): Record<string, number> {
+  const row: Record<string, number> = {};
+  CATEGORIES.forEach((category, i) => {
+    row[`scost_${i}`] = entries[category]?.cost ?? 0;
+    row[`stok_${i}`] = entries[category]?.tokens ?? 0;
+  });
+  return row;
+}
+
+const jsonResult = (row: Record<string, number>) => ({
+  json: async () => [row],
+});
+
+describe("PersonalUsageService.breakdownByCategory ingestion union", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  describe("given only a personal project (no userEmail / ingestionTenantId)", () => {
+    it("issues a single query and returns the personal-tenant rows only", async () => {
+      queryMock.mockResolvedValue(
+        jsonResult(rowFor({ system_prompt: { cost: 0.8, tokens: 800 } })),
+      );
+
+      const rows = await new PersonalUsageService().breakdownByCategory({
+        personalProjectId: "personal",
+        window,
+      });
+
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      expect(rows).toEqual([
+        { category: "system_prompt", costUsd: 0.8, tokens: 800 },
+      ]);
+    });
+  });
+
+  describe("given userEmail + ingestionTenantId", () => {
+    it("issues a second gov-tenant query filtered by principal email and merges the totals", async () => {
+      queryMock.mockImplementation(
+        async ({
+          query_params,
+        }: {
+          query_params: Record<string, string | number>;
+        }) =>
+          query_params.tenantId === "gov"
+            ? jsonResult(rowFor({ system_prompt: { cost: 0.5, tokens: 500 } }))
+            : jsonResult(rowFor({ system_prompt: { cost: 0.8, tokens: 800 } })),
+      );
+
+      const rows = await new PersonalUsageService().breakdownByCategory({
+        personalProjectId: "personal",
+        ingestionTenantId: "gov",
+        userEmail: "me@example.com",
+        window,
+      });
+
+      expect(queryMock).toHaveBeenCalledTimes(2);
+      // The gov query carries the principal-email predicate + bound param.
+      const govCall = queryMock.mock.calls.find(
+        ([arg]) => arg.query_params.tenantId === "gov",
+      );
+      expect(govCall?.[0].query).toContain(
+        "Attributes[{userKey:String}] = {userEmail:String}",
+      );
+      expect(govCall?.[0].query_params.userEmail).toBe("me@example.com");
+      // Merged: personal 0.8 + gov 0.5 = 1.3 / 800 + 500 = 1300.
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.category).toBe("system_prompt");
+      expect(rows[0]?.costUsd).toBeCloseTo(1.3, 10);
+      expect(rows[0]?.tokens).toBe(1300);
+    });
+  });
+
+  describe("given the gov-tenant union query fails", () => {
+    it("degrades to the personal-tenant rows instead of surfacing the error", async () => {
+      queryMock.mockImplementation(
+        async ({
+          query_params,
+        }: {
+          query_params: Record<string, string | number>;
+        }) => {
+          if (query_params.tenantId === "gov") throw new Error("CH down");
+          return jsonResult(
+            rowFor({ system_prompt: { cost: 0.8, tokens: 800 } }),
+          );
+        },
+      );
+
+      const rows = await new PersonalUsageService().breakdownByCategory({
+        personalProjectId: "personal",
+        ingestionTenantId: "gov",
+        userEmail: "me@example.com",
+        window,
+      });
+
+      expect(rows).toEqual([
+        { category: "system_prompt", costUsd: 0.8, tokens: 800 },
+      ]);
+    });
+  });
+});

--- a/langwatch/ee/governance/services/activity-monitor/activityMonitor.service.ts
+++ b/langwatch/ee/governance/services/activity-monitor/activityMonitor.service.ts
@@ -29,17 +29,22 @@
  */
 import type { ClickHouseClient } from "@clickhouse/client";
 import type { PrismaClient } from "@prisma/client";
-
+import {
+  blockCategoryCostAttr,
+  blockCategoryTokensAttr,
+  CATEGORIES,
+  type Category,
+} from "~/server/app-layer/traces/block-classification/categories";
 import { getClickHouseClientForOrganization } from "~/server/clickhouse/clickhouseClient";
-import { PROJECT_KIND } from "../governanceProject.service";
+import {
+  resolveTraceDepartmentId,
+  UNASSIGNED_DEPARTMENT,
+} from "../department/departmentAttribution";
 import {
   GOVERNANCE_ATTR,
   GOVERNANCE_ORIGIN_KIND_VALUE,
 } from "../governanceAttributeKeys";
-import {
-  UNASSIGNED_DEPARTMENT,
-  resolveTraceDepartmentId,
-} from "../department/departmentAttribution";
+import { PROJECT_KIND } from "../governanceProject.service";
 
 export interface SummaryResult {
   spentThisWindowUsd: number;
@@ -55,6 +60,15 @@ export interface SummaryResult {
   newUsersThisWindow: number;
   openAnomalyCount: number;
   anomalyBreakdown: { critical: number; warning: number; info: number };
+}
+
+export interface CategoryBreakdownRow {
+  /** Wire taxonomy value (ADR-033 CATEGORY_ENUM) — the stable key for labels. */
+  category: Category;
+  /** Cost attributed to this content category across the org in the window. */
+  costUsd: number;
+  /** Tokens attributed to this content category across the org in the window. */
+  tokens: number;
 }
 
 export interface SpendByUserRow {
@@ -320,7 +334,9 @@ export class ActivityMonitorService {
       input.organizationId,
     );
     const openAnomalyCount =
-      anomalyBreakdown.critical + anomalyBreakdown.warning + anomalyBreakdown.info;
+      anomalyBreakdown.critical +
+      anomalyBreakdown.warning +
+      anomalyBreakdown.info;
 
     const govProjectId = await this.resolveGovProjectId(input.organizationId);
     if (!govProjectId) {
@@ -500,8 +516,86 @@ export class ActivityMonitorService {
       // Trend-vs-previous needs a windowed CTE comparison; deferred to 3b.
       trendVsPreviousPct: 0,
       hasPriorBaseline: false,
-      mostUsedTarget: r.mostUsedTarget && r.mostUsedTarget !== "" ? r.mostUsedTarget : null,
+      mostUsedTarget:
+        r.mostUsedTarget && r.mostUsedTarget !== "" ? r.mostUsedTarget : null,
     }));
+  }
+
+  /**
+   * Per-content-category cost + token breakdown across the org's governance-
+   * origin coding-agent traffic (ADR-033 PR D). Powers the Activity Monitor's
+   * aggregate "Cost breakdown by category" section. Category totals ride the
+   * reserved `langwatch.reserved.blockcat.<category>.{cost_usd,tokens}`
+   * attributes the trace fold accumulates onto trace_summaries.
+   *
+   * Same tenancy + origin filter + latest-version dedup as `spendByUser`: pin
+   * `TenantId = govProjectId`, keep only `origin.kind = ingestion_source`, and
+   * dedup to the latest version per trace via the IN-tuple pattern (so summing
+   * the surviving rows counts each trace once). Analytics only — never billing.
+   *
+   * Empty result (all categories zero) → [], which the dashboard reads as
+   * "nothing captured" and renders the payload-capture enablement hint.
+   */
+  async categoryBreakdown(input: {
+    organizationId: string;
+    windowDays: number;
+  }): Promise<CategoryBreakdownRow[]> {
+    const govProjectId = await this.resolveGovProjectId(input.organizationId);
+    if (!govProjectId) return [];
+
+    const ch = await this.getClickhouse(input.organizationId);
+    if (!ch) return [];
+
+    const now = Date.now();
+    const windowMs = input.windowDays * 24 * 60 * 60 * 1000;
+
+    const selects = CATEGORIES.map(
+      (_category, i) =>
+        `sum(toFloat64OrZero(ts.Attributes[{c${i}:String}])) AS cost_${i},\n` +
+        `sum(toFloat64OrZero(ts.Attributes[{k${i}:String}])) AS tok_${i}`,
+    ).join(",\n");
+
+    const query_params: Record<string, string | number> = {
+      tenantId: govProjectId,
+      windowStart: now - windowMs,
+      originKey: GOVERNANCE_ATTR.ORIGIN_KIND,
+      originValue: GOVERNANCE_ORIGIN_KIND_VALUE,
+    };
+    CATEGORIES.forEach((category, i) => {
+      query_params[`c${i}`] = blockCategoryCostAttr(category);
+      query_params[`k${i}`] = blockCategoryTokensAttr(category);
+    });
+
+    const result = await ch.query({
+      query: `
+        SELECT
+          ${selects}
+        FROM trace_summaries ts
+        WHERE ts.TenantId = {tenantId:String}
+          AND ts.OccurredAt >= fromUnixTimestamp64Milli({windowStart:UInt64})
+          AND ts.Attributes[{originKey:String}] = {originValue:String}
+          AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
+            SELECT TenantId, TraceId, max(UpdatedAt)
+            FROM trace_summaries
+            WHERE TenantId = {tenantId:String}
+              AND OccurredAt >= fromUnixTimestamp64Milli({windowStart:UInt64})
+            GROUP BY TenantId, TraceId
+          )
+      `,
+      query_params,
+      format: "JSONEachRow",
+    });
+    const [row] = (await result.json()) as Array<Record<string, number | null>>;
+    if (!row) return [];
+
+    const breakdown: CategoryBreakdownRow[] = [];
+    CATEGORIES.forEach((category, i) => {
+      const costUsd = Number(row[`cost_${i}`]) || 0;
+      const tokens = Number(row[`tok_${i}`]) || 0;
+      if (costUsd <= 0 && tokens <= 0) return;
+      breakdown.push({ category, costUsd, tokens });
+    });
+    return breakdown.sort((a, b) => b.costUsd - a.costUsd);
   }
 
   /**
@@ -529,7 +623,10 @@ export class ActivityMonitorService {
     windowDays: number;
   }): Promise<SpendByDepartmentRow[]> {
     const projects = await this.prisma.project.findMany({
-      where: { team: { organizationId: input.organizationId }, archivedAt: null },
+      where: {
+        team: { organizationId: input.organizationId },
+        archivedAt: null,
+      },
       select: { id: true, departmentId: true },
     });
     if (projects.length === 0) return [];
@@ -613,7 +710,10 @@ export class ActivityMonitorService {
       acc.set(key, {
         spendUsd: prior.spendUsd + Number(r.spendUsdStr),
         requestCount: prior.requestCount + Number(r.requests),
-        lastActivityMs: Math.max(prior.lastActivityMs, Number(r.lastActivityMs)),
+        lastActivityMs: Math.max(
+          prior.lastActivityMs,
+          Number(r.lastActivityMs),
+        ),
       });
     }
 
@@ -781,7 +881,9 @@ export class ActivityMonitorService {
     }>;
     if (sourceRows.length === 0) return [];
 
-    const sourceIds = sourceRows.map((r) => r.sourceId).filter((id) => id !== "");
+    const sourceIds = sourceRows
+      .map((r) => r.sourceId)
+      .filter((id) => id !== "");
     const sources = await this.prisma.ingestionSource.findMany({
       where: { id: { in: sourceIds }, organizationId: input.organizationId },
       select: {
@@ -790,9 +892,7 @@ export class ActivityMonitorService {
         team: { select: { id: true, name: true } },
       },
     });
-    const teamBySource = new Map(
-      sources.map((s) => [s.id, s.team] as const),
-    );
+    const teamBySource = new Map(sources.map((s) => [s.id, s.team] as const));
 
     const ORG_WIDE_KEY = "__org_wide__";
     const byTeam = new Map<
@@ -822,7 +922,10 @@ export class ActivityMonitorService {
         existing.prevSpend += prevSpend;
         existing.requestCount += requestCount;
         existing.sourceCount += 1;
-        existing.lastActivityMs = Math.max(existing.lastActivityMs, lastActivityMs);
+        existing.lastActivityMs = Math.max(
+          existing.lastActivityMs,
+          lastActivityMs,
+        );
       } else {
         byTeam.set(key, {
           teamId,
@@ -1195,7 +1298,9 @@ export class ActivityMonitorService {
     if (!ch) return [];
 
     const limit = input.limit ?? 50;
-    const beforeMs = input.beforeIso ? new Date(input.beforeIso).getTime() : Date.now();
+    const beforeMs = input.beforeIso
+      ? new Date(input.beforeIso).getTime()
+      : Date.now();
 
     // Pull recent traces for the source. Webhook log_records are out of
     // scope for this endpoint (the per-source detail page renders trace

--- a/langwatch/ee/governance/services/activity-monitor/activityMonitor.service.ts
+++ b/langwatch/ee/governance/services/activity-monitor/activityMonitor.service.ts
@@ -566,8 +566,16 @@ export class ActivityMonitorService {
       query_params[`k${i}`] = blockCategoryTokensAttr(category);
     });
 
-    const result = await ch.query({
-      query: `
+    // Resource-guarded: 36 sum(Attributes[...]) over the whole org window is
+    // the aggregation shape that has OOM'd ClickHouse before. Bounded threads,
+    // hard time cap, external group-by spill — and any failure degrades to []
+    // (the dashboard's "nothing captured" state) rather than surfacing a 500.
+    // Analytics display only, so degrade-to-empty is safe; never used for
+    // billing.
+    let row: Record<string, number | null> | undefined;
+    try {
+      const result = await ch.query({
+        query: `
         SELECT
           ${selects}
         FROM trace_summaries ts
@@ -581,11 +589,16 @@ export class ActivityMonitorService {
               AND OccurredAt >= fromUnixTimestamp64Milli({windowStart:UInt64})
             GROUP BY TenantId, TraceId
           )
+        SETTINGS max_threads = 2, max_execution_time = 45,
+          max_bytes_before_external_group_by = 500000000
       `,
-      query_params,
-      format: "JSONEachRow",
-    });
-    const [row] = (await result.json()) as Array<Record<string, number | null>>;
+        query_params,
+        format: "JSONEachRow",
+      });
+      [row] = (await result.json()) as Array<Record<string, number | null>>;
+    } catch {
+      return [];
+    }
     if (!row) return [];
 
     const breakdown: CategoryBreakdownRow[] = [];

--- a/langwatch/ee/governance/services/activity-monitor/activityMonitor.service.ts
+++ b/langwatch/ee/governance/services/activity-monitor/activityMonitor.service.ts
@@ -334,9 +334,7 @@ export class ActivityMonitorService {
       input.organizationId,
     );
     const openAnomalyCount =
-      anomalyBreakdown.critical +
-      anomalyBreakdown.warning +
-      anomalyBreakdown.info;
+      anomalyBreakdown.critical + anomalyBreakdown.warning + anomalyBreakdown.info;
 
     const govProjectId = await this.resolveGovProjectId(input.organizationId);
     if (!govProjectId) {
@@ -636,10 +634,7 @@ export class ActivityMonitorService {
     windowDays: number;
   }): Promise<SpendByDepartmentRow[]> {
     const projects = await this.prisma.project.findMany({
-      where: {
-        team: { organizationId: input.organizationId },
-        archivedAt: null,
-      },
+      where: { team: { organizationId: input.organizationId }, archivedAt: null },
       select: { id: true, departmentId: true },
     });
     if (projects.length === 0) return [];
@@ -723,10 +718,7 @@ export class ActivityMonitorService {
       acc.set(key, {
         spendUsd: prior.spendUsd + Number(r.spendUsdStr),
         requestCount: prior.requestCount + Number(r.requests),
-        lastActivityMs: Math.max(
-          prior.lastActivityMs,
-          Number(r.lastActivityMs),
-        ),
+        lastActivityMs: Math.max(prior.lastActivityMs, Number(r.lastActivityMs)),
       });
     }
 
@@ -894,9 +886,7 @@ export class ActivityMonitorService {
     }>;
     if (sourceRows.length === 0) return [];
 
-    const sourceIds = sourceRows
-      .map((r) => r.sourceId)
-      .filter((id) => id !== "");
+    const sourceIds = sourceRows.map((r) => r.sourceId).filter((id) => id !== "");
     const sources = await this.prisma.ingestionSource.findMany({
       where: { id: { in: sourceIds }, organizationId: input.organizationId },
       select: {
@@ -905,7 +895,9 @@ export class ActivityMonitorService {
         team: { select: { id: true, name: true } },
       },
     });
-    const teamBySource = new Map(sources.map((s) => [s.id, s.team] as const));
+    const teamBySource = new Map(
+      sources.map((s) => [s.id, s.team] as const),
+    );
 
     const ORG_WIDE_KEY = "__org_wide__";
     const byTeam = new Map<
@@ -935,10 +927,7 @@ export class ActivityMonitorService {
         existing.prevSpend += prevSpend;
         existing.requestCount += requestCount;
         existing.sourceCount += 1;
-        existing.lastActivityMs = Math.max(
-          existing.lastActivityMs,
-          lastActivityMs,
-        );
+        existing.lastActivityMs = Math.max(existing.lastActivityMs, lastActivityMs);
       } else {
         byTeam.set(key, {
           teamId,
@@ -1311,9 +1300,7 @@ export class ActivityMonitorService {
     if (!ch) return [];
 
     const limit = input.limit ?? 50;
-    const beforeMs = input.beforeIso
-      ? new Date(input.beforeIso).getTime()
-      : Date.now();
+    const beforeMs = input.beforeIso ? new Date(input.beforeIso).getTime() : Date.now();
 
     // Pull recent traces for the source. Webhook log_records are out of
     // scope for this endpoint (the per-source detail page renders trace

--- a/langwatch/ee/governance/services/personalUsage.service.ts
+++ b/langwatch/ee/governance/services/personalUsage.service.ts
@@ -29,6 +29,12 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import { ANALYTICS_CLICKHOUSE_SETTINGS } from "~/server/analytics/clickhouse/clickhouse-analytics.service";
 import {
+  blockCategoryCostAttr,
+  blockCategoryTokensAttr,
+  CATEGORIES,
+  type Category,
+} from "~/server/app-layer/traces/block-classification/categories";
+import {
   getClickHouseClientForProject,
   isClickHouseEnabled,
 } from "~/server/clickhouse/clickhouseClient";
@@ -76,6 +82,15 @@ export interface PersonalUsageBreakdown {
   /** Portion actually billed per token (excludes bundled spend). */
   billedUsd: number;
   requests: number;
+}
+
+export interface PersonalUsageCategoryBreakdown {
+  /** Wire taxonomy value (ADR-033 CATEGORY_ENUM) — the stable key for labels. */
+  category: Category;
+  /** Cost attributed to this content category over the window. */
+  costUsd: number;
+  /** Tokens attributed to this content category over the window. */
+  tokens: number;
 }
 
 export interface PersonalUsageQueryInput {
@@ -458,6 +473,90 @@ export class PersonalUsageService {
     return Array.from(aggregated.values())
       .sort((a, b) => b.spentUsd - a.spentUsd)
       .slice(0, limit);
+  }
+
+  /**
+   * Per-content-category cost + token breakdown (ADR-033 PR D). Powers the
+   * "Usage breakdown" lanes on /me. Category totals ride the reserved
+   * `langwatch.reserved.blockcat.<category>.{cost_usd,tokens}` attributes the
+   * trace fold accumulates onto trace_summaries, so this reads the personal
+   * project tenant directly — the same dedup-per-trace pattern as the sibling
+   * spend queries (argMax by UpdatedAt) so a replayed/re-folded trace counts
+   * once. Analytics only: these numbers never feed billing (ADR-033 invariant).
+   *
+   * Categories with zero cost AND zero tokens are dropped, so an all-zero
+   * result is an empty array — the /me view reads that as "nothing captured"
+   * and renders the payload-capture enablement hint.
+   *
+   * Ingestion-source ledger traffic is NOT unioned here: the gateway ledger
+   * carries no per-category totals (categories live only on trace summaries),
+   * so there is nothing to merge.
+   */
+  async breakdownByCategory(
+    input: PersonalUsageQueryInput,
+  ): Promise<PersonalUsageCategoryBreakdown[]> {
+    const window = input.window ?? defaultMonthWindow();
+    const client = await getClickHouseClientForProject(input.personalProjectId);
+    if (!client) return [];
+
+    // One argMax-per-trace column per (category, metric), summed in the outer
+    // query. Aliases are index-based (disjoint from any inner name) to avoid the
+    // ClickHouse alias-shadowing trap where an outer aggregate resolves a bare
+    // name back to itself.
+    const inner = CATEGORIES.map((category, i) => {
+      const costKey = `cost_${i}`;
+      const tokKey = `tok_${i}`;
+      return (
+        `argMax(toFloat64OrZero(Attributes[{c${i}:String}]), UpdatedAt) AS ${costKey},\n` +
+        `argMax(toFloat64OrZero(Attributes[{k${i}:String}]), UpdatedAt) AS ${tokKey}`
+      );
+    }).join(",\n");
+    const outer = CATEGORIES.map(
+      (_category, i) =>
+        `sum(cost_${i}) AS scost_${i}, sum(tok_${i}) AS stok_${i}`,
+    ).join(",\n");
+
+    const query_params: Record<string, string | number> = {
+      tenantId: input.personalProjectId,
+      fromMs: window.start.getTime(),
+      toMs: window.end.getTime(),
+    };
+    CATEGORIES.forEach((category, i) => {
+      query_params[`c${i}`] = blockCategoryCostAttr(category);
+      query_params[`k${i}`] = blockCategoryTokensAttr(category);
+    });
+
+    const result = await client.query({
+      query: `
+        SELECT
+          ${outer}
+        FROM (
+          SELECT
+            TraceId,
+            ${inner}
+          FROM trace_summaries
+          WHERE TenantId = {tenantId:String}
+            AND OccurredAt >= {fromMs:DateTime64(3, 'UTC')}
+            AND OccurredAt <  {toMs:DateTime64(3, 'UTC')}
+          GROUP BY TraceId
+        )
+        SETTINGS ${formatSettings(ANALYTICS_CLICKHOUSE_SETTINGS)}
+      `,
+      query_params,
+      format: "JSONEachRow",
+    });
+
+    const [row] = (await result.json()) as Array<Record<string, number | null>>;
+    if (!row) return [];
+
+    const breakdown: PersonalUsageCategoryBreakdown[] = [];
+    CATEGORIES.forEach((category, i) => {
+      const costUsd = Number(row[`scost_${i}`]) || 0;
+      const tokens = Number(row[`stok_${i}`]) || 0;
+      if (costUsd <= 0 && tokens <= 0) return;
+      breakdown.push({ category, costUsd, tokens });
+    });
+    return breakdown.sort((a, b) => b.costUsd - a.costUsd);
   }
 
   private async queryIngestionPrincipalBreakdown(

--- a/langwatch/ee/governance/services/personalUsage.service.ts
+++ b/langwatch/ee/governance/services/personalUsage.service.ts
@@ -38,6 +38,7 @@ import {
   getClickHouseClientForProject,
   isClickHouseEnabled,
 } from "~/server/clickhouse/clickhouseClient";
+import { GOVERNANCE_ATTR } from "./governanceAttributeKeys";
 
 export interface PersonalUsageWindow {
   /** Inclusive UTC start of the rollup window. */
@@ -107,6 +108,16 @@ export interface PersonalUsageQueryInput {
    * traffic.
    */
   userId?: string;
+  /**
+   * Owner's principal EMAIL. Used only by `breakdownByCategory` to
+   * attribute ingestion-source traffic on the org's Governance Project
+   * trace summaries: those rows carry the acting user on
+   * `Attributes['langwatch.user_id']` (an email, per GOVERNANCE_ATTR.USER_ID),
+   * so the category union filters on it. Distinct from `userId`, which keys
+   * the gateway_budget_ledger PRINCIPAL paths (summary / buckets / models).
+   * Requires `ingestionTenantId` to take effect; omitted → no category union.
+   */
+  userEmail?: string;
   /**
    * The org's hidden Governance Project tenant id. Ingestion-source
    * ledger rows are written under THIS tenant (ingestionRoutes.ts writes
@@ -488,9 +499,15 @@ export class PersonalUsageService {
    * result is an empty array — the /me view reads that as "nothing captured"
    * and renders the payload-capture enablement hint.
    *
-   * Ingestion-source ledger traffic is NOT unioned here: the gateway ledger
-   * carries no per-category totals (categories live only on trace summaries),
-   * so there is nothing to merge.
+   * Ingestion-source union: unlike the gateway_budget_ledger (which carries no
+   * per-category split), the org's Governance Project trace summaries DO carry
+   * the blockcat attrs plus per-user attribution on
+   * `Attributes['langwatch.user_id']` (the principal EMAIL). So when
+   * `userEmail` + `ingestionTenantId` are supplied, a second query over that
+   * gov tenant — filtered to this user's rows — is unioned in, picking up
+   * coding-agent traffic that lands under the governance tenant rather than the
+   * personal project. That union degrades to no-union on failure so a CH hiccup
+   * never blanks the personal rows.
    */
   async breakdownByCategory(
     input: PersonalUsageQueryInput,
@@ -499,32 +516,96 @@ export class PersonalUsageService {
     const client = await getClickHouseClientForProject(input.personalProjectId);
     if (!client) return [];
 
-    // One argMax-per-trace column per (category, metric), summed in the outer
-    // query. Aliases are index-based (disjoint from any inner name) to avoid the
-    // ClickHouse alias-shadowing trap where an outer aggregate resolves a bare
-    // name back to itself.
-    const inner = CATEGORIES.map((category, i) => {
-      const costKey = `cost_${i}`;
-      const tokKey = `tok_${i}`;
-      return (
-        `argMax(toFloat64OrZero(Attributes[{c${i}:String}]), UpdatedAt) AS ${costKey},\n` +
-        `argMax(toFloat64OrZero(Attributes[{k${i}:String}]), UpdatedAt) AS ${tokKey}`
-      );
-    }).join(",\n");
+    // Personal-tenant totals. Left un-guarded on purpose: a throw here is a real
+    // query regression the integration test must catch, not a degrade path.
+    const totals = await this.queryCategoryTotals(client, {
+      tenantId: input.personalProjectId,
+      window,
+    });
+
+    // Ingestion-source union over the gov tenant, scoped to this principal's
+    // rows via the user_id (email) attribute. Best-effort: on failure keep the
+    // personal rows rather than surfacing a 500 for an analytics-only view.
+    if (input.userEmail && input.ingestionTenantId) {
+      try {
+        const ingestion = await this.queryCategoryTotals(client, {
+          tenantId: input.ingestionTenantId,
+          window,
+          userEmail: input.userEmail,
+        });
+        for (const [category, v] of ingestion) {
+          const existing = totals.get(category) ?? { costUsd: 0, tokens: 0 };
+          existing.costUsd += v.costUsd;
+          existing.tokens += v.tokens;
+          totals.set(category, existing);
+        }
+      } catch {
+        // no-union: `totals` already holds the personal-tenant rows.
+      }
+    }
+
+    const breakdown: PersonalUsageCategoryBreakdown[] = [];
+    for (const category of CATEGORIES) {
+      const v = totals.get(category);
+      if (!v) continue;
+      if (v.costUsd <= 0 && v.tokens <= 0) continue;
+      breakdown.push({ category, costUsd: v.costUsd, tokens: v.tokens });
+    }
+    return breakdown.sort((a, b) => b.costUsd - a.costUsd);
+  }
+
+  /**
+   * One category-totals query over a single tenant's trace summaries: one
+   * argMax-per-trace column per (category, metric), summed in the outer query.
+   * Aliases are index-based (disjoint from any inner name) to avoid the
+   * ClickHouse alias-shadowing trap where an outer aggregate resolves a bare
+   * name back to itself. Returns every category (including zeros) keyed by enum
+   * value; the caller merges, filters zeros, and sorts.
+   *
+   * `userEmail` (ingestion-source union only): the argMax dedup pattern has a
+   * single WHERE (in the per-trace subquery), so the principal-attribution
+   * filter `Attributes['langwatch.user_id'] = {userEmail}` is applied there —
+   * dedup + aggregation happen above it, so one WHERE fully scopes the result.
+   *
+   * Resource-guarded like the org variant (`max_threads`/`max_execution_time`
+   * merged with the analytics external-group-by spill) — the per-category
+   * sum-over-attributes shape has OOM'd ClickHouse before.
+   */
+  private async queryCategoryTotals(
+    client: ClickHouseClient,
+    params: {
+      tenantId: string;
+      window: PersonalUsageWindow;
+      userEmail?: string;
+    },
+  ): Promise<Map<Category, { costUsd: number; tokens: number }>> {
+    const inner = CATEGORIES.map(
+      (_category, i) =>
+        `argMax(toFloat64OrZero(Attributes[{c${i}:String}]), UpdatedAt) AS cost_${i},\n` +
+        `argMax(toFloat64OrZero(Attributes[{k${i}:String}]), UpdatedAt) AS tok_${i}`,
+    ).join(",\n");
     const outer = CATEGORIES.map(
       (_category, i) =>
         `sum(cost_${i}) AS scost_${i}, sum(tok_${i}) AS stok_${i}`,
     ).join(",\n");
 
     const query_params: Record<string, string | number> = {
-      tenantId: input.personalProjectId,
-      fromMs: window.start.getTime(),
-      toMs: window.end.getTime(),
+      tenantId: params.tenantId,
+      fromMs: params.window.start.getTime(),
+      toMs: params.window.end.getTime(),
     };
     CATEGORIES.forEach((category, i) => {
       query_params[`c${i}`] = blockCategoryCostAttr(category);
       query_params[`k${i}`] = blockCategoryTokensAttr(category);
     });
+
+    const userFilter = params.userEmail
+      ? "AND Attributes[{userKey:String}] = {userEmail:String}"
+      : "";
+    if (params.userEmail) {
+      query_params.userKey = GOVERNANCE_ATTR.USER_ID;
+      query_params.userEmail = params.userEmail;
+    }
 
     const result = await client.query({
       query: `
@@ -538,25 +619,27 @@ export class PersonalUsageService {
           WHERE TenantId = {tenantId:String}
             AND OccurredAt >= {fromMs:DateTime64(3, 'UTC')}
             AND OccurredAt <  {toMs:DateTime64(3, 'UTC')}
+            ${userFilter}
           GROUP BY TraceId
         )
-        SETTINGS ${formatSettings(ANALYTICS_CLICKHOUSE_SETTINGS)}
+        SETTINGS max_threads = 2, max_execution_time = 45, ${formatSettings(
+          ANALYTICS_CLICKHOUSE_SETTINGS,
+        )}
       `,
       query_params,
       format: "JSONEachRow",
     });
 
     const [row] = (await result.json()) as Array<Record<string, number | null>>;
-    if (!row) return [];
-
-    const breakdown: PersonalUsageCategoryBreakdown[] = [];
+    const totals = new Map<Category, { costUsd: number; tokens: number }>();
+    if (!row) return totals;
     CATEGORIES.forEach((category, i) => {
-      const costUsd = Number(row[`scost_${i}`]) || 0;
-      const tokens = Number(row[`stok_${i}`]) || 0;
-      if (costUsd <= 0 && tokens <= 0) return;
-      breakdown.push({ category, costUsd, tokens });
+      totals.set(category, {
+        costUsd: Number(row[`scost_${i}`]) || 0,
+        tokens: Number(row[`stok_${i}`]) || 0,
+      });
     });
-    return breakdown.sort((a, b) => b.costUsd - a.costUsd);
+    return totals;
   }
 
   private async queryIngestionPrincipalBreakdown(

--- a/langwatch/src/app/api/me/[[...route]]/app.ts
+++ b/langwatch/src/app/api/me/[[...route]]/app.ts
@@ -114,13 +114,24 @@ export function registerMeRoutes(
       };
 
       // Independent rollups — CH multiplexes them happily.
-      const [summary, dailyBuckets, breakdownByModel] = await Promise.all([
-        usage.summary(input),
-        usage.dailyBuckets(input),
-        usage.breakdownByModel(input),
-      ]);
+      const [summary, dailyBuckets, breakdownByModel, breakdownByCategory] =
+        await Promise.all([
+          usage.summary(input),
+          usage.dailyBuckets(input),
+          usage.breakdownByModel(input),
+          // Category totals live only on trace summaries — no ledger union.
+          usage.breakdownByCategory({
+            personalProjectId: input.personalProjectId,
+            window: input.window,
+          }),
+        ]);
 
-      return c.json({ summary, dailyBuckets, breakdownByModel });
+      return c.json({
+        summary,
+        dailyBuckets,
+        breakdownByModel,
+        breakdownByCategory,
+      });
     },
   );
 }

--- a/langwatch/src/app/api/me/[[...route]]/app.ts
+++ b/langwatch/src/app/api/me/[[...route]]/app.ts
@@ -105,10 +105,19 @@ export function registerMeRoutes(
           })
         : null;
 
+      // The category union attributes gov-tenant trace summaries by the
+      // principal EMAIL (Attributes['langwatch.user_id']), not the userId the
+      // ledger paths key on — so resolve the owner's email from ownerUserId.
+      const owner = await prisma.user.findUnique({
+        where: { id: project.ownerUserId },
+        select: { email: true },
+      });
+
       const usage = new PersonalUsageService();
       const input = {
         personalProjectId: project.id,
         userId: project.ownerUserId,
+        userEmail: owner?.email ?? undefined,
         ingestionTenantId: governanceProject?.id,
         window,
       };
@@ -119,10 +128,14 @@ export function registerMeRoutes(
           usage.summary(input),
           usage.dailyBuckets(input),
           usage.breakdownByModel(input),
-          // Category totals live only on trace summaries — no ledger union.
+          // Category totals live on trace summaries: personal-tenant rows plus
+          // this user's ingestion-source rows on the gov tenant (attributed by
+          // principal email), when both are available.
           usage.breakdownByCategory({
             personalProjectId: input.personalProjectId,
             window: input.window,
+            userEmail: input.userEmail,
+            ingestionTenantId: input.ingestionTenantId,
           }),
         ]);
 

--- a/langwatch/src/app/api/me/[[...route]]/schemas.ts
+++ b/langwatch/src/app/api/me/[[...route]]/schemas.ts
@@ -64,8 +64,15 @@ const breakdownSchema = z.object({
   requests: z.number(),
 });
 
+const categoryBreakdownSchema = z.object({
+  category: z.string(),
+  costUsd: z.number(),
+  tokens: z.number(),
+});
+
 export const meUsageResponseSchema = z.object({
   summary: summarySchema,
   dailyBuckets: z.array(bucketSchema),
   breakdownByModel: z.array(breakdownSchema),
+  breakdownByCategory: z.array(categoryBreakdownSchema),
 });

--- a/langwatch/src/components/governance/CategoryBreakdownBars.tsx
+++ b/langwatch/src/components/governance/CategoryBreakdownBars.tsx
@@ -1,0 +1,109 @@
+import { Box, HStack, Link, Text, VStack } from "@chakra-ui/react";
+import { formatBudgetUsd } from "~/components/gateway/formatBudgetUsd";
+import { Tooltip } from "~/components/ui/tooltip";
+
+/**
+ * Shared cost-breakdown-by-content-category lanes (ADR-033 PR D), rendered on
+ * both the /me usage view and the org Activity Monitor. Presentational only —
+ * the caller decides the window, fetches the rows, and owns the empty-state
+ * (use `CategoryBreakdownEnablementHint` when there is nothing to show).
+ *
+ * Copy shows the human category label, never the raw wire enum
+ * (dev/docs/best_practices/copywriting.md).
+ */
+export interface CategoryBreakdownBarRow {
+  /** Wire taxonomy value — stable React key. */
+  category: string;
+  /** Human-readable lane label. */
+  label: string;
+  costUsd: number;
+  tokens: number;
+  /** Share of total category cost, 0–100. */
+  sharePct: number;
+}
+
+export function CategoryBreakdownBars({
+  rows,
+}: {
+  rows: CategoryBreakdownBarRow[];
+}) {
+  const maxCost = Math.max(...rows.map((r) => r.costUsd), 0.000001);
+  return (
+    <VStack align="stretch" gap={3}>
+      {rows.map((row) => {
+        const widthPct = (row.costUsd / maxCost) * 100;
+        return (
+          <HStack key={row.category} gap={3}>
+            <Text fontSize="sm" minWidth="160px">
+              {row.label}
+            </Text>
+            <Tooltip
+              openDelay={100}
+              positioning={{ placement: "top" }}
+              content={
+                <VStack gap={0.5} align="start">
+                  <Text fontWeight="semibold">{row.label}</Text>
+                  <Text>{formatBudgetUsd(row.costUsd)}</Text>
+                  <Text>{row.tokens.toLocaleString()} tokens</Text>
+                </VStack>
+              }
+            >
+              <Box
+                flex={1}
+                height="14px"
+                backgroundColor="bg.muted"
+                borderRadius="sm"
+                overflow="hidden"
+                position="relative"
+                cursor="default"
+              >
+                <Box
+                  position="absolute"
+                  left={0}
+                  top={0}
+                  height="full"
+                  width={`${Math.max(row.costUsd > 0 ? 2 : 0, widthPct)}%`}
+                  backgroundColor="purple.400"
+                />
+              </Box>
+            </Tooltip>
+            <HStack gap={2} minWidth="120px" justifyContent="end" fontSize="sm">
+              <Text>{formatBudgetUsd(row.costUsd)}</Text>
+              <Text
+                color="fg.subtle"
+                fontSize="xs"
+                minWidth="34px"
+                textAlign="end"
+              >
+                {Math.round(row.sharePct)}%
+              </Text>
+            </HStack>
+          </HStack>
+        );
+      })}
+    </VStack>
+  );
+}
+
+/**
+ * Empty-state for the category breakdown when no content was captured
+ * (ADR-033 Decision 7). Category numbers only exist when payload capture is on,
+ * so the hint says what the customer must do and links to the settings.
+ */
+export function CategoryBreakdownEnablementHint({
+  settingsHref,
+}: {
+  settingsHref: string;
+}) {
+  return (
+    <VStack align="start" gap={1} paddingY={2}>
+      <Text fontSize="sm" color="fg.muted">
+        Turn on payload capture to see where your tokens go — which share is
+        system prompt, MCP tools, skills, thinking, and more.
+      </Text>
+      <Link href={settingsHref} color="blue.600" fontSize="sm">
+        Enable payload capture →
+      </Link>
+    </VStack>
+  );
+}

--- a/langwatch/src/components/governance/CategoryBreakdownBars.tsx
+++ b/langwatch/src/components/governance/CategoryBreakdownBars.tsx
@@ -98,8 +98,9 @@ export function CategoryBreakdownEnablementHint({
   return (
     <VStack align="start" gap={1} paddingY={2}>
       <Text fontSize="sm" color="fg.muted">
-        Turn on payload capture to see where your tokens go — which share is
-        system prompt, MCP tools, skills, thinking, and more.
+        Your coding-agent traffic may not be captured with content yet, so
+        there's nothing to break down. Turn on payload capture to see where your
+        tokens go — system prompt, MCP tools, skills, thinking, and more.
       </Text>
       <Link href={settingsHref} color="blue.600" fontSize="sm">
         Enable payload capture →

--- a/langwatch/src/components/governance/__tests__/CategoryBreakdownBars.integration.test.tsx
+++ b/langwatch/src/components/governance/__tests__/CategoryBreakdownBars.integration.test.tsx
@@ -62,14 +62,14 @@ describe("<CategoryBreakdownBars/>", () => {
 
   describe("given no captured content", () => {
     /** @scenario "The breakdown shows an enablement hint when no content was captured" */
-    it("explains payload capture must be enabled and links to the settings", () => {
+    it("explains coding-agent traffic may not be captured and links to enabling payload capture", () => {
       render(<CategoryBreakdownEnablementHint settingsHref="/me/configure" />, {
         wrapper: Wrapper,
       });
 
       expect(
         screen.getByText(
-          /turn on payload capture to see where your tokens go/i,
+          /your coding-agent traffic may not be captured.*turn on payload capture to see where your tokens go/i,
         ),
       ).toBeInTheDocument();
       const link = screen.getByRole("link", {

--- a/langwatch/src/components/governance/__tests__/CategoryBreakdownBars.integration.test.tsx
+++ b/langwatch/src/components/governance/__tests__/CategoryBreakdownBars.integration.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The category cost-breakdown lanes shared by the /me usage view and the org
+ * Activity Monitor (ADR-033 PR D). Renders human-readable category labels with
+ * their cost + share, and an enablement hint when nothing was captured.
+ *
+ * Spec: specs/ai-gateway/governance/cost-breakdown-dashboard.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  CategoryBreakdownBars,
+  CategoryBreakdownEnablementHint,
+} from "../CategoryBreakdownBars";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("<CategoryBreakdownBars/>", () => {
+  afterEach(cleanup);
+
+  describe("given classified category totals", () => {
+    /** @scenario "The personal usage view shows the user's cost breakdown by category" */
+    it("lists each category by its human label with cost and percent share", () => {
+      render(
+        <CategoryBreakdownBars
+          rows={[
+            {
+              category: "mcp_tool_definitions",
+              label: "MCP tool definitions",
+              costUsd: 0.6,
+              tokens: 600,
+              sharePct: 60,
+            },
+            {
+              category: "system_prompt",
+              label: "System prompt",
+              costUsd: 0.4,
+              tokens: 400,
+              sharePct: 40,
+            },
+          ]}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      // Human labels, not the raw wire enum values.
+      expect(screen.getByText("MCP tool definitions")).toBeInTheDocument();
+      expect(screen.getByText("System prompt")).toBeInTheDocument();
+      expect(
+        screen.queryByText("mcp_tool_definitions"),
+      ).not.toBeInTheDocument();
+      // Share percentages surface.
+      expect(screen.getByText("60%")).toBeInTheDocument();
+      expect(screen.getByText("40%")).toBeInTheDocument();
+    });
+  });
+
+  describe("given no captured content", () => {
+    /** @scenario "The breakdown shows an enablement hint when no content was captured" */
+    it("explains payload capture must be enabled and links to the settings", () => {
+      render(<CategoryBreakdownEnablementHint settingsHref="/me/configure" />, {
+        wrapper: Wrapper,
+      });
+
+      expect(screen.getByText(/payload capture/i)).toBeInTheDocument();
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute("href", "/me/configure");
+    });
+  });
+});

--- a/langwatch/src/components/governance/__tests__/CategoryBreakdownBars.integration.test.tsx
+++ b/langwatch/src/components/governance/__tests__/CategoryBreakdownBars.integration.test.tsx
@@ -67,8 +67,12 @@ describe("<CategoryBreakdownBars/>", () => {
         wrapper: Wrapper,
       });
 
-      expect(screen.getByText(/payload capture/i)).toBeInTheDocument();
-      const link = screen.getByRole("link");
+      expect(
+        screen.getByText(/turn on payload capture to see where your tokens go/i),
+      ).toBeInTheDocument();
+      const link = screen.getByRole("link", {
+        name: /enable payload capture/i,
+      });
       expect(link).toHaveAttribute("href", "/me/configure");
     });
   });

--- a/langwatch/src/components/governance/__tests__/CategoryBreakdownBars.integration.test.tsx
+++ b/langwatch/src/components/governance/__tests__/CategoryBreakdownBars.integration.test.tsx
@@ -68,7 +68,9 @@ describe("<CategoryBreakdownBars/>", () => {
       });
 
       expect(
-        screen.getByText(/turn on payload capture to see where your tokens go/i),
+        screen.getByText(
+          /turn on payload capture to see where your tokens go/i,
+        ),
       ).toBeInTheDocument();
       const link = screen.getByRole("link", {
         name: /enable payload capture/i,

--- a/langwatch/src/components/me/usePersonalContext.ts
+++ b/langwatch/src/components/me/usePersonalContext.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
-
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useRequiredSession } from "~/hooks/useRequiredSession";
+import { categoryLabel } from "~/server/app-layer/traces/block-classification/categories";
 import { api } from "~/utils/api";
 
 import { useWorkspaceData } from "../useWorkspaceData";
@@ -65,6 +65,14 @@ export type PersonalContext = {
   budget: PersonalBudgetState;
   spendByDay: Array<{ day: string; usd: number; billedUsd: number }>;
   spendByTool: Array<{ tool: string; usd: number; billedUsd: number }>;
+  /** Cost split by content category (ADR-033). Empty when no payload captured. */
+  spendByCategory: Array<{
+    category: string;
+    label: string;
+    costUsd: number;
+    tokens: number;
+    sharePct: number;
+  }>;
   /** Personal project the /me recent-activity table reads from + deep-links into. */
   personalProjectId: string | null;
   personalProjectSlug: string | null;
@@ -133,8 +141,8 @@ export function usePersonalContext(): PersonalContext {
       period: raw.period ?? "",
       scope: raw.scope ?? "",
       requestIncreaseUrl:
-        "requestIncreaseUrl" in raw ? raw.requestIncreaseUrl ?? null : null,
-      adminEmail: "adminEmail" in raw ? raw.adminEmail ?? null : null,
+        "requestIncreaseUrl" in raw ? (raw.requestIncreaseUrl ?? null) : null,
+      adminEmail: "adminEmail" in raw ? (raw.adminEmail ?? null) : null,
     };
   }, [personalBudgetQuery.data]);
 
@@ -204,6 +212,17 @@ export function usePersonalContext(): PersonalContext {
         usd: row.spentUsd,
         billedUsd: row.billedUsd,
       })) ?? [],
+    spendByCategory: (() => {
+      const rows = personalUsageQuery.data?.breakdownByCategory ?? [];
+      const total = rows.reduce((sum, r) => sum + r.costUsd, 0);
+      return rows.map((r) => ({
+        category: r.category,
+        label: categoryLabel(r.category),
+        costUsd: r.costUsd,
+        tokens: r.tokens,
+        sharePct: total > 0 ? (r.costUsd / total) * 100 : 0,
+      }));
+    })(),
     personalProjectId: personalContextQuery.data?.workspace.project.id ?? null,
     personalProjectSlug:
       personalContextQuery.data?.workspace.project.slug ?? null,

--- a/langwatch/src/components/me/usePersonalContext.ts
+++ b/langwatch/src/components/me/usePersonalContext.ts
@@ -141,8 +141,8 @@ export function usePersonalContext(): PersonalContext {
       period: raw.period ?? "",
       scope: raw.scope ?? "",
       requestIncreaseUrl:
-        "requestIncreaseUrl" in raw ? (raw.requestIncreaseUrl ?? null) : null,
-      adminEmail: "adminEmail" in raw ? (raw.adminEmail ?? null) : null,
+        "requestIncreaseUrl" in raw ? raw.requestIncreaseUrl ?? null : null,
+      adminEmail: "adminEmail" in raw ? raw.adminEmail ?? null : null,
     };
   }, [personalBudgetQuery.data]);
 

--- a/langwatch/src/pages/me/index.tsx
+++ b/langwatch/src/pages/me/index.tsx
@@ -243,11 +243,7 @@ function MyUsagePage() {
                   );
                 })}
               </HStack>
-              <HStack
-                justifyContent="space-between"
-                fontSize="xs"
-                color="fg.muted"
-              >
+              <HStack justifyContent="space-between" fontSize="xs" color="fg.muted">
                 <Text>{spendByDay[0]?.day}</Text>
                 <Text>{spendByDay[spendByDay.length - 1]?.day}</Text>
               </HStack>
@@ -316,8 +312,15 @@ function MyUsagePage() {
                         )}
                       </Box>
                     </Tooltip>
-                    <VStack gap={0} align="end" minWidth="90px" fontSize="sm">
-                      {showBilled && <Text>{fmtUsd(tool.billedUsd)}</Text>}
+                    <VStack
+                      gap={0}
+                      align="end"
+                      minWidth="90px"
+                      fontSize="sm"
+                    >
+                      {showBilled && (
+                        <Text>{fmtUsd(tool.billedUsd)}</Text>
+                      )}
                       {showTheoretical && tool.usd - tool.billedUsd > 1e-6 && (
                         <Text color="fg.subtle" fontSize="xs">
                           {fmtUsd(tool.usd - tool.billedUsd)} bundled
@@ -373,12 +376,7 @@ function SummaryCard({
       padding={4}
       backgroundColor="bg.subtle"
     >
-      <Text
-        fontSize="xs"
-        color="fg.muted"
-        textTransform="uppercase"
-        letterSpacing="wider"
-      >
+      <Text fontSize="xs" color="fg.muted" textTransform="uppercase" letterSpacing="wider">
         {title}
       </Text>
       <Text
@@ -389,11 +387,7 @@ function SummaryCard({
       >
         {value}
       </Text>
-      <Text
-        fontSize="sm"
-        color={tone === "red" ? "red.500" : "fg.muted"}
-        marginTop={1}
-      >
+      <Text fontSize="sm" color={tone === "red" ? "red.500" : "fg.muted"} marginTop={1}>
         {subline}
       </Text>
     </Box>
@@ -463,12 +457,7 @@ function BudgetBanner({
   const colors =
     tone === "red"
       ? { bg: "red.50", border: "red.200", title: "red.700", text: "red.700" }
-      : {
-          bg: "yellow.50",
-          border: "yellow.200",
-          title: "yellow.800",
-          text: "yellow.800",
-        };
+      : { bg: "yellow.50", border: "yellow.200", title: "yellow.800", text: "yellow.800" };
 
   return (
     <Box
@@ -555,12 +544,7 @@ function LegendChip({
       _hover={{ opacity: active ? 0.8 : 0.65 }}
       title={active ? `Hide ${label}` : `Show ${label}`}
     >
-      <Box
-        width="10px"
-        height="10px"
-        borderRadius="sm"
-        backgroundColor={color}
-      />
+      <Box width="10px" height="10px" borderRadius="sm" backgroundColor={color} />
       <Text
         color="fg.muted"
         textDecoration={active ? undefined : "line-through"}

--- a/langwatch/src/pages/me/index.tsx
+++ b/langwatch/src/pages/me/index.tsx
@@ -9,11 +9,11 @@ import {
 } from "@chakra-ui/react";
 import numeral from "numeral";
 import { useState } from "react";
-import Head from "~/utils/compat/next-head";
-
-import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
-import { Tooltip } from "~/components/ui/tooltip";
 import { formatBudgetUsd } from "~/components/gateway/formatBudgetUsd";
+import {
+  CategoryBreakdownBars,
+  CategoryBreakdownEnablementHint,
+} from "~/components/governance/CategoryBreakdownBars";
 import { AiToolsPortal } from "~/components/me/AiToolsPortal";
 import { BudgetExceededBanner } from "~/components/me/BudgetExceededBanner";
 import MyLayout from "~/components/me/MyLayout";
@@ -24,6 +24,9 @@ import {
 } from "~/components/me/PersonalTracesEmptyState";
 import { TraceIngestSection } from "~/components/me/TraceIngestSection";
 import { usePersonalContext } from "~/components/me/usePersonalContext";
+import { Tooltip } from "~/components/ui/tooltip";
+import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
+import Head from "~/utils/compat/next-head";
 
 // /me/usage frequently surfaces sub-cent spend; defer to the shared
 // gateway formatter so values like $0.000165 don't render as $0.00.
@@ -41,6 +44,7 @@ function MyUsagePage() {
     budget,
     spendByDay,
     spendByTool,
+    spendByCategory,
     personalProjectId,
     personalProjectSlug,
     organizationName,
@@ -239,7 +243,11 @@ function MyUsagePage() {
                   );
                 })}
               </HStack>
-              <HStack justifyContent="space-between" fontSize="xs" color="fg.muted">
+              <HStack
+                justifyContent="space-between"
+                fontSize="xs"
+                color="fg.muted"
+              >
                 <Text>{spendByDay[0]?.day}</Text>
                 <Text>{spendByDay[spendByDay.length - 1]?.day}</Text>
               </HStack>
@@ -308,15 +316,8 @@ function MyUsagePage() {
                         )}
                       </Box>
                     </Tooltip>
-                    <VStack
-                      gap={0}
-                      align="end"
-                      minWidth="90px"
-                      fontSize="sm"
-                    >
-                      {showBilled && (
-                        <Text>{fmtUsd(tool.billedUsd)}</Text>
-                      )}
+                    <VStack gap={0} align="end" minWidth="90px" fontSize="sm">
+                      {showBilled && <Text>{fmtUsd(tool.billedUsd)}</Text>}
                       {showTheoretical && tool.usd - tool.billedUsd > 1e-6 && (
                         <Text color="fg.subtle" fontSize="xs">
                           {fmtUsd(tool.usd - tool.billedUsd)} bundled
@@ -327,6 +328,14 @@ function MyUsagePage() {
                 );
               })}
             </VStack>
+          )}
+        </SectionCard>
+
+        <SectionCard title="Usage breakdown">
+          {spendByCategory.length === 0 ? (
+            <CategoryBreakdownEnablementHint settingsHref="/me/configure" />
+          ) : (
+            <CategoryBreakdownBars rows={spendByCategory} />
           )}
         </SectionCard>
 
@@ -364,7 +373,12 @@ function SummaryCard({
       padding={4}
       backgroundColor="bg.subtle"
     >
-      <Text fontSize="xs" color="fg.muted" textTransform="uppercase" letterSpacing="wider">
+      <Text
+        fontSize="xs"
+        color="fg.muted"
+        textTransform="uppercase"
+        letterSpacing="wider"
+      >
         {title}
       </Text>
       <Text
@@ -375,7 +389,11 @@ function SummaryCard({
       >
         {value}
       </Text>
-      <Text fontSize="sm" color={tone === "red" ? "red.500" : "fg.muted"} marginTop={1}>
+      <Text
+        fontSize="sm"
+        color={tone === "red" ? "red.500" : "fg.muted"}
+        marginTop={1}
+      >
         {subline}
       </Text>
     </Box>
@@ -445,7 +463,12 @@ function BudgetBanner({
   const colors =
     tone === "red"
       ? { bg: "red.50", border: "red.200", title: "red.700", text: "red.700" }
-      : { bg: "yellow.50", border: "yellow.200", title: "yellow.800", text: "yellow.800" };
+      : {
+          bg: "yellow.50",
+          border: "yellow.200",
+          title: "yellow.800",
+          text: "yellow.800",
+        };
 
   return (
     <Box
@@ -532,7 +555,12 @@ function LegendChip({
       _hover={{ opacity: active ? 0.8 : 0.65 }}
       title={active ? `Hide ${label}` : `Show ${label}`}
     >
-      <Box width="10px" height="10px" borderRadius="sm" backgroundColor={color} />
+      <Box
+        width="10px"
+        height="10px"
+        borderRadius="sm"
+        backgroundColor={color}
+      />
       <Text
         color="fg.muted"
         textDecoration={active ? undefined : "line-through"}

--- a/langwatch/src/pages/settings/governance.tsx
+++ b/langwatch/src/pages/settings/governance.tsx
@@ -19,6 +19,10 @@ import {
 } from "lucide-react";
 import numeral from "numeral";
 import { useEffect, useState } from "react";
+import {
+  CategoryBreakdownBars,
+  CategoryBreakdownEnablementHint,
+} from "~/components/governance/CategoryBreakdownBars";
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
 import { QuarantineFillAlert } from "~/components/governance/QuarantineFillAlert";
 import { SpendByTeamBar } from "~/components/governance/SpendByTeamBar";
@@ -32,6 +36,7 @@ import { toaster } from "~/components/ui/toaster";
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { categoryLabel } from "~/server/app-layer/traces/block-classification/categories";
 import { api, type RouterOutputs } from "~/utils/api";
 import { getHexColorForString } from "~/utils/rotatingColors";
 
@@ -128,6 +133,10 @@ function GovernanceOverviewPage() {
     { organizationId: orgId, windowDays: 30, groupBy: chartGroupBy },
     { enabled: !!orgId, refetchOnWindowFocus: false },
   );
+  const categoryBreakdownQuery = api.activityMonitor.categoryBreakdown.useQuery(
+    { organizationId: orgId, windowDays: 30 },
+    { enabled: !!orgId, refetchOnWindowFocus: false },
+  );
 
   const sources = sourcesQuery.data ?? [];
   const policies = policiesQuery.data ?? [];
@@ -139,6 +148,16 @@ function GovernanceOverviewPage() {
   const anomalies = anomaliesQuery.data ?? [];
   const anomalyRules = anomalyRulesQuery.data ?? [];
   const catalogTiles = catalogQuery.data ?? [];
+
+  const categoryRows = categoryBreakdownQuery.data ?? [];
+  const categoryTotal = categoryRows.reduce((sum, r) => sum + r.costUsd, 0);
+  const categoryBars = categoryRows.map((r) => ({
+    category: r.category,
+    label: categoryLabel(r.category),
+    costUsd: r.costUsd,
+    tokens: r.tokens,
+    sharePct: categoryTotal > 0 ? (r.costUsd / categoryTotal) * 100 : 0,
+  }));
 
   const hasSources = sources.length > 0;
   const hasPolicies = policies.length > 0;
@@ -405,6 +424,17 @@ function GovernanceOverviewPage() {
                 />
               ))}
             </VStack>
+          )}
+        </SectionCard>
+
+        <SectionCard
+          title="Cost breakdown by category"
+          subline="Coding-agent spend split by content category — system prompt, MCP tools, skills, thinking, and more (last 30 days). Analytics only; never affects billing."
+        >
+          {categoryBars.length === 0 ? (
+            <CategoryBreakdownEnablementHint settingsHref="/settings/governance" />
+          ) : (
+            <CategoryBreakdownBars rows={categoryBars} />
           )}
         </SectionCard>
 

--- a/langwatch/src/server/api/routers/user.ts
+++ b/langwatch/src/server/api/routers/user.ts
@@ -603,12 +603,15 @@ export const userRouter = createTRPCRouter({
             userId,
             ingestionTenantId,
           }),
-          // Category totals live only on the personal-project trace summaries
-          // (the gateway ledger carries no per-category split), so this reads
-          // the personal tenant without the ingestion-ledger union.
+          // Category totals live on trace summaries (the gateway ledger carries
+          // no per-category split). Personal-tenant rows plus, when the org has
+          // a governance tenant, this user's ingestion-source rows there —
+          // attributed by principal email on the gov trace summaries.
           usage.breakdownByCategory({
             personalProjectId: workspace.project.id,
             window,
+            userEmail: ctx.session.user.email ?? undefined,
+            ingestionTenantId,
           }),
         ]);
 

--- a/langwatch/src/server/api/routers/user.ts
+++ b/langwatch/src/server/api/routers/user.ts
@@ -551,6 +551,7 @@ export const userRouter = createTRPCRouter({
           },
           dailyBuckets: [],
           breakdownByModel: [],
+          breakdownByCategory: [],
         };
       }
 
@@ -582,31 +583,40 @@ export const userRouter = createTRPCRouter({
       // personal project tenant by the /me table (tracesV2.list), so it
       // isn't fetched here.
       const ingestionTenantId = governanceProject?.id;
-      const [summary, dailyBuckets, breakdownByModel] = await Promise.all([
-        usage.summary({
-          personalProjectId: workspace.project.id,
-          window,
-          userId,
-          ingestionTenantId,
-        }),
-        usage.dailyBuckets({
-          personalProjectId: workspace.project.id,
-          window,
-          userId,
-          ingestionTenantId,
-        }),
-        usage.breakdownByModel({
-          personalProjectId: workspace.project.id,
-          window,
-          userId,
-          ingestionTenantId,
-        }),
-      ]);
+      const [summary, dailyBuckets, breakdownByModel, breakdownByCategory] =
+        await Promise.all([
+          usage.summary({
+            personalProjectId: workspace.project.id,
+            window,
+            userId,
+            ingestionTenantId,
+          }),
+          usage.dailyBuckets({
+            personalProjectId: workspace.project.id,
+            window,
+            userId,
+            ingestionTenantId,
+          }),
+          usage.breakdownByModel({
+            personalProjectId: workspace.project.id,
+            window,
+            userId,
+            ingestionTenantId,
+          }),
+          // Category totals live only on the personal-project trace summaries
+          // (the gateway ledger carries no per-category split), so this reads
+          // the personal tenant without the ingestion-ledger union.
+          usage.breakdownByCategory({
+            personalProjectId: workspace.project.id,
+            window,
+          }),
+        ]);
 
       return {
         summary,
         dailyBuckets,
         breakdownByModel,
+        breakdownByCategory,
       };
     }),
 

--- a/langwatch/src/server/app-layer/traces/block-classification/__tests__/categories.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/__tests__/categories.unit.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { catchAllFor, InputCategory, OutputCategory } from "../categories";
+import {
+  CATEGORIES,
+  CATEGORY_LABELS,
+  catchAllFor,
+  categoryLabel,
+  InputCategory,
+  OutputCategory,
+} from "../categories";
 
 describe("catchAllFor", () => {
   describe("when the axis is input", () => {
@@ -22,5 +29,26 @@ describe("InputCategory and OutputCategory", () => {
     expect(input).toHaveLength(12);
     expect(output).toHaveLength(6);
     expect(new Set([...input, ...output]).size).toBe(18);
+  });
+});
+
+describe("CATEGORIES and CATEGORY_LABELS", () => {
+  const allValues = [
+    ...Object.values(InputCategory),
+    ...Object.values(OutputCategory),
+  ];
+
+  it("lists every enum value in CATEGORIES exactly once", () => {
+    expect([...CATEGORIES].sort()).toEqual([...allValues].sort());
+    expect(CATEGORIES).toHaveLength(18);
+  });
+
+  it("maps every category to a human label distinct from its wire value", () => {
+    for (const category of allValues) {
+      const label = CATEGORY_LABELS[category];
+      expect(label).toBeTruthy();
+      expect(label).not.toBe(category);
+      expect(categoryLabel(category)).toBe(label);
+    }
   });
 });

--- a/langwatch/src/server/app-layer/traces/block-classification/categories.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/categories.ts
@@ -41,6 +41,45 @@ export type Category = InputCategory | OutputCategory;
 
 export type Axis = "input" | "output";
 
+/** Every taxonomy value, input axis first then output axis. Single source for
+ * callers that must iterate the whole enum (fold rollups, dashboard queries) —
+ * order is stable so derived column/alias lists stay deterministic. */
+export const CATEGORIES: readonly Category[] = [
+  ...Object.values(InputCategory),
+  ...Object.values(OutputCategory),
+];
+
+/** Human-readable dashboard labels. Copy says what the lane means to the
+ * customer, never the raw wire enum (dev/docs/best_practices/copywriting.md).
+ * Pinned to the enum by the categories unit test so a new category can't ship
+ * without a label. */
+export const CATEGORY_LABELS: Record<Category, string> = {
+  [InputCategory.SYSTEM_PROMPT]: "System prompt",
+  [InputCategory.USER_INPUT]: "User input",
+  [InputCategory.PRIOR_CONTEXT]: "Prior context",
+  [InputCategory.TOOL_RESULT_BUILTIN]: "Built-in tool results",
+  [InputCategory.TOOL_RESULT_MCP]: "MCP tool results",
+  [InputCategory.TOOL_DEFINITIONS]: "Tool definitions",
+  [InputCategory.MCP_TOOL_DEFINITIONS]: "MCP tool definitions",
+  [InputCategory.SKILL_CONTENT]: "Skill content",
+  [InputCategory.MEMORY_CONTEXT]: "Memory context",
+  [InputCategory.FILE_ATTACHMENT]: "File attachments",
+  [InputCategory.IMAGE]: "Images",
+  [InputCategory.OTHER_INPUT]: "Other input",
+  [OutputCategory.ASSISTANT_TEXT]: "Assistant text",
+  [OutputCategory.TOOL_CALL_BUILTIN]: "Built-in tool calls",
+  [OutputCategory.TOOL_CALL_MCP]: "MCP tool calls",
+  [OutputCategory.SKILL_INVOCATION]: "Skill invocations",
+  [OutputCategory.THINKING]: "Thinking",
+  [OutputCategory.OTHER_OUTPUT]: "Other output",
+};
+
+/** Dashboard label for a category, falling back to the raw value if an
+ * unmapped one ever reaches the UI (never in practice — the test guards it). */
+export function categoryLabel(category: Category): string {
+  return CATEGORY_LABELS[category] ?? category;
+}
+
 /** The catch-all category for an axis — receives unattributable tokens so
  * per-category totals always reconcile to provider truth (ADR-033 Decision 2.4). */
 export function catchAllFor(axis: Axis): Category {

--- a/specs/ai-gateway/governance/cost-breakdown-dashboard.feature
+++ b/specs/ai-gateway/governance/cost-breakdown-dashboard.feature
@@ -7,25 +7,25 @@ Feature: Cost breakdown by content category on governance dashboards
   follow the host pages — no new gating. The numbers are analytics only and
   never affect billing, budgets, or plan limits. (ADR-033)
 
-  @integration @unimplemented
+  @integration
   Scenario: The personal usage view shows the user's cost breakdown by category
     Given a user whose coding-agent traffic produced classified category totals
     When the user opens their personal usage view
     Then a usage breakdown section lists the categories with their cost share
 
-  @integration @unimplemented
+  @integration
   Scenario: The breakdown shows an enablement hint when no content was captured
     Given a user whose traffic produced no category totals because payload capture is off
     When the user opens their personal usage view
     Then the breakdown section explains that payload capture must be enabled to see it
 
-  @integration @unimplemented
+  @integration
   Scenario: The org activity monitor aggregates category totals across users
     Given an organization with classified coding-agent traffic from several users
     When an admin with activity-monitor access opens the activity monitor
     Then the aggregate cost breakdown by category is shown
 
-  @integration @unimplemented
+  @integration
   Scenario: Category totals never affect billing or plan limits
     Given a project with classified category totals recorded
     When usage limits and billing amounts are computed


### PR DESCRIPTION
# Related Issue

- Resolves #5319

## What

Final rung of the ADR-033 stack: surface the ingest-time content-block **category cost split** on the two existing governance dashboards.

- **Personal usage (`/me`)** gains a "Usage breakdown" section — cost lanes per content category (system prompt, MCP tool definitions, thinking, ...) with cost + % share. Empty totals render a payload-capture enablement hint.
- **Org Activity Monitor** gains an aggregate "Cost breakdown by category" section behind the existing `activityMonitor:view` gating.

Data comes from the reserved `langwatch.reserved.blockcat.<category>.{cost_usd,tokens}` attributes the trace fold already accumulates onto `trace_summaries` (PRs A–C). No new tables, no new gating — availability and RBAC follow the host pages (ADR-033 Decision 9).

## Why

Ships the competitive "where do my coding-agent tokens go, by content type" insight computed from real token cost — the read-side payoff of the classification pipeline. Analytics only; **never feeds billing** (ADR-033 invariant).

## How

- `categories.ts`: single-source `CATEGORIES` list + `CATEGORY_LABELS` so dashboards iterate the taxonomy and label lanes without hardcoding wire strings.
- `PersonalUsageService.breakdownByCategory` (personal tenant, argMax-per-trace dedup) and `ActivityMonitorService.categoryBreakdown` (org governance-origin, IN-tuple dedup) mirror their sibling spend queries exactly (TenantId-first, partition-pruned, `ANALYTICS_CLICKHOUSE_SETTINGS`).
- Exposed via the existing surfaces: `user.personalUsage` tRPC + `/api/me/usage` REST (parity), `activityMonitor.categoryBreakdown` tRPC.
- Shared presentational `CategoryBreakdownBars` + `CategoryBreakdownEnablementHint` used by both pages.

## Scenarios (specs/ai-gateway/governance/cost-breakdown-dashboard.feature — 4/4 bound, `@unimplemented` removed)

| Scenario | Test |
|---|---|
| The personal usage view shows the user's cost breakdown by category | `personalUsageCategoryBreakdown.service.integration.test.ts` + `CategoryBreakdownBars.integration.test.tsx` |
| The breakdown shows an enablement hint when no content was captured | `CategoryBreakdownBars.integration.test.tsx` |
| The org activity monitor aggregates category totals across users | `activityMonitorCategoryBreakdown.service.integration.test.ts` |
| Category totals never affect billing or plan limits | `categoryBillingBoundary.unit.test.ts` (static import check) + `categoryBillingBoundary.integration.test.ts` (identical trace-count meter with/without blockcat attrs) |

All service integration tests run against real ClickHouse; billing-boundary is proven both structurally (no import path billing → block-classification) and behaviourally (metering unchanged).

Screenshots: N/A — dashboards only light up with classified coding-agent traffic + payload capture enabled; no representative local fixture.

## Deployment Impact

None — read-only dashboard queries over existing `trace_summaries` attributes; gating reuses host pages.

https://claude.ai/code/session_01BTXJNbJdzwj9uZsPtYMCLh