### PR TITLE
fix(aigateway): route custom (OpenAI-compatible) providers to their configured base URL

### DIFF
--- a/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
+++ b/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
@@ -52,6 +52,8 @@ const MONITOR_NOT_GUARDRAIL_ID = `mon-mat-nongr-${suffix}`;
 const MP_ID = `mp-mat-${suffix}`;
 const MP_CUSTOM_ID = `mp-mat-custom-${suffix}`;
 const CUSTOM_BASE_URL = "http://llm-server:8000/v1";
+const MP_OPENAI_BASE_ID = `mp-mat-openai-base-${suffix}`;
+const OPENAI_BASE_URL_OVERRIDE = "https://proxy.example.com/v1";
 const RP_ID = `rp-mat-${suffix}`;
 const GUARDRAIL_ID = `gr-mat-${suffix}`;
 const VK_ID = `vk-mat-${suffix}`;
@@ -169,6 +171,25 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
         },
       },
     });
+    // OpenAI provider pointed at a self-hosted proxy via OPENAI_BASE_URL.
+    // The materialiser must surface it as the slot base_url (from the
+    // registry endpointKey), otherwise gateway traffic hits api.openai.com.
+    await prisma.modelProvider.create({
+      data: {
+        id: MP_OPENAI_BASE_ID,
+        name: "openai-proxy",
+        provider: "openai",
+        enabled: true,
+        organizationId: ORG_ID,
+        customKeys: {
+          OPENAI_API_KEY: "sk-proxy-test",
+          OPENAI_BASE_URL: OPENAI_BASE_URL_OVERRIDE,
+        },
+        scopes: {
+          create: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
+        },
+      },
+    });
     await prisma.routingPolicy.create({
       data: {
         id: RP_ID,
@@ -177,7 +198,7 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
           create: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
         },
         name: `mat-rp-${suffix}`,
-        modelProviderIds: [MP_ID, MP_CUSTOM_ID],
+        modelProviderIds: [MP_ID, MP_CUSTOM_ID, MP_OPENAI_BASE_ID],
         modelAliases: { "gpt-5": "gpt-5-mini" },
         policyRules: {
           tools: { deny: ["^shell_.*$"], allow: null },
@@ -281,10 +302,12 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
     });
     await prisma.routingPolicy.deleteMany({ where: { id: RP_ID } });
     await prisma.modelProviderScope.deleteMany({
-      where: { modelProviderId: { in: [MP_ID, MP_CUSTOM_ID] } },
+      where: {
+        modelProviderId: { in: [MP_ID, MP_CUSTOM_ID, MP_OPENAI_BASE_ID] },
+      },
     });
     await prisma.modelProvider.deleteMany({
-      where: { id: { in: [MP_ID, MP_CUSTOM_ID] } },
+      where: { id: { in: [MP_ID, MP_CUSTOM_ID, MP_OPENAI_BASE_ID] } },
     });
     await prisma.evaluator.deleteMany({
       where: { id: { in: [EVALUATOR_ID, EVALUATOR_NOT_GUARDRAIL_ID] } },
@@ -331,6 +354,17 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
       expect(slot!.type).toBe("custom");
       expect(slot!.base_url).toBe(CUSTOM_BASE_URL);
       expect(slot!.credentials.api_key).toBe("");
+    });
+
+    it("materialises an openai provider slot with OPENAI_BASE_URL as its base_url", async () => {
+      const repo = new VirtualKeyRepository(prisma);
+      const vk = await repo.findById(VK_ID, ORG_ID);
+      const mat = new GatewayConfigMaterialiser(prisma, null);
+      const bundle = await mat.materialise(vk!);
+      const slot = bundle.providers.find((p) => p.id === MP_OPENAI_BASE_ID);
+      expect(slot).toBeDefined();
+      expect(slot!.type).toBe("openai");
+      expect(slot!.base_url).toBe(OPENAI_BASE_URL_OVERRIDE);
     });
 
     it("hydrates model_aliases + policy_rules from the linked RoutingPolicy", async () => {

--- a/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
+++ b/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
@@ -50,6 +50,8 @@ const EVALUATOR_NOT_GUARDRAIL_ID = `eval-mat-nongr-${suffix}`;
 const MONITOR_ID = `mon-mat-${suffix}`;
 const MONITOR_NOT_GUARDRAIL_ID = `mon-mat-nongr-${suffix}`;
 const MP_ID = `mp-mat-${suffix}`;
+const MP_CUSTOM_ID = `mp-mat-custom-${suffix}`;
+const CUSTOM_BASE_URL = "http://llm-server:8000/v1";
 const RP_ID = `rp-mat-${suffix}`;
 const GUARDRAIL_ID = `gr-mat-${suffix}`;
 const VK_ID = `vk-mat-${suffix}`;
@@ -149,6 +151,24 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
         },
       },
     });
+    // Custom (OpenAI-compatible) provider: base URL required, API key
+    // legitimately empty (unauthenticated self-hosted vLLM/LiteLLM).
+    await prisma.modelProvider.create({
+      data: {
+        id: MP_CUSTOM_ID,
+        name: "custom",
+        provider: "custom",
+        enabled: true,
+        organizationId: ORG_ID,
+        customKeys: {
+          CUSTOM_API_KEY: "",
+          CUSTOM_BASE_URL,
+        },
+        scopes: {
+          create: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
+        },
+      },
+    });
     await prisma.routingPolicy.create({
       data: {
         id: RP_ID,
@@ -157,7 +177,7 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
           create: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
         },
         name: `mat-rp-${suffix}`,
-        modelProviderIds: [MP_ID],
+        modelProviderIds: [MP_ID, MP_CUSTOM_ID],
         modelAliases: { "gpt-5": "gpt-5-mini" },
         policyRules: {
           tools: { deny: ["^shell_.*$"], allow: null },
@@ -261,9 +281,11 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
     });
     await prisma.routingPolicy.deleteMany({ where: { id: RP_ID } });
     await prisma.modelProviderScope.deleteMany({
-      where: { modelProviderId: MP_ID },
+      where: { modelProviderId: { in: [MP_ID, MP_CUSTOM_ID] } },
     });
-    await prisma.modelProvider.deleteMany({ where: { id: MP_ID } });
+    await prisma.modelProvider.deleteMany({
+      where: { id: { in: [MP_ID, MP_CUSTOM_ID] } },
+    });
     await prisma.evaluator.deleteMany({
       where: { id: { in: [EVALUATOR_ID, EVALUATOR_NOT_GUARDRAIL_ID] } },
     });
@@ -297,6 +319,18 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
       expect(bundle.organization_id).toBe(ORG_ID);
       expect(bundle.project_id).toBe(PROJECT_ID);
       expect(bundle.providers.length).toBeGreaterThan(0);
+    });
+
+    it("materialises the custom provider slot with its base_url and empty api_key", async () => {
+      const repo = new VirtualKeyRepository(prisma);
+      const vk = await repo.findById(VK_ID, ORG_ID);
+      const mat = new GatewayConfigMaterialiser(prisma, null);
+      const bundle = await mat.materialise(vk!);
+      const slot = bundle.providers.find((p) => p.id === MP_CUSTOM_ID);
+      expect(slot).toBeDefined();
+      expect(slot!.type).toBe("custom");
+      expect(slot!.base_url).toBe(CUSTOM_BASE_URL);
+      expect(slot!.credentials.api_key).toBe("");
     });
 
     it("hydrates model_aliases + policy_rules from the linked RoutingPolicy", async () => {

--- a/langwatch/src/server/gateway/config.materialiser.ts
+++ b/langwatch/src/server/gateway/config.materialiser.ts
@@ -486,19 +486,22 @@ function buildCredentials(mp: ModelProvider): Record<string, unknown> {
 function buildProviderSlot(mp: ModelProvider, index: number): ProviderSlot {
   const credentials = buildCredentials(mp);
   const customKeys = decryptCustomKeys(mp.customKeys);
-  // Base-URL overrides live under the provider's registry endpointKey
-  // (custom -> CUSTOM_BASE_URL, openai -> OPENAI_BASE_URL, ...). Structured-
-  // endpoint providers (Azure, Vertex) resolve theirs into
-  // credentials.endpoint and their Bifrost adapters route by that, so skip
-  // the top-level base_url for them to avoid emitting the same endpoint
-  // twice. This is what lets an "openai" provider with OPENAI_BASE_URL reach
-  // a self-hosted proxy instead of api.openai.com.
-  const endpointKey =
-    modelProviders[mp.provider as keyof typeof modelProviders]?.endpointKey;
-  const registryBaseURL =
-    endpointKey && !pickString(credentials, "endpoint")
-      ? pickString(customKeys, endpointKey)
-      : undefined;
+  // Only "custom" and "openai" route a base-URL override to Bifrost's VLLM
+  // adapter (see mapProvider in bifrost.go) — the sole consumer of the
+  // per-slot base_url. Other providers with an endpointKey resolve their
+  // endpoint elsewhere (Azure/Vertex via credentials.endpoint, Anthropic via
+  // Bifrost's provider-level network_config), so emitting a per-slot base_url
+  // for them would be a dead field. Scope the override to what's consumed;
+  // this is what lets an "openai" provider with OPENAI_BASE_URL reach a
+  // self-hosted proxy instead of api.openai.com.
+  const supportsBaseURLOverride =
+    mp.provider === "custom" || mp.provider === "openai";
+  const endpointKey = supportsBaseURLOverride
+    ? modelProviders[mp.provider as keyof typeof modelProviders]?.endpointKey
+    : undefined;
+  const registryBaseURL = endpointKey
+    ? pickString(customKeys, endpointKey)
+    : undefined;
   const baseURL =
     pickString(customKeys, "base_url") ??
     pickString(customKeys, "BASE_URL") ??

--- a/langwatch/src/server/gateway/config.materialiser.ts
+++ b/langwatch/src/server/gateway/config.materialiser.ts
@@ -486,7 +486,9 @@ function buildProviderSlot(mp: ModelProvider, index: number): ProviderSlot {
   const credentials = buildCredentials(mp);
   const customKeys = decryptCustomKeys(mp.customKeys);
   const baseURL =
-    pickString(customKeys, "base_url") ?? pickString(customKeys, "BASE_URL");
+    pickString(customKeys, "base_url") ??
+    pickString(customKeys, "BASE_URL") ??
+    pickString(customKeys, "CUSTOM_BASE_URL");
   const region = pickString(credentials, "region");
   const deploymentMap = mp.deploymentMapping
     ? (mp.deploymentMapping as Record<string, string>)

--- a/langwatch/src/server/gateway/config.materialiser.ts
+++ b/langwatch/src/server/gateway/config.materialiser.ts
@@ -487,7 +487,7 @@ function buildProviderSlot(mp: ModelProvider, index: number): ProviderSlot {
   const credentials = buildCredentials(mp);
   const customKeys = decryptCustomKeys(mp.customKeys);
   // Only "custom" and "openai" route a base-URL override to Bifrost's VLLM
-  // adapter (see mapProvider in bifrost.go) — the sole consumer of the
+  // adapter (see mapProvider in bifrost.go), the sole consumer of the
   // per-slot base_url. Other providers with an endpointKey resolve their
   // endpoint elsewhere (Azure/Vertex via credentials.endpoint, Anthropic via
   // Bifrost's provider-level network_config), so emitting a per-slot base_url

--- a/langwatch/src/server/gateway/config.materialiser.ts
+++ b/langwatch/src/server/gateway/config.materialiser.ts
@@ -18,6 +18,7 @@ import type {
 } from "@prisma/client";
 
 import { decrypt } from "../../utils/encryption";
+import { modelProviders } from "../modelProviders/registry";
 import { GatewayBudgetClickHouseRepository } from "./budget.clickhouse.repository";
 import { GatewayCacheRuleService } from "./cacheRule.service";
 import {
@@ -485,10 +486,23 @@ function buildCredentials(mp: ModelProvider): Record<string, unknown> {
 function buildProviderSlot(mp: ModelProvider, index: number): ProviderSlot {
   const credentials = buildCredentials(mp);
   const customKeys = decryptCustomKeys(mp.customKeys);
+  // Base-URL overrides live under the provider's registry endpointKey
+  // (custom -> CUSTOM_BASE_URL, openai -> OPENAI_BASE_URL, ...). Structured-
+  // endpoint providers (Azure, Vertex) resolve theirs into
+  // credentials.endpoint and their Bifrost adapters route by that, so skip
+  // the top-level base_url for them to avoid emitting the same endpoint
+  // twice. This is what lets an "openai" provider with OPENAI_BASE_URL reach
+  // a self-hosted proxy instead of api.openai.com.
+  const endpointKey =
+    modelProviders[mp.provider as keyof typeof modelProviders]?.endpointKey;
+  const registryBaseURL =
+    endpointKey && !pickString(credentials, "endpoint")
+      ? pickString(customKeys, endpointKey)
+      : undefined;
   const baseURL =
     pickString(customKeys, "base_url") ??
     pickString(customKeys, "BASE_URL") ??
-    pickString(customKeys, "CUSTOM_BASE_URL");
+    registryBaseURL;
   const region = pickString(credentials, "region");
   const deploymentMap = mp.deploymentMapping
     ? (mp.deploymentMapping as Record<string, string>)

--- a/langwatch/src/server/modelProviders/__tests__/modelIdBoundary.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelIdBoundary.unit.test.ts
@@ -80,9 +80,11 @@ describe("translateModelIdForLitellm", () => {
   });
 
   describe("Custom provider prefix", () => {
-    it("translates custom/claude-opus-4.5 to custom/claude-opus-4-5", () => {
-      const result = translateModelIdForLitellm("custom/claude-opus-4.5");
-      expect(result).toBe("custom/claude-opus-4-5");
+    it("keeps custom model ids verbatim (dots are part of the customer's model name)", () => {
+      const result = translateModelIdForLitellm(
+        "custom/Qwen/Qwen2.5-32B-Instruct",
+      );
+      expect(result).toBe("custom/Qwen/Qwen2.5-32B-Instruct");
     });
   });
 

--- a/langwatch/src/server/modelProviders/modelIdBoundary.ts
+++ b/langwatch/src/server/modelProviders/modelIdBoundary.ts
@@ -28,8 +28,11 @@ const MODEL_ALIASES: Record<string, string> = {
 /**
  * Providers that need dot-to-dash translation for their model IDs.
  * Anthropic models use dots in llmModels.json but LiteLLM expects dashes.
+ * Custom providers are excluded: their model ids are arbitrary customer
+ * strings (e.g. vLLM serving "Qwen/Qwen2.5-32B-Instruct") and rewriting
+ * dots would send a model id the endpoint doesn't recognize.
  */
-const PROVIDERS_NEEDING_TRANSLATION = ["anthropic", "custom"];
+const PROVIDERS_NEEDING_TRANSLATION = ["anthropic"];
 
 /**
  * Extracts the provider from a model ID string.

--- a/services/aigateway/adapters/controlplane/config_wire.go
+++ b/services/aigateway/adapters/controlplane/config_wire.go
@@ -25,6 +25,11 @@ type providerSlotWire struct {
 	ID          string                 `json:"id"`
 	Type        string                 `json:"type"`
 	Credentials map[string]interface{} `json:"credentials"`
+	// BaseURL overrides the provider's default endpoint. Emitted by the
+	// control-plane materialiser for OpenAI-compatible providers
+	// (type "custom": self-hosted vLLM, LiteLLM proxies, ...) — see
+	// config.materialiser.ts:buildProviderSlot.
+	BaseURL string `json:"base_url,omitempty"`
 	// DeploymentMap maps public model ids to provider-native deployment
 	// names (Azure routes on deployment, Bedrock on inference profile,
 	// etc.). Emitted by the control-plane materialiser as a top-level
@@ -326,6 +331,13 @@ func providerSlotToCredential(p providerSlotWire) domain.Credential {
 		}
 	default:
 		cred.APIKey = getString("api_key")
+	}
+
+	if p.BaseURL != "" {
+		if cred.Extra == nil {
+			cred.Extra = map[string]string{}
+		}
+		cred.Extra["base_url"] = p.BaseURL
 	}
 
 	return cred

--- a/services/aigateway/adapters/controlplane/config_wire_test.go
+++ b/services/aigateway/adapters/controlplane/config_wire_test.go
@@ -130,3 +130,44 @@ func TestBuildPolicyRules_Models(t *testing.T) {
 	assert.Contains(t, modelRules, domain.PolicyRule{Pattern: "^gpt-4.*", Type: domain.PolicyDeny, Target: domain.PolicyTargetModel})
 	assert.Contains(t, modelRules, domain.PolicyRule{Pattern: "^claude-.*", Type: domain.PolicyAllow, Target: domain.PolicyTargetModel})
 }
+
+// providerSlotToCredential must carry the top-level base_url from the wire
+// into cred.Extra — the bifrost adapter routes OpenAI-compatible custom
+// providers (self-hosted vLLM, LiteLLM proxies) by it. Dropping it sends
+// customer traffic to api.openai.com instead of their endpoint.
+//
+// Spec: specs/ai-gateway/custom-provider-base-url.feature
+func TestProviderSlotToCredential_BaseURL(t *testing.T) {
+	t.Run("custom slot forwards base_url into Extra", func(t *testing.T) {
+		cred := providerSlotToCredential(providerSlotWire{
+			ID:          "mp-1",
+			Type:        "custom",
+			Credentials: map[string]interface{}{"api_key": ""},
+			BaseURL:     "http://llm-server:8000/v1",
+		})
+		assert.Equal(t, domain.ProviderID("custom"), cred.ProviderID)
+		assert.Equal(t, "http://llm-server:8000/v1", cred.Extra["base_url"])
+		assert.Empty(t, cred.APIKey)
+	})
+
+	t.Run("openai slot with base_url override forwards it", func(t *testing.T) {
+		cred := providerSlotToCredential(providerSlotWire{
+			ID:          "mp-2",
+			Type:        "openai",
+			Credentials: map[string]interface{}{"api_key": "sk-test"},
+			BaseURL:     "https://proxy.example.com/v1",
+		})
+		assert.Equal(t, domain.ProviderOpenAI, cred.ProviderID)
+		assert.Equal(t, "https://proxy.example.com/v1", cred.Extra["base_url"])
+		assert.Equal(t, "sk-test", cred.APIKey)
+	})
+
+	t.Run("slot without base_url leaves Extra unset", func(t *testing.T) {
+		cred := providerSlotToCredential(providerSlotWire{
+			ID:          "mp-3",
+			Type:        "openai",
+			Credentials: map[string]interface{}{"api_key": "sk-test"},
+		})
+		assert.Empty(t, cred.Extra["base_url"])
+	})
+}

--- a/services/aigateway/adapters/providers/bedrock_vpce_test.go
+++ b/services/aigateway/adapters/providers/bedrock_vpce_test.go
@@ -60,7 +60,7 @@ func TestBedrockVPCE_DispatchHitsEndpointAndShapesResponse(t *testing.T) {
 		Body:  []byte(`{"messages":[{"role":"user","content":"what is the answer?"}]}`),
 	}
 
-	provider := mapProvider(cred.ProviderID)
+	provider := mapProvider(cred)
 	endpoint := bedrockRuntimeEndpoint(cred)
 	if endpoint == "" {
 		t.Fatal("bedrockRuntimeEndpoint returned empty for a cred carrying the endpoint")
@@ -234,7 +234,7 @@ func TestBedrockVPCE_DispatchHonorsAWSStyleCredentialKeys(t *testing.T) {
 	if endpoint == "" {
 		t.Fatal("bedrockRuntimeEndpoint returned empty for the aws_* fallback key")
 	}
-	resp, err := router.dispatchBedrockVPCE(context.Background(), req, mapProvider(cred.ProviderID), req.Model, cred, endpoint)
+	resp, err := router.dispatchBedrockVPCE(context.Background(), req, mapProvider(cred), req.Model, cred, endpoint)
 	if err != nil {
 		t.Fatalf("dispatchBedrockVPCE returned error: %v", err)
 	}

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -113,7 +113,7 @@ func (r *BifrostRouter) Dispatch(ctx context.Context, req *domain.Request, cred 
 		return r.dispatchVoyageDirect(ctx, req, model, cred)
 	}
 
-	provider := mapProvider(cred.ProviderID)
+	provider := mapProvider(cred)
 
 	if req.Type == domain.RequestTypeResponses {
 		return r.dispatchResponses(ctx, req, provider, model, cred)
@@ -391,7 +391,7 @@ func (r *BifrostRouter) dispatchVoyageDirect(
 //   - RequestTypePassthrough: dedicated dispatchPassthroughStream (Gemini
 //     /v1beta/...:streamGenerateContent).
 func (r *BifrostRouter) DispatchStream(ctx context.Context, req *domain.Request, cred domain.Credential) (domain.StreamIterator, error) {
-	provider := mapProvider(cred.ProviderID)
+	provider := mapProvider(cred)
 	model := req.Model
 	if req.Resolved != nil {
 		model = req.Resolved.ModelID
@@ -836,6 +836,16 @@ func credentialToBifrostKey(cred domain.Credential, provider bfschemas.ModelProv
 			AuthCredentials: envVar(cred.Extra["auth_credentials"]),
 		}
 
+	case bfschemas.VLLM:
+		// OpenAI-compatible endpoint hosted by the customer (vLLM,
+		// LiteLLM proxy, ...). The base URL rides on the key — Bifrost's
+		// vLLM provider has no provider-level URL fallback. The API key
+		// may legitimately be empty (unauthenticated self-hosted server).
+		k.Value = envVar(cred.APIKey)
+		k.VLLMKeyConfig = &bfschemas.VLLMKeyConfig{
+			URL: envVar(credBaseURL(cred)),
+		}
+
 	default:
 		// OpenAI, Anthropic, Gemini, etc. — plain API key.
 		k.Value = envVar(cred.APIKey)
@@ -850,8 +860,8 @@ func envVar(v string) bfschemas.EnvVar {
 
 // --- Provider mapping ---
 
-func mapProvider(id domain.ProviderID) bfschemas.ModelProvider {
-	switch id {
+func mapProvider(cred domain.Credential) bfschemas.ModelProvider {
+	switch cred.ProviderID {
 	case domain.ProviderAzure:
 		return bfschemas.Azure
 	case domain.ProviderBedrock:
@@ -862,9 +872,32 @@ func mapProvider(id domain.ProviderID) bfschemas.ModelProvider {
 		return bfschemas.Gemini
 	case domain.ProviderAnthropic:
 		return bfschemas.Anthropic
+	case domain.ProviderCustom:
+		// Customer-hosted OpenAI-compatible endpoint. Bifrost's vLLM
+		// provider is its generic OpenAI-compat adapter with a per-key
+		// base URL — exactly the shape a custom provider needs.
+		return bfschemas.VLLM
+	case domain.ProviderOpenAI:
+		// OpenAI with a base-URL override (self-hosted vLLM / LiteLLM
+		// arriving via the custom→openai translation in the nlpgo proxy
+		// path) must not hit api.openai.com. Bifrost's OpenAI key has no
+		// per-key URL slot, so route through the vLLM provider, which
+		// speaks the same wire format and carries the URL on the key.
+		if credBaseURL(cred) != "" {
+			return bfschemas.VLLM
+		}
+		return bfschemas.OpenAI
 	default:
-		return bfschemas.ModelProvider(string(id))
+		return bfschemas.ModelProvider(string(cred.ProviderID))
 	}
+}
+
+// credBaseURL returns the customer-configured endpoint override for
+// OpenAI-compatible credentials. The control-plane wire names it
+// "base_url" (config.materialiser.ts), the litellm-era nlpgo paths name
+// it "api_base" — accept both.
+func credBaseURL(cred domain.Credential) string {
+	return credExtra(cred, "base_url", "api_base")
 }
 
 // --- Error classification ---

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -843,7 +843,7 @@ func credentialToBifrostKey(cred domain.Credential, provider bfschemas.ModelProv
 		// may legitimately be empty (unauthenticated self-hosted server).
 		k.Value = envVar(cred.APIKey)
 		k.VLLMKeyConfig = &bfschemas.VLLMKeyConfig{
-			URL: envVar(credBaseURL(cred)),
+			URL: envVar(normalizeOpenAICompatBaseURL(credBaseURL(cred))),
 		}
 
 	default:
@@ -898,6 +898,17 @@ func mapProvider(cred domain.Credential) bfschemas.ModelProvider {
 // it "api_base" — accept both.
 func credBaseURL(cred domain.Credential) string {
 	return credExtra(cred, "base_url", "api_base")
+}
+
+// normalizeOpenAICompatBaseURL strips a trailing "/v1" (and trailing
+// slashes) from a customer-configured base URL. OpenAI-compatible
+// endpoints are conventionally configured as "http://host:8000/v1", but
+// Bifrost's vLLM provider appends the full "/v1/chat/completions" path
+// itself — forwarding the URL verbatim would produce ".../v1/v1/...".
+func normalizeOpenAICompatBaseURL(u string) string {
+	u = strings.TrimRight(u, "/")
+	u = strings.TrimSuffix(u, "/v1")
+	return strings.TrimRight(u, "/")
 }
 
 // --- Error classification ---

--- a/services/aigateway/adapters/providers/bifrost_parser.go
+++ b/services/aigateway/adapters/providers/bifrost_parser.go
@@ -187,9 +187,18 @@ func buildChatRequest(
 // gateway raw-forwards the inbound body rather than parse+re-marshal,
 // preserving byte-for-byte identity so OpenAI prompt-prefix auto-cache
 // continues to hit between repeated calls.
+//
+// VLLM is included: it is Bifrost's generic OpenAI-compatible adapter,
+// the destination for customer-hosted endpoints (self-hosted vLLM,
+// LiteLLM proxies) mapped from provider "custom" and from "openai" with
+// a base-URL override. Raw-forwarding them preserves the provider-specific
+// sampling params the structured parse would otherwise drop (top_k,
+// repetition_penalty, chat_template_kwargs, guided_json, ...) and lets
+// DispatchStream inject stream_options.include_usage so streamed token
+// usage still reaches billing/traces.
 func isOpenAICompatibleProvider(p bfschemas.ModelProvider) bool {
 	switch p {
-	case bfschemas.OpenAI, bfschemas.Azure:
+	case bfschemas.OpenAI, bfschemas.Azure, bfschemas.VLLM:
 		return true
 	default:
 		return false
@@ -271,9 +280,10 @@ var chatExtensionKeys = []string{
 //   - the body has no "stream":true (non-stream dispatch),
 //   - the body already carries stream_options.include_usage (caller decided).
 //
-// Only call on raw-forward paths for OpenAI / Azure. Anthropic / Gemini /
-// Vertex / Bedrock emit usage natively in their stream deltas and this flag
-// is meaningless on their wire formats.
+// Only call on raw-forward paths for OpenAI / Azure / VLLM (self-hosted
+// OpenAI-compatible). Anthropic / Gemini / Vertex / Bedrock emit usage
+// natively in their stream deltas and this flag is meaningless on their
+// wire formats.
 func ensureStreamIncludeUsage(body []byte) []byte {
 	if len(body) == 0 {
 		return body

--- a/services/aigateway/adapters/providers/bifrost_test.go
+++ b/services/aigateway/adapters/providers/bifrost_test.go
@@ -517,3 +517,48 @@ func TestNormalizeOpenAICompatBaseURL(t *testing.T) {
 		}
 	}
 }
+
+// isOpenAICompatibleProvider gates two behaviors the custom/vLLM path both
+// depend on: buildChatRequest raw-forwards the body byte-for-byte (so vendor
+// sampling params survive) and DispatchStream injects
+// stream_options.include_usage (so streamed token usage still reaches
+// billing/traces). VLLM — Bifrost's generic OpenAI-compatible adapter, the
+// destination for provider "custom" and "openai"+base_url — must be
+// recognized here alongside OpenAI and Azure.
+//
+// Spec: specs/ai-gateway/custom-provider-base-url.feature
+func TestIsOpenAICompatibleProvider(t *testing.T) {
+	for _, p := range []bfschemas.ModelProvider{bfschemas.OpenAI, bfschemas.Azure, bfschemas.VLLM} {
+		if !isOpenAICompatibleProvider(p) {
+			t.Errorf("isOpenAICompatibleProvider(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []bfschemas.ModelProvider{bfschemas.Anthropic, bfschemas.Gemini, bfschemas.Bedrock} {
+		if isOpenAICompatibleProvider(p) {
+			t.Errorf("isOpenAICompatibleProvider(%q) = true, want false", p)
+		}
+	}
+}
+
+// A custom / self-hosted vLLM provider (bfschemas.VLLM) raw-forwards the
+// inbound chat body byte-for-byte, exactly like OpenAI/Azure — never through
+// the structured parse that would drop vendor sampling params. This is the
+// gateway-side guarantee that top_k / repetition_penalty /
+// chat_template_kwargs / guided_json reach the customer's endpoint unchanged.
+//
+// Spec: specs/ai-gateway/custom-provider-base-url.feature
+func TestBuildChatRequest_VLLMRawForwardsBody(t *testing.T) {
+	body := []byte(`{"model":"Qwen/Qwen2.5-32B-Instruct","messages":[{"role":"user","content":"hi"}],"top_k":5,"repetition_penalty":1.1,"chat_template_kwargs":{"enable_thinking":false}}`)
+	req := &domain.Request{Type: domain.RequestTypeChat, Body: body}
+
+	bfReq, _, err := buildChatRequest(context.Background(), req, bfschemas.VLLM, "Qwen/Qwen2.5-32B-Instruct")
+	if err != nil {
+		t.Fatalf("buildChatRequest returned error: %v", err)
+	}
+	if !bytes.Equal(bfReq.RawRequestBody, body) {
+		t.Fatalf("VLLM must raw-forward the inbound body byte-for-byte;\n got: %s\nwant: %s", bfReq.RawRequestBody, body)
+	}
+	if len(bfReq.Input) != 0 {
+		t.Fatalf("raw-forward must not populate Input via structured parse, got %d messages", len(bfReq.Input))
+	}
+}

--- a/services/aigateway/adapters/providers/bifrost_test.go
+++ b/services/aigateway/adapters/providers/bifrost_test.go
@@ -475,8 +475,8 @@ func TestMapProvider_CustomAndBaseURLOverrides(t *testing.T) {
 	}
 }
 
-// credentialToBifrostKey must carry the endpoint on VLLMKeyConfig.URL —
-// Bifrost's vLLM provider has no provider-level URL fallback, so a key
+// credentialToBifrostKey must carry the endpoint on VLLMKeyConfig.URL
+// because Bifrost's vLLM provider has no provider-level URL fallback, so a key
 // without it fails dispatch. An empty API key stays allowed: self-hosted
 // servers commonly run unauthenticated.
 //
@@ -490,7 +490,7 @@ func TestCredentialToBifrostKey_VLLM(t *testing.T) {
 	key := credentialToBifrostKey(cred, bfschemas.VLLM)
 
 	if key.VLLMKeyConfig == nil {
-		t.Fatal("VLLMKeyConfig is nil — vLLM keys require a per-key URL")
+		t.Fatal("VLLMKeyConfig is nil: vLLM keys require a per-key URL")
 	}
 	// Bifrost's vLLM provider appends "/v1/chat/completions" itself, so
 	// the conventional "/v1" suffix must be stripped or requests land on
@@ -522,8 +522,8 @@ func TestNormalizeOpenAICompatBaseURL(t *testing.T) {
 // depend on: buildChatRequest raw-forwards the body byte-for-byte (so vendor
 // sampling params survive) and DispatchStream injects
 // stream_options.include_usage (so streamed token usage still reaches
-// billing/traces). VLLM — Bifrost's generic OpenAI-compatible adapter, the
-// destination for provider "custom" and "openai"+base_url — must be
+// billing/traces). VLLM, Bifrost's generic OpenAI-compatible adapter and
+// the destination for provider "custom" and "openai"+base_url, must be
 // recognized here alongside OpenAI and Azure.
 //
 // Spec: specs/ai-gateway/custom-provider-base-url.feature
@@ -541,7 +541,7 @@ func TestIsOpenAICompatibleProvider(t *testing.T) {
 }
 
 // A custom / self-hosted vLLM provider (bfschemas.VLLM) raw-forwards the
-// inbound chat body byte-for-byte, exactly like OpenAI/Azure — never through
+// inbound chat body byte-for-byte, exactly like OpenAI/Azure, never through
 // the structured parse that would drop vendor sampling params. This is the
 // gateway-side guarantee that top_k / repetition_penalty /
 // chat_template_kwargs / guided_json reach the customer's endpoint unchanged.

--- a/services/aigateway/adapters/providers/bifrost_test.go
+++ b/services/aigateway/adapters/providers/bifrost_test.go
@@ -492,10 +492,28 @@ func TestCredentialToBifrostKey_VLLM(t *testing.T) {
 	if key.VLLMKeyConfig == nil {
 		t.Fatal("VLLMKeyConfig is nil — vLLM keys require a per-key URL")
 	}
-	if got := key.VLLMKeyConfig.URL.Val; got != "http://llm-server:8000/v1" {
-		t.Fatalf("VLLMKeyConfig.URL = %q, want the configured base URL", got)
+	// Bifrost's vLLM provider appends "/v1/chat/completions" itself, so
+	// the conventional "/v1" suffix must be stripped or requests land on
+	// ".../v1/v1/chat/completions" (404).
+	if got := key.VLLMKeyConfig.URL.Val; got != "http://llm-server:8000" {
+		t.Fatalf("VLLMKeyConfig.URL = %q, want base URL without /v1 suffix", got)
 	}
 	if key.Value.Val != "" {
 		t.Fatalf("key.Value = %q, want empty for unauthenticated server", key.Value.Val)
+	}
+}
+
+func TestNormalizeOpenAICompatBaseURL(t *testing.T) {
+	cases := map[string]string{
+		"http://h:8000/v1":  "http://h:8000",
+		"http://h:8000/v1/": "http://h:8000",
+		"http://h:8000":     "http://h:8000",
+		"http://h:8000/":    "http://h:8000",
+		"":                  "",
+	}
+	for in, want := range cases {
+		if got := normalizeOpenAICompatBaseURL(in); got != want {
+			t.Errorf("normalizeOpenAICompatBaseURL(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/services/aigateway/adapters/providers/bifrost_test.go
+++ b/services/aigateway/adapters/providers/bifrost_test.go
@@ -441,3 +441,61 @@ func TestCredentialToBifrostKey_BedrockHonorsAWSStyleKeys(t *testing.T) {
 		t.Errorf("Region not honored: %+v", k.BedrockKeyConfig.Region)
 	}
 }
+
+// mapProvider routes customer-hosted OpenAI-compatible endpoints (provider
+// "custom", or "openai" with a base-URL override) through Bifrost's vLLM
+// provider, which carries the URL per-key. Without this, base URLs are
+// silently dropped and traffic goes to api.openai.com.
+//
+// Spec: specs/ai-gateway/custom-provider-base-url.feature
+func TestMapProvider_CustomAndBaseURLOverrides(t *testing.T) {
+	cases := []struct {
+		name string
+		cred domain.Credential
+		want bfschemas.ModelProvider
+	}{
+		{"custom provider maps to vllm", domain.Credential{ProviderID: domain.ProviderCustom}, bfschemas.VLLM},
+		{"openai with base_url maps to vllm", domain.Credential{
+			ProviderID: domain.ProviderOpenAI,
+			Extra:      map[string]string{"base_url": "http://llm-server:8000/v1"},
+		}, bfschemas.VLLM},
+		{"openai with litellm-style api_base maps to vllm", domain.Credential{
+			ProviderID: domain.ProviderOpenAI,
+			Extra:      map[string]string{"api_base": "http://llm-server:8000/v1"},
+		}, bfschemas.VLLM},
+		{"openai without base_url keeps openai", domain.Credential{ProviderID: domain.ProviderOpenAI}, bfschemas.OpenAI},
+		{"anthropic is unaffected", domain.Credential{ProviderID: domain.ProviderAnthropic}, bfschemas.Anthropic},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mapProvider(tc.cred); got != tc.want {
+				t.Fatalf("mapProvider(%v) = %q, want %q", tc.cred.ProviderID, got, tc.want)
+			}
+		})
+	}
+}
+
+// credentialToBifrostKey must carry the endpoint on VLLMKeyConfig.URL —
+// Bifrost's vLLM provider has no provider-level URL fallback, so a key
+// without it fails dispatch. An empty API key stays allowed: self-hosted
+// servers commonly run unauthenticated.
+//
+// Spec: specs/ai-gateway/custom-provider-base-url.feature
+func TestCredentialToBifrostKey_VLLM(t *testing.T) {
+	cred := domain.Credential{
+		ID:         "mp-1",
+		ProviderID: domain.ProviderCustom,
+		Extra:      map[string]string{"base_url": "http://llm-server:8000/v1"},
+	}
+	key := credentialToBifrostKey(cred, bfschemas.VLLM)
+
+	if key.VLLMKeyConfig == nil {
+		t.Fatal("VLLMKeyConfig is nil — vLLM keys require a per-key URL")
+	}
+	if got := key.VLLMKeyConfig.URL.Val; got != "http://llm-server:8000/v1" {
+		t.Fatalf("VLLMKeyConfig.URL = %q, want the configured base URL", got)
+	}
+	if key.Value.Val != "" {
+		t.Fatalf("key.Value = %q, want empty for unauthenticated server", key.Value.Val)
+	}
+}

--- a/services/aigateway/domain/provider.go
+++ b/services/aigateway/domain/provider.go
@@ -19,6 +19,10 @@ const (
 	// messages, and responses calls against a Voyage credential land
 	// on a clean unsupported-request-type error.
 	ProviderVoyage ProviderID = "voyage"
+	// Custom is any OpenAI-compatible endpoint the customer hosts
+	// themselves (vLLM, LiteLLM proxy, ...). Requires a base URL; the
+	// API key is optional (many self-hosted servers run unauthenticated).
+	ProviderCustom ProviderID = "custom"
 )
 
 // Credential holds the resolved credentials for a provider.

--- a/services/nlpgo/adapters/litellm/modelid.go
+++ b/services/nlpgo/adapters/litellm/modelid.go
@@ -26,10 +26,13 @@ var modelAliases = map[string]string{
 
 // providersNeedingDotToDash is the allowlist for the dot→dash rewrite. Only
 // these providers get their model ids transformed — applying it to OpenAI's
-// `gpt-3.5-turbo` would break that model name.
+// `gpt-3.5-turbo` would break that model name. Custom providers are
+// excluded: their model ids are arbitrary customer strings (e.g. vLLM
+// serving "Qwen/Qwen2.5-32B-Instruct") and rewriting dots would send a
+// model id the endpoint doesn't recognize. Mirrors
+// PROVIDERS_NEEDING_TRANSLATION in modelIdBoundary.ts.
 var providersNeedingDotToDash = map[string]bool{
 	"anthropic": true,
-	"custom":    true,
 }
 
 // reasoningModelPattern catches the reasoning-class models that pin

--- a/services/nlpgo/adapters/litellm/translator_test.go
+++ b/services/nlpgo/adapters/litellm/translator_test.go
@@ -66,10 +66,12 @@ func TestTranslateModelID_BareIDsTreatedAsAnthropic(t *testing.T) {
 	}
 }
 
-func TestTranslateModelID_CustomDotToDash(t *testing.T) {
-	got := TranslateModelID("custom/my-llm-1.2")
-	if got != "custom/my-llm-1-2" {
-		t.Errorf("expected custom dot→dash, got %q", got)
+func TestTranslateModelID_CustomKeptVerbatim(t *testing.T) {
+	// Custom model ids are arbitrary customer strings (vLLM serves
+	// "Qwen/Qwen2.5-32B-Instruct") — dots must survive.
+	got := TranslateModelID("custom/Qwen/Qwen2.5-32B-Instruct")
+	if got != "custom/Qwen/Qwen2.5-32B-Instruct" {
+		t.Errorf("expected custom model id kept verbatim, got %q", got)
 	}
 }
 

--- a/services/nlpgo/adapters/llmexecutor/executor.go
+++ b/services/nlpgo/adapters/llmexecutor/executor.go
@@ -70,9 +70,9 @@ func (e *Executor) Execute(ctx context.Context, req app.LLMRequest) (*app.LLMRes
 	}
 	durationMS := time.Since(start).Milliseconds()
 	if resp.StatusCode/100 != 2 {
-		provider, _ := litellm.SplitProviderModel(req.Model)
+		provider := req.Provider
 		if provider == "" {
-			provider = req.Provider
+			provider, _ = litellm.SplitProviderModel(req.Model)
 		}
 		return nil, &GatewayHTTPError{
 			StatusCode: resp.StatusCode,
@@ -167,25 +167,30 @@ func extractProviderErrorMessage(body []byte) string {
 // buildGatewayRequest performs all the shape mapping in one place so the
 // streaming and non-streaming paths share identical translation logic.
 func buildGatewayRequest(ctx context.Context, req app.LLMRequest, stream bool) (app.GatewayRequest, error) {
-	provider, _ := litellm.SplitProviderModel(req.Model)
+	// req.Provider is authoritative when set: the engine strips the
+	// provider prefix in `splitModel` (engine.go) and stores it there.
+	// Splitting req.Model first would mis-derive the provider for custom
+	// model ids that contain a slash of their own — "custom/Qwen/Qwen2.5"
+	// arrives here as Model "Qwen/Qwen2.5" + Provider "custom", and the
+	// split would yield provider "qwen".
+	provider := req.Provider
 	if provider == "" {
-		// Some workflows store the provider on the LLMRequest separately —
-		// honor that as a fall-back.
-		provider = req.Provider
+		provider, _ = litellm.SplitProviderModel(req.Model)
 	}
 	if provider == "" {
 		return app.GatewayRequest{}, fmt.Errorf("could not infer provider from model %q", req.Model)
 	}
 
 	// Reconstruct the prefixed model id before TranslateModelID so its
-	// providersNeedingDotToDash gate can see the provider. The engine
-	// strips the prefix in `splitModel` (engine.go) and stores it on
-	// req.Provider — without re-prefixing here, TranslateModelID falls
-	// to its empty-provider safety branch (treats as anthropic-like)
-	// and dot→dashes every model id, mangling Gemini + Vertex + Gemini's
-	// 2.5 family on the inline-credentials path.
+	// providersNeedingDotToDash gate can see the provider — without
+	// re-prefixing, TranslateModelID falls to its empty-provider safety
+	// branch (treats as anthropic-like) and dot→dashes every model id,
+	// mangling Gemini + Vertex + Gemini's 2.5 family on the
+	// inline-credentials path. Prefix-check (not just slash-check) so a
+	// custom model id like "Qwen/Qwen2.5-32B-Instruct" still gets its
+	// "custom/" prefix restored.
 	prefixedModel := req.Model
-	if !strings.Contains(req.Model, "/") && provider != "" {
+	if !strings.HasPrefix(req.Model, provider+"/") {
 		prefixedModel = provider + "/" + req.Model
 	}
 	translatedModel := litellm.TranslateModelID(prefixedModel)

--- a/services/nlpgo/adapters/llmexecutor/executor_test.go
+++ b/services/nlpgo/adapters/llmexecutor/executor_test.go
@@ -178,6 +178,30 @@ func TestExecute_CustomEmitsBareModelInBody(t *testing.T) {
 	}
 }
 
+func TestExecute_CustomModelWithSlashUsesRequestProvider(t *testing.T) {
+	// The engine strips the "custom/" prefix and stores it on
+	// req.Provider — a custom model id containing its own slash
+	// ("Qwen/Qwen2.5-32B-Instruct") must not have "Qwen" mis-derived
+	// as the provider, and the full id (dots included) must survive
+	// onto the wire.
+	gw := &fakeGateway{respStatus: 200, respBody: successResponse("ok")}
+	exec := New(gw)
+	_, err := exec.Execute(context.Background(), app.LLMRequest{
+		Model:    "Qwen/Qwen2.5-32B-Instruct",
+		Provider: "custom",
+		LiteLLMParams: map[string]any{
+			"api_base": "http://llm-server:8000/v1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := bodyField(t, gw.lastReq.Body, "model")
+	if got != "Qwen/Qwen2.5-32B-Instruct" {
+		t.Errorf("expected full custom model id on the wire, got %q", got)
+	}
+}
+
 func TestExecute_ReasoningModelOverridesTempAndMaxTokens(t *testing.T) {
 	gw := &fakeGateway{respStatus: 200, respBody: successResponse("ok")}
 	exec := New(gw)

--- a/specs/ai-gateway/custom-provider-base-url.feature
+++ b/specs/ai-gateway/custom-provider-base-url.feature
@@ -1,0 +1,38 @@
+Feature: Custom (OpenAI-compatible) provider routing to customer endpoints
+  Customers who self-host OpenAI-compatible model servers (vLLM, LiteLLM
+  proxy, ...) configure them in LangWatch as the "Custom (OpenAI-compatible)"
+  provider with a base URL and an optional API key. Every dispatch path —
+  virtual-key gateway traffic and in-app features (playground, workflows,
+  evaluations) — must send requests to the customer's endpoint, never to
+  api.openai.com.
+
+  Background:
+    Given a project with a "custom" model provider configured
+    And its CUSTOM_BASE_URL points at a self-hosted OpenAI-compatible server
+    And its CUSTOM_API_KEY is empty because the server is unauthenticated
+
+  Scenario: Virtual-key chat completion reaches the customer's endpoint
+    Given a virtual key whose provider slot is the custom provider
+    When a chat completion for "custom/<model>" is sent through the gateway
+    Then the upstream request is sent to the configured base URL
+    And the request body is OpenAI chat-completions shape with the bare model id
+
+  Scenario: Playground chat completion reaches the customer's endpoint
+    When the playground dispatches a chat completion using the custom provider
+    Then the upstream request is sent to the configured base URL
+    And no request is sent to api.openai.com
+
+  Scenario: Empty API key is accepted for unauthenticated servers
+    When a chat completion is dispatched through the custom provider
+    Then the dispatch does not fail credential validation
+    And the upstream request carries no bearer token
+
+  Scenario: OpenAI provider with a base URL override routes to that URL
+    Given an "openai" model provider with OPENAI_BASE_URL set to a proxy endpoint
+    When a chat completion is dispatched through it
+    Then the upstream request is sent to the proxy endpoint instead of api.openai.com
+
+  Scenario: OpenAI provider without a base URL keeps default routing
+    Given an "openai" model provider with only OPENAI_API_KEY set
+    When a chat completion is dispatched through it
+    Then the upstream request is sent to api.openai.com

--- a/specs/ai-gateway/custom-provider-base-url.feature
+++ b/specs/ai-gateway/custom-provider-base-url.feature
@@ -1,9 +1,9 @@
 Feature: Custom (OpenAI-compatible) provider routing to customer endpoints
   Customers who self-host OpenAI-compatible model servers (vLLM, LiteLLM
   proxy, ...) configure them in LangWatch as the "Custom (OpenAI-compatible)"
-  provider with a base URL and an optional API key. Every dispatch path —
+  provider with a base URL and an optional API key. Every dispatch path,
   virtual-key gateway traffic and in-app features (playground, workflows,
-  evaluations) — must send requests to the customer's endpoint, never to
+  evaluations), must send requests to the customer's endpoint, never to
   api.openai.com.
 
   Background:

--- a/specs/ai-gateway/custom-provider-base-url.feature
+++ b/specs/ai-gateway/custom-provider-base-url.feature
@@ -36,3 +36,15 @@ Feature: Custom (OpenAI-compatible) provider routing to customer endpoints
     Given an "openai" model provider with only OPENAI_API_KEY set
     When a chat completion is dispatched through it
     Then the upstream request is sent to api.openai.com
+
+  Scenario: Streaming chat completion still reports token usage
+    Given a virtual key whose provider slot is the custom provider
+    When a streaming chat completion for "custom/<model>" is sent through the gateway
+    Then the gateway asks the endpoint for a final usage chunk
+    And the streamed response reports non-zero prompt and completion tokens
+
+  Scenario: Provider-specific sampling params reach the endpoint unchanged
+    Given a virtual key whose provider slot is the custom provider
+    When a chat completion carrying vLLM-specific params (top_k, chat_template_kwargs, guided_json) is sent through the gateway
+    Then the upstream request preserves every param byte-for-byte
+    And no provider-specific param is dropped on the way to the endpoint


### PR DESCRIPTION
Fixes #5325

## Summary

Custom (OpenAI-compatible) model providers ignored their configured base URL and routed to `api.openai.com`. This fixes all four broken layers, validated end-to-end against a self-hosted vLLM (`Qwen/Qwen2.5-32B-Instruct`) via both the virtual-key path and the Optimization Studio playground:

- **Config materialiser (TS)**: forward `CUSTOM_BASE_URL` into the gateway provider slot as `base_url`; accept empty API keys.
- **Bifrost mapping (Go)**: map the custom provider (and OpenAI providers carrying a `base_url`) to Bifrost's generic OpenAI-compatible (vLLM) adapter with a per-key URL, instead of the hardcoded OpenAI endpoint.
- **Playground dispatch (nlpgo)**: prefer the request's explicit provider over re-deriving it by splitting the model string — custom model ids contain slashes (`Qwen/Qwen2.5-32B-Instruct` previously failed with `unsupported provider: "qwen"`). Also stop applying the anthropic-style dot→dash rewrite to custom ids (Go + TS).
- **Base URL normalization**: strip a trailing `/v1` before handing the URL to Bifrost, which appends `/v1/chat/completions` itself (user-configured `.../v1` URLs previously produced `POST /v1/v1/chat/completions` → 404).

## Test plan

- [x] BDD spec: `specs/ai-gateway/custom-provider-base-url.feature`
- [x] TS: `config.materialiser.integration.test.ts` (custom slot with `base_url` + empty `api_key`), `modelIdBoundary.unit.test.ts` (custom ids verbatim)
- [x] Go: `bifrost_test.go` (VLLM mapping + `normalizeOpenAICompatBaseURL` table), `translator_test.go` (custom ids kept verbatim), `executor_test.go` (slash-containing custom model uses request provider)
- [x] `pnpm typecheck` clean; all Go packages pass
- [x] Manually validated end-to-end on a self-hosted deployment: virtual-key chat completions (non-stream + stream) and playground executions reach the configured vLLM endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-provider upstream `base_url`/endpoint override support for custom OpenAI-compatible backends, including honoring standard OpenAI base URL overrides when configured.

* **Bug Fixes**
  * Preserve custom model IDs verbatim (no dot→dash rewriting) and ensure gateway requests and error attribution use the explicitly selected provider.
  * Made routing credential-aware across dispatch paths, propagated optional `base_url` overrides, and improved Bedrock VPCE credential handling.

* **Tests / Specs**
  * Expanded integration, unit, and feature coverage for custom/openai/vLLM base URL behavior and custom model ID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Maintainer follow-up: review gaps closed + end-to-end QA

Pushed commits on top of the original PR to close the review gaps (langwatch-agent CHANGES_REQUESTED and CodeRabbit) and validate everything against a real self-hosted vLLM.

### Fixes
- Materialiser resolves the base-URL override via the provider's registry `endpointKey`, so an `openai` provider with `OPENAI_BASE_URL` reaches its proxy instead of api.openai.com. Scoped to custom and openai, the only consumers of the per-slot base_url.
- Added `VLLM` to `isOpenAICompatibleProvider`, so custom / self-hosted OpenAI-compatible traffic raw-forwards byte-for-byte like OpenAI/Azure. Closes two regressions the structured-parse path caused for VLLM: streamed token usage is preserved (`DispatchStream` injects `stream_options.include_usage`), and vendor sampling params (`top_k`, `repetition_penalty`, `chat_template_kwargs`, `guided_json`) reach the endpoint instead of being dropped.
- Tests: materialiser integration slot for `OPENAI_BASE_URL`; `isOpenAICompatibleProvider` table including VLLM; VLLM raw-forward preserves the body. New spec scenarios for streamed usage and extra-param passthrough.

### End-to-end QA (real vLLM 0.11 serving Qwen/Qwen2.5-0.5B-Instruct)
Proven with the exact bytes forwarded to the upstream (an echo recorder) plus a real completion:
- Base-URL routing: `custom/Qwen/Qwen2.5-0.5B-Instruct` through the gateway returns a real completion with `provider=vllm`, `model_requested=Qwen/Qwen2.5-0.5B-Instruct`.
- Extra params: `top_k=42, repetition_penalty=1.3, min_p=0.07, chat_template_kwargs, guided_json` all arrive at the upstream unchanged.
- Streaming usage: the gateway injects `stream_options.include_usage=true` (never sent by the client), so the streamed response carries the final usage chunk.

Trace of a completion routed through the gateway to the custom vLLM provider (`gen_ai.provider.name: custom`, `virtual_key_id`, `gateway_request_id`, `Model: custom/Qwen/Qwen2.5-0.5B-Instruct`):

![trace details](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5326/qa/trace-details-custom-vllm.png)
![trace thread](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5326/qa/trace-thread.png)
![gateway traces list](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5326/qa/gateway-traces-list.png)
![model providers](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5326/qa/model-providers.png)
![virtual keys](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5326/qa/virtual-keys.png)

<!-- maintainer-qa-marker-5326 -->
