### PR TITLE
test(event-sourcing): guard test_event_handler_log cleanup on table existence (#5308)

### DIFF
--- a/langwatch/src/server/event-sourcing/__tests__/integration/cleanup-missing-table.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/integration/cleanup-missing-table.integration.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+  startTestContainers,
+  stopTestContainers,
+} from "./testContainers";
+
+const TEST_DATABASE = "test_langwatch";
+
+/**
+ * Regression guard for #5308. `test_event_handler_log` is created lazily (only
+ * when the map projection runs), so any test that calls `cleanupTestData(tenantId)`
+ * without it hits an `ALTER TABLE ... DELETE` on an absent table. The
+ * `@clickhouse/client` default logger writes that error to `console.error` BEFORE
+ * the promise rejects, so the caller's try/catch silences the throw but not the
+ * log line, which has twice masqueraded as a real failure (#4824, PR #5071). The
+ * fix guards the DELETE on `EXISTS TABLE`; this test executes the path and asserts
+ * the client never logs the missing-table error.
+ */
+describe("cleanupTestData benign missing-table log-noise (#5308)", () => {
+  beforeAll(async () => {
+    await startTestContainers();
+  });
+
+  afterAll(async () => {
+    await stopTestContainers();
+  });
+
+  describe("given test_event_handler_log does not exist", () => {
+    describe("when cleanupTestData runs for a tenant", () => {
+      it("does not log a Could not find table error from the ClickHouse client", async () => {
+        const client = getTestClickHouseClient();
+        expect(client).not.toBeNull();
+
+        // Guarantee the lazily-created table is absent for this run.
+        await client!.exec({
+          query: `DROP TABLE IF EXISTS "${TEST_DATABASE}".test_event_handler_log`,
+        });
+
+        const errorSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        let loggedArgs: string[] = [];
+        try {
+          await cleanupTestData("noise-guard-tenant");
+        } finally {
+          loggedArgs = errorSpy.mock.calls.flat().map((arg) => {
+            if (typeof arg === "string") return arg;
+            if (arg instanceof Error) return `${arg.stack ?? arg.message}`;
+            try {
+              return JSON.stringify(arg);
+            } catch {
+              return String(arg);
+            }
+          });
+          errorSpy.mockRestore();
+        }
+
+        const haystack = loggedArgs.join(" ");
+        expect(haystack).not.toContain("test_event_handler_log");
+        expect(haystack).not.toContain("Could not find table");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/__tests__/integration/testContainers.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/integration/testContainers.ts
@@ -267,17 +267,26 @@ export async function cleanupTestData(tenantId?: string): Promise<void> {
       query_params: { tenantId },
     });
 
-    // Clean up test_event_handler_log table (created in testPipelines.ts)
-    // Use try/catch since the table may not exist if no events were processed
-    try {
+    // Clean up test_event_handler_log (created lazily in testPipelines.ts, only
+    // when events are processed, so it is absent on shards that never ran the map
+    // projection). Guard on EXISTS rather than catching the error: the ClickHouse
+    // client logs the "Could not find table" error BEFORE a try/catch can swallow
+    // the throw, and that benign line has twice masqueraded as a real failure and
+    // burned triage (#4824, PR #5071). See #5308. `EXISTS TABLE` never errors on a
+    // missing table (it returns 0), so no noise is emitted on the absent path.
+    const [existsRow] = await clickHouseClient
+      .query({
+        query: `EXISTS TABLE "${TEST_DATABASE}".test_event_handler_log`,
+        format: "JSONEachRow",
+      })
+      .then((r) => r.json<{ result: number }>());
+    if (existsRow?.result === 1) {
       await clickHouseClient.exec({
         query: `
           ALTER TABLE "${TEST_DATABASE}".test_event_handler_log DELETE WHERE TenantId = {tenantId:String}
         `,
         query_params: { tenantId },
       });
-    } catch {
-      // Table doesn't exist - this is fine
     }
   } else {
     // Clean up all test data using TRUNCATE (synchronous and faster)


### PR DESCRIPTION
## Ticket

Closes #5308. Integration-test cleanup (`cleanupTestData`) emits `ClickHouseError: Could not find table: test_event_handler_log`, a benign line that has twice been mistaken for a real failure and burned triage (#4824, PR #5071).

## G-START verdict

PROCEED. Verified against current main (`c030de4`): the try/catch in `cleanupTestData`'s per-tenant branch is unchanged and the noise mechanism still holds. Not superseded by any open PR.

## Change

The per-tenant branch ran `ALTER TABLE ... DELETE` on `test_event_handler_log` inside a try/catch. The table is created lazily (only when the map projection runs), so any test that calls `cleanupTestData(tenantId)` without it hits a missing table. The `@clickhouse/client` default logger writes the error to `console.error` **before** the promise rejects, so the try/catch silences the throw but not the log line.

Guard the DELETE on `EXISTS TABLE` (which returns `0` for a missing table and never errors) so the failing query, and its logged error, never run. The `else` (full-cleanup) branch already used `TRUNCATE ... IF EXISTS` and was unaffected.

## Evidence

**Mechanism confirmed** (direct probe against the test ClickHouse): running the pre-fix `ALTER TABLE ... DELETE` on the absent table prints
```
[ERROR][@clickhouse/client][Connection] ... Caused by: ClickHouseError: Could not find table: test_event_handler_log. code: '60', type: 'UNKNOWN_TABLE'
```
to `console.error`, even though the caller's try/catch catches the thrown rejection. That is the benign noise.

**Regression guard** (`cleanup-missing-table.integration.test.ts`, new): drops the table, runs `cleanupTestData`, and asserts the client never logs the missing-table error. It executes the real path (not a string check), so:
- against the pre-fix `testContainers.ts`: **FAILS** — `AssertionError: expected '[...][ERROR][@cl...]' not to contain 'test_event_handler_log'` (it caught the real logged `Could not find table: test_event_handler_log`).
- against the fix: **PASSES** — `Test Files 1 passed, Tests 1 passed`.

Typecheck clean. Scoped to the test helper; no product-code or lockfile changes.

## Advisory note

Advisory PR from the tech-debt-fixer bot, opened for human review, not to be merged by the bot. The human makes the merge call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test data cleanup so it no longer produces noisy “missing table” errors when a tenant’s ClickHouse table is not yet present.
  * Added a regression test to verify cleanup runs quietly in this scenario and does not log table-missing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->