### PR TITLE
perf(build): lazy-split non-base Shiki grammars off the eager chunk (−1.34 MB gzip/page)

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/__tests__/shikiEagerChunks.unit.test.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/__tests__/shikiEagerChunks.unit.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Guard: the Vite `manualChunks` eager-Shiki allow-list (langwatch/vite.config.ts)
+ * must stay in sync with the canonical SHIKI_BASE_LANGS / SHIKI_THEMES owned by
+ * shikiAdapter.ts. If they drift, a base grammar silently drops to a lazy chunk
+ * and its first highlight stalls on a network fetch. This test fails loudly if
+ * a base language/theme is no longer force-kept in the eager `shiki` chunk.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+import { bundledLanguagesInfo } from "shiki";
+import { describe, expect, it } from "vitest";
+import { SHIKI_BASE_LANGS, SHIKI_THEMES } from "../shikiAdapter";
+
+// SHIKI_BASE_LANGS holds Shiki aliases (e.g. "bash"); the vite.config regex
+// matches grammar FILE names (e.g. "shellscript"). Resolve alias -> file name
+// using Shiki's own registry so the mapping can't itself drift.
+const aliasToFile = new Map<string, string>();
+for (const info of bundledLanguagesInfo) {
+  aliasToFile.set(info.id, info.id);
+  for (const alias of info.aliases ?? []) aliasToFile.set(alias, info.id);
+}
+const grammarFile = (lang: string) => aliasToFile.get(lang) ?? lang;
+
+// Pull the two eager allow-list alternations out of vite.config.ts. Both look
+// like `(a|b|c)\.m?js$`; pick the language one by "shellscript", the theme one
+// by "github-dark".
+const viteConfig = readFileSync(join(process.cwd(), "vite.config.ts"), "utf8");
+const alternations = [
+  ...viteConfig.matchAll(/\(([a-z0-9-|]+)\)\\\.m\?js\$/g),
+].map((m) => m[1].split("|"));
+const eagerLangFiles = new Set(
+  alternations.find((a) => a.includes("shellscript")) ?? [],
+);
+const eagerThemes = new Set(
+  alternations.find((a) => a.includes("github-dark")) ?? [],
+);
+
+describe("Shiki eager-chunk allow-list in vite.config", () => {
+  describe("given the manualChunks eager regexes are parsed from vite.config", () => {
+    it("finds a non-empty eager language and theme set", () => {
+      expect(eagerLangFiles.size).toBeGreaterThan(0);
+      expect(eagerThemes.size).toBeGreaterThan(0);
+    });
+
+    it("keeps every canonical base language eager", () => {
+      for (const lang of SHIKI_BASE_LANGS) {
+        expect(
+          eagerLangFiles.has(grammarFile(lang)),
+          `SHIKI_BASE_LANGS includes "${lang}" (grammar file "${grammarFile(
+            lang,
+          )}") but vite.config manualChunks would lazy-load it. Add it to the eager language regex.`,
+        ).toBe(true);
+      }
+    });
+
+    it("keeps every base theme eager", () => {
+      for (const theme of SHIKI_THEMES) {
+        expect(
+          eagerThemes.has(theme),
+          `SHIKI_THEMES includes "${theme}" but vite.config manualChunks would lazy-load it. Add it to the eager theme regex.`,
+        ).toBe(true);
+      }
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/__tests__/shikiEagerChunks.unit.test.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/__tests__/shikiEagerChunks.unit.test.ts
@@ -29,7 +29,7 @@ const grammarFile = (lang: string) => aliasToFile.get(lang) ?? lang;
 const viteConfig = readFileSync(join(process.cwd(), "vite.config.ts"), "utf8");
 const alternations = [
   ...viteConfig.matchAll(/\(([a-z0-9-|]+)\)\\\.m\?js\$/g),
-].map((m) => m[1].split("|"));
+].map((m) => m[1]?.split("|") ?? []);
 const eagerLangFiles = new Set(
   alternations.find((a) => a.includes("shellscript")) ?? [],
 );

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/__tests__/shikiEagerChunks.unit.test.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/__tests__/shikiEagerChunks.unit.test.ts
@@ -4,9 +4,10 @@
  * Drift guard: exercises the REAL `shikiManualChunk()` that vite.config's
  * `manualChunks` delegates to. Every canonical base language / theme
  * (SHIKI_BASE_LANGS / SHIKI_THEMES, owned by shikiAdapter.ts) must be
- * force-kept in the eager "shiki" chunk, and a non-base grammar must NOT be.
- * If the eager allow-list in shikiChunking.ts drifts from the canonical lists,
- * this fails loudly — without depending on the config's source formatting.
+ * force-kept in the eager "shiki" chunk; EVERY other bundled grammar must be
+ * left lazy; and every Shiki core/engine package must stay eager. If the eager
+ * allow-list in shikiChunking.ts drifts or its regexes over-broaden, this fails
+ * loudly — without depending on the config's source formatting.
  */
 import { bundledLanguagesInfo } from "shiki";
 import { describe, expect, it } from "vitest";
@@ -23,10 +24,8 @@ for (const info of bundledLanguagesInfo) {
 const langFile = (lang: string): string => aliasToFile.get(lang) ?? lang;
 
 // Synthetic module ids of the shape Rollup passes to manualChunks.
-const langPath = (lang: string) =>
-  `/repo/node_modules/.pnpm/@shikijs+langs@3.23.0/node_modules/@shikijs/langs/dist/${langFile(
-    lang,
-  )}.mjs`;
+const langPath = (file: string) =>
+  `/repo/node_modules/.pnpm/@shikijs+langs@3.23.0/node_modules/@shikijs/langs/dist/${file}.mjs`;
 const themePath = (theme: string) =>
   `/repo/node_modules/.pnpm/@shikijs+themes@3.23.0/node_modules/@shikijs/themes/dist/${theme}.mjs`;
 
@@ -37,7 +36,7 @@ describe("shikiManualChunk (vite.config eager Shiki allow-list)", () => {
     it("force-keeps every SHIKI_BASE_LANGS grammar in the eager chunk", () => {
       for (const lang of SHIKI_BASE_LANGS) {
         expect(
-          shikiManualChunk(langPath(lang)),
+          shikiManualChunk(langPath(langFile(lang))),
           `base language "${lang}" (grammar file "${langFile(
             lang,
           )}") must stay eager — update shikiChunking.ts`,
@@ -57,24 +56,53 @@ describe("shikiManualChunk (vite.config eager Shiki allow-list)", () => {
     });
   });
 
-  describe("given a grammar that is not a base language", () => {
-    it("leaves it to split into its own lazy chunk", () => {
-      const nonBase = bundledLanguagesInfo.find((i) => !baseFiles.has(i.id));
+  describe("given every grammar that is not a base language", () => {
+    it("leaves all ~340 of them to split into their own lazy chunks", () => {
+      const nonBase = bundledLanguagesInfo.filter((i) => !baseFiles.has(i.id));
+      expect(nonBase.length).toBeGreaterThan(100);
+      const eagerByMistake = nonBase.filter(
+        (i) => shikiManualChunk(langPath(i.id)) !== undefined,
+      );
       expect(
-        nonBase,
-        "expected at least one non-base bundled grammar",
-      ).toBeDefined();
-      expect(shikiManualChunk(langPath(nonBase!.id))).toBeUndefined();
+        eagerByMistake.map((i) => i.id),
+        "these non-base grammars are eager but should be lazy — the base-language regex is over-broad",
+      ).toEqual([]);
     });
   });
 
-  describe("given a Shiki core module", () => {
-    it("keeps the engine eager", () => {
+  describe("given a Shiki core / engine package", () => {
+    // Every alternation in shikiChunking.ts's SHIKI_CORE regex must stay eager
+    // to avoid the boot-cycle white-screen.
+    const corePkgPaths: Array<[string, string]> = [
+      ["@shikijs/core", "/repo/node_modules/@shikijs/core/dist/index.mjs"],
+      [
+        "@shikijs/engine-oniguruma",
+        "/repo/node_modules/@shikijs/engine-oniguruma/dist/index.mjs",
+      ],
+      ["shiki", "/repo/node_modules/shiki/dist/index.mjs"],
+      [
+        "oniguruma-to-es",
+        "/repo/node_modules/oniguruma-to-es/dist/index.mjs",
+      ],
+      [
+        "oniguruma-parser",
+        "/repo/node_modules/oniguruma-parser/dist/index.mjs",
+      ],
+      [
+        "hast-util-to-html",
+        "/repo/node_modules/hast-util-to-html/dist/index.mjs",
+      ],
+    ];
+    it.each(corePkgPaths)("keeps %s in the eager chunk", (_pkg, path) => {
+      expect(shikiManualChunk(path)).toBe("shiki");
+    });
+  });
+
+  describe("given a non-Shiki module", () => {
+    it("returns undefined (no opinion)", () => {
       expect(
-        shikiManualChunk(
-          "/repo/node_modules/.pnpm/@shikijs+core@3.23.0/node_modules/@shikijs/core/dist/index.mjs",
-        ),
-      ).toBe("shiki");
+        shikiManualChunk("/repo/node_modules/react/index.js"),
+      ).toBeUndefined();
     });
   });
 });

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/__tests__/shikiEagerChunks.unit.test.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/__tests__/shikiEagerChunks.unit.test.ts
@@ -1,67 +1,80 @@
 /**
  * @vitest-environment jsdom
  *
- * Guard: the Vite `manualChunks` eager-Shiki allow-list (langwatch/vite.config.ts)
- * must stay in sync with the canonical SHIKI_BASE_LANGS / SHIKI_THEMES owned by
- * shikiAdapter.ts. If they drift, a base grammar silently drops to a lazy chunk
- * and its first highlight stalls on a network fetch. This test fails loudly if
- * a base language/theme is no longer force-kept in the eager `shiki` chunk.
+ * Drift guard: exercises the REAL `shikiManualChunk()` that vite.config's
+ * `manualChunks` delegates to. Every canonical base language / theme
+ * (SHIKI_BASE_LANGS / SHIKI_THEMES, owned by shikiAdapter.ts) must be
+ * force-kept in the eager "shiki" chunk, and a non-base grammar must NOT be.
+ * If the eager allow-list in shikiChunking.ts drifts from the canonical lists,
+ * this fails loudly — without depending on the config's source formatting.
  */
-import { readFileSync } from "fs";
-import { join } from "path";
 import { bundledLanguagesInfo } from "shiki";
 import { describe, expect, it } from "vitest";
 import { SHIKI_BASE_LANGS, SHIKI_THEMES } from "../shikiAdapter";
+import { shikiManualChunk } from "../shikiChunking";
 
-// SHIKI_BASE_LANGS holds Shiki aliases (e.g. "bash"); the vite.config regex
-// matches grammar FILE names (e.g. "shellscript"). Resolve alias -> file name
-// using Shiki's own registry so the mapping can't itself drift.
+// Resolve a Shiki lang alias (e.g. "bash") to its grammar FILE name
+// (e.g. "shellscript") using Shiki's own registry, so the mapping can't drift.
 const aliasToFile = new Map<string, string>();
 for (const info of bundledLanguagesInfo) {
   aliasToFile.set(info.id, info.id);
   for (const alias of info.aliases ?? []) aliasToFile.set(alias, info.id);
 }
-const grammarFile = (lang: string) => aliasToFile.get(lang) ?? lang;
+const langFile = (lang: string): string => aliasToFile.get(lang) ?? lang;
 
-// Pull the two eager allow-list alternations out of vite.config.ts. Both look
-// like `(a|b|c)\.m?js$`; pick the language one by "shellscript", the theme one
-// by "github-dark".
-const viteConfig = readFileSync(join(process.cwd(), "vite.config.ts"), "utf8");
-const alternations = [
-  ...viteConfig.matchAll(/\(([a-z0-9-|]+)\)\\\.m\?js\$/g),
-].map((m) => m[1]?.split("|") ?? []);
-const eagerLangFiles = new Set(
-  alternations.find((a) => a.includes("shellscript")) ?? [],
-);
-const eagerThemes = new Set(
-  alternations.find((a) => a.includes("github-dark")) ?? [],
-);
+// Synthetic module ids of the shape Rollup passes to manualChunks.
+const langPath = (lang: string) =>
+  `/repo/node_modules/.pnpm/@shikijs+langs@3.23.0/node_modules/@shikijs/langs/dist/${langFile(
+    lang,
+  )}.mjs`;
+const themePath = (theme: string) =>
+  `/repo/node_modules/.pnpm/@shikijs+themes@3.23.0/node_modules/@shikijs/themes/dist/${theme}.mjs`;
 
-describe("Shiki eager-chunk allow-list in vite.config", () => {
-  describe("given the manualChunks eager regexes are parsed from vite.config", () => {
-    it("finds a non-empty eager language and theme set", () => {
-      expect(eagerLangFiles.size).toBeGreaterThan(0);
-      expect(eagerThemes.size).toBeGreaterThan(0);
-    });
+const baseFiles = new Set(SHIKI_BASE_LANGS.map(langFile));
 
-    it("keeps every canonical base language eager", () => {
+describe("shikiManualChunk (vite.config eager Shiki allow-list)", () => {
+  describe("given a canonical base language", () => {
+    it("force-keeps every SHIKI_BASE_LANGS grammar in the eager chunk", () => {
       for (const lang of SHIKI_BASE_LANGS) {
         expect(
-          eagerLangFiles.has(grammarFile(lang)),
-          `SHIKI_BASE_LANGS includes "${lang}" (grammar file "${grammarFile(
+          shikiManualChunk(langPath(lang)),
+          `base language "${lang}" (grammar file "${langFile(
             lang,
-          )}") but vite.config manualChunks would lazy-load it. Add it to the eager language regex.`,
-        ).toBe(true);
+          )}") must stay eager — update shikiChunking.ts`,
+        ).toBe("shiki");
       }
     });
+  });
 
-    it("keeps every base theme eager", () => {
+  describe("given a canonical base theme", () => {
+    it("force-keeps every SHIKI_THEMES file in the eager chunk", () => {
       for (const theme of SHIKI_THEMES) {
         expect(
-          eagerThemes.has(theme),
-          `SHIKI_THEMES includes "${theme}" but vite.config manualChunks would lazy-load it. Add it to the eager theme regex.`,
-        ).toBe(true);
+          shikiManualChunk(themePath(theme)),
+          `base theme "${theme}" must stay eager — update shikiChunking.ts`,
+        ).toBe("shiki");
       }
+    });
+  });
+
+  describe("given a grammar that is not a base language", () => {
+    it("leaves it to split into its own lazy chunk", () => {
+      const nonBase = bundledLanguagesInfo.find((i) => !baseFiles.has(i.id));
+      expect(
+        nonBase,
+        "expected at least one non-base bundled grammar",
+      ).toBeDefined();
+      expect(shikiManualChunk(langPath(nonBase!.id))).toBeUndefined();
+    });
+  });
+
+  describe("given a Shiki core module", () => {
+    it("keeps the engine eager", () => {
+      expect(
+        shikiManualChunk(
+          "/repo/node_modules/.pnpm/@shikijs+core@3.23.0/node_modules/@shikijs/core/dist/index.mjs",
+        ),
+      ).toBe("shiki");
     });
   });
 });

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/__tests__/shikiEagerChunks.unit.test.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/__tests__/shikiEagerChunks.unit.test.ts
@@ -80,10 +80,7 @@ describe("shikiManualChunk (vite.config eager Shiki allow-list)", () => {
         "/repo/node_modules/@shikijs/engine-oniguruma/dist/index.mjs",
       ],
       ["shiki", "/repo/node_modules/shiki/dist/index.mjs"],
-      [
-        "oniguruma-to-es",
-        "/repo/node_modules/oniguruma-to-es/dist/index.mjs",
-      ],
+      ["oniguruma-to-es", "/repo/node_modules/oniguruma-to-es/dist/index.mjs"],
       [
         "oniguruma-parser",
         "/repo/node_modules/oniguruma-parser/dist/index.mjs",

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/shikiAdapter.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/shikiAdapter.ts
@@ -11,7 +11,7 @@ import {
 // highlighter on first use; every other Shiki language is lazy-loaded on
 // demand via `ensureShikiLangLoaded`. See
 // dev/docs/adr/027-trace-drawer-code-highlighting.md
-const SHIKI_BASE_LANGS = [
+export const SHIKI_BASE_LANGS = [
   "json",
   "markdown",
   "bash",
@@ -22,7 +22,7 @@ const SHIKI_BASE_LANGS = [
   "ini",
 ] as const;
 
-const SHIKI_THEMES = ["github-dark", "github-light"] as const;
+export const SHIKI_THEMES = ["github-dark", "github-light"] as const;
 
 type SharedShikiTheme = (typeof SHIKI_THEMES)[number];
 

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/shikiChunking.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/shikiChunking.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure chunk-assignment for Shiki modules, shared by the Vite build
+ * (`vite.config.ts` `manualChunks`) and its guard test so the test can exercise
+ * the REAL logic instead of scraping the config source.
+ *
+ * Keeps Shiki's core (engine + oniguruma + singleton factory) plus only the
+ * base grammars/themes the app highlights on first paint in the eager `shiki`
+ * chunk; every other bundled grammar (~340 of them) falls through to its own
+ * lazy chunk, loaded on demand by shikiAdapter.ts (`ensureShikiLangLoaded`).
+ *
+ * The base grammar FILE names below (bash's grammar file is `shellscript`) and
+ * base themes must mirror SHIKI_BASE_LANGS / SHIKI_THEMES in shikiAdapter.ts —
+ * `shikiChunking.unit.test.ts` exercises this function against those canonical
+ * lists and fails if they drift. Deliberately dependency-free so the Vite
+ * config can import it without pulling in the runtime highlighter.
+ */
+const SHIKI_LANGS_OR_THEMES = /[\\/]@shikijs[\\/+](langs|themes)[\\/]/;
+const BASE_LANG_FILES =
+  /[\\/](json|markdown|shellscript|bash|typescript|python|ini)\.m?js$/;
+const BASE_THEME_FILES = /[\\/](github-dark|github-light)\.m?js$/;
+const SHIKI_CORE =
+  /[\\/]node_modules[\\/](\.pnpm[\\/])?(@shikijs[\\/+]|shiki[\\/@]|oniguruma-to-es|oniguruma-parser|hast-util-to-html)/;
+
+/** Returns "shiki" to force `id` into the eager chunk, or undefined to leave it
+ * to Rollup's default splitting (→ its own lazy chunk). */
+export function shikiManualChunk(id: string): "shiki" | undefined {
+  if (SHIKI_LANGS_OR_THEMES.test(id)) {
+    if (BASE_LANG_FILES.test(id) || BASE_THEME_FILES.test(id)) return "shiki";
+    return undefined;
+  }
+  if (SHIKI_CORE.test(id)) return "shiki";
+  return undefined;
+}

--- a/langwatch/vite.config.ts
+++ b/langwatch/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { generate as generateSelfsigned } from "selfsigned";
+import { shikiManualChunk } from "./src/features/traces-v2/components/TraceDrawer/markdownView/shikiChunking";
 
 // Load `.env` into the Vite config's process environment. Vite normally
 // only exposes `VITE_*` vars to client code — but this config itself
@@ -171,42 +172,13 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id: string) {
-          // Keep Shiki's CORE (engine + oniguruma + the singleton factory) and
-          // only the base grammars/themes the app highlights on first paint in
-          // one eager chunk. Every OTHER bundled grammar (~340 of them) is left
-          // to split into its own lazy chunk, loaded on demand by
-          // shikiAdapter.ts (`ensureShikiLangLoaded`). Forcing all grammars in
-          // here ballooned the eager chunk to ~9.5 MB raw / 1.66 MB gzip on
-          // every page load.
-          //
-          // Boot-cycle note: under the rolldown bundler the default split hoists
-          // Shiki's singleton factory into the entry chunk and leaves the Shiki
-          // chunk calling back into it at module top level. Because the entry
-          // eagerly loads Shiki, that call runs before the entry has initialized
-          // the export, throwing "undefined is not a function" at boot and
-          // white-screening the app. Keeping the core in one chunk removes the
-          // cross-chunk cycle; splitting only the leaf grammar/theme files
-          // (which have no such back-reference) is safe.
-          if (/[\\/]@shikijs[\\/+](langs|themes)[\\/]/.test(id)) {
-            // Base grammars (see SHIKI_BASE_LANGS) and base themes stay eager;
-            // all other leaf grammar/theme files fall through to lazy chunks.
-            if (
-              /[\\/](json|markdown|shellscript|bash|typescript|python|ini)\.m?js$/.test(
-                id,
-              ) ||
-              /[\\/](github-dark|github-light)\.m?js$/.test(id)
-            ) {
-              return "shiki";
-            }
-            return undefined;
-          }
-          if (
-            /[\\/]node_modules[\\/](\.pnpm[\\/])?(@shikijs[\\/+]|shiki[\\/@]|oniguruma-to-es|oniguruma-parser|hast-util-to-html)/.test(
-              id,
-            )
-          ) {
-            return "shiki";
-          }
+          // Shiki chunk-splitting lives in shikiChunking.ts (dependency-free) so
+          // its guard test can exercise the real logic. It keeps the core + base
+          // grammars/themes eager and splits the other ~340 grammars into lazy
+          // chunks — removing the ~9.5 MB raw / 1.66 MB gzip eager Shiki chunk
+          // that used to load on every page. See that file for the boot-cycle
+          // rationale.
+          return shikiManualChunk(id);
         },
       },
     },

--- a/langwatch/vite.config.ts
+++ b/langwatch/vite.config.ts
@@ -171,14 +171,35 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id: string) {
-          // Keep the whole Shiki ecosystem in one self-contained chunk.
-          // Under the rolldown bundler the default split hoists Shiki's
-          // singleton factory into the entry chunk and leaves the Shiki
-          // chunk calling back into it at module top level. Because the
-          // entry eagerly loads Shiki, that call runs before the entry has
-          // initialized the export, throwing "undefined is not a function"
-          // at boot and white-screening the app. One chunk removes the
-          // cross-chunk cycle.
+          // Keep Shiki's CORE (engine + oniguruma + the singleton factory) and
+          // only the base grammars/themes the app highlights on first paint in
+          // one eager chunk. Every OTHER bundled grammar (~340 of them) is left
+          // to split into its own lazy chunk, loaded on demand by
+          // shikiAdapter.ts (`ensureShikiLangLoaded`). Forcing all grammars in
+          // here ballooned the eager chunk to ~9.5 MB raw / 1.66 MB gzip on
+          // every page load.
+          //
+          // Boot-cycle note: under the rolldown bundler the default split hoists
+          // Shiki's singleton factory into the entry chunk and leaves the Shiki
+          // chunk calling back into it at module top level. Because the entry
+          // eagerly loads Shiki, that call runs before the entry has initialized
+          // the export, throwing "undefined is not a function" at boot and
+          // white-screening the app. Keeping the core in one chunk removes the
+          // cross-chunk cycle; splitting only the leaf grammar/theme files
+          // (which have no such back-reference) is safe.
+          if (/[\\/]@shikijs[\\/+](langs|themes)[\\/]/.test(id)) {
+            // Base grammars (see SHIKI_BASE_LANGS) and base themes stay eager;
+            // all other leaf grammar/theme files fall through to lazy chunks.
+            if (
+              /[\\/](json|markdown|shellscript|bash|typescript|python|ini)\.m?js$/.test(
+                id,
+              ) ||
+              /[\\/](github-dark|github-light)\.m?js$/.test(id)
+            ) {
+              return "shiki";
+            }
+            return undefined;
+          }
           if (
             /[\\/]node_modules[\\/](\.pnpm[\\/])?(@shikijs[\\/+]|shiki[\\/@]|oniguruma-to-es|oniguruma-parser|hast-util-to-html)/.test(
               id,


### PR DESCRIPTION
Part of langwatch/tasks#99 (Tier 2) · parent langwatch/tasks#105

## What

`vite.config.ts`'s `manualChunks` rule forced **all ~347 `@shikijs/langs` grammars** into one eager `shiki` chunk that loads on **every page**. It was added to fix a boot-cycle white-screen, but over-corrected. This keeps only Shiki's **core** (engine + oniguruma + singleton factory) plus the **6 base grammars** (`json, markdown, shellscript/bash, typescript, python, ini`) and **2 themes** (`github-dark/light`) eager, and lets the other **~340 grammars split into lazy chunks** that `shikiAdapter.ts` already loads on demand (ADR-027).

## 📊 Benchmark (rolldown prod build, before/after)

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| **Eager `shiki` chunk** | 9,498 kB raw / **1,660 kB gzip** | 1,151 kB raw / **320 kB gzip** | **−1,340 kB gzip (−81%)** |
| Grammar chunks | 0 (all eager) | ~292 lazy | on demand |

**~1.34 MB gzip removed from the eager JS of every page load.** For scale: this is ~660× the Tier-1 modal change (#5342, 2 kB), and it's the chunk the Lighthouse "reduce JS execution" finding was actually about. This one should move real LCP/TBT.

## Why it doesn't compromise the experience

- **Common languages stay eager** (json, markdown, bash, typescript, python, ini) → highlighting is still instant, byte-identical behavior.
- **Rare languages lazy-load on demand** — which `shikiAdapter.ts` *already* did by design (ADR-027); this PR just restores that after the chunk rule had defeated it. Code is always readable; only rare-language *colors* arrive a beat later on first view.
- **No adapter code changed** — only the bundler chunking.

## Verification

- **Boot-cycle (the risk this rule guarded): CLEARED.** Served the prod build and loaded it in a real browser — React mounts, the app routes client-side to `/auth/signin`, and there is **no `"undefined is not a function"`** / no module-init crash (only expected backend-502 noise). A boot cycle would white-screen before React mounts.
- `shikiAdapter` unit tests: **11/11 pass**.
- Production build: clean.

## ⚠️ Remaining QA before merge

End-to-end highlighting of a **rare (lazy-loaded) language** in a logged-in trace/code view was **not** dogfooded — the static preview has no backend. Someone should open a trace containing e.g. `go` / `yaml` / `painless` and confirm the grammar lazy-loads and highlights. (Base languages are unaffected.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Refined syntax-highlighting bundling to more precisely eager-load only the essential Shiki base languages and themes, while leaving other Shiki assets to load lazily. This helps improve load times and reduces bundle size.
* **Tests**
  * Added unit coverage to verify the eager-chunk allow-list for Shiki base languages/themes and core modules remains aligned with canonical Shiki definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->