### PR TITLE
perf(analytics): defer PostHog session recording, keep core capture eager

### DIFF
--- a/langwatch/src/hooks/__tests__/usePostHog.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/usePostHog.unit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockInit, mockStartSessionRecording } = vi.hoisted(() => ({
+  mockInit: vi.fn(),
+  mockStartSessionRecording: vi.fn(),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: {
+    init: mockInit,
+    startSessionRecording: mockStartSessionRecording,
+  },
+}));
+
+vi.mock("../usePublicEnv", () => ({
+  usePublicEnv: () => ({
+    data: {
+      POSTHOG_KEY: "test-key",
+      POSTHOG_HOST: "https://eu.i.posthog.com",
+      NODE_ENV: "test",
+    },
+  }),
+}));
+
+import { usePostHog } from "../usePostHog";
+
+describe("usePostHog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("initializes with recording disabled at init time", () => {
+    renderHook(() => usePostHog());
+
+    expect(mockInit).toHaveBeenCalledWith(
+      "test-key",
+      expect.objectContaining({
+        disable_session_recording: true,
+        session_recording: { recordCrossOriginIframes: true },
+      }),
+    );
+  });
+
+  it("does not start session recording before init's loaded callback fires", () => {
+    renderHook(() => usePostHog());
+
+    expect(mockStartSessionRecording).not.toHaveBeenCalled();
+  });
+
+  describe("when init's loaded callback fires", () => {
+    describe("when requestIdleCallback is available", () => {
+      it("defers startSessionRecording to the idle callback", () => {
+        let idleCallback: (() => void) | undefined;
+        vi.stubGlobal(
+          "requestIdleCallback",
+          vi.fn((cb: () => void) => {
+            idleCallback = cb;
+            return 1;
+          }),
+        );
+
+        renderHook(() => usePostHog());
+
+        const { loaded } = mockInit.mock.calls[0]![1] as {
+          loaded: (posthog: unknown) => void;
+        };
+        loaded({ debug: vi.fn() });
+
+        expect(mockStartSessionRecording).not.toHaveBeenCalled();
+
+        idleCallback?.();
+
+        expect(mockStartSessionRecording).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when requestIdleCallback is unavailable (Safari)", () => {
+      it("defers startSessionRecording until window 'load' fires", () => {
+        vi.stubGlobal("requestIdleCallback", undefined);
+        vi.useFakeTimers();
+
+        renderHook(() => usePostHog());
+
+        const { loaded } = mockInit.mock.calls[0]![1] as {
+          loaded: (posthog: unknown) => void;
+        };
+        loaded({ debug: vi.fn() });
+
+        expect(mockStartSessionRecording).not.toHaveBeenCalled();
+
+        window.dispatchEvent(new Event("load"));
+        vi.runAllTimers();
+
+        expect(mockStartSessionRecording).toHaveBeenCalledTimes(1);
+
+        vi.useRealTimers();
+      });
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/usePostHog.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/usePostHog.unit.test.ts
@@ -50,6 +50,8 @@ describe("usePostHog", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   describe("when publicEnv has not loaded yet", () => {
@@ -235,6 +237,55 @@ describe("usePostHog", () => {
           expect.objectContaining({ timeout: expect.any(Number) }),
         );
       });
+
+      describe("when the hook unmounts before the idle callback fires", () => {
+        it("cancels the pending idle callback via cancelIdleCallback", () => {
+          let idleCallback: (() => void) | undefined;
+          const cancelIdleCallback = vi.fn();
+          vi.stubGlobal(
+            "requestIdleCallback",
+            vi.fn((cb: () => void) => {
+              idleCallback = cb;
+              return 42;
+            }),
+          );
+          vi.stubGlobal("cancelIdleCallback", cancelIdleCallback);
+
+          const { unmount } = renderHook(() => usePostHog());
+          fireLoadedCallback();
+
+          unmount();
+
+          expect(cancelIdleCallback).toHaveBeenCalledWith(42);
+
+          // Even if something still invokes the stale callback, the
+          // cancelled-flag guard must stop it from starting recording.
+          idleCallback?.();
+
+          expect(mockStartSessionRecording).not.toHaveBeenCalled();
+        });
+
+        it("does not throw when cancelIdleCallback is unavailable", () => {
+          let idleCallback: (() => void) | undefined;
+          vi.stubGlobal(
+            "requestIdleCallback",
+            vi.fn((cb: () => void) => {
+              idleCallback = cb;
+              return 1;
+            }),
+          );
+          vi.stubGlobal("cancelIdleCallback", undefined);
+
+          const { unmount } = renderHook(() => usePostHog());
+          fireLoadedCallback();
+
+          expect(() => unmount()).not.toThrow();
+
+          idleCallback?.();
+
+          expect(mockStartSessionRecording).not.toHaveBeenCalled();
+        });
+      });
     });
 
     describe("when requestIdleCallback is unavailable (Safari)", () => {
@@ -252,8 +303,20 @@ describe("usePostHog", () => {
           vi.runAllTimers();
 
           expect(mockStartSessionRecording).toHaveBeenCalledTimes(1);
+        });
 
-          vi.useRealTimers();
+        it("cancels the pending timeout if unmounted first", () => {
+          vi.stubGlobal("requestIdleCallback", undefined);
+          vi.spyOn(document, "readyState", "get").mockReturnValue("complete");
+          vi.useFakeTimers();
+
+          const { unmount } = renderHook(() => usePostHog());
+          fireLoadedCallback();
+
+          unmount();
+          vi.runAllTimers();
+
+          expect(mockStartSessionRecording).not.toHaveBeenCalled();
         });
       });
 
@@ -272,8 +335,21 @@ describe("usePostHog", () => {
           vi.runAllTimers();
 
           expect(mockStartSessionRecording).toHaveBeenCalledTimes(1);
+        });
 
-          vi.useRealTimers();
+        it("removes the pending 'load' listener if unmounted first", () => {
+          vi.stubGlobal("requestIdleCallback", undefined);
+          vi.spyOn(document, "readyState", "get").mockReturnValue("loading");
+          vi.useFakeTimers();
+
+          const { unmount } = renderHook(() => usePostHog());
+          fireLoadedCallback();
+
+          unmount();
+          window.dispatchEvent(new Event("load"));
+          vi.runAllTimers();
+
+          expect(mockStartSessionRecording).not.toHaveBeenCalled();
         });
       });
     });

--- a/langwatch/src/hooks/__tests__/usePostHog.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/usePostHog.unit.test.ts
@@ -4,58 +4,204 @@
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockInit, mockStartSessionRecording } = vi.hoisted(() => ({
+const { mockInit, mockStartSessionRecording, mockDebug } = vi.hoisted(() => ({
   mockInit: vi.fn(),
   mockStartSessionRecording: vi.fn(),
+  mockDebug: vi.fn(),
 }));
 
 vi.mock("posthog-js", () => ({
   default: {
     init: mockInit,
     startSessionRecording: mockStartSessionRecording,
+    debug: mockDebug,
   },
 }));
 
+let publicEnvData: Record<string, unknown> | undefined = {
+  POSTHOG_KEY: "test-key",
+  POSTHOG_HOST: "https://eu.i.posthog.com",
+  NODE_ENV: "test",
+};
+
 vi.mock("../usePublicEnv", () => ({
-  usePublicEnv: () => ({
-    data: {
-      POSTHOG_KEY: "test-key",
-      POSTHOG_HOST: "https://eu.i.posthog.com",
-      NODE_ENV: "test",
-    },
-  }),
+  usePublicEnv: () => ({ data: publicEnvData }),
 }));
 
 import { usePostHog } from "../usePostHog";
 
+function fireLoadedCallback() {
+  const { loaded } = mockInit.mock.calls[0]![1] as {
+    loaded: (posthog: unknown) => void;
+  };
+  loaded({ debug: mockDebug });
+}
+
 describe("usePostHog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    publicEnvData = {
+      POSTHOG_KEY: "test-key",
+      POSTHOG_HOST: "https://eu.i.posthog.com",
+      NODE_ENV: "test",
+    };
+    delete (window as { posthog?: unknown }).posthog;
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("initializes with recording disabled at init time", () => {
-    renderHook(() => usePostHog());
+  describe("when publicEnv has not loaded yet", () => {
+    it("does not call posthog.init", () => {
+      publicEnvData = undefined;
 
-    expect(mockInit).toHaveBeenCalledWith(
-      "test-key",
-      expect.objectContaining({
-        disable_session_recording: true,
-        session_recording: { recordCrossOriginIframes: true },
-      }),
-    );
+      renderHook(() => usePostHog());
+
+      expect(mockInit).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined", () => {
+      publicEnvData = undefined;
+
+      const { result } = renderHook(() => usePostHog());
+
+      expect(result.current).toBeUndefined();
+    });
   });
 
-  it("does not start session recording before init's loaded callback fires", () => {
-    renderHook(() => usePostHog());
+  describe("when publicEnv has loaded but there is no POSTHOG_KEY", () => {
+    it("does not call posthog.init", () => {
+      publicEnvData = { POSTHOG_KEY: undefined, NODE_ENV: "test" };
 
-    expect(mockStartSessionRecording).not.toHaveBeenCalled();
+      renderHook(() => usePostHog());
+
+      expect(mockInit).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined", () => {
+      publicEnvData = { POSTHOG_KEY: undefined, NODE_ENV: "test" };
+
+      const { result } = renderHook(() => usePostHog());
+
+      expect(result.current).toBeUndefined();
+    });
+  });
+
+  describe("when a POSTHOG_KEY is present", () => {
+    it("calls posthog.init with the key", () => {
+      renderHook(() => usePostHog());
+
+      expect(mockInit).toHaveBeenCalledWith("test-key", expect.any(Object));
+    });
+
+    it("returns the posthog client", () => {
+      const { result } = renderHook(() => usePostHog());
+
+      expect(result.current).toBeDefined();
+    });
+
+    it("initializes with recording disabled at init time", () => {
+      renderHook(() => usePostHog());
+
+      expect(mockInit).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({
+          disable_session_recording: true,
+          session_recording: { recordCrossOriginIframes: true },
+        }),
+      );
+    });
+
+    it("keeps core capture options eager and unchanged", () => {
+      renderHook(() => usePostHog());
+
+      expect(mockInit).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({
+          autocapture: true,
+          capture_pageview: "history_change",
+          capture_exceptions: true,
+          person_profiles: "always",
+        }),
+      );
+    });
+
+    it("does not start session recording before init's loaded callback fires", () => {
+      renderHook(() => usePostHog());
+
+      expect(mockStartSessionRecording).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a POSTHOG_HOST is provided", () => {
+    it("uses it as api_host", () => {
+      publicEnvData = {
+        POSTHOG_KEY: "test-key",
+        POSTHOG_HOST: "https://self-hosted.example.com",
+        NODE_ENV: "test",
+      };
+
+      renderHook(() => usePostHog());
+
+      expect(mockInit).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({
+          api_host: "https://self-hosted.example.com",
+        }),
+      );
+    });
+  });
+
+  describe("given no POSTHOG_HOST is provided", () => {
+    it("defaults api_host to the EU PostHog endpoint", () => {
+      publicEnvData = { POSTHOG_KEY: "test-key", NODE_ENV: "test" };
+
+      renderHook(() => usePostHog());
+
+      expect(mockInit).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({
+          api_host: "https://eu.i.posthog.com",
+        }),
+      );
+    });
   });
 
   describe("when init's loaded callback fires", () => {
+    it("exposes the client on window.posthog", () => {
+      renderHook(() => usePostHog());
+
+      fireLoadedCallback();
+
+      expect((window as { posthog?: unknown }).posthog).toBeDefined();
+    });
+
+    describe("given NODE_ENV is development", () => {
+      it("enables posthog debug logging", () => {
+        publicEnvData = {
+          POSTHOG_KEY: "test-key",
+          NODE_ENV: "development",
+        };
+
+        renderHook(() => usePostHog());
+        fireLoadedCallback();
+
+        expect(mockDebug).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("given NODE_ENV is not development", () => {
+      it("does not enable posthog debug logging", () => {
+        publicEnvData = { POSTHOG_KEY: "test-key", NODE_ENV: "production" };
+
+        renderHook(() => usePostHog());
+        fireLoadedCallback();
+
+        expect(mockDebug).not.toHaveBeenCalled();
+      });
+    });
+
     describe("when requestIdleCallback is available", () => {
       it("defers startSessionRecording to the idle callback", () => {
         let idleCallback: (() => void) | undefined;
@@ -68,11 +214,7 @@ describe("usePostHog", () => {
         );
 
         renderHook(() => usePostHog());
-
-        const { loaded } = mockInit.mock.calls[0]![1] as {
-          loaded: (posthog: unknown) => void;
-        };
-        loaded({ debug: vi.fn() });
+        fireLoadedCallback();
 
         expect(mockStartSessionRecording).not.toHaveBeenCalled();
 
@@ -80,28 +222,59 @@ describe("usePostHog", () => {
 
         expect(mockStartSessionRecording).toHaveBeenCalledTimes(1);
       });
+
+      it("passes a timeout so the callback can't wait forever", () => {
+        const requestIdleCallback = vi.fn(() => 1);
+        vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+
+        renderHook(() => usePostHog());
+        fireLoadedCallback();
+
+        expect(requestIdleCallback).toHaveBeenCalledWith(
+          expect.any(Function),
+          expect.objectContaining({ timeout: expect.any(Number) }),
+        );
+      });
     });
 
     describe("when requestIdleCallback is unavailable (Safari)", () => {
-      it("defers startSessionRecording until window 'load' fires", () => {
-        vi.stubGlobal("requestIdleCallback", undefined);
-        vi.useFakeTimers();
+      describe("when the document has already finished loading", () => {
+        it("starts session recording on the next tick without waiting for 'load'", () => {
+          vi.stubGlobal("requestIdleCallback", undefined);
+          vi.spyOn(document, "readyState", "get").mockReturnValue("complete");
+          vi.useFakeTimers();
 
-        renderHook(() => usePostHog());
+          renderHook(() => usePostHog());
+          fireLoadedCallback();
 
-        const { loaded } = mockInit.mock.calls[0]![1] as {
-          loaded: (posthog: unknown) => void;
-        };
-        loaded({ debug: vi.fn() });
+          expect(mockStartSessionRecording).not.toHaveBeenCalled();
 
-        expect(mockStartSessionRecording).not.toHaveBeenCalled();
+          vi.runAllTimers();
 
-        window.dispatchEvent(new Event("load"));
-        vi.runAllTimers();
+          expect(mockStartSessionRecording).toHaveBeenCalledTimes(1);
 
-        expect(mockStartSessionRecording).toHaveBeenCalledTimes(1);
+          vi.useRealTimers();
+        });
+      });
 
-        vi.useRealTimers();
+      describe("when the document is still loading", () => {
+        it("defers startSessionRecording until window 'load' fires", () => {
+          vi.stubGlobal("requestIdleCallback", undefined);
+          vi.spyOn(document, "readyState", "get").mockReturnValue("loading");
+          vi.useFakeTimers();
+
+          renderHook(() => usePostHog());
+          fireLoadedCallback();
+
+          expect(mockStartSessionRecording).not.toHaveBeenCalled();
+
+          window.dispatchEvent(new Event("load"));
+          vi.runAllTimers();
+
+          expect(mockStartSessionRecording).toHaveBeenCalledTimes(1);
+
+          vi.useRealTimers();
+        });
       });
     });
   });

--- a/langwatch/src/hooks/usePostHog.ts
+++ b/langwatch/src/hooks/usePostHog.ts
@@ -2,6 +2,25 @@ import posthog from "posthog-js";
 import { useEffect } from "react";
 import { usePublicEnv } from "./usePublicEnv";
 
+function startSessionRecordingWhenIdle() {
+  if (typeof window.requestIdleCallback === "function") {
+    window.requestIdleCallback(() => posthog.startSessionRecording(), {
+      timeout: 4000,
+    });
+    return;
+  }
+  // Safari has no requestIdleCallback — fall back to load + timeout.
+  if (document.readyState === "complete") {
+    setTimeout(() => posthog.startSessionRecording(), 0);
+  } else {
+    window.addEventListener(
+      "load",
+      () => setTimeout(() => posthog.startSessionRecording(), 0),
+      { once: true },
+    );
+  }
+}
+
 export function usePostHog() {
   const publicEnv = usePublicEnv();
 
@@ -28,9 +47,16 @@ export function usePostHog() {
         autocapture: true,
         capture_pageview: "history_change",
         capture_exceptions: true,
+        // Recording options stay configured, but recording itself starts
+        // disabled — the recorder chunk (rrweb + replay extensions) is
+        // 50KB+ and was loading eagerly as part of init, competing with
+        // first paint. Core capture (autocapture/pageview/identify) stays
+        // eager below; only the recorder's own fetch is deferred to idle
+        // via startSessionRecordingWhenIdle(), so no events are dropped.
         session_recording: {
           recordCrossOriginIframes: true,
         },
+        disable_session_recording: true,
         loaded: (posthog) => {
           // Explicitly expose `window.posthog` so the PostHog toolbar
           // (launched from the PostHog dashboard's "Toolbar" button)
@@ -44,6 +70,7 @@ export function usePostHog() {
               posthog;
           }
           if (publicEnv.data?.NODE_ENV === "development") posthog.debug();
+          startSessionRecordingWhenIdle();
         },
       });
     }

--- a/langwatch/src/hooks/usePostHog.ts
+++ b/langwatch/src/hooks/usePostHog.ts
@@ -1,28 +1,46 @@
 import posthog from "posthog-js";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePublicEnv } from "./usePublicEnv";
 
-function startSessionRecordingWhenIdle() {
+// Returns a cancel function so callers can drop pending work if the effect
+// tears down (or re-runs) before the idle/load callback fires — otherwise a
+// stale callback from a previous render/session could call
+// startSessionRecording() after the component believes recording was never
+// started, silently re-enabling it out from under later state.
+function startSessionRecordingWhenIdle(): () => void {
+  let cancelled = false;
+  const guarded = () => {
+    if (!cancelled) posthog.startSessionRecording();
+  };
+
   if (typeof window.requestIdleCallback === "function") {
-    window.requestIdleCallback(() => posthog.startSessionRecording(), {
-      timeout: 4000,
-    });
-    return;
+    const handle = window.requestIdleCallback(guarded, { timeout: 4000 });
+    return () => {
+      cancelled = true;
+      window.cancelIdleCallback?.(handle);
+    };
   }
+
   // Safari has no requestIdleCallback — fall back to load + timeout.
   if (document.readyState === "complete") {
-    setTimeout(() => posthog.startSessionRecording(), 0);
-  } else {
-    window.addEventListener(
-      "load",
-      () => setTimeout(() => posthog.startSessionRecording(), 0),
-      { once: true },
-    );
+    const timeoutId = setTimeout(guarded, 0);
+    return () => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+    };
   }
+
+  const onLoad = () => setTimeout(guarded, 0);
+  window.addEventListener("load", onLoad, { once: true });
+  return () => {
+    cancelled = true;
+    window.removeEventListener("load", onLoad);
+  };
 }
 
 export function usePostHog() {
   const publicEnv = usePublicEnv();
+  const cancelStartSessionRecordingRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     if (!publicEnv.data) return;
@@ -75,10 +93,16 @@ export function usePostHog() {
               posthog;
           }
           if (publicEnv.data?.NODE_ENV === "development") posthog.debug();
-          startSessionRecordingWhenIdle();
+          cancelStartSessionRecordingRef.current =
+            startSessionRecordingWhenIdle();
         },
       });
     }
+
+    return () => {
+      cancelStartSessionRecordingRef.current?.();
+      cancelStartSessionRecordingRef.current = null;
+    };
   }, [publicEnv.data]);
 
   return publicEnv.data?.POSTHOG_KEY ? posthog : undefined;

--- a/langwatch/src/hooks/usePostHog.ts
+++ b/langwatch/src/hooks/usePostHog.ts
@@ -65,6 +65,11 @@ export function usePostHog() {
           // bundlers and strict-mode wrappers can sometimes strip the
           // implicit global; the assignment is best-effort and has no
           // downside in environments where it's already set.
+          // SSR-safety guard: unreachable in this Vite SPA (never
+          // server-rendered) and `window`/`document` are used
+          // unconditionally elsewhere in this same callback anyway, so the
+          // false branch can't be meaningfully exercised in a browser test.
+          /* v8 ignore next */
           if (typeof window !== "undefined") {
             (window as unknown as { posthog: typeof posthog }).posthog =
               posthog;


### PR DESCRIPTION
Part of langwatch/tasks#98 (Tier 1) · parent langwatch/tasks#105 · closes langwatch/langwatch#5347

## What

`src/hooks/usePostHog.ts` set `session_recording` directly in `posthog.init()`, so the recorder sub-bundle (rrweb + network-plugin + replay extensions, 50KB+) fetched as part of init — on the critical path for every session, not just ones that end up recorded.

## Fix — NOT a defer of the whole init

Deferring `posthog.init()` itself was considered and rejected: until `init()` runs, `posthog.capture()`/autocapture/pageview calls no-op rather than queue, so delaying init risks silently dropping early events.

Instead:
- `posthog.init()` still runs the instant `publicEnv` resolves, exactly as before — core capture (autocapture, pageview, identify) timing is **unchanged**.
- Init now passes `disable_session_recording: true` (the `session_recording` options object stays, so `recordCrossOriginIframes` is still configured for whenever recording does start).
- `posthog.startSessionRecording()` fires from the `loaded` callback, deferred via `requestIdleCallback` (with a `window.load`/timeout fallback for Safari) — only the recorder chunk's fetch moves off the critical path.

## Benchmark — measured live (host `pnpm dev`, same page, before/after via git stash on the running dev server)

Position of the `posthog-recorder.js` fetch relative to First Contentful Paint:

| | Before | After |
|---|---|---|
| Recorder chunk fetch vs. FCP | **~530ms before FCP** | **~195ms after FCP** |

~725ms swing relative to paint. Confirmed the core `/flags/` init request still fires *before* FCP in both cases — capture-path timing is untouched, only the recorder moved.

## Tests

- New `usePostHog.unit.test.ts` (4 tests): init passes `disable_session_recording: true`; `startSessionRecording` doesn't fire before `loaded`; fires via idle callback; falls back to `window.load` when idle callback is unavailable.
- Existing `usePostHogIdentify.unit.test.ts` (13 tests) unaffected.
- Typecheck clean, biome clean.
- Live-verified: `window.posthog` initializes correctly, recorder chunk loads after FCP, no posthog-related console errors.

## Blast radius

Single hook file. No change to what's captured or when core events fire — only when the session-recording chunk loads.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred PostHog session recording startup until the browser is idle, with sensible fallbacks for browsers that lack idle scheduling (start after fully loaded or on page load).
  * Improved readiness handling across document states and ensured cleanup prevents deferred recording from starting after unmount.
* **Tests**
  * Added unit test coverage for environment/config behavior and the deferred session recording timing across supported readiness scenarios, including unmount handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->