### PR TITLE
fix(claude-code): classify from the raw request/response body — full cache-tier + tool + output fidelity

### DIFF
--- a/dev/docs/runbooks/e2e-coding-agent-cost-intelligence.md
+++ b/dev/docs/runbooks/e2e-coding-agent-cost-intelligence.md
@@ -109,6 +109,15 @@ Read it back three ways:
   category sum equal to that displayed cost is exactly what this end-to-end run
   exercises.
 
+## Kill-switch scope
+
+`block-classification-killswitch` (global) / `block-classification-project-killswitch`
+(per-project) stop the ingest-time block classifier only. They do NOT stop
+session-step tracking: the trace fold keeps appending `session_steps` /
+`session.thread_id` from usage attributes on every coding-agent span. There is
+currently no runtime off-ramp for session tracking — disabling it requires a
+deploy.
+
 ## No classification? Check in order
 
 1. Flag not set in the **worker** env → put it in `langwatch/.env`, restart.

--- a/langwatch/ee/governance/routers/__tests__/governance.rbac.integration.test.ts
+++ b/langwatch/ee/governance/routers/__tests__/governance.rbac.integration.test.ts
@@ -45,6 +45,7 @@ import { globalForApp, resetApp } from "~/server/app-layer/app";
 import { createTestApp } from "~/server/app-layer/presets";
 import { PlanProviderService } from "~/server/app-layer/subscription/plan-provider";
 import { prisma } from "~/server/db";
+import { activityMonitorRouter } from "../activityMonitor";
 import { ACTIVITY_MONITOR_PROCEDURES } from "./activityMonitorProcedures.fixtures";
 
 // The new requireEnterprisePlan middleware (Phase 4b-4/5) 403s every
@@ -238,6 +239,19 @@ describe("governance routers — RBAC enforcement", () => {
           scopeId: organizationId,
         }),
       ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    // The guard-probe loop below only closes the whole-router gap if the
+    // fixture actually lists every procedure — pin the two in lockstep so a
+    // new procedure that isn't added to the fixture fails here first.
+    it("keeps the guard-probe fixture exhaustive over the router's procedures", () => {
+      const routerProcedures = Object.keys(
+        activityMonitorRouter._def.procedures,
+      ).sort();
+      const fixtureProcedures = ACTIVITY_MONITOR_PROCEDURES.map(
+        ([name]) => name,
+      ).sort();
+      expect(fixtureProcedures).toEqual(routerProcedures);
     });
 
     // Every activityMonitor procedure gates on `activityMonitor:view`, so a

--- a/langwatch/ee/governance/services/__tests__/activityMonitorCategoryBreakdown.service.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/activityMonitorCategoryBreakdown.service.integration.test.ts
@@ -178,21 +178,28 @@ describe("ActivityMonitorService.categoryBreakdown", () => {
   });
 
   afterAll(async () => {
+    // beforeAll may have thrown before the gov projects were created — an
+    // unconditional .id deref here would mask the root-cause failure.
+    const govProjectIds = [primaryGovProject, crossGovProject]
+      .filter(Boolean)
+      .map((p) => p.id);
     await prisma.project
       .deleteMany({
-        where: { id: { in: [primaryGovProject.id, crossGovProject.id] } },
+        where: { id: { in: govProjectIds } },
       })
       .catch(() => undefined);
+    const orgIds = [primaryOrg, crossOrg].filter(Boolean).map((o) => o.id);
     await prisma.team
       .deleteMany({
-        where: { organizationId: { in: [primaryOrg.id, crossOrg.id] } },
+        where: { organizationId: { in: orgIds } },
       })
       .catch(() => undefined);
     await prisma.organization
-      .deleteMany({ where: { id: { in: [primaryOrg.id, crossOrg.id] } } })
+      .deleteMany({ where: { id: { in: orgIds } } })
       .catch(() => undefined);
-    await cleanupTestData(primaryGovProject.id);
-    await cleanupTestData(crossGovProject.id);
+    for (const tenantId of govProjectIds) {
+      await cleanupTestData(tenantId);
+    }
   });
 
   describe("given an organization with classified coding-agent traffic from several users", () => {

--- a/langwatch/ee/governance/services/__tests__/governanceProject.service.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/governanceProject.service.integration.test.ts
@@ -51,6 +51,7 @@ import { PrismaOrganizationRepository } from "~/server/app-layer/organizations/r
 import {
   PROJECT_KIND,
   ensureHiddenGovernanceProject,
+  resolvePersonalUsageIngestionScope,
 } from "../governanceProject.service";
 
 describe("ensureHiddenGovernanceProject — lazy-ensure invariants for the hidden Governance Project", () => {
@@ -278,6 +279,106 @@ describe("ensureHiddenGovernanceProject — lazy-ensure invariants for the hidde
     it("slug is org-scoped + stable (governance-${organizationId})", async () => {
       const project = await ensureHiddenGovernanceProject(prisma, primaryOrg.id);
       expect(project.slug).toBe(`governance-${primaryOrg.id}`);
+    });
+  });
+
+  // resolvePersonalUsageIngestionScope decides which tenant + principal email
+  // the /me cross-tenant category union runs under — the multi-tenancy seam
+  // both /api/me/usage and the tRPC personalUsage procedure depend on.
+  describe("resolvePersonalUsageIngestionScope", () => {
+    describe("given the org has a Governance Project", () => {
+      it("returns that org's gov tenant id and the owner's email", async () => {
+        const governanceProject = await ensureHiddenGovernanceProject(
+          prisma,
+          primaryOrg.id,
+        );
+        createdProjectIds.add(governanceProject.id);
+        const primaryTeam = await prisma.team.findFirst({
+          where: { organizationId: primaryOrg.id },
+        });
+
+        const scope = await resolvePersonalUsageIngestionScope({
+          prisma,
+          teamId: primaryTeam!.id,
+          ownerUserId: primaryUser.id,
+        });
+
+        expect(scope.ingestionTenantId).toBe(governanceProject.id);
+        expect(scope.userEmail).toBe(
+          `gov-helper-test-${testNamespace}@example.com`,
+        );
+      });
+    });
+
+    describe("given the org has no Governance Project", () => {
+      it("returns an absent tenant and never provisions one on read", async () => {
+        const freshOrg = await prisma.organization.create({
+          data: {
+            name: `Scope Org ${testNamespace}`,
+            slug: `scope-org-${testNamespace}`,
+          },
+        });
+        const freshTeam = await prisma.team.create({
+          data: {
+            name: `Scope Team ${testNamespace}`,
+            slug: `scope-team-${testNamespace}`,
+            organizationId: freshOrg.id,
+          },
+        });
+        createdTeamIds.add(freshTeam.id);
+
+        try {
+          const scope = await resolvePersonalUsageIngestionScope({
+            prisma,
+            teamId: freshTeam.id,
+            ownerUserId: primaryUser.id,
+          });
+
+          expect(scope.ingestionTenantId).toBeUndefined();
+          expect(scope.userEmail).toBe(
+            `gov-helper-test-${testNamespace}@example.com`,
+          );
+
+          const provisioned = await prisma.project.count({
+            where: {
+              kind: PROJECT_KIND.INTERNAL_GOVERNANCE,
+              team: { organizationId: freshOrg.id },
+            },
+          });
+          expect(provisioned).toBe(0);
+        } finally {
+          await prisma.team
+            .deleteMany({ where: { organizationId: freshOrg.id } })
+            .catch(() => undefined);
+          await prisma.organization
+            .delete({ where: { id: freshOrg.id } })
+            .catch(() => undefined);
+        }
+      });
+    });
+
+    describe("given an unknown team or owner", () => {
+      it("degrades each field to undefined instead of throwing", async () => {
+        const unknownTeam = await resolvePersonalUsageIngestionScope({
+          prisma,
+          teamId: `missing-team-${testNamespace}`,
+          ownerUserId: primaryUser.id,
+        });
+        expect(unknownTeam.ingestionTenantId).toBeUndefined();
+        expect(unknownTeam.userEmail).toBe(
+          `gov-helper-test-${testNamespace}@example.com`,
+        );
+
+        const primaryTeam = await prisma.team.findFirst({
+          where: { organizationId: primaryOrg.id },
+        });
+        const unknownOwner = await resolvePersonalUsageIngestionScope({
+          prisma,
+          teamId: primaryTeam!.id,
+          ownerUserId: `missing-user-${testNamespace}`,
+        });
+        expect(unknownOwner.userEmail).toBeUndefined();
+      });
     });
   });
 });

--- a/langwatch/ee/governance/services/personalUsage.service.ts
+++ b/langwatch/ee/governance/services/personalUsage.service.ts
@@ -46,6 +46,15 @@ import {
 
 const logger = createLogger("langwatch:personal-usage");
 
+/**
+ * Hard cap on the rollup window span. `dailyBuckets` materializes one bucket
+ * object per day of the window synchronously on the app server, so an
+ * unbounded caller-supplied window is an event-loop hang, not just a slow
+ * query. Both entrypoints (tRPC personalUsage, GET /api/me/usage) must reject
+ * wider windows before calling into this service.
+ */
+export const MAX_WINDOW_SPAN_MS = 400 * 24 * 60 * 60 * 1000;
+
 export interface PersonalUsageWindow {
   /** Inclusive UTC start of the rollup window. */
   start: Date;

--- a/langwatch/src/app/api/me/[[...route]]/__tests__/schemas.unit.test.ts
+++ b/langwatch/src/app/api/me/[[...route]]/__tests__/schemas.unit.test.ts
@@ -1,0 +1,46 @@
+import { MAX_WINDOW_SPAN_MS } from "@ee/governance/services/personalUsage.service";
+import { describe, expect, it } from "vitest";
+
+import { meUsageQuerySchema } from "../schemas";
+
+describe("meUsageQuerySchema", () => {
+  describe("given both window bounds within the span cap", () => {
+    it("accepts the window", () => {
+      const result = meUsageQuerySchema.safeParse({
+        windowStartMs: 0,
+        windowEndMs: MAX_WINDOW_SPAN_MS,
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("given a window wider than the span cap", () => {
+    // dailyBuckets allocates one bucket per day of the window on the app
+    // server, so an unbounded span is an event-loop hang — the schema must
+    // reject it before it reaches the service.
+    it("rejects the window", () => {
+      const result = meUsageQuerySchema.safeParse({
+        windowStartMs: 0,
+        windowEndMs: MAX_WINDOW_SPAN_MS + 1,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("given only one bound", () => {
+    it("rejects the half-specified window", () => {
+      expect(meUsageQuerySchema.safeParse({ windowStartMs: 0 }).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("given an inverted window", () => {
+    it("rejects it", () => {
+      expect(
+        meUsageQuerySchema.safeParse({ windowStartMs: 10, windowEndMs: 5 })
+          .success,
+      ).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/app/api/me/[[...route]]/app.ts
+++ b/langwatch/src/app/api/me/[[...route]]/app.ts
@@ -10,12 +10,15 @@ import {
 } from "~/server/api/security";
 import { prisma } from "~/server/db";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
+import { createLogger } from "~/utils/logger/server";
 
 import type { AuthMiddlewareVariables } from "../../middleware/auth";
 import { baseResponses } from "../../shared/base-responses";
 import { meUsageQuerySchema, meUsageResponseSchema } from "./schemas";
 
 patchZodOpenapi();
+
+const logger = createLogger("langwatch:api:me");
 
 /**
  * Hono app for /api/me — the personal-developer surface. Today it
@@ -120,12 +123,24 @@ export function registerMeRoutes(
           // Category totals live on trace summaries: personal-tenant rows plus
           // this user's ingestion-source rows on the gov tenant (attributed by
           // principal email), when both are available.
-          usage.breakdownByCategory({
-            personalProjectId: input.personalProjectId,
-            window: input.window,
-            userEmail: input.userEmail,
-            ingestionTenantId: input.ingestionTenantId,
-          }),
+          //
+          // Degrade to [] on failure so one category-query error (its ClickHouse
+          // scan is heavier than the others and has OOM'd before) can't 500 the
+          // whole payload — mirrors the tRPC twin in user.ts.
+          usage
+            .breakdownByCategory({
+              personalProjectId: input.personalProjectId,
+              window: input.window,
+              userEmail: input.userEmail,
+              ingestionTenantId: input.ingestionTenantId,
+            })
+            .catch((error) => {
+              logger.error(
+                { error, projectId: project.id },
+                "personal usage category breakdown failed; degrading to empty",
+              );
+              return [];
+            }),
         ]);
 
       return c.json({

--- a/langwatch/src/app/api/me/[[...route]]/schemas.ts
+++ b/langwatch/src/app/api/me/[[...route]]/schemas.ts
@@ -1,3 +1,4 @@
+import { MAX_WINDOW_SPAN_MS } from "@ee/governance/services/personalUsage.service";
 import { z } from "zod";
 import {
   CATEGORIES,
@@ -39,6 +40,15 @@ export const meUsageQuerySchema = z
       q.windowEndMs === undefined ||
       q.windowStartMs < q.windowEndMs,
     { message: "windowStartMs must be before windowEndMs." },
+  )
+  // dailyBuckets allocates one bucket object per day in the window on the
+  // app server, so an unbounded span is a self-inflicted event-loop hang.
+  .refine(
+    (q) =>
+      q.windowStartMs === undefined ||
+      q.windowEndMs === undefined ||
+      q.windowEndMs - q.windowStartMs <= MAX_WINDOW_SPAN_MS,
+    { message: "window span must not exceed 400 days." },
   );
 
 const mostUsedModelSchema = z

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
@@ -9,6 +9,7 @@ import {
 } from "@chakra-ui/react";
 import { useMemo, useRef } from "react";
 import { LuCircleX } from "react-icons/lu";
+import { CategoryBreakdownBars } from "~/components/governance/CategoryBreakdownBars";
 import {
   ContentPrivacyMarkers,
   PiiIncompleteNotice,
@@ -17,6 +18,7 @@ import { RedactedField } from "~/components/ui/RedactedField";
 import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
 import { useSpanDetail } from "../../../hooks/useSpanDetail";
 import { useTraceResources } from "../../../hooks/useTraceResources";
+import { spanContentBreakdownRows } from "../../../utils/contentBreakdown";
 import { AttributeTable } from "../AttributeTable";
 import { IOViewer } from "../IOViewer";
 import { hasPromptMetadata, PromptAccordion } from "../PromptAccordion";
@@ -71,11 +73,22 @@ export function SpanAccordions({
   const hasError = span.status === "error" || !!detail?.error;
   const hasEvents = !!detail?.events && detail.events.length > 0;
 
+  // This span's own content-category split (ADR-033), read from the reserved
+  // blockcat totals the classifier stamped on it. Present only for a classified
+  // coding-agent span (e.g. a codex turn) — the place a codex skill shows up,
+  // since it never becomes a waterfall tool span.
+  const contentRows = useMemo(
+    () => spanContentBreakdownRows(detail?.params),
+    [detail?.params],
+  );
+  const hasContentBreakdown = contentRows.length > 0;
+
   const sections = useMemo(() => {
     const list: string[] = [];
     if (hasError && !hasIO) list.push("exceptions");
     list.push("io");
     if (hasError && hasIO) list.push("exceptions");
+    if (hasContentBreakdown) list.push("content");
     if (hasPrompt) list.push("prompt");
     list.push("attributes");
     // Instrumentation scope used to be a chip pinned to the right of
@@ -87,7 +100,7 @@ export function SpanAccordions({
     if (hasScope) list.push("scope");
     list.push("events");
     return list;
-  }, [hasError, hasIO, hasPrompt, hasScope]);
+  }, [hasError, hasIO, hasContentBreakdown, hasPrompt, hasScope]);
 
   // Same rule as the trace summary view: only auto-expand Attributes when
   // the span itself has attributes (resource-only is rarely interesting
@@ -96,6 +109,7 @@ export function SpanAccordions({
   const [openSections, setOpenSections] = useAutoOpenSections(span.spanId, {
     exceptions: hasError,
     io: hasIO || hasPrivacyMarkers,
+    content: hasContentBreakdown,
     prompt: hasPrompt,
     attributes: hasSpanAttrs || !!detail?.costSuggestion,
     scope: hasScope,
@@ -215,6 +229,26 @@ export function SpanAccordions({
                       </RedactedField>
                     </VStack>
                   )}
+                </Section>
+              );
+            }
+            if (id === "content") {
+              return (
+                <Section
+                  key="content"
+                  value="content"
+                  title="Content breakdown"
+                  count={contentRows.length}
+                  isFirst={isFirst}
+                  open={isOpen}
+                >
+                  <VStack align="stretch" gap={3}>
+                    <Text textStyle="xs" color="fg.muted">
+                      Where this span’s tokens and cost went, by content type
+                      (system prompt, tools, skills, thinking, and more).
+                    </Text>
+                    <CategoryBreakdownBars rows={contentRows} />
+                  </VStack>
                 </Section>
               );
             }

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
@@ -1,6 +1,7 @@
 import { Box, HStack, Text, VStack } from "@chakra-ui/react";
 import { useMemo, useRef } from "react";
 import { LuCalendarClock, LuFileText, LuFlaskConical } from "react-icons/lu";
+import { CategoryBreakdownBars } from "~/components/governance/CategoryBreakdownBars";
 import { PrivacyDroppedNotice } from "~/components/ui/PrivacyDroppedNotice";
 import { RedactedField } from "~/components/ui/RedactedField";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -12,6 +13,7 @@ import { useTraceEvaluations } from "../../../hooks/useTraceEvaluations";
 import { useTraceEvents } from "../../../hooks/useTraceEvents";
 import { useTraceResources } from "../../../hooks/useTraceResources";
 import { useFocusSectionStore } from "../../../stores/focusSectionStore";
+import { traceContentBreakdownRows } from "../../../utils/contentBreakdown";
 import { rankedErrorSpans } from "../../../utils/errorSpans";
 import { AttributeTable } from "../AttributeTable";
 import { ExceptionsContent } from "../ExceptionsContent";
@@ -55,6 +57,16 @@ export function TraceSummaryAccordions({
   const hasTraceAttributes = Object.keys(traceAttributes).length > 0;
   const hasAttributes = hasTraceAttributes || hasResourceAttributes;
   const hasScope = !!resources.scope?.name;
+
+  // Per-content-category cost/token split (ADR-033), derived from the reserved
+  // blockcat totals the fold rolled onto this trace's summary attributes. Only
+  // coding-agent traffic captured with content produces these, so the section
+  // is absent for everything else.
+  const contentRows = useMemo(
+    () => traceContentBreakdownRows(trace.attributes),
+    [trace.attributes],
+  );
+  const hasContentBreakdown = contentRows.length > 0;
 
   const {
     rich: richEvals,
@@ -118,6 +130,7 @@ export function TraceSummaryAccordions({
   const sections = useMemo(() => {
     const list: Array<
       | "io"
+      | "content"
       | "prompts"
       | "attributes"
       | "scope"
@@ -129,6 +142,11 @@ export function TraceSummaryAccordions({
     if (hasError && !hasIO) list.push("exceptions");
     list.push("io");
     if (hasError && hasIO) list.push("exceptions");
+    // Content-category breakdown sits right under I/O — it explains where this
+    // trace's tokens/cost went by content type, so it reads best next to the
+    // input/output it is decomposing. Only present for classified coding-agent
+    // traffic.
+    if (hasContentBreakdown) list.push("content");
     // Prompts the trace used — the span-level Prompt accordion only shows
     // when a span is selected, so the trace summary surfaced no prompt
     // info even when spans carried managed prompts. `containsPrompt` is
@@ -147,6 +165,7 @@ export function TraceSummaryAccordions({
     return list;
   }, [
     hasIO,
+    hasContentBreakdown,
     hasError,
     trace.containsPrompt,
     hasEvalsContent,
@@ -161,6 +180,7 @@ export function TraceSummaryAccordions({
   const [openSections, setOpenSections] = useAutoOpenSections(trace.traceId, {
     exceptions: hasError,
     io: hasIO || hasRedactedIO,
+    content: hasContentBreakdown,
     prompts: trace.containsPrompt,
     attributes: hasTraceAttributes,
     scope: hasScope,
@@ -253,6 +273,26 @@ export function TraceSummaryAccordions({
                       <MissingIORow label="Output" mode="output" />
                     )}
                   </RedactedField>
+                </VStack>
+              </Section>
+            );
+          }
+          if (id === "content") {
+            return (
+              <Section
+                key="content"
+                value="content"
+                title="Content breakdown"
+                count={contentRows.length}
+                isFirst={isFirst}
+                open={isOpen}
+              >
+                <VStack align="stretch" gap={3}>
+                  <Text textStyle="xs" color="fg.muted">
+                    Where this trace’s tokens and cost went, by content type
+                    (system prompt, tools, skills, thinking, and more).
+                  </Text>
+                  <CategoryBreakdownBars rows={contentRows} />
                 </VStack>
               </Section>
             );

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/__tests__/TraceSummaryContentBreakdown.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/__tests__/TraceSummaryContentBreakdown.integration.test.tsx
@@ -59,9 +59,15 @@ vi.mock("../useSectionFocusGlow", () => ({
 }));
 
 // Force the Content-breakdown section open so its (lazy-mounted) children render.
+// `useSectionPresenceStore` MUST be stubbed too: every AccordionShell `Section`
+// reads it unconditionally (traceId/tab → trackPresence), so a partial mock that
+// omits it makes the export `undefined` and crashes the render.
 vi.mock("../sectionPresence", () => ({
   useAutoOpenSections: () => [["io", "content"], () => undefined],
   useSyncSectionPresence: () => undefined,
+  useSectionPresenceStore: (
+    selector: (s: { traceId: string | null; tab: string | null }) => unknown,
+  ) => selector({ traceId: null, tab: null }),
 }));
 
 function traceWith(attributes: Record<string, string>): TraceHeader {

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/__tests__/TraceSummaryContentBreakdown.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/__tests__/TraceSummaryContentBreakdown.integration.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Content-breakdown section in the trace summary (ADR-033). A coding-agent
+ * trace whose fold rolled up per-category blockcat totals onto its summary
+ * attributes shows a "Content breakdown" accordion with a lane per content
+ * category — including `skill_content`, the lane a codex skill has no waterfall
+ * span for. A trace with no classified content shows no such section.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TraceHeader } from "~/server/api/routers/tracesV2.schemas";
+import {
+  blockCategoryCostAttr,
+  blockCategoryTokensAttr,
+  InputCategory,
+  OutputCategory,
+} from "~/server/app-layer/traces/block-classification/categories";
+import { TraceSummaryAccordions } from "../TraceSummaryAccordions";
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", slug: "test-project" },
+  }),
+}));
+
+vi.mock("~/hooks/useFieldRedaction", () => ({
+  useFieldRedaction: () => ({
+    isRedacted: false,
+    isLoading: false,
+    visibleTo: null,
+  }),
+}));
+
+vi.mock("../../../../hooks/useTraceEvents", () => ({
+  useTraceEvents: () => ({ events: [], isLoading: false }),
+}));
+
+vi.mock("../../../../hooks/useTraceResources", () => ({
+  useTraceResources: () => ({
+    resourceAttributes: {},
+    isLoading: false,
+    scope: undefined,
+  }),
+}));
+
+vi.mock("../../../../hooks/useTraceEvaluations", () => ({
+  useTraceEvaluations: () => ({ rich: [], pendingCount: 0, isLoading: false }),
+}));
+
+vi.mock("../../../../stores/focusSectionStore", () => ({
+  useFocusSectionStore: (selector: (s: { request: () => void }) => unknown) =>
+    selector({ request: () => undefined }),
+}));
+
+vi.mock("../useSectionFocusGlow", () => ({
+  useSectionFocusGlow: () => ({ glow: null, handleGlowDone: () => undefined }),
+}));
+
+// Force the Content-breakdown section open so its (lazy-mounted) children render.
+vi.mock("../sectionPresence", () => ({
+  useAutoOpenSections: () => [["io", "content"], () => undefined],
+  useSyncSectionPresence: () => undefined,
+}));
+
+function traceWith(attributes: Record<string, string>): TraceHeader {
+  return {
+    traceId: "trace-1",
+    timestamp: 1_700_000_000_000,
+    name: "trace-1",
+    attributes,
+    status: "success",
+    containsPrompt: false,
+    spanCount: 1,
+    models: [],
+  } as unknown as TraceHeader;
+}
+
+const renderAccordions = (trace: TraceHeader) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <TraceSummaryAccordions trace={trace} spans={[]} />
+    </ChakraProvider>,
+  );
+
+afterEach(cleanup);
+
+describe("TraceSummaryAccordions content breakdown", () => {
+  describe("given a trace with classified coding-agent content", () => {
+    it("renders the Content breakdown section with the skill_content lane", () => {
+      renderAccordions(
+        traceWith({
+          [blockCategoryTokensAttr(InputCategory.SYSTEM_PROMPT)]: "3997",
+          [blockCategoryCostAttr(InputCategory.SYSTEM_PROMPT)]: "0.02",
+          [blockCategoryTokensAttr(InputCategory.SKILL_CONTENT)]: "279",
+          [blockCategoryCostAttr(InputCategory.SKILL_CONTENT)]: "0.0013953165",
+          [blockCategoryTokensAttr(OutputCategory.ASSISTANT_TEXT)]: "36",
+          [blockCategoryCostAttr(OutputCategory.ASSISTANT_TEXT)]: "0.001",
+        }),
+      );
+
+      expect(screen.getByText("Content breakdown")).toBeInTheDocument();
+      // The skill lane the codex waterfall could never show.
+      expect(screen.getByText("Skill content")).toBeInTheDocument();
+      expect(screen.getByText("System prompt")).toBeInTheDocument();
+    });
+  });
+
+  describe("given a trace with no classified content", () => {
+    it("does not render the Content breakdown section", () => {
+      renderAccordions(traceWith({ "gen_ai.usage.input_tokens": "1000" }));
+
+      expect(screen.queryByText("Content breakdown")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/utils/__tests__/contentBreakdown.unit.test.ts
+++ b/langwatch/src/features/traces-v2/utils/__tests__/contentBreakdown.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  blockCategoryCostAttr,
+  blockCategoryTokensAttr,
+  InputCategory,
+  OutputCategory,
+} from "~/server/app-layer/traces/block-classification/categories";
+import { traceContentBreakdownRows } from "../contentBreakdown";
+
+describe("traceContentBreakdownRows", () => {
+  describe("given trace attributes carrying reserved blockcat totals", () => {
+    it("derives one row per non-zero category, sorted by cost, with shares", () => {
+      const attributes: Record<string, string> = {
+        [blockCategoryTokensAttr(InputCategory.SYSTEM_PROMPT)]: "3997",
+        [blockCategoryCostAttr(InputCategory.SYSTEM_PROMPT)]: "0.02",
+        [blockCategoryTokensAttr(InputCategory.SKILL_CONTENT)]: "279",
+        [blockCategoryCostAttr(InputCategory.SKILL_CONTENT)]: "0.0013953165",
+        [blockCategoryTokensAttr(OutputCategory.ASSISTANT_TEXT)]: "36",
+        [blockCategoryCostAttr(OutputCategory.ASSISTANT_TEXT)]: "0.001",
+      };
+
+      const rows = traceContentBreakdownRows(attributes);
+
+      // Sorted by cost desc: system ($0.02) > skill ($0.00139) > assistant
+      // ($0.001). Skill content is present — the exact lane the codex trace was
+      // missing from the waterfall.
+      expect(rows.map((r) => r.category)).toEqual([
+        InputCategory.SYSTEM_PROMPT,
+        InputCategory.SKILL_CONTENT,
+        OutputCategory.ASSISTANT_TEXT,
+      ]);
+      const skill = rows.find(
+        (r) => r.category === InputCategory.SKILL_CONTENT,
+      );
+      expect(skill?.tokens).toBe(279);
+      expect(skill?.label).toBe("Skill content");
+      // Shares sum to ~100 across the priced lanes.
+      const shareSum = rows.reduce((s, r) => s + r.sharePct, 0);
+      expect(shareSum).toBeCloseTo(100, 5);
+    });
+
+    it("keeps a tokens-only lane from an unpriced model (cost 0, tokens > 0)", () => {
+      const attributes: Record<string, string> = {
+        [blockCategoryTokensAttr(InputCategory.SYSTEM_PROMPT)]: "500",
+        [blockCategoryCostAttr(InputCategory.SYSTEM_PROMPT)]: "0",
+      };
+
+      const rows = traceContentBreakdownRows(attributes);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.tokens).toBe(500);
+      expect(rows[0]?.costUsd).toBe(0);
+    });
+  });
+
+  describe("given a trace with no classified content", () => {
+    it("returns an empty array (so the section is not rendered)", () => {
+      expect(traceContentBreakdownRows({})).toEqual([]);
+      expect(traceContentBreakdownRows(undefined)).toEqual([]);
+      expect(traceContentBreakdownRows(null)).toEqual([]);
+      // Non-blockcat attributes never leak into the breakdown.
+      expect(
+        traceContentBreakdownRows({ "gen_ai.usage.input_tokens": "1000" }),
+      ).toEqual([]);
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/utils/__tests__/contentBreakdown.unit.test.ts
+++ b/langwatch/src/features/traces-v2/utils/__tests__/contentBreakdown.unit.test.ts
@@ -5,7 +5,10 @@ import {
   InputCategory,
   OutputCategory,
 } from "~/server/app-layer/traces/block-classification/categories";
-import { traceContentBreakdownRows } from "../contentBreakdown";
+import {
+  spanContentBreakdownRows,
+  traceContentBreakdownRows,
+} from "../contentBreakdown";
 
 describe("traceContentBreakdownRows", () => {
   describe("given trace attributes carrying reserved blockcat totals", () => {
@@ -62,6 +65,56 @@ describe("traceContentBreakdownRows", () => {
       expect(
         traceContentBreakdownRows({ "gen_ai.usage.input_tokens": "1000" }),
       ).toEqual([]);
+    });
+  });
+});
+
+describe("spanContentBreakdownRows", () => {
+  describe("given a span's unflattened params carrying nested blockcat", () => {
+    it("reads the nested langwatch.reserved.blockcat totals into rows", () => {
+      // The span mapper unflattens dotted attribute keys, so blockcat lands at
+      // params.langwatch.reserved.blockcat.<category>.{tokens,cost_usd}.
+      const params = {
+        langwatch: {
+          reserved: {
+            blockcat: {
+              [InputCategory.SYSTEM_PROMPT]: {
+                tokens: "3997",
+                cost_usd: "0.02",
+              },
+              [InputCategory.SKILL_CONTENT]: {
+                tokens: "279",
+                cost_usd: "0.0013953165",
+              },
+            },
+          },
+        },
+        // A sibling attribute that must not be mistaken for a category.
+        "gen_ai.usage.input_tokens": "4408",
+      };
+
+      const rows = spanContentBreakdownRows(params);
+
+      expect(rows.map((r) => r.category)).toEqual([
+        InputCategory.SYSTEM_PROMPT,
+        InputCategory.SKILL_CONTENT,
+      ]);
+      const skill = rows.find(
+        (r) => r.category === InputCategory.SKILL_CONTENT,
+      );
+      expect(skill?.tokens).toBe(279);
+      expect(skill?.label).toBe("Skill content");
+    });
+  });
+
+  describe("given a span with no classified content", () => {
+    it("returns an empty array", () => {
+      expect(spanContentBreakdownRows(undefined)).toEqual([]);
+      expect(spanContentBreakdownRows(null)).toEqual([]);
+      expect(spanContentBreakdownRows({})).toEqual([]);
+      expect(spanContentBreakdownRows({ langwatch: { reserved: {} } })).toEqual(
+        [],
+      );
     });
   });
 });

--- a/langwatch/src/features/traces-v2/utils/contentBreakdown.ts
+++ b/langwatch/src/features/traces-v2/utils/contentBreakdown.ts
@@ -1,0 +1,40 @@
+/**
+ * Per-trace content-block cost breakdown (ADR-033).
+ *
+ * The ingest classifier stamps each coding-agent span with per-category token +
+ * cost totals, and the trace fold rolls them up onto the trace summary under
+ * `langwatch.reserved.blockcat.<category>.{tokens,cost_usd}`. Those aggregated
+ * totals ride on the trace header's `attributes` map, so a per-trace breakdown
+ * needs no extra query — it reads the same numbers the fold already summed and
+ * the Metadata section already surfaces raw.
+ *
+ * Pure: attributes-in / rows-out. Zero-only categories are dropped, so a trace
+ * with no classified coding-agent content yields `[]` (the caller renders the
+ * section only when there is something to show).
+ */
+
+import {
+  type CategoryBreakdownBarRow,
+  toCategoryBarRows,
+} from "~/components/governance/CategoryBreakdownBars";
+import {
+  blockCategoryCostAttr,
+  blockCategoryTokensAttr,
+  CATEGORIES,
+} from "~/server/app-layer/traces/block-classification/categories";
+
+export function traceContentBreakdownRows(
+  attributes: Record<string, string> | null | undefined,
+): CategoryBreakdownBarRow[] {
+  if (!attributes) return [];
+  const rows = CATEGORIES.map((category) => ({
+    category,
+    costUsd: Number(attributes[blockCategoryCostAttr(category)] ?? "0") || 0,
+    tokens: Number(attributes[blockCategoryTokensAttr(category)] ?? "0") || 0,
+  }))
+    // Drop categories the trace never touched; keep a lane that has tokens but
+    // no cost (an unpriced/custom model), matching the /me + governance views.
+    .filter((r) => r.costUsd > 0 || r.tokens > 0)
+    .sort((a, b) => b.costUsd - a.costUsd || b.tokens - a.tokens);
+  return toCategoryBarRows(rows);
+}

--- a/langwatch/src/features/traces-v2/utils/contentBreakdown.ts
+++ b/langwatch/src/features/traces-v2/utils/contentBreakdown.ts
@@ -1,16 +1,19 @@
 /**
- * Per-trace content-block cost breakdown (ADR-033).
+ * Content-block cost breakdown (ADR-033), per trace or per span.
  *
  * The ingest classifier stamps each coding-agent span with per-category token +
- * cost totals, and the trace fold rolls them up onto the trace summary under
- * `langwatch.reserved.blockcat.<category>.{tokens,cost_usd}`. Those aggregated
- * totals ride on the trace header's `attributes` map, so a per-trace breakdown
- * needs no extra query — it reads the same numbers the fold already summed and
- * the Metadata section already surfaces raw.
+ * cost totals under `langwatch.reserved.blockcat.<category>.{tokens,cost_usd}`,
+ * and the trace fold rolls them up onto the trace summary. So the same numbers
+ * are readable in two shapes with no extra query:
+ *   - the TRACE header's `attributes` — a FLAT `Record<string,string>` (fold
+ *     aggregate across the trace's spans);
+ *   - a SPAN detail's `params` — the UNFLATTENED nested object the span mapper
+ *     builds (`safeUnflatten`), so blockcat lives at
+ *     `params.langwatch.reserved.blockcat.<category>.{tokens,cost_usd}`.
  *
- * Pure: attributes-in / rows-out. Zero-only categories are dropped, so a trace
- * with no classified coding-agent content yields `[]` (the caller renders the
- * section only when there is something to show).
+ * Pure: data-in / rows-out. Zero-only categories are dropped, so content that
+ * was never classified yields `[]` (the caller renders the section only when
+ * there is something to show).
  */
 
 import {
@@ -21,20 +24,58 @@ import {
   blockCategoryCostAttr,
   blockCategoryTokensAttr,
   CATEGORIES,
+  type Category,
 } from "~/server/app-layer/traces/block-classification/categories";
 
-export function traceContentBreakdownRows(
-  attributes: Record<string, string> | null | undefined,
+/** Build sorted bar rows from a per-category `{ tokens, costUsd }` accessor. */
+function buildRows(
+  get: (category: Category) => { costUsd: number; tokens: number },
 ): CategoryBreakdownBarRow[] {
-  if (!attributes) return [];
-  const rows = CATEGORIES.map((category) => ({
-    category,
-    costUsd: Number(attributes[blockCategoryCostAttr(category)] ?? "0") || 0,
-    tokens: Number(attributes[blockCategoryTokensAttr(category)] ?? "0") || 0,
-  }))
-    // Drop categories the trace never touched; keep a lane that has tokens but
+  const rows = CATEGORIES.map((category) => ({ category, ...get(category) }))
+    // Drop categories the content never touched; keep a lane that has tokens but
     // no cost (an unpriced/custom model), matching the /me + governance views.
     .filter((r) => r.costUsd > 0 || r.tokens > 0)
     .sort((a, b) => b.costUsd - a.costUsd || b.tokens - a.tokens);
   return toCategoryBarRows(rows);
+}
+
+/** Rows from a trace header's FLAT attributes map (fold aggregate). */
+export function traceContentBreakdownRows(
+  attributes: Record<string, string> | null | undefined,
+): CategoryBreakdownBarRow[] {
+  if (!attributes) return [];
+  return buildRows((category) => ({
+    costUsd: Number(attributes[blockCategoryCostAttr(category)] ?? "0") || 0,
+    tokens: Number(attributes[blockCategoryTokensAttr(category)] ?? "0") || 0,
+  }));
+}
+
+/** Rows from a span detail's UNFLATTENED `params` (single-span totals). */
+export function spanContentBreakdownRows(
+  params: unknown,
+): CategoryBreakdownBarRow[] {
+  const blockcat = readNested(params, ["langwatch", "reserved", "blockcat"]);
+  if (!blockcat || typeof blockcat !== "object") return [];
+  const byCategory = blockcat as Record<string, unknown>;
+  return buildRows((category) => {
+    const entry = byCategory[category];
+    const rec =
+      entry && typeof entry === "object"
+        ? (entry as Record<string, unknown>)
+        : null;
+    return {
+      costUsd: rec ? Number(rec.cost_usd ?? "0") || 0 : 0,
+      tokens: rec ? Number(rec.tokens ?? "0") || 0 : 0,
+    };
+  });
+}
+
+/** Walk a dotted path through a (possibly null-prototype) nested object. */
+function readNested(obj: unknown, path: string[]): unknown {
+  let cur = obj;
+  for (const key of path) {
+    if (!cur || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur;
 }

--- a/langwatch/src/server/api/routers/llmModelCosts.ts
+++ b/langwatch/src/server/api/routers/llmModelCosts.ts
@@ -242,10 +242,10 @@ export const llmModelCostsRouter = createTRPCRouter({
             message:
               "Invalid or unsafe regular expression (avoid nested quantifiers like (a+)+)",
           }),
-        inputCostPerToken: z.number().nonnegative().optional(),
-        outputCostPerToken: z.number().nonnegative().optional(),
-        cacheReadCostPerToken: z.number().nonnegative().optional(),
-        cacheCreationCostPerToken: z.number().nonnegative().optional(),
+        inputCostPerToken: z.number().finite().nonnegative().optional(),
+        outputCostPerToken: z.number().finite().nonnegative().optional(),
+        cacheReadCostPerToken: z.number().finite().nonnegative().optional(),
+        cacheCreationCostPerToken: z.number().finite().nonnegative().optional(),
       }),
     )
     .use(checkProjectPermission("traces:view"))

--- a/langwatch/src/server/api/routers/user.ts
+++ b/langwatch/src/server/api/routers/user.ts
@@ -569,8 +569,10 @@ export const userRouter = createTRPCRouter({
         };
       }
 
+      // `!== undefined`, not truthiness: 0 is a valid epoch start bound (the
+      // /me Hono route treats it the same way).
       const window =
-        input.windowStartMs && input.windowEndMs
+        input.windowStartMs !== undefined && input.windowEndMs !== undefined
           ? {
               start: new Date(input.windowStartMs),
               end: new Date(input.windowEndMs),

--- a/langwatch/src/server/api/routers/user.ts
+++ b/langwatch/src/server/api/routers/user.ts
@@ -1,6 +1,9 @@
 import { CliBootstrapService } from "@ee/governance/services/cliBootstrap.service";
 import { findHiddenGovernanceProject } from "@ee/governance/services/governanceProject.service";
-import { PersonalUsageService } from "@ee/governance/services/personalUsage.service";
+import {
+  MAX_WINDOW_SPAN_MS,
+  PersonalUsageService,
+} from "@ee/governance/services/personalUsage.service";
 import { PersonalVirtualKeyService } from "@ee/governance/services/personalVirtualKey.service";
 import { PersonalWorkspaceService } from "@ee/governance/services/personalWorkspace.service";
 import { RoutingPolicyService } from "@ee/governance/services/routingPolicy.service";
@@ -508,12 +511,23 @@ export const userRouter = createTRPCRouter({
    */
   personalUsage: protectedProcedure
     .input(
-      z.object({
-        organizationId: z.string(),
-        /** Defaults to start-of-current-month → now if omitted. */
-        windowStartMs: z.number().optional(),
-        windowEndMs: z.number().optional(),
-      }),
+      z
+        .object({
+          organizationId: z.string(),
+          /** Defaults to start-of-current-month → now if omitted. */
+          windowStartMs: z.number().optional(),
+          windowEndMs: z.number().optional(),
+        })
+        // dailyBuckets allocates one bucket object per day of the window on
+        // the app server, so an unbounded span is an event-loop hang.
+        .refine(
+          (q) =>
+            q.windowStartMs === undefined ||
+            q.windowEndMs === undefined ||
+            (q.windowEndMs > q.windowStartMs &&
+              q.windowEndMs - q.windowStartMs <= MAX_WINDOW_SPAN_MS),
+          { message: "window span must be positive and at most 400 days." },
+        ),
     )
     .use(checkOrganizationPermission("organization:view"))
     .query(async ({ ctx, input }) => {

--- a/langwatch/src/server/app-layer/traces/__tests__/claude-code-log-to-span.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/claude-code-log-to-span.unit.test.ts
@@ -153,14 +153,18 @@ describe("convertClaudeCodeLogsToSpans", () => {
       expect(strVal(span, "langwatch.span.type")).toBe("llm");
       expect(strVal(span, "gen_ai.request.model")).toBe("claude-opus-4-7");
       // Tokens + cache + cost (cache_read ~0.1x vs cache_creation ~1.25x stay distinct).
-      expect(attr(span, "gen_ai.usage.input_tokens")).toEqual({ intValue: 120 });
+      expect(attr(span, "gen_ai.usage.input_tokens")).toEqual({
+        intValue: 120,
+      });
       expect(attr(span, "gen_ai.usage.cache_read.input_tokens")).toEqual({
         intValue: 63429,
       });
       expect(attr(span, "gen_ai.usage.cache_creation.input_tokens")).toEqual({
         intValue: 1024,
       });
-      expect(attr(span, "langwatch.span.cost")).toEqual({ doubleValue: 0.0875 });
+      expect(attr(span, "langwatch.span.cost")).toEqual({
+        doubleValue: 0.0875,
+      });
       // Input from the earlier-batch body, output from the response.
       expect(strVal(span, "gen_ai.input.messages")).toBe(
         JSON.stringify([{ role: "user", content: "Reply with PONG-Z" }]),
@@ -217,7 +221,9 @@ describe("convertClaudeCodeLogsToSpans", () => {
       // The verbatim bodies are surfaced for full-fidelity debugging (the system
       // prompt, tool/skill schemas, and message history behind the cache tokens).
       expect(strVal(span, "langwatch.claude_code.request_body")).toBe(reqBody);
-      expect(strVal(span, "langwatch.claude_code.response_body")).toBe(respBody);
+      expect(strVal(span, "langwatch.claude_code.response_body")).toBe(
+        respBody,
+      );
       // The light readable view is unchanged.
       expect(strVal(span, "gen_ai.input.messages")).toBe(
         JSON.stringify([{ role: "user", content: "Reply with PONG-Z" }]),
@@ -349,8 +355,12 @@ describe("convertClaudeCodeLogsToSpans", () => {
         }),
       ]);
       expect(spans).toHaveLength(2);
-      const first = spans.find((s) => s.span.spanId === "a1a1a1a1a1a1a1a1")!.span;
-      const second = spans.find((s) => s.span.spanId === "a2a2a2a2a2a2a2a2")!.span;
+      const first = spans.find(
+        (s) => s.span.spanId === "a1a1a1a1a1a1a1a1",
+      )!.span;
+      const second = spans.find(
+        (s) => s.span.spanId === "a2a2a2a2a2a2a2a2",
+      )!.span;
       expect(strVal(first, "gen_ai.input.messages")).toBe(
         JSON.stringify([{ role: "user", content: "first question" }]),
       );
@@ -456,8 +466,11 @@ describe("convertClaudeCodeLogsToSpans", () => {
       // Fold 1: anchor + response only (body still missing) — one missing part.
       const partial = convertClaudeCodeLogsToSpans([anchor, response])[0]!.span;
       // Fold 2: the body lands — the SAME span, now complete.
-      const complete = convertClaudeCodeLogsToSpans([anchor, response, body])[0]!
-        .span;
+      const complete = convertClaudeCodeLogsToSpans([
+        anchor,
+        response,
+        body,
+      ])[0]!.span;
 
       expect(partial.spanId).toBe("a0a0a0a0a0a0a0a0");
       expect(complete.spanId).toBe(partial.spanId);
@@ -491,7 +504,9 @@ describe("convertClaudeCodeLogsToSpans", () => {
       expect(spans).toHaveLength(1);
       const { span } = spans[0]!;
       expect(attr(span, "langwatch.span.cost")).toEqual({ doubleValue: 0.39 });
-      expect(attr(span, "gen_ai.usage.output_tokens")).toEqual({ intValue: 24 });
+      expect(attr(span, "gen_ai.usage.output_tokens")).toEqual({
+        intValue: 24,
+      });
       expect(strVal(span, "gen_ai.input.messages")).toBeUndefined();
       expect(strVal(span, "gen_ai.completion")).toBeUndefined();
     });
@@ -528,7 +543,9 @@ describe("convertClaudeCodeLogsToSpans", () => {
       expect(attr(span, "langwatch.span.cost")).toEqual({
         doubleValue: 0.000512,
       });
-      expect(attr(span, "gen_ai.usage.input_tokens")).toEqual({ intValue: 457 });
+      expect(attr(span, "gen_ai.usage.input_tokens")).toEqual({
+        intValue: 457,
+      });
       expect(strVal(span, "gen_ai.completion")).toBe(
         '{"title": "List temporary directory"}',
       );
@@ -617,7 +634,10 @@ describe("convertClaudeCodeLogsToSpans", () => {
       )[0]!;
       expect(strVal(span, "gen_ai.input.messages")).toBe(
         JSON.stringify([
-          { role: "user", content: "Turn 2: reply with exactly PONG-CLAUDE-B2." },
+          {
+            role: "user",
+            content: "Turn 2: reply with exactly PONG-CLAUDE-B2.",
+          },
         ]),
       );
     });
@@ -630,7 +650,99 @@ describe("convertClaudeCodeLogsToSpans", () => {
       // ...but the verbatim request body still carries what we DO have: the
       // first ~60KB holds the system prompt + tool schemas that drive the cache
       // tokens, confined to its own raw debugging attribute.
-      expect(strVal(span, "langwatch.claude_code.request_body")).toBe(truncated);
+      expect(strVal(span, "langwatch.claude_code.request_body")).toBe(
+        truncated,
+      );
+    });
+  });
+
+  describe("a truncated api_request_body whose leading turns survived but the newest was cut", () => {
+    // system + first turn + a reply survive; the trailing (current) user turn is
+    // cut mid-write, so recovery yields the prefix without the current prompt.
+    const truncated =
+      '{"system":[{"type":"text","text":"sys"}],"messages":[{"role":"user","content":"earlier turn"},{"role":"assistant","content":"ok"},{"role":"user","content":"the current pro';
+
+    const build = (promptTextById: Map<string, string>) =>
+      convertClaudeCodeLogsToSpans(
+        [
+          rec({
+            eventName: "api_request",
+            spanId: "cccccccccccccccc",
+            attrs: {
+              "event.name": "api_request",
+              model: "claude-opus-4-8",
+              request_id: "req_c",
+              query_source: "repl_main_thread",
+              "prompt.id": "p_77",
+            },
+          }),
+          rec({
+            eventName: "api_request_body",
+            spanId: "dddddddddddddddd",
+            attrs: {
+              "event.name": "api_request_body",
+              model: "claude-opus-4-8",
+              query_source: "repl_main_thread",
+              "prompt.id": "p_77",
+              body_truncated: "true",
+              body: truncated,
+            },
+          }),
+        ],
+        promptTextById,
+      );
+
+    it("reinstates the clean current prompt as the final turn, keeping the recovered prefix", () => {
+      const { span } = build(new Map([["p_77", "the current prompt"]]))[0]!;
+      expect(strVal(span, "gen_ai.input.messages")).toBe(
+        JSON.stringify([
+          { role: "system", content: "sys" },
+          { role: "user", content: "earlier turn" },
+          { role: "assistant", content: "ok" },
+          { role: "user", content: "the current prompt" },
+        ]),
+      );
+    });
+
+    it("does not duplicate the prompt when it already survived in the recovered prefix (mid-turn call)", () => {
+      // The human prompt is the earlier turn that survived; only trailing
+      // tool_results were truncated. Re-appending it would duplicate + mislabel.
+      const midTurn =
+        '{"messages":[{"role":"user","content":"earlier turn"},{"role":"assistant","content":"ok"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"outp';
+      const { span } = convertClaudeCodeLogsToSpans(
+        [
+          rec({
+            eventName: "api_request",
+            spanId: "cccccccccccccccc",
+            attrs: {
+              "event.name": "api_request",
+              model: "claude-opus-4-8",
+              request_id: "req_m",
+              query_source: "repl_main_thread",
+              "prompt.id": "p_88",
+            },
+          }),
+          rec({
+            eventName: "api_request_body",
+            spanId: "dddddddddddddddd",
+            attrs: {
+              "event.name": "api_request_body",
+              model: "claude-opus-4-8",
+              query_source: "repl_main_thread",
+              "prompt.id": "p_88",
+              body_truncated: "true",
+              body: midTurn,
+            },
+          }),
+        ],
+        new Map([["p_88", "earlier turn"]]),
+      )[0]!;
+      expect(strVal(span, "gen_ai.input.messages")).toBe(
+        JSON.stringify([
+          { role: "user", content: "earlier turn" },
+          { role: "assistant", content: "ok" },
+        ]),
+      );
     });
   });
 
@@ -751,7 +863,10 @@ describe("convertClaudeCodeToolLogsToSpans", () => {
 
     it("derives a deterministic span id from tool_use_id, order-independent", () => {
       const a = build();
-      const b = convertClaudeCodeToolLogsToSpans([toolResult(), toolDecision()]);
+      const b = convertClaudeCodeToolLogsToSpans([
+        toolResult(),
+        toolDecision(),
+      ]);
       expect(a[0]!.span.spanId).toBe(b[0]!.span.spanId);
       expect(a[0]!.span.spanId).not.toBe("d1d1d1d1d1d1d1d1");
     });
@@ -863,7 +978,9 @@ describe("convertClaudeCodeTurnToSpans (turn hierarchy)", () => {
     )!.span;
     expect(attr(model, "langwatch.span.cost")).toEqual({ doubleValue: 0.05 });
     expect(attr(model, "gen_ai.usage.input_tokens")).toEqual({ intValue: 100 });
-    expect(strVal(tool, "langwatch.input")).toBe('{"command":"ls /tmp | wc -l"}');
+    expect(strVal(tool, "langwatch.input")).toBe(
+      '{"command":"ls /tmp | wc -l"}',
+    );
 
     // The root envelopes the children in time (starts at/before, ends at/after).
     expect(startNano(root)).toBeLessThanOrEqual(startNano(model));
@@ -921,7 +1038,9 @@ describe("convertClaudeCodeTurnToSpans (tool output recovery)", () => {
   });
 
   it("nudges the output-less tool span earlier so the recovered version wins", () => {
-    const withoutOutput = toolSpanOf(convertClaudeCodeTurnToSpans([toolResult]));
+    const withoutOutput = toolSpanOf(
+      convertClaudeCodeTurnToSpans([toolResult]),
+    );
     const withOutput = toolSpanOf(
       convertClaudeCodeTurnToSpans([toolResult, nextModelBody]),
     );

--- a/langwatch/src/server/app-layer/traces/__tests__/model-cost-matching.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/model-cost-matching.unit.test.ts
@@ -62,6 +62,42 @@ describe("computeSpanCost", () => {
       });
       expect(result).toBe(0);
     });
+
+    it("fills an unset output rate from the registry instead of zeroing it (one-sided override)", () => {
+      // A customer overrides only their input rate. Output must not become free
+      // — it falls back to the registry rate for the model.
+      const registryOutputOnly = computeSpanCost({
+        attrs: { "gen_ai.request.model": "gpt-5-mini" },
+        promptTokens: 0,
+        completionTokens: 500,
+      });
+      expect(registryOutputOnly).toBeGreaterThan(0);
+
+      const oneSided = computeSpanCost({
+        attrs: {
+          "langwatch.model.inputCostPerToken": 1e-6,
+          "gen_ai.request.model": "gpt-5-mini",
+        },
+        promptTokens: 100,
+        completionTokens: 500,
+      });
+      // custom input rate + registry output rate, not custom input + zero output.
+      expect(oneSided).toBeCloseTo(100 * 1e-6 + registryOutputOnly, 10);
+    });
+
+    it("leaves the unset tier at zero when the model is unknown to the registry", () => {
+      // No registry match → nothing to fall back to, so the historical behaviour
+      // (unset output rate = 0) is preserved rather than inventing a rate.
+      const result = computeSpanCost({
+        attrs: {
+          "langwatch.model.inputCostPerToken": 1e-6,
+          "gen_ai.request.model": "totally-unknown-model-xyz",
+        },
+        promptTokens: 100,
+        completionTokens: 500,
+      });
+      expect(result).toBeCloseTo(100 * 1e-6, 10);
+    });
   });
 
   describe("when span has prompt-cache tokens", () => {

--- a/langwatch/src/server/app-layer/traces/__tests__/span-block-classification.readers.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/span-block-classification.readers.unit.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import type { OtlpSpan } from "../../../event-sourcing/pipelines/trace-processing/schemas/otlp";
+import { extractUsagePools } from "../span-block-classification.readers";
+
+type Attr = OtlpSpan["attributes"][number];
+
+function createSpan(attributes: Attr[]): OtlpSpan {
+  return {
+    traceId: "trace-1",
+    spanId: "span-1",
+    name: "chat",
+    kind: 1,
+    startTimeUnixNano: { low: 0, high: 0 },
+    endTimeUnixNano: { low: 1000, high: 0 },
+    attributes,
+    events: [],
+    links: [],
+    status: {},
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  };
+}
+
+function usageAttrs({
+  input,
+  cached,
+}: {
+  input: number;
+  cached: number;
+}): Attr[] {
+  return [
+    { key: "gen_ai.usage.input_tokens", value: { intValue: input } },
+    { key: "gen_ai.usage.cached_tokens", value: { intValue: cached } },
+    { key: "gen_ai.usage.output_tokens", value: { intValue: 50 } },
+  ];
+}
+
+describe("extractUsagePools", () => {
+  describe("when the harness is codex (OpenAI usage convention)", () => {
+    // OpenAI reports cached tokens as a SUBSET of input_tokens; the pools
+    // must be exclusive or input-axis allocation double-counts the cached
+    // prefix (same convention split as sumStepContext).
+    it("subtracts the cached subset out of the fresh input pool", () => {
+      const pools = extractUsagePools(
+        createSpan(usageAttrs({ input: 1000, cached: 900 })),
+        "codex",
+      );
+      expect(pools.inputTokens).toBe(100);
+      expect(pools.cacheReadTokens).toBe(900);
+    });
+
+    it("floors the fresh pool at zero when cached exceeds input", () => {
+      const pools = extractUsagePools(
+        createSpan(usageAttrs({ input: 100, cached: 150 })),
+        "codex",
+      );
+      expect(pools.inputTokens).toBe(0);
+    });
+  });
+
+  describe("when the harness is claude (Anthropic exclusive pools)", () => {
+    it("keeps the reported pools disjoint as-is", () => {
+      const pools = extractUsagePools(
+        createSpan([
+          { key: "gen_ai.usage.input_tokens", value: { intValue: 50 } },
+          {
+            key: "gen_ai.usage.cache_read.input_tokens",
+            value: { intValue: 900 },
+          },
+          {
+            key: "gen_ai.usage.cache_creation.input_tokens",
+            value: { intValue: 100 },
+          },
+          { key: "gen_ai.usage.output_tokens", value: { intValue: 20 } },
+        ]),
+        "claude",
+      );
+      expect(pools.inputTokens).toBe(50);
+      expect(pools.cacheReadTokens).toBe(900);
+      expect(pools.cacheCreationTokens).toBe(100);
+      expect(pools.outputTokens).toBe(20);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/__tests__/span-block-classification.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/span-block-classification.service.unit.test.ts
@@ -129,6 +129,57 @@ describe("OtlpSpanBlockClassificationService", () => {
         const realCost = 300 * 3e-6 + 20 * 1.5e-5;
         expect(Math.abs(catCosts - realCost)).toBeLessThan(1e-9);
       });
+
+      it("conserves stored tokens — per-axis category tokens sum to the provider pool exactly (largest-remainder, no drift)", async () => {
+        // Three equal input blocks (system + prior + fresh) share a 10-token
+        // fresh pool: each scales to ~3.33, and rounding them independently
+        // would store 3+3+3 = 9, drifting a token off the provider's 10. The
+        // largest-remainder rounding must keep the stored sum at exactly 10.
+        const span = createSpan([
+          { key: "langwatch.span.type", value: { stringValue: "llm" } },
+          {
+            key: "gen_ai.request.model",
+            value: { stringValue: "claude-fable-5" },
+          },
+          {
+            key: "langwatch.claude_code.request_body",
+            value: {
+              stringValue: JSON.stringify({
+                system: [
+                  { type: "text", text: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+                ],
+                messages: [
+                  { role: "user", content: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+                  { role: "user", content: "cccccccccccccccccccccccccccccccc" },
+                ],
+              }),
+            },
+          },
+          { key: "gen_ai.usage.input_tokens", value: { intValue: 10 } },
+          { key: "gen_ai.usage.output_tokens", value: { intValue: 4 } },
+          {
+            key: "langwatch.model.inputCostPerToken",
+            value: { doubleValue: 3e-6 },
+          },
+          {
+            key: "langwatch.model.outputCostPerToken",
+            value: { doubleValue: 1.5e-5 },
+          },
+        ]);
+
+        await service.classifySpanBlocks({
+          span,
+          instrumentationScope: CLAUDE_SCOPE,
+        });
+
+        const inputTokenKeys = new Set(
+          Object.values(InputCategory).map((c) => blockCategoryTokensAttr(c)),
+        );
+        const inputTokenSum = span.attributes
+          .filter((a) => inputTokenKeys.has(a.key))
+          .reduce((n, a) => n + Number(a.value.stringValue), 0);
+        expect(inputTokenSum).toBe(10);
+      });
     });
   });
 
@@ -246,6 +297,80 @@ describe("OtlpSpanBlockClassificationService", () => {
 
       expect(
         attrValue(span, blockCategoryTokensAttr(InputCategory.SYSTEM_PROMPT)),
+      ).toBeDefined();
+      expect(
+        attrValue(span, blockCategoryTokensAttr(InputCategory.OTHER_INPUT)),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("given a Claude Code span whose raw body was truncated past the newest turn", () => {
+    it("reinstates the current user prompt from the flattened side-channel so fresh input is not lost", async () => {
+      // Inline truncation drops the tail — the newest user turn — so the raw body
+      // recovers only the system prefix. The clean flattened langwatch.input still
+      // carries the current prompt; without reinstating it the fresh input_tokens
+      // pool has no user block and dumps into other_input.
+      const full = JSON.stringify({
+        system: [{ type: "text", text: "You are a coding assistant." }],
+        messages: [
+          {
+            role: "user",
+            content: "the current prompt, cut off by truncation",
+          },
+        ],
+      });
+      const truncatedBody = full.slice(0, full.indexOf("cut off"));
+
+      const span = createSpan([
+        { key: "langwatch.span.type", value: { stringValue: "llm" } },
+        {
+          key: "gen_ai.request.model",
+          value: { stringValue: "claude-fable-5" },
+        },
+        {
+          key: "langwatch.claude_code.request_body",
+          value: { stringValue: truncatedBody },
+        },
+        // The clean flattened side-channel (log-to-span fills this from the
+        // co-located user_prompt) carries the current turn.
+        {
+          key: "langwatch.input",
+          value: {
+            stringValue: JSON.stringify({
+              type: "chat_messages",
+              value: [{ role: "user", content: "the current prompt" }],
+            }),
+          },
+        },
+        { key: "gen_ai.usage.input_tokens", value: { intValue: 40 } },
+        {
+          key: "gen_ai.usage.cache_read.input_tokens",
+          value: { intValue: 500 },
+        },
+        { key: "gen_ai.usage.output_tokens", value: { intValue: 10 } },
+        {
+          key: "langwatch.model.inputCostPerToken",
+          value: { doubleValue: 3e-6 },
+        },
+        {
+          key: "langwatch.model.outputCostPerToken",
+          value: { doubleValue: 1.5e-5 },
+        },
+        {
+          key: "langwatch.model.cacheReadCostPerToken",
+          value: { doubleValue: 3e-7 },
+        },
+      ]);
+
+      await service.classifySpanBlocks({
+        span,
+        instrumentationScope: CLAUDE_SCOPE,
+      });
+
+      // The reinstated current turn is the fresh user_input block; the fresh
+      // input_tokens pool attributes to it instead of the catch-all.
+      expect(
+        attrValue(span, blockCategoryTokensAttr(InputCategory.USER_INPUT)),
       ).toBeDefined();
       expect(
         attrValue(span, blockCategoryTokensAttr(InputCategory.OTHER_INPUT)),

--- a/langwatch/src/server/app-layer/traces/__tests__/span-block-classification.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/span-block-classification.service.unit.test.ts
@@ -183,6 +183,76 @@ describe("OtlpSpanBlockClassificationService", () => {
     });
   });
 
+  describe("given a Claude Code span with a raw request body (cache_control intact)", () => {
+    it("classifies from the raw body so cache tokens attribute to the cached prefix, not other_input", async () => {
+      // The flattened langwatch.input strips cache_control (breakpoint would be
+      // null → cache pool inferred/dumped). The raw body keeps it, so the cached
+      // system prefix takes the cache_read pool and nothing lands in other_input.
+      const span = createSpan([
+        { key: "langwatch.span.type", value: { stringValue: "llm" } },
+        {
+          key: "gen_ai.request.model",
+          value: { stringValue: "claude-fable-5" },
+        },
+        {
+          key: "langwatch.claude_code.request_body",
+          value: {
+            stringValue: JSON.stringify({
+              system: [
+                {
+                  type: "text",
+                  text: "You are a coding assistant.",
+                  cache_control: { type: "ephemeral" },
+                },
+              ],
+              messages: [{ role: "user", content: "fix the test" }],
+            }),
+          },
+        },
+        // The flattened field is present too, but the raw body must win.
+        {
+          key: "langwatch.input",
+          value: {
+            stringValue: JSON.stringify({
+              type: "chat_messages",
+              value: [{ role: "user", content: "fix the test" }],
+            }),
+          },
+        },
+        { key: "gen_ai.usage.input_tokens", value: { intValue: 5 } },
+        {
+          key: "gen_ai.usage.cache_read.input_tokens",
+          value: { intValue: 500 },
+        },
+        { key: "gen_ai.usage.output_tokens", value: { intValue: 10 } },
+        {
+          key: "langwatch.model.inputCostPerToken",
+          value: { doubleValue: 3e-6 },
+        },
+        {
+          key: "langwatch.model.outputCostPerToken",
+          value: { doubleValue: 1.5e-5 },
+        },
+        {
+          key: "langwatch.model.cacheReadCostPerToken",
+          value: { doubleValue: 3e-7 },
+        },
+      ]);
+
+      await service.classifySpanBlocks({
+        span,
+        instrumentationScope: CLAUDE_SCOPE,
+      });
+
+      expect(
+        attrValue(span, blockCategoryTokensAttr(InputCategory.SYSTEM_PROMPT)),
+      ).toBeDefined();
+      expect(
+        attrValue(span, blockCategoryTokensAttr(InputCategory.OTHER_INPUT)),
+      ).toBeUndefined();
+    });
+  });
+
   describe("given a coding-agent span carrying an explicit provider cost", () => {
     describe("when the span is classified", () => {
       it("reconciles per-category costs to the displayed cost_usd, not the registry estimate", async () => {

--- a/langwatch/src/server/app-layer/traces/block-classification/__tests__/blockClassifier.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/__tests__/blockClassifier.unit.test.ts
@@ -268,10 +268,12 @@ describe("classifyBlocks", () => {
           { name: "mcp__linear__list_issues", description: "list" },
         ],
       });
+      // Tool definitions lead the cacheable prefix (Anthropic order:
+      // tools → system → messages), so they classify ahead of the system prompt.
       expect(categoriesOf(input)).toEqual([
-        InputCategory.SYSTEM_PROMPT,
         InputCategory.TOOL_DEFINITIONS,
         InputCategory.MCP_TOOL_DEFINITIONS,
+        InputCategory.SYSTEM_PROMPT,
       ]);
     });
   });

--- a/langwatch/src/server/app-layer/traces/block-classification/__tests__/blockClassifier.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/__tests__/blockClassifier.unit.test.ts
@@ -158,6 +158,41 @@ describe("classifyBlocks", () => {
     });
   });
 
+  describe("given multiple leading injected-context text parts on the fresh turn", () => {
+    /** @scenario "Injected context markers are classified separately from real user input" */
+    it("keeps peeling markers until real user text appears", () => {
+      // Claude Code emits EACH injected reminder as its own text part; only
+      // the part that finally carries a real body ends the peel window.
+      const { input } = classifyBlocks({
+        inputMessages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "<system-reminder>reminder A</system-reminder>",
+              },
+              {
+                type: "text",
+                text: "<system-reminder>reminder B (claudeMd)</system-reminder>",
+              },
+              { type: "text", text: "fix the bug" },
+            ],
+          },
+        ],
+      });
+      expect(categoriesOf(input)).toEqual([
+        InputCategory.PRIOR_CONTEXT,
+        InputCategory.PRIOR_CONTEXT,
+        InputCategory.USER_INPUT,
+      ]);
+      const userInput = input.find(
+        (b) => b.category === InputCategory.USER_INPUT,
+      );
+      expect(userInput?.charCount).toBe("fix the bug".length);
+    });
+  });
+
   describe("given a tool_use nested in the fresh user message", () => {
     it("keeps it on the input axis instead of leaking an output tool_call category", () => {
       const { input } = classifyBlocks({
@@ -198,7 +233,7 @@ describe("classifyBlocks", () => {
   });
 
   describe("given an injected skill marker in a prior (non-fresh) user turn", () => {
-    /** @scenario "An injected skill block is classified as skill content wherever it appears" */
+    /** @scenario "Injected context markers are classified separately from real user input" */
     it("classifies it as skill_content, not prior_context", () => {
       // Codex relays its skill injections verbatim in the rollout as their own
       // earlier user messages (not prepended to the fresh turn like Claude), so

--- a/langwatch/src/server/app-layer/traces/block-classification/__tests__/claudeCodeBody.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/__tests__/claudeCodeBody.unit.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { classifyBlocks } from "../blockClassifier.service";
+import {
+  parseClaudeCodeRequestBody,
+  parseClaudeCodeResponseBody,
+} from "../claudeCodeBody";
+
+describe("parseClaudeCodeRequestBody", () => {
+  it("parses system + messages with content structure and tools preserved", () => {
+    const body = JSON.stringify({
+      model: "claude-fable-5",
+      system: [
+        {
+          type: "text",
+          text: "You are helpful",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      tools: [{ name: "Bash" }],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+        { role: "assistant", content: [{ type: "text", text: "hello" }] },
+      ],
+    });
+
+    const result = parseClaudeCodeRequestBody(body);
+
+    expect(result?.messages).toHaveLength(3);
+    expect(result?.messages[0]?.role).toBe("system");
+    // content-block structure (incl. cache_control) is kept, not flattened.
+    expect(result?.messages[0]?.content).toEqual([
+      {
+        type: "text",
+        text: "You are helpful",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+    expect(result?.tools).toEqual([{ name: "Bash" }]);
+  });
+
+  it("preserves cache_control so classifyBlocks finds a REAL breakpoint (no inference needed)", () => {
+    const body = JSON.stringify({
+      system: [
+        { type: "text", text: "sys", cache_control: { type: "ephemeral" } },
+      ],
+      messages: [
+        { role: "user", content: "prior turn" },
+        { role: "user", content: "the fresh turn" },
+      ],
+    });
+    const parsed = parseClaudeCodeRequestBody(body)!;
+
+    const { lastInputCacheBreakpointIndex } = classifyBlocks({
+      inputMessages: parsed.messages,
+    });
+
+    expect(lastInputCacheBreakpointIndex).not.toBeNull();
+  });
+
+  it("recovers system + complete leading messages from a truncated body, structure intact", () => {
+    const full = JSON.stringify({
+      system: [{ type: "text", text: "sys prompt" }],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "first" }] },
+        { role: "assistant", content: [{ type: "text", text: "reply" }] },
+        {
+          role: "user",
+          content: [{ type: "text", text: "cut off here, a long tail" }],
+        },
+      ],
+    });
+    const truncated = full.slice(0, full.indexOf("cut off"));
+
+    const result = parseClaudeCodeRequestBody(truncated)!;
+
+    // system + first two turns recovered; the truncated third turn is dropped.
+    expect(result.messages.map((m) => m.role)).toEqual([
+      "system",
+      "user",
+      "assistant",
+    ]);
+    // content kept as a block array, not flattened to a string.
+    expect(Array.isArray(result.messages[1]?.content)).toBe(true);
+  });
+
+  it("returns null for an absent or empty body", () => {
+    expect(parseClaudeCodeRequestBody(undefined)).toBeNull();
+    expect(parseClaudeCodeRequestBody("")).toBeNull();
+  });
+});
+
+describe("parseClaudeCodeResponseBody", () => {
+  it("wraps the response content blocks as one assistant message", () => {
+    const body = JSON.stringify({
+      content: [
+        { type: "thinking", thinking: "..." },
+        { type: "text", text: "the answer" },
+        { type: "tool_use", name: "Bash", input: {} },
+      ],
+    });
+
+    const result = parseClaudeCodeResponseBody(body);
+
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.role).toBe("assistant");
+    expect(Array.isArray(result?.[0]?.content)).toBe(true);
+  });
+
+  it("returns null for a truncated response body so the caller uses the flat reply", () => {
+    expect(
+      parseClaudeCodeResponseBody('{"content":[{"type":"text","text":"cut'),
+    ).toBeNull();
+  });
+});

--- a/langwatch/src/server/app-layer/traces/block-classification/__tests__/claudeCodeBody.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/__tests__/claudeCodeBody.unit.test.ts
@@ -92,6 +92,41 @@ describe("parseClaudeCodeRequestBody", () => {
     expect(parseClaudeCodeRequestBody(undefined)).toBeNull();
     expect(parseClaudeCodeRequestBody("")).toBeNull();
   });
+
+  it("ignores a 'system'/'messages' key nested inside tool_use input during truncation recovery", () => {
+    // tool_use.input is embedded as real unescaped JSON — a naive indexOf
+    // scan latched onto the nested key and recovered a bogus system value.
+    const full = JSON.stringify({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "Write",
+              input: { system: "decoy", messages: ["decoy"] },
+            },
+          ],
+        },
+        { role: "user", content: [{ type: "text", text: "real turn" }] },
+      ],
+      system: [{ type: "text", text: "real sys" }],
+      metadata: { tail: "cut off here, a long tail" },
+    });
+    const truncated = full.slice(0, full.indexOf("cut off"));
+
+    const result = parseClaudeCodeRequestBody(truncated)!;
+
+    const system = result.messages.find((m) => m.role === "system");
+    expect(system?.content).toEqual([{ type: "text", text: "real sys" }]);
+    // The decoy nested 'messages' array did not hijack turn recovery.
+    expect(result.messages.map((m) => m.role)).toEqual([
+      "system",
+      "assistant",
+      "user",
+    ]);
+  });
 });
 
 describe("parseClaudeCodeResponseBody", () => {

--- a/langwatch/src/server/app-layer/traces/block-classification/__tests__/claudeCodeBody.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/__tests__/claudeCodeBody.unit.test.ts
@@ -36,6 +36,8 @@ describe("parseClaudeCodeRequestBody", () => {
       },
     ]);
     expect(result?.tools).toEqual([{ name: "Bash" }]);
+    // A clean parse kept every turn, including the newest.
+    expect(result?.newestTurnComplete).toBe(true);
   });
 
   it("preserves cache_control so classifyBlocks finds a REAL breakpoint (no inference needed)", () => {
@@ -81,6 +83,9 @@ describe("parseClaudeCodeRequestBody", () => {
     ]);
     // content kept as a block array, not flattened to a string.
     expect(Array.isArray(result.messages[1]?.content)).toBe(true);
+    // truncation dropped the tail, so the newest turn is flagged incomplete —
+    // the caller reinstates the current prompt from the clean side-channel.
+    expect(result.newestTurnComplete).toBe(false);
   });
 
   it("returns null for an absent or empty body", () => {

--- a/langwatch/src/server/app-layer/traces/block-classification/__tests__/costAllocation.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/__tests__/costAllocation.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { type Category, InputCategory, OutputCategory } from "../categories";
 import {
   allocateCategoryCosts,
+  inferCacheBreakpointFromPools,
   type TierPrices,
   type TokenBlock,
   type UsagePools,
@@ -253,6 +254,81 @@ describe("allocateCategoryCosts", () => {
       const totals = runPrefix(0, 500);
       expect(totals[InputCategory.SYSTEM_PROMPT]?.tokens).toBe(500);
       expect(totals[InputCategory.OTHER_INPUT]).toBeUndefined();
+    });
+  });
+
+  describe("inferCacheBreakpointFromPools", () => {
+    it("places the boundary at the front by the cached fraction of input", () => {
+      // cached = 900, fresh input = 100 → 90% of the input is the cached prefix,
+      // so the boundary falls after the system_prompt block (the front), leaving
+      // the trailing user block fresh.
+      const inputBlocks: TokenBlock[] = [
+        { idx: 0, category: InputCategory.SYSTEM_PROMPT, tokens: 900 },
+        { idx: 1, category: InputCategory.USER_INPUT, tokens: 100 },
+      ];
+      const pools: UsagePools = {
+        inputTokens: 100,
+        cacheReadTokens: 900,
+        cacheCreationTokens: 0,
+        outputTokens: 0,
+      };
+      expect(inferCacheBreakpointFromPools({ inputBlocks, pools })).toBe(0);
+    });
+
+    it("returns null when the provider reports no cached tokens", () => {
+      const inputBlocks: TokenBlock[] = [
+        { idx: 0, category: InputCategory.SYSTEM_PROMPT, tokens: 900 },
+      ];
+      const pools: UsagePools = {
+        inputTokens: 900,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        outputTokens: 0,
+      };
+      expect(inferCacheBreakpointFromPools({ inputBlocks, pools })).toBeNull();
+    });
+
+    it("returns null when blocks carry no token mass", () => {
+      const inputBlocks: TokenBlock[] = [
+        { idx: 0, category: InputCategory.SYSTEM_PROMPT, tokens: 0 },
+      ];
+      const pools: UsagePools = {
+        inputTokens: 0,
+        cacheReadTokens: 500,
+        cacheCreationTokens: 0,
+        outputTokens: 0,
+      };
+      expect(inferCacheBreakpointFromPools({ inputBlocks, pools })).toBeNull();
+    });
+
+    it("keeps cache tokens out of the catch-all when composed with allocation (flattened-path regression)", () => {
+      // The Claude Code log path: content flattened to text, so no cache_control
+      // marker survived (breakpoint would be null), yet the provider reports a
+      // large cache pool. Without the inferred breakpoint the whole cache pool
+      // dumps to other_input; with it, system_prompt absorbs the cached prefix.
+      const inputBlocks: TokenBlock[] = [
+        { idx: 0, category: InputCategory.SYSTEM_PROMPT, tokens: 900 },
+        { idx: 1, category: InputCategory.USER_INPUT, tokens: 100 },
+      ];
+      const pools: UsagePools = {
+        inputTokens: 100,
+        cacheReadTokens: 700,
+        cacheCreationTokens: 200,
+        outputTokens: 0,
+      };
+      const breakpoint = inferCacheBreakpointFromPools({ inputBlocks, pools });
+
+      const { categoryTotals } = allocateCategoryCosts({
+        inputBlocks,
+        outputBlocks: [],
+        lastCacheBreakpointIndex: breakpoint,
+        pools,
+        prices: {},
+      });
+
+      expect(categoryTotals[InputCategory.SYSTEM_PROMPT]?.tokens).toBe(900);
+      expect(categoryTotals[InputCategory.USER_INPUT]?.tokens).toBe(100);
+      expect(categoryTotals[InputCategory.OTHER_INPUT]).toBeUndefined();
     });
   });
 

--- a/langwatch/src/server/app-layer/traces/block-classification/__tests__/costAllocation.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/__tests__/costAllocation.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { type Category, InputCategory, OutputCategory } from "../categories";
 import {
   allocateCategoryCosts,
-  inferCacheBreakpointFromPools,
+  inferCachedPrefixEstTokens,
   type TierPrices,
   type TokenBlock,
   type UsagePools,
@@ -257,11 +257,11 @@ describe("allocateCategoryCosts", () => {
     });
   });
 
-  describe("inferCacheBreakpointFromPools", () => {
-    it("places the boundary at the front by the cached fraction of input", () => {
-      // cached = 900, fresh input = 100 → 90% of the input is the cached prefix,
-      // so the boundary falls after the system_prompt block (the front), leaving
-      // the trailing user block fresh.
+  describe("inferCachedPrefixEstTokens", () => {
+    it("places the boundary by the cached fraction of the input estimate", () => {
+      // cached = 900, fresh input = 100 → 90% of the 1000-token estimate is the
+      // cached prefix, so the boundary sits at 900 (estimate space): the whole
+      // system_prompt block is cached and the trailing user block stays fresh.
       const inputBlocks: TokenBlock[] = [
         { idx: 0, category: InputCategory.SYSTEM_PROMPT, tokens: 900 },
         { idx: 1, category: InputCategory.USER_INPUT, tokens: 100 },
@@ -272,7 +272,7 @@ describe("allocateCategoryCosts", () => {
         cacheCreationTokens: 0,
         outputTokens: 0,
       };
-      expect(inferCacheBreakpointFromPools({ inputBlocks, pools })).toBe(0);
+      expect(inferCachedPrefixEstTokens({ inputBlocks, pools })).toBe(900);
     });
 
     it("returns null when the provider reports no cached tokens", () => {
@@ -285,7 +285,7 @@ describe("allocateCategoryCosts", () => {
         cacheCreationTokens: 0,
         outputTokens: 0,
       };
-      expect(inferCacheBreakpointFromPools({ inputBlocks, pools })).toBeNull();
+      expect(inferCachedPrefixEstTokens({ inputBlocks, pools })).toBeNull();
     });
 
     it("returns null when blocks carry no token mass", () => {
@@ -298,13 +298,13 @@ describe("allocateCategoryCosts", () => {
         cacheCreationTokens: 0,
         outputTokens: 0,
       };
-      expect(inferCacheBreakpointFromPools({ inputBlocks, pools })).toBeNull();
+      expect(inferCachedPrefixEstTokens({ inputBlocks, pools })).toBeNull();
     });
 
     it("keeps cache tokens out of the catch-all when composed with allocation (flattened-path regression)", () => {
       // The Claude Code log path: content flattened to text, so no cache_control
       // marker survived (breakpoint would be null), yet the provider reports a
-      // large cache pool. Without the inferred breakpoint the whole cache pool
+      // large cache pool. Without the inferred boundary the whole cache pool
       // dumps to other_input; with it, system_prompt absorbs the cached prefix.
       const inputBlocks: TokenBlock[] = [
         { idx: 0, category: InputCategory.SYSTEM_PROMPT, tokens: 900 },
@@ -316,16 +316,53 @@ describe("allocateCategoryCosts", () => {
         cacheCreationTokens: 200,
         outputTokens: 0,
       };
-      const breakpoint = inferCacheBreakpointFromPools({ inputBlocks, pools });
-
       const { categoryTotals } = allocateCategoryCosts({
         inputBlocks,
         outputBlocks: [],
-        lastCacheBreakpointIndex: breakpoint,
+        lastCacheBreakpointIndex: null,
+        inferredCachedPrefixEstTokens: inferCachedPrefixEstTokens({
+          inputBlocks,
+          pools,
+        }),
         pools,
         prices: {},
       });
 
+      expect(categoryTotals[InputCategory.SYSTEM_PROMPT]?.tokens).toBe(900);
+      expect(categoryTotals[InputCategory.USER_INPUT]?.tokens).toBe(100);
+      expect(categoryTotals[InputCategory.OTHER_INPUT]).toBeUndefined();
+    });
+
+    it("splits the straddling block so its fresh portion never leaks to the catch-all (A1/C2 regression)", () => {
+      // Nearly the whole input is cached (950 of 1000), so the inferred boundary
+      // (950 in estimate space) falls INSIDE the trailing user block: 50 of its
+      // 100 tokens are cached, 50 are fresh. A whole-block boundary would swallow
+      // the block into the cached prefix, leave the fresh pool blockless, and dump
+      // its 50 tokens into other_input (zeroing user_input's fresh share). The
+      // fractional split keeps the fresh 50 on user_input.
+      const inputBlocks: TokenBlock[] = [
+        { idx: 0, category: InputCategory.SYSTEM_PROMPT, tokens: 900 },
+        { idx: 1, category: InputCategory.USER_INPUT, tokens: 100 },
+      ];
+      const pools: UsagePools = {
+        inputTokens: 50,
+        cacheReadTokens: 950,
+        cacheCreationTokens: 0,
+        outputTokens: 0,
+      };
+      const { categoryTotals } = allocateCategoryCosts({
+        inputBlocks,
+        outputBlocks: [],
+        lastCacheBreakpointIndex: null,
+        inferredCachedPrefixEstTokens: inferCachedPrefixEstTokens({
+          inputBlocks,
+          pools,
+        }),
+        pools,
+        prices: {},
+      });
+
+      // user_input = 50 cached (from the straddle) + 50 fresh = 100; nothing lost.
       expect(categoryTotals[InputCategory.SYSTEM_PROMPT]?.tokens).toBe(900);
       expect(categoryTotals[InputCategory.USER_INPUT]?.tokens).toBe(100);
       expect(categoryTotals[InputCategory.OTHER_INPUT]).toBeUndefined();

--- a/langwatch/src/server/app-layer/traces/block-classification/__tests__/freshTurnPresence.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/__tests__/freshTurnPresence.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { textContainsPromptLineAligned } from "../freshTurnPresence";
+
+describe("textContainsPromptLineAligned", () => {
+  describe("given the prompt survived as its own line", () => {
+    it("matches at text start, mid-text, and text end", () => {
+      expect(textContainsPromptLineAligned("continue", "continue")).toBe(true);
+      expect(
+        textContainsPromptLineAligned(
+          "<reminder>x</reminder>\ncontinue",
+          "continue",
+        ),
+      ).toBe(true);
+      expect(
+        textContainsPromptLineAligned("continue\n[tool_result...]", "continue"),
+      ).toBe(true);
+    });
+
+    it("matches a multi-line prompt block", () => {
+      const prompt = "fix the bug\nthen run the tests";
+      expect(
+        textContainsPromptLineAligned(`prefix\n${prompt}\nsuffix`, prompt),
+      ).toBe(true);
+    });
+  });
+
+  describe("given the prompt only appears inside other prose", () => {
+    // The regression this predicate exists for: a bare `includes` judged a
+    // short prompt ("ok", "continue") as already present because it occurred
+    // inside a recovered file dump, so the fresh turn was never reinstated.
+    it("does not match a mid-line substring", () => {
+      expect(
+        textContainsPromptLineAligned(
+          "the loop will continue until done",
+          "continue",
+        ),
+      ).toBe(false);
+      expect(textContainsPromptLineAligned("look ok?", "ok")).toBe(false);
+    });
+  });
+
+  describe("given an empty or whitespace prompt", () => {
+    it("never matches", () => {
+      expect(textContainsPromptLineAligned("anything", "")).toBe(false);
+      expect(textContainsPromptLineAligned("anything", "   ")).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/block-classification/__tests__/freshTurnPresence.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/__tests__/freshTurnPresence.unit.test.ts
@@ -40,6 +40,42 @@ describe("textContainsPromptLineAligned", () => {
     });
   });
 
+  describe("given the surviving line is padded with whitespace", () => {
+    // Regression: the needle is trimmed but the recovered line may be indented
+    // or trailing-padded. Requiring a bare `\n` boundary made a genuinely
+    // present-but-padded prompt read as absent, so it got appended twice.
+    it("matches an indented occurrence", () => {
+      expect(
+        textContainsPromptLineAligned(
+          "prefix\n    continue\nsuffix",
+          "continue",
+        ),
+      ).toBe(true);
+    });
+
+    it("matches a trailing-padded occurrence (incl. CRLF)", () => {
+      expect(
+        textContainsPromptLineAligned("continue   \nnext", "continue"),
+      ).toBe(true);
+      expect(
+        textContainsPromptLineAligned("continue\r\nnext", "continue"),
+      ).toBe(true);
+    });
+
+    it("matches when the whole text is just the padded prompt", () => {
+      expect(textContainsPromptLineAligned("   continue   ", "continue")).toBe(
+        true,
+      );
+    });
+
+    it("still rejects a mid-line substring even with surrounding whitespace", () => {
+      // Non-whitespace on the same line means it's embedded, not its own turn.
+      expect(
+        textContainsPromptLineAligned("  the loop will continue  ", "continue"),
+      ).toBe(false);
+    });
+  });
+
   describe("given an empty or whitespace prompt", () => {
     it("never matches", () => {
       expect(textContainsPromptLineAligned("anything", "")).toBe(false);

--- a/langwatch/src/server/app-layer/traces/block-classification/blockClassifier.service.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/blockClassifier.service.ts
@@ -490,11 +490,13 @@ export function classifyBlocks({
   const lastUserIdx = lastIndexOfUser(messages);
   const toolNames = new Map<string, string>();
 
-  // Prompt order: system prefix, then tool definitions, then the conversation —
-  // so the emitted input sequence matches the cacheable-prefix layout the cost
-  // allocator reasons about by position. This splits out only the LEADING run of
-  // system messages; a system message that appears later keeps its original
-  // position in the conversation phase below.
+  // Prompt order: tool definitions, then the system prefix, then the conversation
+  // — Anthropic builds the cacheable prefix as `tools → system → messages`, so the
+  // emitted input sequence must match that layout for the cost allocator's
+  // position-based cache-tier split to line up with where the provider actually
+  // placed the cache boundary. This splits out only the LEADING run of system
+  // messages; a system message that appears later keeps its original position in
+  // the conversation phase below.
   let firstNonSystem = 0;
   for (let i = 0; i < messages.length; i++) {
     if (roleOf(messages[i]!) !== "system") {
@@ -504,6 +506,7 @@ export function classifyBlocks({
     firstNonSystem = i + 1;
   }
 
+  classifyToolDefinitions(tools, input);
   for (let i = 0; i < firstNonSystem; i++) {
     classifyInputMessage({
       msg: messages[i]!,
@@ -512,7 +515,6 @@ export function classifyBlocks({
       toolNames,
     });
   }
-  classifyToolDefinitions(tools, input);
   for (let i = firstNonSystem; i < messages.length; i++) {
     classifyInputMessage({
       msg: messages[i]!,

--- a/langwatch/src/server/app-layer/traces/block-classification/blockClassifier.service.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/blockClassifier.service.ts
@@ -271,21 +271,23 @@ function classifyInputMessage({
   if (!Array.isArray(content)) return;
 
   // Injected context (system-reminder / skill / mcp-instructions markers) is
-  // prepended only to the FIRST text part of a user message. Peel markers off
-  // that part alone; a later text part carrying a `<tag>` is real content, not
-  // injected context, so it keeps this turn's body category.
+  // prepended ahead of the user's real text. Claude Code may emit EACH injected
+  // reminder as its own text part, so keep peeling leading parts until one
+  // produces a real (non-marker) body; from there on a text part carrying a
+  // `<tag>` is real content, not injected context, and keeps this turn's body
+  // category.
   let leadingTextPending = isUser;
 
   for (const part of content) {
     if (typeof part === "string") {
       if (isUser) {
-        pushUserTextOrMarkers({
+        const pushedBody = pushUserTextOrMarkers({
           acc,
           text: part,
           peel: leadingTextPending,
           bodyCategory: userBodyCategory,
         });
-        leadingTextPending = false;
+        if (pushedBody) leadingTextPending = false;
       } else acc.push(InputCategory.PRIOR_CONTEXT, part);
       continue;
     }
@@ -302,13 +304,13 @@ function classifyInputMessage({
 
     const category = inputPartCategory({ part, fresh, role, toolNames });
     if (part.type === "text" && isUser) {
-      pushUserTextOrMarkers({
+      const pushedBody = pushUserTextOrMarkers({
         acc,
         text: blockText(part),
         peel: leadingTextPending,
         bodyCategory: userBodyCategory,
       });
-      leadingTextPending = false;
+      if (pushedBody) leadingTextPending = false;
     } else {
       acc.push(category, blockText(part));
     }
@@ -370,6 +372,10 @@ function inputPartCategory({
  * wherever it sits, instead of collapsing an injected `<skill>` into
  * prior_context. Only the LEADING part peels: a later part carrying a `<tag>` is
  * real content, not injected context. */
+/**
+ * Returns whether a real (non-marker) body was pushed — the caller uses this
+ * to keep peeling markers off subsequent parts until actual user text appears.
+ */
 function pushUserTextOrMarkers({
   acc,
   text,
@@ -380,14 +386,15 @@ function pushUserTextOrMarkers({
   text: string;
   peel: boolean;
   bodyCategory: Category;
-}): void {
+}): boolean {
   if (!peel) {
     if (text.length > 0) acc.push(bodyCategory, text);
-    return;
+    return text.length > 0;
   }
   const { markers, body } = splitLeadingMarkers(text);
   for (const marker of markers) acc.push(marker.category, marker.raw);
   if (body.length > 0) acc.push(bodyCategory, body);
+  return body.length > 0;
 }
 
 function pushString({

--- a/langwatch/src/server/app-layer/traces/block-classification/categories.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/categories.ts
@@ -88,6 +88,16 @@ export function catchAllFor(axis: Axis): Category {
     : OutputCategory.OTHER_OUTPUT;
 }
 
+const OUTPUT_CATEGORY_VALUES: ReadonlySet<string> = new Set(
+  Object.values(OutputCategory),
+);
+
+/** The axis a category belongs to (input and output category values are
+ * disjoint). Used to reconcile per-category token rounding within an axis. */
+export function axisOf(category: Category): Axis {
+  return OUTPUT_CATEGORY_VALUES.has(category) ? "output" : "input";
+}
+
 /** Built-in vs MCP discrimination on tool names (Claude Code wire convention). */
 export const MCP_TOOL_PREFIX = "mcp__";
 

--- a/langwatch/src/server/app-layer/traces/block-classification/claudeCodeBody.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/claudeCodeBody.ts
@@ -19,6 +19,12 @@
  * Pure: span-in / plain-object-out, no I/O.
  */
 
+import {
+  completeObjectSlices,
+  readJsonStringAt,
+  topLevelKeyIndex,
+} from "../truncated-json-scan";
+
 /** The classifier's input shape: Anthropic-style messages + the request tools. */
 export interface ClaudeCodeStructuredInput {
   messages: Array<{ role: string; content: unknown }>;
@@ -178,107 +184,4 @@ function recoverSystemValue(raw: string): unknown | null {
     return blocks.length > 0 ? blocks : null;
   }
   return null;
-}
-
-/**
- * Index of `"key"` occurring as a KEY of the TOP-LEVEL object (depth 1,
- * outside strings, followed by `:`), or -1. A bare `indexOf('"system"')` can
- * be hijacked by the same key inside a `tool_use.input` payload — that input
- * is embedded as real unescaped JSON, so it false-matches before the real
- * top-level key. String/escape aware, same conventions as
- * {@link completeObjectSlices}.
- *
- * @internal exported for the truncation-recovery twin in
- * canonicalisation/extractors/claudeCode.ts + unit testing
- */
-export function topLevelKeyIndex(raw: string, key: string): number {
-  const needle = `"${key}"`;
-  let depth = 0;
-  let inStr = false;
-  let esc = false;
-  for (let i = 0; i < raw.length; i++) {
-    const ch = raw[i];
-    if (inStr) {
-      if (esc) esc = false;
-      else if (ch === "\\") esc = true;
-      else if (ch === '"') inStr = false;
-      continue;
-    }
-    if (ch === '"') {
-      if (depth === 1 && raw.startsWith(needle, i)) {
-        let j = i + needle.length;
-        while (j < raw.length && /\s/.test(raw[j]!)) j++;
-        if (raw[j] === ":") return i;
-      }
-      inStr = true;
-      continue;
-    }
-    if (ch === "{" || ch === "[") depth++;
-    else if (ch === "}" || ch === "]") depth--;
-  }
-  return -1;
-}
-
-/** Read a complete JSON string literal at `quoteIndex`, or null if truncated. */
-function readJsonStringAt(raw: string, quoteIndex: number): string | null {
-  let esc = false;
-  for (let i = quoteIndex + 1; i < raw.length; i++) {
-    const ch = raw[i];
-    if (esc) {
-      esc = false;
-      continue;
-    }
-    if (ch === "\\") {
-      esc = true;
-      continue;
-    }
-    if (ch === '"') {
-      try {
-        return JSON.parse(raw.slice(quoteIndex, i + 1)) as string;
-      } catch {
-        return null;
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Yield every complete, balanced top-level `{…}` object slice at/after
- * `fromIndex`, string/escape aware, stopping at the first depth-0 `]` so a scan
- * seeded at an array does not bleed into sibling fields. A trailing object cut
- * off by truncation never balances and is never yielded.
- */
-function* completeObjectSlices(
-  raw: string,
-  fromIndex: number,
-): Generator<string> {
-  let depth = 0;
-  let start = -1;
-  let inStr = false;
-  let esc = false;
-  for (let i = fromIndex; i < raw.length; i++) {
-    const ch = raw[i];
-    if (inStr) {
-      if (esc) esc = false;
-      else if (ch === "\\") esc = true;
-      else if (ch === '"') inStr = false;
-      continue;
-    }
-    if (ch === '"') inStr = true;
-    else if (ch === "{") {
-      if (depth === 0) start = i;
-      depth++;
-    } else if (ch === "}") {
-      if (depth > 0) {
-        depth--;
-        if (depth === 0 && start >= 0) {
-          yield raw.slice(start, i + 1);
-          start = -1;
-        }
-      }
-    } else if (ch === "]" && depth === 0) {
-      return;
-    }
-  }
 }

--- a/langwatch/src/server/app-layer/traces/block-classification/claudeCodeBody.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/claudeCodeBody.ts
@@ -23,6 +23,15 @@
 export interface ClaudeCodeStructuredInput {
   messages: Array<{ role: string; content: unknown }>;
   tools: unknown;
+  /**
+   * False when the body was truncated inline, so the recovered `messages` are
+   * only the surviving leading prefix and the NEWEST turn (the tail, always the
+   * first thing truncation drops) is missing. The caller then reinstates the
+   * current turn from a clean side-channel (the co-located `user_prompt` /
+   * `gen_ai.input.messages`) so the fresh user input is not lost. True on the
+   * clean-parse path, where every turn — including the newest — survived.
+   */
+  newestTurnComplete: boolean;
 }
 
 /**
@@ -63,15 +72,20 @@ export function parseClaudeCodeRequestBody(
       }
     }
     if (messages.length === 0) return null;
-    return { messages, tools: obj.tools };
+    // Clean parse: the whole body (including the newest turn) survived.
+    return { messages, tools: obj.tools, newestTurnComplete: true };
   }
 
   // Truncated body: recover complete leading message objects + system blocks,
   // structure intact. `tools` typically sit past the truncation point, so they
   // are usually unrecoverable — acceptable (the fold has no tools content
-  // regardless); the cached prefix (system + early turns) is what matters.
+  // regardless); the cached prefix (system + early turns) is what matters. The
+  // newest turn is the tail truncation drops, so newestTurnComplete is false and
+  // the caller reinstates the current prompt from the clean side-channel.
   const messages = recoverStructuredMessages(raw);
-  return messages ? { messages, tools: undefined } : null;
+  return messages
+    ? { messages, tools: undefined, newestTurnComplete: false }
+    : null;
 }
 
 /**

--- a/langwatch/src/server/app-layer/traces/block-classification/claudeCodeBody.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/claudeCodeBody.ts
@@ -124,7 +124,7 @@ function recoverStructuredMessages(
   const system = recoverSystemValue(raw);
   if (system !== null) out.push({ role: "system", content: system });
 
-  const messagesKey = raw.indexOf('"messages"');
+  const messagesKey = topLevelKeyIndex(raw, "messages");
   if (messagesKey >= 0) {
     const arrayStart = raw.indexOf("[", messagesKey);
     if (arrayStart >= 0) {
@@ -155,7 +155,7 @@ function recoverStructuredMessages(
  * Returns null when there is no system value or nothing parses.
  */
 function recoverSystemValue(raw: string): unknown | null {
-  const key = raw.indexOf('"system"');
+  const key = topLevelKeyIndex(raw, "system");
   if (key < 0) return null;
   let i = raw.indexOf(":", key);
   if (i < 0) return null;
@@ -178,6 +178,45 @@ function recoverSystemValue(raw: string): unknown | null {
     return blocks.length > 0 ? blocks : null;
   }
   return null;
+}
+
+/**
+ * Index of `"key"` occurring as a KEY of the TOP-LEVEL object (depth 1,
+ * outside strings, followed by `:`), or -1. A bare `indexOf('"system"')` can
+ * be hijacked by the same key inside a `tool_use.input` payload — that input
+ * is embedded as real unescaped JSON, so it false-matches before the real
+ * top-level key. String/escape aware, same conventions as
+ * {@link completeObjectSlices}.
+ *
+ * @internal exported for the truncation-recovery twin in
+ * canonicalisation/extractors/claudeCode.ts + unit testing
+ */
+export function topLevelKeyIndex(raw: string, key: string): number {
+  const needle = `"${key}"`;
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === "\\") esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') {
+      if (depth === 1 && raw.startsWith(needle, i)) {
+        let j = i + needle.length;
+        while (j < raw.length && /\s/.test(raw[j]!)) j++;
+        if (raw[j] === ":") return i;
+      }
+      inStr = true;
+      continue;
+    }
+    if (ch === "{" || ch === "[") depth++;
+    else if (ch === "}" || ch === "]") depth--;
+  }
+  return -1;
 }
 
 /** Read a complete JSON string literal at `quoteIndex`, or null if truncated. */

--- a/langwatch/src/server/app-layer/traces/block-classification/claudeCodeBody.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/claudeCodeBody.ts
@@ -1,0 +1,231 @@
+/**
+ * Structured Claude Code body → classifier input (ADR-033, capture-fidelity
+ * Open Question).
+ *
+ * The Claude Code log path attaches the RAW Anthropic api_request_body /
+ * api_response_body to the span (`langwatch.claude_code.request_body` /
+ * `.response_body`). The lifted `langwatch.input` FLATTENS every message to plain
+ * text, which strips `cache_control` and collapses tool_results — so classifying
+ * from it needs a pool-inferred breakpoint and mis-types tool I/O. The raw body
+ * is higher fidelity: it keeps the content-block structure, so parsing IT gives
+ * the classifier a REAL cache_control breakpoint, correctly-typed tool_result
+ * blocks, and structured output (thinking / tool_use) — no inference needed.
+ *
+ * Truncation-tolerant: claude truncates the body inline at ~60KB, so a real turn
+ * does not JSON.parse. A string/escape-aware brace scan recovers the complete
+ * leading message objects and the front-loaded system blocks that survived the
+ * cut, WITH their block structure preserved (truncation always removes the tail).
+ *
+ * Pure: span-in / plain-object-out, no I/O.
+ */
+
+/** The classifier's input shape: Anthropic-style messages + the request tools. */
+export interface ClaudeCodeStructuredInput {
+  messages: Array<{ role: string; content: unknown }>;
+  tools: unknown;
+}
+
+/**
+ * Parse the request body into `{ role, content }` messages (system first) plus
+ * the `tools` array, preserving each message's content-block structure. Returns
+ * null when the body is absent or nothing usable survives.
+ */
+export function parseClaudeCodeRequestBody(
+  raw: unknown,
+): ClaudeCodeStructuredInput | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = null;
+  }
+
+  if (parsed && typeof parsed === "object") {
+    const obj = parsed as {
+      system?: unknown;
+      tools?: unknown;
+      messages?: unknown;
+    };
+    const messages: Array<{ role: string; content: unknown }> = [];
+    if (obj.system !== undefined) {
+      messages.push({ role: "system", content: obj.system });
+    }
+    if (Array.isArray(obj.messages)) {
+      for (const m of obj.messages) {
+        if (!m || typeof m !== "object") continue;
+        const msg = m as { role?: unknown; content?: unknown };
+        messages.push({
+          role: typeof msg.role === "string" ? msg.role : "user",
+          content: msg.content,
+        });
+      }
+    }
+    if (messages.length === 0) return null;
+    return { messages, tools: obj.tools };
+  }
+
+  // Truncated body: recover complete leading message objects + system blocks,
+  // structure intact. `tools` typically sit past the truncation point, so they
+  // are usually unrecoverable — acceptable (the fold has no tools content
+  // regardless); the cached prefix (system + early turns) is what matters.
+  const messages = recoverStructuredMessages(raw);
+  return messages ? { messages, tools: undefined } : null;
+}
+
+/**
+ * Parse the response body into a single assistant message whose content is the
+ * raw block array (`text` / `tool_use` / `thinking`), so output classifies into
+ * assistant_text / tool_call_* / thinking instead of a flat blob. Returns null
+ * when absent or unparseable (the caller then falls back to the flat output).
+ */
+export function parseClaudeCodeResponseBody(
+  raw: unknown,
+): Array<{ role: string; content: unknown }> | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // a truncated response body: caller uses the flat reply text
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const content = (parsed as { content?: unknown }).content;
+  if (!Array.isArray(content) || content.length === 0) return null;
+  return [{ role: "assistant", content }];
+}
+
+/**
+ * Recover complete `{ role, content }` message objects from a truncated request
+ * body, keeping `content` as its raw structure. The front-loaded `system` value
+ * is recovered first (string or content-block array), then the `messages` array
+ * is scanned for complete objects before the cut.
+ */
+function recoverStructuredMessages(
+  raw: string,
+): Array<{ role: string; content: unknown }> | null {
+  const out: Array<{ role: string; content: unknown }> = [];
+
+  const system = recoverSystemValue(raw);
+  if (system !== null) out.push({ role: "system", content: system });
+
+  const messagesKey = raw.indexOf('"messages"');
+  if (messagesKey >= 0) {
+    const arrayStart = raw.indexOf("[", messagesKey);
+    if (arrayStart >= 0) {
+      for (const slice of completeObjectSlices(raw, arrayStart + 1)) {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(slice);
+        } catch {
+          continue;
+        }
+        if (!parsed || typeof parsed !== "object") continue;
+        const msg = parsed as { role?: unknown; content?: unknown };
+        if (msg.content === undefined) continue;
+        out.push({
+          role: typeof msg.role === "string" ? msg.role : "user",
+          content: msg.content,
+        });
+      }
+    }
+  }
+
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * Recover the `system` value from a truncated body: a JSON string, or a
+ * content-block array (recovered block-by-block if the array itself was cut).
+ * Returns null when there is no system value or nothing parses.
+ */
+function recoverSystemValue(raw: string): unknown | null {
+  const key = raw.indexOf('"system"');
+  if (key < 0) return null;
+  let i = raw.indexOf(":", key);
+  if (i < 0) return null;
+  i++;
+  while (i < raw.length && /\s/.test(raw[i]!)) i++;
+  if (i >= raw.length) return null;
+
+  if (raw[i] === '"') {
+    return readJsonStringAt(raw, i);
+  }
+  if (raw[i] === "[") {
+    const blocks: unknown[] = [];
+    for (const slice of completeObjectSlices(raw, i + 1)) {
+      try {
+        blocks.push(JSON.parse(slice));
+      } catch {
+        // skip a block that didn't parse
+      }
+    }
+    return blocks.length > 0 ? blocks : null;
+  }
+  return null;
+}
+
+/** Read a complete JSON string literal at `quoteIndex`, or null if truncated. */
+function readJsonStringAt(raw: string, quoteIndex: number): string | null {
+  let esc = false;
+  for (let i = quoteIndex + 1; i < raw.length; i++) {
+    const ch = raw[i];
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (ch === "\\") {
+      esc = true;
+      continue;
+    }
+    if (ch === '"') {
+      try {
+        return JSON.parse(raw.slice(quoteIndex, i + 1)) as string;
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Yield every complete, balanced top-level `{…}` object slice at/after
+ * `fromIndex`, string/escape aware, stopping at the first depth-0 `]` so a scan
+ * seeded at an array does not bleed into sibling fields. A trailing object cut
+ * off by truncation never balances and is never yielded.
+ */
+function* completeObjectSlices(
+  raw: string,
+  fromIndex: number,
+): Generator<string> {
+  let depth = 0;
+  let start = -1;
+  let inStr = false;
+  let esc = false;
+  for (let i = fromIndex; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === "\\") esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') inStr = true;
+    else if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}") {
+      if (depth > 0) {
+        depth--;
+        if (depth === 0 && start >= 0) {
+          yield raw.slice(start, i + 1);
+          start = -1;
+        }
+      }
+    } else if (ch === "]" && depth === 0) {
+      return;
+    }
+  }
+}

--- a/langwatch/src/server/app-layer/traces/block-classification/costAllocation.service.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/costAllocation.service.ts
@@ -227,6 +227,48 @@ function reconcileCosts(totals: CategoryTotals, target: number): void {
 }
 
 /**
+ * Infer the cached-prefix boundary from the usage pools when the content carried
+ * NO `cache_control` marker but the provider reports cached tokens.
+ *
+ * The Claude Code log path flattens each message's content-block array to a
+ * plain string, which strips the `cache_control` markers the classifier reads to
+ * locate the boundary — so `classifyBlocks` returns a null breakpoint and, left
+ * uncorrected, the whole cache pool (often ~85% of a cached turn's input) dumps
+ * into the axis catch-all (`other_input`).
+ *
+ * The cached prefix is ALWAYS the front of the input, and its size is exactly
+ * `cacheRead + cacheCreation` provider tokens. Block token counts are local
+ * estimates on a different scale, so the boundary is placed by cumulative
+ * estimate proportional to the cached fraction of the input: the returned index
+ * is the last block whose cumulative estimate falls within that fraction, so
+ * `partitionInput` splits the cached prefix (→ cache tiers) from the fresh tail.
+ *
+ * Returns null when there is nothing to infer (no cached tokens, or no block
+ * mass) — the caller then leaves the breakpoint null (all-fresh), unchanged.
+ */
+export function inferCacheBreakpointFromPools({
+  inputBlocks,
+  pools,
+}: {
+  inputBlocks: TokenBlock[];
+  pools: UsagePools;
+}): number | null {
+  const cached = pools.cacheReadTokens + pools.cacheCreationTokens;
+  const total = cached + pools.inputTokens;
+  if (cached <= 0 || total <= 0) return null;
+  const estTotal = inputBlocks.reduce((sum, b) => sum + b.tokens, 0);
+  if (estTotal <= 0) return null;
+
+  const cachedEstTokens = (cached / total) * estTotal;
+  let running = 0;
+  for (let i = 0; i < inputBlocks.length; i++) {
+    running += inputBlocks[i]!.tokens;
+    if (running >= cachedEstTokens) return i;
+  }
+  return inputBlocks.length - 1;
+}
+
+/**
  * Split the cached prefix across the cache_read and cache_creation pools, and
  * return the fresh remainder.
  *

--- a/langwatch/src/server/app-layer/traces/block-classification/costAllocation.service.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/costAllocation.service.ts
@@ -262,6 +262,11 @@ export function inferCachedPrefixEstTokens({
   pools: UsagePools;
 }): number | null {
   const cached = pools.cacheReadTokens + pools.cacheCreationTokens;
+  // `pools.inputTokens` is the FRESH pool, provider-normalized upstream: for
+  // OpenAI/codex — whose reported input already INCLUDES the cached tokens —
+  // `extractUsagePools` subtracts the cached count, so `cached + inputTokens`
+  // here is the total context, not a double-count. Anthropic reports fresh
+  // input separately, so nothing is subtracted there.
   const total = cached + pools.inputTokens;
   if (cached <= 0 || total <= 0) return null;
   const estTotal = inputBlocks.reduce((sum, b) => sum + b.tokens, 0);

--- a/langwatch/src/server/app-layer/traces/block-classification/costAllocation.service.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/costAllocation.service.ts
@@ -110,6 +110,7 @@ export function allocateCategoryCosts({
   inputBlocks,
   outputBlocks,
   lastCacheBreakpointIndex,
+  inferredCachedPrefixEstTokens = null,
   pools,
   prices,
   reconcileToTotalCost,
@@ -117,6 +118,9 @@ export function allocateCategoryCosts({
   inputBlocks: TokenBlock[];
   outputBlocks: TokenBlock[];
   lastCacheBreakpointIndex: number | null;
+  /** Fractional cached-prefix size (estimate space) from `inferCachedPrefixEstTokens`,
+   * used only when `lastCacheBreakpointIndex` is null (no real marker survived). */
+  inferredCachedPrefixEstTokens?: number | null;
   pools: UsagePools;
   prices: TierPrices;
   /**
@@ -131,6 +135,7 @@ export function allocateCategoryCosts({
   const { cachePrefix, fresh } = partitionInput({
     inputBlocks,
     lastCacheBreakpointIndex,
+    inferredCachedPrefixEstTokens,
     cacheReadTokens: pools.cacheReadTokens,
     cacheCreationTokens: pools.cacheCreationTokens,
   });
@@ -238,15 +243,18 @@ function reconcileCosts(totals: CategoryTotals, target: number): void {
  *
  * The cached prefix is ALWAYS the front of the input, and its size is exactly
  * `cacheRead + cacheCreation` provider tokens. Block token counts are local
- * estimates on a different scale, so the boundary is placed by cumulative
- * estimate proportional to the cached fraction of the input: the returned index
- * is the last block whose cumulative estimate falls within that fraction, so
- * `partitionInput` splits the cached prefix (→ cache tiers) from the fresh tail.
+ * estimates on a different scale, so the boundary is placed by the cumulative
+ * estimate proportional to the cached fraction of the input. Returns the
+ * boundary as a FRACTIONAL position in estimate space (not a whole-block index)
+ * so `partitionInput` can split the block that straddles the cached/fresh
+ * boundary — a whole-block boundary would swallow the straddling block's fresh
+ * portion into the cached prefix, leaving the fresh pool blockless and dumping
+ * its tokens into `other_input` (and zeroing `user_input`).
  *
  * Returns null when there is nothing to infer (no cached tokens, or no block
  * mass) — the caller then leaves the breakpoint null (all-fresh), unchanged.
  */
-export function inferCacheBreakpointFromPools({
+export function inferCachedPrefixEstTokens({
   inputBlocks,
   pools,
 }: {
@@ -258,14 +266,36 @@ export function inferCacheBreakpointFromPools({
   if (cached <= 0 || total <= 0) return null;
   const estTotal = inputBlocks.reduce((sum, b) => sum + b.tokens, 0);
   if (estTotal <= 0) return null;
+  return (cached / total) * estTotal;
+}
 
-  const cachedEstTokens = (cached / total) * estTotal;
+/**
+ * Split an ordered block list at a FRACTIONAL boundary in estimate space,
+ * dividing the straddling block between the two sides (keeping idx + category on
+ * both slices). `allocatePool` later rescales each pool to its provider total, so
+ * the estimate-based split point only sets proportions, never the token totals.
+ */
+function splitBlocksAtEstBoundary(
+  blocks: TokenBlock[],
+  boundaryEst: number,
+): { before: TokenBlock[]; after: TokenBlock[] } {
+  const before: TokenBlock[] = [];
+  const after: TokenBlock[] = [];
   let running = 0;
-  for (let i = 0; i < inputBlocks.length; i++) {
-    running += inputBlocks[i]!.tokens;
-    if (running >= cachedEstTokens) return i;
+  for (const block of blocks) {
+    const blockEnd = running + block.tokens;
+    if (blockEnd <= boundaryEst) {
+      before.push(block);
+    } else if (running >= boundaryEst) {
+      after.push(block);
+    } else {
+      const beforePortion = boundaryEst - running;
+      before.push({ ...block, tokens: beforePortion });
+      after.push({ ...block, tokens: block.tokens - beforePortion });
+    }
+    running = blockEnd;
   }
-  return inputBlocks.length - 1;
+  return { before, after };
 }
 
 /**
@@ -293,68 +323,74 @@ export function inferCacheBreakpointFromPools({
 function partitionInput({
   inputBlocks,
   lastCacheBreakpointIndex,
+  inferredCachedPrefixEstTokens,
   cacheReadTokens,
   cacheCreationTokens,
 }: {
   inputBlocks: TokenBlock[];
   lastCacheBreakpointIndex: number | null;
+  /** Fractional cached-prefix size (estimate space) inferred from the pools when
+   * no real cache_control marker survived. Used only when there is no marker. */
+  inferredCachedPrefixEstTokens: number | null;
   cacheReadTokens: number;
   cacheCreationTokens: number;
 }): {
   cachePrefix: { cacheRead: TokenBlock[]; cacheCreation: TokenBlock[] };
   fresh: TokenBlock[];
 } {
-  const cacheRead: TokenBlock[] = [];
-  const cacheCreation: TokenBlock[] = [];
+  const noPrefix = () => ({
+    cachePrefix: {
+      cacheRead: [] as TokenBlock[],
+      cacheCreation: [] as TokenBlock[],
+    },
+    fresh: inputBlocks,
+  });
 
-  // A negative breakpoint is not a real prefix boundary: `slice(0, index + 1)`
-  // with e.g. index = -2 becomes `slice(0, -1)`, silently dropping the last
-  // block off the prefix. Treat any negative index as "no breakpoint".
   const hasCache = cacheReadTokens > 0 || cacheCreationTokens > 0;
-  if (
-    lastCacheBreakpointIndex === null ||
-    lastCacheBreakpointIndex < 0 ||
-    !hasCache
+  if (!hasCache) return noPrefix();
+
+  let prefix: TokenBlock[];
+  let fresh: TokenBlock[];
+  if (lastCacheBreakpointIndex !== null && lastCacheBreakpointIndex >= 0) {
+    // A REAL cache_control marker sits on a block edge, so the cached prefix is
+    // whole blocks 0..index (`slice(0, index + 1)`).
+    const prefixEnd = Math.min(
+      lastCacheBreakpointIndex + 1,
+      inputBlocks.length,
+    );
+    prefix = inputBlocks.slice(0, prefixEnd);
+    fresh = inputBlocks.slice(prefixEnd);
+  } else if (
+    inferredCachedPrefixEstTokens !== null &&
+    inferredCachedPrefixEstTokens > 0
   ) {
-    return { cachePrefix: { cacheRead, cacheCreation }, fresh: inputBlocks };
+    // No marker survived: the cached/fresh boundary is a FRACTIONAL token
+    // position, so split the straddling block between the cached prefix and the
+    // fresh tail — a whole-block boundary would swallow the block's fresh portion
+    // and leave the fresh pool blockless (→ other_input, user_input = 0 fresh).
+    const split = splitBlocksAtEstBoundary(
+      inputBlocks,
+      inferredCachedPrefixEstTokens,
+    );
+    prefix = split.before;
+    fresh = split.after;
+  } else {
+    return noPrefix();
   }
 
-  const prefixEnd = Math.min(lastCacheBreakpointIndex + 1, inputBlocks.length);
-  const prefix = inputBlocks.slice(0, prefixEnd);
-  const fresh = inputBlocks.slice(prefixEnd);
-
-  // The read/creation split point in ESTIMATE space, proportional to the
-  // provider's read share (see the SCALE HAZARD note above). When creation is 0
-  // the boundary is the whole prefix (all read); when read is 0 it is 0 (all
-  // creation) — a blockless pool then has a 0 provider total and is skipped, so
-  // nothing dumps to the catch-all.
+  // Within the cached prefix, split read/creation by the provider's read share
+  // (see the SCALE HAZARD note above). When creation is 0 the boundary is the
+  // whole prefix (all read); when read is 0 it is 0 (all creation).
   const cacheTotalTokens = cacheReadTokens + cacheCreationTokens;
   const estPrefixTokens = prefix.reduce((sum, b) => sum + b.tokens, 0);
   const readBoundary =
     cacheTotalTokens > 0
       ? (cacheReadTokens / cacheTotalTokens) * estPrefixTokens
       : estPrefixTokens;
-
-  let running = 0;
-  for (const block of prefix) {
-    const blockEnd = running + block.tokens;
-    if (blockEnd <= readBoundary) {
-      // Entirely within the cache_read share.
-      cacheRead.push(block);
-    } else if (running >= readBoundary) {
-      // Starts at/after the boundary — entirely cache_creation.
-      cacheCreation.push(block);
-    } else {
-      // Straddles the boundary: split at it so neither pool is left blockless.
-      // Both slices keep idx + category; allocatePool rescales each pool to its
-      // provider total, so the estimate-based split point only sets the tier
-      // proportions, never the final token totals.
-      const readPortion = readBoundary - running;
-      cacheRead.push({ ...block, tokens: readPortion });
-      cacheCreation.push({ ...block, tokens: block.tokens - readPortion });
-    }
-    running = blockEnd;
-  }
+  const { before: cacheRead, after: cacheCreation } = splitBlocksAtEstBoundary(
+    prefix,
+    readBoundary,
+  );
 
   return { cachePrefix: { cacheRead, cacheCreation }, fresh };
 }

--- a/langwatch/src/server/app-layer/traces/block-classification/freshTurnPresence.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/freshTurnPresence.ts
@@ -8,9 +8,16 @@
  * A bare `includes` is not enough: short prompts ("ok", "continue") appear
  * as substrings inside file dumps and reminder prose all the time, which
  * suppressed reinstatement and made the newest turn vanish. The prompt only
- * counts as present when an occurrence is LINE-ALIGNED — it starts at the
- * beginning of a line and ends at the end of one — which is how a prompt
- * that genuinely survived as its own message/part appears in flattened text.
+ * counts as present when an occurrence is LINE-ALIGNED — its line contains only
+ * the prompt plus surrounding whitespace — which is how a prompt that genuinely
+ * survived as its own message/part appears in flattened text.
+ *
+ * `needle` is trimmed but the surviving line may be indented or trailing-padded,
+ * so alignment tolerates leading/trailing WHITESPACE on the match's own line
+ * (not just a bare `\n` boundary) — otherwise a padded but genuinely-present
+ * prompt reads as absent and gets appended twice, distorting classification.
+ * Non-whitespace on either side of the match on the same line still means a
+ * mid-line substring, which does NOT count (the original false-positive guard).
  */
 export function textContainsPromptLineAligned(
   text: string,
@@ -20,15 +27,32 @@ export function textContainsPromptLineAligned(
   if (needle.length === 0) return false;
   let idx = text.indexOf(needle);
   while (idx !== -1) {
-    const startAligned = idx === 0 || text[idx - 1] === "\n";
-    const endIdx = idx + needle.length;
-    const endAligned =
-      endIdx === text.length ||
-      text[endIdx] === "\n" ||
-      // A trailing \r before the newline (CRLF content) still ends the line.
-      (text[endIdx] === "\r" && text[endIdx + 1] === "\n");
-    if (startAligned && endAligned) return true;
+    if (isLineStart(text, idx) && isLineEnd(text, idx + needle.length)) {
+      return true;
+    }
     idx = text.indexOf(needle, idx + 1);
   }
   return false;
+}
+
+/** True when only whitespace sits between `idx` and the preceding newline (or
+ * the start of the text) — the match begins its own (possibly indented) line. */
+function isLineStart(text: string, idx: number): boolean {
+  for (let i = idx - 1; i >= 0; i--) {
+    const ch = text[i];
+    if (ch === "\n") return true;
+    if (ch !== " " && ch !== "\t" && ch !== "\r") return false;
+  }
+  return true;
+}
+
+/** True when only whitespace sits between `idx` and the next newline (or the end
+ * of the text) — the match ends its own line (trailing padding / CRLF included). */
+function isLineEnd(text: string, idx: number): boolean {
+  for (let i = idx; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === "\n") return true;
+    if (ch !== " " && ch !== "\t" && ch !== "\r") return false;
+  }
+  return true;
 }

--- a/langwatch/src/server/app-layer/traces/block-classification/freshTurnPresence.ts
+++ b/langwatch/src/server/app-layer/traces/block-classification/freshTurnPresence.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared "did the fresh user prompt already survive in the recovered prefix?"
+ * predicate for truncated-body recovery. Both consumers (the log-to-span
+ * converter's `gen_ai.input.messages` reinstatement and the classifier's
+ * `appendFreshTurnIfTruncated`) must judge presence identically or the
+ * display and the classification drift.
+ *
+ * A bare `includes` is not enough: short prompts ("ok", "continue") appear
+ * as substrings inside file dumps and reminder prose all the time, which
+ * suppressed reinstatement and made the newest turn vanish. The prompt only
+ * counts as present when an occurrence is LINE-ALIGNED — it starts at the
+ * beginning of a line and ends at the end of one — which is how a prompt
+ * that genuinely survived as its own message/part appears in flattened text.
+ */
+export function textContainsPromptLineAligned(
+  text: string,
+  prompt: string,
+): boolean {
+  const needle = prompt.trim();
+  if (needle.length === 0) return false;
+  let idx = text.indexOf(needle);
+  while (idx !== -1) {
+    const startAligned = idx === 0 || text[idx - 1] === "\n";
+    const endIdx = idx + needle.length;
+    const endAligned =
+      endIdx === text.length ||
+      text[endIdx] === "\n" ||
+      // A trailing \r before the newline (CRLF content) still ends the line.
+      (text[endIdx] === "\r" && text[endIdx + 1] === "\n");
+    if (startAligned && endAligned) return true;
+    idx = text.indexOf(needle, idx + 1);
+  }
+  return false;
+}

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/claudeCode.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/claudeCode.unit.test.ts
@@ -8,6 +8,7 @@ import {
   extractAssistantTextFromResponseBody,
   extractUserTextFromRequestBody,
   isConversationalQuerySource,
+  recoverInputMessagesFromTruncatedBody,
 } from "../claudeCode";
 import { createLogExtractorContext } from "./_testHelpers";
 
@@ -287,19 +288,92 @@ describe("buildInputMessagesFromRequestBody (exported helper)", () => {
     ]);
   });
 
-  it("returns null for truncated / malformed / message-less bodies", () => {
+  it("returns null for empty / message-less bodies", () => {
     expect(buildInputMessagesFromRequestBody(undefined)).toBeNull();
     expect(buildInputMessagesFromRequestBody("")).toBeNull();
-    // claude truncates large request bodies inline -> invalid JSON tail.
-    expect(
-      buildInputMessagesFromRequestBody('{"model":"x","messages":[{"role":"u'),
-    ).toBeNull();
     expect(buildInputMessagesFromRequestBody(JSON.stringify({}))).toBeNull();
     // messages present but every turn flattens to empty -> null.
     expect(
       buildInputMessagesFromRequestBody(
         JSON.stringify({ messages: [{ role: "user", content: [] }] }),
       ),
+    ).toBeNull();
+    // Truncated before any complete turn and no system -> nothing to recover.
+    expect(
+      buildInputMessagesFromRequestBody('{"model":"x","messages":[{"role":"u'),
+    ).toBeNull();
+  });
+
+  it("recovers system + complete leading turns from a body truncated in the last turn", () => {
+    // The real failure mode: claude cut the ~60KB body inside the newest turn.
+    // The front-loaded system prompt and the earlier complete turns survive and
+    // must be recovered so the cost classifier does not strand the cached prefix
+    // in other_input.
+    const full = JSON.stringify({
+      model: "claude-fable-5",
+      system: [
+        {
+          type: "text",
+          text: "You are helpful",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [
+        { role: "user", content: "first question" },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "first answer" }],
+        },
+        { role: "user", content: "second question, now cut off partway" },
+      ],
+    });
+    const truncated = full.slice(0, full.indexOf("second question") + 6);
+
+    expect(buildInputMessagesFromRequestBody(truncated)).toEqual([
+      { role: "system", content: "You are helpful" },
+      { role: "user", content: "first question" },
+      { role: "assistant", content: "first answer" },
+      // the truncated third turn never balances and is dropped
+    ]);
+  });
+});
+
+describe("recoverInputMessagesFromTruncatedBody (exported helper)", () => {
+  it("recovers complete leading system blocks when the system array itself is cut", () => {
+    const full = JSON.stringify({
+      system: [
+        { type: "text", text: "block one" },
+        { type: "text", text: "block two, cut here somewhere long" },
+      ],
+      messages: [{ role: "user", content: "go" }],
+    });
+    // Cut inside the SECOND system block's text (before it closes).
+    const truncated = full.slice(0, full.indexOf("cut here"));
+
+    expect(recoverInputMessagesFromTruncatedBody(truncated)).toEqual([
+      { role: "system", content: "block one" },
+    ]);
+  });
+
+  it("keeps brace/quote characters inside content from corrupting the scan", () => {
+    const full = JSON.stringify({
+      messages: [
+        { role: "user", content: 'a message with { braces } and a "quote"' },
+        { role: "assistant", content: "clean reply" },
+        { role: "user", content: "cut here" },
+      ],
+    });
+    const truncated = full.slice(0, full.indexOf("cut here") + 3);
+
+    expect(recoverInputMessagesFromTruncatedBody(truncated)).toEqual([
+      { role: "user", content: 'a message with { braces } and a "quote"' },
+      { role: "assistant", content: "clean reply" },
+    ]);
+  });
+
+  it("returns null when nothing complete survives", () => {
+    expect(
+      recoverInputMessagesFromTruncatedBody('{"messages":[{"role":"u'),
     ).toBeNull();
   });
 });
@@ -309,7 +383,12 @@ describe("extractAssistantOutputFromResponseBody", () => {
     const body = JSON.stringify({
       content: [
         { type: "text", text: "Let me check." },
-        { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "ls /tmp" } },
+        {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "Bash",
+          input: { command: "ls /tmp" },
+        },
       ],
     });
     const out = extractAssistantOutputFromResponseBody(body) ?? "";
@@ -319,7 +398,9 @@ describe("extractAssistantOutputFromResponseBody", () => {
   });
 
   it("matches the text-only extractor for a plain text reply", () => {
-    const body = JSON.stringify({ content: [{ type: "text", text: "PONG-Z" }] });
+    const body = JSON.stringify({
+      content: [{ type: "text", text: "PONG-Z" }],
+    });
     expect(extractAssistantOutputFromResponseBody(body)).toBe("PONG-Z");
     expect(extractAssistantTextFromResponseBody(body)).toBe("PONG-Z");
   });
@@ -347,7 +428,9 @@ describe("collectToolResultsFromRequestBody", () => {
       messages: [
         {
           role: "assistant",
-          content: [{ type: "tool_use", id: "toolu_a", name: "Bash", input: {} }],
+          content: [
+            { type: "tool_use", id: "toolu_a", name: "Bash", input: {} },
+          ],
         },
         { role: "user", content: [bashResult("toolu_a", "       0")] },
       ],
@@ -385,14 +468,21 @@ describe("collectToolResultsFromRequestBody", () => {
       messages: [
         {
           role: "assistant",
-          content: [{ type: "tool_use", id: "toolu_first", name: "Bash", input: {} }],
+          content: [
+            { type: "tool_use", id: "toolu_first", name: "Bash", input: {} },
+          ],
         },
         { role: "user", content: [bashResult("toolu_first", "first-result")] },
         {
           role: "assistant",
-          content: [{ type: "tool_use", id: "toolu_last", name: "Bash", input: {} }],
+          content: [
+            { type: "tool_use", id: "toolu_last", name: "Bash", input: {} },
+          ],
         },
-        { role: "user", content: [bashResult("toolu_last", "SECOND_RESULT_CUT_HERE")] },
+        {
+          role: "user",
+          content: [bashResult("toolu_last", "SECOND_RESULT_CUT_HERE")],
+        },
       ],
     });
     const truncated = full.slice(0, full.indexOf("SECOND_RESULT_CUT_HERE") + 6);

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts
@@ -36,7 +36,11 @@
  */
 
 import { capPayloadString } from "~/server/event-sourcing/pipelines/trace-processing/utils/capOversizedLogRecord";
-import { topLevelKeyIndex } from "../../block-classification/claudeCodeBody";
+import {
+  completeObjectSlices,
+  readJsonStringAt,
+  topLevelKeyIndex,
+} from "../../truncated-json-scan";
 
 import type {
   CanonicalAttributesExtractor,
@@ -611,76 +615,6 @@ function recoverSystemText(raw: string): string | null {
     return parts.length > 0 ? parts.join("\n\n") : null;
   }
   return null;
-}
-
-/**
- * Read a complete JSON string literal starting at `quoteIndex` (which must point
- * at the opening `"`), honouring escapes. Returns the unescaped value, or null
- * when the string was cut off by truncation (no closing quote).
- */
-function readJsonStringAt(raw: string, quoteIndex: number): string | null {
-  let esc = false;
-  for (let i = quoteIndex + 1; i < raw.length; i++) {
-    const ch = raw[i];
-    if (esc) {
-      esc = false;
-      continue;
-    }
-    if (ch === "\\") {
-      esc = true;
-      continue;
-    }
-    if (ch === '"') {
-      try {
-        return JSON.parse(raw.slice(quoteIndex, i + 1)) as string;
-      } catch {
-        return null;
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Yield every COMPLETE, balanced top-level `{…}` object slice at/after
- * `fromIndex`, tracking string/escape state so braces inside string values do
- * not corrupt the depth count. Stops at the first depth-0 `]` (the end of the
- * enclosing array) so a scan seeded at a `messages`/`system` array does not
- * bleed into sibling fields. A trailing object cut off by truncation never
- * balances and is never yielded.
- */
-function* completeObjectSlices(
-  raw: string,
-  fromIndex: number,
-): Generator<string> {
-  let depth = 0;
-  let start = -1;
-  let inStr = false;
-  let esc = false;
-  for (let i = fromIndex; i < raw.length; i++) {
-    const ch = raw[i];
-    if (inStr) {
-      if (esc) esc = false;
-      else if (ch === "\\") esc = true;
-      else if (ch === '"') inStr = false;
-      continue;
-    }
-    if (ch === '"') inStr = true;
-    else if (ch === "{") {
-      if (depth === 0) start = i;
-      depth++;
-    } else if (ch === "}") {
-      if (depth > 0) {
-        depth--;
-        if (depth === 0 && start >= 0) {
-          yield raw.slice(start, i + 1);
-          start = -1;
-        }
-      }
-    } else if (ch === "]" && depth === 0) {
-      return;
-    }
-  }
 }
 
 export function extractUserTextFromRequestBody(raw: unknown): string | null {

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts
@@ -248,7 +248,11 @@ export function extractAssistantOutputFromResponseBody(
         block.input !== undefined && block.input !== null
           ? safeStringify(block.input)
           : "";
-      parts.push(args ? `[tool_use: ${block.name}]\n${args}` : `[tool_use: ${block.name}]`);
+      parts.push(
+        args
+          ? `[tool_use: ${block.name}]\n${args}`
+          : `[tool_use: ${block.name}]`,
+      );
     }
   }
   if (parts.length === 0) return null;
@@ -305,7 +309,11 @@ function collectToolResultBlocks(
   if (!Array.isArray(content)) return;
   for (const block of content) {
     if (!block || typeof block !== "object") continue;
-    const b = block as { type?: unknown; tool_use_id?: unknown; content?: unknown };
+    const b = block as {
+      type?: unknown;
+      tool_use_id?: unknown;
+      content?: unknown;
+    };
     if (b.type !== "tool_result") continue;
     if (typeof b.tool_use_id !== "string" || b.tool_use_id.length === 0) {
       continue;
@@ -355,7 +363,11 @@ function scanToolResultsFromTruncatedBody(
         continue;
       }
       if (!obj || typeof obj !== "object") continue;
-      const b = obj as { type?: unknown; tool_use_id?: unknown; content?: unknown };
+      const b = obj as {
+        type?: unknown;
+        tool_use_id?: unknown;
+        content?: unknown;
+      };
       if (b.type !== "tool_result") continue;
       if (typeof b.tool_use_id !== "string" || b.tool_use_id.length === 0) {
         continue;
@@ -450,15 +462,26 @@ export function buildInputMessagesFromRequestBody(
   raw: unknown,
 ): Array<{ role: string; content: string }> | null {
   if (raw === null || raw === undefined) return null;
-  let parsed: unknown = raw;
-  if (typeof raw === "string") {
-    if (raw.length === 0) return null;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      return null;
-    }
+  if (typeof raw === "object") return buildFromParsedRequestBody(raw);
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  try {
+    return buildFromParsedRequestBody(JSON.parse(raw));
+  } catch {
+    // claude truncates large request bodies INLINE at ~60KB, so a real
+    // coding-agent turn (system + tools + history) does NOT JSON.parse. Rather
+    // than falling back to just the latest user turn — which strands the whole
+    // cached prefix (system prompt + tool defs), leaving the cost classifier to
+    // dump those tokens into `other_input` — recover what survived the cut.
+    // Truncation always removes the TAIL, so the front-loaded system prompt and
+    // the complete leading turns are intact.
+    return recoverInputMessagesFromTruncatedBody(raw);
   }
+}
+
+/** Build the canonical input-message array from an already-parsed request body. */
+function buildFromParsedRequestBody(
+  parsed: unknown,
+): Array<{ role: string; content: string }> | null {
   if (!parsed || typeof parsed !== "object") return null;
   const obj = parsed as { system?: unknown; messages?: unknown };
   if (!Array.isArray(obj.messages)) return null;
@@ -482,6 +505,155 @@ export function buildInputMessagesFromRequestBody(
   }
 
   return out.length > 0 ? out : null;
+}
+
+/**
+ * Recover input messages from a body claude truncated inline (invalid JSON).
+ * Best-effort, string-aware: pulls the `system` value (string or content-block
+ * array) plus every COMPLETE `{ role, content }` message object present before
+ * the truncation point. An incompletely-written trailing object never balances,
+ * so it is simply skipped. Returns null when nothing usable survives (caller
+ * then falls back to the clean co-located `user_prompt`).
+ *
+ * @internal exported for unit testing only
+ */
+export function recoverInputMessagesFromTruncatedBody(
+  raw: string,
+): Array<{ role: string; content: string }> | null {
+  const out: Array<{ role: string; content: string }> = [];
+
+  const systemText = recoverSystemText(raw);
+  if (systemText && systemText.length > 0) {
+    out.push({ role: "system", content: systemText });
+  }
+
+  const messagesKey = raw.indexOf('"messages"');
+  if (messagesKey >= 0) {
+    const arrayStart = raw.indexOf("[", messagesKey);
+    if (arrayStart >= 0) {
+      for (const slice of completeObjectSlices(raw, arrayStart + 1)) {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(slice);
+        } catch {
+          continue;
+        }
+        if (!parsed || typeof parsed !== "object") continue;
+        const message = parsed as { role?: unknown; content?: unknown };
+        const role = typeof message.role === "string" ? message.role : "user";
+        const content = contentToText(message.content);
+        if (content.length === 0) continue;
+        out.push({ role, content });
+      }
+    }
+  }
+
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * Recover the `system` field's text from a truncated body. Anthropic sends
+ * `system` as a string OR an array of `{ type: "text", text }` blocks (with
+ * cache_control); both shapes are handled. When the value is an array, complete
+ * blocks are flattened even if the array itself was cut off before its closing
+ * `]`. Returns null when no `system` value is present or nothing parses.
+ */
+function recoverSystemText(raw: string): string | null {
+  const key = raw.indexOf('"system"');
+  if (key < 0) return null;
+  let i = raw.indexOf(":", key);
+  if (i < 0) return null;
+  i++;
+  while (i < raw.length && /\s/.test(raw[i]!)) i++;
+  if (i >= raw.length) return null;
+
+  if (raw[i] === '"') {
+    return readJsonStringAt(raw, i);
+  }
+  if (raw[i] === "[") {
+    const parts: string[] = [];
+    for (const slice of completeObjectSlices(raw, i + 1)) {
+      try {
+        const block = JSON.parse(slice);
+        const text = contentToText([block]);
+        if (text.length > 0) parts.push(text);
+      } catch {
+        // skip a block that didn't parse
+      }
+    }
+    return parts.length > 0 ? parts.join("\n\n") : null;
+  }
+  return null;
+}
+
+/**
+ * Read a complete JSON string literal starting at `quoteIndex` (which must point
+ * at the opening `"`), honouring escapes. Returns the unescaped value, or null
+ * when the string was cut off by truncation (no closing quote).
+ */
+function readJsonStringAt(raw: string, quoteIndex: number): string | null {
+  let esc = false;
+  for (let i = quoteIndex + 1; i < raw.length; i++) {
+    const ch = raw[i];
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (ch === "\\") {
+      esc = true;
+      continue;
+    }
+    if (ch === '"') {
+      try {
+        return JSON.parse(raw.slice(quoteIndex, i + 1)) as string;
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Yield every COMPLETE, balanced top-level `{…}` object slice at/after
+ * `fromIndex`, tracking string/escape state so braces inside string values do
+ * not corrupt the depth count. Stops at the first depth-0 `]` (the end of the
+ * enclosing array) so a scan seeded at a `messages`/`system` array does not
+ * bleed into sibling fields. A trailing object cut off by truncation never
+ * balances and is never yielded.
+ */
+function* completeObjectSlices(
+  raw: string,
+  fromIndex: number,
+): Generator<string> {
+  let depth = 0;
+  let start = -1;
+  let inStr = false;
+  let esc = false;
+  for (let i = fromIndex; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === "\\") esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') inStr = true;
+    else if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}") {
+      if (depth > 0) {
+        depth--;
+        if (depth === 0 && start >= 0) {
+          yield raw.slice(start, i + 1);
+          start = -1;
+        }
+      }
+    } else if (ch === "]" && depth === 0) {
+      return;
+    }
+  }
 }
 
 export function extractUserTextFromRequestBody(raw: unknown): string | null {

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/claudeCode.ts
@@ -36,6 +36,7 @@
  */
 
 import { capPayloadString } from "~/server/event-sourcing/pipelines/trace-processing/utils/capOversizedLogRecord";
+import { topLevelKeyIndex } from "../../block-classification/claudeCodeBody";
 
 import type {
   CanonicalAttributesExtractor,
@@ -461,11 +462,34 @@ function contentToText(content: unknown): string {
 export function buildInputMessagesFromRequestBody(
   raw: unknown,
 ): Array<{ role: string; content: string }> | null {
-  if (raw === null || raw === undefined) return null;
-  if (typeof raw === "object") return buildFromParsedRequestBody(raw);
-  if (typeof raw !== "string" || raw.length === 0) return null;
+  return buildInputMessagesFromRequestBodyDetailed(raw).messages;
+}
+
+/**
+ * Like {@link buildInputMessagesFromRequestBody}, but also reports whether the
+ * truncation-recovery path was taken (`recovered`). Callers that reinstate the
+ * fresh user turn must gate on THIS rather than the `body_truncated` attribute:
+ * a body over LangWatch's own oversize cap fails JSON.parse the same way, but
+ * claude never stamped `body_truncated` on it.
+ */
+export function buildInputMessagesFromRequestBodyDetailed(raw: unknown): {
+  messages: Array<{ role: string; content: string }> | null;
+  recovered: boolean;
+} {
+  if (raw === null || raw === undefined) {
+    return { messages: null, recovered: false };
+  }
+  if (typeof raw === "object") {
+    return { messages: buildFromParsedRequestBody(raw), recovered: false };
+  }
+  if (typeof raw !== "string" || raw.length === 0) {
+    return { messages: null, recovered: false };
+  }
   try {
-    return buildFromParsedRequestBody(JSON.parse(raw));
+    return {
+      messages: buildFromParsedRequestBody(JSON.parse(raw)),
+      recovered: false,
+    };
   } catch {
     // claude truncates large request bodies INLINE at ~60KB, so a real
     // coding-agent turn (system + tools + history) does NOT JSON.parse. Rather
@@ -474,7 +498,10 @@ export function buildInputMessagesFromRequestBody(
     // dump those tokens into `other_input` — recover what survived the cut.
     // Truncation always removes the TAIL, so the front-loaded system prompt and
     // the complete leading turns are intact.
-    return recoverInputMessagesFromTruncatedBody(raw);
+    return {
+      messages: recoverInputMessagesFromTruncatedBody(raw),
+      recovered: true,
+    };
   }
 }
 
@@ -527,7 +554,7 @@ export function recoverInputMessagesFromTruncatedBody(
     out.push({ role: "system", content: systemText });
   }
 
-  const messagesKey = raw.indexOf('"messages"');
+  const messagesKey = topLevelKeyIndex(raw, "messages");
   if (messagesKey >= 0) {
     const arrayStart = raw.indexOf("[", messagesKey);
     if (arrayStart >= 0) {
@@ -559,7 +586,7 @@ export function recoverInputMessagesFromTruncatedBody(
  * `]`. Returns null when no `system` value is present or nothing parses.
  */
 function recoverSystemText(raw: string): string | null {
-  const key = raw.indexOf('"system"');
+  const key = topLevelKeyIndex(raw, "system");
   if (key < 0) return null;
   let i = raw.indexOf(":", key);
   if (i < 0) return null;

--- a/langwatch/src/server/app-layer/traces/claude-code-log-to-span.ts
+++ b/langwatch/src/server/app-layer/traces/claude-code-log-to-span.ts
@@ -455,12 +455,24 @@ function resolveInputMessages(
   promptTextById: ReadonlyMap<string, string>,
 ): string | null {
   const parsed = buildInputMessagesFromRequestBody(body.attrs.body);
+  const freshPrompt = asNonEmpty(
+    promptTextById.get(body.attrs["prompt.id"] ?? ""),
+  );
   let messages: Array<{ role: string; content: string }> | null = parsed;
   if (!messages) {
-    const fallback = asNonEmpty(
-      promptTextById.get(body.attrs["prompt.id"] ?? ""),
+    messages = freshPrompt ? [{ role: "user", content: freshPrompt }] : null;
+  } else if (freshPrompt && body.attrs.body_truncated === "true") {
+    // Truncation drops the TAIL, so a recovered conversation is missing the
+    // newest (current) user turn. Reinstate the clean co-located user_prompt as
+    // that final turn — but only when it did not already survive in the prefix
+    // (a mid-turn call keeps the prompt as early prior context and truncated
+    // only the trailing tool_results), so we never duplicate the human prompt.
+    const alreadyPresent = messages.some(
+      (m) => m.role === "user" && m.content.includes(freshPrompt),
     );
-    messages = fallback ? [{ role: "user", content: fallback }] : null;
+    if (!alreadyPresent) {
+      messages = [...messages, { role: "user", content: freshPrompt }];
+    }
   }
   if (!messages) return null;
   const capped = messages.map((m) => ({

--- a/langwatch/src/server/app-layer/traces/claude-code-log-to-span.ts
+++ b/langwatch/src/server/app-layer/traces/claude-code-log-to-span.ts
@@ -67,9 +67,10 @@ import type {
   OtlpResource,
   OtlpSpan,
 } from "../../event-sourcing/pipelines/trace-processing/schemas/otlp";
+import { textContainsPromptLineAligned } from "./block-classification/freshTurnPresence";
 import { ATTR_KEYS } from "./canonicalisation/extractors/_constants";
 import {
-  buildInputMessagesFromRequestBody,
+  buildInputMessagesFromRequestBodyDetailed,
   collectToolResultsFromRequestBody,
   extractAssistantOutputFromResponseBody,
   isConversationalQuerySource,
@@ -454,21 +455,29 @@ function resolveInputMessages(
   body: ClaudeCodeLogRecordInput,
   promptTextById: ReadonlyMap<string, string>,
 ): string | null {
-  const parsed = buildInputMessagesFromRequestBody(body.attrs.body);
+  // Gate reinstatement on the recovery path actually running, not the
+  // `body_truncated` attribute: a body over LangWatch's own oversize cap fails
+  // JSON.parse the same way but claude never stamped the attribute.
+  const { messages: parsed, recovered } =
+    buildInputMessagesFromRequestBodyDetailed(body.attrs.body);
   const freshPrompt = asNonEmpty(
     promptTextById.get(body.attrs["prompt.id"] ?? ""),
   );
   let messages: Array<{ role: string; content: string }> | null = parsed;
   if (!messages) {
     messages = freshPrompt ? [{ role: "user", content: freshPrompt }] : null;
-  } else if (freshPrompt && body.attrs.body_truncated === "true") {
+  } else if (freshPrompt && recovered) {
     // Truncation drops the TAIL, so a recovered conversation is missing the
     // newest (current) user turn. Reinstate the clean co-located user_prompt as
     // that final turn — but only when it did not already survive in the prefix
     // (a mid-turn call keeps the prompt as early prior context and truncated
     // only the trailing tool_results), so we never duplicate the human prompt.
+    // Presence must be LINE-ALIGNED: a bare substring check suppressed short
+    // prompts ("ok", "continue") that appear inside recovered file dumps.
     const alreadyPresent = messages.some(
-      (m) => m.role === "user" && m.content.includes(freshPrompt),
+      (m) =>
+        m.role === "user" &&
+        textContainsPromptLineAligned(m.content, freshPrompt),
     );
     if (!alreadyPresent) {
       messages = [...messages, { role: "user", content: freshPrompt }];

--- a/langwatch/src/server/app-layer/traces/model-cost-matching.ts
+++ b/langwatch/src/server/app-layer/traces/model-cost-matching.ts
@@ -17,31 +17,55 @@ export interface CustomTierRates {
 
 /**
  * Resolve the custom per-token rate override (`computeSpanCost` Priority 1) from
- * a rate accessor, or `null` when the span carries no custom rate. A missing
- * cache rate falls back to the input rate (counted, not discounted).
+ * a rate accessor, or `null` when the span carries no custom rate.
+ *
+ * A custom override is often ONE-SIDED — a customer prices, say, only their
+ * input rate and leaves output unset. Zeroing the unset tiers would silently
+ * make those tokens free (under-billing on display AND in the block-cost split),
+ * so an unset tier falls back per-tier: to the registry rate for the model when
+ * one is known (`registryFallback`), else to the input rate for the cache tiers
+ * (counted, not discounted), else 0. The registry fallback is computed lazily
+ * and only when a tier is actually missing.
  *
  * Single source of the P1 cascade so the two consumers — `computeSpanCost`
  * (which multiplies these by usage to get the span cost) and the block-cost
  * allocator's per-tier pricing (which reconciles Σ per-category cost to that
- * same span cost) — cannot drift. The accessor abstracts over the caller's
- * attribute shape (`NormalizedAttributes` map vs an OTLP span lookup).
+ * same span cost) — cannot drift. BOTH must pass the SAME `registryFallback`, or
+ * the display and the allocation would price the unset tiers differently and
+ * break conservation. The accessor abstracts over the caller's attribute shape
+ * (`NormalizedAttributes` map vs an OTLP span lookup).
  */
 export function resolveCustomTierRates(
   getRate: (key: string) => number | null,
+  registryFallback?: () => Partial<CustomTierRates> | null,
 ): CustomTierRates | null {
   const customInput = getRate(ATTR_KEYS.LANGWATCH_MODEL_INPUT_COST_PER_TOKEN);
   const customOutput = getRate(ATTR_KEYS.LANGWATCH_MODEL_OUTPUT_COST_PER_TOKEN);
   if (customInput === null && customOutput === null) return null;
 
-  const inputRate = customInput ?? 0;
+  const customCacheRead = getRate(
+    ATTR_KEYS.LANGWATCH_MODEL_CACHE_READ_COST_PER_TOKEN,
+  );
+  const customCacheCreation = getRate(
+    ATTR_KEYS.LANGWATCH_MODEL_CACHE_CREATION_COST_PER_TOKEN,
+  );
+
+  // Compute the registry rates once, and only if some tier is actually unset.
+  const needsFallback =
+    customInput === null ||
+    customOutput === null ||
+    customCacheRead === null ||
+    customCacheCreation === null;
+  const fb = needsFallback ? (registryFallback?.() ?? null) : null;
+
+  const inputRate = customInput ?? fb?.inputCostPerToken ?? 0;
   return {
     inputCostPerToken: inputRate,
-    outputCostPerToken: customOutput ?? 0,
+    outputCostPerToken: customOutput ?? fb?.outputCostPerToken ?? 0,
     cacheReadCostPerToken:
-      getRate(ATTR_KEYS.LANGWATCH_MODEL_CACHE_READ_COST_PER_TOKEN) ?? inputRate,
+      customCacheRead ?? fb?.cacheReadCostPerToken ?? inputRate,
     cacheCreationCostPerToken:
-      getRate(ATTR_KEYS.LANGWATCH_MODEL_CACHE_CREATION_COST_PER_TOKEN) ??
-      inputRate,
+      customCacheCreation ?? fb?.cacheCreationCostPerToken ?? inputRate,
   };
 }
 
@@ -110,11 +134,22 @@ export function computeSpanCost({
       0,
   );
 
-  // Priority 1: Custom cost rates from enrichment. A custom cost may carry
-  // its own cache rates (customer override); when it does not, cache tokens
-  // fall back to the input rate (counted, just not discounted).
-  const customRates = resolveCustomTierRates((key) =>
-    coerceToNumber(attrs[key]),
+  const resolvedModel =
+    model ??
+    (typeof attrs[ATTR_KEYS.GEN_AI_RESPONSE_MODEL] === "string"
+      ? (attrs[ATTR_KEYS.GEN_AI_RESPONSE_MODEL] as string)
+      : undefined) ??
+    (typeof attrs[ATTR_KEYS.GEN_AI_REQUEST_MODEL] === "string"
+      ? (attrs[ATTR_KEYS.GEN_AI_REQUEST_MODEL] as string)
+      : undefined);
+
+  // Priority 1: Custom cost rates from enrichment. A one-sided override fills
+  // its unset tiers from the registry rate for this model (see
+  // resolveCustomTierRates) rather than zeroing them — the SAME fallback the
+  // block-cost allocator passes, so display and per-category cost stay conserved.
+  const customRates = resolveCustomTierRates(
+    (key) => coerceToNumber(attrs[key]),
+    resolvedModel ? () => resolveRegistryTierRates(resolvedModel) : undefined,
   );
   if (customRates) {
     return (
@@ -135,15 +170,6 @@ export function computeSpanCost({
   if (numSpanCost !== null && numSpanCost > 0) return numSpanCost;
 
   // Priority 3: Static model registry with fallbacks
-  const resolvedModel =
-    model ??
-    (typeof attrs[ATTR_KEYS.GEN_AI_RESPONSE_MODEL] === "string"
-      ? (attrs[ATTR_KEYS.GEN_AI_RESPONSE_MODEL] as string)
-      : undefined) ??
-    (typeof attrs[ATTR_KEYS.GEN_AI_REQUEST_MODEL] === "string"
-      ? (attrs[ATTR_KEYS.GEN_AI_REQUEST_MODEL] as string)
-      : undefined);
-
   if (
     resolvedModel &&
     (inputTokens > 0 ||

--- a/langwatch/src/server/app-layer/traces/session-rollup/__tests__/sessionSteps.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/session-rollup/__tests__/sessionSteps.unit.test.ts
@@ -54,7 +54,7 @@ describe("appendSessionStep", () => {
 
   describe("given a series at the cap", () => {
     describe("when appending would exceed MAX_SESSION_STEPS", () => {
-      it("merges adjacent pairs keeping the larger input size, halving resolution", () => {
+      it("halves by min/max decimation, keeping BOTH peaks and valleys", () => {
         const attributes: Record<string, string> = {};
         // Fill exactly to the cap: sawtooth 100, 200, 100, 200, ...
         for (let i = 0; i < MAX_SESSION_STEPS; i++) {
@@ -69,7 +69,7 @@ describe("appendSessionStep", () => {
           MAX_SESSION_STEPS,
         );
 
-        // One more append trips the merge.
+        // One more append trips the downsample.
         appendSessionStep({
           attributes,
           harness: "claude",
@@ -78,13 +78,15 @@ describe("appendSessionStep", () => {
         });
 
         const merged = parseSessionSteps(attributes[SESSION_STEPS_ATTR]);
-        // 513 entries → ceil(513 / 2) = 257 after pairwise merge.
+        // 513 entries → 128 four-step buckets (each emits its 100 min + 200 max)
+        // + the trailing 999 = 257 points.
         expect(merged).toHaveLength(Math.ceil((MAX_SESSION_STEPS + 1) / 2));
-        // Sawtooth peaks survive: every merged pair keeps the 200 peak.
-        expect(merged.slice(0, 256).every((s) => s.inputTokens === 200)).toBe(
-          true,
-        );
-        // The odd trailing element is carried through unmerged.
+        // The valleys are NOT erased (the keep-max regression): the decimated
+        // body carries an equal number of 100 valleys and 200 peaks.
+        const body = merged.slice(0, 256);
+        expect(body.filter((s) => s.inputTokens === 100)).toHaveLength(128);
+        expect(body.filter((s) => s.inputTokens === 200)).toHaveLength(128);
+        // The trailing element is carried through as its own bucket.
         expect(merged.at(-1)).toEqual({
           startMs: MAX_SESSION_STEPS * 1000,
           inputTokens: 999,
@@ -94,12 +96,37 @@ describe("appendSessionStep", () => {
           expect(merged[i]!.startMs).toBeGreaterThan(merged[i - 1]!.startMs);
         }
       });
+
+      it("preserves an isolated valley through the downsample (regression: keep-max erased it)", () => {
+        const attributes: Record<string, string> = {};
+        // A single 20k drop in a 200k plateau, at an even index so keep-max
+        // would have paired it with the following 200k peak and merged it away.
+        // Min/max decimation keeps the bucket's min, so the valley survives.
+        const valleyIdx = 100;
+        for (let i = 0; i <= MAX_SESSION_STEPS; i++) {
+          appendSessionStep({
+            attributes,
+            harness: "claude",
+            startMs: i * 1000,
+            inputTokens: i === valleyIdx ? 20_000 : 200_000,
+          });
+        }
+
+        const merged = parseSessionSteps(attributes[SESSION_STEPS_ATTR]);
+        // The lone valley survives — keep-max would have lost it into the peaks.
+        expect(
+          merged.some(
+            (s) => s.inputTokens === 20_000 && s.startMs === valleyIdx * 1000,
+          ),
+        ).toBe(true);
+        expect(merged.some((s) => s.inputTokens === 200_000)).toBe(true);
+      });
     });
   });
 
-  describe("given out-of-order arrivals that trip the merge at the cap", () => {
-    describe("when the merge runs", () => {
-      it("sorts by start time before pairing so the sawtooth is not corrupted", () => {
+  describe("given out-of-order arrivals that trip the downsample at the cap", () => {
+    describe("when the downsample runs", () => {
+      it("sorts by start time first so peaks and valleys are not corrupted", () => {
         const attributes: Record<string, string> = {};
         // Append MAX+1 steps in DESCENDING start time (out of order). Sawtooth
         // is defined by TIME index: even startMs index → 100, odd → 200.
@@ -113,17 +140,17 @@ describe("appendSessionStep", () => {
         }
 
         const merged = parseSessionSteps(attributes[SESSION_STEPS_ATTR]);
-        // 513 entries → ceil(513 / 2) = 257 after pairwise merge.
+        // 513 entries → ceil(513 / 2) = 257 after min/max decimation.
         expect(merged).toHaveLength(Math.ceil((MAX_SESSION_STEPS + 1) / 2));
         // Output is chronologically ordered despite descending arrival.
         for (let i = 1; i < merged.length; i++) {
           expect(merged[i]!.startMs).toBeGreaterThan(merged[i - 1]!.startMs);
         }
-        // Each chronological pair kept its 200 peak — merging by append order
-        // (unsorted) would have paired non-adjacent times and lost peaks.
-        expect(merged.slice(0, 256).every((s) => s.inputTokens === 200)).toBe(
-          true,
-        );
+        // Both extrema survive — decimating by append order (unsorted) would
+        // have bucketed non-adjacent times and corrupted the sawtooth.
+        const body = merged.slice(0, 256);
+        expect(body.filter((s) => s.inputTokens === 100)).toHaveLength(128);
+        expect(body.filter((s) => s.inputTokens === 200)).toHaveLength(128);
       });
     });
   });

--- a/langwatch/src/server/app-layer/traces/session-rollup/sessionRollup.service.ts
+++ b/langwatch/src/server/app-layer/traces/session-rollup/sessionRollup.service.ts
@@ -272,6 +272,11 @@ function accumulateCategoryTotals(
  * are concatenated then sorted by start time before compaction detection, so
  * out-of-order OTLP delivery and Codex's fragmentation across traces are both
  * handled.
+ *
+ * Contract for future readers: `traces` MUST be deduplicated trace-summary
+ * rows (one row per traceId). ClickHouse's ReplacingMergeTree can return
+ * multiple versions of the same trace before merges settle; feeding
+ * duplicates here double-counts both steps and categoryTotals.
  */
 export function rollupSessions({
   traces,

--- a/langwatch/src/server/app-layer/traces/session-rollup/sessionSteps.ts
+++ b/langwatch/src/server/app-layer/traces/session-rollup/sessionSteps.ts
@@ -8,11 +8,12 @@
  * curve and detect compaction events.
  *
  * Why on the trace summary and not a session-keyed fold: the fold framework
- * keys strictly by traceId. For Claude Code, a whole session's turns already
- * fold into one trace summary (log records are additive per trace); Codex
- * fragments a session across traces, which the read-time rollup re-joins by
- * thread id. A session-keyed fold would need a second event per span (rejected
- * in ADR-033 Decision 1). See the ADR Revisions v3 note.
+ * keys strictly by traceId, and both harnesses fragment a session across
+ * traces (the Claude Code reactor derives one trace per turn via
+ * sha256(session:prompt); Codex fragments per rollout), so the read-time
+ * rollup re-joins them by thread id. A session-keyed fold would need a second
+ * event per span (rejected in ADR-033 Decision 1). See the ADR Revisions v3
+ * note.
  *
  * `inputTokens` is the step's **total input context** — fresh input plus
  * cache-read plus cache-creation tokens — not just the freshly-billed prefix.

--- a/langwatch/src/server/app-layer/traces/session-rollup/sessionSteps.ts
+++ b/langwatch/src/server/app-layer/traces/session-rollup/sessionSteps.ts
@@ -45,10 +45,10 @@ export const SESSION_STEPS_ATTR = "langwatch.reserved.session_steps";
 export const SESSION_HARNESS_ATTR = "langwatch.reserved.session.harness";
 
 /**
- * Hard bound on the per-trace step array. Past the cap, adjacent pairs merge
- * keeping the larger input size (ADR-033 Schema, session-fold block): resolution
- * halves but the sawtooth shape — the growth/compaction signal — is preserved,
- * and fold-size pressure stays within ADR-021 limits.
+ * Hard bound on the per-trace step array. Past the cap, the series is halved by
+ * min/max decimation (ADR-033 Schema, session-fold block): resolution halves but
+ * BOTH the sawtooth peaks AND valleys — the growth AND compaction signal — are
+ * preserved, and fold-size pressure stays within ADR-021 limits.
  */
 export const MAX_SESSION_STEPS = 512;
 
@@ -74,41 +74,55 @@ export function parseSessionSteps(raw: string | undefined): SessionStep[] {
 }
 
 /**
- * Collapse a step array to half its length by merging adjacent pairs and
- * keeping the larger input size — preserving the sawtooth peaks that carry the
- * compaction signal. The earlier `startMs` of each pair is kept so ordering
- * survives the merge. A trailing odd element is carried through unmerged.
+ * Halve a step array while preserving BOTH local extrema — peaks AND valleys —
+ * via min/max decimation, so the compaction signal survives past the cap.
  *
- * Steps are sorted by `startMs` first: OTLP spans and log turns can arrive
- * out of chronological order, so pairing raw append-order neighbours could
- * merge a late-arriving early step with a distant one and corrupt the
- * preserved sawtooth. Sorting first makes each merged pair two chronological
- * neighbours, so the halved-resolution curve still tracks real context growth.
+ * The earlier keep-max merge kept only the larger of each adjacent pair, which
+ * systematically ERASED the valleys: the post-compaction low points are exactly
+ * what `detectCompactionEvents` reads a context re-base by, so a marathon session
+ * past the cap lost its compaction events (the drops were merged away into the
+ * neighbouring peaks). Min/max decimation instead buckets consecutive steps in
+ * FOURS and emits each bucket's min and max in start-time order: the peaks keep
+ * the running-max reference high and the valleys keep the drops, so the halved
+ * series still traces the sawtooth the detector walks.
+ *
+ * Steps are start-time sorted first (OTLP spans and log turns arrive out of
+ * chronological order), so each bucket is four chronological neighbours. A bucket
+ * whose min and max coincide (a flat run, or a trailing partial bucket of one)
+ * emits a single point. Output length ≤ ⌈N/2⌉, so one pass clears the cap.
+ *
+ * Residual limit: the two interior points of a four-step bucket are dropped, so
+ * a second peak+valley pair inside one bucket loses resolution — an accepted
+ * trade at the >512-step tail, and strictly better than erasing every valley.
  */
-function mergeAdjacentKeepMax(input: SessionStep[]): SessionStep[] {
+function downsampleKeepExtrema(input: SessionStep[]): SessionStep[] {
   const steps = [...input].sort((a, b) => a.startMs - b.startMs);
-  const merged: SessionStep[] = [];
-  for (let i = 0; i < steps.length; i += 2) {
-    const a = steps[i]!;
-    const b = steps[i + 1];
-    if (!b) {
-      merged.push(a);
-      continue;
+  const out: SessionStep[] = [];
+  for (let i = 0; i < steps.length; i += 4) {
+    let min = steps[i]!;
+    let max = steps[i]!;
+    for (let j = i + 1; j < i + 4 && j < steps.length; j++) {
+      const s = steps[j]!;
+      if (s.inputTokens < min.inputTokens) min = s;
+      if (s.inputTokens > max.inputTokens) max = s;
     }
-    merged.push({
-      startMs: Math.min(a.startMs, b.startMs),
-      inputTokens: Math.max(a.inputTokens, b.inputTokens),
-    });
+    if (min === max) {
+      out.push(min);
+    } else if (min.startMs <= max.startMs) {
+      out.push(min, max);
+    } else {
+      out.push(max, min);
+    }
   }
-  return merged;
+  return out;
 }
 
 /**
  * Append one coding-agent step to a trace's step series on the (mutable)
  * attribute map, stamping the harness marker. Keeps the array bounded at
- * {@link MAX_SESSION_STEPS} by merging adjacent pairs (keep-max) once it would
- * overflow. Pure aside from mutating the passed `attributes` object, which the
- * fold already treats as a fresh per-step copy.
+ * {@link MAX_SESSION_STEPS} by min/max decimation (peaks AND valleys survive)
+ * once it would overflow. Pure aside from mutating the passed `attributes`
+ * object, which the fold already treats as a fresh per-step copy.
  *
  * Cost note: this parses + re-serialises the series each call, which the fold
  * deliberately avoided for its UNBOUNDED collections (events/spanCosts — see the
@@ -139,7 +153,7 @@ export function appendSessionStep({
   // it directly. Bounded at MAX_SESSION_STEPS, so the sort stays cheap.
   steps.sort((a, b) => a.startMs - b.startMs);
   const bounded =
-    steps.length > MAX_SESSION_STEPS ? mergeAdjacentKeepMax(steps) : steps;
+    steps.length > MAX_SESSION_STEPS ? downsampleKeepExtrema(steps) : steps;
   attributes[SESSION_STEPS_ATTR] = JSON.stringify(bounded);
   attributes[SESSION_HARNESS_ATTR] = harness;
 }

--- a/langwatch/src/server/app-layer/traces/span-block-classification.readers.ts
+++ b/langwatch/src/server/app-layer/traces/span-block-classification.readers.ts
@@ -8,6 +8,7 @@
 import { coerceToNumber } from "~/utils/coerceToNumber";
 import type { OtlpSpan } from "../../event-sourcing/pipelines/trace-processing/schemas/otlp";
 import type { UsagePools } from "./block-classification/costAllocation.service";
+import type { CodingAgentHarness } from "./block-classification/harnessDetection";
 import { ATTR_KEYS } from "./canonicalisation/extractors/_constants";
 
 /** First string-valued attribute for `key`, or null. */
@@ -119,7 +120,10 @@ export function parseJsonAttribute(
 
 /** Provider-reported usage pools (fresh / cache-read / cache-creation / output),
  * reading the first positive value across each key's aliases. */
-export function extractUsagePools(span: OtlpSpan): UsagePools {
+export function extractUsagePools(
+  span: OtlpSpan,
+  harness: CodingAgentHarness,
+): UsagePools {
   const num = (...keys: string[]): number => {
     for (const key of keys) {
       const n = coerceToNumber(getNumericAttribute(span, key));
@@ -127,19 +131,28 @@ export function extractUsagePools(span: OtlpSpan): UsagePools {
     }
     return 0;
   };
+  const inputTokens = num(
+    ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS,
+    ATTR_KEYS.GEN_AI_USAGE_PROMPT_TOKENS,
+  );
+  const cacheReadTokens = num(
+    ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+    "gen_ai.usage.cached_tokens",
+  );
   return {
-    inputTokens: num(
-      ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS,
-      ATTR_KEYS.GEN_AI_USAGE_PROMPT_TOKENS,
-    ),
+    // The pools are EXCLUSIVE (Anthropic convention). Codex reports
+    // OpenAI-style usage where cached tokens are a SUBSET of input_tokens —
+    // subtract them out of the fresh pool or input-axis allocation
+    // double-counts the cached prefix (mirrors `sumStepContext`).
+    inputTokens:
+      harness === "codex"
+        ? Math.max(0, inputTokens - cacheReadTokens)
+        : inputTokens,
     outputTokens: num(
       ATTR_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS,
       ATTR_KEYS.GEN_AI_USAGE_COMPLETION_TOKENS,
     ),
-    cacheReadTokens: num(
-      ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
-      "gen_ai.usage.cached_tokens",
-    ),
+    cacheReadTokens,
     cacheCreationTokens: num(
       ATTR_KEYS.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
     ),

--- a/langwatch/src/server/app-layer/traces/span-block-classification.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-block-classification.service.ts
@@ -35,7 +35,11 @@ import {
   type TokenBlock,
   type UsagePools,
 } from "./block-classification/costAllocation.service";
-import { detectCodingAgentHarness } from "./block-classification/harnessDetection";
+import { textContainsPromptLineAligned } from "./block-classification/freshTurnPresence";
+import {
+  type CodingAgentHarness,
+  detectCodingAgentHarness,
+} from "./block-classification/harnessDetection";
 import { ATTR_KEYS } from "./canonicalisation/extractors/_constants";
 import { resolveCustomTierRates } from "./model-cost-matching";
 import {
@@ -158,7 +162,7 @@ export class OtlpSpanBlockClassificationService {
     // is contained, logged, and swallowed so the span still ingests unclassified.
     // The command-level try/catch remains as a second belt.
     try {
-      await this.classifyInner({ span });
+      await this.classifyInner({ span, harness });
     } catch (error) {
       this.logger.warn(
         { error, spanId: span.spanId, traceId: span.traceId },
@@ -168,7 +172,13 @@ export class OtlpSpanBlockClassificationService {
   }
 
   /** The classification work proper — see classifySpanBlocks for the guards. */
-  private async classifyInner({ span }: { span: OtlpSpan }): Promise<void> {
+  private async classifyInner({
+    span,
+    harness,
+  }: {
+    span: OtlpSpan;
+    harness: CodingAgentHarness;
+  }): Promise<void> {
     // 2. Content extraction. PREFER the raw Claude Code request/response bodies
     //    (full fidelity: content-block structure + cache_control intact), so the
     //    cache breakpoint is REAL (not pool-inferred), tool_results keep their
@@ -216,7 +226,7 @@ export class OtlpSpanBlockClassificationService {
     //    the zero-guard in allocateCategoryCosts routes it to the axis catch-all
     //    (ADR-033 "no usage is dropped"). Skip only when there is neither content
     //    nor usage to attribute.
-    const pools = extractUsagePools(span);
+    const pools = extractUsagePools(span, harness);
     const hasUsage =
       pools.inputTokens > 0 ||
       pools.cacheReadTokens > 0 ||
@@ -489,13 +499,20 @@ function lastUserMessage(
   return null;
 }
 
-/** True when any user message's flattened text contains `text`. */
+/**
+ * True when any user message's flattened text contains `text` LINE-ALIGNED.
+ * A bare substring check suppressed short prompts ("ok", "continue") that
+ * appear inside recovered reminder prose or file dumps, silently dropping the
+ * fresh turn and mislabelling a stale prior user message as fresh.
+ */
 function messagesContainUserText(
   messages: Array<{ role: string; content: unknown }>,
   text: string,
 ): boolean {
   return messages.some(
-    (m) => m.role === "user" && contentText(m.content).includes(text),
+    (m) =>
+      m.role === "user" &&
+      textContainsPromptLineAligned(contentText(m.content), text),
   );
 }
 

--- a/langwatch/src/server/app-layer/traces/span-block-classification.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-block-classification.service.ts
@@ -12,6 +12,8 @@ import {
   classifyBlocks,
 } from "./block-classification/blockClassifier.service";
 import {
+  type Axis,
+  axisOf,
   blockCategoryCostAttr,
   blockCategoryTokensAttr,
   type Category,
@@ -27,7 +29,8 @@ import {
 } from "./block-classification/claudeCodeBody";
 import {
   allocateCategoryCosts,
-  inferCacheBreakpointFromPools,
+  type CategoryTotals,
+  inferCachedPrefixEstTokens,
   type TierPrices,
   type TokenBlock,
   type UsagePools,
@@ -175,12 +178,22 @@ export class OtlpSpanBlockClassificationService {
     const structuredInput = parseClaudeCodeRequestBody(
       getStringAttribute(span, ATTR_KEYS.CLAUDE_CODE_REQUEST_BODY),
     );
-    const inputMessages =
-      structuredInput?.messages ??
-      parseMessages(span, [
-        ATTR_KEYS.LANGWATCH_INPUT,
-        ATTR_KEYS.GEN_AI_INPUT_MESSAGES,
-      ]);
+    const flattenedMessages = parseMessages(span, [
+      ATTR_KEYS.LANGWATCH_INPUT,
+      ATTR_KEYS.GEN_AI_INPUT_MESSAGES,
+    ]);
+    const inputMessages = structuredInput
+      ? // The raw body is preferred for its intact block structure, but inline
+        // truncation drops the NEWEST turn (the tail). When it did, reinstate the
+        // current user turn from the clean flattened side-channel (which the
+        // log-to-span converter fills from the co-located user_prompt), so the
+        // fresh user input is classified instead of lost to other_input.
+        appendFreshTurnIfTruncated({
+          structured: structuredInput.messages,
+          newestTurnComplete: structuredInput.newestTurnComplete,
+          flattened: flattenedMessages,
+        })
+      : flattenedMessages;
     const outputMessages =
       parseClaudeCodeResponseBody(
         getStringAttribute(span, ATTR_KEYS.CLAUDE_CODE_RESPONSE_BODY),
@@ -219,15 +232,18 @@ export class OtlpSpanBlockClassificationService {
     const outputBlocks = await this.toTokenBlocks({ blocks: output, model });
     const prices = this.resolveTierPrices({ span, model });
 
-    // 6. Cached-prefix boundary. The Claude Code log path flattens message
-    //    content to plain text, stripping the cache_control markers the
-    //    classifier reads — so `classifyBlocks` returns a null breakpoint even on
-    //    a cached turn. When the provider still reports cached tokens, infer the
-    //    boundary from the usage pools so those tokens attribute to the real
-    //    prefix categories instead of the axis catch-all (other_input).
-    const cacheBreakpoint =
-      lastInputCacheBreakpointIndex ??
-      inferCacheBreakpointFromPools({ inputBlocks, pools });
+    // 6. Cached-prefix boundary. When the content carried a real cache_control
+    //    marker, `lastInputCacheBreakpointIndex` is a whole-block index. When it
+    //    did not (the Claude Code log path flattens content to plain text,
+    //    stripping cache_control) but the provider still reports cached tokens,
+    //    infer the boundary as a FRACTIONAL estimate-space position from the pools
+    //    so those tokens attribute to the real prefix categories instead of the
+    //    axis catch-all (other_input), and the straddling block is split between
+    //    the cached prefix and the fresh tail.
+    const inferredCachedPrefixEstTokens =
+      lastInputCacheBreakpointIndex === null
+        ? inferCachedPrefixEstTokens({ inputBlocks, pools })
+        : null;
 
     // 7. Allocate cache-tier aware and push the classification attributes.
     //    Reconcile Σ to the authoritative displayed cost when the span carries a
@@ -236,7 +252,8 @@ export class OtlpSpanBlockClassificationService {
     const { categoryTotals, blocks } = allocateCategoryCosts({
       inputBlocks,
       outputBlocks,
-      lastCacheBreakpointIndex: cacheBreakpoint,
+      lastCacheBreakpointIndex: lastInputCacheBreakpointIndex,
+      inferredCachedPrefixEstTokens,
       pools,
       prices,
       reconcileToTotalCost: this.resolveReconciliationCost({ span }),
@@ -303,11 +320,22 @@ export class OtlpSpanBlockClassificationService {
     // Rounded for storage: raw float artifacts (0.0000012340000001) inflate
     // the attribute payload without adding information — tokens are integral
     // by nature, USD keeps 10 decimals (sub-nano-dollar precision).
+    //
+    // Tokens are rounded with the largest-remainder method PER AXIS, not
+    // independently: the exact per-category floats sum to the provider's per-axis
+    // pool total, and rounding each on its own drifts that sum by up to one token
+    // per category. Largest-remainder distributes the rounding residual to the
+    // categories with the biggest fractional parts, so the STORED integers still
+    // sum to the provider total (the same conservation the allocator guarantees
+    // in float space). Costs are floats, so they need no such reconciliation.
+    const roundedTokens = roundCategoryTokensPerAxis(categoryTotals);
     for (const [category, total] of Object.entries(categoryTotals)) {
-      if (!total || total.tokens <= 0) continue;
+      if (!total) continue;
+      const tokens = roundedTokens.get(category as Category) ?? 0;
+      if (tokens <= 0) continue;
       pending.push({
         key: blockCategoryTokensAttr(category as Category),
-        value: { stringValue: String(Math.round(total.tokens)) },
+        value: { stringValue: String(tokens) },
       });
       pending.push({
         key: blockCategoryCostAttr(category as Category),
@@ -335,8 +363,17 @@ export class OtlpSpanBlockClassificationService {
     span: OtlpSpan;
     model: string;
   }): TierPrices {
-    const customRates = resolveCustomTierRates((key) =>
-      coerceToNumber(getNumericAttribute(span, key)),
+    // A one-sided custom override fills its unset tiers from the registry rate
+    // for this model — the SAME fallback computeSpanCost passes, so the span's
+    // displayed cost and the per-category allocation price every tier identically
+    // (conservation holds without reconciliation).
+    const registryFallback =
+      model && this.deps.resolveModelPrices
+        ? () => this.deps.resolveModelPrices?.(model) ?? null
+        : undefined;
+    const customRates = resolveCustomTierRates(
+      (key) => coerceToNumber(getNumericAttribute(span, key)),
+      registryFallback,
     );
     if (customRates) return customRates;
 
@@ -394,4 +431,137 @@ export class OtlpSpanBlockClassificationService {
     );
     return explicit !== null && explicit > 0 ? explicit : null;
   }
+}
+
+/**
+ * Reinstate the newest user turn when the raw Claude Code body was truncated.
+ *
+ * Inline truncation always drops the TAIL, so the structured recovery is the
+ * leading prefix (system + complete early turns) MINUS the current turn. The
+ * clean flattened side-channel (`gen_ai.input.messages` / `langwatch.input`,
+ * which the log-to-span converter fills from the co-located `user_prompt`) still
+ * carries the current turn as its last user message — append it so the fresh
+ * input classifies as `user_input` instead of vanishing into `other_input`.
+ *
+ * Guarded against re-adding a turn that already survived: on a mid-turn model
+ * call the human prompt sits early in the conversation (as prior context) and
+ * only the trailing tool_results were truncated, so the recovery already holds
+ * the prompt. Re-appending it there would both duplicate the block AND mislabel
+ * it as the fresh `user_input` turn. We therefore append only when the prompt
+ * text is not already present in the recovered messages — the first model call
+ * of a turn (whose dropped tail IS the human prompt) is the case that needs it.
+ *
+ * No-op when the body parsed whole (`newestTurnComplete`) or no user turn is
+ * recoverable from the side-channel.
+ */
+function appendFreshTurnIfTruncated({
+  structured,
+  newestTurnComplete,
+  flattened,
+}: {
+  structured: Array<{ role: string; content: unknown }>;
+  newestTurnComplete: boolean;
+  flattened: unknown[] | null;
+}): Array<{ role: string; content: unknown }> {
+  if (newestTurnComplete) return structured;
+  const freshTurn = lastUserMessage(flattened);
+  if (!freshTurn) return structured;
+  const freshText = contentText(freshTurn.content);
+  if (freshText && messagesContainUserText(structured, freshText)) {
+    return structured;
+  }
+  return [...structured, freshTurn];
+}
+
+/** The last `role: "user"` message in a flattened message array, or null. */
+function lastUserMessage(
+  messages: unknown[] | null,
+): { role: string; content: unknown } | null {
+  if (!messages) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (!m || typeof m !== "object") continue;
+    const msg = m as { role?: unknown; content?: unknown };
+    if (msg.role !== "user") continue;
+    if (msg.content === undefined || msg.content === null) return null;
+    return { role: "user", content: msg.content };
+  }
+  return null;
+}
+
+/** True when any user message's flattened text contains `text`. */
+function messagesContainUserText(
+  messages: Array<{ role: string; content: unknown }>,
+  text: string,
+): boolean {
+  return messages.some(
+    (m) => m.role === "user" && contentText(m.content).includes(text),
+  );
+}
+
+/** Flatten a message `content` (string or block array) to plain text. */
+function contentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const text = (block as { text?: unknown }).text;
+    if (typeof text === "string" && text.length > 0) parts.push(text);
+  }
+  return parts.join("\n");
+}
+
+/**
+ * Round each category's fractional token count to an integer for storage while
+ * preserving the per-axis sum (largest-remainder / Hamilton). The exact floats
+ * already sum to the provider's per-axis pool total; rounding each in isolation
+ * drifts that sum, so this reconciles WITHIN each axis. Returns a category →
+ * integer-tokens map (categories with no positive allocation are omitted).
+ */
+function roundCategoryTokensPerAxis(
+  categoryTotals: CategoryTotals,
+): Map<Category, number> {
+  const byAxis: Record<Axis, Array<{ category: Category; tokens: number }>> = {
+    input: [],
+    output: [],
+  };
+  for (const [category, total] of Object.entries(categoryTotals)) {
+    if (!total || total.tokens <= 0) continue;
+    byAxis[axisOf(category as Category)].push({
+      category: category as Category,
+      tokens: total.tokens,
+    });
+  }
+
+  const rounded = new Map<Category, number>();
+  for (const axis of ["input", "output"] as const) {
+    const entries = byAxis[axis];
+    const target = Math.round(entries.reduce((sum, e) => sum + e.tokens, 0));
+    const counts = largestRemainderRound(
+      entries.map((e) => e.tokens),
+      target,
+    );
+    entries.forEach((e, i) => rounded.set(e.category, counts[i] ?? 0));
+  }
+  return rounded;
+}
+
+/**
+ * Round `values` to non-negative integers summing EXACTLY to `target`
+ * (largest-remainder): floor everything, then hand the leftover +1s to the
+ * entries with the largest fractional parts. `target` is `round(Σ values)`, so
+ * the leftover count is in `[0, values.length]`.
+ */
+function largestRemainderRound(values: number[], target: number): number[] {
+  const result = values.map((v) => Math.floor(v));
+  let remainder = target - result.reduce((sum, f) => sum + f, 0);
+  const byFracDesc = values
+    .map((v, i) => ({ i, frac: v - Math.floor(v) }))
+    .sort((a, b) => b.frac - a.frac);
+  for (let k = 0; k < byFracDesc.length && remainder > 0; k++) {
+    result[byFracDesc[k]!.i]! += 1;
+    remainder -= 1;
+  }
+  return result;
 }

--- a/langwatch/src/server/app-layer/traces/span-block-classification.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-block-classification.service.ts
@@ -23,6 +23,7 @@ import {
 } from "./block-classification/categories";
 import {
   allocateCategoryCosts,
+  inferCacheBreakpointFromPools,
   type TierPrices,
   type TokenBlock,
   type UsagePools,
@@ -198,14 +199,24 @@ export class OtlpSpanBlockClassificationService {
     const outputBlocks = await this.toTokenBlocks({ blocks: output, model });
     const prices = this.resolveTierPrices({ span, model });
 
-    // 6. Allocate cache-tier aware and push the classification attributes.
+    // 6. Cached-prefix boundary. The Claude Code log path flattens message
+    //    content to plain text, stripping the cache_control markers the
+    //    classifier reads — so `classifyBlocks` returns a null breakpoint even on
+    //    a cached turn. When the provider still reports cached tokens, infer the
+    //    boundary from the usage pools so those tokens attribute to the real
+    //    prefix categories instead of the axis catch-all (other_input).
+    const cacheBreakpoint =
+      lastInputCacheBreakpointIndex ??
+      inferCacheBreakpointFromPools({ inputBlocks, pools });
+
+    // 7. Allocate cache-tier aware and push the classification attributes.
     //    Reconcile Σ to the authoritative displayed cost when the span carries a
     //    provider-billed total (Claude Code's cost_usd) that `computeSpanCost`
     //    trusts over the rate estimate — see resolveReconciliationCost.
     const { categoryTotals, blocks } = allocateCategoryCosts({
       inputBlocks,
       outputBlocks,
-      lastCacheBreakpointIndex: lastInputCacheBreakpointIndex,
+      lastCacheBreakpointIndex: cacheBreakpoint,
       pools,
       prices,
       reconcileToTotalCost: this.resolveReconciliationCost({ span }),

--- a/langwatch/src/server/app-layer/traces/span-block-classification.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-block-classification.service.ts
@@ -12,6 +12,10 @@ import {
   classifyBlocks,
 } from "./block-classification/blockClassifier.service";
 import {
+  parseClaudeCodeRequestBody,
+  parseClaudeCodeResponseBody,
+} from "./block-classification/claudeCodeBody";
+import {
   blockCategoryCostAttr,
   blockCategoryTokensAttr,
   type Category,
@@ -34,6 +38,7 @@ import { resolveCustomTierRates } from "./model-cost-matching";
 import {
   extractUsagePools,
   getNumericAttribute,
+  getStringAttribute,
   parseJsonAttribute,
   parseMessages,
   parseOutputMessages,
@@ -161,13 +166,28 @@ export class OtlpSpanBlockClassificationService {
 
   /** The classification work proper — see classifySpanBlocks for the guards. */
   private async classifyInner({ span }: { span: OtlpSpan }): Promise<void> {
-    // 2. Content extraction — the same attribute surface token estimation reads.
-    const inputMessages = parseMessages(span, [
-      ATTR_KEYS.LANGWATCH_INPUT,
-      ATTR_KEYS.GEN_AI_INPUT_MESSAGES,
-    ]);
-    const outputMessages = parseOutputMessages(span);
-    const tools = parseJsonAttribute(span, ATTR_KEYS.GEN_AI_TOOL_DEFINITIONS);
+    // 2. Content extraction. PREFER the raw Claude Code request/response bodies
+    //    (full fidelity: content-block structure + cache_control intact), so the
+    //    cache breakpoint is REAL (not pool-inferred), tool_results keep their
+    //    type, and output thinking/tool_use blocks classify correctly. Fall back
+    //    to the lifted/flattened fields for non-Claude-Code paths (codex, gateway)
+    //    or when the raw body is absent.
+    const structuredInput = parseClaudeCodeRequestBody(
+      getStringAttribute(span, ATTR_KEYS.CLAUDE_CODE_REQUEST_BODY),
+    );
+    const inputMessages =
+      structuredInput?.messages ??
+      parseMessages(span, [
+        ATTR_KEYS.LANGWATCH_INPUT,
+        ATTR_KEYS.GEN_AI_INPUT_MESSAGES,
+      ]);
+    const outputMessages =
+      parseClaudeCodeResponseBody(
+        getStringAttribute(span, ATTR_KEYS.CLAUDE_CODE_RESPONSE_BODY),
+      ) ?? parseOutputMessages(span);
+    const tools =
+      structuredInput?.tools ??
+      parseJsonAttribute(span, ATTR_KEYS.GEN_AI_TOOL_DEFINITIONS);
     if (inputMessages === null && outputMessages === null) return;
 
     // 3. Classify content parts into cost categories (pure, deterministic).

--- a/langwatch/src/server/app-layer/traces/span-block-classification.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-block-classification.service.ts
@@ -12,10 +12,6 @@ import {
   classifyBlocks,
 } from "./block-classification/blockClassifier.service";
 import {
-  parseClaudeCodeRequestBody,
-  parseClaudeCodeResponseBody,
-} from "./block-classification/claudeCodeBody";
-import {
   blockCategoryCostAttr,
   blockCategoryTokensAttr,
   type Category,
@@ -25,6 +21,10 @@ import {
   SPAN_ATTR_BLOCKS,
   SPAN_ATTR_CLASSIFIER_VERSION,
 } from "./block-classification/categories";
+import {
+  parseClaudeCodeRequestBody,
+  parseClaudeCodeResponseBody,
+} from "./block-classification/claudeCodeBody";
 import {
   allocateCategoryCosts,
   inferCacheBreakpointFromPools,

--- a/langwatch/src/server/app-layer/traces/truncated-json-scan.ts
+++ b/langwatch/src/server/app-layer/traces/truncated-json-scan.ts
@@ -1,0 +1,124 @@
+/**
+ * String/escape-aware scanning primitives for TRUNCATED JSON bodies.
+ *
+ * claude truncates large request bodies INLINE at ~60KB, so a real
+ * coding-agent turn does not JSON.parse. Both truncation-recovery paths — the
+ * canonicalisation extractor (flattened display messages) and the
+ * block-classification body parser (structured classifier input) — rebuild
+ * what survived the cut with these primitives. They live in ONE module because
+ * the two paths must judge truncation identically: if their scanners drift,
+ * the display and the classification disagree about which turns survived.
+ *
+ * Conventions shared by all three scanners: string state is tracked with an
+ * escape flag, so braces/brackets/quotes inside string values never corrupt
+ * the structural scan; a trailing element cut off by truncation never
+ * completes and is never returned.
+ */
+
+/**
+ * Index of `"key"` occurring as a KEY of the TOP-LEVEL object (depth 1,
+ * outside strings, followed by `:`), or -1. A bare `indexOf('"system"')` can
+ * be hijacked by the same key inside a `tool_use.input` payload — that input
+ * is embedded as real unescaped JSON, so it false-matches before the real
+ * top-level key.
+ */
+export function topLevelKeyIndex(raw: string, key: string): number {
+  const needle = `"${key}"`;
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === "\\") esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') {
+      if (depth === 1 && raw.startsWith(needle, i)) {
+        let j = i + needle.length;
+        while (j < raw.length && /\s/.test(raw[j]!)) j++;
+        if (raw[j] === ":") return i;
+      }
+      inStr = true;
+      continue;
+    }
+    if (ch === "{" || ch === "[") depth++;
+    else if (ch === "}" || ch === "]") depth--;
+  }
+  return -1;
+}
+
+/**
+ * Read a complete JSON string literal starting at `quoteIndex` (which must
+ * point at the opening `"`), honouring escapes. Returns the unescaped value,
+ * or null when the string was cut off by truncation (no closing quote).
+ */
+export function readJsonStringAt(
+  raw: string,
+  quoteIndex: number,
+): string | null {
+  let esc = false;
+  for (let i = quoteIndex + 1; i < raw.length; i++) {
+    const ch = raw[i];
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (ch === "\\") {
+      esc = true;
+      continue;
+    }
+    if (ch === '"') {
+      try {
+        return JSON.parse(raw.slice(quoteIndex, i + 1)) as string;
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Yield every COMPLETE, balanced top-level `{…}` object slice at/after
+ * `fromIndex`, tracking string/escape state so braces inside string values do
+ * not corrupt the depth count. Stops at the first depth-0 `]` (the end of the
+ * enclosing array) so a scan seeded at a `messages`/`system` array does not
+ * bleed into sibling fields. A trailing object cut off by truncation never
+ * balances and is never yielded.
+ */
+export function* completeObjectSlices(
+  raw: string,
+  fromIndex: number,
+): Generator<string> {
+  let depth = 0;
+  let start = -1;
+  let inStr = false;
+  let esc = false;
+  for (let i = fromIndex; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === "\\") esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') inStr = true;
+    else if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}") {
+      if (depth > 0) {
+        depth--;
+        if (depth === 0 && start >= 0) {
+          yield raw.slice(start, i + 1);
+          start = -1;
+        }
+      }
+    } else if (ch === "]" && depth === 0) {
+      return;
+    }
+  }
+}

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryCostComputation.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryCostComputation.unit.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
 import { applySpanToSummary } from "../traceSummary.foldProjection";
-import { createInitState, createTestSpan } from "./fixtures/trace-summary-test.fixtures";
+import {
+  createInitState,
+  createTestSpan,
+} from "./fixtures/trace-summary-test.fixtures";
 
 describe("applySpanToSummary cost computation", () => {
   let extractSpy: ReturnType<typeof vi.spyOn>;
@@ -30,7 +33,10 @@ describe("applySpanToSummary cost computation", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       // 100 * 0.000005 + 50 * 0.000015 = 0.0005 + 0.00075 = 0.00125
       expect(result.totalCost).toBeCloseTo(0.00125, 6);
@@ -47,7 +53,10 @@ describe("applySpanToSummary cost computation", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       // gpt-4o is in the static registry, so cost should be computed
       // The exact value depends on the JSON file, but it should be > 0
@@ -66,7 +75,10 @@ describe("applySpanToSummary cost computation", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.totalCost).toBeNull();
     });
@@ -80,7 +92,10 @@ describe("applySpanToSummary cost computation", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.totalCost).toBeNull();
     });
@@ -96,7 +111,10 @@ describe("applySpanToSummary cost computation", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.totalCost).toBeCloseTo(0.005, 6);
     });
@@ -111,7 +129,10 @@ describe("applySpanToSummary cost computation", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.totalCost).toBeNull();
     });
@@ -129,7 +150,10 @@ describe("applySpanToSummary cost computation", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.totalCost).toBeCloseTo(0.0042, 6);
     });
@@ -145,7 +169,10 @@ describe("applySpanToSummary cost computation", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.totalCost).toBeNull();
     });
@@ -158,7 +185,10 @@ describe("applySpanToSummary cost computation", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.totalCost).toBeNull();
     });
@@ -174,7 +204,10 @@ describe("applySpanToSummary cost computation", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.totalPromptTokenCount).toBe(100);
       expect(result.totalCompletionTokenCount).toBe(50);
@@ -184,20 +217,40 @@ describe("applySpanToSummary cost computation", () => {
   });
 
   describe("when custom rates have only inputCostPerToken", () => {
-    it("computes cost using only input rate", () => {
+    it("prices the unset output rate from the registry instead of zeroing it", () => {
+      // Derive the registry's output rate for the model from an output-only span.
+      const registryOutputOnly = applySpanToSummary({
+        state: createInitState(),
+        span: createTestSpan({
+          spanAttributes: {
+            "gen_ai.request.model": "gpt-5-mini",
+            "gen_ai.usage.input_tokens": 0,
+            "gen_ai.usage.output_tokens": 50,
+          },
+        }),
+      }).totalCost;
+      expect(registryOutputOnly).toBeGreaterThan(0);
+
       const span = createTestSpan({
         spanAttributes: {
-          "gen_ai.request.model": "gpt-4o",
+          "gen_ai.request.model": "gpt-5-mini",
           "gen_ai.usage.input_tokens": 100,
           "gen_ai.usage.output_tokens": 50,
           "langwatch.model.inputCostPerToken": 0.00001,
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
-      // 100 * 0.00001 + 50 * 0 = 0.001
-      expect(result.totalCost).toBeCloseTo(0.001, 6);
+      // custom input rate + registry output rate — output is NOT free.
+      expect(result.totalCost).toBeCloseTo(
+        100 * 0.00001 + (registryOutputOnly ?? 0),
+        5,
+      );
+      expect(result.totalCost).toBeGreaterThan(0.001);
     });
   });
 });
@@ -226,7 +279,10 @@ describe("applySpanToSummary guardrail blocking detection", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.blockedByGuardrail).toBe(true);
     });
@@ -241,7 +297,10 @@ describe("applySpanToSummary guardrail blocking detection", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.blockedByGuardrail).toBe(false);
     });
@@ -255,7 +314,10 @@ describe("applySpanToSummary guardrail blocking detection", () => {
         },
       });
 
-      const result = applySpanToSummary({ state: createInitState(), span: span });
+      const result = applySpanToSummary({
+        state: createInitState(),
+        span: span,
+      });
 
       expect(result.blockedByGuardrail).toBe(false);
     });
@@ -318,7 +380,11 @@ describe("applySpanToSummary token timing from OTel instrumentation events (@reg
         endTimeUnixMs: 3000,
         durationMs: 2000,
         events: [
-          { name: "First Token Stream Event", timeUnixMs: 1200, attributes: {} },
+          {
+            name: "First Token Stream Event",
+            timeUnixMs: 1200,
+            attributes: {},
+          },
         ],
       });
 
@@ -366,9 +432,7 @@ describe("applySpanToSummary token timing from OTel instrumentation events (@reg
         startTimeUnixMs: 1000,
         endTimeUnixMs: 4000,
         durationMs: 3000,
-        events: [
-          { name: "first_token", timeUnixMs: 1300, attributes: {} },
-        ],
+        events: [{ name: "first_token", timeUnixMs: 1300, attributes: {} }],
         spanAttributes: {
           "gen_ai.server.time_to_first_token": 500,
         },

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummarySessionSteps.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummarySessionSteps.unit.test.ts
@@ -58,9 +58,33 @@ describe("applySpanToSummary session-step accumulation", () => {
     });
   });
 
-  describe("given a coding-agent span with cache-read usage", () => {
+  describe("given a claude-code span with cache-read usage", () => {
     describe("when it is folded", () => {
-      it("counts the whole prompt context (fresh + cache-read + cache-creation)", () => {
+      it("counts the whole prompt context — Anthropic cache is separate (fresh + cache-read + cache-creation)", () => {
+        const span = createTestSpan({
+          startTimeUnixMs: 1000,
+          spanAttributes: {
+            "gen_ai.system": "claude_code",
+            "gen_ai.request.model": "claude-sonnet-4",
+            "gen_ai.usage.input_tokens": 2000,
+            "gen_ai.usage.cache_read.input_tokens": 30_000,
+            "gen_ai.usage.cache_creation.input_tokens": 8000,
+            "gen_ai.usage.output_tokens": 20,
+          },
+        });
+
+        const state = applySpanToSummary({ state: createInitState(), span });
+
+        expect(parseSessionSteps(state.attributes[SESSION_STEPS_ATTR])).toEqual(
+          [{ startMs: 1000, inputTokens: 40_000 }],
+        );
+      });
+    });
+  });
+
+  describe("given a codex span with cache-read usage", () => {
+    describe("when it is folded", () => {
+      it("counts input_tokens alone — OpenAI cached tokens are a subset, not additive", () => {
         const span = createTestSpan({
           startTimeUnixMs: 1000,
           instrumentationScope: CODEX_SCOPE,
@@ -76,7 +100,7 @@ describe("applySpanToSummary session-step accumulation", () => {
         const state = applySpanToSummary({ state: createInitState(), span });
 
         expect(parseSessionSteps(state.attributes[SESSION_STEPS_ATTR])).toEqual(
-          [{ startMs: 1000, inputTokens: 40_000 }],
+          [{ startMs: 1000, inputTokens: 2000 }],
         );
       });
     });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummarySessionSteps.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummarySessionSteps.unit.test.ts
@@ -234,7 +234,7 @@ function makeCodexSseLogEvent(
 describe("handleTraceLogRecordReceived session-step accumulation", () => {
   describe("given a codex sse log turn with a thread id and input usage", () => {
     describe("when it is folded", () => {
-      it("appends a step summing fresh + cache-read input tokens", () => {
+      it("counts input_token_count alone — codex cached tokens are a subset, not additive (matches the span path)", () => {
         const projection = new TraceSummaryFoldProjection({
           store: { store: async () => {}, get: async () => null },
         });
@@ -243,7 +243,11 @@ describe("handleTraceLogRecordReceived session-step accumulation", () => {
           makeCodexSseLogEvent(
             {
               model: "gpt-5-mini",
-              input_token_count: "3000",
+              // OpenAI/codex input_token_count already INCLUDES the cached
+              // tokens (cached_token_count is a subset), so the step context is
+              // input alone; adding cache would double-count and inflate the
+              // running max, mirroring extractStepInputTokens on the span path.
+              input_token_count: "15000",
               output_token_count: "50",
               cached_token_count: "12000",
               "conversation.id": "codex-thread-1",

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/index.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/index.ts
@@ -1,16 +1,21 @@
 // Only export what the orchestrator (traceSummary.foldProjection.ts) needs.
 // Tests should import directly from the specific service file.
-export { SpanTimingService } from "./span-timing.service";
+
+export { liftCanonicalAttributesFromLogRecord } from "./log-extractor-driver";
+export {
+  NON_BILLABLE_ATTR,
+  SpanCostService,
+  sumStepContext,
+} from "./span-cost.service";
 export { SpanStatusService } from "./span-status.service";
-export { TraceOriginService } from "./trace-origin.service";
-export { SpanCostService, NON_BILLABLE_ATTR } from "./span-cost.service";
+export { SpanTimingService } from "./span-timing.service";
 export { TraceAttributeAccumulationService } from "./trace-attribute-accumulation.service";
 export {
-  TraceIOAccumulationService,
-  shouldOverrideOutput,
   extractIOFromLogRecord,
   OUTPUT_SOURCE,
+  shouldOverrideOutput,
+  TraceIOAccumulationService,
 } from "./trace-io-accumulation.service";
-export { liftCanonicalAttributesFromLogRecord } from "./log-extractor-driver";
-export { TracePromptAccumulationService } from "./trace-prompt-accumulation.service";
 export { TraceNameResolutionService } from "./trace-name-resolution.service";
+export { TraceOriginService } from "./trace-origin.service";
+export { TracePromptAccumulationService } from "./trace-prompt-accumulation.service";

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-cost.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-cost.service.ts
@@ -6,6 +6,40 @@ import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import { coerceToNumber } from "~/utils/coerceToNumber";
 import type { NormalizedSpan } from "../../schemas/spans";
 
+/**
+ * The step's TOTAL input context size for one coding-agent turn (ADR-033 session
+ * tracking), provider-aware. Compaction is a drop in the whole prompt context,
+ * not just the fresh prefix, so the measure must include cached context — but HOW
+ * cache relates to the reported input count differs by provider:
+ *
+ *   - Anthropic (claude): `input` (input_tokens) is fresh-only, with cache_read /
+ *     cache_creation reported SEPARATELY → full context = their sum.
+ *   - OpenAI (codex): `cached_tokens` is a SUBSET of `input` (already counted in
+ *     it) → full context = `input` alone; adding cache double-counts, inflating
+ *     the running max and pushing real compactions' retain ratio below the
+ *     subagent floor (events missed).
+ *
+ * Shared by the span path (`extractStepInputTokens`) and the log-record path so
+ * the two stay definitionally identical — a codex turn measured the same whether
+ * it arrived as a span or a lifted log.
+ */
+export function sumStepContext({
+  harness,
+  input,
+  cacheRead,
+  cacheCreation,
+}: {
+  harness: CodingAgentHarness;
+  input: number;
+  cacheRead: number;
+  cacheCreation: number;
+}): number {
+  const fresh = Math.max(0, input);
+  // Codex: cached tokens are already inside `input` — do not re-add.
+  if (harness === "codex") return fresh;
+  return fresh + Math.max(0, cacheRead) + Math.max(0, cacheCreation);
+}
+
 export const FIRST_TOKEN_EVENTS = new Set([
   "gen_ai.content.chunk",
   "llm.content.completion.chunk",
@@ -144,19 +178,10 @@ export class SpanCostService {
   }
 
   /**
-   * The step's TOTAL input context size (ADR-033 session tracking). Compaction
-   * is a drop in the whole prompt context, not just the fresh prefix, so the
-   * measure must include cached context — but HOW cache relates to the reported
-   * input count differs by provider:
-   *
-   *   - Anthropic (claude): `input_tokens` is fresh-only, with cache_read /
-   *     cache_creation reported SEPARATELY. Full context = their sum.
-   *   - OpenAI (codex): `cached_tokens` is a SUBSET of `input_tokens` (already
-   *     counted in it). Full context = `input_tokens` alone; adding cache would
-   *     double-count — inflating the running max and pushing real compactions'
-   *     retain ratio below the subagent floor (events missed).
-   *
-   * Returns 0 when the span carries no usage.
+   * The span's TOTAL input context size for one coding-agent turn (ADR-033
+   * session tracking), delegating the provider-aware cache math to
+   * {@link sumStepContext} so the span and log paths cannot drift. Returns 0
+   * when the span carries no usage.
    */
   extractStepInputTokens(
     span: NormalizedSpan,
@@ -174,10 +199,13 @@ export class SpanCostService {
         span.spanAttributes[ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS],
       ) ?? 0,
     );
-    // Codex: cached tokens are already inside promptTokens — do not re-add.
-    if (harness === "codex") return promptTokens;
     const cache = cacheTokens ?? this.extractCacheTokens(span);
-    return promptTokens + cache.cacheReadTokens + cache.cacheCreationTokens;
+    return sumStepContext({
+      harness,
+      input: promptTokens,
+      cacheRead: cache.cacheReadTokens,
+      cacheCreation: cache.cacheCreationTokens,
+    });
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -47,6 +47,7 @@ import {
   SpanStatusService,
   SpanTimingService,
   shouldOverrideOutput,
+  sumStepContext,
   TraceAttributeAccumulationService,
   TraceIOAccumulationService,
   TraceNameResolutionService,
@@ -598,27 +599,40 @@ export class TraceSummaryFoldProjection
     // thread id and input usage is one session step. Codex fragments a session
     // across traces, so its step series lives on each trace summary and the
     // read-time rollup re-joins them by thread id. Step context size sums the
-    // whole prompt context (fresh + cache-read + cache-creation), mirroring
-    // the span path's extractStepInputTokens. No extractor lifts
-    // langwatch.cache_creation_tokens today, so that term is 0 on this path —
-    // it is included so the two paths stay definitionally identical if an
-    // extractor ever starts lifting it.
+    // whole prompt context provider-aware (fresh + cache for claude, fresh
+    // alone for codex whose cached_tokens are a subset of input) via the SAME
+    // sumStepContext the span path uses, so a codex turn measures identically
+    // whether it arrived as a span or a lifted log. No extractor lifts
+    // langwatch.cache_creation_tokens today, so that term is 0 on this path.
     const liftedThreadId =
       typeof liftedAttrs["langwatch.thread.id"] === "string"
         ? (liftedAttrs["langwatch.thread.id"] as string)
         : undefined;
     const positive = (value: number): number =>
       Number.isFinite(value) && value > 0 ? value : 0;
-    const stepInputTokens =
-      positive(liftedIn) +
-      positive(Number(liftedAttrs["langwatch.cache_read_tokens"])) +
-      positive(Number(liftedAttrs["langwatch.cache_creation_tokens"]));
+    const freshInput = positive(liftedIn);
+    // Detect the harness on the fresh input (the positivity gate only cares
+    // that the turn carries usage), THEN size the context provider-aware — the
+    // sum must not be additive before we know the provider, or codex would
+    // double-count its cached tokens (subset of input).
     const logHarness = detectLogTurnHarness({
       scopeName: event.data.scopeName,
       liftedAttrs,
       liftedThreadId,
-      liftedInputTokens: stepInputTokens,
+      liftedInputTokens: freshInput,
     });
+    const stepInputTokens = logHarness
+      ? sumStepContext({
+          harness: logHarness,
+          input: freshInput,
+          cacheRead: positive(
+            Number(liftedAttrs["langwatch.cache_read_tokens"]),
+          ),
+          cacheCreation: positive(
+            Number(liftedAttrs["langwatch.cache_creation_tokens"]),
+          ),
+        })
+      : 0;
     if (logHarness && stepInputTokens > 0) {
       appendSessionStep({
         attributes: mergedAttributes,

--- a/specs/ai-gateway/governance/cost-breakdown-dashboard.feature
+++ b/specs/ai-gateway/governance/cost-breakdown-dashboard.feature
@@ -17,7 +17,7 @@ Feature: Cost breakdown by content category on governance dashboards
   Scenario: The breakdown shows an enablement hint when no content was captured
     Given a user whose traffic produced no category totals because payload capture is off
     When the user opens their personal usage view
-    Then the breakdown section explains that payload capture must be enabled to see it
+    Then the breakdown section explains why the breakdown can be empty
 
   @integration
   Scenario: The org activity monitor aggregates category totals across users


### PR DESCRIPTION
Makes the **Claude Code** path classify coding-agent cost at full fidelity, found while dogfooding ADR-033 (#5318). Stacked on #5318 — **merge #5318 first**.

## The core fix — classify from the raw body (P1a)

The Claude Code log path attaches the **raw Anthropic api_request_body / api_response_body** to the span, but the lifted `langwatch.input` **flattens every message to plain text**, which strips `cache_control` and collapses tool_results / output blocks. Classifying the flat field is why a live dashboard showed ~73% `other_input`.

The classifier now **prefers the raw body**, parsed with its **content-block structure intact**:
- **real `cache_control` breakpoint** (not pool-inferred) → correct cache-tier split,
- **tool_result blocks keep their type** (not collapsed to user_input/prior_context),
- **structured output** (`thinking` / `tool_use` → their real categories, not a flat blob).

It falls back to the flattened fields for non-Claude-Code paths (codex, gateway) or when the raw body is absent.

## Truncation machinery (the fallbacks)

Claude truncates the body inline at ~60KB, so a real turn is invalid JSON. Two truncation-tolerant layers back the primary fix:
1. **Structure-preserving recovery** — a string/escape-aware brace scan recovers the complete leading messages + front-loaded system blocks that survived the cut (truncation always removes the *tail*), keeping their block structure. Also powers the display-side `buildInputMessagesFromRequestBody`.
2. **Pool-inferred breakpoint** — when no `cache_control` survives (truncated tail, or the flat-field path), infer the cached-prefix boundary from the provider's `cache_read + cache_creation` counts (the cached prefix is always the front), so cache tokens attribute to the real categories instead of `other_input`.

## Also here (codex + shared)

- **Codex skill findability** — codex relays skill injections as their own earlier user messages, so `<skill>` markers are now peeled in *any* user turn → `skill_content` (not `prior_context`).
- **Flat-string output** — codex's flat `langwatch.output` and Claude's `gen_ai.completion` now classify as `assistant_text` instead of `other_output`.

## Tests

118 green across `claudeCodeBody`, `claudeCode` (recovery), `costAllocation` (inference + straddle/boundary), `blockClassifier`, and the service — including a raw-body span proving cache tokens attribute to `system_prompt` with zero `other_input`.

The ADR's remaining Open Question (classify from the **gateway** body, Path A — which owns the bytes and never truncates) stands: this PR maximizes fidelity on the Path B raw body we have today.

https://claude.ai/code/session_01BTXJNbJdzwj9uZsPtYMCLh

## Review hardening (2c2475774)

A four-lens deep review (correctness, session-rollup/projections, security/tenancy, tests) found no P0/P1. Everything actionable was fixed in-branch:

- **Classifier**: markers now peel across *multiple* leading reminder text parts (Claude Code emits each reminder as its own part; the second one was landing in `user_input`); truncation recovery locates `system`/`messages` at top-level depth so a `tool_use.input` embedding those keys can't hijack the scan.
- **Fresh-turn recovery**: dedupe is line-aligned (short prompts like "continue" were judged already-present inside recovered file dumps and dropped); reinstatement gates on the recovery path running, not the `body_truncated` attribute (LangWatch-capped bodies never carry it).
- **Codex usage convention**: `extractUsagePools` subtracts the OpenAI cached subset out of the fresh pool (mirrors `sumStepContext`) so input-axis allocation can't double-count when codex content+usage co-locate.
- **Usage surfaces**: 400-day window clamp on both personal-usage entrypoints (unbounded span = per-day bucket allocation on the app server); `/api/me/usage` degrades the category query to `[]` like the tRPC twin; `.finite()` on preview rates; `resolvePersonalUsageIngestionScope` (the tenant-union seam) now integration-tested; the activityMonitor RBAC guard-probe fixture is exhaustiveness-pinned to the router.

Known limitations (accepted, documented in the runbook/code): the block-classification kill switch does not stop session-step tracking (no runtime off-ramp); codex spans structurally carry content and usage on different spans today, so codex category totals stay empty until they co-locate (the allocation math is now correct for when they do).