### PR TITLE
fix(routing-policies): list every org model provider in the policy picker

### DIFF
--- a/langwatch/src/pages/settings/routing-policies.tsx
+++ b/langwatch/src/pages/settings/routing-policies.tsx
@@ -87,13 +87,15 @@ function RoutingPoliciesPage() {
   );
 
   // Fuel the structured picker on the drawer with the org's actual
-  // ModelProviders (visible at ORG / TEAM / PROJECT scopes via the
-  // standard scope cascade). Returns id + provider for the drawer's
-  // tagged picker.
-  const credentialsQuery = api.modelProvider.getAllForProject.useQuery(
-    { projectId: project?.id ?? "" },
-    { enabled: !!project?.id, refetchOnWindowFocus: false },
-  );
+  // ModelProviders. Must be the one-entry-per-row org listing:
+  // `getAllForProject` collapses rows by provider key, so two "custom"
+  // providers would surface as a single picker option and every other
+  // row in an existing policy renders as "Unknown credential".
+  const credentialsQuery =
+    api.modelProvider.listAllForOrganizationForFrontend.useQuery(
+      { organizationId: orgId },
+      { enabled: !!orgId, refetchOnWindowFocus: false },
+    );
 
   const [editingId, setEditingId] = useState<string | "new" | null>(null);
   const [policyToDelete, setPolicyToDelete] = useState<Policy | null>(null);
@@ -489,16 +491,16 @@ function RoutingPoliciesPage() {
         }
         availableCredentials={
           credentialsQuery.data
-            ? Object.entries(credentialsQuery.data)
-                .filter(([, mp]) => mp && mp.id)
-                .map(([providerKey, mp]: [string, any]) => ({
-                  id: mp.id as string,
-                  modelProviderName: mp.name ?? providerKey,
+            ? credentialsQuery.data.providers
+                .filter((mp) => !!mp.id)
+                .map((mp) => ({
+                  id: mp.id!,
+                  modelProviderName: mp.name ?? mp.provider,
                   slot: "primary",
                   disabledAt: mp.disabledAt
                     ? new Date(mp.disabledAt).toISOString()
                     : null,
-                  healthStatus: (mp.healthStatus as string) ?? "UNKNOWN",
+                  healthStatus: mp.healthStatus ?? "UNKNOWN",
                 }))
             : []
         }


### PR DESCRIPTION
Fixes #5354

## Summary
- The Routing Policies page fueled its provider picker with `modelProvider.getAllForProject`, which collapses stored rows by provider key — orgs with multiple providers of the same key (e.g. several `custom` OpenAI-compatible providers) saw only one option in "Add model provider", and existing policy rows referencing the others rendered as "Unknown credential"
- Switch to `listAllForOrganizationForFrontend`, which returns one entry per stored row (same query the Virtual Key drawers already use), mapping `name ?? provider` for the label

## Test plan
- [x] `pnpm typecheck`
- [x] Manually verified on a self-hosted org with three `custom` providers: picker lists all three by name, existing policies resolve every row (no "Unknown credential")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential selection in the routing policies drawer so available providers are listed more reliably, including cases with multiple providers.
  * Reduced “Unknown credential” display issues by using a more accurate organization-level credential list.
  * Better handled missing status and disabled timestamps when showing credential options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->