### PR TITLE
fix(aigateway): fall back to next provider on upstream 404

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -17,6 +17,7 @@ const (
 	ReasonSuccess        Reason = "success"
 	ReasonFallback       Reason = "fallback_success"
 	ReasonRetryable5xx   Reason = "retryable_5xx"
+	ReasonNotFound       Reason = "not_found"
 	ReasonRateLimit      Reason = "rate_limit"
 	ReasonTimeout        Reason = "timeout"
 	ReasonNetwork        Reason = "network"
@@ -88,6 +89,7 @@ var eventsPool = sync.Pool{
 // allocate a new map on every Walk call.
 var defaultTriggers = map[Reason]bool{
 	ReasonRetryable5xx: true,
+	ReasonNotFound:     true,
 	ReasonRateLimit:    true,
 	ReasonTimeout:      true,
 	ReasonNetwork:      true,

--- a/services/aigateway/app/dispatch.go
+++ b/services/aigateway/app/dispatch.go
@@ -72,16 +72,21 @@ func findCredential(creds []domain.Credential, id string) domain.Credential {
 
 func classifyProviderError(err error) retry.Reason {
 	// A forwarded upstream response classifies by its real HTTP status: a
-	// terminal client error (4xx other than 429) must NOT trigger credential
-	// fallback — retrying a "credit balance too low" or "invalid request" on
-	// the next key is pointless and only delays the terminal error reaching
-	// the client. Rate-limit (429) and server errors (5xx) stay retryable so
-	// the gateway still falls back across the credential chain.
+	// terminal client error (4xx other than 429/404) must NOT trigger
+	// credential fallback — retrying a "credit balance too low" or "invalid
+	// request" on the next key is pointless and only delays the terminal
+	// error reaching the client. 404 IS fallback-eligible: in multi-provider
+	// chains it usually means "this provider doesn't serve that model"
+	// (common with custom/OpenAI-compatible providers), and the next slot
+	// may. Rate-limit (429) and server errors (5xx) stay retryable so the
+	// gateway still falls back across the credential chain.
 	var ue *domain.UpstreamError
 	if errors.As(err, &ue) {
 		switch {
 		case ue.StatusCode == http.StatusTooManyRequests:
 			return retry.ReasonRateLimit
+		case ue.StatusCode == http.StatusNotFound:
+			return retry.ReasonNotFound
 		case ue.StatusCode >= 500:
 			return retry.ReasonRetryable5xx
 		default:

--- a/services/aigateway/app/dispatch_test.go
+++ b/services/aigateway/app/dispatch_test.go
@@ -383,6 +383,35 @@ func TestHandleChat_FallbackOnProviderError(t *testing.T) {
 	assert.Equal(t, 1, result.Meta.FallbackCount)
 }
 
+func TestHandleChat_FallbackOnUpstream404(t *testing.T) {
+	callCount := 0
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, cred domain.Credential) (*domain.Response, error) {
+			callCount++
+			if cred.ID == "cred-1" {
+				return nil, &domain.UpstreamError{StatusCode: 404, Message: "model not found"}
+			}
+			return successResponse(), nil
+		},
+	}
+
+	bundle := testBundle(
+		domain.Credential{ID: "cred-1", ProviderID: domain.ProviderOpenAI, APIKey: "sk-1"},
+		domain.Credential{ID: "cred-2", ProviderID: domain.ProviderOpenAI, APIKey: "sk-2"},
+	)
+	bundle.Config.Fallback.MaxAttempts = 2
+
+	application := New(
+		WithProviders(provider),
+		WithLogger(zap.NewNop()),
+	)
+
+	result, err := application.HandleChat(context.Background(), bundle, bytes.NewReader(testBody()), "gpt-4")
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+	assert.Equal(t, 1, result.Meta.FallbackCount)
+}
+
 func TestHandleChat_EmitsTraceAfterSuccess(t *testing.T) {
 	provider := &mockProvider{
 		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
@@ -567,8 +596,8 @@ func TestPeekStream(t *testing.T) {
 // A forwarded upstream error must drive credential fallback by its real HTTP
 // status: terminal 4xx (e.g. an Anthropic "credit balance too low" 400) is
 // non-retryable so the gateway stops instead of burning the next key on a
-// pointless retry; 429 and 5xx stay retryable so the fallback chain still
-// kicks in.
+// pointless retry; 404 ("model not served here"), 429 and 5xx stay retryable
+// so the fallback chain still kicks in.
 func TestClassifyProviderError_UpstreamError(t *testing.T) {
 	cases := []struct {
 		status int
@@ -578,7 +607,7 @@ func TestClassifyProviderError_UpstreamError(t *testing.T) {
 		{401, retry.ReasonNonRetryable},
 		{402, retry.ReasonNonRetryable},
 		{403, retry.ReasonNonRetryable},
-		{404, retry.ReasonNonRetryable},
+		{404, retry.ReasonNotFound},
 		{422, retry.ReasonNonRetryable},
 		{429, retry.ReasonRateLimit},
 		{500, retry.ReasonRetryable5xx},

--- a/services/aigateway/app/dispatch_test.go
+++ b/services/aigateway/app/dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -410,6 +411,42 @@ func TestHandleChat_FallbackOnUpstream404(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, callCount)
 	assert.Equal(t, 1, result.Meta.FallbackCount)
+}
+
+func TestHandleChat_TerminatesOnUpstream400(t *testing.T) {
+	callCount := 0
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, cred domain.Credential) (*domain.Response, error) {
+			callCount++
+			if cred.ID == "cred-1" {
+				return nil, &domain.UpstreamError{StatusCode: 400, Message: "invalid request"}
+			}
+			return successResponse(), nil
+		},
+	}
+
+	bundle := testBundle(
+		domain.Credential{ID: "cred-1", ProviderID: domain.ProviderOpenAI, APIKey: "sk-1"},
+		domain.Credential{ID: "cred-2", ProviderID: domain.ProviderOpenAI, APIKey: "sk-2"},
+	)
+	bundle.Config.Fallback.MaxAttempts = 2
+
+	application := New(
+		WithProviders(provider),
+		WithLogger(zap.NewNop()),
+	)
+
+	_, err := application.HandleChat(context.Background(), bundle, bytes.NewReader(testBody()), "gpt-4")
+
+	// A terminal 4xx (here a 400 "invalid request") must not fall back to the
+	// next credential: cred-1 is the only provider dialed, and the upstream
+	// status reaches the caller verbatim instead of being masked by a
+	// pointless retry on cred-2.
+	require.Error(t, err)
+	assert.Equal(t, 1, callCount)
+	var ue *domain.UpstreamError
+	require.True(t, errors.As(err, &ue))
+	assert.Equal(t, 400, ue.StatusCode)
 }
 
 func TestHandleChat_EmitsTraceAfterSuccess(t *testing.T) {


### PR DESCRIPTION
Fixes #5355

## Summary
- `classifyProviderError` treated every 4xx except 429 as non-retryable, so an upstream 404 killed the request even when the next provider in the chain serves the requested model — common with multiple `custom`/OpenAI-compatible providers behind one virtual key
- Add `retry.ReasonNotFound` as a default fallback trigger and classify upstream 404 as such; other 4xx (400/401/402/403/422…) remain terminal, and single-provider chains still surface the 404 unchanged

## Test plan
- [x] `go test ./...` in `services/aigateway` and `pkg/retry`
- [x] New behavioral test `TestHandleChat_FallbackOnUpstream404`: cred-1 returns 404 → chain advances to cred-2, `FallbackCount == 1`
- [x] Classification table updated: `{404 → ReasonNotFound}`
- [x] Verified live on a self-hosted deployment: first provider (embeddings-only backend) 404s a chat request, gateway falls back to the second provider, client receives 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The gateway now retries with fallback behavior when an upstream request returns **404 Not Found**, helping requests continue with another available option.
* **Bug Fixes**
  * Improved error handling so upstream **404** responses are treated as retryable for fallback purposes rather than non-retryable.
  * **429** and other server error retry classifications remain unchanged.
  * Added coverage to ensure **400** upstream errors terminate without fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->