### PR TITLE
feat(aigateway): bound cached VK config staleness with a ConfigTTL refresh

### DIFF
--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -81,6 +81,7 @@ type Service struct {
 	refreshThreshold time.Duration
 	softBump         time.Duration
 	hardGrace        time.Duration
+	configTTL        time.Duration
 
 	// Active orgs whose bundles are currently in L1. Populated on every
 	// storeL1, never cleared explicitly — entries that drop out of L1 via
@@ -107,6 +108,44 @@ type entry struct {
 	bundle        *domain.Bundle
 	softExpiresAt time.Time
 	hardExpiresAt time.Time
+	// configFetchedAt drives the config-staleness refresh: the bundle's
+	// auth (JWT exp) can outlive its config (credentials, base URLs,
+	// routing chain) by many minutes, and not every config mutation emits
+	// a change-feed event (e.g. direct DB writes). configRefreshing is the
+	// in-flight guard so at most one background config fetch runs per entry.
+	configFetchedAt  time.Time
+	configRefreshing bool
+}
+
+// configStale reports whether the entry's config is older than ttl.
+// ttl <= 0 disables staleness (never stale).
+func (e *entry) configStale(ttl time.Duration) bool {
+	if ttl <= 0 {
+		return false
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return time.Since(e.configFetchedAt) > ttl
+}
+
+// tryBeginConfigRefresh claims the per-entry config-refresh slot.
+func (e *entry) tryBeginConfigRefresh() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.configRefreshing {
+		return false
+	}
+	e.configRefreshing = true
+	return true
+}
+
+// endConfigRefresh releases the slot and stamps configFetchedAt so a
+// failed fetch retries only after the next full TTL, not on every request.
+func (e *entry) endConfigRefresh() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.configRefreshing = false
+	e.configFetchedAt = time.Now()
 }
 
 func (e *entry) softExpired() bool {
@@ -206,6 +245,13 @@ type Options struct {
 	L2            L2Store // optional, nil = skip L2
 	Resolver      KeyResolver
 	ConfigFetcher ConfigFetcher
+	// ConfigTTL is the max age of a cached bundle's config (credentials,
+	// base URLs, routing chain) before a background re-fetch. The change
+	// feed already evicts on admin mutations that emit events, but not
+	// every config change does (direct DB writes, mutations without a
+	// change-event kind) — this TTL is the safety net that bounds config
+	// staleness without a process restart. Default 60s. Negative disables.
+	ConfigTTL time.Duration
 	// ChangePoller is the optional control-plane /changes subscriber.
 	// When non-nil, the service spawns a per-org poll loop on Start that
 	// evicts L1 entries whose cached config has been invalidated by an
@@ -233,6 +279,12 @@ func New(opts Options) (*Service, error) {
 	if opts.HardGrace == 0 {
 		opts.HardGrace = 6 * time.Hour
 	}
+	if opts.ConfigTTL == 0 {
+		opts.ConfigTTL = 60 * time.Second
+	}
+	if opts.ConfigTTL < 0 {
+		opts.ConfigTTL = 0 // disabled
+	}
 
 	l1, err := lru.New[[64]byte, *entry](opts.LRUSize)
 	if err != nil {
@@ -254,6 +306,7 @@ func New(opts Options) (*Service, error) {
 		refreshThreshold: opts.RefreshThreshold,
 		softBump:         opts.SoftBump,
 		hardGrace:        opts.HardGrace,
+		configTTL:        opts.ConfigTTL,
 		stopCh:           make(chan struct{}),
 	}, nil
 }
@@ -278,6 +331,8 @@ func (s *Service) Resolve(ctx context.Context, rawKey string) (*domain.Bundle, e
 			// Fresh: serve, maybe trigger background refresh on near-expiry.
 			if e.nearSoftExpiry(s.refreshThreshold) {
 				go s.refreshBackground(rawKey, h) //nolint:gosec // G118: intentional fire-and-forget refresh detached from request
+			} else if e.configStale(s.configTTL) && e.tryBeginConfigRefresh() {
+				go s.refreshConfigBackground(h, e) //nolint:gosec // G118: intentional fire-and-forget refresh detached from request
 			}
 			return e.bundle, nil
 
@@ -420,9 +475,10 @@ func (s *Service) Stop() {
 
 func (s *Service) storeL1(h [64]byte, bundle *domain.Bundle) {
 	s.l1.Add(h, &entry{
-		bundle:        bundle,
-		softExpiresAt: bundle.ExpiresAt,
-		hardExpiresAt: bundle.ExpiresAt.Add(s.hardGrace),
+		bundle:          bundle,
+		softExpiresAt:   bundle.ExpiresAt,
+		hardExpiresAt:   bundle.ExpiresAt.Add(s.hardGrace),
+		configFetchedAt: time.Now(),
 	})
 	// Record the bundle's org so the change-feed loop knows which orgs
 	// to subscribe to. LoadOrStore is the first-write-wins shape — if
@@ -606,6 +662,38 @@ func (s *Service) refreshBackground(rawKey string, h [64]byte) {
 			zap.Error(err),
 		)
 	}
+}
+
+// refreshConfigBackground re-fetches only the bundle's config (not auth)
+// when it crosses ConfigTTL. On success the entry is replaced with a
+// shallow bundle copy carrying the fresh config — the entry's bundle
+// pointer stays immutable, so in-flight requests holding the old bundle
+// are unaffected. On failure the stale config keeps serving and the next
+// attempt waits a full TTL (endConfigRefresh stamps configFetchedAt).
+func (s *Service) refreshConfigBackground(h [64]byte, e *entry) {
+	defer e.endConfigRefresh()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	stale, _, _ := e.snapshot()
+	cfg, err := s.configFetcher.FetchConfig(ctx, stale.VirtualKeyID)
+	if err != nil {
+		s.logger.Warn("config_ttl_refresh_failed",
+			zap.String("vk_id", stale.VirtualKeyID),
+			zap.Error(err),
+		)
+		return
+	}
+
+	fresh := *stale
+	fresh.Config = cfg
+	fresh.Credentials = cfg.Credentials
+	s.storeL1(h, &fresh)
+	if s.l2 != nil {
+		s.l2.Set(ctx, string(h[:]), &fresh)
+	}
+	s.logger.Debug("config_ttl_refresh_success", zap.String("vk_id", stale.VirtualKeyID))
 }
 
 func (s *Service) loop(ctx context.Context) {

--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -689,6 +689,20 @@ func (s *Service) refreshConfigBackground(h [64]byte, e *entry) {
 	fresh := *stale
 	fresh.Config = cfg
 	fresh.Credentials = cfg.Credentials
+
+	// Guard against resurrecting an entry that another path evicted or
+	// replaced while FetchConfig was in flight: a change-feed eviction
+	// (VK/provider updated or revoked), an async auth rejection, or a
+	// foreground auth refresh that swapped in a newer bundle. If the live L1
+	// entry for h is no longer the one we started from, drop this result
+	// instead of writing a stale (possibly revoked) bundle back into L1/L2.
+	// Peek avoids perturbing LRU recency from this background goroutine.
+	if cur, ok := s.l1.Peek(h); !ok || cur != e {
+		s.logger.Debug("config_ttl_refresh_dropped_stale",
+			zap.String("vk_id", stale.VirtualKeyID),
+		)
+		return
+	}
 	s.storeL1(h, &fresh)
 	if s.l2 != nil {
 		s.l2.Set(ctx, string(h[:]), &fresh)

--- a/services/aigateway/adapters/authresolver/service_test.go
+++ b/services/aigateway/adapters/authresolver/service_test.go
@@ -433,3 +433,144 @@ func init() {
 	// Force errors.Is on string comparisons to surface as comparable in test failures.
 	_ = fmt.Sprintf
 }
+
+// --- ConfigTTL refresh --------------------------------------------------------
+
+// fakeConfigFetcher returns a programmable config, counting calls.
+type fakeConfigFetcher struct {
+	fakeResolver
+	cfg     domain.BundleConfig
+	cfgErr  error
+	fetches atomic.Int64
+}
+
+func (f *fakeConfigFetcher) FetchConfig(_ context.Context, _ string) (domain.BundleConfig, error) {
+	f.fetches.Add(1)
+	return f.cfg, f.cfgErr
+}
+
+// backdateConfig makes the L1 entry's config look older than the TTL.
+func backdateConfig(t *testing.T, svc *Service, rawKey string, age time.Duration) *entry {
+	t.Helper()
+	e, ok := svc.l1.Get(hashKey(rawKey))
+	if !ok {
+		t.Fatal("expected L1 entry")
+	}
+	e.mu.Lock()
+	e.configFetchedAt = time.Now().Add(-age)
+	e.mu.Unlock()
+	return e
+}
+
+func TestResolve_FreshEntry_ConfigPastTTL_RefreshesConfigInBackground(t *testing.T) {
+	fetcher := &fakeConfigFetcher{
+		cfg: domain.BundleConfig{Credentials: []domain.Credential{{ID: "cred-new"}}},
+	}
+	svc, _ := newService(t, Options{
+		Resolver:         &fetcher.fakeResolver,
+		ConfigFetcher:    fetcher,
+		ConfigTTL:        60 * time.Second,
+		RefreshThreshold: time.Second, // keep near-soft-expiry path out of the way
+	})
+
+	rawKey := "vk-lw-cfgttl_001"
+	bundle := freshBundle("vk_cfg_001", time.Now().Add(1*time.Hour))
+	bundle.Credentials = []domain.Credential{{ID: "cred-old"}}
+	svc.storeL1(hashKey(rawKey), bundle)
+	backdateConfig(t, svc, rawKey, 2*time.Minute)
+
+	got, err := svc.Resolve(context.Background(), rawKey)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// The triggering request still serves the (stale-config) bundle.
+	if got.Credentials[0].ID != "cred-old" {
+		t.Fatalf("expected triggering request to serve stale config, got %q", got.Credentials[0].ID)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if e, ok := svc.l1.Get(hashKey(rawKey)); ok {
+			b, _, _ := e.snapshot()
+			if len(b.Credentials) == 1 && b.Credentials[0].ID == "cred-new" {
+				return // refreshed
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("expected background config refresh to replace credentials within 2s")
+}
+
+func TestResolve_FreshEntry_ConfigTTLDisabled_NeverRefreshes(t *testing.T) {
+	fetcher := &fakeConfigFetcher{}
+	svc, _ := newService(t, Options{
+		Resolver:         &fetcher.fakeResolver,
+		ConfigFetcher:    fetcher,
+		ConfigTTL:        -1, // disabled
+		RefreshThreshold: time.Second,
+	})
+
+	rawKey := "vk-lw-cfgttl_002"
+	svc.storeL1(hashKey(rawKey), freshBundle("vk_cfg_002", time.Now().Add(1*time.Hour)))
+	backdateConfig(t, svc, rawKey, 10*time.Minute)
+
+	if _, err := svc.Resolve(context.Background(), rawKey); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if n := fetcher.fetches.Load(); n != 0 {
+		t.Fatalf("expected no config fetches with TTL disabled, got %d", n)
+	}
+}
+
+func TestResolve_FreshEntry_ConfigRefreshFailure_KeepsStaleAndWaitsFullTTL(t *testing.T) {
+	fetcher := &fakeConfigFetcher{cfgErr: errors.New("control plane down")}
+	svc, _ := newService(t, Options{
+		Resolver:         &fetcher.fakeResolver,
+		ConfigFetcher:    fetcher,
+		ConfigTTL:        60 * time.Second,
+		RefreshThreshold: time.Second,
+	})
+
+	rawKey := "vk-lw-cfgttl_003"
+	bundle := freshBundle("vk_cfg_003", time.Now().Add(1*time.Hour))
+	bundle.Credentials = []domain.Credential{{ID: "cred-old"}}
+	svc.storeL1(hashKey(rawKey), bundle)
+	e := backdateConfig(t, svc, rawKey, 2*time.Minute)
+
+	if _, err := svc.Resolve(context.Background(), rawKey); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && fetcher.fetches.Load() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if fetcher.fetches.Load() == 0 {
+		t.Fatal("expected one config fetch attempt")
+	}
+	// Wait for endConfigRefresh to release the slot and stamp fetchedAt.
+	for time.Now().Before(deadline) {
+		e.mu.Lock()
+		refreshing := e.configRefreshing
+		e.mu.Unlock()
+		if !refreshing {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Stale config keeps serving and the failed attempt stamped
+	// configFetchedAt, so the next request must NOT re-fetch.
+	got, err := svc.Resolve(context.Background(), rawKey)
+	if err != nil {
+		t.Fatalf("Resolve after failure: %v", err)
+	}
+	if got.Credentials[0].ID != "cred-old" {
+		t.Fatalf("expected stale config to keep serving, got %q", got.Credentials[0].ID)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if n := fetcher.fetches.Load(); n != 1 {
+		t.Fatalf("expected exactly one fetch until next TTL, got %d", n)
+	}
+}

--- a/services/aigateway/adapters/authresolver/service_test.go
+++ b/services/aigateway/adapters/authresolver/service_test.go
@@ -574,3 +574,88 @@ func TestResolve_FreshEntry_ConfigRefreshFailure_KeepsStaleAndWaitsFullTTL(t *te
 		t.Fatalf("expected exactly one fetch until next TTL, got %d", n)
 	}
 }
+
+// blockingConfigFetcher blocks inside FetchConfig until released, so a test
+// can evict or replace the L1 entry while the config fetch is still in flight.
+type blockingConfigFetcher struct {
+	fakeResolver
+	cfg     domain.BundleConfig
+	started chan struct{}
+	release chan struct{}
+	fetches atomic.Int64
+}
+
+func (f *blockingConfigFetcher) FetchConfig(_ context.Context, _ string) (domain.BundleConfig, error) {
+	f.fetches.Add(1)
+	f.started <- struct{}{}
+	<-f.release
+	return f.cfg, nil
+}
+
+// Regression: a background ConfigTTL refresh must not resurrect an entry that
+// another path evicted while the config fetch was in flight (e.g. the VK or
+// provider binding was revoked via the change feed). Otherwise the gateway
+// would keep serving stale or revoked config until the next invalidation. The
+// same live-entry guard covers the L2 write.
+//
+// Spec: specs/ai-gateway/auth-cache.feature
+func TestResolve_ConfigRefresh_EvictedMidFetch_NotResurrected(t *testing.T) {
+	fetcher := &blockingConfigFetcher{
+		cfg:     domain.BundleConfig{Credentials: []domain.Credential{{ID: "cred-new"}}},
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	svc, _ := newService(t, Options{
+		Resolver:         &fetcher.fakeResolver,
+		ConfigFetcher:    fetcher,
+		ConfigTTL:        60 * time.Second,
+		RefreshThreshold: time.Second,
+	})
+
+	rawKey := "vk-lw-cfgttl_race"
+	h := hashKey(rawKey)
+	bundle := freshBundle("vk_cfg_race", time.Now().Add(1*time.Hour))
+	bundle.Credentials = []domain.Credential{{ID: "cred-old"}}
+	svc.storeL1(h, bundle)
+	e := backdateConfig(t, svc, rawKey, 2*time.Minute)
+
+	// Triggering request serves the stale bundle and kicks off the refresh.
+	if _, err := svc.Resolve(context.Background(), rawKey); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// Once the fetch is in flight, evict the entry mid-fetch (change-feed revoke).
+	select {
+	case <-fetcher.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background config refresh did not start")
+	}
+	svc.l1.Remove(h)
+
+	// Release the fetch; the now-stale goroutine must drop its result.
+	close(fetcher.release)
+
+	// Wait for the goroutine to finish (endConfigRefresh clears the flag) so
+	// the store-or-drop decision is settled before asserting.
+	done := false
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		e.mu.Lock()
+		done = !e.configRefreshing
+		e.mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !done {
+		t.Fatal("config refresh goroutine did not finish")
+	}
+
+	if _, ok := svc.l1.Peek(h); ok {
+		t.Fatal("evicted entry was resurrected by the stale config-refresh goroutine")
+	}
+	if n := fetcher.fetches.Load(); n != 1 {
+		t.Fatalf("expected exactly one config fetch, got %d", n)
+	}
+}

--- a/services/aigateway/adapters/authresolver/service_test.go
+++ b/services/aigateway/adapters/authresolver/service_test.go
@@ -464,7 +464,12 @@ func backdateConfig(t *testing.T, svc *Service, rawKey string, age time.Duration
 
 func TestResolve_FreshEntry_ConfigPastTTL_RefreshesConfigInBackground(t *testing.T) {
 	fetcher := &fakeConfigFetcher{
-		cfg: domain.BundleConfig{Credentials: []domain.Credential{{ID: "cred-new"}}},
+		cfg: domain.BundleConfig{
+			Credentials: []domain.Credential{{ID: "cred-new"}},
+			// A non-Credentials Config field, to lock in that the whole Config
+			// is refreshed, not just the mirrored top-level Credentials.
+			AllowedModels: []string{"anthropic/claude-sonnet-4-5"},
+		},
 	}
 	svc, _ := newService(t, Options{
 		Resolver:         &fetcher.fakeResolver,
@@ -492,13 +497,19 @@ func TestResolve_FreshEntry_ConfigPastTTL_RefreshesConfigInBackground(t *testing
 	for time.Now().Before(deadline) {
 		if e, ok := svc.l1.Get(hashKey(rawKey)); ok {
 			b, _, _ := e.snapshot()
-			if len(b.Credentials) == 1 && b.Credentials[0].ID == "cred-new" {
-				return // refreshed
+			// The whole Config is refreshed, not just the mirrored Credentials:
+			// the top-level Credentials mirror and a non-Credentials Config
+			// field (AllowedModels) both reflect the freshly fetched config.
+			credRefreshed := len(b.Credentials) == 1 && b.Credentials[0].ID == "cred-new"
+			cfgRefreshed := len(b.Config.AllowedModels) == 1 &&
+				b.Config.AllowedModels[0] == "anthropic/claude-sonnet-4-5"
+			if credRefreshed && cfgRefreshed {
+				return // whole config refreshed
 			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("expected background config refresh to replace credentials within 2s")
+	t.Fatal("expected background config refresh to replace credentials and the full config within 2s")
 }
 
 func TestResolve_FreshEntry_ConfigTTLDisabled_NeverRefreshes(t *testing.T) {

--- a/services/aigateway/config.go
+++ b/services/aigateway/config.go
@@ -41,6 +41,11 @@ type ControlPlaneConfig struct {
 type AuthCacheConfig struct {
 	SoftBump  time.Duration `env:"SOFT_BUMP"`
 	HardGrace time.Duration `env:"HARD_GRACE"`
+	// ConfigTTL bounds how stale a cached virtual key's config
+	// (credentials, base URLs, routing chain) can get before a background
+	// re-fetch, covering config mutations that don't emit change-feed
+	// events. Default 60s; negative disables.
+	ConfigTTL time.Duration `env:"CONFIG_TTL"`
 }
 
 // CustomerTraceBridgeConfig holds customer trace bridge settings.

--- a/services/aigateway/deps.go
+++ b/services/aigateway/deps.go
@@ -111,6 +111,7 @@ func NewDeps(ctx context.Context, cfg Config) (context.Context, *Deps, error) {
 		Logger:        logger,
 		SoftBump:      cfg.AuthCache.SoftBump,
 		HardGrace:     cfg.AuthCache.HardGrace,
+		ConfigTTL:     cfg.AuthCache.ConfigTTL,
 	})
 	if err != nil {
 		return ctx, nil, fmt.Errorf("auth service init: %w", err)


### PR DESCRIPTION
Fixes #5356

## Summary
- Cached bundle config (credentials, base URLs, routing chain) was only refreshed at JWT exp or via change-feed eviction; mutations that emit no change event (e.g. direct DB writes) served stale config until process restart
- Add `ConfigTTL` (default 60s, env `LW_GATEWAY_AUTH_CACHE_CONFIG_TTL`, negative disables): when a fresh (auth-valid) L1 entry's config crosses the TTL, re-fetch only the config in the background and swap in a shallow bundle copy, so the request path stays non-blocking and entry bundle pointers stay immutable for in-flight requests
- Per-entry in-flight guard: at most one refresh per entry; a failed fetch keeps serving the stale config and waits a full TTL before retrying (no hot retry loop when the control plane is down)
- Change feed remains the fast path; the TTL bounds worst-case staleness for everything the feed doesn't cover

## Deployment Impact
- **Env vars:** adds one optional var, `LW_GATEWAY_AUTH_CACHE_CONFIG_TTL` (parsed into `AuthCacheConfig.ConfigTTL`), defaulting to `60s` when unset. A zero or negative value disables the background config refresh, restoring the prior behavior where config is only refreshed at JWT expiry or via change-feed eviction. No other env vars added or changed.
- **Helm values:** none added or changed. The var is optional with a safe default, so no chart edits are required.
- **Default `helm install` (no overrides):** the gateway starts with `ConfigTTL=60s`, so cached virtual-key config staleness is bounded to about 60s for mutations the change feed does not cover (e.g. direct DB writes). No operator action needed, and the change feed stays the fast path.
- **BYOC dataplane:** the gateway runs in the customer dataplane. The refresh is config-only, runs off the request path, and is capped at one in-flight fetch per active cache entry, so it adds at most a low-rate control-plane config fetch per active virtual key. A failed fetch keeps serving the last-known-good config and backs off a full TTL before retrying, so a control-plane blip does not become a dataplane retry storm.

## Test plan
- [x] `go test -race ./adapters/authresolver/`
- [x] New tests: background refresh replaces credentials within TTL; disabled TTL never fetches; fetch failure keeps stale config and does not re-fetch until the next TTL
- [x] Verified live on a self-hosted deployment: routing-policy and provider-model changes applied via SQL propagated in <=60s with no gateway restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable config staleness window for cached auth configuration, enabling background refresh of credentials and routing details when entries exceed the set age.
  * Introduced `CONFIG_TTL` (`AuthCacheConfig.ConfigTTL`, default 60s; negative/zero disables) to control refresh behavior for cached entries.
* **Bug Fixes**
  * Improved resilience by avoiding overwriting newer/evicted entries during background refresh.
  * Ensured failed background refreshes don't trigger immediate repeated retries while stale credentials continue serving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
