### PR TITLE
fix(docs): route PostHog via first-party proxy + docs-to-app attribution

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1194,7 +1194,7 @@
       "anchors": [
         {
           "anchor": "Sign In to LangWatch",
-          "href": "https://app.langwatch.ai",
+          "href": "https://app.langwatch.ai/?utm_source=docs&utm_medium=docs&utm_campaign=sidebar-signin",
           "icon": "house"
         },
         {
@@ -1218,7 +1218,7 @@
       },
       {
         "label": "Sign In",
-        "href": "https://app.langwatch.ai"
+        "href": "https://app.langwatch.ai/?utm_source=docs&utm_medium=docs&utm_campaign=navbar-signin"
       }
     ],
     "primary": {

--- a/docs/posthog.js
+++ b/docs/posthog.js
@@ -1,8 +1,20 @@
 !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageviewId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
 
+// api_host is the first-party reverse proxy served by the langwatch.ai
+// deployment (same PostHog EU project); direct *.posthog.com requests get
+// dropped by ad blockers, which our developer audience uses heavily. The
+// docs live under langwatch.ai/docs, so production traffic is same-origin;
+// Mintlify preview hosts send cross-origin, which PostHog's CORS allows.
+// The snippet above derives the array.js URL from api_host, so the script
+// also loads through the proxy (/ingest/static/array.js).
 posthog.init('phc_oOlj3H19T2JlGbFXmrGrjSLbDPDNyPKYdIFaTdrkXOY', {
-  api_host: 'https://eu.i.posthog.com',
+  api_host: 'https://langwatch.ai/ingest',
+  ui_host: 'https://eu.posthog.com',
   person_profiles: 'always',
+  // Mintlify navigates client-side after the first load; without this only
+  // the session's landing page fires $pageview and every subsequent docs
+  // page is invisible to analytics.
+  capture_pageview: 'history_change',
 });
 
 // Handle all click interactions for custom components (event delegation)


### PR DESCRIPTION
## Why

The docs are our highest-visibility asset (the claude-code integration page alone went 233 to 11,819 GSC impressions/month between March and June), and we want to measure docs to app.langwatch.ai signup conversion. Auditing PostHog project 66212 against the docs source surfaced three gaps, all fixable at config level:

**1. Client-side navigation pageviews are dropped.** The docs PostHog init has no `capture_pageview` setting and every docs `$pageview` carries `$config_defaults: unset`, so posthog-js only captures the initial page load. Mintlify navigates client-side after that, so every subsequent page a reader opens is invisible. The data shows the entry-page-only signature: 1,304 pageviews across 1,096 sessions in the last 14 days, i.e. 1.19 pages per session on a docs site.

```sql
SELECT properties.$config_defaults AS cfg, count() AS pv, count(DISTINCT properties.$session_id) AS sessions
FROM events
WHERE event = '$pageview' AND timestamp >= now() - INTERVAL 14 DAY
  AND properties.$host = 'langwatch.ai' AND properties.$pathname LIKE '/docs%'
GROUP BY cfg
-- unset | 1304 | 1096
```

**2. Ingestion goes direct to eu.i.posthog.com, which ad blockers drop.** 100% of docs events have no `$lib_custom_api_host` (direct ingestion), while the marketing site on the same origin already routes 100% of its pageviews through the first-party `langwatch.ai/ingest` Cloudflare Pages proxy (632/632 pageviews in the last 3 days) precisely because direct posthog.com endpoints are on the common blocklists and our audience is developers. The docs are served at `langwatch.ai/docs` (docs.langwatch.ai 301s there), so the proxy is same-origin for production docs traffic.

**3. Sign-in CTAs carry no attribution.** Cross-domain person stitching already works (same project key, cookie on `.langwatch.ai`): of 134 signups in the last 30 days, 51 have docs pageviews on their person, 27 of those with the first docs visit before signup. But nothing marks docs referrals in-app, and `$initial_referring_domain = langwatch.ai` cannot distinguish docs from marketing pages.

```sql
WITH signups AS (
  SELECT person_id, min(timestamp) AS signup_at FROM events
  WHERE event = 'onboarding_welcome.viewed' AND timestamp >= now() - INTERVAL 30 DAY
  GROUP BY person_id
), docs_first AS (
  SELECT person_id, min(timestamp) AS first_docs FROM events
  WHERE event = '$pageview' AND timestamp >= now() - INTERVAL 120 DAY
    AND properties.$host = 'langwatch.ai' AND properties.$pathname LIKE '/docs%'
  GROUP BY person_id
)
SELECT count() AS docs_touched, countIf(d.first_docs < s.signup_at) AS before_signup
FROM signups s INNER JOIN docs_first d ON s.person_id = d.person_id
-- 51 | 27 (out of 134 total signups)
```

## What changed

Docs config only, nothing else:

- `docs/posthog.js`: point `api_host` at the existing `https://langwatch.ai/ingest` first-party proxy, set `ui_host` to `https://eu.posthog.com`, and set `capture_pageview: 'history_change'` so Mintlify client-side navigations fire `$pageview`.
- `docs/docs.json`: add `utm_source=docs&utm_medium=docs&utm_campaign=sidebar-signin|navbar-signin` to the two global Sign In links to app.langwatch.ai (sidebar anchor and navbar). No per-page content edits.

## How it works

The loader snippet derives the array.js URL from `api_host`, so the SDK script itself also loads through the proxy (`/ingest/static/array.js`), which the proxy serves from PostHog's asset host with caching. Production docs traffic is same-origin with the proxy; Mintlify preview builds (`*.mintlify.app`) send cross-origin, which PostHog's CORS headers allow through the proxy.

## Test plan

- `node --check docs/posthog.js` and JSON validation of `docs/docs.json` pass.
- Live checks against production: `https://langwatch.ai/ingest/static/array.js` returns 200; a cross-origin `POST https://langwatch.ai/ingest/flags/?v=2` with `Origin: https://langwatch.mintlify.app` returns 200 with `access-control-allow-origin` echoing the origin.
- The docs page CSP (`content-security-policy` on langwatch.ai/docs responses) has no `connect-src` or `script-src` directives, so the proxy host is not blocked.
- After merge (Mintlify auto-deploys main): docs `$pageview` events should start carrying `$lib_custom_api_host = https://langwatch.ai/ingest`, pages per session should rise well above 1.19, and signups landing from docs CTAs will carry `utm_source=docs`.

## Anything surprising?

- docs.langwatch.ai contributes zero events in 90 days; it 301-redirects into `langwatch.ai/docs`, so a single ingestion origin covers everything.
- Expect a step change in docs pageview volume after this merges (client-side navigations plus previously ad-blocked visitors), so annotate the date in PostHog before comparing trends across it.

https://claude.ai/code/session_01Jba6y5WAL6LzH9a4KMZSRR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sign-in links in the docs to use tracked destinations, helping improve analytics for documentation traffic.
  * Adjusted analytics loading to use a first-party route and improved pageview tracking in the app, supporting more reliable measurement across page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->