### PR TITLE
fix(gateway): make the VK usage snippet copy-paste-correct for self-hosted and custom keys

### DIFF
--- a/langwatch/src/components/gateway/EligibleModelProvidersPreview.tsx
+++ b/langwatch/src/components/gateway/EligibleModelProvidersPreview.tsx
@@ -3,124 +3,14 @@ import { ExternalLink } from "lucide-react";
 import { useMemo } from "react";
 
 import { Link } from "~/components/ui/link";
-import { modelProviderRegistry } from "~/features/onboarding/regions/model-providers/registry";
 import { modelProviderIcons } from "~/server/modelProviders/iconsMap";
 
+import {
+  buildScopeHierarchy,
+  type OrgModelProvider,
+  resolveEligible,
+} from "./eligibleModelProviders";
 import type { VirtualKeyScopeEntry } from "./VirtualKeyScopePicker";
-
-type ScopeKey = `${VirtualKeyScopeEntry["scopeType"]}:${string}`;
-
-type OrgModelProvider = {
-  id?: string | null;
-  name?: string | null;
-  provider: string;
-  scopes: Array<{ scopeType: "ORGANIZATION" | "TEAM" | "PROJECT"; scopeId: string }>;
-  models?: string[] | null;
-  customModels?: Array<{ model: string }> | null;
-};
-
-type EligibleModelProvider = {
-  id: string;
-  provider: string;
-  label: string;
-  modelCount: number;
-  inheritedFrom: VirtualKeyScopeEntry;
-  defaultModel: string;
-};
-
-// Resolve the snippet-friendly model string for a provider row. The
-// gateway accepts both bare `gpt-5-mini` (OpenAI-SDK drop-in) and
-// `vendor/model` form. We emit the vendor-prefixed default per the
-// provider registry so a click on the row writes a model that the VK
-// can actually route to that specific provider.
-function resolveProviderDefaultModel(
-  providerKey: string,
-  providerLabel: string,
-  providerModels: string[],
-): string {
-  const registry = modelProviderRegistry.find(
-    (entry) => entry.backendModelProviderKey === providerKey,
-  );
-  const fallbackModel = providerModels[0];
-  const defaultModel = registry?.defaultModel ?? fallbackModel;
-  if (!defaultModel) {
-    // Best-effort: the registry has no default and the provider also
-    // shipped no models in scope. Emit the bare provider name; the
-    // gateway will surface a 404 the user can read instead of a silent
-    // empty model string.
-    return providerLabel.toLowerCase();
-  }
-  return `${providerKey}/${defaultModel}`;
-}
-
-/**
- * Resolves the union eligible-ModelProvider set for a multi-scope VirtualKey
- * client-side, mirroring `scopeResolver.eligibleModelProvidersForVk` on the
- * server. Inheritance rule from specs/ai-gateway/governance/vk-scope-inheritance.feature:
- *
- *   "A VK at scope S sees a ModelProvider P iff P's scope is an ancestor
- *    of S OR equal to S. ORG is the broadest, then TEAM, then PROJECT."
- *
- * Each surviving MP carries the broadest VK scope that admitted it (the
- * "inheritedFrom" chip in the picker UI) — that's the spec's
- * "via ORG"/"via TEAM:platform" annotation.
- */
-function resolveEligible(
-  scopes: VirtualKeyScopeEntry[],
-  providers: OrgModelProvider[],
-  hierarchy: {
-    organizationId: string | undefined;
-    teamOfProject: Map<string, string>;
-  },
-): EligibleModelProvider[] {
-  if (scopes.length === 0 || providers.length === 0) return [];
-  const matchesScope = (
-    mpScope: { scopeType: string; scopeId: string },
-    vkScope: VirtualKeyScopeEntry,
-  ): boolean => {
-    if (mpScope.scopeType === "ORGANIZATION") {
-      return mpScope.scopeId === hierarchy.organizationId;
-    }
-    if (mpScope.scopeType === "TEAM") {
-      if (vkScope.scopeType === "ORGANIZATION") return false;
-      if (vkScope.scopeType === "TEAM") return mpScope.scopeId === vkScope.scopeId;
-      const teamOfVkProject = hierarchy.teamOfProject.get(vkScope.scopeId);
-      return mpScope.scopeId === teamOfVkProject;
-    }
-    if (mpScope.scopeType === "PROJECT") {
-      return vkScope.scopeType === "PROJECT" && mpScope.scopeId === vkScope.scopeId;
-    }
-    return false;
-  };
-
-  const result = new Map<string, EligibleModelProvider>();
-  for (const provider of providers) {
-    if (!provider.id) continue;
-    for (const mpScope of provider.scopes) {
-      const winner = scopes.find((vkScope) => matchesScope(mpScope, vkScope));
-      if (!winner) continue;
-      if (result.has(provider.id)) continue;
-      const chatModels = provider.models ?? [];
-      const customCount = provider.customModels?.length ?? 0;
-      const label = provider.name ?? provider.provider;
-      result.set(provider.id, {
-        id: provider.id,
-        provider: provider.provider,
-        label,
-        modelCount: chatModels.length + customCount,
-        inheritedFrom: winner,
-        defaultModel: resolveProviderDefaultModel(
-          provider.provider,
-          label,
-          chatModels,
-        ),
-      });
-    }
-  }
-  return Array.from(result.values()).sort((a, b) =>
-    a.label.localeCompare(b.label),
-  );
-}
 
 function scopeChipLabel(
   scope: VirtualKeyScopeEntry,
@@ -188,13 +78,10 @@ export function EligibleModelProvidersPreview({
   selectedModel?: string;
   onSelectProviderModel?: (model: string) => void;
 }) {
-  const hierarchy = useMemo(() => {
-    const teamOfProject = new Map<string, string>();
-    for (const p of availableProjects) {
-      if (p.teamId) teamOfProject.set(p.id, p.teamId);
-    }
-    return { organizationId, teamOfProject };
-  }, [availableProjects, organizationId]);
+  const hierarchy = useMemo(
+    () => buildScopeHierarchy(availableProjects, organizationId),
+    [availableProjects, organizationId],
+  );
 
   const names = useMemo(() => {
     const teamNames = new Map(availableTeams.map((t) => [t.id, t.name]));
@@ -353,13 +240,10 @@ export function EligibleModelProvidersSummary({
   isLoading?: boolean;
   providers: OrgModelProvider[];
 }) {
-  const hierarchy = useMemo(() => {
-    const teamOfProject = new Map<string, string>();
-    for (const p of availableProjects) {
-      if (p.teamId) teamOfProject.set(p.id, p.teamId);
-    }
-    return { organizationId, teamOfProject };
-  }, [availableProjects, organizationId]);
+  const hierarchy = useMemo(
+    () => buildScopeHierarchy(availableProjects, organizationId),
+    [availableProjects, organizationId],
+  );
 
   const names = useMemo(() => {
     const teamNames = new Map(availableTeams.map((t) => [t.id, t.name]));
@@ -433,5 +317,3 @@ export function ConfigureModelProvidersLink({
     </Link>
   );
 }
-
-export type { OrgModelProvider, EligibleModelProvider };

--- a/langwatch/src/components/gateway/VirtualKeyCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/VirtualKeyCreateDrawer.tsx
@@ -24,6 +24,10 @@ import {
   EligibleModelProvidersPreview,
   EligibleModelProvidersSummary,
 } from "./EligibleModelProvidersPreview";
+import {
+  firstEligibleDefaultModel,
+  type OrgModelProvider,
+} from "./eligibleModelProviders";
 import { FieldInfoTooltip } from "./FieldInfoTooltip";
 import {
   VirtualKeyScopePicker,
@@ -34,7 +38,12 @@ type VirtualKeyCreateDrawerProps = {
   organizationId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onCreated: (result: { id: string; name: string; secret: string }) => void;
+  onCreated: (result: {
+    id: string;
+    name: string;
+    secret: string;
+    model?: string;
+  }) => void;
 };
 
 export function VirtualKeyCreateDrawer({
@@ -139,6 +148,12 @@ export function VirtualKeyCreateDrawer({
         id: result.virtualKey.id,
         name: result.virtualKey.name,
         secret: result.secret,
+        model: firstEligibleDefaultModel({
+          scopes,
+          providers: providers as OrgModelProvider[],
+          availableProjects,
+          organizationId,
+        }),
       });
       reset();
       onOpenChange(false);

--- a/langwatch/src/components/gateway/VirtualKeySecretReveal.tsx
+++ b/langwatch/src/components/gateway/VirtualKeySecretReveal.tsx
@@ -101,8 +101,8 @@ export function VirtualKeySecretReveal({
                   <Alert.Title>24-hour grace window active.</Alert.Title>
                   <Alert.Description>
                     The previous secret keeps working for 24 hours so clients
-                    can roll over gradually. After that it hard- fails with a
-                    401 even though this key stays active.
+                    can roll over gradually. After that it hard-fails with a 401
+                    even though this key stays active.
                   </Alert.Description>
                 </Alert.Content>
               </Alert.Root>

--- a/langwatch/src/components/gateway/VirtualKeySecretReveal.tsx
+++ b/langwatch/src/components/gateway/VirtualKeySecretReveal.tsx
@@ -20,6 +20,11 @@ type VirtualKeySecretRevealProps = {
   onClose: () => void;
   keyName: string;
   secret: string;
+  // Model string for the copy-paste usage example. Threaded from the
+  // create/rotate surface (which knows the key's eligible providers) so a
+  // self-hosted / custom key shows a model it can actually serve instead of
+  // the OpenAI-only default.
+  model?: string;
   // Distinguishes the initial-mint flow from a rotation. Rotations
   // also carry a grace-window banner (previous secret stays valid
   // for 24h so clients can roll over without a cliff).
@@ -36,6 +41,7 @@ export function VirtualKeySecretReveal({
   onClose,
   keyName,
   secret,
+  model,
   kind = "create",
 }: VirtualKeySecretRevealProps) {
   const [revealed, setRevealed] = useState(false);
@@ -150,7 +156,7 @@ export function VirtualKeySecretReveal({
               </VStack>
 
               <Separator />
-              <VirtualKeyUsageSnippet secret={secret} />
+              <VirtualKeyUsageSnippet secret={secret} model={model} />
             </VStack>
           </Dialog.Body>
           <Dialog.Footer>

--- a/langwatch/src/components/gateway/VirtualKeySecretReveal.tsx
+++ b/langwatch/src/components/gateway/VirtualKeySecretReveal.tsx
@@ -75,115 +75,111 @@ export function VirtualKeySecretReveal({
       closeOnEscape={false}
     >
       <Dialog.Content bg="bg" maxWidth="560px">
-          <Dialog.Header>
-            <Dialog.Title>
-              {kind === "rotate"
-                ? "Save your rotated secret"
-                : "Save your virtual key secret"}
-            </Dialog.Title>
-          </Dialog.Header>
-          <Dialog.Body>
-            <VStack align="stretch" gap={4}>
-              <Alert.Root status="warning">
+        <Dialog.Header>
+          <Dialog.Title>
+            {kind === "rotate"
+              ? "Save your rotated secret"
+              : "Save your virtual key secret"}
+          </Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Body>
+          <VStack align="stretch" gap={4}>
+            <Alert.Root status="warning">
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Title>You will only see this secret once.</Alert.Title>
+                <Alert.Description>
+                  LangWatch stores only a hash. Copy and save the raw secret in
+                  your password manager or secret store before closing.
+                </Alert.Description>
+              </Alert.Content>
+            </Alert.Root>
+            {kind === "rotate" && (
+              <Alert.Root status="info">
                 <Alert.Indicator />
                 <Alert.Content>
-                  <Alert.Title>You will only see this secret once.</Alert.Title>
+                  <Alert.Title>24-hour grace window active.</Alert.Title>
                   <Alert.Description>
-                    LangWatch stores only a hash. Copy and save the raw secret
-                    in your password manager or secret store before closing.
+                    The previous secret keeps working for 24 hours so clients
+                    can roll over gradually. After that it hard- fails with a
+                    401 even though this key stays active.
                   </Alert.Description>
                 </Alert.Content>
               </Alert.Root>
-              {kind === "rotate" && (
-                <Alert.Root status="info">
-                  <Alert.Indicator />
-                  <Alert.Content>
-                    <Alert.Title>24-hour grace window active.</Alert.Title>
-                    <Alert.Description>
-                      The previous secret keeps working for 24 hours so
-                      clients can roll over gradually. After that it hard-
-                      fails with a 401 even though this key stays active.
-                    </Alert.Description>
-                  </Alert.Content>
-                </Alert.Root>
-              )}
+            )}
 
-              <VStack align="start" gap={1}>
-                <Text fontSize="sm" color="fg.muted">
-                  Virtual key name
-                </Text>
-                <Text fontWeight="medium">{keyName}</Text>
-              </VStack>
-
-              <VStack align="stretch" gap={2}>
-                <Text fontSize="sm" color="fg.muted">
-                  Secret
-                </Text>
-                <HStack
-                  border="1px solid"
-                  borderColor="border.subtle"
-                  borderRadius="md"
-                  padding={2}
-                  gap={2}
-                >
-                  <Box flex={1} overflowX="auto">
-                    <Code
-                      fontSize="sm"
-                      bg="transparent"
-                      paddingX={0}
-                      whiteSpace="nowrap"
-                    >
-                      {revealed ? secret : maskSecret(secret)}
-                    </Code>
-                  </Box>
-                  <IconButton
-                    aria-label={revealed ? "Hide secret" : "Reveal secret"}
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setRevealed((v) => !v)}
-                  >
-                    {revealed ? <EyeOff size={14} /> : <Eye size={14} />}
-                  </IconButton>
-                  <IconButton
-                    aria-label="Copy secret"
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleCopy}
-                  >
-                    {copied ? <Check size={14} /> : <Copy size={14} />}
-                  </IconButton>
-                </HStack>
-              </VStack>
-
-              <Separator />
-              <VirtualKeyUsageSnippet secret={secret} model={model} />
+            <VStack align="start" gap={1}>
+              <Text fontSize="sm" color="fg.muted">
+                Virtual key name
+              </Text>
+              <Text fontWeight="medium">{keyName}</Text>
             </VStack>
-          </Dialog.Body>
-          <Dialog.Footer>
-            <HStack width="full" gap={4}>
-              <HStack>
-                <input
-                  type="checkbox"
-                  id="vk-secret-confirm"
-                  checked={confirmed}
-                  onChange={(e) => setConfirmed(e.target.checked)}
-                />
-                <label htmlFor="vk-secret-confirm">
-                  <Text fontSize="sm">
-                    I've saved the secret in a safe place.
-                  </Text>
-                </label>
-              </HStack>
-              <Box flex={1} />
-              <Button
-                colorPalette="orange"
-                onClick={close}
-                disabled={!confirmed}
+
+            <VStack align="stretch" gap={2}>
+              <Text fontSize="sm" color="fg.muted">
+                Secret
+              </Text>
+              <HStack
+                border="1px solid"
+                borderColor="border.subtle"
+                borderRadius="md"
+                padding={2}
+                gap={2}
               >
-                Close
-              </Button>
+                <Box flex={1} overflowX="auto">
+                  <Code
+                    fontSize="sm"
+                    bg="transparent"
+                    paddingX={0}
+                    whiteSpace="nowrap"
+                  >
+                    {revealed ? secret : maskSecret(secret)}
+                  </Code>
+                </Box>
+                <IconButton
+                  aria-label={revealed ? "Hide secret" : "Reveal secret"}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setRevealed((v) => !v)}
+                >
+                  {revealed ? <EyeOff size={14} /> : <Eye size={14} />}
+                </IconButton>
+                <IconButton
+                  aria-label="Copy secret"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleCopy}
+                >
+                  {copied ? <Check size={14} /> : <Copy size={14} />}
+                </IconButton>
+              </HStack>
+            </VStack>
+
+            <Separator />
+            <VirtualKeyUsageSnippet secret={secret} model={model} />
+          </VStack>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <HStack width="full" gap={4}>
+            <HStack>
+              <input
+                type="checkbox"
+                id="vk-secret-confirm"
+                checked={confirmed}
+                onChange={(e) => setConfirmed(e.target.checked)}
+              />
+              <label htmlFor="vk-secret-confirm">
+                <Text fontSize="sm">
+                  I've saved the secret in a safe place.
+                </Text>
+              </label>
             </HStack>
-          </Dialog.Footer>
+            <Box flex={1} />
+            <Button colorPalette="orange" onClick={close} disabled={!confirmed}>
+              Close
+            </Button>
+          </HStack>
+        </Dialog.Footer>
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/langwatch/src/components/gateway/VirtualKeyUsageSnippet.tsx
+++ b/langwatch/src/components/gateway/VirtualKeyUsageSnippet.tsx
@@ -31,11 +31,11 @@ export type VirtualKeyUsageSnippetProps = {
   /** Heading shown above the language selector. */
   title?: string;
   /**
-   * Model string embedded in every snippet's chat-completions call.
-   * Defaults to the bare OpenAI-SDK drop-in (`gpt-5-mini`); pass
-   * `${vendor}/${model}` to disambiguate when the VK fans out across
-   * multiple providers. The VK detail page rewrites this when the
-   * user clicks an eligible-MP row.
+   * Model string embedded in every snippet's chat-completions call, in
+   * resolver-safe `vendor/model` form (e.g. `custom/Qwen2.5-0.5B-Instruct`).
+   * Callers thread the key's first eligible provider so the example names a
+   * model the key can actually serve. Falls back to `gpt-5-mini` only as a
+   * placeholder when the caller has no provider context.
    */
   model?: string;
 };
@@ -59,14 +59,12 @@ interface TabItem {
  * the post-create secret-reveal dialog + the VK detail page so the
  * copy-secret → first-request path has no dead ends.
  */
-// Snippets default to the bare model name (`gpt-5-mini`) — matches
-// the OpenAI-SDK drop-in replacement story that's the primary value
-// prop for the gateway. `provider/model` form is still accepted at
-// dispatch time as the explicit disambiguator for multi-provider VKs
-// (see ai-gateway/model-aliases docs) but isn't what we want a new
-// user to copy-paste, because single-provider VKs would forward the
-// prefix upstream and get 4xx. Closes @ariana #63/#64/#66, @rchaves
-// hands-on dogfood finding.
+// `gpt-5-mini` is only the fallback placeholder for callers that pass no
+// model. The real default is threaded in by the create / reveal / detail
+// surfaces as the key's first eligible provider in `vendor/model` form. The
+// gateway resolver strips the `vendor/` prefix before dispatch (it only
+// selects the provider, then forwards the bare model), so the prefixed form
+// is always safe, including for single-provider keys.
 export function VirtualKeyUsageSnippet({
   secret,
   gatewayBaseUrl,

--- a/langwatch/src/components/gateway/VirtualKeyUsageSnippet.tsx
+++ b/langwatch/src/components/gateway/VirtualKeyUsageSnippet.tsx
@@ -12,19 +12,8 @@ import {
 import { useMemo } from "react";
 import type { HighlighterGeneric } from "shiki";
 import { useColorMode } from "~/components/ui/color-mode";
-
-const HOSTED_GATEWAY_URL = "https://gateway.langwatch.ai/v1";
-const LOCAL_GATEWAY_URL = "http://localhost:5563/v1";
-
-function resolveGatewayBaseUrl(override?: string): string {
-  if (override) return override;
-  if (typeof window === "undefined") return HOSTED_GATEWAY_URL;
-  // Local dev: gateway runs on :5563 alongside the app on :5560. Docker-
-  // Compose + helm ingress use the same port. Any other hostname assumes
-  // the hosted SaaS URL — self-hosters can override via the prop.
-  if (window.location.hostname === "localhost") return LOCAL_GATEWAY_URL;
-  return HOSTED_GATEWAY_URL;
-}
+import { usePublicEnv } from "~/hooks/usePublicEnv";
+import { resolveSnippetGatewayBaseUrl } from "./gatewaySnippetUrl";
 
 export type VirtualKeyUsageSnippetProps = {
   /**
@@ -85,8 +74,12 @@ export function VirtualKeyUsageSnippet({
   model = "gpt-5-mini",
 }: VirtualKeyUsageSnippetProps) {
   const { colorMode } = useColorMode();
+  const publicEnv = usePublicEnv();
   const credential = secret ?? "$LANGWATCH_VK_SECRET";
-  const resolvedBaseUrl = resolveGatewayBaseUrl(gatewayBaseUrl);
+  const resolvedBaseUrl = resolveSnippetGatewayBaseUrl(
+    gatewayBaseUrl,
+    publicEnv.data?.GATEWAY_BASE_URL,
+  );
   const showRetrievalHint = !secret;
 
   const tabItems: TabItem[] = useMemo(() => {

--- a/langwatch/src/components/gateway/__tests__/VirtualKeyUsageSnippet.integration.test.tsx
+++ b/langwatch/src/components/gateway/__tests__/VirtualKeyUsageSnippet.integration.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The copy-paste usage example must name a model the key can actually serve.
+ * A key bound to a self-hosted / custom provider that shows the OpenAI-only
+ * `gpt-5-mini` 404s on the first call, so the create/reveal/detail surfaces
+ * thread the key's eligible-provider model (in resolver-safe `vendor/model`
+ * form) into this snippet. These tests pin that the passed model reaches the
+ * rendered code and that `gpt-5-mini` is only the no-context fallback.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { VirtualKeyUsageSnippet } from "../VirtualKeyUsageSnippet";
+
+vi.mock("~/hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({ data: { GATEWAY_BASE_URL: "http://localhost:5563" } }),
+}));
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("given a VirtualKeyUsageSnippet", () => {
+  afterEach(() => cleanup());
+
+  describe("when a custom-provider model is passed", () => {
+    it("embeds custom/<model> in the copy-paste example, not gpt-5-mini", async () => {
+      const { container } = render(
+        <VirtualKeyUsageSnippet
+          secret="vk-lw-testsecret"
+          model="custom/Qwen2.5-0.5B-Instruct"
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await waitFor(() => {
+        expect(container.textContent).toContain("custom/Qwen2.5-0.5B-Instruct");
+      });
+      expect(container.textContent).not.toContain("gpt-5-mini");
+    });
+  });
+
+  describe("when no model is passed", () => {
+    it("falls back to the gpt-5-mini placeholder", async () => {
+      const { container } = render(
+        <VirtualKeyUsageSnippet secret="vk-lw-testsecret" />,
+        { wrapper: Wrapper },
+      );
+
+      await waitFor(() => {
+        expect(container.textContent).toContain("gpt-5-mini");
+      });
+    });
+  });
+});

--- a/langwatch/src/components/gateway/__tests__/VirtualKeyUsageSnippet.integration.test.tsx
+++ b/langwatch/src/components/gateway/__tests__/VirtualKeyUsageSnippet.integration.test.tsx
@@ -27,6 +27,7 @@ describe("given a VirtualKeyUsageSnippet", () => {
   afterEach(() => cleanup());
 
   describe("when a custom-provider model is passed", () => {
+    /** @scenario Usage example defaults to a model the key can serve */
     it("embeds custom/<model> in the copy-paste example, not gpt-5-mini", async () => {
       const { container } = render(
         <VirtualKeyUsageSnippet
@@ -44,6 +45,7 @@ describe("given a VirtualKeyUsageSnippet", () => {
   });
 
   describe("when no model is passed", () => {
+    /** @scenario Usage example falls back to a safe placeholder when no provider is resolvable */
     it("falls back to the gpt-5-mini placeholder", async () => {
       const { container } = render(
         <VirtualKeyUsageSnippet secret="vk-lw-testsecret" />,

--- a/langwatch/src/components/gateway/__tests__/eligibleModelProviders.unit.test.ts
+++ b/langwatch/src/components/gateway/__tests__/eligibleModelProviders.unit.test.ts
@@ -69,6 +69,7 @@ describe("firstEligibleDefaultModel", () => {
   };
 
   describe("when a custom provider is eligible at the key's scope", () => {
+    /** @scenario Usage example on the key detail page matches the key's provider */
     it("returns custom/<model> so the usage example is servable", () => {
       expect(
         firstEligibleDefaultModel({

--- a/langwatch/src/components/gateway/__tests__/eligibleModelProviders.unit.test.ts
+++ b/langwatch/src/components/gateway/__tests__/eligibleModelProviders.unit.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  firstEligibleDefaultModel,
+  type OrgModelProvider,
+  resolveProviderDefaultModel,
+} from "../eligibleModelProviders";
+
+describe("resolveProviderDefaultModel", () => {
+  describe("when the provider is a self-hosted custom endpoint", () => {
+    it("uses the first custom model in resolver-safe vendor/model form", () => {
+      expect(
+        resolveProviderDefaultModel(
+          "custom",
+          "Custom",
+          [],
+          [{ modelId: "Qwen2.5-0.5B-Instruct" }],
+        ),
+      ).toBe("custom/Qwen2.5-0.5B-Instruct");
+    });
+
+    it("does not fall back to the OpenAI-only gpt-5-mini", () => {
+      expect(
+        resolveProviderDefaultModel(
+          "custom",
+          "Custom",
+          [],
+          [{ modelId: "Qwen2.5-0.5B-Instruct" }],
+        ),
+      ).not.toContain("gpt-5-mini");
+    });
+
+    it("prefers a registry chat model over a custom model when both exist", () => {
+      expect(
+        resolveProviderDefaultModel(
+          "custom",
+          "Custom",
+          ["llama-3"],
+          [{ modelId: "Qwen2.5-0.5B-Instruct" }],
+        ),
+      ).toBe("custom/llama-3");
+    });
+  });
+
+  describe("when the provider is a first-class registry provider", () => {
+    it("prefixes the registry default with the provider key", () => {
+      const result = resolveProviderDefaultModel("openai", "OpenAI", []);
+      expect(result.startsWith("openai/")).toBe(true);
+    });
+  });
+
+  describe("when no model can be resolved", () => {
+    it("returns the bare provider label so the gateway surfaces a readable error", () => {
+      expect(resolveProviderDefaultModel("custom", "My vLLM", [])).toBe(
+        "my vllm",
+      );
+    });
+  });
+});
+
+describe("firstEligibleDefaultModel", () => {
+  const customProvider: OrgModelProvider = {
+    id: "mp-1",
+    name: "Self-hosted vLLM",
+    provider: "custom",
+    scopes: [{ scopeType: "ORGANIZATION", scopeId: "org-1" }],
+    models: [],
+    customModels: [{ modelId: "Qwen2.5-0.5B-Instruct" }],
+  };
+
+  describe("when a custom provider is eligible at the key's scope", () => {
+    it("returns custom/<model> so the usage example is servable", () => {
+      expect(
+        firstEligibleDefaultModel({
+          scopes: [{ scopeType: "ORGANIZATION", scopeId: "org-1" }],
+          providers: [customProvider],
+          availableProjects: [],
+          organizationId: "org-1",
+        }),
+      ).toBe("custom/Qwen2.5-0.5B-Instruct");
+    });
+  });
+
+  describe("when no provider is eligible at the key's scope", () => {
+    it("returns undefined so the caller can fall back to a placeholder", () => {
+      expect(
+        firstEligibleDefaultModel({
+          scopes: [{ scopeType: "ORGANIZATION", scopeId: "org-1" }],
+          providers: [],
+          availableProjects: [],
+          organizationId: "org-1",
+        }),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/components/gateway/__tests__/gatewaySnippetUrl.unit.test.ts
+++ b/langwatch/src/components/gateway/__tests__/gatewaySnippetUrl.unit.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HOSTED_GATEWAY_URL,
+  resolveSnippetGatewayBaseUrl,
+} from "../gatewaySnippetUrl";
+
+describe("resolveSnippetGatewayBaseUrl", () => {
+  describe("when this deployment exposes its gateway URL via publicEnv", () => {
+    it("uses the deployment URL with a /v1 suffix, not the SaaS default", () => {
+      expect(
+        resolveSnippetGatewayBaseUrl(
+          undefined,
+          "https://gw.selfhosted.example",
+        ),
+      ).toBe("https://gw.selfhosted.example/v1");
+    });
+
+    it("strips a trailing slash before appending /v1", () => {
+      expect(
+        resolveSnippetGatewayBaseUrl(undefined, "http://localhost:5563/"),
+      ).toBe("http://localhost:5563/v1");
+    });
+  });
+
+  describe("when an explicit override prop is provided", () => {
+    it("uses the override verbatim over the deployment URL", () => {
+      expect(
+        resolveSnippetGatewayBaseUrl(
+          "https://override.example/v1",
+          "https://gw.selfhosted.example",
+        ),
+      ).toBe("https://override.example/v1");
+    });
+  });
+
+  describe("when publicEnv has not resolved yet", () => {
+    it("falls back to the hosted SaaS URL", () => {
+      expect(resolveSnippetGatewayBaseUrl(undefined, undefined)).toBe(
+        HOSTED_GATEWAY_URL,
+      );
+      expect(resolveSnippetGatewayBaseUrl(undefined, null)).toBe(
+        HOSTED_GATEWAY_URL,
+      );
+    });
+  });
+});

--- a/langwatch/src/components/gateway/eligibleModelProviders.ts
+++ b/langwatch/src/components/gateway/eligibleModelProviders.ts
@@ -115,30 +115,40 @@ export function resolveEligible(
     return false;
   };
 
+  // Rank the VK scope tiers so a provider admitted at several scopes shows the
+  // broadest one (ORG > TEAM > PROJECT) in its "inheritedFrom" badge.
+  const scopeBreadth = { ORGANIZATION: 0, TEAM: 1, PROJECT: 2 } as const;
   const result = new Map<string, EligibleModelProvider>();
   for (const provider of providers) {
     if (!provider.id) continue;
+    let bestWinner: VirtualKeyScopeEntry | undefined;
     for (const mpScope of provider.scopes) {
       const winner = scopes.find((vkScope) => matchesScope(mpScope, vkScope));
       if (!winner) continue;
-      if (result.has(provider.id)) continue;
-      const chatModels = provider.models ?? [];
-      const customCount = provider.customModels?.length ?? 0;
-      const label = provider.name ?? provider.provider;
-      result.set(provider.id, {
-        id: provider.id,
-        provider: provider.provider,
-        label,
-        modelCount: chatModels.length + customCount,
-        inheritedFrom: winner,
-        defaultModel: resolveProviderDefaultModel(
-          provider.provider,
-          label,
-          chatModels,
-          provider.customModels,
-        ),
-      });
+      if (
+        !bestWinner ||
+        scopeBreadth[winner.scopeType] < scopeBreadth[bestWinner.scopeType]
+      ) {
+        bestWinner = winner;
+      }
     }
+    if (!bestWinner) continue;
+    const chatModels = provider.models ?? [];
+    const customCount = provider.customModels?.length ?? 0;
+    const label = provider.name ?? provider.provider;
+    result.set(provider.id, {
+      id: provider.id,
+      provider: provider.provider,
+      label,
+      modelCount: chatModels.length + customCount,
+      inheritedFrom: bestWinner,
+      defaultModel: resolveProviderDefaultModel(
+        provider.provider,
+        label,
+        chatModels,
+        provider.customModels,
+      ),
+    });
   }
   return Array.from(result.values()).sort((a, b) =>
     a.label.localeCompare(b.label),

--- a/langwatch/src/components/gateway/eligibleModelProviders.ts
+++ b/langwatch/src/components/gateway/eligibleModelProviders.ts
@@ -1,0 +1,163 @@
+import { modelProviderRegistry } from "~/features/onboarding/regions/model-providers/registry";
+
+import type { VirtualKeyScopeEntry } from "./VirtualKeyScopePicker";
+
+export type OrgModelProvider = {
+  id?: string | null;
+  name?: string | null;
+  provider: string;
+  scopes: Array<{
+    scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
+    scopeId: string;
+  }>;
+  models?: string[] | null;
+  customModels?: Array<{ modelId: string }> | null;
+};
+
+export type EligibleModelProvider = {
+  id: string;
+  provider: string;
+  label: string;
+  modelCount: number;
+  inheritedFrom: VirtualKeyScopeEntry;
+  defaultModel: string;
+};
+
+export type ScopeHierarchy = {
+  organizationId: string | undefined;
+  teamOfProject: Map<string, string>;
+};
+
+/**
+ * Resolve the snippet-friendly model string for a provider row. The gateway
+ * accepts both bare `gpt-5-mini` (OpenAI-SDK drop-in) and `vendor/model` form,
+ * and its resolver strips the `vendor/` prefix before dispatch (it only
+ * selects the provider, then forwards the bare model upstream), so the
+ * prefixed form is always safe. We emit the vendor-prefixed default so a key
+ * bound to a self-hosted vLLM/LiteLLM provider names a model that endpoint
+ * actually serves instead of the OpenAI-only `gpt-5-mini`.
+ *
+ * Precedence: registry default (openai/anthropic/... have one) -> the
+ * provider's first registry chat model -> the provider's first custom model
+ * (this is where self-hosted "custom" providers keep their model ids, since
+ * the custom registry entry has no default). Bare provider label only as a
+ * last resort so the gateway surfaces a readable 404 instead of an empty
+ * model field.
+ */
+export function resolveProviderDefaultModel(
+  providerKey: string,
+  providerLabel: string,
+  providerModels: string[],
+  customModels?: Array<{ modelId: string }> | null,
+): string {
+  const registry = modelProviderRegistry.find(
+    (entry) => entry.backendModelProviderKey === providerKey,
+  );
+  const fallbackModel = providerModels[0] ?? customModels?.[0]?.modelId;
+  const defaultModel = registry?.defaultModel ?? fallbackModel;
+  if (!defaultModel) {
+    return providerLabel.toLowerCase();
+  }
+  return `${providerKey}/${defaultModel}`;
+}
+
+/**
+ * Build the team-of-project lookup the eligibility walk needs to map a VK's
+ * PROJECT scope up to its owning TEAM.
+ */
+export function buildScopeHierarchy(
+  availableProjects: Array<{ id: string; teamId?: string }>,
+  organizationId: string | undefined,
+): ScopeHierarchy {
+  const teamOfProject = new Map<string, string>();
+  for (const p of availableProjects) {
+    if (p.teamId) teamOfProject.set(p.id, p.teamId);
+  }
+  return { organizationId, teamOfProject };
+}
+
+/**
+ * Resolves the union eligible-ModelProvider set for a multi-scope VirtualKey
+ * client-side, mirroring `scopeResolver.eligibleModelProvidersForVk` on the
+ * server. Inheritance rule from specs/ai-gateway/governance/vk-scope-inheritance.feature:
+ *
+ *   "A VK at scope S sees a ModelProvider P iff P's scope is an ancestor
+ *    of S OR equal to S. ORG is the broadest, then TEAM, then PROJECT."
+ *
+ * Each surviving MP carries the broadest VK scope that admitted it (the
+ * "inheritedFrom" chip in the picker UI).
+ */
+export function resolveEligible(
+  scopes: VirtualKeyScopeEntry[],
+  providers: OrgModelProvider[],
+  hierarchy: ScopeHierarchy,
+): EligibleModelProvider[] {
+  if (scopes.length === 0 || providers.length === 0) return [];
+  const matchesScope = (
+    mpScope: { scopeType: string; scopeId: string },
+    vkScope: VirtualKeyScopeEntry,
+  ): boolean => {
+    if (mpScope.scopeType === "ORGANIZATION") {
+      return mpScope.scopeId === hierarchy.organizationId;
+    }
+    if (mpScope.scopeType === "TEAM") {
+      if (vkScope.scopeType === "ORGANIZATION") return false;
+      if (vkScope.scopeType === "TEAM")
+        return mpScope.scopeId === vkScope.scopeId;
+      const teamOfVkProject = hierarchy.teamOfProject.get(vkScope.scopeId);
+      return mpScope.scopeId === teamOfVkProject;
+    }
+    if (mpScope.scopeType === "PROJECT") {
+      return (
+        vkScope.scopeType === "PROJECT" && mpScope.scopeId === vkScope.scopeId
+      );
+    }
+    return false;
+  };
+
+  const result = new Map<string, EligibleModelProvider>();
+  for (const provider of providers) {
+    if (!provider.id) continue;
+    for (const mpScope of provider.scopes) {
+      const winner = scopes.find((vkScope) => matchesScope(mpScope, vkScope));
+      if (!winner) continue;
+      if (result.has(provider.id)) continue;
+      const chatModels = provider.models ?? [];
+      const customCount = provider.customModels?.length ?? 0;
+      const label = provider.name ?? provider.provider;
+      result.set(provider.id, {
+        id: provider.id,
+        provider: provider.provider,
+        label,
+        modelCount: chatModels.length + customCount,
+        inheritedFrom: winner,
+        defaultModel: resolveProviderDefaultModel(
+          provider.provider,
+          label,
+          chatModels,
+          provider.customModels,
+        ),
+      });
+    }
+  }
+  return Array.from(result.values()).sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+}
+
+/**
+ * The snippet-ready default model for a VK, in resolver-safe `vendor/model`
+ * form: the first eligible provider's default. Undefined when no provider is
+ * eligible/resolvable yet (callers fall back to a placeholder). This is what
+ * makes the copy-paste usage example name a model the key can actually serve.
+ */
+export function firstEligibleDefaultModel(args: {
+  scopes: VirtualKeyScopeEntry[];
+  providers: OrgModelProvider[];
+  availableProjects: Array<{ id: string; teamId?: string }>;
+  organizationId: string | undefined;
+}): string | undefined {
+  const { scopes, providers, availableProjects, organizationId } = args;
+  const hierarchy = buildScopeHierarchy(availableProjects, organizationId);
+  return resolveEligible(scopes, providers, hierarchy)[0]?.defaultModel;
+}

--- a/langwatch/src/components/gateway/gatewaySnippetUrl.ts
+++ b/langwatch/src/components/gateway/gatewaySnippetUrl.ts
@@ -5,8 +5,8 @@ export const HOSTED_GATEWAY_URL = "https://gateway.langwatch.ai/v1";
  * Resolve the `base_url` embedded in the AI Gateway copy-paste snippets.
  *
  * Priority:
- *   1. `override` — explicit prop (already a full base_url incl. `/v1`).
- *   2. `deploymentBaseUrl` — this deployment's own gateway URL from
+ *   1. `override`: explicit prop (already a full base_url incl. `/v1`).
+ *   2. `deploymentBaseUrl`: this deployment's own gateway URL from
  *      publicEnv (`GATEWAY_BASE_URL`), returned WITHOUT the `/v1` suffix the
  *      OpenAI `base_url` needs, so it is appended here. This is what makes
  *      self-hosted installs show their own ingress instead of the SaaS URL.

--- a/langwatch/src/components/gateway/gatewaySnippetUrl.ts
+++ b/langwatch/src/components/gateway/gatewaySnippetUrl.ts
@@ -1,0 +1,24 @@
+/** SaaS fallback shown during SSR / before the publicEnv query resolves. */
+export const HOSTED_GATEWAY_URL = "https://gateway.langwatch.ai/v1";
+
+/**
+ * Resolve the `base_url` embedded in the AI Gateway copy-paste snippets.
+ *
+ * Priority:
+ *   1. `override` — explicit prop (already a full base_url incl. `/v1`).
+ *   2. `deploymentBaseUrl` — this deployment's own gateway URL from
+ *      publicEnv (`GATEWAY_BASE_URL`), returned WITHOUT the `/v1` suffix the
+ *      OpenAI `base_url` needs, so it is appended here. This is what makes
+ *      self-hosted installs show their own ingress instead of the SaaS URL.
+ *   3. SaaS fallback while publicEnv is still loading.
+ */
+export function resolveSnippetGatewayBaseUrl(
+  override: string | undefined,
+  deploymentBaseUrl: string | null | undefined,
+): string {
+  if (override) return override;
+  if (deploymentBaseUrl) {
+    return `${deploymentBaseUrl.replace(/\/+$/, "")}/v1`;
+  }
+  return HOSTED_GATEWAY_URL;
+}

--- a/langwatch/src/pages/settings/gateway/virtual-keys.tsx
+++ b/langwatch/src/pages/settings/gateway/virtual-keys.tsx
@@ -55,6 +55,10 @@ type CreatedSecret = {
   id: string;
   name: string;
   secret: string;
+  // Resolver-safe `vendor/model` example for the reveal snippet, computed
+  // from the key's eligible providers at create time. Undefined for
+  // list-page rotations, where the snippet falls back to its default.
+  model?: string;
   // Differentiates mint flow (initial creation) from rotate — the
   // reveal dialog adds a 24h-grace banner on rotations.
   kind: "create" | "rotate";
@@ -510,6 +514,7 @@ function VirtualKeysPage() {
         onClose={() => setRevealSecret(null)}
         keyName={revealSecret?.name ?? ""}
         secret={revealSecret?.secret ?? ""}
+        model={revealSecret?.model}
         kind={revealSecret?.kind ?? "create"}
       />
       {orgId && (

--- a/langwatch/src/pages/settings/gateway/virtual-keys/[id].tsx
+++ b/langwatch/src/pages/settings/gateway/virtual-keys/[id].tsx
@@ -32,6 +32,10 @@ import {
   EligibleModelProvidersPreview,
   EligibleModelProvidersSummary,
 } from "~/components/gateway/EligibleModelProvidersPreview";
+import {
+  firstEligibleDefaultModel,
+  type OrgModelProvider,
+} from "~/components/gateway/eligibleModelProviders";
 import { FieldInfoTooltip } from "~/components/gateway/FieldInfoTooltip";
 import { GuardrailAttachmentsSection } from "~/components/gateway/GuardrailAttachmentsSection";
 import { VirtualKeyEditDrawer } from "~/components/gateway/VirtualKeyEditDrawer";
@@ -121,18 +125,38 @@ function VirtualKeyDetailPage() {
     name: string;
     secret: string;
   } | null>(null);
-  // Drives the model name written into the "How to use" snippet. Starts
-  // at the bare OpenAI-SDK default; clicking a provider row in the
-  // eligible-MP preview rewrites this to `${vendor}/${defaultModel}` so
-  // the copy-pasteable example points at a model the VK can actually
-  // serve through that provider.
-  const [snippetModel, setSnippetModel] = useState<string>("gpt-5-mini");
+  // Manual override for the model written into the "How to use" snippet.
+  // Null until the user clicks a provider row in the eligible-MP preview;
+  // otherwise the snippet model is derived from the key's first eligible
+  // provider (see snippetModel below).
+  const [snippetModelOverride, setSnippetModelOverride] = useState<
+    string | null
+  >(null);
 
   const canUpdate = hasPermission("virtualKeys:update");
   const canRotate = hasPermission("virtualKeys:rotate");
   const canAttachGuardrails = hasPermission("gatewayGuardrails:attach");
 
   const vk = detailQuery.data;
+
+  // The model shown in the "How to use" snippet: the manual override wins,
+  // else the key's first eligible provider in resolver-safe `vendor/model`
+  // form (so a self-hosted / custom key shows `custom/<model>`, not the
+  // OpenAI-only `gpt-5-mini`). `gpt-5-mini` is only the placeholder shown
+  // before the eligible providers resolve.
+  const computedDefaultModel = useMemo(
+    () =>
+      firstEligibleDefaultModel({
+        scopes: vk?.scopes ?? [],
+        providers: (orgProvidersQuery.data?.providers ??
+          []) as OrgModelProvider[],
+        availableProjects,
+        organizationId: orgId,
+      }),
+    [vk?.scopes, orgProvidersQuery.data?.providers, availableProjects, orgId],
+  );
+  const snippetModel =
+    snippetModelOverride ?? computedDefaultModel ?? "gpt-5-mini";
 
   // Guardrails are project-scoped: only a VK reachable from exactly one
   // PROJECT scope has a single guardrail surface to edit.
@@ -382,7 +406,7 @@ function VirtualKeyDetailPage() {
                         (orgProvidersQuery.data?.providers ?? []) as any
                       }
                       selectedModel={snippetModel}
-                      onSelectProviderModel={setSnippetModel}
+                      onSelectProviderModel={setSnippetModelOverride}
                     />
                   </Box>
                 </VStack>
@@ -445,6 +469,7 @@ function VirtualKeyDetailPage() {
         onClose={() => setRevealSecret(null)}
         keyName={revealSecret?.name ?? ""}
         secret={revealSecret?.secret ?? ""}
+        model={snippetModel}
         kind="rotate"
       />
     </AiGatewayLayout>

--- a/langwatch/src/server/api/routers/publicEnv.ts
+++ b/langwatch/src/server/api/routers/publicEnv.ts
@@ -1,3 +1,4 @@
+import { resolveGatewayBaseUrl } from "@ee/governance/services/gatewayUrl";
 import { z } from "zod";
 
 import { env } from "../../../env.mjs";
@@ -30,15 +31,14 @@ export const publicEnvRouter = publicProcedure
       IS_SAAS: env.IS_SAAS,
       // AI Gateway public base URL (no /v1 suffix) for the copy-paste SDK
       // snippets in VirtualKeyUsageSnippet. Self-hosted deployments must see
-      // their own ingress, not the SaaS default. Mirrors the resolution in
-      // ee/governance/services/gatewayUrl.ts (resolveGatewayBaseUrl); kept
-      // inline to avoid a core -> ee import, so the two must stay in sync.
-      GATEWAY_BASE_URL:
-        env.LW_GATEWAY_PUBLIC_URL ??
-        env.LW_GATEWAY_BASE_URL ??
-        (env.IS_SAAS
-          ? "https://gateway.langwatch.ai"
-          : "http://localhost:5563"),
+      // their own ingress, not the SaaS default. Shares the single resolver
+      // used by the CLI surfaces (login ceremony, personal-VK reveal) so the
+      // public SDK URL and CLI URL can't drift.
+      GATEWAY_BASE_URL: resolveGatewayBaseUrl({
+        publicUrl: env.LW_GATEWAY_PUBLIC_URL,
+        baseUrl: env.LW_GATEWAY_BASE_URL,
+        isSaas: env.IS_SAAS,
+      }),
       SHOW_OPS_IN_MAIN_SIDEBAR: isOpsSidebarEmail(ctx.session?.user?.email),
       POSTHOG_KEY: env.POSTHOG_KEY,
       POSTHOG_HOST: env.POSTHOG_HOST,

--- a/langwatch/src/server/api/routers/publicEnv.ts
+++ b/langwatch/src/server/api/routers/publicEnv.ts
@@ -28,6 +28,17 @@ export const publicEnvRouter = publicProcedure
       HAS_EMAIL_PROVIDER_KEY:
         !!env.SENDGRID_API_KEY || !!(env.USE_AWS_SES && env.AWS_REGION),
       IS_SAAS: env.IS_SAAS,
+      // AI Gateway public base URL (no /v1 suffix) for the copy-paste SDK
+      // snippets in VirtualKeyUsageSnippet. Self-hosted deployments must see
+      // their own ingress, not the SaaS default. Mirrors the resolution in
+      // ee/governance/services/gatewayUrl.ts (resolveGatewayBaseUrl); kept
+      // inline to avoid a core -> ee import, so the two must stay in sync.
+      GATEWAY_BASE_URL:
+        env.LW_GATEWAY_PUBLIC_URL ??
+        env.LW_GATEWAY_BASE_URL ??
+        (env.IS_SAAS
+          ? "https://gateway.langwatch.ai"
+          : "http://localhost:5563"),
       SHOW_OPS_IN_MAIN_SIDEBAR: isOpsSidebarEmail(ctx.session?.user?.email),
       POSTHOG_KEY: env.POSTHOG_KEY,
       POSTHOG_HOST: env.POSTHOG_HOST,

--- a/specs/ai-gateway/virtual-keys.feature
+++ b/specs/ai-gateway/virtual-keys.feature
@@ -63,6 +63,35 @@ Feature: AI Gateway — Virtual Keys
     And after dismissal the full secret can never be retrieved again
     And only the key prefix "vk-lw-xxxx…" is visible in the list
 
+  # ============================================================================
+  # Usage-snippet default model. The copy-paste example must name a model the
+  # key can actually serve. A key bound to a self-hosted OpenAI-compatible
+  # provider (vLLM, LiteLLM) that shows the OpenAI drop-in "gpt-5-mini" sends a
+  # model the endpoint has never heard of, so the first copy-paste call 404s.
+  # The gateway strips the provider prefix before dispatch, so the
+  # "<provider>/<model>" form is always safe: it selects the provider, then
+  # forwards the bare model name upstream.
+  # ============================================================================
+
+  @integration
+  Scenario: Usage example defaults to a model the key can serve
+    Given a virtual key scoped to a custom provider whose model is "Qwen2.5-0.5B-Instruct"
+    When the secret-reveal dialog shows the usage example after create
+    Then the example calls model "custom/Qwen2.5-0.5B-Instruct"
+    And it does not fall back to "gpt-5-mini"
+
+  @integration
+  Scenario: Usage example on the key detail page matches the key's provider
+    Given a virtual key scoped only to a custom provider whose model is "Qwen2.5-0.5B-Instruct"
+    When I open the key detail page usage example
+    Then the example calls model "custom/Qwen2.5-0.5B-Instruct"
+
+  @integration
+  Scenario: Usage example falls back to a safe placeholder when no provider is resolvable
+    Given a virtual key whose eligible providers cannot be resolved on the client
+    When the usage example renders
+    Then the example calls model "gpt-5-mini" as a safe placeholder
+
   @integration
   Scenario: Virtual key secret is stored as peppered HMAC-SHA256 hash
     Given I created a virtual key "demo-key" with secret "vk-lw-01HZX9K3M…"


### PR DESCRIPTION
## Summary

The AI Gateway "Usage example" snippet (the VK secret-reveal dialog and the VK detail page) was wrong in two ways for self-hosted and custom-provider keys, so the copy-pasted example failed on the first call. Both surfaced while dogfooding the gateway against a self-hosted vLLM.

1. **`base_url`** resolved with a client-side hostname heuristic that fell back to the hosted SaaS URL (`gateway.langwatch.ai`) for any non-localhost host, so self-hosted installs pointed at the wrong gateway.
2. **`model`** hardcoded `gpt-5-mini`, which a key bound to a self-hosted OpenAI-compatible provider (vLLM, LiteLLM) cannot serve, so the first call 404s.

## Fix

### base_url
- Expose the deployment's resolved gateway URL via `publicEnv` as `GATEWAY_BASE_URL` (`LW_GATEWAY_PUBLIC_URL ?? LW_GATEWAY_BASE_URL ?? the saas/local default`), reusing the same `resolveGatewayBaseUrl` the CLI surfaces already use so the two cannot drift.
- `VirtualKeyUsageSnippet` reads it and appends `/v1`, so all three surfaces (create reveal, rotate reveal, VK detail page) show this install's own ingress. The divergent client-side hostname heuristic is removed. Resolution extracted to `resolveSnippetGatewayBaseUrl` with unit tests.

### model
- Derive the example `model` from the key's first eligible provider in resolver-safe `vendor/model` form (e.g. `custom/<model>`) instead of the hardcoded `gpt-5-mini`. The create-reveal dialog, rotate-reveal dialog, and detail page all thread it through.
- The gateway resolver strips the `vendor/` prefix before dispatch (it selects the provider, then forwards the bare model), so the prefixed form is always safe, including for single-provider keys. `gpt-5-mini` remains only as a placeholder shown before the eligible providers resolve.
- Extracted the eligible-provider derivation into a shared module and fixed it to resolve custom providers from their `customModels` (the custom registry entry has no default), which also corrects the detail-page provider picker.

## Test plan

- [x] Unit: `gatewaySnippetUrl.unit.test.ts`, `eligibleModelProviders.unit.test.ts` (custom resolves to `custom/<model>`, registry providers get their prefix, empty fallback)
- [x] Integration: `VirtualKeyUsageSnippet.integration.test.tsx` (renders the passed model, falls back to the placeholder when none is passed)
- [x] `pnpm typecheck`
- [x] Browser QA against a real self-hosted vLLM serving `Qwen/Qwen2.5-0.5B-Instruct`: created a VK bound to the vLLM provider and confirmed the reveal dialog and detail page both show `model="custom/Qwen/Qwen2.5-0.5B-Instruct"`, not `gpt-5-mini`. Confirmed vLLM serves that model (200 + token usage), which is exactly what the resolver forwards after stripping the `custom/` prefix.

## Screenshots

Self-hosted deployment: the snippet shows the deployment's own gateway URL, not the SaaS default:

![snippet self-hosted url](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5362/snippet-selfhosted-url.png)

Custom/vLLM key: the create-reveal dialog defaults the example to a model the key can serve (`custom/Qwen/Qwen2.5-0.5B-Instruct`):

![reveal dialog custom model](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5362/servable-model/reveal-dialog-custom-model.png)

The detail page snippet and eligible-provider picker, each provider shown in `vendor/model` form ("Local vLLM" auto-selected first):

![detail snippet eligible providers](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5362/servable-model/detail-snippet-eligible-providers.png)

<!-- qa-marker-5362 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage example snippets and secret-reveal dialogs can now include an eligible model in the copy-paste output (using the `custom/<model>` format when applicable).
  * Virtual key creation now returns an optional default model used to drive the usage snippet and the key detail page preview.
  * Public environment API now exposes `GATEWAY_BASE_URL` for consistent tooling URLs.
* **Bug Fixes**
  * Gateway base URL resolution now prioritizes explicit overrides, trims trailing slashes, appends `/v1`, and reliably falls back when runtime settings aren’t ready.
* **Tests**
  * Added unit/integration coverage for base URL behavior and custom-model vs placeholder (`gpt-5-mini`) snippet rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
