### PR TITLE
test(analytics): share evaluation_runs cleanup helper across integration tests (#5295)

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/cross-evaluator-groupby.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/cross-evaluator-groupby.integration.test.ts
@@ -33,6 +33,7 @@ import type { FlattenAnalyticsMetricsEnum } from "../../registry";
 import type { AggregationTypes } from "../../types";
 import { seedSpans } from "./test-utils/clickhouse-fixtures";
 import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import { deleteEvaluationRunsByTenant } from "./test-utils/clickhouse-cleanup";
 
 const TENANT_ID = "test-cross-eval-2668";
 
@@ -149,15 +150,7 @@ describe("cross-evaluator-groupby", () => {
 
   afterAll(async () => {
     await cleanupTestData(TENANT_ID);
-
-    // cleanupTestData does not delete from evaluation_runs — clean up manually
-    const rawClient = getTestClickHouseClient();
-    if (rawClient) {
-      await rawClient.exec({
-        query: `ALTER TABLE evaluation_runs DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
-        query_params: { tenantId: TENANT_ID },
-      });
-    }
+    await deleteEvaluationRunsByTenant({ client: ch, tenantId: TENANT_ID });
   });
 
   describe("regression: issue #2668 — groupByKey evaluator filter removed from global WHERE", () => {

--- a/langwatch/src/server/analytics/clickhouse/__tests__/filter-evaluation-queries.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/filter-evaluation-queries.integration.test.ts
@@ -22,6 +22,7 @@ import type { FlattenAnalyticsMetricsEnum } from "../../registry";
 import type { AggregationTypes } from "../../types";
 import { seedSpans } from "./test-utils/clickhouse-fixtures";
 import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import { deleteEvaluationRunsByTenant } from "./test-utils/clickhouse-cleanup";
 
 const TENANT_ID = "test-filter-eval-2660";
 
@@ -102,15 +103,7 @@ describe("filter-evaluation-queries", () => {
 
   afterAll(async () => {
     await cleanupTestData(TENANT_ID);
-
-    // cleanupTestData does not delete from evaluation_runs — clean up manually
-    const rawClient = getTestClickHouseClient();
-    if (rawClient) {
-      await rawClient.exec({
-        query: `ALTER TABLE evaluation_runs DELETE WHERE TenantId = {tenantId:String}`,
-        query_params: { tenantId: TENANT_ID },
-      });
-    }
+    await deleteEvaluationRunsByTenant({ client: ch, tenantId: TENANT_ID });
   });
 
   describe("regression: issue #2660 — IN subqueries with LIMIT 1 BY", () => {

--- a/langwatch/src/server/analytics/clickhouse/__tests__/offline-experiment-evaluations-joinability.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/offline-experiment-evaluations-joinability.integration.test.ts
@@ -33,6 +33,7 @@ import { buildTimeseriesQuery } from "../aggregation-builder";
 import { resetParamCounter } from "../filter-translator";
 import type { FlattenAnalyticsMetricsEnum } from "../../registry";
 import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import { deleteEvaluationRunsByTenant } from "./test-utils/clickhouse-cleanup";
 
 const TENANT_ID = "test-offline-exp-3900-fixed";
 
@@ -253,15 +254,7 @@ describe("offline-experiment evaluations on Custom Graphs", () => {
 
   afterAll(async () => {
     await cleanupTestData(TENANT_ID);
-
-    // cleanupTestData does not delete from evaluation_runs — clean up manually
-    const rawClient = getTestClickHouseClient();
-    if (rawClient) {
-      await rawClient.exec({
-        query: `ALTER TABLE evaluation_runs DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
-        query_params: { tenantId: TENANT_ID },
-      });
-    }
+    await deleteEvaluationRunsByTenant({ client: ch, tenantId: TENANT_ID });
   });
 
   describe("given trace_summaries rows exist for each offline-experiment cell traceId", () => {

--- a/langwatch/src/server/analytics/clickhouse/__tests__/test-utils/clickhouse-cleanup.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/test-utils/clickhouse-cleanup.ts
@@ -1,0 +1,34 @@
+/**
+ * ClickHouse test-data cleanup utilities for analytics integration tests.
+ *
+ * The shared `cleanupTestData` helper does not cover the `evaluation_runs`
+ * table, so analytics tests that seed it are responsible for removing their own
+ * rows in `afterAll`.
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+
+/**
+ * Delete every `evaluation_runs` row for a tenant, synchronously.
+ *
+ * Takes the wrapped client (`wrapWithDefaultSettings`) so cleanup carries the
+ * same default settings as the queries under test, rather than the bare client.
+ * Always runs with `mutations_sync = 1` so the mutation finishes before the next
+ * test file starts, preventing cross-file `evaluation_runs` bleed. A nullish
+ * client is a no-op so a failed `beforeAll` does not mask its own error with a
+ * teardown crash.
+ */
+export async function deleteEvaluationRunsByTenant({
+  client,
+  tenantId,
+}: {
+  client: ClickHouseClient | null | undefined;
+  tenantId: string;
+}): Promise<void> {
+  if (!client) return;
+
+  await client.exec({
+    query: `ALTER TABLE evaluation_runs DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
+    query_params: { tenantId },
+  });
+}

--- a/langwatch/src/server/analytics/clickhouse/__tests__/trace-eval-mix-inflation.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/trace-eval-mix-inflation.integration.test.ts
@@ -32,6 +32,7 @@ import type { FlattenAnalyticsMetricsEnum } from "../../registry";
 import type { AggregationTypes } from "../../types";
 import { seedSpans } from "./test-utils/clickhouse-fixtures";
 import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import { deleteEvaluationRunsByTenant } from "./test-utils/clickhouse-cleanup";
 
 const TENANT_ID = "test-trace-eval-mix-3088";
 
@@ -111,15 +112,7 @@ describe("trace-eval-mix-inflation (#3088)", () => {
 
   afterAll(async () => {
     await cleanupTestData(TENANT_ID);
-
-    // cleanupTestData does not delete from evaluation_runs — clean up manually
-    const rawClient = getTestClickHouseClient();
-    if (rawClient) {
-      await rawClient.exec({
-        query: `ALTER TABLE evaluation_runs DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
-        query_params: { tenantId: TENANT_ID },
-      });
-    }
+    await deleteEvaluationRunsByTenant({ client: ch, tenantId: TENANT_ID });
   });
 
   /** Pull a single metric value out of the first current-period row. */


### PR DESCRIPTION
## Ticket

Closes #5295. The analytics ClickHouse integration tests each build a wrapped client (`wrapWithDefaultSettings`) for the queries under test, but their `afterAll` cleanup of `evaluation_runs` reached for the bare client instead, copied file to file. The ticket asks for a shared-helper audit so these cleanups use the wrapped client consistently.

## G-START verdict

PROCEED. Verified against current main (`3fc9dde`): all four files still hold the duplicated bare-client cleanup, and the divergence below is still present. Not superseded by any open PR.

## Change

Add one shared helper, `deleteEvaluationRunsByTenant({ client, tenantId })`, in `__tests__/test-utils/clickhouse-cleanup.ts`, and route all four `afterAll` blocks through it passing the wrapped `ch` client:

- `trace-eval-mix-inflation.integration.test.ts`
- `cross-evaluator-groupby.integration.test.ts`
- `filter-evaluation-queries.integration.test.ts`
- `offline-experiment-evaluations-joinability.integration.test.ts`

Two concrete gains beyond the dedup:

1. **Consistency (the ticket):** cleanup now runs through `wrapWithDefaultSettings`, so it carries the same default settings as the queries under test, instead of the bare `getTestClickHouseClient()`.
2. **A real divergence fixed:** `filter-evaluation-queries` was the odd one out, deleting `evaluation_runs` **without** `SETTINGS mutations_sync = 1`. That left its cleanup mutation asynchronous and able to bleed rows into the next test file. The helper always applies `mutations_sync = 1`, so every file now cleans up synchronously.

The helper no-ops on a nullish client, preserving the previous `if (rawClient)` guard so a failed `beforeAll` cannot mask its own error with a teardown crash. Scoped to the four test files plus the new helper; no product code touched.

## Evidence

- **AC: cleanups use the wrapped client, via one shared helper.** New `deleteEvaluationRunsByTenant` in `test-utils/clickhouse-cleanup.ts`; the four `afterAll` blocks now call it with `client: ch` (the `wrapWithDefaultSettings` client). `grep -c getTestClickHouseClient` on each file drops from 3 to 2 (only the `beforeAll` seed path remains).
- **AC: behavior preserved end-to-end.** Focused integration slice against real ClickHouse:
  ```
  pnpm test:integration run <the 4 files>
  Test Files  4 passed (4)
  Tests  13 passed (13)
  EXIT=0
  ```
- **Typecheck:** `pnpm typecheck` -> EXIT=0.
- **Hygiene:** diff carries no em/en dashes (the replaced blocks removed four pre-existing em-dash comments); no `pnpm-lock.yaml` churn.

## Advisory note

Advisory PR from the tech-debt-fixer bot, opened for human review, not to be merged by the bot. The human makes the merge call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cleanup for multiple analytics integration tests, making test data removal more consistent and reliable.
  * Added a shared cleanup approach for tenant-specific ClickHouse test data, reducing the chance of leftover data affecting later test runs.
  * Updated regression test teardown behavior without changing test expectations or query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->