### PR TITLE
refactor(agents): remove unused findByIdIncludingArchived from AgentRepository (#1915)

### DIFF
--- a/langwatch/src/server/agents/agent.repository.ts
+++ b/langwatch/src/server/agents/agent.repository.ts
@@ -129,20 +129,6 @@ export class AgentRepository {
   constructor(private readonly prisma: PrismaClient) {}
 
   /**
-   * Find an agent by ID regardless of its archived status.
-   * Used for checking archived vs. missing status during suite run resolution.
-   */
-  async findByIdIncludingArchived(input: {
-    id: string;
-    projectId: string;
-  }): Promise<{ id: string; archivedAt: Date | null } | null> {
-    return this.prisma.agent.findFirst({
-      where: { id: input.id, projectId: input.projectId },
-      select: { id: true, archivedAt: true },
-    });
-  }
-
-  /**
    * Find multiple agents by IDs regardless of archived status.
    * Returns only id and archivedAt for lightweight classification.
    */


### PR DESCRIPTION
## Ticket

Closes #1915. `AgentRepository.findByIdIncludingArchived` is dead code: it has no callers anywhere in the codebase.

## G-START verdict

PROCEED. Verified against current main (`3fc9dde`): the method is still defined at `agent.repository.ts` and a repo-wide search finds zero call sites. `AgentRepository` implements no interface that would require the method to stay. Not superseded by any open PR.

## Change

Remove the unused `findByIdIncludingArchived` method (and its doc comment) from `AgentRepository`. Nothing else changes. The sibling `findManyIncludingArchived` covers the batch archived-status lookups the agent flows actually use.

Note: the identically-named method on `ScenarioRepository` is a separate, actively-used method (called from `ScenarioService` and covered by scenario tests) and is untouched.

## Evidence

- **AC: the method is unused.** `grep -rn "findByIdIncludingArchived" langwatch/src --include=*.ts` outside the scenario repo returns only the definition line, before the change; zero call sites.
- **AC: removing it breaks nothing.** `pnpm typecheck` -> EXIT=0 (a used method would surface an unresolved-reference error).
- **Agent repo tests still green:** `pnpm test:unit src/server/agents/__tests__/agent.repository.unit.test.ts` -> `Test Files 1 passed, Tests 3 passed` (the suite never referenced the removed method).
- **Hygiene:** single-file diff, 14 deletions, 0 additions; no em/en dashes; no `pnpm-lock.yaml` churn.

## Advisory note

Advisory PR from the tech-debt-fixer bot, opened for human review, not to be merged by the bot. The human makes the merge call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified agent lookup behavior by removing an older archive-aware lookup path.  
  * Existing agent retrieval continues to work through the current lookup methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->