### PR TITLE
fix: resolve model-provider edit target from the uncollapsed row list (#5380)

### DIFF
--- a/langwatch/src/components/EditModelProviderDrawer.tsx
+++ b/langwatch/src/components/EditModelProviderDrawer.tsx
@@ -1,6 +1,9 @@
 import { Box, Heading, HStack, Spinner, VStack } from "@chakra-ui/react";
 import { useDrawer } from "~/hooks/useDrawer";
-import { useAllModelProvidersList } from "../hooks/useAllModelProvidersList";
+import {
+  findModelProviderById,
+  useAllModelProvidersList,
+} from "../hooks/useAllModelProvidersList";
 import { useModelProvidersSettings } from "../hooks/useModelProvidersSettings";
 import { modelProviderIcons } from "../server/modelProviders/iconsMap";
 import { modelProviders } from "../server/modelProviders/registry";
@@ -20,19 +23,21 @@ export const EditModelProviderDrawer = (
   const { projectId, organizationId, modelProviderId, providerKey } = props;
   const { closeDrawer } = useDrawer();
   const { providers, isLoading } = useModelProvidersSettings({ projectId });
-  // The row this drawer is titled for must come from the same
-  // uncollapsed list `EditModelProviderForm` resolves its edit target
-  // from — the settings table passes ids from that flat list, and the
-  // `providers` Record above dedupes by provider type, so an id lookup
-  // against it can silently miss a same-type row (#5380).
+  // Resolve by id from the flat list — see useAllModelProvidersList for
+  // why the collapsed Record is wrong here (#5380).
   const { providers: allProviders, isLoading: isAllProvidersLoading } =
     useAllModelProvidersList();
 
-  // Get provider - by id (flat list) or provider key (collapsed record;
-  // correct there since it's asking "whichever row owns this provider
-  // type right now", not "this specific row").
-  const provider = modelProviderId
-    ? allProviders.find((p) => p.id === modelProviderId)
+  // A specific row is being edited only when modelProviderId is a real
+  // id — not the Add-flow sentinel "new" and not absent.
+  const isEditingSpecificRow = !!modelProviderId && modelProviderId !== "new";
+
+  // Title/icon source: the specific row by id (shared resolver) when
+  // editing one, else the collapsed record's current winner for this
+  // provider type — right there, since "new"/no-id means "whichever row
+  // owns this provider type right now", not "this specific row".
+  const provider = isEditingSpecificRow
+    ? findModelProviderById(allProviders, modelProviderId)
     : providers?.[providerKey];
 
   // Get provider name for the title
@@ -49,7 +54,6 @@ export const EditModelProviderDrawer = (
   // rendering the form off the (collapsed-record-only) blank fallback
   // and then resetting once the flat list arrives would wipe whatever
   // the user had already typed.
-  const isEditingSpecificRow = !!modelProviderId && modelProviderId !== "new";
   const isFormDataLoading =
     isLoading || !providers || (isEditingSpecificRow && isAllProvidersLoading);
 

--- a/langwatch/src/components/EditModelProviderDrawer.tsx
+++ b/langwatch/src/components/EditModelProviderDrawer.tsx
@@ -25,7 +25,12 @@ export const EditModelProviderDrawer = (
   const { closeDrawer } = useDrawer();
   const { providers, isLoading } = useModelProvidersSettings({ projectId });
   // Resolve by id from the flat list — see useAllModelProvidersList for
-  // why the collapsed Record is wrong here (#5380).
+  // why the collapsed Record is wrong here (#5380). `isAllProvidersLoading`
+  // is that hook's spinner signal ("no definitive answer yet"): true while
+  // the flat-list query is disabled or in-flight, false once it resolves OR
+  // errors — so the gate below keeps spinning until the list is genuinely
+  // ready instead of mounting the form off an empty list, but does not spin
+  // forever if the query 403s.
   const { providers: allProviders, isLoading: isAllProvidersLoading } =
     useAllModelProvidersList();
 

--- a/langwatch/src/components/EditModelProviderDrawer.tsx
+++ b/langwatch/src/components/EditModelProviderDrawer.tsx
@@ -38,7 +38,7 @@ export const EditModelProviderDrawer = (
   // provider type — right there, since "new"/no-id means "whichever row
   // owns this provider type right now", not "this specific row".
   const provider = isEditingSpecificRow
-    ? findModelProviderById(allProviders, modelProviderId)
+    ? findModelProviderById({ providers: allProviders, modelProviderId })
     : providers?.[providerKey];
 
   // Get provider name for the title

--- a/langwatch/src/components/EditModelProviderDrawer.tsx
+++ b/langwatch/src/components/EditModelProviderDrawer.tsx
@@ -1,5 +1,6 @@
 import { Box, Heading, HStack, Spinner, VStack } from "@chakra-ui/react";
 import { useDrawer } from "~/hooks/useDrawer";
+import { useAllModelProvidersList } from "../hooks/useAllModelProvidersList";
 import { useModelProvidersSettings } from "../hooks/useModelProvidersSettings";
 import { modelProviderIcons } from "../server/modelProviders/iconsMap";
 import { modelProviders } from "../server/modelProviders/registry";
@@ -19,13 +20,20 @@ export const EditModelProviderDrawer = (
   const { projectId, organizationId, modelProviderId, providerKey } = props;
   const { closeDrawer } = useDrawer();
   const { providers, isLoading } = useModelProvidersSettings({ projectId });
+  // The row this drawer is titled for must come from the same
+  // uncollapsed list `EditModelProviderForm` resolves its edit target
+  // from — the settings table passes ids from that flat list, and the
+  // `providers` Record above dedupes by provider type, so an id lookup
+  // against it can silently miss a same-type row (#5380).
+  const { providers: allProviders, isLoading: isAllProvidersLoading } =
+    useAllModelProvidersList();
 
-  // Get provider - by id or provider key
-  const provider =
-    providers &&
-    (modelProviderId
-      ? Object.values(providers).find((p) => p.id === modelProviderId)
-      : providers[providerKey]);
+  // Get provider - by id (flat list) or provider key (collapsed record;
+  // correct there since it's asking "whichever row owns this provider
+  // type right now", not "this specific row").
+  const provider = modelProviderId
+    ? allProviders.find((p) => p.id === modelProviderId)
+    : providers?.[providerKey];
 
   // Get provider name for the title
   let providerName = "";
@@ -36,6 +44,14 @@ export const EditModelProviderDrawer = (
   }
 
   const title = providerName;
+
+  // Editing a specific existing row also has to wait on the flat list:
+  // rendering the form off the (collapsed-record-only) blank fallback
+  // and then resetting once the flat list arrives would wipe whatever
+  // the user had already typed.
+  const isEditingSpecificRow = !!modelProviderId && modelProviderId !== "new";
+  const isFormDataLoading =
+    isLoading || !providers || (isEditingSpecificRow && isAllProvidersLoading);
 
   return (
     <Drawer.Root
@@ -68,7 +84,7 @@ export const EditModelProviderDrawer = (
           </HStack>
         </Drawer.Header>
         <Drawer.Body>
-          {isLoading || !providers ? (
+          {isFormDataLoading ? (
             <VStack height="200px" justify="center">
               <Spinner />
             </VStack>

--- a/langwatch/src/components/EditModelProviderDrawer.tsx
+++ b/langwatch/src/components/EditModelProviderDrawer.tsx
@@ -2,6 +2,7 @@ import { Box, Heading, HStack, Spinner, VStack } from "@chakra-ui/react";
 import { useDrawer } from "~/hooks/useDrawer";
 import {
   findModelProviderById,
+  isResolvableProviderId,
   useAllModelProvidersList,
 } from "../hooks/useAllModelProvidersList";
 import { useModelProvidersSettings } from "../hooks/useModelProvidersSettings";
@@ -30,7 +31,7 @@ export const EditModelProviderDrawer = (
 
   // A specific row is being edited only when modelProviderId is a real
   // id — not the Add-flow sentinel "new" and not absent.
-  const isEditingSpecificRow = !!modelProviderId && modelProviderId !== "new";
+  const isEditingSpecificRow = isResolvableProviderId(modelProviderId);
 
   // Title/icon source: the specific row by id (shared resolver) when
   // editing one, else the collapsed record's current winner for this

--- a/langwatch/src/components/__tests__/EditModelProviderDrawer.edit-row-resolution.integration.test.tsx
+++ b/langwatch/src/components/__tests__/EditModelProviderDrawer.edit-row-resolution.integration.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * @vitest-environment jsdom
+ * @regression
+ *
+ * Regression tests for issue #5380 at the drawer level (not just the bare
+ * form). The settings-page edit affordance opens `EditModelProviderDrawer`,
+ * which independently resolves BOTH a header title AND (by mounting
+ * `EditModelProviderForm`) the credential fields. Both resolutions must
+ * agree on which row is being edited.
+ *
+ * These tests pin three implementation details introduced by the #5380
+ * fix that the drawer-title path and the "new provider" path depend on:
+ *   - the header title resolves the SAME row as the form (against the
+ *     uncollapsed flat list from `useAllModelProvidersList`, not the
+ *     collapsed per-provider-type record) — see the "Editing a row shows
+ *     its own saved credential, not another row's" and "Saving an edited
+ *     row updates it in place, not as a duplicate" scenarios in
+ *     specs/model-providers/scope-and-multi-instance.feature, which this
+ *     file does not re-bind (already bound in
+ *     ModelProviderForm.edit-row-resolution.integration.test.tsx).
+ *   - the form does not mount off the blank id-less draft while the flat
+ *     list is still loading (isFormDataLoading)
+ *   - opening the drawer for a brand-new row (modelProviderId="new") does
+ *     NOT search the flat list by the literal id "new" — it must fall
+ *     back to the collapsed per-provider-type record, same as the form's
+ *     own "new" guard, so the header still shows a sensible title.
+ *
+ * `EditModelProviderForm`, `useAllModelProvidersList`, and
+ * `useModelProvidersSettings` are NOT mocked — only the tRPC boundary and
+ * peripheral hooks are, and `../ui/drawer` is replaced with plain
+ * passthrough elements (Chakra's real Drawer.Root renders through a
+ * Portal with focus-trap/dismissable-layer machinery; see
+ * TraceDetailsDrawer.integration.test.tsx for the same substitution) so
+ * the header/body content this file asserts on still renders for real.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockMutateAsync,
+  mockGetAllForProjectForFrontendQuery,
+  mockListAllForOrganizationForFrontendQuery,
+  mockListAllForProjectForFrontendQuery,
+} = vi.hoisted(() => ({
+  mockMutateAsync: vi.fn().mockResolvedValue({}),
+  mockGetAllForProjectForFrontendQuery: vi.fn(),
+  mockListAllForOrganizationForFrontendQuery: vi.fn(),
+  mockListAllForProjectForFrontendQuery: vi.fn(),
+}));
+
+vi.mock("../../utils/api", () => ({
+  api: {
+    modelProvider: {
+      getAllForProjectForFrontend: {
+        useQuery: mockGetAllForProjectForFrontendQuery,
+      },
+      listAllForOrganizationForFrontend: {
+        useQuery: mockListAllForOrganizationForFrontendQuery,
+      },
+      listAllForProjectForFrontend: {
+        useQuery: mockListAllForProjectForFrontendQuery,
+      },
+      update: {
+        useMutation: () => ({ mutateAsync: mockMutateAsync }),
+      },
+      setRoleAssignmentForScope: {
+        useMutation: () => ({
+          mutateAsync: vi.fn().mockResolvedValue({ ok: true }),
+        }),
+      },
+      isManagedProvider: {
+        useQuery: () => ({ data: { managed: false } }),
+      },
+    },
+    useContext: () => ({
+      organization: {
+        getAll: { invalidate: vi.fn() },
+      },
+      modelProvider: {
+        getAllForProject: { invalidate: vi.fn() },
+        getAllForProjectForFrontend: { invalidate: vi.fn() },
+        listAllForProjectForFrontend: { invalidate: vi.fn() },
+        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
+        getResolvedDefault: { invalidate: vi.fn() },
+        getDefaultModelsForProject: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: vi.fn(),
+    openDrawer: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", name: "Web App", slug: "web-app" },
+    team: { id: "team-1", name: "Platform" },
+    organization: {
+      id: "org-1",
+      name: "Acme",
+      teams: [
+        {
+          id: "team-1",
+          name: "Platform",
+          projects: [{ id: "proj-1", name: "Web App" }],
+        },
+      ],
+    },
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("../../hooks/useModelProviderApiKeyValidation", () => ({
+  useModelProviderApiKeyValidation: () => ({
+    validate: vi.fn().mockResolvedValue(true),
+    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
+    isValidating: false,
+    validationError: undefined,
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
+}));
+
+vi.mock("../ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+// Chakra's real Drawer.Root renders through a Portal with focus-trap /
+// dismissable-layer machinery that existing drawer tests in this repo
+// avoid exercising directly (see TraceDetailsDrawer.integration.test.tsx).
+// Replace the shell with plain passthrough elements so the header/body
+// CONTENT (title, spinner, form) — what these tests actually assert on —
+// still renders for real.
+vi.mock("../ui/drawer", () => ({
+  Drawer: {
+    Root: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Content: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Header: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Body: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    CloseTrigger: () => <button aria-label="Close drawer" type="button" />,
+  },
+}));
+
+import type { MaybeStoredModelProvider } from "../../server/modelProviders/registry";
+import { MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
+import { EditModelProviderDrawer } from "../EditModelProviderDrawer";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+// Same fixtures as ModelProviderForm.edit-row-resolution.integration.test.tsx:
+// rowA is org-scoped (the edit target, absent from the collapsed record),
+// rowB is project-scoped (the collapse winner for the "openai" type).
+const rowA: MaybeStoredModelProvider = {
+  id: "row-a",
+  name: "OpenAI",
+  provider: "openai",
+  enabled: true,
+  customKeys: { OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER, OPENAI_BASE_URL: "" },
+  models: null,
+  embeddingsModels: null,
+  customModels: null,
+  customEmbeddingsModels: null,
+  disabledByDefault: false,
+  deploymentMapping: null,
+  extraHeaders: [],
+  scopes: [{ scopeType: "ORGANIZATION", scopeId: "org-1" }],
+  scopeType: "ORGANIZATION",
+  scopeId: "org-1",
+};
+
+const rowB: MaybeStoredModelProvider = {
+  ...rowA,
+  id: "row-b",
+  scopes: [{ scopeType: "PROJECT", scopeId: "proj-1" }],
+  scopeType: "PROJECT",
+  scopeId: "proj-1",
+};
+
+/** Collapsed record has only rowB; flat list has both rows; nothing loading. */
+function primeQueriesLoaded() {
+  mockGetAllForProjectForFrontendQuery.mockReturnValue({
+    data: { providers: { openai: rowB }, modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+  mockListAllForOrganizationForFrontendQuery.mockReturnValue({
+    data: { providers: [rowA, rowB], modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+  mockListAllForProjectForFrontendQuery.mockReturnValue({
+    data: { providers: [rowA, rowB], modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+}
+
+/**
+ * Collapsed record loaded normally; BOTH flat-list queries (org and
+ * project variants) still loading with no data — `hasPermission` mocks
+ * true for everything, so `useAllModelProvidersList` reads the org
+ * variant, but priming both keeps this fixture correct regardless of
+ * which branch is active.
+ */
+function primeQueriesFlatListLoading() {
+  mockGetAllForProjectForFrontendQuery.mockReturnValue({
+    data: { providers: { openai: rowB }, modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+  mockListAllForOrganizationForFrontendQuery.mockReturnValue({
+    data: undefined,
+    isLoading: true,
+    refetch: vi.fn(),
+  });
+  mockListAllForProjectForFrontendQuery.mockReturnValue({
+    data: undefined,
+    isLoading: true,
+    refetch: vi.fn(),
+  });
+}
+
+function renderDrawer(
+  props: Partial<Parameters<typeof EditModelProviderDrawer>[0]> = {},
+) {
+  const defaultProps = {
+    projectId: "proj-1",
+    organizationId: "org-1",
+    modelProviderId: "row-a",
+    providerKey: "openai",
+  };
+  return render(
+    <Wrapper>
+      <EditModelProviderDrawer {...defaultProps} {...props} />
+    </Wrapper>,
+  );
+}
+
+describe("<EditModelProviderDrawer/>", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given an org-scoped and a project-scoped openai row both exist", () => {
+    describe("when the drawer opens targeting the org-scoped row by id", () => {
+      beforeEach(() => {
+        primeQueriesLoaded();
+        renderDrawer({ modelProviderId: "row-a" });
+      });
+
+      it("shows the targeted row's provider title in the header", () => {
+        expect(
+          screen.getByRole("heading", { name: "OpenAI" }),
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("given the flat provider list is still loading", () => {
+    describe("when the drawer opens targeting a specific row by id", () => {
+      beforeEach(() => {
+        primeQueriesFlatListLoading();
+        renderDrawer({ modelProviderId: "row-a" });
+      });
+
+      it("renders a loading spinner", () => {
+        expect(
+          document.querySelectorAll(".chakra-spinner").length,
+        ).toBeGreaterThan(0);
+      });
+
+      it("does not mount the form", () => {
+        expect(screen.queryByText("OPENAI_API_KEY")).toBeNull();
+      });
+    });
+  });
+
+  describe("given the collapsed record already has an openai row", () => {
+    describe("when the drawer opens for a brand-new row (modelProviderId=new)", () => {
+      beforeEach(() => {
+        primeQueriesLoaded();
+        renderDrawer({ modelProviderId: "new" });
+      });
+
+      it("shows the provider-type title from the collapsed record", () => {
+        expect(
+          screen.getByRole("heading", { name: "OpenAI" }),
+        ).toBeTruthy();
+      });
+
+      it("still mounts the form", () => {
+        expect(screen.getByText("OPENAI_API_KEY")).toBeTruthy();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/__tests__/EditModelProviderDrawer.edit-row-resolution.integration.test.tsx
+++ b/langwatch/src/components/__tests__/EditModelProviderDrawer.edit-row-resolution.integration.test.tsx
@@ -35,6 +35,7 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -141,16 +142,10 @@ vi.mock("../ui/toaster", () => ({
 // still renders for real.
 vi.mock("../ui/drawer", () => ({
   Drawer: {
-    Root: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    Content: ({ children }: { children: React.ReactNode }) => (
-      <div>{children}</div>
-    ),
-    Header: ({ children }: { children: React.ReactNode }) => (
-      <div>{children}</div>
-    ),
-    Body: ({ children }: { children: React.ReactNode }) => (
-      <div>{children}</div>
-    ),
+    Root: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Content: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Header: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Body: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     CloseTrigger: () => <button aria-label="Close drawer" type="button" />,
   },
 }));
@@ -159,13 +154,17 @@ import type { MaybeStoredModelProvider } from "../../server/modelProviders/regis
 import { MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
 import { EditModelProviderDrawer } from "../EditModelProviderDrawer";
 
-const Wrapper = ({ children }: { children: React.ReactNode }) => (
+const Wrapper = ({ children }: { children: ReactNode }) => (
   <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
 );
 
-// Same fixtures as ModelProviderForm.edit-row-resolution.integration.test.tsx:
+// Same two-scope shape as ModelProviderForm.edit-row-resolution.integration.test.tsx:
 // rowA is org-scoped (the edit target, absent from the collapsed record),
 // rowB is project-scoped (the collapse winner for the "openai" type).
+// rowB carries its OWN credential values so a wrong-row resolution renders
+// observably different form content — same provider type, so the header
+// title (the registry name for the TYPE, not the row's `name`) cannot
+// discriminate the two rows; the credential fields can.
 const rowA: MaybeStoredModelProvider = {
   id: "row-a",
   name: "OpenAI",
@@ -187,6 +186,10 @@ const rowA: MaybeStoredModelProvider = {
 const rowB: MaybeStoredModelProvider = {
   ...rowA,
   id: "row-b",
+  customKeys: {
+    OPENAI_API_KEY: "sk-row-b-key",
+    OPENAI_BASE_URL: "https://row-b.example.com",
+  },
   scopes: [{ scopeType: "PROJECT", scopeId: "proj-1" }],
   scopeType: "PROJECT",
   scopeId: "proj-1",
@@ -269,7 +272,21 @@ describe("<EditModelProviderDrawer/>", () => {
       });
 
       it("shows the targeted row's provider title in the header", () => {
+        // The header renders the registry display name for the provider
+        // TYPE, so with two same-type rows this alone proves a row
+        // resolved at all (a missed lookup renders an empty heading) —
+        // the row-discriminating check is the credential assertion below.
         expect(screen.getByRole("heading", { name: "OpenAI" })).toBeTruthy();
+      });
+
+      it("mounts the form on the targeted row's credential, not the collapse winner's", () => {
+        // row-a's key renders masked; a regression to the collapsed
+        // Record would resolve row-b and render row-b's values instead.
+        expect(screen.getByDisplayValue(MASKED_KEY_PLACEHOLDER)).toBeTruthy();
+        expect(screen.queryByDisplayValue("sk-row-b-key")).toBeNull();
+        expect(
+          screen.queryByDisplayValue("https://row-b.example.com"),
+        ).toBeNull();
       });
     });
   });

--- a/langwatch/src/components/__tests__/EditModelProviderDrawer.edit-row-resolution.integration.test.tsx
+++ b/langwatch/src/components/__tests__/EditModelProviderDrawer.edit-row-resolution.integration.test.tsx
@@ -195,48 +195,60 @@ const rowB: MaybeStoredModelProvider = {
   scopeId: "proj-1",
 };
 
-/** Collapsed record has only rowB; flat list has both rows; nothing loading. */
+/**
+ * Minimal but *realistic* TanStack Query v4 result. `useAllModelProvidersList`
+ * derives its spinner signal from `isSuccess`/`isError`, not just `isLoading`
+ * — a mock that omits them leaves those gates `undefined` (silently falsy), so
+ * the drawer's spinner/mount gate would be exercised by accident. These
+ * helpers set the full status triplet.
+ */
+function readyQueryResult<T>(data: T) {
+  return {
+    data,
+    isSuccess: true,
+    isError: false,
+    isLoading: false,
+    status: "success" as const,
+    refetch: vi.fn(),
+  };
+}
+
+function notReadyQueryResult() {
+  return {
+    data: undefined,
+    isSuccess: false,
+    isError: false,
+    isLoading: true,
+    status: "loading" as const,
+    refetch: vi.fn(),
+  };
+}
+
+/** Collapsed record has only rowB; flat list has both rows; every query resolved. */
 function primeQueriesLoaded() {
-  mockGetAllForProjectForFrontendQuery.mockReturnValue({
-    data: { providers: { openai: rowB }, modelMetadata: {} },
-    isLoading: false,
-    refetch: vi.fn(),
-  });
-  mockListAllForOrganizationForFrontendQuery.mockReturnValue({
-    data: { providers: [rowA, rowB], modelMetadata: {} },
-    isLoading: false,
-    refetch: vi.fn(),
-  });
-  mockListAllForProjectForFrontendQuery.mockReturnValue({
-    data: { providers: [rowA, rowB], modelMetadata: {} },
-    isLoading: false,
-    refetch: vi.fn(),
-  });
+  mockGetAllForProjectForFrontendQuery.mockReturnValue(
+    readyQueryResult({ providers: { openai: rowB }, modelMetadata: {} }),
+  );
+  const flat = readyQueryResult({ providers: [rowA, rowB], modelMetadata: {} });
+  mockListAllForOrganizationForFrontendQuery.mockReturnValue(flat);
+  mockListAllForProjectForFrontendQuery.mockReturnValue(flat);
 }
 
 /**
- * Collapsed record loaded normally; BOTH flat-list queries (org and
- * project variants) still loading with no data — `hasPermission` mocks
- * true for everything, so `useAllModelProvidersList` reads the org
- * variant, but priming both keeps this fixture correct regardless of
- * which branch is active.
+ * Collapsed record resolved normally; BOTH flat-list queries (org and project
+ * variants) still in-flight — no definitive answer yet (`isSuccess: false,
+ * isError: false`), so the hook's spinner signal stays true and the drawer
+ * must keep spinning rather than mount the form off an empty list.
+ * `hasPermission` mocks true, so `useAllModelProvidersList` reads the org
+ * variant; priming both keeps this fixture correct regardless of branch.
  */
 function primeQueriesFlatListLoading() {
-  mockGetAllForProjectForFrontendQuery.mockReturnValue({
-    data: { providers: { openai: rowB }, modelMetadata: {} },
-    isLoading: false,
-    refetch: vi.fn(),
-  });
-  mockListAllForOrganizationForFrontendQuery.mockReturnValue({
-    data: undefined,
-    isLoading: true,
-    refetch: vi.fn(),
-  });
-  mockListAllForProjectForFrontendQuery.mockReturnValue({
-    data: undefined,
-    isLoading: true,
-    refetch: vi.fn(),
-  });
+  mockGetAllForProjectForFrontendQuery.mockReturnValue(
+    readyQueryResult({ providers: { openai: rowB }, modelMetadata: {} }),
+  );
+  const flat = notReadyQueryResult();
+  mockListAllForOrganizationForFrontendQuery.mockReturnValue(flat);
+  mockListAllForProjectForFrontendQuery.mockReturnValue(flat);
 }
 
 function renderDrawer(

--- a/langwatch/src/components/__tests__/EditModelProviderDrawer.edit-row-resolution.integration.test.tsx
+++ b/langwatch/src/components/__tests__/EditModelProviderDrawer.edit-row-resolution.integration.test.tsx
@@ -269,9 +269,7 @@ describe("<EditModelProviderDrawer/>", () => {
       });
 
       it("shows the targeted row's provider title in the header", () => {
-        expect(
-          screen.getByRole("heading", { name: "OpenAI" }),
-        ).toBeTruthy();
+        expect(screen.getByRole("heading", { name: "OpenAI" })).toBeTruthy();
       });
     });
   });
@@ -303,9 +301,7 @@ describe("<EditModelProviderDrawer/>", () => {
       });
 
       it("shows the provider-type title from the collapsed record", () => {
-        expect(
-          screen.getByRole("heading", { name: "OpenAI" }),
-        ).toBeTruthy();
+        expect(screen.getByRole("heading", { name: "OpenAI" })).toBeTruthy();
       });
 
       it("still mounts the form", () => {

--- a/langwatch/src/components/settings/ModelProviderForm.tsx
+++ b/langwatch/src/components/settings/ModelProviderForm.tsx
@@ -138,15 +138,14 @@ export const EditModelProviderForm = ({
   //     server treats it as a create, and a phantom duplicate row is written
   //     (#5380 P2).
   const cannotResolveTarget = isTargetingSpecificRow && !existingRow;
-  //   - Whether to show the "no longer exists" copy. Only truthful on a
-  //     DEFINITIVE miss: the flat list has actually arrived
-  //     (`isAllProvidersReady`) and the row is still absent. Gating on
-  //     readiness stops the copy flashing mid-load and stops it lying when
-  //     the list merely failed to load. (An `allProviders.length > 0` proxy
+  //   - Whether to show the "no longer exists" copy. This is the subset of
+  //     `cannotResolveTarget` where the flat list has DEFINITIVELY arrived, so
+  //     the row is known absent rather than merely unresolved. Gating on
+  //     readiness stops the copy flashing mid-load and stops it lying when the
+  //     list simply failed to load. (An `allProviders.length > 0` proxy
   //     mis-reads a legitimately empty org as "not loaded" and never fires —
   //     the original #5380 stale-miss hole.)
-  const staleMiss =
-    isTargetingSpecificRow && isAllProvidersReady && !existingRow;
+  const staleMiss = cannotResolveTarget && isAllProvidersReady;
 
   // Memoized so the blank template keeps a stable identity across renders:
   // useModelProviderForm's reset effect lists `provider.extraHeaders` in its

--- a/langwatch/src/components/settings/ModelProviderForm.tsx
+++ b/langwatch/src/components/settings/ModelProviderForm.tsx
@@ -1,8 +1,17 @@
-import { Box, Button, Field, HStack, Input, VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Field,
+  HStack,
+  Input,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 import {
   findModelProviderById,
+  isResolvableProviderId,
   useAllModelProvidersList,
 } from "../../hooks/useAllModelProvidersList";
 import { useDrawer } from "../../hooks/useDrawer";
@@ -55,7 +64,11 @@ export const EditModelProviderForm = ({
   });
   // Flat, uncollapsed list — see useAllModelProvidersList for why the
   // lookup below can't use the collapsed `providers` Record above.
-  const { providers: allProviders } = useAllModelProvidersList();
+  // `isAllProvidersReady` is the hook's "the list definitively arrived"
+  // signal (react-query isSuccess), used below to tell a real stale miss
+  // apart from a list that simply hasn't loaded.
+  const { providers: allProviders, isReady: isAllProvidersReady } =
+    useAllModelProvidersList();
   const { closeDrawer } = useDrawer();
   const { project, team, organization, hasPermission } =
     useOrganizationTeamProject();
@@ -108,23 +121,53 @@ export const EditModelProviderForm = ({
   //     Record above is the wrong source for this lookup (#5380).
   //   - `modelProviderId` undefined → no specific target, fresh blank
   //     (deep-link from evaluator selector or similar).
-  const provider: MaybeStoredModelProvider = useMemo(() => {
-    const existing = findModelProviderById({
-      providers: allProviders,
-      modelProviderId,
-    });
-    if (existing) return existing;
-    return {
-      provider: providerKey,
-      enabled: false,
-      customKeys: null,
-      models: null,
-      embeddingsModels: null,
-      disabledByDefault: true,
-      deploymentMapping: null,
-      extraHeaders: [],
-    };
-  }, [allProviders, modelProviderId, providerKey]);
+  const isTargetingSpecificRow = isResolvableProviderId(modelProviderId);
+  const existingRow = useMemo(
+    () =>
+      isTargetingSpecificRow
+        ? findModelProviderById({ providers: allProviders, modelProviderId })
+        : undefined,
+    [isTargetingSpecificRow, allProviders, modelProviderId],
+  );
+
+  // Two DISTINCT concerns, deliberately not collapsed into one flag:
+  //   - Whether we can SUBMIT. An id-targeted edit that didn't resolve to a
+  //     real row must never submit, in EVERY load state (loading, disabled,
+  //     errored, or genuinely empty), so this gates purely on "targeting a
+  //     row we couldn't resolve". Otherwise Save ships `id: undefined`, the
+  //     server treats it as a create, and a phantom duplicate row is written
+  //     (#5380 P2).
+  const cannotResolveTarget = isTargetingSpecificRow && !existingRow;
+  //   - Whether to show the "no longer exists" copy. Only truthful on a
+  //     DEFINITIVE miss: the flat list has actually arrived
+  //     (`isAllProvidersReady`) and the row is still absent. Gating on
+  //     readiness stops the copy flashing mid-load and stops it lying when
+  //     the list merely failed to load. (An `allProviders.length > 0` proxy
+  //     mis-reads a legitimately empty org as "not loaded" and never fires —
+  //     the original #5380 stale-miss hole.)
+  const staleMiss =
+    isTargetingSpecificRow && isAllProvidersReady && !existingRow;
+
+  // Memoized so the blank template keeps a stable identity across renders:
+  // useModelProviderForm's reset effect lists `provider.extraHeaders` in its
+  // deps, so a fresh `{ ..., extraHeaders: [] }` literal on every render would
+  // refire that effect each render → setState → re-render → "Maximum update
+  // depth exceeded" and a wiped-out Add form. Keyed on the resolved row (or
+  // its absence) and the provider key only.
+  const provider: MaybeStoredModelProvider = useMemo(
+    () =>
+      existingRow ?? {
+        provider: providerKey,
+        enabled: false,
+        customKeys: null,
+        models: null,
+        embeddingsModels: null,
+        disabledByDefault: true,
+        deploymentMapping: null,
+        extraHeaders: [],
+      },
+    [existingRow, providerKey],
+  );
 
   // Detect if provider is using environment variables (enabled but no stored customKeys)
   // Must be computed before the hook call so we can pass it to the hook
@@ -313,6 +356,12 @@ export const EditModelProviderForm = ({
 
   return (
     <VStack gap={4} align="start" width="full">
+      {staleMiss && (
+        <Text color="red.500" fontSize="sm">
+          This provider configuration no longer exists. It may have been deleted
+          from another session.
+        </Text>
+      )}
       <VStack align="start" width="full" gap={4}>
         <Field.Root width="full" required>
           <SmallLabel>
@@ -432,7 +481,9 @@ export const EditModelProviderForm = ({
             size="sm"
             colorPalette="orange"
             loading={state.isSaving || isValidatingApiKey}
-            disabled={!state.isDirty && !isAdvancedDirty}
+            disabled={
+              cannotResolveTarget || (!state.isDirty && !isAdvancedDirty)
+            }
             onClick={handleSave}
           >
             Save

--- a/langwatch/src/components/settings/ModelProviderForm.tsx
+++ b/langwatch/src/components/settings/ModelProviderForm.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Field, HStack, Input, VStack } from "@chakra-ui/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
+import { useAllModelProvidersList } from "../../hooks/useAllModelProvidersList";
 import { useDrawer } from "../../hooks/useDrawer";
 import { useFeatureFlag } from "../../hooks/useFeatureFlag";
 import { useModelProviderApiKeyValidation } from "../../hooks/useModelProviderApiKeyValidation";
@@ -49,6 +50,10 @@ export const EditModelProviderForm = ({
   const { providers } = useModelProvidersSettings({
     projectId: projectId,
   });
+  // Flat, uncollapsed list — the id lookup below must resolve against this,
+  // not the collapsed `providers` Record above (see the lookup comment on
+  // the `provider` memo for why).
+  const { providers: allProviders } = useAllModelProvidersList();
   const { closeDrawer } = useDrawer();
   const { project, team, organization, hasPermission } =
     useOrganizationTeamProject();
@@ -95,19 +100,21 @@ export const EditModelProviderForm = ({
   //     an existing row. The Add Model Provider menu sets this so the
   //     user can stand up a second instance of an already-configured
   //     provider type without colliding with the first.
-  //   - `modelProviderId === "<cuid>"` → edit that specific row. With
-  //     multi-instance enabled the providers Record dedupes by provider
-  //     string and may not contain this row, so we don't fall back on
-  //     `providers[providerKey]` if the id lookup misses (that fallback
-  //     used to silently swap the user's intended row for whichever
-  //     same-type row happened to win the dedupe).
+  //   - `modelProviderId === "<cuid>"` → edit that specific row. The id
+  //     comes from the settings table, which reads the UNCOLLAPSED flat
+  //     list (`useAllModelProvidersList`), so the lookup has to search
+  //     that same flat list rather than the `providers` Record above.
+  //     That Record dedupes by provider string (narrowest scope wins)
+  //     and silently drops every other same-type row — with
+  //     multi-instance enabled, looking this id up against it can miss
+  //     the exact row the user clicked, fall through to the blank draft
+  //     below, and on Save submit `id: undefined`, which the server
+  //     treats as a create instead of an update (#5380).
   //   - `modelProviderId` undefined → no specific target, fresh blank
   //     (deep-link from evaluator selector or similar).
   const provider: MaybeStoredModelProvider = useMemo(() => {
-    if (providers && modelProviderId && modelProviderId !== "new") {
-      const existing = Object.values(providers).find(
-        (p) => p.id === modelProviderId,
-      );
+    if (modelProviderId && modelProviderId !== "new") {
+      const existing = allProviders.find((p) => p.id === modelProviderId);
       if (existing) return existing;
     }
     return {
@@ -120,7 +127,7 @@ export const EditModelProviderForm = ({
       deploymentMapping: null,
       extraHeaders: [],
     };
-  }, [modelProviderId, providerKey, providers]);
+  }, [allProviders, modelProviderId, providerKey]);
 
   // Detect if provider is using environment variables (enabled but no stored customKeys)
   // Must be computed before the hook call so we can pass it to the hook

--- a/langwatch/src/components/settings/ModelProviderForm.tsx
+++ b/langwatch/src/components/settings/ModelProviderForm.tsx
@@ -1,7 +1,10 @@
 import { Box, Button, Field, HStack, Input, VStack } from "@chakra-ui/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
-import { useAllModelProvidersList } from "../../hooks/useAllModelProvidersList";
+import {
+  findModelProviderById,
+  useAllModelProvidersList,
+} from "../../hooks/useAllModelProvidersList";
 import { useDrawer } from "../../hooks/useDrawer";
 import { useFeatureFlag } from "../../hooks/useFeatureFlag";
 import { useModelProviderApiKeyValidation } from "../../hooks/useModelProviderApiKeyValidation";
@@ -50,9 +53,8 @@ export const EditModelProviderForm = ({
   const { providers } = useModelProvidersSettings({
     projectId: projectId,
   });
-  // Flat, uncollapsed list — the id lookup below must resolve against this,
-  // not the collapsed `providers` Record above (see the lookup comment on
-  // the `provider` memo for why).
+  // Flat, uncollapsed list — see useAllModelProvidersList for why the
+  // lookup below can't use the collapsed `providers` Record above.
   const { providers: allProviders } = useAllModelProvidersList();
   const { closeDrawer } = useDrawer();
   const { project, team, organization, hasPermission } =
@@ -100,23 +102,15 @@ export const EditModelProviderForm = ({
   //     an existing row. The Add Model Provider menu sets this so the
   //     user can stand up a second instance of an already-configured
   //     provider type without colliding with the first.
-  //   - `modelProviderId === "<cuid>"` → edit that specific row. The id
-  //     comes from the settings table, which reads the UNCOLLAPSED flat
-  //     list (`useAllModelProvidersList`), so the lookup has to search
-  //     that same flat list rather than the `providers` Record above.
-  //     That Record dedupes by provider string (narrowest scope wins)
-  //     and silently drops every other same-type row — with
-  //     multi-instance enabled, looking this id up against it can miss
-  //     the exact row the user clicked, fall through to the blank draft
-  //     below, and on Save submit `id: undefined`, which the server
-  //     treats as a create instead of an update (#5380).
+  //   - `modelProviderId === "<cuid>"` → edit that specific row, resolved
+  //     via the shared `findModelProviderById` against the flat list —
+  //     see useAllModelProvidersList for why the collapsed `providers`
+  //     Record above is the wrong source for this lookup (#5380).
   //   - `modelProviderId` undefined → no specific target, fresh blank
   //     (deep-link from evaluator selector or similar).
   const provider: MaybeStoredModelProvider = useMemo(() => {
-    if (modelProviderId && modelProviderId !== "new") {
-      const existing = allProviders.find((p) => p.id === modelProviderId);
-      if (existing) return existing;
-    }
+    const existing = findModelProviderById(allProviders, modelProviderId);
+    if (existing) return existing;
     return {
       provider: providerKey,
       enabled: false,

--- a/langwatch/src/components/settings/ModelProviderForm.tsx
+++ b/langwatch/src/components/settings/ModelProviderForm.tsx
@@ -109,7 +109,10 @@ export const EditModelProviderForm = ({
   //   - `modelProviderId` undefined → no specific target, fresh blank
   //     (deep-link from evaluator selector or similar).
   const provider: MaybeStoredModelProvider = useMemo(() => {
-    const existing = findModelProviderById(allProviders, modelProviderId);
+    const existing = findModelProviderById({
+      providers: allProviders,
+      modelProviderId,
+    });
     if (existing) return existing;
     return {
       provider: providerKey,

--- a/langwatch/src/components/settings/ModelProviderForm.tsx
+++ b/langwatch/src/components/settings/ModelProviderForm.tsx
@@ -145,7 +145,7 @@ export const EditModelProviderForm = ({
   //     list simply failed to load. (An `allProviders.length > 0` proxy
   //     mis-reads a legitimately empty org as "not loaded" and never fires —
   //     the original #5380 stale-miss hole.)
-  const staleMiss = cannotResolveTarget && isAllProvidersReady;
+  const isStaleMiss = cannotResolveTarget && isAllProvidersReady;
 
   // Memoized so the blank template keeps a stable identity across renders:
   // useModelProviderForm's reset effect lists `provider.extraHeaders` in its
@@ -355,7 +355,7 @@ export const EditModelProviderForm = ({
 
   return (
     <VStack gap={4} align="start" width="full">
-      {staleMiss && (
+      {isStaleMiss && (
         <Text color="red.500" fontSize="sm">
           This provider configuration no longer exists. It may have been deleted
           from another session.

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx
@@ -29,10 +29,14 @@ const {
   mockUseModelProviderForm,
   mockUseModelProvidersSettings,
   mockUseFeatureFlag,
+  mockListAllForOrgQuery,
+  mockListAllForProjectQuery,
 } = vi.hoisted(() => ({
   mockUseModelProviderForm: vi.fn(),
   mockUseModelProvidersSettings: vi.fn(),
   mockUseFeatureFlag: vi.fn(),
+  mockListAllForOrgQuery: vi.fn(),
+  mockListAllForProjectQuery: vi.fn(),
 }));
 
 vi.mock("../../../hooks/useModelProviderForm", () => ({
@@ -80,6 +84,13 @@ vi.mock("../../../utils/api", () => ({
       isManagedProvider: {
         useQuery: () => ({ data: { managed: false } }),
       },
+      // EditModelProviderForm resolves its edit target from the flat
+      // (uncollapsed) provider list via useAllModelProvidersList (#5380).
+      // primeHooks seeds both with the same mp_existing fixture the
+      // collapsed-record mock below uses, so the id lookup still finds
+      // the row this suite has always intended to render.
+      listAllForOrganizationForFrontend: { useQuery: mockListAllForOrgQuery },
+      listAllForProjectForFrontend: { useQuery: mockListAllForProjectQuery },
     },
   },
 }));
@@ -171,6 +182,18 @@ function primeHooks({ gatewayEnabled }: { gatewayEnabled: boolean }) {
     isLoading: false,
     refetch: vi.fn(),
     hasEnabledProviders: true,
+  });
+  // Flat-list counterpart of the collapsed record above — same row, so
+  // the id-based lookup in ModelProviderForm still resolves "mp_existing".
+  mockListAllForOrgQuery.mockReturnValue({
+    data: { providers: [provider], modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+  mockListAllForProjectQuery.mockReturnValue({
+    data: { providers: [provider], modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
   });
   mockUseModelProviderForm.mockReturnValue([buildState(), buildActions()]);
 }

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx
@@ -17,6 +17,7 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import type {
@@ -97,7 +98,7 @@ vi.mock("../../../utils/api", () => ({
 
 import { EditModelProviderForm } from "../ModelProviderForm";
 
-const Wrapper = ({ children }: { children: React.ReactNode }) => (
+const Wrapper = ({ children }: { children: ReactNode }) => (
   <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
 );
 

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx
@@ -25,12 +25,17 @@ import type { MaybeStoredModelProvider } from "../../../server/modelProviders/re
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockUseModelProviderForm, mockUseModelProvidersSettings } = vi.hoisted(
-  () => ({
-    mockUseModelProviderForm: vi.fn(),
-    mockUseModelProvidersSettings: vi.fn(),
-  }),
-);
+const {
+  mockUseModelProviderForm,
+  mockUseModelProvidersSettings,
+  mockListAllForOrgQuery,
+  mockListAllForProjectQuery,
+} = vi.hoisted(() => ({
+  mockUseModelProviderForm: vi.fn(),
+  mockUseModelProvidersSettings: vi.fn(),
+  mockListAllForOrgQuery: vi.fn(),
+  mockListAllForProjectQuery: vi.fn(),
+}));
 
 vi.mock("../../../hooks/useModelProviderForm", () => ({
   useModelProviderForm: (...args: unknown[]) =>
@@ -77,6 +82,12 @@ vi.mock("../../../utils/api", () => ({
       isManagedProvider: {
         useQuery: () => ({ data: { managed: false } }),
       },
+      // EditModelProviderForm resolves its edit target from the flat
+      // (uncollapsed) provider list via useAllModelProvidersList (#5380).
+      // primeHooksForProvider seeds both with the same fixture the
+      // collapsed-record mock below uses.
+      listAllForOrganizationForFrontend: { useQuery: mockListAllForOrgQuery },
+      listAllForProjectForFrontend: { useQuery: mockListAllForProjectQuery },
     },
   },
 }));
@@ -178,6 +189,17 @@ function primeHooksForProvider({
     refetch: vi.fn(),
     hasEnabledProviders: false,
   });
+  // Flat-list counterpart of the collapsed record above.
+  mockListAllForOrgQuery.mockReturnValue({
+    data: { providers: [provider], modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+  mockListAllForProjectQuery.mockReturnValue({
+    data: { providers: [provider], modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
   mockUseModelProviderForm.mockReturnValue([
     buildState({ displayKeys }),
     buildActions(),
@@ -220,9 +242,7 @@ describe("Feature: Azure Safety model provider form rendering", () => {
       });
 
       it("renders the AZURE_CONTENT_SAFETY_ENDPOINT credential field", () => {
-        expect(
-          screen.getByText("AZURE_CONTENT_SAFETY_ENDPOINT"),
-        ).toBeTruthy();
+        expect(screen.getByText("AZURE_CONTENT_SAFETY_ENDPOINT")).toBeTruthy();
       });
 
       it("renders the AZURE_CONTENT_SAFETY_KEY credential field", () => {
@@ -244,9 +264,7 @@ describe("Feature: Azure Safety model provider form rendering", () => {
       });
 
       it("renders the Save button", () => {
-        expect(
-          screen.getByRole("button", { name: /save/i }),
-        ).toBeTruthy();
+        expect(screen.getByRole("button", { name: /save/i })).toBeTruthy();
       });
     });
   });

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
@@ -205,11 +205,20 @@ function getInputNearLabel(labelText: string): HTMLInputElement {
   while (node && !node.querySelector("input")) {
     node = node.parentElement;
   }
-  const input = node?.querySelector("input");
-  if (!input) {
+  if (!node) {
     throw new Error(`no input found near label "${labelText}"`);
   }
-  return input as HTMLInputElement;
+  // Exactly one input, not just "at least one" — if a future Field.Root
+  // flattening merges this field's wrapper with a sibling field's, a
+  // loose `querySelector` would silently return whichever input happens
+  // to come first in DOM order instead of failing loudly.
+  const inputs = node.querySelectorAll("input");
+  if (inputs.length !== 1) {
+    throw new Error(
+      `expected exactly one input near label "${labelText}", found ${inputs.length}`,
+    );
+  }
+  return inputs[0] as HTMLInputElement;
 }
 
 describe("Feature: editing a model-provider row resolves the correct row by id", () => {
@@ -222,7 +231,7 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
   });
 
   describe("given two openai rows exist at different scopes (org-wide and project-scoped)", () => {
-    describe("when the edit drawer opens targeting the wider-scope row (not the collapse winner)", () => {
+    describe("when the form renders targeting the wider-scope row (edit flow)", () => {
       beforeEach(() => {
         primeQueries();
         render(
@@ -270,7 +279,13 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
           expect(mockMutateAsync).toHaveBeenCalledTimes(1);
         });
         expect(mockMutateAsync).toHaveBeenCalledWith(
-          expect.objectContaining({ id: "row-a", provider: "openai" }),
+          expect.objectContaining({
+            id: "row-a",
+            provider: "openai",
+            customKeys: expect.objectContaining({
+              OPENAI_API_KEY: "sk-reentered-key",
+            }),
+          }),
         );
       });
     });

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * @vitest-environment jsdom
+ * @regression
+ *
+ * Regression tests for issue #5380: editing a model-provider row resolves
+ * the wrong row when a second same-type row exists at a narrower scope,
+ * producing a blank API-key field and, on save, a duplicate row.
+ *
+ * Covers @regression @integration scenarios from
+ * specs/model-providers/scope-and-multi-instance.feature:
+ *   /** @scenario Editing a row shows its own saved credential, not another row's
+ *   /** @scenario Saving an edited row updates it in place, not as a duplicate
+ *
+ * Root cause: `EditModelProviderForm` (src/components/settings/ModelProviderForm.tsx)
+ * resolves the row being edited by searching the COLLAPSED
+ * `Record<providerKey, MaybeStoredModelProvider>` returned by
+ * `useModelProvidersSettings` (one winner per provider type — the
+ * narrowest scope wins). The settings table, however, passes the real
+ * DB id from the UNCOLLAPSED flat list. When the id being edited is not
+ * the collapse winner, the lookup misses and the form silently falls
+ * back to a blank draft with no id: the API key field renders empty,
+ * and Save sends `id: undefined`, which the server treats as a create
+ * — producing a duplicate row instead of an update.
+ *
+ * `useModelProviderForm` and `useModelProvidersSettings` are deliberately
+ * NOT mocked below — the row-resolution memo and the real submit payload
+ * must actually execute for this test to exercise the bug.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockMutateAsync,
+  mockGetAllForProjectForFrontendQuery,
+  mockListAllForOrganizationForFrontendQuery,
+  mockListAllForProjectForFrontendQuery,
+} = vi.hoisted(() => ({
+  mockMutateAsync: vi.fn().mockResolvedValue({}),
+  mockGetAllForProjectForFrontendQuery: vi.fn(),
+  mockListAllForOrganizationForFrontendQuery: vi.fn(),
+  mockListAllForProjectForFrontendQuery: vi.fn(),
+}));
+
+// `useModelProviderForm` / `useModelProvidersSettings` are NOT mocked here
+// (see file header) — only their external boundaries are:
+//   - the tRPC client (`utils/api`)
+//   - peripheral hooks that reach outside this component's own logic
+//     (router-backed drawer state, feature flags, org/team/project context,
+//     the async API-key validation round-trip, and the toaster).
+vi.mock("../../../utils/api", () => ({
+  api: {
+    modelProvider: {
+      getAllForProjectForFrontend: {
+        useQuery: mockGetAllForProjectForFrontendQuery,
+      },
+      listAllForOrganizationForFrontend: {
+        useQuery: mockListAllForOrganizationForFrontendQuery,
+      },
+      listAllForProjectForFrontend: {
+        useQuery: mockListAllForProjectForFrontendQuery,
+      },
+      update: {
+        useMutation: () => ({ mutateAsync: mockMutateAsync }),
+      },
+      setRoleAssignmentForScope: {
+        useMutation: () => ({
+          mutateAsync: vi.fn().mockResolvedValue({ ok: true }),
+        }),
+      },
+      isManagedProvider: {
+        useQuery: () => ({ data: { managed: false } }),
+      },
+    },
+    useContext: () => ({
+      organization: {
+        getAll: { invalidate: vi.fn() },
+      },
+      modelProvider: {
+        getAllForProject: { invalidate: vi.fn() },
+        getAllForProjectForFrontend: { invalidate: vi.fn() },
+        listAllForProjectForFrontend: { invalidate: vi.fn() },
+        // Not read by any query above on current (buggy) code — included
+        // up front so this file is byte-identical across the fail-on-main
+        // run and the pass-after-fix run once the fix adds this
+        // invalidation to useProviderFormSubmit's awaited Promise.all.
+        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
+        getResolvedDefault: { invalidate: vi.fn() },
+        getDefaultModelsForProject: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+vi.mock("../../../hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: vi.fn(),
+    openDrawer: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", name: "Web App", slug: "web-app" },
+    team: { id: "team-1", name: "Platform" },
+    organization: {
+      id: "org-1",
+      name: "Acme",
+      teams: [
+        {
+          id: "team-1",
+          name: "Platform",
+          projects: [{ id: "proj-1", name: "Web App" }],
+        },
+      ],
+    },
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
+  useModelProviderApiKeyValidation: () => ({
+    validate: vi.fn().mockResolvedValue(true),
+    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
+    isValidating: false,
+    validationError: undefined,
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
+}));
+
+vi.mock("../../ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
+import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+import { EditModelProviderForm } from "../ModelProviderForm";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+// rowA is the edit TARGET: the wider (organization) scope, absent from the
+// collapsed record because rowB (narrower scope) wins the provider-type
+// dedupe. rowB is that collapse winner.
+const rowA: MaybeStoredModelProvider = {
+  id: "row-a",
+  name: "OpenAI",
+  provider: "openai",
+  enabled: true,
+  customKeys: { OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER, OPENAI_BASE_URL: "" },
+  models: null,
+  embeddingsModels: null,
+  customModels: null,
+  customEmbeddingsModels: null,
+  disabledByDefault: false,
+  deploymentMapping: null,
+  extraHeaders: [],
+  scopes: [{ scopeType: "ORGANIZATION", scopeId: "org-1" }],
+  scopeType: "ORGANIZATION",
+  scopeId: "org-1",
+};
+
+const rowB: MaybeStoredModelProvider = {
+  ...rowA,
+  id: "row-b",
+  scopes: [{ scopeType: "PROJECT", scopeId: "proj-1" }],
+  scopeType: "PROJECT",
+  scopeId: "proj-1",
+};
+
+function primeQueries() {
+  mockGetAllForProjectForFrontendQuery.mockReturnValue({
+    data: { providers: { openai: rowB }, modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+  mockListAllForOrganizationForFrontendQuery.mockReturnValue({
+    data: { providers: [rowA, rowB], modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+  mockListAllForProjectForFrontendQuery.mockReturnValue({
+    data: { providers: [rowA, rowB], modelMetadata: {} },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+}
+
+/**
+ * `CredentialsSection` labels each credential input with a plain `Text`
+ * (no `htmlFor`/`id` association — see ModelProviderCredentialsSection.tsx
+ * lines ~99-136), so `getByLabelText` can't find it. Instead, walk up from
+ * the label text node to the first ancestor that contains an `<input>`
+ * descendant (the field's own wrapper) and return that input.
+ */
+function getInputNearLabel(labelText: string): HTMLInputElement {
+  const label = screen.getByText(labelText);
+  let node: HTMLElement | null = label;
+  while (node && !node.querySelector("input")) {
+    node = node.parentElement;
+  }
+  const input = node?.querySelector("input");
+  if (!input) {
+    throw new Error(`no input found near label "${labelText}"`);
+  }
+  return input as HTMLInputElement;
+}
+
+describe("Feature: editing a model-provider row resolves the correct row by id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given two openai rows exist at different scopes (org-wide and project-scoped)", () => {
+    describe("when the edit drawer opens targeting the wider-scope row (not the collapse winner)", () => {
+      beforeEach(() => {
+        primeQueries();
+        render(
+          <Wrapper>
+            <EditModelProviderForm
+              projectId="proj-1"
+              organizationId="org-1"
+              modelProviderId="row-a"
+              providerKey="openai"
+            />
+          </Wrapper>,
+        );
+      });
+
+      /** @scenario Editing a row shows its own saved credential, not another row's */
+      it("shows the targeted row's saved API key, masked", () => {
+        const input = getInputNearLabel("OPENAI_API_KEY");
+        expect(input.value).toBe(MASKED_KEY_PLACEHOLDER);
+      });
+    });
+
+    describe("when the user re-enters the API key and clicks Save", () => {
+      beforeEach(async () => {
+        primeQueries();
+        render(
+          <Wrapper>
+            <EditModelProviderForm
+              projectId="proj-1"
+              organizationId="org-1"
+              modelProviderId="row-a"
+              providerKey="openai"
+            />
+          </Wrapper>,
+        );
+        const user = userEvent.setup();
+        const input = getInputNearLabel("OPENAI_API_KEY");
+        await user.clear(input);
+        await user.type(input, "sk-reentered-key");
+        await user.click(screen.getByRole("button", { name: /^save$/i }));
+      });
+
+      /** @scenario Saving an edited row updates it in place, not as a duplicate */
+      it("submits the update for the targeted row's id instead of a blank create", async () => {
+        await waitFor(() => {
+          expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+        });
+        expect(mockMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({ id: "row-a", provider: "openai" }),
+        );
+      });
+    });
+  });
+});

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
@@ -175,22 +175,58 @@ const rowB: MaybeStoredModelProvider = {
   scopeId: "proj-1",
 };
 
-function primeQueries() {
-  mockGetAllForProjectForFrontendQuery.mockReturnValue({
-    data: { providers: { openai: rowB }, modelMetadata: {} },
+/**
+ * Minimal but *realistic* TanStack Query v4 result. `useAllModelProvidersList`
+ * gates on `isSuccess`/`isError` (not just `isLoading`) to tell "the list
+ * definitively arrived" apart from "not loaded yet". A mock that returns only
+ * `{ data, isLoading }` leaves those gates `undefined` — silently falsy — so
+ * every `isReady`-derived branch would be untested by accident. These helpers
+ * set the full status triplet so the gates actually run.
+ */
+function readyQueryResult<T>(data: T) {
+  return {
+    data,
+    isSuccess: true,
+    isError: false,
     isLoading: false,
+    status: "success" as const,
     refetch: vi.fn(),
-  });
-  mockListAllForOrganizationForFrontendQuery.mockReturnValue({
-    data: { providers: [rowA, rowB], modelMetadata: {} },
-    isLoading: false,
+  };
+}
+
+function notReadyQueryResult() {
+  return {
+    data: undefined,
+    isSuccess: false,
+    isError: false,
+    isLoading: true,
+    status: "loading" as const,
     refetch: vi.fn(),
-  });
-  mockListAllForProjectForFrontendQuery.mockReturnValue({
-    data: { providers: [rowA, rowB], modelMetadata: {} },
-    isLoading: false,
-    refetch: vi.fn(),
-  });
+  };
+}
+
+/**
+ * Primes the collapsed-record query and BOTH flat-list queries (org and
+ * project variants). `flatList` drives the uncollapsed list the row-by-id
+ * resolution reads: an explicit row array (ready), `[]` (ready but empty),
+ * or "not-ready" (query still disabled/in-flight, no definitive answer).
+ */
+function primeQueries({
+  flatList = [rowA, rowB],
+  collapsed = { openai: rowB },
+}: {
+  flatList?: MaybeStoredModelProvider[] | "not-ready";
+  collapsed?: Record<string, MaybeStoredModelProvider>;
+} = {}) {
+  mockGetAllForProjectForFrontendQuery.mockReturnValue(
+    readyQueryResult({ providers: collapsed, modelMetadata: {} }),
+  );
+  const flatResult =
+    flatList === "not-ready"
+      ? notReadyQueryResult()
+      : readyQueryResult({ providers: flatList, modelMetadata: {} });
+  mockListAllForOrganizationForFrontendQuery.mockReturnValue(flatResult);
+  mockListAllForProjectForFrontendQuery.mockReturnValue(flatResult);
 }
 
 /**
@@ -229,6 +265,172 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
 
   afterEach(() => {
     cleanup();
+  });
+
+  describe("given an id-targeted edit whose row is absent from the flat list", () => {
+    const renderStale = () =>
+      render(
+        <Wrapper>
+          <EditModelProviderForm
+            projectId="proj-1"
+            organizationId="org-1"
+            modelProviderId="row-stale"
+            providerKey="openai"
+          />
+        </Wrapper>,
+      );
+
+    describe("when the flat list has arrived and is non-empty", () => {
+      beforeEach(() => {
+        primeQueries({ flatList: [rowA, rowB] });
+        renderStale();
+      });
+
+      /**
+       * @regression #5380 P2 stale-id phantom-row: a resolvable id that no
+       * longer names a row must surface the miss and block Save, never
+       * silently degrade to the create path and write a duplicate row.
+       */
+      it("shows the provider-no-longer-exists error copy", () => {
+        expect(screen.getByText(/no longer exists/i)).toBeInTheDocument();
+      });
+
+      it("keeps Save disabled and never calls mutateAsync", () => {
+        expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+        expect(mockMutateAsync).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the flat list has arrived and is empty", () => {
+      beforeEach(() => {
+        primeQueries({ flatList: [], collapsed: {} });
+        renderStale();
+      });
+
+      /**
+       * @regression #5380 P2 empty-org hole: a stale deep-link into an org
+       * with zero providers must STILL block Save. The pre-fix guard proxied
+       * "list loaded" as `allProviders.length > 0`, which reads a legitimately
+       * empty org as "not loaded" — the miss never fired and the phantom
+       * duplicate slipped through. This is the exact hole: it fails against
+       * the pre-fix draft (empty list → no error copy).
+       */
+      it("shows the provider-no-longer-exists error copy", () => {
+        expect(screen.getByText(/no longer exists/i)).toBeInTheDocument();
+      });
+
+      it("keeps Save disabled and never calls mutateAsync", () => {
+        expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+        expect(mockMutateAsync).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the flat list has not arrived yet", () => {
+      beforeEach(() => {
+        primeQueries({ flatList: "not-ready" });
+        renderStale();
+      });
+
+      /**
+       * @regression #5380 P2: the miss is not *definitive* until the list
+       * arrives, so the error copy must not flash mid-load — yet Save still
+       * stays blocked so an unresolved target can never submit.
+       */
+      it("does not render the no-longer-exists error copy while loading", () => {
+        expect(screen.queryByText(/no longer exists/i)).toBeNull();
+      });
+
+      it("keeps Save disabled while the target is unresolved", () => {
+        expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+      });
+    });
+  });
+
+  describe("given a brand-new provider (modelProviderId=new)", () => {
+    const renderNew = () =>
+      render(
+        <Wrapper>
+          <EditModelProviderForm
+            projectId="proj-1"
+            organizationId="org-1"
+            modelProviderId="new"
+            providerKey="openai"
+          />
+        </Wrapper>,
+      );
+
+    describe("when the form first renders", () => {
+      beforeEach(() => {
+        primeQueries();
+        renderNew();
+      });
+
+      it("renders a blank credential field and no stale-miss error", () => {
+        expect(getInputNearLabel("OPENAI_API_KEY").value).toBe("");
+        expect(screen.queryByText(/no longer exists/i)).toBeNull();
+      });
+    });
+
+    describe("when the user enters a key and clicks Save", () => {
+      beforeEach(async () => {
+        primeQueries();
+        renderNew();
+        const user = userEvent.setup();
+        const input = getInputNearLabel("OPENAI_API_KEY");
+        await user.clear(input);
+        await user.type(input, "sk-brand-new-key");
+        await user.click(screen.getByRole("button", { name: /^save$/i }));
+      });
+
+      it("submits a create with no id (server upserts a fresh row)", async () => {
+        await waitFor(() => {
+          expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+        });
+        expect(mockMutateAsync).toHaveBeenCalledWith(
+          expect.not.objectContaining({ id: expect.anything() }),
+        );
+      });
+    });
+
+    /**
+     * @regression #5380 add-flow render loop: the blank template must keep a
+     * stable reference across renders. The pre-fix draft dropped the
+     * `useMemo`, so `extraHeaders: []` was reallocated every render;
+     * useModelProviderForm's reset effect (deps include `provider.extraHeaders`)
+     * then refired on every render — "Maximum update depth exceeded" — and
+     * re-seeded the form, wiping the user's input. Re-rendering with unchanged
+     * props exercises the runtime path and observes the clobber, not source
+     * text.
+     */
+    describe("when the parent re-renders with unchanged props after the user typed", () => {
+      it("retains the user's typed key (the blank template is not re-seeded per render)", async () => {
+        primeQueries();
+        const user = userEvent.setup();
+        const { rerender } = renderNew();
+
+        const input = getInputNearLabel("OPENAI_API_KEY");
+        await user.clear(input);
+        await user.type(input, "sk-survives-rerender");
+        expect(getInputNearLabel("OPENAI_API_KEY").value).toBe(
+          "sk-survives-rerender",
+        );
+
+        rerender(
+          <Wrapper>
+            <EditModelProviderForm
+              projectId="proj-1"
+              organizationId="org-1"
+              modelProviderId="new"
+              providerKey="openai"
+            />
+          </Wrapper>,
+        );
+
+        expect(getInputNearLabel("OPENAI_API_KEY").value).toBe(
+          "sk-survives-rerender",
+        );
+      });
+    });
   });
 
   describe("given two openai rows exist at different scopes (org-wide and project-scoped)", () => {

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
@@ -291,6 +291,7 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
        * longer names a row must surface the miss and block Save, never
        * silently degrade to the create path and write a duplicate row.
        */
+      /** @scenario Editing a provider that was deleted in another session shows it no longer exists */
       it("shows the provider-no-longer-exists error copy", () => {
         expect(screen.getByText(/no longer exists/i)).toBeInTheDocument();
       });
@@ -319,6 +320,7 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
         expect(screen.getByText(/no longer exists/i)).toBeInTheDocument();
       });
 
+      /** @scenario A stale edit link still blocks save when the organization has no providers at all */
       it("keeps Save disabled and never calls mutateAsync", () => {
         expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
         expect(mockMutateAsync).not.toHaveBeenCalled();
@@ -336,6 +338,7 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
        * arrives, so the error copy must not flash mid-load — yet Save still
        * stays blocked so an unresolved target can never submit.
        */
+      /** @scenario While the provider list is still loading the drawer does not claim the provider is missing */
       it("does not render the no-longer-exists error copy while loading", () => {
         expect(screen.queryByText(/no longer exists/i)).toBeNull();
       });
@@ -403,6 +406,7 @@ describe("Feature: editing a model-provider row resolves the correct row by id",
      * text.
      */
     describe("when the parent re-renders with unchanged props after the user typed", () => {
+      /** @scenario Adding a new provider does not wipe the credentials I am typing */
       it("retains the user's typed key (the blank template is not re-seeded per render)", async () => {
         primeQueries();
         const user = userEvent.setup();

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx
@@ -29,6 +29,7 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -141,7 +142,7 @@ import type { MaybeStoredModelProvider } from "../../../server/modelProviders/re
 import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
 import { EditModelProviderForm } from "../ModelProviderForm";
 
-const Wrapper = ({ children }: { children: React.ReactNode }) => (
+const Wrapper = ({ children }: { children: ReactNode }) => (
   <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
 );
 

--- a/langwatch/src/hooks/__tests__/useAllModelProvidersList.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useAllModelProvidersList.integration.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment jsdom
+ * @regression
+ *
+ * Regression test for the #5380 render-loop class. `useAllModelProvidersList`
+ * must hand back a referentially STABLE empty array while its query has no
+ * data (a disabled, in-flight, or errored query). A fresh `[]` per render
+ * hands each render a new array reference; any consumer that lists
+ * `providers` in an effect or memo dependency then re-fires every render —
+ * the same infinite-render loop `useModelProviderForm`'s reset effect trips
+ * on via `provider.extraHeaders`.
+ *
+ * This test EXECUTES the hook and observes the reference across renders; it
+ * does not assert on source text. The mocked query is a realistic TanStack
+ * Query v4 result (the repo pins react-query ^4.44.0), mirroring the boundary
+ * mocks in
+ * src/components/settings/__tests__/ModelProviderForm.edit-row-resolution.integration.test.tsx.
+ */
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockListAllForOrganizationForFrontendQuery,
+  mockListAllForProjectForFrontendQuery,
+} = vi.hoisted(() => ({
+  mockListAllForOrganizationForFrontendQuery: vi.fn(),
+  mockListAllForProjectForFrontendQuery: vi.fn(),
+}));
+
+// Only the two boundaries this hook actually reads are mocked: the tRPC
+// flat-list queries and the org/team/project context.
+vi.mock("../../utils/api", () => ({
+  api: {
+    modelProvider: {
+      listAllForOrganizationForFrontend: {
+        useQuery: mockListAllForOrganizationForFrontendQuery,
+      },
+      listAllForProjectForFrontend: {
+        useQuery: mockListAllForProjectForFrontendQuery,
+      },
+    },
+  },
+}));
+
+vi.mock("../useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", name: "Web App", slug: "web-app" },
+    organization: { id: "org-1", name: "Acme" },
+    // `organization:view` granted → the hook reads the org-wide flat list, so
+    // the organization query below is the active one.
+    hasPermission: () => true,
+  }),
+}));
+
+import type { MaybeStoredModelProvider } from "../../server/modelProviders/registry";
+import { useAllModelProvidersList } from "../useAllModelProvidersList";
+
+/**
+ * Minimal but realistic TanStack Query v4 result. The hook gates on
+ * `isSuccess`/`isError` (not just `isLoading`) to tell "the list definitively
+ * arrived" apart from "not loaded yet", so the full status triplet must be
+ * present or those gates silently read `undefined`.
+ */
+function readyQueryResult<T>(data: T) {
+  return {
+    data,
+    isSuccess: true,
+    isError: false,
+    isLoading: false,
+    status: "success" as const,
+    refetch: vi.fn(),
+  };
+}
+
+function notReadyQueryResult() {
+  return {
+    data: undefined,
+    isSuccess: false,
+    isError: false,
+    isLoading: true,
+    status: "loading" as const,
+    refetch: vi.fn(),
+  };
+}
+
+/**
+ * Both queries always run (React requires every hook to execute); only the
+ * organization one is active here. Priming both mirrors the real render.
+ */
+function primeBothQueries<T extends object>(result: T) {
+  mockListAllForOrganizationForFrontendQuery.mockReturnValue(result);
+  mockListAllForProjectForFrontendQuery.mockReturnValue(result);
+}
+
+function makeProvider(
+  overrides: Partial<MaybeStoredModelProvider> = {},
+): MaybeStoredModelProvider {
+  return {
+    id: "row-a",
+    name: "OpenAI",
+    provider: "openai",
+    enabled: true,
+    customKeys: null,
+    models: null,
+    embeddingsModels: null,
+    customModels: null,
+    customEmbeddingsModels: null,
+    disabledByDefault: false,
+    deploymentMapping: null,
+    extraHeaders: [],
+    scopes: [{ scopeType: "ORGANIZATION", scopeId: "org-1" }],
+    scopeType: "ORGANIZATION",
+    scopeId: "org-1",
+    ...overrides,
+  };
+}
+
+describe("useAllModelProvidersList()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given the query has no data yet (disabled, in-flight, or errored)", () => {
+    describe("when the hook re-renders with unchanged inputs", () => {
+      it("returns the same providers array reference across renders", () => {
+        primeBothQueries(notReadyQueryResult());
+
+        const { result, rerender } = renderHook(() =>
+          useAllModelProvidersList(),
+        );
+        const first = result.current.providers;
+
+        rerender();
+        const second = result.current.providers;
+
+        // Empty list (no rows) — but, crucially, the SAME empty list each
+        // render. A fresh `[]` per render is the reference churn that re-fires
+        // dependent effects into an infinite loop (#5380).
+        expect(first).toEqual([]);
+        expect(second).toBe(first);
+      });
+    });
+  });
+
+  describe("given the query has resolved with rows", () => {
+    describe("when the hook reads the resolved list", () => {
+      it("returns the query's own providers array", () => {
+        const rows: MaybeStoredModelProvider[] = [
+          makeProvider({
+            id: "row-a",
+            scopeType: "ORGANIZATION",
+            scopeId: "org-1",
+          }),
+          makeProvider({
+            id: "row-b",
+            scopeType: "PROJECT",
+            scopeId: "proj-1",
+          }),
+        ];
+        primeBothQueries(
+          readyQueryResult({ providers: rows, modelMetadata: {} }),
+        );
+
+        const { result } = renderHook(() => useAllModelProvidersList());
+
+        expect(result.current.providers).toBe(rows);
+      });
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx
@@ -47,6 +47,7 @@ vi.mock("../../utils/api", () => ({
         getAllForProject: { invalidate: vi.fn() },
         getAllForProjectForFrontend: { invalidate: vi.fn() },
         listAllForProjectForFrontend: { invalidate: vi.fn() },
+        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
         getResolvedDefault: { invalidate: vi.fn() },
         getDefaultModelsForProject: {
           invalidate: mockDefaultModelsInvalidate,

--- a/langwatch/src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx
@@ -26,6 +26,7 @@ const {
   mockInvalidate,
   mockSetRoleAssignmentMutateAsync,
   mockDefaultModelsInvalidate,
+  mockListAllForOrgInvalidate,
 } = vi.hoisted(() => ({
   mockUpdateMutateAsync: vi.fn().mockResolvedValue({}),
   mockUpdateProjectDefaultModelsMutateAsync: vi.fn().mockResolvedValue({}),
@@ -33,6 +34,7 @@ const {
   mockInvalidate: vi.fn(),
   mockSetRoleAssignmentMutateAsync: vi.fn().mockResolvedValue({ ok: true }),
   mockDefaultModelsInvalidate: vi.fn(),
+  mockListAllForOrgInvalidate: vi.fn(),
 }));
 
 vi.mock("../../utils/api", () => ({
@@ -47,7 +49,9 @@ vi.mock("../../utils/api", () => ({
         getAllForProject: { invalidate: vi.fn() },
         getAllForProjectForFrontend: { invalidate: vi.fn() },
         listAllForProjectForFrontend: { invalidate: vi.fn() },
-        listAllForOrganizationForFrontend: { invalidate: vi.fn() },
+        listAllForOrganizationForFrontend: {
+          invalidate: mockListAllForOrgInvalidate,
+        },
         getResolvedDefault: { invalidate: vi.fn() },
         getDefaultModelsForProject: {
           invalidate: mockDefaultModelsInvalidate,
@@ -304,6 +308,27 @@ describe("useProviderFormSubmit()", () => {
         });
 
         expect(mockDefaultModelsInvalidate).toHaveBeenCalled();
+      });
+
+      it("invalidates the org-wide provider list so the settings table refetches", async () => {
+        // #5380 second root cause: after add/save, the settings table
+        // reads listAllForOrganizationForFrontend — without this
+        // invalidation it keeps a stale list until window-focus refetch,
+        // inviting a duplicate re-add of the row just saved.
+        const snapshot = buildSnapshot({
+          useAsDefaultProvider: false,
+          projectDefaultModel: null,
+          projectTopicClusteringModel: null,
+          projectEmbeddingsModel: null,
+          scopes: [{ scopeType: "PROJECT", scopeId: "proj-1" }],
+        });
+        const { result } = renderSubmitHook({ snapshot });
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockListAllForOrgInvalidate).toHaveBeenCalled();
       });
     });
   });

--- a/langwatch/src/hooks/useAllModelProvidersList.ts
+++ b/langwatch/src/hooks/useAllModelProvidersList.ts
@@ -4,7 +4,9 @@ import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
 
 /**
  * Flat (uncollapsed) list of every stored ModelProvider row the caller can
- * see — one entry per row, never deduped by provider type.
+ * see — one entry per row, never deduped by provider type. Canonical
+ * rationale for this hook's existence — point comments elsewhere at this
+ * block instead of restating it.
  *
  * `useModelProvidersSettings` returns a `Record<providerKey, row>` collapsed
  * to a single winner per provider type (narrowest scope wins), which is
@@ -14,7 +16,16 @@ import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
  * non-winning row from that Record entirely, so an id lookup against it
  * silently misses and falls back to a blank draft (#5380). Any caller that
  * looks up a row by id — not by provider key — must read from this flat
- * list instead.
+ * list instead, via `findModelProviderById` below.
+ *
+ * Note on the loading signal: a disabled query (the org/project id is
+ * momentarily unresolved, e.g. before the app-shell context hydrates)
+ * reports `isLoading: false` with `providers: []` — react-query only
+ * reports `isLoading` for a query that's actually enabled and fetching.
+ * Consumers that gate a seed-once form on "don't mount off an empty list"
+ * (`EditModelProviderDrawer`) rely on the surrounding settings page having
+ * already hydrated org/project before the drawer can even open; this hook
+ * does not itself distinguish "genuinely empty" from "not ready yet".
  */
 export function useAllModelProvidersList() {
   const { project, organization, hasPermission } = useOrganizationTeamProject();
@@ -47,10 +58,27 @@ export function useAllModelProvidersList() {
   );
   const activeQuery = canViewOrg ? orgQuery : projectQuery;
 
+  // Both procedures resolve to the identical `{ providers, modelMetadata }`
+  // shape (same MaybeStoredModelProvider[] / ModelMetadataForFrontend
+  // types on both branches), so tRPC's inference already gives
+  // `activeQuery.data?.providers` the right type here with no cast needed.
   return {
-    providers: (activeQuery.data?.providers ??
-      []) as MaybeStoredModelProvider[],
+    providers: activeQuery.data?.providers ?? [],
     isLoading: activeQuery.isLoading,
     refetch: activeQuery.refetch,
   } as const;
+}
+
+/**
+ * Resolves a single row by id from the flat list above. Shared by
+ * `ModelProviderForm`'s edit-target memo and `EditModelProviderDrawer`'s
+ * title lookup so the two can never again resolve different rows for the
+ * same id — the #5380 bug was exactly two separate resolvers drifting.
+ */
+export function findModelProviderById(
+  providers: MaybeStoredModelProvider[],
+  modelProviderId: string | undefined,
+): MaybeStoredModelProvider | undefined {
+  if (!modelProviderId || modelProviderId === "new") return undefined;
+  return providers.find((p) => p.id === modelProviderId);
 }

--- a/langwatch/src/hooks/useAllModelProvidersList.ts
+++ b/langwatch/src/hooks/useAllModelProvidersList.ts
@@ -1,0 +1,56 @@
+import type { MaybeStoredModelProvider } from "../server/modelProviders/registry";
+import { api } from "../utils/api";
+import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
+
+/**
+ * Flat (uncollapsed) list of every stored ModelProvider row the caller can
+ * see — one entry per row, never deduped by provider type.
+ *
+ * `useModelProvidersSettings` returns a `Record<providerKey, row>` collapsed
+ * to a single winner per provider type (narrowest scope wins), which is
+ * correct for surfaces that render "the effective config for provider X"
+ * but wrong for anything that resolves a SPECIFIC row by id: a
+ * multi-instance setup (two "openai" rows at different scopes) drops the
+ * non-winning row from that Record entirely, so an id lookup against it
+ * silently misses and falls back to a blank draft (#5380). Any caller that
+ * looks up a row by id — not by provider key — must read from this flat
+ * list instead.
+ */
+export function useAllModelProvidersList() {
+  const { project, organization, hasPermission } = useOrganizationTeamProject();
+
+  // "All you can see" fans out across the whole organization so an
+  // org:view admin sees providers a sibling project has configured.
+  // Members without `organization:view` (project-only members) 403 on
+  // that endpoint and must fall back to the per-project list, which they
+  // always have permission to read.
+  const canViewOrg = hasPermission("organization:view");
+
+  const orgQuery = api.modelProvider.listAllForOrganizationForFrontend.useQuery(
+    { organizationId: organization?.id ?? "" },
+    {
+      enabled: !!organization?.id && canViewOrg,
+      retry: false,
+      // A focus refetch mid-edit would re-seed whichever form is reading
+      // this list and wipe the user's in-progress typing — same failure
+      // shape #5357 fixed for the model picker.
+      refetchOnWindowFocus: false,
+    },
+  );
+  const projectQuery = api.modelProvider.listAllForProjectForFrontend.useQuery(
+    { projectId: project?.id ?? "" },
+    {
+      enabled: !!project?.id && !canViewOrg,
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  );
+  const activeQuery = canViewOrg ? orgQuery : projectQuery;
+
+  return {
+    providers: (activeQuery.data?.providers ??
+      []) as MaybeStoredModelProvider[],
+    isLoading: activeQuery.isLoading,
+    refetch: activeQuery.refetch,
+  } as const;
+}

--- a/langwatch/src/hooks/useAllModelProvidersList.ts
+++ b/langwatch/src/hooks/useAllModelProvidersList.ts
@@ -70,6 +70,18 @@ export function useAllModelProvidersList() {
 }
 
 /**
+ * True when `modelProviderId` names an actual stored row — i.e. it's
+ * neither absent nor the Add-flow sentinel `"new"`. Shared so every
+ * caller that branches on "is there a specific row to resolve" uses the
+ * same rule.
+ */
+export function isResolvableProviderId(
+  modelProviderId: string | undefined,
+): boolean {
+  return !!modelProviderId && modelProviderId !== "new";
+}
+
+/**
  * Resolves a single row by id from the flat list above. Shared by
  * `ModelProviderForm`'s edit-target memo and `EditModelProviderDrawer`'s
  * title lookup so the two can never again resolve different rows for the
@@ -79,6 +91,6 @@ export function findModelProviderById(
   providers: MaybeStoredModelProvider[],
   modelProviderId: string | undefined,
 ): MaybeStoredModelProvider | undefined {
-  if (!modelProviderId || modelProviderId === "new") return undefined;
+  if (!isResolvableProviderId(modelProviderId)) return undefined;
   return providers.find((p) => p.id === modelProviderId);
 }

--- a/langwatch/src/hooks/useAllModelProvidersList.ts
+++ b/langwatch/src/hooks/useAllModelProvidersList.ts
@@ -18,14 +18,24 @@ import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
  * looks up a row by id — not by provider key — must read from this flat
  * list instead, via `findModelProviderById` below.
  *
- * Note on the loading signal: a disabled query (the org/project id is
- * momentarily unresolved, e.g. before the app-shell context hydrates)
- * reports `isLoading: false` with `providers: []` — react-query only
- * reports `isLoading` for a query that's actually enabled and fetching.
- * Consumers that gate a seed-once form on "don't mount off an empty list"
- * (`EditModelProviderDrawer`) rely on the surrounding settings page having
- * already hydrated org/project before the drawer can even open; this hook
- * does not itself distinguish "genuinely empty" from "not ready yet".
+ * Note on the loading signal: the flat list answers two different questions,
+ * so this hook exposes two flags rather than one overloaded `isLoading`:
+ *
+ *   - `isReady` (≡ react-query `isSuccess`) means the list *definitively
+ *     arrived*: the query ran and resolved. It is false for a disabled query
+ *     (org/project id not yet hydrated), an in-flight fetch, AND an errored
+ *     one. A caller that must tell "genuinely empty" apart from "not loaded
+ *     yet" — e.g. deciding an id lookup is a real stale miss rather than a
+ *     not-ready list — gates on `isReady`, so an empty array only counts as
+ *     empty once `isReady` is true.
+ *   - `isLoading` here is a *spinner* signal: `!isSuccess && !isError`, i.e.
+ *     "no definitive answer yet". It stays true for a disabled query — in
+ *     react-query v4 a disabled query still reports `status: 'loading'`, and
+ *     a surface like `EditModelProviderDrawer` genuinely should keep spinning
+ *     until org/project hydrate rather than mount a form off an empty list.
+ *     It flips to false the moment the query *errors* (a 403 with
+ *     `retry:false`), so a permission failure shows the (empty) surface
+ *     instead of spinning forever.
  */
 export function useAllModelProvidersList() {
   const { project, organization, hasPermission } = useOrganizationTeamProject();
@@ -64,7 +74,13 @@ export function useAllModelProvidersList() {
   // `activeQuery.data?.providers` the right type here with no cast needed.
   return {
     providers: activeQuery.data?.providers ?? [],
-    isLoading: activeQuery.isLoading,
+    // The flat list definitively arrived (see the "Note on the loading
+    // signal" block above): false for disabled, in-flight, and errored
+    // queries.
+    isReady: activeQuery.isSuccess,
+    // Spinner signal — "no definitive answer yet". True while the query is
+    // disabled or fetching; false once it resolves OR errors.
+    isLoading: !activeQuery.isSuccess && !activeQuery.isError,
     refetch: activeQuery.refetch,
   } as const;
 }

--- a/langwatch/src/hooks/useAllModelProvidersList.ts
+++ b/langwatch/src/hooks/useAllModelProvidersList.ts
@@ -8,9 +8,10 @@ import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
 // render — the render-loop class behind #5380, the same one
 // `useModelProviderForm`'s reset effect trips on through `provider.extraHeaders`.
 // A module-level constant keeps the empty-list identity stable so those
-// dependency arrays don't churn. Non-readonly so it stays assignable to
-// `findModelProviderById`, which the row-by-id consumers feed this list into.
-const NO_PROVIDERS: MaybeStoredModelProvider[] = [];
+// dependency arrays don't churn. `readonly` because every caller shares this
+// one instance: a stray `push`/`sort` on a "local" copy would corrupt the
+// empty list for everyone.
+const NO_PROVIDERS: readonly MaybeStoredModelProvider[] = [];
 
 /**
  * Flat (uncollapsed) list of every stored ModelProvider row the caller can
@@ -29,7 +30,8 @@ const NO_PROVIDERS: MaybeStoredModelProvider[] = [];
  * list instead, via `findModelProviderById` below.
  *
  * Note on the loading signal: the flat list answers two different questions,
- * so this hook exposes two flags rather than one overloaded `isLoading`:
+ * so this hook exposes two flags. They are NOT complementary — both go false
+ * once the query errors — so do not "simplify" either into `!other`.
  *
  *   - `isReady` (≡ react-query `isSuccess`) means the list *definitively
  *     arrived*: the query ran and resolved. It is false for a disabled query
@@ -37,15 +39,22 @@ const NO_PROVIDERS: MaybeStoredModelProvider[] = [];
  *     one. A caller that must tell "genuinely empty" apart from "not loaded
  *     yet" — e.g. deciding an id lookup is a real stale miss rather than a
  *     not-ready list — gates on `isReady`, so an empty array only counts as
- *     empty once `isReady` is true.
- *   - `isLoading` here is a *spinner* signal: `!isSuccess && !isError`, i.e.
- *     "no definitive answer yet". It stays true for a disabled query — in
- *     react-query v4 a disabled query still reports `status: 'loading'`, and
- *     a surface like `EditModelProviderDrawer` genuinely should keep spinning
- *     until org/project hydrate rather than mount a form off an empty list.
- *     It flips to false the moment the query *errors* (a 403 with
- *     `retry:false`), so a permission failure shows the (empty) surface
- *     instead of spinning forever.
+ *     empty once `isReady` is true. (Opposite direction to the `isReady` in
+ *     `features/traces-v2/hooks/useTraceQueryArgs.ts`, which is a *pre-fetch*
+ *     gate meaning "we have enough input to enable the query at all". Same
+ *     word, different question.)
+ *   - `isLoading` is react-query's own flag, forwarded unchanged
+ *     (`status === 'loading'`). It stays true for a *disabled* query — v4
+ *     leaves a never-fetched query at `status: 'loading'` — which is what
+ *     `EditModelProviderDrawer` wants: keep spinning until org/project
+ *     hydrate rather than mount a form off an empty list. It flips false the
+ *     moment the query *errors* (a 403 under `retry: false`), so a permission
+ *     failure shows the (empty) surface instead of spinning forever.
+ *
+ *     Deliberately NOT `isInitialLoading` (`isLoading && isFetching`), which
+ *     is false for a disabled query and would make the drawer skip its
+ *     spinner and mount the form off an empty list — the exact failure this
+ *     signal exists to prevent.
  */
 export function useAllModelProvidersList() {
   const { project, organization, hasPermission } = useOrganizationTeamProject();
@@ -84,13 +93,10 @@ export function useAllModelProvidersList() {
   // `activeQuery.data?.providers` the right type here with no cast needed.
   return {
     providers: activeQuery.data?.providers ?? NO_PROVIDERS,
-    // The flat list definitively arrived (see the "Note on the loading
-    // signal" block above): false for disabled, in-flight, and errored
-    // queries.
+    // See the "Note on the loading signal" block above for what each of these
+    // answers, and why they are not complementary.
     isReady: activeQuery.isSuccess,
-    // Spinner signal — "no definitive answer yet". True while the query is
-    // disabled or fetching; false once it resolves OR errors.
-    isLoading: !activeQuery.isSuccess && !activeQuery.isError,
+    isLoading: activeQuery.isLoading,
     refetch: activeQuery.refetch,
   } as const;
 }
@@ -117,7 +123,7 @@ export function findModelProviderById({
   providers,
   modelProviderId,
 }: {
-  providers: MaybeStoredModelProvider[];
+  providers: readonly MaybeStoredModelProvider[];
   modelProviderId: string | undefined;
 }): MaybeStoredModelProvider | undefined {
   if (!isResolvableProviderId(modelProviderId)) return undefined;

--- a/langwatch/src/hooks/useAllModelProvidersList.ts
+++ b/langwatch/src/hooks/useAllModelProvidersList.ts
@@ -2,6 +2,16 @@ import type { MaybeStoredModelProvider } from "../server/modelProviders/registry
 import { api } from "../utils/api";
 import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
 
+// A fresh `[]` on every render with no data (a disabled, in-flight, or
+// errored query) hands each render a new array reference. Any consumer that
+// lists `providers` in an effect or memo dependency then re-fires every
+// render — the render-loop class behind #5380, the same one
+// `useModelProviderForm`'s reset effect trips on through `provider.extraHeaders`.
+// A module-level constant keeps the empty-list identity stable so those
+// dependency arrays don't churn. Non-readonly so it stays assignable to
+// `findModelProviderById`, which the row-by-id consumers feed this list into.
+const NO_PROVIDERS: MaybeStoredModelProvider[] = [];
+
 /**
  * Flat (uncollapsed) list of every stored ModelProvider row the caller can
  * see — one entry per row, never deduped by provider type. Canonical
@@ -73,7 +83,7 @@ export function useAllModelProvidersList() {
   // types on both branches), so tRPC's inference already gives
   // `activeQuery.data?.providers` the right type here with no cast needed.
   return {
-    providers: activeQuery.data?.providers ?? [],
+    providers: activeQuery.data?.providers ?? NO_PROVIDERS,
     // The flat list definitively arrived (see the "Note on the loading
     // signal" block above): false for disabled, in-flight, and errored
     // queries.

--- a/langwatch/src/hooks/useAllModelProvidersList.ts
+++ b/langwatch/src/hooks/useAllModelProvidersList.ts
@@ -87,10 +87,13 @@ export function isResolvableProviderId(
  * title lookup so the two can never again resolve different rows for the
  * same id — the #5380 bug was exactly two separate resolvers drifting.
  */
-export function findModelProviderById(
-  providers: MaybeStoredModelProvider[],
-  modelProviderId: string | undefined,
-): MaybeStoredModelProvider | undefined {
+export function findModelProviderById({
+  providers,
+  modelProviderId,
+}: {
+  providers: MaybeStoredModelProvider[];
+  modelProviderId: string | undefined;
+}): MaybeStoredModelProvider | undefined {
   if (!isResolvableProviderId(modelProviderId)) return undefined;
   return providers.find((p) => p.id === modelProviderId);
 }

--- a/langwatch/src/hooks/useProviderFormSubmit.ts
+++ b/langwatch/src/hooks/useProviderFormSubmit.ts
@@ -433,10 +433,18 @@ export function useProviderFormSubmit({
       // auto-seed (seedOnboardingDefaultsForProvider) runs regardless of
       // the "use as default provider" checkbox — so the DefaultModelsSection
       // card needs to refetch even when the user didn't opt into the replay.
+      // listAllForOrganizationForFrontend is here too: the settings table
+      // reads that org-wide list for org:view users, and this invalidation
+      // is awaited before onSuccess closes the drawer — omit it and the
+      // table re-renders with the stale pre-save list (no loading
+      // affordance), which reads as "the save didn't take" and drives
+      // users to re-add the same provider (the other duplicate-row path
+      // in #5380).
       await Promise.all([
         utils.modelProvider.getAllForProject.invalidate(),
         utils.modelProvider.getAllForProjectForFrontend.invalidate(),
         utils.modelProvider.listAllForProjectForFrontend.invalidate(),
+        utils.modelProvider.listAllForOrganizationForFrontend.invalidate(),
         utils.modelProvider.getResolvedDefault.invalidate(),
         utils.modelProvider.getDefaultModelsForProject.invalidate(),
       ]);

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -46,7 +46,6 @@ export default function ModelsPage() {
 
   const { openDrawer, drawerOpen: isDrawerOpen } = useDrawer();
   const isProviderDrawerOpen = isDrawerOpen("editModelProvider");
-  const updateMutation = api.modelProvider.update.useMutation();
   const deleteMutation = api.modelProvider.delete.useMutation();
   const [providerToDelete, setProviderToDelete] = useState<{
     id?: string;

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -36,12 +36,8 @@ export default function ModelsPage() {
   const { project, organization, team, hasPermission } =
     useOrganizationTeamProject();
   const hasModelProvidersManagePermission = hasPermission("project:manage");
-  // The settings page renders one row per stored ModelProvider — the
-  // Record-by-provider-key shape returned by `useModelProvidersSettings`
-  // collapses multi-instance setups (two "OpenAI" rows at different
-  // scopes) into a single entry and silently drops the loser. The shared
-  // hook fans the flat list out across org/project scope so the table
-  // reflects every row regardless of the viewer's permissions.
+  // Flat, uncollapsed list — see useAllModelProvidersList for why this
+  // table can't use the collapsed Record from useModelProvidersSettings.
   const {
     providers: allProvidersList,
     isLoading,

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -14,6 +14,7 @@ import {
 import { BrainCircuit, Edit, MoreVertical, Plus, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { PageLayout } from "~/components/ui/layouts/PageLayout";
+import { useAllModelProvidersList } from "~/hooks/useAllModelProvidersList";
 import { useAvailableScopes } from "~/hooks/useAvailableScopes";
 import { useDrawer } from "~/hooks/useDrawer";
 import { useUrlScopeFilter } from "~/hooks/useUrlScopeFilter";
@@ -38,34 +39,14 @@ export default function ModelsPage() {
   // The settings page renders one row per stored ModelProvider — the
   // Record-by-provider-key shape returned by `useModelProvidersSettings`
   // collapses multi-instance setups (two "OpenAI" rows at different
-  // scopes) into a single entry and silently drops the loser. Use the
-  // flat list endpoint instead so the table reflects every row.
-  //
-  // The "All you can see" view fans out across the whole organization
-  // so an admin sees providers a sibling project has configured. Members
-  // without `organization:view` (project-only members) fall back to the
-  // per-project endpoint, which they always have permission to read.
-  const canViewOrg = hasPermission("organization:view");
-  const orgQuery = api.modelProvider.listAllForOrganizationForFrontend.useQuery(
-    { organizationId: organization?.id ?? "" },
-    {
-      enabled: !!organization?.id && canViewOrg,
-      retry: false,
-      refetchOnWindowFocus: false,
-    },
-  );
-  const projectQuery = api.modelProvider.listAllForProjectForFrontend.useQuery(
-    { projectId: project?.id ?? "" },
-    {
-      enabled: !!project?.id && !canViewOrg,
-      retry: false,
-      refetchOnWindowFocus: false,
-    },
-  );
-  const activeQuery = canViewOrg ? orgQuery : projectQuery;
-  const allProvidersList = activeQuery.data?.providers ?? [];
-  const isLoading = activeQuery.isLoading;
-  const refetch = activeQuery.refetch;
+  // scopes) into a single entry and silently drops the loser. The shared
+  // hook fans the flat list out across org/project scope so the table
+  // reflects every row regardless of the viewer's permissions.
+  const {
+    providers: allProvidersList,
+    isLoading,
+    refetch,
+  } = useAllModelProvidersList();
 
   const { openDrawer, drawerOpen: isDrawerOpen } = useDrawer();
   const isProviderDrawerOpen = isDrawerOpen("editModelProvider");

--- a/specs/model-providers/scope-and-multi-instance.feature
+++ b/specs/model-providers/scope-and-multi-instance.feature
@@ -177,6 +177,46 @@ Feature: Model Provider Scope and Multi-Instance
     Then the organization-scoped row is updated with the new key
     And exactly two "OpenAI" ModelProvider rows still exist for "acme"
 
+  @regression @integration
+  Scenario: Editing a provider that was deleted in another session shows it no longer exists
+    Given the org "acme" already has a ModelProvider named "OpenAI" scoped to project "web-app"
+    And a second "OpenAI" scoped to organization "acme" was deleted from another session
+    When I open the edit drawer for that organization-scoped "OpenAI" row
+    Then the drawer tells me this provider configuration no longer exists
+    And "Save" is unavailable
+    And no new provider is created
+
+  @regression @integration
+  Scenario: A stale edit link still blocks save when the organization has no providers at all
+    Given the org "acme" has no model providers configured
+    When I open a stale edit link for an "OpenAI" row that no longer exists
+    Then the drawer tells me this provider configuration no longer exists
+    And "Save" is unavailable
+    And no new provider is created
+
+  @regression @integration
+  Scenario: While the provider list is still loading the drawer does not claim the provider is missing
+    Given my model providers are still loading
+    When I open the edit drawer for an "OpenAI" row
+    Then the drawer does not yet say the provider no longer exists
+    And "Save" stays unavailable until the row is resolved
+
+  # An edit that targets a specific row must resolve THAT row or surface a
+  # clear "no longer exists" miss — it must never silently fall back to the
+  # create path. That fallback is exactly what wrote the duplicate rows in
+  # #5380: a stale or unresolved id sailed through as an id-less save, which
+  # the server upserts as a brand-new provider instead of updating in place.
+  # The empty-organization case is called out on its own because the first
+  # attempt proxied "list has loaded" as "list is non-empty", so a legitimately
+  # empty org read as "still loading" and the miss never fired.
+
+  @regression @integration
+  Scenario: Adding a new provider does not wipe the credentials I am typing
+    When I open the Create Model Provider drawer for "openai"
+    And I enter an OPENAI_API_KEY
+    Then the field keeps the value I entered while I keep working in the drawer
+    And my key is not silently cleared
+
   # ────────────────────────────────────────────────────────────────────────────
   # Model Providers page becomes org-level
   # ────────────────────────────────────────────────────────────────────────────

--- a/specs/model-providers/scope-and-multi-instance.feature
+++ b/specs/model-providers/scope-and-multi-instance.feature
@@ -155,6 +155,28 @@ Feature: Model Provider Scope and Multi-Instance
     # Previously the menu hid providers that already had a row — we now allow
     # multiple rows per provider type.
 
+  @regression @integration
+  Scenario: Editing a row shows its own saved credential, not another row's
+    Given the org "acme" already has a ModelProvider named "OpenAI" scoped to project "web-app"
+    And the org "acme" also has a ModelProvider named "OpenAI" scoped to organization "acme"
+    When I open the edit drawer for the organization-scoped "OpenAI" row
+    Then the API key field shows that row's saved credential (masked)
+    And the field is not blank
+    # A row's credential must resolve by its own id. Collapsing same-type
+    # rows down to "one per provider type" for other views (e.g. the
+    # settings list) must never leak into which row an edit drawer
+    # actually opens.
+
+  @regression @integration
+  Scenario: Saving an edited row updates it in place, not as a duplicate
+    Given the org "acme" already has a ModelProvider named "OpenAI" scoped to project "web-app"
+    And the org "acme" also has a ModelProvider named "OpenAI" scoped to organization "acme"
+    When I open the edit drawer for the organization-scoped "OpenAI" row
+    And I re-enter the API key
+    And I click "Save"
+    Then the organization-scoped row is updated with the new key
+    And exactly two "OpenAI" ModelProvider rows still exist for "acme"
+
   # ────────────────────────────────────────────────────────────────────────────
   # Model Providers page becomes org-level
   # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Scariest thing** — this touches the write path for **stored provider credentials**. If the Save gate is wrong in the other direction, an id-targeted edit silently becomes a create and the org grows a phantom duplicate provider row with real API keys in it. That is the bug being fixed; the risk is regressing it. The gate that prevents it is a single boolean, `cannotResolveTarget`.

**Start here** — `langwatch/src/components/settings/ModelProviderForm.tsx`, the `cannotResolveTarget` / `staleMiss` pair. Everything else follows from why those are two booleans and not one.

## Why

Model-provider management was broken across add, edit, and save: editing a provider showed an **empty API key**, and saving that edit created a **duplicate provider** instead of updating in place. The provider list filled with duplicates, and the **Ask AI** query builder in the new traces view stayed blocked.

Closes #5380.

Also fixes #5463 (same root cause, reported independently for multi-instance `custom` providers).

## What changed

- **Resolve the edit target from the flat row list, via one shared resolver** → the previous code looked the row up in the collapsed `Record<providerKey, row>` returned by `useModelProvidersSettings`. That Record keeps one winner per provider *type*, so an id lookup against it misses for every non-winning row. The miss degraded to a blank draft with **no `id`**, which the server reads as an explicit create. Both the drawer and the form now call the same `findModelProviderById` against `useAllModelProvidersList`, so they cannot drift apart again. Blast radius: the hook mirrors the settings page's `canViewOrg ? org-list : project-list` permission fan-out — querying the org list unconditionally would 403 for project-only members and recreate the bug for that role.

- **Never submit an id-targeted edit that didn't resolve** → the alternative was to show an error only once we know the row is gone. That leaves a window: while the list is loading, or disabled, or errored, Save is still live and still ships `id: undefined`. `cannotResolveTarget = isTargetingSpecificRow && !existingRow` disables Save in *every* load state. Consequence if wrong: Save stays disabled when it shouldn't, which is loud and safe — the failure mode we removed was silent and wrote data.

- **Split the flat-list hook's one overloaded boolean into `isReady` + `isLoading`** → a reviewer suggested `isInitialLoading`. That would have regressed `EditModelProviderDrawer`, which uses this flag as its "list is ready" gate: in react-query v4 `isInitialLoading` is `false` for a **disabled** query, so the drawer would skip its spinner and mount the form off an empty list. `isReady` (`isSuccess`) answers "did the list definitively arrive"; `isLoading` (`!isSuccess && !isError`) answers "should I spin". The latter also stops the drawer spinning forever when the query 403s under `retry: false`.

- **Keep `provider` memoized** → resolving it as a bare `existingRow ?? { … }` reallocates `extraHeaders: []` on every render. `useModelProviderForm`'s reset effect lists `provider.extraHeaders` in its deps, so the effect refires each render → `setState` → re-render → **"Maximum update depth exceeded"**, and the Add form is wiped as you type. Caught by driving the real app, not by the type checker.

- **Hoist the empty provider list to a module-level constant** → `providers: data?.providers ?? []` handed every render a fresh array whenever the query had no data. The form's `provider` memo absorbs the churn today (the resolved row stays `undefined`), so it was latent, not live — but it is the same footgun one call away, and it is what makes the pre-fix suite hang on the not-ready path. Alternative was to leave it and rely on every future consumer knowing not to put `providers` in a dependency array. Consequence if wrong: none — a shared frozen empty array cannot be mutated by a consumer without a type error.

Rejected: gating the error copy on `allProviders.length > 0` as a proxy for "list loaded". It misreads an org with **zero** providers as "not loaded", so a stale deep-link there still fell through to the create path — precisely the case in the screenshots below.

## How it works

```
useAllModelProvidersList.ts          flat, uncollapsed row list + row resolver
├── providers            one entry per stored row (never deduped by provider type)
├── isReady   isSuccess  the list definitively arrived (false: disabled | fetching | errored)
├── isLoading            !isSuccess && !isError — "no definitive answer yet" (spinner)
└── findModelProviderById / isResolvableProviderId   the single shared id→row rule

EditModelProviderDrawer.tsx          spins until the flat list is ready, then mounts the form
└── EditModelProviderForm            resolves its own row with the SAME resolver
    ├── cannotResolveTarget          id-targeted + unresolved  → Save disabled (all load states)
    ├── staleMiss                    id-targeted + isReady + unresolved → show the error copy
    └── provider (useMemo)           stable identity; blank template is not reallocated per render

modelProvider.service.ts             unchanged — `if (id && !existing) throw NOT_FOUND`
                                     defense-in-depth, now actually reachable
```

The server guard already existed. It never fired because the client dropped the `id` rather than sending a stale one.

## Human verification (for if you really don't trust me)

1. Boot the app against an org with **zero** model providers.
2. Visit `/settings/model-providers?drawer.open=editModelProvider&drawer.projectId=<pid>&drawer.organizationId=<oid>&drawer.providerKey=openai&drawer.modelProviderId=does_not_exist`
   (the drawer serializes `modelProviderId` into the URL, so this is a real bookmark/deep-link, not a contrived state).
3. Before this PR: a blank form renders and **Save is enabled**. Click it → a new OpenAI row appears. That is the duplicate from the issue.
4. After this PR: "This provider configuration no longer exists…" renders and **Save is disabled**. No row is written.
5. Now add a provider normally, reopen it via **Edit Provider**, and confirm the API key shows masked (`HAS_KEY••••`). Change the name, Save, and confirm the row count stays at 1 and the id is unchanged.
6. Open the new traces view and click **Ask AI** — it opens instead of showing "Connect a model provider".

## How I can prove I was successful

Booted the real app (`pnpm dev`, local Postgres + ClickHouse + Redis) against this branch and drove it with Playwright.

**Which commit the pictures are of.** The screenshots and console samples below were captured on `99ae59d`, and independently re-verified at `4e7e62a`. HEAD has moved three commits since. Those three are behavior-preserving by construction, so the images still depict HEAD's behavior: `isLoading` now forwards `activeQuery.isLoading`, which the pinned react-query 4.44 derives as `status === 'loading'` — provably the same value as the `!isSuccess && !isError` it replaced; `isStaleMiss` derives the identical boolean it previously restated; `NO_PROVIDERS` only stabilizes the identity of an already-empty array; and the last commit is a rename. Nothing in them changes what a user sees. Saying so explicitly because this PR carries no `prove-it-clean` marker, so nothing machine-checks proof staleness against HEAD. A local OpenAI-compatible stub served the credential-validation probe so the real save path — validate → mutate → invalidate → refetch — executed end to end. Assertions are read from the DB and the wire, not only the DOM.

**`add persists` — proven.** Saving a new provider wrote exactly one row and the table refreshed immediately (no stale window).

![add persists](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5383/model-provider-crud-v2/01-add-persists-one-row.png)

**`edit shows the masked existing key` — proven.** Reopened via a cold deep-link (the hard path: no in-memory drawer props). Key renders masked, base URL prefilled, Save correctly disabled because nothing is dirty. Note the screenshot can only show the *easy* case — a sole provider is the collapse winner by definition. The hard case (editing a row that is **not** the winner) is carried by the two falsifying tests above, which fail on pre-fix source.

![masked key](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5383/model-provider-crud-v2/04-edit-shows-masked-key.png)

**`save updates in place, never duplicating` — proven.** Captured the outgoing mutation off the wire:

```json
{"id":"provider_0003elu7Srsfte0CXKJ8JsfCd4r4a","projectId":"project_LSu8hZ…","provider":"custom","name":"QA Renamed In Place", …}
```

The `id` is present, so the server takes the update branch. Postgres after the save — one row, same id, new name, `updatedAt` advanced:

```
                   id                   | provider |        name         | enabled
----------------------------------------+----------+---------------------+---------
 provider_0003elu7Srsfte0CXKJ8JsfCd4r4a | custom   | QA Renamed In Place | t
(1 row)
```

Reopening the drawer afterwards still shows `HAS_KEY••••` — editing a non-credential field does not wipe the stored key.

**`stale/deleted id never creates a phantom row` — proven, before and after.** Same URL, same empty-org state.

Before (parent commit) — no error, **Save enabled**. Clicking it is what produced the duplicates in the issue:

![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5383/model-provider-crud-v2/00-prefix-stale-deeplink-save-enabled.png)

After — error shown, **Save disabled**, and `select count(*) from "ModelProvider"` stays at `0`:

![after empty list](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5383/model-provider-crud-v2/06-stalemiss-empty-list-blocked.png)

Same guard with a non-empty list, and the empty-list case again in dark mode:

![after non-empty](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5383/model-provider-crud-v2/05-stalemiss-nonempty-list-blocked.png)
![dark](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5383/model-provider-crud-v2/07-stalemiss-empty-list-blocked-dark.png)

**`the advanced query builder recognizes the provider` — proven.** With no enabled provider, Ask AI refuses to open and shows the primer. With one, it opens the composer.

![gated](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5383/model-provider-crud-v2/02-askai-gated-no-provider.png)
![opens](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5383/model-provider-crud-v2/03-askai-opens-with-provider.png)

**`the render loop is gone` — proven.** Measured, not inferred. On the intermediate draft, both `modelProviderId=new` and a stale id logged "Maximum update depth exceeded" in the browser console. Re-run against the **pushed HEAD rebased onto current main**, sampling `console.error` for 3s on each path independently:

| path (provider list empty) | `maxUpdateDepthErrors` | other observations |
|---|---|---|
| `modelProviderId=new` (Add) | `0` | typed credential survives re-render; no false "no longer exists" |
| `modelProviderId=<stale>` | `0` | error copy shown, Save disabled, 0 rows written |

The Add-flow row is the one that matters: an unstable blank template re-seeds the form and wipes what the user is typing.

**Falsifiability — proven, unfiltered.** Reverting `ModelProviderForm.tsx` and `EditModelProviderDrawer.tsx` to the pre-PR commit `d1d9a0b` (keeping the new tests, and keeping the hook so the pre-fix `?? []` loop does not hang the run) fails **12 of 19**:

```
 Test Files  2 failed | 1 passed (3)
      Tests  12 failed | 7 passed (19)

 × shows the targeted row's saved API key, masked                       [AC3]
 × mounts the form on the targeted row's credential, not the collapse winner's  [AC3]
 × submits the update for the targeted row's id instead of a blank create       [AC4]
 × shows the provider-no-longer-exists error copy            (×2: non-empty AND empty org)  [AC5]
 × keeps Save disabled and never calls mutateAsync           (×2)       [AC5]
 × keeps Save disabled while the target is unresolved                   [AC5]
 × shows the targeted row's provider title in the header                [AC3]
 × renders a loading spinner  /  × does not mount the form              [drawer gate]

 TestingLibraryElementError: Unable to find an element with the text: /no longer exists/i
```

The 7 that pass on pre-fix are the two hook tests (hook not reverted) plus the negative assertions that are *supposed* to hold before the fix. Restoring the two files: **19 passed (3 files)**.

`NO_PROVIDERS` is pinned separately — swapping it back for a fresh `[]` literal fails on reference identity, not deep equality:

```
 × returns the same providers array reference across renders
 AssertionError: expected [] to be [] // Object.is equality
```

**One honest caveat on AC6.** The "retains the user's typed key" test does **not** fail against `d1d9a0b` — `provider` was already memoized there. The render loop existed only in an intermediate uncommitted draft during this work, never in a pushed commit. AC6's falsifiable guard is the `NO_PROVIDERS` reference-identity test above, plus the live console sample; the retention test is a lock against re-introducing the draft's mistake, not a reproduction of a shipped bug.

`pnpm typecheck` exits 0.

## Anything surprising?

- **The query mocks were a trap.** They returned only `{ data, isLoading, refetch }`. The hook reads `isSuccess`/`isError`, so both were `undefined` under test — any gate written on them would have been *silently untested* while appearing to pass. Mocks now return a realistic v4 query shape. Worth a look during review.
- **Found and filed, not fixed here:** #5575 — the collapse that builds the `Record` picks its winner by scope narrowness alone and **ignores `enabled`**, so a disabled project-scoped row masks an enabled org-scoped one and gates Ask AI. Left out of this PR because that Record also drives credential resolution for evaluators and default models; changing the winner changes which credentials get used, and that deserves its own review. Users who already carry duplicates from this bug may still hit it.
- **Not fixed here, by design:** the drawer and the form still mount the hook independently and each resolve the row. This PR closes the *logic-drift* half (one shared resolver); the *data-ownership* half stays with #5384.
- **Specs updated.** `specs/model-providers/scope-and-multi-instance.feature` gains four `@regression @integration` scenarios: the stale-id miss with the list loaded, the same with an **empty** organization (the case the first attempt missed), the still-loading case that must not claim the provider is gone, and the Add form retaining typed credentials across re-renders.
- **Also filed, not fixed here:** #5578 — these jsdom component tests are swept into the container-backed `vitest.integration.config.ts`, so they boot Redis + ClickHouse they never touch. The two files take 5.9s under a jsdom-only config and had not finished after ~5 minutes under the container one.
- **UX edge noticed during QA:** the per-row kebab menu on the providers table has no `aria-label`, contrary to `dev/docs/best_practices/row-actions-overflow-menu.md`. Not touched here — it made the Playwright drive harder and is worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model provider settings now resolve the edited row from the complete saved provider list for correct multi-scope targeting.
* **Bug Fixes**
  * Fixed edit targeting when multiple providers share the same type across organization/project scopes.
  * Prevented the edit form from mounting or resetting until the full provider list is loaded.
  * Added “no longer exists” feedback for stale targets and disabled Save in those cases; form submissions now refresh the provider list.
* **Tests**
  * Added regression/integration coverage for row-resolution, stale/deleted targets, and loading/multi-instance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


