### PR TITLE
fix(deps): repair corrupted typescript-sdk pnpm-lock.yaml

### DIFF
--- a/typescript-sdk/pnpm-lock.yaml
+++ b/typescript-sdk/pnpm-lock.yaml
@@ -797,18 +797,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
-  '@opentelemetry/sdk-metrics@2.8.0':
-    resolution: {integrity: sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-
-  '@opentelemetry/sdk-metrics@2.8.0':
-    resolution: {integrity: sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-
   '@opentelemetry/sdk-node@0.216.0':
     resolution: {integrity: sha512-c2bPyD62yIhjS2STJVk5uSJMsiPZqJ747QIJQ0lAsxv6CjBlKPDO715dUjB+W5r9AI76wKhdRGVcG5dl06d65A==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -3248,7 +3236,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.205.0
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
@@ -3293,18 +3281,6 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-node@0.216.0(@opentelemetry/api@1.9.1)':
     dependencies:


### PR DESCRIPTION
`typescript-sdk/pnpm-lock.yaml` on main is broken. Two symptoms, one cause.

- CI fails `pnpm install --frozen-lockfile` with `ERR_PNPM_BROKEN_LOCKFILE ... duplicated mapping key (800:3)`.
- Every Dependabot PR against `/typescript-sdk` comments "Dependabot can't parse your pnpm-lock.yaml" and then refuses to update itself (e.g. #5377, #5340). The mcp-server and langwatch Dependabot PRs are fine, which is what pointed at the base lockfile rather than any one bump.

Both symptoms are the same thing: duplicate YAML mapping keys, which pnpm's js-yaml parser and Dependabot's parser both reject outright.

## What happened

The `@opentelemetry/resources` 2.7.0 -> 2.8.0 bump (#5055) got merged badly. The lockfile came out of it with:

- three byte-identical `'@opentelemetry/sdk-metrics@2.8.0'` entries under `packages:`
- three `sdk-metrics@2.8.0` snapshots under `snapshots:`, two of which still pointed at a `resources 2.7.0` snapshot that the bump had already deleted
- one more dangling `resources: 2.7.0` reference inside the `otlp-transformer@0.219.0` snapshot

Nothing since (#5055 was three lockfile-touching commits ago) noticed, because it only bites `--frozen-lockfile` and Dependabot, not a normal local `pnpm install`.

## The fix

- Collapse the duplicate `sdk-metrics@2.8.0` package entries down to the single canonical one.
- Keep the snapshot that references `resources 2.8.0`, drop the two stale `2.7.0` copies.
- Repoint `otlp-transformer`'s `resources` dep at `2.8.0`, the only resources snapshot that still exists.

Net diff is 1 line changed, 25 removed. No version bumps, no re-resolution, just deleting the merge garbage and fixing the one dangling ref.

## Verification

- `pnpm install --frozen-lockfile` in `/typescript-sdk` now exits 0.
- Strict duplicate-key scan: 0 remaining. Dangling `resources 2.7.0` refs: 0.
- Sibling lockfiles (`langwatch`, `mcp-server`, root) scanned clean, so this was isolated to typescript-sdk.

Once this lands, the stuck Dependabot PRs should rebase cleanly against a lockfile they can actually read.
