### PR TITLE
ci: skip secret-backed SDK/langevals test steps on fork PRs

### DIFF
--- a/.github/workflows/langevals-ci.yml
+++ b/.github/workflows/langevals-ci.yml
@@ -86,6 +86,12 @@ jobs:
         run: uv sync --all-extras --all-groups
 
       - name: Run tests
+        # Fork PRs don't receive repository secrets, so a secret-backed run
+        # can only fail on a missing key. Skip it on forks; same-repo PRs
+        # and pushes still run.
+        if: >
+          github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository
         working-directory: langevals
         env:
           OPENAI_API_KEY: ${{ secrets.LANGEVALS_OPENAI_API_KEY }}

--- a/.github/workflows/langevals-ci.yml
+++ b/.github/workflows/langevals-ci.yml
@@ -86,12 +86,14 @@ jobs:
         run: uv sync --all-extras --all-groups
 
       - name: Run tests
-        # Fork PRs don't receive repository secrets, so a secret-backed run
-        # can only fail on a missing key. Skip it on forks; same-repo PRs
-        # and pushes still run.
+        # Fork and Dependabot PRs don't receive repository secrets, so a
+        # secret-backed run can only fail on a missing key. Skip it there;
+        # same-repo PRs, pushes, and label-approved pull_request_target run.
         if: >
-          github.event_name != 'pull_request'
-          || github.event.pull_request.head.repo.full_name == github.repository
+          (github.event_name != 'pull_request'
+           || github.event.pull_request.head.repo.full_name == github.repository)
+          && (github.actor != 'dependabot[bot]'
+           || github.event_name == 'pull_request_target')
         working-directory: langevals
         env:
           OPENAI_API_KEY: ${{ secrets.LANGEVALS_OPENAI_API_KEY }}

--- a/.github/workflows/mcp-javascript-ci.yml
+++ b/.github/workflows/mcp-javascript-ci.yml
@@ -79,9 +79,9 @@ jobs:
         run: pnpm run build
 
       - name: Run tests
-        # Fork PRs don't receive repository secrets, so a secret-backed run
-        # can only fail on a missing key. Skip it on forks; same-repo PRs,
-        # pushes, and label-approved pull_request_target still run.
+        # Fork and Dependabot PRs don't receive repository secrets, so a
+        # secret-backed run can only fail on a missing key. Skip it there;
+        # same-repo PRs, pushes, and label-approved pull_request_target run.
         if: >
           (github.event_name != 'pull_request'
            || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/mcp-javascript-ci.yml
+++ b/.github/workflows/mcp-javascript-ci.yml
@@ -79,7 +79,14 @@ jobs:
         run: pnpm run build
 
       - name: Run tests
-        if: github.actor != 'dependabot[bot]' || github.event_name == 'pull_request_target'
+        # Fork PRs don't receive repository secrets, so a secret-backed run
+        # can only fail on a missing key. Skip it on forks; same-repo PRs,
+        # pushes, and label-approved pull_request_target still run.
+        if: >
+          (github.event_name != 'pull_request'
+           || github.event.pull_request.head.repo.full_name == github.repository)
+          && (github.actor != 'dependabot[bot]'
+           || github.event_name == 'pull_request_target')
         working-directory: mcp-server
         env:
           LANGWATCH_API_KEY: ${{ secrets.MCP_SERVER_LANGWATCH_API_KEY }}

--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -72,9 +72,9 @@ jobs:
         run: go mod download
 
       - name: Run e2e examples
-        # Fork PRs don't receive repository secrets, so a secret-backed run
-        # can only fail on a missing key. Skip it on forks; same-repo PRs,
-        # pushes, and label-approved pull_request_target still run.
+        # Fork and Dependabot PRs don't receive repository secrets, so a
+        # secret-backed run can only fail on a missing key. Skip it there;
+        # same-repo PRs, pushes, and label-approved pull_request_target run.
         if: >
           (github.event_name != 'pull_request'
            || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -72,7 +72,14 @@ jobs:
         run: go mod download
 
       - name: Run e2e examples
-        if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
+        # Fork PRs don't receive repository secrets, so a secret-backed run
+        # can only fail on a missing key. Skip it on forks; same-repo PRs,
+        # pushes, and label-approved pull_request_target still run.
+        if: >
+          (github.event_name != 'pull_request'
+           || github.event.pull_request.head.repo.full_name == github.repository)
+          && (github.event_name != 'pull_request'
+           || github.actor != 'dependabot[bot]')
         working-directory: ./sdk-go/e2e
         run: go run cmd/main.go --ci run-examples
         env:

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -69,7 +69,14 @@ jobs:
         run: pnpm run build
 
       - name: Run tests
-        if: github.actor != 'dependabot[bot]' || github.event_name == 'pull_request_target'
+        # Fork PRs don't receive repository secrets, so a secret-backed run
+        # can only fail on a missing key. Skip it on forks; same-repo PRs,
+        # pushes, and label-approved pull_request_target still run.
+        if: >
+          (github.event_name != 'pull_request'
+           || github.event.pull_request.head.repo.full_name == github.repository)
+          && (github.actor != 'dependabot[bot]'
+           || github.event_name == 'pull_request_target')
         env:
           LANGWATCH_ENDPOINT: ${{ secrets.TYPESCRIPT_SDK_LANGWATCH_ENDPOINT }}
           OPENAI_API_KEY: ${{ secrets.TYPESCRIPT_SDK_OPENAI_API_KEY }}
@@ -229,7 +236,14 @@ jobs:
         run: pnpm run build
 
       - name: Run e2e tests
-        if: github.actor != 'dependabot[bot]' || github.event_name == 'pull_request_target'
+        # Fork PRs don't receive repository secrets, so a secret-backed run
+        # can only fail on a missing key. Skip it on forks; same-repo PRs,
+        # pushes, and label-approved pull_request_target still run.
+        if: >
+          (github.event_name != 'pull_request'
+           || github.event.pull_request.head.repo.full_name == github.repository)
+          && (github.actor != 'dependabot[bot]'
+           || github.event_name == 'pull_request_target')
         env:
           OPENAI_API_KEY: ${{ secrets.TYPESCRIPT_SDK_OPENAI_API_KEY }}
           E2E_TIMEOUT: 120000

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -69,9 +69,9 @@ jobs:
         run: pnpm run build
 
       - name: Run tests
-        # Fork PRs don't receive repository secrets, so a secret-backed run
-        # can only fail on a missing key. Skip it on forks; same-repo PRs,
-        # pushes, and label-approved pull_request_target still run.
+        # Fork and Dependabot PRs don't receive repository secrets, so a
+        # secret-backed run can only fail on a missing key. Skip it there;
+        # same-repo PRs, pushes, and label-approved pull_request_target run.
         if: >
           (github.event_name != 'pull_request'
            || github.event.pull_request.head.repo.full_name == github.repository)
@@ -236,9 +236,9 @@ jobs:
         run: pnpm run build
 
       - name: Run e2e tests
-        # Fork PRs don't receive repository secrets, so a secret-backed run
-        # can only fail on a missing key. Skip it on forks; same-repo PRs,
-        # pushes, and label-approved pull_request_target still run.
+        # Fork and Dependabot PRs don't receive repository secrets, so a
+        # secret-backed run can only fail on a missing key. Skip it there;
+        # same-repo PRs, pushes, and label-approved pull_request_target run.
         if: >
           (github.event_name != 'pull_request'
            || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -69,9 +69,9 @@ jobs:
         run: make test-unit
 
       - name: Run e2e tests
-        # Fork PRs don't receive repository secrets, so a secret-backed run
-        # can only fail on a missing key. Skip it on forks; same-repo PRs,
-        # pushes, and label-approved pull_request_target still run.
+        # Fork and Dependabot PRs don't receive repository secrets, so a
+        # secret-backed run can only fail on a missing key. Skip it there;
+        # same-repo PRs, pushes, and label-approved pull_request_target run.
         if: >
           (github.event_name != 'pull_request'
            || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -69,7 +69,14 @@ jobs:
         run: make test-unit
 
       - name: Run e2e tests
-        if: github.actor != 'dependabot[bot]' || github.event_name == 'pull_request_target'
+        # Fork PRs don't receive repository secrets, so a secret-backed run
+        # can only fail on a missing key. Skip it on forks; same-repo PRs,
+        # pushes, and label-approved pull_request_target still run.
+        if: >
+          (github.event_name != 'pull_request'
+           || github.event.pull_request.head.repo.full_name == github.repository)
+          && (github.actor != 'dependabot[bot]'
+           || github.event_name == 'pull_request_target')
         working-directory: python-sdk
         env:
           LANGWATCH_DEBUG: "true"


### PR DESCRIPTION
## Summary
Fork-authored PRs get a spurious hard-red on the SDK and langevals CI. Those workflows run secret-backed test / e2e steps (real provider keys, a LangWatch API key), but GitHub withholds repository secrets from `pull_request` runs that originate from a fork. The step therefore runs with empty secrets and dies at the first key check, e.g.:

```
ValueError: API key not set. Set LANGWATCH_API_KEY environment variable or pass api_key parameter.
FAILED tests/e2e/test_platform_experiment_e2e.py::TestErrorHandling::test_raises_experiment_not_found_for_non_existent_slug
```

This is not a code problem and it is not fixable by the contributor: it is a structural consequence of fork isolation. It surfaced on recent fork-authored gateway PRs (e.g. #5358), where `sdk-python-ci` showed red even though the change was Go-only and unrelated to the SDK.

## Change
Gate every secret-backed test / e2e step so it is skipped on fork PRs, at the step level (not the job), so the non-secret steps still run and the job stays green instead of false-failing:

- `sdk-python-ci.yml` (Run e2e tests)
- `sdk-javascript-ci.yml` (Run tests, Run e2e tests)
- `sdk-go-ci.yml` (Run e2e examples)
- `mcp-javascript-ci.yml` (Run tests)
- `langevals-ci.yml` (Run tests)

The guard is:

```
(github.event_name != 'pull_request'
 || github.event.pull_request.head.repo.full_name == github.repository)
&& <existing dependabot condition>
```

Behavior by trigger:

| Trigger | Secret step |
| --- | --- |
| push to main / merge_group / workflow_dispatch | runs (secrets present) |
| same-repo `pull_request` (internal contributor) | runs (unchanged) |
| fork `pull_request` (external contributor) | skipped, job stays green |
| `pull_request_target` labeled `approved-ci` | runs (base-context secrets) |
| dependabot `pull_request` | skipped (unchanged) |

Unit / typecheck / build steps are untouched and still run on forks, so external contributors keep the coverage that does not need secrets. The `pull_request_target` + `approved-ci` path (a maintainer opting a fork PR into the full secret suite) also still works.

## Test plan
- [x] All five workflows parse as valid YAML and the folded `if:` expressions render to valid GitHub Actions expressions
- [x] `actionlint` clean on the changed lines (one pre-existing SC2209 style warning on an untouched build step is left as-is)
- [x] Truth table above verified against each workflow's existing condition; fork detection uses the standard `head.repo.full_name == github.repository` idiom


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI safeguards so secret-backed test and e2e steps are skipped for forked pull requests, reducing the risk of failures or unintended secret usage.
  * Kept steps running for non–pull request events and for same-repository pull requests.
  * Preserved existing automation behavior, including special handling for dependency update pull requests and approved `pull_request_target` runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->