### PR TITLE
fix(deps): repair corrupted langwatch pnpm-lock.yaml

### DIFF
--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -15757,12 +15757,6 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-
   '@opentelemetry/sdk-logs@0.205.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
Round two of the same bug. #5387 fixed `typescript-sdk/pnpm-lock.yaml`; this one is `langwatch/pnpm-lock.yaml`, identical failure mode.

- CI fails `pnpm install --frozen-lockfile` with `ERR_PNPM_BROKEN_LOCKFILE ... duplicated mapping key (15707:3)`.
- Dependabot can't parse the lockfile, so every `/langwatch` update PR is stuck.

## What happened

A recent OpenTelemetry Dependabot bump (#4600) merged badly and left the `snapshots:` section with two byte-identical `@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)` entries. Duplicate YAML keys are illegal, so pnpm's parser and Dependabot's parser both bail before doing anything.

Simpler than #5387 though: both copies were identical (same `core 2.8.0`, same `semantic-conventions 1.40.0`), so there is no dangling reference to chase this time. Just delete the second copy.

## The fix

Drop the duplicate `resources@2.8.0` snapshot. 6 lines removed, nothing else touched, no version changes.

## Verification

- `pnpm install --frozen-lockfile` in `/langwatch` (all 2 workspace projects) now exits 0.
- Strict duplicate-key scan: 0 remaining.
- Re-scanned typescript-sdk, mcp-server and the root lockfile, all clean. (typescript-sdk got the same treatment in #5387, now merged.)

## The pattern

Second time in a day a Dependabot OpenTelemetry bump has landed a broken lockfile on main. Might be worth a small CI guard that runs `--frozen-lockfile` (or a duplicate-key check) against the lockfiles on PRs, so these get caught before merge instead of after. Happy to add that as a follow-up if you want it - didn't want to touch CI here without asking.
