### PR TITLE
fix(ci): drop JSON reporter from unit shards + lower hang hard-floor (#4476)

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           pnpm test:unit --run --shard=${{ matrix.shard }}/4 \
             --coverage --coverage.reporter=lcov --coverage.reporter=text \
-            --reporter=default --reporter=json --outputFile=test-results.json \
+            --reporter=default \
             --dangerouslyIgnoreUnhandledErrors
 
       - name: Extract test failures

--- a/langwatch/src/test-unit-global-setup.ts
+++ b/langwatch/src/test-unit-global-setup.ts
@@ -29,10 +29,10 @@ export async function setup(): Promise<void> {
   // langwatch-app-complete required check unblocks. Unref'd so a healthy
   // shard exits immediately on its own; the timer only fires on the wedge.
   // Mirrors the integration globalSetup hard-floor; unit shards otherwise lack
-  // one. A healthy unit shard finishes in ~3 min, so a 6-min floor only fires
-  // on a wedge and caps the wasted wall-clock at ~3 min of idle.
+  // one. A healthy unit shard finishes in ~3 min, so a 4-min floor only fires
+  // on a wedge and caps the wasted wall-clock at ~1 min of idle.
   if (process.env.CI) {
-    const HARD_FLOOR_MS = 6 * 60 * 1000;
+    const HARD_FLOOR_MS = 4 * 60 * 1000;
     const timer = setTimeout(() => {
       // eslint-disable-next-line no-console
       console.log(


### PR DESCRIPTION
## Why

\`test-unit (2)\` consistently ran ~6m45s vs ~2m54s for shards 1/3/4. The extra ~4min is a vitest finalize wedge: after the last \`afterAll\`, an open-handle dump shows only the vmThreads worker's own IPC \`MessagePort\` (application code is clean — posthog/tiktoken/redis leaks cleared, tiktoken removed by #5003). The vitest main process then idles in its finalize path.

The \`--reporter=json\` flag (with \`--outputFile=test-results.json\`) was the prime suspect: it forces vitest to accumulate all test results in-memory and flush a JSON file during the finalize path. Removing it eliminates that code path. The \`--coverage\` flags (lcov + text) are retained as they feed Codecov.

The existing \`HARD_FLOOR_MS = 6 * 60 * 1000\` was masking the wedge rather than preventing it — every shard-2 run hit the floor, burning ~3–4 min of CI wall-clock per push.

## What changed

1. **\`.github/workflows/langwatch-app-ci.yml\`** — removed \`--reporter=json --outputFile=test-results.json\` from the unit-test run command. The downstream \`Extract test failures\` step already guards against a missing file (\`if [ ! -f "$INPUT_JSON" ]; then … exit 0; fi\` in \`extract-failures.sh\`), so no change needed there.

2. **\`langwatch/src/test-unit-global-setup.ts\`** — lowered \`HARD_FLOOR_MS\` from \`6 * 60 * 1000\` to \`4 * 60 * 1000\`. Healthy shards all finish <3 min; 4 min is safe and caps waste at ~1 min if the wedge persists via a different path.

## Human verification

- [ ] Confirm shard \`test-unit (2)\` duration is reduced vs pre-fix (~6m45s)
- [ ] Check whether the hard-floor line appears in shard-2 log

## How I can prove I was successful

CI run #28811013820 (this PR's second run — first failed due to a pre-existing broken lockfile fixed by #5393).

**Results (honest):**

| Shard | Duration | Floor fired? |
|-------|----------|--------------|
| test-unit (1) | ~3m15s | no |
| test-unit (2) | **~4m55s** | **yes** — at 4 min |
| test-unit (3) | ~2m56s | no |
| test-unit (4) | ~3m15s | no |

Log evidence from shard 2:
\`\`\`
[unit globalSetup] hard floor reached at 4 min — forcing process.exit(0) to release the CI step from a vitest finalize wedge
\`\`\`

**Verdict:** The JSON reporter removal did NOT cure the wedge. Shard 2 still hits the floor (now at 4 min instead of 6 min). Net improvement: **~1m50s saved per PR push** (4m55s vs 6m45s). The Tier 2a hypothesis (JSON reporter = wedge cause) is falsified. The wedge lives in vitest's own finalize path upstream of the reporter. This PR is still net-positive via the floor reduction, but the primary fix hypothesis did not hold.

## Scope

Addresses #4476 (Tier 1+2a of the tiered plan; leaves vitest 4.x bump check and upstream vitest report as follow-ups). Tier 2a (JSON reporter removal) is falsified as a root-cause fix — escalates the need for the vitest upstream investigation.

<!-- no-ui-surface -->