### PR TITLE
fix(deps): remove duplicate pnpm-lock.yaml entry for @opentelemetry/resources@2.8.0

### DIFF
--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -15757,12 +15757,6 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-
   '@opentelemetry/sdk-logs@0.205.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
<!-- no-ui-surface -->

## What

`pnpm-lock.yaml` contains two back-to-back identical entries for `@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)` starting at line 15760. YAML does not permit duplicate mapping keys; `pnpm` rejects the file with:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "…/pnpm-lock.yaml" is broken: duplicated mapping key (15760:3)
```

This causes all CI jobs that run `pnpm install` to fail immediately at the setup step.

## Why

The duplicate was introduced by **5111adf64** (`chore(deps): bump @opentelemetry/exporter-trace-otlp-proto from 0.217.0 to 0.219.0`, PR #4600). That bump added a `@opentelemetry/resources@2.8.0` resolution that is identical to the one already added by the preceding `@opentelemetry/sdk-logs` bump (**a88ff8a67**, PR #4577). The result: the same key block appears twice.

**Diff:** 6 lines deleted — the second copy of the duplicate block, no other changes.

## Human verification

Pre-fix (on `origin/main`):
```
$ grep -c "@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':" langwatch/pnpm-lock.yaml
2
```

Post-fix (this branch):
```
$ grep -c "@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':" langwatch/pnpm-lock.yaml
1
```

YAML validity:
```
$ python3 -c "import yaml; yaml.safe_load(open('langwatch/pnpm-lock.yaml'))" && echo "valid"
valid
```

## How I can prove I was successful

- `grep -c "@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':" langwatch/pnpm-lock.yaml` returns `1`
- `pnpm install` completes without `ERR_PNPM_BROKEN_LOCKFILE`
- All CI jobs that previously failed at `setup-pnpm-node` pass