### PR TITLE
fix(dev): skip tracked files in post-checkout env-copy hook

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -30,6 +30,12 @@ for dir in "${env_dirs[@]}"; do
 
   for f in "${src}"/.env*; do
     [ -f "$f" ] || continue
+    filename=$(basename "$f")
+    # Skip tracked files (e.g. .env.example) — copying them would dirty the
+    # worktree and leak local edits into PR diffs (orchardist#703).
+    if git -C "$worktree_root" ls-files --error-unmatch "${dir}/${filename}" >/dev/null 2>&1; then
+      continue
+    fi
     cp "$f" "${dest}/"
     copied=$((copied + 1))
   done


### PR DESCRIPTION
## Summary

- The `.env*` glob in `.githooks/post-checkout` unconditionally copied **all** matching files from the main checkout into new worktrees, including `.env.example` — a tracked file. This dirtied the worktree index on every `git worktree add` and caused `.env.example` modifications to escape into PR diffs (#3008, #2156).
- Fix: add a `git ls-files --error-unmatch` guard before each copy. If the file is tracked in the destination worktree, skip it. Untracked env files (`.env`, `.env.local`, etc.) still copy as intended.

## Verification

Fresh worktree after the fix (`git -C /tmp/wt703test status --porcelain`) was **empty** — no `.env.example` modification. Worktree removed and tmp branch deleted.

Fixes orchardist#703

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SufnT5rv6hGhd2jJ1Z5yeA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented `.env` files that are already tracked in a new worktree from being overwritten during checkout.
  * Continued copying untracked `.env` files as before.
  * Updated the copy count message to reflect only files that were actually copied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->