### PR TITLE
fix(aigateway): use require.ErrorAs in dispatch_test (testifylint) (#5399)

### DIFF
--- a/services/aigateway/app/dispatch_test.go
+++ b/services/aigateway/app/dispatch_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -445,7 +444,7 @@ func TestHandleChat_TerminatesOnUpstream400(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, 1, callCount)
 	var ue *domain.UpstreamError
-	require.True(t, errors.As(err, &ue))
+	require.ErrorAs(t, err, &ue)
 	assert.Equal(t, 400, ue.StatusCode)
 }
 


### PR DESCRIPTION
## Why

`require.True(t, errors.As(err, &ue))` at `services/aigateway/app/dispatch_test.go:448` violates the testifylint `error-is-as` rule. This caused PR #5009 lint to fail at HEAD `47b937eea` even after rebasing — the only-new-issues baseline does not absolve pre-existing violations when the merge result introduces them into the diff context.

The fix replaces it with `require.ErrorAs(t, err, &ue)`, which is the idiomatic testify assertion and satisfies the linter.

## Human verification

```
cd services/aigateway && go test ./app/ -run TestDispatch -count=1
```

Should pass with no failures.

## How I can prove I was successful

Test output from `go test ./app/ -run TestDispatch -count=1` showing PASS.

Closes #5399

<!-- no-ui-surface -->

## Deployment Impact

None. Test-only change inside `services/aigateway` (a unit-test assertion swapped to `require.ErrorAs`); no runtime code, chart, env, or self-hosting surface is modified. The path merely lives under the `services/` tree, which is why this section is required.
