### PR TITLE
perf(clickhouse): bound scenario batch-history preview to the page's StartedAt window

### DIFF
--- a/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
@@ -939,4 +939,99 @@ describe("SimulationClickHouseRepository (integration)", () => {
       });
     });
   });
+
+  describe("getBatchHistoryForScenarioSet()", () => {
+    describe("when a page spans batches from different weeks", () => {
+      it("returns every batch's items and bounds the heavy read to the page's StartedAt window", async () => {
+        const setId = `set-history-${nanoid()}`;
+        const eightWeeksMs = 8 * 7 * 24 * 60 * 60 * 1000;
+        const oldStartedAtMs = now - eightWeeksMs;
+        const oldDate = new Date(oldStartedAtMs);
+
+        // Older batch (a different weekly partition than the recent one).
+        const oldBatchRunId = `batch-old-${nanoid()}`;
+        await insertRow(
+          ch,
+          makeInsertRow({
+            ScenarioSetId: setId,
+            BatchRunId: oldBatchRunId,
+            StartedAt: oldDate,
+            CreatedAt: oldDate,
+            UpdatedAt: new Date(oldStartedAtMs + 1000),
+            FinishedAt: new Date(oldStartedAtMs + 1000),
+            "Messages.Id": ["msg-1", "msg-2"],
+            "Messages.Role": ["user", "assistant"],
+            "Messages.Content": ["old question", "old answer"],
+            "Messages.TraceId": ["trace-1", "trace-2"],
+            "Messages.Rest": ["{}", "{}"],
+          }),
+        );
+
+        // Recent batch (current weekly partition).
+        const recentBatchRunId = `batch-recent-${nanoid()}`;
+        await insertRow(
+          ch,
+          makeInsertRow({
+            ScenarioSetId: setId,
+            BatchRunId: recentBatchRunId,
+            "Messages.Id": ["msg-1", "msg-2"],
+            "Messages.Role": ["user", "assistant"],
+            "Messages.Content": ["new question", "new answer"],
+            "Messages.TraceId": ["trace-1", "trace-2"],
+            "Messages.Rest": ["{}", "{}"],
+          }),
+        );
+
+        // Capture the SQL the repository actually issues so we can assert the
+        // preview read is bounded (partition-pruned) rather than unconstrained.
+        const captured: { query: string; query_params?: Record<string, unknown> }[] =
+          [];
+        const recordingClient = new Proxy(ch, {
+          get(target, prop, receiver) {
+            if (prop === "query") {
+              return (args: { query: string; query_params?: Record<string, unknown> }) => {
+                captured.push({ query: args.query, query_params: args.query_params });
+                return (target.query as typeof target.query).call(target, args);
+              };
+            }
+            return Reflect.get(target, prop, receiver);
+          },
+        });
+        const recordingResilient = createResilientClickHouseClient({
+          client: recordingClient,
+        });
+        const recordingRepo = new SimulationClickHouseRepository(
+          async () => recordingResilient,
+        );
+
+        const result = await recordingRepo.getBatchHistoryForScenarioSet({
+          projectId: tenantId,
+          scenarioSetId: setId,
+          limit: 10,
+        });
+
+        // Both batches (across both weeks) come back with their preview items.
+        const byId = new Map(result.batches.map((b) => [b.batchRunId, b]));
+        expect(byId.has(oldBatchRunId)).toBe(true);
+        expect(byId.has(recentBatchRunId)).toBe(true);
+        expect(byId.get(oldBatchRunId)!.items).toHaveLength(1);
+        expect(byId.get(recentBatchRunId)!.items).toHaveLength(1);
+        expect(
+          byId.get(oldBatchRunId)!.items[0]!.messagePreview.map((m) => m.content),
+        ).toEqual(["old question", "old answer"]);
+
+        // The heavy preview read carries an exact StartedAt envelope that spans
+        // both weeks (min = the old batch), so the older batch is not dropped.
+        const previewQuery = captured.find((c) =>
+          c.query.includes("MessagePreviewRoles"),
+        );
+        expect(previewQuery).toBeDefined();
+        expect(previewQuery!.query).toContain("StartedAt >=");
+        expect(previewQuery!.query).toContain("StartedAt <=");
+        expect(previewQuery!.query_params?.minStartedAtMs).toBe(
+          String(oldStartedAtMs),
+        );
+      });
+    });
+  });
 });

--- a/langwatch/src/server/app-layer/simulations/repositories/__tests__/simulation.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/__tests__/simulation.clickhouse.repository.unit.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import type { ClickHouseClient } from "@clickhouse/client";
-import { SimulationClickHouseRepository } from "../simulation.clickhouse.repository";
+import {
+  SimulationClickHouseRepository,
+  buildStartedAtWindowForPage,
+} from "../simulation.clickhouse.repository";
 import { DEFAULT_SET_ID } from "~/server/scenarios/internal-set-id";
 
 function makeMockClient(rows: unknown[] = []): ClickHouseClient {
@@ -175,6 +178,51 @@ describe("SimulationClickHouseRepository", () => {
           /any\(IF\(ScenarioSetId[^)]*\)\)\s+AS\s+NormalizedSetId\b/
         );
       });
+    });
+  });
+
+  describe("buildStartedAtWindowForPage()", () => {
+    it("spans the min and max StartedAt across the page rows", () => {
+      const { whereClause, params } = buildStartedAtWindowForPage([
+        { MinStartedAt: "3000", MaxStartedAt: "5000" },
+        { MinStartedAt: "1000", MaxStartedAt: "9000" },
+      ]);
+      expect(whereClause).toContain("StartedAt >=");
+      expect(whereClause).toContain("StartedAt <=");
+      expect(params.minStartedAtMs).toBe("1000");
+      expect(params.maxStartedAtMs).toBe("9000");
+    });
+
+    it("handles a single row", () => {
+      const { params } = buildStartedAtWindowForPage([
+        { MinStartedAt: "1500", MaxStartedAt: "1500" },
+      ]);
+      expect(params.minStartedAtMs).toBe("1500");
+      expect(params.maxStartedAtMs).toBe("1500");
+    });
+
+    it("returns an empty clause for an empty page (fall back to unbounded)", () => {
+      const result = buildStartedAtWindowForPage([]);
+      expect(result.whereClause).toBe("");
+      expect(result.params).toEqual({});
+    });
+
+    it("ignores non-finite and non-positive bounds", () => {
+      const result = buildStartedAtWindowForPage([
+        { MinStartedAt: "not-a-number", MaxStartedAt: "0" },
+        { MinStartedAt: "", MaxStartedAt: "NaN" },
+      ]);
+      expect(result.whereClause).toBe("");
+      expect(result.params).toEqual({});
+    });
+
+    it("still bounds when some rows have invalid values but others are valid", () => {
+      const { params } = buildStartedAtWindowForPage([
+        { MinStartedAt: "0", MaxStartedAt: "invalid" },
+        { MinStartedAt: "2000", MaxStartedAt: "4000" },
+      ]);
+      expect(params.minStartedAtMs).toBe("2000");
+      expect(params.maxStartedAtMs).toBe("4000");
     });
   });
 });

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -98,6 +98,44 @@ function buildDateFilter({
   };
 }
 
+/**
+ * Builds a StartedAt partition-pruning window from a page of batch aggregates.
+ *
+ * getBatchHistoryForScenarioSet fetches the batch page (step 1) and then reads
+ * the heavy Messages preview columns for those batches (step 2). simulation_runs
+ * is partitioned by toYearWeek(StartedAt), so without a StartedAt predicate the
+ * step-2 read opens every weekly partition (including cold storage) to serve a
+ * single page. Step 1 already aggregated min/max StartedAt for exactly these
+ * batches over the same rows step 2 reads, so bounding step 2 to that envelope
+ * prunes to the page's few weeks. The bound is exact: step 2's rows are a subset
+ * of the batches step 1 aggregated, and StartedAt is immutable across a run's
+ * ReplacingMergeTree versions.
+ *
+ * Returns an empty clause when no valid bound exists (e.g. empty page), so the
+ * read falls back to its prior unbounded behavior rather than dropping rows.
+ */
+function buildStartedAtWindowForPage(
+  rows: { MinStartedAt: string; MaxStartedAt: string }[],
+): { whereClause: string; params: Record<string, string> } {
+  let minMs = Number.POSITIVE_INFINITY;
+  let maxMs = 0;
+  for (const row of rows) {
+    const lo = Number(row.MinStartedAt);
+    const hi = Number(row.MaxStartedAt);
+    if (Number.isFinite(lo) && lo > 0) minMs = Math.min(minMs, lo);
+    if (Number.isFinite(hi) && hi > 0) maxMs = Math.max(maxMs, hi);
+  }
+  if (!Number.isFinite(minMs) || maxMs <= 0 || minMs > maxMs) {
+    return { whereClause: "", params: {} };
+  }
+  return {
+    whereClause:
+      "AND StartedAt >= fromUnixTimestamp64Milli(toUInt64({minStartedAtMs:String})) " +
+      "AND StartedAt <= fromUnixTimestamp64Milli(toUInt64({maxStartedAtMs:String}))",
+    params: { minStartedAtMs: String(minMs), maxStartedAtMs: String(maxMs) },
+  };
+}
+
 const RUN_COLUMNS = `
   ScenarioRunId, ScenarioId, BatchRunId, ScenarioSetId,
   Status, Name, Description, Metadata,
@@ -314,6 +352,8 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       LastRunAt: string;
       FirstCompletedAt: string;
       AllCompletedAt: string;
+      MinStartedAt: string;
+      MaxStartedAt: string;
     }>(
       `SELECT
         BatchRunId,
@@ -328,7 +368,9 @@ export class SimulationClickHouseRepository implements SimulationRepository {
         )) AS FirstCompletedAt,
         toString(toUnixTimestamp64Milli(
           maxIf(UpdatedAt, Status NOT IN ('STALLED','IN_PROGRESS','PENDING'))
-        )) AS AllCompletedAt
+        )) AS AllCompletedAt,
+        toString(toUnixTimestamp64Milli(min(StartedAt)))                AS MinStartedAt,
+        toString(toUnixTimestamp64Milli(max(StartedAt)))                AS MaxStartedAt
        FROM ${TABLE_NAME}
        WHERE TenantId = {tenantId:String}
          AND ScenarioSetId IN ({scenarioSetIds:Array(String)})
@@ -374,6 +416,11 @@ export class SimulationClickHouseRepository implements SimulationRepository {
 
     const batchRunIds = pageRows.map((r) => r.BatchRunId);
 
+    // Bound the heavy step-2 read to the StartedAt window of the batches on this
+    // page (aggregated in step 1) so it prunes partitions instead of scanning
+    // every weekly partition including cold storage.
+    const startedAtWindow = buildStartedAtWindowForPage(pageRows);
+
     // Step 2: fetch slim item rows (preview columns only)
     const itemRows = await this.queryRows<{
       ScenarioRunId: string;
@@ -393,12 +440,14 @@ export class SimulationClickHouseRepository implements SimulationRepository {
          AND ScenarioSetId IN ({scenarioSetIds:Array(String)})
          AND BatchRunId IN ({batchRunIds:Array(String)})
          AND ArchivedAt IS NULL
-         ${simulationRunDedupPredicate("TenantId = {tenantId:String} AND ScenarioSetId IN ({scenarioSetIds:Array(String)}) AND BatchRunId IN ({batchRunIds:Array(String)})")}
+         ${startedAtWindow.whereClause}
+         ${simulationRunDedupPredicate(`TenantId = {tenantId:String} AND ScenarioSetId IN ({scenarioSetIds:Array(String)}) AND BatchRunId IN ({batchRunIds:Array(String)}) ${startedAtWindow.whereClause}`)}
        ORDER BY CreatedAt ASC`,
       {
         tenantId: projectId,
         scenarioSetIds: expandSetIdFilter(scenarioSetId),
         batchRunIds,
+        ...startedAtWindow.params,
       },
     );
 

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -106,15 +106,21 @@ function buildDateFilter({
  * is partitioned by toYearWeek(StartedAt), so without a StartedAt predicate the
  * step-2 read opens every weekly partition (including cold storage) to serve a
  * single page. Step 1 already aggregated min/max StartedAt for exactly these
- * batches over the same rows step 2 reads, so bounding step 2 to that envelope
- * prunes to the page's few weeks. The bound is exact: step 2's rows are a subset
- * of the batches step 1 aggregated, and StartedAt is immutable across a run's
- * ReplacingMergeTree versions.
+ * batches over the same (deduped, latest-version) rows step 2 returns, so every
+ * page run's latest StartedAt lies inside [min, max]. Bounding step 2 to that
+ * window prunes the heavy read to the page's few weeks without dropping rows.
+ *
+ * The predicate must be applied on the OUTER query only, not inside the
+ * max(UpdatedAt) dedup subquery: StartedAt is not strictly immutable across a
+ * run's ReplacingMergeTree versions (a snapshot arriving before the run-started
+ * event seeds a provisional StartedAt that the started event later overwrites),
+ * so filtering versions by StartedAt before picking the latest could resolve the
+ * wrong version. Filtering the already-deduped outer rows is always correct.
  *
  * Returns an empty clause when no valid bound exists (e.g. empty page), so the
  * read falls back to its prior unbounded behavior rather than dropping rows.
  */
-function buildStartedAtWindowForPage(
+export function buildStartedAtWindowForPage(
   rows: { MinStartedAt: string; MaxStartedAt: string }[],
 ): { whereClause: string; params: Record<string, string> } {
   let minMs = Number.POSITIVE_INFINITY;
@@ -441,7 +447,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
          AND BatchRunId IN ({batchRunIds:Array(String)})
          AND ArchivedAt IS NULL
          ${startedAtWindow.whereClause}
-         ${simulationRunDedupPredicate(`TenantId = {tenantId:String} AND ScenarioSetId IN ({scenarioSetIds:Array(String)}) AND BatchRunId IN ({batchRunIds:Array(String)}) ${startedAtWindow.whereClause}`)}
+         ${simulationRunDedupPredicate("TenantId = {tenantId:String} AND ScenarioSetId IN ({scenarioSetIds:Array(String)}) AND BatchRunId IN ({batchRunIds:Array(String)})")}
        ORDER BY CreatedAt ASC`,
       {
         tenantId: projectId,


### PR DESCRIPTION
## Evidence

From the last 24h of prod app-emitted slow-query warnings (Signal A), the scenario batch-history preview read stood out as a heavy over-read:

- ~63 calls/24h, p50 ~682ms, max ~7.7s
- avg read ~191 MB, max ~268 MB per call, against a per-call budget of 5 MB (~25-38x over)
- read bytes dominated by the `Messages.Content` / `Messages.Role` arrays it slices for grid previews

The query is `SimulationClickHouseRepository.getBatchHistoryForScenarioSet` step 2 (the slim item-preview read). It filters on `TenantId` + `ScenarioSetId` + `BatchRunId` but carries no predicate on the partition column.

## Suspected cause

`simulation_runs` is `PARTITION BY toYearWeek(StartedAt)`. Step 2 has no `StartedAt` predicate, so ClickHouse cannot prune partitions and opens every weekly partition (including cold, S3-tiered ones) to read the heavy `Messages.*` arrays for a single page of batches. The read is small in rows but large in bytes and part-open cost because it walks all partitions.

`getBatchHistoryForScenarioSet` already runs step 1 (the batch-level aggregate) over the same rows, so the page's time window is already knowable there.

## Proposed fix

- Add `min(StartedAt)` / `max(StartedAt)` to the step-1 aggregate (light key columns, and `StartedAt` is the sort/partition column with an existing minmax skip-index, so this is free relative to the scan step 1 already does).
- Bound the step-2 preview read to `StartedAt >= min AND StartedAt <= max` across the page's batches, on the **outer (already-deduped) read only**.

The bound cannot drop rows: step 1's min/max are computed over the same deduped, latest-version rows step 2 returns, so every page run's latest `StartedAt` lies inside `[min, max]`. The predicate is intentionally kept out of the `max(UpdatedAt)` dedup subquery, because `StartedAt` is not strictly immutable across a run's ReplacingMergeTree versions (a snapshot arriving before the run-started event seeds a provisional `StartedAt` that the started event later overwrites); filtering versions by `StartedAt` before resolving the latest could pick the wrong version. Filtering the already-deduped outer rows is always correct. When no valid window exists (empty page), it falls back to the prior unbounded read.

Step 1 itself intentionally stays unbounded: the batch-history list is "all batches for this set, cursor-paginated," so it legitimately needs all partitions, but it only reads light columns.

## Expected impact

- Step-2 preview read prunes from all partitions to the 1-2 weeks the page's batches live in.
- Read bytes drop from ~191 MB avg toward the few MB actually needed; p50/latency and S3 GET bursts on cold partitions fall accordingly.
- No behavior change: same rows, same ordering, same preview columns.

## EXPLAIN check

`EXPLAIN INDEXES` against a large tenant, heavy preview read, old vs new:

```
OLD (no StartedAt bound)        Parts: 165/165   Granules: 1411/1411
NEW (outer StartedAt window)    Parts:   8/162   Granules:   12/1407
```

(The dedup subquery still scans all partitions, but only for the light key columns, which is cheap; the heavy `Messages.*` read is what gets pruned.)

## Test plan

Added an integration test (real ClickHouse via testcontainers) in `simulation.clickhouse.repository.integration.test.ts`:

- Seeds a scenario set with two batches in different weekly partitions (one ~8 weeks old, one current), each with `Messages.*` arrays.
- Asserts both batches come back with their preview items intact (the window must span both weeks, so the older batch is not dropped).
- Captures the issued SQL and asserts the preview read carries the `StartedAt >=` / `StartedAt <=` bound with `minStartedAtMs` equal to the older batch's StartedAt (exact envelope).

Existing repository unit + integration tests still pass; typecheck clean.

Advisory PR from the ClickHouse-optimizer agent; a human should review and run EXPLAIN before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch history retrieval to include both older and recent runs reliably.
  * Added per-page `StartedAt` window filtering for preview queries to limit the scanned time range.
* **Tests**
  * Added integration coverage for batch history across different weekly partitions, including preview content and `StartedAt`-bounded query behavior.
  * Added unit tests for the `StartedAt` window builder across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->