### PR TITLE
refactor(agents): extract shared codeAgentConfig helpers, dedupe drawer/panel (#5288)

### DIFF
--- a/langwatch/src/components/agents/AgentCodeEditorDrawer.tsx
+++ b/langwatch/src/components/agents/AgentCodeEditorDrawer.tsx
@@ -43,6 +43,11 @@ import type {
   CodeComponentConfig,
   Field as DSLField,
 } from "~/optimization_studio/types/dsl";
+import {
+  DEFAULT_CODE,
+  buildCodeConfig,
+  getCodeFromConfig,
+} from "~/optimization_studio/utils/codeAgentConfig";
 import type {
   AgentComponentConfig,
   TypedAgent,
@@ -51,26 +56,8 @@ import { computeBestMatchMappings } from "~/server/scenarios/execution/resolve-f
 import { api } from "~/utils/api";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
 
-const DEFAULT_CODE = `class Code:
-    def __call__(self, input: str):
-        # Your code goes here
-
-        return {"output": input.upper()}
-`;
-
 const DEFAULT_INPUTS: DSLField[] = [{ identifier: "input", type: "str" }];
 const DEFAULT_OUTPUTS: DSLField[] = [{ identifier: "output", type: "str" }];
-
-/**
- * Extract code value from CodeComponentConfig parameters
- */
-const getCodeFromConfig = (config: AgentComponentConfig): string => {
-  const codeConfig = config as CodeComponentConfig;
-  const codeParam = codeConfig.parameters?.find(
-    (p) => p.identifier === "code" && p.type === "code",
-  );
-  return (codeParam?.value as string) ?? DEFAULT_CODE;
-};
 
 /**
  * Extract inputs from CodeComponentConfig
@@ -87,32 +74,6 @@ const getOutputsFromConfig = (config: AgentComponentConfig): DSLField[] => {
   const codeConfig = config as CodeComponentConfig;
   return codeConfig.outputs ?? DEFAULT_OUTPUTS;
 };
-
-/**
- * Build DSL-compatible config for code agent
- */
-const buildCodeConfig = (
-  code: string,
-  inputs: DSLField[],
-  outputs: DSLField[],
-  scenarioMappings: Record<string, FieldMapping>,
-  scenarioOutputField: string | undefined,
-): CodeComponentConfig => ({
-  name: "Code",
-  description: "Python code block",
-  parameters: [
-    {
-      identifier: "code",
-      type: "code",
-      value: code,
-    },
-  ],
-  inputs: inputs as CodeComponentConfig["inputs"],
-  outputs: outputs as CodeComponentConfig["outputs"],
-  scenarioMappings:
-    Object.keys(scenarioMappings).length > 0 ? scenarioMappings : undefined,
-  scenarioOutputField,
-});
 
 export type AgentCodeEditorDrawerProps = {
   open?: boolean;
@@ -270,13 +231,13 @@ export function AgentCodeEditorDrawer(props: AgentCodeEditorDrawerProps) {
     if (!project?.id || !isValid) return;
 
     // Build DSL-compatible config with current inputs/outputs/scenarioMappings/scenarioOutputField
-    const config = buildCodeConfig(
+    const config = buildCodeConfig({
       code,
       inputs,
       outputs,
       scenarioMappings,
       scenarioOutputField,
-    );
+    });
 
     if (agentId) {
       // Editing existing agent - no limit check needed

--- a/langwatch/src/optimization_studio/components/properties/AgentPropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/AgentPropertiesPanel.tsx
@@ -40,6 +40,11 @@ import { api } from "~/utils/api";
 import { useWorkflowStore } from "../../hooks/useWorkflowStore";
 import type { AgentComponent, Field as DslField } from "../../types/dsl";
 import {
+  DEFAULT_CODE,
+  buildCodeConfig,
+  getCodeFromConfig,
+} from "~/optimization_studio/utils/codeAgentConfig";
+import {
   buildAgentNodeData,
   nodeMatchesAgent,
   readCodeSnapshot,
@@ -96,38 +101,6 @@ function buildHttpConfig(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Code Config helpers
-// ---------------------------------------------------------------------------
-
-const DEFAULT_CODE = `class Code:
-    def __call__(self, input: str):
-        # Your code goes here
-
-        return {"output": input.upper()}
-`;
-
-function getCodeFromConfig(config: AgentComponentConfig): string {
-  const codeConfig = config as CodeComponentConfig;
-  const codeParam = codeConfig.parameters?.find(
-    (p) => p.identifier === "code" && p.type === "code",
-  );
-  return (codeParam?.value as string) ?? DEFAULT_CODE;
-}
-
-function buildCodeConfig(
-  code: string,
-  inputs: DslField[],
-  outputs: DslField[],
-): CodeComponentConfig {
-  return {
-    name: "Code",
-    description: "Python code block",
-    parameters: [{ identifier: "code", type: "code", value: code }],
-    inputs: inputs as CodeComponentConfig["inputs"],
-    outputs: outputs as CodeComponentConfig["outputs"],
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Entry component
@@ -523,17 +496,17 @@ function DbAgentPanel({
         auth,
       );
     } else if (agentType === "code") {
-      config = buildCodeConfig(
+      config = buildCodeConfig({
         code,
-        (node.data.inputs ?? []).map((i) => ({
+        inputs: (node.data.inputs ?? []).map((i) => ({
           identifier: i.identifier,
           type: i.type,
         })),
-        (node.data.outputs ?? []).map((o) => ({
+        outputs: (node.data.outputs ?? []).map((o) => ({
           identifier: o.identifier,
           type: o.type,
         })),
-      );
+      });
     }
 
     updateMutation.mutate(

--- a/langwatch/src/optimization_studio/utils/__tests__/codeAgentConfig.unit.test.ts
+++ b/langwatch/src/optimization_studio/utils/__tests__/codeAgentConfig.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentComponentConfig } from "~/server/agents/agent.repository";
+
+import {
+  DEFAULT_CODE,
+  buildCodeConfig,
+  getCodeFromConfig,
+} from "../codeAgentConfig";
+
+describe("codeAgentConfig", () => {
+  describe("getCodeFromConfig", () => {
+    describe("given a config carrying a code parameter", () => {
+      it("returns the code parameter value", () => {
+        const config = {
+          parameters: [{ identifier: "code", type: "code", value: "print(1)" }],
+        } as unknown as AgentComponentConfig;
+        expect(getCodeFromConfig(config)).toBe("print(1)");
+      });
+    });
+
+    describe("given a config without a code parameter", () => {
+      it("falls back to the default code", () => {
+        const config = { parameters: [] } as unknown as AgentComponentConfig;
+        expect(getCodeFromConfig(config)).toBe(DEFAULT_CODE);
+      });
+    });
+  });
+
+  describe("buildCodeConfig", () => {
+    const inputs = [{ identifier: "input", type: "str" as const }];
+    const outputs = [{ identifier: "output", type: "str" as const }];
+
+    describe("when no scenario wiring is supplied (properties panel path)", () => {
+      it("omits the scenario keys entirely", () => {
+        const config = buildCodeConfig({ code: "x", inputs, outputs });
+        expect(config.name).toBe("Code");
+        expect(config.parameters[0]).toMatchObject({
+          identifier: "code",
+          value: "x",
+        });
+        expect("scenarioMappings" in config).toBe(false);
+        expect("scenarioOutputField" in config).toBe(false);
+      });
+    });
+
+    describe("when an empty scenarioMappings map is supplied", () => {
+      it("still omits scenarioMappings", () => {
+        const config = buildCodeConfig({
+          code: "x",
+          inputs,
+          outputs,
+          scenarioMappings: {},
+        });
+        expect("scenarioMappings" in config).toBe(false);
+      });
+    });
+
+    describe("when scenario wiring is supplied (editor drawer path)", () => {
+      it("includes the scenario keys", () => {
+        const config = buildCodeConfig({
+          code: "x",
+          inputs,
+          outputs,
+          scenarioMappings: {
+            input: { source: "trace", key: "input" } as never,
+          },
+          scenarioOutputField: "output",
+        });
+        expect(config.scenarioMappings).toEqual({
+          input: { source: "trace", key: "input" },
+        });
+        expect(config.scenarioOutputField).toBe("output");
+      });
+    });
+  });
+});

--- a/langwatch/src/optimization_studio/utils/codeAgentConfig.ts
+++ b/langwatch/src/optimization_studio/utils/codeAgentConfig.ts
@@ -1,0 +1,55 @@
+import type { FieldMapping } from "~/components/variables";
+import type { AgentComponentConfig } from "~/server/agents/agent.repository";
+
+import type { CodeComponentConfig, Field } from "../types/dsl";
+
+/** Default Python source shown when a new code agent is created. */
+export const DEFAULT_CODE = `class Code:
+    def __call__(self, input: str):
+        # Your code goes here
+
+        return {"output": input.upper()}
+`;
+
+/** Read the `code` parameter value out of a code agent config, or the default. */
+export function getCodeFromConfig(config: AgentComponentConfig): string {
+  const codeConfig = config as CodeComponentConfig;
+  const codeParam = codeConfig.parameters?.find(
+    (p) => p.identifier === "code" && p.type === "code",
+  );
+  return (codeParam?.value as string) ?? DEFAULT_CODE;
+}
+
+/**
+ * Build a DSL-compatible Code component config.
+ *
+ * `scenarioMappings` / `scenarioOutputField` are optional: the optimization
+ * studio properties panel omits them, while the agent editor drawer supplies
+ * them. Each is included only when present, so a config built without scenario
+ * wiring carries neither key.
+ */
+export function buildCodeConfig({
+  code,
+  inputs,
+  outputs,
+  scenarioMappings,
+  scenarioOutputField,
+}: {
+  code: string;
+  inputs: Field[];
+  outputs: Field[];
+  scenarioMappings?: Record<string, FieldMapping>;
+  scenarioOutputField?: string;
+}): CodeComponentConfig {
+  return {
+    name: "Code",
+    description: "Python code block",
+    parameters: [{ identifier: "code", type: "code", value: code }],
+    inputs: inputs as CodeComponentConfig["inputs"],
+    outputs: outputs as CodeComponentConfig["outputs"],
+    ...(scenarioMappings && Object.keys(scenarioMappings).length > 0
+      ? { scenarioMappings }
+      : {}),
+    ...(scenarioOutputField !== undefined ? { scenarioOutputField } : {}),
+  };
+}


### PR DESCRIPTION
## Ticket

Closes langwatch/langwatch#5288. `buildCodeConfig` and `getCodeFromConfig` were copy-pasted across `AgentCodeEditorDrawer.tsx` and `AgentPropertiesPanel.tsx` and had begun to diverge in signature.

## Priority pick

Top-priority langwatch tech-debt ticket that is cleanly deliverable autonomously. Higher up the P2 queue were skipped for fit: langwatch/tasks#94 is already fixed on main (the `resolve-offloaded-traces-batch.ts` duplication it targets no longer exists, commented on the issue), and langwatch/langwatch#4813 targets the `langwatch-scenario` Python package that lives in another repo.

## Change

Extract the shared pair, plus the identical `DEFAULT_CODE` constant, into a new `optimization_studio/utils/codeAgentConfig.ts`, and delete both local copies.

The two `buildCodeConfig` copies had diverged: the drawer's took `scenarioMappings` / `scenarioOutputField`, the panel's did not. The unified helper takes **named params** (per the repo convention for multi-arg functions) with those two fields **optional**, and includes each only when supplied. So the panel path produces a config without the scenario keys (as before) and the drawer path includes them (as before). `getCodeFromConfig` was byte-identical in both; `DEFAULT_CODE` was byte-identical in both. Scoped to the two components plus the new module.

## Evidence

- **Behavior preserved, both surfaces (real render + mocked API boundaries):**
  ```
  pnpm test:integration run \
    AgentCodeEditorDrawer.integration.test.tsx \
    AgentCodeEditorDrawer.save-gate.integration.test.tsx \
    AgentPropertiesPanel.sync.integration.test.tsx
  Test Files  3 passed (3)
  Tests  19 passed (19)   EXIT=0
  ```
- **New unit test for the extracted module** (`codeAgentConfig.unit.test.ts`) locks the newly-unified optionality: no scenario args omits the keys, an empty `scenarioMappings` map omits `scenarioMappings`, and supplied wiring includes both; `getCodeFromConfig` reads the code param and falls back to `DEFAULT_CODE`.
  ```
  pnpm test:unit codeAgentConfig.unit.test.ts
  Test Files  1 passed (1)   Tests  5 passed (5)   EXIT=0
  ```
- **Typecheck:** `pnpm typecheck` -> EXIT=0 (no unused imports left behind).
- **Hygiene:** no em/en dashes; no `pnpm-lock.yaml` churn; 4 files (2 edited, 2 new).

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot. The human makes the merge call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved code-agent editing with consistent default code and clearer handling of inputs and outputs.
  * Added support for saving scenario-related settings only when they’re provided.

* **Bug Fixes**
  * Prevented missing code-agent configuration values from causing empty or inconsistent saved settings.

* **Tests**
  * Added coverage for code-agent configuration loading and saving behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->