### PR TITLE
docs: document Pairwise Compare SDK results

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -112,7 +112,8 @@
                     "group": "Via UI",
                     "pages": [
                       "evaluations/experiments/ui/answer-correctness",
-                      "evaluations/experiments/ui/llm-as-a-judge"
+                      "evaluations/experiments/ui/llm-as-a-judge",
+                      "evaluations/experiments/ui/pairwise-compare"
                     ]
                   },
                   "evaluations/experiments/ci-cd",

--- a/docs/evaluations/experiments/sdk.mdx
+++ b/docs/evaluations/experiments/sdk.mdx
@@ -527,6 +527,49 @@ for index, row in evaluation.loop(list(enumerate(ROWS))):
 evaluation.print_summary()
 ```
   </Tab>
+  <Tab title="TypeScript">
+```typescript
+import { LangWatch } from 'langwatch';
+
+const langwatch = new LangWatch();
+
+const rows = [
+  {
+    input: "Write a function that checks if a given integer is a prime number.",
+    golden: "function isPrime(n) { ... }",
+    candidateAId: "variant-a",
+    candidateAOutput: "function isPrime(n) { ... }",
+    candidateBId: "variant-b",
+    candidateBOutput: "function isPrime(n) { ... }",
+  },
+];
+
+const evaluation = await langwatch.experiments.init("pairwise-sdk-verification");
+
+await evaluation.run(rows, async ({ item, index }) => {
+  await evaluation.evaluate("langevals/pairwise_compare", {
+    index,
+    data: {
+      input: item.input,
+      golden: item.golden,
+      candidate_a_id: item.candidateAId,
+      candidate_a_output: item.candidateAOutput,
+      candidate_b_id: item.candidateBId,
+      candidate_b_output: item.candidateBOutput,
+    },
+    settings: {
+      model: "openai/gpt-5-mini",
+      has_golden_answer: true,
+      swap_and_confirm: true,
+      allow_tie: true,
+      include_metrics: ["cost", "duration"],
+    },
+  });
+});
+
+evaluation.printSummary();
+```
+  </Tab>
 </Tabs>
 
 `swap_and_confirm` performs two judge calls with A/B order reversed on the second pass. If the two calls disagree, the evaluator returns a tie. Set `has_golden_answer` to `false` when you want a pure head-to-head comparison without a reference answer.

--- a/docs/evaluations/experiments/sdk.mdx
+++ b/docs/evaluations/experiments/sdk.mdx
@@ -479,6 +479,62 @@ await evaluation.run(dataset, async ({ item, index }) => {
   Browse our complete list of [available evaluators](/evaluations/evaluators/list) including metrics for RAG quality, hallucination detection, safety, and more.
 </Info>
 
+### Pairwise Compare
+
+`langevals/pairwise_compare` compares two candidate outputs for the same input and asks a judge model to pick the better one. This is useful when you want to compare two prompts, models, or agent configurations directly instead of scoring each one independently.
+
+The example below was verified against the live SDK path using `evaluation.evaluate("langevals/pairwise_compare", ...)`.
+
+<Tabs>
+  <Tab title="Python">
+```python
+import langwatch
+
+ROWS = [
+    {
+        "input": "Write a function that checks if a given integer is a prime number.",
+        "golden": "def is_prime(n): ...",
+        "candidate_a_id": "variant-a",
+        "candidate_a_output": "def is_prime(n: int) -> bool: ...",
+        "candidate_b_id": "variant-b",
+        "candidate_b_output": "def is_prime(n: int) -> bool: ...",
+    }
+]
+
+evaluation = langwatch.experiment.init("pairwise-sdk-verification")
+
+for index, row in evaluation.loop(list(enumerate(ROWS))):
+    evaluation.evaluate(
+        "langevals/pairwise_compare",
+        index=index,
+        data={
+            "input": row["input"],
+            "golden": row["golden"],
+            "candidate_a_id": row["candidate_a_id"],
+            "candidate_a_output": row["candidate_a_output"],
+            "candidate_b_id": row["candidate_b_id"],
+            "candidate_b_output": row["candidate_b_output"],
+        },
+        settings={
+            "model": "openai/gpt-5-mini",
+            "has_golden_answer": True,
+            "swap_and_confirm": True,
+            "allow_tie": True,
+            "include_metrics": ["cost", "duration"],
+        },
+    )
+
+evaluation.print_summary()
+```
+  </Tab>
+</Tabs>
+
+`swap_and_confirm` performs two judge calls with A/B order reversed on the second pass. If the two calls disagree, the evaluator returns a tie. Set `has_golden_answer` to `false` when you want a pure head-to-head comparison without a reference answer.
+
+The SDK result also records the pairwise judge's own evaluator cost and duration. In exported results, those appear under the evaluator columns for `langevals/pairwise_compare`; they are separate from `include_metrics`, which injects each candidate target's cost or duration into the judge prompt.
+
+If you already have your own local pairwise judge, publish its result with `evaluation.log(...)` by sending a `score`, `label`, and `details`. Those custom results are tracked like any other SDK metric. The dedicated pairwise column visualization currently comes from the built-in Pairwise Compare evaluator configuration.
+
 ## Complete Example
 
 <Tabs>
@@ -674,6 +730,8 @@ For each evaluator applied to a target:
 | `{target}_{evaluator}_details` | Additional details or explanation | `gpt-4_faithfulness_details` → `"All claims supported"` |
 | `{target}_{evaluator}_cost` | Cost of running the evaluator | `gpt-4_faithfulness_cost` → `0.0005` |
 | `{target}_{evaluator}_duration_ms` | Evaluator execution time | `gpt-4_faithfulness_duration_ms` → `850` |
+
+For `langevals/pairwise_compare`, the evaluator cost and duration columns describe the pairwise judge run itself. When `swap_and_confirm` is enabled, that judge run may include two model calls.
 
 ### Example CSV Output
 

--- a/docs/evaluations/experiments/ui/pairwise-compare.mdx
+++ b/docs/evaluations/experiments/ui/pairwise-compare.mdx
@@ -1,0 +1,74 @@
+---
+title: How to compare two prompts or models head-to-head
+sidebarTitle: Pairwise Compare
+description: Use the Pairwise Compare evaluator to judge two candidate outputs against each other, with built-in position-bias mitigation.
+---
+
+When you're deciding between two prompts, two models, or two agent configurations, a single-output score can be noisy and hard to compare across runs. **Pairwise Compare** takes a different approach: it shows an LLM judge both candidate outputs side by side for the same input and asks it to pick the better one.
+
+## When to use it
+
+- You have two versions of a prompt, model, or agent and want to know which one is better for each row.
+- A direct head-to-head comparison is more useful than an absolute rubric score.
+- You want to reduce position bias. Pairwise Compare can run the comparison twice with the candidates swapped and only declare a winner if both calls agree.
+
+If you need to score a single target against a reference answer instead, see [Expected Answer Evaluation](/evaluations/experiments/ui/answer-correctness). If you do not have a known answer and are not comparing two existing targets, see [LLM-as-a-Judge](/evaluations/experiments/ui/llm-as-a-judge).
+
+## Setting it up
+
+1. In your [Experiments Workbench](https://app.langwatch.ai/@project/evaluations), add the two prompts, agents, or models you want to compare as separate targets.
+2. Click **Add** in the "Prompts or Agents" header and choose **Pairwise Compare** from the comparison section.
+3. Select **Variant A** and **Variant B** from your existing targets.
+4. If you have a ground-truth answer column, select it as the **Golden field**. If your deployment includes the latest Pairwise Compare settings, you can also disable **Has golden answer** to compare the two candidates directly without a reference answer.
+5. Run the evaluation. Pairwise Compare runs after both variants have produced outputs for that row.
+
+## How the verdict works
+
+Pairwise Compare can use `swap_and_confirm` to reduce first-position bias:
+
+1. Judge call one compares Candidate A vs Candidate B.
+2. Judge call two repeats the comparison with the candidates swapped.
+3. If both calls agree on the same winner, that candidate wins.
+4. If the two calls disagree, the evaluator returns a tie instead of forcing a winner.
+
+This means `swap_and_confirm` uses two judge calls per row.
+
+## No golden answer
+
+When `has_golden_answer` is enabled, the evaluator judges both candidates relative to the reference answer. When it is disabled, the evaluator compares Candidate A and Candidate B directly on their own merits.
+
+That is useful for preference-style tasks where there is no single correct answer, such as tone, style, or creative quality.
+
+## Settings
+
+| Setting | Default | Description |
+| ------- | ------- | ----------- |
+| `model` | — | The judge model. |
+| `has_golden_answer` | `true` | Compare each candidate against a reference answer. Disable it to compare the candidates directly. |
+| `swap_and_confirm` | `true` | Run two judge calls with the candidates swapped, and return a tie if the calls disagree. |
+| `allow_tie` | `true` | Allow the judge to return a tie when the candidates are effectively equivalent. |
+| `include_metrics` | `[]` | Include per-candidate metrics such as cost or duration in the judge context. |
+| `prompt` | — | Optional custom judge instructions. |
+
+## Reading the results
+
+Each row shows a verdict strip with the winning variant, the losing variant, or a tie. Click **why?** to inspect the judge reasoning.
+
+The column header also keeps a scoreboard tally across the full run. For example, you might see `variant-a wins 12 · 2 ties`. Hover the header to see the full tooltip breakdown for both variants and ties.
+
+## Using it from the SDK
+
+Pairwise Compare is a regular built-in evaluator under the hood: `langevals/pairwise_compare`. You can call it from the SDK the same way you call any other evaluator. See [Experiments via SDK](/evaluations/experiments/sdk#pairwise-compare) for a concrete example.
+
+If you run your own pairwise judge locally, you can still publish its score, label, and details with the SDK. Those custom results render as standard evaluator results today. The dedicated pairwise column visualization is driven by LangWatch's Pairwise Compare configuration.
+
+## What's Next?
+
+<CardGroup cols={2}>
+  <Card title="Experiments via SDK" icon="code" href="/evaluations/experiments/sdk">
+    Run Pairwise Compare programmatically from notebooks or scripts.
+  </Card>
+  <Card title="View Evaluators" icon="list" href="/evaluations/evaluators/list">
+    Explore all available evaluation metrics.
+  </Card>
+</CardGroup>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -19854,6 +19854,50 @@ for index, row in evaluation.loop(list(enumerate(ROWS))):
 evaluation.print_summary()
 ```
 
+  ### TypeScript
+
+```typescript
+import { LangWatch } from 'langwatch';
+
+const langwatch = new LangWatch();
+
+const rows = [
+  {
+    input: "Write a function that checks if a given integer is a prime number.",
+    golden: "function isPrime(n) { ... }",
+    candidateAId: "variant-a",
+    candidateAOutput: "function isPrime(n) { ... }",
+    candidateBId: "variant-b",
+    candidateBOutput: "function isPrime(n) { ... }",
+  },
+];
+
+const evaluation = await langwatch.experiments.init("pairwise-sdk-verification");
+
+await evaluation.run(rows, async ({ item, index }) => {
+  await evaluation.evaluate("langevals/pairwise_compare", {
+    index,
+    data: {
+      input: item.input,
+      golden: item.golden,
+      candidate_a_id: item.candidateAId,
+      candidate_a_output: item.candidateAOutput,
+      candidate_b_id: item.candidateBId,
+      candidate_b_output: item.candidateBOutput,
+    },
+    settings: {
+      model: "openai/gpt-5-mini",
+      has_golden_answer: true,
+      swap_and_confirm: true,
+      allow_tie: true,
+      include_metrics: ["cost", "duration"],
+    },
+  });
+});
+
+evaluation.printSummary();
+```
+
 
 
 `swap_and_confirm` performs two judge calls with A/B order reversed on the second pass. If the two calls disagree, the evaluator returns a tie. Set `has_golden_answer` to `false` when you want a pure head-to-head comparison without a reference answer.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -19805,6 +19805,63 @@ await evaluation.run(dataset, async ({ item, index }) => {
   Browse our complete list of [available evaluators](/evaluations/evaluators/list) including metrics for RAG quality, hallucination detection, safety, and more.
 </Info>
 
+### Pairwise Compare
+
+`langevals/pairwise_compare` compares two candidate outputs for the same input and asks a judge model to pick the better one. This is useful when you want to compare two prompts, models, or agent configurations directly instead of scoring each one independently.
+
+The example below was verified against the live SDK path using `evaluation.evaluate("langevals/pairwise_compare", ...)`.
+
+
+  ### Python
+
+```python
+import langwatch
+
+ROWS = [
+    {
+        "input": "Write a function that checks if a given integer is a prime number.",
+        "golden": "def is_prime(n): ...",
+        "candidate_a_id": "variant-a",
+        "candidate_a_output": "def is_prime(n: int) -> bool: ...",
+        "candidate_b_id": "variant-b",
+        "candidate_b_output": "def is_prime(n: int) -> bool: ...",
+    }
+]
+
+evaluation = langwatch.experiment.init("pairwise-sdk-verification")
+
+for index, row in evaluation.loop(list(enumerate(ROWS))):
+    evaluation.evaluate(
+        "langevals/pairwise_compare",
+        index=index,
+        data={
+            "input": row["input"],
+            "golden": row["golden"],
+            "candidate_a_id": row["candidate_a_id"],
+            "candidate_a_output": row["candidate_a_output"],
+            "candidate_b_id": row["candidate_b_id"],
+            "candidate_b_output": row["candidate_b_output"],
+        },
+        settings={
+            "model": "openai/gpt-5-mini",
+            "has_golden_answer": True,
+            "swap_and_confirm": True,
+            "allow_tie": True,
+            "include_metrics": ["cost", "duration"],
+        },
+    )
+
+evaluation.print_summary()
+```
+
+
+
+`swap_and_confirm` performs two judge calls with A/B order reversed on the second pass. If the two calls disagree, the evaluator returns a tie. Set `has_golden_answer` to `false` when you want a pure head-to-head comparison without a reference answer.
+
+The SDK result also records the pairwise judge's own evaluator cost and duration. In exported results, those appear under the evaluator columns for `langevals/pairwise_compare`; they are separate from `include_metrics`, which injects each candidate target's cost or duration into the judge prompt.
+
+If you already have your own local pairwise judge, publish its result with `evaluation.log(...)` by sending a `score`, `label`, and `details`. Those custom results are tracked like any other SDK metric. The dedicated pairwise column visualization currently comes from the built-in Pairwise Compare evaluator configuration.
+
 ## Complete Example
 
 
@@ -20004,6 +20061,8 @@ For each evaluator applied to a target:
 | `{target}_{evaluator}_details` | Additional details or explanation | `gpt-4_faithfulness_details` → `"All claims supported"` |
 | `{target}_{evaluator}_cost` | Cost of running the evaluator | `gpt-4_faithfulness_cost` → `0.0005` |
 | `{target}_{evaluator}_duration_ms` | Evaluator execution time | `gpt-4_faithfulness_duration_ms` → `850` |
+
+For `langevals/pairwise_compare`, the evaluator cost and duration columns describe the pairwise judge run itself. When `swap_and_confirm` is enabled, that judge run may include two model calls.
 
 ### Example CSV Output
 
@@ -20295,6 +20354,85 @@ On the video below, we show how to use the LangWatch Experiments via UI to evalu
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
+---
+
+# FILE: ./evaluations/experiments/ui/pairwise-compare.mdx
+
+---
+title: How to compare two prompts or models head-to-head
+sidebarTitle: Pairwise Compare
+description: Use the Pairwise Compare evaluator to judge two candidate outputs against each other, with built-in position-bias mitigation.
+---
+
+When you're deciding between two prompts, two models, or two agent configurations, a single-output score can be noisy and hard to compare across runs. **Pairwise Compare** takes a different approach: it shows an LLM judge both candidate outputs side by side for the same input and asks it to pick the better one.
+
+## When to use it
+
+- You have two versions of a prompt, model, or agent and want to know which one is better for each row.
+- A direct head-to-head comparison is more useful than an absolute rubric score.
+- You want to reduce position bias. Pairwise Compare can run the comparison twice with the candidates swapped and only declare a winner if both calls agree.
+
+If you need to score a single target against a reference answer instead, see [Expected Answer Evaluation](/evaluations/experiments/ui/answer-correctness). If you do not have a known answer and are not comparing two existing targets, see [LLM-as-a-Judge](/evaluations/experiments/ui/llm-as-a-judge).
+
+## Setting it up
+
+1. In your [Experiments Workbench](https://app.langwatch.ai/@project/evaluations), add the two prompts, agents, or models you want to compare as separate targets.
+2. Click **Add** in the "Prompts or Agents" header and choose **Pairwise Compare** from the comparison section.
+3. Select **Variant A** and **Variant B** from your existing targets.
+4. If you have a ground-truth answer column, select it as the **Golden field**. If your deployment includes the latest Pairwise Compare settings, you can also disable **Has golden answer** to compare the two candidates directly without a reference answer.
+5. Run the evaluation. Pairwise Compare runs after both variants have produced outputs for that row.
+
+## How the verdict works
+
+Pairwise Compare can use `swap_and_confirm` to reduce first-position bias:
+
+1. Judge call one compares Candidate A vs Candidate B.
+2. Judge call two repeats the comparison with the candidates swapped.
+3. If both calls agree on the same winner, that candidate wins.
+4. If the two calls disagree, the evaluator returns a tie instead of forcing a winner.
+
+This means `swap_and_confirm` uses two judge calls per row.
+
+## No golden answer
+
+When `has_golden_answer` is enabled, the evaluator judges both candidates relative to the reference answer. When it is disabled, the evaluator compares Candidate A and Candidate B directly on their own merits.
+
+That is useful for preference-style tasks where there is no single correct answer, such as tone, style, or creative quality.
+
+## Settings
+
+| Setting | Default | Description |
+| ------- | ------- | ----------- |
+| `model` | — | The judge model. |
+| `has_golden_answer` | `true` | Compare each candidate against a reference answer. Disable it to compare the candidates directly. |
+| `swap_and_confirm` | `true` | Run two judge calls with the candidates swapped, and return a tie if the calls disagree. |
+| `allow_tie` | `true` | Allow the judge to return a tie when the candidates are effectively equivalent. |
+| `include_metrics` | `[]` | Include per-candidate metrics such as cost or duration in the judge context. |
+| `prompt` | — | Optional custom judge instructions. |
+
+## Reading the results
+
+Each row shows a verdict strip with the winning variant, the losing variant, or a tie. Click **why?** to inspect the judge reasoning.
+
+The column header also keeps a scoreboard tally across the full run. For example, you might see `variant-a wins 12 · 2 ties`. Hover the header to see the full tooltip breakdown for both variants and ties.
+
+## Using it from the SDK
+
+Pairwise Compare is a regular built-in evaluator under the hood: `langevals/pairwise_compare`. You can call it from the SDK the same way you call any other evaluator. See [Experiments via SDK](/evaluations/experiments/sdk#pairwise-compare) for a concrete example.
+
+If you run your own pairwise judge locally, you can still publish its score, label, and details with the SDK. Those custom results render as standard evaluator results today. The dedicated pairwise column visualization is driven by LangWatch's Pairwise Compare configuration.
+
+## What's Next?
+
+<CardGroup cols={2}>
+  <Card title="Experiments via SDK" icon="code" href="/evaluations/experiments/sdk">
+    Run Pairwise Compare programmatically from notebooks or scripts.
+  </Card>
+  <Card title="View Evaluators" icon="list" href="/evaluations/evaluators/list">
+    Explore all available evaluation metrics.
+  </Card>
+</CardGroup>
+
 ---
 
 # FILE: ./evaluations/guardrails/code-integration.mdx


### PR DESCRIPTION
## Summary

- add a Pairwise Compare guide under Experiments UI docs
- add a verified Python SDK example for `langevals/pairwise_compare`
- clarify that SDK results capture the pairwise judge run's own evaluator cost and duration
- register the new docs page in navigation

## Verification

- ran `python3 -c "import json; json.load(open('docs/docs.json'))"`
- ran `git diff --check`
- ran `cd docs && printf "continue\n" | npx mintlify broken-links`

## Notes

- `include_metrics` injects candidate target cost/duration into the judge prompt.
- SDK evaluator result cost/duration describes the pairwise judge run itself, including the two judge calls when `swap_and_confirm` is enabled.
- Custom local pairwise judges can publish standard SDK metrics today; the dedicated pairwise column visualization is tied to LangWatch's Pairwise Compare configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Pairwise Compare” evaluator documentation workflow, including setup and usage in the Experiments Workbench UI.
  * Introduced a new UI documentation page for Pairwise Compare, covering settings, verdict behavior (including tie handling), and result reading.

* **Documentation**
  * Expanded evaluator SDK/SDK examples (Python and TypeScript) for `langevals/pairwise_compare`, including required fields and judge settings.
  * Clarified how exported cost/duration columns map to pairwise judge runs, including possible two calls when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->