### PR TITLE
fix(prompts): stop prompt playground tabs from leaking memory

### DIFF
--- a/langwatch/src/prompts/VersionHistoryListPopover.tsx
+++ b/langwatch/src/prompts/VersionHistoryListPopover.tsx
@@ -369,7 +369,7 @@ export function VersionHistoryListPopover({
         projectId: project?.id ?? "",
       },
       {
-        enabled: !!project?.id && !!configId,
+        enabled: open && !!project?.id && !!configId,
       },
     );
 

--- a/langwatch/src/prompts/__tests__/VersionHistoryListPopover.test.tsx
+++ b/langwatch/src/prompts/__tests__/VersionHistoryListPopover.test.tsx
@@ -47,14 +47,15 @@ const mockVersions = [
   },
 ] as unknown as VersionedPrompt[];
 
+const { mockUseQuery } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+}));
+
 vi.mock("~/utils/api", () => ({
   api: {
     prompts: {
       getAllVersionsForPrompt: {
-        useQuery: () => ({
-          data: mockVersions,
-          isLoading: false,
-        }),
+        useQuery: mockUseQuery,
       },
     },
   },
@@ -79,6 +80,10 @@ const renderWithChakra = (ui: React.ReactElement) => {
 describe("VersionHistoryListPopover", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseQuery.mockReturnValue({
+      data: mockVersions,
+      isLoading: false,
+    });
   });
 
   afterEach(() => {
@@ -271,6 +276,33 @@ describe("VersionHistoryListPopover", () => {
       // Should show "current" tag - only one should exist (for v2)
       const currentTags = screen.getAllByText("current");
       expect(currentTags).toHaveLength(1);
+    });
+  });
+
+  describe("when the popover is closed", () => {
+    it("does not enable the version history query", () => {
+      renderWithChakra(<VersionHistoryListPopover configId="config-1" />);
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ idOrHandle: "config-1" }),
+        expect.objectContaining({ enabled: false }),
+      );
+    });
+  });
+
+  describe("when the popover is opened", () => {
+    it("enables the version history query", async () => {
+      renderWithChakra(<VersionHistoryListPopover configId="config-1" />);
+
+      const historyButton = screen.getAllByTestId("version-history-button")[0]!;
+      fireEvent.click(historyButton);
+
+      await waitFor(() => {
+        expect(mockUseQuery).toHaveBeenLastCalledWith(
+          expect.objectContaining({ idOrHandle: "config-1" }),
+          expect.objectContaining({ enabled: true }),
+        );
+      });
     });
   });
 });

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/__tests__/DraggableTabsBrowser.inactiveTabUnmount.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/__tests__/DraggableTabsBrowser.inactiveTabUnmount.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression test for GitHub issue #5454: inactive tabs in the Prompt
+ * Playground stay mounted in the DOM instead of unmounting.
+ *
+ * DraggableTabsBrowser renders a Chakra v3 `Tabs.Root` (Ark UI under the
+ * hood) with no `lazyMount`/`unmountOnExit` props, so Ark UI mounts every
+ * `Tabs.Content` panel and only toggles the `hidden` attribute on inactive
+ * ones instead of unmounting them.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DraggableTabsBrowser } from "../ui/DraggableTabsBrowser";
+
+describe("DraggableTabsBrowser", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when a window has multiple tabs and one is inactive", () => {
+    function renderTwoTabWindow() {
+      return render(
+        <ChakraProvider value={defaultSystem}>
+          <DraggableTabsBrowser.Root onTabMove={vi.fn()}>
+            <DraggableTabsBrowser.Group
+              groupId="window-1"
+              activeTabId="tab-1"
+              onTabChange={vi.fn()}
+            >
+              <DraggableTabsBrowser.TabBar tabIds={["tab-1", "tab-2"]}>
+                <DraggableTabsBrowser.Tab id="tab-1">
+                  <DraggableTabsBrowser.Trigger value="tab-1">
+                    Tab 1
+                  </DraggableTabsBrowser.Trigger>
+                </DraggableTabsBrowser.Tab>
+                <DraggableTabsBrowser.Tab id="tab-2">
+                  <DraggableTabsBrowser.Trigger value="tab-2">
+                    Tab 2
+                  </DraggableTabsBrowser.Trigger>
+                </DraggableTabsBrowser.Tab>
+              </DraggableTabsBrowser.TabBar>
+              <DraggableTabsBrowser.Content value="tab-1">
+                <div data-testid="tab-1-content">Tab 1 content</div>
+              </DraggableTabsBrowser.Content>
+              <DraggableTabsBrowser.Content value="tab-2">
+                <div data-testid="tab-2-content">Tab 2 content</div>
+              </DraggableTabsBrowser.Content>
+            </DraggableTabsBrowser.Group>
+          </DraggableTabsBrowser.Root>
+        </ChakraProvider>,
+      );
+    }
+
+    it("keeps the active tab's content mounted", () => {
+      renderTwoTabWindow();
+
+      expect(screen.getByTestId("tab-1-content")).toBeInTheDocument();
+    });
+
+    it("unmounts the inactive tab's content instead of just hiding it", () => {
+      renderTwoTabWindow();
+
+      // Content for the inactive tab ("tab-2") must not exist in the DOM at
+      // all. Ark UI's default behavior only sets a `hidden` attribute on the
+      // panel, which keeps the node present here and fails this assertion.
+      expect(screen.queryByTestId("tab-2-content")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/__tests__/DraggableTabsBrowser.inactiveTabUnmount.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/__tests__/DraggableTabsBrowser.inactiveTabUnmount.test.tsx
@@ -2,12 +2,13 @@
  * @vitest-environment jsdom
  *
  * Regression test for GitHub issue #5454: inactive tabs in the Prompt
- * Playground stay mounted in the DOM instead of unmounting.
+ * Playground stayed mounted in the DOM instead of unmounting.
  *
- * DraggableTabsBrowser renders a Chakra v3 `Tabs.Root` (Ark UI under the
- * hood) with no `lazyMount`/`unmountOnExit` props, so Ark UI mounts every
- * `Tabs.Content` panel and only toggles the `hidden` attribute on inactive
- * ones instead of unmounting them.
+ * Before the fix, DraggableTabsBrowser rendered a Chakra v3 `Tabs.Root`
+ * (Ark UI under the hood) with no `lazyMount`/`unmountOnExit` props, so Ark
+ * UI mounted every `Tabs.Content` panel and only toggled the `hidden`
+ * attribute on inactive ones instead of unmounting them. This test guards
+ * against that regression now that both props are set.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/PromptBrowserWindowContent.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/PromptBrowserWindowContent.tsx
@@ -148,7 +148,13 @@ function PromptBrowserWindowInner(props: {
         }),
       });
     });
-    return () => sub.unsubscribe();
+    return () => {
+      sub.unsubscribe();
+      // Flush any pending debounced write before this tab unmounts (e.g. the
+      // user edited a field then immediately switched prompt tabs). Without
+      // this, switching back would restore stale tab.data.
+      updateTabDataDebounced.flush();
+    };
   }, [form.methods, props.tabId, updateTabDataDebounced]);
 
   // Refs for measuring content and direct DOM manipulation during drag

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/PromptTabbedSection.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/PromptTabbedSection.tsx
@@ -151,8 +151,13 @@ export function PromptTabbedSection({
       size="sm"
       minHeight={0}
       paddingTop={1}
+      // lazyMount (no unmountOnExit): a sub-tab isn't rendered until first
+      // opened, but once mounted it stays. Critically, this keeps the chat
+      // (inside the Conversation panel) alive when the user switches to
+      // Variables/Parameters — unmounting it would abort an in-flight
+      // generation. Inactive *prompt* tabs still fully unmount via the outer
+      // DraggableTabsBrowser, which is where the memory win comes from.
       lazyMount
-      unmountOnExit
     >
       <Tabs.List
         display="flex"

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/PromptTabbedSection.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/PromptTabbedSection.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, HStack, Tabs, Text } from "@chakra-ui/react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { LuEraser } from "react-icons/lu";
 import { useDebounceCallback } from "usehooks-ts";
@@ -99,6 +99,15 @@ export function PromptTabbedSection({
     },
     300,
   );
+
+  // Flush any pending variable-value write before unmount. useDebounceCallback
+  // cancels on unmount, so without this a value typed just before switching
+  // prompt tabs (which unmounts this tab) would be lost.
+  useEffect(() => {
+    return () => {
+      debouncedPersistToStore.flush();
+    };
+  }, [debouncedPersistToStore]);
 
   // Convert inputs to Variable[] format
   const variables: Variable[] = inputs.map((input) => ({

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/PromptTabbedSection.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/PromptTabbedSection.tsx
@@ -151,6 +151,8 @@ export function PromptTabbedSection({
       size="sm"
       minHeight={0}
       paddingTop={1}
+      lazyMount
+      unmountOnExit
     >
       <Tabs.List
         display="flex"

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/__tests__/PromptTabbedSection.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/__tests__/PromptTabbedSection.test.tsx
@@ -647,4 +647,41 @@ describe("PromptTabbedSection Layout Modes", () => {
       // (afterEach restores tabIdRef even if the assertion above throws)
     });
   });
+
+  describe("when a tab is switched away from and reopened", () => {
+    it("restores the variable value the user had typed", async () => {
+      const user = userEvent.setup();
+      const store = getStoreForTesting(TEST_PROJECT_ID);
+      const tabId = store.getState().windows[0]?.tabs[0]?.id;
+      tabIdRef.current = tabId!;
+
+      const formValues = {
+        version: {
+          parameters: {},
+          configData: {
+            inputs: [{ identifier: "topic", type: "str" }],
+            demonstrations: { inline: { records: {} } },
+          },
+        } as any,
+      };
+
+      // Mount, type a value, then unmount — this is "switch away".
+      const first = renderPromptTabbedSection({ layoutMode: "vertical" }, formValues);
+      await user.click(screen.getByRole("tab", { name: /variables/i }));
+      const emptyInput = (await screen.findAllByRole("textbox")).find(
+        (el) => (el as HTMLInputElement).value === "",
+      );
+      await user.type(emptyInput!, "kept");
+      first.unmount();
+
+      // "Switch back": a fresh mount of the same tab must show the value again,
+      // proving the full round-trip (flush on unmount -> restore from store).
+      renderPromptTabbedSection({ layoutMode: "vertical" }, formValues);
+      await user.click(screen.getByRole("tab", { name: /variables/i }));
+      const restored = (await screen.findAllByRole("textbox")).find(
+        (el) => (el as HTMLInputElement).value === "kept",
+      );
+      expect(restored).toBeDefined();
+    });
+  });
 });

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/__tests__/PromptTabbedSection.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/__tests__/PromptTabbedSection.test.tsx
@@ -398,9 +398,13 @@ describe("PromptTabbedSection Store Integration", () => {
   });
 });
 
-// Mock TabIdContext
+// Mock TabIdContext. tabIdRef lets a test point the component at a real store
+// tab id (defaults to a fixed value for tests that don't touch the store).
+const { tabIdRef } = vi.hoisted(() => ({
+  tabIdRef: { current: "test-tab-id" },
+}));
 vi.mock("../../ui/TabContext", () => ({
-  useTabId: () => "test-tab-id",
+  useTabId: () => tabIdRef.current,
 }));
 
 // Mock CopilotKit
@@ -597,6 +601,48 @@ describe("PromptTabbedSection Layout Modes", () => {
       expect(
         screen.getByText(/variables are substituted into the prompt/i),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("when a variable value is edited and the tab unmounts immediately", () => {
+    it("flushes the pending write so the edit is not lost", async () => {
+      const user = userEvent.setup();
+      const store = getStoreForTesting(TEST_PROJECT_ID);
+      const tabId = store.getState().windows[0]?.tabs[0]?.id;
+      // Point the component's useTabId() at the real store tab so its writes land.
+      tabIdRef.current = tabId!;
+
+      const { unmount } = renderPromptTabbedSection(
+        { layoutMode: "vertical" },
+        {
+          version: {
+            parameters: {},
+            configData: {
+              inputs: [{ identifier: "topic", type: "str" }],
+              demonstrations: { inline: { records: {} } },
+            },
+          } as any,
+        },
+      );
+
+      await user.click(screen.getByRole("tab", { name: /variables/i }));
+      const textboxes = await screen.findAllByRole("textbox");
+      const valueInput = textboxes.find(
+        (el) => (el as HTMLInputElement).value === "",
+      );
+      expect(valueInput).toBeDefined();
+      await user.type(valueInput!, "flushed");
+
+      // The 300ms debounce has NOT fired yet (test is faster). Unmounting the
+      // tab (as switching prompt tabs does) must flush the pending write rather
+      // than cancel it — otherwise the edit is lost.
+      unmount();
+
+      expect(store.getState().getByTabId(tabId!)?.variableValues.topic).toBe(
+        "flushed",
+      );
+
+      tabIdRef.current = "test-tab-id";
     });
   });
 });

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/__tests__/PromptTabbedSection.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/__tests__/PromptTabbedSection.test.tsx
@@ -321,15 +321,16 @@ describe("PromptTabbedSection Store Integration", () => {
     });
 
     it("persists variable values to localStorage", () => {
-      store.getState().addTab({
+      const tabId = store.getState().addTab({
         data: createTabData({
           variableValues: { name: "Persisted" },
         }),
       });
 
-      // Check localStorage contains the value
-      const storageKey = `${TEST_PROJECT_ID}:draggable-tabs-browser-store`;
-      const storedData = localStorage.getItem(storageKey);
+      // Tab data (including variableValues) is persisted under its own
+      // per-tab key, not the top-level window/tab-order index key.
+      const tabStorageKey = `${TEST_PROJECT_ID}:tab:${tabId}`;
+      const storedData = localStorage.getItem(tabStorageKey);
       expect(storedData).toBeDefined();
       expect(storedData).toContain("Persisted");
     });

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/__tests__/PromptTabbedSection.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/__tests__/PromptTabbedSection.test.tsx
@@ -487,6 +487,9 @@ describe("PromptTabbedSection Layout Modes", () => {
     cleanup();
     clearStoreInstances();
     localStorage.clear();
+    // Always restore the shared useTabId mock, even if a test asserted and
+    // threw before its own reset, so it can't leak a stale id into later tests.
+    tabIdRef.current = "test-tab-id";
   });
 
   describe("vertical layout mode", () => {
@@ -641,8 +644,7 @@ describe("PromptTabbedSection Layout Modes", () => {
       expect(store.getState().getByTabId(tabId!)?.variableValues.topic).toBe(
         "flushed",
       );
-
-      tabIdRef.current = "test-tab-id";
+      // (afterEach restores tabIdRef even if the assertion above throws)
     });
   });
 });

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/ui/DraggableTabsBrowser.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/ui/DraggableTabsBrowser.tsx
@@ -265,6 +265,8 @@ function DraggableTabsGroup({
           display="flex"
           flexDirection="column"
           variant="enclosed"
+          lazyMount
+          unmountOnExit
           {...props}
         >
           {children}

--- a/langwatch/src/prompts/prompt-playground/components/sidebar/PublishedPromptActions.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/sidebar/PublishedPromptActions.tsx
@@ -102,7 +102,11 @@ export function PublishedPromptActions({
     },
   );
 
-  const canDelete = permission?.hasPermission ?? true;
+  // Default to NOT deletable until the permission query resolves. The query is
+  // gated on the menu being open, so there is a brief loading window on first
+  // open; defaulting to `true` there would enable the destructive Delete action
+  // before we know the caller is actually allowed.
+  const canDelete = permission?.hasPermission === true;
 
   const handleDelete = useCallback(async () => {
     if (!project?.id) return;

--- a/langwatch/src/prompts/prompt-playground/components/sidebar/PublishedPromptActions.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/sidebar/PublishedPromptActions.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Text } from "@chakra-ui/react";
+import { Box, Button, Text, useDisclosure } from "@chakra-ui/react";
 import { useCallback, useState } from "react";
 import { ArrowUp, Copy, RefreshCw } from "react-feather";
 import { LuClock, LuEllipsisVertical, LuPencil, LuTrash2 } from "react-icons/lu";
@@ -37,6 +37,7 @@ export function PublishedPromptActions({
   const [isCopyDialogOpen, setIsCopyDialogOpen] = useState(false);
   const [isPushToCopiesDialogOpen, setIsPushToCopiesDialogOpen] =
     useState(false);
+  const { open, setOpen } = useDisclosure();
   const { deletePrompt } = usePrompts();
   const { project, hasPermission } = useOrganizationTeamProject();
   const { addTab } = useDraggableTabsBrowserStore(({ addTab }) => ({ addTab }));
@@ -52,7 +53,7 @@ export function PublishedPromptActions({
   // Cascade-resolved model for new-tab "view history" prompts.
   const resolvedDefault = api.modelProvider.getResolvedDefault.useQuery(
     { projectId: project?.id ?? "", featureKey: "prompt.create_default" },
-    { enabled: !!project?.id },
+    { enabled: open && !!project?.id },
   );
 
   const isCopiedPrompt = !!prompt?.copiedFromPromptId;
@@ -97,7 +98,7 @@ export function PublishedPromptActions({
       projectId: project?.id ?? "",
     },
     {
-      enabled: !!project?.id,
+      enabled: open && !!project?.id,
     },
   );
 
@@ -137,7 +138,10 @@ export function PublishedPromptActions({
         _groupHover={{ opacity: 1 }}
         transition="opacity 0.2s"
       >
-        <Menu.Root>
+        <Menu.Root
+          open={open}
+          onOpenChange={({ open }) => setOpen(open)}
+        >
           <Menu.Trigger asChild>
             <Button
               variant="ghost"

--- a/langwatch/src/prompts/prompt-playground/components/sidebar/__tests__/PublishedPromptActions.integration.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/sidebar/__tests__/PublishedPromptActions.integration.test.tsx
@@ -101,71 +101,73 @@ describe("PublishedPromptActions", () => {
     cleanup();
   });
 
-  describe("when the menu is closed", () => {
-    it("does not enable the resolved-default model query", () => {
-      renderWithChakra(
-        <PublishedPromptActions
-          promptId="prompt-1"
-          promptHandle="test-prompt"
-        />,
-      );
+  describe("given a rendered row menu", () => {
+    describe("when the menu is closed", () => {
+      it("does not enable the resolved-default model query", () => {
+        renderWithChakra(
+          <PublishedPromptActions
+            promptId="prompt-1"
+            promptHandle="test-prompt"
+          />,
+        );
 
-      expect(mockGetResolvedDefault).toHaveBeenCalledWith(
-        expect.objectContaining({ projectId: "test-project" }),
-        expect.objectContaining({ enabled: false }),
-      );
+        expect(mockGetResolvedDefault).toHaveBeenCalledWith(
+          expect.objectContaining({ projectId: "test-project" }),
+          expect.objectContaining({ enabled: false }),
+        );
+      });
+
+      it("does not enable the modify-permission query", () => {
+        renderWithChakra(
+          <PublishedPromptActions
+            promptId="prompt-1"
+            promptHandle="test-prompt"
+          />,
+        );
+
+        expect(mockCheckModifyPermission).toHaveBeenCalledWith(
+          expect.objectContaining({ idOrHandle: "prompt-1" }),
+          expect.objectContaining({ enabled: false }),
+        );
+      });
     });
 
-    it("does not enable the modify-permission query", () => {
-      renderWithChakra(
-        <PublishedPromptActions
-          promptId="prompt-1"
-          promptHandle="test-prompt"
-        />,
-      );
+    describe("when the menu is opened", () => {
+      it("enables the resolved-default model query", async () => {
+        const user = userEvent.setup();
+        renderWithChakra(
+          <PublishedPromptActions
+            promptId="prompt-1"
+            promptHandle="test-prompt"
+          />,
+        );
 
-      expect(mockCheckModifyPermission).toHaveBeenCalledWith(
-        expect.objectContaining({ idOrHandle: "prompt-1" }),
-        expect.objectContaining({ enabled: false }),
-      );
-    });
-  });
+        const trigger = screen.getByRole("button");
+        await user.click(trigger);
 
-  describe("when the menu is opened", () => {
-    it("enables the resolved-default model query", async () => {
-      const user = userEvent.setup();
-      renderWithChakra(
-        <PublishedPromptActions
-          promptId="prompt-1"
-          promptHandle="test-prompt"
-        />,
-      );
+        expect(mockGetResolvedDefault).toHaveBeenLastCalledWith(
+          expect.objectContaining({ projectId: "test-project" }),
+          expect.objectContaining({ enabled: true }),
+        );
+      });
 
-      const trigger = screen.getByRole("button");
-      await user.click(trigger);
+      it("enables the modify-permission query", async () => {
+        const user = userEvent.setup();
+        renderWithChakra(
+          <PublishedPromptActions
+            promptId="prompt-1"
+            promptHandle="test-prompt"
+          />,
+        );
 
-      expect(mockGetResolvedDefault).toHaveBeenLastCalledWith(
-        expect.objectContaining({ projectId: "test-project" }),
-        expect.objectContaining({ enabled: true }),
-      );
-    });
+        const trigger = screen.getByRole("button");
+        await user.click(trigger);
 
-    it("enables the modify-permission query", async () => {
-      const user = userEvent.setup();
-      renderWithChakra(
-        <PublishedPromptActions
-          promptId="prompt-1"
-          promptHandle="test-prompt"
-        />,
-      );
-
-      const trigger = screen.getByRole("button");
-      await user.click(trigger);
-
-      expect(mockCheckModifyPermission).toHaveBeenLastCalledWith(
-        expect.objectContaining({ idOrHandle: "prompt-1" }),
-        expect.objectContaining({ enabled: true }),
-      );
+        expect(mockCheckModifyPermission).toHaveBeenLastCalledWith(
+          expect.objectContaining({ idOrHandle: "prompt-1" }),
+          expect.objectContaining({ enabled: true }),
+        );
+      });
     });
   });
 });

--- a/langwatch/src/prompts/prompt-playground/components/sidebar/__tests__/PublishedPromptActions.integration.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/sidebar/__tests__/PublishedPromptActions.integration.test.tsx
@@ -168,6 +168,46 @@ describe("PublishedPromptActions", () => {
           expect.objectContaining({ enabled: true }),
         );
       });
+
+      it("keeps Delete disabled while the permission query is still loading", async () => {
+        const user = userEvent.setup();
+        // Query gated on open resolves asynchronously, so on first open the
+        // permission is undefined. Delete must NOT be enabled in that window.
+        mockCheckModifyPermission.mockReturnValue({ data: undefined });
+        renderWithChakra(
+          <PublishedPromptActions
+            promptId="prompt-1"
+            promptHandle="test-prompt"
+          />,
+        );
+
+        await user.click(screen.getByRole("button"));
+
+        const deleteItem = screen
+          .getByText("Delete prompt")
+          .closest('[role="menuitem"]');
+        expect(deleteItem).toHaveAttribute("data-disabled");
+      });
+
+      it("enables Delete once the permission query resolves as allowed", async () => {
+        const user = userEvent.setup();
+        mockCheckModifyPermission.mockReturnValue({
+          data: { hasPermission: true },
+        });
+        renderWithChakra(
+          <PublishedPromptActions
+            promptId="prompt-1"
+            promptHandle="test-prompt"
+          />,
+        );
+
+        await user.click(screen.getByRole("button"));
+
+        const deleteItem = screen
+          .getByText("Delete prompt")
+          .closest('[role="menuitem"]');
+        expect(deleteItem).not.toHaveAttribute("data-disabled");
+      });
     });
   });
 });

--- a/langwatch/src/prompts/prompt-playground/components/sidebar/__tests__/PublishedPromptActions.integration.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/sidebar/__tests__/PublishedPromptActions.integration.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies
+const mockProject = { id: "test-project" };
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: mockProject,
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("~/prompts/hooks/usePrompts", () => ({
+  usePrompts: () => ({ deletePrompt: vi.fn() }),
+}));
+
+vi.mock("~/prompts/hooks/useRenamePromptHandle", () => ({
+  useRenamePromptHandle: () => ({
+    renameHandle: vi.fn(),
+    canRename: true,
+    permissionReason: undefined,
+  }),
+}));
+
+vi.mock("../../../prompt-playground-store/DraggableTabsBrowserStore", () => ({
+  useDraggableTabsBrowserStore: () => ({ addTab: vi.fn() }),
+}));
+
+vi.mock("~/components/annotations/DeleteConfirmationDialog", () => ({
+  DeleteConfirmationDialog: () => null,
+}));
+
+vi.mock("~/prompts/components/CopyPromptDialog", () => ({
+  CopyPromptDialog: () => null,
+}));
+
+vi.mock("~/prompts/components/PushToCopiesDialog", () => ({
+  PushToCopiesDialog: () => null,
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: {
+    create: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const { mockGetResolvedDefault, mockCheckModifyPermission } = vi.hoisted(
+  () => ({
+    mockGetResolvedDefault: vi.fn(),
+    mockCheckModifyPermission: vi.fn(),
+  }),
+);
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    modelProvider: {
+      getResolvedDefault: {
+        useQuery: mockGetResolvedDefault,
+      },
+    },
+    prompts: {
+      checkModifyPermission: {
+        useQuery: mockCheckModifyPermission,
+      },
+      syncFromSource: {
+        useMutation: () => ({ mutateAsync: vi.fn() }),
+      },
+    },
+    useContext: () => ({
+      prompts: {
+        getAllPromptsForProject: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+// Import after mocks
+import { PublishedPromptActions } from "../PublishedPromptActions";
+
+const renderWithChakra = (ui: React.ReactElement) => {
+  return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+};
+
+describe("PublishedPromptActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetResolvedDefault.mockReturnValue({ data: undefined });
+    mockCheckModifyPermission.mockReturnValue({ data: undefined });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when the menu is closed", () => {
+    it("does not enable the resolved-default model query", () => {
+      renderWithChakra(
+        <PublishedPromptActions
+          promptId="prompt-1"
+          promptHandle="test-prompt"
+        />,
+      );
+
+      expect(mockGetResolvedDefault).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: "test-project" }),
+        expect.objectContaining({ enabled: false }),
+      );
+    });
+
+    it("does not enable the modify-permission query", () => {
+      renderWithChakra(
+        <PublishedPromptActions
+          promptId="prompt-1"
+          promptHandle="test-prompt"
+        />,
+      );
+
+      expect(mockCheckModifyPermission).toHaveBeenCalledWith(
+        expect.objectContaining({ idOrHandle: "prompt-1" }),
+        expect.objectContaining({ enabled: false }),
+      );
+    });
+  });
+
+  describe("when the menu is opened", () => {
+    it("enables the resolved-default model query", async () => {
+      const user = userEvent.setup();
+      renderWithChakra(
+        <PublishedPromptActions
+          promptId="prompt-1"
+          promptHandle="test-prompt"
+        />,
+      );
+
+      const trigger = screen.getByRole("button");
+      await user.click(trigger);
+
+      expect(mockGetResolvedDefault).toHaveBeenLastCalledWith(
+        expect.objectContaining({ projectId: "test-project" }),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
+
+    it("enables the modify-permission query", async () => {
+      const user = userEvent.setup();
+      renderWithChakra(
+        <PublishedPromptActions
+          promptId="prompt-1"
+          promptHandle="test-prompt"
+        />,
+      );
+
+      const trigger = screen.getByRole("button");
+      await user.click(trigger);
+
+      expect(mockCheckModifyPermission).toHaveBeenLastCalledWith(
+        expect.objectContaining({ idOrHandle: "prompt-1" }),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
+  });
+});

--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
@@ -3,7 +3,8 @@ import cloneDeep from "lodash.clonedeep";
 import type { DeepPartial } from "react-hook-form";
 import { z } from "zod";
 import { create } from "zustand";
-import { createJSONStorage, persist } from "zustand/middleware";
+import { persist } from "zustand/middleware";
+import type { PersistStorage, StorageValue } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { PromptConfigFormValues } from "~/prompts/types";
@@ -150,6 +151,186 @@ const PersistedStateSchema = z.object({
   windows: z.array(WindowSchema),
   activeWindowId: z.string().nullable(),
 });
+
+/** Slice of state that actually gets persisted (no store actions). */
+type PersistedTopLevelState = Pick<
+  DraggableTabsBrowserState,
+  "windows" | "activeWindowId"
+>;
+
+/** Shape written under the main storage key: tab identity/order only, no data. */
+interface LightTab {
+  id: string;
+}
+interface LightWindow {
+  id: string;
+  tabs: LightTab[];
+  activeTabId: string;
+}
+interface LightPersistedState {
+  windows: LightWindow[];
+  activeWindowId: string | null;
+}
+
+function getTabStorageKey(projectId: string, tabId: string) {
+  return `${projectId}:tab:${tabId}`;
+}
+
+/**
+ * Removes every localStorage key belonging to a project's draggable tabs
+ * browser store: each per-tab `${projectId}:tab:${tabId}` key plus the
+ * light index key itself. Per-tab keys are discovered by scanning
+ * localStorage directly for the `${projectId}:tab:` prefix rather than by
+ * parsing the light index key — this makes cleanup independent of the
+ * index's integrity, so it finds and removes every per-tab key regardless
+ * of whether the index is valid, corrupted, or was never written (e.g. if
+ * `setItem` wrote per-tab keys but threw before writing the index).
+ * Single Responsibility: Shared cleanup routine used by the public
+ * `clearDraggableTabsBrowserStore` utility and by the rehydration
+ * error/inconsistency recovery paths in `onRehydrateStorage`.
+ */
+function clearAllPersistedDataForProject(projectId: string) {
+  const storageKey = `${projectId}:draggable-tabs-browser-store`;
+  const tabKeyPrefix = `${projectId}:tab:`;
+  try {
+    const tabKeysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith(tabKeyPrefix)) {
+        tabKeysToRemove.push(key);
+      }
+    }
+    for (const key of tabKeysToRemove) {
+      localStorage.removeItem(key);
+    }
+
+    localStorage.removeItem(storageKey);
+  } catch (error) {
+    logger.error({ error, projectId }, "Failed to clear persisted store");
+  }
+}
+
+/**
+ * Strips transient UI flags before writing tab data to localStorage so they
+ * don't re-trigger on page reload.
+ */
+function stripTransientFlags(data: TabData): TabData {
+  return {
+    ...data,
+    meta: {
+      ...data.meta,
+      openHistoryOnLoad: undefined,
+    },
+  };
+}
+
+/**
+ * Custom persist storage that splits the heavy per-tab `data` out of the
+ * single windows/tabs storage key into its own key per tab
+ * (`${projectId}:tab:${tabId}`). Only tabs whose `data` reference actually
+ * changed since the last write are re-serialized/re-written, so editing one
+ * tab no longer re-serializes and writes every open tab's content.
+ *
+ * Single Responsibility: Bridges the in-memory windows/tabs tree to a
+ * per-tab-keyed localStorage representation.
+ */
+function createTabAwarePersistStorage(
+  projectId: string,
+): PersistStorage<PersistedTopLevelState> {
+  // Tracks the last-persisted `data` reference per tab so unchanged tabs
+  // (structurally shared by immer) can be skipped on write.
+  const lastPersistedDataRefs = new Map<string, TabData>();
+
+  return {
+    getItem: (name) => {
+      try {
+        const raw = localStorage.getItem(name);
+        if (!raw) return null;
+
+        const parsed = JSON.parse(raw) as {
+          state: LightPersistedState;
+          version?: number;
+        };
+
+        const windows: Window[] = parsed.state.windows.map((w) => ({
+          id: w.id,
+          activeTabId: w.activeTabId,
+          tabs: w.tabs.map((t) => {
+            const tabRaw = localStorage.getItem(
+              getTabStorageKey(projectId, t.id),
+            );
+            const data = tabRaw
+              ? (JSON.parse(tabRaw) as TabData)
+              : (undefined as unknown as TabData);
+            lastPersistedDataRefs.set(t.id, data);
+            return { id: t.id, data };
+          }),
+        }));
+
+        return {
+          state: {
+            windows,
+            activeWindowId: parsed.state.activeWindowId,
+          },
+          version: parsed.version,
+        };
+      } catch (error) {
+        logger.error({ error }, "Failed to read persisted store");
+        return null;
+      }
+    },
+
+    setItem: (name, value: StorageValue<PersistedTopLevelState>) => {
+      try {
+        const currentTabIds = new Set<string>();
+
+        const lightWindows: LightWindow[] = value.state.windows.map((w) => ({
+          id: w.id,
+          activeTabId: w.activeTabId,
+          tabs: w.tabs.map((t) => {
+            currentTabIds.add(t.id);
+            if (lastPersistedDataRefs.get(t.id) !== t.data) {
+              localStorage.setItem(
+                getTabStorageKey(projectId, t.id),
+                JSON.stringify(stripTransientFlags(t.data)),
+              );
+              lastPersistedDataRefs.set(t.id, t.data);
+            }
+            return { id: t.id };
+          }),
+        }));
+
+        // Clean up storage for tabs that no longer exist (removed/closed).
+        for (const tabId of lastPersistedDataRefs.keys()) {
+          if (!currentTabIds.has(tabId)) {
+            localStorage.removeItem(getTabStorageKey(projectId, tabId));
+            lastPersistedDataRefs.delete(tabId);
+          }
+        }
+
+        const lightState: LightPersistedState = {
+          windows: lightWindows,
+          activeWindowId: value.state.activeWindowId,
+        };
+
+        localStorage.setItem(
+          name,
+          JSON.stringify({ state: lightState, version: value.version }),
+        );
+      } catch (error) {
+        logger.error({ error }, "Failed to persist store");
+      }
+    },
+
+    removeItem: (name) => {
+      for (const tabId of lastPersistedDataRefs.keys()) {
+        localStorage.removeItem(getTabStorageKey(projectId, tabId));
+      }
+      lastPersistedDataRefs.clear();
+      localStorage.removeItem(name);
+    },
+  };
+}
 
 function createDraggableTabsBrowserStore(projectId: string) {
   const storageKey = `${projectId}:draggable-tabs-browser-store`;
@@ -485,26 +666,18 @@ function createDraggableTabsBrowserStore(projectId: string) {
       })),
       {
         name: storageKey,
-        storage: createJSONStorage(() => localStorage),
 
-        // Strip transient UI flags before writing to localStorage so they
-        // don't re-trigger on page reload.
+        // Persist per-tab `data` (form values/chat/demonstrations) under its
+        // own localStorage key so editing one tab doesn't re-serialize and
+        // write every other open tab's content. See
+        // createTabAwarePersistStorage for details. Transient UI flags
+        // (meta.openHistoryOnLoad) are stripped there too, right before
+        // each tab's data is written, so they don't re-trigger on reload.
         partialize: (state) => ({
-          ...state,
-          windows: state.windows.map((w) => ({
-            ...w,
-            tabs: w.tabs.map((t) => ({
-              ...t,
-              data: {
-                ...t.data,
-                meta: {
-                  ...t.data.meta,
-                  openHistoryOnLoad: undefined,
-                },
-              },
-            })),
-          })),
+          windows: state.windows,
+          activeWindowId: state.activeWindowId,
         }),
+        storage: createTabAwarePersistStorage(projectId),
 
         // Validate and handle corrupted data during rehydration
         onRehydrateStorage: () => (state, error) => {
@@ -513,11 +686,7 @@ function createDraggableTabsBrowserStore(projectId: string) {
               { error },
               "Failed to rehydrate store, clearing corrupted data",
             );
-            try {
-              localStorage.removeItem(storageKey);
-            } catch (e) {
-              logger.error({ error: e }, "Failed to clear corrupted storage");
-            }
+            clearAllPersistedDataForProject(projectId);
             return;
           }
 
@@ -533,11 +702,7 @@ function createDraggableTabsBrowserStore(projectId: string) {
                 { error: validation.error },
                 "Invalid store data shape, resetting to initial state",
               );
-              try {
-                localStorage.removeItem(storageKey);
-              } catch (e) {
-                logger.error({ error: e }, "Failed to clear invalid storage");
-              }
+              clearAllPersistedDataForProject(projectId);
               // Reset to initial state
               Object.assign(state, initialState);
               return;
@@ -595,11 +760,7 @@ function createDraggableTabsBrowserStore(projectId: string) {
                 "No valid windows after rehydration, resetting to initial state",
               );
               Object.assign(state, initialState);
-              try {
-                localStorage.removeItem(storageKey);
-              } catch (e) {
-                logger.error({ error: e }, "Failed to clear invalid storage");
-              }
+              clearAllPersistedDataForProject(projectId);
             } else if (hasInconsistency) {
               // Log that we fixed inconsistencies
               logger.info("Fixed state inconsistencies during rehydration");
@@ -643,12 +804,7 @@ export function useDraggableTabsBrowserStore<T>(
  * Single Responsibility: Provides emergency recovery mechanism for corrupted store data.
  */
 export function clearDraggableTabsBrowserStore(projectId: string) {
-  const storageKey = `${projectId}:draggable-tabs-browser-store`;
-  try {
-    localStorage.removeItem(storageKey);
-    storeInstances.delete(projectId);
-    logger.info({ projectId }, "Cleared draggable tabs browser store");
-  } catch (error) {
-    logger.error({ error, projectId }, "Failed to clear store");
-  }
+  clearAllPersistedDataForProject(projectId);
+  storeInstances.delete(projectId);
+  logger.info({ projectId }, "Cleared draggable tabs browser store");
 }

--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
@@ -158,9 +158,14 @@ type PersistedTopLevelState = Pick<
   "windows" | "activeWindowId"
 >;
 
-/** Shape written under the main storage key: tab identity/order only, no data. */
+/**
+ * Shape written under the main storage key: tab identity/order only, no data.
+ * `data` is optional purely to read the LEGACY single-key format, where each
+ * tab's full `data` was embedded in the index instead of a per-tab key.
+ */
 interface LightTab {
   id: string;
+  data?: TabData;
 }
 interface LightWindow {
   id: string;
@@ -260,36 +265,45 @@ function createTabAwarePersistStorage(
         const windows: Window[] = parsed.state.windows.map((w) => ({
           id: w.id,
           activeTabId: w.activeTabId,
-          // Drop any tab whose per-tab data key is missing or corrupt rather
-          // than fabricating an invalid tab. Fabricating `undefined` data
-          // would fail whole-state validation in onRehydrateStorage and wipe
-          // *every* tab, and letting JSON.parse throw would reject the entire
-          // store — either way one bad key loses all tabs. Downstream
-          // rehydration validation prunes now-empty windows and repairs a
-          // dangling activeTabId.
+          // Resolve each tab's data from its own per-tab key. Fall back to the
+          // legacy embedded `t.data` (old single-key format) so existing users
+          // don't lose their open tabs on upgrade. Drop a tab only when data is
+          // truly unrecoverable, rather than fabricating an invalid tab:
+          // fabricating `undefined` would fail whole-state validation in
+          // onRehydrateStorage and wipe *every* tab, and letting JSON.parse
+          // throw would reject the entire store — either way one bad key loses
+          // all tabs. Downstream validation prunes now-empty windows and
+          // repairs a dangling activeTabId.
           tabs: w.tabs.flatMap((t) => {
             const tabRaw = localStorage.getItem(
               getTabStorageKey(projectId, t.id),
             );
-            if (!tabRaw) {
-              logger.warn(
-                { tabId: t.id },
-                "Missing per-tab data key during rehydration, dropping tab",
-              );
-              return [];
+            if (tabRaw) {
+              let data: TabData;
+              try {
+                data = JSON.parse(tabRaw) as TabData;
+              } catch (parseError) {
+                logger.warn(
+                  { tabId: t.id, error: parseError },
+                  "Corrupt per-tab data during rehydration, dropping tab",
+                );
+                return [];
+              }
+              lastPersistedDataRefs.set(t.id, data);
+              return [{ id: t.id, data }];
             }
-            let data: TabData;
-            try {
-              data = JSON.parse(tabRaw) as TabData;
-            } catch (parseError) {
-              logger.warn(
-                { tabId: t.id, error: parseError },
-                "Corrupt per-tab data during rehydration, dropping tab",
-              );
-              return [];
+            if (t.data) {
+              // Legacy single-key payload: adopt the embedded data. Do NOT seed
+              // lastPersistedDataRefs so the next persist writes this tab's own
+              // per-tab key (completing the migration) instead of dedup-skipping
+              // it, which would strand the data as the index drops embedded data.
+              return [{ id: t.id, data: t.data }];
             }
-            lastPersistedDataRefs.set(t.id, data);
-            return [{ id: t.id, data }];
+            logger.warn(
+              { tabId: t.id },
+              "Missing per-tab data key during rehydration, dropping tab",
+            );
+            return [];
           }),
         }));
 

--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
@@ -260,15 +260,36 @@ function createTabAwarePersistStorage(
         const windows: Window[] = parsed.state.windows.map((w) => ({
           id: w.id,
           activeTabId: w.activeTabId,
-          tabs: w.tabs.map((t) => {
+          // Drop any tab whose per-tab data key is missing or corrupt rather
+          // than fabricating an invalid tab. Fabricating `undefined` data
+          // would fail whole-state validation in onRehydrateStorage and wipe
+          // *every* tab, and letting JSON.parse throw would reject the entire
+          // store — either way one bad key loses all tabs. Downstream
+          // rehydration validation prunes now-empty windows and repairs a
+          // dangling activeTabId.
+          tabs: w.tabs.flatMap((t) => {
             const tabRaw = localStorage.getItem(
               getTabStorageKey(projectId, t.id),
             );
-            const data = tabRaw
-              ? (JSON.parse(tabRaw) as TabData)
-              : (undefined as unknown as TabData);
+            if (!tabRaw) {
+              logger.warn(
+                { tabId: t.id },
+                "Missing per-tab data key during rehydration, dropping tab",
+              );
+              return [];
+            }
+            let data: TabData;
+            try {
+              data = JSON.parse(tabRaw) as TabData;
+            } catch (parseError) {
+              logger.warn(
+                { tabId: t.id, error: parseError },
+                "Corrupt per-tab data during rehydration, dropping tab",
+              );
+              return [];
+            }
             lastPersistedDataRefs.set(t.id, data);
-            return { id: t.id, data };
+            return [{ id: t.id, data }];
           }),
         }));
 

--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
@@ -289,6 +289,12 @@ function createTabAwarePersistStorage(
           activeTabId: w.activeTabId,
           tabs: w.tabs.map((t) => {
             currentTabIds.add(t.id);
+            // Reference equality is sufficient (not deep-equal) only because
+            // this store is wrapped in Immer: `produce` structurally shares
+            // untouched branches, so an unedited tab's `data` object keeps
+            // the exact same reference across `set()` calls. If this store
+            // is ever updated outside Immer's `set()`, this check silently
+            // degrades to "always write" for every tab.
             if (lastPersistedDataRefs.get(t.id) !== t.data) {
               localStorage.setItem(
                 getTabStorageKey(projectId, t.id),

--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
@@ -176,6 +176,11 @@ function getTabStorageKey(projectId: string, tabId: string) {
   return `${projectId}:tab:${tabId}`;
 }
 
+/** The light index key holding tab identity/order (not per-tab data). */
+function getStorageKey(projectId: string) {
+  return `${projectId}:draggable-tabs-browser-store`;
+}
+
 /**
  * Removes every localStorage key belonging to a project's draggable tabs
  * browser store: each per-tab `${projectId}:tab:${tabId}` key plus the
@@ -190,7 +195,7 @@ function getTabStorageKey(projectId: string, tabId: string) {
  * error/inconsistency recovery paths in `onRehydrateStorage`.
  */
 function clearAllPersistedDataForProject(projectId: string) {
-  const storageKey = `${projectId}:draggable-tabs-browser-store`;
+  const storageKey = getStorageKey(projectId);
   const tabKeyPrefix = `${projectId}:tab:`;
   try {
     const tabKeysToRemove: string[] = [];
@@ -328,18 +333,19 @@ function createTabAwarePersistStorage(
       }
     },
 
-    removeItem: (name) => {
-      for (const tabId of lastPersistedDataRefs.keys()) {
-        localStorage.removeItem(getTabStorageKey(projectId, tabId));
-      }
+    removeItem: () => {
+      // Delegate to the prefix-scan cleanup so this doesn't rely on the
+      // in-memory ref map being populated — otherwise per-tab keys written
+      // by another store instance (e.g. the same project open in a second
+      // browser tab) would be orphaned. Also drop our own tracked refs.
+      clearAllPersistedDataForProject(projectId);
       lastPersistedDataRefs.clear();
-      localStorage.removeItem(name);
     },
   };
 }
 
 function createDraggableTabsBrowserStore(projectId: string) {
-  const storageKey = `${projectId}:draggable-tabs-browser-store`;
+  const storageKey = getStorageKey(projectId);
 
   return create<DraggableTabsBrowserState>()(
     persist(
@@ -653,11 +659,12 @@ function createDraggableTabsBrowserStore(projectId: string) {
          */
         reset: () => {
           set(initialState);
-          try {
-            localStorage.removeItem(storageKey);
-          } catch (error) {
-            logger.error({ error }, "Failed to clear localStorage");
-          }
+          // Remove the light index key AND every per-tab key. A bare
+          // removeItem(storageKey) would strand the `${projectId}:tab:*`
+          // keys (the leak this store split introduced), so delegate to the
+          // prefix-scan cleanup, which is robust even for per-tab keys this
+          // instance never tracked in memory.
+          clearAllPersistedDataForProject(projectId);
         },
 
         /**

--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/__tests__/DraggableTabsBrowserStore.test.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/__tests__/DraggableTabsBrowserStore.test.ts
@@ -480,6 +480,57 @@ describe("DraggableTabsBrowserStore", () => {
   });
 
   describe("rehydration recovery", () => {
+    describe("when reading the legacy single-key persisted format", () => {
+      it("adopts the embedded tab data and migrates it to per-tab keys", async () => {
+        const lightKey = `${TEST_PROJECT_ID}:draggable-tabs-browser-store`;
+
+        // Legacy format: full tab data embedded in the index, NO per-tab keys.
+        // This is what an existing user's localStorage looks like on upgrade.
+        localStorage.setItem(
+          lightKey,
+          JSON.stringify({
+            state: {
+              windows: [
+                {
+                  id: "window-1",
+                  activeTabId: "tab-1",
+                  tabs: [
+                    { id: "tab-1", data: createTabData({ meta: { title: "Legacy A" } }) },
+                    { id: "tab-2", data: createTabData({ meta: { title: "Legacy B" } }) },
+                  ],
+                },
+              ],
+              activeWindowId: "window-1",
+            },
+            version: 0,
+          }),
+        );
+
+        await store.persist.rehydrate();
+
+        // Both tabs survive the upgrade with their data intact.
+        const state = store.getState();
+        expect(state.windows[0]?.tabs.map((t) => t.id)).toEqual([
+          "tab-1",
+          "tab-2",
+        ]);
+        expect(state.getByTabId("tab-1")?.meta.title).toBe("Legacy A");
+        expect(state.getByTabId("tab-2")?.meta.title).toBe("Legacy B");
+
+        // A subsequent write migrates each tab into its own per-tab key.
+        store.getState().updateTabData({
+          tabId: "tab-1",
+          updater: (data) => ({ ...data, meta: { ...data.meta, title: "A2" } }),
+        });
+        expect(localStorage.getItem(`${TEST_PROJECT_ID}:tab:tab-1`)).toContain(
+          "A2",
+        );
+        expect(
+          localStorage.getItem(`${TEST_PROJECT_ID}:tab:tab-2`),
+        ).not.toBeNull();
+      });
+    });
+
     describe("when one tab's per-tab data key is missing", () => {
       it("drops only that tab and keeps the rest instead of wiping the store", async () => {
         const lightKey = `${TEST_PROJECT_ID}:draggable-tabs-browser-store`;

--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/__tests__/DraggableTabsBrowserStore.test.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/__tests__/DraggableTabsBrowserStore.test.ts
@@ -590,6 +590,32 @@ describe("DraggableTabsBrowserStore", () => {
       expect(store.getState().windows).toEqual([]);
       expect(store.getState().activeWindowId).toBeNull();
     });
+
+    it("removes the per-tab localStorage keys of its own tabs", () => {
+      store.getState().addTab({ data: createTabData() });
+      const tabId = store.getState().windows[0]?.tabs[0]?.id;
+      expect(localStorage.getItem(`${TEST_PROJECT_ID}:tab:${tabId}`)).not.toBeNull();
+
+      store.getState().reset();
+
+      expect(localStorage.getItem(`${TEST_PROJECT_ID}:tab:${tabId}`)).toBeNull();
+      expect(
+        localStorage.getItem(`${TEST_PROJECT_ID}:draggable-tabs-browser-store`),
+      ).toBeNull();
+    });
+
+    it("removes orphaned per-tab keys this instance never tracked", () => {
+      // Simulates the same project open in a second browser tab: another
+      // store instance wrote a per-tab key that this instance's in-memory
+      // ref map never saw. reset() must still clear it via the prefix scan.
+      const orphanKey = `${TEST_PROJECT_ID}:tab:orphan-from-other-instance`;
+      localStorage.setItem(orphanKey, JSON.stringify(createTabData()));
+
+      store.getState().addTab({ data: createTabData() });
+      store.getState().reset();
+
+      expect(localStorage.getItem(orphanKey)).toBeNull();
+    });
   });
 
   describe("variableValues", () => {

--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/__tests__/DraggableTabsBrowserStore.test.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/__tests__/DraggableTabsBrowserStore.test.ts
@@ -480,6 +480,45 @@ describe("DraggableTabsBrowserStore", () => {
   });
 
   describe("rehydration recovery", () => {
+    describe("when one tab's per-tab data key is missing", () => {
+      it("drops only that tab and keeps the rest instead of wiping the store", async () => {
+        const lightKey = `${TEST_PROJECT_ID}:draggable-tabs-browser-store`;
+        const tab1Key = `${TEST_PROJECT_ID}:tab:tab-1`;
+
+        // Index references two tabs, but only tab-1's data key exists — tab-2's
+        // per-tab key is absent (e.g. evicted, or a partial write). tab-1 must
+        // survive; fabricating tab-2 would fail whole-state validation and lose
+        // tab-1 too.
+        localStorage.setItem(
+          lightKey,
+          JSON.stringify({
+            state: {
+              windows: [
+                {
+                  id: "window-1",
+                  tabs: [{ id: "tab-1" }, { id: "tab-2" }],
+                  activeTabId: "tab-1",
+                },
+              ],
+              activeWindowId: "window-1",
+            },
+            version: 0,
+          }),
+        );
+        localStorage.setItem(
+          tab1Key,
+          JSON.stringify(createTabData({ meta: { title: "Survivor" } })),
+        );
+
+        await store.persist.rehydrate();
+
+        const state = store.getState();
+        expect(state.windows).toHaveLength(1);
+        expect(state.windows[0]?.tabs.map((t) => t.id)).toEqual(["tab-1"]);
+        expect(state.getByTabId("tab-1")?.meta.title).toBe("Survivor");
+      });
+    });
+
     describe("when a persisted tab fails schema validation", () => {
       it("removes all per-tab keys along with the light index key", async () => {
         const lightKey = `${TEST_PROJECT_ID}:draggable-tabs-browser-store`;

--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/__tests__/DraggableTabsBrowserStore.test.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/__tests__/DraggableTabsBrowserStore.test.ts
@@ -19,10 +19,19 @@ const localStorageMock = (() => {
     clear: () => {
       store = {};
     },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
   };
 })();
 
 vi.stubGlobal("localStorage", localStorageMock);
+
+/** Builds a large-ish string so per-tab payload size differences are obvious. */
+function buildLargeContent(label: string): string {
+  return `${label}-`.repeat(5000); // ~30-40KB per tab
+}
 
 /**
  * Helper to create a minimal TabData object for testing
@@ -414,6 +423,113 @@ describe("DraggableTabsBrowserStore", () => {
       expect(store.getState().windows[0]?.tabs[0]?.data.meta.title).toBe(
         "Updated",
       );
+    });
+  });
+
+  describe("persistence", () => {
+    describe("when updating one tab's data with other large tabs open", () => {
+      it("does not rewrite the untouched tab's full content", () => {
+        store.getState().addTab({
+          data: createTabData({
+            form: { currentValues: { handle: buildLargeContent("tab-1") } },
+          }),
+        });
+        store.getState().addTab({
+          data: createTabData({
+            form: { currentValues: { handle: buildLargeContent("tab-2") } },
+          }),
+        });
+
+        const tab1Id = store.getState().windows[0]?.tabs[0]?.id;
+        const tab2Id = store.getState().windows[0]?.tabs[1]?.id;
+        expect(tab1Id).toBeDefined();
+        expect(tab2Id).toBeDefined();
+
+        const originalSetItem = localStorageMock.setItem.bind(localStorageMock);
+        const setItemSpy = vi.fn(originalSetItem);
+        localStorageMock.setItem = setItemSpy;
+
+        try {
+          store.getState().updateTabData({
+            tabId: tab2Id!,
+            updater: (data) => ({
+              ...data,
+              meta: { ...data.meta, title: "Updated" },
+            }),
+          });
+
+          // Every write that happened while editing tab2 must not embed
+          // tab1's untouched large content anywhere in its payload.
+          const tab1Content = buildLargeContent("tab-1");
+          for (const call of setItemSpy.mock.calls) {
+            const [, value] = call;
+            expect(value.includes(tab1Content)).toBe(false);
+          }
+
+          // Sanity check: tab1's content is still recoverable after tab2 was
+          // edited, proving we didn't just fail to persist it at all.
+          const persistedTab1 = localStorageMock.getItem(
+            `${TEST_PROJECT_ID}:tab:${tab1Id!}`,
+          );
+          expect(persistedTab1).toContain(tab1Content);
+        } finally {
+          localStorageMock.setItem = originalSetItem;
+        }
+      });
+    });
+  });
+
+  describe("rehydration recovery", () => {
+    describe("when a persisted tab fails schema validation", () => {
+      it("removes all per-tab keys along with the light index key", async () => {
+        const lightKey = `${TEST_PROJECT_ID}:draggable-tabs-browser-store`;
+        const tab1Key = `${TEST_PROJECT_ID}:tab:tab-1`;
+        const tab2Key = `${TEST_PROJECT_ID}:tab:tab-2`;
+
+        // Light index key parses fine and references both tabs...
+        localStorage.setItem(
+          lightKey,
+          JSON.stringify({
+            state: {
+              windows: [
+                {
+                  id: "window-1",
+                  tabs: [{ id: "tab-1" }, { id: "tab-2" }],
+                  activeTabId: "tab-1",
+                },
+              ],
+              activeWindowId: "window-1",
+            },
+            version: 0,
+          }),
+        );
+        localStorage.setItem(tab1Key, JSON.stringify(createTabData()));
+        // ...but tab-2's own data is corrupted (missing required `form`
+        // field), which fails PersistedStateSchema validation and should
+        // trigger the "invalid shape" recovery path.
+        localStorage.setItem(tab2Key, JSON.stringify({}));
+
+        await store.persist.rehydrate();
+
+        expect(localStorage.getItem(tab1Key)).toBeNull();
+        expect(localStorage.getItem(tab2Key)).toBeNull();
+        expect(localStorage.getItem(lightKey)).toBeNull();
+      });
+    });
+
+    describe("when the light index key itself is unparseable", () => {
+      it("falls back to removing the light key without throwing", async () => {
+        const lightKey = `${TEST_PROJECT_ID}:draggable-tabs-browser-store`;
+        const tab1Key = `${TEST_PROJECT_ID}:tab:tab-1`;
+
+        localStorage.setItem(tab1Key, JSON.stringify(createTabData()));
+        localStorage.setItem(lightKey, "{not valid json");
+
+        await store.persist.rehydrate();
+
+        expect(localStorage.getItem(lightKey)).toBeNull();
+        expect(localStorage.getItem(tab1Key)).toBeNull();
+      });
     });
   });
 


### PR DESCRIPTION
# Related Issue

- Resolves #5454

## Why

Closes #5454

Users with many prompt tabs open in the Prompt Playground reported memory climbing and the page getting sluggish, independent of which tab was active. Root cause: Ark UI's `Tabs.Root` defaults to mounting every tab panel and only toggling a `hidden` attribute on inactive ones — it never actually unmounts them. So every open tab kept a full form, editor, chat provider, and set of live queries running forever, regardless of visibility.

## What changed

- **Inactive tabs actually unmount.** Added `lazyMount`/`unmountOnExit` to the outer prompt-tab `Tabs.Root` so only the active tab's content is mounted. The nested sub-tabs (Conversation/Variables/Demonstrations/Parameters) use `lazyMount` **without** `unmountOnExit` — switching sub-tabs must not unmount the chat (that would abort an in-flight generation). Chat messages and form values round-trip through the Zustand tab store, so switching prompt tabs doesn't lose saved work.
- **Version history no longer fetches eagerly.** `VersionHistoryListPopover` was firing its full-version-history query on every tab mount, whether or not the user ever opened the history dropdown. Gated the query on the popover's own open state.
- **Sidebar per-row menu, same bug, N+1 variant.** A codebase sweep for the same "query fires on mount instead of on open" pattern found `PublishedPromptActions` (rendered once per prompt row in the sidebar) doing the same thing — fixed the same way.
- **localStorage writes no longer re-serialize every open tab on one tab's edit.** The Zustand store's `persist` middleware was rebuilding and stringifying every open tab's full content into a single localStorage key on every debounced edit in any one tab. Split persistence so each tab's data lives under its own `${projectId}:tab:${tabId}` key — editing one tab now only rewrites that tab's key.
- **Orphaned-key cleanup hardened.** Code review on the per-tab-key split caught a real gap: cleanup could only find per-tab keys by parsing the light index key, so a corrupted or partially-written index (e.g. a `QuotaExceededError` on the index write, after per-tab keys already landed) would strand data with no path to clean it up. Cleanup now scans localStorage directly for the project's key prefix instead of depending on the index.
- **No lost edits on tab switch.** Both debounced writers (prompt form via lodash, variable values via `useDebounceCallback`, which cancels pending work on unmount) now flush on unmount, so an edit typed just before switching tabs is persisted rather than dropped.
- **Legacy persistence migrates, doesn't wipe.** Existing users store tab data in the old single-key format; `getItem` now falls back to that embedded data when a per-tab key is missing and migrates it to a per-tab key on the next write, instead of dropping every tab and clearing the playground on first reload after deploy.
- **Delete stays disabled until its permission check resolves.** With the sidebar menu's permission query now gated on open, `canDelete` defaults to disabled during the brief loading window instead of enabling the destructive action before the check returns.

A broader sweep found the same three anti-patterns recurring in 6 unrelated features (analytics graphs, governance tool catalog, trace viewer, secrets popover, agent menu) plus 3 structurally-similar undo-history stores. Those are out of scope for this PR and tracked separately in #5455.

## Test plan

- New regression test proving the actual bug: `DraggableTabsBrowser.inactiveTabUnmount.test.tsx` — fails against the pre-fix code (content present but `hidden`), passes after.
- `VersionHistoryListPopover.test.tsx` — added cases asserting the query is disabled while closed and enabled once opened.
- `PublishedPromptActions.integration.test.tsx` (new) — same assertion shape for the sidebar menu.
- `DraggableTabsBrowserStore.test.ts` — added cases proving a tab edit doesn't rewrite other tabs' localStorage content, and that per-tab keys are fully cleaned up even when the index is corrupted or unparseable.
- `pnpm typecheck` clean; 67 unit tests + 4 integration tests (Docker-backed) pass across every touched file, plus direct consumers (`PromptTabbedSection`, `PromptPlaygroundChat`, `PromptBrowserWindowContent`) with no regressions.

## Anything surprising?

Ran a self-review pass on the persistence redesign before opening this PR and caught a real P1 (the orphaned-key cleanup gap above) plus a couple of test-quality issues (a test-isolation risk from an unrestored mock, a test named for a scenario it didn't actually assert, and a misnamed `.test.tsx` that should've been `.integration.test.tsx`) — all fixed and covered by tests in this PR, not left as follow-ups.

**Behavioral tradeoff (intentional):** because inactive prompt tabs now fully unmount, switching to a different prompt tab while a chat generation is streaming interrupts that background generation — the completed messages persist, but an in-flight turn does not resume on return. This is inherent to the memory fix and considered an acceptable cost (you rarely switch prompt tabs mid-generation). Sub-tab switching within a tab does **not** interrupt the chat — the nested tabs deliberately keep it mounted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tab panels now lazy mount across tab sections and the draggable tab browser.
  * Version history and published prompt actions now load only while the related popover/menu is open.
  * Draggable tab browser persistence is now saved per tab with automatic cleanup of stale storage keys.
* **Bug Fixes**
  * Inactive tab panels are fully unmounted.
  * Pending tab edits are flushed on unmount to prevent losing the latest variable/form changes.
  * Delete permission is now disabled until permission is known.
* **Tests**
  * Added/expanded regression and integration coverage for conditional query enabling and per-tab persistence/rehydration/reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->