### PR TITLE
fix(langy-agent): add CAP_FOWNER + copy sdk-go before go mod download

### DIFF
--- a/Dockerfile.langy_agent
+++ b/Dockerfile.langy_agent
@@ -26,6 +26,7 @@ WORKDIR /src
 # Cache go module downloads in a layer that only invalidates when go.mod/
 # go.sum changes — the rest of the source tree is a churnier input.
 COPY go.mod go.sum ./
+COPY sdk-go ./sdk-go
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go mod download

--- a/charts/langy-agent/values.yaml
+++ b/charts/langy-agent/values.yaml
@@ -79,8 +79,10 @@ workspaceVolume: {}
 ## and steal worker B's project API key + GitHub token (PR #4913 review).
 ##
 ## Mitigations that keep the blast radius small even with root in the pod:
-##   - Drop ALL caps and add back ONLY what's strictly required: the four
-##     per-UID-handoff caps (SETUID/SETGID/CHOWN/DAC_OVERRIDE) plus
+##   - Drop ALL caps and add back ONLY what's strictly required: the five
+##     per-UID-handoff caps (SETUID/SETGID/CHOWN/DAC_OVERRIDE/FOWNER —
+##     FOWNER lets root chmod a per-worker dir it has already chowned away
+##     to the worker UID) plus
 ##     NET_ADMIN for the iptables OUTPUT-OWNER drop on loopback that
 ##     closes the worker→worker exfil hole at the kernel layer (see
 ##     services/langy-agent/iptables.go). No SYS_*.
@@ -108,6 +110,14 @@ containerSecurityContext:
     # chown per-session dirs to a unique UID, write 0600 config blobs as
     # that UID, and spawn the OpenCode subprocess directly into it.
     #
+    # FOWNER is required because setupWorkerHome (services/langy-agent/worker.go)
+    # chowns the per-worker home to the worker UID and THEN chmods it 0700.
+    # Once the dir is owned by the worker UID, root (UID 0) can only chmod it
+    # with CAP_FOWNER — DAC_OVERRIDE does not cover the chmod ownership check.
+    # Without FOWNER every spawn dies with "chmod home: operation not
+    # permitted" (verified live on the dev gVisor node 2026-07-07). Not
+    # gVisor-specific: the same EPERM occurs on runc under drop-ALL.
+    #
     # NET_ADMIN was added on 2026-06-30 so the manager can install an
     # iptables OUTPUT rule at startup that drops loopback-TCP packets
     # from non-root UIDs to the locked opencode internal port range
@@ -120,7 +130,7 @@ containerSecurityContext:
     #
     # Any addition beyond this needs to be justified in the
     # SecurityContext header above.
-    add: ["CHOWN", "DAC_OVERRIDE", "SETUID", "SETGID", "NET_ADMIN"]
+    add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETUID", "SETGID", "NET_ADMIN"]
 
 # Sandboxed container runtime for this pod. The agent runs LLM-driven
 # arbitrary code (opencode workers shell out to git/npm/gh), so the headline


### PR DESCRIPTION
Two small, independent fixes that both block `langy-agent` from building or running — found while verifying Langy end-to-end under gVisor on the dev cluster (2026-07-07).

## 1. `chart`: add `CAP_FOWNER` (fixes #5458)
`setupWorkerHome` chowns the per-worker home to the worker UID, then chmods it `0700`. Once the dir is owned by a non-root UID, root can only `chmod` it with `CAP_FOWNER` — `DAC_OVERRIDE` doesn't cover the chmod ownership check. Without it, **every worker spawn dies** with `chmod home: operation not permitted` and Langy is non-functional. Verified live: adding `FOWNER` made spawn succeed and `opencode` ran. Not gVisor-specific; never caught because the pod has never run in real prod and unit tests run with full privileges.

## 2. `Dockerfile.langy_agent`: copy `sdk-go` before `go mod download` (fixes #5459)
`go.mod` has `replace github.com/langwatch/langwatch/sdk-go => ./sdk-go`, but the Dockerfile copied only `go.mod/go.sum` before `go mod download`, so a **cold build fails** to resolve the replace target. CI masks it via `cache-from: type=gha` serving a stale layer. Adds `COPY sdk-go ./sdk-go` before the download step. Verified: both langy-agent images built clean from cold.

## Verification
- FOWNER: patched the live dev deployment → worker spawned under gVisor, `opencode` ran, isolation held (401 on all unauthenticated paths), app `/api/langy/chat` returned 200 after a real turn.
- Dockerfile: cold `docker buildx build` of `Dockerfile.langy_agent` succeeded with the COPY added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated container permissions so worker home directories can be set up successfully in more restricted environments, reducing `operation not permitted` errors during startup.
  * Adjusted build caching behavior so dependency downloads refresh when SDK changes are made.

* **Documentation**
  * Clarified the required security capabilities for the manager pod and explained the permission requirements more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deployment Impact
- **Helm values:** `charts/langy-agent/values.yaml` adds `FOWNER` to `containerSecurityContext.capabilities.add`. This widens the langy-agent pod's Linux capability set by one cap (FOWNER) — required for worker spawn to succeed. No new env vars, no new secrets, no service/topology change. Operators who pin or template the capability list must include `FOWNER` or Langy worker spawn will fail with `chmod home: operation not permitted`.
- **Default helm install behavior:** the langy-agent pod (gated behind `release_langy_enabled`, default off) now spawns workers correctly under the drop-ALL securityContext. No change for installs that don't enable Langy.
- **Dockerfile:** `Dockerfile.langy_agent` now copies `sdk-go` before `go mod download` — a build-context fix only; no runtime or image-shape change. Enables cold (cacheless) builds of the langy-agent image.
- **BYOC dataplane:** no impact — no dataplane surface touched.
- **Env vars:** none added or changed.