### PR TITLE
fix(langy): keep model picker dropdown open when moving the mouse to it

### DIFF
--- a/langwatch/src/components/langy/Composer.tsx
+++ b/langwatch/src/components/langy/Composer.tsx
@@ -103,7 +103,17 @@ export function Composer({
           visibility={collapsedProviderIcon ? "visible" : "hidden"}
           aria-hidden={!collapsedProviderIcon}
           onMouseEnter={() => setPickerExpanded(true)}
-          onMouseLeave={collapsePicker}
+          // Mirror the onBlur portal guard below for the pointer path: the
+          // model dropdown's popover is portaled to <body>, a sibling of
+          // this wrapper, so moving the mouse from the pill toward the
+          // option list necessarily fires mouseleave here. Collapsing on
+          // that would close the dropdown the instant the user reaches for
+          // it. While the dropdown is open, leave collapse to onOpenChange
+          // (fires when it actually closes — option picked or click-away).
+          onMouseLeave={() => {
+            if (pickerDropdownOpen) return;
+            collapsePicker();
+          }}
           onFocus={() => setPickerExpanded(true)}
           // Mirror onFocus: collapse when focus moves OUT of the wrapper —
           // BUT not when focus is moving into the Select's own portaled
@@ -181,7 +191,15 @@ export function Composer({
                 mode="chat"
                 size="sm"
                 open={pickerDropdownOpen}
-                onOpenChange={setPickerDropdownOpen}
+                onOpenChange={(open) => {
+                  setPickerDropdownOpen(open);
+                  // When the dropdown closes (option picked or click-away),
+                  // collapse the pill too. The mouse is over the portaled
+                  // popover (outside this wrapper) at that point, so there's
+                  // no mouseleave here to retract it — without this it would
+                  // be left orphaned-expanded.
+                  if (!open) setPickerExpanded(false);
+                }}
               />
             </Box>
           </Box>


### PR DESCRIPTION
## Bug
In the Langy panel, the per-send **model picker** (bottom-right of the composer) can't be used with the mouse: open the dropdown, move the cursor toward the option list, and it **closes the instant you leave the pill** — so you can never actually click a model.

## Root cause
The picker pill expands on hover and collapses on `onMouseLeave={collapsePicker}` (`Composer.tsx`). The `ModelSelector`'s dropdown popover is **portaled to `<body>`** — a sibling of the picker wrapper, not a descendant. So moving the mouse from the pill toward the option list fires `mouseleave` on the wrapper → `collapsePicker()` → the dropdown closes.

The `onBlur` handler already solved this for the **keyboard/focus** path (it treats anything inside a `[data-scope="select"]` subtree as still-within-the-picker). The **pointer** path had no equivalent guard.

## Fix
Mirror the existing `onBlur` portal guard for the pointer path:
- `onMouseLeave`: **don't collapse while the dropdown is open** — let `onOpenChange` collapse it when it actually closes (option picked or click-away).
- `onOpenChange`: also collapse the pill on close, so it isn't left orphaned-expanded when the mouse is over the portaled popover.

Two-handler change in `Composer.tsx`; no API or prop changes.

## Verification
- The fix mirrors the already-shipped, working `onBlur` portal guard directly below it in the same file — same failure mode (portaled popover treated as "outside"), same remedy.
- ⚠️ **Not locally run:** I could not execute the frontend test suite / `pnpm typecheck` in my environment for this change (the worktree it was authored in has no `node_modules`, and the running app is a pre-built image), so I'm relying on CI to run typecheck + tests here. Flagging that explicitly rather than claiming a green local run.
- A live before/after (or a jsdom regression test asserting "mouseleave with the dropdown open keeps it open") is a good follow-up — happy to add either; see PR comment.

## Deployment Impact
None. Frontend-only behavior fix in a React component (`langwatch/src/components/langy/Composer.tsx`). No env vars, helm values, services, migrations, or dataplane surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the model picker’s open/close behavior so it no longer collapses unexpectedly while the dropdown is still open.
  * The picker now retracts properly after the dropdown closes, including after selecting an option or clicking away.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->