### PR TITLE
ci(release-please): author release PRs from a GitHub App, not a personal PAT

### DIFF
--- a/.github/workflows/release-please-chart-lock-sync.yml
+++ b/.github/workflows/release-please-chart-lock-sync.yml
@@ -14,10 +14,10 @@ name: release-please-chart-lock-sync
 #
 # This workflow watches release-please's umbrella PR, runs
 # `helm dependency update`, and pushes the regenerated Chart.lock back to the
-# PR branch so the lock stays meaningful end-to-end. We push with a PAT
-# (RELEASE_PLEASE_TOKEN — same one release-please-sdks.yml uses) so the new
-# commit re-triggers the chart CI; pushes authored by the default GITHUB_TOKEN
-# do NOT trigger downstream workflows.
+# PR branch so the lock stays meaningful end-to-end. We push with a token minted
+# from the release-please GitHub App (same App release-please-sdks.yml uses) so
+# the new commit re-triggers the chart CI; pushes authored by the default
+# GITHUB_TOKEN do NOT trigger downstream workflows.
 
 on:
   pull_request_target:
@@ -41,13 +41,30 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.head_ref, 'release-please--branches--main--components--langwatch')
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - name: Resolve App bot user id
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          user_id="$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)"
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
-          # PAT — pushes by GITHUB_TOKEN don't retrigger downstream workflows,
-          # so the chart CI would never re-validate against the fresh lock.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # App-installation token — pushes by GITHUB_TOKEN don't retrigger
+          # downstream workflows, so the chart CI would never re-validate
+          # against the fresh lock. The App token retriggers them and keeps
+          # the commit attributed to the App rather than a maintainer's PAT.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
@@ -70,8 +87,8 @@ jobs:
 
       - name: Commit + push if Chart.lock changed
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           if git diff --quiet -- charts/langwatch/Chart.lock; then
             echo "→ Chart.lock already in sync, nothing to push"
             exit 0

--- a/.github/workflows/release-please-sdks.yml
+++ b/.github/workflows/release-please-sdks.yml
@@ -17,10 +17,21 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # Mint a short-lived installation token for the release-please GitHub App
+      # so the release PRs (and their commits) are authored by the App's bot
+      # identity instead of a maintainer's personal PAT. App tokens are not the
+      # default GITHUB_TOKEN, so the PRs still trigger downstream CI.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - name: Release Please
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json


### PR DESCRIPTION
## What

Move release-please off a maintainer's **personal PAT** (`RELEASE_PLEASE_TOKEN`, tied to `@0xdeafcafe`) and onto a dedicated **GitHub App**, so release PRs are opened and authored by the App's bot identity instead of a person's account.

Both workflows that used the PAT are switched to mint a short-lived installation token via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token):

- **`release-please-sdks.yml`** — the App token is passed to the release-please action, so the release PRs it opens are authored by `<app>[bot]`.
- **`release-please-chart-lock-sync.yml`** — the App token is used for the `pull_request_target` checkout + push (its other use of the PAT), and the `Chart.lock` commit is attributed to the App bot instead of `github-actions[bot]`.

App-installation tokens are **not** the default `GITHUB_TOKEN`, so the release PRs (and the chart-lock push) still trigger downstream CI — the exact reason the PAT was used in the first place.

## ⚠️ Required before this can work (one-time, human setup)

I can't create the App or set secrets — a maintainer needs to:

1. **Create a GitHub App** (org-owned, e.g. `langwatch-release-bot`) with **Repository permissions**: `Contents: Read & write`, `Pull requests: Read & write`. No webhook needed.
2. **Install it** on the `langwatch/langwatch` repo.
3. Add two secrets (repo or org level):
   - `RELEASE_PLEASE_APP_ID` — the App's numeric App ID
   - `RELEASE_PLEASE_APP_PRIVATE_KEY` — a generated private key (full `.pem` contents)
4. After merge + first successful run, **retire `RELEASE_PLEASE_TOKEN`**.

Until the two secrets exist, the release-please workflows will fail at the token-mint step — so land the App setup and this PR together.

## Verification

- `node --experimental-strip-types .github/scripts/guard-pull-request-target.ts .` → **passed** (the `pull_request_target` chart-lock job keeps its same-repo safe gate).
- `node --test .github/scripts/guard-pull-request-target.test.ts` → **4/4 pass**.
- Both workflow YAMLs parse cleanly; `RELEASE_PLEASE_TOKEN` no longer appears in any workflow.
- Action pinned by full commit SHA (`v3.2.0`) per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
