### PR TITLE
fix(evaluations-legacy): pass resolved model to getEvaluatorDefaultSettings (#5468)

### DIFF
--- a/langwatch/src/server/routes/__tests__/evaluations-legacy-model-cascade.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/evaluations-legacy-model-cascade.unit.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression: the legacy evaluations REST route (POST /api/evaluations/...)
+ * used to call `getEvaluatorDefaultSettings(evaluatorDefinition)` WITHOUT the
+ * resolved-model argument, so every API-triggered evaluation fell through to
+ * the hardcoded global `DEFAULT_MODEL` and ignored the project's model cascade
+ * configuration (issue #5468).
+ *
+ * The fix threads `resolveEvaluatorSettingsDefaults(project.id)` — which wraps
+ * the same cascade resolver the UI and server-side create path use — into the
+ * settings-merge, so a project with a custom default model gets that model.
+ *
+ * These tests pin:
+ *  - AC#3/#4/#6: `resolveEvaluatorSettingsDefaults` returns the cascade model
+ *    for the correct project + the `evaluator.create_default` feature key.
+ *  - AC#2:       when the cascade has nothing configured (resolver -> null),
+ *    `getEvaluatorDefaultSettings` still falls back to `DEFAULT_MODEL`.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The route module imports prisma (db) and the app layer at load time; stub
+// the resolver so no DB is touched. `prisma` itself is only handed to the
+// resolver as `ctx.prisma`, which the mock ignores.
+const getResolvedDefaultForFeature = vi.fn();
+vi.mock("~/server/modelProviders/modelDefaults.read", () => ({
+  getResolvedDefaultForFeature: (...args: unknown[]) =>
+    getResolvedDefaultForFeature(...args),
+}));
+
+import { getEvaluatorDefaultSettings } from "~/server/evaluations/getEvaluator";
+import { DEFAULT_MODEL } from "~/utils/constants";
+import { resolveEvaluatorSettingsDefaults } from "../evaluations-legacy";
+
+// A minimal evaluator definition whose settings carry a `model` field — the
+// exact shape `getEvaluatorDefaultSettings` maps the resolved default onto.
+const evaluatorWithModel = {
+  name: "LLM Judge",
+  requiredFields: ["input", "output"],
+  optionalFields: [],
+  settings: {
+    model: { default: "openai/gpt-5" },
+    max_tokens: { default: 8192 },
+  },
+} as any;
+
+describe("resolveEvaluatorSettingsDefaults", () => {
+  beforeEach(() => {
+    getResolvedDefaultForFeature.mockReset();
+  });
+
+  describe("when the project has a custom default model configured", () => {
+    it("maps the cascade-resolved model into { defaultModel, embeddingsModel }", async () => {
+      getResolvedDefaultForFeature.mockImplementation(
+        async (_ctx: unknown, params: { featureKey: string }) => {
+          if (params.featureKey === "evaluator.create_default") {
+            return {
+              model: "openai/gpt-4o",
+              source: "feature_override",
+              scope: "project",
+            };
+          }
+          return {
+            model: "openai/text-embedding-3-large",
+            source: "feature_override",
+            scope: "project",
+          };
+        },
+      );
+
+      const resolved = await resolveEvaluatorSettingsDefaults("proj-1");
+
+      expect(resolved).toEqual({
+        defaultModel: "openai/gpt-4o",
+        embeddingsModel: "openai/text-embedding-3-large",
+      });
+    });
+
+    it("resolves for the given project id and the evaluator.create_default feature key (AC#3/#4)", async () => {
+      getResolvedDefaultForFeature.mockResolvedValue({
+        model: "anthropic/claude-3-5-sonnet",
+        source: "role_default",
+        scope: "team",
+      });
+
+      await resolveEvaluatorSettingsDefaults("proj-42");
+
+      expect(getResolvedDefaultForFeature).toHaveBeenCalledWith(
+        expect.anything(),
+        { projectId: "proj-42", featureKey: "evaluator.create_default" },
+      );
+      // Never called with an undefined project id (AC#4).
+      for (const call of getResolvedDefaultForFeature.mock.calls) {
+        expect(call[1].projectId).toBe("proj-42");
+      }
+    });
+
+    it("feeds getEvaluatorDefaultSettings the custom model, not DEFAULT_MODEL (AC#6)", async () => {
+      getResolvedDefaultForFeature.mockResolvedValue({
+        model: "openai/gpt-4o",
+        source: "feature_override",
+        scope: "project",
+      });
+
+      const resolved = await resolveEvaluatorSettingsDefaults("proj-1");
+      const settings = getEvaluatorDefaultSettings(
+        evaluatorWithModel,
+        resolved,
+      );
+
+      expect((settings as any).model).toBe("openai/gpt-4o");
+      expect((settings as any).model).not.toBe(DEFAULT_MODEL);
+    });
+  });
+
+  describe("when the project has no custom default configured (resolver returns null)", () => {
+    it("returns nulls so getEvaluatorDefaultSettings falls back to DEFAULT_MODEL (AC#2)", async () => {
+      getResolvedDefaultForFeature.mockResolvedValue(null);
+
+      const resolved = await resolveEvaluatorSettingsDefaults("proj-1");
+      expect(resolved).toEqual({ defaultModel: null, embeddingsModel: null });
+
+      const settings = getEvaluatorDefaultSettings(
+        evaluatorWithModel,
+        resolved,
+      );
+      expect((settings as any).model).toBe(DEFAULT_MODEL);
+    });
+  });
+});

--- a/langwatch/src/server/routes/evaluations-legacy.ts
+++ b/langwatch/src/server/routes/evaluations-legacy.ts
@@ -868,12 +868,13 @@ async function handleEvaluatorCall(
 
   let settings: any = ((evaluatorSettings ?? monitor?.parameters) as any) ?? {};
 
-  const resolved = await resolveEvaluatorSettingsDefaults(project.id);
-
   try {
     settings = evaluatorSettingSchema?.parse({
       ...(!workflowEvaluatorDef
-        ? getEvaluatorDefaultSettings(evaluatorDefinition as any, resolved)
+        ? getEvaluatorDefaultSettings(
+            evaluatorDefinition as any,
+            await resolveEvaluatorSettingsDefaults(project.id),
+          )
         : {}),
       ...(evaluatorSettings ?? (monitor ? (monitor.parameters as object) : {})),
       ...(params.settings ? params.settings : {}),

--- a/langwatch/src/server/routes/evaluations-legacy.ts
+++ b/langwatch/src/server/routes/evaluations-legacy.ts
@@ -74,6 +74,10 @@ import {
 } from "~/server/experiments/types";
 import { mapEsTargetsToTargets } from "~/server/experiments-v3/services/mappers";
 import { getPayloadSizeHistogram } from "~/server/metrics";
+import {
+  getResolvedDefaultForFeature,
+  type ReadCtx,
+} from "~/server/modelProviders/modelDefaults.read";
 import { evaluationNameAutoslug } from "~/server/tracer/collector/evaluationNameAutoslug";
 import { extractChunkTextualContent } from "~/server/tracer/collector/rag";
 import { rAGChunkSchema } from "~/server/tracer/types";
@@ -654,6 +658,44 @@ export const getEvaluatorIncludingCustom = async (
   return availableEvaluators[checkType];
 };
 
+/**
+ * Resolves the project's cascade-configured DEFAULT and EMBEDDINGS models
+ * into the `{ defaultModel, embeddingsModel }` shape that
+ * `getEvaluatorDefaultSettings` consumes for its `model` / `embeddings_model`
+ * fields.
+ *
+ * Without this, the legacy REST route fell through to the hardcoded global
+ * `DEFAULT_MODEL` (`getLatestOpenAIChatFlagship()`), bypassing the project's
+ * model cascade entirely for every API-triggered evaluation (issue #5468).
+ *
+ * The feature keys match the server-side evaluator-create path in
+ * `app/api/evaluators/.../app.v1.ts` (`evaluator.create_default` for the LLM
+ * model, `analytics.topic_clustering_embeddings` for the embeddings model).
+ * When the cascade has nothing configured at any scope, the resolver returns
+ * `null` and `getEvaluatorDefaultSettings` keeps the global fallback — no
+ * regression for projects without a custom default.
+ */
+export const resolveEvaluatorSettingsDefaults = async (
+  projectId: string,
+): Promise<{ defaultModel: string | null; embeddingsModel: string | null }> => {
+  const ctx: ReadCtx = { prisma, session: null };
+  const [resolvedDefault, resolvedEmbeddings] = await Promise.all([
+    getResolvedDefaultForFeature(ctx, {
+      projectId,
+      featureKey: "evaluator.create_default",
+    }),
+    getResolvedDefaultForFeature(ctx, {
+      projectId,
+      featureKey: "analytics.topic_clustering_embeddings",
+    }),
+  ]);
+
+  return {
+    defaultModel: resolvedDefault?.model ?? null,
+    embeddingsModel: resolvedEmbeddings?.model ?? null,
+  };
+};
+
 // --- Evaluator call handler (used by evaluations + guardrails routes) ---
 
 async function handleEvaluatorCall(
@@ -826,10 +868,12 @@ async function handleEvaluatorCall(
 
   let settings: any = ((evaluatorSettings ?? monitor?.parameters) as any) ?? {};
 
+  const resolved = await resolveEvaluatorSettingsDefaults(project.id);
+
   try {
     settings = evaluatorSettingSchema?.parse({
       ...(!workflowEvaluatorDef
-        ? getEvaluatorDefaultSettings(evaluatorDefinition as any)
+        ? getEvaluatorDefaultSettings(evaluatorDefinition as any, resolved)
         : {}),
       ...(evaluatorSettings ?? (monitor ? (monitor.parameters as object) : {})),
       ...(params.settings ? params.settings : {}),


### PR DESCRIPTION
## What

Fixes #5468.

The legacy evaluations route called `getEvaluatorDefaultSettings(evaluatorDefinition as any)` without a `resolved` model argument. When the arg is absent the function falls through to `DEFAULT_MODEL` (`getLatestOpenAIChatFlagship() ?? "openai/gpt-5"`), bypassing the project model cascade entirely.

## Why

Every external API caller (`/api/evaluations`, `/api/guardrails`) was silently getting evaluations run on the global flagship model, even if the project was configured with a different default. The three UI call sites (`CheckConfigForm`, `EvaluatorPropertiesPanel`, `EvaluatorEditorShared`) and the server-side evaluator-create path (`app/api/evaluators/.../app.v1.ts`) were already correct — the legacy REST route was the sole gap.

## How

After the project is loaded in `handleEvaluatorCall`, resolve the project's cascade-configured models and pass them as the second arg to `getEvaluatorDefaultSettings`. The resolution is lazy — `resolveEvaluatorSettingsDefaults(project.id)` is called only inside the `!workflowEvaluatorDef` branch where its result is consumed, so `custom/` evaluators and workflow-evaluator paths skip the two Prisma-backed queries entirely.

Extracted a small exported helper `resolveEvaluatorSettingsDefaults(projectId)` so the resolve+map logic is unit-testable without the Hono/prisma/auth harness.

## Deviations from the original issue sketch (deliberate)

The issue comment suggested `getResolvedDefaultForFeature(project.id, "evaluations")` returning a string. The **actual** contract is different, and following the sketch verbatim would have silently no-op'd:

1. **Signature:** `getResolvedDefaultForFeature(ctx: ReadCtx, { projectId, featureKey })` — takes a `{ prisma, session }` ctx + params object, returns `DefaultModelEffective | null` (an object with `.model`), not a bare string.
2. **Feature key:** there is **no `"evaluations"` key** in the feature registry — `featureByKey("evaluations")` returns `undefined`, so the resolver would return `null` and the fix would do nothing. The correct DEFAULT-role key for the evaluator model is **`evaluator.create_default`** (the same key `app.v1.ts` uses on evaluator create). Embeddings resolve via `analytics.topic_clustering_embeddings`, matching the UI.
3. **Second-arg shape:** `getEvaluatorDefaultSettings(evaluator, resolved?)` expects `{ defaultModel?, embeddingsModel? }`, so the resolved `.model` values are mapped into that shape.

## Human verification

1. Configure a project with a non-default model (e.g. `openai/gpt-4o` while global flagship is `openai/gpt-5`).
2. POST to `/api/evaluations` via the REST API.
3. Observe evaluator runs with the project's configured model, not `openai/gpt-5`.
4. Repeat with a project with no custom model — confirm it still uses `DEFAULT_MODEL` (no regression).

## How I can prove I was successful

**Fails-on-main signature (cascade-bypass case):** on `main`, no resolved arg is passed, so `getEvaluatorDefaultSettings` always returns `model: DEFAULT_MODEL` regardless of project config. The new test stubs `getResolvedDefaultForFeature` to return `"openai/gpt-4o"` and asserts the merged settings carry `openai/gpt-4o` (and `!== DEFAULT_MODEL`) — this passes on this branch and would fail on main. A companion test pins the no-config path (resolver → `null` → `DEFAULT_MODEL`) so there is no regression for projects without a custom default (AC#2).

```
# grep DEFAULT_MODEL in evaluations-legacy.ts — only the JSDoc mention, no code/fallback site:
668: * `DEFAULT_MODEL` (`getLatestOpenAIChatFlagship()`), bypassing the project's

# tsc (tsgo) — 0 errors in changed files; the 2 reported errors pre-exist on main (start.ts, vite.config.ts):
src/start.ts(47,7): error TS2769: No overload matches this call.
vite.config.ts(63,7): error TS2769: No overload matches this call.

# vitest — new cascade test + existing legacy coercion test:
 Test Files  2 passed (2)
      Tests  15 passed (15)
```

<!-- no-ui-surface -->

Backend-only — no UI surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection for legacy evaluation requests by resolving project-level defaults for both the default model and embeddings model.
  * Ensured correct fallback to standard default settings when no cascade configuration is available.
* **Tests**
  * Added unit tests for legacy evaluator default-resolution behavior, covering configured defaults and the unset/no-config fallback cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->