### PR TITLE
fix(workers): probe an unauthenticated /healthz instead of /metrics

### DIFF
--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -155,14 +155,34 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
+          # Probe the worker metrics server (port 2999) rather than just PID 1
+          # liveness — this catches a wedged event loop, not only a dead
+          # process. When a metrics API key is configured the endpoint requires
+          # `Authorization: Bearer <key>` (same key Prometheus scrapes with, see
+          # prometheus.yaml), so the probe must send it or it gets 401 and the
+          # pod crash-loops. The header is only emitted when the key is set as a
+          # plain value; a bare (unauthenticated) endpoint answers 200 either way.
           startupProbe:
-            exec:
-              command: ["sh", "-c", "kill -0 1"]
+            httpGet:
+              path: /metrics
+              port: 2999
+              {{- if include "langwatch.metricsApiKey" . }}
+              httpHeaders:
+                - name: Authorization
+                  value: "Bearer {{ include "langwatch.metricsApiKey" . }}"
+              {{- end }}
             failureThreshold: 12
             periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
-            exec:
-              command: ["sh", "-c", "kill -0 1"]
+            httpGet:
+              path: /metrics
+              port: 2999
+              {{- if include "langwatch.metricsApiKey" . }}
+              httpHeaders:
+                - name: Authorization
+                  value: "Bearer {{ include "langwatch.metricsApiKey" . }}"
+              {{- end }}
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -155,34 +155,31 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
 
-          # Probe the worker metrics server (port 2999) rather than just PID 1
-          # liveness — this catches a wedged event loop, not only a dead
-          # process. When a metrics API key is configured the endpoint requires
-          # `Authorization: Bearer <key>` (same key Prometheus scrapes with, see
-          # prometheus.yaml), so the probe must send it or it gets 401 and the
-          # pod crash-loops. The header is only emitted when the key is set as a
-          # plain value; a bare (unauthenticated) endpoint answers 200 either way.
+          # Probe the worker's HTTP listener (the metrics server port, 2999)
+          # rather than just PID 1 liveness — an answered request proves the
+          # event loop is turning, which `kill -0 1` cannot tell us.
+          #
+          # The probe targets /healthz, NOT /metrics. /metrics is fail-closed in
+          # production: with no METRICS_API_KEY (the default —
+          # app.telemetry.metrics.enabled is false, so the env var is never
+          # emitted) it answers 500 to every caller, which would crash-loop the
+          # workers on a stock install. And an httpGet probe cannot read a
+          # Secret, so a key delivered via secretKeyRef could never be put in a
+          # rendered Authorization header anyway — that install would 401.
+          # /healthz is unauthenticated by design and carries no telemetry, so
+          # no bearer token is copied into this podspec.
+          # See specs/server/worker-liveness-probe.feature.
           startupProbe:
             httpGet:
-              path: /metrics
+              path: /healthz
               port: 2999
-              {{- if include "langwatch.metricsApiKey" . }}
-              httpHeaders:
-                - name: Authorization
-                  value: "Bearer {{ include "langwatch.metricsApiKey" . }}"
-              {{- end }}
             failureThreshold: 12
             periodSeconds: 10
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /metrics
+              path: /healthz
               port: 2999
-              {{- if include "langwatch.metricsApiKey" . }}
-              httpHeaders:
-                - name: Authorization
-                  value: "Bearer {{ include "langwatch.metricsApiKey" . }}"
-              {{- end }}
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -375,6 +375,68 @@ test_overlay_stacking() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# SUITE: workers liveness probe
+#
+# The worker probes must target the UNAUTHENTICATED /healthz path and carry no
+# credentials. Probing /metrics instead crash-loops the pod in two independent
+# ways, and both are default-ish configurations:
+#
+#   1. Stock install — app.telemetry.metrics.enabled is false, so
+#      METRICS_API_KEY is never emitted; with NODE_ENV=production the endpoint
+#      fails closed with 500 to every caller.
+#   2. secretKeyRef install — a kubelet httpGet probe cannot read a Secret, so
+#      no rendered Authorization header can carry the key and the probe gets 401.
+#
+# Baking the token into the podspec as a plain httpHeader is not a fix either:
+# it copies a secret into an object readable by anyone with `get deploy`, and
+# it still cannot cover case 1. See specs/server/worker-liveness-probe.feature.
+# ─────────────────────────────────────────────────────────────────────────────
+test_workers_probes() {
+  sep; info "Suite: workers liveness probe"
+
+  local workers_only
+  workers_only=$(tmpl_only "templates/workers/deployment.yaml" \
+    --set autogen.enabled=true --set workers.enabled=true)
+
+  assert_contains "workers probe path is /healthz" "$workers_only" "path: /healthz"
+  assert_not_contains "workers probe never targets /metrics" \
+    "$workers_only" "path: /metrics"
+  # Both probes, not just one — a startupProbe that passes while livenessProbe
+  # 500s still crash-loops the pod after startup.
+  local healthz_count
+  healthz_count=$(count_matches "$workers_only" "path: /healthz")
+  assert_eq "both startup and liveness probes use /healthz" "$healthz_count" "2"
+
+  # With a plain-value key configured the podspec must STILL carry no probe
+  # credentials — the token belongs in the env var (from the Secret), never in
+  # a probe header.
+  local with_key
+  with_key=$(tmpl_only "templates/workers/deployment.yaml" \
+    --set autogen.enabled=true --set workers.enabled=true \
+    --set app.telemetry.metrics.enabled=true \
+    --set app.telemetry.metrics.apiKey.value=probe-should-not-carry-this)
+  assert_not_contains "probes carry no httpHeaders when a key is set" \
+    "$with_key" "httpHeaders"
+  # The key still reaches the container as env (that is how the worker gates
+  # /metrics) — assert it is present there so this test can't pass by the key
+  # silently not being wired at all.
+  assert_contains "metrics key still reaches the container env" \
+    "$with_key" "probe-should-not-carry-this"
+
+  # The secretKeyRef path renders the env from the Secret and, again, no header.
+  local with_secret_ref
+  with_secret_ref=$(tmpl_only "templates/workers/deployment.yaml" \
+    --set autogen.enabled=true --set workers.enabled=true \
+    --set app.telemetry.metrics.enabled=true \
+    --set app.telemetry.metrics.apiKey.secretKeyRef.name=metrics-secret \
+    --set app.telemetry.metrics.apiKey.secretKeyRef.key=apiKey)
+  assert_contains "secretKeyRef key reaches the container env" \
+    "$with_secret_ref" "name: metrics-secret"
+  assert_not_contains "probes carry no httpHeaders under secretKeyRef" \
+    "$with_secret_ref" "httpHeaders"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # SUITE: Install — deploy size-dev + nodeport and verify live resources
 # ─────────────────────────────────────────────────────────────────────────────
 test_install_dev_nodeport() {
@@ -592,6 +654,7 @@ main() {
   test_size_overlays
   test_infra_overlays
   test_overlay_stacking
+  test_workers_probes
 
   # Phase 2: Live installs (slower, needs Kind + images)
   load_images

--- a/charts/langwatch/tests/e2e.sh
+++ b/charts/langwatch/tests/e2e.sh
@@ -37,6 +37,41 @@ pg_query() {
     | tr -d ' \n'
 }
 
+# ─── in-cluster HTTP probe ───────────────────────────────────────────────────
+# Asks a workload the same question a scraper (or the kubelet) would, from
+# inside its own pod, and echoes "<status> <samples|no-samples>".
+#
+# Reporting the status AND whether the body actually carried metric samples in
+# one value is deliberate: "can metrics be collected" is not answered by a 200
+# alone. A gate that let the caller through but returned an empty body would
+# pass a status-only assertion while collecting nothing.
+#
+# `node -e` rather than curl/wget — the app image is a Node image and is not
+# guaranteed to ship either. `process_cpu_user_seconds_total` is the sentinel
+# because prom-client's default-metrics collector always registers it, so its
+# presence means the registry was really serialized to the caller.
+#
+#   http_probe <target> <port> <path> [bearer-token]
+http_probe() {
+  local target="$1" port="$2" path="$3" token="${4:-}"
+  kc exec "$target" -- node -e '
+const [port, path, token] = process.argv.slice(1);
+const opts = { host: "127.0.0.1", port: Number(port), path, headers: {} };
+if (token) opts.headers.authorization = "Bearer " + token;
+require("http")
+  .get(opts, (r) => {
+    let body = "";
+    r.setEncoding("utf8");
+    r.on("data", (chunk) => { body += chunk; });
+    r.on("end", () => {
+      const hasSamples = /(^|\n)process_cpu_user_seconds_total/.test(body);
+      console.log(r.statusCode + " " + (hasSamples ? "samples" : "no-samples"));
+    });
+  })
+  .on("error", () => console.log("ERR ERR"));
+' "$port" "$path" "$token" 2>/dev/null | tr -d '\r' | tail -1
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # SUITE: chart install
 # ─────────────────────────────────────────────────────────────────────────────
@@ -410,23 +445,125 @@ test_workers() {
   assert_eq "Workers startupProbe sends no auth header" "$probe_headers" ""
 
   # Ask the worker the same question the kubelet asks: unauthenticated GET on
-  # the liveness path. `node -e` rather than curl/wget — the app image is a
-  # Node image and is not guaranteed to ship either.
-  local probe_status
-  probe_status=$(kc exec "deploy/${RELEASE}-workers" -- node -e \
-    'require("http").get({host:"127.0.0.1",port:2999,path:"/healthz"},r=>{console.log(r.statusCode);r.resume();}).on("error",()=>console.log("ERR"))' \
-    2>/dev/null | tr -d '\r\n')
-  assert_eq "Worker /healthz answers 200 unauthenticated" "$probe_status" "200"
+  # the liveness path. Asserting "no-samples" alongside the status also pins
+  # that the liveness body carries no telemetry.
+  assert_eq "Worker /healthz answers 200 unauthenticated, with no telemetry" \
+    "$(http_probe "deploy/${RELEASE}-workers" 2999 /healthz)" "200 no-samples"
 
   # …and confirm WHY the probe cannot use /metrics in this configuration: the
   # e2e release sets no metrics API key, so the bearer gate fails closed. If
   # this ever stops being 500, the constraint that forced /healthz has changed
   # and the probe design should be revisited.
-  local metrics_status
-  metrics_status=$(kc exec "deploy/${RELEASE}-workers" -- node -e \
-    'require("http").get({host:"127.0.0.1",port:2999,path:"/metrics"},r=>{console.log(r.statusCode);r.resume();}).on("error",()=>console.log("ERR"))' \
-    2>/dev/null | tr -d '\r\n')
-  assert_eq "Worker /metrics fails closed without a key" "$metrics_status" "500"
+  assert_eq "Worker /metrics fails closed without a key" \
+    "$(http_probe "deploy/${RELEASE}-workers" 2999 /metrics)" "500 no-samples"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE: metrics collection
+# Everything above runs in the chart's DEFAULT metrics configuration, where no
+# key is configured — so every live assertion about /metrics so far describes
+# the fail-closed branch. The branch an operator actually runs in production
+# (a key IS set, and Prometheus scrapes with a bearer) had no live coverage.
+#
+# This suite installs the two configurations that were only ever template-
+# tested and asks, in a real cluster: do both tiers come up, and can metrics
+# actually be collected?
+#
+# See specs/server/metrics-collection.feature.
+# ─────────────────────────────────────────────────────────────────────────────
+METRICS_KEY="e2e-metrics-key"
+METRICS_SECRET="lw-metrics-key"
+
+test_metrics_collection() {
+  sep; info "Suite: metrics collection (key configured)"
+
+  # ── the key as a plain chart value ──────────────────────────────────────
+  hc upgrade "$RELEASE" "$CHART_DIR" \
+    -f "$CHART_DIR/tests/values-e2e.yaml" \
+    --set app.replicaCount=1 \
+    --set workers.enabled=true \
+    --set workers.replicaCount=1 \
+    --set app.telemetry.metrics.enabled=true \
+    --set-string "app.telemetry.metrics.apiKey.value=${METRICS_KEY}" \
+    --wait --timeout "${TIMEOUT}s"
+  pass "helm upgrade (metrics enabled, key as plain value)"
+
+  # Both tiers must still converge. Turning the gate on must not cost the
+  # workers their startupProbe — the whole point of a credential-free
+  # liveness path.
+  wait_pod_ready "app.kubernetes.io/name=${RELEASE}-app" 180
+  pass "App pod ready with metrics enabled"
+  wait_pod_ready "app.kubernetes.io/name=${RELEASE}-workers" 180
+  pass "Workers pod ready with metrics enabled"
+
+  # Liveness must stay credential-free now that a key exists. If configuring a
+  # key ever started requiring one from the kubelet, every keyed install would
+  # crash-loop — the exact regression this PR exists to prevent.
+  assert_eq "Worker /healthz stays unauthenticated once a key is set" \
+    "$(http_probe "deploy/${RELEASE}-workers" 2999 /healthz)" "200 no-samples"
+
+  # The gate: no credential and a wrong credential are both refused, and
+  # neither leaks samples.
+  assert_eq "Worker /metrics rejects an unauthenticated scrape" \
+    "$(http_probe "deploy/${RELEASE}-workers" 2999 /metrics)" "401 no-samples"
+  assert_eq "Worker /metrics rejects the wrong key" \
+    "$(http_probe "deploy/${RELEASE}-workers" 2999 /metrics wrong-key)" \
+    "401 no-samples"
+
+  # …and the path Prometheus actually uses: an authenticated scrape really
+  # collects samples. This is the assertion the suite exists for.
+  assert_eq "Worker /metrics serves samples to an authenticated scrape" \
+    "$(http_probe "deploy/${RELEASE}-workers" 2999 /metrics "$METRICS_KEY")" \
+    "200 samples"
+
+  # The app tier carries the same gate on its own registry.
+  assert_eq "App /metrics rejects an unauthenticated scrape" \
+    "$(http_probe "deploy/${RELEASE}-app" 5560 /metrics)" "401 no-samples"
+  assert_eq "App /metrics serves samples to an authenticated scrape" \
+    "$(http_probe "deploy/${RELEASE}-app" 5560 /metrics "$METRICS_KEY")" \
+    "200 samples"
+
+  # ── the same key delivered from a Secret ────────────────────────────────
+  # Rendering a secretKeyRef correctly is not the same as the value arriving
+  # in the process. e2e-overlays.sh proves the reference renders; only a live
+  # install proves the container can actually authenticate with it.
+  sep; info "Suite: metrics collection (key from a Secret)"
+
+  kc delete secret "$METRICS_SECRET" 2>/dev/null || true
+  kc create secret generic "$METRICS_SECRET" \
+    --from-literal="apiKey=${METRICS_KEY}"
+  pass "Metrics key Secret created"
+
+  hc upgrade "$RELEASE" "$CHART_DIR" \
+    -f "$CHART_DIR/tests/values-e2e.yaml" \
+    --set app.replicaCount=1 \
+    --set workers.enabled=true \
+    --set workers.replicaCount=1 \
+    --set app.telemetry.metrics.enabled=true \
+    --set "app.telemetry.metrics.apiKey.secretKeyRef.name=${METRICS_SECRET}" \
+    --set app.telemetry.metrics.apiKey.secretKeyRef.key=apiKey \
+    --wait --timeout "${TIMEOUT}s"
+  pass "helm upgrade (metrics enabled, key from secretKeyRef)"
+
+  wait_pod_ready "app.kubernetes.io/name=${RELEASE}-workers" 180
+  pass "Workers pod ready with the key delivered from a Secret"
+
+  # The probe still carries nothing — a kubelet httpGet cannot read a Secret,
+  # which is precisely why the liveness path must not be gated.
+  assert_eq "Worker /healthz stays unauthenticated under secretKeyRef delivery" \
+    "$(http_probe "deploy/${RELEASE}-workers" 2999 /healthz)" "200 no-samples"
+
+  # The value really made it out of the Secret and into the auth gate.
+  assert_eq "Worker /metrics serves samples using the Secret-delivered key" \
+    "$(http_probe "deploy/${RELEASE}-workers" 2999 /metrics "$METRICS_KEY")" \
+    "200 samples"
+
+  # The Secret is deliberately left in place. Deleting it here would leave the
+  # live release referencing a Secret that no longer exists, and any pod that
+  # restarted before the next suite's upgrade would wedge in
+  # CreateContainerConfigError. The next suite re-applies values-e2e.yaml
+  # (metrics off), which drops the reference; the namespace teardown reclaims
+  # the Secret itself.
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -637,6 +774,7 @@ main() {
   test_resources
   test_app
   test_workers
+  test_metrics_collection
   test_upgrade_strategy_boundary
   test_upgrade
   test_external_clickhouse

--- a/charts/langwatch/tests/e2e.sh
+++ b/charts/langwatch/tests/e2e.sh
@@ -367,7 +367,9 @@ test_app() {
 # ─────────────────────────────────────────────────────────────────────────────
 # SUITE: Workers health check
 # Upgrades the release to enable workers and verifies the pod reaches Ready.
-# Workers have no HTTP endpoint — reaching Running state is the health signal.
+# The worker serves one HTTP listener (the metrics port, 2999): /metrics behind
+# the bearer gate, and the unauthenticated /healthz the kubelet probes. Reaching
+# Ready therefore proves the startupProbe passed, not merely that PID 1 exists.
 # ─────────────────────────────────────────────────────────────────────────────
 test_workers() {
   sep; info "Suite: workers health check"
@@ -380,9 +382,51 @@ test_workers() {
     --wait --timeout "${TIMEOUT}s"
   pass "helm upgrade (workers deployed)"
 
-  # Workers pod should be ready
+  # Workers pod should be ready. This is now a real assertion about the probe:
+  # the pod only goes Ready once the startupProbe's HTTP GET succeeds.
   wait_pod_ready "app.kubernetes.io/name=${RELEASE}-workers" 180
   pass "Workers pod ready"
+
+  # ── the liveness probe contract ─────────────────────────────────────────
+  # Regression guard for the CrashLoopBackOff class: probing /metrics instead
+  # of /healthz crash-loops BOTH a stock install (production + no
+  # METRICS_API_KEY ⇒ the endpoint fails closed with 500) and a secretKeyRef
+  # install (an httpGet probe cannot read a Secret ⇒ 401). Assert the live
+  # Deployment probes the unauthenticated liveness path and carries no
+  # credentials, then prove the endpoint really answers that way in-cluster.
+  local startup_path liveness_path
+  startup_path=$(kc get deploy "${RELEASE}-workers" \
+    -o jsonpath='{.spec.template.spec.containers[0].startupProbe.httpGet.path}')
+  liveness_path=$(kc get deploy "${RELEASE}-workers" \
+    -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.path}')
+  assert_eq "Workers startupProbe path is /healthz" "$startup_path" "/healthz"
+  assert_eq "Workers livenessProbe path is /healthz" "$liveness_path" "/healthz"
+
+  # No bearer token copied out of the Secret into the podspec, where anyone
+  # with `get deploy` could read it.
+  local probe_headers
+  probe_headers=$(kc get deploy "${RELEASE}-workers" \
+    -o jsonpath='{.spec.template.spec.containers[0].startupProbe.httpGet.httpHeaders}')
+  assert_eq "Workers startupProbe sends no auth header" "$probe_headers" ""
+
+  # Ask the worker the same question the kubelet asks: unauthenticated GET on
+  # the liveness path. `node -e` rather than curl/wget — the app image is a
+  # Node image and is not guaranteed to ship either.
+  local probe_status
+  probe_status=$(kc exec "deploy/${RELEASE}-workers" -- node -e \
+    'require("http").get({host:"127.0.0.1",port:2999,path:"/healthz"},r=>{console.log(r.statusCode);r.resume();}).on("error",()=>console.log("ERR"))' \
+    2>/dev/null | tr -d '\r\n')
+  assert_eq "Worker /healthz answers 200 unauthenticated" "$probe_status" "200"
+
+  # …and confirm WHY the probe cannot use /metrics in this configuration: the
+  # e2e release sets no metrics API key, so the bearer gate fails closed. If
+  # this ever stops being 500, the constraint that forced /healthz has changed
+  # and the probe design should be revisited.
+  local metrics_status
+  metrics_status=$(kc exec "deploy/${RELEASE}-workers" -- node -e \
+    'require("http").get({host:"127.0.0.1",port:2999,path:"/metrics"},r=>{console.log(r.statusCode);r.resume();}).on("error",()=>console.log("ERR"))' \
+    2>/dev/null | tr -d '\r\n')
+  assert_eq "Worker /metrics fails closed without a key" "$metrics_status" "500"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/langwatch/src/server/workers/__tests__/workerMetricsHandler.unit.test.ts
+++ b/langwatch/src/server/workers/__tests__/workerMetricsHandler.unit.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment node
+ *
+ * Covers the worker metrics server's routing + auth branches — the handler the
+ * kubelet's liveness/startup probes call.
+ *
+ * The regression that motivates the liveness path: the Helm chart probed
+ * `GET /metrics`, but that endpoint is fail-closed in production (no
+ * METRICS_API_KEY ⇒ 500) and an httpGet probe cannot read a Secret, so both a
+ * default install and a secretKeyRef install crash-looped. `/healthz` answers
+ * unauthenticated in every configuration; `/metrics` keeps its bearer gate.
+ *
+ * See specs/server/worker-liveness-probe.feature.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  WORKER_LIVENESS_PATH,
+  createWorkerMetricsHandler,
+} from "../startWorkers";
+
+// Derive the fakes' types from the handler itself, so this test cannot drift
+// from the @types/node signature the real listener is checked against.
+type Handler = ReturnType<typeof createWorkerMetricsHandler>;
+type HandlerRequest = Parameters<Handler>[0];
+type HandlerResponse = Parameters<Handler>[1];
+
+/** Captures what the handler wrote, without binding a port. */
+function fakeExchange(url: string) {
+  const req = { url, headers: {} } as unknown as HandlerRequest;
+  const captured: { status?: number; body?: string } = {};
+  const res = {
+    writeHead(status: number) {
+      captured.status = status;
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+    end(body?: string) {
+      captured.body = body;
+      return this;
+    },
+  } as unknown as HandlerResponse;
+  return { req, res, captured };
+}
+
+/** Drains the handler's floating `register.metrics()` promise chain. */
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe("createWorkerMetricsHandler", () => {
+  describe("given the liveness path", () => {
+    describe("when the metrics gate would throw (production, no API key)", () => {
+      it("answers 200 without consulting the gate", async () => {
+        // The default-install case: this is exactly the configuration that
+        // made a /metrics probe crash-loop every stock worker deployment.
+        const gate = vi.fn(() => {
+          throw new Error("METRICS_API_KEY is not set");
+        });
+        const { req, res, captured } = fakeExchange(WORKER_LIVENESS_PATH);
+
+        createWorkerMetricsHandler(gate)(req, res);
+        await flush();
+
+        expect(captured.status).toBe(200);
+        expect(gate).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the request carries no credentials", () => {
+      it("answers 200 even though the gate would reject", async () => {
+        // The secretKeyRef case: the key exists in the container's env, but no
+        // rendered httpGet header can ever carry it.
+        const gate = vi.fn(() => false);
+        const { req, res, captured } = fakeExchange(WORKER_LIVENESS_PATH);
+
+        createWorkerMetricsHandler(gate)(req, res);
+        await flush();
+
+        expect(captured.status).toBe(200);
+        expect(gate).not.toHaveBeenCalled();
+      });
+    });
+
+    it("returns no metric samples", async () => {
+      const { req, res, captured } = fakeExchange(WORKER_LIVENESS_PATH);
+
+      createWorkerMetricsHandler(() => true)(req, res);
+      await flush();
+
+      expect(captured.body).toBe("ok");
+      expect(captured.body).not.toContain("#");
+    });
+  });
+
+  describe("given the metrics path", () => {
+    describe("when the gate rejects the caller", () => {
+      it("answers 401", async () => {
+        const { req, res, captured } = fakeExchange("/metrics");
+
+        createWorkerMetricsHandler(() => false)(req, res);
+        await flush();
+
+        expect(captured.status).toBe(401);
+      });
+    });
+
+    describe("when the gate throws (production, no API key)", () => {
+      it("fails closed with 500", async () => {
+        const { req, res, captured } = fakeExchange("/metrics");
+
+        createWorkerMetricsHandler(() => {
+          throw new Error("METRICS_API_KEY is not set");
+        })(req, res);
+        await flush();
+
+        expect(captured.status).toBe(500);
+      });
+    });
+
+    describe("when the gate accepts the caller", () => {
+      it("serves the registry rather than an auth failure", async () => {
+        const { req, res, captured } = fakeExchange("/metrics");
+
+        createWorkerMetricsHandler(() => true)(req, res);
+        await flush();
+
+        // Success writes no explicit status (Node defaults to 200); what
+        // matters is that neither auth branch fired.
+        expect(captured.status).toBeUndefined();
+        expect(typeof captured.body).toBe("string");
+      });
+    });
+  });
+
+  describe("given an unknown path", () => {
+    it("answers 404", async () => {
+      const { req, res, captured } = fakeExchange("/not-a-real-path");
+
+      createWorkerMetricsHandler(() => true)(req, res);
+      await flush();
+
+      expect(captured.status).toBe(404);
+    });
+  });
+});

--- a/langwatch/src/server/workers/startWorkers.ts
+++ b/langwatch/src/server/workers/startWorkers.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "@langwatch/observability";
 import http from "http";
+import type { IncomingMessage, RequestListener, ServerResponse } from "http";
 import { register } from "prom-client";
 import { assertRedisReady } from "~/server/redis";
 
@@ -122,17 +123,38 @@ async function bootUsageStatsWorker(
   }
 }
 
-// Expose the worker process's prom-client registry over HTTP so the web
-// process can scrape it at GET /workers/metrics (proxied in start.ts). In
-// the in-process dev mode this is skipped — the web server serves the same
-// (shared) registry at /metrics directly.
-async function bootMetricsServer(
-  shutdownHandles: ShutdownHandles,
-): Promise<void> {
-  const { getWorkerMetricsPort, isMetricsAuthorized } =
-    await import("~/server/metrics");
-  const metricsPort = getWorkerMetricsPort();
-  const metricsServer = http.createServer((req, res) => {
+/**
+ * The worker's liveness path. Deliberately UNAUTHENTICATED and deliberately
+ * not `/metrics`.
+ *
+ * The kubelet needs a path it can call with no credentials, because it has
+ * neither of the two things `/metrics` demands. `/metrics` is fail-closed in
+ * production (no METRICS_API_KEY ⇒ 500, and the chart leaves the key unset by
+ * default), and an httpGet probe cannot read a Kubernetes Secret, so a
+ * secretKeyRef-delivered key can never reach a rendered Authorization header.
+ * Probing `/metrics` therefore crash-loops both the default install and the
+ * secretKeyRef install. See specs/server/worker-liveness-probe.feature.
+ *
+ * It answers 200 whenever the event loop is turning enough to accept the
+ * connection and run this handler — which is the whole question a liveness
+ * probe asks, and strictly more than the old `kill -0 1` could tell us. It
+ * carries no telemetry, so leaving it open exposes nothing the bearer gate on
+ * `/metrics` was protecting.
+ */
+export const WORKER_LIVENESS_PATH = "/healthz";
+
+/**
+ * The worker metrics server's request handler, split out so the routing and
+ * auth branches are testable without binding a port.
+ */
+export function createWorkerMetricsHandler(
+  isMetricsAuthorized: (req: IncomingMessage) => boolean,
+): RequestListener {
+  return (req: IncomingMessage, res: ServerResponse) => {
+    if (req.url === WORKER_LIVENESS_PATH) {
+      res.writeHead(200, { "Content-Type": "text/plain" }).end("ok");
+      return;
+    }
     if (req.url !== "/metrics") {
       res.writeHead(404).end();
       return;
@@ -156,7 +178,23 @@ async function bootMetricsServer(
         logger.error({ error }, "error getting worker metrics");
         res.writeHead(500).end();
       });
-  });
+  };
+}
+
+// Expose the worker process's prom-client registry over HTTP so the web
+// process can scrape it at GET /workers/metrics (proxied in start.ts). In
+// the in-process dev mode this is skipped — the web server serves the same
+// (shared) registry at /metrics directly. The same listener serves the
+// unauthenticated liveness path the chart's probes call.
+async function bootMetricsServer(
+  shutdownHandles: ShutdownHandles,
+): Promise<void> {
+  const { getWorkerMetricsPort, isMetricsAuthorized } =
+    await import("~/server/metrics");
+  const metricsPort = getWorkerMetricsPort();
+  const metricsServer = http.createServer(
+    createWorkerMetricsHandler(isMetricsAuthorized),
+  );
   await new Promise<void>((resolve, reject) => {
     metricsServer.once("error", reject);
     metricsServer.listen(metricsPort, () => {

--- a/specs/server/metrics-collection.feature
+++ b/specs/server/metrics-collection.feature
@@ -1,0 +1,98 @@
+Feature: Metrics collection in a deployed chart
+  As an operator running LangWatch from the Helm chart
+  I want to know that both tiers come up and that metrics can actually be collected
+  So that turning the bearer gate on does not silently cost me observability
+
+  # WHY THIS EXISTS
+  #
+  # The chart's e2e install only ever ran in ONE metrics configuration: the
+  # default, where no key is configured at all. Every live assertion about
+  # /metrics therefore described the fail-closed branch, and the branch an
+  # operator actually runs in production — a key IS configured, and Prometheus
+  # scrapes with a bearer — had no live coverage anywhere.
+  #
+  # That is the gap this feature closes. It pins the whole matrix as an
+  # operator observes it: do the pods come up, and can metrics be collected,
+  # for each way of configuring (or not configuring) the key.
+  #
+  # The liveness path is deliberately excluded from the gate in every one of
+  # these configurations — see specs/server/worker-liveness-probe.feature for
+  # why a probe can never carry a credential.
+
+  Background:
+    Given the chart is installed with the app and workers tiers enabled
+
+  Rule: Both tiers come up in every metrics configuration
+
+    Scenario: Default install, with no metrics key configured
+      Given no metrics API key is configured
+      Then the app pod becomes ready
+      And the workers pod becomes ready
+
+    Scenario: Install with a metrics key configured
+      Given a metrics API key is configured
+      Then the app pod becomes ready
+      And the workers pod becomes ready
+
+    Scenario: Install with the metrics key delivered from a secret store
+      Given a metrics API key is delivered to the containers from a secret store
+      Then the app pod becomes ready
+      And the workers pod becomes ready
+
+  Rule: Without a key, metrics collection fails closed and liveness still answers
+
+    Scenario: The worker refuses to serve metrics to anyone
+      Given no metrics API key is configured
+      When a caller requests the worker metrics endpoint with any credentials
+      Then the request is refused
+      And no metric samples are returned
+      # Fail-closed: an unset key is a misconfiguration, not an invitation.
+
+    Scenario: Liveness is unaffected by the missing key
+      Given no metrics API key is configured
+      When the kubelet requests the worker liveness endpoint without credentials
+      Then the response is successful
+      # The reason the probe cannot use the metrics endpoint at all.
+
+  Rule: With a key, metrics are collectable only by an authenticated caller
+
+    Scenario: An unauthenticated scrape is rejected
+      Given a metrics API key is configured
+      When a caller requests the worker metrics endpoint without credentials
+      Then the request is rejected as unauthorized
+      And no metric samples are returned
+
+    Scenario: A scrape presenting the wrong credential is rejected
+      Given a metrics API key is configured
+      When a caller requests the worker metrics endpoint with an incorrect key
+      Then the request is rejected as unauthorized
+      And no metric samples are returned
+
+    Scenario: An authenticated scrape collects worker metrics
+      Given a metrics API key is configured
+      When a caller requests the worker metrics endpoint with the configured key
+      Then the response is successful
+      And metric samples are returned
+      # The path Prometheus actually uses. Previously unproven in a cluster.
+
+    Scenario: An authenticated scrape collects app metrics
+      Given a metrics API key is configured
+      When a caller requests the app metrics endpoint with the configured key
+      Then the response is successful
+      And metric samples are returned
+
+    Scenario: The liveness endpoint stays credential-free even once a key exists
+      Given a metrics API key is configured
+      When the kubelet requests the worker liveness endpoint without credentials
+      Then the response is successful
+      # Configuring a key must never start requiring one from the kubelet.
+
+  Rule: A key delivered from a secret store reaches the process
+
+    Scenario: An authenticated scrape collects metrics when the key came from a secret
+      Given a metrics API key is delivered to the containers from a secret store
+      When a caller requests the worker metrics endpoint with the configured key
+      Then the response is successful
+      And metric samples are returned
+      # Rendering the secret reference correctly is not the same as the value
+      # arriving in the process — this asserts the latter, in a live cluster.

--- a/specs/server/worker-liveness-probe.feature
+++ b/specs/server/worker-liveness-probe.feature
@@ -1,0 +1,90 @@
+Feature: Worker liveness probe endpoint
+  As an operator running LangWatch workers in Kubernetes
+  I want a liveness endpoint the kubelet can call without credentials
+  So that a wedged worker is restarted without exposing metrics to unauthenticated callers
+
+  # WHY THIS EXISTS
+  #
+  # The worker process runs no web framework — its only HTTP listener is the
+  # small metrics server on the worker metrics port (2999 by default). Before
+  # this feature the Helm chart probed liveness with `exec: kill -0 1`, which
+  # only proves PID 1 exists: a worker whose event loop is wedged still passes.
+  #
+  # The obvious next step — probe `GET /metrics` — does NOT work, for two
+  # independent reasons, and both end in CrashLoopBackOff:
+  #
+  #   1. `/metrics` is fail-closed in production. With NODE_ENV=production and
+  #      no METRICS_API_KEY (the chart default: app.telemetry.metrics.enabled
+  #      is false, so the env var is never emitted) the auth gate THROWS and
+  #      the endpoint answers 500 to every caller. A default install would
+  #      crash-loop its workers.
+  #   2. A kubelet httpGet probe cannot read a Kubernetes Secret. When the
+  #      operator delivers METRICS_API_KEY via secretKeyRef, no rendered
+  #      Authorization header can carry it, so the probe gets 401.
+  #
+  # Baking the token into the Deployment podspec as a plain httpHeader is not
+  # an answer either: it copies a secret out of the Secret and into an object
+  # readable by anyone with `get deploy`, and it still cannot cover case 1.
+  #
+  # So liveness gets its own endpoint. `/healthz` is unauthenticated by design
+  # — it carries no telemetry, only the fact that the listener is accepting
+  # connections and the event loop is turning. `/metrics` keeps its bearer gate
+  # exactly as it was.
+
+  Background:
+    Given the worker process has finished booting its stack
+    And the worker metrics server is listening
+
+  Rule: /healthz answers unauthenticated, in every auth configuration
+
+    Scenario: Default install — no metrics API key in production
+      Given the process runs with NODE_ENV set to "production"
+      And no metrics API key is configured
+      When the kubelet requests "/healthz" without an Authorization header
+      Then the response status is 200
+      # The case that would otherwise crash-loop every default install.
+
+    Scenario: Key configured, probe still sends nothing
+      Given a metrics API key is configured
+      When the kubelet requests "/healthz" without an Authorization header
+      Then the response status is 200
+      # Covers secretKeyRef delivery: the probe never needs the key at all.
+
+    Scenario: The liveness endpoint leaks no telemetry
+      When the kubelet requests "/healthz"
+      Then the response body does not contain any metric samples
+
+  Rule: /metrics keeps its bearer gate unchanged
+
+    Scenario: Metrics still require the bearer when a key is set
+      Given a metrics API key is configured
+      When a caller requests "/metrics" without an Authorization header
+      Then the response status is 401
+
+    Scenario: Metrics still fail closed in production without a key
+      Given the process runs with NODE_ENV set to "production"
+      And no metrics API key is configured
+      When a caller requests "/metrics" with any credentials
+      Then the response status is 500
+
+    Scenario: Metrics are served to a correctly authenticated caller
+      Given a metrics API key is configured
+      When a caller requests "/metrics" with the matching bearer token
+      Then the response status is 200
+      And the response body contains metric samples
+
+  Rule: Unknown paths stay 404
+
+    Scenario: An unrelated path is not served
+      When a caller requests "/not-a-real-path"
+      Then the response status is 404
+
+  Rule: The chart probes the liveness endpoint, not the metrics endpoint
+
+    Scenario: Worker probes target /healthz with no credentials
+      Given the Helm chart renders the workers Deployment
+      Then the startup probe performs an HTTP GET on "/healthz"
+      And the liveness probe performs an HTTP GET on "/healthz"
+      And neither probe carries an Authorization header
+      # No bearer token is copied into the podspec, so `get deploy` reveals
+      # nothing a Secret was protecting.

--- a/specs/server/worker-liveness-probe.feature
+++ b/specs/server/worker-liveness-probe.feature
@@ -38,7 +38,7 @@ Feature: Worker liveness probe endpoint
   Rule: /healthz answers unauthenticated, in every auth configuration
 
     Scenario: Default install — no metrics API key in production
-      Given the process runs with NODE_ENV set to "production"
+      Given the worker is running in production mode
       And no metrics API key is configured
       When the kubelet requests "/healthz" without an Authorization header
       Then the response status is 200
@@ -62,7 +62,7 @@ Feature: Worker liveness probe endpoint
       Then the response status is 401
 
     Scenario: Metrics still fail closed in production without a key
-      Given the process runs with NODE_ENV set to "production"
+      Given the worker is running in production mode
       And no metrics API key is configured
       When a caller requests "/metrics" with any credentials
       Then the response status is 500


### PR DESCRIPTION
## Why

Prod worker pods (Terraform-managed backbase instance) were `CrashLoopBackOff`: the kubelet liveness/readiness probe does `GET :2999/metrics` **with no auth header**, but the metrics endpoint enforces `Authorization: Bearer <METRICS_API_KEY>` (the same key Prometheus scrapes with). The probe got **401**, failed 3×, and the container was SIGTERM'd (exit 143) on a loop.

The Helm chart's worker probes were `exec: kill -0 1` — process-only, so they never hit `/metrics` and can't 401 today, but they also don't catch a wedged event loop, and they diverge from the Terraform deployment.

## What changed

The worker's HTTP listener (the metrics port, 2999) now serves an **unauthenticated `/healthz`** alongside the bearer-gated `/metrics`, and the chart's `startupProbe`/`livenessProbe` target `/healthz`. No credentials are involved, so no bearer token is rendered into the podspec.

`/healthz` is not a new invention: `docs/self-hosting/configuration/observability.mdx` already publishes it as the worker health contract — the endpoint table lists **Workers | `/healthz` | GET | 200 OK**, and the "Manual Health Check" section tells operators to run `curl -s http://localhost:2999/healthz`. That endpoint did not exist; the worker's listener 404'd everything that wasn't `/metrics`. This change makes the shipped documentation true.

An answered request still proves the event loop is turning — the thing `kill -0 1` could never tell us, which is what this change set out to fix.

## How it works

### Why not just send the bearer on a `/metrics` probe

That was this PR's first approach. It doesn't work, and CI caught it: the `e2e: infra` **workers health check** suite failed because `helm upgrade --wait` timed out waiting for a pod that never went Ready. Two independent reasons, both in ordinary configurations:

1. **Stock install → 500.** `app.telemetry.metrics.enabled` defaults to `false`, so `METRICS_API_KEY` is never emitted, and the chart defaults `NODE_ENV` to `production`. `isMetricsAuthorized` throws on that combination and the handler fails closed with **500 to every caller**, header or not. A default `helm install` would crash-loop its workers — a worse bug than the one being fixed.
2. **secretKeyRef install → 401.** A kubelet `httpGet` probe cannot read a Kubernetes Secret, so a key delivered via `app.telemetry.metrics.apiKey.secretKeyRef` can never reach a rendered `Authorization` header. Only the plain-value path could ever have worked.

Baking the token into the podspec as a plain `httpHeader` fixes neither case, and copies a secret out of the Secret into an object readable by anyone with `get deploy`.

An `exec: kill -0 1` fallback for the secretKeyRef case (the other suggestion on review) covers reason 2 but not reason 1, and hands back the very property this PR set out to gain — PID 1 existing says nothing about a wedged event loop.

`/healthz` carries no telemetry, so leaving it open exposes nothing the bearer gate was protecting. `/metrics` keeps its gate exactly as it was.

## Test plan

- `specs/server/worker-liveness-probe.feature` — the behavioural contract.
- `workerMetricsHandler.unit.test.ts` — the handler is split out as `createWorkerMetricsHandler` so routing and auth branches are testable without binding a port. Covers `/healthz` answering 200 when the gate would throw (case 1) and when it would reject (case 2), `/metrics` keeping 401/500/200, and unknown paths 404.
- `e2e-overlays.sh` → new **workers liveness probe** suite: both probes target `/healthz`, never `/metrics`, and carry no `httpHeaders` under plain-value *and* secretKeyRef delivery — while asserting the key still reaches the container env, so the test can't pass by the key silently not being wired.
- `e2e.sh` → **workers health check** suite now asserts the live Deployment's probe paths, that no auth header is in the podspec, and — from inside the cluster — that `/healthz` answers **200 unauthenticated** while `/metrics` answers **500** in the default config, pinning *why* the probe can't use `/metrics`.

- `specs/server/metrics-collection.feature` + a new **metrics collection** suite in `e2e.sh` — closes a coverage hole this PR surfaced. Every live assertion about `/metrics` previously ran in the chart's default configuration, where no key is configured, so only the fail-closed branch was covered; the branch operators actually run (a key is set, Prometheus scrapes with a bearer) had no live coverage, and secretKeyRef delivery was only ever checked as rendered YAML. The suite installs both keyed configurations and asserts in-cluster that both tiers come up and that metrics are genuinely collectable: unauthenticated and wrong-key scrapes are refused without leaking samples, the correct bearer serves real samples from the worker *and* the app, and `/healthz` stays credential-free once a key exists. The secretKeyRef pass proves the value reaches the process, which rendering a reference does not.

Verified the new e2e assertions actually fail against the previous `/metrics` probe rather than passing vacuously.

## Deployment Impact

- **Env vars added/changed:** none.
- **Helm values added/changed:** none. No new knobs; `app.telemetry.metrics.*` is untouched.
- **Default behavior on a vanilla `helm install` with no overrides:** worker `startupProbe`/`livenessProbe` change from `exec: kill -0 1` to `httpGet /healthz:2999`. Workers now restart on a wedged event loop that previously went undetected — the intended improvement. There is **no crash-loop risk in the default config**: `/healthz` is unauthenticated and independent of `METRICS_API_KEY` and `NODE_ENV`, which is the whole point of the path. Pods roll on upgrade (podspec change), as with any probe change.
- **Ordering note:** the app image must contain `/healthz` before the chart that probes it is applied. Both ship in this commit, so a standard chart-plus-image upgrade is fine; pinning an older `images.app.tag` with this chart would fail the startupProbe. Operators who pin image tags independently should upgrade the image first.
- **Startup is now a real deadline.** The metrics listener binds last in `startWorkers`, after the Redis/DB readiness checks and every worker boot, so `/healthz` only answers once the stack is up. The `startupProbe` budget is unchanged (`failureThreshold: 12` × `periodSeconds: 10` = 120s), but it now bounds actual boot time, where `exec: kill -0 1` passed the instant PID 1 existed. A worker that takes over 120s to boot — or never finishes — is now restarted instead of sitting Running-but-useless. That is the intended direction; operators with unusually slow Redis/Postgres startup should be aware of the bound.
- **BYOC dataplane impact:** none — the dataplane does not run this Deployment.
- **`/metrics` behaviour is unchanged**, so Prometheus scraping and the pre-existing `bearer_token` plain-value limitation are exactly as before (that limitation is untouched here and remains a known gap for secretKeyRef-delivered keys).

## Anything surprising?

- **This PR alone does not fix the crashing prod pods.** The pods that were `CrashLoopBackOff` are the Terraform-managed worker deployment in the `langwatch-saas` infra repo; a companion change there has to point its probes at `/healthz` too. This change fixes the chart, and ships the `/healthz` endpoint that the Terraform change will depend on.
- The chart hardcodes port `2999` in the probes. That matches the existing convention (`prometheus.yaml` hardcodes `:2999` for the worker scrape) — the chart exposes no knob for `WORKER_METRICS_PORT`, so there is nothing to thread through. Pre-existing, not introduced here.
- In the single-process dev mode (`WORKERS_IN_PROCESS=1`), workers are hosted inside the app and no listener binds 2999, so `/healthz` is not served there. That is unchanged from how `/metrics` already behaved and does not affect the Kubernetes deployment this PR targets.