### PR TITLE
feat(skills): publish a Claude Code plugin marketplace from the skill sources

### DIFF
--- a/skills/_publish/marketplace.ts
+++ b/skills/_publish/marketplace.ts
@@ -1,0 +1,164 @@
+/**
+ * Builders for the Claude Code plugin marketplace that ships alongside the
+ * published skills in langwatch/skills.
+ *
+ * The whole point is one source of truth: the SAME listPublishedSkills() set
+ * that sync.ts writes as SKILL.md files also drives the marketplace's skill
+ * list here, so the marketplace can never advertise a skill we didn't publish
+ * (or miss one we did).
+ *
+ * Layout produced in the published repo:
+ *
+ *   .claude-plugin/
+ *     marketplace.json   — the catalog: one `langwatch` plugin, source "."
+ *     plugin.json        — the plugin manifest: metadata + enumerated skills
+ *   <slug>/SKILL.md      — feature skills at the root
+ *   recipes/<slug>/SKILL.md
+ *
+ * Users add it with `/plugin marketplace add langwatch/skills` and install with
+ * `/plugin install langwatch@langwatch`.
+ *
+ * These builders are pure (no fs) so they unit-test without a checkout.
+ */
+
+export const MARKETPLACE_NAME = "langwatch";
+export const PLUGIN_NAME = "langwatch";
+
+const HOMEPAGE = "https://langwatch.ai/docs/skills/directory";
+const REPOSITORY = "https://github.com/langwatch/skills";
+
+const PLUGIN_DESCRIPTION =
+  "Give your AI agent observability, evaluation, and optimization with LangWatch — tracing, experiments, simulations, prompt versioning, analytics, and synthetic datasets, driven by the langwatch CLI.";
+
+const MARKETPLACE_DESCRIPTION =
+  "Official LangWatch skills for AI agents — tracing, evaluations, scenarios, prompts, analytics, and datasets.";
+
+const KEYWORDS = [
+  "langwatch",
+  "observability",
+  "tracing",
+  "evaluation",
+  "llm",
+  "llmops",
+  "ai-agents",
+  "prompts",
+  "analytics",
+  "datasets",
+] as const;
+
+/** A published skill reduced to what the marketplace needs. */
+export interface SkillEntry {
+  slug: string;
+  isRecipe: boolean;
+  description: string;
+}
+
+/**
+ * Where a skill lives inside the published repo — mirrors sync.ts's writeSkill
+ * target exactly (recipes nest under recipes/<slug>). This is also the path we
+ * hand Claude Code in the plugin's `skills` array.
+ */
+export function skillPath(skill: { slug: string; isRecipe: boolean }): string {
+  return skill.isRecipe ? `recipes/${skill.slug}` : skill.slug;
+}
+
+/**
+ * The plugin manifest (.claude-plugin/plugin.json).
+ *
+ * `skills` is enumerated, not a wildcard: the docs only guarantee a one-level
+ * `<name>/SKILL.md` scan, but recipes sit two levels deep (recipes/<slug>).
+ * Listing each dir explicitly discovers every skill regardless of depth, and
+ * because the plugin's `source` is the marketplace root, an explicit list is
+ * required anyway — it replaces the default `skills/` scan (which would find
+ * nothing here).
+ */
+export function buildPluginJson(skills: SkillEntry[], version: string) {
+  return {
+    name: PLUGIN_NAME,
+    displayName: "LangWatch",
+    description: PLUGIN_DESCRIPTION,
+    version,
+    author: { name: "LangWatch", url: "https://langwatch.ai" },
+    homepage: HOMEPAGE,
+    repository: REPOSITORY,
+    license: "MIT",
+    keywords: [...KEYWORDS],
+    skills: skills.map((s) => `./${skillPath(s)}`),
+  };
+}
+
+/**
+ * The marketplace catalog (.claude-plugin/marketplace.json). A single-plugin
+ * marketplace where the plugin IS the repo root (`source: "."`); the plugin's
+ * own manifest (plugin.json) carries the skill list and the rest of the
+ * metadata.
+ */
+export function buildMarketplaceJson(skills: SkillEntry[], version: string) {
+  return {
+    name: MARKETPLACE_NAME,
+    owner: { name: "LangWatch", url: "https://langwatch.ai" },
+    description: MARKETPLACE_DESCRIPTION,
+    plugins: [
+      {
+        name: PLUGIN_NAME,
+        source: ".",
+        description: PLUGIN_DESCRIPTION,
+        version,
+      },
+    ],
+  };
+}
+
+/**
+ * The published repo's landing README. The repo has none of its own (sync wipes
+ * the target each run), so this is what users see when they land on
+ * github.com/langwatch/skills to install.
+ */
+export function buildReadme(skills: SkillEntry[], version: string): string {
+  const features = skills.filter((s) => !s.isRecipe);
+  const recipes = skills.filter((s) => s.isRecipe);
+
+  const row = (s: SkillEntry) =>
+    `| [\`${s.slug}\`](./${skillPath(s)}/SKILL.md) | ${s.description} |`;
+
+  const section = (rows: SkillEntry[]) =>
+    ["| Skill | What it does |", "| --- | --- |", ...rows.map(row)].join("\n");
+
+  return `# LangWatch Skills
+
+Reusable [Agent Skills](https://code.claude.com/docs/en/skills) that give your AI agent LangWatch superpowers — tracing, evaluations, simulations, prompt versioning, analytics, and synthetic datasets. Each skill drives the \`langwatch\` CLI, so it works in Claude Code and any compatible coding agent.
+
+> This file is generated from the canonical sources in [langwatch/langwatch](https://github.com/langwatch/langwatch) (\`skills/\`). Edit there, not here.
+
+## Install
+
+### Claude Code plugin marketplace
+
+\`\`\`bash
+/plugin marketplace add langwatch/skills
+/plugin install ${PLUGIN_NAME}@${MARKETPLACE_NAME}
+\`\`\`
+
+That installs every skill below, each invocable as \`/${PLUGIN_NAME}:<skill>\` (for example \`/${PLUGIN_NAME}:tracing\`). Claude also invokes them automatically when a task matches.
+
+### Any agent (skills CLI)
+
+\`\`\`bash
+npx skills add langwatch/skills/<name>
+\`\`\`
+
+## Skills
+
+${section(features)}
+
+## Recipes
+
+Focused, task-specific skills.
+
+${section(recipes)}
+
+---
+
+Version \`${version}\` · [Docs](${HOMEPAGE}) · MIT licensed
+`;
+}

--- a/skills/_publish/sync.ts
+++ b/skills/_publish/sync.ts
@@ -10,7 +10,17 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { inlineMdx } from "../_lib/mdx-inline.js";
-import { listPublishedSkills } from "../_lib/feature-skills.js";
+import {
+  listPublishedSkills,
+  type PublishedSkill,
+} from "../_lib/feature-skills.js";
+import { splitFrontmatter } from "../_lib/frontmatter.js";
+import {
+  buildMarketplaceJson,
+  buildPluginJson,
+  buildReadme,
+  type SkillEntry,
+} from "./marketplace.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,6 +37,45 @@ function writeSkill(targetDir: string, name: string, src: string): void {
   const dir = path.join(targetDir, name);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, "SKILL.md"), inlineMdx(src));
+}
+
+function readDescription(src: string): string {
+  const { frontmatter } = splitFrontmatter(fs.readFileSync(src, "utf8"));
+  const description = frontmatter.description;
+  if (!description) {
+    throw new Error(`Skill has no frontmatter description: ${src}`);
+  }
+  return description;
+}
+
+// Emit the Claude Code plugin marketplace: a single `langwatch` plugin whose
+// source is the repo root, its manifest, and a landing README. All three are
+// derived from the same published set as the SKILL.md files above, so the
+// marketplace can never drift from what we actually ship.
+function writeMarketplace(
+  targetDir: string,
+  skills: PublishedSkill[],
+  version: string
+): void {
+  const entries: SkillEntry[] = skills.map((s) => ({
+    slug: s.slug,
+    isRecipe: s.isRecipe,
+    description: readDescription(s.src),
+  }));
+
+  const pluginDir = path.join(targetDir, ".claude-plugin");
+  fs.mkdirSync(pluginDir, { recursive: true });
+
+  const writeJson = (file: string, value: unknown): void =>
+    fs.writeFileSync(path.join(pluginDir, file), JSON.stringify(value, null, 2) + "\n");
+
+  writeJson("marketplace.json", buildMarketplaceJson(entries, version));
+  writeJson("plugin.json", buildPluginJson(entries, version));
+  fs.writeFileSync(path.join(targetDir, "README.md"), buildReadme(entries, version));
+
+  console.log("  ✓ .claude-plugin/marketplace.json");
+  console.log("  ✓ .claude-plugin/plugin.json");
+  console.log("  ✓ README.md");
 }
 
 export function sync(targetDir: string): void {
@@ -48,17 +97,23 @@ export function sync(targetDir: string): void {
   // Same selection Langy's native generator uses (skills/_compiler/native.ts),
   // so the published set and the in-product set can never drift. Recipes nest
   // under recipes/<slug> in the published repo.
-  for (const skill of listPublishedSkills(skillsRoot)) {
+  const skills = listPublishedSkills(skillsRoot);
+  for (const skill of skills) {
     const target = skill.isRecipe ? path.join("recipes", skill.slug) : skill.slug;
     writeSkill(targetDir, target, skill.src);
     console.log(`  ✓ ${target}`);
   }
 
+  const version = fs
+    .readFileSync(path.join(skillsRoot, "version.txt"), "utf8")
+    .trim();
   fs.copyFileSync(
     path.join(skillsRoot, "version.txt"),
     path.join(targetDir, "version.txt")
   );
   console.log("  ✓ version.txt");
+
+  writeMarketplace(targetDir, skills, version);
   console.log("Done.");
 }
 

--- a/skills/_tests/marketplace.test.ts
+++ b/skills/_tests/marketplace.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  MARKETPLACE_NAME,
+  PLUGIN_NAME,
+  buildMarketplaceJson,
+  buildPluginJson,
+  buildReadme,
+  skillPath,
+  type SkillEntry,
+} from "../_publish/marketplace.js";
+
+const SKILLS: SkillEntry[] = [
+  { slug: "tracing", isRecipe: false, description: "Add tracing to your code." },
+  { slug: "datasets", isRecipe: false, description: "Generate datasets." },
+  { slug: "improve-setup", isRecipe: true, description: "Audit your setup." },
+];
+
+describe("skillPath", () => {
+  describe("given a feature skill", () => {
+    it("places it at the repo root", () => {
+      expect(skillPath({ slug: "tracing", isRecipe: false })).toBe("tracing");
+    });
+  });
+
+  describe("given a recipe", () => {
+    it("nests it under recipes/", () => {
+      expect(skillPath({ slug: "improve-setup", isRecipe: true })).toBe(
+        "recipes/improve-setup"
+      );
+    });
+  });
+});
+
+describe("buildPluginJson", () => {
+  const plugin = buildPluginJson(SKILLS, "1.2.3");
+
+  it("names the plugin langwatch", () => {
+    expect(plugin.name).toBe(PLUGIN_NAME);
+  });
+
+  it("carries the given version through", () => {
+    expect(plugin.version).toBe("1.2.3");
+  });
+
+  it("enumerates every skill directory with a ./ prefix", () => {
+    expect(plugin.skills).toEqual([
+      "./tracing",
+      "./datasets",
+      "./recipes/improve-setup",
+    ]);
+  });
+
+  describe("when a recipe is present", () => {
+    it("points at its nested recipes/ path, not the bare slug", () => {
+      expect(plugin.skills).toContain("./recipes/improve-setup");
+      expect(plugin.skills).not.toContain("./improve-setup");
+    });
+  });
+});
+
+describe("buildMarketplaceJson", () => {
+  const marketplace = buildMarketplaceJson(SKILLS, "1.2.3");
+  const entry = marketplace.plugins[0]!;
+
+  it("names the marketplace langwatch", () => {
+    expect(marketplace.name).toBe(MARKETPLACE_NAME);
+  });
+
+  it("requires an owner name", () => {
+    expect(marketplace.owner.name).toBeTruthy();
+  });
+
+  it("declares exactly one plugin", () => {
+    expect(marketplace.plugins).toHaveLength(1);
+  });
+
+  describe("given the single-plugin layout", () => {
+    it("sources the plugin from the repo root", () => {
+      expect(entry.source).toBe(".");
+    });
+
+    it("names the plugin langwatch so it installs as langwatch@langwatch", () => {
+      expect(entry.name).toBe(PLUGIN_NAME);
+    });
+  });
+});
+
+describe("buildReadme", () => {
+  const readme = buildReadme(SKILLS, "1.2.3");
+
+  it("documents the Claude Code plugin install commands", () => {
+    expect(readme).toContain("/plugin marketplace add langwatch/skills");
+    expect(readme).toContain(
+      `/plugin install ${PLUGIN_NAME}@${MARKETPLACE_NAME}`
+    );
+  });
+
+  it("documents the skills-CLI install command", () => {
+    expect(readme).toContain("npx skills add langwatch/skills/<name>");
+  });
+
+  describe("given feature skills and recipes", () => {
+    it("links a feature skill at its root path", () => {
+      expect(readme).toContain("[`tracing`](./tracing/SKILL.md)");
+    });
+
+    it("links a recipe at its nested path", () => {
+      expect(readme).toContain(
+        "[`improve-setup`](./recipes/improve-setup/SKILL.md)"
+      );
+    });
+
+    it("carries each skill's description into the table", () => {
+      expect(readme).toContain("Add tracing to your code.");
+    });
+  });
+});

--- a/skills/_tests/publish-sync.test.ts
+++ b/skills/_tests/publish-sync.test.ts
@@ -17,6 +17,29 @@ function listMarkdown(dir: string): string[] {
   return out;
 }
 
+// The skill directories actually written to disk, as repo-relative paths
+// (feature skills at the root, recipes under recipes/). Used to prove the
+// generated plugin.json advertises exactly this set — no more, no less.
+function actualSkillDirs(root: string): string[] {
+  const dirs: string[] = [];
+  const hasSkill = (p: string) => fs.existsSync(path.join(p, "SKILL.md"));
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === ".git" || entry.name === ".claude-plugin") continue;
+    if (entry.name === "recipes") {
+      const recipesDir = path.join(root, "recipes");
+      for (const r of fs.readdirSync(recipesDir, { withFileTypes: true })) {
+        if (r.isDirectory() && hasSkill(path.join(recipesDir, r.name))) {
+          dirs.push(`recipes/${r.name}`);
+        }
+      }
+    } else if (hasSkill(path.join(root, entry.name))) {
+      dirs.push(entry.name);
+    }
+  }
+  return dirs;
+}
+
 function stripCode(markdown: string): string {
   return markdown
     .replace(/```[\s\S]*?```/g, "")
@@ -96,6 +119,54 @@ describe("sync publishes self-contained skills", () => {
     } finally {
       fs.rmSync(noGitDir, { recursive: true, force: true });
     }
+  });
+
+  describe("when it emits the Claude Code plugin marketplace", () => {
+    const readJson = (rel: string) =>
+      JSON.parse(fs.readFileSync(path.join(tmpDir, rel), "utf8"));
+
+    it("writes a marketplace.json naming the langwatch plugin at the repo root", () => {
+      const mp = readJson(".claude-plugin/marketplace.json");
+      expect(mp.name).toBe("langwatch");
+      expect(mp.plugins).toHaveLength(1);
+      expect(mp.plugins[0].name).toBe("langwatch");
+      expect(mp.plugins[0].source).toBe(".");
+    });
+
+    it("advertises exactly the skill directories that exist on disk", () => {
+      const plugin = readJson(".claude-plugin/plugin.json");
+      const declared = [...(plugin.skills as string[])].sort();
+      const onDisk = actualSkillDirs(tmpDir)
+        .map((d) => `./${d}`)
+        .sort();
+      expect(declared).toEqual(onDisk);
+    });
+
+    it("points every declared skill path at a real SKILL.md", () => {
+      const plugin = readJson(".claude-plugin/plugin.json");
+      for (const rel of plugin.skills as string[]) {
+        expect(
+          fs.existsSync(path.join(tmpDir, rel, "SKILL.md")),
+          `${rel}/SKILL.md missing`
+        ).toBe(true);
+      }
+    });
+
+    it("stamps the plugin version from version.txt", () => {
+      const version = fs
+        .readFileSync(path.join(tmpDir, "version.txt"), "utf8")
+        .trim();
+      expect(readJson(".claude-plugin/plugin.json").version).toBe(version);
+      expect(readJson(".claude-plugin/marketplace.json").plugins[0].version).toBe(
+        version
+      );
+    });
+
+    it("publishes a README carrying the plugin install command", () => {
+      const readme = fs.readFileSync(path.join(tmpDir, "README.md"), "utf8");
+      expect(readme).toContain("/plugin marketplace add langwatch/skills");
+      expect(readme).toContain("/plugin install langwatch@langwatch");
+    });
   });
 
   it("preserves intra-word underscores in identifiers like LANGWATCH_API_KEY", () => {


### PR DESCRIPTION
## What

Makes LangWatch installable as a **Claude Code plugin marketplace**. After this ships, anyone can add every LangWatch skill natively:

```bash
/plugin marketplace add langwatch/skills
/plugin install langwatch@langwatch
```

…and get all 13 skills, each invocable as `/langwatch:tracing`, `/langwatch:evaluations`, etc. (and auto-invoked when a task matches).

## How it fits the existing pipeline

No new distribution channel — I taught the **existing publisher** to emit the marketplace, so it rides the pipeline that already syncs skills to [`langwatch/skills`](https://github.com/langwatch/skills):

```
skills/*/SKILL.mdx  ──sync.ts──►  langwatch/skills (public)
  (canonical source)                ├── .claude-plugin/marketplace.json   ← NEW
                                    ├── .claude-plugin/plugin.json         ← NEW
                                    ├── README.md                          ← NEW
                                    ├── tracing/SKILL.md · … (unchanged)
                                    └── recipes/<recipe>/SKILL.md
```

All three new files are generated from the **same `listPublishedSkills()` set** that writes the `SKILL.md` files, so the marketplace **can never drift** from what we actually publish. A new skill or recipe flows into the marketplace automatically.

## Design notes

| Decision | Choice | Why |
| --- | --- | --- |
| Marketplace home | Public `langwatch/skills` repo | Clean `add langwatch/skills`, tiny clone, on-brand; existing `npx skills add` path untouched |
| Plugin shape | One `langwatch` plugin, `source: "."` | Bundles all skills; repo root *is* the plugin |
| Skill discovery | **Enumerated** dirs, not `["./"]` | Recipes are two levels deep (`recipes/<slug>`), past the docs' one-level default scan — enumeration is provably complete |
| Skills-only | Excludes internal `.claude/skills` dev tools | Different audience (monorepo contributors vs product users) |

## Verification

Ran against the **real `claude` CLI** (v2.1.204) on a generated fixture:

- ✅ `claude plugin validate --strict` → *Validation passed*
- ✅ `claude plugin details langwatch` → **`Skills (13)`** discovered, correctly named from frontmatter
- ✅ 26 unit + integration tests pass (`marketplace.test.ts`, `publish-sync.test.ts`), incl. a drift guard asserting the plugin advertises exactly the skill dirs on disk
- ✅ Targeted typecheck clean on all changed files

## Files

- `skills/_publish/marketplace.ts` — pure builders for `marketplace.json` / `plugin.json` / `README.md`
- `skills/_publish/sync.ts` — writes the three files after syncing skills
- `skills/_tests/marketplace.test.ts` — unit tests for the builders
- `skills/_tests/publish-sync.test.ts` — integration + drift-guard tests

> The marketplace materializes in `langwatch/skills` on the next `skills-publish` run (triggered by this merge, since it touches `skills/_publish/**`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added generation of Claude Code marketplace files and a published README during skill sync.
  * Skills are now published in the correct locations, including nested paths for recipe content.
  * The published README now includes install instructions, skill links, and version info.

* **Tests**
  * Added coverage for marketplace output, published paths, and sync-generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->