### PR TITLE
perf(trace-processing): shard recordSpan commands to parallelize hot-trace ingestion

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -89,6 +89,7 @@ import { createSuiteRunProcessingPipeline } from "./pipelines/suite-run-processi
 import type { SuiteRunStateData } from "./pipelines/suite-run-processing/projections/suiteRunState.foldProjection";
 import type { SuiteRunStateRepository } from "./pipelines/suite-run-processing/repositories/suiteRunState.repository";
 import { SUITE_RUN_PROJECTION_VERSIONS } from "./pipelines/suite-run-processing/schemas/constants";
+import { resolveSpanCommandShardCount } from "./pipelines/trace-processing/commands/spanCommandGroupKey";
 import { createTraceProcessingPipeline } from "./pipelines/trace-processing/pipeline";
 import { LogRecordAppendStore } from "./pipelines/trace-processing/projections/logRecordStorage.store";
 import { MetricRecordAppendStore } from "./pipelines/trace-processing/projections/metricRecordStorage.store";
@@ -481,6 +482,12 @@ export class PipelineRegistry {
         // ADR-022: Wire BlobStore so RecordSpanCommand can reconstitute
         // oversized commands and best-effort delete the transient S3 spool.
         blobStore: this.deps.blobStore,
+        // Span-command sharding fan-out (env TRACE_SPAN_PROCESSING_SHARDS,
+        // default 1 = disabled). Lets a hot trace's recordSpan commands drain in
+        // parallel across `traceId:<shard>` GroupQueue groups; fold stays per-trace.
+        spanCommandShardCount: resolveSpanCommandShardCount(
+          process.env.TRACE_SPAN_PROCESSING_SHARDS,
+        ),
         governanceKpisSyncReactor,
         governanceOcsfEventsSyncReactor,
       }),

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandSharding.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandSharding.test.ts
@@ -1,20 +1,49 @@
-import { describe, expect, it } from "vitest";
-import { RECORD_SPAN_DEDUPLICATION } from "../commands/recordSpanCommand";
+import { describe, expect, it, vi } from "vitest";
+import {
+  RECORD_SPAN_DEDUPLICATION,
+  RecordSpanCommand,
+} from "../commands/recordSpanCommand";
+import { MAX_SPAN_SHARD_COUNT } from "../commands/spanCommandGroupKey";
 import {
   createTraceProcessingPipeline,
   type TraceProcessingPipelineDeps,
 } from "../pipeline";
 import type { RecordSpanCommandData } from "../schemas/commands";
 
+// The blobStore registration branch eagerly constructs `new RecordSpanCommand`,
+// whose default-dependency path does `require("~/server/db")` (an alias vitest's
+// ESM can't resolve at runtime) and builds a tokenizer. Give the command a
+// complete set of no-op deps so construction is cheap — statics
+// (getAggregateId, schema) and RECORD_SPAN_DEDUPLICATION stay real, which is all
+// the pipeline wiring under test needs. Mirrors the TestRecordSpanCommand
+// pattern in traceProcessing.coalescing.integration.test.ts.
+vi.mock("../commands/recordSpanCommand", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  class StubRecordSpanCommand extends actual.RecordSpanCommand {
+    constructor(deps?: Record<string, unknown>) {
+      super({
+        piiRedactionService: { redactSpan: async () => {} },
+        costEnrichmentService: { enrichSpan: async () => {} },
+        tokenEstimationService: { estimateSpanTokens: async () => {} },
+        contentDropService: {
+          dropSpanContent: async () => ({
+            droppedCount: 0,
+            droppedCategories: [],
+          }),
+        },
+        ...deps,
+      } as never);
+    }
+  }
+  return { ...actual, RecordSpanCommand: StubRecordSpanCommand };
+});
+
 /**
  * Wiring-level integration test: builds the REAL trace-processing pipeline and
  * checks that the composition root installs span-command sharding on the
- * recordSpan command while leaving the trace-summary fold keyed per trace.
- *
- * Boundaries (stores, reactors) are stubbed — `build()` only stores references
- * and never invokes them, and the no-blobStore path registers the command via
- * `withCommand` (the class is constructed later, at queue init, which this test
- * does not reach), so no ClickHouse / Redis / prisma is required.
+ * recordSpan command — through both registration branches — while leaving the
+ * trace-summary fold keyed per trace. `build()` only stores references, so no
+ * store / reactor is ever invoked.
  */
 
 const reactorStub = (name: string) => ({ name, handle: async () => {} }) as any;
@@ -54,18 +83,30 @@ function payload(traceId: string, spanId: string): RecordSpanCommandData {
   return { span: { traceId, spanId } } as unknown as RecordSpanCommandData;
 }
 
-function recordSpanGroupKeyFn(deps: Partial<TraceProcessingPipelineDeps>) {
-  const definition = createTraceProcessingPipeline(buildTraceDeps(deps));
-  const recordSpan = definition.commands.find((c) => c.name === "recordSpan");
-  expect(recordSpan).toBeDefined();
-  expect(recordSpan?.options?.getGroupKey).toBeDefined();
-  return recordSpan!.options!.getGroupKey!;
+function recordSpanCommand(deps: Partial<TraceProcessingPipelineDeps> = {}) {
+  const cmd = createTraceProcessingPipeline(buildTraceDeps(deps)).commands.find(
+    (c) => c.name === "recordSpan",
+  );
+  expect(cmd).toBeDefined();
+  return cmd!;
+}
+
+/** Group-key fn of an enabled (sharded) pipeline. Asserts it was installed. */
+function shardedGroupKey(deps: Partial<TraceProcessingPipelineDeps>) {
+  const getGroupKey = recordSpanCommand(deps).options?.getGroupKey;
+  expect(getGroupKey).toBeDefined();
+  return getGroupKey!;
+}
+
+/** Shard suffix from the LAST colon — robust to colon-bearing trace ids. */
+function shardOf(key: string): number {
+  return Number(key.slice(key.lastIndexOf(":") + 1));
 }
 
 describe("trace-processing pipeline span-command sharding", () => {
   describe("given the pipeline is built with several shards", () => {
     it("spreads a trace's spans across more than one group", () => {
-      const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 8 });
+      const getGroupKey = shardedGroupKey({ spanCommandShardCount: 8 });
       const groups = new Set(
         Array.from({ length: 64 }, (_, i) =>
           getGroupKey(
@@ -80,7 +121,7 @@ describe("trace-processing pipeline span-command sharding", () => {
     });
 
     it("routes the same span to the same group every time", () => {
-      const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 8 });
+      const getGroupKey = shardedGroupKey({ spanCommandShardCount: 8 });
       const p = payload(TRACE_ID, "0a1b2c3d4e5f6071");
       expect(getGroupKey(p)).toBe(getGroupKey(p));
     });
@@ -97,24 +138,61 @@ describe("trace-processing pipeline span-command sharding", () => {
         definition.foldProjections.get("traceSummary")?.definition.key,
       ).toBe(undefined);
     });
+
+    it("clamps an out-of-range shard count so it can't explode the group space", () => {
+      // A caller bypassing PipelineRegistry's env resolver passes an absurd
+      // count; the pipeline clamps to MAX_SPAN_SHARD_COUNT, so every derived
+      // shard stays in range.
+      const getGroupKey = shardedGroupKey({ spanCommandShardCount: 100_000 });
+      for (let i = 0; i < 256; i++) {
+        const key = getGroupKey(
+          payload(TRACE_ID, (i + 1).toString(16).padStart(16, "0")),
+        );
+        expect(shardOf(key)).toBeLessThan(MAX_SPAN_SHARD_COUNT);
+      }
+    });
+  });
+
+  describe("given the blobStore registration branch", () => {
+    it("installs the same sharded getGroupKey as the plain-command path", () => {
+      // The blobStore branch registers recordSpan via withCommandInstance (a
+      // pre-constructed handler) rather than withCommand — assert sharding is not
+      // silently limited to the no-blobStore path.
+      const cmd = recordSpanCommand({
+        spanCommandShardCount: 8,
+        blobStore: {
+          getSpool: async () => Buffer.from(""),
+          deleteSpool: async () => {},
+        } as any,
+      });
+      const getGroupKey = cmd.options?.getGroupKey;
+      expect(getGroupKey).toBeDefined();
+      expect(
+        getGroupKey!(payload(TRACE_ID, "00000000000000ff")).startsWith(
+          `${TRACE_ID}:`,
+        ),
+      ).toBe(true);
+    });
   });
 
   describe("given the pipeline is built with sharding disabled", () => {
     /** @scenario "The pipeline preserves the trace-only key when sharding is off" */
-    it("returns the bare trace id, identical to before sharding existed", () => {
-      const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 1 });
-      expect(getGroupKey(payload(TRACE_ID, "abc"))).toBe(TRACE_ID);
+    it("installs no getGroupKey, keeping the historic getAggregateId trace key", () => {
+      const cmd = recordSpanCommand({ spanCommandShardCount: 1 });
+      expect(cmd.options?.getGroupKey).toBeUndefined();
+      expect(RecordSpanCommand.getAggregateId(payload(TRACE_ID, "abc"))).toBe(
+        TRACE_ID,
+      );
     });
 
-    it("defaults to disabled when no shard count is configured", () => {
-      const getGroupKey = recordSpanGroupKeyFn({});
-      expect(getGroupKey(payload(TRACE_ID, "abc"))).toBe(TRACE_ID);
+    it("installs no getGroupKey when no shard count is configured", () => {
+      expect(recordSpanCommand({}).options?.getGroupKey).toBeUndefined();
     });
   });
 
   describe("given non-OTel-compliant trace and span ids", () => {
     it("still derives a stable sharded group for arbitrary string ids", () => {
-      const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 8 });
+      const getGroupKey = shardedGroupKey({ spanCommandShardCount: 8 });
       const weirdTrace = "my-custom::trace/id";
       const weirdSpan = "span_ABC!@# 123";
       const key = getGroupKey(payload(weirdTrace, weirdSpan));
@@ -122,24 +200,21 @@ describe("trace-processing pipeline span-command sharding", () => {
       expect(getGroupKey(payload(weirdTrace, weirdSpan))).toBe(key);
     });
 
-    it("preserves the raw id as the group key when sharding is off", () => {
-      const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 1 });
+    it("keeps the raw trace id via getAggregateId when sharding is off", () => {
+      const cmd = recordSpanCommand({ spanCommandShardCount: 1 });
+      expect(cmd.options?.getGroupKey).toBeUndefined();
       const weirdTrace = "550e8400-e29b-41d4-a716-446655440000";
-      expect(getGroupKey(payload(weirdTrace, "not-hex"))).toBe(weirdTrace);
+      expect(
+        RecordSpanCommand.getAggregateId(payload(weirdTrace, "not-hex")),
+      ).toBe(weirdTrace);
     });
   });
 
   describe("given the recordSpan command is registered", () => {
     it("keeps the per-span deduplication config intact", () => {
-      const definition = createTraceProcessingPipeline(
-        buildTraceDeps({ spanCommandShardCount: 8 }),
-      );
-      const recordSpan = definition.commands.find(
-        (c) => c.name === "recordSpan",
-      );
-      expect(recordSpan?.options?.deduplication).toBe(
-        RECORD_SPAN_DEDUPLICATION,
-      );
+      expect(
+        recordSpanCommand({ spanCommandShardCount: 8 }).options?.deduplication,
+      ).toBe(RECORD_SPAN_DEDUPLICATION);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandSharding.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandSharding.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { RECORD_SPAN_DEDUPLICATION } from "../commands/recordSpanCommand";
+import {
+  createTraceProcessingPipeline,
+  type TraceProcessingPipelineDeps,
+} from "../pipeline";
+import type { RecordSpanCommandData } from "../schemas/commands";
+
+/**
+ * Wiring-level integration test: builds the REAL trace-processing pipeline and
+ * checks that the composition root installs span-command sharding on the
+ * recordSpan command while leaving the trace-summary fold keyed per trace.
+ *
+ * Boundaries (stores, reactors) are stubbed — `build()` only stores references
+ * and never invokes them, and the no-blobStore path registers the command via
+ * `withCommand` (the class is constructed later, at queue init, which this test
+ * does not reach), so no ClickHouse / Redis / prisma is required.
+ */
+
+const reactorStub = (name: string) => ({ name, handle: async () => {} }) as any;
+const outboxReactorStub = (name: string) =>
+  ({ name, decide: async () => [] }) as any;
+
+function buildTraceDeps(
+  overrides: Partial<TraceProcessingPipelineDeps> = {},
+): TraceProcessingPipelineDeps {
+  const store = {} as any;
+  return {
+    spanAppendStore: store,
+    logRecordAppendStore: store,
+    metricRecordAppendStore: store,
+    traceSummaryStore: store,
+    originGateReactor: reactorStub("originGate"),
+    evaluationTriggerReactor: reactorStub("evaluationTrigger"),
+    customEvaluationSyncReactor: reactorStub("customEvaluationSync"),
+    traceUpdateBroadcastReactor: reactorStub("traceUpdateBroadcast"),
+    projectMetadataReactor: reactorStub("projectMetadata"),
+    simulationMetricsSyncReactor: reactorStub("simulationMetricsSync"),
+    experimentMetricsSyncReactor: reactorStub("experimentMetricsSync"),
+    alertTriggerReactor: outboxReactorStub("alertTrigger"),
+    alertTriggerNotifyOutboxReactor: outboxReactorStub(
+      "alertTriggerNotifyOutbox",
+    ),
+    spanStorageBroadcastReactor: reactorStub("spanStorageBroadcast"),
+    claudeCodeSpanSyncReactor: reactorStub("claudeCodeSpanSync"),
+    ...overrides,
+  };
+}
+
+const TRACE_ID = "534bd8a1bf83e7c58e8aaacefb047cc2";
+
+/** Minimal recordSpan payload — getGroupKey only reads `span.{traceId,spanId}`. */
+function payload(traceId: string, spanId: string): RecordSpanCommandData {
+  return { span: { traceId, spanId } } as unknown as RecordSpanCommandData;
+}
+
+function recordSpanGroupKeyFn(deps: Partial<TraceProcessingPipelineDeps>) {
+  const definition = createTraceProcessingPipeline(buildTraceDeps(deps));
+  const recordSpan = definition.commands.find((c) => c.name === "recordSpan");
+  expect(recordSpan).toBeDefined();
+  expect(recordSpan?.options?.getGroupKey).toBeDefined();
+  return recordSpan!.options!.getGroupKey!;
+}
+
+describe("trace-processing pipeline span-command sharding", () => {
+  describe("given the pipeline is built with several shards", () => {
+    it("spreads a trace's spans across more than one group", () => {
+      const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 8 });
+      const groups = new Set(
+        Array.from({ length: 64 }, (_, i) =>
+          getGroupKey(
+            payload(TRACE_ID, (i + 1).toString(16).padStart(16, "0")),
+          ),
+        ),
+      );
+      expect(groups.size).toBeGreaterThan(1);
+      for (const key of groups) {
+        expect(key.startsWith(`${TRACE_ID}:`)).toBe(true);
+      }
+    });
+
+    it("routes the same span to the same group every time", () => {
+      const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 8 });
+      const p = payload(TRACE_ID, "0a1b2c3d4e5f6071");
+      expect(getGroupKey(p)).toBe(getGroupKey(p));
+    });
+
+    it("keeps the trace-summary fold keyed per trace, not per span", () => {
+      const definition = createTraceProcessingPipeline(
+        buildTraceDeps({ spanCommandShardCount: 8 }),
+      );
+      // No custom fold key → the fold queue falls back to the trace aggregate id,
+      // so the fold stays serialized (and coalesced) per trace regardless of how
+      // the command is sharded.
+      expect(
+        definition.foldProjections.get("traceSummary")?.definition.key,
+      ).toBe(undefined);
+    });
+  });
+
+  describe("given the pipeline is built with sharding disabled", () => {
+    it("returns the bare trace id, identical to before sharding existed", () => {
+      const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 1 });
+      expect(getGroupKey(payload(TRACE_ID, "abc"))).toBe(TRACE_ID);
+    });
+
+    it("defaults to disabled when no shard count is configured", () => {
+      const getGroupKey = recordSpanGroupKeyFn({});
+      expect(getGroupKey(payload(TRACE_ID, "abc"))).toBe(TRACE_ID);
+    });
+  });
+
+  describe("given non-OTel-compliant trace and span ids", () => {
+    it("still derives a stable sharded group for arbitrary string ids", () => {
+      const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 8 });
+      const weirdTrace = "my-custom::trace/id";
+      const weirdSpan = "span_ABC!@# 123";
+      const key = getGroupKey(payload(weirdTrace, weirdSpan));
+      expect(key.startsWith(`${weirdTrace}:`)).toBe(true);
+      expect(getGroupKey(payload(weirdTrace, weirdSpan))).toBe(key);
+    });
+
+    it("preserves the raw id as the group key when sharding is off", () => {
+      const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 1 });
+      const weirdTrace = "550e8400-e29b-41d4-a716-446655440000";
+      expect(getGroupKey(payload(weirdTrace, "not-hex"))).toBe(weirdTrace);
+    });
+  });
+
+  describe("given the recordSpan command is registered", () => {
+    it("keeps the per-span deduplication config intact", () => {
+      const definition = createTraceProcessingPipeline(
+        buildTraceDeps({ spanCommandShardCount: 8 }),
+      );
+      const recordSpan = definition.commands.find(
+        (c) => c.name === "recordSpan",
+      );
+      expect(recordSpan?.options?.deduplication).toBe(
+        RECORD_SPAN_DEDUPLICATION,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandSharding.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/spanCommandSharding.test.ts
@@ -85,6 +85,7 @@ describe("trace-processing pipeline span-command sharding", () => {
       expect(getGroupKey(p)).toBe(getGroupKey(p));
     });
 
+    /** @scenario "The pipeline shards the command while leaving the fold per-trace" */
     it("keeps the trace-summary fold keyed per trace, not per span", () => {
       const definition = createTraceProcessingPipeline(
         buildTraceDeps({ spanCommandShardCount: 8 }),
@@ -99,6 +100,7 @@ describe("trace-processing pipeline span-command sharding", () => {
   });
 
   describe("given the pipeline is built with sharding disabled", () => {
+    /** @scenario "The pipeline preserves the trace-only key when sharding is off" */
     it("returns the bare trace id, identical to before sharding existed", () => {
       const getGroupKey = recordSpanGroupKeyFn({ spanCommandShardCount: 1 });
       expect(getGroupKey(payload(TRACE_ID, "abc"))).toBe(TRACE_ID);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/spanCommandGroupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/spanCommandGroupKey.unit.test.ts
@@ -18,6 +18,7 @@ function makeSpanIds(n: number): string[] {
 describe("spanCommandGroupKey", () => {
   describe("given sharding is disabled", () => {
     describe("when the shard count is one, zero, or negative", () => {
+      /** @scenario "Sharding disabled keeps the historic trace-only group key" */
       it("returns the bare trace id, identical to the historic key", () => {
         for (const shardCount of [1, 0, -4]) {
           expect(
@@ -53,6 +54,7 @@ describe("spanCommandGroupKey", () => {
         expect(Number(shard)).toBeLessThan(8);
       });
 
+      /** @scenario "A span always maps to the same shard" */
       it("derives the same group for the same span every time", () => {
         const spanId = "0a1b2c3d4e5f6071";
         const first = spanCommandGroupKey({
@@ -70,6 +72,7 @@ describe("spanCommandGroupKey", () => {
     });
 
     describe("when deriving keys for many spans of one trace", () => {
+      /** @scenario "Sharding spreads a trace's spans across groups" */
       it("spreads them across more than one group", () => {
         const groups = new Set(
           makeSpanIds(64).map((spanId) =>
@@ -204,6 +207,7 @@ describe("resolveSpanCommandShardCount", () => {
   });
 
   describe("given a value above the maximum", () => {
+    /** @scenario "The configured shard count is clamped to a safe range" */
     it("clamps down to the maximum", () => {
       expect(resolveSpanCommandShardCount("100000")).toBe(MAX_SPAN_SHARD_COUNT);
     });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/spanCommandGroupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/spanCommandGroupKey.unit.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_SPAN_SHARD_COUNT,
+  resolveSpanCommandShardCount,
+  spanCommandGroupKey,
+  spanShardIndex,
+} from "../spanCommandGroupKey";
+
+const TRACE_ID = "534bd8a1bf83e7c58e8aaacefb047cc2";
+
+/** 64 distinct hex span ids, shaped like real OTLP span ids. */
+function makeSpanIds(n: number): string[] {
+  return Array.from({ length: n }, (_, i) =>
+    (i + 1).toString(16).padStart(16, "0"),
+  );
+}
+
+describe("spanCommandGroupKey", () => {
+  describe("given sharding is disabled", () => {
+    describe("when the shard count is one, zero, or negative", () => {
+      it("returns the bare trace id, identical to the historic key", () => {
+        for (const shardCount of [1, 0, -4]) {
+          expect(
+            spanCommandGroupKey({
+              traceId: TRACE_ID,
+              spanId: "abc",
+              shardCount,
+            }),
+          ).toBe(TRACE_ID);
+        }
+      });
+
+      it("returns the same key for every span of the trace", () => {
+        const keys = makeSpanIds(20).map((spanId) =>
+          spanCommandGroupKey({ traceId: TRACE_ID, spanId, shardCount: 1 }),
+        );
+        expect(new Set(keys)).toEqual(new Set([TRACE_ID]));
+      });
+    });
+  });
+
+  describe("given sharding is enabled", () => {
+    describe("when deriving a key for a span", () => {
+      it("prefixes the trace id and suffixes a shard within range", () => {
+        const key = spanCommandGroupKey({
+          traceId: TRACE_ID,
+          spanId: "00000000000000ff",
+          shardCount: 8,
+        });
+        const [prefix, shard] = key.split(":");
+        expect(prefix).toBe(TRACE_ID);
+        expect(Number(shard)).toBeGreaterThanOrEqual(0);
+        expect(Number(shard)).toBeLessThan(8);
+      });
+
+      it("derives the same group for the same span every time", () => {
+        const spanId = "0a1b2c3d4e5f6071";
+        const first = spanCommandGroupKey({
+          traceId: TRACE_ID,
+          spanId,
+          shardCount: 16,
+        });
+        const second = spanCommandGroupKey({
+          traceId: TRACE_ID,
+          spanId,
+          shardCount: 16,
+        });
+        expect(second).toBe(first);
+      });
+    });
+
+    describe("when deriving keys for many spans of one trace", () => {
+      it("spreads them across more than one group", () => {
+        const groups = new Set(
+          makeSpanIds(64).map((spanId) =>
+            spanCommandGroupKey({ traceId: TRACE_ID, spanId, shardCount: 16 }),
+          ),
+        );
+        expect(groups.size).toBeGreaterThan(1);
+      });
+
+      it("uses every shard for a well-distributed span population", () => {
+        const shardCount = 8;
+        const seen = new Set(
+          makeSpanIds(512).map((spanId) =>
+            spanShardIndex({ spanId, shardCount }),
+          ),
+        );
+        expect(seen.size).toBe(shardCount);
+      });
+
+      it("keeps every derived shard within [0, shardCount)", () => {
+        const shardCount = 16;
+        for (const spanId of makeSpanIds(256)) {
+          const shard = spanShardIndex({ spanId, shardCount });
+          expect(shard).toBeGreaterThanOrEqual(0);
+          expect(shard).toBeLessThan(shardCount);
+        }
+      });
+    });
+
+    describe("when two different spans of the same trace are keyed", () => {
+      it("keeps the trace prefix shared so both remain the same aggregate", () => {
+        const a = spanCommandGroupKey({
+          traceId: TRACE_ID,
+          spanId: "1111111111111111",
+          shardCount: 16,
+        });
+        const b = spanCommandGroupKey({
+          traceId: TRACE_ID,
+          spanId: "2222222222222222",
+          shardCount: 16,
+        });
+        expect(a.startsWith(`${TRACE_ID}:`)).toBe(true);
+        expect(b.startsWith(`${TRACE_ID}:`)).toBe(true);
+      });
+    });
+  });
+
+  describe("given non-OTel-compliant trace or span ids", () => {
+    // Span/trace ids are normalized to strings before this helper, but nothing
+    // forces them to be 16-char hex — a customer SDK can send arbitrary strings.
+    // The FNV hash consumes any string, so bucketing stays total and stable.
+    const NON_OTEL_SPAN_IDS = [
+      "not-hex-at-all",
+      "span_ABC!@#$%^&*()",
+      "550e8400-e29b-41d4-a716-446655440000",
+      "スパン-🚀-id",
+      " leading-and-trailing ",
+      "x".repeat(4096),
+      "",
+    ];
+
+    describe("when a non-OTel span id is sharded", () => {
+      it("returns a deterministic integer bucket within [0, shardCount)", () => {
+        const shardCount = 12;
+        for (const spanId of NON_OTEL_SPAN_IDS) {
+          const bucket = spanShardIndex({ spanId, shardCount });
+          expect(Number.isInteger(bucket)).toBe(true);
+          expect(bucket).toBeGreaterThanOrEqual(0);
+          expect(bucket).toBeLessThan(shardCount);
+          expect(spanShardIndex({ spanId, shardCount })).toBe(bucket);
+        }
+      });
+
+      it("keeps the trace prefix on the derived `traceId:<shard>` key", () => {
+        for (const spanId of NON_OTEL_SPAN_IDS) {
+          const key = spanCommandGroupKey({
+            traceId: TRACE_ID,
+            spanId,
+            shardCount: 8,
+          });
+          expect(key.startsWith(`${TRACE_ID}:`)).toBe(true);
+        }
+      });
+    });
+
+    describe("when the trace id itself is non-OTel-compliant", () => {
+      it("preserves the raw trace id verbatim when sharding is disabled", () => {
+        for (const traceId of [
+          "my-custom::trace/id",
+          "550e8400-e29b-41d4-a716-446655440000",
+          "",
+        ]) {
+          expect(
+            spanCommandGroupKey({ traceId, spanId: "any", shardCount: 1 }),
+          ).toBe(traceId);
+        }
+      });
+
+      it("keeps distinct traces in distinct groups even when a trace id contains a colon", () => {
+        // "always suffix when enabled" stops a colon-bearing trace id from
+        // colliding with another trace's `traceId:<shard>` group. Same spanId so
+        // the shard suffix matches — only the trace prefix differs.
+        const plain = spanCommandGroupKey({
+          traceId: "abc",
+          spanId: "s",
+          shardCount: 8,
+        });
+        const colon = spanCommandGroupKey({
+          traceId: "abc:0",
+          spanId: "s",
+          shardCount: 8,
+        });
+        expect(colon).not.toBe(plain);
+      });
+    });
+  });
+});
+
+describe("resolveSpanCommandShardCount", () => {
+  describe("given an absent, non-numeric, or below-one value", () => {
+    it("falls back to one so sharding stays disabled", () => {
+      for (const raw of [undefined, "", "abc", "0", "-3", "2.5", "NaN"]) {
+        expect(resolveSpanCommandShardCount(raw)).toBe(1);
+      }
+    });
+  });
+
+  describe("given a valid in-range value", () => {
+    it("returns the parsed integer", () => {
+      expect(resolveSpanCommandShardCount("16")).toBe(16);
+    });
+  });
+
+  describe("given a value above the maximum", () => {
+    it("clamps down to the maximum", () => {
+      expect(resolveSpanCommandShardCount("100000")).toBe(MAX_SPAN_SHARD_COUNT);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/spanCommandGroupKey.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/spanCommandGroupKey.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  clampSpanShardCount,
   MAX_SPAN_SHARD_COUNT,
   resolveSpanCommandShardCount,
   spanCommandGroupKey,
@@ -48,10 +49,14 @@ describe("spanCommandGroupKey", () => {
           spanId: "00000000000000ff",
           shardCount: 8,
         });
-        const [prefix, shard] = key.split(":");
+        // Extract the suffix from the LAST colon so the assertion holds even for
+        // a colon-bearing trace id (see the non-OTel cases below).
+        const idx = key.lastIndexOf(":");
+        const prefix = key.slice(0, idx);
+        const shard = Number(key.slice(idx + 1));
         expect(prefix).toBe(TRACE_ID);
-        expect(Number(shard)).toBeGreaterThanOrEqual(0);
-        expect(Number(shard)).toBeLessThan(8);
+        expect(shard).toBeGreaterThanOrEqual(0);
+        expect(shard).toBeLessThan(8);
       });
 
       /** @scenario "A span always maps to the same shard" */
@@ -210,6 +215,28 @@ describe("resolveSpanCommandShardCount", () => {
     /** @scenario "The configured shard count is clamped to a safe range" */
     it("clamps down to the maximum", () => {
       expect(resolveSpanCommandShardCount("100000")).toBe(MAX_SPAN_SHARD_COUNT);
+    });
+  });
+});
+
+describe("clampSpanShardCount", () => {
+  describe("given a non-integer or below-one count", () => {
+    it("falls back to one, disabling sharding", () => {
+      for (const n of [0, -5, 1.5, Number.NaN]) {
+        expect(clampSpanShardCount(n)).toBe(1);
+      }
+    });
+  });
+
+  describe("given an in-range count", () => {
+    it("returns it unchanged", () => {
+      expect(clampSpanShardCount(16)).toBe(16);
+    });
+  });
+
+  describe("given a count above the maximum", () => {
+    it("clamps down to the maximum", () => {
+      expect(clampSpanShardCount(100_000)).toBe(MAX_SPAN_SHARD_COUNT);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/spanCommandGroupKey.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/spanCommandGroupKey.ts
@@ -1,0 +1,96 @@
+/**
+ * Span-command sharding for the trace-processing pipeline.
+ *
+ * `recordSpan` commands are grouped on the GroupQueue by a key derived from the
+ * trace id (`getAggregateId`). Every span of a trace therefore lands in one
+ * group and drains one at a time behind a single worker — fine for an ordinary
+ * trace, but a trace that accumulates thousands of spans (reused trace_id, a
+ * runaway agent loop) builds a multi-minute backlog while each span's per-span
+ * work (PII redaction, cost enrichment, token estimation, content-drop) runs
+ * serially.
+ *
+ * The command handler reads no trace-level state — it is a pure per-span
+ * transform that emits one `span_received` event stamped `aggregateId =
+ * traceId`. So the *command* need not serialise on the trace; only the
+ * trace-summary *fold* does, and that runs on its own aggregate-keyed queue,
+ * untouched by this key (see ProjectionRouter.initializeFoldQueues). Splitting
+ * the command key into `traceId:<shard>` lets a hot trace's spans drain across
+ * up to `shardCount` groups in parallel while the fold stays ordered per trace.
+ *
+ * `shardCount <= 1` returns the bare trace id — byte-identical to the historic
+ * key — so the feature is off until an operator raises the count. The per-tenant
+ * soft-cap still bounds how many of a tenant's groups run at once, so a fanned-out
+ * hot trace cannot starve its neighbours (see specs/event-sourcing/tenant-soft-cap.feature).
+ */
+
+/**
+ * Upper bound on the shard count. A hot trace never needs more parallelism than
+ * this, and keeping it small bounds the number of GroupQueue groups (and parked
+ * entries under the tenant soft-cap) a single trace can create.
+ */
+export const MAX_SPAN_SHARD_COUNT = 128;
+
+// FNV-1a (32-bit) constants. A span's bucket must be deterministic across
+// processes and restarts — a span's retries and its dedup squash window must
+// keep landing in the same group — and this is bucket placement, not security,
+// so a fast non-crypto rolling hash is the right tool and avoids a crypto digest
+// on the span-ingest hot path.
+const FNV_OFFSET_BASIS = 2166136261;
+const FNV_PRIME = 16777619;
+
+/**
+ * Deterministic bucket in `[0, shardCount)` for a span id. Callers must pass
+ * `shardCount >= 1`; `spanCommandGroupKey` guarantees this.
+ */
+export function spanShardIndex({
+  spanId,
+  shardCount,
+}: {
+  spanId: string;
+  shardCount: number;
+}): number {
+  let hash = FNV_OFFSET_BASIS;
+  for (let i = 0; i < spanId.length; i++) {
+    hash ^= spanId.charCodeAt(i);
+    hash = Math.imul(hash, FNV_PRIME);
+  }
+  // `>>> 0` folds the signed 32-bit imul result to an unsigned int before the
+  // modulo, so the bucket is always non-negative.
+  return (hash >>> 0) % shardCount;
+}
+
+/**
+ * GroupQueue domain key for a `recordSpan` command.
+ *
+ * Returns `traceId` when sharding is disabled (`shardCount <= 1`) — identical to
+ * the historic `getAggregateId`-derived key — and `traceId:<shard>` otherwise.
+ * The framework prepends `<tenantId>/command/recordSpan/trace:` around this, so
+ * the tenant prefix (and `tenantIdFromGroupId`) is unaffected.
+ */
+export function spanCommandGroupKey({
+  traceId,
+  spanId,
+  shardCount,
+}: {
+  traceId: string;
+  spanId: string;
+  shardCount: number;
+}): string {
+  if (shardCount <= 1) return traceId;
+  return `${traceId}:${spanShardIndex({ spanId, shardCount })}`;
+}
+
+/**
+ * Resolve the operator-configured shard count from an env value, clamped to a
+ * safe range. Non-integer, below-one, or absent values fall back to `1`
+ * (sharding disabled) rather than throwing on the ingest path; values above
+ * {@link MAX_SPAN_SHARD_COUNT} are clamped down.
+ *
+ * Read once at pipeline composition from `TRACE_SPAN_PROCESSING_SHARDS`,
+ * mirroring how `GLOBAL_QUEUE_CONCURRENCY` tunes the GroupQueue.
+ */
+export function resolveSpanCommandShardCount(raw: string | undefined): number {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) return 1;
+  return Math.min(parsed, MAX_SPAN_SHARD_COUNT);
+}

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/spanCommandGroupKey.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/spanCommandGroupKey.ts
@@ -28,7 +28,7 @@
  * this, and keeping it small bounds the number of GroupQueue groups (and parked
  * entries under the tenant soft-cap) a single trace can create.
  */
-export const MAX_SPAN_SHARD_COUNT = 128;
+export const MAX_SPAN_SHARD_COUNT = 128 as const;
 
 // FNV-1a (32-bit) constants. A span's bucket must be deterministic across
 // processes and restarts — a span's retries and its dedup squash window must
@@ -81,16 +81,28 @@ export function spanCommandGroupKey({
 }
 
 /**
- * Resolve the operator-configured shard count from an env value, clamped to a
- * safe range. Non-integer, below-one, or absent values fall back to `1`
- * (sharding disabled) rather than throwing on the ingest path; values above
- * {@link MAX_SPAN_SHARD_COUNT} are clamped down.
+ * Clamp a numeric shard count to the safe range `[1, MAX_SPAN_SHARD_COUNT]`.
+ * Non-integer or below-one values fall back to `1` (sharding disabled) rather
+ * than throwing on the ingest path; values above {@link MAX_SPAN_SHARD_COUNT}
+ * are clamped down.
+ *
+ * Applied as defense-in-depth wherever a shard count enters the pipeline — not
+ * only from env — so a caller that constructs the pipeline directly (a test or
+ * a future composition root) can't explode the number of GroupQueue groups.
+ */
+export function clampSpanShardCount(shardCount: number): number {
+  if (!Number.isInteger(shardCount) || shardCount < 1) return 1;
+  return Math.min(shardCount, MAX_SPAN_SHARD_COUNT);
+}
+
+/**
+ * Resolve the operator-configured shard count from an env value, clamped to the
+ * safe range. Absent, non-numeric, or out-of-range values fall back to `1`
+ * (sharding disabled).
  *
  * Read once at pipeline composition from `TRACE_SPAN_PROCESSING_SHARDS`,
  * mirroring how `GLOBAL_QUEUE_CONCURRENCY` tunes the GroupQueue.
  */
 export function resolveSpanCommandShardCount(raw: string | undefined): number {
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 1) return 1;
-  return Math.min(parsed, MAX_SPAN_SHARD_COUNT);
+  return clampSpanShardCount(Number(raw));
 }

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -19,14 +19,17 @@ import {
   RecordSpanCommand,
 } from "./commands/recordSpanCommand";
 import { ResolveOriginCommand } from "./commands/resolveOriginCommand";
+import { spanCommandGroupKey } from "./commands/spanCommandGroupKey";
 import { LogRecordStorageMapProjection } from "./projections/logRecordStorage.mapProjection";
 import { MetricRecordStorageMapProjection } from "./projections/metricRecordStorage.mapProjection";
 import { SpanStorageMapProjection } from "./projections/spanStorage.mapProjection";
 import { TraceSummaryFoldProjection } from "./projections/traceSummary.foldProjection";
+import type { RecordSpanCommandData } from "./schemas/commands";
 import type { TraceProcessingEvent } from "./schemas/events";
 import type { NormalizedLogRecord } from "./schemas/logRecords";
 import type { NormalizedMetricRecord } from "./schemas/metricRecords";
 import type { NormalizedSpan } from "./schemas/spans";
+import { TraceRequestUtils } from "./utils/traceRequest.utils";
 
 export interface TraceProcessingPipelineDeps {
   spanAppendStore: AppendStore<NormalizedSpan>;
@@ -90,6 +93,14 @@ export interface TraceProcessingPipelineDeps {
    * event_log INSERT succeeds. Optional — without it, the spool path is disabled.
    */
   blobStore?: BlobStore;
+  /**
+   * Number of GroupQueue shards for `recordSpan` commands. `1` (default) keeps
+   * the historic per-trace group key; `> 1` spreads a trace's spans across
+   * `traceId:<shard>` groups so a hot trace drains in parallel. The trace-summary
+   * fold is unaffected — it runs on its own aggregate-keyed queue. See
+   * spanCommandGroupKey.ts.
+   */
+  spanCommandShardCount?: number;
   governanceKpisSyncReactor?: ReactorDefinition<
     TraceProcessingEvent,
     TraceSummaryData
@@ -225,21 +236,42 @@ export function createTraceProcessingPipeline(
     );
   }
 
+  // Span-command sharding: when shardCount > 1, spread a trace's recordSpan
+  // commands across `traceId:<shard>` GroupQueue groups so a hot trace drains in
+  // parallel instead of one span at a time. Defaults to 1 = the historic
+  // per-trace key. The command handler reads no trace state and the emitted
+  // span_received event still carries aggregateId = traceId, so the trace-summary
+  // fold (its own aggregate-keyed queue) is unaffected and the summary stays
+  // exact. See spanCommandGroupKey.ts and
+  // specs/event-sourcing/span-command-sharding.feature.
+  const spanCommandShardCount = deps.spanCommandShardCount ?? 1;
+  const recordSpanOptions = {
+    deduplication: RECORD_SPAN_DEDUPLICATION,
+    getGroupKey: (payload: RecordSpanCommandData) => {
+      const { traceId, spanId } = TraceRequestUtils.normalizeOtlpSpanIds(
+        payload.span,
+      );
+      return spanCommandGroupKey({
+        traceId,
+        spanId,
+        shardCount: spanCommandShardCount,
+      });
+    },
+  };
+
   // ADR-022: When blobStore is provided, inject it into a pre-constructed
   // RecordSpanCommand instance so the worker can reconstitute oversized commands
   // (S3 spool fetch + best-effort delete). Falls back to zero-arg construction
   // (no spool support) when blobStore is absent. Either way the recordSpan
-  // command carries the dedup config from main.
+  // command carries the dedup config and span-command sharding from main.
   const recordSpanBuilder = deps.blobStore
     ? builder.withCommandInstance(
         "recordSpan",
         RecordSpanCommand,
         new RecordSpanCommand({ blobStore: deps.blobStore }),
-        { deduplication: RECORD_SPAN_DEDUPLICATION },
+        recordSpanOptions,
       )
-    : builder.withCommand("recordSpan", RecordSpanCommand, {
-        deduplication: RECORD_SPAN_DEDUPLICATION,
-      });
+    : builder.withCommand("recordSpan", RecordSpanCommand, recordSpanOptions);
 
   return recordSpanBuilder
     .withCommand("assignTopic", AssignTopicCommand)

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -19,7 +19,10 @@ import {
   RecordSpanCommand,
 } from "./commands/recordSpanCommand";
 import { ResolveOriginCommand } from "./commands/resolveOriginCommand";
-import { spanCommandGroupKey } from "./commands/spanCommandGroupKey";
+import {
+  clampSpanShardCount,
+  spanCommandGroupKey,
+} from "./commands/spanCommandGroupKey";
 import { LogRecordStorageMapProjection } from "./projections/logRecordStorage.mapProjection";
 import { MetricRecordStorageMapProjection } from "./projections/metricRecordStorage.mapProjection";
 import { SpanStorageMapProjection } from "./projections/spanStorage.mapProjection";
@@ -236,18 +239,27 @@ export function createTraceProcessingPipeline(
     );
   }
 
-  // Span-command sharding: when shardCount > 1, spread a trace's recordSpan
-  // commands across `traceId:<shard>` GroupQueue groups so a hot trace drains in
-  // parallel instead of one span at a time. Defaults to 1 = the historic
-  // per-trace key. The command handler reads no trace state and the emitted
-  // span_received event still carries aggregateId = traceId, so the trace-summary
-  // fold (its own aggregate-keyed queue) is unaffected and the summary stays
-  // exact. See spanCommandGroupKey.ts and
-  // specs/event-sourcing/span-command-sharding.feature.
-  const spanCommandShardCount = deps.spanCommandShardCount ?? 1;
-  const recordSpanOptions = {
-    deduplication: RECORD_SPAN_DEDUPLICATION,
-    getGroupKey: (payload: RecordSpanCommandData) => {
+  // Span-command sharding: when the shard count is > 1, install a getGroupKey
+  // that spreads a trace's recordSpan commands across `traceId:<shard>`
+  // GroupQueue groups so a hot trace drains in parallel instead of one span at a
+  // time. When disabled (the default), install NO getGroupKey — the command
+  // falls back to getAggregateId, byte-identical to the historic per-trace key
+  // and with zero extra work on the span-ingest hot path. The count is clamped
+  // defensively so a caller constructing the pipeline directly (bypassing
+  // PipelineRegistry's env resolver) can't explode the number of groups. The
+  // command handler reads no trace state and the emitted span_received event
+  // still carries aggregateId = traceId, so the trace-summary fold (its own
+  // aggregate-keyed queue) is unaffected and the summary stays exact. See
+  // spanCommandGroupKey.ts and specs/event-sourcing/span-command-sharding.feature.
+  const spanCommandShardCount = clampSpanShardCount(
+    deps.spanCommandShardCount ?? 1,
+  );
+  const recordSpanOptions: {
+    deduplication: typeof RECORD_SPAN_DEDUPLICATION;
+    getGroupKey?: (payload: RecordSpanCommandData) => string;
+  } = { deduplication: RECORD_SPAN_DEDUPLICATION };
+  if (spanCommandShardCount > 1) {
+    recordSpanOptions.getGroupKey = (payload) => {
       const { traceId, spanId } = TraceRequestUtils.normalizeOtlpSpanIds(
         payload.span,
       );
@@ -256,8 +268,8 @@ export function createTraceProcessingPipeline(
         spanId,
         shardCount: spanCommandShardCount,
       });
-    },
-  };
+    };
+  }
 
   // ADR-022: When blobStore is provided, inject it into a pre-constructed
   // RecordSpanCommand instance so the worker can reconstitute oversized commands

--- a/specs/event-sourcing/span-command-sharding.feature
+++ b/specs/event-sourcing/span-command-sharding.feature
@@ -1,0 +1,75 @@
+Feature: Sharded span-command processing
+
+  `recordSpan` commands are grouped on the GroupQueue by a key derived from the
+  trace id, so every span of a trace lands in one group and drains one at a time
+  behind a single worker. Each span's per-span work — PII redaction, cost
+  enrichment, token estimation, content-drop — runs serially, which is fine for
+  an ordinary trace but not for one that accumulates thousands of spans.
+
+  # Why this exists — hot-trace command backlog
+  #
+  # A single trace with a reused trace_id (or a runaway agent loop) can queue
+  # thousands of recordSpan commands into one group. Observed live: ~6.5k
+  # commands pending on one group, oldest 11 minutes, while every other trace's
+  # spans waited their turn behind it. The command handler reads no trace-level
+  # state — it is a pure per-span transform that emits one span_received event
+  # stamped with the trace as its aggregate — so the *command* need not serialise
+  # on the trace. Only the trace-summary *fold* does, and it runs on its own
+  # aggregate-keyed queue. Splitting the command's group key into
+  # `traceId:<shard>` lets a hot trace's spans drain across several groups in
+  # parallel while the fold stays ordered per trace and the summary stays exact.
+  #
+  # Sharding is off by default (one shard = the historic trace-only key) and is
+  # raised by an operator. The per-tenant soft-cap still bounds how many of a
+  # tenant's groups run at once, so a fanned-out hot trace cannot starve its
+  # neighbours — see tenant-soft-cap.feature.
+
+  Background:
+    Given the trace-processing pipeline records spans via the recordSpan command
+
+  @unit @sharding
+  Scenario: Sharding disabled keeps the historic trace-only group key
+    Given span-command sharding is disabled
+    When the group key is derived for any span of a trace
+    Then the group key is the trace id alone
+    And every span of that trace shares one processing group
+
+  @unit @sharding
+  Scenario: Sharding spreads a trace's spans across groups
+    Given span-command sharding is enabled with several shards
+    When the group keys are derived for many spans of one trace
+    Then the spans are spread across more than one processing group
+    And no group key exceeds the configured shard count
+
+  @unit @sharding
+  Scenario: A span always maps to the same shard
+    Given span-command sharding is enabled
+    When the group key is derived twice for the same span
+    Then both derivations yield the same group
+    And the span's retries and dedup window stay in that one group
+
+  @unit @sharding
+  Scenario: The configured shard count is clamped to a safe range
+    Given an operator-supplied shard count that is absent, non-numeric, or below one
+    Then the resolved shard count falls back to one, leaving sharding disabled
+    And a shard count above the maximum is clamped down to the maximum
+
+  @integration @sharding @pipeline
+  Scenario: The pipeline shards the command while leaving the fold per-trace
+    Given the pipeline is built with several shards
+    When the recordSpan command's group key is derived for two different spans of one trace
+    Then the two spans can resolve to different groups
+    But the trace-summary fold's key remains the trace alone
+
+  @integration @sharding @pipeline
+  Scenario: The pipeline preserves the trace-only key when sharding is off
+    Given the pipeline is built with sharding disabled
+    When the recordSpan command's group key is derived for any span of a trace
+    Then the group key is the trace id alone, identical to before sharding existed
+
+  @integration @sharding @correctness
+  Scenario: The trace summary is exact regardless of sharding
+    Given many spans recorded for one trace with sharding enabled
+    When the spans are processed in parallel across shards
+    And the trace-summary fold catches up
+    Then the accumulated span count equals the number of spans recorded

--- a/specs/event-sourcing/span-command-sharding.feature
+++ b/specs/event-sourcing/span-command-sharding.feature
@@ -67,7 +67,12 @@ Feature: Sharded span-command processing
     When the recordSpan command's group key is derived for any span of a trace
     Then the group key is the trace id alone, identical to before sharding existed
 
-  @integration @sharding @correctness
+  # Correctness here is structural: the fold runs on its own trace-keyed queue,
+  # unaffected by the command shard key (see the scenario above), and existing
+  # fold coverage (fold-coalescing.feature) already proves the accumulated count
+  # is exact. A dedicated end-to-end parallel-drain test through the live
+  # GroupQueue + ClickHouse is a tracked gap.
+  @integration @sharding @correctness @unimplemented
   Scenario: The trace summary is exact regardless of sharding
     Given many spans recorded for one trace with sharding enabled
     When the spans are processed in parallel across shards


### PR DESCRIPTION
## Problem

A trace that accumulates thousands of spans (reused `trace_id`, runaway agent loop) queues all its `recordSpan` commands into **one** GroupQueue group keyed by the trace id, so they drain one-at-a-time behind a single worker. Each span's per-span work — PII redaction, cost enrichment, token estimation, content-drop — runs serially.

Observed live: **~6.5k commands pending on one group, oldest 11 minutes**.

```
Group ID                                              Pipeline          Pend.   Oldest
project_.../command/recordSpan/trace:534bd8a1...      trace_processing  6492    11m ago ⚠
```

## Why this is safe to parallelize

The `recordSpan` handler **reads no trace-level state** — it's a pure per-span transform that emits one `span_received` event stamped `aggregateId = traceId`. So the *command* doesn't need to serialise on the trace; only the trace-summary **fold** does, and it already runs on its **own aggregate-keyed queue** (`ProjectionRouter.initializeFoldQueues`, default group key `trace:<aggregateId>`), untouched by the command's group key. The event-store append is a plain INSERT with no optimistic-concurrency gate, and dedup / idempotency keys are already per-span (`tenantId:traceId:spanId`).

So splitting the command's GroupQueue key from `traceId` into `traceId:<shard>` lets a hot trace's spans drain across up to *N* groups **in parallel**, while the fold stays ordered per trace and the summary stays exact. This is the classic split: **parallelise the command, keep the fold on a single group key.** The framework already separates the two (`getGroupKey` overrides the command queue key; the event still carries `aggregateId = traceId`).

## Design decisions

- **Bounded shards, not per-span.** `traceId:(hash(spanId) % K)` with `K` small (default off; suggested 8–16), never raw `traceId:spanId`. Per-span would create thousands of GroupQueue groups for one trace — and the per-tenant soft-cap would **park** most of them, exactly the parked-set bloat behind prior incidents. Bounded K creates K groups, well within the cap's normal range.
- **Fairness is already handled.** The per-tenant soft-cap (dynamic water-level, engages under load) bounds how many of a tenant's groups run at once, so a fanned-out hot trace can't starve its neighbours.
- **Off by default.** `TRACE_SPAN_PROCESSING_SHARDS` defaults to `1` → the bare trace-only key, **byte-identical to today**. Flip the env to enable; clamped to `[1, 128]`.
- **FNV-1a bucket**, deterministic across processes/restarts (a span's retries and dedup window stay in one group), non-crypto to avoid a digest on the span-ingest hot path.

## What changed

| File | Change |
|---|---|
| `commands/spanCommandGroupKey.ts` | New: pure FNV-1a bucket + `traceId:<shard>` key + env resolver (clamped) |
| `pipeline.ts` | Install `getGroupKey` on the `recordSpan` command (both blobStore branches) |
| `pipelineRegistry.ts` | Resolve shard count from `TRACE_SPAN_PROCESSING_SHARDS` at composition |
| `specs/event-sourcing/span-command-sharding.feature` | Behaviour contract |

## Testing

- **Unit** (15): determinism, range, distribution, disabled→bare-trace passthrough, clamping, and **non-OTel-compliant trace/span ids** (arbitrary/non-hex/empty/unicode + colon-in-traceId collision guard).
- **Wiring** (8): the real pipeline shards the command while the trace-summary fold stays trace-keyed; both blobStore branches install it; dedup config preserved; default = disabled.
- Existing trace-processing command tests: 50 pass (no regression). Changed files typecheck clean.

## Rollout

Ship at `1` (no-op), then raise `TRACE_SPAN_PROCESSING_SHARDS` per environment and watch the `command/recordSpan` group depth and fold-queue lag.

## Follow-up (not in this PR)

The `spanStorage` **map** projection (stored_spans inserts) is still per-event; `SpanAppendStore.bulkAppend` exists but the map handler queue has no coalesce path yet. Wiring that would batch the CH inserts — a separate change to shared handler-queue infra.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional sharding for `recordSpan` command processing so spans from busy traces can be drained in parallel.
  * Span routing now distributes work using trace-aware shard keys while keeping the trace summary aggregation unchanged.
  * Shard count is configurable and safely clamped with a sensible default when unset or invalid.

* **Bug Fixes**
  * Preserves historic trace-only grouping when sharding is disabled.
  * Maintains deterministic shard/group assignment to ensure consistent retries and deduplication behavior.

* **Tests**
  * Added unit and pipeline wiring tests covering enabled/disabled sharding, determinism, and shard limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->