### PR TITLE
fix(outbox): wire the outbox runtime into EventSourcing on workers

### DIFF
--- a/langwatch/src/server/app-layer/__tests__/presets.outboxWiring.integration.test.ts
+++ b/langwatch/src/server/app-layer/__tests__/presets.outboxWiring.integration.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression test for the trigger-dispatch outage.
+ *
+ * The composition root (`presets.ts`) built the EventSourcing runtime BEFORE
+ * the outbox and passed the outbox to the pipeline registry (which never read
+ * it) instead of to `new EventSourcing({...})`. Result: on every worker,
+ * `EventSourcing._outbox` was undefined, so all four `.withOutbox` trigger
+ * reactors were adapted onto the silent drop path — each logging
+ * "...registered without an outbox runtime..." at registration and dropping
+ * every dispatch at runtime. No trigger automation fired.
+ *
+ * This test boots the REAL composition through `initializeDefaultApp` (not
+ * `createTestApp`, which injects null deps and bypasses the es↔outbox wiring —
+ * exactly why the bug shipped uncaught) and asserts the symptom: a WORKER app
+ * registers its outbox reactors WITH a runtime (zero drop-warnings), while a
+ * WEB app has none (drop-warnings expected — web has no consumer to drain).
+ * Before the fix, the worker assertion fails.
+ *
+ * Boot may throw partway through trace-pipeline registration because the test
+ * sandbox cannot resolve the lazy `require("~/server/db")` alias inside
+ * RecordSpanCommand. That is tolerated: the outbox reactors register earlier,
+ * so the wiring symptom is already observable when the throw happens.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Funnel every module's logger into one warn spy so we can see the
+// outbox-reactor-adapter's registration warning, which fires synchronously
+// while `initializeDefaultApp` wires the pipelines.
+const { warnSpy } = vi.hoisted(() => ({ warnSpy: vi.fn() }));
+vi.mock("~/utils/logger/server", () => {
+  const make = () => {
+    const logger = {
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: warnSpy,
+      error: vi.fn(),
+      fatal: vi.fn(),
+      child: () => logger,
+    };
+    return logger;
+  };
+  return { createLogger: make };
+});
+
+import { resetApp } from "~/server/app-layer/app";
+import type { App } from "~/server/app-layer/app";
+import { initializeDefaultApp } from "~/server/app-layer/presets";
+import type { ProcessRole } from "~/server/app-layer/config";
+
+const REGISTER_DROP_WARNING = "registered without an outbox runtime";
+
+function outboxDropWarnings(): number {
+  return warnSpy.mock.calls.filter((args) =>
+    args.some(
+      (arg) => typeof arg === "string" && arg.includes(REGISTER_DROP_WARNING),
+    ),
+  ).length;
+}
+
+/** Boot the composition, tolerating a sandbox-only `require("~/server/db")`
+ *  resolution failure deep in trace-pipeline registration — the outbox
+ *  reactors have already registered by then, which is all this test observes. */
+function bootTolerant(processRole: ProcessRole): App | undefined {
+  try {
+    return initializeDefaultApp({ processRole });
+  } catch {
+    return undefined;
+  }
+}
+
+describe("presets outbox wiring", () => {
+  afterEach(async () => {
+    await resetApp();
+    vi.clearAllMocks();
+  });
+
+  describe("when the app is initialized as a worker", () => {
+    it("registers outbox reactors WITH a runtime (no drop-warnings)", async () => {
+      await resetApp();
+      vi.clearAllMocks();
+
+      const app = bootTolerant("worker");
+
+      // The exact regression: without the fix these reactors register onto the
+      // silent drop path and this count is non-zero.
+      expect(outboxDropWarnings()).toBe(0);
+      // When the boot completes (sandbox permitting), assert the invariant
+      // directly too.
+      if (app?.eventSourcing) {
+        expect(app.eventSourcing.isOutboxWired).toBe(true);
+      }
+    });
+  });
+
+  describe("when the app is initialized as web", () => {
+    it("has no outbox runtime, so its outbox reactors register on the drop path", async () => {
+      await resetApp();
+      vi.clearAllMocks();
+
+      const app = bootTolerant("web");
+
+      // Web correctly has no outbox (no consumer to drain), so the drop-path
+      // registration warning is expected here — this is the control that
+      // proves the worker assertion above is meaningful.
+      expect(outboxDropWarnings()).toBeGreaterThan(0);
+      if (app?.eventSourcing) {
+        expect(app.eventSourcing.isOutboxWired).toBe(false);
+      }
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -513,15 +513,6 @@ export function initializeDefaultApp(options?: {
     "ShareService",
   );
 
-  const es = new EventSourcing({
-    clickhouse: clickhouseEnabled ? resolveClickHouseClient : void 0,
-    redis,
-    enabled: true,
-    isSaas: config.isSaas,
-    processRole: config.processRole,
-    retentionPolicyResolver: retentionPolicyCache,
-  });
-
   // Construct repositories at the composition root — ClickHouse-or-Memory decisions live here.
   const repositories: PipelineRepositories = {
     suiteRunState: clickhouseEnabled
@@ -572,9 +563,10 @@ export function initializeDefaultApp(options?: {
       }
     : undefined;
 
-  // Outbox stack: worker-only consumer loop, but the send-side handle is
-  // wired into the registry so reactors can enqueue settle payloads. Web
-  // processes don't build this (no settle traffic; no consumer to drain).
+  // Outbox stack: worker-only consumer loop. The send-side handle is wired
+  // into the EventSourcing runtime below (passed to `new EventSourcing`), so
+  // its `.withOutbox` reactors can enqueue settle payloads. Web processes
+  // don't build this (no settle traffic; no consumer to drain).
   const outbox =
     config.processRole === "worker"
       ? buildOutboxRuntime({
@@ -588,6 +580,22 @@ export function initializeDefaultApp(options?: {
           traceSummaryRepository: repositories.traceSummaryFold,
         })
       : undefined;
+
+  // EventSourcing must be constructed AFTER `outbox` and be given it here: the
+  // reactor adapter (`.withOutbox` → enqueueSettle) and the global queue's
+  // settle/cadence routing + audit adapter all read `this._outbox`, set once at
+  // construction. Passing `outbox` anywhere else (e.g. only to the registry)
+  // leaves every outbox reactor on the silent drop path — the trigger dispatch
+  // regression fixed here. See presets.outboxWiring.integration.test.ts.
+  const es = new EventSourcing({
+    clickhouse: clickhouseEnabled ? resolveClickHouseClient : void 0,
+    redis,
+    enabled: true,
+    isSaas: config.isSaas,
+    processRole: config.processRole,
+    retentionPolicyResolver: retentionPolicyCache,
+    outbox,
+  });
 
   const registry = new PipelineRegistry({
     eventSourcing: es,
@@ -611,7 +619,6 @@ export function initializeDefaultApp(options?: {
     blobStore,
     governanceKpisSync,
     governanceOcsfEventsSync,
-    outbox,
   });
   const commands = registry.registerAll();
   (globalForApp as any).__scenarioExecutionHandle =

--- a/langwatch/src/server/event-sourcing/eventSourcing.ts
+++ b/langwatch/src/server/event-sourcing/eventSourcing.ts
@@ -163,6 +163,21 @@ export class EventSourcing {
   }
 
   /**
+   * Whether an outbox runtime is wired into this instance.
+   *
+   * This is the exact invariant that silently broke trigger dispatch: on a
+   * worker the outbox must be present so `.withOutbox` reactors enqueue settle
+   * payloads instead of hitting the no-op drop path. It is set once, from the
+   * constructor `outbox` option — passing the runtime anywhere else (e.g. only
+   * to the pipeline registry) leaves this `false` and every trigger silently
+   * drops. Exposed so the composition root's wiring can be asserted in tests
+   * and surfaced as a worker health signal rather than failing invisibly.
+   */
+  get isOutboxWired(): boolean {
+    return !!this._outbox;
+  }
+
+  /**
    * Register a reactor on a global fold projection.
    *
    * Must be called before the projection registry is initialized

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/eventSourcing.outboxWiring.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/eventSourcing.outboxWiring.unit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression: the outbox runtime must reach the reactors it feeds.
+ *
+ * The trigger-dispatch outage (every worker logging "no outbox runtime is
+ * wired" and dropping the dispatch) was a composition-root wiring bug —
+ * `presets.ts` constructed the EventSourcing runtime BEFORE the outbox and
+ * handed the outbox to a different object, so `EventSourcing._outbox` stayed
+ * undefined and every `.withOutbox` reactor was adapted onto the silent drop
+ * path.
+ *
+ * This unit test locks the EventSourcing side of that contract: an instance
+ * constructed WITH an outbox adapts its `.withOutbox` reactors to the live
+ * dispatch path (`isOutboxWired` true, no registration drop-warning); one
+ * constructed WITHOUT it drops (`isOutboxWired` false, drop-warning fires at
+ * registration). The composition root that must actually pass the outbox in is
+ * covered by presets.outboxWiring.integration.test.ts.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shared logger stub so the adapter's `createLogger(...).warn(...)` funnels into
+// one spy we can assert on. The adapter emits the drop-warning synchronously at
+// registration time when no outbox runtime is present.
+const { warnSpy } = vi.hoisted(() => ({ warnSpy: vi.fn() }));
+vi.mock("~/utils/logger/server", () => {
+  const logger = {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: warnSpy,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: () => logger,
+  };
+  return { createLogger: () => logger };
+});
+
+import type { Event } from "../../domain/types";
+import { EventSourcing } from "../../eventSourcing";
+import { createMockFoldProjection } from "../../pipeline/__tests__/testHelpers";
+import { definePipeline } from "../../pipeline/staticBuilder";
+import type { OutboxReactorDefinition } from "../outboxReactor.types";
+import type { OutboxRuntime } from "../setup";
+
+const DROP_WARNING = "registered without an outbox runtime";
+
+function makeOutboxStub(): OutboxRuntime {
+  return {
+    dispatcher: { process: vi.fn(), processBatch: vi.fn() } as any,
+    auditAdapter: {} as any,
+    attachQueue: vi.fn(),
+    enqueueSettle: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** A minimal pipeline whose single reactor is registered via `.withOutbox`, so
+ *  registering it forces the runtime to adapt an outbox reactor (the exact code
+ *  path that regressed). */
+function pipelineWithOutboxReactor() {
+  const fold = createMockFoldProjection({ name: "testFold" });
+  const reactor: OutboxReactorDefinition<Event> = {
+    name: "testOutboxReactor",
+    decide: async () => [],
+  };
+  return definePipeline<Event>()
+    .withName("outbox-wiring-test")
+    .withAggregateType("trace")
+    .withFoldProjection("testFold", fold as any)
+    .withOutbox("testFold", "testOutboxReactor", reactor)
+    .build();
+}
+
+function dropWarningFired(): boolean {
+  return warnSpy.mock.calls.some((args) =>
+    args.some((arg) => typeof arg === "string" && arg.includes(DROP_WARNING)),
+  );
+}
+
+describe("EventSourcing outbox wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when constructed with an outbox runtime", () => {
+    it("reports the outbox as wired", () => {
+      const es = new EventSourcing({ enabled: true, outbox: makeOutboxStub() });
+
+      expect(es.isOutboxWired).toBe(true);
+    });
+
+    it("adapts .withOutbox reactors to the live path, not the drop path", () => {
+      const es = new EventSourcing({ enabled: true, outbox: makeOutboxStub() });
+
+      es.register(pipelineWithOutboxReactor());
+
+      expect(dropWarningFired()).toBe(false);
+    });
+  });
+
+  describe("when constructed without an outbox runtime", () => {
+    it("reports the outbox as not wired", () => {
+      const es = new EventSourcing({ enabled: true });
+
+      expect(es.isOutboxWired).toBe(false);
+    });
+
+    it("adapts .withOutbox reactors to the drop path, warning at registration", () => {
+      const es = new EventSourcing({ enabled: true });
+
+      es.register(pipelineWithOutboxReactor());
+
+      expect(dropWarningFired()).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -50,7 +50,6 @@ import type { RetentionPolicyResolver } from "../data-retention/retentionPolicyR
 import { type CommandDispatcher, Deferred } from "./deferred";
 import type { EventSourcing } from "./eventSourcing";
 import { mapCommands } from "./mapCommands";
-import type { OutboxRuntime } from "./outbox/setup";
 import type { StaticPipelineDefinition } from "./pipeline/staticBuilder.types";
 import { ReportUsageForMonthCommand } from "./pipelines/billing-reporting/commands/reportUsageForMonth.command";
 import {
@@ -214,15 +213,6 @@ export interface PipelineRegistryDeps {
   blobStore?: import("~/server/app-layer/traces/blob-store.service").BlobStore;
   governanceKpisSync?: GovernanceKpisSyncReactorDeps;
   governanceOcsfEventsSync?: GovernanceOcsfEventsSyncReactorDeps;
-  /**
-   * Wired by the worker composition root (`presets.ts`) and `undefined`
-   * on the web process. When set, all four trigger reactors route their
-   * matches into the unified outbox queue's settle stage (ADR-030 +
-   * ADR-026 + ADR-035) — both NOTIFY (email / Slack) and PERSIST
-   * (dataset / annotation) classes now ride settle → cadence; nothing
-   * dispatches inline.
-   */
-  outbox?: OutboxRuntime;
   retentionPolicyResolver?: RetentionPolicyResolver;
 }
 


### PR DESCRIPTION
## Problem

After the event-sourced trigger build went live, **all trigger automations stopped firing in production.** Workers logged, on every dispatch:

```
Outbox reactor received an event but no outbox runtime is wired;
dropping the dispatch (check LANGWATCH_SKIP_OUTBOX / worker outbox wiring)
```

CloudWatch (`/aws/eks/langwatch-cluster/pods`, worker pods) showed **~9,300 drops/hour and zero successful notify dispatches** once the new build became the sole running version. Trace `4d8aee…` — the report that kicked this off — was dropped along with everything else.

## Root cause

A composition-root ordering bug in `presets.ts`:

- `const es = new EventSourcing({…})` was constructed **before** `const outbox = …`, so `es` never received the outbox and `EventSourcing._outbox` stayed `undefined` — on workers too.
- The outbox that *was* built got passed to `PipelineRegistry`, which **never reads it** (dead dependency).
- `EventSourcing.register()` → `buildServiceOptions(def, this._outbox)` → `adaptOutboxReactor(def, undefined)` → the no-op **drop path** for every `.withOutbox` reactor. `createGlobalQueue()` reads the same `this._outbox`, so the queue's settle/cadence routing and audit adapter were never wired either.

Because `outbox`-build and consumer-enable share the same `processRole === "worker"` flag, the worker consumed events *and* dropped every trigger. No cron fallback exists for trace triggers, so nothing else fired them.

The existing `triggerDispatch.fullflow.integration.test.ts` didn't catch it because it hand-wires `createOutboxDispatcher(...)` directly, bypassing the composition root — which is exactly where the bug lived.

## Fix

- **`presets.ts`** — build `outbox` first, construct `EventSourcing` **after** it, and pass it into the constructor (the `outbox` option already existed; it was simply never supplied). Remove the dead `outbox` arg from the `PipelineRegistry(...)` call.
- **`pipelineRegistry.ts`** — delete the dead `outbox?: OutboxRuntime` dep + import. This second, unused channel is what made the wrong wiring look plausible; removing it prevents recurrence.
- **`eventSourcing.ts`** — add `isOutboxWired` as an explicit wiring-health invariant (also usable as a worker health signal so this can't fail invisibly again).

## Tests

- **Unit** — `eventSourcing.outboxWiring.unit.test.ts`: an `EventSourcing` built WITH an outbox adapts `.withOutbox` reactors to the live path; WITHOUT one they hit the drop path. Locks the runtime↔adapter contract. ✅ green
- **Integration** — `presets.outboxWiring.integration.test.ts`: boots the **real composition** via `initializeDefaultApp` and asserts a worker wires the outbox (zero drop-warnings / `isOutboxWired === true`) while web does not. **Verified fail-before / pass-after** (reverting the one-line wiring makes the worker case fail with 2 drop-warnings). ✅ green

Regression suites re-run clean: outbox + event-sourcing runtime unit suites (130 tests) pass.

### On "e2e"
This is a backend worker-wiring defect with no UI surface, so a browser e2e isn't meaningful. The integration test above *is* the end-to-end verification — it exercises the real composition root end-to-end. End-to-end **delivery** (Slack/email/dataset/annotation for every action type) is already covered by the existing `triggerDispatch.fullflow.integration.test.ts`, which is unaffected by this change. Happy to add a heavier boot-worker → drive-span → assert-notification e2e as a follow-up if wanted (it needs the pre-existing `require("~/server/db")` alias in `RecordSpanCommand` converted to a static import first, which is out of scope for this hotfix).

## Deploy note
This is the code fix. Once merged and rolled out, verify the stale worker replicaset serving the old build is fully cycled out so the shared `{event-sourcing/jobs}` queue is drained only by outbox-wired workers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event processing reliability so outbox-backed actions are correctly wired in the appropriate runtime.
  * Reduced the chance of silent failures when reactor work is registered without an available outbox.

* **Tests**
  * Added regression coverage for event-sourcing and outbox wiring across worker and web runtime modes.
  * Added unit coverage for outbox-enabled and outbox-missing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->