### PR TITLE
feat(app): serve content-hashed assets from a runtime-configurable CDN base

### DIFF
--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -148,6 +148,14 @@ spec:
             - name: LANGWATCH_ENDPOINT
               value: {{ .Values.app.http.langwatchEndpoint | default (printf "http://localhost:%v" (.Values.app.service.port | default 5560)) | quote }}
 
+            # Content-hashed asset base (ADR-086). Empty by default → assets are
+            # served same-origin from the pod. Set to a commit-prefixed CDN base
+            # so a rolling deploy never strands a browser on a stale-chunk 404.
+            {{- if .Values.app.assetBase }}
+            - name: LANGWATCH_ASSET_BASE
+              value: {{ .Values.app.assetBase | quote }}
+            {{- end }}
+
             # Cron API key
             {{- if .Values.app.cronApiKey.secretKeyRef.name }}
             - name: CRON_API_KEY

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -223,6 +223,16 @@ app:
     # chart-default installs boot past the post-#3541 required-env validation.
     langwatchEndpoint: ""
 
+  # Base URL for content-hashed frontend assets (JS/CSS chunks). Empty (default)
+  # serves them same-origin straight from the pod, exactly as before. Set to a
+  # commit-prefixed CDN base — e.g. "https://cdn.langwatch.ai/<commit-sha>/" — so
+  # a rolling deploy never strands a browser on a 404: every past build's assets
+  # remain under their own immutable prefix. The deploy pipeline both uploads
+  # dist/client/assets to that prefix and sets this value for the same SHA. See
+  # ADR-086. Rendered into the LANGWATCH_ASSET_BASE env var when non-empty.
+  ## @param app.assetBase [string, default: ""] CDN base URL for content-hashed assets; empty = serve same-origin from the pod.
+  assetBase: ""
+
   # Feature flags to enable/disable specific functionality
   ## @extra app.features Feature flags for the app.
   ## @param app.features.skipEnvValidation [default: false] Skip env var validation (dev only).

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -225,7 +225,7 @@ app:
 
   # Base URL for content-hashed frontend assets (JS/CSS chunks). Empty (default)
   # serves them same-origin straight from the pod, exactly as before. Set to a
-  # commit-prefixed CDN base — e.g. "https://cdn.langwatch.ai/<commit-sha>/" — so
+  # commit-prefixed CDN base — e.g. "https://cdn.langwatch.ai/git-<short-sha>/" — so
   # a rolling deploy never strands a browser on a 404: every past build's assets
   # remain under their own immutable prefix. The deploy pipeline both uploads
   # dist/client/assets to that prefix and sets this value for the same SHA. See

--- a/dev/docs/adr/086-cdn-asset-base.md
+++ b/dev/docs/adr/086-cdn-asset-base.md
@@ -1,0 +1,137 @@
+# ADR-086: Runtime-configurable CDN base for content-hashed assets
+
+**Date:** 2026-07-08
+
+**Status:** Accepted
+
+## Context
+
+The web app is a Vite SPA whose JS/CSS chunks carry content-hash filenames
+(`dialog.anatomy-CGguCKQj.js`). In production these are served directly from the
+app pods by the Node server (`src/server/static-handler.ts`); there is no CDN in
+front. Prod runs three replicas on the default `RollingUpdate` strategy.
+
+During a rolling deploy two builds serve simultaneously behind one Service. A
+browser fetches the HTML shell from build A, then a lazy `import()` of a build-A
+chunk is load-balanced to a build-B pod that does not have that hash — a hard
+`404 (Not Found)`. Reported symptom:
+
+```
+GET https://app.langwatch.ai/assets/dialog.anatomy-CGguCKQj.js net::ERR_ABORTED 404
+```
+
+Two mitigations already exist and remain: the `vite:preloadError` reload guard
+(`src/utils/chunkReload.ts`) and the deliberate `404` for missing `/assets/*`
+(spa-fallback.feature). Neither closes the *mid-deploy* window — a reload can
+re-split across builds, and the 10s cooldown then strands the tab for the rest of
+a multi-minute roll.
+
+No `RollingUpdate` tuning removes the overlap (a Deployment is inherently
+rolling); `Recreate` removes it only by adding downtime; blue-green only shrinks
+the window. The overlap is not the root cause — coupling *asset availability* to
+*which pod/build serves the request* is. The durable fix is to make every build's
+assets available independent of which pod serves the shell.
+
+The hard constraint: the published `langwatch` Docker image is **shared by
+self-hosters and LangWatch SaaS**. Vite's `base` is a compile-time constant, so a
+CDN URL cannot be baked into the image without breaking every self-host install.
+
+## Decision
+
+We will host content-hashed assets on a **commit-prefixed, immutable CDN**
+(CloudFront over S3) and choose the base **at container start**, not build time.
+
+**Asset URL indirection (build).** `vite.config.ts` uses
+`experimental.renderBuiltUrl` so every JS-referenced asset URL is emitted as
+`window.__lwAssetUrl(<path relative to the build root>)`, CSS-referenced assets
+become relative to the CSS file, and HTML entry references stay base-absolute
+(`/assets/…`). `public/` assets stay same-origin.
+
+**Runtime injection (serve).** The server injects an inline classic
+`<script>` into the served HTML shell that defines `window.__lwAssetBase` and
+`window.__lwAssetUrl` from `LANGWATCH_ASSET_BASE`, and rewrites the entry
+`<script>` / `modulepreload` / stylesheet `/assets/…` hrefs to that base. A
+classic inline script runs before deferred module scripts, so the resolver is
+defined before the entry chunk's dynamic imports evaluate.
+
+- **Unset / `/` (self-host default):** `__lwAssetUrl("assets/x.js")` → `/assets/x.js`,
+  served by the pod exactly as before. The HTML rewrite is a no-op. Behaviour is
+  unchanged for self-host.
+- **`https://cdn.langwatch.ai/<commit-sha>/` (SaaS):** assets resolve to the
+  commit-prefixed CDN namespace.
+
+**Immutability model.** Each deploy `aws s3 sync`s `dist/client/assets/` into
+`s3://<bucket>/<commit-sha>/assets/` and **never** `--delete`s. Double
+immutability — the content hash freezes each file's bytes; the commit prefix
+freezes each build's namespace. Old tabs keep resolving because their build's
+prefix still exists. Cleanup is an S3 lifecycle rule expiring prefixes after a
+window safely longer than any tab's lifetime. `langwatch/scripts/upload-assets-to-cdn.sh`
+performs the sync; the SaaS deploy pipeline invokes it with the build's SHA.
+
+**CSP.** When `LANGWATCH_ASSET_BASE` names an external origin, that origin is
+added to `script-src`, `style-src`, `font-src`, `img-src`, `connect-src`, and
+`worker-src`. Same-origin serving adds nothing.
+
+**Ownership boundary.** This repo owns the app-side contract (Vite, server, CSP,
+the `app.assetBase` Helm value → `LANGWATCH_ASSET_BASE`, the upload script,
+this ADR, and `specs/server/cdn-asset-base.feature`). The CloudFront
+distribution, the S3 bucket + lifecycle rule, DNS, and wiring the upload +
+`<sha>` into the SaaS deploy pipeline live in the infra repo and are a handoff.
+
+## Rationale / Trade-offs
+
+Baking the base at build time (a `VITE_ASSET_BASE` arg) is simpler but forks the
+image: the public image would point self-hosters at `cdn.langwatch.ai`. Runtime
+injection keeps one image for both audiences at the cost of a small server-side
+HTML transform and one inline script. Because JS chunks are served *by the CDN*,
+serve-time string replacement in the JS is impossible — the base must resolve in
+the browser at execution time, which is exactly what `renderBuiltUrl`'s `runtime`
+form provides.
+
+We keep the existing `chunkReload` guard and the missing-asset `404` as
+belt-and-suspenders: with the CDN they should effectively never fire, but they
+still cover a self-host install, a prefix expired earlier than a tab's lifetime,
+or an asset genuinely absent from the bucket.
+
+The rollout strategy is left untouched — the fix removes the *need* to serialize
+the roll, so no downtime (`Recreate`) and no new cluster dependency (Argo
+Rollouts blue-green) are introduced.
+
+## Consequences
+
+- Mid-deploy asset `404`s disappear on SaaS without changing the rollout, because
+  both builds' assets are always present in the CDN, keyed by commit.
+- Self-host is unaffected: unset env → same-origin, pod-served assets, no CDN.
+- The server now transforms the HTML shell (read + inject) instead of streaming
+  it; the shell is tiny and already `no-cache`, so the cost is negligible. Asset
+  streaming for non-HTML files is unchanged.
+- CSP is now env-derived for the asset origin; misconfiguration surfaces as a
+  blocked-resource console error rather than a silent 404.
+- New operational duty (infra repo): the S3 lifecycle retention window is both
+  the max tab lifetime (a tab older than it 404s, then `chunkReload` recovers
+  with a reload) AND the **rollback horizon** — rolling the app back to a tag
+  whose prefix expired, or a pre-CDN tag never uploaded, 404s every chunk with no
+  recovery for the entry script. Retention defaults to 365d; to roll back
+  further, disable the CDN in the same apply so assets fall back to same-origin.
+- CloudFront must send permissive CORS (`Access-Control-Allow-Origin`) for the
+  asset prefix: `crossorigin` module scripts and fonts are fetched cross-origin
+  from the CDN and fail without it. The CSP already admits the CDN origin to
+  `connect-src`/`worker-src`/`font-src`; CORS is the server-side half and lives
+  in the infra repo.
+- **Self-sufficient artifact / Web Workers.** The `renderBuiltUrl` runtime
+  expression is self-defaulting — `(globalThis.__lwAssetUrl || (p => "/"+p))(…)`
+  — so the built bundle works even when the resolver was never injected: `vite
+  preview`, the CI boot-smoke, and any raw-`dist/` static server all fall back to
+  same-origin. Reading via `globalThis` (defined in Web Worker scopes too, where
+  `window` is not) means a worker chunk degrades to same-origin rather than
+  throwing. The only consequence: a future CDN-hosted worker asset would be
+  served same-origin (from the pod) instead of the CDN until the server-side
+  resolver is made worker-aware — correct, just not edge-cached.
+
+## References
+
+- Related ADRs: ADR-032 (datasets S3 JSONL — same S3 client/CSP `connect-src` derivation)
+- Spec: `specs/server/cdn-asset-base.feature`, `specs/server/spa-fallback.feature`
+- Code: `src/server/asset-base.ts`, `src/server/static-handler.ts`,
+  `src/start.ts`, `vite.config.ts`, `langwatch/scripts/upload-assets-to-cdn.sh`
+- Vite: `experimental.renderBuiltUrl` (runtime public base path)

--- a/dev/docs/adr/086-cdn-asset-base.md
+++ b/dev/docs/adr/086-cdn-asset-base.md
@@ -65,7 +65,7 @@ defined before the entry chunk's dynamic imports evaluate.
 immutability — the content hash freezes each file's bytes; the commit prefix
 freezes each build's namespace. Old tabs keep resolving because their build's
 prefix still exists. Cleanup is an S3 lifecycle rule expiring prefixes after a
-window safely longer than any tab's lifetime. `langwatch/scripts/upload-assets-to-cdn.sh`
+window safely longer than any tab's lifetime. `platform/app/scripts/upload-assets-to-cdn.sh`
 performs the sync; the SaaS deploy pipeline invokes it with the build's SHA.
 
 **CSP.** When `LANGWATCH_ASSET_BASE` names an external origin, that origin is
@@ -132,6 +132,7 @@ Rollouts blue-green) are introduced.
 
 - Related ADRs: ADR-032 (datasets S3 JSONL — same S3 client/CSP `connect-src` derivation)
 - Spec: `specs/server/cdn-asset-base.feature`, `specs/server/spa-fallback.feature`
-- Code: `src/server/asset-base.ts`, `src/server/static-handler.ts`,
-  `src/start.ts`, `vite.config.ts`, `langwatch/scripts/upload-assets-to-cdn.sh`
+- Code: `platform/app/src/server/asset-base.ts`, `platform/app/src/server/static-handler.ts`,
+  `platform/app/src/server/securityHeaders.ts`, `platform/app/src/start.ts`,
+  `platform/app/vite.config.ts`, `platform/app/scripts/upload-assets-to-cdn.sh`
 - Vite: `experimental.renderBuiltUrl` (runtime public base path)

--- a/dev/docs/adr/086-cdn-asset-base.md
+++ b/dev/docs/adr/086-cdn-asset-base.md
@@ -16,7 +16,7 @@ browser fetches the HTML shell from build A, then a lazy `import()` of a build-A
 chunk is load-balanced to a build-B pod that does not have that hash — a hard
 `404 (Not Found)`. Reported symptom:
 
-```
+```text
 GET https://app.langwatch.ai/assets/dialog.anatomy-CGguCKQj.js net::ERR_ABORTED 404
 ```
 

--- a/dev/docs/adr/086-cdn-asset-base.md
+++ b/dev/docs/adr/086-cdn-asset-base.md
@@ -66,7 +66,11 @@ immutability — the content hash freezes each file's bytes; the commit prefix
 freezes each build's namespace. Old tabs keep resolving because their build's
 prefix still exists. Cleanup is an S3 lifecycle rule expiring prefixes after a
 window safely longer than any tab's lifetime. `platform/app/scripts/upload-assets-to-cdn.sh`
-performs the sync; the SaaS deploy pipeline invokes it with the build's SHA.
+is this repo's reference implementation of that sync and fixes the contract: the
+prefix is the deployed image tag (`git-<short-sha>`), because that is what the
+running app requests via `LANGWATCH_ASSET_BASE`. The SaaS pipeline inlines the
+same `aws s3 sync` rather than calling the script, so the two must agree on that
+prefix.
 
 **CSP.** When `LANGWATCH_ASSET_BASE` names an external origin, that origin is
 added to `script-src`, `style-src`, `font-src`, `img-src`, `connect-src`, and

--- a/dev/docs/adr/086-cdn-asset-base.md
+++ b/dev/docs/adr/086-cdn-asset-base.md
@@ -57,11 +57,11 @@ defined before the entry chunk's dynamic imports evaluate.
 - **Unset / `/` (self-host default):** `__lwAssetUrl("assets/x.js")` → `/assets/x.js`,
   served by the pod exactly as before. The HTML rewrite is a no-op. Behaviour is
   unchanged for self-host.
-- **`https://cdn.langwatch.ai/<commit-sha>/` (SaaS):** assets resolve to the
+- **`https://cdn.langwatch.ai/git-<short-sha>/` (SaaS):** assets resolve to the
   commit-prefixed CDN namespace.
 
 **Immutability model.** Each deploy `aws s3 sync`s `dist/client/assets/` into
-`s3://<bucket>/<commit-sha>/assets/` and **never** `--delete`s. Double
+`s3://<bucket>/git-<short-sha>/assets/` and **never** `--delete`s. Double
 immutability — the content hash freezes each file's bytes; the commit prefix
 freezes each build's namespace. Old tabs keep resolving because their build's
 prefix still exists. Cleanup is an S3 lifecycle rule expiring prefixes after a

--- a/platform/app/.env.example
+++ b/platform/app/.env.example
@@ -24,6 +24,14 @@ NEXTAUTH_URL="http://localhost:5560"
 # BASE_HOST locally; in a cluster, set it to the internal service URL.
 LANGWATCH_API_URL="http://localhost:5560"
 
+# Optional (multi-replica deploys behind a CDN, see ADR-086). Base URL for
+# content-hashed frontend assets. Leave unset to serve them same-origin from the
+# app itself (the default; correct for self-host). Set to a commit-prefixed CDN
+# base — e.g. "https://cdn.example.com/<commit-sha>/" — so a rolling deploy never
+# serves a browser a stale-chunk 404: every past build's assets stay under their
+# own immutable prefix. The deploy pipeline sets this per build.
+#LANGWATCH_ASSET_BASE=""
+
 # This is a comma separated list of the namespaces of the messages you want to print following npm `debug` library standard
 DEBUG=langwatch:*
 

--- a/platform/app/scripts/upload-assets-to-cdn.sh
+++ b/platform/app/scripts/upload-assets-to-cdn.sh
@@ -26,7 +26,7 @@
 #
 # Usage:
 #   BUCKET=langwatch-frontend-assets SHA="git-$(git rev-parse --short HEAD)" \
-#     langwatch/scripts/upload-assets-to-cdn.sh [--dry-run]
+#     platform/app/scripts/upload-assets-to-cdn.sh [--dry-run]
 #
 # Env:
 #   BUCKET      (required) S3 bucket name backing the CDN.

--- a/platform/app/scripts/upload-assets-to-cdn.sh
+++ b/platform/app/scripts/upload-assets-to-cdn.sh
@@ -5,9 +5,9 @@
 # The web app's chunks carry content-hash filenames and, from ADR-086, resolve
 # against a runtime base of the form:
 #
-#     https://<cdn-host>/<commit-sha>/assets/<hash>.js
+#     https://<cdn-host>/git-<short-sha>/assets/<hash>.js
 #
-# This script syncs `dist/client/assets/` into `s3://<bucket>/<commit-sha>/assets/`.
+# This script syncs `dist/client/assets/` into `s3://<bucket>/git-<short-sha>/assets/`.
 # Two invariants make a rolling deploy safe:
 #   1. NEVER `--delete` — a previous build's prefix must survive so a browser
 #      that loaded the old shell can still fetch its (old-hash) chunks.

--- a/platform/app/scripts/upload-assets-to-cdn.sh
+++ b/platform/app/scripts/upload-assets-to-cdn.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Upload content-hashed frontend assets to the immutable, commit-prefixed CDN
+# bucket (CloudFront over S3). See ADR-086.
+#
+# The web app's chunks carry content-hash filenames and, from ADR-086, resolve
+# against a runtime base of the form:
+#
+#     https://<cdn-host>/<commit-sha>/assets/<hash>.js
+#
+# This script syncs `dist/client/assets/` into `s3://<bucket>/<commit-sha>/assets/`.
+# Two invariants make a rolling deploy safe:
+#   1. NEVER `--delete` — a previous build's prefix must survive so a browser
+#      that loaded the old shell can still fetch its (old-hash) chunks.
+#   2. Immutable cache — every object is content-addressed under a per-build
+#      prefix, so it can be cached forever.
+#
+# Old prefixes are reaped by an S3 lifecycle rule (infra repo), configured to
+# retain them well beyond the longest realistic browser-tab lifetime.
+#
+# The langwatch-saas build pipeline inlines this `aws s3 sync` rather than
+# calling this script (submodule-pin timing), so if you run it by hand keep the
+# prefix identical to that pipeline: SHA MUST be the deployed image tag
+# (`git-<short-sha>`), because that is the prefix the running app requests via
+# LANGWATCH_ASSET_BASE=https://<cdn-host>/<tag>/. A full `git rev-parse HEAD`
+# would upload to a prefix the app never reads.
+#
+# Usage:
+#   BUCKET=langwatch-frontend-assets SHA="git-$(git rev-parse --short HEAD)" \
+#     langwatch/scripts/upload-assets-to-cdn.sh [--dry-run]
+#
+# Env:
+#   BUCKET      (required) S3 bucket name backing the CDN.
+#   SHA         (required) Path prefix = the deployed image tag (git-<short-sha>).
+#   DIST        (optional) Client build dir. Default: dist/client (cwd-relative).
+#   AWS_REGION  (optional) Passed through to the AWS CLI.
+
+set -euo pipefail
+
+: "${BUCKET:?set BUCKET to the CDN S3 bucket name}"
+: "${SHA:?set SHA to the commit sha used as the immutable path prefix}"
+
+DIST="${DIST:-dist/client}"
+ASSETS_DIR="${DIST}/assets"
+DEST="s3://${BUCKET}/${SHA}/assets"
+
+if [[ ! -d "${ASSETS_DIR}" ]]; then
+  echo "error: ${ASSETS_DIR} not found — run \`pnpm build\` first" >&2
+  exit 1
+fi
+
+DRY_RUN=()
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=(--dryrun)
+  echo "[dry-run] no objects will be written"
+fi
+
+echo "Syncing ${ASSETS_DIR} -> ${DEST} (immutable, no delete)"
+
+# --size-only avoids re-uploading unchanged content-hashed files on a retry;
+# because filenames are content-addressed, identical name ⇒ identical bytes.
+# Deliberately no --delete: older builds' prefixes must remain reachable.
+# --exclude "*.map": Vite emits sourcemaps into assets/; keep them off the public
+# CDN (the runtime image strips them too) so source isn't disclosed.
+aws s3 sync "${ASSETS_DIR}" "${DEST}" \
+  "${DRY_RUN[@]}" \
+  --size-only \
+  --no-progress \
+  --exclude "*.map" \
+  --cache-control "public, max-age=31536000, immutable"
+
+echo "Done. Set LANGWATCH_ASSET_BASE / app.assetBase to:"
+echo "  https://<cdn-host>/${SHA}/"

--- a/platform/app/src/server/__tests__/asset-base.unit.test.ts
+++ b/platform/app/src/server/__tests__/asset-base.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   ASSET_URL_GLOBAL,
-  assetBaseBootstrapScript,
+  assetBaseBootstrapBody,
   assetBaseOrigin,
   injectAssetBaseIntoHtml,
   normalizeAssetBase,
@@ -16,13 +16,9 @@ const CDN = "https://cdn.langwatch.ai/abc123/";
  * runs rather than a re-implementation of it.
  */
 function evalResolver(base: string): (p: string) => string {
-  const inner = /<script>([\s\S]*?)<\/script>/.exec(
-    assetBaseBootstrapScript(base),
-  )?.[1];
-  if (!inner) throw new Error("bootstrap script had no body");
   const win: Record<string, unknown> = {};
   // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  new Function("window", inner)(win);
+  new Function("window", assetBaseBootstrapBody(base))(win);
   return win[ASSET_URL_GLOBAL] as (p: string) => string;
 }
 

--- a/platform/app/src/server/__tests__/asset-base.unit.test.ts
+++ b/platform/app/src/server/__tests__/asset-base.unit.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ASSET_URL_GLOBAL,
+  assetBaseBootstrapScript,
+  assetBaseOrigin,
+  injectAssetBaseIntoHtml,
+  normalizeAssetBase,
+} from "../asset-base";
+
+const CDN = "https://cdn.langwatch.ai/abc123/";
+
+/**
+ * Execute the injected bootstrap against a stub `window` and return the real
+ * `__lwAssetUrl` resolver, so the tests exercise the JS the browser actually
+ * runs rather than a re-implementation of it.
+ */
+function evalResolver(base: string): (p: string) => string {
+  const inner = /<script>([\s\S]*?)<\/script>/.exec(
+    assetBaseBootstrapScript(base),
+  )?.[1];
+  if (!inner) throw new Error("bootstrap script had no body");
+  const win: Record<string, unknown> = {};
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  new Function("window", inner)(win);
+  return win[ASSET_URL_GLOBAL] as (p: string) => string;
+}
+
+describe("normalizeAssetBase", () => {
+  describe("when the value is absent or same-origin", () => {
+    it("maps undefined to the same-origin sentinel", () => {
+      expect(normalizeAssetBase(undefined)).toBe("/");
+    });
+
+    it("maps an empty or whitespace value to the same-origin sentinel", () => {
+      expect(normalizeAssetBase("")).toBe("/");
+      expect(normalizeAssetBase("   ")).toBe("/");
+    });
+
+    it("maps a bare slash to the same-origin sentinel", () => {
+      expect(normalizeAssetBase("/")).toBe("/");
+    });
+  });
+
+  describe("when the value is a CDN base", () => {
+    /** @scenario A CDN base resolves assets to the CDN, with or without a trailing slash */
+    it("appends a trailing slash when missing", () => {
+      expect(normalizeAssetBase("https://cdn.langwatch.ai/abc123")).toBe(CDN);
+    });
+
+    it("leaves an existing trailing slash intact", () => {
+      expect(normalizeAssetBase(CDN)).toBe(CDN);
+    });
+
+    it("trims surrounding whitespace", () => {
+      expect(normalizeAssetBase(`  ${CDN}  `)).toBe(CDN);
+    });
+  });
+
+  describe("when the value is not an absolute http(s) URL", () => {
+    /** @scenario A misconfigured base fails fast instead of silently serving 404s */
+    it("throws on a scheme-less value that would silently break assets", () => {
+      // Without this, the rewrite emits a broken *relative* url and the CSP
+      // (via new URL()) drops the origin — the silent-404 this feature fixes.
+      expect(() => normalizeAssetBase("cdn.langwatch.ai/abc123/")).toThrow(
+        /absolute http\(s\) URL/,
+      );
+    });
+
+    it("throws on a non-http(s) scheme", () => {
+      expect(() =>
+        normalizeAssetBase("ftp://cdn.langwatch.ai/abc123/"),
+      ).toThrow(/http or https/);
+    });
+  });
+});
+
+describe("assetBaseOrigin", () => {
+  describe("when the base is same-origin", () => {
+    it("returns null so nothing is added to the CSP", () => {
+      expect(assetBaseOrigin("/")).toBeNull();
+    });
+  });
+
+  describe("when the base is an external CDN", () => {
+    it("returns just the origin, dropping the commit-prefix path", () => {
+      expect(assetBaseOrigin(CDN)).toBe("https://cdn.langwatch.ai");
+    });
+  });
+
+  describe("when the base does not parse as a URL", () => {
+    it("returns null rather than throwing (defensive)", () => {
+      expect(assetBaseOrigin("not a url/")).toBeNull();
+    });
+  });
+});
+
+describe("the injected resolver", () => {
+  describe("when the base is same-origin", () => {
+    /** @scenario With no asset base set, assets are served same-origin from the pod */
+    it("prefixes a relative asset path with a leading slash", () => {
+      expect(evalResolver("/")("assets/x.js")).toBe("/assets/x.js");
+    });
+  });
+
+  describe("when the base is a CDN", () => {
+    it("prefixes a relative asset path with the full CDN base", () => {
+      expect(evalResolver(CDN)("assets/x.js")).toBe(`${CDN}assets/x.js`);
+    });
+  });
+});
+
+describe("injectAssetBaseIntoHtml", () => {
+  const shell =
+    "<!doctype html><html><head><title>x</title>" +
+    '<script type="module" src="/assets/index-deadbeef.js"></script>' +
+    '<link rel="stylesheet" href="/assets/index-cafe.css"></head>' +
+    '<body><div id="root"></div></body></html>';
+
+  describe("when the base is same-origin", () => {
+    it("injects the resolver bootstrap into the head", () => {
+      const out = injectAssetBaseIntoHtml(shell, "/");
+      expect(out).toContain(`window.${ASSET_URL_GLOBAL}`);
+      // bootstrap lands inside <head>, before the entry script
+      expect(out.indexOf(ASSET_URL_GLOBAL)).toBeLessThan(
+        out.indexOf("index-deadbeef.js"),
+      );
+    });
+
+    /** @scenario Same-origin rewriting is a no-op for the entry references */
+    it("leaves the base-absolute entry references untouched", () => {
+      const out = injectAssetBaseIntoHtml(shell, "/");
+      expect(out).toContain('src="/assets/index-deadbeef.js"');
+      expect(out).toContain('href="/assets/index-cafe.css"');
+    });
+  });
+
+  describe("when the base is a CDN", () => {
+    it("rewrites the entry script and stylesheet to the CDN base", () => {
+      const out = injectAssetBaseIntoHtml(shell, CDN);
+      expect(out).toContain(`src="${CDN}assets/index-deadbeef.js"`);
+      expect(out).toContain(`href="${CDN}assets/index-cafe.css"`);
+      expect(out).not.toContain('src="/assets/');
+    });
+
+    it("still injects the resolver and points it at the CDN", () => {
+      const out = injectAssetBaseIntoHtml(shell, CDN);
+      expect(out).toContain(`window.${ASSET_URL_GLOBAL}`);
+      expect(out).toContain(JSON.stringify(CDN));
+    });
+
+    it("does not rewrite same-origin public assets like the favicon", () => {
+      const withFavicon = injectAssetBaseIntoHtml(
+        '<html><head><link rel="icon" href="/favicon.ico"></head></html>',
+        CDN,
+      );
+      expect(withFavicon).toContain('href="/favicon.ico"');
+    });
+
+    it("treats a $ in the base literally, not as a replacement token", () => {
+      const out = injectAssetBaseIntoHtml(
+        shell,
+        "https://cdn.example.com/a$1b/",
+      );
+      expect(out).toContain(
+        'src="https://cdn.example.com/a$1b/assets/index-deadbeef.js"',
+      );
+    });
+  });
+
+  describe("when the shell lacks one of the injection anchors", () => {
+    it("injects after the doctype when there is no head or html tag", () => {
+      const out = injectAssetBaseIntoHtml(
+        "<!doctype html><body><div id=root></div></body>",
+        "/",
+      );
+      expect(out).toContain(`window.${ASSET_URL_GLOBAL}`);
+      expect(out).toContain("<div id=root>");
+    });
+
+    it("injects after <html> when there is no <head>", () => {
+      const out = injectAssetBaseIntoHtml(
+        "<html><body><div id=root></div></body></html>",
+        "/",
+      );
+      expect(out).toContain(`window.${ASSET_URL_GLOBAL}`);
+      expect(out.indexOf(ASSET_URL_GLOBAL)).toBeLessThan(
+        out.indexOf("<div id=root>"),
+      );
+    });
+
+    it("prepends the bootstrap when there is no doctype/html/head", () => {
+      const out = injectAssetBaseIntoHtml("<div id=root></div>", "/");
+      expect(out.startsWith("<script>")).toBe(true);
+      expect(out).toContain("<div id=root>");
+    });
+  });
+});

--- a/platform/app/src/server/__tests__/asset-base.unit.test.ts
+++ b/platform/app/src/server/__tests__/asset-base.unit.test.ts
@@ -73,6 +73,22 @@ describe("normalizeAssetBase", () => {
       ).toThrow(/http or https/);
     });
   });
+
+  describe("when the value carries a query or fragment", () => {
+    // The resolver concatenates, so these would swallow the asset path:
+    // "…/abc123?rev=1" + "assets/x.js" puts the path inside the query string.
+    it("throws on a query component", () => {
+      expect(() =>
+        normalizeAssetBase("https://cdn.langwatch.ai/abc123?rev=1"),
+      ).toThrow(/query or fragment/);
+    });
+
+    it("throws on a fragment component", () => {
+      expect(() =>
+        normalizeAssetBase("https://cdn.langwatch.ai/abc123#f"),
+      ).toThrow(/query or fragment/);
+    });
+  });
 });
 
 describe("assetBaseOrigin", () => {
@@ -119,7 +135,7 @@ describe("injectAssetBaseIntoHtml", () => {
 
   describe("when the base is same-origin", () => {
     it("injects the resolver bootstrap into the head", () => {
-      const out = injectAssetBaseIntoHtml(shell, "/");
+      const out = injectAssetBaseIntoHtml({ html: shell, base: "/" });
       expect(out).toContain(`window.${ASSET_URL_GLOBAL}`);
       // bootstrap lands inside <head>, before the entry script
       expect(out.indexOf(ASSET_URL_GLOBAL)).toBeLessThan(
@@ -129,7 +145,7 @@ describe("injectAssetBaseIntoHtml", () => {
 
     /** @scenario Same-origin rewriting is a no-op for the entry references */
     it("leaves the base-absolute entry references untouched", () => {
-      const out = injectAssetBaseIntoHtml(shell, "/");
+      const out = injectAssetBaseIntoHtml({ html: shell, base: "/" });
       expect(out).toContain('src="/assets/index-deadbeef.js"');
       expect(out).toContain('href="/assets/index-cafe.css"');
     });
@@ -137,31 +153,31 @@ describe("injectAssetBaseIntoHtml", () => {
 
   describe("when the base is a CDN", () => {
     it("rewrites the entry script and stylesheet to the CDN base", () => {
-      const out = injectAssetBaseIntoHtml(shell, CDN);
+      const out = injectAssetBaseIntoHtml({ html: shell, base: CDN });
       expect(out).toContain(`src="${CDN}assets/index-deadbeef.js"`);
       expect(out).toContain(`href="${CDN}assets/index-cafe.css"`);
       expect(out).not.toContain('src="/assets/');
     });
 
     it("still injects the resolver and points it at the CDN", () => {
-      const out = injectAssetBaseIntoHtml(shell, CDN);
+      const out = injectAssetBaseIntoHtml({ html: shell, base: CDN });
       expect(out).toContain(`window.${ASSET_URL_GLOBAL}`);
       expect(out).toContain(JSON.stringify(CDN));
     });
 
     it("does not rewrite same-origin public assets like the favicon", () => {
-      const withFavicon = injectAssetBaseIntoHtml(
-        '<html><head><link rel="icon" href="/favicon.ico"></head></html>',
-        CDN,
-      );
+      const withFavicon = injectAssetBaseIntoHtml({
+        html: '<html><head><link rel="icon" href="/favicon.ico"></head></html>',
+        base: CDN,
+      });
       expect(withFavicon).toContain('href="/favicon.ico"');
     });
 
     it("treats a $ in the base literally, not as a replacement token", () => {
-      const out = injectAssetBaseIntoHtml(
-        shell,
-        "https://cdn.example.com/a$1b/",
-      );
+      const out = injectAssetBaseIntoHtml({
+        html: shell,
+        base: "https://cdn.example.com/a$1b/",
+      });
       expect(out).toContain(
         'src="https://cdn.example.com/a$1b/assets/index-deadbeef.js"',
       );
@@ -170,19 +186,19 @@ describe("injectAssetBaseIntoHtml", () => {
 
   describe("when the shell lacks one of the injection anchors", () => {
     it("injects after the doctype when there is no head or html tag", () => {
-      const out = injectAssetBaseIntoHtml(
-        "<!doctype html><body><div id=root></div></body>",
-        "/",
-      );
+      const out = injectAssetBaseIntoHtml({
+        html: "<!doctype html><body><div id=root></div></body>",
+        base: "/",
+      });
       expect(out).toContain(`window.${ASSET_URL_GLOBAL}`);
       expect(out).toContain("<div id=root>");
     });
 
     it("injects after <html> when there is no <head>", () => {
-      const out = injectAssetBaseIntoHtml(
-        "<html><body><div id=root></div></body></html>",
-        "/",
-      );
+      const out = injectAssetBaseIntoHtml({
+        html: "<html><body><div id=root></div></body></html>",
+        base: "/",
+      });
       expect(out).toContain(`window.${ASSET_URL_GLOBAL}`);
       expect(out.indexOf(ASSET_URL_GLOBAL)).toBeLessThan(
         out.indexOf("<div id=root>"),
@@ -190,7 +206,10 @@ describe("injectAssetBaseIntoHtml", () => {
     });
 
     it("prepends the bootstrap when there is no doctype/html/head", () => {
-      const out = injectAssetBaseIntoHtml("<div id=root></div>", "/");
+      const out = injectAssetBaseIntoHtml({
+        html: "<div id=root></div>",
+        base: "/",
+      });
       expect(out.startsWith("<script>")).toBe(true);
       expect(out).toContain("<div id=root>");
     });

--- a/platform/app/src/server/__tests__/static-handler.unit.test.ts
+++ b/platform/app/src/server/__tests__/static-handler.unit.test.ts
@@ -55,7 +55,9 @@ describe("serveStaticOrFallback", () => {
     );
     writeFileSync(
       join(clientDistDir, "index.html"),
-      "<!doctype html><html><body><div id=root></div></body></html>",
+      '<!doctype html><html><head><script type="module" ' +
+        'src="/assets/index-abc123.js"></script></head>' +
+        "<body><div id=root></div></body></html>",
     );
 
     server = createServer((req, res) => {
@@ -149,6 +151,7 @@ describe("serveStaticOrFallback", () => {
   });
 
   describe("when index.html is requested directly", () => {
+    /** @scenario The HTML shell is served with a revalidate cache so reloads pick up new hashes */
     it("serves it with a revalidate Cache-Control, not immutable", async () => {
       const res = await fetch(`${baseUrl}/index.html`);
       expect(res.status).toBe(200);
@@ -156,6 +159,65 @@ describe("serveStaticOrFallback", () => {
       const cacheControl = res.headers.get("cache-control") ?? "";
       expect(cacheControl).toMatch(/no-cache|no-store/);
       expect(cacheControl).not.toMatch(/immutable/);
+    });
+  });
+
+  describe("given the runtime asset base is served into the shell", () => {
+    const original = process.env.LANGWATCH_ASSET_BASE;
+    afterAll(() => {
+      if (original === undefined) delete process.env.LANGWATCH_ASSET_BASE;
+      else process.env.LANGWATCH_ASSET_BASE = original;
+    });
+
+    describe("when no asset base is configured (self-host default)", () => {
+      beforeAll(() => {
+        delete process.env.LANGWATCH_ASSET_BASE;
+      });
+
+      /** @scenario The resolver is injected even when serving same-origin */
+      it("defines the resolver and leaves entry refs same-origin", async () => {
+        const res = await fetch(`${baseUrl}/projects/foo/traces`);
+        const body = await res.text();
+        expect(body).toContain("window.__lwAssetUrl");
+        expect(body).toContain('src="/assets/index-abc123.js"');
+      });
+    });
+
+    describe("when a CDN asset base is configured (SaaS)", () => {
+      beforeAll(() => {
+        process.env.LANGWATCH_ASSET_BASE = "https://cdn.langwatch.ai/abc123/";
+      });
+
+      /** @scenario Entry script and preload links are rewritten to the CDN base */
+      it("rewrites the entry ref to the CDN and points the resolver at it", async () => {
+        const res = await fetch(`${baseUrl}/projects/foo/traces`);
+        const body = await res.text();
+        expect(body).toContain(
+          'src="https://cdn.langwatch.ai/abc123/assets/index-abc123.js"',
+        );
+        expect(body).not.toContain('src="/assets/index-abc123.js"');
+        expect(body).toContain("https://cdn.langwatch.ai/abc123/");
+      });
+
+      it("rewrites a directly requested /index.html too", async () => {
+        const res = await fetch(`${baseUrl}/index.html`);
+        const body = await res.text();
+        expect(res.headers.get("content-type")).toBe("text/html");
+        expect(body).toContain(
+          'src="https://cdn.langwatch.ai/abc123/assets/index-abc123.js"',
+        );
+      });
+
+      it("rewrites the root path via the index.html fall-through", async () => {
+        // `/` reaches the shell through a different branch (tryServeFile on the
+        // dist dir returns false → tryServeHtml(index.html)) than the routes above.
+        const res = await fetch(`${baseUrl}/`);
+        const body = await res.text();
+        expect(res.status).toBe(200);
+        expect(body).toContain(
+          'src="https://cdn.langwatch.ai/abc123/assets/index-abc123.js"',
+        );
+      });
     });
   });
 

--- a/platform/app/src/server/asset-base.ts
+++ b/platform/app/src/server/asset-base.ts
@@ -91,12 +91,21 @@ export function assetBaseOrigin(base: string): string | null {
  * resolver is defined before the entry chunk's dynamic imports evaluate.
  */
 export function assetBaseBootstrapScript(base: string): string {
+  return `<script>${assetBaseBootstrapBody(base)}</script>`;
+}
+
+/**
+ * The bootstrap's JS on its own, without the surrounding `<script>` element, so
+ * tests can execute exactly the code the browser runs instead of regexing it
+ * back out of the rendered tag.
+ */
+export function assetBaseBootstrapBody(base: string): string {
   // `base` is already URL-validated (no raw "<"), but escape "<" for defence in
   // depth so the JSON string literal can never terminate the <script> element.
   const json = JSON.stringify(base).replace(/</g, "\\u003c");
   return (
-    `<script>window.${ASSET_BASE_GLOBAL}=${json};` +
-    `window.${ASSET_URL_GLOBAL}=function(p){return window.${ASSET_BASE_GLOBAL}+p};</script>`
+    `window.${ASSET_BASE_GLOBAL}=${json};` +
+    `window.${ASSET_URL_GLOBAL}=function(p){return window.${ASSET_BASE_GLOBAL}+p};`
   );
 }
 

--- a/platform/app/src/server/asset-base.ts
+++ b/platform/app/src/server/asset-base.ts
@@ -54,6 +54,16 @@ export function normalizeAssetBase(raw: string | undefined): string {
       `LANGWATCH_ASSET_BASE must use http or https; got ${JSON.stringify(raw)}`,
     );
   }
+  // The resolver concatenates the asset path onto this base, so a query or
+  // fragment would swallow it — "…/build?rev=1" + "assets/x.js" resolves to
+  // "…/build?rev=1/assets/x.js", where the path is part of the query. Same
+  // silent 404 the scheme check above exists to prevent.
+  if (url.search || url.hash) {
+    throw new Error(
+      `LANGWATCH_ASSET_BASE must not carry a query or fragment; ` +
+        `got ${JSON.stringify(raw)}`,
+    );
+  }
   return url.href.endsWith("/") ? url.href : `${url.href}/`;
 }
 
@@ -97,8 +107,17 @@ export function assetBaseBootstrapScript(base: string): string {
  * a no-op when the base is same-origin; the resolver bootstrap is always
  * injected (the built bundle references `window.__lwAssetUrl` regardless of base).
  */
-export function injectAssetBaseIntoHtml(html: string, base: string): string {
-  const withBootstrap = insertBootstrap(html, assetBaseBootstrapScript(base));
+export function injectAssetBaseIntoHtml({
+  html,
+  base,
+}: {
+  html: string;
+  base: string;
+}): string {
+  const withBootstrap = insertBootstrap({
+    html,
+    snippet: assetBaseBootstrapScript(base),
+  });
   if (base === "/") return withBootstrap;
   // Whitespace-anchored so it rewrites the `src`/`href` of Vite's entry
   // `<script>` / `modulepreload` / stylesheet tags but never a `data-src` etc.
@@ -115,7 +134,13 @@ export function injectAssetBaseIntoHtml(html: string, base: string): string {
  * Vite's injected entry scripts), else after `<html>`, else after the doctype,
  * else at the very start.
  */
-function insertBootstrap(html: string, snippet: string): string {
+function insertBootstrap({
+  html,
+  snippet,
+}: {
+  html: string;
+  snippet: string;
+}): string {
   for (const anchor of [/<head[^>]*>/i, /<html[^>]*>/i, /<!doctype[^>]*>/i]) {
     const match = anchor.exec(html);
     if (match) {

--- a/platform/app/src/server/asset-base.ts
+++ b/platform/app/src/server/asset-base.ts
@@ -1,0 +1,127 @@
+/**
+ * Runtime-configurable base URL for content-hashed build assets.
+ *
+ * The published Docker image is shared by self-hosters and LangWatch SaaS, and
+ * Vite's `base` is a compile-time constant — so the CDN origin cannot be baked
+ * into the image without breaking every self-host install. Instead the base is
+ * chosen at container start: `vite.config.ts` emits every JS-referenced asset
+ * URL as `window.__lwAssetUrl(<path relative to the build root>)`, and the HTML
+ * shell served by `static-handler.ts` defines that global from
+ * `LANGWATCH_ASSET_BASE` and rewrites the base-absolute entry refs to match.
+ *
+ * - Unset / "/" (self-host default): assets resolve same-origin, served by the
+ *   pod exactly as before; the HTML rewrite is a no-op.
+ * - "https://cdn.langwatch.ai/<commit-sha>/" (SaaS): assets resolve to the
+ *   commit-prefixed CDN namespace, where every past build's assets still exist —
+ *   so a rolling deploy never strands a tab on a 404. See ADR-086.
+ */
+
+// Browser globals the built bundle and the injected bootstrap agree on. The
+// bundle references `__lwAssetUrl`; the bootstrap defines both. Keep in sync
+// with the `renderBuiltUrl` runtime expression in vite.config.ts.
+export const ASSET_URL_GLOBAL = "__lwAssetUrl";
+export const ASSET_BASE_GLOBAL = "__lwAssetBase";
+
+/**
+ * Normalize a raw `LANGWATCH_ASSET_BASE` value to a base that always ends in a
+ * slash (so `base + "assets/x.js"` concatenates cleanly), collapsing unset and
+ * bare "/" to the same-origin sentinel "/".
+ *
+ * A non-"/" value MUST be an absolute http(s) URL. We validate (and throw) here
+ * so the two consumers can never disagree: a scheme-less value like
+ * "cdn.langwatch.ai/x/" would otherwise rewrite asset refs to a broken
+ * *relative* URL (silent 404s on every chunk) while `new URL()` in
+ * `assetBaseOrigin` throws and drops the CSP entry — the exact silent failure
+ * this feature exists to kill. Failing fast at boot surfaces the misconfig in
+ * the pod logs instead. `url.href` also percent-encodes anything unsafe, so a
+ * stray "<" can't break out of the injected `<script>`.
+ */
+export function normalizeAssetBase(raw: string | undefined): string {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed || trimmed === "/") return "/";
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error(
+      `LANGWATCH_ASSET_BASE must be an absolute http(s) URL ` +
+        `(e.g. https://cdn.example.com/<tag>/); got ${JSON.stringify(raw)}`,
+    );
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error(
+      `LANGWATCH_ASSET_BASE must use http or https; got ${JSON.stringify(raw)}`,
+    );
+  }
+  return url.href.endsWith("/") ? url.href : `${url.href}/`;
+}
+
+/** The effective asset base for this process, read from the environment. */
+export function getAssetBase(): string {
+  return normalizeAssetBase(process.env.LANGWATCH_ASSET_BASE);
+}
+
+/**
+ * The external origin to admit into the CSP fetch directives, or null when the
+ * base is same-origin (nothing to add).
+ */
+export function assetBaseOrigin(base: string): string | null {
+  if (base === "/") return null;
+  try {
+    return new URL(base).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The inline classic `<script>` that defines the asset-URL resolver. A classic
+ * inline script runs during HTML parse, before deferred module scripts, so the
+ * resolver is defined before the entry chunk's dynamic imports evaluate.
+ */
+export function assetBaseBootstrapScript(base: string): string {
+  // `base` is already URL-validated (no raw "<"), but escape "<" for defence in
+  // depth so the JSON string literal can never terminate the <script> element.
+  const json = JSON.stringify(base).replace(/</g, "\\u003c");
+  return (
+    `<script>window.${ASSET_BASE_GLOBAL}=${json};` +
+    `window.${ASSET_URL_GLOBAL}=function(p){return window.${ASSET_BASE_GLOBAL}+p};</script>`
+  );
+}
+
+/**
+ * Inject the resolver bootstrap into the HTML shell and rewrite the base-absolute
+ * entry references (`<script src>`, `modulepreload`, stylesheet `<link href>`)
+ * that Vite baked as `/assets/…` to the runtime base. The `/assets/` rewrite is
+ * a no-op when the base is same-origin; the resolver bootstrap is always
+ * injected (the built bundle references `window.__lwAssetUrl` regardless of base).
+ */
+export function injectAssetBaseIntoHtml(html: string, base: string): string {
+  const withBootstrap = insertBootstrap(html, assetBaseBootstrapScript(base));
+  if (base === "/") return withBootstrap;
+  // Whitespace-anchored so it rewrites the `src`/`href` of Vite's entry
+  // `<script>` / `modulepreload` / stylesheet tags but never a `data-src` etc.
+  // Function replacer (not a `$1` string) so a "$" in the base can't be read as
+  // a replacement-pattern token.
+  return withBootstrap.replace(
+    /(\s(?:src|href))="\/assets\//g,
+    (_match, attr: string) => `${attr}="${base}assets/`,
+  );
+}
+
+/**
+ * Place the bootstrap as early as possible: after `<head>` when present (before
+ * Vite's injected entry scripts), else after `<html>`, else after the doctype,
+ * else at the very start.
+ */
+function insertBootstrap(html: string, snippet: string): string {
+  for (const anchor of [/<head[^>]*>/i, /<html[^>]*>/i, /<!doctype[^>]*>/i]) {
+    const match = anchor.exec(html);
+    if (match) {
+      const at = match.index + match[0].length;
+      return html.slice(0, at) + snippet + html.slice(at);
+    }
+  }
+  return snippet + html;
+}

--- a/platform/app/src/server/asset-base.ts
+++ b/platform/app/src/server/asset-base.ts
@@ -11,7 +11,7 @@
  *
  * - Unset / "/" (self-host default): assets resolve same-origin, served by the
  *   pod exactly as before; the HTML rewrite is a no-op.
- * - "https://cdn.langwatch.ai/<commit-sha>/" (SaaS): assets resolve to the
+ * - "https://cdn.langwatch.ai/git-<short-sha>/" (SaaS): assets resolve to the
  *   commit-prefixed CDN namespace, where every past build's assets still exist —
  *   so a rolling deploy never strands a tab on a 404. See ADR-086.
  */

--- a/platform/app/src/server/securityHeaders.ts
+++ b/platform/app/src/server/securityHeaders.ts
@@ -14,25 +14,34 @@ type SecurityHeaderEnvironment = Partial<
 export function buildSecurityHeaders({
   dev,
   environment = process.env,
+  assetOrigin = null,
 }: {
   dev: boolean;
   environment?: SecurityHeaderEnvironment;
+  /**
+   * ADR-086: origin serving content-hashed assets when LANGWATCH_ASSET_BASE is
+   * set. Admitted into every fetch directive the browser needs to load chunks,
+   * styles, fonts, images and workers from it. Null for same-origin serving.
+   */
+  assetOrigin?: string | null;
 }): Record<string, string> {
+  const cdn = assetOrigin ? ` ${assetOrigin}` : "";
+
   const cspHeader = [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.posthog.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.googletagmanager.com https://*.pendo.io https://client.crisp.chat https://static.hsappstatic.net https://*.google-analytics.com https://www.google.com https://*.reo.dev",
-    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.pendo.io https://client.crisp.chat https://*.google.com https://*.reo.dev https://fonts.googleapis.com https://unpkg.com",
-    "img-src 'self' blob: data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://image.crisp.chat https://*.googletagmanager.com https://*.pendo.io https://*.google-analytics.com https://www.google.com https://*.reo.dev",
-    "font-src 'self' data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://client.crisp.chat https://www.google.com https://*.reo.dev https://fonts.gstatic.com",
+    `script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.posthog.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.googletagmanager.com https://*.pendo.io https://client.crisp.chat https://static.hsappstatic.net https://*.google-analytics.com https://www.google.com https://*.reo.dev${cdn}`,
+    `style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.pendo.io https://client.crisp.chat https://*.google.com https://*.reo.dev https://fonts.googleapis.com https://unpkg.com${cdn}`,
+    `img-src 'self' blob: data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://image.crisp.chat https://*.googletagmanager.com https://*.pendo.io https://*.google-analytics.com https://www.google.com https://*.reo.dev${cdn}`,
+    `font-src 'self' data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://client.crisp.chat https://www.google.com https://*.reo.dev https://fonts.gstatic.com${cdn}`,
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",
     "frame-ancestors 'none'",
     ...(!dev ? ["upgrade-insecure-requests"] : []),
-    "worker-src 'self' blob:",
+    `worker-src 'self' blob:${cdn}`,
     `connect-src 'self' ${buildStorageConnectSrc(environment).join(
       " ",
-    )} https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev`,
+    )} https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev${cdn}`,
     "frame-src 'self' https://*.posthog.com https://*.pendo.io https://www.youtube.com https://get.langwatch.ai https://*.googletagmanager.com https://www.google.com https://*.reo.dev",
   ].join("; ");
 

--- a/platform/app/src/server/securityHeaders.unit.test.ts
+++ b/platform/app/src/server/securityHeaders.unit.test.ts
@@ -31,4 +31,65 @@ describe("buildSecurityHeaders", () => {
     expect(headers["Content-Security-Policy"]).toBeUndefined();
     expect(headers["Strict-Transport-Security"]).toBeUndefined();
   });
+
+  describe("given a content-hashed asset CDN (ADR-086)", () => {
+    const CDN = "https://cdn.langwatch.ai";
+    const FETCH_DIRECTIVES = [
+      "script-src",
+      "style-src",
+      "font-src",
+      "img-src",
+      "connect-src",
+      "worker-src",
+    ];
+
+    function directive(csp: string, name: string): string {
+      const found = csp
+        .split("; ")
+        .find((d) => d === name || d.startsWith(`${name} `));
+      if (!found) throw new Error(`directive ${name} not found in CSP`);
+      return found;
+    }
+
+    function csp(assetOrigin: string | null): string {
+      const header = buildSecurityHeaders({
+        dev: false,
+        environment: {},
+        assetOrigin,
+      })["Content-Security-Policy"];
+      if (!header) throw new Error("expected a CSP header in production");
+      return header;
+    }
+
+    describe("when no asset origin is configured (self-host)", () => {
+      /** @scenario No CDN origin is added for same-origin serving */
+      it("adds no external asset origin to the fetch directives", () => {
+        const header = csp(null);
+
+        for (const name of FETCH_DIRECTIVES) {
+          expect(directive(header, name)).not.toContain(CDN);
+        }
+      });
+    });
+
+    describe("when a CDN asset origin is configured", () => {
+      // Regression guard: dropping the origin from one directive (e.g.
+      // worker-src, which Shiki/Monaco need) would otherwise ship green.
+      /** @scenario The CDN origin is added to the fetch directives */
+      it("admits the origin into every fetch directive the browser needs", () => {
+        const header = csp(CDN);
+
+        for (const name of FETCH_DIRECTIVES) {
+          expect(directive(header, name)).toContain(CDN);
+        }
+      });
+
+      it("leaves directives that never fetch assets untouched", () => {
+        const header = csp(CDN);
+
+        expect(directive(header, "frame-src")).not.toContain(CDN);
+        expect(directive(header, "default-src")).not.toContain(CDN);
+      });
+    });
+  });
 });

--- a/platform/app/src/server/static-handler.ts
+++ b/platform/app/src/server/static-handler.ts
@@ -2,6 +2,8 @@ import fs from "fs";
 import type { ServerResponse } from "http";
 import path from "path";
 
+import { getAssetBase, injectAssetBaseIntoHtml } from "./asset-base";
+
 const MIME_TYPES: Record<string, string> = {
   ".js": "application/javascript",
   ".mjs": "application/javascript",
@@ -32,6 +34,11 @@ const HTML_REVALIDATE_CACHE = "no-cache";
  * Returns false only when there is no index.html to fall back to (caller decides
  * how to 404).
  *
+ * The HTML shell (the SPA fallback and any `.html` request) is read and
+ * transformed to inject the runtime asset base (see src/server/asset-base.ts and
+ * ADR-086), so it cannot be streamed raw like other static files. Everything
+ * else is streamed straight off disk.
+ *
  * Why missing /assets/* returns 404 instead of falling through to index.html:
  * Vite hashes asset filenames per build, so chunk URLs from a previous deploy
  * point to files that no longer exist. If we returned the SPA shell with a 200
@@ -60,7 +67,11 @@ export function serveStaticOrFallback({
   }
 
   const staticPath = path.join(clientDistDir, normalizedRelative);
-  if (tryServeFile({ res, filePath: staticPath, pathname })) {
+  if (path.extname(staticPath) === ".html") {
+    if (tryServeHtml({ res, htmlPath: staticPath })) {
+      return true;
+    }
+  } else if (tryServeFile({ res, filePath: staticPath, pathname })) {
     return true;
   }
 
@@ -72,14 +83,17 @@ export function serveStaticOrFallback({
     return true;
   }
 
-  const indexHtml = path.join(clientDistDir, "index.html");
-  return tryServeSpaFallback({ res, indexHtmlPath: indexHtml });
+  return tryServeHtml({
+    res,
+    htmlPath: path.join(clientDistDir, "index.html"),
+  });
 }
 
 /**
  * Open + stream a static file in one step, avoiding the TOCTOU race between
  * existsSync and createReadStream. Returns false when the file doesn't exist
- * or isn't a regular file so the caller can fall through.
+ * or isn't a regular file so the caller can fall through. Never handles HTML —
+ * `.html` is routed to tryServeHtml so the asset base can be injected.
  */
 function tryServeFile({
   res,
@@ -107,8 +121,6 @@ function tryServeFile({
   res.setHeader("Content-Type", MIME_TYPES[ext] ?? "application/octet-stream");
   if (pathname.startsWith("/assets/")) {
     res.setHeader("Cache-Control", IMMUTABLE_CACHE);
-  } else if (ext === ".html") {
-    res.setHeader("Cache-Control", HTML_REVALIDATE_CACHE);
   }
 
   pipeWithErrorHandling({ stream: fs.createReadStream("", { fd }), res });
@@ -116,27 +128,37 @@ function tryServeFile({
 }
 
 /**
- * Serve the SPA shell (index.html) as a fallback for non-asset routes.
- * Returns false only when index.html itself doesn't exist.
+ * Read an HTML shell, inject the runtime asset base, and send it with a
+ * revalidate cache. Held open via fd (atomic, no TOCTOU) while read. Returns
+ * false only when the file doesn't exist or isn't a regular file, so the SPA
+ * fallback can decide how to 404.
  */
-function tryServeSpaFallback({
+function tryServeHtml({
   res,
-  indexHtmlPath,
+  htmlPath,
 }: {
   res: ServerResponse;
-  indexHtmlPath: string;
+  htmlPath: string;
 }): boolean {
   let fd: number;
   try {
-    fd = fs.openSync(indexHtmlPath, "r");
+    fd = fs.openSync(htmlPath, "r");
   } catch {
     return false;
   }
 
-  res.setHeader("Content-Type", "text/html");
-  res.setHeader("Cache-Control", HTML_REVALIDATE_CACHE);
-  pipeWithErrorHandling({ stream: fs.createReadStream("", { fd }), res });
-  return true;
+  try {
+    if (!fs.fstatSync(fd).isFile()) {
+      return false;
+    }
+    const html = fs.readFileSync(fd, "utf8");
+    res.setHeader("Content-Type", "text/html");
+    res.setHeader("Cache-Control", HTML_REVALIDATE_CACHE);
+    res.end(injectAssetBaseIntoHtml(html, getAssetBase()));
+    return true;
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 /**

--- a/platform/app/src/server/static-handler.ts
+++ b/platform/app/src/server/static-handler.ts
@@ -154,7 +154,7 @@ function tryServeHtml({
     const html = fs.readFileSync(fd, "utf8");
     res.setHeader("Content-Type", "text/html");
     res.setHeader("Cache-Control", HTML_REVALIDATE_CACHE);
-    res.end(injectAssetBaseIntoHtml(html, getAssetBase()));
+    res.end(injectAssetBaseIntoHtml({ html, base: getAssetBase() }));
     return true;
   } finally {
     fs.closeSync(fd);

--- a/platform/app/src/start.ts
+++ b/platform/app/src/start.ts
@@ -82,6 +82,7 @@ import {
   initializeInProcessApp,
   initializeWebApp,
 } from "./server/app-layer/presets";
+import { assetBaseOrigin, getAssetBase } from "./server/asset-base";
 import {
   getWorkerMetricsPort,
   isMetricsAuthorized,
@@ -199,7 +200,12 @@ export const startApp = async (dir = resolveAppPackageRoot()) => {
   // In production, resolve the built client assets directory
   const clientDistDir = dev ? null : path.join(dir, "dist/client");
 
-  const securityHeaders = buildSecurityHeaders({ dev });
+  // ADR-086: getAssetBase() throws here at boot when the base is misconfigured
+  // — fail fast rather than serve broken asset URLs.
+  const securityHeaders = buildSecurityHeaders({
+    dev,
+    assetOrigin: assetBaseOrigin(getAssetBase()),
+  });
 
   // Optional HTTPS + HTTP/2 path for local dev. Set
   // `LANGWATCH_DEV_HTTP2=1` and a self-signed cert is auto-generated on

--- a/platform/app/vite.config.ts
+++ b/platform/app/vite.config.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { generate as generateSelfsigned } from "selfsigned";
 import { shikiManualChunk } from "./src/features/traces-v2/components/TraceDrawer/markdownView/shikiChunking";
 import { havenHmrGate } from "./vite/havenHmrGate";
+import { ASSET_URL_GLOBAL } from "./src/server/asset-base";
 
 // Load `.env` into the Vite config's process environment. Vite normally
 // only exposes `VITE_*` vars to client code — but this config itself
@@ -203,6 +204,35 @@ export default defineConfig(async (): Promise<UserConfig> => {
           return shikiManualChunk(id);
         },
       },
+    },
+  },
+  experimental: {
+    // ADR-086: the base for content-hashed assets is chosen at container start,
+    // not build time — one image serves self-host same-origin and SaaS from a
+    // commit-prefixed CDN. Emit every JS-referenced asset URL as a call to the
+    // runtime resolver defined by the served HTML shell (src/server/asset-base.ts);
+    // keep CSS-referenced assets relative to the CSS file (which lives under the
+    // same base, so fonts/images resolve on the CDN); leave HTML entry refs
+    // base-absolute for the server to rewrite; leave public/ assets same-origin.
+    renderBuiltUrl(filename, { type, hostType }) {
+      if (type === "public") return undefined;
+      if (hostType === "js") {
+        // Self-defaulting so the built bundle is usable even when the server
+        // hasn't injected the resolver: `vite preview`, the boot-smoke, and any
+        // raw-`dist/` static server fall back to same-origin ("/"+path). Read
+        // via `globalThis` (defined in the main document AND in Web Worker
+        // scopes, where `window` is undefined) so a worker chunk degrades to
+        // same-origin instead of throwing. The server sets
+        // `globalThis.__lwAssetUrl` to the CDN prefixer when LANGWATCH_ASSET_BASE
+        // is configured.
+        return {
+          runtime: `(globalThis.${ASSET_URL_GLOBAL}||function(p){return "/"+p})(${JSON.stringify(
+            filename,
+          )})`,
+        };
+      }
+      if (hostType === "css") return { relative: true };
+      return undefined;
     },
   },
   server: {

--- a/specs/server/cdn-asset-base.feature
+++ b/specs/server/cdn-asset-base.feature
@@ -1,0 +1,86 @@
+Feature: Production HTTP server — runtime-configurable CDN asset base
+  As an operator running the shared LangWatch image
+  I want the base URL for content-hashed assets chosen at container start, not build time
+  So that one image serves assets same-origin for self-host and from a
+  commit-prefixed CDN for SaaS, and a rolling deploy never strands a tab on a 404
+
+  # Background: Vite hashes asset filenames per build and, before this change,
+  # baked an absolute base ("/") into every chunk URL at build time. During a
+  # rolling deploy two builds serve behind one Service, so a tab that fetched the
+  # HTML shell from build A can have a lazy import() load-balanced to a build-B
+  # pod that lacks that hash — a 404. The fix moves asset hosting off the pods:
+  # Vite emits every asset URL as `window.__lwAssetUrl(<relative path>)`, and the
+  # server injects that resolver into the served HTML shell from LANGWATCH_ASSET_BASE.
+  # SaaS points it at https://cdn.langwatch.ai/<commit-sha>/ where every past
+  # build's commit-prefixed namespace still exists in S3, so both builds' assets
+  # resolve regardless of which pod serves the shell. Self-host leaves it unset
+  # and assets resolve same-origin exactly as before. Companion to spa-fallback.feature.
+
+  Rule: The asset base is chosen at container start, and a bad one fails fast
+
+    @unit
+    Scenario: With no asset base set, assets are served same-origin from the pod
+      Given LANGWATCH_ASSET_BASE is unset
+      When a client loads the app
+      Then asset URLs are same-origin, under /assets/
+
+    @unit
+    Scenario: A CDN base resolves assets to the CDN, with or without a trailing slash
+      Given LANGWATCH_ASSET_BASE is "https://cdn.langwatch.ai/abc123" (no trailing slash)
+      When a client loads the app
+      Then assets are requested from https://cdn.langwatch.ai/abc123/assets/
+
+    @unit
+    Scenario: A misconfigured base fails fast instead of silently serving 404s
+      Given LANGWATCH_ASSET_BASE has no scheme, e.g. "cdn.langwatch.ai/abc123/"
+      When the app starts
+      Then startup fails with an error naming LANGWATCH_ASSET_BASE
+      And no build is served with broken asset URLs
+
+  Rule: The served HTML shell always defines the asset-URL resolver
+
+    @unit
+    Scenario: The resolver is injected even when serving same-origin
+      Given LANGWATCH_ASSET_BASE is unset
+      When a client requests /projects/foo/traces
+      Then the response body defines window.__lwAssetUrl
+      And the resolver returns "/assets/x.js" for the path "assets/x.js"
+
+    @unit
+    Scenario: Entry script and preload links are rewritten to the CDN base
+      Given LANGWATCH_ASSET_BASE is "https://cdn.langwatch.ai/abc123/"
+      And dist/client/index.html references /assets/index-deadbeef.js
+      When a client requests /
+      Then the response body references https://cdn.langwatch.ai/abc123/assets/index-deadbeef.js
+      And the resolver returns "https://cdn.langwatch.ai/abc123/assets/x.js" for the path "assets/x.js"
+
+    @unit
+    Scenario: Same-origin rewriting is a no-op for the entry references
+      Given LANGWATCH_ASSET_BASE is unset
+      And dist/client/index.html references /assets/index-deadbeef.js
+      When a client requests /
+      Then the response body still references /assets/index-deadbeef.js
+
+    @unit
+    Scenario: The HTML shell is served with a revalidate cache so reloads pick up new hashes
+      Given LANGWATCH_ASSET_BASE is "https://cdn.langwatch.ai/abc123/"
+      When a client requests /index.html
+      Then the Content-Type header is text/html
+      And the Cache-Control header instructs caches to revalidate
+
+  Rule: The Content-Security-Policy admits the CDN origin only when one is configured
+
+    @unit
+    Scenario: No CDN origin is added for same-origin serving
+      Given LANGWATCH_ASSET_BASE is unset
+      When the Content-Security-Policy is built
+      Then script-src does not name an external asset origin
+
+    @unit
+    Scenario: The CDN origin is added to the fetch directives
+      Given LANGWATCH_ASSET_BASE is "https://cdn.langwatch.ai/abc123/"
+      When the Content-Security-Policy is built
+      Then script-src includes https://cdn.langwatch.ai
+      And style-src includes https://cdn.langwatch.ai
+      And font-src includes https://cdn.langwatch.ai
+      And connect-src includes https://cdn.langwatch.ai

--- a/specs/server/cdn-asset-base.feature
+++ b/specs/server/cdn-asset-base.feature
@@ -11,7 +11,7 @@ Feature: Production HTTP server — runtime-configurable CDN asset base
   # pod that lacks that hash — a 404. The fix moves asset hosting off the pods:
   # Vite emits every asset URL as `window.__lwAssetUrl(<relative path>)`, and the
   # server injects that resolver into the served HTML shell from LANGWATCH_ASSET_BASE.
-  # SaaS points it at https://cdn.langwatch.ai/<commit-sha>/ where every past
+  # SaaS points it at https://cdn.langwatch.ai/git-<short-sha>/ where every past
   # build's commit-prefixed namespace still exists in S3, so both builds' assets
   # resolve regardless of which pod serves the shell. Self-host leaves it unset
   # and assets resolve same-origin exactly as before. Companion to spa-fallback.feature.

--- a/specs/server/spa-fallback.feature
+++ b/specs/server/spa-fallback.feature
@@ -36,11 +36,14 @@ Feature: Production HTTP server — static asset and SPA fallback behavior
     Then the response status is 404
     And the response is not the index.html document
 
+  # The shell is served with the runtime asset-base resolver injected — see
+  # cdn-asset-base.feature — so it is the index.html document plus that bootstrap,
+  # not a byte-for-byte copy.
   Scenario: Unknown non-asset route falls back to index.html for SPA routing
     When a client requests /projects/foo/traces
     Then the response status is 200
     And the Content-Type header is text/html
-    And the response body equals the contents of index.html
+    And the response body is the index.html document (with the asset-base resolver injected)
 
   Scenario: Asset path traversal is rejected before touching the filesystem
     When a client requests /assets/../../etc/passwd


### PR DESCRIPTION
## Problem

During a rolling deploy the three app replicas serve **two builds at once** behind one Service. A browser that fetched the HTML shell from build A can have a lazy `import()` load-balanced to a build-B pod that doesn't have that content hash — a hard 404:

```
GET https://app.langwatch.ai/assets/dialog.anatomy-CGguCKQj.js net::ERR_ABORTED 404
```

No `RollingUpdate` tuning removes the overlap (a Deployment is inherently rolling); `Recreate` only trades it for downtime; blue-green only shrinks the window. The root cause isn't the overlap — it's coupling *asset availability* to *which pod/build serves the request*.

## Fix

Host content-hashed assets on a **commit-prefixed, immutable CDN** (CloudFront/S3) and choose the base **at container start**, not build time — so the single published image still serves self-host **same-origin**, unchanged.

- `platform/app/vite.config.ts` — `experimental.renderBuiltUrl` emits every JS-referenced asset URL as `window.__lwAssetUrl(<path>)`; CSS refs go relative; HTML entry refs stay base-absolute for the server to rewrite; `public/` assets stay same-origin.
- `platform/app/src/server/asset-base.ts` (new) — normalizes `LANGWATCH_ASSET_BASE`, defines the resolver bootstrap, rewrites `/assets/` entry refs. Injected into the served HTML shell by `static-handler.ts`.
- `platform/app/src/server/securityHeaders.ts` — gains an optional `assetOrigin`, admitting the CDN origin into the six fetch directives the browser needs (`script/style/font/img/connect/worker-src`) when configured.
- `charts/langwatch` — `app.assetBase` value → `LANGWATCH_ASSET_BASE` env, **empty by default** (self-host serves from the pod exactly as before).
- `platform/app/scripts/upload-assets-to-cdn.sh` (new) — `aws s3 sync dist/client/assets → s3://<bucket>/git-<short-sha>/assets`, immutable, **never `--delete`**.

### Immutability model
Double-immutable: the content hash freezes each file's bytes, the `git-<short-sha>` prefix freezes each build's namespace. Old tabs keep resolving because their build's prefix still exists. Both builds' assets are live mid-deploy, so the split that causes the 404 can't happen. Rollout strategy is left untouched.

- **Unset / `/` (self-host):** `__lwAssetUrl("assets/x.js") → /assets/x.js`, pod-served. HTML rewrite is a no-op; byte-neutral.
- **`https://cdn.langwatch.ai/git-<short-sha>/` (SaaS):** resolves to the commit-prefixed CDN namespace.

## Rebase notes

This branch was ~440 commits behind and predated the repo restructure, so it was rebuilt on current `main`. Beyond the `langwatch/` → `platform/app/` path move, two things changed:

- **Dropped the `src/server/csp.ts` this originally added.** `src/server/securityHeaders.ts` landed on main in the meantime and is a richer version of the same builder (it adds `Permissions-Policy` and the `buildStorageConnectSrc` helper). Rather than ship a near-duplicate, `buildSecurityHeaders` gained an optional `assetOrigin`; the CSP test cases moved into `securityHeaders.unit.test.ts`.
- **Renumbered the ADR 038 → 086.** `dev/docs/adr/038-*` is now intent-forked onboarding governance on main. 086 is also the number the `langwatch-saas` infra already references in `frontend-assets-bucket.tf` and `langwatch.tf`.

The nine scenarios in `specs/server/cdn-asset-base.feature` are now tagged `@unit` and each bound to a test. The feature-parity gate fails closed since this branch was written, so the untagged file would have failed CI.

## Verification

- `asset-base.unit.test.ts` + `securityHeaders.unit.test.ts` + `static-handler.unit.test.ts` — 44 passing (normalize, origin, resolver eval, HTML injection/rewrite both bases, direct `/index.html`, CSP with and without a CDN origin).
- `pnpm check:feature-parity` — `specs/server/cdn-asset-base.feature` reports 9/9 bound, check exits 0.
- `biome check` clean on every touched file.
- Shell script parses (`bash -n`).

## Infra status

The infra side is provisioned in langwatch/langwatch-saas#666 and #911. The origin bucket exists and the CloudFront distribution for `cdn.langwatch.ai` is deployed. The remaining infra steps (the artifacts-root apply that installs the OAC bucket policy, and the Cloudflare CNAME) are tracked there, not here — nothing in this PR depends on them, because the feature is off until an operator sets `app.assetBase`.

## Deployment Impact

**Safe to ship as-is — default behaviour is unchanged.** `LANGWATCH_ASSET_BASE` / the chart's `app.assetBase` default to empty, so assets are served same-origin from the pod exactly as before (self-host and current SaaS). Nothing serves from a CDN until an operator sets that value.

- **New env var:** `LANGWATCH_ASSET_BASE` (optional). Unset → same-origin. Set to an absolute `http(s)` URL (e.g. `https://cdn.langwatch.ai/<tag>/`) → assets resolve there. A malformed value now **fails fast at boot** (clear error) rather than silently 404ing.
- **Chart:** adds `app.assetBase` (default `""`) → `LANGWATCH_ASSET_BASE` env, rendered only when non-empty. No change to existing installs.
- **CSP:** the configured CDN origin is admitted into the fetch directives only when `LANGWATCH_ASSET_BASE` is set; no change otherwise.
- **No migrations, no data changes, no new required infra.**
- **Rollback:** trivial — unset the env / `app.assetBase` and redeploy to return to same-origin serving.

See `dev/docs/adr/086-cdn-asset-base.md` and `specs/server/cdn-asset-base.feature`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional CDN hosting for content-hashed frontend assets.
  - Configurable asset base URLs support same-origin and CDN deployments.
  - Frontend HTML automatically resolves and rewrites asset URLs.
  - CDN origins are included in applicable security policies.
  - Added an upload utility for versioned assets with immutable caching.

- **Bug Fixes**
  - Invalid asset base URLs now fail fast with validation.
  - Improved HTML fallback handling and cache revalidation.

- **Documentation**
  - Added guidance for CDN configuration, caching, security, and rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
