### PR TITLE
fix(invite): surface acceptInvite failures instead of dead-ending on the loading screen

### DIFF
--- a/langwatch/src/AppProviders.tsx
+++ b/langwatch/src/AppProviders.tsx
@@ -1,4 +1,5 @@
 import { ChakraProvider } from "@chakra-ui/react";
+import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import type { ReactNode } from "react";
 import { AnalyticsProvider } from "react-contextual-analytics";
@@ -55,11 +56,15 @@ export function InnerProviders({ children }: { children: ReactNode }) {
             isGtagReady,
           })}
         >
-          {postHog ? (
-            <PostHogProvider client={postHog}>{children}</PostHogProvider>
-          ) : (
-            children
-          )}
+          {/* Always wrap in PostHogProvider with the module singleton —
+              `usePostHog()` initializes it in an effect once publicEnv
+              resolves, so conditionally wrapping on that flip changes the
+              element type at this position and React unmounts + remounts
+              the ENTIRE routed page subtree shortly after boot. That
+              remount wiped in-flight page state (#5550: /invite/accept
+              dead-ended on the loading screen). The uninitialized
+              singleton is inert when no POSTHOG_KEY is configured. */}
+          <PostHogProvider client={posthog}>{children}</PostHogProvider>
         </AnalyticsProvider>
         <Toaster />
       </CommandBarProvider>

--- a/langwatch/src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx
@@ -34,8 +34,14 @@ const {
     captureExceptionSpy: vi.fn(),
     mockState: {
       handlers: {} as {
-        onSuccess?: (data: unknown) => void;
-        onError?: (error: { message: string }) => void;
+        onSuccess?: (
+          data: unknown,
+          variables: { inviteCode: string },
+        ) => void;
+        onError?: (
+          error: { message: string },
+          variables: { inviteCode: string },
+        ) => void;
       },
       mutation: {
         isLoading: false,
@@ -197,9 +203,10 @@ describe("useAcceptInviteOnce()", () => {
           mockState.mutation.error = {
             message: INVITE_ALREADY_ACCEPTED_MESSAGE,
           };
-          mockState.handlers.onError?.({
-            message: INVITE_ALREADY_ACCEPTED_MESSAGE,
-          });
+          mockState.handlers.onError?.(
+            { message: INVITE_ALREADY_ACCEPTED_MESSAGE },
+            { inviteCode: "invite-abc" },
+          );
         });
         rerender();
 
@@ -227,6 +234,7 @@ describe("useAcceptInviteOnce()", () => {
           // so toError() preserves the instance rather than stringifying to "[object Object]".
           mockState.handlers.onError?.(
             new Error("The invite has expired") as { message: string },
+            { inviteCode: "invite-abc" },
           );
         });
         rerender();
@@ -244,6 +252,87 @@ describe("useAcceptInviteOnce()", () => {
     });
   });
 
+  describe("given the page subtree remounts after the mutation was dispatched", () => {
+    // Regression for langwatch/langwatch#5550: the module-scoped one-shot
+    // guard correctly blocks a re-submit after a remount, but the outcome
+    // must not be lost with the unmounted instance — otherwise the page
+    // dead-ends on the loading screen with the error only in the console.
+    describe("when the mutation had already failed before the remount", () => {
+      it("reports status='error' with the message on the remounted instance instead of dead-ending on 'loading'", () => {
+        const first = renderHook(() =>
+          useAcceptInviteOnce({
+            inviteCode: "invite-abc",
+            enabled: true,
+          }),
+        );
+
+        act(() => {
+          mockState.mutation.isError = true;
+          mockState.mutation.error = { message: "The invite has expired" };
+          mockState.handlers.onError?.(
+            new Error("The invite has expired") as { message: string },
+            { inviteCode: "invite-abc" },
+          );
+        });
+
+        first.unmount();
+        resetMutationState();
+
+        const second = renderHook(() =>
+          useAcceptInviteOnce({
+            inviteCode: "invite-abc",
+            enabled: true,
+          }),
+        );
+
+        expect(mutateSpy).toHaveBeenCalledTimes(1);
+        expect(second.result.current.status).toBe("error");
+        expect(second.result.current.errorMessage).toBe(
+          "The invite has expired",
+        );
+      });
+    });
+
+    describe("when the mutation fails only after the remount", () => {
+      it("resolves the remounted instance to 'error' once the original instance's onError fires", () => {
+        renderHook(() =>
+          useAcceptInviteOnce({
+            inviteCode: "invite-abc",
+            enabled: true,
+          }),
+        );
+        // Capture the first instance's callbacks before the remount replaces
+        // them — react-query keeps the original mutation's options alive even
+        // after the component that dispatched it unmounts.
+        const firstHandlers = mockState.handlers;
+
+        cleanup();
+        resetMutationState();
+
+        const second = renderHook(() =>
+          useAcceptInviteOnce({
+            inviteCode: "invite-abc",
+            enabled: true,
+          }),
+        );
+
+        expect(second.result.current.status).toBe("loading");
+
+        act(() => {
+          firstHandlers.onError?.(
+            new Error("The invite has expired") as { message: string },
+            { inviteCode: "invite-abc" },
+          );
+        });
+
+        expect(second.result.current.status).toBe("error");
+        expect(second.result.current.errorMessage).toBe(
+          "The invite has expired",
+        );
+      });
+    });
+  });
+
   describe("given the mutation succeeds", () => {
     describe("when the invite has a landing project", () => {
       it("hard-redirects to the project slug, toasts success, and reports 'success' status", () => {
@@ -256,10 +345,13 @@ describe("useAcceptInviteOnce()", () => {
 
         act(() => {
           mockState.mutation.isSuccess = true;
-          mockState.handlers.onSuccess?.({
-            invite: { organization: { name: "Acme" } },
-            project: { slug: "acme-prod" },
-          });
+          mockState.handlers.onSuccess?.(
+            {
+              invite: { organization: { name: "Acme" } },
+              project: { slug: "acme-prod" },
+            },
+            { inviteCode: "invite-abc" },
+          );
         });
         rerender();
 
@@ -282,10 +374,13 @@ describe("useAcceptInviteOnce()", () => {
 
         act(() => {
           mockState.mutation.isSuccess = true;
-          mockState.handlers.onSuccess?.({
-            invite: { organization: { name: "Acme" } },
-            project: null,
-          });
+          mockState.handlers.onSuccess?.(
+            {
+              invite: { organization: { name: "Acme" } },
+              project: null,
+            },
+            { inviteCode: "invite-abc" },
+          );
         });
         rerender();
 

--- a/langwatch/src/hooks/useAcceptInviteOnce.ts
+++ b/langwatch/src/hooks/useAcceptInviteOnce.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 
 import { INVITE_ALREADY_ACCEPTED_MESSAGE } from "~/server/invites/errors";
 import { api } from "~/utils/api";
@@ -16,9 +16,41 @@ import { toaster } from "~/components/ui/toaster";
  */
 const submittedInviteCodes = new Set<string>();
 
-/** Test-only: reset the module-scoped guard between test cases. */
+/**
+ * Module-scoped outcome store, the counterpart of `submittedInviteCodes`.
+ * Because the guard above survives remounts while `useMutation` state does
+ * not, a page-subtree remount after `mutate` was dispatched would otherwise
+ * leave the fresh mutation instance permanently idle → status stuck on
+ * "loading" and the error only visible in the console (#5550). Outcomes are
+ * recorded here by the mutation callbacks (which react-query keeps alive
+ * even if the dispatching component unmounted) and read back via
+ * `useSyncExternalStore`, so any remounted instance resolves to the real
+ * terminal state.
+ */
+interface InviteOutcome {
+  status: Extract<
+    AcceptInviteStatus,
+    "success" | "already-accepted" | "error"
+  >;
+  errorMessage: string | null;
+}
+const inviteOutcomes = new Map<string, InviteOutcome>();
+const outcomeListeners = new Set<() => void>();
+
+function recordInviteOutcome(inviteCode: string, outcome: InviteOutcome): void {
+  inviteOutcomes.set(inviteCode, outcome);
+  for (const listener of outcomeListeners) listener();
+}
+
+function subscribeToInviteOutcomes(listener: () => void): () => void {
+  outcomeListeners.add(listener);
+  return () => outcomeListeners.delete(listener);
+}
+
+/** Test-only: reset the module-scoped guard + outcomes between test cases. */
 export function _resetSubmittedInviteCodesForTests(): void {
   submittedInviteCodes.clear();
+  inviteOutcomes.clear();
 }
 
 type AcceptInviteMutation = ReturnType<
@@ -77,7 +109,11 @@ export function useAcceptInviteOnce({
   enabled,
 }: UseAcceptInviteOnceOptions): UseAcceptInviteOnceResult {
   const mutation = api.organization.acceptInvite.useMutation({
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
+      recordInviteOutcome(variables.inviteCode, {
+        status: "success",
+        errorMessage: null,
+      });
       toaster.create({
         title: "Invite Accepted",
         description: `You have successfully accepted the invite for ${data.invite.organization.name}.`,
@@ -88,11 +124,19 @@ export function useAcceptInviteOnce({
 
       hardRedirect(data.project?.slug ? `/${data.project.slug}` : "/");
     },
-    onError: (error) => {
+    onError: (error, variables) => {
       if (error.message === INVITE_ALREADY_ACCEPTED_MESSAGE) {
+        recordInviteOutcome(variables.inviteCode, {
+          status: "already-accepted",
+          errorMessage: null,
+        });
         hardRedirect("/");
         return;
       }
+      recordInviteOutcome(variables.inviteCode, {
+        status: "error",
+        errorMessage: error.message,
+      });
       // Real failure (expired invite, email mismatch, …). The page renders
       // `errorMessage` inline; also capture for observability.
       captureException(toError(error), {
@@ -104,6 +148,12 @@ export function useAcceptInviteOnce({
   const { mutate } = mutation;
   const shouldTrigger = enabled && typeof inviteCode === "string";
 
+  // Terminal outcome recorded by a previous (possibly unmounted) instance of
+  // this hook for the same invite code — see `inviteOutcomes` above.
+  const storedOutcome = useSyncExternalStore(subscribeToInviteOutcomes, () =>
+    typeof inviteCode === "string" ? inviteOutcomes.get(inviteCode) : undefined,
+  );
+
   useEffect(() => {
     if (!shouldTrigger) return;
     if (typeof inviteCode !== "string") return;
@@ -113,14 +163,16 @@ export function useAcceptInviteOnce({
   }, [shouldTrigger, inviteCode, mutate]);
 
   return {
-    status: deriveStatus(mutation, shouldTrigger),
-    errorMessage: mutation.error?.message ?? null,
+    status: deriveStatus(mutation, shouldTrigger, storedOutcome),
+    errorMessage:
+      mutation.error?.message ?? storedOutcome?.errorMessage ?? null,
   };
 }
 
 function deriveStatus(
   mutation: AcceptInviteMutationResult,
   shouldTrigger: boolean,
+  storedOutcome: InviteOutcome | undefined,
 ): AcceptInviteStatus {
   if (!shouldTrigger) return "idle";
   if (mutation.isSuccess) return "success";
@@ -129,5 +181,10 @@ function deriveStatus(
       ? "already-accepted"
       : "error";
   }
+  // This instance's mutation is idle/loading, but a previous instance may
+  // already have finished — after a page-subtree remount the one-shot guard
+  // blocks a re-submit, so without this fallback the status would be stuck
+  // on "loading" forever (#5550).
+  if (storedOutcome) return storedOutcome.status;
   return "loading";
 }

--- a/langwatch/src/pages/invite/__tests__/accept.integration.test.tsx
+++ b/langwatch/src/pages/invite/__tests__/accept.integration.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression coverage for langwatch/langwatch#5550:
+ * when `acceptInvite` fails, the page must tell the user what happened
+ * (the server's error message) and offer a way out — a "Go to Dashboard"
+ * action next to "Log Out and Try Again" — instead of dead-ending on the
+ * loading screen with the error only in the console.
+ */
+import "@testing-library/jest-dom/vitest";
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AcceptInviteStatus } from "~/hooks/useAcceptInviteOnce";
+
+const { hardRedirectSpy, signOutSpy, mockAcceptState } = vi.hoisted(() => ({
+  hardRedirectSpy: vi.fn(),
+  signOutSpy: vi.fn(),
+  mockAcceptState: {
+    status: "error" as AcceptInviteStatus,
+    errorMessage: null as string | null,
+  },
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ query: { inviteCode: "invite-abc" } }),
+}));
+
+vi.mock("~/hooks/useRequiredSession", () => ({
+  useRequiredSession: () => ({ data: { user: { id: "user-1" } } }),
+}));
+
+vi.mock("~/hooks/useAcceptInviteOnce", () => ({
+  useAcceptInviteOnce: () => mockAcceptState,
+}));
+
+vi.mock("~/utils/auth-client", () => ({
+  signOut: signOutSpy,
+}));
+
+vi.mock("~/utils/hardRedirect", () => ({
+  hardRedirect: hardRedirectSpy,
+}));
+
+import Accept from "../accept";
+
+function renderAccept() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <Accept />
+    </ChakraProvider>,
+  );
+}
+
+describe("Accept invite page", () => {
+  beforeEach(() => {
+    hardRedirectSpy.mockReset();
+    signOutSpy.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given the invite acceptance failed", () => {
+    beforeEach(() => {
+      mockAcceptState.status = "error";
+      mockAcceptState.errorMessage =
+        "The invite was sent to invitee@example.com, but you are signed in as someone-else@example.com";
+    });
+
+    describe("when the page renders", () => {
+      it("shows the server's explanation of what happened", () => {
+        renderAccept();
+
+        expect(
+          screen.getByText("An error occurred while accepting the invite."),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            "The invite was sent to invitee@example.com, but you are signed in as someone-else@example.com",
+          ),
+        ).toBeInTheDocument();
+      });
+
+      it("offers both a dashboard escape hatch and a re-login action", () => {
+        renderAccept();
+
+        expect(
+          screen.getByRole("button", { name: "Go to Dashboard" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: "Log Out and Try Again" }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe("when the user clicks 'Go to Dashboard'", () => {
+      it("hard-navigates home so stale pre-invite caches are busted", async () => {
+        const user = userEvent.setup();
+        renderAccept();
+
+        await user.click(
+          screen.getByRole("button", { name: "Go to Dashboard" }),
+        );
+
+        expect(hardRedirectSpy).toHaveBeenCalledWith("/");
+        expect(signOutSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the user clicks 'Log Out and Try Again'", () => {
+      it("signs the user out", async () => {
+        const user = userEvent.setup();
+        renderAccept();
+
+        await user.click(
+          screen.getByRole("button", { name: "Log Out and Try Again" }),
+        );
+
+        expect(signOutSpy).toHaveBeenCalled();
+        expect(hardRedirectSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given the acceptance is still in flight", () => {
+    it("renders the loading screen without any error alert", () => {
+      mockAcceptState.status = "loading";
+      mockAcceptState.errorMessage = null;
+
+      renderAccept();
+
+      expect(
+        screen.queryByText("An error occurred while accepting the invite."),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/pages/invite/accept.tsx
+++ b/langwatch/src/pages/invite/accept.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, VStack } from "@chakra-ui/react";
+import { Alert, Button, HStack, VStack } from "@chakra-ui/react";
 
 import { LoadingScreen } from "../../components/LoadingScreen";
 import { SetupLayout } from "../../components/SetupLayout";
@@ -6,6 +6,7 @@ import { useRequiredSession } from "../../hooks/useRequiredSession";
 import { useAcceptInviteOnce } from "../../hooks/useAcceptInviteOnce";
 import { useRouter } from "~/utils/compat/next-router";
 import { signOut } from "~/utils/auth-client";
+import { hardRedirect } from "~/utils/hardRedirect";
 
 export default function Accept() {
   const router = useRouter();
@@ -41,9 +42,16 @@ export default function Accept() {
             <Alert.Description>{errorMessage}</Alert.Description>
           </Alert.Content>
         </Alert.Root>
-        <Button colorPalette="orange" onClick={() => void signOut()}>
-          Log Out and Try Again
-        </Button>
+        <HStack gap={3}>
+          {/* Hard navigation on purpose: busts caches primed with pre-invite
+              "no org" state, same reason the hook redirects hard on success. */}
+          <Button colorPalette="orange" onClick={() => hardRedirect("/")}>
+            Go to Dashboard
+          </Button>
+          <Button variant="outline" onClick={() => void signOut()}>
+            Log Out and Try Again
+          </Button>
+        </HStack>
       </VStack>
     </SetupLayout>
   );


### PR DESCRIPTION
# Related Issue

- Resolves #5550

## Why

Accepting an invite while signed in as a different account (or with an expired/invalid code) left the user on the bare LangWatch loading screen forever — the `FORBIDDEN`/`NOT_FOUND` error from `organization.acceptInvite` was only visible in the browser console. Reported from a real invite flow on app.langwatch.ai.

Closes #5550

## What changed

- **`AppProviders.tsx`**: `InnerProviders` now always wraps the routed page in `PostHogProvider` (with the `posthog-js` module singleton). Previously the wrap was conditional on `usePostHog()` resolving, and that element-type flip made React unmount + remount the entire routed page subtree shortly after every SaaS boot.
- **`useAcceptInviteOnce`**: mutation outcomes are now recorded in a module-scoped store (read via `useSyncExternalStore`), the counterpart of the existing module-scoped one-shot submit guard from #3325. A remounted page instance now resolves to the real terminal state instead of reporting `loading` forever.
- **`/invite/accept` error UI**: adds a primary **Go to Dashboard** action (hard navigation, busting stale pre-invite caches) next to **Log Out and Try Again**, so the user always sees what happened and has a way out.

## How it works

Two defects had to interact to produce the dead-end:

1. The PostHog conditional wrap remounted the page subtree once the `publicEnv` query resolved.
2. The one-shot guard (correctly) blocked a re-submit after the remount, but the outcome lived only in the unmounted instance's `useMutation` state — the fresh instance stayed idle, so `deriveStatus` returned `"loading"` and the page rendered `LoadingScreen` indefinitely.

Whether the user saw the error UI or the permanent spinner was a race between the `publicEnv` query (drives the remount) and the session query + mutation dispatch. Both sides are fixed: the tree no longer remounts on posthog init, and the hook now survives any remount (error boundaries, HMR, future provider changes) because react-query keeps the original mutation's callbacks alive even after the dispatching component unmounts — they write the outcome to the store and every subscribed instance re-derives its status.

## Test plan

- `src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx`: two new regression tests — remount after the error, and remount while the mutation is still in flight with the error arriving after. **Both fail without the fix** (status stuck on `loading`), pass with it. All 10 tests green.
- `src/pages/invite/__tests__/accept.integration.test.tsx` (new): error state shows the server's explanation + both actions; "Go to Dashboard" hard-navigates to `/`; "Log Out and Try Again" signs out; loading state shows no alert. 5 tests green.
- `pnpm typecheck` green.
- **Browser-verified end-to-end**: signed in locally, hit `/invite/accept?inviteCode=bogus-code-5550` → error card renders with message and both buttons; "Go to Dashboard" navigates home. Screenshot below.

## Anything surprising?

The provider fix removes a boot-time remount of the whole page tree that every SaaS page paid for — the invite page was just the only surface with one-shot semantics that made it fatal. Passing the uninitialized posthog singleton to `PostHogProvider` is inert when no `POSTHOG_KEY` is configured; `usePostHog()` still owns initialization.

---

### Screenshot — error state after the fix (was: permanent blank loading screen)

![invite accept error UI](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5551/invite-accept/error-ui.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved invite acceptance handling so progress and error state can survive page reloads or remounts without getting stuck.
  * Added a new **Go to Dashboard** action on invite error screens for quicker recovery.

* **Bug Fixes**
  * Fixed invite acceptance errors from disappearing or resetting when the page rerenders.
  * Preserved the displayed error message and status after failures.
  * Updated the error screen to better handle both failed and in-progress invite acceptance states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->