### PR TITLE
fix(langy): stop overloading LW_GATEWAY_BASE_URL for the worker's internal gateway URL

### DIFF
--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -118,7 +118,7 @@ export class LangyCredentialService {
     }
     if (!gatewayBaseUrl) {
       throw new LangyCredentialResolutionError(
-        "LW_GATEWAY_INTERNAL_URL is not configured on the control plane.",
+        "LW_GATEWAY_INTERNAL_URL (or legacy LW_GATEWAY_BASE_URL) is not configured on the control plane.",
       );
     }
 

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -102,8 +102,15 @@ export class LangyCredentialService {
     }
 
     const langwatchEndpoint = process.env.LANGWATCH_API_URL;
+    // The worker's NetworkPolicy blocks external HTTPS egress, so it can
+    // only ever reach the gateway's internal ClusterIP — LW_GATEWAY_PUBLIC_URL
+    // (the browser/CLI-facing URL, see gatewayUrl.ts) would be unreachable
+    // and must never be used here. LW_GATEWAY_INTERNAL_URL is the same
+    // internal-only var ottlGatewayClient.ts already established for the
+    // control-plane -> gateway direction; LW_GATEWAY_BASE_URL is kept only
+    // as a legacy fallback for deploys that haven't set the new var yet.
     const gatewayBaseUrl =
-      process.env.LW_GATEWAY_PUBLIC_URL ?? process.env.LW_GATEWAY_BASE_URL;
+      process.env.LW_GATEWAY_INTERNAL_URL ?? process.env.LW_GATEWAY_BASE_URL;
     if (!langwatchEndpoint) {
       throw new LangyCredentialResolutionError(
         "LANGWATCH_API_URL is not configured on the control plane.",
@@ -111,7 +118,7 @@ export class LangyCredentialService {
     }
     if (!gatewayBaseUrl) {
       throw new LangyCredentialResolutionError(
-        "LW_GATEWAY_BASE_URL is not configured on the control plane.",
+        "LW_GATEWAY_INTERNAL_URL is not configured on the control plane.",
       );
     }
 

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -102,15 +102,31 @@ export class LangyCredentialService {
     }
 
     const langwatchEndpoint = process.env.LANGWATCH_API_URL;
-    // The worker's NetworkPolicy blocks external HTTPS egress, so it can
-    // only ever reach the gateway's internal ClusterIP — LW_GATEWAY_PUBLIC_URL
-    // (the browser/CLI-facing URL, see gatewayUrl.ts) would be unreachable
-    // and must never be used here. LW_GATEWAY_INTERNAL_URL is the same
-    // internal-only var ottlGatewayClient.ts already established for the
-    // control-plane -> gateway direction; LW_GATEWAY_BASE_URL is kept only
-    // as a legacy fallback for deploys that haven't set the new var yet.
+    // Where the worker dials the AI gateway's OpenAI-compatible surface.
+    // Three candidate envs exist and only two of them name the gateway:
+    //
+    //   LW_GATEWAY_INTERNAL_URL  -> gateway (in-cluster). Reachable under the
+    //                               worker's NetworkPolicy, which permits only
+    //                               app pods (:5560) and gateway pods (:5563).
+    //   LW_GATEWAY_PUBLIC_URL    -> gateway (public ingress). The right target,
+    //                               reachable wherever no NetworkPolicy blocks
+    //                               external egress (self-hosted, `pnpm dev`).
+    //   LW_GATEWAY_BASE_URL      -> the CONTROL PLANE, not the gateway. The Go
+    //                               gateway reads this name to dial *back* at
+    //                               us (services/aigateway/config.go). Same name,
+    //                               opposite direction — see the naming-collision
+    //                               note in scripts/start.sh.
+    //
+    // So prefer the internal gateway address, then the public gateway address.
+    // LW_GATEWAY_BASE_URL is last and only for back-compat: the old SaaS dev
+    // cluster did point it at the gateway (`http://langwatch-gateway:80`), and
+    // dropping it would strand those deploys. Never promote it above
+    // LW_GATEWAY_PUBLIC_URL — on a modern deploy it resolves to the app, and
+    // the worker would POST completions at the control plane.
     const gatewayBaseUrl =
-      process.env.LW_GATEWAY_INTERNAL_URL ?? process.env.LW_GATEWAY_BASE_URL;
+      process.env.LW_GATEWAY_INTERNAL_URL ??
+      process.env.LW_GATEWAY_PUBLIC_URL ??
+      process.env.LW_GATEWAY_BASE_URL;
     if (!langwatchEndpoint) {
       throw new LangyCredentialResolutionError(
         "LANGWATCH_API_URL is not configured on the control plane.",
@@ -118,7 +134,7 @@ export class LangyCredentialService {
     }
     if (!gatewayBaseUrl) {
       throw new LangyCredentialResolutionError(
-        "LW_GATEWAY_INTERNAL_URL (or legacy LW_GATEWAY_BASE_URL) is not configured on the control plane.",
+        "No AI gateway URL is configured on the control plane — set LW_GATEWAY_INTERNAL_URL (in-cluster) or LW_GATEWAY_PUBLIC_URL (self-hosted).",
       );
     }
 

--- a/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -245,7 +245,13 @@ describe("LangyCredentialService", () => {
   describe("given both LW_GATEWAY_INTERNAL_URL and LW_GATEWAY_BASE_URL are set", () => {
     describe("when getOrProvision is called", () => {
       it("prefers LW_GATEWAY_INTERNAL_URL — LW_GATEWAY_BASE_URL is the public/browser-facing var", async () => {
-        process.env.LW_GATEWAY_INTERNAL_URL = "http://langwatch-gateway-internal:80/v1";
+        // Exactly the values prod ships: infrastructure/langwatch.tf sets
+        // LW_GATEWAY_INTERNAL_URL to the ClusterIP with no /v1 suffix, while
+        // LW_GATEWAY_BASE_URL (when a deploy sets it at all) carries the
+        // public gateway the browser/CLI use. Picking the public one here
+        // would hand the worker a URL its NetworkPolicy cannot reach.
+        process.env.LW_GATEWAY_INTERNAL_URL =
+          "http://langwatch-gateway-internal:80";
         process.env.LW_GATEWAY_BASE_URL = "https://gateway.langwatch.ai/v1";
         const prisma = makePrisma({
           projectSecret: {

--- a/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -72,10 +72,9 @@ beforeEach(() => {
   // Clear LW_GATEWAY_PUBLIC_URL / LW_GATEWAY_INTERNAL_URL so neither leaks in
   // from the developer's shell (`pnpm dev` setups pre-source .env to dodge
   // the start.sh defaulting bug, and that .env now carries these on the
-  // WSL+minikube layout). The credential service prefers INTERNAL over BASE
-  // (never PUBLIC — the worker's NetworkPolicy blocks external HTTPS, see
-  // LangyCredentialService.ts), so an inherited value would shadow whatever
-  // the test pins via LW_GATEWAY_BASE_URL above.
+  // WSL+minikube layout). Resolution is INTERNAL -> PUBLIC -> BASE, so an
+  // inherited value of either would shadow what the test pins via
+  // LW_GATEWAY_BASE_URL above.
   delete process.env.LW_GATEWAY_PUBLIC_URL;
   delete process.env.LW_GATEWAY_INTERNAL_URL;
 });
@@ -227,9 +226,10 @@ describe("LangyCredentialService", () => {
   });
 
   describe("given env config is incomplete", () => {
-    describe("when both LW_GATEWAY_INTERNAL_URL and LW_GATEWAY_BASE_URL are unset", () => {
+    describe("when no gateway URL env is set at all", () => {
       it("throws LangyCredentialResolutionError before any provisioning", async () => {
         delete process.env.LW_GATEWAY_INTERNAL_URL;
+        delete process.env.LW_GATEWAY_PUBLIC_URL;
         delete process.env.LW_GATEWAY_BASE_URL;
         const prisma = makePrisma();
         const svc = new LangyCredentialService(prisma);
@@ -238,6 +238,65 @@ describe("LangyCredentialService", () => {
           svc.getOrProvision({ projectId: "p1", actorUserId: "u1" }),
         ).rejects.toThrow(/LW_GATEWAY_INTERNAL_URL/);
         expect(vkCreate).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given a self-hosted deploy that sets only LW_GATEWAY_PUBLIC_URL", () => {
+    describe("when getOrProvision is called", () => {
+      // Regression guard. LW_GATEWAY_BASE_URL names the CONTROL PLANE on a
+      // modern deploy (the Go gateway dials back on it — see the
+      // naming-collision note in scripts/start.sh), so falling through to it
+      // here would hand the worker the app's own URL and every completion
+      // would POST at :5560 instead of the gateway's :5563.
+      it("uses the public gateway URL, never falling through to the control-plane LW_GATEWAY_BASE_URL", async () => {
+        delete process.env.LW_GATEWAY_INTERNAL_URL;
+        process.env.LW_GATEWAY_PUBLIC_URL = "https://gateway.acme.internal";
+        process.env.LW_GATEWAY_BASE_URL = "http://langwatch-app:5560";
+        const prisma = makePrisma({
+          projectSecret: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValue({ encryptedValue: "enc:lw_vk_live_stored" }),
+            create: vi.fn().mockResolvedValue({}),
+          },
+        });
+        const svc = new LangyCredentialService(prisma);
+
+        const creds = await svc.getOrProvision({
+          projectId: "p1",
+          actorUserId: "u1",
+        });
+
+        expect(creds.gatewayBaseUrl).toBe("https://gateway.acme.internal/v1");
+      });
+    });
+  });
+
+  describe("given an in-cluster deploy that sets INTERNAL alongside PUBLIC", () => {
+    describe("when getOrProvision is called", () => {
+      it("prefers LW_GATEWAY_INTERNAL_URL — the worker's NetworkPolicy blocks the public ingress", async () => {
+        process.env.LW_GATEWAY_INTERNAL_URL =
+          "http://langwatch-gateway-internal:80";
+        process.env.LW_GATEWAY_PUBLIC_URL = "https://gateway.langwatch.ai";
+        const prisma = makePrisma({
+          projectSecret: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValue({ encryptedValue: "enc:lw_vk_live_stored" }),
+            create: vi.fn().mockResolvedValue({}),
+          },
+        });
+        const svc = new LangyCredentialService(prisma);
+
+        const creds = await svc.getOrProvision({
+          projectId: "p1",
+          actorUserId: "u1",
+        });
+
+        expect(creds.gatewayBaseUrl).toBe(
+          "http://langwatch-gateway-internal:80/v1",
+        );
       });
     });
   });

--- a/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -69,12 +69,15 @@ beforeEach(() => {
   provisionLangyApiKey.mockResolvedValue(undefined);
   process.env.LANGWATCH_API_URL = "https://api.langwatch.test";
   process.env.LW_GATEWAY_BASE_URL = "http://gateway.test:5563/v1";
-  // Clear LW_GATEWAY_PUBLIC_URL so it doesn't leak in from the developer's
-  // shell (`pnpm dev` setups pre-source .env to dodge the start.sh defaulting
-  // bug, and that .env now carries LW_GATEWAY_PUBLIC_URL on the WSL+minikube
-  // layout). The credential service prefers PUBLIC over BASE, so an inherited
-  // value would shadow whatever the test pins via LW_GATEWAY_BASE_URL above.
+  // Clear LW_GATEWAY_PUBLIC_URL / LW_GATEWAY_INTERNAL_URL so neither leaks in
+  // from the developer's shell (`pnpm dev` setups pre-source .env to dodge
+  // the start.sh defaulting bug, and that .env now carries these on the
+  // WSL+minikube layout). The credential service prefers INTERNAL over BASE
+  // (never PUBLIC — the worker's NetworkPolicy blocks external HTTPS, see
+  // LangyCredentialService.ts), so an inherited value would shadow whatever
+  // the test pins via LW_GATEWAY_BASE_URL above.
   delete process.env.LW_GATEWAY_PUBLIC_URL;
+  delete process.env.LW_GATEWAY_INTERNAL_URL;
 });
 
 describe("LangyCredentialService", () => {
@@ -224,16 +227,44 @@ describe("LangyCredentialService", () => {
   });
 
   describe("given env config is incomplete", () => {
-    describe("when LW_GATEWAY_BASE_URL is unset", () => {
+    describe("when both LW_GATEWAY_INTERNAL_URL and LW_GATEWAY_BASE_URL are unset", () => {
       it("throws LangyCredentialResolutionError before any provisioning", async () => {
+        delete process.env.LW_GATEWAY_INTERNAL_URL;
         delete process.env.LW_GATEWAY_BASE_URL;
         const prisma = makePrisma();
         const svc = new LangyCredentialService(prisma);
 
         await expect(
           svc.getOrProvision({ projectId: "p1", actorUserId: "u1" }),
-        ).rejects.toThrow(/LW_GATEWAY_BASE_URL/);
+        ).rejects.toThrow(/LW_GATEWAY_INTERNAL_URL/);
         expect(vkCreate).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given both LW_GATEWAY_INTERNAL_URL and LW_GATEWAY_BASE_URL are set", () => {
+    describe("when getOrProvision is called", () => {
+      it("prefers LW_GATEWAY_INTERNAL_URL — LW_GATEWAY_BASE_URL is the public/browser-facing var", async () => {
+        process.env.LW_GATEWAY_INTERNAL_URL = "http://langwatch-gateway-internal:80/v1";
+        process.env.LW_GATEWAY_BASE_URL = "https://gateway.langwatch.ai/v1";
+        const prisma = makePrisma({
+          projectSecret: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValue({ encryptedValue: "enc:lw_vk_live_stored" }),
+            create: vi.fn().mockResolvedValue({}),
+          },
+        });
+        const svc = new LangyCredentialService(prisma);
+
+        const creds = await svc.getOrProvision({
+          projectId: "p1",
+          actorUserId: "u1",
+        });
+
+        expect(creds.gatewayBaseUrl).toBe(
+          "http://langwatch-gateway-internal:80/v1",
+        );
       });
     });
   });

--- a/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -275,6 +275,31 @@ describe("LangyCredentialService", () => {
     });
   });
 
+  describe("given only the legacy LW_GATEWAY_BASE_URL is set", () => {
+    describe("when getOrProvision is called", () => {
+      it("falls back to LW_GATEWAY_BASE_URL so deploys predating the rename keep working", async () => {
+        delete process.env.LW_GATEWAY_INTERNAL_URL;
+        process.env.LW_GATEWAY_BASE_URL = "http://langwatch-gateway:80";
+        const prisma = makePrisma({
+          projectSecret: {
+            findFirst: vi
+              .fn()
+              .mockResolvedValue({ encryptedValue: "enc:lw_vk_live_stored" }),
+            create: vi.fn().mockResolvedValue({}),
+          },
+        });
+        const svc = new LangyCredentialService(prisma);
+
+        const creds = await svc.getOrProvision({
+          projectId: "p1",
+          actorUserId: "u1",
+        });
+
+        expect(creds.gatewayBaseUrl).toBe("http://langwatch-gateway:80/v1");
+      });
+    });
+  });
+
   describe("given two simultaneous first-use requests for the same project", () => {
     describe("when the ProjectSecret.create loses the race with P2002", () => {
       it("re-reads the winner's encrypted secret and returns the decrypted plaintext", async () => {


### PR DESCRIPTION
## Summary
- `LangyCredentialService.resolveCredentials` now reads `LW_GATEWAY_INTERNAL_URL` first (falling back to the legacy `LW_GATEWAY_BASE_URL`), instead of `LW_GATEWAY_PUBLIC_URL ?? LW_GATEWAY_BASE_URL`.
- Companion fix for [langwatch-saas#671](https://github.com/langwatch/langwatch-saas/pull/671), which was blocked by a `CHANGES_REQUESTED` review from `langwatch-agent` flagging a real production regression.

## Why
PR #671 points the Langy worker's gateway URL at an internal-only ClusterIP. The worker's NetworkPolicy blocks external HTTPS egress, so it can only ever reach that internal address — but the control plane already reuses `LW_GATEWAY_BASE_URL` as the **legacy public gateway URL fallback**:
- `publicEnvRouter` ships it straight to the browser as `GATEWAY_BASE_URL` for SDK copy-paste snippets
- `personalVirtualKeys.ts` / `cliBootstrap.service.ts` fall back to it for the CLI + personal-VK reveal

whenever `LW_GATEWAY_PUBLIC_URL` is unset — which it always is in this deployment. Repointing `LW_GATEWAY_BASE_URL` at an internal ClusterIP would have silently broken all three browser/CLI-facing surfaces in prod.

`LW_GATEWAY_INTERNAL_URL` is not a new concept — `ottlGatewayClient.ts` already established this exact name for the same control-plane → gateway internal direction. This PR just makes Langy's credential resolution use it too, so `LW_GATEWAY_BASE_URL` keeps its existing public-facing meaning everywhere else.

## Test plan
- [x] `npx vitest run src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts` — 14/14 passing, including 2 new tests covering the `LW_GATEWAY_INTERNAL_URL` precedence and the updated unset-var error message
- [x] langwatch-saas#671 updated to set `LW_GATEWAY_INTERNAL_URL` instead of `LW_GATEWAY_BASE_URL` on the Deployment — merge together

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## ⚠️ Rollout order

Ship this **with** [langwatch-saas#671](https://github.com/langwatch/langwatch-saas/pull/671), which sets `LW_GATEWAY_INTERNAL_URL` on the control-plane deployment.

Neither order *breaks* anything:

| order | outcome |
|---|---|
| infra applied first, old app image | old code ignores the new var → Langy stays in its current (already-failing) state. Public gateway URLs unaffected. |
| this app change first, infra not yet applied | falls back to `LW_GATEWAY_BASE_URL` (unset in prod) → same current state. |
| both live | Langy resolves credentials against the internal ClusterIP ✅ |

The fix only **takes effect** once an app image containing this PR is deployed *and* #671 is applied.