### PR TITLE
fix(chart): wire Langy's control-plane endpoints for self-hosted installs

### DIFF
--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -385,6 +385,27 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- end }}
 {{- end }}
 
+{{/* Langy needs a gateway the WORKER can actually reach, which is two separate
+     things: the app must resolve a gateway URL, and the agent's deny-by-default
+     NetworkPolicy must permit egress to it. A chart-managed gateway satisfies
+     both (internal URL + the podSelector egress rule). An external gateway does
+     not: reached over the public ingress it needs allowExternalHttps (or a
+     hand-written egressToGateway rule), and with no URL at all the app throws
+     "is not configured on the control plane" on the first chat. Both configs
+     render happily today and fail only at runtime — catch them at install. */}}
+{{- $langy := index .Values "langyagent" | default dict }}
+{{- if and $langy.chartManaged (not $gw.chartManaged) }}
+  {{- $gwInternal := $gw.internalUrl | default "" }}
+  {{- $gwPublic := $gw.publicUrl | default "" }}
+  {{- $np := $langy.networkPolicy | default dict }}
+  {{- $customEgress := $np.egressToGateway | default list }}
+  {{- if not (or $gwInternal $gwPublic) }}
+    {{- $errors = append $errors "langyagent.chartManaged=true but gateway.chartManaged=false and neither gateway.internalUrl nor gateway.publicUrl is set. The control plane has no AI gateway address to hand the Langy worker, so every chat fails with \"is not configured on the control plane\". Set gateway.internalUrl to the in-cluster gateway Service (preferred), or gateway.publicUrl if the gateway is only reachable over the public ingress." }}
+  {{- else if and (not $gwInternal) (not $np.allowExternalHttps) (not $customEgress) }}
+    {{- $errors = append $errors (printf "langyagent.chartManaged=true with an external gateway reachable only at %q, but the agent NetworkPolicy denies that egress: langyagent.networkPolicy.allowExternalHttps=false and egressToGateway is empty. The worker resolves the URL and every LLM call is dropped. Either set gateway.internalUrl to an in-cluster gateway Service, or set langyagent.networkPolicy.allowExternalHttps=true, or pin a tighter rule via langyagent.networkPolicy.egressToGateway (+ networkPolicy.gatewayPort=443)." $gwPublic) }}
+  {{- end }}
+{{- end }}
+
 {{/* Output errors and warnings */}}
 {{- if $errors }}
 {{- fail (printf "Secret validation failed:\n%s" (join "\n" $errors)) }}

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -247,6 +247,16 @@ spec:
                 secretKeyRef:
                   name: {{ (index .Values "langyagent").secrets.existingSecretName | default "langwatch-langyagent-auth" }}
                   key: {{ (index .Values "langyagent").secrets.internalSecretKey | default "LANGY_INTERNAL_SECRET" }}
+
+            # LANGWATCH_API_URL — the control plane reads this from its own env
+            # and hands it to the Langy worker as the MCP server's
+            # LANGWATCH_ENDPOINT (LangyCredentialService.getOrProvision, which
+            # throws "LANGWATCH_API_URL is not configured on the control plane"
+            # when unset). Must be the CLUSTER-INTERNAL app Service: the agent's
+            # NetworkPolicy permits egress only to the app pod on
+            # networkPolicy.controlPlanePort, never to a public ingress.
+            - name: LANGWATCH_API_URL
+              value: {{ (index .Values "langyagent").controlPlane.langwatchApiUrl | default (printf "http://%s-app:%v" .Release.Name .Values.app.service.port) | quote }}
             {{- end }}
 
             # LW_GATEWAY_PUBLIC_URL — the externally-reachable AI Gateway URL
@@ -270,6 +280,24 @@ spec:
             {{- if $gwPublic }}
             - name: LW_GATEWAY_PUBLIC_URL
               value: {{ $gwPublic | quote }}
+            {{- end }}
+
+            # LW_GATEWAY_INTERNAL_URL — the cluster-internal gateway URL, used
+            # for control-plane -> gateway calls: the Langy worker's
+            # OPENAI_BASE_URL and the HMAC-signed /internal/* OTTL surface.
+            # Deliberately NOT LW_GATEWAY_PUBLIC_URL (the langyagent
+            # NetworkPolicy denies external HTTPS egress, so a public ingress is
+            # unreachable from the worker) and NOT LW_GATEWAY_BASE_URL, which
+            # names the CONTROL PLANE — the Go gateway reads that same key to
+            # dial back at us (services/aigateway/config.go), the opposite
+            # direction. See the naming-collision note in scripts/start.sh.
+            {{- $gwInternal := .Values.gateway.internalUrl | default "" }}
+            {{- if and (not $gwInternal) .Values.gateway.chartManaged }}
+            {{- $gwInternal = printf "http://%s-gateway:%v" .Release.Name .Values.gateway.service.port }}
+            {{- end }}
+            {{- if $gwInternal }}
+            - name: LW_GATEWAY_INTERNAL_URL
+              value: {{ $gwInternal | quote }}
             {{- end }}
 
             # NextAuth configuration (NEXTAUTH_SECRET lives in sharedEnv —

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -41,9 +41,12 @@ tmpl_only() {
 }
 
 # Check rendered YAML contains a string (uses <<< to avoid broken pipe with large output)
+# `--` terminates grep's option parsing: a needle like "- name: FOO" (YAML list
+# item) would otherwise be read as a flag, and grep's usage error would make
+# assert_not_contains report a silent false PASS.
 assert_contains() {
   local label="$1" haystack="$2" needle="$3"
-  if grep -qF "$needle" <<< "$haystack"; then
+  if grep -qF -- "$needle" <<< "$haystack"; then
     pass "$label"
   else
     fail "$label: expected to find '$needle'"
@@ -53,7 +56,7 @@ assert_contains() {
 # Check rendered YAML does NOT contain a string
 assert_not_contains() {
   local label="$1" haystack="$2" needle="$3"
-  if grep -qF "$needle" <<< "$haystack"; then
+  if grep -qF -- "$needle" <<< "$haystack"; then
     fail "$label: expected NOT to find '$needle'"
   else
     pass "$label"
@@ -375,6 +378,80 @@ test_overlay_stacking() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# SUITE: langy-control-plane-env — the two envs LangyCredentialService reads
+#
+# Both must resolve to CLUSTER-INTERNAL Services: the langyagent
+# NetworkPolicy denies external HTTPS egress and permits only the app pod
+# (networkPolicy.controlPlanePort) and the gateway pod (networkPolicy.gatewayPort).
+#
+# Binds specs/langy/langy-selfhost-deployment.feature
+# ─────────────────────────────────────────────────────────────────────────────
+test_langy_control_plane_env() {
+  sep; info "Suite: langy control-plane env wiring"
+
+  local out
+  out=$(tmpl --set autogen.enabled=true \
+    --set langyagent.chartManaged=true \
+    --set gateway.chartManaged=true)
+
+  # Without these the app throws "<VAR> is not configured on the control plane"
+  # on every Langy chat (LangyCredentialService.getOrProvision).
+  # @scenario "Langy reaches the LangWatch API without leaving the cluster"
+  assert_contains "LANGWATCH_API_URL points at the internal app Service" \
+    "$out" "value: \"http://${RELEASE}-app:5560\""
+  # @scenario "Langy reaches the AI gateway without leaving the cluster"
+  assert_contains "LW_GATEWAY_INTERNAL_URL points at the internal gateway Service" \
+    "$out" "value: \"http://${RELEASE}-gateway:80\""
+
+  # Both addresses must land on pod ports the agent's NetworkPolicy permits:
+  # the app Service forwards :5560 -> pod :5560 (controlPlanePort) and the
+  # gateway Service forwards :80 -> pod :5563 (gatewayPort).
+  assert_contains "agent policy permits the app pod port" "$out" "port: 5560"
+  assert_contains "agent policy permits the gateway pod port" "$out" "port: 5563"
+
+  # The public hostname still reaches CLI users, it just never becomes the
+  # worker's gateway address.
+  # @scenario "The public gateway address is never used for worker traffic"
+  local pub
+  pub=$(tmpl --set autogen.enabled=true \
+    --set langyagent.chartManaged=true \
+    --set gateway.chartManaged=true \
+    --set gateway.publicUrl=https://gateway.acme.example)
+  assert_contains "public URL still offered to CLI users" \
+    "$pub" 'value: "https://gateway.acme.example"'
+  assert_contains "worker gateway address stays in-cluster" \
+    "$pub" "value: \"http://${RELEASE}-gateway:80\""
+
+  # LW_GATEWAY_BASE_URL names the CONTROL PLANE (the Go gateway dials back at
+  # us on it), so it must never be set on the app as if it were the gateway.
+  # @scenario "The gateway's own call-back address is never mistaken for the gateway"
+  assert_not_contains "app never receives LW_GATEWAY_BASE_URL" \
+    "$out" "- name: LW_GATEWAY_BASE_URL"
+
+  # Operator overrides win, for split installs / external gateways.
+  # @scenario "Operator-supplied addresses win"
+  local ovr
+  ovr=$(tmpl --set autogen.enabled=true \
+    --set langyagent.chartManaged=true \
+    --set gateway.chartManaged=false \
+    --set gateway.internalUrl=http://gw.other.svc:8080 \
+    --set langyagent.controlPlane.langwatchApiUrl=http://custom-app:9999)
+  assert_contains "gateway.internalUrl override wins" \
+    "$ovr" 'value: "http://gw.other.svc:8080"'
+  assert_contains "langyagent.controlPlane.langwatchApiUrl override wins" \
+    "$ovr" 'value: "http://custom-app:9999"'
+
+  # An external gateway with no internalUrl must not silently fabricate one.
+  # @scenario "An operator running the gateway elsewhere supplies the address"
+  local ext
+  ext=$(tmpl --set autogen.enabled=true \
+    --set langyagent.chartManaged=true \
+    --set gateway.chartManaged=false)
+  assert_not_contains "no LW_GATEWAY_INTERNAL_URL when gateway is external and unset" \
+    "$ext" "- name: LW_GATEWAY_INTERNAL_URL"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # SUITE: Install — deploy size-dev + nodeport and verify live resources
 # ─────────────────────────────────────────────────────────────────────────────
 test_install_dev_nodeport() {
@@ -592,6 +669,7 @@ main() {
   test_size_overlays
   test_infra_overlays
   test_overlay_stacking
+  test_langy_control_plane_env
 
   # Phase 2: Live installs (slower, needs Kind + images)
   load_images

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -441,14 +441,91 @@ test_langy_control_plane_env() {
   assert_contains "langyagent.controlPlane.langwatchApiUrl override wins" \
     "$ovr" 'value: "http://custom-app:9999"'
 
-  # An external gateway with no internalUrl must not silently fabricate one.
+  # An external gateway with an operator-supplied internal URL must not
+  # fabricate a chart-managed one.
   # @scenario "An operator running the gateway elsewhere supplies the address"
   local ext
   ext=$(tmpl --set autogen.enabled=true \
     --set langyagent.chartManaged=true \
-    --set gateway.chartManaged=false)
-  assert_not_contains "no LW_GATEWAY_INTERNAL_URL when gateway is external and unset" \
-    "$ext" "- name: LW_GATEWAY_INTERNAL_URL"
+    --set gateway.chartManaged=false \
+    --set gateway.internalUrl=http://gw.other.svc:8080)
+  assert_not_contains "no chart-managed gateway URL when gateway is external" \
+    "$ext" "value: \"http://${RELEASE}-gateway:80\""
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE: langy-gateway-reachability — install-time guard for hybrid installs
+#
+# Resolving a gateway URL and being ALLOWED to reach it are separate things.
+# The agent's NetworkPolicy is deny-by-default, so an external gateway on the
+# public ingress is unreachable unless the operator opts in. Both broken
+# configs used to render fine and fail only at runtime.
+#
+# Binds specs/langy/langy-selfhost-deployment.feature
+# ─────────────────────────────────────────────────────────────────────────────
+test_langy_gateway_reachability() {
+  sep; info "Suite: langy gateway reachability guard"
+
+  # Renders OK: chart-managed gateway (internal URL + podSelector egress rule).
+  if tmpl --set autogen.enabled=true --set langyagent.chartManaged=true \
+      --set gateway.chartManaged=true > /dev/null 2>&1; then
+    pass "self-hosted (chart-managed gateway) installs"
+  else
+    fail "self-hosted (chart-managed gateway) must install"
+  fi
+
+  # Blocked: no gateway address at all -> app throws on the first chat.
+  # @scenario "An operator running the gateway elsewhere supplies the address"
+  if tmpl --set autogen.enabled=true --set langyagent.chartManaged=true \
+      --set gateway.chartManaged=false > /dev/null 2>&1; then
+    fail "external gateway with no URL must be rejected at install"
+  else
+    pass "external gateway with no URL is rejected at install"
+  fi
+
+  # Blocked: public gateway, but the worker's egress to it is denied.
+  if tmpl --set autogen.enabled=true --set langyagent.chartManaged=true \
+      --set gateway.chartManaged=false \
+      --set gateway.publicUrl=https://gateway.langwatch.ai > /dev/null 2>&1; then
+    fail "public gateway with denied egress must be rejected at install"
+  else
+    pass "public gateway with denied egress is rejected at install"
+  fi
+
+  # Each escape hatch unblocks the hybrid install.
+  if tmpl --set autogen.enabled=true --set langyagent.chartManaged=true \
+      --set gateway.chartManaged=false \
+      --set gateway.publicUrl=https://gateway.langwatch.ai \
+      --set langyagent.networkPolicy.allowExternalHttps=true > /dev/null 2>&1; then
+    pass "hybrid installs with allowExternalHttps=true"
+  else
+    fail "allowExternalHttps=true must unblock the hybrid install"
+  fi
+
+  if tmpl --set autogen.enabled=true --set langyagent.chartManaged=true \
+      --set gateway.chartManaged=false \
+      --set gateway.publicUrl=https://gateway.langwatch.ai \
+      --set 'langyagent.networkPolicy.egressToGateway[0].ipBlock.cidr=203.0.113.7/32' \
+      --set langyagent.networkPolicy.gatewayPort=443 > /dev/null 2>&1; then
+    pass "hybrid installs with a pinned egressToGateway rule"
+  else
+    fail "egressToGateway must unblock the hybrid install"
+  fi
+
+  if tmpl --set autogen.enabled=true --set langyagent.chartManaged=true \
+      --set gateway.chartManaged=false \
+      --set gateway.internalUrl=http://gw.other.svc:8080 > /dev/null 2>&1; then
+    pass "hybrid installs with an in-cluster gateway.internalUrl"
+  else
+    fail "gateway.internalUrl must unblock the hybrid install"
+  fi
+
+  # The guard must never fire when Langy is off (the default).
+  if tmpl --set autogen.enabled=true --set gateway.chartManaged=false > /dev/null 2>&1; then
+    pass "guard does not fire when Langy is disabled"
+  else
+    fail "guard must not fire when Langy is disabled"
+  fi
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -670,6 +747,7 @@ main() {
   test_infra_overlays
   test_overlay_stacking
   test_langy_control_plane_env
+  test_langy_gateway_reachability
 
   # Phase 2: Live installs (slower, needs Kind + images)
   load_images

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1580,6 +1580,9 @@ gateway:
   ## @param gateway.publicUrl [string, default: ""] Externally-reachable URL of the AI Gateway (e.g. https://gateway.your-corp.com). The control plane hands this to CLI users (langwatch claude/codex/cursor) at login. REQUIRED for self-hosted CLI/agentic use: without it the CLI falls back to http://localhost:5563, which a developer laptop cannot reach against a remote cluster. Leave empty to auto-derive from gateway.ingress.host when you set your own host. Set LANGWATCH_GATEWAY_URL on the client to override per-user.
   publicUrl: ""
 
+  ## @param gateway.internalUrl [string, default: ""] Cluster-internal URL the control plane uses to reach the gateway (LW_GATEWAY_INTERNAL_URL) — the Langy worker's OPENAI_BASE_URL and the HMAC-signed /internal/* OTTL surface. Distinct from gateway.publicUrl: the langyagent NetworkPolicy denies external HTTPS egress, so the worker can only reach the gateway's in-cluster Service. Leave empty to auto-derive from the chart-managed gateway Service; set it when gateway.chartManaged=false and the gateway runs elsewhere in-cluster.
+  internalUrl: ""
+
   # The gateway needs its OWN externally-reachable endpoint, separate from
   # the main app — point a second ingress / load balancer at gateway.ingress
   # below (the LLM clients hit the gateway, the browser hits the app). The
@@ -1646,8 +1649,10 @@ langyagent:
   chartManaged: false
 
   ## @param langyagent.controlPlane.agentUrl [string, default: http://<release>-langyagent:80] URL the app uses to reach the agent Service. Leave empty to auto-derive from the release name.
+  ## @param langyagent.controlPlane.langwatchApiUrl [string, default: http://<release>-app:<app.service.port>] Cluster-internal LangWatch API URL (LANGWATCH_API_URL) the control plane hands to the Langy worker's MCP server. Must be in-cluster: the agent NetworkPolicy permits egress only to the app pod on app.service.port. Leave empty to auto-derive from the release name.
   controlPlane:
     agentUrl: ""
+    langwatchApiUrl: ""
 
   ## @param langyagent.secrets.existingSecretName [string, default: langwatch-langyagent-auth] Secret carrying LANGY_INTERNAL_SECRET, shared between the app and the agent pod. Created out-of-band (terraform / external-secrets); the umbrella chart does NOT materialise it.
   ## @param langyagent.secrets.internalSecretKey [string, default: LANGY_INTERNAL_SECRET] Key inside the existing Secret that holds the shared internal secret.

--- a/specs/langy/langy-selfhost-deployment.feature
+++ b/specs/langy/langy-selfhost-deployment.feature
@@ -1,0 +1,50 @@
+Feature: Langy works on a self-hosted install
+  As an operator self-hosting LangWatch
+  I want Langy to reach the LangWatch API and the AI gateway from inside my cluster
+  So that enabling the assistant does not fail on the first message
+
+  # The control plane resolves two endpoints and hands them to the Langy worker
+  # (LangyCredentialService). The worker is locked down: its NetworkPolicy denies
+  # external HTTPS egress and permits only the app pod and the gateway pod. Any
+  # endpoint that leaves the cluster is unreachable, so both must be in-cluster
+  # Service addresses.
+
+  Background:
+    Given an operator installs the LangWatch chart
+    And the operator enables the Langy agent
+
+  Scenario: Langy reaches the LangWatch API without leaving the cluster
+    When the chart renders the app deployment
+    Then the app receives a LangWatch API address pointing at the in-cluster app service
+    And that address is reachable under the Langy worker's network policy
+
+  Scenario: Langy reaches the AI gateway without leaving the cluster
+    Given the operator lets the chart manage the AI gateway
+    When the chart renders the app deployment
+    Then the app receives an internal gateway address pointing at the in-cluster gateway service
+    And that address is reachable under the Langy worker's network policy
+
+  Scenario: The public gateway address is never used for worker traffic
+    Given the operator has published the gateway on a public hostname
+    When the chart renders the app deployment
+    Then the worker's gateway address remains the in-cluster one
+    And the public hostname is still offered to CLI users
+
+  # Regression guard. The gateway reuses the "base URL" name for the opposite
+  # direction — it dials the control plane on it — so handing that value to the
+  # worker would point the assistant at the app instead of the gateway.
+  Scenario: The gateway's own call-back address is never mistaken for the gateway
+    When the chart renders the app deployment
+    Then the app is not given the gateway's call-back address as its gateway address
+
+  Scenario: An operator running the gateway elsewhere supplies the address
+    Given the operator runs the AI gateway outside this chart
+    And the operator has not supplied an internal gateway address
+    When the chart renders the app deployment
+    Then no internal gateway address is invented for them
+
+  Scenario: Operator-supplied addresses win
+    Given the operator supplies their own internal gateway address
+    And the operator supplies their own LangWatch API address
+    When the chart renders the app deployment
+    Then the app receives the operator's addresses unchanged

--- a/specs/langy/langy-selfhost-deployment.feature
+++ b/specs/langy/langy-selfhost-deployment.feature
@@ -39,12 +39,51 @@ Feature: Langy works on a self-hosted install
 
   Scenario: An operator running the gateway elsewhere supplies the address
     Given the operator runs the AI gateway outside this chart
-    And the operator has not supplied an internal gateway address
+    And the operator supplies an internal gateway address
     When the chart renders the app deployment
-    Then no internal gateway address is invented for them
+    Then no chart-managed gateway address is invented for them
 
   Scenario: Operator-supplied addresses win
     Given the operator supplies their own internal gateway address
     And the operator supplies their own LangWatch API address
     When the chart renders the app deployment
     Then the app receives the operator's addresses unchanged
+
+  # Resolving a gateway address and being permitted to reach it are separate
+  # things: the worker's egress is denied by default. A hybrid install — where
+  # the gateway is hosted elsewhere and reachable only over the public internet
+  # — silently dropped every LLM call until the operator opened that egress.
+  # These configurations now fail at install time instead of at first chat.
+
+  Scenario: Enabling Langy without any gateway address is refused at install
+    Given the operator runs the AI gateway outside this chart
+    And the operator supplies no gateway address at all
+    When the operator installs the chart
+    Then the install is refused
+    And the message tells them which address to supply
+
+  Scenario: Enabling Langy against an unreachable public gateway is refused at install
+    Given the operator runs the AI gateway outside this chart
+    And the gateway is reachable only over the public internet
+    And the operator has not opened the worker's egress to it
+    When the operator installs the chart
+    Then the install is refused
+    And the message offers each way to make the gateway reachable
+
+  Scenario Outline: Opening the worker's path to a hosted gateway allows the install
+    Given the operator runs the AI gateway outside this chart
+    And the operator <makes the gateway reachable>
+    When the operator installs the chart
+    Then the install succeeds
+
+    Examples:
+      | makes the gateway reachable                  |
+      | allows the worker's public egress            |
+      | pins an egress rule to the gateway's address |
+      | points the worker at an in-cluster gateway   |
+
+  Scenario: The guard never fires for operators who have not enabled Langy
+    Given the operator has not enabled the Langy agent
+    And the operator runs the AI gateway outside this chart
+    When the operator installs the chart
+    Then the install succeeds


### PR DESCRIPTION
## Summary

**Self-hosted Langy has never worked.** The umbrella chart wires the agent pod (`OPENCODE_AGENT_URL`, `LANGY_INTERNAL_SECRET`) but never sets the two envs `LangyCredentialService.getOrProvision` reads. The first chat message 409s with:

```
LANGWATCH_API_URL is not configured on the control plane.
```

Nobody has hit this because `langy-agent.chartManaged` defaults to `false`. Only operators who explicitly opt in are affected, and nothing else in the app degrades.

Found while verifying the SaaS-side fix ([langwatch-saas#671](https://github.com/langwatch/langwatch-saas/pull/671) / #5576) actually generalises to self-hosters. It didn't.

## The fix

Both endpoints must be **cluster-internal**. The `langy-agent` NetworkPolicy ships `allowExternalHttps: false` and permits egress only to the app pod (`:5560`) and the gateway pod (`:5563`) — a public ingress is simply unreachable from the worker.

| env | value | reaches |
|---|---|---|
| `LANGWATCH_API_URL` | `http://<release>-app:<app.service.port>` | app pod `:5560` |
| `LW_GATEWAY_INTERNAL_URL` | `http://<release>-gateway:<gateway.service.port>` | gateway pod `:5563` |

Both overridable — `langy-agent.controlPlane.langwatchApiUrl` and the new `gateway.internalUrl` — for split installs and externally-run gateways.

### Why not `LW_GATEWAY_BASE_URL`

That name means the **control plane** in this direction. The Go gateway reads it to dial *back* at us, and this very chart already renders `LW_GATEWAY_BASE_URL: "http://<release>-app:5560"` into the gateway's ConfigMap. Handing it to the worker would point LLM completions at the app. `scripts/start.sh` documents the same collision (it once made `langwatch claude` 404).

### Scope note

`LW_GATEWAY_INTERNAL_URL` is set whenever a gateway is present, not only under Langy. `ottlGatewayClient.ts` reads the same env for the HMAC-signed `/internal/*` surface and was previously throwing `OttlGatewayUnavailableError` on every call. This un-breaks it. Verified both pods source `LW_GATEWAY_INTERNAL_SECRET` from the same Secret (`<release>-app-secrets`), so the HMAC channel matches — no new 401s.

## Deployment Impact

**Env vars added** (rendered on `langwatch-app` only, never on the gateway/agent pods): `LANGWATCH_API_URL` (set whenever `langyagent.chartManaged=true`) and `LW_GATEWAY_INTERNAL_URL` (set whenever a gateway is present — chart-managed or an operator-supplied `gateway.internalUrl`). Both resolve to cluster-internal Service DNS names; neither is a new secret or credential.

**Helm values added**: `gateway.internalUrl` (string, default `""`, auto-derives from the chart-managed gateway Service) and `langyagent.controlPlane.langwatchApiUrl` (string, default `""`, auto-derives from the release's app Service). Both are optional overrides for split installs / externally-run gateways; existing `values.yaml` files need no changes.

**Default `helm install` behavior (no overrides)**: no change. `langyagent.chartManaged` defaults to `false`, so none of this code path renders for the common case. For operators who already opted into `langyagent.chartManaged=true`, this PR is a straight bugfix — Langy chat was already 409-ing on every first message; nothing that worked before now fails.

**New install-time guard**: `helm template`/`helm install` now hard-fails (via the existing `$errors`/`fail` validation block in `_helpers.tpl`) when `langyagent.chartManaged=true` and the gateway is external with no reachable address configured (no `gateway.internalUrl`/`publicUrl`, or a `publicUrl` the agent's NetworkPolicy can't reach). This only affects the already-broken opt-in hybrid path — it converts a silent runtime 409 into an install-time error naming the exact value to set, and never fires when `langyagent.chartManaged=false` (the default) or when the gateway is chart-managed.

**BYOC dataplane impact**: none. No dataplane/object-storage config, network egress widening, or new external endpoint is introduced — this only wires cluster-internal env vars for the already-optional (default-off) Langy agent pod and tightens an existing install-time validation block.

## Drive-by: a false-PASS in the test harness

`assert_not_contains "…" "$out" "- name: FOO"` never searched anything. `grep -qF "- name: FOO"` parses the leading `-` as a flag, errors with `grep: invalid option`, exits non-zero — and the helper's `else` branch reports **PASS**. Terminated option parsing with `--` in both `assert_contains` and `assert_not_contains`.

## Test plan

- [x] New `specs/langy/langy-selfhost-deployment.feature`, bound from the chart's `helm template` suite via `@scenario` comments
- [x] `test_langy_control_plane_env` — 10 assertions covering: both envs resolve in-cluster, ports match the NetworkPolicy's permitted pod ports, the public URL still reaches CLI users while the worker stays internal, `LW_GATEWAY_BASE_URL` is never set on the app, both operator overrides win, and no internal URL is fabricated for an external gateway
- [x] **Mutation-tested**: the suite fails against the pre-fix template, passes after
- [x] All pre-existing template suites still pass with the patched assert helpers
- [x] `helm lint` clean
- [x] Rendered and diffed across 7 value permutations (default / langy on / gateway off / overrides / custom release name / custom `app.service.port`)

Rendered with `langy-agent.chartManaged=true`:

```
LANGWATCH_API_URL        = "http://langwatch-app:5560"
LW_GATEWAY_INTERNAL_URL  = "http://langwatch-gateway:80"
OPENCODE_AGENT_URL       = "http://langwatch-langy-agent:80"
```

## Related

Independent of, but consistent with, #5576 (app-side resolution order `INTERNAL → PUBLIC → BASE`) and langwatch-saas#671 (SaaS Terraform). This PR is the chart equivalent for self-hosters. No docs changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
