### PR TITLE
fix(trace-processing): stop the hot-trace fold re-fold storm

### DIFF
--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outboxReactorAdapter.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outboxReactorAdapter.unit.test.ts
@@ -60,8 +60,13 @@ function makeRequest(
 
 function makeDefinition(
   decide: OutboxReactorDefinition<Event>["decide"],
+  shouldReact?: OutboxReactorDefinition<Event>["shouldReact"],
 ): OutboxReactorDefinition<Event> {
-  return { name: "alertTriggerNotifyOutbox", decide };
+  return {
+    name: "alertTriggerNotifyOutbox",
+    decide,
+    ...(shouldReact ? { shouldReact } : {}),
+  };
 }
 
 function makeContext(): ReactorContext<unknown> {
@@ -192,6 +197,66 @@ describe("adaptOutboxReactor", () => {
       await adapted.handle({} as Event, makeContext());
 
       expect(outbox.enqueueSettle).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+/**
+ * `shouldReact` is what stops a stake-sensitive reactor from serializing and
+ * blobbing a payload the queue's dedup would discard. The adapter is the only
+ * thing standing between an `OutboxReactorDefinition` and the router, so a lost
+ * forward would silently re-enable the fan-out on every outbox reactor.
+ */
+describe("adaptOutboxReactor relevance check", () => {
+  const decideNever: OutboxReactorDefinition<Event>["decide"] = async () => [];
+
+  describe("when the definition declares a relevance check", () => {
+    /** @scenario "An outbox reactor's relevance check reaches the dispatcher" */
+    it("forwards it to the adapted reactor with and without an outbox runtime", () => {
+      const shouldReact = vi.fn().mockReturnValue(false);
+      const context = makeContext();
+      const event = {} as Event;
+
+      const withRuntime = adaptOutboxReactor(
+        makeDefinition(decideNever, shouldReact),
+        makeOutboxStub(),
+      );
+      expect(withRuntime.shouldReact?.(event, context)).toBe(false);
+
+      const withoutRuntime = adaptOutboxReactor(
+        makeDefinition(decideNever, shouldReact),
+        undefined,
+      );
+      expect(withoutRuntime.shouldReact?.(event, context)).toBe(false);
+
+      expect(shouldReact).toHaveBeenCalledTimes(2);
+      expect(shouldReact).toHaveBeenCalledWith(event, context);
+    });
+
+    it("keeps `this` bound to the definition", () => {
+      const definition: OutboxReactorDefinition<Event> = {
+        name: "alertTriggerNotifyOutbox",
+        decide: decideNever,
+        shouldReact() {
+          // Throws on an unbound call, so a lost binding fails loudly.
+          return this.name === "alertTriggerNotifyOutbox";
+        },
+      };
+
+      const adapted = adaptOutboxReactor(definition, makeOutboxStub());
+
+      expect(adapted.shouldReact?.({} as Event, makeContext())).toBe(true);
+    });
+  });
+
+  describe("when the definition declares no relevance check", () => {
+    it("leaves shouldReact undefined so the router treats every event as relevant", () => {
+      const adapted = adaptOutboxReactor(
+        makeDefinition(decideNever),
+        makeOutboxStub(),
+      );
+
+      expect(adapted.shouldReact).toBeUndefined();
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
@@ -83,6 +83,13 @@ export interface OutboxReactorDefinition<
 > {
   name: string;
   /**
+   * Optional pure predicate evaluated at dispatch time, before any job is
+   * enqueued — the same contract as `ReactorDefinition.shouldReact`, forwarded
+   * verbatim by `adaptOutboxReactor`. Return false to skip this reactor for the
+   * event and spare the queue a payload that `decide()` would only discard.
+   */
+  shouldReact?(event: E, context: ReactorContext<FoldState>): boolean;
+  /**
    * Decide which (if any) outbox rows to enqueue for this event.
    * Returns an empty array when nothing matches. Replay-safe — the
    * outbox dedupes on (name, dedupKey) so callers do not need to

--- a/langwatch/src/server/event-sourcing/outbox/outboxReactorAdapter.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outboxReactorAdapter.ts
@@ -43,6 +43,9 @@ export function adaptOutboxReactor<E extends Event, FoldState>(
     return {
       name: definition.name,
       options: definition.options,
+      ...(definition.shouldReact
+        ? { shouldReact: definition.shouldReact.bind(definition) }
+        : {}),
       async handle(event: E) {
         // No outbox runtime wired for this process role. The handle only
         // fires on processes that actually consume events, so reaching
@@ -64,6 +67,9 @@ export function adaptOutboxReactor<E extends Event, FoldState>(
   return {
     name: definition.name,
     options: definition.options,
+    ...(definition.shouldReact
+      ? { shouldReact: definition.shouldReact.bind(definition) }
+      : {}),
     async handle(event: E, context: ReactorContext<FoldState>) {
       // Replay short-circuit (ADR-030 / `specs/event-sourcing/reactor-outbox-dispatch.feature`).
       // When the runtime is replaying historical events, the audit row

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryRefoldPolicy.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryRefoldPolicy.unit.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import type { FoldProjectionStore } from "~/server/event-sourcing/projections/foldProjection.types";
+import { FoldProjectionExecutor } from "~/server/event-sourcing/projections/foldProjectionExecutor";
+import { SPAN_RECEIVED_EVENT_TYPE } from "../../schemas/constants";
+import type { TraceProcessingEvent } from "../../schemas/events";
+import {
+  MAX_PROCESSED_SPANS,
+  TraceSummaryFoldProjection,
+} from "../traceSummary.foldProjection";
+import { createInitState } from "./fixtures/trace-summary-test.fixtures";
+
+/**
+ * Regression guard for the 2026-07-09 re-fold storm. Sharding recordSpan across
+ * GroupQueue lanes makes a hot trace's spans reach the fold out of occurredAt
+ * order, so the executor's out-of-order detector fires constantly. The trace
+ * summary is order-insensitive, so a span is simply folded when it arrives and
+ * the event log is never re-read.
+ *
+ * See specs/event-sourcing/hot-trace-fold-amplification.feature.
+ */
+
+const TENANT_ID = createTenantId("project-1");
+const TRACE_ID = "trace-1";
+const CHECKPOINT_MS = 9_000;
+
+function stateWithSpanCount(spanCount: number): TraceSummaryData {
+  return {
+    ...createInitState(),
+    traceId: TRACE_ID,
+    spanCount,
+    LastEventOccurredAt: CHECKPOINT_MS,
+  } as TraceSummaryData;
+}
+
+/** Past the cap the fold never reads `data`, so the span stays minimal. */
+function spanEventAt(occurredAt: number, id: string): TraceProcessingEvent {
+  return {
+    id,
+    type: SPAN_RECEIVED_EVENT_TYPE,
+    aggregateId: TRACE_ID,
+    aggregateType: "trace",
+    tenantId: TENANT_ID,
+    occurredAt,
+    createdAt: occurredAt,
+    version: "2025-12-17",
+    data: { span: { name: "child", spanId: id, traceId: TRACE_ID } },
+  } as unknown as TraceProcessingEvent;
+}
+
+describe("TraceSummaryFoldProjection re-fold policy", () => {
+  /** @scenario "The trace summary is an order-insensitive fold" */
+  it("has opted out of re-folding on out-of-order events", () => {
+    const projection = new TraceSummaryFoldProjection({
+      store: {} as FoldProjectionStore<TraceSummaryData>,
+    });
+
+    expect(projection.options.refoldOnOutOfOrder).toBe(false);
+  });
+
+  describe("given a trace summary with spans already folded", () => {
+    describe("when a batch of three earlier spans is folded", () => {
+      /** @scenario "Folding out-of-order spans without a re-fold still counts every span" */
+      it("skips the event-log replay, counts every span, and never rewinds the checkpoint", async () => {
+        const stored = stateWithSpanCount(MAX_PROCESSED_SPANS + 10);
+        let persisted: TraceSummaryData | undefined;
+        const store: FoldProjectionStore<TraceSummaryData> = {
+          get: vi.fn().mockResolvedValue(stored),
+          store: vi.fn(async (state: TraceSummaryData) => {
+            persisted = state;
+          }),
+        };
+
+        const projection = new TraceSummaryFoldProjection({ store });
+        const eventLoader = vi.fn().mockResolvedValue([]);
+        projection.eventLoader = eventLoader;
+
+        // Every event occurred before the persisted checkpoint — exactly what a
+        // sharded, parallel recordSpan produces.
+        const result = await new FoldProjectionExecutor().executeBatch(
+          projection,
+          [
+            spanEventAt(3_000, "a"),
+            spanEventAt(1_000, "b"),
+            spanEventAt(2_000, "c"),
+          ],
+          { aggregateId: TRACE_ID, tenantId: TENANT_ID },
+        );
+
+        expect(eventLoader).not.toHaveBeenCalled();
+        expect(result.spanCount).toBe(MAX_PROCESSED_SPANS + 13);
+        expect(persisted?.spanCount).toBe(MAX_PROCESSED_SPANS + 13);
+        // The checkpoint is a high-water mark: folding older spans never rewinds it.
+        expect(result.LastEventOccurredAt).toBe(CHECKPOINT_MS);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryRefoldPolicy.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryRefoldPolicy.unit.test.ts
@@ -50,13 +50,24 @@ function spanEventAt(occurredAt: number, id: string): TraceProcessingEvent {
 }
 
 describe("TraceSummaryFoldProjection re-fold policy", () => {
-  /** @scenario "The trace summary is an order-insensitive fold" */
-  it("has opted out of re-folding on out-of-order events", () => {
-    const projection = new TraceSummaryFoldProjection({
-      store: {} as FoldProjectionStore<TraceSummaryData>,
-    });
+  /** @scenario "The trace summary folds an earlier span without reading the event log" */
+  it("folds a span that occurred before the checkpoint without reading the event log", async () => {
+    const store: FoldProjectionStore<TraceSummaryData> = {
+      get: vi.fn().mockResolvedValue(stateWithSpanCount(MAX_PROCESSED_SPANS + 1)),
+      store: vi.fn().mockResolvedValue(undefined),
+    };
+    const projection = new TraceSummaryFoldProjection({ store });
+    const eventLoader = vi.fn().mockResolvedValue([]);
+    projection.eventLoader = eventLoader;
 
-    expect(projection.options.refoldOnOutOfOrder).toBe(false);
+    const result = await new FoldProjectionExecutor().execute(
+      projection,
+      spanEventAt(1_000, "a"),
+      { aggregateId: TRACE_ID, tenantId: TENANT_ID },
+    );
+
+    expect(eventLoader).not.toHaveBeenCalled();
+    expect(result.spanCount).toBe(MAX_PROCESSED_SPANS + 2);
   });
 
   describe("given a trace summary with spans already folded", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -264,19 +264,30 @@ export class TraceSummaryFoldProjection
   readonly store: FoldProjectionStore<TraceSummaryData>;
 
   /**
-   * A span can be folded whenever it arrives — the trace summary reaches the
-   * same state either way, so an out-of-order span never needs the history
-   * replayed. Every accumulator commutes (spanCount and the token/cost totals
-   * are sums, timing is min/max, status is an OR), and every precedence rule
-   * decides from data the span itself carries — output selection compares span
-   * end times (`shouldOverrideOutput`), trace naming compares root-span start
-   * times — never from the order spans were applied in.
+   * A span is folded whenever it arrives; an out-of-order span never replays the
+   * trace's history. Nearly every field is order-free: spanCount and the
+   * token/cost totals are sums, timing is min/max, status is an OR, the semantic
+   * output override compares span end times (`shouldOverrideOutput`), and trace
+   * naming compares root-span start times.
    *
-   * The single exception is `mergeModelsMostRecentFirst`, which orders
-   * `models` by application order so `models[0]` is the trace's primary model.
-   * `executeBatch` folds each batch in occurredAt order, so that holds within a
-   * batch and only relaxes across batch boundaries: a display nicety, not a
-   * correctness property, and not worth an event_log replay.
+   * Three fields ARE resolved in fold order, and we accept that:
+   *   - `models` — `mergeModelsMostRecentFirst` puts the last-folded model first,
+   *     so `models[0]` is the trace's primary model.
+   *   - `computedInput` — among several parentless "root" spans the last-folded
+   *     one wins; among non-root spans the first-folded one wins
+   *     (`trace-io-accumulation.service.ts`, the `isRoot || computedInput === null`
+   *     branch). There is no timestamp tiebreak.
+   *   - `computedOutput` when only a *fallback* (non-semantic) extraction exists —
+   *     the first-folded fallback wins. A later semantic match still overrides it.
+   *
+   * This costs less than it reads. `occurredAt` on a span event is the INGEST
+   * wall-clock (`trace-request-collection.service.ts` stamps `Date.now()`), not
+   * the span's own start time — so the replay never restored span-time order
+   * either, only global ingest order. `executeBatch` folds each batch in
+   * occurredAt order, so within a batch nothing changes; across batches these
+   * three fields may resolve differently than a full replay would, on
+   * multi-root traces. That is a display-level difference in fields whose
+   * selection was already ingest-order dependent, not a lost invariant.
    *
    * Leaving the replay on was ruinous once recordSpan sharded across GroupQueue
    * lanes, because a hot trace's spans then arrive out of order constantly: one

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -263,6 +263,29 @@ export class TraceSummaryFoldProjection
   readonly version = TRACE_SUMMARY_PROJECTION_VERSION_LATEST;
   readonly store: FoldProjectionStore<TraceSummaryData>;
 
+  /**
+   * A span can be folded whenever it arrives — the trace summary reaches the
+   * same state either way, so an out-of-order span never needs the history
+   * replayed. Every accumulator commutes (spanCount and the token/cost totals
+   * are sums, timing is min/max, status is an OR), and every precedence rule
+   * decides from data the span itself carries — output selection compares span
+   * end times (`shouldOverrideOutput`), trace naming compares root-span start
+   * times — never from the order spans were applied in.
+   *
+   * The single exception is `mergeModelsMostRecentFirst`, which orders
+   * `models` by application order so `models[0]` is the trace's primary model.
+   * `executeBatch` folds each batch in occurredAt order, so that holds within a
+   * batch and only relaxes across batch boundaries: a display nicety, not a
+   * correctness property, and not worth an event_log replay.
+   *
+   * Leaving the replay on was ruinous once recordSpan sharded across GroupQueue
+   * lanes, because a hot trace's spans then arrive out of order constantly: one
+   * trace re-folded 730 times in two hours, re-reading 5.66M event rows, and
+   * never caught up (2026-07-09 —
+   * specs/event-sourcing/hot-trace-fold-amplification.feature).
+   */
+  readonly options = { refoldOnOutOfOrder: false } as const;
+
   protected readonly events = traceSummaryEvents;
 
   constructor(deps: { store: FoldProjectionStore<TraceSummaryData> }) {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -602,6 +602,14 @@ describe("evaluationTrigger relevance check", () => {
       await reactor.handle(createSpanEvent(), createContext(atCap));
       expect(deps.evaluation).not.toHaveBeenCalled();
 
+      // A coalesced batch can jump the span count clean past the cap without
+      // ever landing on it, so the guard is `>=`, not `===`.
+      const pastCap = withOrigin({ spanCount: MAX_PROCESSED_SPANS + 1 });
+      const depsPast = createDeps();
+      const reactorPast = createEvaluationTriggerReactor(depsPast);
+      await reactorPast.handle(createSpanEvent(), createContext(pastCap));
+      expect(depsPast.evaluation).not.toHaveBeenCalled();
+
       const belowCap = withOrigin({ spanCount: MAX_PROCESSED_SPANS - 1 });
       const depsBelow = createDeps();
       const reactorBelow = createEvaluationTriggerReactor(depsBelow);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -548,3 +548,61 @@ describe("evaluationTrigger reactor", () => {
     });
   });
 });
+
+/**
+ * The guards below used to live inside `handle`, so every span of a 10k-span
+ * trace was serialized, gzipped and blobbed into Redis before the queue's dedup
+ * threw the job away. They are pure and read only the payload `handle` receives,
+ * so `shouldReact` rejects them pre-enqueue instead (ADR-026). See
+ * specs/event-sourcing/hot-trace-fold-amplification.feature.
+ */
+describe("evaluationTrigger relevance check", () => {
+  const withOrigin = (overrides: Partial<TraceSummaryData> = {}) =>
+    createFoldState({
+      attributes: { "langwatch.origin": "application" },
+      ...overrides,
+    });
+
+  const shouldReact = (
+    event: TraceProcessingEvent,
+    state: TraceSummaryData,
+  ): boolean => {
+    const reactor = createEvaluationTriggerReactor(createDeps());
+    // biome-ignore lint/style/noNonNullAssertion: the reactor always declares one.
+    return reactor.shouldReact!(event, createContext(state));
+  };
+
+  describe("given a trace with a resolved origin", () => {
+    /** @scenario "The origin guard admits a genuine message event before enqueue" */
+    it("agrees to react to a recent span event", () => {
+      expect(shouldReact(createSpanEvent(), withOrigin())).toBe(true);
+    });
+
+    /** @scenario "The origin guard filters a non-message event before enqueue" */
+    it("declines a topic-assigned event", () => {
+      expect(shouldReact(createTopicAssignedEvent(), withOrigin())).toBe(false);
+    });
+
+    /** @scenario "The evaluation trigger declines a synthetic span before enqueue" */
+    it("declines a synthetic span", () => {
+      const synthetic = createSpanEvent({ spanName: TRACK_EVENT_SPAN_NAME });
+      expect(shouldReact(synthetic, withOrigin())).toBe(false);
+    });
+
+    /** @scenario "The evaluation trigger declines past the span processing cap before enqueue" */
+    it("declines once the span count reaches the processing cap", () => {
+      const atCap = withOrigin({ spanCount: MAX_PROCESSED_SPANS });
+      expect(shouldReact(createSpanEvent(), atCap)).toBe(false);
+
+      const belowCap = withOrigin({ spanCount: MAX_PROCESSED_SPANS - 1 });
+      expect(shouldReact(createSpanEvent(), belowCap)).toBe(true);
+    });
+  });
+
+  describe("given a trace whose origin is unresolved", () => {
+    /** @scenario "The origin guard filters a trace with no resolved origin before enqueue" */
+    it("declines a span event", () => {
+      expect(shouldReact(createSpanEvent(), createFoldState())).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -589,13 +589,24 @@ describe("evaluationTrigger relevance check", () => {
       expect(shouldReact(synthetic, withOrigin())).toBe(false);
     });
 
-    /** @scenario "The evaluation trigger declines past the span processing cap before enqueue" */
-    it("declines once the span count reaches the processing cap", () => {
+    /** @scenario "The evaluation trigger dispatches nothing past the span processing cap" */
+    it("dispatches no evaluation once the span count reaches the processing cap", async () => {
+      // The cap guard deliberately lives in handle, not shouldReact: shouldReact
+      // runs once per event of a coalesced batch and would multiply the
+      // once-per-crossing warn by the batch size.
       const atCap = withOrigin({ spanCount: MAX_PROCESSED_SPANS });
-      expect(shouldReact(createSpanEvent(), atCap)).toBe(false);
+      expect(shouldReact(createSpanEvent(), atCap)).toBe(true);
+
+      const deps = createDeps();
+      const reactor = createEvaluationTriggerReactor(deps);
+      await reactor.handle(createSpanEvent(), createContext(atCap));
+      expect(deps.evaluation).not.toHaveBeenCalled();
 
       const belowCap = withOrigin({ spanCount: MAX_PROCESSED_SPANS - 1 });
-      expect(shouldReact(createSpanEvent(), belowCap)).toBe(true);
+      const depsBelow = createDeps();
+      const reactorBelow = createEvaluationTriggerReactor(depsBelow);
+      await reactorBelow.handle(createSpanEvent(), createContext(belowCap));
+      expect(depsBelow.evaluation).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/_originGuardedReactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/_originGuardedReactor.ts
@@ -87,16 +87,34 @@ function passesTraceOriginGuards(
   return true;
 }
 
+/**
+ * An extra pure guard, ANDed with the origin guards. Must be synchronous and
+ * side-effect free: it runs pre-enqueue via `shouldReact` on the fold's hot
+ * path. Guards needing IO belong in `handle`.
+ */
+type ExtraGuard = (
+  event: TraceProcessingEvent,
+  context: ReactorContext<TraceSummaryData>,
+) => boolean;
+
 export function defineOriginGuardedTraceReactor(opts: {
   name: string;
   jobIdPrefix: string;
   ttl?: number;
   delay?: number;
+  isRelevant?: ExtraGuard;
   handle: (
     event: TraceProcessingEvent,
     context: ReactorContext<TraceSummaryData>,
   ) => Promise<void>;
 }): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
+  const passes = (
+    event: TraceProcessingEvent,
+    context: ReactorContext<TraceSummaryData>,
+  ): boolean =>
+    passesTraceOriginGuards(event, context.foldState) &&
+    (opts.isRelevant?.(event, context) ?? true);
+
   return {
     name: opts.name,
     options: {
@@ -106,8 +124,17 @@ export function defineOriginGuardedTraceReactor(opts: {
       delay: opts.delay ?? 30_000,
     },
 
+    // Pre-enqueue (ADR-026). The guards are pure and read only the payload the
+    // handler would receive, so evaluating them here is equivalent to the
+    // early-return in `handle` — except a filtered event never pays a
+    // serialize + gzip + blob write that the queue's dedup would then discard.
+    // A 10k-span trace fans this reactor out once per span; the guards reject
+    // nearly all of it. Kept in `handle` too: the queue is not the only caller
+    // (inline mode), and a fail-open `shouldReact` may dispatch anyway.
+    shouldReact: passes,
+
     async handle(event, context) {
-      if (!passesTraceOriginGuards(event, context.foldState)) return;
+      if (!passes(event, context)) return;
       await opts.handle(event, context);
     },
   };
@@ -125,11 +152,19 @@ export function defineOriginGuardedTraceOutboxReactor(opts: {
   jobIdPrefix: string;
   ttl?: number;
   delay?: number;
+  isRelevant?: ExtraGuard;
   decide: (
     event: TraceProcessingEvent,
     context: ReactorContext<TraceSummaryData>,
   ) => Promise<OutboxEnqueueRequest[]>;
 }): OutboxReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
+  const passes = (
+    event: TraceProcessingEvent,
+    context: ReactorContext<TraceSummaryData>,
+  ): boolean =>
+    passesTraceOriginGuards(event, context.foldState) &&
+    (opts.isRelevant?.(event, context) ?? true);
+
   return {
     name: opts.name,
     options: {
@@ -139,8 +174,11 @@ export function defineOriginGuardedTraceOutboxReactor(opts: {
       delay: opts.delay ?? 30_000,
     },
 
+    // See the `.withReactor` twin above for why this is also a shouldReact.
+    shouldReact: passes,
+
     async decide(event, context) {
-      if (!passesTraceOriginGuards(event, context.foldState)) return [];
+      if (!passes(event, context)) return [];
       return opts.decide(event, context);
     },
   };

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -6,7 +6,10 @@ import { createLogger } from "../../../../../utils/logger/server";
 import { featureFlagService } from "../../../../featureFlag";
 import { evaluatorLoopBlockedCounter } from "../../../../metrics";
 import type { QueueSendOptions } from "../../../queues";
-import type { ReactorDefinition } from "../../../reactors/reactor.types";
+import type {
+  ReactorContext,
+  ReactorDefinition,
+} from "../../../reactors/reactor.types";
 import { ExecuteEvaluationCommand } from "../../evaluation-processing/commands/executeEvaluation.command";
 import type { ExecuteEvaluationCommandData } from "../../evaluation-processing/schemas/commands";
 import {
@@ -36,6 +39,57 @@ export interface EvaluationTriggerReactorDeps {
 }
 
 /**
+ * Pure relevance guard, evaluated pre-enqueue via `shouldReact` (and again in
+ * `handle`, which stays the fail-open path). Both checks read only the payload
+ * the handler would receive, so hoisting them out of `handle` changes nothing
+ * but where the work is skipped — before the queue serializes, gzips and blobs a
+ * payload it would immediately dedup away, rather than after.
+ */
+function isDispatchableEvaluationEvent(
+  event: TraceProcessingEvent,
+  context: ReactorContext<TraceSummaryData>,
+): boolean {
+  // Bug 2 / #3875: synthetic event spans (e.g. thumbs-up/down feedback via /api/track_event)
+  // do not contribute to fold IO and must not re-trigger ON_MESSAGE evaluator runs. We
+  // share `SYNTHETIC_SPAN_NAMES` with the trace-summary fold (foldProjection.ts:88) so a
+  // future synthetic name updates both sites at once.
+  if (
+    isSpanReceivedEvent(event) &&
+    SYNTHETIC_SPAN_NAMES.has(event.data.span.name)
+  ) {
+    return false;
+  }
+
+  // Oversized-trace guard (2026-05-28 incident follow-up). Past the same
+  // processing cap the fold uses to stop deriving the summary
+  // (MAX_PROCESSED_SPANS), a trace is a runaway / reused trace_id and is too
+  // large to keep evaluating: re-running every ON_MESSAGE monitor per span
+  // on a 26k-span trace is pure amplification for no added signal. Skip the
+  // eval dispatch (lighter processing). The span itself is still stored and
+  // the trace stays fully queryable: we drop the WORK, never the DATA.
+  const { foldState } = context;
+  if (foldState.spanCount >= MAX_PROCESSED_SPANS) {
+    // Log once, on the first crossing only. This is a per-span hot path: a
+    // runaway trace would otherwise emit thousands of identical warns, the
+    // very per-span amplification we are skipping the eval to avoid.
+    if (foldState.spanCount === MAX_PROCESSED_SPANS) {
+      logger.warn(
+        {
+          tenantId: context.tenantId,
+          observedTraceId: context.aggregateId,
+          spanCount: foldState.spanCount,
+          cap: MAX_PROCESSED_SPANS,
+        },
+        "Skipping evaluation dispatch: trace reached the processing cap (spans still stored)",
+      );
+    }
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * Dispatches evaluation commands for traces that have a resolved origin.
  *
  * Fires on every trace event (via traceSummary fold). If origin is absent,
@@ -49,43 +103,9 @@ export function createEvaluationTriggerReactor(
   return defineOriginGuardedTraceReactor({
     name: "evaluationTrigger",
     jobIdPrefix: "eval-trigger",
+    isRelevant: isDispatchableEvaluationEvent,
     async handle(event, context) {
-      // Bug 2 / #3875: synthetic event spans (e.g. thumbs-up/down feedback via /api/track_event)
-      // do not contribute to fold IO and must not re-trigger ON_MESSAGE evaluator runs. We
-      // share `SYNTHETIC_SPAN_NAMES` with the trace-summary fold (foldProjection.ts:88) so a
-      // future synthetic name updates both sites at once.
-      if (
-        isSpanReceivedEvent(event) &&
-        SYNTHETIC_SPAN_NAMES.has(event.data.span.name)
-      ) {
-        return;
-      }
       const { tenantId, aggregateId: traceId, foldState } = context;
-
-      // Oversized-trace guard (2026-05-28 incident follow-up). Past the same
-      // processing cap the fold uses to stop deriving the summary
-      // (MAX_PROCESSED_SPANS), a trace is a runaway / reused trace_id and is too
-      // large to keep evaluating: re-running every ON_MESSAGE monitor per span
-      // on a 26k-span trace is pure amplification for no added signal. Skip the
-      // eval dispatch (lighter processing). The span itself is still stored and
-      // the trace stays fully queryable: we drop the WORK, never the DATA.
-      if (foldState.spanCount >= MAX_PROCESSED_SPANS) {
-        // Log once, on the first crossing only. This is a per-span hot path: a
-        // runaway trace would otherwise emit thousands of identical warns, the
-        // very per-span amplification we are skipping the eval to avoid.
-        if (foldState.spanCount === MAX_PROCESSED_SPANS) {
-          logger.warn(
-            {
-              tenantId,
-              observedTraceId: traceId,
-              spanCount: foldState.spanCount,
-              cap: MAX_PROCESSED_SPANS,
-            },
-            "Skipping evaluation dispatch: trace reached the processing cap (spans still stored)",
-          );
-        }
-        return;
-      }
 
       // Infinite-loop prevention (post-2026-05-11 incident). See
       // specs/monitors/online-evaluator-loop-prevention.feature.

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -6,10 +6,7 @@ import { createLogger } from "../../../../../utils/logger/server";
 import { featureFlagService } from "../../../../featureFlag";
 import { evaluatorLoopBlockedCounter } from "../../../../metrics";
 import type { QueueSendOptions } from "../../../queues";
-import type {
-  ReactorContext,
-  ReactorDefinition,
-} from "../../../reactors/reactor.types";
+import type { ReactorDefinition } from "../../../reactors/reactor.types";
 import { ExecuteEvaluationCommand } from "../../evaluation-processing/commands/executeEvaluation.command";
 import type { ExecuteEvaluationCommandData } from "../../evaluation-processing/schemas/commands";
 import {
@@ -40,53 +37,24 @@ export interface EvaluationTriggerReactorDeps {
 
 /**
  * Pure relevance guard, evaluated pre-enqueue via `shouldReact` (and again in
- * `handle`, which stays the fail-open path). Both checks read only the payload
- * the handler would receive, so hoisting them out of `handle` changes nothing
- * but where the work is skipped — before the queue serializes, gzips and blobs a
- * payload it would immediately dedup away, rather than after.
+ * `handle`, the fail-open path). Reads only the payload the handler receives, so
+ * hoisting it out of `handle` changes nothing but where the work is skipped —
+ * before the queue serializes, gzips and blobs a payload it would immediately
+ * dedup away, rather than after.
+ *
+ * Side-effect free, per the `ExtraGuard` contract: `shouldReact` is evaluated
+ * once per event of a coalesced batch, so anything logged here is multiplied by
+ * the batch size. The oversized-trace guard lives in `handle` for exactly that
+ * reason — see below.
  */
-function isDispatchableEvaluationEvent(
-  event: TraceProcessingEvent,
-  context: ReactorContext<TraceSummaryData>,
-): boolean {
+function isDispatchableEvaluationEvent(event: TraceProcessingEvent): boolean {
   // Bug 2 / #3875: synthetic event spans (e.g. thumbs-up/down feedback via /api/track_event)
   // do not contribute to fold IO and must not re-trigger ON_MESSAGE evaluator runs. We
   // share `SYNTHETIC_SPAN_NAMES` with the trace-summary fold (foldProjection.ts:88) so a
   // future synthetic name updates both sites at once.
-  if (
-    isSpanReceivedEvent(event) &&
-    SYNTHETIC_SPAN_NAMES.has(event.data.span.name)
-  ) {
-    return false;
-  }
-
-  // Oversized-trace guard (2026-05-28 incident follow-up). Past the same
-  // processing cap the fold uses to stop deriving the summary
-  // (MAX_PROCESSED_SPANS), a trace is a runaway / reused trace_id and is too
-  // large to keep evaluating: re-running every ON_MESSAGE monitor per span
-  // on a 26k-span trace is pure amplification for no added signal. Skip the
-  // eval dispatch (lighter processing). The span itself is still stored and
-  // the trace stays fully queryable: we drop the WORK, never the DATA.
-  const { foldState } = context;
-  if (foldState.spanCount >= MAX_PROCESSED_SPANS) {
-    // Log once, on the first crossing only. This is a per-span hot path: a
-    // runaway trace would otherwise emit thousands of identical warns, the
-    // very per-span amplification we are skipping the eval to avoid.
-    if (foldState.spanCount === MAX_PROCESSED_SPANS) {
-      logger.warn(
-        {
-          tenantId: context.tenantId,
-          observedTraceId: context.aggregateId,
-          spanCount: foldState.spanCount,
-          cap: MAX_PROCESSED_SPANS,
-        },
-        "Skipping evaluation dispatch: trace reached the processing cap (spans still stored)",
-      );
-    }
-    return false;
-  }
-
-  return true;
+  return !(
+    isSpanReceivedEvent(event) && SYNTHETIC_SPAN_NAMES.has(event.data.span.name)
+  );
 }
 
 /**
@@ -106,6 +74,37 @@ export function createEvaluationTriggerReactor(
     isRelevant: isDispatchableEvaluationEvent,
     async handle(event, context) {
       const { tenantId, aggregateId: traceId, foldState } = context;
+
+      // Oversized-trace guard (2026-05-28 incident follow-up). Past the same
+      // processing cap the fold uses to stop deriving the summary
+      // (MAX_PROCESSED_SPANS), a trace is a runaway / reused trace_id and is too
+      // large to keep evaluating: re-running every ON_MESSAGE monitor per span
+      // on a 26k-span trace is pure amplification for no added signal. Skip the
+      // eval dispatch (lighter processing). The span itself is still stored and
+      // the trace stays fully queryable: we drop the WORK, never the DATA.
+      //
+      // This stays in `handle`, not in the pre-enqueue `shouldReact`, so the
+      // once-per-crossing warn below fires once: `shouldReact` runs per event of
+      // a coalesced batch, and would multiply the log by the batch size. The
+      // enqueue it no longer skips is already collapsed to one job per batch by
+      // the router's dedup-id collapse, so there is nothing left to save.
+      if (foldState.spanCount >= MAX_PROCESSED_SPANS) {
+        // Log once, on the first crossing only. A runaway trace would otherwise
+        // emit thousands of identical warns — the very per-span amplification we
+        // are skipping the eval to avoid.
+        if (foldState.spanCount === MAX_PROCESSED_SPANS) {
+          logger.warn(
+            {
+              tenantId,
+              observedTraceId: traceId,
+              spanCount: foldState.spanCount,
+              cap: MAX_PROCESSED_SPANS,
+            },
+            "Skipping evaluation dispatch: trace reached the processing cap (spans still stored)",
+          );
+        }
+        return;
+      }
 
       // Infinite-loop prevention (post-2026-05-11 incident). See
       // specs/monitors/online-evaluator-loop-prevention.feature.

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refold.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refold.unit.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { incrementEsFoldRefoldTotal } from "~/server/metrics";
+
+vi.mock("~/server/metrics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/server/metrics")>();
+  return { ...actual, incrementEsFoldRefoldTotal: vi.fn() };
+});
+
 import type { Event } from "../../domain/types";
 import {
   createMockFoldProjectionDefinition,
@@ -27,10 +34,13 @@ function makeFold({
   storedState,
   loadedEvents,
   refoldOnOutOfOrder,
+  withEventLoader = true,
 }: {
   storedState: CounterState | null;
   loadedEvents?: Event[];
   refoldOnOutOfOrder?: boolean;
+  /** Omit the loader to exercise the degraded "unavailable" path. */
+  withEventLoader?: boolean;
 }) {
   const store = createMockFoldProjectionStore<CounterState>();
   (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(storedState);
@@ -48,11 +58,16 @@ function makeFold({
   }) as FoldProjectionDefinition<CounterState, Event>;
 
   const eventLoader = vi.fn().mockResolvedValue(loadedEvents ?? []);
-  fold.eventLoader = eventLoader;
+  if (withEventLoader) fold.eventLoader = eventLoader;
+  else fold.eventLoader = undefined;
   if (refoldOnOutOfOrder !== undefined) fold.options = { refoldOnOutOfOrder };
 
   return { fold, store, eventLoader };
 }
+
+const refoldMetric = incrementEsFoldRefoldTotal as unknown as ReturnType<
+  typeof vi.fn
+>;
 
 describe("FoldProjectionExecutor out-of-order re-fold", () => {
   const tenantId = createTestTenantId();
@@ -75,6 +90,7 @@ describe("FoldProjectionExecutor out-of-order re-fold", () => {
     vi.useFakeTimers();
     vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
     executor = new FoldProjectionExecutor();
+    refoldMetric.mockClear();
   });
 
   afterEach(() => {
@@ -106,6 +122,7 @@ describe("FoldProjectionExecutor out-of-order re-fold", () => {
         // Replayed from init(), so the stored count of 99 is discarded entirely.
         expect(result.count).toBe(history.length);
         expect(store.store).toHaveBeenCalledOnce();
+        expect(refoldMetric).toHaveBeenCalledWith("counter", "performed");
       });
     });
 
@@ -128,6 +145,7 @@ describe("FoldProjectionExecutor out-of-order re-fold", () => {
         expect(result.count).toBe(101);
         // The batch was folded oldest-first, so the checkpoint never regresses.
         expect(result.LastEventOccurredAt).toBe(CHECKPOINT_MS);
+        expect(refoldMetric).toHaveBeenCalledWith("counter", "declined");
       });
 
       /** @scenario "A single out-of-order event honours the same opt-out" */
@@ -145,6 +163,24 @@ describe("FoldProjectionExecutor out-of-order re-fold", () => {
       });
     });
 
+    describe("when no event loader is wired", () => {
+      /** @scenario "An out-of-order batch with no event loader applies on top instead" */
+      it("applies the batch on top and records the re-fold as unavailable", async () => {
+        const { fold } = makeFold({
+          storedState: { count: 99, LastEventOccurredAt: CHECKPOINT_MS },
+          withEventLoader: false,
+        });
+
+        const result = await executor.executeBatch(
+          fold,
+          [eventAt(1_000), eventAt(2_000)],
+          context,
+        );
+
+        expect(result.count).toBe(101);
+        expect(refoldMetric).toHaveBeenCalledWith("counter", "unavailable");
+      });
+    });
   });
 
   describe("given a batch that starts at or after the persisted checkpoint", () => {

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refold.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refold.unit.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "../../domain/types";
+import {
+  createMockFoldProjectionDefinition,
+  createMockFoldProjectionStore,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../services/__tests__/testHelpers";
+import type { FoldProjectionDefinition } from "../foldProjection.types";
+import { FoldProjectionExecutor } from "../foldProjectionExecutor";
+import type { ProjectionStoreContext } from "../projectionStoreContext";
+
+/**
+ * State whose `apply` mirrors AbstractFoldProjection: it counts events and
+ * carries the monotonic occurredAt high-water mark the executor reads to detect
+ * out-of-order arrival.
+ */
+interface CounterState {
+  count: number;
+  LastEventOccurredAt: number;
+}
+
+const CHECKPOINT_MS = 5_000;
+
+function makeFold({
+  storedState,
+  loadedEvents,
+  refoldOnOutOfOrder,
+}: {
+  storedState: CounterState | null;
+  loadedEvents?: Event[];
+  refoldOnOutOfOrder?: boolean;
+}) {
+  const store = createMockFoldProjectionStore<CounterState>();
+  (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(storedState);
+
+  const fold = createMockFoldProjectionDefinition("counter", {
+    store,
+    init: () => ({ count: 0, LastEventOccurredAt: 0 }),
+    apply: (state: CounterState, event: Event) => ({
+      count: state.count + 1,
+      LastEventOccurredAt: Math.max(
+        state.LastEventOccurredAt,
+        event.occurredAt ?? 0,
+      ),
+    }),
+  }) as FoldProjectionDefinition<CounterState, Event>;
+
+  const eventLoader = vi.fn().mockResolvedValue(loadedEvents ?? []);
+  fold.eventLoader = eventLoader;
+  if (refoldOnOutOfOrder !== undefined) fold.options = { refoldOnOutOfOrder };
+
+  return { fold, store, eventLoader };
+}
+
+describe("FoldProjectionExecutor out-of-order re-fold", () => {
+  const tenantId = createTestTenantId();
+  const context: ProjectionStoreContext = {
+    aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+    tenantId,
+  };
+  let executor: FoldProjectionExecutor;
+
+  const eventAt = (occurredAt: number) =>
+    createTestEvent(
+      TEST_CONSTANTS.AGGREGATE_ID,
+      TEST_CONSTANTS.AGGREGATE_TYPE,
+      tenantId,
+      undefined,
+      occurredAt,
+    );
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
+    executor = new FoldProjectionExecutor();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("given a batch that starts before the persisted checkpoint", () => {
+    describe("when the projection declares no re-fold policy", () => {
+      /** @scenario "An out-of-order batch re-folds from the event log by default" */
+      it("loads the aggregate's full history and replays it from init state", async () => {
+        const history = [eventAt(1_000), eventAt(2_000), eventAt(CHECKPOINT_MS)];
+        const { fold, store, eventLoader } = makeFold({
+          storedState: { count: 99, LastEventOccurredAt: CHECKPOINT_MS },
+          loadedEvents: history,
+        });
+
+        const result = await executor.executeBatch(
+          fold,
+          [eventAt(1_000), eventAt(2_000)],
+          context,
+        );
+
+        expect(eventLoader).toHaveBeenCalledWith({
+          tenantId,
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          occurredAtMs: 1_000,
+        });
+        // Replayed from init(), so the stored count of 99 is discarded entirely.
+        expect(result.count).toBe(history.length);
+        expect(store.store).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe("when the projection has opted out of re-folding", () => {
+      /** @scenario "An order-insensitive fold never re-folds" */
+      it("never reads the event log and applies the batch on top in occurredAt order", async () => {
+        const { fold, eventLoader } = makeFold({
+          storedState: { count: 99, LastEventOccurredAt: CHECKPOINT_MS },
+          loadedEvents: [eventAt(1_000)],
+          refoldOnOutOfOrder: false,
+        });
+
+        const result = await executor.executeBatch(
+          fold,
+          [eventAt(2_000), eventAt(1_000)],
+          context,
+        );
+
+        expect(eventLoader).not.toHaveBeenCalled();
+        expect(result.count).toBe(101);
+        // The batch was folded oldest-first, so the checkpoint never regresses.
+        expect(result.LastEventOccurredAt).toBe(CHECKPOINT_MS);
+      });
+
+      /** @scenario "A single out-of-order event honours the same opt-out" */
+      it("applies a lone out-of-order event on top without reading the event log", async () => {
+        const { fold, eventLoader } = makeFold({
+          storedState: { count: 99, LastEventOccurredAt: CHECKPOINT_MS },
+          loadedEvents: [eventAt(1_000)],
+          refoldOnOutOfOrder: false,
+        });
+
+        const result = await executor.execute(fold, eventAt(1_000), context);
+
+        expect(eventLoader).not.toHaveBeenCalled();
+        expect(result.count).toBe(100);
+      });
+    });
+
+  });
+
+  describe("given a batch that starts at or after the persisted checkpoint", () => {
+    it("applies the batch without reading the event log", async () => {
+      const { fold, eventLoader } = makeFold({
+        storedState: { count: 1, LastEventOccurredAt: 1_000 },
+      });
+
+      const result = await executor.executeBatch(
+        fold,
+        [eventAt(2_000), eventAt(3_000)],
+        context,
+      );
+
+      expect(eventLoader).not.toHaveBeenCalled();
+      expect(result.count).toBe(3);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.reactorCollapse.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.reactorCollapse.unit.test.ts
@@ -5,6 +5,7 @@ vi.mock("~/server/metrics", async (importOriginal) => {
   return {
     ...actual,
     incrementEsReactorTotal: vi.fn(),
+    incrementEsReactorCollapsedTotal: vi.fn(),
     incrementEsFoldProjectionTotal: vi.fn(),
     observeEsFoldProjectionDuration: vi.fn(),
     incrementEsFoldRefoldTotal: vi.fn(),
@@ -197,6 +198,33 @@ describe("ProjectionRouter reactor dispatch over a coalesced batch", () => {
       const payloads = await dispatchBatch(reactor, batch());
 
       expect(payloads).toHaveLength(BATCH_SIZE);
+    });
+  });
+  describe("when one batch carries two distinct deduplication ids", () => {
+    it("dispatches each survivor in the occurredAt order of the event it carries", async () => {
+      // job A is seen at event-0 and again at event-4; job B only at event-1.
+      // A Map alone would order survivors by FIRST occurrence — [A(event-4),
+      // B(event-1)] — dispatching a later event before an earlier one.
+      const jobFor: Record<string, string> = {
+        "event-0": "A",
+        "event-1": "B",
+        "event-2": "A",
+        "event-3": "B",
+        "event-4": "A",
+      };
+      const reactor: ReactorDefinition<Event> = {
+        name: "two-lane",
+        options: {
+          // biome-ignore lint/style/noNonNullAssertion: every id is in the map.
+          makeJobId: ({ event }) => jobFor[event.id]!,
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchBatch(reactor, batch());
+
+      // Survivors: B's last is event-3, A's last is event-4 → occurredAt order.
+      expect(payloads.map((p) => p.event.id)).toEqual(["event-3", "event-4"]);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.reactorCollapse.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.reactorCollapse.unit.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/metrics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/server/metrics")>();
+  return {
+    ...actual,
+    incrementEsReactorTotal: vi.fn(),
+    incrementEsFoldProjectionTotal: vi.fn(),
+    observeEsFoldProjectionDuration: vi.fn(),
+    incrementEsFoldRefoldTotal: vi.fn(),
+  };
+});
+
+import type { Event } from "../../domain/types";
+import type { ReactorDefinition } from "../../reactors/reactor.types";
+import {
+  createMockFoldProjectionDefinition,
+  createMockFoldProjectionStore,
+  createMockQueueManager,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../services/__tests__/testHelpers";
+import { ProjectionRouter } from "../projectionRouter";
+
+/**
+ * A reactor's `makeJobId` is its collapse key: the queue dedups on it, so N
+ * sends carrying one job id leave exactly one job behind. These pin the router
+ * to reaching that same queue state without paying N serialize+gzip+blob
+ * round-trips per drained batch (2026-07-09 incident; see
+ * specs/event-sourcing/hot-trace-fold-amplification.feature).
+ */
+describe("ProjectionRouter reactor dispatch over a coalesced batch", () => {
+  const tenantId = createTestTenantId();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const BATCH_SIZE = 5;
+
+  /** Five events for one aggregate, already in occurredAt order. */
+  const batch = (): Event[] =>
+    Array.from({ length: BATCH_SIZE }, (_, i) =>
+      createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        tenantId,
+        undefined,
+        1_000 + i,
+        undefined,
+        undefined,
+        `event-${i}`,
+      ),
+    );
+
+  /**
+   * Registers the reactor, drives one coalesced batch through the fold queue's
+   * batch callback, and returns the payloads the reactor's queue received.
+   */
+  async function dispatchBatch(
+    reactor: ReactorDefinition<Event>,
+    events: Event[],
+  ): Promise<Array<{ event: Event; foldState: unknown }>> {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const queueManager = createMockQueueManager({
+      hasReactorQueues: true,
+      getReactorQueue: vi.fn().mockReturnValue({ send }),
+    });
+
+    const router = new ProjectionRouter<Event>(
+      TEST_CONSTANTS.AGGREGATE_TYPE,
+      TEST_CONSTANTS.PIPELINE_NAME,
+      queueManager,
+    );
+
+    const store = createMockFoldProjectionStore<{ count: number }>();
+    (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const fold = createMockFoldProjectionDefinition("counter", {
+      store,
+      init: () => ({ count: 0 }),
+      apply: (state: { count: number }) => ({ count: state.count + 1 }),
+    });
+
+    router.registerFoldProjection(fold);
+    router.registerReactor("counter", reactor);
+    router.initializeFoldQueues();
+
+    const initialize = queueManager.initializeProjectionQueues as ReturnType<
+      typeof vi.fn
+    >;
+    const onEventBatch = initialize.mock.calls[0]?.[2] as (
+      projectionName: string,
+      events: Event[],
+      context: unknown,
+    ) => Promise<void>;
+
+    await onEventBatch("counter", events, { tenantId });
+
+    return send.mock.calls.map(([payload]) => payload);
+  }
+
+  describe("when the reactor's deduplication id is the same for every event", () => {
+    /** @scenario "Reactors keyed on the aggregate are dispatched once per coalesced batch" */
+    it("dispatches once, with the last event in occurredAt order", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "traceUpdateBroadcast",
+        options: {
+          makeJobId: ({ event }) => `trace-update:${event.aggregateId}`,
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchBatch(reactor, batch());
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0]?.event.id).toBe(`event-${BATCH_SIZE - 1}`);
+    });
+  });
+
+  describe("when the reactor's deduplication id includes the event id", () => {
+    /** @scenario "Reactors keyed per event are still dispatched for every event" */
+    it("dispatches for every event", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "customEvaluationSync",
+        options: {
+          makeJobId: ({ event }) => `custom-eval:${event.aggregateId}:${event.id}`,
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchBatch(reactor, batch());
+
+      expect(payloads.map((p) => p.event.id)).toEqual([
+        "event-0",
+        "event-1",
+        "event-2",
+        "event-3",
+        "event-4",
+      ]);
+    });
+  });
+
+  describe("when the reactor declares no deduplication id", () => {
+    /** @scenario "Reactors without a deduplication id are dispatched for every event" */
+    it("dispatches for every event", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "undeduped",
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchBatch(reactor, batch());
+
+      expect(payloads).toHaveLength(BATCH_SIZE);
+    });
+  });
+
+  describe("when an aggregate-keyed reactor finds only some events relevant", () => {
+    /** @scenario "The relevance check still filters events before collapsing" */
+    it("dispatches once, with the last relevant event", async () => {
+      const relevant = new Set(["event-1", "event-3"]);
+      const reactor: ReactorDefinition<Event> = {
+        name: "evaluationTrigger",
+        shouldReact: (event) => relevant.has(event.id),
+        options: {
+          makeJobId: ({ event }) => `eval-trigger:${event.aggregateId}`,
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchBatch(reactor, batch());
+
+      expect(payloads).toHaveLength(1);
+      // event-4 is the batch's last event, but the reactor never cared about it.
+      expect(payloads[0]?.event.id).toBe("event-3");
+    });
+  });
+
+  describe("when the reactor's makeJobId throws", () => {
+    it("fails open and dispatches every event", async () => {
+      const reactor: ReactorDefinition<Event> = {
+        name: "broken",
+        options: {
+          makeJobId: () => {
+            throw new Error("boom");
+          },
+        },
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const payloads = await dispatchBatch(reactor, batch());
+
+      expect(payloads).toHaveLength(BATCH_SIZE);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/foldProjection.types.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjection.types.ts
@@ -132,6 +132,27 @@ export interface FoldProjectionOptions {
    * cache expiry/eviction/restart, not on every event.
    */
   refoldOnStoreMiss?: boolean;
+  /**
+   * Re-fold the aggregate's whole history from the event log when an event
+   * arrives having occurred BEFORE the persisted checkpoint. Defaults to true.
+   *
+   * Set false when `apply` is order-insensitive — its accumulators commute
+   * (sums, counters, min/max) and any precedence rule keys on data carried by
+   * the event rather than on arrival order. Such a fold reaches the same state
+   * whichever order it sees events in, so replaying the history derives nothing.
+   *
+   * The replay is not merely wasted there, it is actively harmful: it reads
+   * EVERY event for the aggregate, and since `apply` raises the checkpoint to
+   * the highest occurredAt it has seen, one replay pins the checkpoint at the
+   * aggregate's maximum event time — making every later batch look out of order
+   * too. A hot trace re-folded 730 times in two hours, re-reading 5.66M event
+   * rows, and never caught up (2026-07-09; see
+   * specs/event-sourcing/hot-trace-fold-amplification.feature).
+   *
+   * Turning it off never drops events: the executor applies them in occurredAt
+   * order on top of the state it loaded.
+   */
+  refoldOnOutOfOrder?: boolean;
 }
 
 /**

--- a/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -1,9 +1,38 @@
+import { incrementEsFoldRefoldTotal } from "~/server/metrics";
 import { createLogger } from "~/utils/logger/server";
 import type { Event } from "../domain/types";
 import type { FoldProjectionDefinition } from "./foldProjection.types";
 import type { ProjectionStoreContext } from "./projectionStoreContext";
 
 const logger = createLogger("langwatch:event-sourcing:fold-executor");
+
+/**
+ * Whether an out-of-order event should replay the aggregate's history rather
+ * than being applied on top of the state already loaded.
+ *
+ * See `FoldProjectionOptions.refoldOnOutOfOrder` for why an order-insensitive
+ * fold must opt out. Either way the caller still applies the events in
+ * occurredAt order, so declining costs nothing but the replay.
+ */
+function canRefold<State, E extends Event>(
+  projection: FoldProjectionDefinition<State, E>,
+  context: ProjectionStoreContext,
+): boolean {
+  if (projection.options?.refoldOnOutOfOrder === false) {
+    incrementEsFoldRefoldTotal(projection.name, "declined");
+    return false;
+  }
+  if (!projection.eventLoader) {
+    incrementEsFoldRefoldTotal(projection.name, "unavailable");
+    logger.warn(
+      { projection: projection.name, aggregateId: context.aggregateId },
+      "Out-of-order event detected but no eventLoader available — cannot re-fold",
+    );
+    return false;
+  }
+  incrementEsFoldRefoldTotal(projection.name, "performed");
+  return true;
+}
 
 /**
  * Returns a context carrying the event's occurredAt as a store read hint, or
@@ -26,13 +55,14 @@ function withOccurredAtHint(
  * 2. If the store missed and `options.refoldOnStoreMiss` is set → re-fold
  *    from the event log up to the delivered event (see below)
  * 3. `state = projection.apply(state, event)`
- * 4. If out-of-order detected and `eventLoader` available → re-fold from scratch
+ * 4. If out-of-order detected and the projection admits a re-fold → re-fold from scratch
  * 5. `projection.store.store(state, context)`
  *
  * Out-of-order detection: compares event.occurredAt against the state's
  * LastEventOccurredAt (tracked by AbstractFoldProjection). If the event
  * occurred earlier than what we've already seen, all events are re-loaded
- * in occurredAt order and replayed from init().
+ * in occurredAt order and replayed from init() — unless the projection set
+ * `options.refoldOnOutOfOrder` to false (see {@link canRefold}).
  *
  * Store-miss re-fold (`options.refoldOnStoreMiss`): a fold whose persisted
  * row cannot be read back into fold state (lossy analytics rows) returns
@@ -75,14 +105,15 @@ export class FoldProjectionExecutor {
       }
     }
 
-    let state = loaded ?? projection.init();
+    const loadedState = loaded ?? projection.init();
 
     // Capture the highest occurredAt before applying the new event.
     const prevLastOccurred =
-      (state as Record<string, unknown>)[projection.LastEventOccurredAtKey] ??
-      0;
+      (loadedState as Record<string, unknown>)[
+        projection.LastEventOccurredAtKey
+      ] ?? 0;
 
-    state = projection.apply(state, event);
+    let state = projection.apply(loadedState, event);
 
     // Detect out-of-order: event's occurredAt is STRICTLY LESS than what we've already seen.
     // Same occurredAt (==) does NOT trigger re-fold — arrival order is the correct
@@ -94,21 +125,14 @@ export class FoldProjectionExecutor {
       typeof eventOccurredAt === "number" &&
       eventOccurredAt > 0 &&
       typeof prevLastOccurred === "number" &&
-      eventOccurredAt < prevLastOccurred
+      eventOccurredAt < prevLastOccurred &&
+      canRefold(projection, context)
     ) {
-      if (!projection.eventLoader) {
-        logger.warn(
-          { projection: projection.name, aggregateId: context.aggregateId },
-          "Out-of-order event detected but no eventLoader available — cannot re-fold",
-        );
-        await projection.store.store(state, context);
-        return state;
-      }
-      const allEvents = await projection.eventLoader({
+      // biome-ignore lint/style/noNonNullAssertion: canRefold returns false without an eventLoader.
+      const allEvents = await projection.eventLoader!({
         tenantId: context.tenantId,
         aggregateId: context.aggregateId,
-        occurredAtMs:
-          typeof eventOccurredAt === "number" ? eventOccurredAt : undefined,
+        occurredAtMs: eventOccurredAt,
       });
 
       logger.info(
@@ -144,7 +168,8 @@ export class FoldProjectionExecutor {
    *
    * Out-of-order handling matches `execute()`: if the earliest event in the
    * batch occurred before the persisted checkpoint, the aggregate is re-folded
-   * from scratch via `eventLoader` (when available).
+   * from scratch via `eventLoader` — when one exists and the projection has not
+   * opted out via `options.refoldOnOutOfOrder` (see {@link canRefold}).
    */
   async executeBatch<State, E extends Event>(
     projection: FoldProjectionDefinition<State, E>,
@@ -189,32 +214,33 @@ export class FoldProjectionExecutor {
       }
     }
 
-    let state = loaded ?? projection.init();
+    const loadedState = loaded ?? projection.init();
 
     const prevLastOccurred =
-      (state as Record<string, unknown>)[projection.LastEventOccurredAtKey] ??
-      0;
+      (loadedState as Record<string, unknown>)[
+        projection.LastEventOccurredAtKey
+      ] ?? 0;
     const earliestOccurredAt = (ordered[0] as Record<string, unknown>)
       .occurredAt;
 
     // Out-of-order vs the persisted checkpoint: the batch starts earlier than
     // what we've already folded. Re-fold from scratch when we can load the full
-    // history; otherwise fall through and apply the batch on top (matches the
-    // single-event executor's degraded behavior when no eventLoader exists).
+    // history AND the projection still gains something by replaying it;
+    // otherwise apply the batch on top (matches the single-event executor's
+    // degraded behavior when no eventLoader exists).
     const outOfOrder =
       typeof earliestOccurredAt === "number" &&
       earliestOccurredAt > 0 &&
       typeof prevLastOccurred === "number" &&
       earliestOccurredAt < prevLastOccurred;
 
-    if (outOfOrder && projection.eventLoader) {
-      const allEvents = await projection.eventLoader({
+    let state = loadedState;
+    if (outOfOrder && canRefold(projection, context)) {
+      // biome-ignore lint/style/noNonNullAssertion: canRefold returns false without an eventLoader.
+      const allEvents = await projection.eventLoader!({
         tenantId: context.tenantId,
         aggregateId: context.aggregateId,
-        occurredAtMs:
-          typeof earliestOccurredAt === "number"
-            ? earliestOccurredAt
-            : undefined,
+        occurredAtMs: earliestOccurredAt,
       });
       logger.info(
         {
@@ -233,12 +259,6 @@ export class FoldProjectionExecutor {
         state = projection.apply(state, e as E);
       }
     } else {
-      if (outOfOrder) {
-        logger.warn(
-          { projection: projection.name, aggregateId: context.aggregateId },
-          "Out-of-order batch detected but no eventLoader available — cannot re-fold",
-        );
-      }
       for (const event of ordered) {
         state = projection.apply(state, event);
       }

--- a/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -228,14 +228,14 @@ export class FoldProjectionExecutor {
     // history AND the projection still gains something by replaying it;
     // otherwise apply the batch on top (matches the single-event executor's
     // degraded behavior when no eventLoader exists).
-    const outOfOrder =
+    const isOutOfOrder =
       typeof earliestOccurredAt === "number" &&
       earliestOccurredAt > 0 &&
       typeof prevLastOccurred === "number" &&
       earliestOccurredAt < prevLastOccurred;
 
     let state = loadedState;
-    if (outOfOrder && canRefold(projection, context)) {
+    if (isOutOfOrder && canRefold(projection, context)) {
       // biome-ignore lint/style/noNonNullAssertion: canRefold returns false without an eventLoader.
       const allEvents = await projection.eventLoader!({
         tenantId: context.tenantId,

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -430,7 +430,7 @@ export class ProjectionRouter<
             // Dispatch to map reactors after map execute succeeds
             const mapReactors = this.reactorsForMap.get(name);
             if (record !== null && mapReactors && mapReactors.length > 0) {
-              await this.dispatchToReactors(name, mapReactors, event, record);
+              await this.dispatchToReactors(name, mapReactors, [event], record);
             }
           },
         },
@@ -703,7 +703,7 @@ export class ProjectionRouter<
             // Dispatch to map reactors after map execute succeeds
             const mapReactors = this.reactorsForMap.get(name);
             if (record !== null && mapReactors && mapReactors.length > 0) {
-              await this.dispatchToReactors(name, mapReactors, event, record);
+              await this.dispatchToReactors(name, mapReactors, [event], record);
             }
           } catch (error) {
             handleError(error, categorizeError(error), this.logger, {
@@ -808,7 +808,7 @@ export class ProjectionRouter<
           await this.dispatchToReactors(
             projectionName,
             reactors,
-            event,
+            [event],
             foldState,
           );
         }
@@ -914,24 +914,22 @@ export class ProjectionRouter<
           },
         });
 
-        // Dispatch reactors for EVERY folded event, with the final fold state.
-        // Fold-state reactors (broadcast, metadata, alerts) carry makeJobId
-        // dedup and collapse to one effective run, so firing per event is cheap.
+        // Dispatch reactors for the whole batch, with the final fold state.
         // Per-span reactors must see every event: customEvaluationSync reads
-        // event.data.span to extract embedded SDK evals, and evaluationTrigger
-        // inspects each span's attributes — firing only once would silently
-        // drop N-1 spans' work, and only under backlog (the recovery path).
-        // The O(n²)->O(n) win lives in the single fold load/store, not here.
+        // event.data.span to extract embedded SDK evals, and its makeJobId
+        // carries the event id, so it is dispatched once per event. Reactors
+        // keyed on the aggregate (broadcast, metadata, alerts) would be squashed
+        // to one job by the queue's dedup anyway, so dispatchToReactors collapses
+        // them here instead of paying N serialize+gzip+blob round-trips to reach
+        // the same state. See ProjectionRouter.collapseByJobId.
         const reactors = this.reactorsForFold.get(projectionName);
         if (reactors && reactors.length > 0) {
-          for (const event of toApply) {
-            await this.dispatchToReactors(
-              projectionName,
-              reactors,
-              event,
-              foldState,
-            );
-          }
+          await this.dispatchToReactors(
+            projectionName,
+            reactors,
+            toApply,
+            foldState,
+          );
         }
       },
     );
@@ -989,28 +987,127 @@ export class ProjectionRouter<
   }
 
   /**
-   * Dispatches a single event to reactors registered on a fold projection.
-   * In queued mode, sends to reactor queues. In inline mode, calls directly.
+   * The events a reactor must actually be sent for, out of a coalesced batch.
+   *
+   * A reactor's `makeJobId` IS its collapse key: the queue dedups on it, so N
+   * sends carrying the same job id leave exactly one job behind — the last one,
+   * since staging replaces a squashed duplicate. Reactors keyed on the aggregate
+   * (`eval-trigger:${tenantId}:${aggregateId}`, `trace-update:…`) therefore
+   * produce one job no matter how many events a backed-up group drains.
+   *
+   * Sending all N anyway is not free: each send serializes `{event, foldState}`,
+   * gzips it, and — once past the envelope's inline ceiling — writes a
+   * content-addressed blob into Redis that the ensuing dedup squash immediately
+   * reclaims. On a 10k-span trace that was ~99 discarded round-trips per drained
+   * batch, per reactor. Collapsing here reaches the same queue state by the same
+   * rule the queue itself would have applied, without the churn.
+   *
+   * Reactors keyed per event (`…:${event.id}`) collapse to nothing and are
+   * dispatched for every event, as are reactors with no job id at all.
+   */
+  private collapseByJobId(
+    reactor: ReactorDefinition<EventType>,
+    events: EventType[],
+    foldState: unknown,
+  ): EventType[] {
+    const makeJobId = reactor.options?.makeJobId;
+    if (!makeJobId || events.length < 2) return events;
+
+    try {
+      // A Map keeps the first insertion's position and the last insertion's
+      // value, so the result is in occurredAt order and each job id carries the
+      // last event that would have won the squash.
+      const lastPerJobId = new Map<string, EventType>();
+      for (const event of events) {
+        lastPerJobId.set(makeJobId({ event, foldState }), event);
+      }
+      return [...lastPerJobId.values()];
+    } catch (error) {
+      // Fail open, like `shouldReact`: a throwing job-id function must never
+      // drop a side effect. Worst case is the un-collapsed fan-out we had before.
+      this.logger.error(
+        {
+          reactorName: reactor.name,
+          eventCount: events.length,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Reactor makeJobId threw while collapsing a batch — dispatching every event",
+      );
+      return events;
+    }
+  }
+
+  /**
+   * Dispatches a coalesced batch of same-aggregate events to reactors registered
+   * on a fold projection. In queued mode, sends to reactor queues. In inline
+   * mode, calls directly. A single event is just a batch of one.
+   *
+   * Events are filtered by `shouldReact` BEFORE they are collapsed, so a reactor
+   * keyed on the aggregate receives the last event it actually cared about
+   * rather than the last event in the batch.
    */
   private async dispatchToReactors(
     foldName: string,
     reactors: ReactorDefinition<EventType>[],
-    event: EventType,
+    events: EventType[],
     foldState: unknown,
   ): Promise<void> {
-    const hasReactorQueues = this.queueManager.hasReactorQueues();
     const errors: Error[] = [];
 
     for (const reactor of reactors) {
       if (reactor.options?.disabled) continue;
       if (this.isReactorExcluded(reactor)) continue;
-      if (!this.reactorShouldReact(reactor, event, foldState)) {
-        incrementEsReactorTotal(this.pipelineName, reactor.name, "skipped");
-        continue;
-      }
 
-      if (hasReactorQueues) {
-        const queueProcessor = this.queueManager.getReactorQueue(reactor.name);
+      const relevant: EventType[] = [];
+      for (const event of events) {
+        if (this.reactorShouldReact(reactor, event, foldState)) {
+          relevant.push(event);
+        } else {
+          incrementEsReactorTotal(this.pipelineName, reactor.name, "skipped");
+        }
+      }
+      if (relevant.length === 0) continue;
+
+      for (const event of this.collapseByJobId(reactor, relevant, foldState)) {
+        await this.dispatchOneToReactor({
+          foldName,
+          reactor,
+          event,
+          foldState,
+          errors,
+        });
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new AggregateError(
+        errors,
+        `${errors.length} reactor(s) failed during dispatch`,
+      );
+    }
+  }
+
+  /**
+   * Sends one event to one reactor, collecting rather than throwing failures so
+   * a single bad reactor can't skip the ones after it.
+   */
+  private async dispatchOneToReactor({
+    foldName,
+    reactor,
+    event,
+    foldState,
+    errors,
+  }: {
+    foldName: string;
+    reactor: ReactorDefinition<EventType>;
+    event: EventType;
+    foldState: unknown;
+    errors: Error[];
+  }): Promise<void> {
+    const hasReactorQueues = this.queueManager.hasReactorQueues();
+
+    if (hasReactorQueues) {
+      const queueProcessor = this.queueManager.getReactorQueue(reactor.name);
         if (queueProcessor) {
           try {
             await queueProcessor.send({ event, foldState });
@@ -1118,14 +1215,6 @@ export class ProjectionRouter<
           errors.push(toError(error));
         }
       }
-    }
-
-    if (errors.length > 0) {
-      throw new AggregateError(
-        errors,
-        `${errors.length} reactor(s) failed during dispatch`,
-      );
-    }
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -1108,73 +1108,31 @@ export class ProjectionRouter<
 
     if (hasReactorQueues) {
       const queueProcessor = this.queueManager.getReactorQueue(reactor.name);
-        if (queueProcessor) {
-          try {
-            await queueProcessor.send({ event, foldState });
-          } catch (error) {
-            this.logger.error(
-              {
-                reactorName: reactor.name,
-                foldName,
-                eventId: event.id,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Failed to dispatch event to reactor queue",
-            );
-            errors.push(toError(error));
-          }
-        } else {
-          // Queue expected but not found — fall back to inline execution
-          this.logger.warn(
+      if (queueProcessor) {
+        try {
+          await queueProcessor.send({ event, foldState });
+        } catch (error) {
+          this.logger.error(
             {
               reactorName: reactor.name,
               foldName,
               eventId: event.id,
+              error: error instanceof Error ? error.message : String(error),
             },
-            "Reactor queue not found, falling back to inline execution",
+            "Failed to dispatch event to reactor queue",
           );
-          try {
-            await withMetrics({
-              fn: () =>
-                reactor.handle(
-                  event,
-                  this.buildReactorContext({ event, foldState }),
-                ),
-              onComplete: (ms) => {
-                incrementEsReactorTotal(
-                  this.pipelineName,
-                  reactor.name,
-                  "completed",
-                );
-                observeEsReactorDuration(this.pipelineName, reactor.name, ms);
-              },
-              onFail: (ms) => {
-                incrementEsReactorTotal(
-                  this.pipelineName,
-                  reactor.name,
-                  "failed",
-                );
-                observeEsReactorDuration(this.pipelineName, reactor.name, ms);
-              },
-            });
-          } catch (error) {
-            this.logger.error(
-              {
-                reactorName: reactor.name,
-                foldName,
-                eventId: event.id,
-                eventType: event.type,
-                aggregateId: String(event.aggregateId),
-                tenantId: event.tenantId,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Reactor failed during inline fallback execution",
-            );
-            errors.push(toError(error));
-          }
+          errors.push(toError(error));
         }
       } else {
-        // Inline mode: call reactor directly
+        // Queue expected but not found — fall back to inline execution
+        this.logger.warn(
+          {
+            reactorName: reactor.name,
+            foldName,
+            eventId: event.id,
+          },
+          "Reactor queue not found, falling back to inline execution",
+        );
         try {
           await withMetrics({
             fn: () =>
@@ -1210,11 +1168,53 @@ export class ProjectionRouter<
               tenantId: event.tenantId,
               error: error instanceof Error ? error.message : String(error),
             },
-            "Reactor failed during inline execution — fold state persisted in CH but reactor side-effect (e.g. ES sync) was lost",
+            "Reactor failed during inline fallback execution",
           );
           errors.push(toError(error));
         }
       }
+    } else {
+      // Inline mode: call reactor directly
+      try {
+        await withMetrics({
+          fn: () =>
+            reactor.handle(
+              event,
+              this.buildReactorContext({ event, foldState }),
+            ),
+          onComplete: (ms) => {
+            incrementEsReactorTotal(
+              this.pipelineName,
+              reactor.name,
+              "completed",
+            );
+            observeEsReactorDuration(this.pipelineName, reactor.name, ms);
+          },
+          onFail: (ms) => {
+            incrementEsReactorTotal(
+              this.pipelineName,
+              reactor.name,
+              "failed",
+            );
+            observeEsReactorDuration(this.pipelineName, reactor.name, ms);
+          },
+        });
+      } catch (error) {
+        this.logger.error(
+          {
+            reactorName: reactor.name,
+            foldName,
+            eventId: event.id,
+            eventType: event.type,
+            aggregateId: String(event.aggregateId),
+            tenantId: event.tenantId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Reactor failed during inline execution — fold state persisted in CH but reactor side-effect (e.g. ES sync) was lost",
+        );
+        errors.push(toError(error));
+      }
+    }
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -5,6 +5,7 @@ import type { FeatureFlagServiceInterface } from "~/server/featureFlag/types";
 import {
   incrementEsFoldProjectionTotal,
   incrementEsMapProjectionTotal,
+  incrementEsReactorCollapsedTotal,
   incrementEsReactorTotal,
   observeEsFoldProjectionDuration,
   observeEsMapProjectionDuration,
@@ -430,7 +431,12 @@ export class ProjectionRouter<
             // Dispatch to map reactors after map execute succeeds
             const mapReactors = this.reactorsForMap.get(name);
             if (record !== null && mapReactors && mapReactors.length > 0) {
-              await this.dispatchToReactors(name, mapReactors, [event], record);
+              await this.dispatchToReactors({
+                foldName: name,
+                reactors: mapReactors,
+                events: [event],
+                foldState: record,
+              });
             }
           },
         },
@@ -703,7 +709,12 @@ export class ProjectionRouter<
             // Dispatch to map reactors after map execute succeeds
             const mapReactors = this.reactorsForMap.get(name);
             if (record !== null && mapReactors && mapReactors.length > 0) {
-              await this.dispatchToReactors(name, mapReactors, [event], record);
+              await this.dispatchToReactors({
+                foldName: name,
+                reactors: mapReactors,
+                events: [event],
+                foldState: record,
+              });
             }
           } catch (error) {
             handleError(error, categorizeError(error), this.logger, {
@@ -805,12 +816,12 @@ export class ProjectionRouter<
         // After fold succeeds, dispatch to reactors for this fold
         const reactors = this.reactorsForFold.get(projectionName);
         if (reactors && reactors.length > 0) {
-          await this.dispatchToReactors(
-            projectionName,
+          await this.dispatchToReactors({
+            foldName: projectionName,
             reactors,
-            [event],
+            events: [event],
             foldState,
-          );
+          });
         }
       },
     );
@@ -924,12 +935,12 @@ export class ProjectionRouter<
         // the same state. See ProjectionRouter.collapseByJobId.
         const reactors = this.reactorsForFold.get(projectionName);
         if (reactors && reactors.length > 0) {
-          await this.dispatchToReactors(
-            projectionName,
+          await this.dispatchToReactors({
+            foldName: projectionName,
             reactors,
-            toApply,
+            events: toApply,
             foldState,
-          );
+          });
         }
       },
     );
@@ -1005,23 +1016,42 @@ export class ProjectionRouter<
    * Reactors keyed per event (`…:${event.id}`) collapse to nothing and are
    * dispatched for every event, as are reactors with no job id at all.
    */
-  private collapseByJobId(
-    reactor: ReactorDefinition<EventType>,
-    events: EventType[],
-    foldState: unknown,
-  ): EventType[] {
+  private collapseByJobId({
+    reactor,
+    events,
+    foldState,
+  }: {
+    reactor: ReactorDefinition<EventType>;
+    events: EventType[];
+    foldState: unknown;
+  }): EventType[] {
     const makeJobId = reactor.options?.makeJobId;
     if (!makeJobId || events.length < 2) return events;
 
     try {
-      // A Map keeps the first insertion's position and the last insertion's
-      // value, so the result is in occurredAt order and each job id carries the
-      // last event that would have won the squash.
-      const lastPerJobId = new Map<string, EventType>();
-      for (const event of events) {
-        lastPerJobId.set(makeJobId({ event, foldState }), event);
-      }
-      return [...lastPerJobId.values()];
+      // Keep the LAST event per job id — the one the queue's dedup squash would
+      // have left behind (STAGE_LUA overwrites the stored value when
+      // `shouldReplace`, which every reactor here defaults to).
+      //
+      // A Map alone would order the survivors by each job id's FIRST
+      // occurrence while holding its last value, so a batch carrying two job
+      // ids could dispatch a later event before an earlier one. Re-sort by the
+      // surviving event's position so dispatch really is in occurredAt order —
+      // `events` arrives sorted, so the index IS that order.
+      const lastIndexPerJobId = new Map<string, number>();
+      events.forEach((event, index) => {
+        lastIndexPerJobId.set(makeJobId({ event, foldState }), index);
+      });
+      const survivors = [...lastIndexPerJobId.values()].sort((a, b) => a - b);
+      if (survivors.length === events.length) return events;
+
+      incrementEsReactorCollapsedTotal(
+        this.pipelineName,
+        reactor.name,
+        events.length - survivors.length,
+      );
+      // biome-ignore lint/style/noNonNullAssertion: every index came from `events`.
+      return survivors.map((index) => events[index]!);
     } catch (error) {
       // Fail open, like `shouldReact`: a throwing job-id function must never
       // drop a side effect. Worst case is the un-collapsed fan-out we had before.
@@ -1046,12 +1076,17 @@ export class ProjectionRouter<
    * keyed on the aggregate receives the last event it actually cared about
    * rather than the last event in the batch.
    */
-  private async dispatchToReactors(
-    foldName: string,
-    reactors: ReactorDefinition<EventType>[],
-    events: EventType[],
-    foldState: unknown,
-  ): Promise<void> {
+  private async dispatchToReactors({
+    foldName,
+    reactors,
+    events,
+    foldState,
+  }: {
+    foldName: string;
+    reactors: ReactorDefinition<EventType>[];
+    events: EventType[];
+    foldState: unknown;
+  }): Promise<void> {
     const errors: Error[] = [];
 
     for (const reactor of reactors) {
@@ -1068,7 +1103,11 @@ export class ProjectionRouter<
       }
       if (relevant.length === 0) continue;
 
-      for (const event of this.collapseByJobId(reactor, relevant, foldState)) {
+      for (const event of this.collapseByJobId({
+        reactor,
+        events: relevant,
+        foldState,
+      })) {
         await this.dispatchOneToReactor({
           foldName,
           reactor,

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -375,6 +375,25 @@ export const observeEsFoldProjectionDuration = (
     .labels(pipelineName, projectionName)
     .observe(durationMs);
 
+register.removeSingleMetric("es_fold_refold_total");
+const esFoldRefoldTotal = new Counter({
+  name: "es_fold_refold_total",
+  help: "Out-of-order fold re-folds, by whether the aggregate's history was replayed from the event log",
+  labelNames: ["projection_name", "outcome"] as const,
+});
+
+/**
+ * `performed` — the aggregate's full history was re-read and replayed.
+ * `declined` — the projection's `shouldRefold` said replaying would change
+ * nothing, so the batch was applied on top instead (the events are never lost;
+ * only the replay is skipped).
+ * `unavailable` — no eventLoader was wired, so a re-fold was impossible.
+ */
+export const incrementEsFoldRefoldTotal = (
+  projectionName: string,
+  outcome: "performed" | "declined" | "unavailable",
+) => esFoldRefoldTotal.labels(projectionName, outcome).inc();
+
 // --- Map projection metrics ---
 register.removeSingleMetric("es_map_projection_total");
 const esMapProjectionTotal = new Counter({

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -384,9 +384,8 @@ const esFoldRefoldTotal = new Counter({
 
 /**
  * `performed` — the aggregate's full history was re-read and replayed.
- * `declined` — the projection's `shouldRefold` said replaying would change
- * nothing, so the batch was applied on top instead (the events are never lost;
- * only the replay is skipped).
+ * `declined` — the projection set `refoldOnOutOfOrder: false`, so the batch was
+ * applied on top instead (the events are never lost; only the replay is skipped).
  * `unavailable` — no eventLoader was wired, so a re-fold was impossible.
  */
 export const incrementEsFoldRefoldTotal = (

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -393,6 +393,25 @@ export const incrementEsFoldRefoldTotal = (
   outcome: "performed" | "declined" | "unavailable",
 ) => esFoldRefoldTotal.labels(projectionName, outcome).inc();
 
+register.removeSingleMetric("es_reactor_collapsed_total");
+const esReactorCollapsedTotal = new Counter({
+  name: "es_reactor_collapsed_total",
+  help: "Reactor dispatches skipped by collapsing a coalesced batch to one send per deduplication id",
+  labelNames: ["pipeline_name", "reactor_name"] as const,
+});
+
+/**
+ * Counts the sends a coalesced batch did NOT make. Each one would have
+ * serialized, gzipped and blobbed `{event, foldState}` only for the queue's
+ * dedup to discard it, so this is the direct measure of the churn the collapse
+ * removes (2026-07-09 incident).
+ */
+export const incrementEsReactorCollapsedTotal = (
+  pipelineName: string,
+  reactorName: string,
+  skipped: number,
+) => esReactorCollapsedTotal.labels(pipelineName, reactorName).inc(skipped);
+
 // --- Map projection metrics ---
 register.removeSingleMetric("es_map_projection_total");
 const esMapProjectionTotal = new Counter({

--- a/specs/event-sourcing/fold-coalescing.feature
+++ b/specs/event-sourcing/fold-coalescing.feature
@@ -43,16 +43,24 @@ Feature: Group-coalesced fold projections
   @unit @coalescing @reactors
   Scenario: Coalescing still dispatches per-span reactors for every event
     Given a coalesced batch of several events for one aggregate
+    And a reactor that is not keyed on the aggregate
     When the batch is folded
     Then the fold state is loaded and stored once
-    And reactors are dispatched once per event, in occurredAt order
+    And that reactor is dispatched once per event, in occurredAt order
 
-  # The per-event reactor dispatch above keeps every span's work, but reactors
-  # that read trace-level data derived from stored_spans (alert triggers,
-  # scenario role metrics) would otherwise re-issue that multi-MB read once per
-  # event. Sharing it across one fold version is what keeps the recovery path
-  # from re-amplifying reads on the single-threaded Redis/ClickHouse, while a
-  # fold that has advanced with newer spans still re-reads (no stale data).
+  # A reactor whose deduplication id varies per event (per-span embedded-eval
+  # sync) — or which declares none at all — must see every event, so it is
+  # dispatched per event as above. A reactor keyed on the aggregate would be
+  # squashed to a single queue job by the dedup anyway, so it is collapsed to one
+  # dispatch instead of paying N serialize+gzip+blob round-trips to reach the same
+  # state. See hot-trace-fold-amplification.feature.
+  #
+  # Separately, reactors that read trace-level data derived from stored_spans
+  # (alert triggers, scenario role metrics) would otherwise re-issue that
+  # multi-MB read once per event. Sharing it across one fold version is what
+  # keeps the recovery path from re-amplifying reads on the single-threaded
+  # Redis/ClickHouse, while a fold that has advanced with newer spans still
+  # re-reads (no stale data).
   @unit @coalescing @reactors
   Scenario: Repeated trace-level derivations within one fold version read stored spans once
     Given several reactor invocations derive trace data for the same trace at one fold version

--- a/specs/event-sourcing/hot-trace-fold-amplification.feature
+++ b/specs/event-sourcing/hot-trace-fold-amplification.feature
@@ -1,0 +1,128 @@
+Feature: Hot-trace fold amplification
+
+  A trace whose spans arrive faster than the fold drains backs its fold group up.
+  Two amplifiers turn that backlog into a stall that never recovers, and both are
+  only visible on the very traces that can least afford them — the 10k-to-80k-span
+  agent runs.
+
+  # Why this exists — incident 2026-07-09
+  #
+  # Sharding recordSpan across GroupQueue lanes (span-command-sharding.feature)
+  # let a hot trace's spans be handled in parallel. They therefore reach the fold
+  # queue out of occurredAt order. The fold's out-of-order detector responded by
+  # re-folding the whole trace from the event log, and because applying an event
+  # raises the checkpoint to the highest occurredAt seen, that first re-fold
+  # pinned the checkpoint at the trace's maximum event time — so every later
+  # batch looked out of order too. One trace re-folded 730 times in two hours,
+  # re-reading 5.66 million event rows out of ClickHouse to fold 73k spans.
+  #
+  # None of it bought anything. The trace summary is an order-insensitive fold:
+  # its accumulators commute and its precedence rules read span timestamps, not
+  # arrival order. A span can simply be folded when it arrives.
+  #
+  # Underneath it, each coalesced batch dispatched every reactor once per event.
+  # Reactors keyed on the trace (evaluation trigger, trace-update broadcast,
+  # alert trigger) collapse to a single queue job by dedup id, so 99 of every 100
+  # sends were discarded — after each had serialized {event, foldState}, gzipped
+  # it, and written a content-addressed blob into Redis that the dedup squash
+  # immediately reclaimed.
+
+  Background:
+    Given a fold projection registered on the GroupQueue with coalescing enabled
+
+  # ── Opting out of the out-of-order re-fold ─────────────────────────
+
+  @unit @fold @refold
+  Scenario: An out-of-order batch re-folds from the event log by default
+    Given a fold whose persisted checkpoint is later than the batch's earliest event
+    When the batch is folded
+    Then the aggregate's full history is loaded and replayed from init state
+
+  @unit @fold @refold
+  Scenario: An order-insensitive fold never re-folds
+    Given a fold that has opted out of re-folding on out-of-order events
+    And a persisted checkpoint later than the batch's earliest event
+    When the batch is folded
+    Then the event log is never read
+    And the batch is applied on top of the existing state in occurredAt order
+
+  @unit @fold @refold
+  Scenario: The trace summary is an order-insensitive fold
+    Given the trace summary fold projection
+    Then it has opted out of re-folding on out-of-order events
+
+  @unit @fold @refold
+  Scenario: Folding out-of-order spans without a re-fold still counts every span
+    Given a trace summary with spans already folded
+    And a batch of three span events that all occurred before the checkpoint
+    When the batch is folded
+    Then the event log is never read
+    And the span count grows by three
+    And the checkpoint does not regress
+
+  @unit @fold @refold
+  Scenario: A single out-of-order event honours the same opt-out
+    Given a fold that has opted out of re-folding on out-of-order events
+    And an event that occurred before the persisted checkpoint
+    When the event is folded
+    Then the event log is never read
+    And the event is applied on top of the existing state
+
+  # ── Collapsing the per-batch reactor fan-out ───────────────────────
+
+  @unit @coalescing @reactors
+  Scenario: Reactors keyed on the aggregate are dispatched once per coalesced batch
+    Given a coalesced batch of five events for one aggregate
+    And a reactor whose deduplication id is the same for every event in the batch
+    When the batch is folded
+    Then the reactor is dispatched once
+    And it receives the last event in occurredAt order
+
+  @unit @coalescing @reactors
+  Scenario: Reactors keyed per event are still dispatched for every event
+    Given a coalesced batch of five events for one aggregate
+    And a reactor whose deduplication id includes the event id
+    When the batch is folded
+    Then the reactor is dispatched five times
+
+  @unit @coalescing @reactors
+  Scenario: Reactors without a deduplication id are dispatched for every event
+    Given a coalesced batch of five events for one aggregate
+    And a reactor with no deduplication id
+    When the batch is folded
+    Then the reactor is dispatched five times
+
+  @unit @coalescing @reactors
+  Scenario: The relevance check still filters events before collapsing
+    Given a coalesced batch of five events for one aggregate
+    And an aggregate-keyed reactor that finds only two of them relevant
+    When the batch is folded
+    Then the reactor is dispatched once
+    And it receives the last relevant event
+
+  # ── Guards run before enqueue, not after dispatch ──────────────────
+
+  @unit @reactors
+  Scenario: The origin guard filters a non-message event before enqueue
+    Given a topic-assigned event on a trace with a resolved origin
+    Then the origin-guarded reactor declines to react
+
+  @unit @reactors
+  Scenario: The origin guard filters a trace with no resolved origin before enqueue
+    Given a span event on a trace whose origin is unresolved
+    Then the origin-guarded reactor declines to react
+
+  @unit @reactors
+  Scenario: The origin guard admits a genuine message event before enqueue
+    Given a recent span event on a recent trace with a resolved origin
+    Then the origin-guarded reactor agrees to react
+
+  @unit @reactors
+  Scenario: The evaluation trigger declines past the span processing cap before enqueue
+    Given a span event on a trace whose span count has passed the span processing cap
+    Then the evaluation trigger declines to react
+
+  @unit @reactors
+  Scenario: The evaluation trigger declines a synthetic span before enqueue
+    Given a synthetic span event on a trace with a resolved origin
+    Then the evaluation trigger declines to react

--- a/specs/event-sourcing/hot-trace-fold-amplification.feature
+++ b/specs/event-sourcing/hot-trace-fold-amplification.feature
@@ -16,9 +16,13 @@ Feature: Hot-trace fold amplification
   # batch looked out of order too. One trace re-folded 730 times in two hours,
   # re-reading 5.66 million event rows out of ClickHouse to fold 73k spans.
   #
-  # None of it bought anything. The trace summary is an order-insensitive fold:
-  # its accumulators commute and its precedence rules read span timestamps, not
-  # arrival order. A span can simply be folded when it arrives.
+  # None of it bought anything. Nearly every trace-summary field is order-free:
+  # the counters and totals are sums, timing is min/max, status is an OR, and the
+  # semantic output override compares span end times. A span can simply be folded
+  # when it arrives. Three fields (models order, computedInput on multi-root
+  # traces, and a fallback-only computedOutput) do resolve in fold order — and
+  # already did, because a span event's occurredAt is the ingest wall-clock, so
+  # the replay only ever restored global INGEST order, never span-time order.
   #
   # Underneath it, each coalesced batch dispatched every reactor once per event.
   # Reactors keyed on the trace (evaluation trigger, trace-update broadcast,
@@ -47,9 +51,11 @@ Feature: Hot-trace fold amplification
     And the batch is applied on top of the existing state in occurredAt order
 
   @unit @fold @refold
-  Scenario: The trace summary is an order-insensitive fold
-    Given the trace summary fold projection
-    Then it has opted out of re-folding on out-of-order events
+  Scenario: The trace summary folds an earlier span without reading the event log
+    Given a trace summary with spans already folded
+    And a span event that occurred before the checkpoint
+    When the event is folded
+    Then the event log is never read
 
   @unit @fold @refold
   Scenario: Folding out-of-order spans without a re-fold still counts every span
@@ -67,6 +73,14 @@ Feature: Hot-trace fold amplification
     When the event is folded
     Then the event log is never read
     And the event is applied on top of the existing state
+
+  @unit @fold @refold
+  Scenario: An out-of-order batch with no event loader applies on top instead
+    Given a fold with no event loader wired
+    And a persisted checkpoint later than the batch's earliest event
+    When the batch is folded
+    Then the batch is applied on top of the existing state
+    And the re-fold is recorded as unavailable
 
   # ── Collapsing the per-batch reactor fan-out ───────────────────────
 
@@ -118,11 +132,18 @@ Feature: Hot-trace fold amplification
     Then the origin-guarded reactor agrees to react
 
   @unit @reactors
-  Scenario: The evaluation trigger declines past the span processing cap before enqueue
+  Scenario: The evaluation trigger dispatches nothing past the span processing cap
     Given a span event on a trace whose span count has passed the span processing cap
-    Then the evaluation trigger declines to react
+    When the evaluation trigger runs
+    Then no evaluation is dispatched
 
   @unit @reactors
   Scenario: The evaluation trigger declines a synthetic span before enqueue
     Given a synthetic span event on a trace with a resolved origin
     Then the evaluation trigger declines to react
+
+  @unit @reactors
+  Scenario: An outbox reactor's relevance check reaches the dispatcher
+    Given an outbox reactor that declines to react
+    When it is adapted for the pipeline, with and without an outbox runtime
+    Then the adapted reactor declines to react as well


### PR DESCRIPTION
Follow-up to #5531. Sharding `recordSpan` across GroupQueue lanes made hot-trace ingestion parallel — and, unintentionally, made the trace-summary fold replay the entire trace from `event_log` on essentially every batch.

## What's happening in prod

`span_received` events now reach the fold queue out of `occurredAt` order. `FoldProjectionExecutor` sees `earliestOccurredAt < LastEventOccurredAt` and re-folds from scratch via `eventLoader`, which reads **every** event for the trace. It is self-perpetuating: `apply()` sets `LastEventOccurredAt = max(prev, occurredAt)`, so once one replay advances the checkpoint to the trace's maximum event time, every remaining batch is "out of order" forever.

CloudWatch, 2h window, `/aws/eks/langwatch-cluster/pods`:

| Trace | Re-folds | Avg events reloaded | Event rows re-read |
|---|---:|---:|---:|
| `a663d235…` | 730 | 7,760 | **5,664,659** |
| `e0233560…` | 620 | 4,809 | 2,981,838 |
| _all traces_ | 9,886 | — | ~9.4M |

Every log line reads `batchSize: 100` — folding 100 spans cost a ~9,000-row ClickHouse read. Observed inversions reach 1,602,185 ms, which is simply that trace's own wall-clock duration: the signature of a pinned checkpoint. The fold *state* store is Redis-cached; the replay path bypasses it entirely.

## A span can just be folded when it arrives

Nearly every trace-summary field is order-free: `spanCount` and the token/cost totals are sums, timing is min/max, status is an OR, the semantic output override compares span end times (`shouldOverrideOutput`), and trace naming compares root-span start times.

Three fields **do** resolve in fold order, and we accept that:

- `models` — `mergeModelsMostRecentFirst` puts the last-folded model first, so `models[0]` is the trace's primary model.
- `computedInput` — among several parentless "root" spans the last-folded one wins; among non-root spans the first-folded one wins (`trace-io-accumulation.service.ts`, the `isRoot || computedInput === null` branch). There is no timestamp tiebreak.
- `computedOutput` when only a *fallback* (non-semantic) extraction exists — the first-folded fallback wins. A later semantic match still overrides it.

This costs less than it reads. A span event's `occurredAt` is the **ingest wall-clock** (`trace-request-collection.service.ts` stamps `Date.now()`), not the span's own start time — so the replay never restored span-time order either, only global *ingest* order. `executeBatch` folds each batch in `occurredAt` order, so nothing changes within a batch; across batches these three fields may resolve differently than a full replay would, on multi-root traces. That is a display-level difference in fields whose selection was already ingest-order dependent, not a lost invariant.

- `FoldProjectionOptions.refoldOnOutOfOrder` (default `true`) lets an order-tolerant fold opt out, alongside the existing `refoldOnStoreMiss`. The executor then applies the batch in `occurredAt` order on top of the loaded state — the same path taken when no `eventLoader` is wired. `traceSummary` opts out.
- New counter `es_fold_refold_total{projection, outcome}` (`performed` / `declined` / `unavailable`) so the decision is never silent.

Expected: re-folds drop from ~9,886/2h to zero.

## Reactors were over-firing

`processFoldProjectionBatch` dispatched every reactor once per event, sequentially awaited. Four reactors have a **per-trace** dedup id — `evaluationTrigger`, `traceUpdateBroadcast`, `alertTrigger`, `alertTriggerNotifyOutbox` — so a 100-event batch issued ~400 `send()` calls that the queue collapsed to 4 jobs. Each of the ~396 doomed sends did two `JSON.stringify`s of `{event, foldState}`, a gzip, and (past the 4 KiB `INLINE_CEILING_BYTES`) a content-addressed blob write into Redis that the dedup squash immediately reclaimed. `groupQueue.send` encodes *before* the dedup Lua, so none of that was avoidable at the queue layer.

- `ProjectionRouter.collapseByJobId` dispatches an aggregate-keyed reactor **once** per batch, carrying the last event that passed its `shouldReact` — the same job the dedup would have left behind (`STAGE_LUA` overwrites the stored value when `shouldReplace`, which every reactor here defaults to). Per-event job ids (`customEvaluationSync`, keyed on `event.id`) and reactors with no job id are dispatched for every event as before.
- Behaviour-preserving: `alertTrigger`, `alertTriggerNotifyOutbox` and `traceUpdateBroadcast` all take `(_event, context)` and read only `foldState`; `evaluationTrigger` was already squashed to the last event by its per-trace job id.
- New counter `es_reactor_collapsed_total{pipeline_name, reactor_name}` counts the sends the collapse skips, so the reduction is measured rather than inferred.

## Guards now run before enqueue

`passesTraceOriginGuards` and `evaluationTrigger`'s synthetic-span check are pure and read only the payload `handle()` would receive, but lived *inside* `handle`, i.e. after the job was serialized and enqueued. They move to `shouldReact` (ADR-026), exactly as `originGate` and `customEvaluationSync` already do it. They remain in `handle` as the fail-open path. `OutboxReactorDefinition` gains `shouldReact`; `adaptOutboxReactor` forwards it.

The oversized-trace cap guard deliberately **stays** in `handle()`: it carries a once-per-crossing `logger.warn`, and `shouldReact` runs once per event of a coalesced batch, which would multiply that log by the batch size — the exact amplification the guard exists to avoid. The enqueue it no longer skips is already collapsed to one job per batch by `collapseByJobId`.

## Spec & tests

`specs/event-sourcing/hot-trace-fold-amplification.feature` — 16 scenarios, all bound. `fold-coalescing.feature`'s "reactors are dispatched once per event" scenario is rescoped to reactors not keyed on the aggregate, and its rationale comment updated.

- `pnpm typecheck` clean
- `vitest run src/server/event-sourcing` — 152 files, 6,737 passed
- `pnpm check:feature-parity` — exit 0

## Not in this PR

- **Batch size.** Measured, not the bottleneck: with the replay gone, per-batch fixed cost is one Redis `get` + one ClickHouse write. The per-event cost is dominated by the drain's blob decode, which a larger batch does not amortise. Left at 100 rather than adding an unmeasured tuning knob.
- **`spanStorageBroadcast`.** A map reactor with a per-trace job id, so it pays the same doomed-send cost once per span (~36k times for the trace above). Map handler jobs are dispatched individually, so there is no batch to collapse — this needs the map-queue coalescing already deferred out of #5531.
- **Deterministic `computedInput` on multi-root traces.** Giving input selection an end-time tiebreak like the output path would make the fold genuinely order-free. It changes user-visible I/O selection semantics, so it belongs in its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-enqueue relevance predicate for trace evaluation (including outbox dispatch) to skip unwanted work earlier.
  * Introduced `refoldOnOutOfOrder` to opt out of full re-folds on out-of-order inputs.
  * Added Event Sourcing metrics for out-of-order fold refolds and reactor batch collapsing.
* **Bug Fixes**
  * Reduced hot-trace fold amplification by gating refolds and preventing checkpoint regression.
* **Tests**
  * Added unit/regression coverage for out-of-order folding and coalesced reactor dispatch with dedup/relevance.
* **Documentation**
  * Updated specs to reflect fold semantics and pre-enqueue guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->