### PR TITLE
ci: add sticky PR impact map comment

### DIFF
--- a/.github/workflows/pr-impact-map.yml
+++ b/.github/workflows/pr-impact-map.yml
@@ -1,0 +1,218 @@
+name: pr-impact-map
+
+# Posts a single sticky comment summarising which areas of the monorepo a PR
+# touches, and rewrites that same comment on every subsequent push.
+#
+# `synchronize` IS "a new commit was pushed to this PR", so one `pull_request`
+# trigger covers both "on open" and "on every push". There is deliberately no
+# `push:` trigger and no `actions/checkout` — the changed-file list comes from
+# the pulls/files API, which keeps the whole job to a single ~5s step.
+#
+# Deliberately non-blocking: this workflow only ever describes the diff, it
+# never judges it. Nothing here should gate a merge, so it is not a candidate
+# for branch protection.
+#
+# No path filter, so it always produces a result and needs no "-unmodified"
+# stub under the complementary-pair system (see specs/ci/path-filters.feature).
+#
+# Spec: specs/ci/pr-impact-map.feature
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Two pushes in quick succession would otherwise race: both runs read "no
+# existing comment" and both POST, leaving duplicates on the thread.
+concurrency:
+  group: pr-impact-map-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    # Fork PRs get a read-only GITHUB_TOKEN, so the comment POST would 403.
+    # Skip quietly rather than paint a red X on a contributor's first PR.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and upsert impact map comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const MARKER = "<!-- pr-impact-map -->";
+
+            // First match wins, so order is load-bearing: `langwatch/**` would
+            // otherwise swallow migrations, specs and tests. Lockfiles are
+            // pulled out above the language buckets so a dependency bump does
+            // not masquerade as a large Go or app change — but `go.mod` and
+            // `package.json` stay with their language, because those express
+            // intent rather than churn.
+            const CATEGORIES = [
+              ["Migrations",     p => /^langwatch\/(prisma|scripts|elastic)\/migrations\//.test(p)],
+              ["Specs",          p => p.startsWith("specs/")],
+              ["Tests",          p => /(^|\/)__tests__\//.test(p)
+                                   || /\.(test|spec)\.[cm]?[jt]sx?$/.test(p)
+                                   || /_test\.go$/.test(p)
+                                   || /(^|\/)test_[^/]+\.py$/.test(p)
+                                   || p.startsWith("agentic-e2e-tests/")],
+              ["CI/CD",          p => p.startsWith(".github/")],
+              ["Deploy",         p => p.startsWith("charts/")
+                                   || /^Dockerfile/.test(p)
+                                   || /^compose[.\w-]*\.ya?ml$/.test(p)],
+              ["Docs",           p => p.startsWith("docs/")
+                                   || p.startsWith("dev/docs/")
+                                   || p.startsWith("skills/")
+                                   || p.endsWith(".md")],
+              ["Deps",           p => /(^|\/)(pnpm-lock\.yaml|go\.sum|uv\.lock|poetry\.lock)$/.test(p)
+                                   || p.endsWith(".lock")],
+              ["SDKs",           p => /^(python-sdk|typescript-sdk|sdk-go|mcp-server|packages)\//.test(p)],
+              ["Go services",    p => /^(services|pkg|cmd)\//.test(p) || p === "go.mod"],
+              ["Python",         p => /^(langwatch_nlp|langevals|langwatch_server)\//.test(p)],
+              ["App · Server",   p => p.startsWith("langwatch/src/server/")
+                                   || p.endsWith("schema.prisma")
+                                   || /^langwatch\/src\/(mcp|tasks|workers)/.test(p)],
+              ["App · Frontend", p => /^langwatch\/src\/(components|pages|app|hooks|stores|styles|features|optimization_studio)\//.test(p)
+                                   || p.endsWith(".tsx")],
+              ["Other",          () => true],
+            ];
+
+            const classify = (path) => CATEGORIES.find(([, test]) => test(path))[0];
+
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const shortSha = pr.head.sha.slice(0, 7);
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            // The pulls/files API caps out at 3000 files. `changed_files` on the
+            // PR payload is authoritative, so a shortfall means we were truncated
+            // and the per-category counts below are a floor, not a total.
+            const truncated = files.length < pr.changed_files;
+
+            const buckets = new Map();
+            for (const file of files) {
+              const name = classify(file.filename);
+              const bucket = buckets.get(name) ?? { files: 0, additions: 0, deletions: 0 };
+              bucket.files += 1;
+              bucket.additions += file.additions;
+              bucket.deletions += file.deletions;
+              buckets.set(name, bucket);
+            }
+
+            const num = (n) => n.toLocaleString("en-US");
+            const rows = [...buckets.entries()].sort((a, b) => b[1].files - a[1].files);
+
+            let body;
+            if (files.length === 0) {
+              body = [
+                MARKER,
+                "### PR Impact Map",
+                "",
+                "No files changed.",
+              ].join("\n");
+            } else {
+              // Share is by file count, not lines: lockfiles and generated code
+              // dominate line counts and would make every dep bump look like a
+              // rewrite.
+              const BAR_WIDTH = 15;
+              const bar = (share) => {
+                const filled = Math.round(share * BAR_WIDTH);
+                return "█".repeat(filled) + "░".repeat(BAR_WIDTH - filled);
+              };
+
+              const table = rows.map(([name, b]) => {
+                const share = b.files / files.length;
+                const pct = Math.round(share * 100);
+                return [
+                  "  ",
+                  name.padEnd(16),
+                  String(b.files).padStart(5),
+                  ("+" + num(b.additions)).padStart(11),
+                  ("-" + num(b.deletions)).padStart(10),
+                  "   ",
+                  bar(share),
+                  " ",
+                  (pct + "%").padStart(4),
+                ].join("");
+              });
+
+              const header =
+                "  " + "Category".padEnd(16) + "Files".padStart(5) +
+                "Added".padStart(11) + "Removed".padStart(10) + "   Share";
+              const rule = "  " + "-".repeat(62);
+
+              // Every figure on the totals row comes from the PR payload, never
+              // from the (possibly truncated) file list, so the row stays
+              // internally consistent even when the category rows are a floor.
+              const totals =
+                "  " + "Total".padEnd(16) + String(pr.changed_files).padStart(5) +
+                ("+" + num(pr.additions)).padStart(11) +
+                ("-" + num(pr.deletions)).padStart(10);
+
+              const fileWord = pr.changed_files === 1 ? "file" : "files";
+              const title =
+                `PR Impact Map · ${num(pr.changed_files)} ${fileWord} · ` +
+                `+${num(pr.additions)} / -${num(pr.deletions)} · ${shortSha}`;
+
+              body = [
+                MARKER,
+                "### PR Impact Map",
+                "",
+                "```",
+                title,
+                "-".repeat(title.length),
+                "",
+                header,
+                rule,
+                ...table,
+                rule,
+                totals,
+                "```",
+                ...(truncated
+                  ? [
+                      "",
+                      `> **File list truncated.** GitHub returned ${num(files.length)} of ` +
+                        `${num(pr.changed_files)} changed files, so the per-category counts ` +
+                        `above are a lower bound. The totals row is complete.`,
+                    ]
+                  : []),
+                "",
+                `<sub>Updated for \`${shortSha}\` · ${new Date().toISOString().replace("T", " ").slice(0, 16)} UTC</sub>`,
+              ].join("\n");
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (c) => c.user?.login === "github-actions[bot]" && c.body?.includes(MARKER)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated impact map comment ${existing.id} on PR #${pr.number}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body,
+              });
+              core.info(`Created impact map comment on PR #${pr.number}.`);
+            }

--- a/specs/ci/pr-impact-map.feature
+++ b/specs/ci/pr-impact-map.feature
@@ -1,0 +1,85 @@
+Feature: PR impact map comment
+  As a reviewer
+  I want a single comment summarising which parts of the monorepo a PR touches
+  So that I can judge blast radius before reading the diff
+
+  Background:
+    Given the pr-impact-map workflow runs on pull_request events
+    And it identifies its own comment by the hidden marker "<!-- pr-impact-map -->"
+
+  Scenario: A comment is posted when a pull request is opened
+    When a pull request is opened
+    Then a comment carrying the impact-map marker is posted exactly once
+
+  Scenario: The existing comment is updated when new commits are pushed
+    Given a pull request already has a comment carrying the impact-map marker
+    When a new commit is pushed to the pull request branch
+    Then the existing comment is updated in place
+    And no additional comment is created
+
+  Scenario: A comment is posted when a closed pull request is reopened
+    Given a pull request has been closed
+    When the pull request is reopened
+    Then the impact-map comment reflects the current head commit
+
+  Scenario: Rapid successive pushes do not create duplicate comments
+    Given a pull request receives two pushes in quick succession
+    When both workflow runs are triggered
+    Then the earlier run is cancelled before it posts
+    And the pull request carries exactly one impact-map comment
+
+  Scenario: Pull requests from forks are skipped
+    Given a pull request originates from a forked repository
+    When the workflow is triggered
+    Then no comment is attempted
+    And the workflow does not fail
+
+  Scenario: Each changed file is counted in exactly one category
+    Given a pull request changes files across several areas of the monorepo
+    When the impact map is built
+    Then every changed file is attributed to exactly one category
+    And the category file counts sum to the pull request's total changed files
+
+  Scenario: The first matching category wins
+    Given a changed file could match more than one category rule
+    When the impact map is built
+    Then the file is attributed to the earliest matching rule
+
+  Scenario: Migration files are attributed to Migrations, not to the application
+    Given a pull request changes "langwatch/prisma/migrations/0001_init/migration.sql"
+    When the impact map is built
+    Then the file is attributed to "Migrations"
+
+  Scenario: Test files are attributed to Tests, not to the code they cover
+    Given a pull request changes "langwatch/src/server/analytics/__tests__/analytics.service.test.ts"
+    When the impact map is built
+    Then the file is attributed to "Tests"
+
+  Scenario: SDK files are attributed to SDKs, not to their language
+    Given a pull request changes "python-sdk/src/langwatch/client.py"
+    When the impact map is built
+    Then the file is attributed to "SDKs"
+
+  Scenario: Lockfiles are attributed to Deps, not to their language
+    Given a pull request changes only "langwatch/pnpm-lock.yaml"
+    When the impact map is built
+    Then the file is attributed to "Deps"
+    And the map does not report a change to the application
+
+  Scenario: Categories with no changed files are omitted
+    Given a pull request changes only documentation
+    When the impact map is built
+    Then only the "Docs" row is rendered
+    And rows with zero files are absent
+
+  Scenario: A pull request with no changed files renders an empty-state message
+    Given a pull request changes no files
+    When the impact map is built
+    Then the comment states that no files were changed
+    And no category table is rendered
+
+  Scenario: Truncation is disclosed when the file list exceeds the API limit
+    Given a pull request changes more files than the GitHub API will return
+    When the impact map is built
+    Then the comment discloses that the file list was truncated
+    And the counts are not presented as complete


### PR DESCRIPTION
Posts a single sticky comment on every PR summarising which areas of the monorepo the diff touches, and rewrites that same comment on every push.

## What it looks like

Rendered from the real file list of `6a440f4` (the ADR-034 analytics PR):

```
PR Impact Map · 89 files · +9,287 / -632 · 6a440f4
--------------------------------------------------

  Category        Files      Added   Removed   Share
  --------------------------------------------------------------
  App · Server       52     +5,196      -269   █████████░░░░░░  58%
  Tests              33     +3,852      -313   ██████░░░░░░░░░  37%
  App · Frontend      2        +48       -50   ░░░░░░░░░░░░░░░   2%
  Docs                1        +94        -0   ░░░░░░░░░░░░░░░   1%
  Specs               1        +97        -0   ░░░░░░░░░░░░░░░   1%
  --------------------------------------------------------------
  Total              89     +9,287      -632
```

Categories with zero files are omitted, so a docs-only PR renders two lines rather than a wall of zeroes. `Share` is share of **files**, not lines — lockfiles and generated code dominate line counts and would make every dependency bump look like a rewrite.

## Design

`synchronize` **is** "a new commit was pushed to this PR", so one `pull_request` trigger covers both "on open" and "on every push". There is deliberately no `push:` trigger, and no cross-referencing of pushes back to PRs.

The changed-file list comes from the `pulls/files` API, so there is no `actions/checkout`, no Node setup and no `pnpm install` — the whole job is one `github-script` step and finishes in a few seconds. Stickiness is an invisible `<!-- pr-impact-map -->` marker: list the PR's comments, `PATCH` the one carrying the marker, `POST` if absent. No third-party actions; `github-script` is pinned to the SHA already used by `pr-auto-approve.yml`.

The comment is **descriptive only** — it never judges the diff. Nothing here should gate a merge, so it is not a candidate for branch protection. It carries no path filter, so it always produces a result and needs no `-unmodified` stub under the complementary-pair system.

## Categories

First match wins; the ordering is load-bearing, since `langwatch/**` would otherwise swallow migrations, specs and tests. The globs are derived from what the existing workflows already pass to `.github/actions/detect-changes`, so the buckets agree with what CI already believes about this repo.

| # | Category | Notes |
|---|---|---|
| 1 | Migrations | `prisma`/`scripts`/`elastic` migrations. Immutable history — highest-consequence thing a PR can touch. |
| 2 | Specs | 744 `.feature` files; they *are* the requirements. |
| 3 | Tests | Separated from source so "did this PR add coverage" is answerable at a glance. |
| 4 | CI/CD | `.github/**` |
| 5 | Deploy | `charts/**`, `Dockerfile*`, `compose*.yml` |
| 6 | Docs | Includes ADRs. Precedes SDKs, so `python-sdk/README.md` lands in Docs. |
| 7 | Deps | Lockfiles only. Sits above the language buckets so a bump doesn't masquerade as a large Go/app change. `go.mod` and `package.json` stay with their language — those express intent, not churn. |
| 8 | SDKs | Published artifacts. Precedes Python, or `python-sdk` lands in the wrong bucket. |
| 9 | Go services | Mirrors the `go-ci.yaml` filter. |
| 10 | Python | Mirrors `langevals-ci` / `langwatch-nlp-ci`. |
| 11 | App · Server | |
| 12 | App · Frontend | |
| 13 | Other | Escape hatch. If this row is ever large, the rules need an entry. |

## Two failure modes handled explicitly

**Rapid pushes race.** Two pushes in quick succession would otherwise both observe "no existing comment" and each `POST` one. The `concurrency` group with `cancel-in-progress` prevents the duplicate.

**Fork PRs get a read-only `GITHUB_TOKEN`**, so the comment `POST` would 403. The clean fix would be `pull_request_target`, but that runs base-branch code with a write token and is gated by `workflow-security-guard.yml` — not worth it for a cosmetic feature. Fork PRs are skipped quietly instead of painting a red X on a contributor's first PR.

## Verification

The script block was extracted from the YAML and executed against the real changed-file list of `6a440f4` with the GitHub API stubbed, covering seven cases: create, sticky update-in-place, empty PR, lockfile-only, docs-only, truncated file list, and single-file pluralisation. All assertions pass, including that every changed file lands in exactly one category and the category counts sum to the PR's total.

Two defects surfaced that way and were fixed before commit: a `1 files` plural bug, and a totals row that mixed the truncated file count with the authoritative line counts. The totals row now sources every figure from the PR payload, so it stays internally consistent even when the category rows are a lower bound.

Truncation is disclosed rather than silent: the `pulls/files` API caps at 3,000 files, and past that the comment says so.

## Deployment impact

None. Adds one non-blocking workflow and one spec file. No charts, services, env vars or `helm` values touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pull request “impact map” comment that summarizes which parts of the monorepo were changed.
  * The comment updates automatically on new commits and reopen events, while avoiding duplicate entries.
  * Includes totals, per-area file counts, and a clear notice when the changed-file list is incomplete.
* **Bug Fixes**
  * Prevents overlapping runs from posting duplicate comments.
  * Skips forked pull requests safely without failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->