### PR TITLE
perf(prompts+sweep): stop tab-label query storms and mount inactive Tabs panels (#5585, #5455)

### DIFF
--- a/langwatch/src/components/LLMMetrics.tsx
+++ b/langwatch/src/components/LLMMetrics.tsx
@@ -170,7 +170,16 @@ export function LLMMetrics() {
         <GridItem colSpan={2}>
           <Card.Root>
             <Card.Body>
-              <Tabs.Root variant="plain" defaultValue="llmCallsGraph">
+              <Tabs.Root
+                variant="plain"
+                defaultValue="llmCallsGraph"
+                // Every panel here is a read-only CustomGraph analytics
+                // query with no user-entered state, so fully unmounting
+                // inactive tabs is safe and avoids firing/holding queries
+                // for graphs the user never looks at.
+                lazyMount
+                unmountOnExit
+              >
                 <Tabs.List gap={12}>
                   <Tabs.Trigger
                     value="llmCallsGraph"

--- a/langwatch/src/components/analytics/UserMetrics.tsx
+++ b/langwatch/src/components/analytics/UserMetrics.tsx
@@ -122,7 +122,16 @@ export function UserMetrics() {
       <GridItem>
         <Card.Root border="1px solid" borderColor="border.emphasized">
           <Card.Body paddingTop={2}>
-            <Tabs.Root variant="plain" defaultValue="messages">
+            <Tabs.Root
+              variant="plain"
+              defaultValue="messages"
+              // Every panel here is a read-only CustomGraph analytics
+              // query with no user-entered state, so fully unmounting
+              // inactive tabs is safe and avoids holding queries for
+              // graphs the user never looks at.
+              lazyMount
+              unmountOnExit
+            >
               <Tabs.List gap={8}>
                 <Tabs.Trigger
                   value="messages"

--- a/langwatch/src/components/experiments/DSPyExperiment.tsx
+++ b/langwatch/src/components/experiments/DSPyExperiment.tsx
@@ -639,6 +639,11 @@ export const RunDetails = React.memo(
           flexDirection="column"
           minWidth="0"
           colorPalette="blue"
+          // Every panel here (Predictors, Evaluations, LLM Calls) is a
+          // read-only render of the same dspyStep query with no
+          // user-entered state, so fully unmounting inactive tabs is safe.
+          lazyMount
+          unmountOnExit
         >
           <Tabs.List
             position="relative"

--- a/langwatch/src/components/ops/foundry/PlaygroundContent.tsx
+++ b/langwatch/src/components/ops/foundry/PlaygroundContent.tsx
@@ -42,7 +42,21 @@ export function PlaygroundContent({ compact = false }: { compact?: boolean }) {
 
       {/* Right pane — minmax(0,1fr) prevents blowout */}
       <GridItem overflow="hidden" display="flex" flexDirection="column">
-        <Tabs.Root defaultValue="editor" variant="line" size="sm" display="flex" flexDirection="column" flex={1} overflow="hidden">
+        <Tabs.Root
+          defaultValue="editor"
+          variant="line"
+          size="sm"
+          display="flex"
+          flexDirection="column"
+          flex={1}
+          overflow="hidden"
+          // lazyMount only (no unmountOnExit): the Editor tab renders
+          // SpanEditorPanel, whose Input/Textarea fields are live editing
+          // surfaces for the selected span. Unmounting on tab switch risks
+          // losing in-progress edits, so inactive tabs are only skipped
+          // until first opened, then kept mounted.
+          lazyMount
+        >
           <Tabs.List borderBottom="1px solid" borderColor="border" px={3} gap={0} flexShrink={0}>
             <Tabs.Trigger value="editor" fontSize="xs" px={3} py={1.5} color="fg.muted" _selected={{ color: "fg.default", borderColor: "orange.500" }}>
               Editor

--- a/langwatch/src/components/scenarios/SaveAndRunMenu.tsx
+++ b/langwatch/src/components/scenarios/SaveAndRunMenu.tsx
@@ -36,13 +36,16 @@ export function SaveAndRunMenu({
 }: SaveAndRunMenuProps) {
   const { project } = useOrganizationTeamProject();
   const { data: prompts } = useAllPromptsForProject();
-  const { data: agents } = api.agents.getAll.useQuery(
-    { projectId: project?.id ?? "" },
-    { enabled: !!project?.id },
-  );
 
   const [searchValue, setSearchValue] = useState("");
   const [open, setOpen] = useState(false);
+
+  // Agents are only shown inside the popover, and the trigger is static —
+  // don't fetch them until the menu is opened.
+  const { data: agents } = api.agents.getAll.useQuery(
+    { projectId: project?.id ?? "" },
+    { enabled: open && !!project?.id },
+  );
   const inputRef = useRef<HTMLInputElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 

--- a/langwatch/src/components/scenarios/__tests__/SaveAndRunMenu.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/SaveAndRunMenu.integration.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SaveAndRunMenu } from "../SaveAndRunMenu";
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { id: "project-1" } }),
+}));
+
+vi.mock("~/prompts/hooks/useAllPromptsForProject", () => ({
+  useAllPromptsForProject: () => ({ data: [] }),
+}));
+
+vi.mock("../useFilteredScenarioTargets", () => ({
+  isAgentTarget: () => false,
+  useFilteredAgents: () => [],
+}));
+
+const { mockGetAll } = vi.hoisted(() => ({ mockGetAll: vi.fn() }));
+vi.mock("~/utils/api", () => ({
+  api: {
+    agents: {
+      getAll: {
+        useQuery: mockGetAll,
+      },
+    },
+  },
+}));
+
+const renderMenu = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <SaveAndRunMenu
+        selectedTarget={{ type: "prompt", id: "p1" } as never}
+        onTargetChange={vi.fn()}
+        onSaveAndRun={vi.fn()}
+        onSaveWithoutRunning={vi.fn()}
+        onCreateAgent={vi.fn()}
+      />
+    </ChakraProvider>,
+  );
+
+describe("SaveAndRunMenu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAll.mockReturnValue({ data: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given a rendered menu", () => {
+    describe("when the menu is closed", () => {
+      it("does not enable the agents query", () => {
+        renderMenu();
+
+        expect(mockGetAll).toHaveBeenCalledWith(
+          expect.objectContaining({ projectId: "project-1" }),
+          expect.objectContaining({ enabled: false }),
+        );
+      });
+    });
+
+    describe("when the menu is opened", () => {
+      it("enables the agents query", async () => {
+        const user = userEvent.setup();
+        renderMenu();
+
+        await user.click(screen.getByRole("button", { name: /save and run/i }));
+
+        expect(mockGetAll).toHaveBeenLastCalledWith(
+          expect.objectContaining({ projectId: "project-1" }),
+          expect.objectContaining({ enabled: true }),
+        );
+      });
+    });
+  });
+});

--- a/langwatch/src/components/secrets/SecretsIndicator.tsx
+++ b/langwatch/src/components/secrets/SecretsIndicator.tsx
@@ -27,9 +27,14 @@ export function SecretsIndicator({
 	projectId,
 	onInsertSecret,
 }: SecretsIndicatorProps) {
-	const secretsQuery = api.secrets.list.useQuery({ projectId });
-	const secrets = secretsQuery.data ?? [];
 	const [open, setOpen] = useState(false);
+	// Only list secrets once the popover is opened — the trigger is static, so
+	// there's no need to fetch on mount for every editor that renders this.
+	const secretsQuery = api.secrets.list.useQuery(
+		{ projectId },
+		{ enabled: open },
+	);
+	const secrets = secretsQuery.data ?? [];
 
 	const handleSecretClick = (secretName: string) => {
 		onInsertSecret?.(secretName);

--- a/langwatch/src/components/traces/TraceDetails.tsx
+++ b/langwatch/src/components/traces/TraceDetails.tsx
@@ -221,6 +221,14 @@ export function TraceDetails(props: {
         colorPalette="blue"
         display="flex"
         flexDirection="column"
+        // lazyMount only (no unmountOnExit): the Thread (messages) tab
+        // renders Conversation -> TraceMessages -> Annotations ->
+        // AnnotationComment, which holds an in-progress annotation
+        // comment via react-hook-form local state. Unmounting that tab
+        // while the user is mid-comment (e.g. after clicking "Annotate"
+        // and switching to another tab) would destroy the draft, so we
+        // only skip mounting tabs that were never opened.
+        lazyMount
       >
         <VStack
           width="full"

--- a/langwatch/src/pages/settings/governance/tool-catalog.tsx
+++ b/langwatch/src/pages/settings/governance/tool-catalog.tsx
@@ -62,7 +62,17 @@ function ToolCatalogPage() {
           <Spacer />
         </HStack>
 
-        <Tabs.Root variant="line" defaultValue="tool-tiles">
+        <Tabs.Root
+          variant="line"
+          defaultValue="tool-tiles"
+          // lazyMount only (no unmountOnExit): the Ingestion Templates tab
+          // renders drawers (EditOttlDrawer, CreateTemplateDrawer) with
+          // their own local form state (OTTL statements, new-template
+          // fields). Unmounting that tab while a drawer is open would
+          // destroy in-progress edits, so we avoid unmountOnExit for the
+          // whole Root and only skip mounting tabs that were never opened.
+          lazyMount
+        >
           <Tabs.List>
             <Tabs.Trigger
               value="tool-tiles"

--- a/langwatch/src/prompts/hooks/__tests__/useLatestPromptVersion.test.ts
+++ b/langwatch/src/prompts/hooks/__tests__/useLatestPromptVersion.test.ts
@@ -46,6 +46,25 @@ describe("useLatestPromptVersion", () => {
     });
   });
 
+  describe("when configured for the always-mounted tab label", () => {
+    it("disables window-focus refetch so N open tabs don't re-storm", () => {
+      mockUseQuery.mockReturnValue({
+        data: { version: 3 },
+        isLoading: false,
+        isFetching: false,
+      });
+
+      renderHook(() =>
+        useLatestPromptVersion({ configId: "config-123", currentVersion: 3 }),
+      );
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ idOrHandle: "config-123" }),
+        expect.objectContaining({ refetchOnWindowFocus: false }),
+      );
+    });
+  });
+
   describe("when current version matches latest", () => {
     it("returns isOutdated as false", () => {
       mockUseQuery.mockReturnValue({

--- a/langwatch/src/prompts/hooks/useLatestPromptVersion.ts
+++ b/langwatch/src/prompts/hooks/useLatestPromptVersion.ts
@@ -51,8 +51,14 @@ export const useLatestPromptVersion = ({
     {
       enabled: !!configId && !!project?.id,
       // Runs in every open tab's always-mounted label (for the outdated
-      // badge). A new version is created via a save, which invalidates this
-      // key, so we don't need per-focus refetches for every open tab.
+      // badge). Deliberately save-driven, not focus-live: a save invalidates
+      // this key (see useHandleSavePrompt), so same-app version bumps update
+      // the badge, but we don't re-fetch for every open tab on each window
+      // focus — that was the N-tab storm this fix targets, and matches the
+      // codebase convention for dashboard queries (see useFilterParams).
+      // Tradeoff: a *different session's* new version isn't reflected until
+      // the next save/reload; true cross-session liveness would need a
+      // lightweight version-number endpoint (noted in #5585).
       staleTime: 30_000,
       refetchOnWindowFocus: false,
     },

--- a/langwatch/src/prompts/hooks/useLatestPromptVersion.ts
+++ b/langwatch/src/prompts/hooks/useLatestPromptVersion.ts
@@ -50,6 +50,11 @@ export const useLatestPromptVersion = ({
     },
     {
       enabled: !!configId && !!project?.id,
+      // Runs in every open tab's always-mounted label (for the outdated
+      // badge). A new version is created via a save, which invalidates this
+      // key, so we don't need per-focus refetches for every open tab.
+      staleTime: 30_000,
+      refetchOnWindowFocus: false,
     },
   );
 

--- a/langwatch/src/prompts/prompt-playground/hooks/useHasUnsavedChanges.ts
+++ b/langwatch/src/prompts/prompt-playground/hooks/useHasUnsavedChanges.ts
@@ -26,7 +26,13 @@ export function useHasUnsavedChanges(tabId: string): boolean {
   // baseline form values to compare against.
   const resolvedDefault = api.modelProvider.getResolvedDefault.useQuery(
     { projectId: project?.id ?? "", featureKey: "prompt.create_default" },
-    { enabled: !!project?.id },
+    {
+      enabled: !!project?.id,
+      // Project-level config; changes rarely. Don't re-fetch on every window
+      // focus — this hook runs in every open tab's always-mounted label.
+      staleTime: 5 * 60_000,
+      refetchOnWindowFocus: false,
+    },
   );
   const resolvedDefaultModel = resolvedDefault.data?.model;
 
@@ -46,6 +52,11 @@ export function useHasUnsavedChanges(tabId: string): boolean {
       },
       {
         enabled: !!configId && !!project?.id,
+        // This runs in every open tab's always-mounted label. The saved
+        // version is stable within a session (a save invalidates this key),
+        // so don't re-fetch it for every tab on each window focus.
+        staleTime: 30_000,
+        refetchOnWindowFocus: false,
       },
     );
 


### PR DESCRIPTION
# Related Issue

- Resolves #5454

## Why

Follow-up to #5454 / #5456. That PR fixed the prompt-playground tab *content* and the localStorage write amplification, and deliberately scoped out two remaining buckets, tracked as **#5585** (the tab-label query layer) and **#5455** (the same anti-patterns in other features). This PR closes both.

Closes #5585
Closes #5455

## What changed

**#5585 — prompt tab-label queries stop re-storming on window focus.** The tab-bar labels are always mounted (one per open tab, outside the lazy content), and each fires full-prompt `getByIdOrHandle` queries via `useHasUnsavedChanges` and `useLatestPromptVersion`, plus `getResolvedDefault`. On React Query defaults (`staleTime: 0`, `refetchOnWindowFocus: true`) that meant N open tabs re-fired ~2N full-prompt fetches on every window focus. Added `staleTime` + `refetchOnWindowFocus: false` to the three label queries. Saves already invalidate `getByIdOrHandle` (`useHandleSavePrompt`), so the unsaved/outdated indicators stay correct.

**#5455 Pattern 1 — inactive `Tabs.Root` panels now unmount (or lazy-mount).** Six features had Ark UI `Tabs.Root` with no `lazyMount`/`unmountOnExit`, keeping every panel's queries/subtree alive. Applied per the same safety rule learned in #5456 (unmounting a panel with editable/live state loses user work):
- Full `lazyMount unmountOnExit` where panels are query/display-only: `LLMMetrics`, `UserMetrics` (CustomGraph analytics), `DSPyExperiment` (read-only result tables).
- `lazyMount` only (no unmount) where a panel holds editable/live state: `TraceDetails` (Thread tab reaches `AnnotationComment`'s `useForm` draft), `PlaygroundContent` (SpanEditorPanel), `tool-catalog` (Ingestion Templates edit drawers).

**#5455 Pattern 2 — popover queries gated on open.** `SecretsIndicator` (`api.secrets.list` had no `enabled` clause) and `SaveAndRunMenu` (`api.agents.getAll`) now fetch only when their popover opens; both triggers are static. Two candidates deliberately NOT gated because their query data is used outside the popover (gating would break rendering, not just defer a fetch): `TraceOverflowMenu` and `EvaluationStatusItem`.

**#5455 Pattern 3 — held, with reason.** The three zundo undo-history stores: `useWorkflowStore` and `useEvaluationsV3Store` already wrap `handleSet` in a `debounce`, so their `partialize`/`equality`-over-collection only runs on the debounced undo-push, not every `set()` — already mitigated. `usePlaygroundStore` lacks the debounce and is the only real candidate, but adding one changes undo granularity (a behavior change) and there's no evidence it causes jank. Per #5455's own "evaluate before changing" note, this should be profile-driven if a symptom surfaces; not changed blind here. Tracked as #5589.

## Test plan

- `useLatestPromptVersion.test.ts` — added a case asserting the label query is configured with `refetchOnWindowFocus: false`.
- `SecretsIndicator.integration.test.tsx` (existing) — passes; it opens the popover then waits for secrets, so it validates the `enabled: open` gating end-to-end.
- `pnpm typecheck` clean across all 11 files.
- Pattern 1 components have no existing unit tests, and Ark's unmount-on-exit isn't reproducible in jsdom (a test asserting it would be non-discriminating, per #5456), so those rely on typecheck + the established prop pattern. TraceDetails integration tests are Docker/ClickHouse-backed — recommend running in CI.

## Anything surprising?

The sweep's Pattern 1 assumption that all panels were "read-only" didn't hold in two cases — `TraceDetails` (annotation-comment draft) and `PlaygroundContent` (span editor) hold editable state — so those got `lazyMount`-only instead of full unmount, avoiding a repeat of the state-loss class we hit in #5456. And Pattern 3's premise was partly stale: two of the three stores were already debounced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabs in multiple areas now lazily mount tab content and unmount inactive panels to reduce unnecessary rendering.

* **Bug Fixes**
  * Preserves in-progress drafts and edits when switching tabs.
  * Reduces prompt flicker by tuning query caching and disabling refetch-on-window-focus.
  * Loads secrets and agent lists only after the relevant popover/menu is opened.

* **Tests**
  * Added unit and integration coverage for lazy tab behavior and fetch-on-open query enabling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->