### PR TITLE
feat(billing): send internal Slack alert on Stripe payment failure

### DIFF
--- a/langwatch/ee/billing/__tests__/notification.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/notification.service.unit.test.ts
@@ -355,9 +355,10 @@ describe("NotificationService", () => {
         organizationId: "org_1",
         organizationName: "Acme",
         plan: "LAUNCH",
-        dbSubscriptionId: "sub_db_1",
+        subscriptionId: "sub_db_1",
         stripeSubscriptionId: "sub_stripe_1",
         livemode: true,
+        priorFailure: { kind: "same-invoice-retry" as const },
       };
 
       beforeEach(() => {
@@ -436,12 +437,30 @@ describe("NotificationService", () => {
         );
       });
 
+      /** @scenario Alert links to the test-mode Stripe dashboard for test-mode events */
+      it("labels the alert header as test mode for test-mode events", async () => {
+        await service.sendSlackSubscriptionEvent({
+          ...basePayload,
+          livemode: false,
+        });
+
+        expect(mockSlackSend).toHaveBeenCalledWith({
+          blocks: expect.arrayContaining([
+            expect.objectContaining({
+              type: "header",
+              text: expect.objectContaining({
+                text: "Subscription payment failed (test mode)",
+              }),
+            }),
+          ]),
+        });
+      });
+
       /** @scenario Alert includes the failed amount in the invoice currency */
       it("shows the amount formatted in the invoice currency", async () => {
         await service.sendSlackSubscriptionEvent({
           ...basePayload,
-          amountDueCents: 3400,
-          currency: "eur",
+          amountDue: { cents: 3400, currency: "eur" },
         });
 
         const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
@@ -454,8 +473,7 @@ describe("NotificationService", () => {
       it("omits the amount line when no amount due is provided", async () => {
         await service.sendSlackSubscriptionEvent({
           ...basePayload,
-          amountDueCents: null,
-          currency: null,
+          amountDue: null,
         });
 
         expect(mockSlackSend).toHaveBeenCalled();
@@ -466,10 +484,10 @@ describe("NotificationService", () => {
       });
 
       /** @scenario First payment failure signals no prior failure */
-      it("indicates this is the first recorded failure when there is no previous failure", async () => {
+      it("indicates there is no prior unresolved failure", async () => {
         await service.sendSlackSubscriptionEvent({
           ...basePayload,
-          previousFailureAt: null,
+          priorFailure: { kind: "no-prior-failure" },
         });
 
         const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
@@ -477,42 +495,35 @@ describe("NotificationService", () => {
         const contextText = contextBlock.elements
           .map((e: any) => e.text)
           .join(" ");
-        expect(contextText.toLowerCase()).toContain("first recorded failure");
+        expect(contextText.toLowerCase()).toContain(
+          "no prior unresolved failure",
+        );
       });
 
       /** @scenario A retry of the same invoice is labelled by its attempt count, not as a repeat failure */
       it("shows the attempt count and does not claim an earlier dunning cycle", async () => {
-        const invoiceCreatedAt = new Date("2026-01-01T00:00:00Z");
-        const laterFailure = new Date("2026-01-02T00:00:00Z");
-
         await service.sendSlackSubscriptionEvent({
           ...basePayload,
           attemptCount: 3,
-          previousFailureAt: laterFailure,
-          invoiceCreatedAt,
+          priorFailure: { kind: "same-invoice-retry" },
         });
 
         const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
         const dataBlock = sentBlocks.find((b: any) => b.type === "section");
         const fieldText = dataBlock.fields.map((f: any) => f.text).join(" ");
-        expect(fieldText).toContain("Attempt 3 for this invoice");
+        expect(fieldText).toContain("*Attempt:* 3 for this invoice");
 
         const contextBlock = sentBlocks.find((b: any) => b.type === "context");
-        const contextText = contextBlock
-          ? contextBlock.elements.map((e: any) => e.text).join(" ")
-          : "";
-        expect(contextText).not.toContain("Previous failure:");
+        expect(contextBlock).toBeUndefined();
       });
 
       /** @scenario A failure with a prior failure from before the current invoice surfaces the previous failure date */
-      it("shows the previous failure date when it predates the current invoice", async () => {
+      it("shows the previous failure date for an earlier-cycle failure", async () => {
         const earlierFailure = new Date("2025-12-01T00:00:00Z");
-        const invoiceCreatedAt = new Date("2026-01-01T00:00:00Z");
 
         await service.sendSlackSubscriptionEvent({
           ...basePayload,
-          previousFailureAt: earlierFailure,
-          invoiceCreatedAt,
+          priorFailure: { kind: "earlier-cycle", at: earlierFailure },
         });
 
         const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
@@ -521,6 +532,7 @@ describe("NotificationService", () => {
           .map((e: any) => e.text)
           .join(" ");
         expect(contextText).toContain("Previous failure:");
+        expect(contextText).toContain("Dec 1, 2025");
       });
     });
   });

--- a/langwatch/ee/billing/__tests__/notification.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/notification.service.unit.test.ts
@@ -348,6 +348,181 @@ describe("NotificationService", () => {
         expect(actionsBlock.elements[0].url).toContain("org_1");
       });
     });
+
+    describe("when sending a payment-failed subscription event", () => {
+      const basePayload = {
+        type: "payment_failed" as const,
+        organizationId: "org_1",
+        organizationName: "Acme",
+        plan: "LAUNCH",
+        dbSubscriptionId: "sub_db_1",
+        stripeSubscriptionId: "sub_stripe_1",
+        livemode: true,
+      };
+
+      beforeEach(() => {
+        config.slackSubscriptionsChannel = "https://hooks.slack.com/subs";
+      });
+
+      /** @scenario Payment failure on a known subscription sends a payment-failed Slack alert */
+      it("sends Slack blocks with the 'Subscription payment failed' header", async () => {
+        await service.sendSlackSubscriptionEvent(basePayload);
+
+        expect(mockSlackSend).toHaveBeenCalledWith({
+          blocks: expect.arrayContaining([
+            expect.objectContaining({
+              type: "header",
+              text: expect.objectContaining({
+                text: "Subscription payment failed",
+              }),
+            }),
+          ]),
+        });
+      });
+
+      /** @scenario Payment failure on a known subscription sends a payment-failed Slack alert */
+      it("includes the organization name and plan", async () => {
+        await service.sendSlackSubscriptionEvent(basePayload);
+
+        const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
+        const dataBlock = sentBlocks.find((b: any) => b.type === "section");
+        const fieldText = dataBlock.fields.map((f: any) => f.text).join(" ");
+        expect(fieldText).toContain("Acme");
+        expect(fieldText).toContain("LAUNCH");
+      });
+
+      /** @scenario Payment failure on a known subscription sends a payment-failed Slack alert */
+      it("links to the organization admin page", async () => {
+        await service.sendSlackSubscriptionEvent(basePayload);
+
+        const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
+        const actionsBlock = sentBlocks.find((b: any) => b.type === "actions");
+        const adminButton = actionsBlock.elements.find((e: any) =>
+          e.url.includes("/organizations/"),
+        );
+        expect(adminButton).toBeDefined();
+        expect(adminButton.url).toContain("org_1");
+      });
+
+      /** @scenario Payment failure on a known subscription sends a payment-failed Slack alert */
+      it("links to the Stripe subscription using the Stripe subscription id", async () => {
+        await service.sendSlackSubscriptionEvent(basePayload);
+
+        const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
+        const actionsBlock = sentBlocks.find((b: any) => b.type === "actions");
+        const stripeButton = actionsBlock.elements.find((e: any) =>
+          e.url.includes("dashboard.stripe.com"),
+        );
+        expect(stripeButton).toBeDefined();
+        expect(stripeButton.url).toBe(
+          "https://dashboard.stripe.com/subscriptions/sub_stripe_1",
+        );
+      });
+
+      /** @scenario Alert links to the test-mode Stripe dashboard for test-mode events */
+      it("points the Stripe link at the test-mode dashboard for test-mode events", async () => {
+        await service.sendSlackSubscriptionEvent({
+          ...basePayload,
+          livemode: false,
+        });
+
+        const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
+        const actionsBlock = sentBlocks.find((b: any) => b.type === "actions");
+        const stripeButton = actionsBlock.elements.find((e: any) =>
+          e.url.includes("dashboard.stripe.com"),
+        );
+        expect(stripeButton.url).toBe(
+          "https://dashboard.stripe.com/test/subscriptions/sub_stripe_1",
+        );
+      });
+
+      /** @scenario Alert includes the failed amount in the invoice currency */
+      it("shows the amount formatted in the invoice currency", async () => {
+        await service.sendSlackSubscriptionEvent({
+          ...basePayload,
+          amountDueCents: 3400,
+          currency: "eur",
+        });
+
+        const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
+        const dataBlock = sentBlocks.find((b: any) => b.type === "section");
+        const fieldText = dataBlock.fields.map((f: any) => f.text).join(" ");
+        expect(fieldText).toContain("€34.00");
+      });
+
+      /** @scenario Alert is still sent when the event payload lacks an invoice amount */
+      it("omits the amount line when no amount due is provided", async () => {
+        await service.sendSlackSubscriptionEvent({
+          ...basePayload,
+          amountDueCents: null,
+          currency: null,
+        });
+
+        expect(mockSlackSend).toHaveBeenCalled();
+        const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
+        const dataBlock = sentBlocks.find((b: any) => b.type === "section");
+        const fieldText = dataBlock.fields.map((f: any) => f.text).join(" ");
+        expect(fieldText).not.toContain("Amount due");
+      });
+
+      /** @scenario First payment failure signals no prior failure */
+      it("indicates this is the first recorded failure when there is no previous failure", async () => {
+        await service.sendSlackSubscriptionEvent({
+          ...basePayload,
+          previousFailureAt: null,
+        });
+
+        const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
+        const contextBlock = sentBlocks.find((b: any) => b.type === "context");
+        const contextText = contextBlock.elements
+          .map((e: any) => e.text)
+          .join(" ");
+        expect(contextText.toLowerCase()).toContain("first recorded failure");
+      });
+
+      /** @scenario A retry of the same invoice is labelled by its attempt count, not as a repeat failure */
+      it("shows the attempt count and does not claim an earlier dunning cycle", async () => {
+        const invoiceCreatedAt = new Date("2026-01-01T00:00:00Z");
+        const laterFailure = new Date("2026-01-02T00:00:00Z");
+
+        await service.sendSlackSubscriptionEvent({
+          ...basePayload,
+          attemptCount: 3,
+          previousFailureAt: laterFailure,
+          invoiceCreatedAt,
+        });
+
+        const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
+        const dataBlock = sentBlocks.find((b: any) => b.type === "section");
+        const fieldText = dataBlock.fields.map((f: any) => f.text).join(" ");
+        expect(fieldText).toContain("Attempt 3 for this invoice");
+
+        const contextBlock = sentBlocks.find((b: any) => b.type === "context");
+        const contextText = contextBlock
+          ? contextBlock.elements.map((e: any) => e.text).join(" ")
+          : "";
+        expect(contextText).not.toContain("Previous failure:");
+      });
+
+      /** @scenario A failure with a prior failure from before the current invoice surfaces the previous failure date */
+      it("shows the previous failure date when it predates the current invoice", async () => {
+        const earlierFailure = new Date("2025-12-01T00:00:00Z");
+        const invoiceCreatedAt = new Date("2026-01-01T00:00:00Z");
+
+        await service.sendSlackSubscriptionEvent({
+          ...basePayload,
+          previousFailureAt: earlierFailure,
+          invoiceCreatedAt,
+        });
+
+        const sentBlocks = mockSlackSend.mock.calls[0]![0].blocks;
+        const contextBlock = sentBlocks.find((b: any) => b.type === "context");
+        const contextText = contextBlock.elements
+          .map((e: any) => e.text)
+          .join(" ");
+        expect(contextText).toContain("Previous failure:");
+      });
+    });
   });
 
   describe("sendSlackSignupEvent()", () => {

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -23,6 +23,23 @@ vi.mock("../../../src/server/app-layer/app", () => ({
   }),
 }));
 
+// createLogger runs at webhookService module load (before this file's const
+// initializers), so the logger spies must be hoisted with the mock itself.
+const { mockLoggerWarn, mockLoggerError, mockLoggerInfo } = vi.hoisted(() => ({
+  mockLoggerWarn: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+}));
+
+vi.mock("../../../src/utils/logger", () => ({
+  createLogger: () => ({
+    warn: mockLoggerWarn,
+    error: mockLoggerError,
+    info: mockLoggerInfo,
+    debug: vi.fn(),
+  }),
+}));
+
 import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
 import type {
   SubscriptionRepository,
@@ -127,6 +144,15 @@ const makeSubscriptionWithOrg = (
     },
   } as unknown as SubscriptionWithOrg;
 };
+
+const makeInvoice = (overrides: Record<string, unknown> = {}) => ({
+  id: "in_1",
+  amount_due: 5000,
+  currency: "usd",
+  attempt_count: 1,
+  created: Math.floor(new Date("2026-01-01T00:00:00Z").getTime() / 1000),
+  ...overrides,
+});
 
 const createMockStripe = (overrides: Record<string, unknown> = {}) => ({
   subscriptions: {
@@ -801,17 +827,22 @@ describe("webhookService", () => {
 
   describe("handleInvoicePaymentFailed()", () => {
     describe("when no subscription found", () => {
-      it("skips without error", async () => {
+      /** @scenario Unknown subscription keeps warn-and-skip with no alert */
+      it("logs a warning and skips without recording or notifying", async () => {
         subRepo.findByStripeId.mockResolvedValue(null);
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_missing",
+          invoice: makeInvoice() as any,
+          livemode: true,
         });
 
         await vi.advanceTimersByTimeAsync(2000);
         await promise;
 
         expect(subRepo.recordPaymentFailure).not.toHaveBeenCalled();
+        expect(mockSendSlackSubscriptionEvent).not.toHaveBeenCalled();
+        expect(mockLoggerWarn).toHaveBeenCalled();
       });
     });
 
@@ -821,9 +852,12 @@ describe("webhookService", () => {
         subRepo.findByStripeId.mockResolvedValue(
           makeSubscription({ status: SubscriptionStatus.ACTIVE }),
         );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_1",
+          invoice: makeInvoice() as any,
+          livemode: true,
         });
 
         await vi.advanceTimersByTimeAsync(2000);
@@ -842,9 +876,12 @@ describe("webhookService", () => {
         subRepo.findByStripeId.mockResolvedValue(
           makeSubscription({ status: SubscriptionStatus.PENDING }),
         );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_1",
+          invoice: makeInvoice() as any,
+          livemode: true,
         });
 
         await vi.advanceTimersByTimeAsync(2000);
@@ -854,6 +891,258 @@ describe("webhookService", () => {
           id: "sub_db_1",
           currentStatus: SubscriptionStatus.PENDING,
         });
+      });
+    });
+
+    describe("when Stripe fires a payment failure for a known subscription", () => {
+      /** @scenario Payment failure on a known subscription sends a payment-failed Slack alert */
+      it("sends a payment-failed notification with org, plan, subscription ids, and livemode", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            plan: "LAUNCH",
+          }),
+        );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice() as any,
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "payment_failed",
+            organizationId: "org_123",
+            organizationName: "Acme",
+            plan: "LAUNCH",
+            dbSubscriptionId: "sub_db_1",
+            stripeSubscriptionId: "sub_stripe_1",
+            livemode: true,
+          }),
+        );
+      });
+
+      /** @scenario Alert links to the test-mode Stripe dashboard for test-mode events */
+      it("passes livemode:false through for test-mode events", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE }),
+        );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice() as any,
+          livemode: false,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ livemode: false }),
+        );
+      });
+
+      /** @scenario Alert includes the failed amount in the invoice currency */
+      it("passes the invoice's amount due and currency", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE }),
+        );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice({ amount_due: 3400, currency: "eur" }) as any,
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ amountDueCents: 3400, currency: "eur" }),
+        );
+      });
+
+      /** @scenario Alert is still sent when the event payload lacks an invoice amount */
+      it("sends the notification with a null amount when the invoice carries none", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE }),
+        );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice({
+            amount_due: null,
+            currency: null,
+          }) as any,
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ amountDueCents: null, currency: null }),
+        );
+      });
+    });
+
+    describe("when the subscription has never had a payment failure", () => {
+      /** @scenario First payment failure signals no prior failure */
+      it("passes a null previousFailureAt", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            lastPaymentFailedDate: null,
+          }),
+        );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice() as any,
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ previousFailureAt: null }),
+        );
+      });
+    });
+
+    describe("when a recorded failure exists from after the current invoice was created", () => {
+      /** @scenario A retry of the same invoice is labelled by its attempt count, not as a repeat failure */
+      it("passes the attempt count and does not claim an earlier dunning cycle", async () => {
+        const invoiceCreatedAt = new Date("2026-01-01T00:00:00Z");
+        const laterFailure = new Date("2026-01-02T00:00:00Z");
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            lastPaymentFailedDate: laterFailure,
+          }),
+        );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice({
+            attempt_count: 3,
+            created: Math.floor(invoiceCreatedAt.getTime() / 1000),
+          }) as any,
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            attemptCount: 3,
+            previousFailureAt: laterFailure,
+            invoiceCreatedAt,
+          }),
+        );
+        // The recorded failure is AFTER the invoice was created (a retry of
+        // this same invoice), not before it — not an earlier dunning cycle.
+        expect(laterFailure.getTime()).toBeGreaterThan(
+          invoiceCreatedAt.getTime(),
+        );
+      });
+    });
+
+    describe("when a recorded failure exists from before the current invoice was created", () => {
+      /** @scenario A failure with a prior failure from before the current invoice surfaces the previous failure date */
+      it("passes the earlier previousFailureAt alongside invoiceCreatedAt", async () => {
+        const earlierFailure = new Date("2025-12-01T00:00:00Z");
+        const invoiceCreatedAt = new Date("2026-01-01T00:00:00Z");
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            lastPaymentFailedDate: earlierFailure,
+          }),
+        );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice({
+            created: Math.floor(invoiceCreatedAt.getTime() / 1000),
+          }) as any,
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            previousFailureAt: earlierFailure,
+            invoiceCreatedAt,
+          }),
+        );
+        expect(earlierFailure.getTime()).toBeLessThan(
+          invoiceCreatedAt.getTime(),
+        );
+      });
+    });
+
+    describe("when the subscription is already cancelled in the database", () => {
+      /** @scenario Late payment failure on a cancelled subscription is skipped without an alert */
+      it("does not record the failure, change status, or notify", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.CANCELLED }),
+        );
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice() as any,
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(subRepo.recordPaymentFailure).not.toHaveBeenCalled();
+        expect(subRepo.cancel).not.toHaveBeenCalled();
+        expect(mockSendSlackSubscriptionEvent).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when assembling or sending the notification throws", () => {
+      /** @scenario Notification failure never fails the webhook */
+      it("still records the failure, resolves successfully, and logs the failure", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE }),
+        );
+        orgRepo.findNameById.mockRejectedValue(
+          new Error("DB connection lost"),
+        );
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice() as any,
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        // Should not throw — the notification error is caught inside the handler.
+        await expect(promise).resolves.toBeUndefined();
+
+        expect(subRepo.recordPaymentFailure).toHaveBeenCalledWith({
+          id: "sub_db_1",
+          currentStatus: SubscriptionStatus.ACTIVE,
+        });
+        expect(mockLoggerError).toHaveBeenCalled();
       });
     });
   });

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -40,6 +40,7 @@ vi.mock("../../../src/utils/logger", () => ({
   }),
 }));
 
+import type Stripe from "stripe";
 import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
 import type {
   SubscriptionRepository,
@@ -79,6 +80,7 @@ const createMockOrganizationRepository = () => ({
   getPricingModel: vi.fn(),
   getStripeCustomerId: vi.fn(),
   findNameById: vi.fn(),
+  findByStripeCustomerId: vi.fn(),
 });
 
 const createMockItemCalculator = () => ({
@@ -145,14 +147,15 @@ const makeSubscriptionWithOrg = (
   } as unknown as SubscriptionWithOrg;
 };
 
-const makeInvoice = (overrides: Record<string, unknown> = {}) => ({
-  id: "in_1",
-  amount_due: 5000,
-  currency: "usd",
-  attempt_count: 1,
-  created: Math.floor(new Date("2026-01-01T00:00:00Z").getTime() / 1000),
-  ...overrides,
-});
+const makeInvoice = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: "in_1",
+    amount_due: 5000,
+    currency: "usd",
+    attempt_count: 1,
+    created: Math.floor(new Date("2026-01-01T00:00:00Z").getTime() / 1000),
+    ...overrides,
+  }) as unknown as Stripe.Invoice;
 
 const createMockStripe = (overrides: Record<string, unknown> = {}) => ({
   subscriptions: {
@@ -833,7 +836,7 @@ describe("webhookService", () => {
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_missing",
-          invoice: makeInvoice() as any,
+          invoice: makeInvoice(),
           livemode: true,
         });
 
@@ -856,7 +859,7 @@ describe("webhookService", () => {
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_1",
-          invoice: makeInvoice() as any,
+          invoice: makeInvoice(),
           livemode: true,
         });
 
@@ -880,7 +883,7 @@ describe("webhookService", () => {
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_1",
-          invoice: makeInvoice() as any,
+          invoice: makeInvoice(),
           livemode: true,
         });
 
@@ -907,7 +910,7 @@ describe("webhookService", () => {
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_stripe_1",
-          invoice: makeInvoice() as any,
+          invoice: makeInvoice(),
           livemode: true,
         });
 
@@ -920,7 +923,7 @@ describe("webhookService", () => {
             organizationId: "org_123",
             organizationName: "Acme",
             plan: "LAUNCH",
-            dbSubscriptionId: "sub_db_1",
+            subscriptionId: "sub_db_1",
             stripeSubscriptionId: "sub_stripe_1",
             livemode: true,
           }),
@@ -936,7 +939,7 @@ describe("webhookService", () => {
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_stripe_1",
-          invoice: makeInvoice() as any,
+          invoice: makeInvoice(),
           livemode: false,
         });
 
@@ -957,7 +960,7 @@ describe("webhookService", () => {
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_stripe_1",
-          invoice: makeInvoice({ amount_due: 3400, currency: "eur" }) as any,
+          invoice: makeInvoice({ amount_due: 3400, currency: "eur" }),
           livemode: true,
         });
 
@@ -965,7 +968,9 @@ describe("webhookService", () => {
         await promise;
 
         expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
-          expect.objectContaining({ amountDueCents: 3400, currency: "eur" }),
+          expect.objectContaining({
+            amountDue: { cents: 3400, currency: "eur" },
+          }),
         );
       });
 
@@ -981,7 +986,7 @@ describe("webhookService", () => {
           invoice: makeInvoice({
             amount_due: null,
             currency: null,
-          }) as any,
+          }),
           livemode: true,
         });
 
@@ -989,14 +994,14 @@ describe("webhookService", () => {
         await promise;
 
         expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
-          expect.objectContaining({ amountDueCents: null, currency: null }),
+          expect.objectContaining({ amountDue: null }),
         );
       });
     });
 
     describe("when the subscription has never had a payment failure", () => {
       /** @scenario First payment failure signals no prior failure */
-      it("passes a null previousFailureAt", async () => {
+      it("classifies the failure as having no prior failure", async () => {
         subRepo.findByStripeId.mockResolvedValue(
           makeSubscription({
             status: SubscriptionStatus.ACTIVE,
@@ -1007,7 +1012,7 @@ describe("webhookService", () => {
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_stripe_1",
-          invoice: makeInvoice() as any,
+          invoice: makeInvoice(),
           livemode: true,
         });
 
@@ -1015,7 +1020,9 @@ describe("webhookService", () => {
         await promise;
 
         expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
-          expect.objectContaining({ previousFailureAt: null }),
+          expect.objectContaining({
+            priorFailure: { kind: "no-prior-failure" },
+          }),
         );
       });
     });
@@ -1048,14 +1055,8 @@ describe("webhookService", () => {
         expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
           expect.objectContaining({
             attemptCount: 3,
-            previousFailureAt: laterFailure,
-            invoiceCreatedAt,
+            priorFailure: { kind: "same-invoice-retry" },
           }),
-        );
-        // The recorded failure is AFTER the invoice was created (a retry of
-        // this same invoice), not before it — not an earlier dunning cycle.
-        expect(laterFailure.getTime()).toBeGreaterThan(
-          invoiceCreatedAt.getTime(),
         );
       });
     });
@@ -1086,12 +1087,87 @@ describe("webhookService", () => {
 
         expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
           expect.objectContaining({
-            previousFailureAt: earlierFailure,
-            invoiceCreatedAt,
+            priorFailure: { kind: "earlier-cycle", at: earlierFailure },
           }),
         );
-        expect(earlierFailure.getTime()).toBeLessThan(
-          invoiceCreatedAt.getTime(),
+      });
+    });
+
+    describe("when the recorded failure and the invoice creation share the same timestamp", () => {
+      it("classifies a same-invoice retry, not an earlier cycle", async () => {
+        const boundary = new Date("2026-01-01T00:00:00Z");
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            lastPaymentFailedDate: boundary,
+          }),
+        );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice({
+            created: Math.floor(boundary.getTime() / 1000),
+          }),
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            priorFailure: { kind: "same-invoice-retry" },
+          }),
+        );
+      });
+    });
+
+    describe("when the invoice carries no creation date", () => {
+      it("does not claim an earlier cycle without a boundary to compare against", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({
+            status: SubscriptionStatus.ACTIVE,
+            lastPaymentFailedDate: new Date("2025-12-01T00:00:00Z"),
+          }),
+        );
+        orgRepo.findNameById.mockResolvedValue({ id: "org_123", name: "Acme" });
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice({ created: null }),
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            priorFailure: { kind: "same-invoice-retry" },
+          }),
+        );
+      });
+    });
+
+    describe("when the organization lookup returns nothing", () => {
+      it("falls back to an unknown organization name and still alerts", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE }),
+        );
+        orgRepo.findNameById.mockResolvedValue(null);
+
+        const promise = service.handleInvoicePaymentFailed({
+          subscriptionId: "sub_stripe_1",
+          invoice: makeInvoice(),
+          livemode: true,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ organizationName: "Unknown" }),
         );
       });
     });
@@ -1105,7 +1181,7 @@ describe("webhookService", () => {
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_stripe_1",
-          invoice: makeInvoice() as any,
+          invoice: makeInvoice(),
           livemode: true,
         });
 
@@ -1130,7 +1206,7 @@ describe("webhookService", () => {
 
         const promise = service.handleInvoicePaymentFailed({
           subscriptionId: "sub_stripe_1",
-          invoice: makeInvoice() as any,
+          invoice: makeInvoice(),
           livemode: true,
         });
 
@@ -1143,6 +1219,59 @@ describe("webhookService", () => {
           currentStatus: SubscriptionStatus.ACTIVE,
         });
         expect(mockLoggerError).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("handleEvent() with checkout.session.completed", () => {
+    describe("when the analytics emitter throws", () => {
+      it("still acknowledges the webhook and logs the failure", async () => {
+        subRepo.linkStripeId.mockResolvedValue({ count: 1 });
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE }),
+        );
+        orgRepo.findByStripeCustomerId.mockResolvedValue({ id: "org_123" });
+
+        const throwingService = new EEWebhookService({
+          subscriptionRepository: subRepo as unknown as SubscriptionRepository,
+          organizationRepository: orgRepo as unknown as OrganizationRepository,
+          stripe: mockStripeInstance as any,
+          itemCalculator,
+          getPostHog: () =>
+            ({
+              capture: () => {
+                throw new Error("posthog down");
+              },
+              groupIdentify: vi.fn(),
+            }) as any,
+        });
+
+        const promise = throwingService.handleEvent({
+          id: "evt_1",
+          type: "checkout.session.completed",
+          livemode: true,
+          data: {
+            object: {
+              subscription: "sub_stripe_1",
+              customer: "cus_1",
+              client_reference_id: "subscription_setup_sub_db_1",
+              metadata: {},
+              created: 1735689600,
+            },
+          },
+        } as unknown as Stripe.Event);
+
+        await vi.advanceTimersByTimeAsync(2000);
+        const result = await promise;
+
+        expect(result).toEqual({ status: "ok" });
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          expect.objectContaining({ err: expect.any(Error) }),
+          expect.stringContaining("checkout analytics"),
+        );
       });
     });
   });

--- a/langwatch/ee/billing/notifications/notification.service.ts
+++ b/langwatch/ee/billing/notifications/notification.service.ts
@@ -86,6 +86,18 @@ const formatDate = (value?: Date | null) =>
       }).format(value)
     : "Now";
 
+const formatCurrencyCents = ({
+  cents,
+  currency,
+}: {
+  cents: number;
+  currency: string;
+}) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(cents / 100);
+
 const buildProspectiveBlocks = (
   payload: ProspectiveNotification,
   adminLink: string,
@@ -273,87 +285,90 @@ const getStripeSubscriptionLink = ({
 }): string =>
   `https://dashboard.stripe.com/${livemode ? "" : "test/"}subscriptions/${stripeSubscriptionId}`;
 
+const paymentFailedContextText = (
+  priorFailure: PaymentFailedNotification["priorFailure"],
+): string | null => {
+  switch (priorFailure.kind) {
+    case "no-prior-failure":
+      return "No prior unresolved failure for this subscription.";
+    case "earlier-cycle":
+      return `Previous failure: ${formatDate(priorFailure.at)}`;
+    case "same-invoice-retry":
+      return null;
+  }
+};
+
 const buildPaymentFailedBlocks = (
   payload: PaymentFailedNotification,
   adminLink: string,
-): NonNullable<IncomingWebhookSendArguments["blocks"]> => {
-  const fields: Array<{ type: "mrkdwn"; text: string }> = [
-    { type: "mrkdwn", text: `*Organization:* ${payload.organizationName}` },
-    { type: "mrkdwn", text: `*Plan:* ${payload.plan}` },
-  ];
+): IncomingWebhookSendArguments["blocks"] => {
+  const contextText = paymentFailedContextText(payload.priorFailure);
 
-  if (payload.amountDueCents != null && payload.currency) {
-    const amountFormatted = new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: payload.currency,
-    }).format(payload.amountDueCents / 100);
-    fields.push({ type: "mrkdwn", text: `*Amount due:* ${amountFormatted}` });
-  }
-
-  if (payload.attemptCount != null) {
-    fields.push({
-      type: "mrkdwn",
-      text: `Attempt ${payload.attemptCount} for this invoice`,
-    });
-  }
-
-  // The retry signal comes from the event itself, not elapsed time: a
-  // previous failure recorded before the current invoice was created marks
-  // an earlier dunning cycle. A previous failure recorded after (e.g. a
-  // retry of this same invoice) is already covered by the attempt count
-  // above and must not be mislabelled as an earlier cycle.
-  const isEarlierDunningCycle =
-    !!payload.previousFailureAt &&
-    !!payload.invoiceCreatedAt &&
-    payload.previousFailureAt.getTime() < payload.invoiceCreatedAt.getTime();
-
-  const contextElements: Array<{ type: "mrkdwn"; text: string }> = [];
-  if (!payload.previousFailureAt) {
-    contextElements.push({
-      type: "mrkdwn",
-      text: "First recorded failure for this subscription.",
-    });
-  } else if (isEarlierDunningCycle) {
-    contextElements.push({
-      type: "mrkdwn",
-      text: `Previous failure: ${formatDate(payload.previousFailureAt)}`,
-    });
-  }
-
-  const blocks: NonNullable<IncomingWebhookSendArguments["blocks"]> = [
+  return [
     {
       type: "header",
-      text: { type: "plain_text", text: "Subscription payment failed" },
+      text: {
+        type: "plain_text",
+        text: payload.livemode
+          ? "Subscription payment failed"
+          : "Subscription payment failed (test mode)",
+      },
     },
-    { type: "section", fields },
+    {
+      type: "section",
+      fields: [
+        {
+          type: "mrkdwn",
+          text: `*Organization:* ${payload.organizationName}`,
+        },
+        { type: "mrkdwn", text: `*Plan:* ${payload.plan}` },
+        ...(payload.amountDue
+          ? [
+              {
+                type: "mrkdwn" as const,
+                text: `*Amount due:* ${formatCurrencyCents(payload.amountDue)}`,
+              },
+            ]
+          : []),
+        ...(payload.attemptCount != null
+          ? [
+              {
+                type: "mrkdwn" as const,
+                text: `*Attempt:* ${payload.attemptCount} for this invoice`,
+              },
+            ]
+          : []),
+      ],
+    },
+    ...(contextText
+      ? [
+          {
+            type: "context" as const,
+            elements: [{ type: "mrkdwn" as const, text: contextText }],
+          },
+        ]
+      : []),
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Open org in admin" },
+          url: adminLink,
+          action_id: "subscription_payment_failed_admin",
+        },
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Open in Stripe" },
+          url: getStripeSubscriptionLink({
+            stripeSubscriptionId: payload.stripeSubscriptionId,
+            livemode: payload.livemode,
+          }),
+          action_id: "subscription_payment_failed_stripe",
+        },
+      ],
+    },
   ];
-
-  if (contextElements.length > 0) {
-    blocks.push({ type: "context", elements: contextElements });
-  }
-
-  blocks.push({
-    type: "actions",
-    elements: [
-      {
-        type: "button",
-        text: { type: "plain_text", text: "Open org in admin" },
-        url: adminLink,
-        action_id: "subscription_payment_failed_admin",
-      },
-      {
-        type: "button",
-        text: { type: "plain_text", text: "Open in Stripe" },
-        url: getStripeSubscriptionLink({
-          stripeSubscriptionId: payload.stripeSubscriptionId,
-          livemode: payload.livemode,
-        }),
-        action_id: "subscription_payment_failed_stripe",
-      },
-    ],
-  });
-
-  return blocks;
 };
 
 // ---------------------------------------------------------------------------
@@ -569,10 +584,10 @@ export class NotificationService {
   async sendSlackLicensePurchase(
     payload: LicensePurchaseNotificationPayload,
   ): Promise<void> {
-    const amountFormatted = new Intl.NumberFormat("en-US", {
-      style: "currency",
+    const amountFormatted = formatCurrencyCents({
+      cents: payload.amountPaid,
       currency: payload.currency,
-    }).format(payload.amountPaid / 100);
+    });
 
     await this.sendSlackMessage({
       channelUrl: this.config.slackSubscriptionsChannel,

--- a/langwatch/ee/billing/notifications/notification.service.ts
+++ b/langwatch/ee/billing/notifications/notification.service.ts
@@ -55,6 +55,11 @@ type CancelledNotification = Extract<
   { type: "cancelled" }
 >;
 
+type PaymentFailedNotification = Extract<
+  SubscriptionNotificationPayload,
+  { type: "payment_failed" }
+>;
+
 type NotificationServiceOptions = {
   config: Pick<
     AppConfig,
@@ -259,6 +264,98 @@ const buildCancelledBlocks = (
   ];
 };
 
+const getStripeSubscriptionLink = ({
+  stripeSubscriptionId,
+  livemode,
+}: {
+  stripeSubscriptionId: string;
+  livemode: boolean;
+}): string =>
+  `https://dashboard.stripe.com/${livemode ? "" : "test/"}subscriptions/${stripeSubscriptionId}`;
+
+const buildPaymentFailedBlocks = (
+  payload: PaymentFailedNotification,
+  adminLink: string,
+): NonNullable<IncomingWebhookSendArguments["blocks"]> => {
+  const fields: Array<{ type: "mrkdwn"; text: string }> = [
+    { type: "mrkdwn", text: `*Organization:* ${payload.organizationName}` },
+    { type: "mrkdwn", text: `*Plan:* ${payload.plan}` },
+  ];
+
+  if (payload.amountDueCents != null && payload.currency) {
+    const amountFormatted = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: payload.currency,
+    }).format(payload.amountDueCents / 100);
+    fields.push({ type: "mrkdwn", text: `*Amount due:* ${amountFormatted}` });
+  }
+
+  if (payload.attemptCount != null) {
+    fields.push({
+      type: "mrkdwn",
+      text: `Attempt ${payload.attemptCount} for this invoice`,
+    });
+  }
+
+  // The retry signal comes from the event itself, not elapsed time: a
+  // previous failure recorded before the current invoice was created marks
+  // an earlier dunning cycle. A previous failure recorded after (e.g. a
+  // retry of this same invoice) is already covered by the attempt count
+  // above and must not be mislabelled as an earlier cycle.
+  const isEarlierDunningCycle =
+    !!payload.previousFailureAt &&
+    !!payload.invoiceCreatedAt &&
+    payload.previousFailureAt.getTime() < payload.invoiceCreatedAt.getTime();
+
+  const contextElements: Array<{ type: "mrkdwn"; text: string }> = [];
+  if (!payload.previousFailureAt) {
+    contextElements.push({
+      type: "mrkdwn",
+      text: "First recorded failure for this subscription.",
+    });
+  } else if (isEarlierDunningCycle) {
+    contextElements.push({
+      type: "mrkdwn",
+      text: `Previous failure: ${formatDate(payload.previousFailureAt)}`,
+    });
+  }
+
+  const blocks: NonNullable<IncomingWebhookSendArguments["blocks"]> = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "Subscription payment failed" },
+    },
+    { type: "section", fields },
+  ];
+
+  if (contextElements.length > 0) {
+    blocks.push({ type: "context", elements: contextElements });
+  }
+
+  blocks.push({
+    type: "actions",
+    elements: [
+      {
+        type: "button",
+        text: { type: "plain_text", text: "Open org in admin" },
+        url: adminLink,
+        action_id: "subscription_payment_failed_admin",
+      },
+      {
+        type: "button",
+        text: { type: "plain_text", text: "Open in Stripe" },
+        url: getStripeSubscriptionLink({
+          stripeSubscriptionId: payload.stripeSubscriptionId,
+          livemode: payload.livemode,
+        }),
+        action_id: "subscription_payment_failed_stripe",
+      },
+    ],
+  });
+
+  return blocks;
+};
+
 // ---------------------------------------------------------------------------
 // NotificationService - Channel dispatch (HOW to send)
 // ---------------------------------------------------------------------------
@@ -428,6 +525,9 @@ export class NotificationService {
         break;
       case "cancelled":
         blocks = buildCancelledBlocks(payload, adminLink);
+        break;
+      case "payment_failed":
+        blocks = buildPaymentFailedBlocks(payload, adminLink);
         break;
     }
 

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -421,24 +421,33 @@ export class EEWebhookService implements WebhookService {
     const posthog = this.getPostHog?.() ?? null;
     if (!posthog) return;
 
-    posthog.capture({
-      distinctId: organizationId,
-      event: "subscription_created",
-      properties: {
-        subscriptionId,
-        $groups: { organization: organizationId },
-      },
-    });
-    posthog.groupIdentify({
-      groupType: "organization",
-      groupKey: organizationId,
-      properties: {
-        subscriptionCreatedAt: new Date(
-          checkoutSession.created * 1000,
-        ).toISOString(),
-        hasActiveSubscription: true,
-      },
-    });
+    // Analytics failures must never fail the webhook — the checkout has
+    // already been linked and activated, and a 500 would make Stripe retry.
+    try {
+      posthog.capture({
+        distinctId: organizationId,
+        event: "subscription_created",
+        properties: {
+          subscriptionId,
+          $groups: { organization: organizationId },
+        },
+      });
+      posthog.groupIdentify({
+        groupType: "organization",
+        groupKey: organizationId,
+        properties: {
+          subscriptionCreatedAt: new Date(
+            checkoutSession.created * 1000,
+          ).toISOString(),
+          hasActiveSubscription: true,
+        },
+      });
+    } catch (err) {
+      logger.error(
+        { subscriptionId, err },
+        "[stripeWebhook] Failed to emit checkout analytics",
+      );
+    }
   }
 
   private async routeSubscriptionLifecycle(

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -1,4 +1,8 @@
-import { Currency, type PrismaClient } from "@prisma/client";
+import {
+  Currency,
+  type PrismaClient,
+  type Subscription,
+} from "@prisma/client";
 import type { PostHog } from "posthog-node";
 import type Stripe from "stripe";
 import { getApp } from "../../../src/server/app-layer/app";
@@ -15,6 +19,7 @@ import {
 } from "../../../src/server/data-retention/retentionPolicy.schema";
 import { createLogger } from "../../../src/utils/logger";
 import { SubscriptionRecordNotFoundError } from "../errors";
+import type { PaymentFailurePrior } from "../types";
 import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
 import { SubscriptionStatus } from "../planTypes";
 import {
@@ -61,6 +66,35 @@ export interface LicensePurchaseHandler {
 export type HandleEventResult =
   | { status: "ok" }
   | { status: "error"; httpStatus: 400 | 500; message: string };
+
+/**
+ * Classifies a previously recorded failure against the failing invoice's
+ * creation date. Elapsed time cannot tell a retry from a new failure (Stripe
+ * retries the same invoice days apart), so the invoice's creation is the
+ * cycle boundary: a prior failure recorded before it carried over from an
+ * earlier dunning cycle; one recorded after it belongs to this invoice's
+ * retries. Without an invoice creation date the earlier-cycle claim cannot
+ * be made truthfully, so the prior failure is treated as a same-invoice
+ * retry.
+ */
+export const classifyPriorFailure = ({
+  previousFailureAt,
+  invoiceCreatedAt,
+}: {
+  previousFailureAt: Date | null;
+  invoiceCreatedAt: Date | null;
+}): PaymentFailurePrior => {
+  if (!previousFailureAt) {
+    return { kind: "no-prior-failure" };
+  }
+  if (
+    invoiceCreatedAt &&
+    previousFailureAt.getTime() < invoiceCreatedAt.getTime()
+  ) {
+    return { kind: "earlier-cycle", at: previousFailureAt };
+  }
+  return { kind: "same-invoice-retry" };
+};
 
 /** Stripe webhooks can arrive before subscription state is fully consistent. */
 const STRIPE_EVENTUAL_CONSISTENCY_DELAY_MS = 2000;
@@ -597,39 +631,69 @@ export class EEWebhookService implements WebhookService {
       return;
     }
 
-    const previousFailureAt = currentSubscription.lastPaymentFailedDate;
+    // Read before recordPaymentFailure stamps a new date over it.
+    const priorFailure = classifyPriorFailure({
+      previousFailureAt: currentSubscription.lastPaymentFailedDate,
+      invoiceCreatedAt: invoice.created
+        ? new Date(invoice.created * 1000)
+        : null,
+    });
 
     await this.subscriptionRepository.recordPaymentFailure({
       id: currentSubscription.id,
       currentStatus: currentSubscription.status,
     });
 
-    // Notification failures must never fail the webhook — Stripe would
-    // retry delivery, and the payment failure has already been recorded.
+    await this.notifyPaymentFailed({
+      subscription: currentSubscription,
+      stripeSubscriptionId: subscriptionId,
+      invoice,
+      livemode,
+      priorFailure,
+    });
+  }
+
+  /**
+   * Best-effort by contract: a notification failure is logged and must never
+   * fail the webhook — Stripe would retry delivery, and the payment failure
+   * has already been recorded.
+   */
+  private async notifyPaymentFailed({
+    subscription,
+    stripeSubscriptionId,
+    invoice,
+    livemode,
+    priorFailure,
+  }: {
+    subscription: Subscription;
+    stripeSubscriptionId: string;
+    invoice: Stripe.Invoice;
+    livemode: boolean;
+    priorFailure: PaymentFailurePrior;
+  }): Promise<void> {
     try {
       const org = await this.organizationRepository.findNameById(
-        currentSubscription.organizationId,
+        subscription.organizationId,
       );
 
       await getApp().notifications.sendSlackSubscriptionEvent({
         type: "payment_failed",
-        organizationId: currentSubscription.organizationId,
+        organizationId: subscription.organizationId,
         organizationName: org?.name ?? "Unknown",
-        plan: currentSubscription.plan,
-        dbSubscriptionId: currentSubscription.id,
-        stripeSubscriptionId: subscriptionId,
+        plan: subscription.plan,
+        subscriptionId: subscription.id,
+        stripeSubscriptionId,
         livemode,
-        amountDueCents: invoice.amount_due ?? null,
-        currency: invoice.currency ?? null,
+        amountDue:
+          invoice.amount_due != null && invoice.currency
+            ? { cents: invoice.amount_due, currency: invoice.currency }
+            : null,
         attemptCount: invoice.attempt_count ?? null,
-        previousFailureAt,
-        invoiceCreatedAt: invoice.created
-          ? new Date(invoice.created * 1000)
-          : null,
+        priorFailure,
       });
     } catch (err) {
       logger.error(
-        { subscriptionId, err },
+        { subscriptionId: stripeSubscriptionId, err },
         "[stripeWebhook] Failed to send payment-failed notification",
       );
     }

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -99,7 +99,11 @@ export type WebhookService = {
     throwOnMissing?: boolean;
   }): Promise<void>;
 
-  handleInvoicePaymentFailed(params: { subscriptionId: string }): Promise<void>;
+  handleInvoicePaymentFailed(params: {
+    subscriptionId: string;
+    invoice: Stripe.Invoice;
+    livemode: boolean;
+  }): Promise<void>;
 
   handleSubscriptionDeleted(params: {
     stripeSubscriptionId: string;
@@ -351,7 +355,11 @@ export class EEWebhookService implements WebhookService {
         return { status: "ok" };
 
       case "invoice.payment_failed":
-        await this.handleInvoicePaymentFailed({ subscriptionId });
+        await this.handleInvoicePaymentFailed({
+          subscriptionId,
+          invoice: event.data.object as Stripe.Invoice,
+          livemode: event.livemode,
+        });
         return { status: "ok" };
     }
   }
@@ -549,8 +557,12 @@ export class EEWebhookService implements WebhookService {
 
   async handleInvoicePaymentFailed({
     subscriptionId,
+    invoice,
+    livemode,
   }: {
     subscriptionId: string;
+    invoice: Stripe.Invoice;
+    livemode: boolean;
   }): Promise<void> {
     await waitForStripeConsistency();
 
@@ -565,10 +577,53 @@ export class EEWebhookService implements WebhookService {
       return;
     }
 
+    // A cancelled subscription can still receive a late invoice.payment_failed
+    // from Stripe's dunning process. Recording it would flip the status from
+    // CANCELLED to FAILED, so skip both the write and the alert entirely.
+    if (currentSubscription.status === SubscriptionStatus.CANCELLED) {
+      logger.info(
+        { subscriptionId },
+        "[stripeWebhook] Subscription already cancelled, skipping payment failure",
+      );
+      return;
+    }
+
+    const previousFailureAt = currentSubscription.lastPaymentFailedDate;
+
     await this.subscriptionRepository.recordPaymentFailure({
       id: currentSubscription.id,
       currentStatus: currentSubscription.status,
     });
+
+    // Notification failures must never fail the webhook — Stripe would
+    // retry delivery, and the payment failure has already been recorded.
+    try {
+      const org = await this.organizationRepository.findNameById(
+        currentSubscription.organizationId,
+      );
+
+      await getApp().notifications.sendSlackSubscriptionEvent({
+        type: "payment_failed",
+        organizationId: currentSubscription.organizationId,
+        organizationName: org?.name ?? "Unknown",
+        plan: currentSubscription.plan,
+        dbSubscriptionId: currentSubscription.id,
+        stripeSubscriptionId: subscriptionId,
+        livemode,
+        amountDueCents: invoice.amount_due ?? null,
+        currency: invoice.currency ?? null,
+        attemptCount: invoice.attempt_count ?? null,
+        previousFailureAt,
+        invoiceCreatedAt: invoice.created
+          ? new Date(invoice.created * 1000)
+          : null,
+      });
+    } catch (err) {
+      logger.error(
+        { subscriptionId, err },
+        "[stripeWebhook] Failed to send payment-failed notification",
+      );
+    }
   }
 
   async handleSubscriptionDeleted({

--- a/langwatch/ee/billing/types.ts
+++ b/langwatch/ee/billing/types.ts
@@ -61,10 +61,32 @@ type CancelledSubscriptionNotification = SubscriptionNotificationBase & {
   cancellationDate?: Date | null;
 };
 
+/**
+ * Internal ops alert for a failed Stripe invoice charge. One alert per
+ * `invoice.payment_failed` event is sent (no dedup) — Stripe fires one per
+ * retry attempt and retries of the same invoice can be days apart, so
+ * elapsed time alone cannot tell a retry from a new failure. The retry
+ * signal instead comes from the invoice itself: `attemptCount` says which
+ * attempt this is, and `previousFailureAt` predating `invoiceCreatedAt`
+ * marks a failure carried over from an earlier dunning cycle.
+ */
+type PaymentFailedSubscriptionNotification = SubscriptionNotificationBase & {
+  type: "payment_failed";
+  dbSubscriptionId: string;
+  stripeSubscriptionId: string;
+  livemode: boolean;
+  amountDueCents?: number | null;
+  currency?: string | null;
+  attemptCount?: number | null;
+  previousFailureAt?: Date | null;
+  invoiceCreatedAt?: Date | null;
+};
+
 export type SubscriptionNotificationPayload =
   | ProspectiveSubscriptionNotification
   | ConfirmedSubscriptionNotification
-  | CancelledSubscriptionNotification;
+  | CancelledSubscriptionNotification
+  | PaymentFailedSubscriptionNotification;
 
 export type ResourceLimitNotificationContext = {
   organizationId: string;

--- a/langwatch/ee/billing/types.ts
+++ b/langwatch/ee/billing/types.ts
@@ -62,24 +62,38 @@ type CancelledSubscriptionNotification = SubscriptionNotificationBase & {
 };
 
 /**
+ * Where a payment failure sits relative to earlier recorded failures,
+ * resolved by the webhook service (domain knowledge — the Slack builder
+ * only renders it):
+ * - `no-prior-failure`: nothing recorded before this event (the date resets
+ *   on successful payment, so this is not necessarily the first failure ever)
+ * - `same-invoice-retry`: a failure was already recorded during this
+ *   invoice's dunning cycle; the attempt count carries the retry signal
+ * - `earlier-cycle`: the previous recorded failure predates this invoice's
+ *   creation, i.e. it carried over from an earlier dunning cycle
+ */
+export type PaymentFailurePrior =
+  | { kind: "no-prior-failure" }
+  | { kind: "same-invoice-retry" }
+  | { kind: "earlier-cycle"; at: Date };
+
+/**
  * Internal ops alert for a failed Stripe invoice charge. One alert per
  * `invoice.payment_failed` event is sent (no dedup) — Stripe fires one per
  * retry attempt and retries of the same invoice can be days apart, so
  * elapsed time alone cannot tell a retry from a new failure. The retry
  * signal instead comes from the invoice itself: `attemptCount` says which
- * attempt this is, and `previousFailureAt` predating `invoiceCreatedAt`
- * marks a failure carried over from an earlier dunning cycle.
+ * attempt this is, and `priorFailure` classifies any previously recorded
+ * failure against the invoice's creation date.
  */
 type PaymentFailedSubscriptionNotification = SubscriptionNotificationBase & {
   type: "payment_failed";
-  dbSubscriptionId: string;
+  subscriptionId: string;
   stripeSubscriptionId: string;
   livemode: boolean;
-  amountDueCents?: number | null;
-  currency?: string | null;
+  amountDue?: { cents: number; currency: string } | null;
   attemptCount?: number | null;
-  previousFailureAt?: Date | null;
-  invoiceCreatedAt?: Date | null;
+  priorFailure: PaymentFailurePrior;
 };
 
 export type SubscriptionNotificationPayload =

--- a/specs/billing/payment-failure-alerting.feature
+++ b/specs/billing/payment-failure-alerting.feature
@@ -1,0 +1,104 @@
+Feature: Internal Slack alert on subscription payment failure
+
+  When Stripe reports a failed payment for a known subscription, the team must
+  be alerted immediately in the billing Slack channel — today the first internal
+  signal is the subscription deletion when Stripe exhausts dunning, potentially
+  weeks later. The alert gives ops the context to act: which organization, which
+  plan, how much failed in which currency, whether this is a repeat failure from
+  an earlier dunning cycle, and direct links to the admin org page and the
+  Stripe subscription.
+
+  Stripe fires one invoice.payment_failed event per retry attempt, and retries
+  of the same invoice can be days apart — elapsed time cannot distinguish a
+  retry from a new failure. One alert per event is accepted (no dedup). The
+  retry signal comes from the event itself: the invoice's attempt count says
+  which attempt this is, and a previous failure recorded before the current
+  invoice was created marks an earlier dunning cycle. Under concurrent
+  deliveries the repeat signal is best-effort.
+
+  Subscription status semantics on payment failure (ACTIVE stays ACTIVE,
+  PENDING becomes FAILED, failure date recorded) are unchanged and remain
+  covered by specs/features/webhook-service-refactor.feature — they are not
+  re-specified here, except the new cancelled-subscription guard below.
+
+  Background:
+    Given an organization with a subscription linked to a Stripe subscription
+
+  # --- Alert content ---
+
+  @unit
+  Scenario: Payment failure on a known subscription sends a payment-failed Slack alert
+    Given the subscription is currently active
+    When Stripe fires an invoice.payment_failed event for the subscription
+    Then a payment-failed Slack notification is sent
+    And the notification includes the organization name and plan
+    And the notification links to the organization admin page
+    And the notification links to the Stripe subscription using the Stripe subscription id
+
+  @unit
+  Scenario: Alert links to the test-mode Stripe dashboard for test-mode events
+    Given the invoice.payment_failed event is a test-mode event
+    When the payment failure is processed
+    Then the Stripe subscription link points at the test-mode dashboard
+
+  @unit
+  Scenario: Alert includes the failed amount in the invoice currency
+    Given the invoice.payment_failed event carries an amount due of 3400 cents in "eur"
+    When the payment failure is processed
+    Then the payment-failed notification shows the amount formatted in euros
+
+  @unit
+  Scenario: Alert is still sent when the event payload lacks an invoice amount
+    Given the invoice.payment_failed event payload carries no amount due
+    When the payment failure is processed
+    Then a payment-failed Slack notification is sent without an amount
+
+  # --- Repeat-failure signal ---
+
+  @unit
+  Scenario: First payment failure signals no prior failure
+    Given the subscription has never had a payment failure
+    When Stripe fires an invoice.payment_failed event for the subscription
+    Then the payment-failed notification indicates this is the first failure
+
+  @unit
+  Scenario: A retry of the same invoice is labelled by its attempt count, not as a repeat failure
+    Given the subscription has a recorded payment failure from after the current invoice was created
+    And the invoice.payment_failed event carries attempt count 3
+    When the payment failure is processed
+    Then the payment-failed notification shows this is attempt 3 for the invoice
+    And the notification does not claim a failure from an earlier dunning cycle
+
+  @unit
+  Scenario: A failure with a prior failure from before the current invoice surfaces the previous failure date
+    Given the subscription has a recorded payment failure from before the current invoice was created
+    When Stripe fires another invoice.payment_failed event for the subscription
+    Then the payment-failed notification shows the date of the previous failure
+    And the previous failure date shown predates the current event
+
+  # --- Cancelled subscriptions ---
+
+  @unit
+  Scenario: Late payment failure on a cancelled subscription is skipped without an alert
+    Given the subscription is already cancelled in our database
+    When Stripe fires an invoice.payment_failed event for the subscription
+    Then the payment failure is not recorded on the subscription
+    And the subscription status is not changed
+    And no Slack notification is sent
+
+  # --- Resilience ---
+
+  @unit
+  Scenario: Notification failure never fails the webhook
+    Given assembling or sending the payment-failed notification throws
+    When Stripe fires an invoice.payment_failed event for the subscription
+    Then the payment failure is still recorded
+    And the webhook handler completes successfully
+    And the notification failure is logged by the handler
+
+  @unit
+  Scenario: Unknown subscription keeps warn-and-skip with no alert
+    Given no subscription record exists for the Stripe subscription
+    When Stripe fires an invoice.payment_failed event
+    Then the handler logs a warning and skips processing
+    And no Slack notification is sent

--- a/specs/billing/payment-failure-alerting.feature
+++ b/specs/billing/payment-failure-alerting.feature
@@ -40,6 +40,7 @@ Feature: Internal Slack alert on subscription payment failure
     Given the invoice.payment_failed event is a test-mode event
     When the payment failure is processed
     Then the Stripe subscription link points at the test-mode dashboard
+    And the alert is labelled as test mode so it cannot be mistaken for a live incident
 
   @unit
   Scenario: Alert includes the failed amount in the invoice currency
@@ -57,9 +58,9 @@ Feature: Internal Slack alert on subscription payment failure
 
   @unit
   Scenario: First payment failure signals no prior failure
-    Given the subscription has never had a payment failure
+    Given the subscription has no recorded payment failure
     When Stripe fires an invoice.payment_failed event for the subscription
-    Then the payment-failed notification indicates this is the first failure
+    Then the payment-failed notification indicates there is no prior unresolved failure
 
   @unit
   Scenario: A retry of the same invoice is labelled by its attempt count, not as a repeat failure


### PR DESCRIPTION
## Why

Closes langwatch/langwatch-saas#893

A customer had three failed subscription payments and the team had zero visibility: `handleInvoicePaymentFailed` only stamped `lastPaymentFailedDate` — a field nothing reads — and the first internal signal would have been the subscription deletion when Stripe exhausts dunning, potentially weeks later. Ops needs to know within minutes when a paying customer's payments start bouncing.

## What changed

- New `payment_failed` type in the billing Slack notification union (`sendSlackSubscriptionEvent`), alongside `prospective`/`confirmed`/`cancelled`. The alert carries the organization name, plan, failed amount formatted in the invoice's own currency, the attempt number for the invoice, the previous-failure date when one carried over from an earlier dunning cycle, and buttons to the admin org page and the Stripe subscription. Test-mode events are labelled "(test mode)" in the header and link to the `/test/` dashboard, so they can't be mistaken for a live incident.
- `handleInvoicePaymentFailed` receives the narrowed `Stripe.Invoice` + `event.livemode` from the webhook router, classifies the failure, records it, then fires the alert via a `notifyPaymentFailed` helper whose contract is best-effort: any failure (including the org-name lookup) is logged and never fails the webhook — a 500 would make Stripe retry and double-alert.
- New guard: a late `invoice.payment_failed` on an already-CANCELLED subscription is skipped entirely — previously `recordPaymentFailure` would have flipped CANCELLED→FAILED (mirrors the existing guard in `handleSubscriptionDeleted`).
- Sweep fix: `emitCheckoutAnalytics` (PostHog) was the one unguarded side effect in a retryable webhook branch; now try/caught with the same rationale.
- Spec: `specs/billing/payment-failure-alerting.feature` (11 scenarios). Status semantics on payment failure (ACTIVE stays ACTIVE, PENDING→FAILED) are unchanged and remain covered by the existing webhook spec.

## How it works

- **Repeat vs retry.** Stripe fires one `invoice.payment_failed` per retry attempt, and retries of the same invoice can be days apart — elapsed time can't distinguish a retry from a new failure. The webhook service resolves a typed `PaymentFailurePrior` (`no-prior-failure` | `same-invoice-retry` | `earlier-cycle`) using the invoice's creation date as the cycle boundary; the Slack builder only renders it. Equal timestamps or a missing creation date classify as same-invoice retry, so the alert never claims an earlier cycle it can't prove. `lastPaymentFailedDate` is read **before** `recordPaymentFailure` stamps it, and the copy says "No prior unresolved failure" (not "first failure") because the date resets on successful payment.
- **Amount.** `invoice.amount_due` (`amount_paid` is 0 on a failed invoice) + `invoice.currency` as one `{ cents, currency }` value, formatted by a shared `formatCurrencyCents` helper (also now used by the license-purchase blocks) — no hardcoded USD.

## Test plan

- 98 unit tests passing across `ee/billing/__tests__/webhookService.unit.test.ts` and `ee/billing/__tests__/notification.service.unit.test.ts`, `@scenario`-bound to the feature file. Full evidence table in the PR conversation.
- Covered beyond the scenarios: boundary cases (prior failure at exactly the invoice-creation timestamp; invoice with no creation date), "Unknown" org-name fallback, and a `handleEvent` test proving a throwing PostHog client still yields `{ status: "ok" }` with the error logged.
- `pnpm typecheck` clean.

## Anything surprising?

- Out of scope per the issue: the latent `customer.subscription.updated` `past_due`→instant-cancel branch and surfacing `lastPaymentFailedDate` in the admin UI.
- Sweep found two pre-existing CANCELLED-resurrection gaps (`handleSubscriptionUpdated` active branch, `syncInvoicePaymentSuccess`) and inconsistent notification guarding across handlers — filed as langwatch/langwatch#5591 rather than expanding this PR.
- No alert dedup by design: one Slack message per Stripe retry attempt, labelled with its attempt number.