### PR TITLE
fix(group-queue): write GQ2 redis blobs with the 4-day backstop, not GQ1's 7-day default

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/README.md
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/README.md
@@ -161,7 +161,7 @@ Payloads of different sizes land in different places, picked at encode time. You
 |---|---|---|
 | **≤ 1 KiB** | Inline raw JSON in the staged value | nothing — the cheap path |
 | **1 KiB to ≤ 4 KiB** | Inline gzip+base64 (if smaller than raw) | nothing |
-| **4 KiB to ≤ 256 KiB** | Standalone Redis key, ref in envelope. Reclaimed on job completion via the holder set, 3-day TTL backstop. | Redis memory growth in the `{queue}:gq:blob:*` keyspace — usually a runaway-fan-out signal |
+| **4 KiB to ≤ 256 KiB** | Standalone Redis key, ref in envelope. Reclaimed on job completion via the holder set, 4-day TTL backstop. | Redis memory growth in the `{queue}:gq:blob:*` keyspace — usually a runaway-fan-out signal |
 | **> 256 KiB, ≤ 50 MiB** | Object store (S3 / file / azure-blob — projectId-scoped to the BYOC bucket) | Object-store request rate; bucket lifecycle policy as backstop for missed reclaims |
 | **> 50 MiB** | Rejected at encode — `PayloadTooLargeError` | Hit by a product bug or a runaway loop — fix upstream rather than raise the cap |
 
@@ -177,7 +177,7 @@ GQ2 (content-addressed) writes are gated behind `GROUP_QUEUE_ENVELOPE_WRITES_ENA
 
 - **Queue name must be hash-tagged.** A non-`{...}` name passes the type checker but fails at runtime in Redis Cluster mode (CROSSSLOT). The `hasRedisHashTag` guard catches this on construction.
 - **The `__*` namespace is reserved.** User payloads must not carry `__custom` or similar — they'll be rejected at `send`-time. The three caller-set routing fields (`__pipelineName`, `__jobType`, `__jobName`) are the only `__*` keys the queue accepts from outside; everything else is queue-internal machinery.
-- **Holders TTL is a backstop, not the primary reclaim.** The happy path reclaims a blob the moment its last holder drops, atomically inside the release Lua. The 3-day TTL is for genuinely-orphaned blobs (mid-completion crash leaves a holder leaked). Don't tune the TTL down without understanding which path is doing the work in your traffic.
+- **Holders TTL is a backstop, not the primary reclaim.** The happy path reclaims a blob the moment its last holder drops, atomically inside the release Lua. The 4-day TTL is for genuinely-orphaned blobs (mid-completion crash leaves a holder leaked). Don't tune the TTL down without understanding which path is doing the work in your traffic.
 - **Cluster mode requires same-slot keys.** Holder Lua touches multiple keys; the hash tag is what makes that safe. If you add new keys to the staging layer, they MUST share the queue's hash tag.
 - **Memory queue is for tests / dev.** It processes jobs in-process with no Lua, no Redis, no tiered storage. Don't reach for it in production code paths; it exists so unit tests don't need a docker-compose dependency.
 - **Holders are per-queue, blobs are per-tenant.** Two queues that stage byte-identical content for the same project will reference the SAME stored blob (at the s3 tier), each with their own holder set. The blob is reclaimed only when both holder sets are empty.

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobTestDoubles.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobTestDoubles.ts
@@ -7,10 +7,29 @@ import type { ObjectStore } from "../tieredBlobStore";
 /** In-memory stand-in for the Redis blob tier (a {@link JobBlobStore}). */
 export class InMemoryJobBlobStore implements JobBlobStore {
   readonly store = new Map<string, Buffer>();
-  async put({ id, data }: { id: string; data: Buffer }): Promise<void> {
+  /** TTLs observed per call, so tests can pin which backstop each tier passes. */
+  readonly putTtls: Array<number | undefined> = [];
+  readonly getTtls: Array<number | undefined> = [];
+  async put({
+    id,
+    data,
+    ttlSeconds,
+  }: {
+    id: string;
+    data: Buffer;
+    ttlSeconds?: number;
+  }): Promise<void> {
+    this.putTtls.push(ttlSeconds);
     this.store.set(id, data);
   }
-  async get({ id }: { id: string }): Promise<Buffer | null> {
+  async get({
+    id,
+    ttlSeconds,
+  }: {
+    id: string;
+    ttlSeconds?: number;
+  }): Promise<Buffer | null> {
+    this.getTtls.push(ttlSeconds);
     return this.store.get(id) ?? null;
   }
   /** In-memory doubles have no TTL so peek and get behave identically. */

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/redisJobBlobStore.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/redisJobBlobStore.integration.test.ts
@@ -11,7 +11,7 @@ const BLOB_PREFIX = `${QUEUE_NAME}:gq:blob:`;
 // GQ1 has no refcount, so a staged-but-not-yet-dispatched job (long retry
 // backoff, paused pipeline, delayed schedule) sees no read between put and TTL
 // tick-down — the backstop must comfortably outlive that residence, so it's
-// 7 days, not 3. GQ2 (content-addressed, refcounted) uses the shorter 3-day
+// 7 days, not 4. GQ2 (content-addressed, refcounted) uses the shorter 4-day
 // number.
 const GQ1_SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import { BLOB_BACKSTOP_TTL_SECONDS } from "../blobConstants";
 import {
   type BlobRef,
   contentHash,
@@ -46,6 +47,34 @@ describe("TieredBlobStore", () => {
         const ref = await store.put({ projectId: PROJECT, data });
 
         expect(await store.get(ref)).toEqual(data);
+      });
+
+      /**
+       * Regression: TieredBlobStore wrote through RedisJobBlobStore's default
+       * (GQ1's 7-day staged-residence backstop) instead of the refcounted GQ2
+       * 3-day orphan backstop the spec configures ("the blob TTL backstop is
+       * configured at 3 days"), so every leaked blob lived 4 days longer than
+       * designed (2026-07-09 Redis memory investigation).
+       */
+      it("writes and refreshes with the 3-day GQ2 backstop, not GQ1's 7-day default", async () => {
+        const { store, redisBlobs } = makeStore();
+        const data = Buffer.from("ttl pinning payload");
+
+        const ref = await store.put({ projectId: PROJECT, data });
+        await store.get(ref);
+
+        expect(redisBlobs.putTtls).toEqual([BLOB_BACKSTOP_TTL_SECONDS]);
+        expect(redisBlobs.getTtls).toEqual([BLOB_BACKSTOP_TTL_SECONDS]);
+      });
+
+      it("peeks without refreshing any TTL", async () => {
+        const { store, redisBlobs } = makeStore();
+        const data = Buffer.from("peek me");
+
+        const ref = await store.put({ projectId: PROJECT, data });
+        await store.peek(ref);
+
+        expect(redisBlobs.getTtls).toEqual([]);
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.unit.test.ts
@@ -52,11 +52,11 @@ describe("TieredBlobStore", () => {
       /**
        * Regression: TieredBlobStore wrote through RedisJobBlobStore's default
        * (GQ1's 7-day staged-residence backstop) instead of the refcounted GQ2
-       * 3-day orphan backstop the spec configures ("the blob TTL backstop is
-       * configured at 3 days"), so every leaked blob lived 4 days longer than
+       * GQ2 orphan backstop the spec configures ("the blob TTL backstop is
+       * configured at 4 days"), so every leaked blob lived days longer than
        * designed (2026-07-09 Redis memory investigation).
        */
-      it("writes and refreshes with the 3-day GQ2 backstop, not GQ1's 7-day default", async () => {
+      it("writes and refreshes with the 4-day GQ2 backstop, not GQ1's 7-day default", async () => {
         const { store, redisBlobs } = makeStore();
         const data = Buffer.from("ttl pinning payload");
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.unit.test.ts
@@ -52,7 +52,7 @@ describe("TieredBlobStore", () => {
       /**
        * Regression: TieredBlobStore wrote through RedisJobBlobStore's default
        * (GQ1's 7-day staged-residence backstop) instead of the refcounted GQ2
-       * GQ2 orphan backstop the spec configures ("the blob TTL backstop is
+       * orphan backstop the spec configures ("the blob TTL backstop is
        * configured at 4 days"), so every leaked blob lived days longer than
        * designed (2026-07-09 Redis memory investigation).
        */

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/blobConstants.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/blobConstants.ts
@@ -20,12 +20,13 @@ export const GQ1_BLOB_BACKSTOP_TTL_SECONDS = 7 * 24 * 60 * 60;
  * Backstop TTL for a GQ2 (content-addressed, refcounted) offloaded blob,
  * refreshed on access. The holder-set TTL is set to at least this (see
  * {@link BlobHolders}); both reclaim eagerly on the happy path, so this only
- * bounds genuine orphans — sized to outlive a weekend. The GQ2 blob has an
+ * bounds genuine orphans — sized at 4 days so a Friday-evening incident still
+ * has its blobs on Monday plus a day of catch-up. The GQ2 blob has an
  * accompanying holder set (per-stage tokens with atomic reclaim in Lua), so
- * the 3-day window here is the safety net for missed releases (crash mid-
+ * the window here is the safety net for missed releases (crash mid-
  * completion), not the primary reclaim mechanism.
  */
-export const BLOB_BACKSTOP_TTL_SECONDS = 3 * 24 * 60 * 60;
+export const BLOB_BACKSTOP_TTL_SECONDS = 4 * 24 * 60 * 60;
 
 /**
  * TTL on a blob's holder set — deliberately longer than the blob TTL so the

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -966,7 +966,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 // can't proceed. Release the OLD hold explicitly and fall
                 // through to the non-retryable fail-safe (complete the slot,
                 // recover via event replay) — otherwise the old hold token
-                // stays in the holder set until the 3-day TTL backstop reclaims
+                // stays in the holder set until the 4-day TTL backstop reclaims
                 // it, leaking the blob for that whole window.
                 let retryJobData: string;
                 try {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -75,9 +75,10 @@ function envelopeWritesEnabled(): boolean {
  * job was squashed by dedup or lost in a crash must eventually expire.
  */
 export interface JobBlobStore {
-  put(params: { id: string; data: Buffer }): Promise<void>;
+  /** `ttlSeconds` overrides the GQ1 default backstop (see {@link RedisJobBlobStore}). */
+  put(params: { id: string; data: Buffer; ttlSeconds?: number }): Promise<void>;
   /** Read the blob AND refresh its backstop TTL. Worker hot path only. */
-  get(params: { id: string }): Promise<Buffer | null>;
+  get(params: { id: string; ttlSeconds?: number }): Promise<Buffer | null>;
   /** Read the blob WITHOUT refreshing its TTL. Non-worker / ops-dashboard inspection path. */
   peek(params: { id: string }): Promise<Buffer | null>;
   delete(params: { id: string }): Promise<void>;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/redisJobBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/redisJobBlobStore.ts
@@ -12,8 +12,11 @@ import type { JobBlobStore } from "./jobEnvelope";
  *
  * A staged-but-not-yet-dispatched job (long retry backoff, paused pipeline,
  * delayed schedule) sees NO intervening read between the producer's `put` and
- * the dispatcher's `get`, so the TTL is set to comfortably outlive the longest
- * plausible staged residence (7 days, see {@link GQ1_BLOB_BACKSTOP_TTL_SECONDS}).
+ * the dispatcher's `get`, so the DEFAULT TTL is set to comfortably outlive the
+ * longest plausible staged residence (7 days, see
+ * {@link GQ1_BLOB_BACKSTOP_TTL_SECONDS}). GQ2 callers pass their own shorter
+ * backstop per call: a refcounted blob reclaims eagerly on the last release,
+ * so its TTL only has to cover genuine orphans, not staged residence.
  */
 export class RedisJobBlobStore implements JobBlobStore {
   private readonly redis: IORedis | Cluster;
@@ -30,12 +33,20 @@ export class RedisJobBlobStore implements JobBlobStore {
     this.keyPrefix = redisBlobKeyPrefix(queueName);
   }
 
-  async put({ id, data }: { id: string; data: Buffer }): Promise<void> {
+  async put({
+    id,
+    data,
+    ttlSeconds,
+  }: {
+    id: string;
+    data: Buffer;
+    ttlSeconds?: number;
+  }): Promise<void> {
     await this.redis.set(
       this.keyPrefix + id,
       data,
       "EX",
-      GQ1_BLOB_BACKSTOP_TTL_SECONDS,
+      ttlSeconds ?? GQ1_BLOB_BACKSTOP_TTL_SECONDS,
     );
   }
 
@@ -44,11 +55,17 @@ export class RedisJobBlobStore implements JobBlobStore {
    * {@link peek} for the inspection path that must NOT extend the backstop TTL.
    * A missing key returns null.
    */
-  async get({ id }: { id: string }): Promise<Buffer | null> {
+  async get({
+    id,
+    ttlSeconds,
+  }: {
+    id: string;
+    ttlSeconds?: number;
+  }): Promise<Buffer | null> {
     return await this.redis.getexBuffer(
       this.keyPrefix + id,
       "EX",
-      GQ1_BLOB_BACKSTOP_TTL_SECONDS,
+      ttlSeconds ?? GQ1_BLOB_BACKSTOP_TTL_SECONDS,
     );
   }
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
@@ -8,7 +8,7 @@ import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
 import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
 import { mintFileUri, mintS3Uri } from "~/server/stored-objects/uri";
 
-import { MAX_BLOB_BYTES } from "./blobConstants";
+import { BLOB_BACKSTOP_TTL_SECONDS, MAX_BLOB_BYTES } from "./blobConstants";
 import { blobNamespaceId } from "./blobKeys";
 import type { JobBlobStore } from "./jobEnvelope";
 import { gqBlobDecodeCapExceededTotal } from "./metrics";
@@ -252,7 +252,13 @@ export class TieredBlobStore {
       await this.objectStoreFor(projectId).put(uri, data, "application/gzip");
       return { tier: "s3", projectId, hash };
     }
-    await this.redisBlobs.put({ id: redisBlobId({ projectId, hash }), data });
+    // GQ2 blobs are refcounted (holder-set eager reclaim), so the TTL is only
+    // the orphan backstop — 3 days, not GQ1's 7-day staged-residence window.
+    await this.redisBlobs.put({
+      id: redisBlobId({ projectId, hash }),
+      data,
+      ttlSeconds: BLOB_BACKSTOP_TTL_SECONDS,
+    });
     return { tier: "redis", projectId, hash };
   }
 
@@ -280,7 +286,7 @@ export class TieredBlobStore {
     if (ref.tier === "redis") {
       const id = redisBlobId({ projectId: ref.projectId, hash: ref.hash });
       return refresh
-        ? this.redisBlobs.get({ id })
+        ? this.redisBlobs.get({ id, ttlSeconds: BLOB_BACKSTOP_TTL_SECONDS })
         : this.redisBlobs.peek({ id });
     }
     // Re-mint OUTSIDE the missing-classification: a destination-resolve / mint

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
@@ -253,7 +253,7 @@ export class TieredBlobStore {
       return { tier: "s3", projectId, hash };
     }
     // GQ2 blobs are refcounted (holder-set eager reclaim), so the TTL is only
-    // the orphan backstop — 3 days, not GQ1's 7-day staged-residence window.
+    // the orphan backstop — 4 days, not GQ1's 7-day staged-residence window.
     await this.redisBlobs.put({
       id: redisBlobId({ projectId, hash }),
       data,

--- a/specs/event-sourcing/payload-store-blob-hardening.feature
+++ b/specs/event-sourcing/payload-store-blob-hardening.feature
@@ -33,7 +33,7 @@ Feature: GroupQueue blob-handling hardening
   Background:
     Given a GroupQueue with GQ2 content-addressed offload enabled
     And the absolute ceiling is configured at 50 MiB
-    And the blob backstop TTL is configured at 3 days
+    And the blob backstop TTL is configured at 4 days
 
   # ===========================================================================
   # Track 1 — bounded-memory offload (cap + hash-over-raw)

--- a/specs/event-sourcing/payload-store-content-addressed.feature
+++ b/specs/event-sourcing/payload-store-content-addressed.feature
@@ -11,7 +11,7 @@ Feature: GroupQueue content-addressed tiered payload store
   # Builds on ADR-026's GQ1 envelope (specs/event-sourcing/payload-envelope.feature).
   # Supersedes ADR-026's blob-lifecycle scenarios: random blob ids become content
   # hashes; best-effort-delete + 7-day pure-backstop TTL becomes holder-set eager
-  # reclaim + 3-day refreshed backstop. The GQ1 envelope/header/routing/two-phase
+  # reclaim + 4-day refreshed backstop. The GQ1 envelope/header/routing/two-phase
   # rollout decisions carry forward unchanged.
   #
   # TWO mechanisms share the word "dedup" — this spec keeps them apart:
@@ -40,7 +40,7 @@ Feature: GroupQueue content-addressed tiered payload store
   #   - Holder set {queue}:gq:blobholders:<hash> tracks references by stagedJobId;
   #     SADD at stage, SREM at every retire edge, atomic with the job-entry write.
   #     Empties -> eager UNLINK (redis) / reclaim-list sweep (s3).
-  #   - 3-day TTL on blob + holder set, refreshed on access, is the orphan
+  #   - 4-day TTL on blob + holder set, refreshed on access, is the orphan
   #     backstop only. A missing blob completes the slot without the handler
   #     (recoverable via replay) — a fail-safe, never a wedge.
   #
@@ -61,7 +61,7 @@ Feature: GroupQueue content-addressed tiered payload store
     And envelope v2 writes are enabled for the deployment
     And the inline tier ceiling is configured at 4 KiB
     And the S3 tier threshold is configured at 256 KiB
-    And the blob TTL backstop is configured at 3 days
+    And the blob TTL backstop is configured at 4 days
 
   # ===========================================================================
   # Track 1 — content-addressed tiers
@@ -142,7 +142,7 @@ Feature: GroupQueue content-addressed tiered payload store
   # s3://{bucket}/{projectId}/<hash>. Isolation is structural — in the key path —
   # not incidental to content. This also makes a project purge a delete-by-prefix
   # over .../{projectId}/* (driven by the platform's project-delete cascade); the
-  # redis tier needs none, its 3-day TTL clears once the project's jobs drain.
+  # redis tier needs none, its 4-day TTL clears once the project's jobs drain.
   Scenario: Blob keys are namespaced by tenant so tenants never share a blob
     Given two tenants whose jobs carry byte-identical user content
     When each payload is offloaded


### PR DESCRIPTION
## What

GQ2 redis-tier blobs were written (and TTL-refreshed on read) with GQ1's 7-day backstop instead of the GQ2 backstop that `blobConstants.BLOB_BACKSTOP_TTL_SECONDS` defines and `specs/event-sourcing/payload-store-content-addressed.feature` specifies. `TieredBlobStore` wrote through `RedisJobBlobStore.put`, which hardcoded the GQ1 constant with no way to override it.

`JobBlobStore.put`/`get` now take an optional `ttlSeconds`; the tiered store passes the GQ2 backstop on write and refresh. GQ1 call sites keep the 7-day default (their TTL is the only reclaim they have and must outlive staged residence).

The GQ2 backstop itself moves from 3 to **4 days** so a Friday-evening incident's blobs survive the weekend plus a day of catch-up; the holder-set TTL derives from the same constant (+1 day) and moves in lockstep. Specs updated to match.

## Why it matters

Prod Redis (2026-07-09 investigation): 279k orphaned GQ2 blobs ≈ 1.9 GB, every one waiting out a **7-day** TTL that was designed to be about half that. Sampled orphan TTLs above the design window confirmed the mis-wiring. (The orphaning itself — holder leaks — is fixed separately.)

## Tests

- `tieredBlobStore.unit.test.ts`: pins put + get to `BLOB_BACKSTOP_TTL_SECONDS`, and `peek` to no refresh.

https://claude.ai/code/session_01BUi7eLwDkxpZGUgujjPJ8L