### PR TITLE
perf(group-queue): run the queue Lua via EVALSHA instead of re-sending 11-23KB scripts per call

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/cachedLuaScript.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/cachedLuaScript.unit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Redis as IORedis } from "ioredis";
+
+import { CachedLuaScript } from "../cachedLuaScript";
+
+function makeRedis({ cacheHit }: { cacheHit: boolean }) {
+  const evalsha = vi.fn(async () => {
+    if (!cacheHit) throw new Error("NOSCRIPT No matching script.");
+    return "sha-result";
+  });
+  const evalFn = vi.fn(async () => "eval-result");
+  return {
+    redis: { evalsha, eval: evalFn } as unknown as IORedis,
+    evalsha,
+    evalFn,
+  };
+}
+
+describe("CachedLuaScript", () => {
+  describe("given the script is already in the server's cache", () => {
+    it("runs via EVALSHA without sending the source", async () => {
+      const { redis, evalsha, evalFn } = makeRedis({ cacheHit: true });
+      const script = new CachedLuaScript("return 1");
+
+      const result = await script.run(redis, 1, "key", "arg");
+
+      expect(result).toBe("sha-result");
+      expect(evalsha).toHaveBeenCalledWith(
+        expect.stringMatching(/^[0-9a-f]{40}$/),
+        1,
+        "key",
+        "arg",
+      );
+      expect(evalFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given an empty script cache (restart / SCRIPT FLUSH / new cluster node)", () => {
+    it("falls back to EVAL once, loading the script for later calls", async () => {
+      const { redis, evalsha, evalFn } = makeRedis({ cacheHit: false });
+      const script = new CachedLuaScript("return 1");
+
+      const result = await script.run(redis, 1, "key", "arg");
+
+      expect(result).toBe("eval-result");
+      expect(evalsha).toHaveBeenCalledOnce();
+      expect(evalFn).toHaveBeenCalledWith("return 1", 1, "key", "arg");
+    });
+  });
+
+  describe("given the script itself errors", () => {
+    it("propagates the error instead of retrying via EVAL", async () => {
+      const evalsha = vi.fn(async () => {
+        throw new Error("ERR user_script:1: attempt to index a nil value");
+      });
+      const evalFn = vi.fn();
+      const script = new CachedLuaScript("return nil.x");
+
+      await expect(
+        script.run({ evalsha, eval: evalFn } as unknown as IORedis, 0),
+      ).rejects.toThrow("attempt to index a nil value");
+      expect(evalFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given two scripts with different sources", () => {
+    it("derives distinct shas so a changed script can never hit a stale cache entry", async () => {
+      const a = makeRedis({ cacheHit: true });
+      const b = makeRedis({ cacheHit: true });
+      await new CachedLuaScript("return 1").run(a.redis, 0);
+      await new CachedLuaScript("return 2").run(b.redis, 0);
+
+      expect(a.evalsha.mock.calls[0]?.[0]).not.toBe(
+        b.evalsha.mock.calls[0]?.[0],
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/cachedLuaScript.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/cachedLuaScript.unit.test.ts
@@ -4,7 +4,7 @@ import type { Redis as IORedis } from "ioredis";
 import { CachedLuaScript } from "../cachedLuaScript";
 
 function makeRedis({ cacheHit }: { cacheHit: boolean }) {
-  const evalsha = vi.fn(async () => {
+  const evalsha = vi.fn(async (..._args: Array<string | number>) => {
     if (!cacheHit) throw new Error("NOSCRIPT No matching script.");
     return "sha-result";
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/blobHolders.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/blobHolders.ts
@@ -1,5 +1,7 @@
 import type { Cluster, Redis as IORedis } from "ioredis";
 
+import { CachedLuaScript } from "./cachedLuaScript";
+
 import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
 import { BLOB_HOLDER_TTL_SECONDS } from "./blobConstants";
 import { blobHolderSetKey, redisBlobKey } from "./blobKeys";
@@ -58,6 +60,9 @@ if redis.call("SREM", KEYS[2], ARGV[2]) == 1 and redis.call("SCARD", KEYS[2]) ==
 end
 return 0
 `;
+
+const releaseScript = new CachedLuaScript(RELEASE_LUA);
+const transferScript = new CachedLuaScript(TRANSFER_LUA);
 
 export type ReleaseOutcome = "still-held" | "reclaimed-redis" | "reclaim-s3";
 
@@ -149,8 +154,8 @@ export class BlobHolders {
       tier === "redis"
         ? [this.holderKey(projectId, hash), this.blobKey(projectId, hash)]
         : [this.holderKey(projectId, hash)];
-    const result = (await this.redis.eval(
-      RELEASE_LUA,
+    const result = (await releaseScript.run(
+      this.redis,
       keys.length,
       ...keys,
       slotId,
@@ -191,8 +196,8 @@ export class BlobHolders {
       oldTier === "redis"
         ? [newHolderKey, oldHolderKey, this.blobKey(oldProjectId, oldHash)]
         : [newHolderKey, oldHolderKey];
-    const result = (await this.redis.eval(
-      TRANSFER_LUA,
+    const result = (await transferScript.run(
+      this.redis,
       keys.length,
       ...keys,
       newSlotId,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/cachedLuaScript.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/cachedLuaScript.ts
@@ -36,7 +36,7 @@ export class CachedLuaScript {
     try {
       return await redis.evalsha(this.sha, numKeys, ...keysAndArgs);
     } catch (err) {
-      if (err instanceof Error && err.message.includes("NOSCRIPT")) {
+      if (err instanceof Error && err.message.startsWith("NOSCRIPT")) {
         return await redis.eval(this.source, numKeys, ...keysAndArgs);
       }
       throw err;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/cachedLuaScript.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/cachedLuaScript.ts
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+
+import type { Cluster, Redis as IORedis } from "ioredis";
+
+/**
+ * EVALSHA wrapper for a Lua script whose source is sent once, not per call.
+ *
+ * The queue's scripts are large — STAGE is ~11 KB and DISPATCH ~22 KB once the
+ * shared helpers are prepended — and run at four-digit rates, so plain EVAL
+ * re-transfers and re-hashes the full source on every call (measured at ~33%
+ * of the prod Redis engine CPU, 2026-07-09). EVALSHA sends the 40-byte sha1
+ * instead; on a NOSCRIPT miss (empty script cache after a restart or
+ * SCRIPT FLUSH, or the first call against a cluster node) it falls back to
+ * EVAL once, which loads the script into that node's cache for every later
+ * call.
+ *
+ * The sha is derived from the source, so a deploy that changes a script can
+ * never execute a stale cached body — a different source is a different sha.
+ * Keys stay hash-tagged by the caller exactly as with EVAL, so cluster slot
+ * routing is unchanged.
+ */
+export class CachedLuaScript {
+  private readonly source: string;
+  private readonly sha: string;
+
+  constructor(source: string) {
+    this.source = source;
+    this.sha = createHash("sha1").update(source).digest("hex");
+  }
+
+  async run(
+    redis: IORedis | Cluster,
+    numKeys: number,
+    ...keysAndArgs: Array<string | number>
+  ): Promise<unknown> {
+    try {
+      return await redis.evalsha(this.sha, numKeys, ...keysAndArgs);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("NOSCRIPT")) {
+        return await redis.eval(this.source, numKeys, ...keysAndArgs);
+      }
+      throw err;
+    }
+  }
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1,6 +1,8 @@
 import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
 
+import { CachedLuaScript } from "./cachedLuaScript";
+
 // Lua scripts inlined as string constants.
 // This avoids loader incompatibilities across turbopack, webpack, vitest, and tsx.
 
@@ -1509,6 +1511,19 @@ export const GROUP_QUEUE_REGISTRY_KEY = "{gq-registry}:names";
  * instead of passing them via KEYS[]; this is safe because keyPrefix includes the hash
  * tag, so all derived keys hash to the same Redis Cluster slot.
  */
+// EVALSHA-cached forms of the scripts above: the source is sent to Redis
+// once per node, every later call ships a 40-byte sha instead of the full
+// 11-23 KB script body (see CachedLuaScript).
+const stageScript = new CachedLuaScript(STAGE_LUA);
+const stageBatchScript = new CachedLuaScript(STAGE_BATCH_LUA);
+const dispatchScript = new CachedLuaScript(DISPATCH_LUA);
+const dispatchBatchScript = new CachedLuaScript(DISPATCH_BATCH_LUA);
+const drainGroupScript = new CachedLuaScript(DRAIN_GROUP_LUA);
+const completeScript = new CachedLuaScript(COMPLETE_LUA);
+const refreshScript = new CachedLuaScript(REFRESH_LUA);
+const restageAndBlockScript = new CachedLuaScript(RESTAGE_AND_BLOCK_LUA);
+const retryRestageScript = new CachedLuaScript(RETRY_RESTAGE_LUA);
+
 export class GroupStagingScripts {
   private readonly keyPrefix: string;
   private readonly queueName: string;
@@ -1580,8 +1595,8 @@ export class GroupStagingScripts {
     const activeKey = `${this.keyPrefix}group:${groupId}:active`;
     const blockedKey = `${this.keyPrefix}blocked`;
 
-    const result = await this.redis.eval(
-      STAGE_LUA,
+    const result = await stageScript.run(
+      this.redis,
       8,
       groupJobsKey,
       readyKey,
@@ -1665,8 +1680,8 @@ export class GroupStagingScripts {
     args.push(String(Date.now()));
     args.push(String(readGlobalBudget()));
 
-    const result = await this.redis.eval(
-      STAGE_BATCH_LUA,
+    const result = await stageBatchScript.run(
+      this.redis,
       3,
       readyKey,
       signalKey,
@@ -1709,8 +1724,8 @@ export class GroupStagingScripts {
     // Env var lets operators flip on per-environment without redeploy.
     const tenantCap = readTenantCap();
 
-    const result = await this.redis.eval(
-      DISPATCH_LUA,
+    const result = await dispatchScript.run(
+      this.redis,
       4,
       readyKey,
       blockedKey,
@@ -1755,8 +1770,8 @@ export class GroupStagingScripts {
 
     const tenantCap = readTenantCap();
 
-    const result = await this.redis.eval(
-      DISPATCH_BATCH_LUA,
+    const result = await dispatchBatchScript.run(
+      this.redis,
       4,
       readyKey,
       blockedKey,
@@ -1808,8 +1823,8 @@ export class GroupStagingScripts {
     const statsKey = `${this.keyPrefix}stats:completed`;
     const errorKey = `${this.keyPrefix}group:${groupId}:error`;
 
-    const result = await this.redis.eval(
-      COMPLETE_LUA,
+    const result = await completeScript.run(
+      this.redis,
       6,
       activeKey,
       jobsKey,
@@ -1848,8 +1863,8 @@ export class GroupStagingScripts {
     const dataKey = `${this.keyPrefix}group:${groupId}:data`;
     const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
 
-    const result = await this.redis.eval(
-      DRAIN_GROUP_LUA,
+    const result = await drainGroupScript.run(
+      this.redis,
       3,
       jobsKey,
       dataKey,
@@ -1891,8 +1906,8 @@ export class GroupStagingScripts {
     const activeKey = `${this.keyPrefix}group:${groupId}:active`;
     const readyKey = `${this.keyPrefix}ready`;
 
-    const result = await this.redis.eval(
-      REFRESH_LUA,
+    const result = await refreshScript.run(
+      this.redis,
       2,
       activeKey,
       readyKey,
@@ -1930,8 +1945,8 @@ export class GroupStagingScripts {
     const statsKey = `${this.keyPrefix}stats:failed`;
     const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
 
-    await this.redis.eval(
-      RESTAGE_AND_BLOCK_LUA,
+    await restageAndBlockScript.run(
+      this.redis,
       4,
       blockedKey,
       readyKey,
@@ -1979,8 +1994,8 @@ export class GroupStagingScripts {
     // TTL = backoff + 2s buffer so the key expires just after the job becomes eligible
     const retryTtlSec = Math.ceil(backoffMs / 1000) + 2;
 
-    const result = await this.redis.eval(
-      RETRY_RESTAGE_LUA,
+    const result = await retryRestageScript.run(
+      this.redis,
       2,
       activeKey,
       totalPendingKey,


### PR DESCRIPTION
## What

Every GroupQueue operation re-sent its full Lua source per call: STAGE is ~11 KB and DISPATCH ~22 KB once the shared park/water-level/routing helpers are prepended, and they run at four-digit rates. `CachedLuaScript` wraps each script with EVALSHA (40-byte sha instead of the source) plus a one-time EVAL fallback on NOSCRIPT — restart, `SCRIPT FLUSH`, or the first call against a cluster node — which loads the script into that node's cache for every later call.

Applied to all nine `GroupStagingScripts` call sites and the blob-holder release/transfer evals. Key hash-tagging, argument order, and reply handling are unchanged; the sha is derived from the source so an edited script can never execute a stale cached body.

## Why

Prod Redis engine CPU has been trending up and breached 50% on 2026-07-09. A 60-second `INFO commandstats` delta attributes ~33% of engine CPU to `eval` at 1,042 calls/s (~45 µs/call) — most of that parsing and hashing the re-sent script body. EVALSHA removes the per-call source transfer and compile entirely.

## Tests

- New `cachedLuaScript.unit.test.ts`: sha path, NOSCRIPT fallback, script-error propagation (no false fallback), distinct shas per source.
- `src/server/event-sourcing/queues` unit suite: 115 passed. Integration suites (real Redis Lua) run in CI.

https://claude.ai/code/session_01BUi7eLwDkxpZGUgujjPJ8L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved Redis-backed group-queue operations by running Lua logic through cached SHA/EVALSHA where available.
  - Reduced repeated transmission of Lua source during processing.
- **Reliability**
  - Added automatic fallback to direct Lua execution when a cached script isn’t available.
  - Kept existing result mapping and error propagation behavior unchanged.
- **Tests**
  - Added unit tests covering cache hit/miss behavior, error propagation, and protection against stale cache reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->