### PR TITLE
perf(observability): stop the anomaly baseline reads from dominating Redis CPU

### DIFF
--- a/langwatch/src/server/observability/__tests__/anomalyDetector.unit.test.ts
+++ b/langwatch/src/server/observability/__tests__/anomalyDetector.unit.test.ts
@@ -3,12 +3,14 @@ import {
   AnomalyDetector,
   HARD_TIER_MULTIPLIER,
   HARD_TIER_SUSTAIN_MINUTES,
+  INSUFFICIENT_DATA_RECHECK_SECONDS,
   MIN_BASELINE_RATE,
   SURFACE_TIER_MULTIPLIER,
   SURFACE_TIER_SUSTAIN_MINUTES,
   percentile,
 } from "../anomalyDetector";
 import type { Anomaly } from "../anomalyState";
+import { TenantRateTracker } from "../tenantRateTracker";
 
 function makeFakes() {
   const stored = new Map<string, Anomaly>();
@@ -313,8 +315,8 @@ describe("AnomalyDetector.tick", () => {
       expect(fakes.rateTracker.perMinuteSeries).not.toHaveBeenCalled();
     });
 
-    /** @scenario Insufficient history is NOT cached so the tenant is re-checked soon */
-    it("does NOT cache when there is insufficient history (we want to retry soon)", async () => {
+    /** @scenario Insufficient history is cached briefly so quiet tenants are not re-read every tick */
+    it("caches the not-enough-data verdict with a short TTL instead of re-reading every tick", async () => {
       const fakes = makeFakes();
       fakes.rateTracker.listActiveTenants.mockResolvedValue(["proj_new"]);
       fakes.rateTracker.perMinuteSeries.mockResolvedValue([5, 10, 5]); // <60 min
@@ -322,7 +324,16 @@ describe("AnomalyDetector.tick", () => {
       const detector = new AnomalyDetector(fakes);
       await detector.tick();
 
-      expect(fakes.rateTracker.setCachedBaseline).not.toHaveBeenCalled();
+      expect(fakes.rateTracker.setCachedBaseline).toHaveBeenCalledWith(
+        "proj_new",
+        0,
+        INSUFFICIENT_DATA_RECHECK_SECONDS,
+      );
+      // The verdict re-check window must stay well under the 1h baseline TTL
+      // so a ramping tenant gets its first baseline within minutes.
+      expect(INSUFFICIENT_DATA_RECHECK_SECONDS).toBeLessThan(
+        TenantRateTracker.BASELINE_TTL_SECONDS / 2,
+      );
     });
   });
 

--- a/langwatch/src/server/observability/__tests__/anomalyDetector.unit.test.ts
+++ b/langwatch/src/server/observability/__tests__/anomalyDetector.unit.test.ts
@@ -27,9 +27,18 @@ function makeFakes() {
         ),
       setCachedBaseline: vi
         .fn()
-        .mockImplementation(async (tid: string, v: number) => {
-          baselineCache.set(tid, v);
-        }),
+        .mockImplementation(
+          async ({
+            tenantId,
+            baseline,
+          }: {
+            tenantId: string;
+            baseline: number;
+            ttlSeconds?: number;
+          }) => {
+            baselineCache.set(tenantId, baseline);
+          },
+        ),
     } as any,
     baselineCache,
     anomalyState: {
@@ -324,11 +333,11 @@ describe("AnomalyDetector.tick", () => {
       const detector = new AnomalyDetector(fakes);
       await detector.tick();
 
-      expect(fakes.rateTracker.setCachedBaseline).toHaveBeenCalledWith(
-        "proj_new",
-        0,
-        INSUFFICIENT_DATA_RECHECK_SECONDS,
-      );
+      expect(fakes.rateTracker.setCachedBaseline).toHaveBeenCalledWith({
+        tenantId: "proj_new",
+        baseline: 0,
+        ttlSeconds: INSUFFICIENT_DATA_RECHECK_SECONDS,
+      });
       // The verdict re-check window must stay well under the 1h baseline TTL
       // so a ramping tenant gets its first baseline within minutes.
       expect(INSUFFICIENT_DATA_RECHECK_SECONDS).toBeLessThan(

--- a/langwatch/src/server/observability/__tests__/tenantRateTracker.unit.test.ts
+++ b/langwatch/src/server/observability/__tests__/tenantRateTracker.unit.test.ts
@@ -203,7 +203,7 @@ describe("TenantRateTracker", () => {
     it("round-trips a numeric baseline through Redis", async () => {
       const redis = fakeRedis();
       const tracker = new TenantRateTracker(redis, nowFn);
-      await tracker.setCachedBaseline("proj_acme", 42.5);
+      await tracker.setCachedBaseline({ tenantId: "proj_acme", baseline: 42.5 });
       expect(await tracker.getCachedBaseline("proj_acme")).toBeCloseTo(42.5);
     });
 
@@ -356,7 +356,11 @@ describe("TenantRateTracker", () => {
     };
     const tracker = new TenantRateTracker(redis, () => now);
 
-    await tracker.setCachedBaseline("proj_acme", 0, 600);
+    await tracker.setCachedBaseline({
+      tenantId: "proj_acme",
+      baseline: 0,
+      ttlSeconds: 600,
+    });
 
     expect(setCalls[0]).toEqual([
       "obs:tenant_rate:baseline:proj_acme",

--- a/langwatch/src/server/observability/__tests__/tenantRateTracker.unit.test.ts
+++ b/langwatch/src/server/observability/__tests__/tenantRateTracker.unit.test.ts
@@ -82,6 +82,12 @@ function fakeRedis() {
     async hmget(key: string, ...fields: string[]) {
       return ops.hmget(key, ...fields);
     },
+    async hgetall(key: string) {
+      const h = hashes.get(key);
+      const out: Record<string, string> = {};
+      if (h) for (const [f, v] of h) out[f] = String(v);
+      return out;
+    },
     async smembers(key: string) {
       return ops.smembers(key);
     },
@@ -264,5 +270,42 @@ describe("TenantRateTracker", () => {
 
     const series = await tracker.perMinuteSeries("proj_acme", 180);
     expect(series).toEqual([1, 2, 3]);
+  });
+
+  it("perMinuteSeries ignores activity outside the lookback window", async () => {
+    const redis = fakeRedis();
+    const tracker = new TenantRateTracker(redis, () => now);
+
+    // Two minutes of old traffic, then a 3-minute gap, then fresh traffic.
+    await tracker.record("proj_acme", 7);
+    now += 60_000;
+    await tracker.record("proj_acme", 8);
+    now += 4 * 60_000;
+    await tracker.record("proj_acme", 9);
+
+    // 3-minute window: the HGETALL reply still contains the old fields, but
+    // they must be dropped and the silent minutes zero-padded.
+    const series = await tracker.perMinuteSeries("proj_acme", 180);
+    expect(series).toEqual([0, 0, 9]);
+  });
+
+  it("setCachedBaseline honours a caller-provided TTL", async () => {
+    const setCalls: unknown[][] = [];
+    const redis = fakeRedis();
+    const originalSet = redis.set.bind(redis);
+    redis.set = async (...args: unknown[]) => {
+      setCalls.push(args);
+      return originalSet(...(args as [string, string]));
+    };
+    const tracker = new TenantRateTracker(redis, () => now);
+
+    await tracker.setCachedBaseline("proj_acme", 0, 600);
+
+    expect(setCalls[0]).toEqual([
+      "obs:tenant_rate:baseline:proj_acme",
+      "0",
+      "EX",
+      600,
+    ]);
   });
 });

--- a/langwatch/src/server/observability/__tests__/tenantRateTracker.unit.test.ts
+++ b/langwatch/src/server/observability/__tests__/tenantRateTracker.unit.test.ts
@@ -295,7 +295,7 @@ describe("TenantRateTracker", () => {
     const originalSet = redis.set.bind(redis);
     redis.set = async (...args: unknown[]) => {
       setCalls.push(args);
-      return originalSet(...(args as [string, string]));
+      return originalSet(...args);
     };
     const tracker = new TenantRateTracker(redis, () => now);
 

--- a/langwatch/src/server/observability/__tests__/tenantRateTracker.unit.test.ts
+++ b/langwatch/src/server/observability/__tests__/tenantRateTracker.unit.test.ts
@@ -54,6 +54,11 @@ function fakeRedis() {
     smembers(key: string) {
       return Array.from(sets.get(key) ?? new Set<string>());
     },
+    hdel(key: string, ...fields: string[]) {
+      const h = hashes.get(key);
+      if (!h) return;
+      for (const f of fields) h.delete(f);
+    },
   };
 
   return {
@@ -70,6 +75,10 @@ function fakeRedis() {
         },
         sadd(key: string, member: string) {
           queued.push(() => ops.sadd(key, member));
+          return pipe;
+        },
+        hdel(key: string, ...fields: string[]) {
+          queued.push(() => ops.hdel(key, ...fields));
           return pipe;
         },
         async exec() {
@@ -90,6 +99,9 @@ function fakeRedis() {
     },
     async smembers(key: string) {
       return ops.smembers(key);
+    },
+    async hdel(key: string, ...fields: string[]) {
+      return ops.hdel(key, ...fields);
     },
     async get(key: string) {
       return strings.get(key) ?? null;
@@ -287,6 +299,51 @@ describe("TenantRateTracker", () => {
     // they must be dropped and the silent minutes zero-padded.
     const series = await tracker.perMinuteSeries("proj_acme", 180);
     expect(series).toEqual([0, 0, 9]);
+  });
+
+  it("perMinuteSeries trims minute fields that have aged past the retention window", async () => {
+    const redis = fakeRedis();
+    const tracker = new TenantRateTracker(redis, () => now);
+    const key = "obs:tenant_rate:proj_acme";
+
+    // A field far older than the 8-day retention window — the shape a hash
+    // takes when it grew unbounded before trimming existed. HGETALL would
+    // otherwise fetch every one of these on each cold baseline read.
+    await tracker.record("proj_acme", 5);
+    const staleMinute = String(Math.floor(now / 60_000));
+    now += 30 * 24 * 60 * 60 * 1000; // 30 days later
+    await tracker.record("proj_acme", 9);
+    const freshMinute = String(Math.floor(now / 60_000));
+
+    // Precondition: write-time trim only drops the single field aging out this
+    // tick, so the 30-day-old orphan is still present before the read.
+    expect(await redis.hgetall(key)).toHaveProperty(staleMinute);
+
+    const series = await tracker.perMinuteSeries("proj_acme", 180);
+    expect(series).toEqual([0, 0, 9]);
+
+    // The read trimmed everything past the window; only in-window data remains.
+    const remaining = await redis.hgetall(key);
+    expect(remaining).not.toHaveProperty(staleMinute);
+    expect(remaining).toHaveProperty(freshMinute);
+  });
+
+  it("record trims the field that has just aged out of the retention window", async () => {
+    const redis = fakeRedis();
+    const tracker = new TenantRateTracker(redis, () => now);
+    const key = "obs:tenant_rate:proj_acme";
+
+    await tracker.record("proj_acme", 4);
+    const firstMinute = String(Math.floor(now / 60_000));
+    expect(await redis.hgetall(key)).toHaveProperty(firstMinute);
+
+    // Advance exactly the 8-day retention window and write again: the write
+    // HDELs the field now exactly one full window old, so a continuously-active
+    // tenant's hash can never grow past the window.
+    now += 8 * 24 * 60 * 60 * 1000;
+    await tracker.record("proj_acme", 1);
+
+    expect(await redis.hgetall(key)).not.toHaveProperty(firstMinute);
   });
 
   it("setCachedBaseline honours a caller-provided TTL", async () => {

--- a/langwatch/src/server/observability/anomalyDetector.ts
+++ b/langwatch/src/server/observability/anomalyDetector.ts
@@ -30,7 +30,7 @@ const logger = createLogger("langwatch:observability:anomalyDetector");
  *
  * Cost-shape: the 7-day baseline is cached for 1h in Redis. Tick-time
  * cost for a stable tenant is one HGET; only on cold/stale cache do we
- * do the 10080-field HMGET to recompute p95. At 1000s of tenants this
+ * do the full-series HGETALL to recompute p95. At 1000s of tenants this
  * keeps the worker comfortably under the Redis ops budget.
  *
  * Kill switch: per-tenant PostHog flag (see
@@ -45,6 +45,15 @@ export const SURFACE_TIER_SUSTAIN_MINUTES = 5;
 export const HARD_TIER_SUSTAIN_MINUTES = 15;
 export const BASELINE_LOOKBACK_SECONDS = 7 * 24 * 60 * 60; // 7 days
 export const MIN_BASELINE_RATE = 5; // skip tenants with <5/min baseline (signal too noisy)
+/**
+ * How long the "not enough data for a baseline yet" verdict is cached.
+ * Deliberately much shorter than the 1h baseline TTL — a ramping tenant
+ * should get its first baseline within minutes of crossing the activity
+ * threshold — but long enough that the fleet's quiet tenants don't re-read
+ * their full minute series every 1-minute tick, which is what pinned prod
+ * Redis engine CPU before this cache existed (2026-07-09).
+ */
+export const INSUFFICIENT_DATA_RECHECK_SECONDS = 10 * 60;
 
 export interface AnomalyDetectorDeps {
   rateTracker: TenantRateTracker;
@@ -201,7 +210,7 @@ export class AnomalyDetector {
 
   /**
    * Return the p95 baseline for a tenant. Uses the 1h Redis cache when
-   * fresh; on cache miss does a single 10080-field HMGET, computes the
+   * fresh; on cache miss does a single full-series HGETALL, computes the
    * p95, persists it back, and returns it.
    *
    * Returns null when:
@@ -217,7 +226,7 @@ export class AnomalyDetector {
     const cached = await this.deps.rateTracker.getCachedBaseline(tenantId);
     if (cached !== null) {
       // Cached value below the floor still tells us "do not evaluate" —
-      // no need to re-scan 10080 fields just to confirm.
+      // no need to re-read the full series just to confirm.
       return cached < MIN_BASELINE_RATE ? null : cached;
     }
 
@@ -231,15 +240,22 @@ export class AnomalyDetector {
     // skip tenants who haven't actually produced traffic.
     const nonZero = series.filter((v) => v > 0);
     if (nonZero.length < 60) {
-      // Less than 1h of actual activity — baseline would be noise. Skip,
-      // but DON'T cache: we want to re-check soon, not pin "no data"
-      // for an hour.
+      // Less than 1h of actual activity — baseline would be noise. Cache the
+      // verdict briefly (0 reads back as below-floor = "do not evaluate"):
+      // long enough that a fleet of quiet tenants doesn't re-read its full
+      // minute series every 1-minute tick, short enough that a ramping
+      // tenant gets its first baseline within minutes.
+      await this.deps.rateTracker.setCachedBaseline(
+        tenantId,
+        0,
+        INSUFFICIENT_DATA_RECHECK_SECONDS,
+      );
       return null;
     }
 
     const baseline = percentile({ values: nonZero, p: 95 });
     // Cache whatever we compute (including below-floor values) so the
-    // "too-quiet" tenants don't keep paying the HMGET cost every tick.
+    // "too-quiet" tenants don't keep paying the series-read cost every tick.
     await this.deps.rateTracker.setCachedBaseline(tenantId, baseline);
     return baseline < MIN_BASELINE_RATE ? null : baseline;
   }

--- a/langwatch/src/server/observability/anomalyDetector.ts
+++ b/langwatch/src/server/observability/anomalyDetector.ts
@@ -245,18 +245,18 @@ export class AnomalyDetector {
       // long enough that a fleet of quiet tenants doesn't re-read its full
       // minute series every 1-minute tick, short enough that a ramping
       // tenant gets its first baseline within minutes.
-      await this.deps.rateTracker.setCachedBaseline(
+      await this.deps.rateTracker.setCachedBaseline({
         tenantId,
-        0,
-        INSUFFICIENT_DATA_RECHECK_SECONDS,
-      );
+        baseline: 0,
+        ttlSeconds: INSUFFICIENT_DATA_RECHECK_SECONDS,
+      });
       return null;
     }
 
     const baseline = percentile({ values: nonZero, p: 95 });
     // Cache whatever we compute (including below-floor values) so the
     // "too-quiet" tenants don't keep paying the series-read cost every tick.
-    await this.deps.rateTracker.setCachedBaseline(tenantId, baseline);
+    await this.deps.rateTracker.setCachedBaseline({ tenantId, baseline });
     return baseline < MIN_BASELINE_RATE ? null : baseline;
   }
 }

--- a/langwatch/src/server/observability/tenantRateTracker.ts
+++ b/langwatch/src/server/observability/tenantRateTracker.ts
@@ -265,11 +265,15 @@ export class TenantRateTracker {
    * briefly so quiet tenants don't re-pay the full-series read every tick).
    * Called once per tenant per tick at most when the cache is cold or stale.
    */
-  async setCachedBaseline(
-    tenantId: string,
-    baseline: number,
-    ttlSeconds: number = TenantRateTracker.BASELINE_TTL_SECONDS,
-  ): Promise<void> {
+  async setCachedBaseline({
+    tenantId,
+    baseline,
+    ttlSeconds = TenantRateTracker.BASELINE_TTL_SECONDS,
+  }: {
+    tenantId: string;
+    baseline: number;
+    ttlSeconds?: number;
+  }): Promise<void> {
     try {
       await this.redis.set(
         `${TenantRateTracker.BASELINE_PREFIX}${tenantId}`,

--- a/langwatch/src/server/observability/tenantRateTracker.ts
+++ b/langwatch/src/server/observability/tenantRateTracker.ts
@@ -38,8 +38,8 @@ export const GLOBAL_KILL_SWITCH_DISTINCT_ID = "global";
  *  - The active-tenants index `obs:tenant_rate:active` is a SET — fast
  *    SMEMBERS for the periodic anomaly sweep, no key SCAN required.
  *  - `obs:tenant_rate:baseline:<tenantId>` caches the computed p95
- *    baseline for ~1h so the worker tick does not redo a 10080-field
- *    HMGET for every tenant every minute.
+ *    baseline for ~1h so the worker tick does not redo the full-series
+ *    HGETALL for every tenant every minute.
  *
  * Why minute-bucketed (not per-event ZSET):
  *  - O(1) write per enqueue (HINCRBY) vs O(log N) for ZADD with random nonce
@@ -56,7 +56,7 @@ export class TenantRateTracker {
    * Baseline cache TTL. The p95 of a 7-day window does not move
    * meaningfully in an hour — caching this is the single biggest
    * tick-cost reduction available, dropping per-tenant tick cost from
-   * one 10080-field HMGET to one HGET.
+   * one full-series HGETALL to one HGET.
    */
   public static readonly BASELINE_TTL_SECONDS = 60 * 60; // 1h
 
@@ -145,9 +145,18 @@ export class TenantRateTracker {
   }
 
   /**
-   * Per-minute rates across the last `lookbackSeconds`. Sorted oldest-first.
-   * Used by the anomaly detector to compute rolling p95 baselines without
-   * fetching unbounded data.
+   * Per-minute rates across the last `lookbackSeconds`. Sorted oldest-first,
+   * zero-padded for silent minutes. Used by the anomaly detector to compute
+   * rolling p95 baselines without fetching unbounded data.
+   *
+   * Reads via HGETALL, not an HMGET enumerating every minute of the window:
+   * the hash only holds minutes with activity, so HGETALL's cost scales with
+   * the tenant's actual traffic, while a 7-day window HMGET forced Redis to
+   * look up 10,080 requested fields (~1.8 ms of engine CPU each) regardless
+   * of how sparse the hash was — measured as the single largest engine-CPU
+   * consumer on prod (2026-07-09). The hash is bounded at one field per
+   * active minute over the 8-day TTL, so the reply can never exceed ~11.5k
+   * fields.
    */
   async perMinuteSeries(
     tenantId: string,
@@ -155,13 +164,18 @@ export class TenantRateTracker {
   ): Promise<number[]> {
     const minuteNow = Math.floor(this.nowFn() / 60_000);
     const minutesBack = Math.max(1, Math.ceil(lookbackSeconds / 60));
-    const fields: string[] = [];
-    for (let i = minutesBack - 1; i >= 0; i--) {
-      fields.push(String(minuteNow - i));
-    }
+    const oldestMinute = minuteNow - (minutesBack - 1);
     const key = `${TenantRateTracker.KEY_PREFIX}${tenantId}`;
-    const values = await this.redis.hmget(key, ...fields);
-    return values.map((v) => (v ? Number.parseInt(v, 10) || 0 : 0));
+    const entries = await this.redis.hgetall(key);
+    const series = new Array<number>(minutesBack).fill(0);
+    for (const [field, value] of Object.entries(entries)) {
+      const minute = Number.parseInt(field, 10);
+      if (!Number.isFinite(minute)) continue;
+      const index = minute - oldestMinute;
+      if (index < 0 || index >= minutesBack) continue;
+      series[index] = Number.parseInt(value, 10) || 0;
+    }
+    return series;
   }
 
   /**
@@ -194,16 +208,22 @@ export class TenantRateTracker {
   }
 
   /**
-   * Persist a fresh baseline with the standard 1h TTL. Called once per
-   * tenant per tick at most when the cache is cold or stale.
+   * Persist a fresh baseline with the standard 1h TTL (or a caller-chosen
+   * shorter one — the detector caches its "not enough data yet" verdict
+   * briefly so quiet tenants don't re-pay the full-series read every tick).
+   * Called once per tenant per tick at most when the cache is cold or stale.
    */
-  async setCachedBaseline(tenantId: string, baseline: number): Promise<void> {
+  async setCachedBaseline(
+    tenantId: string,
+    baseline: number,
+    ttlSeconds: number = TenantRateTracker.BASELINE_TTL_SECONDS,
+  ): Promise<void> {
     try {
       await this.redis.set(
         `${TenantRateTracker.BASELINE_PREFIX}${tenantId}`,
         baseline.toString(),
         "EX",
-        TenantRateTracker.BASELINE_TTL_SECONDS,
+        ttlSeconds,
       );
     } catch (err) {
       logger.debug(

--- a/langwatch/src/server/observability/tenantRateTracker.ts
+++ b/langwatch/src/server/observability/tenantRateTracker.ts
@@ -53,6 +53,21 @@ export class TenantRateTracker {
   private static readonly BASELINE_PREFIX = "obs:tenant_rate:baseline:";
   private static readonly TTL_SECONDS = 8 * 24 * 3600; // 8 days
   /**
+   * Retention window in minutes (== the key TTL). A minute field older than
+   * this is past the point any reader looks at and only inflates the HGETALL
+   * reply, so it is trimmed both on write (the field aging out this tick) and
+   * on read (any orphan older than the window — including hashes that grew
+   * unbounded before trimming existed). Bounds the hash at ~one field per
+   * active minute over the window.
+   */
+  private static readonly RETENTION_MINUTES = TenantRateTracker.TTL_SECONDS / 60;
+  /**
+   * Batch size for the on-read orphan trim. A hash that predates trimming can
+   * hold hundreds of thousands of fields; delete them in chunks so a single
+   * HDEL command never carries a pathological arg list.
+   */
+  private static readonly TRIM_BATCH = 500;
+  /**
    * Baseline cache TTL. The p95 of a 7-day window does not move
    * meaningfully in an hour — caching this is the single biggest
    * tick-cost reduction available, dropping per-tenant tick cost from
@@ -107,6 +122,11 @@ export class TenantRateTracker {
       // ioredis pipelines auto-batch for both standalone and cluster modes
       const pipe = this.redis.pipeline();
       pipe.hincrby(key, String(minute), count);
+      // Drop the field aging out of the window this tick. The key TTL is
+      // refreshed below on every write, so an active tenant's key never
+      // expires — without this trim the hash would accumulate one field per
+      // active minute forever and HGETALL would grow without bound.
+      pipe.hdel(key, String(minute - TenantRateTracker.RETENTION_MINUTES));
       pipe.expire(key, TenantRateTracker.TTL_SECONDS);
       pipe.sadd(TenantRateTracker.ACTIVE_SET, tenantId);
       pipe.expire(TenantRateTracker.ACTIVE_SET, TenantRateTracker.TTL_SECONDS);
@@ -154,9 +174,10 @@ export class TenantRateTracker {
    * the tenant's actual traffic, while a 7-day window HMGET forced Redis to
    * look up 10,080 requested fields (~1.8 ms of engine CPU each) regardless
    * of how sparse the hash was — measured as the single largest engine-CPU
-   * consumer on prod (2026-07-09). The hash is bounded at one field per
-   * active minute over the 8-day TTL, so the reply can never exceed ~11.5k
-   * fields.
+   * consumer on prod (2026-07-09). The hash is trimmed to the retention
+   * window on both write and read (see {@link RETENTION_MINUTES}), so it
+   * holds at most one field per active minute over that window and the reply
+   * can never exceed ~11.5k fields however long the tenant stays active.
    */
   async perMinuteSeries(
     tenantId: string,
@@ -165,17 +186,48 @@ export class TenantRateTracker {
     const minuteNow = Math.floor(this.nowFn() / 60_000);
     const minutesBack = Math.max(1, Math.ceil(lookbackSeconds / 60));
     const oldestMinute = minuteNow - (minutesBack - 1);
+    const retentionCutoff = minuteNow - TenantRateTracker.RETENTION_MINUTES;
     const key = `${TenantRateTracker.KEY_PREFIX}${tenantId}`;
     const entries = await this.redis.hgetall(key);
     const series = new Array<number>(minutesBack).fill(0);
+    const staleFields: string[] = [];
     for (const [field, value] of Object.entries(entries)) {
       const minute = Number.parseInt(field, 10);
       if (!Number.isFinite(minute)) continue;
+      if (minute < retentionCutoff) {
+        staleFields.push(field);
+        continue;
+      }
       const index = minute - oldestMinute;
       if (index < 0 || index >= minutesBack) continue;
       series[index] = Number.parseInt(value, 10) || 0;
     }
+    await this.trimStaleFields(key, staleFields);
     return series;
+  }
+
+  /**
+   * Best-effort removal of minute fields that have aged past the retention
+   * window. Trim-on-write keeps a steadily-active tenant bounded, but a hash
+   * that grew before trimming existed (or a tenant with silent gaps) can
+   * still carry orphans older than the window; the anomaly tick already reads
+   * the whole hash, so it cleans them up here. Batched so a single HDEL never
+   * carries a pathological arg list, and swallowed on error so a cleanup
+   * hiccup never fails the baseline read.
+   */
+  private async trimStaleFields(key: string, fields: string[]): Promise<void> {
+    if (fields.length === 0) return;
+    try {
+      for (let i = 0; i < fields.length; i += TenantRateTracker.TRIM_BATCH) {
+        const batch = fields.slice(i, i + TenantRateTracker.TRIM_BATCH);
+        await this.redis.hdel(key, ...batch);
+      }
+    } catch (err) {
+      logger.debug(
+        { key, err: err instanceof Error ? err.message : String(err) },
+        "TenantRateTracker.perMinuteSeries trim failed (non-fatal)",
+      );
+    }
   }
 
   /**

--- a/specs/event-sourcing/anomaly-detection.feature
+++ b/specs/event-sourcing/anomaly-detection.feature
@@ -58,8 +58,12 @@ Feature: Per-tenant rate anomaly detection
     And the result is written to Redis with a 1h TTL
 
   @unit @anomaly-detection @baseline-cache
-  Scenario: Insufficient history is NOT cached so the tenant is re-checked soon
+  # A fleet of quiet tenants re-reading its full minute series every 1-minute
+  # tick was the dominant Redis engine-CPU cost (2026-07-09). The verdict is
+  # cached briefly — far shorter than the 1h baseline TTL — so a ramping tenant
+  # still gets its first baseline within minutes.
+  Scenario: Insufficient history is cached briefly so quiet tenants are not re-read every tick
     Given tenant "proj_new" has only 3 minutes of activity
     When the AnomalyDetector tick runs
-    Then no baseline is cached for "proj_new"
-    And the tenant is skipped this tick
+    Then the tenant is skipped this tick
+    And the not-enough-data verdict is cached with a short expiry, well under the baseline's

--- a/specs/event-sourcing/anomaly-detection.feature
+++ b/specs/event-sourcing/anomaly-detection.feature
@@ -66,4 +66,4 @@ Feature: Per-tenant rate anomaly detection
     Given tenant "proj_new" has only 3 minutes of activity
     When the AnomalyDetector tick runs
     Then the tenant is skipped this tick
-    And the not-enough-data verdict is cached with a short expiry, well under the baseline's
+    And the not-enough-data verdict is cached with a short expiry, well under the baseline's 1h cache TTL


### PR DESCRIPTION
## What

Two compounding costs in the anomaly detector's 1-minute tick, together measured as the **largest single Redis engine-CPU consumer** on prod (2026-07-09): `hmget` at 29 calls/s × ~1.8 ms/call ≈ 37% of engine CPU.

1. **`perMinuteSeries` enumerated all 10,080 minutes of the 7-day window as explicit HMGET fields**, so Redis paid a lookup per requested field regardless of how sparse the tenant's hash was. It now HGETALLs the hash — which holds one field per *active* minute — and filters to the window client-side, so cost scales with the tenant's actual traffic. To keep that reply bounded, the minute hash is trimmed to the retention window on **both write and read**: `record()` HDELs the field aging out each tick, and `perMinuteSeries()` drops any field older than the window from the reply (which also self-heals hashes that grew unbounded before this change, and cleans up sparse-gap orphans). The key's 8-day TTL alone does *not* bound the hash — it is refreshed on every write, so without the trim old minute fields would accumulate for the tenant's lifetime.

2. **Quiet tenants re-paid the full read every tick, forever.** A tenant with under an hour of activity deliberately never cached a baseline ("re-check soon"), which at fleet scale means every silent tenant re-reads its series every minute. The not-enough-data verdict is now cached for 10 minutes — `0` reads back through the existing below-floor skip path — so a ramping tenant still gets its first baseline within minutes while the fleet's quiet tenants cost one HGET per tick.

## Spec

`specs/event-sourcing/anomaly-detection.feature`: the baseline-cache scenario now states the brief-cache behaviour ("Insufficient history is cached briefly so quiet tenants are not re-read every tick"), with the incident rationale in a comment. Feature-parity gate passes (2,403 scenarios bound).

## Tests

- `perMinuteSeries` window-filtering (old fields in the HGETALL reply are dropped, silent minutes zero-padded)
- `perMinuteSeries` trims fields past the retention window (bounds a hash that grew unbounded); `record()` drops the field aging out on each write
- `setCachedBaseline` (named params) honours the caller-provided TTL
- detector caches the verdict with `INSUFFICIENT_DATA_RECHECK_SECONDS` and that constant stays well under the baseline TTL
- observability suite: 38 passed

https://claude.ai/code/session_01BUi7eLwDkxpZGUgujjPJ8L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced repeated history reads during anomaly detection by caching short-lived “insufficient data” outcomes and trimming per-tenant minute history to a fixed retention window.
- **Anomaly Detection**
  - Tenants below the minimum activity threshold now get a cached “not-enough-data” verdict with a brief recheck interval.
  - Baseline cache entries now support configurable expiration periods.
- **Tests**
  - Updated and extended unit tests to cover baseline TTL handling and minute-series retention/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->