### PR TITLE
fix(group-queue): move dedup-squash blob-hold transfers into the stage eval

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -690,6 +690,375 @@ describe("GroupStagingScripts", () => {
       });
     });
 
+    // GQ2 blob holds move INSIDE the stage eval, atomic with the squash that
+    // displaces the value they guard. The old post-eval fire-and-forget
+    // transfer could reorder against a concurrent squash of the same dedup id
+    // and leave a phantom hold pinning the blob until its TTL — the 2026-07-09
+    // leak (~279k orphaned blobs, ~1.9 GB of prod Redis).
+    describe("given GQ2 offloaded values with blob holds", () => {
+      const TENANT = "project-x";
+      const GROUP = `${TENANT}/group-1`;
+
+      function gq2Value({
+        hash,
+        token,
+        tier = "redis",
+        projectId = TENANT,
+      }: {
+        hash: string;
+        token: string;
+        tier?: "redis" | "s3";
+        projectId?: string;
+      }): string {
+        const header = JSON.stringify({
+          v: 2,
+          e: tier,
+          ref: { tier, projectId, hash },
+          h: token,
+        });
+        return `GQ2|${Buffer.byteLength(header)}|${header}`;
+      }
+
+      function holderKey(hash: string, projectId = TENANT) {
+        return `${keyPrefix()}blobholders:${projectId}/${hash}`;
+      }
+
+      function blobKey(hash: string, projectId = TENANT) {
+        return `${keyPrefix()}blob:${projectId}/${hash}`;
+      }
+
+      /** Simulates the producer's blob write + hold acquire for a staged value. */
+      async function seedBlobAndHold(hash: string, token: string) {
+        await redis.set(blobKey(hash), "gzipped-bytes");
+        await redis.sadd(holderKey(hash), token);
+      }
+
+      describe("when a replace squash displaces a staged GQ2 value", () => {
+        /** @scenario "A dedup squash transfers the hold inside the stage eval" */
+        it("adds the replacement's hold, drops the displaced one, and reclaims its blob in the eval", async () => {
+          const oldValue = gq2Value({ hash: "h1", token: "t1" });
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              groupId: GROUP,
+              dedupId: "hold-replace",
+              dedupTtlMs: 60000,
+              jobDataJson: oldValue,
+            }),
+          );
+          await seedBlobAndHold("h1", "t1");
+          await redis.set(blobKey("h2"), "gzipped-bytes");
+
+          const { isNew, orphanedValue, reclaimS3 } = await scripts.stage(
+            makeJob({
+              stagedJobId: "j2",
+              groupId: GROUP,
+              dedupId: "hold-replace",
+              dedupTtlMs: 60000,
+              jobDataJson: gq2Value({ hash: "h2", token: "t2" }),
+            }),
+          );
+
+          expect(isNew).toBe(false);
+          expect(orphanedValue).toBe(oldValue);
+          expect(reclaimS3).toBe(false);
+          // Replacement holds its blob; the displaced hold and blob are gone.
+          expect(await redis.smembers(holderKey("h2"))).toEqual(["t2"]);
+          expect(await redis.ttl(holderKey("h2"))).toBeGreaterThan(0);
+          expect(await redis.exists(holderKey("h1"))).toBe(0);
+          expect(await redis.exists(blobKey("h1"))).toBe(0);
+        });
+
+        it("keeps a displaced blob other stages still hold", async () => {
+          const shared = gq2Value({ hash: "h-shared", token: "t1" });
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              groupId: GROUP,
+              dedupId: "hold-shared",
+              dedupTtlMs: 60000,
+              jobDataJson: shared,
+            }),
+          );
+          await seedBlobAndHold("h-shared", "t1");
+          // A second staged occupancy (another group) holds the same content.
+          await redis.sadd(holderKey("h-shared"), "t-other");
+
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j2",
+              groupId: GROUP,
+              dedupId: "hold-shared",
+              dedupTtlMs: 60000,
+              jobDataJson: gq2Value({ hash: "h2", token: "t2" }),
+            }),
+          );
+
+          // t1 released, t-other still holds — the blob must survive.
+          expect(await redis.smembers(holderKey("h-shared"))).toEqual([
+            "t-other",
+          ]);
+          expect(await redis.exists(blobKey("h-shared"))).toBe(1);
+        });
+
+        it("reports an s3-tier displaced blob for out-of-band deletion", async () => {
+          const oldValue = gq2Value({ hash: "h-s3", token: "t1", tier: "s3" });
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              groupId: GROUP,
+              dedupId: "hold-s3",
+              dedupTtlMs: 60000,
+              jobDataJson: oldValue,
+            }),
+          );
+          await redis.sadd(holderKey("h-s3"), "t1");
+
+          const { orphanedValue, reclaimS3 } = await scripts.stage(
+            makeJob({
+              stagedJobId: "j2",
+              groupId: GROUP,
+              dedupId: "hold-s3",
+              dedupTtlMs: 60000,
+              jobDataJson: gq2Value({ hash: "h2", token: "t2" }),
+            }),
+          );
+
+          // Lua cannot reach s3: the holder set is emptied here and the caller
+          // is told to delete the object.
+          expect(orphanedValue).toBe(oldValue);
+          expect(reclaimS3).toBe(true);
+          expect(await redis.exists(holderKey("h-s3"))).toBe(0);
+        });
+
+        it("UNLINKs a displaced GQ1 blob directly (mixed-format rollout)", async () => {
+          const gq1Header = JSON.stringify({ v: 1, e: "ref", r: "legacy-id" });
+          const gq1Value = `GQ1|${Buffer.byteLength(gq1Header)}|${gq1Header}`;
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              groupId: GROUP,
+              dedupId: "hold-gq1",
+              dedupTtlMs: 60000,
+              jobDataJson: gq1Value,
+            }),
+          );
+          await redis.set(`${keyPrefix()}blob:legacy-id`, "gq1-bytes");
+
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j2",
+              groupId: GROUP,
+              dedupId: "hold-gq1",
+              dedupTtlMs: 60000,
+              jobDataJson: gq2Value({ hash: "h2", token: "t2" }),
+            }),
+          );
+
+          expect(await redis.exists(`${keyPrefix()}blob:legacy-id`)).toBe(0);
+          expect(await redis.smembers(holderKey("h2"))).toEqual(["t2"]);
+        });
+      });
+
+      describe("when a job is squashed twice in succession", () => {
+        /** @scenario "A squash chain never leaves a phantom hold" */
+        it("leaves only the final value's hold and reclaims every displaced blob", async () => {
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              groupId: GROUP,
+              dedupId: "hold-chain",
+              dedupTtlMs: 60000,
+              jobDataJson: gq2Value({ hash: "h1", token: "t1" }),
+            }),
+          );
+          await seedBlobAndHold("h1", "t1");
+
+          for (const [hash, token] of [
+            ["h2", "t2"],
+            ["h3", "t3"],
+          ] as const) {
+            await redis.set(blobKey(hash), "gzipped-bytes");
+            await scripts.stage(
+              makeJob({
+                stagedJobId: `j-${hash}`,
+                groupId: GROUP,
+                dedupId: "hold-chain",
+                dedupTtlMs: 60000,
+                jobDataJson: gq2Value({ hash, token }),
+              }),
+            );
+          }
+
+          expect(await redis.smembers(holderKey("h3"))).toEqual(["t3"]);
+          expect(await redis.exists(holderKey("h1"))).toBe(0);
+          expect(await redis.exists(holderKey("h2"))).toBe(0);
+          expect(await redis.exists(blobKey("h1"))).toBe(0);
+          expect(await redis.exists(blobKey("h2"))).toBe(0);
+          expect(await redis.exists(blobKey("h3"))).toBe(1);
+        });
+      });
+
+      describe("when the squash keeps the stored payload (replace off)", () => {
+        /** @scenario "A squash that keeps the stored payload acquires no hold for the discarded value" */
+        it("leaves the stored hold untouched and records none for the discarded value", async () => {
+          const kept = gq2Value({ hash: "h-kept", token: "t-kept" });
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              groupId: GROUP,
+              dedupId: "hold-keep",
+              dedupTtlMs: 60000,
+              jobDataJson: kept,
+              shouldExtend: false,
+              shouldReplace: false,
+            }),
+          );
+          await seedBlobAndHold("h-kept", "t-kept");
+
+          const discarded = gq2Value({ hash: "h-disc", token: "t-disc" });
+          const { orphanedValue, reclaimS3 } = await scripts.stage(
+            makeJob({
+              stagedJobId: "j2",
+              groupId: GROUP,
+              dedupId: "hold-keep",
+              dedupTtlMs: 60000,
+              jobDataJson: discarded,
+              shouldExtend: false,
+              shouldReplace: false,
+            }),
+          );
+
+          // The discarded value was never staged: no hold may exist for it —
+          // the old code self-transferred and minted a phantom hold here.
+          expect(orphanedValue).toBe(discarded);
+          expect(reclaimS3).toBe(false);
+          expect(await redis.smembers(holderKey("h-kept"))).toEqual(["t-kept"]);
+          expect(await redis.exists(holderKey("h-disc"))).toBe(0);
+        });
+      });
+
+      describe("when a survive-dispatch squash hits an already-dispatched dedup", () => {
+        /** @scenario "A post-dispatch survive-dispatch squash acquires no hold for the discarded value" */
+        it("records no hold for the discarded value", async () => {
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              groupId: GROUP,
+              dedupId: "hold-survive",
+              dedupTtlMs: 60000,
+              dispatchAfterMs: 0,
+              jobDataJson: gq2Value({ hash: "h1", token: "t1" }),
+              shouldSurviveDispatch: true,
+            }),
+          );
+          const dispatched = await scripts.dispatch({
+            nowMs: Date.now(),
+            activeTtlSec: 30,
+          });
+          expect(dispatched?.stagedJobId).toBe("j1");
+
+          const late = gq2Value({ hash: "h-late", token: "t-late" });
+          const { isNew, orphanedValue, reclaimS3 } = await scripts.stage(
+            makeJob({
+              stagedJobId: "j2",
+              groupId: GROUP,
+              dedupId: "hold-survive",
+              dedupTtlMs: 60000,
+              jobDataJson: late,
+              shouldSurviveDispatch: true,
+            }),
+          );
+
+          expect(isNew).toBe(false);
+          expect(orphanedValue).toBe(late);
+          expect(reclaimS3).toBe(false);
+          expect(await redis.exists(holderKey("h-late"))).toBe(0);
+        });
+      });
+
+      describe("when the displaced ref belongs to another tenant", () => {
+        it("skips the foreign hold and leaves it to its TTL", async () => {
+          const foreign = gq2Value({
+            hash: "h-foreign",
+            token: "t-foreign",
+            projectId: "project-other",
+          });
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              groupId: GROUP,
+              dedupId: "hold-foreign",
+              dedupTtlMs: 60000,
+              jobDataJson: foreign,
+            }),
+          );
+          await redis.set(blobKey("h-foreign", "project-other"), "bytes");
+          await redis.sadd(holderKey("h-foreign", "project-other"), "t-foreign");
+
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j2",
+              groupId: GROUP,
+              dedupId: "hold-foreign",
+              dedupTtlMs: 60000,
+              jobDataJson: gq2Value({ hash: "h2", token: "t2" }),
+            }),
+          );
+
+          // Mirror of the TS release guard (ADR-030 §5): never touch a hold
+          // whose ref is not this group's tenant.
+          expect(
+            await redis.smembers(holderKey("h-foreign", "project-other")),
+          ).toEqual(["t-foreign"]);
+          expect(await redis.exists(blobKey("h-foreign", "project-other"))).toBe(
+            1,
+          );
+        });
+      });
+
+      describe("when the batch script squashes a GQ2 value", () => {
+        it("transfers holds per entry and flags s3 reclaims index-aligned", async () => {
+          const oldS3 = gq2Value({ hash: "hb-s3", token: "tb1", tier: "s3" });
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j0",
+              groupId: GROUP,
+              dedupId: "batch-hold",
+              dedupTtlMs: 60000,
+              jobDataJson: oldS3,
+            }),
+          );
+          await redis.sadd(holderKey("hb-s3"), "tb1");
+
+          const { orphanedValues, reclaimS3Flags } = await scripts.stageBatch([
+            makeJob({
+              stagedJobId: "j1",
+              groupId: GROUP,
+              dedupId: "batch-hold",
+              dedupTtlMs: 60000,
+              jobDataJson: gq2Value({ hash: "hb2", token: "tb2" }),
+            }),
+            makeJob({
+              stagedJobId: "j2",
+              groupId: `${TENANT}/group-2`,
+              dedupId: "batch-fresh-hold",
+              dedupTtlMs: 60000,
+              jobDataJson: gq2Value({ hash: "hb3", token: "tb3" }),
+            }),
+          ]);
+
+          expect(orphanedValues).toEqual([oldS3, ""]);
+          expect(reclaimS3Flags).toEqual([true, false]);
+          expect(await redis.smembers(holderKey("hb2"))).toEqual(["tb2"]);
+          expect(await redis.exists(holderKey("hb-s3"))).toBe(0);
+          // Entry 1 was a fresh stage: its hold is the PRODUCER's to acquire,
+          // not the eval's.
+          expect(await redis.exists(holderKey("hb3"))).toBe(0);
+        });
+      });
+    });
+
     describe("edge cases", () => {
       it("creates genuinely new job after dedup TTL expires", async () => {
         await scripts.stage(

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -719,22 +719,40 @@ describe("GroupStagingScripts", () => {
         return `GQ2|${Buffer.byteLength(header)}|${header}`;
       }
 
-      function holderKey(hash: string, projectId = TENANT) {
+      function holderKey({
+        hash,
+        projectId = TENANT,
+      }: {
+        hash: string;
+        projectId?: string;
+      }) {
         return `${keyPrefix()}blobholders:${projectId}/${hash}`;
       }
 
-      function blobKey(hash: string, projectId = TENANT) {
+      function blobKey({
+        hash,
+        projectId = TENANT,
+      }: {
+        hash: string;
+        projectId?: string;
+      }) {
         return `${keyPrefix()}blob:${projectId}/${hash}`;
       }
 
       /** Simulates the producer's blob write + hold acquire for a staged value. */
-      async function seedBlobAndHold(hash: string, token: string) {
-        await redis.set(blobKey(hash), "gzipped-bytes");
-        await redis.sadd(holderKey(hash), token);
+      async function seedBlobAndHold({
+        hash,
+        token,
+      }: {
+        hash: string;
+        token: string;
+      }) {
+        await redis.set(blobKey({ hash }), "gzipped-bytes");
+        await redis.sadd(holderKey({ hash }), token);
       }
 
       describe("when a replace squash displaces a staged GQ2 value", () => {
-        /** @scenario "A dedup squash transfers the hold inside the stage eval" */
+        /** @scenario "A dedup squash leaves no phantom hold and reclaims only unreferenced blobs" */
         it("adds the replacement's hold, drops the displaced one, and reclaims its blob in the eval", async () => {
           const oldValue = gq2Value({ hash: "h1", token: "t1" });
           await scripts.stage(
@@ -746,8 +764,8 @@ describe("GroupStagingScripts", () => {
               jobDataJson: oldValue,
             }),
           );
-          await seedBlobAndHold("h1", "t1");
-          await redis.set(blobKey("h2"), "gzipped-bytes");
+          await seedBlobAndHold({ hash: "h1", token: "t1" });
+          await redis.set(blobKey({ hash: "h2" }), "gzipped-bytes");
 
           const { isNew, orphanedValue, reclaimS3 } = await scripts.stage(
             makeJob({
@@ -763,10 +781,10 @@ describe("GroupStagingScripts", () => {
           expect(orphanedValue).toBe(oldValue);
           expect(reclaimS3).toBe(false);
           // Replacement holds its blob; the displaced hold and blob are gone.
-          expect(await redis.smembers(holderKey("h2"))).toEqual(["t2"]);
-          expect(await redis.ttl(holderKey("h2"))).toBeGreaterThan(0);
-          expect(await redis.exists(holderKey("h1"))).toBe(0);
-          expect(await redis.exists(blobKey("h1"))).toBe(0);
+          expect(await redis.smembers(holderKey({ hash: "h2" }))).toEqual(["t2"]);
+          expect(await redis.ttl(holderKey({ hash: "h2" }))).toBeGreaterThan(0);
+          expect(await redis.exists(holderKey({ hash: "h1" }))).toBe(0);
+          expect(await redis.exists(blobKey({ hash: "h1" }))).toBe(0);
         });
 
         it("keeps a displaced blob other stages still hold", async () => {
@@ -780,9 +798,9 @@ describe("GroupStagingScripts", () => {
               jobDataJson: shared,
             }),
           );
-          await seedBlobAndHold("h-shared", "t1");
+          await seedBlobAndHold({ hash: "h-shared", token: "t1" });
           // A second staged occupancy (another group) holds the same content.
-          await redis.sadd(holderKey("h-shared"), "t-other");
+          await redis.sadd(holderKey({ hash: "h-shared" }), "t-other");
 
           await scripts.stage(
             makeJob({
@@ -795,10 +813,10 @@ describe("GroupStagingScripts", () => {
           );
 
           // t1 released, t-other still holds — the blob must survive.
-          expect(await redis.smembers(holderKey("h-shared"))).toEqual([
+          expect(await redis.smembers(holderKey({ hash: "h-shared" }))).toEqual([
             "t-other",
           ]);
-          expect(await redis.exists(blobKey("h-shared"))).toBe(1);
+          expect(await redis.exists(blobKey({ hash: "h-shared" }))).toBe(1);
         });
 
         it("reports an s3-tier displaced blob for out-of-band deletion", async () => {
@@ -812,7 +830,7 @@ describe("GroupStagingScripts", () => {
               jobDataJson: oldValue,
             }),
           );
-          await redis.sadd(holderKey("h-s3"), "t1");
+          await redis.sadd(holderKey({ hash: "h-s3" }), "t1");
 
           const { orphanedValue, reclaimS3 } = await scripts.stage(
             makeJob({
@@ -828,7 +846,7 @@ describe("GroupStagingScripts", () => {
           // is told to delete the object.
           expect(orphanedValue).toBe(oldValue);
           expect(reclaimS3).toBe(true);
-          expect(await redis.exists(holderKey("h-s3"))).toBe(0);
+          expect(await redis.exists(holderKey({ hash: "h-s3" }))).toBe(0);
         });
 
         it("UNLINKs a displaced GQ1 blob directly (mixed-format rollout)", async () => {
@@ -856,7 +874,7 @@ describe("GroupStagingScripts", () => {
           );
 
           expect(await redis.exists(`${keyPrefix()}blob:legacy-id`)).toBe(0);
-          expect(await redis.smembers(holderKey("h2"))).toEqual(["t2"]);
+          expect(await redis.smembers(holderKey({ hash: "h2" }))).toEqual(["t2"]);
         });
       });
 
@@ -872,13 +890,13 @@ describe("GroupStagingScripts", () => {
               jobDataJson: gq2Value({ hash: "h1", token: "t1" }),
             }),
           );
-          await seedBlobAndHold("h1", "t1");
+          await seedBlobAndHold({ hash: "h1", token: "t1" });
 
           for (const [hash, token] of [
             ["h2", "t2"],
             ["h3", "t3"],
           ] as const) {
-            await redis.set(blobKey(hash), "gzipped-bytes");
+            await redis.set(blobKey({ hash }), "gzipped-bytes");
             await scripts.stage(
               makeJob({
                 stagedJobId: `j-${hash}`,
@@ -890,12 +908,12 @@ describe("GroupStagingScripts", () => {
             );
           }
 
-          expect(await redis.smembers(holderKey("h3"))).toEqual(["t3"]);
-          expect(await redis.exists(holderKey("h1"))).toBe(0);
-          expect(await redis.exists(holderKey("h2"))).toBe(0);
-          expect(await redis.exists(blobKey("h1"))).toBe(0);
-          expect(await redis.exists(blobKey("h2"))).toBe(0);
-          expect(await redis.exists(blobKey("h3"))).toBe(1);
+          expect(await redis.smembers(holderKey({ hash: "h3" }))).toEqual(["t3"]);
+          expect(await redis.exists(holderKey({ hash: "h1" }))).toBe(0);
+          expect(await redis.exists(holderKey({ hash: "h2" }))).toBe(0);
+          expect(await redis.exists(blobKey({ hash: "h1" }))).toBe(0);
+          expect(await redis.exists(blobKey({ hash: "h2" }))).toBe(0);
+          expect(await redis.exists(blobKey({ hash: "h3" }))).toBe(1);
         });
       });
 
@@ -914,7 +932,7 @@ describe("GroupStagingScripts", () => {
               shouldReplace: false,
             }),
           );
-          await seedBlobAndHold("h-kept", "t-kept");
+          await seedBlobAndHold({ hash: "h-kept", token: "t-kept" });
 
           const discarded = gq2Value({ hash: "h-disc", token: "t-disc" });
           const { orphanedValue, reclaimS3 } = await scripts.stage(
@@ -933,8 +951,8 @@ describe("GroupStagingScripts", () => {
           // the old code self-transferred and minted a phantom hold here.
           expect(orphanedValue).toBe(discarded);
           expect(reclaimS3).toBe(false);
-          expect(await redis.smembers(holderKey("h-kept"))).toEqual(["t-kept"]);
-          expect(await redis.exists(holderKey("h-disc"))).toBe(0);
+          expect(await redis.smembers(holderKey({ hash: "h-kept" }))).toEqual(["t-kept"]);
+          expect(await redis.exists(holderKey({ hash: "h-disc" }))).toBe(0);
         });
       });
 
@@ -973,7 +991,7 @@ describe("GroupStagingScripts", () => {
           expect(isNew).toBe(false);
           expect(orphanedValue).toBe(late);
           expect(reclaimS3).toBe(false);
-          expect(await redis.exists(holderKey("h-late"))).toBe(0);
+          expect(await redis.exists(holderKey({ hash: "h-late" }))).toBe(0);
         });
       });
 
@@ -993,8 +1011,8 @@ describe("GroupStagingScripts", () => {
               jobDataJson: foreign,
             }),
           );
-          await redis.set(blobKey("h-foreign", "project-other"), "bytes");
-          await redis.sadd(holderKey("h-foreign", "project-other"), "t-foreign");
+          await redis.set(blobKey({ hash: "h-foreign", projectId: "project-other" }), "bytes");
+          await redis.sadd(holderKey({ hash: "h-foreign", projectId: "project-other" }), "t-foreign");
 
           await scripts.stage(
             makeJob({
@@ -1009,9 +1027,9 @@ describe("GroupStagingScripts", () => {
           // Mirror of the TS release guard (ADR-030 §5): never touch a hold
           // whose ref is not this group's tenant.
           expect(
-            await redis.smembers(holderKey("h-foreign", "project-other")),
+            await redis.smembers(holderKey({ hash: "h-foreign", projectId: "project-other" })),
           ).toEqual(["t-foreign"]);
-          expect(await redis.exists(blobKey("h-foreign", "project-other"))).toBe(
+          expect(await redis.exists(blobKey({ hash: "h-foreign", projectId: "project-other" }))).toBe(
             1,
           );
         });
@@ -1029,7 +1047,7 @@ describe("GroupStagingScripts", () => {
               jobDataJson: oldS3,
             }),
           );
-          await redis.sadd(holderKey("hb-s3"), "tb1");
+          await redis.sadd(holderKey({ hash: "hb-s3" }), "tb1");
 
           const { orphanedValues, reclaimS3Flags } = await scripts.stageBatch([
             makeJob({
@@ -1050,11 +1068,11 @@ describe("GroupStagingScripts", () => {
 
           expect(orphanedValues).toEqual([oldS3, ""]);
           expect(reclaimS3Flags).toEqual([true, false]);
-          expect(await redis.smembers(holderKey("hb2"))).toEqual(["tb2"]);
-          expect(await redis.exists(holderKey("hb-s3"))).toBe(0);
+          expect(await redis.smembers(holderKey({ hash: "hb2" }))).toEqual(["tb2"]);
+          expect(await redis.exists(holderKey({ hash: "hb-s3" }))).toBe(0);
           // Entry 1 was a fresh stage: its hold is the PRODUCER's to acquire,
           // not the eval's.
-          expect(await redis.exists(holderKey("hb3"))).toBe(0);
+          expect(await redis.exists(holderKey({ hash: "hb3" }))).toBe(0);
         });
       });
     });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
@@ -309,7 +309,18 @@ export class EnvelopeBlobLifecycle {
     if (!hold || hold.ref.tier !== "s3" || !this.tieredBlobs) return;
     // Same guard as release(): never delete an object whose ref isn't this
     // group's tenant (ADR-030 §5).
-    if (hold.ref.projectId !== this.projectIdFor(groupId)) return;
+    if (hold.ref.projectId !== this.projectIdFor(groupId)) {
+      logger.warn(
+        {
+          projectId: this.projectIdFor(groupId),
+          refProjectId: hold.ref.projectId,
+          blobHash: hold.ref.hash,
+          groupId,
+        },
+        "Skipping S3 reclaim for a tenant-mismatched ref",
+      );
+      return;
+    }
     void this.tieredBlobs.delete(hold.ref).catch((err: unknown) => {
       gqBlobReclaimS3FailuresTotal.inc({ queue_name: this.queueName });
       // Tenant-attributed (never a bare hash, never the bucket): every blob

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
@@ -312,6 +312,8 @@ export class EnvelopeBlobLifecycle {
     if (hold.ref.projectId !== this.projectIdFor(groupId)) return;
     void this.tieredBlobs.delete(hold.ref).catch((err: unknown) => {
       gqBlobReclaimS3FailuresTotal.inc({ queue_name: this.queueName });
+      // Tenant-attributed (never a bare hash, never the bucket): every blob
+      // log line carries the owning projectId so logs can't cross tenants.
       logger.warn(
         {
           projectId: hold.ref.projectId,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
@@ -293,6 +293,39 @@ export class EnvelopeBlobLifecycle {
   }
 
   /**
+   * Deletes the s3 object of a blob whose LAST hold was already dropped inside
+   * a stage eval (the dedup-squash hold transfer runs in Lua, which cannot
+   * reach s3 — the eval reports `reclaimS3` and this finishes the job).
+   * Fire-and-forget with the same failure telemetry as the release path.
+   */
+  reclaimOrphanedS3({
+    value,
+    groupId,
+  }: {
+    value: string;
+    groupId: string;
+  }): void {
+    const hold = readEnvelopeHold(value);
+    if (!hold || hold.ref.tier !== "s3" || !this.tieredBlobs) return;
+    // Same guard as release(): never delete an object whose ref isn't this
+    // group's tenant (ADR-030 §5).
+    if (hold.ref.projectId !== this.projectIdFor(groupId)) return;
+    void this.tieredBlobs.delete(hold.ref).catch((err: unknown) => {
+      gqBlobReclaimS3FailuresTotal.inc({ queue_name: this.queueName });
+      logger.warn(
+        {
+          projectId: hold.ref.projectId,
+          blobHash: hold.ref.hash,
+          err: redactStorageUrisInText(
+            err instanceof Error ? err.message : String(err),
+          ),
+        },
+        "S3 blob reclaim failed after squash-transfer holder drop — orphaned until bucket lifecycle sweeps",
+      );
+    });
+  }
+
+  /**
    * Atomically moves the hold from a retired value to its replacement (retry
    * re-encode or dedup squash): one eval adds the new hold, drops the old, and
    * reclaims the old blob if newly unreferenced — no acquire-then-release gap in

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -424,9 +424,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     //   - a genuine new stage, whose hold the eval doesn't manage — acquire it
     //     now. When the squash DISCARDED the new value instead (replace off,
     //     or a post-dispatch survive-dispatch squash: orphanedValue equals
-    //     jobDataJson), it was never staged and gets no hold; its blob is
-    //     covered by the TTL backstop or by the holders of staged jobs sharing
-    //     its content.
+    //     jobDataJson), it was never staged and gets no hold: a discarded GQ1
+    //     blob (uniquely owned by this value) was already UNLINKed directly
+    //     inside the eval, while a GQ2 blob is content-addressed and left to
+    //     the holders of staged jobs sharing its content, or to the TTL
+    //     backstop.
     if (orphanedValue) {
       if (reclaimS3) {
         this.blobLifecycle.reclaimOrphanedS3({ value: orphanedValue, groupId });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -403,7 +403,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       groupId,
     });
 
-    const { isNew, orphanedValue } = await this.scripts.stage({
+    const { isNew, orphanedValue, reclaimS3 } = await this.scripts.stage({
       stagedJobId,
       groupId,
       dispatchAfterMs,
@@ -415,18 +415,22 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       shouldSurviveDispatch,
     });
 
-    // Acquire this occupancy's hold BEFORE releasing any payload a dedup squash
-    // displaced, so a squash re-staging identical content never drops the shared
-    // blob to zero holders. Both are no-ops for inline/legacy values.
+    // Blob holds for a dedup squash move INSIDE the stage eval, atomic with
+    // the displacement — a post-eval transfer can reorder against a concurrent
+    // squash of the same dedup id and leave a phantom hold that pins the blob
+    // until its TTL (the 2026-07-09 leak). Two cases remain on this side:
+    //   - a squash whose displaced blob is s3-tier and newly unreferenced
+    //     (Lua can't reach s3, so the eval reports it for deletion here);
+    //   - a genuine new stage, whose hold the eval doesn't manage — acquire it
+    //     now. When the squash DISCARDED the new value instead (replace off,
+    //     or a post-dispatch survive-dispatch squash: orphanedValue equals
+    //     jobDataJson), it was never staged and gets no hold; its blob is
+    //     covered by the TTL backstop or by the holders of staged jobs sharing
+    //     its content.
     if (orphanedValue) {
-      // Atomic hold transfer: a dedup squash moves the hold from the displaced
-      // value to the new one in one eval, so a partial failure can't reclaim a
-      // live blob (ADR-030 §4).
-      this.blobLifecycle.transfer({
-        newValue: jobDataJson,
-        oldValue: orphanedValue,
-        groupId,
-      });
+      if (reclaimS3) {
+        this.blobLifecycle.reclaimOrphanedS3({ value: orphanedValue, groupId });
+      }
     } else {
       this.blobLifecycle.acquire(jobDataJson);
     }
@@ -548,22 +552,22 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       }),
     );
 
-    const { newStagedCount, orphanedValues } =
+    const { newStagedCount, orphanedValues, reclaimS3Flags } =
       await this.scripts.stageBatch(jobsToStage);
 
-    // Atomically transfer the hold from any in-batch dedup-squashed value to the
-    // job that displaced it (orphanedValues is index-aligned with jobsToStage);
-    // otherwise just acquire. Matches send()'s atomic path, so a partial failure
-    // can't reclaim a live blob the way a separate acquire+release pair can
-    // (ADR-030 §4).
+    // Dedup-squash holds moved inside the stage eval (see send()); here we
+    // only delete s3 objects the eval reported newly unreferenced, and acquire
+    // holds for genuinely new stages. A squash that discarded the NEW value
+    // (orphan === the job's own value) staged nothing and gets no hold.
     jobsToStage.forEach((job, i) => {
       const orphan = orphanedValues[i];
       if (orphan && orphan.length > 0) {
-        this.blobLifecycle.transfer({
-          newValue: job.jobDataJson,
-          oldValue: orphan,
-          groupId: job.groupId,
-        });
+        if (reclaimS3Flags[i]) {
+          this.blobLifecycle.reclaimOrphanedS3({
+            value: orphan,
+            groupId: job.groupId,
+          });
+        }
       } else {
         this.blobLifecycle.acquire(job.jobDataJson);
       }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -2,6 +2,7 @@ import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
 
 import { CachedLuaScript } from "./cachedLuaScript";
+import { BLOB_HOLDER_TTL_SECONDS } from "./blobConstants";
 
 // Lua scripts inlined as string constants.
 // This avoids loader incompatibilities across turbopack, webpack, vitest, and tsx.
@@ -401,7 +402,103 @@ local function gqRoutingMeta(jobDataJson)
 end
 `;
 
+// Lua side of the GQ2 blob-hold lifecycle for the dedup squash. A squash
+// displaces one staged value with another; the displaced value's hold must be
+// released and the replacement's acquired ATOMICALLY WITH THE DISPLACEMENT.
+// The old design returned the displaced value and let send() fire a transfer
+// eval afterwards, fire-and-forget — concurrent squashes of the same dedup id
+// could reorder at Redis, and a late transfer re-added a token an earlier one
+// had displaced, pinning the blob under a phantom hold until its TTL (the
+// 2026-07-09 leak: ~279k orphaned blobs, ~1.9 GB). Doing the hold move inside
+// the stage eval serializes it with the squash it accounts for.
+//
+// Envelope hold parse mirrors the TS readEnvelopeHold: "GQ2|<len>|<headerJson>"
+// with header.ref = {tier, projectId, hash} and header.h = the stage token.
+// GQ1 values ("GQ1|", header.r = blob id) have no refcount — their blob is
+// UNLINKed directly. Legacy bare-JSON / inline values carry no blob at all.
+const BLOB_HOLD_HELPER_LUA = `
+local function gqParseHold(value)
+  local prefix = string.sub(value, 1, 4)
+  if prefix ~= "GQ2|" and prefix ~= "GQ1|" then return nil end
+  local barIdx = string.find(value, "|", 5, true)
+  if not barIdx then return nil end
+  local headerLen = tonumber(string.sub(value, 5, barIdx - 1))
+  if not headerLen or headerLen <= 0 then return nil end
+  local ok, header = pcall(cjson.decode, string.sub(value, barIdx + 1, barIdx + headerLen))
+  if not ok or type(header) ~= "table" then return nil end
+  if prefix == "GQ1|" then
+    if type(header["r"]) == "string" then return { kind = "gq1", blobId = header["r"] } end
+    return nil
+  end
+  local ref = header["ref"]
+  if type(ref) == "table" and type(header["h"]) == "string"
+     and type(ref["projectId"]) == "string" and type(ref["hash"]) == "string" then
+    return {
+      kind = "gq2",
+      projectId = ref["projectId"],
+      hash = ref["hash"],
+      tier = ref["tier"],
+      token = header["h"],
+    }
+  end
+  return nil
+end
+
+-- Acquire the replacement value's hold and release the displaced value's, in
+-- the caller's (atomic) eval. Tenant-guarded like the TS release path: a hold
+-- whose ref is not this group's tenant is skipped and left to its TTL.
+-- Returns the displaced blob's reclaim outcome:
+--   0  nothing to reclaim here (still held, inline value, or skipped)
+--   1  redis-tier blob UNLINKed in this eval (GQ2 last-holder or GQ1)
+--   2  s3-tier blob newly unreferenced — the CALLER must delete the object
+local function gqSquashTransferHolds(keyPrefix, tenant, newValue, oldValue)
+  local newHold = gqParseHold(newValue)
+  local oldHold = gqParseHold(oldValue)
+  if newHold and newHold.kind == "gq2" and newHold.projectId == tenant then
+    local holderKey = keyPrefix .. "blobholders:" .. newHold.projectId .. "/" .. newHold.hash
+    redis.call("SADD", holderKey, newHold.token)
+    redis.call("EXPIRE", holderKey, ${BLOB_HOLDER_TTL_SECONDS})
+  end
+  if not oldHold then return 0 end
+  if oldHold.kind == "gq1" then
+    redis.call("UNLINK", keyPrefix .. "blob:" .. oldHold.blobId)
+    return 1
+  end
+  if oldHold.projectId ~= tenant then return 0 end
+  -- A same-set same-token pair is a self-transfer: keep the hold (mirror of
+  -- the standalone TRANSFER eval's guard).
+  if newHold and newHold.kind == "gq2" and newHold.projectId == oldHold.projectId
+     and newHold.hash == oldHold.hash and newHold.token == oldHold.token then
+    return 0
+  end
+  local oldHolderKey = keyPrefix .. "blobholders:" .. oldHold.projectId .. "/" .. oldHold.hash
+  if redis.call("SREM", oldHolderKey, oldHold.token) == 1 and redis.call("SCARD", oldHolderKey) == 0 then
+    redis.call("DEL", oldHolderKey)
+    if oldHold.tier == "redis" then
+      redis.call("UNLINK", keyPrefix .. "blob:" .. oldHold.projectId .. "/" .. oldHold.hash)
+      return 1
+    end
+    return 2
+  end
+  return 0
+end
+
+-- Reclaim the blob of a squash-DISCARDED new value (replace off, or a
+-- post-dispatch survive-dispatch squash). Only a GQ1 blob is safe to delete
+-- here: its randomUUID id belongs to this value alone. A GQ2 blob is
+-- content-addressed and possibly shared with concurrently-staging producers
+-- whose holds are acquired after their stage returns, so it is left to the
+-- holders of staged jobs sharing its content or to the TTL backstop.
+local function gqReclaimDiscardedNew(keyPrefix, value)
+  local hold = gqParseHold(value)
+  if hold and hold.kind == "gq1" then
+    redis.call("UNLINK", keyPrefix .. "blob:" .. hold.blobId)
+  end
+end
+`;
+
 const STAGE_LUA =
+  BLOB_HOLD_HELPER_LUA +
   TTL_HELPER_LUA +
   PARK_HELPER_LUA +
   `
@@ -455,18 +552,25 @@ if dedupId ~= "" and dedupTtlMs > 0 then
     local rank = redis.call("ZRANK", groupJobsKey, existingJobId)
     if rank then
       -- Still in staging: squash in place (net zero pending count change). The
-      -- squash drops one payload on the floor; if it carried an offloaded blob
-      -- (ADR-026) that blob is now unreferenced and would leak until its TTL
-      -- (the 2026-06-11 capacity incident). Report the displaced value so the
-      -- caller can reclaim its blob. On replace the OLD stored value is dropped;
-      -- otherwise the NEW value we were just handed is the one discarded.
+      -- squash drops one payload on the floor. On replace the OLD stored value
+      -- is displaced and its blob hold is moved to the replacement HERE, in
+      -- the same eval as the displacement — a fire-and-forget transfer after
+      -- the eval can reorder against a concurrent squash of the same dedup id
+      -- and leave a phantom hold (the 2026-07-09 leak). Without replace the
+      -- NEW value we were just handed is the one discarded; it was never
+      -- staged, so no hold may be recorded for it and its blob is left to the
+      -- TTL backstop (or to the holders of jobs sharing its content).
       local orphanedValue = jobDataJson
+      local reclaimS3 = 0
       if shouldExtend == 1 then
         redis.call("ZADD", groupJobsKey, dispatchAfter, existingJobId)
       end
       if shouldReplace == 1 then
         orphanedValue = redis.call("HGET", dataKey, existingJobId) or ""
         redis.call("HSET", dataKey, existingJobId, jobDataJson)
+        reclaimS3 = gqSquashTransferHolds(parkKeyPrefixOf(readyKey), parkTenantOf(groupId), jobDataJson, orphanedValue)
+      else
+        gqReclaimDiscardedNew(parkKeyPrefixOf(readyKey), jobDataJson)
       end
       redis.call("SET", dedupKey, existingJobId, "PX", dedupTtlMs)
       -- Score = earliest pending dispatchAfter (LT keeps the smallest score per group)
@@ -476,15 +580,18 @@ if dedupId ~= "" and dedupTtlMs > 0 then
       refreshGroupKeyTtl(groupJobsKey, dataKey, nowMs)
       redis.call("LPUSH", signalKey, "1")
       redis.call("LTRIM", signalKey, 0, 999)
-      return {0, orphanedValue}
+      return {0, orphanedValue, reclaimS3}
     end
     -- Already dispatched. Default: the dedup key is stale, clean it up and let a
     -- new job stage (the historical TOCTOU behavior). When shouldSurviveDispatch is
     -- set, HONOR the still-alive TTL instead — squash the new job and report its
     -- payload as the orphaned value (same {0, orphanedValue} shape the in-staging
     -- squash returns) so a late re-trigger after dispatch cannot re-run it (#3912).
+    -- The discarded value was never staged: no hold is recorded for it, and a
+    -- GQ1 blob (uniquely owned by this value) is reclaimed here.
     if shouldSurviveDispatch == 1 then
-      return {0, jobDataJson}
+      gqReclaimDiscardedNew(parkKeyPrefixOf(readyKey), jobDataJson)
+      return {0, jobDataJson, 0}
     end
     redis.call("DEL", dedupKey)
   end
@@ -510,10 +617,11 @@ redis.call("LTRIM", signalKey, 0, 999)
 redis.call("INCR", totalPendingKey)
 
 -- A genuinely new stage displaces nothing, so there is no blob to reclaim.
-return {1, ""}
+return {1, "", 0}
 `;
 
 const STAGE_BATCH_LUA =
+  BLOB_HOLD_HELPER_LUA +
   TTL_HELPER_LUA +
   PARK_HELPER_LUA +
   `
@@ -532,9 +640,11 @@ local nowMs        = tonumber(ARGV[#ARGV - 1])
 
 local newStagedCount = 0
 local affectedGroups = {}
--- Per-job (index-aligned) displaced values whose offloaded blob the caller must
--- reclaim; "" for a genuine new stage. Mirrors STAGE_LUA's single-job report.
+-- Per-job (index-aligned) displaced values; "" for a genuine new stage.
+-- Mirrors STAGE_LUA's single-job report. Holds are transferred in this eval;
+-- reclaimS3Flags marks (per job) an s3-tier blob the CALLER must delete.
 local orphanedValues = {}
+local reclaimS3Flags = {}
 
 for i = 1, count do
   -- Per-job stride is 9: stagedJobId..shouldReplace (8) + shouldSurviveDispatch
@@ -559,6 +669,7 @@ for i = 1, count do
 
   local isDeduped = false
   local orphanedValue = ""
+  local reclaimS3 = 0
   -- True only for the post-dispatch squash (already-dispatched dedup honored):
   -- that item stages no job AND the deduped job is already gone, so it must NOT
   -- contribute this group to the post-loop ready bookkeeping (see below).
@@ -568,9 +679,10 @@ for i = 1, count do
     if existingJobId then
       local rank = redis.call("ZRANK", groupJobsKey, existingJobId)
       if rank then
-        -- Still in staging: squash in place. The displaced payload's blob would
-        -- leak (see STAGE_LUA) — on replace it is the OLD stored value, else the
-        -- NEW value we were handed is the one dropped.
+        -- Still in staging: squash in place. On replace the OLD stored value is
+        -- displaced and its hold moved to the replacement here, atomic with the
+        -- displacement (see STAGE_LUA); else the NEW value we were handed is
+        -- dropped, was never staged, and gets no hold.
         orphanedValue = jobDataJson
         if shouldExtend == 1 then
           redis.call("ZADD", groupJobsKey, dispatchAfter, existingJobId)
@@ -578,6 +690,9 @@ for i = 1, count do
         if shouldReplace == 1 then
           orphanedValue = redis.call("HGET", dataKey, existingJobId) or ""
           redis.call("HSET", dataKey, existingJobId, jobDataJson)
+          reclaimS3 = gqSquashTransferHolds(keyPrefix, parkTenantOf(groupId), jobDataJson, orphanedValue)
+        else
+          gqReclaimDiscardedNew(keyPrefix, jobDataJson)
         end
         redis.call("SET", dedupKey, existingJobId, "PX", dedupTtlMs)
         isDeduped = true
@@ -591,6 +706,7 @@ for i = 1, count do
           orphanedValue = jobDataJson
           isDeduped = true
           squashedPostDispatch = true
+          gqReclaimDiscardedNew(keyPrefix, jobDataJson)
         else
           redis.call("DEL", dedupKey)
         end
@@ -607,6 +723,7 @@ for i = 1, count do
     newStagedCount = newStagedCount + 1
   end
   orphanedValues[i] = orphanedValue
+  reclaimS3Flags[i] = reclaimS3
 
   refreshGroupKeyTtl(groupJobsKey, dataKey, nowMs)
 
@@ -646,7 +763,7 @@ if newStagedCount > 0 then
   redis.call("INCRBY", totalPendingKey, newStagedCount)
 end
 
-return {newStagedCount, orphanedValues}
+return {newStagedCount, orphanedValues, reclaimS3Flags}
 `;
 
 const DISPATCH_LUA =
@@ -1554,12 +1671,15 @@ export class GroupStagingScripts {
    * stale dedup key is cleaned up and the new job is staged as genuinely new.
    *
    * A squash drops one payload (the replaced old value, or the discarded new
-   * value when `replace` is off); `orphanedValue` reports it so the caller can
-   * reclaim its offloaded blob (ADR-026) instead of leaking it. It is `""` for a
-   * genuine new stage, which displaces nothing.
+   * value when `replace` is off). Blob holds move INSIDE the eval, atomic with
+   * the displacement (a post-eval transfer can reorder against a concurrent
+   * squash and leave a phantom hold — the 2026-07-09 leak). `orphanedValue`
+   * reports the displaced value ("" for a genuine new stage); when its blob is
+   * s3-tier and newly unreferenced, `reclaimS3` is true and the CALLER must
+   * delete the object (Lua cannot reach s3).
    *
-   * @returns `isNew` (true if staged fresh, false if deduped) plus the displaced
-   *   `orphanedValue` whose blob the caller must reclaim.
+   * @returns `isNew` (true if staged fresh, false if deduped), the displaced
+   *   `orphanedValue`, and whether its s3 object needs out-of-band reclaim.
    */
   async stage({
     stagedJobId,
@@ -1581,7 +1701,7 @@ export class GroupStagingScripts {
     shouldExtend?: boolean;
     shouldReplace?: boolean;
     shouldSurviveDispatch?: boolean;
-  }): Promise<{ isNew: boolean; orphanedValue: string }> {
+  }): Promise<{ isNew: boolean; orphanedValue: string; reclaimS3: boolean }> {
     const groupJobsKey = `${this.keyPrefix}group:${groupId}:jobs`;
     const readyKey = `${this.keyPrefix}ready`;
     const signalKey = `${this.keyPrefix}signal`;
@@ -1620,23 +1740,26 @@ export class GroupStagingScripts {
       String(shouldSurviveDispatch ? 1 : 0),
     );
 
-    // STAGE_LUA returns [code, orphanedValue]. Tolerate a bare integer reply
-    // defensively (e.g. a stale cached script during a rolling deploy).
-    const [code, orphanedValue] = Array.isArray(result)
-      ? (result as [number, unknown])
-      : [result as number, ""];
+    // STAGE_LUA returns [code, orphanedValue, reclaimS3]. Tolerate a bare
+    // integer reply defensively (e.g. a stale cached script during a rolling
+    // deploy).
+    const [code, orphanedValue, reclaimS3] = Array.isArray(result)
+      ? (result as [number, unknown, unknown])
+      : [result as number, "", 0];
     return {
       isNew: Number(code) === 1,
       orphanedValue: orphanedValue == null ? "" : String(orphanedValue),
+      reclaimS3: Number(reclaimS3) === 2,
     };
   }
 
   /**
    * Stage a batch of jobs into their respective group queues.
    *
-   * @returns `newStagedCount` (new jobs, excluding deduped) plus the
-   *   index-aligned `orphanedValues` of squashed jobs whose offloaded blobs the
-   *   caller must reclaim (`""` where nothing was displaced). See {@link stage}.
+   * @returns `newStagedCount` (new jobs, excluding deduped), the index-aligned
+   *   `orphanedValues` of squashed jobs (`""` where nothing was displaced), and
+   *   index-aligned `reclaimS3Flags` marking displaced s3-tier blobs the caller
+   *   must delete out of band. Holds move inside the eval — see {@link stage}.
    */
   async stageBatch(
     jobs: Array<{
@@ -1650,8 +1773,13 @@ export class GroupStagingScripts {
       shouldReplace?: boolean;
       shouldSurviveDispatch?: boolean;
     }>,
-  ): Promise<{ newStagedCount: number; orphanedValues: string[] }> {
-    if (jobs.length === 0) return { newStagedCount: 0, orphanedValues: [] };
+  ): Promise<{
+    newStagedCount: number;
+    orphanedValues: string[];
+    reclaimS3Flags: boolean[];
+  }> {
+    if (jobs.length === 0)
+      return { newStagedCount: 0, orphanedValues: [], reclaimS3Flags: [] };
 
     const readyKey = `${this.keyPrefix}ready`;
     const signalKey = `${this.keyPrefix}signal`;
@@ -1689,18 +1817,21 @@ export class GroupStagingScripts {
       ...args,
     );
 
-    // STAGE_BATCH_LUA returns [newStagedCount, orphanedValues[]]. Tolerate a
-    // bare integer reply defensively (stale cached script mid-deploy).
+    // STAGE_BATCH_LUA returns [newStagedCount, orphanedValues[], reclaimS3Flags[]].
+    // Tolerate a bare integer reply defensively (stale cached script mid-deploy).
     if (Array.isArray(result)) {
-      const [count, orphans] = result as [number, unknown];
+      const [count, orphans, s3Flags] = result as [number, unknown, unknown];
       return {
         newStagedCount: Number(count),
         orphanedValues: Array.isArray(orphans)
           ? orphans.map((v) => (v == null ? "" : String(v)))
           : [],
+        reclaimS3Flags: Array.isArray(s3Flags)
+          ? s3Flags.map((v) => Number(v) === 2)
+          : [],
       };
     }
-    return { newStagedCount: Number(result), orphanedValues: [] };
+    return { newStagedCount: Number(result), orphanedValues: [], reclaimS3Flags: [] };
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -558,8 +558,10 @@ if dedupId ~= "" and dedupTtlMs > 0 then
       -- the eval can reorder against a concurrent squash of the same dedup id
       -- and leave a phantom hold (the 2026-07-09 leak). Without replace the
       -- NEW value we were just handed is the one discarded; it was never
-      -- staged, so no hold may be recorded for it and its blob is left to the
-      -- TTL backstop (or to the holders of jobs sharing its content).
+      -- staged, so no hold may be recorded for it: a discarded GQ1 blob
+      -- (uniquely owned by this value) is unlinked directly, while a GQ2 blob
+      -- is content-addressed and left to the holders of jobs sharing its
+      -- content, or to the TTL backstop.
       local orphanedValue = jobDataJson
       local reclaimS3 = 0
       if shouldExtend == 1 then
@@ -585,8 +587,9 @@ if dedupId ~= "" and dedupTtlMs > 0 then
     -- Already dispatched. Default: the dedup key is stale, clean it up and let a
     -- new job stage (the historical TOCTOU behavior). When shouldSurviveDispatch is
     -- set, HONOR the still-alive TTL instead — squash the new job and report its
-    -- payload as the orphaned value (same {0, orphanedValue} shape the in-staging
-    -- squash returns) so a late re-trigger after dispatch cannot re-run it (#3912).
+    -- payload as the orphaned value (same {code, orphanedValue, reclaimS3}
+    -- three-element shape the in-staging squash returns, reclaimS3 always 0
+    -- here) so a late re-trigger after dispatch cannot re-run it (#3912).
     -- The discarded value was never staged: no hold is recorded for it, and a
     -- GQ1 blob (uniquely owned by this value) is reclaimed here.
     if shouldSurviveDispatch == 1 then

--- a/specs/event-sourcing/payload-store-blob-hardening.feature
+++ b/specs/event-sourcing/payload-store-blob-hardening.feature
@@ -131,10 +131,10 @@ Feature: GroupQueue blob-handling hardening
   # (~1.9 GB, ~90% of Redis growth). The transfer now happens INSIDE the stage
   # eval, atomic with the displacement it accounts for.
   @integration @track4
-  Scenario: A dedup squash transfers the hold inside the stage eval
+  Scenario: A dedup squash leaves no phantom hold and reclaims only unreferenced blobs
     Given a staged offloaded job with a dedup id
     When a second send with the same dedup id squashes it in place
-    Then the replacement's hold is added and the displaced hold removed in the same stage eval
+    Then the replacement's hold is added and the displaced hold is removed
     And a displaced blob with no remaining holders is reclaimed immediately
 
   @integration @track4
@@ -217,7 +217,10 @@ Feature: GroupQueue blob-handling hardening
   # Track 4 — atomic transfer
   #   AC4.1 atomic retry transfer     -> A retry transfers the hold ... in a single atomic step
   #   AC4.2 no reclaim on partial     -> A partial failure during the transfer cannot reclaim a referenced blob
-  #   AC4.3 squash transfer           -> A dedup squash transfers the hold without dropping a shared blob
+  #   AC4.3 squash transfer           -> A dedup squash leaves no phantom hold and reclaims only unreferenced blobs
+  #   AC4.4 squash chain              -> A squash chain never leaves a phantom hold
+  #   AC4.5 discard on replace-off    -> A squash that keeps the stored payload acquires no hold for the discarded value
+  #   AC4.6 discard post-dispatch     -> A post-dispatch survive-dispatch squash acquires no hold for the discarded value
   # Track 5 — tamper / tenancy
   #   AC5.1 re-mint on read           -> The read location is re-minted from (projectId, hash) ...
   #   AC5.2 tamper cannot cross tenant-> A tampered ref cannot read another tenant's blob
@@ -225,6 +228,6 @@ Feature: GroupQueue blob-handling hardening
   # Track 6 — cluster-slot guard
   #   AC6.1 reject hash-tag-less name -> A queue name without a Redis hash tag is rejected at construction
   #
-  # Count: 16 behavioral ACs -> 16 scenarios. Streaming (the original AC1.2) was
+  # Count: 19 behavioral ACs -> 19 scenarios. Streaming (the original AC1.2) was
   # dropped in implementation — the cap is the memory bound (ADR-030 §1).
   # ===========================================================================

--- a/specs/event-sourcing/payload-store-blob-hardening.feature
+++ b/specs/event-sourcing/payload-store-blob-hardening.feature
@@ -123,12 +123,45 @@ Feature: GroupQueue blob-handling hardening
     Then the old blob is reclaimed only if its holder set is empty after the transfer
     And a still-needed blob is never reclaimed
 
-  @integration @track4 @unimplemented
-  Scenario: A dedup squash transfers the hold without dropping a shared blob
-    Given two staged jobs on the same content hash
-    When a squash displaces one of them
-    Then the displaced token is transferred in the same atomic step
-    And the blob remains while the surviving job holds it
+  # The 2026-07-09 incident: send() fired the squash's hold transfer after the
+  # stage eval returned, fire-and-forget. Concurrent squashes of the same dedup
+  # id could reorder at Redis — a later transfer re-added a token an earlier
+  # transfer had already displaced — leaving a phantom hold that pinned the
+  # blob until its TTL. At prod fan-out rates that left ~279k orphaned blobs
+  # (~1.9 GB, ~90% of Redis growth). The transfer now happens INSIDE the stage
+  # eval, atomic with the displacement it accounts for.
+  @integration @track4
+  Scenario: A dedup squash transfers the hold inside the stage eval
+    Given a staged offloaded job with a dedup id
+    When a second send with the same dedup id squashes it in place
+    Then the replacement's hold is added and the displaced hold removed in the same stage eval
+    And a displaced blob with no remaining holders is reclaimed immediately
+
+  @integration @track4
+  Scenario: A squash chain never leaves a phantom hold
+    Given a job squashed twice in succession under one dedup id
+    When both squashes have completed
+    Then only the final value's hold remains in its holder set
+    And every displaced blob with no other referents is gone
+
+  # A squash configured not to replace the payload discards the NEW value, not
+  # the stored one. The discarded value was never staged, so nothing may
+  # acquire a hold for it — the old code self-transferred (new == old) and
+  # minted exactly such a phantom hold. Its blob, when content-unique, is left
+  # to the TTL backstop; when shared, the surviving job's hold keeps it alive.
+  @integration @track4
+  Scenario: A squash that keeps the stored payload acquires no hold for the discarded value
+    Given a staged offloaded job whose dedup is configured to keep the stored payload
+    When a second send with the same dedup id is squashed
+    Then the stored job's hold is untouched
+    And no hold is recorded for the discarded value
+
+  @integration @track4
+  Scenario: A post-dispatch survive-dispatch squash acquires no hold for the discarded value
+    Given a dedup id whose job was already dispatched but whose survive-dispatch TTL is alive
+    When a late re-trigger is squashed against it
+    Then no hold is recorded for the discarded value
+    And the discarded value's blob is left to the TTL backstop
 
   # ===========================================================================
   # Track 5 — tamper resistance and tenant isolation


### PR DESCRIPTION
## The leak

Prod Redis grew 200 MB → 1.9 GB in four days. Read-only scan (2026-07-09): **279k GQ2 blobs + 279k holder sets — 100% orphaned** against a 462-job backlog, every sampled holder set pinned by exactly one never-released hold. ~90% of total keyspace and essentially all of the memory growth.

## Root cause

`send()` fired the dedup squash's hold transfer **after** the stage eval returned, fire-and-forget. Concurrent squashes of the same dedup id reorder at Redis: a late transfer re-adds a token an earlier transfer already displaced → a phantom hold pins the blob until its TTL. Two sibling paths minted the phantom deterministically: a `replace: false` squash and a post-dispatch `shouldSurviveDispatch` squash both report the NEW value as the orphan, and `send()` self-transferred it (`new == old`), acquiring a hold for a value that was never staged.

## Fix

Hold transfers move **inside** `STAGE_LUA` / `STAGE_BATCH_LUA`, atomic with the displacement they account for (the ADR-030 follow-up the transfer-fallback comment was already tracking):

- **Replace squash**: replacement hold SADDed + displaced hold SREMed in the eval; a newly-unreferenced redis-tier or GQ1 blob is UNLINKed right there. An s3-tier blob is reported via a new `reclaimS3` return element and deleted by the caller (Lua can't reach s3).
- **Discarded-new squashes** (replace off / survive-dispatch): no hold is ever recorded; a GQ1 blob (uniquely owned by the value) is UNLINKed, a GQ2 blob is left to the holders of jobs sharing its content or to the TTL backstop.
- **Tenant guard** mirrors the TS release path (ADR-030 §5): a foreign ref is skipped and left to its TTL.
- The standalone TRANSFER eval remains for the retry re-stage path — single-flight per group, no ordering race.

## Specs & tests

- `payload-store-blob-hardening.feature` Track 4 rewritten around the atomic in-eval transfer; four bound scenarios (squash transfer, squash chain, both discarded-new paths) with the incident numbers in the narrative.
- 9 new integration tests against real Redis: hold movement through `stage`/`stageBatch`, s3 reclaim flag, GQ1 mixed-format UNLINK, shared-content blob survival, foreign-tenant skip, post-dispatch squash.
- Queue integration suite: 212 passed. Event-sourcing unit lane: 6,737 passed. Feature-parity gate: 2,407 scenarios bound.

## Companion PRs from the same investigation

- #5594 — GQ2 blobs were getting GQ1's 7-day TTL instead of the intended backstop (now 4 days)
- #5595 — EVALSHA for the queue Lua (~33% of Redis engine CPU)
- #5596 — anomaly-detector baseline reads (~37% of Redis engine CPU)

https://claude.ai/code/session_01BUi7eLwDkxpZGUgujjPJ8L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atomic blob hold handling during dedup squashes and replacement operations to prevent phantom/orphaned holds across squash chains.
  * Added correct S3-tier reclamation behavior for displaced staged payloads, including tenant-safe cleanup and safer discard handling.
  * Enhanced batch staging consistency so holds/reclamation are applied per job with correct flags.

* **Tests**
  * Added integration test coverage for GQ2 blob-hold transfer/reclamation, repeated squashes, dispatch/survive-dispatch behavior, and batch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->