### PR TITLE
feat(billing): derive billing profile in one resolver (ADR-039 rollout 1-4)

### DIFF
--- a/dev/docs/adr/039-billing-profile-single-resolution.md
+++ b/dev/docs/adr/039-billing-profile-single-resolution.md
@@ -1,0 +1,191 @@
+# ADR-039: Billing profile is derived in one resolver — plan precedence, capabilities, and billing mechanics stop being stored or re-branched
+
+Date: 2026-07-09
+Status: Accepted (locked 2026-07-10)
+
+> One-line: the **composite plan provider** becomes the single derivation point for **plan precedence** (ENTERPRISE license > active subscription > other license > free), **capabilities**, and **billing mechanics** (`meterUnit`, `memberPolicy`), so that stored duplicates like `Organization.pricingModel` are demoted to **self-healed cache** and every enforcement block carries a typed **resolution**.
+
+## Context
+
+A paying Growth customer was hard-blocked at "Team Members: 6/6" and ops was paged. Root cause: the org carried `pricingModel = TIERED` while holding an active `GROWTH_SEAT_*` subscription — `migrateToSeatEvent` was skipped by webhook ordering (`customer.subscription.updated` activated the sub before `invoice.payment_succeeded`, whose `previousStatus !== ACTIVE` gate then never fired; sibling of hazard C3 in the Stripe assessment). The red-team pass found the same drift had a second, worse effect: `getOrganizationForBilling` filters `WHERE pricingModel = SEAT_EVENT` (`organization.prisma.repository.ts:207`), so drifted orgs were also **excluded from Stripe event metering** — silently under-billed the whole time.
+
+Every surface that asked "how does this org pay?" read a different signal:
+
+- `Organization.pricingModel` — stored column, schema default `TIERED`, flipped only at signup, in `migrateToSeatEvent`, or by hand in backoffice. Read for money decisions (metering gate) and UX decisions.
+- `Subscription.plan` — the actual ground truth (`GROWTH_SEAT_*` ⇒ seat-event), consulted via `isGrowthSeatEventPlan` at some sites only.
+- `PlanInfo.planSource` — composite provider; a valid license silently beats an active paid subscription.
+- `plan.type === "ENTERPRISE"` — string checks at ~12 sites (`assertEnterprisePlan`).
+
+~40 branch sites across 7 server files and 9 frontend files re-derive answers from these raw signals. Additional hazards found during investigation:
+
+- `clearTrialLicenseIfPresent` (`webhookService.ts:940`) deletes **any** license on subscription activation — no trial marker exists. An enterprise-licensed org buying any subscription loses its license; a missed webhook leaves a stale license shadowing the paid subscription forever.
+- `getSeatSyncService` / `syncSeatsToStripe` is dead code (zero callers) — the intended auto seat-sync never ran.
+- `PLAN_LIMITS` (ee/billing) and `planTemplates` (ee/licensing) define the "same" plans independently (assessment hazard H11).
+- Member counts include PENDING/WAITING_APPROVAL invites, so stale invites silently consume seats.
+
+Forcing function: the incident recurs until derivation is centralized. Blast radius: money (seat billing, meter unit) and access (enterprise features, member adds) — full rigor applies.
+
+Hard constraints (locked):
+1. **License schema is append-only** — `verifySignature` re-serializes the parsed payload; removing/renaming fields breaks all issued licenses. New fields only. (The dead `evaluationsCredit` field in `types.ts:14` exists for exactly this reason and must survive constants unification.)
+2. **No new service layer** — the consolidation lives in the existing composite plan provider (`src/server/app-layer/subscription/composite-plan-provider.ts`).
+3. **OSS/self-hosted unaffected** — non-SaaS builds keep license-only resolution; no Stripe imports leak into OSS paths.
+4. **No Stripe migration** — existing subscriptions/prices/items unchanged; only our interpretation layer changes.
+
+Prior art: `specs/licensing/dual-pricing-model.feature` (PricingModel = HOW, PlanTypes = WHAT — revised by this ADR), `specs/licensing/enforcement-members.feature`, ADR-019 (layering), Obsidian `EPIC/Q2/stripe/assessment.md` §11 (C1–C3, H8, H11).
+
+## Decision
+
+1. **Plan precedence is a rank, computed only in the composite plan provider.**
+   `ENTERPRISE license > active subscription > non-ENTERPRISE license > free.`
+   "Active subscription" means DB `Subscription.status = 'ACTIVE'` — exactly today's `planProvider` predicate; this ADR does not change dunning/grace semantics (`FAILED`/`PENDING` fall through the rank as they do today — see Open questions for grace handling).
+   WHY: an active subscription must beat a stale GROWTH/PRO license (the seat-flow dead-end class), while a sales-issued ENTERPRISE license must survive a leftover self-serve subscription (access > billing leak). Rejects: license-always-wins (perpetuates the dead-end), subscription-always-wins (kills enterprise SaaS deals mid-contract), highest-entitlement-wins (non-deterministic to reason about).
+
+2. **Billing mechanics are derived from the winning source, never from stored state — and the metering gate moves with them.**
+   The resolver computes `billing: { meterUnit, memberPolicy, showUsageLimits, isLegacyTiered }` on `PlanInfo`. Seat-event behavior is `activeSubscription.plan ∈ GROWTH_SEAT_PLAN_TYPES` — the `pricingModel` column is **not consulted for any decision**. This explicitly includes the Stripe usage-reporting pipeline: `getOrganizationForBilling` (`organization.prisma.repository.ts:207`) and `resolveMeterDecision` (`usage.service.ts:305`) migrate off the column onto the resolver **in step 1 of the rollout**, before any backfill (see Rollout). WHY: any stored duplicate of derivable truth drifts; deriving makes the incident class impossible by construction — and the metering gate is the money path that proves the column was never "just display".
+
+3. **`Organization.pricingModel` becomes a self-healed display cache.**
+   After the metering gate has moved (Decision 2), no decision reads the column. The resolver heals drift (plan-says-seat-event, column-says-TIERED) with a **write-once-guarded** fire-and-forget update: fire only if column ≠ target and no heal for this org fired within a TTL (multi-pod and read-replica-lag safe); heals also invalidate the meter decision cache for the org. A one-time backfill script fixes already-drifted orgs. The column stays for backoffice display and analytics. Rejects: dropping the column (breaks backoffice/analytics for no behavioral gain), keeping it authoritative with fixed migrations (drift remains reachable via backoffice edits and missed webhooks), naive fire-on-every-read (write amplification against replica lag).
+
+4. **`memberPolicy` maps one-to-one from the winning source.**
+   - active seat-event subscription → `purchase_seat` (proration modal, existing `addTeamMemberOrEvents` flow)
+   - ENTERPRISE license → `hard_cap` (contact-us; seats live in the signed payload, deals are sales-owned)
+   - non-ENTERPRISE license on **SaaS** → `upgrade` (subscription page; a purchased subscription outranks the license per Decision 1, preserving today's self-serve escape)
+   - any license on **self-hosted** → `hard_cap` (no Stripe; expansion requires a new license)
+   - legacy tiered paid subscription → `upgrade` (existing tiered→seat migration flow with credit)
+   - free → `upgrade`
+   Rejects: `hard_cap` for all licenses (downgrades self-serve-capable SaaS customers to contact-us — a new blocking scenario; caught in v3 review), routing licenses to Stripe seat purchase directly (contradicts the signed payload), `upgrade` on self-hosted (no Stripe — dead-end button), auto-regenerating licenses (separate ADR-sized feature — see Open questions).
+
+5. **Every member-limit denial carries a typed `resolution`.**
+   `checkLimit` results and `LimitExceededError` gain `resolution: "purchase_seat" | "upgrade" | "hard_cap"`, propagated through all five tRPC block paths (admin invite, non-admin invite request, approve request, lite→full role change, stale FE pre-check → server throw). The FE has one handler: `purchase_seat` → proration modal, `upgrade` → plans page, `hard_cap` → contact-us. On the **public API path** (`resource-limit.ts` middleware → 403 JSON to SDK/REST consumers) `resolution` is advisory metadata in the error body, not a rendered flow — documented as the sixth path. Rejects: server-side auto-purchase (charges money without an explicit confirmation click), fixing only the invite path (incident recurs via the other four).
+
+6. **Capabilities replace plan-type string checks.**
+   The resolver computes `capabilities: { rbac, scim, sso, groups, customRoles, audit }` (exact set finalized at implementation from the current `assertEnterprisePlan` call sites); `assertEnterprisePlan` becomes `assertCapability`. WHY: same scattered-branching disease; done once while consumers are already being touched.
+
+7. **Plan definitions unify into one constants module.**
+   A single shared module feeds both SaaS `PLAN_LIMITS` and license-generation `planTemplates` (kills hazard H11 drift). Safe for issued licenses — red-team confirmed: `verifySignature` re-serializes the payload that was signed at generation time (`validation.ts:47`); templates matter only at generation. The unified module preserves generation-side legacy fields (`evaluationsCredit`) for payload-schema stability.
+
+8. **`isTrial` is added to new license payloads; webhooks clear only trials.**
+   `clearTrialLicenseIfPresent` checks the flag; a non-trial license coexisting with an activating subscription raises an ops alert instead of silent deletion. Existing licenses without the flag are treated as **non-trial** (never auto-deleted — deleting a paid license is the worse failure). Pre-flag trial licenses in the wild (especially long-dated ENTERPRISE evals, which outrank subscriptions) are handled by a one-time audit: query prod for orgs with `license IS NOT NULL`, classify with sales, revoke or re-issue with `isTrial` (see Rollout / Open questions). Rejects: keeping the unconditional wipe (destroys enterprise licenses).
+
+9. **Ops alerts split by resolution.**
+   `purchase_seat` shown → info-level breadcrumb (self-serve friction funnel, no page). `hard_cap` / `upgrade` denial → real alert (sales signal). Rejects: single undifferentiated alert (the ambiguity that triggered this investigation), alerting only on hard blocks (loses seat-purchase friction data).
+
+10. **The five member-block paths and the seat flow consume only derived fields.**
+    `useInviteActions`' three-condition gate (`activePlanSource === "subscription" && pricingModel === "SEAT_EVENT" && api.subscription`) collapses to `limitInfo.resolution === "purchase_seat"`. All 9 FE sites reading `organization.pricingModel` switch to `useActivePlan().billing.*`. `seatSyncService` dead code is deleted (self-heal in Decision 3 replaces its intent). Server sites (`EESubscriptionService.updateSubscriptionItems`, `previewProration`, `usage-meter-policy`, `usage.service`) read the resolver's output.
+
+11. **Orphaned paying subscription under an ENTERPRISE license: let it run, alert only.**
+    When the rank resolves to an ENTERPRISE license while an active Stripe subscription exists, the subscription keeps billing (seats and, where applicable, events) and an ops alert fires on detection. No code cancels or mutates the subscription; no runbook obligation is created. WHY (user decision): code auto-cancelling paid subscriptions on a derived signal is exactly the C1–C3 hazard class, and the case is rare; the accepted cost is a known billing leak until a human acts on the alert. Rejects: auto-cancel with proration (money-mutating code on a derived signal), alert + mandatory runbook (process weight disproportionate to frequency).
+
+12. **The precedence flip ships behind a feature flag; the rest ships unflagged.**
+    A flag gates only the license-vs-subscription precedence change (Decision 1) — the single behavior change for existing orgs — giving a kill-switch without redeploy. Derivation, self-heal, `resolution`, capabilities, and alert-split ship unflagged: they are strictly corrective. Rejects: flagging the whole resolver (keeps ~40 dual branches alive — the disease itself), no flag (reverting a money-path change requires a redeploy while a paying org is mis-resolved).
+
+13. **Pending-invite seat consumption: surface, don't change.**
+    PENDING/WAITING_APPROVAL invites keep reserving seats (prevents overselling: 6 seats + 6 pending invites must not admit 12 people). The 6/6 UI and every block modal itemize the count — "4 members + 2 pending invites" — with revoke affordances. No billing-semantics change. Rejects: not counting pending invites (oversell risk), leaving the count opaque (the "blocked at 6/6 while seeing 4 members" confusion stays).
+
+## Rollout (ordered — sequencing is load-bearing)
+
+1. **Move the metering gate**: `getOrganizationForBilling` + `resolveMeterDecision` read the resolver, not the column. Ship + verify metering population is unchanged for non-drifted orgs.
+2. **Resolver ships** with derivation, capabilities, `resolution`, self-heal (write-once guard), alert split. Precedence flip dark behind the flag.
+3. **Audit** — two lists reviewed by ops/CS before any data change: (a) drifted orgs (TIERED + active seat sub) whose event metering will turn ON — **billing starts forward from cutover, no retroactive catch-up**, enforced by **checkpoint seeding**: at cutover, each newly-metered org's `lastReportedTotal` checkpoint is seeded to its current month-to-date billable-events total, so the first `reportUsageForMonth` run bills only post-cutover events (the checkpoint otherwise defaults to 0 and would bill the entire month-to-date — `reportUsageForMonth.command.ts:202,265`); CS gets the list for heads-up; (b) orgs with `license IS NOT NULL` — classify trials with sales, re-issue with `isTrial` or revoke.
+4. **Backfill** `pricingModel` (now display-only, per step 1 — the update no longer changes billing behavior by itself; metering for drifted orgs starts at step 1's deploy).
+5. **Flip the precedence flag** after the license audit confirms no org resolves unexpectedly.
+6. Consumer migration (~40 sites) and `seatSyncService` deletion ride steps 2–5 in the same PR series.
+
+WHY this order: backfilling the column before step 1 would activate the *old* metering gate on the drifted cohort as a side effect of a "display" update — the red-team's adversarial scenario (40 surprise metered-usage invoices, finance escalation).
+
+## Constants
+
+| Name | Value | Purpose |
+|---|---|---|
+| `PLAN_RANK` | `ENTERPRISE_LICENSE(3) > ACTIVE_SUBSCRIPTION(2) > OTHER_LICENSE(1) > FREE(0)` | Deterministic winner when sources coexist |
+| Active-subscription predicate | `Subscription.status = 'ACTIVE'` (DB) | Today's semantics preserved; grace/dunning unchanged |
+| `MemberPolicy` | `"purchase_seat" \| "upgrade" \| "hard_cap"` | How an org expands members at cap |
+| `MeterUnit` | `"events" \| "traces"` | Usage metering basis (seat-event → events) |
+| `LimitResolution` | same values as `MemberPolicy` | Carried on `checkLimit` / `LimitExceededError` |
+| `GROWTH_SEAT_PLAN_TYPES` | existing, `ee/billing/utils/growthSeatEvent.ts:39` | The plan strings that mean seat-event |
+| License payload addition | `isTrial?: boolean` (absent = non-trial) | Only trials are auto-cleared on sub activation |
+| Self-heal guard TTL | 24h per org (Redis-backed, reuse `TtlCache`) | Write-once heal; multi-pod / replica-lag safe |
+| Precedence feature flag | `release_billing_precedence_rank` | Kill-switch for Decision 1 only |
+
+## Invariants
+
+| Invariant | Meaning | Satisfied by / test anchor |
+|---|---|---|
+| I1 | An org with an active `GROWTH_SEAT_*` subscription always gets seat-event behavior, regardless of `pricingModel` | Derivation in resolver; test: TIERED column + seat sub → `memberPolicy === "purchase_seat"` **and** org is metered |
+| I2 | An ENTERPRISE license is never silently deleted or outranked by a subscription | Rank + `isTrial` guard; test: enterprise license + activating sub → license intact, plan = enterprise, ops alert fired |
+| I3 | No member-limit denial is emitted without a `resolution` (rendered on the 5 tRPC paths; advisory JSON on the public API path) | Typed error everywhere; integration test per path incl. `resource-limit.ts` 403 body |
+| I4 | After rollout step 1, no billing or access decision reads `pricingModel`; column drift is display-only and converges | Metering gate moved first; lazy heal test: drifted org → first `getActivePlan` heals column once (guard blocks repeat) and invalidates meter cache |
+| I5 | OSS builds resolve identically to today | License-only provider path untouched; existing OSS test suite |
+| I6 | A seat purchase confirmation is always explicit | No server-side auto-charge; FE modal is the only purchase trigger |
+| I7 | SaaS and license generation read one plan-definition source | Shared constants module; compile-time: both import from it |
+| I8 | Turning metering on for a drifted org never bills retroactively | Checkpoint seeding at cutover (rollout step 3a); test: seed org checkpoint to month-to-date N → first report bills only events beyond N |
+
+## Schema
+
+No Prisma migration. Changes:
+
+```ts
+// License payload (append-only — new optional field)
+{ ..., isTrial?: boolean }  // absent ⇒ non-trial ⇒ never auto-cleared
+
+// PlanInfo additions (computed, not stored)
+billing: {
+  meterUnit: "events" | "traces";
+  memberPolicy: "purchase_seat" | "upgrade" | "hard_cap";
+  showUsageLimits: boolean;
+  isLegacyTiered: boolean;
+};
+capabilities: { rbac: boolean; scim: boolean; sso: boolean; /* finalized from call sites */ };
+```
+
+One-time backfill (rollout step 4 — only after the metering gate has moved; read-verify then run):
+
+```sql
+-- Orgs with an active seat-event subscription but a stale pricingModel
+UPDATE "Organization" o SET "pricingModel" = 'SEAT_EVENT'
+WHERE o."pricingModel" <> 'SEAT_EVENT'
+  AND EXISTS (SELECT 1 FROM "Subscription" s
+              WHERE s."organizationId" = o.id AND s.status = 'ACTIVE'
+                AND s.plan LIKE 'GROWTH_SEAT_%');
+```
+
+## Rejected alternatives
+
+- License-always-wins precedence — perpetuates the seat-flow dead-end (the incident).
+- Subscription-always-wins — breaks enterprise SaaS deals provisioned as licenses.
+- Highest-entitlement-wins — non-deterministic; billing and entitlement diverge.
+- `pricingModel` stays authoritative with fixed migrations — stored-state drift remains reachable (backoffice, missed webhooks).
+- Dropping the `pricingModel` column — breaks backoffice/analytics for no behavioral gain over cache.
+- Server-side auto seat purchase — charges without explicit consent.
+- Auto-cancelling the orphaned subscription under an ENTERPRISE license — money-mutating code on a derived signal (C1–C3 hazard class).
+- Keeping drifted orgs permanently un-metered — revenue leak becomes policy; two org classes forever.
+- Retroactive catch-up billing for drifted orgs — surprise charges for usage customers were told was included.
+- Fixing only the invite path — four other paths keep the incident alive.
+- Deferring capabilities / plan-constants unification — leaves the same disease in neighboring organs (user chose in-scope).
+- New `BillingProfileService` — a second authority recreates the two-sources problem one layer up.
+- Flagging the whole resolver — keeps ~40 dual branches alive during rollout.
+- Not counting pending invites toward seats — oversell risk (6 seats admitting 12 people).
+- Nightly reconciliation cron for the column — operational surface for display-only data.
+
+## Consequences
+
+**Positive:** the incident class is impossible by construction; enterprise licenses can't be destroyed by a webhook; the silent under-metering of drifted orgs is found and fixed; one place to read when debugging "why is this org billed/gated like this"; ops can distinguish self-serve friction from stuck customers; H11 drift killed.
+
+**Negative:** ~40 call sites churn across an ordered PR series (mitigated: mechanical, each site becomes simpler); precedence change is a behavior change for GROWTH/PRO-licensed SaaS orgs that also hold an active subscription — they flip from license-limits to subscription-limits (audited in rollout step 3, kill-switch via flag); drifted orgs start being metered (correct per contract, but CS-visible — heads-up list required); the orphaned-sub-under-ENTERPRISE-license leak persists until a human acts on the alert (explicitly accepted, Decision 11); **while the precedence flag is off (rollout steps 2–5), license+subscription orgs keep license-wins resolution — their metering mismatch and seat-flow dead-end persist until the flag flips; step 2 fully fixes only the no-license drift class (the original incident)**; the resolver gains responsibility (mitigated: it was already the choke point for planSource).
+
+**Neutral:** `dual-pricing-model.feature` needs revision (PricingModel demoted from "HOW billing works" to cache); backoffice keeps editing the column but edits no longer affect behavior (H8 remains for subscription-row edits — out of scope).
+
+## Open questions
+
+- Dunning/grace semantics: `FAILED`/`PENDING` subs fall out of the rank instantly (today's behavior — a transient payment failure drops entitlements). Owner: Sergio; candidate follow-up ADR on grace periods.
+- License self-serve seat expansion (regenerate license with more seats) — deferred, owner: Sergio, separate ADR.
+- Backoffice subscription edits bypassing invariants (assessment H8) — out of scope here; tracked in the Stripe assessment.
+- Whether `resolution` should extend to non-member limit types (projects, workflows) — decide at implementation; the enum is designed to extend.
+- Exact `capabilities` key set — finalized from the 12 `assertEnterprisePlan` call sites during implementation.
+- Count and classification of pre-flag licenses in prod (rollout step 3b) — needs the license audit query; owner: Sergio + sales.
+
+## Revisions
+
+- v1 (2026-07-09): Initial draft. Round 1 locked: full-consolidation scope, money+access blast radius, 4 hard constraints. Round 2 locked: precedence rank (after worked ACME example — user initially leaned subscription-always-wins), derive-from-plan authority with cache column, memberPolicy mapping, capabilities in scope. Round 3 locked: typed resolution on all 5 paths, lazy heal + backfill, plan-constants unification in scope (user overrode defer recommendation), alerts split by resolution.
+- v3 (2026-07-10): Adversarial consistency review vs conversation locks (all 16 locks verified present). Finding 1 reopened the memberPolicy fork: `hard_cap` for all licenses was a self-serve regression — non-ENT-license SaaS orgs can buy a subscription that outranks their license; user locked SaaS→`upgrade` / self-hosted→`hard_cap` / ENTERPRISE→`hard_cap` (Decision 4). Finding 2: I8 had no mechanism — `reportUsageForMonth` checkpoint defaults to 0 and would bill the full month-to-date; fixed via checkpoint seeding at cutover (Rollout 3a, I8). Finding 3: flag-off window consequence stated explicitly (Consequences).
+- v2 (2026-07-09): Red-team pass (devils-advocate) folded in. Blocker 1 — `pricingModel` was NOT cosmetic: it gates Stripe event metering (`getOrganizationForBilling`); drifted orgs were silently un-metered. Added ordered Rollout section (metering gate moves before backfill), I8 (no retroactive billing), user locked bill-forward cutover. Blocker 2 — orphaned paying sub under an ENTERPRISE license: user locked let-it-run + alert-only (Decision 11). Also from red-team: active-subscription predicate pinned to `status='ACTIVE'` (Decision 1), pre-flag trial-license audit (Decision 8 + rollout 3b), public API documented as sixth advisory path (Decision 5, I3), self-heal write-once guard + meter-cache invalidation (Decision 3), plan-constants unification confirmed safe (Decision 7). New user locks: precedence flip behind feature flag (Decision 12), pending-invite seats surfaced not changed (Decision 13).

--- a/dev/docs/adr/039-billing-profile-single-resolution.md
+++ b/dev/docs/adr/039-billing-profile-single-resolution.md
@@ -7,7 +7,7 @@ Status: Accepted (locked 2026-07-10)
 
 ## Context
 
-A paying Growth customer was hard-blocked at "Team Members: 6/6" and ops was paged. Root cause: the org carried `pricingModel = TIERED` while holding an active `GROWTH_SEAT_*` subscription — `migrateToSeatEvent` was skipped by webhook ordering (`customer.subscription.updated` activated the sub before `invoice.payment_succeeded`, whose `previousStatus !== ACTIVE` gate then never fired; sibling of hazard C3 in the Stripe assessment). The red-team pass found the same drift had a second, worse effect: `getOrganizationForBilling` filters `WHERE pricingModel = SEAT_EVENT` (`organization.prisma.repository.ts:207`), so drifted orgs were also **excluded from Stripe event metering** — silently under-billed the whole time.
+A paying Growth customer was hard-blocked at "Team Members: 6/6" and ops was paged. Root cause: the org carried `pricingModel = TIERED` while holding an active `GROWTH_SEAT_*` subscription — `migrateToSeatEvent` was skipped by webhook ordering (`customer.subscription.updated` activated the sub before `invoice.payment_succeeded`, whose `previousStatus !== ACTIVE` gate then never fired; sibling of hazard C3 in the Stripe assessment). The red-team pass found the same drift had a second, worse effect: `getOrganizationForBilling` filters `WHERE pricingModel = SEAT_EVENT` (`organization.prisma.repository.ts:207`), so drifted orgs were also **excluded from the usage-metering population**.
 
 Every surface that asked "how does this org pay?" read a different signal:
 
@@ -65,10 +65,10 @@ Prior art: `specs/licensing/dual-pricing-model.feature` (PricingModel = HOW, Pla
    A single shared module feeds both SaaS `PLAN_LIMITS` and license-generation `planTemplates` (kills hazard H11 drift). Safe for issued licenses — red-team confirmed: `verifySignature` re-serializes the payload that was signed at generation time (`validation.ts:47`); templates matter only at generation. The unified module preserves generation-side legacy fields (`evaluationsCredit`) for payload-schema stability.
 
 8. **`isTrial` is added to new license payloads; webhooks clear only trials.**
-   `clearTrialLicenseIfPresent` checks the flag; a non-trial license coexisting with an activating subscription raises an ops alert instead of silent deletion. Existing licenses without the flag are treated as **non-trial** (never auto-deleted — deleting a paid license is the worse failure). Pre-flag trial licenses in the wild (especially long-dated ENTERPRISE evals, which outrank subscriptions) are handled by a one-time audit: query prod for orgs with `license IS NOT NULL`, classify with sales, revoke or re-issue with `isTrial` (see Rollout / Open questions). Rejects: keeping the unconditional wipe (destroys enterprise licenses).
+   `clearTrialLicenseIfPresent` checks the flag; a non-trial license coexisting with an activating subscription raises an ops alert instead of silent deletion. Existing licenses without the flag are treated as **non-trial** (never auto-deleted — deleting a paid license is the worse failure). Pre-flag trial licenses in the wild are reconciled by a one-time review of stored licenses (internal cutover runbook) — re-issue with `isTrial` or revoke. Rejects: keeping the unconditional wipe (destroys enterprise licenses).
 
 9. **Ops alerts split by resolution.**
-   `purchase_seat` shown → info-level breadcrumb (self-serve friction funnel, no page). `hard_cap` / `upgrade` denial → real alert (sales signal). Rejects: single undifferentiated alert (the ambiguity that triggered this investigation), alerting only on hard blocks (loses seat-purchase friction data).
+   `purchase_seat` shown → info-level breadcrumb (self-serve friction funnel, no page). `hard_cap` / `upgrade` denial → real ops alert. Rejects: single undifferentiated alert (the ambiguity that triggered this investigation), alerting only on hard blocks (loses seat-purchase friction data).
 
 10. **The five member-block paths and the seat flow consume only derived fields.**
     `useInviteActions`' three-condition gate (`activePlanSource === "subscription" && pricingModel === "SEAT_EVENT" && api.subscription`) collapses to `limitInfo.resolution === "purchase_seat"`. All 9 FE sites reading `organization.pricingModel` switch to `useActivePlan().billing.*`. `seatSyncService` dead code is deleted (self-heal in Decision 3 replaces its intent). Server sites (`EESubscriptionService.updateSubscriptionItems`, `previewProration`, `usage-meter-policy`, `usage.service`) read the resolver's output.
@@ -86,12 +86,12 @@ Prior art: `specs/licensing/dual-pricing-model.feature` (PricingModel = HOW, Pla
 
 1. **Move the metering gate**: `getOrganizationForBilling` + `resolveMeterDecision` read the resolver, not the column. Ship + verify metering population is unchanged for non-drifted orgs.
 2. **Resolver ships** with derivation, capabilities, `resolution`, self-heal (write-once guard), alert split. Precedence flip dark behind the flag.
-3. **Audit** — two lists reviewed by ops/CS before any data change: (a) drifted orgs (TIERED + active seat sub) whose event metering will turn ON — **billing starts forward from cutover, no retroactive catch-up**, enforced by **checkpoint seeding**: at cutover, each newly-metered org's `lastReportedTotal` checkpoint is seeded to its current month-to-date billable-events total, so the first `reportUsageForMonth` run bills only post-cutover events (the checkpoint otherwise defaults to 0 and would bill the entire month-to-date — `reportUsageForMonth.command.ts:202,265`); CS gets the list for heads-up; (b) orgs with `license IS NOT NULL` — classify trials with sales, re-issue with `isTrial` or revoke.
+3. **Checkpoint seeding** (before any data change): each org whose metering turns on mid-cycle gets its `lastReportedTotal` checkpoint seeded to its current month-to-date total, so the first `reportUsageForMonth` run reports only post-cutover events — the checkpoint otherwise defaults to 0 and would report the entire month-to-date (`reportUsageForMonth.command.ts:202,265`). The operational cutover procedure (review steps, affected-population handling, license reconciliation) lives in the internal ops runbook, not in this ADR.
 4. **Backfill** `pricingModel` (now display-only, per step 1 — the update no longer changes billing behavior by itself; metering for drifted orgs starts at step 1's deploy).
-5. **Flip the precedence flag** after the license audit confirms no org resolves unexpectedly.
+5. **Flip the precedence flag** after the license reconciliation (internal runbook) confirms no org resolves unexpectedly.
 6. Consumer migration (~40 sites) and `seatSyncService` deletion ride steps 2–5 in the same PR series.
 
-WHY this order: backfilling the column before step 1 would activate the *old* metering gate on the drifted cohort as a side effect of a "display" update — the red-team's adversarial scenario (40 surprise metered-usage invoices, finance escalation).
+WHY this order: backfilling the column before step 1 would activate the *old* metering gate on the drifted cohort as a side effect of a "display" update — otherwise the first metering run reports retroactively (Invariant I8 violation).
 
 ## Constants
 
@@ -159,7 +159,7 @@ WHERE o."pricingModel" <> 'SEAT_EVENT'
 - Server-side auto seat purchase — charges without explicit consent.
 - Auto-cancelling the orphaned subscription under an ENTERPRISE license — money-mutating code on a derived signal (C1–C3 hazard class).
 - Keeping drifted orgs permanently un-metered — revenue leak becomes policy; two org classes forever.
-- Retroactive catch-up billing for drifted orgs — surprise charges for usage customers were told was included.
+- Retroactive catch-up metering for drifted orgs — violates Invariant I8.
 - Fixing only the invite path — four other paths keep the incident alive.
 - Deferring capabilities / plan-constants unification — leaves the same disease in neighboring organs (user chose in-scope).
 - New `BillingProfileService` — a second authority recreates the two-sources problem one layer up.
@@ -171,7 +171,7 @@ WHERE o."pricingModel" <> 'SEAT_EVENT'
 
 **Positive:** the incident class is impossible by construction; enterprise licenses can't be destroyed by a webhook; the silent under-metering of drifted orgs is found and fixed; one place to read when debugging "why is this org billed/gated like this"; ops can distinguish self-serve friction from stuck customers; H11 drift killed.
 
-**Negative:** ~40 call sites churn across an ordered PR series (mitigated: mechanical, each site becomes simpler); precedence change is a behavior change for GROWTH/PRO-licensed SaaS orgs that also hold an active subscription — they flip from license-limits to subscription-limits (audited in rollout step 3, kill-switch via flag); drifted orgs start being metered (correct per contract, but CS-visible — heads-up list required); the orphaned-sub-under-ENTERPRISE-license leak persists until a human acts on the alert (explicitly accepted, Decision 11); **while the precedence flag is off (rollout steps 2–5), license+subscription orgs keep license-wins resolution — their metering mismatch and seat-flow dead-end persist until the flag flips; step 2 fully fixes only the no-license drift class (the original incident)**; the resolver gains responsibility (mitigated: it was already the choke point for planSource).
+**Negative:** ~40 call sites churn across an ordered PR series (mitigated: mechanical, each site becomes simpler); precedence change is a behavior change for GROWTH/PRO-licensed SaaS orgs that also hold an active subscription — they flip from license-limits to subscription-limits (reviewed at cutover per the internal runbook, kill-switch via flag); metering for previously-excluded organizations begins at cutover; the orphaned-sub-under-ENTERPRISE-license leak persists until a human acts on the alert (explicitly accepted, Decision 11); **while the precedence flag is off (rollout steps 2–5), license+subscription orgs keep license-wins resolution — their metering mismatch and seat-flow dead-end persist until the flag flips; step 2 fully fixes only the no-license drift class (the original incident)**; the resolver gains responsibility (mitigated: it was already the choke point for planSource).
 
 **Neutral:** `dual-pricing-model.feature` needs revision (PricingModel demoted from "HOW billing works" to cache); backoffice keeps editing the column but edits no longer affect behavior (H8 remains for subscription-row edits — out of scope).
 
@@ -182,10 +182,11 @@ WHERE o."pricingModel" <> 'SEAT_EVENT'
 - Backoffice subscription edits bypassing invariants (assessment H8) — out of scope here; tracked in the Stripe assessment.
 - Whether `resolution` should extend to non-member limit types (projects, workflows) — decide at implementation; the enum is designed to extend.
 - Exact `capabilities` key set — finalized from the 12 `assertEnterprisePlan` call sites during implementation.
-- Count and classification of pre-flag licenses in prod (rollout step 3b) — needs the license audit query; owner: Sergio + sales.
+- Reconciliation of pre-flag licenses (rollout step 3b) — procedure in the internal ops runbook; owner: Sergio.
 
 ## Revisions
 
+- v4 (2026-07-10): Redaction pass — operational/business cutover detail (affected-population review, customer communication, license reconciliation procedure) moved out of this public ADR into the internal ops runbook; engineering invariants unchanged.
 - v1 (2026-07-09): Initial draft. Round 1 locked: full-consolidation scope, money+access blast radius, 4 hard constraints. Round 2 locked: precedence rank (after worked ACME example — user initially leaned subscription-always-wins), derive-from-plan authority with cache column, memberPolicy mapping, capabilities in scope. Round 3 locked: typed resolution on all 5 paths, lazy heal + backfill, plan-constants unification in scope (user overrode defer recommendation), alerts split by resolution.
 - v3 (2026-07-10): Adversarial consistency review vs conversation locks (all 16 locks verified present). Finding 1 reopened the memberPolicy fork: `hard_cap` for all licenses was a self-serve regression — non-ENT-license SaaS orgs can buy a subscription that outranks their license; user locked SaaS→`upgrade` / self-hosted→`hard_cap` / ENTERPRISE→`hard_cap` (Decision 4). Finding 2: I8 had no mechanism — `reportUsageForMonth` checkpoint defaults to 0 and would bill the full month-to-date; fixed via checkpoint seeding at cutover (Rollout 3a, I8). Finding 3: flag-off window consequence stated explicitly (Consequences).
 - v2 (2026-07-09): Red-team pass (devils-advocate) folded in. Blocker 1 — `pricingModel` was NOT cosmetic: it gates Stripe event metering (`getOrganizationForBilling`); drifted orgs were silently un-metered. Added ordered Rollout section (metering gate moves before backfill), I8 (no retroactive billing), user locked bill-forward cutover. Blocker 2 — orphaned paying sub under an ENTERPRISE license: user locked let-it-run + alert-only (Decision 11). Also from red-team: active-subscription predicate pinned to `status='ACTIVE'` (Decision 1), pre-flag trial-license audit (Decision 8 + rollout 3b), public API documented as sixth advisory path (Decision 5, I3), self-heal write-once guard + meter-cache invalidation (Decision 3), plan-constants unification confirmed safe (Decision 7). New user locks: precedence flip behind feature flag (Decision 12), pending-invite seats surfaced not changed (Decision 13).

--- a/dev/docs/adr/039-billing-profile-single-resolution.md
+++ b/dev/docs/adr/039-billing-profile-single-resolution.md
@@ -7,7 +7,7 @@ Status: Accepted (locked 2026-07-10)
 
 ## Context
 
-A paying Growth customer was hard-blocked at "Team Members: 6/6" and ops was paged. Root cause: the org carried `pricingModel = TIERED` while holding an active `GROWTH_SEAT_*` subscription — `migrateToSeatEvent` was skipped by webhook ordering (`customer.subscription.updated` activated the sub before `invoice.payment_succeeded`, whose `previousStatus !== ACTIVE` gate then never fired; sibling of hazard C3 in the Stripe assessment). The red-team pass found the same drift had a second, worse effect: `getOrganizationForBilling` filters `WHERE pricingModel = SEAT_EVENT` (`organization.prisma.repository.ts:207`), so drifted orgs were also **excluded from the usage-metering population**.
+A paying Growth customer was hard-blocked at "Team Members: 6/6" and ops was paged. Root cause: the org carried `pricingModel = TIERED` while holding an active `GROWTH_SEAT_*` subscription — `migrateToSeatEvent` was skipped by webhook ordering (`customer.subscription.updated` activated the sub before `invoice.payment_succeeded`, whose `previousStatus !== ACTIVE` gate then never fired). The red-team pass found the same drift had a second, worse effect: `getOrganizationForBilling` filters `WHERE pricingModel = SEAT_EVENT` (`organization.prisma.repository.ts:207`), so drifted orgs were also **excluded from the usage-metering population**.
 
 Every surface that asked "how does this org pay?" read a different signal:
 
@@ -20,7 +20,7 @@ Every surface that asked "how does this org pay?" read a different signal:
 
 - `clearTrialLicenseIfPresent` (`webhookService.ts:940`) deletes **any** license on subscription activation — no trial marker exists. An enterprise-licensed org buying any subscription loses its license; a missed webhook leaves a stale license shadowing the paid subscription forever.
 - `getSeatSyncService` / `syncSeatsToStripe` is dead code (zero callers) — the intended auto seat-sync never ran.
-- `PLAN_LIMITS` (ee/billing) and `planTemplates` (ee/licensing) define the "same" plans independently (assessment hazard H11).
+- `PLAN_LIMITS` (ee/billing) and `planTemplates` (ee/licensing) define the "same" plans independently, so their values drift silently.
 - Member counts include PENDING/WAITING_APPROVAL invites, so stale invites silently consume seats.
 
 Forcing function: the incident recurs until derivation is centralized. Blast radius: money (seat billing, meter unit) and access (enterprise features, member adds) — full rigor applies.
@@ -31,7 +31,7 @@ Hard constraints (locked):
 3. **OSS/self-hosted unaffected** — non-SaaS builds keep license-only resolution; no Stripe imports leak into OSS paths.
 4. **No Stripe migration** — existing subscriptions/prices/items unchanged; only our interpretation layer changes.
 
-Prior art: `specs/licensing/dual-pricing-model.feature` (PricingModel = HOW, PlanTypes = WHAT — revised by this ADR), `specs/licensing/enforcement-members.feature`, ADR-019 (layering), Obsidian `EPIC/Q2/stripe/assessment.md` §11 (C1–C3, H8, H11).
+Prior art: `specs/licensing/dual-pricing-model.feature` (PricingModel = HOW, PlanTypes = WHAT — revised by this ADR), `specs/licensing/enforcement-members.feature`, ADR-019 (layering), and the internal billing assessment.
 
 ## Decision
 
@@ -62,7 +62,7 @@ Prior art: `specs/licensing/dual-pricing-model.feature` (PricingModel = HOW, Pla
    The resolver computes `capabilities: { rbac, scim, sso, groups, customRoles, audit }` (exact set finalized at implementation from the current `assertEnterprisePlan` call sites); `assertEnterprisePlan` becomes `assertCapability`. WHY: same scattered-branching disease; done once while consumers are already being touched.
 
 7. **Plan definitions unify into one constants module.**
-   A single shared module feeds both SaaS `PLAN_LIMITS` and license-generation `planTemplates` (kills hazard H11 drift). Safe for issued licenses — red-team confirmed: `verifySignature` re-serializes the payload that was signed at generation time (`validation.ts:47`); templates matter only at generation. The unified module preserves generation-side legacy fields (`evaluationsCredit`) for payload-schema stability.
+   A single shared module feeds both SaaS `PLAN_LIMITS` and license-generation `planTemplates` (kills the silent plan-definition drift). Safe for issued licenses — red-team confirmed: `verifySignature` re-serializes the payload that was signed at generation time (`validation.ts:47`); templates matter only at generation. The unified module preserves generation-side legacy fields (`evaluationsCredit`) for payload-schema stability.
 
 8. **`isTrial` is added to new license payloads; webhooks clear only trials.**
    `clearTrialLicenseIfPresent` checks the flag; a non-trial license coexisting with an activating subscription raises an ops alert instead of silent deletion. Existing licenses without the flag are treated as **non-trial** (never auto-deleted — deleting a paid license is the worse failure). Pre-flag trial licenses in the wild are reconciled by a one-time review of stored licenses (internal cutover runbook) — re-issue with `isTrial` or revoke. Rejects: keeping the unconditional wipe (destroys enterprise licenses).
@@ -74,7 +74,7 @@ Prior art: `specs/licensing/dual-pricing-model.feature` (PricingModel = HOW, Pla
     `useInviteActions`' three-condition gate (`activePlanSource === "subscription" && pricingModel === "SEAT_EVENT" && api.subscription`) collapses to `limitInfo.resolution === "purchase_seat"`. All 9 FE sites reading `organization.pricingModel` switch to `useActivePlan().billing.*`. `seatSyncService` dead code is deleted (self-heal in Decision 3 replaces its intent). Server sites (`EESubscriptionService.updateSubscriptionItems`, `previewProration`, `usage-meter-policy`, `usage.service`) read the resolver's output.
 
 11. **Orphaned paying subscription under an ENTERPRISE license: let it run, alert only.**
-    When the rank resolves to an ENTERPRISE license while an active Stripe subscription exists, the subscription keeps billing (seats and, where applicable, events) and an ops alert fires on detection. No code cancels or mutates the subscription; no runbook obligation is created. WHY (user decision): code auto-cancelling paid subscriptions on a derived signal is exactly the C1–C3 hazard class, and the case is rare; the accepted cost is a known billing leak until a human acts on the alert. Rejects: auto-cancel with proration (money-mutating code on a derived signal), alert + mandatory runbook (process weight disproportionate to frequency).
+    When the rank resolves to an ENTERPRISE license while an active Stripe subscription exists, the subscription keeps billing (seats and, where applicable, events) and an ops alert fires on detection. No code cancels or mutates the subscription; no runbook obligation is created. WHY (user decision): code auto-cancelling paid subscriptions on a derived signal is exactly the class of money-mutating automation this ADR avoids, and the case is rare; the accepted cost is a known billing leak until a human acts on the alert. Rejects: auto-cancel with proration (money-mutating code on a derived signal), alert + mandatory runbook (process weight disproportionate to frequency).
 
 12. **The precedence flip ships behind a feature flag; the rest ships unflagged.**
     A flag gates only the license-vs-subscription precedence change (Decision 1) — the single behavior change for existing orgs — giving a kill-switch without redeploy. Derivation, self-heal, `resolution`, capabilities, and alert-split ship unflagged: they are strictly corrective. Rejects: flagging the whole resolver (keeps ~40 dual branches alive — the disease itself), no flag (reverting a money-path change requires a redeploy while a paying org is mis-resolved).
@@ -157,8 +157,8 @@ WHERE o."pricingModel" <> 'SEAT_EVENT'
 - `pricingModel` stays authoritative with fixed migrations — stored-state drift remains reachable (backoffice, missed webhooks).
 - Dropping the `pricingModel` column — breaks backoffice/analytics for no behavioral gain over cache.
 - Server-side auto seat purchase — charges without explicit consent.
-- Auto-cancelling the orphaned subscription under an ENTERPRISE license — money-mutating code on a derived signal (C1–C3 hazard class).
-- Keeping drifted orgs permanently un-metered — revenue leak becomes policy; two org classes forever.
+- Auto-cancelling the orphaned subscription under an ENTERPRISE license — money-mutating code on a derived signal.
+- Permanently excluding drifted orgs from the metering population — two org classes forever.
 - Retroactive catch-up metering for drifted orgs — violates Invariant I8.
 - Fixing only the invite path — four other paths keep the incident alive.
 - Deferring capabilities / plan-constants unification — leaves the same disease in neighboring organs (user chose in-scope).
@@ -169,17 +169,17 @@ WHERE o."pricingModel" <> 'SEAT_EVENT'
 
 ## Consequences
 
-**Positive:** the incident class is impossible by construction; enterprise licenses can't be destroyed by a webhook; the silent under-metering of drifted orgs is found and fixed; one place to read when debugging "why is this org billed/gated like this"; ops can distinguish self-serve friction from stuck customers; H11 drift killed.
+**Positive:** the incident class is impossible by construction; enterprise licenses can't be destroyed by a webhook; the metering-population drift is found and fixed; one place to read when debugging "why is this org billed/gated like this"; ops can distinguish self-serve friction from stuck customers; plan-definition drift killed.
 
 **Negative:** ~40 call sites churn across an ordered PR series (mitigated: mechanical, each site becomes simpler); precedence change is a behavior change for GROWTH/PRO-licensed SaaS orgs that also hold an active subscription — they flip from license-limits to subscription-limits (reviewed at cutover per the internal runbook, kill-switch via flag); metering for previously-excluded organizations begins at cutover; the orphaned-sub-under-ENTERPRISE-license leak persists until a human acts on the alert (explicitly accepted, Decision 11); **while the precedence flag is off (rollout steps 2–5), license+subscription orgs keep license-wins resolution — their metering mismatch and seat-flow dead-end persist until the flag flips; step 2 fully fixes only the no-license drift class (the original incident)**; the resolver gains responsibility (mitigated: it was already the choke point for planSource).
 
-**Neutral:** `dual-pricing-model.feature` needs revision (PricingModel demoted from "HOW billing works" to cache); backoffice keeps editing the column but edits no longer affect behavior (H8 remains for subscription-row edits — out of scope).
+**Neutral:** `dual-pricing-model.feature` needs revision (PricingModel demoted from "HOW billing works" to cache); backoffice keeps editing the column but edits no longer affect behavior (raw subscription-row edits remain out of scope).
 
 ## Open questions
 
 - Dunning/grace semantics: `FAILED`/`PENDING` subs fall out of the rank instantly (today's behavior — a transient payment failure drops entitlements). Owner: Sergio; candidate follow-up ADR on grace periods.
 - License self-serve seat expansion (regenerate license with more seats) — deferred, owner: Sergio, separate ADR.
-- Backoffice subscription edits bypassing invariants (assessment H8) — out of scope here; tracked in the Stripe assessment.
+- Backoffice subscription edits bypassing invariants — out of scope here; tracked internally.
 - Whether `resolution` should extend to non-member limit types (projects, workflows) — decide at implementation; the enum is designed to extend.
 - Exact `capabilities` key set — finalized from the 12 `assertEnterprisePlan` call sites during implementation.
 - Reconciliation of pre-flag licenses (rollout step 3b) — procedure in the internal ops runbook; owner: Sergio.
@@ -189,4 +189,4 @@ WHERE o."pricingModel" <> 'SEAT_EVENT'
 - v4 (2026-07-10): Redaction pass — operational/business cutover detail (affected-population review, customer communication, license reconciliation procedure) moved out of this public ADR into the internal ops runbook; engineering invariants unchanged.
 - v1 (2026-07-09): Initial draft. Round 1 locked: full-consolidation scope, money+access blast radius, 4 hard constraints. Round 2 locked: precedence rank (after worked ACME example — user initially leaned subscription-always-wins), derive-from-plan authority with cache column, memberPolicy mapping, capabilities in scope. Round 3 locked: typed resolution on all 5 paths, lazy heal + backfill, plan-constants unification in scope (user overrode defer recommendation), alerts split by resolution.
 - v3 (2026-07-10): Adversarial consistency review vs conversation locks (all 16 locks verified present). Finding 1 reopened the memberPolicy fork: `hard_cap` for all licenses was a self-serve regression — non-ENT-license SaaS orgs can buy a subscription that outranks their license; user locked SaaS→`upgrade` / self-hosted→`hard_cap` / ENTERPRISE→`hard_cap` (Decision 4). Finding 2: I8 had no mechanism — `reportUsageForMonth` checkpoint defaults to 0 and would bill the full month-to-date; fixed via checkpoint seeding at cutover (Rollout 3a, I8). Finding 3: flag-off window consequence stated explicitly (Consequences).
-- v2 (2026-07-09): Red-team pass (devils-advocate) folded in. Blocker 1 — `pricingModel` was NOT cosmetic: it gates Stripe event metering (`getOrganizationForBilling`); drifted orgs were silently un-metered. Added ordered Rollout section (metering gate moves before backfill), I8 (no retroactive billing), user locked bill-forward cutover. Blocker 2 — orphaned paying sub under an ENTERPRISE license: user locked let-it-run + alert-only (Decision 11). Also from red-team: active-subscription predicate pinned to `status='ACTIVE'` (Decision 1), pre-flag trial-license audit (Decision 8 + rollout 3b), public API documented as sixth advisory path (Decision 5, I3), self-heal write-once guard + meter-cache invalidation (Decision 3), plan-constants unification confirmed safe (Decision 7). New user locks: precedence flip behind feature flag (Decision 12), pending-invite seats surfaced not changed (Decision 13).
+- v2 (2026-07-09): Red-team pass (devils-advocate) folded in. Blocker 1 — `pricingModel` was NOT cosmetic: it gates the usage-metering population (`getOrganizationForBilling`). Added ordered Rollout section (metering gate moves before backfill), I8 (no retroactive billing), user locked bill-forward cutover. Blocker 2 — orphaned paying sub under an ENTERPRISE license: user locked let-it-run + alert-only (Decision 11). Also from red-team: active-subscription predicate pinned to `status='ACTIVE'` (Decision 1), pre-flag trial-license audit (Decision 8 + rollout 3b), public API documented as sixth advisory path (Decision 5, I3), self-heal write-once guard + meter-cache invalidation (Decision 3), plan-constants unification confirmed safe (Decision 7). New user locks: precedence flip behind feature flag (Decision 12), pending-invite seats surfaced not changed (Decision 13).

--- a/dev/docs/adr/039-billing-profile-single-resolution.md
+++ b/dev/docs/adr/039-billing-profile-single-resolution.md
@@ -31,7 +31,7 @@ Hard constraints (locked):
 3. **OSS/self-hosted unaffected** — non-SaaS builds keep license-only resolution; no Stripe imports leak into OSS paths.
 4. **No Stripe migration** — existing subscriptions/prices/items unchanged; only our interpretation layer changes.
 
-Prior art: `specs/licensing/dual-pricing-model.feature` (PricingModel = HOW, PlanTypes = WHAT — revised by this ADR), `specs/licensing/enforcement-members.feature`, ADR-019 (layering), and the internal billing assessment.
+Prior art: `specs/licensing/dual-pricing-model.feature` (PricingModel = HOW, PlanTypes = WHAT — revised by this ADR), `specs/licensing/enforcement-members.feature`, and ADR-019 (layering).
 
 ## Decision
 

--- a/langwatch/ee/billing/__tests__/planProvider.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planProvider.unit.test.ts
@@ -90,6 +90,37 @@ describe("createSaaSPlanProvider", () => {
         expect(plan.maxMembers).toBe(PLAN_LIMITS[PlanTypes.FREE].maxMembers);
       });
 
+      describe("when the only subscription is not ACTIVE", () => {
+        /** @scenario A PENDING subscription does not win plan resolution */
+        it("queries only ACTIVE subscriptions so a PENDING one resolves free", async () => {
+          const db = createMockDb();
+          const provider = createSaaSPlanProvider(db);
+
+          const plan = await provider.getActivePlan("org_1");
+
+          expect(plan.type).toBe(PlanTypes.FREE);
+          expect(db.subscription.findFirst).toHaveBeenCalledWith(
+            expect.objectContaining({
+              where: expect.objectContaining({
+                status: { in: ["active".toUpperCase()] },
+              }),
+            }),
+          );
+        });
+
+        /** @scenario A FAILED subscription does not win plan resolution */
+        it("resolves free when no ACTIVE subscription matches the filter", async () => {
+          // The provider's WHERE restricts to ACTIVE, so a FAILED-only org
+          // yields findFirst → null and falls through to the free plan.
+          const db = createMockDb({ findFirstResult: null });
+          const provider = createSaaSPlanProvider(db);
+
+          const plan = await provider.getActivePlan("org_1");
+
+          expect(plan.free).toBe(true);
+        });
+      });
+
       describe("when organization has SEAT_EVENT pricing model", () => {
         /** @scenario 'SEAT_EVENT organization on FREE plan gets 50,000 events per month' */
         it("returns FREE with 50,000 messages per month", async () => {

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -35,7 +35,10 @@ import {
   RETENTION_CATEGORIES,
 } from "../../../src/server/data-retention/retentionPolicy.schema";
 import { SubscriptionStatus } from "../planTypes";
-import { EEWebhookService } from "../services/webhookService";
+import {
+  EEWebhookService,
+  licenseConflictAlertCooldown,
+} from "../services/webhookService";
 
 const createMockSubscriptionRepository = () => ({
   findLastNonCancelled: vi.fn(),
@@ -173,9 +176,10 @@ describe("webhookService", () => {
   let mockStripeInstance: ReturnType<typeof createMockStripe>;
   let service: EEWebhookService;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    await licenseConflictAlertCooldown.delete("org_123");
     subRepo = createMockSubscriptionRepository();
     orgRepo = createMockOrganizationRepository();
     itemCalculator = createMockItemCalculator();
@@ -460,6 +464,38 @@ describe("webhookService", () => {
             licensePlanType: "ENTERPRISE",
           }),
         );
+      });
+
+      it("does not re-alert for the same org within the cooldown window", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            organization: {
+              name: "Acme",
+              license: makeLicenseKey({ isTrial: false }),
+            },
+          }),
+        );
+
+        const first = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await first;
+
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        const second = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await second;
+
+        expect(mockSendSlackLicenseConflictAlert).toHaveBeenCalledTimes(1);
       });
 
       it("treats a pre-flag license (no isTrial field) as non-trial", async () => {

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSendSlackSubscriptionEvent = vi.fn().mockResolvedValue(undefined);
+const mockSendSlackLicenseConflictAlert = vi.fn().mockResolvedValue(undefined);
 const mockSetForScope = vi.fn().mockResolvedValue(undefined);
 const mockRemoveForScope = vi.fn().mockResolvedValue(undefined);
 // Seat provisioning is create-if-absent: it reads the org's current rules and
@@ -12,6 +13,7 @@ vi.mock("../../../src/server/app-layer/app", () => ({
   getApp: () => ({
     notifications: {
       sendSlackSubscriptionEvent: mockSendSlackSubscriptionEvent,
+      sendSlackLicenseConflictAlert: mockSendSlackLicenseConflictAlert,
     },
     dataRetention: {
       policy: {
@@ -126,6 +128,32 @@ const makeSubscriptionWithOrg = (
       ...(organization as Record<string, unknown>),
     },
   } as unknown as SubscriptionWithOrg;
+};
+
+/** Builds an encodable license key whose payload parseLicenseKey accepts. */
+const makeLicenseKey = ({ isTrial }: { isTrial?: boolean } = {}): string => {
+  const signedLicense = {
+    data: {
+      licenseId: "lic_test_1",
+      version: 1,
+      organizationName: "Acme",
+      email: "admin@acme.test",
+      issuedAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2027-01-01T00:00:00.000Z",
+      plan: {
+        type: "ENTERPRISE",
+        name: "Enterprise",
+        maxMembers: 100,
+        maxProjects: 500,
+        maxMessagesPerMonth: 10000000,
+        maxWorkflows: 1000,
+        canPublish: true,
+      },
+      ...(isTrial !== undefined && { isTrial }),
+    },
+    signature: "test-signature",
+  };
+  return Buffer.from(JSON.stringify(signedLicense)).toString("base64");
 };
 
 const createMockStripe = (overrides: Record<string, unknown> = {}) => ({
@@ -355,7 +383,7 @@ describe("webhookService", () => {
         subRepo.activate.mockResolvedValue(
           makeSubscriptionWithOrg({
             status: SubscriptionStatus.ACTIVE,
-            organization: { name: "Acme", license: "trial-license-key" },
+            organization: { name: "Acme", license: makeLicenseKey({ isTrial: true }) },
           }),
         );
 
@@ -377,6 +405,82 @@ describe("webhookService", () => {
             organizationId: "org_123",
           }),
         );
+      });
+
+      /** @scenario Subscription activation clears a trial license */
+      it("clears a license explicitly marked as trial", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            organization: {
+              name: "Acme",
+              license: makeLicenseKey({ isTrial: true }),
+            },
+          }),
+        );
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(orgRepo.clearTrialLicense).toHaveBeenCalledWith("org_123");
+        expect(mockSendSlackLicenseConflictAlert).not.toHaveBeenCalled();
+      });
+
+      /** @scenario Subscription activation preserves a non-trial license and alerts ops */
+      it("keeps a non-trial license and alerts ops", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            organization: {
+              name: "Acme",
+              license: makeLicenseKey({ isTrial: false }),
+            },
+          }),
+        );
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(orgRepo.clearTrialLicense).not.toHaveBeenCalled();
+        expect(mockSendSlackLicenseConflictAlert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            organizationId: "org_123",
+            licensePlanType: "ENTERPRISE",
+          }),
+        );
+      });
+
+      it("treats a pre-flag license (no isTrial field) as non-trial", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({
+            status: SubscriptionStatus.ACTIVE,
+            organization: { name: "Acme", license: makeLicenseKey() },
+          }),
+        );
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(orgRepo.clearTrialLicense).not.toHaveBeenCalled();
+        expect(mockSendSlackLicenseConflictAlert).toHaveBeenCalled();
       });
     });
 

--- a/langwatch/ee/billing/notifications/notification.service.ts
+++ b/langwatch/ee/billing/notifications/notification.service.ts
@@ -411,6 +411,28 @@ export class NotificationService {
   }
 
   /**
+   * Sends a Slack alert when a non-trial license coexists with an active
+   * Stripe subscription (ADR-039 Decisions 8 & 11). The license is never
+   * auto-deleted and the subscription is never auto-cancelled — a human
+   * resolves which source should remain.
+   */
+  async sendSlackLicenseConflictAlert(context: {
+    organizationId: string;
+    organizationName: string;
+    licensePlanType: string;
+    subscriptionPlan: string;
+    reason: string;
+  }): Promise<void> {
+    await this.sendSlackMessage({
+      channelUrl: this.config.slackPlanLimitChannel,
+      body: {
+        text: `License/subscription conflict: ${context.organizationName} holds a non-trial ${context.licensePlanType} license AND an active ${context.subscriptionPlan} subscription (${context.reason}). Neither was touched — manual resolution needed. ${this.getAdminLink(context.organizationId)}`,
+      },
+      errorLog: "Failed to send Slack license-conflict notification",
+    });
+  }
+
+  /**
    * Sends a Slack notification for subscription events (prospective or confirmed).
    */
   async sendSlackSubscriptionEvent(

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -13,6 +13,7 @@ import {
   PLATFORM_DEFAULT_RETENTION_DAYS,
   RETENTION_CATEGORIES,
 } from "../../../src/server/data-retention/retentionPolicy.schema";
+import { parseLicenseKey } from "../../licensing/validation";
 import { createLogger } from "../../../src/utils/logger";
 import { SubscriptionRecordNotFoundError } from "../errors";
 import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
@@ -937,11 +938,38 @@ export class EEWebhookService implements WebhookService {
     }
   }
 
+  /**
+   * ADR-039 Decision 8: only licenses explicitly marked `isTrial` are cleared
+   * when a subscription activates. A non-trial license (including every
+   * license issued before the flag existed) is never auto-deleted — deleting
+   * a paid license is the worse failure — so the conflict is surfaced to ops
+   * instead.
+   */
   private async clearTrialLicenseIfPresent(
     updatedSubscription: SubscriptionWithOrg,
     reason: string,
   ) {
-    if (!updatedSubscription.organization.license) return;
+    const licenseKey = updatedSubscription.organization.license;
+    if (!licenseKey) return;
+
+    const parsed = parseLicenseKey(licenseKey);
+    const isTrial = parsed?.data.isTrial === true;
+
+    if (!isTrial) {
+      logger.warn(
+        { organizationId: updatedSubscription.organizationId },
+        `[stripeWebhook] Non-trial license coexists with an activating subscription — keeping license, alerting ops (${reason})`,
+      );
+      await getApp().notifications.sendSlackLicenseConflictAlert({
+        organizationId: updatedSubscription.organizationId,
+        organizationName: updatedSubscription.organization.name,
+        licensePlanType: parsed?.data.plan.type ?? "unparseable",
+        subscriptionPlan: updatedSubscription.plan,
+        reason,
+      });
+      return;
+    }
+
     logger.info(
       { organizationId: updatedSubscription.organizationId },
       `[stripeWebhook] Clearing trial license — ${reason}`,

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -9,6 +9,7 @@ import type {
   SubscriptionWithOrg,
 } from "../../../src/server/app-layer/subscription/subscription.repository";
 import { traced } from "../../../src/server/app-layer/tracing";
+import { TtlCache } from "../../../src/server/utils/ttlCache";
 import {
   PLATFORM_DEFAULT_RETENTION_DAYS,
   RETENTION_CATEGORIES,
@@ -32,6 +33,14 @@ import type {
 const logger = createLogger("langwatch:billing:webhookService");
 
 const VALID_CURRENCIES_FOR_CHECKOUT = new Set<string>(Object.values(Currency));
+
+// handleSubscriptionUpdated fires on every Stripe subscription update, so a
+// non-trial license coexisting with a subscription would re-alert on each
+// event. One alert per org per window, atomic across pods via Redis SET NX.
+export const licenseConflictAlertCooldown = new TtlCache<true>(
+  24 * 60 * 60 * 1000,
+  "ttlcache:billing:licenseConflictAlert:",
+);
 const maskCustomerId = (id: string) => `${id.slice(0, 7)}...${id.slice(-4)}`;
 
 type ItemCalculator = {
@@ -960,13 +969,19 @@ export class EEWebhookService implements WebhookService {
         { organizationId: updatedSubscription.organizationId },
         `[stripeWebhook] Non-trial license coexists with an activating subscription — keeping license, alerting ops (${reason})`,
       );
-      await getApp().notifications.sendSlackLicenseConflictAlert({
-        organizationId: updatedSubscription.organizationId,
-        organizationName: updatedSubscription.organization.name,
-        licensePlanType: parsed?.data.plan.type ?? "unparseable",
-        subscriptionPlan: updatedSubscription.plan,
-        reason,
-      });
+      const claimed = await licenseConflictAlertCooldown.claim(
+        updatedSubscription.organizationId,
+        true,
+      );
+      if (claimed) {
+        await getApp().notifications.sendSlackLicenseConflictAlert({
+          organizationId: updatedSubscription.organizationId,
+          organizationName: updatedSubscription.organization.name,
+          licensePlanType: parsed?.data.plan.type ?? "unparseable",
+          subscriptionPlan: updatedSubscription.plan,
+          reason,
+        });
+      }
       return;
     }
 

--- a/langwatch/ee/governance/routers/__tests__/governance.rbac.integration.test.ts
+++ b/langwatch/ee/governance/routers/__tests__/governance.rbac.integration.test.ts
@@ -69,7 +69,7 @@ describe("governance routers — RBAC enforcement", () => {
       globalForApp.__langwatch_app = createTestApp({
         planProvider: PlanProviderService.create({
           getActivePlan: async () => enterprisePlan,
-        }),
+        }, { isSaaS: true }),
       });
 
       const organization = await prisma.organization.create({

--- a/langwatch/ee/governance/routers/__tests__/license-gate-governance.integration.test.ts
+++ b/langwatch/ee/governance/routers/__tests__/license-gate-governance.integration.test.ts
@@ -125,7 +125,7 @@ function configureApp(plan: PlanInfo) {
   globalForApp.__langwatch_app = createTestApp({
     planProvider: PlanProviderService.create({
       getActivePlan: async () => plan,
-    }),
+    }, { isSaaS: true }),
   });
 }
 

--- a/langwatch/ee/governance/services/__tests__/anomalyRule.thresholdConfig.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/anomalyRule.thresholdConfig.integration.test.ts
@@ -53,7 +53,7 @@ beforeAll(async () => {
   globalForApp.__langwatch_app = createTestApp({
     planProvider: PlanProviderService.create({
       getActivePlan: async () => enterprisePlan,
-    }),
+    }, { isSaaS: true }),
   });
 
   const organization = await prisma.organization.create({

--- a/langwatch/ee/governance/services/__tests__/auditSurface.crossSurface.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/auditSurface.crossSurface.integration.test.ts
@@ -84,7 +84,7 @@ describe("Audit uniformity: identical payload shape across all governance surfac
       planProvider: PlanProviderService.create({
         getActivePlan: vi.fn().mockResolvedValue(FREE_PLAN) as unknown as
           PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/ee/licensing/licenseGenerationService.ts
+++ b/langwatch/ee/licensing/licenseGenerationService.ts
@@ -8,6 +8,12 @@ interface GenerateLicenseKeyParams {
   planType: string;
   maxMembers: number;
   privateKey: string;
+  /**
+   * Marks the license as a trial (ADR-039 Decision 8): trial licenses are
+   * auto-cleared when a Stripe subscription activates; non-trial licenses
+   * never are. Omitted (not stamped) for purchased licenses.
+   */
+  isTrial?: boolean;
   /** Override current time for deterministic testing */
   now?: Date;
 }
@@ -29,6 +35,7 @@ export function generateLicenseKey({
   planType,
   maxMembers,
   privateKey,
+  isTrial,
   now = new Date(),
 }: GenerateLicenseKeyParams): GenerateLicenseKeyResult {
   const template = getPlanTemplate(planType);
@@ -78,6 +85,9 @@ export function generateLicenseKey({
     issuedAt: now.toISOString(),
     expiresAt: expiresAt.toISOString(),
     plan,
+    // Only stamped when explicitly set — absent means non-trial, and key
+    // order must stay stable for signature re-serialization.
+    ...(isTrial !== undefined && { isTrial }),
   };
 
   const signedLicense = signLicense(licenseData, privateKey);

--- a/langwatch/ee/licensing/planInfo.ts
+++ b/langwatch/ee/licensing/planInfo.ts
@@ -5,8 +5,47 @@
  * Keeping it in a separate file prevents webpack from bundling
  * server-side code when client components import from ee/licensing.
  */
+/**
+ * How an organization expands full members once its cap is reached (ADR-039
+ * Decision 4). Doubles as the `resolution` carried on member-limit denials.
+ */
+export type MemberPolicy = "purchase_seat" | "upgrade" | "hard_cap";
+
+/** Usage metering basis (ADR-039 Decision 2). */
+export type MeterUnit = "events" | "traces";
+
+/**
+ * Billing mechanics derived from the winning plan source. Never stored —
+ * `Organization.pricingModel` is a display cache, not an input (ADR-039).
+ */
+export type BillingProfile = {
+  meterUnit: MeterUnit;
+  memberPolicy: MemberPolicy;
+  showUsageLimits: boolean;
+  isLegacyTiered: boolean;
+};
+
+/**
+ * Feature capabilities derived from the winning plan (ADR-039 Decision 6).
+ * Replaces scattered `plan.type === "ENTERPRISE"` string checks.
+ */
+export type PlanCapabilities = {
+  rbac: boolean;
+  scim: boolean;
+  sso: boolean;
+  groups: boolean;
+  customRoles: boolean;
+};
+
 export type PlanInfo = {
   planSource: "license" | "subscription" | "free";
+  /**
+   * Billing mechanics + capabilities, stamped by the composite plan provider
+   * (ADR-039). Optional because raw plan literals (PLAN_LIMITS, templates)
+   * don't carry them — the resolver is the only writer.
+   */
+  billing?: BillingProfile;
+  capabilities?: PlanCapabilities;
   type: string;
   name: string;
   free: boolean;

--- a/langwatch/ee/licensing/types.ts
+++ b/langwatch/ee/licensing/types.ts
@@ -44,6 +44,10 @@ export const LicenseDataSchema = z.object({
   issuedAt: z.string(), // ISO 8601 date string
   expiresAt: z.string(), // ISO 8601 date string
   plan: LicensePlanLimitsSchema,
+  // ADR-039 Decision 8: only trial licenses are auto-cleared when a Stripe
+  // subscription activates. Optional for backward compatibility with existing
+  // signed licenses — absent means non-trial (never auto-deleted).
+  isTrial: z.boolean().optional(),
 });
 
 export type LicenseData = z.infer<typeof LicenseDataSchema>;

--- a/langwatch/scripts/backfill-pricing-model.ts
+++ b/langwatch/scripts/backfill-pricing-model.ts
@@ -1,0 +1,50 @@
+/**
+ * ADR-039 rollout step 4: one-time backfill converging the pricingModel
+ * display cache for organizations whose column drifted against their active
+ * seat-event subscription (the incident class — migrateToSeatEvent skipped
+ * by webhook ordering).
+ *
+ * Safe ONLY after rollout step 1 shipped (metering gate reads the resolver,
+ * not the column) and step 3a ran (scripts/seed-billing-checkpoints.ts) —
+ * otherwise this update switches Stripe metering on retroactively for the
+ * cohort.
+ *
+ * Run with:
+ *   DATABASE_URL=... npx tsx scripts/backfill-pricing-model.ts --dry-run
+ *   DATABASE_URL=... npx tsx scripts/backfill-pricing-model.ts
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { findDriftedSeatEventOrgs } from "../src/server/app-layer/billing/driftedOrgs";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const driftedOrgs = await findDriftedSeatEventOrgs(prisma);
+
+  console.log(`Found ${driftedOrgs.length} drifted organization(s)`);
+  for (const org of driftedOrgs) {
+    console.log(`  ${org.id} (${org.name}): ${org.pricingModel} -> SEAT_EVENT`);
+  }
+
+  if (DRY_RUN) {
+    console.log("DRY-RUN: no rows updated");
+    return;
+  }
+
+  const result = await prisma.organization.updateMany({
+    where: { id: { in: driftedOrgs.map((o) => o.id) } },
+    data: { pricingModel: "SEAT_EVENT" },
+  });
+
+  console.log(`Updated ${result.count} organization(s)`);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => void prisma.$disconnect());

--- a/langwatch/scripts/seed-billing-checkpoints.ts
+++ b/langwatch/scripts/seed-billing-checkpoints.ts
@@ -1,0 +1,84 @@
+/**
+ * ADR-039 rollout step 3a: seed billing meter checkpoints for the drifted
+ * cohort (organizations with an ACTIVE GROWTH_SEAT_* subscription whose
+ * pricingModel column still says TIERED) so that turning their event
+ * metering on bills FORWARD ONLY (Invariant I8 — no retroactive charges).
+ *
+ * For each drifted org, the current billing month's checkpoint is created at
+ * its month-to-date billable-events total. Create-only: existing checkpoints
+ * are never modified (an existing checkpoint means the org was already
+ * metered and is owed its delta).
+ *
+ * MUST run BEFORE scripts/backfill-pricing-model.ts and before flipping any
+ * metering for the cohort. Review the printed org list with ops/CS first.
+ *
+ * Run with:
+ *   DATABASE_URL=... npx tsx scripts/seed-billing-checkpoints.ts --dry-run
+ *   DATABASE_URL=... npx tsx scripts/seed-billing-checkpoints.ts
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { queryBillableEventsTotal } from "../ee/billing/services/billableEventsQuery";
+import { findDriftedSeatEventOrgs } from "../src/server/app-layer/billing/driftedOrgs";
+import { PrismaBillingCheckpointService } from "../src/server/app-layer/billing/billingCheckpoint.service";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const prisma = new PrismaClient();
+
+function currentBillingMonth(): string {
+  const now = new Date();
+  const month = `${now.getUTCMonth() + 1}`.padStart(2, "0");
+  return `${now.getUTCFullYear()}-${month}`;
+}
+
+async function main() {
+  const billingMonth = currentBillingMonth();
+  const checkpoints = new PrismaBillingCheckpointService(prisma);
+
+  const driftedOrgs = await findDriftedSeatEventOrgs(prisma);
+
+  console.log(
+    `Found ${driftedOrgs.length} drifted organization(s) (active seat sub, column != SEAT_EVENT) for billing month ${billingMonth}`,
+  );
+
+  for (const org of driftedOrgs) {
+    const monthToDateTotal = await queryBillableEventsTotal({
+      organizationId: org.id,
+      billingMonth,
+    });
+
+    if (monthToDateTotal === null) {
+      console.error(
+        `  SKIP ${org.id} (${org.name}): ClickHouse unavailable — rerun before cutover`,
+      );
+      continue;
+    }
+
+    if (DRY_RUN) {
+      console.log(
+        `  DRY-RUN ${org.id} (${org.name}): would seed checkpoint at ${monthToDateTotal} events`,
+      );
+      continue;
+    }
+
+    const { seeded } = await checkpoints.seedIfAbsent({
+      organizationId: org.id,
+      billingMonth,
+      monthToDateTotal,
+    });
+
+    console.log(
+      seeded
+        ? `  SEEDED ${org.id} (${org.name}): checkpoint at ${monthToDateTotal} events`
+        : `  EXISTS ${org.id} (${org.name}): checkpoint already present, untouched`,
+    );
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => void prisma.$disconnect());

--- a/langwatch/scripts/seed-billing-checkpoints.ts
+++ b/langwatch/scripts/seed-billing-checkpoints.ts
@@ -10,7 +10,8 @@
  * metered and is owed its delta).
  *
  * MUST run BEFORE scripts/backfill-pricing-model.ts and before flipping any
- * metering for the cohort. Review the printed org list with ops/CS first.
+ * metering for the cohort. Review the printed list before running (see the
+ * internal cutover runbook).
  *
  * Run with:
  *   DATABASE_URL=... npx tsx scripts/seed-billing-checkpoints.ts --dry-run

--- a/langwatch/src/app/api/agents/__tests__/agents-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/agents/__tests__/agents-rest-api.integration.test.ts
@@ -49,7 +49,7 @@ describe("Feature: Agent REST API", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyPlanLimitReached: mockNotifyPlanLimitReached,
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
@@ -40,7 +40,7 @@ describe("Feature: Dashboard REST API", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/app/api/dataset/__tests__/dataset-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/dataset/__tests__/dataset-rest-api.integration.test.ts
@@ -41,7 +41,7 @@ describe("Feature: Dataset REST API", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyPlanLimitReached: mockNotifyPlanLimitReached,
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/app/api/dataset/__tests__/dataset-upload-api.integration.test.ts
+++ b/langwatch/src/app/api/dataset/__tests__/dataset-upload-api.integration.test.ts
@@ -27,7 +27,7 @@ describe("Feature: Dataset File Upload REST API", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/app/api/governance/__tests__/governance-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/governance/__tests__/governance-rest-api.integration.test.ts
@@ -73,7 +73,7 @@ describe("Feature: Governance REST API", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/app/api/middleware/__tests__/resource-limit-enforcement.integration.test.ts
+++ b/langwatch/src/app/api/middleware/__tests__/resource-limit-enforcement.integration.test.ts
@@ -41,7 +41,7 @@ describe("Feature: REST API resource limit enforcement parity", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/app/api/prompts/__tests__/prompts-api.integration.test.ts
+++ b/langwatch/src/app/api/prompts/__tests__/prompts-api.integration.test.ts
@@ -54,7 +54,7 @@ describe("Prompts API", () => {
         getActivePlan: vi
           .fn()
           .mockResolvedValue(FREE_PLAN) as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/app/api/prompts/__tests__/shorthand-prompt-syntax.integration.test.ts
+++ b/langwatch/src/app/api/prompts/__tests__/shorthand-prompt-syntax.integration.test.ts
@@ -38,7 +38,7 @@ describe("Feature: Shorthand prompt tag syntax (REST API)", () => {
         getActivePlan: vi
           .fn()
           .mockResolvedValue(FREE_PLAN) as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/app/api/suites/__tests__/suites-api.integration.test.ts
+++ b/langwatch/src/app/api/suites/__tests__/suites-api.integration.test.ts
@@ -38,7 +38,7 @@ describe("Feature: Suites REST API", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/server/api/routers/__tests__/enterprise-guards.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/enterprise-guards.integration.test.ts
@@ -123,7 +123,7 @@ describe.skipIf(isTestcontainersOnly)(
       globalForApp.__langwatch_app = createTestApp({
         planProvider: PlanProviderService.create({
           getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-        }),
+        }, { isSaaS: true }),
       });
     });
 

--- a/langwatch/src/server/api/routers/__tests__/limits.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/limits.integration.test.ts
@@ -64,7 +64,7 @@ describe("Limits Router Integration", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan,
-      }),
+      }, { isSaaS: true }),
     });
 
     const organization = await prisma.organization.upsert({
@@ -135,7 +135,7 @@ describe("Limits Router Integration", () => {
       globalForApp.__langwatch_app = createTestApp({
         planProvider: PlanProviderService.create({
           getActivePlan: mockGetActivePlan,
-        }),
+        }, { isSaaS: true }),
       });
     });
 

--- a/langwatch/src/server/api/routers/__tests__/onboarding.initializeOrganization.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/onboarding.initializeOrganization.integration.test.ts
@@ -68,7 +68,7 @@ describe("onboarding.initializeOrganization integration", () => {
       } as any,
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan,
-      }),
+      }, { isSaaS: true }),
     });
 
     const ctx = createInnerTRPCContext({
@@ -100,7 +100,7 @@ describe("onboarding.initializeOrganization integration", () => {
       } as any,
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan,
-      }),
+      }, { isSaaS: true }),
     });
 
     if (createdOrganizationIds.length > 0) {

--- a/langwatch/src/server/api/routers/__tests__/organization.invites.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.invites.integration.test.ts
@@ -196,7 +196,7 @@ describe("Organization Invites Integration", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan,
-      }),
+      }, { isSaaS: true }),
     });
 
     // Create admin caller
@@ -232,7 +232,7 @@ describe("Organization Invites Integration", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan,
-      }),
+      }, { isSaaS: true }),
     });
   });
 

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.integration.test.ts
@@ -83,7 +83,7 @@ describe.skip("organizationRouter member role validation", () => {
           maxMembersLite: 100,
           overrideAddingLimitations: true,
         }),
-      } as any),
+      } as any, { isSaaS: true }),
     });
 
     txMock = {

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
@@ -131,7 +131,7 @@ describe.skipIf(isTestcontainersOnly)(
       globalForApp.__langwatch_app = createTestApp({
         planProvider: PlanProviderService.create({
           getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-        }),
+        }, { isSaaS: true }),
       });
 
       // Guarantee target user starts as MEMBER with built-in MEMBER team role

--- a/langwatch/src/server/api/routers/__tests__/plan.getActivePlan.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/plan.getActivePlan.integration.test.ts
@@ -81,7 +81,7 @@ describe.skipIf(isTestcontainersOnly)("plan.getActivePlan integration", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
     });
 
     const ctx = createInnerTRPCContext({

--- a/langwatch/src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
@@ -84,7 +84,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
           maxProjects: 50,
           overrideAddingLimitations: true,
         }) as PlanProvider["getActivePlan"],
-      }),
+      }, { isSaaS: true }),
       usageLimits: {
         notifyResourceLimitReached: vi.fn().mockResolvedValue(undefined),
         checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/server/api/routers/__tests__/project.create.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/project.create.planLimit.integration.test.ts
@@ -94,7 +94,7 @@ describe.skipIf(isTestcontainersOnly)(
       globalForApp.__langwatch_app = createTestApp({
         planProvider: PlanProviderService.create({
           getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-        }),
+        }, { isSaaS: true }),
         usageLimits: {
           notifyResourceLimitReached: mockNotifyResourceLimitReached,
           checkAndSendWarning: vi.fn().mockResolvedValue(undefined),
@@ -319,7 +319,7 @@ describe.skipIf(isTestcontainersOnly)(
             maxProjects: 10,
             overrideAddingLimitations: false,
           }) as PlanProvider["getActivePlan"],
-        }),
+        }, { isSaaS: true }),
         usageLimits: {
           notifyResourceLimitReached: vi.fn().mockResolvedValue(undefined),
           checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/server/api/routers/__tests__/rbac.member-leak-coverage.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/rbac.member-leak-coverage.integration.test.ts
@@ -109,7 +109,7 @@ describe("#47 RBAC member-leak coverage (integration)", () => {
       ),
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan,
-      }),
+      }, { isSaaS: true }),
     });
 
     // Org + 2 users + 1 regular team + 2 personal-workspace teams.

--- a/langwatch/src/server/api/routers/__tests__/team.createTeamWithMembers.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/team.createTeamWithMembers.planLimit.integration.test.ts
@@ -93,7 +93,7 @@ describe.skipIf(isTestcontainersOnly)(
       globalForApp.__langwatch_app = createTestApp({
         planProvider: PlanProviderService.create({
           getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
-        }),
+        }, { isSaaS: true }),
         usageLimits: {
           notifyResourceLimitReached: mockNotifyResourceLimitReached,
           checkAndSendWarning: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/server/api/routers/__tests__/user.personaHome.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/user.personaHome.integration.test.ts
@@ -53,7 +53,7 @@ describe("user.persona-home customization integration", () => {
     globalForApp.__langwatch_app = createTestApp({
       planProvider: PlanProviderService.create({
         getActivePlan: async (): Promise<PlanInfo> => FREE_PLAN,
-      }),
+      }, { isSaaS: true }),
     });
 
     await prisma.organization.create({

--- a/langwatch/src/server/app-layer/billing/__tests__/billingCheckpoint.seed.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/billingCheckpoint.seed.unit.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { PrismaBillingCheckpointService } from "../billingCheckpoint.service";
+
+function makePrisma({ existing }: { existing: boolean }) {
+  return {
+    billingMeterCheckpoint: {
+      findUnique: vi
+        .fn()
+        .mockResolvedValue(existing ? { organizationId: "org-1" } : null),
+      create: vi.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+describe("PrismaBillingCheckpointService.seedIfAbsent()", () => {
+  describe("when no checkpoint exists for the billing month", () => {
+    it("creates the checkpoint at the month-to-date total", async () => {
+      const prisma = makePrisma({ existing: false });
+      const service = new PrismaBillingCheckpointService(prisma as never);
+
+      const result = await service.seedIfAbsent({
+        organizationId: "org-1",
+        billingMonth: "2026-07",
+        monthToDateTotal: 10_000,
+      });
+
+      expect(result.seeded).toBe(true);
+      expect(prisma.billingMeterCheckpoint.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          organizationId: "org-1",
+          billingMonth: "2026-07",
+          lastReportedTotal: 10_000,
+        }),
+      });
+    });
+  });
+
+  describe("when a checkpoint already exists", () => {
+    /** @scenario Seeding never lowers an existing checkpoint */
+    it("does not modify the existing checkpoint", async () => {
+      const prisma = makePrisma({ existing: true });
+      const service = new PrismaBillingCheckpointService(prisma as never);
+
+      const result = await service.seedIfAbsent({
+        organizationId: "org-1",
+        billingMonth: "2026-07",
+        monthToDateTotal: 10_000,
+      });
+
+      expect(result.seeded).toBe(false);
+      expect(prisma.billingMeterCheckpoint.create).not.toHaveBeenCalled();
+    });
+
+    /** @scenario Seeding is idempotent */
+    it("leaves the checkpoint unchanged on a repeat run", async () => {
+      const prisma = makePrisma({ existing: true });
+      const service = new PrismaBillingCheckpointService(prisma as never);
+
+      await service.seedIfAbsent({
+        organizationId: "org-1",
+        billingMonth: "2026-07",
+        monthToDateTotal: 10_000,
+      });
+      await service.seedIfAbsent({
+        organizationId: "org-1",
+        billingMonth: "2026-07",
+        monthToDateTotal: 10_000,
+      });
+
+      expect(prisma.billingMeterCheckpoint.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/billing/__tests__/driftedOrgs.integration.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/driftedOrgs.integration.test.ts
@@ -1,0 +1,137 @@
+import { PricingModel, type Organization } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import { PrismaOrganizationRepository } from "../../organizations/repositories/organization.prisma.repository";
+import { findDriftedSeatEventOrgs } from "../driftedOrgs";
+
+/**
+ * ADR-039 rollout step 4: the pricingModel backfill converges exactly the
+ * drifted cohort (active seat-event sub + column != SEAT_EVENT) and the
+ * column update itself changes no billing decision (the metering gate reads
+ * the subscription fact since rollout step 1).
+ *
+ * Pairs with: specs/licensing/pricing-model-backfill.feature
+ */
+describe("findDriftedSeatEventOrgs()", () => {
+  const ns = `backfill-${nanoid(8)}`;
+  const createdOrgIds: string[] = [];
+
+  async function createOrg({
+    pricingModel,
+    subscription,
+  }: {
+    pricingModel: PricingModel;
+    subscription?: { plan: string; status: string };
+  }): Promise<Organization> {
+    const org = await prisma.organization.create({
+      data: {
+        name: `Org ${nanoid(6)} ${ns}`,
+        slug: `org-${nanoid(6)}-${ns}`,
+        pricingModel,
+      },
+    });
+    createdOrgIds.push(org.id);
+    if (subscription) {
+      await prisma.subscription.create({
+        data: {
+          organizationId: org.id,
+          plan: subscription.plan as never,
+          status: subscription.status as never,
+        },
+      });
+    }
+    return org;
+  }
+
+  function driftedIdsWithin(all: Array<{ id: string }>): string[] {
+    return all.map((o) => o.id).filter((id) => createdOrgIds.includes(id));
+  }
+
+  beforeAll(async () => {
+    // no-op: orgs created per test
+  });
+
+  afterAll(async () => {
+    await prisma.subscription.deleteMany({
+      where: { organizationId: { in: createdOrgIds } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: createdOrgIds } },
+    });
+  });
+
+  describe("when an organization drifted (TIERED column + active seat subscription)", () => {
+    /** @scenario Backfill flips organizations with an active seat-event subscription */
+    it("includes it in the backfill population and the update converges it", async () => {
+      const org = await createOrg({
+        pricingModel: PricingModel.TIERED,
+        subscription: { plan: "GROWTH_SEAT_EUR_ANNUAL", status: "ACTIVE" },
+      });
+
+      const drifted = await findDriftedSeatEventOrgs(prisma);
+      expect(driftedIdsWithin(drifted)).toContain(org.id);
+
+      await prisma.organization.updateMany({
+        where: { id: { in: driftedIdsWithin(drifted) } },
+        data: { pricingModel: "SEAT_EVENT" },
+      });
+
+      const updated = await prisma.organization.findUnique({
+        where: { id: org.id },
+        select: { pricingModel: true },
+      });
+      expect(updated?.pricingModel).toBe("SEAT_EVENT");
+    });
+  });
+
+  describe("when the seat subscription is cancelled", () => {
+    /** @scenario Backfill ignores organizations whose seat subscription is cancelled */
+    it("excludes the organization from the backfill population", async () => {
+      const org = await createOrg({
+        pricingModel: PricingModel.TIERED,
+        subscription: { plan: "GROWTH_SEAT_EUR_MONTHLY", status: "CANCELLED" },
+      });
+
+      const drifted = await findDriftedSeatEventOrgs(prisma);
+
+      expect(driftedIdsWithin(drifted)).not.toContain(org.id);
+    });
+  });
+
+  describe("when the organization is on a legacy tiered plan", () => {
+    /** @scenario Backfill ignores organizations on legacy tiered plans */
+    it("excludes the organization from the backfill population", async () => {
+      const org = await createOrg({
+        pricingModel: PricingModel.TIERED,
+        subscription: { plan: "ACCELERATE", status: "ACTIVE" },
+      });
+
+      const drifted = await findDriftedSeatEventOrgs(prisma);
+
+      expect(driftedIdsWithin(drifted)).not.toContain(org.id);
+    });
+  });
+
+  describe("when the column converges", () => {
+    /** @scenario Backfilling the column does not change any billing decision */
+    it("resolves the same metering population before and after the update", async () => {
+      const org = await createOrg({
+        pricingModel: PricingModel.TIERED,
+        subscription: { plan: "GROWTH_SEAT_USD_MONTHLY", status: "ACTIVE" },
+      });
+      const repository = new PrismaOrganizationRepository(prisma);
+
+      const before = await repository.getOrganizationForBilling(org.id);
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { pricingModel: "SEAT_EVENT" },
+      });
+      const after = await repository.getOrganizationForBilling(org.id);
+
+      expect(before?.id).toBe(org.id);
+      expect(after?.id).toBe(org.id);
+      expect(before?.subscriptions).toEqual(after?.subscriptions);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/billing/billingCheckpoint.service.ts
+++ b/langwatch/src/server/app-layer/billing/billingCheckpoint.service.ts
@@ -50,6 +50,21 @@ export interface BillingCheckpointService {
     pendingReportedTotal: number;
     consecutiveFailures: number;
   }): Promise<void>;
+
+  /**
+   * Seeds the month's checkpoint for an organization whose metering turns on
+   * mid-month, so the first report bills only post-cutover events (ADR-039
+   * Invariant I8: no retroactive billing). Create-only: an existing
+   * checkpoint is NEVER modified — the org was already metered, and raising
+   * its checkpoint would skip legitimately-owed usage.
+   *
+   * @returns whether a new checkpoint row was created
+   */
+  seedIfAbsent(params: {
+    organizationId: string;
+    billingMonth: string;
+    monthToDateTotal: number;
+  }): Promise<{ seeded: boolean }>;
 }
 
 /**
@@ -174,5 +189,37 @@ export class PrismaBillingCheckpointService implements BillingCheckpointService 
         consecutiveFailures: params.consecutiveFailures,
       },
     });
+  }
+
+  async seedIfAbsent(params: {
+    organizationId: string;
+    billingMonth: string;
+    monthToDateTotal: number;
+  }): Promise<{ seeded: boolean }> {
+    const existing = await this.prisma.billingMeterCheckpoint.findUnique({
+      where: {
+        organizationId_billingMonth: {
+          organizationId: params.organizationId,
+          billingMonth: params.billingMonth,
+        },
+      },
+      select: { organizationId: true },
+    });
+    if (existing) {
+      return { seeded: false };
+    }
+
+    // create (not upsert-with-noop) so a concurrent seed surfaces as a
+    // unique-constraint conflict instead of silently racing.
+    await this.prisma.billingMeterCheckpoint.create({
+      data: {
+        organizationId: params.organizationId,
+        billingMonth: params.billingMonth,
+        lastReportedTotal: params.monthToDateTotal,
+        pendingReportedTotal: null,
+        consecutiveFailures: 0,
+      },
+    });
+    return { seeded: true };
   }
 }

--- a/langwatch/src/server/app-layer/billing/driftedOrgs.ts
+++ b/langwatch/src/server/app-layer/billing/driftedOrgs.ts
@@ -1,0 +1,27 @@
+import type { PrismaClient } from "@prisma/client";
+import { GROWTH_SEAT_PLAN_TYPES } from "../../../../ee/billing/utils/growthSeatEvent";
+
+/**
+ * The ADR-039 drifted cohort: organizations holding an ACTIVE seat-event
+ * subscription while their pricingModel display cache still says otherwise
+ * (the incident class — migrateToSeatEvent skipped by webhook ordering).
+ *
+ * Shared by the checkpoint-seeding and pricingModel-backfill rollout scripts
+ * so both operate on exactly the same population.
+ */
+export async function findDriftedSeatEventOrgs(
+  prisma: PrismaClient,
+): Promise<Array<{ id: string; name: string; pricingModel: string }>> {
+  return prisma.organization.findMany({
+    where: {
+      pricingModel: { not: "SEAT_EVENT" },
+      subscriptions: {
+        some: {
+          status: "ACTIVE",
+          plan: { in: [...GROWTH_SEAT_PLAN_TYPES] },
+        },
+      },
+    },
+    select: { id: true, name: true, pricingModel: true },
+  });
+}

--- a/langwatch/src/server/app-layer/organizations/__tests__/organization.prisma.repository.billing-gate.integration.test.ts
+++ b/langwatch/src/server/app-layer/organizations/__tests__/organization.prisma.repository.billing-gate.integration.test.ts
@@ -1,0 +1,118 @@
+import { PricingModel, type Organization } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import { PrismaOrganizationRepository } from "../repositories/organization.prisma.repository";
+
+/**
+ * ADR-039 rollout step 1 (Invariant I1, money half): the Stripe metering
+ * population derives from the active seat-event subscription, never from the
+ * Organization.pricingModel column. Column drift (the incident class) must not
+ * exclude a paying org from usage billing, and a stale SEAT_EVENT column must
+ * not include an org that stopped paying for seats.
+ *
+ * Pairs with: specs/licensing/metering-gate-derivation.feature
+ */
+describe("PrismaOrganizationRepository.getOrganizationForBilling()", () => {
+  const ns = `billing-gate-${nanoid(8)}`;
+  let repository: PrismaOrganizationRepository;
+  const createdOrgIds: string[] = [];
+
+  async function createOrg({
+    pricingModel,
+    subscription,
+  }: {
+    pricingModel: PricingModel;
+    subscription?: { plan: string; status: string };
+  }): Promise<Organization> {
+    const org = await prisma.organization.create({
+      data: {
+        name: `Org ${nanoid(6)} ${ns}`,
+        slug: `org-${nanoid(6)}-${ns}`,
+        pricingModel,
+        stripeCustomerId: `cus_${nanoid(8)}`,
+      },
+    });
+    createdOrgIds.push(org.id);
+
+    if (subscription) {
+      await prisma.subscription.create({
+        data: {
+          organizationId: org.id,
+          plan: subscription.plan as never,
+          status: subscription.status as never,
+        },
+      });
+    }
+
+    return org;
+  }
+
+  beforeAll(() => {
+    repository = new PrismaOrganizationRepository(prisma);
+  });
+
+  afterAll(async () => {
+    await prisma.subscription.deleteMany({
+      where: { organizationId: { in: createdOrgIds } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: createdOrgIds } },
+    });
+  });
+
+  describe("when the column drifted to TIERED but an active seat subscription exists", () => {
+    /** @scenario Organization with an active seat subscription and a stale TIERED column is metered */
+    it("includes the organization in the metering population", async () => {
+      const org = await createOrg({
+        pricingModel: PricingModel.TIERED,
+        subscription: { plan: "GROWTH_SEAT_EUR_MONTHLY", status: "ACTIVE" },
+      });
+
+      const result = await repository.getOrganizationForBilling(org.id);
+
+      expect(result?.subscriptions).toHaveLength(1);
+    });
+  });
+
+  describe("when the column says SEAT_EVENT but no seat subscription exists", () => {
+    /** @scenario Organization without a seat subscription is not metered even if the column says SEAT_EVENT */
+    it("excludes the organization from the metering population", async () => {
+      const org = await createOrg({ pricingModel: PricingModel.SEAT_EVENT });
+
+      const result = await repository.getOrganizationForBilling(org.id);
+
+      expect(result).toBeNull();
+    });
+
+    it("excludes the organization when its seat subscription is cancelled", async () => {
+      const org = await createOrg({
+        pricingModel: PricingModel.SEAT_EVENT,
+        subscription: { plan: "GROWTH_SEAT_USD_MONTHLY", status: "CANCELLED" },
+      });
+
+      const result = await repository.getOrganizationForBilling(org.id);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("when organizations have no column drift", () => {
+    /** @scenario Metering population is unchanged for organizations without column drift */
+    it("includes only the seat-subscribed organization", async () => {
+      const seatOrg = await createOrg({
+        pricingModel: PricingModel.SEAT_EVENT,
+        subscription: { plan: "GROWTH_SEAT_EUR_ANNUAL", status: "ACTIVE" },
+      });
+      const tieredOrg = await createOrg({ pricingModel: PricingModel.TIERED });
+
+      const seatResult = await repository.getOrganizationForBilling(seatOrg.id);
+      const tieredResult = await repository.getOrganizationForBilling(
+        tieredOrg.id,
+      );
+
+      expect(seatResult?.id).toBe(seatOrg.id);
+      expect(tieredResult).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
@@ -1,6 +1,5 @@
 import {
   OrganizationUserRole,
-  PricingModel,
   RoleBindingScopeType,
   TeamUserRole,
   type Currency,
@@ -203,8 +202,20 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
   async getOrganizationForBilling(
     organizationId: string,
   ): Promise<OrganizationForBilling | null> {
+    // ADR-039: the metering population derives from the active seat-event
+    // subscription, never from the pricingModel column — column drift must
+    // not exclude a paying org from usage billing (nor a stale SEAT_EVENT
+    // column include an org that stopped paying for seats).
     return this.prisma.organization.findFirst({
-      where: { id: organizationId, pricingModel: PricingModel.SEAT_EVENT },
+      where: {
+        id: organizationId,
+        subscriptions: {
+          some: {
+            status: "ACTIVE",
+            plan: { in: [...GROWTH_SEAT_PLAN_TYPES] },
+          },
+        },
+      },
       select: {
         id: true,
         stripeCustomerId: true,

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -128,6 +128,7 @@ import { ShareService } from "./share/share.service";
 import { SimulationRunService } from "./simulations/simulation-run.service";
 import { createCompositePlanProvider } from "./subscription/composite-plan-provider";
 import { PlanProviderService } from "./subscription/plan-provider";
+import { createPricingModelSelfHeal } from "./subscription/pricing-model-heal";
 import type { SubscriptionService } from "./subscription/subscription.service";
 import { SuiteRunService } from "./suites/suite-run.service";
 import { NullTopicRepository } from "./topics/null-topic.repository";
@@ -388,6 +389,17 @@ export function initializeDefaultApp(options?: {
     simulationReads,
   );
 
+  const pricingModelSelfHeal = createPricingModelSelfHeal({
+    hasActiveSeatEventSubscription: (organizationId) =>
+      orgRepo.hasActiveSeatEventSubscription(organizationId),
+    getPricingModel: (organizationId) =>
+      orgRepo.getPricingModel(organizationId),
+    setPricingModel: ({ organizationId, pricingModel }) =>
+      orgRepo.setPricingModel({ organizationId, pricingModel }),
+    invalidateMeterDecision: (organizationId) =>
+      usage.invalidateMeterDecision(organizationId),
+  });
+
   const planProvider = config.isSaas
     ? PlanProviderService.create(
         createCompositePlanProvider({
@@ -400,7 +412,7 @@ export function initializeDefaultApp(options?: {
               getLicenseHandler().getActivePlan(organizationId),
           },
         }),
-        { isSaaS: true },
+        { isSaaS: true, selfHeal: pricingModelSelfHeal },
       )
     : PlanProviderService.create({
         getActivePlan: async ({ organizationId }) => {

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -400,6 +400,7 @@ export function initializeDefaultApp(options?: {
               getLicenseHandler().getActivePlan(organizationId),
           },
         }),
+        { isSaaS: true },
       )
     : PlanProviderService.create({
         getActivePlan: async ({ organizationId }) => {
@@ -409,7 +410,7 @@ export function initializeDefaultApp(options?: {
             planSource: plan.free ? ("free" as const) : ("license" as const),
           };
         },
-      });
+      }, { isSaaS: false });
 
   let subscription: SubscriptionService | undefined;
   let usageReportingService: StripeUsageReportingService | undefined;
@@ -964,9 +965,10 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
       null,
       SimulationRunService.create(null),
     ),
-    planProvider: PlanProviderService.create({
-      getActivePlan: async () => FREE_PLAN,
-    }),
+    planProvider: PlanProviderService.create(
+      { getActivePlan: async () => FREE_PLAN },
+      { isSaaS: false },
+    ),
     subscription: undefined,
     notifications: NotificationService.createNull(),
     nurturing: undefined,

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -322,11 +322,9 @@ export function initializeDefaultApp(options?: {
     ExperimentService.create(prisma),
     "ExperimentService",
   );
+  const appOrgRepo = new PrismaOrganizationRepository(prisma);
   const organizations = traced(
-    new OrganizationService(
-      new PrismaOrganizationRepository(prisma),
-      new PromptTagRepository(prisma),
-    ),
+    new OrganizationService(appOrgRepo, new PromptTagRepository(prisma)),
     "OrganizationService",
   );
   const traceService = TraceService.create(prisma, {
@@ -398,6 +396,19 @@ export function initializeDefaultApp(options?: {
       orgRepo.setPricingModel({ organizationId, pricingModel }),
     invalidateMeterDecision: (organizationId) =>
       usage.invalidateMeterDecision(organizationId),
+    notifyLicenseSubscriptionConflict: async ({
+      organizationId,
+      licensePlanType,
+    }) => {
+      const org = await appOrgRepo.findNameById(organizationId);
+      await getApp().notifications.sendSlackLicenseConflictAlert({
+        organizationId,
+        organizationName: org?.name ?? organizationId,
+        licensePlanType,
+        subscriptionPlan: "GROWTH_SEAT_*",
+        reason: "license outranks an active seat subscription at resolution",
+      });
+    },
   });
 
   const planProvider = config.isSaas

--- a/langwatch/src/server/app-layer/subscription/__tests__/billing-profile.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/billing-profile.unit.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveBillingProfile,
+  deriveCapabilities,
+} from "../billing-profile";
+
+const seatPlan = {
+  type: "GROWTH_SEAT_USD_MONTHLY",
+  free: false,
+  planSource: "subscription" as const,
+};
+const enterpriseLicense = {
+  type: "ENTERPRISE",
+  free: false,
+  planSource: "license" as const,
+};
+const growthLicense = {
+  type: "GROWTH",
+  free: false,
+  planSource: "license" as const,
+};
+const tieredPlan = {
+  type: "LAUNCH",
+  free: false,
+  planSource: "subscription" as const,
+};
+const freePlan = { type: "FREE", free: true, planSource: "free" as const };
+
+describe("deriveBillingProfile()", () => {
+  describe("when the winning source is a seat-event subscription", () => {
+    /** @scenario Seat-event subscription resolves member policy purchase_seat */
+    it("resolves member policy purchase_seat", () => {
+      expect(
+        deriveBillingProfile({ plan: seatPlan, isSaaS: true }).memberPolicy,
+      ).toBe("purchase_seat");
+    });
+
+    it("meters events", () => {
+      expect(
+        deriveBillingProfile({ plan: seatPlan, isSaaS: true }).meterUnit,
+      ).toBe("events");
+    });
+
+    it("hides usage limits", () => {
+      expect(
+        deriveBillingProfile({ plan: seatPlan, isSaaS: true })
+          .showUsageLimits,
+      ).toBe(false);
+    });
+
+    it("is not legacy tiered", () => {
+      expect(
+        deriveBillingProfile({ plan: seatPlan, isSaaS: true }).isLegacyTiered,
+      ).toBe(false);
+    });
+  });
+
+  describe("when the winning source is an ENTERPRISE license", () => {
+    /** @scenario ENTERPRISE license resolves member policy hard_cap */
+    it("resolves member policy hard_cap on SaaS", () => {
+      expect(
+        deriveBillingProfile({ plan: enterpriseLicense, isSaaS: true })
+          .memberPolicy,
+      ).toBe("hard_cap");
+    });
+  });
+
+  describe("when the winning source is a non-ENTERPRISE license", () => {
+    /** @scenario Non-ENTERPRISE license on SaaS resolves member policy upgrade */
+    it("resolves member policy upgrade on SaaS", () => {
+      expect(
+        deriveBillingProfile({ plan: growthLicense, isSaaS: true })
+          .memberPolicy,
+      ).toBe("upgrade");
+    });
+
+    /** @scenario Any license on self-hosted resolves member policy hard_cap */
+    it("resolves member policy hard_cap on self-hosted", () => {
+      expect(
+        deriveBillingProfile({ plan: growthLicense, isSaaS: false })
+          .memberPolicy,
+      ).toBe("hard_cap");
+    });
+  });
+
+  describe("when the winning source is a legacy tiered subscription", () => {
+    /** @scenario Legacy tiered paid subscription resolves member policy upgrade */
+    it("resolves member policy upgrade", () => {
+      expect(
+        deriveBillingProfile({ plan: tieredPlan, isSaaS: true }).memberPolicy,
+      ).toBe("upgrade");
+    });
+
+    it("meters traces", () => {
+      expect(
+        deriveBillingProfile({ plan: tieredPlan, isSaaS: true }).meterUnit,
+      ).toBe("traces");
+    });
+
+    it("shows usage limits", () => {
+      expect(
+        deriveBillingProfile({ plan: tieredPlan, isSaaS: true })
+          .showUsageLimits,
+      ).toBe(true);
+    });
+
+    it("is legacy tiered", () => {
+      expect(
+        deriveBillingProfile({ plan: tieredPlan, isSaaS: true })
+          .isLegacyTiered,
+      ).toBe(true);
+    });
+  });
+
+  describe("when the organization is free", () => {
+    /** @scenario Free organization resolves member policy upgrade */
+    it("resolves member policy upgrade", () => {
+      expect(
+        deriveBillingProfile({ plan: freePlan, isSaaS: true }).memberPolicy,
+      ).toBe("upgrade");
+    });
+
+    it("resolves member policy hard_cap on self-hosted", () => {
+      expect(
+        deriveBillingProfile({ plan: freePlan, isSaaS: false }).memberPolicy,
+      ).toBe("hard_cap");
+    });
+  });
+});
+
+describe("deriveCapabilities()", () => {
+  describe("when the winning plan is ENTERPRISE", () => {
+    /** @scenario Enterprise plan resolves with enterprise capabilities enabled */
+    it("enables enterprise capabilities", () => {
+      const capabilities = deriveCapabilities({ plan: enterpriseLicense });
+      expect(capabilities).toEqual({
+        rbac: true,
+        scim: true,
+        sso: true,
+        groups: true,
+        customRoles: true,
+      });
+    });
+  });
+
+  describe("when the winning plan is a growth seat subscription", () => {
+    /** @scenario Growth plan resolves with enterprise capabilities disabled */
+    it("disables rbac", () => {
+      expect(deriveCapabilities({ plan: seatPlan }).rbac).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/subscription/__tests__/plan-provider-stamping.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/plan-provider-stamping.unit.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { FREE_PLAN } from "../../../../../ee/licensing/constants";
+import { PlanProviderService } from "../plan-provider";
+
+const seatSubscriptionPlan = {
+  ...FREE_PLAN,
+  type: "GROWTH_SEAT_USD_MONTHLY",
+  name: "Growth",
+  free: false,
+  planSource: "subscription" as const,
+};
+
+const enterpriseLicensePlan = {
+  ...FREE_PLAN,
+  type: "ENTERPRISE",
+  name: "Enterprise",
+  free: false,
+  planSource: "license" as const,
+};
+
+function providerReturning(plan: unknown) {
+  return { getActivePlan: vi.fn().mockResolvedValue(plan) };
+}
+
+describe("PlanProviderService", () => {
+  describe("when resolving any plan", () => {
+    it("stamps the billing profile derived from the winning source", async () => {
+      const service = PlanProviderService.create(
+        providerReturning(seatSubscriptionPlan),
+        { isSaaS: true },
+      );
+
+      const plan = await service.getActivePlan({ organizationId: "org_1" });
+
+      expect(plan.billing).toEqual({
+        meterUnit: "events",
+        memberPolicy: "purchase_seat",
+        showUsageLimits: false,
+        isLegacyTiered: false,
+      });
+    });
+
+    it("stamps capabilities derived from the winning plan", async () => {
+      const service = PlanProviderService.create(
+        providerReturning(enterpriseLicensePlan),
+        { isSaaS: true },
+      );
+
+      const plan = await service.getActivePlan({ organizationId: "org_1" });
+
+      expect(plan.capabilities?.sso).toBe(true);
+    });
+
+    it("preserves every field of the inner plan", async () => {
+      const service = PlanProviderService.create(
+        providerReturning(seatSubscriptionPlan),
+        { isSaaS: true },
+      );
+
+      const plan = await service.getActivePlan({ organizationId: "org_1" });
+
+      expect(plan).toMatchObject(seatSubscriptionPlan);
+    });
+  });
+
+  describe("when running self-hosted", () => {
+    /** @scenario Self-hosted resolution behavior is unchanged */
+    it("returns the license plan's own fields unchanged", async () => {
+      const service = PlanProviderService.create(
+        providerReturning(enterpriseLicensePlan),
+        { isSaaS: false },
+      );
+
+      const plan = await service.getActivePlan({ organizationId: "org_1" });
+
+      expect(plan).toMatchObject(enterpriseLicensePlan);
+    });
+
+    it("derives the billing profile with self-hosted member policy", async () => {
+      const service = PlanProviderService.create(
+        providerReturning({
+          ...FREE_PLAN,
+          type: "GROWTH",
+          free: false,
+          planSource: "license" as const,
+        }),
+        { isSaaS: false },
+      );
+
+      const plan = await service.getActivePlan({ organizationId: "org_1" });
+
+      expect(plan.billing?.memberPolicy).toBe("hard_cap");
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/subscription/__tests__/plan-provider-wiring.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/plan-provider-wiring.unit.test.ts
@@ -13,7 +13,7 @@ describe("PlanProvider wiring patterns", () => {
       const planProvider = PlanProviderService.create({
         getActivePlan: ({ organizationId, user }) =>
           mockSaasProvider.getActivePlan(organizationId, user),
-      });
+      }, { isSaaS: true });
 
       const user = { id: "u1", email: "a@b.com" };
       const result = await planProvider.getActivePlan({
@@ -21,7 +21,7 @@ describe("PlanProvider wiring patterns", () => {
         user,
       });
 
-      expect(result).toBe(FREE_PLAN);
+      expect(result).toMatchObject(FREE_PLAN);
       expect(mockSaasProvider.getActivePlan).toHaveBeenCalledWith("org_1", user);
     });
 
@@ -32,7 +32,7 @@ describe("PlanProvider wiring patterns", () => {
       const planProvider = PlanProviderService.create({
         getActivePlan: ({ organizationId, user }) =>
           mockSaasProvider.getActivePlan(organizationId, user),
-      });
+      }, { isSaaS: true });
 
       const user = {
         id: "u1",
@@ -54,14 +54,14 @@ describe("PlanProvider wiring patterns", () => {
       const planProvider = PlanProviderService.create({
         getActivePlan: ({ organizationId }) =>
           mockLicenseHandler.getActivePlan(organizationId),
-      });
+      }, { isSaaS: true });
 
       const result = await planProvider.getActivePlan({
         organizationId: "org_1",
         user: { id: "u1" },
       });
 
-      expect(result).toBe(FREE_PLAN);
+      expect(result).toMatchObject(FREE_PLAN);
       expect(mockLicenseHandler.getActivePlan).toHaveBeenCalledWith("org_1");
     });
   });
@@ -76,13 +76,13 @@ describe("PlanProvider wiring patterns", () => {
       };
       const planProvider = PlanProviderService.create({
         getActivePlan: async () => customPlan,
-      });
+      }, { isSaaS: true });
 
       const result = await planProvider.getActivePlan({
         organizationId: "org_1",
       });
 
-      expect(result).toBe(customPlan);
+      expect(result).toMatchObject(customPlan);
     });
   });
 
@@ -93,7 +93,7 @@ describe("PlanProvider wiring patterns", () => {
         getActivePlan: ({ organizationId, user }) => {
           throw error;
         },
-      });
+      }, { isSaaS: true });
 
       await expect(
         planProvider.getActivePlan({ organizationId: "org_1" })
@@ -106,7 +106,7 @@ describe("PlanProvider wiring patterns", () => {
         getActivePlan: ({ organizationId }) => {
           throw error;
         },
-      });
+      }, { isSaaS: true });
 
       await expect(
         planProvider.getActivePlan({ organizationId: "org_1" })

--- a/langwatch/src/server/app-layer/subscription/__tests__/plan-provider.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/plan-provider.unit.test.ts
@@ -21,7 +21,7 @@ describe("PlanProviderService", () => {
       const source: PlanProvider = {
         getActivePlan: vi.fn().mockResolvedValue(STUB_PLAN),
       };
-      const service = PlanProviderService.create(source);
+      const service = PlanProviderService.create(source, { isSaaS: true });
 
       const user: PlanProviderUser = {
         id: "user_1",
@@ -33,7 +33,7 @@ describe("PlanProviderService", () => {
         user,
       });
 
-      expect(result).toBe(STUB_PLAN);
+      expect(result).toMatchObject(STUB_PLAN);
       expect(source.getActivePlan).toHaveBeenCalledWith({
         organizationId: "org_1",
         user,
@@ -44,7 +44,7 @@ describe("PlanProviderService", () => {
       const source: PlanProvider = {
         getActivePlan: vi.fn().mockResolvedValue(STUB_PLAN),
       };
-      const service = PlanProviderService.create(source);
+      const service = PlanProviderService.create(source, { isSaaS: true });
 
       const user: PlanProviderUser = {
         id: "user_1",
@@ -63,13 +63,13 @@ describe("PlanProviderService", () => {
       const source: PlanProvider = {
         getActivePlan: vi.fn().mockResolvedValue(FREE_PLAN),
       };
-      const service = PlanProviderService.create(source);
+      const service = PlanProviderService.create(source, { isSaaS: true });
 
       const result = await service.getActivePlan({
         organizationId: "org_1",
       });
 
-      expect(result).toBe(FREE_PLAN);
+      expect(result).toMatchObject(FREE_PLAN);
       expect(source.getActivePlan).toHaveBeenCalledWith({
         organizationId: "org_1",
       });
@@ -82,7 +82,7 @@ describe("PlanProviderService", () => {
       const source: PlanProvider = {
         getActivePlan: vi.fn().mockRejectedValue(error),
       };
-      const service = PlanProviderService.create(source);
+      const service = PlanProviderService.create(source, { isSaaS: true });
 
       await expect(
         service.getActivePlan({ organizationId: "org_1" })
@@ -97,7 +97,7 @@ describe("PlanProviderService", () => {
       const service = PlanProviderService.create({
         getActivePlan: ({ organizationId, user }) =>
           saasGetActivePlan(organizationId, user),
-      });
+      }, { isSaaS: true });
 
       const user: PlanProviderUser = { id: "u1", email: "a@b.com" };
       const result = await service.getActivePlan({
@@ -105,7 +105,7 @@ describe("PlanProviderService", () => {
         user,
       });
 
-      expect(result).toBe(STUB_PLAN);
+      expect(result).toMatchObject(STUB_PLAN);
       expect(saasGetActivePlan).toHaveBeenCalledWith("org_1", user);
     });
 
@@ -115,14 +115,14 @@ describe("PlanProviderService", () => {
       const service = PlanProviderService.create({
         getActivePlan: ({ organizationId }) =>
           licenseGetActivePlan(organizationId),
-      });
+      }, { isSaaS: true });
 
       const result = await service.getActivePlan({
         organizationId: "org_1",
         user: { id: "u1" },
       });
 
-      expect(result).toBe(FREE_PLAN);
+      expect(result).toMatchObject(FREE_PLAN);
       expect(licenseGetActivePlan).toHaveBeenCalledWith("org_1");
     });
   });

--- a/langwatch/src/server/app-layer/subscription/__tests__/pricing-model-heal.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/pricing-model-heal.unit.test.ts
@@ -1,12 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { TtlCache } from "../../../utils/ttlCache";
 import { createPricingModelSelfHeal } from "../pricing-model-heal";
 
 describe("createPricingModelSelfHeal()", () => {
-  let hasActiveSeatEventSubscription: ReturnType<typeof vi.fn>;
-  let getPricingModel: ReturnType<typeof vi.fn>;
-  let setPricingModel: ReturnType<typeof vi.fn>;
-  let invalidateMeterDecision: ReturnType<typeof vi.fn>;
+  let hasActiveSeatEventSubscription: Mock<(organizationId: string) => Promise<boolean>>;
+  let getPricingModel: Mock<(organizationId: string) => Promise<string | null>>;
+  let setPricingModel: Mock<
+    (params: {
+      organizationId: string;
+      pricingModel: "SEAT_EVENT";
+    }) => Promise<void>
+  >;
+  let invalidateMeterDecision: Mock<(organizationId: string) => Promise<void>>;
   let guard: TtlCache<true>;
 
   function makeHeal() {
@@ -75,6 +80,58 @@ describe("createPricingModelSelfHeal()", () => {
 
       expect(setPricingModel).not.toHaveBeenCalled();
       expect(invalidateMeterDecision).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a non-free license wins while an active seat subscription exists", () => {
+    /** @scenario An ENTERPRISE license winning over an active subscription alerts without touching the subscription */
+    it("alerts ops and mutates nothing beyond the column heal", async () => {
+      const notifyLicenseSubscriptionConflict = vi
+        .fn()
+        .mockResolvedValue(undefined);
+      const heal = createPricingModelSelfHeal({
+        hasActiveSeatEventSubscription,
+        getPricingModel,
+        setPricingModel,
+        invalidateMeterDecision,
+        notifyLicenseSubscriptionConflict,
+        guard,
+      });
+
+      await heal({
+        organizationId: "org-conflict",
+        plan: { planSource: "license", type: "ENTERPRISE", free: false },
+      });
+
+      expect(notifyLicenseSubscriptionConflict).toHaveBeenCalledWith({
+        organizationId: "org-conflict",
+        licensePlanType: "ENTERPRISE",
+      });
+    });
+
+    it("does not alert when the winning plan is not a license", async () => {
+      const notifyLicenseSubscriptionConflict = vi
+        .fn()
+        .mockResolvedValue(undefined);
+      const heal = createPricingModelSelfHeal({
+        hasActiveSeatEventSubscription,
+        getPricingModel,
+        setPricingModel,
+        invalidateMeterDecision,
+        notifyLicenseSubscriptionConflict,
+        guard,
+      });
+
+      await heal({
+        organizationId: "org-sub",
+        plan: {
+          planSource: "subscription",
+          type: "GROWTH_SEAT_USD_MONTHLY",
+          free: false,
+        },
+      });
+
+      expect(notifyLicenseSubscriptionConflict).not.toHaveBeenCalled();
     });
   });
 

--- a/langwatch/src/server/app-layer/subscription/__tests__/pricing-model-heal.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/pricing-model-heal.unit.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TtlCache } from "../../../utils/ttlCache";
+import { createPricingModelSelfHeal } from "../pricing-model-heal";
+
+describe("createPricingModelSelfHeal()", () => {
+  let hasActiveSeatEventSubscription: ReturnType<typeof vi.fn>;
+  let getPricingModel: ReturnType<typeof vi.fn>;
+  let setPricingModel: ReturnType<typeof vi.fn>;
+  let invalidateMeterDecision: ReturnType<typeof vi.fn>;
+  let guard: TtlCache<true>;
+
+  function makeHeal() {
+    return createPricingModelSelfHeal({
+      hasActiveSeatEventSubscription,
+      getPricingModel,
+      setPricingModel,
+      invalidateMeterDecision,
+      guard,
+    });
+  }
+
+  beforeEach(() => {
+    hasActiveSeatEventSubscription = vi.fn().mockResolvedValue(true);
+    getPricingModel = vi.fn().mockResolvedValue("TIERED");
+    setPricingModel = vi.fn().mockResolvedValue(undefined);
+    invalidateMeterDecision = vi.fn().mockResolvedValue(undefined);
+    guard = new TtlCache<true>(60_000, `test:heal:${Math.random()}:`);
+  });
+
+  describe("when the column drifted against an active seat subscription", () => {
+    /** @scenario Resolving a drifted organization heals the pricingModel column */
+    it("updates the pricingModel to SEAT_EVENT", async () => {
+      await makeHeal()({ organizationId: "org-drifted" });
+
+      expect(setPricingModel).toHaveBeenCalledWith({
+        organizationId: "org-drifted",
+        pricingModel: "SEAT_EVENT",
+      });
+    });
+
+    /** @scenario A heal invalidates the organization's meter decision cache */
+    it("invalidates the meter decision cache after healing", async () => {
+      await makeHeal()({ organizationId: "org-drifted" });
+
+      expect(invalidateMeterDecision).toHaveBeenCalledWith("org-drifted");
+    });
+  });
+
+  describe("when a heal already ran within the guard window", () => {
+    /** @scenario The self-heal fires at most once per guard window */
+    it("does not issue another pricingModel update", async () => {
+      const heal = makeHeal();
+      await heal({ organizationId: "org-drifted" });
+      await heal({ organizationId: "org-drifted" });
+
+      expect(setPricingModel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the organization has no active seat subscription", () => {
+    it("does not touch the column", async () => {
+      hasActiveSeatEventSubscription.mockResolvedValue(false);
+
+      await makeHeal()({ organizationId: "org-tiered" });
+
+      expect(setPricingModel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the column already says SEAT_EVENT", () => {
+    it("does not write or invalidate", async () => {
+      getPricingModel.mockResolvedValue("SEAT_EVENT");
+
+      await makeHeal()({ organizationId: "org-ok" });
+
+      expect(setPricingModel).not.toHaveBeenCalled();
+      expect(invalidateMeterDecision).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a dependency throws", () => {
+    it("swallows the error (fire-and-forget)", async () => {
+      setPricingModel.mockRejectedValue(new Error("db down"));
+
+      await expect(
+        makeHeal()({ organizationId: "org-drifted" }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/subscription/billing-profile.ts
+++ b/langwatch/src/server/app-layer/subscription/billing-profile.ts
@@ -1,0 +1,87 @@
+import { isGrowthSeatEventPlan } from "../../../../ee/billing/utils/growthSeatEvent";
+import type {
+  BillingProfile,
+  MemberPolicy,
+  PlanCapabilities,
+} from "../../../../ee/licensing/planInfo";
+
+type WinningPlan = {
+  type: string;
+  free: boolean;
+  planSource: "license" | "subscription" | "free";
+};
+
+const isEnterprise = (plan: WinningPlan) => plan.type === "ENTERPRISE";
+
+/**
+ * Derives billing mechanics from the winning plan source (ADR-039 Decision 4):
+ * - seat-event subscription → purchase_seat (self-serve proration flow)
+ * - ENTERPRISE license → hard_cap (sales-owned deals)
+ * - non-ENTERPRISE license on SaaS → upgrade (a purchased subscription
+ *   outranks the license, preserving the self-serve escape)
+ * - any license on self-hosted → hard_cap (no Stripe)
+ * - everything else paid (legacy tiered) and free → upgrade on SaaS,
+ *   hard_cap on self-hosted
+ */
+export function deriveBillingProfile({
+  plan,
+  isSaaS,
+}: {
+  plan: WinningPlan;
+  isSaaS: boolean;
+}): BillingProfile {
+  const isSeatEvent =
+    plan.planSource === "subscription" && isGrowthSeatEventPlan(plan.type);
+  const isLegacyTiered =
+    plan.planSource === "subscription" && !isSeatEvent && !plan.free;
+
+  return {
+    meterUnit: isSeatEvent ? "events" : "traces",
+    memberPolicy: deriveMemberPolicy({ plan, isSaaS, isSeatEvent }),
+    // Seat-event orgs are usage-billed: limits are not a wall, so hide them.
+    showUsageLimits: !isSeatEvent,
+    isLegacyTiered,
+  };
+}
+
+function deriveMemberPolicy({
+  plan,
+  isSaaS,
+  isSeatEvent,
+}: {
+  plan: WinningPlan;
+  isSaaS: boolean;
+  isSeatEvent: boolean;
+}): MemberPolicy {
+  if (isSeatEvent) {
+    return "purchase_seat";
+  }
+  if (!isSaaS) {
+    // No Stripe on self-hosted: expansion always requires a new license.
+    return "hard_cap";
+  }
+  if (plan.planSource === "license" && isEnterprise(plan)) {
+    return "hard_cap";
+  }
+  return "upgrade";
+}
+
+/**
+ * Enterprise-gated capabilities (ADR-039 Decision 6). The key set mirrors the
+ * former `assertEnterprisePlan` call sites; all keys currently share the same
+ * ENTERPRISE gate, kept as independent flags so future plans can unbundle.
+ */
+export function deriveCapabilities({
+  plan,
+}: {
+  plan: WinningPlan;
+}): PlanCapabilities {
+  const enterprise = isEnterprise(plan);
+  return {
+    rbac: enterprise,
+    scim: enterprise,
+    sso: enterprise,
+    groups: enterprise,
+    customRoles: enterprise,
+  };
+}

--- a/langwatch/src/server/app-layer/subscription/plan-provider.ts
+++ b/langwatch/src/server/app-layer/subscription/plan-provider.ts
@@ -1,5 +1,6 @@
 import type { PlanInfo } from "../../../../ee/licensing/planInfo";
 import { deriveBillingProfile, deriveCapabilities } from "./billing-profile";
+import type { PricingModelSelfHeal } from "./pricing-model-heal";
 
 export type PlanResolver = (organizationId: string) => Promise<PlanInfo>;
 
@@ -21,13 +22,14 @@ export class PlanProviderService implements PlanProvider {
   private constructor(
     private readonly provider: PlanProvider,
     private readonly isSaaS: boolean,
+    private readonly selfHeal?: PricingModelSelfHeal,
   ) {}
 
   static create(
     provider: PlanProvider,
-    { isSaaS }: { isSaaS: boolean },
+    { isSaaS, selfHeal }: { isSaaS: boolean; selfHeal?: PricingModelSelfHeal },
   ): PlanProviderService {
-    return new PlanProviderService(provider, isSaaS);
+    return new PlanProviderService(provider, isSaaS, selfHeal);
   }
 
   /**
@@ -42,6 +44,12 @@ export class PlanProviderService implements PlanProvider {
     user?: PlanProviderUser;
   }): Promise<PlanInfo> {
     const plan = await this.provider.getActivePlan(params);
+
+    // Lazy pricingModel convergence (ADR-039 Decision 3). Fire-and-forget:
+    // the heal guards, logs, and swallows internally — never blocks or
+    // fails plan resolution.
+    void this.selfHeal?.({ organizationId: params.organizationId });
+
     return {
       ...plan,
       billing: deriveBillingProfile({ plan, isSaaS: this.isSaaS }),

--- a/langwatch/src/server/app-layer/subscription/plan-provider.ts
+++ b/langwatch/src/server/app-layer/subscription/plan-provider.ts
@@ -1,4 +1,5 @@
 import type { PlanInfo } from "../../../../ee/licensing/planInfo";
+import { deriveBillingProfile, deriveCapabilities } from "./billing-profile";
 
 export type PlanResolver = (organizationId: string) => Promise<PlanInfo>;
 
@@ -17,16 +18,34 @@ export interface PlanProvider {
 }
 
 export class PlanProviderService implements PlanProvider {
-  private constructor(private readonly provider: PlanProvider) {}
+  private constructor(
+    private readonly provider: PlanProvider,
+    private readonly isSaaS: boolean,
+  ) {}
 
-  static create(provider: PlanProvider): PlanProviderService {
-    return new PlanProviderService(provider);
+  static create(
+    provider: PlanProvider,
+    { isSaaS }: { isSaaS: boolean },
+  ): PlanProviderService {
+    return new PlanProviderService(provider, isSaaS);
   }
 
+  /**
+   * Resolves the winning plan and stamps its derived billing profile and
+   * capabilities (ADR-039). This wrapper is the single derivation point —
+   * both the SaaS composite provider and the self-hosted license provider
+   * flow through it, so no consumer ever re-derives billing mechanics from
+   * raw stored signals.
+   */
   async getActivePlan(params: {
     organizationId: string;
     user?: PlanProviderUser;
   }): Promise<PlanInfo> {
-    return this.provider.getActivePlan(params);
+    const plan = await this.provider.getActivePlan(params);
+    return {
+      ...plan,
+      billing: deriveBillingProfile({ plan, isSaaS: this.isSaaS }),
+      capabilities: deriveCapabilities({ plan }),
+    };
   }
 }

--- a/langwatch/src/server/app-layer/subscription/plan-provider.ts
+++ b/langwatch/src/server/app-layer/subscription/plan-provider.ts
@@ -45,10 +45,10 @@ export class PlanProviderService implements PlanProvider {
   }): Promise<PlanInfo> {
     const plan = await this.provider.getActivePlan(params);
 
-    // Lazy pricingModel convergence (ADR-039 Decision 3). Fire-and-forget:
-    // the heal guards, logs, and swallows internally — never blocks or
-    // fails plan resolution.
-    void this.selfHeal?.({ organizationId: params.organizationId });
+    // Lazy pricingModel convergence + license/subscription conflict detection
+    // (ADR-039 Decisions 3 & 11). Fire-and-forget: the heal guards, logs, and
+    // swallows internally — never blocks or fails plan resolution.
+    void this.selfHeal?.({ organizationId: params.organizationId, plan });
 
     return {
       ...plan,

--- a/langwatch/src/server/app-layer/subscription/pricing-model-heal.ts
+++ b/langwatch/src/server/app-layer/subscription/pricing-model-heal.ts
@@ -1,0 +1,77 @@
+import { createLogger } from "../../../utils/logger/server";
+import { TtlCache } from "../../utils/ttlCache";
+
+const logger = createLogger("langwatch:billing:pricingModelHeal");
+
+const HEAL_GUARD_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Write-once guard: at most one drift check (and heal) per organization per
+ * window, atomic across pods via Redis SET NX (ADR-039 Decision 3). Prevents
+ * write amplification against read-replica lag and multi-pod races.
+ */
+export const pricingModelHealGuard = new TtlCache<true>(
+  HEAL_GUARD_TTL_MS,
+  "ttlcache:billing:pricingModelHeal:",
+);
+
+export type PricingModelSelfHeal = (params: {
+  organizationId: string;
+}) => Promise<void>;
+
+/**
+ * Lazily converges the Organization.pricingModel display cache with the
+ * organization's actual seat-event billing (ADR-039 Decision 3). No decision
+ * reads the column after rollout step 1 — this keeps backoffice display and
+ * analytics from contradicting how the organization is billed.
+ *
+ * Fire-and-forget from the resolver: failures are logged, never thrown.
+ */
+export function createPricingModelSelfHeal({
+  hasActiveSeatEventSubscription,
+  getPricingModel,
+  setPricingModel,
+  invalidateMeterDecision,
+  guard = pricingModelHealGuard,
+}: {
+  hasActiveSeatEventSubscription: (organizationId: string) => Promise<boolean>;
+  getPricingModel: (organizationId: string) => Promise<string | null>;
+  setPricingModel: (params: {
+    organizationId: string;
+    pricingModel: "SEAT_EVENT";
+  }) => Promise<void>;
+  invalidateMeterDecision: (organizationId: string) => Promise<void>;
+  guard?: TtlCache<true>;
+}): PricingModelSelfHeal {
+  return async ({ organizationId }) => {
+    try {
+      const claimed = await guard.claim(organizationId, true);
+      if (!claimed) {
+        return;
+      }
+
+      const isSeatEvent = await hasActiveSeatEventSubscription(organizationId);
+      if (!isSeatEvent) {
+        return;
+      }
+
+      const pricingModel = await getPricingModel(organizationId);
+      if (pricingModel === "SEAT_EVENT") {
+        return;
+      }
+
+      await setPricingModel({ organizationId, pricingModel: "SEAT_EVENT" });
+      await invalidateMeterDecision(organizationId);
+
+      logger.info(
+        { organizationId, previousPricingModel: pricingModel },
+        "healed drifted pricingModel to SEAT_EVENT",
+      );
+    } catch (error) {
+      logger.error(
+        { organizationId, error },
+        "pricingModel self-heal failed (non-fatal)",
+      );
+    }
+  };
+}

--- a/langwatch/src/server/app-layer/subscription/pricing-model-heal.ts
+++ b/langwatch/src/server/app-layer/subscription/pricing-model-heal.ts
@@ -17,6 +17,11 @@ export const pricingModelHealGuard = new TtlCache<true>(
 
 export type PricingModelSelfHeal = (params: {
   organizationId: string;
+  plan?: {
+    planSource: "license" | "subscription" | "free";
+    type: string;
+    free: boolean;
+  };
 }) => Promise<void>;
 
 /**
@@ -32,6 +37,7 @@ export function createPricingModelSelfHeal({
   getPricingModel,
   setPricingModel,
   invalidateMeterDecision,
+  notifyLicenseSubscriptionConflict,
   guard = pricingModelHealGuard,
 }: {
   hasActiveSeatEventSubscription: (organizationId: string) => Promise<boolean>;
@@ -41,9 +47,13 @@ export function createPricingModelSelfHeal({
     pricingModel: "SEAT_EVENT";
   }) => Promise<void>;
   invalidateMeterDecision: (organizationId: string) => Promise<void>;
+  notifyLicenseSubscriptionConflict?: (params: {
+    organizationId: string;
+    licensePlanType: string;
+  }) => Promise<void>;
   guard?: TtlCache<true>;
 }): PricingModelSelfHeal {
-  return async ({ organizationId }) => {
+  return async ({ organizationId, plan }) => {
     try {
       const claimed = await guard.claim(organizationId, true);
       if (!claimed) {
@@ -53,6 +63,16 @@ export function createPricingModelSelfHeal({
       const isSeatEvent = await hasActiveSeatEventSubscription(organizationId);
       if (!isSeatEvent) {
         return;
+      }
+
+      // ADR-039 Decision 11: a license winning the rank while a paid
+      // seat-event subscription runs is a billing conflict a human must
+      // resolve. Alert only — never cancel or mutate the subscription.
+      if (plan?.planSource === "license" && !plan.free) {
+        await notifyLicenseSubscriptionConflict?.({
+          organizationId,
+          licensePlanType: plan.type,
+        });
       }
 
       const pricingModel = await getPricingModel(organizationId);

--- a/langwatch/src/server/app-layer/usage/__tests__/usage-meter-policy.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage-meter-policy.unit.test.ts
@@ -1,4 +1,3 @@
-import { PricingModel } from "@prisma/client";
 import { describe, expect, it } from "vitest";
 import { normalizeUsageUnit, resolveUsageMeter } from "../usage-meter-policy";
 
@@ -6,9 +5,9 @@ describe("resolveUsageMeter", () => {
   describe("when paid organization (isFree=false)", () => {
     describe("when no license override", () => {
       /** @scenario "Paid TIERED organization counts each trace as one unit" */
-      it("returns traces for TIERED pricing model", () => {
+      it("returns traces for a paid org without seat-event billing", () => {
         const decision = resolveUsageMeter({
-          pricingModel: PricingModel.TIERED,
+          isSeatEvent: false,
           isFree: false,
           hasValidLicenseOverride: false,
         });
@@ -17,9 +16,9 @@ describe("resolveUsageMeter", () => {
       });
 
       /** @scenario "Paid SEAT_EVENT organization counts each span toward the limit" */
-      it("returns events for SEAT_EVENT pricing model", () => {
+      it("returns events for seat-event billing", () => {
         const decision = resolveUsageMeter({
-          pricingModel: PricingModel.SEAT_EVENT,
+          isSeatEvent: true,
           isFree: false,
           hasValidLicenseOverride: false,
         });
@@ -27,9 +26,9 @@ describe("resolveUsageMeter", () => {
         expect(decision.usageUnit).toBe("events");
       });
 
-      it("defaults to traces when pricingModel is null", () => {
+      it("defaults to traces when not seat-event billed", () => {
         const decision = resolveUsageMeter({
-          pricingModel: null,
+          isSeatEvent: false,
           isFree: false,
           hasValidLicenseOverride: false,
         });
@@ -40,9 +39,9 @@ describe("resolveUsageMeter", () => {
 
     describe("when license override is active", () => {
       /** @scenario "Licensed organization respects its own counting rule" */
-      it("uses license usageUnit over pricingModel", () => {
+      it("uses license usageUnit over subscription billing", () => {
         const decision = resolveUsageMeter({
-          pricingModel: PricingModel.TIERED,
+          isSeatEvent: false,
           licenseUsageUnit: "events",
           isFree: false,
           hasValidLicenseOverride: true,
@@ -53,7 +52,7 @@ describe("resolveUsageMeter", () => {
 
       it("normalizes license usageUnit", () => {
         const decision = resolveUsageMeter({
-          pricingModel: PricingModel.TIERED,
+          isSeatEvent: false,
           licenseUsageUnit: "EVENT",
           isFree: false,
           hasValidLicenseOverride: true,
@@ -62,9 +61,9 @@ describe("resolveUsageMeter", () => {
         expect(decision.usageUnit).toBe("events");
       });
 
-      it("falls back to pricingModel when license has no usageUnit", () => {
+      it("falls back to subscription billing when license has no usageUnit", () => {
         const decision = resolveUsageMeter({
-          pricingModel: PricingModel.SEAT_EVENT,
+          isSeatEvent: true,
           licenseUsageUnit: undefined,
           isFree: false,
           hasValidLicenseOverride: true,
@@ -77,9 +76,9 @@ describe("resolveUsageMeter", () => {
 
   describe("when free organization (isFree=true)", () => {
     /** @scenario "Free TIERED organization counts each span toward the limit" */
-    it("returns events for TIERED pricing model", () => {
+    it("returns events for a free org without seat-event billing", () => {
       const decision = resolveUsageMeter({
-        pricingModel: PricingModel.TIERED,
+        isSeatEvent: false,
         isFree: true,
         hasValidLicenseOverride: false,
       });
@@ -88,9 +87,9 @@ describe("resolveUsageMeter", () => {
     });
 
     /** @scenario "Free SEAT_EVENT organization counts each span toward the limit" */
-    it("returns events for SEAT_EVENT pricing model", () => {
+    it("returns events for seat-event billing", () => {
       const decision = resolveUsageMeter({
-        pricingModel: PricingModel.SEAT_EVENT,
+        isSeatEvent: true,
         isFree: true,
         hasValidLicenseOverride: false,
       });
@@ -98,9 +97,9 @@ describe("resolveUsageMeter", () => {
       expect(decision.usageUnit).toBe("events");
     });
 
-    it("returns events when pricingModel is null", () => {
+    it("returns events when not seat-event billed", () => {
       const decision = resolveUsageMeter({
-        pricingModel: null,
+        isSeatEvent: false,
         isFree: true,
         hasValidLicenseOverride: false,
       });
@@ -110,7 +109,7 @@ describe("resolveUsageMeter", () => {
 
     it("respects license override even when free", () => {
       const decision = resolveUsageMeter({
-        pricingModel: PricingModel.TIERED,
+        isSeatEvent: false,
         licenseUsageUnit: "traces",
         isFree: true,
         hasValidLicenseOverride: true,
@@ -123,18 +122,18 @@ describe("resolveUsageMeter", () => {
   describe("reason traceability", () => {
     it("includes unit source in reason", () => {
       const decision = resolveUsageMeter({
-        pricingModel: PricingModel.TIERED,
+        isSeatEvent: false,
         isFree: false,
         hasValidLicenseOverride: false,
       });
 
       expect(decision.reason).toContain("unit=traces");
-      expect(decision.reason).toContain("pricingModel(TIERED)");
+      expect(decision.reason).toContain("subscription(seatEvent=false)");
     });
 
     it("includes license source in reason when override active", () => {
       const decision = resolveUsageMeter({
-        pricingModel: PricingModel.TIERED,
+        isSeatEvent: false,
         licenseUsageUnit: "events",
         isFree: false,
         hasValidLicenseOverride: true,
@@ -145,7 +144,7 @@ describe("resolveUsageMeter", () => {
 
     it("reports freeTier as source when free TIERED", () => {
       const decision = resolveUsageMeter({
-        pricingModel: PricingModel.TIERED,
+        isSeatEvent: false,
         isFree: true,
         hasValidLicenseOverride: false,
       });
@@ -156,7 +155,7 @@ describe("resolveUsageMeter", () => {
 
     it("includes isFree in reason when paid", () => {
       const decision = resolveUsageMeter({
-        pricingModel: PricingModel.TIERED,
+        isSeatEvent: false,
         isFree: false,
         hasValidLicenseOverride: false,
       });
@@ -170,7 +169,7 @@ describe("counting unit by organization profile", () => {
   /** @scenario Free TIERED organization counts each span toward the limit */
   it("counts each span (events unit) for a free TIERED organization", () => {
     const decision = resolveUsageMeter({
-      pricingModel: PricingModel.TIERED,
+      isSeatEvent: false,
       isFree: true,
       hasValidLicenseOverride: false,
     });
@@ -181,7 +180,7 @@ describe("counting unit by organization profile", () => {
   /** @scenario Free SEAT_EVENT organization counts each span toward the limit */
   it("counts each span (events unit) for a free SEAT_EVENT organization", () => {
     const decision = resolveUsageMeter({
-      pricingModel: PricingModel.SEAT_EVENT,
+      isSeatEvent: true,
       isFree: true,
       hasValidLicenseOverride: false,
     });
@@ -192,7 +191,7 @@ describe("counting unit by organization profile", () => {
   /** @scenario Paid TIERED organization counts each trace as one unit */
   it("counts each trace (traces unit) for a paid TIERED organization", () => {
     const decision = resolveUsageMeter({
-      pricingModel: PricingModel.TIERED,
+      isSeatEvent: false,
       isFree: false,
       hasValidLicenseOverride: false,
     });
@@ -203,7 +202,7 @@ describe("counting unit by organization profile", () => {
   /** @scenario Paid SEAT_EVENT organization counts each span toward the limit */
   it("counts each span (events unit) for a paid SEAT_EVENT organization", () => {
     const decision = resolveUsageMeter({
-      pricingModel: PricingModel.SEAT_EVENT,
+      isSeatEvent: true,
       isFree: false,
       hasValidLicenseOverride: false,
     });
@@ -214,7 +213,7 @@ describe("counting unit by organization profile", () => {
   /** @scenario Licensed organization respects its own counting rule */
   it("uses the license-specified counting unit for a licensed organization", () => {
     const decision = resolveUsageMeter({
-      pricingModel: PricingModel.SEAT_EVENT,
+      isSeatEvent: true,
       licenseUsageUnit: "traces",
       isFree: true,
       hasValidLicenseOverride: true,

--- a/langwatch/src/server/app-layer/usage/__tests__/usage-service-getResolvedUsageUnit.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage-service-getResolvedUsageUnit.unit.test.ts
@@ -5,7 +5,6 @@ import type { OrganizationService } from "../../organizations/organization.servi
 import { UsageService } from "../usage.service";
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import type { PlanInfo } from "../../../../../ee/licensing/planInfo";
-import { PricingModel } from "@prisma/client";
 
 vi.mock("~/env.mjs", () => ({
   env: { IS_SAAS: true },
@@ -51,7 +50,7 @@ describe("UsageService.getResolvedUsageUnit", () => {
     getCurrentMonthCount: vi.fn(),
   };
   const mockOrgRepo = {
-    getPricingModel: vi.fn().mockResolvedValue(null),
+    hasActiveSeatEventSubscription: vi.fn().mockResolvedValue(false),
   };
   const mockPlanResolver = vi.fn() as unknown as PlanResolver;
 
@@ -59,7 +58,7 @@ describe("UsageService.getResolvedUsageUnit", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockOrgRepo.getPricingModel.mockResolvedValue(PricingModel.TIERED);
+    mockOrgRepo.hasActiveSeatEventSubscription.mockResolvedValue(false);
     service = Object.create(UsageService.prototype);
     Object.assign(service, {
       organizationService: mockOrgService,
@@ -97,6 +96,22 @@ describe("UsageService.getResolvedUsageUnit", () => {
       });
 
       expect(unit).toBe("traces");
+    });
+  });
+
+  describe("when the pricingModel column drifted against an active seat subscription", () => {
+    /** @scenario Meter unit comes from the resolved billing profile, not the pricingModel column */
+    it("returns events derived from the subscription fact", async () => {
+      mockOrgRepo.hasActiveSeatEventSubscription.mockResolvedValue(true);
+      (mockPlanResolver as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ...PAID_TIERED_PLAN,
+      });
+
+      const unit = await service.getResolvedUsageUnit({
+        organizationId: "org-drifted",
+      });
+
+      expect(unit).toBe("events");
     });
   });
 

--- a/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -1,4 +1,3 @@
-import { PricingModel } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TtlCache } from "~/server/utils/ttlCache";
 import { UNLIMITED_MESSAGES } from "../../../../../ee/billing/planLimits";
@@ -92,7 +91,7 @@ describe("UsageService", () => {
   };
 
   const mockOrgRepo = {
-    getPricingModel: vi.fn().mockResolvedValue(null),
+    hasActiveSeatEventSubscription: vi.fn().mockResolvedValue(false),
   };
 
   const mockPlanResolver = vi.fn() as unknown as PlanResolver;
@@ -105,7 +104,7 @@ describe("UsageService", () => {
     for (const key of Object.keys(mockEnv)) {
       delete mockEnv[key];
     }
-    mockOrgRepo.getPricingModel.mockResolvedValue(null);
+    mockOrgRepo.hasActiveSeatEventSubscription.mockResolvedValue(false);
     (mockPlanResolver as ReturnType<typeof vi.fn>).mockResolvedValue({
       ...FREE_PLAN,
       maxMessagesPerMonth: 1000,
@@ -589,7 +588,7 @@ describe("UsageService", () => {
   describe("getCurrentMonthCountForDisplay", () => {
     describe("given a seat-based plan with no message cap (metered events)", () => {
       beforeEach(() => {
-        mockOrgRepo.getPricingModel.mockResolvedValue(PricingModel.SEAT_EVENT);
+        mockOrgRepo.hasActiveSeatEventSubscription.mockResolvedValue(true);
         (mockPlanResolver as ReturnType<typeof vi.fn>).mockResolvedValue({
           ...SEAT_UNLIMITED_PLAN,
         });

--- a/langwatch/src/server/app-layer/usage/usage-meter-policy.ts
+++ b/langwatch/src/server/app-layer/usage/usage-meter-policy.ts
@@ -1,5 +1,3 @@
-import { PricingModel } from "@prisma/client";
-
 export type UsageUnit = "traces" | "events";
 
 export interface MeterDecision {
@@ -12,25 +10,29 @@ export interface MeterDecision {
  *
  * Precedence:
  *   1. License override with explicit usageUnit → use that unit
- *   2. PricingModel SEAT_EVENT → always events
- *   3. Free tier (isFree=true) → events regardless of pricing model
- *   4. Paid non-SEAT_EVENT → traces
+ *   2. Seat-event billed (active GROWTH_SEAT_* subscription) → always events
+ *   3. Free tier (isFree=true) → events regardless of billing
+ *   4. Paid non-seat-event → traces
+ *
+ * `isSeatEvent` derives from the organization's active subscription plan
+ * (ADR-039) — never from the Organization.pricingModel column, which is a
+ * display cache that can drift.
  *
  * This is a pure decision function — no side effects, no I/O.
  */
 export function resolveUsageMeter({
-  pricingModel,
+  isSeatEvent,
   licenseUsageUnit,
   hasValidLicenseOverride,
   isFree,
 }: {
-  pricingModel: PricingModel | null;
+  isSeatEvent: boolean;
   licenseUsageUnit?: string;
   hasValidLicenseOverride: boolean;
   isFree: boolean;
 }): MeterDecision {
   const usageUnit = resolveUsageUnit({
-    pricingModel,
+    isSeatEvent,
     licenseUsageUnit,
     hasValidLicenseOverride,
     isFree,
@@ -40,7 +42,7 @@ export function resolveUsageMeter({
     usageUnit,
     hasValidLicenseOverride,
     licenseUsageUnit,
-    pricingModel,
+    isSeatEvent,
     isFree,
   });
 
@@ -48,12 +50,12 @@ export function resolveUsageMeter({
 }
 
 function resolveUsageUnit({
-  pricingModel,
+  isSeatEvent,
   licenseUsageUnit,
   hasValidLicenseOverride,
   isFree,
 }: {
-  pricingModel: PricingModel | null;
+  isSeatEvent: boolean;
   licenseUsageUnit?: string;
   hasValidLicenseOverride: boolean;
   isFree: boolean;
@@ -63,12 +65,12 @@ function resolveUsageUnit({
     return normalizeUsageUnit(licenseUsageUnit);
   }
 
-  // PricingModel-derived: SEAT_EVENT → events, else → traces
-  if (pricingModel === PricingModel.SEAT_EVENT) {
+  // Subscription-derived: seat-event billing → events, else → traces
+  if (isSeatEvent) {
     return "events";
   }
 
-  // Free-tier always counts events regardless of pricing model
+  // Free-tier always counts events regardless of billing
   if (isFree) {
     return "events";
   }
@@ -92,21 +94,21 @@ function buildReason({
   usageUnit,
   hasValidLicenseOverride,
   licenseUsageUnit,
-  pricingModel,
+  isSeatEvent,
   isFree,
 }: {
   usageUnit: UsageUnit;
   hasValidLicenseOverride: boolean;
   licenseUsageUnit?: string;
-  pricingModel: PricingModel | null;
+  isSeatEvent: boolean;
   isFree: boolean;
 }): string {
   const unitSource =
     hasValidLicenseOverride && licenseUsageUnit
       ? `license(${licenseUsageUnit})`
-      : isFree && pricingModel !== PricingModel.SEAT_EVENT
+      : isFree && !isSeatEvent
         ? "freeTier"
-        : `pricingModel(${pricingModel ?? "null"})`;
+        : `subscription(seatEvent=${isSeatEvent})`;
 
   return `unit=${usageUnit} from ${unitSource}, isFree=${isFree}`;
 }

--- a/langwatch/src/server/app-layer/usage/usage.service.ts
+++ b/langwatch/src/server/app-layer/usage/usage.service.ts
@@ -286,6 +286,15 @@ export class UsageService {
     });
   }
 
+  /**
+   * Drops the cached meter decision for an organization so the next check
+   * recomputes it from the resolved plan. Called by the pricingModel
+   * self-heal (ADR-039 Decision 3) when billing state converges.
+   */
+  async invalidateMeterDecision(organizationId: string): Promise<void> {
+    await this.decisionCache.delete(organizationId);
+  }
+
   private async getCachedMeterDecision(
     organizationId: string,
     plan?: PlanInfo,

--- a/langwatch/src/server/app-layer/usage/usage.service.ts
+++ b/langwatch/src/server/app-layer/usage/usage.service.ts
@@ -302,14 +302,17 @@ export class UsageService {
     organizationId: string,
     resolvedPlan?: PlanInfo,
   ): Promise<MeterDecision> {
-    const pricingModel =
-      (await this.organizationRepository?.getPricingModel(organizationId)) ??
-      null;
+    // ADR-039: seat-event billing derives from the active subscription plan,
+    // never from the pricingModel display cache (which can drift).
+    const isSeatEvent =
+      (await this.organizationRepository?.hasActiveSeatEventSubscription(
+        organizationId,
+      )) ?? false;
     const plan = resolvedPlan ?? (await this.planResolver(organizationId));
     const hasValidLicenseOverride = plan.planSource === "license";
 
     const decision = resolveUsageMeter({
-      pricingModel,
+      isSeatEvent,
       licenseUsageUnit: plan.usageUnit,
       hasValidLicenseOverride,
       isFree: plan.free,

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportUsageForMonth.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportUsageForMonth.command.unit.test.ts
@@ -284,6 +284,56 @@ describe("ReportUsageForMonthCommand", () => {
     });
   });
 
+  describe("given a checkpoint seeded at metering cutover", () => {
+    /** @scenario A seeded checkpoint bills only post-cutover events */
+    it("reports only events beyond the seeded total", async () => {
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockBillingCheckpoints.getCheckpoint.mockResolvedValue({
+        lastReportedTotal: 10_000,
+        pendingReportedTotal: null,
+        consecutiveFailures: 0,
+      });
+      mockQueryBillableEventsTotal.mockResolvedValue(10_500);
+      mockReportUsageDelta.mockResolvedValue([{ reported: true }]);
+      mockBillingCheckpoints.writeIntent.mockResolvedValue(undefined);
+      mockBillingCheckpoints.confirm.mockResolvedValue(undefined);
+      mockSelfDispatch.mockResolvedValue(undefined);
+      const handler = await createHandler();
+
+      await handler.handle(makeCommand());
+
+      expect(mockReportUsageDelta).toHaveBeenCalledWith(
+        expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({ value: 500 }),
+          ]),
+        }),
+      );
+    });
+
+    /** @scenario An unseeded newly-metered organization would bill the full month-to-date */
+    it("reports the entire month-to-date when no checkpoint exists", async () => {
+      mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());
+      mockBillingCheckpoints.getCheckpoint.mockResolvedValue(null);
+      mockQueryBillableEventsTotal.mockResolvedValue(10_500);
+      mockReportUsageDelta.mockResolvedValue([{ reported: true }]);
+      mockBillingCheckpoints.writeIntent.mockResolvedValue(undefined);
+      mockBillingCheckpoints.confirm.mockResolvedValue(undefined);
+      mockSelfDispatch.mockResolvedValue(undefined);
+      const handler = await createHandler();
+
+      await handler.handle(makeCommand());
+
+      expect(mockReportUsageDelta).toHaveBeenCalledWith(
+        expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({ value: 10_500 }),
+          ]),
+        }),
+      );
+    });
+  });
+
   describe("given first run for new org (no checkpoint)", () => {
     it("creates checkpoint at reported total", async () => {
       mockOrganizations.getOrganizationForBilling.mockResolvedValue(makeOrg());

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportUsageForMonth.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportUsageForMonth.command.ts
@@ -123,7 +123,7 @@ export class ReportUsageForMonthCommand
       if (!org) {
         logger.warn(
           { organizationId },
-          "organization not found or not SEAT_EVENT, skipping",
+          "organization not found or has no active seat-event subscription, skipping",
         );
         return [];
       }

--- a/langwatch/src/server/repositories/organization.repository.ts
+++ b/langwatch/src/server/repositories/organization.repository.ts
@@ -60,6 +60,23 @@ export class OrganizationRepository {
   }
 
   /**
+   * Converges the pricingModel display cache (ADR-039 Decision 3). Only the
+   * self-heal writes through this — decisions never read the column.
+   */
+  async setPricingModel({
+    organizationId,
+    pricingModel,
+  }: {
+    organizationId: string;
+    pricingModel: PricingModel;
+  }): Promise<void> {
+    await this.prisma.organization.update({
+      where: { id: organizationId },
+      data: { pricingModel },
+    });
+  }
+
+  /**
    * Gets the Stripe customer ID for an organization
    */
   async getStripeCustomerId(organizationId: string): Promise<string | null> {

--- a/langwatch/src/server/repositories/organization.repository.ts
+++ b/langwatch/src/server/repositories/organization.repository.ts
@@ -1,4 +1,5 @@
 import type { PricingModel, PrismaClient } from "@prisma/client";
+import { GROWTH_SEAT_PLAN_TYPES } from "../../../ee/billing/utils/growthSeatEvent";
 
 /**
  * Repository for organization-related data access
@@ -37,6 +38,25 @@ export class OrganizationRepository {
       select: { pricingModel: true },
     });
     return org?.pricingModel ?? null;
+  }
+
+  /**
+   * Whether the organization holds an ACTIVE seat-event (GROWTH_SEAT_*)
+   * subscription. Seat-billing decisions derive from this subscription fact
+   * (ADR-039) — never from the pricingModel display cache, which can drift.
+   */
+  async hasActiveSeatEventSubscription(
+    organizationId: string,
+  ): Promise<boolean> {
+    const subscription = await this.prisma.subscription.findFirst({
+      where: {
+        organizationId,
+        status: "ACTIVE",
+        plan: { in: [...GROWTH_SEAT_PLAN_TYPES] },
+      },
+      select: { id: true },
+    });
+    return subscription !== null;
   }
 
   /**

--- a/langwatch/src/server/routes/__tests__/auth-cli-governance.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/auth-cli-governance.integration.test.ts
@@ -87,7 +87,7 @@ describe("GET /api/auth/cli/governance/*", () => {
       planProvider: PlanProviderService.create({
         getActivePlan: async ({ organizationId }) =>
           organizationId === ORG_C ? freePlan : enterprisePlan,
-      }),
+      }, { isSaaS: true }),
     });
 
     await prisma.organization.create({

--- a/langwatch/src/server/routes/ingest/__tests__/dogfood-smoke.e2e.integration.test.ts
+++ b/langwatch/src/server/routes/ingest/__tests__/dogfood-smoke.e2e.integration.test.ts
@@ -111,7 +111,7 @@ async function configureApp(plan: PlanInfo) {
   globalForApp.__langwatch_app = createTestApp({
     planProvider: PlanProviderService.create({
       getActivePlan: async () => plan,
-    }),
+    }, { isSaaS: true }),
   });
 }
 

--- a/specs/licensing/billing-profile-resolver.feature
+++ b/specs/licensing/billing-profile-resolver.feature
@@ -1,0 +1,128 @@
+Feature: Billing profile resolution in the composite plan provider
+  # ADR-039 rollout step 2. The composite plan provider computes the billing
+  # block (meterUnit, memberPolicy, showUsageLimits, isLegacyTiered) and
+  # capabilities from the winning plan source. The pricingModel column is
+  # self-healed cache, never an input. Precedence-rank scenarios live in
+  # precedence-flag-flip.feature (they ship behind the flag).
+
+  As the platform
+  I want one resolver to answer how an organization pays and what it can access
+  So that no surface re-derives billing behavior from raw stored signals
+
+  # --- Active subscription predicate ---
+
+  @unit @unimplemented
+  Scenario: A PENDING subscription does not win plan resolution
+    Given an organization whose only subscription has status "PENDING"
+    When the active plan is resolved
+    Then the plan resolves as if no subscription exists
+
+  @unit @unimplemented
+  Scenario: A FAILED subscription does not win plan resolution
+    Given an organization whose only subscription has status "FAILED"
+    When the active plan is resolved
+    Then the plan resolves as if no subscription exists
+
+  # --- memberPolicy mapping (Decision 4) ---
+
+  @unit @unimplemented
+  Scenario: Seat-event subscription resolves member policy purchase_seat
+    Given an organization whose winning plan source is an ACTIVE "GROWTH_SEAT_USD_MONTHLY" subscription
+    When the active plan is resolved
+    Then the billing profile member policy is "purchase_seat"
+
+  @unit @unimplemented
+  Scenario: ENTERPRISE license resolves member policy hard_cap
+    Given a SaaS organization whose winning plan source is a valid ENTERPRISE license
+    When the active plan is resolved
+    Then the billing profile member policy is "hard_cap"
+
+  @unit @unimplemented
+  Scenario: Non-ENTERPRISE license on SaaS resolves member policy upgrade
+    Given a SaaS organization whose winning plan source is a valid GROWTH license
+    When the active plan is resolved
+    Then the billing profile member policy is "upgrade"
+
+  @unit @unimplemented
+  Scenario: Any license on self-hosted resolves member policy hard_cap
+    Given a self-hosted deployment whose organization has a valid GROWTH license
+    When the active plan is resolved
+    Then the billing profile member policy is "hard_cap"
+
+  @unit @unimplemented
+  Scenario: Legacy tiered paid subscription resolves member policy upgrade
+    Given an organization whose winning plan source is an ACTIVE "LAUNCH" subscription
+    When the active plan is resolved
+    Then the billing profile member policy is "upgrade"
+
+  @unit @unimplemented
+  Scenario: Free organization resolves member policy upgrade
+    Given an organization with no subscription and no license
+    When the active plan is resolved
+    Then the billing profile member policy is "upgrade"
+
+  # --- Capabilities (Decision 6) ---
+
+  @unit @unimplemented
+  Scenario: Enterprise plan resolves with enterprise capabilities enabled
+    Given an organization whose winning plan is ENTERPRISE
+    When the active plan is resolved
+    Then the plan capabilities include rbac, scim, and sso as enabled
+
+  @unit @unimplemented
+  Scenario: Growth plan resolves with enterprise capabilities disabled
+    Given an organization whose winning plan source is an ACTIVE "GROWTH_SEAT_EUR_MONTHLY" subscription
+    When the active plan is resolved
+    Then the plan capabilities report rbac as disabled
+
+  # --- Self-heal (Decision 3) ---
+
+  @integration @unimplemented
+  Scenario: Resolving a drifted organization heals the pricingModel column
+    Given an organization with pricingModel "TIERED" and an ACTIVE seat-event subscription
+    When the active plan is resolved
+    Then the organization's pricingModel is updated to "SEAT_EVENT"
+
+  @integration @unimplemented
+  Scenario: The self-heal fires at most once per guard window
+    Given an organization whose pricingModel was healed within the guard window
+    When the active plan is resolved again
+    Then no additional pricingModel update is issued
+
+  @integration @unimplemented
+  Scenario: A heal invalidates the organization's meter decision cache
+    Given an organization with a cached meter decision based on the stale column
+    When the resolver heals the organization's pricingModel
+    Then the next meter decision is recomputed from the resolved plan
+
+  # --- Trial licenses (Decision 8) ---
+
+  @integration @unimplemented
+  Scenario: Subscription activation clears a trial license
+    Given an organization holding a license marked as trial
+    When a Stripe subscription activates for the organization
+    Then the trial license is removed
+
+  @integration @unimplemented
+  Scenario: Subscription activation preserves a non-trial license and alerts ops
+    Given an organization holding a license not marked as trial
+    When a Stripe subscription activates for the organization
+    Then the license remains stored
+    And an ops alert reports the license and subscription conflict
+
+  # --- Orphaned subscription (Decision 11) ---
+
+  @integration @unimplemented
+  Scenario: An ENTERPRISE license winning over an active subscription alerts without touching the subscription
+    Given an organization with a valid ENTERPRISE license and an ACTIVE seat-event subscription
+    When the active plan is resolved
+    Then an ops alert reports the coexisting paid subscription
+    And the Stripe subscription is not modified or cancelled
+
+  # --- OSS parity (Invariant I5) ---
+
+  @unit @unimplemented
+  Scenario: Self-hosted resolution behavior is unchanged
+    Given a self-hosted deployment with a valid ENTERPRISE license
+    When the active plan is resolved
+    Then the plan matches the license exactly as before the resolver change

--- a/specs/licensing/billing-profile-resolver.feature
+++ b/specs/licensing/billing-profile-resolver.feature
@@ -77,19 +77,19 @@ Feature: Billing profile resolution in the composite plan provider
 
   # --- Self-heal (Decision 3) ---
 
-  @integration @unimplemented
+  @unit
   Scenario: Resolving a drifted organization heals the pricingModel column
     Given an organization with pricingModel "TIERED" and an ACTIVE seat-event subscription
     When the active plan is resolved
     Then the organization's pricingModel is updated to "SEAT_EVENT"
 
-  @integration @unimplemented
+  @unit
   Scenario: The self-heal fires at most once per guard window
     Given an organization whose pricingModel was healed within the guard window
     When the active plan is resolved again
     Then no additional pricingModel update is issued
 
-  @integration @unimplemented
+  @unit
   Scenario: A heal invalidates the organization's meter decision cache
     Given an organization with a cached meter decision based on the stale column
     When the resolver heals the organization's pricingModel

--- a/specs/licensing/billing-profile-resolver.feature
+++ b/specs/licensing/billing-profile-resolver.feature
@@ -97,13 +97,13 @@ Feature: Billing profile resolution in the composite plan provider
 
   # --- Trial licenses (Decision 8) ---
 
-  @integration @unimplemented
+  @unit
   Scenario: Subscription activation clears a trial license
     Given an organization holding a license marked as trial
     When a Stripe subscription activates for the organization
     Then the trial license is removed
 
-  @integration @unimplemented
+  @unit
   Scenario: Subscription activation preserves a non-trial license and alerts ops
     Given an organization holding a license not marked as trial
     When a Stripe subscription activates for the organization
@@ -112,7 +112,7 @@ Feature: Billing profile resolution in the composite plan provider
 
   # --- Orphaned subscription (Decision 11) ---
 
-  @integration @unimplemented
+  @unit
   Scenario: An ENTERPRISE license winning over an active subscription alerts without touching the subscription
     Given an organization with a valid ENTERPRISE license and an ACTIVE seat-event subscription
     When the active plan is resolved

--- a/specs/licensing/billing-profile-resolver.feature
+++ b/specs/licensing/billing-profile-resolver.feature
@@ -11,13 +11,13 @@ Feature: Billing profile resolution in the composite plan provider
 
   # --- Active subscription predicate ---
 
-  @unit @unimplemented
+  @unit
   Scenario: A PENDING subscription does not win plan resolution
     Given an organization whose only subscription has status "PENDING"
     When the active plan is resolved
     Then the plan resolves as if no subscription exists
 
-  @unit @unimplemented
+  @unit
   Scenario: A FAILED subscription does not win plan resolution
     Given an organization whose only subscription has status "FAILED"
     When the active plan is resolved
@@ -25,37 +25,37 @@ Feature: Billing profile resolution in the composite plan provider
 
   # --- memberPolicy mapping (Decision 4) ---
 
-  @unit @unimplemented
+  @unit
   Scenario: Seat-event subscription resolves member policy purchase_seat
     Given an organization whose winning plan source is an ACTIVE "GROWTH_SEAT_USD_MONTHLY" subscription
     When the active plan is resolved
     Then the billing profile member policy is "purchase_seat"
 
-  @unit @unimplemented
+  @unit
   Scenario: ENTERPRISE license resolves member policy hard_cap
     Given a SaaS organization whose winning plan source is a valid ENTERPRISE license
     When the active plan is resolved
     Then the billing profile member policy is "hard_cap"
 
-  @unit @unimplemented
+  @unit
   Scenario: Non-ENTERPRISE license on SaaS resolves member policy upgrade
     Given a SaaS organization whose winning plan source is a valid GROWTH license
     When the active plan is resolved
     Then the billing profile member policy is "upgrade"
 
-  @unit @unimplemented
+  @unit
   Scenario: Any license on self-hosted resolves member policy hard_cap
     Given a self-hosted deployment whose organization has a valid GROWTH license
     When the active plan is resolved
     Then the billing profile member policy is "hard_cap"
 
-  @unit @unimplemented
+  @unit
   Scenario: Legacy tiered paid subscription resolves member policy upgrade
     Given an organization whose winning plan source is an ACTIVE "LAUNCH" subscription
     When the active plan is resolved
     Then the billing profile member policy is "upgrade"
 
-  @unit @unimplemented
+  @unit
   Scenario: Free organization resolves member policy upgrade
     Given an organization with no subscription and no license
     When the active plan is resolved
@@ -63,13 +63,13 @@ Feature: Billing profile resolution in the composite plan provider
 
   # --- Capabilities (Decision 6) ---
 
-  @unit @unimplemented
+  @unit
   Scenario: Enterprise plan resolves with enterprise capabilities enabled
     Given an organization whose winning plan is ENTERPRISE
     When the active plan is resolved
     Then the plan capabilities include rbac, scim, and sso as enabled
 
-  @unit @unimplemented
+  @unit
   Scenario: Growth plan resolves with enterprise capabilities disabled
     Given an organization whose winning plan source is an ACTIVE "GROWTH_SEAT_EUR_MONTHLY" subscription
     When the active plan is resolved
@@ -121,7 +121,7 @@ Feature: Billing profile resolution in the composite plan provider
 
   # --- OSS parity (Invariant I5) ---
 
-  @unit @unimplemented
+  @unit
   Scenario: Self-hosted resolution behavior is unchanged
     Given a self-hosted deployment with a valid ENTERPRISE license
     When the active plan is resolved

--- a/specs/licensing/member-block-resolution.feature
+++ b/specs/licensing/member-block-resolution.feature
@@ -1,0 +1,100 @@
+Feature: Member limit denials carry a typed resolution everywhere
+  # ADR-039 rollout step 6 / Decisions 5, 9, 10, 13. Every path that can deny
+  # adding a full member returns the same typed resolution, the UI routes it
+  # through one handler, ops alerts split by resolution, and the seat-billed
+  # incident class (blocked instead of offered a seat) can never recur.
+
+  As an organization administrator on a seat-billed plan
+  I want every member-add denial to offer me the way forward
+  So that I am never dead-ended while willing to pay for another seat
+
+  # --- The incident regression ---
+
+  @regression @integration @unimplemented
+  Scenario: A seat-billed organization with a stale TIERED column is offered a seat purchase, not blocked
+    Given an organization with pricingModel "TIERED" and an ACTIVE seat-event subscription at its member cap
+    When an admin submits an invite for a new full member
+    Then the seat purchase confirmation is offered
+    And no hard-block error is returned
+
+  # --- Typed resolution on every denial path (Decision 5) ---
+
+  @integration @unimplemented
+  Scenario: Admin invite denial carries the resolution
+    Given an organization at its full member cap
+    When an admin creates an invite for a new full member
+    Then the denial includes the plan's member resolution
+
+  @integration @unimplemented
+  Scenario: Non-admin invite request denial carries the resolution
+    Given an organization at its full member cap
+    When a non-admin submits an invite request for a new full member
+    Then the denial includes the plan's member resolution
+
+  @integration @unimplemented
+  Scenario: Invite approval denial carries the resolution
+    Given an organization at its full member cap with an invite awaiting approval
+    When an admin approves the pending invite
+    Then the denial includes the plan's member resolution
+
+  @integration @unimplemented
+  Scenario: Lite-to-full role change denial carries the resolution
+    Given an organization at its full member cap with a lite member
+    When an admin changes the lite member's role to a full member role
+    Then the denial includes the plan's member resolution
+
+  @integration @unimplemented
+  Scenario: Public API limit denial carries the resolution as advisory metadata
+    Given an organization at a resource limit
+    When an API client hits the limit through the public API
+    Then the 403 response body includes the resolution field
+
+  # --- One UI handler (Decision 10) ---
+
+  @integration @unimplemented
+  Scenario: Resolution purchase_seat opens the seat proration modal
+    Given a member denial with resolution "purchase_seat"
+    When the UI handles the denial
+    Then the seat proration modal opens
+
+  @integration @unimplemented
+  Scenario: Resolution upgrade routes to plan management
+    Given a member denial with resolution "upgrade"
+    When the UI handles the denial
+    Then the user is directed to the plan management page
+
+  @integration @unimplemented
+  Scenario: Resolution hard_cap directs to contact us
+    Given a member denial with resolution "hard_cap"
+    When the UI handles the denial
+    Then the user is directed to contact support
+
+  # --- Alert split (Decision 9) ---
+
+  @integration @unimplemented
+  Scenario: A purchase_seat denial produces an info breadcrumb, not an ops page
+    Given an organization at its seat cap with resolution "purchase_seat"
+    When the member denial is recorded
+    Then an info-level notification is emitted
+    And no ops alert fires
+
+  @integration @unimplemented
+  Scenario: A hard_cap denial fires a real ops alert
+    Given an organization at its member cap with resolution "hard_cap"
+    When the member denial is recorded
+    Then an ops alert fires identifying the organization and limit
+
+  # --- Pending invites surfaced (Decision 13) ---
+
+  @integration @unimplemented
+  Scenario: The member cap message itemizes members and pending invites
+    Given an organization with 4 full members and 2 pending full-member invites on a 6-seat plan
+    When an admin views the member limit state
+    Then the count shows 4 members and 2 pending invites
+    And each pending invite can be revoked from the same view
+
+  @unit @unimplemented
+  Scenario: Pending invites still reserve seats
+    Given an organization with 4 full members and 2 pending full-member invites on a 6-seat plan
+    When a member limit check runs for one more full member
+    Then the check reports the cap as reached

--- a/specs/licensing/metering-cutover-checkpoint-seeding.feature
+++ b/specs/licensing/metering-cutover-checkpoint-seeding.feature
@@ -3,6 +3,12 @@ Feature: Metering cutover bills forward only
   # metering turns on mid-month, only post-cutover events may be reported.
   # The reporting checkpoint defaults to 0, which would report the entire
   # month-to-date on first run — cutover seeds it.
+  #
+  # Implementation mapping: BillingCheckpointService.seedIfAbsent
+  # (src/server/app-layer/billing/billingCheckpoint.service.ts) seeds
+  # lastReportedTotal; ReportUsageForMonthCommand reports
+  # targetTotal - lastReportedTotal; the cutover entry point is
+  # scripts/seed-billing-checkpoints.ts.
 
   As the billing operations team
   I want newly-metered organizations reported only from the cutover moment

--- a/specs/licensing/metering-cutover-checkpoint-seeding.feature
+++ b/specs/licensing/metering-cutover-checkpoint-seeding.feature
@@ -8,7 +8,7 @@ Feature: Metering cutover bills forward only
   I want newly-metered organizations billed only from the cutover moment
   So that no customer receives retroactive charges for previously un-metered usage
 
-  @integration @unimplemented
+  @integration
   Scenario: A seeded checkpoint bills only post-cutover events
     Given an organization newly included in the metering population mid-month
     And its reporting checkpoint was seeded to its month-to-date total of 10000 events
@@ -16,7 +16,7 @@ Feature: Metering cutover bills forward only
     When the usage report runs for the current billing month
     Then exactly 500 events are reported to Stripe
 
-  @integration @unimplemented
+  @integration
   Scenario: An unseeded newly-metered organization would bill the full month-to-date
     Given an organization newly included in the metering population mid-month
     And its reporting checkpoint is absent
@@ -25,13 +25,13 @@ Feature: Metering cutover bills forward only
     # This scenario documents WHY seeding exists; it guards the seeding
     # requirement by proving the default behavior is retroactive.
 
-  @unit @unimplemented
+  @unit
   Scenario: Seeding never lowers an existing checkpoint
     Given an organization with an existing reporting checkpoint of 12000 events
     When checkpoint seeding runs with a month-to-date total of 10000 events
     Then the checkpoint remains 12000
 
-  @unit @unimplemented
+  @unit
   Scenario: Seeding is idempotent
     Given an organization whose checkpoint was already seeded at cutover
     When checkpoint seeding runs again with the same cohort

--- a/specs/licensing/metering-cutover-checkpoint-seeding.feature
+++ b/specs/licensing/metering-cutover-checkpoint-seeding.feature
@@ -1,0 +1,38 @@
+Feature: Metering cutover bills forward only
+  # ADR-039 rollout step 3 / Invariant I8. Organizations whose event metering
+  # turns on mid-month (the drifted cohort) must never be billed for events
+  # that occurred before the cutover. The reporting checkpoint defaults to 0,
+  # which would bill the entire month-to-date on first run — cutover seeds it.
+
+  As the billing operations team
+  I want newly-metered organizations billed only from the cutover moment
+  So that no customer receives retroactive charges for previously un-metered usage
+
+  @integration @unimplemented
+  Scenario: A seeded checkpoint bills only post-cutover events
+    Given an organization newly included in the metering population mid-month
+    And its reporting checkpoint was seeded to its month-to-date total of 10000 events
+    And the organization records 500 more events after the cutover
+    When the usage report runs for the current billing month
+    Then exactly 500 events are reported to Stripe
+
+  @integration @unimplemented
+  Scenario: An unseeded newly-metered organization would bill the full month-to-date
+    Given an organization newly included in the metering population mid-month
+    And its reporting checkpoint is absent
+    When the usage report runs for the current billing month
+    Then the report would include events from before the cutover
+    # This scenario documents WHY seeding exists; it guards the seeding
+    # requirement by proving the default behavior is retroactive.
+
+  @unit @unimplemented
+  Scenario: Seeding never lowers an existing checkpoint
+    Given an organization with an existing reporting checkpoint of 12000 events
+    When checkpoint seeding runs with a month-to-date total of 10000 events
+    Then the checkpoint remains 12000
+
+  @unit @unimplemented
+  Scenario: Seeding is idempotent
+    Given an organization whose checkpoint was already seeded at cutover
+    When checkpoint seeding runs again with the same cohort
+    Then the checkpoint value is unchanged

--- a/specs/licensing/metering-cutover-checkpoint-seeding.feature
+++ b/specs/licensing/metering-cutover-checkpoint-seeding.feature
@@ -1,12 +1,12 @@
 Feature: Metering cutover bills forward only
-  # ADR-039 rollout step 3 / Invariant I8. Organizations whose event metering
-  # turns on mid-month (the drifted cohort) must never be billed for events
-  # that occurred before the cutover. The reporting checkpoint defaults to 0,
-  # which would bill the entire month-to-date on first run — cutover seeds it.
+  # ADR-039 rollout step 3 / Invariant I8. When an organization's event
+  # metering turns on mid-month, only post-cutover events may be reported.
+  # The reporting checkpoint defaults to 0, which would report the entire
+  # month-to-date on first run — cutover seeds it.
 
   As the billing operations team
-  I want newly-metered organizations billed only from the cutover moment
-  So that no customer receives retroactive charges for previously un-metered usage
+  I want newly-metered organizations reported only from the cutover moment
+  So that mid-cycle metering enablement never reports retroactively
 
   @integration
   Scenario: A seeded checkpoint bills only post-cutover events

--- a/specs/licensing/metering-gate-derivation.feature
+++ b/specs/licensing/metering-gate-derivation.feature
@@ -1,12 +1,12 @@
 Feature: Stripe metering gate derives from the active plan
   # ADR-039 rollout step 1. The event-metering population and meter unit
   # must derive from the resolved plan, never from the Organization.pricingModel
-  # column, so column drift can no longer silently exclude a paying org
-  # from usage billing.
+  # column, so the metering population always matches the active seat
+  # subscriptions regardless of column drift.
 
   As the billing reporting pipeline
   I want the metering population and meter unit derived from the resolved plan
-  So that a paying seat-billed organization is always metered regardless of stored column drift
+  So that the metering population always matches active seat subscriptions regardless of stored column drift
 
   @integration
   Scenario: Organization with an active seat subscription and a stale TIERED column is metered

--- a/specs/licensing/metering-gate-derivation.feature
+++ b/specs/licensing/metering-gate-derivation.feature
@@ -8,28 +8,28 @@ Feature: Stripe metering gate derives from the active plan
   I want the metering population and meter unit derived from the resolved plan
   So that a paying seat-billed organization is always metered regardless of stored column drift
 
-  @integration @unimplemented
+  @integration
   Scenario: Organization with an active seat subscription and a stale TIERED column is metered
     Given an organization with pricingModel "TIERED"
     And the organization has an ACTIVE "GROWTH_SEAT_EUR_MONTHLY" subscription
     When the billing reporting pipeline selects organizations to meter
     Then the organization is included in the metering population
 
-  @integration @unimplemented
+  @integration
   Scenario: Organization without a seat subscription is not metered even if the column says SEAT_EVENT
     Given an organization with pricingModel "SEAT_EVENT"
     And the organization has no ACTIVE seat-event subscription
     When the billing reporting pipeline selects organizations to meter
     Then the organization is not included in the metering population
 
-  @unit @unimplemented
+  @unit
   Scenario: Meter unit comes from the resolved billing profile, not the pricingModel column
     Given an organization whose resolved plan reports meter unit "events"
     And the organization's pricingModel column says "TIERED"
     When the meter decision is resolved for the organization
     Then the decision uses meter unit "events"
 
-  @integration @unimplemented
+  @integration
   Scenario: Metering population is unchanged for organizations without column drift
     Given an organization with pricingModel "SEAT_EVENT" and an ACTIVE seat-event subscription
     And an organization with pricingModel "TIERED" and no subscription

--- a/specs/licensing/metering-gate-derivation.feature
+++ b/specs/licensing/metering-gate-derivation.feature
@@ -1,0 +1,37 @@
+Feature: Stripe metering gate derives from the active plan
+  # ADR-039 rollout step 1. The event-metering population and meter unit
+  # must derive from the resolved plan, never from the Organization.pricingModel
+  # column, so column drift can no longer silently exclude a paying org
+  # from usage billing.
+
+  As the billing reporting pipeline
+  I want the metering population and meter unit derived from the resolved plan
+  So that a paying seat-billed organization is always metered regardless of stored column drift
+
+  @integration @unimplemented
+  Scenario: Organization with an active seat subscription and a stale TIERED column is metered
+    Given an organization with pricingModel "TIERED"
+    And the organization has an ACTIVE "GROWTH_SEAT_EUR_MONTHLY" subscription
+    When the billing reporting pipeline selects organizations to meter
+    Then the organization is included in the metering population
+
+  @integration @unimplemented
+  Scenario: Organization without a seat subscription is not metered even if the column says SEAT_EVENT
+    Given an organization with pricingModel "SEAT_EVENT"
+    And the organization has no ACTIVE seat-event subscription
+    When the billing reporting pipeline selects organizations to meter
+    Then the organization is not included in the metering population
+
+  @unit @unimplemented
+  Scenario: Meter unit comes from the resolved billing profile, not the pricingModel column
+    Given an organization whose resolved plan reports meter unit "events"
+    And the organization's pricingModel column says "TIERED"
+    When the meter decision is resolved for the organization
+    Then the decision uses meter unit "events"
+
+  @integration @unimplemented
+  Scenario: Metering population is unchanged for organizations without column drift
+    Given an organization with pricingModel "SEAT_EVENT" and an ACTIVE seat-event subscription
+    And an organization with pricingModel "TIERED" and no subscription
+    When the billing reporting pipeline selects organizations to meter
+    Then only the seat-subscribed organization is included

--- a/specs/licensing/precedence-flag-flip.feature
+++ b/specs/licensing/precedence-flag-flip.feature
@@ -1,0 +1,55 @@
+Feature: Plan precedence rank behind the release flag
+  # ADR-039 rollout step 5 / Decisions 1 and 12. The precedence rank
+  # (ENTERPRISE license > active subscription > non-ENTERPRISE license > free)
+  # is the only behavior change for existing organizations, so it ships
+  # behind a feature flag that acts as a kill-switch.
+
+  As a paying organization
+  I want the plan source that reflects what I actually pay for to win
+  So that a stale license can never dead-end my paid subscription
+
+  # --- Flag disabled: today's behavior preserved ---
+
+  @unit @unimplemented
+  Scenario: With the flag disabled a valid license still beats an active subscription
+    Given the precedence flag is disabled
+    And an organization with a valid GROWTH license and an ACTIVE seat-event subscription
+    When the active plan is resolved
+    Then the plan comes from the license
+
+  # --- Flag enabled: the rank applies ---
+
+  @unit @unimplemented
+  Scenario: An active subscription outranks a non-ENTERPRISE license
+    Given the precedence flag is enabled
+    And an organization with a valid GROWTH license and an ACTIVE seat-event subscription
+    When the active plan is resolved
+    Then the plan comes from the subscription
+
+  @unit @unimplemented
+  Scenario: An ENTERPRISE license outranks an active subscription
+    Given the precedence flag is enabled
+    And an organization with a valid ENTERPRISE license and an ACTIVE seat-event subscription
+    When the active plan is resolved
+    Then the plan comes from the ENTERPRISE license
+
+  @unit @unimplemented
+  Scenario: A non-ENTERPRISE license outranks having no subscription
+    Given the precedence flag is enabled
+    And an organization with a valid GROWTH license and no subscription
+    When the active plan is resolved
+    Then the plan comes from the license
+
+  @unit @unimplemented
+  Scenario: An expired license never wins the rank
+    Given the precedence flag is enabled
+    And an organization with an expired ENTERPRISE license and an ACTIVE seat-event subscription
+    When the active plan is resolved
+    Then the plan comes from the subscription
+
+  @integration @unimplemented
+  Scenario: A stale GROWTH license no longer dead-ends the seat purchase flow
+    Given the precedence flag is enabled
+    And an organization with a valid GROWTH license and an ACTIVE seat-event subscription at its member cap
+    When a member limit check runs
+    Then the denial carries resolution "purchase_seat"

--- a/specs/licensing/pricing-model-backfill.feature
+++ b/specs/licensing/pricing-model-backfill.feature
@@ -8,25 +8,25 @@ Feature: Pricing model backfill converges drifted organizations
   I want drifted pricingModel columns converged to match the active subscription
   So that display and analytics surfaces stop contradicting how the organization is billed
 
-  @integration @unimplemented
+  @integration
   Scenario: Backfill flips organizations with an active seat-event subscription
     Given an organization with pricingModel "TIERED" and an ACTIVE "GROWTH_SEAT_EUR_ANNUAL" subscription
     When the pricing model backfill runs
     Then the organization's pricingModel becomes "SEAT_EVENT"
 
-  @integration @unimplemented
+  @integration
   Scenario: Backfill ignores organizations whose seat subscription is cancelled
     Given an organization with pricingModel "TIERED" and a CANCELLED "GROWTH_SEAT_EUR_MONTHLY" subscription
     When the pricing model backfill runs
     Then the organization's pricingModel remains "TIERED"
 
-  @integration @unimplemented
+  @integration
   Scenario: Backfill ignores organizations on legacy tiered plans
     Given an organization with pricingModel "TIERED" and an ACTIVE "ACCELERATE" subscription
     When the pricing model backfill runs
     Then the organization's pricingModel remains "TIERED"
 
-  @integration @unimplemented
+  @integration
   Scenario: Backfilling the column does not change any billing decision
     Given a drifted organization whose plan already resolves to seat-event behavior
     When the pricing model backfill updates its column

--- a/specs/licensing/pricing-model-backfill.feature
+++ b/specs/licensing/pricing-model-backfill.feature
@@ -1,0 +1,33 @@
+Feature: Pricing model backfill converges drifted organizations
+  # ADR-039 rollout step 4. One-time backfill for organizations whose
+  # pricingModel column drifted from their active subscription. Runs only
+  # after the metering gate has moved off the column (step 1), so the
+  # column update itself changes no billing behavior.
+
+  As the platform operations team
+  I want drifted pricingModel columns converged to match the active subscription
+  So that display and analytics surfaces stop contradicting how the organization is billed
+
+  @integration @unimplemented
+  Scenario: Backfill flips organizations with an active seat-event subscription
+    Given an organization with pricingModel "TIERED" and an ACTIVE "GROWTH_SEAT_EUR_ANNUAL" subscription
+    When the pricing model backfill runs
+    Then the organization's pricingModel becomes "SEAT_EVENT"
+
+  @integration @unimplemented
+  Scenario: Backfill ignores organizations whose seat subscription is cancelled
+    Given an organization with pricingModel "TIERED" and a CANCELLED "GROWTH_SEAT_EUR_MONTHLY" subscription
+    When the pricing model backfill runs
+    Then the organization's pricingModel remains "TIERED"
+
+  @integration @unimplemented
+  Scenario: Backfill ignores organizations on legacy tiered plans
+    Given an organization with pricingModel "TIERED" and an ACTIVE "ACCELERATE" subscription
+    When the pricing model backfill runs
+    Then the organization's pricingModel remains "TIERED"
+
+  @integration @unimplemented
+  Scenario: Backfilling the column does not change any billing decision
+    Given a drifted organization whose plan already resolves to seat-event behavior
+    When the pricing model backfill updates its column
+    Then the organization's resolved billing profile is identical before and after the update


### PR DESCRIPTION
## What

PR 1 of 3 for ADR-039 (`dev/docs/adr/039-billing-profile-single-resolution.md`, Accepted): derive billing mechanics from the winning plan source in the composite plan provider, instead of branching on the `Organization.pricingModel` column across the platform.

Tracked by langwatch/langwatch-saas#891. PR 2 (precedence flag + typed resolution + alert split) and PR 3 (UI consolidation + plan-constants unification) stack on this.

## Why

Customer incident: paying Growth org hard-blocked at Team Members 6/6 because `pricingModel=TIERED` drifted against an active `GROWTH_SEAT_*` subscription (webhook-ordering skip of `migrateToSeatEvent`). The same drift also excluded the org from the usage-metering population.

## Scope (ADR rollout steps 1-4) — all landed

- [x] Billing-profile derivation module + `PlanInfo.billing`/`capabilities` types
- [x] Metering gate (`getOrganizationForBilling`, `resolveUsageMeter`) derives from the active seat subscription, not the column
- [x] `PlanProviderService` stamps billing profile + capabilities (single derivation point, SaaS + OSS)
- [x] `pricingModel` lazy self-heal: 24h write-once Redis guard, meter-cache invalidation
- [x] License `isTrial` flag (append-only payload field); activation clears ONLY trials; non-trial conflict → Slack ops alert; license/sub coexistence detection (Decision 11, alert-only)
- [x] Checkpoint seeding (`seedIfAbsent`, create-only) + `scripts/seed-billing-checkpoints.ts` — forward-only billing for the drifted cohort (Invariant I8)
- [x] `scripts/backfill-pricing-model.ts` (run ONLY after seeding; shared `findDriftedSeatEventOrgs` predicate)

## Proof

- 29 feature scenarios bound and green (`specs/licensing/`: metering-gate-derivation 4, billing-profile-resolver 17, metering-cutover-checkpoint-seeding 4, pricing-model-backfill 4); `pnpm check:feature-parity` OK (2432 scenarios / 725 files)
- Integration: 8/8 (billing gate vs drifted/cancelled/clean orgs; backfill population + no-billing-change)
- Unit: 2202 green across `src/server/app-layer`, `ee/billing`, `ee/licensing`, billing-reporting pipeline
- Invariants: I1 (drifted org metered + purchase_seat), I2 (non-trial license never deleted, ops alerted), I4 (write-once heal + cache invalidation; no decision reads the column), I5 (OSS resolution unchanged), I8 (seeded checkpoint bills delta only)

## Rollout ordering (load-bearing)

1. Deploy this PR (metering gate off the column)
2. `seed-billing-checkpoints.ts --dry-run` → review per the internal cutover runbook → run
3. `backfill-pricing-model.ts --dry-run` → run

Reversing 1↔3 runs the first metering pass against a zero checkpoint = retroactive reporting (Invariant I8 violation).

## Deployment Impact

- **Env vars:** none added or changed.
- **Helm values / default install:** unchanged — no new services, ports, or config.
- **BYOC dataplane:** unaffected (control-plane/TS only; no gateway or collector changes).
- **Feature flag:** `release_billing_precedence_rank` (PR2) defaults OFF — no behavior change until flipped via PostHog/ops store after the ADR-039 rollout step-3b license audit.
- **Ops scripts (PR1):** `seed-billing-checkpoints.ts` must run before `backfill-pricing-model.ts`; both are manual, dry-run-first. See the ADR Rollout section and the internal cutover runbook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing plans now resolve consistently across subscriptions, licenses, and free tiers, with derived usage limits and feature access.
  * Member-limit denials now include resolution-specific next steps (purchase seats, upgrade, or contact support).
  * Trial vs non-trial license activation is handled more precisely, and metering cutovers use checkpoints to avoid retroactive charges.
  * License conflicts trigger throttled Slack alerts.

* **Bug Fixes**
  * Pending/inactive subscriptions no longer determine the active plan.
  * Drifted billing/usage decisions are corrected by relying on active seat-event subscriptions rather than stored pricing state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->