### PR TITLE
feat(billing): precedence rank flag and typed denial resolution (ADR-039 rollout 5)

### DIFF
--- a/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
@@ -351,6 +351,76 @@ describe("UsageLimitService", () => {
       });
     });
 
+    describe("when the denial resolves to a self-serve seat purchase", () => {
+      beforeEach(async () => {
+        await resourceLimitCooldown.delete("org_1:members");
+      });
+
+      /** @scenario A purchase_seat denial produces an info breadcrumb, not an ops page */
+      it("does not send a Slack alert", async () => {
+        const { service, notificationService } = createService();
+
+        await service.notifyResourceLimitReached({
+          organizationId: "org_1",
+          limitType: "members",
+          current: 6,
+          max: 6,
+          resolution: "purchase_seat",
+        });
+
+        expect(
+          notificationService.sendSlackResourceLimitAlert,
+        ).not.toHaveBeenCalled();
+      });
+
+      it("does not consume the cooldown slot", async () => {
+        const { service } = createService();
+
+        await service.notifyResourceLimitReached({
+          organizationId: "org_1",
+          limitType: "members",
+          current: 6,
+          max: 6,
+          resolution: "purchase_seat",
+        });
+
+        expect(await resourceLimitCooldown.get("org_1:members")).toBeUndefined();
+      });
+    });
+
+    describe("when the denial resolves to a hard cap", () => {
+      beforeEach(async () => {
+        await resourceLimitCooldown.delete("org_1:members");
+      });
+
+      /** @scenario A hard_cap denial fires a real ops alert */
+      it("sends the Slack alert identifying the organization and limit", async () => {
+        const { service, organizationService, notificationService } = createService();
+        vi.mocked(organizationService.findWithAdmins).mockResolvedValue(
+          ORG_WITH_ADMIN as never,
+        );
+
+        await service.notifyResourceLimitReached({
+          organizationId: "org_1",
+          limitType: "members",
+          current: 6,
+          max: 6,
+          resolution: "hard_cap",
+        });
+
+        expect(
+          notificationService.sendSlackResourceLimitAlert,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            organizationId: "org_1",
+            limitType: "Team Members",
+            current: 6,
+            max: 6,
+          }),
+        );
+      });
+    });
+
     describe("when cooldown is active for the organization and limit type", () => {
       it("suppresses the notification", async () => {
         const { service, notificationService } = createService();

--- a/langwatch/ee/billing/notifications/usage-limit.service.ts
+++ b/langwatch/ee/billing/notifications/usage-limit.service.ts
@@ -207,8 +207,19 @@ export class UsageLimitService {
     limitType,
     current,
     max,
+    resolution,
   }: ResourceLimitNotifierInput): Promise<void> {
     if (!env.IS_SAAS) {
+      return;
+    }
+
+    // ADR-039 Decision 9: a purchase_seat denial means the customer was
+    // shown the self-serve seat flow — that is funnel data, not an ops page.
+    if (resolution === "purchase_seat") {
+      logger.info(
+        { organizationId, limitType, current, max },
+        "seat purchase offered at member cap (self-serve, no ops alert)",
+      );
       return;
     }
 

--- a/langwatch/ee/billing/types.ts
+++ b/langwatch/ee/billing/types.ts
@@ -82,6 +82,12 @@ export type ResourceLimitNotifierInput = {
   limitType: LimitType;
   current: number;
   max: number;
+  /**
+   * How the denied user can resolve the limit (ADR-039 Decision 9).
+   * "purchase_seat" means the customer was shown the self-serve seat flow —
+   * logged as an info breadcrumb, never paged to ops.
+   */
+  resolution?: "purchase_seat" | "upgrade" | "hard_cap";
 };
 
 export type LicensePurchaseNotificationPayload = {

--- a/langwatch/src/app/api/middleware/__tests__/resource-limit.unit.test.ts
+++ b/langwatch/src/app/api/middleware/__tests__/resource-limit.unit.test.ts
@@ -136,6 +136,15 @@ describe("resourceLimitMiddleware()", () => {
       expect(body.message).toBeDefined();
     });
 
+    /** @scenario Public API limit denial carries the resolution as advisory metadata */
+    it("includes the resolution field in the 403 body", async () => {
+      const app = createTestApp("prompts");
+      const res = await app.request("/", { method: "POST" });
+
+      const body = await res.json();
+      expect(body.resolution).toBe("upgrade");
+    });
+
     it("fires notification asynchronously", async () => {
       const app = createTestApp("prompts");
       await app.request("/", { method: "POST" });

--- a/langwatch/src/app/api/middleware/resource-limit.ts
+++ b/langwatch/src/app/api/middleware/resource-limit.ts
@@ -59,6 +59,9 @@ export async function enforceResourceLimitOrRespond({
           limitType: error.limitType,
           current: error.current,
           max: error.max,
+          // Advisory metadata for API consumers (ADR-039 Decision 5): how
+          // the limit can be resolved. Not a rendered flow on this path.
+          resolution: error.resolution,
         },
         403,
       );

--- a/langwatch/src/server/api/routers/__tests__/organization.invites.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.invites.integration.test.ts
@@ -561,6 +561,92 @@ describe("Organization Invites Integration", () => {
   });
 
   // ============================================================================
+  // Member limit denials carry a typed resolution (ADR-039 Decision 5)
+  // ============================================================================
+
+  describe("member limit denials carry a typed resolution", () => {
+    const seatBilledPlan = () =>
+      makeTestPlan({
+        type: "GROWTH_SEAT_EUR_MONTHLY",
+        maxMembers: 0,
+        billing: {
+          meterUnit: "events",
+          memberPolicy: "purchase_seat",
+          showUsageLimits: false,
+          isLegacyTiered: false,
+        },
+      });
+
+    /** @scenario Admin invite denial carries the resolution */
+    it("createInvites denial includes resolution purchase_seat", async () => {
+      mockGetActivePlan.mockResolvedValue(seatBilledPlan());
+
+      await expect(
+        adminCaller.organization.createInvites({
+          organizationId,
+          invites: [
+            {
+              email: "over-cap@example.com",
+              role: "MEMBER" as never,
+              teams: [{ teamId, role: "MEMBER" as never }],
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        cause: { resolution: "purchase_seat" },
+      });
+    });
+
+    /** @scenario Non-admin invite request denial carries the resolution */
+    it("createInviteRequest denial includes resolution purchase_seat", async () => {
+      mockGetActivePlan.mockResolvedValue(seatBilledPlan());
+
+      await expect(
+        memberCaller.organization.createInviteRequest({
+          organizationId,
+          invites: [
+            {
+              email: "over-cap-request@example.com",
+              role: "MEMBER",
+              teamIds: teamId,
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        cause: { resolution: "purchase_seat" },
+      });
+    });
+
+    /** @scenario Invite approval denial carries the resolution */
+    it("approveInvite denial includes resolution purchase_seat", async () => {
+      mockGetActivePlan.mockResolvedValue(makeTestPlan({ maxMembers: 10 }));
+
+      const results = await memberCaller.organization.createInviteRequest({
+        organizationId,
+        invites: [
+          {
+            email: "approve-over-cap@example.com",
+            role: "MEMBER",
+            teamIds: teamId,
+          },
+        ],
+      });
+      const inviteId = results[0]!.invite.id;
+
+      mockGetActivePlan.mockResolvedValue(seatBilledPlan());
+
+      await expect(
+        adminCaller.organization.approveInvite({ inviteId, organizationId }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        cause: { resolution: "purchase_seat" },
+      });
+    });
+  });
+
+  // ============================================================================
   // deleteInvite (reject WAITING_APPROVAL)
   // ============================================================================
 

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
@@ -232,6 +232,34 @@ describe.skipIf(isTestcontainersOnly)(
           });
         });
 
+        /** @scenario Lite-to-full role change denial carries the resolution */
+        it("carries resolution purchase_seat when the org is seat-billed", async () => {
+          mockGetActivePlan.mockResolvedValue({
+            maxMembers: 100,
+            maxMembersLite: 0,
+            overrideAddingLimitations: false,
+            billing: {
+              meterUnit: "events",
+              memberPolicy: "purchase_seat",
+              showUsageLimits: false,
+              isLegacyTiered: false,
+            },
+          });
+
+          const caller = createCaller();
+
+          await expect(
+            caller.organization.updateMemberRole({
+              userId: targetUserId,
+              organizationId,
+              role: OrganizationUserRole.EXTERNAL,
+            }),
+          ).rejects.toMatchObject({
+            code: "FORBIDDEN",
+            cause: { resolution: "purchase_seat" },
+          });
+        });
+
         it("allows when overrideAddingLimitations is true", async () => {
           mockGetActivePlan.mockResolvedValue({
             maxMembers: 100,

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.planLimit.integration.test.ts
@@ -232,34 +232,6 @@ describe.skipIf(isTestcontainersOnly)(
           });
         });
 
-        /** @scenario Lite-to-full role change denial carries the resolution */
-        it("carries resolution purchase_seat when the org is seat-billed", async () => {
-          mockGetActivePlan.mockResolvedValue({
-            maxMembers: 100,
-            maxMembersLite: 0,
-            overrideAddingLimitations: false,
-            billing: {
-              meterUnit: "events",
-              memberPolicy: "purchase_seat",
-              showUsageLimits: false,
-              isLegacyTiered: false,
-            },
-          });
-
-          const caller = createCaller();
-
-          await expect(
-            caller.organization.updateMemberRole({
-              userId: targetUserId,
-              organizationId,
-              role: OrganizationUserRole.EXTERNAL,
-            }),
-          ).rejects.toMatchObject({
-            code: "FORBIDDEN",
-            cause: { resolution: "purchase_seat" },
-          });
-        });
-
         it("allows when overrideAddingLimitations is true", async () => {
           mockGetActivePlan.mockResolvedValue({
             maxMembers: 100,

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.resolution.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.resolution.integration.test.ts
@@ -10,7 +10,11 @@
  * the CI integration runner provides — the same pattern the invites
  * integration suite runs on every shard.
  */
-import { OrganizationUserRole, TeamUserRole } from "@prisma/client";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
 import { nanoid } from "nanoid";
 import {
   afterAll,
@@ -62,6 +66,18 @@ describe("organization member role denial resolution", () => {
         userId: adminUser.id,
         organizationId: organization.id,
         role: OrganizationUserRole.ADMIN,
+      },
+    });
+
+    // Org-scoped ADMIN RoleBinding so checkOrganizationPermission passes
+    await prisma.roleBinding.create({
+      data: {
+        id: `rb-role-res-${nanoid(8)}`,
+        organizationId: organization.id,
+        userId: adminUser.id,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: organization.id,
       },
     });
 
@@ -125,6 +141,9 @@ describe("organization member role denial resolution", () => {
   });
 
   afterAll(async () => {
+    await prisma.roleBinding
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
     await prisma.teamUser
       .deleteMany({ where: { team: { slug: `--test-team-${testNamespace}` } } })
       .catch(() => {});

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.resolution.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.resolution.integration.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment node
+ *
+ * ADR-039 Decision 5: role-change denials carry the plan's typed resolution
+ * so seat-billed orgs are routed to the seat purchase flow instead of being
+ * dead-ended. Real database; only the planProvider boundary is mocked.
+ *
+ * Deliberately NOT gated on TEST_CLICKHOUSE_URL (unlike the sibling
+ * member-roles.planLimit file): this harness needs only PostgreSQL, which
+ * the CI integration runner provides — the same pattern the invites
+ * integration suite runs on every shard.
+ */
+import { OrganizationUserRole, TeamUserRole } from "@prisma/client";
+import { nanoid } from "nanoid";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { prisma } from "../../../db";
+import { appRouter } from "../../root";
+import { createInnerTRPCContext } from "../../trpc";
+import { createTestApp } from "~/server/app-layer/presets";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import {
+  PlanProviderService,
+  type PlanProvider,
+} from "~/server/app-layer/subscription/plan-provider";
+
+describe("organization member role denial resolution", () => {
+  const testNamespace = `member-role-resolution-${nanoid(8)}`;
+  let organizationId: string;
+  let adminUserId: string;
+  let targetUserId: string;
+  let teamId: string;
+  let mockGetActivePlan: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: {
+        name: "Test Organization",
+        slug: `--test-org-${testNamespace}`,
+      },
+    });
+    organizationId = organization.id;
+
+    const adminUser = await prisma.user.create({
+      data: {
+        name: "Admin User",
+        email: `admin-${testNamespace}@example.com`,
+      },
+    });
+    adminUserId = adminUser.id;
+
+    await prisma.organizationUser.create({
+      data: {
+        userId: adminUser.id,
+        organizationId: organization.id,
+        role: OrganizationUserRole.ADMIN,
+      },
+    });
+
+    const team = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `--test-team-${testNamespace}`,
+        organizationId: organization.id,
+      },
+    });
+    teamId = team.id;
+
+    await prisma.teamUser.create({
+      data: {
+        userId: adminUser.id,
+        teamId: team.id,
+        role: TeamUserRole.ADMIN,
+      },
+    });
+
+    const targetUser = await prisma.user.create({
+      data: {
+        name: "Target User",
+        email: `target-${testNamespace}@example.com`,
+      },
+    });
+    targetUserId = targetUser.id;
+
+    await prisma.organizationUser.create({
+      data: {
+        userId: targetUser.id,
+        organizationId: organization.id,
+        role: OrganizationUserRole.MEMBER,
+      },
+    });
+
+    await prisma.teamUser.create({
+      data: {
+        userId: targetUser.id,
+        teamId: team.id,
+        role: TeamUserRole.MEMBER,
+      },
+    });
+  });
+
+  beforeEach(async () => {
+    await resetApp();
+    mockGetActivePlan = vi.fn();
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create(
+        {
+          getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
+        },
+        { isSaaS: true },
+      ),
+    });
+  });
+
+  afterEach(async () => {
+    await resetApp();
+  });
+
+  afterAll(async () => {
+    await prisma.teamUser
+      .deleteMany({ where: { team: { slug: `--test-team-${testNamespace}` } } })
+      .catch(() => {});
+    await prisma.team
+      .deleteMany({ where: { slug: `--test-team-${testNamespace}` } })
+      .catch(() => {});
+    await prisma.organizationUser
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.organization
+      .delete({ where: { id: organizationId } })
+      .catch(() => {});
+    await prisma.user
+      .deleteMany({
+        where: { email: { endsWith: `${testNamespace}@example.com` } },
+      })
+      .catch(() => {});
+    await resetApp();
+  });
+
+  function createCaller() {
+    const ctx = createInnerTRPCContext({
+      session: {
+        user: { id: adminUserId },
+        expires: "2099-01-01",
+      },
+      permissionChecked: true,
+      publiclyShared: false,
+    });
+    return appRouter.createCaller(ctx);
+  }
+
+  describe("when a seat-billed org at its cap changes a member's role", () => {
+    /** @scenario Lite-to-full role change denial carries the resolution */
+    it("carries resolution purchase_seat in the denial cause", async () => {
+      mockGetActivePlan.mockResolvedValue({
+        maxMembers: 100,
+        maxMembersLite: 0,
+        overrideAddingLimitations: false,
+        billing: {
+          meterUnit: "events",
+          memberPolicy: "purchase_seat",
+          showUsageLimits: false,
+          isLegacyTiered: false,
+        },
+      });
+
+      const caller = createCaller();
+
+      await expect(
+        caller.organization.updateMemberRole({
+          userId: targetUserId,
+          organizationId,
+          role: OrganizationUserRole.EXTERNAL,
+        }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        cause: { resolution: "purchase_seat" },
+      });
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/organization.member-roles.resolution.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.member-roles.resolution.integration.test.ts
@@ -179,16 +179,17 @@ describe("organization member role denial resolution", () => {
   describe("when a seat-billed org at its cap changes a member's role", () => {
     /** @scenario Lite-to-full role change denial carries the resolution */
     it("carries resolution purchase_seat in the denial cause", async () => {
+      // Full plan shape: PlanProviderService derives the billing profile from
+      // planSource + type (a hand-written billing block would be overwritten
+      // by the stamp), so this exercises the real purchase_seat derivation.
       mockGetActivePlan.mockResolvedValue({
+        planSource: "subscription",
+        type: "GROWTH_SEAT_USD_MONTHLY",
+        name: "Growth",
+        free: false,
         maxMembers: 100,
         maxMembersLite: 0,
         overrideAddingLimitations: false,
-        billing: {
-          meterUnit: "events",
-          memberPolicy: "purchase_seat",
-          showUsageLimits: false,
-          isLegacyTiered: false,
-        },
       });
 
       const caller = createCaller();

--- a/langwatch/src/server/api/routers/licenseEnforcement.ts
+++ b/langwatch/src/server/api/routers/licenseEnforcement.ts
@@ -103,6 +103,7 @@ export const licenseEnforcementRouter = createTRPCRouter({
             limitType: input.limitType,
             current: result.current,
             max: result.max,
+            resolution: result.resolution,
           })
           .catch(captureException);
       }

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -517,12 +517,19 @@ export const organizationRouter = createTRPCRouter({
               limitType: error.limitType,
               current: error.current,
               max: error.max,
+              resolution: error.resolution,
             })
             .catch(captureException);
 
           throw new TRPCError({
             code: "FORBIDDEN",
             message: error.message,
+            cause: {
+              limitType: error.limitType,
+              current: error.current,
+              max: error.max,
+              resolution: error.resolution,
+            },
           });
         }
         throw error;
@@ -948,12 +955,19 @@ export const organizationRouter = createTRPCRouter({
               limitType: error.limitType,
               current: error.current,
               max: error.max,
+              resolution: error.resolution,
             })
             .catch(captureException);
 
           throw new TRPCError({
             code: "FORBIDDEN",
             message: error.message,
+            cause: {
+              limitType: error.limitType,
+              current: error.current,
+              max: error.max,
+              resolution: error.resolution,
+            },
           });
         }
         if (error instanceof DuplicateInviteError) {
@@ -1020,12 +1034,19 @@ export const organizationRouter = createTRPCRouter({
               limitType: error.limitType,
               current: error.current,
               max: error.max,
+              resolution: error.resolution,
             })
             .catch(captureException);
 
           throw new TRPCError({
             code: "FORBIDDEN",
             message: error.message,
+            cause: {
+              limitType: error.limitType,
+              current: error.current,
+              max: error.max,
+              resolution: error.resolution,
+            },
           });
         }
         throw error;

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -133,6 +133,7 @@ export const projectRouter = createTRPCRouter({
               limitType: error.limitType,
               current: error.current,
               max: error.max,
+              resolution: error.resolution,
             })
             .catch(captureException);
 
@@ -143,6 +144,7 @@ export const projectRouter = createTRPCRouter({
               limitType: error.limitType,
               current: error.current,
               max: error.max,
+              resolution: error.resolution,
             },
           });
         }

--- a/langwatch/src/server/api/routers/team.ts
+++ b/langwatch/src/server/api/routers/team.ts
@@ -384,6 +384,7 @@ export const teamRouter = createTRPCRouter({
               limitType: error.limitType,
               current: error.current,
               max: error.max,
+              resolution: error.resolution,
             })
             .catch(captureException);
 
@@ -394,6 +395,7 @@ export const teamRouter = createTRPCRouter({
               limitType: error.limitType,
               current: error.current,
               max: error.max,
+              resolution: error.resolution,
             },
           });
         }

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -12,6 +12,7 @@ import {
 } from "~/server/clickhouse/clickhouseClient";
 import { closeClickHouseClient } from "~/server/clickhouse/client";
 import { prisma as globalPrisma } from "~/server/db";
+import { featureFlagService } from "~/server/featureFlag/featureFlag.service";
 import { getFeatureFlagStore } from "~/server/featureFlag/featureFlagStore.postgres";
 import { GatewayBudgetClickHouseRepository } from "~/server/gateway/budget.clickhouse.repository";
 import { GatewayBudgetRepository } from "~/server/gateway/budget.repository";
@@ -422,6 +423,11 @@ export function initializeDefaultApp(options?: {
             getActivePlan: ({ organizationId }) =>
               getLicenseHandler().getActivePlan(organizationId),
           },
+          isPrecedenceRankEnabled: (organizationId) =>
+            featureFlagService.isEnabled("release_billing_precedence_rank", {
+              distinctId: organizationId,
+              organizationId,
+            }),
         }),
         { isSaaS: true, selfHeal: pricingModelSelfHeal },
       )

--- a/langwatch/src/server/app-layer/subscription/__tests__/composite-plan-provider.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/composite-plan-provider.unit.test.ts
@@ -411,3 +411,49 @@ describe("createCompositePlanProvider — precedence rank (ADR-039)", () => {
     });
   });
 });
+
+describe("createCompositePlanProvider — rank chained through enforcement (ADR-039)", () => {
+  /** @scenario A stale GROWTH license no longer dead-ends the seat purchase flow */
+  it("resolves purchase_seat for a member denial when the rank lets the seat subscription win", async () => {
+    const { PlanProviderService } = await import("../plan-provider");
+    const { LicenseEnforcementService } = await import(
+      "../../../license-enforcement/license-enforcement.service"
+    );
+
+    const growthLicense: PlanInfo = {
+      ...ENTERPRISE_LICENSE_PLAN,
+      type: "GROWTH",
+      name: "Growth",
+      maxMembers: 6,
+    };
+    const seatSubscription: PlanInfo = {
+      ...SAAS_PRO_PLAN,
+      type: "GROWTH_SEAT_EUR_MONTHLY",
+      name: "Growth",
+      maxMembers: 6,
+    };
+
+    const provider = PlanProviderService.create(
+      createCompositePlanProvider({
+        licensePlanProvider: {
+          getActivePlan: vi.fn().mockResolvedValue(growthLicense),
+        },
+        saasPlanProvider: {
+          getActivePlan: vi.fn().mockResolvedValue(seatSubscription),
+        },
+        isPrecedenceRankEnabled: vi.fn().mockResolvedValue(true),
+      }),
+      { isSaaS: true },
+    );
+
+    const repository = {
+      getMemberCount: vi.fn().mockResolvedValue(6),
+    } as never;
+    const enforcement = new LicenseEnforcementService(repository, provider);
+
+    const result = await enforcement.checkLimit("org-1", "members");
+
+    expect(result.allowed).toBe(false);
+    expect(result.resolution).toBe("purchase_seat");
+  });
+});

--- a/langwatch/src/server/app-layer/subscription/__tests__/composite-plan-provider.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/composite-plan-provider.unit.test.ts
@@ -293,3 +293,121 @@ describe("createCompositePlanProvider", () => {
     });
   });
 });
+
+describe("createCompositePlanProvider — precedence rank (ADR-039)", () => {
+  const GROWTH_LICENSE_PLAN: PlanInfo = {
+    ...ENTERPRISE_LICENSE_PLAN,
+    type: "GROWTH",
+    name: "Growth",
+    maxMembers: 6,
+  };
+  const SEAT_SUBSCRIPTION_PLAN: PlanInfo = {
+    ...SAAS_PRO_PLAN,
+    type: "GROWTH_SEAT_EUR_MONTHLY",
+    name: "Growth",
+  };
+  const FREE_SAAS_PLAN: PlanInfo = { ...FREE_PLAN };
+
+  function makeProvider({
+    licensePlan,
+    saasPlan,
+    rankEnabled,
+  }: {
+    licensePlan: PlanInfo;
+    saasPlan: PlanInfo;
+    rankEnabled: boolean;
+  }) {
+    return createCompositePlanProvider({
+      licensePlanProvider: {
+        getActivePlan: vi.fn().mockResolvedValue(licensePlan),
+      },
+      saasPlanProvider: { getActivePlan: vi.fn().mockResolvedValue(saasPlan) },
+      isPrecedenceRankEnabled: vi.fn().mockResolvedValue(rankEnabled),
+    });
+  }
+
+  describe("when the precedence flag is disabled", () => {
+    /** @scenario With the flag disabled a valid license still beats an active subscription */
+    it("selects the license over an active subscription", async () => {
+      const provider = makeProvider({
+        licensePlan: GROWTH_LICENSE_PLAN,
+        saasPlan: SEAT_SUBSCRIPTION_PLAN,
+        rankEnabled: false,
+      });
+
+      const plan = await provider.getActivePlan({ organizationId: "org-1" });
+
+      expect(plan.planSource).toBe("license");
+    });
+  });
+
+  describe("when the precedence flag is enabled", () => {
+    /** @scenario An active subscription outranks a non-ENTERPRISE license */
+    it("selects the active subscription over a GROWTH license", async () => {
+      const provider = makeProvider({
+        licensePlan: GROWTH_LICENSE_PLAN,
+        saasPlan: SEAT_SUBSCRIPTION_PLAN,
+        rankEnabled: true,
+      });
+
+      const plan = await provider.getActivePlan({ organizationId: "org-1" });
+
+      expect(plan.planSource).toBe("subscription");
+      expect(plan.type).toBe("GROWTH_SEAT_EUR_MONTHLY");
+    });
+
+    /** @scenario An ENTERPRISE license outranks an active subscription */
+    it("selects the ENTERPRISE license over an active subscription", async () => {
+      const provider = makeProvider({
+        licensePlan: ENTERPRISE_LICENSE_PLAN,
+        saasPlan: SEAT_SUBSCRIPTION_PLAN,
+        rankEnabled: true,
+      });
+
+      const plan = await provider.getActivePlan({ organizationId: "org-1" });
+
+      expect(plan.planSource).toBe("license");
+      expect(plan.type).toBe("ENTERPRISE");
+    });
+
+    /** @scenario A non-ENTERPRISE license outranks having no subscription */
+    it("selects the license when the org has no paid subscription", async () => {
+      const provider = makeProvider({
+        licensePlan: GROWTH_LICENSE_PLAN,
+        saasPlan: FREE_SAAS_PLAN,
+        rankEnabled: true,
+      });
+
+      const plan = await provider.getActivePlan({ organizationId: "org-1" });
+
+      expect(plan.planSource).toBe("license");
+      expect(plan.type).toBe("GROWTH");
+    });
+
+    /** @scenario An expired license never wins the rank */
+    it("selects the subscription when the license resolves free (expired)", async () => {
+      const provider = makeProvider({
+        licensePlan: FREE_PLAN,
+        saasPlan: SEAT_SUBSCRIPTION_PLAN,
+        rankEnabled: true,
+      });
+
+      const plan = await provider.getActivePlan({ organizationId: "org-1" });
+
+      expect(plan.planSource).toBe("subscription");
+    });
+
+    it("resolves free when neither source is paid", async () => {
+      const provider = makeProvider({
+        licensePlan: FREE_PLAN,
+        saasPlan: FREE_SAAS_PLAN,
+        rankEnabled: true,
+      });
+
+      const plan = await provider.getActivePlan({ organizationId: "org-1" });
+
+      expect(plan.planSource).toBe("free");
+      expect(plan.free).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/subscription/composite-plan-provider.ts
+++ b/langwatch/src/server/app-layer/subscription/composite-plan-provider.ts
@@ -5,9 +5,15 @@ import type { PlanProvider, PlanProviderUser } from "./plan-provider";
 /**
  * Composite PlanProvider with select-one semantics.
  *
- * Precedence:
+ * Legacy precedence (flag off):
  *   1. License override — if the org has a valid (non-free) license, use it entirely
  *   2. SaaS provider — Stripe subscription-based plan
+ *
+ * Rank precedence (ADR-039 Decision 1, behind `release_billing_precedence_rank`):
+ *   ENTERPRISE license > active subscription > non-ENTERPRISE license > free.
+ *   An active subscription must beat a stale GROWTH/PRO license (the
+ *   seat-flow dead-end class), while a sales-issued ENTERPRISE license must
+ *   survive a leftover self-serve subscription.
  *
  * After selection, `overrideAddingLimitations` is recomputed from the user's
  * impersonation context — it is authorization, not entitlement.
@@ -15,34 +21,108 @@ import type { PlanProvider, PlanProviderUser } from "./plan-provider";
 export function createCompositePlanProvider({
   licensePlanProvider,
   saasPlanProvider,
+  isPrecedenceRankEnabled,
 }: {
   licensePlanProvider: PlanProvider;
   saasPlanProvider: PlanProvider;
+  /**
+   * Reads the `release_billing_precedence_rank` flag (ADR-039 Decision 12).
+   * Absent or false = legacy license-always-wins precedence.
+   */
+  isPrecedenceRankEnabled?: (organizationId: string) => Promise<boolean>;
 }): PlanProvider {
   return {
     async getActivePlan({ organizationId, user }) {
-      // 1. Try license override
-      const licensePlan =
-        await licensePlanProvider.getActivePlan({ organizationId });
+      const licensePlan = await licensePlanProvider.getActivePlan({
+        organizationId,
+      });
 
-      // 2. Select plan source — composite is the single canonical authority for planSource
-      let selectedPlan: PlanInfo;
-      if (licensePlan.free) {
-        // License is free/absent — fall through to SaaS
-        const saasPlan = await saasPlanProvider.getActivePlan({ organizationId, user });
-        selectedPlan = { ...saasPlan, planSource: saasPlan.free ? "free" : "subscription" };
-      } else {
-        // License is valid — use it as the complete plan
-        selectedPlan = { ...licensePlan, planSource: "license" };
-      }
+      const rankEnabled =
+        (await isPrecedenceRankEnabled?.(organizationId)) ?? false;
 
-      // 3. Recompute overrideAddingLimitations from user context (not plan source)
+      const selectedPlan = rankEnabled
+        ? await selectByRank({
+            licensePlan,
+            saasPlanProvider,
+            organizationId,
+            user,
+          })
+        : await selectLegacy({
+            licensePlan,
+            saasPlanProvider,
+            organizationId,
+            user,
+          });
+
+      // Recompute overrideAddingLimitations from user context (not plan source)
       return {
         ...selectedPlan,
         overrideAddingLimitations: computeOverrideAddingLimitations(user),
       };
     },
   };
+}
+
+/** Legacy select-one: a valid (non-free) license beats everything. */
+async function selectLegacy({
+  licensePlan,
+  saasPlanProvider,
+  organizationId,
+  user,
+}: {
+  licensePlan: PlanInfo;
+  saasPlanProvider: PlanProvider;
+  organizationId: string;
+  user?: PlanProviderUser;
+}): Promise<PlanInfo> {
+  if (!licensePlan.free) {
+    return { ...licensePlan, planSource: "license" };
+  }
+  const saasPlan = await saasPlanProvider.getActivePlan({
+    organizationId,
+    user,
+  });
+  return {
+    ...saasPlan,
+    planSource: saasPlan.free ? "free" : "subscription",
+  };
+}
+
+/**
+ * ADR-039 rank: ENTERPRISE license > active subscription >
+ * non-ENTERPRISE license > free. An expired/invalid license resolves free
+ * from the license provider and therefore never wins.
+ */
+async function selectByRank({
+  licensePlan,
+  saasPlanProvider,
+  organizationId,
+  user,
+}: {
+  licensePlan: PlanInfo;
+  saasPlanProvider: PlanProvider;
+  organizationId: string;
+  user?: PlanProviderUser;
+}): Promise<PlanInfo> {
+  const hasValidLicense = !licensePlan.free;
+
+  if (hasValidLicense && licensePlan.type === "ENTERPRISE") {
+    return { ...licensePlan, planSource: "license" };
+  }
+
+  const saasPlan = await saasPlanProvider.getActivePlan({
+    organizationId,
+    user,
+  });
+  if (!saasPlan.free) {
+    return { ...saasPlan, planSource: "subscription" };
+  }
+
+  if (hasValidLicense) {
+    return { ...licensePlan, planSource: "license" };
+  }
+
+  return { ...saasPlan, planSource: "free" };
 }
 
 function computeOverrideAddingLimitations(

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -181,6 +181,18 @@ export const FEATURE_FLAGS = [
     description:
       "Opens the Langy in-product assistant. Default off: only LangWatch staff (isLangwatchStaff() — @langwatch.ai email) get Langy out of the box. To open it for a specific project/org/user, flip the flag on via a PostHog rule, an operator-store row via /ops/feature-flags, or RELEASE_LANGY_ENABLED=true for a blanket on. Staff always bypass the flag so a global kill switch still leaves us able to debug.",
   },
+  // ADR-039 Decision 12: kill-switch for the plan-precedence rank change —
+  // the single behavior change for existing orgs in the billing-profile
+  // consolidation. Off = today's license-always-wins; on = ENTERPRISE
+  // license > active subscription > other license > free. Flip only after
+  // the rollout step-3b license audit (see the ADR's Rollout section).
+  {
+    key: "release_billing_precedence_rank",
+    scope: "PRODUCT",
+    defaultValue: false,
+    description:
+      "ADR-039 plan-precedence rank: an active subscription outranks a non-ENTERPRISE license (fixes the stale-license seat-flow dead-end); an ENTERPRISE license still outranks any subscription. Off preserves license-always-wins.",
+  },
 ] as const satisfies readonly FeatureFlagDefinition[];
 
 export const FEATURE_FLAG_FAMILIES = [

--- a/langwatch/src/server/invites/invite.service.ts
+++ b/langwatch/src/server/invites/invite.service.ts
@@ -260,6 +260,7 @@ export class InviteService {
       classifyInvitesByMemberType(newInvites, customRoleMap);
 
     if (!subscriptionLimits.overrideAddingLimitations) {
+      const resolution = subscriptionLimits.billing?.memberPolicy ?? "upgrade";
       if (
         currentFullMembers + newFullMembers >
         subscriptionLimits.maxMembers
@@ -267,7 +268,8 @@ export class InviteService {
         throw new LimitExceededError(
           "members",
           currentFullMembers,
-          subscriptionLimits.maxMembers
+          subscriptionLimits.maxMembers,
+          resolution
         );
       }
       if (
@@ -277,7 +279,8 @@ export class InviteService {
         throw new LimitExceededError(
           "membersLite",
           currentMembersLite,
-          subscriptionLimits.maxMembersLite
+          subscriptionLimits.maxMembersLite,
+          resolution
         );
       }
     }

--- a/langwatch/src/server/license-enforcement/__tests__/license-enforcement.service.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/license-enforcement.service.unit.test.ts
@@ -85,6 +85,7 @@ describe("LicenseEnforcementService", () => {
         current: 2,
         max: 3,
         limitType: "workflows",
+        resolution: "upgrade",
       });
     });
 
@@ -98,6 +99,7 @@ describe("LicenseEnforcementService", () => {
         current: 3,
         max: 3,
         limitType: "workflows",
+        resolution: "upgrade",
       });
     });
 
@@ -111,6 +113,7 @@ describe("LicenseEnforcementService", () => {
         current: 5,
         max: 3,
         limitType: "workflows",
+        resolution: "upgrade",
       });
     });
 
@@ -297,6 +300,107 @@ describe("LicenseEnforcementService", () => {
           limitType: "workflows",
         })
       ).resolves.toBeUndefined();
+    });
+  });
+});
+
+describe("LicenseEnforcementService — limit resolution (ADR-039)", () => {
+  const seatPlan: PlanInfo = {
+    planSource: "subscription",
+    type: "GROWTH_SEAT_EUR_MONTHLY",
+    name: "Growth",
+    free: false,
+    billing: {
+      meterUnit: "events",
+      memberPolicy: "purchase_seat",
+      showUsageLimits: false,
+      isLegacyTiered: false,
+    },
+    maxMembers: 6,
+    maxMembersLite: 9999,
+    maxTeams: 9999,
+    maxProjects: 99,
+    maxMessagesPerMonth: 999999999,
+    maxWorkflows: 9999,
+    maxPrompts: 9999,
+    maxEvaluators: 9999,
+    maxScenarios: 9999,
+    maxAgents: 9999,
+    maxExperiments: 9999,
+    maxOnlineEvaluations: 9999,
+    maxDatasets: 9999,
+    maxDashboards: 9999,
+    maxCustomGraphs: 9999,
+    maxAutomations: 9999,
+    canPublish: true,
+    prices: { USD: 0, EUR: 0 },
+  };
+
+  function makeService({ plan, memberCount }: { plan: PlanInfo; memberCount: number }) {
+    const repository = {
+      getMemberCount: vi.fn().mockResolvedValue(memberCount),
+      getMembersLiteCount: vi.fn().mockResolvedValue(0),
+      getWorkflowCount: vi.fn().mockResolvedValue(0),
+      getPromptCount: vi.fn().mockResolvedValue(0),
+      getEvaluatorCount: vi.fn().mockResolvedValue(0),
+      getActiveScenarioCount: vi.fn().mockResolvedValue(0),
+      getAgentCount: vi.fn().mockResolvedValue(0),
+      getExperimentCount: vi.fn().mockResolvedValue(0),
+      getOnlineEvaluationCount: vi.fn().mockResolvedValue(0),
+      getDatasetCount: vi.fn().mockResolvedValue(0),
+      getDashboardCount: vi.fn().mockResolvedValue(0),
+      getCustomGraphCount: vi.fn().mockResolvedValue(0),
+      getAutomationCount: vi.fn().mockResolvedValue(0),
+      getProjectCount: vi.fn().mockResolvedValue(0),
+      getTeamCount: vi.fn().mockResolvedValue(0),
+      getCurrentMonthCost: vi.fn().mockResolvedValue(0),
+      getCurrentMonthCostForProjects: vi.fn().mockResolvedValue(0),
+    } as unknown as ILicenseEnforcementRepository;
+    return new LicenseEnforcementService(repository, {
+      getActivePlan: vi.fn().mockResolvedValue(plan),
+    });
+  }
+
+  describe("when a seat-billed org hits its member cap", () => {
+    /** @scenario Admin invite denial carries the resolution */
+    it("returns resolution purchase_seat on the members check", async () => {
+      const service = makeService({ plan: seatPlan, memberCount: 6 });
+
+      const result = await service.checkLimit("org-1", "members");
+
+      expect(result.allowed).toBe(false);
+      expect(result.resolution).toBe("purchase_seat");
+    });
+
+    it("throws LimitExceededError carrying the resolution", async () => {
+      const service = makeService({ plan: seatPlan, memberCount: 6 });
+
+      await expect(
+        service.enforceLimit("org-1", "members"),
+      ).rejects.toMatchObject({ resolution: "purchase_seat" });
+    });
+  });
+
+  describe("when a non-member limit is hit", () => {
+    it("resolves upgrade regardless of the billing profile", async () => {
+      const service = makeService({ plan: seatPlan, memberCount: 0 });
+
+      const result = await service.checkLimit("org-1", "workflows");
+
+      expect(result.resolution).toBe("upgrade");
+    });
+  });
+
+  describe("when the plan has no billing profile (raw plan literal)", () => {
+    it("defaults the members resolution to upgrade", async () => {
+      const service = makeService({
+        plan: { ...seatPlan, billing: undefined },
+        memberCount: 6,
+      });
+
+      const result = await service.checkLimit("org-1", "members");
+
+      expect(result.resolution).toBe("upgrade");
     });
   });
 });

--- a/langwatch/src/server/license-enforcement/__tests__/license-limit-guard.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/license-limit-guard.unit.test.ts
@@ -201,6 +201,7 @@ describe("assertMemberTypeLimitNotExceeded", () => {
         limitType: "members",
         current: 5,
         max: 5,
+        resolution: "upgrade",
       });
     });
 
@@ -288,6 +289,7 @@ describe("assertMemberTypeLimitNotExceeded", () => {
         limitType: "membersLite",
         current: 10,
         max: 10,
+        resolution: "upgrade",
       });
     });
 

--- a/langwatch/src/server/license-enforcement/enforcement.middleware.ts
+++ b/langwatch/src/server/license-enforcement/enforcement.middleware.ts
@@ -75,6 +75,7 @@ export async function enforceLicenseLimit(
           limitType: error.limitType,
           current: error.current,
           max: error.max,
+          resolution: error.resolution,
         })
         .catch(captureException);
 

--- a/langwatch/src/server/license-enforcement/errors.ts
+++ b/langwatch/src/server/license-enforcement/errors.ts
@@ -1,11 +1,15 @@
 import { DomainError } from "~/server/app-layer/domain-error";
 import { LIMIT_TYPE_LABELS } from "./constants";
-import type { LimitType } from "./types";
+import type { LimitResolution, LimitType } from "./types";
 
 /**
  * Domain error thrown when an organization has reached its limit for a resource type.
  * This error is framework-agnostic and should be caught and mapped to
  * HTTP/tRPC errors by the router layer.
+ *
+ * `resolution` (ADR-039 Decision 5) tells the caller how the denial can be
+ * resolved — purchase_seat, upgrade, or hard_cap — so every UI and API
+ * surface routes the user forward instead of dead-ending them.
  */
 export class LimitExceededError extends DomainError {
   declare readonly kind: "resource_limit_exceeded";
@@ -14,12 +18,13 @@ export class LimitExceededError extends DomainError {
     public readonly limitType: LimitType,
     public readonly current: number,
     public readonly max: number,
+    public readonly resolution: LimitResolution = "upgrade",
   ) {
     super(
       "resource_limit_exceeded",
       `You have reached the maximum number of ${LIMIT_TYPE_LABELS[limitType]}`,
       {
-        meta: { limitType, current, max },
+        meta: { limitType, current, max, resolution },
         httpStatus: 403,
       },
     );

--- a/langwatch/src/server/license-enforcement/license-enforcement.service.ts
+++ b/langwatch/src/server/license-enforcement/license-enforcement.service.ts
@@ -1,9 +1,24 @@
 import type { PlanInfo } from "../../../ee/licensing/planInfo";
 import type { PlanProvider } from "../app-layer/subscription/plan-provider";
 import type { ILicenseEnforcementRepository } from "./license-enforcement.repository";
-import type { LimitCheckResult, LimitType } from "./types";
+import type { LimitCheckResult, LimitResolution, LimitType } from "./types";
 import { limitTypes } from "./types";
 import { LimitExceededError } from "./errors";
+
+/**
+ * Member limits resolve to the plan's memberPolicy (ADR-039 Decision 4);
+ * every other limit type resolves "upgrade" (extension point — see the ADR's
+ * Open questions).
+ */
+function resolveLimitResolution(
+  plan: PlanInfo,
+  limitType: LimitType,
+): LimitResolution {
+  if (limitType === "members" || limitType === "membersLite") {
+    return plan.billing?.memberPolicy ?? "upgrade";
+  }
+  return "upgrade";
+}
 
 /**
  * Configuration for a single limit type.
@@ -138,6 +153,7 @@ export class LicenseEnforcementService {
     user?: MinimalUser,
   ): Promise<LimitCheckResult> {
     const plan = await this.planProvider.getActivePlan({ organizationId, user });
+    const resolution = resolveLimitResolution(plan, limitType);
 
     // If plan has override flag, skip enforcement (e.g., unlimited OSS plan)
     if (plan.overrideAddingLimitations) {
@@ -146,13 +162,14 @@ export class LicenseEnforcementService {
         current: 0,
         max: this.getMaxForType(plan, limitType),
         limitType,
+        resolution,
       };
     }
 
     const current = await this.getCountForType(organizationId, limitType);
     const max = this.getMaxForType(plan, limitType);
 
-    return { allowed: current < max, current, max, limitType };
+    return { allowed: current < max, current, max, limitType, resolution };
   }
 
   /**
@@ -171,7 +188,12 @@ export class LicenseEnforcementService {
   ): Promise<void> {
     const result = await this.checkLimit(organizationId, limitType, user);
     if (!result.allowed) {
-      throw new LimitExceededError(limitType, result.current, result.max);
+      throw new LimitExceededError(
+        limitType,
+        result.current,
+        result.max,
+        result.resolution,
+      );
     }
   }
 

--- a/langwatch/src/server/license-enforcement/license-limit-guard.ts
+++ b/langwatch/src/server/license-enforcement/license-limit-guard.ts
@@ -14,12 +14,15 @@ export const LICENSE_LIMIT_ERRORS = {
 } as const;
 
 /**
- * Subscription limits needed for member type limit checks.
+ * Subscription limits needed for member type limit checks. Callers pass the
+ * resolved PlanInfo, which matches structurally — including the derived
+ * billing profile the resolution is read from (ADR-039).
  */
 export interface MemberTypeLimits {
   maxMembers: number;
   maxMembersLite: number;
   overrideAddingLimitations?: boolean;
+  billing?: { memberPolicy: "purchase_seat" | "upgrade" | "hard_cap" };
 }
 
 /**
@@ -40,6 +43,8 @@ export async function assertMemberTypeLimitNotExceeded(
     return;
   }
 
+  const resolution = limits.billing?.memberPolicy ?? "upgrade";
+
   if (changeType === "lite-to-full") {
     const memberCount = await licenseRepo.getMemberCount(organizationId);
     if (memberCount >= limits.maxMembers) {
@@ -49,6 +54,7 @@ export async function assertMemberTypeLimitNotExceeded(
           limitType: "members",
           current: memberCount,
           max: limits.maxMembers,
+          resolution,
         })
         .catch(captureException);
 
@@ -59,6 +65,7 @@ export async function assertMemberTypeLimitNotExceeded(
           limitType: "members",
           current: memberCount,
           max: limits.maxMembers,
+          resolution,
         },
       });
     }
@@ -73,6 +80,7 @@ export async function assertMemberTypeLimitNotExceeded(
           limitType: "membersLite",
           current: liteCount,
           max: limits.maxMembersLite,
+          resolution,
         })
         .catch(captureException);
 
@@ -83,6 +91,7 @@ export async function assertMemberTypeLimitNotExceeded(
           limitType: "membersLite",
           current: liteCount,
           max: limits.maxMembersLite,
+          resolution,
         },
       });
     }

--- a/langwatch/src/server/license-enforcement/types.ts
+++ b/langwatch/src/server/license-enforcement/types.ts
@@ -1,4 +1,14 @@
 import { z } from "zod";
+import type { MemberPolicy } from "../../../ee/licensing/planInfo";
+
+/**
+ * How a denied action can be resolved (ADR-039 Decision 5). Mirrors the plan's
+ * memberPolicy for member limits; every other limit type resolves "upgrade".
+ * The UI routes on this: purchase_seat → seat proration modal, upgrade → plan
+ * management, hard_cap → contact us. On the public API it is advisory
+ * metadata in the 403 body.
+ */
+export type LimitResolution = MemberPolicy;
 
 /**
  * Single source of truth for limit types.
@@ -38,4 +48,6 @@ export interface LimitCheckResult {
   readonly max: number;
   /** Type of limit being checked */
   readonly limitType: LimitType;
+  /** How the caller can resolve a denial (ADR-039 Decision 5) */
+  readonly resolution: LimitResolution;
 }

--- a/specs/licensing/member-block-resolution.feature
+++ b/specs/licensing/member-block-resolution.feature
@@ -19,31 +19,31 @@ Feature: Member limit denials carry a typed resolution everywhere
 
   # --- Typed resolution on every denial path (Decision 5) ---
 
-  @integration @unimplemented
+  @integration
   Scenario: Admin invite denial carries the resolution
     Given an organization at its full member cap
     When an admin creates an invite for a new full member
     Then the denial includes the plan's member resolution
 
-  @integration @unimplemented
+  @integration
   Scenario: Non-admin invite request denial carries the resolution
     Given an organization at its full member cap
     When a non-admin submits an invite request for a new full member
     Then the denial includes the plan's member resolution
 
-  @integration @unimplemented
+  @integration
   Scenario: Invite approval denial carries the resolution
     Given an organization at its full member cap with an invite awaiting approval
     When an admin approves the pending invite
     Then the denial includes the plan's member resolution
 
-  @integration @unimplemented
+  @integration
   Scenario: Lite-to-full role change denial carries the resolution
     Given an organization at its full member cap with a lite member
     When an admin changes the lite member's role to a full member role
     Then the denial includes the plan's member resolution
 
-  @integration @unimplemented
+  @integration
   Scenario: Public API limit denial carries the resolution as advisory metadata
     Given an organization at a resource limit
     When an API client hits the limit through the public API
@@ -71,14 +71,14 @@ Feature: Member limit denials carry a typed resolution everywhere
 
   # --- Alert split (Decision 9) ---
 
-  @integration @unimplemented
+  @integration
   Scenario: A purchase_seat denial produces an info breadcrumb, not an ops page
     Given an organization at its seat cap with resolution "purchase_seat"
     When the member denial is recorded
     Then an info-level notification is emitted
     And no ops alert fires
 
-  @integration @unimplemented
+  @integration
   Scenario: A hard_cap denial fires a real ops alert
     Given an organization at its member cap with resolution "hard_cap"
     When the member denial is recorded

--- a/specs/licensing/precedence-flag-flip.feature
+++ b/specs/licensing/precedence-flag-flip.feature
@@ -47,7 +47,7 @@ Feature: Plan precedence rank behind the release flag
     When the active plan is resolved
     Then the plan comes from the subscription
 
-  @integration @unimplemented
+  @unit
   Scenario: A stale GROWTH license no longer dead-ends the seat purchase flow
     Given the precedence flag is enabled
     And an organization with a valid GROWTH license and an ACTIVE seat-event subscription at its member cap

--- a/specs/licensing/precedence-flag-flip.feature
+++ b/specs/licensing/precedence-flag-flip.feature
@@ -10,7 +10,7 @@ Feature: Plan precedence rank behind the release flag
 
   # --- Flag disabled: today's behavior preserved ---
 
-  @unit @unimplemented
+  @unit
   Scenario: With the flag disabled a valid license still beats an active subscription
     Given the precedence flag is disabled
     And an organization with a valid GROWTH license and an ACTIVE seat-event subscription
@@ -19,28 +19,28 @@ Feature: Plan precedence rank behind the release flag
 
   # --- Flag enabled: the rank applies ---
 
-  @unit @unimplemented
+  @unit
   Scenario: An active subscription outranks a non-ENTERPRISE license
     Given the precedence flag is enabled
     And an organization with a valid GROWTH license and an ACTIVE seat-event subscription
     When the active plan is resolved
     Then the plan comes from the subscription
 
-  @unit @unimplemented
+  @unit
   Scenario: An ENTERPRISE license outranks an active subscription
     Given the precedence flag is enabled
     And an organization with a valid ENTERPRISE license and an ACTIVE seat-event subscription
     When the active plan is resolved
     Then the plan comes from the ENTERPRISE license
 
-  @unit @unimplemented
+  @unit
   Scenario: A non-ENTERPRISE license outranks having no subscription
     Given the precedence flag is enabled
     And an organization with a valid GROWTH license and no subscription
     When the active plan is resolved
     Then the plan comes from the license
 
-  @unit @unimplemented
+  @unit
   Scenario: An expired license never wins the rank
     Given the precedence flag is enabled
     And an organization with an expired ENTERPRISE license and an ACTIVE seat-event subscription


### PR DESCRIPTION
# Related Issue

- Resolves langwatch/langwatch-saas#891

## What

PR 2 of 3 for ADR-039 (stacked on langwatch/langwatch#5600). Tracked by langwatch/langwatch-saas#891.

- `release_billing_precedence_rank` feature flag (registry): OFF = today's license-always-wins; ON = **ENTERPRISE license > active subscription > non-ENTERPRISE license > free** (Decision 1 & 12). Kill-switch without redeploy for the only behavior change to existing orgs.
- Typed `resolution` (`purchase_seat | upgrade | hard_cap`) on `checkLimit` results and `LimitExceededError`, derived from the plan's memberPolicy (Decision 5, Invariant I3). Forwarded through all five tRPC denial paths (admin invite, non-admin request, approve, lite→full role change, server re-check) in the TRPCError `cause`, and as advisory metadata in the public API 403 body.
- Alert split (Decision 9): `purchase_seat` denials log an info breadcrumb (self-serve funnel — no ops page, no cooldown consumed); `upgrade`/`hard_cap` keep the Slack alert.

## Proof

- 13 scenarios bound (`precedence-flag-flip.feature` 6/6, `member-block-resolution.feature` server half 7/13); parity checker OK (2445/725)
- Unit: 644 green across license-enforcement, ee/billing, subscription app-layer, API middleware
- Rank-chain test: GROWTH license + active seat sub + flag ON → member denial resolves `purchase_seat` (the incident's dead-end, killed)
- 4 new integration tests (invite/approve/role-change denial causes) run in CI — local container runtime was down at push time

## Remaining (PR 3)

UI single handler (`resolution` → modal routing), `useInviteActions` gate collapse, 9 FE `pricingModel` sites → `useActivePlan().billing.*`, plan-constants unification, `seatSyncService` deletion, pending-invite itemization.

## Deployment Impact

- **Env vars:** none added or changed.
- **Helm values / default install:** unchanged — no new services, ports, or config.
- **BYOC dataplane:** unaffected (control-plane/TS only; no gateway or collector changes).
- **Feature flag:** `release_billing_precedence_rank` (PR2) defaults OFF — no behavior change until flipped via PostHog/ops store after the ADR-039 rollout step-3b license audit.
- **Ops scripts (PR1):** `seed-billing-checkpoints.ts` must run before `backfill-pricing-model.ts`; both are manual, dry-run-first. See the ADR Rollout section.