### PR TITLE
fix(security): raise mcp-server python-dotenv and python-liquid transitive floors

### DIFF
--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -16,5 +16,13 @@ dependencies = [
 [tool.uv]
 exclude-newer = "7 days"
 
+# Transitive-dependency security pins. Keep these even when the importing
+# package isn't a direct dependency, so a future re-resolution can't silently
+# pull a vulnerable version back in.
+constraint-dependencies = [
+    "python-dotenv>=1.2.2",  # security: python-dotenv advisory (#934)
+    "python-liquid>=2.2.1",  # security: python-liquid advisory (#1528)
+]
+
 [tool.uv.sources]
 langwatch = { path = "../python-sdk", editable = true }

--- a/mcp-server/uv.lock
+++ b/mcp-server/uv.lock
@@ -10,6 +10,12 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[manifest]
+constraints = [
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-liquid", specifier = ">=2.2.1" },
+]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -1006,7 +1012,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.32.1" },
     { name = "pksuid", specifier = ">=1.1.2" },
     { name = "pydantic", specifier = ">=2" },
-    { name = "pytest", marker = "extra == 'tests'", specifier = ">=7.4.2,<8.0.0" },
+    { name = "pytest", marker = "extra == 'tests'", specifier = ">=7.4.2,<10.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = ">=0.21.1,<0.22.0" },
     { name = "python-liquid", specifier = ">=2.2.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -1020,7 +1026,7 @@ provides-extras = ["langchain", "dspy", "litellm", "dev", "tests"]
 [package.metadata.requires-dev]
 dev = [{ name = "black", specifier = ">=26.3.1" }]
 examples = [
-    { name = "anthropic", specifier = ">=0.36.0,<0.37.0" },
+    { name = "anthropic", specifier = ">=0.36.0,<0.114.0" },
     { name = "chainlit", specifier = ">=2.11.1,<3" },
     { name = "cloudpickle", specifier = ">=3.1.1" },
     { name = "dspy-ai", specifier = ">=3.0.3,<4" },
@@ -1040,7 +1046,7 @@ examples = [
     { name = "langsmith", specifier = ">=0.8.0" },
     { name = "litellm", specifier = ">=1.84.0" },
     { name = "nltk", specifier = ">=3.9.4" },
-    { name = "openai", specifier = ">=1.68.2,<2.44.0" },
+    { name = "openai", specifier = ">=1.68.2,<2.45.0" },
     { name = "openinference-instrumentation-dspy", specifier = ">=0.1.23,<0.2.0" },
     { name = "openinference-instrumentation-litellm", specifier = ">=0.1.19" },
     { name = "openinference-instrumentation-openai", specifier = ">=0.1.30" },
@@ -1049,12 +1055,12 @@ examples = [
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pypdf", specifier = ">=6.8.0" },
-    { name = "pytest", specifier = ">=7.4.2,<8.0.0" },
+    { name = "pytest", specifier = ">=7.4.2,<10.0.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "strands-agents", extras = ["otel"], specifier = ">=1.14.0,<2.0.0" },
     { name = "streamlit", specifier = ">=1.37.1,<2.0.0" },
     { name = "unstructured", extras = ["pdf"], specifier = ">=0.18.18" },
-    { name = "uvicorn", specifier = ">=0.38.0,<0.41.0" },
+    { name = "uvicorn", specifier = ">=0.38.0,<0.50.0" },
 ]
 tests = [
     { name = "factory-boy", specifier = ">=3.3.3" },
@@ -2000,16 +2006,16 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
 name = "python-liquid"
-version = "2.2.0"
+version = "2.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -2017,9 +2023,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/15/f76284f919bd1eda0490b4fc34b416ccb10dcb20628b4afe133bf1c03366/python_liquid-2.2.0.tar.gz", hash = "sha256:ee3cda2ce6e9ef873a9d0e5180ad1de38dc39bf05044d8a6459ca1b999dbe13e", size = 95137, upload-time = "2026-05-06T17:51:28.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/1d/ae3f6e2f7a2a7faef68811fd16f645fd5a1cf01f8348763c8d0c67a83305/python_liquid-2.2.2.tar.gz", hash = "sha256:20f33d4762e6e0b39597e27ef7c577c07a481670818291526e5e50d2844dc406", size = 95277, upload-time = "2026-06-23T06:49:02.306Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/1b/33701a1ee066054a1e6ae1ec27540dd86f63c6138d214985599440c2a0dc/python_liquid-2.2.0-py3-none-any.whl", hash = "sha256:4d71b3f2c0147ffe150ba84e252b8c71e04f12c60a1d770962b0c8c977419f09", size = 140932, upload-time = "2026-05-06T17:51:27.468Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d4/0d4bb6ac8f13e8cd8afe392c76083e94bb514ef2d918d5b0de95ad0e5446/python_liquid-2.2.2-py3-none-any.whl", hash = "sha256:32d745d4ea48f00f01279cf6e7b93823b7f6e5f401eac29eb658a9b6b560c23c", size = 141053, upload-time = "2026-06-23T06:49:00.877Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Pin transitive-dependency security floors for the mcp-server `uv` lock:

- **python-dotenv** 1.1.1 -> 1.2.2 (advisory #934, moderate)
- **python-liquid** 2.2.0 -> 2.2.2 (advisory #1528, moderate)

Both are added to `[tool.uv] constraint-dependencies` so a future re-resolution cannot silently pull a vulnerable version back in. python-liquid reaches this env via the langwatch SDK path dependency (used for prompt templating); python-dotenv via the tooling stack.

## Verification

- `uv lock` resolves 129 packages, only python-dotenv and python-liquid change.
- `uv sync --frozen` succeeds.
- Smoke test in the resolved env: python-liquid 2.2.2 renders a templated string correctly, the langwatch SDK imports cleanly against it, and python-dotenv 1.2.2 exposes `load_dotenv`.

The mcp-server has no Python unit suite (the server itself is TypeScript; this lock is the auxiliary Python evaluation env), so verification is resolution + import/render smoke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added security constraints to ensure supported versions of transitive dependencies are used.
  * Included safeguards to preserve these constraints during future dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->