### PR TITLE
fix(security): raise langevals pydantic-settings transitive floor

### DIFF
--- a/langevals/pyproject.toml
+++ b/langevals/pyproject.toml
@@ -78,6 +78,7 @@ override-dependencies = [
     # 0.316.0 is API-compatible with Phoenix and is the version Phoenix itself moved
     # to in 16.4.0.
     "strawberry-graphql>=0.316.0",
+    "pydantic-settings>=2.14.2",  # security: pydantic-settings advisory (#1517)
 ]
 
 [tool.uv.workspace]

--- a/langevals/uv.lock
+++ b/langevals/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-23T06:13:23.836588Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -34,6 +34,7 @@ members = [
 overrides = [
     { name = "langchain", specifier = ">=0.3.30" },
     { name = "langsmith", specifier = ">=0.8.18" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "strawberry-graphql", specifier = ">=0.316.0" },
 ]
 
@@ -3927,16 +3928,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Pin the transitive-dependency security floor for the langevals `uv` lock:

- **pydantic-settings** 2.14.1 -> 2.14.2 (advisory #1517, moderate)

Added to the existing `[tool.uv] override-dependencies` block (the convention langevals already uses for langsmith and strawberry-graphql security pins).

## Scope

The other moderate alerts on this lock are deliberately left out because they are not one-PR-safe:

- **langchain** `1.3.9` (#1477) and **langchain-text-splitters** `1.1.2` (#916): langevals resolves both on the 0.3.x line; the only patched versions are on the 1.x line, so fixing them is a langchain 0.3 -> 1.x migration, not a floor bump.
- **diskcache** (#424): no patched version published.

## Verification

- `uv lock` resolves 315 packages, only pydantic-settings changes.
- `uv sync --frozen` succeeds.
- pydantic-settings 2.14.2 imports and `BaseSettings` instantiates correctly in the resolved env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a security-related configuration dependency to improve application settings management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->