### PR TITLE
refactor(scenarios): drop the manual Promise in ScenarioFormDrawer.handleSave (#1912)

### DIFF
--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -7,7 +7,7 @@ import { KSUID_RESOURCES } from "../../utils/constants";
 import { type UseFormReturn, useWatch } from "react-hook-form";
 import { getComplexProps, setFlowCallbacks, useDrawer, useDrawerParams } from "../../hooks/useDrawer";
 import { AgentTypeSelectorDrawer } from "../agents/AgentTypeSelectorDrawer";
-import { checkCompoundLimits } from "../../hooks/useCompoundLicenseCheck";
+import { checkCompoundLimitsAsync } from "../../hooks/useCompoundLicenseCheck";
 import { useLicenseEnforcement } from "../../hooks/useLicenseEnforcement";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { useRunScenario } from "../../hooks/useRunScenario";
@@ -225,31 +225,27 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
       }
 
       // Create mode: no scenarioId in URL yet
-      return new Promise((resolve) => {
-        checkCompoundLimits([scenarioEnforcement], async () => {
-          try {
-            const result = await createMutation.mutateAsync({
-              projectId: project.id,
-              ...data,
-              ...(models ?? {}),
-            });
-            // Transition to edit mode to prevent double-create on subsequent saves.
-            // Skip when the drawer is about to close (save-without-running).
-            if (!skipTransition) {
-              transitionToEditMode(result.id);
-            }
-            resolve(result);
-          } catch {
-            // Error already handled by global mutation cache if license error
-            resolve(null);
-          }
+      const allowed = await checkCompoundLimitsAsync([scenarioEnforcement]);
+      if (!allowed) {
+        // Limit exceeded: the upgrade modal is shown and there is nothing to create.
+        return null;
+      }
+      try {
+        const result = await createMutation.mutateAsync({
+          projectId: project.id,
+          ...data,
+          ...(models ?? {}),
         });
-
-        // If limit exceeded, modal is shown and callback won't run - resolve null
-        if (!scenarioEnforcement.isAllowed) {
-          resolve(null);
+        // Transition to edit mode to prevent double-create on subsequent saves.
+        // Skip when the drawer is about to close (save-without-running).
+        if (!skipTransition) {
+          transitionToEditMode(result.id);
         }
-      });
+        return result;
+      } catch {
+        // Error already handled by global mutation cache if license error
+        return null;
+      }
     },
     [project?.id, scenario, createMutation, updateMutation, scenarioEnforcement, transitionToEditMode],
   );

--- a/langwatch/src/hooks/useCompoundLicenseCheck.ts
+++ b/langwatch/src/hooks/useCompoundLicenseCheck.ts
@@ -39,3 +39,20 @@ export function checkCompoundLimits(
     checkCompoundLimits(rest, onAllPassed);
   });
 }
+
+/**
+ * Promise-returning variant of {@link checkCompoundLimits} for async/await
+ * call sites. Resolves `true` once every enforcement passes, or `false` as
+ * soon as one is blocked. A blocked check shows its upgrade modal and never
+ * calls back, so the blocked case is detected synchronously via `isAllowed`.
+ */
+export function checkCompoundLimitsAsync(
+  enforcements: EnforcementResult[]
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    checkCompoundLimits(enforcements, () => resolve(true));
+    if (enforcements.some((enforcement) => !enforcement.isAllowed)) {
+      resolve(false);
+    }
+  });
+}


### PR DESCRIPTION
## Ticket

Closes langwatch/tasks#45. `ScenarioFormDrawer.handleSave` wrapped the callback-based `checkCompoundLimits` in a manual `new Promise` with two competing resolve paths (the async success/error callback and a trailing `resolve(null)` for the blocked-upgrade-modal case), which is fragile to reason about and maintain.

## Change

- Add `checkCompoundLimitsAsync(enforcements): Promise<boolean>` next to `checkCompoundLimits` in `useCompoundLicenseCheck.ts`. It resolves `true` once every enforcement passes, or `false` when one is blocked (a blocked check shows its upgrade modal and never calls back, so the blocked case is detected synchronously via `isAllowed`, exactly as the old inline code did).
- Rewrite the create branch of `handleSave` as a straight async/await flow: `await` the helper, return `null` if blocked, otherwise `await createMutation.mutateAsync`, transition to edit mode unless skipped, and return the result (returning `null` on error).

The shared callback-based `checkCompoundLimits` and its other two callers (`WorkflowSelectorDrawer`, `WorkflowSelectorForEvaluatorDrawer`) are untouched, so the blast radius is one component.

Behavior is identical: allowed -> create (+ transition unless `skipTransition`); blocked or create-error -> `null`.

## Evidence

- **Behavior preserved:** `pnpm test:integration run` on the three ScenarioFormDrawer suites (`ScenarioFormDrawer.integration`, `.mapping-gate.integration`, `.save-and-run.integration`) -> `Test Files 3 passed (3)`, `Tests 33 passed (33)`.
- **Type-clean:** `pnpm typecheck` reports no errors in the changed files (the only failures are pre-existing `marked`/`sanitize-html`/`selfsigned` drift unrelated to this change).
- **Scoped:** two files, one new helper plus the rewritten create branch; no manual `Promise` constructor remains in `handleSave`.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot. The human makes the merge call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scenario creation checks against license limits before saving.
  - Prevented scenarios from being created when applicable limits are exceeded.
  - Improved handling of scenario creation failures to provide consistent user-facing feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->