### PR TITLE
feat(traces-v2): cursor-paged span-tree fetch + bounded per-trace span reads

### DIFF
--- a/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
@@ -143,7 +143,7 @@ describe("fetchSpanTreePages", () => {
       });
     });
 
-    it("keeps a single row for a span that reappears on a later page", async () => {
+    it("keeps a single row, re-sorted to its corrected position, for a span that reappears on a later page", async () => {
       const { utils } = makeUtils([
         {
           nodes: [node("a", 1), node("b", 2)],
@@ -155,7 +155,7 @@ describe("fetchSpanTreePages", () => {
 
       const nodes = await fetchSpanTreePages({ utils, input });
 
-      expect(nodes.map((n) => n.spanId)).toEqual(["a", "b"]);
+      expect(nodes.map((n) => n.spanId)).toEqual(["b", "a"]);
       expect(nodes.find((n) => n.spanId === "a")?.startTimeMs).toBe(3);
     });
   });

--- a/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
@@ -64,7 +64,11 @@ function makeUtils(pages: Page[]) {
   (proto as { query: typeof query }).query = query;
   Object.setPrototypeOf(untyped, proto);
   const utils = {
-    client: createTRPCClientProxy(untyped),
+    // v10 types the proxy factory against the legacy `TRPCClient` interop
+    // shape, not the `TRPCUntypedClient` it actually wraps at runtime.
+    client: createTRPCClientProxy(
+      untyped as unknown as Parameters<typeof createTRPCClientProxy>[0],
+    ),
   } as unknown as Parameters<typeof fetchSpanTreePages>[0]["utils"];
   return { utils, query };
 }

--- a/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
@@ -4,7 +4,9 @@ import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
 
 import {
   fetchSpanTreePages,
+  mergeSpanTreeDelta,
   SPAN_TREE_PAGE_SIZE,
+  spanTreeDeltaSinceMs,
   spanTreeQueryFn,
   spanTreeQueryKey,
 } from "../spanTreePagedQuery";
@@ -38,18 +40,24 @@ type Page = {
 const input = { projectId: "p1", traceId: "t1" };
 
 function makeUtils(pages: Page[]) {
-  const fetch = vi.fn();
-  for (const page of pages) fetch.mockResolvedValueOnce(page);
+  // `fetchSpanTreePages` wraps `utils.client` (the old-style string-path
+  // TRPCClient) in `createTRPCClientProxy`, which forwards
+  // `….tracesV2.spanTreePaginated.query(input, opts)` to
+  // `client.query("tracesV2.spanTreePaginated", input, opts)`.
+  const query = vi.fn();
+  for (const page of pages) query.mockResolvedValueOnce(page);
   const utils = {
-    tracesV2: { spanTreePaginated: { fetch } },
+    client: { query },
   } as unknown as Parameters<typeof fetchSpanTreePages>[0]["utils"];
-  return { utils, fetch };
+  return { utils, query };
 }
+
+const PAGED_PATH = "tracesV2.spanTreePaginated";
 
 describe("fetchSpanTreePages", () => {
   describe("when the trace fits in a single page", () => {
     it("returns that page's nodes from one fetch and never reports progress", async () => {
-      const { utils, fetch } = makeUtils([
+      const { utils, query } = makeUtils([
         { nodes: [node("a"), node("b")], nextCursor: null },
       ]);
       const onPage = vi.fn();
@@ -57,10 +65,11 @@ describe("fetchSpanTreePages", () => {
       const nodes = await fetchSpanTreePages({ utils, input, onPage });
 
       expect(nodes.map((n) => n.spanId)).toEqual(["a", "b"]);
-      expect(fetch).toHaveBeenCalledTimes(1);
-      expect(fetch).toHaveBeenCalledWith(
+      expect(query).toHaveBeenCalledTimes(1);
+      expect(query).toHaveBeenCalledWith(
+        PAGED_PATH,
         { ...input, limit: SPAN_TREE_PAGE_SIZE, cursor: undefined },
-        expect.anything(),
+        { signal: undefined },
       );
       expect(onPage).not.toHaveBeenCalled();
     });
@@ -68,7 +77,7 @@ describe("fetchSpanTreePages", () => {
 
   describe("when the trace spans multiple pages", () => {
     it("threads each page's nextCursor into the following fetch and concatenates in order", async () => {
-      const { utils, fetch } = makeUtils([
+      const { utils, query } = makeUtils([
         {
           nodes: [node("a", 1), node("b", 2)],
           nextCursor: { startTimeMs: 2, spanId: "b" },
@@ -83,16 +92,17 @@ describe("fetchSpanTreePages", () => {
       const nodes = await fetchSpanTreePages({ utils, input });
 
       expect(nodes.map((n) => n.spanId)).toEqual(["a", "b", "c"]);
-      expect(fetch).toHaveBeenNthCalledWith(
+      expect(query).toHaveBeenNthCalledWith(
         2,
+        PAGED_PATH,
         {
           ...input,
           limit: SPAN_TREE_PAGE_SIZE,
           cursor: { startTimeMs: 2, spanId: "b" },
         },
-        expect.anything(),
+        { signal: undefined },
       );
-      expect(fetch).toHaveBeenCalledTimes(3);
+      expect(query).toHaveBeenCalledTimes(3);
     });
 
     it("reports cumulative progress after every non-final page", async () => {
@@ -112,13 +122,49 @@ describe("fetchSpanTreePages", () => {
         onPage.mock.calls[0]![0].map((n: SpanTreeNode) => n.spanId),
       ).toEqual(["a"]);
     });
+
+    it("forwards the abort signal to every page request", async () => {
+      const controller = new AbortController();
+      const { utils, query } = makeUtils([
+        {
+          nodes: [node("a")],
+          nextCursor: { startTimeMs: 0, spanId: "a" },
+        },
+        { nodes: [node("b")], nextCursor: null },
+      ]);
+
+      await fetchSpanTreePages({ utils, input, signal: controller.signal });
+
+      expect(query).toHaveBeenNthCalledWith(1, PAGED_PATH, expect.anything(), {
+        signal: controller.signal,
+      });
+      expect(query).toHaveBeenNthCalledWith(2, PAGED_PATH, expect.anything(), {
+        signal: controller.signal,
+      });
+    });
+
+    it("keeps a single row for a span that reappears on a later page", async () => {
+      const { utils } = makeUtils([
+        {
+          nodes: [node("a", 1), node("b", 2)],
+          nextCursor: { startTimeMs: 2, spanId: "b" },
+        },
+        // Span "a" re-emitted with a corrected start time lands on page 2.
+        { nodes: [node("a", 3)], nextCursor: null },
+      ]);
+
+      const nodes = await fetchSpanTreePages({ utils, input });
+
+      expect(nodes.map((n) => n.spanId)).toEqual(["a", "b"]);
+      expect(nodes.find((n) => n.spanId === "a")?.startTimeMs).toBe(3);
+    });
   });
 
   describe("when the request is aborted between pages", () => {
     it("throws an AbortError instead of fetching the next page", async () => {
       const controller = new AbortController();
-      const { utils, fetch } = makeUtils([]);
-      fetch.mockImplementationOnce(async () => {
+      const { utils, query } = makeUtils([]);
+      query.mockImplementationOnce(async () => {
         controller.abort();
         return {
           nodes: [node("a")],
@@ -128,24 +174,24 @@ describe("fetchSpanTreePages", () => {
 
       await expect(
         fetchSpanTreePages({ utils, input, signal: controller.signal }),
-      ).rejects.toThrow(/aborted/i);
-      expect(fetch).toHaveBeenCalledTimes(1);
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(query).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("when the request is aborted while the final page's fetch is pending", () => {
     it("throws an AbortError instead of returning the stale final page", async () => {
       const controller = new AbortController();
-      const { utils, fetch } = makeUtils([]);
-      fetch.mockImplementationOnce(async () => {
+      const { utils, query } = makeUtils([]);
+      query.mockImplementationOnce(async () => {
         controller.abort();
         return { nodes: [node("a")], nextCursor: null };
       });
 
       await expect(
         fetchSpanTreePages({ utils, input, signal: controller.signal }),
-      ).rejects.toThrow(/aborted/i);
-      expect(fetch).toHaveBeenCalledTimes(1);
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(query).toHaveBeenCalledTimes(1);
     });
   });
 });
@@ -176,6 +222,33 @@ describe("spanTreeQueryFn progressive publishing", () => {
       );
       expect(published?.map((n) => n.spanId)).toEqual(["a"]);
     });
+
+    it("grows the published partial with every page instead of freezing at page one", async () => {
+      const published: string[][] = [];
+      const { utils } = makeUtils([
+        {
+          nodes: [node("a")],
+          nextCursor: { startTimeMs: 0, spanId: "a" },
+        },
+        {
+          nodes: [node("b")],
+          nextCursor: { startTimeMs: 0, spanId: "b" },
+        },
+        { nodes: [node("c")], nextCursor: null },
+      ]);
+      const originalSet = queryClient.setQueryData.bind(queryClient);
+      vi.spyOn(queryClient, "setQueryData").mockImplementation(
+        (key, data) => {
+          published.push((data as SpanTreeNode[]).map((n) => n.spanId));
+          return originalSet(key, data);
+        },
+      );
+
+      const queryFn = spanTreeQueryFn({ utils, queryClient, input });
+      await queryFn({});
+
+      expect(published).toEqual([["a"], ["a", "b"]]);
+    });
   });
 
   describe("when the cache already holds a full tree (refetch)", () => {
@@ -197,6 +270,59 @@ describe("spanTreeQueryFn progressive publishing", () => {
         spanTreeQueryKey(input),
       );
       expect(cached).toBe(fullTree);
+    });
+  });
+});
+
+describe("spanTreeDeltaSinceMs", () => {
+  describe("when the tree has spans", () => {
+    it("returns 1ms before the newest span start so same-millisecond arrivals are re-fetched", () => {
+      expect(
+        spanTreeDeltaSinceMs([node("a", 100), node("b", 300), node("c", 200)]),
+      ).toBe(299);
+    });
+  });
+
+  describe("when the tree is empty", () => {
+    it("returns 0 so a live trace picks up its first spans", () => {
+      expect(spanTreeDeltaSinceMs([])).toBe(0);
+    });
+  });
+});
+
+describe("mergeSpanTreeDelta", () => {
+  describe("when the delta only re-returns boundary rows already in the tree", () => {
+    it("returns the same array reference so quiet polls cause no re-render", () => {
+      const existing = [node("a", 1), node("b", 2)];
+
+      expect(mergeSpanTreeDelta(existing, [node("b", 2)])).toBe(existing);
+      expect(mergeSpanTreeDelta(existing, [])).toBe(existing);
+    });
+  });
+
+  describe("when the delta carries new spans", () => {
+    it("appends them in (startTimeMs, spanId) order", () => {
+      const existing = [node("a", 1), node("c", 3)];
+
+      const merged = mergeSpanTreeDelta(existing, [
+        node("d", 2),
+        node("b", 3),
+      ]);
+
+      expect(merged.map((n) => n.spanId)).toEqual(["a", "d", "b", "c"]);
+    });
+  });
+
+  describe("when the delta carries a newer version of an existing span", () => {
+    it("replaces the stale node instead of duplicating it", () => {
+      const existing = [node("a", 1), node("b", 2)];
+      const updated = { ...node("b", 2), durationMs: 42 };
+
+      const merged = mergeSpanTreeDelta(existing, [updated]);
+
+      expect(merged.map((n) => n.spanId)).toEqual(["a", "b"]);
+      expect(merged.find((n) => n.spanId === "b")?.durationMs).toBe(42);
+      expect(merged).not.toBe(existing);
     });
   });
 });

--- a/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
@@ -132,6 +132,22 @@ describe("fetchSpanTreePages", () => {
       expect(fetch).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("when the request is aborted while the final page's fetch is pending", () => {
+    it("throws an AbortError instead of returning the stale final page", async () => {
+      const controller = new AbortController();
+      const { utils, fetch } = makeUtils([]);
+      fetch.mockImplementationOnce(async () => {
+        controller.abort();
+        return { nodes: [node("a")], nextCursor: null };
+      });
+
+      await expect(
+        fetchSpanTreePages({ utils, input, signal: controller.signal }),
+      ).rejects.toThrow(/aborted/i);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe("spanTreeQueryFn progressive publishing", () => {

--- a/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
@@ -1,0 +1,186 @@
+import { QueryClient } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
+
+import {
+  fetchSpanTreePages,
+  SPAN_TREE_PAGE_SIZE,
+  spanTreeQueryFn,
+  spanTreeQueryKey,
+} from "../spanTreePagedQuery";
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    tracesV2: {
+      // `getQueryKey` resolves the procedure path via the proxy's `_def()`.
+      spanTree: { _def: () => ({ path: ["tracesV2", "spanTree"] }) },
+    },
+  },
+}));
+
+const node = (spanId: string, startTimeMs = 0): SpanTreeNode => ({
+  spanId,
+  parentSpanId: null,
+  name: spanId,
+  type: null,
+  startTimeMs,
+  endTimeMs: startTimeMs + 1,
+  durationMs: 1,
+  status: "ok",
+  model: null,
+});
+
+type Page = {
+  nodes: SpanTreeNode[];
+  nextCursor: { startTimeMs: number; spanId: string } | null;
+};
+
+const input = { projectId: "p1", traceId: "t1" };
+
+function makeUtils(pages: Page[]) {
+  const fetch = vi.fn();
+  for (const page of pages) fetch.mockResolvedValueOnce(page);
+  const utils = {
+    tracesV2: { spanTreePaginated: { fetch } },
+  } as unknown as Parameters<typeof fetchSpanTreePages>[0]["utils"];
+  return { utils, fetch };
+}
+
+describe("fetchSpanTreePages", () => {
+  describe("when the trace fits in a single page", () => {
+    it("returns that page's nodes from one fetch and never reports progress", async () => {
+      const { utils, fetch } = makeUtils([
+        { nodes: [node("a"), node("b")], nextCursor: null },
+      ]);
+      const onPage = vi.fn();
+
+      const nodes = await fetchSpanTreePages({ utils, input, onPage });
+
+      expect(nodes.map((n) => n.spanId)).toEqual(["a", "b"]);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(
+        { ...input, limit: SPAN_TREE_PAGE_SIZE, cursor: undefined },
+        expect.anything(),
+      );
+      expect(onPage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the trace spans multiple pages", () => {
+    it("threads each page's nextCursor into the following fetch and concatenates in order", async () => {
+      const { utils, fetch } = makeUtils([
+        {
+          nodes: [node("a", 1), node("b", 2)],
+          nextCursor: { startTimeMs: 2, spanId: "b" },
+        },
+        {
+          nodes: [node("c", 3)],
+          nextCursor: { startTimeMs: 3, spanId: "c" },
+        },
+        { nodes: [], nextCursor: null },
+      ]);
+
+      const nodes = await fetchSpanTreePages({ utils, input });
+
+      expect(nodes.map((n) => n.spanId)).toEqual(["a", "b", "c"]);
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        {
+          ...input,
+          limit: SPAN_TREE_PAGE_SIZE,
+          cursor: { startTimeMs: 2, spanId: "b" },
+        },
+        expect.anything(),
+      );
+      expect(fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("reports cumulative progress after every non-final page", async () => {
+      const { utils } = makeUtils([
+        {
+          nodes: [node("a")],
+          nextCursor: { startTimeMs: 0, spanId: "a" },
+        },
+        { nodes: [node("b")], nextCursor: null },
+      ]);
+      const onPage = vi.fn();
+
+      await fetchSpanTreePages({ utils, input, onPage });
+
+      expect(onPage).toHaveBeenCalledTimes(1);
+      expect(
+        onPage.mock.calls[0]![0].map((n: SpanTreeNode) => n.spanId),
+      ).toEqual(["a"]);
+    });
+  });
+
+  describe("when the request is aborted between pages", () => {
+    it("throws an AbortError instead of fetching the next page", async () => {
+      const controller = new AbortController();
+      const { utils, fetch } = makeUtils([]);
+      fetch.mockImplementationOnce(async () => {
+        controller.abort();
+        return {
+          nodes: [node("a")],
+          nextCursor: { startTimeMs: 0, spanId: "a" },
+        };
+      });
+
+      await expect(
+        fetchSpanTreePages({ utils, input, signal: controller.signal }),
+      ).rejects.toThrow(/aborted/i);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("spanTreeQueryFn progressive publishing", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  describe("when the cache entry is empty (first load)", () => {
+    it("publishes each partial page so the waterfall paints early", async () => {
+      const { utils } = makeUtils([
+        {
+          nodes: [node("a")],
+          nextCursor: { startTimeMs: 0, spanId: "a" },
+        },
+        { nodes: [node("b")], nextCursor: null },
+      ]);
+
+      const queryFn = spanTreeQueryFn({ utils, queryClient, input });
+      const result = await queryFn({});
+
+      expect(result.map((n) => n.spanId)).toEqual(["a", "b"]);
+      const published = queryClient.getQueryData<SpanTreeNode[]>(
+        spanTreeQueryKey(input),
+      );
+      expect(published?.map((n) => n.spanId)).toEqual(["a"]);
+    });
+  });
+
+  describe("when the cache already holds a full tree (refetch)", () => {
+    it("does not shrink the cached tree with smaller partials", async () => {
+      const fullTree = [node("a"), node("b"), node("c")];
+      queryClient.setQueryData(spanTreeQueryKey(input), fullTree);
+      const { utils } = makeUtils([
+        {
+          nodes: [node("a")],
+          nextCursor: { startTimeMs: 0, spanId: "a" },
+        },
+        { nodes: [node("b")], nextCursor: null },
+      ]);
+
+      const queryFn = spanTreeQueryFn({ utils, queryClient, input });
+      await queryFn({});
+
+      const cached = queryClient.getQueryData<SpanTreeNode[]>(
+        spanTreeQueryKey(input),
+      );
+      expect(cached).toBe(fullTree);
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
@@ -1,4 +1,9 @@
 import { QueryClient } from "@tanstack/react-query";
+import {
+  createTRPCClientProxy,
+  httpBatchLink,
+  TRPCUntypedClient,
+} from "@trpc/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
 
@@ -40,14 +45,26 @@ type Page = {
 const input = { projectId: "p1", traceId: "t1" };
 
 function makeUtils(pages: Page[]) {
-  // `fetchSpanTreePages` wraps `utils.client` (the old-style string-path
-  // TRPCClient) in `createTRPCClientProxy`, which forwards
-  // `….tracesV2.spanTreePaginated.query(input, opts)` to
-  // `client.query("tracesV2.spanTreePaginated", input, opts)`.
   const query = vi.fn();
   for (const page of pages) query.mockResolvedValueOnce(page);
+  // The real thing `api.useUtils().client` returns: a `createTRPCClientProxy`
+  // wrapper, NOT the client itself. That distinction is load-bearing — the
+  // proxy only resolves keys the client *owns*, so `utils.client.query` is a
+  // recursive path proxy and `.bind()`ing it produces a function that throws
+  // on call. A plain `{ query }` double resolves `query` as an own property
+  // and would let that bug through green, which is how it shipped once.
+  const untyped = new TRPCUntypedClient({
+    links: [httpBatchLink({ url: "http://localhost/api/trpc" })],
+  });
+  // Stub `query` on the prototype chain, never as an own property: the proxy
+  // resolves a key to the raw client only when the client OWNS it, so an own
+  // `query` makes `utils.client.query` the real function and papers over the
+  // bug above. Inherited — as on the real client — it stays a path proxy.
+  const proto = Object.create(TRPCUntypedClient.prototype) as object;
+  (proto as { query: typeof query }).query = query;
+  Object.setPrototypeOf(untyped, proto);
   const utils = {
-    client: { query },
+    client: createTRPCClientProxy(untyped),
   } as unknown as Parameters<typeof fetchSpanTreePages>[0]["utils"];
   return { utils, query };
 }

--- a/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/spanTreePagedQuery.unit.test.ts
@@ -25,7 +25,11 @@ vi.mock("~/utils/api", () => ({
   },
 }));
 
-const node = (spanId: string, startTimeMs = 0): SpanTreeNode => ({
+const node = (
+  spanId: string,
+  startTimeMs = 0,
+  updatedAtMs = startTimeMs,
+): SpanTreeNode => ({
   spanId,
   parentSpanId: null,
   name: spanId,
@@ -33,6 +37,7 @@ const node = (spanId: string, startTimeMs = 0): SpanTreeNode => ({
   startTimeMs,
   endTimeMs: startTimeMs + 1,
   durationMs: 1,
+  updatedAtMs,
   status: "ok",
   model: null,
 });
@@ -297,16 +302,35 @@ describe("spanTreeQueryFn progressive publishing", () => {
 
 describe("spanTreeDeltaSinceMs", () => {
   describe("when the tree has spans", () => {
-    it("returns 1ms before the newest span start so same-millisecond arrivals are re-fetched", () => {
+    it("returns 1ms before the newest row version so same-millisecond writes are re-fetched", () => {
       expect(
         spanTreeDeltaSinceMs([node("a", 100), node("b", 300), node("c", 200)]),
       ).toBe(299);
+    });
+
+    it("keys off the row version, not the span start, so in-place updates advance the mark", () => {
+      // The root starts first and ends last: its start is the OLDEST in the
+      // trace while its version is the NEWEST. A start-keyed mark would sit
+      // at the newest start (300) and never re-read the root, freezing its
+      // duration — and with it the waterfall's time scale.
+      const root = node("root", 100, 900);
+      const leaf = node("leaf", 300, 300);
+
+      expect(spanTreeDeltaSinceMs([root, leaf])).toBe(899);
     });
   });
 
   describe("when the tree is empty", () => {
     it("returns 0 so a live trace picks up its first spans", () => {
       expect(spanTreeDeltaSinceMs([])).toBe(0);
+    });
+  });
+
+  describe("when the spans carry no row version (preview fixtures)", () => {
+    it("returns 0 rather than a bogus mark, so the first server rows correct it", () => {
+      const previewNode = { ...node("a", 100), updatedAtMs: undefined };
+
+      expect(spanTreeDeltaSinceMs([previewNode])).toBe(0);
     });
   });
 });

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useSpanTree.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useSpanTree.unit.test.ts
@@ -40,6 +40,7 @@ const getQueryData = vi.fn();
 const setQueryData = vi.fn();
 
 let treeData: SpanTreeNode[] | undefined;
+let treeIsPreviousData = false;
 let sseConnectionState = "connected";
 let traceQueryArgs = {
   isLive: true,
@@ -50,7 +51,11 @@ let traceQueryArgs = {
 vi.mock("@tanstack/react-query", () => ({
   useQuery: (options: TreeQueryOptions) => {
     capturedTreeOptions.push(options);
-    return { data: treeData, isLoading: false };
+    return {
+      data: treeData,
+      isLoading: false,
+      isPreviousData: treeIsPreviousData,
+    };
   },
   useQueryClient: () => ({ getQueryData, setQueryData }),
 }));
@@ -114,6 +119,7 @@ describe("useSpanTree", () => {
     getQueryData.mockReset();
     setQueryData.mockReset();
     treeData = [node("a", 100)];
+    treeIsPreviousData = false;
     sseConnectionState = "connected";
     traceQueryArgs = {
       isLive: true,
@@ -176,6 +182,15 @@ describe("useSpanTree", () => {
 
     it("waits for the tree to load before polling (no high-water mark yet)", () => {
       treeData = undefined;
+
+      renderHook(() => useSpanTree());
+
+      expect(lastDeltaCall().options.enabled).toBe(false);
+    });
+
+    it("does not poll from a previous trace's tree while keepPreviousData bridges a trace switch", () => {
+      treeData = [node("a", 100)];
+      treeIsPreviousData = true;
 
       renderHook(() => useSpanTree());
 

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useSpanTree.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useSpanTree.unit.test.ts
@@ -14,7 +14,7 @@ type TreeQueryOptions = {
 };
 
 type DeltaQueryCall = {
-  input: { sinceStartTimeMs: number };
+  input: { sinceUpdatedAtMs: number };
   options: {
     enabled: boolean;
     refetchInterval: unknown;
@@ -22,7 +22,11 @@ type DeltaQueryCall = {
   };
 };
 
-const node = (spanId: string, startTimeMs: number): SpanTreeNode => ({
+const node = (
+  spanId: string,
+  startTimeMs: number,
+  updatedAtMs = startTimeMs,
+): SpanTreeNode => ({
   spanId,
   parentSpanId: null,
   name: spanId,
@@ -30,6 +34,7 @@ const node = (spanId: string, startTimeMs: number): SpanTreeNode => ({
   startTimeMs,
   endTimeMs: startTimeMs + 1,
   durationMs: 1,
+  updatedAtMs,
   status: "ok",
   model: null,
 });
@@ -38,6 +43,7 @@ const capturedTreeOptions: TreeQueryOptions[] = [];
 const capturedDeltaCalls: DeltaQueryCall[] = [];
 const getQueryData = vi.fn();
 const setQueryData = vi.fn();
+const deltaInvalidate = vi.fn();
 
 let treeData: SpanTreeNode[] | undefined;
 let treeIsPreviousData = false;
@@ -64,7 +70,9 @@ vi.mock("@tanstack/react-query", () => ({
 
 vi.mock("~/utils/api", () => ({
   api: {
-    useUtils: () => ({}),
+    useUtils: () => ({
+      tracesV2: { spanTreeDelta: { invalidate: deltaInvalidate } },
+    }),
     tracesV2: {
       spanTreeDelta: {
         useQuery: (
@@ -81,16 +89,21 @@ vi.mock("~/utils/api", () => ({
 
 const QUERY_FN_MARKER = () => Promise.resolve([]);
 
-vi.mock("../spanTreePagedQuery", () => ({
-  spanTreeQueryKey: (input: unknown) => ["spanTree", input],
-  spanTreeQueryFn: () => QUERY_FN_MARKER,
-  spanTreeDeltaSinceMs: (nodes: SpanTreeNode[]) =>
-    nodes.length === 0
-      ? 0
-      : Math.max(0, Math.max(...nodes.map((n) => n.startTimeMs)) - 1),
-  mergeSpanTreeDelta: (existing: SpanTreeNode[], delta: SpanTreeNode[]) =>
-    delta.length === 0 ? existing : [...existing, ...delta],
-}));
+vi.mock("../spanTreePagedQuery", async () => {
+  const actual = await vi.importActual<
+    typeof import("../spanTreePagedQuery")
+  >("../spanTreePagedQuery");
+  return {
+    spanTreeQueryKey: (input: unknown) => ["spanTree", input],
+    spanTreeQueryFn: () => QUERY_FN_MARKER,
+    // NOT stubbed: which column the high-water mark comes from is precisely
+    // what these tests are about. A hand-rolled stub here would keep passing
+    // while the hook polled from the wrong one.
+    spanTreeDeltaSinceMs: actual.spanTreeDeltaSinceMs,
+    mergeSpanTreeDelta: (existing: SpanTreeNode[], delta: SpanTreeNode[]) =>
+      delta.length === 0 ? existing : [...existing, ...delta],
+  };
+});
 
 vi.mock("../useTraceQueryArgs", () => ({
   useTraceQueryArgs: () => traceQueryArgs,
@@ -120,6 +133,7 @@ describe("useSpanTree", () => {
     capturedDeltaCalls.length = 0;
     getQueryData.mockReset();
     setQueryData.mockReset();
+    deltaInvalidate.mockReset();
     treeData = [node("a", 100)];
     treeIsPreviousData = false;
     treeIsFetching = false;
@@ -157,10 +171,20 @@ describe("useSpanTree", () => {
   });
 
   describe("when the trace is live and SSE is connected", () => {
-    it("does not poll deltas — SSE invalidation keeps the tree fresh push-style", () => {
+    it("keeps the delta armed but runs it on no timer — SSE invalidation drives it push-style", () => {
       renderHook(() => useSpanTree());
 
-      expect(lastDeltaCall().options.enabled).toBe(false);
+      expect(lastDeltaCall().options.enabled).toBe(true);
+      expect(lastDeltaCall().options.refetchInterval).toBe(false);
+    });
+
+    it("never re-walks the tree on an SSE update — that is ceil(N/500) requests per batch", () => {
+      // The tree query owns the page walk; it must not be given a timer of
+      // its own, and `useTraceFreshness` invalidates `spanTreeDelta` rather
+      // than `spanTree` so a live 100k-span trace merges deltas in place.
+      renderHook(() => useSpanTree());
+
+      expect(lastTreeOptions().refetchInterval).toBeUndefined();
     });
   });
 
@@ -179,8 +203,17 @@ describe("useSpanTree", () => {
       expect(lastDeltaCall().input).toMatchObject({
         projectId: "p1",
         traceId: "t1",
-        sinceStartTimeMs: 299,
+        sinceUpdatedAtMs: 299,
       });
+    });
+
+    it("takes the mark from the newest row version, so a re-projected root span is re-read", () => {
+      // Root starts first (oldest start) but is updated last (newest version).
+      treeData = [node("root", 100, 900), node("leaf", 300, 300)];
+
+      renderHook(() => useSpanTree());
+
+      expect(lastDeltaCall().input).toMatchObject({ sinceUpdatedAtMs: 899 });
     });
 
     it("waits for the tree to load before polling (no high-water mark yet)", () => {
@@ -234,6 +267,33 @@ describe("useSpanTree", () => {
       lastDeltaCall().options.onSuccess([]);
 
       expect(setQueryData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when SSE reconnects after being down", () => {
+    it("fetches one catch-up delta, since a span that landed during the gap raises no event of its own", () => {
+      sseConnectionState = "disconnected";
+      const { rerender } = renderHook(() => useSpanTree());
+      expect(deltaInvalidate).not.toHaveBeenCalled();
+
+      sseConnectionState = "connected";
+      rerender();
+
+      expect(deltaInvalidate).toHaveBeenCalledWith({
+        projectId: "p1",
+        traceId: "t1",
+      });
+    });
+
+    it("does not catch up on a trace that is no longer live", () => {
+      traceQueryArgs = { ...traceQueryArgs, isLive: false };
+      sseConnectionState = "disconnected";
+      const { rerender } = renderHook(() => useSpanTree());
+
+      sseConnectionState = "connected";
+      rerender();
+
+      expect(deltaInvalidate).not.toHaveBeenCalled();
     });
   });
 

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useSpanTree.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useSpanTree.unit.test.ts
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
+
+import { LIVE_REFETCH_MS } from "../../constants/freshness";
+import { useSpanTree } from "../useSpanTree";
+
+type TreeQueryOptions = {
+  queryKey: unknown;
+  queryFn: unknown;
+  enabled: boolean;
+  refetchInterval?: unknown;
+};
+
+type DeltaQueryCall = {
+  input: { sinceStartTimeMs: number };
+  options: {
+    enabled: boolean;
+    refetchInterval: unknown;
+    onSuccess: (delta: SpanTreeNode[]) => void;
+  };
+};
+
+const node = (spanId: string, startTimeMs: number): SpanTreeNode => ({
+  spanId,
+  parentSpanId: null,
+  name: spanId,
+  type: null,
+  startTimeMs,
+  endTimeMs: startTimeMs + 1,
+  durationMs: 1,
+  status: "ok",
+  model: null,
+});
+
+const capturedTreeOptions: TreeQueryOptions[] = [];
+const capturedDeltaCalls: DeltaQueryCall[] = [];
+const getQueryData = vi.fn();
+const setQueryData = vi.fn();
+
+let treeData: SpanTreeNode[] | undefined;
+let sseConnectionState = "connected";
+let traceQueryArgs = {
+  isLive: true,
+  isReady: true,
+  queryArgs: { projectId: "p1", traceId: "t1" },
+};
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (options: TreeQueryOptions) => {
+    capturedTreeOptions.push(options);
+    return { data: treeData, isLoading: false };
+  },
+  useQueryClient: () => ({ getQueryData, setQueryData }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useUtils: () => ({}),
+    tracesV2: {
+      spanTreeDelta: {
+        useQuery: (
+          input: DeltaQueryCall["input"],
+          options: DeltaQueryCall["options"],
+        ) => {
+          capturedDeltaCalls.push({ input, options });
+          return {};
+        },
+      },
+    },
+  },
+}));
+
+const QUERY_FN_MARKER = () => Promise.resolve([]);
+
+vi.mock("../spanTreePagedQuery", () => ({
+  spanTreeQueryKey: (input: unknown) => ["spanTree", input],
+  spanTreeQueryFn: () => QUERY_FN_MARKER,
+  spanTreeDeltaSinceMs: (nodes: SpanTreeNode[]) =>
+    nodes.length === 0
+      ? 0
+      : Math.max(0, Math.max(...nodes.map((n) => n.startTimeMs)) - 1),
+  mergeSpanTreeDelta: (existing: SpanTreeNode[], delta: SpanTreeNode[]) =>
+    delta.length === 0 ? existing : [...existing, ...delta],
+}));
+
+vi.mock("../useTraceQueryArgs", () => ({
+  useTraceQueryArgs: () => traceQueryArgs,
+}));
+
+vi.mock("../../stores/sseStatusStore", () => ({
+  useSseStatusStore: (
+    selector: (state: { sseConnectionState: string }) => boolean,
+  ) => selector({ sseConnectionState }),
+}));
+
+const lastTreeOptions = (): TreeQueryOptions => {
+  const options = capturedTreeOptions[capturedTreeOptions.length - 1];
+  if (!options) throw new Error("no tree query options were captured");
+  return options;
+};
+
+const lastDeltaCall = (): DeltaQueryCall => {
+  const call = capturedDeltaCalls[capturedDeltaCalls.length - 1];
+  if (!call) throw new Error("no delta query call was captured");
+  return call;
+};
+
+describe("useSpanTree", () => {
+  beforeEach(() => {
+    capturedTreeOptions.length = 0;
+    capturedDeltaCalls.length = 0;
+    getQueryData.mockReset();
+    setQueryData.mockReset();
+    treeData = [node("a", 100)];
+    sseConnectionState = "connected";
+    traceQueryArgs = {
+      isLive: true,
+      isReady: true,
+      queryArgs: { projectId: "p1", traceId: "t1" },
+    };
+  });
+
+  describe("when the drawer trace is ready", () => {
+    it("keys and fetches the shared paged span-tree entry without its own poll interval", () => {
+      renderHook(() => useSpanTree());
+
+      expect(lastTreeOptions().queryKey).toEqual([
+        "spanTree",
+        { projectId: "p1", traceId: "t1" },
+      ]);
+      expect(lastTreeOptions().queryFn).toBe(QUERY_FN_MARKER);
+      expect(lastTreeOptions().enabled).toBe(true);
+      expect(lastTreeOptions().refetchInterval).toBeUndefined();
+    });
+  });
+
+  describe("when the traceId is a preview-mode synthetic (not ready)", () => {
+    it("disables both the fetch and the delta poll", () => {
+      traceQueryArgs = { ...traceQueryArgs, isReady: false };
+
+      renderHook(() => useSpanTree());
+
+      expect(lastTreeOptions().enabled).toBe(false);
+      expect(lastDeltaCall().options.enabled).toBe(false);
+    });
+  });
+
+  describe("when the trace is live and SSE is connected", () => {
+    it("does not poll deltas — SSE invalidation keeps the tree fresh push-style", () => {
+      renderHook(() => useSpanTree());
+
+      expect(lastDeltaCall().options.enabled).toBe(false);
+    });
+  });
+
+  describe("when the trace is live and SSE is disconnected", () => {
+    beforeEach(() => {
+      sseConnectionState = "disconnected";
+    });
+
+    it("polls spanTreeDelta from the loaded tree's high-water mark instead of re-walking every page", () => {
+      treeData = [node("a", 100), node("b", 300)];
+
+      renderHook(() => useSpanTree());
+
+      expect(lastDeltaCall().options.enabled).toBe(true);
+      expect(lastDeltaCall().options.refetchInterval).toBe(LIVE_REFETCH_MS);
+      expect(lastDeltaCall().input).toMatchObject({
+        projectId: "p1",
+        traceId: "t1",
+        sinceStartTimeMs: 299,
+      });
+    });
+
+    it("waits for the tree to load before polling (no high-water mark yet)", () => {
+      treeData = undefined;
+
+      renderHook(() => useSpanTree());
+
+      expect(lastDeltaCall().options.enabled).toBe(false);
+    });
+
+    it("merges delta spans into the shared cache entry", () => {
+      const existing = [node("a", 100)];
+      getQueryData.mockReturnValue(existing);
+
+      renderHook(() => useSpanTree());
+      lastDeltaCall().options.onSuccess([node("b", 200)]);
+
+      expect(setQueryData).toHaveBeenCalledWith(
+        ["spanTree", { projectId: "p1", traceId: "t1" }],
+        [node("a", 100), node("b", 200)],
+      );
+    });
+
+    it("leaves the cache untouched when the delta carries nothing new", () => {
+      const existing = [node("a", 100)];
+      getQueryData.mockReturnValue(existing);
+
+      renderHook(() => useSpanTree());
+      lastDeltaCall().options.onSuccess([]);
+
+      expect(setQueryData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the trace is no longer live", () => {
+    it("does not poll deltas even with SSE disconnected", () => {
+      traceQueryArgs = { ...traceQueryArgs, isLive: false };
+      sseConnectionState = "disconnected";
+
+      renderHook(() => useSpanTree());
+
+      expect(lastDeltaCall().options.enabled).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useSpanTree.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useSpanTree.unit.test.ts
@@ -41,6 +41,7 @@ const setQueryData = vi.fn();
 
 let treeData: SpanTreeNode[] | undefined;
 let treeIsPreviousData = false;
+let treeIsFetching = false;
 let sseConnectionState = "connected";
 let traceQueryArgs = {
   isLive: true,
@@ -54,6 +55,7 @@ vi.mock("@tanstack/react-query", () => ({
     return {
       data: treeData,
       isLoading: false,
+      isFetching: treeIsFetching,
       isPreviousData: treeIsPreviousData,
     };
   },
@@ -120,6 +122,7 @@ describe("useSpanTree", () => {
     setQueryData.mockReset();
     treeData = [node("a", 100)];
     treeIsPreviousData = false;
+    treeIsFetching = false;
     sseConnectionState = "connected";
     traceQueryArgs = {
       isLive: true,
@@ -182,6 +185,19 @@ describe("useSpanTree", () => {
 
     it("waits for the tree to load before polling (no high-water mark yet)", () => {
       treeData = undefined;
+
+      renderHook(() => useSpanTree());
+
+      expect(lastDeltaCall().options.enabled).toBe(false);
+    });
+
+    it("does not poll from a partially published tree while the page walk is still running", () => {
+      // Progressive publishing sets the cache entry after page 1, so `data` is
+      // defined long before the walk finishes. Polling from that partial
+      // high-water mark would ask for the whole remainder of the trace in one
+      // response — the unbounded fetch this paging exists to avoid.
+      treeData = [node("a", 100)];
+      treeIsFetching = true;
 
       renderHook(() => useSpanTree());
 

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useTraceSpanTree.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useTraceSpanTree.unit.test.ts
@@ -12,16 +12,20 @@ type SpanTreeInput = {
 
 const capturedInputs: SpanTreeInput[] = [];
 
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [], isLoading: false }),
+  useQueryClient: () => ({}),
+}));
+
 vi.mock("~/utils/api", () => ({
-  api: {
-    tracesV2: {
-      spanTree: {
-        useQuery: (input: SpanTreeInput) => {
-          capturedInputs.push(input);
-          return { data: [], isLoading: false };
-        },
-      },
-    },
+  api: { useUtils: () => ({}) },
+}));
+
+vi.mock("../spanTreePagedQuery", () => ({
+  spanTreeQueryKey: (input: SpanTreeInput) => ["spanTree", input],
+  spanTreeQueryFn: ({ input }: { input: SpanTreeInput }) => {
+    capturedInputs.push(input);
+    return () => Promise.resolve([]);
   },
 }));
 

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useTraceSpanTree.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useTraceSpanTree.unit.test.ts
@@ -10,10 +10,20 @@ type SpanTreeInput = {
   occurredAtMs?: number;
 };
 
-const capturedInputs: SpanTreeInput[] = [];
+type CapturedQueryOptions = {
+  queryKey: unknown;
+  queryFn: unknown;
+  enabled: boolean;
+};
+
+const capturedQueryOptions: CapturedQueryOptions[] = [];
+let previewTraceId = false;
 
 vi.mock("@tanstack/react-query", () => ({
-  useQuery: () => ({ data: [], isLoading: false }),
+  useQuery: (options: CapturedQueryOptions) => {
+    capturedQueryOptions.push(options);
+    return { data: [], isLoading: false };
+  },
   useQueryClient: () => ({}),
 }));
 
@@ -21,11 +31,13 @@ vi.mock("~/utils/api", () => ({
   api: { useUtils: () => ({}) },
 }));
 
+const QUERY_FN_MARKER = () => Promise.resolve([]);
+
 vi.mock("../spanTreePagedQuery", () => ({
   spanTreeQueryKey: (input: SpanTreeInput) => ["spanTree", input],
   spanTreeQueryFn: ({ input }: { input: SpanTreeInput }) => {
-    capturedInputs.push(input);
-    return () => Promise.resolve([]);
+    void input;
+    return QUERY_FN_MARKER;
   },
 }));
 
@@ -34,30 +46,37 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
 }));
 
 vi.mock("../../onboarding/data/samplePreviewTraces", () => ({
-  isPreviewTraceId: () => false,
+  isPreviewTraceId: () => previewTraceId,
 }));
 
-const lastInput = (): SpanTreeInput => {
-  const input = capturedInputs[capturedInputs.length - 1];
-  if (!input) {
-    throw new Error("no query input was captured");
+const lastOptions = (): CapturedQueryOptions => {
+  const options = capturedQueryOptions[capturedQueryOptions.length - 1];
+  if (!options) {
+    throw new Error("no query options were captured");
   }
-  return input;
+  return options;
 };
 
 describe("useTraceSpanTree", () => {
   beforeEach(() => {
-    capturedInputs.length = 0;
+    capturedQueryOptions.length = 0;
+    previewTraceId = false;
   });
 
   describe("when the row's trace timestamp is supplied", () => {
-    it("forwards it as the occurredAtMs partition hint", () => {
+    it("keys and fetches the shared paged span-tree entry, forwarding the occurredAtMs partition hint", () => {
       renderHook(() => useTraceSpanTree("trace-123", 1_700_000_000_000));
 
-      expect(lastInput()).toMatchObject({
-        traceId: "trace-123",
-        occurredAtMs: 1_700_000_000_000,
-      });
+      expect(lastOptions().queryKey).toEqual([
+        "spanTree",
+        {
+          projectId: "p1",
+          traceId: "trace-123",
+          occurredAtMs: 1_700_000_000_000,
+        },
+      ]);
+      expect(lastOptions().queryFn).toBe(QUERY_FN_MARKER);
+      expect(lastOptions().enabled).toBe(true);
     });
   });
 
@@ -65,7 +84,24 @@ describe("useTraceSpanTree", () => {
     it("leaves occurredAtMs undefined (unconstrained scan fallback)", () => {
       renderHook(() => useTraceSpanTree("trace-123"));
 
-      expect(lastInput().occurredAtMs).toBeUndefined();
+      expect(lastOptions().queryKey).toEqual([
+        "spanTree",
+        {
+          projectId: "p1",
+          traceId: "trace-123",
+          occurredAtMs: undefined,
+        },
+      ]);
+    });
+  });
+
+  describe("when the traceId is a preview-mode synthetic", () => {
+    it("disables the fetch so the seeded cache entry is not clobbered", () => {
+      previewTraceId = true;
+
+      renderHook(() => useTraceSpanTree("preview-trace"));
+
+      expect(lastOptions().enabled).toBe(false);
     });
   });
 });

--- a/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
+++ b/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
@@ -1,4 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
+import { getUntypedClient } from "@trpc/client";
 import { getQueryKey } from "@trpc/react-query";
 import type {
   SpanTreeCursor,
@@ -81,12 +82,22 @@ export async function fetchSpanTreePages({
   // just between pages), and no throwaway per-page React Query cache
   // entries are created — the assembled tree lives under the spanTree key.
   //
-  // Dot-path form with a pinned signature: the typed proxy
-  // (`createTRPCClientProxy`) cannot wrap this router (its `subscription`
-  // procedure collides with the proxy's reserved method names), and
-  // `utils.client.query`'s own generic is keyed to the empty v10 legacy
+  // `utils.client` is not the vanilla client — `useUtils()` hands back
+  // `createTRPCClientProxy(client)`, and that proxy only resolves a key to the
+  // real client when the client *owns* it. `query` lives on
+  // `TRPCUntypedClient.prototype`, so `utils.client.query` is a recursive path
+  // proxy instead; binding it yields a function that throws on call
+  // (`clientCallTypeToProcedureType("bind")` is `undefined`). `getUntypedClient`
+  // unwraps the proxy back to the client the provider was built with.
+  //
+  // Dot-path form with a pinned signature: the typed proxy cannot wrap this
+  // router (its `subscription` procedure collides with the proxy's reserved
+  // method names), and `query`'s own generic is keyed to the empty v10 legacy
   // `_def.queries` interop shape, so neither types this call natively.
-  const queryPage = utils.client.query.bind(utils.client) as (
+  const client = getUntypedClient(
+    utils.client as unknown as Parameters<typeof getUntypedClient>[0],
+  );
+  const queryPage = client.query.bind(client) as (
     path: "tracesV2.spanTreePaginated",
     input: SpanTreeQueryInput & { limit: number; cursor?: SpanTreeCursor },
     opts?: { signal?: AbortSignal },

--- a/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
+++ b/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
@@ -158,21 +158,31 @@ export function spanTreeQueryFn({
 
 /**
  * Lower bound for the live-delta poll over a loaded tree: 1ms before the
- * newest span start. `spanTreeDelta` filters `StartTime > since` at sub-ms
- * precision while tree rows carry ms-truncated times, so polling from the
- * exact high-water mark could permanently miss a span that started later
- * within the same millisecond; backing off 1ms re-fetches the boundary rows
- * instead, and {@link mergeSpanTreeDelta} dedupes them. 0 for an empty tree,
- * so a live trace whose spans haven't been ingested yet still picks them up.
+ * newest ROW VERSION it holds.
+ *
+ * Keyed on `updatedAtMs`, not `startTimeMs`. A span updated in place — end
+ * time, duration, status, cost, all re-projected as it closes — keeps its
+ * start time, so a start-keyed mark can only ever surface brand-new spans.
+ * The root span is the worst case: it starts first and ends last, so its
+ * duration (and with it the waterfall's whole time scale) stayed frozen at
+ * first projection for as long as SSE was down.
+ *
+ * Both bounds are ms-truncated from `DateTime64(3)`, so a row written later
+ * within the same millisecond as the mark would be missed by a strict `>`;
+ * backing off 1ms re-fetches the boundary rows and
+ * {@link mergeSpanTreeDelta} dedupes them.
+ *
+ * 0 for an empty tree, so a live trace whose spans haven't been ingested yet
+ * still picks them up — and likewise for preview fixtures carrying no
+ * version, where the mark corrects itself on the first server-sourced row.
  */
 export function spanTreeDeltaSinceMs(nodes: SpanTreeNode[]): number {
-  let highWaterMs: number | undefined;
+  let highWaterMs = 0;
   for (const node of nodes) {
-    if (highWaterMs === undefined || node.startTimeMs > highWaterMs) {
-      highWaterMs = node.startTimeMs;
-    }
+    const updatedAtMs = node.updatedAtMs ?? 0;
+    if (updatedAtMs > highWaterMs) highWaterMs = updatedAtMs;
   }
-  return highWaterMs === undefined ? 0 : Math.max(0, highWaterMs - 1);
+  return highWaterMs === 0 ? 0 : Math.max(0, highWaterMs - 1);
 }
 
 /** Every field of SpanTreeNode is a scalar (or null), so shallow works. */

--- a/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
+++ b/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
@@ -4,9 +4,9 @@ import type {
   SpanTreeCursor,
   SpanTreeNode,
 } from "~/server/api/routers/tracesV2.schemas";
-import { api } from "~/utils/api";
+import { api, type RouterOutputs } from "~/utils/api";
 
-/**
+/*
  * Traces can carry 20k–100k+ spans, so the span tree is never fetched as a
  * single response. The tRPC `spanTree` procedure remains the cache-key anchor
  * — preview-mode seeding, SSE invalidation, refresh, and close-time cancel all
@@ -14,6 +14,13 @@ import { api } from "~/utils/api";
  * more: the query function built here pages through `spanTreePaginated` and
  * assembles the tree client-side, publishing pages progressively so the
  * waterfall starts painting after the first page.
+ */
+
+/**
+ * Rows per `spanTreePaginated` page: large enough that the common trace
+ * (p999 ≈ 312 spans) still loads in one round trip, small enough that a
+ * 100k-span trace streams into the waterfall instead of stalling on one
+ * giant response.
  */
 export const SPAN_TREE_PAGE_SIZE = 500;
 
@@ -34,6 +41,16 @@ export function spanTreeQueryKey(input: SpanTreeQueryInput) {
   return getQueryKey(api.tracesV2.spanTree, input, "query");
 }
 
+/**
+ * Ascending `(startTimeMs, spanId)` — the order pages arrive in and the order
+ * the assembled tree is kept in. SpanId ties break bytewise to match the
+ * ClickHouse `SpanId ASC` collation.
+ */
+function bySpanTreeOrder(a: SpanTreeNode, b: SpanTreeNode): number {
+  if (a.startTimeMs !== b.startTimeMs) return a.startTimeMs - b.startTimeMs;
+  return a.spanId < b.spanId ? -1 : a.spanId > b.spanId ? 1 : 0;
+}
+
 export async function fetchSpanTreePages({
   utils,
   input,
@@ -45,28 +62,45 @@ export async function fetchSpanTreePages({
   signal?: AbortSignal;
   onPage?: (nodes: SpanTreeNode[]) => void;
 }): Promise<SpanTreeNode[]> {
-  const nodes: SpanTreeNode[] = [];
+  // Accumulate by spanId, last write wins: pages are keyed by
+  // (startTimeMs, spanId), so a span re-emitted with a corrected start time
+  // mid-walk could land on two pages — deduping here keeps it a single
+  // waterfall row (and a single React key).
+  const nodesById = new Map<string, SpanTreeNode>();
+  // Vanilla-client queries, not `utils.….fetch`: the abort signal reaches
+  // the in-flight HTTP request (closing the drawer cancels mid-page, not
+  // just between pages), and no throwaway per-page React Query cache
+  // entries are created — the assembled tree lives under the spanTree key.
+  //
+  // Dot-path form with a pinned signature: the typed proxy
+  // (`createTRPCClientProxy`) cannot wrap this router (its `subscription`
+  // procedure collides with the proxy's reserved method names), and
+  // `utils.client.query`'s own generic is keyed to the empty v10 legacy
+  // `_def.queries` interop shape, so neither types this call natively.
+  const queryPage = utils.client.query.bind(utils.client) as (
+    path: "tracesV2.spanTreePaginated",
+    input: SpanTreeQueryInput & { limit: number; cursor?: SpanTreeCursor },
+    opts?: { signal?: AbortSignal },
+  ) => Promise<RouterOutputs["tracesV2"]["spanTreePaginated"]>;
   let cursor: SpanTreeCursor | undefined;
   for (;;) {
     if (signal?.aborted) {
       throw new DOMException("span tree fetch aborted", "AbortError");
     }
-    const page = await utils.tracesV2.spanTreePaginated.fetch(
+    const page = await queryPage(
+      "tracesV2.spanTreePaginated",
       { ...input, limit: SPAN_TREE_PAGE_SIZE, cursor },
-      // Pages are throwaway transport: the assembled tree lives under the
-      // spanTree key, so don't keep per-page cache entries around (for a
-      // 100k-span trace they would double the client-side footprint).
-      { cacheTime: 0 },
+      { signal },
     );
     if (signal?.aborted) {
       throw new DOMException("span tree fetch aborted", "AbortError");
     }
-    nodes.push(...page.nodes);
+    for (const node of page.nodes) nodesById.set(node.spanId, node);
     if (!page.nextCursor) break;
     cursor = page.nextCursor;
-    onPage?.([...nodes]);
+    onPage?.([...nodesById.values()]);
   }
-  return nodes;
+  return [...nodesById.values()];
 }
 
 /**
@@ -97,4 +131,57 @@ export function spanTreeQueryFn({
         queryClient.setQueryData(queryKey, partial);
       },
     });
+}
+
+/**
+ * Lower bound for the live-delta poll over a loaded tree: 1ms before the
+ * newest span start. `spanTreeDelta` filters `StartTime > since` at sub-ms
+ * precision while tree rows carry ms-truncated times, so polling from the
+ * exact high-water mark could permanently miss a span that started later
+ * within the same millisecond; backing off 1ms re-fetches the boundary rows
+ * instead, and {@link mergeSpanTreeDelta} dedupes them. 0 for an empty tree,
+ * so a live trace whose spans haven't been ingested yet still picks them up.
+ */
+export function spanTreeDeltaSinceMs(nodes: SpanTreeNode[]): number {
+  let highWaterMs: number | undefined;
+  for (const node of nodes) {
+    if (highWaterMs === undefined || node.startTimeMs > highWaterMs) {
+      highWaterMs = node.startTimeMs;
+    }
+  }
+  return highWaterMs === undefined ? 0 : Math.max(0, highWaterMs - 1);
+}
+
+/** Every field of SpanTreeNode is a scalar (or null), so shallow works. */
+function sameNode(a: SpanTreeNode, b: SpanTreeNode): boolean {
+  if (a === b) return true;
+  const keysA = Object.keys(a) as (keyof SpanTreeNode)[];
+  const keysB = Object.keys(b) as (keyof SpanTreeNode)[];
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every((key) => a[key] === b[key]);
+}
+
+/**
+ * Merges a `spanTreeDelta` result into the assembled tree: dedupes by spanId
+ * (a delta row is the span's latest version, so it wins), keeps the tree in
+ * `(startTimeMs, spanId)` order, and returns the SAME array reference when
+ * nothing actually changed — the delta poll re-fetches boundary rows every
+ * cycle, and an unchanged reference keeps React Query consumers from
+ * re-rendering on quiet polls.
+ */
+export function mergeSpanTreeDelta(
+  existing: SpanTreeNode[],
+  delta: SpanTreeNode[],
+): SpanTreeNode[] {
+  if (delta.length === 0) return existing;
+  const byId = new Map(existing.map((node) => [node.spanId, node]));
+  let changed = false;
+  for (const node of delta) {
+    const prev = byId.get(node.spanId);
+    if (prev !== undefined && sameNode(prev, node)) continue;
+    byId.set(node.spanId, node);
+    changed = true;
+  }
+  if (!changed) return existing;
+  return [...byId.values()].sort(bySpanTreeOrder);
 }

--- a/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
+++ b/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
@@ -58,6 +58,9 @@ export async function fetchSpanTreePages({
       // 100k-span trace they would double the client-side footprint).
       { cacheTime: 0 },
     );
+    if (signal?.aborted) {
+      throw new DOMException("span tree fetch aborted", "AbortError");
+    }
     nodes.push(...page.nodes);
     if (!page.nextCursor) break;
     cursor = page.nextCursor;

--- a/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
+++ b/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
@@ -67,6 +67,15 @@ export async function fetchSpanTreePages({
   // mid-walk could land on two pages — deduping here keeps it a single
   // waterfall row (and a single React key).
   const nodesById = new Map<string, SpanTreeNode>();
+  // Pages arrive in (startTimeMs, spanId) order, and `Map.set` keeps an
+  // updated key at its original position — so the assembled tree only falls
+  // out of order when a later page re-emits a span (corrected start time).
+  // Track that case instead of unconditionally re-sorting per page.
+  let needsSort = false;
+  const materialize = () => {
+    const nodes = [...nodesById.values()];
+    return needsSort ? nodes.sort(bySpanTreeOrder) : nodes;
+  };
   // Vanilla-client queries, not `utils.….fetch`: the abort signal reaches
   // the in-flight HTTP request (closing the drawer cancels mid-page, not
   // just between pages), and no throwaway per-page React Query cache
@@ -95,12 +104,15 @@ export async function fetchSpanTreePages({
     if (signal?.aborted) {
       throw new DOMException("span tree fetch aborted", "AbortError");
     }
-    for (const node of page.nodes) nodesById.set(node.spanId, node);
+    for (const node of page.nodes) {
+      if (nodesById.has(node.spanId)) needsSort = true;
+      nodesById.set(node.spanId, node);
+    }
     if (!page.nextCursor) break;
     cursor = page.nextCursor;
-    onPage?.([...nodesById.values()]);
+    onPage?.(materialize());
   }
-  return [...nodesById.values()];
+  return materialize();
 }
 
 /**

--- a/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
+++ b/langwatch/src/features/traces-v2/hooks/spanTreePagedQuery.ts
@@ -1,0 +1,97 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { getQueryKey } from "@trpc/react-query";
+import type {
+  SpanTreeCursor,
+  SpanTreeNode,
+} from "~/server/api/routers/tracesV2.schemas";
+import { api } from "~/utils/api";
+
+/**
+ * Traces can carry 20k–100k+ spans, so the span tree is never fetched as a
+ * single response. The tRPC `spanTree` procedure remains the cache-key anchor
+ * — preview-mode seeding, SSE invalidation, refresh, and close-time cancel all
+ * go through `utils.tracesV2.spanTree` — but nothing fetches through it any
+ * more: the query function built here pages through `spanTreePaginated` and
+ * assembles the tree client-side, publishing pages progressively so the
+ * waterfall starts painting after the first page.
+ */
+export const SPAN_TREE_PAGE_SIZE = 500;
+
+export interface SpanTreeQueryInput {
+  projectId: string;
+  traceId: string;
+  occurredAtMs?: number;
+}
+
+type TrpcUtils = ReturnType<typeof api.useUtils>;
+
+/**
+ * React Query key of the assembled span tree — identical to the key the tRPC
+ * `spanTree.useQuery` hook would produce, so setData / invalidate / cancel via
+ * `utils.tracesV2.spanTree` keep operating on the same cache entry.
+ */
+export function spanTreeQueryKey(input: SpanTreeQueryInput) {
+  return getQueryKey(api.tracesV2.spanTree, input, "query");
+}
+
+export async function fetchSpanTreePages({
+  utils,
+  input,
+  signal,
+  onPage,
+}: {
+  utils: TrpcUtils;
+  input: SpanTreeQueryInput;
+  signal?: AbortSignal;
+  onPage?: (nodes: SpanTreeNode[]) => void;
+}): Promise<SpanTreeNode[]> {
+  const nodes: SpanTreeNode[] = [];
+  let cursor: SpanTreeCursor | undefined;
+  for (;;) {
+    if (signal?.aborted) {
+      throw new DOMException("span tree fetch aborted", "AbortError");
+    }
+    const page = await utils.tracesV2.spanTreePaginated.fetch(
+      { ...input, limit: SPAN_TREE_PAGE_SIZE, cursor },
+      // Pages are throwaway transport: the assembled tree lives under the
+      // spanTree key, so don't keep per-page cache entries around (for a
+      // 100k-span trace they would double the client-side footprint).
+      { cacheTime: 0 },
+    );
+    nodes.push(...page.nodes);
+    if (!page.nextCursor) break;
+    cursor = page.nextCursor;
+    onPage?.([...nodes]);
+  }
+  return nodes;
+}
+
+/**
+ * Query function for the span-tree cache entry. Progressive publishing only
+ * kicks in while the entry is smaller than what has been fetched — during a
+ * refetch (SSE invalidation, refresh) the cache still holds the full previous
+ * tree, and publishing a smaller partial would collapse the waterfall and
+ * re-grow it page by page.
+ */
+export function spanTreeQueryFn({
+  utils,
+  queryClient,
+  input,
+}: {
+  utils: TrpcUtils;
+  queryClient: QueryClient;
+  input: SpanTreeQueryInput;
+}) {
+  const queryKey = spanTreeQueryKey(input);
+  return ({ signal }: { signal?: AbortSignal }) =>
+    fetchSpanTreePages({
+      utils,
+      input,
+      signal,
+      onPage: (partial) => {
+        const existing = queryClient.getQueryData<SpanTreeNode[]>(queryKey);
+        if (existing && existing.length >= partial.length) return;
+        queryClient.setQueryData(queryKey, partial);
+      },
+    });
+}

--- a/langwatch/src/features/traces-v2/hooks/useOpenTraceDrawer.ts
+++ b/langwatch/src/features/traces-v2/hooks/useOpenTraceDrawer.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -11,6 +12,7 @@ import {
 } from "../onboarding/data/samplePreviewTraces";
 import { useDrawerStore } from "../stores/drawerStore";
 import type { TraceListItem } from "../types/trace";
+import { spanTreeQueryFn, spanTreeQueryKey } from "./spanTreePagedQuery";
 
 function listItemToHeader(item: TraceListItem): TraceHeader {
   return {
@@ -58,6 +60,7 @@ export function useOpenTraceDrawer() {
   const { openDrawer } = useDrawer();
   const { project } = useOrganizationTeamProject();
   const utils = api.useContext();
+  const queryClient = useQueryClient();
 
   return useCallback(
     (trace: TraceListItem) => {
@@ -224,7 +227,13 @@ export function useOpenTraceDrawer() {
         // fetch the cache tokens never appear until a hard refresh. staleTime:0
         // pulls the full header (with attributes) immediately, behind the seed.
         void utils.tracesV2.header.prefetch(input, { staleTime: 0 });
-        void utils.tracesV2.spanTree.prefetch(input, opts);
+        // Same key + queryFn as `useSpanTree`, so the drawer's mount joins
+        // this in-flight paged fetch instead of firing a second one.
+        void queryClient.prefetchQuery({
+          queryKey: spanTreeQueryKey(input),
+          queryFn: spanTreeQueryFn({ utils, queryClient, input }),
+          ...opts,
+        });
         void utils.tracesV2.spanLangwatchSignals.prefetch(input, opts);
         void utils.tracesV2.traceEvents.prefetch(input, opts);
         void utils.tracesV2.resourceInfo.prefetch(input, opts);
@@ -254,6 +263,6 @@ export function useOpenTraceDrawer() {
         t: String(trace.timestamp),
       });
     },
-    [openDrawer, project?.id, utils],
+    [openDrawer, project?.id, utils, queryClient],
   );
 }

--- a/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
+++ b/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
@@ -58,10 +58,19 @@ export function useSpanTree() {
       sinceStartTimeMs: tree !== undefined ? spanTreeDeltaSinceMs(tree) : 0,
     },
     {
-      // Gated on the tree having loaded: until then the main query's own
-      // fetch (and its retries) is the source of truth, and there is no
-      // high-water mark to poll from.
-      enabled: isReady && isLive && !sseConnected && tree !== undefined,
+      // Gated on the walk having FINISHED, not merely on `tree` being
+      // defined: progressive publishing sets the cache entry after page 1, so
+      // a mid-walk poll would take its high-water mark from a partial tree and
+      // ask for every span after it — one response of up to
+      // MAX_LIGHT_SPAN_READ_ROWS, i.e. exactly the unbounded fetch paging
+      // exists to avoid. Until the walk lands, the main query is the source of
+      // truth (and its retries have no high-water mark to poll from anyway).
+      enabled:
+        isReady &&
+        isLive &&
+        !sseConnected &&
+        tree !== undefined &&
+        !treeQuery.isFetching,
       refetchInterval: LIVE_REFETCH_MS,
       // Deltas are throwaway transport into the spanTree cache entry —
       // don't retain per-poll entries of their own.

--- a/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
+++ b/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
@@ -1,6 +1,8 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "~/utils/api";
 import { LIVE_REFETCH_MS } from "../constants/freshness";
 import { useSseStatusStore } from "../stores/sseStatusStore";
+import { spanTreeQueryFn, spanTreeQueryKey } from "./spanTreePagedQuery";
 import { useTraceQueryArgs } from "./useTraceQueryArgs";
 
 export function useSpanTree() {
@@ -12,12 +14,20 @@ export function useSpanTree() {
   const sseConnected = useSseStatusStore(
     (s) => s.sseConnectionState === "connected",
   );
+  const utils = api.useUtils();
+  const queryClient = useQueryClient();
 
-  return api.tracesV2.spanTree.useQuery(queryArgs, {
-    // Disable the real tRPC fetch when the traceId is a
-    // preview-mode synthetic — `useOpenTraceDrawer` has already
-    // seeded the cache with hand-crafted span data; firing a real
-    // request would just return empty and clobber the seed.
+  // Raw useQuery on the tRPC `spanTree` key: the cache entry (and all the
+  // seeding / invalidation machinery pointed at it) is unchanged, but the
+  // fetch pages through `spanTreePaginated` so huge traces stream in page
+  // by page instead of arriving as one unbounded response.
+  return useQuery({
+    queryKey: spanTreeQueryKey(queryArgs),
+    queryFn: spanTreeQueryFn({ utils, queryClient, input: queryArgs }),
+    // Disable the real fetch when the traceId is a preview-mode
+    // synthetic — `useOpenTraceDrawer` has already seeded the cache
+    // with hand-crafted span data; firing a real request would just
+    // return empty and clobber the seed.
     enabled: isReady,
     staleTime: 300_000,
     cacheTime: 1_800_000,

--- a/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
+++ b/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
 import { api } from "~/utils/api";
 import { LIVE_REFETCH_MS } from "../constants/freshness";
@@ -13,10 +14,11 @@ import { useTraceQueryArgs } from "./useTraceQueryArgs";
 
 export function useSpanTree() {
   const { isLive, isReady, queryArgs } = useTraceQueryArgs();
-  // `useTraceFreshness` invalidates `tracesV2.spanTree` on every
-  // `trace_updated` SSE event for the open trace — when SSE is healthy
-  // the cache is kept fresh push-style and any timed refetch is pure
-  // duplication. Poll only when SSE is off (paused / disconnected).
+  // SSE health decides the delta poll's CADENCE, not whether it runs at all.
+  // While SSE is up, `useTraceFreshness` invalidates the delta on each
+  // `span.stored` event and the merge happens push-style, so a timer would be
+  // pure duplication; while SSE is down there is nothing to push, so it falls
+  // back to an interval.
   const sseConnected = useSseStatusStore(
     (s) => s.sseConnectionState === "connected",
   );
@@ -41,21 +43,20 @@ export function useSpanTree() {
     refetchOnWindowFocus: true,
   });
 
-  // Live fallback while SSE is down: poll `spanTreeDelta` from the loaded
-  // tree's high-water mark and merge new spans in place. Re-running the
-  // tree query instead would restart the whole page walk every interval —
-  // hundreds of requests per poll on exactly the huge live traces paging
-  // exists for. Trade-off: a span re-emitted with an *earlier* corrected
-  // start time is invisible to the delta filter until SSE reconnects and
-  // its invalidation re-walks the full tree.
-  // `keepPreviousData` means `data` can briefly be the PREVIOUS trace's
-  // tree right after a trace switch — its high-water mark would make the
-  // delta poll skip this trace's spans, so wait for current data.
+  // Live updates arrive as deltas merged into the assembled tree, never as a
+  // re-walk: re-running the tree query would restart the whole page walk —
+  // `ceil(N/500)` sequential requests on exactly the huge live traces paging
+  // exists for. This is the single update path for both SSE states; only the
+  // trigger differs (SSE event vs. interval, see `refetchInterval` below).
+  //
+  // `keepPreviousData` means `data` can briefly be the PREVIOUS trace's tree
+  // right after a trace switch — its high-water mark would make the delta
+  // poll skip this trace's spans, so wait for current data.
   const tree = treeQuery.isPreviousData ? undefined : treeQuery.data;
   api.tracesV2.spanTreeDelta.useQuery(
     {
       ...queryArgs,
-      sinceStartTimeMs: tree !== undefined ? spanTreeDeltaSinceMs(tree) : 0,
+      sinceUpdatedAtMs: tree !== undefined ? spanTreeDeltaSinceMs(tree) : 0,
     },
     {
       // Gated on the walk having FINISHED, not merely on `tree` being
@@ -66,12 +67,10 @@ export function useSpanTree() {
       // exists to avoid. Until the walk lands, the main query is the source of
       // truth (and its retries have no high-water mark to poll from anyway).
       enabled:
-        isReady &&
-        isLive &&
-        !sseConnected &&
-        tree !== undefined &&
-        !treeQuery.isFetching,
-      refetchInterval: LIVE_REFETCH_MS,
+        isReady && isLive && tree !== undefined && !treeQuery.isFetching,
+      // Only when SSE can't push. With SSE up, `useTraceFreshness` invalidates
+      // this query per `span.stored` batch, which refetches it on the spot.
+      refetchInterval: sseConnected ? false : LIVE_REFETCH_MS,
       // Deltas are throwaway transport into the spanTree cache entry —
       // don't retain per-poll entries of their own.
       cacheTime: 0,
@@ -84,6 +83,30 @@ export function useSpanTree() {
       },
     },
   );
+
+  // One catch-up delta when SSE comes back. While it was down the interval
+  // was doing the polling; once it reconnects the interval stops and updates
+  // arrive as events — but a span that landed between the final poll and the
+  // reconnect produces no event of its own, so without this it would sit
+  // unseen until the next unrelated batch (or forever, on a trace that just
+  // finished). The high-water mark makes this exact, not a re-walk.
+  const wasSseConnected = useRef(sseConnected);
+  useEffect(() => {
+    const reconnected = sseConnected && !wasSseConnected.current;
+    wasSseConnected.current = sseConnected;
+    if (!reconnected || !isReady || !isLive) return;
+    void utils.tracesV2.spanTreeDelta.invalidate({
+      projectId: queryArgs.projectId,
+      traceId: queryArgs.traceId,
+    });
+  }, [
+    sseConnected,
+    isReady,
+    isLive,
+    utils,
+    queryArgs.projectId,
+    queryArgs.traceId,
+  ]);
 
   return treeQuery;
 }

--- a/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
+++ b/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
@@ -1,8 +1,14 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
 import { api } from "~/utils/api";
 import { LIVE_REFETCH_MS } from "../constants/freshness";
 import { useSseStatusStore } from "../stores/sseStatusStore";
-import { spanTreeQueryFn, spanTreeQueryKey } from "./spanTreePagedQuery";
+import {
+  mergeSpanTreeDelta,
+  spanTreeDeltaSinceMs,
+  spanTreeQueryFn,
+  spanTreeQueryKey,
+} from "./spanTreePagedQuery";
 import { useTraceQueryArgs } from "./useTraceQueryArgs";
 
 export function useSpanTree() {
@@ -21,7 +27,7 @@ export function useSpanTree() {
   // seeding / invalidation machinery pointed at it) is unchanged, but the
   // fetch pages through `spanTreePaginated` so huge traces stream in page
   // by page instead of arriving as one unbounded response.
-  return useQuery({
+  const treeQuery = useQuery({
     queryKey: spanTreeQueryKey(queryArgs),
     queryFn: spanTreeQueryFn({ utils, queryClient, input: queryArgs }),
     // Disable the real fetch when the traceId is a preview-mode
@@ -33,6 +39,39 @@ export function useSpanTree() {
     cacheTime: 1_800_000,
     keepPreviousData: true,
     refetchOnWindowFocus: true,
-    refetchInterval: isLive && !sseConnected ? LIVE_REFETCH_MS : false,
   });
+
+  // Live fallback while SSE is down: poll `spanTreeDelta` from the loaded
+  // tree's high-water mark and merge new spans in place. Re-running the
+  // tree query instead would restart the whole page walk every interval —
+  // hundreds of requests per poll on exactly the huge live traces paging
+  // exists for. Trade-off: a span re-emitted with an *earlier* corrected
+  // start time is invisible to the delta filter until SSE reconnects and
+  // its invalidation re-walks the full tree.
+  const tree = treeQuery.data;
+  api.tracesV2.spanTreeDelta.useQuery(
+    {
+      ...queryArgs,
+      sinceStartTimeMs: tree !== undefined ? spanTreeDeltaSinceMs(tree) : 0,
+    },
+    {
+      // Gated on the tree having loaded: until then the main query's own
+      // fetch (and its retries) is the source of truth, and there is no
+      // high-water mark to poll from.
+      enabled: isReady && isLive && !sseConnected && tree !== undefined,
+      refetchInterval: LIVE_REFETCH_MS,
+      // Deltas are throwaway transport into the spanTree cache entry —
+      // don't retain per-poll entries of their own.
+      cacheTime: 0,
+      onSuccess: (delta) => {
+        const queryKey = spanTreeQueryKey(queryArgs);
+        const existing = queryClient.getQueryData<SpanTreeNode[]>(queryKey);
+        if (!existing) return;
+        const merged = mergeSpanTreeDelta(existing, delta);
+        if (merged !== existing) queryClient.setQueryData(queryKey, merged);
+      },
+    },
+  );
+
+  return treeQuery;
 }

--- a/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
+++ b/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
@@ -48,7 +48,10 @@ export function useSpanTree() {
   // exists for. Trade-off: a span re-emitted with an *earlier* corrected
   // start time is invisible to the delta filter until SSE reconnects and
   // its invalidation re-walks the full tree.
-  const tree = treeQuery.data;
+  // `keepPreviousData` means `data` can briefly be the PREVIOUS trace's
+  // tree right after a trace switch — its high-water mark would make the
+  // delta poll skip this trace's spans, so wait for current data.
+  const tree = treeQuery.isPreviousData ? undefined : treeQuery.data;
   api.tracesV2.spanTreeDelta.useQuery(
     {
       ...queryArgs,

--- a/langwatch/src/features/traces-v2/hooks/useTraceFreshness.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceFreshness.ts
@@ -153,8 +153,17 @@ export function useTraceFreshness() {
       // refetchInterval can stay off while SSE is connected. The key
       // is scoped to `projectId` + `traceId` so only the open trace
       // is invalidated, not the entire CSR cache.
+      //
+      // The span tree is refreshed through `spanTreeDelta`, NOT by
+      // invalidating `spanTree` itself: the tree is assembled by walking
+      // `spanTreePaginated`, so invalidating it re-runs `ceil(N/500)`
+      // sequential page requests — ~200 on a 100k-span trace, which cannot
+      // finish inside the 2s debounce window, and `invalidateQueries`
+      // defaults to `cancelRefetch: true` so the next batch would abort and
+      // restart it before it ever landed. `useSpanTree` merges the delta into
+      // the same cache entry in place.
       const key = { projectId, traceId: openTraceId };
-      void trpcUtils.tracesV2.spanTree.invalidate(key);
+      void trpcUtils.tracesV2.spanTreeDelta.invalidate(key);
       void trpcUtils.tracesV2.spanDetail.invalidate(key);
       void trpcUtils.tracesV2.spanLangwatchSignals.invalidate(key);
       void trpcUtils.tracesV2.traceEvents.invalidate(key);

--- a/langwatch/src/features/traces-v2/hooks/useTraceSpanTree.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceSpanTree.ts
@@ -1,6 +1,8 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
 import { isPreviewTraceId } from "../onboarding/data/samplePreviewTraces";
+import { spanTreeQueryFn, spanTreeQueryKey } from "./spanTreePagedQuery";
 
 /**
  * Span tree for a specific trace. Used by table-row peek expansions and
@@ -14,14 +16,20 @@ import { isPreviewTraceId } from "../onboarding/data/samplePreviewTraces";
  * so the `stored_spans` read prunes to the trace's weekly partitions instead
  * of cold-scanning every partition (incl. S3). It is optional; callers that
  * don't have it fall back to the unconstrained scan.
+ *
+ * Fetches page by page via `spanTreePaginated` into the shared `spanTree`
+ * cache key — see `spanTreePagedQuery.ts`.
  */
 export function useTraceSpanTree(traceId: string, occurredAtMs?: number) {
   const { project } = useOrganizationTeamProject();
-  return api.tracesV2.spanTree.useQuery(
-    { projectId: project?.id ?? "", traceId, occurredAtMs },
-    {
-      enabled: !!project?.id && !!traceId && !isPreviewTraceId(traceId),
-      staleTime: 300_000,
-    },
-  );
+  const utils = api.useUtils();
+  const queryClient = useQueryClient();
+  const input = { projectId: project?.id ?? "", traceId, occurredAtMs };
+
+  return useQuery({
+    queryKey: spanTreeQueryKey(input),
+    queryFn: spanTreeQueryFn({ utils, queryClient, input }),
+    enabled: !!project?.id && !!traceId && !isPreviewTraceId(traceId),
+    staleTime: 300_000,
+  });
 }

--- a/langwatch/src/server/api/routers/__tests__/tracesV2.spanTreePage.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/tracesV2.spanTreePage.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { SpanSummaryRow } from "~/server/app-layer/traces/repositories/span-storage.repository";
+import { mapSpanSummaryPage } from "../tracesV2";
+
+const row = (spanId: string, startTimeMs: number): SpanSummaryRow => ({
+  spanId,
+  parentSpanId: null,
+  spanName: spanId,
+  durationMs: 1,
+  statusCode: null,
+  spanType: null,
+  model: null,
+  cost: null,
+  inputTokens: null,
+  outputTokens: null,
+  cacheReadTokens: null,
+  cacheCreationTokens: null,
+  startTimeMs,
+});
+
+describe("mapSpanSummaryPage", () => {
+  describe("when the repository reports more spans past the page", () => {
+    it("keys the next cursor off the page's last row", () => {
+      const page = mapSpanSummaryPage({
+        rows: [row("a", 1), row("b", 2)],
+        hasMore: true,
+      });
+
+      expect(page.nodes.map((n) => n.spanId)).toEqual(["a", "b"]);
+      expect(page.nextCursor).toEqual({ startTimeMs: 2, spanId: "b" });
+    });
+  });
+
+  describe("when the repository reports the trace exhausted", () => {
+    it("returns a null cursor even for a page that filled to the requested limit", () => {
+      const page = mapSpanSummaryPage({
+        rows: [row("a", 1), row("b", 2)],
+        hasMore: false,
+      });
+
+      expect(page.nextCursor).toBeNull();
+    });
+
+    it("returns a null cursor for an empty terminal page", () => {
+      const page = mapSpanSummaryPage({ rows: [], hasMore: false });
+
+      expect(page.nodes).toEqual([]);
+      expect(page.nextCursor).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/tracesV2.spanTreePage.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/tracesV2.spanTreePage.unit.test.ts
@@ -48,4 +48,12 @@ describe("mapSpanSummaryPage", () => {
       expect(page.nextCursor).toBeNull();
     });
   });
+
+  describe("when a repository breaks the hasMore-implies-rows invariant", () => {
+    it("fails loudly instead of silently truncating the walk with a null cursor", () => {
+      expect(() => mapSpanSummaryPage({ rows: [], hasMore: true })).toThrow(
+        /hasMore without any rows/,
+      );
+    });
+  });
 });

--- a/langwatch/src/server/api/routers/__tests__/tracesV2.spanTreePage.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/tracesV2.spanTreePage.unit.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import type { SpanSummaryRow } from "~/server/app-layer/traces/repositories/span-storage.repository";
 import { mapSpanSummaryPage } from "../tracesV2";
 
-const row = (spanId: string, startTimeMs: number): SpanSummaryRow => ({
+const row = (
+  spanId: string,
+  startTimeMs: number,
+  updatedAtMs = startTimeMs,
+): SpanSummaryRow => ({
   spanId,
   parentSpanId: null,
   spanName: spanId,
@@ -16,6 +20,7 @@ const row = (spanId: string, startTimeMs: number): SpanSummaryRow => ({
   cacheReadTokens: null,
   cacheCreationTokens: null,
   startTimeMs,
+  updatedAtMs,
 });
 
 describe("mapSpanSummaryPage", () => {

--- a/langwatch/src/server/api/routers/tracesV2.schemas.ts
+++ b/langwatch/src/server/api/routers/tracesV2.schemas.ts
@@ -166,6 +166,15 @@ const spanTreeNodeSchema = z.object({
   outputTokens: z.number().nullish(),
   cacheReadTokens: z.number().nullish(),
   cacheCreationTokens: z.number().nullish(),
+  /**
+   * Row version (ms) — when the span was last projected, NOT span timing.
+   * The live delta poll takes its high-water mark from this: `startTimeMs`
+   * never moves when a span is updated in place (end time, duration, status,
+   * cost), so it cannot serve as the mark. `.nullish()` for preview-mode
+   * fixtures that carry no version — the mark then reads as 0 and corrects
+   * itself on the first server-sourced row.
+   */
+  updatedAtMs: z.number().nullish(),
 });
 
 export type SpanTreeNode = z.infer<typeof spanTreeNodeSchema>;

--- a/langwatch/src/server/api/routers/tracesV2.schemas.ts
+++ b/langwatch/src/server/api/routers/tracesV2.schemas.ts
@@ -177,8 +177,10 @@ export type SpanTreeNode = z.infer<typeof spanTreeNodeSchema>;
  * pages stay stable while spans are still being ingested.
  */
 export const spanTreeCursorSchema = z.object({
-  startTimeMs: z.number(),
-  spanId: z.string(),
+  // Bound to a ClickHouse Int64 param — reject Infinity / floats / negatives
+  // so a hand-crafted cursor can't turn into an unparseable bind and a 500.
+  startTimeMs: z.number().int().min(0),
+  spanId: z.string().min(1).max(128),
 });
 
 export type SpanTreeCursor = z.infer<typeof spanTreeCursorSchema>;

--- a/langwatch/src/server/api/routers/tracesV2.schemas.ts
+++ b/langwatch/src/server/api/routers/tracesV2.schemas.ts
@@ -171,6 +171,19 @@ const spanTreeNodeSchema = z.object({
 export type SpanTreeNode = z.infer<typeof spanTreeNodeSchema>;
 
 /**
+ * Cursor for the paged span-tree read (`tracesV2.spanTreePaginated`): the
+ * next page starts strictly after `(startTimeMs, spanId)` in
+ * `(StartTimeMs ASC, SpanId ASC)` order. Keyed rather than offset-based so
+ * pages stay stable while spans are still being ingested.
+ */
+export const spanTreeCursorSchema = z.object({
+  startTimeMs: z.number(),
+  spanId: z.string(),
+});
+
+export type SpanTreeCursor = z.infer<typeof spanTreeCursorSchema>;
+
+/**
  * Per-span LangWatch instrumentation signals — fetched via
  * `tracesV2.spanLangwatchSignals` as a separate, secondary call so the
  * primary span tree query stays cheap. Keys correspond to attribute-prefix

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -187,6 +187,14 @@ export function mapSpanSummaryPage(page: SpanSummaryPage): {
   nextCursor: SpanTreeCursor | null;
 } {
   const last = page.hasMore ? page.rows.at(-1) : undefined;
+  if (page.hasMore && !last) {
+    // A null cursor here would read as end-of-trace and silently drop every
+    // remaining span — fail loudly instead if a repository ever breaks the
+    // "hasMore implies rows" invariant.
+    throw new Error(
+      "span-summary page reported hasMore without any rows to key the cursor from",
+    );
+  }
   return {
     nodes: page.rows.map(mapSpanSummaryToTreeNode),
     nextCursor: last

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -60,10 +60,12 @@ import type {
   ContentPrivacy,
   SpanDetail,
   SpanLangwatchSignals,
+  SpanTreeCursor,
   SpanTreeNode,
   TraceHeader,
   TraceResourceInfoDto,
 } from "./tracesV2.schemas";
+import { spanTreeCursorSchema } from "./tracesV2.schemas";
 
 // ---------------------------------------------------------------------------
 // Shared input fragments
@@ -1220,30 +1222,48 @@ export const tracesV2Router = createTRPCRouter({
       );
     }),
 
+  /**
+   * One page of the span tree in `(startTimeMs, spanId)` order. This is the
+   * only fetch path the frontend uses for span trees — traces can carry
+   * 20k–100k+ spans, so the client assembles the tree page by page (see
+   * `spanTreePagedQuery.ts`) instead of ever pulling it in one response.
+   * `nextCursor` is null on the final page.
+   */
   spanTreePaginated: protectedProcedure
     .input(
       z.object({
         projectId: z.string(),
         traceId: z.string(),
         limit: z.number().int().min(1).max(1000).default(200),
-        offset: z.number().int().min(0).default(0),
+        cursor: spanTreeCursorSchema.optional(),
         ...spanReadHintShape,
       }),
     )
     .use(checkProjectPermission("traces:view"))
     .query(
-      async ({ input }): Promise<{ nodes: SpanTreeNode[]; total: number }> => {
+      async ({
+        input,
+      }): Promise<{
+        nodes: SpanTreeNode[];
+        nextCursor: SpanTreeCursor | null;
+      }> => {
         const app = getApp();
-        const result = await app.traces.spans.getSpanSummariesPaginated({
+        const rows = await app.traces.spans.getSpanSummariesPage({
           tenantId: input.projectId,
           traceId: input.traceId,
           limit: input.limit,
-          offset: input.offset,
+          cursor: input.cursor,
           ...occurredAtFromInput(input),
         });
+        // A short page means the trace is exhausted. A full page may be too
+        // (exact multiple of `limit`) — the follow-up fetch returns empty and
+        // closes the loop.
+        const last = rows.length === input.limit ? rows.at(-1) : undefined;
         return {
-          nodes: result.rows.map(mapSpanSummaryToTreeNode),
-          total: result.total,
+          nodes: rows.map(mapSpanSummaryToTreeNode),
+          nextCursor: last
+            ? { startTimeMs: last.startTimeMs, spanId: last.spanId }
+            : null,
         };
       },
     ),
@@ -1269,6 +1289,14 @@ export const tracesV2Router = createTRPCRouter({
       return rows.map(mapSpanSummaryToTreeNode);
     }),
 
+  /**
+   * Whole-tree read in one response. The frontend no longer fetches through
+   * this — `useSpanTree` pages via `spanTreePaginated` under the same React
+   * Query key, and this procedure remains as that cache entry's type/key
+   * anchor (preview seeding, SSE invalidation, cancel). The underlying read
+   * is bounded (`MAX_LIGHT_SPAN_READ_ROWS`) so a direct call can never
+   * materialize a 100k-span trace in one shot.
+   */
   spanTree: protectedProcedure
     .input(
       z.object({

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -13,7 +13,10 @@ import { deriveTraceStatus } from "~/server/app-layer/traces/derive-trace-status
 import { TraceNotFoundError } from "~/server/app-layer/traces/errors";
 import { translateFilterToClickHouse } from "~/server/app-layer/traces/filter-to-clickhouse";
 import { deriveUnmappedCostSuggestion } from "~/server/app-layer/traces/model-cost-span-preview.service";
-import type { SpanSummaryRow } from "~/server/app-layer/traces/repositories/span-storage.repository";
+import type {
+  SpanSummaryPage,
+  SpanSummaryRow,
+} from "~/server/app-layer/traces/repositories/span-storage.repository";
 import {
   traceMetadataUpdateSchema,
   updateTraceMetadata,
@@ -170,6 +173,25 @@ function mapTraceSummaryToHeader(summary: TraceSummaryData): TraceHeader {
     lastUsedPromptVersionId: summary.lastUsedPromptVersionId ?? null,
     lastUsedPromptSpanId: summary.lastUsedPromptSpanId ?? null,
     attributes: summary.attributes,
+  };
+}
+
+/**
+ * Maps one repository span-summary page onto the wire shape of
+ * `tracesV2.spanTreePaginated`. `nextCursor` comes from the repository's
+ * over-fetch-derived `hasMore` — never from comparing the page length to the
+ * requested limit, which would misread a repository-clamped page as final.
+ */
+export function mapSpanSummaryPage(page: SpanSummaryPage): {
+  nodes: SpanTreeNode[];
+  nextCursor: SpanTreeCursor | null;
+} {
+  const last = page.hasMore ? page.rows.at(-1) : undefined;
+  return {
+    nodes: page.rows.map(mapSpanSummaryToTreeNode),
+    nextCursor: last
+      ? { startTimeMs: last.startTimeMs, spanId: last.spanId }
+      : null,
   };
 }
 
@@ -1248,23 +1270,14 @@ export const tracesV2Router = createTRPCRouter({
         nextCursor: SpanTreeCursor | null;
       }> => {
         const app = getApp();
-        const rows = await app.traces.spans.getSpanSummariesPage({
+        const page = await app.traces.spans.getSpanSummariesPage({
           tenantId: input.projectId,
           traceId: input.traceId,
           limit: input.limit,
           cursor: input.cursor,
           ...occurredAtFromInput(input),
         });
-        // A short page means the trace is exhausted. A full page may be too
-        // (exact multiple of `limit`) — the follow-up fetch returns empty and
-        // closes the loop.
-        const last = rows.length === input.limit ? rows.at(-1) : undefined;
-        return {
-          nodes: rows.map(mapSpanSummaryToTreeNode),
-          nextCursor: last
-            ? { startTimeMs: last.startTimeMs, spanId: last.spanId }
-            : null,
-        };
+        return mapSpanSummaryPage(page);
       },
     ),
 

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -223,6 +223,7 @@ function mapSpanSummaryToTreeNode(row: SpanSummaryRow): SpanTreeNode {
     outputTokens: row.outputTokens,
     cacheReadTokens: row.cacheReadTokens,
     cacheCreationTokens: row.cacheCreationTokens,
+    updatedAtMs: row.updatedAtMs,
   };
 }
 
@@ -1289,12 +1290,19 @@ export const tracesV2Router = createTRPCRouter({
       },
     ),
 
+  /**
+   * Spans of a live trace whose row version is newer than `sinceUpdatedAtMs`.
+   * Keyed on the row version rather than the span start so an in-place update
+   * (end time, duration, status, cost) is picked up too — the root span
+   * starts first and ends last, so a start-keyed delta left its duration, and
+   * with it the waterfall's time scale, frozen at first projection.
+   */
   spanTreeDelta: protectedProcedure
     .input(
       z.object({
         projectId: z.string(),
         traceId: z.string(),
-        sinceStartTimeMs: z.number(),
+        sinceUpdatedAtMs: z.number().int().min(0),
         ...spanReadHintShape,
       }),
     )
@@ -1304,7 +1312,7 @@ export const tracesV2Router = createTRPCRouter({
       const rows = await app.traces.spans.getSpanSummariesSince({
         tenantId: input.projectId,
         traceId: input.traceId,
-        sinceStartTimeMs: input.sinceStartTimeMs,
+        sinceUpdatedAtMs: input.sinceUpdatedAtMs,
         ...occurredAtFromInput(input),
       });
       return rows.map(mapSpanSummaryToTreeNode);

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -716,3 +716,165 @@ describe("SpanStorageClickHouseRepository per-span cost columns (integration)", 
     });
   });
 });
+
+// Cursor-paged span-summary walk. Own tenant/trace fixtures so page shapes
+// are deterministic and the heavy single-trace dataset above is untouched.
+const pageTenantId = `test-span-page-${nanoid()}`;
+
+function makePageSpanRow(
+  pageTraceId: string,
+  spanId: string,
+  startTime: Date,
+  overrides: Record<string, unknown> = {},
+): ReturnType<typeof makeSpanRow> {
+  return {
+    ...makeSpanRow(0, {
+      TenantId: pageTenantId,
+      TraceId: pageTraceId,
+      SpanId: spanId,
+      StartTime: startTime,
+      EndTime: new Date(startTime.getTime() + 50),
+      CreatedAt: startTime,
+      UpdatedAt: startTime,
+      SpanAttributes: { idx: spanId },
+      ...overrides,
+    }),
+  };
+}
+
+async function walkSpanSummaries(pageTraceId: string, limit: number) {
+  const pages: Awaited<
+    ReturnType<SpanStorageClickHouseRepository["findSpanSummariesPage"]>
+  >[] = [];
+  let cursor: { startTimeMs: number; spanId: string } | undefined;
+  for (;;) {
+    const page = await repo.findSpanSummariesPage({
+      tenantId: pageTenantId,
+      traceId: pageTraceId,
+      limit,
+      cursor,
+      occurredAtMs: base,
+    });
+    pages.push(page);
+    if (!page.hasMore) break;
+    const last = page.rows.at(-1);
+    if (!last) throw new Error("hasMore page returned no rows");
+    cursor = { startTimeMs: last.startTimeMs, spanId: last.spanId };
+  }
+  return pages;
+}
+
+describe("SpanStorageClickHouseRepository cursor-paged span summaries (integration)", () => {
+  const exactTraceId = `trace-${nanoid()}`;
+  const tieTraceId = `trace-${nanoid()}`;
+  const longTraceId = `trace-${nanoid()}`;
+  const EXACT_SPANS = 40;
+  const PAGE = 10;
+
+  beforeAll(async () => {
+    // Exact-multiple-of-page-size trace (40 spans / pages of 10), including a
+    // stale earlier version of one mid-trace span that dedup must not emit.
+    await insertRows(
+      Array.from({ length: EXACT_SPANS }, (_, i) =>
+        makePageSpanRow(exactTraceId, spanIdFor(i), new Date(base + i * 10)),
+      ),
+    );
+    await insertRows([
+      makePageSpanRow(exactTraceId, spanIdFor(25), new Date(base - 5_000), {
+        SpanAttributes: { idx: spanIdFor(25), stale: "yes" },
+      }),
+    ]);
+
+    // Four spans sharing one StartTime, so a page boundary falls between
+    // same-millisecond rows and only the SpanId tiebreak separates pages.
+    await insertRows(
+      ["tie-a", "tie-b", "tie-c", "tie-d"].map((spanId) =>
+        makePageSpanRow(tieTraceId, spanId, new Date(base + 500)),
+      ),
+    );
+
+    // Long-running trace: three spans near the occurredAt hint and two more
+    // three days later — past the hint's +2-day partition window.
+    await insertRows([
+      ...[0, 1, 2].map((i) =>
+        makePageSpanRow(longTraceId, `early-${i}`, new Date(base + i)),
+      ),
+      ...[0, 1].map((i) =>
+        makePageSpanRow(
+          longTraceId,
+          `late-${i}`,
+          new Date(base + 3 * 24 * 60 * 60 * 1000 + i),
+        ),
+      ),
+    ]);
+  }, 60_000);
+
+  describe("when walking a trace whose span count is an exact multiple of the page size", () => {
+    it("returns every span exactly once, in (startTimeMs, spanId) order, latest version only", async () => {
+      const pages = await walkSpanSummaries(exactTraceId, PAGE);
+
+      const all = pages.flatMap((p) => p.rows);
+      expect(all.map((r) => r.spanId)).toEqual(
+        Array.from({ length: EXACT_SPANS }, (_, i) => spanIdFor(i)),
+      );
+      // The stale version of span 25 must not surface as a duplicate or
+      // displace the live row's position.
+      expect(all.filter((r) => r.spanId === spanIdFor(25))).toHaveLength(1);
+    });
+
+    it("reports the final full page as terminal instead of requiring an empty follow-up fetch", async () => {
+      const pages = await walkSpanSummaries(exactTraceId, PAGE);
+
+      expect(pages).toHaveLength(EXACT_SPANS / PAGE);
+      expect(pages.map((p) => p.hasMore)).toEqual([true, true, true, false]);
+      expect(pages.every((p) => p.rows.length === PAGE)).toBe(true);
+    });
+  });
+
+  describe("when a page boundary falls between spans sharing a StartTime", () => {
+    it("the SpanId tiebreak neither skips nor duplicates the same-millisecond spans", async () => {
+      const pages = await walkSpanSummaries(tieTraceId, 2);
+
+      expect(pages.map((p) => p.rows.map((r) => r.spanId))).toEqual([
+        ["tie-a", "tie-b"],
+        ["tie-c", "tie-d"],
+      ]);
+    });
+  });
+
+  describe("when a long-running trace has spans past the occurredAt hint's window", () => {
+    it("the walk still reaches them instead of ending at the window edge", async () => {
+      const pages = await walkSpanSummaries(longTraceId, 2);
+
+      const all = pages.flatMap((p) => p.rows.map((r) => r.spanId));
+      expect(all).toEqual(["early-0", "early-1", "early-2", "late-0", "late-1"]);
+    });
+  });
+});
+
+describe("SpanStorageClickHouseRepository langwatch signals read (integration)", () => {
+  const signalsTraceId = `trace-${nanoid()}`;
+
+  beforeAll(async () => {
+    await insertRows([
+      makePageSpanRow(signalsTraceId, "sig-prompt", new Date(base), {
+        SpanAttributes: { "langwatch.prompt.id": "prompt-1" },
+      }),
+      makePageSpanRow(signalsTraceId, "sig-none", new Date(base + 1)),
+    ]);
+  }, 60_000);
+
+  describe("when a trace has spans carrying langwatch signal attributes", () => {
+    it("executes the capped, ordered scan and returns the signal buckets per span", async () => {
+      const rows = await repo.findLangwatchSignalsByTraceId({
+        tenantId: pageTenantId,
+        traceId: signalsTraceId,
+        occurredAtMs: base,
+      });
+
+      expect(rows).toEqual([
+        { spanId: "sig-prompt", signals: ["prompt"] },
+      ]);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
@@ -316,6 +316,7 @@ describe("SpanStorageClickHouseRepository span-summary pages", () => {
     CustomCacheCreationRate: "",
     LwSpanCost: "",
     StartTimeMs: startTimeMs,
+    UpdatedAtMs: startTimeMs,
   });
 
   function repoWithSpyClient(pages: SpanSummaryQueryRow[][] = [[]]) {
@@ -388,6 +389,36 @@ describe("SpanStorageClickHouseRepository span-summary pages", () => {
       );
       expect(sql).toContain("StartTime >=");
       expect(sql).not.toContain("StartTime <=");
+    });
+
+    it("keeps every cursor bound out of the dedup subquery so a page can't emit a stale span version", async () => {
+      // The subquery elects each span's latest version via max(UpdatedAt), so
+      // it has to see every version. Bounding it by the cursor's StartTime
+      // breaks that for a span re-emitted with a corrected EARLIER start: its
+      // latest version sorts below the bound, the inner scan elects an older
+      // one instead, and the outer tuple filter emits that stale row — which
+      // then wins the waterfall, the client deduping last-write-wins.
+      const { repo, query } = repoWithSpyClient([[summaryRow("s-2")]]);
+
+      await repo.findSpanSummariesPage({
+        tenantId: "p-1",
+        traceId: "t-1",
+        limit: 2,
+        cursor: { startTimeMs: 1_700_000_000_000, spanId: "s-1" },
+        occurredAtMs: Date.now(),
+      });
+
+      const sql = query.mock.calls[0]?.[0]?.query as string;
+      const dedupSubquery = sql.slice(
+        sql.indexOf("(TenantId, TraceId, SpanId, UpdatedAt) IN ("),
+      );
+      expect(dedupSubquery).toContain("max(UpdatedAt)");
+      expect(dedupSubquery).not.toContain("cursorStartTimeMs");
+      expect(dedupSubquery).not.toContain("cursorSpanId");
+      // The outer scan still restates it — that is what prunes partitions.
+      expect(sql).toContain(
+        "AND StartTime >= fromUnixTimestamp64Milli({cursorStartTimeMs:Int64})",
+      );
     });
 
     it("treats an empty cursor page as authoritative end-of-trace instead of rescanning unhinted", async () => {
@@ -496,11 +527,46 @@ describe("SpanStorageClickHouseRepository bounded light readers", () => {
       await repo.findSpanSummariesSince({
         tenantId: "p-1",
         traceId: "t-1",
-        sinceStartTimeMs: Date.now(),
+        sinceUpdatedAtMs: Date.now(),
       });
 
       expect(query.mock.calls[0]?.[0]?.query as string).toContain(
         `LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}`,
+      );
+    });
+
+    it("bounds on the row version, never the span start, so in-place updates are visible", async () => {
+      // A span updated in place (end time, duration, status, cost) keeps its
+      // StartTime. Bounding on StartTime would make the live poll structurally
+      // incapable of ever seeing it — the root span, which ends last, would
+      // stay frozen at its first projection.
+      const { repo, query } = repoWithSpyClient();
+      await repo.findSpanSummariesSince({
+        tenantId: "p-1",
+        traceId: "t-1",
+        sinceUpdatedAtMs: 1_700_000_000_000,
+      });
+
+      const sql = query.mock.calls[0]?.[0]?.query as string;
+      expect(sql).toContain(
+        "AND UpdatedAt > fromUnixTimestamp64Milli({sinceUpdatedAtMs:Int64})",
+      );
+      expect(sql).not.toContain("StartTime > fromUnixTimestamp64Milli");
+      expect(query.mock.calls[0]?.[0]?.query_params).toMatchObject({
+        sinceUpdatedAtMs: 1_700_000_000_000,
+      });
+    });
+
+    it("selects the row version so the client can advance its high-water mark", async () => {
+      const { repo, query } = repoWithSpyClient();
+      await repo.findSpanSummariesSince({
+        tenantId: "p-1",
+        traceId: "t-1",
+        sinceUpdatedAtMs: 0,
+      });
+
+      expect(query.mock.calls[0]?.[0]?.query as string).toContain(
+        "toUnixTimestamp64Milli(UpdatedAt) AS UpdatedAtMs",
       );
     });
   });
@@ -544,6 +610,7 @@ describe("mapSpanSummaryRow", () => {
     CustomCacheCreationRate: "",
     LwSpanCost: "",
     StartTimeMs: 1700000000000,
+    UpdatedAtMs: 1700000000000,
     ...overrides,
   });
 

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   clampSpanReadLimit,
   MAX_DERIVATION_SPANS,
+  MAX_LIGHT_SPAN_READ_ROWS,
 } from "../span-storage.repository";
 
 describe("serializeAttributes", () => {
@@ -226,6 +227,15 @@ describe("given a requested span-read limit", () => {
       expect(clampSpanReadLimit(Infinity)).toBe(MAX_DERIVATION_SPANS);
     });
   });
+
+  describe("when a caller supplies its own ceiling", () => {
+    it("clamps to that ceiling instead of the derivation default", () => {
+      expect(
+        clampSpanReadLimit(50_000, { max: MAX_LIGHT_SPAN_READ_ROWS }),
+      ).toBe(MAX_LIGHT_SPAN_READ_ROWS);
+      expect(clampSpanReadLimit(undefined, { max: 100 })).toBe(100);
+    });
+  });
 });
 
 describe("SpanStorageClickHouseRepository single-trace reads", () => {
@@ -278,6 +288,235 @@ describe("SpanStorageClickHouseRepository single-trace reads", () => {
 
       const settings = query.mock.calls[0]?.[0]?.clickhouse_settings;
       expect(settings?.max_memory_usage).toBe(String(2 * 1024 * 1024 * 1024));
+    });
+  });
+});
+
+describe("SpanStorageClickHouseRepository span-summary pages", () => {
+  const summaryRow = (
+    spanId: string,
+    startTimeMs = 1_700_000_000_000,
+  ): SpanSummaryQueryRow => ({
+    SpanId: spanId,
+    ParentSpanId: null,
+    SpanName: spanId,
+    DurationMs: 1,
+    StatusCode: null,
+    SpanType: "llm",
+    Model: "",
+    ResponseModel: "",
+    Cost: "",
+    InputTokens: "",
+    OutputTokens: "",
+    CacheReadTokens: "",
+    CacheCreationTokens: "",
+    CustomInputRate: "",
+    CustomOutputRate: "",
+    CustomCacheReadRate: "",
+    CustomCacheCreationRate: "",
+    LwSpanCost: "",
+    StartTimeMs: startTimeMs,
+  });
+
+  function repoWithSpyClient(pages: SpanSummaryQueryRow[][] = [[]]) {
+    const query = vi.fn();
+    for (const rows of pages) {
+      query.mockResolvedValueOnce({ json: async () => rows });
+    }
+    query.mockResolvedValue({ json: async () => [] });
+    const repo = new SpanStorageClickHouseRepository((async () => ({
+      query,
+    })) as unknown as ConstructorParameters<
+      typeof SpanStorageClickHouseRepository
+    >[0]);
+    return { repo, query };
+  }
+
+  describe("when a page fills to the requested limit and more spans exist", () => {
+    it("over-fetches one row to derive hasMore and returns only the page", async () => {
+      const { repo, query } = repoWithSpyClient([
+        [summaryRow("s-1"), summaryRow("s-2"), summaryRow("s-3")],
+      ]);
+
+      const page = await repo.findSpanSummariesPage({
+        tenantId: "p-1",
+        traceId: "t-1",
+        limit: 2,
+        occurredAtMs: Date.now(),
+      });
+
+      expect(query.mock.calls[0]?.[0]?.query_params?.limit).toBe(3);
+      expect(page.rows.map((r) => r.spanId)).toEqual(["s-1", "s-2"]);
+      expect(page.hasMore).toBe(true);
+    });
+  });
+
+  describe("when the page comes back short of the limit", () => {
+    it("reports hasMore false without any follow-up fetch", async () => {
+      const { repo, query } = repoWithSpyClient([
+        [summaryRow("s-1"), summaryRow("s-2")],
+      ]);
+
+      const page = await repo.findSpanSummariesPage({
+        tenantId: "p-1",
+        traceId: "t-1",
+        limit: 2,
+        occurredAtMs: Date.now(),
+      });
+
+      expect(page.rows).toHaveLength(2);
+      expect(page.hasMore).toBe(false);
+      expect(query).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when reading a cursor page", () => {
+    it("bounds StartTime from below only — an upper bound would truncate long-running traces at the hint window's edge", async () => {
+      const { repo, query } = repoWithSpyClient([[summaryRow("s-2")]]);
+
+      await repo.findSpanSummariesPage({
+        tenantId: "p-1",
+        traceId: "t-1",
+        limit: 2,
+        cursor: { startTimeMs: 1_700_000_000_000, spanId: "s-1" },
+        occurredAtMs: Date.now(),
+      });
+
+      const sql = query.mock.calls[0]?.[0]?.query as string;
+      expect(sql).toContain(
+        "(toUnixTimestamp64Milli(StartTime), SpanId) > ({cursorStartTimeMs:Int64}, {cursorSpanId:String})",
+      );
+      expect(sql).toContain("StartTime >=");
+      expect(sql).not.toContain("StartTime <=");
+    });
+
+    it("treats an empty cursor page as authoritative end-of-trace instead of rescanning unhinted", async () => {
+      const { repo, query } = repoWithSpyClient([[]]);
+
+      const page = await repo.findSpanSummariesPage({
+        tenantId: "p-1",
+        traceId: "t-1",
+        limit: 2,
+        cursor: { startTimeMs: 1_700_000_000_000, spanId: "s-1" },
+        occurredAtMs: Date.now(),
+      });
+
+      expect(page).toEqual({ rows: [], hasMore: false });
+      expect(query).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when reading the first page with an occurredAtMs hint", () => {
+    it("prunes partitions with the hint as a lower bound only", async () => {
+      const occurredAtMs = 1_700_000_000_000;
+      const { repo, query } = repoWithSpyClient([[summaryRow("s-1")]]);
+
+      await repo.findSpanSummariesPage({
+        tenantId: "p-1",
+        traceId: "t-1",
+        limit: 2,
+        occurredAtMs,
+      });
+
+      const call = query.mock.calls[0]?.[0];
+      expect(call?.query as string).toContain(
+        "StartTime >= fromUnixTimestamp64Milli({pageFromMs:Int64})",
+      );
+      expect(call?.query as string).not.toContain("StartTime <=");
+      expect(call?.query_params?.pageFromMs).toBe(
+        occurredAtMs - 2 * 24 * 60 * 60 * 1000,
+      );
+    });
+
+    it("retries unbounded when the hinted read is empty (stale or skewed hint)", async () => {
+      const { repo, query } = repoWithSpyClient([[], [summaryRow("s-1")]]);
+
+      const page = await repo.findSpanSummariesPage({
+        tenantId: "p-1",
+        traceId: "t-1",
+        limit: 2,
+        occurredAtMs: 1_700_000_000_000,
+      });
+
+      expect(query).toHaveBeenCalledTimes(2);
+      expect(query.mock.calls[1]?.[0]?.query as string).not.toContain(
+        "pageFromMs",
+      );
+      expect(page.rows.map((r) => r.spanId)).toEqual(["s-1"]);
+    });
+  });
+});
+
+describe("SpanStorageClickHouseRepository bounded light readers", () => {
+  function repoWithSpyClient() {
+    const query = vi.fn().mockResolvedValue({ json: async () => [] });
+    const repo = new SpanStorageClickHouseRepository((async () => ({
+      query,
+    })) as unknown as ConstructorParameters<
+      typeof SpanStorageClickHouseRepository
+    >[0]);
+    return { repo, query };
+  }
+
+  const byTrace = {
+    tenantId: "p-1",
+    traceId: "t-1",
+    occurredAtMs: Date.now(),
+  };
+
+  describe("when reading the whole-tree span summary anchor", () => {
+    it("caps the read at the light-row ceiling", async () => {
+      const { repo, query } = repoWithSpyClient();
+      await repo.getSpanSummaryByTraceId(byTrace);
+
+      expect(query.mock.calls[0]?.[0]?.query as string).toContain(
+        `LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}`,
+      );
+    });
+  });
+
+  describe("when reading per-span langwatch signals", () => {
+    it("caps the scan at the light-row ceiling, ordered by the raw StartTime column the subquery actually has", async () => {
+      const { repo, query } = repoWithSpyClient();
+      await repo.findLangwatchSignalsByTraceId(byTrace);
+
+      const sql = query.mock.calls[0]?.[0]?.query as string;
+      expect(sql).toContain(`LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}`);
+      // The signals subquery selects only SpanId + mapKeys(SpanAttributes);
+      // ordering by the StartTimeMs alias (which it never computes) makes
+      // ClickHouse reject the whole query with UNKNOWN_IDENTIFIER.
+      expect(sql).toContain("ORDER BY StartTime ASC");
+      expect(sql).not.toContain("ORDER BY StartTimeMs");
+    });
+  });
+
+  describe("when reading the span-summary delta since a high-water mark", () => {
+    it("caps the read at the light-row ceiling", async () => {
+      const { repo, query } = repoWithSpyClient();
+      await repo.findSpanSummariesSince({
+        tenantId: "p-1",
+        traceId: "t-1",
+        sinceStartTimeMs: Date.now(),
+      });
+
+      expect(query.mock.calls[0]?.[0]?.query as string).toContain(
+        `LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}`,
+      );
+    });
+  });
+
+  describe("when reading the full-span delta since a high-water mark", () => {
+    it("caps the read at the derivation ceiling", async () => {
+      const { repo, query } = repoWithSpyClient();
+      await repo.findSpansSince({
+        tenantId: "p-1",
+        traceId: "t-1",
+        sinceStartTimeMs: Date.now(),
+      });
+
+      expect(query.mock.calls[0]?.[0]?.query as string).toContain(
+        `LIMIT ${MAX_DERIVATION_SPANS}`,
+      );
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -219,7 +219,8 @@ const SUMMARY_SPAN_SELECT = `
   SpanAttributes['langwatch.model.cacheReadCostPerToken'] AS CustomCacheReadRate,
   SpanAttributes['langwatch.model.cacheCreationCostPerToken'] AS CustomCacheCreationRate,
   SpanAttributes['langwatch.span.cost'] AS LwSpanCost,
-  toUnixTimestamp64Milli(StartTime) AS StartTimeMs
+  toUnixTimestamp64Milli(StartTime) AS StartTimeMs,
+  toUnixTimestamp64Milli(UpdatedAt) AS UpdatedAtMs
 `;
 
 /**
@@ -288,9 +289,16 @@ function mapModelSpanSampleRow(
  * picks the latest version (max UpdatedAt) per spanId. Caller assembles the
  * surrounding `AND (TenantId, TraceId, SpanId, UpdatedAt) IN (…)`.
  *
- * Kept as a function so optional extra predicates (partition window,
- * sinceStartTimeMs) are applied symmetrically in inner + outer scopes —
- * essential because the dedup must see the same row set as the outer scan.
+ * Kept as a function so an optional extra predicate (the partition-hint
+ * window, or the `since` readers' row-version bound) can be applied to the
+ * inner scope as well as the outer.
+ *
+ * Only pass a predicate that a span's versions cannot straddle. The subquery
+ * elects each span's latest version, so it has to see every version: bound it
+ * by something a re-projection can move — a span's StartTime, say — and it
+ * will elect a stale version whose row the outer filter then emits. This is
+ * why the span-tree cursor's `StartTime >=` bound is deliberately NOT passed
+ * in (see `findSpanSummariesPage`).
  */
 function dedupInTuple(extraInnerWhere: string): string {
   return `(TenantId, TraceId, SpanId, UpdatedAt) IN (
@@ -345,6 +353,7 @@ export interface SpanSummaryQueryRow {
   CustomCacheCreationRate: string;
   LwSpanCost: string;
   StartTimeMs: number;
+  UpdatedAtMs: number;
 }
 
 /** "" → null, malformed → null, otherwise the parsed number. */
@@ -421,6 +430,7 @@ export function mapSpanSummaryRow(row: SpanSummaryQueryRow): SpanSummaryRow {
     cacheReadTokens,
     cacheCreationTokens,
     startTimeMs: Number(row.StartTimeMs),
+    updatedAtMs: Number(row.UpdatedAtMs),
   };
 }
 
@@ -1723,21 +1733,29 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
           : "";
       // Keyed pagination over (StartTimeMs, SpanId): the tuple compare uses
       // the same millisecond expression the rows are ordered (and returned)
-      // by, so page boundaries are exact even though StartTime itself has
-      // sub-ms precision.
+      // by, so page boundaries are exact. `StartTime` is `DateTime64(3)` —
+      // already exactly milliseconds — so `toUnixTimestamp64Milli` is a
+      // representation change, not a lossy truncation, and no two rows can
+      // differ by less than the tuple can express.
       //
       // The coarse `StartTime >=` bound restates the tuple predicate on the
       // raw partition key: `toYearWeek(StartTime)` partition pruning can't
       // see through `toUnixTimestamp64Milli(...)`, so without it every page
       // re-scans the partitions pagination already moved past — exactly the
-      // long-running multi-week traces that need paging. It goes into the
-      // dedup subquery too (else the inner scan stays unpruned), same trade
-      // the `since` readers make: a span's versions share its StartTime, so
-      // bounding the version scan by it is safe. The exact tuple predicate
-      // stays OUT of the dedup subquery — dedup must pick the latest version
-      // per span; if the winning version sorts before the cursor, the span
-      // belongs to an earlier page and is correctly excluded by the outer
-      // filter rather than re-emitted stale.
+      // long-running multi-week traces that need paging.
+      //
+      // NEITHER cursor predicate may enter the dedup subquery. The subquery's
+      // job is to elect each span's LATEST version, which it can only do if it
+      // sees every version. Restricting it to `StartTime >= cursor` breaks
+      // that whenever a span was re-emitted with a corrected EARLIER start:
+      // the latest version then sorts below the bound, the inner scan elects a
+      // stale older version instead, and the outer tuple filter emits it
+      // happily — and the client's dedup is last-write-wins per spanId, so the
+      // stale row wins the waterfall row. (`pageLowerBound` does stay in: it
+      // is the ±2-day hint window applied identically to both scopes, and a
+      // correction would have to move a span's start by more than two days to
+      // slip past it — whereas the cursor bound advances into the trace on
+      // every single page.)
       const cursorCoarseBound = cursor
         ? `AND StartTime >= fromUnixTimestamp64Milli({cursorStartTimeMs:Int64})`
         : "";
@@ -1756,7 +1774,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
             AND TraceId = {traceId:String}
             ${pageLowerBound}
             ${cursorFilter}
-            AND ${dedupInTuple(`${pageLowerBound} ${cursorCoarseBound}`)}
+            AND ${dedupInTuple(pageLowerBound)}
           ORDER BY StartTimeMs ASC, SpanId ASC
           LIMIT {limit:UInt32}
         `,
@@ -1797,23 +1815,33 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
   async findSpanSummariesSince({
     tenantId,
     traceId,
-    sinceStartTimeMs,
+    sinceUpdatedAtMs,
   }: {
     tenantId: string;
     traceId: string;
-    sinceStartTimeMs: number;
+    sinceUpdatedAtMs: number;
   } & OccurredAtHint): Promise<SpanSummaryRow[]> {
     EventUtils.validateTenantId(
       { tenantId },
       "SpanStorageClickHouseRepository.findSpanSummariesSince",
     );
 
-    // Poll reader: see findSpansSince — `StartTime > sinceStartTimeMs` already
-    // prunes partitions, so this does NOT resolve or clamp to the trace's
-    // OccurredAt window. An upper bound would silently stop the spanTreeDelta
-    // live view from showing new spans on a long-running trace.
+    // Keyed on the ROW VERSION, not the span start. A span updated in place —
+    // end time, duration, status, cost, all re-projected as the span closes —
+    // keeps its StartTime, so a `StartTime >` poll can only ever see brand-new
+    // spans. The root span is the worst case: it starts first and ends last,
+    // so a start-keyed poll left its duration (and with it the waterfall's
+    // whole time scale) frozen at first projection until SSE reconnected.
+    //
+    // UpdatedAt is not the partition key, so this gives up partition pruning.
+    // The read stays cheap because (TenantId, TraceId) is the table's sort-key
+    // prefix and carries a bloom-filter index: partitions that hold none of
+    // this trace's rows are skipped on the index, not scanned.
+    //
+    // Deliberately NOT clamped to the trace's OccurredAt window: an upper
+    // bound would silently stop the live view on a long-running trace.
     const sinceFilter =
-      "AND StartTime > fromUnixTimestamp64Milli({sinceStartTimeMs:Int64})";
+      "AND UpdatedAt > fromUnixTimestamp64Milli({sinceUpdatedAtMs:Int64})";
     const client = await this.resolveClient(tenantId);
     const result = await client.query({
       query: `
@@ -1826,7 +1854,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         ORDER BY StartTimeMs ASC
         LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}
       `,
-      query_params: { tenantId, traceId, sinceStartTimeMs },
+      query_params: { tenantId, traceId, sinceUpdatedAtMs },
       format: "JSONEachRow",
     });
 

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -24,11 +24,14 @@ import type {
   SpanLangwatchSignalsRow,
   SpanResourceInfo,
   SpanStorageRepository,
+  SpanSummaryPageCursor,
   SpanSummaryRow,
 } from "./span-storage.repository";
 import {
   clampSpanReadLimit,
   LANGWATCH_SIGNAL_BUCKETS,
+  MAX_DERIVATION_SPANS,
+  MAX_LIGHT_SPAN_READ_ROWS,
 } from "./span-storage.repository";
 
 const TABLE_NAME = "stored_spans" as const;
@@ -1066,6 +1069,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
               ${partition.sqlAnd}
               AND ${dedupInTuple(partition.sqlAndInner)}
             ORDER BY StartTimeMs ASC
+            LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}
           `,
           query_params: { tenantId, traceId, ...partition.params },
           format: "JSONEachRow",
@@ -1250,6 +1254,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
                 Events_Name AS event_name,
                 Events_Attributes AS event_attrs
               ORDER BY event_timestamp ASC
+              LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}
             `,
             query_params: { tenantId, traceId, ...partition.params },
             format: "JSONEachRow",
@@ -1460,6 +1465,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
               ${partition.sqlAnd}
               AND ${dedupInTuple(partition.sqlAndInner)}
             ORDER BY StartTimeMs ASC
+            LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}
           `,
           query_params: { tenantId, traceId, ...partition.params },
           format: "JSONEachRow",
@@ -1514,6 +1520,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
                 AND TraceId = {traceId:String}
                 ${partition.sqlAnd}
                 AND ${dedupInTuple(partition.sqlAndInner)}
+              LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}
             )
           `,
           query_params: { tenantId, traceId, ...partition.params },
@@ -1650,6 +1657,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
           ${sinceFilter}
           AND ${dedupInTuple(sinceFilter)}
         ORDER BY StartTime ASC
+        LIMIT ${MAX_DERIVATION_SPANS}
       `,
       query_params: { tenantId, traceId, sinceStartTimeMs },
       format: "JSONEachRow",
@@ -1659,79 +1667,74 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     return mapNormalizedSpansToSpans(rows.map(mapChRowToNormalized));
   }
 
-  async findSpanSummariesPaginated({
+  async findSpanSummariesPage({
     tenantId,
     traceId,
     limit,
-    offset,
+    cursor,
     occurredAtMs,
   }: {
     tenantId: string;
     traceId: string;
     limit: number;
-    offset: number;
-  } & OccurredAtHint): Promise<{ rows: SpanSummaryRow[]; total: number }> {
+    cursor?: SpanSummaryPageCursor;
+  } & OccurredAtHint): Promise<SpanSummaryRow[]> {
     EventUtils.validateTenantId(
       { tenantId },
-      "SpanStorageClickHouseRepository.findSpanSummariesPaginated",
+      "SpanStorageClickHouseRepository.findSpanSummariesPage",
     );
 
-    return this.readTraceSpans<{ rows: SpanSummaryRow[]; total: number }>(
+    const effectiveLimit = Math.min(
+      Math.max(1, Math.trunc(limit)),
+      MAX_LIGHT_SPAN_READ_ROWS,
+    );
+
+    return this.readTraceSpans<SpanSummaryRow[]>(
       { tenantId, traceId, occurredAtMs },
-      (result) => result.rows.length === 0,
+      (rows) => rows.length === 0,
       async (window) => {
         const partition = partitionFragment(window);
         const client = await this.resolveClient(tenantId);
-        // Same two-step rationale as findSpansPaginated, except the page
-        // query is already light (summary columns only). Splitting still
-        // helps because count() OVER () forces the deduped row set to be
-        // materialized in full before the LIMIT — a wasted scan when the
-        // user is on page N and we just want a number.
-        const [pageResult, countResult] = await Promise.all([
-          client.query({
-            query: `
-              SELECT ${SUMMARY_SPAN_SELECT}
-              FROM ${TABLE_NAME}
-              WHERE TenantId = {tenantId:String}
-                AND TraceId = {traceId:String}
-                ${partition.sqlAnd}
-                AND ${dedupInTuple(partition.sqlAndInner)}
-              ORDER BY StartTime ASC
-              LIMIT {limit:UInt32}
-              OFFSET {offset:UInt32}
-            `,
-            query_params: {
-              tenantId,
-              traceId,
-              limit,
-              offset,
-              ...partition.params,
-            },
-            format: "JSONEachRow",
-          }),
-          client.query({
-            query: `
-              SELECT count(DISTINCT SpanId) AS Total
-              FROM ${TABLE_NAME}
-              WHERE TenantId = {tenantId:String}
-                AND TraceId = {traceId:String}
-                ${partition.sqlAnd}
-            `,
-            query_params: { tenantId, traceId, ...partition.params },
-            format: "JSONEachRow",
-          }),
-        ]);
+        // Keyed pagination over (StartTimeMs, SpanId): the tuple compare uses
+        // the same millisecond expression the rows are ordered (and returned)
+        // by, so page boundaries are exact even though StartTime itself has
+        // sub-ms precision. The cursor predicate stays OUT of the dedup
+        // subquery on purpose — dedup must pick the latest version per span
+        // across the whole trace; if the winning version sorts before the
+        // cursor, the span belongs to an earlier page and is correctly
+        // excluded by the outer filter rather than re-emitted stale.
+        const cursorFilter = cursor
+          ? `AND (toUnixTimestamp64Milli(StartTime), SpanId) > ({cursorStartTimeMs:Int64}, {cursorSpanId:String})`
+          : "";
+        const result = await client.query({
+          query: `
+            SELECT ${SUMMARY_SPAN_SELECT}
+            FROM ${TABLE_NAME}
+            WHERE TenantId = {tenantId:String}
+              AND TraceId = {traceId:String}
+              ${partition.sqlAnd}
+              ${cursorFilter}
+              AND ${dedupInTuple(partition.sqlAndInner)}
+            ORDER BY StartTimeMs ASC, SpanId ASC
+            LIMIT {limit:UInt32}
+          `,
+          query_params: {
+            tenantId,
+            traceId,
+            limit: effectiveLimit,
+            ...(cursor
+              ? {
+                  cursorStartTimeMs: Math.trunc(cursor.startTimeMs),
+                  cursorSpanId: cursor.spanId,
+                }
+              : {}),
+            ...partition.params,
+          },
+          format: "JSONEachRow",
+        });
 
-        const pageRows = await pageResult.json<SpanSummaryQueryRow>();
-        const countRows = (await countResult.json()) as Array<{
-          Total: number | string;
-        }>;
-        const total = countRows.length > 0 ? Number(countRows[0]!.Total) : 0;
-
-        return {
-          rows: pageRows.map(mapSpanSummaryRow),
-          total,
-        };
+        const rows = await result.json<SpanSummaryQueryRow>();
+        return rows.map(mapSpanSummaryRow);
       },
     );
   }
@@ -1766,6 +1769,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
           ${sinceFilter}
           AND ${dedupInTuple(sinceFilter)}
         ORDER BY StartTimeMs ASC
+        LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}
       `,
       query_params: { tenantId, traceId, sinceStartTimeMs },
       format: "JSONEachRow",

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -24,6 +24,7 @@ import type {
   SpanLangwatchSignalsRow,
   SpanResourceInfo,
   SpanStorageRepository,
+  SpanSummaryPage,
   SpanSummaryPageCursor,
   SpanSummaryRow,
 } from "./span-storage.repository";
@@ -1524,8 +1525,9 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
               -- same earliest-starting prefix; an unordered LIMIT would let
               -- ClickHouse return an arbitrary subset that varies with merges
               -- and part ordering, making which spans carry signals
-              -- nondeterministic across calls.
-              ORDER BY StartTimeMs ASC
+              -- nondeterministic across calls. Must be the raw StartTime
+              -- column — this subquery computes no StartTimeMs alias.
+              ORDER BY StartTime ASC
               LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}
             )
           `,
@@ -1684,79 +1686,112 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     traceId: string;
     limit: number;
     cursor?: SpanSummaryPageCursor;
-  } & OccurredAtHint): Promise<SpanSummaryRow[]> {
+  } & OccurredAtHint): Promise<SpanSummaryPage> {
     EventUtils.validateTenantId(
       { tenantId },
       "SpanStorageClickHouseRepository.findSpanSummariesPage",
     );
 
-    const effectiveLimit = Math.min(
-      Math.max(1, Math.trunc(limit)),
-      MAX_LIGHT_SPAN_READ_ROWS,
-    );
+    const effectiveLimit = clampSpanReadLimit(limit, {
+      max: MAX_LIGHT_SPAN_READ_ROWS,
+    });
 
-    return this.readTraceSpans<SpanSummaryRow[]>(
-      { tenantId, traceId, occurredAtMs },
-      (rows) => rows.length === 0,
-      async (window) => {
-        const partition = partitionFragment(window);
-        const client = await this.resolveClient(tenantId);
-        // Keyed pagination over (StartTimeMs, SpanId): the tuple compare uses
-        // the same millisecond expression the rows are ordered (and returned)
-        // by, so page boundaries are exact even though StartTime itself has
-        // sub-ms precision.
-        //
-        // The coarse `StartTime >=` bound restates the tuple predicate on the
-        // raw partition key: `toYearWeek(StartTime)` partition pruning can't
-        // see through `toUnixTimestamp64Milli(...)`, so without it every page
-        // re-scans the partitions pagination already moved past — exactly the
-        // long-running multi-week traces that need paging, and the only
-        // pruning at all when no occurredAtMs hint was threaded. It goes into
-        // the dedup subquery too (else the inner scan stays unpruned), same
-        // trade the `since` readers make: a span's versions share its
-        // StartTime, so bounding the version scan by it is safe. The exact
-        // tuple predicate stays OUT of the dedup subquery — dedup must pick
-        // the latest version per span; if the winning version sorts before
-        // the cursor, the span belongs to an earlier page and is correctly
-        // excluded by the outer filter rather than re-emitted stale.
-        const cursorCoarseBound = cursor
-          ? `AND StartTime >= fromUnixTimestamp64Milli({cursorStartTimeMs:Int64})`
+    // This reader deliberately does NOT go through readTraceSpans /
+    // withPartitionHint — a paged read breaks both of that seam's
+    // assumptions:
+    //
+    //   - Its ±2-day window has an UPPER bound, and a page that runs into it
+    //     comes back short-but-non-empty, which the router would read as
+    //     end-of-trace: every span a long-running trace produced past
+    //     `occurredAt + 2d` would be silently dropped. Pages therefore bound
+    //     StartTime from below only; forward partitions cost one primary-key
+    //     probe each (TraceId is 2nd in the ORDER BY key), not a scan.
+    //   - Its empty-means-hint-missed fallback can't tell a missed hint from
+    //     an exhausted cursor, so a legitimately empty page would rerun as an
+    //     unhinted rescan. Cursor pages carry an exact lower bound (the
+    //     cursor itself), so their result is authoritative and never falls
+    //     back; only the first page keeps the empty→unbounded retry, because
+    //     its lower bound comes from a hint that can be plain wrong (stale
+    //     URL, clock skew).
+    const runPage = async (
+      lowerBoundMs: number | undefined,
+    ): Promise<SpanSummaryPage> => {
+      const client = await this.resolveClient(tenantId);
+      const pageLowerBound =
+        lowerBoundMs !== undefined
+          ? `AND StartTime >= fromUnixTimestamp64Milli({pageFromMs:Int64})`
           : "";
-        const cursorFilter = cursor
-          ? `${cursorCoarseBound}
-              AND (toUnixTimestamp64Milli(StartTime), SpanId) > ({cursorStartTimeMs:Int64}, {cursorSpanId:String})`
-          : "";
-        const result = await client.query({
-          query: `
-            SELECT ${SUMMARY_SPAN_SELECT}
-            FROM ${TABLE_NAME}
-            WHERE TenantId = {tenantId:String}
-              AND TraceId = {traceId:String}
-              ${partition.sqlAnd}
-              ${cursorFilter}
-              AND ${dedupInTuple(`${partition.sqlAndInner} ${cursorCoarseBound}`)}
-            ORDER BY StartTimeMs ASC, SpanId ASC
-            LIMIT {limit:UInt32}
-          `,
-          query_params: {
-            tenantId,
-            traceId,
-            limit: effectiveLimit,
-            ...(cursor
-              ? {
-                  cursorStartTimeMs: Math.trunc(cursor.startTimeMs),
-                  cursorSpanId: cursor.spanId,
-                }
-              : {}),
-            ...partition.params,
-          },
-          format: "JSONEachRow",
-        });
+      // Keyed pagination over (StartTimeMs, SpanId): the tuple compare uses
+      // the same millisecond expression the rows are ordered (and returned)
+      // by, so page boundaries are exact even though StartTime itself has
+      // sub-ms precision.
+      //
+      // The coarse `StartTime >=` bound restates the tuple predicate on the
+      // raw partition key: `toYearWeek(StartTime)` partition pruning can't
+      // see through `toUnixTimestamp64Milli(...)`, so without it every page
+      // re-scans the partitions pagination already moved past — exactly the
+      // long-running multi-week traces that need paging. It goes into the
+      // dedup subquery too (else the inner scan stays unpruned), same trade
+      // the `since` readers make: a span's versions share its StartTime, so
+      // bounding the version scan by it is safe. The exact tuple predicate
+      // stays OUT of the dedup subquery — dedup must pick the latest version
+      // per span; if the winning version sorts before the cursor, the span
+      // belongs to an earlier page and is correctly excluded by the outer
+      // filter rather than re-emitted stale.
+      const cursorCoarseBound = cursor
+        ? `AND StartTime >= fromUnixTimestamp64Milli({cursorStartTimeMs:Int64})`
+        : "";
+      const cursorFilter = cursor
+        ? `${cursorCoarseBound}
+            AND (toUnixTimestamp64Milli(StartTime), SpanId) > ({cursorStartTimeMs:Int64}, {cursorSpanId:String})`
+        : "";
+      // Over-fetch one row past the page: `hasMore` comes from that row's
+      // existence, so an exact-multiple-of-page-size trace terminates without
+      // a follow-up empty fetch.
+      const result = await client.query({
+        query: `
+          SELECT ${SUMMARY_SPAN_SELECT}
+          FROM ${TABLE_NAME}
+          WHERE TenantId = {tenantId:String}
+            AND TraceId = {traceId:String}
+            ${pageLowerBound}
+            ${cursorFilter}
+            AND ${dedupInTuple(`${pageLowerBound} ${cursorCoarseBound}`)}
+          ORDER BY StartTimeMs ASC, SpanId ASC
+          LIMIT {limit:UInt32}
+        `,
+        query_params: {
+          tenantId,
+          traceId,
+          limit: effectiveLimit + 1,
+          ...(lowerBoundMs !== undefined ? { pageFromMs: lowerBoundMs } : {}),
+          ...(cursor
+            ? {
+                cursorStartTimeMs: Math.trunc(cursor.startTimeMs),
+                cursorSpanId: cursor.spanId,
+              }
+            : {}),
+        },
+        format: "JSONEachRow",
+      });
 
-        const rows = await result.json<SpanSummaryQueryRow>();
-        return rows.map(mapSpanSummaryRow);
-      },
-    );
+      const rows = (await result.json<SpanSummaryQueryRow>()).map(
+        mapSpanSummaryRow,
+      );
+      return {
+        rows: rows.slice(0, effectiveLimit),
+        hasMore: rows.length > effectiveLimit,
+      };
+    };
+
+    if (cursor) return runPage(undefined);
+
+    const hintMs =
+      occurredAtMs ?? (await this.resolveTraceOccurredAtMs(tenantId, traceId));
+    if (hintMs === undefined) return runPage(undefined);
+    const bounded = await runPage(hintMs - PARTITION_WINDOW_MS);
+    if (bounded.rows.length > 0) return bounded;
+    return runPage(undefined);
   }
 
   async findSpanSummariesSince({

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -1520,6 +1520,12 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
                 AND TraceId = {traceId:String}
                 ${partition.sqlAnd}
                 AND ${dedupInTuple(partition.sqlAndInner)}
+              -- Order before the cap so a runaway trace consistently yields the
+              -- same earliest-starting prefix; an unordered LIMIT would let
+              -- ClickHouse return an arbitrary subset that varies with merges
+              -- and part ordering, making which spans carry signals
+              -- nondeterministic across calls.
+              ORDER BY StartTimeMs ASC
               LIMIT ${MAX_LIGHT_SPAN_READ_ROWS}
             )
           `,

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -1698,13 +1698,27 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         // Keyed pagination over (StartTimeMs, SpanId): the tuple compare uses
         // the same millisecond expression the rows are ordered (and returned)
         // by, so page boundaries are exact even though StartTime itself has
-        // sub-ms precision. The cursor predicate stays OUT of the dedup
-        // subquery on purpose — dedup must pick the latest version per span
-        // across the whole trace; if the winning version sorts before the
-        // cursor, the span belongs to an earlier page and is correctly
+        // sub-ms precision.
+        //
+        // The coarse `StartTime >=` bound restates the tuple predicate on the
+        // raw partition key: `toYearWeek(StartTime)` partition pruning can't
+        // see through `toUnixTimestamp64Milli(...)`, so without it every page
+        // re-scans the partitions pagination already moved past — exactly the
+        // long-running multi-week traces that need paging, and the only
+        // pruning at all when no occurredAtMs hint was threaded. It goes into
+        // the dedup subquery too (else the inner scan stays unpruned), same
+        // trade the `since` readers make: a span's versions share its
+        // StartTime, so bounding the version scan by it is safe. The exact
+        // tuple predicate stays OUT of the dedup subquery — dedup must pick
+        // the latest version per span; if the winning version sorts before
+        // the cursor, the span belongs to an earlier page and is correctly
         // excluded by the outer filter rather than re-emitted stale.
+        const cursorCoarseBound = cursor
+          ? `AND StartTime >= fromUnixTimestamp64Milli({cursorStartTimeMs:Int64})`
+          : "";
         const cursorFilter = cursor
-          ? `AND (toUnixTimestamp64Milli(StartTime), SpanId) > ({cursorStartTimeMs:Int64}, {cursorSpanId:String})`
+          ? `${cursorCoarseBound}
+              AND (toUnixTimestamp64Milli(StartTime), SpanId) > ({cursorStartTimeMs:Int64}, {cursorSpanId:String})`
           : "";
         const result = await client.query({
           query: `
@@ -1714,7 +1728,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
               AND TraceId = {traceId:String}
               ${partition.sqlAnd}
               ${cursorFilter}
-              AND ${dedupInTuple(partition.sqlAndInner)}
+              AND ${dedupInTuple(`${partition.sqlAndInner} ${cursorCoarseBound}`)}
             ORDER BY StartTimeMs ASC, SpanId ASC
             LIMIT {limit:UInt32}
           `,

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
@@ -85,6 +85,13 @@ export interface SpanSummaryRow {
   cacheReadTokens: number | null;
   cacheCreationTokens: number | null;
   startTimeMs: number;
+  /**
+   * Row version, not span timing: bumped every time a span is re-projected.
+   * The live delta poll keys off this rather than `startTimeMs`, because a
+   * span updated in place (end time, duration, status, cost) keeps its start
+   * time and a start-keyed poll could never see it.
+   */
+  updatedAtMs: number;
 }
 
 /**
@@ -245,11 +252,17 @@ export interface SpanStorageRepository {
       cursor?: SpanSummaryPageCursor;
     } & OccurredAtHint,
   ): Promise<SpanSummaryPage>;
+  /**
+   * Spans of a trace whose row version is newer than `sinceUpdatedAtMs`.
+   * Keyed on the row version, not the span start: an in-place update (end
+   * time, duration, status, cost) keeps the span's start time, so a
+   * start-keyed poll would never observe it.
+   */
   findSpanSummariesSince(
     params: {
       tenantId: string;
       traceId: string;
-      sinceStartTimeMs: number;
+      sinceUpdatedAtMs: number;
     } & OccurredAtHint,
   ): Promise<SpanSummaryRow[]>;
   findSpansPaginated(
@@ -380,7 +393,7 @@ export class NullSpanStorageRepository implements SpanStorageRepository {
     _params: {
       tenantId: string;
       traceId: string;
-      sinceStartTimeMs: number;
+      sinceUpdatedAtMs: number;
     } & OccurredAtHint,
   ): Promise<SpanSummaryRow[]> {
     return [];

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
@@ -29,6 +29,29 @@ export function clampSpanReadLimit(limit?: number): number {
   return Math.min(Math.max(1, Math.trunc(requested)), MAX_DERIVATION_SPANS);
 }
 
+/**
+ * Per-query safety ceiling for the light single-shot per-trace projections
+ * (span summaries, signal keys, resource info, trace events, summary deltas).
+ * These rows are slim — no SpanAttributes values, input/output, or Events
+ * payloads — so the ceiling is generous, but it exists because traces have
+ * been seen with 20k–100k+ spans and an unbounded read materializes every
+ * row in ClickHouse and Node at once. The complete view of huge traces is
+ * the cursor-paged span-tree read (`findSpanSummariesPage`), which never
+ * needs more than one page in memory.
+ */
+export const MAX_LIGHT_SPAN_READ_ROWS = 10_000;
+
+/**
+ * Cursor for keyed span-summary pagination: the page starts strictly after
+ * `(startTimeMs, spanId)` in `(StartTimeMs ASC, SpanId ASC)` order. Keyed
+ * instead of offset-based so pages stay stable while spans are still being
+ * ingested, and so ClickHouse never scans-and-discards `offset` rows.
+ */
+export interface SpanSummaryPageCursor {
+  startTimeMs: number;
+  spanId: string;
+}
+
 export interface SpanSummaryRow {
   spanId: string;
   parentSpanId: string | null;
@@ -196,14 +219,19 @@ export interface SpanStorageRepository {
   findSpanResourcesByTraceId(
     params: { tenantId: string; traceId: string } & OccurredAtHint,
   ): Promise<SpanResourceInfo[]>;
-  findSpanSummariesPaginated(
+  /**
+   * One page of span summaries in `(StartTimeMs, SpanId)` order, starting
+   * strictly after `cursor` (or from the beginning when omitted). Callers
+   * derive the next cursor from the last row when a full page came back.
+   */
+  findSpanSummariesPage(
     params: {
       tenantId: string;
       traceId: string;
       limit: number;
-      offset: number;
+      cursor?: SpanSummaryPageCursor;
     } & OccurredAtHint,
-  ): Promise<{ rows: SpanSummaryRow[]; total: number }>;
+  ): Promise<SpanSummaryRow[]>;
   findSpanSummariesSince(
     params: {
       tenantId: string;
@@ -324,15 +352,15 @@ export class NullSpanStorageRepository implements SpanStorageRepository {
     return [];
   }
 
-  async findSpanSummariesPaginated(
+  async findSpanSummariesPage(
     _params: {
       tenantId: string;
       traceId: string;
       limit: number;
-      offset: number;
+      cursor?: SpanSummaryPageCursor;
     } & OccurredAtHint,
-  ): Promise<{ rows: SpanSummaryRow[]; total: number }> {
-    return { rows: [], total: 0 };
+  ): Promise<SpanSummaryRow[]> {
+    return [];
   }
 
   async findSpanSummariesSince(

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
@@ -16,17 +16,18 @@ import type { SpanInsertData } from "../types";
 export const MAX_DERIVATION_SPANS = 512;
 
 /**
- * Clamps a requested span-read limit to the `[1, MAX_DERIVATION_SPANS]` range.
- * `MAX_DERIVATION_SPANS` is a hard ceiling a caller can only lower, never raise,
- * so every full-span / derivation read is bounded even for a leaked trace_id.
+ * Clamps a requested span-read limit to the `[1, max]` range (default ceiling
+ * `MAX_DERIVATION_SPANS`). The ceiling is hard — a caller can only lower it,
+ * never raise it — so every span read is bounded even for a leaked trace_id.
  * A missing or non-finite limit (undefined, NaN, Infinity) defaults to the
  * ceiling so the value never propagates into a ClickHouse `UInt32` param.
  */
-export function clampSpanReadLimit(limit?: number): number {
-  const requested = Number.isFinite(limit)
-    ? (limit as number)
-    : MAX_DERIVATION_SPANS;
-  return Math.min(Math.max(1, Math.trunc(requested)), MAX_DERIVATION_SPANS);
+export function clampSpanReadLimit(
+  limit?: number,
+  { max = MAX_DERIVATION_SPANS }: { max?: number } = {},
+): number {
+  const requested = Number.isFinite(limit) ? (limit as number) : max;
+  return Math.min(Math.max(1, Math.trunc(requested)), max);
 }
 
 /**
@@ -50,6 +51,17 @@ export const MAX_LIGHT_SPAN_READ_ROWS = 10_000;
 export interface SpanSummaryPageCursor {
   startTimeMs: number;
   spanId: string;
+}
+
+/**
+ * One page of the keyed span-summary walk. `hasMore` is derived from an
+ * over-fetched `limit + 1`-th row, so exhaustion is known without a follow-up
+ * empty fetch — the extra fetch would both waste a round trip and (on the
+ * repository side) be indistinguishable from a missed partition hint.
+ */
+export interface SpanSummaryPage {
+  rows: SpanSummaryRow[];
+  hasMore: boolean;
 }
 
 export interface SpanSummaryRow {
@@ -222,7 +234,8 @@ export interface SpanStorageRepository {
   /**
    * One page of span summaries in `(StartTimeMs, SpanId)` order, starting
    * strictly after `cursor` (or from the beginning when omitted). Callers
-   * derive the next cursor from the last row when a full page came back.
+   * derive the next cursor from the last row when `hasMore` is set; a page
+   * with `hasMore: false` is authoritative end-of-trace.
    */
   findSpanSummariesPage(
     params: {
@@ -231,7 +244,7 @@ export interface SpanStorageRepository {
       limit: number;
       cursor?: SpanSummaryPageCursor;
     } & OccurredAtHint,
-  ): Promise<SpanSummaryRow[]>;
+  ): Promise<SpanSummaryPage>;
   findSpanSummariesSince(
     params: {
       tenantId: string;
@@ -359,8 +372,8 @@ export class NullSpanStorageRepository implements SpanStorageRepository {
       limit: number;
       cursor?: SpanSummaryPageCursor;
     } & OccurredAtHint,
-  ): Promise<SpanSummaryRow[]> {
-    return [];
+  ): Promise<SpanSummaryPage> {
+    return { rows: [], hasMore: false };
   }
 
   async findSpanSummariesSince(

--- a/langwatch/src/server/app-layer/traces/span-storage.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-storage.service.ts
@@ -15,6 +15,7 @@ import type {
   SpanLangwatchSignalsRow,
   SpanResourceInfo,
   SpanStorageRepository,
+  SpanSummaryPageCursor,
   SpanSummaryRow,
 } from "./repositories/span-storage.repository";
 import type { TraceIOExtractionService } from "./trace-io-extraction.service";
@@ -202,10 +203,10 @@ export class SpanStorageService {
     );
   }
 
-  async getSpanSummariesPaginated(
-    params: Paginated,
-  ): Promise<{ rows: SpanSummaryRow[]; total: number }> {
-    return this.repository.findSpanSummariesPaginated(params);
+  async getSpanSummariesPage(
+    params: ByTraceId & { limit: number; cursor?: SpanSummaryPageCursor },
+  ): Promise<SpanSummaryRow[]> {
+    return this.repository.findSpanSummariesPage(params);
   }
 
   async getSpanSummariesSince(params: Since): Promise<SpanSummaryRow[]> {

--- a/langwatch/src/server/app-layer/traces/span-storage.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-storage.service.ts
@@ -15,6 +15,7 @@ import type {
   SpanLangwatchSignalsRow,
   SpanResourceInfo,
   SpanStorageRepository,
+  SpanSummaryPage,
   SpanSummaryPageCursor,
   SpanSummaryRow,
 } from "./repositories/span-storage.repository";
@@ -205,7 +206,7 @@ export class SpanStorageService {
 
   async getSpanSummariesPage(
     params: ByTraceId & { limit: number; cursor?: SpanSummaryPageCursor },
-  ): Promise<SpanSummaryRow[]> {
+  ): Promise<SpanSummaryPage> {
     return this.repository.findSpanSummariesPage(params);
   }
 

--- a/langwatch/src/server/app-layer/traces/span-storage.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-storage.service.ts
@@ -39,7 +39,14 @@ export interface SpanReadBlobResolutionDeps {
 type ByTraceId = { tenantId: string; traceId: string } & OccurredAtHint;
 type BySpanId = ByTraceId & { spanId: string };
 type Paginated = ByTraceId & { limit: number; offset: number };
+/** Full-span delta: keyed on span start (see `findSpansSince`). */
 type Since = ByTraceId & { sinceStartTimeMs: number };
+/**
+ * Span-summary delta: keyed on the ROW VERSION, so spans updated in place
+ * (end time, duration, status, cost) are picked up too — a start-keyed poll
+ * only ever sees brand-new spans.
+ */
+type SinceUpdated = ByTraceId & { sinceUpdatedAtMs: number };
 
 /**
  * Read-side visibility gate. Read routes pass the caller's plan cutoff
@@ -210,7 +217,9 @@ export class SpanStorageService {
     return this.repository.findSpanSummariesPage(params);
   }
 
-  async getSpanSummariesSince(params: Since): Promise<SpanSummaryRow[]> {
+  async getSpanSummariesSince(
+    params: SinceUpdated,
+  ): Promise<SpanSummaryRow[]> {
     return this.repository.findSpanSummariesSince(params);
   }
 

--- a/specs/traces-v2/data-layer.feature
+++ b/specs/traces-v2/data-layer.feature
@@ -256,7 +256,7 @@ Rule: Progressive drawer loading
     Then `useOpenTraceDrawer` seeds `tracesV2.header` from the row payload
     And the URL updates to `?drawer.open=traceV2Details&drawer.traceId=abc123&drawer.t=<timestamp>`
     And `useTraceHeader` fires `tracesV2.header` (staleTime 5 min, cacheTime 30 min)
-    And `useSpanTree` fires `tracesV2.spanTree` (with the `occurredAtMs` partition-pruning hint)
+    And `useSpanTree` starts loading the span tree page by page (forwarding the `occurredAtMs` partition-pruning hint)
     And `useSpanLangwatchSignals` fires `tracesV2.spanLangwatchSignals` in parallel
     And `tracesV2.spanDetail` does NOT fire (no selected span)
 
@@ -269,9 +269,28 @@ Rule: Progressive drawer loading
     Given a trace with more spans than one page
     When `useSpanTree` fires
     Then the client fetches the tree page by page via `tracesV2.spanTreePaginated`
-    And each page's `nextCursor` (startTimeMs, spanId) keys the next page, so concurrent ingestion cannot skip or duplicate spans
+    And each page's `nextCursor` keys the next page, so concurrent ingestion cannot skip or duplicate spans
     And already-fetched spans render in the waterfall while later pages are still loading
     And no span endpoint returns every span of the trace in a single unbounded response
+
+  Scenario: Pagination reaches spans recorded long after the trace began
+    Given a long-running trace whose newest spans started days after its first span
+    When the client pages through the span tree
+    Then every span is returned, including those far past the trace's recorded start
+    And no page ends the walk early because of a time-window guess
+
+  Scenario: Finishing pagination never widens into an unbounded storage scan
+    Given a trace whose span count is an exact multiple of the page size
+    When the client fetches the final page
+    Then the walk terminates without an extra empty fetch
+    And the storage read never widens beyond the pages' own time bounds
+
+  Scenario: Live fallback polling fetches only new spans
+    Given an open live trace whose realtime connection is down
+    When the periodic fallback refresh fires
+    Then only spans newer than the newest already-loaded span are requested
+    And they are merged into the loaded tree in place
+    And the full page walk does not rerun on every poll
 
   Scenario: A huge trace cannot exhaust server memory through per-trace span reads
     Given a runaway trace with 100,000+ spans
@@ -526,7 +545,7 @@ Rule: Batched tRPC requests with skipBatch opt-out
 
   Scenario: Drawer open batches header and span tree by default
     When the user clicks a trace row
-    Then `tracesV2.header` and `tracesV2.spanTree` fire in the same tick
+    Then `tracesV2.header` and the first `tracesV2.spanTreePaginated` page fire in the same tick
     And they are batched into a single HTTP request unless one opts out
 
   Scenario: Heavy queries opt out of batching

--- a/specs/traces-v2/data-layer.feature
+++ b/specs/traces-v2/data-layer.feature
@@ -262,8 +262,22 @@ Rule: Progressive drawer loading
 
   Scenario: Span tree returns lightweight skeleton only
     When `useSpanTree` fires
-    Then `tracesV2.spanTree` returns SpanTreeNode rows: spanId, parentSpanId, name, type, startTimeMs, endTimeMs, durationMs, status, model
+    Then the span tree is returned as SpanTreeNode rows: spanId, parentSpanId, name, type, startTimeMs, endTimeMs, durationMs, status, model
     And it does NOT return SpanAttributes, input/output, or Events (those live on `spanDetail`)
+
+  Scenario: Span tree is fetched in cursor pages, never as one response
+    Given a trace with more spans than one page
+    When `useSpanTree` fires
+    Then the client fetches the tree page by page via `tracesV2.spanTreePaginated`
+    And each page's `nextCursor` (startTimeMs, spanId) keys the next page, so concurrent ingestion cannot skip or duplicate spans
+    And already-fetched spans render in the waterfall while later pages are still loading
+    And no span endpoint returns every span of the trace in a single unbounded response
+
+  Scenario: A huge trace cannot exhaust server memory through per-trace span reads
+    Given a runaway trace with 100,000+ spans
+    When any per-trace read fires (span tree, signals, resource info, trace events, live deltas)
+    Then the read is bounded server-side and returns at most a fixed ceiling of rows
+    And the complete span tree remains reachable through the cursor-paged fetch
 
   Scenario: Clicking a span fetches full detail
     Given the drawer is open with a trace

--- a/specs/traces-v2/data-layer.feature
+++ b/specs/traces-v2/data-layer.feature
@@ -285,12 +285,35 @@ Rule: Progressive drawer loading
     Then the walk terminates without an extra empty fetch
     And the storage read never widens beyond the pages' own time bounds
 
-  Scenario: Live fallback polling fetches only new spans
+  Scenario: Live fallback polling fetches only what changed
     Given an open live trace whose realtime connection is down
     When the periodic fallback refresh fires
-    Then only spans newer than the newest already-loaded span are requested
+    Then only spans changed since the newest already-loaded change are requested
     And they are merged into the loaded tree in place
     And the full page walk does not rerun on every poll
+
+  Scenario: A span that is updated in place is picked up by the live refresh
+    Given an open live trace whose realtime connection is down
+    And a span already in the loaded tree finishes, changing its duration and status
+    When the periodic fallback refresh fires
+    Then that span's new duration and status are shown
+    And this holds for the root span, which starts before every other span and ends after them
+
+  Scenario: Realtime span updates do not re-walk the whole trace
+    Given an open live trace with 100,000+ spans and a healthy realtime connection
+    When a batch of new spans is recorded
+    Then only the changed spans are requested
+    And the client does not restart the page walk
+
+  Scenario: Reconnecting picks up whatever was missed
+    Given an open live trace whose realtime connection was down and has just come back
+    When no further span is recorded
+    Then any span that changed between the last poll and the reconnect is still picked up
+
+  Scenario: A page never shows a superseded version of a span
+    Given a span was recorded twice, the newer version correcting its start time to be earlier
+    When the client pages past the point where the correction landed
+    Then the page shows the newer version of that span, never the superseded one
 
   Scenario: A huge trace cannot exhaust server memory through per-trace span reads
     Given a runaway trace with 100,000+ spans


### PR DESCRIPTION
## Problem

The trace drawer's span-tree fetch (`tracesV2.spanTree` → `getSpanSummaryByTraceId`) had **no LIMIT and no pagination** — every span of the trace travels as one response and is materialized in full in ClickHouse, Node, and the browser. Traces now reach 20k–100k+ spans, so opening one risks an OOM. Several sibling per-trace reads (signals, resource info, trace events, live deltas) were unbounded too.

## What changed

**Cursor-paged span tree (client + API)**
- `spanTreePaginated` reworked from `limit`/`offset` to a keyed cursor `(startTimeMs, spanId)`. Keyed pages stay stable while spans are still being ingested (offset pages skip/duplicate under concurrent inserts) and ClickHouse never scans-and-discards `offset` rows. The per-page `count(DISTINCT SpanId)` query is gone — `nextCursor: null` terminates the loop.
- The repository over-fetches `limit + 1` rows and returns `{ rows, hasMore }`: the router keys `nextCursor` off `hasMore`, so exhaustion never needs a follow-up empty fetch (exact-multiple-of-page-size traces used to pay one, and it re-opened an unhinted partition scan).
- Pages bound `StartTime` **from below only**. The ±2-day hint window's upper bound silently ended pagination at `occurredAt + 2d` whenever the last in-window page came back short — dropping every later span of a long-running trace. Cursor pages are bounded by the cursor itself and are authoritative (no `withPartitionHint` fallback); only the cursor-less first page keeps the hinted-empty → unbounded retry for stale/skewed hints.
- `useSpanTree`, `useTraceSpanTree`, and the drawer-open prefetch page through `spanTreePaginated` (500/page) via a shared query function (`spanTreePagedQuery.ts`) **under the same React Query key** the tRPC `spanTree` hook used. Preview-mode seeding, SSE invalidation, refresh, and close-time cancel all keep working unmodified, and the prefetch and drawer mount dedupe into one in-flight fetch.
- Page requests go through the vanilla tRPC client with the abort signal attached, so closing the drawer cancels the in-flight page too (not just between pages); assembly dedupes by spanId. Pages publish progressively on first load, so the (already virtualized) waterfall starts painting after the first page; refetches never shrink the cached tree mid-page.
- Cursor input is validated at the boundary (`startTimeMs` int ≥ 0, `spanId` length-capped) so a hand-crafted cursor can't turn into an unparseable ClickHouse Int64 bind and a 500.

**Live fallback polls deltas, not the whole tree**
- When a live trace's SSE connection is down, `useSpanTree` now polls `tracesV2.spanTreeDelta` from the loaded tree's high-water mark and merges new spans in place — previously the fallback re-ran the full page walk every interval (hundreds of requests per poll on exactly the huge traces paging exists for).

**Server-side ceilings (defense in depth)**
- `getSpanSummaryByTraceId` (kept as the cache-key anchor; no longer fetched by the frontend), `findLangwatchSignalsByTraceId`, `findSpanResourcesByTraceId`, `getTraceEventsByTraceId`, `findSpanSummariesSince`: capped at `MAX_LIGHT_SPAN_READ_ROWS` (10k slim rows).
- `findSpansSince` (full-span delta): capped at `MAX_DERIVATION_SPANS` (512), consistent with the existing full-span read clamp; pollers resume from their high-water mark on the next SSE event.
- The signals scan's pre-cap ordering now uses the raw `StartTime` column — the `StartTimeMs` alias doesn't exist in that subquery, so the ordered form errored (`UNKNOWN_IDENTIFIER`) on every drawer open.

## Spec
- `specs/traces-v2/data-layer.feature`: scenarios for the cursor-paged span-tree fetch, bounded per-trace reads for runaway traces, the window-edge walk of long-running traces, terminal pages that never widen into unbounded scans, and delta-based live fallback polling.

## Tests
- `spanTreePagedQuery.unit.test.ts`: cursor threading, ordering, progress callbacks, abort between/mid pages (AbortError by name), per-page signal forwarding, spanId dedup, progressive-publish grow path vs no-shrink-on-refetch, delta merge + high-water-mark helpers.
- `span-storage.clickhouse.repository.unit.test.ts`: over-fetch/`hasMore` semantics, lower-bound-only page bounds, authoritative empty cursor pages, hinted-empty fallback, `LIMIT` ceilings on every bounded reader, signals-scan ordering.
- `span-storage.clickhouse.repository.integration.test.ts` (testcontainers): full cursor walk over an exact-multiple trace (dedup + terminal page), same-StartTime tie-break across a page boundary, a long-running trace whose spans straddle the `occurredAt + 2d` window edge, and the signals read end-to-end.
- `useSpanTree.unit.test.ts` (new) + `useTraceSpanTree.unit.test.ts`: query key/fn wiring, preview gating, delta-poll gating (live + SSE-down + tree loaded), in-place merge.
- `tracesV2.spanTreePage.unit.test.ts`: `hasMore` → `nextCursor` mapping.
- `pnpm typecheck` clean; traces-v2 + app-layer + router suites pass (162 files / 2048 tests), span-storage integration suite passes locally against ClickHouse 25.10.

## Partition pruning on cursor pages
The cursor's `startTimeMs` is also pushed down as a raw `StartTime >=` bound (outer query + dedup subquery). The tuple predicate alone is opaque to partition pruning — `EXPLAIN indexes=1` shows `Condition: true` on the `toYearWeek(StartTime)` partition index — while the restated bound yields `toYearWeek(StartTime) in [cursorWeek, +Inf)`, so later pages skip the weekly partitions pagination already moved past. This matters exactly for long-running multi-week traces, and it is the only pruning at all when no `occurredAtMs` hint is threaded. Forward partitions right of the bound cost one primary-key probe each (`TraceId` is 2nd in the table's ORDER BY key), which is what makes the open upper bound affordable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced cursor-based pagination for trace span trees to better support very large traces.
  * Span trees now load progressively, with incremental results as pages arrive.
  * Drawer prefetching is aligned with the new paged span-tree loading for smoother opening.
* **Bug Fixes**
  * Improved cancellation behavior so multi-page loading stops cleanly without stale updates.
  * Prevented progressive loading from overwriting already-complete cached trees.
  * Added server-side safety caps to bound heavy span reads.
* **Tests**
  * Expanded coverage for pagination, progressive rendering, delta merging, abort/cancellation, and large-trace limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
