### PR TITLE
fix(event-sourcing): register blob holds before write/stage so shared blobs can't be reclaimed mid-fan-out

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobTestDoubles.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobTestDoubles.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from "node:crypto";
 import { Readable } from "node:stream";
 
+import { ObjectNotFoundError } from "~/server/stored-objects/errors";
+
 import type { JobBlobStore } from "../jobEnvelope";
 import type { ObjectStore } from "../tieredBlobStore";
 
@@ -43,8 +45,11 @@ export class InMemoryJobBlobStore implements JobBlobStore {
 
 /**
  * In-memory stand-in for the stored-objects StorageRegistry (the GQ2 s3 tier).
- * A miss throws a `NoSuchKey`-named error so the tier classifies it as gone;
- * deletes are recorded so out-of-band reclaim can be asserted.
+ * A miss throws the registry's real {@link ObjectNotFoundError} — faithful to
+ * what `S3Driver`/`LocalFilesystemDriver` actually throw, so a
+ * missing-vs-transient classification gap between the double and production
+ * can't hide behind the double. Deletes are recorded so out-of-band reclaim
+ * can be asserted.
  */
 export class InMemoryObjectStore implements ObjectStore {
   readonly store = new Map<string, Buffer>();
@@ -55,9 +60,7 @@ export class InMemoryObjectStore implements ObjectStore {
   async get(uri: string): Promise<Readable> {
     const bytes = this.store.get(uri);
     if (!bytes) {
-      const err = new Error(`no object at ${uri}`);
-      err.name = "NoSuchKey";
-      throw err;
+      throw new ObjectNotFoundError(uri);
     }
     return Readable.from(bytes);
   }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/envelopeBlobLifecycle.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/envelopeBlobLifecycle.integration.test.ts
@@ -319,6 +319,7 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
 
   describe("given stagings sharing one content-addressed blob", () => {
     describe("when a value is encoded", () => {
+      /** @scenario "A staging's hold on its shared blob exists before the blob is written" */
       it("registers the occupancy's hold before encode returns", async () => {
         const value = await lifecycle.encode({
           jobData: REDIS_TIER_PAYLOAD,
@@ -337,6 +338,7 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
     });
 
     describe("when one staging retires before a concurrent one dispatches", () => {
+      /** @scenario "A fan-out sibling completing early never reclaims a blob a concurrent staging references" */
       it("keeps the shared s3 blob alive for the remaining staging", async () => {
         const shared = { bulk: incompressible(768 * 1024) }; // > 256 KiB gzipped → s3
         const first = await lifecycle.encode({
@@ -348,16 +350,9 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
           groupId: TENANT_GROUP,
         });
         expect(readEnvelopeHold(second)!.ref.tier).toBe("s3");
-        // Ensure the FIRST staging's hold has landed (post-stage refresh), so
-        // its release below actually removes a member — the interleave where a
-        // hold-after-staging design empties the set and reclaims the blob out
-        // from under the second staging.
-        lifecycle.acquire(first);
-        await vi.waitFor(async () =>
-          expect(await redis.scard(holderKey(hashOf(first)))).toBeGreaterThan(
-            0,
-          ),
-        );
+        // Both stagings' holds land at encode-time (hold-before-write), so the
+        // set already has 2 members before either is released.
+        expect(await redis.scard(holderKey(hashOf(first)))).toBe(2);
 
         // The first staging completes and releases its hold while the second
         // is still awaiting dispatch.
@@ -380,12 +375,9 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
           jobData: REDIS_TIER_PAYLOAD,
           groupId: TENANT_GROUP,
         });
-        lifecycle.acquire(first);
-        await vi.waitFor(async () =>
-          expect(await redis.scard(holderKey(hashOf(first)))).toBeGreaterThan(
-            0,
-          ),
-        );
+        // Both stagings' holds land at encode-time (hold-before-write), so the
+        // set already has 2 members before either is released.
+        expect(await redis.scard(holderKey(hashOf(first)))).toBe(2);
 
         lifecycle.release({ values: [first], groupId: TENANT_GROUP });
         await new Promise((resolve) => setTimeout(resolve, 150));
@@ -412,6 +404,7 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
       });
 
     describe("when the same content is re-held before the delete executes", () => {
+      /** @scenario "An s3 reclaim is skipped when the content is re-held before the delete executes" */
       it("skips the delete so the new occupancy never references a deleted object", async () => {
         const graced = gracedLifecycle(200);
         const shared = { bulk: incompressible(768 * 1024) };

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/envelopeBlobLifecycle.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/envelopeBlobLifecycle.integration.test.ts
@@ -54,6 +54,9 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
         kind: "s3",
         bucket: "test-bucket",
       }),
+      // No reclaim grace by default so out-of-band delete assertions stay
+      // prompt; the grace behaviour has its own dedicated suite below.
+      s3ReclaimGraceMs: 0,
     });
   });
 
@@ -150,9 +153,12 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
         });
         const newHash = hashOf(newValue);
         const newHolderKey = `${queueName}:gq:blobholders:proj2/${newHash}`;
-        lifecycle.acquire(oldValue);
+        // Drop the hold proj2's own encode registered: the guard under test is
+        // about a foreign value arriving in proj1's group (mis-routed/forged),
+        // where no legitimate proj2 staging exists.
+        await redis.del(newHolderKey);
         const oldKey = holderKey(hashOf(oldValue));
-        await vi.waitFor(async () => expect(await redis.scard(oldKey)).toBe(1));
+        expect(await redis.scard(oldKey)).toBe(1); // encode-time hold
 
         lifecycle.transfer({ newValue, oldValue, groupId: TENANT_GROUP });
 
@@ -178,10 +184,9 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
         });
         const hash = hashOf(v1);
         expect(hashOf(v2)).toBe(hash); // same content → same blob
-        lifecycle.acquire(v1);
-        await vi.waitFor(async () =>
-          expect(await redis.scard(holderKey(hash))).toBe(1),
-        );
+        // Each encode registered its own hold up front, so both occupancies
+        // are already in the holder set before any transfer runs.
+        expect(await redis.scard(holderKey(hash))).toBe(2);
 
         lifecycle.transfer({
           newValue: v2,
@@ -213,9 +218,9 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
         });
 
         expect(hashOf(v2)).toBe(hashOf(v1));
-        lifecycle.acquire(v1);
         const key = holderKey(hashOf(v1));
-        await vi.waitFor(async () => expect(await redis.scard(key)).toBe(1));
+        // Both encode-time holds are registered before anything is staged.
+        expect(await redis.scard(key)).toBe(2);
 
         lifecycle.transfer({
           newValue: v2,
@@ -308,6 +313,143 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
         await vi.waitFor(async () =>
           expect(await redis.scard(holderKey(hashOf(gq2Value)))).toBe(1),
         );
+      });
+    });
+  });
+
+  describe("given stagings sharing one content-addressed blob", () => {
+    describe("when a value is encoded", () => {
+      it("registers the occupancy's hold before encode returns", async () => {
+        const value = await lifecycle.encode({
+          jobData: REDIS_TIER_PAYLOAD,
+          groupId: TENANT_GROUP,
+        });
+
+        // No acquire() call: by the time the value exists (and could be
+        // staged), the hold must already be in the holder set — a hold that
+        // only lands after staging leaves a window where a sibling's release
+        // reclaims the shared blob.
+        const hold = readEnvelopeHold(value)!;
+        expect(await redis.smembers(holderKey(hold.ref.hash))).toContain(
+          hold.token,
+        );
+      });
+    });
+
+    describe("when one staging retires before a concurrent one dispatches", () => {
+      it("keeps the shared s3 blob alive for the remaining staging", async () => {
+        const shared = { bulk: incompressible(768 * 1024) }; // > 256 KiB gzipped → s3
+        const first = await lifecycle.encode({
+          jobData: shared,
+          groupId: TENANT_GROUP,
+        });
+        const second = await lifecycle.encode({
+          jobData: shared,
+          groupId: TENANT_GROUP,
+        });
+        expect(readEnvelopeHold(second)!.ref.tier).toBe("s3");
+        // Ensure the FIRST staging's hold has landed (post-stage refresh), so
+        // its release below actually removes a member — the interleave where a
+        // hold-after-staging design empties the set and reclaims the blob out
+        // from under the second staging.
+        lifecycle.acquire(first);
+        await vi.waitFor(async () =>
+          expect(await redis.scard(holderKey(hashOf(first)))).toBeGreaterThan(
+            0,
+          ),
+        );
+
+        // The first staging completes and releases its hold while the second
+        // is still awaiting dispatch.
+        lifecycle.release({ values: [first], groupId: TENANT_GROUP });
+        // Wait past the point an unguarded release would have deleted it.
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
+        expect(objectStore.deleted).toHaveLength(0);
+        expect(
+          await lifecycle.decode({ value: second, groupId: TENANT_GROUP }),
+        ).toEqual(shared);
+      });
+
+      it("keeps the shared redis blob alive for the remaining staging", async () => {
+        const first = await lifecycle.encode({
+          jobData: REDIS_TIER_PAYLOAD,
+          groupId: TENANT_GROUP,
+        });
+        const second = await lifecycle.encode({
+          jobData: REDIS_TIER_PAYLOAD,
+          groupId: TENANT_GROUP,
+        });
+        lifecycle.acquire(first);
+        await vi.waitFor(async () =>
+          expect(await redis.scard(holderKey(hashOf(first)))).toBeGreaterThan(
+            0,
+          ),
+        );
+
+        lifecycle.release({ values: [first], groupId: TENANT_GROUP });
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
+        expect(await redis.exists(blobKey(hashOf(second)))).toBe(1);
+        expect(
+          await lifecycle.decode({ value: second, groupId: TENANT_GROUP }),
+        ).toEqual(REDIS_TIER_PAYLOAD);
+      });
+    });
+  });
+
+  describe("given an s3 reclaim decision with a grace window", () => {
+    const gracedLifecycle = (graceMs: number) =>
+      new EnvelopeBlobLifecycle({
+        redis,
+        queueName,
+        objectStoreFor: () => objectStore,
+        resolveStorageDestination: async () => ({
+          kind: "s3",
+          bucket: "test-bucket",
+        }),
+        s3ReclaimGraceMs: graceMs,
+      });
+
+    describe("when the same content is re-held before the delete executes", () => {
+      it("skips the delete so the new occupancy never references a deleted object", async () => {
+        const graced = gracedLifecycle(200);
+        const shared = { bulk: incompressible(768 * 1024) };
+        const first = await graced.encode({
+          jobData: shared,
+          groupId: TENANT_GROUP,
+        });
+
+        // Sole holder retires → reclaim decided; a new staging re-holds the
+        // same content inside the grace window.
+        graced.release({ values: [first], groupId: TENANT_GROUP });
+        const second = await graced.encode({
+          jobData: shared,
+          groupId: TENANT_GROUP,
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 400));
+        expect(objectStore.deleted).toHaveLength(0);
+        expect(
+          await graced.decode({ value: second, groupId: TENANT_GROUP }),
+        ).toEqual(shared);
+      });
+    });
+
+    describe("when nothing re-holds the content within the grace", () => {
+      it("deletes the object once the grace elapses", async () => {
+        const graced = gracedLifecycle(100);
+        const value = await graced.encode({
+          jobData: { bulk: incompressible(768 * 1024) },
+          groupId: TENANT_GROUP,
+        });
+
+        graced.release({ values: [value], groupId: TENANT_GROUP });
+
+        await vi.waitFor(() => expect(objectStore.deleted).toHaveLength(1), {
+          timeout: 2000,
+          interval: 25,
+        });
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -473,6 +473,43 @@ describe("jobEnvelope", () => {
         ).toEqual(big);
       });
 
+      it("registers the hold before the blob is written, for the blob the envelope references", async () => {
+        // Ordering is the correctness property: content-addressed blobs are
+        // shared across jobs, so a hold that lands after the write leaves a
+        // window where another job's release reclaims the blob. Hold-first
+        // means a racing reclaim either sees the hold or deletes bytes the
+        // write below restores.
+        const { tieredBlobs, redisBlobs } = makeTiered();
+        const order: string[] = [];
+        const acquired: { projectId?: string; hash?: string; token?: string } =
+          {};
+        const originalPut = redisBlobs.put.bind(redisBlobs);
+        redisBlobs.put = async (params) => {
+          order.push("write");
+          return originalPut(params);
+        };
+
+        const encoded = await encodeJobEnvelope({
+          jobData: big,
+          tieredBlobs,
+          projectId: PROJECT,
+          acquireHold: async ({ projectId, hash, token }) => {
+            order.push("hold");
+            acquired.projectId = projectId;
+            acquired.hash = hash;
+            acquired.token = token;
+          },
+        });
+
+        expect(order).toEqual(["hold", "write"]);
+        const hold = readEnvelopeHold(encoded)!;
+        expect(acquired).toEqual({
+          projectId: PROJECT,
+          hash: hold.ref.hash,
+          token: hold.token,
+        });
+      });
+
       it("exposes routing meta from the header without resolving the blob", async () => {
         const { tieredBlobs } = makeTiered();
         const encoded = await encodeJobEnvelope({

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.unit.test.ts
@@ -175,9 +175,52 @@ describe("TieredBlobStore", () => {
           "over the threshold so it lands in the s3 tier",
         );
         const ref = await store.put({ projectId: PROJECT, data });
-        objectStore.store.clear(); // the object vanished (NoSuchKey)
+        // The double throws the registry's real ObjectNotFoundError, the shape
+        // production reads actually see for a deleted object.
+        objectStore.store.clear();
 
         expect(await store.get(ref)).toBeNull();
+      });
+
+      it("classifies every not-found shape as missing, never transient", async () => {
+        // A miss can surface as the driver's translated error OR a raw
+        // SDK/errno shape (an ObjectStore that doesn't translate). Treating
+        // any of these as transient sends the job through the full retry
+        // ladder instead of the immediate missing-blob fail-safe.
+        const missingShapes: (() => Error)[] = [
+          () => Object.assign(new Error("miss"), { name: "NoSuchKey" }),
+          () => Object.assign(new Error("miss"), { name: "NotFound" }),
+          () => Object.assign(new Error("miss"), { code: "ENOENT" }),
+          () =>
+            Object.assign(new Error("miss"), {
+              $metadata: { httpStatusCode: 404 },
+            }),
+          () =>
+            Object.assign(new Error("Object not found: s3://b/k"), {
+              name: "ObjectNotFoundError",
+            }),
+        ];
+        for (const shape of missingShapes) {
+          const gone: ObjectStore = {
+            put: async () => {},
+            get: async () => {
+              throw shape();
+            },
+            delete: async () => {},
+          };
+          const store = new TieredBlobStore({
+            redisBlobs: new InMemoryJobBlobStore(),
+            objectStoreFor: () => gone,
+            resolveDestination: async () => ({
+              kind: "s3",
+              bucket: "test-bucket",
+            }),
+            s3ThresholdBytes: 8,
+          });
+          const ref: BlobRef = { tier: "s3", projectId: PROJECT, hash: "h" };
+
+          expect(await store.get(ref)).toBeNull();
+        }
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/blobConstants.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/blobConstants.ts
@@ -44,3 +44,14 @@ export const BLOB_HOLDER_TTL_SECONDS = BLOB_BACKSTOP_TTL_SECONDS + 24 * 60 * 60;
  * (ADR-030 §1).
  */
 export const MAX_BLOB_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Grace period between an s3-tier reclaim decision (holder set emptied) and
+ * the out-of-band DeleteObject. Unlike the redis tier — whose UNLINK is atomic
+ * with the emptiness check inside the release Lua — the s3 delete is a
+ * separate network call, so a staging on another pod can re-hold the same
+ * content in the gap. The reclaimer waits this long and re-checks the holder
+ * set before deleting; a skipped delete degrades to the TTL / bucket-lifecycle
+ * backstop, never to a deleted live blob.
+ */
+export const S3_RECLAIM_GRACE_MS = 5_000;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/blobHolders.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/blobHolders.ts
@@ -118,6 +118,22 @@ export class BlobHolders {
       .exec();
   }
 
+  /**
+   * Whether ANY slot currently holds the blob. Used by the s3 reclaim grace
+   * re-check: the reclaim decision is made inside the release eval, but the s3
+   * DeleteObject is a separate call — if the content was re-held in the gap,
+   * the delete must be skipped.
+   */
+  async isHeld({
+    projectId,
+    hash,
+  }: {
+    projectId: TenantId;
+    hash: string;
+  }): Promise<boolean> {
+    return (await this.redis.exists(this.holderKey(projectId, hash))) === 1;
+  }
+
   /** Refreshes the holder set's TTL on access (dispatch), so it outlives the blob it guards. */
   async touch({
     projectId,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
@@ -7,6 +7,7 @@ import {
   redactStorageUrisInText,
 } from "../../../stored-objects/project-storage-destination";
 import { createTenantId, type TenantId } from "../../domain/tenantId";
+import { S3_RECLAIM_GRACE_MS } from "./blobConstants";
 import { BlobHolders } from "./blobHolders";
 import {
   decodeJobEnvelope,
@@ -20,7 +21,11 @@ import {
 import { gqBlobReclaimS3FailuresTotal } from "./metrics";
 import { hasRedisHashTag } from "./redisHashTag";
 import { RedisJobBlobStore } from "./redisJobBlobStore";
-import { type ObjectStore, TieredBlobStore } from "./tieredBlobStore";
+import {
+  type BlobRef,
+  type ObjectStore,
+  TieredBlobStore,
+} from "./tieredBlobStore";
 
 const logger = createLogger("langwatch:event-sourcing:envelope-blob-lifecycle");
 
@@ -36,6 +41,7 @@ export class EnvelopeBlobLifecycle {
   private readonly tieredBlobs?: TieredBlobStore;
   private readonly queueName: string;
   private readonly writesEnabled?: boolean;
+  private readonly s3ReclaimGraceMs: number;
 
   constructor({
     redis,
@@ -43,6 +49,7 @@ export class EnvelopeBlobLifecycle {
     objectStoreFor,
     resolveStorageDestination,
     writesEnabled,
+    s3ReclaimGraceMs,
   }: {
     redis: IORedis | Cluster;
     queueName: string;
@@ -58,9 +65,15 @@ export class EnvelopeBlobLifecycle {
      * env var (call-time read so tests can toggle without module reload).
      */
     writesEnabled?: boolean;
+    /**
+     * Grace between an s3 reclaim decision and its DeleteObject; see
+     * {@link S3_RECLAIM_GRACE_MS}. Injectable so tests don't wait wall-clock.
+     */
+    s3ReclaimGraceMs?: number;
   }) {
     this.queueName = queueName;
     this.writesEnabled = writesEnabled;
+    this.s3ReclaimGraceMs = s3ReclaimGraceMs ?? S3_RECLAIM_GRACE_MS;
     // The holder release/transfer evals touch two keys (holder + blob); in
     // cluster mode they must share a slot, which requires the queue name to
     // carry a hash tag. Fail fast rather than CROSSSLOT-leak silently at runtime
@@ -103,6 +116,12 @@ export class EnvelopeBlobLifecycle {
   /**
    * Encodes a job payload into a staged envelope, offloading a large body to the
    * content-addressed tiered store under the group's tenant namespace.
+   *
+   * The occupancy's hold on the shared blob is registered HERE, awaited, before
+   * the blob is written and before the returned value can be staged — so by the
+   * time any other job's release can observe this occupancy, its hold is
+   * already in the holder set. The fire-and-forget post-stage
+   * {@link EnvelopeBlobLifecycle.acquire} is only a TTL refresh on top of this.
    */
   async encode({
     jobData,
@@ -119,6 +138,8 @@ export class EnvelopeBlobLifecycle {
       writesEnabled: this.writesEnabled,
       queueName: this.queueName,
       logger,
+      acquireHold: ({ projectId, hash, token }) =>
+        this.blobHolders.acquire({ projectId, hash, slotId: token }),
     });
   }
 
@@ -182,9 +203,14 @@ export class EnvelopeBlobLifecycle {
   }
 
   /**
-   * Acquires this staged occupancy's hold on its GQ2 blob (no-op for GQ1,
-   * inline, and legacy values). Fire-and-forget: a missed acquire degrades to
-   * the blob's TTL backstop, never to a premature reclaim.
+   * Re-asserts this staged occupancy's hold on its GQ2 blob (no-op for GQ1,
+   * inline, and legacy values). The authoritative hold is registered inside
+   * {@link encode}, awaited, before the blob is written — content-addressed
+   * blobs are shared across jobs, so a hold that only exists after staging
+   * leaves a window where another job's release reclaims the blob out from
+   * under this one. This post-stage call is an idempotent SADD + TTL refresh
+   * for values that were encoded earlier (re-stages, drained-sibling
+   * re-stages), and safe to fire-and-forget.
    */
   acquire(value: string): void {
     const hold = readEnvelopeHold(value);
@@ -249,26 +275,8 @@ export class EnvelopeBlobLifecycle {
             slotId: hold.token,
           })
           .then((outcome) => {
-            if (outcome === "reclaim-s3" && this.tieredBlobs) {
-              return this.tieredBlobs.delete(hold.ref).catch((err: unknown) => {
-                // S3 reclaim failed — the holder is already gone, so no future
-                // release will retry this object. Warn AND counter so oncall
-                // sees a recurring failure before the bucket-lifecycle
-                // backstop kicks in (2026-06-24 review).
-                gqBlobReclaimS3FailuresTotal.inc({
-                  queue_name: this.queueName,
-                });
-                logger.warn(
-                  {
-                    projectId: hold.ref.projectId,
-                    blobHash: hold.ref.hash,
-                    err: redactStorageUrisInText(
-                      err instanceof Error ? err.message : String(err),
-                    ),
-                  },
-                  "S3 blob reclaim failed after holder drop — orphaned until bucket lifecycle sweeps",
-                );
-              });
+            if (outcome === "reclaim-s3") {
+              return this.reclaimS3(hold.ref, "holder drop");
             }
           })
           .catch((err: unknown) => {
@@ -369,20 +377,8 @@ export class EnvelopeBlobLifecycle {
         oldSlotId: oldHold.token,
       })
       .then((outcome) => {
-        if (outcome === "reclaim-s3" && this.tieredBlobs) {
-          return this.tieredBlobs.delete(oldHold.ref).catch((err: unknown) => {
-            gqBlobReclaimS3FailuresTotal.inc({ queue_name: this.queueName });
-            logger.warn(
-              {
-                projectId: oldHold.ref.projectId,
-                blobHash: oldHold.ref.hash,
-                err: redactStorageUrisInText(
-                  err instanceof Error ? err.message : String(err),
-                ),
-              },
-              "S3 blob reclaim failed after transfer — orphaned until bucket lifecycle sweeps",
-            );
-          });
+        if (outcome === "reclaim-s3") {
+          return this.reclaimS3(oldHold.ref, "transfer");
         }
       })
       .catch((err: unknown) => {
@@ -398,6 +394,55 @@ export class EnvelopeBlobLifecycle {
           "Blob holder transfer failed; relying on the TTL backstop",
         );
       });
+  }
+
+  /**
+   * Out-of-band s3 reclaim with a grace re-check. The release/transfer eval
+   * decided the holder set was empty, but the DeleteObject is a separate
+   * network call — a staging elsewhere can re-hold the same content in the gap
+   * (its hold is registered before its PUT, so a re-held blob is always
+   * rewritten). Wait out the grace, re-check the holder set, and skip the
+   * delete when the content is held again: a skipped orphan degrades to the
+   * TTL / bucket-lifecycle backstop, never to a deleted live blob.
+   */
+  private async reclaimS3(ref: BlobRef, edge: string): Promise<void> {
+    if (!this.tieredBlobs) return;
+    try {
+      if (this.s3ReclaimGraceMs > 0) {
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, this.s3ReclaimGraceMs);
+          // Never keep a worker process alive just to finish a best-effort
+          // delete; an abandoned reclaim is an orphan for the backstop.
+          timer.unref?.();
+        });
+      }
+      if (
+        await this.blobHolders.isHeld({
+          projectId: ref.projectId,
+          hash: ref.hash,
+        })
+      ) {
+        return;
+      }
+      await this.tieredBlobs.delete(ref);
+    } catch (err: unknown) {
+      // S3 reclaim failed — the holder is already gone, so no future release
+      // will retry this object. Warn AND counter so oncall sees a recurring
+      // failure before the bucket-lifecycle backstop kicks in (2026-06-24
+      // review).
+      gqBlobReclaimS3FailuresTotal.inc({ queue_name: this.queueName });
+      logger.warn(
+        {
+          projectId: ref.projectId,
+          blobHash: ref.hash,
+          edge,
+          err: redactStorageUrisInText(
+            err instanceof Error ? err.message : String(err),
+          ),
+        },
+        "S3 blob reclaim failed after holder drop — orphaned until bucket lifecycle sweeps",
+      );
+    }
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
@@ -440,7 +440,7 @@ export class EnvelopeBlobLifecycle {
             err instanceof Error ? err.message : String(err),
           ),
         },
-        "S3 blob reclaim failed after holder drop — orphaned until bucket lifecycle sweeps",
+        `S3 blob reclaim failed after ${edge} — orphaned until bucket lifecycle sweeps`,
       );
     }
   }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -415,13 +415,16 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       shouldSurviveDispatch,
     });
 
-    // Acquire this occupancy's hold BEFORE releasing any payload a dedup squash
-    // displaced, so a squash re-staging identical content never drops the shared
-    // blob to zero holders. Both are no-ops for inline/legacy values.
+    // This occupancy's hold was registered inside encode(), awaited, BEFORE the
+    // blob write and before the stage above — so no concurrent release could
+    // reclaim the shared blob while this value was in flight (ADR-029 AC3.9).
+    // What remains here is squash bookkeeping and a TTL refresh; both are
+    // no-ops for inline/legacy values.
     if (orphanedValue) {
       // Atomic hold transfer: a dedup squash moves the hold from the displaced
       // value to the new one in one eval, so a partial failure can't reclaim a
-      // live blob (ADR-030 §4).
+      // live blob (ADR-030 §4). The new value's encode-time hold makes the SADD
+      // half idempotent.
       this.blobLifecycle.transfer({
         newValue: jobDataJson,
         oldValue: orphanedValue,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -338,6 +338,11 @@ export async function encodeJobEnvelope({
       // holder-set TTL backstop clears it (ADR-030 §3).
       if (acquireHold) {
         await acquireHold({ projectId, hash, token });
+      } else if (logger) {
+        logger.warn(
+          { projectId, queueName },
+          "GQ2 encode staged a tiered blob without acquireHold wired — hold-before-write race protection is disabled",
+        );
       }
       const ref = await tieredBlobs.put({
         projectId,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { gunzip, gzip } from "node:zlib";
 
+import { generate } from "@langwatch/ksuid";
 import type { Logger } from "pino";
 
 import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
@@ -326,7 +327,7 @@ export async function encodeJobEnvelope({
       // Per-stage hold token: the holder-set member identifying this staged
       // occupancy. Lives in the (inline) header, never in the content-addressed
       // body, so it doesn't perturb the blob hash that collapses the fan-out.
-      const token = randomUUID();
+      const token = generate("holdtoken").toString();
       // The hash the tiered store will key by (it hashes the same raw payload
       // json, so the two derivations can't diverge). Known before the write so
       // the hold can be registered first.

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -8,7 +8,11 @@ import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
 
 import { MAX_BLOB_BYTES } from "./blobConstants";
 import { gqEnvelopeGQ2DowngradeTotal, gqPayloadTooLargeTotal } from "./metrics";
-import type { BlobRef, TieredBlobStore } from "./tieredBlobStore";
+import {
+  type BlobRef,
+  contentHash,
+  type TieredBlobStore,
+} from "./tieredBlobStore";
 
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
@@ -255,6 +259,7 @@ export async function encodeJobEnvelope({
   writesEnabled,
   queueName,
   logger,
+  acquireHold,
 }: {
   jobData: Record<string, unknown>;
   blobs?: JobBlobStore;
@@ -272,6 +277,20 @@ export async function encodeJobEnvelope({
   queueName?: string;
   /** Optional logger for tenant-attributed warn on cap / downgrade. */
   logger?: Logger;
+  /**
+   * Registers this occupancy's hold on the content-addressed blob BEFORE the
+   * blob is written. Ordering is the correctness property: content-addressed
+   * blobs are shared across every job carrying identical bytes, so another
+   * job's terminal release can reclaim the blob at any moment the holder set
+   * doesn't yet list us. Registering first means a concurrent
+   * release-and-reclaim either sees our hold (and keeps the blob) or deletes
+   * a copy our own subsequent PUT rewrites (ADR-029 AC3.9).
+   */
+  acquireHold?: (params: {
+    projectId: TenantId;
+    hash: string;
+    token: string;
+  }) => Promise<void>;
 }): Promise<string> {
   const json = JSON.stringify(jobData);
   const enabled = writesEnabled ?? envelopeWritesEnabled();
@@ -304,6 +323,22 @@ export async function encodeJobEnvelope({
     const payloadJson = JSON.stringify(payload);
     const payloadBytes = Buffer.byteLength(payloadJson);
     if (payloadBytes > INLINE_CEILING_BYTES) {
+      // Per-stage hold token: the holder-set member identifying this staged
+      // occupancy. Lives in the (inline) header, never in the content-addressed
+      // body, so it doesn't perturb the blob hash that collapses the fan-out.
+      const token = randomUUID();
+      // The hash the tiered store will key by (it hashes the same raw payload
+      // json, so the two derivations can't diverge). Known before the write so
+      // the hold can be registered first.
+      const hash = contentHash(payloadJson);
+      // Hold BEFORE write (awaited): once the hold is in the holder set, no
+      // concurrent release can reclaim this content; and any reclaim that won
+      // the race before our hold landed deleted bytes the PUT below rewrites.
+      // A crash between these two steps leaves a hold guarding nothing — the
+      // holder-set TTL backstop clears it (ADR-030 §3).
+      if (acquireHold) {
+        await acquireHold({ projectId, hash, token });
+      }
       const ref = await tieredBlobs.put({
         projectId,
         data: await gzipAsync(payloadJson),
@@ -315,10 +350,7 @@ export async function encodeJobEnvelope({
       });
       header.e = ref.tier;
       header.ref = ref;
-      // Per-stage hold token: the holder-set member identifying this staged
-      // occupancy. Lives in the (inline) header, never in the content-addressed
-      // body, so it doesn't perturb the blob hash that collapses the fan-out.
-      header.h = randomUUID();
+      header.h = token;
       return finalize(ENVELOPE_PREFIX_V2, header, "");
     }
     return finalize(

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
@@ -5,6 +5,7 @@ import type { Logger } from "pino";
 
 import { COMMAND_INLINE_THRESHOLD } from "~/server/app-layer/traces/lean-for-projection";
 import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
+import { ObjectNotFoundError } from "~/server/stored-objects/errors";
 import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
 import { mintFileUri, mintS3Uri } from "~/server/stored-objects/uri";
 
@@ -113,15 +114,26 @@ async function streamToBuffer(
   return Buffer.concat(chunks);
 }
 
-/** Whether an object-store error means the object is absent (vs a transient failure). */
+/**
+ * Whether an object-store error means the object is absent (vs a transient
+ * failure). Covers BOTH shapes a miss can arrive in: the stored-objects
+ * drivers' own {@link ObjectNotFoundError} (what `StorageRegistry.get`
+ * actually throws — `S3Driver`/`LocalFilesystemDriver` translate their SDK
+ * miss into it), and the raw SDK/errno shapes for any `ObjectStore`
+ * implementation that doesn't translate. Missing either shape misclassifies a
+ * gone-forever blob as transient, sending the job into a full retry ladder
+ * instead of the immediate missing-blob fail-safe.
+ */
 function isObjectMissingError(err: unknown): boolean {
   if (err == null || typeof err !== "object") return false;
+  if (err instanceof ObjectNotFoundError) return true;
   const e = err as {
     name?: string;
     code?: string;
     $metadata?: { httpStatusCode?: number };
   };
   return (
+    e.name === "ObjectNotFoundError" ||
     e.name === "NoSuchKey" ||
     e.name === "NotFound" ||
     e.code === "ENOENT" ||

--- a/specs/event-sourcing/payload-store-blob-hardening.feature
+++ b/specs/event-sourcing/payload-store-blob-hardening.feature
@@ -105,6 +105,36 @@ Feature: GroupQueue blob-handling hardening
     Then the blob survives until the last referencing job retires
     And no still-staged job is left pointing at a reclaimed blob
 
+  @integration @track3
+  # A hold that only lands after staging leaves a window where a fast sibling's
+  # completion sees an "empty" holder set and reclaims a blob a concurrent
+  # staging still needs. Hold-first closes it: a racing reclaim either sees the
+  # hold, or deletes bytes the staging's own idempotent write restores.
+  Scenario: A staging's hold on its shared blob exists before the blob is written
+    When a job whose payload offloads to a shared content-addressed blob is encoded
+    Then its hold is registered in the holder set before the blob write
+    And before the job becomes dispatchable
+
+  @integration @track3
+  Scenario: A fan-out sibling completing early never reclaims a blob a concurrent staging references
+    Given two stagings encoding the same content-addressed payload
+    When the first retires before the second is dispatched
+    Then the shared blob survives the first staging's release
+    And the second staging decodes its payload intact
+
+  @integration @track3
+  # The redis-tier reclaim is atomic inside the release eval; the s3 delete is a
+  # separate network call, so the reclaim decision can be stale by the time the
+  # delete executes. The reclaimer re-checks after a grace window and skips the
+  # delete when the content is held again — a skipped orphan degrades to the
+  # TTL / bucket-lifecycle backstop, never to a deleted live blob.
+  Scenario: An s3 reclaim is skipped when the content is re-held before the delete executes
+    Given an s3-tier blob whose last holder released
+    And a new staging re-holds the same content before the reclaim delete runs
+    When the grace window elapses and the reclaimer re-checks the holder set
+    Then the delete is skipped
+    And the new staging decodes its payload intact
+
   # ===========================================================================
   # Track 4 — atomic hold transfer (no reclaim gap)
   # ===========================================================================
@@ -181,6 +211,9 @@ Feature: GroupQueue blob-handling hardening
   #   AC3.1 holder TTL ≥ blob TTL     -> The holder-set TTL is never shorter than the blob TTL
   #   AC3.2 dispatch refreshes both   -> Dispatch refreshes the holder set as well as the blob
   #   AC3.3 no premature reclaim      -> A long-lived fan-out does not prematurely reclaim a referenced blob
+  #   AC3.4 hold-before-write         -> A staging's hold on its shared blob exists before the blob is written
+  #   AC3.5 sibling-safe release      -> A fan-out sibling completing early never reclaims a blob ...
+  #   AC3.6 s3 reclaim grace re-check -> An s3 reclaim is skipped when the content is re-held ...
   # Track 4 — atomic transfer
   #   AC4.1 atomic retry transfer     -> A retry transfers the hold ... in a single atomic step
   #   AC4.2 no reclaim on partial     -> A partial failure during the transfer cannot reclaim a referenced blob
@@ -192,6 +225,6 @@ Feature: GroupQueue blob-handling hardening
   # Track 6 — cluster-slot guard
   #   AC6.1 reject hash-tag-less name -> A queue name without a Redis hash tag is rejected at construction
   #
-  # Count: 16 behavioral ACs -> 16 scenarios. Streaming (the original AC1.2) was
+  # Count: 19 behavioral ACs -> 19 scenarios. Streaming (the original AC1.2) was
   # dropped in implementation — the cap is the memory bound (ADR-030 §1).
   # ===========================================================================


### PR DESCRIPTION
## Problem

GQ2's content-addressed payload store shares one blob across every job carrying identical bytes (the fan-out win from ADR-029). But each occupancy's hold on that blob was registered **fire-and-forget, after staging**. That leaves a window where a fast sibling job completes, releases its own hold, sees an "empty" holder set, and reclaims a blob that a concurrent staging still references. The staged job then finds its payload gone and takes the missing-blob fail-safe instead of running its handler.

ADR-029's spec already required the hold to be atomic with staging (`payload-store-content-addressed.feature` AC3.9: *"SADD at stage … atomic with the job-entry write"*) — the implementation didn't match it.

A second, compounding gap: a genuinely deleted s3-tier object surfaces as the stored-objects drivers' `ObjectNotFoundError`, which `TieredBlobStore`'s missing-vs-transient classifier didn't recognize — so a gone-forever blob was treated as a transient outage and rode the full 25-attempt retry ladder (~2.5h+) before reaching the same fail-safe it should have hit on attempt 1. The unit-test double threw a `NoSuchKey`-named error rather than the real class, which is exactly why tests passed while the real read path misclassified.

## Fix

1. **Hold before write, awaited** (`jobEnvelope.ts`, `envelopeBlobLifecycle.ts`): `encode()` now registers the occupancy's hold in the holder set *before* the blob is written and before the returned value can be staged. A racing reclaim either sees the hold (and keeps the blob), or deletes bytes the staging's own idempotent content-addressed PUT restores immediately after. A crash between hold and write degrades to the holder-TTL backstop, never to a reclaimed live blob. The post-stage `acquire()` becomes an idempotent TTL refresh.
2. **S3 reclaim grace re-check** (`envelopeBlobLifecycle.ts`, `blobHolders.isHeld`): the redis tier's reclaim is atomic inside the release Lua, but the s3 `DeleteObject` is a separate network call whose decision can be stale by the time it executes. The reclaimer now waits `S3_RECLAIM_GRACE_MS` and re-checks the holder set, skipping the delete when the content was re-held. A skipped delete degrades to the TTL / bucket-lifecycle backstop.
3. **Not-found classification** (`tieredBlobStore.ts`): `isObjectMissingError` now recognizes `ObjectNotFoundError` (instance and shape) alongside the raw SDK/errno shapes, so a missing blob reaches the fail-safe immediately instead of burning the whole retry budget. The in-memory object-store double now throws the registry's real error class so this shape gap can't hide behind the double again.

## Tests

The old interleavings are reproduced deterministically; all of these **fail against the previous implementation**:

- `jobEnvelope.unit`: hold is registered before the blob write, for the same (hash, token) the envelope references.
- `envelopeBlobLifecycle.integration`: encode returns with the hold already in the holder set; a sibling's release never reclaims a blob a concurrent staging references (redis + s3 tiers); the s3 grace re-check skips the delete when the content is re-held, and still deletes when nothing re-holds it.
- `tieredBlobStore.unit`: every not-found shape (driver class, `NoSuchKey`, `NotFound`, `ENOENT`, HTTP 404) classifies as missing, never transient.

Spec: three new Track-3 scenarios in `specs/event-sourcing/payload-store-blob-hardening.feature` (hold-before-write, sibling-safe release, s3 reclaim grace re-check).

Verified: full groupQueue suite green — 208 integration + 94 unit — plus `pnpm typecheck`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented premature reclamation by ensuring shared blobs remain held while referenced by active staging operations.
  - Improved payload/envelope sequencing so holder registration occurs before blob writes.
  - Hardened “missing blob” detection across backends to avoid misclassification.
  - Added an S3 reclaim grace window that skips deletion when content is re-held before cleanup completes.

- **Tests**
  - Expanded integration and unit coverage for shared staging, fast sibling behavior, fan-out scenarios, retry alignment, and grace-window reclaim skip/delete behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->