### PR TITLE
fix(scenarios): accept documented image/file attachment parts in MESSAGE_SNAPSHOT

### DIFF
--- a/langwatch/src/app/api/files/[[...route]]/app.ts
+++ b/langwatch/src/app/api/files/[[...route]]/app.ts
@@ -1,18 +1,18 @@
 import { Readable } from "node:stream";
-import { HTTPException } from "hono/http-exception";
 import type { MiddlewareHandler } from "hono";
-import { prisma } from "~/server/db";
+import { HTTPException } from "hono/http-exception";
+import { anyAuthenticated, createServiceApp } from "~/server/api/security";
 import { requireProjectPermission } from "~/server/auth/permissions";
+import { prisma } from "~/server/db";
 import { rateLimit } from "~/server/rateLimit";
+import { isReadbackSafe } from "~/server/stored-objects/safe-media-types";
 import {
   resolveStoredObjectOwner,
   StoredObjectOwnerLookupUnavailableError,
 } from "~/server/stored-objects/stored-objects-cross-tenant-lookup";
 import { createStoredObjectsService } from "~/server/stored-objects/stored-objects-factory";
-import { isReadbackSafe } from "~/server/stored-objects/safe-media-types";
-import { dualAuth } from "../../middleware/dual-auth";
 import type { DualAuthVariables } from "../../middleware/dual-auth";
-import { anyAuthenticated, createServiceApp } from "~/server/api/security";
+import { dualAuth } from "../../middleware/dual-auth";
 
 // File reads authenticate via dualAuth (project API key OR user session) and
 // authorize per-object in the handler (authorizeFileRead checks the caller's
@@ -66,10 +66,7 @@ const FILES_RESPONSE_BASE_HEADERS: Readonly<Record<string, string>> = {
   "Referrer-Policy": "no-referrer",
 };
 
-function jsonResponse(
-  body: unknown,
-  status: number,
-): Response {
+function jsonResponse(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: {
@@ -118,20 +115,32 @@ async function authorizeFileRead({
  * Content-Type allowlist, Content-Disposition, Content-Length, and all
  * security headers. For HEAD requests the stream is drained and the body is
  * omitted; for GET the stream is forwarded.
+ *
+ * `requestedFilename` is the caller-supplied display name (the `filename`
+ * query param the attachment chip appends). Stored objects are
+ * content-addressed, so the row itself has no filename; passing the
+ * message-level one through gives downloads from the browser viewer a
+ * human name instead of the object id. It runs through the same
+ * `sanitizeFilenameSegment` allowlist as the id (header injection is
+ * neutralised), and an empty sanitised result falls back to the id.
  */
 function streamFileResponse({
   row,
   stream,
   method,
   mediaType,
+  requestedFilename,
 }: {
   row: { id: string; size_bytes: number };
   stream: import("node:stream").Readable;
   method: "GET" | "HEAD";
   mediaType: string;
+  requestedFilename?: string;
 }): Response {
   const contentType = safeMediaType(mediaType);
-  const filename = sanitizeFilenameSegment(row.id);
+  const filename =
+    (requestedFilename ? sanitizeFilenameSegment(requestedFilename) : "") ||
+    sanitizeFilenameSegment(row.id);
 
   const headers: Record<string, string> = {
     "Content-Type": contentType,
@@ -216,17 +225,16 @@ async function handleFileRead(
     max: FILES_RATE_LIMIT_MAX,
   });
   if (!rl.allowed) {
-    return new Response(
-      JSON.stringify({ error: "rate_limited" }),
-      {
-        status: 429,
-        headers: {
-          "Content-Type": "application/json",
-          "Retry-After": String(Math.max(1, Math.ceil((rl.resetAt - Date.now()) / 1000))),
-          ...FILES_RESPONSE_BASE_HEADERS,
-        },
+    return new Response(JSON.stringify({ error: "rate_limited" }), {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        "Retry-After": String(
+          Math.max(1, Math.ceil((rl.resetAt - Date.now()) / 1000)),
+        ),
+        ...FILES_RESPONSE_BASE_HEADERS,
       },
-    );
+    });
   }
 
   // Step 2: resolve the owning project.
@@ -304,6 +312,7 @@ async function handleFileRead(
     stream: result.stream,
     method: options.method,
     mediaType: result.row.media_type,
+    requestedFilename: c.req.query("filename"),
   });
 }
 

--- a/langwatch/src/app/api/files/[[...route]]/app.ts
+++ b/langwatch/src/app/api/files/[[...route]]/app.ts
@@ -132,7 +132,7 @@ function streamFileResponse({
   requestedFilename,
 }: {
   row: { id: string; size_bytes: number };
-  stream: import("node:stream").Readable;
+  stream: Readable;
   method: "GET" | "HEAD";
   mediaType: string;
   requestedFilename?: string;

--- a/langwatch/src/components/simulations/MediaPart.tsx
+++ b/langwatch/src/components/simulations/MediaPart.tsx
@@ -7,8 +7,11 @@
  *  - Missing: when the URL returns a 404/missing status, renders a placeholder badge.
  *
  * Uses native HTML5 <audio>, <img>, <video> — no third-party player library.
+ * Non-media binary parts (documents) render as an attachment chip that opens
+ * the stored file in a new tab.
  */
-import { Badge, Box, Text, VStack } from "@chakra-ui/react";
+import { Badge, Box, Icon, Text, VStack } from "@chakra-ui/react";
+import { ExternalLink, File, FileText } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { api } from "~/utils/api";
 import type { AudioPlaybackProps } from "./useSequentialAudioPlayback";
@@ -99,11 +102,7 @@ interface MediaPartProps {
  * Renders a single AG-UI media content part as a native HTML5 media element,
  * a data: URI, or a missing-badge placeholder.
  */
-export function MediaPart({
-  part,
-  projectId,
-  audioPlayback,
-}: MediaPartProps) {
+export function MediaPart({ part, projectId, audioPlayback }: MediaPartProps) {
   // Resolve src and category from the part shape
   let src: string;
   let mimeType: string | undefined;
@@ -135,7 +134,9 @@ export function MediaPart({
     !src.startsWith("data:") &&
     (part.type === "binary" ? !!part.url : part.source.type === "url");
 
-  const [status, setStatus] = useState<LoadStatus>(isUrlBased ? "loading" : "ok");
+  const [status, setStatus] = useState<LoadStatus>(
+    isUrlBased ? "loading" : "ok",
+  );
 
   // Probe at most once per <src>: a single failed audio/video element can fire
   // `error` repeatedly while the browser retries decoders, and a long scenario
@@ -298,11 +299,62 @@ export function MediaPart({
     );
   }
 
-  // binary fallback — link to download
+  // binary fallback — attachment chip. Stored-object URLs open in a new tab
+  // (the /api/files read route serves Content-Disposition: inline, so PDFs
+  // render in the browser's viewer); legacy inline base64 falls back to a
+  // download, since browsers block top-frame navigation to data: URIs.
+  // Stored objects are content-addressed and carry no filename of their own,
+  // so pass the message-level one along — downloads from the opened viewer
+  // then keep the original name instead of the object id.
+  const filename = part.type === "binary" ? part.filename : undefined;
+  const chipHref =
+    isUrlBased && filename && extractStoredObjectId(src)
+      ? `${src}?filename=${encodeURIComponent(filename)}`
+      : src;
+  const documentLike =
+    mimeType === "application/pdf" || (mimeType?.startsWith("text/") ?? false);
   return (
-    <Box data-testid="media-part-binary">
-      <a href={src} download={part.type === "binary" ? part.filename : undefined}>
-        {part.type === "binary" && part.filename ? part.filename : mimeType ?? "file"}
+    <Box asChild data-testid="media-part-binary">
+      <a
+        href={chipHref}
+        {...(isUrlBased
+          ? { target: "_blank", rel: "noopener noreferrer" }
+          : { download: filename ?? "" })}
+        aria-label={
+          isUrlBased
+            ? `Open ${filename ?? "attachment"} in a new tab`
+            : `Download ${filename ?? "attachment"}`
+        }
+      >
+        <Box
+          display="inline-flex"
+          alignItems="center"
+          gap={2}
+          paddingX={3}
+          paddingY={2}
+          borderRadius="md"
+          bg="bg.subtle"
+          border="1px solid"
+          borderColor="border"
+          _hover={{ bg: "bg.muted" }}
+        >
+          <Icon
+            as={documentLike ? FileText : File}
+            boxSize={4}
+            color="fg.muted"
+          />
+          <Text fontSize="sm" fontWeight="medium">
+            {filename ?? mimeType ?? "file"}
+          </Text>
+          {isUrlBased && (
+            <Icon
+              as={ExternalLink}
+              boxSize={3}
+              color="fg.subtle"
+              data-testid="media-part-binary-open"
+            />
+          )}
+        </Box>
       </a>
     </Box>
   );

--- a/langwatch/src/components/simulations/MediaPart.tsx
+++ b/langwatch/src/components/simulations/MediaPart.tsx
@@ -311,7 +311,7 @@ export function MediaPart({ part, projectId, audioPlayback }: MediaPartProps) {
     isUrlBased && filename && extractStoredObjectId(src)
       ? `${src}?filename=${encodeURIComponent(filename)}`
       : src;
-  const documentLike =
+  const isDocumentLike =
     mimeType === "application/pdf" || (mimeType?.startsWith("text/") ?? false);
   return (
     <Box asChild data-testid="media-part-binary">
@@ -339,7 +339,7 @@ export function MediaPart({ part, projectId, audioPlayback }: MediaPartProps) {
           _hover={{ bg: "bg.muted" }}
         >
           <Icon
-            as={documentLike ? FileText : File}
+            as={isDocumentLike ? FileText : File}
             boxSize={4}
             color="fg.muted"
           />

--- a/langwatch/src/components/simulations/MediaPart.tsx
+++ b/langwatch/src/components/simulations/MediaPart.tsx
@@ -308,7 +308,7 @@ export function MediaPart({ part, projectId, audioPlayback }: MediaPartProps) {
   // then keep the original name instead of the object id.
   const filename = part.type === "binary" ? part.filename : undefined;
   const chipHref =
-    isUrlBased && filename && extractStoredObjectId(src)
+    filename && storedObjectId
       ? `${src}?filename=${encodeURIComponent(filename)}`
       : src;
   const isDocumentLike =

--- a/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -147,6 +147,14 @@ export function ScenarioMessageRenderer({
             );
 
           case "media": {
+            // Audio/video players stretch to the container width; attachment
+            // chips hug the message side like a bubble would (user sent it →
+            // right, agent → left). Mirrored into data-media-align because
+            // jsdom cannot read the compiled flex styles.
+            const innerAlign =
+              item.part.type === "binary"
+                ? alignForRole(item.role)
+                : ("stretch" as const);
             return (
               <VStack
                 key={item.id}
@@ -155,7 +163,8 @@ export function ScenarioMessageRenderer({
                 width="100%"
               >
                 <VStack
-                  align="stretch"
+                  align={innerAlign}
+                  data-media-align={innerAlign}
                   gap={1}
                   width={{ base: "100%", md: "min(420px, 95%)" }}
                 >

--- a/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
@@ -364,6 +364,67 @@ describe("<ScenarioMessageRenderer/>", () => {
     });
   });
 
+  describe("when a message carries a stored document attachment (binary part)", () => {
+    /** @scenario "A document attachment renders as a labeled chip that opens the file in a new tab" */
+    it("renders a chip with a file icon and filename that opens the stored file in a new tab", () => {
+      renderWith([
+        {
+          id: "msg_pdf_attachment",
+          role: "user",
+          content: [
+            { type: "text", text: "Please summarize this document." },
+            {
+              type: "binary",
+              mimeType: "application/pdf",
+              id: "so_123",
+              url: "/api/files/proj_test/so_123",
+              filename: "document.pdf",
+            },
+          ],
+        } as unknown as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      const chip = screen.getByTestId("media-part-binary");
+      // The filename query gives downloads from the opened viewer the
+      // original name (stored objects are content-addressed, no name of
+      // their own).
+      expect(chip).toHaveAttribute(
+        "href",
+        "/api/files/proj_test/so_123?filename=document.pdf",
+      );
+      expect(chip).toHaveAttribute("target", "_blank");
+      expect(chip).toHaveAttribute("rel", "noopener noreferrer");
+      expect(chip).not.toHaveAttribute("download");
+      expect(screen.getByText("document.pdf")).toBeInTheDocument();
+      // File icon plus the open-in-new-tab affordance.
+      expect(chip.querySelector("svg")).not.toBeNull();
+      expect(screen.getByTestId("media-part-binary-open")).toBeInTheDocument();
+    });
+
+    it("falls back to a download link for legacy inline base64 attachments", () => {
+      renderWith([
+        {
+          id: "msg_pdf_legacy",
+          role: "user",
+          content: [
+            {
+              type: "binary",
+              mimeType: "application/pdf",
+              data: "JVBERi0xLjQ=",
+              filename: "legacy.pdf",
+            },
+          ],
+        } as unknown as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      const chip = screen.getByTestId("media-part-binary");
+      expect(chip).toHaveAttribute("download", "legacy.pdf");
+      expect(chip).not.toHaveAttribute("target");
+      expect(screen.getByText("legacy.pdf")).toBeInTheDocument();
+      expect(screen.queryByTestId("media-part-binary-open")).toBeNull();
+    });
+  });
+
   // -------------------------------------------------------------------------
   // #4698 — text-first part ordering + audio-only + assistant=left.
   //

--- a/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
@@ -399,6 +399,15 @@ describe("<ScenarioMessageRenderer/>", () => {
       // File icon plus the open-in-new-tab affordance.
       expect(chip.querySelector("svg")).not.toBeNull();
       expect(screen.getByTestId("media-part-binary-open")).toBeInTheDocument();
+
+      // The user sent the attachment, so the chip hugs the right side like a
+      // user bubble (audio players stretch instead — see data-media-align).
+      const mediaWrapper = chip.closest("[data-media-align]");
+      expect(mediaWrapper).toHaveAttribute("data-media-align", "flex-end");
+      expect(chip.closest("[data-align]")).toHaveAttribute(
+        "data-align",
+        "flex-end",
+      );
     });
 
     it("falls back to a download link for legacy inline base64 attachments", () => {

--- a/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
@@ -381,7 +381,7 @@ describe("<ScenarioMessageRenderer/>", () => {
               filename: "document.pdf",
             },
           ],
-        } as unknown as ScenarioMessageSnapshotEvent["messages"][number],
+        },
       ]);
 
       const chip = screen.getByTestId("media-part-binary");
@@ -423,7 +423,7 @@ describe("<ScenarioMessageRenderer/>", () => {
               filename: "legacy.pdf",
             },
           ],
-        } as unknown as ScenarioMessageSnapshotEvent["messages"][number],
+        },
       ]);
 
       const chip = screen.getByTestId("media-part-binary");

--- a/langwatch/src/server/scenarios/schemas/__tests__/event-schemas.unit.test.ts
+++ b/langwatch/src/server/scenarios/schemas/__tests__/event-schemas.unit.test.ts
@@ -123,7 +123,7 @@ describe("scenarioMessageSnapshotSchema — regression: previously-valid shapes 
  * `extractInlineMediaFromEvent` ever ran — runs showed a report but zero
  * conversation turns in the simulations UI.
  */
-describe("scenarioMessageSnapshotSchema — image/file attachment wire acceptance", () => {
+describe("given a MESSAGE_SNAPSHOT wire event carrying attachment content", () => {
   const WEBP_DATA_URI = `data:image/webp;base64,${Buffer.from(
     "fake-webp-bytes",
   ).toString("base64")}`;
@@ -131,128 +131,138 @@ describe("scenarioMessageSnapshotSchema — image/file attachment wire acceptanc
     "%PDF-1.4 fake pdf bytes",
   ).toString("base64")}`;
 
-  /** @scenario "MESSAGE_SNAPSHOT with an AI-SDK image part is accepted (201) and the image is externalized" */
-  it("ACCEPTS an AI-SDK image turn: [text, {type:'image', image:'data:...'}] (was 400 before the fix)", () => {
-    const event = makeSnapshotEvent([
-      { type: "text", text: "What do you see in this image?" },
-      { type: "image", image: WEBP_DATA_URI },
-    ]);
+  describe("when the message carries an AI-SDK image part", () => {
+    /** @scenario "Documented image and file attachment shapes validate on the wire" */
+    it("ACCEPTS a mixed [text, image] turn (was 400 before the fix)", () => {
+      const event = makeSnapshotEvent([
+        { type: "text", text: "What do you see in this image?" },
+        { type: "image", image: WEBP_DATA_URI },
+      ]);
 
-    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+      expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("ACCEPTS an image-only turn with no text part", () => {
+      const event = makeSnapshotEvent([
+        { type: "image", image: WEBP_DATA_URI },
+      ]);
+
+      expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("preserves the image data URI through validation so the extractor can externalize it", () => {
+      const event = makeSnapshotEvent([
+        { type: "text", text: "What do you see in this image?" },
+        { type: "image", image: WEBP_DATA_URI },
+      ]);
+
+      const result = scenarioMessageSnapshotSchema.safeParse(event);
+      expect(result.success).toBe(true);
+
+      const message = (result.success ? result.data.messages[0] : undefined) as
+        | { content: Array<{ type: string; image?: string }> }
+        | undefined;
+      const part = message?.content.find((p) => p.type === "image");
+      expect(part?.image).toBe(WEBP_DATA_URI);
+    });
+
+    /** @scenario "AI-SDK image parts with http(s) URLs validate and pass through unchanged" */
+    it("ACCEPTS an external http URL image", () => {
+      const event = makeSnapshotEvent([
+        { type: "image", image: "https://example.com/cat.png" },
+      ]);
+
+      expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+    });
   });
 
-  it("ACCEPTS an image-only turn: [{type:'image', image:'data:...'}] with no text part", () => {
-    const event = makeSnapshotEvent([{ type: "image", image: WEBP_DATA_URI }]);
+  describe("when the message carries an OpenAI file part", () => {
+    /** @scenario "Documented image and file attachment shapes validate on the wire" */
+    it("ACCEPTS a [text, file] turn in the multimodal-files docs shape (was 400 before the fix)", () => {
+      const event = makeSnapshotEvent([
+        { type: "text", text: "Please summarize this document." },
+        {
+          type: "file",
+          file: { filename: "document.pdf", file_data: PDF_DATA_URI },
+        },
+      ]);
 
-    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+      expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("preserves the file_data and filename through validation so the extractor can externalize them", () => {
+      const event = makeSnapshotEvent([
+        {
+          type: "file",
+          file: { filename: "document.pdf", file_data: PDF_DATA_URI },
+        },
+      ]);
+
+      const result = scenarioMessageSnapshotSchema.safeParse(event);
+      expect(result.success).toBe(true);
+
+      const message = (result.success ? result.data.messages[0] : undefined) as
+        | {
+            content: Array<{
+              type: string;
+              file?: { file_data?: string; filename?: string };
+            }>;
+          }
+        | undefined;
+      const part = message?.content.find((p) => p.type === "file");
+      expect(part?.file?.file_data).toBe(PDF_DATA_URI);
+      expect(part?.file?.filename).toBe("document.pdf");
+    });
+
+    /** @scenario "OpenAI file parts carrying only a provider file_id pass through unchanged" */
+    it("ACCEPTS a part carrying only a provider file_id", () => {
+      const event = makeSnapshotEvent([
+        { type: "file", file: { file_id: "file-abc123" } },
+      ]);
+
+      expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+    });
   });
 
-  it("preserves the image data URI through validation so the extractor can externalize it", () => {
-    const event = makeSnapshotEvent([
-      { type: "text", text: "What do you see in this image?" },
-      { type: "image", image: WEBP_DATA_URI },
-    ]);
+  describe("when the message carries an AI-SDK file part", () => {
+    /** @scenario "AI-SDK file parts with a document mediaType validate on the wire" */
+    it("ACCEPTS a document mediaType part and preserves its data", () => {
+      const base64 = Buffer.from("%PDF-1.4 fake pdf bytes").toString("base64");
+      const event = makeSnapshotEvent([
+        {
+          type: "file",
+          mediaType: "application/pdf",
+          data: base64,
+          filename: "document.pdf",
+        },
+      ]);
 
-    const result = scenarioMessageSnapshotSchema.safeParse(event);
-    expect(result.success).toBe(true);
+      const result = scenarioMessageSnapshotSchema.safeParse(event);
+      expect(result.success).toBe(true);
 
-    const message = (result.success ? result.data.messages[0] : undefined) as
-      | { content: Array<{ type: string; image?: string }> }
-      | undefined;
-    const part = message?.content.find((p) => p.type === "image");
-    expect(part?.image).toBe(WEBP_DATA_URI);
+      const message = (result.success ? result.data.messages[0] : undefined) as
+        | { content: Array<{ type: string; data?: string }> }
+        | undefined;
+      const part = message?.content.find((p) => p.type === "file");
+      expect(part?.data).toBe(base64);
+    });
   });
 
-  /** @scenario "AI-SDK image parts with http(s) URLs validate and pass through unchanged" */
-  it("ACCEPTS an AI-SDK image part with an external http URL", () => {
-    const event = makeSnapshotEvent([
-      { type: "image", image: "https://example.com/cat.png" },
-    ]);
+  describe("when the message carries post-extraction rewrites", () => {
+    /** @scenario "Post-extraction image and file rewrites still validate on the wire" */
+    it("ACCEPTS the image url reference and the binary reference", () => {
+      const event = makeSnapshotEvent([
+        { type: "image", image: "/api/files/proj-1/abc123" },
+        {
+          type: "binary",
+          mimeType: "application/pdf",
+          id: "def456",
+          url: "/api/files/proj-1/def456",
+          filename: "document.pdf",
+        },
+      ]);
 
-    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
-  });
-
-  /** @scenario "MESSAGE_SNAPSHOT with an OpenAI file part is accepted (201) and the file is externalized preserving the filename" */
-  it("ACCEPTS an OpenAI file turn: [text, {type:'file', file:{filename, file_data}}] (multimodal-files docs shape)", () => {
-    const event = makeSnapshotEvent([
-      { type: "text", text: "Please summarize this document." },
-      {
-        type: "file",
-        file: { filename: "document.pdf", file_data: PDF_DATA_URI },
-      },
-    ]);
-
-    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
-  });
-
-  it("preserves the file_data and filename through validation so the extractor can externalize them", () => {
-    const event = makeSnapshotEvent([
-      {
-        type: "file",
-        file: { filename: "document.pdf", file_data: PDF_DATA_URI },
-      },
-    ]);
-
-    const result = scenarioMessageSnapshotSchema.safeParse(event);
-    expect(result.success).toBe(true);
-
-    const message = (result.success ? result.data.messages[0] : undefined) as
-      | {
-          content: Array<{
-            type: string;
-            file?: { file_data?: string; filename?: string };
-          }>;
-        }
-      | undefined;
-    const part = message?.content.find((p) => p.type === "file");
-    expect(part?.file?.file_data).toBe(PDF_DATA_URI);
-    expect(part?.file?.filename).toBe("document.pdf");
-  });
-
-  /** @scenario "AI-SDK file parts with a document mediaType validate on the wire" */
-  it("ACCEPTS an AI-SDK file part with a document mediaType and preserves its data", () => {
-    const base64 = Buffer.from("%PDF-1.4 fake pdf bytes").toString("base64");
-    const event = makeSnapshotEvent([
-      {
-        type: "file",
-        mediaType: "application/pdf",
-        data: base64,
-        filename: "document.pdf",
-      },
-    ]);
-
-    const result = scenarioMessageSnapshotSchema.safeParse(event);
-    expect(result.success).toBe(true);
-
-    const message = (result.success ? result.data.messages[0] : undefined) as
-      | { content: Array<{ type: string; data?: string }> }
-      | undefined;
-    const part = message?.content.find((p) => p.type === "file");
-    expect(part?.data).toBe(base64);
-  });
-
-  /** @scenario "OpenAI file parts carrying only a provider file_id pass through unchanged" */
-  it("ACCEPTS an OpenAI file part carrying only a provider file_id", () => {
-    const event = makeSnapshotEvent([
-      { type: "file", file: { file_id: "file-abc123" } },
-    ]);
-
-    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
-  });
-
-  /** @scenario "Post-extraction image and file rewrites still validate on the wire" */
-  it("ACCEPTS the post-extraction rewrites: image url reference and binary reference", () => {
-    const event = makeSnapshotEvent([
-      { type: "image", image: "/api/files/proj-1/abc123" },
-      {
-        type: "binary",
-        mimeType: "application/pdf",
-        id: "def456",
-        url: "/api/files/proj-1/def456",
-        filename: "document.pdf",
-      },
-    ]);
-
-    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+      expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+    });
   });
 });

--- a/langwatch/src/server/scenarios/schemas/__tests__/event-schemas.unit.test.ts
+++ b/langwatch/src/server/scenarios/schemas/__tests__/event-schemas.unit.test.ts
@@ -114,3 +114,145 @@ describe("scenarioMessageSnapshotSchema — regression: previously-valid shapes 
     expect(scenarioEventSchema.safeParse(event).success).toBe(true);
   });
 });
+
+/**
+ * Regression guard for the image/file attachment wire leg: the typescript
+ * scenario SDK stopped JSON-stringifying array content, so the documented
+ * multimodal shapes (scenario docs: multimodal-images, multimodal-files)
+ * started arriving as raw arrays and were 400-rejected here BEFORE
+ * `extractInlineMediaFromEvent` ever ran — runs showed a report but zero
+ * conversation turns in the simulations UI.
+ */
+describe("scenarioMessageSnapshotSchema — image/file attachment wire acceptance", () => {
+  const WEBP_DATA_URI = `data:image/webp;base64,${Buffer.from(
+    "fake-webp-bytes",
+  ).toString("base64")}`;
+  const PDF_DATA_URI = `data:application/pdf;base64,${Buffer.from(
+    "%PDF-1.4 fake pdf bytes",
+  ).toString("base64")}`;
+
+  /** @scenario "MESSAGE_SNAPSHOT with an AI-SDK image part is accepted (201) and the image is externalized" */
+  it("ACCEPTS an AI-SDK image turn: [text, {type:'image', image:'data:...'}] (was 400 before the fix)", () => {
+    const event = makeSnapshotEvent([
+      { type: "text", text: "What do you see in this image?" },
+      { type: "image", image: WEBP_DATA_URI },
+    ]);
+
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  it("ACCEPTS an image-only turn: [{type:'image', image:'data:...'}] with no text part", () => {
+    const event = makeSnapshotEvent([{ type: "image", image: WEBP_DATA_URI }]);
+
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  it("preserves the image data URI through validation so the extractor can externalize it", () => {
+    const event = makeSnapshotEvent([
+      { type: "text", text: "What do you see in this image?" },
+      { type: "image", image: WEBP_DATA_URI },
+    ]);
+
+    const result = scenarioMessageSnapshotSchema.safeParse(event);
+    expect(result.success).toBe(true);
+
+    const message = (result.success ? result.data.messages[0] : undefined) as
+      | { content: Array<{ type: string; image?: string }> }
+      | undefined;
+    const part = message?.content.find((p) => p.type === "image");
+    expect(part?.image).toBe(WEBP_DATA_URI);
+  });
+
+  /** @scenario "AI-SDK image parts with http(s) URLs validate and pass through unchanged" */
+  it("ACCEPTS an AI-SDK image part with an external http URL", () => {
+    const event = makeSnapshotEvent([
+      { type: "image", image: "https://example.com/cat.png" },
+    ]);
+
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  /** @scenario "MESSAGE_SNAPSHOT with an OpenAI file part is accepted (201) and the file is externalized preserving the filename" */
+  it("ACCEPTS an OpenAI file turn: [text, {type:'file', file:{filename, file_data}}] (multimodal-files docs shape)", () => {
+    const event = makeSnapshotEvent([
+      { type: "text", text: "Please summarize this document." },
+      {
+        type: "file",
+        file: { filename: "document.pdf", file_data: PDF_DATA_URI },
+      },
+    ]);
+
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  it("preserves the file_data and filename through validation so the extractor can externalize them", () => {
+    const event = makeSnapshotEvent([
+      {
+        type: "file",
+        file: { filename: "document.pdf", file_data: PDF_DATA_URI },
+      },
+    ]);
+
+    const result = scenarioMessageSnapshotSchema.safeParse(event);
+    expect(result.success).toBe(true);
+
+    const message = (result.success ? result.data.messages[0] : undefined) as
+      | {
+          content: Array<{
+            type: string;
+            file?: { file_data?: string; filename?: string };
+          }>;
+        }
+      | undefined;
+    const part = message?.content.find((p) => p.type === "file");
+    expect(part?.file?.file_data).toBe(PDF_DATA_URI);
+    expect(part?.file?.filename).toBe("document.pdf");
+  });
+
+  /** @scenario "AI-SDK file parts with a document mediaType validate on the wire" */
+  it("ACCEPTS an AI-SDK file part with a document mediaType and preserves its data", () => {
+    const base64 = Buffer.from("%PDF-1.4 fake pdf bytes").toString("base64");
+    const event = makeSnapshotEvent([
+      {
+        type: "file",
+        mediaType: "application/pdf",
+        data: base64,
+        filename: "document.pdf",
+      },
+    ]);
+
+    const result = scenarioMessageSnapshotSchema.safeParse(event);
+    expect(result.success).toBe(true);
+
+    const message = (result.success ? result.data.messages[0] : undefined) as
+      | { content: Array<{ type: string; data?: string }> }
+      | undefined;
+    const part = message?.content.find((p) => p.type === "file");
+    expect(part?.data).toBe(base64);
+  });
+
+  /** @scenario "OpenAI file parts carrying only a provider file_id pass through unchanged" */
+  it("ACCEPTS an OpenAI file part carrying only a provider file_id", () => {
+    const event = makeSnapshotEvent([
+      { type: "file", file: { file_id: "file-abc123" } },
+    ]);
+
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  /** @scenario "Post-extraction image and file rewrites still validate on the wire" */
+  it("ACCEPTS the post-extraction rewrites: image url reference and binary reference", () => {
+    const event = makeSnapshotEvent([
+      { type: "image", image: "/api/files/proj-1/abc123" },
+      {
+        type: "binary",
+        mimeType: "application/pdf",
+        id: "def456",
+        url: "/api/files/proj-1/def456",
+        filename: "document.pdf",
+      },
+    ]);
+
+    expect(scenarioEventSchema.safeParse(event).success).toBe(true);
+  });
+});

--- a/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
@@ -857,7 +857,6 @@ describe("extractInlineMediaFromEvent", () => {
   });
 
   describe("when an event has an AI-SDK image part with a base64 data URI (typescript scenario SDK shape)", () => {
-    /** @scenario "A simulated user message with an image attachment is accepted and the image is stored for the run conversation" */
     it("extracts the bytes and rewrites image to /api/files/<projectId>/<id>", async () => {
       const base64Payload = makeBase64Payload("WEBP_BYTES");
       const storedId = "stored-image-id";
@@ -926,7 +925,6 @@ describe("extractInlineMediaFromEvent", () => {
   });
 
   describe("when an event has an OpenAI file part with a data URI file_data (multimodal-files docs shape)", () => {
-    /** @scenario "A simulated user message with a document attachment is accepted and keeps its filename" */
     it("extracts the bytes and rewrites the part to a binary reference preserving the filename", async () => {
       const base64Payload = makeBase64Payload("%PDF-1.4 fake pdf bytes");
       const storedId = "stored-openai-file-id";

--- a/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
@@ -855,4 +855,246 @@ describe("extractInlineMediaFromEvent", () => {
       });
     });
   });
+
+  describe("when an event has an AI-SDK image part with a base64 data URI (typescript scenario SDK shape)", () => {
+    /** @scenario "MESSAGE_SNAPSHOT with an AI-SDK image part is accepted (201) and the image is externalized" */
+    it("extracts the bytes and rewrites image to /api/files/<projectId>/<id>", async () => {
+      const base64Payload = makeBase64Payload("WEBP_BYTES");
+      const storedId = "stored-image-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: "image/webp",
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        { type: "text", text: "What do you see in this image?" },
+        { type: "image", image: `data:image/webp;base64,${base64Payload}` },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(service.storeFromBytes).toHaveBeenCalledOnce();
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediaType: "image/webp",
+          bytes: Buffer.from("WEBP_BYTES"),
+        }),
+      );
+
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
+      expect(content[0]).toEqual({
+        type: "text",
+        text: "What do you see in this image?",
+      });
+      expect(content[1]).toEqual({
+        type: "image",
+        image: `/api/files/proj-1/${storedId}`,
+      });
+
+      expect(refs).toHaveLength(1);
+      expect(refs[0]!.id).toBe(storedId);
+    });
+  });
+
+  describe("when an event has an AI-SDK image part with an http URL", () => {
+    /** @scenario "AI-SDK image parts with http(s) URLs validate and pass through unchanged" */
+    it("returns the event unchanged and does not call the storage service", async () => {
+      const service = makeService();
+      const event = makeEventWithContent([
+        { type: "image", image: "https://example.com/cat.png" },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(rewrittenEvent).toBe(event);
+      expect(refs).toHaveLength(0);
+      expect(service.storeFromBytes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when an event has an OpenAI file part with a data URI file_data (multimodal-files docs shape)", () => {
+    /** @scenario "MESSAGE_SNAPSHOT with an OpenAI file part is accepted (201) and the file is externalized preserving the filename" */
+    it("extracts the bytes and rewrites the part to a binary reference preserving the filename", async () => {
+      const base64Payload = makeBase64Payload("%PDF-1.4 fake pdf bytes");
+      const storedId = "stored-openai-file-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: "application/pdf",
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        { type: "text", text: "Please summarize this document." },
+        {
+          type: "file",
+          file: {
+            filename: "document.pdf",
+            file_data: `data:application/pdf;base64,${base64Payload}`,
+          },
+        },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(service.storeFromBytes).toHaveBeenCalledOnce();
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediaType: "application/pdf",
+          bytes: Buffer.from("%PDF-1.4 fake pdf bytes"),
+        }),
+      );
+
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
+      const part = content[1] as {
+        type: string;
+        id: string;
+        url: string;
+        data: unknown;
+        filename: string;
+      };
+      expect(part.type).toBe("binary");
+      expect(part.id).toBe(storedId);
+      expect(part.url).toBe(`/api/files/proj-1/${storedId}`);
+      expect(part.data).toBeUndefined();
+      expect(part.filename).toBe("document.pdf");
+
+      expect(refs).toHaveLength(1);
+      expect(refs[0]!.id).toBe(storedId);
+    });
+  });
+
+  describe("when an event has an OpenAI file part with raw base64 file_data (OpenAI API wire format)", () => {
+    it("infers the mime type from the filename extension and externalizes the bytes", async () => {
+      const base64Payload = makeBase64Payload("%PDF-1.4 raw base64 pdf");
+      const storedId = "stored-raw-file-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: "application/pdf",
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        {
+          type: "file",
+          file: { filename: "report.pdf", file_data: base64Payload },
+        },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediaType: "application/pdf",
+          bytes: Buffer.from("%PDF-1.4 raw base64 pdf"),
+        }),
+      );
+
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
+      expect(content[0]).toMatchObject({
+        type: "binary",
+        url: `/api/files/proj-1/${storedId}`,
+        filename: "report.pdf",
+      });
+      expect(refs).toHaveLength(1);
+    });
+  });
+
+  describe("when an event has an OpenAI file part carrying only a provider file_id", () => {
+    /** @scenario "OpenAI file parts carrying only a provider file_id pass through unchanged" */
+    it("returns the event unchanged and does not call the storage service", async () => {
+      const service = makeService();
+      const event = makeEventWithContent([
+        { type: "file", file: { file_id: "file-abc123" } },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(rewrittenEvent).toBe(event);
+      expect(refs).toHaveLength(0);
+      expect(service.storeFromBytes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when an event has an OpenAI file part with an audio data URI", () => {
+    it("routes to the input_audio externalization path so the rewrite stays playable", async () => {
+      const base64Payload = makeBase64Payload("WAV_BYTES");
+      const storedId = "stored-openai-audio-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: "audio/wav",
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        {
+          type: "file",
+          file: {
+            filename: "recording.wav",
+            file_data: `data:audio/wav;base64,${base64Payload}`,
+          },
+        },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediaType: "audio/wav",
+          bytes: Buffer.from("WAV_BYTES"),
+        }),
+      );
+
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
+      expect(content[0]).toEqual({
+        type: "input_audio",
+        input_audio: {
+          data: undefined,
+          url: `/api/files/proj-1/${storedId}`,
+          mimeType: "audio/wav",
+        },
+      });
+      expect(refs).toHaveLength(1);
+    });
+  });
 });

--- a/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
@@ -1094,6 +1094,175 @@ describe("extractInlineMediaFromEvent", () => {
     });
   });
 
+  describe("when a data URI carries MIME parameters (RFC 2397)", () => {
+    it("resolves the bare type before the first semicolon for OpenAI file parts", async () => {
+      const base64Payload = makeBase64Payload("%PDF-1.4 parameterized");
+      const storedId = "stored-param-file-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: "application/pdf",
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        {
+          type: "file",
+          file: {
+            filename: "doc.pdf",
+            file_data: `data:application/pdf;name=doc.pdf;base64,${base64Payload}`,
+          },
+        },
+      ]);
+
+      await extractInlineMediaFromEvent({ ...BASE_PARAMS, event, service });
+
+      // Never "application/pdf;name=doc.pdf" — that fails the readback
+      // allowlist and would leak parameters into storage Content-Type.
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({ mediaType: "application/pdf" }),
+      );
+    });
+
+    it("resolves the bare type for bareImage data URIs (the twin parser path)", async () => {
+      const base64Payload = makeBase64Payload("PNG_BYTES");
+      const storedId = "stored-param-image-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: "image/png",
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        {
+          type: "image",
+          image: `data:image/png;name=x.png;base64,${base64Payload}`,
+        },
+      ]);
+
+      await extractInlineMediaFromEvent({ ...BASE_PARAMS, event, service });
+
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({ mediaType: "image/png" }),
+      );
+    });
+  });
+
+  describe("when an OpenAI file part carries a non-readback-safe document type", () => {
+    it("still externalizes it — the chip downloads bytes verbatim, so the octet-stream readback downgrade is acceptable", async () => {
+      const base64Payload = makeBase64Payload("col1,col2\n1,2");
+      const storedId = "stored-csv-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: "text/csv",
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        {
+          type: "file",
+          file: { filename: "report.csv", file_data: base64Payload },
+        },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({ mediaType: "text/csv" }),
+      );
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
+      expect(content[0]).toMatchObject({
+        type: "binary",
+        filename: "report.csv",
+        url: `/api/files/proj-1/${storedId}`,
+      });
+      expect(refs).toHaveLength(1);
+    });
+  });
+
+  describe("when an OpenAI file part carries a malformed data URI", () => {
+    it("passes through unchanged when the data URI has no comma", async () => {
+      const service = makeService();
+      const event = makeEventWithContent([
+        {
+          type: "file",
+          file: { filename: "x.pdf", file_data: "data:application/pdf;base64" },
+        },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(rewrittenEvent).toBe(event);
+      expect(refs).toHaveLength(0);
+      expect(service.storeFromBytes).not.toHaveBeenCalled();
+    });
+
+    it("passes through unchanged when the data URI lacks the base64 marker", async () => {
+      const service = makeService();
+      const event = makeEventWithContent([
+        {
+          type: "file",
+          file: { filename: "x.txt", file_data: "data:text/plain,hello" },
+        },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(rewrittenEvent).toBe(event);
+      expect(refs).toHaveLength(0);
+      expect(service.storeFromBytes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a raw-base64 OpenAI file part has an unrecognized extension", () => {
+    it("externalizes it as application/octet-stream (generic download)", async () => {
+      const base64Payload = makeBase64Payload("mystery-bytes");
+      const storedId = "stored-unknown-ext-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: "application/octet-stream",
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        {
+          type: "file",
+          file: { filename: "artifact.xyz", file_data: base64Payload },
+        },
+      ]);
+
+      await extractInlineMediaFromEvent({ ...BASE_PARAMS, event, service });
+
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({ mediaType: "application/octet-stream" }),
+      );
+    });
+  });
+
   describe("when an event has an OpenAI file part with an audio data URI", () => {
     it("routes to the input_audio externalization path so the rewrite stays playable", async () => {
       const base64Payload = makeBase64Payload("WAV_BYTES");

--- a/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
@@ -857,7 +857,7 @@ describe("extractInlineMediaFromEvent", () => {
   });
 
   describe("when an event has an AI-SDK image part with a base64 data URI (typescript scenario SDK shape)", () => {
-    /** @scenario "MESSAGE_SNAPSHOT with an AI-SDK image part is accepted (201) and the image is externalized" */
+    /** @scenario "A simulated user message with an image attachment is accepted and the image is stored for the run conversation" */
     it("extracts the bytes and rewrites image to /api/files/<projectId>/<id>", async () => {
       const base64Payload = makeBase64Payload("WEBP_BYTES");
       const storedId = "stored-image-id";
@@ -926,7 +926,7 @@ describe("extractInlineMediaFromEvent", () => {
   });
 
   describe("when an event has an OpenAI file part with a data URI file_data (multimodal-files docs shape)", () => {
-    /** @scenario "MESSAGE_SNAPSHOT with an OpenAI file part is accepted (201) and the file is externalized preserving the filename" */
+    /** @scenario "A simulated user message with a document attachment is accepted and keeps its filename" */
     it("extracts the bytes and rewrites the part to a binary reference preserving the filename", async () => {
       const base64Payload = makeBase64Payload("%PDF-1.4 fake pdf bytes");
       const storedId = "stored-openai-file-id";
@@ -1045,6 +1045,54 @@ describe("extractInlineMediaFromEvent", () => {
       expect(rewrittenEvent).toBe(event);
       expect(refs).toHaveLength(0);
       expect(service.storeFromBytes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when an event has an OpenAI file part with raw base64 audio file_data", () => {
+    /** @scenario "Raw-base64 audio file payloads resolve a playable audio type from the filename" */
+    it("infers the audio mime type from the filename and routes through input_audio so the rewrite stays playable", async () => {
+      const base64Payload = makeBase64Payload("RAW_WAV_BYTES");
+      const storedId = "stored-raw-audio-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: "audio/wav",
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        {
+          type: "file",
+          file: { filename: "recording.wav", file_data: base64Payload },
+        },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediaType: "audio/wav",
+          bytes: Buffer.from("RAW_WAV_BYTES"),
+        }),
+      );
+
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
+      expect(content[0]).toEqual({
+        type: "input_audio",
+        input_audio: {
+          data: undefined,
+          url: `/api/files/proj-1/${storedId}`,
+          mimeType: "audio/wav",
+        },
+      });
+      expect(refs).toHaveLength(1);
     });
   });
 

--- a/langwatch/src/server/stored-objects/__tests__/files-route.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/files-route.integration.test.ts
@@ -493,6 +493,75 @@ describe("GET /api/files/:projectId/:id (project-scoped — #4947)", () => {
     });
   });
 
+  describe("when the caller passes a filename query param (attachment chip)", () => {
+    /** @scenario "A document attachment renders as a labeled chip that opens the file in a new tab" */
+    it("uses the requested filename in Content-Disposition so viewer downloads keep the original name", async () => {
+      const fileId = `stored-${nanoid(8)}`;
+      const content = "%PDF-1.4 fake pdf bytes";
+      const row = makeStoredObjectRow({
+        id: fileId,
+        project_id: projectAId,
+        media_type: "application/pdf",
+        size_bytes: Buffer.from(content).length,
+      });
+      mockGetById.mockResolvedValueOnce({
+        row,
+        stream: makeReadableStream(content),
+      });
+
+      const res = await app.request(
+        `/api/files/${projectAId}/${fileId}?filename=document.pdf`,
+        { headers: { "X-Auth-Token": projectAKey } },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Disposition")).toBe(
+        'inline; filename="document.pdf"',
+      );
+    });
+
+    it("sanitizes header-hostile filenames and falls back to the object id when nothing survives", async () => {
+      const fileId = `stored-${nanoid(8)}`;
+      const content = "bytes";
+      const row = makeStoredObjectRow({
+        id: fileId,
+        project_id: projectAId,
+        media_type: "application/pdf",
+        size_bytes: Buffer.from(content).length,
+      });
+      mockGetById
+        .mockResolvedValueOnce({ row, stream: makeReadableStream(content) })
+        .mockResolvedValueOnce({ row, stream: makeReadableStream(content) });
+
+      // CRLF + quote injection attempt — every hostile byte is replaced.
+      const hostile = encodeURIComponent('a"\r\nSet-Cookie: pwn=1;.pdf');
+      const res = await app.request(
+        `/api/files/${projectAId}/${fileId}?filename=${hostile}`,
+        { headers: { "X-Auth-Token": projectAKey } },
+      );
+      expect(res.status).toBe(200);
+      const disposition = res.headers.get("Content-Disposition") ?? "";
+      expect(disposition).not.toContain("\r");
+      expect(disposition).not.toContain("\n");
+      expect(disposition).not.toContain('a"');
+      expect(res.headers.get("Set-Cookie")).toBeNull();
+
+      // Hostile bytes are replaced (not stripped) — the header stays quoted
+      // ASCII with underscores standing in for every rejected character.
+      expect(disposition).toMatch(/^inline; filename="[A-Za-z0-9._-]+"$/);
+
+      // An empty filename param falls back to the object id.
+      const res2 = await app.request(
+        `/api/files/${projectAId}/${fileId}?filename=`,
+        { headers: { "X-Auth-Token": projectAKey } },
+      );
+      expect(res2.status).toBe(200);
+      expect(res2.headers.get("Content-Disposition")).toBe(
+        `inline; filename="${fileId}"`,
+      );
+    });
+  });
+
   describe("when a HEAD request is made for a project-scoped url", () => {
     it("returns 200 with the length but no body, scoped to the URL's project", async () => {
       const fileId = `stored-${nanoid(8)}`;

--- a/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
@@ -39,18 +39,23 @@ import { prisma } from "~/server/db";
 // onError handler turns that into a 500 — masking the route logic entirely.
 // Hoisted so the DELETE scope-guard tests can control the set-scoped run-id
 // lookup and assert which runs get archived (or that none do).
-const { mockGetRunIdsForSet, mockDeleteRun } = vi.hoisted(() => ({
-  mockGetRunIdsForSet: vi
-    .fn()
-    .mockResolvedValue({ runIds: [] as string[], reachedCap: false }),
-  mockDeleteRun: vi.fn().mockResolvedValue(undefined),
-}));
+const { mockGetRunIdsForSet, mockDeleteRun, mockMessageSnapshot } = vi.hoisted(
+  () => ({
+    mockGetRunIdsForSet: vi
+      .fn()
+      .mockResolvedValue({ runIds: [] as string[], reachedCap: false }),
+    mockDeleteRun: vi.fn().mockResolvedValue(undefined),
+    // Hoisted so tests can assert the REWRITTEN payload reaches dispatch —
+    // the seam between "route returned 201" and "the user sees the turn".
+    mockMessageSnapshot: vi.fn().mockResolvedValue(undefined),
+  }),
+);
 
 vi.mock("~/server/app-layer/app", () => ({
   getApp: () => ({
     simulations: {
       startRun: vi.fn().mockResolvedValue(undefined),
-      messageSnapshot: vi.fn().mockResolvedValue(undefined),
+      messageSnapshot: mockMessageSnapshot,
       textMessageStart: vi.fn().mockResolvedValue(undefined),
       textMessageEnd: vi.fn().mockResolvedValue(undefined),
       finishRun: vi.fn().mockResolvedValue(undefined),
@@ -530,6 +535,7 @@ describe("POST /api/scenario-events (ingest)", () => {
     /** @scenario "A simulated user message with an image attachment shows the image in the run conversation" */
     it("returns 201 (not 400) and externalizes the image bytes via storeFromBytes", async () => {
       const extractedId = `stored-${nanoid(8)}`;
+      mockMessageSnapshot.mockClear();
       mockStoreFromBytes.mockResolvedValueOnce({
         id: extractedId,
         mediaType: "image/webp",
@@ -560,6 +566,77 @@ describe("POST /api/scenario-events (ingest)", () => {
           mediaType: "image/webp",
           purpose: "scenario_event",
           bytes: Buffer.from("fake-webp-bytes"),
+        }),
+      );
+
+      // The dispatched snapshot carries the REWRITTEN payload: the image part
+      // references the stored object and no inline base64 survives — this is
+      // what the read path folds into the run the user sees.
+      expect(mockMessageSnapshot).toHaveBeenCalledOnce();
+      const dispatched = mockMessageSnapshot.mock.calls[0]?.[0] as {
+        messages: Array<{ content: Array<Record<string, unknown>> }>;
+      };
+      expect(dispatched.messages[0]?.content[1]).toEqual({
+        type: "image",
+        image: `/api/files/${testProjectId}/${extractedId}`,
+      });
+      expect(JSON.stringify(dispatched.messages)).not.toContain("base64,");
+    });
+  });
+
+  describe("when a MESSAGE_SNAPSHOT carries an AI-SDK file turn ({type:'file', mediaType, data})", () => {
+    /** @scenario "AI-SDK file parts with a document mediaType validate on the wire" */
+    it("returns 201 (not 400) and externalizes the file bytes via storeFromBytes", async () => {
+      const extractedId = `stored-${nanoid(8)}`;
+      mockStoreFromBytes.mockResolvedValueOnce({
+        id: extractedId,
+        mediaType: "application/pdf",
+        isDuplicate: false,
+      });
+
+      const scenarioRunId = `run-${nanoid(6)}`;
+      const body = {
+        type: ScenarioEventType.MESSAGE_SNAPSHOT,
+        timestamp: Date.now(),
+        batchRunId: `batch-${nanoid(6)}`,
+        scenarioId: `scenario-${nanoid(6)}`,
+        scenarioRunId,
+        scenarioSetId: "default",
+        messages: [
+          {
+            id: `msg-${nanoid(6)}`,
+            role: "user",
+            content: [
+              { type: "text", text: "Please summarize this document." },
+              {
+                type: "file",
+                mediaType: "application/pdf",
+                data: Buffer.from("%PDF-1.4 ai-sdk file bytes").toString(
+                  "base64",
+                ),
+                filename: "document.pdf",
+              },
+            ],
+          },
+        ],
+      };
+
+      const res = await app.request("/api/scenario-events", {
+        method: "POST",
+        headers: {
+          "X-Auth-Token": testApiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockStoreFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: testProjectId,
+          mediaType: "application/pdf",
+          purpose: "scenario_event",
+          bytes: Buffer.from("%PDF-1.4 ai-sdk file bytes"),
         }),
       );
     });

--- a/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
@@ -527,7 +527,7 @@ describe("POST /api/scenario-events (ingest)", () => {
   });
 
   describe("when a MESSAGE_SNAPSHOT carries an AI-SDK image turn (multimodal-images docs shape)", () => {
-    /** @scenario "A simulated user message with an image attachment is accepted and the image is stored for the run conversation" */
+    /** @scenario "A simulated user message with an image attachment shows the image in the run conversation" */
     it("returns 201 (not 400) and externalizes the image bytes via storeFromBytes", async () => {
       const extractedId = `stored-${nanoid(8)}`;
       mockStoreFromBytes.mockResolvedValueOnce({
@@ -566,7 +566,7 @@ describe("POST /api/scenario-events (ingest)", () => {
   });
 
   describe("when a MESSAGE_SNAPSHOT carries an OpenAI file turn (multimodal-files docs shape)", () => {
-    /** @scenario "A simulated user message with a document attachment is accepted and keeps its filename" */
+    /** @scenario "A simulated user message with a document attachment stays available under its original filename" */
     it("returns 201 (not 400) and externalizes the file bytes via storeFromBytes", async () => {
       const extractedId = `stored-${nanoid(8)}`;
       mockStoreFromBytes.mockResolvedValueOnce({

--- a/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
@@ -527,7 +527,7 @@ describe("POST /api/scenario-events (ingest)", () => {
   });
 
   describe("when a MESSAGE_SNAPSHOT carries an AI-SDK image turn (multimodal-images docs shape)", () => {
-    /** @scenario "MESSAGE_SNAPSHOT with an AI-SDK image part is accepted (201) and the image is externalized" */
+    /** @scenario "A simulated user message with an image attachment is accepted and the image is stored for the run conversation" */
     it("returns 201 (not 400) and externalizes the image bytes via storeFromBytes", async () => {
       const extractedId = `stored-${nanoid(8)}`;
       mockStoreFromBytes.mockResolvedValueOnce({
@@ -566,7 +566,7 @@ describe("POST /api/scenario-events (ingest)", () => {
   });
 
   describe("when a MESSAGE_SNAPSHOT carries an OpenAI file turn (multimodal-files docs shape)", () => {
-    /** @scenario "MESSAGE_SNAPSHOT with an OpenAI file part is accepted (201) and the file is externalized preserving the filename" */
+    /** @scenario "A simulated user message with a document attachment is accepted and keeps its filename" */
     it("returns 201 (not 400) and externalizes the file bytes via storeFromBytes", async () => {
       const extractedId = `stored-${nanoid(8)}`;
       mockStoreFromBytes.mockResolvedValueOnce({

--- a/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
@@ -255,6 +255,70 @@ function makeMessageSnapshotWithInputAudio(scenarioRunId: string) {
   };
 }
 
+/**
+ * A SCENARIO_MESSAGE_SNAPSHOT whose message content is a multimodal image turn:
+ * `[text, {type:"image", image:"data:image/webp;base64,..."}]` — the AI-SDK
+ * shape the typescript scenario SDK ships for image attachments (scenario
+ * docs: multimodal-images). Validated by the same STRICT messages union that
+ * 400-rejected voice audio before #5149; images regressed the same way once
+ * the SDK stopped JSON-stringifying array content.
+ */
+function makeMessageSnapshotWithImage(scenarioRunId: string) {
+  const imageBase64 = Buffer.from("fake-webp-bytes").toString("base64");
+  return {
+    type: ScenarioEventType.MESSAGE_SNAPSHOT,
+    timestamp: Date.now(),
+    batchRunId: `batch-${nanoid(6)}`,
+    scenarioId: `scenario-${nanoid(6)}`,
+    scenarioRunId,
+    scenarioSetId: "default",
+    messages: [
+      {
+        id: `msg-${nanoid(6)}`,
+        role: "user",
+        content: [
+          { type: "text", text: "What do you see in this image?" },
+          { type: "image", image: `data:image/webp;base64,${imageBase64}` },
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * A SCENARIO_MESSAGE_SNAPSHOT whose message content carries an OpenAI
+ * ChatCompletion file part: `[text, {type:"file", file:{filename, file_data}}]`
+ * — the shape both scenario SDKs document for document attachments (scenario
+ * docs: multimodal-files).
+ */
+function makeMessageSnapshotWithOpenAiFile(scenarioRunId: string) {
+  const pdfBase64 = Buffer.from("%PDF-1.4 fake pdf bytes").toString("base64");
+  return {
+    type: ScenarioEventType.MESSAGE_SNAPSHOT,
+    timestamp: Date.now(),
+    batchRunId: `batch-${nanoid(6)}`,
+    scenarioId: `scenario-${nanoid(6)}`,
+    scenarioRunId,
+    scenarioSetId: "default",
+    messages: [
+      {
+        id: `msg-${nanoid(6)}`,
+        role: "user",
+        content: [
+          { type: "text", text: "Please summarize this document." },
+          {
+            type: "file",
+            file: {
+              filename: "document.pdf",
+              file_data: `data:application/pdf;base64,${pdfBase64}`,
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
@@ -457,6 +521,80 @@ describe("POST /api/scenario-events (ingest)", () => {
           projectId: testProjectId,
           mediaType: "audio/wav",
           purpose: "scenario_event",
+        }),
+      );
+    });
+  });
+
+  describe("when a MESSAGE_SNAPSHOT carries an AI-SDK image turn (multimodal-images docs shape)", () => {
+    /** @scenario "MESSAGE_SNAPSHOT with an AI-SDK image part is accepted (201) and the image is externalized" */
+    it("returns 201 (not 400) and externalizes the image bytes via storeFromBytes", async () => {
+      const extractedId = `stored-${nanoid(8)}`;
+      mockStoreFromBytes.mockResolvedValueOnce({
+        id: extractedId,
+        mediaType: "image/webp",
+        isDuplicate: false,
+      });
+
+      const scenarioRunId = `run-${nanoid(6)}`;
+      const body = makeMessageSnapshotWithImage(scenarioRunId);
+
+      const res = await app.request("/api/scenario-events", {
+        method: "POST",
+        headers: {
+          "X-Auth-Token": testApiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      // Before the wire-leg fix this returned 400 — the scenarioEventSchema
+      // message union had no member accepting the AI-SDK
+      // `{type:"image", image}` part, so zValidator rejected the snapshot
+      // before extraction ever ran and the run showed zero turns in the UI.
+      expect(res.status).toBe(201);
+
+      expect(mockStoreFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: testProjectId,
+          mediaType: "image/webp",
+          purpose: "scenario_event",
+          bytes: Buffer.from("fake-webp-bytes"),
+        }),
+      );
+    });
+  });
+
+  describe("when a MESSAGE_SNAPSHOT carries an OpenAI file turn (multimodal-files docs shape)", () => {
+    /** @scenario "MESSAGE_SNAPSHOT with an OpenAI file part is accepted (201) and the file is externalized preserving the filename" */
+    it("returns 201 (not 400) and externalizes the file bytes via storeFromBytes", async () => {
+      const extractedId = `stored-${nanoid(8)}`;
+      mockStoreFromBytes.mockResolvedValueOnce({
+        id: extractedId,
+        mediaType: "application/pdf",
+        isDuplicate: false,
+      });
+
+      const scenarioRunId = `run-${nanoid(6)}`;
+      const body = makeMessageSnapshotWithOpenAiFile(scenarioRunId);
+
+      const res = await app.request("/api/scenario-events", {
+        method: "POST",
+        headers: {
+          "X-Auth-Token": testApiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      expect(res.status).toBe(201);
+
+      expect(mockStoreFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: testProjectId,
+          mediaType: "application/pdf",
+          purpose: "scenario_event",
+          bytes: Buffer.from("%PDF-1.4 fake pdf bytes"),
         }),
       );
     });

--- a/langwatch/src/server/stored-objects/content-extractor.ts
+++ b/langwatch/src/server/stored-objects/content-extractor.ts
@@ -36,7 +36,10 @@ import { binaryInputPartSchema } from "./binary-part";
 import { coerceContentToArray } from "./coerce-content-to-array";
 import { isReadbackSafe } from "./safe-media-types";
 import type { StoredObjectsService } from "./stored-objects.service";
-import { visitContentPartAsync } from "./visit-content-part";
+import {
+  parseBase64DataUri,
+  visitContentPartAsync,
+} from "./visit-content-part";
 
 const tracer = getLangWatchTracer("langwatch.stored-objects.content-extractor");
 
@@ -60,30 +63,6 @@ export interface ExtractedRef {
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Parse a `data:` URI into its mime type + base64 payload. Returns null when
- * the input isn't a `data:<mime>;base64,<...>` shape; non-base64 data URIs
- * (`data:<mime>,<urlencoded>`) are out of scope — extraction is for binary
- * payloads only, not for short URL-encoded text data.
- *
- * Spec: RFC 2397, but only the `base64` form. Examples we accept:
- *   data:image/png;base64,iVBORw0KGgo...
- *   data:audio/wav;base64,UklGR...
- */
-function parseBase64DataUri(
-  uri: string,
-): { mimeType: string; base64: string } | null {
-  if (!uri.startsWith("data:")) return null;
-  const commaIdx = uri.indexOf(",");
-  if (commaIdx === -1) return null;
-  const header = uri.slice(5, commaIdx); // strip "data:"
-  const payload = uri.slice(commaIdx + 1);
-  if (!header.endsWith(";base64")) return null;
-  const mimeType = header.slice(0, -7); // strip ";base64"
-  if (!mimeType) return null;
-  return { mimeType, base64: payload };
-}
 
 /**
  * Rewrites a single content part, storing any inline bytes via the service.
@@ -163,6 +142,12 @@ async function processContentPart({
     },
 
     async binary(binPart) {
+      // Unlike the media/document handler above, this path deliberately has
+      // no isReadbackSafe gate: binary parts render as a download chip, not
+      // inline, so a non-allowlisted type (text/csv, application/json, ...)
+      // coming back as application/octet-stream still round-trips the exact
+      // bytes — and the chip carries the original filename for the save.
+      //
       // Enforce exactly-one-of(data, url, id) at the boundary before touching.
       // AG-UI's InputContentSchema permits the ambiguous cases; rejecting them
       // here matches the runtime invariant the extractor depends on.

--- a/langwatch/src/server/stored-objects/content-extractor.ts
+++ b/langwatch/src/server/stored-objects/content-extractor.ts
@@ -203,11 +203,14 @@ async function processContentPart({
       };
 
       const original = part as Record<string, unknown>;
-      // AI-SDK file shape (`type:"file", mediaType, data`) is dispatched here
-      // by the visitor when mimeType is not audio/*. Normalise to a clean
+      // File shapes (AI-SDK `{type:"file", mediaType, data}` and OpenAI
+      // `{type:"file", file:{file_data, filename}}`) are dispatched here by
+      // the visitor when the mime type is not audio/*. Normalise to a clean
       // `binary` shape (the same canonical form the inputAudio handler
       // produces for the audio path) so the rewrite is not a chimera of
-      // `type:"file"` + binary externalised fields.
+      // `type:"file"` + binary externalised fields. The filename comes from
+      // the dispatched part — the visitor already resolved it from whichever
+      // nesting the wire shape used.
       const isFileShape = original.type === "file";
       const rewrittenPart = isFileShape
         ? {
@@ -216,8 +219,8 @@ async function processContentPart({
             id: stored.id,
             url: `/api/files/${projectId}/${stored.id}`,
             data: undefined,
-            ...(typeof original.filename === "string"
-              ? { filename: original.filename }
+            ...(typeof binPart.filename === "string"
+              ? { filename: binPart.filename }
               : {}),
           }
         : {
@@ -321,7 +324,8 @@ async function processContentPart({
       const original = part as Record<string, unknown>;
       const isFileShape = original.type === "file";
       const originalInputAudio =
-        typeof original.input_audio === "object" && original.input_audio !== null
+        typeof original.input_audio === "object" &&
+        original.input_audio !== null
           ? (original.input_audio as Record<string, unknown>)
           : {};
 

--- a/langwatch/src/server/stored-objects/visit-content-part.ts
+++ b/langwatch/src/server/stored-objects/visit-content-part.ts
@@ -210,6 +210,36 @@ export function visitContentPart<R>(
     }
   }
 
+  // OpenAI ChatCompletion file part: {type:"file", file:{filename?, file_data?, file_id?}}.
+  // The scenario multimodal-files docs instruct exactly this shape for
+  // document attachments in simulated user messages. Bytes dispatch to
+  // `binary` (or `inputAudio` for audio mime types, keeping a playable shape
+  // downstream) so the extractor externalises them; a `file_id`-only part
+  // references a provider-hosted file with no bytes, so it falls through to
+  // `unknown` and passes along unchanged.
+  if (
+    o["type"] === "file" &&
+    typeof o["file"] === "object" &&
+    o["file"] !== null
+  ) {
+    const binPart = openAiFilePayloadToBinaryPart(
+      o["file"] as Record<string, unknown>,
+    );
+    if (binPart?.mimeType.startsWith("audio/")) {
+      return visitor.inputAudio
+        ? visitor.inputAudio({
+            data: binPart.data,
+            format: mediaTypeToAudioFormat(binPart.mimeType),
+            mimeType: binPart.mimeType,
+          })
+        : visitor.unknown?.(part);
+    }
+    if (binPart) {
+      return visitor.binary(binPart);
+    }
+    return visitor.unknown?.(part);
+  }
+
   // binary parts
   if (o["type"] === "binary" && o["mimeType"]) {
     return visitor.binary({
@@ -244,17 +274,13 @@ export function visitContentPart<R>(
     (o["image_url"] as Record<string, unknown>)["url"]
   ) {
     const url = (o["image_url"] as Record<string, unknown>)["url"] as string;
-    return visitor.imageUrl
-      ? visitor.imageUrl(url)
-      : visitor.unknown?.(part);
+    return visitor.imageUrl ? visitor.imageUrl(url) : visitor.unknown?.(part);
   }
 
   // Bare {image:"..."} shape (rare; some fixtures)
   if (o["image"]) {
     const src = o["image"] as string;
-    return visitor.bareImage
-      ? visitor.bareImage(src)
-      : visitor.unknown?.(part);
+    return visitor.bareImage ? visitor.bareImage(src) : visitor.unknown?.(part);
   }
 
   return visitor.unknown?.(part);
@@ -376,6 +402,36 @@ export async function visitContentPartAsync<R>(
     }
   }
 
+  // OpenAI ChatCompletion file part: {type:"file", file:{filename?, file_data?, file_id?}}.
+  // The scenario multimodal-files docs instruct exactly this shape for
+  // document attachments in simulated user messages. Bytes dispatch to
+  // `binary` (or `inputAudio` for audio mime types, keeping a playable shape
+  // downstream) so the extractor externalises them; a `file_id`-only part
+  // references a provider-hosted file with no bytes, so it falls through to
+  // `unknown` and passes along unchanged.
+  if (
+    o["type"] === "file" &&
+    typeof o["file"] === "object" &&
+    o["file"] !== null
+  ) {
+    const binPart = openAiFilePayloadToBinaryPart(
+      o["file"] as Record<string, unknown>,
+    );
+    if (binPart?.mimeType.startsWith("audio/")) {
+      return visitor.inputAudio
+        ? visitor.inputAudio({
+            data: binPart.data,
+            format: mediaTypeToAudioFormat(binPart.mimeType),
+            mimeType: binPart.mimeType,
+          })
+        : visitor.unknown?.(part);
+    }
+    if (binPart) {
+      return visitor.binary(binPart);
+    }
+    return visitor.unknown?.(part);
+  }
+
   // binary parts
   if (o["type"] === "binary" && o["mimeType"]) {
     return visitor.binary({
@@ -410,20 +466,81 @@ export async function visitContentPartAsync<R>(
     (o["image_url"] as Record<string, unknown>)["url"]
   ) {
     const url = (o["image_url"] as Record<string, unknown>)["url"] as string;
-    return visitor.imageUrl
-      ? visitor.imageUrl(url)
-      : visitor.unknown?.(part);
+    return visitor.imageUrl ? visitor.imageUrl(url) : visitor.unknown?.(part);
   }
 
   // Bare {image:"..."} shape (rare; some fixtures)
   if (o["image"]) {
     const src = o["image"] as string;
-    return visitor.bareImage
-      ? visitor.bareImage(src)
-      : visitor.unknown?.(part);
+    return visitor.bareImage ? visitor.bareImage(src) : visitor.unknown?.(part);
   }
 
   return visitor.unknown?.(part);
+}
+
+/**
+ * Decode an OpenAI ChatCompletion `file` payload ({file_data, filename,
+ * file_id}) into a binary part the visitor can dispatch. `file_data` accepts
+ * both a base64 data: URI (the shape the scenario multimodal-files docs
+ * instruct) and raw base64 (the OpenAI API wire format), resolving the mime
+ * type from the data URI header or the filename extension. Returns null when
+ * the payload carries no bytes (e.g. provider-hosted `file_id` references),
+ * so the caller can fall through to `unknown` and pass the part along
+ * unchanged.
+ */
+function openAiFilePayloadToBinaryPart(
+  file: Record<string, unknown>,
+): BinaryPart | null {
+  const fileData =
+    typeof file["file_data"] === "string" ? file["file_data"] : undefined;
+  if (!fileData) return null;
+  const filename =
+    typeof file["filename"] === "string" ? file["filename"] : undefined;
+
+  if (fileData.startsWith("data:")) {
+    const commaIdx = fileData.indexOf(",");
+    if (commaIdx === -1) return null;
+    const header = fileData.slice(5, commaIdx);
+    if (!header.endsWith(";base64")) return null;
+    const mimeType = header.slice(0, -7).toLowerCase();
+    if (!mimeType) return null;
+    return {
+      type: "binary",
+      mimeType,
+      data: fileData.slice(commaIdx + 1),
+      filename,
+    };
+  }
+
+  return {
+    type: "binary",
+    mimeType: mimeTypeFromFilename(filename),
+    data: fileData,
+    filename,
+  };
+}
+
+/**
+ * Mime type for a raw-base64 OpenAI `file_data` payload, inferred from the
+ * filename extension. Covers the document types the /api/files read path
+ * serves faithfully; everything else downgrades to a generic download.
+ */
+function mimeTypeFromFilename(filename: string | undefined): string {
+  const ext = filename?.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "pdf":
+      return "application/pdf";
+    case "txt":
+      return "text/plain";
+    case "csv":
+      return "text/csv";
+    case "json":
+      return "application/json";
+    case "md":
+      return "text/markdown";
+    default:
+      return "application/octet-stream";
+  }
 }
 
 /**

--- a/langwatch/src/server/stored-objects/visit-content-part.ts
+++ b/langwatch/src/server/stored-objects/visit-content-part.ts
@@ -179,13 +179,10 @@ export function visitContentPart<R>(
   // go to `binary` (generic externalisation by mimeType).
   if (o["type"] === "file" && typeof o["mediaType"] === "string") {
     // MIME types are case-insensitive per RFC 2045 §5.1, so an `Audio/WAV`
-    // file part should route the same as `audio/wav`. Normalise the type
-    // discriminator for the `audio/` prefix check + format mapping, but keep
-    // the original-case mimeType on the dispatched part so downstream
-    // consumers that pattern-match the exact value (e.g. an explicit
-    // allowlist) don't silently see a different string than the wire shape.
-    const mimeTypeRaw = o["mediaType"];
-    const mimeType = mimeTypeRaw.toLowerCase();
+    // file part routes the same as `audio/wav`. The dispatched part carries
+    // the lowercased type — the readback allowlist and storage Content-Type
+    // both expect the canonical form.
+    const mimeType = o["mediaType"].toLowerCase();
     const data = typeof o["data"] === "string" ? o["data"] : undefined;
     const url = typeof o["url"] === "string" ? o["url"] : undefined;
     if (data || url) {
@@ -371,13 +368,10 @@ export async function visitContentPartAsync<R>(
   // go to `binary` (generic externalisation by mimeType).
   if (o["type"] === "file" && typeof o["mediaType"] === "string") {
     // MIME types are case-insensitive per RFC 2045 §5.1, so an `Audio/WAV`
-    // file part should route the same as `audio/wav`. Normalise the type
-    // discriminator for the `audio/` prefix check + format mapping, but keep
-    // the original-case mimeType on the dispatched part so downstream
-    // consumers that pattern-match the exact value (e.g. an explicit
-    // allowlist) don't silently see a different string than the wire shape.
-    const mimeTypeRaw = o["mediaType"];
-    const mimeType = mimeTypeRaw.toLowerCase();
+    // file part routes the same as `audio/wav`. The dispatched part carries
+    // the lowercased type — the readback allowlist and storage Content-Type
+    // both expect the canonical form.
+    const mimeType = o["mediaType"].toLowerCase();
     const data = typeof o["data"] === "string" ? o["data"] : undefined;
     const url = typeof o["url"] === "string" ? o["url"] : undefined;
     if (data || url) {
@@ -479,14 +473,43 @@ export async function visitContentPartAsync<R>(
 }
 
 /**
+ * Parse a `data:` URI into its mime type + base64 payload. Returns null when
+ * the input isn't a `data:<mime>[;param=value...];base64,<...>` shape;
+ * non-base64 data URIs (`data:<mime>,<urlencoded>`) are out of scope —
+ * extraction is for binary payloads only, not for short URL-encoded text.
+ *
+ * Spec: RFC 2397, only the `base64` form. The mime type is the substring
+ * BEFORE the first `;`, so parameterized URIs
+ * (`data:application/pdf;name=doc.pdf;base64,...`) resolve to the bare type —
+ * never a parameter-laden string that would fail the readback allowlist or
+ * leak into storage Content-Type headers. Lowercased per RFC 2045 §5.1.
+ *
+ * Single source of truth for both the visitor's file dispatch and the
+ * content-extractor's image/bareImage handlers — one parser, one behaviour.
+ */
+export function parseBase64DataUri(
+  uri: string,
+): { mimeType: string; base64: string } | null {
+  if (!uri.startsWith("data:")) return null;
+  const commaIdx = uri.indexOf(",");
+  if (commaIdx === -1) return null;
+  const header = uri.slice(5, commaIdx); // strip "data:"
+  if (!header.endsWith(";base64")) return null;
+  const semiIdx = header.indexOf(";");
+  const mimeType = header.slice(0, semiIdx).toLowerCase();
+  if (!mimeType) return null;
+  return { mimeType, base64: uri.slice(commaIdx + 1) };
+}
+
+/**
  * Decode an OpenAI ChatCompletion `file` payload ({file_data, filename,
  * file_id}) into a binary part the visitor can dispatch. `file_data` accepts
  * both a base64 data: URI (the shape the scenario multimodal-files docs
  * instruct) and raw base64 (the OpenAI API wire format), resolving the mime
  * type from the data URI header or the filename extension. Returns null when
- * the payload carries no bytes (e.g. provider-hosted `file_id` references),
- * so the caller can fall through to `unknown` and pass the part along
- * unchanged.
+ * the payload carries no bytes (e.g. provider-hosted `file_id` references)
+ * or the data URI is malformed, so the caller can fall through to `unknown`
+ * and pass the part along unchanged.
  */
 function openAiFilePayloadToBinaryPart(
   file: Record<string, unknown>,
@@ -498,16 +521,12 @@ function openAiFilePayloadToBinaryPart(
     typeof file["filename"] === "string" ? file["filename"] : undefined;
 
   if (fileData.startsWith("data:")) {
-    const commaIdx = fileData.indexOf(",");
-    if (commaIdx === -1) return null;
-    const header = fileData.slice(5, commaIdx);
-    if (!header.endsWith(";base64")) return null;
-    const mimeType = header.slice(0, -7).toLowerCase();
-    if (!mimeType) return null;
+    const parsed = parseBase64DataUri(fileData);
+    if (!parsed) return null;
     return {
       type: "binary",
-      mimeType,
-      data: fileData.slice(commaIdx + 1),
+      mimeType: parsed.mimeType,
+      data: parsed.base64,
       filename,
     };
   }

--- a/langwatch/src/server/stored-objects/visit-content-part.ts
+++ b/langwatch/src/server/stored-objects/visit-content-part.ts
@@ -522,8 +522,10 @@ function openAiFilePayloadToBinaryPart(
 
 /**
  * Mime type for a raw-base64 OpenAI `file_data` payload, inferred from the
- * filename extension. Covers the document types the /api/files read path
- * serves faithfully; everything else downgrades to a generic download.
+ * filename extension. Audio extensions must resolve to `audio/*` so the part
+ * routes through the `input_audio` externalization path and stays playable;
+ * image extensions keep the /api/files readback faithful. Everything else
+ * downgrades to a generic download.
  */
 function mimeTypeFromFilename(filename: string | undefined): string {
   const ext = filename?.split(".").pop()?.toLowerCase();
@@ -538,6 +540,23 @@ function mimeTypeFromFilename(filename: string | undefined): string {
       return "application/json";
     case "md":
       return "text/markdown";
+    case "wav":
+      return "audio/wav";
+    case "mp3":
+      return "audio/mpeg";
+    case "flac":
+      return "audio/flac";
+    case "ogg":
+      return "audio/ogg";
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "webp":
+      return "image/webp";
+    case "gif":
+      return "image/gif";
     default:
       return "application/octet-stream";
   }

--- a/langwatch/src/server/tracer/types.ts
+++ b/langwatch/src/server/tracer/types.ts
@@ -131,6 +131,45 @@ export const chatRichContentSchema = z.union([
       mimeType: z.string().optional(),
     }),
   }),
+  /**
+   * AI-SDK image part. `image` is a data: URI pre-extraction, a
+   * /api/files/{projectId}/{id} reference after ingest-side extraction, or an
+   * external http(s) URL (passed through, never re-hosted). This is the shape
+   * the typescript scenario SDK ships for image attachments in simulated user
+   * messages (scenario docs: multimodal-images).
+   */
+  z.object({
+    type: z.literal("image"),
+    image: z.string(),
+    mediaType: z.string().optional(),
+  }),
+  /**
+   * AI-SDK file part. Non-audio mediaTypes are externalized to a `binary`
+   * reference at ingest; audio/* mediaTypes route through the `input_audio`
+   * externalization path (see `visitContentPart`).
+   */
+  z.object({
+    type: z.literal("file"),
+    mediaType: z.string(),
+    data: z.string().optional(),
+    url: z.string().optional(),
+    filename: z.string().optional(),
+  }),
+  /**
+   * OpenAI ChatCompletion file part (scenario docs: multimodal-files).
+   * `file_data` is a data: URI or raw base64; `file_id` references a file
+   * hosted on the provider side and carries no bytes, so it passes through
+   * extraction unchanged. Externalized at ingest to a `binary` reference
+   * preserving the filename.
+   */
+  z.object({
+    type: z.literal("file"),
+    file: z.object({
+      file_data: z.string().optional(),
+      file_id: z.string().optional(),
+      filename: z.string().optional(),
+    }),
+  }),
 ]);
 
 export type ChatRichContent = z.infer<typeof chatRichContentSchema>;

--- a/specs/features/scenarios/externalize-event-byte-content.feature
+++ b/specs/features/scenarios/externalize-event-byte-content.feature
@@ -423,20 +423,29 @@ Feature: Externalize event byte content to stored_objects
   # zero conversation turns in the simulations UI.
 
   @integration
-  Scenario: MESSAGE_SNAPSHOT with an AI-SDK image part is accepted (201) and the image is externalized
-    Given a MESSAGE_SNAPSHOT whose message content is [text, {type:"image", image:"data:image/webp;base64,..."}]
-    When the event is POSTed to /api/scenario-events
-    Then the request is accepted with 201 rather than 400 from schema validation
-    And the inline image bytes are externalized to a stored_objects row with media type image/webp
-    And the image part is rewritten to reference /api/files/<projectId>/<id>
+  Scenario: A simulated user message with an image attachment is accepted and the image is stored for the run conversation
+    Given a scenario run whose user turn attaches an inline image, as documented on the multimodal-images page
+    When the SDK reports the conversation snapshot
+    Then the snapshot is accepted instead of being rejected by validation
+    And the image bytes are stored out-of-band
+    And the conversation references the stored image so the run can display it
 
   @integration
-  Scenario: MESSAGE_SNAPSHOT with an OpenAI file part is accepted (201) and the file is externalized preserving the filename
-    Given a MESSAGE_SNAPSHOT whose message content is [text, {type:"file", file:{filename:"document.pdf", file_data:"data:application/pdf;base64,..."}}]
-    When the event is POSTed to /api/scenario-events
-    Then the request is accepted with 201 rather than 400 from schema validation
-    And the inline file bytes are externalized to a stored_objects row with media type application/pdf
-    And the part is rewritten to a binary reference carrying url and filename and no inline data
+  Scenario: A simulated user message with a document attachment is accepted and keeps its filename
+    Given a scenario run whose user turn attaches an inline PDF document, as documented on the multimodal-files page
+    When the SDK reports the conversation snapshot
+    Then the snapshot is accepted instead of being rejected by validation
+    And the document bytes are stored out-of-band
+    And the stored attachment keeps its original filename
+    And no inline bytes remain in the message
+
+  @unit
+  Scenario: Documented image and file attachment shapes validate on the wire
+    Given message content carrying an AI-SDK image part with inline image data
+    And message content carrying an OpenAI file part with inline document data
+    When the wire validator parses the snapshots
+    Then both parse successfully
+    And the inline payloads survive validation intact for the extractor
 
   @unit
   Scenario: AI-SDK file parts with a document mediaType validate on the wire
@@ -452,6 +461,13 @@ Feature: Externalize event byte content to stored_objects
     Then the parse succeeds
     And no stored_objects row is created
     And the part passes through unchanged
+
+  @unit
+  Scenario: Raw-base64 audio file payloads resolve a playable audio type from the filename
+    Given an OpenAI file part whose file_data is raw base64 with filename "recording.wav"
+    When the extractor processes the part
+    Then the payload routes through the input_audio externalization path
+    And the stored object carries an audio media type so playback works
 
   @unit
   Scenario: Post-extraction image and file rewrites still validate on the wire
@@ -753,3 +769,17 @@ Feature: Externalize event byte content to stored_objects
   # AC37 "Azure Blob support — DEFERRED in this PR"                          -> Scenario: Stored-objects writes do not mint azure-blob URIs in this PR
   # AC38 "Project-delete cascade removes rows AND bytes"                     -> Scenario: When a project is deleted, deleteOwnedBy removes both the stored_objects rows and the underlying bytes
   # AC39 "MediaPart playback contract (onLoadedData / non-zero duration)"    -> Scenario: MediaPart audio playback reports a non-zero duration once the browser has decoded the media
+  # AC40 "S3 client supports every production credential mode"               -> Scenario: S3 client uses explicit credentials when env keys are present
+  #                                                                          -> Scenario: S3 client forwards sessionToken when set so SSO/STS credentials work
+  #                                                                          -> Scenario: S3 client omits credentials so the SDK default provider chain handles IRSA and instance profiles
+  #                                                                          -> Scenario: S3 client honors S3_REGION env for real AWS deployments instead of the R2/MinIO 'auto' default
+  #                                                                          -> Scenario: S3 client defaults region to 'auto' for R2 and MinIO compatibility
+  #                                                                          -> Scenario: S3 client falls back to default chain when credentials are partial — prevents misleading 'empty string credentials' bug
+  # AC41 "Documented image/file attachment shapes accepted and externalized" -> Scenario: A simulated user message with an image attachment is accepted and the image is stored for the run conversation
+  #                                                                          -> Scenario: A simulated user message with a document attachment is accepted and keeps its filename
+  #                                                                          -> Scenario: Documented image and file attachment shapes validate on the wire
+  #                                                                          -> Scenario: AI-SDK file parts with a document mediaType validate on the wire
+  #                                                                          -> Scenario: AI-SDK image parts with http(s) URLs validate and pass through unchanged
+  #                                                                          -> Scenario: Raw-base64 audio file payloads resolve a playable audio type from the filename
+  #                                                                          -> Scenario: Post-extraction image and file rewrites still validate on the wire
+  #                                                                          -> Scenario: OpenAI file parts carrying only a provider file_id pass through unchanged

--- a/specs/features/scenarios/externalize-event-byte-content.feature
+++ b/specs/features/scenarios/externalize-event-byte-content.feature
@@ -411,6 +411,64 @@ Feature: Externalize event byte content to stored_objects
     Then the AG-UI schema rejects it as invalid
 
   # ---------------------------------------------------------------
+  # Ingest — image and file attachment wire acceptance (AC41)
+  # ---------------------------------------------------------------
+  #
+  # The documented multimodal shapes (scenario docs: multimodal-images,
+  # multimodal-files) must pass the route validator so the snapshot reaches
+  # the extractor. Same failure mode as the voice wire leg above: the
+  # typescript scenario SDK stopped JSON-stringifying array content, so
+  # AI-SDK image parts and OpenAI-shaped file parts arrive as raw arrays
+  # and were 400-rejected before extraction ever ran, leaving runs with
+  # zero conversation turns in the simulations UI.
+
+  @integration
+  Scenario: MESSAGE_SNAPSHOT with an AI-SDK image part is accepted (201) and the image is externalized
+    Given a MESSAGE_SNAPSHOT whose message content is [text, {type:"image", image:"data:image/webp;base64,..."}]
+    When the event is POSTed to /api/scenario-events
+    Then the request is accepted with 201 rather than 400 from schema validation
+    And the inline image bytes are externalized to a stored_objects row with media type image/webp
+    And the image part is rewritten to reference /api/files/<projectId>/<id>
+
+  @integration
+  Scenario: MESSAGE_SNAPSHOT with an OpenAI file part is accepted (201) and the file is externalized preserving the filename
+    Given a MESSAGE_SNAPSHOT whose message content is [text, {type:"file", file:{filename:"document.pdf", file_data:"data:application/pdf;base64,..."}}]
+    When the event is POSTed to /api/scenario-events
+    Then the request is accepted with 201 rather than 400 from schema validation
+    And the inline file bytes are externalized to a stored_objects row with media type application/pdf
+    And the part is rewritten to a binary reference carrying url and filename and no inline data
+
+  @unit
+  Scenario: AI-SDK file parts with a document mediaType validate on the wire
+    Given a MESSAGE_SNAPSHOT whose message content includes {type:"file", mediaType:"application/pdf", data:"<base64>"}
+    When the wire validator parses the event
+    Then the parse succeeds
+    And the part survives with its data intact for the extractor
+
+  @unit
+  Scenario: AI-SDK image parts with http(s) URLs validate and pass through unchanged
+    Given a message content part {type:"image", image:"https://example.com/cat.png"}
+    When the wire validator parses the event and the extractor processes the part
+    Then the parse succeeds
+    And no stored_objects row is created
+    And the part passes through unchanged
+
+  @unit
+  Scenario: Post-extraction image and file rewrites still validate on the wire
+    Given an image part rewritten to {type:"image", image:"/api/files/<projectId>/<id>"}
+    And a file part rewritten to {type:"binary", mimeType, url, id, filename}
+    When the wire validator parses a MESSAGE_SNAPSHOT carrying them
+    Then the parse succeeds
+
+  @unit
+  Scenario: OpenAI file parts carrying only a provider file_id pass through unchanged
+    Given a message content part {type:"file", file:{file_id:"file-abc123"}}
+    When the wire validator parses the event and the extractor processes the part
+    Then the parse succeeds
+    And no stored_objects row is created
+    And the part passes through unchanged
+
+  # ---------------------------------------------------------------
   # S3 client credential mode handling (AC40)
   # ---------------------------------------------------------------
   #

--- a/specs/features/scenarios/externalize-event-byte-content.feature
+++ b/specs/features/scenarios/externalize-event-byte-content.feature
@@ -436,6 +436,14 @@ Feature: Externalize event byte content to stored_objects
     Then the run conversation keeps the user turn with its document attachment
     And the document stays available under its original filename
 
+  @integration
+  Scenario: A document attachment renders as a labeled chip that opens the file in a new tab
+    Given a run conversation carrying a stored document attachment named "document.pdf"
+    When the conversation renders
+    Then the attachment shows a file icon and its filename
+    And activating it opens the stored document in a new browser tab
+    And downloading from the opened document keeps the original filename
+
   @unit
   Scenario: Documented image and file attachment shapes validate on the wire
     Given message content carrying an AI-SDK image part with inline image data
@@ -774,6 +782,7 @@ Feature: Externalize event byte content to stored_objects
   #                                                                          -> Scenario: S3 client falls back to default chain when credentials are partial — prevents misleading 'empty string credentials' bug
   # AC41 "Documented image/file attachment shapes accepted and externalized" -> Scenario: A simulated user message with an image attachment shows the image in the run conversation
   #                                                                          -> Scenario: A simulated user message with a document attachment stays available under its original filename
+  #                                                                          -> Scenario: A document attachment renders as a labeled chip that opens the file in a new tab
   #                                                                          -> Scenario: Documented image and file attachment shapes validate on the wire
   #                                                                          -> Scenario: AI-SDK file parts with a document mediaType validate on the wire
   #                                                                          -> Scenario: AI-SDK image parts with http(s) URLs validate and pass through unchanged

--- a/specs/features/scenarios/externalize-event-byte-content.feature
+++ b/specs/features/scenarios/externalize-event-byte-content.feature
@@ -423,21 +423,18 @@ Feature: Externalize event byte content to stored_objects
   # zero conversation turns in the simulations UI.
 
   @integration
-  Scenario: A simulated user message with an image attachment is accepted and the image is stored for the run conversation
+  Scenario: A simulated user message with an image attachment shows the image in the run conversation
     Given a scenario run whose user turn attaches an inline image, as documented on the multimodal-images page
     When the SDK reports the conversation snapshot
-    Then the snapshot is accepted instead of being rejected by validation
-    And the image bytes are stored out-of-band
-    And the conversation references the stored image so the run can display it
+    Then the run conversation keeps the user turn with its image attachment
+    And the image is available for display in the run
 
   @integration
-  Scenario: A simulated user message with a document attachment is accepted and keeps its filename
+  Scenario: A simulated user message with a document attachment stays available under its original filename
     Given a scenario run whose user turn attaches an inline PDF document, as documented on the multimodal-files page
     When the SDK reports the conversation snapshot
-    Then the snapshot is accepted instead of being rejected by validation
-    And the document bytes are stored out-of-band
-    And the stored attachment keeps its original filename
-    And no inline bytes remain in the message
+    Then the run conversation keeps the user turn with its document attachment
+    And the document stays available under its original filename
 
   @unit
   Scenario: Documented image and file attachment shapes validate on the wire
@@ -775,8 +772,8 @@ Feature: Externalize event byte content to stored_objects
   #                                                                          -> Scenario: S3 client honors S3_REGION env for real AWS deployments instead of the R2/MinIO 'auto' default
   #                                                                          -> Scenario: S3 client defaults region to 'auto' for R2 and MinIO compatibility
   #                                                                          -> Scenario: S3 client falls back to default chain when credentials are partial — prevents misleading 'empty string credentials' bug
-  # AC41 "Documented image/file attachment shapes accepted and externalized" -> Scenario: A simulated user message with an image attachment is accepted and the image is stored for the run conversation
-  #                                                                          -> Scenario: A simulated user message with a document attachment is accepted and keeps its filename
+  # AC41 "Documented image/file attachment shapes accepted and externalized" -> Scenario: A simulated user message with an image attachment shows the image in the run conversation
+  #                                                                          -> Scenario: A simulated user message with a document attachment stays available under its original filename
   #                                                                          -> Scenario: Documented image and file attachment shapes validate on the wire
   #                                                                          -> Scenario: AI-SDK file parts with a document mediaType validate on the wire
   #                                                                          -> Scenario: AI-SDK image parts with http(s) URLs validate and pass through unchanged


### PR DESCRIPTION
# fix(scenarios): accept documented image/file attachment parts in MESSAGE_SNAPSHOT

## Customer context

A customer asked whether we plan to support attachments (documents) on the simulated user's first message, because they currently work around it with a pipeline that pulls documents from blob storage. We already document exactly this on the scenario docs (multimodal-images and multimodal-files pages), but the image flow silently broke and the file flow never worked end to end: runs show a report and a green card, and zero conversation turns.

## Root cause

The typescript scenario SDK used to `JSON.stringify` array message content into AG-UI's string-typed `content`. The voice work changed the converter to pass content arrays through as real arrays so the ingest content-extractor could walk them (that part was correct and is what shipped `input_audio` support in #5150). Side effect: the documented multimodal shapes started arriving at `/api/scenario-events` as raw arrays, and the route validator (`zValidator("json", scenarioEventSchema)`) rejected them with a 400 before `extractInlineMediaFromEvent` ever ran:

- AI-SDK image parts `{type:"image", image:"data:..."}` (multimodal-images docs, JS SDK) matched no member of the message union (`MessageSchema | chatMessageSchema | scenarioAudioMessageSchema`). `chatRichContentSchema` only knew the OpenAI `image_url` shape.
- OpenAI file parts `{type:"file", file:{filename, file_data}}` (multimodal-files docs, both SDKs) matched nothing either, and the shared `visitContentPart` walker had no branch for them, so even if accepted the bytes would have flowed inline into ClickHouse `Messages.Content` (the fat-payload class we just got burned by).

`RUN_STARTED`/`RUN_FINISHED` still validate fine, which is why runs appear with a verdict and report but an empty conversation. This is the exact same failure mode as the voice `input_audio` wire leg (#5149/#5150), now for images and files.

## What changed (server-side only, no UI files touched)

1. **`chatRichContentSchema`** (`src/server/tracer/types.ts`): three additive union members, mirroring the `input_audio` precedent
   - AI-SDK image: `{type:"image", image, mediaType?}` (data URI pre-extraction, `/api/files/...` after, http(s) passthrough)
   - AI-SDK file: `{type:"file", mediaType, data?, url?, filename?}`
   - OpenAI file: `{type:"file", file:{file_data?, file_id?, filename?}}`
2. **`visitContentPart` / `visitContentPartAsync`** (`src/server/stored-objects/visit-content-part.ts`): new branch dispatching OpenAI file payloads to `binary` (or `input_audio` for `audio/*`, keeping a playable shape), parsing the data URI or falling back to filename-extension mime inference. `file_id`-only parts pass through unchanged since there are no bytes to externalize. AI-SDK image parts already reached the existing `bareImage` branch, so extraction and rendering were already wired for them once validation admits the event.
3. **`content-extractor`** binary rewrite takes the filename from the dispatched part, so the OpenAI `file.filename` survives externalization (`{type:"binary", mimeType, id, url, filename}`).
4. **Attachment chip** (`MediaPart`): document attachments used to render as a bare text link. They now render as a chip with a file icon, the filename, and an external-link affordance that opens the stored file in a new tab (the `/api/files` route serves `Content-Disposition: inline`, so PDFs open in the browser viewer). Stored objects are content-addressed and carry no name of their own, so the chip passes the message-level filename through a new sanitized `filename` query param on the read route, and downloads from the opened viewer keep the original name instead of the object id. Legacy inline base64 parts keep the download fallback since browsers block top-frame `data:` navigation.

Images already rendered through the existing `bareImage` bubble. All bytes are externalized to stored_objects before anything lands in ClickHouse, so this does not reintroduce inline fat payloads.

## Tests

- `specs/features/scenarios/externalize-event-byte-content.feature`: new AC41 section for image/file attachment wire acceptance
- `event-schemas.unit.test.ts`: wire acceptance regression tests (the DB-free proxy for route 201 vs 400) for every documented shape plus post-extraction rewrites, and byte-preservation assertions so validation can never strip what the extractor needs
- `content-extractor.unit.test.ts`: AI-SDK image externalization + rewrite, http passthrough, OpenAI file with data URI, raw base64 with mime inference, `file_id` passthrough, audio-mime routing to `input_audio`
- `scenario-events-ingest.integration.test.ts`: end-to-end POSTs through the real route + auth for the image turn and the OpenAI file turn, asserting 201 and `storeFromBytes` receiving the decoded bytes

## Dogfood evidence (real SDK, local app)

Ran the actual `multimodal-images.test.ts` from the scenario repo (the same `multimodal-images-test` set from the customer-facing docs) against a local app on this branch, plus a documented OpenAI file turn for the file leg:

- All 3 image scenarios pass, message snapshots return 201, and ClickHouse stores `{"type":"image","image":"/api/files/<project>/<id>"}` with the agent's replies describing the fixture image (proof the bytes made the round trip)
- The PDF turn stores `{"type":"binary","mimeType":"application/pdf","id":...,"url":"/api/files/...","filename":"document.pdf"}`
- Identical fixture bytes dedupe to a single stored object across runs

Screenshots, taken on this branch rebased onto the merged simulations UI refresh (#5540, #5549). The customer-reported symptom was green cards with no conversation at all; these show the conversation, image, and document rendering again:

| Set page, fresh runs with conversation previews | Run drawer, question + image render |
|---|---|
| ![set page](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5667/multimodal/images-set-page.png) | ![images drawer](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5667/multimodal/images-drawer.png) |

| File attachment chip, opens the stored PDF in a new tab |
|---|
| ![files drawer](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5667/multimodal/files-drawer.png) |

## Notes for review

- The widened `chatRichContentSchema` is additive only; no previously accepted shape changed. It is the same vocabulary the visitor already claimed to speak, and widening it also stops trace-side typed chat messages from rejecting AI-SDK multimodal parts.
- Rebased onto main after #5540 and #5549 (the simulations page and drawer refresh) merged, and re-verified end to end on the new UI: SDK image runs and the documented file turn all ingest, externalize, and render (screenshots above are from the rebased branch). The attachment chip landed after the rebase, so it sits on top of the refreshed drawer rather than conflicting with it.
- One rendering nuance that belongs with the drawer surface, not here: a text part alongside a file part collapses into the media caption (the audio transcript convention applied to binary parts). It reads fine for the documented "please summarize this document" flow.
- The scenario SDK repo's `schema.ts` is synced from the backend event schemas; the SDK-side copy does not validate outgoing messages, so no SDK release is needed for this fix to take effect for existing SDK versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for image and file attachments in scenario messages, including inline, external URL, and provider-referenced content.
  * Inline media is automatically stored and replaced with accessible file references.
  * Attachments now preserve filenames and offer improved download or open-in-new-tab behavior.
  * Added richer document attachment chips with appropriate icons and accessibility labels.

* **Bug Fixes**
  * Prevented valid multimodal scenario events from being rejected during ingestion.
  * Improved MIME type handling for files, audio, data URIs, and raw base64 content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->