### PR TITLE
chore(deps): change dependabot to weekly now we are caught up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/langwatch"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 50
     cooldown:
       default-days: 8
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/typescript-sdk"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 50
     cooldown:
       default-days: 8
@@ -25,7 +25,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/mcp-server"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 50
     cooldown:
       default-days: 8
@@ -33,7 +33,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/python-sdk"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 50
     cooldown:
       default-days: 8
@@ -41,11 +41,11 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 50
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 50


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automated dependency update checks to run weekly instead of daily.
  * Standardized the maximum number of open update pull requests.
  * Added consistent cooldown settings for package dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->