### PR TITLE
chore(dependabot): weekly cadence and grouped dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,16 +9,28 @@ version: 2
 # Update policy:
 #   - Runs weekly (Monday) instead of daily, so version churn arrives as one
 #     predictable batch rather than a daily trickle.
-#   - The three JS packages share one entry via `directories`, and npm version
-#     updates are grouped by dependency name (group-by: dependency-name). A
-#     dependency shared by langwatch, typescript-sdk and mcp-server is bumped
-#     in all of them in a single PR instead of one PR per package.
-#   - uv (python-sdk) and docker non-major version updates are each grouped
-#     into a single PR; github-actions bumps are grouped into a single PR.
-#   - Security updates are intentionally NOT grouped (no group targets
-#     security-updates), so every advisory fix stays an independent,
-#     individually-mergeable PR. Grouped security PRs tend to fail as a unit
-#     when one member cannot resolve, which would block the rest.
+#   - Coordinated dependency families that release in lockstep (@aws-sdk/*,
+#     @opentelemetry/*, @ai-sdk/*, @copilotkit/*, vitest, react, ...) are each
+#     grouped into ONE PR via `patterns`. Because the three JS packages share
+#     one entry through `directories`, a family (or any shared dependency) is
+#     bumped across langwatch, typescript-sdk and mcp-server together instead
+#     of one PR per package per dependency.
+#   - Everything left over is caught by a `minor-and-patch` group, so the long
+#     tail of trivial version bumps is a single PR. Major bumps of ungrouped
+#     dependencies stay individual for deliberate review.
+#   - Security updates are intentionally handled as fast as possible and are
+#     NOT affected by any of the above throttling:
+#       * `cooldown` applies to version updates only, never to security
+#         updates, so an advisory fix is never delayed by it.
+#       * The weekly `schedule` gates version updates only; security updates
+#         are advisory-triggered and open continuously.
+#       * No group targets `security-updates`, so every advisory fix stays an
+#         independent, individually-mergeable PR that lands as soon as a
+#         patched version is available (grouped security PRs also tend to fail
+#         as a unit when one member cannot resolve, blocking the rest).
+#     The only floor on a security fix is the package managers' own 7-day
+#     minimum-release-age / exclude-newer gate, which is a deliberate
+#     supply-chain safeguard and is intentionally left in place.
 updates:
   - package-ecosystem: "npm"
     directories:
@@ -32,11 +44,59 @@ updates:
     cooldown:
       default-days: 8
     groups:
-      npm-cross-package:
+      ai-sdk:
+        applies-to: version-updates
+        patterns:
+          - "@ai-sdk/*"
+          - "ai"
+      aws-sdk:
+        applies-to: version-updates
+        patterns:
+          - "@aws-sdk/*"
+      opentelemetry:
+        applies-to: version-updates
+        patterns:
+          - "@opentelemetry/*"
+          - "import-in-the-middle"
+      copilotkit:
+        applies-to: version-updates
+        patterns:
+          - "@copilotkit/*"
+      vitest:
+        applies-to: version-updates
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      react:
+        applies-to: version-updates
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-is"
+      typescript-native-preview:
+        applies-to: version-updates
+        patterns:
+          - "@typescript/native-preview"
+      types:
+        applies-to: version-updates
+        patterns:
+          - "@types/*"
+      anthropic:
+        applies-to: version-updates
+        patterns:
+          - "@anthropic-ai/*"
+      posthog:
+        applies-to: version-updates
+        patterns:
+          - "posthog-js"
+          - "posthog-node"
+      minor-and-patch:
         applies-to: version-updates
         patterns:
           - "*"
-        group-by: dependency-name
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "uv"
     directory: "/python-sdk"
@@ -47,6 +107,15 @@ updates:
     cooldown:
       default-days: 8
     groups:
+      opentelemetry:
+        applies-to: version-updates
+        patterns:
+          - "opentelemetry-*"
+          - "openinference-*"
+      langchain:
+        applies-to: version-updates
+        patterns:
+          - "langchain*"
       minor-and-patch:
         applies-to: version-updates
         patterns:
@@ -78,5 +147,6 @@ updates:
     open-pull-requests-limit: 50
     groups:
       github-actions:
+        applies-to: version-updates
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,47 +5,78 @@ version: 2
 # versions younger than that: the package manager would refuse to resolve
 # them and the update run would fail. The cooldowns below keep candidate
 # selection behind the same gate, with one extra day of margin.
+#
+# Update policy:
+#   - Runs weekly (Monday) instead of daily, so version churn arrives as one
+#     predictable batch rather than a daily trickle.
+#   - The three JS packages share one entry via `directories`, and npm version
+#     updates are grouped by dependency name (group-by: dependency-name). A
+#     dependency shared by langwatch, typescript-sdk and mcp-server is bumped
+#     in all of them in a single PR instead of one PR per package.
+#   - uv (python-sdk) and docker non-major version updates are each grouped
+#     into a single PR; github-actions bumps are grouped into a single PR.
+#   - Security updates are intentionally NOT grouped (no group targets
+#     security-updates), so every advisory fix stays an independent,
+#     individually-mergeable PR. Grouped security PRs tend to fail as a unit
+#     when one member cannot resolve, which would block the rest.
 updates:
   - package-ecosystem: "npm"
-    directory: "/langwatch"
+    directories:
+      - "/langwatch"
+      - "/typescript-sdk"
+      - "/mcp-server"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     open-pull-requests-limit: 50
     cooldown:
       default-days: 8
-
-  - package-ecosystem: "npm"
-    directory: "/typescript-sdk"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 50
-    cooldown:
-      default-days: 8
-
-  - package-ecosystem: "npm"
-    directory: "/mcp-server"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 50
-    cooldown:
-      default-days: 8
+    groups:
+      npm-cross-package:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        group-by: dependency-name
 
   - package-ecosystem: "uv"
     directory: "/python-sdk"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     open-pull-requests-limit: 50
     cooldown:
       default-days: 8
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     open-pull-requests-limit: 50
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     open-pull-requests-limit: 50
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Optimizes `.github/dependabot.yml` so version updates arrive as a predictable weekly batch of *grouped* PRs instead of a daily trickle of one PR per dependency per directory, while security fixes stay immediate.

Following GitHub's [guidance on optimizing version-update PR creation](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates). Motivated by ~250 individual Dependabot PRs over the last two weeks.

## Changes

**Weekly (Monday) cadence** for every ecosystem (was daily).

**Family grouping** — coordinated families that release in lockstep are each grouped into one PR. Because the three JS packages (`/langwatch`, `/typescript-sdk`, `/mcp-server`) share a single npm entry via `directories`, a family is bumped across all of them together:

- `@aws-sdk/*` (7 packages, lockstep)
- `@opentelemetry/*` + `import-in-the-middle` (9+ packages)
- `@ai-sdk/*` + `ai`
- `@copilotkit/*`, `vitest` + `@vitest/*`, `react`/`react-dom`/`react-is`, `@types/*`, `@typescript/native-preview`, `@anthropic-ai/*`, `posthog-*`
- uv (`/python-sdk`): `opentelemetry-*` / `openinference-*`, `langchain*`

**Long-tail catch-all** — a `minor-and-patch` group sweeps everything else into a single PR. Ungrouped majors stay individual for deliberate review.

**GitHub Actions** grouped into one PR; **docker** minor/patch grouped.

Cooldowns (8 days) are preserved so version-update candidate selection stays behind the pnpm `minimumReleaseAge` / uv `exclude-newer` 7-day gate.

## Security updates stay immediate

Deliberately unthrottled, and this is now documented in the file:

- **Cooldown is version-only** (GitHub: "only available for version updates, not security updates"), so it never delays an advisory fix.
- The **weekly schedule gates version updates only**; security updates are advisory-triggered and open continuously.
- **No group targets `security-updates`**, so every advisory fix is an independent, individually-mergeable PR that lands as soon as a patched version exists.

The only remaining floor on a security fix is the package managers' own 7-day minimum-release-age / exclude-newer gate, an intentional supply-chain safeguard left in place.

## Why not `group-by: dependency-name`

An earlier revision used `group-by: dependency-name`. That splits a group into one PR per dependency, so it cannot consolidate a lockstep family (e.g. the 7 `@aws-sdk/*` packages would still be 7 PRs). Pattern-based family groups over `directories` give both goals: same-dependency-across-packages consolidation and whole-family consolidation.

## Validation

Passes the official Dependabot JSON schema (`json.schemastore.org/dependabot-2.0.json`) and GitHub's own `.github/dependabot.yml` config-validation check in CI. All group sub-keys (`patterns`, `applies-to`, `update-types`) and `directories` confirmed valid.

## Possible follow-ups (not in this PR)

- `/skills` is another npm workspace sharing deps and could join the npm `directories` list.
- `/langevals` and `/mcp-server` also have `uv` locks not currently covered by version updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update checks to run weekly on Mondays (instead of daily).
  * Grouped related dependency updates to reduce the number of update pull requests, including coordinated grouping for npm, uv, Docker, and GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->