### PR TITLE
chore(dependabot): pin @opentelemetry/otlp-transformer (ignore updates)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,12 @@ updates:
     open-pull-requests-limit: 50
     cooldown:
       default-days: 8
+    ignore:
+      # Pinned intentionally: langwatch needs @opentelemetry/otlp-transformer
+      # held at 0.55.0, and keeps a separate @opentelemetry/otlp-transformer-next
+      # alias for the newer line. Do not let dependabot bump the pinned one
+      # (this exact-name ignore does not affect the -next alias).
+      - dependency-name: "@opentelemetry/otlp-transformer"
     groups:
       ai-sdk:
         applies-to: version-updates


### PR DESCRIPTION
## What

Tell Dependabot to never update `@opentelemetry/otlp-transformer`, which `langwatch/` pins at `0.55.0` on purpose.

```yaml
ignore:
  - dependency-name: "@opentelemetry/otlp-transformer"
```

## Why

`langwatch/package.json` intentionally carries two entries:
- `"@opentelemetry/otlp-transformer": "0.55.0"` (the pinned one this ignore protects)
- `"@opentelemetry/otlp-transformer-next": "npm:@opentelemetry/otlp-transformer@0.219.0"` (the newer line, aliased)

Without this ignore, the `opentelemetry` group would try to bump the pinned `0.55.0` to the latest. The ignore matches the exact name `@opentelemetry/otlp-transformer`, so it does **not** affect the separate `@opentelemetry/otlp-transformer-next` alias.

## Note

A blanket ignore also suppresses security updates for this specific package (that is the nature of a hard pin). If a security advisory ever lands on it, it will need a manual bump. Everything else in the `@opentelemetry/*` group is unaffected.

## Validation

Passes the Dependabot JSON schema and GitHub's own config-validation check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automated dependency update settings to keep a pinned telemetry package version unchanged while allowing related package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->