### PR TITLE
test(mcp): stub docs fetch so integration tests do not ping github

### DIFF
--- a/langwatch/src/mcp/__tests__/mcp-handler.integration.test.ts
+++ b/langwatch/src/mcp/__tests__/mcp-handler.integration.test.ts
@@ -11,12 +11,14 @@ import { createHash, randomUUID } from "node:crypto";
 import { createServer, type Server } from "node:http";
 import {
   afterAll,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
   expect,
   it,
   vi,
+  type MockInstance,
 } from "vitest";
 import type { McpHandler } from "../handler";
 
@@ -85,6 +87,53 @@ function mcpInitializeBody() {
       clientInfo: { name: "test-client", version: "1.0.0" },
     },
   };
+}
+
+// Canned docs page returned by the stubbed network boundary below. The
+// `fetch_langwatch_docs` / `fetch_scenario_docs` tools fetch live pages from
+// langwatch.ai, which redirects to GitHub raw content; GitHub rate-limits CI
+// runners (HTTP 429), so integration tests must not depend on that external
+// host. These tests only assert that the handler routes a tools/call through
+// to the docs tool and returns its content, so a fixed page is the right thing
+// to fake at the fetch boundary.
+const DOCS_PAGE_FIXTURE = [
+  "# LangWatch Documentation",
+  "",
+  "LangWatch is an observability and evaluation platform for LLM applications.",
+  "Follow the links below to integrate the LangWatch SDK into your codebase.",
+  "",
+  "- [Introduction](https://langwatch.ai/docs/introduction.md)",
+  "- [Integration overview](https://langwatch.ai/docs/integration/overview.md)",
+].join("\n");
+
+/**
+ * Replace global `fetch` for the duration of a docs-tool test so the tool
+ * resolves a fixed page instead of reaching langwatch.ai / GitHub. Returns the
+ * spy so the caller can restore it. The stub only serves the docs hosts and
+ * delegates every other request to the real implementation, so tests that hit
+ * the local server over `fetch` keep working.
+ */
+function stubDocsFetch(): MockInstance {
+  const realFetch = globalThis.fetch;
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const requestUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      if (requestUrl.includes("langwatch.ai")) {
+        return Promise.resolve(
+          new Response(DOCS_PAGE_FIXTURE, {
+            status: 200,
+            headers: { "content-type": "text/markdown" },
+          }),
+        );
+      }
+      return realFetch(input, init);
+    });
 }
 
 /**
@@ -1018,6 +1067,14 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when fetch_langwatch_docs is called with a specific URL", () => {
+    let fetchSpy: MockInstance;
+    beforeEach(() => {
+      fetchSpy = stubDocsFetch();
+    });
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
     it("returns page content", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
@@ -1066,6 +1123,14 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when fetch_langwatch_docs is called with a specific docs page URL", () => {
+    let fetchSpy: MockInstance;
+    beforeEach(() => {
+      fetchSpy = stubDocsFetch();
+    });
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
     it("fetches the page and returns its content", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 


### PR DESCRIPTION
## What

The `fetch_langwatch_docs` integration tests in `mcp-handler.integration.test.ts` drove the real MCP handler, which fetches `langwatch.ai/docs/...` live. That host redirects to GitHub raw content, and GitHub rate-limits CI runners, so the suite flaked with:

```
AssertionError: expected '429: too many requests\n...' to contain 'langwatch'
```

Integration tests should not depend on an external host we do not control.

## Change

- Added a scoped `fetch` spy (`stubDocsFetch`) that serves a fixed docs page for `langwatch.ai` requests and delegates every other request to the real `fetch`.
- Installed it via `beforeEach`/`afterEach` inside the two `fetch_langwatch_docs` describe blocks only, so the sibling tests that hit the local test server over `fetch` (SSE transport, OAuth token) keep exercising real network I/O.

The tests still assert what they were written to prove: that the handler routes a `tools/call` through to the docs tool and returns its content. Only the uncontrolled outbound hop is faked.

## Evidence

Ran the full file locally against the integration testcontainers:

- `pnpm test:integration --run src/mcp/__tests__/mcp-handler.integration.test.ts` -> 31 passed (previously the two docs tests flaked on GitHub 429).
- Confirmed the two docs tests pass with the canned fixture and no network hop; SSE/OAuth tests still pass unchanged.
- `pnpm typecheck` clean.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by using deterministic documentation-page responses.
  * Prevented test failures caused by external redirects, network availability, or rate limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->