### PR TITLE
ci(docs): cache pnpm store in check_generated_files

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -70,13 +70,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      # Shared pnpm + Node setup with pnpm-store caching, so this job stops
+      # re-downloading the full langwatch + skills dependency trees on every run.
+      - name: Setup pnpm + Node
+        uses: ./.github/actions/setup-pnpm-node
         with:
-          node-version: "24"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache-dependency-path: |
+            langwatch/pnpm-lock.yaml
+            skills/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## What

The `check_generated_files` job in `docs-ci.yml` runs on every pull request and installs the `langwatch` and `skills` dependency trees, but with no pnpm-store cache. The `setup-node` step ran before `pnpm/action-setup`, so its `cache: pnpm` hook had no pnpm store path to key on, and there was no manual cache step. Every docs-CI run re-downloaded the full dependency set.

## Change

Switch the job to the shared `./.github/actions/setup-pnpm-node` composite action, which sets up pnpm first and then Node with pnpm-store caching. This is the same pattern already used by `langwatch-app-ci`, `mcp-javascript-ci` and `sdk-javascript-ci`. Both workspace lockfiles (`langwatch/pnpm-lock.yaml`, `skills/pnpm-lock.yaml`) feed the cache key.

Node version (24) and pnpm are unchanged; only caching and step ordering change.

## Evidence

- YAML validated.
- The composite action is the established, already-green setup path in the sibling JS/TS workflows; no behavior change beyond caching.
- CI on this PR exercises the job end to end.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated documentation checks by streamlining the build environment setup.
  * Added dependency caching to help validation workflows run more efficiently and consistently.
  * Existing checks for generated documentation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->