### PR TITLE
[design] Langy egress enforcement (PR4/4) — ADR-043 + spec + plan (blocked on PR3)

### DIFF
--- a/dev/docs/adr/043-langy-egress-enforcement.md
+++ b/dev/docs/adr/043-langy-egress-enforcement.md
@@ -1,0 +1,279 @@
+# ADR-043: Langy egress enforcement — monitor first, enforce last
+
+**Date:** 2026-07-10
+
+**Status:** Draft
+
+> **This is the PR4-of-4 design in the Langy egress-hardening series.** It is
+> deliberately docs-only and **blocked on PR3**: it builds the enforcement rungs
+> on top of the egress instrumentation seam (PR1) and the monitor-only telemetry
+> (PR3). Nothing here should be implemented until PR3's seam is merged and has
+> observed real traffic — the whole thesis is "let monitoring prove what's
+> legitimate before anything blocks."
+
+## Context
+
+The `langy-agent` pod runs many `opencode` workers as subprocesses. Each worker
+holds a different user's **live** credentials in its environment — the project's
+LangWatch API key, an AI-gateway virtual key, and (when connected) a GitHub
+user-to-server token — and it executes LLM-generated shell. A prompt-injected
+worker is therefore a realistic attacker, and the single highest-value action
+that attacker can take is **outbound exfiltration**: `curl` the secrets it holds,
+or the customer's trace/PII data it can read via MCP, to an attacker-controlled
+host.
+
+Two prior decisions bound the *pod* but not the *destination*:
+
+- **ADR-033** closed sibling-to-sibling exfiltration (a worker driving another
+  worker's `opencode` control port) with a per-worker `OPENCODE_SERVER_PASSWORD`,
+  and established that **kernel netfilter is unavailable under gVisor** — the pod
+  runs `runtimeClassName: gvisor`, whose Sentry implements no `iptables`/`nftables`
+  in any backend. Any egress control that depends on `iptables` (transparent
+  redirect, OWNER-match DROP, NAT) is off the table in this pod.
+- The chart's NetworkPolicy (`charts/langy-agent/templates/networkpolicy.yaml`)
+  is deny-by-default at L3/L4. Its `allowExternalHttps` rule (default **off**;
+  turned **on** for installs that need `git clone` / `gh` / package installs)
+  opens `:443` to `0.0.0.0/0` with RFC-1918 and the cloud metadata service
+  (`169.254.169.254`) carved out. That carve-out stops SSRF into internal
+  services, but the moment `allowExternalHttps` is on, a worker may reach **any
+  public host on :443** — this is the exfiltration hole this series closes.
+
+NetworkPolicy cannot close it by itself: **L3/L4 policy cannot express FQDN
+egress** ("allow github.com, deny everything else") without a CNI that adds a
+DNS-aware datapath (Cilium). `docs/langy-github-app.md §4` already documents this
+limitation. So the L7 controls have to live somewhere the pod actually controls.
+
+The series splits the work so risk lands last:
+
+| PR | Adds | Blocks anything? |
+|----|------|------------------|
+| PR1 | The **egress seam**: a per-worker forward proxy the worker's tools egress through (`HTTPS_PROXY` in the worker env), mirroring the existing per-worker `authProxy` inbound pattern. | No |
+| PR2 | (series scaffolding — credential-envelope + config plumbing) | No |
+| PR3 | **Monitoring** on the seam: every outbound `CONNECT` is observed, attributed to a worker/conversation, and emitted as telemetry; anomalies are flagged. Observe → detect → flag. | **No — nothing is denied.** |
+| **PR4 (this ADR)** | **Enforcement** rungs on top: require-TLS + per-destination throttle, the **customer allow-list**, an always-on FQDN floor, and retirement of the superseded direct-egress path. | Yes — but default posture stays monitor-only. |
+
+## Decision
+
+We add an **enforcement ladder** to the egress adapter, climbed in the order
+monitoring earned. Each rung is independently shippable behind config, and the
+**default posture after PR4 is still monitor-only** — enforcement that could
+break a customer's legitimate workflow is opt-in, and enforcement that is
+always-on is scoped to destinations monitoring already proved are the only
+legitimate ones.
+
+### Rung 0 (inherited from PR3): always-on monitoring
+
+Every outbound flow is observed and attributed. Nothing below removes this
+floor; every deny/throttle/flag **also** emits the same telemetry, so an
+enforced deny is a *monitored* deny. This is what makes "flag it" and "block it"
+the same event with a different verb.
+
+### Rung 1: require TLS + per-destination throttle
+
+At the L7 adapter:
+
+1. **Require TLS.** The adapter only proxies opaque `CONNECT host:443` tunnels.
+   It refuses to forward cleartext `http://` requests to external hosts. A
+   worker that tries to exfiltrate over plaintext HTTP to a public host is
+   denied at the seam (the destination never sees the bytes). Loopback and the
+   in-cluster control-plane/gateway paths are unaffected (they have their own
+   explicit rules; see "Legitimate paths" below).
+2. **Per-destination throttle.** The adapter cannot see inside TLS, so the
+   throttle is on the *shape* of the flow, not its content: new-connection rate
+   and bytes-transferred **per destination host, per worker**. A worker opening
+   a burst of connections to a rare host, or streaming a large volume to one
+   destination — the classic exfiltration signature — is throttled (slowed, then
+   tar-pitted) rather than hard-denied. Throttle is a *soft* rung on purpose: it
+   degrades a suspicious flow without a false-positive cliff, and it always
+   flags (rung 0) so an operator sees it.
+
+### Rung 2: customer-configurable allow-list (the crux)
+
+**Enforcement is the customer's policy, not ours.** Each project may set an
+optional allow-list of hosts Langy's workers may reach. The semantics are the
+whole point:
+
+- **No allow-list set → monitor only.** Every destination is *observed and
+  flagged* (rung 0) but **nothing is blocked** on allow-list grounds. This is the
+  default. A customer who does nothing gets watching, not breakage.
+- **Allow-list set → restrict to it.** Every host on the list is allowed;
+  **every other host is denied** and flagged. The customer has opted in to
+  enforcement, and the enforcement is exactly the set they declared they trust.
+
+An allow-list ("hosts I trust") is a cleaner mental model than a deny-list
+("hosts I fear") — it is finite, it composes with the always-on monitoring
+beneath (the monitor tells you what to *add* to the list), and its default of
+"unset = watch" is safe. A deny-list's default of "unset = allow-all" is not,
+and a deny-list can never be complete.
+
+### Rung 3: FQDN-bounded floor (always-on, once proven)
+
+Independently of the customer's allow-list, the adapter enforces a small,
+operator-controlled **floor** of the destinations Langy structurally needs:
+`github.com` / `api.github.com` / `codeload.github.com` (PR-opening), the AI
+gateway, and the LangWatch control plane. This floor is the last rung because it
+is only safe to make always-on **after monitoring (PR3) has proven this is
+actually the complete set of legitimate destinations** — turning it on before
+that risks silently breaking a real workflow nobody knew existed. The floor and
+the customer allow-list compose: the effective allow set is `floor ∪
+customer-list`; when the customer sets no list, the floor is still enforced but
+everything else is monitor-only (the floor is a floor, not a ceiling).
+
+### Rung 4: drop the legacy synchronous egress path
+
+Once the seam is the sole egress path, the direct worker-to-internet path it
+superseded is removed: the worker env no longer offers unproxied egress, and the
+broad `allowExternalHttps` `0.0.0.0/0:443` NetworkPolicy rule is narrowed to
+"the adapter's own upstream," so the L3/L4 backstop and the L7 adapter agree on
+one chokepoint. This rung lands last because it is only safe once rungs 1-3 have
+been observed working in production against real traffic.
+
+## Where FQDN enforcement lives
+
+**In the Go egress adapter, at L7 — not in NetworkPolicy, and not requiring a
+particular CNI.** The adapter terminates the worker's `CONNECT github.com:443`
+and reads the FQDN **directly out of the CONNECT authority** (and, as a
+cross-check, the TLS SNI). That is the only place in this pod where an FQDN is
+observable without netfilter, which ADR-033 established is dead under gVisor.
+NetworkPolicy stays exactly as it is: the coarse L3/L4 backstop with the RFC-1918
++ metadata carve-out. It is not asked to do FQDN, because it cannot.
+
+**Honest limit — the L7 adapter is cooperative, not mandatory, in the stock
+pod.** Within one pod netns, nothing at L3/L4 forces a worker's traffic *through*
+the loopback proxy: a prompt-injected worker can ignore `HTTPS_PROXY` and
+`connect()` straight to an external `IP:443`, because the pod-level NetworkPolicy
+still permits `:443` egress (it must — the proxy itself egresses there, and L4
+can't tell proxy bytes from worker bytes). Under gVisor we cannot `iptables
+REDIRECT` worker traffic into the proxy. So the adapter's FQDN/allow-list/TLS
+enforcement is authoritative for **cooperating** clients and is the primary
+mechanism; the **bypass path is not blocked but it is still *seen*** — PR3's
+monitoring must be at the flow level (VPC flow logs / a CNI flow layer), not
+only at the proxy, precisely so a direct-IP bypass is observed and flagged even
+when it isn't blocked. Two optional floors make enforcement *mandatory* for
+operators who need it, and the ADR recommends them without hard-requiring either:
+
+- **Preferred: a Cilium FQDN egress policy at the CNI.** Where the operator runs
+  Cilium, a `CiliumNetworkPolicy` with `toFQDNs` enforces the same allow set in
+  the datapath, which a worker cannot bypass. The adapter and the CNI policy
+  enforce the *same* list; the adapter is the CNI-agnostic default, the Cilium
+  policy is the bypass-proof upgrade.
+- **Fallback: the ADR-033 "Fix B" per-worker netns.** Put each worker in its own
+  network namespace whose only route out is the adapter's veth. ADR-033 validated
+  this works under gVisor (needs `CAP_SYS_ADMIN`) and named the missing piece —
+  "egress without NAT needs a userspace forward proxy over the veth" — which *is*
+  this adapter. So if a customer needs bypass-proof enforcement without Cilium,
+  Fix B + this adapter is the combination, at the cost of the broader capability.
+
+## Where the allow-list config lives
+
+**A per-project setting, resolved by the control plane and threaded into the
+existing per-request credentials envelope** — never a hardcoded list, never a
+chart value (which would be per-install, not per-project).
+
+This mirrors the model-allow-list precedent exactly. Today
+`LangyCredentialService.getModelsAllowed()` reads a project's `modelsAllowed`
+and `langy.ts` enforces it server-side as defense-in-depth before dispatch
+(`langwatch/src/server/routes/langy.ts:389-409`). The egress allow-list follows
+the same shape, with one deliberate divergence:
+
+- **Home: a project-level Langy egress policy, not the virtual key's config.**
+  `modelsAllowed` lives on the `VirtualKey` because the *gateway* is its
+  enforcement point and the VK is the gateway's unit of policy. The egress
+  allow-list's enforcement point is the *agent pod's egress adapter*, not the
+  gateway — putting it on the VK would be a category error. It is a Langy
+  project network policy, so it lives with the project (a nullable
+  `Project.langyEgressAllowlist` JSON column, or a small `LangyEgressPolicy`
+  row keyed by `projectId` — PR4 picks one; the plan proposes the column for
+  parity with the existing per-project Langy fields).
+- **Resolution: `LangyCredentialService.getEgressAllowlist({ projectId })`**,
+  returning `string[] | null`. `null`/empty ⇒ monitor-only (rung 2 default);
+  non-empty ⇒ the enforced set. Same `null-means-watch` convention as
+  `getModelsAllowed`.
+- **Transport: the credentials envelope.** `LangyCredentials` gains
+  `egressAllowlist?: string[]`; the Go `Credentials` struct
+  (`services/langy-agent/worker.go`) gains the matching `egressAllowlist` field.
+  It rides the same per-`/chat` path every other capability rides — no second
+  channel. Because a worker is per-conversation and capabilities are bound at
+  spawn (the `CredentialSignature` pattern), the allow-list is bound at spawn
+  too: a change to the project's list recycles the worker on its next turn, so a
+  live worker never silently runs under a stale policy. The per-worker egress
+  adapter is constructed with that worker's list, exactly as `startAuthProxy` is
+  constructed with that worker's password.
+- **The presence of the list is the mode.** No separate `egressMode` enum: an
+  absent/empty list *is* monitor-only and a non-empty list *is* enforce. This is
+  the whole "default watch, opt-in to restrict" decision expressed as one field,
+  and it keeps the envelope minimal.
+
+## Rationale / trade-offs
+
+- **Why monitor-first, enforce-last.** The failure mode of premature egress
+  enforcement is a silently broken customer workflow (a package registry, a
+  private git host, an internal API the customer legitimately reaches) with no
+  data to tell you it was legitimate. Monitoring first turns "I think this is
+  the allow set" into "here is the observed allow set," so every block is a
+  block of something we watched not being used. It also lets a customer read
+  their own traffic before deciding to enforce, which is what makes the
+  allow-list *theirs*.
+- **Why customer-owned allow-list, not a LangWatch-owned deny-list.** We do not
+  know a given customer's legitimate destinations — their internal hosts, their
+  registries, their git remotes. A deny-list we maintain is both incomplete
+  (misses their attacker) and wrong (blocks their internal host). An allow-list
+  they own is complete *for their environment* by construction, and the default
+  of "unset = watch" means we never break an install that hasn't opted in.
+- **Trade-off accepted: cooperative L7 enforcement has a bypass in the stock
+  pod.** We accept this because (a) the bypass is *monitored*, not invisible;
+  (b) the honest alternative — mandatory enforcement — costs either a CNI
+  dependency (Cilium) or the broader `CAP_SYS_ADMIN` + per-worker netns of
+  ADR-033 Fix B, neither of which every operator wants; and (c) we surface both
+  as documented upgrades. Pretending L3/L4 policy can FQDN-block, or that the
+  loopback proxy is unbypassable, would be the worse outcome.
+- **Trade-off accepted: throttle is heuristic.** Byte/connection-rate signatures
+  are not proof of exfiltration; they can false-positive on a legitimate large
+  clone. That is exactly why throttle *slows and flags* rather than hard-denies,
+  and why the hard-deny rung (allow-list) is customer-scoped.
+
+## Consequences
+
+- **Config surface.** A new per-project `langyEgressAllowlist` (nullable) and a
+  `LangyCredentialService.getEgressAllowlist` resolver; `LangyCredentials` and
+  the Go `Credentials` struct each gain `egressAllowlist?: string[]`. `langy.ts`
+  threads it into the envelope, alongside the existing model/GitHub plumbing.
+- **Egress adapter.** The PR1 adapter gains, per rung: a TLS-required guard, a
+  per-destination throttle, an allow-list matcher (host + the always-on floor),
+  and the FQDN read from the CONNECT authority. All four *also* emit PR3's
+  telemetry, so every enforcement action is a monitored event.
+- **Chart.** `charts/langy-agent`: the always-on floor becomes a values list
+  (`networkPolicy.egressFqdnFloor` / adapter config), documented as "operator
+  floor, not customer policy." The broad `allowExternalHttps: 0.0.0.0/0:443`
+  rule is narrowed to the adapter's upstream once rung 4 lands. Optional Cilium
+  `CiliumNetworkPolicy` with `toFQDNs` shipped as an opt-in template for
+  bypass-proof installs; ADR-033 Fix B referenced as the non-Cilium bypass-proof
+  fallback.
+- **Docs.** `docs/langy-github-app.md §4` (which already flags the L3/L4 FQDN
+  limitation and names Cilium) is updated to point at the adapter as the primary
+  FQDN enforcement point and this ADR as the design.
+- **No new user-facing breakage by default.** Because default posture stays
+  monitor-only, an existing install upgrades into *watching*, not *blocking*.
+  Blocking begins only when a customer sets an allow-list, or when an operator
+  turns on the FQDN floor / rung 4 after reading their monitoring.
+- **Hard dependency on PR3.** None of PR4 is safe to build or merge before PR3's
+  monitoring seam exists and has observed real traffic — the enforcement rungs
+  are defined *relative to* what monitoring proved legitimate. This ADR exists so
+  PR4 is a fast-follow the moment PR3 lands.
+
+## References
+
+- Related ADRs: ADR-033 (Langy worker network isolation under gVisor — the
+  netfilter-is-dead constraint and the Fix B netns fallback this builds on).
+- Spec: `specs/langy/langy-egress-enforcement.feature`
+- Plan: `specs/langy/langy-pr4-plan.md`
+- Code seams: `services/langy-agent/authproxy.go` (per-worker proxy pattern the
+  egress adapter mirrors), `services/langy-agent/worker.go` (`Credentials`
+  envelope + `buildWorkerEnv`), `services/langy-agent/handler.go` (`/chat`
+  dispatch), `langwatch/src/server/routes/langy.ts` (envelope construction +
+  defense-in-depth allow-list check), `langwatch/src/server/services/langy/
+  LangyCredentialService.ts` (`getModelsAllowed` precedent).
+- Chart: `charts/langy-agent/templates/networkpolicy.yaml`,
+  `charts/langy-agent/values.yaml` (`networkPolicy.allowExternalHttps`).
+- Docs: `docs/langy-github-app.md §4` (NetworkPolicy / egress; existing FQDN /
+  Cilium note).

--- a/dev/docs/adr/README.md
+++ b/dev/docs/adr/README.md
@@ -25,6 +25,7 @@ Document **important technical and architectural decisions** — context, trade-
 | [037](./037-automation-operator-surfaces.md) | Automation operator surfaces — authoring drawer & dispatch-health view | Accepted |
 | [038](./038-intent-forked-onboarding-governance-vs-llmops.md) | Onboarding forks on a first-class Organization intent | Accepted |
 | [039](./039-outbox-heartbeat.md) | Outbox heartbeat primitive | Accepted |
+| [043](./043-langy-egress-enforcement.md) | Langy egress enforcement — monitor first, enforce last | Draft |
 | [030](./030-transactional-outbox-for-stake-sensitive-dispatch.md) | Transactional outbox for stake-sensitive reactor dispatch | Accepted |
 
 ## When to Write an ADR

--- a/specs/langy/langy-egress-enforcement.feature
+++ b/specs/langy/langy-egress-enforcement.feature
@@ -1,0 +1,161 @@
+@unimplemented
+Feature: Langy worker egress enforcement — monitor first, enforce last
+  As the operator of the langy-agent backend, and as a customer whose project
+  Langy acts on
+  I want outbound traffic from a prompt-injectable Langy worker to be watched by
+  default and restricted only to the destinations the customer trusts
+  So that a compromised worker cannot exfiltrate the live LangWatch key, gateway
+     key, GitHub token, or the customer's trace/PII data to an attacker host,
+     while a customer who has configured nothing is never silently broken
+
+  # ---------------------------------------------------------------------------
+  # Background: the threat and the layering
+  #
+  # Each worker holds a different user's live credentials and runs LLM-generated
+  # shell, so outbound exfiltration is the top risk. The pod runs under gVisor,
+  # where kernel netfilter is unavailable (ADR-033) — so iptables redirect / NAT
+  # / OWNER-match cannot gate egress. NetworkPolicy bounds L3/L4 (deny-by-default
+  # with RFC-1918 + the cloud metadata service carved out) but cannot express
+  # FQDN egress without a CNI like Cilium.
+  #
+  # PR1 adds a per-worker egress adapter (a forward proxy the worker's tools
+  # egress through, mirroring the inbound authProxy). PR3 adds MONITORING on that
+  # adapter: every outbound flow is observed, attributed to a worker/conversation,
+  # and flagged — but nothing is blocked. This feature (PR4) adds the ENFORCEMENT
+  # rungs on top, in the order monitoring earned:
+  #   0. always-on monitoring (from PR3) — every rung below also flags
+  #   1. require TLS + per-destination throttle
+  #   2. customer allow-list: unset -> monitor only; set -> restrict to it
+  #   3. always-on FQDN floor (github / gateway / control-plane), once proven
+  #
+  # The customer allow-list is a per-project setting resolved by the control
+  # plane and threaded into the per-request credentials envelope; the adapter is
+  # constructed with that worker's list at spawn.
+  # ---------------------------------------------------------------------------
+
+  # ===========================================================================
+  # Rung 0 / Rung 2 default — no allow-list means monitor, not block
+  # ===========================================================================
+
+  Scenario: With no allow-list, outbound traffic is monitored but allowed
+    Given a project has not configured a Langy egress allow-list
+    And a worker is running for a conversation in that project
+    When the worker makes an outbound TLS connection to any external host
+    Then the connection is allowed
+    And the destination is recorded and attributed to the worker's conversation
+    And nothing is blocked on allow-list grounds
+
+  Scenario: With no allow-list, a suspicious destination is flagged without being blocked
+    Given a project has not configured a Langy egress allow-list
+    And a worker is running for a conversation in that project
+    When the worker connects to a destination never seen for that project before
+    Then the connection is allowed
+    And the destination is flagged as anomalous for an operator to review
+
+  # ===========================================================================
+  # Rung 2 — allow-list set means restrict to it
+  # ===========================================================================
+
+  Scenario: With an allow-list set, a listed host is allowed
+    Given a project's Langy egress allow-list contains "registry.npmjs.org"
+    And a worker is running for a conversation in that project
+    When the worker makes an outbound TLS connection to "registry.npmjs.org"
+    Then the connection is allowed
+    And the destination is recorded and attributed to the worker's conversation
+
+  Scenario: With an allow-list set, a non-listed host is blocked and flagged
+    Given a project's Langy egress allow-list contains "registry.npmjs.org"
+    And a worker is running for a conversation in that project
+    When the worker attempts an outbound TLS connection to "attacker.example.com"
+    Then the connection is denied at the egress adapter
+    And the destination never receives any bytes
+    And the denied attempt is flagged and attributed to the worker's conversation
+
+  Scenario: Changing the allow-list does not leave a live worker on the old policy
+    Given a worker is running under a project with allow-list "a.example.com"
+    When the project's allow-list is changed to "b.example.com"
+    And the same conversation takes its next turn
+    Then the worker is recycled so it runs under the new allow-list
+    And a request to "b.example.com" is allowed
+    And a request to "a.example.com" is denied
+
+  # ===========================================================================
+  # Rung 1 — require TLS
+  # ===========================================================================
+
+  Scenario: Cleartext egress to an external host is refused
+    Given a worker is running for a conversation
+    When the worker attempts a plaintext HTTP request to an external host
+    Then the request is refused at the egress adapter
+    And the worker cannot send the bytes over cleartext to a public destination
+
+  Scenario: TLS egress to an allowed host still succeeds
+    Given a worker is running for a conversation
+    And the destination host is permitted for that worker
+    When the worker opens a TLS tunnel to that host
+    Then the tunnel is established and the request succeeds
+
+  # ===========================================================================
+  # Rung 1 — per-destination throttle
+  # ===========================================================================
+
+  Scenario: A high-volume flow to a single destination is throttled and flagged
+    Given a worker is running for a conversation
+    When the worker streams an unusually large volume to a single destination
+    Then the flow to that destination is throttled
+    And the flow is flagged for an operator to review
+    And other destinations for that worker are not slowed
+
+  Scenario: A burst of new connections to a rare host is throttled
+    Given a worker is running for a conversation
+    When the worker opens many new connections to a rarely-seen host in a short window
+    Then the new-connection rate to that host is throttled
+    And the burst is flagged and attributed to the worker's conversation
+
+  # ===========================================================================
+  # Rung 3 — always-on FQDN floor
+  # ===========================================================================
+
+  Scenario: Structural destinations stay reachable regardless of allow-list
+    Given the operator FQDN floor includes GitHub, the AI gateway, and the control plane
+    And a project has not configured a Langy egress allow-list
+    When a worker performs its GitHub, gateway, or control-plane traffic
+    Then those connections are allowed by the floor
+    And the worker's legitimate PR / model / API work is unaffected
+
+  Scenario: The floor composes with, and is not widened by, an empty customer list
+    Given a project has not configured a Langy egress allow-list
+    When a worker connects to a host outside the operator FQDN floor
+    Then the floor does not deny it
+    But it remains monitor-only rather than allow-listed
+
+  # ===========================================================================
+  # Rung 3 limitation — cooperative L7, honestly bounded
+  # ===========================================================================
+
+  Scenario: A direct-IP bypass of the adapter is still observed
+    Given a worker is running under an enforced allow-list
+    When the worker ignores its proxy and connects directly to an external IP on 443
+    Then the adapter cannot block that cooperative bypass in the stock pod
+    But the direct connection is still observed at the flow level and flagged
+    And an operator who needs it blocked can enable the Cilium FQDN policy or the per-worker netns floor
+
+  # ===========================================================================
+  # Rung 4 — the legacy path is gone
+  # ===========================================================================
+
+  Scenario: The worker has no unproxied egress path once enforcement lands
+    Given the egress adapter is the sole egress path for workers
+    When a worker's tools make outbound requests
+    Then all egress is observed and enforced at the adapter
+    And the previous direct worker-to-internet path is no longer available
+
+  # ===========================================================================
+  # Safe-by-default posture
+  # ===========================================================================
+
+  Scenario: An install that configures nothing upgrades into watching, not blocking
+    Given an existing install with no per-project allow-lists and the FQDN floor off
+    When workers make their normal outbound requests after this change ships
+    Then no new outbound request is blocked by default
+    And every outbound request is monitored and attributable

--- a/specs/langy/langy-pr4-plan.md
+++ b/specs/langy/langy-pr4-plan.md
@@ -1,0 +1,206 @@
+# Plan: Langy egress enforcement (PR4 of 4)
+
+- **ADR:** `dev/docs/adr/043-langy-egress-enforcement.md`
+- **Spec:** `specs/langy/langy-egress-enforcement.feature`
+- **Branch (design):** `design/langy-pr4` (this doc + ADR + spec; docs-only)
+- **Implementation branch (later):** `feat/langy-egress-enforcement`
+- **BLOCKED ON PR3** — the egress instrumentation seam (PR1) and the monitor-only
+  telemetry (PR3) must be merged and have observed real traffic first. Every rung
+  below is defined relative to what PR3's monitoring proved legitimate. Do not
+  implement until PR3 lands.
+
+## Goal
+
+Turn the always-on egress *monitoring* PR3 provides into an enforcement ladder,
+climbed in the order monitoring earned, with the default posture staying
+monitor-only:
+
+1. **Require TLS + per-destination throttle** at the L7 adapter.
+2. **Customer allow-list** — per-project, opt-in. Unset ⇒ monitor only; set ⇒
+   restrict to it. This is the crux: enforcement is the customer's policy.
+3. **FQDN floor** — always-on for the destinations Langy structurally needs
+   (GitHub / gateway / control plane), once monitoring proved that set.
+4. **Drop the legacy synchronous egress path** superseded by the seam.
+
+## Target flow (config → envelope → adapter)
+
+```
+ Project settings                Chat time (langy.ts /chat)          Worker pod (Go adapter)
+ ────────────────                ──────────────────────────          ───────────────────────
+ customer sets                   getOrProvision()                    spawnWorker()
+ egress allow-list  ──────┐       + getEgressAllowlist()  ───┐        + startEgressAdapter(
+ (per-project, nullable)  │             │                    │            allowlist, floor)
+                          │             ▼                    │              │
+                          │      credentials.egressAllowlist │              ▼
+                          │             │                    └──► worker env: HTTPS_PROXY
+                          └─────────────┴──► /chat body ──────────► Credentials{egressAllowlist}
+                                                                            │
+   null/empty  = monitor only  ◄── presence of list IS the mode ──►  non-empty = enforce
+                                                                            │
+                                                                    per-CONNECT decision:
+                                                                    require-TLS → throttle →
+                                                                    allow-list ∪ floor → flag
+```
+
+## What already exists (reuse, don't reinvent)
+
+| Thing | Where | Reuse for |
+|---|---|---|
+| Per-worker proxy pattern (inbound) | `services/langy-agent/authproxy.go` (`startAuthProxy`, per-worker listener + secret, `shutdown`) | The egress adapter is the **outbound** twin: per-worker forward proxy, constructed with that worker's policy, shut down with the worker. Mirror it — don't invent a new topology. |
+| Credentials envelope | `services/langy-agent/worker.go` `Credentials` struct + `buildWorkerEnv`; TS `LangyCredentials` | Add `egressAllowlist` to both; inject `HTTPS_PROXY` (loopback adapter) into the worker env in `buildWorkerEnv`. |
+| Capability-change worker recycle | `worker.go` `CredentialSignature` / `signatureOf` | Add `egressAllowlist` to the signature so a policy change recycles the worker (spec: "does not leave a live worker on the old policy"). |
+| Model allow-list precedent | `LangyCredentialService.getModelsAllowed()` + defense-in-depth check in `langy.ts:389-409` | Copy the shape for `getEgressAllowlist()` (`string[] | null`, null = watch) and the envelope threading. |
+| Envelope construction | `langwatch/src/server/routes/langy.ts:367,482-494` | Add `egressAllowlist` to the `/chat` body next to `modelOverride`. |
+| NetworkPolicy egress + carve-outs | `charts/langy-agent/templates/networkpolicy.yaml`, `values.yaml` `networkPolicy.allowExternalHttps` | Narrow the `0.0.0.0/0:443` rule to the adapter's upstream (rung 4); add the FQDN-floor values + optional Cilium template. |
+| gVisor / netfilter constraint + netns fallback | ADR-033 | FQDN enforcement lives at L7 (no netfilter); Fix B netns is the non-Cilium bypass-proof floor. |
+
+## Config schema
+
+**Per-project setting (control plane).** Nullable; unset = monitor-only.
+
+- `Project.langyEgressAllowlist Json?` — an array of host patterns
+  (`["registry.npmjs.org", "*.internal.acme.com"]`), validated through a Zod
+  schema at read time (mirror `parseVirtualKeyConfig`). Chosen over a VK-config
+  field because the *adapter*, not the gateway, enforces it — the VK is a
+  category mismatch (ADR §"Where the allow-list config lives"). A dedicated
+  `LangyEgressPolicy` row keyed by `projectId` is the alternative if we want an
+  audit trail on policy changes; the column is proposed for parity with the
+  existing per-project Langy fields.
+- Resolver: `LangyCredentialService.getEgressAllowlist({ projectId }): Promise<string[] | null>`.
+  `null`/empty ⇒ monitor-only; non-empty ⇒ enforced set.
+
+**Envelope (both sides).**
+
+- TS `LangyCredentials` gains `egressAllowlist?: string[]`.
+- Go `Credentials` gains `EgressAllowlist []string \`json:"egressAllowlist,omitempty"\``.
+
+**Operator floor (chart, not per-project).**
+
+- `charts/langy-agent/values.yaml`: `networkPolicy.egressFqdnFloor: [github.com,
+  api.github.com, codeload.github.com, <gateway>, <control-plane>]` — the
+  always-on rung 3 set, documented as "operator floor, not customer policy."
+- Effective allow set at the adapter = `floor ∪ customerAllowlist`.
+
+## Enforcement points (file by file)
+
+Control plane (TypeScript):
+
+- [ ] `prisma/schema.prisma` — add `langyEgressAllowlist Json?` to `Project`
+      (+ migration). Include `projectId` in every read (multitenancy).
+- [ ] `langwatch/src/server/services/langy/LangyCredentialService.ts` — add
+      `getEgressAllowlist({ projectId })`, Zod-validated, `string[] | null`,
+      `null` = watch. Mirror `getModelsAllowed` (tenancy in the WHERE, parse
+      through Zod so a drifted value fails closed rather than disabling
+      enforcement).
+- [ ] `langwatch/src/server/routes/langy.ts` — resolve the allow-list and add
+      `egressAllowlist` to the `credentials` object built at ~L367; it then
+      rides the existing `/chat` body at L482-494. No new channel.
+- [ ] Settings UI (optional, can trail the enforcement): a per-project "Langy
+      egress allow-list" editor. Follow `dev/docs/best_practices/` (scope
+      selector, drawers). Copy per `copywriting.md`: say what it does for the
+      customer ("hosts Langy may reach for this project — leave empty to watch
+      without blocking"), not how it's built. **Not required for PR4 to
+      enforce** — the resolver + envelope are the enforcement path; UI is how a
+      customer sets the value (a tRPC mutation writing the column is the minimum).
+
+Agent pod (Go, `services/langy-agent/`):
+
+- [ ] `egressadapter.go` (new) — per-worker forward proxy mirroring
+      `authproxy.go`: `startEgressAdapter({ allowlist, floor, throttle }) ->
+      *egressAdapter` with `shutdown()`. Per-`CONNECT` decision pipeline:
+      1. **require-TLS** — accept only `CONNECT host:443` tunnels; refuse
+         cleartext forward to external hosts.
+      2. **throttle** — per-destination-host, per-worker new-connection-rate +
+         byte-rate limiter; slow + tar-pit, never a hard cliff.
+      3. **allow-list ∪ floor** — read FQDN from the CONNECT authority (SNI as
+         cross-check); if the effective set is non-empty and the host is not in
+         it, deny; if the customer set is empty, allow (monitor-only) but the
+         floor still applies.
+      4. **flag** — every decision (allow / throttle / deny) emits PR3's
+         telemetry, attributed to the conversation. Enforcement = a monitored
+         event with a verb.
+- [ ] `worker.go` — `Credentials` gains `EgressAllowlist`; `signatureOf` folds
+      it in (policy change → recycle); `buildWorkerEnv` injects
+      `HTTPS_PROXY=http://127.0.0.1:<egressPort>` (and `HTTP_PROXY`, `NO_PROXY`
+      for loopback + in-cluster) so worker tools egress through the adapter.
+- [ ] `manager.go` — allocate the per-worker egress port, start/stop the adapter
+      alongside the existing authProxy in the worker lifecycle.
+- [ ] `handler.go` — thread `req.Credentials.EgressAllowlist` through to
+      `mgr.Get` (already carries `creds`); no schema surprise, it's on
+      `Credentials`.
+- [ ] `egressadapter_test.go` (new) — the security-critical Go tests: cleartext
+      refused; non-listed host denied (bytes never sent); listed host allowed;
+      empty list = allow + flag; floor always allowed; throttle slows one
+      destination without slowing others; policy-change recycles the worker.
+      These are the executable acceptance bar (not string assertions).
+
+Chart:
+
+- [ ] `charts/langy-agent/values.yaml` + `templates/` — add
+      `networkPolicy.egressFqdnFloor` (adapter config) and a documented "floor,
+      not policy" note. **Rung 4:** narrow `allowExternalHttps`'s
+      `0.0.0.0/0:443` to the adapter's upstream once the adapter is the sole
+      egress path. Optional `templates/ciliumnetworkpolicy.yaml` (guarded by a
+      values flag) with `toFQDNs` for bypass-proof installs; reference ADR-033
+      Fix B (per-worker netns) as the non-Cilium bypass-proof fallback in the
+      values comment.
+
+Docs:
+
+- [ ] `docs/langy-github-app.md §4` — update the existing L3/L4-FQDN note to
+      point at the egress adapter as the primary FQDN enforcement point and
+      ADR-043 as the design; keep the Cilium option, add the netns fallback.
+
+## Safe rollout order (monitor → throttle → block)
+
+Each step is independently shippable and observable before the next. **The
+default posture never blocks until a customer or operator opts in.**
+
+1. **PR3 (dependency), monitor-only.** Adapter observes + attributes + flags.
+   Nothing denied. Bake in prod; read the traffic.
+2. **Rung 1a — require TLS.** Turn on cleartext refusal. Low false-positive risk
+   (worker egress is HTTPS already); watch the flag stream for any legitimate
+   plaintext flow first.
+3. **Rung 1b — throttle.** Enable per-destination throttle. Soft by design;
+   tune thresholds against the monitored byte/connection distributions from
+   step 1. Still no hard denies.
+4. **Rung 2 — customer allow-list.** Ship the resolver + envelope + adapter
+   matcher. Default stays monitor-only (unset list). Customers opt in per
+   project after reading their own monitored traffic. First hard-deny rung, but
+   customer-scoped.
+5. **Rung 3 — FQDN floor.** Only after monitoring across installs confirms the
+   structural set (GitHub / gateway / control plane) is complete, make the floor
+   always-on. Operator flag; off by default until proven per install.
+6. **Rung 4 — drop the legacy path.** Once rungs 1-3 are observed working,
+   remove unproxied worker egress and narrow the `0.0.0.0/0:443` NetworkPolicy
+   rule to the adapter upstream. Last, because it's the irreversible one.
+
+## Acceptance
+
+The bar is `specs/langy/langy-egress-enforcement.feature`, bound to executable
+Go tests in `egressadapter_test.go` (deny/allow/throttle/require-TLS/floor/
+recycle) plus a control-plane integration test that `getEgressAllowlist` returns
+`null` = watch and a set list = enforce, and that the envelope carries it.
+Scenarios stay `@unimplemented` until bound to those tests. The honest-limit
+scenario (direct-IP bypass observed-but-not-blocked in the stock pod) is asserted
+against the monitoring layer, and the Cilium / netns floors are the documented
+bypass-proof upgrades.
+
+## Open questions
+
+1. **Host-pattern syntax for the allow-list.** Exact hosts only, or wildcards
+   (`*.internal.acme.com`)? Wildcards are more usable but widen the matcher's
+   attack surface. Proposal: start exact-host + a single leading-label wildcard;
+   validate through Zod.
+2. **Adapter config home for the column vs a `LangyEgressPolicy` row.** Column is
+   simplest and matches existing per-project Langy fields; a row gives a change
+   audit trail. Proposal: column now, revisit if customers ask for policy
+   history.
+3. **Throttle thresholds.** Must be derived from PR3's observed distributions,
+   not guessed — so the numbers are a step-3 tuning task, not a design constant.
+4. **Does the customer allow-list also gate the FQDN floor?** No — floor is
+   operator-owned and always-on once enabled; the customer list is additive
+   (`floor ∪ list`). Confirmed in ADR §Rung 3.
+5. **Bypass-proofing default.** Do we ship Cilium `toFQDNs` on by default where
+   Cilium is present, or leave it opt-in? Proposal: opt-in template; the stock
+   default is cooperative-adapter + monitored-bypass, upgradable per install.


### PR DESCRIPTION
## [design] Langy egress enforcement (PR4 of 4) — docs only

**Docs-only.** No implementation code. This is the ADR + Gherkin spec +
implementation plan so PR4 is a fast-follow once its dependency lands.

> **Blocked on PR3.** PR4 builds the enforcement rungs on top of the egress
> instrumentation seam (PR1) and the monitor-only telemetry (PR3). None of that
> is merged yet, so this PR intentionally ships design only. The whole thesis is
> **monitor first, enforce last** — let monitoring prove what's legitimate before
> anything blocks.

### What's here
- `dev/docs/adr/043-langy-egress-enforcement.md` — the enforcement ladder, the
  customer allow-list model, where the config lives, where FQDN enforcement runs,
  and the explicit dependency on PR3's monitoring seam.
- `specs/langy/langy-egress-enforcement.feature` — `@unimplemented` Gherkin: no
  allow-list ⇒ monitored-but-allowed; allow-list set ⇒ non-listed host blocked +
  flagged; TLS required; throttle on suspicious flows; the FQDN floor; and the
  honest cooperative-bypass limitation.
- `specs/langy/langy-pr4-plan.md` — file-by-file plan, the config schema, the
  enforcement points, and the safe rollout order (monitor → throttle → block).

### The enforcement ladder (PR4)
0. **Monitoring** (from PR3) — always-on floor; every rung below also flags.
1. **Require TLS + per-destination throttle** — L7 controls the adapter expresses
   (the NetworkPolicy already bounds L3/L4).
2. **Customer allow-list** (the crux) — a per-project, opt-in list of hosts Langy
   may reach. **No list ⇒ monitor only (nothing blocked); list set ⇒ restrict to
   it (everything else denied).** Enforcement is the customer's policy, defaulting
   to watch.
3. **FQDN floor** — always-on for GitHub / gateway / control-plane, once
   monitoring proved that's the complete legitimate set.
4. **Drop the legacy direct-egress path** superseded by the seam.

### Key decisions for review
- **Allow-list config lives on the project** (`Project.langyEgressAllowlist`,
  nullable), resolved by `LangyCredentialService.getEgressAllowlist()` and
  threaded into the **per-request credentials envelope** — mirroring the existing
  `getModelsAllowed` precedent. Deliberately **not** on the VirtualKey config
  (that's the gateway's unit of policy; the *agent pod* enforces egress). Presence
  of the list **is** the mode — no separate enum.
- **FQDN enforcement lives in the Go egress adapter at L7**, reading the FQDN from
  the `CONNECT` authority — because netfilter is dead under gVisor (ADR-033), so
  NetworkPolicy can't FQDN-block and stays the coarse L3/L4 backstop. Honestly
  bounded: the L7 adapter is *cooperative* in the stock pod (a worker can bypass
  the loopback proxy via direct-IP:443, which is still **monitored**); the
  bypass-proof upgrades are a Cilium `toFQDNs` policy (preferred) or the ADR-033
  Fix B per-worker netns (fallback).

### Constraints honored
Docs only; no `.github/workflows/` touched; no AI attribution.
