### PR TITLE
[design] Langy — event-driven worker + streaming + self-observability (ADR-044 + specs)

### DIFF
--- a/dev/docs/adr/043-langy-event-driven-turns.md
+++ b/dev/docs/adr/043-langy-event-driven-turns.md
@@ -1,0 +1,393 @@
+# ADR-043: Event-driven Langy turns — worker spawn, liveness reconcile, stream persistence split, self-observability
+
+**Date:** 2026-07-10
+
+**Status:** Draft
+
+> **This is a design-only ADR (PR3 of 4).** It is written and merged *ahead*
+> of its implementation because PR3's code depends on two changes being built
+> in parallel that have not yet landed on `main`:
+>
+> - **PR1** — Go telemetry on the langy-agent manager plus two new adapter
+>   seams in `services/langy-agent/`: `adapters/workerpool` (the pod-side
+>   spawner of opencode subprocesses) and `adapters/egress` (a single
+>   `http.RoundTripper` boundary every worker outbound call flows through).
+>   Today the manager emits no telemetry of its own.
+> - **PR2** — a `langy_conversation` event-sourcing aggregate with the events
+>   and commands PR3 reacts to and dispatches (`agent_turn_started`,
+>   `status_reported`, `progress_reported`, `agent_turn_failed`,
+>   `turn_finalized`; `StartAgentTurn`, `RecordStatus`, `RecordProgress`,
+>   `FinalizeTurn`, `ReconcileAgentTurn`).
+>
+> Building PR3's code against `main` now would reference symbols that do not
+> exist. This ADR + its Gherkin specs (`specs/langy/langy-event-driven-turns.feature`,
+> `specs/langy/langy-self-observability.feature`) + the plan
+> (`specs/langy/langy-pr3-plan.md`) are the spec-first artefacts so PR3 can be
+> implemented as a fast-follow the moment PR1 + PR2 merge. The exact interfaces
+> and seams consumed from PR1/PR2 are pinned in **"Dependencies"** below; if
+> they land with different names, this ADR is the reconciliation point.
+
+## Context
+
+Langy is LangWatch's in-product AI assistant. A chat turn runs an `opencode`
+subprocess (one per conversation) inside the `langy-agent` pod, spawned and
+fronted by a Go manager (`services/langy-agent/`). The control plane's Hono
+route `POST /api/langy/chat` (`src/server/routes/langy.ts`) is the auth +
+persistence + stream-bridge layer.
+
+Today that route is **synchronous and stateless**:
+
+1. It authenticates, resolves per-project credentials
+   (`LangyCredentialService.getOrProvision`), persists the user message, and
+   reserves a GitHub-PR permit.
+2. It `fetch`es `POST {OPENCODE_AGENT_URL}/chat` on the manager and **holds the
+   HTTP connection open for up to 120 s** (`AGENT_CHAT_TIMEOUT_MS`).
+3. The manager (`handler.go::handleChat`) claims the worker (`Worker.tryClaim`),
+   posts the prompt to opencode, and streams opencode's `/event` SSE back as
+   NDJSON.
+4. The route bridges NDJSON → a `createUIMessageStream` UI stream → browser
+   tokens, then persists the assistant message and reconciles the PR permit in
+   the stream executor's `finally`.
+
+Four properties fall out of that shape, and all four are now costing us:
+
+- **No deploy survival.** The turn lives entirely in one held-open request
+  against one worker pod. A rollout of `langwatch-app` or `langy-agent` mid-turn
+  drops the socket; the turn is lost with no terminal state. The route's own
+  comments call this out ("no idempotency key… a mid-task failure surfaces to
+  the user instead of being silently retried").
+- **No refresh-resume.** Tokens exist only on the wire. A browser refresh
+  during a turn loses everything streamed so far; on reconnect there is nothing
+  to reattach to.
+- **No liveness.** If opencode wedges (or the pod is OOM-killed), the turn hangs
+  until the 120 s client timeout. There is no heartbeat and nothing sweeps a
+  stalled turn to a terminal state.
+- **No central observability of Langy itself.** The opencode OTel plugin exports
+  gen-AI/tool spans **only to each user's own project** (`buildWorkerEnv`'s
+  `OPENCODE_OTLP_*`). The manager emits nothing. The team that builds Langy has
+  no aggregate view of how Langy behaves in the wild — spawn latency, stall
+  rate, tool usage, egress — to improve it.
+
+The scenario/simulation subsystem already solved the first three problems with
+an **event-sourced, reactor-driven, pool-backed** execution model. A queued
+event drives a `runIn:["worker"]` reactor
+(`scenarioExecution.reactor.ts`) that submits to an in-process
+`ScenarioExecutionPool` (`execution-pool.ts`), wired via `setPool()` in
+`src/workers.ts`; a drain-on-shutdown path
+(`drainInFlightRuns` + `pool.inFlightJobs`) and a startup reconciler
+(`reconcileOrphanedQueuedRuns`) give every run a terminal state across worker
+restarts. PR2 gives Langy the aggregate to hang the same machinery on.
+
+The fourth problem — self-observability — is exactly the **dual-export** the AI
+gateway already ships: `customertracebridge` tees gen-AI spans to the customer's
+project via the `AITraceEmitter` port, using a private `TracerProvider` (empty
+resource, `AlwaysSample`) whose `routerExporter` fans spans to per-project OTLP
+endpoints keyed on a `langwatch.project_id` span attribute.
+
+This ADR adapts both proven patterns to Langy.
+
+## Decision
+
+We will move Langy turns onto the `langy_conversation` aggregate and drive
+execution off events, split token persistence from durable turn state, add a
+heartbeat/reconcile liveness layer, tee Langy's own activity to an internal
+LangWatch project, and observe (flag-only) every worker egress call. Five parts.
+
+### 1. `spawnAgent` reactor + `LangyWorkerPool` (event-driven spawn)
+
+Replace the synchronous `POST /chat` trigger with the scenario pattern.
+
+- **New reactor** `createSpawnAgentReactor(): SpawnAgentReactorHandle` in
+  `src/server/event-sourcing/pipelines/langy-processing/reactors/spawnAgent.reactor.ts`,
+  a direct analog of `createScenarioExecutionReactor`. It exposes
+  `{ reactor, setPool }`, runs `runIn: ["worker"]`, reacts only to
+  `agent_turn_started` (an `isAgentTurnStartedEvent` type guard, mirroring
+  `isSimulationRunQueuedEvent`), skips when the pool is unwired or the turn was
+  already cancelled/superseded on the fold, and `pool.submit(...)`s a job
+  carrying `{ tenantId(projectId), conversationId, turnId, prompt, system,
+  modelOverride, actorUserId }`. Fire-and-forget: it does **not** await the
+  turn, so the GroupQueue keeps draining later events for the same aggregate.
+
+- **New pool** `LangyWorkerPool` in
+  `src/server/services/langy/execution/langy-worker-pool.ts`, a direct analog of
+  `ScenarioExecutionPool`: `submit`, `setSpawnFunction`, `inFlightJobs`,
+  `drain`, per-turn in-flight tracking keyed by `turnId`. Concurrency here
+  bounds how many manager calls one control-plane worker makes concurrently; the
+  **hard capacity gate stays the manager's `ErrMaxWorkers` → "at-capacity"**, so
+  the pool defers real capacity to the pod and mainly provides in-flight
+  tracking, drain, and reconcile hooks. (The pod-side spawner is PR1's
+  `adapters/workerpool`; the TS pool never spawns opencode itself.)
+
+- **The spawn function** (wired in a new `langy-turn.processor.ts`, analog of
+  `startScenarioProcessor`) does what the old route inline-did, minus holding a
+  browser socket:
+  1. `LangyCredentialService.getOrProvision({ projectId, actorUserId })`.
+  2. `POST {OPENCODE_AGENT_URL}/chat` with the internal Bearer secret (the
+     manager endpoint is unchanged; the *caller* moves from the route to the
+     pool). PR1's `adapters/workerpool` may rename this to a spawn/turn call;
+     the pool consumes whatever PR1 exposes.
+  3. Bridge the NDJSON stream into the **Redis token buffer** (part 3) instead
+     of a UI stream, reusing the existing `message.part.delta`/`field==="text"`
+     parsing from `langy.ts`.
+  4. Dispatch durable milestone commands (`RecordStatus`/`RecordProgress`) and,
+     on completion, `FinalizeTurn` carrying the full assistant answer.
+  5. Refresh the Redis heartbeat key every N seconds (part 2).
+
+- **Wiring** mirrors scenarios exactly. In `src/workers.ts` under
+  `processRole === "worker"`: construct the pool, `getLangySpawnAgentHandle()?.setPool(pool)`
+  (a `presets.ts` global accessor set from `commands.spawnAgentHandle`, exactly
+  like `__scenarioExecutionHandle`), then `startLangyTurnProcessor(pool)` and
+  push its `close()` onto `shutdownHandles`. The PR2 pipeline registers the
+  reactor with `.withReactor("langyTurnState", "spawnAgent", deps.spawnAgentReactor)`.
+
+- **The route becomes a dispatcher + reader.** `POST /api/langy/chat` keeps all
+  its auth/RBAC/rate-limit/permit logic, then `dispatch(StartAgentTurn{...})`
+  (which the fold's busy-guard rejects if a turn is already in-flight for the
+  conversation — replacing `Worker.tryClaim`'s 409) and **attaches to the token
+  stream** (part 3) rather than proxying the manager. Normal turn and refresh
+  turn now share one read path.
+
+### 2. Heartbeat + reconcile (liveness, deploy-survival, resume)
+
+- **Heartbeat is a cheap Redis liveness signal, not a durable event.** While a
+  turn runs, the spawn function `SET langy:hb:{turnId} <ts> EX <2×interval>`
+  (hash-tagged on conversationId — see part 3). A live worker refreshes it; a
+  dead pod stops, and the key expires. Authoritative liveness is the TTL, not
+  the event log. (The fold MAY cache `lastHeartbeatAt` for display only.)
+
+- **A delayed reconcile reactor** `reconcileAgentTurn.reactor.ts`
+  (`runIn:["worker"]`, `options.delay = HEARTBEAT_GRACE_MS`,
+  `makeJobId: turnId`, `ttl`) arms on `agent_turn_started` and re-arms on every
+  `status_reported`/`progress_reported` (those durable milestones double as the
+  reconcile timer's re-arm). When it fires it checks: turn still in-flight on
+  the fold **and** heartbeat key absent/stale → dispatch `ReconcileAgentTurn`.
+  A healthy turn keeps emitting milestones that re-arm the timer; a stalled turn
+  stops emitting, the last-armed timer fires past the grace window, and
+  reconcile runs.
+
+- **A startup + periodic sweep** `reconcileLangyTurns` (analog of
+  `reconcileOrphanedQueuedRuns`, run on worker boot and on an interval) scans
+  the fold for in-flight turns whose heartbeat is missing/stale and dispatches
+  `ReconcileAgentTurn`. This is the **deploy-survival backstop**: when a pod is
+  replaced, its per-turn timers are lost, but the next sweep on any worker
+  catches the orphaned turn. Replay does not re-fire this (ADR-030 `isReplay`
+  short-circuits customer-visible side effects); the sweep, not replay, drives
+  recovery.
+
+- **`ReconcileAgentTurn` applies a policy** (in PR2's command; PR3 supplies the
+  behaviour it should encode):
+  - **resume** — first check whether a `turn_finalized` arrived or the manager
+    still owns a live worker for the conversation (`mgr.Status`/session probe);
+    if so, reattach/no-op rather than respawn. Prevents duplicate side effects.
+  - **retry** (`attempts < N` **and** the turn recorded no side-effecting
+    progress, e.g. no `progress_reported: pr_opened`) → emit
+    `agent_turn_failed(reason: "stalled")` for the current attempt, then
+    `StartAgentTurn` with `attempts+1`. The fresh `agent_turn_started` re-drives
+    the spawn reactor.
+  - **give-up** (`attempts ≥ N`) → `agent_turn_failed(reason: "exhausted")`,
+    terminal, surfaced to the user.
+  - **fail-fast** (worker signalled a hard, non-retryable error — NDJSON `error`
+    event, manager 4xx) → `agent_turn_failed(reason: "error", detail)`,
+    terminal.
+
+  Retry-safety is gated on turn idempotency, which Langy does **not** have today
+  (a re-driven turn could open a second PR). Until an idempotency key exists on
+  the manager side, a turn that made side-effecting progress is **not** retried
+  — it gives up and surfaces. This is the same hazard the current route documents
+  and refuses to auto-retry; reconcile inherits that conservatism.
+
+### 3. Streaming + refresh-resume (persistence split)
+
+Persistence is split by durability class — this is a firm decision, not an
+option:
+
+- **Tokens live only in a short-lived Redis buffer**, keyed per `(conversation,
+  turn)`, **never in the event log.** A Redis **Stream** at
+  `langy:stream:{{conversationId}}:{turnId}` (hash-tag on conversationId so the
+  stream, heartbeat, and any pub/sub for a conversation share a cluster slot —
+  ADR-006). The spawn function `XADD`s a chunk every ~50–100 tokens with
+  `MAXLEN ~ N` trimming; TTL 2–5 min via `EXPIRE` refreshed on each append; a
+  terminal `{type:"end"}` entry marks completion.
+
+- **`status_reported` / `progress_reported` ARE durable events** — the milestone
+  skeleton (tool started, PR opened, "searching traces…") survives forever on
+  the aggregate.
+
+- **`turn_finalized` carries the whole final answer** as a durable event; it is
+  the source of truth for a finished turn (and what `persistMessage` used to
+  write becomes a projection of it).
+
+- **Refresh-resume** (one read path for both normal and reconnecting clients):
+  1. Read the latest turn's state from the fold.
+  2. **Finished** (`turn_finalized` present) → return the final answer from the
+     event. No Redis needed. Idempotent.
+  3. **In-flight** → `XRANGE langy:stream:{turn} - +` to replay the buffered
+     tail, then `XREAD BLOCK` from the last-seen id to stream the live edge
+     until the terminal marker. **One primitive** (Redis Streams) gives gap-free
+     replay + live attach; capturing the last-id between replay and block read
+     closes the pub/sub race where a chunk emitted in the gap is lost.
+  4. **In-flight but the Redis buffer aged out** (long turn past TTL, or pod died
+     and buffer expired) → the durable `status_reported`/`progress_reported`
+     milestones ARE the resumable state; render those and show "still
+     working — reconnect shortly", while reconcile (part 2) decides retry vs
+     give-up. Tokens are best-effort; milestones are the guarantee.
+
+### 4. Dogfood / self-observability (internal project tee)
+
+Tee Langy's own activity to a single internal LangWatch project so the team can
+observe and improve Langy — mirroring `customertracebridge`.
+
+- **Manager-side dual-export (target).** PR1 gives the manager OTel. Point the
+  worker's `OPENCODE_OTLP_ENDPOINT` (in `buildWorkerEnv`) at a **manager-local
+  OTLP receiver** instead of straight at the user's project. The manager fans
+  each span to **two** exporters, exactly like `routerExporter`: (a) the user's
+  project (as today — this behaviour must not regress), and (b) a **static
+  internal-project exporter** configured from new env
+  `LANGY_INTERNAL_OTLP_ENDPOINT` + `LANGY_INTERNAL_OTLP_HEADERS` (the internal
+  project's ingest key). When the internal env is unset (self-hosted, or the tee
+  is disabled), no tee happens — behaviour is exactly today's single export. The
+  manager's own PR1 spans (spawn, turn lifecycle, heartbeat, reconcile, egress —
+  part 5) also go to the internal project, giving the "how does Langy-the-system
+  behave" view.
+
+- **Content governance (decision required — flagged).** Teeing a user's actual
+  conversation content (`gen_ai.input/output.messages`) into LangWatch's own
+  project is a data-governance step. Default posture in this ADR: the internal
+  tee **strips message-content attributes** and keeps structural/behavioural
+  signal (span shape, tool names, model, token counts, latency, status, egress),
+  so the team gets Langy-behaviour observability without ingesting customer
+  conversation bodies. Full-content teeing, if wanted, must be a separate,
+  explicit, consented switch. `dropFilterExporter` is the precedent for
+  "started/ended in-process but attribute-filtered before export."
+
+- **Cheaper v1 fallback (if the manager-local receiver is deferred):** keep
+  opencode → user project unchanged and tee **only the manager's own PR1 spans**
+  to the internal project. That yields spawn/stall/egress observability
+  immediately with no OTLP receiver in the manager, but the internal project
+  does not see gen-AI/tool spans. Recommended only as a stepping stone.
+
+### 5. Egress monitoring (F2a, monitor-only)
+
+Instrument PR1's `adapters/egress` seam — the single `http.RoundTripper` every
+worker outbound call passes through.
+
+- For each outbound call emit a **span** `langy.egress` and **metrics**
+  (`langy_egress_requests_total`, `langy_egress_bytes`) with attributes:
+  destination host/port, bytes up/down, TLS state (version + SNI, or "plaintext"
+  if no TLS), and which worker/conversation (UID → conversationId).
+- A **scorer flags** suspicious shapes and sets `langy.egress.flagged=true` +
+  `langy.egress.flag_reason`, grounded in ADR-033's threat model and
+  `charts/langy-agent/templates/networkpolicy.yaml`: egress to a non-allowlisted
+  host, plaintext HTTP to an external destination, a call toward the private
+  ranges the NetworkPolicy denies (`10/8`, `172.16/12`, `192.168/16`) or the
+  cloud metadata IP (`169.254.169.254`), exfil-shaped large uploads, and
+  high fan-out to many distinct hosts in one turn.
+- **Flag only — never block.** These spans/metrics go to the internal project
+  (part 4). Enforcement (dropping/killing on a flag) is **PR4**; PR3 observes so
+  PR4 has ground truth to tune thresholds against before it starts blocking.
+
+## Rationale / Trade-offs
+
+- **Reuse over reinvention.** Every moving part is an established pattern: the
+  reactor+pool+drain+reconcile machinery is lifted from scenarios; the
+  dual-export is lifted from the gateway. This keeps PR3 small and legible and
+  means the on-call model, the ADR-030 replay semantics, and the GroupQueue
+  routing already apply.
+- **Durability class drives storage.** Tokens are high-volume, low-value-at-rest,
+  and only interesting live — Redis with a TTL is right; putting them on the
+  immutable event log would bloat it for no replay value. Milestones and the
+  final answer are low-volume and valuable forever — events are right. The split
+  is the whole point of part 3.
+- **Liveness without event-log pollution.** A per-second heartbeat as events
+  would flood the log; as a Redis TTL key it is invisible to replay and self-
+  cleaning. The durable milestones re-arm the reconcile timer, so we get precise
+  liveness without a dedicated heartbeat event stream.
+- **Conservative retry.** Because Langy turns are not idempotent, blind retry
+  could double-open PRs. Reconcile retries only turns with no side-effecting
+  progress and otherwise surfaces — accepting "occasionally a stalled turn ends
+  as a user-visible failure" over "occasionally we open two PRs." Making turns
+  idempotent (a manager-side idempotency key) is the follow-up that lifts this.
+- **Observe before enforce.** Egress is flag-only in PR3 so PR4's enforcement is
+  tuned against real traffic, not guesses — a compromised-worker false-positive
+  that kills a legitimate `npm install` is worse than a one-PR observation delay.
+- **Cost of the internal tee.** Dual-export doubles OTLP volume for Langy spans
+  and ingests into an internal project we pay to store. Stripping content
+  (part 4) and sampling the internal exporter bound that. Accepted for the
+  ability to actually improve Langy.
+
+## Consequences
+
+- `POST /api/langy/chat` stops proxying the manager; it dispatches
+  `StartAgentTurn` and reads the token stream. The 120 s held-open request and
+  `isAgentHealthy` preflight are retired in favour of async spawn + reconcile.
+  The GitHub-PR permit lifecycle (`reserveLangyGithubPrPermit` …
+  `recordExtraLangyGithubPrs`), today tightly coupled to the stream executor's
+  `finally`, must move to command-dispatch + a `turn_finalized` reactor — called
+  out as a migration risk in the plan.
+- `src/workers.ts` gains a Langy block mirroring the scenario block (pool +
+  processor + `setPool` + shutdown handle). `presets.ts` gains a
+  `getLangySpawnAgentHandle()` accessor. The PR2 pipeline gains two reactors and
+  the reconcile command.
+- The manager (`services/langy-agent/`) gains a local OTLP receiver + fan-out
+  exporter (or, in the fallback, just its own PR1 spans exported to the internal
+  project), reads `LANGY_INTERNAL_OTLP_*`, and instruments `adapters/egress`.
+  `buildWorkerEnv`'s `OPENCODE_OTLP_ENDPOINT` retargets to the manager-local
+  receiver under the target design.
+- New env: `LANGY_INTERNAL_OTLP_ENDPOINT`, `LANGY_INTERNAL_OTLP_HEADERS` (manager
+  + `.env.example`). New Redis keyspace: `langy:stream:*`, `langy:hb:*`.
+- Deploy survival and refresh-resume both fall out of the same event-sourced
+  turn + reconcile machinery — one mechanism, two features.
+- **Hard dependency ordering:** PR3 cannot merge before PR1 (seams) and PR2
+  (aggregate). If PR1/PR2 land with different symbol names than pinned in
+  "Dependencies", update that section and the plan before implementing.
+- Enforcement of egress flags, per-user cost attribution on the internal tee,
+  and turn idempotency are explicitly **out of scope** (PR4 / follow-ups).
+
+## Dependencies (interfaces & seams consumed)
+
+**From PR2 (`langy_conversation` aggregate — `src/server/event-sourcing/pipelines/langy-processing/`):**
+
+| Symbol | Kind | PR3 use |
+|---|---|---|
+| `agent_turn_started` | event | `spawnAgent` reactor reacts; reconcile arms |
+| `status_reported`, `progress_reported` | events | durable milestones; re-arm reconcile timer; resumable skeleton |
+| `turn_finalized` | event | carries full answer; finished-turn source of truth |
+| `agent_turn_failed` | event | reconcile terminal outcomes |
+| `StartAgentTurn` | command | route dispatches; reconcile re-dispatches on retry |
+| `RecordStatus`, `RecordProgress` | commands | spawn function dispatches milestones |
+| `FinalizeTurn` | command | spawn function dispatches on completion |
+| `ReconcileAgentTurn` | command | encodes the resume/retry/give-up/fail-fast policy above |
+| `langyTurnState` fold projection | projection | in-flight/turn state read by reactors, sweep, route |
+
+**From PR1 (`services/langy-agent/`):**
+
+| Seam | PR3 use |
+|---|---|
+| Go telemetry init (`serve.go`) | manager tracer/meter the internal tee + egress spans hang on |
+| `adapters/workerpool` | pod-side opencode spawner the TS pool's spawn function calls |
+| `adapters/egress` (`http.RoundTripper` boundary) | instrumented in part 5 (spans + metrics + flag scorer) |
+
+**Consumed unchanged from `main`:** `ScenarioExecutionPool` / `createScenarioExecutionReactor`
+/ `startScenarioProcessor` / `src/workers.ts` wiring (pattern to copy);
+`LangyCredentialService.getOrProvision`; `customertracebridge` (`Emitter`,
+`Registry`, `routerExporter`, `dropFilterExporter`, `AITraceEmitter`,
+`SetFromBundle`, `normalizeEndpoint` — pattern to copy for the manager tee);
+`handler.go::handleChat` + `buildWorkerEnv` + `ErrMaxWorkers`; reactor framework
+`ReactorOptions { delay, ttl, makeJobId, runIn }` + `ReactorContext.isReplay`.
+
+## References
+
+- Specs: `specs/langy/langy-event-driven-turns.feature`,
+  `specs/langy/langy-self-observability.feature`
+- Plan: `specs/langy/langy-pr3-plan.md`
+- Related ADRs: 033 (langy worker network isolation — threat model),
+  002 / 007 (event sourcing), 006 (Redis cluster hash tags), 023 / 025
+  (orphan-sweep reactor chain — reconcile precedent), 030 (replay short-circuit
+  of side effects), 017 (gateway trace payload capture), 039 (outbox heartbeat)
+- Reference code: `src/server/event-sourcing/pipelines/simulation-processing/reactors/scenarioExecution.reactor.ts`,
+  `src/server/scenarios/execution/execution-pool.ts`,
+  `src/server/scenarios/scenario.processor.ts`, `src/workers.ts`,
+  `src/server/routes/langy.ts`, `src/server/services/langy/LangyCredentialService.ts`,
+  `services/aigateway/adapters/customertracebridge/`,
+  `services/langy-agent/worker.go` (`buildWorkerEnv`), `services/langy-agent/handler.go`,
+  `charts/langy-agent/templates/networkpolicy.yaml`

--- a/dev/docs/adr/044-langy-event-driven-turns.md
+++ b/dev/docs/adr/044-langy-event-driven-turns.md
@@ -1,4 +1,4 @@
-# ADR-043: Event-driven Langy turns — worker spawn, liveness reconcile, stream persistence split, self-observability
+# ADR-044: Event-driven Langy turns — worker spawn, liveness reconcile, stream persistence split, self-observability
 
 **Date:** 2026-07-10
 

--- a/specs/langy/langy-event-driven-turns.feature
+++ b/specs/langy/langy-event-driven-turns.feature
@@ -4,7 +4,7 @@ Feature: Langy turns are event-driven, survive deploys, and resume on refresh
   I want my turn to keep running when I refresh or when a deploy happens
   So that I never lose an answer to a dropped connection or a stalled worker
 
-  # Design: dev/docs/adr/043-langy-event-driven-turns.md
+  # Design: dev/docs/adr/044-langy-event-driven-turns.md
   # Blocked on PR1 (langy-agent telemetry + adapters/workerpool + adapters/egress)
   # and PR2 (langy_conversation aggregate: agent_turn_started, status_reported,
   # progress_reported, turn_finalized, agent_turn_failed; StartAgentTurn,

--- a/specs/langy/langy-event-driven-turns.feature
+++ b/specs/langy/langy-event-driven-turns.feature
@@ -1,0 +1,133 @@
+@unimplemented
+Feature: Langy turns are event-driven, survive deploys, and resume on refresh
+  As a LangWatch user chatting with Langy
+  I want my turn to keep running when I refresh or when a deploy happens
+  So that I never lose an answer to a dropped connection or a stalled worker
+
+  # Design: dev/docs/adr/043-langy-event-driven-turns.md
+  # Blocked on PR1 (langy-agent telemetry + adapters/workerpool + adapters/egress)
+  # and PR2 (langy_conversation aggregate: agent_turn_started, status_reported,
+  # progress_reported, turn_finalized, agent_turn_failed; StartAgentTurn,
+  # RecordStatus, RecordProgress, FinalizeTurn, ReconcileAgentTurn).
+  #
+  # This replaces the synchronous POST /chat proxy in src/server/routes/langy.ts
+  # with the scenario execution pattern (scenarioExecution.reactor -> execution-pool,
+  # wired via setPool() in src/workers.ts). Tokens live in a short-lived Redis
+  # buffer; milestones and the final answer are durable events.
+
+  Background:
+    Given I am authenticated with permission to use Langy in my project
+    And the Langy worker backend is available
+
+  # ===========================================================================
+  # Event-driven spawn (replaces the synchronous POST /chat trigger)
+  # ===========================================================================
+
+  Scenario: Sending a message starts a turn without holding the request on the worker
+    When I send a message to Langy
+    Then a turn is started for my conversation
+    And the worker is spawned by reacting to the turn-started event, not by a direct proxy call
+    And I begin receiving tokens as the worker produces them
+
+  Scenario: A second message while a turn is in flight is rejected as busy
+    Given a turn is already in flight for my conversation
+    When I send another message in the same conversation
+    Then the request is rejected as conversation-busy
+    And the in-flight turn is left untouched
+
+  Scenario: When the worker backend is at capacity the turn is not silently dropped
+    Given the worker backend has no free capacity
+    When I send a message to Langy
+    Then I am told the assistant is at capacity
+    And no turn is left stuck without a terminal state
+
+  # ===========================================================================
+  # Streaming persistence split (tokens in Redis, milestones + answer as events)
+  # ===========================================================================
+
+  Scenario: Tokens stream from the worker to my browser
+    When Langy is generating a response
+    Then I see tokens render as they arrive
+
+  Scenario: Durable milestones are recorded as events, not as tokens
+    When Langy searches traces and then opens a pull request during a turn
+    Then the "searching traces" milestone is recorded durably on the conversation
+    And the "pull request opened" milestone is recorded durably on the conversation
+    And the raw token deltas are not written to the durable event log
+
+  Scenario: The final answer is recorded durably when the turn completes
+    When a turn completes
+    Then the whole final answer is recorded as a durable turn-finalized event
+    And reloading the conversation later shows that answer without any live worker
+
+  # ===========================================================================
+  # Refresh-resume mid-stream
+  # ===========================================================================
+
+  Scenario: Refreshing mid-stream replays what I missed and reattaches to the live edge
+    Given Langy is part way through generating a response
+    When I refresh the page and reopen the conversation
+    Then I see the tokens produced so far
+    And I then see the remaining tokens stream in live
+    And the answer is complete when the turn finishes
+
+  Scenario: Reopening a finished turn shows the answer from durable state
+    Given a turn finished while I was away
+    When I reopen the conversation
+    Then I see the complete final answer
+    And no worker is spawned to reproduce it
+
+  Scenario: Reopening a long turn whose token buffer expired falls back to milestones
+    Given a turn is still in flight but its live token buffer has expired
+    When I reopen the conversation
+    Then I see the durable milestones recorded so far
+    And I am told the turn is still working and to reconnect shortly
+
+  # ===========================================================================
+  # Liveness: heartbeat + reconcile
+  # ===========================================================================
+
+  Scenario: A healthy turn keeps its liveness signal fresh
+    Given a turn is in flight and progressing
+    Then its liveness signal is refreshed while it runs
+    And no reconciliation is triggered for it
+
+  Scenario: A stalled turn is reconciled and retried
+    Given a turn is in flight and made no side-effecting progress
+    When the worker stops signalling liveness past the grace window
+    Then the stalled turn is reconciled
+    And a fresh attempt is started for the same conversation
+
+  Scenario: A turn that exhausted its retries fails terminally
+    Given a turn has already been retried the maximum number of times
+    When it stalls again
+    Then the turn fails with an exhausted reason
+    And the failure is surfaced to me rather than retried forever
+
+  Scenario: A turn that hit a hard error fails fast without retry
+    Given a turn's worker reports a hard, non-retryable error
+    When the turn is reconciled
+    Then it fails fast with an error reason
+    And it is not retried
+
+  Scenario: A stalled turn that already opened a pull request is not blindly retried
+    Given a turn stalled after it had already opened a pull request
+    When the turn is reconciled
+    Then it is not automatically retried
+    And the outcome is surfaced to me instead of risking a duplicate pull request
+
+  # ===========================================================================
+  # Deploy survival (same machinery as refresh-resume)
+  # ===========================================================================
+
+  Scenario: A turn interrupted by a deploy is recovered by a surviving worker
+    Given a turn is in flight when its worker pod is replaced during a deploy
+    When another worker sweeps for turns with no live liveness signal
+    Then the interrupted turn is reconciled
+    And it reaches a terminal state instead of hanging forever
+
+  Scenario: Recovery is driven by the liveness sweep, not by event replay
+    Given a control-plane worker restarts and replays the conversation log
+    When it encounters an in-flight turn during replay
+    Then it does not re-spawn a worker from the replay itself
+    And recovery is left to the liveness sweep so no side effect fires twice

--- a/specs/langy/langy-pr3-plan.md
+++ b/specs/langy/langy-pr3-plan.md
@@ -1,6 +1,6 @@
 # Langy PR3 — event-driven worker + streaming + self-observability — implementation plan
 
-> **ADR:** `dev/docs/adr/043-langy-event-driven-turns.md`
+> **ADR:** `dev/docs/adr/044-langy-event-driven-turns.md`
 > **Specs:** `specs/langy/langy-event-driven-turns.feature`,
 > `specs/langy/langy-self-observability.feature`
 > **Branch:** `design/langy-pr3` (this PR ships docs only)

--- a/specs/langy/langy-pr3-plan.md
+++ b/specs/langy/langy-pr3-plan.md
@@ -1,0 +1,300 @@
+# Langy PR3 — event-driven worker + streaming + self-observability — implementation plan
+
+> **ADR:** `dev/docs/adr/043-langy-event-driven-turns.md`
+> **Specs:** `specs/langy/langy-event-driven-turns.feature`,
+> `specs/langy/langy-self-observability.feature`
+> **Branch:** `design/langy-pr3` (this PR ships docs only)
+> **Blocked on:** PR1 (langy-agent Go telemetry + `adapters/workerpool` +
+> `adapters/egress`) and PR2 (`langy_conversation` aggregate + events +
+> commands). Do not start coding until both merge; then implement in the order
+> below.
+
+This plan is deliberately concrete: it names the real symbols PR3 copies from
+and the exact seams it consumes, so the fast-follow is mechanical.
+
+## The pattern being copied (read these first)
+
+| Concern | Reference (scenarios/gateway) | PR3 analog (langy) |
+|---|---|---|
+| Event → spawn reactor | `createScenarioExecutionReactor()` in `src/server/event-sourcing/pipelines/simulation-processing/reactors/scenarioExecution.reactor.ts` | `createSpawnAgentReactor()` |
+| In-process pool | `ScenarioExecutionPool` in `src/server/scenarios/execution/execution-pool.ts` | `LangyWorkerPool` |
+| Spawn fn + processor | `startScenarioProcessor()` in `src/server/scenarios/scenario.processor.ts` | `startLangyTurnProcessor()` |
+| Worker wiring | `src/workers.ts` scenario block (`setPool` + `startScenarioProcessor` + shutdown handle) | langy block |
+| Global handle accessor | `getScenarioExecutionHandle()` in `src/server/app-layer/presets.ts` (`__scenarioExecutionHandle`) | `getLangySpawnAgentHandle()` (`__langySpawnAgentHandle`) |
+| Pipeline registration | `.withReactor("simulationRunState", "scenarioExecution", …)` in `simulation-processing/pipeline.ts` | `.withReactor("langyTurnState", "spawnAgent", …)` (PR2 pipeline) |
+| Startup reconciler | `reconcileOrphanedQueuedRuns()` + `ORPHAN_QUEUED_THRESHOLD_MS` in `scenario-orphan-reconciler.ts` | `reconcileLangyTurns()` |
+| Drain-on-shutdown | `drainInFlightRuns()` + `pool.inFlightJobs` | same shape |
+| Delayed dedup reactor | `ReactorOptions { delay, ttl, makeJobId }` (`reactor.types.ts`) | `reconcileAgentTurn` reactor |
+| Dual OTLP export | `services/aigateway/adapters/customertracebridge/` (`Emitter`, `routerExporter`, `dropFilterExporter`, `AITraceEmitter`, `normalizeEndpoint`) | manager-side `langytracebridge` |
+
+## Consumed from PR1 / PR2 (do not build these here)
+
+- **PR2 events:** `agent_turn_started`, `status_reported`, `progress_reported`,
+  `turn_finalized`, `agent_turn_failed`. **PR2 commands:** `StartAgentTurn`,
+  `RecordStatus`, `RecordProgress`, `FinalizeTurn`, `ReconcileAgentTurn`.
+  **PR2 fold:** `langyTurnState` (in-flight flag, attempts, latest turnId,
+  optional `lastHeartbeatAt` display cache). **PR2 pipeline dir:**
+  `src/server/event-sourcing/pipelines/langy-processing/`.
+- **PR1 seams:** manager OTel init in `services/langy-agent/serve.go`;
+  `services/langy-agent/adapters/workerpool` (opencode spawner);
+  `services/langy-agent/adapters/egress` (one `http.RoundTripper` all worker
+  outbound calls pass through).
+
+If any name differs when PR1/PR2 land, reconcile the ADR "Dependencies" table
+and this section first, then implement.
+
+## Build order
+
+### Step 0 — regenerate + branch
+`pnpm start:prepare:files` in `langwatch/`. Branch `feat/langy-pr3-event-driven`
+off the merged PR2 head.
+
+### Step 1 — Redis token buffer module (foundation, no PR2/PR1 needed to unit-test)
+New `src/server/services/langy/streaming/langyTokenBuffer.ts`.
+
+- **Key shape (hash-tagged on conversationId so buffer + heartbeat + pub/sub
+  colocate on one cluster slot — ADR-006):**
+  - stream: `langy:stream:{<conversationId>}:<turnId>`
+  - heartbeat: `langy:hb:{<conversationId>}:<turnId>`
+- **Backing structure:** Redis **Stream** (`XADD`/`XRANGE`/`XREAD BLOCK`) — one
+  primitive gives ordered ids + gap-free replay + live blocking read, so a chunk
+  emitted between "replay tail" and "attach live" is never lost (the pub/sub
+  race). Do **not** use pub/sub for the live edge.
+- **Writer API:**
+  - `appendChunk({ conversationId, turnId, text })` — buffers deltas, flushes an
+    `XADD * type delta text <joined>` every ~50–100 tokens; `XADD … MAXLEN ~ 2000`
+    to bound length; `EXPIRE <key> 300` (2–5 min) refreshed on each flush.
+  - `markEnd({ conversationId, turnId })` — `XADD * type end`.
+  - `heartbeat({ conversationId, turnId })` — `SET langy:hb:{…} <now> EX <2×interval>`.
+- **Reader API:**
+  - `readTail({ conversationId, turnId })` → `XRANGE key - +`, returns entries +
+    the last id.
+  - `follow({ conversationId, turnId, fromId })` → async iterator over
+    `XREAD BLOCK <n> STREAMS key <fromId>`, ends on the `type=end` entry.
+  - `liveness({ conversationId, turnId })` → `EXISTS`/`GET` on the hb key +
+    freshness check.
+- **Config:** `CHUNK_TOKENS=64`, `STREAM_TTL_MS=180_000`,
+  `HEARTBEAT_INTERVAL_MS=5_000`, `HEARTBEAT_GRACE_MS=30_000` in a
+  `langy.streaming.constants.ts` (mirrors `scenario.constants.ts`).
+- **Tests:** `langyTokenBuffer.unit.test.ts` against a Redis mock / testcontainer
+  — append→readTail→follow ordering, MAXLEN trim, TTL set, end marker,
+  heartbeat set/expire. Verifies the resume race is closed (append during the
+  replay→follow gap is still delivered).
+
+### Step 2 — `LangyWorkerPool` (copy `ScenarioExecutionPool`)
+New `src/server/services/langy/execution/langy-worker-pool.ts`.
+
+- Job shape `LangyTurnJobData { projectId, conversationId, turnId, prompt,
+  system, modelOverride?, actorUserId }` (analog of `ExecutionJobData`).
+- Same members: `submit`, `setSpawnFunction`, per-turn in-flight map keyed by
+  `turnId`, `inFlightJobs`, `drain`, `activeCount`/`pendingCount`. Concurrency
+  from `LANGY_WORKER.CONCURRENCY`.
+- Difference from scenarios: the pool does **not** spawn a child process; its
+  `SpawnFunction` calls the Go manager (step 3). Hard capacity stays the
+  manager's `ErrMaxWorkers`; the pool's concurrency only bounds concurrent
+  manager calls per control-plane worker. Keep `inFlightJobs` so `drain` can
+  emit a terminal `agent_turn_failed` for anything mid-flight on shutdown
+  (mirror `drainInFlightRuns`).
+- **Tests:** `langy-worker-pool.unit.test.ts` — buffering at capacity, dequeue on
+  completion, drain emits terminal failures, in-flight tracking covers the
+  pre-registration window.
+
+### Step 3 — turn processor + spawn function (copy `startScenarioProcessor`)
+New `src/server/services/langy/execution/langy-turn.processor.ts`.
+
+- `startLangyTurnProcessor(pool)`:
+  1. `pool.setSpawnFunction(async (job) => runTurn(job, deps))`.
+  2. Start the reconcile sweep (step 5) on boot + interval.
+  3. Return `{ close }` that runs `drainInFlightRuns`-equivalent then clears the
+     interval. Push onto `shutdownHandles` in `workers.ts`.
+- `runTurn(job, deps)` — the spawn function; what `langy.ts`'s stream executor
+  did, minus the browser socket:
+  1. `LangyCredentialService.getOrProvision({ projectId, actorUserId })`
+     (reuse verbatim — includes GitHub token mint + VK).
+  2. `POST {OPENCODE_AGENT_URL}/chat` with `Authorization: Bearer <LANGY_INTERNAL_SECRET>`
+     and body `{ conversationId, prompt, system, credentials, modelOverride }`
+     (unchanged wire shape from `handler.go::chatRequest`; if PR1's
+     `adapters/workerpool` exposes a spawn/turn endpoint, call that instead).
+  3. Bridge NDJSON exactly as `langy.ts` does today (`message.part.delta` with
+     `properties.field==="text"`, legacy `text` shape) — but sink deltas into
+     `langyTokenBuffer.appendChunk` instead of `writer.write`.
+  4. `heartbeat()` on a `HEARTBEAT_INTERVAL_MS` timer for the turn's life.
+  5. Dispatch `RecordStatus`/`RecordProgress` on the agent's progress sentinels
+     (`[langy:progress:*]`, reuse `githubProgressEvents.ts` / `langySentinels.ts`).
+  6. On completion: `dispatch(FinalizeTurn{ conversationId, turnId, answer:
+     stripLangySentinels(fullText) })`, then `markEnd()`.
+  7. On manager error / NDJSON `error` event / transport failure: dispatch
+     `agent_turn_failed(reason:"error", detail)`, `markEnd()`.
+- **GitHub-PR permit migration (highest-risk item — call out in the PR).** Today
+  the permit lifecycle (`reserveLangyGithubPrPermit` → strip `githubToken` when
+  over-cap → `recordExtraLangyGithubPrs` reconcile in the executor `finally`) is
+  bound to the synchronous stream. Move it to: **reserve at command dispatch**
+  (route, step 4) so the cap still gates `githubToken` before the worker spawns;
+  **reconcile + release on `turn_finalized`** via a small reactor
+  (`langyPrPermitReconcile.reactor.ts`) that reads `progress_reported: pr_opened`
+  count and calls `recordExtraLangyGithubPrs` / release. Preserve the exact
+  release-only-if-`permit.reserved` and latch semantics from `langy.ts` (the
+  erosion-via-blip bug). This is the one place a naive port re-introduces a
+  known cap-bypass — port the comments too.
+- **Tests:** `langy-turn.processor.integration.test.ts` — mock manager NDJSON,
+  assert buffer appends, milestone dispatches, `FinalizeTurn` with stripped text,
+  heartbeat refresh, error path dispatches `agent_turn_failed`.
+
+### Step 4 — spawnAgent reactor + route becomes dispatcher/reader
+New `src/server/event-sourcing/pipelines/langy-processing/reactors/spawnAgent.reactor.ts`
+(copy `scenarioExecution.reactor.ts` line-for-line structure):
+
+```
+createSpawnAgentReactor(): { reactor, setPool }
+  reactor.options = { runIn: ["worker"] }
+  handle(event, ctx):
+    if (!isAgentTurnStartedEvent(event)) return
+    if (!pool) { warn; return }
+    if (ctx.foldState.cancelledAt || ctx.foldState.supersededTurnId) return
+    pool.submit({ projectId: String(event.tenantId), conversationId,
+                  turnId, prompt, system, modelOverride, actorUserId })
+```
+
+`presets.ts`: add `getLangySpawnAgentHandle()` reading
+`(globalForApp).__langySpawnAgentHandle`, set from `commands.spawnAgentHandle`
+in the pipeline construction block (mirror the two `__scenarioExecutionHandle`
+sites).
+
+`src/server/routes/langy.ts` — `POST /langy/chat` rewrite:
+- Keep everything up to and including credential/model-allowlist checks, rate
+  limit, RBAC loop, `persistMessage(user)`, and permit **reserve**.
+- Replace the `fetch(agentUrl/chat)` + `createUIMessageStream` executor with:
+  1. `dispatch(StartAgentTurn{ projectId, conversationId, prompt: userText,
+     system, modelOverride, actorUserId, permit })`. The fold busy-guard returns
+     "already in flight" → respond 409 conversation-busy (replaces
+     `Worker.tryClaim`).
+  2. Build the response stream by attaching to `langyTokenBuffer`: read fold
+     turn state → if finished, emit `turn_finalized.answer`; else
+     `readTail` then `follow` until end. Keep the `x-langy-conversation-id`
+     header and the `createUIMessageStream` envelope so the client is unchanged.
+- New `GET /langy/conversations/:id/stream?turnId=` (or fold the attach into the
+  existing GET) so a refreshed client reattaches without POSTing a new message.
+- **Tests:** extend `langy-route-auth.test.ts` / `langy-chat-rbac.unit.test.ts`;
+  new `langy-chat-resume.integration.test.ts` (POST starts a turn + streams;
+  second client attaches mid-turn and sees tail + live edge; finished turn
+  serves from `turn_finalized`).
+
+### Step 5 — reconcile (delayed reactor + sweep)
+New `reconcileAgentTurn.reactor.ts` in the PR2 reactors dir:
+- `options = { runIn:["worker"], delay: HEARTBEAT_GRACE_MS,
+  makeJobId: ({event}) => turnId, ttl: HEARTBEAT_GRACE_MS*2 }`.
+- Arms on `agent_turn_started`; re-arms on `status_reported`/`progress_reported`
+  (shouldReact returns true for those three, false otherwise).
+- `handle`: if turn still in-flight on the fold AND `langyTokenBuffer.liveness`
+  stale/absent → `dispatch(ReconcileAgentTurn{ conversationId, turnId })`.
+- Register with `.withReactor("langyTurnState", "reconcileAgentTurn", …)` (PR2
+  pipeline).
+
+New `src/server/services/langy/execution/langy-turn-reconciler.ts` (copy
+`scenario-orphan-reconciler.ts`):
+- `reconcileLangyTurns({ findInFlight, checkLiveness, dispatchReconcile, now,
+  thresholdMs })` — scan fold for in-flight turns with stale/absent heartbeat,
+  dispatch `ReconcileAgentTurn`. Run at processor boot + on a `setInterval`
+  (cap the interval well under the 5-min Redis TTL; e.g. 20 s).
+- `ReconcileAgentTurn`'s policy lives in PR2's command; PR3's reconciler just
+  detects and dispatches. Policy (encode in PR2, asserted by PR3 specs): resume
+  (finalized/live worker) → retry (`attempts<N` && no side-effecting progress) →
+  give-up (`attempts>=N`) → fail-fast (hard error).
+- **Tests:** `langy-turn-reconciler.integration.test.ts` — stalled turn with no
+  progress retries; exhausted turn gives up; turn with `pr_opened` progress is
+  not retried; deploy case (heartbeat expired, no live timer) is caught by the
+  sweep.
+
+### Step 6 — worker wiring
+`src/workers.ts`, add under `processRole === "worker"` (copy the scenario block
+verbatim in structure):
+```
+const { LangyWorkerPool } = await import("./server/services/langy/execution/langy-worker-pool");
+const { startLangyTurnProcessor } = await import("./server/services/langy/execution/langy-turn.processor");
+const langyPool = new LangyWorkerPool({ concurrency: LANGY_WORKER.CONCURRENCY });
+getLangySpawnAgentHandle()?.setPool(langyPool);
+const langyProcessor = await startLangyTurnProcessor(langyPool);
+if (langyProcessor) shutdownHandles.push(() => langyProcessor.close());
+```
+Web process gets no pool (worker-only, per the outbox worker-only rule).
+
+### Step 7 — manager dual-export (self-observability, part 4) [Go]
+New `services/langy-agent/langytracebridge/` (copy `customertracebridge`):
+- A private `TracerProvider` (empty resource, `AlwaysSample`) whose exporter
+  fans each span to **two** sinks: the user's project (per-span
+  `langwatch.project_id` → `routerExporter`, as the worker does today) and a
+  **static internal exporter** built from `LANGY_INTERNAL_OTLP_ENDPOINT` +
+  `LANGY_INTERNAL_OTLP_HEADERS`. Reuse `normalizeEndpoint` (appends
+  `/v1/traces`).
+- Retarget `buildWorkerEnv`'s `OPENCODE_OTLP_ENDPOINT` at a manager-local OTLP
+  receiver so opencode spans flow through the manager (which then dual-exports).
+  Keep the user-project export byte-identical to today.
+- **Content strip on the internal sink:** a `dropContentExporter` (analog of
+  `dropFilterExporter`) that strips `gen_ai.input.messages` /
+  `gen_ai.output.messages` before the internal export. Default on.
+- Manager's own PR1 spans (spawn, turn lifecycle, reconcile) already flow to the
+  internal exporter since they originate on the manager tracer.
+- **Fallback if the local receiver is deferred:** skip the opencode retarget;
+  export only manager PR1 spans to the internal project. Ship as a stepping
+  stone, follow up with the receiver.
+- **Tests:** Go — `langytracebridge_test.go` (fan-out to both sinks; internal
+  sink omits message content; no internal env → single export only).
+
+### Step 8 — egress monitoring (part 5, flag-only) [Go]
+Instrument PR1's `services/langy-agent/adapters/egress` `http.RoundTripper`:
+- Per call: start span `langy.egress` (kind client) with `server.address`,
+  `server.port`, bytes up/down, `tls.protocol.version`/SNI (or a
+  `langy.egress.plaintext=true` flag), `langy.conversation.id`, worker UID.
+  Metrics `langy_egress_requests_total{host,flagged}`, `langy_egress_bytes`.
+- `scoreEgress()` sets `langy.egress.flagged=true` + `langy.egress.flag_reason`
+  for: host outside the allowed set (control plane, gateway, git/gh/registry
+  hosts), plaintext to external, destination in `10/8`/`172.16/12`/`192.168/16`
+  or `169.254.0.0/16` (metadata), large-upload/exfil shape, high distinct-host
+  fan-out per turn. Grounded in `charts/langy-agent/templates/networkpolicy.yaml`
+  + ADR-033.
+- **Never block.** Only observe + flag; spans go to the internal project.
+- **Tests:** Go — `egress_scorer_test.go` (each flag reason; allowed TLS host not
+  flagged; blocking never invoked).
+
+### Step 9 — env + chart + docs
+- `.env.example` + `langwatch/env.mjs`: `LANGY_INTERNAL_OTLP_ENDPOINT`,
+  `LANGY_INTERNAL_OTLP_HEADERS` (optional; unset = no tee). Manager config
+  (`services/langy-agent/config.go`) reads them.
+- `charts/langy-agent`: values for the internal OTLP endpoint/secret;
+  NetworkPolicy egress already permits the control-plane/gateway sinks — confirm
+  the internal OTLP endpoint is reachable (it is the control plane's ingest, so
+  the existing control-plane egress rule covers it).
+- Update `dev/docs/best_practices` only if a new streaming/resume UI pattern
+  emerges on the client; the client envelope is unchanged so likely none.
+
+## Test strategy (outside-in)
+
+1. Bind the two `.feature` files first (remove `@unimplemented` per scenario as
+   coverage lands).
+2. Integration before unit: route resume test (step 4) and reconciler test
+   (step 5) are the load-bearing ones — they prove deploy-survival + refresh.
+3. Redis-backed tests use a testcontainer (match the CI ClickHouse/Redis pin
+   discipline). Scenario/user-sim fixtures, if any, use `openai("gpt-5-mini")`.
+4. Run end-to-end locally (no `CI=1`) before opening the PR.
+
+## Risks / open questions (flag for review)
+
+- **Streaming-resume mechanism.** Chose Redis **Streams** (`XRANGE` tail +
+  `XREAD BLOCK` live) over List+pub/sub specifically to close the replay→attach
+  gap race. Confirm we're happy adding a `langy:stream:*` keyspace to the
+  cluster and the TTL/MAXLEN bounds. Alternative if Streams are unwanted:
+  List + a monotonic "last delivered index" the reader long-polls — more code,
+  same guarantee.
+- **Internal-project content.** Default strips user message/answer text from the
+  internal tee (behaviour-only observability). If the team wants full-content
+  dogfooding, that's a separate consented switch — needs a data-governance call.
+- **GitHub-PR permit migration** is the riskiest port: moving the reserve/
+  reconcile/release out of the synchronous `finally` into dispatch + a
+  `turn_finalized` reactor must preserve the `permit.reserved`-gated release and
+  the per-PR (not per-turn) reconcile, or it re-opens the documented cap-bypass.
+- **Retry idempotency.** Reconcile refuses to retry turns that made side-
+  effecting progress (no idempotency key exists yet). A manager-side idempotency
+  key is the follow-up that would let stalled-after-PR turns retry safely.
+- **Manager-local OTLP receiver** is the one genuinely new piece of Go infra
+  (steps 7). If it slips, ship the step-7 fallback (manager spans only) so the
+  self-observability value lands without blocking on the receiver.

--- a/specs/langy/langy-self-observability.feature
+++ b/specs/langy/langy-self-observability.feature
@@ -1,0 +1,92 @@
+@unimplemented
+Feature: Langy is observable to the team that builds it
+  As a member of the LangWatch team improving Langy
+  I want Langy's own activity and its workers' network egress in an internal project
+  So that I can see how Langy behaves in the wild and spot suspicious worker behaviour
+
+  # Design: dev/docs/adr/043-langy-event-driven-turns.md (parts 4 and 5)
+  # Blocked on PR1 (langy-agent manager telemetry + adapters/egress seam).
+  #
+  # Mirrors the AI gateway's dual-export (services/aigateway/adapters/
+  # customertracebridge): today the opencode OTel plugin exports gen-AI/tool
+  # spans ONLY to each user's own project (buildWorkerEnv's OPENCODE_OTLP_*),
+  # and the manager emits nothing. This tees Langy's activity to one internal
+  # LangWatch project as well, and observes every worker egress call.
+  #
+  # Egress is FLAG-ONLY here. Enforcement (blocking/killing on a flag) is PR4.
+
+  Background:
+    Given the langy-agent manager is configured with an internal observability project
+    And a user runs Langy in their own project
+
+  # ===========================================================================
+  # Self-observability: agent activity teed to the internal project
+  # ===========================================================================
+
+  Scenario: Langy activity still appears in the user's own project
+    When the user completes a Langy turn
+    Then a trace for that turn appears in the user's own project
+    And it is labelled "langy" as before
+
+  Scenario: The same Langy activity also appears in the internal project
+    When the user completes a Langy turn
+    Then a corresponding trace also appears in the internal observability project
+    And the team can see the turn's shape, tools used, model, token counts, and latency
+
+  Scenario: The internal tee does not carry the user's conversation content by default
+    When the user completes a Langy turn
+    Then the trace in the internal project omits the user's message and answer text
+    And it retains the structural and behavioural signal needed to improve Langy
+
+  Scenario: Manager lifecycle activity is visible in the internal project
+    When a turn is spawned, runs, and finishes
+    Then the internal project shows the spawn, turn lifecycle, and reconcile activity
+    And the team can measure spawn latency and stall rate across turns
+
+  Scenario: The tee is disabled cleanly when no internal project is configured
+    Given no internal observability project is configured
+    When the user completes a Langy turn
+    Then activity is exported only to the user's own project
+    And nothing is teed anywhere else
+
+  # ===========================================================================
+  # Egress monitoring (F2a — monitor and flag only, never block)
+  # ===========================================================================
+
+  Scenario: Every outbound worker call is observed
+    When a worker makes an outbound network call during a turn
+    Then the call is recorded with its destination, size, and encryption state
+    And it is attributed to the worker and its conversation
+
+  Scenario: A call to an allowed host over TLS is observed and not flagged
+    When a worker calls an allowed host over TLS
+    Then the call is recorded
+    And it is not flagged as suspicious
+
+  Scenario: A call to an unexpected host is flagged
+    When a worker makes an outbound call to a host outside the allowed set
+    Then the call is recorded and flagged as suspicious
+    And the reason identifies the unexpected destination
+    But the call is not blocked
+
+  Scenario: Plaintext egress to an external destination is flagged
+    When a worker sends data to an external destination without encryption
+    Then the call is flagged as suspicious
+    But the call is not blocked
+
+  Scenario: A call toward internal or metadata addresses is flagged
+    When a worker attempts to reach a private-range or cloud-metadata address
+    Then the call is flagged as suspicious
+    And the reason identifies it as an internal or metadata destination
+    But the call is not blocked
+
+  Scenario: An exfiltration-shaped upload is flagged
+    When a worker uploads an unusually large amount of data to an external host
+    Then the call is flagged as suspicious
+    But the call is not blocked
+
+  Scenario: Flags surface in the internal project for the team to review
+    Given a worker made a flagged egress call during a turn
+    When the team reviews Langy activity in the internal project
+    Then the flagged call is visible with its reason
+    And enforcement of the flag is left to a later change

--- a/specs/langy/langy-self-observability.feature
+++ b/specs/langy/langy-self-observability.feature
@@ -4,7 +4,7 @@ Feature: Langy is observable to the team that builds it
   I want Langy's own activity and its workers' network egress in an internal project
   So that I can see how Langy behaves in the wild and spot suspicious worker behaviour
 
-  # Design: dev/docs/adr/043-langy-event-driven-turns.md (parts 4 and 5)
+  # Design: dev/docs/adr/044-langy-event-driven-turns.md (parts 4 and 5)
   # Blocked on PR1 (langy-agent manager telemetry + adapters/egress seam).
   #
   # Mirrors the AI gateway's dual-export (services/aigateway/adapters/


### PR DESCRIPTION
## [design] Langy PR3 of 4 — event-driven worker + streaming + self-observability

**Docs only.** No implementation code. This is the spec-first artefact for PR3
(spec → test → code is required here). PR3's code is **blocked on**:

- **PR1** — langy-agent Go telemetry + `adapters/workerpool` + `adapters/egress` seam
- **PR2** — the `langy_conversation` aggregate, events, and commands

Building PR3 against `main` now would reference symbols that don't exist, so this
PR lands the ADR + Gherkin specs + implementation plan and PR3 becomes a
mechanical fast-follow the moment PR1 + PR2 merge.

### What's here
- `dev/docs/adr/044-langy-event-driven-turns.md` — ADR covering all five items,
  with an explicit **Dependencies** table pinning every interface/seam consumed
  from PR1/PR2.
- `specs/langy/langy-event-driven-turns.feature` — worker spawns off the event,
  stalled turn reconciles, refresh mid-stream resumes, deploy survival.
- `specs/langy/langy-self-observability.feature` — agent activity teed to an
  internal project; egress observed + flagged (monitor-only).
- `specs/langy/langy-pr3-plan.md` — file-by-file plan, exact reactor/pool wiring,
  Redis buffer shape, build order, tests, risks.

### Five items designed
1. **spawnAgent reactor + `LangyWorkerPool`** — mirrors
   `scenarioExecution.reactor` → `ScenarioExecutionPool`, wired via `setPool()`
   in `src/workers.ts`. Replaces the synchronous `POST /chat` proxy.
2. **Heartbeat + reconcile** — Redis-TTL heartbeat (not durable events); delayed
   reconcile reactor + startup/periodic sweep (mirrors
   `reconcileOrphanedQueuedRuns`). Policy: resume / retry / give-up / fail-fast.
   Same machinery gives deploy-survival and refresh-resume.
3. **Streaming split** — tokens live only in a short-lived Redis **Stream**
   (`XRANGE` tail + `XREAD BLOCK` live edge, gap-free resume); `status_reported`/
   `progress_reported`/`turn_finalized` are durable events.
4. **Self-observability** — manager-side dual-export mirroring
   `customertracebridge`; tees Langy activity to an internal project, content
   stripped by default.
5. **Egress monitoring (F2a)** — instrument PR1's `adapters/egress`; span +
   metrics + flag scorer grounded in ADR-033 + the NetworkPolicy. Flag only;
   enforcement is PR4.

### Decisions to weigh in on
- **Resume mechanism:** Redis Streams over List+pub/sub (closes the
  replay→attach race). OK to add a `langy:stream:*` keyspace?
- **Internal-project content:** default strips user message/answer text (behaviour
  observability only). Full-content dogfooding would need a consented switch.
- **GitHub-PR permit migration** out of the synchronous `finally` is the riskiest
  port — must preserve the `permit.reserved`-gated release + per-PR reconcile.

ADR: **044** (renumbered from 043 to deconflict with PR4's
`043-langy-egress-enforcement` ADR, which claimed 043 first).