### PR TITLE
feat(me): My Usage empty-state redesign + traceLogs teaser-window gate

### DIFF
--- a/langwatch/src/components/me/PersonalTracesEmptyState.tsx
+++ b/langwatch/src/components/me/PersonalTracesEmptyState.tsx
@@ -75,7 +75,13 @@ function OfferBody({
   );
 }
 
-const OfferCard: React.FC<Offer> = ({ icon, title, description, onClick, href }) => {
+const OfferCard: React.FC<Offer> = ({
+  icon,
+  title,
+  description,
+  onClick,
+  href,
+}) => {
   if (href) {
     return (
       <Link href={href} display="block" _hover={{ textDecoration: "none" }}>
@@ -92,7 +98,14 @@ const OfferCard: React.FC<Offer> = ({ icon, title, description, onClick, href })
   );
 };
 
-export function PersonalTracesEmptyState({
+/**
+ * The three getting-started offers on their own — a coding assistant, an
+ * ingestion key, an API key. Rendered inside the recent-activity hero
+ * (`PersonalTracesEmptyState`) and, standalone, as the "Get started" panel
+ * of the /me usage section's empty state. Shared so the two surfaces can't
+ * drift apart.
+ */
+export function PersonalGetStartedOffers({
   projectSlug,
 }: {
   projectSlug?: string | null;
@@ -123,6 +136,20 @@ export function PersonalTracesEmptyState({
   ];
 
   return (
+    <SimpleGrid columns={{ base: 1, md: 3 }} gap={3}>
+      {offers.map((offer) => (
+        <OfferCard key={offer.title} {...offer} />
+      ))}
+    </SimpleGrid>
+  );
+}
+
+export function PersonalTracesEmptyState({
+  projectSlug,
+}: {
+  projectSlug?: string | null;
+}) {
+  return (
     <IntegratePaneShell isCompact ariaLabel="Start sending your AI usage">
       <VStack align="stretch" gap={6}>
         <VStack align="start" gap={1.5}>
@@ -136,14 +163,10 @@ export function PersonalTracesEmptyState({
           </Text>
           <Text textStyle="sm" color="fg.muted" lineHeight="tall">
             Send your AI usage to LangWatch with the tools you already have set
-            up above — no SDK wiring required.
+            up above, no SDK wiring required.
           </Text>
         </VStack>
-        <SimpleGrid columns={{ base: 1, md: 3 }} gap={3}>
-          {offers.map((offer) => (
-            <OfferCard key={offer.title} {...offer} />
-          ))}
-        </SimpleGrid>
+        <PersonalGetStartedOffers projectSlug={projectSlug} />
       </VStack>
     </IntegratePaneShell>
   );

--- a/langwatch/src/pages/me/index.tsx
+++ b/langwatch/src/pages/me/index.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import Head from "~/utils/compat/next-head";
 
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
+import { ShikiCommandBox } from "~/components/code/ShikiCommandBox";
 import { Tooltip } from "~/components/ui/tooltip";
 import { formatBudgetUsd } from "~/components/gateway/formatBudgetUsd";
 import { AiToolsPortal } from "~/components/me/AiToolsPortal";
@@ -21,6 +22,7 @@ import { PersonalRecentTracesTable } from "~/components/me/PersonalRecentTracesT
 import {
   PERSONAL_AI_TOOLS_ANCHOR,
   PERSONAL_TRACE_INGEST_ANCHOR,
+  PersonalGetStartedOffers,
 } from "~/components/me/PersonalTracesEmptyState";
 import { TraceIngestSection } from "~/components/me/TraceIngestSection";
 import { usePersonalContext } from "~/components/me/usePersonalContext";
@@ -47,6 +49,15 @@ function MyUsagePage() {
   } = ctx;
 
   const isOverBudget = budget.status === "exceeded";
+
+  // Nothing has been sent yet: no requests, no daily spend, no per-tool spend.
+  // Instead of four separate "no data" panels the section collapses to one
+  // intentional get-started state — muted stat cards, a preview of the
+  // dashboard to come, and the tools that light it up.
+  const isSectionEmpty =
+    summary.requestsThisMonth === 0 &&
+    spendByDay.length === 0 &&
+    spendByTool.length === 0;
 
   // "Spent this month" leads with the actually-billed amount; the theoretical
   // bundled portion (e.g. Claude Max usage that isn't billed per token) is most
@@ -148,198 +159,226 @@ function MyUsagePage() {
           <SummaryCard
             title="Spent this month"
             value={fmtUsd(summary.billedThisMonthUsd)}
-            subline={spentSubline}
+            subline={isSectionEmpty ? "No usage yet" : spentSubline}
             tone={isOverBudget ? "red" : "default"}
+            muted={isSectionEmpty}
           />
           <SummaryCard
             title="Requests this month"
             value={numeral(summary.requestsThisMonth).format("0,0")}
-            subline={fmtPctDelta(summary.requestsDeltaPctVsLastMonth) ?? "—"}
+            subline={
+              isSectionEmpty
+                ? "No usage yet"
+                : (fmtPctDelta(summary.requestsDeltaPctVsLastMonth) ?? "—")
+            }
+            muted={isSectionEmpty}
           />
           <SummaryCard
             title="Most-used model"
             value={summary.mostUsedModel?.name ?? "—"}
             subline={
-              summary.mostUsedModel
-                ? `${summary.mostUsedModel.usagePct}% of usage`
-                : "Run a request to see this"
+              isSectionEmpty
+                ? "No usage yet"
+                : summary.mostUsedModel
+                  ? `${summary.mostUsedModel.usagePct}% of usage`
+                  : "Run a request to see this"
             }
+            muted={isSectionEmpty}
           />
         </SimpleGrid>
 
-        <SectionCard title="Spending over time">
-          {spendByDay.length === 0 ? (
-            <EmptyState
-              message="No usage yet"
-              hint="Run `langwatch claude` to get started"
-            />
-          ) : (
-            <VStack align="stretch" gap={2}>
-              <CostSeriesLegend
-                showTheoretical={showTheoretical}
-                showBilled={showBilled}
-                onToggleTheoretical={() => setShowTheoretical((v) => !v)}
-                onToggleBilled={() => setShowBilled((v) => !v)}
-              />
-              <HStack gap={1} alignItems="end" height="120px" paddingTop={2}>
-                {spendByDay.map((d) => {
-                  const theoreticalPct = (d.usd / maxDay) * 100;
-                  const billedPct = (d.billedUsd / maxDay) * 100;
-                  return (
-                    <Tooltip
-                      key={d.day}
-                      openDelay={100}
-                      positioning={{ placement: "top" }}
-                      content={
-                        <VStack gap={0.5} align="start">
-                          <Text fontWeight="semibold">{d.day}</Text>
-                          <Text>Theoretical: {fmtUsd(d.usd)}</Text>
-                          <Text>Billed: {fmtUsd(d.billedUsd)}</Text>
-                        </VStack>
-                      }
-                    >
-                      <Box
-                        flex={1}
-                        position="relative"
-                        height="full"
-                        cursor="default"
-                      >
-                        {/* Always-present baseline so empty days still read as a
+        {isSectionEmpty ? (
+          <>
+            <UsagePreviewPanel />
+            <SectionCard title="Get started">
+              <PersonalGetStartedOffers projectSlug={personalProjectSlug} />
+            </SectionCard>
+          </>
+        ) : (
+          <>
+            <SectionCard title="Spending over time">
+              {spendByDay.length === 0 ? (
+                <EmptyState
+                  message="No usage yet"
+                  hint="Run `langwatch claude` to get started"
+                />
+              ) : (
+                <VStack align="stretch" gap={2}>
+                  <CostSeriesLegend
+                    showTheoretical={showTheoretical}
+                    showBilled={showBilled}
+                    onToggleTheoretical={() => setShowTheoretical((v) => !v)}
+                    onToggleBilled={() => setShowBilled((v) => !v)}
+                  />
+                  <HStack
+                    gap={1}
+                    alignItems="end"
+                    height="120px"
+                    paddingTop={2}
+                  >
+                    {spendByDay.map((d) => {
+                      const theoreticalPct = (d.usd / maxDay) * 100;
+                      const billedPct = (d.billedUsd / maxDay) * 100;
+                      return (
+                        <Tooltip
+                          key={d.day}
+                          openDelay={100}
+                          positioning={{ placement: "top" }}
+                          content={
+                            <VStack gap={0.5} align="start">
+                              <Text fontWeight="semibold">{d.day}</Text>
+                              <Text>Theoretical: {fmtUsd(d.usd)}</Text>
+                              <Text>Billed: {fmtUsd(d.billedUsd)}</Text>
+                            </VStack>
+                          }
+                        >
+                          <Box
+                            flex={1}
+                            position="relative"
+                            height="full"
+                            cursor="default"
+                          >
+                            {/* Always-present baseline so empty days still read as a
                             point on the timeline instead of a blank gap. */}
-                        <Box
-                          position="absolute"
-                          bottom={0}
-                          width="full"
-                          height="2px"
-                          borderRadius="full"
-                          backgroundColor="blue.200"
-                        />
-                        {showTheoretical && d.usd > 0 && (
-                          <Box
-                            position="absolute"
-                            bottom={0}
-                            width="full"
-                            backgroundColor="blue.200"
-                            borderRadius="sm"
-                            height={`${Math.max(2, theoreticalPct)}%`}
-                          />
-                        )}
-                        {showBilled && d.billedUsd > 0 && (
-                          <Box
-                            position="absolute"
-                            bottom={0}
-                            width="full"
-                            backgroundColor="blue.400"
-                            borderRadius="sm"
-                            height={`${Math.max(2, billedPct)}%`}
-                          />
-                        )}
-                      </Box>
-                    </Tooltip>
-                  );
-                })}
-              </HStack>
-              <HStack justifyContent="space-between" fontSize="xs" color="fg.muted">
-                <Text>{spendByDay[0]?.day}</Text>
-                <Text>{spendByDay[spendByDay.length - 1]?.day}</Text>
-              </HStack>
-            </VStack>
-          )}
-        </SectionCard>
-
-        <SectionCard title="By tool">
-          {spendByTool.length === 0 ? (
-            <EmptyState message="No tool data yet" />
-          ) : (
-            <VStack align="stretch" gap={3}>
-              <CostSeriesLegend
-                showTheoretical={showTheoretical}
-                showBilled={showBilled}
-                onToggleTheoretical={() => setShowTheoretical((v) => !v)}
-                onToggleBilled={() => setShowBilled((v) => !v)}
-              />
-              {spendByTool.map((tool) => {
-                const theoreticalPct = (tool.usd / maxTool) * 100;
-                const billedPct = (tool.billedUsd / maxTool) * 100;
-                return (
-                  <HStack key={tool.tool} gap={3}>
-                    <Text fontSize="sm" minWidth="120px">
-                      {tool.tool}
-                    </Text>
-                    <Tooltip
-                      openDelay={100}
-                      positioning={{ placement: "top" }}
-                      content={
-                        <VStack gap={0.5} align="start">
-                          <Text fontWeight="semibold">{tool.tool}</Text>
-                          <Text>Theoretical: {fmtUsd(tool.usd)}</Text>
-                          <Text>Billed: {fmtUsd(tool.billedUsd)}</Text>
-                        </VStack>
-                      }
-                    >
-                      <Box
-                        flex={1}
-                        height="14px"
-                        backgroundColor="bg.muted"
-                        borderRadius="sm"
-                        overflow="hidden"
-                        position="relative"
-                        cursor="default"
-                      >
-                        {showTheoretical && (
-                          <Box
-                            position="absolute"
-                            left={0}
-                            top={0}
-                            height="full"
-                            width={`${Math.max(tool.usd > 0 ? 2 : 0, theoreticalPct)}%`}
-                            backgroundColor="blue.200"
-                          />
-                        )}
-                        {showBilled && (
-                          <Box
-                            position="absolute"
-                            left={0}
-                            top={0}
-                            height="full"
-                            width={`${Math.max(tool.billedUsd > 0 ? 2 : 0, billedPct)}%`}
-                            backgroundColor="blue.400"
-                          />
-                        )}
-                      </Box>
-                    </Tooltip>
-                    <VStack
-                      gap={0}
-                      align="end"
-                      minWidth="90px"
-                      fontSize="sm"
-                    >
-                      {showBilled && (
-                        <Text>{fmtUsd(tool.billedUsd)}</Text>
-                      )}
-                      {showTheoretical && tool.usd - tool.billedUsd > 1e-6 && (
-                        <Text color="fg.subtle" fontSize="xs">
-                          {fmtUsd(tool.usd - tool.billedUsd)} bundled
-                        </Text>
-                      )}
-                    </VStack>
+                            <Box
+                              position="absolute"
+                              bottom={0}
+                              width="full"
+                              height="2px"
+                              borderRadius="full"
+                              backgroundColor="blue.200"
+                            />
+                            {showTheoretical && d.usd > 0 && (
+                              <Box
+                                position="absolute"
+                                bottom={0}
+                                width="full"
+                                backgroundColor="blue.200"
+                                borderRadius="sm"
+                                height={`${Math.max(2, theoreticalPct)}%`}
+                              />
+                            )}
+                            {showBilled && d.billedUsd > 0 && (
+                              <Box
+                                position="absolute"
+                                bottom={0}
+                                width="full"
+                                backgroundColor="blue.400"
+                                borderRadius="sm"
+                                height={`${Math.max(2, billedPct)}%`}
+                              />
+                            )}
+                          </Box>
+                        </Tooltip>
+                      );
+                    })}
                   </HStack>
-                );
-              })}
-            </VStack>
-          )}
-        </SectionCard>
+                  <HStack
+                    justifyContent="space-between"
+                    fontSize="xs"
+                    color="fg.muted"
+                  >
+                    <Text>{spendByDay[0]?.day}</Text>
+                    <Text>{spendByDay[spendByDay.length - 1]?.day}</Text>
+                  </HStack>
+                </VStack>
+              )}
+            </SectionCard>
 
-        <SectionCard title="Recent activity" flushContent>
-          {personalProjectId && personalProjectSlug ? (
-            <PersonalRecentTracesTable
-              projectId={personalProjectId}
-              projectSlug={personalProjectSlug}
-            />
-          ) : (
-            <EmptyState message="No requests yet" />
-          )}
-        </SectionCard>
+            <SectionCard title="By tool">
+              {spendByTool.length === 0 ? (
+                <EmptyState message="No tool data yet" />
+              ) : (
+                <VStack align="stretch" gap={3}>
+                  <CostSeriesLegend
+                    showTheoretical={showTheoretical}
+                    showBilled={showBilled}
+                    onToggleTheoretical={() => setShowTheoretical((v) => !v)}
+                    onToggleBilled={() => setShowBilled((v) => !v)}
+                  />
+                  {spendByTool.map((tool) => {
+                    const theoreticalPct = (tool.usd / maxTool) * 100;
+                    const billedPct = (tool.billedUsd / maxTool) * 100;
+                    return (
+                      <HStack key={tool.tool} gap={3}>
+                        <Text fontSize="sm" minWidth="120px">
+                          {tool.tool}
+                        </Text>
+                        <Tooltip
+                          openDelay={100}
+                          positioning={{ placement: "top" }}
+                          content={
+                            <VStack gap={0.5} align="start">
+                              <Text fontWeight="semibold">{tool.tool}</Text>
+                              <Text>Theoretical: {fmtUsd(tool.usd)}</Text>
+                              <Text>Billed: {fmtUsd(tool.billedUsd)}</Text>
+                            </VStack>
+                          }
+                        >
+                          <Box
+                            flex={1}
+                            height="14px"
+                            backgroundColor="bg.muted"
+                            borderRadius="sm"
+                            overflow="hidden"
+                            position="relative"
+                            cursor="default"
+                          >
+                            {showTheoretical && (
+                              <Box
+                                position="absolute"
+                                left={0}
+                                top={0}
+                                height="full"
+                                width={`${Math.max(tool.usd > 0 ? 2 : 0, theoreticalPct)}%`}
+                                backgroundColor="blue.200"
+                              />
+                            )}
+                            {showBilled && (
+                              <Box
+                                position="absolute"
+                                left={0}
+                                top={0}
+                                height="full"
+                                width={`${Math.max(tool.billedUsd > 0 ? 2 : 0, billedPct)}%`}
+                                backgroundColor="blue.400"
+                              />
+                            )}
+                          </Box>
+                        </Tooltip>
+                        <VStack
+                          gap={0}
+                          align="end"
+                          minWidth="90px"
+                          fontSize="sm"
+                        >
+                          {showBilled && <Text>{fmtUsd(tool.billedUsd)}</Text>}
+                          {showTheoretical &&
+                            tool.usd - tool.billedUsd > 1e-6 && (
+                              <Text color="fg.subtle" fontSize="xs">
+                                {fmtUsd(tool.usd - tool.billedUsd)} bundled
+                              </Text>
+                            )}
+                        </VStack>
+                      </HStack>
+                    );
+                  })}
+                </VStack>
+              )}
+            </SectionCard>
+
+            <SectionCard title="Recent activity" flushContent>
+              {personalProjectId && personalProjectSlug ? (
+                <PersonalRecentTracesTable
+                  projectId={personalProjectId}
+                  projectSlug={personalProjectSlug}
+                />
+              ) : (
+                <EmptyState message="No requests yet" />
+              )}
+            </SectionCard>
+          </>
+        )}
       </VStack>
     </MyLayout>
   );
@@ -350,12 +389,17 @@ function SummaryCard({
   value,
   subline,
   tone = "default",
+  muted = false,
 }: {
   title: string;
   value: string;
   subline: string;
   tone?: "default" | "red";
+  // Softens the headline value when the card has nothing to report yet, so a
+  // placeholder "$0.00 / 0 / —" reads as "waiting" rather than broken.
+  muted?: boolean;
 }) {
+  const valueColor = tone === "red" ? "red.500" : muted ? "fg.muted" : "fg";
   return (
     <Box
       borderWidth="1px"
@@ -364,21 +408,101 @@ function SummaryCard({
       padding={4}
       backgroundColor="bg.subtle"
     >
-      <Text fontSize="xs" color="fg.muted" textTransform="uppercase" letterSpacing="wider">
+      <Text
+        fontSize="xs"
+        color="fg.muted"
+        textTransform="uppercase"
+        letterSpacing="wider"
+      >
         {title}
       </Text>
       <Text
         fontSize="2xl"
         fontWeight="semibold"
         marginTop={1}
-        color={tone === "red" ? "red.500" : "fg"}
+        color={valueColor}
       >
         {value}
       </Text>
-      <Text fontSize="sm" color={tone === "red" ? "red.500" : "fg.muted"} marginTop={1}>
+      <Text
+        fontSize="sm"
+        marginTop={1}
+        color={tone === "red" ? "red.500" : muted ? "fg.subtle" : "fg.muted"}
+      >
         {subline}
       </Text>
     </Box>
+  );
+}
+
+// Deterministic bar heights (percent) for the ghost spend preview — a gently
+// rising, jagged shape that reads as "spend over time" without implying real
+// numbers. Fixed so it never flickers or re-rolls between renders.
+const GHOST_BAR_HEIGHTS = [
+  18, 30, 22, 42, 28, 50, 34, 24, 46, 60, 38, 54, 30, 66, 44, 58, 36, 72, 50,
+  64, 40, 78, 56, 68, 46, 84, 60, 74,
+];
+
+// A faint, non-interactive placeholder chart shown before any usage lands.
+// Bars fade out toward their tips so the block reads as a preview, not data.
+function GhostSpendPreview() {
+  return (
+    <Box
+      aria-hidden="true"
+      pointerEvents="none"
+      opacity={0.6}
+      css={{
+        maskImage: "linear-gradient(to bottom, transparent 0%, black 55%)",
+        WebkitMaskImage:
+          "linear-gradient(to bottom, transparent 0%, black 55%)",
+      }}
+    >
+      <HStack gap={1} alignItems="end" height="96px">
+        {GHOST_BAR_HEIGHTS.map((height, index) => (
+          <Box
+            key={index}
+            flex={1}
+            height={`${height}%`}
+            borderRadius="sm"
+            backgroundColor="bg.emphasized"
+          />
+        ))}
+      </HStack>
+      <Box
+        height="2px"
+        marginTop={1}
+        borderRadius="full"
+        backgroundColor="border.muted"
+      />
+    </Box>
+  );
+}
+
+// The empty-state stand-in for the "Spending over time" + "By tool" panels:
+// a preview of the dashboard to come plus the one command that starts filling
+// it. Replaces two separate "no data" boxes with a single intentional panel.
+function UsagePreviewPanel() {
+  return (
+    <SectionCard title="Your dashboard, once your tools send requests">
+      <VStack align="stretch" gap={4}>
+        <GhostSpendPreview />
+        <Text fontSize="sm" color="fg.muted">
+          Your spending over time and top tools by cost appear here as soon as
+          your coding assistants and agents start sending requests.
+        </Text>
+        <VStack align="stretch" gap={2}>
+          <Text fontSize="xs" fontWeight="medium" color="fg.muted">
+            Start a session from your terminal
+          </Text>
+          <ShikiCommandBox
+            command="langwatch claude"
+            lang="bash"
+            showPrompt
+            copyLabel="Command"
+          />
+        </VStack>
+      </VStack>
+    </SectionCard>
   );
 }
 
@@ -445,7 +569,12 @@ function BudgetBanner({
   const colors =
     tone === "red"
       ? { bg: "red.50", border: "red.200", title: "red.700", text: "red.700" }
-      : { bg: "yellow.50", border: "yellow.200", title: "yellow.800", text: "yellow.800" };
+      : {
+          bg: "yellow.50",
+          border: "yellow.200",
+          title: "yellow.800",
+          text: "yellow.800",
+        };
 
   return (
     <Box
@@ -532,7 +661,12 @@ function LegendChip({
       _hover={{ opacity: active ? 0.8 : 0.65 }}
       title={active ? `Hide ${label}` : `Show ${label}`}
     >
-      <Box width="10px" height="10px" borderRadius="sm" backgroundColor={color} />
+      <Box
+        width="10px"
+        height="10px"
+        borderRadius="sm"
+        backgroundColor={color}
+      />
       <Text
         color="fg.muted"
         textDecoration={active ? undefined : "line-through"}

--- a/langwatch/src/server/api/routers/__tests__/tracesV2.redaction.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/tracesV2.redaction.unit.test.ts
@@ -3,6 +3,7 @@ import type { ContentCategory } from "~/server/data-privacy/dataPrivacy.types";
 import type { CategoryVisibility } from "~/server/traces/protections";
 import {
   buildContentPrivacy,
+  gateTraceLogVisibility,
   redactTraceLogContent,
   redactV2Content,
   type TraceLogRecordDto,
@@ -454,6 +455,105 @@ describe("redactTraceLogContent", () => {
       expect(
         redactTraceLogContent(assistantResponse, inputOnly).attributes.body,
       ).toBeUndefined();
+    });
+  });
+});
+
+/**
+ * R2 teaser window: the sibling span reads teaser-redact spans older than the
+ * free-plan visibility cutoff, but the `traceLogs` read applied only the
+ * captured-content permission gate — so a free-plan viewer WITH captured-content
+ * permission could read raw prompts / responses older than their window through
+ * the logs endpoint, a bypass of the teaser the span reads enforce.
+ * `gateTraceLogVisibility` closes that.
+ */
+describe("gateTraceLogVisibility", () => {
+  function logRow(
+    attributes: Record<string, string>,
+    timeUnixMs: number,
+    body = attributes.body ?? attributes["event.name"] ?? "",
+  ): TraceLogRecordDto {
+    return {
+      spanId: "77bb432be48046f6",
+      timeUnixMs,
+      body,
+      attributes,
+      resourceAttributes: { "langwatch.origin": "coding_agent" },
+      scopeName: "com.anthropic.claude_code.events",
+      scopeVersion: null,
+    };
+  }
+
+  const full = { canSeeCapturedInput: true, canSeeCapturedOutput: true };
+  const CUTOFF = 1_000;
+
+  describe("given a free-plan cutoff and a record older than the window", () => {
+    const stale = logRow(
+      { "event.name": "assistant_response", body: "old private answer" },
+      CUTOFF - 1,
+    );
+
+    it("withholds the content even for a viewer allowed to see it", () => {
+      const out = gateTraceLogVisibility(stale, full, CUTOFF);
+
+      expect(out.attributes.body).toBeUndefined();
+      expect(out.bodyRedacted).toBe(true);
+      expect(JSON.stringify(out)).not.toContain("old private answer");
+    });
+
+    it("offers no audience label — a plan gate is not an audience gate", () => {
+      const out = gateTraceLogVisibility(
+        stale,
+        { ...full, capturedOutputVisibleTo: "Admins" },
+        CUTOFF,
+      );
+
+      expect(out.bodyVisibleTo).toBeNull();
+    });
+
+    it("keeps a stale cost anchor's metadata (no content body to withhold)", () => {
+      const anchor = logRow(
+        { "event.name": "api_request", request_id: "req_1", cost_usd: "0.19" },
+        CUTOFF - 1,
+      );
+
+      const out = gateTraceLogVisibility(anchor, full, CUTOFF);
+
+      expect(out.attributes.cost_usd).toBe("0.19");
+      expect(out.bodyRedacted).toBeUndefined();
+    });
+  });
+
+  describe("given a free-plan cutoff and a record inside the window", () => {
+    const fresh = logRow(
+      { "event.name": "assistant_response", body: "recent answer" },
+      CUTOFF + 1,
+    );
+
+    it("falls through to the viewer's captured-content permission", () => {
+      expect(gateTraceLogVisibility(fresh, full, CUTOFF).attributes.body).toBe(
+        "recent answer",
+      );
+      expect(
+        gateTraceLogVisibility(
+          fresh,
+          { canSeeCapturedInput: false, canSeeCapturedOutput: false },
+          CUTOFF,
+        ).attributes.body,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("given a paid plan with no window (cutoff null)", () => {
+    it("leaves the permission gate in sole control, even for an old record", () => {
+      const old = logRow(
+        { "event.name": "assistant_response", body: "answer" },
+        1,
+      );
+
+      expect(gateTraceLogVisibility(old, full, null).attributes.body).toBe(
+        "answer",
+      );
     });
   });
 });

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -1577,13 +1577,21 @@ export const tracesV2Router = createTRPCRouter({
       const protections = await getUserProtectionsForProject(ctx, {
         projectId: input.projectId,
       });
+      // Free-plan teaser window: records older than the plan cutoff have their
+      // content withheld regardless of the viewer's captured-content
+      // permission, exactly as the sibling span reads teaser-redact pre-cutoff
+      // spans (`applyVisibilityGate`). Without this the raw-log read would
+      // surface older-than-window prompts / responses the span reads hide.
+      const visibilityCutoffMs = await getVisibilityCutoffMsForProject(
+        input.projectId,
+      );
       const rows = await app.traces.logRecords.getLogsByTraceId(
         input.projectId,
         input.traceId,
         input.occurredAtMs,
       );
       return rows.map((row) =>
-        redactTraceLogContent(
+        gateTraceLogVisibility(
           {
             spanId: row.spanId,
             timeUnixMs: row.timeUnixMs,
@@ -1594,6 +1602,7 @@ export const tracesV2Router = createTRPCRouter({
             scopeVersion: row.scopeVersion,
           },
           protections,
+          visibilityCutoffMs,
         ),
       );
     }),
@@ -1708,4 +1717,38 @@ export function redactTraceLogContent(
         ? (protections.capturedOutputVisibleTo ?? null)
         : null,
   };
+}
+
+/**
+ * Apply BOTH gates to one trace-correlated log record: the free-plan teaser
+ * window and the viewer's captured-content permission.
+ *
+ * A record older than the plan `visibilityCutoffMs` has its captured content
+ * withheld regardless of the viewer's permission — a plan gate, not an audience
+ * gate, so it offers no "visible to …" label (there is no group that can see
+ * it, only a plan upgrade). This mirrors the sibling span reads, which
+ * teaser-redact pre-cutoff spans via `applyVisibilityGate`. Post-cutoff records
+ * (and every record when `visibilityCutoffMs` is null — a paid plan with no
+ * window) fall through to the viewer's real captured-input / captured-output
+ * visibility. Fails closed: a pre-cutoff record is gated as if no captured
+ * content were visible.
+ */
+export function gateTraceLogVisibility(
+  row: TraceLogRecordDto,
+  protections: {
+    canSeeCapturedInput?: boolean | null;
+    canSeeCapturedOutput?: boolean | null;
+    capturedInputVisibleTo?: string | null;
+    capturedOutputVisibleTo?: string | null;
+  },
+  visibilityCutoffMs: number | null,
+): TraceLogRecordDto {
+  const isBeforeCutoff =
+    visibilityCutoffMs !== null && row.timeUnixMs < visibilityCutoffMs;
+  return redactTraceLogContent(
+    row,
+    isBeforeCutoff
+      ? { canSeeCapturedInput: false, canSeeCapturedOutput: false }
+      : protections,
+  );
 }


### PR DESCRIPTION
Two follow-ups on the coding-agent enhanced-telemetry surface (stacked on `feat/claude-code-enhanced-telemetry-beta`, #5708). Independent — can be split if preferred.

## 1. My Usage empty-state redesign (`feat(me)`)

When a personal user has no usage yet, the `/me` My Usage section rendered four separate empty panels — three dead-looking stat cards (`$0.00 / 0 / —`), two large empty chart boxes, and an empty recent-activity table — repeating "no data" four times and burying the get-started offers at the very bottom.

This collapses that into one intentional get-started state:
- **Muted** (not dead) stat cards with a consistent "No usage yet" subline.
- A single **dashboard-preview panel**: a faint ghost chart of the shape to come + a copyable `langwatch claude` command (via `ShikiCommandBox`) — which also satisfies the spec's outstanding "copy-pasteable CLI snippet" requirement in `my-usage-dashboard.feature`.
- The get-started offers promoted to their own **"Get started"** panel.

The full dashboard renders unchanged the moment any usage arrives (`isSectionEmpty` gate). `PersonalGetStartedOffers` is extracted from `PersonalTracesEmptyState` so the recent-activity hero and the new panel share one offers grid.

> The bulk of the `index.tsx` line count is indentation churn from gating the existing panels in a fragment — the real change is `+148/-14` (`git diff -w`).

## 2. Free-plan visibility teaser window on `traceLogs` (`fix(traces)`)

Every sibling span/trace read passes the plan cutoff from `getVisibilityCutoffMsForProject` and teaser-redacts content older than the free-plan window (`applyVisibilityGate`). The `tracesV2.traceLogs` read applied only the captured-content **permission** gate — so a free-plan viewer *with* content permission could read raw prompts/responses older than their window through the logs endpoint, bypassing the teaser the span reads enforce. (The separate content-privacy *security* gate on this endpoint was already fixed.)

New `gateTraceLogVisibility`: pre-cutoff records are content-redacted fail-closed with no audience label (a plan gate, not an audience gate); post-cutoff records — and every record on a paid plan with no window — fall through to the viewer's real permission. Cost anchors / metadata pass through intact. 6 new unit tests.

**Known follow-up:** the read-time enrichment path (`TraceService.enrichCodingAgentTrace → getLogsByTraceId`) also reads logs uncapped; it feeds spans that are gated downstream, but that path still wants a confirming audit.

## Testing
- `pnpm typecheck` clean.
- `tracesV2.redaction.unit.test.ts` — 29 passed (6 new teaser-window cases).
- Empty-state UI: visual sign-off still pending on a running instance (feature-flag + zero-usage personal project); typecheck + review only so far.

## Not included (deferred telemetry items — blocked or need decisions)
- **RAW_API_BODIES → light-events flip** — needs prod confirmation that `assistant_response` arrives before dropping the raw-body fallback.
- **C1 write-time cost column + body-stripping** — stripping depends on the flip above; the column alone is redundant with the working read-time join.
- **C6 native trace linking (`parent_of`/`agent_id`)** — greenfield; open call on the canonical `parent_agent_id` key + the one-session-many-traces drawer model.
- **C3 logs UI + efficiency-analytics feature** — need the two reserved calls (rollup vs direct query; drawer-only vs drawer+dashboard).
