### PR TITLE
perf: cut redundant JSON work; zstd + size-gated msgpack in the queue

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -190,6 +190,7 @@
     "monaco-editor": "^0.55.1",
     "monacopilot": "^1.2.12",
     "motion": "^12.42.2",
+    "msgpackr": "^2.0.4",
     "mustache": "^4.2.0",
     "nanoid": "^5.1.16",
     "next-themes": "^0.4.6",

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -460,6 +460,9 @@ importers:
       motion:
         specifier: ^12.42.2
         version: 12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      msgpackr:
+        specifier: ^2.0.4
+        version: 2.0.4
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
@@ -483,7 +486,7 @@ importers:
         version: 17.5.0
       openai:
         specifier: ^6.45.0
-        version: 6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.0)(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
+        version: 6.45.0(@aws-sdk/credential-provider-node@3.972.60)(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
       papaparse:
         specifier: ^5.5.4
         version: 5.5.4
@@ -16658,9 +16661,9 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.2(@types/node@25.6.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(vite@8.1.2(@types/node@25.6.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -16714,7 +16717,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.2(@types/node@25.6.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@4.1.9':
     dependencies:

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.codec.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.codec.unit.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import { detectCompression, MSGPACK_MIN_BYTES } from "../bodyCodec";
+import { decodeJobEnvelope, encodeJobEnvelope } from "../jobEnvelope";
+import { TieredBlobStore } from "../tieredBlobStore";
+import { InMemoryJobBlobStore, InMemoryObjectStore } from "./blobTestDoubles";
+
+const PROJECT = createTenantId("project-codec");
+
+function makeTiered() {
+  const redisBlobs = new InMemoryJobBlobStore();
+  const objectStore = new InMemoryObjectStore();
+  const tieredBlobs = new TieredBlobStore({
+    redisBlobs,
+    objectStoreFor: () => objectStore,
+    resolveDestination: async () => ({ kind: "s3", bucket: "test-bucket" }),
+    s3ThresholdBytes: 256 * 1024,
+  });
+  return { tieredBlobs, redisBlobs, objectStore };
+}
+
+/** Comfortably over MSGPACK_MIN_BYTES, and string-heavy like a real LLM body. */
+const bigPayload = () => ({
+  __jobName: "record-span",
+  __pipelineName: "traces",
+  traceId: "trace-1",
+  input: { value: "the quick brown fox ".repeat(MSGPACK_MIN_BYTES / 10) },
+});
+
+/** Under INLINE_CEILING_BYTES, so it never leaves the envelope. */
+const smallPayload = () => ({
+  __jobName: "record-span",
+  __pipelineName: "traces",
+  traceId: "trace-1",
+  input: { value: "hello" },
+});
+
+describe("jobEnvelope body codecs", () => {
+  beforeEach(() => {
+    vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("given a blob written before the codec change (gzip + JSON)", () => {
+    describe("when a reader that supports zstd and msgpack decodes it", () => {
+      it("decodes it without a migration", async () => {
+        const { tieredBlobs, objectStore, redisBlobs } = makeTiered();
+        const jobData = bigPayload();
+
+        // Write with both new-format flags OFF — byte-for-byte what the
+        // currently-deployed encoder produces.
+        const encoded = await encodeJobEnvelope({
+          jobData,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        const stored = [
+          ...redisBlobs.store.values(),
+          ...objectStore.store.values(),
+        ];
+        expect(stored).toHaveLength(1);
+        expect(detectCompression(stored[0]!)).toBe("gzip");
+
+        // Now read it on a pod that has the new codecs enabled.
+        vi.stubEnv("GROUP_QUEUE_ZSTD_WRITES_ENABLED", "true");
+        vi.stubEnv("GROUP_QUEUE_MSGPACK_WRITES_ENABLED", "true");
+
+        expect(
+          await decodeJobEnvelope({ value: encoded, tieredBlobs }),
+        ).toEqual(jobData);
+      });
+    });
+  });
+
+  describe("given zstd writes are enabled", () => {
+    beforeEach(() => {
+      vi.stubEnv("GROUP_QUEUE_ZSTD_WRITES_ENABLED", "true");
+    });
+
+    it("compresses the blob with zstd", async () => {
+      const { tieredBlobs, objectStore, redisBlobs } = makeTiered();
+
+      await encodeJobEnvelope({
+        jobData: bigPayload(),
+        tieredBlobs,
+        projectId: PROJECT,
+      });
+
+      const stored = [
+        ...redisBlobs.store.values(),
+        ...objectStore.store.values(),
+      ];
+      expect(detectCompression(stored[0]!)).toBe("zstd");
+    });
+
+    it("round-trips the payload", async () => {
+      const { tieredBlobs } = makeTiered();
+      const jobData = bigPayload();
+
+      const encoded = await encodeJobEnvelope({
+        jobData,
+        tieredBlobs,
+        projectId: PROJECT,
+      });
+
+      expect(await decodeJobEnvelope({ value: encoded, tieredBlobs })).toEqual(
+        jobData,
+      );
+    });
+
+    it("round-trips multibyte characters", async () => {
+      const { tieredBlobs } = makeTiered();
+      const jobData = {
+        __jobName: "x",
+        text: "日本語テキスト 🎉 ".repeat(MSGPACK_MIN_BYTES / 10),
+      };
+
+      const encoded = await encodeJobEnvelope({
+        jobData,
+        tieredBlobs,
+        projectId: PROJECT,
+      });
+
+      expect(await decodeJobEnvelope({ value: encoded, tieredBlobs })).toEqual(
+        jobData,
+      );
+    });
+  });
+
+  describe("given msgpack writes are enabled", () => {
+    beforeEach(() => {
+      vi.stubEnv("GROUP_QUEUE_MSGPACK_WRITES_ENABLED", "true");
+    });
+
+    describe("when the payload is over the msgpack threshold", () => {
+      it("round-trips it", async () => {
+        const { tieredBlobs } = makeTiered();
+        const jobData = bigPayload();
+
+        const encoded = await encodeJobEnvelope({
+          jobData,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        expect(
+          await decodeJobEnvelope({ value: encoded, tieredBlobs }),
+        ).toEqual(jobData);
+      });
+
+      it("stores it under a different content-addressed key than the JSON encoding", async () => {
+        // The codec is folded into the content hash. Without that, a JSON-encoded
+        // and a msgpack-encoded copy of the same payload would collide on one
+        // content-addressed key with DIFFERENT bytes, and whichever landed second
+        // would silently dedup onto the first — handing a reader a codec it was
+        // not expecting. Both encodings go into the SAME store here, so a
+        // collision would show up as a single key.
+        const jobData = bigPayload();
+        const { tieredBlobs, redisBlobs, objectStore } = makeTiered();
+
+        await encodeJobEnvelope({ jobData, tieredBlobs, projectId: PROJECT });
+
+        vi.stubEnv("GROUP_QUEUE_MSGPACK_WRITES_ENABLED", "false");
+        await encodeJobEnvelope({ jobData, tieredBlobs, projectId: PROJECT });
+
+        const keys = [
+          ...redisBlobs.store.keys(),
+          ...objectStore.store.keys(),
+        ];
+        expect(keys).toHaveLength(2);
+      });
+    });
+
+    describe("when the payload is under the msgpack threshold", () => {
+      it("keeps it as JSON, because msgpack is slower than JSON.stringify at that size", async () => {
+        const { tieredBlobs } = makeTiered();
+        const jobData = smallPayload();
+
+        const encoded = await encodeJobEnvelope({
+          jobData,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        // Small bodies stay inline in the envelope, and an inline body is always
+        // JSON — so the payload is readable in the raw envelope string.
+        expect(encoded).toContain('"input":{"value":"hello"}');
+        expect(
+          await decodeJobEnvelope({ value: encoded, tieredBlobs }),
+        ).toEqual(jobData);
+      });
+    });
+  });
+
+  describe("given the same event is fanned out to several reactors", () => {
+    it("collapses them onto one stored blob", async () => {
+      // The dedup that makes the codec choice worth anything: one encode, N
+      // decodes. Machinery (__jobName et al) is lifted into the header so it
+      // cannot perturb the content hash.
+      vi.stubEnv("GROUP_QUEUE_ZSTD_WRITES_ENABLED", "true");
+      vi.stubEnv("GROUP_QUEUE_MSGPACK_WRITES_ENABLED", "true");
+      const { tieredBlobs, objectStore, redisBlobs } = makeTiered();
+
+      const payload = bigPayload();
+      const reactors = ["reactor-a", "reactor-b", "reactor-c"];
+
+      const encoded = await Promise.all(
+        reactors.map((jobName) =>
+          encodeJobEnvelope({
+            jobData: { ...payload, __jobName: jobName },
+            tieredBlobs,
+            projectId: PROJECT,
+          }),
+        ),
+      );
+
+      const stored = [
+        ...redisBlobs.store.values(),
+        ...objectStore.store.values(),
+      ];
+      expect(stored).toHaveLength(1);
+
+      for (const [i, value] of encoded.entries()) {
+        expect(await decodeJobEnvelope({ value, tieredBlobs })).toEqual({
+          ...payload,
+          __jobName: reactors[i],
+        });
+      }
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/bodyCodec.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/bodyCodec.ts
@@ -1,0 +1,153 @@
+import { promisify } from "node:util";
+import { gunzip, gzip, zstdCompress, zstdDecompress } from "node:zlib";
+
+import { Packr } from "msgpackr";
+
+import { MAX_BLOB_BYTES } from "./blobConstants";
+
+const gzipAsync = promisify(gzip);
+const gunzipAsync = promisify(gunzip);
+const zstdCompressAsync = promisify(zstdCompress);
+const zstdDecompressAsync = promisify(zstdDecompress);
+
+/**
+ * Cap decompression output at the encode ceiling (ADR-030 §1) so a corrupt or
+ * tampered blob can't OOM the worker. Both codecs throw past the limit; decode
+ * lets that propagate to the missing-blob fail-safe.
+ */
+const GUNZIP_OPTS = { maxOutputLength: MAX_BLOB_BYTES };
+const ZSTD_OPTS = { maxOutputLength: MAX_BLOB_BYTES };
+
+/**
+ * msgpackr's record extension rewrites repeated object shapes into a shared
+ * structure table. That table is stateful across packs, which would make the
+ * bytes for a given payload depend on what the encoder packed *before* it —
+ * fatal for content-addressed dedup, where identical payloads must produce
+ * identical bytes on every pod. `useRecords: false` keeps each pack
+ * self-contained and deterministic.
+ */
+const packr = new Packr({ useRecords: false, structuredClone: false });
+
+/** How a payload was turned into bytes. */
+export type PayloadCodec = "json" | "msgpack";
+/** How those bytes were compressed. */
+export type CompressionCodec = "none" | "gzip" | "zstd";
+
+/**
+ * msgpack pays off only on large payloads. Below this, `JSON.stringify` beats
+ * `msgpackr.pack` outright (measured ~1.7-1.9x on 1.5-6KB job bodies): our
+ * payloads are dominated by long UTF-8 strings — LLM prompts, completions, RAG
+ * contexts — which msgpack stores essentially the way JSON does, so there is no
+ * structural redundancy for it to win back, while V8's JSON fast path is hard to
+ * beat on exactly that shape. Above the threshold msgpack's faster *decode*
+ * (2-3x) dominates and it wins.
+ */
+export const MSGPACK_MIN_BYTES = 100 * 1024;
+
+/**
+ * Magic bytes. Compression is detected by sniffing rather than by trusting the
+ * envelope header, so blobs written before this change — already sitting in S3
+ * under a content hash — keep decoding with no migration and no dual-write.
+ */
+const GZIP_MAGIC = [0x1f, 0x8b];
+const ZSTD_MAGIC = [0x28, 0xb5, 0x2f, 0xfd];
+
+const startsWith = (buf: Buffer, magic: number[]): boolean =>
+  buf.length >= magic.length && magic.every((byte, i) => buf[i] === byte);
+
+export function detectCompression(buf: Buffer): CompressionCodec {
+  if (startsWith(buf, GZIP_MAGIC)) return "gzip";
+  if (startsWith(buf, ZSTD_MAGIC)) return "zstd";
+  return "none";
+}
+
+export async function compress(
+  data: Buffer | string,
+  codec: CompressionCodec,
+): Promise<Buffer> {
+  switch (codec) {
+    case "gzip":
+      return await gzipAsync(data);
+    case "zstd":
+      return await zstdCompressAsync(data);
+    case "none":
+      return Buffer.isBuffer(data) ? data : Buffer.from(data);
+  }
+}
+
+/** Decompresses by sniffing the payload, so gzip and zstd blobs coexist. */
+export async function decompress(buf: Buffer): Promise<Buffer> {
+  switch (detectCompression(buf)) {
+    case "gzip":
+      return await gunzipAsync(buf, GUNZIP_OPTS);
+    case "zstd":
+      return await zstdDecompressAsync(buf, ZSTD_OPTS);
+    case "none":
+      return buf;
+  }
+}
+
+/**
+ * Serializes a payload, choosing msgpack only above {@link MSGPACK_MIN_BYTES}.
+ *
+ * Returns the codec alongside the bytes because the caller must fold it into the
+ * content hash — see {@link contentHashSource}.
+ */
+export function encodePayload(
+  payload: Record<string, unknown>,
+  { msgpackEnabled }: { msgpackEnabled: boolean },
+): { bytes: Buffer; codec: PayloadCodec; json: string | null } {
+  const json = JSON.stringify(payload);
+  const jsonBytes = Buffer.byteLength(json);
+
+  if (!msgpackEnabled || jsonBytes < MSGPACK_MIN_BYTES) {
+    return { bytes: Buffer.from(json), codec: "json", json };
+  }
+
+  return { bytes: packr.pack(payload), codec: "msgpack", json };
+}
+
+/**
+ * Deserializes a payload by sniffing the leading byte.
+ *
+ * JSON object/array bodies begin with `{` (0x7b) or `[` (0x5b); msgpack encodes a
+ * top-level map as fixmap (0x80-0x8f), map16 (0xde) or map32 (0xdf). The ranges
+ * are disjoint, so this is unambiguous for the shapes we actually store — and
+ * sniffing means we never trust a header that could disagree with the bytes.
+ */
+export function decodePayload(buf: Buffer): Record<string, unknown> {
+  const first = buf[0];
+  const isMsgpack =
+    first !== undefined &&
+    ((first >= 0x80 && first <= 0x8f) || first === 0xde || first === 0xdf);
+
+  return isMsgpack
+    ? (packr.unpack(buf) as Record<string, unknown>)
+    : (JSON.parse(buf.toString("utf-8")) as Record<string, unknown>);
+}
+
+/**
+ * The dedup key for a content-addressed blob.
+ *
+ * The codec MUST be part of the hash. Blobs are content-addressed, so a hash
+ * collision means "reuse the stored copy" — and during a rollout one pod may
+ * encode a payload as JSON while another encodes the same payload as msgpack. If
+ * both hashed only the payload they would land on the same key with *different
+ * bytes*, and the second writer would silently dedup onto the first, handing a
+ * reader bytes in a codec it wasn't expecting. Folding the codec in keeps the two
+ * representations on separate keys, at the cost of storing both during the
+ * transition.
+ */
+export function contentHashSource({
+  codec,
+  json,
+  bytes,
+}: {
+  codec: PayloadCodec;
+  json: string | null;
+  bytes: Buffer;
+}): string | Buffer {
+  // Hash the raw payload representation, never the compressed output: gzip/zstd
+  // determinism varies with library version and level (ADR-030 §1).
+  return codec === "json" && json !== null ? `json:${json}` : bytes;
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/bodyCodec.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/bodyCodec.ts
@@ -33,6 +33,17 @@ export type PayloadCodec = "json" | "msgpack";
 /** How those bytes were compressed. */
 export type CompressionCodec = "none" | "gzip" | "zstd";
 
+const COMPRESSION_MEDIA_TYPES: Record<CompressionCodec, string> = {
+  none: "application/octet-stream",
+  gzip: "application/gzip",
+  zstd: "application/zstd",
+};
+
+/** Durable-storage media type matching what {@link compress} actually wrote. */
+export function compressionMediaType(codec: CompressionCodec): string {
+  return COMPRESSION_MEDIA_TYPES[codec];
+}
+
 /**
  * msgpack pays off only on large payloads. Below this, `JSON.stringify` beats
  * `msgpackr.pack` outright (measured ~1.7-1.9x on 1.5-6KB job bodies): our
@@ -129,14 +140,12 @@ export function decodePayload(buf: Buffer): Record<string, unknown> {
 /**
  * The dedup key for a content-addressed blob.
  *
- * The codec MUST be part of the hash. Blobs are content-addressed, so a hash
- * collision means "reuse the stored copy" — and during a rollout one pod may
- * encode a payload as JSON while another encodes the same payload as msgpack. If
- * both hashed only the payload they would land on the same key with *different
- * bytes*, and the second writer would silently dedup onto the first, handing a
- * reader bytes in a codec it wasn't expecting. Folding the codec in keeps the two
- * representations on separate keys, at the cost of storing both during the
- * transition.
+ * JSON and msgpack representations of the same payload are already different
+ * byte sequences (UTF-8 JSON text vs. msgpackr's binary map encoding), so the
+ * two codecs never land on the same key without an explicit prefix — hashing
+ * the raw JSON string keeps this call byte-for-byte the same hash a pre-rollout
+ * pod would have computed, so cross-version dedup during the msgpack rollout
+ * isn't degraded by a hash that only this pod's code produces.
  */
 export function contentHashSource({
   codec,
@@ -149,5 +158,5 @@ export function contentHashSource({
 }): string | Buffer {
   // Hash the raw payload representation, never the compressed output: gzip/zstd
   // determinism varies with library version and level (ADR-030 §1).
-  return codec === "json" && json !== null ? `json:${json}` : bytes;
+  return codec === "json" && json !== null ? json : bytes;
 }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -1,25 +1,44 @@
 import { randomUUID } from "node:crypto";
-import { promisify } from "node:util";
-import { gunzip, gzip } from "node:zlib";
 
 import type { Logger } from "pino";
 
 import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
 
 import { MAX_BLOB_BYTES } from "./blobConstants";
+import {
+  type CompressionCodec,
+  compress,
+  contentHashSource,
+  decodePayload,
+  decompress,
+  encodePayload,
+} from "./bodyCodec";
 import { gqEnvelopeGQ2DowngradeTotal, gqPayloadTooLargeTotal } from "./metrics";
 import type { BlobRef, TieredBlobStore } from "./tieredBlobStore";
 
-const gzipAsync = promisify(gzip);
-const gunzipAsync = promisify(gunzip);
-
 /**
- * Cap decompression output at the same ceiling encode enforces (ADR-030 §1), so
- * a tampered or corrupt blob (e.g. a tenant zip-bombing their own BYOC object)
- * can't OOM the worker. zlib throws past the limit; decode lets that propagate to
- * the missing-blob fail-safe (complete the slot, recover via replay).
+ * Compression and payload codec are chosen at WRITE time behind flags, but READ
+ * always sniffs the bytes and accepts every format we have ever written. That
+ * asymmetry is the whole rollout story: ship readers that understand zstd and
+ * msgpack with writes still off, let the fleet cycle, then flip the flags.
+ *
+ * Writing first is NOT safe here. `decodeJobEnvelope` throwing a plain Error
+ * (unknown codec, failed parse) does not retry — `GroupQueue` only re-stages on
+ * `TransientBlobStoreError`, so everything else terminates at the non-retryable
+ * fail-safe, which completes the slot and drops the job to replay. An old worker
+ * meeting a new body during a rolling deploy would silently discard it.
  */
-const DECODE_GUNZIP_OPTS = { maxOutputLength: MAX_BLOB_BYTES };
+function zstdWritesEnabled(): boolean {
+  return process.env.GROUP_QUEUE_ZSTD_WRITES_ENABLED === "true";
+}
+
+function msgpackWritesEnabled(): boolean {
+  return process.env.GROUP_QUEUE_MSGPACK_WRITES_ENABLED === "true";
+}
+
+function writeCompression(): CompressionCodec {
+  return zstdWritesEnabled() ? "zstd" : "gzip";
+}
 
 /**
  * Versioned envelope for staged job values: `GQ<v>|<headerLen>|<headerJson><body>`.
@@ -189,7 +208,13 @@ function finalize(
 
 /**
  * Picks the inline encoding for a body that stays in the envelope: raw JSON, or
- * gzip+base64 when compression actually wins (mutates `header.e` to `"gz"`).
+ * compressed+base64 when compression actually wins (mutates `header.e` to
+ * `"gz"`).
+ *
+ * `"gz"` means "compressed"; the codec itself is sniffed from the magic bytes on
+ * decode rather than named in the header, so a zstd body and a gzip body are
+ * both `"gz"` and a reader never has to trust a header that could disagree with
+ * the bytes it actually got.
  */
 async function inlineBody(
   json: string,
@@ -197,10 +222,12 @@ async function inlineBody(
   header: EnvelopeHeader,
 ): Promise<string> {
   if (jsonBytes > COMPRESSION_THRESHOLD_BYTES) {
-    const compressed = (await gzipAsync(json)).toString("base64");
+    const compressed = (await compress(json, writeCompression())).toString(
+      "base64",
+    );
     // High-entropy payloads (inline base64-ish data) can come out LARGER after
-    // gzip+base64; keep raw JSON unless compression actually wins. `"gz"` costs
-    // one more header byte than `"j"`.
+    // compress+base64; keep raw JSON unless compression actually wins. `"gz"`
+    // costs one more header byte than `"j"`.
     if (Buffer.byteLength(compressed) + 1 < jsonBytes) {
       header.e = "gz";
       return compressed;
@@ -273,19 +300,13 @@ export async function encodeJobEnvelope({
   /** Optional logger for tenant-attributed warn on cap / downgrade. */
   logger?: Logger;
 }): Promise<string> {
-  const json = JSON.stringify(jobData);
   const enabled = writesEnabled ?? envelopeWritesEnabled();
-  if (!enabled) {
-    return json;
-  }
-  const jsonBytes = Buffer.byteLength(json);
-  assertPayloadWithinCap(jsonBytes, { projectId, queueName, logger });
 
   // GQ2: content-addressed, tenant-namespaced, tiered offload. Active only once
   // the composition root supplies a tiered store and the job's tenant. If
   // either is missing we fall back to GQ1 — noisy so a regression in the
   // composition root can't ship a silently-downgraded pipeline.
-  if (tieredBlobs && projectId) {
+  if (enabled && tieredBlobs && projectId) {
     const header = routingHeader(jobData, 2);
     // Lift queue machinery into the header so it doesn't perturb the content
     // hash. Without this, N reactors fanning out the same event produce N
@@ -301,17 +322,26 @@ export async function encodeJobEnvelope({
     if (Object.keys(machinery).length > 0) {
       header.m = machinery;
     }
-    const payloadJson = JSON.stringify(payload);
-    const payloadBytes = Buffer.byteLength(payloadJson);
+
+    // GQ2 never serializes `jobData` as a whole — only the payload. The old
+    // `JSON.stringify(jobData)` above this branch was a second full pass whose
+    // result this path then threw away.
+    const { bytes, codec, json: payloadJson } = encodePayload(payload, {
+      msgpackEnabled: msgpackWritesEnabled(),
+    });
+    const payloadBytes = bytes.length;
+    assertPayloadWithinCap(payloadBytes, { projectId, queueName, logger });
+
     if (payloadBytes > INLINE_CEILING_BYTES) {
       const ref = await tieredBlobs.put({
         projectId,
-        data: await gzipAsync(payloadJson),
-        // Hash the RAW payload json string directly, not the gzip output — the
-        // dedup key is independent of gzip determinism (zlib version/level;
-        // ADR-030 §1). `contentHash` accepts strings and lets crypto handle the
-        // UTF-8 conversion internally so we don't allocate a full-payload Buffer.
-        hashSource: payloadJson,
+        data: await compress(bytes, writeCompression()),
+        // Hash the RAW payload, never the compressed output — the dedup key must
+        // not depend on gzip/zstd determinism (library version/level; ADR-030
+        // §1). The codec is folded in so a JSON-encoded and a msgpack-encoded
+        // copy of the same payload can't collide on one key with different bytes
+        // mid-rollout.
+        hashSource: contentHashSource({ codec, json: payloadJson, bytes }),
       });
       header.e = ref.tier;
       header.ref = ref;
@@ -321,12 +351,22 @@ export async function encodeJobEnvelope({
       header.h = randomUUID();
       return finalize(ENVELOPE_PREFIX_V2, header, "");
     }
+
+    // Inline bodies are under INLINE_CEILING_BYTES (4KB) and msgpack only
+    // engages above MSGPACK_MIN_BYTES (100KB), so an inline body is always JSON.
     return finalize(
       ENVELOPE_PREFIX_V2,
       header,
-      await inlineBody(payloadJson, payloadBytes, header),
+      await inlineBody(payloadJson ?? bytes.toString("utf-8"), payloadBytes, header),
     );
   }
+
+  const json = JSON.stringify(jobData);
+  if (!enabled) {
+    return json;
+  }
+  const jsonBytes = Buffer.byteLength(json);
+  assertPayloadWithinCap(jsonBytes, { projectId, queueName, logger });
 
   // GQ1 fallback path: reached when the caller opted into writes but didn't
   // supply BOTH a tiered store and a projectId. Loud so a composition-root
@@ -347,7 +387,7 @@ export async function encodeJobEnvelope({
   const header = routingHeader(jobData, 1);
   if (blobs && jsonBytes > BLOB_OFFLOAD_THRESHOLD_BYTES) {
     const id = randomUUID();
-    await blobs.put({ id, data: await gzipAsync(json) });
+    await blobs.put({ id, data: await compress(json, writeCompression()) });
     header.e = "ref";
     header.r = id;
     return finalize(ENVELOPE_PREFIX_V1, header, "");
@@ -405,9 +445,7 @@ export async function decodeJobEnvelope({
         "Job envelope tiered blob is missing (deleted or expired)",
       );
     }
-    const parsedBody = JSON.parse(
-      (await gunzipAsync(data, DECODE_GUNZIP_OPTS)).toString("utf8"),
-    ) as Record<string, unknown>;
+    const parsedBody = decodePayload(await decompress(data));
     return mergeMachinery(parsedBody, header);
   }
 
@@ -430,18 +468,13 @@ export async function decodeJobEnvelope({
         `Job envelope blob ${header.r} is missing (deleted or expired)`,
       );
     }
-    return JSON.parse(
-      (await gunzipAsync(data, DECODE_GUNZIP_OPTS)).toString("utf8"),
-    ) as Record<string, unknown>;
+    return decodePayload(await decompress(data));
   }
 
-  const json =
+  const parsedBody =
     header.e === "gz"
-      ? (
-          await gunzipAsync(Buffer.from(body, "base64"), DECODE_GUNZIP_OPTS)
-        ).toString("utf8")
-      : body;
-  const parsedBody = JSON.parse(json) as Record<string, unknown>;
+      ? decodePayload(await decompress(Buffer.from(body, "base64")))
+      : (JSON.parse(body) as Record<string, unknown>);
   // GQ2 inline lifted machinery into header.m too; GQ1 (v=1) never did.
   return header.v === 2 ? mergeMachinery(parsedBody, header) : parsedBody;
 }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -6,8 +6,9 @@ import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
 
 import { MAX_BLOB_BYTES } from "./blobConstants";
 import {
-  type CompressionCodec,
   compress,
+  compressionMediaType,
+  type CompressionCodec,
   contentHashSource,
   decodePayload,
   decompress,
@@ -333,15 +334,17 @@ export async function encodeJobEnvelope({
     assertPayloadWithinCap(payloadBytes, { projectId, queueName, logger });
 
     if (payloadBytes > INLINE_CEILING_BYTES) {
+      const compression = writeCompression();
       const ref = await tieredBlobs.put({
         projectId,
-        data: await compress(bytes, writeCompression()),
+        data: await compress(bytes, compression),
         // Hash the RAW payload, never the compressed output — the dedup key must
         // not depend on gzip/zstd determinism (library version/level; ADR-030
         // §1). The codec is folded in so a JSON-encoded and a msgpack-encoded
         // copy of the same payload can't collide on one key with different bytes
         // mid-rollout.
         hashSource: contentHashSource({ codec, json: payloadJson, bytes }),
+        mediaType: compressionMediaType(compression),
       });
       header.e = ref.tier;
       header.ref = ref;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
@@ -234,6 +234,7 @@ export class TieredBlobStore {
     projectId,
     data,
     hashSource,
+    mediaType = "application/gzip",
   }: {
     projectId: TenantId;
     data: Buffer;
@@ -243,13 +244,20 @@ export class TieredBlobStore {
      * `data`, i.e. hash exactly what is stored.
      */
     hashSource?: Buffer | string;
+    /**
+     * Media type stored alongside the s3-tier object. Defaults to the
+     * historical `application/gzip` for callers that don't compress with
+     * anything else; a caller writing zstd (or another codec) must pass the
+     * matching media type so durable storage isn't mislabeled.
+     */
+    mediaType?: string;
   }): Promise<BlobRef> {
     const hash = contentHash(hashSource ?? data);
     if (data.length > this.s3ThresholdBytes) {
       const uri = await this.mintUri({ projectId, hash });
       // Idempotent: identical content mints the same URI, so a racing or retried
       // PUT overwrites the same object instead of duplicating it.
-      await this.objectStoreFor(projectId).put(uri, data, "application/gzip");
+      await this.objectStoreFor(projectId).put(uri, data, mediaType);
       return { tier: "s3", projectId, hash };
     }
     // GQ2 blobs are refcounted (holder-set eager reclaim), so the TTL is only

--- a/langwatch/src/server/routes/evaluations-legacy.ts
+++ b/langwatch/src/server/routes/evaluations-legacy.ts
@@ -196,15 +196,18 @@ secured
       }
 
       let body: Record<string, any>;
+      let payloadSize: number;
       try {
-        body = await c.req.json();
+        // Size comes from the wire bytes, not a re-serialisation of the parsed
+        // body — these payloads carry full dataset entries and LLM outputs.
+        const raw = await c.req.text();
+        payloadSize = Buffer.byteLength(raw, "utf8");
+        body = JSON.parse(raw);
       } catch {
         return c.json({ message: "Invalid body, expecting json" }, 400);
       }
 
-      getPayloadSizeHistogram("log_results").observe(
-        JSON.stringify(body).length,
-      );
+      getPayloadSizeHistogram("log_results").observe(payloadSize);
 
       let params: ESBatchEvaluationRESTParams;
       try {

--- a/langwatch/src/server/routes/misc.ts
+++ b/langwatch/src/server/routes/misc.ts
@@ -265,13 +265,19 @@ secured
       const project = c.get("project");
 
       let body: unknown;
+      let payloadSize: number;
       try {
-        body = await c.req.json();
+        // Take the size from the wire bytes rather than re-serialising the
+        // parsed body: bodies here run to 20MB, and the old
+        // `JSON.stringify(body).length` both cost a full second pass and
+        // reported UTF-16 code units instead of transferred bytes.
+        const raw = await c.req.text();
+        payloadSize = Buffer.byteLength(raw, "utf8");
+        body = JSON.parse(raw);
       } catch {
         return c.json({ message: "Bad request" }, 400);
       }
 
-      const payloadSize = JSON.stringify(body).length;
       const payloadSizeMB = payloadSize / (1024 * 1024);
       getPayloadSizeHistogram("log_steps").observe(payloadSize);
 

--- a/langwatch/src/utils/truncate.test.ts
+++ b/langwatch/src/utils/truncate.test.ts
@@ -95,4 +95,24 @@ describe("safeTruncate", () => {
     const result = safeTruncate(circular) as Record<string, unknown>;
     expect(result).toEqual(circular);
   });
+
+  it("measures a key-sensitive toJSON in its real property-key context, not standalone", () => {
+    // JSON.stringify(value) alone always calls value.toJSON("") — a toJSON
+    // that returns something small for key "" but large for its real key
+    // would be under-measured if the drop-keys pass serialized it standalone,
+    // letting an oversized entry slip past maxTotalLength. An own-property
+    // toJSON (rather than a prototype method) survives truncateRecursive's
+    // plain-object rebuild, so this is reachable with real input shapes.
+    function makeKeySensitive(): Record<string, unknown> {
+      return {
+        toJSON: (key: string) => (key === "" ? "x" : "y".repeat(2 * 1024)),
+      };
+    }
+
+    const input = { evil: makeKeySensitive(), other: "small" };
+    const result = safeTruncate(input, 512) as Record<string, unknown>;
+
+    expect(JSON.stringify(result).length).toBeLessThanOrEqual(512);
+    expect(result.evil).toBeUndefined();
+  });
 });

--- a/langwatch/src/utils/truncate.ts
+++ b/langwatch/src/utils/truncate.ts
@@ -51,28 +51,47 @@ const truncateWithSizeLimit = (
     }
   }
 
-  // If still too large, start dropping keys
+  // If still too large, start dropping keys.
+  //
+  // The serialised length of an object is the sum of its entries' lengths plus
+  // the separators, so we can track the running total by serialising each value
+  // exactly once. Re-serialising the whole accumulated object on every key (as
+  // this used to) is quadratic, and it runs on precisely the inputs already
+  // known to be oversized.
   if (typeof data === "object" && data !== null && !Array.isArray(data)) {
     const entries = Object.entries(data);
-    let result: Record<string, unknown> = {};
+    const result: Record<string, unknown> = {};
 
-    // biome-ignore lint/style/useForOf: this is a fair use case for a for loop, as we need to access the index of the entries array.
-    for (let i = 0; i < entries.length; i++) {
-      const tempResult = {
-        ...result,
-        // @ts-ignore
-        [entries[i][0]]: truncateRecursive(entries[i][1], {
-          maxStringLength: 2 * 1024,
-          maxTotalLength,
-        }),
-      };
+    // Matches what the old whole-object `JSON.stringify(tempResult).length`
+    // measured: the accumulated object *without* the truncation marker, which
+    // is why the budget below keeps the same `- 50` headroom for it.
+    let length = "{}".length;
+    let kept = 0;
 
-      if (JSON.stringify(tempResult).length <= maxTotalLength - 50) {
-        // Leave room for truncation marker
-        result = tempResult;
-      } else {
-        break;
-      }
+    for (const [key, value] of entries) {
+      const truncated = truncateRecursive(value, {
+        maxStringLength: 2 * 1024,
+        maxTotalLength,
+      });
+
+      // JSON.stringify returns undefined for undefined/function values; those
+      // keys vanish from the serialised form, so they cost nothing and must not
+      // be measured with `.length`.
+      const serializedValue = JSON.stringify(truncated);
+      const entryLength =
+        serializedValue === undefined
+          ? 0
+          : JSON.stringify(key).length +
+            ":".length +
+            serializedValue.length +
+            (kept > 0 ? ",".length : 0);
+
+      // Leave room for the truncation marker.
+      if (length + entryLength > maxTotalLength - 50) break;
+
+      result[key] = truncated;
+      length += entryLength;
+      if (entryLength > 0) kept++;
     }
 
     return {

--- a/langwatch/src/utils/truncate.ts
+++ b/langwatch/src/utils/truncate.ts
@@ -51,8 +51,6 @@ const truncateWithSizeLimit = (
     }
   }
 
-  // If still too large, start dropping keys.
-  //
   // The serialised length of an object is the sum of its entries' lengths plus
   // the separators, so we can track the running total by serialising each value
   // exactly once. Re-serialising the whole accumulated object on every key (as
@@ -74,14 +72,25 @@ const truncateWithSizeLimit = (
         maxTotalLength,
       });
 
-      // JSON.stringify returns undefined for undefined/function values; those
-      // keys vanish from the serialised form, so they cost nothing and must not
-      // be measured with `.length`.
-      const serializedValue = JSON.stringify(truncated);
+      // Serialize within the real property-key context, not standalone:
+      // `JSON.stringify(truncated)` alone always invokes a custom `toJSON()`
+      // with key `""`, so a key-sensitive `toJSON()` could measure smaller (or
+      // larger) here than it renders inside the final object, letting an
+      // oversized entry slip past `maxTotalLength`. Wrapping in `{ [key]: ... }`
+      // reproduces the exact key `JSON.stringify` will call `toJSON()` with.
+      //
+      // `JSON.stringify` drops undefined/function/symbol values from an
+      // object entirely, which is indistinguishable from key `""` here, so
+      // the wrapped form comes back as the literal string `"{}"` — those keys
+      // cost nothing and must not be measured with `.length`.
+      const quotedKey = JSON.stringify(key);
+      const wrapped = JSON.stringify({ [key]: truncated });
+      const serializedValue =
+        wrapped === "{}" ? undefined : wrapped.slice(quotedKey.length + 2, -1);
       const entryLength =
         serializedValue === undefined
           ? 0
-          : JSON.stringify(key).length +
+          : quotedKey.length +
             ":".length +
             serializedValue.length +
             (kept > 0 ? ",".length : 0);


### PR DESCRIPTION
Serialisation performance pass, driven by benchmarks rather than folklore. Three commits, reviewable independently.

## Headline: native `JSON.parse` was already optimal; `JSON.stringify` was not the bottleneck either

Benchmarked on Node 24.13.0 (prod's version) against fixtures modelled on a real `RecordSpanCommand`:

| payload | `JSON.stringify` | `msgpackr.pack` | `JSON.parse` | `msgpackr.unpack` |
|---|---|---|---|---|
| 1.5 KB | 2.3µs | 4.4µs (**1.9x slower**) | 3.1µs | 5.1µs (**1.7x slower**) |
| 5.9 KB | 5.5µs | 9.2µs (**1.7x slower**) | 5.8µs | 7.1µs (1.2x slower) |
| 80 KB | 57µs | 64µs | 32µs | 16µs (**2.0x faster**) |
| 977 KB | 771µs | 632µs | 338µs | 101µs (**3.3x faster**) |

msgpack loses outright on small and typical jobs. The reason is structural: our payloads are dominated by long UTF-8 strings (LLM prompts, completions, RAG contexts), which msgpack stores much the way JSON does — there is no structural redundancy for it to win back, while V8's JSON fast path is hard to beat on exactly that shape. After gzip, msgpack output is also marginally *larger*. `fast-json-stringify` was a wash-to-regression (0.8–1.08x): our schemas bottom out in free-form user data, so it delegates straight back to `JSON.stringify` and adds overhead.

**Compression, not serialisation, was the real cost** — gzip is ~75% of encode. zstd (built into `node:zlib` on Node 24, no new dependency) encodes ~5x faster than gzip level 6 on large bodies.

## What's in here

**`perf(routes)`** — `/api/dspy/log_steps` and legacy `log_results` each ran `JSON.stringify(body).length` purely to feed a histogram, then discarded the string: a full second serialisation of bodies capped at 20MB / 10MB. Now taken from the wire bytes. Also fixes the metric, which was reporting UTF-16 code units rather than bytes transferred.

**`perf(truncate)`** — `safeTruncate`'s key-dropping fallback re-serialised the whole accumulated object per key (O(n²)), on precisely the inputs already known to be oversized. Now linear. Existing suites pin exactly which keys survive, so this is provably behaviour-preserving.

**`perf(groupQueue)`** — drops a redundant full `JSON.stringify(jobData)` that GQ2 discarded; adds zstd and size-gated (>100KB) msgpack.

## Rollout: readers first

Decode **sniffs magic bytes** and accepts gzip/zstd and JSON/msgpack from the moment it ships. Writes stay behind `GROUP_QUEUE_ZSTD_WRITES_ENABLED` / `GROUP_QUEUE_MSGPACK_WRITES_ENABLED`. Deploy, let the fleet cycle, then flip. Already-persisted S3 blobs keep decoding with no migration and no dual-write.

Writing before reading would **not** be safe. `GroupQueue` re-stages only on `TransientBlobStoreError`; any other decode error terminates at the non-retryable fail-safe, which *completes the slot and drops the job*. An old worker meeting a new body during a rolling deploy would silently discard it. This mirrors the `GROUP_QUEUE_ENVELOPE_WRITES_ENABLED` gate built for GQ1 (ADR-026).

**The codec is folded into the content hash.** Blobs are content-addressed, so a JSON-encoded and a msgpack-encoded copy of the same payload would otherwise land on one key with *different bytes*, and the second writer would silently dedup onto the first — handing a reader a codec it wasn't expecting. Covered by a test.

## Deliberately not in here

- **superjson on tRPC** — measured, and it *is* expensive: 4.4x on encode for a realistic 25-row trace-list response (+234µs), because it recursively walks the tree hunting for `Date`s. But removing it turns every `Date` crossing tRPC into a `string` across **80 routers and 116 frontend call sites**. That belongs in its own PR, so a revert can be a revert. Worth doing next.
- **The ClickHouse "double stringify"** — investigated and it is *not* waste. The column is `Map(String, String)`, so values genuinely must be strings; the client then JSON-encoding the row is just how `JSONEachRow` works. Avoiding it means `RowBinary`, which is a bigger change with no evidence behind it yet.
- **Streaming the collector's parse** — the collector Zod-validates and splits the body, so a streaming parser would still materialise the object graph. Streaming pays on the *blob write path* (we currently hold ~3 copies of a payload at peak), which is a good follow-up.

## Testing

128 tests green across the touched areas. New `jobEnvelope.codec.unit.test.ts` covers the rollout-critical cases: a blob written by today's encoder decodes under the new reader; fan-out still collapses to one blob; small payloads stay JSON even with msgpack on; the two codecs land on distinct keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved queued event payload handling with more efficient serialization/compression (including automatic msgpack and zstd when enabled).
  * Preserved compatibility when reading previously stored event data and ensured correct decoding across storage tiers.
  * Enhanced event deduplication to avoid collisions and correctly handle fan-out reactors.
  * Request size measurements now reflect actual UTF-8 bytes received.
  * Improved truncation performance for oversized structured data while preserving truncation indicators.
* **Bug Fixes**
  * Improved handling of multibyte characters and large request bodies.
  * Maintained consistent bad-request responses for malformed JSON.
* **Tests**
  * Added unit coverage for queue body codec behavior, round-tripping, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->