### PR TITLE
feat(langy): worker shutdown-handoff + resume-on-next-worker (ADR-048)

### DIFF
--- a/dev/docs/adr/048-langy-shutdown-handoff.md
+++ b/dev/docs/adr/048-langy-shutdown-handoff.md
@@ -1,0 +1,242 @@
+# ADR-048: Langy worker shutdown-handoff — checkpoint on SIGTERM, resume on the next worker
+
+**Date:** 2026-07-11
+
+**Status:** Proposed
+
+**Builds on:** ADR-046 (event-sourced Langy conversations), ADR-047 (Langy
+foundations — hexagonal Go service), ADR-044 (event-driven worker + streaming +
+self-observability). Based on **PR3** (`feat/langy-worker-streaming`), where the
+panic-recovery (`clog.Go`/`HandlePanic`) and early-OTel-flush-on-SIGTERM
+primitives live, so this composes with them directly. Independent of the ADR-043
+egress enforcement (PR4, a sibling branch) — the handoff is egress-agnostic.
+
+## Context
+
+Langy runs each conversation on a dedicated `opencode` subprocess inside a
+single-replica `langyagent` pod (ADR-047: "SINGLE REPLICA ONLY … a turn that was
+mid-flight when the pod died is lost"). Today, when Kubernetes terminates the pod
+— a routine deploy, a node drain, an HPA-less rollout — the manager receives
+SIGTERM, the lifecycle group drains, and every worker subprocess is killed by a
+process-group signal. Any turn that was streaming at that instant is lost: the
+control plane's reconcile sweep (ADR-044 part 2) eventually terminalises it as
+`agent_turn_failed`, and the **next** turn starts the model over from a cold
+`opencode` session with none of the work the previous turn had already done.
+
+For short chat answers this is tolerable. For the long, tool-heavy turns Langy is
+being built toward (multi-step investigations, a `gh pr create` flow that has
+already cloned, branched, and edited), throwing away an in-flight turn on every
+deploy is expensive and user-visible — the user watches a half-written answer
+vanish and has to re-ask.
+
+The constraint that shapes everything here: **on SIGTERM the pod has a bounded,
+uncatchable deadline.** Kubernetes sends SIGTERM, waits
+`terminationGracePeriodSeconds` (TGP), then sends SIGKILL, which no handler can
+intercept — the same honest limit ADR-044's telemetry flush lives with. So a
+graceful handoff can only ever be *best-effort*: it narrows the loss window, it
+does not close it. A hard OOM or a TGP overrun still loses the turn and falls
+back to today's cold restart.
+
+Two more facts constrain the design:
+
+- **Only the model knows what is meaningfully complete.** The manager sees an
+  opaque ndjson token stream; it cannot decide where a resumable boundary is.
+  The checkpoint must be *worker-authored* — `opencode` (or a small MCP tool it
+  calls) writes it — which makes this a protocol between `opencode` and the
+  control plane, not just manager plumbing.
+- **The manager holds no durable state** (ADR-047: workers are in-memory,
+  `SESSIONS_ROOT` is wiped on boot). Anything that must survive the pod dying has
+  to be persisted by the control plane, on the event-sourced
+  `langy-conversation-processing` pipeline (ADR-046).
+
+## Decision
+
+We add a four-step **shutdown-handoff protocol**. On SIGTERM the manager asks
+each live worker to checkpoint; the worker authors an opaque resume token and
+emits it as a terminal ndjson frame on the in-flight turn stream; the control
+plane persists that token against the conversation as a durable event; the next
+turn threads it back to a fresh worker, which resumes instead of cold-starting.
+
+### 1. Manager: a pre-drain SIGTERM hook that notifies each worker
+
+On SIGTERM, **before** the worker pool's process-group kill, the manager POSTs
+`shutdown_imminent{ deadline }` to each live worker's `opencode` control API
+(through the per-worker authProxy, ADR-047 — the same bearer-gated path every
+control call uses). `deadline` is an absolute wall-clock instant (unix millis).
+
+This is wired as a `pkg/lifecycle` **Closer registered after the worker-pool**,
+so in the reverse-order stop sequence it runs *before* the worker-pool drain
+(which kills the process groups and tears down the authProxies). It waits,
+bounded by `deadline`, for each in-flight worker's turn to quiesce — i.e. for its
+`StreamEvents` loop to see the terminal `handoff` frame and let the still-open
+`/chat` HTTP response flush it to the control plane — and only then returns,
+handing control to the worker-pool drain.
+
+**Composition with the early-flush (PR3).** PR3's serve.go already has an
+`otel-early-flush` Closer — also a pre-drain SIGTERM step. This PR registers the
+handoff Closer *after* it, so the two coexist as sibling pre-drain Closers with
+stop order **handoff → early-flush → http → worker-pool**: the handoff starts
+first because the worker-authored checkpoint is the scarce artifact that benefits
+most from a wall-clock head start, and the early-flush (bounded, operating on
+already-buffered data) follows and also captures the handoff's own spans. Neither
+depends on the other; both must complete before the worker-pool drain. The
+notify fan-out goroutines are panic-guarded with `clog.Go` (PR3), so a panic
+mid-shutdown can't crash the process before the drain.
+
+### 2. Worker: a worker-authored, opaque resume token on a terminal frame
+
+On receiving `shutdown_imminent`, `opencode` writes a resumable checkpoint (the
+last completed step + a continue-token capturing "done so far") and emits a
+single terminal ndjson event on the turn's `/event` stream:
+
+```json
+{ "type": "handoff", "token": "<opaque base64/JSON blob>" }
+```
+
+`streamSessionEvents` treats `handoff` as a terminal event type (alongside
+`message.completed` / `session.idle` / `error`), so it forwards the frame to the
+sink and returns, ending the turn cleanly.
+
+**Token shape.** The token is **opaque to the manager and to the control plane**
+— the manager forwards it, the control plane persists it verbatim, only
+`opencode` authors and consumes it. The *recommended* shape `opencode` writes
+(documented here, enforced nowhere outside `opencode`) is:
+
+```json
+{
+  "v": 1,
+  "sessionId": "<opencode internal session id>",
+  "step": "<label of the last completed step>",
+  "continue": "<worker-authored 'done so far' continuation state>",
+  "issuedAt": 1752000000000
+}
+```
+
+Keeping it opaque is deliberate: the resumable boundary is a model concern that
+will evolve (checkpoint granularity, compression, a server-side blob ref instead
+of an inline blob) without a manager or control-plane change. The manager treats
+it as an opaque string with a sane size cap; the control plane stores it as a
+`Nullable(String)` fold column.
+
+### 3. Control plane: persist the token as a durable pipeline event
+
+The in-flight turn's `/chat` response carries the `handoff` frame back to
+`runTurn` (the control-plane spawn function, ADR-044). Instead of finalising the
+turn, `runTurn` dispatches a new command on the `langy-conversation-processing`
+pipeline (ADR-046), mirroring the existing `defineCommand` → event → fold
+pattern:
+
+- **`recordTurnHandoff` → `conversation_handoff_pending`** carries
+  `{ conversationId, turnId, token }`. Its fold handler stores the token on the
+  conversation state (`PendingHandoffToken` + `PendingHandoffTurnId`), **clears
+  `CurrentTurnId`** (the turn is no longer in flight — it handed off, it did not
+  fail), and sets `Status = idle`. Idempotency key
+  `…:handoff:<turnId>` — a retried handoff for the same turn writes one event.
+
+The token lives in the fold state (a new pair of columns on the
+`langy_conversations` ClickHouse table, migration `00043`), so it survives the
+pod dying and is readable by any future worker via the existing fold read path.
+
+### 4. Resume: thread the token to a fresh worker on the next turn, once
+
+The next `/chat` turn for that conversation resolves the conversation as usual,
+then — before dispatching `StartAgentTurn` — reads any pending handoff off the
+fold (`getPendingHandoff`). If one exists it:
+
+- threads `resumeToken` into the out-of-band spawn handoff (ADR-044's Redis
+  `LangyTurnHandoff`), so `runTurn` puts it on the manager `/chat` body; the
+  manager threads it through `spawn` → `PostMessage`, and `opencode` restores the
+  checkpoint instead of cold-starting; and
+- dispatches **`consumeTurnHandoff` → `conversation_handoff_consumed`**
+  `{ conversationId, turnId }`, whose fold handler clears
+  `PendingHandoffToken` / `PendingHandoffTurnId`. Idempotency key
+  `…:handoff-consumed:<turnId>` makes a double-consume a single durable event.
+
+If no handoff is pending, the turn is a normal cold start — exactly today's
+behaviour.
+
+### Deadline math
+
+The `deadline` sent to each worker MUST be strictly `< TGP − drainBudget`, where
+`drainBudget` is the time the worker-pool drain needs after the handoff (per-worker
+SIGINT → 2 s grace → SIGKILL, plus authProxy/egress teardown and a margin). The
+manager only knows its own `GracefulSeconds` budget, not TGP, so we enforce the
+process-local invariant and document the operator's obligation:
+
+```
+handoffDeadline + drainBudget  <  GracefulSeconds        (validated at config load)
+GracefulSeconds                <  terminationGracePeriodSeconds   (operator sizes the chart)
+⟹  handoffDeadline  <  GracefulSeconds − drainBudget  <  TGP − drainBudget   ✓
+```
+
+Config: `LANGY_SHUTDOWN_HANDOFF_DEADLINE_MS` (default 5000) and
+`LANGY_SHUTDOWN_DRAIN_BUDGET_MS` (default 3000); `LoadConfig` fails closed if
+`handoff + drain ≥ graceful`. The worker receives `deadline = now + handoffBudget`.
+
+## Rationale / Trade-offs
+
+- **Why a durable pipeline event, not a Redis key?** ADR-044 already stashes the
+  *spawn inputs* in a short-lived Redis handoff. A resume token is different: it
+  is the durable "this conversation has unfinished, resumable work" fact that
+  must outlive the pod and be replayable, so it belongs on the event log and the
+  fold, exactly like `turn_finalized`. Using the ADR-046 command→event→fold
+  machinery gets idempotency, replay-safety, and the cross-worker read for free.
+
+- **Why worker-authored + opaque?** The manager cannot know a resumable
+  boundary; the model can. Making the token opaque to both the manager and the
+  control plane means the checkpoint format can evolve entirely inside
+  `opencode` — the layer that both writes and reads it — without touching Go
+  plumbing or a ClickHouse schema. The opacity boundary is the whole point:
+  **manager forwards, control plane persists, opencode authors/consumes.**
+
+- **Why best-effort, stated honestly?** SIGKILL is uncatchable. We accept that a
+  hard OOM or a TGP overrun loses the turn and falls back to cold restart (the
+  current behaviour, ADR-047). The handoff narrows the window from "every deploy
+  loses in-flight turns" to "only an ungraceful kill does" — a large practical
+  win without pretending to a guarantee we cannot make.
+
+- **Idempotency vs. eventual consistency.** The fold is written asynchronously,
+  so a rare double-read of a pending token could thread it to two workers. We
+  accept this: the `consumeTurnHandoff` idempotency key collapses the durable
+  event to one, and `opencode`'s resume is itself idempotent (re-applying a
+  checkpoint is safe). We do not add a distributed lock for a rare, benign race.
+
+- **Alternatives rejected.** (a) *Persisting the full turn transcript* — the
+  content already lives in `langy_messages`; re-deriving a resume point from it
+  server-side re-introduces the "manager guesses the boundary" problem. (b) *A
+  second HTTP channel from worker to control plane for the token* — the in-flight
+  `/chat` stream is already open and already flows worker→manager→control-plane;
+  reusing it needs no new auth surface. (c) *Blocking the whole grace window on
+  the handoff* — capped by `deadline` so a slow/dead worker can never eat the
+  drain budget out from under the process-group kill.
+
+## Consequences
+
+- Deploys and node drains no longer discard an in-flight Langy turn when the
+  worker checkpoints in time; the next turn resumes from where it left off.
+- New durable vocabulary on `langy-conversation-processing`:
+  `conversation_handoff_pending` / `conversation_handoff_consumed` events and
+  their `recordTurnHandoff` / `consumeTurnHandoff` commands; two new fold columns
+  (`PendingHandoffToken`, `PendingHandoffTurnId`) and CH migration `00043`.
+- New manager surface: a config-driven pre-drain SIGTERM Closer (sibling to
+  PR3's early-flush), a per-worker `shutdown_imminent` POST, a `handoff` terminal
+  frame in `streamSessionEvents`, and a `resumeToken` threaded through `spawn` →
+  `PostMessage` (via the PR3 `baseURL` control-call API).
+- `opencode` gains a contract it must honour to make any of this real: accept
+  `shutdown_imminent`, author the checkpoint + `handoff` frame, and accept a
+  `resumeToken` on the next prompt. Until `opencode` implements it, the Go and TS
+  sides degrade cleanly — no `handoff` frame ⇒ the turn reconciles as it does
+  today; no `resumeToken` support ⇒ a cold start.
+- The honest limit remains: SIGKILL / OOM / a TGP shorter than
+  `graceful + handoff` still loses the turn. Operators must size
+  `terminationGracePeriodSeconds` above `GracefulSeconds`.
+
+## References
+
+- Related ADRs: ADR-046 (event-sourced Langy conversations), ADR-047 (Langy
+  foundations), ADR-044 (event-driven worker + streaming), ADR-043 (egress
+  enforcement), ADR-033 (worker network isolation).
+- Spec: `specs/langy/langy-shutdown-handoff.feature`
+- Code: `services/langyagent/` (serve.go, config.go, adapters/workerpool),
+  `langwatch/src/server/routes/langy.ts`, the `langy-conversation-processing`
+  pipeline, `langwatch/src/server/services/langy/execution/langy-turn.processor.ts`.

--- a/langwatch/src/server/app-layer/langy/__tests__/langy-conversation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-conversation.service.unit.test.ts
@@ -23,6 +23,7 @@ function makeRepo(overrides?: Partial<LangyConversationReadRepository>) {
     findById: vi.fn(),
     findAllForUser: vi.fn(),
     findActiveOwnedIds: vi.fn(),
+    findPendingHandoff: vi.fn(async () => null),
     ...overrides,
   } as unknown as LangyConversationReadRepository;
 }
@@ -33,9 +34,15 @@ function makeCommands(
   return {
     sendMessage: vi.fn(async () => {}),
     startAgentTurn: vi.fn(async () => {}),
+    recordToolCallStarted: vi.fn(async () => {}),
+    recordToolCallCompleted: vi.fn(async () => {}),
+    recordAgentResponded: vi.fn(async () => {}),
+    failAgentTurn: vi.fn(async () => {}),
     reconcileAgentTurn: vi.fn(async () => {}),
     archiveConversation: vi.fn(async () => {}),
     updateConversationMetadata: vi.fn(async () => {}),
+    recordTurnHandoff: vi.fn(async () => {}),
+    consumeTurnHandoff: vi.fn(async () => {}),
     ...overrides,
   };
 }
@@ -270,6 +277,80 @@ describe("LangyConversationService", () => {
           title: "hi",
         }),
       );
+    });
+  });
+
+  describe("given a turn checkpointed on shutdown (ADR-048 handoff)", () => {
+    describe("when the handoff token is recorded", () => {
+      it("dispatches recordTurnHandoff with the opaque token", async () => {
+        const recordTurnHandoff = vi.fn(async () => {});
+        const svc = new LangyConversationService(
+          makeRepo(),
+          makeCommands({ recordTurnHandoff }),
+        );
+
+        await svc.recordTurnHandoff({
+          projectId: "p1",
+          conversationId: "c1",
+          turnId: "t1",
+          token: "opaque-resume-token",
+        });
+
+        expect(recordTurnHandoff).toHaveBeenCalledTimes(1);
+        expect(recordTurnHandoff).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId: "p1",
+            conversationId: "c1",
+            turnId: "t1",
+            token: "opaque-resume-token",
+          }),
+        );
+      });
+    });
+
+    describe("when the next turn reads the pending handoff", () => {
+      it("returns the token and turn threaded off the fold, then round-trips to consume", async () => {
+        const findPendingHandoff = vi.fn(async () => ({
+          token: "opaque-resume-token",
+          turnId: "t1",
+        }));
+        const consumeTurnHandoff = vi.fn(async () => {});
+        const svc = new LangyConversationService(
+          makeRepo({ findPendingHandoff }),
+          makeCommands({ consumeTurnHandoff }),
+        );
+
+        const pending = await svc.getPendingHandoff({
+          projectId: "p1",
+          conversationId: "c1",
+        });
+        expect(pending).toEqual({ token: "opaque-resume-token", turnId: "t1" });
+
+        // Resume consumes the handoff, keyed on the handed-off turn.
+        await svc.consumeHandoff({
+          projectId: "p1",
+          conversationId: "c1",
+          turnId: pending!.turnId,
+        });
+        expect(consumeTurnHandoff).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId: "p1",
+            conversationId: "c1",
+            turnId: "t1",
+          }),
+        );
+      });
+    });
+
+    describe("when there is no pending handoff", () => {
+      it("returns null so the next turn cold-starts", async () => {
+        const svc = new LangyConversationService(makeRepo(), makeCommands());
+        const pending = await svc.getPendingHandoff({
+          projectId: "p1",
+          conversationId: "c1",
+        });
+        expect(pending).toBeNull();
+      });
     });
   });
 });

--- a/langwatch/src/server/app-layer/langy/langy-conversation.service.ts
+++ b/langwatch/src/server/app-layer/langy/langy-conversation.service.ts
@@ -8,6 +8,8 @@ import type {
   LangyAgentRespondedEventData,
   LangyAgentTurnFailedEventData,
   LangyConversationArchivedEventData,
+  LangyConversationHandoffConsumedEventData,
+  LangyConversationHandoffPendingEventData,
   LangyConversationMetadataUpdatedEventData,
   LangyAgentTurnStartedEventData,
   LangyMessagePart,
@@ -210,6 +212,45 @@ export class LangyConversationReadRepository {
     const rows = await result.json<{ ConversationId: string }>();
     return rows.map((r) => r.ConversationId);
   }
+
+  /**
+   * The pending shutdown-handoff token for a conversation, or null when there
+   * is nothing to resume (ADR-048). Point lookup on the (TenantId,
+   * ConversationId) sort key, latest-version via argMax — never FINAL. The token
+   * is opaque here; the caller threads it to a fresh worker and consumes it.
+   */
+  async findPendingHandoff({
+    projectId,
+    conversationId,
+  }: {
+    projectId: string;
+    conversationId: string;
+  }): Promise<{ token: string; turnId: string } | null> {
+    const client = await this.resolver(projectId);
+    const result = await client.query({
+      query: `
+        SELECT
+          argMax(PendingHandoffToken, UpdatedAt) AS PendingHandoffToken,
+          argMax(PendingHandoffTurnId, UpdatedAt) AS PendingHandoffTurnId
+        FROM ${TABLE_NAME}
+        WHERE TenantId = {tenantId:String}
+          AND ConversationId = {conversationId:String}
+        GROUP BY ConversationId
+        HAVING ${LATEST_ARCHIVED_MS} = 0
+      `,
+      query_params: { tenantId: projectId, conversationId },
+      format: "JSONEachRow",
+    });
+    const rows = await result.json<{
+      PendingHandoffToken: string | null;
+      PendingHandoffTurnId: string | null;
+    }>();
+    const row = rows[0];
+    if (!row || !row.PendingHandoffToken || !row.PendingHandoffTurnId) {
+      return null;
+    }
+    return { token: row.PendingHandoffToken, turnId: row.PendingHandoffTurnId };
+  }
 }
 
 /** Command dispatchers injected from the event-sourcing pipeline registry. */
@@ -225,6 +266,8 @@ export interface LangyConversationCommands {
   reconcileAgentTurn: Dispatch<LangyTurnFinalizedEventData>;
   archiveConversation: Dispatch<LangyConversationArchivedEventData>;
   updateConversationMetadata: Dispatch<LangyConversationMetadataUpdatedEventData>;
+  recordTurnHandoff: Dispatch<LangyConversationHandoffPendingEventData>;
+  consumeTurnHandoff: Dispatch<LangyConversationHandoffConsumedEventData>;
 }
 
 function newConversationId(): string {
@@ -483,6 +526,68 @@ export class LangyConversationService {
       conversationId,
       turnId,
       error,
+    });
+  }
+
+  /**
+   * The pending shutdown-handoff for a conversation, or null (ADR-048). Read
+   * from the fold; the token is opaque to the control plane.
+   */
+  async getPendingHandoff({
+    projectId,
+    conversationId,
+  }: {
+    projectId: string;
+    conversationId: string;
+  }): Promise<{ token: string; turnId: string } | null> {
+    return this.repository.findPendingHandoff({ projectId, conversationId });
+  }
+
+  /**
+   * Persist an opaque, worker-authored resume token a turn left when it
+   * checkpointed on pod termination (ADR-048): `conversation_handoff_pending`.
+   * Clears the fold's CurrentTurnId (the turn handed off, it did not fail) and
+   * stores the token for the next turn to resume from.
+   */
+  async recordTurnHandoff({
+    projectId,
+    conversationId,
+    turnId,
+    token,
+  }: {
+    projectId: string;
+    conversationId: string;
+    turnId: string;
+    token: string;
+  }): Promise<void> {
+    await this.commands.recordTurnHandoff({
+      tenantId: projectId,
+      occurredAt: Date.now(),
+      conversationId,
+      turnId,
+      token,
+    });
+  }
+
+  /**
+   * Clear a pending handoff once the next turn has threaded it to a fresh
+   * worker (ADR-048): `conversation_handoff_consumed`. Idempotent on the turn,
+   * so a double-consume collapses to one durable event.
+   */
+  async consumeHandoff({
+    projectId,
+    conversationId,
+    turnId,
+  }: {
+    projectId: string;
+    conversationId: string;
+    turnId: string;
+  }): Promise<void> {
+    await this.commands.consumeTurnHandoff({
+      tenantId: projectId,
+      occurredAt: Date.now(),
+      conversationId,
+      turnId,
     });
   }
 

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -1074,6 +1074,8 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
           reconcileAgentTurn: noop,
           archiveConversation: noop,
           updateConversationMetadata: noop,
+          recordTurnHandoff: noop,
+          consumeTurnHandoff: noop,
         },
         async () => {
           throw new Error("ClickHouse not available in test app");
@@ -1158,6 +1160,8 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
         reconcileAgentTurn: noop,
         archiveConversation: noop,
         updateConversationMetadata: noop,
+        recordTurnHandoff: noop,
+        consumeTurnHandoff: noop,
       } as AppCommands["langy"],
       billing: {
         reportUsageForMonth: noop,

--- a/langwatch/src/server/clickhouse/migrations/00043_add_langy_conversation_handoff.sql
+++ b/langwatch/src/server/clickhouse/migrations/00043_add_langy_conversation_handoff.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ADR-048 shutdown-handoff: two columns on the langy_conversations fold table
+-- carrying the opaque, worker-authored resume token a turn leaves when it
+-- checkpoints on pod termination, and the turn it belongs to (idempotent
+-- consume). Both NULL for a conversation with nothing to resume — the common
+-- case. The token is opaque to the platform: stored verbatim, only opencode
+-- authors and reads it (the manager forwards it, the control plane persists it).
+--
+-- ReplacingMergeTree(UpdatedAt) fold semantics are unchanged; these are just two
+-- more latest-version columns the fold projection writes.
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.langy_conversations
+    ADD COLUMN IF NOT EXISTS PendingHandoffToken Nullable(String) CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.langy_conversations
+    ADD COLUMN IF NOT EXISTS PendingHandoffTurnId Nullable(String) CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF
+
+-- +goose Down
+-- +goose ENVSUB ON
+
+-- Down migration is intentionally commented out to prevent accidental data loss.
+-- To roll back, uncomment below and run manually.
+
+-- +goose StatementBegin
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.langy_conversations DROP COLUMN IF EXISTS PendingHandoffToken;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.langy_conversations DROP COLUMN IF EXISTS PendingHandoffTurnId;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF

--- a/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/commands.ts
@@ -8,6 +8,8 @@ import {
   langyAgentRespondedEventDataSchema,
   langyAgentTurnFailedEventDataSchema,
   langyConversationArchivedEventDataSchema,
+  langyConversationHandoffConsumedEventDataSchema,
+  langyConversationHandoffPendingEventDataSchema,
   langyConversationMetadataUpdatedEventDataSchema,
   langyAgentTurnStartedEventDataSchema,
   langyMessageSentEventDataSchema,
@@ -193,4 +195,48 @@ export const UpdateConversationMetadataCommand = defineCommand({
   }),
   makeJobId: (d) =>
     `${d.tenantId}:${d.conversationId}:metadata:${d.occurredAt}`,
+});
+
+/**
+ * RecordTurnHandoff → conversation_handoff_pending (ADR-048). Persists the
+ * opaque, worker-authored resume token for a turn that checkpointed on pod
+ * termination. Idempotency keyed on the turn so a retried handoff writes one
+ * event.
+ */
+export const RecordTurnHandoffCommand = defineCommand({
+  commandType: LANGY_CONVERSATION_COMMAND_TYPES.RECORD_TURN_HANDOFF,
+  eventType: LANGY_CONVERSATION_EVENT_TYPES.CONVERSATION_HANDOFF_PENDING,
+  eventVersion: LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_PENDING,
+  aggregateType: "langy_conversation",
+  schema: langyConversationHandoffPendingEventDataSchema,
+  aggregateId: (d) => d.conversationId,
+  idempotencyKey: (d) =>
+    `${d.tenantId}:${d.conversationId}:handoff:${d.turnId}`,
+  spanAttributes: (d) => ({
+    "payload.conversation.id": d.conversationId,
+    "payload.turn.id": d.turnId,
+  }),
+  makeJobId: (d) => `${d.tenantId}:${d.conversationId}:handoff:${d.turnId}`,
+});
+
+/**
+ * ConsumeTurnHandoff → conversation_handoff_consumed (ADR-048). Clears the
+ * pending token once the next turn has threaded it to a fresh worker.
+ * Idempotency keyed on the turn so a double-consume collapses to one event.
+ */
+export const ConsumeTurnHandoffCommand = defineCommand({
+  commandType: LANGY_CONVERSATION_COMMAND_TYPES.CONSUME_TURN_HANDOFF,
+  eventType: LANGY_CONVERSATION_EVENT_TYPES.CONVERSATION_HANDOFF_CONSUMED,
+  eventVersion: LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_CONSUMED,
+  aggregateType: "langy_conversation",
+  schema: langyConversationHandoffConsumedEventDataSchema,
+  aggregateId: (d) => d.conversationId,
+  idempotencyKey: (d) =>
+    `${d.tenantId}:${d.conversationId}:handoff-consumed:${d.turnId}`,
+  spanAttributes: (d) => ({
+    "payload.conversation.id": d.conversationId,
+    "payload.turn.id": d.turnId,
+  }),
+  makeJobId: (d) =>
+    `${d.tenantId}:${d.conversationId}:handoff-consumed:${d.turnId}`,
 });

--- a/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/index.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/index.ts
@@ -3,10 +3,12 @@ export type { LangyConversationProcessingPipelineDeps } from "./pipeline";
 
 export {
   ArchiveConversationCommand,
+  ConsumeTurnHandoffCommand,
   FailAgentTurnCommand,
   RecordAgentRespondedCommand,
   RecordToolCallCompletedCommand,
   RecordToolCallStartedCommand,
+  RecordTurnHandoffCommand,
   ReconcileAgentTurnCommand,
   SendMessageCommand,
   StartAgentTurnCommand,

--- a/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/pipeline.ts
@@ -4,10 +4,12 @@ import type { AppendStore } from "../../projections/mapProjection.types";
 import type { ReactorDefinition } from "../../reactors/reactor.types";
 import {
   ArchiveConversationCommand,
+  ConsumeTurnHandoffCommand,
   FailAgentTurnCommand,
   RecordAgentRespondedCommand,
   RecordToolCallCompletedCommand,
   RecordToolCallStartedCommand,
+  RecordTurnHandoffCommand,
   ReconcileAgentTurnCommand,
   SendMessageCommand,
   StartAgentTurnCommand,
@@ -118,5 +120,7 @@ export function createLangyConversationProcessingPipeline(
     .withCommand("reconcileAgentTurn", ReconcileAgentTurnCommand)
     .withCommand("archiveConversation", ArchiveConversationCommand)
     .withCommand("updateConversationMetadata", UpdateConversationMetadataCommand)
+    .withCommand("recordTurnHandoff", RecordTurnHandoffCommand)
+    .withCommand("consumeTurnHandoff", ConsumeTurnHandoffCommand)
     .build();
 }

--- a/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/projections/__tests__/langyConversationState.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/projections/__tests__/langyConversationState.foldProjection.unit.test.ts
@@ -226,4 +226,77 @@ describe("LangyConversationStateFoldProjection", () => {
       expect(state).not.toHaveProperty("LastHeartbeatAt");
     });
   });
+
+  describe("given an agent turn in progress that hands off on shutdown (ADR-048)", () => {
+    const started = fold.apply(
+      fold.apply(fold.init(), messageSent({}, 1000)),
+      event(
+        "AGENT_TURN_STARTED",
+        LANGY_CONVERSATION_EVENT_VERSIONS.AGENT_TURN_STARTED,
+        { turnId: "turn-1" },
+        1500,
+      ),
+    );
+
+    const handedOff = fold.apply(
+      started,
+      event(
+        "CONVERSATION_HANDOFF_PENDING",
+        LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_PENDING,
+        { turnId: "turn-1", token: "opaque-resume-token" },
+        1800,
+      ),
+    );
+
+    describe("when the turn checkpoints and hands off", () => {
+      it("stores the pending token, clears the in-flight turn, and returns to idle", () => {
+        expect(handedOff.PendingHandoffToken).toBe("opaque-resume-token");
+        expect(handedOff.PendingHandoffTurnId).toBe("turn-1");
+        expect(handedOff.CurrentTurnId).toBeNull();
+        expect(handedOff.Status).toBe(LANGY_CONVERSATION_STATUS.IDLE);
+      });
+
+      it("does not record the turn as failed (a handoff is not a failure)", () => {
+        expect(handedOff.Status).not.toBe(LANGY_CONVERSATION_STATUS.FAILED);
+        expect(handedOff.LastError).toBeNull();
+      });
+    });
+
+    describe("when the next turn consumes the pending handoff", () => {
+      const consumed = fold.apply(
+        handedOff,
+        event(
+          "CONVERSATION_HANDOFF_CONSUMED",
+          LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_CONSUMED,
+          { turnId: "turn-1" },
+          2000,
+        ),
+      );
+
+      it("clears the pending token", () => {
+        expect(consumed.PendingHandoffToken).toBeNull();
+        expect(consumed.PendingHandoffTurnId).toBeNull();
+      });
+
+      it("consuming again is a no-op on an already-cleared fold (idempotent)", () => {
+        const consumedTwice = fold.apply(
+          consumed,
+          event(
+            "CONVERSATION_HANDOFF_CONSUMED",
+            LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_CONSUMED,
+            { turnId: "turn-1" },
+            2100,
+          ),
+        );
+        expect(consumedTwice.PendingHandoffToken).toBeNull();
+        expect(consumedTwice.PendingHandoffTurnId).toBeNull();
+      });
+    });
+
+    it("a fresh conversation has no pending handoff", () => {
+      const init = fold.init();
+      expect(init.PendingHandoffToken).toBeNull();
+      expect(init.PendingHandoffTurnId).toBeNull();
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/projections/langyConversationState.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/projections/langyConversationState.foldProjection.ts
@@ -14,6 +14,8 @@ import type {
   LangyAgentTurnFailedEvent,
   LangyAgentTurnStartedEvent,
   LangyConversationArchivedEvent,
+  LangyConversationHandoffConsumedEvent,
+  LangyConversationHandoffPendingEvent,
   LangyConversationMetadataUpdatedEvent,
   LangyMessageSentEvent,
   LangyToolCallCompletedEvent,
@@ -26,6 +28,8 @@ import {
   LangyAgentTurnFailedEventSchema,
   LangyAgentTurnStartedEventSchema,
   LangyConversationArchivedEventSchema,
+  LangyConversationHandoffConsumedEventSchema,
+  LangyConversationHandoffPendingEventSchema,
   LangyConversationMetadataUpdatedEventSchema,
   LangyMessageSentEventSchema,
   LangyToolCallCompletedEventSchema,
@@ -63,6 +67,15 @@ export interface LangyConversationStateData {
    */
   CurrentTurnId: string | null;
   LastError: string | null;
+  /**
+   * ADR-048 shutdown-handoff. When a turn checkpoints on pod termination it
+   * leaves an opaque, worker-authored resume token here; the next turn threads
+   * it to a fresh worker and clears it. Null when there is nothing to resume.
+   * The token is opaque to the pipeline — stored verbatim, only opencode reads
+   * it. PendingHandoffTurnId is the turn that handed off (idempotent consume).
+   */
+  PendingHandoffToken: string | null;
+  PendingHandoffTurnId: string | null;
   ArchivedAt: number | null;
   CreatedAt: number;
   UpdatedAt: number;
@@ -85,6 +98,8 @@ const langyConversationEvents = [
   LangyTurnFinalizedEventSchema,
   LangyConversationArchivedEventSchema,
   LangyConversationMetadataUpdatedEventSchema,
+  LangyConversationHandoffPendingEventSchema,
+  LangyConversationHandoffConsumedEventSchema,
 ] as const;
 
 /**
@@ -132,6 +147,8 @@ export class LangyConversationStateFoldProjection
       LastActivityAt: null,
       CurrentTurnId: null,
       LastError: null,
+      PendingHandoffToken: null,
+      PendingHandoffTurnId: null,
       ArchivedAt: null,
     };
   }
@@ -298,5 +315,39 @@ export class LangyConversationStateFoldProjection
         : null;
     }
     return next;
+  }
+
+  // ADR-048: a turn checkpointed on shutdown. Store the opaque resume token and
+  // the turn it belongs to, CLEAR CurrentTurnId (the turn handed off — it did
+  // not fail), and return the conversation to idle so the next message can pick
+  // the token up. Never un-archives (nextStatus guards it).
+  handleLangyConversationConversationHandoffPending(
+    event: LangyConversationHandoffPendingEvent,
+    state: LangyConversationStateData,
+  ): LangyConversationStateData {
+    return {
+      ...state,
+      ConversationId: state.ConversationId || event.data.conversationId,
+      Status: this.nextStatus(state, LANGY_CONVERSATION_STATUS.IDLE),
+      CurrentTurnId: null,
+      PendingHandoffToken: event.data.token,
+      PendingHandoffTurnId: event.data.turnId,
+      LastActivityAt: event.occurredAt,
+    };
+  }
+
+  // ADR-048: the next turn threaded the pending token to a fresh worker. Clear
+  // it so it is consumed exactly once. Idempotent on the command, so replaying
+  // this is a no-op on an already-cleared fold.
+  handleLangyConversationConversationHandoffConsumed(
+    event: LangyConversationHandoffConsumedEvent,
+    state: LangyConversationStateData,
+  ): LangyConversationStateData {
+    return {
+      ...state,
+      ConversationId: state.ConversationId || event.data.conversationId,
+      PendingHandoffToken: null,
+      PendingHandoffTurnId: null,
+    };
   }
 }

--- a/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/repositories/langyConversationState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/repositories/langyConversationState.clickhouse.repository.ts
@@ -40,6 +40,8 @@ interface ClickHouseLangyConversationRecord {
   LastActivityAt: number | null;
   CurrentTurnId: string | null;
   LastError: string | null;
+  PendingHandoffToken: string | null;
+  PendingHandoffTurnId: string | null;
   CreatedAt: number;
   UpdatedAt: number;
   ArchivedAt: number | null;
@@ -62,6 +64,8 @@ interface ClickHouseLangyConversationWriteRecord {
   LastActivityAt: Date | null;
   CurrentTurnId: string | null;
   LastError: string | null;
+  PendingHandoffToken: string | null;
+  PendingHandoffTurnId: string | null;
   CreatedAt: Date;
   UpdatedAt: Date;
   ArchivedAt: Date | null;
@@ -90,6 +94,8 @@ export class LangyConversationStateRepositoryClickHouse<
         record.LastActivityAt === null ? null : Number(record.LastActivityAt),
       CurrentTurnId: record.CurrentTurnId,
       LastError: record.LastError,
+      PendingHandoffToken: record.PendingHandoffToken,
+      PendingHandoffTurnId: record.PendingHandoffTurnId,
       ArchivedAt: record.ArchivedAt === null ? null : Number(record.ArchivedAt),
       CreatedAt: Number(record.CreatedAt),
       UpdatedAt: Number(record.UpdatedAt),
@@ -120,6 +126,8 @@ export class LangyConversationStateRepositoryClickHouse<
         data.LastActivityAt != null ? new Date(data.LastActivityAt) : null,
       CurrentTurnId: data.CurrentTurnId,
       LastError: data.LastError,
+      PendingHandoffToken: data.PendingHandoffToken,
+      PendingHandoffTurnId: data.PendingHandoffTurnId,
       CreatedAt: data.CreatedAt != null ? new Date(data.CreatedAt) : new Date(),
       UpdatedAt: new Date(data.UpdatedAt),
       ArchivedAt: data.ArchivedAt != null ? new Date(data.ArchivedAt) : null,
@@ -159,6 +167,8 @@ export class LangyConversationStateRepositoryClickHouse<
             t.MessageCount AS MessageCount,
             if(t.LastActivityAt IS NOT NULL, toUnixTimestamp64Milli(t.LastActivityAt), NULL) AS LastActivityAt,
             t.CurrentTurnId AS CurrentTurnId, t.LastError AS LastError,
+            t.PendingHandoffToken AS PendingHandoffToken,
+            t.PendingHandoffTurnId AS PendingHandoffTurnId,
             toUnixTimestamp64Milli(t.CreatedAt) AS CreatedAt,
             toUnixTimestamp64Milli(t.UpdatedAt) AS UpdatedAt,
             if(t.ArchivedAt IS NOT NULL, toUnixTimestamp64Milli(t.ArchivedAt), NULL) AS ArchivedAt,

--- a/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/schemas/constants.ts
@@ -25,6 +25,12 @@ export const LANGY_CONVERSATION_EVENT_TYPES = {
   // Beyond the prescribed vocabulary — preserves the PATCH rename/share route.
   // See ADR-046 open question 1.
   METADATA_UPDATED: "lw.langy_conversation.conversation_metadata_updated",
+  // ADR-048 shutdown-handoff: a turn checkpointed on pod termination and left an
+  // opaque, worker-authored resume token for the next turn to pick up
+  // (CONVERSATION_HANDOFF_PENDING); the next turn threaded it to a fresh worker
+  // and cleared it (CONVERSATION_HANDOFF_CONSUMED).
+  CONVERSATION_HANDOFF_PENDING: "lw.langy_conversation.conversation_handoff_pending",
+  CONVERSATION_HANDOFF_CONSUMED: "lw.langy_conversation.conversation_handoff_consumed",
 } as const;
 
 export const LANGY_CONVERSATION_PROCESSING_EVENT_TYPES = [
@@ -38,6 +44,8 @@ export const LANGY_CONVERSATION_PROCESSING_EVENT_TYPES = [
   LANGY_CONVERSATION_EVENT_TYPES.TURN_FINALIZED,
   LANGY_CONVERSATION_EVENT_TYPES.ARCHIVED,
   LANGY_CONVERSATION_EVENT_TYPES.METADATA_UPDATED,
+  LANGY_CONVERSATION_EVENT_TYPES.CONVERSATION_HANDOFF_PENDING,
+  LANGY_CONVERSATION_EVENT_TYPES.CONVERSATION_HANDOFF_CONSUMED,
 ] as const;
 
 export type LangyConversationProcessingEventType =
@@ -88,6 +96,9 @@ export const LANGY_CONVERSATION_COMMAND_TYPES = {
   RECONCILE_AGENT_TURN: "lw.langy_conversation.reconcile_agent_turn",
   ARCHIVE: "lw.langy_conversation.archive_conversation",
   UPDATE_METADATA: "lw.langy_conversation.update_metadata",
+  // ADR-048 shutdown-handoff write surface.
+  RECORD_TURN_HANDOFF: "lw.langy_conversation.record_turn_handoff",
+  CONSUME_TURN_HANDOFF: "lw.langy_conversation.consume_turn_handoff",
 } as const;
 
 export const LANGY_CONVERSATION_PROCESSING_COMMAND_TYPES = [
@@ -100,6 +111,8 @@ export const LANGY_CONVERSATION_PROCESSING_COMMAND_TYPES = [
   LANGY_CONVERSATION_COMMAND_TYPES.RECONCILE_AGENT_TURN,
   LANGY_CONVERSATION_COMMAND_TYPES.ARCHIVE,
   LANGY_CONVERSATION_COMMAND_TYPES.UPDATE_METADATA,
+  LANGY_CONVERSATION_COMMAND_TYPES.RECORD_TURN_HANDOFF,
+  LANGY_CONVERSATION_COMMAND_TYPES.CONSUME_TURN_HANDOFF,
 ] as const;
 
 export type LangyConversationProcessingCommandType =
@@ -133,6 +146,8 @@ export const LANGY_CONVERSATION_EVENT_VERSIONS = {
   TURN_FINALIZED: "2026-07-10",
   ARCHIVED: "2026-07-10",
   METADATA_UPDATED: "2026-07-10",
+  CONVERSATION_HANDOFF_PENDING: "2026-07-11",
+  CONVERSATION_HANDOFF_CONSUMED: "2026-07-11",
 } as const;
 
 /**

--- a/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/schemas/events.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/schemas/events.ts
@@ -241,6 +241,58 @@ export type LangyConversationMetadataUpdatedEvent = z.infer<
 >;
 
 /**
+ * ConversationHandoffPending (ADR-048) — a turn checkpointed on pod termination
+ * and left an opaque, worker-authored resume token. The fold stores the token
+ * (PendingHandoffToken/PendingHandoffTurnId), clears CurrentTurnId (the turn
+ * handed off, it did not fail), and returns the conversation to idle. The token
+ * is OPAQUE to the pipeline — persisted verbatim, only opencode authors and
+ * consumes it.
+ */
+export const langyConversationHandoffPendingEventDataSchema = z.object({
+  conversationId: z.string(),
+  turnId: z.string(),
+  token: z.string(),
+});
+export type LangyConversationHandoffPendingEventData = z.infer<
+  typeof langyConversationHandoffPendingEventDataSchema
+>;
+
+export const LangyConversationHandoffPendingEventSchema = EventSchema.extend({
+  type: z.literal(LANGY_CONVERSATION_EVENT_TYPES.CONVERSATION_HANDOFF_PENDING),
+  version: z.literal(
+    LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_PENDING,
+  ),
+  data: langyConversationHandoffPendingEventDataSchema,
+});
+export type LangyConversationHandoffPendingEvent = z.infer<
+  typeof LangyConversationHandoffPendingEventSchema
+>;
+
+/**
+ * ConversationHandoffConsumed (ADR-048) — the next turn threaded the pending
+ * resume token to a fresh worker and cleared it from the fold. Idempotency on
+ * the command collapses a double-consume to a single event.
+ */
+export const langyConversationHandoffConsumedEventDataSchema = z.object({
+  conversationId: z.string(),
+  turnId: z.string(),
+});
+export type LangyConversationHandoffConsumedEventData = z.infer<
+  typeof langyConversationHandoffConsumedEventDataSchema
+>;
+
+export const LangyConversationHandoffConsumedEventSchema = EventSchema.extend({
+  type: z.literal(LANGY_CONVERSATION_EVENT_TYPES.CONVERSATION_HANDOFF_CONSUMED),
+  version: z.literal(
+    LANGY_CONVERSATION_EVENT_VERSIONS.CONVERSATION_HANDOFF_CONSUMED,
+  ),
+  data: langyConversationHandoffConsumedEventDataSchema,
+});
+export type LangyConversationHandoffConsumedEvent = z.infer<
+  typeof LangyConversationHandoffConsumedEventSchema
+>;
+
+/**
  * Union of all langy-conversation-processing event types.
  */
 export type LangyConversationProcessingEvent =
@@ -253,7 +305,9 @@ export type LangyConversationProcessingEvent =
   | LangyAgentTurnFailedEvent
   | LangyTurnFinalizedEvent
   | LangyConversationArchivedEvent
-  | LangyConversationMetadataUpdatedEvent;
+  | LangyConversationMetadataUpdatedEvent
+  | LangyConversationHandoffPendingEvent
+  | LangyConversationHandoffConsumedEvent;
 
 export {
   isLangyMessageSentEvent,
@@ -266,4 +320,6 @@ export {
   isLangyTurnFinalizedEvent,
   isLangyConversationArchivedEvent,
   isLangyConversationMetadataUpdatedEvent,
+  isLangyConversationHandoffPendingEvent,
+  isLangyConversationHandoffConsumedEvent,
 } from "./typeGuards";

--- a/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/schemas/typeGuards.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/langy-conversation-processing/schemas/typeGuards.ts
@@ -7,6 +7,8 @@ import type {
   LangyConversationArchivedEvent,
   LangyConversationMetadataUpdatedEvent,
   LangyConversationProcessingEvent,
+  LangyConversationHandoffPendingEvent,
+  LangyConversationHandoffConsumedEvent,
   LangyMessageSentEvent,
   LangyToolCallCompletedEvent,
   LangyToolCallStartedEvent,
@@ -71,4 +73,20 @@ export function isLangyConversationMetadataUpdatedEvent(
   event: LangyConversationProcessingEvent,
 ): event is LangyConversationMetadataUpdatedEvent {
   return event.type === LANGY_CONVERSATION_EVENT_TYPES.METADATA_UPDATED;
+}
+
+export function isLangyConversationHandoffPendingEvent(
+  event: LangyConversationProcessingEvent,
+): event is LangyConversationHandoffPendingEvent {
+  return (
+    event.type === LANGY_CONVERSATION_EVENT_TYPES.CONVERSATION_HANDOFF_PENDING
+  );
+}
+
+export function isLangyConversationHandoffConsumedEvent(
+  event: LangyConversationProcessingEvent,
+): event is LangyConversationHandoffConsumedEvent {
+  return (
+    event.type === LANGY_CONVERSATION_EVENT_TYPES.CONVERSATION_HANDOFF_CONSUMED
+  );
 }

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -495,6 +495,25 @@ langyRoute().post("/langy/chat", async (c) => {
     ? `${langyOverride}\n\n${capReachedNote}`
     : langyOverride;
 
+  // ADR-048 resume-on-next-worker: if a prior turn checkpointed on pod shutdown,
+  // it left an opaque, worker-authored resume token on the conversation fold.
+  // Thread it to the fresh worker so it continues from the checkpoint instead of
+  // cold-starting, then consume it once the turn has started (below). The token
+  // is opaque to the control plane — read, forwarded, never interpreted. A read
+  // failure degrades to a cold start; it must never block a new turn.
+  let pendingHandoff: { token: string; turnId: string } | null = null;
+  try {
+    pendingHandoff = await conversationService.getPendingHandoff({
+      projectId,
+      conversationId: conversation.id,
+    });
+  } catch (error) {
+    logger.warn(
+      { error, conversationId: conversation.id },
+      "failed to read pending langy handoff — cold-starting",
+    );
+  }
+
   const handoffStore = createLangyTurnHandoffStore({ redis: connection });
   await handoffStore.stash({
     projectId,
@@ -506,6 +525,7 @@ langyRoute().post("/langy/chat", async (c) => {
     ...(modelOverride ? { modelOverride } : {}),
     credentials,
     permitReserved: permit.reserved,
+    ...(pendingHandoff ? { resumeToken: pendingHandoff.token } : {}),
   });
 
   try {
@@ -518,6 +538,26 @@ langyRoute().post("/langy/chat", async (c) => {
     await releaseReservedPermit();
     logger.error({ error }, "failed to dispatch langy StartAgentTurn");
     return c.json({ error: "Agent request failed" }, { status: 502 });
+  }
+
+  // ADR-048: the resume token is now threaded to the new worker — clear it so it
+  // is consumed exactly once. Keyed on the handed-off turn (idempotent), so a
+  // rare double-read collapses to one durable event. Best-effort: a failure
+  // leaves the token pending for the next turn to re-consume (still idempotent),
+  // and opencode's resume is itself idempotent, so at worst it is applied twice.
+  if (pendingHandoff) {
+    await conversationService
+      .consumeHandoff({
+        projectId,
+        conversationId: conversation.id,
+        turnId: pendingHandoff.turnId,
+      })
+      .catch((error) =>
+        logger.warn(
+          { error, conversationId: conversation.id },
+          "failed to consume langy handoff",
+        ),
+      );
   }
 
   // Attach to the turn's live token stream (tail + follow). Same read path a

--- a/langwatch/src/server/services/langy/execution/__tests__/langy-turn.processor.unit.test.ts
+++ b/langwatch/src/server/services/langy/execution/__tests__/langy-turn.processor.unit.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+import { runTurn, type RunTurnDeps } from "../langy-turn.processor";
+import type { LangyTurnJobData } from "../langy-worker-pool";
+
+/**
+ * ADR-048: when the manager streams a terminal `handoff` frame, runTurn must
+ * persist the opaque resume token (recordTurnHandoff) instead of finalizing,
+ * and it must thread a pending resume token onto the manager /chat body.
+ */
+
+function ndjsonResponse(lines: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(line + "\n"));
+      controller.close();
+    },
+  });
+  return { ok: true, body: stream } as unknown as Response;
+}
+
+function makeBuffer() {
+  return {
+    heartbeat: vi.fn(async () => {}),
+    appendChunk: vi.fn(async () => {}),
+    appendMilestone: vi.fn(async () => {}),
+    markEnd: vi.fn(async () => {}),
+    markError: vi.fn(async () => {}),
+    flush: vi.fn(async () => {}),
+  };
+}
+
+function makeConversations() {
+  return {
+    recordTurnHandoff: vi.fn(async () => {}),
+    finalizeTurn: vi.fn(async () => ({ messageId: "m" })),
+    failTurn: vi.fn(async () => {}),
+    recordToolCallCompleted: vi.fn(async () => {}),
+  };
+}
+
+function job(overrides?: Partial<LangyTurnJobData>): LangyTurnJobData {
+  return {
+    projectId: "p1",
+    conversationId: "c1",
+    turnId: "t1",
+    actorUserId: "alice",
+    prompt: "hi",
+    system: "sys",
+    permitReserved: false,
+    credentials: {} as LangyTurnJobData["credentials"],
+    ...overrides,
+  } as LangyTurnJobData;
+}
+
+function deps(overrides: Partial<RunTurnDeps>): RunTurnDeps {
+  return {
+    conversations: makeConversations() as unknown as RunTurnDeps["conversations"],
+    ephemeral: { publish: vi.fn(async () => {}) } as unknown as RunTurnDeps["ephemeral"],
+    buffer: makeBuffer() as unknown as RunTurnDeps["buffer"],
+    agentUrl: "http://manager",
+    internalSecret: "secret",
+    ...overrides,
+  } as RunTurnDeps;
+}
+
+describe("runTurn (ADR-048 shutdown-handoff)", () => {
+  describe("given the manager streams a terminal handoff frame", () => {
+    it("persists the resume token and does not finalize the turn", async () => {
+      const conversations = makeConversations();
+      const fetchImpl = vi.fn(async () =>
+        ndjsonResponse([
+          '{"type":"message.part.delta","properties":{"field":"text","delta":"partial answer"}}',
+          '{"type":"handoff","token":"opaque-resume-token"}',
+        ]),
+      ) as unknown as typeof fetch;
+
+      await runTurn(
+        job(),
+        deps({
+          conversations: conversations as unknown as RunTurnDeps["conversations"],
+          fetchImpl,
+        }),
+      );
+
+      expect(conversations.recordTurnHandoff).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "p1",
+          conversationId: "c1",
+          turnId: "t1",
+          token: "opaque-resume-token",
+        }),
+      );
+      expect(conversations.finalizeTurn).not.toHaveBeenCalled();
+      expect(conversations.failTurn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a pending resume token on the job", () => {
+    it("threads it onto the manager /chat request body", async () => {
+      let sentBody: Record<string, unknown> = {};
+      const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+        sentBody = JSON.parse(init.body as string);
+        return ndjsonResponse(['{"type":"handoff","token":"x"}']);
+      }) as unknown as typeof fetch;
+
+      await runTurn(
+        job({ resumeToken: "prior-checkpoint" }),
+        deps({ fetchImpl }),
+      );
+
+      expect(sentBody.resumeToken).toBe("prior-checkpoint");
+    });
+
+    it("omits the resume token on a cold start", async () => {
+      let sentBody: Record<string, unknown> = {};
+      const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+        sentBody = JSON.parse(init.body as string);
+        return ndjsonResponse(['{"type":"handoff","token":"x"}']);
+      }) as unknown as typeof fetch;
+
+      await runTurn(job(), deps({ fetchImpl }));
+
+      expect(sentBody).not.toHaveProperty("resumeToken");
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/execution/langy-turn.processor.ts
+++ b/langwatch/src/server/services/langy/execution/langy-turn.processor.ts
@@ -79,17 +79,30 @@ export interface RunTurnDeps {
  */
 function parseAgentLine(
   line: string,
-): { delta?: string; error?: string } | null {
+): { delta?: string; error?: string; handoff?: string } | null {
   if (!line.trim()) return null;
   try {
     const event = JSON.parse(line) as {
       type?: string;
       error?: string;
+      token?: string;
       part?: { type?: string; text?: string };
-      properties?: { field?: string; delta?: string };
+      properties?: { field?: string; delta?: string; token?: string };
     };
     if (event.type === "error") {
       return { error: event.error || "agent error" };
+    }
+    // ADR-048: a terminal handoff frame carries an opaque resume token the
+    // worker authored when it checkpointed on manager shutdown. Empty string is
+    // still a handoff (the turn ended for handoff), just with nothing to resume.
+    if (event.type === "handoff") {
+      const token =
+        typeof event.token === "string"
+          ? event.token
+          : typeof event.properties?.token === "string"
+            ? event.properties.token
+            : "";
+      return { handoff: token };
     }
     if (event.type === "text" && event.part?.text) {
       return { delta: event.part.text };
@@ -122,6 +135,7 @@ export async function runTurn(
     system,
     modelOverride,
     credentials,
+    resumeToken,
   } = job;
   const doFetch = deps.fetchImpl ?? fetch;
   const turnLogger = logger.child({ projectId, conversationId, turnId });
@@ -186,6 +200,8 @@ export async function runTurn(
         system,
         credentials,
         ...(modelOverride ? { modelOverride } : {}),
+        // ADR-048: resume from a prior turn's checkpoint if one is pending.
+        ...(resumeToken ? { resumeToken } : {}),
       }),
       signal: AbortSignal.timeout(AGENT_CHAT_TIMEOUT_MS),
     });
@@ -199,12 +215,19 @@ export async function runTurn(
     const decoder = new TextDecoder();
     let buffer = "";
     let hardError: string | null = null;
+    let handoffToken: string | null = null;
 
     const handleLine = async (line: string) => {
       const parsed = parseAgentLine(line);
       if (!parsed) return;
       if (parsed.error) {
         hardError = parsed.error;
+        return;
+      }
+      if (parsed.handoff !== undefined) {
+        // ADR-048: the turn checkpointed on manager shutdown. Capture the opaque
+        // resume token; the stream ends on this terminal frame.
+        handoffToken = parsed.handoff;
         return;
       }
       if (parsed.delta) {
@@ -232,6 +255,36 @@ export async function runTurn(
 
     if (hardError) {
       throw new Error(hardError);
+    }
+
+    if (handoffToken !== null) {
+      // ADR-048: the worker handed off mid-turn on pod shutdown. Persist the
+      // opaque resume token durably (conversation_handoff_pending) so the next
+      // turn resumes from the checkpoint. Do NOT finalize — the turn did not
+      // complete; recordTurnHandoff clears the fold's CurrentTurnId so the
+      // conversation is not left "running".
+      await deps.conversations.recordTurnHandoff({
+        projectId,
+        conversationId,
+        turnId,
+        token: handoffToken,
+      });
+      await deps.buffer.markEnd({ conversationId, turnId });
+      // The turn paused for handoff — return the reserved PR permit so the pause
+      // does not burn the user's daily slot; the resumed turn re-reserves its
+      // own. Same release-only-if-reserved latch as the failure path (a Redis-
+      // down reserve returns reserved:false and must not walk the counter down).
+      if (job.permitReserved) {
+        await releaseLangyGithubPrPermit({ userId: job.actorUserId }).catch(
+          (releaseError) =>
+            turnLogger.warn(
+              { releaseError },
+              "failed to release PR permit on handoff",
+            ),
+        );
+      }
+      turnLogger.info("langy turn handed off — checkpoint persisted for resume");
+      return;
     }
 
     // Terminal: the whole final answer is the durable source of truth; tokens

--- a/langwatch/src/server/services/langy/streaming/langyTurnHandoff.ts
+++ b/langwatch/src/server/services/langy/streaming/langyTurnHandoff.ts
@@ -33,6 +33,14 @@ export interface LangyTurnHandoff {
    * route (a Redis-down reserve returns `reserved: false`).
    */
   permitReserved: boolean;
+  /**
+   * ADR-048 shutdown-handoff: an opaque, worker-authored resume token from a
+   * prior turn that checkpointed on pod termination. Set by the route when it
+   * found a pending handoff on the conversation fold; `runTurn` threads it onto
+   * the manager /chat body so opencode resumes from the checkpoint instead of a
+   * cold start. Absent on a normal turn.
+   */
+  resumeToken?: string;
 }
 
 /** Minimal Redis surface. Injected so unit tests need no live server. */

--- a/services/langyagent/adapters/httpapi/handlers.go
+++ b/services/langyagent/adapters/httpapi/handlers.go
@@ -33,6 +33,12 @@ type chatRequest struct {
 	// checks its own `validate:"required"` fields (see domain.Credentials).
 	Credentials   domain.Credentials `json:"credentials"`
 	ModelOverride string             `json:"modelOverride,omitempty"`
+	// ResumeToken (ADR-048) is an opaque, worker-authored checkpoint from a
+	// prior turn that handed off on shutdown. The control plane sets it on the
+	// next turn's /chat body when it found a pending handoff for the
+	// conversation; the manager forwards it verbatim into the worker, never
+	// parsing it. Absent ⇒ a normal cold start.
+	ResumeToken string `json:"resumeToken,omitempty"`
 }
 
 // validateChatRequest checks the decoded body against its `validate` tags. On
@@ -128,6 +134,7 @@ func chatHandler(application *app.App, maxBodyBytes int64) http.HandlerFunc {
 			Prompt:         req.Prompt,
 			System:         req.System,
 			Credentials:    creds,
+			ResumeToken:    req.ResumeToken,
 		}, sink); err != nil {
 			// Pre-stream failures only (e.g. conversation-busy → 409). Once the
 			// stream has begun, the app writes error events into the sink and

--- a/services/langyagent/adapters/httpapi/handlers_test.go
+++ b/services/langyagent/adapters/httpapi/handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/langwatch/langwatch/pkg/health"
 	"github.com/langwatch/langwatch/pkg/herr"
@@ -19,10 +20,10 @@ import (
 
 type stubWorker struct{ claimOK bool }
 
-func (w *stubWorker) Claim() bool                                       { return w.claimOK }
-func (w *stubWorker) Release()                                          {}
-func (w *stubWorker) Touch()                                            {}
-func (w *stubWorker) PostMessage(context.Context, string, string) error { return nil }
+func (w *stubWorker) Claim() bool                                               { return w.claimOK }
+func (w *stubWorker) Release()                                                  {}
+func (w *stubWorker) Touch()                                                    {}
+func (w *stubWorker) PostMessage(context.Context, string, string, string) error { return nil }
 func (w *stubWorker) StreamEvents(_ context.Context, sink app.ChatSink) error {
 	_, _ = sink.Write([]byte("{\"type\":\"message.part.delta\"}\n"))
 	return nil
@@ -39,10 +40,11 @@ func (p *stubPool) Acquire(context.Context, string, domain.Credentials) (app.Wor
 	}
 	return p.worker, nil
 }
-func (p *stubPool) Status() (int, int)         { return 2, 20 }
-func (p *stubPool) KillSessionVanished(string) {}
-func (p *stubPool) StartReaper()               {}
-func (p *stubPool) Shutdown()                  {}
+func (p *stubPool) Status() (int, int)                         { return 2, 20 }
+func (p *stubPool) KillSessionVanished(string)                 {}
+func (p *stubPool) StartReaper()                               {}
+func (p *stubPool) ShutdownHandoff(context.Context, time.Time) {}
+func (p *stubPool) Shutdown()                                  {}
 
 const internalSecret = "test-internal-secret"
 

--- a/services/langyagent/adapters/workerpool/handoff_test.go
+++ b/services/langyagent/adapters/workerpool/handoff_test.go
@@ -1,0 +1,257 @@
+package workerpool
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ADR-048: `handoff` must be a terminal event type so streamSessionEvents
+// forwards the frame and returns cleanly, ending the turn.
+func TestTerminalEventTypes_IncludesHandoff(t *testing.T) {
+	if _, ok := terminalEventTypes["handoff"]; !ok {
+		t.Fatalf("expected \"handoff\" to be a terminal event type (ADR-048)")
+	}
+}
+
+// notifyShutdownImminent POSTs the session-scoped shutdown notice with the
+// absolute deadline (unix millis) opencode must checkpoint before.
+func TestNotifyShutdownImminent_PostsDeadline(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody struct {
+		Deadline int64 `json:"deadline"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	deadline := time.UnixMilli(1_752_000_000_000)
+	err := notifyShutdownImminent(context.Background(), srv.URL, "bearer-abc", "sess-1", deadline)
+	if err != nil {
+		t.Fatalf("notifyShutdownImminent: %v", err)
+	}
+	if gotPath != "/session/sess-1/shutdown_imminent" {
+		t.Errorf("path = %q, want /session/sess-1/shutdown_imminent", gotPath)
+	}
+	if gotAuth != "Bearer bearer-abc" {
+		t.Errorf("auth = %q, want Bearer bearer-abc", gotAuth)
+	}
+	if gotBody.Deadline != deadline.UnixMilli() {
+		t.Errorf("deadline = %d, want %d", gotBody.Deadline, deadline.UnixMilli())
+	}
+}
+
+func TestNotifyShutdownImminent_ErrorOnServerFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if err := notifyShutdownImminent(context.Background(), srv.URL, "b", "sess-1", time.Now()); err == nil {
+		t.Fatalf("expected an error when opencode answers 500 to shutdown_imminent")
+	}
+}
+
+// The token in a handoff frame is opaque to the manager; extractHandoffToken
+// only asserts the frame shape (bare and nested) for bookkeeping/tests.
+func TestExtractHandoffToken(t *testing.T) {
+	bare := map[string]any{"type": "handoff", "token": "opaque-1"}
+	if tok, ok := extractHandoffToken(bare); !ok || tok != "opaque-1" {
+		t.Errorf("bare: got (%q,%v), want (opaque-1,true)", tok, ok)
+	}
+	nested := map[string]any{"type": "handoff", "properties": map[string]any{"token": "opaque-2"}}
+	if tok, ok := extractHandoffToken(nested); !ok || tok != "opaque-2" {
+		t.Errorf("nested: got (%q,%v), want (opaque-2,true)", tok, ok)
+	}
+	notHandoff := map[string]any{"type": "message.done"}
+	if _, ok := extractHandoffToken(notHandoff); ok {
+		t.Errorf("a non-handoff event must not report a handoff token")
+	}
+}
+
+// A resume token (ADR-048) rides the prompt_async body so opencode restores
+// "done so far" instead of cold-starting.
+func TestPostMessage_IncludesResumeToken(t *testing.T) {
+	var body struct {
+		ResumeToken string `json:"resumeToken"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	err := postMessage(context.Background(), srv.URL, "b", "sess-1", "sys", "hi", "resume-token-xyz")
+	if err != nil {
+		t.Fatalf("postMessage: %v", err)
+	}
+	if body.ResumeToken != "resume-token-xyz" {
+		t.Errorf("resumeToken = %q, want resume-token-xyz", body.ResumeToken)
+	}
+}
+
+// A cold start omits the resume token entirely (omitempty), so opencode sees no
+// checkpoint field at all.
+func TestPostMessage_OmitsResumeTokenWhenEmpty(t *testing.T) {
+	var raw map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	if err := postMessage(context.Background(), srv.URL, "b", "sess-1", "sys", "hi", ""); err != nil {
+		t.Fatalf("postMessage: %v", err)
+	}
+	if _, present := raw["resumeToken"]; present {
+		t.Errorf("resumeToken must be omitted on a cold start, got %v", raw["resumeToken"])
+	}
+}
+
+// The in-flight turn's event tail must terminate on a `handoff` frame and
+// forward it to the sink, so the control plane can persist the token off the
+// still-open /chat response (ADR-048).
+func TestStreamSessionEvents_HandoffFrameTerminatesAndForwards(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("test server needs a Flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "data: {\"type\":\"message.part.delta\",\"sessionID\":\"sess-1\",\"properties\":{\"field\":\"text\",\"delta\":\"partial\"}}\n\n")
+		fl.Flush()
+		io.WriteString(w, "data: {\"type\":\"handoff\",\"sessionID\":\"sess-1\",\"token\":\"opaque-resume\"}\n\n")
+		fl.Flush()
+		// Hold the connection open; streamSessionEvents must return on the
+		// terminal handoff frame without waiting for us to close.
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- streamSessionEvents(context.Background(), srv.URL, "b", "sess-1", &out, func() {})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("streamSessionEvents returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("streamSessionEvents did not return on the terminal handoff frame")
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "\"type\":\"handoff\"") || !strings.Contains(got, "opaque-resume") {
+		t.Errorf("sink missing forwarded handoff frame; got: %q", got)
+	}
+	if !strings.Contains(got, "partial") {
+		t.Errorf("sink missing the pre-handoff delta; got: %q", got)
+	}
+}
+
+// newHandoffWorker builds a Worker pointing at a test opencode control server,
+// claimed (in-flight), for the ShutdownHandoff pool tests. Same-package access
+// to the unexported fields keeps this out of the real spawn path.
+func newHandoffWorker(conversationID, sessionID, baseURL string) *Worker {
+	w := &Worker{
+		conversationID:    conversationID,
+		baseURL:           baseURL,
+		bearerToken:       "b",
+		openCodeSessionID: sessionID,
+	}
+	w.Claim() // mark in-flight
+	return w
+}
+
+// ShutdownHandoff notifies every live worker and returns as soon as the
+// in-flight turns quiesce (their StreamEvents saw the terminal handoff frame and
+// Released), well before the deadline.
+func TestPool_ShutdownHandoff_NotifiesAndWaitsForQuiesce(t *testing.T) {
+	var mu sync.Mutex
+	notified := map[string]bool{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/shutdown_imminent") {
+			mu.Lock()
+			notified[r.URL.Path] = true
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := newTestPool(4)
+	w1 := newHandoffWorker("conv-1", "sess-1", srv.URL)
+	w2 := newHandoffWorker("conv-2", "sess-2", srv.URL)
+	p.workers["conv-1"] = w1
+	p.workers["conv-2"] = w2
+
+	// Simulate the in-flight turns finishing shortly after the notice.
+	go func() {
+		time.Sleep(120 * time.Millisecond)
+		w1.Release()
+		w2.Release()
+	}()
+
+	start := time.Now()
+	p.ShutdownHandoff(context.Background(), time.Now().Add(3*time.Second))
+	elapsed := time.Since(start)
+
+	if elapsed >= 3*time.Second {
+		t.Errorf("ShutdownHandoff waited for the full deadline (%s) instead of returning on quiesce", elapsed)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !notified["/session/sess-1/shutdown_imminent"] || !notified["/session/sess-2/shutdown_imminent"] {
+		t.Errorf("expected every live worker to be notified, got %v", notified)
+	}
+}
+
+// A turn that never quiesces caps at the deadline and falls back to cold restart
+// (the honest ADR-048 limit) — it must not block past the deadline.
+func TestPool_ShutdownHandoff_CapsAtDeadline(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := newTestPool(4)
+	// Claimed and never released — the turn does not quiesce.
+	p.workers["conv-stuck"] = newHandoffWorker("conv-stuck", "sess-stuck", srv.URL)
+
+	start := time.Now()
+	p.ShutdownHandoff(context.Background(), time.Now().Add(250*time.Millisecond))
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Errorf("ShutdownHandoff blocked past the deadline: %s", elapsed)
+	}
+	if elapsed < 200*time.Millisecond {
+		t.Errorf("ShutdownHandoff returned before the deadline: %s", elapsed)
+	}
+}
+
+// No live workers ⇒ a no-op that returns immediately.
+func TestPool_ShutdownHandoff_NoWorkersIsNoop(t *testing.T) {
+	p := newTestPool(4)
+	start := time.Now()
+	p.ShutdownHandoff(context.Background(), time.Now().Add(5*time.Second))
+	if time.Since(start) > 500*time.Millisecond {
+		t.Errorf("ShutdownHandoff with no workers should return immediately")
+	}
+}

--- a/services/langyagent/adapters/workerpool/opencode.go
+++ b/services/langyagent/adapters/workerpool/opencode.go
@@ -29,6 +29,12 @@ var terminalEventTypes = map[string]struct{}{
 	"session.idle":      {},
 	"session.completed": {},
 	"error":             {},
+	// ADR-048: opencode emits a terminal `handoff` frame carrying an opaque
+	// resume token when it checkpoints on a shutdown-imminent notice. Treating
+	// it as terminal lets the in-flight turn's StreamEvents forward the frame to
+	// the sink (and thence to the control plane over the open /chat response)
+	// and return cleanly, exactly like any other terminal event.
+	"handoff": {},
 }
 
 // errAuthProbeUnreachable marks a transport-level failure of the auth
@@ -285,8 +291,9 @@ func createOpenCodeSession(ctx context.Context, port int, bearerToken string) (s
 // postMessage queues a turn for the worker. 204/2xx → success. 404 means the
 // session vanished (rare; surfaces as domain.ErrSessionNotFound so the
 // orchestrator can recycle the worker). baseURL is the worker's precomputed
-// "http://127.0.0.1:<port>" so no per-turn Sprintf is needed.
-func postMessage(ctx context.Context, baseURL, bearerToken, sessionID, system, userText string) error {
+// "http://127.0.0.1:<port>" so no per-turn Sprintf is needed. resumeToken
+// (ADR-048) rides the payload when resuming a prior turn's checkpoint.
+func postMessage(ctx context.Context, baseURL, bearerToken, sessionID, system, userText, resumeToken string) error {
 	type part struct {
 		Type string `json:"type"`
 		Text string `json:"text"`
@@ -294,9 +301,16 @@ func postMessage(ctx context.Context, baseURL, bearerToken, sessionID, system, u
 	payload := struct {
 		Parts  []part `json:"parts"`
 		System string `json:"system,omitempty"`
+		// ResumeToken (ADR-048) is the opaque, worker-authored checkpoint from a
+		// prior turn that handed off on shutdown. Present only when the control
+		// plane found a pending handoff for this conversation; opencode restores
+		// "done so far" from it instead of cold-starting. Opaque to the manager —
+		// forwarded verbatim, never parsed. omitempty ⇒ a normal cold start.
+		ResumeToken string `json:"resumeToken,omitempty"`
 	}{
-		Parts:  []part{{Type: "text", Text: userText}},
-		System: system,
+		Parts:       []part{{Type: "text", Text: userText}},
+		System:      system,
+		ResumeToken: resumeToken,
 	}
 	body, _ := json.Marshal(payload)
 	url := baseURL + "/session/" + sessionID + "/prompt_async"
@@ -320,6 +334,58 @@ func postMessage(ctx context.Context, baseURL, bearerToken, sessionID, system, u
 		return fmt.Errorf("post message: %d %s", resp.StatusCode, string(b))
 	}
 	return nil
+}
+
+// notifyShutdownImminent POSTs a shutdown-imminent notice to the worker's
+// opencode control API (ADR-048), telling it to checkpoint the in-flight turn
+// and emit a terminal `handoff` frame before the manager kills its process
+// group. `deadline` is the absolute wall-clock instant (unix millis) the worker
+// must checkpoint before — strictly inside the graceful window (see the ADR-048
+// deadline math). Best-effort: a non-2xx or transport error is returned to the
+// caller, which logs and proceeds with the drain (a worker that cannot be
+// notified simply cold-starts on its next turn, today's behaviour). opencode is
+// expected to answer 2xx/204; a 404 means the session already vanished.
+func notifyShutdownImminent(ctx context.Context, baseURL, bearerToken, sessionID string, deadline time.Time) error {
+	body := bytes.NewBufferString(fmt.Sprintf(`{"deadline":%d}`, deadline.UnixMilli()))
+	url := baseURL + "/session/" + sessionID + "/shutdown_imminent"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	addBearer(req, bearerToken)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusNoContent {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("shutdown_imminent: %d %s", resp.StatusCode, string(b))
+	}
+	return nil
+}
+
+// extractHandoffToken pulls the opaque resume token out of a decoded `handoff`
+// ndjson frame (ADR-048). The token is opaque to the manager — this exists only
+// so tests (and any future manager-side bookkeeping) can assert the frame shape;
+// the token itself is never interpreted here, only on the control plane (which
+// persists it) and in opencode (which authors and consumes it). Tolerates the
+// bare `token` field and a nested `properties.token`, mirroring the
+// session-id shape-tolerance in eventBelongsToSession.
+func extractHandoffToken(event map[string]any) (string, bool) {
+	if typ, _ := event["type"].(string); typ != "handoff" {
+		return "", false
+	}
+	if v, _ := event["token"].(string); v != "" {
+		return v, true
+	}
+	if props, _ := event["properties"].(map[string]any); props != nil {
+		if v, _ := props["token"].(string); v != "" {
+			return v, true
+		}
+	}
+	return "", true
 }
 
 // streamSessionEvents tails /event from the worker and forwards every event

--- a/services/langyagent/adapters/workerpool/pool.go
+++ b/services/langyagent/adapters/workerpool/pool.go
@@ -211,6 +211,96 @@ func (p *Pool) Shutdown() {
 	p.baseCancel()
 }
 
+// ShutdownHandoff is the ADR-048 pre-drain SIGTERM step. For each live worker it
+// posts a shutdown-imminent notice (so opencode checkpoints the in-flight turn
+// and emits a terminal `handoff` frame), then waits — bounded by deadline — for
+// every in-flight turn to quiesce, so the frames flush to the control plane over
+// the still-open /chat responses before Shutdown kills the process groups.
+//
+// It runs BEFORE Shutdown (registered as a lifecycle Closer after the
+// worker-pool, so reverse-order stop fires it first). Best-effort by design: a
+// worker that cannot be notified, or a turn that does not quiesce before the
+// deadline, falls back to a cold restart on its next turn — the honest
+// SIGKILL/OOM limit stated in ADR-048. The deadline caps the whole step so a
+// slow/dead worker can never eat the drain budget out from under the kill.
+func (p *Pool) ShutdownHandoff(ctx context.Context, deadline time.Time) {
+	// Snapshot the live workers under the lock; do all network I/O outside it.
+	p.mu.Lock()
+	workers := make([]*Worker, 0, len(p.workers))
+	for _, w := range p.workers {
+		workers = append(workers, w)
+	}
+	p.mu.Unlock()
+	if len(workers) == 0 {
+		return
+	}
+
+	hctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	log := clog.Get(p.baseCtx)
+	log.Info("shutdown handoff: notifying live workers",
+		zap.Int("workers", len(workers)),
+		zap.Time("deadline", deadline),
+	)
+
+	// Notify each worker in parallel. Bare goroutine guarded by HandlePanic so a
+	// panic in one POST can never take the manager down mid-shutdown (PR4 has no
+	// clog.Go yet; this is exactly what it would do — composes when it lands).
+	var wg sync.WaitGroup
+	for _, w := range workers {
+		wg.Add(1)
+		w := w
+		// clog.Go panic-guards the goroutine so a panic in one notify can never
+		// take the manager down mid-shutdown (PR3).
+		clog.Go(hctx, "shutdown-handoff-notify", func() {
+			defer wg.Done()
+			// Cap a single hung notify so it cannot consume the whole budget.
+			nctx, ncancel := context.WithTimeout(hctx, 2*time.Second)
+			defer ncancel()
+			if err := w.NotifyShutdownImminent(nctx, deadline); err != nil {
+				log.Warn("shutdown handoff: notify failed",
+					zap.String("conversation", w.conversationID),
+					zap.Error(err),
+				)
+			}
+		})
+	}
+	wg.Wait()
+
+	// Wait for in-flight turns to drain (their StreamEvents saw the terminal
+	// handoff frame and Released the worker) or the deadline. Polling keeps this
+	// lock-light; the deadline caps it.
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if p.countInFlight(workers) == 0 {
+			log.Info("shutdown handoff: all in-flight turns quiesced")
+			return
+		}
+		select {
+		case <-hctx.Done():
+			log.Warn("shutdown handoff: deadline reached with turns still in flight — falling back to cold restart",
+				zap.Int("still_in_flight", p.countInFlight(workers)),
+			)
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// countInFlight reports how many of the given workers still have a turn in
+// flight. Used by ShutdownHandoff to wait for the in-flight turns to quiesce.
+func (p *Pool) countInFlight(workers []*Worker) int {
+	n := 0
+	for _, w := range workers {
+		if w.isInFlight() {
+			n++
+		}
+	}
+	return n
+}
+
 // Acquire returns the worker for conversationID, spawning one if needed. Two
 // concurrent callers for the same conversationID share the same spawn promise —
 // only one subprocess is ever created.

--- a/services/langyagent/adapters/workerpool/worker.go
+++ b/services/langyagent/adapters/workerpool/worker.go
@@ -102,9 +102,30 @@ func (w *Worker) Release() {
 	w.mu.Unlock()
 }
 
-// PostMessage queues a turn on the worker's opencode session.
-func (w *Worker) PostMessage(ctx context.Context, system, prompt string) error {
-	return postMessage(ctx, w.baseURL, w.bearerToken, w.openCodeSessionID, system, prompt)
+// PostMessage queues a turn on the worker's opencode session. resumeToken
+// (ADR-048) is the opaque checkpoint from a prior turn that handed off on
+// shutdown; empty on a normal cold start. It is forwarded verbatim to opencode,
+// never parsed by the manager.
+func (w *Worker) PostMessage(ctx context.Context, system, prompt, resumeToken string) error {
+	return postMessage(ctx, w.baseURL, w.bearerToken, w.openCodeSessionID, system, prompt, resumeToken)
+}
+
+// NotifyShutdownImminent posts a shutdown-imminent notice to this worker's
+// opencode control API (ADR-048), asking it to checkpoint the in-flight turn and
+// emit a terminal `handoff` frame before the process-group kill. deadline is the
+// absolute instant the worker must checkpoint before.
+func (w *Worker) NotifyShutdownImminent(ctx context.Context, deadline time.Time) error {
+	return notifyShutdownImminent(ctx, w.baseURL, w.bearerToken, w.openCodeSessionID, deadline)
+}
+
+// isInFlight reports whether a turn currently owns this worker (Claimed but not
+// yet Released). The shutdown-handoff step waits on this clearing so the
+// in-flight turn's StreamEvents can forward the terminal `handoff` frame to the
+// control plane before the drain kills the process group (ADR-048).
+func (w *Worker) isInFlight() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.inFlight
 }
 
 // StreamEvents tails the worker's /event stream and forwards this session's

--- a/services/langyagent/app/app.go
+++ b/services/langyagent/app/app.go
@@ -66,6 +66,10 @@ type ChatRequest struct {
 	Prompt         string
 	System         string
 	Credentials    domain.Credentials
+	// ResumeToken (ADR-048) is an opaque, worker-authored checkpoint from a prior
+	// turn that handed off on shutdown. Threaded into PostMessage so opencode
+	// resumes from it; empty on a normal cold start.
+	ResumeToken string
 }
 
 // Chat runs one chat turn: acquire the worker, claim it, post the prompt, and
@@ -146,7 +150,7 @@ func (a *App) Chat(ctx context.Context, req ChatRequest, sink ChatSink) error {
 		errCh <- err
 	}()
 
-	if err := worker.PostMessage(ctx, req.System, req.Prompt); err != nil {
+	if err := worker.PostMessage(ctx, req.System, req.Prompt, req.ResumeToken); err != nil {
 		// Cancel the SSE consumer, then DRAIN it (<-errCh) BEFORE writing any error
 		// event. StreamEvents writes to the same http.ResponseWriter as the sink;
 		// waiting for it to return first avoids a concurrent write on the ndjson

--- a/services/langyagent/app/app_test.go
+++ b/services/langyagent/app/app_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/langwatch/langwatch/pkg/herr"
 	"github.com/langwatch/langwatch/services/langyagent/domain"
@@ -26,16 +27,18 @@ func (f *fakePool) Acquire(_ context.Context, _ string, _ domain.Credentials) (W
 	}
 	return f.worker, nil
 }
-func (f *fakePool) Status() (int, int)            { return 0, 0 }
-func (f *fakePool) KillSessionVanished(id string) { f.killed = append(f.killed, id) }
-func (f *fakePool) StartReaper()                  {}
-func (f *fakePool) Shutdown()                     {}
+func (f *fakePool) Status() (int, int)                         { return 0, 0 }
+func (f *fakePool) KillSessionVanished(id string)              { f.killed = append(f.killed, id) }
+func (f *fakePool) StartReaper()                               {}
+func (f *fakePool) ShutdownHandoff(context.Context, time.Time) {}
+func (f *fakePool) Shutdown()                                  {}
 
 type fakeWorker struct {
 	claimOK          bool
 	claimed          int
 	released         int
 	postErr          error
+	gotResumeToken   string
 	streamErr        error
 	streamWrites     bool // write one event on the stream (happy path)
 	blockUntilCancel bool // wait for ctx cancellation before returning (post-error path)
@@ -44,7 +47,8 @@ type fakeWorker struct {
 func (w *fakeWorker) Claim() bool { w.claimed++; return w.claimOK }
 func (w *fakeWorker) Release()    { w.released++ }
 func (w *fakeWorker) Touch()      {}
-func (w *fakeWorker) PostMessage(_ context.Context, _, _ string) error {
+func (w *fakeWorker) PostMessage(_ context.Context, _, _, resumeToken string) error {
+	w.gotResumeToken = resumeToken
 	return w.postErr
 }
 func (w *fakeWorker) StreamEvents(ctx context.Context, sink ChatSink) error {

--- a/services/langyagent/app/ports.go
+++ b/services/langyagent/app/ports.go
@@ -7,6 +7,7 @@ package app
 
 import (
 	"context"
+	"time"
 
 	"github.com/langwatch/langwatch/services/langyagent/domain"
 )
@@ -23,6 +24,12 @@ type WorkerPool interface {
 	KillSessionVanished(conversationID string)
 	// StartReaper begins the idle-worker sweep.
 	StartReaper()
+	// ShutdownHandoff (ADR-048) is the pre-drain SIGTERM step: it notifies each
+	// live worker that shutdown is imminent (so opencode checkpoints the
+	// in-flight turn and emits a terminal handoff frame) and waits, bounded by
+	// deadline, for those turns to quiesce. Runs BEFORE Shutdown so the handoff
+	// frames reach the control plane before the process-group kill.
+	ShutdownHandoff(ctx context.Context, deadline time.Time)
 	// Shutdown tears down every worker.
 	Shutdown()
 }
@@ -37,8 +44,10 @@ type Worker interface {
 	Release()
 	// Touch resets the idle timer.
 	Touch()
-	// PostMessage queues the turn on the worker's opencode session.
-	PostMessage(ctx context.Context, system, prompt string) error
+	// PostMessage queues the turn on the worker's opencode session. resumeToken
+	// (ADR-048) carries an opaque prior-turn checkpoint to resume from; empty on
+	// a cold start.
+	PostMessage(ctx context.Context, system, prompt, resumeToken string) error
 	// StreamEvents forwards this session's opencode events into sink until a
 	// terminal event or ctx cancellation.
 	StreamEvents(ctx context.Context, sink ChatSink) error

--- a/services/langyagent/config.go
+++ b/services/langyagent/config.go
@@ -76,6 +76,21 @@ type Config struct {
 	// non-IP-literal host as unexpected; operators should set the real hosts.
 	EgressAllowedHosts string `env:"LANGY_EGRESS_ALLOWED_HOSTS"`
 
+	// ShutdownHandoffDeadlineMS (ADR-048) is the wall-clock budget the manager
+	// gives each live worker to checkpoint on SIGTERM before the process-group
+	// kill. The `deadline` posted to a worker is now + this. MUST leave room for
+	// the drain: LoadConfig fails closed if
+	// ShutdownHandoffDeadlineMS + ShutdownDrainBudgetMS >= GracefulSeconds*1000
+	// (see the ADR-048 deadline math — SIGKILL is uncatchable, so the whole
+	// handoff+drain must fit inside the graceful window, which the operator sizes
+	// below the pod terminationGracePeriodSeconds).
+	ShutdownHandoffDeadlineMS int64 `env:"LANGY_SHUTDOWN_HANDOFF_DEADLINE_MS" validate:"gte=0"`
+	// ShutdownDrainBudgetMS (ADR-048) is the time reserved AFTER the handoff for
+	// the worker-pool drain (per-worker SIGINT -> 2s grace -> SIGKILL, authproxy
+	// teardown, margin). Subtracted from the graceful window so the handoff
+	// deadline can never eat the drain budget out from under the kill.
+	ShutdownDrainBudgetMS int64 `env:"LANGY_SHUTDOWN_DRAIN_BUDGET_MS" validate:"gte=0"`
+
 	// WorkspaceRoot is the shared-templates directory the pod entrypoint seeds
 	// with AGENTS.md and skills/ (see entrypoint.sh). setupWorkerHome reads
 	// ${WorkspaceRoot}/AGENTS.md and symlinks ${WorkspaceRoot}/skills into each
@@ -125,6 +140,11 @@ const (
 	// prompt + credentials, never large-context LLM payloads.
 	defaultMaxBodyBytes      = 1_000_000
 	defaultOTelPluginVersion = "1.0.0"
+	// ADR-048 shutdown-handoff budgets (ms). Defaults sum to 8s, comfortably
+	// under the 10s default graceful window; the operator sizes
+	// terminationGracePeriodSeconds above the graceful window.
+	defaultShutdownHandoffDeadlineMS = 5_000
+	defaultShutdownDrainBudgetMS     = 3_000
 )
 
 func defaultConfig() Config {
@@ -135,14 +155,16 @@ func defaultConfig() Config {
 			GracefulSeconds:     defaultGracefulSeconds,
 			MaxRequestBodyBytes: defaultMaxBodyBytes,
 		},
-		MaxWorkers:         defaultMaxWorkers,
-		WorkerIdleMS:       defaultWorkerIdleMS,
-		ReadinessTimeoutMS: defaultReadinessTimeoutMS,
-		SessionsRoot:       defaultSessionsRoot,
-		WorkspaceRoot:      defaultWorkspaceRoot,
-		OTelPluginVersion:  defaultOTelPluginVersion,
-		OpenCodeBinaryPath: "opencode",
-		reaperInterval:     defaultReaperInterval,
+		MaxWorkers:                defaultMaxWorkers,
+		WorkerIdleMS:              defaultWorkerIdleMS,
+		ReadinessTimeoutMS:        defaultReadinessTimeoutMS,
+		SessionsRoot:              defaultSessionsRoot,
+		WorkspaceRoot:             defaultWorkspaceRoot,
+		OTelPluginVersion:         defaultOTelPluginVersion,
+		OpenCodeBinaryPath:        "opencode",
+		ShutdownHandoffDeadlineMS: defaultShutdownHandoffDeadlineMS,
+		ShutdownDrainBudgetMS:     defaultShutdownDrainBudgetMS,
+		reaperInterval:            defaultReaperInterval,
 		OTel: config.OTel{
 			SampleRatio: 1.0, // overridden to 0.1 for non-local in LoadConfig
 		},
@@ -176,6 +198,19 @@ func LoadConfig(ctx context.Context) (Config, error) {
 		return Config{}, fmt.Errorf(
 			"LANGY_UNSAFE_DEV_DISABLE_ISOLATION cannot be enabled when ENVIRONMENT=%q — per-worker isolation may only be disabled in local development",
 			cfg.Environment,
+		)
+	}
+	// ADR-048 deadline math: the handoff budget plus the drain budget must fit
+	// strictly inside the graceful shutdown window, so the worker-authored
+	// checkpoint AND the process-group kill that follows both complete before the
+	// graceful deadline — which the operator in turn sizes below the pod's
+	// terminationGracePeriodSeconds (SIGKILL is uncatchable). A config that
+	// violates this would post a `deadline` the worker cannot meet before the kill.
+	gracefulMS := int64(cfg.Server.GracefulSeconds) * 1000
+	if gracefulMS > 0 && cfg.ShutdownHandoffDeadlineMS+cfg.ShutdownDrainBudgetMS >= gracefulMS {
+		return Config{}, fmt.Errorf(
+			"LANGY_SHUTDOWN_HANDOFF_DEADLINE_MS (%d) + LANGY_SHUTDOWN_DRAIN_BUDGET_MS (%d) must be < the graceful shutdown window (%d ms) — see ADR-048 deadline math",
+			cfg.ShutdownHandoffDeadlineMS, cfg.ShutdownDrainBudgetMS, gracefulMS,
 		)
 	}
 	return cfg, nil
@@ -212,4 +247,16 @@ func (c Config) ReaperInterval() time.Duration {
 		return defaultReaperInterval
 	}
 	return c.reaperInterval
+}
+
+// ShutdownHandoffDeadline is the budget a live worker gets to checkpoint on
+// SIGTERM before the process-group kill (ADR-048).
+func (c Config) ShutdownHandoffDeadline() time.Duration {
+	return time.Duration(c.ShutdownHandoffDeadlineMS) * time.Millisecond
+}
+
+// ShutdownDrainBudget is the time reserved after the handoff for the worker
+// drain (ADR-048).
+func (c Config) ShutdownDrainBudget() time.Duration {
+	return time.Duration(c.ShutdownDrainBudgetMS) * time.Millisecond
 }

--- a/services/langyagent/config_test.go
+++ b/services/langyagent/config_test.go
@@ -17,6 +17,7 @@ func clearLangyEnv(t *testing.T) {
 		"LANGY_WORKSPACE_ROOT", "LANGY_UNSAFE_DEV_DISABLE_ISOLATION",
 		"OPENCODE_OTEL_PLUGIN_VERSION", "LOG_LEVEL", "LOG_FORMAT",
 		"OTEL_OTLP_ENDPOINT", "OTEL_SAMPLE_RATIO",
+		"LANGY_SHUTDOWN_HANDOFF_DEADLINE_MS", "LANGY_SHUTDOWN_DRAIN_BUDGET_MS",
 	} {
 		t.Setenv(k, "")
 	}
@@ -164,5 +165,58 @@ func TestLoadConfig_UnsafeDevDisableIsolationRefusedInNonLocalEnvs(t *testing.T)
 				t.Fatalf("expected LoadConfig to refuse LANGY_UNSAFE_DEV_DISABLE_ISOLATION when ENVIRONMENT=%q", env)
 			}
 		})
+	}
+}
+
+func TestLoadConfig_ShutdownHandoffDefaults(t *testing.T) {
+	clearLangyEnv(t)
+	t.Setenv("LANGY_INTERNAL_SECRET", "secret")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.ShutdownHandoffDeadline() != 5*time.Second {
+		t.Errorf("ShutdownHandoffDeadline default = %s, want 5s", cfg.ShutdownHandoffDeadline())
+	}
+	if cfg.ShutdownDrainBudget() != 3*time.Second {
+		t.Errorf("ShutdownDrainBudget default = %s, want 3s", cfg.ShutdownDrainBudget())
+	}
+	// The ADR-048 invariant holds for the defaults: handoff + drain (8s) < the
+	// 10s default graceful window.
+	if d := cfg.ShutdownHandoffDeadlineMS + cfg.ShutdownDrainBudgetMS; d >= int64(cfg.Server.GracefulSeconds)*1000 {
+		t.Errorf("defaults violate the ADR-048 deadline math: %d >= %d", d, int64(cfg.Server.GracefulSeconds)*1000)
+	}
+}
+
+// The ADR-048 deadline math is enforced at load: handoff + drain must be
+// strictly less than the graceful window, so the worker-authored checkpoint AND
+// the process-group kill both fit before the graceful deadline (which the
+// operator sizes below terminationGracePeriodSeconds — SIGKILL is uncatchable).
+func TestLoadConfig_ShutdownHandoffDeadlineMathRefused(t *testing.T) {
+	clearLangyEnv(t)
+	t.Setenv("LANGY_INTERNAL_SECRET", "secret")
+	// Default graceful window is 10s; 8s handoff + 3s drain = 11s overruns it.
+	t.Setenv("LANGY_SHUTDOWN_HANDOFF_DEADLINE_MS", "8000")
+	t.Setenv("LANGY_SHUTDOWN_DRAIN_BUDGET_MS", "3000")
+
+	if _, err := LoadConfig(context.Background()); err == nil {
+		t.Fatalf("expected LoadConfig to refuse handoff+drain that overrun the graceful window")
+	}
+}
+
+func TestLoadConfig_ShutdownHandoffBudgetsWithinGracefulAccepted(t *testing.T) {
+	clearLangyEnv(t)
+	t.Setenv("LANGY_INTERNAL_SECRET", "secret")
+	// 4s handoff + 2s drain = 6s < 10s graceful window.
+	t.Setenv("LANGY_SHUTDOWN_HANDOFF_DEADLINE_MS", "4000")
+	t.Setenv("LANGY_SHUTDOWN_DRAIN_BUDGET_MS", "2000")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.ShutdownHandoffDeadline() != 4*time.Second {
+		t.Errorf("ShutdownHandoffDeadline = %s, want 4s", cfg.ShutdownHandoffDeadline())
 	}
 }

--- a/services/langyagent/serve.go
+++ b/services/langyagent/serve.go
@@ -68,21 +68,50 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config) er
 			application.Pool().Shutdown()
 		}),
 		lifecycle.ListenServer("http", srv),
-		// Registered LAST so it stops FIRST (shutdown is reverse-order): on
-		// SIGTERM, force-flush buffered telemetry BEFORE the potentially-slow
-		// worker drain, so a grace period later cut short by SIGKILL still ships
-		// what we already have. ForceFlushGlobal flushes the manager's tracer
-		// provider, the internal tee (registered on the same global provider), and
-		// the meter provider. The normal full Shutdown of "otel"/"langy-internal-
-		// tee" (registered first) still runs LAST for the final flush + close.
-		// HONEST LIMIT: SIGKILL / OOM are uncatchable — this early flush plus the
-		// short BatchScheduledDelay narrow the loss window, they are not a
-		// zero-loss guarantee. Bounded so a dead collector can't eat the grace
-		// budget out from under the worker drain.
+		// otel-early-flush (PR3, ADR-044): on SIGTERM, force-flush buffered
+		// telemetry BEFORE the worker drain so a grace period later cut short by
+		// SIGKILL still ships what we already have. Registered BEFORE the handoff
+		// Closer below so it stops AFTER it (reverse-order). ForceFlushGlobal
+		// flushes the tracer provider, the internal tee, and the meter provider;
+		// the full Shutdown of "otel"/"langy-internal-tee" (registered first) still
+		// runs LAST. HONEST LIMIT: SIGKILL / OOM are uncatchable — this narrows the
+		// loss window, it is not a zero-loss guarantee. Bounded so a dead collector
+		// can't eat the grace budget out from under the worker drain.
 		lifecycle.Closer("otel-early-flush", func(ctx context.Context) error {
 			flushCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 			defer cancel()
 			otelsetup.ForceFlushGlobal(flushCtx)
+			return nil
+		}),
+		// ADR-048 shutdown-handoff. Registered LAST so it stops FIRST on SIGTERM
+		// (reverse-order): before the http listener drains and well before the
+		// worker-pool process-group kill, notify each live worker that shutdown is
+		// imminent so opencode checkpoints the in-flight turn and emits a terminal
+		// `handoff` frame. The frame flows out over the still-open /chat response
+		// (ListenServer keeps in-flight requests alive via WithoutCancel) to the
+		// control plane, which persists the resume token.
+		//
+		// COMPOSES WITH THE EARLY-FLUSH ABOVE: both are pre-drain SIGTERM steps.
+		// Stop order is handoff -> early-flush -> http -> worker-pool (this one is
+		// registered after early-flush, so it stops first). Neither depends on the
+		// other; both must finish before the worker drain. Its goroutines are
+		// panic-guarded with clog.Go (PR3), so a panic mid-shutdown can't crash
+		// the process before the drain.
+		//
+		// The deadline is capped to always leave the drain its budget before the
+		// graceful window closes (deadline < gracefulDeadline - drainBudget),
+		// which holds regardless of any lifecycle drain-delay already consumed —
+		// the honest ADR-048 math (graceful < terminationGracePeriodSeconds, so
+		// deadline < TGP - drainBudget; SIGKILL is still uncatchable).
+		lifecycle.Closer("langy-shutdown-handoff", func(ctx context.Context) error {
+			deadline := time.Now().Add(cfg.ShutdownHandoffDeadline())
+			if dl, ok := ctx.Deadline(); ok {
+				latest := dl.Add(-cfg.ShutdownDrainBudget())
+				if deadline.After(latest) {
+					deadline = latest
+				}
+			}
+			application.Pool().ShutdownHandoff(ctx, deadline)
 			return nil
 		}),
 	)

--- a/specs/langy/langy-shutdown-handoff.feature
+++ b/specs/langy/langy-shutdown-handoff.feature
@@ -1,0 +1,99 @@
+Feature: Langy worker shutdown-handoff and resume-on-next-worker
+  As a Langy user
+  I want an in-flight turn to survive a pod termination
+  So that a deploy or node drain resumes my work instead of restarting it cold
+
+  # Behavioural contract for ADR-048. On SIGTERM the manager asks each live
+  # worker to checkpoint before the process-group kill; opencode authors an
+  # opaque resume token and emits it as a terminal "handoff" ndjson frame on the
+  # in-flight turn stream; the control plane persists it as a durable event on
+  # the langy-conversation-processing pipeline; the next turn threads it back to
+  # a fresh worker, which resumes instead of cold-starting. Best-effort: an
+  # uncatchable SIGKILL still falls back to a cold restart.
+
+  Background:
+    Given I am signed in with Langy enabled for project "demo"
+
+  # ============================================================================
+  # Manager: notify each worker before the drain
+  # ============================================================================
+
+  Scenario: On SIGTERM the manager notifies each live worker before killing it
+    Given a worker is streaming an in-flight turn
+    When the manager receives SIGTERM
+    Then the manager posts a shutdown-imminent notice to that worker
+    And it does so before the worker's process group is killed
+    And the notice carries a deadline the worker must checkpoint before
+
+  Scenario: The handoff deadline leaves room for the drain
+    Given a graceful shutdown budget and a worker-drain budget are configured
+    Then the handoff deadline plus the drain budget is less than the graceful budget
+    And the manager refuses to start if that invariant does not hold
+
+  Scenario: A worker with no turn in flight needs no handoff
+    Given a worker is idle when the manager receives SIGTERM
+    When the manager drains the pool
+    Then no in-flight turn is lost for that worker
+    And it is simply killed and cold-started on its next turn
+
+  # ============================================================================
+  # Worker: author the token, emit the terminal frame
+  # ============================================================================
+
+  Scenario: The worker emits a terminal handoff frame carrying an opaque token
+    Given a worker received a shutdown-imminent notice mid-turn
+    When it checkpoints the work done so far
+    Then it emits a terminal "handoff" event on the turn stream
+    And the frame carries a resume token that is opaque to the manager
+    And the turn stream ends cleanly on that frame
+
+  # ============================================================================
+  # Control plane: persist the token durably
+  # ============================================================================
+
+  Scenario: The control plane persists the handoff token against the conversation
+    Given a turn stream delivers a terminal "handoff" frame
+    When the control plane consumes it
+    Then a "conversation_handoff_pending" event is recorded for the conversation
+    And the conversation fold stores the pending handoff token
+    And the fold no longer shows a turn in flight
+    And the turn is not recorded as failed
+
+  Scenario: Recording the same handoff twice does not duplicate it
+    Given a "recordTurnHandoff" command with a fixed idempotency key
+    When the command is dispatched twice for the same turn
+    Then exactly one "conversation_handoff_pending" event exists
+
+  # ============================================================================
+  # Resume: thread the token to a fresh worker, once
+  # ============================================================================
+
+  Scenario: The next turn resumes from the pending handoff instead of cold-starting
+    Given a conversation has a pending handoff token
+    When I send my next message on that conversation
+    Then the resume token is passed to the fresh worker before it starts
+    And the worker resumes from the checkpoint rather than a cold start
+
+  Scenario: Consuming the pending handoff clears it exactly once
+    Given a conversation has a pending handoff token
+    When the next turn consumes the pending handoff
+    Then a "conversation_handoff_consumed" event is recorded
+    And the conversation fold no longer has a pending handoff token
+    And consuming it again records no further durable event
+
+  Scenario: A conversation with no pending handoff starts cold
+    Given a conversation has no pending handoff token
+    When I send my next message on that conversation
+    Then no resume token is passed to the worker
+    And the turn is a normal cold start
+
+  # ============================================================================
+  # Honest limit
+  # ============================================================================
+
+  Scenario: An ungraceful kill still falls back to a cold restart
+    Given a worker is streaming an in-flight turn
+    When the pod is SIGKILLed before any handoff frame is emitted
+    Then no handoff token is persisted for the conversation
+    And the reconcile sweep terminalises the orphaned turn as before
+    And the next turn is a normal cold start


### PR DESCRIPTION
## What

Adds a best-effort **worker shutdown-handoff** so an in-flight Langy turn survives a pod termination: on SIGTERM the manager asks each live worker to checkpoint before the process-group kill, `opencode` authors an opaque resume token and emits it as a terminal `handoff` ndjson frame on the in-flight turn stream, the control plane persists it as a durable event on `langy-conversation-processing`, and the next `/chat` turn threads it back to a fresh worker — which resumes instead of cold-starting.

Design: **ADR-048** (`dev/docs/adr/048-langy-shutdown-handoff.md`), spec `specs/langy/langy-shutdown-handoff.feature`.

**Based on PR3** (`feat/langy-worker-streaming`), where the `clog.Go` / early-OTel-flush primitives live — so the handoff composes with them directly. Independent of PR4 egress (a sibling branch); the handoff is egress-agnostic.

## Protocol

1. **SIGTERM (manager)** — a pre-drain lifecycle Closer (sibling to PR3's `otel-early-flush`, registered after it so stop order is `handoff → early-flush → http → worker-pool`) POSTs `shutdown_imminent{deadline}` to each live worker's opencode control API, then waits (bounded by `deadline`) for in-flight turns to quiesce before the worker-pool drain kills the process groups. Notify fan-out is panic-guarded with `clog.Go`.
2. **Worker** — opencode writes a resumable checkpoint and emits `{"type":"handoff","token":…}`; `streamSessionEvents` treats `handoff` as terminal and forwards it.
3. **Control plane** — `runTurn` sees the frame, dispatches `recordTurnHandoff → conversation_handoff_pending` (stores the token on the fold, clears `CurrentTurnId`, returns to idle) instead of finalizing.
4. **Resume** — the next turn reads the pending token off the fold, threads `resumeToken` through the spawn → PostMessage path, and dispatches `consumeTurnHandoff → conversation_handoff_consumed` to clear it (idempotent on the handed-off turn).

## Key decisions (see ADR-048)

- **Token opacity boundary**: opaque to the manager (forwards) and the control plane (persists verbatim on two new fold columns); only opencode authors/consumes it. The recommended shape is documented but enforced nowhere outside opencode, so the checkpoint format can evolve without a Go or schema change.
- **Deadline math**: `handoffDeadline + drainBudget < GracefulSeconds` (validated at config load), and the operator sizes `terminationGracePeriodSeconds > GracefulSeconds`, so `deadline < TGP − drainBudget`. The Closer additionally caps the deadline to `gracefulDeadline − drainBudget` at runtime, so the drain always keeps its budget regardless of drain-delay already consumed.
- **SIGKILL caveat (honest)**: SIGKILL / OOM / a too-short TGP still loses the turn and falls back to today's cold restart. This narrows the loss window; it is not a guarantee.

## Surface

- **Go (`services/langyagent`)**: config (`LANGY_SHUTDOWN_HANDOFF_DEADLINE_MS`, `LANGY_SHUTDOWN_DRAIN_BUDGET_MS` + deadline-math validation), `Pool.ShutdownHandoff`, `notifyShutdownImminent`, `handoff` terminal frame, `resumeToken` threaded through `PostMessage`, pre-drain Closer in `serve.go` (alongside PR3's early-flush).
- **Control plane (TS)**: `conversation_handoff_pending` / `conversation_handoff_consumed` events + `recordTurnHandoff` / `consumeTurnHandoff` commands + fold handlers, two fold columns (CH migration `00043`), `runTurn` handoff parse/persist + resume-token threading, `routes/langy.ts` read+thread+consume.

## Verify

- `go build ./cmd/... ./services/langyagent/...` — clean; `go test ./services/langyagent/...` — green.
- `pnpm typecheck` — no new errors from these files. The 1 remaining error (`langy-turn.processor.ts` `reconcilePrPermit` call, a pino `Logger<never>` typing quirk) is pre-existing verbatim on the PR3 base.
- New tests: deadline math, handoff-frame parse (Go + TS), persist→resume round-trip, idempotent consume — 32 TS + full Go suite green.