### PR TITLE
fix(groupQueue): classify redis-tier blob-read errors as transient, await holder bookkeeping

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
@@ -183,74 +183,90 @@ export class EnvelopeBlobLifecycle {
 
   /**
    * Acquires this staged occupancy's hold on its GQ2 blob (no-op for GQ1,
-   * inline, and legacy values). Fire-and-forget: a missed acquire degrades to
-   * the blob's TTL backstop, never to a premature reclaim.
+   * inline, and legacy values). Awaited by the caller (2026-07-11 fix): this
+   * was previously fire-and-forget, which let a killed worker process drop
+   * the acquire silently — before it ever reached Redis — leaving a
+   * concurrent squash's release free to reclaim a blob this occupancy still
+   * needed. A failed acquire still only warns and degrades to the TTL
+   * backstop; it never throws to the caller.
    */
-  acquire(value: string): void {
+  async acquire(value: string): Promise<void> {
     const hold = readEnvelopeHold(value);
     if (!hold) return;
-    void this.blobHolders
-      .acquire({
+    try {
+      await this.blobHolders.acquire({
         projectId: hold.ref.projectId,
         hash: hold.ref.hash,
         slotId: hold.token,
-      })
-      .catch((err: unknown) => {
-        // Tenant-attributed (never a bare hash, never the bucket): every blob
-        // log line carries the owning projectId so logs can't cross tenants.
-        logger.warn(
-          {
-            projectId: hold.ref.projectId,
-            blobHash: hold.ref.hash,
-            tier: hold.ref.tier,
-            err: redactStorageUrisInText(
-              err instanceof Error ? err.message : String(err),
-            ),
-          },
-          "Blob holder acquire failed; relying on the TTL backstop",
-        );
       });
+    } catch (err) {
+      // Tenant-attributed (never a bare hash, never the bucket): every blob
+      // log line carries the owning projectId so logs can't cross tenants.
+      logger.warn(
+        {
+          projectId: hold.ref.projectId,
+          blobHash: hold.ref.hash,
+          tier: hold.ref.tier,
+          err: redactStorageUrisInText(
+            err instanceof Error ? err.message : String(err),
+          ),
+        },
+        "Blob holder acquire failed; relying on the TTL backstop",
+      );
+    }
   }
 
   /**
    * Releases holds for retired staged values: a GQ2 value releases its holder —
    * reclaiming the blob when the last hold drops, deleting an s3 object
-   * out-of-band; a legacy GQ1 value deletes its randomUUID blob. Fire-and-forget:
-   * the blob TTL is the correctness backstop, so the hot path never waits.
+   * out-of-band; a legacy GQ1 value deletes its randomUUID blob. Awaited by
+   * the caller (2026-07-11 fix): this was previously fire-and-forget, so a
+   * killed worker process could drop a release before it reached Redis,
+   * leaking the holder (or, combined with a concurrent transfer, racing it).
+   * Each value's release still degrades to a warn + the TTL backstop rather
+   * than throwing — one bad value must not abort the rest of the batch.
    */
-  release({ values, groupId }: { values: string[]; groupId: string }): void {
+  async release({
+    values,
+    groupId,
+  }: {
+    values: string[];
+    groupId: string;
+  }): Promise<void> {
     const expected = this.projectIdFor(groupId);
-    for (const value of values) {
-      // Single parse per value: hold + GQ1 blobId from one splitEnvelope so a
-      // maxBatch=10 coalesced completion doesn't do ~20 redundant Buffer.from +
-      // JSON.parse (2026-06-24 review).
-      const { hold, blobId } = readEnvelopeRetirement(value);
-      if (hold) {
-        // Tenant guard: never release a hold whose ref isn't this group's
-        // tenant. A mis-routed or forged GQ2 value must not reclaim another
-        // tenant's blob on the fail-safe cleanup path (ADR-030 §5).
-        if (hold.ref.projectId !== expected) {
-          logger.warn(
-            {
-              projectId: expected,
-              refProjectId: hold.ref.projectId,
-              blobHash: hold.ref.hash,
-              groupId,
-            },
-            "Skipping blob release for a tenant-mismatched ref",
-          );
-          continue;
-        }
-        void this.blobHolders
-          .release({
-            projectId: hold.ref.projectId,
-            hash: hold.ref.hash,
-            tier: hold.ref.tier,
-            slotId: hold.token,
-          })
-          .then((outcome) => {
+    await Promise.all(
+      values.map(async (value) => {
+        // Single parse per value: hold + GQ1 blobId from one splitEnvelope so a
+        // maxBatch=10 coalesced completion doesn't do ~20 redundant Buffer.from +
+        // JSON.parse (2026-06-24 review).
+        const { hold, blobId } = readEnvelopeRetirement(value);
+        if (hold) {
+          // Tenant guard: never release a hold whose ref isn't this group's
+          // tenant. A mis-routed or forged GQ2 value must not reclaim another
+          // tenant's blob on the fail-safe cleanup path (ADR-030 §5).
+          if (hold.ref.projectId !== expected) {
+            logger.warn(
+              {
+                projectId: expected,
+                refProjectId: hold.ref.projectId,
+                blobHash: hold.ref.hash,
+                groupId,
+              },
+              "Skipping blob release for a tenant-mismatched ref",
+            );
+            return;
+          }
+          try {
+            const outcome = await this.blobHolders.release({
+              projectId: hold.ref.projectId,
+              hash: hold.ref.hash,
+              tier: hold.ref.tier,
+              slotId: hold.token,
+            });
             if (outcome === "reclaim-s3" && this.tieredBlobs) {
-              return this.tieredBlobs.delete(hold.ref).catch((err: unknown) => {
+              try {
+                await this.tieredBlobs.delete(hold.ref);
+              } catch (err) {
                 // S3 reclaim failed — the holder is already gone, so no future
                 // release will retry this object. Warn AND counter so oncall
                 // sees a recurring failure before the bucket-lifecycle
@@ -268,10 +284,9 @@ export class EnvelopeBlobLifecycle {
                   },
                   "S3 blob reclaim failed after holder drop — orphaned until bucket lifecycle sweeps",
                 );
-              });
+              }
             }
-          })
-          .catch((err: unknown) => {
+          } catch (err) {
             logger.warn(
               {
                 projectId: hold.ref.projectId,
@@ -283,28 +298,35 @@ export class EnvelopeBlobLifecycle {
               },
               "Blob holder release/reclaim failed; relying on the TTL backstop",
             );
-          });
-        continue;
-      }
-      if (blobId) {
-        void this.blobs.delete({ id: blobId }).catch(() => undefined);
-      }
-    }
+          }
+          return;
+        }
+        if (blobId) {
+          try {
+            await this.blobs.delete({ id: blobId });
+          } catch {
+            // GQ1 blobs have no refcount/backstop beyond their own TTL;
+            // best-effort cleanup only.
+          }
+        }
+      }),
+    );
   }
 
   /**
    * Deletes the s3 object of a blob whose LAST hold was already dropped inside
    * a stage eval (the dedup-squash hold transfer runs in Lua, which cannot
    * reach s3 — the eval reports `reclaimS3` and this finishes the job).
-   * Fire-and-forget with the same failure telemetry as the release path.
+   * Awaited by the caller (2026-07-11 fix), same rationale as {@link release}.
+   * Same failure telemetry as the release path either way.
    */
-  reclaimOrphanedS3({
+  async reclaimOrphanedS3({
     value,
     groupId,
   }: {
     value: string;
     groupId: string;
-  }): void {
+  }): Promise<void> {
     const hold = readEnvelopeHold(value);
     if (!hold || hold.ref.tier !== "s3" || !this.tieredBlobs) return;
     // Same guard as release(): never delete an object whose ref isn't this
@@ -321,7 +343,9 @@ export class EnvelopeBlobLifecycle {
       );
       return;
     }
-    void this.tieredBlobs.delete(hold.ref).catch((err: unknown) => {
+    try {
+      await this.tieredBlobs.delete(hold.ref);
+    } catch (err) {
       gqBlobReclaimS3FailuresTotal.inc({ queue_name: this.queueName });
       // Tenant-attributed (never a bare hash, never the bucket): every blob
       // log line carries the owning projectId so logs can't cross tenants.
@@ -335,7 +359,7 @@ export class EnvelopeBlobLifecycle {
         },
         "S3 blob reclaim failed after squash-transfer holder drop — orphaned until bucket lifecycle sweeps",
       );
-    });
+    }
   }
 
   /**
@@ -344,8 +368,17 @@ export class EnvelopeBlobLifecycle {
    * reclaims the old blob if newly unreferenced — no acquire-then-release gap in
    * which a partial failure could reclaim a live blob (ADR-030 §4). Falls back to
    * ordered acquire+release when either side isn't a GQ2 hold.
+   *
+   * Awaited by the caller (2026-07-11 fix): this was previously fire-and-forget
+   * end to end, so a killed worker process — or simply a subsequent squash on
+   * the same group racing ahead before this one's Redis round trip landed —
+   * could interleave with another transfer/release for the same blob in
+   * whatever order the network happened to deliver them, rather than the
+   * caller's own call order. Awaiting makes each transfer complete (or fail
+   * loudly into its own warn) before the next squash on this group can start
+   * its own.
    */
-  transfer({
+  async transfer({
     newValue,
     oldValue,
     groupId,
@@ -353,7 +386,7 @@ export class EnvelopeBlobLifecycle {
     newValue: string;
     oldValue: string;
     groupId: string;
-  }): void {
+  }): Promise<void> {
     const expected = this.projectIdFor(groupId);
     const newHold = readEnvelopeHold(newValue);
     const oldHold = readEnvelopeHold(oldValue);
@@ -370,7 +403,7 @@ export class EnvelopeBlobLifecycle {
         },
         "Skipping blob acquire for a tenant-mismatched replacement ref",
       );
-      this.release({ values: [oldValue], groupId });
+      await this.release({ values: [oldValue], groupId });
       return;
     }
     // Fall back to ordered acquire+release when either side isn't a GQ2 hold, or
@@ -385,27 +418,25 @@ export class EnvelopeBlobLifecycle {
     // atomic like TRANSFER_LUA — extending the Lua for the mixed-format case
     // is tracked as a follow-up.
     if (!newHold || !oldHold || oldHold.ref.projectId !== expected) {
-      void (async () => {
-        try {
-          await this.acquireAwait(newValue);
-        } catch (err) {
-          logger.warn(
-            {
-              refProjectId: newHold?.ref.projectId,
-              blobHash: newHold?.ref.hash,
-              groupId,
-              err: err instanceof Error ? err.message : String(err),
-            },
-            "transfer fallback: acquire failed; skipping release to keep old blob alive under TTL",
-          );
-          return;
-        }
-        this.release({ values: [oldValue], groupId });
-      })();
+      try {
+        await this.acquireAwait(newValue);
+      } catch (err) {
+        logger.warn(
+          {
+            refProjectId: newHold?.ref.projectId,
+            blobHash: newHold?.ref.hash,
+            groupId,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "transfer fallback: acquire failed; skipping release to keep old blob alive under TTL",
+        );
+        return;
+      }
+      await this.release({ values: [oldValue], groupId });
       return;
     }
-    void this.blobHolders
-      .transfer({
+    try {
+      const outcome = await this.blobHolders.transfer({
         newProjectId: newHold.ref.projectId,
         newHash: newHold.ref.hash,
         newSlotId: newHold.token,
@@ -413,37 +444,37 @@ export class EnvelopeBlobLifecycle {
         oldHash: oldHold.ref.hash,
         oldTier: oldHold.ref.tier,
         oldSlotId: oldHold.token,
-      })
-      .then((outcome) => {
-        if (outcome === "reclaim-s3" && this.tieredBlobs) {
-          return this.tieredBlobs.delete(oldHold.ref).catch((err: unknown) => {
-            gqBlobReclaimS3FailuresTotal.inc({ queue_name: this.queueName });
-            logger.warn(
-              {
-                projectId: oldHold.ref.projectId,
-                blobHash: oldHold.ref.hash,
-                err: redactStorageUrisInText(
-                  err instanceof Error ? err.message : String(err),
-                ),
-              },
-              "S3 blob reclaim failed after transfer — orphaned until bucket lifecycle sweeps",
-            );
-          });
-        }
-      })
-      .catch((err: unknown) => {
-        logger.warn(
-          {
-            projectId: oldHold.ref.projectId,
-            blobHash: oldHold.ref.hash,
-            tier: oldHold.ref.tier,
-            err: redactStorageUrisInText(
-              err instanceof Error ? err.message : String(err),
-            ),
-          },
-          "Blob holder transfer failed; relying on the TTL backstop",
-        );
       });
+      if (outcome === "reclaim-s3" && this.tieredBlobs) {
+        try {
+          await this.tieredBlobs.delete(oldHold.ref);
+        } catch (err) {
+          gqBlobReclaimS3FailuresTotal.inc({ queue_name: this.queueName });
+          logger.warn(
+            {
+              projectId: oldHold.ref.projectId,
+              blobHash: oldHold.ref.hash,
+              err: redactStorageUrisInText(
+                err instanceof Error ? err.message : String(err),
+              ),
+            },
+            "S3 blob reclaim failed after transfer — orphaned until bucket lifecycle sweeps",
+          );
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        {
+          projectId: oldHold.ref.projectId,
+          blobHash: oldHold.ref.hash,
+          tier: oldHold.ref.tier,
+          err: redactStorageUrisInText(
+            err instanceof Error ? err.message : String(err),
+          ),
+        },
+        "Blob holder transfer failed; relying on the TTL backstop",
+      );
+    }
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -22,7 +22,10 @@ import {
   tenantIdFromGroupId,
 } from "../../../observability/tenantRateTracker";
 import { connection } from "../../../redis";
-import type { ProjectStorageDestination } from "../../../stored-objects/project-storage-destination";
+import {
+  redactStorageUrisInText,
+  type ProjectStorageDestination,
+} from "../../../stored-objects/project-storage-destination";
 import { isDispatchError } from "../../outbox/dispatchError";
 import type {
   DeduplicationConfig,
@@ -431,10 +434,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     //     backstop.
     if (orphanedValue) {
       if (reclaimS3) {
-        this.blobLifecycle.reclaimOrphanedS3({ value: orphanedValue, groupId });
+        await this.blobLifecycle.reclaimOrphanedS3({
+          value: orphanedValue,
+          groupId,
+        });
       }
     } else {
-      this.blobLifecycle.acquire(jobDataJson);
+      await this.blobLifecycle.acquire(jobDataJson);
     }
 
     if (isNew) {
@@ -561,19 +567,21 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // only delete s3 objects the eval reported newly unreferenced, and acquire
     // holds for genuinely new stages. A squash that discarded the NEW value
     // (orphan === the job's own value) staged nothing and gets no hold.
-    jobsToStage.forEach((job, i) => {
-      const orphan = orphanedValues[i];
-      if (orphan && orphan.length > 0) {
-        if (reclaimS3Flags[i]) {
-          this.blobLifecycle.reclaimOrphanedS3({
-            value: orphan,
-            groupId: job.groupId,
-          });
+    await Promise.all(
+      jobsToStage.map(async (job, i) => {
+        const orphan = orphanedValues[i];
+        if (orphan && orphan.length > 0) {
+          if (reclaimS3Flags[i]) {
+            await this.blobLifecycle.reclaimOrphanedS3({
+              value: orphan,
+              groupId: job.groupId,
+            });
+          }
+        } else {
+          await this.blobLifecycle.acquire(job.jobDataJson);
         }
-      } else {
-        this.blobLifecycle.acquire(job.jobDataJson);
-      }
-    });
+      }),
+    );
 
     const dedupedCount = payloads.length - newStagedCount;
     if (newStagedCount > 0) {
@@ -721,13 +729,16 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           projectId: tenantIdFromGroupId(groupId),
           stagedJobId,
           groupId,
+          err: redactStorageUrisInText(
+            err instanceof Error ? err.message : String(err),
+          ),
         },
         "Failed to parse staged job data",
       );
       // Missing blob or unparseable value: complete the slot so it's not stuck;
       // recover via event replay.
       await this.scripts.complete({ groupId, stagedJobId });
-      this.blobLifecycle.release({ values: [jobDataJson], groupId });
+      await this.blobLifecycle.release({ values: [jobDataJson], groupId });
       return;
     }
 
@@ -914,7 +925,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               // removed from staging during the drain, so completing the
               // dispatched job is enough to free the group.
               await this.scripts.complete({ groupId, stagedJobId, jobName });
-              this.blobLifecycle.release({
+              await this.blobLifecycle.release({
                 values: [
                   jobDataJson,
                   ...drainedSiblings.map((sibling) => sibling.jobDataJson),
@@ -998,7 +1009,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                     },
                     "Retry re-encode failed; releasing old hold and falling through to fail-safe",
                   );
-                  this.blobLifecycle.release({
+                  await this.blobLifecycle.release({
                     values: [jobDataJson],
                     groupId,
                   });
@@ -1028,7 +1039,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 // hash, so it's SADD+SREM on one holder set (the blob stays
                 // referenced); for a mixed/GQ1 value it falls back to ordered
                 // acquire+release. Drained siblings keep their ORIGINAL values.
-                this.blobLifecycle.transfer({
+                await this.blobLifecycle.transfer({
                   newValue: retryJobData,
                   oldValue: jobDataJson,
                   groupId,
@@ -1103,7 +1114,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                       }),
                   ),
                 );
-                this.blobLifecycle.release({ values: [jobDataJson], groupId });
+                await this.blobLifecycle.release({
+                  values: [jobDataJson],
+                  groupId,
+                });
               }
             }
           },
@@ -1189,6 +1203,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           queueName: this.queueName,
           groupId,
           stagedJobId: sibling.stagedJobId,
+          err: err instanceof Error ? err.message : String(err),
         },
         "Failed to parse drained sibling job data — dropping (recoverable via replay)",
       );
@@ -1218,7 +1233,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         });
         // Re-acquire the sibling's hold (idempotent: it kept its hold through
         // the drain, and its value — hence token — is unchanged).
-        this.blobLifecycle.acquire(sibling.jobDataJson);
+        await this.blobLifecycle.acquire(sibling.jobDataJson);
       } catch (err) {
         this.logger.error(
           {
@@ -1315,7 +1330,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
     // Acquire the re-staged value's hold; the caller releases the dispatched
     // one after this returns (acquire-before-release keeps a GQ2 blob alive).
-    this.blobLifecycle.acquire(jobDataJson);
+    await this.blobLifecycle.acquire(jobDataJson);
 
     gqGroupsBlockedTotal.inc(routingLabels);
     gqJobsExhaustedTotal.inc(routingLabels);
@@ -1366,7 +1381,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         "Blob store unreachable after retries; completing slot to recover via replay",
       );
       await this.scripts.complete({ groupId, stagedJobId });
-      this.blobLifecycle.release({ values: [jobDataJson], groupId });
+      await this.blobLifecycle.release({ values: [jobDataJson], groupId });
       return;
     }
     const backoffMs = getBackoffMs(attempt);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
@@ -271,9 +271,10 @@ export class TieredBlobStore {
   }
 
   /**
-   * Returns null when a redis-tier blob is gone; lets an s3 read error
-   * propagate. Either way the envelope decode treats the absence as a missing
-   * blob and reaches the fail-safe (complete the slot, recover via replay).
+   * Returns null when a blob is genuinely gone (key absent, or a durable-store
+   * "not found"). A client-side failure on either tier (connection drop,
+   * timeout, OOM rejection, network 5xx) throws {@link TransientBlobStoreError}
+   * instead, so the caller retries rather than treating a blip as "missing".
    */
   async get(ref: BlobRef): Promise<Buffer | null> {
     return this.fetch(ref, /* refresh */ true);
@@ -293,9 +294,25 @@ export class TieredBlobStore {
   private async fetch(ref: BlobRef, refresh: boolean): Promise<Buffer | null> {
     if (ref.tier === "redis") {
       const id = redisBlobId({ projectId: ref.projectId, hash: ref.hash });
-      return refresh
-        ? this.redisBlobs.get({ id, ttlSeconds: BLOB_BACKSTOP_TTL_SECONDS })
-        : this.redisBlobs.peek({ id });
+      // A redis-tier miss is represented by a null return (GETEX/GET on an
+      // absent key), never an exception — so any exception here is the
+      // client itself (connection drop, command timeout, OOM-from-noeviction
+      // rejection), not "the blob is gone". Treat it as transient (retry),
+      // mirroring the s3 branch below, instead of letting it fall through to
+      // the decode fail-safe and permanently drop a job over a blip
+      // (2026-07-11 incident: uncaught ioredis errors here were indistinguishable
+      // from a genuinely missing blob).
+      try {
+        return await (refresh
+          ? this.redisBlobs.get({ id, ttlSeconds: BLOB_BACKSTOP_TTL_SECONDS })
+          : this.redisBlobs.peek({ id }));
+      } catch (err) {
+        throw new TransientBlobStoreError({
+          projectId: ref.projectId,
+          hash: ref.hash,
+          cause: err,
+        });
+      }
     }
     // Re-mint OUTSIDE the missing-classification: a destination-resolve / mint
     // failure is transient (retry), never "missing" (ADR-030 §2).


### PR DESCRIPTION
## Summary

Investigated a steady ~15-34k/day rate of `"Failed to parse staged job data"` errors in prod (mostly on `governanceOcsfEventsSync`, `governanceKpisSync`, `projectMetadata`, `gatewayBudgetSync` — the reactors whose fold-state payloads are most likely to cross the blob-offload threshold). Root cause: an asymmetry between the two `TieredBlobStore` tiers.

- **`tieredBlobStore.ts`**: the s3-tier `fetch()` branch already classified errors — a genuine "not found" returns `null`, anything else (network blip, 5xx) throws `TransientBlobStoreError` so the caller retries (ADR-030 §2). The **redis-tier branch had no error handling at all** — any exception from `RedisJobBlobStore.get()`/`.peek()` (connection drop, timeout, an `OOM command not allowed` rejection under the cluster's `noeviction` policy) propagated raw. Since a redis-tier miss is already represented by a `null` return (not an exception), any thrown error here is now wrapped as `TransientBlobStoreError` too, so it retries instead of permanently completing the slot and dropping the job.
- **`envelopeBlobLifecycle.ts` / `groupQueue.ts`**: `acquire`/`release`/`transfer`/`reclaimOrphanedS3` were fire-and-forget (`void promise.catch(...)`) from every call site. A killed worker process mid-flight could drop one of these silently — before it even reached Redis, never even hitting the existing `.catch()` warning — and nothing ordered one squash's holder bookkeeping against the next squash on the same group. All four are now `async`, awaited at every call site, and still degrade internally to a warn + the TTL backstop on failure rather than throwing — job completion/retry semantics are unchanged, only the ordering and drop-safety improved.
- Logged the actual (redacted) error message on the `"Failed to parse staged job data"` and `"Failed to parse drained sibling job data"` catch-alls, which previously gave zero way to distinguish a missing blob from a malformed envelope from a transient store error — this is what made the original bug so hard to diagnose from logs alone.

## Test plan
- [x] `pnpm run typecheck` — no errors in any of the three touched files (pre-existing unrelated errors elsewhere in the repo, confirmed present on origin/main baseline)
- [x] Unit tests: `tieredBlobStore.unit.test.ts`, `jobEnvelope.unit.test.ts`, `jobEnvelope.codec.unit.test.ts`, `groupQueue.retries.unit.test.ts`, `groupQueue.blockingConnection.unit.test.ts`, `groupQueue.waitUntilReady.unit.test.ts` — 72/72 passing
- [ ] Integration tests (`envelopeBlobLifecycle.integration.test.ts`, `blobHolders.integration.test.ts`, `redisJobBlobStore.integration.test.ts`, `groupQueue.gq2.integration.test.ts`) — could not run in this sandbox (testcontainers couldn't detect a container runtime strategy here); please have CI verify
- [ ] Deploy and confirm the `"Failed to parse staged job data"` volume drops, and that the new `err` field on that log line surfaces the actual failure reason for any remaining occurrences

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of queued event processing by ensuring storage cleanup and ownership changes complete before processing continues.
  * Added safer retry behavior for temporary storage failures, reducing incorrect “missing data” results.
  * Strengthened cleanup when jobs fail, expire, or are retried.

* **Security & Privacy**
  * Sensitive storage addresses are now redacted from error logs.

* **Reliability**
  * Improved handling of orphaned and transferred stored data, including clearer monitoring when cleanup cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->