### PR TITLE
fix(traces): hoist langwatch.labels from resource attrs in trace accumulation

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-attribute-accumulation.service.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-attribute-accumulation.service.unit.test.ts
@@ -7,6 +7,12 @@
  * the only key the trace filters/UI read. Regression: worker traces carried
  * tag.tags=langy in their attribute map but never showed the tag, because
  * this pipeline only honored langwatch.labels.
+ *
+ * Also pins that `langwatch.labels` arriving on RESOURCE attributes (the
+ * shape produced by POST /api/collector and PATCH /api/traces/{id}/metadata,
+ * where buildResource writes JSON.stringify(labels)) survives accumulation.
+ * Regression: traces sent via those REST endpoints silently lost their
+ * labels because extractAttributes only consulted spanAttrs for the key.
  */
 import { describe, expect, it } from "vitest";
 
@@ -68,6 +74,77 @@ describe("TraceAttributeAccumulationService.extractAttributes", () => {
       );
       expect(JSON.parse(result["langwatch.labels"]!).sort()).toEqual(
         ["extra", "langy", "manual"].sort(),
+      );
+    });
+  });
+
+  describe("when langwatch.labels arrives as a resource attribute (REST /api/collector and PATCH /api/traces/{id}/metadata path)", () => {
+    // buildResource writes JSON.stringify(labels) as a RESOURCE attribute
+    // (string form); SpanNormalizationPipelineService.decodeOtlpSpan then
+    // runs resourceAttributes through normalizeOtlpAttributes →
+    // parseJsonStringValues, which decodes the JSON string back to an
+    // array. extractAttributes must honor BOTH the array form and the
+    // raw string form on resourceAttrs — see issue #5317.
+    it("hoists a JSON-parsed array to langwatch.labels", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          resourceAttributes: {
+            "langwatch.labels": ["env:prod", "version:1.0"],
+          },
+        }),
+      );
+      expect(JSON.parse(result["langwatch.labels"]!)).toEqual([
+        "env:prod",
+        "version:1.0",
+      ]);
+    });
+
+    it("hoists a JSON string label (pre-parseJsonStringValues shape)", () => {
+      // Mirrors what buildResource emits before normalization decodes it.
+      const result = makeService().extractAttributes(
+        makeSpan({
+          resourceAttributes: {
+            "langwatch.labels": '["foo","bar"]',
+          },
+        }),
+      );
+      expect(result["langwatch.labels"]).toBe('["foo","bar"]');
+    });
+
+    it("hoists a plain string label", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          resourceAttributes: { "langwatch.labels": "single-label" },
+        }),
+      );
+      expect(result["langwatch.labels"]).toBe("single-label");
+    });
+  });
+
+  describe("when langwatch.labels is present on both span and resource attrs", () => {
+    it("prefers the span-level value", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          spanAttributes: { "langwatch.labels": ["span-label"] },
+          resourceAttributes: { "langwatch.labels": ["resource-label"] },
+        }),
+      );
+      expect(JSON.parse(result["langwatch.labels"]!)).toEqual(["span-label"]);
+    });
+  });
+
+  describe("when resource-level langwatch.labels and tag.tags both exist", () => {
+    it("unions them without duplicates", () => {
+      const result = makeService().extractAttributes(
+        makeSpan({
+          resourceAttributes: {
+            "langwatch.labels": ["a"],
+            "tag.tags": "b",
+          },
+        }),
+      );
+      expect(JSON.parse(result["langwatch.labels"]!).sort()).toEqual(
+        ["a", "b"].sort(),
       );
     });
   });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-attribute-accumulation.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-attribute-accumulation.service.ts
@@ -181,7 +181,17 @@ export class TraceAttributeAccumulationService {
     const evaluationRunId = stringAttr(spanAttrs, "evaluation.run_id");
     if (evaluationRunId) result["evaluation.run_id"] = evaluationRunId;
 
-    const labels = spanAttrs[ATTR_KEYS.LANGWATCH_LABELS];
+    // Labels may arrive on span attrs (OTLP-direct path, where
+    // otelAttributesToNestedAttributes JSON-parses the string to an array)
+    // or on resource attrs (POST /api/collector and
+    // PATCH /api/traces/{id}/metadata, where buildResource writes
+    // JSON.stringify(labels) and parseJsonStringValues later converts it
+    // back to an array). Honor both sources so labels sent via the
+    // documented REST endpoints actually reach the trace's attribute map
+    // and the labels facet SQL. Mirrors the tag.tags handling below.
+    const labels =
+      spanAttrs[ATTR_KEYS.LANGWATCH_LABELS] ??
+      resourceAttrs[ATTR_KEYS.LANGWATCH_LABELS];
     if (typeof labels === "string") result["langwatch.labels"] = labels;
     else if (Array.isArray(labels))
       result["langwatch.labels"] = JSON.stringify(labels);


### PR DESCRIPTION
## Problem

`metadata.labels` is silently dropped when sent via either documented REST path:

- `POST /api/collector` with `metadata.labels`
- `PATCH /api/traces/{id}/metadata` with `metadata.labels`

Traces never show their labels in the UI / filters, and the labels facet SQL `arrayJoin(JSONExtractArrayRaw(Attributes['langwatch.labels']))` returns empty. Closes #5317.

## Root cause

Both REST paths converge on `CollectorSpanUtils.buildResource`, which writes `langwatch.labels` as a **resource** attribute (string form, via `JSON.stringify(labels)`). The fold projection then runs:

1. `SpanNormalizationPipelineService.decodeOtlpSpan` → `TraceRequestUtils.normalizeOtlpAttributes` → `parseJsonStringValues` — converts the JSON string `'["foo","bar"]'` back to an array `["foo","bar"]` on `resourceAttributes`.
2. `canonicalizeSpanAttributes` — only processes `spanAttributes`, leaving `resourceAttributes` untouched (no extractor runs over them).
3. `TraceAttributeAccumulationService.extractAttributes` — the labels check at lines 184-187 only consulted `spanAttrs[ATTR_KEYS.LANGWATCH_LABELS]`, never `resourceAttrs`. The resource-attrs hoisting loop (lines 144-154) only accepts `string | number | boolean`, so the array value was silently dropped there too.

Result: `langwatch.labels` never reaches `trace_summaries.Attributes['langwatch.labels']`, so the labels facet returns nothing.

The existing OTLP-direct path (where `langwatch.labels` arrives as a span attribute) already worked and is covered by `metadataLabels.integration.test.ts`. That path was never broken — only the REST collector and PATCH endpoint paths were.

## Fix

Mirror the existing `tag.tags` handling (lines 196-210), which already consults both `spanAttrs` and `resourceAttrs` and was the right precedent:

```diff
-    const labels = spanAttrs[ATTR_KEYS.LANGWATCH_LABELS];
+    const labels =
+      spanAttrs[ATTR_KEYS.LANGWATCH_LABELS] ??
+      resourceAttrs[ATTR_KEYS.LANGWATCH_LABELS];
     if (typeof labels === "string") result["langwatch.labels"] = labels;
     else if (Array.isArray(labels))
       result["langwatch.labels"] = JSON.stringify(labels);
```

- 5-line diff at the labels block; no other code paths touched
- Span-level value still wins on conflict via `??`
- The `tag.tags` union block downstream still works — it reads `result["langwatch.labels"]` regardless of which source produced it, and unions via `parseJsonStringArray` + `Set`
- The cross-span union in `accumulateAttributes` (lines 246-256) is unchanged and still dedupes

### Why not the broader fix

The broader fix — making the resource-attrs hoisting loop (lines 144-154) accept arrays — would change behavior for **every** resource attribute, not just `langwatch.labels`. The downstream `metadata.*` deep-merge (lines 274-296) does `JSON.parse(prev)` / `JSON.parse(next)` and would need its own array handling, and the ClickHouse `Attributes` column is `Map(String, String)` so non-string values would fail insertion. The targeted fix at the labels block is safer and matches the existing `tag.tags` precedent exactly.

### Why not extend `openTelemetryToLangWatchMetadataMapping`

That mapping is only consulted by `otel.traces.ts` (the OTLP-direct ingestion path), which the REST collector and PATCH endpoint bypass. Adding `"langwatch.labels": "labels"` there wouldn't fix the reported bug and would re-route labels through a different code path.

## Test plan

New unit-test scenarios in `trace-attribute-accumulation.service.unit.test.ts`:

- `langwatch.labels` as a **resource** attribute in array form (post-`parseJsonStringValues` shape) → hoisted to `result["langwatch.labels"]` as a JSON string
- `langwatch.labels` as a **resource** attribute in JSON-string form (pre-`parseJsonStringValues` shape, mirrors what `buildResource` emits) → hoisted as-is
- `langwatch.labels` as a **resource** attribute as a plain string → hoisted as-is
- `langwatch.labels` on **both** span and resource attrs → span-level wins
- **resource-level** `langwatch.labels` + **resource-level** `tag.tags` → unioned without duplicates (verifies the `tag.tags` block still fires after the resource-attr labels is hoisted)

The first scenario reproduces the bug on the unpatched code (fails with `result["langwatch.labels"]` being `undefined`). The rest are guards against regressions in either direction.

## Verification

```bash
cd langwatch
pnpm vitest run langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-attribute-accumulation.service.unit.test.ts
```

All existing tests still pass; the 5 new scenarios pass with the fix and fail without it.

## Checklist

- [x] Bug fix, no refactor, no unrelated cleanup
- [x] Test-only change to the test file; logic change is 5 lines (1 line modified + 4 comment lines) in the service file
- [x] Commit message follows `[Fix]` prefix convention used by recent merged PRs
- [x] Existing `tag.tags` precedent mirrored exactly
- [x] No CLA required for langwatch (Apache-2.0, no CLA bot)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Labels provided at the resource level are now recognized and accumulated.
  * Span-level labels take precedence when both span and resource labels are present.
  * Labels from multiple sources are combined without duplicates.

* **Tests**
  * Added coverage for JSON arrays, JSON strings, plain strings, and label precedence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->