### PR TITLE
fix(recursion): stop the langwatch platform self-referencing its own trace ingest

### DIFF
--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -29,6 +29,15 @@ var services = map[string]ServiceBoot{
 }
 
 func main() {
+	// A langwatch platform process must never carry the langwatch SDK's own
+	// LANGWATCH_API_KEY. With it set, the platform's OTel/SDK bootstrap exports the
+	// platform's own operational telemetry into its own trace ingest — a
+	// self-referencing feedback loop (every ingested span does more work that emits
+	// more spans). Refuse to boot rather than silently self-reference.
+	if os.Getenv("LANGWATCH_API_KEY") != "" {
+		panic("LANGWATCH_API_KEY must not be set on a langwatch platform process — it makes " +
+			"the platform self-reference its own trace ingest (a feedback loop).")
+	}
 	os.Exit(run(os.Args))
 }
 

--- a/langwatch/prisma/seed.ts
+++ b/langwatch/prisma/seed.ts
@@ -98,8 +98,17 @@ const PUBLIC_TOKEN_ROLE_NAME = "local-dev-public-ingestion";
 const MODEL_DEFAULT_CONFIG_ID = "local-dev-model-default-config";
 
 async function main() {
-  const apiKey = process.env.LANGWATCH_API_KEY ?? DEFAULT_INGESTION_KEY;
-  console.log(`🌱 Seeding static local dev identity (ingestion key: ${apiKey})`);
+  // Prefer the haven-injected local credential (HAVEN_SEED_LANGWATCH_API_KEY); the
+  // platform never carries LANGWATCH_API_KEY anymore, but keep it as a fallback for
+  // non-haven flows that still pass one explicitly.
+  const apiKey =
+    process.env.HAVEN_SEED_LANGWATCH_API_KEY ??
+    process.env.LANGWATCH_API_KEY ??
+    DEFAULT_INGESTION_KEY;
+  // Redact — in non-haven flows apiKey may be a real credential, and logs get shipped.
+  console.log(
+    `🌱 Seeding static local dev identity (ingestion key: ${apiKey.slice(0, 8)}…)`,
+  );
 
   const organization = await prisma.organization.upsert({
     where: { id: ORG_ID },

--- a/langwatch/src/instrumentation.node.ts
+++ b/langwatch/src/instrumentation.node.ts
@@ -1,3 +1,9 @@
+// Platform self-reference guard — the FIRST import so it runs before any OTel or
+// langwatch module is evaluated (or any import-time side effect can wire an exporter).
+// A platform process holding LANGWATCH_API_KEY would self-reference its own trace
+// ingest; the boot module throws. See langwatchPlatformGuard for the full rationale.
+import "./langwatchPlatformGuard.boot";
+
 import { metrics } from "@opentelemetry/api";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
 import {

--- a/langwatch/src/langwatchPlatformGuard.boot.ts
+++ b/langwatch/src/langwatchPlatformGuard.boot.ts
@@ -1,0 +1,8 @@
+import { assertPlatformHasNoLangwatchApiKey } from "./langwatchPlatformGuard";
+
+// Side-effect module: importing it runs the platform self-reference guard. It is the
+// VERY FIRST import in instrumentation.node.ts, so the platform refuses to boot before
+// any OTel/langwatch module — or a future import-time side effect — can wire an
+// exporter. Kept separate from langwatchPlatformGuard.ts so the pure function stays
+// unit-testable without the ambient-process.env check firing merely on import.
+assertPlatformHasNoLangwatchApiKey();

--- a/langwatch/src/langwatchPlatformGuard.ts
+++ b/langwatch/src/langwatchPlatformGuard.ts
@@ -1,0 +1,26 @@
+/**
+ * A langwatch *platform* process (the app server + the workers) must never carry the
+ * langwatch SDK's own `LANGWATCH_API_KEY`. With it set, the platform's OTel/SDK
+ * bootstrap wires a langwatch exporter and ships the platform's OWN operational
+ * telemetry into its OWN trace ingest — a self-referencing feedback loop: every
+ * ingested span does more work (Redis, Postgres, ClickHouse) that emits more spans,
+ * which get ingested, which… The observed symptom is a runaway `recordSpan` backlog.
+ *
+ * Run via `langwatchPlatformGuard.boot`, imported first in `instrumentation.node.ts` —
+ * the only platform file that calls `setupObservability()` (the exporter-wiring point),
+ * itself loaded by exactly the two platform entry points: the Next.js `register()` hook
+ * (the app) and `workers.ts`. SDK-client subprocesses that legitimately call
+ * `setupObservability()` with a key — the `ai-server` dogfood tool, and the scenario
+ * child via `@langwatch/scenario` — do NOT load it, so they are unaffected. We refuse
+ * to boot rather than silently self-reference.
+ */
+export function assertPlatformHasNoLangwatchApiKey(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (env.LANGWATCH_API_KEY) {
+    throw new Error(
+      "LANGWATCH_API_KEY must not be set on a langwatch platform process — it makes the " +
+        "platform self-reference its own trace ingest (a feedback loop).",
+    );
+  }
+}

--- a/langwatch/src/langwatchPlatformGuard.unit.test.ts
+++ b/langwatch/src/langwatchPlatformGuard.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { assertPlatformHasNoLangwatchApiKey } from "./langwatchPlatformGuard";
+
+describe("assertPlatformHasNoLangwatchApiKey", () => {
+  describe("given LANGWATCH_API_KEY is unset", () => {
+    it("allows boot", () => {
+      expect(() => assertPlatformHasNoLangwatchApiKey({})).not.toThrow();
+    });
+  });
+
+  describe("given LANGWATCH_API_KEY is set", () => {
+    it("refuses to boot", () => {
+      expect(() =>
+        assertPlatformHasNoLangwatchApiKey({ LANGWATCH_API_KEY: "sk-lw-real-key" }),
+      ).toThrow(/must not be set on a langwatch platform/);
+    });
+  });
+
+  describe("given a non-trigger credential is set (e.g. haven's HAVEN_SEED_LANGWATCH_API_KEY)", () => {
+    it("allows boot, because only LANGWATCH_API_KEY is the SDK trigger", () => {
+      expect(() =>
+        assertPlatformHasNoLangwatchApiKey({
+          HAVEN_SEED_LANGWATCH_API_KEY: "sk-lw-local-development-key",
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("given LANGWATCH_API_KEY is set to an empty string", () => {
+    it("allows boot, treating empty as unset", () => {
+      expect(() =>
+        assertPlatformHasNoLangwatchApiKey({ LANGWATCH_API_KEY: "" }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/tools/thuishaven/domain/domain_test.go
+++ b/tools/thuishaven/domain/domain_test.go
@@ -243,14 +243,43 @@ func validCHIdentifier(s string) bool {
 	return true
 }
 
-func TestOverlayEmitsStableAPIKey(t *testing.T) {
+func TestOverlayEmitsHavenSeedLangwatchAPIKey(t *testing.T) {
 	st := Stack{Slug: "portless", APIPort: 1, Services: []Service{{Name: "app"}, {Name: "gateway"}, {Name: "nlp"}}}
-	if valueOf(st.OverlayEnv(), "LANGWATCH_API_KEY") != "" {
-		t.Fatalf("no key set → LANGWATCH_API_KEY must be absent")
+	if valueOf(st.OverlayEnv(), "HAVEN_SEED_LANGWATCH_API_KEY") != "" {
+		t.Fatalf("no key set → HAVEN_SEED_LANGWATCH_API_KEY must be absent")
 	}
 	st.LocalAPIKey = DefaultLocalAPIKey
-	if got := valueOf(st.OverlayEnv(), "LANGWATCH_API_KEY"); got != DefaultLocalAPIKey {
-		t.Errorf("LANGWATCH_API_KEY = %q, want the stable default %q", got, DefaultLocalAPIKey)
+	if got := valueOf(st.OverlayEnv(), "HAVEN_SEED_LANGWATCH_API_KEY"); got != DefaultLocalAPIKey {
+		t.Errorf("HAVEN_SEED_LANGWATCH_API_KEY = %q, want the stable default %q", got, DefaultLocalAPIKey)
+	}
+}
+
+// TestOverlayNeverEmitsLangwatchApiKey is the watertight guard: haven must NEVER put
+// LANGWATCH_API_KEY (the langwatch SDK's own key contract) into a platform child's env.
+// A platform process that saw it would self-instrument into its own trace ingest — a
+// feedback loop. haven carries the stable local credential under HAVEN_SEED_LANGWATCH_API_KEY
+// instead, and the TS + Go platform entry points panic if LANGWATCH_API_KEY is ever set.
+// (LANGWATCH_ENDPOINT is a benign address and is intentionally still emitted — only the
+// key triggers self-referencing.) If this test fails, that guarantee is broken.
+func TestOverlayNeverEmitsLangwatchApiKey(t *testing.T) {
+	// Fully-populated stack with the local API key set — the case that used to emit it.
+	st := Stack{
+		Slug: "portless", APIPort: 1, RedisDB: 3, WorkerMetricsPort: 2,
+		LocalAPIKey: DefaultLocalAPIKey,
+		Services:    []Service{{Name: "app"}, {Name: "gateway"}, {Name: "nlp"}, {Name: "langyagent"}},
+	}
+	if hasKey(st.OverlayEnv(), "LANGWATCH_API_KEY") {
+		t.Fatalf("overlay emitted LANGWATCH_API_KEY — a platform must never receive the " +
+			"langwatch SDK key contract (it self-references its own ingest). Use " +
+			"HAVEN_SEED_LANGWATCH_API_KEY instead.")
+	}
+	// The renamed key MUST be present so client callers still authenticate, and the
+	// benign endpoint stays exactly as it was.
+	if !hasKey(st.OverlayEnv(), "HAVEN_SEED_LANGWATCH_API_KEY") {
+		t.Errorf("overlay must emit HAVEN_SEED_LANGWATCH_API_KEY (the stable local credential)")
+	}
+	if !hasKey(st.OverlayEnv(), "LANGWATCH_ENDPOINT") {
+		t.Errorf("overlay must still emit LANGWATCH_ENDPOINT (a benign address, unchanged)")
 	}
 }
 

--- a/tools/thuishaven/domain/overlay.go
+++ b/tools/thuishaven/domain/overlay.go
@@ -63,9 +63,13 @@ func (s Stack) OverlayEnv() []string {
 		fmt.Sprintf("REDIS_DB_INDEX=%d", s.RedisDB),
 	}
 	// A stable local API key so the seed always mints the same credential and any
-	// agent can authenticate without rediscovering it per worktree.
+	// agent can authenticate without rediscovering it per worktree. Emitted as
+	// HAVEN_SEED_LANGWATCH_API_KEY, never LANGWATCH_API_KEY: the latter is the langwatch
+	// SDK trigger, and a platform process that had it set would self-instrument into
+	// its own trace ingest. The TS + Go platform entry points panic if LANGWATCH_API_KEY
+	// is ever set; domain_test.go pins that this overlay never emits it.
 	if s.LocalAPIKey != "" {
-		env = append(env, "LANGWATCH_API_KEY="+s.LocalAPIKey)
+		env = append(env, "HAVEN_SEED_LANGWATCH_API_KEY="+s.LocalAPIKey)
 	}
 	// The rest of the static seeded identity (see prisma/seed.ts's header comment
 	// for the full rationale) — same story: fixed values so any worktree or agent


### PR DESCRIPTION
## Problem

Under haven, the local langwatch instance was ingesting its **own** operational spans — a runaway `recordSpan` backlog (500k+ jobs), all `service.name=langwatch-backend`, auto-instrumented `ioredis` spans on `obs:tenant_rate:*` (the ingestion rate-limiter itself). Ingesting a span does more Redis work → more spans → more ingest. A feedback loop.

**Root cause:** haven's overlay injected `LANGWATCH_API_KEY` into every child (so seed / scenario / langy clients could authenticate). But `instrumentation.node.ts` treats a set `LANGWATCH_API_KEY` as "self-instrument via the langwatch SDK and export to `LANGWATCH_ENDPOINT`" — which under haven is the app itself.

Not a prod issue as shipped (the helm charts never set `LANGWATCH_API_KEY` on a backend deployment), but the latent trap is real.

## Fix

The API key is the trigger; `LANGWATCH_ENDPOINT` is a benign address and is left unchanged.

1. **haven** emits `HAVEN_SEED_LANGWATCH_API_KEY` (never `LANGWATCH_API_KEY`) for the seeded local-dev credential. `TestOverlayNeverEmitsLangwatchApiKey` pins that the overlay can never emit the SDK key again.
2. **The platform refuses to boot with `LANGWATCH_API_KEY` set.** The Go mono-binary (`cmd/service/main.go`) panics; the TS OTel bootstrap throws via a small guard module (`langwatchPlatformGuard.ts` + `.boot.ts`), imported **first** in `instrumentation.node.ts` — the only platform file that calls `setupObservability()` (the exporter-wiring point). SDK-client subprocesses that legitimately hold a key never load it: `ai-server` (dogfood) and the scenario child (via `@langwatch/scenario`).
3. **Naming scope.** The platform guards stay generic ("a platform can't have `LANGWATCH_API_KEY`"); only the haven domain (`overlay.go`, its test) and the seed name `HAVEN_SEED_LANGWATCH_API_KEY`. The seed reads `HAVEN_SEED_LANGWATCH_API_KEY ?? LANGWATCH_API_KEY` and no longer logs the key in full (redacted to a prefix).

## Verification
- thuishaven `go build` / `go vet` / `go test ./domain/` green, incl. the guard test; `cmd/service` builds with the boot-panic.
- `pnpm typecheck` clean; guard unit tests (`langwatchPlatformGuard.unit.test.ts`) pass.

## Deliberately deferred
- Namespacing `LANGWATCH_ENDPOINT` (benign address; the key alone closes the loop).
- Clearing the local ~500k `recordSpan` Redis backlog (operational).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented platform services from starting with a self-referencing ingestion configuration.
  - Updated local environment setup to use a dedicated seeded ingestion credential.
  - Prevented sensitive ingestion keys from appearing in startup logs.

- **Tests**
  - Added coverage verifying platform safeguards and environment-variable behavior.
  - Added regression checks ensuring the standard API key is never emitted by local overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->