### PR TITLE
refactor(typescript-sdk): extract createIntegrationObservability() helper for test setup (#3288)

### DIFF
--- a/sdks/typescript/src/client-sdk/tracing/__tests__/integration/create-tracing-proxy.integration.test.ts
+++ b/sdks/typescript/src/client-sdk/tracing/__tests__/integration/create-tracing-proxy.integration.test.ts
@@ -3,8 +3,8 @@ import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-tr
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { createTracingProxy } from "../../create-tracing-proxy";
 import { getLangWatchTracer } from "../../../../observability-sdk";
-import { NoOpLogger } from "../../../../logger";
-import { setupObservability } from "../../../../observability-sdk/setup/node";
+import { createIntegrationObservability } from "../../../../observability-sdk/setup/node/__tests__/createIntegrationObservability";
+import type { setupObservability } from "../../../../observability-sdk/setup/node";
 
 /**
  * Integration tests for createTracingProxy with real OpenTelemetry setup.
@@ -35,14 +35,9 @@ describe("createTracingProxy Integration Tests", () => {
     // from being attached — without it, test spans get buffered into the batch exporter and
     // never reach the InMemorySpanExporter, causing widespread "expected 1 span, got 0" flakes
     // (see langwatch/langwatch#3097).
-    observabilityHandle = setupObservability({
+    observabilityHandle = createIntegrationObservability({
       serviceName: "tracing-proxy-integration-test",
-      langwatch: "disabled",
       spanProcessors: [spanProcessor],
-      debug: { logger: new NoOpLogger() },
-      advanced: {
-        throwOnSetupError: true,
-      },
       attributes: {
         "test.suite": "tracing-proxy-integration",
         "test.environment": "vitest"

--- a/sdks/typescript/src/observability-sdk/instrumentation/langchain/__tests__/integration/simple-agent-and-tool.integration.test.ts
+++ b/sdks/typescript/src/observability-sdk/instrumentation/langchain/__tests__/integration/simple-agent-and-tool.integration.test.ts
@@ -10,9 +10,9 @@ import { z } from "zod";
 import { AgentExecutor, createToolCallingAgent } from "langchain/agents";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 import { LangWatchCallbackHandler } from "../..";
-import { setupObservability } from "../../../../setup/node";
+import type { setupObservability } from "../../../../setup/node";
 import { getLangWatchTracer } from "../../../../tracer";
-import { NoOpLogger } from "../../../../../logger";
+import { createIntegrationObservability } from "../../../../setup/node/__tests__/createIntegrationObservability";
 
 const RUN_EXTERNAL = process.env.RUN_EXTERNAL_LLM_TESTS === "true";
 
@@ -37,13 +37,10 @@ describe.skipIf(!RUN_EXTERNAL)("LangChain Integration Tests", () => {
     spanExporter = new InMemorySpanExporter();
     spanProcessor = new SimpleSpanProcessor(spanExporter);
 
-    observabilityHandle = setupObservability({
-      langwatch: "disabled",
+    observabilityHandle = createIntegrationObservability({
       serviceName: "langchain-integration-test",
-      debug: { logger: new NoOpLogger() },
       spanProcessors: [spanProcessor],
       advanced: {
-        throwOnSetupError: true,
         UNSAFE_forceOpenTelemetryReinitialization: true,
       },
       attributes: {

--- a/sdks/typescript/src/observability-sdk/setup/node/__tests__/createIntegrationObservability.ts
+++ b/sdks/typescript/src/observability-sdk/setup/node/__tests__/createIntegrationObservability.ts
@@ -1,0 +1,34 @@
+import { NoOpLogger } from "../../../../logger";
+import { setupObservability } from "../index";
+
+type SetupObservabilityOptions = NonNullable<
+  Parameters<typeof setupObservability>[0]
+>;
+
+/**
+ * Shared setup for observability integration tests.
+ *
+ * Standardizes the block these suites converged on after #3240: LangWatch
+ * export disabled (the tests assert against their own in-memory processors, not
+ * the network), setup errors thrown rather than swallowed, and a NoOpLogger so
+ * the SDK's own diagnostics stay out of test output. Callers pass the per-suite
+ * serviceName and processors; every default here is overridable, and any extra
+ * `advanced` flags merge over the thrown-on-error default.
+ *
+ * Making `langwatch: "disabled"` the default for this class of test keeps new
+ * integration tests from repeating the #3240 mistake of hitting the real
+ * exporter.
+ */
+export function createIntegrationObservability(
+  overrides: Omit<SetupObservabilityOptions, "langwatch"> & {
+    langwatch?: SetupObservabilityOptions["langwatch"];
+  },
+): ReturnType<typeof setupObservability> {
+  const { advanced, debug, ...rest } = overrides;
+  return setupObservability({
+    langwatch: "disabled",
+    debug: { logger: new NoOpLogger(), ...debug },
+    ...rest,
+    advanced: { throwOnSetupError: true, ...advanced },
+  });
+}

--- a/sdks/typescript/src/observability-sdk/span/__tests__/integration/span.integration.test.ts
+++ b/sdks/typescript/src/observability-sdk/span/__tests__/integration/span.integration.test.ts
@@ -3,10 +3,10 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { setupObservability } from "../../../setup/node";
+import type { setupObservability } from "../../../setup/node";
 import { getLangWatchTracer } from "../../../tracer";
 import { createLangWatchSpan } from "../..";
-import { NoOpLogger } from "../../../../logger";
+import { createIntegrationObservability } from "../../../setup/node/__tests__/createIntegrationObservability";
 import * as semconv from "../../../semconv";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 
@@ -71,16 +71,13 @@ describe("Span Integration Tests", () => {
     spanExporter = new InMemorySpanExporter();
     spanProcessor = new SimpleSpanProcessor(spanExporter);
 
-    observabilityHandle = setupObservability({
+    observabilityHandle = createIntegrationObservability({
       serviceName: "span-integration-test",
-      langwatch: "disabled",
       attributes: {
         "test.suite": "span-integration",
         "test.component": "span-data-formats",
       },
       spanProcessors: [spanProcessor],
-      debug: { logger: new NoOpLogger() },
-      advanced: { throwOnSetupError: true }
     });
   });
 

--- a/sdks/typescript/src/observability-sdk/tracer/__tests__/integration/tracer.integration.test.ts
+++ b/sdks/typescript/src/observability-sdk/tracer/__tests__/integration/tracer.integration.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { getLangWatchTracer } from "../..";
-import { NoOpLogger } from "../../../../logger";
+import { createIntegrationObservability } from "../../../setup/node/__tests__/createIntegrationObservability";
 import * as semconv from "../../../semconv";
-import { setupObservability } from "../../../setup/node";
+import type { setupObservability } from "../../../setup/node";
 
 /**
  * Integration tests for LangWatch tracer with real OpenTelemetry setup.
@@ -55,14 +55,9 @@ describe("Tracer Integration Tests", () => {
 
     // Setup observability with real OpenTelemetry SDK
     // Use spanProcessors instead of traceExporter as we don't want to wrap in a BatchSpanProcessor
-    observabilityHandle = setupObservability({
+    observabilityHandle = createIntegrationObservability({
       serviceName: "tracer-integration-test",
-      langwatch: "disabled",
       spanProcessors: [spanProcessor],
-      debug: { logger: new NoOpLogger() },
-      advanced: {
-        throwOnSetupError: true,
-      },
       attributes: {
         "test.suite": "tracer-integration",
         "test.environment": "vitest"


### PR DESCRIPTION
## Ticket

Closes #3288. After the #3240 OTLP flakiness fix, several observability integration suites converged on the same `setupObservability({ langwatch: "disabled", debug: { logger: new NoOpLogger() }, advanced: { throwOnSetupError: true }, ... })` block, differing only in `serviceName` and processors. The repetition is a missing abstraction and an easy place to forget the `langwatch: "disabled"` guard and hit the real exporter again.

## Change

- New test helper `createIntegrationObservability` (under `observability-sdk/setup/node/__tests__/`) that defaults `langwatch: "disabled"`, a `NoOpLogger`, and `throwOnSetupError: true`, merging any extra `advanced` flags over the default. Every default is overridable.
- Migrated the call sites that used exactly that block: `tracer`, `span`, `create-tracing-proxy`, and the langchain `simple-agent-and-tool` suite (which keeps its `UNSAFE_forceOpenTelemetryReinitialization` flag via `advanced`).
- The `setupObservability` import in each migrated file becomes a type-only import (used for the handle type).

### Intentionally not migrated

These use a deliberately different setup; folding them into the helper would change behavior, so they are left as-is:

- `complex-multi-agent` (langchain) omits `throwOnSetupError`.
- `logger` suite uses a mock logger, not `NoOpLogger`.
- `setup-*` suites exercise real `langwatch: { apiKey }` setup, not the disabled path.

A follow-up could reconcile those individually if desired; that is a per-site judgement call rather than a mechanical swap.

## Evidence

- `npx vitest run` on the three non-gated migrated suites: **54 passed** (tracer, span, create-tracing-proxy). The langchain suite is `describe.skipIf(!RUN_EXTERNAL_LLM_TESTS)` and skips by default; its file compiles and loads under the helper.
- `npx tsc --noEmit`: clean.
- `npx eslint` on the changed files: clean (the newly type-only imports use `import type`).

The helper lives under `__tests__/` and is only imported by test files, so tsup (which builds from explicit entry points) never bundles it into the published package.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized observability integration test setup across tracing, instrumentation, spans, and tracers.
  * Improved test failure visibility by consistently surfacing setup errors.
  * Reduced repetitive test configuration while preserving configurable overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->