### PR TITLE
fix(scenarios): bound generate dispatch so a failing gateway can't surface as HTML (#5758)

### DIFF
--- a/langwatch/src/components/scenarios/services/__tests__/scenarioGeneration.unit.test.ts
+++ b/langwatch/src/components/scenarios/services/__tests__/scenarioGeneration.unit.test.ts
@@ -88,6 +88,53 @@ describe("generateScenarioWithAI()", () => {
     });
   });
 
+  describe("when the response body is not JSON (HTML error page)", () => {
+    // Regression for langwatch#5758. The generate endpoint answers with JSON on
+    // every outcome, so a NON-JSON body means the response came from a layer in
+    // FRONT of the app — a reverse-proxy / gateway 502·504, an auth-redirect
+    // login page, a timeout error page, or an older self-hosted Next.js build.
+    // Before the fix, `response.json()` threw a raw
+    // `Unexpected token '<', "<!DOCTYPE "... is not valid JSON` that leaked to
+    // the user and masked the real HTTP status. A real Response is used so the
+    // genuine JSON.parse crash is exercised, not a hand-faked reject.
+    const HTML_ERROR_BODY =
+      "<!DOCTYPE html>\n<html><head><title>502 Bad Gateway</title></head>" +
+      "<body><h1>502 Bad Gateway</h1></body></html>";
+
+    beforeEach(() => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        new Response(HTML_ERROR_BODY, {
+          status: 502,
+          statusText: "Bad Gateway",
+          headers: { "content-type": "text/html" },
+        })
+      );
+    });
+
+    it("does not leak a raw JSON.parse error to the caller", async () => {
+      const error = await generateScenarioWithAI(
+        "test prompt",
+        "project-123",
+        null
+      ).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).not.toMatch(
+        /Unexpected token|is not valid JSON|DOCTYPE/i
+      );
+    });
+
+    it("surfaces the HTTP status so the failure is actionable", async () => {
+      const error = await generateScenarioWithAI(
+        "test prompt",
+        "project-123",
+        null
+      ).catch((e: unknown) => e);
+
+      expect((error as Error).message).toContain("502");
+    });
+  });
+
   describe("when API returns an error response", () => {
     it("throws error with message from API", async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/langwatch/src/components/scenarios/services/scenarioGeneration.ts
+++ b/langwatch/src/components/scenarios/services/scenarioGeneration.ts
@@ -69,27 +69,43 @@ export async function generateScenarioWithAI(
     }),
   });
 
+  // The endpoint answers with JSON on every outcome — 200 success and 4xx/5xx
+  // error envelopes alike. A NON-JSON body therefore did not come from the
+  // route handler; it came from a layer in FRONT of the app: a reverse-proxy
+  // or gateway 502/504, an auth-redirect login page, a timeout error page, or
+  // an older self-hosted build. Parsing it as JSON throws a raw
+  // `Unexpected token '<', "<!DOCTYPE "...` that masks the real HTTP status and
+  // strands the user — convert it into an actionable, status-bearing error
+  // instead (langwatch#5758).
+  let payload: { error?: string; domainError?: unknown; scenario?: unknown };
+  try {
+    payload = await response.json();
+  } catch {
+    const statusText = response.statusText ? ` ${response.statusText}` : "";
+    throw new Error(
+      `The server returned an unexpected response (HTTP ${response.status}${statusText}) instead of scenario data. This is usually temporary — please try again in a moment.`,
+    );
+  }
+
   if (!response.ok) {
-    const error = await response.json();
     const domainError = serializedDomainErrorSchema.safeParse(
-      error.domainError,
+      payload.domainError,
     );
     if (domainError.success) {
       throw new ScenarioGenerationError(
-        error.error || "Failed to generate scenario",
+        payload.error || "Failed to generate scenario",
         domainError.data.kind,
         domainError.data.meta,
       );
     }
-    throw new Error(error.error || "Failed to generate scenario");
+    throw new Error(payload.error || "Failed to generate scenario");
   }
 
-  const data = await response.json();
-  if (!data.scenario) {
+  if (!payload.scenario) {
     throw new Error("Invalid response: missing scenario data");
   }
 
-  const parsed = generatedScenarioSchema.safeParse(data.scenario);
+  const parsed = generatedScenarioSchema.safeParse(payload.scenario);
   if (!parsed.success) {
     throw new Error(`Invalid scenario data: ${parsed.error.message}`);
   }

--- a/langwatch/src/server/nlpgo/__tests__/goHandledError.unit.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/goHandledError.unit.test.ts
@@ -1,7 +1,7 @@
 import { APICallError, RetryError } from "ai";
 import { describe, expect, it } from "vitest";
 import { DomainError } from "../../app-layer/domain-error";
-import { nlpgoHandledErrorFrom } from "../goHandledError";
+import { isAbortLikeError, nlpgoHandledErrorFrom } from "../goHandledError";
 
 /** The exact envelope nlpgo returned for an unroutable provider prefix. */
 const MISSING_PROVIDER_BODY = JSON.stringify({
@@ -93,5 +93,29 @@ describe("nlpgoHandledErrorFrom", () => {
     it("returns null for a plain Error", () => {
       expect(nlpgoHandledErrorFrom(new Error("boom"))).toBeNull();
     });
+  });
+});
+
+describe("isAbortLikeError()", () => {
+  it("matches a DOMException abort by name (the AbortSignal.timeout reason shape)", () => {
+    // A DOMException is NOT instanceof Error in this runtime — the exact quirk
+    // the helper matches on `name` to guard against.
+    expect(isAbortLikeError(new DOMException("timed out", "TimeoutError"))).toBe(
+      true,
+    );
+    expect(isAbortLikeError(new DOMException("aborted", "AbortError"))).toBe(
+      true,
+    );
+  });
+
+  it("matches the Next.js ResponseAborted name (mirrors the SDK's isAbortError)", () => {
+    expect(isAbortLikeError({ name: "ResponseAborted" })).toBe(true);
+  });
+
+  it("does not match a non-abort error, null, or undefined", () => {
+    expect(isAbortLikeError(new Error("boom"))).toBe(false);
+    expect(isAbortLikeError({ name: "APICallError" })).toBe(false);
+    expect(isAbortLikeError(null)).toBe(false);
+    expect(isAbortLikeError(undefined)).toBe(false);
   });
 });

--- a/langwatch/src/server/nlpgo/goHandledError.ts
+++ b/langwatch/src/server/nlpgo/goHandledError.ts
@@ -47,6 +47,27 @@ export class NlpgoHandledError extends DomainError {
  * Unwraps the AI SDK's RetryError to the last attempt, since
  * generateObject surfaces exhausted retries that way.
  */
+/**
+ * True when `error` is an abort — e.g. an `AbortSignal.timeout` cap firing.
+ * `AbortSignal.timeout().reason` is a `DOMException` (name "TimeoutError"), not
+ * `instanceof Error` in this runtime, so match on the `name` property directly.
+ * Mirrors the abort names in `@ai-sdk/provider-utils`' `isAbortError`
+ * ("AbortError" / "TimeoutError" / Next.js "ResponseAborted") — kept as a local
+ * copy because `ai` doesn't re-export it and provider-utils isn't a direct dep.
+ * No `RetryError` unwrap: the AI SDK re-throws aborts RAW before wrapping, so an
+ * abort is never a `RetryError.lastError` (verified against ai@6.0.217). Lives
+ * here beside `nlpgoHandledErrorFrom` so every `generateObject` caller can share
+ * one abort predicate.
+ */
+export function isAbortLikeError(error: unknown): boolean {
+  const name = (error as { name?: unknown } | null | undefined)?.name;
+  return (
+    name === "AbortError" ||
+    name === "TimeoutError" ||
+    name === "ResponseAborted"
+  );
+}
+
 export function nlpgoHandledErrorFrom(error: unknown): NlpgoHandledError | null {
   const cause = RetryError.isInstance(error) ? error.lastError : error;
   if (!APICallError.isInstance(cause) || !cause.responseBody) {

--- a/langwatch/src/server/routes/__tests__/scenario-generate.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/scenario-generate.unit.test.ts
@@ -15,7 +15,7 @@
  */
 import { APICallError } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetServerAuthSession = vi.fn();
 vi.mock("~/server/auth", async (importOriginal) => ({
@@ -74,6 +74,10 @@ describe("POST /api/scenario/generate — gateway-failure resilience (#5758)", (
     mockHasProjectPermission.mockResolvedValue(true);
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe("given the gateway keeps returning a retryable 502", () => {
     it("bounds the dispatch to 2 attempts, not the SDK default of 3", async () => {
       let attempts = 0;
@@ -94,7 +98,7 @@ describe("POST /api/scenario/generate — gateway-failure resilience (#5758)", (
       expect(attempts).toBe(2);
     });
 
-    it("answers with a JSON envelope, never a thrown/htmlerror", async () => {
+    it("answers with a JSON envelope, not a thrown error or HTML", async () => {
       mockGetVercelAIModel.mockResolvedValue(
         new MockLanguageModelV3({
           doGenerate: async () => {
@@ -112,20 +116,34 @@ describe("POST /api/scenario/generate — gateway-failure resilience (#5758)", (
     });
   });
 
-  describe("given the gateway hangs and the abort cap fires", () => {
-    it("maps the timeout to a fast 504 JSON message instead of stranding the request", async () => {
+  describe("given the gateway hangs past the abort cap", () => {
+    it("aborts via a real AbortSignal.timeout and returns a fast 504 JSON message", async () => {
+      // Drive a real, short abort cap (not the 30s default) against a gateway
+      // that honours the AbortSignal the SDK forwards but never resolves on
+      // its own — the shape of a genuinely hung upstream.
+      vi.stubEnv("SCENARIO_GENERATE_TIMEOUT_MS", "80");
       mockGetVercelAIModel.mockResolvedValue(
         new MockLanguageModelV3({
-          doGenerate: async () => {
-            throw Object.assign(new Error("The operation timed out."), {
-              name: "TimeoutError",
-            });
-          },
+          doGenerate: ({ abortSignal }) =>
+            new Promise((_resolve, reject) => {
+              if (abortSignal?.aborted) {
+                reject(abortSignal.reason);
+                return;
+              }
+              abortSignal?.addEventListener("abort", () =>
+                reject(abortSignal.reason),
+              );
+            }),
         }),
       );
 
       const res = await post(validBody);
 
+      // Falsifiable at the REAL seam: delete the handler's `abortSignal` and
+      // this doGenerate never rejects — the request hangs and the test times
+      // out. So this pins the EXISTENCE of the cap, not just an error-name ->
+      // 504 mapping. It also proves a real AbortSignal.timeout reaches the
+      // handler as a catchable abort (the TimeoutError name survives the SDK).
       expect(res.status).toBe(504);
       expect(res.headers.get("content-type")).toContain("application/json");
       const payload = (await res.json()) as { error?: string };

--- a/langwatch/src/server/routes/__tests__/scenario-generate.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/scenario-generate.unit.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression for langwatch#5758. Scenario generation dispatches its LLM call
+ * through the nlp-service /go/proxy gateway (the same path as the scenario
+ * User-Simulator, #5760). When that gateway is broken or slow, the endpoint
+ * MUST fail fast with a clean JSON envelope — never leave the request open
+ * long enough for a front reverse-proxy to substitute an html 502/504 page
+ * (the source of the customer's `Unexpected token '<', "<!DOCTYPE "...`).
+ *
+ * These tests run the REAL route handler and the REAL AI SDK retry loop (only
+ * auth / rbac / model-resolution / db are stubbed), so they observe the actual
+ * OUTCOME — the number of upstream attempts and the response shape — not merely
+ * that an option was forwarded.
+ */
+import { APICallError } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetServerAuthSession = vi.fn();
+vi.mock("~/server/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/server/auth")>()),
+  getServerAuthSession: (...args: unknown[]) => mockGetServerAuthSession(...args),
+}));
+
+const mockHasProjectPermission = vi.fn();
+vi.mock("~/server/api/rbac", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/server/api/rbac")>()),
+  hasProjectPermission: (...args: unknown[]) =>
+    mockHasProjectPermission(...args),
+}));
+
+const mockGetVercelAIModel = vi.fn();
+vi.mock("~/server/modelProviders/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/server/modelProviders/utils")>()),
+  getVercelAIModel: (...args: unknown[]) => mockGetVercelAIModel(...args),
+}));
+
+vi.mock("~/server/db", () => ({ prisma: {} }));
+
+// Import AFTER the mocks so the route binds the stubbed dependencies.
+import { app } from "../scenario-generate";
+
+const post = (body: unknown) =>
+  app.request("/api/scenario/generate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const validBody = {
+  prompt: "A frustrated customer asking for a refund on a late order",
+  currentScenario: null,
+  projectId: "project_test",
+};
+
+/** A retryable gateway failure, the shape the AI SDK retries on. */
+const retryableGatewayError = () =>
+  new APICallError({
+    message: "gateway_unavailable",
+    url: "http://nlp/go/proxy/v1/chat/completions",
+    requestBodyValues: {},
+    statusCode: 502,
+    isRetryable: true,
+  });
+
+describe("POST /api/scenario/generate — gateway-failure resilience (#5758)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerAuthSession.mockResolvedValue({
+      user: { id: "user_test" },
+      expires: "1",
+    });
+    mockHasProjectPermission.mockResolvedValue(true);
+  });
+
+  describe("given the gateway keeps returning a retryable 502", () => {
+    it("bounds the dispatch to 2 attempts, not the SDK default of 3", async () => {
+      let attempts = 0;
+      mockGetVercelAIModel.mockResolvedValue(
+        new MockLanguageModelV3({
+          doGenerate: async () => {
+            attempts++;
+            throw retryableGatewayError();
+          },
+        }),
+      );
+
+      await post(validBody);
+
+      // Falsifiable: without `maxRetries: 1` the AI SDK default (2 retries)
+      // makes this 3 — which is the ~6s window that let a front proxy return
+      // html in production. The fix pins it to a single retry (2 attempts).
+      expect(attempts).toBe(2);
+    });
+
+    it("answers with a JSON envelope, never a thrown/htmlerror", async () => {
+      mockGetVercelAIModel.mockResolvedValue(
+        new MockLanguageModelV3({
+          doGenerate: async () => {
+            throw retryableGatewayError();
+          },
+        }),
+      );
+
+      const res = await post(validBody);
+
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const payload = (await res.json()) as { error?: string };
+      expect(res.status).toBeGreaterThanOrEqual(500);
+      expect(typeof payload.error).toBe("string");
+    });
+  });
+
+  describe("given the gateway hangs and the abort cap fires", () => {
+    it("maps the timeout to a fast 504 JSON message instead of stranding the request", async () => {
+      mockGetVercelAIModel.mockResolvedValue(
+        new MockLanguageModelV3({
+          doGenerate: async () => {
+            throw Object.assign(new Error("The operation timed out."), {
+              name: "TimeoutError",
+            });
+          },
+        }),
+      );
+
+      const res = await post(validBody);
+
+      expect(res.status).toBe(504);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const payload = (await res.json()) as { error?: string };
+      expect(payload.error).toMatch(/too long|try again/i);
+    });
+  });
+});

--- a/langwatch/src/server/routes/scenario-generate.ts
+++ b/langwatch/src/server/routes/scenario-generate.ts
@@ -6,7 +6,7 @@
  * Uses the Vercel AI SDK to generate a structured scenario object
  * (name, situation, criteria) from a user prompt.
  */
-import { generateObject } from "ai";
+import { generateObject, RetryError } from "ai";
 import { z } from "zod";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import { hasProjectPermission } from "~/server/api/rbac";
@@ -89,7 +89,32 @@ When refining an existing scenario, incorporate the user's feedback while preser
 // does NOT make a broken gateway succeed (that's #5762) — it guarantees the
 // endpoint always returns a fast, clean JSON envelope regardless of provider.
 const SCENARIO_GENERATE_MAX_RETRIES = 1;
-const SCENARIO_GENERATE_TIMEOUT_MS = 30_000;
+const SCENARIO_GENERATE_DEFAULT_TIMEOUT_MS = 30_000;
+
+// Read at call time (not module load) so ops can tune the cap without a deploy
+// and the regression test can drive a real, fast abort against a hanging
+// gateway — see scenario-generate.unit.test.ts. A non-positive/NaN override
+// falls back to the default.
+function scenarioGenerateTimeoutMs(): number {
+  const override = Number(process.env.SCENARIO_GENERATE_TIMEOUT_MS);
+  return Number.isFinite(override) && override > 0
+    ? override
+    : SCENARIO_GENERATE_DEFAULT_TIMEOUT_MS;
+}
+
+/**
+ * True when `error` is (or wraps) an abort — the AbortSignal.timeout cap firing.
+ * `AbortSignal.timeout().reason` is a `DOMException` (name "TimeoutError"), which
+ * is NOT `instanceof Error` in this runtime, so match on the `name` property
+ * directly. The AI SDK re-throws aborts unwrapped, but unwrap an exhausted-retry
+ * `RetryError` too so a wrapped abort still maps to the clean 504.
+ */
+function isAbortLikeError(error: unknown): boolean {
+  const root =
+    RetryError.isInstance(error) && error.lastError ? error.lastError : error;
+  const name = (root as { name?: unknown } | null | undefined)?.name;
+  return name === "TimeoutError" || name === "AbortError";
+}
 
 const secured = createServiceApp({ basePath: "/api/scenario" });
 
@@ -139,7 +164,7 @@ secured.access(
       system: SYSTEM_PROMPT,
       prompt: userPrompt,
       maxRetries: SCENARIO_GENERATE_MAX_RETRIES,
-      abortSignal: AbortSignal.timeout(SCENARIO_GENERATE_TIMEOUT_MS),
+      abortSignal: AbortSignal.timeout(scenarioGenerateTimeoutMs()),
     });
 
     return c.json({ scenario: result.object });
@@ -162,10 +187,7 @@ secured.access(
     // The abort cap fired (slow/hung gateway). Answer with a clean, fast
     // JSON envelope instead of leaving the request open for an upstream
     // proxy to fill with an html timeout page (langwatch#5758).
-    if (
-      error instanceof Error &&
-      (error.name === "TimeoutError" || error.name === "AbortError")
-    ) {
+    if (isAbortLikeError(error)) {
       logger.warn({ error }, "Scenario generation timed out");
       return c.json(
         {

--- a/langwatch/src/server/routes/scenario-generate.ts
+++ b/langwatch/src/server/routes/scenario-generate.ts
@@ -75,6 +75,22 @@ Given a description of an agent and desired scenario, generate:
 
 When refining an existing scenario, incorporate the user's feedback while preserving the overall structure and any parts they haven't asked to change.`;
 
+// Bound the LLM dispatch so a failing or slow gateway can't hold the request
+// open long enough for a front reverse-proxy / ingress / CDN to give up and
+// return its OWN html error page — which the browser then tries to JSON.parse,
+// yielding the customer's `Unexpected token '<', "<!DOCTYPE "...` (langwatch#5758).
+// The generate call routes through the same nlp-service /go/proxy path as the
+// scenario User-Simulator, so when that gateway is misconfigured (e.g. the
+// Azure "endpoint not set" bug fixed server-side by #5762) an UNBOUNDED call
+// retried 3× (the AI SDK default) and burned ~6s per attempt-set before the
+// app answered — plenty of time for an upstream proxy to substitute html.
+// `maxRetries: 1` matches the sibling generateObject caller (ai-query.ts); the
+// abort cap mirrors the gateway-call timeout in trace-api-span-query.ts. This
+// does NOT make a broken gateway succeed (that's #5762) — it guarantees the
+// endpoint always returns a fast, clean JSON envelope regardless of provider.
+const SCENARIO_GENERATE_MAX_RETRIES = 1;
+const SCENARIO_GENERATE_TIMEOUT_MS = 30_000;
+
 const secured = createServiceApp({ basePath: "/api/scenario" });
 
 secured.access(
@@ -122,6 +138,8 @@ secured.access(
       schema: scenarioSchema,
       system: SYSTEM_PROMPT,
       prompt: userPrompt,
+      maxRetries: SCENARIO_GENERATE_MAX_RETRIES,
+      abortSignal: AbortSignal.timeout(SCENARIO_GENERATE_TIMEOUT_MS),
     });
 
     return c.json({ scenario: result.object });
@@ -138,6 +156,23 @@ secured.access(
       return c.json(
         { error: handled.message, domainError: handled.serialize() },
         { status: handled.httpStatus as 400 },
+      );
+    }
+
+    // The abort cap fired (slow/hung gateway). Answer with a clean, fast
+    // JSON envelope instead of leaving the request open for an upstream
+    // proxy to fill with an html timeout page (langwatch#5758).
+    if (
+      error instanceof Error &&
+      (error.name === "TimeoutError" || error.name === "AbortError")
+    ) {
+      logger.warn({ error }, "Scenario generation timed out");
+      return c.json(
+        {
+          error:
+            "Scenario generation took too long and was stopped. This is usually temporary — please try again in a moment.",
+        },
+        { status: 504 },
       );
     }
 

--- a/langwatch/src/server/routes/scenario-generate.ts
+++ b/langwatch/src/server/routes/scenario-generate.ts
@@ -6,14 +6,17 @@
  * Uses the Vercel AI SDK to generate a structured scenario object
  * (name, situation, criteria) from a user prompt.
  */
-import { generateObject, RetryError } from "ai";
+import { generateObject } from "ai";
 import { z } from "zod";
 import { createServiceApp, handlerManagedAuth } from "~/server/api/security";
 import { hasProjectPermission } from "~/server/api/rbac";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import { getVercelAIModel } from "~/server/modelProviders/utils";
-import { nlpgoHandledErrorFrom } from "~/server/nlpgo/goHandledError";
+import {
+  isAbortLikeError,
+  nlpgoHandledErrorFrom,
+} from "~/server/nlpgo/goHandledError";
 import { createLogger } from "~/utils/logger/server";
 import type { NextRequestShim as any } from "./types";
 
@@ -85,35 +88,20 @@ When refining an existing scenario, incorporate the user's feedback while preser
 // retried 3× (the AI SDK default) and burned ~6s per attempt-set before the
 // app answered — plenty of time for an upstream proxy to substitute html.
 // `maxRetries: 1` matches the sibling generateObject caller (ai-query.ts); the
-// abort cap mirrors the gateway-call timeout in trace-api-span-query.ts. This
-// does NOT make a broken gateway succeed (that's #5762) — it guarantees the
-// endpoint always returns a fast, clean JSON envelope regardless of provider.
+// 30s abort cap is a conservative upper bound for a single small generation.
+// This does NOT make a broken gateway succeed (that's #5762) — it guarantees
+// the endpoint always returns a fast, clean JSON envelope regardless of provider.
 const SCENARIO_GENERATE_MAX_RETRIES = 1;
 const SCENARIO_GENERATE_DEFAULT_TIMEOUT_MS = 30_000;
 
-// Read at call time (not module load) so ops can tune the cap without a deploy
-// and the regression test can drive a real, fast abort against a hanging
-// gateway — see scenario-generate.unit.test.ts. A non-positive/NaN override
-// falls back to the default.
+// Read at call time (not module load) so the regression test can drive a real,
+// fast abort via `vi.stubEnv` — the 30s default would otherwise make the test
+// wait 30s. A non-positive/NaN override falls back to the default.
 function scenarioGenerateTimeoutMs(): number {
   const override = Number(process.env.SCENARIO_GENERATE_TIMEOUT_MS);
   return Number.isFinite(override) && override > 0
     ? override
     : SCENARIO_GENERATE_DEFAULT_TIMEOUT_MS;
-}
-
-/**
- * True when `error` is (or wraps) an abort — the AbortSignal.timeout cap firing.
- * `AbortSignal.timeout().reason` is a `DOMException` (name "TimeoutError"), which
- * is NOT `instanceof Error` in this runtime, so match on the `name` property
- * directly. The AI SDK re-throws aborts unwrapped, but unwrap an exhausted-retry
- * `RetryError` too so a wrapped abort still maps to the clean 504.
- */
-function isAbortLikeError(error: unknown): boolean {
-  const root =
-    RetryError.isInstance(error) && error.lastError ? error.lastError : error;
-  const name = (root as { name?: unknown } | null | undefined)?.name;
-  return name === "TimeoutError" || name === "AbortError";
 }
 
 const secured = createServiceApp({ basePath: "/api/scenario" });

--- a/specs/scenarios/ai-create-modal.feature
+++ b/specs/scenarios/ai-create-modal.feature
@@ -90,6 +90,29 @@ Feature: AI Create Modal for Scenarios
     Then a new empty scenario is created
     And I am navigated to the scenario editor
 
+  # Resilience when the generation gateway is unavailable or slow (langwatch#5758).
+  # The endpoint always answers with JSON, and fails fast, so the modal shows a
+  # clear, retryable error instead of a raw parsing crash or an opaque hang.
+  @integration @unimplemented
+  Scenario: Show a clear, retryable error when the generation service is unavailable
+    Given the AI generation service is unavailable
+    When I click the "New Scenario" button
+    And I enter a description
+    And I click "Generate with AI"
+    Then I see the error state within a few seconds
+    And the error message does not contain a raw parsing error
+    And I see a "Try again" option
+
+  @integration @unimplemented
+  Scenario: Show a clear error when generation takes too long
+    Given the AI generation service does not respond in time
+    When I click the "New Scenario" button
+    And I enter a description
+    And I click "Generate with AI"
+    Then I see the error state
+    And the error message indicates the request took too long
+    And I see a "Try again" option
+
   @integration @unimplemented
   Scenario: Display error when API keys not configured
     Given the user has no API keys configured for the default model


### PR DESCRIPTION
> **Reworked after the client-only approach was rejected.** The customer's real problem is that scenario generation **fails**, and the failure surfaces as opaque HTML. This PR fixes the **server-side** failure surface; the fix that makes generation actually succeed is **#5762** (see below). Start here: `langwatch/src/server/routes/scenario-generate.ts`.

## Root cause — traced end-to-end and LIVE-reproduced

`POST /api/scenario/generate` resolves the `scenarios.generator` model and calls the Vercel AI SDK's `generateObject`, which dispatches **through the nlp-service `/go/proxy/v1/chat/completions` gateway** — the *same* path as the scenario User-Simulator (`getVercelAIModel` → `${LANGWATCH_NLP_SERVICE}/go/proxy/v1`).

**So this is #5760 on the generate path.** Reproduced live on this branch (which lacks #5762), with an Azure provider configured:

```
POST /api/scenario/generate  →  HTTP 502  application/json  (6109 ms)
{"error":"gateway_unavailable","domainError":{"kind":"dispatcher_error",...,"httpStatus":502}}

nlpgo log:
  path=/go/proxy/v1/chat/completions  code=gateway_unavailable  reason=dispatcher_error  status=502
    ↳ error_reasons=[provider_timeout (map[message:endpoint not set status:0])]   ← the exact #5760 "endpoint not set"
  (three request_ids — the AI SDK retried the dispatch 3×)
```

Two independent facts fall out of this:

1. **Generation fails** because the Azure `/go/proxy` path is broken → the "endpoint not set" bug **fixed server-side by #5762**. Generate is a co-beneficiary; #5762 is the "generation actually works" fix (for Azure). This PR does **not** duplicate it.
2. **The failure surfaces as HTML** because the app's `generateObject` call was **unbounded**: the AI SDK default (2 retries → **3 attempts**) burned **~6 s** on an instant config error. The app itself always answers with JSON (even the 502 is `application/json`), so the customer's `<!DOCTYPE html>` is an **upstream non-JSON response** (a reverse-proxy / ingress / CDN error or timeout page) served because the app was too slow to answer — not something the app emits. **The exact upstream mode is unconfirmed** — the customer's Network-tab status was never captured (issue #5758 lists it as still-needed). The fix is mode-agnostic, so this doesn't block disposition; only the precise root-cause label is inferred.

## What changed

- **Bound the gateway dispatch** in `scenario-generate.ts`: `maxRetries: 1` (matches the sibling `generateObject` caller `ai-query.ts:228`) + `AbortSignal.timeout(30_000)`. A failing/hung gateway now returns a **fast, clean JSON envelope** — never long enough for a front proxy to substitute HTML. **Provider-agnostic.**
- **Clean 504 on timeout** via a shared `isAbortLikeError` (in `nlpgo/goHandledError.ts`). _Review caught that this branch was initially **dead**: it gated on `instanceof Error`, but a real `AbortSignal.timeout` reason is a `DOMException` (name `"TimeoutError"`) that fails that check, so timeouts silently fell to the generic 500. Now matched by `name` (including the Next.js `ResponseAborted` name), verified live to map a real abort → 504 in ~80 ms._
- **Kept the client `response.json()` guard** (`scenarioGeneration.ts`) as defense-in-depth: if a body is ever non-JSON (a front-proxy page slipping through), the modal shows a status-bearing message, not the raw `Unexpected token '<'`.

## How I can prove I was successful

### 1. Real-app browser proof (the actual modal)

Before (un-fixed client) vs after (this PR), against a genuinely-non-JSON gateway response:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5761/before-unexpected-token.png) | ![after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5761/after-clean-message.png) |
| Modal shows the raw **`Unexpected token '<', "<!DOCTYPE "... is not valid JSON`** — the exact customer error | Modal shows a clean, status-bearing message |

Additionally, booting the app with a **real broken Azure gateway** (Azure provider, `scenarios.generator` → `azure/gpt-4o-mini`) and driving **Create new scenario → Generate with AI** now renders a clean, fast, actionable failure with a **Try again** button (live Playwright observation) —
> Something went wrong while generating your scenario.
> `dispatcher_error: gateway_unavailable (reason: dispatcher_error)`

— instead of the raw parse crash, and in **~2 s** instead of a **~6 s** hang.

### 2. Two falsifiable server regression tests (real handler + real AI SDK retry loop)

Both run the real Hono handler + the real AI SDK retry loop against a `MockLanguageModelV3` — the surface that actually gates:
1. **Retry bound** — asserts the dispatch is capped at **2 attempts**. Revert `maxRetries` → `Failed after 3 attempts` → `expected 3 to be 2` (RED).
2. **Real abort → 504** — fires a genuine `AbortSignal.timeout` (short cap) against a signal-honouring hang. Revert the `abortSignal` → the request hangs → the test **times out** (RED). This test found and fixed the dead-504 bug above.

Plus `isAbortLikeError` unit-tested across all three abort names, and the existing 11 client tests.

### 3. Verification scope (honest)

Run **locally**: `vitest` (server 3/3 + client 11/11 + goHandledError incl. new abort tests) and both `pnpm typecheck` / `pnpm typecheck:tests` clean. ⚠️ The repo's CI **unit-test / `typecheck:tests` jobs `skip`** on this PR's path filters, so test-level verification here is **local, not CI-gated** — but the full blast radius of the shared-module change (only `scenario-generate.ts` + the `goHandledError` test import it) was run locally.

## Human verification

1. **Falsifiability (server fix):**
   `cd langwatch && npx vitest run src/server/routes/__tests__/scenario-generate.unit.test.ts` → 3 pass. Delete the `abortSignal:` line in `scenario-generate.ts` → the abort test hangs → RED. Delete `maxRetries:` → the retry test fails `expected 3 to be 2`. Restore → green.
2. **Dead-504 fix:** on `git show 15fcd20c9^:.../scenario-generate.ts` the 504 branch used `instanceof Error`; a `DOMException` abort skips it → generic 500. Current code matches by `name` → 504.
3. **Modal:** in a running app with a broken/misconfigured provider, open **Create new scenario → Generate with AI** → a clean error + **Try again**, not `Unexpected token '<'`, within ~2 s.

## Open question for the owner (blocks final disposition of #5758)

**Which model provider is the customer on?** The support thread is Slack-Connect (unfetchable from here).
- **Azure** → #5762 closes the "can't generate" half; this PR guarantees the failure is never opaque HTML.
- **Non-Azure** → the same `api_base`/`endpoint` key-mismatch class may affect that provider's bifrost branch (the "two dispatch paths diverge" gotcha from #5760) — a targeted follow-up on that branch, tracked under #5758.

**Do not merge** — owner gate (#5758). Non-blocking review follow-ups (generic-500 error exposure; `NextRequestShim as any` ×5; unified AI-SDK-error classification) are catalogued in the review-verdict comment for triage under #5758.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI scenario generation error handling for gateway failures and non-JSON responses.
  - Added request timeouts and bounded retries to prevent prolonged or failed requests.
  - Return clear JSON error responses, including timeout guidance and HTTP status context.
  - Scenario generation modal now shows retryable errors with a **Try again** option.

- **Tests**
  - Added coverage for gateway outages, timeout behavior, malformed responses, and abort handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->