### PR TITLE
fix(metrics): normalize entity IDs out of the http_request_duration path label

### DIFF
--- a/langwatch/src/server/__tests__/metrics.unit.test.ts
+++ b/langwatch/src/server/__tests__/metrics.unit.test.ts
@@ -212,6 +212,12 @@ describe("normalizeMetricsPath", () => {
       );
     });
 
+    it("collapses digit-free nanoid tokens to {id}", () => {
+      expect(normalizeMetricsPath("/share/oSjKKVKjjGwZaKqBt")).toBe(
+        "/share/{id}",
+      );
+    });
+
     it("keeps the id inside a longer route template", () => {
       expect(normalizeMetricsPath("/api/trace/trace_A1b2C3d4E5f6/share")).toBe(
         "/api/trace/{id}/share",

--- a/langwatch/src/server/__tests__/metrics.unit.test.ts
+++ b/langwatch/src/server/__tests__/metrics.unit.test.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_WORKER_METRICS_PORT,
   getWorkerMetricsPort,
   isMetricsAuthorized,
+  normalizeMetricsPath,
 } from "../metrics";
 
 function requestWithAuth(authorization?: string): IncomingMessage {
@@ -164,6 +165,86 @@ describe("isMetricsAuthorized", () => {
   describe("when METRICS_API_KEY is unset outside production", () => {
     it("allows access for dev convenience", () => {
       expect(isMetricsAuthorized(requestWithAuth())).toBe(true);
+    });
+  });
+});
+
+describe("normalizeMetricsPath", () => {
+  describe("when the path carries entity IDs", () => {
+    it("collapses prefixed entity ids to {id}", () => {
+      expect(normalizeMetricsPath("/api/traces/trace_MWS36ZJSXeAGyj5zXLk7M")).toBe(
+        "/api/traces/{id}",
+      );
+      expect(normalizeMetricsPath("/api/prompts/prompt_Ab12Cd34Ef56")).toBe(
+        "/api/prompts/{id}",
+      );
+    });
+
+    it("collapses hex trace ids to {id}", () => {
+      expect(
+        normalizeMetricsPath("/api/trace/search/traces/957239e7ddb315d5518a4792601c3d67"),
+      ).toBe("/api/trace/search/traces/{id}");
+    });
+
+    it("collapses uuids to {id}", () => {
+      expect(
+        normalizeMetricsPath(
+          "/api/evaluations/v3/runs/e07e9880-edb4-458b-94d8-5f179468f096/results",
+        ),
+      ).toBe("/api/evaluations/v3/runs/{id}/results");
+    });
+
+    it("collapses numeric segments to {id}", () => {
+      expect(normalizeMetricsPath("/api/experiments/12345")).toBe(
+        "/api/experiments/{id}",
+      );
+    });
+
+    it("collapses percent-encoded segments to {id}", () => {
+      expect(normalizeMetricsPath("/api/traces/dHJhY2VfQUJD%3D%3D")).toBe(
+        "/api/traces/{id}",
+      );
+    });
+
+    it("collapses unprefixed nanoid tokens to {id}", () => {
+      expect(normalizeMetricsPath("/share/oS6jK-KV33KjjGwZ1aKq8")).toBe(
+        "/share/{id}",
+      );
+    });
+
+    it("keeps the id inside a longer route template", () => {
+      expect(normalizeMetricsPath("/api/trace/trace_A1b2C3d4E5f6/share")).toBe(
+        "/api/trace/{id}/share",
+      );
+    });
+  });
+
+  describe("when the path is a static route", () => {
+    it("keeps route words untouched", () => {
+      expect(normalizeMetricsPath("/api/evaluations/list")).toBe(
+        "/api/evaluations/list",
+      );
+      expect(normalizeMetricsPath("/api/prompts/tags/production")).toBe(
+        "/api/prompts/tags/production",
+      );
+    });
+
+    it("keeps underscore route words that look nothing like ids", () => {
+      expect(normalizeMetricsPath("/api/topics/batch_clustering")).toBe(
+        "/api/topics/batch_clustering",
+      );
+    });
+
+    it("keeps the root path", () => {
+      expect(normalizeMetricsPath("/")).toBe("/");
+    });
+  });
+
+  describe("when the path has duplicate slashes", () => {
+    it("collapses them so the same route maps to one label", () => {
+      expect(normalizeMetricsPath("/api//traces/trace_A1b2C3d4E5f6")).toBe(
+        "/api/traces/{id}",
+      );
     });
   });
 });

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -30,6 +30,47 @@ export const isMetricsAuthorized = (req: IncomingMessage): boolean => {
   );
 };
 
+/**
+ * Collapses ID-shaped path segments to `{id}` so the `path` label on the HTTP
+ * request histogram stays low-cardinality (route template, not raw URL).
+ *
+ * Every distinct label value is a permanent series in this process's registry
+ * AND in Prometheus's head, held for the lifetime of the process. The
+ * Next.js → Hono migration (#3170) dropped the route-template normalization
+ * the original middleware had, so raw URLs — `/api/traces/trace_<nanoid>` and
+ * friends — accumulate one series per entity ever requested and grow the
+ * registry without bound. A path label must never contain per-entity IDs.
+ */
+export const normalizeMetricsPath = (path: string): string => {
+  const segments = path.replace(/\/{2,}/g, "/").split("/");
+  const normalized = segments.map((segment) => {
+    if (segment === "") return segment;
+    // percent-encoded leftovers (`abc%3D%3D`) are never route words
+    if (segment.includes("%")) return "{id}";
+    // purely numeric
+    if (/^\d+$/.test(segment)) return "{id}";
+    // uuid
+    if (
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        segment,
+      )
+    )
+      return "{id}";
+    // bare hex ids (trace ids are 16/32 hex chars)
+    if (/^[0-9a-f]{8,}$/i.test(segment)) return "{id}";
+    // prefixed entity ids: trace_…, project_…, prompt_…, eval_… — the tail of
+    // a generated id always carries a digit or uppercase, which route words
+    // (`batch_clustering`) never do
+    if (/^[a-z]+_[A-Za-z0-9_-]{6,}$/.test(segment) && /[A-Z0-9]/.test(segment))
+      return "{id}";
+    // long unprefixed tokens (nanoid, base64ish)
+    if (/^[A-Za-z0-9_-]{16,}$/.test(segment) && /\d/.test(segment))
+      return "{id}";
+    return segment;
+  });
+  return normalized.join("/") || "/";
+};
+
 type Endpoint =
   | "collector"
   | "log_steps"

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -63,8 +63,12 @@ export const normalizeMetricsPath = (path: string): string => {
     // (`batch_clustering`) never do
     if (/^[a-z]+_[A-Za-z0-9_-]{6,}$/.test(segment) && /[A-Z0-9]/.test(segment))
       return "{id}";
-    // long unprefixed tokens (nanoid, base64ish)
-    if (/^[A-Za-z0-9_-]{16,}$/.test(segment) && /\d/.test(segment))
+    // long unprefixed tokens (nanoid, base64ish) — a digit or an uppercase
+    // letter marks a generated token; route words are lowercase-only
+    if (
+      /^[A-Za-z0-9_-]{16,}$/.test(segment) &&
+      (/\d/.test(segment) || /[A-Z]/.test(segment))
+    )
       return "{id}";
     return segment;
   });

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -77,7 +77,11 @@ import {
   initializeWebApp,
 } from "./server/app-layer/presets";
 import { buildStorageConnectSrc } from "./server/buildStorageConnectSrc";
-import { getWorkerMetricsPort, isMetricsAuthorized } from "./server/metrics";
+import {
+  getWorkerMetricsPort,
+  isMetricsAuthorized,
+  normalizeMetricsPath,
+} from "./server/metrics";
 import { shutdownPostHog } from "./server/posthog";
 import { verifyRedisReady } from "./server/redis";
 import { serveStaticOrFallback } from "./server/static-handler";
@@ -105,7 +109,7 @@ export const metricsMiddleware = promBundle({
   },
   normalizePath: (req) => {
     if (req.url?.includes("/assets/")) return "/assets/*";
-    return req.url?.split("?")[0] ?? req.url;
+    return normalizeMetricsPath(req.url?.split("?")[0] ?? "/");
   },
 });
 


### PR DESCRIPTION
## What

`normalizeMetricsPath` collapses ID-shaped path segments to `{id}` before they reach the `path` label on the HTTP request duration histogram:

- prefixed entity ids (`trace_…`, `prompt_…`)
- bare hex ids and uuids
- numeric segments
- percent-encoded segments
- long unprefixed tokens (nanoid/base64-ish)
- duplicate slashes (`/api//traces/…` → `/api/traces/…`)

Static route words (`/api/evaluations/list`, `batch_clustering`, `tags/production`) are untouched.

## Why

The Next.js → Hono migration (#3170) replaced the original route-template normalization (which used Next.js route metadata) with the raw URL path. Since then, every unique entity URL requested mints a **permanent** series in the process's prom-client registry — and in Prometheus. The registry grows without bound over each pod's lifetime, and the `/metrics` exposition grows with it. A path label must carry route templates, never per-entity IDs.

This restores the bounded labelling the middleware had before the migration, as one shared `normalizeMetricsPath` in `src/server/metrics.ts`.

## Tests

- `src/server/__tests__/metrics.unit.test.ts`: covers all ID shapes (prefixed, hex, uuid, numeric, percent-encoded, nanoid), IDs mid-path, static-route preservation (including underscore route words), root path, and duplicate-slash collapse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced HTTP request metrics by normalizing URL paths to reduce high-cardinality labels.
  * Dynamic segments that look like IDs (including encoded, numeric, UUID-like, hex-like, and prefixed tokens) are grouped under a consistent `{id}` label.
  * Collapses duplicate slashes and preserves static route wording for clearer, more stable metrics.
* **Tests**
  * Added unit coverage to verify normalization across common route patterns and ID formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->