### PR TITLE
fix(ci): fail hard-floor test shards closed

### DIFF
--- a/langwatch/src/__tests__/test-integration-global-setup.unit.test.ts
+++ b/langwatch/src/__tests__/test-integration-global-setup.unit.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setup } from "../server/event-sourcing/__tests__/integration/globalSetup";
+
+describe("Feature: Test shard hard-floor failures", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv("CI", "true");
+    vi.stubEnv("CI_CLICKHOUSE_URL", "http://localhost:8123");
+    vi.stubEnv("CI_REDIS_URL", "redis://localhost:6379");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  describe("when the hard-floor timeout expires", () => {
+    it("keeps the test process running before twenty minutes", async () => {
+      const exit = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => undefined) as typeof process.exit);
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+      await setup();
+      vi.advanceTimersByTime(20 * 60 * 1000 - 1);
+
+      expect(exit).not.toHaveBeenCalled();
+    });
+
+    /** @scenario An integration test shard hard floor exits with failure after twenty minutes */
+    it("exits the test process with a failure status at twenty minutes", async () => {
+      const exit = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => undefined) as typeof process.exit);
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+      await setup();
+      vi.advanceTimersByTime(20 * 60 * 1000);
+
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/langwatch/src/__tests__/test-unit-global-setup.unit.test.ts
+++ b/langwatch/src/__tests__/test-unit-global-setup.unit.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setup } from "../test-unit-global-setup";
+
+describe("Feature: Test shard hard-floor failures", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv("CI", "true");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  describe("when the hard-floor timeout expires", () => {
+    it("keeps the test process running before four minutes", async () => {
+      const exit = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => undefined) as typeof process.exit);
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      await setup();
+      vi.advanceTimersByTime(4 * 60 * 1000 - 1);
+
+      expect(exit).not.toHaveBeenCalled();
+    });
+
+    /** @scenario A unit test shard hard floor exits with failure after four minutes */
+    it("exits the test process with a failure status at four minutes", async () => {
+      const exit = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => undefined) as typeof process.exit);
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      await setup();
+      vi.advanceTimersByTime(4 * 60 * 1000);
+
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -267,7 +267,7 @@ describe("aggregation-builder", () => {
         aggregation: "p90",
         alias: "trace_time_to_first_token_ms",
         rawColumn: "TimeToFirstTokenMs",
-        outerAggregation: /\bquantileExact\(0\.9\)\s*\(\s*trace_time_to_first_token_ms\s*\)/,
+        outerAggregation: /\bquantileTDigest\(0\.9\)\s*\(\s*trace_time_to_first_token_ms\s*\)/,
       },
     ])(
       "routes $metric through the CTE alias in arrayJoin groupBy path",

--- a/langwatch/src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts
@@ -4,6 +4,10 @@ import { TeamUserRole } from "@prisma/client";
 import { teamRouter } from "../team";
 import { createInnerTRPCContext } from "../../trpc";
 
+vi.mock("../../../auditLog", () => ({
+  auditLog: vi.fn(() => Promise.resolve()),
+}));
+
 // team.update writes membership to RoleBinding. A user can hold MORE THAN ONE
 // TEAM binding on a team — a built-in role plus additive custom-role grants —
 // and RBAC unions them. The settings form shows/edits only the displayed

--- a/langwatch/src/server/event-sourcing/__tests__/integration/globalSetup.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/integration/globalSetup.ts
@@ -12,6 +12,7 @@ import {
   type StartedRedisContainer,
 } from "@testcontainers/redis";
 import { migrateUp } from "~/server/clickhouse/goose";
+import { scheduleTestShardHardFloor } from "~/test-shard-hard-floor";
 
 const TEST_DATABASE = "test_langwatch";
 
@@ -242,26 +243,14 @@ function ensureLocalPostgresDatabase(databaseUrl: string): void {
  * Connection URLs are written to a temp file for test workers to read.
  */
 export async function setup(): Promise<void> {
-  // Hard floor: vitest's integration shard 4 of 6 in CI reproducibly wedges
-  // after the last test of the last file passes. Every diagnostic we have
-  // run (handle dumps, --no-coverage, --no-json-reporter, pool=threads vs
-  // pool=forks) shows the worker reaches steady state with no application
-  // handles open, then vitest main process sits idle for the full job
-  // timeout cap. The wedge appears to be in vitest's own shard / reporter
-  // finalize path and we cannot fix it from inside a test. Schedule a hard
-  // process.exit(0) so the step at least completes and the rest of the
-  // langwatch-app-complete required check unblocks. Unref'd so a healthy
-  // shard exits immediately on its own; the timer only fires on the wedge.
+  // Bound a shard that cannot finalize without allowing unfinished or failed
+  // tests to be reported as successful.
   if (process.env.CI) {
     const HARD_FLOOR_MS = 20 * 60 * 1000;
-    const timer = setTimeout(() => {
-      // eslint-disable-next-line no-console
-      console.log(
-        `[globalSetup] hard floor reached at ${HARD_FLOOR_MS / 60_000} min after start — forcing process.exit(0) to release the CI step from a vitest finalize wedge`,
-      );
-      process.exit(0);
-    }, HARD_FLOOR_MS);
-    timer.unref();
+    scheduleTestShardHardFloor({
+      timeoutMs: HARD_FLOOR_MS,
+      message: `[globalSetup] hard floor reached at ${HARD_FLOOR_MS / 60_000} min after start — failing the unfinished CI shard`,
+    });
   }
 
   // Skip if using CI service containers

--- a/langwatch/src/test-shard-hard-floor.ts
+++ b/langwatch/src/test-shard-hard-floor.ts
@@ -1,0 +1,16 @@
+interface TestShardHardFloorOptions {
+  timeoutMs: number;
+  message: string;
+}
+
+export function scheduleTestShardHardFloor({
+  timeoutMs,
+  message,
+}: TestShardHardFloorOptions): void {
+  const timer = setTimeout(() => {
+    // eslint-disable-next-line no-console
+    console.error(message);
+    process.exit(1);
+  }, timeoutMs);
+  timer.unref();
+}

--- a/langwatch/src/test-unit-global-setup.ts
+++ b/langwatch/src/test-unit-global-setup.ts
@@ -1,3 +1,5 @@
+import { scheduleTestShardHardFloor } from "./test-shard-hard-floor";
+
 /**
  * Global setup for the UNIT test config (vitest.config.ts).
  *
@@ -6,40 +8,17 @@
  * src/server/event-sourcing/__tests__/integration/globalSetup.ts). Unit tests
  * need no containers or other setup, so the hard-floor is the only thing here.
  *
- * Why a hard-floor on unit too: `langwatch-app-ci` runs `test-unit` (4 shards)
- * and `test-integration` (6 shards). A vitest finalize wedge — diagnosed at
- * length as living in vitest's own shard/reporter finalize path, NOT an
- * application handle leak — makes a *random* shard hang after its last test
- * passes, until the job timeout cap. Integration shards already survive this
- * via the hard-floor in their globalSetup; unit shards had no globalSetup at
- * all, so when the wedge lands on a unit shard the step runs to the 25-min job
- * timeout, gets cancelled, and fails the `langwatch-app-complete` required
- * check (observed cancelling app-ci repeatedly). Extending the same accepted
- * mask to unit lets a wedged unit shard force-exit(0) and unblock the check.
+ * The hard floor bounds CI time when a shard cannot finalize. It must fail the
+ * shard so unfinished or already-failing tests cannot be reported as green.
  */
 export async function setup(): Promise<void> {
-  // Hard floor: a vitest finalize wedge can reproducibly hang a CI shard after
-  // the last test of the last file passes. Every diagnostic the team has run
-  // (handle dumps, --no-coverage, --no-json-reporter, pool=threads vs
-  // pool=forks) shows the worker reaches steady state with no application
-  // handles open, then the vitest main process sits idle for the full job
-  // timeout cap. The wedge appears to be in vitest's own shard / reporter
-  // finalize path and we cannot fix it from inside a test. Schedule a hard
-  // process.exit(0) so the step at least completes and the rest of the
-  // langwatch-app-complete required check unblocks. Unref'd so a healthy
-  // shard exits immediately on its own; the timer only fires on the wedge.
-  // Mirrors the integration globalSetup hard-floor; unit shards otherwise lack
-  // one. A healthy unit shard finishes in ~3 min, so a 4-min floor only fires
-  // on a wedge and caps the wasted wall-clock at ~1 min of idle.
+  // A healthy unit shard finishes in about 3 minutes. The unref'd timer only
+  // fires when the shard remains alive past the 4-minute ceiling.
   if (process.env.CI) {
     const HARD_FLOOR_MS = 4 * 60 * 1000;
-    const timer = setTimeout(() => {
-      // eslint-disable-next-line no-console
-      console.log(
-        `[unit globalSetup] hard floor reached at ${HARD_FLOOR_MS / 60_000} min — forcing process.exit(0) to release the CI step from a vitest finalize wedge`,
-      );
-      process.exit(0);
-    }, HARD_FLOOR_MS);
-    timer.unref();
+    scheduleTestShardHardFloor({
+      timeoutMs: HARD_FLOOR_MS,
+      message: `[unit globalSetup] hard floor reached at ${HARD_FLOOR_MS / 60_000} min — failing the unfinished CI shard`,
+    });
   }
 }

--- a/specs/ci/test-shard-hard-floor.feature
+++ b/specs/ci/test-shard-hard-floor.feature
@@ -1,0 +1,16 @@
+Feature: Test shard hard-floor failures
+  As a maintainer
+  I want a wedged test shard to fail visibly
+  So that unfinished or failing tests cannot be reported as successful
+
+  @regression @unit
+  Scenario: A unit test shard hard floor exits with failure after four minutes
+    Given a CI unit test shard has a four-minute hard-floor timeout
+    When four minutes expire before Vitest finishes
+    Then the test process exits with a non-zero status
+
+  @regression @unit
+  Scenario: An integration test shard hard floor exits with failure after twenty minutes
+    Given a CI integration test shard has a twenty-minute hard-floor timeout
+    When twenty minutes expire before Vitest finishes
+    Then the test process exits with a non-zero status


### PR DESCRIPTION
## Why

The unit and integration test hard floors currently call `process.exit(0)`. If a shard cannot finalize, that success code can hide unfinished test files and already-recorded failures behind a green CI result.

Closes #4450

## What changed

- move the shared hard-floor timer behavior into one helper;
- exit with status 1 when either hard floor expires;
- keep the existing 4-minute unit and 20-minute integration ceilings;
- update the setup comments and logs to describe fail-closed behavior;
- add runtime regressions for both setup paths immediately before and exactly at each timeout;
- repair two stale shard-2 tests that the fail-closed signal exposed.

## How it works

Both global setup paths schedule the same unref'd timer through a shared helper. Healthy shards still exit normally before the timer fires; a shard that remains alive at its existing ceiling now logs the hard-floor event and terminates with status 1.

### Follow-up from the first fail-closed CI run

The first CI run did what this change is intended to do: instead of reporting shard 2 as green, it exposed three pre-existing test failures that were already present on `main`.

- Updated the `performance.first_token` p90 assertion to expect `quantileTDigest`, matching the production contract for `performance.*` percentile metrics.
- Stubbed `auditLog` in the isolated `team.update` unit test so the tRPC audit middleware does not use the process-wide Prisma client. The test continues to exercise the real team update and RoleBinding synchronization paths.
- Kept the unit hard floor at four minutes. The failed GitHub run showed test failures followed by an unfinished shard, so any ceiling change is deferred until a clean runner-specific retry proves it is needed.

## Test plan

```text
pnpm test:unit src/__tests__/test-unit-global-setup.unit.test.ts src/__tests__/test-integration-global-setup.unit.test.ts src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts --run
pnpm check:feature-parity
pnpm typecheck
pnpm typecheck:tests
```

Run these commands from `langwatch/`. The regression tests use fake timers and the real unit/integration global setup functions. The integration test supplies CI service URLs and returns before starting containers or migrations.

## Anything surprising?

The fail-closed behavior surfaced failures that the previous `process.exit(0)` path had been masking. The follow-up test changes are test-only corrections for those inherited failures; they do not change analytics query generation or team membership behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI test shards now exit with a non-zero status when they exceed the configured “hard-floor” timeout instead of lingering past the threshold.
  * Unit shards are limited to 4 minutes; integration shards are limited to 20 minutes.

* **Tests**
  * Added/extended unit and integration regression coverage to verify behavior just before the cutoff and at the exact timeout.
  * Added CI feature scenarios to validate hard-floor timing for both unit and integration shards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->