### PR TITLE
fix(topic-clustering): bound the heavy trace fetch to a 49-day hot-tier window

### DIFF
--- a/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
@@ -181,4 +181,45 @@ describe("fetchTracesFromClickHouse integration", () => {
       expect(page2.traces[0]?.trace_id).toBe(`${EMPTY_TENANT}-trace-002000`);
     });
   });
+
+  describe("when a trace is older than the fetch window", () => {
+    // The heavy ComputedInput fetch is bounded to a 49-day hot-tier window so
+    // cursor-paging never reads the payload column back into S3 cold storage.
+    // A trace whose OccurredAt predates the window must not be returned.
+    const WINDOW_TENANT = "topic-fetch-window-test";
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
+    beforeAll(async () => {
+      const now = Date.now();
+      const input = JSON.stringify("hello world");
+      const row = (id: string, occurredAt: number): TraceRow => ({
+        ...traceRow(WINDOW_TENANT, 0, input),
+        TraceId: `${WINDOW_TENANT}-${id}`,
+        OccurredAt: new Date(occurredAt),
+        UpdatedAt: new Date(occurredAt),
+        TopicId: null,
+      });
+      await insertRows(ch, [
+        row("recent", now - 10 * DAY_MS), // inside the 49-day window
+        row("stale", now - 60 * DAY_MS), // older than the window
+      ]);
+    }, 60_000);
+
+    afterAll(async () => {
+      await cleanupTestData(WINDOW_TENANT);
+    });
+
+    it("returns the in-window trace and excludes the older one", async () => {
+      const res = await fetchTracesFromClickHouse(
+        ch,
+        WINDOW_TENANT,
+        false,
+        [],
+        [],
+      );
+      const ids = res.traces.map((t) => t.trace_id);
+      expect(ids).toContain(`${WINDOW_TENANT}-recent`);
+      expect(ids).not.toContain(`${WINDOW_TENANT}-stale`);
+    });
+  });
 });

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -352,7 +352,7 @@ export async function fetchTracesFromClickHouse(
         SELECT TraceId
         FROM trace_summaries
         WHERE TenantId = {tenantId:String}
-          AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})
+          AND OccurredAt >= fromUnixTimestamp64Milli({fetchWindowStartMs:UInt64})
           AND OccurredAt < now64(3)
         GROUP BY TenantId, TraceId
         ${pageHavingClause}
@@ -367,13 +367,13 @@ export async function fetchTracesFromClickHouse(
         toString(toUnixTimestamp64Milli(t.OccurredAt)) AS OccurredAtMs
       FROM trace_summaries t
       WHERE TenantId = {tenantId:String}
-        AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})
+        AND OccurredAt >= fromUnixTimestamp64Milli({fetchWindowStartMs:UInt64})
         AND OccurredAt < now64(3)
         AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
           SELECT TenantId, TraceId, max(UpdatedAt)
           FROM trace_summaries
           WHERE TenantId = {tenantId:String}
-            AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})
+            AND OccurredAt >= fromUnixTimestamp64Milli({fetchWindowStartMs:UInt64})
             AND OccurredAt < now64(3)
             AND TraceId IN (SELECT TraceId FROM page)
           GROUP BY TenantId, TraceId
@@ -381,7 +381,7 @@ export async function fetchTracesFromClickHouse(
     `,
     query_params: {
       tenantId: projectId,
-      twelveMonthsAgo: fetchWindowStartMs,
+      fetchWindowStartMs,
       topicIds: topicIds.length > 0 ? topicIds : ["__none__"],
       subtopicIds: subtopicIds.length > 0 ? subtopicIds : ["__none__"],
       ...(searchAfter

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -28,6 +28,34 @@ import type {
 
 const logger = createLogger("langwatch:topicClustering");
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Look-back for the batch-vs-incremental MODE decision
+ * (`fetchCountsFromClickHouse`). Deliberately wide: it answers "does this
+ * project already have a mature topic model?", which depends on the project's
+ * whole history, not just recent traffic. Narrowing it silently flips
+ * historically-mature-but-quiet projects out of incremental mode into the
+ * heavy full-batch re-cluster path — measured on prod, dropping this to 49d
+ * would flip 54 of 73 incremental projects to batch. This query reads only
+ * light key columns (no ComputedInput), so its scan stays cheap even across
+ * cold-tier partitions.
+ */
+const CLUSTERING_MODE_WINDOW_DAYS = 365;
+
+/**
+ * Look-back for the trace FETCH (`fetchTracesFromClickHouse`) that reads the
+ * heavy ComputedInput payload. Kept inside the ClickHouse hot tier (~90 days)
+ * so cursor-paging never walks the payload column back into S3 cold storage —
+ * the source of the multi-hundred-MB cold reads that stalled the worker event
+ * loop. 49 days matches the retention recovery floor and sits comfortably
+ * within hot. Trade-off: an unassigned trace older than 49 days is no longer
+ * retroactively clustered; for the 2-day batch cadence and hot-tier ingest
+ * this is negligible, and new/recent traffic (all within the window) is
+ * unaffected.
+ */
+const CLUSTERING_FETCH_WINDOW_DAYS = 49;
+
 export const clusterTopicsForProject = async (
   projectId: string,
   searchAfter?: [number, string],
@@ -190,7 +218,9 @@ export async function fetchCountsFromClickHouse({
   projectId: string;
 }): Promise<TraceCounts> {
   const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
-  const twelveMonthsAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
+  // Wide MODE window (kept at 365d): light-column scan that decides
+  // batch-vs-incremental, so it must reflect the project's whole history.
+  const twelveMonthsAgo = Date.now() - CLUSTERING_MODE_WINDOW_DAYS * DAY_MS;
 
   // trace_summaries is a ReplacingMergeTree, so we count one row per trace
   // (its latest version). Rather than the IN-tuple dedup pattern — which
@@ -249,7 +279,9 @@ export async function fetchTracesFromClickHouse(
   subtopicIds: string[],
   searchAfter?: [number, string],
 ): Promise<TraceSearchResult> {
-  const twelveMonthsAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
+  // Narrow FETCH window (49d, hot-tier only): bounds how far cursor-paging
+  // reads the heavy ComputedInput column, keeping it off S3 cold storage.
+  const fetchWindowStartMs = Date.now() - CLUSTERING_FETCH_WINDOW_DAYS * DAY_MS;
 
   // Page selection runs on the lightweight key columns only: it picks the
   // 2000 most-recent matching traces without ever reading ComputedInput.
@@ -349,7 +381,7 @@ export async function fetchTracesFromClickHouse(
     `,
     query_params: {
       tenantId: projectId,
-      twelveMonthsAgo,
+      twelveMonthsAgo: fetchWindowStartMs,
       topicIds: topicIds.length > 0 ? topicIds : ["__none__"],
       subtopicIds: subtopicIds.length > 0 ? subtopicIds : ["__none__"],
       ...(searchAfter


### PR DESCRIPTION
## Problem

Topic clustering's page fetch (`fetchTracesFromClickHouse`) reads the heavy `ComputedInput` payload and cursor-pages back through a **365-day** window of `trace_summaries`. Only the most-recent **~90 days** live on the ClickHouse hot tier; everything older is S3-tiered. So paging walked the payload column across **cold storage** on every batch run.

Measured on prod (`system.parts`, last-12-months partitions):

| tier | parts | size |
|---|---|---|
| local (hot EBS) | 226 | 12.41 GiB (~last 13 wks) |
| object (S3 cold) | 401 | **38.45 GiB** (3–12 mo old) |

~75% of the scanned bytes were cold — the source of the multi-hundred-MB cold reads that also amplify worker event-loop stalls.

## Why not just shrink the whole window to 49 days

Because the **mode-decision** count query uses the same window, and shrinking it breaks mode selection. `isIncrementalProcessing = topicIds.length > 0 && assignedTracesCount >= 1200`, where `assignedTracesCount` is measured over the window. A 49-day window measures only recent traffic, so historically-mature-but-quiet projects fall under 1200 and flip **out of** cheap incremental into the **heavy full-batch re-cluster** path.

Measured on prod: of **73** currently-incremental projects, a blanket 49-day change would flip **54** to batch — the opposite of reducing load.

## Fix: split the two windows by role

- **MODE** (`fetchCountsFromClickHouse`): **stays 365 days.** Reads only light key columns (no payload), so its scan stays cheap even across cold-tier partitions, and it correctly reflects the project's whole history → no mode flips.
- **FETCH** (`fetchTracesFromClickHouse`): **49 days**, inside the hot tier, so the `ComputedInput` read never touches S3.

Both are named constants (`CLUSTERING_MODE_WINDOW_DAYS`, `CLUSTERING_FETCH_WINDOW_DAYS`) with the rationale documented at the definition.

## Trade-off

An unassigned trace older than 49 days is no longer retroactively clustered. For the 2-day batch cadence and hot-tier ingest this is negligible; new/recent traffic (all within the window) is unaffected. 49 days matches the retention recovery floor and sits comfortably within the ~90-day hot tier.

## Tests

Integration case in `fetchTracesFromClickHouse.integration.test.ts`: seeds an in-window (10-day) and an out-of-window (60-day) trace, asserts the fetch returns the former and excludes the latter.

## Remaining cold read (explicit)

The MODE count query still scans up to 365 days, including S3 cold-tier partitions — deliberately, since project maturity is a whole-history question (see the flip measurement above). It reads only light key columns (`OccurredAt`, `TopicId`, `UpdatedAt`; no `ComputedInput`), so it is not in the stall/OOM class this PR eliminates. Killing even that residual scan means answering "is this project mature?" without querying trace data at all (e.g. from the `topics` table or a maintained counter) — follow-up, out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topic clustering trace retrieval by consistently limiting results to the supported 49-day fetch window.
  * Ensured older traces are excluded from clustering results while recent traces remain available.
  * Standardized the clustering decision look-back period to one year.

* **Tests**
  * Added integration coverage confirming that in-window traces are returned and older traces are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->