### PR TITLE
feat(traces): canonicalise Vertex AI Agent Engine (Google ADK) spans

### DIFF
--- a/langwatch/src/server/app-layer/traces/canonicalisation/canonicalizeSpanAttributesService.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/canonicalizeSpanAttributesService.ts
@@ -18,6 +18,7 @@ import {
   StrandsExtractor,
   TraceloopExtractor,
   VercelExtractor,
+  VertexAdkExtractor,
 } from "./extractors";
 import type {
   CanonicalAttributesExtractor,
@@ -36,6 +37,7 @@ export class CanonicalizeSpanAttributesService {
     // Priority is determined by the order of registration.
     new LangWatchExtractor(),
     new GenAIExtractor(),
+    new VertexAdkExtractor(),
     new MastraExtractor(),
     new OpenInferenceExtractor(),
     new TraceloopExtractor(),

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/_testHelpers.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/_testHelpers.ts
@@ -19,14 +19,17 @@ export { parseJsonStringAttrs };
  * and `setAttrIfAbsent` are wrapped in vi.fn() for easy assertion.
  *
  * JSON-looking string values in attrs are auto-parsed to match the production
- * pipeline's `parseJsonStringValues()` step.
+ * pipeline's `parseJsonStringValues()` step — pass `skipJsonParsing` to feed
+ * raw string values instead, exercising an extractor's own defensive
+ * safeJsonParse path.
  */
 export function createExtractorContext(
   attrs: Record<string, unknown>,
   spanOverrides?: Partial<ExtractorContext["span"]>,
   events?: NormalizedEvent[],
+  options?: { skipJsonParsing?: boolean },
 ): ExtractorContext {
-  const parsed = parseJsonStringAttrs(attrs);
+  const parsed = options?.skipJsonParsing ? attrs : parseJsonStringAttrs(attrs);
   const bag = new SpanDataBag(parsed as NormalizedAttributes, events ?? []);
   const out: NormalizedAttributes = {};
 

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vertexAdk.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vertexAdk.unit.test.ts
@@ -1,0 +1,554 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { NormalizedAttributes } from "../../../../../event-sourcing/pipelines/trace-processing/schemas/spans";
+import { SpanDataBag } from "../../spanDataBag";
+import { ATTR_KEYS } from "../_constants";
+import type { ExtractorContext } from "../_types";
+import { VertexAdkExtractor } from "../vertexAdk";
+import { createExtractorContext } from "./_testHelpers";
+
+/**
+ * Anonymised replicas of real Google ADK / Vertex AI Agent Engine span
+ * payloads (agent names, ids, prompts, and tool schemas replaced with
+ * synthetic equivalents; structure preserved verbatim).
+ */
+
+const SYSTEM_INSTRUCTION =
+  "You are TravelPlanner, a travel planning assistant. Keep answers short.";
+
+const llmRequestPayload = {
+  model: "gemini-2.5-pro",
+  config: {
+    system_instruction: SYSTEM_INSTRUCTION,
+    tools: [
+      {
+        function_declarations: [
+          {
+            description: "Look up the current weather for a city.",
+            name: "lookup_weather",
+            parameters: {
+              properties: { city: { type: "STRING" } },
+              required: ["city"],
+              type: "OBJECT",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  contents: [
+    {
+      parts: [{ text: "What's the weather like in Amsterdam today?" }],
+      role: "user",
+    },
+    {
+      parts: [
+        {
+          function_call: {
+            id: "tool-call-0001",
+            args: { city: "Amsterdam" },
+            name: "lookup_weather",
+          },
+        },
+      ],
+      role: "model",
+    },
+    {
+      parts: [
+        {
+          function_response: {
+            id: "tool-call-0001",
+            name: "lookup_weather",
+            response: { temperature: "18C", condition: "cloudy" },
+          },
+        },
+      ],
+      role: "user",
+    },
+  ],
+};
+
+const llmResponsePayload = {
+  content: {
+    parts: [
+      { text: "I'll check the forecast before suggesting an itinerary." },
+      {
+        function_call: {
+          id: "tool-call-0002",
+          args: { city: "Amsterdam", days: 3 },
+          name: "lookup_forecast",
+        },
+      },
+    ],
+    role: "model",
+  },
+  partial: false,
+  usage_metadata: {
+    cached_content_token_count: 2100,
+    candidates_token_count: 64,
+    prompt_token_count: 2500,
+    total_token_count: 2564,
+  },
+};
+
+/** Standard gen_ai.* attributes as emitted by ADK on a generate_content span */
+const llmSpanBaseAttrs = {
+  "gen_ai.operation.name": "generate_content",
+  "gen_ai.conversation.id": "session-1234abcd",
+  "gen_ai.request.model": "gemini-2.5-pro",
+  "gen_ai.provider.name": "gcp.vertex.agent",
+  "gen_ai.agent.name": "TravelPlanner",
+  "gcp.vertex.agent.invocation_id": "e-11111111-2222-3333-4444-555555555555",
+  "gcp.vertex.agent.session_id": "session-1234abcd",
+  "gcp.vertex.agent.event_id": "66666666-7777-8888-9999-000000000000",
+};
+
+const llmSpanAttrs = (): Record<string, unknown> => ({
+  ...llmSpanBaseAttrs,
+  "gen_ai.usage.input_tokens": 2500,
+  "gen_ai.usage.output_tokens": 64,
+  "gcp.vertex.agent.llm_request": JSON.stringify(llmRequestPayload),
+  "gcp.vertex.agent.llm_response": JSON.stringify(llmResponsePayload),
+});
+
+const toolSpanAttrs = (): Record<string, unknown> => ({
+  "gen_ai.operation.name": "execute_tool",
+  "gen_ai.tool.name": "lookup_weather",
+  "gen_ai.tool.description": "Look up the current weather for a city.",
+  "gen_ai.tool.type": "FunctionTool",
+  "gen_ai.tool.call.id": "tool-call-0001",
+  "gcp.vertex.agent.event_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "gcp.vertex.agent.llm_request": "{}",
+  "gcp.vertex.agent.llm_response": "{}",
+  "gcp.vertex.agent.tool_call_args": JSON.stringify({ city: "Amsterdam" }),
+  "gcp.vertex.agent.tool_response": JSON.stringify({
+    temperature: "18C",
+    condition: "cloudy",
+  }),
+});
+
+describe("VertexAdkExtractor", () => {
+  const extractor = new VertexAdkExtractor();
+
+  describe("given a generate_content span", () => {
+    describe("when the span is canonicalised", () => {
+      it("extracts the conversation as gen_ai.input.messages", () => {
+        const ctx = createExtractorContext(llmSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_INPUT_MESSAGES]).toEqual([
+          {
+            role: "user",
+            content: "What's the weather like in Amsterdam today?",
+          },
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "tool-call-0001",
+                type: "function",
+                function: {
+                  name: "lookup_weather",
+                  arguments: JSON.stringify({ city: "Amsterdam" }),
+                },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            tool_call_id: "tool-call-0001",
+            name: "lookup_weather",
+            content: JSON.stringify({
+              temperature: "18C",
+              condition: "cloudy",
+            }),
+          },
+        ]);
+      });
+
+      it("extracts the model reply as gen_ai.output.messages", () => {
+        const ctx = createExtractorContext(llmSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES]).toEqual([
+          {
+            role: "assistant",
+            content: "I'll check the forecast before suggesting an itinerary.",
+            tool_calls: [
+              {
+                id: "tool-call-0002",
+                type: "function",
+                function: {
+                  name: "lookup_forecast",
+                  arguments: JSON.stringify({ city: "Amsterdam", days: 3 }),
+                },
+              },
+            ],
+          },
+        ]);
+      });
+
+      it("surfaces the system instruction separately from the chat messages", () => {
+        const ctx = createExtractorContext(llmSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_SYSTEM_INSTRUCTIONS]).toBe(
+          SYSTEM_INSTRUCTION,
+        );
+        const input = ctx.out[ATTR_KEYS.GEN_AI_INPUT_MESSAGES] as unknown[];
+        for (const message of input) {
+          expect((message as { role: string }).role).not.toBe("system");
+        }
+      });
+
+      it("annotates input and output messages as chat_messages", () => {
+        const ctx = createExtractorContext(llmSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.LANGWATCH_RESERVED_VALUE_TYPES]).toEqual([
+          `${ATTR_KEYS.GEN_AI_INPUT_MESSAGES}=chat_messages`,
+          `${ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES}=chat_messages`,
+        ]);
+      });
+
+      it("lifts tool declarations to gen_ai.tool.definitions", () => {
+        const ctx = createExtractorContext(llmSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_TOOL_DEFINITIONS]).toEqual(
+          llmRequestPayload.config.tools,
+        );
+      });
+
+      it("types the span as llm", () => {
+        const ctx = createExtractorContext(llmSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.SPAN_TYPE]).toBe("llm");
+      });
+
+      it("consumes the vendor request/response payload attributes", () => {
+        const ctx = createExtractorContext(llmSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.bag.attrs.has("gcp.vertex.agent.llm_request")).toBe(false);
+        expect(ctx.bag.attrs.has("gcp.vertex.agent.llm_response")).toBe(false);
+      });
+
+      it("keeps the vendor session/invocation ids as passthrough attributes", () => {
+        const ctx = createExtractorContext(llmSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.bag.attrs.has("gcp.vertex.agent.session_id")).toBe(true);
+        expect(ctx.bag.attrs.has("gcp.vertex.agent.invocation_id")).toBe(true);
+      });
+    });
+
+    describe("when the span already reports standard token usage", () => {
+      it("keeps the explicitly reported token counts", () => {
+        const ctx = createExtractorContext(llmSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS]).toBeUndefined();
+        expect(ctx.out[ATTR_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS]).toBeUndefined();
+        expect(ctx.bag.attrs.get(ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS)).toBe(
+          2500,
+        );
+      });
+
+      it("still lifts cached prompt tokens as cache-read tokens", () => {
+        const ctx = createExtractorContext(llmSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(
+          ctx.out[ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS],
+        ).toBe(2100);
+      });
+    });
+
+    describe("when the span reports no standard token usage", () => {
+      it("falls back to the response usage metadata", () => {
+        const attrs = llmSpanAttrs();
+        delete attrs["gen_ai.usage.input_tokens"];
+        delete attrs["gen_ai.usage.output_tokens"];
+        const ctx = createExtractorContext(attrs);
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS]).toBe(2500);
+        expect(ctx.out[ATTR_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS]).toBe(64);
+      });
+    });
+
+    describe("when gen_ai.input.messages is already present", () => {
+      it("does not overwrite the existing messages", () => {
+        const existing = [{ role: "user", content: "already extracted" }];
+        const ctx = createExtractorContext({
+          ...llmSpanAttrs(),
+          [ATTR_KEYS.GEN_AI_INPUT_MESSAGES]: existing,
+        });
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_INPUT_MESSAGES]).toBeUndefined();
+        expect(ctx.bag.attrs.get(ATTR_KEYS.GEN_AI_INPUT_MESSAGES)).toEqual(
+          existing,
+        );
+      });
+    });
+
+    describe("when the response carries raw Gemini candidates", () => {
+      it("extracts output messages from candidates[].content", () => {
+        const attrs = llmSpanAttrs();
+        attrs["gcp.vertex.agent.llm_response"] = JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ text: "Pack an umbrella." }],
+                role: "model",
+              },
+            },
+          ],
+        });
+        const ctx = createExtractorContext(attrs);
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES]).toEqual([
+          { role: "assistant", content: "Pack an umbrella." },
+        ]);
+      });
+    });
+
+    describe("when the system instruction is a content object", () => {
+      it("joins the text parts", () => {
+        const attrs = llmSpanAttrs();
+        attrs["gcp.vertex.agent.llm_request"] = JSON.stringify({
+          model: "gemini-2.5-pro",
+          config: {
+            system_instruction: {
+              parts: [{ text: "Be concise." }, { text: "Be kind." }],
+            },
+          },
+          contents: [{ parts: [{ text: "hi" }], role: "user" }],
+        });
+        const ctx = createExtractorContext(attrs);
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_SYSTEM_INSTRUCTIONS]).toBe(
+          "Be concise.\nBe kind.",
+        );
+      });
+    });
+
+    describe("when generation config parameters are present", () => {
+      it("lifts them to gen_ai.request.* parameters", () => {
+        const attrs = llmSpanAttrs();
+        attrs["gcp.vertex.agent.llm_request"] = JSON.stringify({
+          model: "gemini-2.5-pro",
+          config: {
+            temperature: 0.2,
+            top_p: 0.9,
+            top_k: 40,
+            max_output_tokens: 1024,
+          },
+          contents: [{ parts: [{ text: "hi" }], role: "user" }],
+        });
+        const ctx = createExtractorContext(attrs);
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_REQUEST_TEMPERATURE]).toBe(0.2);
+        expect(ctx.out[ATTR_KEYS.GEN_AI_REQUEST_TOP_P]).toBe(0.9);
+        expect(ctx.out[ATTR_KEYS.GEN_AI_REQUEST_TOP_K]).toBe(40);
+        expect(ctx.out[ATTR_KEYS.GEN_AI_REQUEST_MAX_TOKENS]).toBe(1024);
+      });
+    });
+  });
+
+  describe("given an execute_tool span", () => {
+    describe("when the span is canonicalised", () => {
+      it("types the span as tool", () => {
+        const ctx = createExtractorContext(toolSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.SPAN_TYPE]).toBe("tool");
+      });
+
+      it("lifts the call arguments to langwatch.input and gen_ai.tool.call.arguments", () => {
+        const ctx = createExtractorContext(toolSpanAttrs());
+
+        extractor.apply(ctx);
+
+        const expected = JSON.stringify({ city: "Amsterdam" });
+        expect(ctx.out[ATTR_KEYS.LANGWATCH_INPUT]).toBe(expected);
+        expect(ctx.out[ATTR_KEYS.GEN_AI_TOOL_CALL_ARGUMENTS]).toBe(expected);
+      });
+
+      it("lifts the tool response to langwatch.output and gen_ai.tool.call.result", () => {
+        const ctx = createExtractorContext(toolSpanAttrs());
+
+        extractor.apply(ctx);
+
+        const expected = JSON.stringify({
+          temperature: "18C",
+          condition: "cloudy",
+        });
+        expect(ctx.out[ATTR_KEYS.LANGWATCH_OUTPUT]).toBe(expected);
+        expect(ctx.out[ATTR_KEYS.GEN_AI_TOOL_CALL_RESULT]).toBe(expected);
+      });
+
+      it("does not produce chat messages from the empty request/response payloads", () => {
+        const ctx = createExtractorContext(toolSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_INPUT_MESSAGES]).toBeUndefined();
+        expect(ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES]).toBeUndefined();
+      });
+
+      it("consumes the vendor tool payload attributes", () => {
+        const ctx = createExtractorContext(toolSpanAttrs());
+
+        extractor.apply(ctx);
+
+        expect(ctx.bag.attrs.has("gcp.vertex.agent.tool_call_args")).toBe(
+          false,
+        );
+        expect(ctx.bag.attrs.has("gcp.vertex.agent.tool_response")).toBe(
+          false,
+        );
+        expect(ctx.bag.attrs.has("gcp.vertex.agent.llm_request")).toBe(false);
+        expect(ctx.bag.attrs.has("gcp.vertex.agent.llm_response")).toBe(false);
+      });
+    });
+
+    describe("when the span type is explicitly set", () => {
+      it("respects the explicit type", () => {
+        const ctx = createExtractorContext({
+          ...toolSpanAttrs(),
+          [ATTR_KEYS.SPAN_TYPE]: "component",
+        });
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.SPAN_TYPE]).toBeUndefined();
+      });
+    });
+  });
+
+  describe("given an invoke_agent span", () => {
+    describe("when the span is canonicalised", () => {
+      it("types the span as agent", () => {
+        const ctx = createExtractorContext({
+          "gen_ai.operation.name": "invoke_agent",
+          "gen_ai.provider.name": "gcp.vertex.agent",
+          "gen_ai.agent.name": "TravelPlanner",
+        });
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.SPAN_TYPE]).toBe("agent");
+      });
+    });
+  });
+
+  describe("given a span missing gen_ai.conversation.id", () => {
+    describe("when the vendor session id is present", () => {
+      it("falls back to gcp.vertex.agent.session_id", () => {
+        const attrs = llmSpanAttrs();
+        delete attrs["gen_ai.conversation.id"];
+        const ctx = createExtractorContext(attrs);
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_CONVERSATION_ID]).toBe(
+          "session-1234abcd",
+        );
+      });
+    });
+  });
+
+  describe("given the payload arrives as a JSON string that bypassed pre-parsing", () => {
+    it("parses the request payload itself", () => {
+      const ctx = createRawContext({
+        "gen_ai.provider.name": "gcp.vertex.agent",
+        "gcp.vertex.agent.llm_request": JSON.stringify({
+          model: "gemini-2.5-pro",
+          contents: [{ parts: [{ text: "hello" }], role: "user" }],
+        }),
+      });
+
+      extractor.apply(ctx);
+
+      expect(ctx.out[ATTR_KEYS.GEN_AI_INPUT_MESSAGES]).toEqual([
+        { role: "user", content: "hello" },
+      ]);
+    });
+  });
+
+  describe("given a span from a different SDK", () => {
+    describe("when the span is canonicalised", () => {
+      it("does nothing", () => {
+        const ctx = createExtractorContext({
+          "gen_ai.operation.name": "chat",
+          "gen_ai.provider.name": "openai",
+          "gen_ai.request.model": "gpt-5-mini",
+        });
+
+        extractor.apply(ctx);
+
+        expect(ctx.out).toEqual({});
+        expect(ctx.recordRule).not.toHaveBeenCalled();
+      });
+    });
+  });
+});
+
+/**
+ * Builds a context WITHOUT the helper's automatic JSON-string parsing, so
+ * the extractor's own defensive safeJsonParse path is exercised.
+ */
+function createRawContext(raw: Record<string, unknown>): ExtractorContext {
+  const bag = new SpanDataBag(raw as NormalizedAttributes, []);
+  const out: NormalizedAttributes = {};
+
+  const setAttr = vi.fn((key: string, value: unknown) => {
+    if (value === null || value === undefined) return;
+    out[key] = value;
+  });
+  const setAttrIfAbsent = vi.fn((key: string, value: unknown) => {
+    if (!(key in out)) {
+      if (value === null || value === undefined) return;
+      out[key] = value;
+    }
+  });
+
+  return {
+    bag,
+    out,
+    span: {
+      name: "test",
+      kind: 0,
+      instrumentationScope: { name: "test", version: null },
+      statusMessage: null,
+      statusCode: null,
+      parentSpanId: "abc123",
+    },
+    recordRule: vi.fn(),
+    setAttr,
+    setAttrIfAbsent,
+  };
+}

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vertexAdk.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vertexAdk.unit.test.ts
@@ -307,6 +307,23 @@ describe("VertexAdkExtractor", () => {
       });
     });
 
+    describe("when the response carries a finish reason", () => {
+      it("lifts it to gen_ai.response.finish_reasons", () => {
+        const attrs = llmSpanAttrs();
+        attrs["gcp.vertex.agent.llm_response"] = JSON.stringify({
+          content: { parts: [{ text: "Done." }], role: "model" },
+          finish_reason: "STOP",
+        });
+        const ctx = createExtractorContext(attrs);
+
+        extractor.apply(ctx);
+
+        expect(ctx.out[ATTR_KEYS.GEN_AI_RESPONSE_FINISH_REASONS]).toEqual([
+          "STOP",
+        ]);
+      });
+    });
+
     describe("when the response carries raw Gemini candidates", () => {
       it("extracts output messages from candidates[].content", () => {
         const attrs = llmSpanAttrs();
@@ -432,6 +449,28 @@ describe("VertexAdkExtractor", () => {
         );
         expect(ctx.bag.attrs.has("gcp.vertex.agent.llm_request")).toBe(false);
         expect(ctx.bag.attrs.has("gcp.vertex.agent.llm_response")).toBe(false);
+      });
+    });
+
+    describe("when the tool input/output were already set by an earlier source", () => {
+      it("does not record the tool lift rules", () => {
+        const ctx = createExtractorContext({
+          ...toolSpanAttrs(),
+          [ATTR_KEYS.LANGWATCH_INPUT]: "already set",
+          [ATTR_KEYS.GEN_AI_TOOL_CALL_ARGUMENTS]: "already set",
+          [ATTR_KEYS.LANGWATCH_OUTPUT]: "already set",
+          [ATTR_KEYS.GEN_AI_TOOL_CALL_RESULT]: "already set",
+        });
+
+        extractor.apply(ctx);
+
+        expect(ctx.recordRule).not.toHaveBeenCalledWith(
+          "vertex-adk:tool_call_args->input",
+        );
+        expect(ctx.recordRule).not.toHaveBeenCalledWith(
+          "vertex-adk:tool_response->output",
+        );
+        expect(ctx.out[ATTR_KEYS.LANGWATCH_INPUT]).toBeUndefined();
       });
     });
 

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vertexAdk.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/vertexAdk.unit.test.ts
@@ -1,9 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import type { NormalizedAttributes } from "../../../../../event-sourcing/pipelines/trace-processing/schemas/spans";
-import { SpanDataBag } from "../../spanDataBag";
 import { ATTR_KEYS } from "../_constants";
-import type { ExtractorContext } from "../_types";
 import { VertexAdkExtractor } from "../vertexAdk";
 import { createExtractorContext } from "./_testHelpers";
 
@@ -522,13 +519,18 @@ describe("VertexAdkExtractor", () => {
 
   describe("given the payload arrives as a JSON string that bypassed pre-parsing", () => {
     it("parses the request payload itself", () => {
-      const ctx = createRawContext({
-        "gen_ai.provider.name": "gcp.vertex.agent",
-        "gcp.vertex.agent.llm_request": JSON.stringify({
-          model: "gemini-2.5-pro",
-          contents: [{ parts: [{ text: "hello" }], role: "user" }],
-        }),
-      });
+      const ctx = createExtractorContext(
+        {
+          "gen_ai.provider.name": "gcp.vertex.agent",
+          "gcp.vertex.agent.llm_request": JSON.stringify({
+            model: "gemini-2.5-pro",
+            contents: [{ parts: [{ text: "hello" }], role: "user" }],
+          }),
+        },
+        undefined,
+        undefined,
+        { skipJsonParsing: true },
+      );
 
       extractor.apply(ctx);
 
@@ -555,39 +557,3 @@ describe("VertexAdkExtractor", () => {
     });
   });
 });
-
-/**
- * Builds a context WITHOUT the helper's automatic JSON-string parsing, so
- * the extractor's own defensive safeJsonParse path is exercised.
- */
-function createRawContext(raw: Record<string, unknown>): ExtractorContext {
-  const bag = new SpanDataBag(raw as NormalizedAttributes, []);
-  const out: NormalizedAttributes = {};
-
-  const setAttr = vi.fn((key: string, value: unknown) => {
-    if (value === null || value === undefined) return;
-    out[key] = value;
-  });
-  const setAttrIfAbsent = vi.fn((key: string, value: unknown) => {
-    if (!(key in out)) {
-      if (value === null || value === undefined) return;
-      out[key] = value;
-    }
-  });
-
-  return {
-    bag,
-    out,
-    span: {
-      name: "test",
-      kind: 0,
-      instrumentationScope: { name: "test", version: null },
-      statusMessage: null,
-      statusCode: null,
-      parentSpanId: "abc123",
-    },
-    recordRule: vi.fn(),
-    setAttr,
-    setAttrIfAbsent,
-  };
-}

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/_geminiContent.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/_geminiContent.ts
@@ -1,0 +1,134 @@
+/**
+ * Gemini Content Format Conversion
+ *
+ * Helpers for translating the Gemini API content shapes carried in
+ * Vertex AI Agent Engine (Google ADK) payloads — { role, parts:
+ * [{ text | function_call | function_response }] } — into canonical
+ * chat messages. Used by the VertexAdk extractor.
+ */
+
+import { isNonEmptyString, isRecord } from "./_guards";
+
+export const safeStringify = (value: unknown): string | null => {
+  try {
+    const s = JSON.stringify(value);
+    return typeof s === "string" ? s : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Gemini content roles are "user" | "model"; chat messages use
+ * "user" | "assistant".
+ */
+const geminiRoleToChatRole = (role: unknown, defaultRole: string): string => {
+  if (role === "model") return "assistant";
+  return isNonEmptyString(role) ? role : defaultRole;
+};
+
+/**
+ * Converts a single Gemini content object ({ role, parts }) into chat
+ * messages. Text and function_call parts fold into one message (an
+ * assistant turn can carry both text and tool calls); function_response
+ * parts become separate tool-role messages, matching chat semantics —
+ * ADK wraps tool results in a user-role content.
+ */
+export const convertGeminiContent = (
+  content: unknown,
+  defaultRole: string,
+): unknown[] => {
+  if (!isRecord(content)) return [];
+
+  const role = geminiRoleToChatRole(content.role, defaultRole);
+  const parts = Array.isArray(content.parts) ? content.parts : [];
+
+  const messages: unknown[] = [];
+  let texts: string[] = [];
+  let toolCalls: unknown[] = [];
+
+  const flush = () => {
+    if (texts.length === 0 && toolCalls.length === 0) return;
+    messages.push({
+      role,
+      ...(texts.length > 0 ? { content: texts.join("\n") } : {}),
+      ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+    });
+    texts = [];
+    toolCalls = [];
+  };
+
+  for (const part of parts) {
+    if (!isRecord(part)) continue;
+
+    if (typeof part.text === "string") {
+      texts.push(part.text);
+      continue;
+    }
+
+    if (isRecord(part.function_call)) {
+      const fc = part.function_call;
+      toolCalls.push({
+        ...(isNonEmptyString(fc.id) ? { id: fc.id } : {}),
+        type: "function",
+        function: {
+          name: isNonEmptyString(fc.name) ? fc.name : "",
+          arguments: safeStringify(fc.args ?? {}) ?? "{}",
+        },
+      });
+      continue;
+    }
+
+    if (isRecord(part.function_response)) {
+      flush();
+      const fr = part.function_response;
+      messages.push({
+        role: "tool",
+        ...(isNonEmptyString(fr.id) ? { tool_call_id: fr.id } : {}),
+        ...(isNonEmptyString(fr.name) ? { name: fr.name } : {}),
+        content: safeStringify(fr.response ?? {}) ?? "{}",
+      });
+      continue;
+    }
+  }
+  flush();
+
+  return messages;
+};
+
+/**
+ * ADK system instructions are usually a plain string, but the Gemini API
+ * also accepts a content object ({ parts: [{ text }] }) or a list of
+ * strings/parts.
+ */
+export const systemInstructionText = (raw: unknown): string | null => {
+  if (typeof raw === "string") {
+    return raw.length > 0 ? raw : null;
+  }
+
+  const partsToText = (parts: unknown[]): string | null => {
+    const texts: string[] = [];
+    for (const part of parts) {
+      if (typeof part === "string") {
+        texts.push(part);
+      } else if (isRecord(part) && typeof part.text === "string") {
+        texts.push(part.text);
+      }
+    }
+    return texts.length > 0 ? texts.join("\n") : null;
+  };
+
+  if (Array.isArray(raw)) return partsToText(raw);
+  if (isRecord(raw) && Array.isArray(raw.parts)) return partsToText(raw.parts);
+  return null;
+};
+
+/**
+ * Tool-call args/response arrive as a JSON string or an already-parsed
+ * object. Normalise to a non-empty string for langwatch.input/output.
+ */
+export const stringifyToolPayload = (raw: unknown): string | null => {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw === "string") return raw.length > 0 ? raw : null;
+  return safeStringify(raw);
+};

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/_geminiContent.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/_geminiContent.ts
@@ -22,7 +22,13 @@ export const safeStringify = (value: unknown): string | null => {
  * Gemini content roles are "user" | "model"; chat messages use
  * "user" | "assistant".
  */
-const geminiRoleToChatRole = (role: unknown, defaultRole: string): string => {
+const geminiRoleToChatRole = ({
+  role,
+  defaultRole,
+}: {
+  role: unknown;
+  defaultRole: string;
+}): string => {
   if (role === "model") return "assistant";
   return isNonEmptyString(role) ? role : defaultRole;
 };
@@ -34,13 +40,16 @@ const geminiRoleToChatRole = (role: unknown, defaultRole: string): string => {
  * parts become separate tool-role messages, matching chat semantics —
  * ADK wraps tool results in a user-role content.
  */
-export const convertGeminiContent = (
-  content: unknown,
-  defaultRole: string,
-): unknown[] => {
+export const convertGeminiContent = ({
+  content,
+  defaultRole,
+}: {
+  content: unknown;
+  defaultRole: string;
+}): unknown[] => {
   if (!isRecord(content)) return [];
 
-  const role = geminiRoleToChatRole(content.role, defaultRole);
+  const role = geminiRoleToChatRole({ role: content.role, defaultRole });
   const parts = Array.isArray(content.parts) ? content.parts : [];
 
   const messages: unknown[] = [];

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/index.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/index.ts
@@ -13,3 +13,4 @@ export { SpringAIExtractor } from "./springAI";
 export { StrandsExtractor } from "./strands";
 export { TraceloopExtractor } from "./traceloop";
 export { VercelExtractor } from "./vercel";
+export { VertexAdkExtractor } from "./vertexAdk";

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vertexAdk.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vertexAdk.ts
@@ -31,6 +31,11 @@
  */
 
 import { ATTR_KEYS } from "./_constants";
+import {
+  convertGeminiContent,
+  stringifyToolPayload,
+  systemInstructionText,
+} from "./_geminiContent";
 import { inferSpanTypeIfAbsent, recordValueType } from "./_extraction";
 import { asNumber, isNonEmptyString, isRecord, safeJsonParse } from "./_guards";
 import type {
@@ -54,130 +59,6 @@ const OPERATION_NAME_SPAN_TYPE_MAP: Record<string, string> = {
   chat: "llm",
   execute_tool: "tool",
   invoke_agent: "agent",
-};
-
-const safeStringify = (value: unknown): string | null => {
-  try {
-    const s = JSON.stringify(value);
-    return typeof s === "string" ? s : null;
-  } catch {
-    return null;
-  }
-};
-
-/**
- * Gemini content roles are "user" | "model"; chat messages use
- * "user" | "assistant".
- */
-const geminiRoleToChatRole = (role: unknown, defaultRole: string): string => {
-  if (role === "model") return "assistant";
-  return isNonEmptyString(role) ? role : defaultRole;
-};
-
-/**
- * Converts a single Gemini content object ({ role, parts }) into chat
- * messages. Text and function_call parts fold into one message (an
- * assistant turn can carry both text and tool calls); function_response
- * parts become separate tool-role messages, matching chat semantics —
- * ADK wraps tool results in a user-role content.
- */
-const convertGeminiContent = (
-  content: unknown,
-  defaultRole: string,
-): unknown[] => {
-  if (!isRecord(content)) return [];
-
-  const role = geminiRoleToChatRole(content.role, defaultRole);
-  const parts = Array.isArray(content.parts) ? content.parts : [];
-
-  const messages: unknown[] = [];
-  let texts: string[] = [];
-  let toolCalls: unknown[] = [];
-
-  const flush = () => {
-    if (texts.length === 0 && toolCalls.length === 0) return;
-    messages.push({
-      role,
-      ...(texts.length > 0 ? { content: texts.join("\n") } : {}),
-      ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
-    });
-    texts = [];
-    toolCalls = [];
-  };
-
-  for (const part of parts) {
-    if (!isRecord(part)) continue;
-
-    if (typeof part.text === "string") {
-      texts.push(part.text);
-      continue;
-    }
-
-    if (isRecord(part.function_call)) {
-      const fc = part.function_call;
-      toolCalls.push({
-        ...(isNonEmptyString(fc.id) ? { id: fc.id } : {}),
-        type: "function",
-        function: {
-          name: isNonEmptyString(fc.name) ? fc.name : "",
-          arguments: safeStringify(fc.args ?? {}) ?? "{}",
-        },
-      });
-      continue;
-    }
-
-    if (isRecord(part.function_response)) {
-      flush();
-      const fr = part.function_response;
-      messages.push({
-        role: "tool",
-        ...(isNonEmptyString(fr.id) ? { tool_call_id: fr.id } : {}),
-        ...(isNonEmptyString(fr.name) ? { name: fr.name } : {}),
-        content: safeStringify(fr.response ?? {}) ?? "{}",
-      });
-      continue;
-    }
-  }
-  flush();
-
-  return messages;
-};
-
-/**
- * ADK system instructions are usually a plain string, but the Gemini API
- * also accepts a content object ({ parts: [{ text }] }) or a list of
- * strings/parts.
- */
-const systemInstructionText = (raw: unknown): string | null => {
-  if (typeof raw === "string") {
-    return raw.length > 0 ? raw : null;
-  }
-
-  const partsToText = (parts: unknown[]): string | null => {
-    const texts: string[] = [];
-    for (const part of parts) {
-      if (typeof part === "string") {
-        texts.push(part);
-      } else if (isRecord(part) && typeof part.text === "string") {
-        texts.push(part.text);
-      }
-    }
-    return texts.length > 0 ? texts.join("\n") : null;
-  };
-
-  if (Array.isArray(raw)) return partsToText(raw);
-  if (isRecord(raw) && Array.isArray(raw.parts)) return partsToText(raw.parts);
-  return null;
-};
-
-/**
- * Tool-call args/response arrive as a JSON string or an already-parsed
- * object. Normalise to a non-empty string for langwatch.input/output.
- */
-const stringifyToolPayload = (raw: unknown): string | null => {
-  if (raw === undefined || raw === null) return null;
-  if (typeof raw === "string") return raw.length > 0 ? raw : null;
-  return safeStringify(raw);
 };
 
 export class VertexAdkExtractor implements CanonicalAttributesExtractor {
@@ -306,14 +187,14 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
       [ATTR_KEYS.GEN_AI_REQUEST_TOP_K, config.top_k],
       [ATTR_KEYS.GEN_AI_REQUEST_MAX_TOKENS, config.max_output_tokens],
     ];
-    let paramsExtracted = false;
+    let hasExtractedParams = false;
     for (const [key, raw] of paramMap) {
       const value = asNumber(raw);
       if (value !== null && this.setIfMissing(ctx, key, value)) {
-        paramsExtracted = true;
+        hasExtractedParams = true;
       }
     }
-    if (paramsExtracted) {
+    if (hasExtractedParams) {
       ctx.recordRule(`${this.id}:params`);
     }
   }
@@ -364,14 +245,14 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
         ],
         [ATTR_KEYS.GEN_AI_USAGE_REASONING_TOKENS, usage.thoughts_token_count],
       ];
-      let usageExtracted = false;
+      let hasExtractedUsage = false;
       for (const [key, raw] of usageMap) {
         const value = asNumber(raw);
         if (value !== null && this.setIfMissing(ctx, key, value)) {
-          usageExtracted = true;
+          hasExtractedUsage = true;
         }
       }
-      if (usageExtracted) {
+      if (hasExtractedUsage) {
         ctx.recordRule(`${this.id}:usage_metadata->gen_ai.usage`);
       }
     }
@@ -402,11 +283,11 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     );
     if (args !== null) {
       attrs.take(VERTEX_ADK_KEYS.TOOL_CALL_ARGS);
-      const argsSet = [
+      const hasSetArgs = [
         this.setIfMissing(ctx, ATTR_KEYS.LANGWATCH_INPUT, args),
         this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_CALL_ARGUMENTS, args),
       ].some(Boolean);
-      if (argsSet) {
+      if (hasSetArgs) {
         ctx.recordRule(`${this.id}:tool_call_args->input`);
       }
     }
@@ -416,11 +297,11 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     );
     if (result !== null) {
       attrs.take(VERTEX_ADK_KEYS.TOOL_RESPONSE);
-      const resultSet = [
+      const hasSetResult = [
         this.setIfMissing(ctx, ATTR_KEYS.LANGWATCH_OUTPUT, result),
         this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_CALL_RESULT, result),
       ].some(Boolean);
-      if (resultSet) {
+      if (hasSetResult) {
         ctx.recordRule(`${this.id}:tool_response->output`);
       }
     }

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vertexAdk.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vertexAdk.ts
@@ -1,0 +1,436 @@
+/**
+ * Vertex AI Agent Engine (Google ADK) Extractor
+ *
+ * Handles: Google Agent Development Kit / Vertex AI Agent Engine telemetry
+ * Reference: https://google.github.io/adk-docs/observability/
+ *
+ * ADK emits standard gen_ai.* attributes (operation name, model, provider
+ * "gcp.vertex.agent", token usage) but carries the actual conversation
+ * content in vendor-specific JSON payloads:
+ * - gcp.vertex.agent.llm_request: { model, config: { system_instruction,
+ *   tools, ... }, contents: [{ role, parts: [{ text | function_call |
+ *   function_response }] }] } (Gemini content format)
+ * - gcp.vertex.agent.llm_response: { content: { role, parts }, partial,
+ *   usage_metadata } (or raw Gemini { candidates: [{ content }] })
+ * - gcp.vertex.agent.tool_call_args / tool_response on execute_tool spans
+ *
+ * Detection: gen_ai.provider.name / gen_ai.system = "gcp.vertex.agent",
+ * or presence of any gcp.vertex.agent.* payload attribute
+ *
+ * Canonical attributes produced:
+ * - langwatch.span.type (from gen_ai.operation.name: generate_content →
+ *   llm, execute_tool → tool, invoke_agent → agent)
+ * - gen_ai.input.messages / gen_ai.system_instructions (from llm_request)
+ * - gen_ai.output.messages (from llm_response)
+ * - gen_ai.request.model + gen_ai.request.* params (from llm_request)
+ * - gen_ai.tool.definitions (from llm_request.config.tools)
+ * - gen_ai.usage.* tokens (from llm_response.usage_metadata, only when
+ *   the standard gen_ai.usage.* attributes are absent)
+ * - langwatch.input/output + gen_ai.tool.call.arguments/result (from
+ *   tool_call_args / tool_response on execute_tool spans)
+ */
+
+import { ATTR_KEYS } from "./_constants";
+import { inferSpanTypeIfAbsent, recordValueType } from "./_extraction";
+import { asNumber, isNonEmptyString, isRecord, safeJsonParse } from "./_guards";
+import type {
+  CanonicalAttributesExtractor,
+  ExtractorContext,
+} from "./_types";
+
+const VERTEX_ADK_PROVIDER = "gcp.vertex.agent";
+
+const VERTEX_ADK_KEYS = {
+  LLM_REQUEST: "gcp.vertex.agent.llm_request",
+  LLM_RESPONSE: "gcp.vertex.agent.llm_response",
+  TOOL_CALL_ARGS: "gcp.vertex.agent.tool_call_args",
+  TOOL_RESPONSE: "gcp.vertex.agent.tool_response",
+  SESSION_ID: "gcp.vertex.agent.session_id",
+} as const;
+
+const OPERATION_NAME_SPAN_TYPE_MAP: Record<string, string> = {
+  generate_content: "llm",
+  call_llm: "llm",
+  chat: "llm",
+  execute_tool: "tool",
+  invoke_agent: "agent",
+};
+
+const safeStringify = (value: unknown): string | null => {
+  try {
+    const s = JSON.stringify(value);
+    return typeof s === "string" ? s : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Gemini content roles are "user" | "model"; chat messages use
+ * "user" | "assistant".
+ */
+const geminiRoleToChatRole = (role: unknown, defaultRole: string): string => {
+  if (role === "model") return "assistant";
+  return isNonEmptyString(role) ? role : defaultRole;
+};
+
+/**
+ * Converts a single Gemini content object ({ role, parts }) into chat
+ * messages. Text and function_call parts fold into one message (an
+ * assistant turn can carry both text and tool calls); function_response
+ * parts become separate tool-role messages, matching chat semantics —
+ * ADK wraps tool results in a user-role content.
+ */
+const convertGeminiContent = (
+  content: unknown,
+  defaultRole: string,
+): unknown[] => {
+  if (!isRecord(content)) return [];
+
+  const role = geminiRoleToChatRole(content.role, defaultRole);
+  const parts = Array.isArray(content.parts) ? content.parts : [];
+
+  const messages: unknown[] = [];
+  let texts: string[] = [];
+  let toolCalls: unknown[] = [];
+
+  const flush = () => {
+    if (texts.length === 0 && toolCalls.length === 0) return;
+    messages.push({
+      role,
+      ...(texts.length > 0 ? { content: texts.join("\n") } : {}),
+      ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+    });
+    texts = [];
+    toolCalls = [];
+  };
+
+  for (const part of parts) {
+    if (!isRecord(part)) continue;
+
+    if (typeof part.text === "string") {
+      texts.push(part.text);
+      continue;
+    }
+
+    if (isRecord(part.function_call)) {
+      const fc = part.function_call;
+      toolCalls.push({
+        ...(isNonEmptyString(fc.id) ? { id: fc.id } : {}),
+        type: "function",
+        function: {
+          name: isNonEmptyString(fc.name) ? fc.name : "",
+          arguments: safeStringify(fc.args ?? {}) ?? "{}",
+        },
+      });
+      continue;
+    }
+
+    if (isRecord(part.function_response)) {
+      flush();
+      const fr = part.function_response;
+      messages.push({
+        role: "tool",
+        ...(isNonEmptyString(fr.id) ? { tool_call_id: fr.id } : {}),
+        ...(isNonEmptyString(fr.name) ? { name: fr.name } : {}),
+        content: safeStringify(fr.response ?? {}) ?? "{}",
+      });
+      continue;
+    }
+  }
+  flush();
+
+  return messages;
+};
+
+/**
+ * ADK system instructions are usually a plain string, but the Gemini API
+ * also accepts a content object ({ parts: [{ text }] }) or a list of
+ * strings/parts.
+ */
+const systemInstructionText = (raw: unknown): string | null => {
+  if (typeof raw === "string") {
+    return raw.length > 0 ? raw : null;
+  }
+
+  const partsToText = (parts: unknown[]): string | null => {
+    const texts: string[] = [];
+    for (const part of parts) {
+      if (typeof part === "string") {
+        texts.push(part);
+      } else if (isRecord(part) && typeof part.text === "string") {
+        texts.push(part.text);
+      }
+    }
+    return texts.length > 0 ? texts.join("\n") : null;
+  };
+
+  if (Array.isArray(raw)) return partsToText(raw);
+  if (isRecord(raw) && Array.isArray(raw.parts)) return partsToText(raw.parts);
+  return null;
+};
+
+/**
+ * Tool-call args/response arrive as a JSON string or an already-parsed
+ * object. Normalise to a non-empty string for langwatch.input/output.
+ */
+const stringifyToolPayload = (raw: unknown): string | null => {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw === "string") return raw.length > 0 ? raw : null;
+  return safeStringify(raw);
+};
+
+export class VertexAdkExtractor implements CanonicalAttributesExtractor {
+  readonly id = "vertex-adk";
+
+  apply(ctx: ExtractorContext): void {
+    const { attrs } = ctx.bag;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Detection Check
+    // Provider name (bag or already lifted from legacy gen_ai.system by the
+    // GenAI extractor) or presence of any gcp.vertex.agent.* payload key
+    // ─────────────────────────────────────────────────────────────────────────
+    const provider =
+      attrs.get(ATTR_KEYS.GEN_AI_PROVIDER_NAME) ??
+      attrs.get(ATTR_KEYS.GEN_AI_SYSTEM) ??
+      ctx.out[ATTR_KEYS.GEN_AI_PROVIDER_NAME];
+    const isVertexAdk =
+      provider === VERTEX_ADK_PROVIDER ||
+      attrs.has(VERTEX_ADK_KEYS.LLM_REQUEST) ||
+      attrs.has(VERTEX_ADK_KEYS.LLM_RESPONSE) ||
+      attrs.has(VERTEX_ADK_KEYS.TOOL_CALL_ARGS) ||
+      attrs.has(VERTEX_ADK_KEYS.TOOL_RESPONSE);
+
+    if (!isVertexAdk) return;
+
+    this.applySpanType(ctx);
+    this.liftLlmRequest(ctx);
+    this.liftLlmResponse(ctx);
+    this.liftToolCall(ctx);
+    this.liftSessionId(ctx);
+  }
+
+  /**
+   * Sets a canonical attribute only when neither the raw attributes nor a
+   * previous extractor already provide it. (ctx.setAttrIfAbsent checks the
+   * bag too in production, but the explicit guard keeps the behaviour
+   * self-contained and unit-testable.)
+   */
+  private setIfMissing(ctx: ExtractorContext, key: string, value: unknown) {
+    if (ctx.bag.attrs.has(key) || ctx.out[key] !== undefined) return false;
+    ctx.setAttr(key, value);
+    return true;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Span Type
+  // ADK relies on gen_ai.operation.name; without this mapping the fallback
+  // extractor sees generic gen_ai.* signals and types execute_tool spans
+  // as "llm"
+  // ─────────────────────────────────────────────────────────────────────────
+  private applySpanType(ctx: ExtractorContext): void {
+    const operationName = ctx.bag.attrs.get(ATTR_KEYS.GEN_AI_OPERATION_NAME);
+    if (!isNonEmptyString(operationName)) return;
+
+    const proposedSpanType = OPERATION_NAME_SPAN_TYPE_MAP[operationName];
+    if (proposedSpanType) {
+      inferSpanTypeIfAbsent(
+        ctx,
+        proposedSpanType,
+        `${this.id}:gen_ai.operation.name->langwatch.span.type`,
+      );
+    }
+  }
+
+  private liftLlmRequest(ctx: ExtractorContext): void {
+    const { attrs } = ctx.bag;
+
+    const request = safeJsonParse(attrs.get(VERTEX_ADK_KEYS.LLM_REQUEST));
+    if (!isRecord(request)) return;
+    attrs.take(VERTEX_ADK_KEYS.LLM_REQUEST);
+
+    // Model (standard gen_ai.request.model usually present; fallback only)
+    if (
+      isNonEmptyString(request.model) &&
+      this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_REQUEST_MODEL, request.model)
+    ) {
+      ctx.recordRule(`${this.id}:llm_request.model->gen_ai.request.model`);
+    }
+
+    // Input messages (Gemini contents → chat messages)
+    if (
+      !attrs.has(ATTR_KEYS.GEN_AI_INPUT_MESSAGES) &&
+      ctx.out[ATTR_KEYS.GEN_AI_INPUT_MESSAGES] === undefined &&
+      Array.isArray(request.contents)
+    ) {
+      const messages = request.contents.flatMap((content) =>
+        convertGeminiContent(content, "user"),
+      );
+      if (messages.length > 0) {
+        ctx.setAttr(ATTR_KEYS.GEN_AI_INPUT_MESSAGES, messages);
+        ctx.recordRule(`${this.id}:llm_request->gen_ai.input.messages`);
+        recordValueType(ctx, ATTR_KEYS.GEN_AI_INPUT_MESSAGES, "chat_messages");
+      }
+    }
+
+    const config = isRecord(request.config) ? request.config : undefined;
+    if (config === undefined) return;
+
+    // System instructions
+    const sysInstruction = systemInstructionText(config.system_instruction);
+    if (
+      sysInstruction !== null &&
+      this.setIfMissing(
+        ctx,
+        ATTR_KEYS.GEN_AI_SYSTEM_INSTRUCTIONS,
+        sysInstruction,
+      )
+    ) {
+      ctx.recordRule(`${this.id}:system_instruction`);
+    }
+
+    // Tool definitions
+    if (Array.isArray(config.tools) && config.tools.length > 0) {
+      if (
+        this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_DEFINITIONS, config.tools)
+      ) {
+        ctx.recordRule(`${this.id}:tools->gen_ai.tool.definitions`);
+      }
+    }
+
+    // Request parameters
+    const paramMap: [string, unknown][] = [
+      [ATTR_KEYS.GEN_AI_REQUEST_TEMPERATURE, config.temperature],
+      [ATTR_KEYS.GEN_AI_REQUEST_TOP_P, config.top_p],
+      [ATTR_KEYS.GEN_AI_REQUEST_TOP_K, config.top_k],
+      [ATTR_KEYS.GEN_AI_REQUEST_MAX_TOKENS, config.max_output_tokens],
+    ];
+    let paramsExtracted = false;
+    for (const [key, raw] of paramMap) {
+      const value = asNumber(raw);
+      if (value !== null && this.setIfMissing(ctx, key, value)) {
+        paramsExtracted = true;
+      }
+    }
+    if (paramsExtracted) {
+      ctx.recordRule(`${this.id}:params`);
+    }
+  }
+
+  private liftLlmResponse(ctx: ExtractorContext): void {
+    const { attrs } = ctx.bag;
+
+    const response = safeJsonParse(attrs.get(VERTEX_ADK_KEYS.LLM_RESPONSE));
+    if (!isRecord(response)) return;
+    attrs.take(VERTEX_ADK_KEYS.LLM_RESPONSE);
+
+    // Output messages: ADK LlmResponse carries a single content object;
+    // raw Gemini responses carry candidates[].content
+    if (
+      !attrs.has(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES) &&
+      ctx.out[ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES] === undefined
+    ) {
+      const messages: unknown[] = [];
+      if (isRecord(response.content)) {
+        messages.push(...convertGeminiContent(response.content, "assistant"));
+      } else if (Array.isArray(response.candidates)) {
+        for (const candidate of response.candidates) {
+          if (isRecord(candidate) && isRecord(candidate.content)) {
+            messages.push(
+              ...convertGeminiContent(candidate.content, "assistant"),
+            );
+          }
+        }
+      }
+      if (messages.length > 0) {
+        ctx.setAttr(ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES, messages);
+        ctx.recordRule(`${this.id}:llm_response->gen_ai.output.messages`);
+        recordValueType(ctx, ATTR_KEYS.GEN_AI_OUTPUT_MESSAGES, "chat_messages");
+      }
+    }
+
+    // Usage tokens (fallback when the standard gen_ai.usage.* are absent)
+    const usage = isRecord(response.usage_metadata)
+      ? response.usage_metadata
+      : undefined;
+    if (usage !== undefined) {
+      const usageMap: [string, unknown][] = [
+        [ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS, usage.prompt_token_count],
+        [ATTR_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS, usage.candidates_token_count],
+        [
+          ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+          usage.cached_content_token_count,
+        ],
+        [ATTR_KEYS.GEN_AI_USAGE_REASONING_TOKENS, usage.thoughts_token_count],
+      ];
+      let usageExtracted = false;
+      for (const [key, raw] of usageMap) {
+        const value = asNumber(raw);
+        if (value !== null && this.setIfMissing(ctx, key, value)) {
+          usageExtracted = true;
+        }
+      }
+      if (usageExtracted) {
+        ctx.recordRule(`${this.id}:usage_metadata->gen_ai.usage`);
+      }
+    }
+
+    // Finish reason
+    if (isNonEmptyString(response.finish_reason)) {
+      if (
+        this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_RESPONSE_FINISH_REASONS, [
+          response.finish_reason,
+        ])
+      ) {
+        ctx.recordRule(`${this.id}:finish_reason`);
+      }
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Tool Calls (execute_tool spans)
+  // Mirrors the Vercel ai.toolCall.* lift: args/result become
+  // langwatch.input/output plus the gen_ai.tool.call.* semconv keys so
+  // the span detail reads like a real tool call
+  // ─────────────────────────────────────────────────────────────────────────
+  private liftToolCall(ctx: ExtractorContext): void {
+    const { attrs } = ctx.bag;
+
+    const args = stringifyToolPayload(
+      attrs.get(VERTEX_ADK_KEYS.TOOL_CALL_ARGS),
+    );
+    if (args !== null) {
+      attrs.take(VERTEX_ADK_KEYS.TOOL_CALL_ARGS);
+      this.setIfMissing(ctx, ATTR_KEYS.LANGWATCH_INPUT, args);
+      this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_CALL_ARGUMENTS, args);
+      ctx.recordRule(`${this.id}:tool_call_args->input`);
+    }
+
+    const result = stringifyToolPayload(
+      attrs.get(VERTEX_ADK_KEYS.TOOL_RESPONSE),
+    );
+    if (result !== null) {
+      attrs.take(VERTEX_ADK_KEYS.TOOL_RESPONSE);
+      this.setIfMissing(ctx, ATTR_KEYS.LANGWATCH_OUTPUT, result);
+      this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_CALL_RESULT, result);
+      ctx.recordRule(`${this.id}:tool_response->output`);
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Conversation ID
+  // ADK usually emits gen_ai.conversation.id alongside; fall back to the
+  // vendor session id when it doesn't. The vendor key stays as a
+  // passthrough attribute — it's an identifier users may filter on.
+  // ─────────────────────────────────────────────────────────────────────────
+  private liftSessionId(ctx: ExtractorContext): void {
+    const sessionId = ctx.bag.attrs.get(VERTEX_ADK_KEYS.SESSION_ID);
+    if (
+      isNonEmptyString(sessionId) &&
+      this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_CONVERSATION_ID, sessionId)
+    ) {
+      ctx.recordRule(`${this.id}:session_id->gen_ai.conversation.id`);
+    }
+  }
+}

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vertexAdk.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vertexAdk.ts
@@ -402,9 +402,13 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     );
     if (args !== null) {
       attrs.take(VERTEX_ADK_KEYS.TOOL_CALL_ARGS);
-      this.setIfMissing(ctx, ATTR_KEYS.LANGWATCH_INPUT, args);
-      this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_CALL_ARGUMENTS, args);
-      ctx.recordRule(`${this.id}:tool_call_args->input`);
+      const argsSet = [
+        this.setIfMissing(ctx, ATTR_KEYS.LANGWATCH_INPUT, args),
+        this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_CALL_ARGUMENTS, args),
+      ].some(Boolean);
+      if (argsSet) {
+        ctx.recordRule(`${this.id}:tool_call_args->input`);
+      }
     }
 
     const result = stringifyToolPayload(
@@ -412,9 +416,13 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     );
     if (result !== null) {
       attrs.take(VERTEX_ADK_KEYS.TOOL_RESPONSE);
-      this.setIfMissing(ctx, ATTR_KEYS.LANGWATCH_OUTPUT, result);
-      this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_CALL_RESULT, result);
-      ctx.recordRule(`${this.id}:tool_response->output`);
+      const resultSet = [
+        this.setIfMissing(ctx, ATTR_KEYS.LANGWATCH_OUTPUT, result),
+        this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_CALL_RESULT, result),
+      ].some(Boolean);
+      if (resultSet) {
+        ctx.recordRule(`${this.id}:tool_response->output`);
+      }
     }
   }
 

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vertexAdk.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/vertexAdk.ts
@@ -98,7 +98,15 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
    * bag too in production, but the explicit guard keeps the behaviour
    * self-contained and unit-testable.)
    */
-  private setIfMissing(ctx: ExtractorContext, key: string, value: unknown) {
+  private setIfMissing({
+    ctx,
+    key,
+    value,
+  }: {
+    ctx: ExtractorContext;
+    key: string;
+    value: unknown;
+  }) {
     if (ctx.bag.attrs.has(key) || ctx.out[key] !== undefined) return false;
     ctx.setAttr(key, value);
     return true;
@@ -134,7 +142,7 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     // Model (standard gen_ai.request.model usually present; fallback only)
     if (
       isNonEmptyString(request.model) &&
-      this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_REQUEST_MODEL, request.model)
+      this.setIfMissing({ ctx, key: ATTR_KEYS.GEN_AI_REQUEST_MODEL, value: request.model })
     ) {
       ctx.recordRule(`${this.id}:llm_request.model->gen_ai.request.model`);
     }
@@ -146,7 +154,7 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
       Array.isArray(request.contents)
     ) {
       const messages = request.contents.flatMap((content) =>
-        convertGeminiContent(content, "user"),
+        convertGeminiContent({ content, defaultRole: "user" }),
       );
       if (messages.length > 0) {
         ctx.setAttr(ATTR_KEYS.GEN_AI_INPUT_MESSAGES, messages);
@@ -162,11 +170,7 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     const sysInstruction = systemInstructionText(config.system_instruction);
     if (
       sysInstruction !== null &&
-      this.setIfMissing(
-        ctx,
-        ATTR_KEYS.GEN_AI_SYSTEM_INSTRUCTIONS,
-        sysInstruction,
-      )
+      this.setIfMissing({ ctx, key: ATTR_KEYS.GEN_AI_SYSTEM_INSTRUCTIONS, value: sysInstruction, })
     ) {
       ctx.recordRule(`${this.id}:system_instruction`);
     }
@@ -174,7 +178,7 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     // Tool definitions
     if (Array.isArray(config.tools) && config.tools.length > 0) {
       if (
-        this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_DEFINITIONS, config.tools)
+        this.setIfMissing({ ctx, key: ATTR_KEYS.GEN_AI_TOOL_DEFINITIONS, value: config.tools })
       ) {
         ctx.recordRule(`${this.id}:tools->gen_ai.tool.definitions`);
       }
@@ -190,7 +194,7 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     let hasExtractedParams = false;
     for (const [key, raw] of paramMap) {
       const value = asNumber(raw);
-      if (value !== null && this.setIfMissing(ctx, key, value)) {
+      if (value !== null && this.setIfMissing({ ctx, key: key, value: value })) {
         hasExtractedParams = true;
       }
     }
@@ -214,12 +218,15 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     ) {
       const messages: unknown[] = [];
       if (isRecord(response.content)) {
-        messages.push(...convertGeminiContent(response.content, "assistant"));
+        messages.push(...convertGeminiContent({ content: response.content, defaultRole: "assistant" }));
       } else if (Array.isArray(response.candidates)) {
         for (const candidate of response.candidates) {
           if (isRecord(candidate) && isRecord(candidate.content)) {
             messages.push(
-              ...convertGeminiContent(candidate.content, "assistant"),
+              ...convertGeminiContent({
+                content: candidate.content,
+                defaultRole: "assistant",
+              }),
             );
           }
         }
@@ -248,7 +255,7 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
       let hasExtractedUsage = false;
       for (const [key, raw] of usageMap) {
         const value = asNumber(raw);
-        if (value !== null && this.setIfMissing(ctx, key, value)) {
+        if (value !== null && this.setIfMissing({ ctx, key: key, value: value })) {
           hasExtractedUsage = true;
         }
       }
@@ -260,9 +267,9 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     // Finish reason
     if (isNonEmptyString(response.finish_reason)) {
       if (
-        this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_RESPONSE_FINISH_REASONS, [
+        this.setIfMissing({ ctx, key: ATTR_KEYS.GEN_AI_RESPONSE_FINISH_REASONS, value: [
           response.finish_reason,
-        ])
+        ] })
       ) {
         ctx.recordRule(`${this.id}:finish_reason`);
       }
@@ -284,8 +291,8 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     if (args !== null) {
       attrs.take(VERTEX_ADK_KEYS.TOOL_CALL_ARGS);
       const hasSetArgs = [
-        this.setIfMissing(ctx, ATTR_KEYS.LANGWATCH_INPUT, args),
-        this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_CALL_ARGUMENTS, args),
+        this.setIfMissing({ ctx, key: ATTR_KEYS.LANGWATCH_INPUT, value: args }),
+        this.setIfMissing({ ctx, key: ATTR_KEYS.GEN_AI_TOOL_CALL_ARGUMENTS, value: args }),
       ].some(Boolean);
       if (hasSetArgs) {
         ctx.recordRule(`${this.id}:tool_call_args->input`);
@@ -298,8 +305,8 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     if (result !== null) {
       attrs.take(VERTEX_ADK_KEYS.TOOL_RESPONSE);
       const hasSetResult = [
-        this.setIfMissing(ctx, ATTR_KEYS.LANGWATCH_OUTPUT, result),
-        this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_TOOL_CALL_RESULT, result),
+        this.setIfMissing({ ctx, key: ATTR_KEYS.LANGWATCH_OUTPUT, value: result }),
+        this.setIfMissing({ ctx, key: ATTR_KEYS.GEN_AI_TOOL_CALL_RESULT, value: result }),
       ].some(Boolean);
       if (hasSetResult) {
         ctx.recordRule(`${this.id}:tool_response->output`);
@@ -317,7 +324,7 @@ export class VertexAdkExtractor implements CanonicalAttributesExtractor {
     const sessionId = ctx.bag.attrs.get(VERTEX_ADK_KEYS.SESSION_ID);
     if (
       isNonEmptyString(sessionId) &&
-      this.setIfMissing(ctx, ATTR_KEYS.GEN_AI_CONVERSATION_ID, sessionId)
+      this.setIfMissing({ ctx, key: ATTR_KEYS.GEN_AI_CONVERSATION_ID, value: sessionId })
     ) {
       ctx.recordRule(`${this.id}:session_id->gen_ai.conversation.id`);
     }

--- a/specs/traces/vertex-adk-canonicalisation.feature
+++ b/specs/traces/vertex-adk-canonicalisation.feature
@@ -1,0 +1,73 @@
+Feature: Vertex AI Agent Engine (Google ADK) span canonicalisation
+  As a LangWatch user tracing agents built with Google's Agent Development Kit
+  I want LLM and tool spans reported via Vertex AI to show their inputs and outputs
+  So that I can inspect conversations without digging through raw span attributes
+
+  # =========================================================================
+  # What this covers
+  # =========================================================================
+  #
+  # Google ADK / Vertex AI Agent Engine reports spans with standard gen_ai.*
+  # attributes (operation name, model, provider "gcp.vertex.agent", token
+  # usage) but carries the actual conversation content in vendor payloads:
+  #
+  #   - gcp.vertex.agent.llm_request   (system instruction + chat contents)
+  #   - gcp.vertex.agent.llm_response  (model reply, incl. tool calls)
+  #   - gcp.vertex.agent.tool_call_args / gcp.vertex.agent.tool_response
+  #
+  # Without dedicated handling those payloads pass through as opaque
+  # attributes and the span shows no input or output.
+
+  Background:
+    Given a span reported by a Vertex AI agent
+
+  Scenario: LLM call input is extracted from the request payload
+    Given the span carries a request payload with a conversation history
+    When the span is canonicalised
+    Then the span input shows the conversation as chat messages
+
+  Scenario: The system instruction is surfaced separately from the conversation
+    Given the span carries a request payload with a system instruction
+    When the span is canonicalised
+    Then the system instruction is shown as the span's system instructions
+    And it does not appear as a chat message
+
+  Scenario: LLM call output is extracted from the response payload
+    Given the span carries a response payload with the model's reply
+    When the span is canonicalised
+    Then the span output shows the reply as a chat message
+
+  Scenario: Tool interactions in the conversation are preserved
+    Given the conversation history contains a tool call and its result
+    When the span is canonicalised
+    Then the tool call appears as an assistant tool call message
+    And the tool result appears as a tool message
+
+  Scenario: Tool execution spans show their arguments and result
+    Given a tool execution span with call arguments and a response
+    When the span is canonicalised
+    Then the span input shows the tool call arguments
+    And the span output shows the tool response
+
+  Scenario: Tool execution spans are classified as tool spans
+    Given a tool execution span
+    When the span is canonicalised
+    Then the span is typed as a tool span, not an LLM span
+
+  Scenario: Token usage falls back to the response usage metadata
+    Given the span reports no standard token usage
+    And the response payload carries usage metadata
+    When the span is canonicalised
+    Then the span metrics show the prompt and completion token counts
+    And cached prompt tokens are reported as cache-read tokens
+
+  Scenario: Explicitly reported token usage is not overridden
+    Given the span reports standard token usage
+    And the response payload carries different usage metadata
+    When the span is canonicalised
+    Then the span metrics keep the explicitly reported token counts
+
+  Scenario: Spans from other providers are untouched
+    Given a span reported by a different SDK
+    When the span is canonicalised
+    Then no Vertex AI extraction is applied


### PR DESCRIPTION
## Problem

A customer reported un-enriched spans from Vertex AI Agent Engine: inputs/outputs empty in the span inspection UI, with the actual data buried in raw attributes like `gcp.vertex.agent.llm_request`.

Google ADK emits standard `gen_ai.*` attributes (operation, model, provider `gcp.vertex.agent`, usage) but carries the conversation content only in vendor JSON payloads no extractor read:

- `gcp.vertex.agent.llm_request` — system instruction + Gemini-format `contents`
- `gcp.vertex.agent.llm_response` — model reply incl. tool calls + `usage_metadata`
- `gcp.vertex.agent.tool_call_args` / `tool_response` on `execute_tool` spans

A second bug fell out of the same gap: `execute_tool` spans were typed `llm` because the fallback extractor saw generic `gen_ai.*` signals and doesn't know ADK's operation names.

## Change

New `VertexAdkExtractor` (registered right after GenAI), which:

- converts Gemini `contents` → canonical `gen_ai.input.messages` (text, assistant `tool_calls`, tool-role results)
- converts the response `content` (or raw `candidates[]`) → `gen_ai.output.messages`
- surfaces `config.system_instruction` (string or parts object) as `gen_ai.system_instructions`
- lifts `config.tools` → `gen_ai.tool.definitions`, config params → `gen_ai.request.*`
- falls back to `usage_metadata` for tokens only when standard `gen_ai.usage.*` are absent; always lifts `cached_content_token_count` → cache-read tokens
- maps `tool_call_args`/`tool_response` → `langwatch.input`/`output` + `gen_ai.tool.call.arguments`/`result` (mirrors the Vercel `ai.toolCall.*` lift)
- types spans from `gen_ai.operation.name` (`generate_content`/`call_llm` → llm, `execute_tool` → tool, `invoke_agent` → agent), respecting explicit types
- falls back to `gcp.vertex.agent.session_id` for `gen_ai.conversation.id`

Spec: `specs/traces/vertex-adk-canonicalisation.feature`. Unit tests use anonymised replicas of the customer payloads (structure preserved, all content/ids synthetic).

## Testing

- 25 new unit tests (`vertexAdk.unit.test.ts`)
- Full canonicalisation suite: 435 passed
- `src/server/event-sourcing/pipelines/trace-processing` + `src/server/traces`: 999 passed
- `pnpm typecheck` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vertex AI Agent Engine (ADK) canonicalisation support during trace canonicalisation.
  * Converts Vertex chat content into canonical input/output messages, lifts system instructions, tool definitions, tool call arguments/results, finish reasons, request settings, and conversation/session identifiers.
  * Improves canonical attribute precedence by adjusting extractor execution order for better collision handling.
* **Tests**
  * Added unit tests and a Gherkin feature spec for Vertex ADK parsing, token-metrics mapping (including cached-token fallbacks), idempotency, tool/agent typing, and ensuring non-Vertex spans remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
