### PR TITLE
feat(ops): keep Deja View access while impersonating a customer

### DIFF
--- a/langwatch/src/server/api/__tests__/ops-scope-resolution.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/ops-scope-resolution.unit.test.ts
@@ -47,6 +47,34 @@ describe("resolveOpsScope (lw#3584)", () => {
       expect(scope).toEqual({ kind: "platform" });
     });
   });
+
+  describe("when an admin is impersonating a customer user", () => {
+    /** @scenario Admin impersonating a customer keeps ops access */
+    it("carries the impersonator's grant through: returns { kind: 'platform' }", () => {
+      const scope = resolveOpsScope({
+        userId: "customer-1",
+        userEmail: "person@example.com",
+        impersonatorEmail: "admin@langwatch.ai",
+        permission: "ops:view",
+        prisma: {} as unknown,
+      });
+      expect(scope).toEqual({ kind: "platform" });
+    });
+  });
+
+  describe("when the impersonator is not an admin", () => {
+    /** @scenario Non-admin impersonator does not gain ops access */
+    it("returns { kind: 'none' }", () => {
+      const scope = resolveOpsScope({
+        userId: "customer-1",
+        userEmail: "person@example.com",
+        impersonatorEmail: "other-person@example.com",
+        permission: "ops:view",
+        prisma: {} as unknown,
+      });
+      expect(scope).toEqual({ kind: "none" });
+    });
+  });
 });
 
 describe("checkOpsPermission middleware (lw#3584)", () => {
@@ -105,6 +133,35 @@ describe("checkOpsPermission middleware (lw#3584)", () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect((ctx as { opsScope?: unknown }).opsScope).toEqual({
       kind: "none",
+    });
+  });
+
+  /** @scenario Admin impersonating a customer keeps ops access */
+  it("grants access when the session's impersonator is an admin", async () => {
+    const middleware = checkOpsPermission({ permission: "ops:view" });
+    const next = vi.fn().mockResolvedValue("OK");
+    const ctx = {
+      session: {
+        user: {
+          id: "customer-1",
+          email: "person@example.com",
+          impersonator: {
+            id: "admin-1",
+            email: "admin@langwatch.ai",
+          },
+        },
+      },
+      prisma: {} as unknown,
+    } as unknown as Parameters<ReturnType<typeof checkOpsPermission>>[0]["ctx"];
+    const result = await middleware({
+      ctx,
+      input: undefined,
+      next,
+    } as unknown as Parameters<ReturnType<typeof checkOpsPermission>>[0]);
+    expect(result).toBe("OK");
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((ctx as { opsScope?: unknown }).opsScope).toEqual({
+      kind: "platform",
     });
   });
 });

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -1547,16 +1547,25 @@ export type OpsScope = { kind: "none" } | { kind: "platform" };
  *
  * Only users listed in ADMIN_EMAILS get the `platform` scope. All ops
  * data is platform-wide so no org-scoped tier exists.
+ *
+ * Impersonation: an impersonation session rewrites `session.user` to the
+ * impersonated (customer) identity, which would hide the ops UI (Deja
+ * View) exactly when an admin impersonates a customer to debug their
+ * account. The impersonator's own grant carries through instead — the
+ * scope is resolved against the real admin's email as well.
  */
 export function resolveOpsScope({
   userEmail,
+  impersonatorEmail,
 }: {
   userId: string;
   userEmail: string | null | undefined;
+  /** Email of the real admin behind an impersonation session, if any. */
+  impersonatorEmail?: string | null;
   permission: Permission;
   prisma: unknown;
 }): OpsScope {
-  if (isAdmin({ email: userEmail })) {
+  if (isAdmin({ email: userEmail }) || isAdmin({ email: impersonatorEmail })) {
     return { kind: "platform" };
   }
 
@@ -1580,6 +1589,7 @@ export const checkOpsPermission =
     const opsScope = await resolveOpsScope({
       userId: user.id,
       userEmail: user.email,
+      impersonatorEmail: user.impersonator?.email,
       permission,
       prisma: ctx.prisma,
     });

--- a/specs/ops/dejaview-impersonation-access.feature
+++ b/specs/ops/dejaview-impersonation-access.feature
@@ -1,0 +1,37 @@
+Feature: Ops access (Deja View) while impersonating a user
+  As a platform admin debugging a customer account
+  I want the ops tooling (Deja View) to stay available while I impersonate the customer
+  So that I can inspect the customer's stored events in the context of their account
+
+  # =========================================================================
+  # What this covers
+  # =========================================================================
+  #
+  # Impersonation rewrites the session identity to the impersonated
+  # (customer) user, keeping the real admin as the session's impersonator.
+  # Ops access is granted per admin email, so before this feature the ops
+  # UI (Deja View) disappeared exactly when an admin was impersonating a
+  # customer to debug their traces. The impersonator's own grant now
+  # carries through the impersonation session.
+
+  Scenario: Admin impersonating a customer keeps ops access
+    Given an admin is impersonating a customer user
+    When the ops scope is resolved for the session
+    Then the session has platform ops access
+    And the Deja View section is available in the UI
+
+  Scenario: Customer session without impersonation has no ops access
+    Given a customer user is signed in normally
+    When the ops scope is resolved for the session
+    Then the session has no ops access
+    And the Deja View section is not shown
+
+  Scenario: Non-admin impersonator does not gain ops access
+    Given a session is impersonating with an impersonator who is not an admin
+    When the ops scope is resolved for the session
+    Then the session has no ops access
+
+  Scenario: Admin session without impersonation keeps ops access
+    Given an admin is signed in normally
+    When the ops scope is resolved for the session
+    Then the session has platform ops access


### PR DESCRIPTION
## Problem

Ops access (`resolveOpsScope`) is granted per admin email, but impersonation rewrites `session.user` to the impersonated customer's identity. Result: the ops UI — Deja View in particular — disappeared exactly when an admin impersonated a customer to debug their traces.

## Change

`resolveOpsScope` now also resolves against the session's `impersonator` email (the real admin behind the impersonation), so the admin's own grant carries through. Non-admin sessions and non-admin impersonators still get `{ kind: "none" }`.

No frontend changes needed: the `ops.getScope` probe drives `useOpsPermission` → MainMenu / `useDejaViewLink`, so Deja View lights up automatically while impersonating.

Spec: `specs/ops/dejaview-impersonation-access.feature`

## Testing

- `ops-scope-resolution.unit.test.ts`: 8 passed (3 new: impersonating admin grants platform scope, non-admin impersonator denied, middleware wiring through `session.user.impersonator`)
- `pnpm typecheck` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved Ops access and the Deja View section when an administrator impersonates a customer.
  * Prevented non-administrator impersonators from receiving Ops access.
  * Kept standard access restrictions for regular (non-impersonated) customer sessions.
* **Tests**
  * Added unit test coverage for impersonation-based Ops scope and permission behavior.
  * Added a new feature spec validating Deja View visibility during impersonation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
