### PR TITLE
feat(ops): deja view normalisation preview with bonsai mapping rules

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -155,6 +155,7 @@
     "ajv": "^8.20.0",
     "bcrypt": "^6.0.0",
     "better-auth": "^1.6.23",
+    "bonsai-js": "^0.5.0",
     "bullmq": "^5.79.2",
     "bullmq-otel": "^1.3.1",
     "chakra-react-select": "^6.1.3",

--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -374,6 +374,9 @@
       "js-yaml@>=3.0.0 <3.15.0": ">=3.15.0 <4",
       "js-yaml@>=4.0.0 <4.2.0": ">=4.2.0 <5",
       "dompurify@<3.4.11": ">=3.4.11 <4"
+    },
+    "patchedDependencies": {
+      "bonsai-js": "patches/bonsai-js.patch"
     }
   },
   "ct3aMetadata": {

--- a/langwatch/patches/bonsai-js.patch
+++ b/langwatch/patches/bonsai-js.patch
@@ -1,0 +1,26 @@
+diff --git a/package.json b/package.json
+index 085d5c970cddf6efa74ba1ebbdc32fa01ec9bc2f..dc10cd3589bfb9ad57bb193eeaba30c4bb5db292 100644
+--- a/package.json
++++ b/package.json
+@@ -9,15 +9,18 @@
+   "exports": {
+     ".": {
+       "types": "./dist/index.d.mts",
+-      "import": "./dist/index.mjs"
++      "import": "./dist/index.mjs",
++      "require": "./dist/index.mjs"
+     },
+     "./stdlib": {
+       "types": "./dist/stdlib/index.d.mts",
+-      "import": "./dist/stdlib/index.mjs"
++      "import": "./dist/stdlib/index.mjs",
++      "require": "./dist/stdlib/index.mjs"
+     },
+     "./autocomplete": {
+       "types": "./dist/autocomplete/index.d.mts",
+-      "import": "./dist/autocomplete/index.mjs"
++      "import": "./dist/autocomplete/index.mjs",
++      "require": "./dist/autocomplete/index.mjs"
+     }
+   },
+   "files": [

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       better-auth:
         specifier: ^1.6.23
         version: 1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@5.7.1(prisma@5.7.1))(prisma@5.7.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
+      bonsai-js:
+        specifier: ^0.5.0
+        version: 0.5.0
       bullmq:
         specifier: ^5.79.2
         version: 5.79.2
@@ -495,7 +498,7 @@ importers:
         version: 17.5.0
       openai:
         specifier: ^6.45.0
-        version: 6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.0)(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
+        version: 6.45.0(@aws-sdk/credential-provider-node@3.972.60)(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
       papaparse:
         specifier: ^5.5.4
         version: 5.5.4
@@ -6190,6 +6193,10 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
+
+  bonsai-js@0.5.0:
+    resolution: {integrity: sha512-s+pMKvpcbTcPfck5OC5awLJTadxTBJ7ksOqeM9UCOXJjTeoKqlcGosMdFFjMdiay/6PWj1RF2tsofge6fPiYHQ==}
+    engines: {node: '>=22'}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -16837,9 +16844,9 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@25.6.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(vite@8.1.3(@types/node@25.6.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -16893,7 +16900,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@25.6.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@4.1.9':
     dependencies:
@@ -18031,6 +18038,8 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  bonsai-js@0.5.0: {}
 
   bowser@2.14.1: {}
 

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -57,6 +57,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-LBc1N1GezKyerwGBwpMHZPFoMYZTHjpxVKWJilBVvTU=
 
+patchedDependencies:
+  bonsai-js:
+    hash: e95f4234205647268ecd7f23c9901c1a6f40307a55e42e969fc4b67edcb92c29
+    path: patches/bonsai-js.patch
+
 importers:
 
   .:
@@ -339,7 +344,7 @@ importers:
         version: 1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@5.7.1(prisma@5.7.1))(prisma@5.7.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
       bonsai-js:
         specifier: ^0.5.0
-        version: 0.5.0
+        version: 0.5.0(patch_hash=e95f4234205647268ecd7f23c9901c1a6f40307a55e42e969fc4b67edcb92c29)
       bullmq:
         specifier: ^5.79.2
         version: 5.79.2
@@ -498,7 +503,7 @@ importers:
         version: 17.5.0
       openai:
         specifier: ^6.45.0
-        version: 6.45.0(@aws-sdk/credential-provider-node@3.972.60)(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
+        version: 6.45.0(@aws-sdk/credential-provider-node@3.972.60)(@smithy/signature-v4@5.6.0)(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
       papaparse:
         specifier: ^5.5.4
         version: 5.5.4
@@ -16844,9 +16849,9 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@25.6.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(vite@8.1.3(@types/node@25.6.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -16900,7 +16905,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@25.6.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.9':
     dependencies:
@@ -18039,7 +18044,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bonsai-js@0.5.0: {}
+  bonsai-js@0.5.0(patch_hash=e95f4234205647268ecd7f23c9901c1a6f40307a55e42e969fc4b67edcb92c29): {}
 
   bowser@2.14.1: {}
 

--- a/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
+++ b/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
@@ -18,6 +18,7 @@ import { EventTimeline } from "./EventTimeline";
 import { buildFragment, parseFragment } from "./fragment";
 import { KeyboardHints } from "./KeyboardHints";
 import { LeftPanel } from "./LeftPanel";
+import { NormalisationPreviewPanel } from "./NormalisationPreviewPanel";
 import { ReplayHeader } from "./ReplayHeader";
 import { RightPanel } from "./RightPanel";
 import { SearchHeader } from "./SearchHeader";
@@ -61,6 +62,8 @@ export function DejaViewContent() {
   const [selectedProjection, setSelectedProjection] = useState<string | null>(
     initialState.proj ?? null,
   );
+  const [showNormalisationPreview, setShowNormalisationPreview] =
+    useState(false);
   const [showEventDetail, setShowEventDetail] = useState(
     initialState.detail ?? false,
   );
@@ -349,9 +352,16 @@ export function DejaViewContent() {
           eventCursor={eventCursor}
           eventCount={events.length}
           onBack={handleBack}
+          previewActive={showNormalisationPreview}
+          onTogglePreview={() => setShowNormalisationPreview((s) => !s)}
         />
 
-        {eventsQuery.isLoading ? (
+        {showNormalisationPreview ? (
+          <NormalisationPreviewPanel
+            aggregateId={selectedAggregate.aggregateId}
+            tenantId={selectedAggregate.tenantId}
+          />
+        ) : eventsQuery.isLoading ? (
           <Center flex={1}>
             <Spinner size="lg" />
           </Center>

--- a/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
+++ b/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
@@ -360,6 +360,7 @@ export function DejaViewContent() {
           <NormalisationPreviewPanel
             aggregateId={selectedAggregate.aggregateId}
             tenantId={selectedAggregate.tenantId}
+            events={events}
           />
         ) : eventsQuery.isLoading ? (
           <Center flex={1}>

--- a/langwatch/src/components/ops/dejaview/NormalisationPreviewPanel.tsx
+++ b/langwatch/src/components/ops/dejaview/NormalisationPreviewPanel.tsx
@@ -1,0 +1,402 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Center,
+  HStack,
+  Input,
+  NativeSelect,
+  Spinner,
+  Table,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { FlaskConical, Play, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { api, type RouterOutputs } from "~/utils/api";
+
+/**
+ * Deja View normalisation preview: replays this aggregate's stored raw
+ * span events through the canonicalisation code of the RUNNING build and
+ * shows the produced attributes, the rules that fired, and the drift vs
+ * what is stored. Experimental mapping rules (blocks below) run on top so
+ * a new vendor mapping can be prototyped against real events before an
+ * extractor exists. Read-only.
+ */
+
+type RuleDraft = {
+  key: string;
+  keyIsRegex: boolean;
+  valuePattern: string;
+  actionType: "copy" | "move";
+  targetKey: string;
+};
+
+const emptyRule = (): RuleDraft => ({
+  key: "",
+  keyIsRegex: false,
+  valuePattern: "",
+  actionType: "copy",
+  targetKey: "",
+});
+
+export function NormalisationPreviewPanel({
+  aggregateId,
+  tenantId,
+}: {
+  aggregateId: string;
+  tenantId: string;
+}) {
+  const [rules, setRules] = useState<RuleDraft[]>([]);
+  const preview = api.ops.previewNormalisation.useMutation();
+
+  const updateRule = (index: number, patch: Partial<RuleDraft>) => {
+    setRules((prev) =>
+      prev.map((r, i) => (i === index ? { ...r, ...patch } : r)),
+    );
+  };
+
+  const run = () => {
+    preview.mutate({
+      aggregateId,
+      tenantId,
+      rules: rules
+        .filter((r) => r.key.length > 0 && r.targetKey.length > 0)
+        .map((r) => ({
+          match: {
+            key: r.key,
+            keyIsRegex: r.keyIsRegex,
+            valuePattern: r.valuePattern.length > 0 ? r.valuePattern : undefined,
+          },
+          action: { type: r.actionType, targetKey: r.targetKey },
+        })),
+    });
+  };
+
+  const result = preview.data;
+
+  return (
+    <Box flex={1} overflowY="auto" minH={0} w="full" padding={6}>
+      <VStack align="stretch" gap={4} maxW="1200px">
+        <HStack gap={2}>
+          <FlaskConical size={16} />
+          <Text textStyle="sm" fontWeight="semibold">
+            Normalisation preview
+          </Text>
+          <Text textStyle="xs" color="fg.muted">
+            Replays this aggregate&apos;s stored span events through the
+            canonicalisation code of this build. Read-only.
+          </Text>
+        </HStack>
+
+        <VStack
+          align="stretch"
+          gap={2}
+          padding={3}
+          borderWidth="1px"
+          borderColor="border.muted"
+          borderRadius="md"
+        >
+          <Text textStyle="xs" fontWeight="medium" color="fg.muted">
+            Experimental mapping rules (optional)
+          </Text>
+          {rules.map((rule, index) => (
+            <HStack key={index} gap={2} align="center">
+              <Input
+                size="xs"
+                fontFamily="mono"
+                placeholder="source key"
+                value={rule.key}
+                onChange={(e) => updateRule(index, { key: e.target.value })}
+                flex={2}
+              />
+              <Button
+                size="xs"
+                variant={rule.keyIsRegex ? "solid" : "outline"}
+                colorPalette={rule.keyIsRegex ? "blue" : "gray"}
+                onClick={() =>
+                  updateRule(index, { keyIsRegex: !rule.keyIsRegex })
+                }
+                title="Treat source key as a regex"
+              >
+                .*
+              </Button>
+              <Input
+                size="xs"
+                fontFamily="mono"
+                placeholder="value regex (group 1 extracted, optional)"
+                value={rule.valuePattern}
+                onChange={(e) =>
+                  updateRule(index, { valuePattern: e.target.value })
+                }
+                flex={2}
+              />
+              <NativeSelect.Root size="xs" width="90px" flexShrink={0}>
+                <NativeSelect.Field
+                  value={rule.actionType}
+                  onChange={(e) =>
+                    updateRule(index, {
+                      actionType: e.target.value as "copy" | "move",
+                    })
+                  }
+                >
+                  <option value="copy">copy →</option>
+                  <option value="move">move →</option>
+                </NativeSelect.Field>
+                <NativeSelect.Indicator />
+              </NativeSelect.Root>
+              <Input
+                size="xs"
+                fontFamily="mono"
+                placeholder="target key (e.g. langwatch.input)"
+                value={rule.targetKey}
+                onChange={(e) =>
+                  updateRule(index, { targetKey: e.target.value })
+                }
+                flex={2}
+              />
+              <Button
+                size="xs"
+                variant="ghost"
+                onClick={() =>
+                  setRules((prev) => prev.filter((_, i) => i !== index))
+                }
+                title="Remove rule"
+              >
+                <Trash2 size={13} />
+              </Button>
+            </HStack>
+          ))}
+          <HStack>
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() => setRules((prev) => [...prev, emptyRule()])}
+            >
+              <Plus size={13} />
+              Add rule
+            </Button>
+            <Box flex={1} />
+            <Button
+              size="xs"
+              colorPalette="blue"
+              onClick={run}
+              loading={preview.isPending}
+            >
+              <Play size={13} />
+              Run preview
+            </Button>
+          </HStack>
+        </VStack>
+
+        {preview.error && (
+          <Box
+            padding={3}
+            borderRadius="md"
+            borderWidth="1px"
+            borderColor="red.200"
+          >
+            <Text textStyle="xs" color="red.500">
+              {preview.error.message}
+            </Text>
+          </Box>
+        )}
+
+        {preview.isPending && (
+          <Center paddingY={8}>
+            <Spinner size="md" />
+          </Center>
+        )}
+
+        {result && (
+          <VStack align="stretch" gap={3}>
+            <HStack gap={2} wrap="wrap">
+              <Badge size="sm" variant="outline">
+                {result.eventsScanned} events scanned
+              </Badge>
+              <Badge size="sm" variant="outline">
+                {result.spanEventsFound} span events
+              </Badge>
+              {result.skippedInvalidEvents > 0 && (
+                <Badge size="sm" variant="outline" colorPalette="orange">
+                  {result.skippedInvalidEvents} unparseable
+                </Badge>
+              )}
+              {result.ruleStats.map((stat) => (
+                <Badge
+                  key={stat.ruleIndex}
+                  size="sm"
+                  variant="subtle"
+                  colorPalette={stat.matchedSpanCount > 0 ? "green" : "gray"}
+                >
+                  rule {stat.ruleIndex + 1}: {stat.matchedSpanCount} span
+                  {stat.matchedSpanCount === 1 ? "" : "s"}
+                </Badge>
+              ))}
+            </HStack>
+
+            {result.spans.length === 0 && (
+              <Text textStyle="sm" color="fg.muted">
+                No span-received events to replay in this aggregate.
+              </Text>
+            )}
+
+            {result.spans.map((span) => (
+              <SpanPreviewCard key={span.spanId} span={span} />
+            ))}
+          </VStack>
+        )}
+      </VStack>
+    </Box>
+  );
+}
+
+type SpanPreview =
+  RouterOutputs["ops"]["previewNormalisation"]["spans"][number];
+
+function SpanPreviewCard({ span }: { span: SpanPreview }) {
+  const [showAttributes, setShowAttributes] = useState(false);
+
+  return (
+    <VStack
+      align="stretch"
+      gap={2}
+      padding={3}
+      borderWidth="1px"
+      borderColor="border.muted"
+      borderRadius="md"
+    >
+      <HStack gap={2}>
+        <Text textStyle="sm" fontWeight="medium">
+          {span.name}
+        </Text>
+        <Text textStyle="xs" fontFamily="mono" color="fg.muted">
+          {span.spanId}
+        </Text>
+        <Box flex={1} />
+        <Button
+          size="xs"
+          variant="ghost"
+          onClick={() => setShowAttributes((s) => !s)}
+        >
+          {showAttributes ? "Hide" : "Show"} replayed attributes
+        </Button>
+      </HStack>
+
+      {span.appliedRules.length > 0 && (
+        <HStack gap={1} wrap="wrap">
+          {span.appliedRules.map((rule, i) => (
+            <Badge key={i} size="sm" variant="subtle" fontFamily="mono">
+              {rule}
+            </Badge>
+          ))}
+        </HStack>
+      )}
+
+      {span.storedDiff !== null && (
+        <DiffSection
+          title={
+            span.storedDiff.length === 0
+              ? "Stored vs replayed: identical (this build reproduces storage)"
+              : `Stored vs replayed: ${span.storedDiff.length} attribute(s) differ`
+          }
+          entries={span.storedDiff}
+        />
+      )}
+
+      {span.rulesDiff !== null && (
+        <DiffSection
+          title={
+            span.rulesDiff.length === 0
+              ? "Mapping rules: no effect on this span"
+              : `Mapping rules: ${span.rulesDiff.length} attribute(s) affected`
+          }
+          entries={span.rulesDiff}
+        />
+      )}
+
+      {showAttributes && (
+        <Box
+          as="pre"
+          padding={2}
+          borderRadius="sm"
+          bg="bg.muted"
+          overflowX="auto"
+          textStyle="xs"
+          fontFamily="mono"
+        >
+          {JSON.stringify(span.replayedAttributes, null, 2)}
+        </Box>
+      )}
+    </VStack>
+  );
+}
+
+const DIFF_COLOR: Record<string, string> = {
+  added: "green",
+  removed: "red",
+  changed: "orange",
+};
+
+function DiffSection({
+  title,
+  entries,
+}: {
+  title: string;
+  entries: NonNullable<SpanPreview["storedDiff"]>;
+}) {
+  return (
+    <VStack align="stretch" gap={1}>
+      <Text textStyle="xs" color="fg.muted">
+        {title}
+      </Text>
+      {entries.length > 0 && (
+        <Box overflowX="auto">
+          <Table.Root size="sm" variant="line">
+            <Table.Body>
+              {entries.map((entry) => (
+                <Table.Row key={`${entry.kind}:${entry.key}`}>
+                  <Table.Cell width="90px">
+                    <Badge
+                      size="sm"
+                      variant="subtle"
+                      colorPalette={DIFF_COLOR[entry.kind] ?? "gray"}
+                    >
+                      {entry.kind}
+                    </Badge>
+                  </Table.Cell>
+                  <Table.Cell fontFamily="mono" textStyle="xs">
+                    {entry.key}
+                  </Table.Cell>
+                  <Table.Cell
+                    fontFamily="mono"
+                    textStyle="xs"
+                    color="fg.muted"
+                    maxW="300px"
+                    overflow="hidden"
+                    textOverflow="ellipsis"
+                    whiteSpace="nowrap"
+                    title={entry.before ?? undefined}
+                  >
+                    {entry.before ?? "—"}
+                  </Table.Cell>
+                  <Table.Cell
+                    fontFamily="mono"
+                    textStyle="xs"
+                    maxW="300px"
+                    overflow="hidden"
+                    textOverflow="ellipsis"
+                    whiteSpace="nowrap"
+                    title={entry.after ?? undefined}
+                  >
+                    {entry.after ?? "—"}
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table.Root>
+        </Box>
+      )}
+    </VStack>
+  );
+}

--- a/langwatch/src/components/ops/dejaview/NormalisationPreviewPanel.tsx
+++ b/langwatch/src/components/ops/dejaview/NormalisationPreviewPanel.tsx
@@ -12,82 +12,237 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { FlaskConical, Play, Plus, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api, type RouterOutputs } from "~/utils/api";
+import dynamic from "~/utils/compat/next-dynamic";
+import type { Monaco, OnMount } from "@monaco-editor/react";
+import {
+  BONSAI_LANGUAGE_ID,
+  isValidBonsaiExpression,
+  registerBonsaiLanguage,
+  setBonsaiCompletionKeys,
+  validateBonsaiModel,
+} from "./bonsaiMonaco";
+import type { EventResult } from "./types";
 
 /**
  * Deja View normalisation preview: replays this aggregate's stored raw
  * span events through the canonicalisation code of the RUNNING build and
- * shows the produced attributes, the rules that fired, and the drift vs
- * what is stored. Experimental mapping rules (blocks below) run on top so
- * a new vendor mapping can be prototyped against real events before an
- * extractor exists. Read-only.
+ * shows the produced attributes, the rules that fired, the drift vs what
+ * is stored, and — when experimental mapping rules are supplied — the
+ * impact of those rules on every projection folding this aggregate.
+ * Rules can be regex blocks or bonsai expressions (Monaco-edited, with
+ * autocomplete over the selected event's attribute keys). Read-only.
  */
 
-type RuleDraft = {
+const MonacoEditor = dynamic(() => import("@monaco-editor/react"), {
+  ssr: false,
+  loading: () => (
+    <Box padding={2} color="fg.muted" textStyle="xs">
+      Loading editor...
+    </Box>
+  ),
+});
+
+const SPAN_RECEIVED_EVENT_TYPE = "lw.obs.trace.span_received";
+
+/** Canonical keys worth writing to — surfaced as target suggestions. */
+const KNOWN_TARGET_KEYS = [
+  "gen_ai.input.messages",
+  "gen_ai.output.messages",
+  "gen_ai.system_instructions",
+  "langwatch.input",
+  "langwatch.output",
+  "langwatch.span.type",
+  "gen_ai.request.model",
+  "gen_ai.response.model",
+  "gen_ai.usage.input_tokens",
+  "gen_ai.usage.output_tokens",
+  "gen_ai.tool.call.arguments",
+  "gen_ai.tool.call.result",
+  "gen_ai.conversation.id",
+] as const;
+
+const EXPRESSION_EXAMPLES: Array<{
+  label: string;
+  expression: string;
+  targetKey: string;
+}> = [
+  {
+    label: "Lift a vendor payload field",
+    expression: 'attr("gcp.vertex.agent.llm_request").contents',
+    targetKey: "gen_ai.input.messages",
+  },
+  {
+    label: "User messages only",
+    expression:
+      'attr("gen_ai.input.messages") |> filter(.role == "user") |> map(.content)',
+    targetKey: "langwatch.input",
+  },
+  {
+    label: "Consume with fallback",
+    expression: 'take("vendor.custom_output") ?? attr("langwatch.output")',
+    targetKey: "langwatch.output",
+  },
+  {
+    label: "Total tokens",
+    expression:
+      '(attr("gen_ai.usage.input_tokens") ?? 0) + (attr("gen_ai.usage.output_tokens") ?? 0)',
+    targetKey: "langwatch.usage.total_tokens",
+  },
+];
+
+type MapRuleDraft = {
   key: string;
-  keyIsRegex: boolean;
+  matcher: "exact" | "regex";
   valuePattern: string;
   actionType: "copy" | "move";
   targetKey: string;
 };
 
-const emptyRule = (): RuleDraft => ({
-  key: "",
-  keyIsRegex: false,
-  valuePattern: "",
-  actionType: "copy",
-  targetKey: "",
-});
+type ExpressionRuleDraft = {
+  expression: string;
+  targetKey: string;
+};
+
+type PreviewInput = Parameters<
+  ReturnType<typeof api.ops.previewNormalisation.useMutation>["mutate"]
+>[0];
+
+const AUTO_RUN_DEBOUNCE_MS = 700;
 
 export function NormalisationPreviewPanel({
   aggregateId,
   tenantId,
+  events,
 }: {
   aggregateId: string;
   tenantId: string;
+  events: EventResult[];
 }) {
-  const [rules, setRules] = useState<RuleDraft[]>([]);
+  const [mapRules, setMapRules] = useState<MapRuleDraft[]>([]);
+  const [expressionRules, setExpressionRules] = useState<
+    ExpressionRuleDraft[]
+  >([]);
+  const [selectedEventId, setSelectedEventId] = useState<string>("all");
   const preview = api.ops.previewNormalisation.useMutation();
 
-  const updateRule = (index: number, patch: Partial<RuleDraft>) => {
-    setRules((prev) =>
-      prev.map((r, i) => (i === index ? { ...r, ...patch } : r)),
-    );
-  };
+  const spanEvents = useMemo(
+    () => events.filter((e) => e.eventType === SPAN_RECEIVED_EVENT_TYPE),
+    [events],
+  );
 
-  const run = () => {
-    preview.mutate({
-      aggregateId,
-      tenantId,
-      rules: rules
+  // Attribute keys of the selected event (or all span events) feed both
+  // the source-key datalist and the Monaco attr() completions.
+  const attributeKeys = useMemo(() => {
+    const relevant =
+      selectedEventId === "all"
+        ? spanEvents
+        : spanEvents.filter((e) => e.eventId === selectedEventId);
+    const keys = new Set<string>();
+    for (const event of relevant) {
+      for (const key of extractAttributeKeys(event.payload)) keys.add(key);
+    }
+    return [...keys].sort();
+  }, [spanEvents, selectedEventId]);
+
+  useEffect(() => {
+    setBonsaiCompletionKeys(attributeKeys);
+  }, [attributeKeys]);
+
+  const buildInput = (): PreviewInput => ({
+    aggregateId,
+    tenantId,
+    eventId: selectedEventId === "all" ? undefined : selectedEventId,
+    rules: [
+      ...mapRules
         .filter((r) => r.key.length > 0 && r.targetKey.length > 0)
         .map((r) => ({
+          kind: "map" as const,
           match: {
             key: r.key,
-            keyIsRegex: r.keyIsRegex,
-            valuePattern: r.valuePattern.length > 0 ? r.valuePattern : undefined,
+            keyIsRegex: r.matcher === "regex",
+            valuePattern:
+              r.valuePattern.length > 0 ? r.valuePattern : undefined,
           },
           action: { type: r.actionType, targetKey: r.targetKey },
         })),
-    });
-  };
+      ...expressionRules
+        .filter(
+          (r) =>
+            r.targetKey.length > 0 && isValidBonsaiExpression(r.expression),
+        )
+        .map((r) => ({
+          kind: "expression" as const,
+          expression: r.expression,
+          targetKey: r.targetKey,
+        })),
+    ],
+  });
+
+  const run = () => preview.mutate(buildInput());
+
+  // Live updates: once the operator has run the preview, edits re-run it
+  // automatically (debounced). Invalid expressions are filtered out by
+  // buildInput, so typing never spams the server with parse errors.
+  const hasRunRef = useRef(false);
+  if (preview.data && !hasRunRef.current) hasRunRef.current = true;
+  const serializedInput = JSON.stringify({
+    mapRules,
+    expressionRules,
+    selectedEventId,
+  });
+  useEffect(() => {
+    if (!hasRunRef.current) return;
+    const timer = setTimeout(() => preview.mutate(buildInput()), AUTO_RUN_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serializedInput]);
 
   const result = preview.data;
 
   return (
     <Box flex={1} overflowY="auto" minH={0} w="full" padding={6}>
       <VStack align="stretch" gap={4} maxW="1200px">
-        <HStack gap={2}>
+        <HStack gap={2} wrap="wrap">
           <FlaskConical size={16} />
           <Text textStyle="sm" fontWeight="semibold">
             Normalisation preview
           </Text>
           <Text textStyle="xs" color="fg.muted">
-            Replays this aggregate&apos;s stored span events through the
-            canonicalisation code of this build. Read-only.
+            Replays stored span events through this build&apos;s
+            canonicalisation. Read-only.
           </Text>
+          <Box flex={1} />
+          <Text textStyle="xs" color="fg.muted">
+            Event:
+          </Text>
+          <NativeSelect.Root size="xs" width="320px">
+            <NativeSelect.Field
+              value={selectedEventId}
+              onChange={(e) => setSelectedEventId(e.target.value)}
+            >
+              <option value="all">All span events ({spanEvents.length})</option>
+              {spanEvents.map((event, index) => (
+                <option key={event.eventId} value={event.eventId}>
+                  #{index + 1} · {spanNameFromPayload(event.payload)}
+                </option>
+              ))}
+            </NativeSelect.Field>
+            <NativeSelect.Indicator />
+          </NativeSelect.Root>
         </HStack>
+
+        <datalist id="nprev-source-keys">
+          {attributeKeys.map((key) => (
+            <option key={key} value={key} />
+          ))}
+        </datalist>
+        <datalist id="nprev-target-keys">
+          {KNOWN_TARGET_KEYS.map((key) => (
+            <option key={key} value={key} />
+          ))}
+        </datalist>
 
         <VStack
           align="stretch"
@@ -98,36 +253,42 @@ export function NormalisationPreviewPanel({
           borderRadius="md"
         >
           <Text textStyle="xs" fontWeight="medium" color="fg.muted">
-            Experimental mapping rules (optional)
+            Map rules — match a source key, write a canonical key
           </Text>
-          {rules.map((rule, index) => (
+          {mapRules.map((rule, index) => (
             <HStack key={index} gap={2} align="center">
               <Input
                 size="xs"
                 fontFamily="mono"
                 placeholder="source key"
+                list="nprev-source-keys"
                 value={rule.key}
-                onChange={(e) => updateRule(index, { key: e.target.value })}
+                onChange={(e) =>
+                  updateAt(setMapRules, index, { key: e.target.value })
+                }
                 flex={2}
               />
-              <Button
-                size="xs"
-                variant={rule.keyIsRegex ? "solid" : "outline"}
-                colorPalette={rule.keyIsRegex ? "blue" : "gray"}
-                onClick={() =>
-                  updateRule(index, { keyIsRegex: !rule.keyIsRegex })
-                }
-                title="Treat source key as a regex"
-              >
-                .*
-              </Button>
+              <NativeSelect.Root size="xs" width="90px" flexShrink={0}>
+                <NativeSelect.Field
+                  value={rule.matcher}
+                  onChange={(e) =>
+                    updateAt(setMapRules, index, {
+                      matcher: e.target.value as MapRuleDraft["matcher"],
+                    })
+                  }
+                >
+                  <option value="exact">exact</option>
+                  <option value="regex">regex</option>
+                </NativeSelect.Field>
+                <NativeSelect.Indicator />
+              </NativeSelect.Root>
               <Input
                 size="xs"
                 fontFamily="mono"
                 placeholder="value regex (group 1 extracted, optional)"
                 value={rule.valuePattern}
                 onChange={(e) =>
-                  updateRule(index, { valuePattern: e.target.value })
+                  updateAt(setMapRules, index, { valuePattern: e.target.value })
                 }
                 flex={2}
               />
@@ -135,8 +296,8 @@ export function NormalisationPreviewPanel({
                 <NativeSelect.Field
                   value={rule.actionType}
                   onChange={(e) =>
-                    updateRule(index, {
-                      actionType: e.target.value as "copy" | "move",
+                    updateAt(setMapRules, index, {
+                      actionType: e.target.value as MapRuleDraft["actionType"],
                     })
                   }
                 >
@@ -148,19 +309,18 @@ export function NormalisationPreviewPanel({
               <Input
                 size="xs"
                 fontFamily="mono"
-                placeholder="target key (e.g. langwatch.input)"
+                placeholder="target key"
+                list="nprev-target-keys"
                 value={rule.targetKey}
                 onChange={(e) =>
-                  updateRule(index, { targetKey: e.target.value })
+                  updateAt(setMapRules, index, { targetKey: e.target.value })
                 }
                 flex={2}
               />
               <Button
                 size="xs"
                 variant="ghost"
-                onClick={() =>
-                  setRules((prev) => prev.filter((_, i) => i !== index))
-                }
+                onClick={() => removeAt(setMapRules, index)}
                 title="Remove rule"
               >
                 <Trash2 size={13} />
@@ -171,10 +331,81 @@ export function NormalisationPreviewPanel({
             <Button
               size="xs"
               variant="outline"
-              onClick={() => setRules((prev) => [...prev, emptyRule()])}
+              onClick={() =>
+                setMapRules((prev) => [
+                  ...prev,
+                  {
+                    key: "",
+                    matcher: "exact",
+                    valuePattern: "",
+                    actionType: "copy",
+                    targetKey: "",
+                  },
+                ])
+              }
             >
               <Plus size={13} />
-              Add rule
+              Add map rule
+            </Button>
+          </HStack>
+        </VStack>
+
+        <VStack
+          align="stretch"
+          gap={2}
+          padding={3}
+          borderWidth="1px"
+          borderColor="border.muted"
+          borderRadius="md"
+        >
+          <HStack gap={2} wrap="wrap">
+            <Text textStyle="xs" fontWeight="medium" color="fg.muted">
+              Expression rules — bonsai expressions over the span&apos;s
+              attributes; the result is written to the target key
+            </Text>
+            <Box flex={1} />
+            {EXPRESSION_EXAMPLES.map((example) => (
+              <Button
+                key={example.label}
+                size="xs"
+                variant="ghost"
+                color="fg.muted"
+                onClick={() =>
+                  setExpressionRules((prev) => [
+                    ...prev,
+                    {
+                      expression: example.expression,
+                      targetKey: example.targetKey,
+                    },
+                  ])
+                }
+                title={example.expression}
+              >
+                + {example.label}
+              </Button>
+            ))}
+          </HStack>
+          {expressionRules.map((rule, index) => (
+            <ExpressionRuleEditor
+              key={index}
+              rule={rule}
+              onChange={(patch) => updateAt(setExpressionRules, index, patch)}
+              onRemove={() => removeAt(setExpressionRules, index)}
+            />
+          ))}
+          <HStack>
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() =>
+                setExpressionRules((prev) => [
+                  ...prev,
+                  { expression: "", targetKey: "" },
+                ])
+              }
+            >
+              <Plus size={13} />
+              Add expression rule
             </Button>
             <Box flex={1} />
             <Button
@@ -187,6 +418,10 @@ export function NormalisationPreviewPanel({
               Run preview
             </Button>
           </HStack>
+          <Text textStyle="xs" color="fg.muted">
+            Map rules run before expression rules. After the first run,
+            edits re-run the preview automatically.
+          </Text>
         </VStack>
 
         {preview.error && (
@@ -202,14 +437,14 @@ export function NormalisationPreviewPanel({
           </Box>
         )}
 
-        {preview.isPending && (
+        {preview.isPending && !result && (
           <Center paddingY={8}>
             <Spinner size="md" />
           </Center>
         )}
 
         {result && (
-          <VStack align="stretch" gap={3}>
+          <VStack align="stretch" gap={3} opacity={preview.isPending ? 0.6 : 1}>
             <HStack gap={2} wrap="wrap">
               <Badge size="sm" variant="outline">
                 {result.eventsScanned} events scanned
@@ -235,14 +470,65 @@ export function NormalisationPreviewPanel({
               ))}
             </HStack>
 
+            {result.projections.length > 0 && (
+              <VStack align="stretch" gap={2}>
+                <Text textStyle="sm" fontWeight="semibold">
+                  Projection impact
+                </Text>
+                <Text textStyle="xs" color="fg.muted">
+                  Every projection folding this aggregate, with vs without
+                  your rules. Rules apply across all span events here —
+                  projections accumulate over the whole event stream.
+                </Text>
+                {result.projections.map((impact) => (
+                  <VStack
+                    key={impact.projectionName}
+                    align="stretch"
+                    gap={1}
+                    padding={3}
+                    borderWidth="1px"
+                    borderColor="border.muted"
+                    borderRadius="md"
+                  >
+                    <HStack gap={2}>
+                      <Text textStyle="sm" fontWeight="medium">
+                        {impact.projectionName}
+                      </Text>
+                      <Badge size="sm" variant="subtle">
+                        {impact.aggregateType}
+                      </Badge>
+                      <Text textStyle="xs" color="fg.muted">
+                        {impact.appliedEventCount} events folded
+                      </Text>
+                      <Box flex={1} />
+                      {impact.changes.length === 0 ? (
+                        <Badge size="sm" variant="subtle" colorPalette="gray">
+                          no change
+                        </Badge>
+                      ) : (
+                        <Badge size="sm" variant="subtle" colorPalette="orange">
+                          {impact.changes.length} change
+                          {impact.changes.length === 1 ? "" : "s"}
+                        </Badge>
+                      )}
+                    </HStack>
+                    {impact.changes.length > 0 && (
+                      <DiffTable entries={impact.changes} />
+                    )}
+                  </VStack>
+                ))}
+              </VStack>
+            )}
+
             {result.spans.length === 0 && (
               <Text textStyle="sm" color="fg.muted">
-                No span-received events to replay in this aggregate.
+                No span-received events to replay
+                {selectedEventId !== "all" ? " for the selected event" : ""}.
               </Text>
             )}
 
             {result.spans.map((span) => (
-              <SpanPreviewCard key={span.spanId} span={span} />
+              <SpanPreviewCard key={span.eventId} span={span} />
             ))}
           </VStack>
         )}
@@ -251,8 +537,85 @@ export function NormalisationPreviewPanel({
   );
 }
 
-type SpanPreview =
-  RouterOutputs["ops"]["previewNormalisation"]["spans"][number];
+function ExpressionRuleEditor({
+  rule,
+  onChange,
+  onRemove,
+}: {
+  rule: ExpressionRuleDraft;
+  onChange: (patch: Partial<ExpressionRuleDraft>) => void;
+  onRemove: () => void;
+}) {
+  const monacoRef = useRef<Monaco | null>(null);
+
+  const onMount: OnMount = (editor, monaco) => {
+    monacoRef.current = monaco;
+    registerBonsaiLanguage(monaco);
+    const model = editor.getModel();
+    if (model) validateBonsaiModel(monaco, model);
+    editor.onDidChangeModelContent(() => {
+      const currentModel = editor.getModel();
+      if (currentModel) validateBonsaiModel(monaco, currentModel);
+    });
+  };
+
+  return (
+    <HStack gap={2} align="start">
+      <Box
+        flex={4}
+        borderWidth="1px"
+        borderColor="border.muted"
+        borderRadius="sm"
+        overflow="hidden"
+      >
+        <MonacoEditor
+          height="58px"
+          language={BONSAI_LANGUAGE_ID}
+          value={rule.expression}
+          beforeMount={(monaco: Monaco) => registerBonsaiLanguage(monaco)}
+          onMount={onMount}
+          onChange={(value: string | undefined) =>
+            onChange({ expression: value ?? "" })
+          }
+          options={{
+            minimap: { enabled: false },
+            lineNumbers: "off",
+            folding: false,
+            glyphMargin: false,
+            lineDecorationsWidth: 4,
+            renderLineHighlight: "none",
+            overviewRulerLanes: 0,
+            scrollBeyondLastLine: false,
+            wordWrap: "on",
+            fontSize: 12,
+            automaticLayout: true,
+            scrollbar: { vertical: "hidden" },
+            placeholder: 'attr("vendor.key") |> upper',
+          }}
+        />
+      </Box>
+      <Text textStyle="xs" color="fg.muted" paddingTop={2}>
+        →
+      </Text>
+      <Input
+        size="xs"
+        fontFamily="mono"
+        placeholder="target key"
+        list="nprev-target-keys"
+        value={rule.targetKey}
+        onChange={(e) => onChange({ targetKey: e.target.value })}
+        flex={2}
+      />
+      <Button size="xs" variant="ghost" onClick={onRemove} title="Remove rule">
+        <Trash2 size={13} />
+      </Button>
+    </HStack>
+  );
+}
+
+type PreviewResult = RouterOutputs["ops"]["previewNormalisation"];
+type SpanPreview = PreviewResult["spans"][number];
+type DiffEntry = NonNullable<SpanPreview["storedDiff"]>[number];
 
 function SpanPreviewCard({ span }: { span: SpanPreview }) {
   const [showAttributes, setShowAttributes] = useState(false);
@@ -291,6 +654,16 @@ function SpanPreviewCard({ span }: { span: SpanPreview }) {
             </Badge>
           ))}
         </HStack>
+      )}
+
+      {span.ruleErrors.length > 0 && (
+        <VStack align="stretch" gap={1}>
+          {span.ruleErrors.map((err) => (
+            <Text key={err.ruleIndex} textStyle="xs" color="red.500">
+              rule {err.ruleIndex + 1} failed on this span: {err.error}
+            </Text>
+          ))}
+        </VStack>
       )}
 
       {span.storedDiff !== null && (
@@ -343,60 +716,123 @@ function DiffSection({
   entries,
 }: {
   title: string;
-  entries: NonNullable<SpanPreview["storedDiff"]>;
+  entries: DiffEntry[];
 }) {
   return (
     <VStack align="stretch" gap={1}>
       <Text textStyle="xs" color="fg.muted">
         {title}
       </Text>
-      {entries.length > 0 && (
-        <Box overflowX="auto">
-          <Table.Root size="sm" variant="line">
-            <Table.Body>
-              {entries.map((entry) => (
-                <Table.Row key={`${entry.kind}:${entry.key}`}>
-                  <Table.Cell width="90px">
-                    <Badge
-                      size="sm"
-                      variant="subtle"
-                      colorPalette={DIFF_COLOR[entry.kind] ?? "gray"}
-                    >
-                      {entry.kind}
-                    </Badge>
-                  </Table.Cell>
-                  <Table.Cell fontFamily="mono" textStyle="xs">
-                    {entry.key}
-                  </Table.Cell>
-                  <Table.Cell
-                    fontFamily="mono"
-                    textStyle="xs"
-                    color="fg.muted"
-                    maxW="300px"
-                    overflow="hidden"
-                    textOverflow="ellipsis"
-                    whiteSpace="nowrap"
-                    title={entry.before ?? undefined}
-                  >
-                    {entry.before ?? "—"}
-                  </Table.Cell>
-                  <Table.Cell
-                    fontFamily="mono"
-                    textStyle="xs"
-                    maxW="300px"
-                    overflow="hidden"
-                    textOverflow="ellipsis"
-                    whiteSpace="nowrap"
-                    title={entry.after ?? undefined}
-                  >
-                    {entry.after ?? "—"}
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-            </Table.Body>
-          </Table.Root>
-        </Box>
-      )}
+      {entries.length > 0 && <DiffTable entries={entries} />}
     </VStack>
   );
+}
+
+function DiffTable({ entries }: { entries: DiffEntry[] }) {
+  return (
+    <Box overflowX="auto">
+      <Table.Root size="sm" variant="line">
+        <Table.Body>
+          {entries.map((entry) => (
+            <Table.Row key={`${entry.kind}:${entry.key}`}>
+              <Table.Cell width="90px">
+                <Badge
+                  size="sm"
+                  variant="subtle"
+                  colorPalette={DIFF_COLOR[entry.kind] ?? "gray"}
+                >
+                  {entry.kind}
+                </Badge>
+              </Table.Cell>
+              <Table.Cell fontFamily="mono" textStyle="xs">
+                {entry.key}
+                {entry.ruleIndex !== undefined && (
+                  <Text as="span" color="fg.muted">
+                    {" "}
+                    ← {entry.sourceKey ?? `rule ${entry.ruleIndex + 1} (expression)`}
+                  </Text>
+                )}
+              </Table.Cell>
+              <Table.Cell
+                fontFamily="mono"
+                textStyle="xs"
+                color="fg.muted"
+                maxW="300px"
+                overflow="hidden"
+                textOverflow="ellipsis"
+                whiteSpace="nowrap"
+                title={entry.before ?? undefined}
+              >
+                {entry.before ?? "—"}
+              </Table.Cell>
+              <Table.Cell
+                fontFamily="mono"
+                textStyle="xs"
+                maxW="300px"
+                overflow="hidden"
+                textOverflow="ellipsis"
+                whiteSpace="nowrap"
+                title={entry.after ?? undefined}
+              >
+                {entry.after ?? "—"}
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function updateAt<T>(
+  setter: React.Dispatch<React.SetStateAction<T[]>>,
+  index: number,
+  patch: Partial<T>,
+): void {
+  setter((prev) =>
+    prev.map((item, i) => (i === index ? { ...item, ...patch } : item)),
+  );
+}
+
+function removeAt<T>(
+  setter: React.Dispatch<React.SetStateAction<T[]>>,
+  index: number,
+): void {
+  setter((prev) => prev.filter((_, i) => i !== index));
+}
+
+/** Pulls the OTLP attribute keys out of a span-received event payload. */
+function extractAttributeKeys(payload: unknown): string[] {
+  const parsed = typeof payload === "string" ? safeParse(payload) : payload;
+  if (!parsed || typeof parsed !== "object") return [];
+  const span = (parsed as { span?: unknown }).span;
+  if (!span || typeof span !== "object") return [];
+  const attributes = (span as { attributes?: unknown }).attributes;
+  if (!Array.isArray(attributes)) return [];
+  return attributes
+    .map((kv) =>
+      kv && typeof kv === "object" ? (kv as { key?: unknown }).key : undefined,
+    )
+    .filter((key): key is string => typeof key === "string");
+}
+
+function spanNameFromPayload(payload: unknown): string {
+  const parsed = typeof payload === "string" ? safeParse(payload) : payload;
+  const name =
+    parsed && typeof parsed === "object"
+      ? ((parsed as { span?: { name?: unknown } }).span?.name ?? null)
+      : null;
+  return typeof name === "string" && name.length > 0 ? name : "span";
+}
+
+function safeParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
 }

--- a/langwatch/src/components/ops/dejaview/NormalisationPreviewPanel.tsx
+++ b/langwatch/src/components/ops/dejaview/NormalisationPreviewPanel.tsx
@@ -18,6 +18,7 @@ import dynamic from "~/utils/compat/next-dynamic";
 import type { Monaco, OnMount } from "@monaco-editor/react";
 import {
   BONSAI_LANGUAGE_ID,
+  evaluateBonsaiExpression,
   isValidBonsaiExpression,
   registerBonsaiLanguage,
   setBonsaiCompletionKeys,
@@ -92,6 +93,13 @@ const EXPRESSION_EXAMPLES: Array<{
   },
 ];
 
+/** Shown above the expression editors as a quick how-it-works reference. */
+const GENERIC_EXAMPLE_SNIPPET = `attr("gen_ai.request.model")                                read any attribute (dotted keys need attr)
+attr("vendor.messages") |> filter(.role == "user") |> map(.content)   pipe through transforms
+take("vendor.raw_output") ?? attr("langwatch.output")       take() consumes the source, ?? falls back
+has("gen_ai.output.messages")                               probe for a key
+attrs                                                       the whole attribute map`;
+
 type MapRuleDraft = {
   key: string;
   matcher: "exact" | "regex";
@@ -110,6 +118,30 @@ type PreviewInput = Parameters<
 >[0];
 
 const AUTO_RUN_DEBOUNCE_MS = 700;
+
+/**
+ * Shared Monaco options. quickSuggestions.strings is the important one:
+ * the main completion surface is INSIDE attr("…") string quotes, and
+ * Monaco disables quick suggestions in strings by default — without
+ * this, attribute-key completions never appear. Word-based suggestions
+ * are disabled so buffer words don't drown the curated list.
+ */
+const BONSAI_EDITOR_OPTIONS = {
+  minimap: { enabled: false },
+  lineNumbers: "off" as const,
+  folding: false,
+  glyphMargin: false,
+  lineDecorationsWidth: 4,
+  renderLineHighlight: "none" as const,
+  overviewRulerLanes: 0,
+  scrollBeyondLastLine: false,
+  wordWrap: "on" as const,
+  fontSize: 12,
+  automaticLayout: true,
+  quickSuggestions: { other: true, comments: false, strings: true },
+  suggestOnTriggerCharacters: true,
+  wordBasedSuggestions: "off" as const,
+};
 
 export function NormalisationPreviewPanel({
   aggregateId,
@@ -180,7 +212,27 @@ export function NormalisationPreviewPanel({
     ],
   });
 
-  const run = () => preview.mutate(buildInput());
+  // Payload rule indexes ≠ draft indexes (empty/invalid drafts are
+  // filtered out), so remember which payload rule maps to which
+  // expression-draft editor for error highlighting.
+  const expressionPayloadIndexRef = useRef<Map<number, number>>(new Map());
+  const buildInputTracked = (): PreviewInput => {
+    const input = buildInput();
+    const mapping = new Map<number, number>();
+    let draftIndex = -1;
+    (input.rules ?? []).forEach((rule, payloadIndex) => {
+      if (rule.kind !== "expression") return;
+      // Recover the draft index by matching filtered order.
+      draftIndex = expressionRules.findIndex(
+        (d, i) => i > draftIndex && d.expression === rule.expression,
+      );
+      if (draftIndex >= 0) mapping.set(payloadIndex, draftIndex);
+    });
+    expressionPayloadIndexRef.current = mapping;
+    return input;
+  };
+
+  const run = () => preview.mutate(buildInputTracked());
 
   // Live updates: once the operator has run the preview, edits re-run it
   // automatically (debounced). Invalid expressions are filtered out by
@@ -194,12 +246,65 @@ export function NormalisationPreviewPanel({
   });
   useEffect(() => {
     if (!hasRunRef.current) return;
-    const timer = setTimeout(() => preview.mutate(buildInput()), AUTO_RUN_DEBOUNCE_MS);
+    const timer = setTimeout(
+      () => preview.mutate(buildInputTracked()),
+      AUTO_RUN_DEBOUNCE_MS,
+    );
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serializedInput]);
 
   const result = preview.data;
+  // Every array is guarded: if the API process is serving an older build
+  // of the preview endpoint (dev-server version skew), missing fields
+  // must degrade to empty sections, never crash the panel.
+  const resultSpans = result?.spans ?? [];
+  const resultProjections = result?.projections ?? [];
+  const resultRuleStats = result?.ruleStats ?? [];
+
+  // Aggregate per-rule runtime errors across spans and attach them to
+  // the expression editor that produced them.
+  const expressionErrorsByDraft = useMemo(() => {
+    const byDraft = new Map<number, { count: number; message: string }>();
+    for (const span of resultSpans) {
+      for (const err of span.ruleErrors ?? []) {
+        const draftIndex = expressionPayloadIndexRef.current.get(err.ruleIndex);
+        if (draftIndex === undefined) continue;
+        const existing = byDraft.get(draftIndex);
+        if (existing) {
+          existing.count += 1;
+        } else {
+          byDraft.set(draftIndex, { count: 1, message: err.error });
+        }
+      }
+    }
+    return byDraft;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [result]);
+
+  // Playground context: prefer the replayed canonical attributes of the
+  // selected event once a run exists; before that, decode the raw OTLP
+  // attributes straight off the stored event so the playground works
+  // without a server round-trip.
+  const playgroundContext = useMemo(() => {
+    const targetEventId =
+      selectedEventId !== "all" ? selectedEventId : spanEvents[0]?.eventId;
+    if (targetEventId === undefined) return null;
+    const fromRun = resultSpans.find((s) => s.eventId === targetEventId);
+    if (fromRun) {
+      return {
+        attributes: fromRun.replayedAttributes as Record<string, unknown>,
+        label: "replayed canonical attributes",
+      };
+    }
+    const event = spanEvents.find((e) => e.eventId === targetEventId);
+    if (!event) return null;
+    return {
+      attributes: decodeOtlpSpanAttributes(event.payload),
+      label: "raw event attributes — run the preview for the canonical view",
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [result, selectedEventId, spanEvents]);
 
   return (
     <Box flex={1} overflowY="auto" minH={0} w="full" padding={6}>
@@ -385,10 +490,23 @@ export function NormalisationPreviewPanel({
               </Button>
             ))}
           </HStack>
+          <Box
+            as="pre"
+            padding={2}
+            borderRadius="sm"
+            bg="bg.muted"
+            overflowX="auto"
+            textStyle="xs"
+            fontFamily="mono"
+            color="fg.muted"
+          >
+            {GENERIC_EXAMPLE_SNIPPET}
+          </Box>
           {expressionRules.map((rule, index) => (
             <ExpressionRuleEditor
               key={index}
               rule={rule}
+              serverError={expressionErrorsByDraft.get(index) ?? null}
               onChange={(patch) => updateAt(setExpressionRules, index, patch)}
               onRemove={() => removeAt(setExpressionRules, index)}
             />
@@ -424,6 +542,13 @@ export function NormalisationPreviewPanel({
           </Text>
         </VStack>
 
+        {playgroundContext && (
+          <PlaygroundSection
+            attributes={playgroundContext.attributes}
+            contextLabel={playgroundContext.label}
+          />
+        )}
+
         {preview.error && (
           <Box
             padding={3}
@@ -452,12 +577,12 @@ export function NormalisationPreviewPanel({
               <Badge size="sm" variant="outline">
                 {result.spanEventsFound} span events
               </Badge>
-              {result.skippedInvalidEvents > 0 && (
+              {(result.skippedInvalidEvents ?? 0) > 0 && (
                 <Badge size="sm" variant="outline" colorPalette="orange">
                   {result.skippedInvalidEvents} unparseable
                 </Badge>
               )}
-              {result.ruleStats.map((stat) => (
+              {resultRuleStats.map((stat) => (
                 <Badge
                   key={stat.ruleIndex}
                   size="sm"
@@ -470,7 +595,7 @@ export function NormalisationPreviewPanel({
               ))}
             </HStack>
 
-            {result.projections.length > 0 && (
+            {resultProjections.length > 0 && (
               <VStack align="stretch" gap={2}>
                 <Text textStyle="sm" fontWeight="semibold">
                   Projection impact
@@ -480,7 +605,7 @@ export function NormalisationPreviewPanel({
                   your rules. Rules apply across all span events here —
                   projections accumulate over the whole event stream.
                 </Text>
-                {result.projections.map((impact) => (
+                {resultProjections.map((impact) => (
                   <VStack
                     key={impact.projectionName}
                     align="stretch"
@@ -520,14 +645,14 @@ export function NormalisationPreviewPanel({
               </VStack>
             )}
 
-            {result.spans.length === 0 && (
+            {resultSpans.length === 0 && (
               <Text textStyle="sm" color="fg.muted">
                 No span-received events to replay
                 {selectedEventId !== "all" ? " for the selected event" : ""}.
               </Text>
             )}
 
-            {result.spans.map((span) => (
+            {resultSpans.map((span) => (
               <SpanPreviewCard key={span.eventId} span={span} />
             ))}
           </VStack>
@@ -539,10 +664,12 @@ export function NormalisationPreviewPanel({
 
 function ExpressionRuleEditor({
   rule,
+  serverError,
   onChange,
   onRemove,
 }: {
   rule: ExpressionRuleDraft;
+  serverError: { count: number; message: string } | null;
   onChange: (patch: Partial<ExpressionRuleDraft>) => void;
   onRemove: () => void;
 }) {
@@ -560,11 +687,12 @@ function ExpressionRuleEditor({
   };
 
   return (
+    <VStack align="stretch" gap={1}>
     <HStack gap={2} align="start">
       <Box
         flex={4}
         borderWidth="1px"
-        borderColor="border.muted"
+        borderColor={serverError ? "red.400" : "border.muted"}
         borderRadius="sm"
         overflow="hidden"
       >
@@ -578,17 +706,7 @@ function ExpressionRuleEditor({
             onChange({ expression: value ?? "" })
           }
           options={{
-            minimap: { enabled: false },
-            lineNumbers: "off",
-            folding: false,
-            glyphMargin: false,
-            lineDecorationsWidth: 4,
-            renderLineHighlight: "none",
-            overviewRulerLanes: 0,
-            scrollBeyondLastLine: false,
-            wordWrap: "on",
-            fontSize: 12,
-            automaticLayout: true,
+            ...BONSAI_EDITOR_OPTIONS,
             scrollbar: { vertical: "hidden" },
             placeholder: 'attr("vendor.key") |> upper',
           }}
@@ -610,6 +728,13 @@ function ExpressionRuleEditor({
         <Trash2 size={13} />
       </Button>
     </HStack>
+    {serverError && (
+      <Text textStyle="xs" color="red.500">
+        failed on {serverError.count} span
+        {serverError.count === 1 ? "" : "s"}: {serverError.message}
+      </Text>
+    )}
+    </VStack>
   );
 }
 
@@ -784,6 +909,128 @@ function DiffTable({ entries }: { entries: DiffEntry[] }) {
   );
 }
 
+const PLAYGROUND_DEBOUNCE_MS = 350;
+const MAX_PLAYGROUND_RESULT_LENGTH = 8_000;
+
+/**
+ * Free-form bonsai scratchpad: write any expression and see it evaluated
+ * live (client-side, no server round-trip) against the selected event's
+ * attributes. The fastest way to iterate before committing something to
+ * an expression rule.
+ */
+function PlaygroundSection({
+  attributes,
+  contextLabel,
+}: {
+  attributes: Record<string, unknown>;
+  contextLabel: string;
+}) {
+  const [code, setCode] = useState("");
+  const [output, setOutput] = useState<
+    { ok: true; value: string } | { ok: false; error: string } | null
+  >(null);
+
+  const attributesRef = useRef(attributes);
+  attributesRef.current = attributes;
+
+  useEffect(() => {
+    if (code.trim().length === 0) {
+      setOutput(null);
+      return;
+    }
+    const timer = setTimeout(() => {
+      const evaluated = evaluateBonsaiExpression(code, attributesRef.current);
+      if (evaluated.ok) {
+        let rendered: string;
+        try {
+          rendered = JSON.stringify(evaluated.value, null, 2) ?? "undefined";
+        } catch {
+          rendered = String(evaluated.value);
+        }
+        if (rendered.length > MAX_PLAYGROUND_RESULT_LENGTH) {
+          rendered = `${rendered.slice(0, MAX_PLAYGROUND_RESULT_LENGTH)}…`;
+        }
+        setOutput({ ok: true, value: rendered });
+      } else {
+        setOutput(evaluated);
+      }
+    }, PLAYGROUND_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [code, attributes]);
+
+  const onMount: OnMount = (editor, monaco) => {
+    registerBonsaiLanguage(monaco);
+    const validate = () => {
+      const model = editor.getModel();
+      if (model) validateBonsaiModel(monaco, model);
+    };
+    validate();
+    editor.onDidChangeModelContent(validate);
+  };
+
+  return (
+    <VStack
+      align="stretch"
+      gap={2}
+      padding={3}
+      borderWidth="1px"
+      borderColor="border.muted"
+      borderRadius="md"
+    >
+      <HStack gap={2}>
+        <Text textStyle="xs" fontWeight="medium" color="fg.muted">
+          Playground — evaluate any expression live
+        </Text>
+        <Box flex={1} />
+        <Text textStyle="xs" color="fg.muted">
+          context: {contextLabel}
+        </Text>
+      </HStack>
+      <Box
+        borderWidth="1px"
+        borderColor="border.muted"
+        borderRadius="sm"
+        overflow="hidden"
+      >
+        <MonacoEditor
+          height="180px"
+          language={BONSAI_LANGUAGE_ID}
+          value={code}
+          beforeMount={(monaco: Monaco) => registerBonsaiLanguage(monaco)}
+          onMount={onMount}
+          onChange={(value: string | undefined) => setCode(value ?? "")}
+          options={{
+            ...BONSAI_EDITOR_OPTIONS,
+            lineNumbers: "on",
+            placeholder:
+              'attr("gcp.vertex.agent.llm_request").contents |> map(.parts)',
+          }}
+        />
+      </Box>
+      {output !== null &&
+        (output.ok ? (
+          <Box
+            as="pre"
+            padding={2}
+            borderRadius="sm"
+            bg="bg.muted"
+            overflowX="auto"
+            textStyle="xs"
+            fontFamily="mono"
+            maxH="260px"
+            overflowY="auto"
+          >
+            {output.value}
+          </Box>
+        ) : (
+          <Text textStyle="xs" color="red.500" fontFamily="mono">
+            {output.error}
+          </Text>
+        ))}
+    </VStack>
+  );
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────
@@ -835,4 +1082,70 @@ function safeParse(raw: string): unknown {
   } catch {
     return null;
   }
+}
+
+/**
+ * Decodes a stored span-received event's OTLP attributes into plain
+ * values for the playground: {stringValue} strings (JSON-looking ones
+ * parsed, mirroring the pipeline's parseJsonStringValues), int/double/
+ * bool values, and nested array/kvlist values.
+ */
+function decodeOtlpSpanAttributes(payload: unknown): Record<string, unknown> {
+  const parsed = typeof payload === "string" ? safeParse(payload) : payload;
+  const span =
+    parsed && typeof parsed === "object"
+      ? (parsed as { span?: unknown }).span
+      : null;
+  const attributes =
+    span && typeof span === "object"
+      ? (span as { attributes?: unknown }).attributes
+      : null;
+  if (!Array.isArray(attributes)) return {};
+
+  const out: Record<string, unknown> = {};
+  for (const kv of attributes) {
+    if (!kv || typeof kv !== "object") continue;
+    const key = (kv as { key?: unknown }).key;
+    if (typeof key !== "string") continue;
+    out[key] = decodeOtlpAnyValue((kv as { value?: unknown }).value);
+  }
+  return out;
+}
+
+function decodeOtlpAnyValue(value: unknown): unknown {
+  if (!value || typeof value !== "object") return value;
+  const v = value as Record<string, unknown>;
+  if (typeof v.stringValue === "string") {
+    const s = v.stringValue.trim();
+    if (
+      (s.startsWith("{") && s.endsWith("}")) ||
+      (s.startsWith("[") && s.endsWith("]"))
+    ) {
+      const parsed = safeParse(v.stringValue);
+      if (parsed !== null) return parsed;
+    }
+    return v.stringValue;
+  }
+  if (v.intValue !== undefined && v.intValue !== null) return Number(v.intValue);
+  if (v.doubleValue !== undefined && v.doubleValue !== null) {
+    return Number(v.doubleValue);
+  }
+  if (v.boolValue !== undefined && v.boolValue !== null) {
+    return v.boolValue === true || v.boolValue === "true";
+  }
+  const arrayValue = v.arrayValue as { values?: unknown[] } | undefined;
+  if (Array.isArray(arrayValue?.values)) {
+    return arrayValue.values.map(decodeOtlpAnyValue);
+  }
+  const kvlistValue = v.kvlistValue as
+    | { values?: Array<{ key?: unknown; value?: unknown }> }
+    | undefined;
+  if (Array.isArray(kvlistValue?.values)) {
+    return Object.fromEntries(
+      kvlistValue.values
+        .filter((kv) => typeof kv?.key === "string")
+        .map((kv) => [kv.key as string, decodeOtlpAnyValue(kv.value)]),
+    );
+  }
+  return undefined;
 }

--- a/langwatch/src/components/ops/dejaview/ReplayHeader.tsx
+++ b/langwatch/src/components/ops/dejaview/ReplayHeader.tsx
@@ -1,5 +1,5 @@
 import { Badge, Box, Button, HStack, Text } from "@chakra-ui/react";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, FlaskConical } from "lucide-react";
 
 export function ReplayHeader({
   aggregateId,
@@ -7,12 +7,16 @@ export function ReplayHeader({
   eventCursor,
   eventCount,
   onBack,
+  previewActive,
+  onTogglePreview,
 }: {
   aggregateId: string;
   tenantId: string;
   eventCursor: number;
   eventCount: number;
   onBack: () => void;
+  previewActive: boolean;
+  onTogglePreview: () => void;
 }) {
   return (
     <HStack
@@ -48,6 +52,15 @@ export function ReplayHeader({
         </Badge>
       </HStack>
       <Box flex={1} />
+      <Button
+        size="xs"
+        variant={previewActive ? "solid" : "outline"}
+        colorPalette={previewActive ? "blue" : "gray"}
+        onClick={onTogglePreview}
+      >
+        <FlaskConical size={13} />
+        Normalisation preview
+      </Button>
       <Badge size="sm" variant="outline" colorPalette="blue">
         Event {eventCount > 0 ? eventCursor + 1 : 0} / {eventCount}
       </Badge>

--- a/langwatch/src/components/ops/dejaview/bonsaiMonaco.ts
+++ b/langwatch/src/components/ops/dejaview/bonsaiMonaco.ts
@@ -193,3 +193,43 @@ export function isValidBonsaiExpression(text: string): boolean {
   if (text.trim().length === 0) return false;
   return validator.validate(text).valid;
 }
+
+/**
+ * Client-side evaluation for the playground: runs an expression against
+ * an attribute map with the same attr()/has()/take() helpers the server
+ * uses. `take` operates on a copy — the caller's map is never mutated.
+ */
+export function evaluateBonsaiExpression(
+  expression: string,
+  attributes: Record<string, unknown>,
+): { ok: true; value: unknown } | { ok: false; error: string } {
+  if (expression.trim().length === 0) {
+    return { ok: false, error: "empty expression" };
+  }
+  const scratch: Record<string, unknown> = { ...attributes };
+  const instance = bonsai({ timeout: 50, maxDepth: 30 })
+    .use(strings)
+    .use(arrays)
+    .use(math)
+    .use(types);
+  instance.addFunction("attr", (key: unknown) =>
+    typeof key === "string" ? scratch[key] : undefined,
+  );
+  instance.addFunction("has", (key: unknown) =>
+    typeof key === "string" ? key in scratch : false,
+  );
+  instance.addFunction("take", (key: unknown) => {
+    if (typeof key !== "string") return undefined;
+    const value = scratch[key];
+    delete scratch[key];
+    return value;
+  });
+  try {
+    return {
+      ok: true,
+      value: instance.evaluateSync(expression, { attrs: scratch }),
+    };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/langwatch/src/components/ops/dejaview/bonsaiMonaco.ts
+++ b/langwatch/src/components/ops/dejaview/bonsaiMonaco.ts
@@ -1,0 +1,195 @@
+import type { Monaco } from "@monaco-editor/react";
+import { bonsai } from "bonsai-js";
+import { arrays, math, strings, types } from "bonsai-js/stdlib";
+import type { editor, languages, Position } from "monaco-editor";
+
+/**
+ * Client-side Monaco support for the normalisation-preview expression
+ * rules: a lightweight "bonsai" language (tokens for strings, numbers,
+ * pipes), autocomplete for `attr("…")`/`has`/`take` over the selected
+ * event's attribute keys plus the stdlib transforms, and live parse
+ * validation via the same bonsai parser the server uses — so an
+ * expression that shows no marker here will compile server-side too.
+ */
+
+export const BONSAI_LANGUAGE_ID = "bonsai";
+const MARKER_OWNER = "bonsai-preview";
+
+/** Mirrors the server evaluator in normalisation-preview.rules.ts. */
+const validator = bonsai({ timeout: 50, maxDepth: 30 })
+  .use(strings)
+  .use(arrays)
+  .use(math)
+  .use(types);
+// Parse-time stubs for the server's bag functions so references to them
+// validate cleanly in the editor.
+validator.addFunction("attr", () => undefined);
+validator.addFunction("has", () => false);
+validator.addFunction("take", () => undefined);
+
+/** Stdlib transforms + bag helpers surfaced in autocomplete. */
+const TRANSFORM_SUGGESTIONS: Array<{ label: string; detail: string }> = [
+  { label: "upper", detail: "uppercase a string" },
+  { label: "lower", detail: "lowercase a string" },
+  { label: "trim", detail: "trim whitespace" },
+  { label: "split", detail: "split(sep) a string into an array" },
+  { label: "count", detail: "length of an array or string" },
+  { label: "sort", detail: "sort an array" },
+  { label: "round", detail: "round a number" },
+  { label: "filter", detail: "filter(.field == value) an array" },
+  { label: "map", detail: "map(.field) over an array" },
+  { label: "find", detail: "find(.field == value) in an array" },
+  { label: "some", detail: "some(.predicate) over an array" },
+  { label: "every", detail: "every(.predicate) over an array" },
+];
+
+/**
+ * Attribute keys offered inside attr()/has()/take() completions. Mutable
+ * module state because Monaco completion providers are registered once
+ * per language, while the key set follows the selected event.
+ */
+let currentAttributeKeys: string[] = [];
+export function setBonsaiCompletionKeys(keys: string[]): void {
+  currentAttributeKeys = keys;
+}
+
+let registeredOn: Monaco | null = null;
+
+export function registerBonsaiLanguage(monaco: Monaco): void {
+  if (registeredOn === monaco) return;
+  registeredOn = monaco;
+
+  if (
+    !monaco.languages
+      .getLanguages()
+      .some((l: { id: string }) => l.id === BONSAI_LANGUAGE_ID)
+  ) {
+    monaco.languages.register({ id: BONSAI_LANGUAGE_ID });
+  }
+
+  monaco.languages.setMonarchTokensProvider(BONSAI_LANGUAGE_ID, {
+    tokenizer: {
+      root: [
+        [/"(?:[^"\\]|\\.)*"/, "string"],
+        [/'(?:[^'\\]|\\.)*'/, "string"],
+        [/\|>/, "keyword"],
+        [/\?\?/, "keyword"],
+        [/\b(?:true|false|null)\b/, "keyword"],
+        [/\b(?:attr|has|take)\b/, "type"],
+        [/\d+(?:\.\d+)?/, "number"],
+        [/[a-zA-Z_][\w$]*/, "identifier"],
+        [/[()[\]{}.,]/, "delimiter"],
+      ],
+    },
+  });
+
+  monaco.languages.registerCompletionItemProvider(BONSAI_LANGUAGE_ID, {
+    triggerCharacters: ['"', "'", "(", ">", "."],
+    provideCompletionItems: (model: editor.ITextModel, position: Position) => {
+      const word = model.getWordUntilPosition(position);
+      const range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+
+      const line = model.getLineContent(position.lineNumber);
+      const beforeCursor = line.slice(0, position.column - 1);
+
+      // Inside attr("…") / has("…") / take("…") → suggest attribute keys.
+      if (/(?:attr|has|take)\(\s*["']?[^"')]*$/.test(beforeCursor)) {
+        return {
+          suggestions: currentAttributeKeys.map(
+            (key): languages.CompletionItem => ({
+              label: key,
+              kind: monaco.languages.CompletionItemKind.Field,
+              insertText: key,
+              range,
+              detail: "attribute on this event",
+            }),
+          ),
+        };
+      }
+
+      const snippet = (
+        label: string,
+        insertText: string,
+        detail: string,
+      ): languages.CompletionItem => ({
+        label,
+        kind: monaco.languages.CompletionItemKind.Method,
+        insertText,
+        insertTextRules:
+          monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+        range,
+        detail,
+      });
+
+      const suggestions: languages.CompletionItem[] = [
+        snippet("attr", 'attr("$1")', "read an attribute by (dotted) key"),
+        snippet("has", 'has("$1")', "true when the attribute exists"),
+        snippet(
+          "take",
+          'take("$1")',
+          "read AND consume an attribute (like an extractor)",
+        ),
+        {
+          label: "attrs",
+          kind: monaco.languages.CompletionItemKind.Variable,
+          insertText: "attrs",
+          range,
+          detail: "the whole attribute map",
+        },
+        ...TRANSFORM_SUGGESTIONS.map(
+          (t): languages.CompletionItem => ({
+            label: t.label,
+            kind: monaco.languages.CompletionItemKind.Method,
+            insertText: t.label,
+            range,
+            detail: t.detail,
+          }),
+        ),
+      ];
+      return { suggestions };
+    },
+  });
+}
+
+/**
+ * Parse-validates a model's expression and paints squiggles at the
+ * reported positions. Returns true when the expression is valid.
+ */
+export function validateBonsaiModel(
+  monaco: Monaco,
+  model: editor.ITextModel,
+): boolean {
+  const text = model.getValue();
+  if (text.trim().length === 0) {
+    monaco.editor.setModelMarkers(model, MARKER_OWNER, []);
+    return false;
+  }
+
+  const result = validator.validate(text);
+  monaco.editor.setModelMarkers(
+    model,
+    MARKER_OWNER,
+    result.valid
+      ? []
+      : result.errors.map((err) => ({
+          severity: monaco.MarkerSeverity.Error,
+          message: err.message,
+          startLineNumber: err.position?.line ?? 1,
+          startColumn: err.position?.column ?? 1,
+          endLineNumber: err.position?.line ?? 1,
+          endColumn: (err.position?.column ?? 1) + 1,
+        })),
+  );
+  return result.valid;
+}
+
+/** Quick validity probe for non-editor callers (run-button gating). */
+export function isValidBonsaiExpression(text: string): boolean {
+  if (text.trim().length === 0) return false;
+  return validator.validate(text).valid;
+}

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -377,6 +377,8 @@ export const opsRouter = createTRPCRouter({
         aggregateId: z.string().min(1),
         tenantId: z.string().min(1),
         rules: mappingRulesSchema,
+        /** When set, only this event's span is returned in `spans`. */
+        eventId: z.string().min(1).optional(),
       }),
     )
     .mutation(async ({ input }) => {
@@ -386,6 +388,7 @@ export const opsRouter = createTRPCRouter({
           aggregateId: input.aggregateId,
           tenantId: input.tenantId,
           rules: input.rules,
+          eventId: input.eventId,
         });
       } catch (err) {
         if (err instanceof InvalidMappingRuleError) {

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -5,6 +5,10 @@ import { checkOpsPermission } from "~/server/api/rbac";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import { DASHBOARD_EVENT } from "~/server/app-layer/ops/metrics-collector";
+import {
+  InvalidMappingRuleError,
+  mappingRulesSchema,
+} from "~/server/app-layer/ops/normalisation-preview.rules";
 import type { DashboardData } from "~/server/app-layer/ops/types";
 import {
   resolveHotDays,
@@ -356,6 +360,39 @@ export const opsRouter = createTRPCRouter({
         projectionNames: input.projectionNames,
         sampleSize: input.sampleSize,
       };
+    }),
+
+  /**
+   * Deja View normalisation preview — replays an aggregate's stored
+   * span-received events through the CURRENT canonicalisation code and
+   * returns replayed attributes + fired rules + drift vs stored spans.
+   * Optional experimental mapping rules run on top. Read-only, so
+   * ops:view suffices; a mutation only because it's an explicit
+   * "run"-button action with a non-trivial input payload.
+   */
+  previewNormalisation: protectedProcedure
+    .use(opsViewPermission)
+    .input(
+      z.object({
+        aggregateId: z.string().min(1),
+        tenantId: z.string().min(1),
+        rules: mappingRulesSchema,
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const ops = requireOps();
+      try {
+        return await ops.normalisationPreview.previewAggregate({
+          aggregateId: input.aggregateId,
+          tenantId: input.tenantId,
+          rules: input.rules,
+        });
+      } catch (err) {
+        if (err instanceof InvalidMappingRuleError) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: err.message });
+        }
+        throw err;
+      }
     }),
 
   getReplayHistory: protectedProcedure

--- a/langwatch/src/server/app-layer/dependencies.ts
+++ b/langwatch/src/server/app-layer/dependencies.ts
@@ -17,6 +17,7 @@ import type { DspyStepService } from "./dspy-steps/dspy-step.service";
 import type { EvaluationExecutionService } from "./evaluations/evaluation-execution.service";
 import type { EvaluationRunService } from "./evaluations/evaluation-run.service";
 import type { EventExplorerService } from "./ops/event-explorer.service";
+import type { NormalisationPreviewService } from "./ops/normalisation-preview.service";
 import type { OpsMetricsCollector } from "./ops/metrics-collector";
 import type { QueueService } from "./ops/queue.service";
 import type { ReplayService } from "./ops/replay.service";
@@ -52,6 +53,7 @@ export interface DataRetentionDependencies {
 export interface OpsDependencies {
   queues: QueueService;
   eventExplorer: EventExplorerService;
+  normalisationPreview: NormalisationPreviewService;
   replay: ReplayService;
   metricsCollector: OpsMetricsCollector | null;
 }

--- a/langwatch/src/server/app-layer/ops/__tests__/normalisation-preview.rules.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/normalisation-preview.rules.unit.test.ts
@@ -14,6 +14,7 @@ const rule = (overrides: {
   type?: "copy" | "move";
   targetKey: string;
 }): MappingRule => ({
+  kind: "map",
   match: {
     key: overrides.key,
     keyIsRegex: overrides.keyIsRegex ?? false,
@@ -45,7 +46,8 @@ describe("applyMappingRules", () => {
       expect(result.ruleResults[0]).toEqual({
         ruleIndex: 0,
         matchedKeys: ["vendor.input"],
-        producedKey: "langwatch.input",
+        writes: [{ sourceKey: "vendor.input", targetKey: "langwatch.input" }],
+        error: null,
       });
     });
 
@@ -198,7 +200,7 @@ describe("compileMappingRules", () => {
         compileMappingRules([
           rule({ key: "([", keyIsRegex: true, targetKey: "t" }),
         ]),
-      ).toThrowError(/Rule 1: invalid regex in match\.key/);
+      ).toThrowError(/Rule 1: invalid match\.key/);
     });
   });
 
@@ -208,7 +210,120 @@ describe("compileMappingRules", () => {
         compileMappingRules([
           rule({ key: "k", valuePattern: "([", targetKey: "t" }),
         ]),
-      ).toThrowError(/Rule 1: invalid regex in match\.valuePattern/);
+      ).toThrowError(/Rule 1: invalid match\.valuePattern/);
+    });
+  });
+
+  describe("given an expression that does not parse", () => {
+    it("throws naming the rule", () => {
+      expect(() =>
+        compileMappingRules([
+          { kind: "expression", expression: "attrs |>", targetKey: "t" },
+        ]),
+      ).toThrowError(/Rule 1: invalid expression/);
+    });
+  });
+});
+
+describe("applyMappingRules with expression rules", () => {
+  const expr = (expression: string, targetKey = "langwatch.input"): MappingRule => ({
+    kind: "expression",
+    expression,
+    targetKey,
+  });
+
+  describe("given an expression reading attributes via attr()", () => {
+    it("writes the evaluated result to the target key", () => {
+      const compiled = compileMappingRules([
+        expr('attr("vendor.user_name") |> upper'),
+      ]);
+
+      const result = applyMappingRules(
+        { "vendor.user_name": "amsterdam" },
+        compiled,
+      );
+
+      expect(result.attributes["langwatch.input"]).toBe("AMSTERDAM");
+      expect(result.ruleResults[0]).toEqual({
+        ruleIndex: 0,
+        matchedKeys: [],
+        writes: [{ sourceKey: null, targetKey: "langwatch.input" }],
+        error: null,
+      });
+    });
+  });
+
+  describe("given pipes over structured attribute values", () => {
+    it("supports filter/map over arrays", () => {
+      const compiled = compileMappingRules([
+        expr('attr("vendor.messages") |> filter(.role == "user") |> map(.text)'),
+      ]);
+
+      const result = applyMappingRules(
+        {
+          "vendor.messages": [
+            { role: "user", text: "hi" },
+            { role: "model", text: "hello" },
+            { role: "user", text: "bye" },
+          ],
+        },
+        compiled,
+      );
+
+      expect(result.attributes["langwatch.input"]).toEqual(["hi", "bye"]);
+    });
+  });
+
+  describe("given the bag-style helpers", () => {
+    it("has() probes for a key", () => {
+      const compiled = compileMappingRules([
+        expr('has("vendor.a") && !has("vendor.b")', "probe"),
+      ]);
+
+      const result = applyMappingRules({ "vendor.a": 1 }, compiled);
+
+      expect(result.attributes.probe).toBe(true);
+    });
+
+    it("take() reads and consumes the source key", () => {
+      const compiled = compileMappingRules([
+        expr('take("vendor.output")', "langwatch.output"),
+      ]);
+
+      const result = applyMappingRules({ "vendor.output": "done" }, compiled);
+
+      expect(result.attributes).toEqual({ "langwatch.output": "done" });
+    });
+  });
+
+  describe("given an expression evaluating to null", () => {
+    it("writes nothing", () => {
+      const compiled = compileMappingRules([
+        expr('attr("missing.key") ?? null'),
+      ]);
+
+      const result = applyMappingRules({ other: 1 }, compiled);
+
+      expect(result.attributes).toEqual({ other: 1 });
+      expect(result.ruleResults[0]?.writes).toEqual([]);
+      expect(result.ruleResults[0]?.error).toBeNull();
+    });
+  });
+
+  describe("given an expression that fails at runtime on this span", () => {
+    it("records the error on the rule result instead of throwing", () => {
+      const compiled = compileMappingRules([
+        // filter over a non-array value → runtime type error
+        expr('attr("vendor.messages") |> filter(.role == "user")'),
+      ]);
+
+      const result = applyMappingRules(
+        { "vendor.messages": "not-an-array" },
+        compiled,
+      );
+
+      expect(result.ruleResults[0]?.error).toBeTruthy();
+      expect(result.attributes["langwatch.input"]).toBeUndefined();
     });
   });
 });

--- a/langwatch/src/server/app-layer/ops/__tests__/normalisation-preview.rules.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/normalisation-preview.rules.unit.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyMappingRules,
+  compileMappingRules,
+  InvalidMappingRuleError,
+  type MappingRule,
+} from "../normalisation-preview.rules";
+
+const rule = (overrides: {
+  key: string;
+  keyIsRegex?: boolean;
+  valuePattern?: string;
+  type?: "copy" | "move";
+  targetKey: string;
+}): MappingRule => ({
+  match: {
+    key: overrides.key,
+    keyIsRegex: overrides.keyIsRegex ?? false,
+    valuePattern: overrides.valuePattern,
+  },
+  action: {
+    type: overrides.type ?? "copy",
+    targetKey: overrides.targetKey,
+  },
+});
+
+describe("applyMappingRules", () => {
+  describe("given an exact-key copy rule", () => {
+    it("copies the value to the target key and keeps the source", () => {
+      const compiled = compileMappingRules([
+        rule({ key: "vendor.input", targetKey: "langwatch.input" }),
+      ]);
+
+      const result = applyMappingRules(
+        { "vendor.input": "hello", untouched: 1 },
+        compiled,
+      );
+
+      expect(result.attributes).toEqual({
+        "vendor.input": "hello",
+        "langwatch.input": "hello",
+        untouched: 1,
+      });
+      expect(result.ruleResults[0]).toEqual({
+        ruleIndex: 0,
+        matchedKeys: ["vendor.input"],
+        producedKey: "langwatch.input",
+      });
+    });
+
+    it("does not match when the key is absent", () => {
+      const compiled = compileMappingRules([
+        rule({ key: "vendor.input", targetKey: "langwatch.input" }),
+      ]);
+
+      const result = applyMappingRules({ other: "x" }, compiled);
+
+      expect(result.attributes).toEqual({ other: "x" });
+      expect(result.ruleResults[0]?.matchedKeys).toEqual([]);
+    });
+  });
+
+  describe("given a move rule", () => {
+    it("removes the source key after writing the target", () => {
+      const compiled = compileMappingRules([
+        rule({
+          key: "vendor.output",
+          targetKey: "langwatch.output",
+          type: "move",
+        }),
+      ]);
+
+      const result = applyMappingRules({ "vendor.output": "done" }, compiled);
+
+      expect(result.attributes).toEqual({ "langwatch.output": "done" });
+    });
+  });
+
+  describe("given a regex key rule", () => {
+    it("matches every attribute key the regex hits", () => {
+      const compiled = compileMappingRules([
+        rule({
+          key: "^gcp\\.vertex\\.agent\\.tool_",
+          keyIsRegex: true,
+          targetKey: "langwatch.input",
+        }),
+      ]);
+
+      const result = applyMappingRules(
+        {
+          "gcp.vertex.agent.tool_call_args": '{"city":"Amsterdam"}',
+          "gcp.vertex.agent.session_id": "s-1",
+        },
+        compiled,
+      );
+
+      expect(result.ruleResults[0]?.matchedKeys).toEqual([
+        "gcp.vertex.agent.tool_call_args",
+      ]);
+      expect(result.attributes["langwatch.input"]).toBe(
+        '{"city":"Amsterdam"}',
+      );
+    });
+  });
+
+  describe("given a value pattern with a capture group", () => {
+    it("extracts capture group 1 as the produced value", () => {
+      const compiled = compileMappingRules([
+        rule({
+          key: "vendor.blob",
+          valuePattern: '"model":"([^"]+)"',
+          targetKey: "gen_ai.request.model",
+        }),
+      ]);
+
+      const result = applyMappingRules(
+        { "vendor.blob": '{"model":"gemini-2.5-pro","other":1}' },
+        compiled,
+      );
+
+      expect(result.attributes["gen_ai.request.model"]).toBe("gemini-2.5-pro");
+    });
+
+    it("stringifies object values before matching", () => {
+      const compiled = compileMappingRules([
+        rule({
+          key: "vendor.blob",
+          valuePattern: '"model":"([^"]+)"',
+          targetKey: "gen_ai.request.model",
+        }),
+      ]);
+
+      const result = applyMappingRules(
+        { "vendor.blob": { model: "gemini-2.5-pro" } },
+        compiled,
+      );
+
+      expect(result.attributes["gen_ai.request.model"]).toBe("gemini-2.5-pro");
+    });
+
+    it("does not match when the pattern misses", () => {
+      const compiled = compileMappingRules([
+        rule({
+          key: "vendor.blob",
+          valuePattern: '"nope":"([^"]+)"',
+          targetKey: "gen_ai.request.model",
+        }),
+      ]);
+
+      const result = applyMappingRules({ "vendor.blob": "{}" }, compiled);
+
+      expect(result.attributes["gen_ai.request.model"]).toBeUndefined();
+      expect(result.ruleResults[0]?.matchedKeys).toEqual([]);
+    });
+  });
+
+  describe("given multiple rules", () => {
+    it("later rules see earlier rules' writes", () => {
+      const compiled = compileMappingRules([
+        rule({ key: "a", targetKey: "b", type: "move" }),
+        rule({ key: "b", targetKey: "c" }),
+      ]);
+
+      const result = applyMappingRules({ a: "v" }, compiled);
+
+      expect(result.attributes).toEqual({ b: "v", c: "v" });
+    });
+  });
+
+  describe("given the input attributes", () => {
+    it("never mutates them", () => {
+      const attrs = { "vendor.output": "done" };
+      const compiled = compileMappingRules([
+        rule({
+          key: "vendor.output",
+          targetKey: "langwatch.output",
+          type: "move",
+        }),
+      ]);
+
+      applyMappingRules(attrs, compiled);
+
+      expect(attrs).toEqual({ "vendor.output": "done" });
+    });
+  });
+});
+
+describe("compileMappingRules", () => {
+  describe("given an invalid key regex", () => {
+    it("throws naming the rule and field", () => {
+      expect(() =>
+        compileMappingRules([
+          rule({ key: "([", keyIsRegex: true, targetKey: "t" }),
+        ]),
+      ).toThrowError(InvalidMappingRuleError);
+      expect(() =>
+        compileMappingRules([
+          rule({ key: "([", keyIsRegex: true, targetKey: "t" }),
+        ]),
+      ).toThrowError(/Rule 1: invalid regex in match\.key/);
+    });
+  });
+
+  describe("given an invalid value pattern", () => {
+    it("throws naming the rule and field", () => {
+      expect(() =>
+        compileMappingRules([
+          rule({ key: "k", valuePattern: "([", targetKey: "t" }),
+        ]),
+      ).toThrowError(/Rule 1: invalid regex in match\.valuePattern/);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/__tests__/normalisation-preview.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/normalisation-preview.service.unit.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, it, vi } from "vitest";
 
+// A deterministic fake registry: one fold projection that tracks the last
+// langwatch.input attribute it sees on span-received events.
+vi.mock("~/server/event-sourcing/pipelineRegistry", () => ({
+  getDejaViewProjections: () => [
+    {
+      projectionName: "fakeTraceSummary",
+      eventTypes: ["lw.obs.trace.span_received"],
+      init: () => ({ inputText: null as string | null, spanCount: 0 }),
+      apply: (
+        state: { inputText: string | null; spanCount: number },
+        event: {
+          data: { span?: { attributes?: Array<{ key: string; value: { stringValue?: string | null } }> } };
+        },
+      ) => {
+        const attrs = event.data.span?.attributes ?? [];
+        const input = attrs.find((a) => a.key === "langwatch.input");
+        return {
+          spanCount: state.spanCount + 1,
+          inputText: input?.value?.stringValue ?? state.inputText,
+        };
+      },
+    },
+  ],
+  getProjectionMetadata: () => [
+    { projectionName: "fakeTraceSummary", aggregateType: "trace" },
+  ],
+}));
+
 import { SPAN_RECEIVED_EVENT_TYPE } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
 import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import {
@@ -197,6 +225,7 @@ describe("NormalisationPreviewService", () => {
 
   describe("given experimental mapping rules", () => {
     const vendorRule: MappingRule = {
+      kind: "map",
       match: {
         key: "vendor.payload",
         keyIsRegex: false,
@@ -230,6 +259,8 @@ describe("NormalisationPreviewService", () => {
         kind: "added",
         before: null,
         after: "Amsterdam",
+        sourceKey: "vendor.payload",
+        ruleIndex: 0,
       });
       expect(result.ruleStats).toEqual([
         { ruleIndex: 0, matchedSpanCount: 1 },
@@ -246,6 +277,7 @@ describe("NormalisationPreviewService", () => {
           tenantId: TENANT_ID,
           rules: [
             {
+              kind: "map",
               match: { key: "([", keyIsRegex: true },
               action: { type: "copy", targetKey: "t" },
             } as MappingRule,
@@ -253,6 +285,125 @@ describe("NormalisationPreviewService", () => {
         }),
       ).rejects.toThrowError(InvalidMappingRuleError);
       expect(repo.findEventsByAggregate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a specific event is selected", () => {
+    const twoSpanRows = () => [
+      spanEventRow(
+        spanReceivedPayload([
+          { key: "vendor.payload", value: { stringValue: '{"city":"Amsterdam"}' } },
+        ]),
+        "ev-1",
+      ),
+      spanEventRow(
+        spanReceivedPayload([
+          { key: "vendor.payload", value: { stringValue: '{"city":"Utrecht"}' } },
+        ]),
+        "ev-2",
+      ),
+    ];
+    const cityRule: MappingRule = {
+      kind: "map",
+      match: {
+        key: "vendor.payload",
+        keyIsRegex: false,
+        valuePattern: '"city":"([^"]+)"',
+      },
+      action: { type: "copy", targetKey: "langwatch.input" },
+    };
+
+    it("returns only that event's span", async () => {
+      const repo = makeRepo(twoSpanRows());
+      const service = new NormalisationPreviewService(repo, null);
+
+      const result = await service.previewAggregate({
+        aggregateId: TRACE_ID,
+        tenantId: TENANT_ID,
+        rules: [],
+        eventId: "ev-2",
+      });
+
+      expect(result.spans).toHaveLength(1);
+      expect(result.spans[0]!.eventId).toBe("ev-2");
+      expect(result.spanEventsFound).toBe(2);
+    });
+
+    it("still counts rule matches across all events", async () => {
+      const repo = makeRepo(twoSpanRows());
+      const service = new NormalisationPreviewService(repo, null);
+
+      const result = await service.previewAggregate({
+        aggregateId: TRACE_ID,
+        tenantId: TENANT_ID,
+        rules: [cityRule],
+        eventId: "ev-1",
+      });
+
+      expect(result.spans).toHaveLength(1);
+      expect(result.ruleStats).toEqual([{ ruleIndex: 0, matchedSpanCount: 2 }]);
+    });
+  });
+
+  describe("given rules and projections folding this aggregate", () => {
+    const cityRule: MappingRule = {
+      kind: "map",
+      match: {
+        key: "vendor.payload",
+        keyIsRegex: false,
+        valuePattern: '"city":"([^"]+)"',
+      },
+      action: { type: "copy", targetKey: "langwatch.input" },
+    };
+
+    it("reports how the rules change each projection's state", async () => {
+      const repo = makeRepo([
+        spanEventRow(
+          spanReceivedPayload([
+            { key: "vendor.payload", value: { stringValue: '{"city":"Amsterdam"}' } },
+          ]),
+        ),
+      ]);
+      const service = new NormalisationPreviewService(repo, null);
+
+      const result = await service.previewAggregate({
+        aggregateId: TRACE_ID,
+        tenantId: TENANT_ID,
+        rules: [cityRule],
+      });
+
+      expect(result.projections).toHaveLength(1);
+      const impact = result.projections[0]!;
+      expect(impact.projectionName).toBe("fakeTraceSummary");
+      expect(impact.aggregateType).toBe("trace");
+      expect(impact.appliedEventCount).toBe(1);
+      expect(impact.changes).toContainEqual({
+        key: "inputText",
+        kind: "changed",
+        before: "null",
+        after: "Amsterdam",
+      });
+      // spanCount folds identically on both sides — not in the diff
+      expect(impact.changes.map((c) => c.key)).not.toContain("spanCount");
+    });
+
+    it("computes no projection impact when no rules are supplied", async () => {
+      const repo = makeRepo([
+        spanEventRow(
+          spanReceivedPayload([
+            { key: "gen_ai.request.model", value: { stringValue: "m" } },
+          ]),
+        ),
+      ]);
+      const service = new NormalisationPreviewService(repo, null);
+
+      const result = await service.previewAggregate({
+        aggregateId: TRACE_ID,
+        tenantId: TENANT_ID,
+        rules: [],
+      });
+
+      expect(result.projections).toEqual([]);
     });
   });
 

--- a/langwatch/src/server/app-layer/ops/__tests__/normalisation-preview.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/normalisation-preview.service.unit.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { SPAN_RECEIVED_EVENT_TYPE } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
+import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import {
+  InvalidMappingRuleError,
+  type MappingRule,
+} from "../normalisation-preview.rules";
+import {
+  diffAttributes,
+  NormalisationPreviewService,
+  type StoredSpansReader,
+} from "../normalisation-preview.service";
+import type {
+  EventExplorerRepository,
+  RawEventRow,
+} from "../repositories/event-explorer.repository";
+
+const TENANT_ID = "project-test-1";
+const TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+const SPAN_ID = "146d016273244006";
+
+/** Minimal valid OTLP span-received event payload. */
+const spanReceivedPayload = (attributes: Array<{ key: string; value: unknown }>) => ({
+  span: {
+    traceId: TRACE_ID,
+    spanId: SPAN_ID,
+    name: "generate_content",
+    kind: 1,
+    startTimeUnixNano: "1700000000000000000",
+    endTimeUnixNano: "1700000001000000000",
+    attributes,
+    events: [],
+    links: [],
+    status: { message: null, code: null },
+  },
+  resource: null,
+  instrumentationScope: { name: "test-scope", version: "1.2.3" },
+  piiRedactionLevel: "DISABLED",
+});
+
+const spanEventRow = (payload: unknown, eventId = "ev-1"): RawEventRow => ({
+  eventId,
+  eventType: SPAN_RECEIVED_EVENT_TYPE,
+  eventTimestamp: "1700000000000",
+  payload: JSON.stringify(payload),
+});
+
+function makeRepo(rows: RawEventRow[]): EventExplorerRepository {
+  return {
+    findAggregates: vi.fn().mockResolvedValue([]),
+    searchAggregates: vi.fn().mockResolvedValue([]),
+    findEventsByAggregate: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+function makeStoredSpans(spans: NormalizedSpan[]): StoredSpansReader {
+  return {
+    getNormalizedSpansByTraceId: vi.fn().mockResolvedValue(spans),
+  };
+}
+
+describe("NormalisationPreviewService", () => {
+  describe("given an aggregate with a stored span-received event", () => {
+    it("replays the span through the current canonicalisation code", async () => {
+      const repo = makeRepo([
+        spanEventRow(
+          spanReceivedPayload([
+            {
+              key: "gen_ai.request.model",
+              value: { stringValue: "gpt-5-mini" },
+            },
+            {
+              key: "gen_ai.usage.input_tokens",
+              value: { intValue: 42 },
+            },
+          ]),
+        ),
+      ]);
+      const service = new NormalisationPreviewService(repo, null);
+
+      const result = await service.previewAggregate({
+        aggregateId: TRACE_ID,
+        tenantId: TENANT_ID,
+        rules: [],
+      });
+
+      expect(result.spanEventsFound).toBe(1);
+      expect(result.spans).toHaveLength(1);
+      const span = result.spans[0]!;
+      expect(span.spanId).toBe(SPAN_ID);
+      expect(span.replayedAttributes["gen_ai.request.model"]).toBe(
+        "gpt-5-mini",
+      );
+      expect(span.appliedRules.length).toBeGreaterThan(0);
+      expect(span.storedDiff).toBeNull();
+      expect(span.rulesDiff).toBeNull();
+    });
+
+    it("ignores non-span events and counts unparseable span events", async () => {
+      const repo = makeRepo([
+        {
+          eventId: "ev-other",
+          eventType: "lw.obs.trace.topic_assigned",
+          eventTimestamp: "1700000000000",
+          payload: "{}",
+        },
+        spanEventRow({ nonsense: true }, "ev-bad"),
+        spanEventRow("not-json-at-all}{", "ev-worse"),
+        spanEventRow(
+          spanReceivedPayload([
+            { key: "gen_ai.request.model", value: { stringValue: "m" } },
+          ]),
+          "ev-good",
+        ),
+      ]);
+      const service = new NormalisationPreviewService(repo, null);
+
+      const result = await service.previewAggregate({
+        aggregateId: TRACE_ID,
+        tenantId: TENANT_ID,
+        rules: [],
+      });
+
+      expect(result.eventsScanned).toBe(4);
+      expect(result.spanEventsFound).toBe(3);
+      expect(result.skippedInvalidEvents).toBe(2);
+      expect(result.spans).toHaveLength(1);
+    });
+  });
+
+  describe("given stored spans are available", () => {
+    it("reports the drift between stored and replayed attributes", async () => {
+      const repo = makeRepo([
+        spanEventRow(
+          spanReceivedPayload([
+            {
+              key: "gen_ai.request.model",
+              value: { stringValue: "gpt-5-mini" },
+            },
+          ]),
+        ),
+      ]);
+      const stored = makeStoredSpans([
+        {
+          spanId: SPAN_ID,
+          spanAttributes: {
+            // Older build stored a different model value and an extra key
+            "gen_ai.request.model": "old-model",
+            "legacy.key": "still here",
+          },
+        } as unknown as NormalizedSpan,
+      ]);
+      const service = new NormalisationPreviewService(repo, stored);
+
+      const result = await service.previewAggregate({
+        aggregateId: TRACE_ID,
+        tenantId: TENANT_ID,
+        rules: [],
+      });
+
+      const diff = result.spans[0]!.storedDiff!;
+      expect(diff).toContainEqual({
+        key: "gen_ai.request.model",
+        kind: "changed",
+        before: "old-model",
+        after: "gpt-5-mini",
+      });
+      expect(diff.map((d) => d.key)).toContain("legacy.key");
+    });
+
+    it("continues without a diff when the stored-span fetch fails", async () => {
+      const repo = makeRepo([
+        spanEventRow(
+          spanReceivedPayload([
+            { key: "gen_ai.request.model", value: { stringValue: "m" } },
+          ]),
+        ),
+      ]);
+      const stored: StoredSpansReader = {
+        getNormalizedSpansByTraceId: vi
+          .fn()
+          .mockRejectedValue(new Error("clickhouse down")),
+      };
+      const service = new NormalisationPreviewService(repo, stored);
+
+      const result = await service.previewAggregate({
+        aggregateId: TRACE_ID,
+        tenantId: TENANT_ID,
+        rules: [],
+      });
+
+      expect(result.spans).toHaveLength(1);
+      expect(result.spans[0]!.storedDiff).toBeNull();
+    });
+  });
+
+  describe("given experimental mapping rules", () => {
+    const vendorRule: MappingRule = {
+      match: {
+        key: "vendor.payload",
+        keyIsRegex: false,
+        valuePattern: '"city":"([^"]+)"',
+      },
+      action: { type: "copy", targetKey: "langwatch.input" },
+    };
+
+    it("applies rules on top of the replayed attributes and reports the diff", async () => {
+      const repo = makeRepo([
+        spanEventRow(
+          spanReceivedPayload([
+            {
+              key: "vendor.payload",
+              value: { stringValue: '{"city":"Amsterdam"}' },
+            },
+          ]),
+        ),
+      ]);
+      const service = new NormalisationPreviewService(repo, null);
+
+      const result = await service.previewAggregate({
+        aggregateId: TRACE_ID,
+        tenantId: TENANT_ID,
+        rules: [vendorRule],
+      });
+
+      const rulesDiff = result.spans[0]!.rulesDiff!;
+      expect(rulesDiff).toContainEqual({
+        key: "langwatch.input",
+        kind: "added",
+        before: null,
+        after: "Amsterdam",
+      });
+      expect(result.ruleStats).toEqual([
+        { ruleIndex: 0, matchedSpanCount: 1 },
+      ]);
+    });
+
+    it("rejects the whole run on an invalid rule regex without touching storage", async () => {
+      const repo = makeRepo([]);
+      const service = new NormalisationPreviewService(repo, null);
+
+      await expect(
+        service.previewAggregate({
+          aggregateId: TRACE_ID,
+          tenantId: TENANT_ID,
+          rules: [
+            {
+              match: { key: "([", keyIsRegex: true },
+              action: { type: "copy", targetKey: "t" },
+            } as MappingRule,
+          ],
+        }),
+      ).rejects.toThrowError(InvalidMappingRuleError);
+      expect(repo.findEventsByAggregate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given an aggregate without span events", () => {
+    it("reports that there is nothing to replay", async () => {
+      const repo = makeRepo([
+        {
+          eventId: "ev-other",
+          eventType: "lw.obs.trace.topic_assigned",
+          eventTimestamp: "1700000000000",
+          payload: "{}",
+        },
+      ]);
+      const service = new NormalisationPreviewService(repo, null);
+
+      const result = await service.previewAggregate({
+        aggregateId: TRACE_ID,
+        tenantId: TENANT_ID,
+        rules: [],
+      });
+
+      expect(result.spans).toEqual([]);
+      expect(result.spanEventsFound).toBe(0);
+    });
+  });
+});
+
+describe("diffAttributes", () => {
+  describe("when maps are identical", () => {
+    it("returns an empty diff", () => {
+      expect(diffAttributes({ a: 1, b: "x" }, { a: 1, b: "x" })).toEqual([]);
+    });
+  });
+
+  describe("when keys are added, removed, and changed", () => {
+    it("classifies each entry", () => {
+      const diff = diffAttributes(
+        { removed: "gone", changed: "before" },
+        { changed: "after", added: "new" },
+      );
+
+      expect(diff).toEqual([
+        { key: "removed", kind: "removed", before: "gone", after: null },
+        { key: "changed", kind: "changed", before: "before", after: "after" },
+        { key: "added", kind: "added", before: null, after: "new" },
+      ]);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/normalisation-preview.rules.ts
+++ b/langwatch/src/server/app-layer/ops/normalisation-preview.rules.ts
@@ -1,0 +1,171 @@
+/**
+ * Experimental mapping rules for the Deja View normalisation preview.
+ *
+ * A rule matches span attributes by key (exact or regex), optionally
+ * extracts a piece of the value via a regex capture group, and writes the
+ * result to a target attribute key. Rules let operators prototype a new
+ * vendor mapping (e.g. "lift gcp.vertex.agent.llm_request contents into
+ * gen_ai.input.messages") against real stored events before writing a
+ * canonicalisation extractor. They run in-process, read-only, and only
+ * inside the preview — never against live ingestion.
+ *
+ * The shape is deliberately a discriminated block ("match" + "action") so
+ * richer action types (e.g. a sandboxed expression DSL) can be added
+ * later without breaking stored links or the UI builder.
+ */
+
+import { z } from "zod";
+
+/** Bounds keep admin-supplied regexes from turning into a foot-gun. */
+export const MAX_RULES = 25;
+const MAX_PATTERN_LENGTH = 512;
+const MAX_KEY_LENGTH = 512;
+/** Longest attribute-value prefix a value regex is executed against. */
+const MAX_VALUE_SCAN_LENGTH = 32_768;
+
+export const mappingRuleSchema = z.object({
+  match: z.object({
+    /** Attribute key to match — exact string, or a regex when keyIsRegex. */
+    key: z.string().min(1).max(MAX_KEY_LENGTH),
+    keyIsRegex: z.boolean().default(false),
+    /**
+     * Optional regex run against the (stringified) attribute value. When it
+     * has a capture group, group 1 becomes the produced value; otherwise the
+     * full match does. Without valuePattern the whole value is carried over.
+     */
+    valuePattern: z.string().max(MAX_PATTERN_LENGTH).optional(),
+  }),
+  action: z.object({
+    type: z.enum(["copy", "move"]),
+    /** Canonical key to write, e.g. gen_ai.input.messages. */
+    targetKey: z.string().min(1).max(MAX_KEY_LENGTH),
+  }),
+});
+
+export const mappingRulesSchema = z
+  .array(mappingRuleSchema)
+  .max(MAX_RULES)
+  .default([]);
+
+export type MappingRule = z.infer<typeof mappingRuleSchema>;
+
+export type MappingRuleResult = {
+  ruleIndex: number;
+  /** Attribute keys the rule matched, across the span it ran on. */
+  matchedKeys: string[];
+  producedKey: string | null;
+};
+
+export type ApplyMappingRulesResult = {
+  attributes: Record<string, unknown>;
+  ruleResults: MappingRuleResult[];
+};
+
+export class InvalidMappingRuleError extends Error {
+  constructor(
+    readonly ruleIndex: number,
+    readonly field: "match.key" | "match.valuePattern",
+    detail: string,
+  ) {
+    super(`Rule ${ruleIndex + 1}: invalid regex in ${field}: ${detail}`);
+    this.name = "InvalidMappingRuleError";
+  }
+}
+
+/**
+ * Compiles every regex in the rule set up front so an invalid pattern
+ * rejects the whole run with the offending rule named, instead of failing
+ * span-by-span halfway through.
+ */
+export function compileMappingRules(rules: MappingRule[]): CompiledRule[] {
+  return rules.map((rule, index) => {
+    let keyRegex: RegExp | null = null;
+    if (rule.match.keyIsRegex) {
+      try {
+        keyRegex = new RegExp(rule.match.key);
+      } catch (err) {
+        throw new InvalidMappingRuleError(index, "match.key", String(err));
+      }
+    }
+
+    let valueRegex: RegExp | null = null;
+    if (rule.match.valuePattern !== undefined) {
+      try {
+        valueRegex = new RegExp(rule.match.valuePattern);
+      } catch (err) {
+        throw new InvalidMappingRuleError(
+          index,
+          "match.valuePattern",
+          String(err),
+        );
+      }
+    }
+
+    return { rule, index, keyRegex, valueRegex };
+  });
+}
+
+export type CompiledRule = {
+  rule: MappingRule;
+  index: number;
+  keyRegex: RegExp | null;
+  valueRegex: RegExp | null;
+};
+
+const stringifyValue = (value: unknown): string | null => {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Applies compiled rules to one span's attributes. Pure — returns a new
+ * attribute map; the input is never mutated. Rules run in order; later
+ * rules see the writes (and moves) of earlier ones.
+ */
+export function applyMappingRules(
+  attributes: Record<string, unknown>,
+  compiledRules: CompiledRule[],
+): ApplyMappingRulesResult {
+  const out: Record<string, unknown> = { ...attributes };
+  const ruleResults: MappingRuleResult[] = [];
+
+  for (const { rule, index, keyRegex, valueRegex } of compiledRules) {
+    const matchedKeys: string[] = [];
+    let producedKey: string | null = null;
+
+    const candidateKeys = keyRegex
+      ? Object.keys(out).filter((k) => keyRegex.test(k))
+      : rule.match.key in out
+        ? [rule.match.key]
+        : [];
+
+    for (const key of candidateKeys) {
+      const rawValue = out[key];
+      let produced: unknown = rawValue;
+
+      if (valueRegex) {
+        const asString = stringifyValue(rawValue);
+        if (asString === null) continue;
+        const scanned = asString.slice(0, MAX_VALUE_SCAN_LENGTH);
+        const match = valueRegex.exec(scanned);
+        if (!match) continue;
+        produced = match[1] ?? match[0];
+      }
+
+      matchedKeys.push(key);
+      out[rule.action.targetKey] = produced;
+      producedKey = rule.action.targetKey;
+      if (rule.action.type === "move" && key !== rule.action.targetKey) {
+        delete out[key];
+      }
+    }
+
+    ruleResults.push({ ruleIndex: index, matchedKeys, producedKey });
+  }
+
+  return { attributes: out, ruleResults };
+}

--- a/langwatch/src/server/app-layer/ops/normalisation-preview.rules.ts
+++ b/langwatch/src/server/app-layer/ops/normalisation-preview.rules.ts
@@ -1,29 +1,40 @@
 /**
  * Experimental mapping rules for the Deja View normalisation preview.
  *
- * A rule matches span attributes by key (exact or regex), optionally
- * extracts a piece of the value via a regex capture group, and writes the
- * result to a target attribute key. Rules let operators prototype a new
- * vendor mapping (e.g. "lift gcp.vertex.agent.llm_request contents into
- * gen_ai.input.messages") against real stored events before writing a
- * canonicalisation extractor. They run in-process, read-only, and only
- * inside the preview — never against live ingestion.
+ * Two rule kinds, both writing to a target attribute key:
+ * - "map": match span attributes by key (exact or regex), optionally
+ *   extract a piece of the value via a regex capture group, copy/move it.
+ * - "expression": a bonsai expression (https://github.com/danfry1/bonsai-js
+ *   — safe, sandboxed, no arbitrary JS) evaluated against the span's
+ *   canonical attributes. `attr("dotted.key")` reads an attribute; the
+ *   whole attribute map is also available as `attrs` for non-dotted
+ *   access. Pipes + the strings/arrays/math/types stdlib are enabled.
  *
- * The shape is deliberately a discriminated block ("match" + "action") so
- * richer action types (e.g. a sandboxed expression DSL) can be added
- * later without breaking stored links or the UI builder.
+ * Rules let operators prototype a new vendor mapping against real stored
+ * events before writing a canonicalisation extractor. They run
+ * in-process, read-only, and only inside the preview — never against
+ * live ingestion. Expression rules are the intended long-term direction
+ * (eventually all remapping could be authored this way); map rules are
+ * the quick regex path.
  */
 
+import { bonsai } from "bonsai-js";
+import { arrays, math, strings, types } from "bonsai-js/stdlib";
 import { z } from "zod";
 
-/** Bounds keep admin-supplied regexes from turning into a foot-gun. */
+/** Bounds keep admin-supplied patterns/expressions from becoming a foot-gun. */
 export const MAX_RULES = 25;
 const MAX_PATTERN_LENGTH = 512;
 const MAX_KEY_LENGTH = 512;
+const MAX_EXPRESSION_LENGTH = 4_000;
 /** Longest attribute-value prefix a value regex is executed against. */
 const MAX_VALUE_SCAN_LENGTH = 32_768;
+const EXPRESSION_TIMEOUT_MS = 50;
 
-export const mappingRuleSchema = z.object({
+const targetKeySchema = z.string().min(1).max(MAX_KEY_LENGTH);
+
+export const mapRuleSchema = z.object({
+  kind: z.literal("map"),
   match: z.object({
     /** Attribute key to match — exact string, or a regex when keyIsRegex. */
     key: z.string().min(1).max(MAX_KEY_LENGTH),
@@ -38,9 +49,21 @@ export const mappingRuleSchema = z.object({
   action: z.object({
     type: z.enum(["copy", "move"]),
     /** Canonical key to write, e.g. gen_ai.input.messages. */
-    targetKey: z.string().min(1).max(MAX_KEY_LENGTH),
+    targetKey: targetKeySchema,
   }),
 });
+
+export const expressionRuleSchema = z.object({
+  kind: z.literal("expression"),
+  /** bonsai expression; its result is written to targetKey (null/undefined = no write). */
+  expression: z.string().min(1).max(MAX_EXPRESSION_LENGTH),
+  targetKey: targetKeySchema,
+});
+
+export const mappingRuleSchema = z.discriminatedUnion("kind", [
+  mapRuleSchema,
+  expressionRuleSchema,
+]);
 
 export const mappingRulesSchema = z
   .array(mappingRuleSchema)
@@ -48,12 +71,22 @@ export const mappingRulesSchema = z
   .default([]);
 
 export type MappingRule = z.infer<typeof mappingRuleSchema>;
+export type MapRule = z.infer<typeof mapRuleSchema>;
+export type ExpressionRule = z.infer<typeof expressionRuleSchema>;
+
+export type MappingRuleWrite = {
+  /** Attribute key the value came from; null for expression rules. */
+  sourceKey: string | null;
+  targetKey: string;
+};
 
 export type MappingRuleResult = {
   ruleIndex: number;
   /** Attribute keys the rule matched, across the span it ran on. */
   matchedKeys: string[];
-  producedKey: string | null;
+  writes: MappingRuleWrite[];
+  /** Runtime evaluation error for this span (expression rules), if any. */
+  error: string | null;
 };
 
 export type ApplyMappingRulesResult = {
@@ -64,21 +97,76 @@ export type ApplyMappingRulesResult = {
 export class InvalidMappingRuleError extends Error {
   constructor(
     readonly ruleIndex: number,
-    readonly field: "match.key" | "match.valuePattern",
+    readonly field: "match.key" | "match.valuePattern" | "expression",
     detail: string,
   ) {
-    super(`Rule ${ruleIndex + 1}: invalid regex in ${field}: ${detail}`);
+    super(`Rule ${ruleIndex + 1}: invalid ${field}: ${detail}`);
     this.name = "InvalidMappingRuleError";
   }
 }
 
 /**
- * Compiles every regex in the rule set up front so an invalid pattern
- * rejects the whole run with the offending rule named, instead of failing
- * span-by-span halfway through.
+ * One sandboxed evaluator, shared for parse-validation and evaluation.
+ * `attr` resolves against a per-evaluation attribute map (set right
+ * before each evaluateSync call — evaluation is synchronous so there is
+ * no interleaving).
+ */
+let currentAttrs: Record<string, unknown> = {};
+const evaluator = bonsai({
+  timeout: EXPRESSION_TIMEOUT_MS,
+  maxDepth: 30,
+})
+  .use(strings)
+  .use(arrays)
+  .use(math)
+  .use(types);
+evaluator.addFunction("attr", (key: unknown) =>
+  typeof key === "string" ? currentAttrs[key] : undefined,
+);
+// Bag-style helpers mirroring the extractor AttributeBag API, so an
+// expression prototype behaves like real extractor code: `has` probes,
+// `take` reads AND consumes the source key (its removal shows up in the
+// rules diff, like a map rule with action "move").
+evaluator.addFunction("has", (key: unknown) =>
+  typeof key === "string" ? key in currentAttrs : false,
+);
+evaluator.addFunction("take", (key: unknown) => {
+  if (typeof key !== "string") return undefined;
+  const value = currentAttrs[key];
+  delete currentAttrs[key];
+  return value;
+});
+
+export type CompiledRule =
+  | {
+      kind: "map";
+      rule: MapRule;
+      index: number;
+      keyRegex: RegExp | null;
+      valueRegex: RegExp | null;
+    }
+  | { kind: "expression"; rule: ExpressionRule; index: number };
+
+/**
+ * Compiles/validates every rule up front so an invalid regex or
+ * unparseable expression rejects the whole run with the offending rule
+ * named, instead of failing span-by-span halfway through.
  */
 export function compileMappingRules(rules: MappingRule[]): CompiledRule[] {
-  return rules.map((rule, index) => {
+  return rules.map((rule, index): CompiledRule => {
+    if (rule.kind === "expression") {
+      const validation = evaluator.validate(rule.expression);
+      if (!validation.valid) {
+        const first = validation.errors[0];
+        throw new InvalidMappingRuleError(
+          index,
+          "expression",
+          first?.message ?? "expression does not parse",
+        );
+      }
+      return { kind: "expression", rule, index };
+    }
+
     let keyRegex: RegExp | null = null;
     if (rule.match.keyIsRegex) {
       try {
@@ -101,16 +189,9 @@ export function compileMappingRules(rules: MappingRule[]): CompiledRule[] {
       }
     }
 
-    return { rule, index, keyRegex, valueRegex };
+    return { kind: "map", rule, index, keyRegex, valueRegex };
   });
 }
-
-export type CompiledRule = {
-  rule: MappingRule;
-  index: number;
-  keyRegex: RegExp | null;
-  valueRegex: RegExp | null;
-};
 
 const stringifyValue = (value: unknown): string | null => {
   if (typeof value === "string") return value;
@@ -124,7 +205,9 @@ const stringifyValue = (value: unknown): string | null => {
 /**
  * Applies compiled rules to one span's attributes. Pure — returns a new
  * attribute map; the input is never mutated. Rules run in order; later
- * rules see the writes (and moves) of earlier ones.
+ * rules see the writes (and moves) of earlier ones. Runtime expression
+ * failures are recorded per rule (a span's data may legitimately not
+ * fit), never thrown.
  */
 export function applyMappingRules(
   attributes: Record<string, unknown>,
@@ -133,39 +216,81 @@ export function applyMappingRules(
   const out: Record<string, unknown> = { ...attributes };
   const ruleResults: MappingRuleResult[] = [];
 
-  for (const { rule, index, keyRegex, valueRegex } of compiledRules) {
-    const matchedKeys: string[] = [];
-    let producedKey: string | null = null;
-
-    const candidateKeys = keyRegex
-      ? Object.keys(out).filter((k) => keyRegex.test(k))
-      : rule.match.key in out
-        ? [rule.match.key]
-        : [];
-
-    for (const key of candidateKeys) {
-      const rawValue = out[key];
-      let produced: unknown = rawValue;
-
-      if (valueRegex) {
-        const asString = stringifyValue(rawValue);
-        if (asString === null) continue;
-        const scanned = asString.slice(0, MAX_VALUE_SCAN_LENGTH);
-        const match = valueRegex.exec(scanned);
-        if (!match) continue;
-        produced = match[1] ?? match[0];
-      }
-
-      matchedKeys.push(key);
-      out[rule.action.targetKey] = produced;
-      producedKey = rule.action.targetKey;
-      if (rule.action.type === "move" && key !== rule.action.targetKey) {
-        delete out[key];
-      }
+  for (const compiled of compiledRules) {
+    if (compiled.kind === "expression") {
+      ruleResults.push(applyExpressionRule(out, compiled));
+    } else {
+      ruleResults.push(applyMapRule(out, compiled));
     }
-
-    ruleResults.push({ ruleIndex: index, matchedKeys, producedKey });
   }
 
   return { attributes: out, ruleResults };
+}
+
+function applyExpressionRule(
+  out: Record<string, unknown>,
+  compiled: Extract<CompiledRule, { kind: "expression" }>,
+): MappingRuleResult {
+  const { rule, index } = compiled;
+  try {
+    currentAttrs = out;
+    const value = evaluator.evaluateSync(rule.expression, { attrs: out });
+    if (value !== undefined && value !== null) {
+      out[rule.targetKey] = value;
+      return {
+        ruleIndex: index,
+        matchedKeys: [],
+        writes: [{ sourceKey: null, targetKey: rule.targetKey }],
+        error: null,
+      };
+    }
+    return { ruleIndex: index, matchedKeys: [], writes: [], error: null };
+  } catch (err) {
+    return {
+      ruleIndex: index,
+      matchedKeys: [],
+      writes: [],
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    currentAttrs = {};
+  }
+}
+
+function applyMapRule(
+  out: Record<string, unknown>,
+  compiled: Extract<CompiledRule, { kind: "map" }>,
+): MappingRuleResult {
+  const { rule, index, keyRegex, valueRegex } = compiled;
+  const matchedKeys: string[] = [];
+  const writes: MappingRuleWrite[] = [];
+
+  const candidateKeys = keyRegex
+    ? Object.keys(out).filter((k) => keyRegex.test(k))
+    : rule.match.key in out
+      ? [rule.match.key]
+      : [];
+
+  for (const key of candidateKeys) {
+    const rawValue = out[key];
+    let produced: unknown = rawValue;
+
+    if (valueRegex) {
+      const asString = stringifyValue(rawValue);
+      if (asString === null) continue;
+      const scanned = asString.slice(0, MAX_VALUE_SCAN_LENGTH);
+      const match = valueRegex.exec(scanned);
+      if (!match) continue;
+      produced = match[1] ?? match[0];
+    }
+
+    matchedKeys.push(key);
+    out[rule.action.targetKey] = produced;
+    writes.push({ sourceKey: key, targetKey: rule.action.targetKey });
+    if (rule.action.type === "move" && key !== rule.action.targetKey) {
+      delete out[key];
+    }
+  }
+
+  return { ruleIndex: index, matchedKeys, writes, error: null };
 }

--- a/langwatch/src/server/app-layer/ops/normalisation-preview.service.ts
+++ b/langwatch/src/server/app-layer/ops/normalisation-preview.service.ts
@@ -7,25 +7,45 @@
  * produces, side by side with what is stored. Canonicalisation runs
  * inside a map projection, so its output is frozen at ingest — Deja
  * View's fold-projection replay can't exercise it; this service closes
- * that gap. Optional experimental mapping rules run on top so operators
- * can prototype a vendor mapping before writing an extractor.
+ * that gap. Optional experimental mapping rules (regex blocks or bonsai
+ * expressions) run on top so operators can prototype a vendor mapping
+ * before writing an extractor.
+ *
+ * When rules are supplied, the preview also folds every Deja View
+ * projection that consumes this aggregate's events twice — once over the
+ * replayed (no rules) events and once with the rules applied — and
+ * reports the state diff, so a rule's downstream impact on projections
+ * is visible before it exists anywhere real. Rules apply across all span
+ * events for the fold: projections accumulate state over the whole event
+ * stream, so a per-event fold is not meaningful.
  *
  * Strictly read-only: nothing is stored, queued, or emitted.
  */
 
 import { CanonicalizeSpanAttributesService } from "~/server/app-layer/traces/canonicalisation";
 import { SpanNormalizationPipelineService } from "~/server/app-layer/traces/span-normalization.service";
+import {
+  getDejaViewProjections,
+  getProjectionMetadata,
+} from "~/server/event-sourcing/pipelineRegistry";
 import { SPAN_RECEIVED_EVENT_TYPE } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
-import { spanReceivedEventDataSchema } from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
+import {
+  type SpanReceivedEventData,
+  spanReceivedEventDataSchema,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
 import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import { createLogger } from "~/utils/logger/server";
 import {
   applyMappingRules,
+  type ApplyMappingRulesResult,
+  type CompiledRule,
   compileMappingRules,
   type MappingRule,
-  type MappingRuleResult,
 } from "./normalisation-preview.rules";
-import type { EventExplorerRepository } from "./repositories/event-explorer.repository";
+import type {
+  EventExplorerRepository,
+  RawEventRow,
+} from "./repositories/event-explorer.repository";
 
 const MAX_EVENTS = 500;
 
@@ -35,9 +55,17 @@ export type AttributeDiffEntry = {
   kind: "added" | "removed" | "changed";
   before: string | null;
   after: string | null;
+  /**
+   * For rule-produced entries: the attribute key the value came from
+   * (null for expression rules, which draw on the whole span) and the
+   * rule that wrote it. Absent on entries not produced by a rule.
+   */
+  sourceKey?: string | null;
+  ruleIndex?: number;
 };
 
 export type SpanNormalisationPreview = {
+  eventId: string;
   spanId: string;
   traceId: string;
   name: string;
@@ -56,12 +84,24 @@ export type SpanNormalisationPreview = {
    * replayed attributes. Null when no rules were supplied.
    */
   rulesDiff: AttributeDiffEntry[] | null;
+  /** Per-rule runtime errors on this span (expression rules). */
+  ruleErrors: Array<{ ruleIndex: number; error: string }>;
+};
+
+export type ProjectionImpact = {
+  projectionName: string;
+  aggregateType: string;
+  appliedEventCount: number;
+  /** Flattened state diff: fold(replayed events) vs fold(rules applied). */
+  changes: AttributeDiffEntry[];
 };
 
 export type NormalisationPreviewResult = {
   spans: SpanNormalisationPreview[];
-  /** Per-rule match statistics aggregated across all replayed spans. */
+  /** Per-rule match statistics aggregated across ALL replayed spans. */
   ruleStats: Array<{ ruleIndex: number; matchedSpanCount: number }>;
+  /** Rule impact on every projection folding this aggregate's events. */
+  projections: ProjectionImpact[];
   eventsScanned: number;
   spanEventsFound: number;
   skippedInvalidEvents: number;
@@ -79,6 +119,14 @@ export type StoredSpansReader = {
   }): Promise<NormalizedSpan[]>;
 };
 
+type ReplayedRow = {
+  row: RawEventRow;
+  data: SpanReceivedEventData;
+  span: NormalizedSpan;
+  appliedRules: string[];
+  ruleRun: ApplyMappingRulesResult | null;
+};
+
 export class NormalisationPreviewService {
   private readonly logger = createLogger("langwatch:ops:normalisation-preview");
   private readonly normalizationPipeline = new SpanNormalizationPipelineService(
@@ -94,9 +142,11 @@ export class NormalisationPreviewService {
     aggregateId: string;
     tenantId: string;
     rules: MappingRule[];
+    /** When set, only this event's span appears in `spans` (rules and projections still consider all events). */
+    eventId?: string;
   }): Promise<NormalisationPreviewResult> {
     // Compiles (and thereby validates) rules before any replay work so an
-    // invalid regex rejects the run as a whole.
+    // invalid regex or expression rejects the run as a whole.
     const compiledRules = compileMappingRules(params.rules);
 
     const rows = await this.repo.findEventsByAggregate({
@@ -105,68 +155,42 @@ export class NormalisationPreviewService {
       limit: MAX_EVENTS,
     });
 
-    const spanRows = rows.filter(
+    const spanRowCount = rows.filter(
       (row) => row.eventType === SPAN_RECEIVED_EVENT_TYPE,
+    ).length;
+
+    const { replayedRows, skippedInvalidEvents } = this.replayRows(
+      params.tenantId,
+      rows,
+      compiledRules,
     );
 
-    const spans: SpanNormalisationPreview[] = [];
+    const storedBySpanId = await this.fetchStoredSpans(params);
+
+    const spans = replayedRows
+      .filter(
+        (replayed) =>
+          params.eventId === undefined ||
+          replayed.row.eventId === params.eventId,
+      )
+      .map((replayed) => this.toSpanPreview(replayed, storedBySpanId));
+
     const ruleMatchedSpans = new Map<number, number>();
-    let skippedInvalidEvents = 0;
-
-    const storedByspanId = await this.fetchStoredSpans(params);
-
-    for (const row of spanRows) {
-      let payload: unknown;
-      try {
-        payload =
-          typeof row.payload === "string"
-            ? JSON.parse(row.payload)
-            : row.payload;
-      } catch {
-        skippedInvalidEvents++;
-        continue;
+    for (const replayed of replayedRows) {
+      for (const result of replayed.ruleRun?.ruleResults ?? []) {
+        if (result.matchedKeys.length > 0 || result.writes.length > 0) {
+          ruleMatchedSpans.set(
+            result.ruleIndex,
+            (ruleMatchedSpans.get(result.ruleIndex) ?? 0) + 1,
+          );
+        }
       }
-
-      const parsed = spanReceivedEventDataSchema.safeParse(payload);
-      if (!parsed.success) {
-        skippedInvalidEvents++;
-        this.logger.debug(
-          { eventId: row.eventId, aggregateId: params.aggregateId },
-          "Skipping span event whose payload does not parse as span-received data",
-        );
-        continue;
-      }
-
-      const { span, appliedRules } =
-        this.normalizationPipeline.normalizeSpanReceivedWithDiagnostics(
-          params.tenantId,
-          parsed.data.span,
-          parsed.data.resource,
-          parsed.data.instrumentationScope,
-        );
-
-      const stored = storedByspanId?.get(span.spanId) ?? null;
-      const storedDiff = stored
-        ? diffAttributes(stored.spanAttributes, span.spanAttributes)
-        : null;
-
-      let rulesDiff: AttributeDiffEntry[] | null = null;
-      if (compiledRules.length > 0) {
-        const ruleRun = applyMappingRules(span.spanAttributes, compiledRules);
-        rulesDiff = diffAttributes(span.spanAttributes, ruleRun.attributes);
-        countMatchedRules(ruleRun.ruleResults, ruleMatchedSpans);
-      }
-
-      spans.push({
-        spanId: span.spanId,
-        traceId: span.traceId,
-        name: span.name,
-        replayedAttributes: span.spanAttributes,
-        appliedRules,
-        storedDiff,
-        rulesDiff,
-      });
     }
+
+    const projections =
+      compiledRules.length > 0
+        ? this.computeProjectionImpact(params, rows, replayedRows)
+        : [];
 
     return {
       spans,
@@ -174,10 +198,194 @@ export class NormalisationPreviewService {
         ruleIndex,
         matchedSpanCount: ruleMatchedSpans.get(ruleIndex) ?? 0,
       })),
+      projections,
       eventsScanned: rows.length,
-      spanEventsFound: spanRows.length,
+      spanEventsFound: spanRowCount,
       skippedInvalidEvents,
     };
+  }
+
+  private replayRows(
+    tenantId: string,
+    rows: RawEventRow[],
+    compiledRules: CompiledRule[],
+  ): { replayedRows: ReplayedRow[]; skippedInvalidEvents: number } {
+    const replayedRows: ReplayedRow[] = [];
+    let skippedInvalidEvents = 0;
+
+    for (const row of rows) {
+      if (row.eventType !== SPAN_RECEIVED_EVENT_TYPE) continue;
+
+      const payload = parseJsonPayload(row.payload);
+      const parsed = spanReceivedEventDataSchema.safeParse(payload);
+      if (!parsed.success) {
+        skippedInvalidEvents++;
+        this.logger.debug(
+          { eventId: row.eventId },
+          "Skipping span event whose payload does not parse as span-received data",
+        );
+        continue;
+      }
+
+      const { span, appliedRules } =
+        this.normalizationPipeline.normalizeSpanReceivedWithDiagnostics(
+          tenantId,
+          parsed.data.span,
+          parsed.data.resource,
+          parsed.data.instrumentationScope,
+        );
+
+      replayedRows.push({
+        row,
+        data: parsed.data,
+        span,
+        appliedRules,
+        ruleRun:
+          compiledRules.length > 0
+            ? applyMappingRules(span.spanAttributes, compiledRules)
+            : null,
+      });
+    }
+
+    return { replayedRows, skippedInvalidEvents };
+  }
+
+  private toSpanPreview(
+    replayed: ReplayedRow,
+    storedBySpanId: Map<string, NormalizedSpan> | null,
+  ): SpanNormalisationPreview {
+    const { row, span, appliedRules, ruleRun } = replayed;
+
+    const stored = storedBySpanId?.get(span.spanId) ?? null;
+    const storedDiff = stored
+      ? diffAttributes(stored.spanAttributes, span.spanAttributes)
+      : null;
+
+    let rulesDiff: AttributeDiffEntry[] | null = null;
+    const ruleErrors: Array<{ ruleIndex: number; error: string }> = [];
+    if (ruleRun) {
+      // Annotate rule-produced entries with the source key + rule that
+      // wrote them (last write to a target wins, matching apply order).
+      const writeByTarget = new Map<
+        string,
+        { sourceKey: string | null; ruleIndex: number }
+      >();
+      for (const result of ruleRun.ruleResults) {
+        for (const write of result.writes) {
+          writeByTarget.set(write.targetKey, {
+            sourceKey: write.sourceKey,
+            ruleIndex: result.ruleIndex,
+          });
+        }
+        if (result.error !== null) {
+          ruleErrors.push({ ruleIndex: result.ruleIndex, error: result.error });
+        }
+      }
+      rulesDiff = diffAttributes(span.spanAttributes, ruleRun.attributes).map(
+        (entry) => {
+          const write = writeByTarget.get(entry.key);
+          return write ? { ...entry, ...write } : entry;
+        },
+      );
+    }
+
+    return {
+      eventId: row.eventId,
+      spanId: span.spanId,
+      traceId: span.traceId,
+      name: span.name,
+      replayedAttributes: span.spanAttributes,
+      appliedRules,
+      storedDiff,
+      rulesDiff,
+      ruleErrors,
+    };
+  }
+
+  /**
+   * Folds every Deja View projection that consumes this aggregate's event
+   * types twice: over the replayed events (no rules) and over the events
+   * with rules applied, then diffs the flattened states. Both sides carry
+   * the replayed canonical attributes re-encoded into the event payload,
+   * so the round-trip distortion cancels out and the diff is purely the
+   * rules' effect.
+   */
+  private computeProjectionImpact(
+    params: { aggregateId: string; tenantId: string },
+    rows: RawEventRow[],
+    replayedRows: ReplayedRow[],
+  ): ProjectionImpact[] {
+    const replayedByEventId = new Map(
+      replayedRows.map((r) => [r.row.eventId, r]),
+    );
+    const eventTypesInAggregate = new Set(rows.map((r) => r.eventType));
+
+    const aggregateTypeByProjection = new Map(
+      getProjectionMetadata().map((p) => [p.projectionName, p.aggregateType]),
+    );
+
+    const impacts: ProjectionImpact[] = [];
+    for (const projection of getDejaViewProjections()) {
+      if (!projection.eventTypes.some((t) => eventTypesInAggregate.has(t))) {
+        continue;
+      }
+      const aggregateType =
+        aggregateTypeByProjection.get(projection.projectionName) ?? "";
+
+      let before = projection.init();
+      let after = projection.init();
+      let appliedEventCount = 0;
+
+      for (const row of rows) {
+        if (!projection.eventTypes.includes(row.eventType)) continue;
+
+        const replayed = replayedByEventId.get(row.eventId);
+        const baselineData = replayed
+          ? withSpanAttributes(replayed.data, replayed.span.spanAttributes)
+          : parseJsonPayload(row.payload);
+        const rulesData =
+          replayed?.ruleRun !== null && replayed?.ruleRun !== undefined
+            ? withSpanAttributes(replayed.data, replayed.ruleRun.attributes)
+            : baselineData;
+
+        const timestampMs = parseInt(row.eventTimestamp, 10);
+        const makeEvent = (data: unknown) => ({
+          id: row.eventId,
+          aggregateId: params.aggregateId,
+          aggregateType,
+          tenantId: params.tenantId,
+          createdAt: timestampMs,
+          occurredAt: timestampMs,
+          type: row.eventType,
+          version: "",
+          data,
+        });
+
+        try {
+          before = projection.apply(before, makeEvent(baselineData));
+          after = projection.apply(after, makeEvent(rulesData));
+          appliedEventCount++;
+        } catch (err) {
+          this.logger.debug(
+            {
+              error: err,
+              eventId: row.eventId,
+              projectionName: projection.projectionName,
+            },
+            "Skipping event that failed to apply during projection impact computation",
+          );
+        }
+      }
+
+      impacts.push({
+        projectionName: projection.projectionName,
+        aggregateType,
+        appliedEventCount,
+        changes: diffAttributes(flattenState(before), flattenState(after)),
+      });
+    }
+
+    return impacts;
   }
 
   /**
@@ -206,19 +414,94 @@ export class NormalisationPreviewService {
   }
 }
 
-const countMatchedRules = (
-  ruleResults: MappingRuleResult[],
-  ruleMatchedSpans: Map<number, number>,
-): void => {
-  for (const result of ruleResults) {
-    if (result.matchedKeys.length > 0) {
-      ruleMatchedSpans.set(
-        result.ruleIndex,
-        (ruleMatchedSpans.get(result.ruleIndex) ?? 0) + 1,
-      );
-    }
+const parseJsonPayload = (payload: unknown): unknown => {
+  if (typeof payload !== "string") return payload;
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return {};
   }
 };
+
+/**
+ * Rebuilds a span-received event payload with the span's attributes
+ * replaced by `attributes` (re-encoded as OTLP key-values). Everything
+ * else on the payload is preserved.
+ */
+const withSpanAttributes = (
+  data: SpanReceivedEventData,
+  attributes: Record<string, unknown>,
+): unknown => ({
+  ...data,
+  span: {
+    ...data.span,
+    attributes: Object.entries(attributes)
+      .map(([key, value]) => ({ key, value: encodeOtlpValue(value) }))
+      .filter((kv) => kv.value !== null),
+  },
+});
+
+const encodeOtlpValue = (
+  value: unknown,
+): Record<string, unknown> | null => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return { stringValue: value };
+  if (typeof value === "boolean") return { boolValue: value };
+  if (typeof value === "number") {
+    return Number.isInteger(value) && Number.isSafeInteger(value)
+      ? { intValue: value }
+      : { doubleValue: value };
+  }
+  try {
+    const s = JSON.stringify(value);
+    return typeof s === "string" ? { stringValue: s } : null;
+  } catch {
+    return null;
+  }
+};
+
+const MAX_FLATTEN_DEPTH = 8;
+const MAX_FLATTEN_KEYS = 2_000;
+
+/**
+ * Flattens arbitrary projection state into dotted-path leaves so two
+ * states can be diffed with the same table the attribute diffs use.
+ */
+export function flattenState(state: unknown): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const walk = (value: unknown, path: string, depth: number): void => {
+    if (Object.keys(out).length >= MAX_FLATTEN_KEYS) return;
+    if (
+      value === null ||
+      typeof value !== "object" ||
+      depth >= MAX_FLATTEN_DEPTH
+    ) {
+      out[path.length > 0 ? path : "(root)"] =
+        value !== null && typeof value === "object"
+          ? JSON.stringify(value)
+          : value;
+      return;
+    }
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        out[path.length > 0 ? path : "(root)"] = "[]";
+        return;
+      }
+      value.forEach((item, i) => walk(item, `${path}[${i}]`, depth + 1));
+      return;
+    }
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) {
+      out[path.length > 0 ? path : "(root)"] = "{}";
+      return;
+    }
+    for (const [key, item] of entries) {
+      walk(item, path.length > 0 ? `${path}.${key}` : key, depth + 1);
+    }
+  };
+  walk(state, "", 0);
+  return out;
+}
 
 const MAX_DIFF_VALUE_LENGTH = 2_000;
 

--- a/langwatch/src/server/app-layer/ops/normalisation-preview.service.ts
+++ b/langwatch/src/server/app-layer/ops/normalisation-preview.service.ts
@@ -1,0 +1,275 @@
+/**
+ * Deja View normalisation preview.
+ *
+ * Replays an aggregate's stored span-received events through the CURRENT
+ * span-normalisation pipeline (the same code the spanStorage map
+ * projection runs at ingest time) and reports what today's build
+ * produces, side by side with what is stored. Canonicalisation runs
+ * inside a map projection, so its output is frozen at ingest — Deja
+ * View's fold-projection replay can't exercise it; this service closes
+ * that gap. Optional experimental mapping rules run on top so operators
+ * can prototype a vendor mapping before writing an extractor.
+ *
+ * Strictly read-only: nothing is stored, queued, or emitted.
+ */
+
+import { CanonicalizeSpanAttributesService } from "~/server/app-layer/traces/canonicalisation";
+import { SpanNormalizationPipelineService } from "~/server/app-layer/traces/span-normalization.service";
+import { SPAN_RECEIVED_EVENT_TYPE } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
+import { spanReceivedEventDataSchema } from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
+import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import { createLogger } from "~/utils/logger/server";
+import {
+  applyMappingRules,
+  compileMappingRules,
+  type MappingRule,
+  type MappingRuleResult,
+} from "./normalisation-preview.rules";
+import type { EventExplorerRepository } from "./repositories/event-explorer.repository";
+
+const MAX_EVENTS = 500;
+
+/** Attribute-level difference between two attribute maps. */
+export type AttributeDiffEntry = {
+  key: string;
+  kind: "added" | "removed" | "changed";
+  before: string | null;
+  after: string | null;
+};
+
+export type SpanNormalisationPreview = {
+  spanId: string;
+  traceId: string;
+  name: string;
+  /** Attributes the current build produces from the raw event. */
+  replayedAttributes: Record<string, unknown>;
+  /** Canonicalisation rules that fired during the replay. */
+  appliedRules: string[];
+  /**
+   * Diff of stored (ingest-time build) vs replayed (current build)
+   * attributes. Empty when the current build reproduces storage exactly.
+   * Null when the stored span could not be found for comparison.
+   */
+  storedDiff: AttributeDiffEntry[] | null;
+  /**
+   * Diff introduced by the experimental mapping rules, relative to the
+   * replayed attributes. Null when no rules were supplied.
+   */
+  rulesDiff: AttributeDiffEntry[] | null;
+};
+
+export type NormalisationPreviewResult = {
+  spans: SpanNormalisationPreview[];
+  /** Per-rule match statistics aggregated across all replayed spans. */
+  ruleStats: Array<{ ruleIndex: number; matchedSpanCount: number }>;
+  eventsScanned: number;
+  spanEventsFound: number;
+  skippedInvalidEvents: number;
+};
+
+/**
+ * The slice of SpanStorageService the preview needs to fetch stored spans
+ * for the drift diff. Structural so tests can stub it and environments
+ * without span storage can omit it (storedDiff is null then).
+ */
+export type StoredSpansReader = {
+  getNormalizedSpansByTraceId(params: {
+    tenantId: string;
+    traceId: string;
+  }): Promise<NormalizedSpan[]>;
+};
+
+export class NormalisationPreviewService {
+  private readonly logger = createLogger("langwatch:ops:normalisation-preview");
+  private readonly normalizationPipeline = new SpanNormalizationPipelineService(
+    new CanonicalizeSpanAttributesService(),
+  );
+
+  constructor(
+    private readonly repo: EventExplorerRepository,
+    private readonly storedSpans: StoredSpansReader | null,
+  ) {}
+
+  async previewAggregate(params: {
+    aggregateId: string;
+    tenantId: string;
+    rules: MappingRule[];
+  }): Promise<NormalisationPreviewResult> {
+    // Compiles (and thereby validates) rules before any replay work so an
+    // invalid regex rejects the run as a whole.
+    const compiledRules = compileMappingRules(params.rules);
+
+    const rows = await this.repo.findEventsByAggregate({
+      aggregateId: params.aggregateId,
+      tenantId: params.tenantId,
+      limit: MAX_EVENTS,
+    });
+
+    const spanRows = rows.filter(
+      (row) => row.eventType === SPAN_RECEIVED_EVENT_TYPE,
+    );
+
+    const spans: SpanNormalisationPreview[] = [];
+    const ruleMatchedSpans = new Map<number, number>();
+    let skippedInvalidEvents = 0;
+
+    const storedByspanId = await this.fetchStoredSpans(params);
+
+    for (const row of spanRows) {
+      let payload: unknown;
+      try {
+        payload =
+          typeof row.payload === "string"
+            ? JSON.parse(row.payload)
+            : row.payload;
+      } catch {
+        skippedInvalidEvents++;
+        continue;
+      }
+
+      const parsed = spanReceivedEventDataSchema.safeParse(payload);
+      if (!parsed.success) {
+        skippedInvalidEvents++;
+        this.logger.debug(
+          { eventId: row.eventId, aggregateId: params.aggregateId },
+          "Skipping span event whose payload does not parse as span-received data",
+        );
+        continue;
+      }
+
+      const { span, appliedRules } =
+        this.normalizationPipeline.normalizeSpanReceivedWithDiagnostics(
+          params.tenantId,
+          parsed.data.span,
+          parsed.data.resource,
+          parsed.data.instrumentationScope,
+        );
+
+      const stored = storedByspanId?.get(span.spanId) ?? null;
+      const storedDiff = stored
+        ? diffAttributes(stored.spanAttributes, span.spanAttributes)
+        : null;
+
+      let rulesDiff: AttributeDiffEntry[] | null = null;
+      if (compiledRules.length > 0) {
+        const ruleRun = applyMappingRules(span.spanAttributes, compiledRules);
+        rulesDiff = diffAttributes(span.spanAttributes, ruleRun.attributes);
+        countMatchedRules(ruleRun.ruleResults, ruleMatchedSpans);
+      }
+
+      spans.push({
+        spanId: span.spanId,
+        traceId: span.traceId,
+        name: span.name,
+        replayedAttributes: span.spanAttributes,
+        appliedRules,
+        storedDiff,
+        rulesDiff,
+      });
+    }
+
+    return {
+      spans,
+      ruleStats: params.rules.map((_, ruleIndex) => ({
+        ruleIndex,
+        matchedSpanCount: ruleMatchedSpans.get(ruleIndex) ?? 0,
+      })),
+      eventsScanned: rows.length,
+      spanEventsFound: spanRows.length,
+      skippedInvalidEvents,
+    };
+  }
+
+  /**
+   * Stored spans are keyed by spanId for the drift diff. Fetch failures
+   * degrade to "no comparison" (storedDiff: null) — the replay itself is
+   * still valuable when span storage is unreachable.
+   */
+  private async fetchStoredSpans(params: {
+    aggregateId: string;
+    tenantId: string;
+  }): Promise<Map<string, NormalizedSpan> | null> {
+    if (!this.storedSpans) return null;
+    try {
+      const stored = await this.storedSpans.getNormalizedSpansByTraceId({
+        tenantId: params.tenantId,
+        traceId: params.aggregateId,
+      });
+      return new Map(stored.map((s) => [s.spanId, s]));
+    } catch (error) {
+      this.logger.warn(
+        { error, aggregateId: params.aggregateId },
+        "Could not load stored spans for comparison; preview continues without storedDiff",
+      );
+      return null;
+    }
+  }
+}
+
+const countMatchedRules = (
+  ruleResults: MappingRuleResult[],
+  ruleMatchedSpans: Map<number, number>,
+): void => {
+  for (const result of ruleResults) {
+    if (result.matchedKeys.length > 0) {
+      ruleMatchedSpans.set(
+        result.ruleIndex,
+        (ruleMatchedSpans.get(result.ruleIndex) ?? 0) + 1,
+      );
+    }
+  }
+};
+
+const MAX_DIFF_VALUE_LENGTH = 2_000;
+
+const renderValue = (value: unknown): string => {
+  const s = typeof value === "string" ? value : (JSON.stringify(value) ?? "");
+  return s.length > MAX_DIFF_VALUE_LENGTH
+    ? `${s.slice(0, MAX_DIFF_VALUE_LENGTH)}…`
+    : s;
+};
+
+/**
+ * Key-level diff of two attribute maps, values rendered as (truncated)
+ * strings for display. Order: removed, changed, added — grouped by key
+ * name within each kind for stable output.
+ */
+export function diffAttributes(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): AttributeDiffEntry[] {
+  const entries: AttributeDiffEntry[] = [];
+  const beforeKeys = new Set(Object.keys(before));
+  const afterKeys = new Set(Object.keys(after));
+
+  for (const key of [...beforeKeys].sort()) {
+    if (!afterKeys.has(key)) {
+      entries.push({
+        key,
+        kind: "removed",
+        before: renderValue(before[key]),
+        after: null,
+      });
+    }
+  }
+  for (const key of [...beforeKeys].sort()) {
+    if (afterKeys.has(key)) {
+      const beforeStr = renderValue(before[key]);
+      const afterStr = renderValue(after[key]);
+      if (beforeStr !== afterStr) {
+        entries.push({ key, kind: "changed", before: beforeStr, after: afterStr });
+      }
+    }
+  }
+  for (const key of [...afterKeys].sort()) {
+    if (!beforeKeys.has(key)) {
+      entries.push({
+        key,
+        kind: "added",
+        before: null,
+        after: renderValue(after[key]),
+      });
+    }
+  }
+  return entries;
+}

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -113,6 +113,7 @@ import { NullEvaluationRunRepository } from "./evaluations/repositories/evaluati
 import { MonitorService } from "./monitors/monitor.service";
 import { PrismaMonitorRepository } from "./monitors/repositories/monitor.prisma.repository";
 import { EventExplorerService } from "./ops/event-explorer.service";
+import { NormalisationPreviewService } from "./ops/normalisation-preview.service";
 import { getOpsMetricsCollector } from "./ops/metrics-collector";
 import { QueueService } from "./ops/queue.service";
 import { ReplayService } from "./ops/replay.service";
@@ -864,6 +865,10 @@ export function initializeDefaultApp(options?: {
   const ops = {
     queues: new QueueService(queueRepo),
     eventExplorer: new EventExplorerService(eventExplorerRepo),
+    normalisationPreview: new NormalisationPreviewService(
+      eventExplorerRepo,
+      spanStorage,
+    ),
     replay: new ReplayService(replayRepo),
     metricsCollector: redis
       ? getOpsMetricsCollector({ redis, queueRepo })
@@ -1066,6 +1071,10 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
       queues: new QueueService(new NullQueueRepository()),
       eventExplorer: new EventExplorerService(
         new NullEventExplorerRepository(),
+      ),
+      normalisationPreview: new NormalisationPreviewService(
+        new NullEventExplorerRepository(),
+        null,
       ),
       replay: new ReplayService(new NullReplayRepository()),
       metricsCollector: null,

--- a/langwatch/src/server/app-layer/traces/span-normalization.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-normalization.service.ts
@@ -36,6 +36,26 @@ export class SpanNormalizationPipelineService {
     otlpResource: OtlpResource | null,
     otlpInstrumentationScope: OtlpInstrumentationScope | null,
   ): NormalizedSpan {
+    return this.normalizeSpanReceivedWithDiagnostics(
+      tenantId,
+      otlpSpan,
+      otlpResource,
+      otlpInstrumentationScope,
+    ).span;
+  }
+
+  /**
+   * Same pipeline as normalizeSpanReceived, but also surfaces which
+   * canonicalisation rules fired. Applied rules are otherwise only
+   * emitted as telemetry — the Deja View normalisation preview needs
+   * them as data.
+   */
+  normalizeSpanReceivedWithDiagnostics(
+    tenantId: string,
+    otlpSpan: OtlpSpan,
+    otlpResource: OtlpResource | null,
+    otlpInstrumentationScope: OtlpInstrumentationScope | null,
+  ): { span: NormalizedSpan; appliedRules: string[] } {
     return this.tracer.withActiveSpan(
       "SpanNormalizationPipelineService.normalizeSpanReceived",
       {
@@ -78,7 +98,10 @@ export class SpanNormalizationPipelineService {
         normalizedSpan.spanAttributes = canonicalizedResult.attributes;
         normalizedSpan.events = canonicalizedResult.events;
 
-        return normalizedSpan;
+        return {
+          span: normalizedSpan,
+          appliedRules: canonicalizedResult.appliedRules,
+        };
       },
     );
   }
@@ -195,6 +218,7 @@ export class SpanNormalizationPipelineService {
   private canonicalizeSpanAttributes(normalizedSpan: NormalizedSpan): {
     attributes: NormalizedAttributes;
     events: NormalizedEvent[];
+    appliedRules: string[];
   } {
     const result = this.tracer.withActiveSpan(
       "SpanNormalizationPipelineService.canonicalizeSpanAttributes",
@@ -228,6 +252,7 @@ export class SpanNormalizationPipelineService {
     return {
       attributes: result.attributes,
       events: result.events,
+      appliedRules: result.appliedRules,
     };
   }
 }

--- a/specs/ops/dejaview-normalisation-preview.feature
+++ b/specs/ops/dejaview-normalisation-preview.feature
@@ -1,0 +1,55 @@
+Feature: Deja View normalisation preview
+  As a platform operator debugging span enrichment
+  I want to replay a trace's stored raw events through the current canonicalisation code
+  So that I can see what the running build would produce — and try extra mapping rules — without writing anything
+
+  # =========================================================================
+  # What this covers
+  # =========================================================================
+  #
+  # Span canonicalisation runs inside a map projection at ingest time, so
+  # its output is frozen into storage with whatever code was deployed then.
+  # Deja View can replay fold projections live, but not the span mapping.
+  # The normalisation preview closes that gap: it re-runs the span
+  # normalisation pipeline in-process over the stored raw span events of an
+  # aggregate and reports what today's code produces, side by side with
+  # what is stored. Operators can additionally supply experimental mapping
+  # rules (match an attribute key, optionally extract via regex, write to a
+  # target key) to prototype new vendor mappings before writing an
+  # extractor. Everything is read-only.
+
+  Background:
+    Given an operator with ops access viewing an aggregate in Deja View
+
+  Scenario: Replaying a trace shows what the current build produces
+    Given the aggregate has stored span-received events
+    When the operator runs the normalisation preview
+    Then each span shows the attributes the current code produces
+    And each span shows which canonicalisation rules fired
+
+  Scenario: Preview shows drift against what is stored
+    Given a span was ingested by an older build
+    And the current build canonicalises it differently
+    When the operator runs the normalisation preview
+    Then the span shows the attributes that changed between stored and replayed
+
+  Scenario: Experimental mapping rules are applied on top
+    Given the operator adds a mapping rule from a vendor attribute to a canonical key
+    When the operator runs the normalisation preview
+    Then the preview shows the additional attributes the rule produced
+    And the preview reports how many spans each rule matched
+
+  Scenario: An invalid regex in a rule fails the run with a clear error
+    Given the operator adds a mapping rule with an invalid regex
+    When the operator runs the normalisation preview
+    Then the run is rejected naming the offending rule
+    And no preview results are produced
+
+  Scenario: Nothing is written
+    When the operator runs the normalisation preview
+    Then stored spans, projections, and events are unchanged
+
+  Scenario: Aggregates without span events report clearly
+    Given the aggregate has no span-received events
+    When the operator runs the normalisation preview
+    Then the preview reports that there is nothing to replay

--- a/specs/ops/dejaview-normalisation-preview.feature
+++ b/specs/ops/dejaview-normalisation-preview.feature
@@ -83,7 +83,18 @@ Feature: Deja View normalisation preview
     Given the operator is writing an expression rule
     Then unparseable expressions are flagged as they are typed
     And completions suggest the selected event's attribute keys and available transforms
-    And example expressions can be inserted as starting points
+    And a generic reference snippet and insertable examples show how expressions work
+
+  Scenario: The playground evaluates free-form expressions live
+    Given the operator writes any expression in the playground
+    Then the result is shown as they type, without a server round-trip
+    And the expression evaluates against the selected event's attributes
+    And evaluation failures are shown in place
+
+  Scenario: Failing rules are highlighted where they are edited
+    Given an expression rule fails at runtime on some spans
+    When the preview runs
+    Then the failing rule's editor is highlighted with how many spans it failed on
 
   Scenario: Nothing is written
     When the operator runs the normalisation preview

--- a/specs/ops/dejaview-normalisation-preview.feature
+++ b/specs/ops/dejaview-normalisation-preview.feature
@@ -37,13 +37,53 @@ Feature: Deja View normalisation preview
     Given the operator adds a mapping rule from a vendor attribute to a canonical key
     When the operator runs the normalisation preview
     Then the preview shows the additional attributes the rule produced
+    And each produced attribute names the source key it came from
     And the preview reports how many spans each rule matched
 
-  Scenario: An invalid regex in a rule fails the run with a clear error
-    Given the operator adds a mapping rule with an invalid regex
+  Scenario: A single event can be previewed
+    Given the aggregate has several span-received events
+    When the operator selects one event and runs the preview
+    Then only that event's span is shown in the results
+    And the operator can step to the next event and preview it individually
+
+  Scenario: Rule building suggests known keys
+    Given the operator is adding a mapping rule
+    Then the source key suggests attribute keys present on the selected event
+    And the target key suggests known canonical attribute keys
+
+  Scenario: Rules show their impact on every projection
+    Given the operator adds a mapping rule
+    When the operator runs the normalisation preview
+    Then every projection that folds this aggregate's events is shown
+    And each projection shows how its state changes with the rules applied
+    # Rules apply across all span events when folding — projections
+    # accumulate state over the whole event stream, so a per-event
+    # projection fold is not meaningful.
+    And projections whose state is unaffected report no change
+
+  Scenario: Expression rules compute values over the span's attributes
+    Given the operator adds an expression rule reading an attribute and transforming it
+    When the operator runs the normalisation preview
+    Then the expression's result is written to the target key
+    And an expression can consume its source attribute like an extractor would
+
+  Scenario: An expression that fails on one span does not fail the run
+    Given an expression rule that only fits some spans' data
+    When the operator runs the normalisation preview
+    Then spans the expression fails on report the failure
+    And the remaining spans still show their results
+
+  Scenario: An invalid regex or unparseable expression fails the run with a clear error
+    Given the operator adds a mapping rule with an invalid regex or expression
     When the operator runs the normalisation preview
     Then the run is rejected naming the offending rule
     And no preview results are produced
+
+  Scenario: Expressions are edited with live assistance
+    Given the operator is writing an expression rule
+    Then unparseable expressions are flagged as they are typed
+    And completions suggest the selected event's attribute keys and available transforms
+    And example expressions can be inserted as starting points
 
   Scenario: Nothing is written
     When the operator runs the normalisation preview


### PR DESCRIPTION
## Problem

Span canonicalisation runs inside the `spanStorage` **map** projection, so its output is frozen into ClickHouse with whatever code was deployed at ingest time. Deja View replays **fold** projections with live code, but there was no way to see what the current build's canonicalisation would produce from stored raw events — which is exactly what you want when developing a new vendor mapping (e.g. the Vertex ADK extractor in #5773) or verifying a normalisation change against a customer's real trace.

## Change

**Backend** (`NormalisationPreviewService`, ops-gated, strictly read-only):
- Replays an aggregate's stored `span_received` events through the current `SpanNormalizationPipelineService` in-process; per span: replayed attributes, fired canonicalisation rules (`appliedRules` surfaced as data via `normalizeSpanReceivedWithDiagnostics`), a **stored-vs-replayed drift diff**, and a rules diff with the **source key named inline** on every rule-produced entry.
- **Per-event preview**: an optional `eventId` narrows the span results to one event while rule stats still cover the aggregate.
- **Projection impact**: when rules are supplied, every Deja View projection consuming this aggregate is folded twice — with vs without the rules — and the flattened state diff is returned. Rules apply across all span events for the fold (projections accumulate over the whole stream, so a per-event fold isn't meaningful).
- **Two rule kinds**:
  - *map*: match a key (exact/regex), optional value-regex capture extraction, copy/move to a target key.
  - *expression*: a [bonsai-js](https://github.com/danfry1/bonsai-js) expression (safe sandboxed DSL — MIT, zero deps, resource-limited, no arbitrary JS) evaluated against the span's canonical attributes, with `attr()` / `has()` / `take()` bag-style helpers mirroring the extractor `AttributeBag` API — `take` consumes its source like a real extractor. Compile errors reject the run naming the rule; runtime failures are reported per span.

**UI**: the Deja View "Normalisation preview" toggle now offers: an event selector (all / individual span events), map-rule blocks with source keys pre-populated from the selected event's attributes, an explicit exact/regex selector, target-key suggestions from known canonical fields, and **Monaco-edited expression rules** — custom `bonsai` language, live parse markers (same parser as the server), completions over the event's attribute keys + stdlib transforms, click-to-insert examples, and debounced auto-rerun after the first run for live feedback. Results show per-span cards (rule chips, inline `target ← source` annotations, per-span expression errors) and per-projection impact cards.

## Future direction

Expression rules are the intended long-term shape — remapping could eventually be authored entirely as bonsai expressions (context-aware/async functions and richer bag access are easy follow-ons). The map blocks stay as the quick regex path.

Spec: `specs/ops/dejaview-normalisation-preview.feature`

## Testing

- 31 unit tests (rules engine incl. expressions/bag helpers/runtime-error isolation; service incl. per-event filtering, projection impact via a mocked registry, drift diff, invalid-rule rejection)
- `src/server/app-layer/ops` + `src/server/app-layer/traces`: 1225 passed; `pnpm typecheck` clean
- Verified the ESM-only bonsai-js loads in the running Next.js dev server (tRPC ops router resolves normally)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only Deja View normalisation preview for replaying stored span events.
  * Preview current canonicalised attributes, applied rules, stored-versus-replayed differences, and projection impact.
  * Added configurable mapping and expression rules with validation, diagnostics, and live preview updates.
  * Added an expression playground with autocomplete, local evaluation, and inline error reporting.
* **Bug Fixes**
  * Improved compatibility when loading the expression language package in CommonJS environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->