### PR TITLE
fix(replay): unfreeze live processing and cut weeks off projection rebuilds

### DIFF
--- a/dev/docs/adr/015-projection-replay-coordination.md
+++ b/dev/docs/adr/015-projection-replay-coordination.md
@@ -114,6 +114,49 @@ After all projections complete, the service runs `OPTIMIZE TABLE {table}` (witho
 - The CLI package still exists for the TUI experience but contains no business logic — it delegates entirely to the framework service
 - `OPTIMIZE TABLE` is best-effort — if it fails, eventual consistency handles it
 
+## Amendment (2026-07-14): Per-batch pause in the optimized replay + bulk write/query fixes
+
+The optimized multi-projection path (`replayOptimized`) had drifted from this
+ADR in ways that made production replays take weeks while freezing live
+processing for the entire run:
+
+1. **Pause/drain scope.** `replayOptimized` paused ALL selected projections
+   and drained ALL discovered aggregates once, up front, and only unpaused
+   after the last batch — a full-run freeze, contradicting the "seconds per
+   batch" pause window above. It now pauses, drains (only the current batch's
+   aggregates), replays, and unpauses **per batch**, exactly like the
+   non-optimized path, with the unpause in a per-batch `finally` so a batch
+   failure can never leave projections frozen. The marker protocol
+   (pending/cutoff/done) already guarantees correctness across the unpaused
+   gaps between batches.
+
+2. **Map-projection bulk writes.** The replay `MapAccumulator` grouped
+   buffered records per AGGREGATE and sequentially awaited one
+   `store.bulkAppend` per group. For `spanStorage` the aggregate is a single
+   trace, so each trace became its own awaited ClickHouse INSERT
+   (`wait_for_async_insert: 1`, ~200ms each). Records are now flushed in
+   chunks (default 5000) per TENANT; `AppendStore.bulkAppend` takes a
+   tenant-scoped `BulkAppendContext` (no `aggregateId` — records carry what
+   stores need per row). The live `append()` path is unchanged.
+
+3. **Partition pruning.** `event_log` is `PARTITION BY
+   toYearWeek(EventOccurredAt)`, but the cutoff/load queries filtered only on
+   TenantId/AggregateId, scanning every partition (including S3 cold storage)
+   once per batch. Each batch now first computes the `EventOccurredAt`
+   min/max over ALL events of its aggregates (`getAggregateOccurredAtBounds`,
+   a cheap key-column read) and passes that range to the cutoff and load
+   queries. The bound is provably safe — every event those queries must see
+   existed when the bounds were computed; later appends fall after the cutoff
+   and are handled live. (Bounding by the replay's `since` would be unsafe:
+   folds rebuild from `init()` and need history predating `since`.)
+
+4. **Per-tenant I/O and progress cadence.** Cutoff and load queries now run
+   in parallel across tenants within a batch; replay-phase progress emits are
+   throttled (every 100 aggregates) instead of per aggregate; and the ops
+   replay lock (1h TTL) is refreshed at least once per batch
+   (`ReplayRepository.refreshLock`), so long runs no longer silently lose
+   status updates when the lock expires mid-run.
+
 ## References
 
 - Related ADRs: None (first event-sourcing operational tooling ADR)

--- a/dev/docs/adr/015-projection-replay-coordination.md
+++ b/dev/docs/adr/015-projection-replay-coordination.md
@@ -159,6 +159,12 @@ processing for the entire run:
 
 ## References
 
-- Related ADRs: None (first event-sourcing operational tooling ADR)
+- Related ADRs:
+  - [ADR-007: Event Sourcing Architecture](./007-event-sourcing-architecture.md) — the event-sourcing foundation this replay tooling operates on
+  - [ADR-021: Lean Fold Cache](./021-lean-fold-cache.md) — fold cache whose rebuilds are coordinated through this replay protocol
+  - [ADR-022: event_log as single source of truth](./022-event-log-source-of-truth.md) — the event log replays read from
+  - [ADR-024: Cold-path tiered storage](./024-cold-path-tiered-storage.md) — the S3 cold storage that the amendment's partition pruning avoids scanning
+  - [ADR-034: Event-Sourced Analytics Materialization](./034-event-sourced-analytics-materialization.md) — analytics projections rebuilt via this replay mechanism
+- Spec: `specs/event-sourcing/projection-replay.feature` — behavioural scenarios for the replay coordination this ADR decides
 - ClickHouse ReplacingMergeTree: https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replacingmergetree
 - BullMQ GroupQueue pause mechanism: internal `{event-sourcing/jobs}:gq:paused-jobs` set

--- a/langwatch/src/features/traces-v2/components/TraceTable/evalColumns.ts
+++ b/langwatch/src/features/traces-v2/components/TraceTable/evalColumns.ts
@@ -80,7 +80,11 @@ export function buildEvalColumnDef({
   field: EvalColumnField;
   evaluatorKey: string;
   label: string;
-}): ColumnDef<TraceListItem, ReturnType<typeof evalFieldValue>> {
+}): ColumnDef<TraceListItem, unknown> {
+  // TanStack's ColumnDef is invariant in TValue (function-typed props like
+  // aggregatedCell), so a concretely-typed def is not assignable to the
+  // ColumnDef<T, unknown> arrays lenses build. Erase the value type at this
+  // boundary once instead of casting at every push site.
   return evalCol.accessor(
     (row) =>
       evalFieldValue({ ev: latestEvalForKey({ row, evaluatorKey }), field }),
@@ -95,5 +99,5 @@ export function buildEvalColumnDef({
       maxSize: 320,
       enableSorting: false,
     },
-  );
+  ) as ColumnDef<TraceListItem, unknown>;
 }

--- a/langwatch/src/features/traces-v2/components/TraceTable/evalColumns.ts
+++ b/langwatch/src/features/traces-v2/components/TraceTable/evalColumns.ts
@@ -82,9 +82,10 @@ export function buildEvalColumnDef({
   label: string;
 }): ColumnDef<TraceListItem, unknown> {
   // TanStack's ColumnDef is invariant in TValue (function-typed props like
-  // aggregatedCell), so a concretely-typed def is not assignable to the
-  // ColumnDef<T, unknown> arrays lenses build. Erase the value type at this
-  // boundary once instead of casting at every push site.
+  // aggregatedCell), so a concretely-typed def is not assignable to
+  // useTraceLensColumns' defs array (Array<ColumnDef<TraceListItem, unknown>>).
+  // Erase the value type at this boundary once instead of casting at the
+  // push site.
   return evalCol.accessor(
     (row) =>
       evalFieldValue({ ev: latestEvalForKey({ row, evaluatorKey }), field }),

--- a/langwatch/src/server/app-layer/ops/__tests__/replay.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/replay.service.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { ReplayService } from "../replay.service";
+import { LOCK_REFRESH_INTERVAL_MS, ReplayService } from "../replay.service";
 import {
   IDLE_STATUS,
   type ReplayHistoryEntry,
@@ -7,7 +7,7 @@ import {
   type ReplayStatus,
 } from "../repositories/replay.repository";
 import { createReplayRuntime } from "~/server/event-sourcing/replay/replayPreset";
-import type { ReplayCallbacks } from "~/server/event-sourcing/replay/types";
+import type { ReplayProgress } from "~/server/event-sourcing/replay/types";
 
 vi.mock("~/env.mjs", () => ({
   env: { REDIS_URL: "redis://unit-test" },
@@ -54,16 +54,10 @@ function createFakeRepo() {
   return repo;
 }
 
+type StubbedRuntime = ReturnType<typeof createReplayRuntime>;
+
 function stubRuntime(
-  replayOptimized: (
-    config: unknown,
-    callbacks?: ReplayCallbacks,
-  ) => Promise<{
-    aggregatesReplayed: number;
-    totalEvents: number;
-    batchErrors: number;
-    firstError?: string;
-  }>,
+  replayOptimized: StubbedRuntime["service"]["replayOptimized"],
 ) {
   mockedCreateReplayRuntime.mockReturnValue({
     projections: [
@@ -78,9 +72,34 @@ function stubRuntime(
       },
     ],
     mapProjections: [],
-    service: { replayOptimized } as never,
+    service: { replayOptimized } as StubbedRuntime["service"],
     close: vi.fn(async () => undefined),
-  } as never);
+  } satisfies StubbedRuntime);
+}
+
+function buildProgress(
+  overrides: Partial<ReplayProgress> = {},
+): ReplayProgress {
+  return {
+    phase: "replaying",
+    currentProjectionName: "traceSummary",
+    currentProjectionKind: "fold",
+    currentProjectionIndex: 0,
+    totalProjections: 1,
+    totalAggregates: 1000,
+    tenantCount: 1,
+    currentBatch: 1,
+    totalBatches: 1,
+    batchAggregates: 1000,
+    batchPhase: "replay",
+    batchEventsProcessed: 0,
+    aggregatesCompleted: 0,
+    totalEventsReplayed: 0,
+    elapsedSec: 0,
+    skippedCount: 0,
+    batchErrors: 0,
+    ...overrides,
+  };
 }
 
 describe("ops ReplayService", () => {
@@ -130,6 +149,101 @@ describe("ops ReplayService", () => {
     });
   });
 
+  describe("given a single batch running longer than the lock refresh interval", () => {
+    describe("when progress is emitted after the interval elapses", () => {
+      it("refreshes the lock from the time-gated progress path", async () => {
+        vi.useFakeTimers();
+        try {
+          const repo = createFakeRepo();
+          const service = new ReplayService(repo);
+
+          stubRuntime(async (_config, callbacks) => {
+            // First emit is inside the interval — must NOT refresh.
+            callbacks?.onProgress?.(buildProgress());
+            // Same batch keeps running past the refresh interval.
+            vi.advanceTimersByTime(LOCK_REFRESH_INTERVAL_MS + 1_000);
+            callbacks?.onProgress?.(buildProgress());
+            return { aggregatesReplayed: 1000, totalEvents: 5000, batchErrors: 0 };
+          });
+
+          const { runId } = await service.startReplay({
+            projectionNames: ["traceSummary"],
+            since: "2026-01-01",
+            tenantIds: [],
+            description: "unit",
+            userName: "tester",
+          });
+
+          await vi.waitFor(async () => {
+            const status = await service.getStatus();
+            expect(status.state).toBe("completed");
+          });
+
+          // No batch completions fired, so the single refresh can only have
+          // come from the time-gated onProgress heartbeat.
+          expect(repo.refreshLock).toHaveBeenCalledTimes(1);
+          expect(repo.refreshLock).toHaveBeenCalledWith({
+            runId,
+            ttlSeconds: 3600,
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+    });
+  });
+
+  describe("given a replay whose lock refresh reports the lock is no longer held", () => {
+    describe("when the next progress emit runs its cancellation check", () => {
+      it("aborts the stale run instead of continuing to replay", async () => {
+        const repo = createFakeRepo();
+        const service = new ReplayService(repo);
+        let resumedAfterAbort = false;
+
+        stubRuntime(async (_config, callbacks) => {
+          // Simulate expiry + takeover: this run no longer holds the lock.
+          await repo.releaseLock({ runId: (await repo.getLockHolder())! });
+          // The batch-complete heartbeat now refreshes against a lost lock.
+          callbacks?.onBatchComplete?.({
+            projectionName: "traceSummary",
+            projectionKind: "fold",
+            batchNum: 1,
+            totalBatches: 2,
+            aggregatesInBatch: 1000,
+            eventsInBatch: 5000,
+            durationSec: 1,
+          });
+          // Let the fire-and-forget refreshLock promise settle so the
+          // abort flag is observed by the next progress emit.
+          await new Promise((resolve) => setImmediate(resolve));
+          callbacks?.onProgress?.(buildProgress());
+          resumedAfterAbort = true;
+          return { aggregatesReplayed: 2000, totalEvents: 10000, batchErrors: 0 };
+        });
+
+        await service.startReplay({
+          projectionNames: ["traceSummary"],
+          since: "2026-01-01",
+          tenantIds: [],
+          description: "unit",
+          userName: "tester",
+        });
+
+        await vi.waitFor(async () => {
+          const status = await service.getStatus();
+          expect(status.state).toBe("cancelled");
+        });
+
+        // The throw from onProgress must have aborted the stale run before
+        // it could keep replaying alongside the new lock holder.
+        expect(resumedAfterAbort).toBe(false);
+        expect(repo.pushToHistory).toHaveBeenCalledWith({
+          entry: expect.objectContaining({ state: "cancelled" }),
+        });
+      });
+    });
+  });
+
   describe("given a replay whose lock was taken over by another run", () => {
     describe("when the stale run finishes", () => {
       it("does not overwrite the new holder's status", async () => {
@@ -153,13 +267,16 @@ describe("ops ReplayService", () => {
         });
 
         // The run must bail out without flipping state to completed.
+        // executeReplay's finally always releases the lock, so the second
+        // releaseLock call (the first is the stub's simulated takeover)
+        // deterministically marks the stale run as finished.
         await vi.waitFor(() => {
-          expect(mockedCreateReplayRuntime).toHaveBeenCalled();
+          expect(repo.releaseLock).toHaveBeenCalledTimes(2);
         });
-        await new Promise((resolve) => setTimeout(resolve, 20));
 
         const status = await service.getStatus();
         expect(status.state).toBe("running");
+        expect(repo.pushToHistory).not.toHaveBeenCalled();
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/__tests__/replay.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/replay.service.unit.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+import { ReplayService } from "../replay.service";
+import {
+  IDLE_STATUS,
+  type ReplayHistoryEntry,
+  type ReplayRepository,
+  type ReplayStatus,
+} from "../repositories/replay.repository";
+import { createReplayRuntime } from "~/server/event-sourcing/replay/replayPreset";
+import type { ReplayCallbacks } from "~/server/event-sourcing/replay/types";
+
+vi.mock("~/env.mjs", () => ({
+  env: { REDIS_URL: "redis://unit-test" },
+}));
+
+vi.mock("~/server/event-sourcing/replay/replayPreset", () => ({
+  createReplayRuntime: vi.fn(),
+}));
+
+const mockedCreateReplayRuntime = vi.mocked(createReplayRuntime);
+
+/** In-memory ReplayRepository double with spy-wrapped lock methods. */
+function createFakeRepo() {
+  let status: ReplayStatus = { ...IDLE_STATUS };
+  let lockHolder: string | null = null;
+  const history: ReplayHistoryEntry[] = [];
+
+  const repo: ReplayRepository = {
+    getStatus: vi.fn(async () => status),
+    writeStatus: vi.fn(async (params: { status: ReplayStatus }) => {
+      status = params.status;
+    }),
+    acquireLock: vi.fn(async (params: { runId: string }) => {
+      if (lockHolder) return false;
+      lockHolder = params.runId;
+      return true;
+    }),
+    refreshLock: vi.fn(async (params: { runId: string }) => {
+      return lockHolder === params.runId;
+    }),
+    releaseLock: vi.fn(async (params: { runId: string }) => {
+      if (lockHolder === params.runId) lockHolder = null;
+    }),
+    getLockHolder: vi.fn(async () => lockHolder),
+    isCancelled: vi.fn(async () => false),
+    setCancelled: vi.fn(async () => undefined),
+    clearCancelFlag: vi.fn(async () => undefined),
+    pushToHistory: vi.fn(async (params: { entry: ReplayHistoryEntry }) => {
+      history.push(params.entry);
+    }),
+    getHistory: vi.fn(async () => history),
+  };
+
+  return repo;
+}
+
+function stubRuntime(
+  replayOptimized: (
+    config: unknown,
+    callbacks?: ReplayCallbacks,
+  ) => Promise<{
+    aggregatesReplayed: number;
+    totalEvents: number;
+    batchErrors: number;
+    firstError?: string;
+  }>,
+) {
+  mockedCreateReplayRuntime.mockReturnValue({
+    projections: [
+      {
+        projectionName: "traceSummary",
+        pipelineName: "trace_processing",
+        aggregateType: "trace",
+        source: "pipeline",
+        pauseKey: "trace_processing/projection/traceSummary",
+        kind: "fold",
+        definition: {} as never,
+      },
+    ],
+    mapProjections: [],
+    service: { replayOptimized } as never,
+    close: vi.fn(async () => undefined),
+  } as never);
+}
+
+describe("ops ReplayService", () => {
+  describe("given a replay run spanning multiple batches", () => {
+    describe("when each batch completes", () => {
+      it("refreshes the replay lock at least once per batch", async () => {
+        const repo = createFakeRepo();
+        const service = new ReplayService(repo);
+
+        stubRuntime(async (_config, callbacks) => {
+          for (let batchNum = 1; batchNum <= 3; batchNum++) {
+            callbacks?.onBatchComplete?.({
+              projectionName: "traceSummary",
+              projectionKind: "fold",
+              batchNum,
+              totalBatches: 3,
+              aggregatesInBatch: 1000,
+              eventsInBatch: 5000,
+              durationSec: 1,
+            });
+          }
+          return { aggregatesReplayed: 3000, totalEvents: 15000, batchErrors: 0 };
+        });
+
+        const { runId } = await service.startReplay({
+          projectionNames: ["traceSummary"],
+          since: "2026-01-01",
+          tenantIds: [],
+          description: "unit",
+          userName: "tester",
+        });
+
+        await vi.waitFor(async () => {
+          const status = await service.getStatus();
+          expect(status.state).toBe("completed");
+        });
+
+        // One refresh per completed batch keeps the 1h lock TTL from
+        // expiring on multi-hour runs (expiry silently stopped progress
+        // updates: lockHolder !== runId).
+        expect(repo.refreshLock).toHaveBeenCalledTimes(3);
+        expect(repo.refreshLock).toHaveBeenCalledWith({
+          runId,
+          ttlSeconds: 3600,
+        });
+      });
+    });
+  });
+
+  describe("given a replay whose lock was taken over by another run", () => {
+    describe("when the stale run finishes", () => {
+      it("does not overwrite the new holder's status", async () => {
+        const repo = createFakeRepo();
+        const service = new ReplayService(repo);
+
+        stubRuntime(async () => {
+          // Simulate the lock being lost mid-run (e.g. expiry + takeover).
+          await repo.releaseLock({
+            runId: (await repo.getLockHolder())!,
+          });
+          return { aggregatesReplayed: 1, totalEvents: 1, batchErrors: 0 };
+        });
+
+        await service.startReplay({
+          projectionNames: ["traceSummary"],
+          since: "2026-01-01",
+          tenantIds: [],
+          description: "unit",
+          userName: "tester",
+        });
+
+        // The run must bail out without flipping state to completed.
+        await vi.waitFor(() => {
+          expect(mockedCreateReplayRuntime).toHaveBeenCalled();
+        });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        const status = await service.getStatus();
+        expect(status.state).toBe("running");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/replay.service.ts
+++ b/langwatch/src/server/app-layer/ops/replay.service.ts
@@ -13,6 +13,14 @@ const logger = createLogger("langwatch:ops:replay-service");
 
 const REPLAY_LOCK_TTL_SECONDS = 3600;
 
+/**
+ * How often (at most) the running replay re-extends its lock from progress
+ * callbacks. Batch completions also refresh unconditionally — together they
+ * keep the lock alive for runs longer than REPLAY_LOCK_TTL_SECONDS, whose
+ * expiry used to silently stop status updates mid-run.
+ */
+const LOCK_REFRESH_INTERVAL_MS = 60_000;
+
 class ReplayCancelledError extends Error {
   constructor() {
     super("Replay cancelled");
@@ -153,6 +161,19 @@ export class ReplayService {
       let lastCancelCheck = Date.now();
       const CANCEL_CHECK_INTERVAL_MS = 3000;
 
+      let lastLockRefresh = Date.now();
+      const refreshLock = () => {
+        lastLockRefresh = Date.now();
+        this.repo
+          .refreshLock({
+            runId: params.runId,
+            ttlSeconds: REPLAY_LOCK_TTL_SECONDS,
+          })
+          .catch((err) => {
+            logger.warn({ error: err }, "Failed to refresh replay lock");
+          });
+      };
+
       const result = await runtime.service.replayOptimized(
         {
           projections: selectedProjections,
@@ -162,6 +183,11 @@ export class ReplayService {
           aggregateIds: params.aggregateIds,
         },
         {
+          // Heartbeat: refresh the lock at least once per completed batch so
+          // a run longer than the lock TTL never loses it mid-flight.
+          onBatchComplete: () => {
+            refreshLock();
+          },
           onProgress: (progress: ReplayProgress) => {
             this.updateProgress({ runId: params.runId, progress }).catch(
               (err) => {
@@ -181,6 +207,12 @@ export class ReplayService {
                   if (cancelled) cancelledFlag = true;
                 })
                 .catch(() => {});
+            }
+
+            // Also refresh from progress emits, time-gated — covers a single
+            // batch that runs longer than one lock refresh interval.
+            if (now - lastLockRefresh > LOCK_REFRESH_INTERVAL_MS) {
+              refreshLock();
             }
 
             if (cancelledFlag) {

--- a/langwatch/src/server/app-layer/ops/replay.service.ts
+++ b/langwatch/src/server/app-layer/ops/replay.service.ts
@@ -19,7 +19,7 @@ const REPLAY_LOCK_TTL_SECONDS = 3600;
  * keep the lock alive for runs longer than REPLAY_LOCK_TTL_SECONDS, whose
  * expiry used to silently stop status updates mid-run.
  */
-const LOCK_REFRESH_INTERVAL_MS = 60_000;
+export const LOCK_REFRESH_INTERVAL_MS = 60_000;
 
 class ReplayCancelledError extends Error {
   constructor() {
@@ -169,6 +169,18 @@ export class ReplayService {
             runId: params.runId,
             ttlSeconds: REPLAY_LOCK_TTL_SECONDS,
           })
+          .then((stillHeld) => {
+            if (!stillHeld) {
+              // Lock expired and another run took over — abort this stale
+              // run via the existing cancellation path so it stops touching
+              // the shared projection pause keys.
+              logger.warn(
+                { runId: params.runId },
+                "Replay lock lost to another run; aborting stale replay",
+              );
+              cancelledFlag = true;
+            }
+          })
           .catch((err) => {
             logger.warn({ error: err }, "Failed to refresh replay lock");
           });
@@ -260,7 +272,17 @@ export class ReplayService {
         });
       }
     } catch (err) {
-      if (err instanceof ReplayCancelledError) {
+      // If another run has taken the lock over, it owns the status row now —
+      // finalizing here would overwrite the successor's "running" status with
+      // this stale run's cancelled/failed state. A null holder (expired, no
+      // successor) still finalizes so the run's end state stays observable.
+      const lockHolder = await this.repo.getLockHolder();
+      if (lockHolder !== null && lockHolder !== params.runId) {
+        logger.warn(
+          { runId: params.runId, lockHolder },
+          "Skipping replay finalization: lock now held by another run",
+        );
+      } else if (err instanceof ReplayCancelledError) {
         await this.finalizeCancelled({
           runId: params.runId,
           historyCtx: params,

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/replay.redis.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/replay.redis.repository.integration.test.ts
@@ -1,0 +1,110 @@
+import type { Redis } from "ioredis";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { ReplayRedisRepository } from "../replay.redis.repository";
+
+// Exercises the refreshLock Lua check-and-extend script against a real Redis,
+// so the KEYS/ARGV wiring and integer-reply handling stay honest. The unit
+// tests cover the service via an in-memory fake that reimplements these
+// semantics — a script bug would slip past them silently.
+const REPLAY_LOCK_KEY = "ops:replay:lock";
+
+const HOLDER_RUN_ID = "run-holder";
+const OTHER_RUN_ID = "run-intruder";
+const INITIAL_TTL_SECONDS = 30;
+const EXTENDED_TTL_SECONDS = 120;
+
+let redis: Redis;
+let repository: ReplayRedisRepository;
+
+async function clearReplayKeys() {
+  const keys = await redis.keys("ops:replay:*");
+  if (keys.length > 0) await redis.del(...keys);
+}
+
+beforeAll(async () => {
+  ({ redisConnection: redis } = await startTestContainers());
+  repository = new ReplayRedisRepository(redis);
+  await clearReplayKeys();
+});
+
+afterEach(async () => {
+  await clearReplayKeys();
+});
+
+afterAll(async () => {
+  await stopTestContainers();
+});
+
+describe("ReplayRedisRepository refreshLock", () => {
+  describe("given a lock held by a run", () => {
+    describe("when the holder refreshes the lock", () => {
+      it("returns true and extends the key TTL", async () => {
+        await repository.acquireLock({
+          runId: HOLDER_RUN_ID,
+          ttlSeconds: INITIAL_TTL_SECONDS,
+        });
+
+        const refreshed = await repository.refreshLock({
+          runId: HOLDER_RUN_ID,
+          ttlSeconds: EXTENDED_TTL_SECONDS,
+        });
+
+        expect(refreshed).toBe(true);
+        const ttl = await redis.ttl(REPLAY_LOCK_KEY);
+        expect(ttl).toBeGreaterThan(INITIAL_TTL_SECONDS);
+        expect(ttl).toBeLessThanOrEqual(EXTENDED_TTL_SECONDS);
+      });
+    });
+
+    describe("when a different run attempts a refresh", () => {
+      it("returns false and leaves the TTL unchanged", async () => {
+        await repository.acquireLock({
+          runId: HOLDER_RUN_ID,
+          ttlSeconds: INITIAL_TTL_SECONDS,
+        });
+
+        const refreshed = await repository.refreshLock({
+          runId: OTHER_RUN_ID,
+          ttlSeconds: EXTENDED_TTL_SECONDS,
+        });
+
+        expect(refreshed).toBe(false);
+        const ttl = await redis.ttl(REPLAY_LOCK_KEY);
+        expect(ttl).toBeGreaterThan(0);
+        expect(ttl).toBeLessThanOrEqual(INITIAL_TTL_SECONDS);
+      });
+
+      it("keeps the original holder on the lock", async () => {
+        await repository.acquireLock({
+          runId: HOLDER_RUN_ID,
+          ttlSeconds: INITIAL_TTL_SECONDS,
+        });
+
+        await repository.refreshLock({
+          runId: OTHER_RUN_ID,
+          ttlSeconds: EXTENDED_TTL_SECONDS,
+        });
+
+        expect(await repository.getLockHolder()).toBe(HOLDER_RUN_ID);
+      });
+    });
+  });
+
+  describe("given no lock is held", () => {
+    describe("when a refresh is attempted", () => {
+      it("returns false and does not create the lock key", async () => {
+        const refreshed = await repository.refreshLock({
+          runId: HOLDER_RUN_ID,
+          ttlSeconds: EXTENDED_TTL_SECONDS,
+        });
+
+        expect(refreshed).toBe(false);
+        expect(await redis.exists(REPLAY_LOCK_KEY)).toBe(0);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/repositories/replay.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/replay.redis.repository.ts
@@ -54,6 +54,25 @@ export class ReplayRedisRepository implements ReplayRepository {
     return result !== null;
   }
 
+  async refreshLock(params: {
+    runId: string;
+    ttlSeconds: number;
+  }): Promise<boolean> {
+    // Atomic check-and-extend: only the current holder may push the TTL out.
+    const result = await this.redis.eval(
+      `if redis.call('get', KEYS[1]) == ARGV[1] then
+        return redis.call('expire', KEYS[1], ARGV[2])
+      else
+        return 0
+      end`,
+      1,
+      REPLAY_LOCK_KEY,
+      params.runId,
+      String(params.ttlSeconds),
+    );
+    return result === 1;
+  }
+
   async releaseLock(params: { runId: string }): Promise<void> {
     const holder = await this.redis.get(REPLAY_LOCK_KEY);
     if (holder === params.runId) {

--- a/langwatch/src/server/app-layer/ops/repositories/replay.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/replay.repository.ts
@@ -57,6 +57,15 @@ export interface ReplayRepository {
     runId: string;
     ttlSeconds: number;
   }): Promise<boolean>;
+  /**
+   * Extend the lock's TTL, but only while `runId` still holds it. Long
+   * replays heartbeat this per batch — without it the lock expires mid-run
+   * and progress updates silently stop.
+   */
+  refreshLock(params: {
+    runId: string;
+    ttlSeconds: number;
+  }): Promise<boolean>;
   releaseLock(params: { runId: string }): Promise<void>;
   getLockHolder(): Promise<string | null>;
 
@@ -76,6 +85,10 @@ export class NullReplayRepository implements ReplayRepository {
   async writeStatus(): Promise<void> {}
 
   async acquireLock(): Promise<boolean> {
+    return false;
+  }
+
+  async refreshLock(): Promise<boolean> {
     return false;
   }
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/logRecordStorage.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/logRecordStorage.store.ts
@@ -1,6 +1,9 @@
 import type { LogRecordStorageRepository } from "~/server/app-layer/traces/repositories/log-record-storage.repository";
 import { PLATFORM_DEFAULT_RETENTION_DAYS } from "~/server/data-retention/retentionPolicy.schema";
-import type { AppendStore } from "../../../projections/mapProjection.types";
+import type {
+  AppendStore,
+  BulkAppendContext,
+} from "../../../projections/mapProjection.types";
 import type { ProjectionStoreContext } from "../../../projections/projectionStoreContext";
 import type { NormalizedLogRecord } from "../schemas/logRecords";
 
@@ -18,7 +21,7 @@ export class LogRecordAppendStore implements AppendStore<NormalizedLogRecord> {
 
   async bulkAppend(
     records: NormalizedLogRecord[],
-    context: ProjectionStoreContext,
+    context: BulkAppendContext,
   ): Promise<void> {
     if (records.length === 0) return;
     const retentionDays =

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/metricRecordStorage.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/metricRecordStorage.store.ts
@@ -1,6 +1,9 @@
 import type { MetricRecordStorageRepository } from "~/server/app-layer/traces/repositories/metric-record-storage.repository";
 import { PLATFORM_DEFAULT_RETENTION_DAYS } from "~/server/data-retention/retentionPolicy.schema";
-import type { AppendStore } from "../../../projections/mapProjection.types";
+import type {
+  AppendStore,
+  BulkAppendContext,
+} from "../../../projections/mapProjection.types";
 import type { ProjectionStoreContext } from "../../../projections/projectionStoreContext";
 import type { NormalizedMetricRecord } from "../schemas/metricRecords";
 
@@ -20,7 +23,7 @@ export class MetricRecordAppendStore
 
   async bulkAppend(
     records: NormalizedMetricRecord[],
-    context: ProjectionStoreContext,
+    context: BulkAppendContext,
   ): Promise<void> {
     if (records.length === 0) return;
     const retentionDays =

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorage.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/spanStorage.store.ts
@@ -1,7 +1,10 @@
 import type { SpanStorageRepository } from "~/server/app-layer/traces/repositories/span-storage.repository";
 import type { SpanInsertData } from "~/server/app-layer/traces/types";
 import { PLATFORM_DEFAULT_RETENTION_DAYS } from "~/server/data-retention/retentionPolicy.schema";
-import type { AppendStore } from "../../../projections/mapProjection.types";
+import type {
+  AppendStore,
+  BulkAppendContext,
+} from "../../../projections/mapProjection.types";
 import type { ProjectionStoreContext } from "../../../projections/projectionStoreContext";
 import type { NormalizedSpan } from "../schemas/spans";
 
@@ -75,7 +78,7 @@ export class SpanAppendStore implements AppendStore<NormalizedSpan> {
 
   async bulkAppend(
     records: NormalizedSpan[],
-    context: ProjectionStoreContext,
+    context: BulkAppendContext,
   ): Promise<void> {
     if (records.length === 0) return;
     const retentionDays =

--- a/langwatch/src/server/event-sourcing/projections/mapProjection.types.ts
+++ b/langwatch/src/server/event-sourcing/projections/mapProjection.types.ts
@@ -1,4 +1,6 @@
+import type { ResolvedRetention } from "../../data-retention/retentionPolicy.schema";
 import type { Event } from "../domain/types";
+import type { TenantId } from "../domain/tenantId";
 import type { KillSwitchOptions } from "../pipeline/staticBuilder.types";
 import type { ProjectionStoreContext } from "./projectionStoreContext";
 
@@ -103,6 +105,27 @@ export interface MapProjectionOptions {
 }
 
 /**
+ * Tenant-scoped context for bulk appends.
+ *
+ * Unlike the per-event {@link ProjectionStoreContext}, a bulk write batches
+ * records from MANY aggregates of one tenant into a single insert, so there is
+ * deliberately no `aggregateId` here — anything a store needs per row must be
+ * carried on the record itself.
+ */
+export interface BulkAppendContext {
+  /** Tenant identifier for multi-tenant isolation (e.g. CH client routing). */
+  tenantId: TenantId;
+
+  /**
+   * Resolved retention policy for the tenant. Absent/null means the resolver
+   * could not produce a value; the write path then stamps
+   * PLATFORM_DEFAULT_RETENTION_DAYS, never indefinite — see
+   * {@link ProjectionStoreContext.retentionPolicy}.
+   */
+  retentionPolicy?: ResolvedRetention | null;
+}
+
+/**
  * Store interface for map projections.
  * Appends individual records produced by the map function.
  */
@@ -110,6 +133,10 @@ export interface AppendStore<Record> {
   /** Appends a single record to the store. */
   append(record: Record, context: ProjectionStoreContext): Promise<void>;
 
-  /** Appends multiple records in a single batch. Used by replay for bulk writes. */
-  bulkAppend?(records: Record[], context: ProjectionStoreContext): Promise<void>;
+  /**
+   * Appends multiple records in a single batch. Used by replay for bulk
+   * writes. Records within one call may span many aggregates of the same
+   * tenant, so the context is tenant-scoped ({@link BulkAppendContext}).
+   */
+  bulkAppend?(records: Record[], context: BulkAppendContext): Promise<void>;
 }

--- a/langwatch/src/server/event-sourcing/replay/__tests__/replayEventLoader.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/replay/__tests__/replayEventLoader.integration.test.ts
@@ -4,6 +4,8 @@ import {
   countEventsForAggregates,
   batchGetCutoffEventIds,
   batchLoadAggregateEvents,
+  getAggregateOccurredAtBounds,
+  loadEventsForAggregatesBulk,
 } from "../replayEventLoader";
 import {
   startTestContainers,
@@ -323,6 +325,136 @@ describe("replayEventLoader", () => {
       expect(cutoff).toBeDefined();
       // Must be evt-002 (tenant's last), not evt-other-001 (other tenant's)
       expect(cutoff!.eventId).toBe("evt-002");
+    });
+  });
+
+  describe("getAggregateOccurredAtBounds", () => {
+    it("returns the occurred-at range covering every event of the aggregates", async () => {
+      const client = getTestClickHouseClient()!;
+      const bounds = await getAggregateOccurredAtBounds({
+        client,
+        tenantId,
+        aggregateIds: ["agg-1", "agg-2"],
+      });
+
+      expect(bounds).toEqual({ minMs: 1700000000000, maxMs: 1700000002000 });
+    });
+
+    describe("when the aggregates have no events", () => {
+      it("returns null", async () => {
+        const client = getTestClickHouseClient()!;
+        const bounds = await getAggregateOccurredAtBounds({
+          client,
+          tenantId,
+          aggregateIds: ["nonexistent-agg"],
+        });
+
+        expect(bounds).toBeNull();
+      });
+    });
+
+    describe("when the aggregate id list is empty", () => {
+      it("returns null without querying", async () => {
+        const client = getTestClickHouseClient()!;
+        const bounds = await getAggregateOccurredAtBounds({
+          client,
+          tenantId,
+          aggregateIds: [],
+        });
+
+        expect(bounds).toBeNull();
+      });
+    });
+  });
+
+  describe("when occurred-at bounds prune the queries", () => {
+    // The bounds come from getAggregateOccurredAtBounds over the same
+    // aggregates, so the bounded queries must return exactly what the
+    // unbounded ones do — pruning is a partition optimisation, never a
+    // result filter.
+    it("batchGetCutoffEventIds returns the same cutoffs as unbounded", async () => {
+      const client = getTestClickHouseClient()!;
+      const bounds = await getAggregateOccurredAtBounds({
+        client,
+        tenantId,
+        aggregateIds: ["agg-1", "agg-2"],
+      });
+      const bounded = await batchGetCutoffEventIds({
+        client,
+        tenantId,
+        aggregateIds: ["agg-1", "agg-2"],
+        eventTypes: ["test.event"],
+        occurredAtBounds: bounds!,
+      });
+      const unbounded = await batchGetCutoffEventIds({
+        client,
+        tenantId,
+        aggregateIds: ["agg-1", "agg-2"],
+        eventTypes: ["test.event"],
+      });
+
+      expect(bounded).toEqual(unbounded);
+      expect(bounded.get(`${tenantId}:test:agg-1`)!.eventId).toBe("evt-002");
+    });
+
+    it("batchLoadAggregateEvents returns the same events as unbounded", async () => {
+      const client = getTestClickHouseClient()!;
+      const bounds = await getAggregateOccurredAtBounds({
+        client,
+        tenantId,
+        aggregateIds: ["agg-1"],
+      });
+      const events = await batchLoadAggregateEvents({
+        client,
+        tenantId,
+        aggregateIds: ["agg-1"],
+        eventTypes: ["test.event"],
+        maxCutoffEventId: "evt-002",
+        cursorEventId: "",
+        batchSize: 100,
+        occurredAtBounds: bounds!,
+      });
+
+      expect(events.map((e) => e.id)).toEqual(["evt-001", "evt-002"]);
+    });
+
+    it("loadEventsForAggregatesBulk returns the same events as unbounded", async () => {
+      const client = getTestClickHouseClient()!;
+      const bounds = await getAggregateOccurredAtBounds({
+        client,
+        tenantId,
+        aggregateIds: ["agg-1", "agg-2"],
+      });
+      const cutoffs = await batchGetCutoffEventIds({
+        client,
+        tenantId,
+        aggregateIds: ["agg-1", "agg-2"],
+        eventTypes: ["test.event"],
+        occurredAtBounds: bounds!,
+      });
+
+      const bounded = await loadEventsForAggregatesBulk({
+        client,
+        tenantId,
+        aggregateIds: ["agg-1", "agg-2"],
+        cutoffs,
+        occurredAtBounds: bounds!,
+      });
+      const unbounded = await loadEventsForAggregatesBulk({
+        client,
+        tenantId,
+        aggregateIds: ["agg-1", "agg-2"],
+        cutoffs,
+      });
+
+      expect(bounded.get(`${tenantId}:test:agg-1`)?.map((e) => e.id)).toEqual([
+        "evt-001",
+        "evt-002",
+      ]);
+      expect(bounded.get(`${tenantId}:test:agg-2`)?.map((e) => e.id)).toEqual([
+        "evt-003",
+      ]);
+      expect([...bounded.keys()].sort()).toEqual([...unbounded.keys()].sort());
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/replay/__tests__/replayEventLoader.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/replay/__tests__/replayEventLoader.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import {
   discoverAffectedAggregates,
   countEventsForAggregates,
@@ -334,6 +334,7 @@ describe("replayEventLoader", () => {
       const bounds = await getAggregateOccurredAtBounds({
         client,
         tenantId,
+        aggregateTypes: ["test"],
         aggregateIds: ["agg-1", "agg-2"],
       });
 
@@ -341,28 +342,36 @@ describe("replayEventLoader", () => {
     });
 
     describe("when the aggregates have no events", () => {
-      it("returns null", async () => {
+      it("returns undefined", async () => {
         const client = getTestClickHouseClient()!;
         const bounds = await getAggregateOccurredAtBounds({
           client,
           tenantId,
+          aggregateTypes: ["test"],
           aggregateIds: ["nonexistent-agg"],
         });
 
-        expect(bounds).toBeNull();
+        expect(bounds).toBeUndefined();
       });
     });
 
     describe("when the aggregate id list is empty", () => {
-      it("returns null without querying", async () => {
+      it("returns undefined without querying", async () => {
         const client = getTestClickHouseClient()!;
-        const bounds = await getAggregateOccurredAtBounds({
-          client,
-          tenantId,
-          aggregateIds: [],
-        });
+        const querySpy = vi.spyOn(client, "query");
+        try {
+          const bounds = await getAggregateOccurredAtBounds({
+            client,
+            tenantId,
+            aggregateTypes: ["test"],
+            aggregateIds: [],
+          });
 
-        expect(bounds).toBeNull();
+          expect(bounds).toBeUndefined();
+          expect(querySpy).not.toHaveBeenCalled();
+        } finally {
+          querySpy.mockRestore();
+        }
       });
     });
   });
@@ -377,6 +386,7 @@ describe("replayEventLoader", () => {
       const bounds = await getAggregateOccurredAtBounds({
         client,
         tenantId,
+        aggregateTypes: ["test"],
         aggregateIds: ["agg-1", "agg-2"],
       });
       const bounded = await batchGetCutoffEventIds({
@@ -402,6 +412,7 @@ describe("replayEventLoader", () => {
       const bounds = await getAggregateOccurredAtBounds({
         client,
         tenantId,
+        aggregateTypes: ["test"],
         aggregateIds: ["agg-1"],
       });
       const events = await batchLoadAggregateEvents({
@@ -418,11 +429,57 @@ describe("replayEventLoader", () => {
       expect(events.map((e) => e.id)).toEqual(["evt-001", "evt-002"]);
     });
 
+    describe("when the bounds are deliberately narrower than the data", () => {
+      // Bounds ending at 1700000001000 exclude agg-2's only event
+      // (evt-003 at 1700000002000). Correct bounds never filter results,
+      // so an exclusion here proves the predicate is actually wired into
+      // the SQL -- guarding against the pruning being silently dropped.
+      const narrowBounds = { minMs: 1700000000000, maxMs: 1700000001000 };
+
+      it("batchGetCutoffEventIds excludes events outside the bounds", async () => {
+        const client = getTestClickHouseClient()!;
+        const cutoffs = await batchGetCutoffEventIds({
+          client,
+          tenantId,
+          aggregateIds: ["agg-1", "agg-2"],
+          eventTypes: ["test.event"],
+          occurredAtBounds: narrowBounds,
+        });
+
+        expect(cutoffs.get(`${tenantId}:test:agg-1`)!.eventId).toBe("evt-002");
+        expect(cutoffs.has(`${tenantId}:test:agg-2`)).toBe(false);
+      });
+
+      it("loadEventsForAggregatesBulk excludes events outside the bounds", async () => {
+        const client = getTestClickHouseClient()!;
+        const cutoffs = await batchGetCutoffEventIds({
+          client,
+          tenantId,
+          aggregateIds: ["agg-1", "agg-2"],
+          eventTypes: ["test.event"],
+        });
+
+        const bounded = await loadEventsForAggregatesBulk({
+          client,
+          tenantId,
+          aggregateIds: ["agg-1", "agg-2"],
+          cutoffs,
+          occurredAtBounds: narrowBounds,
+        });
+
+        expect(bounded.get(`${tenantId}:test:agg-1`)?.map((e) => e.id)).toEqual(
+          ["evt-001", "evt-002"],
+        );
+        expect(bounded.has(`${tenantId}:test:agg-2`)).toBe(false);
+      });
+    });
+
     it("loadEventsForAggregatesBulk returns the same events as unbounded", async () => {
       const client = getTestClickHouseClient()!;
       const bounds = await getAggregateOccurredAtBounds({
         client,
         tenantId,
+        aggregateTypes: ["test"],
         aggregateIds: ["agg-1", "agg-2"],
       });
       const cutoffs = await batchGetCutoffEventIds({

--- a/langwatch/src/server/event-sourcing/replay/__tests__/replayExecutor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/replay/__tests__/replayExecutor.unit.test.ts
@@ -423,18 +423,23 @@ describe("MapAccumulator", () => {
 
       expect(bulkAppendSpy).toHaveBeenCalledTimes(2);
 
-      const allRecords = bulkAppendSpy.mock.calls.flatMap(
-        (call: unknown[]) => call[0] as Array<{ doubled: number }>,
-      );
-      expect(allRecords).toHaveLength(3);
-      expect(allRecords).toContainEqual({ doubled: 2 });
-      expect(allRecords).toContainEqual({ doubled: 4 });
-      expect(allRecords).toContainEqual({ doubled: 6 });
+      const byTenant = new Map<string, Array<{ doubled: number }>>();
+      for (const [records, context] of bulkAppendSpy.mock.calls as Array<
+        [Array<{ doubled: number }>, { tenantId: string }]
+      >) {
+        byTenant.set(String(context.tenantId), records);
+      }
+      expect(byTenant.get("t-A")).toEqual([{ doubled: 2 }, { doubled: 6 }]);
+      expect(byTenant.get("t-B")).toEqual([{ doubled: 4 }]);
     });
   });
 
-  describe("when bulkAppend is used across multiple aggregates", () => {
-    it("groups records by aggregateId so each call carries the originating context", async () => {
+  describe("when events span multiple aggregates of one tenant", () => {
+    it("flushes them in a single tenant-scoped bulkAppend call, never one per aggregate", async () => {
+      // Regression: drain used to group buffered records per AGGREGATE and
+      // sequentially await one bulkAppend per group. For spanStorage the
+      // aggregate is a single trace, so a 1000-aggregate replay batch
+      // degenerated into ~1000 sequential awaited ClickHouse INSERTs.
       const { projection, bulkAppendSpy } = createTestMapProjection();
       const acc = new MapAccumulator(projection);
 
@@ -444,17 +449,17 @@ describe("MapAccumulator", () => {
 
       await acc.flush();
 
-      expect(bulkAppendSpy).toHaveBeenCalledTimes(2);
+      expect(bulkAppendSpy).toHaveBeenCalledTimes(1);
 
-      const byAggregate = new Map<string, Array<{ doubled: number }>>();
-      for (const [records, context] of bulkAppendSpy.mock.calls as Array<
-        [Array<{ doubled: number }>, { aggregateId: string }]
-      >) {
-        expect(context.aggregateId).not.toBe("");
-        byAggregate.set(context.aggregateId, records);
-      }
-      expect(byAggregate.get("agg-A")).toEqual([{ doubled: 2 }, { doubled: 6 }]);
-      expect(byAggregate.get("agg-B")).toEqual([{ doubled: 4 }]);
+      const [records, context] = bulkAppendSpy.mock.calls[0]! as [
+        Array<{ doubled: number }>,
+        { tenantId: string; aggregateId?: string },
+      ];
+      expect(records).toEqual([{ doubled: 2 }, { doubled: 4 }, { doubled: 6 }]);
+      // The context is tenant-scoped: no single aggregateId can describe a
+      // multi-aggregate chunk, so the contract no longer carries one.
+      expect(String(context.tenantId)).toBe("tenant-1");
+      expect(context.aggregateId).toBeUndefined();
     });
   });
 
@@ -539,21 +544,22 @@ describe("MapAccumulator", () => {
       expect(bulkAppendSpy).toHaveBeenCalledTimes(3);
     });
 
-    it("keeps per-aggregate context grouping on incremental writes", async () => {
+    it("chunks incremental writes across aggregates instead of splitting per aggregate", async () => {
       const { projection, bulkAppendSpy } = createTestMapProjection();
       const acc = new MapAccumulator(projection, { writeBatchSize: 2 });
 
       await acc.apply(makeEvent({ aggregateId: "agg-A", data: { value: 1 } }));
       await acc.apply(makeEvent({ aggregateId: "agg-B", data: { value: 2 } }));
 
-      // Incremental write fired: one call per aggregate, each with its context.
-      expect(bulkAppendSpy).toHaveBeenCalledTimes(2);
-      for (const [records, context] of bulkAppendSpy.mock.calls as Array<
-        [Array<{ doubled: number }>, { aggregateId: string }]
-      >) {
-        expect(records).toHaveLength(1);
-        expect(["agg-A", "agg-B"]).toContain(context.aggregateId);
-      }
+      // Incremental write fired: ONE tenant-scoped call carrying both
+      // aggregates' records — not one call per aggregate.
+      expect(bulkAppendSpy).toHaveBeenCalledTimes(1);
+      const [records, context] = bulkAppendSpy.mock.calls[0]! as [
+        Array<{ doubled: number }>,
+        { tenantId: string },
+      ];
+      expect(records).toEqual([{ doubled: 2 }, { doubled: 4 }]);
+      expect(String(context.tenantId)).toBe("tenant-1");
     });
   });
 

--- a/langwatch/src/server/event-sourcing/replay/__tests__/replayService.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/replay/__tests__/replayService.integration.test.ts
@@ -329,17 +329,17 @@ describe("ReplayService tenant-specific ClickHouse", () => {
       expect(result.aggregatesReplayed).toBe(2);
       expect(result.totalEvents).toBe(2);
 
-      // Records flushed via bulkAppend grouped by aggregate (one call per agg).
-      expect(bulkAppend).toHaveBeenCalledTimes(2);
+      // Records flushed via ONE tenant-scoped bulkAppend covering both
+      // aggregates — never one awaited call per aggregate (that per-trace
+      // grouping is what made span-storage replays take weeks).
+      expect(bulkAppend).toHaveBeenCalledTimes(1);
       const appendedRecords = bulkAppend.mock.calls.flatMap(([records]) => records as any[]);
       expect(appendedRecords.map((r) => r.src).sort()).toEqual(["trace-a1", "trace-a2"]);
       expect(appendedRecords.map((r) => r.doubled).sort((a, b) => a - b)).toEqual([2, 4]);
 
-      // Each bulkAppend call must carry the per-aggregate context (not a
-      // shared/generic context), so the store can route records correctly.
-      for (const [records, ctx] of bulkAppend.mock.calls as Array<[any[], any]>) {
+      // The bulk call carries the tenant-scoped context.
+      for (const [, ctx] of bulkAppend.mock.calls as Array<[any[], any]>) {
         expect(ctx.tenantId).toBe(tenantA);
-        expect(records.every((r) => r.src === ctx.aggregateId)).toBe(true);
       }
 
       // Pause was held active while records were being written.
@@ -491,13 +491,14 @@ describe("ReplayService tenant-specific ClickHouse", () => {
         .sort();
       expect(foldedAggregates).toEqual(["trace-a1", "trace-a2"]);
 
-      // Map bulk-appended both aggregates, grouped per aggregate (preserving
-      // per-aggregate context is the bugfix this PR introduced — see
-      // 44d05f65f "preserve per-aggregate context on map projection bulkAppend").
-      expect(bulkAppend).toHaveBeenCalledTimes(2);
+      // Map bulk-appended both aggregates in a single tenant-scoped call.
+      expect(bulkAppend).toHaveBeenCalledTimes(1);
       for (const [records, ctx] of bulkAppend.mock.calls as Array<[any[], any]>) {
         expect(ctx.tenantId).toBe(tenantA);
-        expect(records.every((r) => r.src === ctx.aggregateId)).toBe(true);
+        expect((records as { src: string }[]).map((r) => r.src).sort()).toEqual([
+          "trace-a1",
+          "trace-a2",
+        ]);
       }
 
       // Fold projection was paused while its own WRITE phase ran. The map's
@@ -824,6 +825,119 @@ describe("ReplayService tenant-specific ClickHouse", () => {
       expect(bulkAppend).toHaveBeenCalled();
       expect(batchKinds).toEqual(["map"]);
       expect([...progressKinds]).toEqual(["map"]);
+    });
+  });
+
+  describe("replayOptimized batch pause windows", () => {
+    const pausedSetKey = "{event-sourcing/jobs}:gq:paused-jobs";
+
+    function createTrackedMapProjection({
+      name,
+      bulkAppend,
+    }: {
+      name: string;
+      bulkAppend: any;
+    }): RegisteredMapProjection {
+      return {
+        projectionName: name,
+        pipelineName: "test_pipeline",
+        aggregateType: "trace",
+        source: "pipeline",
+        pauseKey: `test_pipeline/handler/${name}`,
+        kind: "map",
+        definition: {
+          name,
+          eventTypes: ["trace.upserted"],
+          map: (event: any) => ({ src: event.aggregateId }),
+          store: { append: async () => undefined, bulkAppend },
+        },
+      };
+    }
+
+    describe("when a replay spans multiple batches", () => {
+      it("pauses only while a batch is replayed and resumes between batches", async () => {
+        const redis = getTestRedisConnection()!;
+        const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+        const mapName = `optBatchPause_${suffix}`;
+        const mapPauseKey = `test_pipeline/handler/${mapName}`;
+
+        const pausedDuringWrite: number[] = [];
+        const bulkAppend = vi.fn(async (_records: any[], _ctx: any) => {
+          pausedDuringWrite.push(await redis.sismember(pausedSetKey, mapPauseKey));
+        });
+        const projection = createTrackedMapProjection({ name: mapName, bulkAppend });
+        const service = createServiceWithResolver();
+
+        const pausedAtBatchComplete: number[] = [];
+        const pendingChecks: Promise<void>[] = [];
+
+        // aggregateBatchSize 1 with tenant A's two trace aggregates → 2 batches.
+        const result = await service.replayOptimized(
+          {
+            projections: [],
+            mapProjections: [projection],
+            tenantIds: [tenantA],
+            since: "2023-11-01",
+            aggregateBatchSize: 1,
+          },
+          {
+            onBatchComplete: () => {
+              // The sismember is issued synchronously here (same Redis
+              // connection, ordered before the next batch's re-pause) but
+              // resolves async — collect it so assertions wait for it.
+              pendingChecks.push(
+                redis.sismember(pausedSetKey, mapPauseKey).then((paused) => {
+                  pausedAtBatchComplete.push(paused);
+                }),
+              );
+            },
+          },
+        );
+        await Promise.all(pendingChecks);
+
+        expect(result.batchErrors).toBe(0);
+        expect(result.aggregatesReplayed).toBe(2);
+
+        // One flush per batch — pause held while each batch's records land.
+        expect(bulkAppend).toHaveBeenCalledTimes(2);
+        expect(pausedDuringWrite).toEqual([1, 1]);
+
+        // Between batches (onBatchComplete fires after the batch's finally
+        // unpauses), live processing is running again — the freeze is
+        // per-batch, never for the whole run.
+        expect(pausedAtBatchComplete).toEqual([0, 0]);
+
+        // Unpaused at the end too.
+        expect(await redis.sismember(pausedSetKey, mapPauseKey)).toBe(0);
+      });
+    });
+
+    describe("when a batch fails", () => {
+      it("unpauses the projections instead of leaving live processing frozen", async () => {
+        const redis = getTestRedisConnection()!;
+        const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+        const mapName = `optBatchFail_${suffix}`;
+        const mapPauseKey = `test_pipeline/handler/${mapName}`;
+
+        const bulkAppend = vi.fn(async () => {
+          throw new Error("bulk write boom");
+        });
+        const projection = createTrackedMapProjection({ name: mapName, bulkAppend });
+        const service = createServiceWithResolver();
+
+        const result = await service.replayOptimized({
+          projections: [],
+          mapProjections: [projection],
+          tenantIds: [tenantA],
+          since: "2023-11-01",
+        });
+
+        expect(result.batchErrors).toBeGreaterThan(0);
+        expect(result.firstError).toMatch(/bulk write boom/);
+
+        // The per-batch finally unpaused despite the failure.
+        expect(await redis.sismember(pausedSetKey, mapPauseKey)).toBe(0);
+      });
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/replay/__tests__/replayService.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/replay/__tests__/replayService.integration.test.ts
@@ -940,4 +940,126 @@ describe("ReplayService tenant-specific ClickHouse", () => {
       });
     });
   });
+
+  describe("replayOptimized multi-tenant batches", () => {
+    describe("when a batch spans multiple tenants", () => {
+      it("routes each tenant's records to its own tenant-scoped bulkAppend call", async () => {
+        const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+        const mapName = `optMultiTenant_${suffix}`;
+        // A unique event type keeps discovery scoped to exactly the aggregates
+        // seeded below, independent of data earlier tests inserted.
+        const eventType = `trace.multitenant_${suffix}`;
+        const aggA1 = `trace-mt-a1-${suffix}`;
+        const aggA2 = `trace-mt-a2-${suffix}`;
+        const aggB1 = `trace-mt-b1-${suffix}`;
+
+        await client.insert({
+          table: "event_log",
+          values: [
+            {
+              TenantId: tenantA,
+              AggregateType: "trace",
+              AggregateId: aggA1,
+              EventId: `evt-mt-a-001-${suffix}`,
+              EventType: eventType,
+              EventTimestamp: 1700000005000,
+              EventOccurredAt: 1700000005000,
+              EventVersion: "2025-01-01",
+              EventPayload: JSON.stringify({ value: 1 }),
+              _retention_days: 0,
+            },
+            {
+              TenantId: tenantA,
+              AggregateType: "trace",
+              AggregateId: aggA2,
+              EventId: `evt-mt-a-002-${suffix}`,
+              EventType: eventType,
+              EventTimestamp: 1700000006000,
+              EventOccurredAt: 1700000006000,
+              EventVersion: "2025-01-01",
+              EventPayload: JSON.stringify({ value: 2 }),
+              _retention_days: 0,
+            },
+            {
+              TenantId: tenantB,
+              AggregateType: "trace",
+              AggregateId: aggB1,
+              EventId: `evt-mt-b-001-${suffix}`,
+              EventType: eventType,
+              EventTimestamp: 1700000007000,
+              EventOccurredAt: 1700000007000,
+              EventVersion: "2025-01-01",
+              EventPayload: JSON.stringify({ value: 3 }),
+              _retention_days: 0,
+            },
+          ],
+          format: "JSONEachRow",
+        });
+
+        // Discovery must see all three freshly inserted events — poll until
+        // ClickHouse reports them visible (insert visibility is not
+        // synchronous on CI).
+        for (let attempt = 0; attempt < 50; attempt++) {
+          const visible = await client.query({
+            query: `SELECT count() AS c FROM event_log WHERE TenantId IN ({tenantA:String}, {tenantB:String}) AND EventType = {eventType:String}`,
+            query_params: { tenantA, tenantB, eventType },
+            format: "JSONEachRow",
+          });
+          const [row] = (await visible.json()) as Array<{ c: string }>;
+          if (Number(row?.c) >= 3) break;
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+
+        const bulkAppend = vi.fn().mockResolvedValue(undefined);
+        const projection: RegisteredMapProjection = {
+          projectionName: mapName,
+          pipelineName: "test_pipeline",
+          aggregateType: "trace",
+          source: "pipeline",
+          pauseKey: `test_pipeline/handler/${mapName}`,
+          kind: "map",
+          definition: {
+            name: mapName,
+            eventTypes: [eventType],
+            map: (event: any) => ({ src: event.aggregateId }),
+            store: { append: async () => undefined, bulkAppend },
+          },
+        };
+
+        const service = createServiceWithResolver();
+
+        const result = await service.replayOptimized({
+          projections: [],
+          mapProjections: [projection],
+          tenantIds: [tenantA, tenantB],
+          since: "2023-11-01",
+        });
+
+        expect(result.batchErrors).toBe(0);
+        // 2 aggregates for tenant A + 1 for tenant B, one event each.
+        expect(result.aggregatesReplayed).toBe(3);
+        expect(result.totalEvents).toBe(3);
+
+        // The per-tenant cutoff/load fan-out resolved a client for each tenant.
+        expect(resolverCalls).toContain(tenantA);
+        expect(resolverCalls).toContain(tenantB);
+
+        // Records flush in per-tenant chunks: exactly one tenant-scoped
+        // bulkAppend per tenant, each carrying ONLY that tenant's aggregates.
+        // A boundsByTenant keying bug or cross-tenant mixup in the parallel
+        // cutoff/load path would drop or mix records across these calls.
+        expect(bulkAppend).toHaveBeenCalledTimes(2);
+        const recordsByTenant = new Map<string, string[]>();
+        for (const [records, ctx] of bulkAppend.mock.calls as Array<[Array<{ src: string }>, any]>) {
+          expect(recordsByTenant.has(ctx.tenantId)).toBe(false);
+          recordsByTenant.set(
+            ctx.tenantId,
+            records.map((r) => r.src).sort(),
+          );
+        }
+        expect(recordsByTenant.get(tenantA)).toEqual([aggA1, aggA2]);
+        expect(recordsByTenant.get(tenantB)).toEqual([aggB1]);
+      });
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/replay/replayEventLoader.ts
+++ b/langwatch/src/server/event-sourcing/replay/replayEventLoader.ts
@@ -197,20 +197,26 @@ function occurredAtPredicate(bounds?: OccurredAtBounds): {
  *
  * The query itself reads only the tiny `EventOccurredAt` column via the
  * primary-key filter — cheap compared to the payload-bearing load queries it
- * lets ClickHouse prune.
+ * lets ClickHouse prune. `event_log` is ORDER BY (TenantId, AggregateType,
+ * AggregateId, IdempotencyKey), so the `AggregateType` predicate is required
+ * for the key filter to stay a binary search instead of degrading to a scan
+ * of the whole tenant prefix.
  *
- * Returns null when the aggregates have no events (nothing to prune or load).
+ * Returns undefined when the aggregates have no events (nothing to prune or
+ * load).
  */
 export async function getAggregateOccurredAtBounds({
   client,
   tenantId,
+  aggregateTypes,
   aggregateIds,
 }: {
   client: ClickHouseClient;
   tenantId: string;
+  aggregateTypes: string[];
   aggregateIds: string[];
-}): Promise<OccurredAtBounds | null> {
-  if (aggregateIds.length === 0) return null;
+}): Promise<OccurredAtBounds | undefined> {
+  if (aggregateIds.length === 0) return undefined;
 
   const result = await client.query({
     query: `
@@ -220,9 +226,10 @@ export async function getAggregateOccurredAtBounds({
         max(EventOccurredAt) AS maxOccurredAt
       FROM event_log
       WHERE TenantId = {tenantId:String}
+        AND AggregateType IN ({aggregateTypes:Array(String)})
         AND AggregateId IN ({aggregateIds:Array(String)})
     `,
-    query_params: { tenantId, aggregateIds },
+    query_params: { tenantId, aggregateTypes, aggregateIds },
     format: "JSONEachRow",
   });
 
@@ -232,7 +239,7 @@ export async function getAggregateOccurredAtBounds({
     maxOccurredAt: string;
   }[];
   const row = rows[0];
-  if (!row || parseInt(row.cnt, 10) === 0) return null;
+  if (!row || parseInt(row.cnt, 10) === 0) return undefined;
 
   return {
     minMs: parseInt(row.minOccurredAt, 10),

--- a/langwatch/src/server/event-sourcing/replay/replayEventLoader.ts
+++ b/langwatch/src/server/event-sourcing/replay/replayEventLoader.ts
@@ -158,19 +158,109 @@ export interface CutoffInfo {
 }
 
 /**
+ * Inclusive `EventOccurredAt` range (ms) covering EVERY event of a set of
+ * aggregates. Used purely as a partition-pruning predicate: `event_log` is
+ * `PARTITION BY toYearWeek(EventOccurredAt)`, so without a WHERE on
+ * `EventOccurredAt` every cutoff/load query scans ALL partitions — including
+ * cold storage on S3 — once per batch.
+ */
+export interface OccurredAtBounds {
+  minMs: number;
+  maxMs: number;
+}
+
+/** SQL fragment + params for an optional occurred-at pruning predicate. */
+function occurredAtPredicate(bounds?: OccurredAtBounds): {
+  sql: string;
+  params: Record<string, unknown>;
+} {
+  if (!bounds) return { sql: "", params: {} };
+  return {
+    sql: `AND EventOccurredAt >= {minOccurredAtMs:UInt64}
+        AND EventOccurredAt <= {maxOccurredAtMs:UInt64}`,
+    params: { minOccurredAtMs: bounds.minMs, maxOccurredAtMs: bounds.maxMs },
+  };
+}
+
+/**
+ * Compute the `EventOccurredAt` min/max over ALL events of the given
+ * aggregates (no event-type filter, full history).
+ *
+ * This is the provably-safe pruning bound for a replay batch's subsequent
+ * cutoff/load queries: every event those queries must see already existed
+ * when this query ran, so it lies within [min, max] by construction. Events
+ * appended afterwards carry an `EventTimestamp` after the batch's cutoff and
+ * are handled by live processing per the replay marker protocol (ADR-015),
+ * so excluding them from the bounded queries is correct. (Bounding by the
+ * replay's `since` instead would be UNSAFE: fold projections rebuild from
+ * `init()` and need the aggregate's full history, which can predate `since`.)
+ *
+ * The query itself reads only the tiny `EventOccurredAt` column via the
+ * primary-key filter — cheap compared to the payload-bearing load queries it
+ * lets ClickHouse prune.
+ *
+ * Returns null when the aggregates have no events (nothing to prune or load).
+ */
+export async function getAggregateOccurredAtBounds({
+  client,
+  tenantId,
+  aggregateIds,
+}: {
+  client: ClickHouseClient;
+  tenantId: string;
+  aggregateIds: string[];
+}): Promise<OccurredAtBounds | null> {
+  if (aggregateIds.length === 0) return null;
+
+  const result = await client.query({
+    query: `
+      SELECT
+        count() AS cnt,
+        min(EventOccurredAt) AS minOccurredAt,
+        max(EventOccurredAt) AS maxOccurredAt
+      FROM event_log
+      WHERE TenantId = {tenantId:String}
+        AND AggregateId IN ({aggregateIds:Array(String)})
+    `,
+    query_params: { tenantId, aggregateIds },
+    format: "JSONEachRow",
+  });
+
+  const rows = (await result.json()) as {
+    cnt: string;
+    minOccurredAt: string;
+    maxOccurredAt: string;
+  }[];
+  const row = rows[0];
+  if (!row || parseInt(row.cnt, 10) === 0) return null;
+
+  return {
+    minMs: parseInt(row.minOccurredAt, 10),
+    maxMs: parseInt(row.maxOccurredAt, 10),
+  };
+}
+
+/**
  * Get cutoff event info for a batch of aggregates in one query.
+ *
+ * `occurredAtBounds` (when available) enables partition pruning; pass bounds
+ * from {@link getAggregateOccurredAtBounds} so no event of these aggregates
+ * can fall outside the range.
  */
 export async function batchGetCutoffEventIds({
   client,
   tenantId,
   aggregateIds,
   eventTypes,
+  occurredAtBounds,
 }: {
   client: ClickHouseClient;
   tenantId: string;
   aggregateIds: string[];
   eventTypes: readonly string[];
+  occurredAtBounds?: OccurredAtBounds;
 }): Promise<Map<string, CutoffInfo>> {
+  const pruning = occurredAtPredicate(occurredAtBounds);
   const result = await client.query({
     query: `
       SELECT
@@ -182,9 +272,10 @@ export async function batchGetCutoffEventIds({
       WHERE TenantId = {tenantId:String}
         AND EventType IN ({eventTypes:Array(String)})
         AND AggregateId IN ({aggregateIds:Array(String)})
+        ${pruning.sql}
       GROUP BY AggregateType, AggregateId
     `,
-    query_params: { tenantId, eventTypes: [...eventTypes], aggregateIds },
+    query_params: { tenantId, eventTypes: [...eventTypes], aggregateIds, ...pruning.params },
     format: "JSONEachRow",
   });
 
@@ -217,14 +308,17 @@ export async function loadEventsForAggregatesBulk({
   tenantId,
   aggregateIds,
   cutoffs,
+  occurredAtBounds,
 }: {
   client: ClickHouseClient;
   tenantId: string;
   aggregateIds: string[];
   cutoffs: Map<string, CutoffInfo>;
+  occurredAtBounds?: OccurredAtBounds;
 }): Promise<Map<string, ReplayEvent[]>> {
   if (aggregateIds.length === 0) return new Map();
 
+  const pruning = occurredAtPredicate(occurredAtBounds);
   const result = await client.query({
     query: `
       SELECT EventId, EventTimestamp, EventOccurredAt, EventType, EventPayload,
@@ -233,9 +327,10 @@ export async function loadEventsForAggregatesBulk({
       FROM event_log
       WHERE TenantId = {tenantId:String}
         AND AggregateId IN ({aggregateIds:Array(String)})
+        ${pruning.sql}
       ORDER BY AggregateId, EventTimestamp ASC, EventId ASC
     `,
-    query_params: { tenantId, aggregateIds },
+    query_params: { tenantId, aggregateIds, ...pruning.params },
     format: "JSONEachRow",
   });
 
@@ -278,6 +373,7 @@ export async function batchLoadAggregateEvents({
   maxCutoffEventId,
   cursorEventId,
   batchSize,
+  occurredAtBounds,
 }: {
   client: ClickHouseClient;
   tenantId: string;
@@ -286,8 +382,10 @@ export async function batchLoadAggregateEvents({
   maxCutoffEventId: string;
   cursorEventId: string;
   batchSize: number;
+  occurredAtBounds?: OccurredAtBounds;
 }): Promise<ReplayEvent[]> {
   const hasCursor = cursorEventId.length > 0;
+  const pruning = occurredAtPredicate(occurredAtBounds);
 
   const query = `
     SELECT EventId, EventTimestamp, EventOccurredAt, EventType, EventPayload,
@@ -299,6 +397,7 @@ export async function batchLoadAggregateEvents({
       AND AggregateId IN ({aggregateIds:Array(String)})
       AND EventId <= {maxCutoffEventId:String}
       ${hasCursor ? "AND EventId > {cursorEventId:String}" : ""}
+      ${pruning.sql}
     ORDER BY EventId ASC
     LIMIT {batchSize:UInt32}
   `;
@@ -312,6 +411,7 @@ export async function batchLoadAggregateEvents({
       maxCutoffEventId,
       ...(hasCursor ? { cursorEventId } : {}),
       batchSize,
+      ...pruning.params,
     },
     format: "JSONEachRow",
   });

--- a/langwatch/src/server/event-sourcing/replay/replayExecutor.ts
+++ b/langwatch/src/server/event-sourcing/replay/replayExecutor.ts
@@ -1,6 +1,9 @@
 import type { TenantId } from "../domain/tenantId";
 import type { FoldProjectionDefinition } from "../projections/foldProjection.types";
-import type { MapProjectionDefinition } from "../projections/mapProjection.types";
+import type {
+  BulkAppendContext,
+  MapProjectionDefinition,
+} from "../projections/mapProjection.types";
 import type { ProjectionStoreContext } from "../projections/projectionStoreContext";
 import type { ReplayEvent } from "./replayEventLoader";
 import type { Event } from "../domain/types";
@@ -157,9 +160,11 @@ export class FoldAccumulator {
  * Unlike FoldAccumulator (which merges state per aggregate), MapAccumulator
  * buffers one output record per event along with the originating event's
  * `ProjectionStoreContext`. Records are grouped by tenantId and flushed in
- * bulk via `store.bulkAppend()` (or sequential `store.append()` as fallback);
- * the per-event context is preserved on the fallback path so stores keying
- * off `context.aggregateId` behave the same as the non-optimized replay.
+ * per-tenant chunks via `store.bulkAppend()` (tenant-scoped context, records
+ * from many aggregates per call) or via sequential `store.append()` as a
+ * fallback; the per-event context is preserved on the fallback path so stores
+ * keying off `context.aggregateId` behave the same as the non-optimized
+ * replay.
  *
  * Map records are append-only and need no cross-page state, so `apply`
  * flushes incrementally: once the buffer reaches `writeBatchSize` the
@@ -250,27 +255,19 @@ export class MapAccumulator {
       const retentionPolicy = await this.resolveRetention(tenantId);
 
       if (store.bulkAppend) {
-        // Group by aggregateId so each `bulkAppend` call gets a real
-        // per-aggregate context. Stores that key off `context.aggregateId`
-        // (rather than reading it from the record) then see the same value
-        // they would on the non-optimized `append()` path.
-        const byAggregate = new Map<string, BufferedMapRecord[]>();
-        for (const entry of entries) {
-          const key = entry.context.aggregateId;
-          let list = byAggregate.get(key);
-          if (!list) {
-            list = [];
-            byAggregate.set(key, list);
-          }
-          list.push(entry);
-        }
-
-        for (const aggregateEntries of byAggregate.values()) {
-          const groupContext = { ...aggregateEntries[0]!.context, retentionPolicy };
-          for (let i = 0; i < aggregateEntries.length; i += writeBatchSize) {
-            const chunk = aggregateEntries.slice(i, i + writeBatchSize).map((e) => e.record);
-            await store.bulkAppend(chunk, groupContext);
-          }
+        // One bulk write per TENANT chunk — never per aggregate. For
+        // spanStorage-style projections the aggregate is a single trace, so
+        // per-aggregate grouping degenerated into one awaited ClickHouse
+        // INSERT per trace (~200ms each, sequential) and dominated replay
+        // time. `bulkAppend` takes a tenant-scoped BulkAppendContext; records
+        // carry everything stores need per row.
+        const context: BulkAppendContext = {
+          tenantId: tenantId as TenantId,
+          retentionPolicy,
+        };
+        for (let i = 0; i < entries.length; i += writeBatchSize) {
+          const chunk = entries.slice(i, i + writeBatchSize).map((e) => e.record);
+          await store.bulkAppend(chunk, context);
         }
       } else {
         // Sequential fallback: pass each record's original per-event context

--- a/langwatch/src/server/event-sourcing/replay/replayExecutor.ts
+++ b/langwatch/src/server/event-sourcing/replay/replayExecutor.ts
@@ -155,7 +155,7 @@ export class FoldAccumulator {
 }
 
 interface BufferedMapRecord {
-  record: any;
+  record: unknown;
   context: ProjectionStoreContext;
 }
 

--- a/langwatch/src/server/event-sourcing/replay/replayExecutor.ts
+++ b/langwatch/src/server/event-sourcing/replay/replayExecutor.ts
@@ -154,6 +154,11 @@ export class FoldAccumulator {
   }
 }
 
+interface BufferedMapRecord {
+  record: any;
+  context: ProjectionStoreContext;
+}
+
 /**
  * Accumulates map projection records as events are fed in one at a time.
  *
@@ -172,11 +177,6 @@ export class FoldAccumulator {
  * to the final `flush()`. Memory is therefore bounded by `writeBatchSize`,
  * not by the number of events in an aggregate batch.
  */
-interface BufferedMapRecord {
-  record: any;
-  context: ProjectionStoreContext;
-}
-
 export class MapAccumulator {
   private byTenant = new Map<string, BufferedMapRecord[]>();
   private bufferedCount = 0;

--- a/langwatch/src/server/event-sourcing/replay/replayService.ts
+++ b/langwatch/src/server/event-sourcing/replay/replayService.ts
@@ -14,11 +14,13 @@ import type {
 } from "./types";
 import type { CutoffInfo, DiscoveredAggregate, ReplayEvent } from "./replayEventLoader";
 import { isAtOrBeforeCutoff } from "./replayConstants";
+import type { OccurredAtBounds } from "./replayEventLoader";
 import {
   discoverAffectedAggregates,
   countEventsForAggregates,
   batchGetCutoffEventIds,
   batchLoadAggregateEvents,
+  getAggregateOccurredAtBounds,
   loadEventsForAggregatesBulk,
 } from "./replayEventLoader";
 import {
@@ -44,6 +46,14 @@ export interface ReplayLogWriter {
 
 /** No-op log for when no logging is needed. */
 const nullLog: ReplayLogWriter = { write() {} };
+
+/**
+ * Emit replay-phase progress once per this many completed aggregates (plus
+ * once at the end of the batch). Every emit fans out to the progress callback
+ * — which the ops layer persists to Redis in multiple round trips — so
+ * per-aggregate emits (1000/batch) hammered Redis for no operator benefit.
+ */
+const PROGRESS_EMIT_EVERY_AGGREGATES = 100;
 
 export class ReplayService {
   constructor(private readonly deps: {
@@ -472,13 +482,23 @@ export class ReplayService {
     await waitForActiveJobs({ redis, aggregates: batch, projectionName, kind: "fold" });
     log.write({ step: "drain-batch", tenant: tenantId, count: batch.length, durationMs: Date.now() - drainStart });
 
-    // 4. CUTOFF
+    // 4. CUTOFF — occurred-at bounds first (over all events of the batch's
+    //    aggregates) so the cutoff + load queries prune event_log's weekly
+    //    partitions instead of scanning cold storage. See
+    //    getAggregateOccurredAtBounds for why this bound is safe.
     onBatchPhase("cutoff");
+    const occurredAtBounds =
+      (await getAggregateOccurredAtBounds({
+        client,
+        tenantId,
+        aggregateIds: batch.map((a) => a.aggregateId),
+      })) ?? undefined;
     const cutoffs = await batchGetCutoffEventIds({
       client,
       tenantId,
       aggregateIds: batch.map((a) => a.aggregateId),
       eventTypes: projection.definition.eventTypes,
+      occurredAtBounds,
     });
 
     const withCutoffKeys: string[] = [];
@@ -528,6 +548,7 @@ export class ReplayService {
         maxCutoffEventId,
         cursorEventId,
         batchSize,
+        occurredAtBounds,
       });
 
       if (events.length === 0) break;
@@ -823,13 +844,21 @@ export class ReplayService {
     await waitForActiveJobs({ redis, aggregates: batch, projectionName, kind: "map" });
     log.write({ step: "drain-batch", tenant: tenantId, count: batch.length, durationMs: Date.now() - drainStart, kind: "map" });
 
-    // 4. CUTOFF
+    // 4. CUTOFF — occurred-at bounds first, for partition pruning (see
+    //    replayBatch / getAggregateOccurredAtBounds).
     onBatchPhase("cutoff");
+    const occurredAtBounds =
+      (await getAggregateOccurredAtBounds({
+        client,
+        tenantId,
+        aggregateIds: batch.map((a) => a.aggregateId),
+      })) ?? undefined;
     const cutoffs = await batchGetCutoffEventIds({
       client,
       tenantId,
       aggregateIds: batch.map((a) => a.aggregateId),
       eventTypes: projection.definition.eventTypes,
+      occurredAtBounds,
     });
 
     const withCutoffKeys: string[] = [];
@@ -882,6 +911,7 @@ export class ReplayService {
         maxCutoffEventId,
         cursorEventId,
         batchSize,
+        occurredAtBounds,
       });
 
       if (events.length === 0) break;
@@ -1082,132 +1112,153 @@ export class ReplayService {
       return { aggregatesReplayed: 0, totalEvents: 0, batchErrors: 0 };
     }
 
-    // 2. Pause ALL projections at once (fold + map)
+    // 2. Pause + drain happen PER BATCH inside the loop below (ADR-015: the
+    //    pause window is "seconds per batch", not the whole run — a full-run
+    //    pause froze live processing for as long as the replay took). The
+    //    replay marker protocol (pending/cutoff/done) keeps replayed
+    //    aggregates correct across the unpaused gaps between batches.
     const allProjectionsToPause = [...config.projections, ...mapProjections];
-    for (const p of allProjectionsToPause) {
-      await pauseProjection({
-        redis: this.deps.redis,
-        pauseKey: p.pauseKey,
-      });
-    }
-    log.write({ step: "pause-all", projections: allProjectionsToPause.map((p) => p.projectionName) });
+    const pausedProjectionEntries = allProjectionsToPause.map((p) => ({
+      projectionName: p.projectionName,
+      kind: p.kind,
+    }));
 
-    // 3. Drain ALL active jobs across all projections
-    const allDiscoveredAggregates: DiscoveredAggregate[] = remaining.map((key) => {
-      const entry = aggregateProjectionMap.get(key)!;
-      return { tenantId: entry.tenantId, aggregateType: entry.aggregateType, aggregateId: entry.aggregateId };
-    });
+    const runTenantCount = new Set(
+      remaining.map((key) => aggregateProjectionMap.get(key)!.tenantId),
+    ).size;
 
     const totalBatches = Math.ceil(remaining.length / aggregateBatchSize);
     let aggregatesCompleted = skippedCount;
 
-    try {
-      await waitForAllActiveJobs({
-        redis: this.deps.redis,
-        aggregates: allDiscoveredAggregates,
-        projections: allProjectionsToPause.map((p) => ({
-          projectionName: p.projectionName,
-          kind: p.kind,
-        })),
+    for (let i = 0; i < remaining.length; i += aggregateBatchSize) {
+      const batchKeys = remaining.slice(i, i + aggregateBatchSize);
+      const batchNum = Math.floor(i / aggregateBatchSize) + 1;
+      const batchStartTime = Date.now();
+
+      const batchAggregates: DiscoveredAggregate[] = batchKeys.map((key) => {
+        const entry = aggregateProjectionMap.get(key)!;
+        return {
+          tenantId: entry.tenantId,
+          aggregateType: entry.aggregateType,
+          aggregateId: entry.aggregateId,
+        };
       });
-      log.write({ step: "drain-all", aggregateCount: allDiscoveredAggregates.length });
 
-      for (let i = 0; i < remaining.length; i += aggregateBatchSize) {
-        const batchKeys = remaining.slice(i, i + aggregateBatchSize);
-        const batchNum = Math.floor(i / aggregateBatchSize) + 1;
-        const batchStartTime = Date.now();
+      const progress: ReplayProgress = {
+        phase: "replaying",
+        currentProjectionName: allProjectionNames.join("+"),
+        currentProjectionKind: runProjectionKind,
+        currentProjectionIndex: 0,
+        totalProjections: allProjectionNames.length,
+        totalAggregates: allAggregateKeys.length,
+        tenantCount: runTenantCount,
+        currentBatch: batchNum,
+        totalBatches,
+        batchAggregates: batchKeys.length,
+        batchPhase: "pause",
+        batchEventsProcessed: 0,
+        aggregatesCompleted,
+        totalEventsReplayed,
+        elapsedSec: (Date.now() - startTime) / 1000,
+        skippedCount,
+        batchErrors: totalBatchErrors,
+        firstError,
+      };
 
-        const progress: ReplayProgress = {
-          phase: "replaying",
-          currentProjectionName: allProjectionNames.join("+"),
-          currentProjectionKind: runProjectionKind,
-          currentProjectionIndex: 0,
-          totalProjections: allProjectionNames.length,
-          totalAggregates: allAggregateKeys.length,
-          tenantCount: new Set(allDiscoveredAggregates.map((a) => a.tenantId)).size,
-          currentBatch: batchNum,
-          totalBatches,
-          batchAggregates: batchKeys.length,
-          batchPhase: "mark",
-          batchEventsProcessed: 0,
-          aggregatesCompleted,
-          totalEventsReplayed,
-          elapsedSec: (Date.now() - startTime) / 1000,
-          skippedCount,
+      const emit = () => {
+        progress.elapsedSec = (Date.now() - startTime) / 1000;
+        callbacks?.onProgress?.({ ...progress });
+      };
+
+      emit();
+
+      // Pause only for this batch's window.
+      for (const p of allProjectionsToPause) {
+        await pauseProjection({
+          redis: this.deps.redis,
+          pauseKey: p.pauseKey,
+        });
+      }
+      log.write({
+        step: "pause-batch",
+        batch: batchNum,
+        projections: allProjectionNames,
+      });
+
+      let batchResult: { eventsReplayed: number };
+      try {
+        // Drain only THIS batch's aggregates — not every discovered aggregate.
+        progress.batchPhase = "drain";
+        emit();
+        await waitForAllActiveJobs({
+          redis: this.deps.redis,
+          aggregates: batchAggregates,
+          projections: pausedProjectionEntries,
+        });
+        log.write({ step: "drain-batch", batch: batchNum, aggregateCount: batchAggregates.length });
+
+        batchResult = await this.replayBatchOptimized({
+          batchKeys,
+          aggregateProjectionMap,
+          projectionByName,
+          mapProjectionByName,
+          aggregateBatchSize,
+          concurrency,
+          log,
+          onBatchPhase: (phase, eventsProcessed) => {
+            progress.batchPhase = phase;
+            if (eventsProcessed !== undefined) {
+              progress.batchEventsProcessed = eventsProcessed;
+              progress.totalEventsReplayed = totalEventsReplayed + eventsProcessed;
+            }
+            emit();
+          },
+        });
+      } catch (error) {
+        totalBatchErrors++;
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        if (!firstError) firstError = errorMsg;
+        log.write({ step: "error", batch: batchNum, error: errorMsg });
+
+        progress.batchErrors = totalBatchErrors;
+        progress.firstError = firstError;
+        emit();
+
+        return {
+          aggregatesReplayed: aggregatesCompleted - skippedCount,
+          totalEvents: totalEventsReplayed,
           batchErrors: totalBatchErrors,
           firstError,
         };
-
-        const emit = () => {
-          progress.elapsedSec = (Date.now() - startTime) / 1000;
-          callbacks?.onProgress?.({ ...progress });
-        };
-
-        emit();
-
-        try {
-          const batchResult = await this.replayBatchOptimized({
-            batchKeys,
-            aggregateProjectionMap,
-            projectionByName,
-            mapProjectionByName,
-            aggregateBatchSize,
-            concurrency,
-            log,
-            onBatchPhase: (phase, eventsProcessed) => {
-              progress.batchPhase = phase;
-              if (eventsProcessed !== undefined) {
-                progress.batchEventsProcessed = eventsProcessed;
-                progress.totalEventsReplayed = totalEventsReplayed + eventsProcessed;
-              }
-              emit();
-            },
-          });
-
-          totalEventsReplayed += batchResult.eventsReplayed;
-          aggregatesCompleted += batchKeys.length;
-
-          for (const key of batchKeys) {
-            const entry = aggregateProjectionMap.get(key)!;
-            touchedTenants.add(entry.tenantId);
-          }
-
-          callbacks?.onBatchComplete?.({
-            projectionName: allProjectionNames.join("+"),
-            projectionKind: runProjectionKind,
-            batchNum,
-            totalBatches,
-            aggregatesInBatch: batchKeys.length,
-            eventsInBatch: batchResult.eventsReplayed,
-            durationSec: (Date.now() - batchStartTime) / 1000,
-          });
-        } catch (error) {
-          totalBatchErrors++;
-          const errorMsg = error instanceof Error ? error.message : String(error);
-          if (!firstError) firstError = errorMsg;
-          log.write({ step: "error", batch: batchNum, error: errorMsg });
-
-          progress.batchErrors = totalBatchErrors;
-          progress.firstError = firstError;
-          emit();
-
-          return {
-            aggregatesReplayed: aggregatesCompleted - skippedCount,
-            totalEvents: totalEventsReplayed,
-            batchErrors: totalBatchErrors,
-            firstError,
-          };
+      } finally {
+        // Unpause after EVERY batch — including the error return above — so
+        // a failed batch can never leave live processing frozen.
+        for (const p of allProjectionsToPause) {
+          await unpauseProjection({
+            redis: this.deps.redis,
+            pauseKey: p.pauseKey,
+          }).catch(() => {});
         }
+        log.write({ step: "unpause-batch", batch: batchNum, projections: allProjectionNames });
       }
-    } finally {
-      // 5. Unpause ALL projections — always runs, even on unexpected errors
-      for (const p of allProjectionsToPause) {
-        await unpauseProjection({
-          redis: this.deps.redis,
-          pauseKey: p.pauseKey,
-        }).catch(() => {});
+
+      totalEventsReplayed += batchResult.eventsReplayed;
+      aggregatesCompleted += batchKeys.length;
+
+      for (const key of batchKeys) {
+        const entry = aggregateProjectionMap.get(key)!;
+        touchedTenants.add(entry.tenantId);
       }
-      log.write({ step: "unpause-all", projections: allProjectionsToPause.map((p) => p.projectionName) });
+
+      callbacks?.onBatchComplete?.({
+        projectionName: allProjectionNames.join("+"),
+        projectionKind: runProjectionKind,
+        batchNum,
+        totalBatches,
+        aggregatesInBatch: batchKeys.length,
+        eventsInBatch: batchResult.eventsReplayed,
+        durationSec: (Date.now() - batchStartTime) / 1000,
+      });
     }
 
     // 6. Cleanup markers for all projections
@@ -1322,19 +1373,33 @@ export class ReplayService {
       }
     }
 
+    // Per-tenant queries are independent — run them in parallel instead of
+    // serially awaiting one tenant at a time. Each tenant first computes its
+    // occurred-at bounds (cheap, key-column-only) so the cutoff and load
+    // queries can prune event_log's weekly partitions; see
+    // getAggregateOccurredAtBounds for the safety argument.
     const allCutoffs = new Map<string, CutoffInfo>();
-    for (const [tenantId, entries] of byTenant) {
-      const client = await this.resolveClient(tenantId);
-      const tenantCutoffs = await batchGetCutoffEventIds({
-        client,
-        tenantId,
-        aggregateIds: entries.map((e) => e.aggregateId),
-        eventTypes: [...allEventTypes],
-      });
-      for (const [k, v] of tenantCutoffs) {
-        allCutoffs.set(k, v);
-      }
-    }
+    const boundsByTenant = new Map<string, OccurredAtBounds | undefined>();
+    await Promise.all(
+      [...byTenant.entries()].map(async ([tenantId, entries]) => {
+        const client = await this.resolveClient(tenantId);
+        const aggregateIds = entries.map((e) => e.aggregateId);
+        const occurredAtBounds =
+          (await getAggregateOccurredAtBounds({ client, tenantId, aggregateIds })) ??
+          undefined;
+        boundsByTenant.set(tenantId, occurredAtBounds);
+        const tenantCutoffs = await batchGetCutoffEventIds({
+          client,
+          tenantId,
+          aggregateIds,
+          eventTypes: [...allEventTypes],
+          occurredAtBounds,
+        });
+        for (const [k, v] of tenantCutoffs) {
+          allCutoffs.set(k, v);
+        }
+      }),
+    );
 
     // Split into with/without cutoffs
     const withCutoffKeys: string[] = [];
@@ -1389,31 +1454,36 @@ export class ReplayService {
       }
     }
 
-    // Load events grouped by tenant (one CH query per tenant)
+    // Load events grouped by tenant (one CH query per tenant, in parallel).
     const allEvents = new Map<string, ReplayEvent[]>();
 
-    for (const [tenantId, entries] of byTenant) {
-      const client = await this.resolveClient(tenantId);
-      const aggIds = entries
-        .filter((e) => allCutoffs.has(e.key))
-        .map((e) => e.aggregateId);
+    await Promise.all(
+      [...byTenant.entries()].map(async ([tenantId, entries]) => {
+        const aggIds = entries
+          .filter((e) => allCutoffs.has(e.key))
+          .map((e) => e.aggregateId);
 
-      if (aggIds.length === 0) continue;
+        if (aggIds.length === 0) return;
 
-      const tenantEvents = await loadEventsForAggregatesBulk({
-        client,
-        tenantId,
-        aggregateIds: aggIds,
-        cutoffs: allCutoffs,
-      });
+        const client = await this.resolveClient(tenantId);
+        const tenantEvents = await loadEventsForAggregatesBulk({
+          client,
+          tenantId,
+          aggregateIds: aggIds,
+          cutoffs: allCutoffs,
+          occurredAtBounds: boundsByTenant.get(tenantId),
+        });
 
-      for (const [aggKey, events] of tenantEvents) {
-        allEvents.set(aggKey, events);
-      }
-    }
+        for (const [aggKey, events] of tenantEvents) {
+          allEvents.set(aggKey, events);
+        }
+      }),
+    );
 
     // Apply all relevant projections per aggregate — with concurrency
     let eventsProcessed = 0;
+    let aggregatesApplied = 0;
+    const totalToApply = withCutoffKeys.length;
 
     await pMapLimited(withCutoffKeys, async (aggKey) => {
       const events = allEvents.get(aggKey) ?? [];
@@ -1430,7 +1500,15 @@ export class ReplayService {
         eventsProcessed++;
       }
 
-      onBatchPhase("replay", eventsProcessed);
+      // Throttled progress: emit every N aggregates plus the batch's last —
+      // never once per aggregate (each emit persists status to Redis).
+      aggregatesApplied++;
+      if (
+        aggregatesApplied % PROGRESS_EMIT_EVERY_AGGREGATES === 0 ||
+        aggregatesApplied === totalToApply
+      ) {
+        onBatchPhase("replay", eventsProcessed);
+      }
     }, concurrency);
 
     // 4. WRITE — flush all accumulators (fold states + map records in bulk)

--- a/langwatch/src/server/event-sourcing/replay/replayService.ts
+++ b/langwatch/src/server/event-sourcing/replay/replayService.ts
@@ -487,19 +487,25 @@ export class ReplayService {
     //    partitions instead of scanning cold storage. See
     //    getAggregateOccurredAtBounds for why this bound is safe.
     onBatchPhase("cutoff");
-    const occurredAtBounds =
-      (await getAggregateOccurredAtBounds({
-        client,
-        tenantId,
-        aggregateIds: batch.map((a) => a.aggregateId),
-      })) ?? undefined;
-    const cutoffs = await batchGetCutoffEventIds({
+    const occurredAtBounds = await getAggregateOccurredAtBounds({
       client,
       tenantId,
+      aggregateTypes: [...new Set(batch.map((a) => a.aggregateType))],
       aggregateIds: batch.map((a) => a.aggregateId),
-      eventTypes: projection.definition.eventTypes,
-      occurredAtBounds,
     });
+    // Undefined bounds means the batch's aggregates have zero events — skip
+    // the cutoff query, which would otherwise scan every partition unbounded
+    // just to return empty. An empty cutoff map routes every aggregate down
+    // the without-cutoff/unmark path below.
+    const cutoffs = occurredAtBounds
+      ? await batchGetCutoffEventIds({
+          client,
+          tenantId,
+          aggregateIds: batch.map((a) => a.aggregateId),
+          eventTypes: projection.definition.eventTypes,
+          occurredAtBounds,
+        })
+      : new Map<string, CutoffInfo>();
 
     const withCutoffKeys: string[] = [];
     const withoutCutoffKeys: string[] = [];
@@ -847,19 +853,24 @@ export class ReplayService {
     // 4. CUTOFF — occurred-at bounds first, for partition pruning (see
     //    replayBatch / getAggregateOccurredAtBounds).
     onBatchPhase("cutoff");
-    const occurredAtBounds =
-      (await getAggregateOccurredAtBounds({
-        client,
-        tenantId,
-        aggregateIds: batch.map((a) => a.aggregateId),
-      })) ?? undefined;
-    const cutoffs = await batchGetCutoffEventIds({
+    const occurredAtBounds = await getAggregateOccurredAtBounds({
       client,
       tenantId,
+      aggregateTypes: [...new Set(batch.map((a) => a.aggregateType))],
       aggregateIds: batch.map((a) => a.aggregateId),
-      eventTypes: projection.definition.eventTypes,
-      occurredAtBounds,
     });
+    // Undefined bounds means the batch's aggregates have zero events — skip
+    // the cutoff query (see replayBatch); the empty cutoff map routes
+    // everything down the without-cutoff/unmark path below.
+    const cutoffs = occurredAtBounds
+      ? await batchGetCutoffEventIds({
+          client,
+          tenantId,
+          aggregateIds: batch.map((a) => a.aggregateId),
+          eventTypes: projection.definition.eventTypes,
+          occurredAtBounds,
+        })
+      : new Map<string, CutoffInfo>();
 
     const withCutoffKeys: string[] = [];
     const withoutCutoffKeys: string[] = [];
@@ -1172,21 +1183,24 @@ export class ReplayService {
 
       emit();
 
-      // Pause only for this batch's window.
-      for (const p of allProjectionsToPause) {
-        await pauseProjection({
-          redis: this.deps.redis,
-          pauseKey: p.pauseKey,
-        });
-      }
-      log.write({
-        step: "pause-batch",
-        batch: batchNum,
-        projections: allProjectionNames,
-      });
-
       let batchResult: { eventsReplayed: number };
       try {
+        // Pause only for this batch's window. The pause loop lives INSIDE the
+        // try/finally so a mid-loop pauseProjection failure still unpauses
+        // whatever was already paused (unpauseProjection is an idempotent
+        // SREM, so unpausing never-paused projections is safe).
+        for (const p of allProjectionsToPause) {
+          await pauseProjection({
+            redis: this.deps.redis,
+            pauseKey: p.pauseKey,
+          });
+        }
+        log.write({
+          step: "pause-batch",
+          batch: batchNum,
+          projections: allProjectionNames,
+        });
+
         // Drain only THIS batch's aggregates — not every discovered aggregate.
         progress.batchPhase = "drain";
         emit();
@@ -1202,7 +1216,6 @@ export class ReplayService {
           aggregateProjectionMap,
           projectionByName,
           mapProjectionByName,
-          aggregateBatchSize,
           concurrency,
           log,
           onBatchPhase: (phase, eventsProcessed) => {
@@ -1261,12 +1274,12 @@ export class ReplayService {
       });
     }
 
-    // 6. Cleanup markers for all projections
+    // 3. Cleanup markers for all projections
     for (const name of allProjectionNames) {
       await cleanupAll({ redis: this.deps.redis, projectionName: name });
     }
 
-    // 7. Trigger OPTIMIZE TABLE on touched CH tables
+    // 4. Trigger OPTIMIZE TABLE on touched CH tables
     if (totalEventsReplayed > 0 && totalBatchErrors === 0) {
       const tables = new Set<string>();
       for (const p of config.projections) {
@@ -1304,7 +1317,6 @@ export class ReplayService {
     aggregateProjectionMap,
     projectionByName,
     mapProjectionByName,
-    aggregateBatchSize: _aggregateBatchSize,
     concurrency,
     log,
     onBatchPhase,
@@ -1316,7 +1328,6 @@ export class ReplayService {
     >;
     projectionByName: Map<string, RegisteredFoldProjection>;
     mapProjectionByName: Map<string, RegisteredMapProjection>;
-    aggregateBatchSize: number;
     concurrency: number;
     log: ReplayLogWriter;
     onBatchPhase: (phase: BatchPhase, eventsProcessed?: number) => void;
@@ -1380,13 +1391,24 @@ export class ReplayService {
     // getAggregateOccurredAtBounds for the safety argument.
     const allCutoffs = new Map<string, CutoffInfo>();
     const boundsByTenant = new Map<string, OccurredAtBounds | undefined>();
-    await Promise.all(
-      [...byTenant.entries()].map(async ([tenantId, entries]) => {
+    await pMapLimited(
+      [...byTenant.entries()],
+      async ([tenantId, entries]) => {
         const client = await this.resolveClient(tenantId);
         const aggregateIds = entries.map((e) => e.aggregateId);
-        const occurredAtBounds =
-          (await getAggregateOccurredAtBounds({ client, tenantId, aggregateIds })) ??
-          undefined;
+        const occurredAtBounds = await getAggregateOccurredAtBounds({
+          client,
+          tenantId,
+          aggregateTypes: [...new Set(entries.map((e) => e.aggregateType))],
+          aggregateIds,
+        });
+        if (!occurredAtBounds) {
+          // Undefined bounds means this tenant's aggregates have zero events —
+          // skip the cutoff query, which would otherwise scan every partition
+          // unbounded just to return empty. With no allCutoffs entries these
+          // aggregates fall into the without-cutoff/unmark path below.
+          return;
+        }
         boundsByTenant.set(tenantId, occurredAtBounds);
         const tenantCutoffs = await batchGetCutoffEventIds({
           client,
@@ -1398,7 +1420,8 @@ export class ReplayService {
         for (const [k, v] of tenantCutoffs) {
           allCutoffs.set(k, v);
         }
-      }),
+      },
+      concurrency,
     );
 
     // Split into with/without cutoffs
@@ -1457,8 +1480,9 @@ export class ReplayService {
     // Load events grouped by tenant (one CH query per tenant, in parallel).
     const allEvents = new Map<string, ReplayEvent[]>();
 
-    await Promise.all(
-      [...byTenant.entries()].map(async ([tenantId, entries]) => {
+    await pMapLimited(
+      [...byTenant.entries()],
+      async ([tenantId, entries]) => {
         const aggIds = entries
           .filter((e) => allCutoffs.has(e.key))
           .map((e) => e.aggregateId);
@@ -1477,7 +1501,8 @@ export class ReplayService {
         for (const [aggKey, events] of tenantEvents) {
           allEvents.set(aggKey, events);
         }
-      }),
+      },
+      concurrency,
     );
 
     // Apply all relevant projections per aggregate — with concurrency

--- a/specs/event-sourcing/projection-replay.feature
+++ b/specs/event-sourcing/projection-replay.feature
@@ -44,3 +44,28 @@ Feature: Projection replay
     Then each projection's output is rebuilt from the same event history
     And live events for the affected aggregates are skipped or deferred for both projections
     And live processing for both projections resumes once the replay completes
+
+  Scenario: Only the batch being replayed pauses live processing
+    Given a replay of the "spanStorage" projection spanning multiple batches
+    When the replay works through its batches
+    Then live processing is paused only while a batch is being replayed
+    And live processing resumes between batches
+    And live processing is never paused for the whole run at once
+
+  Scenario: A batch failure resumes live processing
+    Given a replay of the "spanStorage" projection is in progress
+    When a batch fails partway through
+    Then the replay stops and reports the failure
+    And live processing for the affected projections resumes
+
+  Scenario: Rebuilt records are written in bulk
+    Given aggregates with existing event history across many traces
+    When the replay rebuilds the "spanStorage" projection
+    Then rebuilt records land in large batched writes per tenant
+    And the rebuild does not wait on one write per trace
+
+  Scenario: A long replay keeps reporting progress until it finishes
+    Given a replay is running for longer than its coordination lock's initial lifetime
+    When each batch completes
+    Then the replay's coordination lock is extended
+    And progress and cancellation keep working for the whole run

--- a/specs/event-sourcing/projection-replay.feature
+++ b/specs/event-sourcing/projection-replay.feature
@@ -7,6 +7,8 @@ Feature: Projection replay
   until the replay finishes, so the projection ends up consistent with both
   the historical events and the live stream.
 
+  # Related ADRs: 015 (projection replay coordination)
+
   Background:
     Given a registered map projection "spanStorage" for aggregate type "trace"
 
@@ -16,7 +18,7 @@ Feature: Projection replay
     Then live processing for the affected aggregates is paused
     And a cutoff is taken marking the last historical event covered by the replay
     And the projection's records are rewritten from the event history up to the cutoff
-    And live processing resumes once the replay completes
+    And live processing for those aggregates resumes as soon as their batch is replayed
 
   Scenario: Live events at or before the cutoff are skipped during replay
     Given a replay of the "spanStorage" projection is in progress
@@ -43,7 +45,7 @@ Feature: Projection replay
     When an operator starts a replay covering both "traceSummary" and "spanStorage"
     Then each projection's output is rebuilt from the same event history
     And live events for the affected aggregates are skipped or deferred for both projections
-    And live processing for both projections resumes once the replay completes
+    And live processing for both projections resumes as soon as each batch is replayed
 
   Scenario: Only the batch being replayed pauses live processing
     Given a replay of the "spanStorage" projection spanning multiple batches


### PR DESCRIPTION
## Problem

Rebuilding map projections via ops replay (`ops.startReplay` → `replayOptimized`) was effectively unusable in production:

- **Weeks-long runs.** `MapAccumulator.drain` grouped buffered records per **aggregate** and sequentially awaited one `bulkAppend` per group. For `spanStorage` the aggregate is a single trace, so each trace's handful of spans became its own awaited ClickHouse INSERT with `wait_for_async_insert: 1` (~200ms) — one at a time, for millions of traces.
- **Global freeze.** `replayOptimized` paused ALL selected projections and drained ALL discovered aggregates **before the first batch**, and only unpaused after the last — live processing for those projections was frozen for the whole run. ADR-015 intended a "seconds per batch" pause window (the non-optimized path already did it per batch).
- **No partition pruning.** `event_log` is `PARTITION BY toYearWeek(EventOccurredAt)`, but the cutoff/load queries filtered only on `TenantId`/`AggregateId` — full partition scans (including S3 cold storage), repeated per batch.
- **Sequential per-tenant I/O** within each batch.
- **Lost lock, per-aggregate progress spam.** The 1h ops replay lock was never refreshed, so runs longer than an hour silently stopped updating status (`lockHolder !== runId`); every aggregate also triggered multi-round-trip Redis status writes.

## Fixes

1. **Bulk map writes per tenant** — `MapAccumulator` now flushes one `bulkAppend` per tenant chunk (default 5000 records, many aggregates per call). The `AppendStore.bulkAppend` contract takes a tenant-scoped `BulkAppendContext` (no `aggregateId` — no store used it; records carry what stores need per row). The live `append()` path and the no-`bulkAppend` fallback are unchanged.
2. **Per-batch pause windows** — `replayOptimized` pauses, drains **only the current batch's aggregates**, replays, and unpauses in a per-batch `finally`, so a batch failure can never leave projections frozen. The replay marker protocol (pending/cutoff/done — unchanged) guarantees correctness across the unpaused gaps. ADR-015 amended.
3. **Partition pruning** — each batch first computes the `EventOccurredAt` min/max over ALL events of its aggregates (`getAggregateOccurredAtBounds`, a cheap key-column-only read filtered on the full `TenantId`/`AggregateType`/`AggregateId` primary-key prefix; empty bounds — zero-event aggregates — skip the cutoff/load queries entirely) and threads that range into `batchGetCutoffEventIds`, `loadEventsForAggregatesBulk`, and `batchLoadAggregateEvents`. This bound is provably safe: every event those queries must see existed when the bounds were computed, and later appends fall after the cutoff and are handled live. (Bounding by the replay's `since` would be unsafe — fold rebuilds need history predating `since`.) The non-optimized fold/map batch paths get the same pruning.
4. **Parallel per-tenant I/O** — cutoff and event-load queries within a batch now run across tenants with bounded parallelism (`pMapLimited` under the same `concurrency` cap as the apply step).
5. **Lock heartbeat + progress throttle** — new `ReplayRepository.refreshLock` (atomic holder-checked TTL extend); the ops service refreshes it on every batch completion and time-gated (60s) from progress emits. Replay-phase progress emits are throttled to every 100 aggregates (plus batch end) instead of every aggregate. A refresh that reports the lock lost aborts the stale run via the existing cancellation path, and finalization is skipped when another run holds the lock, so a superseded run can never clobber its successor's status.

## Spec / docs

- `specs/event-sourcing/projection-replay.feature`: new scenarios for per-batch pause windows, batch-failure unpause, bulk writes, and lock lifetime.
- `dev/docs/adr/015-projection-replay-coordination.md`: amendment documenting all of the above.

## Tests

- `replayExecutor.unit.test.ts`: per-tenant single-call flush (regression for the per-aggregate INSERT storm), cross-aggregate chunking on incremental writes.
- `replayService.integration.test.ts` (testcontainers): paused-during-write / unpaused-between-batches across a 2-batch optimized run; batch failure unpauses; existing scenarios updated for the tenant-scoped bulk contract.
- `replayEventLoader.integration.test.ts`: `getAggregateOccurredAtBounds` and bounded-vs-unbounded parity for cutoff/load queries, plus a narrow-bounds exclusion test proving the predicate is wired into the SQL.
- New `replay.redis.repository.integration.test.ts`: the `refreshLock` Lua check-and-extend script against real Redis (holder extends TTL, foreign runId refuses and leaves TTL untouched).
- New `ops/__tests__/replay.service.unit.test.ts`: lock refreshed once per completed batch and time-gated from progress emits; stale-lock run does not clobber the new holder's status; a run whose lock refresh reports the lock lost aborts instead of replaying alongside its successor. `replayService.integration.test.ts` also gained a multi-tenant `replayOptimized` batch test covering the per-tenant cutoff/load fan-out.

`pnpm typecheck` clean; event-sourcing unit suite (166 files / 6826 tests), ops unit suite, and the replay integration suites all pass locally.


## Deployment Impact

No deployment impact — runtime behaviour change only. No env vars added or changed, no helm values added or changed, vanilla `helm install` behaviour is unchanged, and there is no BYOC dataplane impact. The changes alter how ops-triggered projection replays execute (bulk ClickHouse writes, per-batch pause windows, partition-pruned queries, replay-lock heartbeat); the ADR edit documents that behaviour. Operators will notice replays completing far faster and live projection processing no longer freezing for the duration of a replay.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved projection replay performance with tenant-scoped bulk writes and pause/drain coordination per batch.
  - Added occurred-at bounds to partition-prune cutoff and replay event loading.
- **Bug Fixes**
  - Live processing now pauses only for the currently replaying batch and resumes reliably, even if a batch fails.
  - Replay lock is refreshed during long runs, and stale runs no longer overwrite the status of a newer lock holder.
- **Tests**
  - Added/updated unit and integration coverage for lock refresh, batched pause semantics, and occurred-at bounds pruning.
- **Documentation**
  - Updated the projection replay coordination ADR to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
