### PR TITLE
perf(clickhouse): prune analytics span JOIN to referenced SpanAttributes keys

### DIFF
--- a/platform/app/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
@@ -274,6 +274,32 @@ describe("column-pruning", () => {
         expect(result.sql).not.toContain("ss.Input");
         expect(result.sql).not.toContain("ss.Output");
       });
+
+      /** @scenario Stored spans JOIN materializes only the referenced SpanAttributes key */
+      it("projects a narrow SpanAttributes map instead of the whole column", () => {
+        const result = buildTimeseriesQuery({
+          ...baseInput,
+          series: [
+            {
+              metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+              aggregation: "cardinality" as const,
+            },
+          ],
+          groupBy: "metadata.span_type",
+        });
+
+        // The JOIN subquery reconstructs a map of only the referenced key so the
+        // wide SpanAttributes values never reach the join buffer.
+        expect(result.sql).toContain(
+          "map('langwatch.span.type', SpanAttributes['langwatch.span.type']) AS SpanAttributes",
+        );
+        // The bare whole-map column is never selected into the subquery.
+        expect(result.sql).not.toMatch(/,\s*SpanAttributes\s+FROM stored_spans/);
+        // Outer accesses still resolve against the reconstructed map.
+        expect(result.sql).toContain(
+          "ss.SpanAttributes['langwatch.span.type']",
+        );
+      });
     });
 
     describe("when grouping by events.event_type", () => {

--- a/platform/app/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
@@ -22,9 +22,13 @@ import { resetParamCounter } from "../filter-translator";
  * Emptying rather than removing keeps each item's shape, so
  * `map(...) AS SpanAttributes` stays distinguishable from a bare
  * `SpanAttributes`, which is the whole point of the assertion.
+ *
+ * Quoted strings are emptied first: an attribute key is arbitrary text, so a
+ * key like `'tool(args)'` would otherwise contribute an unbalanced parenthesis
+ * and leave its enclosing call un-emptied.
  */
 function selectListItems(selectList: string): string[] {
-  let flattened = selectList;
+  let flattened = selectList.replace(/'[^']*'/g, "''");
   let previous = "";
   while (flattened !== previous) {
     previous = flattened;
@@ -36,6 +40,32 @@ function selectListItems(selectList: string): string[] {
 describe("column-pruning", () => {
   beforeEach(() => {
     resetParamCounter();
+  });
+
+  // The whole-map assertions below are only as trustworthy as the split they
+  // rely on, so pin it here rather than inferring it from a passing assertion.
+  describe("given a SELECT list is split into items", () => {
+    it("keeps a reconstructed map as one item", () => {
+      expect(
+        selectListItems(
+          "TraceId, map('k', SpanAttributes['k']) AS SpanAttributes",
+        ),
+      ).toEqual(["TraceId", "map() AS SpanAttributes"]);
+    });
+
+    it("keeps it as one item when the key contains parentheses", () => {
+      expect(
+        selectListItems(
+          "TraceId, map('tool(args)', SpanAttributes['tool(args)']) AS SpanAttributes",
+        ),
+      ).toEqual(["TraceId", "map() AS SpanAttributes"]);
+    });
+
+    it("still surfaces a whole-map projection in any position", () => {
+      expect(selectListItems("SpanAttributes, TraceId, DurationMs")).toContain(
+        "SpanAttributes",
+      );
+    });
   });
 
   const baseInput = {

--- a/platform/app/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
@@ -13,29 +13,24 @@ import { fieldMappings, TRACE_IDENTITY_COLUMNS } from "../field-mappings";
 import { resetParamCounter } from "../filter-translator";
 
 /**
- * Splits a SELECT list on the commas that separate its items, ignoring commas
- * nested inside call parentheses or string literals. A plain `split(",")` would
- * tear `map('k', SpanAttributes['k']) AS SpanAttributes` in half and make the
- * whole-map assertion below meaningless.
+ * Splits a SELECT list into its items. Commas inside a call cannot split an
+ * item, so parenthesised groups are emptied first, innermost outwards, until
+ * none are left: a plain `split(",")` would otherwise tear
+ * `map('k', SpanAttributes['k']) AS SpanAttributes` in half at its inner comma
+ * and make the whole-map assertion below meaningless.
+ *
+ * Emptying rather than removing keeps each item's shape, so
+ * `map(...) AS SpanAttributes` stays distinguishable from a bare
+ * `SpanAttributes`, which is the whole point of the assertion.
  */
-function splitTopLevel(selectList: string): string[] {
-  const items: string[] = [];
-  let depth = 0;
-  let quoted = false;
-  let current = "";
-  for (const char of selectList) {
-    if (char === "'") quoted = !quoted;
-    if (!quoted && char === "(") depth++;
-    if (!quoted && char === ")") depth--;
-    if (char === "," && depth === 0 && !quoted) {
-      items.push(current.trim());
-      current = "";
-      continue;
-    }
-    current += char;
+function selectListItems(selectList: string): string[] {
+  let flattened = selectList;
+  let previous = "";
+  while (flattened !== previous) {
+    previous = flattened;
+    flattened = flattened.replace(/\([^()]*\)/g, "()");
   }
-  if (current.trim() !== "") items.push(current.trim());
-  return items;
+  return flattened.split(",").map((item) => item.trim());
 }
 
 describe("column-pruning", () => {
@@ -327,7 +322,7 @@ describe("column-pruning", () => {
           /SELECT\s+(?<list>[\s\S]*?)\s+FROM stored_spans/.exec(result.sql)
             ?.groups?.list;
         expect(storedSpansSelect).toBeDefined();
-        const selectedItems = splitTopLevel(storedSpansSelect!);
+        const selectedItems = selectListItems(storedSpansSelect!);
         expect(selectedItems).not.toContain("SpanAttributes");
         // Outer accesses still resolve against the reconstructed map.
         expect(result.sql).toContain(

--- a/platform/app/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
@@ -12,6 +12,32 @@ import { buildTimeseriesQuery } from "../aggregation-builder";
 import { fieldMappings, TRACE_IDENTITY_COLUMNS } from "../field-mappings";
 import { resetParamCounter } from "../filter-translator";
 
+/**
+ * Splits a SELECT list on the commas that separate its items, ignoring commas
+ * nested inside call parentheses or string literals. A plain `split(",")` would
+ * tear `map('k', SpanAttributes['k']) AS SpanAttributes` in half and make the
+ * whole-map assertion below meaningless.
+ */
+function splitTopLevel(selectList: string): string[] {
+  const items: string[] = [];
+  let depth = 0;
+  let quoted = false;
+  let current = "";
+  for (const char of selectList) {
+    if (char === "'") quoted = !quoted;
+    if (!quoted && char === "(") depth++;
+    if (!quoted && char === ")") depth--;
+    if (char === "," && depth === 0 && !quoted) {
+      items.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim() !== "") items.push(current.trim());
+  return items;
+}
+
 describe("column-pruning", () => {
   beforeEach(() => {
     resetParamCounter();
@@ -293,10 +319,16 @@ describe("column-pruning", () => {
         expect(result.sql).toContain(
           "map('langwatch.span.type', SpanAttributes['langwatch.span.type']) AS SpanAttributes",
         );
-        // The bare whole-map column is never selected into the subquery.
-        expect(result.sql).not.toMatch(
-          /,\s*SpanAttributes\s+FROM stored_spans/,
-        );
+        // The bare whole-map column is never selected into the subquery, in
+        // any position. Checked against the extracted SELECT list rather than
+        // the raw SQL, so a mid-list `SpanAttributes,` cannot slip through the
+        // way an end-of-list-only pattern would.
+        const storedSpansSelect =
+          /SELECT\s+(?<list>[\s\S]*?)\s+FROM stored_spans/.exec(result.sql)
+            ?.groups?.list;
+        expect(storedSpansSelect).toBeDefined();
+        const selectedItems = splitTopLevel(storedSpansSelect!);
+        expect(selectedItems).not.toContain("SpanAttributes");
         // Outer accesses still resolve against the reconstructed map.
         expect(result.sql).toContain(
           "ss.SpanAttributes['langwatch.span.type']",

--- a/platform/app/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
@@ -294,7 +294,9 @@ describe("column-pruning", () => {
           "map('langwatch.span.type', SpanAttributes['langwatch.span.type']) AS SpanAttributes",
         );
         // The bare whole-map column is never selected into the subquery.
-        expect(result.sql).not.toMatch(/,\s*SpanAttributes\s+FROM stored_spans/);
+        expect(result.sql).not.toMatch(
+          /,\s*SpanAttributes\s+FROM stored_spans/,
+        );
         // Outer accesses still resolve against the reconstructed map.
         expect(result.sql).toContain(
           "ss.SpanAttributes['langwatch.span.type']",

--- a/platform/app/src/server/analytics/clickhouse/__tests__/field-mappings-column-extraction.unit.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/field-mappings-column-extraction.unit.test.ts
@@ -3,6 +3,8 @@ import {
   extractReferencedEvaluationColumns,
   extractReferencedSpanColumns,
   extractReferencedTraceColumns,
+  narrowSpanAttributesColumns,
+  spanAttributesNarrowProjection,
 } from "../field-mappings";
 
 describe("extractReferencedSpanColumns", () => {
@@ -230,6 +232,85 @@ describe("extractReferencedTraceColumns", () => {
         "1=1",
       ]);
       expect(result.size).toBe(0);
+    });
+  });
+});
+
+describe("spanAttributesNarrowProjection", () => {
+  it("reconstructs a single-key map aliased as SpanAttributes", () => {
+    expect(spanAttributesNarrowProjection(["langwatch.span.type"])).toBe(
+      "map('langwatch.span.type', SpanAttributes['langwatch.span.type']) AS SpanAttributes",
+    );
+  });
+
+  it("reconstructs a multi-key map preserving each referenced key", () => {
+    expect(
+      spanAttributesNarrowProjection([
+        "langwatch.span.type",
+        "gen_ai.request.model",
+      ]),
+    ).toBe(
+      "map('langwatch.span.type', SpanAttributes['langwatch.span.type'], 'gen_ai.request.model', SpanAttributes['gen_ai.request.model']) AS SpanAttributes",
+    );
+  });
+});
+
+describe("narrowSpanAttributesColumns", () => {
+  describe("when SpanAttributes is not selected", () => {
+    it("returns the column set unchanged", () => {
+      const columns = new Set(["DurationMs", "StatusCode"]);
+      const result = narrowSpanAttributesColumns(columns, ["ss.DurationMs > 0"]);
+      expect(result).toBe(columns);
+    });
+  });
+
+  describe("when every SpanAttributes use is a clean keyed access", () => {
+    it("replaces the whole map with a narrow reconstructed map", () => {
+      const result = narrowSpanAttributesColumns(new Set(["SpanAttributes"]), [
+        "ss.SpanAttributes['langwatch.span.type']",
+      ]);
+      expect(result).toContain(
+        "map('langwatch.span.type', SpanAttributes['langwatch.span.type']) AS SpanAttributes",
+      );
+      expect(result.has("SpanAttributes")).toBe(false);
+    });
+
+    it("dedupes repeated keys across expressions", () => {
+      const result = narrowSpanAttributesColumns(new Set(["SpanAttributes"]), [
+        "ss.SpanAttributes['langwatch.span.type'] AS field",
+        "ss.SpanAttributes['langwatch.span.type'] != ''",
+      ]);
+      const narrow = [...result].find((c) => c.includes("map("));
+      expect(narrow).toBe(
+        "map('langwatch.span.type', SpanAttributes['langwatch.span.type']) AS SpanAttributes",
+      );
+    });
+
+    it("keeps sibling identity columns alongside the narrow map", () => {
+      const result = narrowSpanAttributesColumns(
+        new Set(["TraceId", "SpanAttributes"]),
+        ["ss.SpanAttributes['gen_ai.request.model']"],
+      );
+      expect(result.has("TraceId")).toBe(true);
+      expect(result.has("SpanAttributes")).toBe(false);
+    });
+  });
+
+  describe("when a SpanAttributes use cannot be reduced to a known key", () => {
+    it("keeps the whole map for a generic map reference", () => {
+      const columns = new Set(["SpanAttributes"]);
+      const result = narrowSpanAttributesColumns(columns, [
+        "mapKeys(ss.SpanAttributes)",
+        "ss.SpanAttributes['langwatch.span.type']",
+      ]);
+      expect(result.has("SpanAttributes")).toBe(true);
+      expect([...result].some((c) => c.includes("map("))).toBe(false);
+    });
+
+    it("keeps the whole map when SpanAttributes is selected but never keyed", () => {
+      const columns = new Set(["SpanAttributes"]);
+      const result = narrowSpanAttributesColumns(columns, ["1=1"]);
+      expect(result.has("SpanAttributes")).toBe(true);
     });
   });
 });

--- a/platform/app/src/server/analytics/clickhouse/__tests__/field-mappings-column-extraction.unit.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/field-mappings-column-extraction.unit.test.ts
@@ -259,18 +259,20 @@ describe("narrowSpanAttributesColumns", () => {
   describe("when SpanAttributes is not selected", () => {
     it("returns the column set unchanged", () => {
       const columns = new Set(["DurationMs", "StatusCode"]);
-      const result = narrowSpanAttributesColumns(columns, [
-        "ss.DurationMs > 0",
-      ]);
+      const result = narrowSpanAttributesColumns({
+        columns,
+        expressions: ["ss.DurationMs > 0"],
+      });
       expect(result).toBe(columns);
     });
   });
 
   describe("when every SpanAttributes use is a clean keyed access", () => {
     it("replaces the whole map with a narrow reconstructed map", () => {
-      const result = narrowSpanAttributesColumns(new Set(["SpanAttributes"]), [
-        "ss.SpanAttributes['langwatch.span.type']",
-      ]);
+      const result = narrowSpanAttributesColumns({
+        columns: new Set(["SpanAttributes"]),
+        expressions: ["ss.SpanAttributes['langwatch.span.type']"],
+      });
       expect(result).toContain(
         "map('langwatch.span.type', SpanAttributes['langwatch.span.type']) AS SpanAttributes",
       );
@@ -278,10 +280,13 @@ describe("narrowSpanAttributesColumns", () => {
     });
 
     it("dedupes repeated keys across expressions", () => {
-      const result = narrowSpanAttributesColumns(new Set(["SpanAttributes"]), [
-        "ss.SpanAttributes['langwatch.span.type'] AS field",
-        "ss.SpanAttributes['langwatch.span.type'] != ''",
-      ]);
+      const result = narrowSpanAttributesColumns({
+        columns: new Set(["SpanAttributes"]),
+        expressions: [
+          "ss.SpanAttributes['langwatch.span.type'] AS field",
+          "ss.SpanAttributes['langwatch.span.type'] != ''",
+        ],
+      });
       const narrow = [...result].find((c) => c.includes("map("));
       expect(narrow).toBe(
         "map('langwatch.span.type', SpanAttributes['langwatch.span.type']) AS SpanAttributes",
@@ -289,10 +294,10 @@ describe("narrowSpanAttributesColumns", () => {
     });
 
     it("keeps sibling identity columns alongside the narrow map", () => {
-      const result = narrowSpanAttributesColumns(
-        new Set(["TraceId", "SpanAttributes"]),
-        ["ss.SpanAttributes['gen_ai.request.model']"],
-      );
+      const result = narrowSpanAttributesColumns({
+        columns: new Set(["TraceId", "SpanAttributes"]),
+        expressions: ["ss.SpanAttributes['gen_ai.request.model']"],
+      });
       expect(result.has("TraceId")).toBe(true);
       expect(result.has("SpanAttributes")).toBe(false);
     });
@@ -301,17 +306,23 @@ describe("narrowSpanAttributesColumns", () => {
   describe("when a SpanAttributes use cannot be reduced to a known key", () => {
     it("keeps the whole map for a generic map reference", () => {
       const columns = new Set(["SpanAttributes"]);
-      const result = narrowSpanAttributesColumns(columns, [
-        "mapKeys(ss.SpanAttributes)",
-        "ss.SpanAttributes['langwatch.span.type']",
-      ]);
+      const result = narrowSpanAttributesColumns({
+        columns,
+        expressions: [
+          "mapKeys(ss.SpanAttributes)",
+          "ss.SpanAttributes['langwatch.span.type']",
+        ],
+      });
       expect(result.has("SpanAttributes")).toBe(true);
       expect([...result].some((c) => c.includes("map("))).toBe(false);
     });
 
     it("keeps the whole map when SpanAttributes is selected but never keyed", () => {
       const columns = new Set(["SpanAttributes"]);
-      const result = narrowSpanAttributesColumns(columns, ["1=1"]);
+      const result = narrowSpanAttributesColumns({
+        columns,
+        expressions: ["1=1"],
+      });
       expect(result.has("SpanAttributes")).toBe(true);
     });
   });

--- a/platform/app/src/server/analytics/clickhouse/__tests__/field-mappings-column-extraction.unit.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/field-mappings-column-extraction.unit.test.ts
@@ -259,7 +259,9 @@ describe("narrowSpanAttributesColumns", () => {
   describe("when SpanAttributes is not selected", () => {
     it("returns the column set unchanged", () => {
       const columns = new Set(["DurationMs", "StatusCode"]);
-      const result = narrowSpanAttributesColumns(columns, ["ss.DurationMs > 0"]);
+      const result = narrowSpanAttributesColumns(columns, [
+        "ss.DurationMs > 0",
+      ]);
       expect(result).toBe(columns);
     });
   });

--- a/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -15,6 +15,8 @@ import {
   extractReferencedEvaluationColumns,
   extractReferencedSpanColumns,
   extractReferencedTraceColumns,
+  narrowSpanAttributesColumns,
+  spanAttributesNarrowProjection,
   TRACE_ANALYTICS_COLUMNS,
   TRACE_IDENTITY_COLUMNS,
   tableAliases,
@@ -43,7 +45,10 @@ function resolveRequiredColumns(
 ): ReadonlySet<string> | undefined {
   switch (table) {
     case "stored_spans":
-      return extractReferencedSpanColumns(expressions);
+      return narrowSpanAttributesColumns(
+        extractReferencedSpanColumns(expressions),
+        expressions,
+      );
     case "evaluation_runs":
       return extractReferencedEvaluationColumns(expressions);
     default:
@@ -2868,7 +2873,9 @@ export function buildDataForFilterQuery(
     case "spans.model":
       joins = buildJoinClause({
         table: "stored_spans",
-        requiredColumns: new Set(["SpanAttributes"]),
+        requiredColumns: new Set([
+          spanAttributesNarrowProjection(["gen_ai.request.model"]),
+        ]),
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
       });
       sql = `
@@ -2894,7 +2901,9 @@ export function buildDataForFilterQuery(
     case "spans.type":
       joins = buildJoinClause({
         table: "stored_spans",
-        requiredColumns: new Set(["SpanAttributes"]),
+        requiredColumns: new Set([
+          spanAttributesNarrowProjection(["langwatch.span.type"]),
+        ]),
         spanTimeFilter: SPAN_TIME_FILTER_START_END,
       });
       sql = `

--- a/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -45,10 +45,10 @@ function resolveRequiredColumns(
 ): ReadonlySet<string> | undefined {
   switch (table) {
     case "stored_spans":
-      return narrowSpanAttributesColumns(
-        extractReferencedSpanColumns(expressions),
+      return narrowSpanAttributesColumns({
+        columns: extractReferencedSpanColumns(expressions),
         expressions,
-      );
+      });
     case "evaluation_runs":
       return extractReferencedEvaluationColumns(expressions);
     default:

--- a/platform/app/src/server/analytics/clickhouse/field-mappings.ts
+++ b/platform/app/src/server/analytics/clickhouse/field-mappings.ts
@@ -672,10 +672,13 @@ export function spanAttributesNarrowProjection(
  * the input set unchanged when SpanAttributes is not selected or cannot be
  * narrowed.
  */
-export function narrowSpanAttributesColumns(
-  columns: ReadonlySet<string>,
-  expressions: string[],
-): ReadonlySet<string> {
+export function narrowSpanAttributesColumns({
+  columns,
+  expressions,
+}: {
+  columns: ReadonlySet<string>;
+  expressions: string[];
+}): ReadonlySet<string> {
   if (!columns.has("SpanAttributes")) {
     return columns;
   }

--- a/platform/app/src/server/analytics/clickhouse/field-mappings.ts
+++ b/platform/app/src/server/analytics/clickhouse/field-mappings.ts
@@ -641,6 +641,69 @@ export function extractReferencedSpanColumns(
 }
 
 /**
+ * Build a JOIN-subquery projection that materializes only the referenced keys
+ * of `SpanAttributes` as a narrow reconstructed map, e.g.
+ * `map('langwatch.span.type', SpanAttributes['langwatch.span.type']) AS SpanAttributes`.
+ *
+ * `SpanAttributes` is a `Map(String, String)` whose values can be multi-megabyte
+ * (RAG contexts, full input/output IO). Selecting the whole column into a JOIN
+ * subquery buffers every value on the join side even when the outer query only
+ * reads one small key (e.g. the span type), which drove a per-query 3.5 GiB
+ * MEMORY_LIMIT_EXCEEDED in prod. The reconstructed map keeps the column name and
+ * type identical, so outer `ss.SpanAttributes['key']` accesses are unchanged.
+ */
+export function spanAttributesNarrowProjection(
+  keys: readonly string[],
+): string {
+  const entries = keys
+    .map((key) => `'${key}', SpanAttributes['${key}']`)
+    .join(", ");
+  return `map(${entries}) AS SpanAttributes`;
+}
+
+/**
+ * Narrow the `SpanAttributes` entry of a stored_spans required-column set to a
+ * reconstructed map of only the referenced keys, when it is safe to do so.
+ *
+ * Safe means every `SpanAttributes` mention in the expressions is a plain
+ * single-quoted key access (`SpanAttributes['key']`) with no generic use of the
+ * whole map (e.g. `mapKeys(SpanAttributes)`). If any mention cannot be reduced to
+ * a known key, the whole map is kept so no referenced value is dropped. Returns
+ * the input set unchanged when SpanAttributes is not selected or cannot be
+ * narrowed.
+ */
+export function narrowSpanAttributesColumns(
+  columns: ReadonlySet<string>,
+  expressions: string[],
+): ReadonlySet<string> {
+  if (!columns.has("SpanAttributes")) {
+    return columns;
+  }
+
+  const joined = expressions.join(" ");
+  const allRefs = joined.match(/SpanAttributes/g) ?? [];
+  const keyMatches = [...joined.matchAll(/SpanAttributes\['([^'\]]+)'\]/g)];
+
+  // Only narrow when EVERY SpanAttributes reference is a clean keyed access;
+  // any generic or unparseable use means we cannot know which values are needed.
+  if (keyMatches.length === 0 || allRefs.length !== keyMatches.length) {
+    return columns;
+  }
+
+  const keys = [
+    ...new Set(
+      keyMatches
+        .map((match) => match[1])
+        .filter((key): key is string => key !== undefined),
+    ),
+  ];
+  const narrowed = new Set(columns);
+  narrowed.delete("SpanAttributes");
+  narrowed.add(spanAttributesNarrowProjection(keys));
+  return narrowed;
+}
+
+/**
  * Extract which evaluation_runs columns are referenced in a set of SQL expressions.
  */
 export function extractReferencedEvaluationColumns(

--- a/specs/analytics/clickhouse-column-pruning.feature
+++ b/specs/analytics/clickhouse-column-pruning.feature
@@ -68,6 +68,13 @@ Feature: ClickHouse Analytics Column Pruning
     And wide columns like Input and Output are excluded from the stored_spans source
 
   @unit
+  Scenario: Stored spans JOIN materializes only the referenced SpanAttributes key
+    When an analytics query groups by "metadata.span_type"
+    Then the stored_spans source reconstructs a narrow map of only the referenced SpanAttributes key
+    And the whole SpanAttributes map column is not selected into the stored_spans source
+    And outer references still resolve against the reconstructed map
+
+  @unit
   Scenario: Stored spans JOIN adapts columns to event-based grouping
     When an analytics query groups by "events.event_type"
     Then the stored_spans source includes the Events.Name column


### PR DESCRIPTION
## Evidence

Prod ClickHouse raised a per-query `MEMORY_LIMIT_EXCEEDED` (Code 241, `would use 3.50 GiB`, the per-query cap, not the server-wide OvercommitTracker) on an analytics metric comparison query in the last 24h. The query groups traces by span type across a current-vs-previous window:

```
WITH deduped_traces AS (
  SELECT DISTINCT ts.TraceId, if(ss.SpanAttributes['langwatch.span.type'] = '' OR ... , 'unknown', ss.SpanAttributes['langwatch.span.type']) AS group_key, ...
  FROM (deduped trace_summaries) ts
  INNER JOIN (SELECT TenantId, TraceId, SpanId, SpanAttributes FROM stored_spans WHERE ... StartTime window) ss
    ON ts.TenantId = ss.TenantId AND ts.TraceId = ss.TraceId
) SELECT ... GROUP BY ...
```

The failure fired in `MergeTreeSelect` while feeding the JOIN. Redacted; tenant identifiers omitted.

## Suspected cause

The `stored_spans` JOIN subquery projects the whole `SpanAttributes` column even though the outer query only reads a single key (`['langwatch.span.type']`). `SpanAttributes` is a `Map(String, String)` whose values can be multi-megabyte (RAG contexts under `langwatch.rag.contexts`, full input/output IO). Selecting the whole map materialises every value on the join side; for a busy tenant over a multi-day window that accumulates past the 3.5 GiB per-query ceiling.

The builder already prunes at the column level (`resolveRequiredColumns` / `extractReferencedSpanColumns`), but for `SpanAttributes` it keeps the entire map because column-level pruning cannot see that only one key is used.

## Proposed fix

Extend the pruning from column level to map-key level. When every `SpanAttributes` reference in the query's expressions is a plain keyed access, the JOIN subquery reconstructs a narrow map of only the referenced keys:

```
map('langwatch.span.type', SpanAttributes['langwatch.span.type']) AS SpanAttributes
```

The column keeps its name and `Map(String, String)` type, so every outer `ss.SpanAttributes['key']` access is unchanged. Only the small referenced keys flow into the join buffer; the wide unreferenced values (RAG contexts, IO) are dropped from the buffered side.

Safety: the narrowing only applies when every `SpanAttributes` mention is a clean single-quoted key access with no generic use of the whole map (for example `mapKeys(...)`). If any reference cannot be reduced to a known key, the whole map is kept, so no referenced value is ever dropped. The two span facet-discovery queries (`spans.model`, `spans.type`) that hardcoded the whole-map projection are switched to the same narrow projection for their single key.

## Expected impact

The heavy `MergeTreeSelect` + JOIN memory footprint drops from "whole SpanAttributes map per span" to "only the referenced keys per span". For the span-type group-by that is a single short string instead of the full attribute map, which removes the per-query memory pressure that produced the 3.5 GiB failure. Disk bytes read are largely unchanged (ClickHouse still reads the Map subcolumns to extract each key); the win is on the buffered/pipelined side, which is what hit the ceiling. Latency should improve or hold; the headline is eliminating the OOM.

The materialized-column direction (promoting the hottest small `SpanAttributes` keys to real columns) would remove the underlying map read entirely and is tracked separately as an RFC; this change is the safe, contained SQL-side fix.

## EXPLAIN check

Validated the narrow-map JOIN shape against live prod ClickHouse (read-only EXPLAIN, real large tenant). SYNTAX and PLAN both accept the reconstructed map, and the outer `ss.SpanAttributes['langwatch.span.type']` access resolves against it:

```
PLAN (narrow map):
Expression (Project names)
  Distinct (DISTINCT)
    ...
      Join
        Expression (Left Pre Join Actions)
          ...
        Expression ((WHERE + Change column names ...))   -- narrow stored_spans subquery
```

Reviewer should re-run against a representative tenant before merge.

## Test plan

- New unit tests for the two helpers (`spanAttributesNarrowProjection`, `narrowSpanAttributesColumns`), including the safety fallbacks (generic map use kept whole; SpanAttributes selected but never keyed kept whole; identity columns preserved; keys deduped).
- New assertion in the column-pruning suite that a `metadata.span_type` group-by emits the narrow map and no bare whole-map projection, and that outer key access still resolves.
- Full analytics ClickHouse unit suite passes (330 passing). One unrelated test, `routes 'performance.first_token' through the CTE alias in arrayJoin groupBy path`, fails on `origin/main` (HEAD `080c59f5d`) independently of this change (a p90/quantile metric-routing assertion, a different subsystem); it is not touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Analytics queries now retrieve only the span attributes they reference, reducing unnecessary data processing.
  * Queries involving stored spans preserve access to selected attributes while avoiding retrieval of the complete attribute map.

* **Reliability**
  * Attribute filtering remains accurate for single-key, multi-key, duplicate, and nested references.
  * Queries continue to fall back safely when attribute references cannot be narrowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->