### PR TITLE
perf(analytics): add column pruning to the documents and feedbacks stored_spans JOINs (#2643)

### DIFF
--- a/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -15,6 +15,21 @@ const {
   hasEvalMixedWithTraceMetrics,
 } = __testOnly__;
 
+/**
+ * The SELECT list of every `stored_spans` subquery in a built statement, in
+ * order, as column arrays.
+ *
+ * Asserting on the list rather than on `sql.toContain("SomeColumn")` is what
+ * makes a pruning test discriminate. The outer query names the same columns on
+ * the join alias, so a substring check is satisfied by the outer reference
+ * alone and stays green when the subquery selects the whole analytics set, or
+ * drops a column the ARRAY JOIN needs.
+ */
+const storedSpansSelectLists = (sql: string): string[][] =>
+  Array.from(sql.matchAll(/JOIN \(SELECT (.+?) FROM stored_spans/g)).map(
+    ([, columns]) => (columns ?? "").split(",").map((column) => column.trim()),
+  );
+
 describe("aggregation-builder", () => {
   beforeEach(() => {
     resetParamCounter();
@@ -1540,7 +1555,18 @@ describe("aggregation-builder", () => {
       expect(result.sql).toMatch(/JOIN \(SELECT [^)]*FROM stored_spans/);
       expect(result.sql).not.toContain("JOIN stored_spans ");
       expect(result.sql).not.toMatch(/SELECT\s+\*\s+FROM\s+stored_spans/);
-      expect(result.sql).toContain("SpanAttributes");
+
+      // The exact list, not `toContain("SpanAttributes")`. The outer ARRAY JOIN
+      // and the rag.contexts predicate both name SpanAttributes on the `ss`
+      // alias, so a substring check passes even when the subquery does not
+      // select it, and it also cannot see a regression that widens the list.
+      // Both of them: the top-10 part and the total-count part each carry their
+      // own subquery, and pruning one while leaving the other wide would halve
+      // the benefit while every substring assertion stayed green.
+      expect(storedSpansSelectLists(result.sql)).toEqual([
+        ["TenantId", "TraceId", "SpanId", "SpanAttributes"],
+        ["TenantId", "TraceId", "SpanId", "SpanAttributes"],
+      ]);
     });
 
     it("prunes the stored_spans join to the StartTime partition window", () => {
@@ -1667,6 +1693,18 @@ describe("aggregation-builder", () => {
       expect(result.sql).toMatch(/JOIN \(SELECT [^)]*FROM stored_spans/);
       expect(result.sql).not.toContain("ss.StartTime");
       expect(result.sql).not.toContain("SpanAttributes");
+      // Exactly the three Events arrays the ARRAY JOIN reads, plus identity.
+      // Omitting one of them would still satisfy the regex above.
+      expect(storedSpansSelectLists(result.sql)).toEqual([
+        [
+          "TenantId",
+          "TraceId",
+          "SpanId",
+          '"Events.Timestamp"',
+          '"Events.Name"',
+          '"Events.Attributes"',
+        ],
+      ]);
       expect(result.sql).toContain(
         "StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY",
       );

--- a/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/platform/app/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -1531,10 +1531,16 @@ describe("aggregation-builder", () => {
       expect(result.params.tenantId).toBe(projectId);
     });
 
-    it("includes JOIN with stored_spans", () => {
+    it("joins a column-pruned stored_spans subquery", () => {
       const result = buildTopDocumentsQuery(projectId, startDate, endDate);
 
-      expect(result.sql).toContain("JOIN stored_spans");
+      // The stored_spans join is a column-pruned subquery (identity columns +
+      // the SpanAttributes the ARRAY JOIN reads), not the raw table with its
+      // full analytics column set.
+      expect(result.sql).toMatch(/JOIN \(SELECT [^)]*FROM stored_spans/);
+      expect(result.sql).not.toContain("JOIN stored_spans ");
+      expect(result.sql).not.toMatch(/SELECT\s+\*\s+FROM\s+stored_spans/);
+      expect(result.sql).toContain("SpanAttributes");
     });
 
     it("prunes the stored_spans join to the StartTime partition window", () => {
@@ -1542,15 +1548,18 @@ describe("aggregation-builder", () => {
 
       // stored_spans is partitioned by toYearWeek(StartTime); without a
       // StartTime bound the join scans every weekly partition (incl. cold S3).
-      // Both the top-10 and the total-count parts must carry the predicate.
+      // The bound is pushed into the pruned subquery (partition prune before
+      // the join) rather than left on the outer ss alias, for both the top-10
+      // and the total-count parts.
+      expect(result.sql).not.toContain("ss.StartTime");
       expect(
         result.sql.match(
-          /ss\.StartTime >= \{startDate:DateTime64\(3\)\} - INTERVAL 2 DAY/g,
+          /StartTime >= \{startDate:DateTime64\(3\)\} - INTERVAL 2 DAY/g,
         ) ?? [],
       ).toHaveLength(2);
       expect(
         result.sql.match(
-          /ss\.StartTime < \{endDate:DateTime64\(3\)\} \+ INTERVAL 2 DAY/g,
+          /StartTime < \{endDate:DateTime64\(3\)\} \+ INTERVAL 2 DAY/g,
         ) ?? [],
       ).toHaveLength(2);
     });
@@ -1651,13 +1660,18 @@ describe("aggregation-builder", () => {
     it("prunes the stored_spans join to the StartTime partition window", () => {
       const result = buildFeedbacksQuery(projectId, startDate, endDate);
 
-      // Same partition-pruning rationale as the documents query: bound the
-      // stored_spans scan to the date window instead of every weekly partition.
+      // Same partition-pruning rationale as the documents query, now pushed
+      // into the pruned subquery instead of the outer ss alias. The subquery
+      // selects only the Events.* arrays the ARRAY JOIN reads, not the wide
+      // SpanAttributes map.
+      expect(result.sql).toMatch(/JOIN \(SELECT [^)]*FROM stored_spans/);
+      expect(result.sql).not.toContain("ss.StartTime");
+      expect(result.sql).not.toContain("SpanAttributes");
       expect(result.sql).toContain(
-        "ss.StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY",
+        "StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY",
       );
       expect(result.sql).toContain(
-        "ss.StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY",
+        "StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY",
       );
     });
 

--- a/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/platform/app/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -3021,6 +3021,16 @@ export function buildTopDocumentsQuery(
     ]),
   );
 
+  // Prune the stored_spans JOIN to the identity columns plus SpanAttributes
+  // (all the ARRAY JOIN and rag.contexts filter need), and push the StartTime
+  // window into the subquery, instead of joining the full analytics column set
+  // and materialising the heavy Attributes map (#2551 / #2605 pattern).
+  const spanJoin = buildJoinClause({
+    table: "stored_spans",
+    requiredColumns: new Set(["SpanAttributes"]),
+    spanTimeFilter: SPAN_TIME_FILTER_START_END,
+  });
+
   const sql = `
     WITH document_refs AS (
       SELECT
@@ -3028,13 +3038,11 @@ export function buildTopDocumentsQuery(
         toString(context.document_id) AS document_id,
         toString(context.content) AS content
       FROM ${dedupedTraceSummaries(ts, traceColumns, DATE_FILTER_START_END)}
-      JOIN stored_spans ${ss} ON ${ts}.TenantId = ${ss}.TenantId AND ${ts}.TraceId = ${ss}.TraceId
+      ${spanJoin}
       ARRAY JOIN JSONExtract(${ss}.SpanAttributes['langwatch.rag.contexts'], 'Array(JSON)') AS context
       WHERE ${ts}.TenantId = {tenantId:String}
         AND ${ts}.OccurredAt >= {startDate:DateTime64(3)}
         AND ${ts}.OccurredAt < {endDate:DateTime64(3)}
-        AND ${ss}.StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY
-        AND ${ss}.StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY
         AND ${ss}.SpanAttributes['langwatch.rag.contexts'] != ''
         ${filterWhere}
     )
@@ -3053,13 +3061,11 @@ export function buildTopDocumentsQuery(
   const totalSql = `
     SELECT uniq(toString(context.document_id)) AS total
     FROM ${dedupedTraceSummaries(ts, traceColumns, DATE_FILTER_START_END)}
-    JOIN stored_spans ${ss} ON ${ts}.TenantId = ${ss}.TenantId AND ${ts}.TraceId = ${ss}.TraceId
+    ${spanJoin}
     ARRAY JOIN JSONExtract(${ss}.SpanAttributes['langwatch.rag.contexts'], 'Array(JSON)') AS context
     WHERE ${ts}.TenantId = {tenantId:String}
       AND ${ts}.OccurredAt >= {startDate:DateTime64(3)}
       AND ${ts}.OccurredAt < {endDate:DateTime64(3)}
-      AND ${ss}.StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY
-      AND ${ss}.StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY
       AND ${ss}.SpanAttributes['langwatch.rag.contexts'] != ''
       ${filterWhere}
   `;
@@ -3117,6 +3123,19 @@ export function buildFeedbacksQuery(
     ]),
   );
 
+  // Prune the stored_spans JOIN to identity columns plus the Events.* arrays
+  // the feedback ARRAY JOIN reads, and push the StartTime window into the
+  // subquery, instead of joining the full analytics column set (#2551 / #2605).
+  const spanJoin = buildJoinClause({
+    table: "stored_spans",
+    requiredColumns: new Set([
+      '"Events.Timestamp"',
+      '"Events.Name"',
+      '"Events.Attributes"',
+    ]),
+    spanTimeFilter: SPAN_TIME_FILTER_START_END,
+  });
+
   const sql = `
     SELECT
       ${ts}.TraceId AS trace_id,
@@ -3125,7 +3144,7 @@ export function buildFeedbacksQuery(
       event_name AS event_type,
       event_attrs AS attributes
     FROM ${dedupedTraceSummaries(ts, traceColumns, DATE_FILTER_START_END)}
-    JOIN stored_spans ${ss} ON ${ts}.TenantId = ${ss}.TenantId AND ${ts}.TraceId = ${ss}.TraceId
+    ${spanJoin}
     ARRAY JOIN
       ${ss}."Events.Timestamp" AS event_timestamp,
       ${ss}."Events.Name" AS event_name,
@@ -3133,8 +3152,6 @@ export function buildFeedbacksQuery(
     WHERE ${ts}.TenantId = {tenantId:String}
       AND ${ts}.OccurredAt >= {startDate:DateTime64(3)}
       AND ${ts}.OccurredAt < {endDate:DateTime64(3)}
-      AND ${ss}.StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY
-      AND ${ss}.StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY
       AND event_name = 'thumbs_up_down'
       AND mapContains(event_attrs, 'event.metrics.vote')
       ${filterWhere}


### PR DESCRIPTION
## Ticket

Closes #2643. Three hand-written `JOIN stored_spans` statements in the analytics aggregation builder used raw JOINs without the column-pruning subquery pattern (`buildJoinClause` + `requiredColumns`) that #2605 applied to the rest of the analytics JOINs. Same class of unbounded read that caused the #2551 OOM.

## Change

Route all three JOINs through `buildJoinClause`:
- `buildTopDocumentsQuery` (the top-10 CTE + the total-count query): a shared pruned join selecting identity columns + `SpanAttributes` (all the `ARRAY JOIN` and the `rag.contexts` filter read).
- `buildFeedbacksQuery`: a pruned join selecting identity columns + the `Events.Timestamp` / `Events.Name` / `Events.Attributes` arrays the feedback `ARRAY JOIN` reads, and NOT the wide `SpanAttributes` map.

The 2-day-padded `StartTime` window is pushed into the pruned subquery (partition prune before the join) instead of sitting on the outer `ss` alias. The pushed bound is `SPAN_TIME_FILTER_START_END`, byte-identical to the outer filter it replaces, so results are unchanged.

Note: the issue titles the function `buildDocumentsQuery`; the actual function is `buildTopDocumentsQuery` (same JOINs).

## Evidence

- `aggregation-builder.test.ts`: updated the existing documents/feedbacks JOIN + StartTime-prune assertions to the new pruned-subquery form and added column-pruning assertions (pruned `JOIN (SELECT ...)`, no raw `JOIN stored_spans`, no `SELECT *`, feedbacks subquery excludes `SpanAttributes`). Full suite: **96 passed, 1 pre-existing unrelated failure** (`performance.first_token`, also failing on `main`).
- `pnpm typecheck` clean.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved analytics query efficiency by selecting only the data needed for document and feedback results.
  * Added more effective time-based filtering to reduce unnecessary data processing.
  * Optimized document and feedback analytics queries for faster execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->