### PR TITLE
test(traces): cover the /404 guard on all trace deep-link redirects

### DIFF
--- a/langwatch/src/pages/[project]/messages/__tests__/legacyTraceDeepLinkRedirect.integration.test.tsx
+++ b/langwatch/src/pages/[project]/messages/__tests__/legacyTraceDeepLinkRedirect.integration.test.tsx
@@ -54,4 +54,31 @@ describe("legacy trace deep-link redirects", () => {
       );
     });
   });
+
+  describe("when the link is malformed", () => {
+    /** @scenario "A malformed trace link lands on not-found instead of a blank page" */
+    it("redirects to not-found when the trace id is missing", () => {
+      mockQuery = { project: "acme" };
+
+      render(<TraceDetailsRedirect />);
+
+      expect(mockReplace).toHaveBeenCalledWith("/404");
+    });
+
+    it("redirects to not-found when the project slug is missing", () => {
+      mockQuery = { trace: "trace-1" };
+
+      render(<TraceDetailsRedirect />);
+
+      expect(mockReplace).toHaveBeenCalledWith("/404");
+    });
+
+    it("redirects the span deep link to not-found when the trace id is missing", () => {
+      mockQuery = { project: "acme", span: "span-9" };
+
+      render(<TraceDetailsWithSpanRedirect />);
+
+      expect(mockReplace).toHaveBeenCalledWith("/404");
+    });
+  });
 });

--- a/langwatch/src/pages/[project]/traces/__tests__/traceDeepLinkRedirect.integration.test.tsx
+++ b/langwatch/src/pages/[project]/traces/__tests__/traceDeepLinkRedirect.integration.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The canonical /[project]/traces/[trace] short link (used by notification
+ * links and API responses) must open the Trace Explorer drawer for that
+ * trace, and a malformed link must land on not-found instead of a blank
+ * page. Only the router is harnessed — the real redirect component runs.
+ */
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockQuery: Record<string, string | undefined> = {};
+const mockReplace = vi.fn();
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ query: mockQuery, isReady: true, replace: mockReplace }),
+}));
+
+import TraceDeepLinkRedirect from "../[trace]";
+
+describe("canonical trace deep-link redirect", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockQuery = {};
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when opening a trace short link", () => {
+    it("redirects to the Trace Explorer drawer for that trace", () => {
+      mockQuery = { project: "acme", trace: "trace-1" };
+
+      render(<TraceDeepLinkRedirect />);
+
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/acme/traces?drawer.open=traceV2Details&drawer.traceId=trace-1",
+      );
+    });
+  });
+
+  describe("when the link is malformed", () => {
+    /** @scenario "A malformed trace link lands on not-found instead of a blank page" */
+    it("redirects to not-found when the trace id is missing", () => {
+      mockQuery = { project: "acme" };
+
+      render(<TraceDeepLinkRedirect />);
+
+      expect(mockReplace).toHaveBeenCalledWith("/404");
+    });
+
+    it("redirects to not-found when the project slug is missing", () => {
+      mockQuery = { trace: "trace-1" };
+
+      render(<TraceDeepLinkRedirect />);
+
+      expect(mockReplace).toHaveBeenCalledWith("/404");
+    });
+  });
+});

--- a/specs/traces-v2/default-drawer-routing.feature
+++ b/specs/traces-v2/default-drawer-routing.feature
@@ -88,3 +88,9 @@ Feature: Trace Explorer is the default trace experience from every entry point
     Scenario: Notification links point at the Trace Explorer trace path
       When a trigger notification includes a link to a trace
       Then the link opens the Trace Explorer with that trace's drawer open
+
+    @integration
+    Scenario: A malformed trace link lands on not-found instead of a blank page
+      Given I received a trace link that is missing its project or trace id
+      When I open the link
+      Then I land on the not-found page


### PR DESCRIPTION
## Problem

The `/404` guard on the trace deep-link redirects (added in #5663 to fix a permanently-blank page on malformed/stale links) had no regression test on any of its three entry points — and the canonical `/[project]/traces/[trace]` redirect had no test at all. Deleting the guard would not fail a single test.

Flagged by CodeRabbit on #5663 (https://github.com/langwatch/langwatch/pull/5663#discussion_r3567074161); the PR merged before the test landed, so this is the follow-up.

## What changed

- New scenario in `specs/traces-v2/default-drawer-routing.feature`: "A malformed trace link lands on not-found instead of a blank page" (`@integration`, bound).
- `legacyTraceDeepLinkRedirect.integration.test.tsx`: three malformed-link tests asserting `router.replace("/404")` when the project slug or trace id is missing, across both legacy redirect components.
- New `traceDeepLinkRedirect.integration.test.tsx` for the canonical `/traces/[trace]` short link: happy path plus both malformed variants.

## Tests

- `pnpm test:integration` on the two files: 8/8 pass.
- `check:feature-parity`: 2407 scenarios bound, 0 unbound.
- `pnpm typecheck` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed legacy trace and span deep links now redirect to the 404 page when required query parameters are missing.
  * Valid trace short links still open the Trace Explorer with the correct drawer/navigation context.

* **Tests**
  * Added integration coverage for both current and legacy deep-link routing, including malformed cases.
  * Extended the Trace Explorer default routing spec to expect `not-found` for malformed trace links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->