### PR TITLE
feat(haven): offer to add the Go bin dir to PATH on `make haven install`

### DIFF
--- a/dev/haven.mk
+++ b/dev/haven.mk
@@ -46,7 +46,7 @@ haven:
 ifeq ($(strip $(HAVEN_ARGS)),)
 	@go build -o bin/haven $(HAVEN_PKG) && echo "built bin/haven"
 else ifeq ($(strip $(HAVEN_ARGS)),install)
-	@go install $(HAVEN_PKG) && echo "installed haven -> $$(go env GOPATH)/bin/haven — run 'haven ...' directly from now on"
+	@go install $(HAVEN_PKG) && bash scripts/haven-install-path.sh
 else
 	@$(HAVEN) $(HAVEN_ARGS)
 endif

--- a/scripts/__tests__/haven-install-path.unit.bats
+++ b/scripts/__tests__/haven-install-path.unit.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/haven-install-path.sh — the post-`make haven install`
+# PATH check (specs/setup/haven-install-path.feature). Tests drive
+# haven_ensure_path directly with a temp rc file and a controlled PATH.
+# bats runs without a TTY, so the interactive branch is reached by
+# overriding the haven_stdin_is_tty seam and feeding the answer on stdin.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  RC="$TEST_DIR/.zshrc"
+  BINDIR="$TEST_DIR/gobin"
+  mkdir -p "$BINDIR"
+  export SHELL=/bin/zsh
+  source "$SCRIPT_DIR/haven-install-path.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- haven_path_contains ---
+
+@test "haven_path_contains: finds an exact PATH entry" {
+  PATH="$BINDIR:$PATH" haven_path_contains "$BINDIR"
+}
+
+@test "haven_path_contains: does not match a prefix of a longer entry" {
+  PATH="$BINDIR-other:$PATH" run haven_path_contains "$BINDIR"
+  [ "$status" -ne 0 ]
+}
+
+# --- haven_rc_file / haven_path_line per shell ---
+
+@test "haven_rc_file: zsh uses .zshrc, honoring ZDOTDIR" {
+  SHELL=/bin/zsh ZDOTDIR="$TEST_DIR" run haven_rc_file
+  [ "$output" = "$TEST_DIR/.zshrc" ]
+}
+
+@test "haven_rc_file: bash uses ~/.bashrc" {
+  SHELL=/bin/bash run haven_rc_file
+  [ "$output" = "$HOME/.bashrc" ]
+}
+
+@test "haven_rc_file: fish uses config.fish" {
+  SHELL=/usr/bin/fish XDG_CONFIG_HOME="$TEST_DIR/xdg" run haven_rc_file
+  [ "$output" = "$TEST_DIR/xdg/fish/config.fish" ]
+}
+
+@test "haven_rc_file: unknown shell yields empty" {
+  SHELL=/bin/tcsh run haven_rc_file
+  [ "$output" = "" ]
+}
+
+@test "haven_path_line: fish uses fish_add_path, others export PATH" {
+  SHELL=/usr/bin/fish run haven_path_line "$BINDIR"
+  [ "$output" = "fish_add_path $BINDIR" ]
+  SHELL=/bin/zsh run haven_path_line "$BINDIR"
+  [ "$output" = "export PATH=\"$BINDIR:\$PATH\"" ]
+}
+
+# --- haven_ensure_path ---
+
+# @scenario "Go bin dir already on PATH"
+@test "bin dir on PATH: confirms install and offers nothing" {
+  PATH="$BINDIR:$PATH" run haven_ensure_path "$BINDIR" "$RC"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"installed haven -> $BINDIR/haven"* ]]
+  [[ "$output" == *"run 'haven ...' directly"* ]]
+  [ ! -f "$RC" ]
+}
+
+# @scenario "Non-interactive install never edits the rc file"
+@test "bin dir missing, no TTY: prints the line, leaves rc untouched" {
+  touch "$RC"
+  run haven_ensure_path "$BINDIR" "$RC" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not on your PATH"* ]]
+  [[ "$output" == *"export PATH=\"$BINDIR:\$PATH\""* ]]
+  [ ! -s "$RC" ]
+}
+
+# @scenario "Go bin dir missing from PATH, user accepts"
+@test "user accepts: appends the PATH line to the rc file" {
+  run_with_tty_answer "y"
+  [ "$status" -eq 0 ]
+  grep -qxF "export PATH=\"$BINDIR:\$PATH\"" "$RC"
+  [[ "$output" == *"restart your shell"* ]]
+}
+
+@test "user accepts via empty answer (default yes)" {
+  run_with_tty_answer ""
+  [ "$status" -eq 0 ]
+  grep -qxF "export PATH=\"$BINDIR:\$PATH\"" "$RC"
+}
+
+# @scenario "Go bin dir missing from PATH, user declines"
+@test "user declines: rc untouched, manual line printed" {
+  touch "$RC"
+  run_with_tty_answer "n"
+  [ "$status" -eq 0 ]
+  [ ! -s "$RC" ]
+  [[ "$output" == *"Skipped"* ]]
+  [[ "$output" == *"export PATH=\"$BINDIR:\$PATH\""* ]]
+}
+
+# @scenario "Accepting twice does not duplicate the PATH line"
+@test "second run after accept: no duplicate line, says already configured" {
+  run_with_tty_answer "y"
+  run_with_tty_answer "y"
+  [ "$status" -eq 0 ]
+  [ "$(grep -cxF "export PATH=\"$BINDIR:\$PATH\"" "$RC")" -eq 1 ]
+  [[ "$output" == *"already adds it"* ]]
+}
+
+# @scenario "Unrecognized shell falls back to instructions"
+@test "unknown shell: empty rc arg prints instructions only" {
+  SHELL=/bin/tcsh run haven_ensure_path "$BINDIR" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"shell isn't one we know how to configure"* ]]
+  [[ "$output" == *"export PATH=\"$BINDIR:\$PATH\""* ]]
+}
+
+# Take the interactive branch (haven_stdin_is_tty overridden to true) and
+# answer the prompt with $1.
+run_with_tty_answer() {
+  local answer="$1"
+  haven_stdin_is_tty() { return 0; }
+  run haven_ensure_path "$BINDIR" "$RC" <<<"$answer"
+}

--- a/scripts/haven-install-path.sh
+++ b/scripts/haven-install-path.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Post-install PATH check for `make haven install` (dev/haven.mk).
+#
+# `go install ./cmd/haven` drops the binary in the Go bin dir (GOBIN, or
+# GOPATH/bin). If that dir isn't on PATH the freshly installed `haven`
+# command doesn't resolve, so this script offers to append a PATH line to
+# the user's shell rc — interactively, never silently. Spec:
+# specs/setup/haven-install-path.feature. Tests:
+# scripts/__tests__/haven-install-path.unit.bats.
+
+haven_go_bin_dir() {
+  local gobin
+  gobin="$(go env GOBIN)"
+  if [ -n "$gobin" ]; then
+    echo "$gobin"
+  else
+    echo "$(go env GOPATH)/bin"
+  fi
+}
+
+haven_path_contains() {
+  case ":$PATH:" in
+    *":$1:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# The rc file for the user's login shell; empty when we don't know the shell
+# well enough to edit its config safely.
+haven_rc_file() {
+  case "$(basename "${SHELL:-}")" in
+    zsh) echo "${ZDOTDIR:-$HOME}/.zshrc" ;;
+    bash) echo "$HOME/.bashrc" ;;
+    fish) echo "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish" ;;
+    *) echo "" ;;
+  esac
+}
+
+haven_path_line() { # $1 = bin dir
+  case "$(basename "${SHELL:-}")" in
+    fish) echo "fish_add_path $1" ;;
+    *) echo "export PATH=\"$1:\$PATH\"" ;;
+  esac
+}
+
+# Overridable seam for tests: whether we can prompt the user.
+haven_stdin_is_tty() {
+  [ -t 0 ]
+}
+
+# Check PATH for the Go bin dir and offer to fix the rc file if missing.
+# $1 = bin dir, $2 = rc file (from haven_rc_file). Reads the prompt answer
+# from stdin only when stdin is a TTY; otherwise prints instructions.
+haven_ensure_path() {
+  local bindir="$1" rc="$2" line answer
+  echo "installed haven -> $bindir/haven"
+
+  if haven_path_contains "$bindir"; then
+    echo "run 'haven ...' directly from now on"
+    return 0
+  fi
+
+  line="$(haven_path_line "$bindir")"
+
+  if [ -z "$rc" ]; then
+    echo "NOTE: $bindir is not on your PATH and your shell isn't one we know how to configure."
+    echo "Add this to your shell config, then restart your shell:"
+    echo "  $line"
+    return 0
+  fi
+
+  if [ -f "$rc" ] && grep -qxF "$line" "$rc"; then
+    echo "NOTE: $bindir is not on your PATH yet, but $rc already adds it."
+    echo "Restart your shell (or 'source $rc') to pick it up."
+    return 0
+  fi
+
+  if ! haven_stdin_is_tty; then
+    echo "NOTE: $bindir is not on your PATH. Add this to $rc, then restart your shell:"
+    echo "  $line"
+    return 0
+  fi
+
+  printf '%s is not on your PATH. Add it to %s? [Y/n] ' "$bindir" "$rc"
+  read -r answer || answer=""
+  case "$answer" in
+    n* | N*)
+      echo "Skipped. To add it yourself, append this to $rc:"
+      echo "  $line"
+      ;;
+    *)
+      {
+        echo ""
+        echo "# added by 'make haven install' (langwatch)"
+        echo "$line"
+      } >>"$rc"
+      echo "Added to $rc — restart your shell (or 'source $rc'), then run 'haven ...' directly."
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+  haven_ensure_path "$(haven_go_bin_dir)" "$(haven_rc_file)"
+fi

--- a/specs/setup/haven-install-path.feature
+++ b/specs/setup/haven-install-path.feature
@@ -1,0 +1,56 @@
+Feature: haven install offers to put the Go bin dir on PATH
+  `make haven install` runs `go install ./cmd/haven`, which drops the binary
+  in the Go bin dir (GOBIN, or GOPATH/bin). If that dir is not on PATH, the
+  freshly installed `haven` command doesn't work and the "run 'haven ...'
+  directly" promise is broken. The install target should notice and offer to
+  fix it, instead of leaving the user to diagnose a command-not-found.
+
+  # Behavior lives in scripts/haven-install-path.sh, invoked by the
+  # `make haven install` branch in dev/haven.mk after `go install`.
+  # Bound by scripts/__tests__/haven-install-path.unit.bats.
+
+  @unit
+  Scenario: Go bin dir already on PATH
+    Given the Go bin dir is already on PATH
+    When I run "make haven install"
+    Then it confirms where haven was installed
+    And no PATH change is offered
+
+  @unit
+  Scenario: Go bin dir missing from PATH, user accepts
+    Given the Go bin dir is not on PATH
+    And the install runs in an interactive terminal
+    When I accept the offer to add it to PATH
+    Then a PATH line for the Go bin dir is appended to my shell rc file
+    And I am told to restart my shell or source the rc file
+
+  @unit
+  Scenario: Go bin dir missing from PATH, user declines
+    Given the Go bin dir is not on PATH
+    And the install runs in an interactive terminal
+    When I decline the offer
+    Then my shell rc file is not modified
+    And the line to add manually is printed
+
+  @unit
+  Scenario: Non-interactive install never edits the rc file
+    Given the Go bin dir is not on PATH
+    And the install runs without a terminal attached
+    When I run "make haven install"
+    Then my shell rc file is not modified
+    And the line to add manually is printed
+
+  @unit
+  Scenario: Accepting twice does not duplicate the PATH line
+    Given my shell rc file already has the PATH line from a previous accept
+    When I run "make haven install" again
+    Then the rc file still has exactly one PATH line
+    And I am told the rc file is already configured
+
+  @unit
+  Scenario: Unrecognized shell falls back to instructions
+    Given my login shell is not zsh, bash, or fish
+    And the Go bin dir is not on PATH
+    When I run "make haven install"
+    Then no rc file is touched
+    And the export line to add manually is printed


### PR DESCRIPTION
## What

`make haven install` runs `go install ./cmd/haven` and then promises "run 'haven ...' directly from now on" — but if GOBIN (or GOPATH/bin) isn't on PATH, the command doesn't resolve and the user is left with a command-not-found to diagnose.

The install branch now runs `scripts/haven-install-path.sh` after `go install`:

- Go bin dir already on PATH → confirms the install location, nothing else.
- Missing from PATH, interactive → offers (default yes) to append a PATH line to the shell rc; supports zsh (`ZDOTDIR`-aware), bash, and fish (`fish_add_path`).
- Declined, non-interactive, or unrecognized shell → prints the exact line to add manually, never touches the rc.
- Re-running after an accept never duplicates the line — it tells you the rc is already configured and to restart the shell.

## Spec + tests

- `specs/setup/haven-install-path.feature` — 6 scenarios, all `@unit`
- `scripts/__tests__/haven-install-path.unit.bats` — 14 tests, all passing; scenarios bound via `# @scenario` annotations (feature-parity checker: 6/6 bound)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-install guidance for making the Go binary directory available on `PATH`.
  * Supports Bash, Zsh, and Fish configuration files.
  * Offers interactive configuration while providing safe manual instructions in non-interactive environments.
  * Prevents duplicate PATH entries and handles unrecognized shells gracefully.

* **Tests**
  * Added automated coverage for PATH detection, shell configuration, interactive prompts, and fallback guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->