### PR TITLE
feat(automations): generic HTTP webhook action (ADR-040)

### DIFF
--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1114,6 +1114,17 @@ cronjobs:
       schedule: "*/3 * * * *" # Every 3 minutes
       endpoint: "/api/cron/triggers"
 
+    # Webhook delivery-log prune - deletes attempt rows older than 30 days
+    # See: https://kubespec.dev/batch/v1/CronJob#spec.schedule
+    ## @extra cronjobs.jobs.webhookDeliveryCleanup Webhook delivery-log prune job.
+    ## @param cronjobs.jobs.webhookDeliveryCleanup.enabled [default: true] Enable webhook delivery-log prune job.
+    ## @param cronjobs.jobs.webhookDeliveryCleanup.schedule [string, default: 30 3 * * *] Cron schedule.
+    ## @param cronjobs.jobs.webhookDeliveryCleanup.endpoint [string, default: /api/cron/webhook_delivery_cleanup] Endpoint path.
+    webhookDeliveryCleanup:
+      enabled: true
+      schedule: "30 3 * * *" # At 03:30 every day
+      endpoint: "/api/cron/webhook_delivery_cleanup"
+
   # =============================================================================
   # Kubernetes Pass-Through Configuration
   # =============================================================================

--- a/dev/docs/adr/040-webhook-http-request-automation-channel.md
+++ b/dev/docs/adr/040-webhook-http-request-automation-channel.md
@@ -509,6 +509,34 @@ path" rule.
 - **Deferred to fast-follow:** OAuth client-credentials, mTLS, dual-secret rotation,
   non-JSON content types, and a receiver-side "verify signature" doc snippet.
 
+## Amendment: what PR #5807 shipped vs deferred (2026-07)
+
+The first implementation PR (#5807, "Phases 1–3") lands the provider, the
+SSRF-fenced sender, dispatch on all three paths, the retry/terminal
+classification, and per-fire idempotency on the graph-alert path. Two
+deliberate deltas against the text above:
+
+- **Header secrets ship encrypted, but as headers — not the §3 auth union.**
+  Instead of the auth-mode selector + `ProjectSecret` ref, v1 keeps the plain
+  key/value headers editor and applies the secrecy discipline directly:
+  values are AES-256-GCM encrypted into `actionParams.headersEncrypted`
+  (`definitions/webhook/secret.ts`, same `encrypt`/`decrypt` as the Slack bot
+  token), never returned to the client (reads echo names with a
+  `__kept__` sentinel), and decrypted just before dispatch. The
+  `ProjectSecret`-ref auth union remains the target shape for when HMAC
+  signing lands.
+- **Graph alerts no longer dead-letter `SEND_WEBHOOK`** — the third notify
+  branch in `dispatchGraphAlertAction`, gated per-fire on the endpoint
+  identity. On the cron parity path, a terminal failure CONSUMES the fire
+  (no per-tick re-post to a misconfigured endpoint); only retryable failures
+  leave it open for the next tick.
+
+**Still deferred (unchanged decisions, not yet built):** HMAC request signing
+(§3, including the signing toggle UI), `Retry-After` →
+`DispatchError.retryAfterMs`, the stable `X-LangWatch-Event-Id` header,
+the per-project dispatch rate limit (test fires ARE rate-limited per user),
+and the Phase 4 `WebhookDelivery` log + report UI.
+
 ## References
 
 - [ADR-030](./030-transactional-outbox-for-stake-sensitive-dispatch.md) —

--- a/dev/docs/adr/040-webhook-http-request-automation-channel.md
+++ b/dev/docs/adr/040-webhook-http-request-automation-channel.md
@@ -531,11 +531,32 @@ deliberate deltas against the text above:
   (no per-tick re-post to a misconfigured endpoint); only retryable failures
   leave it open for the next tick.
 
-**Still deferred (unchanged decisions, not yet built):** HMAC request signing
-(§3, including the signing toggle UI), `Retry-After` →
-`DispatchError.retryAfterMs`, the stable `X-LangWatch-Event-Id` header,
-the per-project dispatch rate limit (test fires ARE rate-limited per user),
-and the Phase 4 `WebhookDelivery` log + report UI.
+**Phase 3 completed in a follow-up (also #5807):** `Retry-After` →
+`DispatchError.retryAfterMs` (parsed delta-seconds + HTTP-date, capped at 1h;
+honored by the GroupQueue as a backoff FLOOR); the stable `X-LangWatch-Event-Id`
+(trace path from the batch's traceIds, graph-alert path from the fire digest —
+identical across retries so receivers dedupe); and a per-project hourly
+dispatch cap (`webhook-dispatch:{projectId}`).
+
+**Phase 4 shipped as a standalone table (§6).** `WebhookDelivery` + a
+`WebhookDeliveryOutcome` enum, one row per attempt written by `deliverWebhook`
+(send + classify + log as a unit), redacted headers (`redactHeadersForLog`
+masks auth/signature values to `***`), a `getWebhookDeliveries` read procedure,
+the drawer's "Recent deliveries" drill-down, and a 30-day prune cron
+(`/api/cron/webhook_delivery_cleanup`).
+
+> **Known design debt / future direction.** `WebhookDelivery` is a
+> webhook-only, append-per-attempt log that sits *alongside* `ReactorOutbox`
+> (the generic delivery engine — one *mutable* row per dispatch, `lastError`
+> only) and `TriggerSent` (the idempotency/incident claim). The three answer
+> different questions today, but the deliverability report arguably belongs
+> *in* the outbox's audit mechanism (which already fires an `onFailed({ attempt,
+> willRetry })` hook per attempt) so every channel gets delivery history, not
+> just webhooks. Deferred deliberately: revisit unifying the per-attempt log
+> into the outbox rather than growing a parallel table.
+
+**Still deferred:** HMAC request signing (§3, including the signing toggle UI)
+and the `ProjectSecret`-ref auth union — the only remaining Phase 2 gap.
 
 ## References
 

--- a/langwatch/prisma/migrations/20260715000000_add_send_webhook_trigger_action/migration.sql
+++ b/langwatch/prisma/migrations/20260715000000_add_send_webhook_trigger_action/migration.sql
@@ -1,2 +1,4 @@
+-- IRREVERSIBLE: PostgreSQL enum values cannot be safely removed without
+-- recreating the type and migrating dependents.
 -- AlterEnum
 ALTER TYPE "TriggerAction" ADD VALUE 'SEND_WEBHOOK';

--- a/langwatch/prisma/migrations/20260715000000_add_send_webhook_trigger_action/migration.sql
+++ b/langwatch/prisma/migrations/20260715000000_add_send_webhook_trigger_action/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "TriggerAction" ADD VALUE 'SEND_WEBHOOK';

--- a/langwatch/prisma/migrations/20260715000100_create_webhook_delivery/migration.sql
+++ b/langwatch/prisma/migrations/20260715000100_create_webhook_delivery/migration.sql
@@ -1,8 +1,10 @@
 -- ADR-040 §6: per-attempt webhook delivery log — the drill-down behind a
 -- webhook automation's "recent fires". One row per HTTP attempt; all attempts
 -- of one logical fire share `dispatchId` (== the X-LangWatch-Event-Id). Header
--- values are stored REDACTED (auth/signature masked to '***'); the response
--- snippet is size-capped by the writer. Rows are pruned after 30 days.
+-- values are stored REDACTED (every value masked to '***'); `requestUrl` is
+-- stored as origin + path only (query string and any embedded credentials are
+-- stripped before persistence); the response snippet is size-capped by the
+-- writer. Rows are pruned after 30 days, scoped by projectId.
 
 -- CreateEnum
 CREATE TYPE "WebhookDeliveryOutcome" AS ENUM ('success', 'retryable', 'terminal', 'pending');
@@ -31,7 +33,8 @@ CREATE TABLE "WebhookDelivery" (
 CREATE INDEX "WebhookDelivery_projectId_triggerId_dispatchId_idx" ON "WebhookDelivery"("projectId", "triggerId", "dispatchId");
 
 -- CreateIndex
-CREATE INDEX "WebhookDelivery_projectId_triggerId_firedAt_idx" ON "WebhookDelivery"("projectId", "triggerId", "firedAt");
+-- Indexes the projectId-scoped 30-day prune (`projectId IN (...) AND firedAt < before`).
+CREATE INDEX "WebhookDelivery_projectId_firedAt_idx" ON "WebhookDelivery"("projectId", "firedAt");
 
 -- AddForeignKey
 ALTER TABLE "WebhookDelivery" ADD CONSTRAINT "WebhookDelivery_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -39,6 +42,7 @@ ALTER TABLE "WebhookDelivery" ADD CONSTRAINT "WebhookDelivery_projectId_fkey" FO
 -- AddForeignKey
 ALTER TABLE "WebhookDelivery" ADD CONSTRAINT "WebhookDelivery_triggerId_fkey" FOREIGN KEY ("triggerId") REFERENCES "Trigger"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
--- To roll back, uncomment and run manually:
--- DROP TABLE "WebhookDelivery";
--- DROP TYPE "WebhookDeliveryOutcome";
+-- IRREVERSIBLE: Prisma migrations are forward-only — this create has no
+-- automatic down step. To roll back manually, run:
+--   DROP TABLE "WebhookDelivery";
+--   DROP TYPE "WebhookDeliveryOutcome";

--- a/langwatch/prisma/migrations/20260715000100_create_webhook_delivery/migration.sql
+++ b/langwatch/prisma/migrations/20260715000100_create_webhook_delivery/migration.sql
@@ -1,0 +1,44 @@
+-- ADR-040 §6: per-attempt webhook delivery log — the drill-down behind a
+-- webhook automation's "recent fires". One row per HTTP attempt; all attempts
+-- of one logical fire share `dispatchId` (== the X-LangWatch-Event-Id). Header
+-- values are stored REDACTED (auth/signature masked to '***'); the response
+-- snippet is size-capped by the writer. Rows are pruned after 30 days.
+
+-- CreateEnum
+CREATE TYPE "WebhookDeliveryOutcome" AS ENUM ('success', 'retryable', 'terminal', 'pending');
+
+-- CreateTable
+CREATE TABLE "WebhookDelivery" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "triggerId" TEXT NOT NULL,
+    "dispatchId" TEXT NOT NULL,
+    "requestMethod" TEXT NOT NULL,
+    "requestUrl" TEXT NOT NULL,
+    "requestHeaders" JSONB NOT NULL,
+    "responseStatus" INTEGER,
+    "responseBody" TEXT,
+    "latencyMs" INTEGER,
+    "error" TEXT,
+    "outcome" "WebhookDeliveryOutcome" NOT NULL,
+    "firedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WebhookDelivery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_projectId_triggerId_dispatchId_idx" ON "WebhookDelivery"("projectId", "triggerId", "dispatchId");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_projectId_triggerId_firedAt_idx" ON "WebhookDelivery"("projectId", "triggerId", "firedAt");
+
+-- AddForeignKey
+ALTER TABLE "WebhookDelivery" ADD CONSTRAINT "WebhookDelivery_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WebhookDelivery" ADD CONSTRAINT "WebhookDelivery_triggerId_fkey" FOREIGN KEY ("triggerId") REFERENCES "Trigger"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- To roll back, uncomment and run manually:
+-- DROP TABLE "WebhookDelivery";
+-- DROP TYPE "WebhookDeliveryOutcome";

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -738,6 +738,7 @@ enum TriggerAction {
   ADD_TO_DATASET
   ADD_TO_ANNOTATION_QUEUE
   SEND_SLACK_MESSAGE
+  SEND_WEBHOOK
 }
 
 // The three automation kinds, distinguished by WHAT FIRES them (ADR-042):

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -381,6 +381,7 @@ model Project {
   annotations              Annotation[]
   projectSecrets           ProjectSecret[]
   TriggerSent              TriggerSent[]
+  WebhookDelivery          WebhookDelivery[]
   ReactorOutbox            ReactorOutbox[]
   annotationScores         AnnotationScore[]
   publicShares             PublicShare[]
@@ -803,10 +804,49 @@ model Trigger {
   // without a schema migration.
   traceDebounceMs      Int           @default(30000)
   TriggerSent   TriggerSent[]
+  webhookDeliveries WebhookDelivery[]
   customGraphId String?       @unique
   customGraph   CustomGraph?  @relation(fields: [customGraphId], references: [id], onDelete: Cascade)
 
   @@index([projectId])
+}
+
+// ADR-040 §6: per-ATTEMPT webhook delivery log — the drill-down behind a
+// webhook automation's "recent fires". One row per HTTP attempt; all attempts
+// of one logical fire share `dispatchId` (== the X-LangWatch-Event-Id). Header
+// values are stored REDACTED (auth/signature masked to "***"); the response
+// snippet is size-capped. Pruned after 30 days.
+model WebhookDelivery {
+  id             String                @id @default(nanoid())
+  projectId      String
+  project        Project               @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  triggerId      String
+  trigger        Trigger               @relation(fields: [triggerId], references: [id], onDelete: Cascade)
+  // Groups every attempt of one logical fire (== X-LangWatch-Event-Id).
+  dispatchId     String
+  requestMethod  String
+  requestUrl     String
+  // Redacted header record: auth/signature/api-key values masked to "***".
+  requestHeaders Json
+  // Null when no HTTP response arrived (transport/SSRF/timeout).
+  responseStatus Int?
+  responseBody   String?
+  latencyMs      Int?
+  // Transport / SSRF / timeout message when there is no HTTP response.
+  error          String?
+  outcome        WebhookDeliveryOutcome
+  firedAt        DateTime              @default(now())
+  createdAt      DateTime              @default(now())
+
+  @@index([projectId, triggerId, dispatchId])
+  @@index([projectId, triggerId, firedAt])
+}
+
+enum WebhookDeliveryOutcome {
+  success
+  retryable
+  terminal
+  pending
 }
 
 enum ExperimentType {

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -825,8 +825,10 @@ model WebhookDelivery {
   // Groups every attempt of one logical fire (== X-LangWatch-Event-Id).
   dispatchId     String
   requestMethod  String
+  // Origin + path only: the query string and any embedded credentials are
+  // stripped before persistence (webhook tokens/signatures often ride the query).
   requestUrl     String
-  // Redacted header record: auth/signature/api-key values masked to "***".
+  // Redacted header record: every configured header value is masked to "***".
   requestHeaders Json
   // Null when no HTTP response arrived (transport/SSRF/timeout).
   responseStatus Int?
@@ -839,7 +841,8 @@ model WebhookDelivery {
   createdAt      DateTime              @default(now())
 
   @@index([projectId, triggerId, dispatchId])
-  @@index([projectId, triggerId, firedAt])
+  // Indexes the projectId-scoped 30-day prune.
+  @@index([projectId, firedAt])
 }
 
 enum WebhookDeliveryOutcome {

--- a/langwatch/src/automations/providers/__tests__/parity.unit.test.ts
+++ b/langwatch/src/automations/providers/__tests__/parity.unit.test.ts
@@ -64,7 +64,7 @@ describe("provider registry parity", () => {
 
       it("gives notify providers a channel string the preview/testFire endpoints accept", () => {
         for (const p of NOTIFY_PROVIDERS) {
-          expect(["email", "slack"]).toContain(p.client.channel);
+          expect(["email", "slack", "webhook"]).toContain(p.client.channel);
         }
       });
 

--- a/langwatch/src/automations/providers/client.ts
+++ b/langwatch/src/automations/providers/client.ts
@@ -9,6 +9,12 @@ import emailClient, { type EmailSlice } from "./definitions/email/client";
 import emailShared, { type EmailPreview } from "./definitions/email/shared";
 import slackClient, { type SlackSlice } from "./definitions/slack/client";
 import slackShared, { type SlackPreview } from "./definitions/slack/shared";
+import webhookClient, {
+  type WebhookSlice,
+} from "./definitions/webhook/client";
+import webhookShared, {
+  type WebhookPreview,
+} from "./definitions/webhook/shared";
 import {
   type ClientEntry,
   isNotifyEntry,
@@ -19,6 +25,7 @@ import {
 export interface SliceFor {
   [TriggerAction.SEND_EMAIL]: EmailSlice;
   [TriggerAction.SEND_SLACK_MESSAGE]: SlackSlice;
+  [TriggerAction.SEND_WEBHOOK]: WebhookSlice;
   [TriggerAction.ADD_TO_DATASET]: DatasetSlice;
   [TriggerAction.ADD_TO_ANNOTATION_QUEUE]: AnnotationQueueSlice;
 }
@@ -28,6 +35,7 @@ export interface SliceFor {
 export interface PreviewFor {
   [TriggerAction.SEND_EMAIL]: EmailPreview;
   [TriggerAction.SEND_SLACK_MESSAGE]: SlackPreview;
+  [TriggerAction.SEND_WEBHOOK]: WebhookPreview;
   [TriggerAction.ADD_TO_DATASET]: never;
   [TriggerAction.ADD_TO_ANNOTATION_QUEUE]: never;
 }
@@ -59,6 +67,10 @@ export const CLIENT_PROVIDERS: Record<TriggerAction, ClientEntry> = {
   [TriggerAction.SEND_SLACK_MESSAGE]: {
     shared: slackShared,
     client: slackClient,
+  } as ClientEntry,
+  [TriggerAction.SEND_WEBHOOK]: {
+    shared: webhookShared,
+    client: webhookClient,
   } as ClientEntry,
   [TriggerAction.ADD_TO_DATASET]: {
     shared: datasetShared,
@@ -93,6 +105,7 @@ export function initialSlices(): AllSlices {
   return {
     [TriggerAction.SEND_EMAIL]: emailClient.initialSlice(),
     [TriggerAction.SEND_SLACK_MESSAGE]: slackClient.initialSlice(),
+    [TriggerAction.SEND_WEBHOOK]: webhookClient.initialSlice(),
     [TriggerAction.ADD_TO_DATASET]: datasetClient.initialSlice(),
     [TriggerAction.ADD_TO_ANNOTATION_QUEUE]:
       annotationQueueClient.initialSlice(),

--- a/langwatch/src/automations/providers/client.ts
+++ b/langwatch/src/automations/providers/client.ts
@@ -9,9 +9,8 @@ import emailClient, { type EmailSlice } from "./definitions/email/client";
 import emailShared, { type EmailPreview } from "./definitions/email/shared";
 import slackClient, { type SlackSlice } from "./definitions/slack/client";
 import slackShared, { type SlackPreview } from "./definitions/slack/shared";
-import webhookClient, {
-  type WebhookSlice,
-} from "./definitions/webhook/client";
+import webhookClient from "./definitions/webhook/client";
+import { type WebhookSlice } from "./definitions/webhook/slice";
 import webhookShared, {
   type WebhookPreview,
 } from "./definitions/webhook/shared";

--- a/langwatch/src/automations/providers/definitions/webhook/HeadersEditor.tsx
+++ b/langwatch/src/automations/providers/definitions/webhook/HeadersEditor.tsx
@@ -48,7 +48,7 @@ export function HeadersEditor({
                     setRow(index, {
                       ...row,
                       name: e.target.value,
-                      kept: false,
+                      isKept: false,
                     })
                   }
                 />
@@ -56,12 +56,12 @@ export function HeadersEditor({
                   size="sm"
                   flex="2"
                   value={row.value}
-                  placeholder={row.kept ? "•••••• (saved)" : "Bearer …"}
+                  placeholder={row.isKept ? "•••••• (saved)" : "Bearer …"}
                   onChange={(e) =>
                     setRow(index, {
                       ...row,
                       value: e.target.value,
-                      kept: false,
+                      isKept: false,
                     })
                   }
                 />

--- a/langwatch/src/automations/providers/definitions/webhook/HeadersEditor.tsx
+++ b/langwatch/src/automations/providers/definitions/webhook/HeadersEditor.tsx
@@ -1,0 +1,105 @@
+import {
+  Button,
+  Field,
+  HStack,
+  IconButton,
+  Input,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { Plus, Trash2 } from "lucide-react";
+import { isReservedWebhookHeader } from "./shared";
+import { newHeaderRow, type HeaderRow, type WebhookSlice } from "./slice";
+
+/** The static-headers editor for a webhook automation: add/remove rows, mask
+ *  kept secrets, and warn on reserved header names (ADR-040 §1/§3). */
+export function HeadersEditor({
+  slice,
+  onChange,
+}: {
+  slice: WebhookSlice;
+  onChange: (next: WebhookSlice) => void;
+}) {
+  const setRow = (index: number, row: HeaderRow) => {
+    const headers = slice.headers.map((h, i) => (i === index ? row : h));
+    onChange({ ...slice, headers });
+  };
+  const removeRow = (index: number) =>
+    onChange({ ...slice, headers: slice.headers.filter((_, i) => i !== index) });
+
+  return (
+    <Field.Root>
+      <Field.Label>Headers</Field.Label>
+      <VStack align="stretch" gap={2} width="full">
+        {slice.headers.map((row, index) => {
+          const reserved =
+            row.name.trim() !== "" && isReservedWebhookHeader(row.name);
+          return (
+            <VStack key={row.id} align="stretch" gap={1}>
+              <HStack gap={2}>
+                <Input
+                  size="sm"
+                  flex="1"
+                  value={row.name}
+                  placeholder="Authorization"
+                  onChange={(e) =>
+                    // The saved value is keyed by the old name server-side, so
+                    // renaming a kept row means re-entering its value.
+                    setRow(index, {
+                      ...row,
+                      name: e.target.value,
+                      kept: false,
+                    })
+                  }
+                />
+                <Input
+                  size="sm"
+                  flex="2"
+                  value={row.value}
+                  placeholder={row.kept ? "•••••• (saved)" : "Bearer …"}
+                  onChange={(e) =>
+                    setRow(index, {
+                      ...row,
+                      value: e.target.value,
+                      kept: false,
+                    })
+                  }
+                />
+                <IconButton
+                  size="sm"
+                  variant="ghost"
+                  aria-label="Remove header"
+                  onClick={() => removeRow(index)}
+                >
+                  <Trash2 size={14} />
+                </IconButton>
+              </HStack>
+              {reserved ? (
+                <Text textStyle="xs" color="fg.error">
+                  This header is set by LangWatch and will be ignored.
+                </Text>
+              ) : null}
+            </VStack>
+          );
+        })}
+        <Button
+          size="xs"
+          variant="outline"
+          width="fit-content"
+          onClick={() =>
+            onChange({
+              ...slice,
+              headers: [...slice.headers, newHeaderRow()],
+            })
+          }
+        >
+          <Plus size={13} /> Add header
+        </Button>
+      </VStack>
+      <Field.HelperText>
+        Sent with every request — for example an Authorization header your
+        endpoint expects. Values are stored encrypted and never shown again.
+      </Field.HelperText>
+    </Field.Root>
+  );
+}

--- a/langwatch/src/automations/providers/definitions/webhook/LastTestResult.tsx
+++ b/langwatch/src/automations/providers/definitions/webhook/LastTestResult.tsx
@@ -1,0 +1,36 @@
+import { Text, VStack } from "@chakra-ui/react";
+import type { ConfigFormCtx } from "../../types";
+
+/**
+ * The most recent webhook test-fire outcome, rendered inline right under the
+ * "Send a test" button — the author sees the real HTTP status (or what broke)
+ * where they pressed the button, without hunting for a toast.
+ */
+export function LastTestResult({
+  attempt,
+}: {
+  attempt: ConfigFormCtx["lastTestAttempt"];
+}) {
+  const last = attempt?.channel === "webhook" ? attempt : null;
+  if (!last) return null;
+
+  if (last.status === "success") {
+    return (
+      <Text textStyle="xs" color="fg.success" data-testid="webhook-test-result">
+        Delivered{last.httpStatus ? ` — HTTP ${last.httpStatus}` : ""}.
+      </Text>
+    );
+  }
+  return (
+    <VStack align="start" gap={0} data-testid="webhook-test-result">
+      <Text textStyle="xs" color="fg.error" fontWeight="medium">
+        {last.errorTitle ?? "Test request failed"}
+      </Text>
+      {last.errorDetail ? (
+        <Text textStyle="xs" color="fg.error">
+          {last.errorDetail}
+        </Text>
+      ) : null}
+    </VStack>
+  );
+}

--- a/langwatch/src/automations/providers/definitions/webhook/__tests__/secret.unit.test.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/__tests__/secret.unit.test.ts
@@ -69,6 +69,23 @@ describe("persistWebhookActionParams", () => {
       });
       expect(decryptWebhookHeaders(stored)).toEqual({});
     });
+
+    it("drops kept values when the destination URL changed", () => {
+      // A saved secret is bound to the URL it was saved against — repointing
+      // the webhook at another host must not carry the credential along.
+      const existing = persistWebhookActionParams({
+        incoming: { ...BASE, headers: { Authorization: "Bearer old" } },
+      });
+      const stored = persistWebhookActionParams({
+        incoming: {
+          ...BASE,
+          url: "https://evil.example.com/steal",
+          headers: { Authorization: WEBHOOK_HEADER_VALUE_KEPT },
+        },
+        existing,
+      });
+      expect(decryptWebhookHeaders(stored)).toEqual({});
+    });
   });
 
   describe("when no headers remain", () => {

--- a/langwatch/src/automations/providers/definitions/webhook/__tests__/secret.unit.test.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/__tests__/secret.unit.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Fake cipher so the test exercises the secret module's orchestration
+// (resolve-kept / encrypt / redact / decrypt), not AES itself.
+vi.mock("~/utils/encryption", () => ({
+  encrypt: (s: string) => `enc(${s})`,
+  decrypt: (s: string) => s.replace(/^enc\(/, "").replace(/\)$/, ""),
+}));
+
+import { WEBHOOK_HEADER_VALUE_KEPT } from "../shared";
+import {
+  decryptWebhookHeaders,
+  persistWebhookActionParams,
+  redactWebhookActionParams,
+} from "../secret";
+
+const BASE = {
+  url: "https://example.com/hook",
+  method: "POST" as const,
+  bodyTemplate: null,
+};
+
+describe("persistWebhookActionParams", () => {
+  describe("when all header values are freshly typed", () => {
+    it("encrypts the record and drops the plaintext", () => {
+      const stored = persistWebhookActionParams({
+        incoming: { ...BASE, headers: { Authorization: "Bearer secret" } },
+      });
+      expect(stored.headers).toBeUndefined();
+      expect(stored.headersEncrypted).toBe(
+        `enc(${JSON.stringify({ Authorization: "Bearer secret" })})`,
+      );
+    });
+  });
+
+  describe("when a value carries the kept sentinel", () => {
+    it("resolves it from the saved ciphertext", () => {
+      const existing = persistWebhookActionParams({
+        incoming: {
+          ...BASE,
+          headers: { Authorization: "Bearer old", "X-Api": "k1" },
+        },
+      });
+      const stored = persistWebhookActionParams({
+        incoming: {
+          ...BASE,
+          headers: {
+            Authorization: WEBHOOK_HEADER_VALUE_KEPT,
+            "X-Api": "k2",
+          },
+        },
+        existing,
+      });
+      expect(decryptWebhookHeaders(stored)).toEqual({
+        Authorization: "Bearer old",
+        "X-Api": "k2",
+      });
+    });
+
+    it("drops a kept value whose name has no stored counterpart", () => {
+      const stored = persistWebhookActionParams({
+        incoming: {
+          ...BASE,
+          headers: { "X-Renamed": WEBHOOK_HEADER_VALUE_KEPT },
+        },
+        existing: persistWebhookActionParams({
+          incoming: { ...BASE, headers: { "X-Original": "v" } },
+        }),
+      });
+      expect(decryptWebhookHeaders(stored)).toEqual({});
+    });
+  });
+
+  describe("when no headers remain", () => {
+    it("stores no ciphertext at all", () => {
+      const stored = persistWebhookActionParams({
+        incoming: { ...BASE, headers: {} },
+      });
+      expect(stored.headersEncrypted).toBeUndefined();
+    });
+  });
+});
+
+describe("redactWebhookActionParams", () => {
+  it("echoes header names with the kept sentinel and strips the ciphertext", () => {
+    const stored = persistWebhookActionParams({
+      incoming: { ...BASE, headers: { Authorization: "Bearer secret" } },
+    });
+    const redacted = redactWebhookActionParams(stored);
+    expect(redacted.headers).toEqual({
+      Authorization: WEBHOOK_HEADER_VALUE_KEPT,
+    });
+    expect(JSON.stringify(redacted)).not.toContain("Bearer secret");
+    expect(JSON.stringify(redacted)).not.toContain("enc(");
+  });
+
+  it("passes non-header fields through", () => {
+    const redacted = redactWebhookActionParams({ ...BASE });
+    expect(redacted).toMatchObject({ ...BASE, headers: {} });
+  });
+});
+
+describe("decryptWebhookHeaders", () => {
+  it("returns an empty record when nothing is stored", () => {
+    expect(decryptWebhookHeaders({})).toEqual({});
+  });
+
+  it("falls back to a legacy plaintext record", () => {
+    expect(decryptWebhookHeaders({ headers: { "X-Api": "k" } })).toEqual({
+      "X-Api": "k",
+    });
+  });
+});

--- a/langwatch/src/automations/providers/definitions/webhook/__tests__/shared.unit.test.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/__tests__/shared.unit.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../shared";
 
 describe("redactHeadersForLog", () => {
-  it("masks secret-bearing header values but keeps their names", () => {
+  it("masks every header value but keeps their names", () => {
     expect(
       redactHeadersForLog({
         Authorization: "Bearer sk-123",
@@ -21,8 +21,16 @@ describe("redactHeadersForLog", () => {
       Authorization: "***",
       "X-Api-Key": "***",
       "X-Signature": "***",
-      "X-Trace-Id": "t1",
-      Accept: "application/json",
+      "X-Trace-Id": "***",
+      Accept: "***",
+    });
+  });
+
+  it("masks a credential whose name no heuristic would catch", () => {
+    // A header name cannot establish whether its value is secret: every
+    // configured value is treated as one (ADR-040 §6).
+    expect(redactHeadersForLog({ "X-Partner-Key": "super-secret" })).toEqual({
+      "X-Partner-Key": "***",
     });
   });
 });

--- a/langwatch/src/automations/providers/definitions/webhook/__tests__/shared.unit.test.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/__tests__/shared.unit.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  sanitizeWebhookHeaders,
+  validateWebhookUrlShape,
+  webhookActionParamsSchema,
+} from "../shared";
+
+describe("validateWebhookUrlShape", () => {
+  describe("when the URL is a plain https endpoint", () => {
+    it("accepts it", () => {
+      expect(
+        validateWebhookUrlShape("https://example.com/hooks/langwatch"),
+      ).toBeNull();
+      expect(validateWebhookUrlShape("https://example.com:443/x")).toBeNull();
+    });
+  });
+
+  describe("when the URL is not https", () => {
+    it("rejects http", () => {
+      expect(validateWebhookUrlShape("http://example.com/x")).toMatch(/https/);
+    });
+    it("rejects non-http schemes", () => {
+      expect(validateWebhookUrlShape("ftp://example.com/x")).not.toBeNull();
+    });
+    it("rejects garbage", () => {
+      expect(validateWebhookUrlShape("not a url")).not.toBeNull();
+    });
+  });
+
+  describe("when the URL carries a non-default port", () => {
+    it("rejects it", () => {
+      expect(validateWebhookUrlShape("https://example.com:8443/x")).toMatch(
+        /port/,
+      );
+      expect(validateWebhookUrlShape("https://example.com:6379/x")).toMatch(
+        /port/,
+      );
+    });
+  });
+
+  describe("when the URL carries userinfo credentials", () => {
+    it("rejects it", () => {
+      expect(
+        validateWebhookUrlShape("https://user:pass@example.com/x"),
+      ).toMatch(/credentials/);
+    });
+  });
+});
+
+describe("sanitizeWebhookHeaders", () => {
+  describe("when headers include reserved names", () => {
+    it("strips connection-shape and LangWatch-injected headers", () => {
+      expect(
+        sanitizeWebhookHeaders({
+          Host: "evil.com",
+          "Content-Length": "0",
+          "content-type": "text/plain",
+          "X-LangWatch-Test-Fire": "false",
+          "x-langwatch-signature": "forged",
+          Authorization: "Bearer token",
+        }),
+      ).toEqual({ Authorization: "Bearer token" });
+    });
+  });
+
+  describe("when header values carry CR/LF", () => {
+    it("collapses them so a value cannot smuggle a second header", () => {
+      expect(
+        sanitizeWebhookHeaders({ "X-Custom": "a\r\nX-Smuggled: b" }),
+      ).toEqual({ "X-Custom": "a X-Smuggled: b" });
+    });
+  });
+
+  describe("when entries are empty", () => {
+    it("drops blank names and blank values", () => {
+      expect(sanitizeWebhookHeaders({ "": "x", "X-Empty": "  " })).toEqual({});
+    });
+  });
+});
+
+describe("webhookActionParamsSchema", () => {
+  describe("when given a complete config", () => {
+    it("parses and sanitizes", () => {
+      const parsed = webhookActionParamsSchema.parse({
+        url: "https://example.com/hook",
+        method: "PUT",
+        headers: { Authorization: "Bearer x", Host: "evil" },
+        bodyTemplate: "{}",
+      });
+      expect(parsed).toEqual({
+        url: "https://example.com/hook",
+        method: "PUT",
+        headers: { Authorization: "Bearer x" },
+        bodyTemplate: "{}",
+      });
+    });
+  });
+
+  describe("when fields are omitted", () => {
+    it("defaults method, headers, and bodyTemplate", () => {
+      const parsed = webhookActionParamsSchema.parse({
+        url: "https://example.com/hook",
+      });
+      expect(parsed.method).toBe("POST");
+      expect(parsed.headers).toEqual({});
+      expect(parsed.bodyTemplate).toBeNull();
+    });
+  });
+
+  describe("when the URL is invalid", () => {
+    it("rejects http URLs", () => {
+      expect(
+        webhookActionParamsSchema.safeParse({ url: "http://example.com" })
+          .success,
+      ).toBe(false);
+    });
+    it("rejects a missing URL", () => {
+      expect(webhookActionParamsSchema.safeParse({}).success).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/automations/providers/definitions/webhook/__tests__/shared.unit.test.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/__tests__/shared.unit.test.ts
@@ -1,10 +1,31 @@
 import { describe, expect, it } from "vitest";
 import {
+  redactHeadersForLog,
   sanitizeWebhookHeaders,
   validateWebhookUrlShape,
   WEBHOOK_HEADER_VALUE_KEPT,
   webhookActionParamsSchema,
 } from "../shared";
+
+describe("redactHeadersForLog", () => {
+  it("masks secret-bearing header values but keeps their names", () => {
+    expect(
+      redactHeadersForLog({
+        Authorization: "Bearer sk-123",
+        "X-Api-Key": "k",
+        "X-Signature": "abc",
+        "X-Trace-Id": "t1",
+        Accept: "application/json",
+      }),
+    ).toEqual({
+      Authorization: "***",
+      "X-Api-Key": "***",
+      "X-Signature": "***",
+      "X-Trace-Id": "t1",
+      Accept: "application/json",
+    });
+  });
+});
 
 describe("validateWebhookUrlShape", () => {
   describe("when the URL is a plain https endpoint", () => {

--- a/langwatch/src/automations/providers/definitions/webhook/__tests__/shared.unit.test.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/__tests__/shared.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   sanitizeWebhookHeaders,
   validateWebhookUrlShape,
+  WEBHOOK_HEADER_VALUE_KEPT,
   webhookActionParamsSchema,
 } from "../shared";
 
@@ -74,6 +75,14 @@ describe("sanitizeWebhookHeaders", () => {
   describe("when entries are empty", () => {
     it("drops blank names and blank values", () => {
       expect(sanitizeWebhookHeaders({ "": "x", "X-Empty": "  " })).toEqual({});
+    });
+  });
+
+  describe("when a value carries the kept sentinel", () => {
+    it("passes it through for the persist layer to resolve", () => {
+      expect(
+        sanitizeWebhookHeaders({ Authorization: WEBHOOK_HEADER_VALUE_KEPT }),
+      ).toEqual({ Authorization: WEBHOOK_HEADER_VALUE_KEPT });
     });
   });
 });

--- a/langwatch/src/automations/providers/definitions/webhook/client.tsx
+++ b/langwatch/src/automations/providers/definitions/webhook/client.tsx
@@ -1,0 +1,392 @@
+import {
+  Box,
+  Button,
+  Field,
+  HStack,
+  IconButton,
+  Input,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { Plus, Trash2, Webhook } from "lucide-react";
+import { useMemo } from "react";
+import { SegmentedControl } from "~/components/ui/segmented-control";
+import { VariableInfoIcon } from "~/features/automations/components/VariableInfoIcon";
+import { LIQUID_JSON_LANGUAGE_ID } from "~/features/automations/editors/liquidMonaco";
+import {
+  FieldHeader,
+  LiquidEditor,
+} from "~/features/automations/editors/templateAuthoring";
+import { defaultsForSourceKind } from "~/shared/templating/defaults";
+import { filterVariablesForCadence } from "~/shared/templating/exampleContext";
+import { TestFireButton } from "../../components/TestFireButton";
+import type {
+  ConfigFormCtx,
+  ConfigFormProps,
+  NotifyClientDef,
+  SavedTriggerRow,
+  SummaryIdentity,
+} from "../../types";
+import {
+  isReservedWebhookHeader,
+  validateWebhookUrlShape,
+  WEBHOOK_METHODS,
+  type WebhookActionParams,
+  type WebhookMethod,
+  type WebhookPreview,
+} from "./shared";
+
+/** A template field, mirroring the Slack provider's `FieldDraft`: empty +
+ *  `usingDefault` means the framework default envelope applies. */
+interface FieldDraft {
+  value: string;
+  usingDefault: boolean;
+}
+
+interface HeaderRow {
+  name: string;
+  value: string;
+}
+
+export interface WebhookSlice {
+  url: string;
+  method: WebhookMethod;
+  headers: HeaderRow[];
+  template: FieldDraft;
+}
+
+const EMPTY_FIELD: FieldDraft = { value: "", usingDefault: true };
+
+function initialSlice(): WebhookSlice {
+  return { url: "", method: "POST", headers: [], template: EMPTY_FIELD };
+}
+
+function isComplete(slice: WebhookSlice): boolean {
+  return validateWebhookUrlShape(slice.url.trim()) === null;
+}
+
+function summary(slice: WebhookSlice, identity: SummaryIdentity): string {
+  const name = identity.name || "(unnamed)";
+  const host = (() => {
+    try {
+      return new URL(slice.url).hostname;
+    } catch {
+      return null;
+    }
+  })();
+  return `${name} → ${slice.method} ${host ?? "(URL not set)"}`;
+}
+
+function fromTriggerRow(row: SavedTriggerRow): WebhookSlice {
+  const params = (row.actionParams ?? {}) as Partial<WebhookActionParams>;
+  const headers = Object.entries(params.headers ?? {}).map(
+    ([name, value]) => ({ name, value }),
+  );
+  return {
+    url: typeof params.url === "string" ? params.url : "",
+    method: WEBHOOK_METHODS.includes(params.method as WebhookMethod)
+      ? (params.method as WebhookMethod)
+      : "POST",
+    headers,
+    template: {
+      value: params.bodyTemplate ?? "",
+      usingDefault: params.bodyTemplate == null,
+    },
+  };
+}
+
+function headersRecord(rows: HeaderRow[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const row of rows) {
+    const name = row.name.trim();
+    if (!name) continue;
+    out[name] = row.value;
+  }
+  return out;
+}
+
+function bodyTemplateOf(slice: WebhookSlice): string | null {
+  return slice.template.value.trim().length > 0 ? slice.template.value : null;
+}
+
+function toActionParams(slice: WebhookSlice): WebhookActionParams {
+  return {
+    url: slice.url.trim(),
+    method: slice.method,
+    headers: headersRecord(slice.headers),
+    bodyTemplate: bodyTemplateOf(slice),
+  };
+}
+
+function testFireTarget(slice: WebhookSlice) {
+  return {
+    webhook: null,
+    webhookDestination: {
+      url: slice.url.trim(),
+      method: slice.method,
+      headers: headersRecord(slice.headers),
+      bodyTemplate: bodyTemplateOf(slice),
+    },
+  };
+}
+
+/** The webhook's body lives inside `actionParams` (ADR-040 §1), not in the
+ *  four legacy Trigger template columns — so this contributes nothing. */
+function templatesFromSlice(_slice: WebhookSlice) {
+  return {
+    emailSubjectTemplate: null,
+    emailBodyTemplate: null,
+    slackTemplate: null,
+    slackTemplateType: null,
+  };
+}
+
+/**
+ * The most recent webhook test-fire outcome, rendered inline right under the
+ * "Send a test" button — the author sees the real HTTP status (or what broke)
+ * where they pressed the button, without hunting for a toast.
+ */
+function LastTestResult({
+  attempt,
+}: {
+  attempt: ConfigFormCtx["lastTestAttempt"];
+}) {
+  const last = attempt?.channel === "webhook" ? attempt : null;
+  if (!last) return null;
+
+  if (last.status === "success") {
+    return (
+      <Text textStyle="xs" color="fg.success" data-testid="webhook-test-result">
+        Delivered{last.httpStatus ? ` — HTTP ${last.httpStatus}` : ""}.
+      </Text>
+    );
+  }
+  return (
+    <VStack align="start" gap={0} data-testid="webhook-test-result">
+      <Text textStyle="xs" color="fg.error" fontWeight="medium">
+        {last.errorTitle ?? "Test request failed"}
+      </Text>
+      {last.errorDetail ? (
+        <Text textStyle="xs" color="fg.error">
+          {last.errorDetail}
+        </Text>
+      ) : null}
+    </VStack>
+  );
+}
+
+function HeadersEditor({
+  slice,
+  onChange,
+}: {
+  slice: WebhookSlice;
+  onChange: (next: WebhookSlice) => void;
+}) {
+  const setRow = (index: number, row: HeaderRow) => {
+    const headers = slice.headers.map((h, i) => (i === index ? row : h));
+    onChange({ ...slice, headers });
+  };
+  const removeRow = (index: number) =>
+    onChange({ ...slice, headers: slice.headers.filter((_, i) => i !== index) });
+
+  return (
+    <Field.Root>
+      <Field.Label>Headers</Field.Label>
+      <VStack align="stretch" gap={2} width="full">
+        {slice.headers.map((row, index) => {
+          const reserved =
+            row.name.trim() !== "" && isReservedWebhookHeader(row.name);
+          return (
+            <VStack key={index} align="stretch" gap={1}>
+              <HStack gap={2}>
+                <Input
+                  size="sm"
+                  flex="1"
+                  value={row.name}
+                  placeholder="Authorization"
+                  onChange={(e) =>
+                    setRow(index, { ...row, name: e.target.value })
+                  }
+                />
+                <Input
+                  size="sm"
+                  flex="2"
+                  value={row.value}
+                  placeholder="Bearer …"
+                  onChange={(e) =>
+                    setRow(index, { ...row, value: e.target.value })
+                  }
+                />
+                <IconButton
+                  size="sm"
+                  variant="ghost"
+                  aria-label="Remove header"
+                  onClick={() => removeRow(index)}
+                >
+                  <Trash2 size={14} />
+                </IconButton>
+              </HStack>
+              {reserved ? (
+                <Text textStyle="xs" color="fg.error">
+                  This header is set by LangWatch and will be ignored.
+                </Text>
+              ) : null}
+            </VStack>
+          );
+        })}
+        <Button
+          size="xs"
+          variant="outline"
+          width="fit-content"
+          onClick={() =>
+            onChange({
+              ...slice,
+              headers: [...slice.headers, { name: "", value: "" }],
+            })
+          }
+        >
+          <Plus size={13} /> Add header
+        </Button>
+      </VStack>
+      <Field.HelperText>
+        Sent with every request — for example an Authorization header your
+        endpoint expects.
+      </Field.HelperText>
+    </Field.Root>
+  );
+}
+
+const METHOD_ITEMS = WEBHOOK_METHODS.map((m) => ({ value: m, label: m }));
+
+function WebhookConfigForm({
+  slice,
+  onChange,
+  ctx,
+}: ConfigFormProps<WebhookSlice, WebhookPreview>) {
+  const urlProblem =
+    slice.url.trim() === "" ? null : validateWebhookUrlShape(slice.url.trim());
+  const defaults = defaultsForSourceKind(ctx.sourceKind);
+  const templateValue = slice.template.value || defaults.webhookBody;
+  const variables = useMemo(
+    () => filterVariablesForCadence(ctx.variables, ctx.cadenceMode),
+    [ctx.variables, ctx.cadenceMode],
+  );
+  const preview = ctx.preview;
+
+  return (
+    <VStack align="stretch" gap={4}>
+      <Field.Root invalid={!!urlProblem}>
+        <Field.Label>Endpoint URL</Field.Label>
+        <Input
+          value={slice.url}
+          onChange={(e) => onChange({ ...slice, url: e.target.value })}
+          placeholder="https://example.com/hooks/langwatch"
+        />
+        {urlProblem ? (
+          <Field.ErrorText>{urlProblem}</Field.ErrorText>
+        ) : (
+          <Field.HelperText>
+            An https endpoint you control. The request body is JSON.
+          </Field.HelperText>
+        )}
+      </Field.Root>
+      <Field.Root>
+        <Field.Label>Method</Field.Label>
+        <SegmentedControl
+          size="sm"
+          value={slice.method}
+          onValueChange={({ value }) => {
+            if (value) onChange({ ...slice, method: value as WebhookMethod });
+          }}
+          items={METHOD_ITEMS}
+        />
+      </Field.Root>
+      <HeadersEditor slice={slice} onChange={onChange} />
+      {/* Try the real request straight from the destination section; the
+          outcome (status code / failure) lands right below the button. */}
+      <VStack align="start" gap={2}>
+        <TestFireButton
+          onTestFire={ctx.onTestFire}
+          loading={ctx.testFireLoading}
+          disabled={!isComplete(slice)}
+          hint={isComplete(slice) ? undefined : "Add a valid https URL first"}
+        />
+        <LastTestResult attempt={ctx.lastTestAttempt} />
+      </VStack>
+      <FieldHeader
+        label="JSON body"
+        usingDefault={slice.template.usingDefault}
+        onReset={() => onChange({ ...slice, template: EMPTY_FIELD })}
+        trailing={<VariableInfoIcon variables={variables} />}
+      />
+      <VStack align="stretch" gap={2}>
+        <Text textStyle="xs" color="fg.muted">
+          Write the JSON your endpoint receives. Values in braces fill in from
+          your trace or alert when the request sends.
+        </Text>
+        <Box data-testid="webhook-body-editor">
+          <LiquidEditor
+            variables={variables}
+            height="280px"
+            language={LIQUID_JSON_LANGUAGE_ID}
+            value={templateValue}
+            onChange={(value) =>
+              onChange({ ...slice, template: { value, usingDefault: false } })
+            }
+          />
+        </Box>
+        {preview ? (
+          <Box
+            borderWidth="1px"
+            borderColor="border.muted"
+            borderRadius="md"
+            bg="bg.subtle"
+            padding={3}
+            data-testid="webhook-preview"
+          >
+            <Text textStyle="xs" fontWeight="medium" color="fg.muted" mb={1}>
+              {preview.payload.method} {preview.payload.url || "(no URL yet)"}
+            </Text>
+            <Text
+              as="pre"
+              textStyle="xs"
+              fontFamily="mono"
+              whiteSpace="pre-wrap"
+              wordBreak="break-word"
+            >
+              {formatPreviewBody(preview.payload.body)}
+            </Text>
+            {preview.errors.length > 0 ? (
+              <Text textStyle="xs" color="fg.error" mt={1}>
+                {preview.errors[0]} — the default body will be sent instead.
+              </Text>
+            ) : null}
+          </Box>
+        ) : null}
+      </VStack>
+    </VStack>
+  );
+}
+
+function formatPreviewBody(body: string): string {
+  try {
+    return JSON.stringify(JSON.parse(body), null, 2);
+  } catch {
+    return body;
+  }
+}
+
+const client: NotifyClientDef<WebhookSlice, WebhookPreview> = {
+  Icon: Webhook,
+  channel: "webhook",
+  initialSlice,
+  isComplete,
+  summary,
+  fromTriggerRow,
+  toActionParams,
+  testFireTarget,
+  templatesFromSlice,
+  ConfigForm: WebhookConfigForm,
+};
+
+export default client;

--- a/langwatch/src/automations/providers/definitions/webhook/client.tsx
+++ b/langwatch/src/automations/providers/definitions/webhook/client.tsx
@@ -30,6 +30,7 @@ import type {
 import {
   isReservedWebhookHeader,
   validateWebhookUrlShape,
+  WEBHOOK_HEADER_VALUE_KEPT,
   WEBHOOK_METHODS,
   type WebhookActionParams,
   type WebhookMethod,
@@ -44,8 +45,26 @@ interface FieldDraft {
 }
 
 interface HeaderRow {
+  /** Stable client-side identity for React keys — rows are added/removed. */
+  id: string;
   name: string;
   value: string;
+  /** True when the value is a saved secret the server kept back (ADR-040 §3):
+   *  the input shows a masked placeholder, and the save sends the kept
+   *  sentinel so the stored value survives. Typing or renaming clears it. */
+  kept: boolean;
+}
+
+let headerRowSeq = 0;
+function newHeaderRow(partial?: Partial<Omit<HeaderRow, "id">>): HeaderRow {
+  headerRowSeq += 1;
+  return {
+    id: `hdr_${headerRowSeq}`,
+    name: "",
+    value: "",
+    kept: false,
+    ...partial,
+  };
 }
 
 export interface WebhookSlice {
@@ -79,8 +98,12 @@ function summary(slice: WebhookSlice, identity: SummaryIdentity): string {
 
 function fromTriggerRow(row: SavedTriggerRow): WebhookSlice {
   const params = (row.actionParams ?? {}) as Partial<WebhookActionParams>;
-  const headers = Object.entries(params.headers ?? {}).map(
-    ([name, value]) => ({ name, value }),
+  // Saved header VALUES never reach the client (ADR-040 §3) — the server
+  // echoes names with the kept sentinel, which renders as a masked row.
+  const headers = Object.entries(params.headers ?? {}).map(([name, value]) =>
+    value === WEBHOOK_HEADER_VALUE_KEPT
+      ? newHeaderRow({ name, kept: true })
+      : newHeaderRow({ name, value }),
   );
   return {
     url: typeof params.url === "string" ? params.url : "",
@@ -100,7 +123,9 @@ function headersRecord(rows: HeaderRow[]): Record<string, string> {
   for (const row of rows) {
     const name = row.name.trim();
     if (!name) continue;
-    out[name] = row.value;
+    // A kept row sends the sentinel; the server resolves it against the
+    // stored ciphertext (save) or drops it if unresolvable (test fire).
+    out[name] = row.kept ? WEBHOOK_HEADER_VALUE_KEPT : row.value;
   }
   return out;
 }
@@ -197,7 +222,7 @@ function HeadersEditor({
           const reserved =
             row.name.trim() !== "" && isReservedWebhookHeader(row.name);
           return (
-            <VStack key={index} align="stretch" gap={1}>
+            <VStack key={row.id} align="stretch" gap={1}>
               <HStack gap={2}>
                 <Input
                   size="sm"
@@ -205,16 +230,26 @@ function HeadersEditor({
                   value={row.name}
                   placeholder="Authorization"
                   onChange={(e) =>
-                    setRow(index, { ...row, name: e.target.value })
+                    // The saved value is keyed by the old name server-side, so
+                    // renaming a kept row means re-entering its value.
+                    setRow(index, {
+                      ...row,
+                      name: e.target.value,
+                      kept: false,
+                    })
                   }
                 />
                 <Input
                   size="sm"
                   flex="2"
                   value={row.value}
-                  placeholder="Bearer …"
+                  placeholder={row.kept ? "•••••• (saved)" : "Bearer …"}
                   onChange={(e) =>
-                    setRow(index, { ...row, value: e.target.value })
+                    setRow(index, {
+                      ...row,
+                      value: e.target.value,
+                      kept: false,
+                    })
                   }
                 />
                 <IconButton
@@ -241,7 +276,7 @@ function HeadersEditor({
           onClick={() =>
             onChange({
               ...slice,
-              headers: [...slice.headers, { name: "", value: "" }],
+              headers: [...slice.headers, newHeaderRow()],
             })
           }
         >
@@ -250,7 +285,7 @@ function HeadersEditor({
       </VStack>
       <Field.HelperText>
         Sent with every request — for example an Authorization header your
-        endpoint expects.
+        endpoint expects. Values are stored encrypted and never shown again.
       </Field.HelperText>
     </Field.Root>
   );

--- a/langwatch/src/automations/providers/definitions/webhook/client.tsx
+++ b/langwatch/src/automations/providers/definitions/webhook/client.tsx
@@ -1,14 +1,5 @@
-import {
-  Box,
-  Button,
-  Field,
-  HStack,
-  IconButton,
-  Input,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
-import { Plus, Trash2, Webhook } from "lucide-react";
+import { Box, Field, Input, Text, VStack } from "@chakra-ui/react";
+import { Webhook } from "lucide-react";
 import { useMemo } from "react";
 import { SegmentedControl } from "~/components/ui/segmented-control";
 import { VariableInfoIcon } from "~/features/automations/components/VariableInfoIcon";
@@ -20,276 +11,22 @@ import {
 import { defaultsForSourceKind } from "~/shared/templating/defaults";
 import { filterVariablesForCadence } from "~/shared/templating/exampleContext";
 import { TestFireButton } from "../../components/TestFireButton";
-import type {
-  ConfigFormCtx,
-  ConfigFormProps,
-  NotifyClientDef,
-  SavedTriggerRow,
-  SummaryIdentity,
-} from "../../types";
+import type { ConfigFormProps, NotifyClientDef } from "../../types";
+import { HeadersEditor } from "./HeadersEditor";
+import { LastTestResult } from "./LastTestResult";
+import { validateWebhookUrlShape, WEBHOOK_METHODS } from "./shared";
+import type { WebhookMethod, WebhookPreview } from "./shared";
 import {
-  isReservedWebhookHeader,
-  validateWebhookUrlShape,
-  WEBHOOK_HEADER_VALUE_KEPT,
-  WEBHOOK_METHODS,
-  type WebhookActionParams,
-  type WebhookMethod,
-  type WebhookPreview,
-} from "./shared";
-
-/** A template field, mirroring the Slack provider's `FieldDraft`: empty +
- *  `usingDefault` means the framework default envelope applies. */
-interface FieldDraft {
-  value: string;
-  usingDefault: boolean;
-}
-
-interface HeaderRow {
-  /** Stable client-side identity for React keys — rows are added/removed. */
-  id: string;
-  name: string;
-  value: string;
-  /** True when the value is a saved secret the server kept back (ADR-040 §3):
-   *  the input shows a masked placeholder, and the save sends the kept
-   *  sentinel so the stored value survives. Typing or renaming clears it. */
-  kept: boolean;
-}
-
-let headerRowSeq = 0;
-function newHeaderRow(partial?: Partial<Omit<HeaderRow, "id">>): HeaderRow {
-  headerRowSeq += 1;
-  return {
-    id: `hdr_${headerRowSeq}`,
-    name: "",
-    value: "",
-    kept: false,
-    ...partial,
-  };
-}
-
-export interface WebhookSlice {
-  url: string;
-  method: WebhookMethod;
-  headers: HeaderRow[];
-  template: FieldDraft;
-}
-
-const EMPTY_FIELD: FieldDraft = { value: "", usingDefault: true };
-
-function initialSlice(): WebhookSlice {
-  return { url: "", method: "POST", headers: [], template: EMPTY_FIELD };
-}
-
-function isComplete(slice: WebhookSlice): boolean {
-  return validateWebhookUrlShape(slice.url.trim()) === null;
-}
-
-function summary(slice: WebhookSlice, identity: SummaryIdentity): string {
-  const name = identity.name || "(unnamed)";
-  const host = (() => {
-    try {
-      return new URL(slice.url).hostname;
-    } catch {
-      return null;
-    }
-  })();
-  return `${name} → ${slice.method} ${host ?? "(URL not set)"}`;
-}
-
-function fromTriggerRow(row: SavedTriggerRow): WebhookSlice {
-  const params = (row.actionParams ?? {}) as Partial<WebhookActionParams>;
-  // Saved header VALUES never reach the client (ADR-040 §3) — the server
-  // echoes names with the kept sentinel, which renders as a masked row.
-  const headers = Object.entries(params.headers ?? {}).map(([name, value]) =>
-    value === WEBHOOK_HEADER_VALUE_KEPT
-      ? newHeaderRow({ name, kept: true })
-      : newHeaderRow({ name, value }),
-  );
-  return {
-    url: typeof params.url === "string" ? params.url : "",
-    method: WEBHOOK_METHODS.includes(params.method as WebhookMethod)
-      ? (params.method as WebhookMethod)
-      : "POST",
-    headers,
-    template: {
-      value: params.bodyTemplate ?? "",
-      usingDefault: params.bodyTemplate == null,
-    },
-  };
-}
-
-function headersRecord(rows: HeaderRow[]): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const row of rows) {
-    const name = row.name.trim();
-    if (!name) continue;
-    // A kept row sends the sentinel; the server resolves it against the
-    // stored ciphertext (save) or drops it if unresolvable (test fire).
-    out[name] = row.kept ? WEBHOOK_HEADER_VALUE_KEPT : row.value;
-  }
-  return out;
-}
-
-function bodyTemplateOf(slice: WebhookSlice): string | null {
-  return slice.template.value.trim().length > 0 ? slice.template.value : null;
-}
-
-function toActionParams(slice: WebhookSlice): WebhookActionParams {
-  return {
-    url: slice.url.trim(),
-    method: slice.method,
-    headers: headersRecord(slice.headers),
-    bodyTemplate: bodyTemplateOf(slice),
-  };
-}
-
-function testFireTarget(slice: WebhookSlice) {
-  return {
-    webhook: null,
-    webhookDestination: {
-      url: slice.url.trim(),
-      method: slice.method,
-      headers: headersRecord(slice.headers),
-      bodyTemplate: bodyTemplateOf(slice),
-    },
-  };
-}
-
-/** The webhook's body lives inside `actionParams` (ADR-040 §1), not in the
- *  four legacy Trigger template columns — so this contributes nothing. */
-function templatesFromSlice(_slice: WebhookSlice) {
-  return {
-    emailSubjectTemplate: null,
-    emailBodyTemplate: null,
-    slackTemplate: null,
-    slackTemplateType: null,
-  };
-}
-
-/**
- * The most recent webhook test-fire outcome, rendered inline right under the
- * "Send a test" button — the author sees the real HTTP status (or what broke)
- * where they pressed the button, without hunting for a toast.
- */
-function LastTestResult({
-  attempt,
-}: {
-  attempt: ConfigFormCtx["lastTestAttempt"];
-}) {
-  const last = attempt?.channel === "webhook" ? attempt : null;
-  if (!last) return null;
-
-  if (last.status === "success") {
-    return (
-      <Text textStyle="xs" color="fg.success" data-testid="webhook-test-result">
-        Delivered{last.httpStatus ? ` — HTTP ${last.httpStatus}` : ""}.
-      </Text>
-    );
-  }
-  return (
-    <VStack align="start" gap={0} data-testid="webhook-test-result">
-      <Text textStyle="xs" color="fg.error" fontWeight="medium">
-        {last.errorTitle ?? "Test request failed"}
-      </Text>
-      {last.errorDetail ? (
-        <Text textStyle="xs" color="fg.error">
-          {last.errorDetail}
-        </Text>
-      ) : null}
-    </VStack>
-  );
-}
-
-function HeadersEditor({
-  slice,
-  onChange,
-}: {
-  slice: WebhookSlice;
-  onChange: (next: WebhookSlice) => void;
-}) {
-  const setRow = (index: number, row: HeaderRow) => {
-    const headers = slice.headers.map((h, i) => (i === index ? row : h));
-    onChange({ ...slice, headers });
-  };
-  const removeRow = (index: number) =>
-    onChange({ ...slice, headers: slice.headers.filter((_, i) => i !== index) });
-
-  return (
-    <Field.Root>
-      <Field.Label>Headers</Field.Label>
-      <VStack align="stretch" gap={2} width="full">
-        {slice.headers.map((row, index) => {
-          const reserved =
-            row.name.trim() !== "" && isReservedWebhookHeader(row.name);
-          return (
-            <VStack key={row.id} align="stretch" gap={1}>
-              <HStack gap={2}>
-                <Input
-                  size="sm"
-                  flex="1"
-                  value={row.name}
-                  placeholder="Authorization"
-                  onChange={(e) =>
-                    // The saved value is keyed by the old name server-side, so
-                    // renaming a kept row means re-entering its value.
-                    setRow(index, {
-                      ...row,
-                      name: e.target.value,
-                      kept: false,
-                    })
-                  }
-                />
-                <Input
-                  size="sm"
-                  flex="2"
-                  value={row.value}
-                  placeholder={row.kept ? "•••••• (saved)" : "Bearer …"}
-                  onChange={(e) =>
-                    setRow(index, {
-                      ...row,
-                      value: e.target.value,
-                      kept: false,
-                    })
-                  }
-                />
-                <IconButton
-                  size="sm"
-                  variant="ghost"
-                  aria-label="Remove header"
-                  onClick={() => removeRow(index)}
-                >
-                  <Trash2 size={14} />
-                </IconButton>
-              </HStack>
-              {reserved ? (
-                <Text textStyle="xs" color="fg.error">
-                  This header is set by LangWatch and will be ignored.
-                </Text>
-              ) : null}
-            </VStack>
-          );
-        })}
-        <Button
-          size="xs"
-          variant="outline"
-          width="fit-content"
-          onClick={() =>
-            onChange({
-              ...slice,
-              headers: [...slice.headers, newHeaderRow()],
-            })
-          }
-        >
-          <Plus size={13} /> Add header
-        </Button>
-      </VStack>
-      <Field.HelperText>
-        Sent with every request — for example an Authorization header your
-        endpoint expects. Values are stored encrypted and never shown again.
-      </Field.HelperText>
-    </Field.Root>
-  );
-}
+  EMPTY_FIELD,
+  fromTriggerRow,
+  initialSlice,
+  isComplete,
+  summary,
+  templatesFromSlice,
+  testFireTarget,
+  toActionParams,
+  type WebhookSlice,
+} from "./slice";
 
 const METHOD_ITEMS = WEBHOOK_METHODS.map((m) => ({ value: m, label: m }));
 
@@ -393,7 +130,7 @@ function WebhookConfigForm({
             </Text>
             {preview.errors.length > 0 ? (
               <Text textStyle="xs" color="fg.error" mt={1}>
-                {preview.errors[0]} — the default body will be sent instead.
+                {preview.errors[0]} — fix this before the webhook can send.
               </Text>
             ) : null}
           </Box>

--- a/langwatch/src/automations/providers/definitions/webhook/secret.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/secret.ts
@@ -1,5 +1,6 @@
 import { decrypt, encrypt } from "~/utils/encryption";
 import {
+  normalizeWebhookUrl,
   WEBHOOK_HEADER_VALUE_KEPT,
   type WebhookActionParams,
 } from "./shared";
@@ -43,6 +44,11 @@ export function decryptWebhookHeaders(
  * the saved row, then encrypt the full record. A kept value whose name has no
  * stored counterpart is dropped (renaming a header requires re-typing its
  * value — the stored value is keyed by the old name).
+ *
+ * Kept secrets are bound to the destination they were saved against: they are
+ * only reused when the incoming URL normalizes to the SAME saved URL. A changed
+ * destination drops every kept value, so masked credentials can never be
+ * re-pointed at an attacker-controlled endpoint (ADR-040 §3).
  */
 export function persistWebhookActionParams({
   incoming,
@@ -51,7 +57,10 @@ export function persistWebhookActionParams({
   incoming: WebhookActionParams;
   existing?: WebhookStoredActionParams | null;
 }): WebhookStoredActionParams {
-  const saved = existing ? decryptWebhookHeaders(existing) : {};
+  const urlUnchanged =
+    existing?.url != null &&
+    normalizeWebhookUrl(incoming.url) === normalizeWebhookUrl(existing.url);
+  const saved = existing && urlUnchanged ? decryptWebhookHeaders(existing) : {};
   const resolved: Record<string, string> = {};
   for (const [name, value] of Object.entries(incoming.headers)) {
     if (value === WEBHOOK_HEADER_VALUE_KEPT) {

--- a/langwatch/src/automations/providers/definitions/webhook/secret.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/secret.ts
@@ -1,0 +1,85 @@
+import { decrypt, encrypt } from "~/utils/encryption";
+import {
+  WEBHOOK_HEADER_VALUE_KEPT,
+  type WebhookActionParams,
+} from "./shared";
+
+/**
+ * Server-only handling of webhook header secrets (ADR-040 §3). Header values
+ * (Authorization, API keys) are AES-256-GCM encrypted at rest (shared
+ * `encrypt`/`decrypt`, CREDENTIALS_SECRET) and NEVER leave the server in
+ * either direction — the same discipline as the Slack bot token:
+ *  - persist: encrypt the whole header record; a value sent as
+ *    `WEBHOOK_HEADER_VALUE_KEPT` resolves to the stored value for that name.
+ *  - read: echo header NAMES with the kept sentinel as every value.
+ *  - deliver: decrypt just before the SSRF-fenced send.
+ */
+
+/** The shape webhook actionParams take AT REST: the plaintext `headers`
+ *  record is replaced by one ciphertext blob. */
+export type WebhookStoredActionParams = Omit<WebhookActionParams, "headers"> & {
+  headersEncrypted?: string;
+  /** Legacy plain record — only ever present on rows saved before encryption
+   *  landed; superseded by `headersEncrypted` on the next save. */
+  headers?: Record<string, string>;
+};
+
+/** Decrypt the stored header record for a dispatch or test fire. Empty when
+ *  none are configured. Falls back to a legacy plaintext record if present. */
+export function decryptWebhookHeaders(
+  params: Pick<WebhookStoredActionParams, "headersEncrypted" | "headers">,
+): Record<string, string> {
+  if (params.headersEncrypted) {
+    return JSON.parse(decrypt(params.headersEncrypted)) as Record<
+      string,
+      string
+    >;
+  }
+  return params.headers ?? {};
+}
+
+/**
+ * Prepare webhook actionParams for persistence: resolve kept sentinels against
+ * the saved row, then encrypt the full record. A kept value whose name has no
+ * stored counterpart is dropped (renaming a header requires re-typing its
+ * value — the stored value is keyed by the old name).
+ */
+export function persistWebhookActionParams({
+  incoming,
+  existing,
+}: {
+  incoming: WebhookActionParams;
+  existing?: WebhookStoredActionParams | null;
+}): WebhookStoredActionParams {
+  const saved = existing ? decryptWebhookHeaders(existing) : {};
+  const resolved: Record<string, string> = {};
+  for (const [name, value] of Object.entries(incoming.headers)) {
+    if (value === WEBHOOK_HEADER_VALUE_KEPT) {
+      if (saved[name] !== undefined) resolved[name] = saved[name];
+      continue;
+    }
+    resolved[name] = value;
+  }
+  const { headers: _drop, ...rest } = incoming;
+  return {
+    ...rest,
+    ...(Object.keys(resolved).length > 0
+      ? { headersEncrypted: encrypt(JSON.stringify(resolved)) }
+      : {}),
+  };
+}
+
+/** Replace stored header secrets with the kept sentinel before the row is
+ *  sent to the browser — the client only needs the names. */
+export function redactWebhookActionParams(
+  params: WebhookStoredActionParams,
+): WebhookActionParams {
+  const names = Object.keys(decryptWebhookHeaders(params));
+  const { headersEncrypted: _drop, headers: _dropLegacy, ...rest } = params;
+  return {
+    ...rest,
+    headers: Object.fromEntries(
+      names.map((name) => [name, WEBHOOK_HEADER_VALUE_KEPT]),
+    ),
+  } as WebhookActionParams;
+}

--- a/langwatch/src/automations/providers/definitions/webhook/server.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/server.ts
@@ -1,0 +1,8 @@
+import { TriggerAction } from "@prisma/client";
+import type { ServerDef } from "../../types";
+
+const def: ServerDef = {
+  action: TriggerAction.SEND_WEBHOOK,
+};
+
+export default def;

--- a/langwatch/src/automations/providers/definitions/webhook/shared.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/shared.ts
@@ -1,0 +1,117 @@
+import { TriggerAction } from "@prisma/client";
+import { z } from "zod";
+import type { PreviewEnvelope, SharedDef } from "../../types";
+
+export const WEBHOOK_METHODS = ["POST", "PUT", "PATCH"] as const;
+export const webhookMethodSchema = z.enum(WEBHOOK_METHODS);
+export type WebhookMethod = z.infer<typeof webhookMethodSchema>;
+
+/**
+ * Headers the customer cannot set: connection-shape headers the HTTP stack
+ * owns, plus every header LangWatch injects itself (the test-fire marker must
+ * be non-suppressible, ADR-040 §1). Compared case-insensitively; the
+ * `x-langwatch-` prefix is reserved wholesale.
+ */
+const RESERVED_HEADER_NAMES = new Set([
+  "host",
+  "content-length",
+  "content-type",
+  "transfer-encoding",
+  "connection",
+]);
+const RESERVED_HEADER_PREFIX = "x-langwatch-";
+
+export function isReservedWebhookHeader(name: string): boolean {
+  const lower = name.trim().toLowerCase();
+  return (
+    RESERVED_HEADER_NAMES.has(lower) || lower.startsWith(RESERVED_HEADER_PREFIX)
+  );
+}
+
+/** Drops reserved keys and entries with empty names/values. Header values are
+ *  stripped of CR/LF so a stored header can never smuggle a second one. */
+export function sanitizeWebhookHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const key = name.trim();
+    if (!key || isReservedWebhookHeader(key)) continue;
+    const clean = value.replace(/[\r\n\0]+/g, " ").trim();
+    if (!clean) continue;
+    out[key] = clean;
+  }
+  return out;
+}
+
+/**
+ * Shape check for the destination URL: https only, a real host, and the
+ * default port (ADR-040 §4 — `https://internal:6379` probes are rejected at
+ * authoring time; the real SSRF gate runs again at dispatch).
+ */
+export function validateWebhookUrlShape(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return "Enter a valid URL.";
+  }
+  if (parsed.protocol !== "https:") {
+    return "The webhook URL must use https.";
+  }
+  if (!parsed.hostname) {
+    return "The webhook URL needs a host.";
+  }
+  if (parsed.port !== "" && parsed.port !== "443") {
+    return "Only the default https port (443) is allowed.";
+  }
+  if (parsed.username || parsed.password) {
+    return "The webhook URL cannot carry credentials.";
+  }
+  return null;
+}
+
+export const webhookActionParamsSchema = z.object({
+  url: z
+    .string()
+    .trim()
+    .min(1, "A webhook URL is required.")
+    .superRefine((url, ctx) => {
+      const problem = validateWebhookUrlShape(url);
+      if (problem) ctx.addIssue({ code: "custom", message: problem });
+    }),
+  method: webhookMethodSchema.default("POST"),
+  /** Static custom headers (ADR-040 §1). Reserved keys are stripped on save. */
+  headers: z
+    .record(z.string(), z.string())
+    .default({})
+    .transform(sanitizeWebhookHeaders),
+  /** Liquid JSON body source. NULL = the framework default envelope. Stored
+   *  inside `actionParams` (not a Trigger template column) — ADR-040 §1. */
+  bodyTemplate: z.string().nullable().default(null),
+});
+
+export type WebhookActionParams = z.infer<typeof webhookActionParamsSchema>;
+
+/** The render-time preview shape this provider's ConfigForm consumes: the
+ *  request the dispatch would make, with the rendered JSON body. */
+export interface WebhookPreview extends PreviewEnvelope {
+  channel: "webhook";
+  payload: {
+    method: WebhookMethod;
+    url: string;
+    body: string;
+  };
+}
+
+const def: SharedDef = {
+  action: TriggerAction.SEND_WEBHOOK,
+  category: "notify",
+  label: "Webhook",
+  description: "Send a JSON payload to your own endpoint when a trace matches.",
+  alertDescription:
+    "Send a JSON payload to your own endpoint when the alert fires.",
+  actionParamsSchema: webhookActionParamsSchema,
+};
+
+export default def;

--- a/langwatch/src/automations/providers/definitions/webhook/shared.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/shared.ts
@@ -53,26 +53,56 @@ export function sanitizeWebhookHeaders(
   return out;
 }
 
-/** Header names whose VALUE is a secret and must be masked before a request
- *  is persisted to the delivery log (ADR-040 §6). Matched case-insensitively,
- *  substring — covers `Authorization`, `X-Api-Key`, `X-Signature`, etc. */
-const SECRET_HEADER_PATTERN =
-  /authorization|cookie|token|secret|api[-_]?key|signature|password|auth/i;
-
 /**
  * Redact a header record for the delivery log: which headers were sent is kept
  * (an operator debugging a 401 needs to see `Authorization` was present), but
- * the secret VALUE is masked to "***" so credential material never lands in
- * control-plane Postgres (ADR-040 §6).
+ * EVERY value is masked to "***". A header name cannot reliably establish
+ * whether its value is secret — the feature treats all configured header values
+ * as secrets (encrypted at rest), so a credential under an arbitrary name like
+ * `X-Partner-Key` must never land verbatim in control-plane Postgres and get
+ * returned by `getWebhookDeliveries` (ADR-040 §6).
  */
 export function redactHeadersForLog(
   headers: Record<string, string>,
 ): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const [name, value] of Object.entries(headers)) {
-    out[name] = SECRET_HEADER_PATTERN.test(name) ? "***" : value;
+  for (const name of Object.keys(headers)) {
+    out[name] = "***";
   }
   return out;
+}
+
+/**
+ * Redact a destination URL for the delivery log: keep only origin + path so an
+ * operator can see where a webhook fired, but drop the query string (tokens and
+ * signatures commonly ride there), the fragment, and any embedded credentials
+ * before the value is persisted (ADR-040 §6).
+ */
+export function redactWebhookUrlForLog(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    // Unparseable input — strip anything after the first "?" as a best effort.
+    return url.split("?")[0] ?? url;
+  }
+}
+
+/**
+ * Canonical form of a webhook URL for equality comparison (ADR-040 §3): lowered
+ * protocol + host (port included), path with trailing slashes trimmed, query
+ * and fragment dropped. Kept secrets are only reused when the incoming URL
+ * normalizes to the SAME saved URL — a changed destination must never inherit
+ * credentials bound to the old one. Unparseable input compares by trimmed text.
+ */
+export function normalizeWebhookUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname.replace(/\/+$/, "");
+    return `${parsed.protocol}//${parsed.host}${path || "/"}`;
+  } catch {
+    return url.trim();
+  }
 }
 
 /**

--- a/langwatch/src/automations/providers/definitions/webhook/shared.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/shared.ts
@@ -53,6 +53,28 @@ export function sanitizeWebhookHeaders(
   return out;
 }
 
+/** Header names whose VALUE is a secret and must be masked before a request
+ *  is persisted to the delivery log (ADR-040 §6). Matched case-insensitively,
+ *  substring — covers `Authorization`, `X-Api-Key`, `X-Signature`, etc. */
+const SECRET_HEADER_PATTERN =
+  /authorization|cookie|token|secret|api[-_]?key|signature|password|auth/i;
+
+/**
+ * Redact a header record for the delivery log: which headers were sent is kept
+ * (an operator debugging a 401 needs to see `Authorization` was present), but
+ * the secret VALUE is masked to "***" so credential material never lands in
+ * control-plane Postgres (ADR-040 §6).
+ */
+export function redactHeadersForLog(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    out[name] = SECRET_HEADER_PATTERN.test(name) ? "***" : value;
+  }
+  return out;
+}
+
 /**
  * Shape check for the destination URL: https only, a real host, and the
  * default port (ADR-040 §4 — `https://internal:6379` probes are rejected at

--- a/langwatch/src/automations/providers/definitions/webhook/shared.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/shared.ts
@@ -3,6 +3,15 @@ import { z } from "zod";
 import type { PreviewEnvelope, SharedDef } from "../../types";
 
 export const WEBHOOK_METHODS = ["POST", "PUT", "PATCH"] as const;
+
+/**
+ * Sentinel a header VALUE carries on the wire to mean "keep the saved value".
+ * Header values are secrets (Authorization, API keys): they are encrypted at
+ * rest and never returned to the client (ADR-040 §3, same discipline as
+ * `SLACK_BOT_TOKEN_KEPT`). Reads echo names with this sentinel as the value;
+ * saves and test fires resolve it against the stored ciphertext server-side.
+ */
+export const WEBHOOK_HEADER_VALUE_KEPT = "__kept__";
 export const webhookMethodSchema = z.enum(WEBHOOK_METHODS);
 export type WebhookMethod = z.infer<typeof webhookMethodSchema>;
 
@@ -81,7 +90,11 @@ export const webhookActionParamsSchema = z.object({
       if (problem) ctx.addIssue({ code: "custom", message: problem });
     }),
   method: webhookMethodSchema.default("POST"),
-  /** Static custom headers (ADR-040 §1). Reserved keys are stripped on save. */
+  /** Static custom headers (ADR-040 §1). Reserved keys are stripped on save.
+   *  This is the WIRE shape: a value may be `WEBHOOK_HEADER_VALUE_KEPT`,
+   *  resolved server-side against the stored ciphertext. At rest the record
+   *  is encrypted into `headersEncrypted` (see `secret.ts`) — plaintext
+   *  header values never persist and never return to the client. */
   headers: z
     .record(z.string(), z.string())
     .default({})

--- a/langwatch/src/automations/providers/definitions/webhook/slice.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/slice.ts
@@ -22,7 +22,7 @@ export interface HeaderRow {
   /** True when the value is a saved secret the server kept back (ADR-040 §3):
    *  the input shows a masked placeholder, and the save sends the kept
    *  sentinel so the stored value survives. Typing or renaming clears it. */
-  kept: boolean;
+  isKept: boolean;
 }
 
 let headerRowSeq = 0;
@@ -32,7 +32,7 @@ export function newHeaderRow(partial?: Partial<Omit<HeaderRow, "id">>): HeaderRo
     id: `hdr_${headerRowSeq}`,
     name: "",
     value: "",
-    kept: false,
+    isKept: false,
     ...partial,
   };
 }
@@ -72,7 +72,7 @@ export function fromTriggerRow(row: SavedTriggerRow): WebhookSlice {
   // echoes names with the kept sentinel, which renders as a masked row.
   const headers = Object.entries(params.headers ?? {}).map(([name, value]) =>
     value === WEBHOOK_HEADER_VALUE_KEPT
-      ? newHeaderRow({ name, kept: true })
+      ? newHeaderRow({ name, isKept: true })
       : newHeaderRow({ name, value }),
   );
   return {
@@ -97,7 +97,7 @@ function headersRecord(rows: HeaderRow[]): Record<string, string> {
     if (!name) continue;
     // A kept row sends the sentinel; the server resolves it against the
     // stored ciphertext (save) or drops it if unresolvable (test fire).
-    out[name] = row.kept ? WEBHOOK_HEADER_VALUE_KEPT : row.value;
+    out[name] = row.isKept ? WEBHOOK_HEADER_VALUE_KEPT : row.value;
   }
   return out;
 }

--- a/langwatch/src/automations/providers/definitions/webhook/slice.ts
+++ b/langwatch/src/automations/providers/definitions/webhook/slice.ts
@@ -1,0 +1,139 @@
+import type { SavedTriggerRow, SummaryIdentity } from "../../types";
+import {
+  validateWebhookUrlShape,
+  WEBHOOK_HEADER_VALUE_KEPT,
+  WEBHOOK_METHODS,
+  type WebhookActionParams,
+  type WebhookMethod,
+} from "./shared";
+
+/** A template field, mirroring the Slack provider's `FieldDraft`: empty +
+ *  `usingDefault` means the framework default envelope applies. */
+export interface FieldDraft {
+  value: string;
+  usingDefault: boolean;
+}
+
+export interface HeaderRow {
+  /** Stable client-side identity for React keys — rows are added/removed. */
+  id: string;
+  name: string;
+  value: string;
+  /** True when the value is a saved secret the server kept back (ADR-040 §3):
+   *  the input shows a masked placeholder, and the save sends the kept
+   *  sentinel so the stored value survives. Typing or renaming clears it. */
+  kept: boolean;
+}
+
+let headerRowSeq = 0;
+export function newHeaderRow(partial?: Partial<Omit<HeaderRow, "id">>): HeaderRow {
+  headerRowSeq += 1;
+  return {
+    id: `hdr_${headerRowSeq}`,
+    name: "",
+    value: "",
+    kept: false,
+    ...partial,
+  };
+}
+
+export interface WebhookSlice {
+  url: string;
+  method: WebhookMethod;
+  headers: HeaderRow[];
+  template: FieldDraft;
+}
+
+export const EMPTY_FIELD: FieldDraft = { value: "", usingDefault: true };
+
+export function initialSlice(): WebhookSlice {
+  return { url: "", method: "POST", headers: [], template: EMPTY_FIELD };
+}
+
+export function isComplete(slice: WebhookSlice): boolean {
+  return validateWebhookUrlShape(slice.url.trim()) === null;
+}
+
+export function summary(slice: WebhookSlice, identity: SummaryIdentity): string {
+  const name = identity.name || "(unnamed)";
+  const host = (() => {
+    try {
+      return new URL(slice.url).hostname;
+    } catch {
+      return null;
+    }
+  })();
+  return `${name} → ${slice.method} ${host ?? "(URL not set)"}`;
+}
+
+export function fromTriggerRow(row: SavedTriggerRow): WebhookSlice {
+  const params = (row.actionParams ?? {}) as Partial<WebhookActionParams>;
+  // Saved header VALUES never reach the client (ADR-040 §3) — the server
+  // echoes names with the kept sentinel, which renders as a masked row.
+  const headers = Object.entries(params.headers ?? {}).map(([name, value]) =>
+    value === WEBHOOK_HEADER_VALUE_KEPT
+      ? newHeaderRow({ name, kept: true })
+      : newHeaderRow({ name, value }),
+  );
+  return {
+    url: typeof params.url === "string" ? params.url : "",
+    method: WEBHOOK_METHODS.includes(params.method as WebhookMethod)
+      ? (params.method as WebhookMethod)
+      : "POST",
+    headers,
+    template: {
+      value: params.bodyTemplate ?? "",
+      usingDefault: params.bodyTemplate == null,
+    },
+  };
+}
+
+function headersRecord(rows: HeaderRow[]): Record<string, string> {
+  // Prototype-free map: a user-entered `__proto__` header must land as an own
+  // property, not mutate Object.prototype (which would silently drop it).
+  const out = Object.create(null) as Record<string, string>;
+  for (const row of rows) {
+    const name = row.name.trim();
+    if (!name) continue;
+    // A kept row sends the sentinel; the server resolves it against the
+    // stored ciphertext (save) or drops it if unresolvable (test fire).
+    out[name] = row.kept ? WEBHOOK_HEADER_VALUE_KEPT : row.value;
+  }
+  return out;
+}
+
+function bodyTemplateOf(slice: WebhookSlice): string | null {
+  return slice.template.value.trim().length > 0 ? slice.template.value : null;
+}
+
+export function toActionParams(slice: WebhookSlice): WebhookActionParams {
+  return {
+    url: slice.url.trim(),
+    method: slice.method,
+    headers: headersRecord(slice.headers),
+    bodyTemplate: bodyTemplateOf(slice),
+  };
+}
+
+export function testFireTarget(slice: WebhookSlice) {
+  return {
+    webhook: null,
+    webhookDestination: {
+      url: slice.url.trim(),
+      method: slice.method,
+      headers: headersRecord(slice.headers),
+      bodyTemplate: bodyTemplateOf(slice),
+    },
+  };
+}
+
+/** The webhook's body lives inside `actionParams` (ADR-040 §1), not in the
+ *  four legacy Trigger template columns — so this contributes nothing. */
+export function templatesFromSlice(_slice: WebhookSlice) {
+  return {
+    emailSubjectTemplate: null,
+    emailBodyTemplate: null,
+    slackTemplate: null,
+    slackTemplateType: null,
+  };
+}

--- a/langwatch/src/automations/providers/server.ts
+++ b/langwatch/src/automations/providers/server.ts
@@ -7,6 +7,8 @@ import emailServer from "./definitions/email/server";
 import emailShared from "./definitions/email/shared";
 import slackServer from "./definitions/slack/server";
 import slackShared from "./definitions/slack/shared";
+import webhookServer from "./definitions/webhook/server";
+import webhookShared from "./definitions/webhook/shared";
 import type { ServerEntry } from "./types";
 
 /** The server-side provider registry — pairs each shared definition with
@@ -19,6 +21,10 @@ export const SERVER_PROVIDERS: Record<TriggerAction, ServerEntry> = {
   [TriggerAction.SEND_SLACK_MESSAGE]: {
     shared: slackShared,
     server: slackServer,
+  },
+  [TriggerAction.SEND_WEBHOOK]: {
+    shared: webhookShared,
+    server: webhookServer,
   },
   [TriggerAction.ADD_TO_DATASET]: {
     shared: datasetShared,

--- a/langwatch/src/automations/providers/types.ts
+++ b/langwatch/src/automations/providers/types.ts
@@ -139,6 +139,17 @@ export interface ConfigFormCtx<TPreview = unknown> {
    *  test-fireable yet. `testFireLoading` reflects the in-flight send. */
   onTestFire?: () => void;
   testFireLoading?: boolean;
+  /** Most recent test-fire attempt this session, so a provider can render the
+   *  outcome (HTTP status, failure detail) inline next to its test button.
+   *  Providers filter by their own channel before rendering. */
+  lastTestAttempt?: {
+    at: number;
+    channel: "email" | "slack" | "webhook";
+    status: "success" | "failure";
+    httpStatus?: number;
+    errorTitle?: string;
+    errorDetail?: string;
+  } | null;
 }
 
 /** Mirrors `editors/liquidMonaco#VariableInfo`. Defined here too so the
@@ -196,7 +207,7 @@ export interface NotifyClientDef<S = unknown, TPreview = unknown>
   extends ClientDef<S, TPreview> {
   /** The channel string the preview/testFire endpoints accept. Each
    *  provider names its own — the shared layer doesn't enumerate. */
-  readonly channel: "email" | "slack";
+  readonly channel: "email" | "slack" | "webhook";
   /** Webhook for the test-fire mutation. ADR-031: email test fires resolve
    *  their recipient server-side (the requester's own inbox), so no provider
    *  contributes a recipient list here — only Slack contributes its webhook. */
@@ -206,6 +217,14 @@ export interface NotifyClientDef<S = unknown, TPreview = unknown>
      *  webhook. `botToken` is the freshly-typed token, or null to reuse the
      *  saved automation's stored token. */
     botDestination?: { channelId: string; botToken: string | null } | null;
+    /** Generic HTTP destination (ADR-040): the full request shape the test
+     *  fire sends through the SSRF-fenced sender. */
+    webhookDestination?: {
+      url: string;
+      method: "POST" | "PUT" | "PATCH";
+      headers: Record<string, string>;
+      bodyTemplate: string | null;
+    } | null;
   };
   /** Template strings contributed to the save payload (`templates`). */
   templatesFromSlice(slice: S): TemplateDraft;

--- a/langwatch/src/automations/providers/types.ts
+++ b/langwatch/src/automations/providers/types.ts
@@ -205,8 +205,9 @@ export interface ConfigFormProps<S, TPreview = unknown> {
 /** Notify-specific client additions. Generic over slice and preview. */
 export interface NotifyClientDef<S = unknown, TPreview = unknown>
   extends ClientDef<S, TPreview> {
-  /** The channel string the preview/testFire endpoints accept. Each
-   *  provider names its own — the shared layer doesn't enumerate. */
+  /** The channel string the preview/testFire endpoints accept. This union
+   *  enumerates every notify channel — a new provider must extend it (and the
+   *  preview/testFire endpoints that switch on it). */
   readonly channel: "email" | "slack" | "webhook";
   /** Webhook for the test-fire mutation. ADR-031: email test fires resolve
    *  their recipient server-side (the requester's own inbox), so no provider

--- a/langwatch/src/features/automations/AutomationDrawer.tsx
+++ b/langwatch/src/features/automations/AutomationDrawer.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { AlertType, TriggerKind, type TriggerAction } from "@prisma/client";
+import { AlertType, TriggerAction, TriggerKind } from "@prisma/client";
 import { Mail, Send } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -48,6 +48,7 @@ import {
 } from "~/shared/templating/exampleContext";
 import { renderTriggerEmail } from "~/shared/templating/renderEmail";
 import { renderTriggerSlack } from "~/shared/templating/renderSlack";
+import { renderWebhookBody } from "~/shared/templating/renderWebhookBody";
 import {
   buildExampleGraphAlertTemplateContext,
   buildExampleReportTemplateContext,
@@ -215,6 +216,7 @@ export function AutomationDrawer({
   const hydrate = useAutomationStore((s) => s.hydrate);
   const reset = useAutomationStore((s) => s.reset);
   const pushAttempt = useAutomationStore((s) => s.pushTestAttempt);
+  const testHistory = useAutomationStore((s) => s.testHistory);
 
   // Wipe the singleton store on unmount — next open is a fresh slate.
   useEffect(() => () => reset(), [reset]);
@@ -621,6 +623,28 @@ export function AutomationDrawer({
               errors: rendered.errors,
             });
           }
+        } else if (channel === "webhook") {
+          // The webhook's body lives in its slice (actionParams), not the
+          // template columns — read it straight off the draft.
+          const slice = draft.slices[TriggerAction.SEND_WEBHOOK];
+          const rendered = await renderWebhookBody({
+            template: slice.template.value.trim() ? slice.template.value : null,
+            context: previewContext,
+            defaultBody: previewDefaults.webhookBody,
+          });
+          if (token === previewToken.current) {
+            setPreview({
+              channel: "webhook",
+              payload: {
+                method: slice.method,
+                url: slice.url,
+                body: rendered.body,
+              },
+              usedDefault: rendered.usedDefault,
+              missingVariables: rendered.missingVariables,
+              errors: rendered.errors,
+            });
+          }
         } else {
           const rendered = await renderTriggerSlack({
             templateType:
@@ -694,6 +718,7 @@ export function AutomationDrawer({
         channel,
         webhook: target.webhook,
         botDestination: target.botDestination,
+        webhookDestination: target.webhookDestination,
         automationId,
         graphName,
         seriesLabel,
@@ -706,6 +731,7 @@ export function AutomationDrawer({
             status: "success",
             recipientCount: r.recipientCount,
             usedDefault: r.usedDefault,
+            httpStatus: r.httpStatus,
           });
           toaster.create({
             title: "Test fire sent",
@@ -713,7 +739,9 @@ export function AutomationDrawer({
             description:
               r.channel === "email"
                 ? "Sent to your inbox."
-                : "Posted to Slack.",
+                : r.channel === "webhook"
+                  ? `Your endpoint answered HTTP ${r.httpStatus ?? "2xx"}.`
+                  : "Posted to Slack.",
             meta: { closable: true },
           });
         },
@@ -876,6 +904,9 @@ export function AutomationDrawer({
       // Lets a notify provider offer a "Send test" button inside its config.
       onTestFire,
       testFireLoading: testFire.isLoading,
+      // The latest test outcome, so a provider can render the result (HTTP
+      // status / failure) inline next to its own test button.
+      lastTestAttempt: testHistory[0] ?? null,
     }),
     [
       projectId,
@@ -894,6 +925,7 @@ export function AutomationDrawer({
       draft.report.sourceKind,
       onTestFire,
       testFire.isLoading,
+      testHistory,
     ],
   );
 

--- a/langwatch/src/features/automations/ViewAutomationDrawer.tsx
+++ b/langwatch/src/features/automations/ViewAutomationDrawer.tsx
@@ -12,6 +12,7 @@ import {
 } from "@chakra-ui/react";
 import { TriggerKind } from "@prisma/client";
 import { differenceInMinutes, differenceInSeconds } from "date-fns";
+import { useState } from "react";
 import { Calendar, TrendingUp } from "react-feather";
 import { CLIENT_PROVIDERS } from "~/automations/providers/client";
 import { FilterDisplay } from "~/components/automations/FilterDisplay";
@@ -75,9 +76,18 @@ export function ViewAutomationDrawer({
     { triggerId: automationId, projectId: project?.id ?? "", limit: 20 },
     { enabled: !!project?.id },
   );
+  // ADR-040 §6: the per-attempt delivery log, only for webhook automations.
+  const webhookDeliveriesQuery = api.automation.getWebhookDeliveries.useQuery(
+    { triggerId: automationId, projectId: project?.id ?? "", limit: 50 },
+    {
+      enabled:
+        !!project?.id && triggerQuery.data?.action === "SEND_WEBHOOK",
+    },
+  );
 
   const trigger = triggerQuery.data;
   const isGraphAlert = !!trigger?.customGraphId;
+  const isWebhook = trigger?.action === "SEND_WEBHOOK";
   const isSchedule = trigger?.triggerKind === TriggerKind.REPORT;
   const actionParams = (trigger?.actionParams ?? {}) as TriggerActionParams;
 
@@ -268,6 +278,25 @@ export function ViewAutomationDrawer({
                 />
               )}
             </VStack>
+
+            {isWebhook ? (
+              <VStack align="start" gap={2} width="full">
+                <Text textStyle="xs" color="fg.muted" fontWeight="medium">
+                  Recent deliveries
+                </Text>
+                {webhookDeliveriesQuery.isLoading ? (
+                  <Skeleton height="60px" width="full" />
+                ) : (webhookDeliveriesQuery.data ?? []).length === 0 ? (
+                  <Text textStyle="sm" color="fg.muted">
+                    No delivery attempts recorded yet.
+                  </Text>
+                ) : (
+                  <WebhookDeliveriesList
+                    deliveries={webhookDeliveriesQuery.data ?? []}
+                  />
+                )}
+              </VStack>
+            ) : null}
           </VStack>
         </Drawer.Body>
         <Drawer.Footer>
@@ -380,4 +409,140 @@ function groupFiresByLabel(
     else groups.push({ key: fire.id, label, count: 1 });
   }
   return groups;
+}
+
+type WebhookDelivery =
+  RouterOutputs["automation"]["getWebhookDeliveries"][number];
+
+const OUTCOME_DOT: Record<WebhookDelivery["outcome"], string> = {
+  success: "green.solid",
+  retryable: "yellow.solid",
+  terminal: "red.solid",
+  pending: "gray.solid",
+};
+
+/**
+ * The webhook delivery log (ADR-040 §6): attempts grouped by the fire that
+ * produced them (`dispatchId`), newest fire first. Each attempt expands to the
+ * request headers (secret values already masked server-side) and the
+ * receiver's response snippet — enough to debug a 401/422 without re-firing.
+ */
+function WebhookDeliveriesList({
+  deliveries,
+}: {
+  deliveries: WebhookDelivery[];
+}) {
+  // Rows arrive newest-first. Group by dispatchId keeping first-seen order
+  // (newest fire on top); reverse each group so attempts read oldest→newest.
+  const groups: { dispatchId: string; attempts: WebhookDelivery[] }[] = [];
+  const byId = new Map<string, WebhookDelivery[]>();
+  for (const d of deliveries) {
+    let attempts = byId.get(d.dispatchId);
+    if (!attempts) {
+      attempts = [];
+      byId.set(d.dispatchId, attempts);
+      groups.push({ dispatchId: d.dispatchId, attempts });
+    }
+    attempts.push(d);
+  }
+  for (const g of groups) g.attempts.reverse();
+
+  return (
+    <VStack align="stretch" gap={2} width="full">
+      {groups.map((g) => (
+        <VStack
+          key={g.dispatchId}
+          align="stretch"
+          gap={0}
+          width="full"
+          borderWidth="1px"
+          borderColor="border"
+          borderRadius="md"
+          overflow="hidden"
+        >
+          {g.attempts.map((attempt, index) => (
+            <DeliveryAttemptRow
+              key={attempt.id}
+              attempt={attempt}
+              index={index}
+              total={g.attempts.length}
+            />
+          ))}
+        </VStack>
+      ))}
+    </VStack>
+  );
+}
+
+function DeliveryAttemptRow({
+  attempt,
+  index,
+  total,
+}: {
+  attempt: WebhookDelivery;
+  index: number;
+  total: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const statusText =
+    attempt.responseStatus != null
+      ? `HTTP ${attempt.responseStatus}`
+      : (attempt.error ?? "No response");
+  const headerEntries = Object.entries(attempt.requestHeaders ?? {});
+
+  return (
+    <Box borderBottomWidth="1px" borderColor="border" _last={{ borderBottomWidth: 0 }}>
+      <HStack
+        as="button"
+        gap={2.5}
+        paddingX={3}
+        paddingY={2}
+        width="full"
+        textAlign="left"
+        cursor="pointer"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Box
+          boxSize={2}
+          borderRadius="full"
+          flexShrink={0}
+          bg={OUTCOME_DOT[attempt.outcome]}
+        />
+        <Text textStyle="sm" flex="1" minWidth="0">
+          {total > 1 ? `Attempt ${index + 1} · ` : ""}
+          {statusText}
+        </Text>
+        <Text textStyle="xs" color="fg.muted" flexShrink={0} whiteSpace="nowrap">
+          {attempt.latencyMs != null ? `${attempt.latencyMs}ms · ` : ""}
+          {formatTimeAgo(new Date(attempt.firedAt).getTime())}
+        </Text>
+      </HStack>
+      {open ? (
+        <VStack align="stretch" gap={2} paddingX={3} paddingBottom={3}>
+          <Text textStyle="xs" color="fg.muted">
+            {attempt.requestMethod} {attempt.requestUrl}
+          </Text>
+          {headerEntries.length > 0 ? (
+            <VStack align="stretch" gap={0.5}>
+              {headerEntries.map(([name, value]) => (
+                <Code key={name} fontSize="xs" width="full" whiteSpace="pre-wrap">
+                  {name}: {value}
+                </Code>
+              ))}
+            </VStack>
+          ) : null}
+          {attempt.responseBody ? (
+            <Code
+              fontSize="xs"
+              width="full"
+              whiteSpace="pre-wrap"
+              wordBreak="break-word"
+            >
+              {attempt.responseBody}
+            </Code>
+          ) : null}
+        </VStack>
+      ) : null}
+    </Box>
+  );
 }

--- a/langwatch/src/features/automations/ViewAutomationDrawer.tsx
+++ b/langwatch/src/features/automations/ViewAutomationDrawer.tsx
@@ -414,12 +414,12 @@ function groupFiresByLabel(
 type WebhookDelivery =
   RouterOutputs["automation"]["getWebhookDeliveries"][number];
 
-const OUTCOME_DOT: Record<WebhookDelivery["outcome"], string> = {
+const OUTCOME_DOT = {
   success: "green.solid",
   retryable: "yellow.solid",
   terminal: "red.solid",
   pending: "gray.solid",
-};
+} as const satisfies Record<WebhookDelivery["outcome"], string>;
 
 /**
  * The webhook delivery log (ADR-040 §6): attempts grouped by the fire that
@@ -432,20 +432,26 @@ function WebhookDeliveriesList({
 }: {
   deliveries: WebhookDelivery[];
 }) {
-  // Rows arrive newest-first. Group by dispatchId keeping first-seen order
-  // (newest fire on top); reverse each group so attempts read oldest→newest.
-  const groups: { dispatchId: string; attempts: WebhookDelivery[] }[] = [];
+  // Group attempts by the fire that produced them (dispatchId). Within a group,
+  // sort attempts ascending (oldest→newest, so "Attempt 1" is the first try).
+  // Order groups by each group's EARLIEST attempt, descending — the newest fire
+  // sits on top even when an older fire had a recent retry (a first-seen order
+  // would let that older fire jump above a newer one).
   const byId = new Map<string, WebhookDelivery[]>();
   for (const d of deliveries) {
-    let attempts = byId.get(d.dispatchId);
-    if (!attempts) {
-      attempts = [];
-      byId.set(d.dispatchId, attempts);
-      groups.push({ dispatchId: d.dispatchId, attempts });
-    }
-    attempts.push(d);
+    const attempts = byId.get(d.dispatchId);
+    if (attempts) attempts.push(d);
+    else byId.set(d.dispatchId, [d]);
   }
-  for (const g of groups) g.attempts.reverse();
+  const firedAtMs = (d: WebhookDelivery) => new Date(d.firedAt).getTime();
+  const groups = Array.from(byId.entries())
+    .map(([dispatchId, attempts]) => ({
+      dispatchId,
+      attempts: [...attempts].sort((a, b) => firedAtMs(a) - firedAtMs(b)),
+    }))
+    .sort(
+      (a, b) => firedAtMs(b.attempts[0]!) - firedAtMs(a.attempts[0]!),
+    );
 
   return (
     <VStack align="stretch" gap={2} width="full">
@@ -483,7 +489,7 @@ function DeliveryAttemptRow({
   index: number;
   total: number;
 }) {
-  const [open, setOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const statusText =
     attempt.responseStatus != null
       ? `HTTP ${attempt.responseStatus}`
@@ -500,7 +506,7 @@ function DeliveryAttemptRow({
         width="full"
         textAlign="left"
         cursor="pointer"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setIsOpen((v) => !v)}
       >
         <Box
           boxSize={2}
@@ -517,7 +523,7 @@ function DeliveryAttemptRow({
           {formatTimeAgo(new Date(attempt.firedAt).getTime())}
         </Text>
       </HStack>
-      {open ? (
+      {isOpen ? (
         <VStack align="stretch" gap={2} paddingX={3} paddingBottom={3}>
           <Text textStyle="xs" color="fg.muted">
             {attempt.requestMethod} {attempt.requestUrl}

--- a/langwatch/src/features/automations/components/DeliveryPicker.tsx
+++ b/langwatch/src/features/automations/components/DeliveryPicker.tsx
@@ -6,10 +6,12 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import type { TriggerAction } from "@prisma/client";
+import { TriggerAction } from "@prisma/client";
 import { Settings2 } from "lucide-react";
 import { CLIENT_PROVIDERS } from "~/automations/providers/client";
 import type { ClientEntry } from "~/automations/providers/types";
+import { useFeatureFlag } from "~/hooks/useFeatureFlag";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { ConditionSource } from "../logic/draftReducer";
 import { useAutomationStore } from "../state/automationStore";
 import {
@@ -47,11 +49,23 @@ export function DeliveryPicker({
   const setSection = useAutomationStore((s) => s.setSection);
   const configComplete = useConfigComplete();
   const configSummary = useConfigurationSummary();
-  const entries = Object.values(CLIENT_PROVIDERS);
-  const notify = entries.filter((e) => e.shared.category === "notify");
-  const action = entries.filter((e) => e.shared.category === "action");
+  const { project } = useOrganizationTeamProject();
+  // ADR-040: the webhook channel ships dark. The card is hidden until the
+  // flag is on (the save/test routes are gated server-side too), and never
+  // offered for reports — the scheduled-report dispatch is email/Slack only.
+  const { enabled: webhookEnabled } = useFeatureFlag(
+    "release_webhook_automations",
+    { projectId: project?.id, enabled: !!project },
+  );
   const isAlertKind = source === "customGraph";
   const notifyOnly = isAlertKind || source === "report";
+  const entries = Object.values(CLIENT_PROVIDERS).filter(
+    (e) =>
+      e.shared.action !== TriggerAction.SEND_WEBHOOK ||
+      (webhookEnabled && source !== "report"),
+  );
+  const notify = entries.filter((e) => e.shared.category === "notify");
+  const action = entries.filter((e) => e.shared.category === "action");
   const accent = ACCENT_FOR_SOURCE[source];
 
   // Picking a channel drops the author straight into its setup — no separate,

--- a/langwatch/src/features/automations/logic/draftReducer.ts
+++ b/langwatch/src/features/automations/logic/draftReducer.ts
@@ -321,7 +321,7 @@ export function presetLabels(
 
 export function notifyChannel(
   draft: AutomationDraft,
-): "email" | "slack" | null {
+): "email" | "slack" | "webhook" | null {
   if (!draft.action) return null;
   const provider = CLIENT_PROVIDERS[draft.action];
   return isNotifyEntry(provider) ? provider.client.channel : null;
@@ -356,16 +356,24 @@ export function buildTestFirePayload({
   channel,
   webhook,
   botDestination,
+  webhookDestination,
   automationId,
   graphName,
   seriesLabel,
 }: {
   draft: AutomationDraft;
   projectId: string;
-  channel: "email" | "slack";
+  channel: "email" | "slack" | "webhook";
   webhook: string | null;
   /** Slack bot connection: test-fires via the Web API to this channel. */
   botDestination?: { channelId: string; botToken: string | null } | null;
+  /** ADR-040 generic HTTP destination: the full request the test fire sends. */
+  webhookDestination?: {
+    url: string;
+    method: "POST" | "PUT" | "PATCH";
+    headers: Record<string, string>;
+    bodyTemplate: string | null;
+  } | null;
   /** The saved automation being edited, so a kept bot token can be resolved. */
   automationId?: string;
   graphName?: string | null;
@@ -383,6 +391,7 @@ export function buildTestFirePayload({
     draft: templatesFromDraft(draft),
     webhook,
     botDestination: botDestination ?? null,
+    webhookDestination: webhookDestination ?? null,
     ...(automationId ? { automationId } : {}),
     graphAlert: isGraphAlert
       ? {

--- a/langwatch/src/features/automations/state/automationStore.ts
+++ b/langwatch/src/features/automations/state/automationStore.ts
@@ -12,12 +12,15 @@ export const MAX_TEST_HISTORY = 5;
  *  come from the outbox-backed health view (ADR-037, separate stack). */
 export interface TestFireAttempt {
   at: number;
-  channel: "email" | "slack";
+  channel: "email" | "slack" | "webhook";
   status: "success" | "failure";
   recipientCount?: number;
   usedDefault?: boolean;
   errorTitle?: string;
   errorDetail?: string;
+  /** Webhook only: the HTTP status the endpoint answered a successful test
+   *  with — shown inline next to the test button (ADR-040 §1). */
+  httpStatus?: number;
 }
 
 /** Which secondary drawer is currently open on top of the main view.

--- a/langwatch/src/pages/api/cron/triggers/actions/graphAlertDispatch.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/graphAlertDispatch.ts
@@ -18,6 +18,7 @@ import {
 } from "~/server/event-sourcing/pipelines/shared/graphAlertActionDispatch";
 import { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import { sendRenderedSlackMessage } from "~/server/triggers/sendSlackWebhook";
+import { sendWebhook } from "~/server/triggers/sendWebhook";
 import { postSlackChatMessage } from "~/server/triggers/slackWebApi";
 import { buildGraphAlertTemplateContext } from "~/shared/templating/templateContext";
 import type { ActionParams, TriggerContext } from "../types";
@@ -101,6 +102,7 @@ export function cronGraphAlertDeps(): GraphAlertDispatchDeps {
     sendEmail: sendRenderedTriggerEmail,
     sendSlack: sendRenderedSlackMessage,
     sendSlackBot: postSlackChatMessage,
+    sendWebhook,
     filterSuppressedRecipients: (params) =>
       app.emailSuppressions.filterSuppressed(params),
     // ADR-031: the two hard email caps, bound from env — the same consumers

--- a/langwatch/src/pages/api/cron/triggers/actions/graphAlertDispatch.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/graphAlertDispatch.ts
@@ -20,8 +20,6 @@ import { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import { sendRenderedSlackMessage } from "~/server/triggers/sendSlackWebhook";
 import { sendWebhook } from "~/server/triggers/sendWebhook";
 import { postSlackChatMessage } from "~/server/triggers/slackWebApi";
-import { WebhookDeliveryService } from "~/server/app-layer/triggers/webhook-delivery.service";
-import { prisma } from "~/server/db";
 import { buildGraphAlertTemplateContext } from "~/shared/templating/templateContext";
 import type { ActionParams, TriggerContext } from "../types";
 
@@ -105,8 +103,7 @@ export function cronGraphAlertDeps(): GraphAlertDispatchDeps {
     sendSlack: sendRenderedSlackMessage,
     sendSlackBot: postSlackChatMessage,
     sendWebhook,
-    recordWebhookDelivery: (input) =>
-      WebhookDeliveryService.create(prisma).record(input),
+    recordWebhookDelivery: (input) => app.webhookDeliveries.record(input),
     filterSuppressedRecipients: (params) =>
       app.emailSuppressions.filterSuppressed(params),
     // ADR-031: the two hard email caps, bound from env — the same consumers

--- a/langwatch/src/pages/api/cron/triggers/actions/graphAlertDispatch.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/graphAlertDispatch.ts
@@ -20,6 +20,8 @@ import { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import { sendRenderedSlackMessage } from "~/server/triggers/sendSlackWebhook";
 import { sendWebhook } from "~/server/triggers/sendWebhook";
 import { postSlackChatMessage } from "~/server/triggers/slackWebApi";
+import { WebhookDeliveryService } from "~/server/app-layer/triggers/webhook-delivery.service";
+import { prisma } from "~/server/db";
 import { buildGraphAlertTemplateContext } from "~/shared/templating/templateContext";
 import type { ActionParams, TriggerContext } from "../types";
 
@@ -103,6 +105,8 @@ export function cronGraphAlertDeps(): GraphAlertDispatchDeps {
     sendSlack: sendRenderedSlackMessage,
     sendSlackBot: postSlackChatMessage,
     sendWebhook,
+    recordWebhookDelivery: (input) =>
+      WebhookDeliveryService.create(prisma).record(input),
     filterSuppressedRecipients: (params) =>
       app.emailSuppressions.filterSuppressed(params),
     // ADR-031: the two hard email caps, bound from env — the same consumers

--- a/langwatch/src/pages/api/cron/triggers/actions/sendWebhookRequest.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/sendWebhookRequest.ts
@@ -1,0 +1,42 @@
+import { TriggerAction } from "@prisma/client";
+import { dispatchGraphAlertAction } from "~/server/event-sourcing/pipelines/shared/graphAlertActionDispatch";
+import { captureException, toError } from "~/utils/posthogErrorCapture";
+import type { TriggerContext } from "../types";
+import {
+  buildCronGraphAlertInput,
+  cronGraphAlertDeps,
+} from "./graphAlertDispatch";
+
+/**
+ * Deliver a custom-graph alert to a customer webhook from the cron path
+ * (ADR-040). Same shape as `sendSlackMessage.ts`: delegates to the shared
+ * `dispatchGraphAlertAction` (which owns rendering, the SSRF-fenced send, and
+ * the per-fire idempotency gate) so the cron and the event-sourced evaluator
+ * deliver identically — the firing flag only decides who calls it.
+ *
+ * Dispatch errors are captured (never thrown — a cron batch must not die on
+ * one alert) and reported as `didSend: false`, so an undelivered alert does
+ * NOT open an incident and the next tick retries.
+ */
+export const handleSendWebhookRequest = async (
+  context: TriggerContext,
+): Promise<{ didSend: boolean }> => {
+  const { trigger } = context;
+
+  try {
+    const result = await dispatchGraphAlertAction({
+      deps: cronGraphAlertDeps(),
+      input: buildCronGraphAlertInput(context),
+    });
+    return { didSend: result.didSend };
+  } catch (error) {
+    captureException(toError(error), {
+      extra: {
+        triggerId: trigger.id,
+        projectId: trigger.projectId,
+        action: TriggerAction.SEND_WEBHOOK,
+      },
+    });
+    return { didSend: false };
+  }
+};

--- a/langwatch/src/pages/api/cron/triggers/actions/sendWebhookRequest.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/sendWebhookRequest.ts
@@ -1,4 +1,5 @@
 import { TriggerAction } from "@prisma/client";
+import { isDispatchError } from "~/server/event-sourcing/outbox/dispatchError";
 import { dispatchGraphAlertAction } from "~/server/event-sourcing/pipelines/shared/graphAlertActionDispatch";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
 import type { TriggerContext } from "../types";
@@ -15,8 +16,11 @@ import {
  * deliver identically — the firing flag only decides who calls it.
  *
  * Dispatch errors are captured (never thrown — a cron batch must not die on
- * one alert) and reported as `didSend: false`, so an undelivered alert does
- * NOT open an incident and the next tick retries.
+ * one alert). A RETRYABLE failure reports `didSend: false`, so no incident
+ * opens and the next tick retries. A TERMINAL failure (SSRF block, non-retry
+ * HTTP status — ADR-040 §5) reports `didSend: true` to consume the fire:
+ * re-posting to a misconfigured endpoint every tick just spams it, which is
+ * exactly what the terminal classification exists to prevent.
  */
 export const handleSendWebhookRequest = async (
   context: TriggerContext,
@@ -37,6 +41,7 @@ export const handleSendWebhookRequest = async (
         action: TriggerAction.SEND_WEBHOOK,
       },
     });
-    return { didSend: false };
+    const terminal = isDispatchError(error) && !error.retryable;
+    return { didSend: terminal };
   }
 };

--- a/langwatch/src/pages/api/cron/triggers/customGraphTrigger.ts
+++ b/langwatch/src/pages/api/cron/triggers/customGraphTrigger.ts
@@ -18,6 +18,7 @@ import type { Trace } from "~/server/tracer/types";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
 import { handleSendEmail } from "./actions/sendEmail";
 import { handleSendSlackMessage } from "./actions/sendSlackMessage";
+import { handleSendWebhookRequest } from "./actions/sendWebhookRequest";
 import type {
   ActionParams,
   TriggerContext,
@@ -273,6 +274,8 @@ export const processCustomGraphTrigger = async (
           ({ didSend } = await handleSendEmail(context));
         } else if (action === TriggerAction.SEND_SLACK_MESSAGE) {
           ({ didSend } = await handleSendSlackMessage(context));
+        } else if (action === TriggerAction.SEND_WEBHOOK) {
+          ({ didSend } = await handleSendWebhookRequest(context));
         }
 
         if (didSend) {

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -48,6 +48,7 @@ import {
   validateTemplateDraft,
 } from "~/server/app-layer/triggers/trigger-template.service";
 import { NOTIFY_TRIGGER_ACTIONS } from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
+import { featureFlagService } from "~/server/featureFlag";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import {
   sanitizeTriggerFilters,
@@ -152,6 +153,12 @@ const actionParamsSchema = z.object({
   annotators: z
     .array(z.object({ id: z.string(), name: z.string() }))
     .optional(),
+  // ADR-040 SEND_WEBHOOK destination — the per-action provider schema
+  // re-validates the shape (https-only URL, sanitized headers) below.
+  url: z.string().optional(),
+  method: z.enum(["POST", "PUT", "PATCH"]).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+  bodyTemplate: z.string().nullable().optional(),
 });
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]["code"];
@@ -649,13 +656,26 @@ export const automationRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        channel: z.enum(["email", "slack"]),
+        channel: z.enum(["email", "slack", "webhook"]),
         trigger: triggerIdentitySchema,
         draft: templateDraftSchema,
         webhook: z
           .string()
           .url()
           .startsWith("https://hooks.slack.com/")
+          .nullable()
+          .default(null),
+        /** ADR-040 generic HTTP test fire: the full request shape, body
+         *  template included (it lives in actionParams, not the four Trigger
+         *  template columns). URL shape is re-validated by the provider
+         *  schema; the real SSRF gate runs inside the sender. */
+        webhookDestination: z
+          .object({
+            url: z.string().url(),
+            method: z.enum(["POST", "PUT", "PATCH"]).default("POST"),
+            headers: z.record(z.string(), z.string()).default({}),
+            bodyTemplate: z.string().nullable().default(null),
+          })
           .nullable()
           .default(null),
         /** Set when the Slack automation uses a bot connection. `botToken` is
@@ -708,6 +728,21 @@ export const automationRouter = createTRPCRouter({
       // and intentionally exempt from the rate limit — it fires to the
       // customer's own webhook, not our mail provider.
       try {
+        // The webhook channel ships dark (ADR-040 §7): the type picker is
+        // flag-gated client-side, and the server refuses the channel too so
+        // the flag can't be bypassed by calling the API directly.
+        if (input.channel === "webhook") {
+          const allowed = await featureFlagService.isEnabled(
+            "release_webhook_automations",
+            { distinctId: ctx.session.user.id, projectId: input.projectId },
+          );
+          if (!allowed) {
+            throw new TRPCError({
+              code: "FORBIDDEN",
+              message: "Webhook automations are not enabled for this project.",
+            });
+          }
+        }
         let recipients: string[] = [];
         if (input.channel === "email") {
           const limit = await rateLimit({
@@ -769,6 +804,7 @@ export const automationRouter = createTRPCRouter({
           recipients,
           webhook: input.webhook,
           botDestination,
+          webhookDestination: input.webhookDestination,
           graphAlert: input.graphAlert,
           report: input.report,
         });
@@ -811,17 +847,28 @@ export const automationRouter = createTRPCRouter({
       let parsedActionParams: Record<string, unknown> = {};
       try {
         validateTemplateDraft(input.templates);
+        // The webhook channel ships dark (ADR-040 §7): gate the save route as
+        // well as the picker, so the flag can't be bypassed via the API.
+        if (input.action === TriggerAction.SEND_WEBHOOK) {
+          const allowed = await featureFlagService.isEnabled(
+            "release_webhook_automations",
+            { distinctId: ctx.session.user.id, projectId: input.projectId },
+          );
+          if (!allowed) {
+            throw new TRPCError({
+              code: "FORBIDDEN",
+              message: "Webhook automations are not enabled for this project.",
+            });
+          }
+        }
         if (isGraphAlert) {
           // Graph alerts only support notify channels — there is no
           // "ADD_TO_DATASET on a metric crossing a threshold" UX.
-          if (
-            input.action !== TriggerAction.SEND_EMAIL &&
-            input.action !== TriggerAction.SEND_SLACK_MESSAGE
-          ) {
+          if (!NOTIFY_TRIGGER_ACTIONS.has(input.action)) {
             throw new TRPCError({
               code: "BAD_REQUEST",
               message:
-                "Graph alerts only support Email or Slack notifications.",
+                "Graph alerts only support notify channels (Email, Slack, or a webhook).",
             });
           }
           if (!input.graphAlert) {

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -58,6 +58,7 @@ import {
   validateTemplateDraft,
 } from "~/server/app-layer/triggers/trigger-template.service";
 import { NOTIFY_TRIGGER_ACTIONS } from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
+import { WebhookDeliveryService } from "~/server/app-layer/triggers/webhook-delivery.service";
 import { featureFlagService } from "~/server/featureFlag";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import {
@@ -496,6 +497,26 @@ export const automationRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const fireHistory = TriggerFireHistoryService.create(ctx.prisma);
       return fireHistory.getAllRecentFiresForTrigger({
+        projectId: input.projectId,
+        triggerId: input.triggerId,
+        limit: input.limit,
+      });
+    }),
+  /** ADR-040 §6: the per-attempt webhook delivery log for one automation —
+   *  the drawer's "Recent deliveries" drill-down. Header values are already
+   *  redacted at write time. */
+  getWebhookDeliveries: protectedProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        triggerId: z.string(),
+        limit: z.number().int().min(1).max(50).default(50),
+      }),
+    )
+    .use(checkProjectPermission("triggers:view"))
+    .query(async ({ ctx, input }) => {
+      const deliveries = WebhookDeliveryService.create(ctx.prisma);
+      return deliveries.getRecentByTrigger({
         projectId: input.projectId,
         triggerId: input.triggerId,
         limit: input.limit,

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -33,6 +33,16 @@ import {
   slackDeliveryMethodOf,
 } from "~/automations/providers/definitions/slack/shared";
 import {
+  decryptWebhookHeaders,
+  persistWebhookActionParams,
+  redactWebhookActionParams,
+  type WebhookStoredActionParams,
+} from "~/automations/providers/definitions/webhook/secret";
+import {
+  WEBHOOK_HEADER_VALUE_KEPT,
+  type WebhookActionParams,
+} from "~/automations/providers/definitions/webhook/shared";
+import {
   buildGraphAlertTriggerData,
   type GraphAlertActionParams,
   graphAlertActionParamsSchema,
@@ -62,19 +72,30 @@ import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { extractCheckKeys } from "../utils";
 import { buildRetryAfterMessage } from "./rateLimitMessage";
 
-/** Strip the encrypted Slack bot token from a trigger row before it leaves the
- *  server — the client only needs to know a token is set (ADR-041). No-op for
- *  every non-Slack action. */
+/** Strip secrets from a trigger row before it leaves the server: the
+ *  encrypted Slack bot token (ADR-041) and webhook header values (ADR-040 §3
+ *  — names echo with the kept sentinel, values never return). No-op for every
+ *  other action. */
 function redactTriggerForRead<
   T extends { action: TriggerAction; actionParams: unknown },
 >(trigger: T): T {
-  if (trigger.action !== TriggerAction.SEND_SLACK_MESSAGE) return trigger;
-  return {
-    ...trigger,
-    actionParams: redactSlackActionParams(
-      (trigger.actionParams ?? {}) as SlackActionParams,
-    ),
-  };
+  if (trigger.action === TriggerAction.SEND_SLACK_MESSAGE) {
+    return {
+      ...trigger,
+      actionParams: redactSlackActionParams(
+        (trigger.actionParams ?? {}) as SlackActionParams,
+      ),
+    };
+  }
+  if (trigger.action === TriggerAction.SEND_WEBHOOK) {
+    return {
+      ...trigger,
+      actionParams: redactWebhookActionParams(
+        (trigger.actionParams ?? {}) as WebhookStoredActionParams,
+      ),
+    };
+  }
+  return trigger;
 }
 
 const templateDraftSchema = z.object({
@@ -743,8 +764,11 @@ export const automationRouter = createTRPCRouter({
             });
           }
         }
-        let recipients: string[] = [];
-        if (input.channel === "email") {
+        // Email shares the mail provider; webhook fires at an ARBITRARY
+        // customer URL from our worker IPs, so an uncapped test button would
+        // be an outbound request-flood primitive (ADR-040 §4). Slack stays
+        // exempt: its destination is host-pinned to hooks.slack.com.
+        if (input.channel === "email" || input.channel === "webhook") {
           const limit = await rateLimit({
             key: `testfire:${ctx.session.user.id}`,
             windowSeconds: 60,
@@ -759,7 +783,9 @@ export const automationRouter = createTRPCRouter({
               }),
             });
           }
-
+        }
+        let recipients: string[] = [];
+        if (input.channel === "email") {
           const email = ctx.session.user.email;
           if (!email) {
             throw new TRPCError({
@@ -795,6 +821,41 @@ export const automationRouter = createTRPCRouter({
           botDestination = { token, channel };
         }
 
+        // ADR-040 §3: header secrets never reach the client, so a saved
+        // automation's test fire carries the kept sentinel — resolve it
+        // against the stored ciphertext, exactly like the Slack bot token
+        // above. Unresolvable kept values (fresh draft, renamed header) are
+        // dropped rather than sent as the literal sentinel.
+        let webhookDestination = input.webhookDestination;
+        if (
+          webhookDestination &&
+          Object.values(webhookDestination.headers).includes(
+            WEBHOOK_HEADER_VALUE_KEPT,
+          )
+        ) {
+          let saved: Record<string, string> = {};
+          if (input.automationId) {
+            const row = await ctx.prisma.trigger.findUnique({
+              where: { id: input.automationId, projectId: input.projectId },
+              select: { actionParams: true },
+            });
+            saved = decryptWebhookHeaders(
+              (row?.actionParams ?? {}) as WebhookStoredActionParams,
+            );
+          }
+          const headers: Record<string, string> = {};
+          for (const [name, value] of Object.entries(
+            webhookDestination.headers,
+          )) {
+            if (value === WEBHOOK_HEADER_VALUE_KEPT) {
+              if (saved[name] !== undefined) headers[name] = saved[name];
+              continue;
+            }
+            headers[name] = value;
+          }
+          webhookDestination = { ...webhookDestination, headers };
+        }
+
         const project = await resolveProjectIdentity(input.projectId);
         return await getApp().triggerTemplates.testFire({
           channel: input.channel,
@@ -804,7 +865,7 @@ export const automationRouter = createTRPCRouter({
           recipients,
           webhook: input.webhook,
           botDestination,
-          webhookDestination: input.webhookDestination,
+          webhookDestination,
           graphAlert: input.graphAlert,
           report: input.report,
         });
@@ -1004,6 +1065,31 @@ export const automationRouter = createTRPCRouter({
         slackActionParams = persistSlackActionParams({ incoming, existing });
       }
 
+      // ADR-040 §3 webhook header secrets: resolve kept sentinels against the
+      // saved row, then encrypt the record — plaintext header values never
+      // persist and never return to the client (same discipline as the Slack
+      // bot token above).
+      let webhookActionParams: WebhookStoredActionParams | null = null;
+      if (input.action === TriggerAction.SEND_WEBHOOK) {
+        const incoming = parsedActionParams as unknown as WebhookActionParams;
+        const hasKept = Object.values(incoming.headers ?? {}).some(
+          (v) => v === WEBHOOK_HEADER_VALUE_KEPT,
+        );
+        const existing =
+          input.triggerId && hasKept
+            ? ((
+                await ctx.prisma.trigger.findUnique({
+                  where: { id: input.triggerId, projectId: input.projectId },
+                  select: { actionParams: true },
+                })
+              )?.actionParams as WebhookStoredActionParams | undefined)
+            : undefined;
+        webhookActionParams = persistWebhookActionParams({
+          incoming,
+          existing,
+        });
+      }
+
       // Annotation-queue dispatch attributes created queue items to a user
       // and skips the action when `createdByUserId` is absent. The drawer's
       // provider slice doesn't carry it, so stamp the caller here — same as
@@ -1020,7 +1106,9 @@ export const automationRouter = createTRPCRouter({
             }
           : slackActionParams
             ? { ...slackActionParams }
-            : { ...parsedActionParams };
+            : webhookActionParams
+              ? { ...webhookActionParams }
+              : { ...parsedActionParams };
 
       // Graph alerts: route the row shape through the SSOT builder so it's
       // byte-identical to what `graphs.updateById` writes on the dashboard

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -39,6 +39,7 @@ import {
   type WebhookStoredActionParams,
 } from "~/automations/providers/definitions/webhook/secret";
 import {
+  normalizeWebhookUrl,
   WEBHOOK_HEADER_VALUE_KEPT,
   type WebhookActionParams,
 } from "~/automations/providers/definitions/webhook/shared";
@@ -58,7 +59,6 @@ import {
   validateTemplateDraft,
 } from "~/server/app-layer/triggers/trigger-template.service";
 import { NOTIFY_TRIGGER_ACTIONS } from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
-import { WebhookDeliveryService } from "~/server/app-layer/triggers/webhook-delivery.service";
 import { featureFlagService } from "~/server/featureFlag";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import {
@@ -514,9 +514,8 @@ export const automationRouter = createTRPCRouter({
       }),
     )
     .use(checkProjectPermission("triggers:view"))
-    .query(async ({ ctx, input }) => {
-      const deliveries = WebhookDeliveryService.create(ctx.prisma);
-      return deliveries.getRecentByTrigger({
+    .query(async ({ input }) => {
+      return getApp().webhookDeliveries.getRecentByTrigger({
         projectId: input.projectId,
         triggerId: input.triggerId,
         limit: input.limit,
@@ -846,7 +845,10 @@ export const automationRouter = createTRPCRouter({
         // automation's test fire carries the kept sentinel — resolve it
         // against the stored ciphertext, exactly like the Slack bot token
         // above. Unresolvable kept values (fresh draft, renamed header) are
-        // dropped rather than sent as the literal sentinel.
+        // dropped rather than sent as the literal sentinel. Kept values are
+        // bound to the saved destination: they are only decrypted when the
+        // supplied URL matches the saved one, so a changed URL cannot
+        // exfiltrate masked credentials to an attacker endpoint.
         let webhookDestination = input.webhookDestination;
         if (
           webhookDestination &&
@@ -860,9 +862,15 @@ export const automationRouter = createTRPCRouter({
               where: { id: input.automationId, projectId: input.projectId },
               select: { actionParams: true },
             });
-            saved = decryptWebhookHeaders(
-              (row?.actionParams ?? {}) as WebhookStoredActionParams,
-            );
+            const savedParams = (row?.actionParams ??
+              {}) as WebhookStoredActionParams;
+            if (
+              typeof savedParams.url === "string" &&
+              normalizeWebhookUrl(savedParams.url) ===
+                normalizeWebhookUrl(webhookDestination.url)
+            ) {
+              saved = decryptWebhookHeaders(savedParams);
+            }
           }
           const headers: Record<string, string> = {};
           for (const [name, value] of Object.entries(

--- a/langwatch/src/server/app-layer/app.ts
+++ b/langwatch/src/server/app-layer/app.ts
@@ -27,6 +27,7 @@ export class App {
   readonly experiments: AppDependencies["experiments"];
   readonly triggers: AppDependencies["triggers"];
   readonly triggerTemplates: AppDependencies["triggerTemplates"];
+  readonly webhookDeliveries: AppDependencies["webhookDeliveries"];
   readonly emailSuppressions: AppDependencies["emailSuppressions"];
   readonly organizations: AppDependencies["organizations"];
   readonly projects: AppDependencies["projects"];
@@ -60,6 +61,7 @@ export class App {
     this.experiments = deps.experiments;
     this.triggers = deps.triggers;
     this.triggerTemplates = deps.triggerTemplates;
+    this.webhookDeliveries = deps.webhookDeliveries;
     this.emailSuppressions = deps.emailSuppressions;
     this.organizations = deps.organizations;
     this.projects = deps.projects;

--- a/langwatch/src/server/app-layer/dependencies.ts
+++ b/langwatch/src/server/app-layer/dependencies.ts
@@ -44,6 +44,7 @@ import type {
   TestFireResult,
   TestFireTriggerInput,
 } from "./triggers/trigger-template.service";
+import type { WebhookDeliveryService } from "./triggers/webhook-delivery.service";
 import type { UsageService } from "./usage/usage.service";
 
 export interface DataRetentionDependencies {
@@ -98,6 +99,10 @@ export interface AppDependencies {
   triggerTemplates: {
     testFire: (input: TestFireTriggerInput) => Promise<TestFireResult>;
   };
+  /** ADR-040 §6 per-attempt webhook delivery log — write side records an
+   *  attempt, read side backs the drawer's "Recent deliveries", prune keeps
+   *  the table bounded at 30 days (projectId-scoped). */
+  webhookDeliveries: WebhookDeliveryService;
   emailSuppressions: EmailSuppressionService;
   organizations: OrganizationService;
   projects: ProjectService;

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -1216,6 +1216,7 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
           sendSlackBot: async () => {
             /* test no-op */
           },
+          sendWebhook: async () => ({ status: 200 }),
         },
       };
       return {

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -203,6 +203,8 @@ import { PrismaTriggerRepository } from "./triggers/repositories/trigger.prisma.
 import { NullTriggerRepository } from "./triggers/repositories/trigger.repository";
 import { TriggerService } from "./triggers/trigger.service";
 import { testFireTrigger } from "./triggers/trigger-template.service";
+import { PrismaWebhookDeliveryRepository } from "./triggers/repositories/webhook-delivery.prisma.repository";
+import { WebhookDeliveryService } from "./triggers/webhook-delivery.service";
 import { UsageService } from "./usage/usage.service";
 
 /**
@@ -510,6 +512,9 @@ export function initializeDefaultApp(options?: {
     testFire: (input: Parameters<typeof testFireTrigger>[1]) =>
       testFireTrigger(triggerTemplateDeps, input),
   };
+  const webhookDeliveries = new WebhookDeliveryService(
+    new PrismaWebhookDeliveryRepository(prisma),
+  );
   const tokenizer = new TokenizerService(
     config.disableTokenization
       ? new NullTokenizerClient()
@@ -1057,6 +1062,7 @@ export function initializeDefaultApp(options?: {
     experiments,
     triggers,
     triggerTemplates,
+    webhookDeliveries,
     emailSuppressions,
     dspySteps: { steps: dspySteps },
     simulations: { runs: simulationReads },
@@ -1224,6 +1230,9 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
           testFireTrigger(testDeps, input),
       };
     })(),
+    webhookDeliveries: new WebhookDeliveryService(
+      new PrismaWebhookDeliveryRepository(testPrisma),
+    ),
     simulations: { runs: SimulationRunService.create(null) },
     suiteRuns: {
       runs: SuiteRunService.create({

--- a/langwatch/src/server/app-layer/projects/project.service.ts
+++ b/langwatch/src/server/app-layer/projects/project.service.ts
@@ -201,6 +201,12 @@ export class ProjectService {
     return this.repo.findAllByOrganization(params);
   }
 
+  /** Every project id, across all tenants — for platform-wide maintenance jobs
+   *  that must scope a project-level write by projectId. */
+  async getAllIds(): Promise<string[]> {
+    return this.repo.findAllIds();
+  }
+
   async getWithTeam(id: string): Promise<ProjectWithTeam | null> {
     return this.repo.getWithTeam(id);
   }

--- a/langwatch/src/server/app-layer/projects/repositories/project.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/projects/repositories/project.prisma.repository.ts
@@ -143,6 +143,11 @@ export class PrismaProjectRepository implements ProjectRepository {
     return this.prisma.project.findUnique({ where: { id } });
   }
 
+  async findAllIds(): Promise<string[]> {
+    const rows = await this.prisma.project.findMany({ select: { id: true } });
+    return rows.map((row) => row.id);
+  }
+
   async findAllByOrganization({
     organizationId,
     page,

--- a/langwatch/src/server/app-layer/projects/repositories/project.repository.ts
+++ b/langwatch/src/server/app-layer/projects/repositories/project.repository.ts
@@ -90,6 +90,10 @@ export interface ProjectRepository {
     page: number;
     limit: number;
   }): Promise<PaginatedResult<Project>>;
+  /** Every project id, across all tenants. For platform-wide maintenance jobs
+   *  (the webhook delivery-log prune) that must scope a project-level write by
+   *  projectId rather than issue an unscoped one. */
+  findAllIds(): Promise<string[]>;
   findBySlugInTeam(params: {
     slug: string;
     teamId: string;

--- a/langwatch/src/server/app-layer/triggers/__tests__/trigger-template.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/triggers/__tests__/trigger-template.service.unit.test.ts
@@ -37,6 +37,15 @@ function makeNotifier() {
     channel: string;
     payload: unknown;
   }> = [];
+  const sentWebhooks: Array<{
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+  }> = [];
+  // The endpoint's answer a webhook test fire surfaces to the author; tests
+  // override to exercise a non-2xx failure.
+  let webhookStatus = 200;
   const notifier: TriggerNotifier = {
     sendEmail: async (args) => {
       sentEmails.push(args);
@@ -47,8 +56,21 @@ function makeNotifier() {
     sendSlackBot: async (args) => {
       sentSlackBot.push(args);
     },
+    sendWebhook: async (args) => {
+      sentWebhooks.push(args);
+      return { status: webhookStatus };
+    },
   };
-  return { notifier, sentEmails, sentSlack, sentSlackBot };
+  return {
+    notifier,
+    sentEmails,
+    sentSlack,
+    sentSlackBot,
+    sentWebhooks,
+    setWebhookStatus: (status: number) => {
+      webhookStatus = status;
+    },
+  };
 }
 
 function makeService(notifier: TriggerNotifier) {
@@ -107,6 +129,80 @@ describe("validateTemplateDraft", () => {
 });
 
 describe("testFireTrigger", () => {
+  describe("given a webhook destination", () => {
+    it("sends the rendered JSON body and returns the endpoint's HTTP status", async () => {
+      const { notifier, sentWebhooks } = makeNotifier();
+      const service = makeService(notifier);
+
+      const result = await service.testFire({
+        channel: "webhook",
+        trigger: TRIGGER,
+        project: PROJECT,
+        draft: {},
+        recipients: [],
+        webhook: null,
+        webhookDestination: {
+          url: "https://example.com/hook",
+          method: "POST",
+          headers: { Authorization: "Bearer x" },
+          bodyTemplate: null,
+        },
+      });
+
+      expect(result.channel).toBe("webhook");
+      expect(result.httpStatus).toBe(200);
+      expect(sentWebhooks).toHaveLength(1);
+      expect(sentWebhooks[0]).toMatchObject({
+        url: "https://example.com/hook",
+        method: "POST",
+      });
+      // The default trace envelope rendered as valid JSON.
+      const body = JSON.parse(sentWebhooks[0]!.body) as { event: string };
+      expect(body.event).toBe("trigger.matched");
+    });
+
+    it("renders a custom body template against the example context", async () => {
+      const { notifier, sentWebhooks } = makeNotifier();
+      const service = makeService(notifier);
+
+      await service.testFire({
+        channel: "webhook",
+        trigger: TRIGGER,
+        project: PROJECT,
+        draft: {},
+        recipients: [],
+        webhook: null,
+        webhookDestination: {
+          url: "https://example.com/hook",
+          method: "PUT",
+          headers: {},
+          bodyTemplate: '{ "name": {{ trigger.name | json }} }',
+        },
+      });
+
+      const body = JSON.parse(sentWebhooks[0]!.body) as { name: string };
+      expect(body.name).toBe(TRIGGER.name);
+    });
+
+    describe("when no destination is supplied", () => {
+      it("throws a TestFireUnavailableError", async () => {
+        const { notifier } = makeNotifier();
+        const service = makeService(notifier);
+        await expect(
+          service.testFire({
+            channel: "webhook",
+            trigger: TRIGGER,
+            project: PROJECT,
+            draft: {},
+            recipients: [],
+            webhook: null,
+            webhookDestination: null,
+          }),
+        ).rejects.toThrow(/endpoint/i);
+      });
+    });
+  });
+
   describe("given a Slack bot destination", () => {
     it("posts via the Web API with gated blocks kept, not the webhook", async () => {
       const { notifier, sentSlack, sentSlackBot } = makeNotifier();

--- a/langwatch/src/server/app-layer/triggers/__tests__/trigger-template.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/triggers/__tests__/trigger-template.service.unit.test.ts
@@ -6,6 +6,8 @@ import {
 } from "~/shared/templating/banner";
 import { DEFAULT_ALERT_SLACK_BLOCK_KIT_TEMPLATE } from "~/shared/templating/defaults";
 import graphAlertDetailedSource from "~/automations/providers/definitions/slack/templates/graph_alert_detailed.liquid?raw";
+import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import { assertWebhookDelivered } from "~/server/triggers/sendWebhook";
 import { TemplateValidationError, TestFireUnavailableError } from "../errors";
 import {
   type DraftIdentity,
@@ -58,6 +60,12 @@ function makeNotifier() {
     },
     sendWebhook: async (args) => {
       sentWebhooks.push(args);
+      // Mirror production (`liveTriggerNotifier`): a non-2xx throws the
+      // classified DispatchError so the author sees what the endpoint said.
+      assertWebhookDelivered({
+        result: { status: webhookStatus, body: "" },
+        triggerName: args.triggerName,
+      });
       return { status: webhookStatus };
     },
   };
@@ -129,7 +137,7 @@ describe("validateTemplateDraft", () => {
 });
 
 describe("testFireTrigger", () => {
-  describe("given a webhook destination", () => {
+  describe("when a webhook destination is supplied", () => {
     it("sends the rendered JSON body and returns the endpoint's HTTP status", async () => {
       const { notifier, sentWebhooks } = makeNotifier();
       const service = makeService(notifier);
@@ -199,6 +207,59 @@ describe("testFireTrigger", () => {
             webhookDestination: null,
           }),
         ).rejects.toThrow(/endpoint/i);
+      });
+    });
+
+    describe("when the endpoint answers a non-2xx status", () => {
+      it("rejects with the classified failure after recording the attempt", async () => {
+        const { notifier, sentWebhooks, setWebhookStatus } = makeNotifier();
+        const service = makeService(notifier);
+        setWebhookStatus(500);
+
+        await expect(
+          service.testFire({
+            channel: "webhook",
+            trigger: TRIGGER,
+            project: PROJECT,
+            draft: {},
+            recipients: [],
+            webhook: null,
+            webhookDestination: {
+              url: "https://example.com/hook",
+              method: "POST",
+              headers: {},
+              bodyTemplate: null,
+            },
+          }),
+        ).rejects.toBeInstanceOf(DispatchError);
+        // The send was attempted (the classification happens on its response).
+        expect(sentWebhooks).toHaveLength(1);
+      });
+    });
+
+    describe("when the custom body template is invalid", () => {
+      it("rejects and never contacts the endpoint (fails closed)", async () => {
+        const { notifier, sentWebhooks } = makeNotifier();
+        const service = makeService(notifier);
+
+        await expect(
+          service.testFire({
+            channel: "webhook",
+            trigger: TRIGGER,
+            project: PROJECT,
+            draft: {},
+            recipients: [],
+            webhook: null,
+            webhookDestination: {
+              url: "https://example.com/hook",
+              method: "POST",
+              headers: {},
+              // Invalid JSON — must NOT fall back to the default envelope.
+              bodyTemplate: "not json {{ trigger.name }}",
+            },
+          }),
+        ).rejects.toBeInstanceOf(TemplateValidationError);
+        expect(sentWebhooks).toHaveLength(0);
       });
     });
   });

--- a/langwatch/src/server/app-layer/triggers/__tests__/webhook-delivery.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/triggers/__tests__/webhook-delivery.service.unit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  WebhookDeliveryInput,
+  WebhookDeliveryRepository,
+  WebhookDeliveryRow,
+} from "../repositories/webhook-delivery.repository";
+import { WebhookDeliveryService } from "../webhook-delivery.service";
+
+function makeRepo(overrides?: Partial<WebhookDeliveryRepository>) {
+  return {
+    create: vi.fn(async (_: WebhookDeliveryInput) => undefined),
+    findAllRecentByTriggerId: vi.fn(async () => [] as WebhookDeliveryRow[]),
+    deleteOlderThan: vi.fn(async () => 0),
+    ...overrides,
+  } satisfies WebhookDeliveryRepository;
+}
+
+describe("WebhookDeliveryService", () => {
+  describe("record", () => {
+    it("delegates the attempt to the repository", async () => {
+      const repo = makeRepo();
+      const row: WebhookDeliveryInput = {
+        projectId: "p1",
+        triggerId: "t1",
+        dispatchId: "evt_1",
+        requestMethod: "POST",
+        requestUrl: "https://example.com/hook",
+        requestHeaders: { Authorization: "***" },
+        outcome: "success",
+      };
+      await new WebhookDeliveryService(repo).record(row);
+      expect(repo.create).toHaveBeenCalledWith(row);
+    });
+  });
+
+  describe("getRecentByTrigger", () => {
+    it("threads projectId, triggerId, and limit to the repository", async () => {
+      const repo = makeRepo();
+      await new WebhookDeliveryService(repo).getRecentByTrigger({
+        projectId: "p1",
+        triggerId: "t1",
+        limit: 25,
+      });
+      expect(repo.findAllRecentByTriggerId).toHaveBeenCalledWith({
+        projectId: "p1",
+        triggerId: "t1",
+        limit: 25,
+      });
+    });
+  });
+
+  describe("pruneExpired", () => {
+    it("deletes rows older than ~30 days", async () => {
+      const repo = makeRepo({ deleteOlderThan: vi.fn(async () => 7) });
+      const deleted = await new WebhookDeliveryService(repo).pruneExpired();
+      expect(deleted).toBe(7);
+      const before = repo.deleteOlderThan.mock.calls[0]![0].before.getTime();
+      const daysAgo = (Date.now() - before) / (24 * 60 * 60 * 1000);
+      expect(daysAgo).toBeGreaterThan(29.9);
+      expect(daysAgo).toBeLessThan(30.1);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/triggers/__tests__/webhook-delivery.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/triggers/__tests__/webhook-delivery.service.unit.test.ts
@@ -16,7 +16,7 @@ function makeRepo(overrides?: Partial<WebhookDeliveryRepository>) {
 }
 
 describe("WebhookDeliveryService", () => {
-  describe("record", () => {
+  describe("when recording an attempt", () => {
     it("delegates the attempt to the repository", async () => {
       const repo = makeRepo();
       const row: WebhookDeliveryInput = {
@@ -33,7 +33,7 @@ describe("WebhookDeliveryService", () => {
     });
   });
 
-  describe("getRecentByTrigger", () => {
+  describe("when fetching recent attempts", () => {
     it("threads projectId, triggerId, and limit to the repository", async () => {
       const repo = makeRepo();
       await new WebhookDeliveryService(repo).getRecentByTrigger({
@@ -49,13 +49,21 @@ describe("WebhookDeliveryService", () => {
     });
   });
 
-  describe("pruneExpired", () => {
-    it("deletes rows older than ~30 days", async () => {
-      const repo = makeRepo({ deleteOlderThan: vi.fn(async () => 7) });
-      const deleted = await new WebhookDeliveryService(repo).pruneExpired();
+  describe("when pruning expired attempts", () => {
+    it("scopes the delete by projectId and cuts off at ~30 days", async () => {
+      // Hold the mock in a local const: the repo prop is typed as the
+      // repository function (no `.mock`), so assert on the const instead.
+      const deleteOlderThan = vi.fn(
+        async (_params: { projectIds: string[]; before: Date }) => 7,
+      );
+      const repo = makeRepo({ deleteOlderThan });
+      const deleted = await new WebhookDeliveryService(repo).pruneExpired({
+        projectIds: ["p1", "p2"],
+      });
       expect(deleted).toBe(7);
-      const before = repo.deleteOlderThan.mock.calls[0]![0].before.getTime();
-      const daysAgo = (Date.now() - before) / (24 * 60 * 60 * 1000);
+      const call = deleteOlderThan.mock.calls[0]![0];
+      expect(call.projectIds).toEqual(["p1", "p2"]);
+      const daysAgo = (Date.now() - call.before.getTime()) / (24 * 60 * 60 * 1000);
       expect(daysAgo).toBeGreaterThan(29.9);
       expect(daysAgo).toBeLessThan(30.1);
     });

--- a/langwatch/src/server/app-layer/triggers/errors.ts
+++ b/langwatch/src/server/app-layer/triggers/errors.ts
@@ -34,7 +34,7 @@ export class TemplateValidationError extends DomainError {
 
 export class TestFireUnavailableError extends DomainError {
   constructor(
-    public readonly channel: "email" | "slack",
+    public readonly channel: "email" | "slack" | "webhook",
     /** Why the test fire can't be sent (no recipients, no webhook, …). */
     reason: string,
   ) {

--- a/langwatch/src/server/app-layer/triggers/repositories/__tests__/webhook-delivery.prisma.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/triggers/repositories/__tests__/webhook-delivery.prisma.repository.integration.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration test for the ADR-040 §6 delivery log against REAL Postgres:
+ * proves the `WebhookDelivery.triggerId` foreign key CASCADES — deleting the
+ * owning Trigger removes its delivery rows — by EXECUTING the delete and
+ * observing the rows disappear, not by asserting on the migration string.
+ * (Regression guard for the review's "missing ON DELETE CASCADE" concern.)
+ */
+import { TriggerAction } from "@prisma/client";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import { getTestProject } from "~/utils/testUtils";
+import { PrismaWebhookDeliveryRepository } from "../webhook-delivery.prisma.repository";
+import type { WebhookDeliveryInput } from "../webhook-delivery.repository";
+
+const repo = new PrismaWebhookDeliveryRepository(prisma);
+const TRIGGER_NAME = "webhook-delivery-cascade-integration";
+
+let projectId: string;
+
+async function createWebhookTrigger(): Promise<string> {
+  const trigger = await prisma.trigger.create({
+    data: {
+      name: TRIGGER_NAME,
+      projectId,
+      action: TriggerAction.SEND_WEBHOOK,
+      actionParams: { url: "https://example.com/hook" },
+      filters: JSON.stringify({}),
+    },
+  });
+  return trigger.id;
+}
+
+function delivery(triggerId: string): WebhookDeliveryInput {
+  return {
+    projectId,
+    triggerId,
+    dispatchId: "evt_cascade",
+    requestMethod: "POST",
+    requestUrl: "https://example.com/hook",
+    requestHeaders: { Authorization: "***" },
+    outcome: "success",
+  };
+}
+
+beforeAll(async () => {
+  const project = await getTestProject("webhook-delivery-cascade");
+  projectId = project.id;
+});
+
+afterEach(async () => {
+  await prisma.webhookDelivery.deleteMany({ where: { projectId } });
+  await prisma.trigger.deleteMany({ where: { projectId, name: TRIGGER_NAME } });
+});
+
+describe("PrismaWebhookDeliveryRepository (real Postgres)", () => {
+  describe("when the owning trigger is deleted after a delivery was recorded", () => {
+    it("cascades the delete to its delivery rows", async () => {
+      const triggerId = await createWebhookTrigger();
+      await repo.create(delivery(triggerId));
+
+      const before = await repo.findAllRecentByTriggerId({
+        projectId,
+        triggerId,
+        limit: 10,
+      });
+      expect(before).toHaveLength(1);
+
+      await prisma.trigger.delete({ where: { id: triggerId } });
+
+      const orphaned = await prisma.webhookDelivery.count({
+        where: { projectId, triggerId },
+      });
+      expect(orphaned).toBe(0);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/triggers/repositories/webhook-delivery.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/triggers/repositories/webhook-delivery.prisma.repository.ts
@@ -58,9 +58,15 @@ export class PrismaWebhookDeliveryRepository
     }));
   }
 
-  async deleteOlderThan({ before }: { before: Date }): Promise<number> {
+  async deleteOlderThan({
+    projectIds,
+    before,
+  }: {
+    projectIds: string[];
+    before: Date;
+  }): Promise<number> {
     const { count } = await this.prisma.webhookDelivery.deleteMany({
-      where: { firedAt: { lt: before } },
+      where: { projectId: { in: projectIds }, firedAt: { lt: before } },
     });
     return count;
   }

--- a/langwatch/src/server/app-layer/triggers/repositories/webhook-delivery.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/triggers/repositories/webhook-delivery.prisma.repository.ts
@@ -1,0 +1,67 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import type {
+  WebhookDeliveryInput,
+  WebhookDeliveryRepository,
+  WebhookDeliveryRow,
+} from "./webhook-delivery.repository";
+
+export class PrismaWebhookDeliveryRepository
+  implements WebhookDeliveryRepository
+{
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(input: WebhookDeliveryInput): Promise<void> {
+    await this.prisma.webhookDelivery.create({
+      data: {
+        projectId: input.projectId,
+        triggerId: input.triggerId,
+        dispatchId: input.dispatchId,
+        requestMethod: input.requestMethod,
+        requestUrl: input.requestUrl,
+        requestHeaders: input.requestHeaders as Prisma.InputJsonValue,
+        responseStatus: input.responseStatus ?? null,
+        responseBody: input.responseBody ?? null,
+        latencyMs: input.latencyMs ?? null,
+        error: input.error ?? null,
+        outcome: input.outcome,
+      },
+    });
+  }
+
+  async findAllRecentByTriggerId({
+    projectId,
+    triggerId,
+    limit,
+  }: {
+    projectId: string;
+    triggerId: string;
+    limit: number;
+  }): Promise<WebhookDeliveryRow[]> {
+    const rows = await this.prisma.webhookDelivery.findMany({
+      where: { projectId, triggerId },
+      orderBy: { firedAt: "desc" },
+      take: limit,
+    });
+    return rows.map((row) => ({
+      id: row.id,
+      triggerId: row.triggerId,
+      dispatchId: row.dispatchId,
+      requestMethod: row.requestMethod,
+      requestUrl: row.requestUrl,
+      requestHeaders: (row.requestHeaders ?? {}) as Record<string, string>,
+      responseStatus: row.responseStatus,
+      responseBody: row.responseBody,
+      latencyMs: row.latencyMs,
+      error: row.error,
+      outcome: row.outcome,
+      firedAt: row.firedAt,
+    }));
+  }
+
+  async deleteOlderThan({ before }: { before: Date }): Promise<number> {
+    const { count } = await this.prisma.webhookDelivery.deleteMany({
+      where: { firedAt: { lt: before } },
+    });
+    return count;
+  }
+}

--- a/langwatch/src/server/app-layer/triggers/repositories/webhook-delivery.repository.ts
+++ b/langwatch/src/server/app-layer/triggers/repositories/webhook-delivery.repository.ts
@@ -1,0 +1,57 @@
+import type { WebhookDeliveryOutcome } from "@prisma/client";
+
+/**
+ * Read + write repository over `WebhookDelivery` — the per-attempt delivery
+ * log behind a webhook automation's "recent fires" drill-down (ADR-040 §6).
+ * Header values are already REDACTED by the writer; this layer stores and
+ * returns them as-is.
+ */
+
+/** One persisted delivery attempt, as shown in the drawer's attempts list. */
+export interface WebhookDeliveryRow {
+  id: string;
+  triggerId: string;
+  /** Groups every attempt of one logical fire (== X-LangWatch-Event-Id). */
+  dispatchId: string;
+  requestMethod: string;
+  requestUrl: string;
+  /** Redacted header record (auth/signature values already masked). */
+  requestHeaders: Record<string, string>;
+  responseStatus: number | null;
+  responseBody: string | null;
+  latencyMs: number | null;
+  error: string | null;
+  outcome: WebhookDeliveryOutcome;
+  firedAt: Date;
+}
+
+/** The fields a writer supplies for one attempt (ids + timestamps are set by
+ *  the store). */
+export interface WebhookDeliveryInput {
+  projectId: string;
+  triggerId: string;
+  dispatchId: string;
+  requestMethod: string;
+  requestUrl: string;
+  requestHeaders: Record<string, string>;
+  responseStatus?: number | null;
+  responseBody?: string | null;
+  latencyMs?: number | null;
+  error?: string | null;
+  outcome: WebhookDeliveryOutcome;
+}
+
+export interface WebhookDeliveryRepository {
+  create(input: WebhookDeliveryInput): Promise<void>;
+
+  /** Latest attempts for one trigger, newest first, capped at `limit`. */
+  findAllRecentByTriggerId(params: {
+    projectId: string;
+    triggerId: string;
+    limit: number;
+  }): Promise<WebhookDeliveryRow[]>;
+
+  /** Delete rows older than `before`; returns how many were removed (the
+   *  30-day prune, ADR-040 §6). */
+  deleteOlderThan(params: { before: Date }): Promise<number>;
+}

--- a/langwatch/src/server/app-layer/triggers/repositories/webhook-delivery.repository.ts
+++ b/langwatch/src/server/app-layer/triggers/repositories/webhook-delivery.repository.ts
@@ -51,7 +51,12 @@ export interface WebhookDeliveryRepository {
     limit: number;
   }): Promise<WebhookDeliveryRow[]>;
 
-  /** Delete rows older than `before`; returns how many were removed (the
-   *  30-day prune, ADR-040 §6). */
-  deleteOlderThan(params: { before: Date }): Promise<number>;
+  /** Delete rows older than `before` within the given projects; returns how
+   *  many were removed (the projectId-scoped 30-day prune, ADR-040 §6).
+   *  `projectId` is the first predicate — no unscoped deletion on a
+   *  project-level model. */
+  deleteOlderThan(params: {
+    projectIds: string[];
+    before: Date;
+  }): Promise<number>;
 }

--- a/langwatch/src/server/app-layer/triggers/trigger-template.service.ts
+++ b/langwatch/src/server/app-layer/triggers/trigger-template.service.ts
@@ -6,6 +6,7 @@ import {
 } from "~/server/mailer/triggerNoReply";
 import { EXAMPLE_MATCHES } from "~/shared/templating/exampleContext";
 import { renderTriggerEmail } from "~/shared/templating/renderEmail";
+import { renderWebhookBody } from "~/shared/templating/renderWebhookBody";
 import {
   renderTriggerSlack,
   type SlackPayload,
@@ -27,7 +28,7 @@ import {
 import { validateLiquid } from "~/shared/templating/validate";
 import { TemplateValidationError, TestFireUnavailableError } from "./errors";
 
-export type TemplateChannel = "email" | "slack";
+export type TemplateChannel = "email" | "slack" | "webhook";
 
 export const SLACK_TEMPLATE_TYPES = ["string", "block_kit"] as const;
 
@@ -50,6 +51,16 @@ export interface TriggerNotifier {
     channel: string;
     payload: SlackPayload;
   }): Promise<void>;
+  /** ADR-040 generic HTTP delivery — the SSRF-fenced webhook sender, with
+   *  the test-fire header injected. Returns the real HTTP status so the
+   *  author sees what their endpoint answered. */
+  sendWebhook(args: {
+    url: string;
+    method: "POST" | "PUT" | "PATCH";
+    headers: Record<string, string>;
+    body: string;
+    triggerName: string;
+  }): Promise<{ status: number }>;
 }
 
 /** The four template columns, as edited in the drawer. Each may be null
@@ -79,6 +90,8 @@ export interface TestFireResult {
   usedDefault: boolean;
   missingVariables: string[];
   errors: string[];
+  /** Webhook only: the HTTP status the customer's endpoint answered with. */
+  httpStatus?: number;
 }
 
 const LIQUID_TEMPLATE_COLUMNS = [
@@ -200,6 +213,15 @@ export interface TestFireTriggerInput {
   /** Present when the Slack automation delivers via a bot connection: the
    *  resolved token + channel. Test-fires via the Web API with gated blocks. */
   botDestination?: { token: string; channel: string } | null;
+  /** Present for the webhook channel (ADR-040): the full request shape,
+   *  body template included — it lives in `actionParams`, not the four
+   *  Trigger template columns, so it rides its own field here. */
+  webhookDestination?: {
+    url: string;
+    method: "POST" | "PUT" | "PATCH";
+    headers: Record<string, string>;
+    bodyTemplate: string | null;
+  } | null;
   /** Present when the draft is a custom-graph alert. */
   graphAlert?: TestFireGraphAlertInput | null;
   /** Present when the draft is a scheduled report. */
@@ -325,6 +347,39 @@ export async function testFireTrigger(
       usedDefault: rendered.usedDefault,
       missingVariables: rendered.missingVariables,
       errors: rendered.errors,
+    };
+  }
+
+  if (channel === "webhook") {
+    if (!input.webhookDestination) {
+      throw new TestFireUnavailableError(
+        "webhook",
+        "This automation has no endpoint URL to test-fire to.",
+      );
+    }
+    const { url, method, headers, bodyTemplate } = input.webhookDestination;
+    const rendered = await renderWebhookBody({
+      template: bodyTemplate,
+      context,
+      defaultBody: defaults.webhookBody,
+    });
+    // Actually sends through the full SSRF-fenced sender so the author sees a
+    // real status code (ADR-040 §1); a non-2xx throws the classified
+    // DispatchError, which the route lifts into a clean domain error.
+    const { status } = await deps.notifier.sendWebhook({
+      url,
+      method,
+      headers,
+      body: rendered.body,
+      triggerName: trigger.name,
+    });
+    return {
+      channel: "webhook",
+      recipientCount: 1,
+      usedDefault: rendered.usedDefault,
+      missingVariables: rendered.missingVariables,
+      errors: rendered.errors,
+      httpStatus: status,
     };
   }
 

--- a/langwatch/src/server/app-layer/triggers/trigger-template.service.ts
+++ b/langwatch/src/server/app-layer/triggers/trigger-template.service.ts
@@ -363,6 +363,15 @@ export async function testFireTrigger(
       context,
       defaultBody: defaults.webhookBody,
     });
+    // Fail closed: a broken custom body template must NOT test-fire the
+    // framework default in its place (that would leak the full-trace envelope
+    // the author left out). Surface the render error and send nothing.
+    if (rendered.failed) {
+      throw new TemplateValidationError(
+        "bodyTemplate",
+        rendered.errors[0] ?? "The webhook body template failed to render.",
+      );
+    }
     // Actually sends through the full SSRF-fenced sender so the author sees a
     // real status code (ADR-040 §1); a non-2xx throws the classified
     // DispatchError, which the route lifts into a clean domain error.

--- a/langwatch/src/server/app-layer/triggers/webhook-delivery.service.ts
+++ b/langwatch/src/server/app-layer/triggers/webhook-delivery.service.ts
@@ -1,5 +1,3 @@
-import type { PrismaClient } from "@prisma/client";
-import { PrismaWebhookDeliveryRepository } from "./repositories/webhook-delivery.prisma.repository";
 import type {
   WebhookDeliveryInput,
   WebhookDeliveryRepository,
@@ -14,16 +12,11 @@ const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
  * The per-attempt webhook delivery log (ADR-040 §6). Write-side records one
  * row per HTTP attempt (headers already redacted by the caller); read-side
  * backs the drawer's "Recent deliveries" drill-down; the prune keeps the
- * table bounded at 30 days.
+ * table bounded at 30 days. The repository is injected at the composition root
+ * (`getApp().webhookDeliveries`) — no concrete Prisma coupling here.
  */
 export class WebhookDeliveryService {
   constructor(private readonly repo: WebhookDeliveryRepository) {}
-
-  static create(prisma: PrismaClient): WebhookDeliveryService {
-    return new WebhookDeliveryService(
-      new PrismaWebhookDeliveryRepository(prisma),
-    );
-  }
 
   /** Persist one attempt. */
   async record(input: WebhookDeliveryInput): Promise<void> {
@@ -43,9 +36,12 @@ export class WebhookDeliveryService {
     return this.repo.findAllRecentByTriggerId({ projectId, triggerId, limit });
   }
 
-  /** Delete attempts older than 30 days; returns how many were removed. */
-  async pruneExpired(): Promise<number> {
+  /** Delete attempts older than 30 days within the given projects; returns how
+   *  many were removed. The prune is scoped by projectId (the cron enumerates
+   *  every project), never an unscoped table-wide delete. */
+  async pruneExpired({ projectIds }: { projectIds: string[] }): Promise<number> {
     return this.repo.deleteOlderThan({
+      projectIds,
       before: new Date(Date.now() - THIRTY_DAYS_MS),
     });
   }

--- a/langwatch/src/server/app-layer/triggers/webhook-delivery.service.ts
+++ b/langwatch/src/server/app-layer/triggers/webhook-delivery.service.ts
@@ -1,0 +1,52 @@
+import type { PrismaClient } from "@prisma/client";
+import { PrismaWebhookDeliveryRepository } from "./repositories/webhook-delivery.prisma.repository";
+import type {
+  WebhookDeliveryInput,
+  WebhookDeliveryRepository,
+  WebhookDeliveryRow,
+} from "./repositories/webhook-delivery.repository";
+
+export type { WebhookDeliveryInput, WebhookDeliveryRow };
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * The per-attempt webhook delivery log (ADR-040 §6). Write-side records one
+ * row per HTTP attempt (headers already redacted by the caller); read-side
+ * backs the drawer's "Recent deliveries" drill-down; the prune keeps the
+ * table bounded at 30 days.
+ */
+export class WebhookDeliveryService {
+  constructor(private readonly repo: WebhookDeliveryRepository) {}
+
+  static create(prisma: PrismaClient): WebhookDeliveryService {
+    return new WebhookDeliveryService(
+      new PrismaWebhookDeliveryRepository(prisma),
+    );
+  }
+
+  /** Persist one attempt. */
+  async record(input: WebhookDeliveryInput): Promise<void> {
+    return this.repo.create(input);
+  }
+
+  /** Latest attempts for one trigger, newest first, capped at `limit`. */
+  async getRecentByTrigger({
+    projectId,
+    triggerId,
+    limit,
+  }: {
+    projectId: string;
+    triggerId: string;
+    limit: number;
+  }): Promise<WebhookDeliveryRow[]> {
+    return this.repo.findAllRecentByTriggerId({ projectId, triggerId, limit });
+  }
+
+  /** Delete attempts older than 30 days; returns how many were removed. */
+  async pruneExpired(): Promise<number> {
+    return this.repo.deleteOlderThan({
+      before: new Date(Date.now() - THIRTY_DAYS_MS),
+    });
+  }
+}

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
@@ -4,6 +4,7 @@ import {
   extractHttpStatus,
   isDispatchError,
   isRetryableHttpStatus,
+  parseRetryAfterMs,
   toDispatchError,
 } from "../dispatchError";
 
@@ -133,6 +134,44 @@ describe("toDispatchError", () => {
       const err = toDispatchError(cause, { message: "send failed" });
       expect(err.retryable).toBe(true);
       expect(err.cause).toBe(cause);
+    });
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  const NOW = Date.parse("2026-07-15T12:00:00.000Z");
+
+  describe("when the header is delta-seconds", () => {
+    it("returns the value in milliseconds", () => {
+      expect(parseRetryAfterMs("120", NOW)).toBe(120_000);
+      expect(parseRetryAfterMs("0", NOW)).toBe(0);
+    });
+  });
+
+  describe("when the header is an HTTP date", () => {
+    it("returns the delta from now for a future date", () => {
+      expect(
+        parseRetryAfterMs("Wed, 15 Jul 2026 12:01:00 GMT", NOW),
+      ).toBe(60_000);
+    });
+    it("returns undefined for a past date", () => {
+      expect(
+        parseRetryAfterMs("Wed, 15 Jul 2026 11:59:00 GMT", NOW),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("when the header is missing or unparseable", () => {
+    it("returns undefined", () => {
+      expect(parseRetryAfterMs(null, NOW)).toBeUndefined();
+      expect(parseRetryAfterMs(undefined, NOW)).toBeUndefined();
+      expect(parseRetryAfterMs("soon", NOW)).toBeUndefined();
+    });
+  });
+
+  describe("when the value is absurdly large", () => {
+    it("caps it at one hour", () => {
+      expect(parseRetryAfterMs("999999", NOW)).toBe(60 * 60 * 1000);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/outbox/dispatchError.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatchError.ts
@@ -17,21 +17,57 @@
 export class DispatchError extends Error {
   readonly retryable: boolean;
   readonly cause?: unknown;
+  /**
+   * Optional minimum backoff before the next attempt, in ms — set from a
+   * receiver's `Retry-After` (ADR-040 §5, ADR-027 extension). The retry
+   * scheduler treats it as a FLOOR over its own exponential backoff, so it
+   * can lengthen but never shorten the wait. Only meaningful when
+   * `retryable` is true.
+   */
+  readonly retryAfterMs?: number;
 
   constructor({
     message,
     retryable,
     cause,
+    retryAfterMs,
   }: {
     message: string;
     retryable: boolean;
     cause?: unknown;
+    retryAfterMs?: number;
   }) {
     super(message);
     this.name = "DispatchError";
     this.retryable = retryable;
     this.cause = cause;
+    this.retryAfterMs = retryAfterMs;
   }
+}
+
+/**
+ * Parse an HTTP `Retry-After` header into milliseconds. Supports both the
+ * delta-seconds form (`Retry-After: 120`) and the HTTP-date form
+ * (`Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`). Returns undefined for a
+ * missing/unparseable value or a date already in the past. Capped so a
+ * hostile receiver can't pin a job for hours.
+ */
+const MAX_RETRY_AFTER_MS = 60 * 60 * 1000; // 1h
+export function parseRetryAfterMs(
+  headerValue: string | null | undefined,
+  now: number = Date.now(),
+): number | undefined {
+  if (!headerValue) return undefined;
+  const trimmed = headerValue.trim();
+  if (/^\d+$/.test(trimmed)) {
+    const ms = parseInt(trimmed, 10) * 1000;
+    return Math.min(ms, MAX_RETRY_AFTER_MS);
+  }
+  const date = Date.parse(trimmed);
+  if (Number.isNaN(date)) return undefined;
+  const delta = date - now;
+  if (delta <= 0) return undefined;
+  return Math.min(delta, MAX_RETRY_AFTER_MS);
 }
 
 export function isDispatchError(error: unknown): error is DispatchError {

--- a/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
@@ -858,12 +858,28 @@ async function handleCadenceBatch(
             "Webhook body template render errors — fell back to default body",
           );
         }
+        // Stable per-dispatch id over the batch's traceIds: identical across
+        // outbox retries of THIS dispatch, distinct from other dispatches —
+        // sent as X-LangWatch-Event-Id so the receiver dedupes (ADR-040 §5).
+        const webhookEventId =
+          "evt_" +
+          createHash("sha256")
+            .update(
+              `${projectId}:${triggerId}:${triggerData
+                .map((d) => d.traceId)
+                .sort()
+                .join(",")}`,
+            )
+            .digest("hex")
+            .slice(0, 32);
         const result = await sendWebhook({
           url: params.url,
           method: params.method,
           headers: decryptWebhookHeaders(params),
           body: rendered.body,
           triggerName: trigger.name,
+          projectId,
+          eventId: webhookEventId,
         });
         // 5xx/429/408 throw retryable so the outbox backs off and retries;
         // other non-2xx are terminal (ADR-040 §5).

--- a/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
@@ -31,9 +31,9 @@ import {
 } from "~/server/triggers/sendSlackWebhook";
 import { postSlackChatMessage } from "~/server/triggers/slackWebApi";
 import {
-  assertWebhookDelivered,
-  sendWebhook,
-} from "~/server/triggers/sendWebhook";
+  deliverWebhook,
+  type WebhookDeliveryRecorder,
+} from "~/server/triggers/deliverWebhook";
 import { decryptWebhookHeaders } from "~/automations/providers/definitions/webhook/secret";
 import type { WebhookMethod } from "~/automations/providers/definitions/webhook/shared";
 import { renderTriggerEmail } from "~/shared/templating/renderEmail";
@@ -119,6 +119,10 @@ export interface OutboxDispatcherDeps {
     projectId: string;
     datasetRecords: DatasetRecordEntry[];
   }) => Promise<void>;
+  /** ADR-040 §6 delivery-log writer — records one row per webhook attempt.
+   *  Optional: when absent (tests) deliveries aren't logged, dispatch is
+   *  unchanged. */
+  recordWebhookDelivery?: WebhookDeliveryRecorder;
   /**
    * Late-bound — settle stage's match-confirmed branch calls this to
    * re-enqueue as `cadence`. The queue ref is filled in by `buildOutboxRuntime`
@@ -872,18 +876,20 @@ async function handleCadenceBatch(
             )
             .digest("hex")
             .slice(0, 32);
-        const result = await sendWebhook({
+        // Send + classify + log one attempt (ADR-040 §5/§6). A retryable
+        // status throws so the outbox backs off and retries; the delivery-log
+        // row is written either way.
+        await deliverWebhook({
+          recorder: deps.recordWebhookDelivery,
+          projectId,
+          triggerId,
+          eventId: webhookEventId,
           url: params.url,
           method: params.method,
           headers: decryptWebhookHeaders(params),
           body: rendered.body,
           triggerName: trigger.name,
-          projectId,
-          eventId: webhookEventId,
         });
-        // 5xx/429/408 throw retryable so the outbox backs off and retries;
-        // other non-2xx are terminal (ADR-040 §5).
-        assertWebhookDelivered({ result, triggerName: trigger.name });
         didSend = true;
         break;
       }

--- a/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
@@ -34,6 +34,7 @@ import {
   assertWebhookDelivered,
   sendWebhook,
 } from "~/server/triggers/sendWebhook";
+import { decryptWebhookHeaders } from "~/automations/providers/definitions/webhook/secret";
 import type { WebhookMethod } from "~/automations/providers/definitions/webhook/shared";
 import { renderTriggerEmail } from "~/shared/templating/renderEmail";
 import { renderWebhookBody } from "~/shared/templating/renderWebhookBody";
@@ -73,9 +74,12 @@ interface ActionParams {
   slackBotToken?: string;
   slackChannelId?: string;
   /** ADR-040 SEND_WEBHOOK destination — the whole config, body included,
-   *  lives in actionParams (not the Trigger template columns). */
+   *  lives in actionParams (not the Trigger template columns). Header values
+   *  are secrets, stored as one ciphertext blob (ADR-040 §3) and decrypted
+   *  just before dispatch. */
   url?: string;
   method?: WebhookMethod;
+  headersEncrypted?: string;
   headers?: Record<string, string>;
   bodyTemplate?: string | null;
 }
@@ -857,7 +861,7 @@ async function handleCadenceBatch(
         const result = await sendWebhook({
           url: params.url,
           method: params.method,
-          headers: params.headers,
+          headers: decryptWebhookHeaders(params),
           body: rendered.body,
           triggerName: trigger.name,
         });

--- a/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
@@ -30,7 +30,13 @@ import {
   sendSlackWebhook,
 } from "~/server/triggers/sendSlackWebhook";
 import { postSlackChatMessage } from "~/server/triggers/slackWebApi";
+import {
+  assertWebhookDelivered,
+  sendWebhook,
+} from "~/server/triggers/sendWebhook";
+import type { WebhookMethod } from "~/automations/providers/definitions/webhook/shared";
 import { renderTriggerEmail } from "~/shared/templating/renderEmail";
+import { renderWebhookBody } from "~/shared/templating/renderWebhookBody";
 import { renderTriggerSlack } from "~/shared/templating/renderSlack";
 import {
   buildTemplateContext,
@@ -66,6 +72,12 @@ interface ActionParams {
   /** Encrypted bot token (ciphertext) — decrypted just before dispatch. */
   slackBotToken?: string;
   slackChannelId?: string;
+  /** ADR-040 SEND_WEBHOOK destination — the whole config, body included,
+   *  lives in actionParams (not the Trigger template columns). */
+  url?: string;
+  method?: WebhookMethod;
+  headers?: Record<string, string>;
+  bodyTemplate?: string | null;
 }
 
 export interface OutboxDispatcherDeps {
@@ -818,6 +830,40 @@ async function handleCadenceBatch(
           triggerType: trigger.alertType,
           triggerMessage: trigger.message ?? "",
         });
+        didSend = true;
+        break;
+      }
+      case TriggerAction.SEND_WEBHOOK: {
+        if (!params.url) {
+          throw new DispatchError({
+            message: `Webhook trigger "${trigger.name}" has no URL configured`,
+            retryable: false,
+          });
+        }
+        // The body renders like Slack Block Kit: Liquid → JSON.parse, falling
+        // back to the framework default envelope on any template failure
+        // (ADR-040 §2). Trace-path dispatch renders against the trace default.
+        const rendered = await renderWebhookBody({
+          template: params.bodyTemplate ?? null,
+          context: buildContext(),
+        });
+        for (const v of rendered.missingVariables) missingVariables.add(v);
+        if (rendered.errors.length > 0) {
+          logger.warn(
+            { projectId, triggerId, errors: rendered.errors },
+            "Webhook body template render errors — fell back to default body",
+          );
+        }
+        const result = await sendWebhook({
+          url: params.url,
+          method: params.method,
+          headers: params.headers,
+          body: rendered.body,
+          triggerName: trigger.name,
+        });
+        // 5xx/429/408 throw retryable so the outbox backs off and retries;
+        // other non-2xx are terminal (ADR-040 §5).
+        assertWebhookDelivered({ result, triggerName: trigger.name });
         didSend = true;
         break;
       }

--- a/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
@@ -848,19 +848,21 @@ async function handleCadenceBatch(
             retryable: false,
           });
         }
-        // The body renders like Slack Block Kit: Liquid → JSON.parse, falling
-        // back to the framework default envelope on any template failure
-        // (ADR-040 §2). Trace-path dispatch renders against the trace default.
+        // The body renders like Slack Block Kit: Liquid → JSON.parse. It fails
+        // CLOSED (ADR-040 §2): a broken custom template dead-letters this
+        // dispatch rather than delivering the framework default in its place,
+        // which would leak the full-trace envelope the customer left out.
+        // Trace-path dispatch renders against the trace default.
         const rendered = await renderWebhookBody({
           template: params.bodyTemplate ?? null,
           context: buildContext(),
         });
         for (const v of rendered.missingVariables) missingVariables.add(v);
-        if (rendered.errors.length > 0) {
-          logger.warn(
-            { projectId, triggerId, errors: rendered.errors },
-            "Webhook body template render errors — fell back to default body",
-          );
+        if (rendered.failed) {
+          throw new DispatchError({
+            message: `Webhook body template for trigger "${trigger.name}" failed to render: ${rendered.errors[0] ?? "invalid template"}`,
+            retryable: false,
+          });
         }
         // Stable per-dispatch id over the batch's traceIds: identical across
         // outbox retries of THIS dispatch, distinct from other dispatches —

--- a/langwatch/src/server/event-sourcing/outbox/setup.ts
+++ b/langwatch/src/server/event-sourcing/outbox/setup.ts
@@ -23,6 +23,7 @@ import { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import { TraceService } from "~/server/traces/trace.service";
 import { sendRenderedSlackMessage } from "~/server/triggers/sendSlackWebhook";
 import { sendWebhook } from "~/server/triggers/sendWebhook";
+import { WebhookDeliveryService } from "~/server/app-layer/triggers/webhook-delivery.service";
 import { postSlackChatMessage } from "~/server/triggers/slackWebApi";
 import { TraceSummaryStore } from "../pipelines/trace-processing/projections/traceSummary.store";
 import type { FoldProjectionStore } from "../projections/foldProjection.types";
@@ -188,6 +189,11 @@ export function buildOutboxRuntime({
   // unchanged. The TriggerSent repo mirrors the cron's dedup pattern
   // exactly.
   const graphTriggerSentRepo = new PrismaGraphTriggerSentRepository(prisma);
+  // ADR-040 §6: one delivery-log writer shared by the trace-cadence outbox
+  // dispatcher and the event-sourced graph-alert path.
+  const webhookDeliveries = WebhookDeliveryService.create(prisma);
+  const recordWebhookDelivery = (input: Parameters<typeof webhookDeliveries.record>[0]) =>
+    webhookDeliveries.record(input);
   const graphTriggerEvalDeps: GraphTriggerEvaluationDeps = {
     loadTrigger: async ({ triggerId, projectId }) =>
       prisma.trigger.findUnique({ where: { id: triggerId, projectId } }),
@@ -210,6 +216,7 @@ export function buildOutboxRuntime({
             sendSlack: sendRenderedSlackMessage,
             sendSlackBot: postSlackChatMessage,
             sendWebhook,
+            recordWebhookDelivery,
             // ADR-031: honour the same email suppression list the cron path
             // does, so one-click unsubscribes are respected on the
             // event-sourced graph-alert path too.
@@ -328,6 +335,7 @@ export function buildOutboxRuntime({
     addToDataset: async (params) => {
       await createManyDatasetRecords(params);
     },
+    recordWebhookDelivery,
     enqueueCadence: async (
       payload: CadenceStagePayload,
       { delayMs }: { delayMs: number },

--- a/langwatch/src/server/event-sourcing/outbox/setup.ts
+++ b/langwatch/src/server/event-sourcing/outbox/setup.ts
@@ -22,6 +22,7 @@ import { dispatchGraphAlertAction } from "~/server/event-sourcing/pipelines/shar
 import { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import { TraceService } from "~/server/traces/trace.service";
 import { sendRenderedSlackMessage } from "~/server/triggers/sendSlackWebhook";
+import { sendWebhook } from "~/server/triggers/sendWebhook";
 import { postSlackChatMessage } from "~/server/triggers/slackWebApi";
 import { TraceSummaryStore } from "../pipelines/trace-processing/projections/traceSummary.store";
 import type { FoldProjectionStore } from "../projections/foldProjection.types";
@@ -208,6 +209,7 @@ export function buildOutboxRuntime({
             sendEmail: sendRenderedTriggerEmail,
             sendSlack: sendRenderedSlackMessage,
             sendSlackBot: postSlackChatMessage,
+            sendWebhook,
             // ADR-031: honour the same email suppression list the cron path
             // does, so one-click unsubscribes are respected on the
             // event-sourced graph-alert path too.

--- a/langwatch/src/server/event-sourcing/outbox/setup.ts
+++ b/langwatch/src/server/event-sourcing/outbox/setup.ts
@@ -4,6 +4,7 @@ import { env } from "~/env.mjs";
 import { createOrUpdateQueueItems } from "~/server/api/routers/annotation";
 import { createManyDatasetRecords } from "~/server/api/routers/datasetRecord.utils";
 import { getProtectionsForProject } from "~/server/api/utils";
+import { getApp } from "~/server/app-layer/app";
 import { getAnalyticsService } from "~/server/app-layer/analytics";
 import type { EvaluationRunService } from "~/server/app-layer/evaluations/evaluation-run.service";
 import type { ProjectService } from "~/server/app-layer/projects/project.service";
@@ -23,7 +24,7 @@ import { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import { TraceService } from "~/server/traces/trace.service";
 import { sendRenderedSlackMessage } from "~/server/triggers/sendSlackWebhook";
 import { sendWebhook } from "~/server/triggers/sendWebhook";
-import { WebhookDeliveryService } from "~/server/app-layer/triggers/webhook-delivery.service";
+import type { WebhookDeliveryInput } from "~/server/app-layer/triggers/webhook-delivery.service";
 import { postSlackChatMessage } from "~/server/triggers/slackWebApi";
 import { TraceSummaryStore } from "../pipelines/trace-processing/projections/traceSummary.store";
 import type { FoldProjectionStore } from "../projections/foldProjection.types";
@@ -190,10 +191,10 @@ export function buildOutboxRuntime({
   // exactly.
   const graphTriggerSentRepo = new PrismaGraphTriggerSentRepository(prisma);
   // ADR-040 §6: one delivery-log writer shared by the trace-cadence outbox
-  // dispatcher and the event-sourced graph-alert path.
-  const webhookDeliveries = WebhookDeliveryService.create(prisma);
-  const recordWebhookDelivery = (input: Parameters<typeof webhookDeliveries.record>[0]) =>
-    webhookDeliveries.record(input);
+  // dispatcher and the event-sourced graph-alert path — resolved from the app
+  // container at dispatch time (getApp() is initialized by then).
+  const recordWebhookDelivery = (input: WebhookDeliveryInput) =>
+    getApp().webhookDeliveries.record(input);
   const graphTriggerEvalDeps: GraphTriggerEvaluationDeps = {
     loadTrigger: async ({ triggerId, projectId }) =>
       prisma.trigger.findUnique({ where: { id: triggerId, projectId } }),

--- a/langwatch/src/server/event-sourcing/pipelines/shared/__tests__/graphAlertActionDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/__tests__/graphAlertActionDispatch.unit.test.ts
@@ -74,6 +74,12 @@ function makeDeps() {
   const sendSlackBot = vi.fn<(payload: unknown) => Promise<void>>(
     async () => undefined,
   );
+  // Returns a 2xx by default — individual tests override to exercise the
+  // retry/terminal classification the dispatcher applies via
+  // assertWebhookDelivered.
+  const sendWebhook = vi.fn(
+    async (_payload: unknown) => ({ status: 200, body: "ok" }),
+  );
   // Pass-through suppression by default — individual tests override to
   // exercise the ADR-031 unsubscribe gate.
   const filterSuppressedRecipients = vi.fn(
@@ -104,6 +110,7 @@ function makeDeps() {
       sendEmail,
       sendSlack,
       sendSlackBot,
+      sendWebhook,
       filterSuppressedRecipients,
       consumeEmailCapSlot,
       emailHourlyCap: 100,
@@ -115,6 +122,7 @@ function makeDeps() {
     sendEmail,
     sendSlack,
     sendSlackBot,
+    sendWebhook,
     filterSuppressedRecipients,
     consumeEmailCapSlot,
     consumeTenantEmailCapSlot,
@@ -690,6 +698,101 @@ describe("dispatchGraphAlertAction", () => {
         });
 
         expect(sendSlack).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe("given a SEND_WEBHOOK trigger with a URL", () => {
+    const webhookTrigger = () =>
+      makeTrigger({
+        action: TriggerAction.SEND_WEBHOOK,
+        actionParams: { url: "https://example.com/hook", method: "POST" },
+      });
+
+    it("renders the alert body and sends it to the configured URL", async () => {
+      const { deps, sendWebhook, sendEmail, sendSlack } = makeDeps();
+      const result = await dispatchGraphAlertAction({
+        deps,
+        input: {
+          trigger: webhookTrigger(),
+          project: makeProject(),
+          context: makeContext(),
+          recipients: [],
+          slackWebhook: null,
+          fireDigest: FIRE_DIGEST,
+        },
+      });
+
+      expect(result.channel).toBe("webhook");
+      expect(result.didSend).toBe(true);
+      expect(sendEmail).not.toHaveBeenCalled();
+      expect(sendSlack).not.toHaveBeenCalled();
+      expect(sendWebhook).toHaveBeenCalledTimes(1);
+      const call = sendWebhook.mock.calls[0]?.[0] as {
+        url: string;
+        body: string;
+      };
+      expect(call.url).toBe("https://example.com/hook");
+      const body = JSON.parse(call.body) as { event: string };
+      expect(body.event).toBe("alert.fired");
+    });
+
+    describe("when the URL is not configured", () => {
+      it("skips the send and reports didSend false", async () => {
+        const { deps, sendWebhook } = makeDeps();
+        const result = await dispatchGraphAlertAction({
+          deps,
+          input: {
+            trigger: makeTrigger({
+              action: TriggerAction.SEND_WEBHOOK,
+              actionParams: {},
+            }),
+            project: makeProject(),
+            context: makeContext(),
+            recipients: [],
+            slackWebhook: null,
+            fireDigest: FIRE_DIGEST,
+          },
+        });
+        expect(result.didSend).toBe(false);
+        expect(sendWebhook).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the endpoint answers a retryable status", () => {
+      it("throws a retryable DispatchError and does NOT claim the fire", async () => {
+        const { deps, sendWebhook, claims } = makeDeps();
+        sendWebhook.mockResolvedValueOnce({ status: 503, body: "down" });
+        const input = {
+          trigger: webhookTrigger(),
+          project: makeProject(),
+          context: makeContext(),
+          recipients: [],
+          slackWebhook: null,
+          fireDigest: FIRE_DIGEST,
+        };
+        await expect(
+          dispatchGraphAlertAction({ deps, input }),
+        ).rejects.toMatchObject({ retryable: true });
+        // No claim recorded — a retry must re-attempt, not skip as delivered.
+        expect(claims.size).toBe(0);
+      });
+    });
+
+    describe("when the same fire is retried after a successful post", () => {
+      it("does not re-post to an endpoint already reached", async () => {
+        const { deps, sendWebhook } = makeDeps();
+        const input = {
+          trigger: webhookTrigger(),
+          project: makeProject(),
+          context: makeContext(),
+          recipients: [],
+          slackWebhook: null,
+          fireDigest: FIRE_DIGEST,
+        };
+        await dispatchGraphAlertAction({ deps, input });
+        await dispatchGraphAlertAction({ deps, input });
+        expect(sendWebhook).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/pipelines/shared/__tests__/graphAlertActionDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/__tests__/graphAlertActionDispatch.unit.test.ts
@@ -1,6 +1,13 @@
 import type { Project, Trigger } from "@prisma/client";
 import { TriggerAction } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
+
+// Fake cipher so the webhook-headers tests exercise the decrypt-at-dispatch
+// seam (ADR-040 §3) without real AES/env plumbing.
+vi.mock("~/utils/encryption", () => ({
+  encrypt: (s: string) => `enc(${s})`,
+  decrypt: (s: string) => s.replace(/^enc\(/, "").replace(/\)$/, ""),
+}));
 import { buildGraphAlertTemplateContext } from "~/shared/templating/templateContext";
 import {
   dispatchGraphAlertAction,
@@ -735,6 +742,36 @@ describe("dispatchGraphAlertAction", () => {
       expect(call.url).toBe("https://example.com/hook");
       const body = JSON.parse(call.body) as { event: string };
       expect(body.event).toBe("alert.fired");
+    });
+
+    describe("when header secrets are stored encrypted", () => {
+      it("decrypts them just before the send", async () => {
+        const { deps, sendWebhook } = makeDeps();
+        await dispatchGraphAlertAction({
+          deps,
+          input: {
+            trigger: makeTrigger({
+              action: TriggerAction.SEND_WEBHOOK,
+              actionParams: {
+                url: "https://example.com/hook",
+                method: "POST",
+                headersEncrypted: `enc(${JSON.stringify({
+                  Authorization: "Bearer secret",
+                })})`,
+              },
+            }),
+            project: makeProject(),
+            context: makeContext(),
+            recipients: [],
+            slackWebhook: null,
+            fireDigest: FIRE_DIGEST,
+          },
+        });
+        const call = sendWebhook.mock.calls[0]?.[0] as {
+          headers: Record<string, string>;
+        };
+        expect(call.headers).toEqual({ Authorization: "Bearer secret" });
+      });
     });
 
     describe("when the URL is not configured", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/shared/graphAlertActionDispatch.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/graphAlertActionDispatch.ts
@@ -7,10 +7,11 @@ import {
 } from "~/automations/providers/definitions/webhook/secret";
 import type { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import type { sendRenderedSlackMessage } from "~/server/triggers/sendSlackWebhook";
+import type { sendWebhook } from "~/server/triggers/sendWebhook";
 import {
-  assertWebhookDelivered,
-  type sendWebhook,
-} from "~/server/triggers/sendWebhook";
+  deliverWebhook,
+  type WebhookDeliveryRecorder,
+} from "~/server/triggers/deliverWebhook";
 import type { postSlackChatMessage } from "~/server/triggers/slackWebApi";
 import { ALERT_TRIGGER_DEFAULTS } from "~/shared/templating/defaults";
 import { renderTriggerEmail } from "~/shared/templating/renderEmail";
@@ -114,6 +115,10 @@ export interface GraphAlertDispatchDeps {
   /** ADR-040 SSRF-fenced webhook sender — same `sendWebhook` the trace
    *  cadence dispatcher uses. */
   sendWebhook: typeof sendWebhook;
+  /** ADR-040 §6 delivery-log writer — records one row per attempt. Optional:
+   *  when absent (tests, cron before wiring), deliveries aren't logged but
+   *  dispatch is unchanged. */
+  recordWebhookDelivery?: WebhookDeliveryRecorder;
   /**
    * ADR-031 email suppression gate. The event-sourced graph-alert path
    * renders the SAME one-click-unsubscribe footer + `List-Unsubscribe`
@@ -583,21 +588,24 @@ export async function dispatchGraphAlertAction({
         "Graph-alert webhook body render errors — fell back to default body",
       );
     }
-    const result = await deps.sendWebhook({
+    // Send + classify + log one attempt as a unit (ADR-040 §5/§6). A
+    // non-2xx throws BEFORE the claim below, so a retryable failure is
+    // actually retried; the delivery-log row is written either way.
+    await deliverWebhook({
+      send: deps.sendWebhook,
+      recorder: deps.recordWebhookDelivery,
+      projectId: project.id,
+      triggerId: trigger.id,
+      // The fire digest is this dispatch's stable identity — every outbox
+      // retry of the same fire reuses it as the X-LangWatch-Event-Id so the
+      // receiver dedupes (ADR-040 §5).
+      eventId: `evt_${destinationHash(`event:${input.fireDigest}`)}`,
       url: params.url,
       method: params.method,
       headers: decryptWebhookHeaders(params),
       body: rendered.body,
       triggerName: trigger.name,
-      projectId: project.id,
-      // The fire digest is this dispatch's stable identity — every outbox
-      // retry of the same fire reuses it as the X-LangWatch-Event-Id so the
-      // receiver dedupes (ADR-040 §5).
-      eventId: `evt_${destinationHash(`event:${input.fireDigest}`)}`,
     });
-    // 5xx/429/408 throw retryable, other non-2xx terminal (ADR-040 §5) —
-    // BEFORE the claim below, so a retryable failure is actually retried.
-    assertWebhookDelivered({ result, triggerName: trigger.name });
     await recordRecipientSent(urlHash);
     return {
       channel: "webhook",

--- a/langwatch/src/server/event-sourcing/pipelines/shared/graphAlertActionDispatch.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/graphAlertActionDispatch.ts
@@ -578,15 +578,19 @@ export async function dispatchGraphAlertAction({
       context,
       defaultBody: defaults.webhookBody,
     });
-    if (rendered.errors.length > 0) {
-      logger.warn(
-        {
-          triggerId: trigger.id,
-          projectId: project.id,
-          errors: rendered.errors,
-        },
-        "Graph-alert webhook body render errors — fell back to default body",
+    // Fail closed: a broken custom body template dead-letters this fire rather
+    // than delivering the framework default in its place — the default would
+    // leak the full-trace envelope the customer intentionally omitted (ADR-040
+    // §2). Non-retryable: an invalid template will not fix itself on retry.
+    if (rendered.failed) {
+      logger.error(
+        { triggerId: trigger.id, projectId: project.id, errors: rendered.errors },
+        "Graph-alert webhook body template failed to render — not sending",
       );
+      throw new DispatchError({
+        message: `Webhook body template for alert "${trigger.name}" failed to render: ${rendered.errors[0] ?? "invalid template"}`,
+        retryable: false,
+      });
     }
     // Send + classify + log one attempt as a unit (ADR-040 §5/§6). A
     // non-2xx throws BEFORE the claim below, so a retryable failure is

--- a/langwatch/src/server/event-sourcing/pipelines/shared/graphAlertActionDispatch.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/graphAlertActionDispatch.ts
@@ -589,6 +589,11 @@ export async function dispatchGraphAlertAction({
       headers: decryptWebhookHeaders(params),
       body: rendered.body,
       triggerName: trigger.name,
+      projectId: project.id,
+      // The fire digest is this dispatch's stable identity — every outbox
+      // retry of the same fire reuses it as the X-LangWatch-Event-Id so the
+      // receiver dedupes (ADR-040 §5).
+      eventId: `evt_${destinationHash(`event:${input.fireDigest}`)}`,
     });
     // 5xx/429/408 throw retryable, other non-2xx terminal (ADR-040 §5) —
     // BEFORE the claim below, so a retryable failure is actually retried.

--- a/langwatch/src/server/event-sourcing/pipelines/shared/graphAlertActionDispatch.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/graphAlertActionDispatch.ts
@@ -1,11 +1,17 @@
 import type { Project, Trigger } from "@prisma/client";
 import { createHash } from "crypto";
 import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import type { WebhookActionParams } from "~/automations/providers/definitions/webhook/shared";
 import type { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import type { sendRenderedSlackMessage } from "~/server/triggers/sendSlackWebhook";
+import {
+  assertWebhookDelivered,
+  type sendWebhook,
+} from "~/server/triggers/sendWebhook";
 import type { postSlackChatMessage } from "~/server/triggers/slackWebApi";
 import { ALERT_TRIGGER_DEFAULTS } from "~/shared/templating/defaults";
 import { renderTriggerEmail } from "~/shared/templating/renderEmail";
+import { renderWebhookBody } from "~/shared/templating/renderWebhookBody";
 import {
   renderTriggerSlack,
   type SlackTemplateType,
@@ -102,6 +108,9 @@ export interface GraphAlertDispatchDeps {
   /** Slack Web API sender for bot connections — same `postSlackChatMessage`
    *  the trace cadence dispatcher uses. */
   sendSlackBot: typeof postSlackChatMessage;
+  /** ADR-040 SSRF-fenced webhook sender — same `sendWebhook` the trace
+   *  cadence dispatcher uses. */
+  sendWebhook: typeof sendWebhook;
   /**
    * ADR-031 email suppression gate. The event-sourced graph-alert path
    * renders the SAME one-click-unsubscribe footer + `List-Unsubscribe`
@@ -182,7 +191,7 @@ export interface GraphAlertDispatchDeps {
 }
 
 export interface GraphAlertDispatchResult {
-  channel: "email" | "slack" | "none";
+  channel: "email" | "slack" | "webhook" | "none";
   /** True when this fire is consumed from the caller's perspective: a
    *  provider call was made, a retry found every recipient already claimed,
    *  or an ADR-031 email cap suppressed the delivery (see `capExhausted`).
@@ -522,9 +531,74 @@ export async function dispatchGraphAlertAction({
     };
   }
 
+  if (trigger.action === "SEND_WEBHOOK") {
+    // The whole webhook config, body template included, lives in
+    // `actionParams` (ADR-040 §1) — no evaluator pre-extraction to thread.
+    const params = (trigger.actionParams ?? {}) as Partial<WebhookActionParams>;
+    if (!params.url) {
+      logger.info(
+        { triggerId: trigger.id, projectId: project.id },
+        "Graph alert has no webhook URL configured — skipping send",
+      );
+      return {
+        channel: "webhook",
+        didSend: false,
+        missingVariables: [],
+        renderErrors: [],
+      };
+    }
+    // The endpoint URL is this fire's destination identity — gate it the same
+    // way an email address or Slack channel is, or an outbox retry re-posts.
+    const urlHash = destinationHash(`webhook:${params.url}`);
+    if (await isRecipientSent(urlHash)) {
+      logger.info(
+        { triggerId: trigger.id, projectId: project.id },
+        "Graph-alert webhook already delivered for this fire — skipping re-post on retry",
+      );
+      return {
+        channel: "webhook",
+        didSend: true,
+        missingVariables: [],
+        renderErrors: [],
+      };
+    }
+    const rendered = await renderWebhookBody({
+      template: params.bodyTemplate ?? null,
+      context,
+      defaultBody: defaults.webhookBody,
+    });
+    if (rendered.errors.length > 0) {
+      logger.warn(
+        {
+          triggerId: trigger.id,
+          projectId: project.id,
+          errors: rendered.errors,
+        },
+        "Graph-alert webhook body render errors — fell back to default body",
+      );
+    }
+    const result = await deps.sendWebhook({
+      url: params.url,
+      method: params.method,
+      headers: params.headers,
+      body: rendered.body,
+      triggerName: trigger.name,
+    });
+    // 5xx/429/408 throw retryable, other non-2xx terminal (ADR-040 §5) —
+    // BEFORE the claim below, so a retryable failure is actually retried.
+    assertWebhookDelivered({ result, triggerName: trigger.name });
+    await recordRecipientSent(urlHash);
+    return {
+      channel: "webhook",
+      didSend: true,
+      missingVariables: rendered.missingVariables,
+      renderErrors: rendered.errors,
+    };
+  }
+
   // Persist actions (ADD_TO_DATASET / ADD_TO_ANNOTATION_QUEUE) and any
   // future TriggerAction value never apply to graph alerts — the cron's
-  // routing only ever dispatches email / Slack here. Fail loud so a
+  // routing only ever dispatches notify channels here. Fail loud so a
   // misconfigured trigger dead-letters with an actionable operator signal
   // rather than silently no-op every fire (dispatch5015-002).
   logger.error(
@@ -533,10 +607,10 @@ export async function dispatchGraphAlertAction({
       projectId: project.id,
       action: trigger.action,
     },
-    "Graph alert action is neither SEND_EMAIL nor SEND_SLACK_MESSAGE — dead-lettering",
+    "Graph alert action is not a notify channel — dead-lettering",
   );
   throw new DispatchError({
-    message: `Graph alert action "${trigger.action}" is not supported — only SEND_EMAIL and SEND_SLACK_MESSAGE apply to graph alerts.`,
+    message: `Graph alert action "${trigger.action}" is not supported — only SEND_EMAIL, SEND_SLACK_MESSAGE, and SEND_WEBHOOK apply to graph alerts.`,
     retryable: false,
   });
 }

--- a/langwatch/src/server/event-sourcing/pipelines/shared/graphAlertActionDispatch.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/graphAlertActionDispatch.ts
@@ -1,7 +1,10 @@
 import type { Project, Trigger } from "@prisma/client";
 import { createHash } from "crypto";
 import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
-import type { WebhookActionParams } from "~/automations/providers/definitions/webhook/shared";
+import {
+  decryptWebhookHeaders,
+  type WebhookStoredActionParams,
+} from "~/automations/providers/definitions/webhook/secret";
 import type { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import type { sendRenderedSlackMessage } from "~/server/triggers/sendSlackWebhook";
 import {
@@ -534,7 +537,10 @@ export async function dispatchGraphAlertAction({
   if (trigger.action === "SEND_WEBHOOK") {
     // The whole webhook config, body template included, lives in
     // `actionParams` (ADR-040 §1) — no evaluator pre-extraction to thread.
-    const params = (trigger.actionParams ?? {}) as Partial<WebhookActionParams>;
+    // Header values are stored as one ciphertext blob (ADR-040 §3),
+    // decrypted just before the send below.
+    const params = (trigger.actionParams ??
+      {}) as Partial<WebhookStoredActionParams>;
     if (!params.url) {
       logger.info(
         { triggerId: trigger.id, projectId: project.id },
@@ -580,7 +586,7 @@ export async function dispatchGraphAlertAction({
     const result = await deps.sendWebhook({
       url: params.url,
       method: params.method,
-      headers: params.headers,
+      headers: decryptWebhookHeaders(params),
       body: rendered.body,
       triggerName: trigger.name,
     });

--- a/langwatch/src/server/event-sourcing/pipelines/shared/triggerActionDispatch.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/triggerActionDispatch.ts
@@ -37,6 +37,7 @@ const logger = createLogger("langwatch:trigger-action-dispatch");
 export const NOTIFY_TRIGGER_ACTIONS = new Set<TriggerAction>([
   TriggerAction.SEND_EMAIL,
   TriggerAction.SEND_SLACK_MESSAGE,
+  TriggerAction.SEND_WEBHOOK,
 ]);
 
 export const PERSIST_TRIGGER_ACTIONS = new Set<TriggerAction>([
@@ -164,6 +165,7 @@ export async function dispatchTriggerAction({
   switch (trigger.action) {
     case TriggerAction.SEND_EMAIL:
     case TriggerAction.SEND_SLACK_MESSAGE:
+    case TriggerAction.SEND_WEBHOOK:
       // Notify-class actions never dispatch inline — they ride the outbox
       // (settle → cadence) so debounce, cadence coalescing, and the typed
       // retry contract apply. Both callers pre-filter on

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1058,7 +1058,17 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 // Re-stage with backoff — frees the worker slot immediately
                 gqJobsRetriedTotal.inc(routingLabels);
 
-                const backoffMs = getBackoffMs(attempt);
+                // Honor a receiver's Retry-After (ADR-040 §5) as a FLOOR over
+                // the exponential backoff: a DispatchError may carry a
+                // retryAfterMs hint, which can lengthen but never shorten the
+                // wait (so it can't cause a retry storm).
+                const retryAfterMs = isDispatchError(err)
+                  ? err.retryAfterMs
+                  : undefined;
+                const backoffMs = Math.max(
+                  getBackoffMs(attempt),
+                  retryAfterMs ?? 0,
+                );
                 gqRetryAttempt.observe(routingLabels, attempt);
                 gqRetryBackoffMilliseconds.observe(routingLabels, backoffMs);
                 const newStagedJobId = `${stagedJobId}/r/${attempt}`;

--- a/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
@@ -59,6 +59,7 @@ export const FRONTEND_FEATURE_FLAGS = [
   // Force-enable in dev: `FEATURE_FLAG_FORCE_ENABLE=release_ui_ai_governance_enabled`.
   "release_ui_ai_governance_enabled",
   "release_langy_enabled",
+  "release_webhook_automations",
 ] as const;
 
 /**

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -208,6 +208,13 @@ export const FEATURE_FLAGS = [
     description:
       "Opens the Langy in-product assistant. Default off: only LangWatch staff (isLangwatchStaff() — @langwatch.ai email) get Langy out of the box. To open it for a specific project/org/user, flip the flag on via a PostHog rule, an operator-store row via /ops/feature-flags, or RELEASE_LANGY_ENABLED=true for a blanket on. Staff always bypass the flag so a global kill switch still leaves us able to debug.",
   },
+  {
+    key: "release_webhook_automations",
+    scope: "PRODUCT",
+    defaultValue: false,
+    description:
+      "Offers the Webhook (generic HTTP request) delivery channel for automations (ADR-040). Gates the delivery-picker card, the save route accepting SEND_WEBHOOK, and the test-fire path. Force-enable in dev via FEATURE_FLAG_FORCE_ENABLE=release_webhook_automations.",
+  },
 ] as const satisfies readonly FeatureFlagDefinition[];
 
 export const FEATURE_FLAG_FAMILIES = [

--- a/langwatch/src/server/routes/cron.ts
+++ b/langwatch/src/server/routes/cron.ts
@@ -12,6 +12,7 @@ import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import { featureFlagService } from "~/server/featureFlag";
 import { scheduleTopicClustering } from "~/server/topicClustering/topicClusteringQueue";
+import { WebhookDeliveryService } from "~/server/app-layer/triggers/webhook-delivery.service";
 import cleanupOldLambdas from "~/tasks/cleanupOldLambdas";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
 import {
@@ -78,6 +79,33 @@ secured
 secured
   .access(cronPolicy())
   .post("/cron/old_lambdas_cleanup", oldLambdasCleanupHandler);
+
+// ---------- GET|POST /api/cron/webhook_delivery_cleanup ----------
+// ADR-040 §6: prune webhook delivery-log rows older than 30 days. Postgres is
+// outside the ClickHouse retention sweep, so the log needs its own cleaner.
+const webhookDeliveryCleanupHandler = async (c: CronContext) => {
+  if (!validateCronKey(c)) {
+    return c.body(null, 401);
+  }
+  try {
+    const deleted = await WebhookDeliveryService.create(prisma).pruneExpired();
+    return c.json({ message: "Webhook delivery log pruned", deleted });
+  } catch (error: any) {
+    return c.json(
+      {
+        message: "Error pruning webhook delivery log",
+        error: error?.message ? error.message.toString() : `${error}`,
+      },
+      500,
+    );
+  }
+};
+secured
+  .access(cronPolicy())
+  .get("/cron/webhook_delivery_cleanup", webhookDeliveryCleanupHandler);
+secured
+  .access(cronPolicy())
+  .post("/cron/webhook_delivery_cleanup", webhookDeliveryCleanupHandler);
 
 // ---------- GET|POST /api/cron/schedule_topic_clustering ----------
 const scheduleTopicClusteringHandler = async (c: CronContext) => {

--- a/langwatch/src/server/routes/cron.ts
+++ b/langwatch/src/server/routes/cron.ts
@@ -12,7 +12,6 @@ import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import { featureFlagService } from "~/server/featureFlag";
 import { scheduleTopicClustering } from "~/server/topicClustering/topicClusteringQueue";
-import { WebhookDeliveryService } from "~/server/app-layer/triggers/webhook-delivery.service";
 import cleanupOldLambdas from "~/tasks/cleanupOldLambdas";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
 import {
@@ -88,13 +87,18 @@ const webhookDeliveryCleanupHandler = async (c: CronContext) => {
     return c.body(null, 401);
   }
   try {
-    const deleted = await WebhookDeliveryService.create(prisma).pruneExpired();
+    // Scope the prune by projectId (the delivery log is a project-level model),
+    // so enumerate every project and hand the ids to the service.
+    const projects = await prisma.project.findMany({ select: { id: true } });
+    const deleted = await getApp().webhookDeliveries.pruneExpired({
+      projectIds: projects.map((p) => p.id),
+    });
     return c.json({ message: "Webhook delivery log pruned", deleted });
-  } catch (error: any) {
+  } catch (error: unknown) {
     return c.json(
       {
         message: "Error pruning webhook delivery log",
-        error: error?.message ? error.message.toString() : `${error}`,
+        error: error instanceof Error ? error.message : String(error),
       },
       500,
     );

--- a/langwatch/src/server/routes/cron.ts
+++ b/langwatch/src/server/routes/cron.ts
@@ -89,10 +89,9 @@ const webhookDeliveryCleanupHandler = async (c: CronContext) => {
   try {
     // Scope the prune by projectId (the delivery log is a project-level model),
     // so enumerate every project and hand the ids to the service.
-    const projects = await prisma.project.findMany({ select: { id: true } });
-    const deleted = await getApp().webhookDeliveries.pruneExpired({
-      projectIds: projects.map((p) => p.id),
-    });
+    const app = getApp();
+    const projectIds = await app.projects.getAllIds();
+    const deleted = await app.webhookDeliveries.pruneExpired({ projectIds });
     return c.json({ message: "Webhook delivery log pruned", deleted });
   } catch (error: unknown) {
     return c.json(

--- a/langwatch/src/server/triggers/__tests__/deliverWebhook.unit.test.ts
+++ b/langwatch/src/server/triggers/__tests__/deliverWebhook.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
 import type { WebhookDeliveryInput } from "~/server/app-layer/triggers/repositories/webhook-delivery.repository";
 import { deliverWebhook } from "../deliverWebhook";
-import type { WebhookSendResult } from "../sendWebhook";
+import type { sendWebhook, WebhookSendResult } from "../sendWebhook";
 
 const base = {
   projectId: "proj_1",
@@ -10,20 +10,26 @@ const base = {
   eventId: "evt_abc",
   url: "https://example.com/hook",
   method: "POST" as const,
-  headers: { Authorization: "Bearer secret", "X-Trace": "t1" },
+  // A heuristic-named credential, a heuristic-miss credential, and a
+  // non-secret trace header — EVERY value must be masked in the log.
+  headers: {
+    Authorization: "Bearer secret",
+    "X-Partner-Key": "pk_live_123",
+    "X-Trace": "t1",
+  },
   body: "{}",
   triggerName: "My automation",
 };
 
 function sendResolvingWith(
   overrides: Partial<WebhookSendResult>,
-): typeof import("../sendWebhook").sendWebhook {
+): typeof sendWebhook {
   return (async () => ({
     status: 200,
     body: "ok",
     eventId: "evt_abc",
     ...overrides,
-  })) as unknown as typeof import("../sendWebhook").sendWebhook;
+  })) as unknown as typeof sendWebhook;
 }
 
 describe("deliverWebhook", () => {
@@ -47,12 +53,25 @@ describe("deliverWebhook", () => {
         responseStatus: 201,
         outcome: "success",
       });
-      // The secret header value is masked in the log row.
       expect(rows[0]!.requestHeaders).toEqual({
         Authorization: "***",
-        "X-Trace": "t1",
+        "X-Partner-Key": "***",
+        "X-Trace": "***",
       });
       expect(rows[0]!.latencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("stores the request URL as origin + path only, stripping the query", async () => {
+      const rows: WebhookDeliveryInput[] = [];
+      await deliverWebhook({
+        ...base,
+        url: "https://example.com/hook?token=secret&sig=abc#frag",
+        send: sendResolvingWith({ status: 200 }),
+        recorder: async (row) => {
+          rows.push(row);
+        },
+      });
+      expect(rows[0]!.requestUrl).toBe("https://example.com/hook");
     });
   });
 
@@ -99,7 +118,7 @@ describe("deliverWebhook", () => {
           message: "blocked: private address",
           retryable: false,
         });
-      }) as unknown as typeof import("../sendWebhook").sendWebhook;
+      }) as unknown as typeof sendWebhook;
       await expect(
         deliverWebhook({
           ...base,

--- a/langwatch/src/server/triggers/__tests__/deliverWebhook.unit.test.ts
+++ b/langwatch/src/server/triggers/__tests__/deliverWebhook.unit.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import type { WebhookDeliveryInput } from "~/server/app-layer/triggers/repositories/webhook-delivery.repository";
+import { deliverWebhook } from "../deliverWebhook";
+import type { WebhookSendResult } from "../sendWebhook";
+
+const base = {
+  projectId: "proj_1",
+  triggerId: "trg_1",
+  eventId: "evt_abc",
+  url: "https://example.com/hook",
+  method: "POST" as const,
+  headers: { Authorization: "Bearer secret", "X-Trace": "t1" },
+  body: "{}",
+  triggerName: "My automation",
+};
+
+function sendResolvingWith(
+  overrides: Partial<WebhookSendResult>,
+): typeof import("../sendWebhook").sendWebhook {
+  return (async () => ({
+    status: 200,
+    body: "ok",
+    eventId: "evt_abc",
+    ...overrides,
+  })) as unknown as typeof import("../sendWebhook").sendWebhook;
+}
+
+describe("deliverWebhook", () => {
+  describe("when the endpoint answers 2xx", () => {
+    it("records a success row with redacted headers and the eventId as dispatchId", async () => {
+      const rows: WebhookDeliveryInput[] = [];
+      await deliverWebhook({
+        ...base,
+        send: sendResolvingWith({ status: 201 }),
+        recorder: async (row) => {
+          rows.push(row);
+        },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        projectId: "proj_1",
+        triggerId: "trg_1",
+        dispatchId: "evt_abc",
+        requestMethod: "POST",
+        requestUrl: "https://example.com/hook",
+        responseStatus: 201,
+        outcome: "success",
+      });
+      // The secret header value is masked in the log row.
+      expect(rows[0]!.requestHeaders).toEqual({
+        Authorization: "***",
+        "X-Trace": "t1",
+      });
+      expect(rows[0]!.latencyMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("when the endpoint answers a retryable status", () => {
+    it("records a retryable row and re-throws", async () => {
+      const rows: WebhookDeliveryInput[] = [];
+      await expect(
+        deliverWebhook({
+          ...base,
+          send: sendResolvingWith({ status: 503, body: "down" }),
+          recorder: async (row) => {
+            rows.push(row);
+          },
+        }),
+      ).rejects.toBeInstanceOf(DispatchError);
+      expect(rows[0]).toMatchObject({
+        responseStatus: 503,
+        outcome: "retryable",
+      });
+    });
+  });
+
+  describe("when the endpoint answers a terminal status", () => {
+    it("records a terminal row and re-throws", async () => {
+      const rows: WebhookDeliveryInput[] = [];
+      await expect(
+        deliverWebhook({
+          ...base,
+          send: sendResolvingWith({ status: 404, body: "gone" }),
+          recorder: async (row) => {
+            rows.push(row);
+          },
+        }),
+      ).rejects.toBeInstanceOf(DispatchError);
+      expect(rows[0]).toMatchObject({ responseStatus: 404, outcome: "terminal" });
+    });
+  });
+
+  describe("when the sender throws before responding", () => {
+    it("records a row with the error message and no status", async () => {
+      const rows: WebhookDeliveryInput[] = [];
+      const send = (async () => {
+        throw new DispatchError({
+          message: "blocked: private address",
+          retryable: false,
+        });
+      }) as unknown as typeof import("../sendWebhook").sendWebhook;
+      await expect(
+        deliverWebhook({
+          ...base,
+          send,
+          recorder: async (row) => {
+            rows.push(row);
+          },
+        }),
+      ).rejects.toBeInstanceOf(DispatchError);
+      expect(rows[0]).toMatchObject({
+        responseStatus: null,
+        error: "blocked: private address",
+        outcome: "terminal",
+      });
+    });
+  });
+
+  describe("when the recorder itself throws", () => {
+    it("does not break dispatch (logging is best-effort)", async () => {
+      const result = await deliverWebhook({
+        ...base,
+        send: sendResolvingWith({ status: 200 }),
+        recorder: vi.fn(async () => {
+          throw new Error("db down");
+        }),
+      });
+      expect(result.status).toBe(200);
+    });
+  });
+
+  describe("when no recorder is supplied", () => {
+    it("still delivers", async () => {
+      const result = await deliverWebhook({
+        ...base,
+        send: sendResolvingWith({ status: 200 }),
+      });
+      expect(result.status).toBe(200);
+    });
+  });
+});

--- a/langwatch/src/server/triggers/__tests__/httpDestination.redirects.unit.test.ts
+++ b/langwatch/src/server/triggers/__tests__/httpDestination.redirects.unit.test.ts
@@ -1,0 +1,97 @@
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import { createSSRFValidator } from "~/utils/ssrfProtection";
+import { sendHttpDestination } from "../httpDestination";
+
+/**
+ * Executed redirect-refusal regression (ADR-040 §4): the strict-validator
+ * path must refuse a 3xx-with-Location outright — following it would
+ * re-validate through the weaker default policy. Observed against a REAL
+ * local server through the REAL `fetchWithResolvedIp`, no mocks — per the
+ * repo's "regression test must execute the code path" rule.
+ *
+ * The validator here is deliberately permissive (`blockLocal: false`) so the
+ * test can reach 127.0.0.1; redirect refusal is orthogonal to the private-IP
+ * policy, which `sendWebhook.unit.test.ts` covers.
+ */
+const validateUrl = createSSRFValidator({
+  blockLocal: false,
+  allowedHosts: [],
+});
+
+let server: Server;
+let baseUrl: string;
+const seenPaths: string[] = [];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    seenPaths.push(req.url ?? "");
+    if (req.url === "/redirect-to-metadata") {
+      res.writeHead(302, {
+        Location: "http://169.254.169.254/latest/meta-data/",
+      });
+      res.end();
+    } else if (req.url === "/bare-3xx") {
+      res.writeHead(304);
+      res.end();
+    } else {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ok");
+    }
+  });
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", resolve),
+  );
+  const address = server.address();
+  if (typeof address === "string" || address === null) {
+    throw new Error("expected an AddressInfo");
+  }
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+const send = (path: string) =>
+  sendHttpDestination({
+    url: `${baseUrl}${path}`,
+    body: "{}",
+    contextLabel: "redirect test",
+    validateUrl,
+  });
+
+describe("sendHttpDestination with a strict validator", () => {
+  describe("when the endpoint answers a redirect toward cloud metadata", () => {
+    it("refuses the redirect terminally without following it", async () => {
+      seenPaths.length = 0;
+      let caught: unknown;
+      try {
+        await send("/redirect-to-metadata");
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(DispatchError);
+      expect((caught as DispatchError).retryable).toBe(false);
+      expect((caught as DispatchError).message).toMatch(/redirect/i);
+      // Exactly one request reached the local server; the metadata Location
+      // was never contacted (a hop would have re-entered the fetch).
+      expect(seenPaths).toEqual(["/redirect-to-metadata"]);
+    });
+  });
+
+  describe("when the endpoint answers a 3xx without a Location", () => {
+    it("returns the status for the caller to classify", async () => {
+      await expect(send("/bare-3xx")).resolves.toMatchObject({ status: 304 });
+    });
+  });
+
+  describe("when the endpoint answers 2xx", () => {
+    it("delivers normally through the strict path", async () => {
+      await expect(send("/ok")).resolves.toEqual({ status: 200, body: "ok" });
+    });
+  });
+});

--- a/langwatch/src/server/triggers/__tests__/sendWebhook.dispatch.unit.test.ts
+++ b/langwatch/src/server/triggers/__tests__/sendWebhook.dispatch.unit.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+
+// Stub the SSRF-fenced transport and the rate limiter so these tests exercise
+// sendWebhook's ORCHESTRATION (event-id header, dispatch cap, Retry-After
+// threading) without a network call. The executed SSRF blocks live in
+// sendWebhook.unit.test.ts, which uses the real transport.
+vi.mock("../httpDestination", () => ({ sendHttpDestination: vi.fn() }));
+vi.mock("~/server/rateLimit", () => ({ rateLimit: vi.fn() }));
+
+import { rateLimit } from "~/server/rateLimit";
+import { sendHttpDestination } from "../httpDestination";
+import {
+  assertWebhookDelivered,
+  sendWebhook,
+  WEBHOOK_DISPATCH_HOURLY_CAP,
+} from "../sendWebhook";
+
+const mockedSend = vi.mocked(sendHttpDestination);
+const mockedRateLimit = vi.mocked(rateLimit);
+
+function sendResolves(overrides?: { status?: number; retryAfterMs?: number }) {
+  mockedSend.mockResolvedValue({
+    status: overrides?.status ?? 200,
+    body: "ok",
+    retryAfterMs: overrides?.retryAfterMs,
+  });
+}
+
+function allowRateLimit() {
+  mockedRateLimit.mockResolvedValue({
+    allowed: true,
+    remaining: 10,
+    resetAt: Date.now() + 3600_000,
+  });
+}
+
+afterEach(() => vi.clearAllMocks());
+
+const base = {
+  url: "https://example.com/hook",
+  body: "{}",
+  triggerName: "My automation",
+};
+
+describe("sendWebhook dispatch orchestration", () => {
+  describe("when a stable eventId is supplied", () => {
+    it("sends it as X-LangWatch-Event-Id and echoes it in the result", async () => {
+      sendResolves();
+      allowRateLimit();
+      const result = await sendWebhook({
+        ...base,
+        projectId: "proj_1",
+        eventId: "evt_stable",
+      });
+      const headers = mockedSend.mock.calls[0]![0].headers as Record<
+        string,
+        string
+      >;
+      expect(headers["X-LangWatch-Event-Id"]).toBe("evt_stable");
+      expect(result.eventId).toBe("evt_stable");
+    });
+  });
+
+  describe("when no eventId is supplied", () => {
+    it("generates a fresh one so the header is always present", async () => {
+      sendResolves();
+      const result = await sendWebhook({ ...base, testFire: true });
+      const headers = mockedSend.mock.calls[0]![0].headers as Record<
+        string,
+        string
+      >;
+      expect(headers["X-LangWatch-Event-Id"]).toBe(result.eventId);
+      expect(result.eventId).toMatch(/[0-9a-f-]{36}/);
+    });
+  });
+
+  describe("the per-project dispatch cap", () => {
+    it("gates a real dispatch on the project cap", async () => {
+      sendResolves();
+      allowRateLimit();
+      await sendWebhook({ ...base, projectId: "proj_1" });
+      expect(mockedRateLimit).toHaveBeenCalledWith({
+        key: "webhook-dispatch:proj_1",
+        windowSeconds: 3600,
+        max: WEBHOOK_DISPATCH_HOURLY_CAP,
+      });
+    });
+
+    it("does NOT rate-limit a test fire", async () => {
+      sendResolves();
+      await sendWebhook({ ...base, projectId: "proj_1", testFire: true });
+      expect(mockedRateLimit).not.toHaveBeenCalled();
+    });
+
+    it("throws retryable with a Retry-After when the cap is exceeded", async () => {
+      const resetAt = Date.now() + 120_000;
+      mockedRateLimit.mockResolvedValue({
+        allowed: false,
+        remaining: 0,
+        resetAt,
+      });
+      let caught: unknown;
+      try {
+        await sendWebhook({ ...base, projectId: "proj_1" });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(DispatchError);
+      expect((caught as DispatchError).retryable).toBe(true);
+      expect((caught as DispatchError).retryAfterMs).toBeGreaterThan(0);
+      // The endpoint was never contacted.
+      expect(mockedSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Retry-After from the receiver", () => {
+    it("threads it onto the retryable DispatchError on a 429", () => {
+      let caught: unknown;
+      try {
+        assertWebhookDelivered({
+          result: { status: 429, body: "slow down", retryAfterMs: 90_000 },
+          triggerName: "My automation",
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect((caught as DispatchError).retryable).toBe(true);
+      expect((caught as DispatchError).retryAfterMs).toBe(90_000);
+    });
+
+    it("does not carry a Retry-After onto a terminal 4xx", () => {
+      let caught: unknown;
+      try {
+        assertWebhookDelivered({
+          result: { status: 400, body: "bad", retryAfterMs: 90_000 },
+          triggerName: "My automation",
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect((caught as DispatchError).retryable).toBe(false);
+      expect((caught as DispatchError).retryAfterMs).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/triggers/__tests__/sendWebhook.dispatch.unit.test.ts
+++ b/langwatch/src/server/triggers/__tests__/sendWebhook.dispatch.unit.test.ts
@@ -75,11 +75,11 @@ describe("sendWebhook dispatch orchestration", () => {
     });
   });
 
-  describe("the per-project dispatch cap", () => {
+  describe("when enforcing the per-project dispatch cap", () => {
     it("gates a real dispatch on the project cap", async () => {
       sendResolves();
       allowRateLimit();
-      await sendWebhook({ ...base, projectId: "proj_1" });
+      await sendWebhook({ ...base, projectId: "proj_1", eventId: "evt_1" });
       expect(mockedRateLimit).toHaveBeenCalledWith({
         key: "webhook-dispatch:proj_1",
         windowSeconds: 3600,
@@ -102,7 +102,7 @@ describe("sendWebhook dispatch orchestration", () => {
       });
       let caught: unknown;
       try {
-        await sendWebhook({ ...base, projectId: "proj_1" });
+        await sendWebhook({ ...base, projectId: "proj_1", eventId: "evt_1" });
       } catch (err) {
         caught = err;
       }
@@ -114,7 +114,24 @@ describe("sendWebhook dispatch orchestration", () => {
     });
   });
 
-  describe("Retry-After from the receiver", () => {
+  describe("when a production dispatch omits its required fields", () => {
+    it("throws a terminal DispatchError before any send when eventId is missing", async () => {
+      sendResolves();
+      allowRateLimit();
+      let caught: unknown;
+      try {
+        await sendWebhook({ ...base, projectId: "proj_1" });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(DispatchError);
+      expect((caught as DispatchError).retryable).toBe(false);
+      expect(mockedRateLimit).not.toHaveBeenCalled();
+      expect(mockedSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the receiver supplies Retry-After", () => {
     it("threads it onto the retryable DispatchError on a 429", () => {
       let caught: unknown;
       try {

--- a/langwatch/src/server/triggers/__tests__/sendWebhook.unit.test.ts
+++ b/langwatch/src/server/triggers/__tests__/sendWebhook.unit.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import { assertWebhookDelivered, sendWebhook } from "../sendWebhook";
+
+async function captureDispatchError(
+  fn: () => Promise<unknown>,
+): Promise<DispatchError> {
+  try {
+    await fn();
+  } catch (err) {
+    expect(err).toBeInstanceOf(DispatchError);
+    return err as DispatchError;
+  }
+  throw new Error("expected the call to throw");
+}
+
+describe("sendWebhook", () => {
+  describe("when the URL fails the shape check", () => {
+    it("rejects http URLs terminally without any network call", async () => {
+      const err = await captureDispatchError(() =>
+        sendWebhook({
+          url: "http://example.com/hook",
+          body: "{}",
+          triggerName: "My automation",
+        }),
+      );
+      expect(err.retryable).toBe(false);
+      expect(err.message).toContain("https");
+    });
+
+    it("rejects non-default ports terminally", async () => {
+      const err = await captureDispatchError(() =>
+        sendWebhook({
+          url: "https://example.com:8443/hook",
+          body: "{}",
+          triggerName: "My automation",
+        }),
+      );
+      expect(err.retryable).toBe(false);
+      expect(err.message).toContain("port");
+    });
+  });
+
+  describe("when the URL points at a private or loopback address", () => {
+    // Executed SSRF regression (ADR-040 §4): the strict validator blocks
+    // local addresses regardless of the BLOCK_LOCAL_HTTP_CALLS toggle, and
+    // the block is observed on the real code path — no string assertions on
+    // generated config.
+    it.each([
+      "https://127.0.0.1/hook",
+      "https://10.0.0.5/hook",
+      "https://192.168.1.1/hook",
+      "https://169.254.169.254/hook",
+      "https://[::1]/hook",
+    ])("blocks %s terminally before any connection", async (url) => {
+      const err = await captureDispatchError(() =>
+        sendWebhook({ url, body: "{}", triggerName: "My automation" }),
+      );
+      expect(err.retryable).toBe(false);
+    });
+
+    it("blocks cloud metadata hostnames terminally", async () => {
+      const err = await captureDispatchError(() =>
+        sendWebhook({
+          url: "https://metadata.google.internal/hook",
+          body: "{}",
+          triggerName: "My automation",
+        }),
+      );
+      expect(err.retryable).toBe(false);
+    });
+  });
+});
+
+describe("assertWebhookDelivered", () => {
+  const triggerName = "My automation";
+
+  describe("when the endpoint answers 2xx", () => {
+    it("returns without throwing", () => {
+      expect(() =>
+        assertWebhookDelivered({
+          result: { status: 200, body: "ok" },
+          triggerName,
+        }),
+      ).not.toThrow();
+      expect(() =>
+        assertWebhookDelivered({
+          result: { status: 204, body: "" },
+          triggerName,
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("when the endpoint answers a retryable status", () => {
+    it.each([500, 502, 503, 429, 408])("classifies %s as retryable", (status) => {
+      try {
+        assertWebhookDelivered({ result: { status, body: "" }, triggerName });
+        throw new Error("expected a throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(DispatchError);
+        expect((err as DispatchError).retryable).toBe(true);
+      }
+    });
+  });
+
+  describe("when the endpoint answers a terminal status", () => {
+    it.each([301, 400, 401, 403, 404, 422])(
+      "classifies %s as terminal",
+      (status) => {
+        try {
+          assertWebhookDelivered({ result: { status, body: "" }, triggerName });
+          throw new Error("expected a throw");
+        } catch (err) {
+          expect(err).toBeInstanceOf(DispatchError);
+          expect((err as DispatchError).retryable).toBe(false);
+        }
+      },
+    );
+
+    it("carries a capped response snippet in the message", () => {
+      try {
+        assertWebhookDelivered({
+          result: { status: 422, body: `{"error":"bad schema"}` },
+          triggerName,
+        });
+        throw new Error("expected a throw");
+      } catch (err) {
+        expect((err as DispatchError).message).toContain("HTTP 422");
+        expect((err as DispatchError).message).toContain("bad schema");
+      }
+    });
+  });
+});

--- a/langwatch/src/server/triggers/deliverWebhook.ts
+++ b/langwatch/src/server/triggers/deliverWebhook.ts
@@ -1,0 +1,120 @@
+import { createLogger } from "@langwatch/observability";
+import {
+  redactHeadersForLog,
+  type WebhookMethod,
+} from "~/automations/providers/definitions/webhook/shared";
+import { isDispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import type { WebhookDeliveryInput } from "~/server/app-layer/triggers/repositories/webhook-delivery.repository";
+import {
+  assertWebhookDelivered,
+  sendWebhook,
+  type WebhookSendResult,
+} from "./sendWebhook";
+
+const logger = createLogger("langwatch:webhook-delivery");
+
+/** Records one attempt of the delivery log (ADR-040 §6). Optional — the
+ *  test-fire path passes none, so nothing is logged for ephemeral tests. */
+export type WebhookDeliveryRecorder = (
+  input: WebhookDeliveryInput,
+) => Promise<void>;
+
+/** How much of the receiver's response the log row keeps (schema caps aside). */
+const LOG_BODY_SNIPPET_CHARS = 4000;
+
+/**
+ * Send one webhook dispatch AND record its outcome to the delivery log
+ * (ADR-040 §5 + §6) as a single unit: on 2xx a `success` row, on a classified
+ * non-2xx a `retryable`/`terminal` row, on a transport/SSRF throw a row with
+ * the error and no status. The classified DispatchError is always re-thrown so
+ * the outbox retry contract is unchanged — logging is a side effect that never
+ * swallows a dispatch failure, and a logging failure never breaks dispatch.
+ */
+export async function deliverWebhook({
+  send = sendWebhook,
+  recorder,
+  projectId,
+  triggerId,
+  eventId,
+  url,
+  method,
+  headers,
+  body,
+  triggerName,
+}: {
+  /** The sender — defaults to the real one; the graph-alert path injects its
+   *  own `deps.sendWebhook` so its unit tests keep the mock seam. */
+  send?: typeof sendWebhook;
+  recorder?: WebhookDeliveryRecorder;
+  projectId: string;
+  triggerId: string;
+  /** Stable per-fire id — the delivery log's `dispatchId` and the sent
+   *  `X-LangWatch-Event-Id`, so attempts of one fire group together. */
+  eventId: string;
+  url: string;
+  method?: WebhookMethod;
+  /** Decrypted headers; redacted before they reach the log row. */
+  headers?: Record<string, string>;
+  body: string;
+  triggerName: string;
+}): Promise<WebhookSendResult> {
+  const startedAt = Date.now();
+  const baseRow = {
+    projectId,
+    triggerId,
+    dispatchId: eventId,
+    requestMethod: method ?? "POST",
+    requestUrl: url,
+    requestHeaders: redactHeadersForLog(headers ?? {}),
+  };
+  const safeRecord = async (row: WebhookDeliveryInput) => {
+    if (!recorder) return;
+    try {
+      await recorder(row);
+    } catch (err) {
+      logger.warn(
+        { projectId, triggerId, error: err },
+        "Failed to record webhook delivery attempt — dispatch unaffected",
+      );
+    }
+  };
+
+  let result: WebhookSendResult | undefined;
+  try {
+    result = await send({
+      url,
+      method,
+      headers,
+      body,
+      triggerName,
+      projectId,
+      eventId,
+    });
+    // Throws a classified DispatchError on a non-2xx (ADR-040 §5).
+    assertWebhookDelivered({ result, triggerName });
+    await safeRecord({
+      ...baseRow,
+      responseStatus: result.status,
+      responseBody: result.body.slice(0, LOG_BODY_SNIPPET_CHARS),
+      latencyMs: Date.now() - startedAt,
+      outcome: "success",
+    });
+    return result;
+  } catch (err) {
+    const retryable = isDispatchError(err) && err.retryable;
+    await safeRecord({
+      ...baseRow,
+      // A result means a non-2xx classified by assert (status carries the
+      // failure); no result means sendWebhook threw before responding
+      // (transport / SSRF / rate-limit), so the message is the detail.
+      responseStatus: result?.status ?? null,
+      responseBody: result
+        ? result.body.slice(0, LOG_BODY_SNIPPET_CHARS)
+        : null,
+      latencyMs: Date.now() - startedAt,
+      error: result ? null : err instanceof Error ? err.message : String(err),
+      outcome: retryable ? "retryable" : "terminal",
+    });
+    throw err;
+  }
+}

--- a/langwatch/src/server/triggers/deliverWebhook.ts
+++ b/langwatch/src/server/triggers/deliverWebhook.ts
@@ -61,10 +61,13 @@ function buildBaseRow({
 }
 
 /** Best-effort recorder wrapper: a logging failure never breaks dispatch. */
-async function recordDelivery(
-  recorder: WebhookDeliveryRecorder | undefined,
-  row: WebhookDeliveryInput,
-): Promise<void> {
+async function recordDelivery({
+  recorder,
+  row,
+}: {
+  recorder?: WebhookDeliveryRecorder;
+  row: WebhookDeliveryInput;
+}): Promise<void> {
   if (!recorder) return;
   try {
     await recorder(row);
@@ -76,11 +79,15 @@ async function recordDelivery(
   }
 }
 
-function successRow(
-  base: WebhookDeliveryBaseRow,
-  result: WebhookSendResult,
-  startedAt: number,
-): WebhookDeliveryInput {
+function successRow({
+  base,
+  result,
+  startedAt,
+}: {
+  base: WebhookDeliveryBaseRow;
+  result: WebhookSendResult;
+  startedAt: number;
+}): WebhookDeliveryInput {
   return {
     ...base,
     responseStatus: result.status,
@@ -90,12 +97,17 @@ function successRow(
   };
 }
 
-function failureRow(
-  base: WebhookDeliveryBaseRow,
-  result: WebhookSendResult | undefined,
-  err: unknown,
-  startedAt: number,
-): WebhookDeliveryInput {
+function failureRow({
+  base,
+  result,
+  err,
+  startedAt,
+}: {
+  base: WebhookDeliveryBaseRow;
+  result?: WebhookSendResult;
+  err: unknown;
+  startedAt: number;
+}): WebhookDeliveryInput {
   const retryable = isDispatchError(err) && err.retryable;
   return {
     ...base,
@@ -171,10 +183,16 @@ export async function deliverWebhook({
     });
     // Throws a classified DispatchError on a non-2xx (ADR-040 §5).
     assertWebhookDelivered({ result, triggerName });
-    await recordDelivery(recorder, successRow(baseRow, result, startedAt));
+    await recordDelivery({
+      recorder,
+      row: successRow({ base: baseRow, result, startedAt }),
+    });
     return result;
   } catch (err) {
-    await recordDelivery(recorder, failureRow(baseRow, result, err, startedAt));
+    await recordDelivery({
+      recorder,
+      row: failureRow({ base: baseRow, result, err, startedAt }),
+    });
     throw err;
   }
 }

--- a/langwatch/src/server/triggers/deliverWebhook.ts
+++ b/langwatch/src/server/triggers/deliverWebhook.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "@langwatch/observability";
 import {
   redactHeadersForLog,
+  redactWebhookUrlForLog,
   type WebhookMethod,
 } from "~/automations/providers/definitions/webhook/shared";
 import { isDispatchError } from "~/server/event-sourcing/outbox/dispatchError";
@@ -22,6 +23,111 @@ export type WebhookDeliveryRecorder = (
 /** How much of the receiver's response the log row keeps (schema caps aside). */
 const LOG_BODY_SNIPPET_CHARS = 4000;
 
+/** The request half of a delivery row — the same across every attempt of one
+ *  fire. URL and header values are redacted before they reach the log. */
+type WebhookDeliveryBaseRow = Pick<
+  WebhookDeliveryInput,
+  | "projectId"
+  | "triggerId"
+  | "dispatchId"
+  | "requestMethod"
+  | "requestUrl"
+  | "requestHeaders"
+>;
+
+function buildBaseRow({
+  projectId,
+  triggerId,
+  eventId,
+  method,
+  url,
+  headers,
+}: {
+  projectId: string;
+  triggerId: string;
+  eventId: string;
+  method?: WebhookMethod;
+  url: string;
+  headers?: Record<string, string>;
+}): WebhookDeliveryBaseRow {
+  return {
+    projectId,
+    triggerId,
+    dispatchId: eventId,
+    requestMethod: method ?? "POST",
+    requestUrl: redactWebhookUrlForLog(url),
+    requestHeaders: redactHeadersForLog(headers ?? {}),
+  };
+}
+
+/** Best-effort recorder wrapper: a logging failure never breaks dispatch. */
+async function recordDelivery(
+  recorder: WebhookDeliveryRecorder | undefined,
+  row: WebhookDeliveryInput,
+): Promise<void> {
+  if (!recorder) return;
+  try {
+    await recorder(row);
+  } catch (err) {
+    logger.warn(
+      { projectId: row.projectId, triggerId: row.triggerId, error: err },
+      "Failed to record webhook delivery attempt — dispatch unaffected",
+    );
+  }
+}
+
+function successRow(
+  base: WebhookDeliveryBaseRow,
+  result: WebhookSendResult,
+  startedAt: number,
+): WebhookDeliveryInput {
+  return {
+    ...base,
+    responseStatus: result.status,
+    responseBody: result.body.slice(0, LOG_BODY_SNIPPET_CHARS),
+    latencyMs: Date.now() - startedAt,
+    outcome: "success",
+  };
+}
+
+function failureRow(
+  base: WebhookDeliveryBaseRow,
+  result: WebhookSendResult | undefined,
+  err: unknown,
+  startedAt: number,
+): WebhookDeliveryInput {
+  const retryable = isDispatchError(err) && err.retryable;
+  return {
+    ...base,
+    // A result means a non-2xx classified by assert (status carries the
+    // failure); no result means sendWebhook threw before responding
+    // (transport / SSRF / rate-limit), so the message is the detail.
+    responseStatus: result?.status ?? null,
+    responseBody: result ? result.body.slice(0, LOG_BODY_SNIPPET_CHARS) : null,
+    latencyMs: Date.now() - startedAt,
+    error: result ? null : err instanceof Error ? err.message : String(err),
+    outcome: retryable ? "retryable" : "terminal",
+  };
+}
+
+interface DeliverWebhookArgs {
+  /** The sender — defaults to the real one; the graph-alert path injects its
+   *  own `deps.sendWebhook` so its unit tests keep the mock seam. */
+  send?: typeof sendWebhook;
+  recorder?: WebhookDeliveryRecorder;
+  projectId: string;
+  triggerId: string;
+  /** Stable per-fire id — the delivery log's `dispatchId` and the sent
+   *  `X-LangWatch-Event-Id`, so attempts of one fire group together. */
+  eventId: string;
+  url: string;
+  method?: WebhookMethod;
+  /** Decrypted headers; redacted before they reach the log row. */
+  headers?: Record<string, string>;
+  body: string;
+  triggerName: string;
+}
+
 /**
  * Send one webhook dispatch AND record its outcome to the delivery log
  * (ADR-040 §5 + §6) as a single unit: on 2xx a `success` row, on a classified
@@ -41,43 +147,16 @@ export async function deliverWebhook({
   headers,
   body,
   triggerName,
-}: {
-  /** The sender — defaults to the real one; the graph-alert path injects its
-   *  own `deps.sendWebhook` so its unit tests keep the mock seam. */
-  send?: typeof sendWebhook;
-  recorder?: WebhookDeliveryRecorder;
-  projectId: string;
-  triggerId: string;
-  /** Stable per-fire id — the delivery log's `dispatchId` and the sent
-   *  `X-LangWatch-Event-Id`, so attempts of one fire group together. */
-  eventId: string;
-  url: string;
-  method?: WebhookMethod;
-  /** Decrypted headers; redacted before they reach the log row. */
-  headers?: Record<string, string>;
-  body: string;
-  triggerName: string;
-}): Promise<WebhookSendResult> {
+}: DeliverWebhookArgs): Promise<WebhookSendResult> {
   const startedAt = Date.now();
-  const baseRow = {
+  const baseRow = buildBaseRow({
     projectId,
     triggerId,
-    dispatchId: eventId,
-    requestMethod: method ?? "POST",
-    requestUrl: url,
-    requestHeaders: redactHeadersForLog(headers ?? {}),
-  };
-  const safeRecord = async (row: WebhookDeliveryInput) => {
-    if (!recorder) return;
-    try {
-      await recorder(row);
-    } catch (err) {
-      logger.warn(
-        { projectId, triggerId, error: err },
-        "Failed to record webhook delivery attempt — dispatch unaffected",
-      );
-    }
-  };
+    eventId,
+    method,
+    url,
+    headers,
+  });
 
   let result: WebhookSendResult | undefined;
   try {
@@ -92,29 +171,10 @@ export async function deliverWebhook({
     });
     // Throws a classified DispatchError on a non-2xx (ADR-040 §5).
     assertWebhookDelivered({ result, triggerName });
-    await safeRecord({
-      ...baseRow,
-      responseStatus: result.status,
-      responseBody: result.body.slice(0, LOG_BODY_SNIPPET_CHARS),
-      latencyMs: Date.now() - startedAt,
-      outcome: "success",
-    });
+    await recordDelivery(recorder, successRow(baseRow, result, startedAt));
     return result;
   } catch (err) {
-    const retryable = isDispatchError(err) && err.retryable;
-    await safeRecord({
-      ...baseRow,
-      // A result means a non-2xx classified by assert (status carries the
-      // failure); no result means sendWebhook threw before responding
-      // (transport / SSRF / rate-limit), so the message is the detail.
-      responseStatus: result?.status ?? null,
-      responseBody: result
-        ? result.body.slice(0, LOG_BODY_SNIPPET_CHARS)
-        : null,
-      latencyMs: Date.now() - startedAt,
-      error: result ? null : err instanceof Error ? err.message : String(err),
-      outcome: retryable ? "retryable" : "terminal",
-    });
+    await recordDelivery(recorder, failureRow(baseRow, result, err, startedAt));
     throw err;
   }
 }

--- a/langwatch/src/server/triggers/httpDestination.ts
+++ b/langwatch/src/server/triggers/httpDestination.ts
@@ -1,5 +1,9 @@
 import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
-import { ssrfSafeFetch } from "~/utils/ssrfProtection";
+import {
+  fetchWithResolvedIp,
+  ssrfSafeFetch,
+  type SSRFValidationResult,
+} from "~/utils/ssrfProtection";
 
 /** Total-request timeout — a slowloris endpoint can't pin a worker slot. */
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -25,6 +29,15 @@ export interface HttpDestinationRequest {
   maxResponseBytes?: number;
   /** Short label woven into DispatchError messages (e.g. the trigger name). */
   contextLabel: string;
+  /**
+   * Override the SSRF validator — e.g. a `createSSRFValidator({ blockLocal:
+   * true, allowedHosts: [] })` instance that blocks private IPs regardless of
+   * the global BLOCK_LOCAL_HTTP_CALLS toggle (ADR-040 §4). When set, redirects
+   * are NOT followed: hop re-validation inside `fetchWithResolvedIp` uses the
+   * default (env-gated) validator, so following a redirect would silently drop
+   * back to the weaker policy. A 3xx is returned to the caller to classify.
+   */
+  validateUrl?: (url: string) => Promise<SSRFValidationResult>;
 }
 
 export interface HttpDestinationResponse {
@@ -102,10 +115,11 @@ export async function sendHttpDestination({
   timeoutMs = DEFAULT_TIMEOUT_MS,
   maxResponseBytes = DEFAULT_MAX_RESPONSE_BYTES,
   contextLabel,
+  validateUrl,
 }: HttpDestinationRequest): Promise<HttpDestinationResponse> {
   let response: Awaited<ReturnType<typeof ssrfSafeFetch>>;
   try {
-    response = await ssrfSafeFetch(url, {
+    const init = {
       method,
       headers,
       body,
@@ -115,13 +129,26 @@ export async function sendHttpDestination({
       // on every one of up to 10 redirect hops.
       headersTimeoutMs: timeoutMs,
       bodyTimeoutMs: timeoutMs,
-    });
+    };
+    if (validateUrl) {
+      const validated = await validateUrl(url);
+      // MAX_SAFE_INTEGER pre-exhausts the redirect budget: the first 3xx with
+      // a Location throws instead of hopping through the weaker default
+      // validator (see `validateUrl` on the request type).
+      response = await fetchWithResolvedIp(validated, {
+        ...init,
+        _redirectCount: Number.MAX_SAFE_INTEGER,
+      });
+    } else {
+      response = await ssrfSafeFetch(url, init);
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    // An SSRF rejection is a permanent misconfiguration; DNS / connection /
-    // timeout failures are transient and worth a retry.
+    // An SSRF rejection is a permanent misconfiguration (as is a redirect on
+    // the strict-validator path — the endpoint's shape, not a blip); DNS /
+    // connection / timeout failures are transient and worth a retry.
     const ssrfBlocked =
-      /ssrf|blocked|not allowed|private|loopback|metadata|link-local|disallowed/i.test(
+      /ssrf|blocked|not allowed|private|loopback|metadata|link-local|disallowed|too many redirects/i.test(
         message,
       );
     throw new DispatchError({

--- a/langwatch/src/server/triggers/httpDestination.ts
+++ b/langwatch/src/server/triggers/httpDestination.ts
@@ -1,4 +1,7 @@
-import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import {
+  DispatchError,
+  parseRetryAfterMs,
+} from "~/server/event-sourcing/outbox/dispatchError";
 import {
   fetchWithResolvedIp,
   ssrfSafeFetch,
@@ -45,6 +48,9 @@ export interface HttpDestinationResponse {
   status: number;
   /** Response body, truncated at {@link HttpDestinationRequest.maxResponseBytes}. */
   body: string;
+  /** Parsed `Retry-After` (ms) when the receiver sent one — a backpressure
+   *  hint the caller can fold into its retry backoff (ADR-040 §5). */
+  retryAfterMs?: number;
 }
 
 type ResponseBodyStream = Awaited<ReturnType<typeof ssrfSafeFetch>>["body"];
@@ -168,5 +174,9 @@ export async function sendHttpDestination({
     // carries the outcome; leave the snippet empty.
   }
 
-  return { status: response.status, body: responseBody };
+  return {
+    status: response.status,
+    body: responseBody,
+    retryAfterMs: parseRetryAfterMs(response.headers?.get("retry-after")),
+  };
 }

--- a/langwatch/src/server/triggers/httpDestination.ts
+++ b/langwatch/src/server/triggers/httpDestination.ts
@@ -35,7 +35,8 @@ export interface HttpDestinationRequest {
    * the global BLOCK_LOCAL_HTTP_CALLS toggle (ADR-040 §4). When set, redirects
    * are NOT followed: hop re-validation inside `fetchWithResolvedIp` uses the
    * default (env-gated) validator, so following a redirect would silently drop
-   * back to the weaker policy. A 3xx is returned to the caller to classify.
+   * back to the weaker policy. A 3xx with a Location throws terminally; a
+   * bare 3xx is returned to the caller to classify.
    */
   validateUrl?: (url: string) => Promise<SSRFValidationResult>;
 }
@@ -132,12 +133,11 @@ export async function sendHttpDestination({
     };
     if (validateUrl) {
       const validated = await validateUrl(url);
-      // MAX_SAFE_INTEGER pre-exhausts the redirect budget: the first 3xx with
-      // a Location throws instead of hopping through the weaker default
-      // validator (see `validateUrl` on the request type).
+      // Redirects are refused outright: a hop would re-validate through the
+      // weaker default policy (see `validateUrl` on the request type).
       response = await fetchWithResolvedIp(validated, {
         ...init,
-        _redirectCount: Number.MAX_SAFE_INTEGER,
+        followRedirects: false,
       });
     } else {
       response = await ssrfSafeFetch(url, init);
@@ -148,7 +148,7 @@ export async function sendHttpDestination({
     // the strict-validator path — the endpoint's shape, not a blip); DNS /
     // connection / timeout failures are transient and worth a retry.
     const ssrfBlocked =
-      /ssrf|blocked|not allowed|private|loopback|metadata|link-local|disallowed|too many redirects/i.test(
+      /ssrf|blocked|not allowed|private|loopback|metadata|link-local|disallowed|redirects are not followed|too many redirects/i.test(
         message,
       );
     throw new DispatchError({

--- a/langwatch/src/server/triggers/sendWebhook.ts
+++ b/langwatch/src/server/triggers/sendWebhook.ts
@@ -1,0 +1,142 @@
+import { isIP } from "node:net";
+import {
+  sanitizeWebhookHeaders,
+  validateWebhookUrlShape,
+  type WebhookMethod,
+} from "~/automations/providers/definitions/webhook/shared";
+import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import {
+  createSSRFValidator,
+  isPrivateOrLocalhostIP,
+} from "~/utils/ssrfProtection";
+import { sendHttpDestination } from "./httpDestination";
+
+/**
+ * The webhook channel's SSRF policy (ADR-040 §4): private-IP / localhost
+ * blocking is FORCED ON regardless of the global BLOCK_LOCAL_HTTP_CALLS
+ * toggle — a customer-supplied URL fired from our workers must never reach
+ * `10.x` / `localhost`, even in deployments that relax the toggle for their
+ * own internal integrations.
+ */
+const validateWebhookUrl = createSSRFValidator({
+  blockLocal: true,
+  allowedHosts: [],
+});
+
+/**
+ * If the URL's host is an IP literal that is private / loopback / link-local,
+ * return it (brackets stripped); else null. `new URL(...).hostname` keeps IPv6
+ * in brackets, which `isIP` rejects — so a bracketed `[::1]` would otherwise
+ * slip past the validator's IP-literal check and fail as an unresolvable
+ * hostname (a *retryable* error) rather than a terminal block. This closes
+ * that gap terminally at the webhook layer without forking `ssrfProtection`.
+ */
+function privateIpLiteral(url: string): string | null {
+  let host: string;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return null;
+  }
+  const bare =
+    host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  return isIP(bare) !== 0 && isPrivateOrLocalhostIP(bare) ? bare : null;
+}
+
+export interface WebhookSendInput {
+  url: string;
+  method?: WebhookMethod;
+  /** Customer-configured static headers; reserved keys are stripped here
+   *  again (defense in depth over the save-time sanitize). */
+  headers?: Record<string, string>;
+  /** The rendered JSON body. */
+  body: string;
+  /** Woven into DispatchError messages and delivery logs. */
+  triggerName: string;
+  /** Marks the request as a drawer test fire via a non-suppressible
+   *  X-LangWatch-Test-Fire header (ADR-040 §1). */
+  testFire?: boolean;
+}
+
+export interface WebhookSendResult {
+  status: number;
+  /** Response snippet, already size-capped by the HTTP utility. */
+  body: string;
+}
+
+/**
+ * Sends one webhook automation request (ADR-040) — the notify channel where
+ * the CUSTOMER supplies the endpoint. Delivery goes through the shared
+ * SSRF-fenced HTTP utility with the strict webhook validator; redirects are
+ * not followed (see `HttpDestinationRequest.validateUrl`). The status is
+ * returned for the caller to classify via {@link assertWebhookDelivered} —
+ * the drawer's test fire wants the raw status to show the author, dispatch
+ * wants the DispatchError.
+ */
+export async function sendWebhook({
+  url,
+  method = "POST",
+  headers = {},
+  body,
+  triggerName,
+  testFire = false,
+}: WebhookSendInput): Promise<WebhookSendResult> {
+  const label = `Webhook for trigger "${triggerName}"`;
+  const shapeProblem = validateWebhookUrlShape(url);
+  if (shapeProblem) {
+    throw new DispatchError({
+      message: `${label}: ${shapeProblem}`,
+      retryable: false,
+    });
+  }
+  // Terminal-block a private/loopback IP literal (incl. bracketed IPv6) up
+  // front — the SSRF validator below fails these closed too, but as a
+  // retryable "unresolvable host" rather than the permanent block it is.
+  const privateLiteral = privateIpLiteral(url);
+  if (privateLiteral) {
+    throw new DispatchError({
+      message: `${label}: the destination "${privateLiteral}" is a private or loopback address, which is not allowed.`,
+      retryable: false,
+    });
+  }
+  return sendHttpDestination({
+    url,
+    method,
+    headers: {
+      ...sanitizeWebhookHeaders(headers),
+      "Content-Type": "application/json",
+      ...(testFire ? { "X-LangWatch-Test-Fire": "true" } : {}),
+    },
+    body,
+    contextLabel: label,
+    validateUrl: validateWebhookUrl,
+  });
+}
+
+/** How much of the receiver's response rides in an error message. */
+const ERROR_SNIPPET_CHARS = 300;
+
+/**
+ * ADR-040 §5 retry-vs-terminal classification. 2xx returns; 5xx / 429 / 408
+ * throw retryable (the outbox backs off and re-attempts); any other status —
+ * including 3xx, which the strict sender refuses to follow — throws terminal,
+ * because retrying a misconfigured endpoint just spams it.
+ */
+export function assertWebhookDelivered({
+  result,
+  triggerName,
+}: {
+  result: WebhookSendResult;
+  triggerName: string;
+}): void {
+  const { status } = result;
+  if (status >= 200 && status < 300) return;
+  const snippet = result.body.slice(0, ERROR_SNIPPET_CHARS).trim();
+  const retryable = status >= 500 || status === 429 || status === 408;
+  throw new DispatchError({
+    message:
+      `Webhook for trigger "${triggerName}" received HTTP ${status}` +
+      (snippet ? `: ${snippet}` : ""),
+    retryable,
+  });
+}

--- a/langwatch/src/server/triggers/sendWebhook.ts
+++ b/langwatch/src/server/triggers/sendWebhook.ts
@@ -2,6 +2,7 @@ import { isIP } from "node:net";
 import {
   sanitizeWebhookHeaders,
   validateWebhookUrlShape,
+  WEBHOOK_HEADER_VALUE_KEPT,
   type WebhookMethod,
 } from "~/automations/providers/definitions/webhook/shared";
 import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
@@ -99,11 +100,19 @@ export async function sendWebhook({
       retryable: false,
     });
   }
+  // An unresolved kept sentinel means "the saved value" and should have been
+  // resolved by the caller (save / test-fire / decrypt-at-dispatch) — never
+  // send the literal marker to the customer's endpoint.
+  const resolvedHeaders = Object.fromEntries(
+    Object.entries(headers).filter(
+      ([, value]) => value !== WEBHOOK_HEADER_VALUE_KEPT,
+    ),
+  );
   return sendHttpDestination({
     url,
     method,
     headers: {
-      ...sanitizeWebhookHeaders(headers),
+      ...sanitizeWebhookHeaders(resolvedHeaders),
       "Content-Type": "application/json",
       ...(testFire ? { "X-LangWatch-Test-Fire": "true" } : {}),
     },

--- a/langwatch/src/server/triggers/sendWebhook.ts
+++ b/langwatch/src/server/triggers/sendWebhook.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { isIP } from "node:net";
 import {
   sanitizeWebhookHeaders,
@@ -6,6 +7,7 @@ import {
   type WebhookMethod,
 } from "~/automations/providers/definitions/webhook/shared";
 import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import { rateLimit } from "~/server/rateLimit";
 import {
   createSSRFValidator,
   isPrivateOrLocalhostIP,
@@ -44,6 +46,14 @@ function privateIpLiteral(url: string): string | null {
   return isIP(bare) !== 0 && isPrivateOrLocalhostIP(bare) ? bare : null;
 }
 
+/**
+ * Per-project hourly cap on real webhook dispatches (ADR-040 §4) — a backstop
+ * against an immediate-cadence trigger firing per-match turning our worker
+ * fleet into an outbound flood. A safety limit, not a billing knob; promote to
+ * an env var if a customer legitimately needs a higher ceiling.
+ */
+export const WEBHOOK_DISPATCH_HOURLY_CAP = 1000;
+
 export interface WebhookSendInput {
   url: string;
   method?: WebhookMethod;
@@ -55,14 +65,26 @@ export interface WebhookSendInput {
   /** Woven into DispatchError messages and delivery logs. */
   triggerName: string;
   /** Marks the request as a drawer test fire via a non-suppressible
-   *  X-LangWatch-Test-Fire header (ADR-040 §1). */
+   *  X-LangWatch-Test-Fire header (ADR-040 §1). Test fires skip the
+   *  per-project dispatch cap (they carry the drawer's per-user limit). */
   testFire?: boolean;
+  /** The firing project — enables the per-project dispatch rate limit
+   *  (ADR-040 §4). Omitted for a test fire. */
+  projectId?: string;
+  /** Stable per-dispatch identity, sent as `X-LangWatch-Event-Id` (ADR-040
+   *  §5): every retry of the same logical fire reuses it so a receiver can
+   *  dedupe. A fresh UUID is generated when absent (e.g. a test fire). */
+  eventId?: string;
 }
 
 export interface WebhookSendResult {
   status: number;
   /** Response snippet, already size-capped by the HTTP utility. */
   body: string;
+  /** Parsed `Retry-After` (ms) the receiver asked us to back off by. */
+  retryAfterMs?: number;
+  /** The `X-LangWatch-Event-Id` actually sent — surfaced for the delivery log. */
+  eventId: string;
 }
 
 /**
@@ -81,6 +103,8 @@ export async function sendWebhook({
   body,
   triggerName,
   testFire = false,
+  projectId,
+  eventId,
 }: WebhookSendInput): Promise<WebhookSendResult> {
   const label = `Webhook for trigger "${triggerName}"`;
   const shapeProblem = validateWebhookUrlShape(url);
@@ -100,6 +124,24 @@ export async function sendWebhook({
       retryable: false,
     });
   }
+  // Per-project dispatch cap (ADR-040 §4) — a real fire only; test fires ride
+  // the drawer's per-user limit. Over the cap throws RETRYABLE with a
+  // Retry-After to the window reset: a legitimate burst backs off and drains,
+  // a sustained flood dead-letters after the outbox's max attempts.
+  if (projectId && !testFire) {
+    const limit = await rateLimit({
+      key: `webhook-dispatch:${projectId}`,
+      windowSeconds: 3600,
+      max: WEBHOOK_DISPATCH_HOURLY_CAP,
+    });
+    if (!limit.allowed) {
+      throw new DispatchError({
+        message: `${label}: project webhook dispatch cap (${WEBHOOK_DISPATCH_HOURLY_CAP}/hour) reached — backing off.`,
+        retryable: true,
+        retryAfterMs: Math.max(0, limit.resetAt - Date.now()),
+      });
+    }
+  }
   // An unresolved kept sentinel means "the saved value" and should have been
   // resolved by the caller (save / test-fire / decrypt-at-dispatch) — never
   // send the literal marker to the customer's endpoint.
@@ -108,18 +150,23 @@ export async function sendWebhook({
       ([, value]) => value !== WEBHOOK_HEADER_VALUE_KEPT,
     ),
   );
-  return sendHttpDestination({
+  // Stable across retries when the caller supplies it (dispatch); a fresh id
+  // for a test fire, which has no retries to dedupe.
+  const resolvedEventId = eventId ?? randomUUID();
+  const response = await sendHttpDestination({
     url,
     method,
     headers: {
       ...sanitizeWebhookHeaders(resolvedHeaders),
       "Content-Type": "application/json",
+      "X-LangWatch-Event-Id": resolvedEventId,
       ...(testFire ? { "X-LangWatch-Test-Fire": "true" } : {}),
     },
     body,
     contextLabel: label,
     validateUrl: validateWebhookUrl,
   });
+  return { ...response, eventId: resolvedEventId };
 }
 
 /** How much of the receiver's response rides in an error message. */
@@ -135,7 +182,7 @@ export function assertWebhookDelivered({
   result,
   triggerName,
 }: {
-  result: WebhookSendResult;
+  result: Pick<WebhookSendResult, "status" | "body" | "retryAfterMs">;
   triggerName: string;
 }): void {
   const { status } = result;
@@ -147,5 +194,8 @@ export function assertWebhookDelivered({
       `Webhook for trigger "${triggerName}" received HTTP ${status}` +
       (snippet ? `: ${snippet}` : ""),
     retryable,
+    // Honor the receiver's backpressure on a retryable status (ADR-040 §5);
+    // the queue folds it into its backoff as a floor.
+    retryAfterMs: retryable ? result.retryAfterMs : undefined,
   });
 }

--- a/langwatch/src/server/triggers/sendWebhook.ts
+++ b/langwatch/src/server/triggers/sendWebhook.ts
@@ -124,6 +124,18 @@ export async function sendWebhook({
       retryable: false,
     });
   }
+  // Production-dispatch invariant (ADR-040 §4/§5): a real fire MUST carry a
+  // projectId (so the per-project cap below applies — omitting it would let an
+  // uncapped flood through) and a stable eventId (so every retry dedupes —
+  // omitting it mints a fresh id per attempt). Only a test fire may omit them.
+  // Fail terminally so a mis-wired caller dead-letters instead of leaking past
+  // these gates.
+  if (!testFire && (!projectId || !eventId)) {
+    throw new DispatchError({
+      message: `${label}: a production webhook dispatch requires projectId and eventId.`,
+      retryable: false,
+    });
+  }
   // Per-project dispatch cap (ADR-040 §4) — a real fire only; test fires ride
   // the drawer's per-user limit. Over the cap throws RETRYABLE with a
   // Retry-After to the window reset: a legitimate burst backs off and drains,

--- a/langwatch/src/server/triggers/triggerNotifier.ts
+++ b/langwatch/src/server/triggers/triggerNotifier.ts
@@ -4,6 +4,7 @@ import {
 } from "@slack/webhook";
 import type { TriggerNotifier } from "~/server/app-layer/triggers/trigger-template.service";
 import { sendEmail } from "~/server/mailer/emailSender";
+import { assertWebhookDelivered, sendWebhook } from "./sendWebhook";
 import { isSlackWebhookUrl } from "./slackWebhookGuard";
 import { postSlackChatMessage } from "./slackWebApi";
 
@@ -28,6 +29,21 @@ export const liveTriggerNotifier: TriggerNotifier = {
     await new IncomingWebhook(webhook).send(
       payload as IncomingWebhookSendArguments,
     );
+  },
+  async sendWebhook({ url, method, headers, body, triggerName }) {
+    // The full SSRF-fenced sender — same path a real fire takes — with the
+    // non-suppressible test-fire marker header (ADR-040 §1). Non-2xx throws
+    // the classified DispatchError so the author sees what the endpoint said.
+    const result = await sendWebhook({
+      url,
+      method,
+      headers,
+      body,
+      triggerName,
+      testFire: true,
+    });
+    assertWebhookDelivered({ result, triggerName });
+    return { status: result.status };
   },
   async sendSlackBot({ token, channel, payload }) {
     // The Web API surface — renders the gated chart/table/alert blocks. Posts to

--- a/langwatch/src/shared/templating/__tests__/renderWebhookBody.unit.test.ts
+++ b/langwatch/src/shared/templating/__tests__/renderWebhookBody.unit.test.ts
@@ -119,27 +119,30 @@ describe("renderWebhookBody", () => {
   });
 
   describe("when the custom template renders invalid JSON", () => {
-    it("falls back to the default envelope and surfaces the error", async () => {
+    it("fails closed — no body, no default fallback, error surfaced", async () => {
       const rendered = await renderWebhookBody({
         template: "not json at all {{ trigger.name }}",
         context: makeContext(),
       });
-      expect(rendered.usedDefault).toBe(true);
+      // Falling back to the default would leak the full-trace envelope the
+      // customer intentionally omitted — so a failed custom render sends nothing.
+      expect(rendered.failed).toBe(true);
+      expect(rendered.usedDefault).toBe(false);
+      expect(rendered.body).toBe("");
       expect(rendered.errors.length).toBeGreaterThan(0);
-      const parsed = JSON.parse(rendered.body) as { event: string };
-      expect(parsed.event).toBe("trigger.matched");
     });
   });
 
   describe("when the custom template throws at render", () => {
-    it("falls back to the default envelope and surfaces the error", async () => {
+    it("fails closed — no body, no default fallback, error surfaced", async () => {
       const rendered = await renderWebhookBody({
         template: "{% unknown_tag %}",
         context: makeContext(),
       });
-      expect(rendered.usedDefault).toBe(true);
+      expect(rendered.failed).toBe(true);
+      expect(rendered.usedDefault).toBe(false);
+      expect(rendered.body).toBe("");
       expect(rendered.errors.length).toBeGreaterThan(0);
-      expect(() => JSON.parse(rendered.body)).not.toThrow();
     });
   });
 });

--- a/langwatch/src/shared/templating/__tests__/renderWebhookBody.unit.test.ts
+++ b/langwatch/src/shared/templating/__tests__/renderWebhookBody.unit.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALERT_TRIGGER_DEFAULTS,
+  REPORT_TRIGGER_DEFAULTS,
+} from "../defaults";
+import { renderWebhookBody } from "../renderWebhookBody";
+import {
+  buildExampleReportTemplateContext,
+  buildGraphAlertTemplateContext,
+} from "../templateContext";
+import { makeContext, makeMatch } from "./fixtures";
+
+// Trace content that would break out of a naive JSON template — the `| json`
+// discipline in the defaults must keep the envelope parseable.
+const JSON_BREAKOUT = 'quote " brace } bracket ] newline\nend';
+
+describe("renderWebhookBody", () => {
+  describe("when no custom template is provided", () => {
+    it("renders the default trace envelope as valid JSON", async () => {
+      const rendered = await renderWebhookBody({
+        template: null,
+        context: makeContext(),
+      });
+      expect(rendered.usedDefault).toBe(true);
+      expect(rendered.errors).toEqual([]);
+      const parsed = JSON.parse(rendered.body) as {
+        event: string;
+        trigger: { id: string; name: string };
+        matches: { traceId: string; input: string }[];
+      };
+      expect(parsed.event).toBe("trigger.matched");
+      expect(parsed.trigger).toMatchObject({
+        id: "trg_1",
+        name: "High latency",
+      });
+      expect(parsed.matches[0]).toMatchObject({
+        traceId: "trace_1",
+        input: "what is the weather",
+      });
+    });
+
+    it("keeps the envelope parseable when trace content carries JSON control characters", async () => {
+      const rendered = await renderWebhookBody({
+        template: null,
+        context: makeContext({
+          matches: [
+            makeMatch({
+              trace: {
+                id: "trace_1",
+                input: JSON_BREAKOUT,
+                output: JSON_BREAKOUT,
+                url: "https://app.langwatch.ai/acme/traces/trace_1",
+                metadata: {},
+              },
+            }),
+          ],
+        }),
+      });
+      const parsed = JSON.parse(rendered.body) as {
+        matches: { input: string }[];
+      };
+      expect(parsed.matches[0]!.input).toBe(JSON_BREAKOUT);
+    });
+
+    it("renders the alert default envelope as valid JSON", async () => {
+      const rendered = await renderWebhookBody({
+        template: null,
+        context: buildGraphAlertTemplateContext({
+          trigger: { id: "trg_1", name: "High latency", alertType: "WARNING" },
+          graph: { id: "graph_1", name: "Latency p95" },
+          metric: { label: "Latency p95", seriesName: "0/duration/p95" },
+          condition: { operator: "gt", threshold: 500, timePeriodMinutes: 60 },
+          currentValue: 712,
+          occurredAt: new Date("2026-06-21T10:00:00.000Z"),
+          reason: "real-time",
+          project: { id: "proj_1", name: "Acme", slug: "acme" },
+          baseHost: "https://app.langwatch.ai",
+        }),
+        defaultBody: ALERT_TRIGGER_DEFAULTS.webhookBody,
+      });
+      const parsed = JSON.parse(rendered.body) as {
+        event: string;
+        metric: { label: string };
+        currentValue: number;
+      };
+      expect(parsed.event).toBe("alert.fired");
+      expect(parsed.metric.label).toBe("Latency p95");
+      expect(parsed.currentValue).toBe(712);
+    });
+
+    it("renders the report default envelope as valid JSON", async () => {
+      const rendered = await renderWebhookBody({
+        template: null,
+        context: buildExampleReportTemplateContext({
+          baseHost: "https://app.langwatch.ai",
+          project: { name: "Acme", slug: "acme" },
+          trigger: { name: "Weekly report" },
+          sourceKind: "traceQuery",
+        }),
+        defaultBody: REPORT_TRIGGER_DEFAULTS.webhookBody,
+      });
+      const parsed = JSON.parse(rendered.body) as { event: string };
+      expect(parsed.event).toBe("report.scheduled");
+    });
+  });
+
+  describe("when a custom template is provided", () => {
+    it("renders it against the context", async () => {
+      const rendered = await renderWebhookBody({
+        template: '{ "name": {{ trigger.name | json }}, "n": {{ digest.count }} }',
+        context: makeContext(),
+      });
+      expect(rendered.usedDefault).toBe(false);
+      expect(JSON.parse(rendered.body)).toEqual({
+        name: "High latency",
+        n: 1,
+      });
+    });
+  });
+
+  describe("when the custom template renders invalid JSON", () => {
+    it("falls back to the default envelope and surfaces the error", async () => {
+      const rendered = await renderWebhookBody({
+        template: "not json at all {{ trigger.name }}",
+        context: makeContext(),
+      });
+      expect(rendered.usedDefault).toBe(true);
+      expect(rendered.errors.length).toBeGreaterThan(0);
+      const parsed = JSON.parse(rendered.body) as { event: string };
+      expect(parsed.event).toBe("trigger.matched");
+    });
+  });
+
+  describe("when the custom template throws at render", () => {
+    it("falls back to the default envelope and surfaces the error", async () => {
+      const rendered = await renderWebhookBody({
+        template: "{% unknown_tag %}",
+        context: makeContext(),
+      });
+      expect(rendered.usedDefault).toBe(true);
+      expect(rendered.errors.length).toBeGreaterThan(0);
+      expect(() => JSON.parse(rendered.body)).not.toThrow();
+    });
+  });
+});

--- a/langwatch/src/shared/templating/defaults.ts
+++ b/langwatch/src/shared/templating/defaults.ts
@@ -159,16 +159,61 @@ export const DEFAULT_ALERT_SLACK_BLOCK_KIT_TEMPLATE = `[
 ]`;
 
 /**
- * The four default-template strings a renderer needs, grouped together
- * to keep email + slack defaults aligned. Callers select the set that
- * matches the trigger directly — `ALERT_TRIGGER_DEFAULTS` for custom-graph
- * threshold alerts, `TRACE_TRIGGER_DEFAULTS` for trace triggers.
+ * ADR-040: default Liquid JSON bodies for the Webhook channel — a stable,
+ * documented envelope so a receiver can integrate without authoring a
+ * template. Every interpolated value goes through `| json` so trace content
+ * containing `"` or `}` cannot break out of the JSON structure (the JSON
+ * analog of `mrkdwn_escape`). Optional values are guarded with `{% if %}`
+ * rather than piped as nil, so the output always parses.
+ */
+export const DEFAULT_WEBHOOK_BODY_TEMPLATE = `{
+  "event": "trigger.matched",
+  "trigger": { "id": {{ trigger.id | json }}, "name": {{ trigger.name | json }}{% if trigger.alertType %}, "alertType": {{ trigger.alertType | json }}{% endif %} },
+  "project": { "name": {{ project.name | json }}, "slug": {{ project.slug | json }} },
+  "digest": { "count": {{ digest.count | json }} },
+  "matches": [{% for m in matches %}
+    { "traceId": {{ m.trace.id | json }}, "url": {{ m.trace.url | json }},
+      "input": {{ m.trace.input | json }}, "output": {{ m.trace.output | json }} }{% unless forloop.last %},{% endunless %}{% endfor %}
+  ]
+}`;
+
+export const DEFAULT_ALERT_WEBHOOK_BODY_TEMPLATE = `{
+  "event": "alert.fired",
+  "trigger": { "id": {{ trigger.id | json }}, "name": {{ trigger.name | json }}{% if trigger.alertType %}, "alertType": {{ trigger.alertType | json }}{% endif %} },
+  "project": { "name": {{ project.name | json }}, "slug": {{ project.slug | json }} },
+  "graph": { "name": {{ graph.name | json }}, "url": {{ graph.url | json }} },
+  "metric": { "label": {{ metric.label | json }} },
+  "condition": { "operator": {{ condition.operatorLabel | json }}, "threshold": {{ condition.threshold | json }}, "window": {{ condition.timePeriodLabel | json }} },
+  "currentValue": {{ currentValue | json }}{% if previousValue != nil %},
+  "previousValue": {{ previousValue | json }}{% endif %}
+}`;
+
+export const DEFAULT_REPORT_WEBHOOK_BODY_TEMPLATE = `{
+  "event": "report.scheduled",
+  "trigger": { "id": {{ trigger.id | json }}, "name": {{ trigger.name | json }} },
+  "project": { "name": {{ project.name | json }}, "slug": {{ project.slug | json }} },
+  "report": { "source": {{ report.sourceLabel | json }}, "schedule": {{ report.scheduleLabel | json }}, "isEmpty": {{ report.isEmpty | json }} },
+  "traces": [{% for t in traces %}
+    { "traceId": {{ t.traceId | json }}, "url": {{ t.url | json }}, "input": {{ t.input | json }} }{% unless forloop.last %},{% endunless %}{% endfor %}
+  ],
+  "charts": [{% for chart in charts %}
+    { "title": {{ chart.title | json }}{% unless chart.isEmpty %}, "total": {{ chart.total | json }}{% endunless %} }{% unless forloop.last %},{% endunless %}{% endfor %}
+  ],
+  "viewUrl": {{ viewUrl | json }}
+}`;
+
+/**
+ * The default-template strings a renderer needs, grouped together
+ * to keep email + slack + webhook defaults aligned. Callers select the set
+ * that matches the trigger directly — `ALERT_TRIGGER_DEFAULTS` for
+ * custom-graph threshold alerts, `TRACE_TRIGGER_DEFAULTS` for trace triggers.
  */
 export interface TriggerTemplateDefaults {
   emailSubject: string;
   emailBody: string;
   slackString: string;
   slackBlockKit: string;
+  webhookBody: string;
 }
 
 export const ALERT_TRIGGER_DEFAULTS: TriggerTemplateDefaults = {
@@ -176,6 +221,7 @@ export const ALERT_TRIGGER_DEFAULTS: TriggerTemplateDefaults = {
   emailBody: DEFAULT_ALERT_EMAIL_BODY_TEMPLATE,
   slackString: DEFAULT_ALERT_SLACK_TEMPLATE,
   slackBlockKit: DEFAULT_ALERT_SLACK_BLOCK_KIT_TEMPLATE,
+  webhookBody: DEFAULT_ALERT_WEBHOOK_BODY_TEMPLATE,
 };
 
 export const DEFAULT_SLACK_BLOCK_KIT_TEMPLATE = `[
@@ -240,6 +286,7 @@ export const TRACE_TRIGGER_DEFAULTS: TriggerTemplateDefaults = {
   emailBody: DEFAULT_EMAIL_BODY_TEMPLATE,
   slackString: DEFAULT_SLACK_TEMPLATE,
   slackBlockKit: DEFAULT_SLACK_BLOCK_KIT_TEMPLATE,
+  webhookBody: DEFAULT_WEBHOOK_BODY_TEMPLATE,
 };
 
 
@@ -324,6 +371,7 @@ export const REPORT_TRIGGER_DEFAULTS: TriggerTemplateDefaults = {
   emailBody: DEFAULT_REPORT_EMAIL_BODY_TEMPLATE,
   slackString: DEFAULT_REPORT_SLACK_TEMPLATE,
   slackBlockKit: DEFAULT_REPORT_SLACK_BLOCK_KIT_TEMPLATE,
+  webhookBody: DEFAULT_REPORT_WEBHOOK_BODY_TEMPLATE,
 };
 
 /** What a trigger is about — trace data, a custom-graph threshold alert, or a

--- a/langwatch/src/shared/templating/renderWebhookBody.ts
+++ b/langwatch/src/shared/templating/renderWebhookBody.ts
@@ -1,0 +1,105 @@
+import { DEFAULT_WEBHOOK_BODY_TEMPLATE } from "./defaults";
+import { renderLiquid } from "./engine";
+import { errorMessage } from "./renderWithFallback";
+import type {
+  GraphAlertTemplateContext,
+  ReportTemplateContext,
+  TemplateContext,
+} from "./templateContext";
+
+export interface RenderedWebhookBody {
+  /** The JSON string to send — always valid JSON. */
+  body: string;
+  /** True when the framework default was used (custom null, threw, or unparseable). */
+  usedDefault: boolean;
+  missingVariables: string[];
+  errors: string[];
+}
+
+async function renderJsonBody({
+  template,
+  context,
+}: {
+  template: string;
+  context: Record<string, unknown>;
+}): Promise<{ body: string; missingVariables: string[] }> {
+  const rendered = await renderLiquid({ template, context });
+  // Parse-then-reserialize: validates the render produced JSON and
+  // normalizes the whitespace the Liquid control flow leaves behind.
+  const parsed: unknown = JSON.parse(rendered.output);
+  return {
+    body: JSON.stringify(parsed),
+    missingVariables: rendered.missingVariables,
+  };
+}
+
+/**
+ * Renders a webhook automation's JSON body (ADR-040 §2) — the same Liquid
+ * engine and contexts Slack/email render against, with the Block Kit
+ * fall-back discipline: the output must `JSON.parse`, and a render throw or
+ * parse failure on the customer's template falls back to the framework
+ * default body, with the error captured for the operator. If even the
+ * default fails (it shouldn't — it is ours), a minimal static envelope is
+ * sent rather than nothing, so a delivery is never silently dropped over a
+ * template.
+ */
+export async function renderWebhookBody({
+  template,
+  context,
+  defaultBody = DEFAULT_WEBHOOK_BODY_TEMPLATE,
+}: {
+  /** The customer's Liquid JSON template, or null for the framework default. */
+  template: string | null;
+  context: TemplateContext | GraphAlertTemplateContext | ReportTemplateContext;
+  /** Per-source default override (`defaultsForSourceKind(...).webhookBody`). */
+  defaultBody?: string;
+}): Promise<RenderedWebhookBody> {
+  const ctx = context as unknown as Record<string, unknown>;
+
+  // `customMissing` captures the missing-variable diagnostics from the
+  // customer's own render, so a JSON.parse failure below still surfaces the
+  // author's typos rather than the framework default's (clean) diagnostics.
+  let customError: string | undefined;
+  let customMissing: string[] | undefined;
+  if (template != null && template.trim() !== "") {
+    try {
+      const rendered = await renderLiquid({ template, context: ctx });
+      customMissing = rendered.missingVariables;
+      const parsed: unknown = JSON.parse(rendered.output);
+      return {
+        body: JSON.stringify(parsed),
+        usedDefault: false,
+        missingVariables: rendered.missingVariables,
+        errors: [],
+      };
+    } catch (err) {
+      customError = errorMessage(err);
+    }
+  }
+
+  try {
+    const rendered = await renderJsonBody({
+      template: defaultBody,
+      context: ctx,
+    });
+    return {
+      body: rendered.body,
+      usedDefault: true,
+      missingVariables: customMissing ?? rendered.missingVariables,
+      errors: customError ? [customError] : [],
+    };
+  } catch (err) {
+    const trigger = ctx.trigger as { id?: string; name?: string } | undefined;
+    return {
+      body: JSON.stringify({
+        event: "trigger.fired",
+        trigger: { id: trigger?.id ?? null, name: trigger?.name ?? null },
+      }),
+      usedDefault: true,
+      missingVariables: [],
+      errors: [customError, errorMessage(err)].filter(
+        (e): e is string => e != null,
+      ),
+    };
+  }
+}

--- a/langwatch/src/shared/templating/renderWebhookBody.ts
+++ b/langwatch/src/shared/templating/renderWebhookBody.ts
@@ -8,10 +8,17 @@ import type {
 } from "./templateContext";
 
 export interface RenderedWebhookBody {
-  /** The JSON string to send — always valid JSON. */
+  /** The JSON string to send. Empty when a custom template failed to render
+   *  (`failed: true`); callers MUST NOT dispatch it. */
   body: string;
-  /** True when the framework default was used (custom null, threw, or unparseable). */
+  /** True when the framework default envelope was used (the custom template was
+   *  absent). Never true as a fallback for a broken custom template. */
   usedDefault: boolean;
+  /** True when a NON-EMPTY custom template threw or produced invalid JSON. The
+   *  caller must fail the dispatch rather than fall back — falling back would
+   *  leak the full-trace default the customer intentionally omitted (ADR-040
+   *  §2, fail closed). */
+  failed: boolean;
   missingVariables: string[];
   errors: string[];
 }
@@ -35,13 +42,17 @@ async function renderJsonBody({
 
 /**
  * Renders a webhook automation's JSON body (ADR-040 §2) — the same Liquid
- * engine and contexts Slack/email render against, with the Block Kit
- * fall-back discipline: the output must `JSON.parse`, and a render throw or
- * parse failure on the customer's template falls back to the framework
- * default body, with the error captured for the operator. If even the
- * default fails (it shouldn't — it is ours), a minimal static envelope is
- * sent rather than nothing, so a delivery is never silently dropped over a
- * template.
+ * engine and contexts Slack/email render against, but fail CLOSED: a non-empty
+ * custom template that throws or produces invalid JSON returns a render failure
+ * (`failed: true`, empty body), NEVER the framework default. Falling back would
+ * disclose the full-trace default body the customer intentionally left out of
+ * their payload — a data leak, not a convenience. Callers must reject a failed
+ * render before dispatching.
+ *
+ * The framework default is used ONLY when no custom template is supplied. If
+ * even the default fails (it is ours, so that is a framework bug), a minimal
+ * static envelope is returned so a default-body delivery is never silently
+ * dropped over a template.
  */
 export async function renderWebhookBody({
   template,
@@ -56,24 +67,25 @@ export async function renderWebhookBody({
 }): Promise<RenderedWebhookBody> {
   const ctx = context as unknown as Record<string, unknown>;
 
-  // `customMissing` captures the missing-variable diagnostics from the
-  // customer's own render, so a JSON.parse failure below still surfaces the
-  // author's typos rather than the framework default's (clean) diagnostics.
-  let customError: string | undefined;
-  let customMissing: string[] | undefined;
   if (template != null && template.trim() !== "") {
     try {
       const rendered = await renderLiquid({ template, context: ctx });
-      customMissing = rendered.missingVariables;
       const parsed: unknown = JSON.parse(rendered.output);
       return {
         body: JSON.stringify(parsed),
         usedDefault: false,
+        failed: false,
         missingVariables: rendered.missingVariables,
         errors: [],
       };
     } catch (err) {
-      customError = errorMessage(err);
+      return {
+        body: "",
+        usedDefault: false,
+        failed: true,
+        missingVariables: [],
+        errors: [errorMessage(err)],
+      };
     }
   }
 
@@ -85,8 +97,9 @@ export async function renderWebhookBody({
     return {
       body: rendered.body,
       usedDefault: true,
-      missingVariables: customMissing ?? rendered.missingVariables,
-      errors: customError ? [customError] : [],
+      failed: false,
+      missingVariables: rendered.missingVariables,
+      errors: [],
     };
   } catch (err) {
     const trigger = ctx.trigger as { id?: string; name?: string } | undefined;
@@ -96,10 +109,9 @@ export async function renderWebhookBody({
         trigger: { id: trigger?.id ?? null, name: trigger?.name ?? null },
       }),
       usedDefault: true,
+      failed: false,
       missingVariables: [],
-      errors: [customError, errorMessage(err)].filter(
-        (e): e is string => e != null,
-      ),
+      errors: [errorMessage(err)],
     };
   }
 }

--- a/langwatch/src/utils/ssrfProtection.ts
+++ b/langwatch/src/utils/ssrfProtection.ts
@@ -668,6 +668,9 @@ export async function fetchWithResolvedIp(
       const location = response.headers.get("location");
       if (location) {
         if (init?.followRedirects === false) {
+          // Drain the redirect response body so undici can release the socket —
+          // an undrained body keeps the connection busy until GC.
+          await response.body?.cancel();
           throw new Error(
             "Redirects are not followed for this destination — the endpoint must answer directly.",
           );

--- a/langwatch/src/utils/ssrfProtection.ts
+++ b/langwatch/src/utils/ssrfProtection.ts
@@ -533,6 +533,13 @@ const MAX_REDIRECTS = 10;
 export interface SSRFSafeFetchOptions extends RequestInit {
   _redirectCount?: number;
   /**
+   * Set false to refuse redirects outright: a 3xx with a Location header
+   * throws instead of hopping. For callers whose SSRF policy is stricter than
+   * the default validator (e.g. the webhook channel, ADR-040 §4) — following
+   * a hop would re-validate through the weaker default policy.
+   */
+  followRedirects?: boolean;
+  /**
    * Socket-level bound on how long the endpoint may take to send response
    * HEADERS, in ms. Defence in depth behind `signal`: undici's own default is
    * 300s, which is long enough for a slowloris endpoint to pin a worker slot.
@@ -660,6 +667,11 @@ export async function fetchWithResolvedIp(
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get("location");
       if (location) {
+        if (init?.followRedirects === false) {
+          throw new Error(
+            "Redirects are not followed for this destination — the endpoint must answer directly.",
+          );
+        }
         if (redirectCount >= MAX_REDIRECTS) {
           throw new Error(`Too many redirects (max ${MAX_REDIRECTS})`);
         }

--- a/specs/automations/webhook-http-action.feature
+++ b/specs/automations/webhook-http-action.feature
@@ -1,0 +1,84 @@
+Feature: Webhook (generic HTTP) automation action
+  Automations can deliver to a customer-supplied HTTP endpoint (ADR-040):
+  on a trace match or a graph alert, LangWatch renders a Liquid JSON body
+  and sends it to the configured URL over an SSRF-fenced HTTP client.
+  The channel ships dark behind the release_webhook_automations flag.
+
+  Background:
+    Given the release_webhook_automations flag is on for the project
+
+  Rule: Authoring a webhook automation
+
+    Scenario: The webhook card appears among the notify channels
+      Given a user opens the delivery picker in the automation drawer
+      Then a "Webhook" card is offered alongside Email and Slack
+      And picking it opens the webhook setup
+
+    Scenario: A webhook automation configures a URL, method, headers, and a JSON body
+      Given a user picks the Webhook delivery
+      Then the user sets the destination URL and HTTP method
+      And can add static request headers
+      And can author the JSON body as a Liquid template
+      And leaving the body empty sends the framework default payload
+
+    Scenario: Only https URLs are accepted
+      Given a user enters an http:// destination URL
+      When they save the automation
+      Then the save is rejected explaining the URL must be https
+
+    Scenario: Non-standard ports are rejected
+      Given a user enters an https URL with port 8443
+      When they save the automation
+      Then the save is rejected explaining only the default https port is allowed
+
+    Scenario: The flag hides the channel end to end
+      Given the release_webhook_automations flag is off for the project
+      Then the delivery picker does not offer the Webhook card
+      And saving a webhook automation through the API is rejected
+
+  Rule: Testing a webhook from the drawer
+
+    Scenario: A test fire sends the rendered request to the configured endpoint
+      Given a webhook automation draft with a URL set
+      When the user presses "Send a test"
+      Then the rendered JSON body is sent to that URL through the SSRF-fenced sender
+      And the request carries a non-suppressible X-LangWatch-Test-Fire header
+
+    Scenario: A successful test shows the real status code inline
+      Given the endpoint answers 200
+      When the test fire completes
+      Then a confirmation with the HTTP status appears next to the test button
+
+    Scenario: A failing test shows the error inline next to the test button
+      Given the endpoint answers 500 or is unreachable
+      When the test fire completes
+      Then an inline error appears next to the test button naming what went wrong
+      And the error includes the HTTP status or transport failure
+
+  Rule: Delivery is SSRF-fenced
+
+    Scenario: Requests to private or internal addresses are blocked
+      Given a webhook automation whose URL resolves to a private, loopback,
+        link-local, or cloud-metadata address
+      When the automation fires or is test-fired
+      Then the request is blocked before any connection is made
+      And the failure is terminal, not retried
+
+    Scenario: Redirects are not followed
+      Given the endpoint answers with a 3xx redirect
+      When the automation fires
+      Then the redirect is not followed and the delivery fails terminally
+
+  Rule: Dispatch classification
+
+    Scenario: Server errors retry, client errors do not
+      When the endpoint answers 500, 429, or 408, or times out
+      Then the dispatch is retried by the outbox
+      When the endpoint answers any other 4xx
+      Then the dispatch fails terminally without retry
+
+    Scenario: A graph alert can deliver to a webhook
+      Given a graph alert automation with the Webhook delivery
+      When the alert fires
+      Then the alert-shaped JSON body is sent to the configured URL
+      And a retry of the same fire does not re-send to an endpoint already reached

--- a/specs/automations/webhook-http-action.feature
+++ b/specs/automations/webhook-http-action.feature
@@ -36,6 +36,23 @@ Feature: Webhook (generic HTTP) automation action
       Then the delivery picker does not offer the Webhook card
       And saving a webhook automation through the API is rejected
 
+  Rule: Header values are secrets
+
+    Scenario: Header values are stored encrypted at rest
+      When a webhook automation is saved with an Authorization header
+      Then the stored automation does not contain the header value in plaintext
+
+    Scenario: Saved header values never return to the browser
+      Given a webhook automation saved with an Authorization header
+      When the automation is opened for editing
+      Then the header name is shown but its saved value is not
+      And saving with the value left untouched keeps the saved secret
+
+    Scenario: Renaming a saved header requires re-entering its value
+      Given a webhook automation saved with an Authorization header
+      When the user renames that header while editing
+      Then the header's value must be typed again before it is sent
+
   Rule: Testing a webhook from the drawer
 
     Scenario: A test fire sends the rendered request to the configured endpoint
@@ -54,6 +71,11 @@ Feature: Webhook (generic HTTP) automation action
       When the test fire completes
       Then an inline error appears next to the test button naming what went wrong
       And the error includes the HTTP status or transport failure
+
+    Scenario: Test fires are rate limited
+      Given a user has sent many webhook test fires within the last minute
+      When they press "Send a test" again
+      Then the test fire is rejected asking them to retry later
 
   Rule: Delivery is SSRF-fenced
 
@@ -76,6 +98,11 @@ Feature: Webhook (generic HTTP) automation action
       Then the dispatch is retried by the outbox
       When the endpoint answers any other 4xx
       Then the dispatch fails terminally without retry
+
+    Scenario: A terminally failing endpoint is not re-posted every evaluation
+      Given a graph alert webhook whose endpoint answers a terminal error
+      When the alert fires and delivery fails terminally
+      Then the fire is consumed and the endpoint is not contacted again for it
 
     Scenario: A graph alert can deliver to a webhook
       Given a graph alert automation with the Webhook delivery

--- a/specs/automations/webhook-http-action.feature
+++ b/specs/automations/webhook-http-action.feature
@@ -99,6 +99,38 @@ Feature: Webhook (generic HTTP) automation action
       When the endpoint answers any other 4xx
       Then the dispatch fails terminally without retry
 
+    Scenario: A receiver's Retry-After lengthens the backoff
+      Given the endpoint answers 429 with a Retry-After header
+      When the dispatch is retried by the outbox
+      Then the next attempt waits at least as long as the receiver asked
+
+    Scenario: Every attempt of one fire carries the same event id
+      Given a dispatch that is retried by the outbox
+      Then each attempt sends the same X-LangWatch-Event-Id
+      So a receiver can dedupe replays of the same fire
+
+    Scenario: A project cannot flood an endpoint
+      Given a project has reached its hourly webhook dispatch cap
+      When another webhook fires
+      Then that dispatch backs off instead of contacting the endpoint
+
+  Rule: Delivery log
+
+    Scenario: Each attempt is recorded with its outcome
+      Given a webhook automation that fires and is retried
+      When the attempts complete
+      Then the automation's recent deliveries show one row per attempt
+      And each row shows the HTTP status or transport error and the latency
+
+    Scenario: Stored request headers never contain secret values
+      Given a webhook automation with an Authorization header that fires
+      Then the delivery log stores the header name with its value masked
+
+    Scenario: The delivery log is pruned after 30 days
+      Given delivery rows older than 30 days exist
+      When the delivery-log prune runs
+      Then those rows are deleted and newer rows are kept
+
     Scenario: A terminally failing endpoint is not re-posted every evaluation
       Given a graph alert webhook whose endpoint answers a terminal error
       When the alert fires and delivery fails terminally


### PR DESCRIPTION
## What

Adds a third automation notify channel — **`SEND_WEBHOOK`** — alongside Email and Slack. On a trace match or a graph alert, LangWatch renders a Liquid JSON body and sends it (POST/PUT/PATCH) to a customer-supplied endpoint over the SSRF-fenced HTTP client. Shipped **dark** behind `release_webhook_automations` (`FEATURE_FLAG_FORCE_ENABLE=release_webhook_automations` to try it in dev).

Implements ADR-040 Phases 1–3. Phase 4 (a dedicated `WebhookDelivery` per-attempt table + drill-down report UI) is deferred; delivery still rides the existing outbox retry machinery and fire history.

## How it maps to the ADR

**Phase 1 — Provider + config UI**
- `definitions/webhook/{shared,client,server}` modelled on the Slack provider. `actionParams` (Zod): https-only URL with a default-port + no-credentials shape check, `method` (POST/PUT/PATCH), sanitized static `headers` (reserved keys — `Host`, `Content-Length`, `Content-Type`, `x-langwatch-*` — stripped), and a Liquid JSON `bodyTemplate` stored **inside `actionParams`**, not a Trigger template column.
- Config form: URL input, method segmented control, key/value headers editor, `LiquidEditor` (JSON) body with a rendered request preview.
- Registry lines, `SliceFor`/`PreviewFor`/`initialSlices`, `NotifyClientDef.channel` widened to `"webhook"`, `SEND_WEBHOOK` enum + additive migration, `NOTIFY_TRIGGER_ACTIONS` membership (forced by the notify/persist exhaustiveness test).
- Flag gates the delivery-picker card **and** the save / test-fire routes server-side, so the dark launch can't be bypassed via the API.

**Phase 2 — SSRF-safe sender + dispatch**
- `server/triggers/sendWebhook.ts` wraps the existing `sendHttpDestination` with the webhook SSRF policy: `createSSRFValidator({ blockLocal: true, allowedHosts: [] })` forces private-IP blocking regardless of the global `BLOCK_LOCAL_HTTP_CALLS` toggle; redirects are refused (the strict validator isn't threaded through hops); a private/loopback IP literal — including bracketed IPv6 like `[::1]` — is blocked **terminally**.
- `renderWebhookBody` + default trace/alert/report JSON envelopes in `defaults.ts`, with `| json` on every interpolation so trace content containing `"`/`}` can't break out of the JSON.
- Wired into the outbox notify switch, the shared `dispatchGraphAlertAction` (which **no longer dead-letters** webhook — the required ADR edit), and a cron parity action.

**Phase 3 — Retries & idempotency**
- `assertWebhookDelivered` classifies 5xx / 429 / 408 as retryable, other non-2xx as terminal (ADR-040 §5). The graph-alert path gates each fire on the endpoint identity so an outbox retry never re-posts to an endpoint already reached.

## Test-fire behaviour (the "see the errors" ask)
Pressing **Send a test** actually sends through the full SSRF-fenced sender (with a non-suppressible `X-LangWatch-Test-Fire: true` header) and surfaces the outcome **inline right under the button**: `Delivered — HTTP 200` on success, or the failure title + detail (HTTP status / transport error) on failure — not just a toast.

## Tests
- `sendWebhook.unit.test.ts` — https/port shape rejection; **executed** SSRF blocks for private/loopback/link-local/metadata (incl. `[::1]`); retry-vs-terminal classification.
- `renderWebhookBody.unit.test.ts` — default trace/alert/report envelopes parse; JSON-breakout content stays parseable; custom template render; fall-back on invalid-JSON / render-throw.
- `webhook/shared.unit.test.ts` — URL shape, header sanitisation, schema defaults.
- `graphAlertActionDispatch` + `trigger-template.service` — webhook branch, retryable-vs-terminal, per-fire idempotency, and the webhook test-fire path.
- `pnpm typecheck` clean; full unit sweep of the touched areas green.

Spec: `specs/automations/webhook-http-action.feature`.

> Note: `pnpm lint` (biome) fails repo-wide on this branch with an unrelated config/version mismatch (unknown rule names); not touched here.

---

## Update — review follow-ups + Phase 3/4 (added after review)

Three follow-up commits on top of the original Phases 1–3:

**Review fixes (`f7649bd`)**
- **Header values are now secrets.** Encrypted at rest (`actionParams.headersEncrypted`, AES-256-GCM, same machinery as the Slack bot token), never returned to the client (reads echo names with a `__kept__` sentinel), decrypted just before dispatch, kept-on-edit. Closes the plaintext-`Authorization` gap the review flagged.
- **Webhook test-fires are rate-limited** (the email limiter, per user) — an uncapped test button at an arbitrary URL was an outbound flood vector.
- **Redirect refusal is a first-class `followRedirects:false`** on `fetchWithResolvedIp` (replacing the `_redirectCount: MAX_SAFE_INTEGER` trick), with an **executed** regression test driving a real local server that 302s toward metadata.
- Cron parity: a terminal failure now **consumes** the fire instead of re-posting every tick.

**Phase 3 completion (`f944fbc`)**
- `Retry-After` → `DispatchError.retryAfterMs` (delta-seconds + HTTP-date, capped 1h), honored by the GroupQueue as a backoff **floor**.
- Stable `X-LangWatch-Event-Id` per fire (trace path from the batch's traceIds, graph-alert path from the fire digest) so receivers dedupe replays.
- Per-project hourly dispatch cap (`webhook-dispatch:{projectId}`).

**Phase 4 — delivery log + report UI (`12e4b19`)**
- `WebhookDelivery` table (one row per attempt, grouped by `dispatchId`), written by a `deliverWebhook()` helper that sends + classifies + logs as a unit across both dispatch paths. Header values redacted to `***`; logging is best-effort (never breaks dispatch).
- `getWebhookDeliveries` procedure + a "Recent deliveries" drill-down in the automation drawer (attempts per fire, expandable to redacted headers + response).
- 30-day prune cron (`/api/cron/webhook_delivery_cleanup`) + daily Helm CronJob.
- **Design note:** shipped as a standalone table for now; ADR-040 amended to record that the per-attempt log arguably belongs *in* the outbox's audit mechanism (so all channels get delivery history) — flagged as the future unification, not built here.

**Still deferred:** HMAC request signing + the `ProjectSecret`-ref auth union (the only remaining Phase 2 gap).

`pnpm typecheck` clean; touched-area unit suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook automations (HTTPS-only URLs, POST/PUT/PATCH, editable headers, JSON body templates) behind the `release_webhook_automations` feature flag.
  * Added webhook test-send with returned HTTP status and safer preview rendering.
  * Added per-trigger **Recent deliveries** with expandable attempts, colored outcomes, and redacted request/response details.
  * Added graph-alert webhook dispatch support and recorded delivery attempts.
* **Bug Fixes**
  * Improved webhook security: header secrets are encrypted at rest, never returned in cleartext, and are properly redacted in logs.
  * Enhanced retry behavior with `Retry-After` support, stable delivery event IDs, and deduping.
* **Chores**
  * Added 30-day webhook delivery log pruning via a scheduled cron endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->