### PR TITLE
refactor(experiment-runs): extract the shared deduped-items filter (#3178)

### DIFF
--- a/platform/app/src/server/experiments-v3/services/__tests__/experiment-run-dedup-safety.unit.test.ts
+++ b/platform/app/src/server/experiments-v3/services/__tests__/experiment-run-dedup-safety.unit.test.ts
@@ -16,13 +16,21 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
+import { buildDedupedRunItemsWhere } from "../clickhouse-experiment-run.queries";
 
 describe("experiment-run.service dedup OOM safety", () => {
   const sourcePath = path.resolve(__dirname, "..", "experiment-run.service.ts");
+  const queriesPath = path.resolve(
+    __dirname,
+    "..",
+    "clickhouse-experiment-run.queries.ts",
+  );
   const source = fs.readFileSync(sourcePath, "utf-8");
+  const querySource = fs.readFileSync(queriesPath, "utf-8");
 
   it("does not use LIMIT 1 BY anywhere in the file", () => {
     expect(source).not.toContain("LIMIT 1 BY");
+    expect(querySource).not.toContain("LIMIT 1 BY");
   });
 
   describe("experiment_runs dedup", () => {
@@ -33,11 +41,60 @@ describe("experiment-run.service dedup OOM safety", () => {
   });
 
   describe("experiment_run_items dedup", () => {
-    it("uses max(OccurredAt) GROUP BY for experiment_run_items dedup", () => {
+    // The single-run getRunItems read still spells its dedup out inline, so it
+    // is checked as source text. The multi-run reads compose theirs through
+    // buildDedupedRunItemsWhere, which is asserted on the rendered SQL below.
+    it("uses max(OccurredAt) GROUP BY for the inline experiment_run_items dedup", () => {
       expect(source).toContain("max(OccurredAt)");
       expect(source).toMatch(
         /GROUP BY\s+TenantId,\s*ExperimentId,\s*RunId,\s*RowIndex,\s*TargetId,\s*ResultType,\s*coalesce\(EvaluatorId,\s*''\)/,
       );
+    });
+
+    describe("when the shared multi-run dedup filter is built", () => {
+      const rendered = buildDedupedRunItemsWhere();
+
+      it("resolves the latest version with a max(OccurredAt) GROUP BY subquery", () => {
+        expect(rendered).toContain("max(OccurredAt)");
+        expect(rendered).toMatch(
+          /GROUP BY\s+TenantId,\s*ExperimentId,\s*RunId,\s*RowIndex,\s*TargetId,\s*ResultType,\s*coalesce\(EvaluatorId,\s*''\)/,
+        );
+      });
+
+      it("resolves dedup through an IN-tuple on the key columns and OccurredAt", () => {
+        expect(rendered).toMatch(
+          /\(\s*TenantId,\s*ExperimentId,\s*RunId,\s*RowIndex,\s*TargetId,\s*ResultType,\s*coalesce\(EvaluatorId,\s*''\)\s*,\s*OccurredAt\s*\)\s*IN\s*\(/,
+        );
+      });
+
+      it("bounds both the outer read and the dedup subquery by tenant and OccurredAt", () => {
+        // Partition pruning and tenant isolation must survive on both sides:
+        // an unbounded subquery scans every weekly partition back to cold storage.
+        expect(
+          rendered.match(/TenantId = \{tenantId:String\}/g),
+        ).toHaveLength(2);
+        expect(
+          rendered.match(/OccurredAt >= \{minOccurredAt:DateTime64\(3\)\}/g),
+        ).toHaveLength(2);
+        expect(
+          rendered.match(/OccurredAt <= \{maxOccurredAt:DateTime64\(3\)\}/g),
+        ).toHaveLength(2);
+      });
+    });
+
+    describe("when extra filters are passed", () => {
+      const rendered = buildDedupedRunItemsWhere({
+        extraFilters: ["ResultType = 'evaluator'"],
+      });
+
+      it("narrows the outer read only, leaving the dedup subquery unfiltered", () => {
+        // The subquery has to see every version of a row to pick the latest.
+        // Narrowing it would resolve max(OccurredAt) against a filtered subset
+        // and resurrect superseded rows.
+        const subquery = rendered.slice(rendered.indexOf("IN ("));
+        expect(rendered).toContain("ResultType = 'evaluator'");
+        expect(subquery).not.toContain("ResultType = 'evaluator'");
+      });
     });
   });
 

--- a/platform/app/src/server/experiments-v3/services/__tests__/experiment-run-dedup-safety.unit.test.ts
+++ b/platform/app/src/server/experiments-v3/services/__tests__/experiment-run-dedup-safety.unit.test.ts
@@ -70,9 +70,9 @@ describe("experiment-run.service dedup OOM safety", () => {
       it("bounds both the outer read and the dedup subquery by tenant and OccurredAt", () => {
         // Partition pruning and tenant isolation must survive on both sides:
         // an unbounded subquery scans every weekly partition back to cold storage.
-        expect(
-          rendered.match(/TenantId = \{tenantId:String\}/g),
-        ).toHaveLength(2);
+        expect(rendered.match(/TenantId = \{tenantId:String\}/g)).toHaveLength(
+          2,
+        );
         expect(
           rendered.match(/OccurredAt >= \{minOccurredAt:DateTime64\(3\)\}/g),
         ).toHaveLength(2);

--- a/platform/app/src/server/experiments-v3/services/clickhouse-experiment-run.queries.ts
+++ b/platform/app/src/server/experiments-v3/services/clickhouse-experiment-run.queries.ts
@@ -56,6 +56,66 @@ export const WARN_OLD_RUN_AGE_MS = 30 * 24 * 60 * 60 * 1000;
  * `Math.min(...[])` → `Infinity`) which ClickHouse would reject with an
  * opaque parse error.
  */
+/**
+ * Business dedup key for `experiment_run_items`, a ReplacingMergeTree
+ * versioned on `OccurredAt`.
+ *
+ * One constant because the key appears in three positions that must agree: the
+ * left side of the IN-tuple, the subquery projection, and the subquery GROUP
+ * BY. If those drift apart the filter silently stops deduplicating and
+ * superseded rows are counted twice.
+ */
+const RUN_ITEMS_DEDUP_KEY =
+  "TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')";
+
+/**
+ * Scope shared by the multi-run `experiment_run_items` reads: the tenant, the
+ * OccurredAt bound that lets ClickHouse prune the weekly partitions, and the
+ * exact (ExperimentId, RunId) pairs.
+ *
+ * Filtering by exact pairs rather than `ExperimentId IN (...) AND RunId IN
+ * (...)` avoids matching the cartesian product of the two sets whenever a
+ * runId is reused across experiments.
+ */
+const RUN_ITEMS_SCOPE = `TenantId = {tenantId:String}
+          AND OccurredAt >= {minOccurredAt:DateTime64(3)}
+          AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
+          AND (ExperimentId, RunId) IN {runPairs:Array(Tuple(String, String))}`;
+
+/**
+ * Build the WHERE clause that scopes an `experiment_run_items` read to a set of
+ * runs and keeps only the latest version of each business key.
+ *
+ * Dedup uses an IN-tuple subquery on (key columns, OccurredAt) rather than the
+ * per-row dedup anti-pattern. That pattern reads every selected column
+ * (including heavy payloads like EvaluationDetails / EvaluationInputs) before
+ * deduplicating, which can OOM on large parts. The IN-tuple pattern resolves
+ * dedup using only lightweight key columns and the ReplacingMergeTree version
+ * column. See `dev/docs/best_practices/clickhouse-queries.md`.
+ *
+ * `extraFilters` narrow the outer read only, never the dedup subquery. The
+ * subquery has to see every version of a row to pick the latest one; narrowing
+ * it by, say, EvaluationStatus would resolve `max(OccurredAt)` against a
+ * filtered subset and resurrect superseded rows.
+ */
+export function buildDedupedRunItemsWhere({
+  extraFilters = [],
+}: { extraFilters?: string[] } = {}): string {
+  const extra = extraFilters
+    .map((filter) => `\n          AND ${filter}`)
+    .join("");
+
+  return `WHERE ${RUN_ITEMS_SCOPE}${extra}
+          AND (${RUN_ITEMS_DEDUP_KEY}, OccurredAt) IN (
+            SELECT
+              ${RUN_ITEMS_DEDUP_KEY},
+              max(OccurredAt)
+            FROM experiment_run_items
+            WHERE ${RUN_ITEMS_SCOPE}
+            GROUP BY ${RUN_ITEMS_DEDUP_KEY}
+          )`;
+}
+
 export function computeOccurredAtRangeForRuns(
   runs: Pick<ClickHouseExperimentRunRow, "CreatedAt" | "UpdatedAt">[],
 ): { minOccurredAt: string; maxOccurredAt: string; minMs: number } {

--- a/platform/app/src/server/experiments-v3/services/clickhouse-experiment-run.queries.ts
+++ b/platform/app/src/server/experiments-v3/services/clickhouse-experiment-run.queries.ts
@@ -100,7 +100,9 @@ const RUN_ITEMS_SCOPE = `TenantId = {tenantId:String}
  */
 export function buildDedupedRunItemsWhere({
   extraFilters = [],
-}: { extraFilters?: string[] } = {}): string {
+}: {
+  extraFilters?: string[];
+} = {}): string {
   const extra = extraFilters
     .map((filter) => `\n          AND ${filter}`)
     .join("");

--- a/platform/app/src/server/experiments-v3/services/experiment-run.service.ts
+++ b/platform/app/src/server/experiments-v3/services/experiment-run.service.ts
@@ -6,6 +6,7 @@ import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseCli
 import { prisma as defaultPrisma } from "~/server/db";
 import { ExperimentService } from "~/server/experiments/experiment.service";
 import {
+  buildDedupedRunItemsWhere,
   computeOccurredAtRangeForRuns,
   OCCURRED_AT_BUFFER_MS,
   WARN_OLD_RUN_AGE_MS,
@@ -634,14 +635,6 @@ export class ExperimentRunService {
     });
 
     // Fetch per-evaluator breakdown for all runs.
-    //
-    // Dedup uses an IN-tuple subquery on (key columns, OccurredAt) instead
-    // of the per-row dedup anti-pattern. That pattern reads every selected column
-    // (including heavy payloads like EvaluationDetails / EvaluationInputs)
-    // before deduplicating, which can OOM on large parts. The IN-tuple
-    // pattern resolves dedup using only lightweight key columns and the
-    // ReplacingMergeTree version column (OccurredAt). See
-    // trace-dedup-oom-safety.unit.test.ts for the rationale.
     const breakdownResult = await clickHouseClient.query({
       query: `
         SELECT
@@ -653,29 +646,12 @@ export class ExperimentRunService {
           if(countIf(Passed IS NOT NULL) > 0, countIf(Passed = 1) / countIf(Passed IS NOT NULL), NULL) AS passRate,
           countIf(Passed IS NOT NULL) AS hasPassedCount
         FROM experiment_run_items
-        WHERE TenantId = {tenantId:String}
-          AND OccurredAt >= {minOccurredAt:DateTime64(3)}
-          AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
-          AND (ExperimentId, RunId) IN {runPairs:Array(Tuple(String, String))}
-          AND ResultType = 'evaluator'
-          AND EvaluationStatus = 'processed'
-          AND (TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, ''), OccurredAt) IN (
-            SELECT
-              TenantId,
-              ExperimentId,
-              RunId,
-              RowIndex,
-              TargetId,
-              ResultType,
-              coalesce(EvaluatorId, ''),
-              max(OccurredAt)
-            FROM experiment_run_items
-            WHERE TenantId = {tenantId:String}
-              AND OccurredAt >= {minOccurredAt:DateTime64(3)}
-              AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
-              AND (ExperimentId, RunId) IN {runPairs:Array(Tuple(String, String))}
-            GROUP BY TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
-          )
+        ${buildDedupedRunItemsWhere({
+          extraFilters: [
+            "ResultType = 'evaluator'",
+            "EvaluationStatus = 'processed'",
+          ],
+        })}
         GROUP BY ExperimentId, RunId, EvaluatorId
         LIMIT 10000
       `,
@@ -706,8 +682,6 @@ export class ExperimentRunService {
     }
 
     // Fetch cost/duration summary per run.
-    // Same exact-pair + OccurredAt-bounded + IN-tuple-dedup pattern as
-    // the breakdown query above — see comment there for the rationale.
     const costResult = await clickHouseClient.query({
       query: `
         SELECT
@@ -720,27 +694,7 @@ export class ExperimentRunService {
           avgIf(EvaluationCost, ResultType = 'evaluator' AND EvaluationCost IS NOT NULL) AS evaluationsAverageCost,
           avgIf(EvaluationDurationMs, ResultType = 'evaluator' AND EvaluationDurationMs IS NOT NULL) AS evaluationsAverageDuration
         FROM experiment_run_items
-        WHERE TenantId = {tenantId:String}
-          AND OccurredAt >= {minOccurredAt:DateTime64(3)}
-          AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
-          AND (ExperimentId, RunId) IN {runPairs:Array(Tuple(String, String))}
-          AND (TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, ''), OccurredAt) IN (
-            SELECT
-              TenantId,
-              ExperimentId,
-              RunId,
-              RowIndex,
-              TargetId,
-              ResultType,
-              coalesce(EvaluatorId, ''),
-              max(OccurredAt)
-            FROM experiment_run_items
-            WHERE TenantId = {tenantId:String}
-              AND OccurredAt >= {minOccurredAt:DateTime64(3)}
-              AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
-              AND (ExperimentId, RunId) IN {runPairs:Array(Tuple(String, String))}
-            GROUP BY TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
-          )
+        ${buildDedupedRunItemsWhere()}
         GROUP BY ExperimentId, RunId
         LIMIT 10000
       `,


### PR DESCRIPTION
## Ticket

Closes #3178. In `enrichRunsWithBreakdownAndCosts`, the per-evaluator breakdown and the per-run cost summary carry the **same** scope predicate and the **same** IN-tuple dedup subquery, differing only in projection and `GROUP BY`. The cost query's own comment said *"Same exact-pair + OccurredAt-bounded + IN-tuple-dedup pattern as the breakdown query above"*, which is precisely the drift risk the ticket describes.

The premise still holds, though the code moved since filing: #3159's follow-up refactor pulled both queries into one shared method, but left the two SQL blocks duplicated inside it.

## Change

**Option B** from the ticket. `buildDedupedRunItemsWhere({ extraFilters })` lands in `clickhouse-experiment-run.queries.ts`, next to the `OccurredAt` range math it pairs with, and both queries compose around it. The dedup key existed in **six** positions that had to agree (IN-tuple, subquery projection, GROUP BY, twice over); it now exists once.

`extraFilters` narrow the **outer read only**. The dedup subquery must see every version of a row to resolve `max(OccurredAt)`, so pushing a filter into it would resolve the max against a filtered subset and resurrect superseded rows. That boundary was implicit in two hand-written copies; the helper makes it explicit and tested.

**The safety guard needed attention, and this is the part worth reviewing.** `experiment-run-dedup-safety.unit.test.ts` matches **source text**. Extracting the SQL would have left it passing while silently narrowing its coverage to the one remaining inline query, which is a worse outcome than it failing. It now also asserts on the **rendered** filter, which is strictly stronger than text matching.

## Evidence

| AC | Proof |
| --- | --- |
| One source of truth for the deduped-items selection | Dedup key defined once; both queries compose the same helper |
| Breakdown and cost queries both consume it | `git diff` on the service: 55 lines of duplicated SQL removed |
| **No behavior change** | **The emitted SQL is byte-identical to `origin/main`** (whitespace-normalized) for *both* queries, verified by rendering the helper and diffing against the `main` literals. A refactor that emits the same SQL cannot change behavior |
| Guard still guards | Strengthened, 5 tests to 9. **Mutation-tested**: leaking `extraFilters` into the subquery fails it; dropping the subquery's `OccurredAt` bound fails it; restored, 9/9 green |
| No regression | `pnpm test:unit src/server/experiments-v3` → **209 passed (12 files)**; `pnpm typecheck` clean |

**One AC I could not satisfy, flagged rather than papered over:** the ticket asks that `experimentRunProcessing.integration.test.ts` "continue to pass against real ClickHouse". That suite is `describe.skip`ped on `main` ("chronic async-event-handler timeout flake, see #3240"), so it runs neither in CI nor locally: I booted the ClickHouse testcontainer and got `1 skipped (5 tests)`. It also covers the event-sourcing pipeline, not this read path, so it would not have exercised these queries either way. The byte-identical-SQL proof is what carries "no behavior change" here.

**On the ticket's last AC** ("the `getRun` items query may also be a candidate; evaluate"): evaluated, and left alone deliberately. It is the single-pair variant scoped by `ExperimentId = {experimentId:String} AND RunId = {runId:String}` rather than the `runPairs` tuple, so sharing would mean passing the scope in as a parameter and reduce the helper to a bare dedup wrapper. Happy to fold it in if you would rather have the one abstraction.

## Advisory note

Advisory PR from the tech-debt-fixer bot, for human review, not to be merged by the bot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved experiment run item retrieval to consistently return the latest available records.
  * Fixed deduplication across multiple experiment runs while preserving tenant and time-range filtering.
  * Ensured evaluator and cost summaries remain accurate when additional filters are applied.

* **Tests**
  * Added regression coverage for deduplication, filtering, and multi-run query scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->