### PR TITLE
fix(model-providers): show custom model Display Name in selection UI

### DIFF
--- a/langwatch/src/components/ModelSelector.tsx
+++ b/langwatch/src/components/ModelSelector.tsx
@@ -133,7 +133,7 @@ export const useModelSelectionOptions = (
     const provider = modelValue.split("/")[0]!;
 
     return {
-      label: modelDisplayLabel(modelValue, displayNames),
+      label: modelDisplayLabel({ fullModelId: modelValue, displayNames }),
       value: modelValue,
       icon: modelProviderIcons[provider as keyof typeof modelProviderIcons],
       isDisabled: false,

--- a/langwatch/src/components/ModelSelector.tsx
+++ b/langwatch/src/components/ModelSelector.tsx
@@ -125,7 +125,9 @@ export const useModelSelectionOptions = (
     }
   }
 
-  const displayNames = buildCustomModelDisplayNames(providersByKey);
+  const displayNames = buildCustomModelDisplayNames(
+    modelProviders.data?.providers ?? [],
+  );
 
   const selectOptions: ModelOption[] = allModels.map((modelValue) => {
     const provider = modelValue.split("/")[0]!;

--- a/langwatch/src/components/ModelSelector.tsx
+++ b/langwatch/src/components/ModelSelector.tsx
@@ -13,6 +13,10 @@ import React, { useEffect, useState } from "react";
 import { LuSettings2 } from "react-icons/lu";
 import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";
 import {
+  buildCustomModelDisplayNames,
+  modelDisplayLabel,
+} from "../server/modelProviders/customModelDisplayNames";
+import {
   modelProviderIcons,
   ProviderIconGlyph,
 } from "../server/modelProviders/iconsMap";
@@ -121,12 +125,13 @@ export const useModelSelectionOptions = (
     }
   }
 
+  const displayNames = buildCustomModelDisplayNames(providersByKey);
+
   const selectOptions: ModelOption[] = allModels.map((modelValue) => {
     const provider = modelValue.split("/")[0]!;
-    const modelName = modelValue.split("/").slice(1).join("/");
 
     return {
-      label: modelName,
+      label: modelDisplayLabel(modelValue, displayNames),
       value: modelValue,
       icon: modelProviderIcons[provider as keyof typeof modelProviderIcons],
       isDisabled: false,

--- a/langwatch/src/components/__tests__/ModelMultiSelect.displayName.integration.test.tsx
+++ b/langwatch/src/components/__tests__/ModelMultiSelect.displayName.integration.test.tsx
@@ -4,11 +4,15 @@
  * ModelMultiSelect shares `useModelSelectionOptions` with every other
  * model picker in the app (ModelSelector, LLMModelDisplay, ...) —
  * specs/model-providers/custom-model-display-name.feature, "Shared
- * model pickers show the configured display name". Issue #5759: the
- * hook's `selectOptions` mapping rebuilds each item's `label` from the
- * raw model id via `value.split("/").slice(1).join("/")` and never
- * reads the provider's configured custom-model display name
- * (src/components/ModelSelector.tsx, `useModelSelectionOptions`).
+ * model pickers show the configured display name".
+ *
+ * Regression cover for issue #5759, where the hook's `selectOptions`
+ * mapping rebuilt each item's `label` from the raw model id via
+ * `value.split("/").slice(1).join("/")`, ignoring the provider's
+ * configured custom-model display name
+ * (src/components/ModelSelector.tsx, `useModelSelectionOptions`). The
+ * label now resolves through `modelDisplayLabel`, which is why fixing
+ * the one hook fixed every picker that shares it.
  *
  * Renders the real hook against a mocked tRPC boundary (only
  * `api.modelProvider.listAllForProjectForFrontend` and

--- a/langwatch/src/components/__tests__/ModelMultiSelect.displayName.integration.test.tsx
+++ b/langwatch/src/components/__tests__/ModelMultiSelect.displayName.integration.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * ModelMultiSelect shares `useModelSelectionOptions` with every other
+ * model picker in the app (ModelSelector, LLMModelDisplay, ...) —
+ * specs/model-providers/custom-model-display-name.feature, "Shared
+ * model pickers show the configured display name". Issue #5759: the
+ * hook's `selectOptions` mapping rebuilds each item's `label` from the
+ * raw model id via `value.split("/").slice(1).join("/")` and never
+ * reads the provider's configured custom-model display name
+ * (src/components/ModelSelector.tsx, `useModelSelectionOptions`).
+ *
+ * Renders the real hook against a mocked tRPC boundary (only
+ * `api.modelProvider.listAllForProjectForFrontend` and
+ * `useOrganizationTeamProject` are mocked) — no dropdown/portal
+ * involved, ModelMultiSelect always renders its full option list.
+ *
+ * @see specs/model-providers/custom-model-display-name.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { id: "proj-1" } }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    modelProvider: {
+      listAllForProjectForFrontend: {
+        useQuery: () => ({
+          data: {
+            providers: [
+              {
+                provider: "custom",
+                enabled: true,
+                customModels: [
+                  {
+                    modelId: "gpt-5.1",
+                    displayName: "Ada Prod Model",
+                    mode: "chat",
+                  },
+                ],
+                customEmbeddingsModels: null,
+              },
+            ],
+          },
+          isLoading: false,
+        }),
+      },
+    },
+  },
+}));
+
+import { ModelMultiSelect } from "../ModelMultiSelect";
+
+afterEach(() => cleanup());
+
+function renderPicker() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <ModelMultiSelect value={[]} onChange={() => undefined} />
+    </ChakraProvider>,
+  );
+}
+
+describe("<ModelMultiSelect/>", () => {
+  describe("given a custom model with a configured display name", () => {
+    describe("when the picker lists its options", () => {
+      /** @scenario Shared model pickers show the configured display name */
+      it("lists the custom model by its display name", () => {
+        renderPicker();
+
+        expect(screen.getByText("Ada Prod Model")).toBeInTheDocument();
+      });
+
+      it("does not list the custom model by its raw model id", () => {
+        renderPicker();
+
+        expect(screen.queryByText("gpt-5.1")).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/llmPromptConfigs/__tests__/LLMModelDisplay.displayName.integration.test.tsx
+++ b/langwatch/src/components/llmPromptConfigs/__tests__/LLMModelDisplay.displayName.integration.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * LLMModelDisplay renders a model's label outside any picker context —
+ * e.g. the model column of the prompts list (src/prompts/PromptsList.tsx)
+ * — specs/model-providers/custom-model-display-name.feature, "Model
+ * labels outside pickers show the display name". It reads its label
+ * from `useModelSelectionOptions`'s `modelOption.label`, which issue
+ * #5759 rebuilds from the raw model id instead of a configured custom
+ * display name.
+ *
+ * Renders the real hook (`useModelSelectionOptions`, not mocked) against
+ * a mocked tRPC boundary, unlike the existing LLMModelDisplay.test.tsx
+ * (which mocks the hook itself away and so can't exercise this bug).
+ *
+ * @see specs/model-providers/custom-model-display-name.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { id: "proj-1" } }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    modelProvider: {
+      listAllForProjectForFrontend: {
+        useQuery: () => ({
+          data: {
+            providers: [
+              {
+                provider: "custom",
+                enabled: true,
+                customModels: [
+                  {
+                    modelId: "gpt-5.1",
+                    displayName: "Ada Prod Model",
+                    mode: "chat",
+                  },
+                ],
+                customEmbeddingsModels: null,
+              },
+            ],
+          },
+          isLoading: false,
+        }),
+      },
+    },
+  },
+}));
+
+import { LLMModelDisplay } from "../LLMModelDisplay";
+
+afterEach(() => cleanup());
+
+function renderDisplay(model: string) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <LLMModelDisplay model={model} />
+    </ChakraProvider>,
+  );
+}
+
+describe("<LLMModelDisplay/>", () => {
+  describe("given a surface that displays a renamed custom model without offering a choice", () => {
+    /** @scenario Model labels outside pickers show the display name */
+    it("reads the configured display name", () => {
+      renderDisplay("custom/gpt-5.1");
+
+      expect(screen.getByText("Ada Prod Model")).toBeInTheDocument();
+    });
+
+    it("does not read the raw model id", () => {
+      renderDisplay("custom/gpt-5.1");
+
+      expect(screen.queryByText("gpt-5.1")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/components/scenarios/SimulationModelSelect.tsx
+++ b/langwatch/src/components/scenarios/SimulationModelSelect.tsx
@@ -81,20 +81,10 @@ export function SimulationModelSelect({
   }, [projectProviders.data]);
 
   // Configured custom-model display names, keyed by `<provider>/<modelId>`.
-  // Merged per row (rather than collapsed into one Record by provider key)
-  // so a provider stored at two scopes doesn't lose one row's custom
-  // models to the other's.
-  const displayNames = useMemo(() => {
-    const providers = projectProviders.data?.providers ?? [];
-    const map: Record<string, string> = {};
-    for (const provider of providers) {
-      Object.assign(
-        map,
-        buildCustomModelDisplayNames({ [provider.provider]: provider }),
-      );
-    }
-    return map;
-  }, [projectProviders.data]);
+  const displayNames = useMemo(
+    () => buildCustomModelDisplayNames(projectProviders.data?.providers ?? []),
+    [projectProviders.data],
+  );
 
   const inheritModel = resolvedDefault.data?.model ?? "";
 

--- a/langwatch/src/components/scenarios/SimulationModelSelect.tsx
+++ b/langwatch/src/components/scenarios/SimulationModelSelect.tsx
@@ -7,6 +7,7 @@ import {
   INHERIT_SENTINEL,
   ProviderModelSelector,
 } from "../settings/ProviderModelSelector";
+import { buildCustomModelDisplayNames } from "../../server/modelProviders/customModelDisplayNames";
 import { LATEST_ALIAS_PROVIDERS } from "../../server/modelProviders/latestAliases";
 
 /**
@@ -79,6 +80,22 @@ export function SimulationModelSelect({
     return Array.from(new Set([...aliases, ...custom, ...registry]));
   }, [projectProviders.data]);
 
+  // Configured custom-model display names, keyed by `<provider>/<modelId>`.
+  // Merged per row (rather than collapsed into one Record by provider key)
+  // so a provider stored at two scopes doesn't lose one row's custom
+  // models to the other's.
+  const displayNames = useMemo(() => {
+    const providers = projectProviders.data?.providers ?? [];
+    const map: Record<string, string> = {};
+    for (const provider of providers) {
+      Object.assign(
+        map,
+        buildCustomModelDisplayNames({ [provider.provider]: provider }),
+      );
+    }
+    return map;
+  }, [projectProviders.data]);
+
   const inheritModel = resolvedDefault.data?.model ?? "";
 
   return (
@@ -98,6 +115,7 @@ export function SimulationModelSelect({
             ? { model: inheritModel, label: "Default model" }
             : undefined
         }
+        displayNames={displayNames}
       />
     </VStack>
   );

--- a/langwatch/src/components/scenarios/__tests__/SimulationModelSelect.displayName.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/SimulationModelSelect.displayName.integration.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * SimulationModelSelect is the model picker for the scenario
+ * user-simulator / judge roles — specs/model-providers/custom-model-display-name.feature,
+ * "Scenario model picker shows the configured display name". It wraps
+ * ProviderModelSelector but builds `options` itself from the project's
+ * providers and (issue #5759) never computes or forwards a
+ * `displayNames` map, so the dropdown item falls back to
+ * ProviderModelSelector's raw-id label.
+ *
+ * @see specs/model-providers/custom-model-display-name.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { id: "proj-1" } }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    modelProvider: {
+      listAllForProjectForFrontend: {
+        useQuery: () => ({
+          data: {
+            providers: [
+              {
+                provider: "custom",
+                enabled: true,
+                customModels: [
+                  {
+                    modelId: "gpt-5.1",
+                    displayName: "Ada Prod Model",
+                    mode: "chat",
+                  },
+                ],
+              },
+            ],
+          },
+          isLoading: false,
+        }),
+      },
+      getResolvedDefault: {
+        useQuery: () => ({ data: undefined }),
+      },
+    },
+  },
+}));
+
+import { SimulationModelSelect } from "../SimulationModelSelect";
+
+afterEach(() => cleanup());
+
+function renderPicker() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <SimulationModelSelect
+        label="User simulator"
+        value={null}
+        onChange={() => undefined}
+        featureKey="scenarios.user_simulator"
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe("<SimulationModelSelect/>", () => {
+  describe("given a custom model with a configured display name", () => {
+    describe("when the dropdown lists its options", () => {
+      /** @scenario Scenario model picker shows the configured display name */
+      it("lists the custom model by its display name", () => {
+        renderPicker();
+
+        const listbox = screen.getByRole("listbox", { hidden: true });
+        expect(within(listbox).getByText("Ada Prod Model")).toBeInTheDocument();
+      });
+
+      it("does not list the custom model by its raw model id", () => {
+        renderPicker();
+
+        const listbox = screen.getByRole("listbox", { hidden: true });
+        expect(within(listbox).queryByText("gpt-5.1")).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/scenarios/__tests__/SimulationModelSelect.displayName.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/SimulationModelSelect.displayName.integration.test.tsx
@@ -3,11 +3,14 @@
  *
  * SimulationModelSelect is the model picker for the scenario
  * user-simulator / judge roles — specs/model-providers/custom-model-display-name.feature,
- * "Scenario model picker shows the configured display name". It wraps
- * ProviderModelSelector but builds `options` itself from the project's
- * providers and (issue #5759) never computes or forwards a
- * `displayNames` map, so the dropdown item falls back to
- * ProviderModelSelector's raw-id label.
+ * "Scenario model picker shows the configured display name".
+ *
+ * Regression cover for issue #5759. It wraps ProviderModelSelector but
+ * builds `options` itself from the project's providers, so it bypasses
+ * `useModelSelectionOptions` entirely and no other test reaches it. It
+ * used to forward no `displayNames` map, leaving the dropdown on
+ * ProviderModelSelector's raw-id fallback; these tests pin the map
+ * forwarding that fixed it.
  *
  * @see specs/model-providers/custom-model-display-name.feature
  */

--- a/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
+++ b/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
@@ -270,21 +270,12 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
     } satisfies Record<ModelRoleKey, string[]>;
   }, [projectProviders.data]);
 
-  // Configured custom-model display names, keyed by `<provider>/<modelId>`,
-  // for every provider row this project can see - merged per row (rather
-  // than collapsed into one Record by provider key) so a provider stored
-  // at two scopes doesn't lose one row's custom models to the other's.
-  const displayNames = useMemo(() => {
-    const providers = projectProviders.data?.providers ?? [];
-    const map: Record<string, string> = {};
-    for (const provider of providers) {
-      Object.assign(
-        map,
-        buildCustomModelDisplayNames({ [provider.provider]: provider }),
-      );
-    }
-    return map;
-  }, [projectProviders.data]);
+  // Configured custom-model display names for every provider row this
+  // project can see, keyed by `<provider>/<modelId>`.
+  const displayNames = useMemo(
+    () => buildCustomModelDisplayNames(projectProviders.data?.providers ?? []),
+    [projectProviders.data],
+  );
 
   const setOverride = useCallback((key: string, model: string | null) => {
     setConfig((prev) => {

--- a/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
+++ b/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
@@ -36,6 +36,7 @@ import { api, type RouterOutputs } from "~/utils/api";
 
 import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { buildCustomModelDisplayNames } from "~/server/modelProviders/customModelDisplayNames";
 import { LATEST_ALIAS_PROVIDERS } from "~/server/modelProviders/latestAliases";
 import { INHERIT_SENTINEL, ProviderModelSelector } from "./ProviderModelSelector";
 import {
@@ -269,6 +270,22 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
     } satisfies Record<ModelRoleKey, string[]>;
   }, [projectProviders.data]);
 
+  // Configured custom-model display names, keyed by `<provider>/<modelId>`,
+  // for every provider row this project can see - merged per row (rather
+  // than collapsed into one Record by provider key) so a provider stored
+  // at two scopes doesn't lose one row's custom models to the other's.
+  const displayNames = useMemo(() => {
+    const providers = projectProviders.data?.providers ?? [];
+    const map: Record<string, string> = {};
+    for (const provider of providers) {
+      Object.assign(
+        map,
+        buildCustomModelDisplayNames({ [provider.provider]: provider }),
+      );
+    }
+    return map;
+  }, [projectProviders.data]);
+
   const setOverride = useCallback((key: string, model: string | null) => {
     setConfig((prev) => {
       const next = { ...prev };
@@ -368,6 +385,7 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
                   }
                   modelOptions={modelOptionsByRole[role]}
                   onSetOverride={setOverride}
+                  displayNames={displayNames}
                 />
               ))}
             </VStack>
@@ -412,6 +430,7 @@ function RoleRow({
   onToggleExpand,
   modelOptions,
   onSetOverride,
+  displayNames,
 }: {
   role: ModelRoleKey;
   config: Record<string, string>;
@@ -426,6 +445,8 @@ function RoleRow({
   onToggleExpand: () => void;
   modelOptions: string[];
   onSetOverride: (key: string, model: string | null) => void;
+  /** Configured custom-model display names, keyed by `<provider>/<modelId>`. */
+  displayNames: Record<string, string>;
 }) {
   const current = config[role] ?? "";
   // Prefer the picked-scope cascade answer; fall back to the
@@ -477,6 +498,7 @@ function RoleRow({
             onChange={(m) => onSetOverride(role, m)}
             inheritOption={inheritOption}
             disabled={unsupportedAtScope}
+            displayNames={displayNames}
           />
         </Box>
         {canExpand ? (
@@ -527,6 +549,7 @@ function RoleRow({
               inheritedRoleModel={inheritedModel}
               modelOptions={modelOptions}
               onSetOverride={onSetOverride}
+              displayNames={displayNames}
             />
           ))}
         </VStack>
@@ -544,6 +567,7 @@ function FeatureRow({
   inheritedRoleModel,
   modelOptions,
   onSetOverride,
+  displayNames,
 }: {
   feature: FeatureProjection;
   override: string;
@@ -558,6 +582,8 @@ function FeatureRow({
   inheritedRoleModel?: string;
   modelOptions: string[];
   onSetOverride: (key: string, model: string | null) => void;
+  /** Configured custom-model display names, keyed by `<provider>/<modelId>`. */
+  displayNames: Record<string, string>;
 }) {
   // The feature's "would inherit" placeholder follows the same cascade
   // the resolver does: a role-level pick in THIS config (in-progress)
@@ -608,6 +634,7 @@ function FeatureRow({
           options={modelOptions}
           onChange={(m) => onSetOverride(feature.key, m)}
           inheritOption={inheritOption ?? undefined}
+          displayNames={displayNames}
         />
       </Box>
       <Box width="24px" flexShrink={0} />

--- a/langwatch/src/components/settings/DefaultModelsSection.tsx
+++ b/langwatch/src/components/settings/DefaultModelsSection.tsx
@@ -98,6 +98,11 @@ interface DefaultModelsSectionProps {
    *  children of the picked scope). When omitted, falls back to the
    *  org returned from the tRPC payload — fine for standalone mounts. */
   hierarchy?: ScopeHierarchy;
+  /** Configured custom-model display names, keyed by `<provider>/<modelId>`,
+   *  forwarded to each row's `ModelChip`. The section doesn't fetch
+   *  provider data itself; the page passes this down from the same
+   *  provider list it uses for `enabledProviderKeys`. */
+  displayNames?: Record<string, string>;
 }
 
 export function DefaultModelsSection({
@@ -106,6 +111,7 @@ export function DefaultModelsSection({
   enabledProviderKeys,
   noProvidersConfigured = false,
   hierarchy,
+  displayNames,
 }: DefaultModelsSectionProps = {}) {
   const { project, team, organization } = useOrganizationTeamProject();
   const projectId = project?.id ?? "";
@@ -276,6 +282,7 @@ export function DefaultModelsSection({
             onDelete={handleDelete}
             onAdd={openAdd}
             enabledProviderKeys={enabledProviderKeys ?? null}
+            displayNames={displayNames}
           />
         </Card.Body>
       </Card.Root>
@@ -294,6 +301,7 @@ function AllConfigsView({
   onDelete,
   onAdd,
   enabledProviderKeys,
+  displayNames,
 }: {
   configs: ConfigRow[];
   /** Full cascade input. `configs` is filter-narrowed for display, but
@@ -306,6 +314,7 @@ function AllConfigsView({
   onDelete: (c: ConfigRow) => void;
   onAdd: () => void;
   enabledProviderKeys: Set<string> | null;
+  displayNames?: Record<string, string>;
 }) {
   if (configs.length === 0) {
     return (
@@ -366,6 +375,7 @@ function AllConfigsView({
                   anchorScope={mostSpecificScope(c.scopes)}
                   onEdit={() => onEdit(c)}
                   enabledProviderKeys={enabledProviderKeys}
+                  displayNames={displayNames}
                 />
               </Table.Cell>
             ))}
@@ -430,6 +440,7 @@ function ConfigCell({
   anchorScope,
   onEdit,
   enabledProviderKeys,
+  displayNames,
 }: {
   role: ModelRoleKey;
   config: Record<string, string>;
@@ -442,6 +453,7 @@ function ConfigCell({
    *  menu. Edits the whole policy, not just the cell. */
   onEdit: () => void;
   enabledProviderKeys: Set<string> | null;
+  displayNames?: Record<string, string>;
 }) {
   const isInvalid = (model: string) =>
     !!enabledProviderKeys &&
@@ -476,6 +488,7 @@ function ConfigCell({
             model={resolvedRoleModel}
             size="sm"
             invalid={isInvalid(resolvedRoleModel)}
+            displayNames={displayNames}
           />
         ) : (
           <Badge colorPalette="orange" variant="subtle">
@@ -492,6 +505,7 @@ function ConfigCell({
             model={config[f.key]!}
             size="sm"
             invalid={isInvalid(config[f.key]!)}
+            displayNames={displayNames}
           />
         </ChipWithEdit>
       ))}

--- a/langwatch/src/components/settings/ModelChip.tsx
+++ b/langwatch/src/components/settings/ModelChip.tsx
@@ -6,7 +6,6 @@
  */
 import { Box, HStack, Text } from "@chakra-ui/react";
 import { AlertTriangle } from "lucide-react";
-import { Tooltip } from "../ui/tooltip";
 import { modelDisplayLabel } from "~/server/modelProviders/customModelDisplayNames";
 import { modelProviderIcons } from "~/server/modelProviders/iconsMap";
 import {
@@ -17,6 +16,7 @@ import {
   MODEL_ICON_SIZE,
   MODEL_ICON_SIZE_SM,
 } from "../llmPromptConfigs/constants";
+import { Tooltip } from "../ui/tooltip";
 
 interface Props {
   /** Full model id of the form "provider/family-variant". */
@@ -43,6 +43,10 @@ export function ModelChip({
 }: Props) {
   const providerKey = model.split("/")[0] ?? "";
   const family = modelDisplayLabel(model, displayNames);
+  // Alias detection reads the id, never `family` — a custom model can
+  // carry any display name, and branching on it would let one named
+  // "latest" masquerade as the alias (and vice versa).
+  const idFamily = model.split("/").slice(1).join("/");
   const icon =
     modelProviderIcons[providerKey as keyof typeof modelProviderIcons];
   const iconSlot = size === "sm" ? MODEL_ICON_SIZE_SM : MODEL_ICON_SIZE;
@@ -50,12 +54,11 @@ export function ModelChip({
   // the resolved concrete id inline in muted text so the table reads
   // as a single line, parens-disambiguated, instead of a stacked pair.
   const aliasResolved = isLatestAlias(model) ? resolveLatestAlias(model) : null;
-  const aliasLabel =
-    isLatestAlias(model)
-      ? family === "latest"
-        ? "Latest"
-        : "Latest smaller"
-      : null;
+  const aliasLabel = isLatestAlias(model)
+    ? idFamily === "latest"
+      ? "Latest"
+      : "Latest smaller"
+    : null;
 
   const chip = (
     <HStack

--- a/langwatch/src/components/settings/ModelChip.tsx
+++ b/langwatch/src/components/settings/ModelChip.tsx
@@ -42,7 +42,7 @@ export function ModelChip({
   displayNames,
 }: Props) {
   const providerKey = model.split("/")[0] ?? "";
-  const family = modelDisplayLabel(model, displayNames);
+  const family = modelDisplayLabel({ fullModelId: model, displayNames });
   // Alias detection reads the id, never `family` — a custom model can
   // carry any display name, and branching on it would let one named
   // "latest" masquerade as the alias (and vice versa).

--- a/langwatch/src/components/settings/ModelChip.tsx
+++ b/langwatch/src/components/settings/ModelChip.tsx
@@ -2,12 +2,12 @@
  * Renders a model identifier ("openai/gpt-5.5") with the provider's
  * icon and the family name in mono font — the same primitive
  * `ProviderModelSelector` uses inside its dropdown items. Used in the
- * Default Models table cells and in the override drawer so the page
- * reads consistent with the model-provider list above it.
+ * Default Models table cells (DefaultModelsSection.tsx).
  */
 import { Box, HStack, Text } from "@chakra-ui/react";
 import { AlertTriangle } from "lucide-react";
 import { Tooltip } from "../ui/tooltip";
+import { modelDisplayLabel } from "~/server/modelProviders/customModelDisplayNames";
 import { modelProviderIcons } from "~/server/modelProviders/iconsMap";
 import {
   isLatestAlias,
@@ -29,6 +29,9 @@ interface Props {
    *  reading this default will fail at runtime until the user re-adds
    *  the provider or picks a different model. */
   invalid?: boolean;
+  /** Configured custom-model display names, keyed by `<provider>/<modelId>`.
+   *  Falls back to the id-derived family name for any model without an entry. */
+  displayNames?: Record<string, string>;
 }
 
 export function ModelChip({
@@ -36,9 +39,10 @@ export function ModelChip({
   size = "md",
   inherited = false,
   invalid = false,
+  displayNames,
 }: Props) {
   const providerKey = model.split("/")[0] ?? "";
-  const family = model.split("/").slice(1).join("/");
+  const family = modelDisplayLabel(model, displayNames);
   const icon =
     modelProviderIcons[providerKey as keyof typeof modelProviderIcons];
   const iconSlot = size === "sm" ? MODEL_ICON_SIZE_SM : MODEL_ICON_SIZE;

--- a/langwatch/src/components/settings/ProviderModelSelector.tsx
+++ b/langwatch/src/components/settings/ProviderModelSelector.tsx
@@ -106,7 +106,7 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
           };
         }
         return {
-          label: modelDisplayLabel(modelValue, displayNames),
+          label: modelDisplayLabel({ fullModelId: modelValue, displayNames }),
           value: modelValue,
           icon,
           subtitle: "",
@@ -205,7 +205,7 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
         lineClamp={1}
         wordBreak="break-all"
       >
-        {modelDisplayLabel(inheritOption.model, displayNames)}
+        {modelDisplayLabel({ fullModelId: inheritOption.model, displayNames })}
       </Box>
     </HStack>
   ) : (
@@ -222,7 +222,7 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
         wordBreak="break-all"
         color={isUnknown ? "gray.500" : undefined}
       >
-        {selectedItem?.label ?? modelDisplayLabel(model, displayNames)}
+        {selectedItem?.label ?? modelDisplayLabel({ fullModelId: model, displayNames })}
       </Box>
     </HStack>
   );
@@ -338,7 +338,7 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
                   fontFamily="mono"
                   lineClamp={1}
                 >
-                  {modelDisplayLabel(inheritOption.model, displayNames)}
+                  {modelDisplayLabel({ fullModelId: inheritOption.model, displayNames })}
                 </Text>
               </Box>
             </HStack>

--- a/langwatch/src/components/settings/ProviderModelSelector.tsx
+++ b/langwatch/src/components/settings/ProviderModelSelector.tsx
@@ -8,6 +8,7 @@ import {
 } from "@chakra-ui/react";
 import { Search } from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
+import { modelDisplayLabel } from "../../server/modelProviders/customModelDisplayNames";
 import { modelProviderIcons } from "../../server/modelProviders/iconsMap";
 import {
   isLatestAlias,
@@ -62,6 +63,7 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
   size = "full",
   disabled = false,
   inheritOption,
+  displayNames,
 }: {
   model: string;
   options: string[];
@@ -74,6 +76,9 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
     /** Short label shown above the model, e.g. "Inherit (from organization)" or "Suggested from openai". */
     label: string;
   };
+  /** Configured custom-model display names, keyed by `<provider>/<modelId>`.
+   *  Falls back to the id-derived label for any model without an entry. */
+  displayNames?: Record<string, string>;
 }) {
   const [modelSearch, setModelSearch] = useState("");
 
@@ -101,13 +106,13 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
           };
         }
         return {
-          label: modelValue.split("/").slice(1).join("/"),
+          label: modelDisplayLabel(modelValue, displayNames),
           value: modelValue,
           icon,
           subtitle: "",
         };
       }),
-    [options],
+    [options, displayNames],
   );
 
   // Group models by provider
@@ -200,7 +205,7 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
         lineClamp={1}
         wordBreak="break-all"
       >
-        {inheritOption.model.split("/").slice(1).join("/")}
+        {modelDisplayLabel(inheritOption.model, displayNames)}
       </Box>
     </HStack>
   ) : (
@@ -217,7 +222,7 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
         wordBreak="break-all"
         color={isUnknown ? "gray.500" : undefined}
       >
-        {selectedItem?.label ?? model.split("/").slice(1).join("/")}
+        {selectedItem?.label ?? modelDisplayLabel(model, displayNames)}
       </Box>
     </HStack>
   );
@@ -333,7 +338,7 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
                   fontFamily="mono"
                   lineClamp={1}
                 >
-                  {inheritOption.model.split("/").slice(1).join("/")}
+                  {modelDisplayLabel(inheritOption.model, displayNames)}
                 </Text>
               </Box>
             </HStack>

--- a/langwatch/src/components/settings/__tests__/DefaultModelOverrideDrawer.displayName.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/DefaultModelOverrideDrawer.displayName.integration.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #5759: the Default Models override drawer builds its own
+ * `displayNames` map (`buildCustomModelDisplayNames`) from the project's
+ * provider rows and threads it into every role's `ProviderModelSelector`.
+ * The map-build itself is covered by customModelDisplayNames' own unit
+ * tests, and `ProviderModelSelector`'s rendering of a `displayNames` prop
+ * is covered by ProviderModelSelector.displayName.integration.test.tsx -
+ * but nothing exercised the WIRING between them: "drawer fetches provider
+ * rows" -> "drawer builds displayNames" -> "drawer passes
+ * displayNames={displayNames} to <ProviderModelSelector>". That chain was
+ * pinned only by manual screenshots. `displayNames` is an OPTIONAL prop,
+ * so a refactor that silently drops `displayNames={displayNames}` from a
+ * role row's <ProviderModelSelector> still compiles and still passes
+ * every other existing test.
+ *
+ * Renders the real `DefaultModelOverrideDrawer` (not a stub) with only
+ * the tRPC boundary + peripheral hooks mocked, so the whole chain - map
+ * build, prop threading, dropdown + trigger render - runs for real.
+ *
+ * Query strategy - two layers:
+ *
+ * 1. Select.Content (role="listbox") is mounted-but-hidden regardless of
+ *    open state (same as ProviderModelSelector.displayName.integration.
+ *    test.tsx), and Select.HiddenSelect mirrors every item as a native
+ *    <option>, so unscoped getByText can double-match. That harness
+ *    handles it by scoping to a single global listbox/trigger - not
+ *    available here, because this drawer renders THREE role rows
+ *    (Default/Fast/Embeddings), each with its OWN <ProviderModelSelector>.
+ *
+ * 2. `~/components/ui/select.tsx`'s SelectContent portals by default
+ *    (`portalled = true`, and ProviderModelSelector never overrides it),
+ *    so a role's listbox is NOT a DOM descendant of its own
+ *    `role-row-<role>` container - plain DOM-containment scoping can't
+ *    isolate "the Default role's dropdown" from the other two. Worse,
+ *    Default and Fast share the exact same chat-model pool
+ *    (`modelOptionsByRole` in DefaultModelOverrideDrawer.tsx builds one
+ *    `chatOptions` list and reuses it for both roles), so the renamed
+ *    model is a legitimate, real option in BOTH dropdowns - an unscoped
+ *    `getAllByRole("listbox")[0]` guess would be fragile even if it
+ *    happened to pass.
+ *
+ *    Verified directly against @zag-js/select's connect module
+ *    (node_modules/.pnpm/@zag-js+select@1.41.2/node_modules/@zag-js/select/
+ *    dist/select.connect.mjs):
+ *    `getTriggerProps()` stamps `"aria-controls": dom.getContentId(scope)`
+ *    on the trigger (role="combobox"), and `getContentProps()` stamps the
+ *    SAME id plus `role: "listbox"` on its own Content. That id pairing
+ *    is per-<Select.Root> instance and portal-proof, so resolving a
+ *    role's listbox FROM its own row's trigger (found by plain DOM
+ *    containment, since only Content portals - the trigger does not) is
+ *    the one collision-proof way to scope to a single role's dropdown.
+ *    (Also verified the native hidden <select> carries `"aria-hidden":
+ *    true` in the same module, which is why the working harness's
+ *    unscoped `getByRole("combobox")` never trips over it either.)
+ *
+ * `~/components/settings/ScopeChipPicker` is stubbed the same way
+ * AddOverrideDrawer.editMode.integration.test.tsx stubs it ("ScopeChipPicker
+ * pulls in data hooks we don't need here") - it's orthogonal to display-name
+ * threading, and the assertions below never touch scope-picking UI.
+ *
+ * @see specs/model-providers/custom-model-display-name.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DefaultModelOverrideDrawer } from "../DefaultModelOverrideDrawer";
+
+const mockCloseDrawer = vi.fn();
+const mockGetDefaultModels = vi.fn();
+const mockGetInheritedValues = vi.fn();
+const mockListAllForProjectForFrontend = vi.fn();
+const mockSave = vi.fn();
+const mockInvalidate = vi.fn();
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: mockCloseDrawer,
+    openDrawer: vi.fn(),
+    drawerOpen: () => false,
+    canGoBack: false,
+    goBack: vi.fn(),
+    currentDrawer: undefined,
+  }),
+  useDrawerParams: () => ({}),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", slug: "acme-app", name: "Acme App" },
+    organization: { id: "org-1", name: "Acme" },
+    team: { id: "team-1", name: "Platform" },
+    hasPermission: () => true,
+  }),
+}));
+
+// Orthogonal to display-name threading and pulls in its own data hooks -
+// see AddOverrideDrawer.editMode.integration.test.tsx for the same stub
+// on the same component.
+vi.mock("~/components/settings/ScopeChipPicker", () => ({
+  ScopeChipPicker: () => <div data-testid="scope-chip-picker" />,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({
+      modelProvider: {
+        getDefaultModelsForProject: { invalidate: mockInvalidate },
+        getResolvedDefault: { invalidate: vi.fn() },
+      },
+    }),
+    modelProvider: {
+      getDefaultModelsForProject: {
+        useQuery: () => mockGetDefaultModels(),
+      },
+      getInheritedValuesForScopes: {
+        useQuery: () => mockGetInheritedValues(),
+      },
+      listAllForProjectForFrontend: {
+        useQuery: () => mockListAllForProjectForFrontend(),
+      },
+      saveDefaultModelsConfig: {
+        useMutation: () => ({ mutateAsync: mockSave, isPending: false }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+const MODEL_ID = "gpt-5.1";
+const DISPLAY_NAME = "Ada Prod Model";
+const PROVIDER = "custom";
+const FULL_ID = `${PROVIDER}/${MODEL_ID}`;
+
+const AVAILABLE = {
+  organization: { id: "org-1", name: "Acme" },
+  teams: [{ id: "team-1", name: "Platform" }],
+  projects: [{ id: "proj-1", name: "Acme App", teamId: "team-1" }],
+};
+
+const CONFIG_ROW = {
+  id: "cfg_1",
+  // Only the Default role is pinned - Fast/Embeddings stay on "Inherit"
+  // (empty), which is irrelevant to this file's assertions.
+  config: { DEFAULT: FULL_ID },
+  createdAt: new Date("2026-05-15T12:00:00Z"),
+  updatedAt: new Date("2026-05-15T12:00:00Z"),
+  authorId: "user-1",
+  scopes: [{ type: "PROJECT" as const, id: "proj-1", name: "Acme App" }],
+};
+
+const PAYLOAD = {
+  projectId: "proj-1",
+  teamId: "team-1",
+  organizationId: "org-1",
+  organizationName: "Acme",
+  effective: {
+    DEFAULT: null,
+    FAST: null,
+    EMBEDDINGS: null,
+  },
+  configs: [CONFIG_ROW],
+  available: AVAILABLE,
+  features: [],
+};
+
+const PROVIDER_ROW = {
+  id: "mp_1",
+  name: "Custom",
+  provider: PROVIDER,
+  enabled: true,
+  customModels: [{ modelId: MODEL_ID, displayName: DISPLAY_NAME, mode: "chat" as const }],
+  customEmbeddingsModels: [],
+};
+
+function renderDrawer(editingId = "cfg_1") {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <DefaultModelOverrideDrawer editingId={editingId} />
+    </ChakraProvider>,
+  );
+}
+
+function roleRow(role: "default" | "fast" | "embeddings") {
+  return screen.getByTestId(`role-row-${role}`);
+}
+
+/** The trigger is never portaled (only Select.Content is), so plain DOM
+ *  containment safely scopes it to one role row. */
+function triggerFor(role: "default" | "fast" | "embeddings") {
+  return within(roleRow(role)).getByRole("combobox");
+}
+
+/** Resolves the role's OWN listbox via its trigger's `aria-controls`,
+ *  which @zag-js/select stamps with the same id it gives that trigger's
+ *  Content - see the file header for why DOM containment alone can't do
+ *  this (Content portals; Default and Fast also share one option pool). */
+function listboxFor(role: "default" | "fast" | "embeddings") {
+  const contentId = triggerFor(role).getAttribute("aria-controls");
+  if (!contentId) {
+    throw new Error(`combobox for role "${role}" has no aria-controls`);
+  }
+  const listbox = document.getElementById(contentId);
+  if (!listbox) {
+    throw new Error(`no element with id="${contentId}" for role "${role}"`);
+  }
+  return listbox;
+}
+
+describe("<DefaultModelOverrideDrawer/>", () => {
+  beforeEach(() => {
+    mockGetDefaultModels.mockReturnValue({ data: PAYLOAD, isLoading: false });
+    mockGetInheritedValues.mockReturnValue({
+      data: { inherited: {}, referenceScope: null },
+      isLoading: false,
+    });
+    mockListAllForProjectForFrontend.mockReturnValue({
+      data: { providers: [PROVIDER_ROW] },
+      isLoading: false,
+      isError: false,
+    });
+    mockSave.mockReset();
+    mockInvalidate.mockReset();
+    mockCloseDrawer.mockReset();
+  });
+  afterEach(() => cleanup());
+
+  describe("given a project whose Default role is saved as a renamed custom model", () => {
+    describe("when the drawer opens editing that config", () => {
+      it("renders the Default role's dropdown item as the display name", () => {
+        renderDrawer();
+
+        expect(
+          within(listboxFor("default")).getByText(DISPLAY_NAME),
+        ).toBeInTheDocument();
+      });
+
+      it("does not render the raw model id as the Default role's dropdown item", () => {
+        renderDrawer();
+
+        expect(
+          within(listboxFor("default")).queryByText(MODEL_ID),
+        ).not.toBeInTheDocument();
+      });
+
+      it("renders the Default role's collapsed trigger as the display name", () => {
+        renderDrawer();
+
+        expect(
+          within(triggerFor("default")).getByText(DISPLAY_NAME),
+        ).toBeInTheDocument();
+      });
+
+      it("does not render the raw model id as the Default role's trigger value", () => {
+        renderDrawer();
+
+        expect(
+          within(triggerFor("default")).queryByText(MODEL_ID),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/settings/__tests__/DefaultModelsSection.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/DefaultModelsSection.integration.test.tsx
@@ -22,6 +22,7 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DefaultModelsSection } from "../DefaultModelsSection";
 
@@ -177,13 +178,34 @@ const FAKE_PAYLOAD = {
   ],
 };
 
-function renderSection() {
+function renderSection(
+  props: Partial<ComponentProps<typeof DefaultModelsSection>> = {},
+) {
   return render(
     <ChakraProvider value={defaultSystem}>
-      <DefaultModelsSection />
+      <DefaultModelsSection {...props} />
     </ChakraProvider>,
   );
 }
+
+// Issue #5759: a custom model's configured Display Name must reach the
+// table chip too, not just the drawer's dropdown - pins the
+// DefaultModelsSection -> ModelChip prop-threading hop. Deliberately
+// disjoint from its own raw id (never "gpt-5.1-custom") so a dropped
+// `displayNames={displayNames}` is provable by exact string identity,
+// not a substring match the raw id could still slip through.
+const CUSTOM_MODEL_ID = "gpt-5.1";
+const CUSTOM_DISPLAY_NAME = "Ada Prod Model";
+const CUSTOM_FULL_ID = `custom/${CUSTOM_MODEL_ID}`;
+
+const CUSTOM_MODEL_CONFIG_ROW = {
+  id: "cfg_custom_display_name",
+  config: { DEFAULT: CUSTOM_FULL_ID },
+  createdAt: new Date("2026-05-15T12:00:00Z"),
+  updatedAt: new Date("2026-05-15T12:00:00Z"),
+  authorId: "user-1",
+  scopes: [{ type: "PROJECT", id: "proj-1", name: "Acme App" }],
+};
 
 describe("<DefaultModelsSection />", () => {
   beforeEach(() => {
@@ -267,5 +289,24 @@ describe("<DefaultModelsSection />", () => {
     // Same URL-routed drawer as Edit — without an editingId so the
     // drawer initialises in create mode.
     expect(mockOpenDrawer).toHaveBeenCalledWith("defaultModelOverride", {});
+  });
+
+  describe("given a config whose role model is a renamed custom model", () => {
+    describe("when the section receives the resolved displayNames map", () => {
+      it("renders the table chip with the configured display name, not the raw model id", () => {
+        mockGetDefaultModels.mockReturnValue({
+          data: { ...FAKE_PAYLOAD, configs: [CUSTOM_MODEL_CONFIG_ROW] },
+          isLoading: false,
+        });
+
+        renderSection({
+          displayNames: { [CUSTOM_FULL_ID]: CUSTOM_DISPLAY_NAME },
+        });
+
+        expect(
+          screen.getByTestId(`model-chip-${CUSTOM_FULL_ID}`).textContent,
+        ).toBe(CUSTOM_DISPLAY_NAME);
+      });
+    });
   });
 });

--- a/langwatch/src/components/settings/__tests__/ModelChip.displayName.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelChip.displayName.integration.test.tsx
@@ -1,13 +1,14 @@
 /**
  * @vitest-environment jsdom
  *
- * Issue #5759: ModelChip (the Default Models table's per-role model
- * pill) rebuilds its label from the raw model id via
- * `model.split("/").slice(1).join("/")` and never reads the provider's
- * configured custom-model display name.
+ * Regression cover for issue #5759. ModelChip (the Default Models
+ * table's per-role model pill) used to rebuild its label from the raw
+ * model id via `model.split("/").slice(1).join("/")`, ignoring the
+ * provider's configured custom-model display name. It now resolves the
+ * label through `modelDisplayLabel` off an optional `displayNames` prop.
  *
- * `ModelChip` does not yet accept a `displayNames` prop — these tests
- * are expected to fail on the rendered label until issue #5759 is fixed.
+ * The prop is optional, so dropping it at a call site would compile
+ * silently — these tests are what makes that fail instead.
  *
  * @see specs/model-providers/custom-model-display-name.feature
  */

--- a/langwatch/src/components/settings/__tests__/ModelChip.displayName.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelChip.displayName.integration.test.tsx
@@ -33,7 +33,10 @@ describe("<ModelChip/>", () => {
       /** @scenario Default models table chip shows the configured display name */
       it("reads the configured display name", () => {
         renderChip(
-          <ModelChip model={FULL_ID} displayNames={{ [FULL_ID]: DISPLAY_NAME }} />,
+          <ModelChip
+            model={FULL_ID}
+            displayNames={{ [FULL_ID]: DISPLAY_NAME }}
+          />,
         );
 
         expect(screen.getByText(DISPLAY_NAME)).toBeInTheDocument();
@@ -41,7 +44,10 @@ describe("<ModelChip/>", () => {
 
       it("does not read the raw model id", () => {
         renderChip(
-          <ModelChip model={FULL_ID} displayNames={{ [FULL_ID]: DISPLAY_NAME }} />,
+          <ModelChip
+            model={FULL_ID}
+            displayNames={{ [FULL_ID]: DISPLAY_NAME }}
+          />,
         );
 
         expect(screen.queryByText(MODEL_ID)).not.toBeInTheDocument();
@@ -58,6 +64,22 @@ describe("<ModelChip/>", () => {
         );
 
         expect(screen.getByText("gpt-4o-mini")).toBeInTheDocument();
+      });
+    });
+
+    describe("when a display name is configured against a `latest` alias id", () => {
+      const ALIAS_ID = "openai/latest";
+
+      it("still picks the alias label from the id, not the display name", () => {
+        renderChip(
+          <ModelChip
+            model={ALIAS_ID}
+            displayNames={{ [ALIAS_ID]: "My Latest" }}
+          />,
+        );
+
+        expect(screen.getByText("Latest")).toBeInTheDocument();
+        expect(screen.queryByText("Latest smaller")).not.toBeInTheDocument();
       });
     });
   });

--- a/langwatch/src/components/settings/__tests__/ModelChip.displayName.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelChip.displayName.integration.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #5759: ModelChip (the Default Models table's per-role model
+ * pill) rebuilds its label from the raw model id via
+ * `model.split("/").slice(1).join("/")` and never reads the provider's
+ * configured custom-model display name.
+ *
+ * `ModelChip` does not yet accept a `displayNames` prop — these tests
+ * are expected to fail on the rendered label until issue #5759 is fixed.
+ *
+ * @see specs/model-providers/custom-model-display-name.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ModelChip } from "../ModelChip";
+
+afterEach(() => cleanup());
+
+function renderChip(ui: React.ReactElement) {
+  return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+const MODEL_ID = "gpt-5.1";
+const DISPLAY_NAME = "Ada Prod Model";
+const FULL_ID = `custom/${MODEL_ID}`;
+
+describe("<ModelChip/>", () => {
+  describe("given the Default Models table with no editor open", () => {
+    describe("when the role's saved model is a renamed custom model", () => {
+      /** @scenario Default models table chip shows the configured display name */
+      it("reads the configured display name", () => {
+        renderChip(
+          <ModelChip model={FULL_ID} displayNames={{ [FULL_ID]: DISPLAY_NAME }} />,
+        );
+
+        expect(screen.getByText(DISPLAY_NAME)).toBeInTheDocument();
+      });
+
+      it("does not read the raw model id", () => {
+        renderChip(
+          <ModelChip model={FULL_ID} displayNames={{ [FULL_ID]: DISPLAY_NAME }} />,
+        );
+
+        expect(screen.queryByText(MODEL_ID)).not.toBeInTheDocument();
+      });
+    });
+
+    describe("when the role's saved model has no entry in the displayNames map", () => {
+      it("falls back to the model id's family part, unchanged from today", () => {
+        renderChip(
+          <ModelChip
+            model="openai/gpt-4o-mini"
+            displayNames={{ [FULL_ID]: DISPLAY_NAME }}
+          />,
+        );
+
+        expect(screen.getByText("gpt-4o-mini")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/settings/__tests__/ProviderModelSelector.displayName.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ProviderModelSelector.displayName.integration.test.tsx
@@ -1,0 +1,302 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #5759: a custom model's configured Display Name never reaches
+ * ProviderModelSelector — it rebuilds every item's label from the raw
+ * Model ID via `value.split("/").slice(1).join("/")` and never reads
+ * the provider's configured `displayName`. Same bug hits the inherit
+ * entry's subtitle and the collapsed trigger's inherit placeholder.
+ *
+ * `ProviderModelSelector` does not yet accept a `displayNames` prop —
+ * these tests are expected to fail (assertion, not import/type error at
+ * runtime; `pnpm typecheck` additionally flags the unknown prop) until
+ * issue #5759 is fixed.
+ *
+ * Query strategy: Select.Content (role="listbox") is mounted in the DOM
+ * whether or not the dropdown is open (Ark/Chakra Select only toggles a
+ * `hidden` attribute + `data-state`), so item labels are queryable via
+ * `within(listbox).getByText(...)` without driving a click. Unscoped
+ * `screen.getByText`/`queryByText` is unsafe here: Chakra's
+ * `Select.HiddenSelect` mirrors every item as a native `<option>`
+ * sibling, so any label also rendered in the real listbox produces a
+ * "multiple elements found" error unless queries are scoped to the
+ * listbox (for item text) or the trigger (for the collapsed value).
+ *
+ * @see specs/model-providers/custom-model-display-name.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ProviderModelSelector } from "../ProviderModelSelector";
+
+afterEach(() => cleanup());
+
+function renderSelector(ui: React.ReactElement) {
+  return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+function listbox() {
+  return screen.getByRole("listbox", { hidden: true });
+}
+
+function trigger() {
+  return screen.getByRole("combobox");
+}
+
+const MODEL_ID = "gpt-5.1";
+const DISPLAY_NAME = "Ada Prod Model";
+const PROVIDER = "custom";
+const FULL_ID = `${PROVIDER}/${MODEL_ID}`;
+const DISPLAY_NAMES = { [FULL_ID]: DISPLAY_NAME };
+
+const EMBED_MODEL_ID = "text-embed-3";
+const EMBED_DISPLAY_NAME = "Ada Prod Embed";
+const EMBED_FULL_ID = `${PROVIDER}/${EMBED_MODEL_ID}`;
+// One unified map carries both chat and embeddings entries — pins that
+// buildCustomModelDisplayNames is not mode-gated (a single map serves
+// every role's ProviderModelSelector instance, chat or embeddings).
+const UNIFIED_DISPLAY_NAMES = {
+  [FULL_ID]: DISPLAY_NAME,
+  [EMBED_FULL_ID]: EMBED_DISPLAY_NAME,
+};
+
+describe("<ProviderModelSelector/>", () => {
+  describe("given a custom model with a configured display name", () => {
+    describe("when the dropdown lists its options", () => {
+      /** @scenario Dropdown item shows the configured display name */
+      it("renders the item's label as the display name", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={[FULL_ID]}
+            onChange={vi.fn()}
+            displayNames={DISPLAY_NAMES}
+          />,
+        );
+
+        expect(within(listbox()).getByText(DISPLAY_NAME)).toBeInTheDocument();
+      });
+
+      it("does not render the raw model id as the item's label", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={[FULL_ID]}
+            onChange={vi.fn()}
+            displayNames={DISPLAY_NAMES}
+          />,
+        );
+
+        expect(within(listbox()).queryByText(MODEL_ID)).not.toBeInTheDocument();
+      });
+    });
+
+    describe("when the model is selected and the selector is collapsed", () => {
+      /** @scenario Collapsed selector shows the configured display name */
+      it("renders the trigger's value as the display name", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model={FULL_ID}
+            options={[FULL_ID]}
+            onChange={vi.fn()}
+            displayNames={DISPLAY_NAMES}
+          />,
+        );
+
+        expect(within(trigger()).getByText(DISPLAY_NAME)).toBeInTheDocument();
+      });
+    });
+
+    describe("when the user picks the item from the dropdown", () => {
+      /** @scenario Selecting a renamed model stores its model id */
+      it("calls onChange with the model id, not the display name", async () => {
+        const onChange = vi.fn();
+        const user = userEvent.setup();
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={[FULL_ID]}
+            onChange={onChange}
+            displayNames={DISPLAY_NAMES}
+          />,
+        );
+
+        await user.click(trigger());
+        await user.click(within(listbox()).getByText(DISPLAY_NAME));
+
+        expect(onChange).toHaveBeenCalledWith(FULL_ID);
+      });
+    });
+
+    describe("when the user searches by the display name", () => {
+      /** @scenario Search by display name finds a renamed model */
+      it("keeps the model listed", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={[FULL_ID]}
+            onChange={vi.fn()}
+            displayNames={DISPLAY_NAMES}
+          />,
+        );
+
+        fireEvent.change(screen.getByPlaceholderText("Search models"), {
+          target: { value: "Ada" },
+        });
+
+        expect(within(listbox()).getByText(DISPLAY_NAME)).toBeInTheDocument();
+      });
+    });
+
+    describe("when the user searches by the raw model id", () => {
+      /** @scenario Search by model id finds a renamed model */
+      it("keeps the model listed, shown by its display name", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={[FULL_ID]}
+            onChange={vi.fn()}
+            displayNames={DISPLAY_NAMES}
+          />,
+        );
+
+        fireEvent.change(screen.getByPlaceholderText("Search models"), {
+          target: { value: MODEL_ID },
+        });
+
+        expect(within(listbox()).getByText(DISPLAY_NAME)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given the provider also has a custom embeddings model with a configured display name", () => {
+    describe("when the embeddings role dropdown lists its options", () => {
+      /** @scenario Custom embeddings model shows the configured display name */
+      it("renders the embeddings item's label as its display name", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={[EMBED_FULL_ID]}
+            onChange={vi.fn()}
+            displayNames={UNIFIED_DISPLAY_NAMES}
+          />,
+        );
+
+        expect(
+          within(listbox()).getByText(EMBED_DISPLAY_NAME),
+        ).toBeInTheDocument();
+      });
+
+      it("does not render the raw embeddings model id as the item's label", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={[EMBED_FULL_ID]}
+            onChange={vi.fn()}
+            displayNames={UNIFIED_DISPLAY_NAMES}
+          />,
+        );
+
+        expect(
+          within(listbox()).queryByText(EMBED_MODEL_ID),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given a provider with both a renamed custom model and registry models", () => {
+    const options = [FULL_ID, `${PROVIDER}/gpt-4o-mini`, `${PROVIDER}/gpt-4o`];
+
+    describe("when the dropdown lists its options", () => {
+      /** @scenario Registry model labels are unchanged alongside a custom model */
+      it("still shows the registry models by their id-derived labels", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={options}
+            onChange={vi.fn()}
+            displayNames={DISPLAY_NAMES}
+          />,
+        );
+
+        expect(within(listbox()).getByText("gpt-4o-mini")).toBeInTheDocument();
+        expect(within(listbox()).getByText("gpt-4o")).toBeInTheDocument();
+      });
+
+      it("shows the custom model by its display name", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={options}
+            onChange={vi.fn()}
+            displayNames={DISPLAY_NAMES}
+          />,
+        );
+
+        expect(within(listbox()).getByText(DISPLAY_NAME)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given the role inherits the renamed custom model from a broader scope", () => {
+    const inheritOption = {
+      model: FULL_ID,
+      label: "Inherit (from organization)",
+    };
+
+    describe("when the role dropdown offering the inherit entry is rendered", () => {
+      /** @scenario Inherit entry shows the display name without replacing its own label */
+      it("renders the inherit entry's subtitle as the display name", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={[FULL_ID]}
+            onChange={vi.fn()}
+            displayNames={DISPLAY_NAMES}
+            inheritOption={inheritOption}
+          />,
+        );
+
+        expect(within(listbox()).getByText(DISPLAY_NAME)).toBeInTheDocument();
+      });
+
+      it("renders the collapsed selector's placeholder as the display name", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={[FULL_ID]}
+            onChange={vi.fn()}
+            displayNames={DISPLAY_NAMES}
+            inheritOption={inheritOption}
+          />,
+        );
+
+        expect(within(trigger()).getByText(DISPLAY_NAME)).toBeInTheDocument();
+      });
+
+      it("leaves the inherit entry's own caller-supplied label untouched", () => {
+        renderSelector(
+          <ProviderModelSelector
+            model=""
+            options={[FULL_ID]}
+            onChange={vi.fn()}
+            displayNames={DISPLAY_NAMES}
+            inheritOption={inheritOption}
+          />,
+        );
+
+        expect(
+          within(listbox()).getByText("Inherit (from organization)"),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/settings/__tests__/ProviderModelSelector.displayName.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ProviderModelSelector.displayName.integration.test.tsx
@@ -51,6 +51,10 @@ function trigger() {
   return screen.getByRole("combobox");
 }
 
+function inheritItem() {
+  return screen.getByTestId("provider-model-selector-inherit");
+}
+
 const MODEL_ID = "gpt-5.1";
 const DISPLAY_NAME = "Ada Prod Model";
 const PROVIDER = "custom";
@@ -265,7 +269,10 @@ describe("<ProviderModelSelector/>", () => {
           />,
         );
 
-        expect(within(listbox()).getByText(DISPLAY_NAME)).toBeInTheDocument();
+        // Scoped to the inherit entry, not the whole listbox: the
+        // inherited model is also a real option here, so both legitimately
+        // render the display name and an unscoped getByText matches twice.
+        expect(within(inheritItem()).getByText(DISPLAY_NAME)).toBeInTheDocument();
       });
 
       it("renders the collapsed selector's placeholder as the display name", () => {

--- a/langwatch/src/components/settings/__tests__/ProviderModelSelector.displayName.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ProviderModelSelector.displayName.integration.test.tsx
@@ -1,16 +1,20 @@
 /**
  * @vitest-environment jsdom
  *
- * Issue #5759: a custom model's configured Display Name never reaches
- * ProviderModelSelector — it rebuilds every item's label from the raw
- * Model ID via `value.split("/").slice(1).join("/")` and never reads
- * the provider's configured `displayName`. Same bug hits the inherit
- * entry's subtitle and the collapsed trigger's inherit placeholder.
+ * Regression cover for issue #5759, where a custom model's configured
+ * Display Name never reached ProviderModelSelector: it rebuilt every
+ * item's label from the raw Model ID via
+ * `value.split("/").slice(1).join("/")`, and the same fallback hit the
+ * inherit entry's subtitle and the collapsed trigger's placeholder.
+ * Labels now resolve through `modelDisplayLabel` off an optional
+ * `displayNames` prop.
  *
- * `ProviderModelSelector` does not yet accept a `displayNames` prop —
- * these tests are expected to fail (assertion, not import/type error at
- * runtime; `pnpm typecheck` additionally flags the unknown prop) until
- * issue #5759 is fixed.
+ * The prop is optional, so dropping it at a call site would compile
+ * silently — these tests are what makes that fail instead. Note the
+ * label is resolved where `selectOptions` is BUILT, not where it is
+ * rendered: the search filter matches on `item.label`, so a
+ * render-only fix would make the item vanish when a user types the
+ * name they can see (see the search tests below).
  *
  * Query strategy: Select.Content (role="listbox") is mounted in the DOM
  * whether or not the dropdown is open (Ark/Chakra Select only toggles a

--- a/langwatch/src/components/settings/__tests__/ProviderModelSelector.displayName.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ProviderModelSelector.displayName.integration.test.tsx
@@ -272,7 +272,9 @@ describe("<ProviderModelSelector/>", () => {
         // Scoped to the inherit entry, not the whole listbox: the
         // inherited model is also a real option here, so both legitimately
         // render the display name and an unscoped getByText matches twice.
-        expect(within(inheritItem()).getByText(DISPLAY_NAME)).toBeInTheDocument();
+        expect(
+          within(inheritItem()).getByText(DISPLAY_NAME),
+        ).toBeInTheDocument();
       });
 
       it("renders the collapsed selector's placeholder as the display name", () => {

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -28,6 +28,7 @@ import { Menu } from "../../components/ui/menu";
 import { TriggerAnchor } from "../../components/ui/TriggerAnchor";
 import { Tooltip } from "../../components/ui/tooltip";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
+import { buildCustomModelDisplayNames } from "../../server/modelProviders/customModelDisplayNames";
 import { modelProviderIcons } from "../../server/modelProviders/iconsMap";
 import { modelProviders as modelProvidersRegistry } from "../../server/modelProviders/registry";
 import { filterProvidersByScope } from "../../utils/filterProvidersByScope";
@@ -82,6 +83,22 @@ export default function ModelsPage() {
     () => new Set(allEnabledProviders.map((p) => p.provider)),
     [allEnabledProviders],
   );
+
+  // Configured custom-model display names, keyed by `<provider>/<modelId>`,
+  // for the Default Models table's chips. Built from the ALL set (not the
+  // scope-filtered one) for the same reason as `enabledProviderKeys` above,
+  // and merged per row so a provider stored at two scopes doesn't lose one
+  // row's custom models to the other's.
+  const defaultModelsDisplayNames = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const provider of allProvidersList) {
+      Object.assign(
+        map,
+        buildCustomModelDisplayNames({ [provider.provider]: provider }),
+      );
+    }
+    return map;
+  }, [allProvidersList]);
 
   // Client-side filter for the scope dropdown at the top of the page.
   // The list query returns every provider the caller can see; this just
@@ -396,6 +413,7 @@ export default function ModelsPage() {
           enabledProviderKeys={enabledProviderKeys}
           noProvidersConfigured={!isLoading && enabledProviders.length === 0}
           hierarchy={hierarchy}
+          displayNames={defaultModelsDisplayNames}
         />
 
         <Dialog.Root

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -84,21 +84,13 @@ export default function ModelsPage() {
     [allEnabledProviders],
   );
 
-  // Configured custom-model display names, keyed by `<provider>/<modelId>`,
-  // for the Default Models table's chips. Built from the ALL set (not the
-  // scope-filtered one) for the same reason as `enabledProviderKeys` above,
-  // and merged per row so a provider stored at two scopes doesn't lose one
-  // row's custom models to the other's.
-  const defaultModelsDisplayNames = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const provider of allProvidersList) {
-      Object.assign(
-        map,
-        buildCustomModelDisplayNames({ [provider.provider]: provider }),
-      );
-    }
-    return map;
-  }, [allProvidersList]);
+  // Display names for the Default Models table's chips. Built from the ALL
+  // set (not the scope-filtered one) for the same reason as
+  // `enabledProviderKeys` above.
+  const defaultModelsDisplayNames = useMemo(
+    () => buildCustomModelDisplayNames(allProvidersList),
+    [allProvidersList],
+  );
 
   // Client-side filter for the scope dropdown at the top of the page.
   // The list query returns every provider the caller can see; this just

--- a/langwatch/src/server/modelProviders/__tests__/customModelDisplayNames.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/customModelDisplayNames.unit.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the custom-model display-name resolver.
+ *
+ * Binds the two `@unit` scenarios in
+ * specs/model-providers/custom-model-display-name.feature. The
+ * `@integration` scenarios in the same file are bound against the
+ * components that consume this resolver (ProviderModelSelector,
+ * ModelChip, useModelSelectionOptions, etc.) — see their own test files.
+ *
+ * `buildCustomModelDisplayNames` / `modelDisplayLabel` do not exist yet
+ * (issue #5759) — this file is expected to fail on the import until the
+ * resolver module is implemented.
+ */
+import { describe, expect, it } from "vitest";
+import type { CustomModelEntry } from "../customModel.schema";
+import { toLegacyCompatibleCustomModels } from "../customModel.schema";
+import {
+  buildCustomModelDisplayNames,
+  modelDisplayLabel,
+} from "../customModelDisplayNames";
+import type { MaybeStoredModelProvider } from "../registry";
+
+const makeProvider = (
+  overrides: Partial<MaybeStoredModelProvider> & { provider: string },
+): MaybeStoredModelProvider => ({
+  enabled: true,
+  customKeys: null,
+  models: null,
+  embeddingsModels: null,
+  customModels: null,
+  customEmbeddingsModels: null,
+  deploymentMapping: null,
+  extraHeaders: null,
+  ...overrides,
+});
+
+describe("buildCustomModelDisplayNames()", () => {
+  describe("given a custom chat model with a display name", () => {
+    it('keys the map by "<provider>/<modelId>"', () => {
+      const providers: Record<string, MaybeStoredModelProvider> = {
+        custom: makeProvider({
+          provider: "custom",
+          customModels: [
+            { modelId: "gpt-5.1", displayName: "Ada Prod Model", mode: "chat" },
+          ],
+        }),
+      };
+
+      const result = buildCustomModelDisplayNames(providers);
+
+      expect(result["custom/gpt-5.1"]).toBe("Ada Prod Model");
+    });
+  });
+
+  describe("given both a custom chat model and a custom embeddings model on the same provider", () => {
+    it("includes both in one map, regardless of mode", () => {
+      const providers: Record<string, MaybeStoredModelProvider> = {
+        custom: makeProvider({
+          provider: "custom",
+          customModels: [
+            { modelId: "gpt-5.1", displayName: "Ada Prod Model", mode: "chat" },
+          ],
+          customEmbeddingsModels: [
+            {
+              modelId: "text-embed-3",
+              displayName: "Ada Prod Embed",
+              mode: "embedding",
+            },
+          ],
+        }),
+      };
+
+      const result = buildCustomModelDisplayNames(providers);
+
+      expect(result["custom/gpt-5.1"]).toBe("Ada Prod Model");
+      expect(result["custom/text-embed-3"]).toBe("Ada Prod Embed");
+    });
+  });
+
+  describe("given custom entries whose display name is blank, absent, or whose model id is absent", () => {
+    // Mirrors the Background fixture's model id but deliberately uses a
+    // blank/absent display name — this block tests the malformed-entry
+    // path, not the happy path (which lives in the ProviderModelSelector /
+    // ModelChip integration tests).
+    const entries: CustomModelEntry[] = [
+      { modelId: "gpt-5.1", displayName: "", mode: "chat" },
+      { modelId: "gpt-5.2", mode: "chat" } as CustomModelEntry,
+      { displayName: "Orphan", mode: "chat" } as CustomModelEntry,
+    ];
+    const providers: Record<string, MaybeStoredModelProvider> = {
+      custom: makeProvider({ provider: "custom", customModels: entries }),
+    };
+
+    /** @scenario A blank or incomplete custom entry falls back to the model id */
+    it("resolves entries with a model id to that id, skips the entry with no model id, and never yields a blank or undefined name", () => {
+      const displayNames = buildCustomModelDisplayNames(providers);
+
+      // Entries with a model id resolve to that model id ...
+      expect(modelDisplayLabel("custom/gpt-5.1", displayNames)).toBe("gpt-5.1");
+      expect(modelDisplayLabel("custom/gpt-5.2", displayNames)).toBe("gpt-5.2");
+
+      // ... an entry without a model id is skipped (no "custom/undefined" key) ...
+      expect(Object.keys(displayNames)).not.toContain("custom/undefined");
+
+      // ... and no entry resolves to a blank or undefined name.
+      for (const value of Object.values(displayNames)) {
+        expect(value).toBeTruthy();
+        expect(value).not.toBe("undefined");
+      }
+    });
+
+    it("does not add a key for the entry with no model id", () => {
+      const result = buildCustomModelDisplayNames({
+        custom: makeProvider({
+          provider: "custom",
+          customModels: [{ displayName: "Orphan", mode: "chat" } as CustomModelEntry],
+        }),
+      });
+
+      expect(Object.keys(result)).toHaveLength(0);
+    });
+  });
+});
+
+describe("modelDisplayLabel()", () => {
+  describe("given a configured display name for the model", () => {
+    it("returns the display name", () => {
+      const label = modelDisplayLabel("custom/gpt-5.1", {
+        "custom/gpt-5.1": "Ada Prod Model",
+      });
+
+      expect(label).toBe("Ada Prod Model");
+    });
+  });
+
+  describe("given a blank display name stored for the model", () => {
+    it("falls back to the model id's family part instead of rendering blank", () => {
+      // Pins `||` over `??`: a `??`-based implementation would return ""
+      // here because the key IS present (not undefined) — only `||`
+      // treats a blank string as "missing". `"" ?? "gpt-5.1"` is `""`.
+      const label = modelDisplayLabel("custom/gpt-5.1", {
+        "custom/gpt-5.1": "",
+      });
+
+      expect(label).toBe("gpt-5.1");
+      expect(label).not.toBe("");
+    });
+  });
+
+  describe("given no entry for the model in the map", () => {
+    it("falls back to the model id's family part", () => {
+      const label = modelDisplayLabel("openai/gpt-4o-mini", {
+        "custom/gpt-5.1": "Ada Prod Model",
+      });
+
+      expect(label).toBe("gpt-4o-mini");
+    });
+  });
+
+  describe("given no map at all", () => {
+    it("falls back to the model id's family part", () => {
+      const label = modelDisplayLabel("openai/gpt-4o-mini");
+
+      expect(label).toBe("gpt-4o-mini");
+    });
+  });
+
+  describe("given a custom entry normalized from the legacy string form, whose display name equals its model id", () => {
+    /** @scenario A legacy custom model resolves to its model id */
+    it("resolves to its model id", () => {
+      const legacyEntries = toLegacyCompatibleCustomModels(["gpt-5.1"], "chat");
+      const providers: Record<string, MaybeStoredModelProvider> = {
+        custom: makeProvider({ provider: "custom", customModels: legacyEntries }),
+      };
+
+      const displayNames = buildCustomModelDisplayNames(providers);
+
+      expect(modelDisplayLabel("custom/gpt-5.1", displayNames)).toBe("gpt-5.1");
+    });
+  });
+});

--- a/langwatch/src/server/modelProviders/__tests__/customModelDisplayNames.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/customModelDisplayNames.unit.test.ts
@@ -7,9 +7,10 @@
  * components that consume this resolver (ProviderModelSelector,
  * ModelChip, useModelSelectionOptions, etc.) — see their own test files.
  *
- * `buildCustomModelDisplayNames` / `modelDisplayLabel` do not exist yet
- * (issue #5759) — this file is expected to fail on the import until the
- * resolver module is implemented.
+ * The malformed-entry cases below are not hypothetical: `customModels`
+ * is a JSON column and `toLegacyCompatibleCustomModels` returns an
+ * unchecked cast (customModel.schema.ts), so blank, whitespace-only and
+ * field-missing entries can reach the resolver from a hand-edited row.
  */
 import { describe, expect, it } from "vitest";
 import type { CustomModelEntry } from "../customModel.schema";
@@ -36,164 +37,198 @@ const makeProvider = (
 
 describe("buildCustomModelDisplayNames()", () => {
   describe("given a custom chat model with a display name", () => {
-    it('keys the map by "<provider>/<modelId>"', () => {
-      const result = buildCustomModelDisplayNames([
-        makeProvider({
-          provider: "custom",
-          customModels: [
-            { modelId: "gpt-5.1", displayName: "Ada Prod Model", mode: "chat" },
-          ],
-        }),
-      ]);
+    describe("when display names are built for it", () => {
+      it('keys the map by "<provider>/<modelId>"', () => {
+        const result = buildCustomModelDisplayNames([
+          makeProvider({
+            provider: "custom",
+            customModels: [
+              {
+                modelId: "gpt-5.1",
+                displayName: "Ada Prod Model",
+                mode: "chat",
+              },
+            ],
+          }),
+        ]);
 
-      expect(result["custom/gpt-5.1"]).toBe("Ada Prod Model");
+        expect(result["custom/gpt-5.1"]).toBe("Ada Prod Model");
+      });
     });
   });
 
-  describe("given both a custom chat model and a custom embeddings model on the same provider", () => {
-    it("includes both in one map, regardless of mode", () => {
-      const result = buildCustomModelDisplayNames([
-        makeProvider({
-          provider: "custom",
-          customModels: [
-            { modelId: "gpt-5.1", displayName: "Ada Prod Model", mode: "chat" },
-          ],
-          customEmbeddingsModels: [
-            {
-              modelId: "text-embed-3",
-              displayName: "Ada Prod Embed",
-              mode: "embedding",
-            },
-          ],
-        }),
-      ]);
+  describe("given a chat model and an embeddings model on the same provider", () => {
+    describe("when display names are built for them", () => {
+      it("includes both in one map, regardless of mode", () => {
+        const result = buildCustomModelDisplayNames([
+          makeProvider({
+            provider: "custom",
+            customModels: [
+              {
+                modelId: "gpt-5.1",
+                displayName: "Ada Prod Model",
+                mode: "chat",
+              },
+            ],
+            customEmbeddingsModels: [
+              {
+                modelId: "text-embed-3",
+                displayName: "Ada Prod Embed",
+                mode: "embedding",
+              },
+            ],
+          }),
+        ]);
 
-      expect(result["custom/gpt-5.1"]).toBe("Ada Prod Model");
-      expect(result["custom/text-embed-3"]).toBe("Ada Prod Embed");
+        expect(result["custom/gpt-5.1"]).toBe("Ada Prod Model");
+        expect(result["custom/text-embed-3"]).toBe("Ada Prod Embed");
+      });
     });
   });
 
   describe("given the same provider stored at two scopes, each with its own custom model", () => {
-    it("keeps both rows' models rather than letting one row win", () => {
-      const result = buildCustomModelDisplayNames([
-        makeProvider({
-          provider: "openai",
-          customModels: [
-            { modelId: "org-tune", displayName: "Org Tune", mode: "chat" },
-          ],
-        }),
-        makeProvider({
-          provider: "openai",
-          customModels: [
-            { modelId: "proj-tune", displayName: "Project Tune", mode: "chat" },
-          ],
-        }),
-      ]);
+    describe("when display names are built across both rows", () => {
+      it("keeps both rows' models rather than letting one row win", () => {
+        const result = buildCustomModelDisplayNames([
+          makeProvider({
+            provider: "openai",
+            customModels: [
+              { modelId: "org-tune", displayName: "Org Tune", mode: "chat" },
+            ],
+          }),
+          makeProvider({
+            provider: "openai",
+            customModels: [
+              {
+                modelId: "proj-tune",
+                displayName: "Project Tune",
+                mode: "chat",
+              },
+            ],
+          }),
+        ]);
 
-      expect(result["openai/org-tune"]).toBe("Org Tune");
-      expect(result["openai/proj-tune"]).toBe("Project Tune");
+        expect(result["openai/org-tune"]).toBe("Org Tune");
+        expect(result["openai/proj-tune"]).toBe("Project Tune");
+      });
     });
   });
 
-  describe("given custom entries whose display name is blank, absent, or whose model id is absent", () => {
-    // Mirrors the Background fixture's model id but deliberately uses a
-    // blank/absent display name — this block tests the malformed-entry
-    // path, not the happy path (which lives in the ProviderModelSelector /
-    // ModelChip integration tests).
+  describe("given custom entries whose display name is blank, whitespace-only, absent, or whose model id is absent", () => {
     const entries: CustomModelEntry[] = [
       { modelId: "gpt-5.1", displayName: "", mode: "chat" },
-      { modelId: "gpt-5.2", mode: "chat" } as CustomModelEntry,
+      { modelId: "gpt-5.2", displayName: "   ", mode: "chat" },
+      { modelId: "gpt-5.3", mode: "chat" } as CustomModelEntry,
       { displayName: "Orphan", mode: "chat" } as CustomModelEntry,
     ];
     const providers = [
       makeProvider({ provider: "custom", customModels: entries }),
     ];
 
-    /** @scenario A blank or incomplete custom entry falls back to the model id */
-    it("resolves entries with a model id to that id, skips the entry with no model id, and never yields a blank or undefined name", () => {
-      const displayNames = buildCustomModelDisplayNames(providers);
+    describe("when display names are resolved for them", () => {
+      /** @scenario A blank or incomplete custom entry falls back to the model id */
+      it("resolves each entry that has a model id to that model id", () => {
+        const displayNames = buildCustomModelDisplayNames(providers);
 
-      // Entries with a model id resolve to that model id ...
-      expect(modelDisplayLabel("custom/gpt-5.1", displayNames)).toBe("gpt-5.1");
-      expect(modelDisplayLabel("custom/gpt-5.2", displayNames)).toBe("gpt-5.2");
+        expect(
+          modelDisplayLabel({ fullModelId: "custom/gpt-5.1", displayNames }),
+        ).toBe("gpt-5.1");
+        expect(
+          modelDisplayLabel({ fullModelId: "custom/gpt-5.2", displayNames }),
+        ).toBe("gpt-5.2");
+        expect(
+          modelDisplayLabel({ fullModelId: "custom/gpt-5.3", displayNames }),
+        ).toBe("gpt-5.3");
+      });
 
-      // ... an entry without a model id is skipped (no "custom/undefined" key) ...
-      expect(Object.keys(displayNames)).not.toContain("custom/undefined");
+      it("skips the entry with no model id", () => {
+        const displayNames = buildCustomModelDisplayNames(providers);
 
-      // ... and no entry resolves to a blank or undefined name.
-      for (const value of Object.values(displayNames)) {
-        expect(value).toBeTruthy();
-        expect(value).not.toBe("undefined");
-      }
-    });
+        expect(Object.keys(displayNames)).not.toContain("custom/undefined");
+      });
 
-    it("does not add a key for the entry with no model id", () => {
-      const result = buildCustomModelDisplayNames([
-        makeProvider({
-          provider: "custom",
-          customModels: [
-            { displayName: "Orphan", mode: "chat" } as CustomModelEntry,
-          ],
-        }),
-      ]);
+      it("never yields a blank or undefined name", () => {
+        const displayNames = buildCustomModelDisplayNames(providers);
 
-      expect(Object.keys(result)).toHaveLength(0);
+        for (const value of Object.values(displayNames)) {
+          expect(value.trim()).toBeTruthy();
+          expect(value).not.toBe("undefined");
+        }
+      });
     });
   });
 });
 
 describe("modelDisplayLabel()", () => {
   describe("given a configured display name for the model", () => {
-    it("returns the display name", () => {
-      const label = modelDisplayLabel("custom/gpt-5.1", {
-        "custom/gpt-5.1": "Ada Prod Model",
-      });
+    describe("when the label is resolved", () => {
+      it("returns the display name", () => {
+        const label = modelDisplayLabel({
+          fullModelId: "custom/gpt-5.1",
+          displayNames: { "custom/gpt-5.1": "Ada Prod Model" },
+        });
 
-      expect(label).toBe("Ada Prod Model");
+        expect(label).toBe("Ada Prod Model");
+      });
     });
   });
 
   describe("given a blank display name stored for the model", () => {
-    it("falls back to the model id's family part instead of rendering blank", () => {
-      // Pins `||` over `??`: a `??`-based implementation would return ""
-      // here because the key IS present (not undefined) — only `||`
-      // treats a blank string as "missing". `"" ?? "gpt-5.1"` is `""`.
-      const label = modelDisplayLabel("custom/gpt-5.1", {
-        "custom/gpt-5.1": "",
-      });
+    describe("when the label is resolved", () => {
+      it("falls back to the model id's family part instead of rendering blank", () => {
+        // Pins `||` over `??`: a `??`-based implementation would return ""
+        // here because the key IS present (not undefined) — only `||`
+        // treats a blank string as "missing". `"" ?? "gpt-5.1"` is `""`.
+        const label = modelDisplayLabel({
+          fullModelId: "custom/gpt-5.1",
+          displayNames: { "custom/gpt-5.1": "" },
+        });
 
-      expect(label).toBe("gpt-5.1");
-      expect(label).not.toBe("");
+        expect(label).toBe("gpt-5.1");
+        expect(label).not.toBe("");
+      });
     });
   });
 
   describe("given no entry for the model in the map", () => {
-    it("falls back to the model id's family part", () => {
-      const label = modelDisplayLabel("openai/gpt-4o-mini", {
-        "custom/gpt-5.1": "Ada Prod Model",
-      });
+    describe("when the label is resolved", () => {
+      it("falls back to the model id's family part", () => {
+        const label = modelDisplayLabel({
+          fullModelId: "openai/gpt-4o-mini",
+          displayNames: { "custom/gpt-5.1": "Ada Prod Model" },
+        });
 
-      expect(label).toBe("gpt-4o-mini");
+        expect(label).toBe("gpt-4o-mini");
+      });
     });
   });
 
   describe("given no map at all", () => {
-    it("falls back to the model id's family part", () => {
-      const label = modelDisplayLabel("openai/gpt-4o-mini");
+    describe("when the label is resolved", () => {
+      it("falls back to the model id's family part", () => {
+        const label = modelDisplayLabel({ fullModelId: "openai/gpt-4o-mini" });
 
-      expect(label).toBe("gpt-4o-mini");
+        expect(label).toBe("gpt-4o-mini");
+      });
     });
   });
 
   describe("given a custom entry normalized from the legacy string form, whose display name equals its model id", () => {
-    /** @scenario A legacy custom model resolves to its model id */
-    it("resolves to its model id", () => {
-      const legacyEntries = toLegacyCompatibleCustomModels(["gpt-5.1"], "chat");
-      const displayNames = buildCustomModelDisplayNames([
-        makeProvider({ provider: "custom", customModels: legacyEntries }),
-      ]);
+    describe("when the label is resolved", () => {
+      /** @scenario A legacy custom model resolves to its model id */
+      it("resolves to its model id", () => {
+        const legacyEntries = toLegacyCompatibleCustomModels(
+          ["gpt-5.1"],
+          "chat",
+        );
+        const displayNames = buildCustomModelDisplayNames([
+          makeProvider({ provider: "custom", customModels: legacyEntries }),
+        ]);
 
-      expect(modelDisplayLabel("custom/gpt-5.1", displayNames)).toBe("gpt-5.1");
+        expect(
+          modelDisplayLabel({ fullModelId: "custom/gpt-5.1", displayNames }),
+        ).toBe("gpt-5.1");
+      });
     });
   });
 });

--- a/langwatch/src/server/modelProviders/__tests__/customModelDisplayNames.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/customModelDisplayNames.unit.test.ts
@@ -37,16 +37,14 @@ const makeProvider = (
 describe("buildCustomModelDisplayNames()", () => {
   describe("given a custom chat model with a display name", () => {
     it('keys the map by "<provider>/<modelId>"', () => {
-      const providers: Record<string, MaybeStoredModelProvider> = {
-        custom: makeProvider({
+      const result = buildCustomModelDisplayNames([
+        makeProvider({
           provider: "custom",
           customModels: [
             { modelId: "gpt-5.1", displayName: "Ada Prod Model", mode: "chat" },
           ],
         }),
-      };
-
-      const result = buildCustomModelDisplayNames(providers);
+      ]);
 
       expect(result["custom/gpt-5.1"]).toBe("Ada Prod Model");
     });
@@ -54,8 +52,8 @@ describe("buildCustomModelDisplayNames()", () => {
 
   describe("given both a custom chat model and a custom embeddings model on the same provider", () => {
     it("includes both in one map, regardless of mode", () => {
-      const providers: Record<string, MaybeStoredModelProvider> = {
-        custom: makeProvider({
+      const result = buildCustomModelDisplayNames([
+        makeProvider({
           provider: "custom",
           customModels: [
             { modelId: "gpt-5.1", displayName: "Ada Prod Model", mode: "chat" },
@@ -68,12 +66,32 @@ describe("buildCustomModelDisplayNames()", () => {
             },
           ],
         }),
-      };
-
-      const result = buildCustomModelDisplayNames(providers);
+      ]);
 
       expect(result["custom/gpt-5.1"]).toBe("Ada Prod Model");
       expect(result["custom/text-embed-3"]).toBe("Ada Prod Embed");
+    });
+  });
+
+  describe("given the same provider stored at two scopes, each with its own custom model", () => {
+    it("keeps both rows' models rather than letting one row win", () => {
+      const result = buildCustomModelDisplayNames([
+        makeProvider({
+          provider: "openai",
+          customModels: [
+            { modelId: "org-tune", displayName: "Org Tune", mode: "chat" },
+          ],
+        }),
+        makeProvider({
+          provider: "openai",
+          customModels: [
+            { modelId: "proj-tune", displayName: "Project Tune", mode: "chat" },
+          ],
+        }),
+      ]);
+
+      expect(result["openai/org-tune"]).toBe("Org Tune");
+      expect(result["openai/proj-tune"]).toBe("Project Tune");
     });
   });
 
@@ -87,9 +105,9 @@ describe("buildCustomModelDisplayNames()", () => {
       { modelId: "gpt-5.2", mode: "chat" } as CustomModelEntry,
       { displayName: "Orphan", mode: "chat" } as CustomModelEntry,
     ];
-    const providers: Record<string, MaybeStoredModelProvider> = {
-      custom: makeProvider({ provider: "custom", customModels: entries }),
-    };
+    const providers = [
+      makeProvider({ provider: "custom", customModels: entries }),
+    ];
 
     /** @scenario A blank or incomplete custom entry falls back to the model id */
     it("resolves entries with a model id to that id, skips the entry with no model id, and never yields a blank or undefined name", () => {
@@ -110,12 +128,14 @@ describe("buildCustomModelDisplayNames()", () => {
     });
 
     it("does not add a key for the entry with no model id", () => {
-      const result = buildCustomModelDisplayNames({
-        custom: makeProvider({
+      const result = buildCustomModelDisplayNames([
+        makeProvider({
           provider: "custom",
-          customModels: [{ displayName: "Orphan", mode: "chat" } as CustomModelEntry],
+          customModels: [
+            { displayName: "Orphan", mode: "chat" } as CustomModelEntry,
+          ],
         }),
-      });
+      ]);
 
       expect(Object.keys(result)).toHaveLength(0);
     });
@@ -169,11 +189,9 @@ describe("modelDisplayLabel()", () => {
     /** @scenario A legacy custom model resolves to its model id */
     it("resolves to its model id", () => {
       const legacyEntries = toLegacyCompatibleCustomModels(["gpt-5.1"], "chat");
-      const providers: Record<string, MaybeStoredModelProvider> = {
-        custom: makeProvider({ provider: "custom", customModels: legacyEntries }),
-      };
-
-      const displayNames = buildCustomModelDisplayNames(providers);
+      const displayNames = buildCustomModelDisplayNames([
+        makeProvider({ provider: "custom", customModels: legacyEntries }),
+      ]);
 
       expect(modelDisplayLabel("custom/gpt-5.1", displayNames)).toBe("gpt-5.1");
     });

--- a/langwatch/src/server/modelProviders/customModelDisplayNames.ts
+++ b/langwatch/src/server/modelProviders/customModelDisplayNames.ts
@@ -3,22 +3,30 @@ import type { MaybeStoredModelProvider } from "./registry";
 
 /**
  * Builds a lookup of `<provider>/<modelId>` -> configured Display Name
- * for every custom model across all providers, chat and embeddings
- * alike. Mirrors `mergeCustomModelMetadata`'s dual-list walk
- * (src/server/api/routers/modelProviders.utils.ts) so the one map
- * serves every `ProviderModelSelector` instance, whatever role it's
- * rendering for.
+ * for every custom model on the given provider rows, chat and
+ * embeddings alike, so one map serves every role a picker renders.
+ *
+ * Takes rows rather than a `Record` keyed by provider: a provider can
+ * be stored at several scopes, and collapsing those rows by key first
+ * would drop one row's custom models on the floor.
+ *
+ * Not to be confused with `mergeCustomModelMetadata`
+ * (src/server/api/routers/modelProviders.utils.ts), which also reads
+ * `displayName` off these same lists. Its record is keyed by model-
+ * provider id, not provider type, so the two key spaces don't join —
+ * it answers "what can this model do", this answers "what do we call
+ * it".
  *
  * Entries with no `modelId` or a blank/absent `displayName` are
  * omitted — the column is JSON and `toLegacyCompatibleCustomModels`
  * returns an unchecked cast, so malformed rows can reach here.
  */
 export const buildCustomModelDisplayNames = (
-  modelProviders: Record<string, MaybeStoredModelProvider>,
+  modelProviders: readonly MaybeStoredModelProvider[],
 ): Record<string, string> => {
   const displayNames: Record<string, string> = {};
 
-  for (const [providerKey, config] of Object.entries(modelProviders)) {
+  for (const config of modelProviders) {
     const entries: CustomModelEntry[] = [
       ...(config.customModels ?? []),
       ...(config.customEmbeddingsModels ?? []),
@@ -26,7 +34,7 @@ export const buildCustomModelDisplayNames = (
 
     for (const entry of entries) {
       if (!entry?.modelId || !entry.displayName) continue;
-      displayNames[`${providerKey}/${entry.modelId}`] = entry.displayName;
+      displayNames[`${config.provider}/${entry.modelId}`] = entry.displayName;
     }
   }
 

--- a/langwatch/src/server/modelProviders/customModelDisplayNames.ts
+++ b/langwatch/src/server/modelProviders/customModelDisplayNames.ts
@@ -10,6 +10,15 @@ import type { MaybeStoredModelProvider } from "./registry";
  * be stored at several scopes, and collapsing those rows by key first
  * would drop one row's custom models on the floor.
  *
+ * Two rows of the same provider defining the SAME `modelId` with
+ * different display names resolve to whichever row the query returned
+ * last. `findAllAccessibleForProject` issues a bare `findMany` with no
+ * `orderBy`, so row order carries no scope precedence — picking the
+ * first instead of the last would be equally arbitrary, and no
+ * precedence rule exists elsewhere in the picker to mirror. Both rows
+ * key to the same `<provider>/<modelId>`, so only the label is
+ * ambiguous; the stored value is identical either way.
+ *
  * Not to be confused with `mergeCustomModelMetadata`
  * (src/server/api/routers/modelProviders.utils.ts), which also reads
  * `displayName` off these same lists. Its record is keyed by model-

--- a/langwatch/src/server/modelProviders/customModelDisplayNames.ts
+++ b/langwatch/src/server/modelProviders/customModelDisplayNames.ts
@@ -17,9 +17,10 @@ import type { MaybeStoredModelProvider } from "./registry";
  * it answers "what can this model do", this answers "what do we call
  * it".
  *
- * Entries with no `modelId` or a blank/absent `displayName` are
- * omitted — the column is JSON and `toLegacyCompatibleCustomModels`
- * returns an unchecked cast, so malformed rows can reach here.
+ * Entries with no `modelId`, or whose `displayName` is absent or only
+ * whitespace, are omitted — the column is JSON and
+ * `toLegacyCompatibleCustomModels` returns an unchecked cast, so
+ * malformed rows can reach here.
  */
 export const buildCustomModelDisplayNames = (
   modelProviders: readonly MaybeStoredModelProvider[],
@@ -33,8 +34,9 @@ export const buildCustomModelDisplayNames = (
     ];
 
     for (const entry of entries) {
-      if (!entry?.modelId || !entry.displayName) continue;
-      displayNames[`${config.provider}/${entry.modelId}`] = entry.displayName;
+      const displayName = entry?.displayName?.trim();
+      if (!entry?.modelId || !displayName) continue;
+      displayNames[`${config.provider}/${entry.modelId}`] = displayName;
     }
   }
 
@@ -50,10 +52,13 @@ export const buildCustomModelDisplayNames = (
  * `||`, not `??`: a blank stored display name must fall through to
  * the id-derived label rather than render blank.
  */
-export const modelDisplayLabel = (
-  fullModelId: string,
-  displayNames?: Record<string, string>,
-): string => {
+export const modelDisplayLabel = ({
+  fullModelId,
+  displayNames,
+}: {
+  fullModelId: string;
+  displayNames?: Record<string, string>;
+}): string => {
   return (
     displayNames?.[fullModelId] || fullModelId.split("/").slice(1).join("/")
   );

--- a/langwatch/src/server/modelProviders/customModelDisplayNames.ts
+++ b/langwatch/src/server/modelProviders/customModelDisplayNames.ts
@@ -1,0 +1,52 @@
+import type { CustomModelEntry } from "./customModel.schema";
+import type { MaybeStoredModelProvider } from "./registry";
+
+/**
+ * Builds a lookup of `<provider>/<modelId>` -> configured Display Name
+ * for every custom model across all providers, chat and embeddings
+ * alike. Mirrors `mergeCustomModelMetadata`'s dual-list walk
+ * (src/server/api/routers/modelProviders.utils.ts) so the one map
+ * serves every `ProviderModelSelector` instance, whatever role it's
+ * rendering for.
+ *
+ * Entries with no `modelId` or a blank/absent `displayName` are
+ * omitted — the column is JSON and `toLegacyCompatibleCustomModels`
+ * returns an unchecked cast, so malformed rows can reach here.
+ */
+export const buildCustomModelDisplayNames = (
+  modelProviders: Record<string, MaybeStoredModelProvider>,
+): Record<string, string> => {
+  const displayNames: Record<string, string> = {};
+
+  for (const [providerKey, config] of Object.entries(modelProviders)) {
+    const entries: CustomModelEntry[] = [
+      ...(config.customModels ?? []),
+      ...(config.customEmbeddingsModels ?? []),
+    ];
+
+    for (const entry of entries) {
+      if (!entry?.modelId || !entry.displayName) continue;
+      displayNames[`${providerKey}/${entry.modelId}`] = entry.displayName;
+    }
+  }
+
+  return displayNames;
+};
+
+/**
+ * Resolves the label to render for a full model id
+ * (`<provider>/<modelId>`): the configured custom display name when
+ * one exists, otherwise the id's family part — the same fallback
+ * every selector used before display names existed.
+ *
+ * `||`, not `??`: a blank stored display name must fall through to
+ * the id-derived label rather than render blank.
+ */
+export const modelDisplayLabel = (
+  fullModelId: string,
+  displayNames?: Record<string, string>,
+): string => {
+  return (
+    displayNames?.[fullModelId] || fullModelId.split("/").slice(1).join("/")
+  );
+};

--- a/specs/model-providers/custom-model-display-name.feature
+++ b/specs/model-providers/custom-model-display-name.feature
@@ -1,0 +1,139 @@
+Feature: Custom Model Display Name in Selection UI
+  As a user who has given a custom model a friendly Display Name
+  I want that name shown wherever the model is listed or selected
+  So that I recognise my models by the name I chose instead of a raw provider ID
+
+  # Scope: the READ side of custom models — every surface that renders a model
+  # label. The write side (Add Model dialog, the Custom Models table inside the
+  # provider drawer) is covered by `custom-models-management.feature` and is not
+  # repeated here.
+  #
+  # Three components independently rebuild a model label from its ID with
+  # `split("/").slice(1).join("/")`: `useModelSelectionOptions` (ModelSelector),
+  # `ProviderModelSelector`, and `ModelChip`. A custom model's `displayName` is
+  # stored and sent to the browser but never read on that path — see #5759.
+  #
+  # Fixture note: the Display Name is deliberately DISJOINT from the Model ID
+  # ("Ada Prod Model" vs "gpt-5.1"). The originally-reported "gpt-5.1-custom" is
+  # a superstring of its own ID, so "the raw ID is not shown" is unassertable
+  # against it.
+
+  Background:
+    Given I am logged in
+    And I have access to a project
+    And an enabled provider "custom" has a custom chat model
+      | Model ID | Display Name   |
+      | gpt-5.1  | Ada Prod Model |
+
+  # --- Selection surfaces -------------------------------------------------
+
+  @integration
+  Scenario: Dropdown item shows the configured display name
+    When I open the Default Models editor and expand the Default role dropdown
+    Then the custom model's item reads "Ada Prod Model"
+    And that item's label does not contain "gpt-5.1"
+
+  @integration
+  Scenario: Collapsed selector shows the configured display name
+    Given the custom model is the selected Default role model
+    When I view the Default role selector collapsed
+    Then it reads "Ada Prod Model"
+
+  @integration
+  Scenario: Shared model pickers show the configured display name
+    When I open a model picker backed by the shared model-selection options
+    Then the custom model is listed as "Ada Prod Model"
+
+  @integration
+  Scenario: Default models table chip shows the configured display name
+    Given the custom model is saved as the Default role model
+    When I view the Default Models table with no editor open
+    Then the role's chip reads "Ada Prod Model"
+
+  @integration
+  Scenario: Scenario model picker shows the configured display name
+    When I open the simulation model picker
+    Then the custom model is listed as "Ada Prod Model"
+
+  @integration
+  Scenario: Custom embeddings model shows the configured display name
+    Given the provider also has a custom embeddings model
+      | Model ID     | Display Name   |
+      | text-embed-3 | Ada Prod Embed |
+    When I expand the Embeddings role dropdown
+    Then the embeddings model's item reads "Ada Prod Embed"
+    And that item's label does not contain "text-embed-3"
+
+  @integration
+  Scenario: Inherit entry shows the display name without replacing its own label
+    Given the Default role inherits the custom model from a broader scope
+    When I expand a role dropdown that offers an inherit entry
+    Then the inherit entry's subtitle reads "Ada Prod Model"
+    And the collapsed selector's placeholder reads "Ada Prod Model"
+    But the inherit entry's own label still reads the text its caller supplied
+
+  @integration
+  Scenario: Model labels outside pickers show the display name
+    Given the custom model is referenced by a saved prompt
+    When I view a surface that displays the model without offering a choice
+    Then it reads "Ada Prod Model"
+
+  # --- Search -------------------------------------------------------------
+
+  @integration
+  Scenario: Search by display name finds a renamed model
+    When I expand a role dropdown and search for "Ada"
+    Then the custom model remains listed
+
+  @integration
+  Scenario: Search by model id finds a renamed model
+    When I expand a role dropdown and search for "gpt-5.1"
+    Then the custom model remains listed
+
+  # --- Regression and failure modes ---------------------------------------
+
+  @integration
+  Scenario: Registry model labels are unchanged alongside a custom model
+    Given the same provider also offers the registry models "gpt-4o-mini" and "gpt-4o"
+    When I expand the Default role dropdown
+    Then the registry models still read "gpt-4o-mini" and "gpt-4o"
+    And the custom model reads "Ada Prod Model"
+
+  @integration
+  Scenario: Selecting a renamed model stores its model id
+    When I pick "Ada Prod Model" from the Default role dropdown
+    Then the value recorded for that role is the model's full ID, not its display name
+
+  @unit
+  Scenario: A blank or incomplete custom entry falls back to the model id
+    Given custom entries whose display name is blank, absent, or whose model id is absent
+    When display names are resolved for them
+    Then entries with a model id resolve to that model id
+    And an entry without a model id is skipped
+    And no entry resolves to a blank or undefined name
+
+  @unit
+  Scenario: A legacy custom model resolves to its model id
+    Given a custom entry normalized from the legacy string form, whose display name equals its model id
+    When display names are resolved for it
+    Then it resolves to its model id
+
+# --- AC Coverage Map ---
+# AC1  "Dropdown item shows the Display Name"           → Scenario: Dropdown item shows the configured display name
+# AC2  "Closed trigger shows the Display Name"          → Scenario: Collapsed selector shows the configured display name
+# AC3  "Shared pickers show the Display Name"           → Scenario: Shared model pickers show the configured display name
+# AC4  "Legacy rows render the Model ID"                → Scenario: A legacy custom model resolves to its model id
+# AC5  "Registry labels unchanged on a mixed provider"  → Scenario: Registry model labels are unchanged alongside a custom model
+# AC6  "Malformed / blank entry falls back"             → Scenario: A blank or incomplete custom entry falls back to the model id
+# AC7  "Search still matches the raw Model ID"          → Scenario: Search by model id finds a renamed model
+# AC8  "Ripple: selection value unchanged"              → Scenario: Selecting a renamed model stores its model id
+# AC9  "Falsifiability at both seams"                   → not a behaviour; it is the falsifiability property OF the
+#                                                         scenarios above. Evidenced by the two revert checks recorded
+#                                                         on the PR (resolver seam, ProviderModelSelector map-prop seam),
+#                                                         each naming the test + assertion that goes red.
+# AC10 "Inherit rendering shows the Display Name"       → Scenario: Inherit entry shows the display name without replacing its own label
+# AC11 "Default Models table chip"                      → Scenario: Default models table chip shows the configured display name
+# AC12 "Search matches the Display Name"                → Scenario: Search by display name finds a renamed model
+# AC13 "Scenario model pickers"                         → Scenario: Scenario model picker shows the configured display name
+# AC14 "Ripple: non-picker model labels"                → Scenario: Model labels outside pickers show the display name
+# AC15 "Custom embeddings models"                       → Scenario: Custom embeddings model shows the configured display name


### PR DESCRIPTION
**Scariest thing** — this touches the label of *every* model picker in the product, so the failure mode isn't "custom model looks wrong", it's "every registry model silently gets a different label". That's why the resolver only ever holds keys for user-defined custom models and everything else falls through to the exact `split("/")` expression used today; a mixed-provider test asserts `gpt-4o-mini`/`gpt-4o` render as literals.

**Start here** — `langwatch/src/server/modelProviders/customModelDisplayNames.ts` (49 lines, the whole idea). Then `ModelSelector.tsx:134` — one line, and it's the seam that fixes ~9 pickers at once.

## Why

A custom model's configured **Display Name** never reached the model pickers — they rendered the raw **Model ID**. Name a model `Ada Prod Model` in Model Providers and every selector still listed it as `gpt-5.1`. The name was stored correctly and even sent to the browser; it was simply never read when a dropdown drew its labels. Cosmetic, but customer-reported, and the Custom Models editor literally promises _"How this model appears in selectors across LangWatch"_ right under the field.

Closes #5759

## What changed

- **A shared display-name resolver, consulted at the label sites** → alternative: reuse the server's existing `modelMetadata.name`, which already carries the right value in the *same* query payload the pickers fetch. Rejected because `modelMetadata` covers registry models too, whose `name` differs from today's split-derived label — adopting it wholesale would silently restyle every model in every picker. Blast radius of the chosen approach is bounded: no custom model matched → byte-identical label.
- **Resolve where the label is *computed*, not where it's rendered** → alternative: patch the four render sites. Rejected because `ProviderModelSelector` filters search on `item.label`; patching rendered text only would leave the filter matching the stale label, so the item **vanishes** the moment a user types the name they can see. There is a test for exactly this.
- **Read both `customModels` and `customEmbeddingsModels`, un-mode-gated** → alternative: mirror the mode-gated loop in `ModelSelector.tsx:113-122`. Rejected because the Embeddings role renders on the same page; mode-gating the *label map* would have left `Ada Prod Embed` reading `text-embed-3`. Mode filtering stays where it belongs — in the options list.
- **`||`, not `??`, for the fallback** → `"" ?? x` yields `""`. A blank stored name would have rendered a blank dropdown row. Pinned by a unit test.
- **`getCustomModels`'s `string[]` contract left alone** → alternative: widen it to carry labels. Rejected: a 305-line suite pins it, and an ID-collector is the wrong home for a label.

## How it works

```
server/modelProviders/customModelDisplayNames.ts   [new]
├── buildCustomModelDisplayNames(providers)  →  { "custom/gpt-5.1": "Ada Prod Model" }
│     walks customModels + customEmbeddingsModels across all providers,
│     skips entries with no modelId or a blank displayName
└── modelDisplayLabel(fullId, displayNames?)  →  display name, else the id's family part

consumed by the three components that render a model label:
├── components/ModelSelector.tsx            useModelSelectionOptions → ~9 pickers
│                                            + LLMModelDisplay (prompts list, studio canvas)
├── components/settings/ProviderModelSelector.tsx   item label, closed trigger,
│                                            inherit placeholder + subtitle
│                                            (its own caller-supplied label untouched)
└── components/settings/ModelChip.tsx        Default Models table cells

threaded from the callers that already hold provider data:
DefaultModelOverrideDrawer · DefaultModelsSection · SimulationModelSelect · model-providers page
```

The resolver is a pure function, not a hook: callers already have the provider configs, and `ProviderModelSelector`/`ModelChip` stay presentational (their standalone tests render them with no tRPC provider).

## Human verification (for if you really don't trust me)

1. Settings → **Model Providers** → add a **Custom (OpenAI-compatible)** provider.
2. Under **Custom Models** → **Add** → **Add model**: Model ID `gpt-5.1`, Display Name `Ada Prod Model`. Save the model, save the provider.
3. **Default Models** → **Select default models** → open the **Default** dropdown.
   - Before this PR: the item reads `gpt-5.1`.
   - After: it reads `Ada Prod Model`.
4. Type `Ada` in the dropdown's search box — the model stays listed (this is the bit a render-only fix breaks).
5. Pick it, choose a scope, **Add config**. The **Default Models table** row must also read `Ada Prod Model` — not just the dropdown.
6. Confirm a registry model (e.g. `gpt-4o-mini`) still reads exactly as before.

## How I can prove I was successful

**proven — the bug reproduces on `origin/main` and is gone after the fix, in the running app.**

Booted a local stack (postgres + clickhouse + redis + `pnpm dev`), signed in, and configured the custom model through the real UI. Persisted row, straight from postgres — the write path was never the problem:

```json
{"mode": "chat", "modelId": "gpt-5.1", "displayName": "Ada Prod Model", ...}
{"mode": "embedding", "modelId": "text-embed-3", "displayName": "Ada Prod Embed"}
```

Dropdown option labels read out of the live DOM, same query both times:

```js
[...document.querySelectorAll('[role="option"]')].map(i => i.innerText.trim())

// BEFORE (origin/main @ 5e5c7e55f)
["Browser Test Org", "Browser Test Org", "Browser Test Org", "gpt-5.1", "gpt-5.1"]

// AFTER
["Browser Test Org", "Browser Test Org", "Browser Test Org", "Ada Prod Model", "Ada Prod Model", "Ada Prod Embed"]
```

**BEFORE** — Default Models dropdown showing the raw Model ID `gpt-5.1`:

![before](https://raw.githubusercontent.com/langwatch/langwatch/pr-screenshots/pr-5759/5759-before-dropdown-raw-id.png)

**AFTER** — same dropdown, same fixture, showing `Ada Prod Model`:

![after](https://raw.githubusercontent.com/langwatch/langwatch/pr-screenshots/pr-5759/5759-after-dropdown-display-name.png)

**AFTER** — the Default Models **table** (drawer closed) showing `Ada Prod Model` and `Ada Prod Embed`. This is the surface that would have shipped broken if only the dropdown were fixed:

![after-table](https://raw.githubusercontent.com/langwatch/langwatch/pr-screenshots/pr-5759/5759-after-table-display-name.png)

The chips' testids are still `model-chip-custom/gpt-5.1` / `model-chip-custom/text-embed-3` — **proven** that only the label changed and the stored value is untouched.

**AFTER** — the prompt playground's model picker, a completely separate code path (`useModelSelectionOptions` → `LLMModelDisplay`, not the settings selector). Reads `Ada Prod Model`; the string `gpt-5.1` appears nowhere on the page (`hasAda: true, hasRawId: false`, read from the live DOM):

![after-prompt-picker](https://raw.githubusercontent.com/langwatch/langwatch/pr-screenshots/pr-5759/5759-after-prompt-picker.png)

**AFTER** — the simulation run-plan drawer's model picker (`SimulationModelSelect`, which builds its own options and bypasses the shared hook entirely, so nothing else here covers it). Reads `Ada Prod Model`; `gpt-5.1` appears nowhere on the page:

![after-simulation-picker](https://raw.githubusercontent.com/langwatch/langwatch/pr-screenshots/pr-5759/5759-after-simulation-picker.png)

**proven — tests fail before, pass after.** Committed RED first (`53dc2dfd`), fix second (`db79bf4a`):

```
# on the test-only commit
Test Files  5 failed (5)
     Tests  19 failed | 3 passed (22)
TestingLibraryElementError: Unable to find an element with the text: Ada Prod Model

# after the fix
Test Files  5 passed (5)     Tests  22 passed (22)     [integration]
Test Files  1 passed (1)     Tests   9 passed (9)      [unit]
```
Zero import errors on the integration side — every failure was a real label assertion, not a missing module. The 3 that passed pre-fix are deliberate regression guards (registry labels unchanged; the inherit entry's own label).

**proven — falsifiable at every seam, checked by hand rather than assumed.** I reverted each seam individually and watched it go red:

| Reverted | Result |
|---|---|
| `ModelSelector.tsx:134` label wiring | hook-backed tests RED: `Tests 4 failed (4)` — "Unable to find an element with the text: Ada Prod Model" |
| `ProviderModelSelector` map-prop threading | `Tests 11 failed \| 5 passed` — and `ModelChip`'s tests stayed GREEN, confirming the seams are independently pinned |
| `ModelChip.tsx` alias branch back to `family === "latest"` | RED — renders `Latest smaller` |
| `displayNames={displayNames}` deleted at `DefaultModelOverrideDrawer.tsx:492` + `DefaultModelsSection.tsx:491` | `Tests 5 failed \| 5 passed` |

That last row is why the final commit exists. `displayNames` is **optional** on both leaf components, so a refactor that dropped the prop from the drawer or the table would compile and leave every test green — silently reintroducing "no test asserts a rendered label equals a configured display name", which is the gap that caused this bug in the first place. The existing `DefaultModelsSection` fixtures use `customModels: []`/`null` and were structurally blind to it; there was no drawer test at all. Now the drawer test renders the real drawer over mocked tRPC, so the whole chain runs: map build → threading → render.

**proven — no regressions.** `pnpm typecheck` ✅ · `pnpm typecheck:tests` ✅ · `pnpm check:feature-parity` ✅ (all 14 scenarios bound; `OK: 2488 enforced scenario(s)`) · full suites for every touched component: `Test Files 38 passed | 1 skipped`, `Tests 263 passed | 6 skipped`, zero failures. Final tally for this PR's own tests: **10 unit + 33 integration green**.

**claimed — one CI flake, not caused by this PR.** The first `langwatch-app-ci` run failed on `× triggers with the same value from trace_analytics` (`graph-trigger-dual-path.integration.test.ts`). Three independent checks say it isn't mine: this PR touches **zero** trigger files (`git diff --name-only 5e5c7e55f..HEAD | grep -i trigger` → nothing), the file passes locally on this branch (`Tests 18 passed`), and **re-running the identical commit went green**. Flagging rather than burying it — if it recurs on unrelated PRs it's worth its own issue.

**proven — the design review found a real regression, and it's fixed (`44aa2ee0`).** Worth knowing about, since it's the kind of thing that survives a green suite:

`ModelChip` repurposed `family` from "the id's family part" to "the resolved display label", but line 55 still branched on `family === "latest"` to choose the alias copy. A custom model named `My Latest` on `openai/latest` would therefore render **"Latest smaller"**. A presentational value was driving a structural branch. Alias detection now reads a separate `idFamily`; the regression test goes red against the old line (verified: renders `Latest smaller`, test fails). The same review also flipped `buildCustomModelDisplayNames` to take provider rows rather than a Record — three of four callers were each building a single-entry Record per row and merging, purely to avoid collapsing a provider stored at two scopes. Rows make that footgun unrepresentable; a unit test pins the two-scope case.

## Anything surprising?

- **The investigation initially found two label sites; there are three.** `ModelChip` (the Default Models *table*) was caught by an AC review before any code was written. Without it you'd pick `Ada Prod Model` in the dropdown, hit save, and the table underneath would still say `gpt-5.1` — two spellings of one model on one screen.
- **Custom *embeddings* models were nearly missed too** — a parallel list with its own Display Name field, rendering on the same page. Hence the un-mode-gated map.
- **Deliberately out of scope — all four filed, none left to evaporate:**
  - #5826 — stock `.env.example` can't boot the API (empty `OPENAI_API_KEY` defeats the `??` guard). Hit this for real while booting the repro.
  - #5827 — `toLegacyCompatibleCustomModels` casts instead of parsing, which is why three call sites hand-guard the shape and why this resolver is defensive.
  - #5828 — display names don't resolve for canonical `{mpId}/{model}` ids. Not a regression (the old `split("/")` did the same), but the feature silently won't apply there.
  - #5829 — unify model-label rendering; four paths each rebuild the label from the id. This duplication *is* the root cause of #5759 — the fix adds the shared primitive, but the shape that produced the bug survives.

  Detail on each, and why they're out of scope here:
  - **Onboarding's model picker** (`ModelProviderModelSettings.tsx:42`) is a fourth, hand-rolled label path. Its own tags input writes `displayName: value`, so a name distinct from the ID can only reach it from a previously-saved provider row — too narrow to justify widening this fix.
  - `toLegacyCompatibleCustomModels` returns an **unchecked cast** (`customModel.schema.ts:110`), which is why three call sites hand-guard `if (m?.modelId)` and why this resolver is defensive. Should be one `customModelEntrySchema` parse instead.
  - **A canonical-wire-format gap**: `modelDisplayLabel` resolves in legacy `<provider>/<modelId>` space, but `modelProviders.utils.ts:295-299` says a canonical `{mpId}/{model}` form also exists. A default stored canonically renders the raw id. Not a regression — the old `split("/")` did the same — but the display-name feature silently won't apply there.
  - `env.OPENAI_API_KEY ?? "bogus"` (`server/routes/misc.ts:173`) doesn't guard the empty string `.env.example` ships, so a stock `.env` crashloops the API at module load. Unrelated; found while booting the repro.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom model **display names** are now rendered consistently across model selectors, dropdown options (including simulations/embeddings), inherited entries, and the default-models settings and model chips.
  * Model search can match using either the **configured display name** or the underlying **model ID**.
* **Bug Fixes**
  * Custom display names no longer affect **“latest” alias** labeling or **registry model** naming.
* **Tests**
  * Added unit, integration, and Cucumber coverage to validate display-name rendering, searching, inheritance behavior, and fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->