### PR TITLE
refactor(errors): rename DomainError → HandledError, match Go herr shape

### DIFF
--- a/dev/docs/adr/045-domain-errors-handled-boundary.md
+++ b/dev/docs/adr/045-domain-errors-handled-boundary.md
@@ -1,4 +1,4 @@
-# ADR-045: Domain errors as the handled-error boundary (TS `DomainError` ⇔ Go `herr`)
+# ADR-045: Handled errors as the handled-error boundary (TS `HandledError` ⇔ Go `herr`)
 
 **Date:** 2026-07-10
 
@@ -19,19 +19,19 @@ the whole point:
    The caller cannot act on the raw detail, and presenting it as if they could is
    both a poor experience and a leak surface.
 
-The platform already has the machinery for (1): the app-layer `DomainError`
-(`src/server/app-layer/domain-error.ts`) — an abstract `Error` subclass carrying
-a serialisable `kind`, `meta`, `telemetry` (traceId/spanId captured from the
-active OTel span), `httpStatus`, and a `reasons` cause chain, with a
-`serialize()` producing `SerializedDomainError`. It is wired into both transports:
+The platform already has the machinery for (1): the app-layer `HandledError`
+(`src/server/app-layer/handled-error.ts`) — an abstract `Error` subclass carrying
+a serialisable `code`, `meta`, `traceId`/`spanId` (captured from the active OTel
+span), `httpStatus`, and a `reasons` cause chain, with a `serialize()` producing
+`SerializedHandledError`. It is wired into both transports:
 
-- **tRPC** (`src/server/api/trpc.ts`): a `domainErrorMiddleware` converts a
-  `DomainError` thrown in a procedure into a correctly-coded `TRPCError` (via
-  `domainErrorToTRPCCode`), and the `errorFormatter` calls `.serialize()` and
+- **tRPC** (`src/server/api/trpc.ts`): a `handledErrorMiddleware` converts a
+  `HandledError` thrown in a procedure into a correctly-coded `TRPCError` (via
+  `handledErrorToTRPCCode`), and the `errorFormatter` calls `.serialize()` and
   attaches the result to the error's `data.domainError`.
 - **Hono** (`src/app/api/middleware/error-handler.ts`, wired by every
-  `createServiceApp` at `SecuredApp.onError`): a `DomainError` becomes
-  `{ error: kind, message, ...meta }` at its `httpStatus`.
+  `createServiceApp` at `SecuredApp.onError`): a `HandledError` becomes
+  `{ error: code, message, ...meta }` at its `httpStatus`.
 
 The Go services have the exact same split in `pkg/herr`: a handled error is an
 `herr.E{ Code, Meta, TraceID, SpanID, Reasons }` created deliberately via
@@ -42,11 +42,11 @@ non-`herr` reasons** before they leave the process.
 What is missing is not machinery but **discipline and reach**. Large parts of the
 codebase — the Langy route is the clearest offender — hand-roll
 `c.json({ error: "..." }, { status })` with generic strings, or wrap unknown
-failures in ad-hoc `extends Error` classes, bypassing the `DomainError` path
+failures in ad-hoc `extends Error` classes, bypassing the `HandledError` path
 entirely. The result is opaque, inconsistent errors: the same "not found" is a
 typed 404 in one place and a bare string in another, and an internal crash can
 surface its raw message as though it were an actionable API error. We also have
-no stated rule for **when** to reach for a `DomainError` versus a plain `Error`,
+no stated rule for **when** to reach for a `HandledError` versus a plain `Error`,
 so the two get used interchangeably.
 
 ## Decision
@@ -57,65 +57,65 @@ an unknown/internal error.**
 
 Concretely:
 
-1. **Throw a `DomainError` (Go: return an `herr.E`) only when the cause is both
+1. **Throw a `HandledError` (Go: return an `herr.E`) only when the cause is both
    known and user-relevant.** Not-found, forbidden, not-owned, validation,
    conflict, timeout, rate-limited, precondition-not-met, quota-exceeded — the
-   failures we can name and a caller can respond to. Give each a stable `kind`
+   failures we can name and a caller can respond to. Give each a stable `code`
    (Go: `Code`) and put the identifying context in `meta`.
 
 2. **For anything internal or unanticipated, use a plain JavaScript `Error` (Go:
    a plain `error`).** A database crash, an infra timeout we don't model, a bug.
-   Do **not** invent a `DomainError` to dress it up. It will correctly degrade to
+   Do **not** invent a `HandledError` to dress it up. It will correctly degrade to
    "unknown" at the boundary.
 
 3. **The boundary only serialises handled errors.** The presence of a serialised
    domain payload IS the signal of "handled":
-   - tRPC: `data.domainError` is the `SerializedDomainError`, or `null`.
-   - Hono: a `DomainError` yields `{ error: kind, message, ...meta }`; an
+   - tRPC: `data.domainError` is the `SerializedHandledError`, or `null`.
+   - Hono: a `HandledError` yields `{ error: code, message, ...meta }`; an
      unhandled error yields a generic internal response.
    - An unhandled error carries **no** `domainError` payload. Its raw detail is
      **logged server-side with the trace id**, never presented to the client as
      an actionable error. Clients render it as a single generic "something went
-     wrong" plus the trace id for support (`DomainError.toUserMessage` already
-     returns `"An unknown error occurred"` for non-domain errors and hands the
+     wrong" plus the trace id for support (`HandledError.toUserMessage` already
+     returns `"An unknown error occurred"` for non-handled errors and hands the
      original to a log callback).
 
 4. **A handled error may wrap an unhandled cause without leaking it.**
-   `serialize()` walks `reasons` and masks any non-`DomainError` link as
-   `{ kind: "unknown" }`. So `new EvaluationNotFoundError(..., { reasons: [pgError] })`
+   `serialize()` walks `reasons` and masks any non-`HandledError` link as
+   `{ code: "unknown" }`. So `new EvaluationNotFoundError(..., { reasons: [pgError] })`
    keeps the useful top and hides the internal bottom. Use this when a known
    failure was ultimately triggered by an internal one.
 
 5. **Handled-ness is preserved across the Go↔TS boundary.** When the control
    plane proxies a Go service, an `herr` envelope is adapted into a
-   `DomainError` (`Code → kind`, `meta → meta`, `trace_id/span_id →
-   telemetry`, `reasons → reasons`); a plain Go `error` stays unhandled and
+   `HandledError` (`Code → code`, `meta → meta`, `trace_id/span_id →
+   traceId/spanId`, `reasons → reasons`); a plain Go `error` stays unhandled and
    becomes "unknown." A handled error in Go is a handled error in the browser.
 
 6. **Non-tRPC/Hono transports carry the same shape.** Streamed responses (e.g.
    the Langy chat NDJSON stream) that today emit `{ type: "error", error:
-   string }` must instead emit the `SerializedDomainError` on their error event,
+   string }` must instead emit the `SerializedHandledError` on their error event,
    so the client's handled/unknown logic is identical regardless of transport.
 
 7. **The client is the single place that decides presentation.** A shared reader
-   (`readDomainError`, already used by
+   (`readHandledError`, already used by
    `src/features/automations/logic/errorExplainer.ts`) lifts `data.domainError`;
-   an `explain*`-style mapping keyed on `kind` turns it into user-facing copy and
+   an `explain*`-style mapping keyed on `code` turns it into user-facing copy and
    an optional action/render choice. The server never dictates UI; it emits the
    typed fact, the client renders it. Absence of a domain payload → the generic
    unknown treatment.
 
-`kind` (Go: `Code`) is a **serialisable string discriminant** and is the correct
+`code` (Go: `Code`) is a **serialisable string discriminant** and is the correct
 check across process, worker, and serialisation boundaries — use
-`err.kind === "evaluation_not_found"`, not `instanceof`, in those cases
+`err.code === "evaluation_not_found"`, not `instanceof`, in those cases
 (`instanceof` is same-process only and breaks across the Next.js/turbopack module
-boundary, which is why the Hono handler checks `"kind" in error`).
+boundary, which is why the Hono handler checks `"code" in error`).
 
 ## Rationale / Trade-offs
 
 The alternative — let every route decide its own error shape — is what we have,
 and it produces exactly the opacity described above. Centralising on
-`DomainError`/`herr` costs each domain a small `errors.ts` of typed subclasses
+`HandledError`/`herr` costs each domain a small `errors.ts` of typed subclasses
 and the discipline to throw them instead of returning strings, but it buys a
 single, predictable contract: a client (human or agent) can always tell a "you
 did something we understand, here's what and why" from a "we broke, sorry,"
@@ -138,37 +138,37 @@ the reference.
 
 ## Consequences
 
-- **New per-domain `errors.ts` modules** of `DomainError` subclasses, each with a
-  stable `kind` and a sensible `httpStatus`. Existing ad-hoc `extends Error`
+- **New per-domain `errors.ts` modules** of `HandledError` subclasses, each with a
+  stable `code` and a sensible `httpStatus`. Existing ad-hoc `extends Error`
   classes (e.g. Langy's `LangyCredentialResolutionError`,
-  `LangyConversationNotOwnedError`) become `DomainError` subclasses with a `kind`.
+  `LangyConversationNotOwnedError`) become `HandledError` subclasses with a `code`.
 - **Service routes stop hand-rolling `c.json({ error: string })`.** They throw a
-  `DomainError`; `createServiceApp`'s `onError` already serialises it. A generic
+  `HandledError`; `createServiceApp`'s `onError` already serialises it. A generic
   string response becomes a code smell.
 - **Streamed transports gain a structured error event** carrying
-  `SerializedDomainError`. The Langy chat stream is the first adopter.
-- **The control plane grows a small `herr → DomainError` adapter** used wherever
+  `SerializedHandledError`. The Langy chat stream is the first adopter.
+- **The control plane grows a small `herr → HandledError` adapter** used wherever
   it proxies a Go service (Langy agent, NLP, gateway), so cross-language handled
   errors stay handled.
-- **The client standardises on `readDomainError` + a `kind`-keyed explainer.**
+- **The client standardises on `readHandledError` + a `code`-keyed explainer.**
   Features render handled errors usefully and unhandled errors as one calm
   generic state plus a trace id. Langy's `<LangyError>` is a richer instance of
   this pattern (card / inline / suppress).
-- **Observability improves for free:** every `DomainError` captures the active
-  span's trace/span id, and tRPC already logs `domainErrorKind`, so handled
-  failures are queryable by kind and joinable to their trace.
+- **Observability improves for free:** every `HandledError` captures the active
+  span's trace/span id, and tRPC already logs `handledErrorCode`, so handled
+  failures are queryable by code and joinable to their trace.
 - **"Unknown" is a first-class, intended outcome.** An unhandled error producing
   a generic client response with a trace id is the system working as designed,
-  not a gap to be filled by inventing a domain error for it.
+  not a gap to be filled by inventing a handled error for it.
 
 ## References
 
-- Code (TS): `src/server/app-layer/domain-error.ts` (`DomainError`,
-  `SerializedDomainError`, `NotFoundError`, `ValidationError`),
-  `src/server/api/trpc.ts` (`domainErrorMiddleware`, `errorFormatter`),
+- Code (TS): `src/server/app-layer/handled-error.ts` (`HandledError`,
+  `SerializedHandledError`, `NotFoundError`, `ValidationError`),
+  `src/server/api/trpc.ts` (`handledErrorMiddleware`, `errorFormatter`),
   `src/app/api/middleware/error-handler.ts` (`handleError`),
   `src/features/automations/logic/errorExplainer.ts`
-  (`readDomainError`/`explainDomainError`).
+  (`readHandledError`/`explainHandledError`).
 - Code (Go): `pkg/herr/herr.go` (`E`, `New`), `pkg/herr/http.go`
   (`WriteHTTP`, code→status registry).
 - Related ADRs: [027](./027-typed-dispatcherror-contract.md) (typed

--- a/dev/docs/adr/045-domain-errors-handled-boundary.md
+++ b/dev/docs/adr/045-domain-errors-handled-boundary.md
@@ -160,6 +160,14 @@ the reference.
 - **"Unknown" is a first-class, intended outcome.** An unhandled error producing
   a generic client response with a trace id is the system working as designed,
   not a gap to be filled by inventing a handled error for it.
+- **The `kind` → `code` rename ships non-breaking.** Renaming the wire
+  discriminant from the old `DomainError.kind` to `HandledError.code` would break
+  any client still reading `kind` during a rolling deploy. To avoid that,
+  serialisation emits **both**: `code` plus a deprecated `kind` alias holding the
+  same value (top-level and in nested `reasons`), and the client readers resolve
+  the discriminant from `code ?? kind`. This makes both rollout directions safe
+  (old client ↔ new server, new client ↔ old server). The `kind` alias is
+  transitional — remove it once no consumer reads `kind`.
 
 ## References
 

--- a/dev/docs/adr/README.md
+++ b/dev/docs/adr/README.md
@@ -36,7 +36,7 @@ Document **important technical and architectural decisions** — context, trade-
 | [042](./042-local-observability-stack.md) | Local observability stack (logs, traces, metrics → Grafana) | Accepted |
 | [043](./043-automation-facet-model.md) | Automations as orthogonal facets (name / type / subject / cadence / severity / delivery) | Proposed |
 | [044](./044-scheduled-reports-automation-kind.md) | Scheduled reports — a schedule-triggered automation kind + generic event-sourcing scheduler | Proposed |
-| [045](./045-domain-errors-handled-boundary.md) | Domain errors as the handled-error boundary (TS `DomainError` ⇔ Go `herr`) | Accepted |
+| [045](./045-domain-errors-handled-boundary.md) | Handled errors as the handled-error boundary (TS `HandledError` ⇔ Go `herr`) | Accepted |
 
 ## When to Write an ADR
 

--- a/langwatch/ee/admin/impersonation.service.ts
+++ b/langwatch/ee/admin/impersonation.service.ts
@@ -1,5 +1,5 @@
 import { Prisma, type PrismaClient } from "@prisma/client";
-import { DomainError, NotFoundError } from "~/server/app-layer/domain-error";
+import { HandledError, NotFoundError } from "~/server/app-layer/handled-error";
 import { isAdmin } from "./isAdmin";
 
 /** Impersonation window handed to the UI once a start call succeeds. */
@@ -11,7 +11,7 @@ const IMPERSONATION_TTL_MS = 1000 * 60 * 60; // 1 hour
  * admin to re-enter them would defeat the revocation. Maps to HTTP 400
  * because the request itself is well-formed; only the target state is wrong.
  */
-export class CannotImpersonateDeactivatedUserError extends DomainError {
+export class CannotImpersonateDeactivatedUserError extends HandledError {
   constructor(userId: string) {
     super(
       "cannot_impersonate_deactivated_user",
@@ -29,7 +29,7 @@ export class CannotImpersonateDeactivatedUserError extends DomainError {
  * deliberately denied, not a system failure — clients should render an
  * "impersonation not permitted" message, not retry.
  */
-export class CannotImpersonateAdminError extends DomainError {
+export class CannotImpersonateAdminError extends HandledError {
   constructor(userId: string) {
     super(
       "cannot_impersonate_admin",

--- a/langwatch/ee/admin/routes/admin.ts
+++ b/langwatch/ee/admin/routes/admin.ts
@@ -23,7 +23,7 @@ import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import { auditLog } from "~/server/auditLog";
 import { UserService } from "~/server/users/user.service";
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 import { isAdmin } from "../isAdmin";
 import {
   ORGANIZATION_SAFE_SELECT,
@@ -54,7 +54,7 @@ const ALLOWED_RESOURCES = new Set([
 //
 // Both verbs share the same admin guard + BetterAuth session lookup, so we
 // route them through a single helper and let the service do the real work.
-// The service throws `DomainError` subclasses for business-rule rejections;
+// The service throws `HandledError` subclasses for business-rule rejections;
 // the helper below maps those to HTTP status codes, keeping the route
 // thin and leaving the rules in one testable place.
 
@@ -115,8 +115,8 @@ async function handleImpersonate(c: any, method: "POST" | "DELETE") {
   } catch (err) {
     // Use `kind`, not `instanceof`, for the discriminant — survives the
     // bundler duplicating class identities across module boundaries (see
-    // the rule in CLAUDE.md + domain-error.ts's doc comment).
-    if (DomainError.isHandled(err)) {
+    // the rule in CLAUDE.md + handled-error.ts's doc comment).
+    if (HandledError.isHandled(err)) {
       return c.json({ message: err.message }, err.httpStatus as any);
     }
     throw err;

--- a/langwatch/ee/admin/routes/admin.ts
+++ b/langwatch/ee/admin/routes/admin.ts
@@ -113,9 +113,11 @@ async function handleImpersonate(c: any, method: "POST" | "DELETE") {
       req: c.req.raw,
     });
   } catch (err) {
-    // Use `kind`, not `instanceof`, for the discriminant — survives the
-    // bundler duplicating class identities across module boundaries (see
-    // the rule in CLAUDE.md + handled-error.ts's doc comment).
+    // Handled errors carry client-safe copy: narrow with isHandled, then return
+    // { message, httpStatus }; anything else re-throws to the global handler.
+    // isHandled is an instanceof check, reliable here since the error is thrown
+    // and caught in the same server module graph. See handled-error.ts's doc
+    // comment for when the serialisable `code` discriminant is needed instead.
     if (HandledError.isHandled(err)) {
       return c.json({ message: err.message }, err.httpStatus as any);
     }

--- a/langwatch/packages/api/README.md
+++ b/langwatch/packages/api/README.md
@@ -78,7 +78,7 @@ export { GET, POST, PUT, PATCH, DELETE } from "./things.service";
 - **Tracing + logging** via `@langwatch/observability` (automatic, disable with `tracer: false` / `logger: false`)
 - **Auth, org, resource limits** applied in the right order per-endpoint
 - **Input/output/params/query validation** from Zod schemas, auto-wired to OpenAPI
-- **Error formatting** that duck-types `DomainError` (kind, meta, reasons, telemetry) and catches Zod errors
+- **Error formatting** that duck-types `HandledError` (code, meta, reasons, traceId/spanId) and catches Zod errors
 - **Versioned routing** at `/api/{name}/{date}/...` with forward-copying from previous versions
 
 ## Handler signature
@@ -186,9 +186,9 @@ v.sse(
 
 ## Error handling
 
-Throw `DomainError` subclasses (from `~/server/app-layer/domain-error`). The framework:
+Throw `HandledError` subclasses (from `~/server/app-layer/handled-error`). The framework:
 
-1. Catches and serializes them with `kind`, `meta`, `reasons`, `telemetry`
+1. Catches and serializes them with `code`, `meta`, `reasons`, `traceId`/`spanId`
 2. Catches `ZodError` and maps each issue to a `schema_failure` reason (cher-style)
 3. Returns union format for unversioned requests (includes legacy `error` field)
 4. Returns clean format for versioned requests
@@ -197,7 +197,7 @@ Validation error example:
 
 ```json
 {
-  "kind": "validation_error",
+  "code": "validation_error",
   "message": "Validation error",
   "reasons": [
     {
@@ -240,7 +240,7 @@ src/
   builder.ts          # createService(), ServiceBuilder, VersionBuilder
   versioning.ts       # Forward-copy algorithm + request-time resolution
   middleware.ts       # Built-in tracer + logger (uses @langwatch/observability)
-  errors.ts           # Error handler (DomainError, ZodError, version-gated format)
+  errors.ts           # Error handler (HandledError, ZodError, version-gated format)
   sse.ts              # v.sse() with typed events
   types.ts            # ServiceConfig, EndpointConfig, Handler, BaseApp
   index.ts            # Public re-exports + routeHandlers()
@@ -257,6 +257,6 @@ When creating a new API service using this framework:
 5. Use `.provide()` for service-layer dependencies — factories get `{ project, _legacy: { organization, prisma } }`
 6. Define Zod schemas for input/output/params next to the service, not in a shared types file
 7. Handlers return raw data when `output` is set; the framework validates and serializes
-8. Throw `NotFoundError` / `DomainError` for error responses — don't return `c.json({ error }, 404)` manually
+8. Throw `NotFoundError` / `HandledError` for error responses — don't return `c.json({ error }, 404)` manually
 9. Use `status: 201` in endpoint config for creation endpoints
 10. Use the Quick start in this README as the reference until an existing service has been migrated to the package

--- a/langwatch/packages/api/src/__tests__/builder.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/builder.unit.test.ts
@@ -395,6 +395,8 @@ describe("output validation", () => {
       expect(res.status).toBe(500);
       expect(await jsonBody(res)).toEqual({
         code: "internal_error",
+        // Deprecated back-compat alias of `code` (see ErrorResponseBody.kind).
+        kind: "internal_error",
         message: "Internal server error",
       });
     });

--- a/langwatch/packages/api/src/__tests__/builder.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/builder.unit.test.ts
@@ -343,7 +343,7 @@ describe("input validation", () => {
 
       expect(res.status).toBe(422);
       expect(await jsonBody(res)).toMatchObject({
-        kind: "validation_error",
+        code: "validation_error",
         reasons: [
           {
             code: "schema_failure",
@@ -394,7 +394,7 @@ describe("output validation", () => {
 
       expect(res.status).toBe(500);
       expect(await jsonBody(res)).toEqual({
-        kind: "internal_error",
+        code: "internal_error",
         message: "Internal server error",
       });
     });
@@ -678,7 +678,7 @@ describe("version forward-copying via builder", () => {
       const oldRes = await makeRequest(app, "/api/test/2025-06-01/old");
       expect(oldRes.status).toBe(410);
       const oldBody = await jsonBody(oldRes);
-      expect((oldBody as { kind: string }).kind).toBe("endpoint_withdrawn");
+      expect((oldBody as { code: string }).code).toBe("endpoint_withdrawn");
       expect(oldRes.headers.get("X-API-Version")).toBe("2025-06-01");
       expect(oldRes.headers.get("X-API-Version-Status")).toBe("stable");
 
@@ -906,25 +906,26 @@ describe("error handling", () => {
 
       const res = await makeRequest(app, "/api/test/2025-03-15/fail");
       expect(res.status).toBe(500);
-      const body = (await jsonBody(res)) as { kind: string };
-      expect(body.kind).toBe("internal_error");
+      const body = (await jsonBody(res)) as { code: string };
+      expect(body.code).toBe("internal_error");
     });
   });
 
-  describe("when a handler throws a DomainError-like error", () => {
+  describe("when a handler throws a HandledError-like error", () => {
     it("serializes it correctly", async () => {
       const app = buildTestService()
         .version("2025-03-15", (v) => {
           v.get("/fail", {}, async () => {
             const err = Object.assign(new Error("Not found"), {
-              kind: "thing_not_found",
+              code: "thing_not_found",
               httpStatus: 404,
               meta: { id: "123" },
               serialize() {
                 return {
-                  kind: "thing_not_found",
+                  code: "thing_not_found",
                   meta: { id: "123" },
-                  telemetry: { traceId: undefined, spanId: undefined },
+                  traceId: undefined,
+                  spanId: undefined,
                   httpStatus: 404,
                   reasons: [],
                 };
@@ -938,10 +939,10 @@ describe("error handling", () => {
       const res = await makeRequest(app, "/api/test/2025-03-15/fail");
       expect(res.status).toBe(404);
       const body = (await jsonBody(res)) as {
-        kind: string;
+        code: string;
         meta: { id: string };
       };
-      expect(body.kind).toBe("thing_not_found");
+      expect(body.code).toBe("thing_not_found");
       expect(body.meta.id).toBe("123");
     });
   });

--- a/langwatch/packages/api/src/__tests__/errors.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/errors.unit.test.ts
@@ -125,6 +125,32 @@ describe("formatError", () => {
         expect(body.error).toBe("Not Found");
       });
     });
+
+    describe("back-compat `kind` alias", () => {
+      it("emits `kind` equal to `code` for a HandledError (versioned)", () => {
+        const err = makeHandledError({ code: "not_found", httpStatus: 404 });
+        const { body } = formatError({ err, isVersioned: true });
+        expect(body.kind).toBe("not_found");
+        expect(body.kind).toBe(body.code);
+      });
+
+      it("emits `kind` for synthesized error bodies too", () => {
+        const zodErr = (() => {
+          try {
+            z.object({ name: z.string() }).parse({});
+            throw new Error("should not reach");
+          } catch (e) {
+            return e as ZodError;
+          }
+        })();
+        expect(formatError({ err: zodErr, isVersioned: true }).body.kind).toBe(
+          "validation_error",
+        );
+        expect(
+          formatError({ err: new Error("oops"), isVersioned: true }).body.kind,
+        ).toBe("internal_error");
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/langwatch/packages/api/src/__tests__/errors.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/errors.unit.test.ts
@@ -1,55 +1,58 @@
 import { describe, it, expect } from "vitest";
 import { ZodError, z } from "zod";
 
-import { formatError, isDomainErrorLike } from "../errors.js";
+import { formatError, isHandledErrorLike } from "../errors.js";
 
 // ---------------------------------------------------------------------------
-// Helpers -- fake DomainError-like object (duck-typed)
+// Helpers -- fake HandledError-like object (duck-typed)
 // ---------------------------------------------------------------------------
 
-function makeDomainError(
+function makeHandledError(
   overrides: {
-    kind?: string;
+    code?: string;
     message?: string;
     httpStatus?: number;
     meta?: Record<string, unknown>;
   } = {},
 ): Error & {
-  kind: string;
+  code: string;
   httpStatus: number;
   meta: Record<string, unknown>;
   serialize: () => {
-    kind: string;
+    code: string;
     meta: Record<string, unknown>;
-    telemetry: { traceId: undefined; spanId: undefined };
+    traceId: undefined;
+    spanId: undefined;
     httpStatus: number;
-    reasons: Array<{ kind: string }>;
+    reasons: Array<{ code: string }>;
   };
 } {
-  const kind = overrides.kind ?? "test_error";
+  const code = overrides.code ?? "test_error";
   const httpStatus = overrides.httpStatus ?? 422;
   const meta = overrides.meta ?? {};
   const message = overrides.message ?? "Test error message";
 
   const error = new Error(message) as Error & {
-    kind: string;
+    code: string;
     httpStatus: number;
     meta: Record<string, unknown>;
     serialize: () => {
-      kind: string;
+      code: string;
       meta: Record<string, unknown>;
-      telemetry: { traceId: undefined; spanId: undefined };
+      traceId: undefined;
+      spanId: undefined;
       httpStatus: number;
-      reasons: Array<{ kind: string }>;
+      reasons: Array<{ code: string }>;
     };
   };
-  error.kind = kind;
+  error.code = code;
   error.httpStatus = httpStatus;
   error.meta = meta;
   error.serialize = () => ({
-    kind,
+    code,
     meta,
-    telemetry: { traceId: undefined, spanId: undefined },
+    traceId: undefined,
+    spanId: undefined,
     httpStatus,
     reasons: [],
   });
@@ -58,40 +61,40 @@ function makeDomainError(
 }
 
 // ---------------------------------------------------------------------------
-// isDomainErrorLike
+// isHandledErrorLike
 // ---------------------------------------------------------------------------
 
-describe("isDomainErrorLike", () => {
-  describe("when given a DomainError-like object", () => {
+describe("isHandledErrorLike", () => {
+  describe("when given a HandledError-like object", () => {
     it("returns true", () => {
-      const err = makeDomainError();
-      expect(isDomainErrorLike(err)).toBe(true);
+      const err = makeHandledError();
+      expect(isHandledErrorLike(err)).toBe(true);
     });
   });
 
   describe("when given a plain Error", () => {
     it("returns false", () => {
-      expect(isDomainErrorLike(new Error("plain"))).toBe(false);
+      expect(isHandledErrorLike(new Error("plain"))).toBe(false);
     });
   });
 
   describe("when given null", () => {
     it("returns false", () => {
-      expect(isDomainErrorLike(null)).toBe(false);
+      expect(isHandledErrorLike(null)).toBe(false);
     });
   });
 });
 
 // ---------------------------------------------------------------------------
-// formatError -- DomainError-like
+// formatError -- HandledError-like
 // ---------------------------------------------------------------------------
 
 describe("formatError", () => {
-  describe("when given a DomainError-like error", () => {
+  describe("when given a HandledError-like error", () => {
     describe("when the request is versioned", () => {
       it("returns the new format without the error field", () => {
-        const err = makeDomainError({
-          kind: "not_found",
+        const err = makeHandledError({
+          code: "not_found",
           message: "Resource not found",
           httpStatus: 404,
           meta: { id: "abc" },
@@ -100,7 +103,7 @@ describe("formatError", () => {
         const { status, body } = formatError({ err, isVersioned: true });
 
         expect(status).toBe(404);
-        expect(body.kind).toBe("not_found");
+        expect(body.code).toBe("not_found");
         expect(body.message).toBe("Resource not found");
         expect(body.meta).toEqual({ id: "abc" });
         expect(body.error).toBeUndefined();
@@ -109,8 +112,8 @@ describe("formatError", () => {
 
     describe("when the request is unversioned", () => {
       it("returns the union format with the error field", () => {
-        const err = makeDomainError({
-          kind: "not_found",
+        const err = makeHandledError({
+          code: "not_found",
           message: "Resource not found",
           httpStatus: 404,
         });
@@ -118,7 +121,7 @@ describe("formatError", () => {
         const { status, body } = formatError({ err, isVersioned: false });
 
         expect(status).toBe(404);
-        expect(body.kind).toBe("not_found");
+        expect(body.code).toBe("not_found");
         expect(body.error).toBe("Not Found");
       });
     });
@@ -149,7 +152,7 @@ describe("formatError", () => {
       });
 
       expect(status).toBe(422);
-      expect(body.kind).toBe("validation_error");
+      expect(body.code).toBe("validation_error");
       expect(body.message).toBe("Validation error");
       expect(body.reasons).toEqual(
         expect.arrayContaining([
@@ -198,7 +201,7 @@ describe("formatError", () => {
       const { status, body } = formatError({ err, isVersioned: true });
 
       expect(status).toBe(403);
-      expect(body.kind).toBe("http_error");
+      expect(body.code).toBe("http_error");
       expect(body.message).toBe("Forbidden");
     });
   });
@@ -216,7 +219,7 @@ describe("formatError", () => {
         const { status, body } = formatError({ err, isVersioned: true });
 
         expect(status).toBe(500);
-        expect(body.kind).toBe("internal_error");
+        expect(body.code).toBe("internal_error");
         expect(body.message).toBe("Internal server error");
       } finally {
         process.env["NODE_ENV"] = originalEnv;
@@ -231,7 +234,7 @@ describe("formatError", () => {
         const { status, body } = formatError({ err, isVersioned: true });
 
         expect(status).toBe(500);
-        expect(body.kind).toBe("internal_error");
+        expect(body.code).toBe("internal_error");
         expect(body.message).toBe("secret internal details");
       } finally {
         process.env["NODE_ENV"] = originalEnv;

--- a/langwatch/packages/api/src/errors.ts
+++ b/langwatch/packages/api/src/errors.ts
@@ -5,38 +5,40 @@ import { ZodError } from "zod";
 import { httpStatusText } from "./types.js";
 
 // ---------------------------------------------------------------------------
-// Duck-typed interfaces for DomainError (no imports from langwatch app)
+// Duck-typed interfaces for HandledError (no imports from langwatch app)
 // ---------------------------------------------------------------------------
 
 /**
- * Shape that a DomainError-like object must satisfy for the framework error
+ * Shape that a HandledError-like object must satisfy for the framework error
  * handler to use its `serialize()` output.
  *
  * We duck-type rather than import so this package stays standalone.
  */
-interface DomainErrorLike {
-  kind: string;
+interface HandledErrorLike {
+  code: string;
   message: string;
   httpStatus: number;
   meta: Record<string, unknown>;
   serialize(): {
-    kind: string;
+    code: string;
     meta: Record<string, unknown>;
-    telemetry?: { traceId?: string; spanId?: string };
+    traceId?: string;
+    spanId?: string;
+    traceUrl?: string;
     httpStatus: number;
     reasons: Array<{
-      kind: string;
+      code: string;
       meta?: Record<string, unknown>;
       reasons?: unknown[];
     }>;
   };
 }
 
-function isDomainErrorLike(err: unknown): err is DomainErrorLike {
+function isHandledErrorLike(err: unknown): err is HandledErrorLike {
   if (typeof err !== "object" || err === null) return false;
   const obj = err as Record<string, unknown>;
   return (
-    typeof obj["kind"] === "string" &&
+    typeof obj["code"] === "string" &&
     typeof obj["httpStatus"] === "number" &&
     typeof obj["serialize"] === "function"
   );
@@ -56,7 +58,7 @@ interface ValidationReason {
 }
 
 interface ValidationErrorPayload {
-  kind: "validation_error";
+  code: "validation_error";
   message: string;
   reasons: ValidationReason[];
   httpStatus: 422;
@@ -64,7 +66,7 @@ interface ValidationErrorPayload {
 
 function zodErrorToPayload(err: ZodError): ValidationErrorPayload {
   return {
-    kind: "validation_error",
+    code: "validation_error",
     message: "Validation error",
     reasons: err.issues.map((issue) => ({
       code: "schema_failure" as const,
@@ -85,11 +87,13 @@ function zodErrorToPayload(err: ZodError): ValidationErrorPayload {
 interface ErrorResponseBody {
   /** Present only for unversioned (backwards-compat) responses. */
   error?: string;
-  kind: string;
+  code: string;
   message: string;
   meta?: Record<string, unknown>;
   reasons?: unknown[];
-  telemetry?: { traceId?: string; spanId?: string };
+  traceId?: string;
+  spanId?: string;
+  traceUrl?: string;
 }
 
 function finalizeErrorResponse({
@@ -119,19 +123,21 @@ function formatError({
   err: unknown;
   isVersioned: boolean;
 }): { status: ContentfulStatusCode; body: ErrorResponseBody } {
-  // 1. DomainError-like errors
-  if (isDomainErrorLike(err)) {
+  // 1. HandledError-like errors
+  if (isHandledErrorLike(err)) {
     const serialized = err.serialize();
     const status = serialized.httpStatus as ContentfulStatusCode;
     return finalizeErrorResponse({
       status,
       isVersioned,
       body: {
-        kind: serialized.kind,
-        message: err.message ?? serialized.kind,
+        code: serialized.code,
+        message: err.message ?? serialized.code,
         meta: serialized.meta,
         reasons: serialized.reasons,
-        telemetry: serialized.telemetry,
+        traceId: serialized.traceId,
+        spanId: serialized.spanId,
+        ...(serialized.traceUrl ? { traceUrl: serialized.traceUrl } : {}),
       },
     });
   }
@@ -144,7 +150,7 @@ function formatError({
       status,
       isVersioned,
       body: {
-        kind: payload.kind,
+        code: payload.code,
         message: payload.message,
         reasons: payload.reasons,
       },
@@ -158,7 +164,7 @@ function formatError({
     return finalizeErrorResponse({
       status,
       isVersioned,
-      body: { kind: "http_error", message: err.message },
+      body: { code: "http_error", message: err.message },
     });
   }
 
@@ -172,7 +178,7 @@ function formatError({
   return finalizeErrorResponse({
     status,
     isVersioned,
-    body: { kind: "internal_error", message },
+    body: { code: "internal_error", message },
   });
 }
 
@@ -196,4 +202,4 @@ export function createErrorHandler(): (
   };
 }
 
-export { formatError, isDomainErrorLike, zodErrorToPayload };
+export { formatError, isHandledErrorLike as isHandledErrorLike, zodErrorToPayload };

--- a/langwatch/packages/api/src/errors.ts
+++ b/langwatch/packages/api/src/errors.ts
@@ -202,4 +202,4 @@ export function createErrorHandler(): (
   };
 }
 
-export { formatError, isHandledErrorLike as isHandledErrorLike, zodErrorToPayload };
+export { formatError, isHandledErrorLike, zodErrorToPayload };

--- a/langwatch/packages/api/src/errors.ts
+++ b/langwatch/packages/api/src/errors.ts
@@ -88,6 +88,13 @@ interface ErrorResponseBody {
   /** Present only for unversioned (backwards-compat) responses. */
   error?: string;
   code: string;
+  /**
+   * @deprecated Back-compat alias of `code`, emitted during the
+   * `DomainError` → `HandledError` transition so clients still reading the old
+   * `kind` discriminant keep working. Read `code` in new code; removed once no
+   * consumer reads `kind`.
+   */
+  kind?: string;
   message: string;
   meta?: Record<string, unknown>;
   reasons?: unknown[];
@@ -106,6 +113,10 @@ function finalizeErrorResponse({
   isVersioned: boolean;
 }): { status: ContentfulStatusCode; body: ErrorResponseBody } {
   if (!isVersioned) body.error = httpStatusText(status);
+  // Emit the deprecated `kind` alias alongside `code` so clients still reading
+  // the old discriminant keep working through the transition. See
+  // ErrorResponseBody.kind.
+  body.kind = body.code;
   return { status, body };
 }
 

--- a/langwatch/packages/api/src/pipeline.ts
+++ b/langwatch/packages/api/src/pipeline.ts
@@ -69,7 +69,7 @@ export function buildWithdrawnMiddlewareStack({
   stack.push(async (c) =>
     c.json(
       {
-        kind: "endpoint_withdrawn",
+        code: "endpoint_withdrawn",
         message: "This endpoint has been removed",
       },
       410,

--- a/langwatch/packages/observability/src/__tests__/requestLogging.unit.test.ts
+++ b/langwatch/packages/observability/src/__tests__/requestLogging.unit.test.ts
@@ -21,7 +21,7 @@ describe("requestLogging", () => {
       });
     });
 
-    describe("when error has httpStatus (DomainError)", () => {
+    describe("when error has httpStatus (HandledError)", () => {
       it("returns the httpStatus value", () => {
         const err = Object.assign(new Error("not found"), { httpStatus: 404 });
         expect(getStatusCodeFromError(err)).toBe(404);

--- a/langwatch/packages/observability/src/request/requestLogging.ts
+++ b/langwatch/packages/observability/src/request/requestLogging.ts
@@ -17,7 +17,7 @@ export interface RequestLogData {
 /**
  * Extracts HTTP status code from an error object.
  * Returns 500 for generic errors, 200 if no error.
- * Checks both `status` (HttpError, Hono) and `httpStatus` (DomainError).
+ * Checks both `status` (HttpError, Hono) and `httpStatus` (HandledError).
  */
 export function getStatusCodeFromError(error: unknown): number {
   if (error && typeof error === "object") {

--- a/langwatch/src/app/api/middleware/__tests__/error-handler.unit.test.ts
+++ b/langwatch/src/app/api/middleware/__tests__/error-handler.unit.test.ts
@@ -57,7 +57,7 @@ describe("handleError()", () => {
   }
 
   describe("when error is a LimitExceededError", () => {
-    it("returns 403 with DomainError shape", async () => {
+    it("returns 403 with HandledError shape", async () => {
       const error = new LimitExceededError("prompts", 5, 5);
       const app = createTestApp(error);
 

--- a/langwatch/src/app/api/middleware/error-handler.ts
+++ b/langwatch/src/app/api/middleware/error-handler.ts
@@ -2,7 +2,7 @@ import { INVALID_TRACE_ID } from "@langwatch/observability/constants";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 import { NotFoundError as PromptNotFoundError } from "~/server/prompt-config/errors";
 import { grafanaConfigFromEnv, grafanaLinksForTrace } from "~/utils/grafanaLinks";
 
@@ -67,16 +67,16 @@ function determineErrorResponse(
     name?: string;
   },
 ): { statusCode: ContentfulStatusCode; response: object } {
-  // DomainErrors are handled first — normalize to client-safe shape.
-  // Use kind + httpStatus check instead of instanceof to handle
+  // HandledErrors are handled first — normalize to client-safe shape.
+  // Use code + httpStatus check instead of instanceof to handle
   // module-boundary class identity mismatches in Next.js/turbopack.
-  // See domain-error.ts: "use kind instead of instanceof in cross-process cases"
-  if (DomainError.is(error) || ("kind" in error && "httpStatus" in error)) {
-    const { kind, message, httpStatus, meta } = error as DomainError;
+  // See handled-error.ts: "use code instead of instanceof in cross-process cases"
+  if (HandledError.is(error) || ("code" in error && "httpStatus" in error)) {
+    const { code, message, httpStatus, meta } = error as HandledError;
     return {
       statusCode: (httpStatus ?? 500) as ContentfulStatusCode,
       response: {
-        ...errorSchema.parse({ error: kind, message }),
+        ...errorSchema.parse({ error: code, message }),
         ...(meta ?? {}),
       },
     };

--- a/langwatch/src/app/api/middleware/resource-limit.ts
+++ b/langwatch/src/app/api/middleware/resource-limit.ts
@@ -54,7 +54,7 @@ export async function enforceResourceLimitOrRespond({
 
       return c.json(
         {
-          error: error.kind,
+          error: error.code,
           message,
           limitType: error.limitType,
           current: error.current,

--- a/langwatch/src/app/api/prompts/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/prompts/[[...route]]/app.v1.ts
@@ -48,7 +48,7 @@ import {
   buildStandardSuccessResponse,
   handlePossibleConflictError,
 } from "./utils";
-import { handleSystemPromptDomainErrors } from "./utils/handle-system-prompt-domain-errors";
+import { handleSystemPromptHandledErrors } from "./utils/handle-system-prompt-handled-errors";
 
 const logger = createLogger("langwatch:api:prompts");
 
@@ -1035,7 +1035,7 @@ export function registerPromptRoutes(
           });
         }
         handlePossibleConflictError(error, data.scope);
-        handleSystemPromptDomainErrors(error);
+        handleSystemPromptHandledErrors(error);
 
         // Re-throw other errors to be handled by the error middleware
         throw error;

--- a/langwatch/src/app/api/prompts/[[...route]]/utils/__tests__/handle-system-prompt-handled-errors.unit.test.ts
+++ b/langwatch/src/app/api/prompts/[[...route]]/utils/__tests__/handle-system-prompt-handled-errors.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the REST handler that maps system-prompt DomainErrors
+ * Unit tests for the REST handler that maps system-prompt HandledErrors
  * thrown by the prompt service to Hono HTTP exceptions.
  *
  * Pinned by Issue #3196 so a future refactor of either error class can
@@ -16,15 +16,15 @@ import {
   SystemPromptRequiredError,
 } from "~/server/prompt-config/errors";
 
-import { handleSystemPromptDomainErrors } from "../handle-system-prompt-domain-errors";
+import { handleSystemPromptHandledErrors } from "../handle-system-prompt-handled-errors";
 
-describe("handleSystemPromptDomainErrors", () => {
+describe("handleSystemPromptHandledErrors", () => {
   describe("when given a SystemPromptRequiredError (Issue #3196)", () => {
     /** @scenario "Toast on server-side validation failure shows a friendly message" */
     it("throws an HTTPException(400) with the friendly user-facing message", () => {
       const domainError = new SystemPromptRequiredError();
       try {
-        handleSystemPromptDomainErrors(domainError);
+        handleSystemPromptHandledErrors(domainError);
       } catch (err) {
         expect(err).toBeInstanceOf(HTTPException);
         const httpError = err as HTTPException;
@@ -37,7 +37,7 @@ describe("handleSystemPromptDomainErrors", () => {
         expect(httpError.cause).toBe(domainError);
         return;
       }
-      throw new Error("Expected handleSystemPromptDomainErrors to throw");
+      throw new Error("Expected handleSystemPromptHandledErrors to throw");
     });
   });
 
@@ -45,7 +45,7 @@ describe("handleSystemPromptDomainErrors", () => {
     it("throws an HTTPException(409) with the friendly user-facing message", () => {
       const domainError = new SystemPromptConflictError();
       try {
-        handleSystemPromptDomainErrors(domainError);
+        handleSystemPromptHandledErrors(domainError);
       } catch (err) {
         expect(err).toBeInstanceOf(HTTPException);
         const httpError = err as HTTPException;
@@ -56,22 +56,22 @@ describe("handleSystemPromptDomainErrors", () => {
         expect(httpError.cause).toBe(domainError);
         return;
       }
-      throw new Error("Expected handleSystemPromptDomainErrors to throw");
+      throw new Error("Expected handleSystemPromptHandledErrors to throw");
     });
   });
 
   describe("when given any other error", () => {
     it("returns without throwing so the global error middleware can handle it", () => {
       expect(() =>
-        handleSystemPromptDomainErrors(new Error("Unrelated")),
+        handleSystemPromptHandledErrors(new Error("Unrelated")),
       ).not.toThrow();
     });
 
     it("returns without throwing for non-Error inputs", () => {
-      expect(() => handleSystemPromptDomainErrors(null)).not.toThrow();
-      expect(() => handleSystemPromptDomainErrors(undefined)).not.toThrow();
+      expect(() => handleSystemPromptHandledErrors(null)).not.toThrow();
+      expect(() => handleSystemPromptHandledErrors(undefined)).not.toThrow();
       expect(() =>
-        handleSystemPromptDomainErrors("string error"),
+        handleSystemPromptHandledErrors("string error"),
       ).not.toThrow();
     });
   });

--- a/langwatch/src/app/api/prompts/[[...route]]/utils/handle-system-prompt-handled-errors.ts
+++ b/langwatch/src/app/api/prompts/[[...route]]/utils/handle-system-prompt-handled-errors.ts
@@ -6,7 +6,7 @@ import {
 } from "~/server/prompt-config/errors";
 
 /**
- * Maps system-prompt DomainErrors thrown by the prompt service to Hono HTTP
+ * Maps system-prompt HandledErrors thrown by the prompt service to Hono HTTP
  * exceptions with the correct status code.
  *
  *   - {@link SystemPromptConflictError} → 409 Conflict
@@ -16,12 +16,12 @@ import {
  *
  * Any other error type is re-thrown unchanged so the global handler can deal
  * with it. The error's own `message` is forwarded as the response body, since
- * both DomainErrors carry user-facing copy.
+ * both HandledErrors carry user-facing copy.
  *
  * @param error - The error to handle
  * @returns void
  */
-export const handleSystemPromptDomainErrors = (error: any) => {
+export const handleSystemPromptHandledErrors = (error: any) => {
   if (error instanceof SystemPromptRequiredError) {
     throw new HTTPException(400, {
       message: error.message,

--- a/langwatch/src/app/api/prompts/[[...route]]/utils/handle-system-prompt-handled-errors.ts
+++ b/langwatch/src/app/api/prompts/[[...route]]/utils/handle-system-prompt-handled-errors.ts
@@ -21,7 +21,7 @@ import {
  * @param error - The error to handle
  * @returns void
  */
-export const handleSystemPromptHandledErrors = (error: any) => {
+export const handleSystemPromptHandledErrors = (error: unknown) => {
   if (error instanceof SystemPromptRequiredError) {
     throw new HTTPException(400, {
       message: error.message,

--- a/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
@@ -96,7 +96,7 @@ secured.access(requires("scenarios:manage")).post(
     }
 
     // Enforce scenario set limit on RUN_STARTED events.
-    // ScenarioSetLimitExceededError (DomainError with httpStatus 403)
+    // ScenarioSetLimitExceededError (HandledError with httpStatus 403)
     // propagates to handleError which returns 403 + meta fields.
     await checkScenarioSetLimitForRunStarted({ project, event });
     await dispatchSimulationEvent(project.id, event);

--- a/langwatch/src/app/api/scenario-events/__tests__/scenario-set-limit.unit.test.ts
+++ b/langwatch/src/app/api/scenario-events/__tests__/scenario-set-limit.unit.test.ts
@@ -186,7 +186,7 @@ describe("scenario-events endpoint integration with scenario set limit", () => {
       const error = new ScenarioSetLimitExceededError(3, 3);
 
       expect(error.httpStatus).toBe(403);
-      expect(error.kind).toBe("scenario_set_limit_exceeded");
+      expect(error.code).toBe("scenario_set_limit_exceeded");
       expect(error.meta.current).toBe(3);
       expect(error.meta.max).toBe(3);
       expect(error.message).toContain("maximum number of scenario sets");

--- a/langwatch/src/components/scenarios/services/__tests__/scenarioGeneration.unit.test.ts
+++ b/langwatch/src/components/scenarios/services/__tests__/scenarioGeneration.unit.test.ts
@@ -167,7 +167,7 @@ describe("generateScenarioWithAI()", () => {
           Promise.resolve({
             error: "bad_request",
             domainError: {
-              kind: "missing_provider",
+              code: "missing_provider",
               meta: { reason: "missing_provider" },
               httpStatus: 400,
             },

--- a/langwatch/src/components/scenarios/services/scenarioGeneration.ts
+++ b/langwatch/src/components/scenarios/services/scenarioGeneration.ts
@@ -16,9 +16,9 @@ export const generatedScenarioSchema = z.object({
  */
 export type GeneratedScenario = z.infer<typeof generatedScenarioSchema>;
 
-/** Serialized DomainError shape the generate endpoint attaches to handled failures */
-const serializedDomainErrorSchema = z.object({
-  kind: z.string(),
+/** Serialized HandledError shape the generate endpoint attaches to handled failures */
+const serializedHandledErrorSchema = z.object({
+  code: z.string(),
   meta: z.record(z.string(), z.unknown()).optional(),
 });
 
@@ -88,14 +88,14 @@ export async function generateScenarioWithAI(
   }
 
   if (!response.ok) {
-    const domainError = serializedDomainErrorSchema.safeParse(
+    const handled = serializedHandledErrorSchema.safeParse(
       payload.domainError,
     );
-    if (domainError.success) {
+    if (handled.success) {
       throw new ScenarioGenerationError(
         payload.error || "Failed to generate scenario",
-        domainError.data.kind,
-        domainError.data.meta,
+        handled.data.code,
+        handled.data.meta,
       );
     }
     throw new Error(payload.error || "Failed to generate scenario");

--- a/langwatch/src/features/automations/AutomationDrawer.tsx
+++ b/langwatch/src/features/automations/AutomationDrawer.tsx
@@ -77,7 +77,7 @@ import {
 } from "./logic/draftReducer";
 import { ALERT_TEMPLATE_VARIABLES } from "./editors/alertVariables";
 import { REPORT_TEMPLATE_VARIABLES } from "./editors/reportVariables";
-import { explainDomainError, readDomainError } from "./logic/errorExplainer";
+import { explainHandledError, readHandledError } from "./logic/errorExplainer";
 import { useGraphAlertLabels } from "./logic/useGraphAlertLabels";
 import { useAutomationStore } from "./state/automationStore";
 import {
@@ -718,9 +718,9 @@ export function AutomationDrawer({
           });
         },
         onError: (err) => {
-          const domain = readDomainError(err);
+          const domain = readHandledError(err);
           const { title, description } = domain
-            ? explainDomainError(domain)
+            ? explainHandledError(domain)
             : { title: "Test fire failed", description: err.message };
           pushAttempt({
             at: Date.now(),
@@ -803,9 +803,9 @@ export function AutomationDrawer({
         },
         onError: (err) => {
           if (isHandledByGlobalHandler(err)) return;
-          const domain = readDomainError(err);
+          const domain = readHandledError(err);
           const { title, description } = domain
-            ? explainDomainError(domain)
+            ? explainHandledError(domain)
             : { title: "Could not save automation", description: err.message };
           toaster.create({
             title,

--- a/langwatch/src/features/automations/logic/errorExplainer.ts
+++ b/langwatch/src/features/automations/logic/errorExplainer.ts
@@ -1,38 +1,38 @@
 /**
- * Reads the structured `domainError` the server attaches via `errorFormatter`
- * (see `src/server/api/trpc.ts`) and translates each known `kind` into a
+ * Reads the structured handled error the server attaches via `errorFormatter`
+ * (see `src/server/api/trpc.ts`) and translates each known `code` into a
  * field-targeted toast. Pure — no React, no Chakra — so the UI just calls
- * `explainDomainError` with the `{ kind, meta, … }` shape and renders the
+ * `explainHandledError` with the `{ code, meta, … }` shape and renders the
  * returned title/description.
  */
 
-export interface DomainErrorShape {
-  kind: string;
+export interface HandledErrorShape {
+  code: string;
   meta: Record<string, unknown>;
   httpStatus: number;
 }
 
 /** Reads `error.data.domainError` from any tRPC client error, returning null
- *  when the cause was not one of our domain errors (e.g. an infrastructure
+ *  when the cause was not one of our handled errors (e.g. an infrastructure
  *  failure or a Zod parse error). Validates the shape before returning so a
- *  malformed payload can't crash `explainDomainError` on `domain.meta.*`
+ *  malformed payload can't crash `explainHandledError` on `domain.meta.*`
  *  access — the helper trusts `unknown` input and a misconfigured server
  *  shouldn't take the UI with it. */
-export function readDomainError(err: unknown): DomainErrorShape | null {
+export function readHandledError(err: unknown): HandledErrorShape | null {
   const candidate = (err as { data?: { domainError?: unknown } })?.data
     ?.domainError;
   if (!candidate || typeof candidate !== "object") return null;
 
   const value = candidate as {
-    kind?: unknown;
+    code?: unknown;
     meta?: unknown;
     httpStatus?: unknown;
   };
-  if (typeof value.kind !== "string") return null;
+  if (typeof value.code !== "string") return null;
   if (typeof value.httpStatus !== "number") return null;
 
   return {
-    kind: value.kind,
+    code: value.code,
     httpStatus: value.httpStatus,
     meta:
       value.meta && typeof value.meta === "object"
@@ -41,16 +41,16 @@ export function readDomainError(err: unknown): DomainErrorShape | null {
   };
 }
 
-export interface DomainErrorExplanation {
+export interface HandledErrorExplanation {
   title: string;
   /** Empty string when there's nothing to add beyond the title. */
   description: string;
 }
 
-export function explainDomainError(
-  domain: DomainErrorShape,
-): DomainErrorExplanation {
-  switch (domain.kind) {
+export function explainHandledError(
+  domain: HandledErrorShape,
+): HandledErrorExplanation {
+  switch (domain.code) {
     case "template_validation_error": {
       const field = String(domain.meta.field ?? "template");
       const syntax = String(domain.meta.syntaxError ?? "Invalid Liquid syntax");

--- a/langwatch/src/features/automations/logic/errorExplainer.ts
+++ b/langwatch/src/features/automations/logic/errorExplainer.ts
@@ -25,14 +25,24 @@ export function readHandledError(err: unknown): HandledErrorShape | null {
 
   const value = candidate as {
     code?: unknown;
+    // `kind` is the deprecated pre-`HandledError` discriminant — read it as a
+    // fallback so a payload from an older server (or an older client reading a
+    // newer server) still resolves during the transition.
+    kind?: unknown;
     meta?: unknown;
     httpStatus?: unknown;
   };
-  if (typeof value.code !== "string") return null;
+  const code =
+    typeof value.code === "string"
+      ? value.code
+      : typeof value.kind === "string"
+        ? value.kind
+        : null;
+  if (code === null) return null;
   if (typeof value.httpStatus !== "number") return null;
 
   return {
-    code: value.code,
+    code,
     httpStatus: value.httpStatus,
     meta:
       value.meta && typeof value.meta === "object"

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerEmptyState.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerEmptyState.tsx
@@ -39,9 +39,9 @@ type ErrorKind = "not-found" | "load-failed" | "no-selection";
 function classifyError(error: unknown, traceId: string | undefined): ErrorKind {
   if (!traceId) return "no-selection";
   const data = (
-    error as { data?: { code?: string; domainError?: { kind?: string } } }
+    error as { data?: { code?: string; domainError?: { code?: string } } }
   )?.data;
-  if (data?.domainError?.kind === "trace_not_found") return "not-found";
+  if (data?.domainError?.code === "trace_not_found") return "not-found";
   if (data?.code === "NOT_FOUND") return "not-found";
   return "load-failed";
 }

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerEmptyState.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerEmptyState.tsx
@@ -39,9 +39,17 @@ type ErrorKind = "not-found" | "load-failed" | "no-selection";
 function classifyError(error: unknown, traceId: string | undefined): ErrorKind {
   if (!traceId) return "no-selection";
   const data = (
-    error as { data?: { code?: string; domainError?: { code?: string } } }
+    error as {
+      data?: {
+        code?: string;
+        // `kind` is the deprecated pre-`HandledError` discriminant, read as a
+        // fallback so this resolves across the transition.
+        domainError?: { code?: string; kind?: string };
+      };
+    }
   )?.data;
-  if (data?.domainError?.code === "trace_not_found") return "not-found";
+  const domainCode = data?.domainError?.code ?? data?.domainError?.kind;
+  if (domainCode === "trace_not_found") return "not-found";
   if (data?.code === "NOT_FOUND") return "not-found";
   return "load-failed";
 }

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/EditableTraceName.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/EditableTraceName.tsx
@@ -70,7 +70,7 @@ export function EditableTraceName({
       setIsEditing(false);
     },
     onError: (error) => {
-      // The server attaches the serialised DomainError to error.data so
+      // The server attaches the serialised HandledError to error.data so
       // we can show the rich message + meta — falls back to error.message
       // for unhandled cases.
       const dErr = error.data?.domainError;

--- a/langwatch/src/pages/api/experiment/init.ts
+++ b/langwatch/src/pages/api/experiment/init.ts
@@ -130,7 +130,7 @@ export default async function handler(
       }
 
       return res.status(403).json({
-        error: error.kind,
+        error: error.code,
         message,
         limitType: error.limitType,
         current: error.current,

--- a/langwatch/src/server/api-key/api-key.service.ts
+++ b/langwatch/src/server/api-key/api-key.service.ts
@@ -3,7 +3,7 @@ import { createLogger } from "@langwatch/observability";
 import type { ApiKey, PrismaClient } from "@prisma/client";
 import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
 import type { Permission } from "~/server/api/rbac";
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 import { parseCustomRolePermissions, permissionFormatSchema } from "~/server/rbac/custom-role-permissions";
 import { checkRoleBindingPermission } from "~/server/rbac/role-binding-resolver";
 import { CUSTOM_ROLE_KIND, RoleRepository } from "~/server/role/repositories/role.repository";
@@ -548,7 +548,7 @@ export class ApiKeyService {
         permissions: customRole.permissions,
       });
     } catch (err) {
-      if (DomainError.isHandled(err) && err.kind === "malformed_custom_role_permissions") {
+      if (HandledError.isHandled(err) && err.code === "malformed_custom_role_permissions") {
         throw new ApiKeyScopeViolationError(
           `Custom role ${customRoleId} has malformed permissions`,
           {

--- a/langwatch/src/server/api-key/api-key.service.ts
+++ b/langwatch/src/server/api-key/api-key.service.ts
@@ -3,8 +3,11 @@ import { createLogger } from "@langwatch/observability";
 import type { ApiKey, PrismaClient } from "@prisma/client";
 import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
 import type { Permission } from "~/server/api/rbac";
-import { HandledError } from "~/server/app-layer/handled-error";
-import { parseCustomRolePermissions, permissionFormatSchema } from "~/server/rbac/custom-role-permissions";
+import {
+  MalformedCustomRolePermissionsError,
+  parseCustomRolePermissions,
+  permissionFormatSchema,
+} from "~/server/rbac/custom-role-permissions";
 import { checkRoleBindingPermission } from "~/server/rbac/role-binding-resolver";
 import { CUSTOM_ROLE_KIND, RoleRepository } from "~/server/role/repositories/role.repository";
 import { KSUID_RESOURCES } from "~/utils/constants";
@@ -548,7 +551,7 @@ export class ApiKeyService {
         permissions: customRole.permissions,
       });
     } catch (err) {
-      if (HandledError.isHandled(err) && err.code === "malformed_custom_role_permissions") {
+      if (err instanceof MalformedCustomRolePermissionsError) {
         throw new ApiKeyScopeViolationError(
           `Custom role ${customRoleId} has malformed permissions`,
           {

--- a/langwatch/src/server/api-key/auth-middleware.ts
+++ b/langwatch/src/server/api-key/auth-middleware.ts
@@ -2,7 +2,7 @@ import { createLogger } from "@langwatch/observability";
 import type { Organization, PrismaClient, Project } from "@prisma/client";
 import type { MiddlewareHandler } from "hono";
 import type { Permission } from "~/server/api/rbac";
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 import { resolveApiKeyPermission } from "~/server/rbac/role-binding-resolver";
 import { getTokenType } from "./api-key-token.utils";
 import { ApiKeyPermissionDeniedError } from "./errors";
@@ -382,7 +382,7 @@ export async function enforceApiKeyCeiling({
 export function apiKeyCeilingDenialResponse(
   error: unknown,
 ): { error: string; message: string; status: 403 } {
-  if (DomainError.isHandled(error) && error.kind === "api_key_permission_denied") {
+  if (HandledError.isHandled(error) && error.code === "api_key_permission_denied") {
     return { error: "Forbidden", message: error.message, status: 403 };
   }
   throw error;

--- a/langwatch/src/server/api-key/errors.ts
+++ b/langwatch/src/server/api-key/errors.ts
@@ -1,10 +1,10 @@
-import { DomainError, NotFoundError } from "../app-layer/domain-error";
+import { HandledError, NotFoundError } from "../app-layer/handled-error";
 
 /**
  * Thrown when an API key cannot be located by id.
  */
 export class ApiKeyNotFoundError extends NotFoundError {
-  declare readonly kind: "api_key_not_found";
+  declare readonly code: "api_key_not_found";
 
   constructor(apiKeyId: string, options: { reasons?: readonly Error[] } = {}) {
     super("api_key_not_found", "API Key", apiKeyId, {
@@ -18,8 +18,8 @@ export class ApiKeyNotFoundError extends NotFoundError {
 /**
  * Thrown when a user attempts to modify an API key they do not own.
  */
-export class ApiKeyNotOwnedError extends DomainError {
-  declare readonly kind: "api_key_not_owned";
+export class ApiKeyNotOwnedError extends HandledError {
+  declare readonly code: "api_key_not_owned";
 
   constructor(
     apiKeyId: string,
@@ -37,8 +37,8 @@ export class ApiKeyNotOwnedError extends DomainError {
 /**
  * Thrown when an API key is already revoked and cannot be revoked again.
  */
-export class ApiKeyAlreadyRevokedError extends DomainError {
-  declare readonly kind: "api_key_already_revoked";
+export class ApiKeyAlreadyRevokedError extends HandledError {
+  declare readonly code: "api_key_already_revoked";
 
   constructor(
     apiKeyId: string,
@@ -59,8 +59,8 @@ export class ApiKeyAlreadyRevokedError extends DomainError {
  * permission set (intersection of requested scopes ∩ user's current role)
  * does not grant the action.
  */
-export class ApiKeyPermissionDeniedError extends DomainError {
-  declare readonly kind: "api_key_permission_denied";
+export class ApiKeyPermissionDeniedError extends HandledError {
+  declare readonly code: "api_key_permission_denied";
 
   constructor(
     permission: string,
@@ -87,8 +87,8 @@ export class ApiKeyPermissionDeniedError extends DomainError {
  * creator's ceiling — e.g., binding a role the creator does not hold on the
  * target scope. Surfaced to the user before the token is persisted.
  */
-export class ApiKeyScopeViolationError extends DomainError {
-  declare readonly kind: "api_key_scope_violation";
+export class ApiKeyScopeViolationError extends HandledError {
+  declare readonly code: "api_key_scope_violation";
 
   constructor(
     message: string,

--- a/langwatch/src/server/api/routers/__tests__/translate.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/translate.unit.test.ts
@@ -194,7 +194,7 @@ describe("translateRouter.translate()", () => {
       expect(error).toMatchObject({ code: "BAD_REQUEST" });
 
       // Serialised wire shape the frontend extractor reads — proves the
-      // typed error reaches domainErrorMiddleware untouched (the claim the
+      // typed error reaches handledErrorMiddleware untouched (the claim the
       // translate.ts comment makes) instead of being mis-tagged as an
       // AI_CALL_FAILED or flattened to a generic 500.
       const wire = errorFormatterForTesting({

--- a/langwatch/src/server/api/routers/apiKey.ts
+++ b/langwatch/src/server/api/routers/apiKey.ts
@@ -2,15 +2,15 @@ import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 import { ApiKeyService } from "~/server/api-key/api-key.service";
 import { auditLog } from "~/server/auditLog";
 import { skipPermissionCheck } from "../rbac";
 import { permissionFormatSchema } from "~/server/rbac/custom-role-permissions";
 
-function mapApiKeyDomainError(error: unknown): never {
-  if (DomainError.isHandled(error)) {
-    switch (error.kind) {
+function mapApiKeyHandledError(error: unknown): never {
+  if (HandledError.isHandled(error)) {
+    switch (error.code) {
       case "api_key_not_found":
         throw new TRPCError({ code: "NOT_FOUND", message: error.message, cause: error });
       case "api_key_not_owned":
@@ -34,7 +34,7 @@ async function ensureCallerIsOrgMember(
   try {
     await service.ensureCallerIsOrgMember({ userId, organizationId });
   } catch (error) {
-    mapApiKeyDomainError(error);
+    mapApiKeyHandledError(error);
   }
 }
 
@@ -292,7 +292,7 @@ export const apiKeyRouter = createTRPCRouter({
           },
         };
       } catch (error) {
-        mapApiKeyDomainError(error);
+        mapApiKeyHandledError(error);
       }
     }),
 
@@ -351,7 +351,7 @@ export const apiKeyRouter = createTRPCRouter({
           permissionMode: updated.permissionMode,
         };
       } catch (error) {
-        mapApiKeyDomainError(error);
+        mapApiKeyHandledError(error);
       }
     }),
 
@@ -390,7 +390,7 @@ export const apiKeyRouter = createTRPCRouter({
           args: { apiKeyId: input.apiKeyId },
         });
       } catch (error) {
-        mapApiKeyDomainError(error);
+        mapApiKeyHandledError(error);
       }
       return { success: true };
     }),

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -12,7 +12,7 @@ import {
 import { EMAIL_RX } from "~/automations/providers/definitions/email/shared";
 import { actionParamsSchemaFor } from "~/automations/providers/server";
 import { getApp } from "~/server/app-layer/app";
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 import { translateFilterToClickHouse } from "~/server/app-layer/traces/filter-to-clickhouse";
 import { listSlackChannels } from "~/server/triggers/slackWebApi";
 import {
@@ -179,7 +179,7 @@ function httpStatusToTRPCCode(httpStatus: number): TRPCErrorCode {
 
 /**
  * Wraps any thrown value as a `TRPCError` whose `cause` is preserved when the
- * value is a `DomainError`. The shared `errorFormatter` in `trpc.ts` serialises
+ * value is a `HandledError`. The shared `errorFormatter` in `trpc.ts` serialises
  * that cause as `error.data.domainError = { kind, meta, telemetry, … }` so the
  * client gets the full structured payload — that is the "incredibly good error
  * handling" surface (see ADR-036 follow-up).
@@ -188,9 +188,9 @@ function toTemplateTRPCError(err: unknown): TRPCError {
   if (err instanceof TRPCError) return err;
   // A provider rejection (Slack not_in_channel, dead webhook, bad token) arrives
   // as a DispatchError with an already-actionable message — lift it onto the
-  // typed DomainError channel so the UI shows a clean 4xx, not a generic 500.
+  // typed HandledError channel so the UI shows a clean 4xx, not a generic 500.
   const domainError =
-    err instanceof DomainError
+    err instanceof HandledError
       ? err
       : isDispatchError(err)
         ? new NotificationDeliveryError(err.message)

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -180,7 +180,7 @@ function httpStatusToTRPCCode(httpStatus: number): TRPCErrorCode {
 /**
  * Wraps any thrown value as a `TRPCError` whose `cause` is preserved when the
  * value is a `HandledError`. The shared `errorFormatter` in `trpc.ts` serialises
- * that cause as `error.data.domainError = { kind, meta, telemetry, … }` so the
+ * that cause as `error.data.domainError = { code, meta, traceId, spanId, … }` so the
  * client gets the full structured payload — that is the "incredibly good error
  * handling" surface (see ADR-036 follow-up).
  */

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -19,7 +19,7 @@ import {
 } from "../../../optimization_studio/types/dsl";
 import { slugify } from "../../../utils/slugify";
 import { getApp } from "../../app-layer/app";
-import { DomainError } from "../../app-layer/domain-error";
+import { HandledError } from "../../app-layer/handled-error";
 import { DspyStepNotFoundError } from "../../app-layer/dspy-steps/errors";
 import { DatasetService } from "../../datasets/dataset.service";
 import { prisma } from "../../db";
@@ -51,9 +51,9 @@ import {
 
 type TRPCContext = ReturnType<typeof createInnerTRPCContext>;
 
-/** Maps experiment domain errors to TRPCError using kind discriminant. */
+/** Maps experiment handled errors to TRPCError using the code discriminant. */
 const mapExperimentError = (error: unknown): never => {
-  if (error instanceof DomainError && error.kind === "experiment_not_found") {
+  if (error instanceof HandledError && error.code === "experiment_not_found") {
     throw new TRPCError({ code: "NOT_FOUND", message: error.message });
   }
   throw error;

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -4,7 +4,7 @@ import { resolveNonBilledCost } from "~/features/traces-v2/utils/costAttribution
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getVisibilityCutoffMsForProject } from "~/server/api/utils";
 import { getApp } from "~/server/app-layer/app";
-import { ValidationError } from "~/server/app-layer/domain-error";
+import { ValidationError } from "~/server/app-layer/handled-error";
 import {
   generateTraceAction,
   generateTraceQueryFromPrompt,
@@ -1087,7 +1087,7 @@ export const tracesV2Router = createTRPCRouter({
    * Lets a user rename a trace. Trim happens in the procedure so the event
    * always carries a canonical form, then the schema check rejects empty /
    * over-long names — when those rejections fire we surface them as a
-   * `ValidationError` (DomainError), so the client receives the rich
+   * `ValidationError` (HandledError), so the client receives the rich
    * `domainError` payload via tRPC's error formatter alongside the safe
    * user-facing message. The command pipeline still re-validates via Zod
    * as a defence-in-depth check (replays from a poisoned event store).

--- a/langwatch/src/server/api/routers/translate.ts
+++ b/langwatch/src/server/api/routers/translate.ts
@@ -36,7 +36,7 @@ export const translateRouter = createTRPCRouter({
       // cascade resolver (resolveModelForFeature) throws the typed
       // ModelNotConfiguredError when nothing is set and
       // ModelProviderDisabledError when the resolved FAST model's provider
-      // is disabled, and both must reach domainErrorMiddleware untouched to
+      // is disabled, and both must reach handledErrorMiddleware untouched to
       // open their own toasts. wrapAiCall only passes ModelNotConfiguredError
       // through, so resolving inside it would mis-tag a disabled provider as
       // an AI_CALL_FAILED.

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -37,7 +37,7 @@ import type { Parser } from "@trpc-internal/parser";
 import type { UnsetMarker } from "@trpc-internal/utils";
 import superjson from "superjson";
 import { ZodError } from "zod";
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 import type { Session } from "~/server/auth";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
@@ -146,7 +146,7 @@ export function errorFormatterForTesting({
     : null;
 
   const domainError =
-    error.cause instanceof DomainError ? error.cause.serialize() : null;
+    error.cause instanceof HandledError ? error.cause.serialize() : null;
 
   // Surface ModelNotConfiguredError on the wire so the frontend
   // interceptor in `utils/trpcError.ts::extractMissingModelInfo` can
@@ -481,7 +481,7 @@ export const tracerMiddleware = t.middleware(async ({ path, type, next }) => {
   );
 });
 
-function domainErrorToTRPCCode(error: DomainError): TRPCError["code"] {
+function handledErrorToTRPCCode(error: HandledError): TRPCError["code"] {
   const map: Partial<Record<number, TRPCError["code"]>> = {
     400: "BAD_REQUEST",
     401: "UNAUTHORIZED",
@@ -495,16 +495,16 @@ function domainErrorToTRPCCode(error: DomainError): TRPCError["code"] {
 }
 
 /**
- * Converts DomainErrors thrown in procedures to properly-coded TRPCErrors.
- * Without this, DomainErrors fall through as INTERNAL_SERVER_ERROR.
+ * Converts HandledErrors thrown in procedures to properly-coded TRPCErrors.
+ * Without this, HandledErrors fall through as INTERNAL_SERVER_ERROR.
  * Placed inner to loggerMiddleware so the logger sees the correct code.
  */
-const domainErrorMiddleware = t.middleware(async ({ next }) => {
+const handledErrorMiddleware = t.middleware(async ({ next }) => {
   const result = await next();
-  if (!result.ok && result.error.cause instanceof DomainError) {
+  if (!result.ok && result.error.cause instanceof HandledError) {
     const domainError = result.error.cause;
     throw new TRPCError({
-      code: domainErrorToTRPCCode(domainError),
+      code: handledErrorToTRPCCode(domainError),
       message: domainError.message,
       cause: domainError,
     });
@@ -587,12 +587,12 @@ export function handleTrpcCallLogging({
         : 500;
     logData.statusCode = resolvedStatus;
 
-    // Include domain error kind in log data for structured filtering
+    // Include handled error code in log data for structured filtering
     if (
       result.error instanceof TRPCError &&
-      result.error.cause instanceof DomainError
+      result.error.cause instanceof HandledError
     ) {
-      logData.domainErrorKind = result.error.cause.kind;
+      logData.handledErrorCode = result.error.cause.code;
     }
 
     // Only capture 5xx errors (actual bugs)
@@ -729,7 +729,7 @@ const permissionProcedureBuilder = <TParams extends ProcedureParams>(
       return procedure
         .use(tracerMiddleware as any)
         .use(loggerMiddleware as any)
-        .use(domainErrorMiddleware as any)
+        .use(handledErrorMiddleware as any)
         .use(middleware as any)
         .use(enforcePermissionCheck as any)
         .use(auditLogMutations as any) as any;

--- a/langwatch/src/server/app-layer/broadcast/errors.ts
+++ b/langwatch/src/server/app-layer/broadcast/errors.ts
@@ -1,7 +1,7 @@
-import { DomainError } from "../domain-error";
+import { HandledError } from "../handled-error";
 
-export class BroadcasterNotActiveError extends DomainError {
-  declare readonly kind: "broadcaster_not_active";
+export class BroadcasterNotActiveError extends HandledError {
+  declare readonly code: "broadcaster_not_active";
 
   constructor(options: { reasons?: readonly Error[] } = {}) {
     super("broadcaster_not_active", "This broadcaster is not in an active state, you may retry.", {

--- a/langwatch/src/server/app-layer/dspy-steps/errors.ts
+++ b/langwatch/src/server/app-layer/dspy-steps/errors.ts
@@ -1,7 +1,7 @@
-import { NotFoundError } from "../domain-error";
+import { NotFoundError } from "../handled-error";
 
 export class DspyStepNotFoundError extends NotFoundError {
-  declare readonly kind: "dspy_step_not_found";
+  declare readonly code: "dspy_step_not_found";
 
   constructor(
     stepId: string,

--- a/langwatch/src/server/app-layer/evaluations/errors.ts
+++ b/langwatch/src/server/app-layer/evaluations/errors.ts
@@ -1,7 +1,7 @@
-import { DomainError, NotFoundError } from "../domain-error";
+import { HandledError, NotFoundError } from "../handled-error";
 
 export class EvaluationNotFoundError extends NotFoundError {
-  declare readonly kind: "evaluation_not_found";
+  declare readonly code: "evaluation_not_found";
 
   constructor(
     evaluationId: string,
@@ -15,8 +15,8 @@ export class EvaluationNotFoundError extends NotFoundError {
   }
 }
 
-export class TraceNotEvaluatableError extends DomainError {
-  declare readonly kind: "trace_not_evaluatable";
+export class TraceNotEvaluatableError extends HandledError {
+  declare readonly code: "trace_not_evaluatable";
 
   constructor(
     traceId: string,
@@ -31,8 +31,8 @@ export class TraceNotEvaluatableError extends DomainError {
   }
 }
 
-export class EvaluatorConfigError extends DomainError {
-  declare readonly kind: "evaluator_config_error";
+export class EvaluatorConfigError extends HandledError {
+  declare readonly code: "evaluator_config_error";
 
   constructor(
     message: string,
@@ -46,8 +46,8 @@ export class EvaluatorConfigError extends DomainError {
   }
 }
 
-export class EvaluatorExecutionError extends DomainError {
-  declare readonly kind: "evaluator_execution_error";
+export class EvaluatorExecutionError extends HandledError {
+  declare readonly code: "evaluator_execution_error";
 
   constructor(
     message: string,
@@ -68,8 +68,8 @@ export class EvaluatorExecutionError extends DomainError {
  * carries the raw field name so the client can translate it into
  * user-facing language ("Variant A") instead of showing the wire identifier.
  */
-export class EvaluatorMissingFieldError extends DomainError {
-  declare readonly kind: "evaluator_missing_field";
+export class EvaluatorMissingFieldError extends HandledError {
+  declare readonly code: "evaluator_missing_field";
 
   constructor(
     field: string,
@@ -93,7 +93,7 @@ export class EvaluatorMissingFieldError extends DomainError {
 }
 
 export class EvaluatorNotFoundError extends NotFoundError {
-  declare readonly kind: "evaluator_not_found";
+  declare readonly code: "evaluator_not_found";
 
   constructor(
     evaluatorType: string,

--- a/langwatch/src/server/app-layer/handled-error.ts
+++ b/langwatch/src/server/app-layer/handled-error.ts
@@ -5,6 +5,13 @@ import { grafanaTraceUrlFromEnv } from "~/utils/grafanaLinks";
 
 export interface SerializedReason {
   code: string;
+  /**
+   * @deprecated Back-compat alias of `code`, emitted during the
+   * `DomainError` → `HandledError` transition so clients still reading the old
+   * `kind` discriminant keep working. Read `code` in new code; this alias is
+   * removed once no consumer reads `kind`.
+   */
+  kind: string;
   meta?: Record<string, unknown>;
   reasons?: SerializedReason[];
 }
@@ -18,6 +25,13 @@ export interface SerializedReason {
  */
 export interface SerializedHandledError {
   code: string;
+  /**
+   * @deprecated Back-compat alias of `code`, emitted during the
+   * `DomainError` → `HandledError` transition so clients still reading the old
+   * `kind` discriminant keep working. Read `code` in new code; this alias is
+   * removed once no consumer reads `kind`.
+   */
+  kind: string;
   meta: Record<string, unknown>;
   traceId: string | undefined;
   spanId: string | undefined;
@@ -98,6 +112,8 @@ export abstract class HandledError extends Error {
     const traceUrl = grafanaTraceUrlFromEnv(this.traceId);
     return {
       code: this.code,
+      // Deprecated back-compat alias — see SerializedHandledError.kind.
+      kind: this.code,
       meta: this.meta,
       traceId: this.traceId,
       spanId: this.spanId,
@@ -159,13 +175,15 @@ function serializeReason(error: Error): SerializedReason {
   if (error instanceof HandledError) {
     return {
       code: error.code,
+      // Deprecated back-compat alias — see SerializedReason.kind.
+      kind: error.code,
       ...(Object.keys(error.meta).length > 0 && { meta: error.meta }),
       ...(error.reasons.length > 0 && {
         reasons: error.reasons.map(serializeReason),
       }),
     };
   }
-  return { code: "unknown" };
+  return { code: "unknown", kind: "unknown" };
 }
 
 

--- a/langwatch/src/server/app-layer/handled-error.ts
+++ b/langwatch/src/server/app-layer/handled-error.ts
@@ -3,7 +3,22 @@ import type { ZodError } from "zod";
 
 import { grafanaTraceUrlFromEnv } from "~/utils/grafanaLinks";
 
-export interface DomainErrorTelemetry {
+export interface SerializedReason {
+  code: string;
+  meta?: Record<string, unknown>;
+  reasons?: SerializedReason[];
+}
+
+/**
+ * Serialised, client-safe shape of a {@link HandledError}. Mirrors the Go
+ * `herr.E` (`pkg/herr`): `code`/`meta`/`traceId`/`spanId`/`reasons` line up
+ * field-for-field with `Code`/`Meta`/`TraceID`/`SpanID`/`Reasons`. `httpStatus`
+ * and `traceUrl` are TypeScript-side conveniences with no `herr.E` equivalent
+ * (Go maps code→status via a registry and builds the trace link elsewhere).
+ */
+export interface SerializedHandledError {
+  code: string;
+  meta: Record<string, unknown>;
   traceId: string | undefined;
   spanId: string | undefined;
   /**
@@ -13,59 +28,53 @@ export interface DomainErrorTelemetry {
    * nothing to a client that can't reach it.
    */
   traceUrl?: string;
-}
-
-export interface SerializedReason {
-  kind: string;
-  meta?: Record<string, unknown>;
-  reasons?: SerializedReason[];
-}
-
-export interface SerializedDomainError {
-  kind: string;
-  meta: Record<string, unknown>;
-  telemetry: DomainErrorTelemetry;
   httpStatus: number;
   reasons: SerializedReason[];
 }
 
 /**
- * Base class for all handled domain errors.
+ * Base class for all handled errors — the TypeScript counterpart of Go's
+ * `herr.E` (`pkg/herr`). Its shape matches `herr.E` field-for-field:
+ * `code`↔`Code`, `meta`↔`Meta`, `traceId`↔`TraceID`, `spanId`↔`SpanID`,
+ * `reasons`↔`Reasons`. (`httpStatus` is TS-only; Go maps code→status via a
+ * registry. Stack traces stay on the native `Error.stack` and never serialise.)
  *
- * `kind` is a serialisable string discriminant — safe across process/worker
+ * `code` is a serialisable string discriminant — safe across process/worker
  * boundaries and serialisation (use instead of `instanceof` in those cases):
  *
  * ```ts
- * if (err.kind === "evaluation_not_found") { ... }   // cross-process safe
- * if (err instanceof EvaluationNotFoundError) { ...} // same-process only
+ * if (err.code === "evaluation_not_found") { ... }   // cross-process safe
+ * if (err instanceof EvaluationNotFoundError) { ...}  // same-process only
  * ```
  *
  * `meta` carries domain-specific context (e.g. `{ spanId }`) included in the
  * serialised shape. `httpStatus` is the suggested HTTP response code (defaults
  * to 500; subclasses set appropriate defaults). `traceId` / `spanId` are
- * captured automatically from the active OTel span. `reasons` serialises
- * DomainErrors by kind and masks everything else as `{ kind: "unknown" }`.
+ * captured automatically from the active OTel span. `reasons` serialises nested
+ * HandledErrors by code and masks everything else as `{ code: "unknown" }`.
  *
  * Serialised shape:
  * ```json
  * {
- *   "kind": "span_not_found",
+ *   "code": "span_not_found",
  *   "meta": { "spanId": "abc" },
- *   "telemetry": { "traceId": "...", "spanId": "..." },
+ *   "traceId": "...",
+ *   "spanId": "...",
  *   "httpStatus": 404,
- *   "reasons": [{ "kind": "invalid_span_id" }, { "kind": "unknown" }]
+ *   "reasons": [{ "code": "invalid_span_id" }, { "code": "unknown" }]
  * }
  * ```
  */
-export abstract class DomainError extends Error {
+export abstract class HandledError extends Error {
   readonly isHandled = true as const;
   readonly meta: Record<string, unknown>;
-  readonly telemetry: DomainErrorTelemetry;
+  readonly traceId: string | undefined;
+  readonly spanId: string | undefined;
   readonly httpStatus: number;
   readonly reasons: readonly Error[];
 
   constructor(
-    public readonly kind: string,
+    public readonly code: string,
     message: string,
     options: {
       meta?: Record<string, unknown>;
@@ -75,21 +84,24 @@ export abstract class DomainError extends Error {
   ) {
     super(message);
     const ctx = trace.getActiveSpan()?.spanContext();
-    this.telemetry = { traceId: ctx?.traceId, spanId: ctx?.spanId };
+    this.traceId = ctx?.traceId;
+    this.spanId = ctx?.spanId;
     this.meta = options.meta ?? {};
     this.httpStatus = options.httpStatus ?? 500;
     this.reasons = options.reasons ?? [];
   }
 
   /** Produce the full user-facing serialised shape. */
-  serialize(): SerializedDomainError {
-    // telemetry.traceId is the real trace id for domain errors, so it links
-    // straight to the trace when a Grafana is configured — see grafanaTraceUrlFromEnv.
-    const traceUrl = grafanaTraceUrlFromEnv(this.telemetry.traceId);
+  serialize(): SerializedHandledError {
+    // traceId is the real trace id for handled errors, so it links straight to
+    // the trace when a Grafana is configured — see grafanaTraceUrlFromEnv.
+    const traceUrl = grafanaTraceUrlFromEnv(this.traceId);
     return {
-      kind: this.kind,
+      code: this.code,
       meta: this.meta,
-      telemetry: traceUrl ? { ...this.telemetry, traceUrl } : this.telemetry,
+      traceId: this.traceId,
+      spanId: this.spanId,
+      ...(traceUrl ? { traceUrl } : {}),
       httpStatus: this.httpStatus,
       reasons: this.reasons.map(serializeReason),
     };
@@ -101,34 +113,34 @@ export abstract class DomainError extends Error {
    * Usage:
    *   EvaluationNotFoundError.is(err)   // error is EvaluationNotFoundError
    *   NotFoundError.is(err)             // error is NotFoundError
-   *   DomainError.is(err)               // error is DomainError
+   *   HandledError.is(err)              // error is HandledError
    */
-  static is<T extends DomainError>(
+  static is<T extends HandledError>(
     this: abstract new (...args: never) => T,
     error: unknown,
   ): error is T {
     return error instanceof this;
   }
 
-  /** Returns true when `error` is a known, handled DomainError. */
-  static isHandled(error: unknown): error is DomainError {
-    return error instanceof DomainError;
+  /** Returns true when `error` is a known, handled HandledError. */
+  static isHandled(error: unknown): error is HandledError {
+    return error instanceof HandledError;
   }
 
   /** Returns true when `error` is an unhandled infrastructure Error. */
   static isUnhandled(error: unknown): boolean {
-    return error instanceof Error && !(error instanceof DomainError);
+    return error instanceof Error && !(error instanceof HandledError);
   }
 
   /**
    * Returns a safe user-facing message for any error:
-   * - DomainErrors → their own message (safe to show users)
+   * - HandledErrors → their own message (safe to show users)
    * - Everything else → a generic "unknown error" string, and the original
    *   error is passed to the optional `log` callback for server-side logging.
    *
    * ```ts
    * } catch (e) {
-   *   const msg = DomainError.toUserMessage(e, (err) => logger.error(err));
+   *   const msg = HandledError.toUserMessage(e, (err) => logger.error(err));
    *   throw new TRPCError({ code: "NOT_FOUND", message: msg });
    * }
    * ```
@@ -137,40 +149,40 @@ export abstract class DomainError extends Error {
     error: unknown,
     log?: (error: unknown) => void,
   ): string {
-    if (error instanceof DomainError) return error.message;
+    if (error instanceof HandledError) return error.message;
     log?.(error);
     return "An unknown error occurred";
   }
 }
 
 function serializeReason(error: Error): SerializedReason {
-  if (error instanceof DomainError) {
+  if (error instanceof HandledError) {
     return {
-      kind: error.kind,
+      code: error.code,
       ...(Object.keys(error.meta).length > 0 && { meta: error.meta }),
       ...(error.reasons.length > 0 && {
         reasons: error.reasons.map(serializeReason),
       }),
     };
   }
-  return { kind: "unknown" };
+  return { code: "unknown" };
 }
 
 
 /**
  * Thrown when a requested resource does not exist (HTTP 404).
  *
- * Domain-specific subclasses narrow `kind` via `declare` and populate `meta`
+ * Domain-specific subclasses narrow `code` via `declare` and populate `meta`
  * with identifying fields (e.g. `{ spanId }`).
  */
-export class NotFoundError extends DomainError {
+export class NotFoundError extends HandledError {
   constructor(
-    kind: string,
+    code: string,
     resource: string,
     id: string,
     options: { meta?: Record<string, unknown>; reasons?: readonly Error[] } = {},
   ) {
-    super(kind, `${resource} not found: ${id}`, {
+    super(code, `${resource} not found: ${id}`, {
       meta: { id, ...options.meta },
       httpStatus: 404,
       reasons: options.reasons,
@@ -182,7 +194,7 @@ export class NotFoundError extends DomainError {
 /**
  * Thrown when input fails domain-level validation rules (HTTP 422).
  */
-export class ValidationError extends DomainError {
+export class ValidationError extends HandledError {
   constructor(
     message: string,
     options: { meta?: Record<string, unknown>; reasons?: readonly Error[] } = {},

--- a/langwatch/src/server/app-layer/index.ts
+++ b/langwatch/src/server/app-layer/index.ts
@@ -1,10 +1,10 @@
-// Domain errors
+// Handled errors
 export {
-  DomainError,
+  HandledError,
   NotFoundError,
   ValidationError
-} from "./domain-error";
-export type { SerializedDomainError } from "./domain-error";
+} from "./handled-error";
+export type { SerializedHandledError } from "./handled-error";
 
 // Tracing
 export { traced } from "./tracing";

--- a/langwatch/src/server/app-layer/organizations/errors.ts
+++ b/langwatch/src/server/app-layer/organizations/errors.ts
@@ -1,7 +1,7 @@
-import { NotFoundError } from "../domain-error";
+import { NotFoundError } from "../handled-error";
 
 export class OrganizationNotFoundForTeamError extends NotFoundError {
-  declare readonly kind: "organization_not_found_for_team";
+  declare readonly code: "organization_not_found_for_team";
 
   constructor(teamId: string, options: { reasons?: readonly Error[] } = {}) {
     super("organization_not_found_for_team", "Organization for team", teamId, {

--- a/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
@@ -10,7 +10,7 @@ import {
 } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { generate } from "@langwatch/ksuid";
-import { NotFoundError, ValidationError } from "~/server/app-layer/domain-error";
+import { NotFoundError, ValidationError } from "~/server/app-layer/handled-error";
 import { GROWTH_SEAT_PLAN_TYPES } from "../../../../../ee/billing/utils/growthSeatEvent";
 import { encrypt } from "~/utils/encryption";
 import { KSUID_RESOURCES } from "~/utils/constants";

--- a/langwatch/src/server/app-layer/permissions/__tests__/errors.unit.test.ts
+++ b/langwatch/src/server/app-layer/permissions/__tests__/errors.unit.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { LiteMemberRestrictedError } from "../errors";
-import { DomainError } from "../../domain-error";
+import { HandledError } from "../../handled-error";
 
 describe("LiteMemberRestrictedError", () => {
   describe("when constructed with a resource", () => {
-    it("sets kind to lite_member_restricted", () => {
+    it("sets code to lite_member_restricted", () => {
       const error = new LiteMemberRestrictedError("prompts");
-      expect(error.kind).toBe("lite_member_restricted");
+      expect(error.code).toBe("lite_member_restricted");
     });
 
     it("sets the user-facing message", () => {
@@ -26,9 +26,9 @@ describe("LiteMemberRestrictedError", () => {
       expect(error.meta).toEqual({ resource: "datasets" });
     });
 
-    it("is an instance of DomainError", () => {
+    it("is an instance of HandledError", () => {
       const error = new LiteMemberRestrictedError("prompts");
-      expect(error).toBeInstanceOf(DomainError);
+      expect(error).toBeInstanceOf(HandledError);
     });
 
     it("sets name to LiteMemberRestrictedError", () => {
@@ -43,7 +43,7 @@ describe("LiteMemberRestrictedError", () => {
       const serialized = error.serialize();
 
       expect(serialized).toMatchObject({
-        kind: "lite_member_restricted",
+        code: "lite_member_restricted",
         meta: { resource: "evaluations" },
         httpStatus: 401,
         reasons: [],

--- a/langwatch/src/server/app-layer/permissions/__tests__/errors.unit.test.ts
+++ b/langwatch/src/server/app-layer/permissions/__tests__/errors.unit.test.ts
@@ -49,5 +49,13 @@ describe("LiteMemberRestrictedError", () => {
         reasons: [],
       });
     });
+
+    it("emits the deprecated `kind` alias equal to `code` for back-compat", () => {
+      const error = new LiteMemberRestrictedError("evaluations");
+      const serialized = error.serialize();
+
+      expect(serialized.kind).toBe("lite_member_restricted");
+      expect(serialized.kind).toBe(serialized.code);
+    });
   });
 });

--- a/langwatch/src/server/app-layer/permissions/errors.ts
+++ b/langwatch/src/server/app-layer/permissions/errors.ts
@@ -1,7 +1,7 @@
-import { DomainError } from "../domain-error";
+import { HandledError } from "../handled-error";
 
-export class LiteMemberRestrictedError extends DomainError {
-  declare readonly kind: "lite_member_restricted";
+export class LiteMemberRestrictedError extends HandledError {
+  declare readonly code: "lite_member_restricted";
 
   constructor(resource: string) {
     super("lite_member_restricted", "This feature is not available for your account", {

--- a/langwatch/src/server/app-layer/subscription/errors.ts
+++ b/langwatch/src/server/app-layer/subscription/errors.ts
@@ -1,10 +1,10 @@
-import { DomainError } from "../domain-error";
+import { HandledError } from "../handled-error";
 
 /**
  * Thrown when a Stripe-dependent operation is invoked in self-hosted
  * (non-SaaS) deployments where no billing provider is available.
  */
-export class SubscriptionServiceUnavailableError extends DomainError {
+export class SubscriptionServiceUnavailableError extends HandledError {
   constructor() {
     super(
       "subscription_service_unavailable",

--- a/langwatch/src/server/app-layer/subscription/errors.ts
+++ b/langwatch/src/server/app-layer/subscription/errors.ts
@@ -5,6 +5,8 @@ import { HandledError } from "../handled-error";
  * (non-SaaS) deployments where no billing provider is available.
  */
 export class SubscriptionServiceUnavailableError extends HandledError {
+  declare readonly code: "subscription_service_unavailable";
+
   constructor() {
     super(
       "subscription_service_unavailable",

--- a/langwatch/src/server/app-layer/traces/__tests__/model-cost-span-preview.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/model-cost-span-preview.integration.test.ts
@@ -21,7 +21,7 @@ import {
   startTestContainers,
   stopTestContainers,
 } from "../../../event-sourcing/__tests__/integration/testContainers";
-import { ValidationError } from "../../domain-error";
+import { ValidationError } from "../../handled-error";
 import {
   deriveUnmappedCostSuggestion,
   previewCostRuleMatchingSpans,

--- a/langwatch/src/server/app-layer/traces/errors.ts
+++ b/langwatch/src/server/app-layer/traces/errors.ts
@@ -1,8 +1,8 @@
 // TODO: wire or delete — never thrown
-import { DomainError, NotFoundError } from "~/server/app-layer/domain-error";
+import { HandledError, NotFoundError } from "~/server/app-layer/handled-error";
 
 export class TraceNotFoundError extends NotFoundError {
-  declare readonly kind: "trace_not_found";
+  declare readonly code: "trace_not_found";
 
   constructor(traceId: string, options: { reasons?: readonly Error[] } = {}) {
     super("trace_not_found", "Trace", traceId, {
@@ -14,7 +14,7 @@ export class TraceNotFoundError extends NotFoundError {
 }
 
 export class SpanNotFoundError extends NotFoundError {
-  declare readonly kind: "span_not_found";
+  declare readonly code: "span_not_found";
 
   constructor(spanId: string, options: { reasons?: readonly Error[] } = {}) {
     super("span_not_found", "Span", spanId, {
@@ -25,8 +25,8 @@ export class SpanNotFoundError extends NotFoundError {
   }
 }
 
-export class QueryTimeoutError extends DomainError {
-  declare readonly kind: "query_timeout";
+export class QueryTimeoutError extends HandledError {
+  declare readonly code: "query_timeout";
 
   constructor(durationMs: number, hint?: string) {
     super(
@@ -41,8 +41,8 @@ export class QueryTimeoutError extends DomainError {
   }
 }
 
-export class FilterParseError extends DomainError {
-  declare readonly kind: "filter_parse_error";
+export class FilterParseError extends HandledError {
+  declare readonly code: "filter_parse_error";
 
   constructor(message: string, position?: number) {
     super("filter_parse_error", message, {
@@ -56,8 +56,8 @@ export class FilterParseError extends DomainError {
   }
 }
 
-export class FilterFieldUnknownError extends DomainError {
-  declare readonly kind: "filter_field_unknown";
+export class FilterFieldUnknownError extends HandledError {
+  declare readonly code: "filter_field_unknown";
 
   constructor(field: string, knownFields: string[]) {
     super("filter_field_unknown", `Unknown field: @${field}`, {
@@ -68,8 +68,8 @@ export class FilterFieldUnknownError extends DomainError {
   }
 }
 
-export class TimeRangeTooWideError extends DomainError {
-  declare readonly kind: "time_range_too_wide";
+export class TimeRangeTooWideError extends HandledError {
+  declare readonly code: "time_range_too_wide";
 
   constructor(maxDays: number) {
     super(
@@ -84,8 +84,8 @@ export class TimeRangeTooWideError extends DomainError {
   }
 }
 
-export class ClickHouseUnavailableError extends DomainError {
-  declare readonly kind: "clickhouse_unavailable";
+export class ClickHouseUnavailableError extends HandledError {
+  declare readonly code: "clickhouse_unavailable";
 
   constructor() {
     super("clickhouse_unavailable", "Database temporarily unavailable", {

--- a/langwatch/src/server/app-layer/traces/model-cost-span-preview.service.ts
+++ b/langwatch/src/server/app-layer/traces/model-cost-span-preview.service.ts
@@ -7,7 +7,7 @@ import {
   matchModelCostWithFallbacks,
 } from "~/server/tracer/collector/cost";
 import { compileSafeRegex } from "~/utils/safeRegex";
-import { ValidationError } from "../domain-error";
+import { ValidationError } from "../handled-error";
 import type { SpanStorageService } from "./span-storage.service";
 
 /**

--- a/langwatch/src/server/app-layer/triggers/errors.ts
+++ b/langwatch/src/server/app-layer/triggers/errors.ts
@@ -3,16 +3,18 @@ import { HandledError } from "~/server/app-layer/handled-error";
 /**
  * Domain errors raised by the automation authoring path (ADR-036). Each is a
  * concrete `HandledError` subclass so the existing tRPC `errorFormatter`
- * serialises it onto the wire as `error.data.domainError` with the `kind`
- * discriminator plus structured `meta`. The client matches on `kind` and
+ * serialises it onto the wire as `error.data.domainError` with the `code`
+ * discriminator plus structured `meta`. The client matches on `code` and
  * renders field-targeted, actionable errors (highlight the offending field,
  * list the offending recipient, etc.) rather than a generic toast.
  *
- * `kind` strings stay stable across versions — the client uses them as a
+ * `code` strings stay stable across versions — the client uses them as a
  * discriminator, exactly like the existing `EvaluationNotFoundError` flow.
  */
 
 export class TemplateValidationError extends HandledError {
+  declare readonly code: "template_validation_error";
+
   constructor(
     /** Template field that failed to parse — `emailSubjectTemplate`,
      *  `emailBodyTemplate`, `slackTemplate`, or `slackTemplateType`. */
@@ -33,6 +35,8 @@ export class TemplateValidationError extends HandledError {
 }
 
 export class TestFireUnavailableError extends HandledError {
+  declare readonly code: "test_fire_unavailable";
+
   constructor(
     public readonly channel: "email" | "slack",
     /** Why the test fire can't be sent (no recipients, no webhook, …). */
@@ -51,6 +55,8 @@ export class TestFireUnavailableError extends HandledError {
  * recipient so the UI can highlight the chip that needs fixing.
  */
 export class InvalidEmailRecipientError extends HandledError {
+  declare readonly code: "invalid_email_recipient";
+
   constructor(public readonly recipient: string) {
     super(
       "invalid_email_recipient",
@@ -65,6 +71,8 @@ export class InvalidEmailRecipientError extends HandledError {
 }
 
 export class MissingSlackWebhookError extends HandledError {
+  declare readonly code: "missing_slack_webhook";
+
   constructor() {
     super(
       "missing_slack_webhook",
@@ -84,6 +92,8 @@ export class MissingSlackWebhookError extends HandledError {
  * generic 500. `field` targets the channel input, the most common fix.
  */
 export class NotificationDeliveryError extends HandledError {
+  declare readonly code: "notification_delivery_error";
+
   constructor(message: string) {
     super("notification_delivery_error", message, {
       meta: { field: "slackChannelId" },
@@ -94,6 +104,8 @@ export class NotificationDeliveryError extends HandledError {
 }
 
 export class MissingAnnotatorError extends HandledError {
+  declare readonly code: "missing_annotator";
+
   constructor() {
     super(
       "missing_annotator",
@@ -105,6 +117,8 @@ export class MissingAnnotatorError extends HandledError {
 }
 
 export class ProjectNotFoundError extends HandledError {
+  declare readonly code: "project_not_found";
+
   constructor(public readonly projectId: string) {
     super("project_not_found", `Project not found: ${projectId}`, {
       meta: { projectId },

--- a/langwatch/src/server/app-layer/triggers/errors.ts
+++ b/langwatch/src/server/app-layer/triggers/errors.ts
@@ -1,8 +1,8 @@
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 
 /**
  * Domain errors raised by the automation authoring path (ADR-036). Each is a
- * concrete `DomainError` subclass so the existing tRPC `errorFormatter`
+ * concrete `HandledError` subclass so the existing tRPC `errorFormatter`
  * serialises it onto the wire as `error.data.domainError` with the `kind`
  * discriminator plus structured `meta`. The client matches on `kind` and
  * renders field-targeted, actionable errors (highlight the offending field,
@@ -12,7 +12,7 @@ import { DomainError } from "~/server/app-layer/domain-error";
  * discriminator, exactly like the existing `EvaluationNotFoundError` flow.
  */
 
-export class TemplateValidationError extends DomainError {
+export class TemplateValidationError extends HandledError {
   constructor(
     /** Template field that failed to parse — `emailSubjectTemplate`,
      *  `emailBodyTemplate`, `slackTemplate`, or `slackTemplateType`. */
@@ -32,7 +32,7 @@ export class TemplateValidationError extends DomainError {
   }
 }
 
-export class TestFireUnavailableError extends DomainError {
+export class TestFireUnavailableError extends HandledError {
   constructor(
     public readonly channel: "email" | "slack",
     /** Why the test fire can't be sent (no recipients, no webhook, …). */
@@ -50,7 +50,7 @@ export class TestFireUnavailableError extends DomainError {
  * An email address failed RFC-shape validation. Carries the offending
  * recipient so the UI can highlight the chip that needs fixing.
  */
-export class InvalidEmailRecipientError extends DomainError {
+export class InvalidEmailRecipientError extends HandledError {
   constructor(public readonly recipient: string) {
     super(
       "invalid_email_recipient",
@@ -64,7 +64,7 @@ export class InvalidEmailRecipientError extends DomainError {
   }
 }
 
-export class MissingSlackWebhookError extends DomainError {
+export class MissingSlackWebhookError extends HandledError {
   constructor() {
     super(
       "missing_slack_webhook",
@@ -80,10 +80,10 @@ export class MissingSlackWebhookError extends DomainError {
  * `not_in_channel` / `channel_not_found`, a dead webhook, a bad bot token. The
  * underlying `DispatchError` already carries an actionable, provider-specific
  * message (see `explainSlackPostError`); this lifts it onto the typed
- * `DomainError` channel so the drawer renders it as a clear 4xx instead of a
+ * `HandledError` channel so the drawer renders it as a clear 4xx instead of a
  * generic 500. `field` targets the channel input, the most common fix.
  */
-export class NotificationDeliveryError extends DomainError {
+export class NotificationDeliveryError extends HandledError {
   constructor(message: string) {
     super("notification_delivery_error", message, {
       meta: { field: "slackChannelId" },
@@ -93,7 +93,7 @@ export class NotificationDeliveryError extends DomainError {
   }
 }
 
-export class MissingAnnotatorError extends DomainError {
+export class MissingAnnotatorError extends HandledError {
   constructor() {
     super(
       "missing_annotator",
@@ -104,7 +104,7 @@ export class MissingAnnotatorError extends DomainError {
   }
 }
 
-export class ProjectNotFoundError extends DomainError {
+export class ProjectNotFoundError extends HandledError {
   constructor(public readonly projectId: string) {
     super("project_not_found", `Project not found: ${projectId}`, {
       meta: { projectId },

--- a/langwatch/src/server/app-layer/usage/errors.ts
+++ b/langwatch/src/server/app-layer/usage/errors.ts
@@ -1,4 +1,4 @@
-import { DomainError } from "../domain-error";
+import { HandledError } from "../handled-error";
 
 /**
  * Domain error thrown when an organization has reached its scenario set limit.
@@ -7,8 +7,8 @@ import { DomainError } from "../domain-error";
  * ClickHouse-based (not Prisma-based), so it does not belong in the
  * license-enforcement LimitType system.
  */
-export class ScenarioSetLimitExceededError extends DomainError {
-  declare readonly kind: "scenario_set_limit_exceeded";
+export class ScenarioSetLimitExceededError extends HandledError {
+  declare readonly code: "scenario_set_limit_exceeded";
 
   constructor(current: number, max: number) {
     super(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/commands.ts
@@ -102,7 +102,7 @@ export type ResolveOriginCommandData = z.infer<
  * rejects pure-whitespace and over-long names without an extra transform
  * step that defineCommand's `z.ZodObject<z.ZodRawShape>` constraint
  * doesn't accept. Anything that fails this Zod check should bubble up
- * as a `ValidationError` (DomainError) rather than reaching the command
+ * as a `ValidationError` (HandledError) rather than reaching the command
  * pipeline.
  */
 export const changeTraceNameInputSchema = z.object({

--- a/langwatch/src/server/experiments/errors.ts
+++ b/langwatch/src/server/experiments/errors.ts
@@ -1,7 +1,7 @@
-import { NotFoundError } from "../app-layer/domain-error";
+import { NotFoundError } from "../app-layer/handled-error";
 
 export class ExperimentNotFoundError extends NotFoundError {
-  declare readonly kind: "experiment_not_found";
+  declare readonly code: "experiment_not_found";
 
   constructor(
     experimentId: string,

--- a/langwatch/src/server/license-enforcement/errors.ts
+++ b/langwatch/src/server/license-enforcement/errors.ts
@@ -1,4 +1,4 @@
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 import { LIMIT_TYPE_LABELS } from "./constants";
 import type { LimitType } from "./types";
 
@@ -7,8 +7,8 @@ import type { LimitType } from "./types";
  * This error is framework-agnostic and should be caught and mapped to
  * HTTP/tRPC errors by the router layer.
  */
-export class LimitExceededError extends DomainError {
-  declare readonly kind: "resource_limit_exceeded";
+export class LimitExceededError extends HandledError {
+  declare readonly code: "resource_limit_exceeded";
 
   constructor(
     public readonly limitType: LimitType,

--- a/langwatch/src/server/nlpgo/__tests__/goHandledError.unit.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/goHandledError.unit.test.ts
@@ -1,6 +1,6 @@
 import { APICallError, RetryError } from "ai";
 import { describe, expect, it } from "vitest";
-import { DomainError } from "../../app-layer/domain-error";
+import { HandledError } from "../../app-layer/handled-error";
 import { isAbortLikeError, nlpgoHandledErrorFrom } from "../goHandledError";
 
 /** The exact envelope nlpgo returned for an unroutable provider prefix. */
@@ -31,14 +31,14 @@ function makeAPICallError({
 
 describe("nlpgoHandledErrorFrom", () => {
   describe("given an APICallError carrying nlpgo's handled-error envelope", () => {
-    it("maps it to a DomainError keyed by meta.reason", () => {
+    it("maps it to a HandledError keyed by meta.reason", () => {
       const error = nlpgoHandledErrorFrom(
         makeAPICallError({ responseBody: MISSING_PROVIDER_BODY }),
       );
 
       expect(error).not.toBeNull();
-      expect(DomainError.isHandled(error)).toBe(true);
-      expect(error?.kind).toBe("missing_provider");
+      expect(HandledError.isHandled(error)).toBe(true);
+      expect(error?.code).toBe("missing_provider");
       expect(error?.httpStatus).toBe(400);
       expect(error?.meta).toEqual({ reason: "missing_provider" });
     });
@@ -53,7 +53,7 @@ describe("nlpgoHandledErrorFrom", () => {
         }),
       );
 
-      expect(error?.kind).toBe("upstream_timeout");
+      expect(error?.code).toBe("upstream_timeout");
       expect(error?.httpStatus).toBe(504);
     });
   });
@@ -67,7 +67,7 @@ describe("nlpgoHandledErrorFrom", () => {
         errors: [inner],
       });
 
-      expect(nlpgoHandledErrorFrom(retry)?.kind).toBe("missing_provider");
+      expect(nlpgoHandledErrorFrom(retry)?.code).toBe("missing_provider");
     });
   });
 

--- a/langwatch/src/server/nlpgo/goHandledError.ts
+++ b/langwatch/src/server/nlpgo/goHandledError.ts
@@ -1,6 +1,6 @@
 import { APICallError, RetryError } from "ai";
 import { z } from "zod";
-import { DomainError } from "../app-layer/domain-error";
+import { HandledError } from "../app-layer/handled-error";
 
 /**
  * nlpgo's handled-error envelope (services/nlpgo herr package). Every
@@ -22,17 +22,17 @@ const goErrorEnvelopeSchema = z.object({
 
 /**
  * A handled error the Go side (nlpgo / AI Gateway) returned as a typed
- * envelope. `kind` is the most specific discriminant available —
+ * envelope. `code` is the most specific discriminant available —
  * `meta.reason` when present (e.g. "missing_provider"), the envelope
  * `type` otherwise (e.g. "bad_request").
  */
-export class NlpgoHandledError extends DomainError {
+export class NlpgoHandledError extends HandledError {
   constructor(
-    kind: string,
+    code: string,
     message: string,
     options: { httpStatus: number; meta?: Record<string, unknown> },
   ) {
-    super(kind, message, options);
+    super(code, message, options);
     this.name = "NlpgoHandledError";
   }
 }
@@ -88,9 +88,9 @@ export function nlpgoHandledErrorFrom(error: unknown): NlpgoHandledError | null 
 
   const envelope = parsed.data.error;
   const reason = envelope.meta?.reason;
-  const kind = typeof reason === "string" ? reason : envelope.type;
+  const code = typeof reason === "string" ? reason : envelope.type;
 
-  return new NlpgoHandledError(kind, envelope.message ?? envelope.type, {
+  return new NlpgoHandledError(code, envelope.message ?? envelope.type, {
     httpStatus: cause.statusCode ?? 500,
     meta: envelope.meta,
   });

--- a/langwatch/src/server/prompt-config/__tests__/system-prompt-required.unit.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/system-prompt-required.unit.test.ts
@@ -3,15 +3,15 @@
  *
  * Today, when `prompts.create` is called with neither `prompt` nor a system
  * message in `messages`, the server throws `SystemPromptConflictError` with
- * no `httpStatus` field. The tRPC `domainErrorMiddleware` doesn't recognise
- * it as a `DomainError`, so the call bubbles up as INTERNAL_SERVER_ERROR
+ * no `httpStatus` field. The tRPC `handledErrorMiddleware` doesn't recognise
+ * it as a `HandledError`, so the call bubbles up as INTERNAL_SERVER_ERROR
  * (HTTP 500) and is captured as an "uncaught" bug.
  *
  * After the fix:
- *   - A dedicated `SystemPromptRequiredError` (extends `DomainError`,
+ *   - A dedicated `SystemPromptRequiredError` (extends `HandledError`,
  *     `httpStatus: 400`) is thrown for the missing-system-prompt case.
  *   - The original `SystemPromptConflictError` (both prompt + system
- *     message set) is preserved as a separate, still-409 `DomainError`.
+ *     message set) is preserved as a separate, still-409 `HandledError`.
  *   - The middleware auto-maps both to the correct tRPC codes
  *     (BAD_REQUEST and CONFLICT) — no manual try/catch in the router.
  *
@@ -21,7 +21,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 import { PromptService } from "~/server/prompt-config/prompt.service";
 import { PromptVersionService } from "~/server/prompt-config/prompt-version.service";
 
@@ -31,7 +31,7 @@ describe("PromptService.createPrompt — missing system prompt (Issue #3196 regr
   describe("given a PromptService", () => {
     describe("when creating a prompt with neither a prompt nor a system message", () => {
       /** @scenario "prompts.create returns 400 BAD_REQUEST when both prompt and system message are missing" */
-      it("throws a DomainError with httpStatus 400 and kind 'system_prompt_required' when no prompt and no system message are supplied", async () => {
+      it("throws a HandledError with httpStatus 400 and code 'system_prompt_required' when no prompt and no system message are supplied", async () => {
         const service = new PromptService({} as any);
         (service as any).repository = {
           createConfigWithInitialVersion: vi.fn(),
@@ -51,9 +51,9 @@ describe("PromptService.createPrompt — missing system prompt (Issue #3196 regr
           }),
         );
 
-        expect(error).toBeInstanceOf(DomainError);
-        expect((error as DomainError).kind).toBe("system_prompt_required");
-        expect((error as DomainError).httpStatus).toBe(400);
+        expect(error).toBeInstanceOf(HandledError);
+        expect((error as HandledError).code).toBe("system_prompt_required");
+        expect((error as HandledError).httpStatus).toBe(400);
         expect((error as Error).message).toMatch(/system prompt is required/i);
         expect((error as Error).message).not.toMatch(
           /SystemPromptConflictError/,
@@ -63,7 +63,7 @@ describe("PromptService.createPrompt — missing system prompt (Issue #3196 regr
 
     describe("when creating a prompt with both a prompt and a system message", () => {
       /** @scenario "prompts.create still rejects when both prompt and a system message are provided (existing conflict preserved)" */
-      it("still throws a DomainError with httpStatus 409 when both prompt and a system message are provided (no regression on AC 5)", async () => {
+      it("still throws a HandledError with httpStatus 409 when both prompt and a system message are provided (no regression on AC 5)", async () => {
         const service = new PromptService({} as any);
         (service as any).repository = {
           createConfigWithInitialVersion: vi.fn(),
@@ -88,9 +88,9 @@ describe("PromptService.createPrompt — missing system prompt (Issue #3196 regr
           }),
         );
 
-        expect(error).toBeInstanceOf(DomainError);
-        expect((error as DomainError).kind).toBe("system_prompt_conflict");
-        expect((error as DomainError).httpStatus).toBe(409);
+        expect(error).toBeInstanceOf(HandledError);
+        expect((error as HandledError).code).toBe("system_prompt_conflict");
+        expect((error as HandledError).httpStatus).toBe(409);
       });
     });
   });

--- a/langwatch/src/server/prompt-config/errors/system-prompt-conflict.error.ts
+++ b/langwatch/src/server/prompt-config/errors/system-prompt-conflict.error.ts
@@ -1,4 +1,4 @@
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 
 /**
  * Thrown when a caller supplies BOTH a top-level `prompt` field AND a system
@@ -8,7 +8,7 @@ import { DomainError } from "~/server/app-layer/domain-error";
  * For the distinct "neither prompt nor system message was supplied" case
  * (HTTP 400 Bad Request), use [[SystemPromptRequiredError]].
  */
-export class SystemPromptConflictError extends DomainError {
+export class SystemPromptConflictError extends HandledError {
   constructor(message?: string) {
     super(
       "system_prompt_conflict",

--- a/langwatch/src/server/prompt-config/errors/system-prompt-required.error.ts
+++ b/langwatch/src/server/prompt-config/errors/system-prompt-required.error.ts
@@ -1,4 +1,4 @@
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 
 /**
  * Thrown when neither a top-level `prompt` nor a system message in
@@ -8,7 +8,7 @@ import { DomainError } from "~/server/app-layer/domain-error";
  * HTTP 400 Bad Request — the message is user-facing and surfaced verbatim
  * via the toast in the UI.
  */
-export class SystemPromptRequiredError extends DomainError {
+export class SystemPromptRequiredError extends HandledError {
   constructor(message?: string) {
     super("system_prompt_required", message ?? "System prompt is required.", {
       httpStatus: 400,

--- a/langwatch/src/server/rbac/__tests__/custom-role-permissions.unit.test.ts
+++ b/langwatch/src/server/rbac/__tests__/custom-role-permissions.unit.test.ts
@@ -124,7 +124,7 @@ describe("parseCustomRolePermissions", () => {
         });
       } catch (err) {
         expect(err).toBeInstanceOf(MalformedCustomRolePermissionsError);
-        expect((err as MalformedCustomRolePermissionsError).kind).toBe(
+        expect((err as MalformedCustomRolePermissionsError).code).toBe(
           "malformed_custom_role_permissions",
         );
         expect((err as MalformedCustomRolePermissionsError).meta).toMatchObject(

--- a/langwatch/src/server/rbac/custom-role-permissions.ts
+++ b/langwatch/src/server/rbac/custom-role-permissions.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { Prisma } from "@prisma/client";
-import { DomainError } from "../app-layer/domain-error";
+import { HandledError } from "../app-layer/handled-error";
 import { Actions, Resources } from "../api/rbac";
 
 const VALID_PERMISSIONS: Set<string> = new Set(
@@ -30,8 +30,8 @@ export const CustomRolePermissionsSchema = z.array(permissionFormatSchema);
  * "no permissions granted" is a dangerous fail-open (nothing to verify →
  * every check trivially passes).
  */
-export class MalformedCustomRolePermissionsError extends DomainError {
-  declare readonly kind: "malformed_custom_role_permissions";
+export class MalformedCustomRolePermissionsError extends HandledError {
+  declare readonly code: "malformed_custom_role_permissions";
 
   constructor(
     customRoleId: string,

--- a/langwatch/src/server/routes/evaluations-legacy.ts
+++ b/langwatch/src/server/routes/evaluations-legacy.ts
@@ -40,7 +40,7 @@ import {
 } from "~/server/api-key/auth-middleware";
 import { TokenResolver } from "~/server/api-key/token-resolver";
 import { getApp } from "~/server/app-layer/app";
-import { DomainError } from "~/server/app-layer/domain-error";
+import { HandledError } from "~/server/app-layer/handled-error";
 import { EvaluatorMissingFieldError } from "~/server/app-layer/evaluations/errors";
 import { prisma } from "~/server/db";
 import {
@@ -265,13 +265,13 @@ secured
           });
           const validationError = fromZodError(error);
           return c.json({ error: validationError.message }, 400);
-        } else if (DomainError.is(error)) {
+        } else if (HandledError.is(error)) {
           logger.warn(
-            { kind: error.kind, meta: error.meta, projectId: project.id },
-            "domain error processing batch evaluation",
+            { code: error.code, meta: error.meta, projectId: project.id },
+            "handled error processing batch evaluation",
           );
           return c.json(
-            { error: error.kind, message: error.message },
+            { error: error.code, message: error.message },
             error.httpStatus as 400,
           );
         } else {
@@ -1062,14 +1062,14 @@ async function handleEvaluatorCall(
       data.data[requiredField] === undefined ||
       data.data[requiredField] === null
     ) {
-      const domainError = new EvaluatorMissingFieldError(
+      const handledError = new EvaluatorMissingFieldError(
         requiredField,
         evaluatorDefinition.name,
       );
       logger.warn(
         {
-          kind: domainError.kind,
-          meta: domainError.meta,
+          code: handledError.code,
+          meta: handledError.meta,
           projectId: project.id,
         },
         "missing required field for evaluator",
@@ -1080,12 +1080,14 @@ async function handleEvaluatorCall(
           // this endpoint's existing wire shape for external API consumers.
           // `kind`/`meta` are additive so the workbench client can build a
           // friendly message (e.g. map candidate_a_id -> "Variant A")
-          // without depending on the message being a specific string.
-          error: domainError.message,
-          kind: domainError.kind,
-          meta: domainError.meta,
+          // without depending on the message being a specific string. The
+          // wire field is named `kind` for back-compat; it carries the
+          // HandledError `code`.
+          error: handledError.message,
+          kind: handledError.code,
+          meta: handledError.meta,
         },
-        domainError.httpStatus as 400,
+        handledError.httpStatus as 400,
       );
     }
   }

--- a/langwatch/src/server/routes/evaluations-legacy.ts
+++ b/langwatch/src/server/routes/evaluations-legacy.ts
@@ -265,7 +265,7 @@ secured
           });
           const validationError = fromZodError(error);
           return c.json({ error: validationError.message }, 400);
-        } else if (HandledError.is(error)) {
+        } else if (HandledError.isHandled(error)) {
           logger.warn(
             { code: error.code, meta: error.meta, projectId: project.id },
             "handled error processing batch evaluation",

--- a/langwatch/src/server/routes/misc.ts
+++ b/langwatch/src/server/routes/misc.ts
@@ -459,7 +459,7 @@ secured
           }
           return c.json(
             {
-              error: error.kind,
+              error: error.code,
               message,
               limitType: error.limitType,
               current: error.current,

--- a/langwatch/src/server/teams/team.service.ts
+++ b/langwatch/src/server/teams/team.service.ts
@@ -1,5 +1,5 @@
 import { Prisma, RoleBindingScopeType, TeamUserRole, type PrismaClient } from "@prisma/client";
-import { NotFoundError, ValidationError } from "~/server/app-layer/domain-error";
+import { NotFoundError, ValidationError } from "~/server/app-layer/handled-error";
 import { PrismaRoleBindingRepository } from "~/server/app-layer/role-bindings/repositories/role-binding.prisma.repository";
 import type {
   RoleBindingRepository,

--- a/langwatch/src/utils/__tests__/api.unit.test.ts
+++ b/langwatch/src/utils/__tests__/api.unit.test.ts
@@ -229,14 +229,14 @@ describe("Global mutation error handler", () => {
       expect(extractLiteMemberRestrictionInfo(error)).toBeNull();
     });
 
-    it("returns null for UNAUTHORIZED with wrong domainError kind", () => {
+    it("returns null for UNAUTHORIZED with wrong domainError code", () => {
       const error = new TRPCClientError("Unauthorized", {
         result: {
           error: {
             data: {
               code: "UNAUTHORIZED",
               httpStatus: 401,
-              domainError: { kind: "some_other_error" },
+              domainError: { code: "some_other_error" },
             },
           },
         },
@@ -252,7 +252,7 @@ describe("Global mutation error handler", () => {
               code: "UNAUTHORIZED",
               httpStatus: 401,
               domainError: {
-                kind: "lite_member_restricted",
+                code: "lite_member_restricted",
                 meta: { resource: "prompts" },
               },
             },
@@ -272,7 +272,7 @@ describe("Global mutation error handler", () => {
               code: "UNAUTHORIZED",
               httpStatus: 401,
               domainError: {
-                kind: "lite_member_restricted",
+                code: "lite_member_restricted",
                 meta: {},
               },
             },
@@ -369,7 +369,7 @@ describe("Global mutation error handler", () => {
               code: "UNAUTHORIZED",
               httpStatus: 401,
               domainError: {
-                kind: "lite_member_restricted",
+                code: "lite_member_restricted",
                 meta: { resource: "prompts" },
               },
             },
@@ -424,7 +424,7 @@ describe("Global mutation error handler", () => {
               code: "UNAUTHORIZED",
               httpStatus: 401,
               domainError: {
-                kind: "lite_member_restricted",
+                code: "lite_member_restricted",
                 meta: { resource: "datasets" },
               },
             },
@@ -465,7 +465,7 @@ describe("Global mutation error handler", () => {
               code: "UNAUTHORIZED",
               httpStatus: 401,
               domainError: {
-                kind: "lite_member_restricted",
+                code: "lite_member_restricted",
                 meta: { resource: "datasets" },
               },
             },

--- a/langwatch/src/utils/__tests__/api.unit.test.ts
+++ b/langwatch/src/utils/__tests__/api.unit.test.ts
@@ -283,6 +283,27 @@ describe("Global mutation error handler", () => {
         resource: undefined,
       });
     });
+
+    it("extracts resource from the deprecated `kind` discriminant (old server)", () => {
+      const error = new TRPCClientError("Unauthorized", {
+        result: {
+          error: {
+            data: {
+              code: "UNAUTHORIZED",
+              httpStatus: 401,
+              // A pre-HandledError server serialises the discriminant as `kind`.
+              domainError: {
+                kind: "lite_member_restricted",
+                meta: { resource: "prompts" },
+              },
+            },
+          },
+        },
+      });
+      expect(extractLiteMemberRestrictionInfo(error)).toEqual({
+        resource: "prompts",
+      });
+    });
   });
 
   describe("isHandledByLiteMemberHandler", () => {

--- a/langwatch/src/utils/trpcError.ts
+++ b/langwatch/src/utils/trpcError.ts
@@ -98,12 +98,15 @@ export function extractLiteMemberRestrictionInfo(
   if (error.data?.code !== "UNAUTHORIZED") return null;
 
   const handledError = error.data?.domainError as
-    | { code?: string; meta?: { resource?: string } }
+    | { code?: string; kind?: string; meta?: { resource?: string } }
     | undefined;
 
-  if (handledError?.code !== "lite_member_restricted") return null;
+  // `kind` is the deprecated pre-`HandledError` discriminant, read as a
+  // fallback so this resolves across the transition (see SerializedHandledError).
+  const handledCode = handledError?.code ?? handledError?.kind;
+  if (handledCode !== "lite_member_restricted") return null;
 
-  return { resource: handledError.meta?.resource };
+  return { resource: handledError?.meta?.resource };
 }
 
 export function extractLimitExceededInfo(

--- a/langwatch/src/utils/trpcError.ts
+++ b/langwatch/src/utils/trpcError.ts
@@ -97,13 +97,13 @@ export function extractLiteMemberRestrictionInfo(
   if (!(error instanceof TRPCClientError)) return null;
   if (error.data?.code !== "UNAUTHORIZED") return null;
 
-  const domainError = error.data?.domainError as
-    | { kind?: string; meta?: { resource?: string } }
+  const handledError = error.data?.domainError as
+    | { code?: string; meta?: { resource?: string } }
     | undefined;
 
-  if (domainError?.kind !== "lite_member_restricted") return null;
+  if (handledError?.code !== "lite_member_restricted") return null;
 
-  return { resource: domainError.meta?.resource };
+  return { resource: handledError.meta?.resource };
 }
 
 export function extractLimitExceededInfo(

--- a/specs/features/domain-error-contract.feature
+++ b/specs/features/domain-error-contract.feature
@@ -129,3 +129,21 @@ Feature: Handled errors — the handled-error boundary
     Given a serialised handled error crosses a worker or process boundary
     Then consumers branch on `error.code`, not `instanceof`
     And identity survives the boundary intact
+
+  # ==========================================================================
+  # Transition: `kind` → `code` rename stays non-breaking during rollout
+  # ==========================================================================
+
+  @bdd @domain-errors
+  Scenario: A serialised handled error carries `code` and a deprecated `kind` alias
+    Given a HandledError is serialised for the wire
+    Then the payload carries the discriminant as `code`
+    And it also carries the same value as a deprecated `kind` alias
+    And nested reasons carry the same `code`/`kind` pair
+    So an older client still reading `kind` keeps working through the rollout
+
+  @bdd @domain-errors
+  Scenario: A client resolves a handled error from either discriminant field
+    Given a client reads the discriminant off `data.domainError`
+    When the payload carries only the deprecated `kind` (an older server)
+    Then the client resolves the same handled error as if it had read `code`

--- a/specs/features/domain-error-contract.feature
+++ b/specs/features/domain-error-contract.feature
@@ -1,16 +1,16 @@
-Feature: Domain errors — the handled-error boundary
+Feature: Handled errors — the handled-error boundary
 
   Every error that crosses an API boundary is exactly one of two things, and the
   contract turns on the difference:
 
     - HANDLED — we understand it and the caller can act on it (not found,
       forbidden, not-owned, timeout, validation, conflict, rate-limited). It is a
-      `DomainError` in TypeScript / an `herr.E` in Go, with a stable `kind`
-      (Go: `Code`), user-relevant `message`, structured `meta`, `telemetry`
-      (traceId/spanId), an `httpStatus`, and a `reasons` cause chain.
+      `HandledError` in TypeScript / an `herr.E` in Go, with a stable `code`
+      (Go: `Code`), user-relevant `message`, structured `meta`, `traceId`/`spanId`,
+      an `httpStatus`, and a `reasons` cause chain.
     - UNHANDLED — anything we did not anticipate (a database crash, a nil deref,
       an infra timeout, a bug). It is a plain `Error` / plain `error`. It has no
-      user-relevant meaning and MUST NOT be dressed up as a domain error.
+      user-relevant meaning and MUST NOT be dressed up as a handled error.
 
   The rule: only handled errors cross the boundary with meaning. An unhandled
   error is reported to the client as a single generic "unknown", its detail
@@ -18,31 +18,31 @@ Feature: Domain errors — the handled-error boundary
   error. The presence of a serialised domain payload IS the signal of "handled".
 
   This contract is the same in both languages and applies everywhere. See
-  ADR-045. The machinery already exists (`src/server/app-layer/domain-error.ts`,
+  ADR-045. The machinery already exists (`src/server/app-layer/handled-error.ts`,
   wired into tRPC's `errorFormatter` and Hono's `onError`); these scenarios pin
   its intended behaviour and its reach.
 
   Background:
-    Given the DomainError base and its serialisation are available in the app layer
-    And tRPC attaches a serialised domain error to `data.domainError`
-    And Hono's `onError` normalises a DomainError to `{ error: kind, message, ...meta }`
+    Given the HandledError base and its serialisation are available in the app layer
+    And tRPC attaches a serialised handled error to `data.domainError`
+    And Hono's `onError` normalises a HandledError to `{ error: code, message, ...meta }`
 
   # ==========================================================================
   # Handled: known, user-relevant failures cross the boundary with meaning
   # ==========================================================================
 
   @bdd @domain-errors
-  Scenario: A known failure is serialised as a domain error over tRPC
-    Given a procedure throws a NotFoundError of kind "evaluation_not_found" with meta { id }
+  Scenario: A known failure is serialised as a handled error over tRPC
+    Given a procedure throws a NotFoundError of code "evaluation_not_found" with meta { id }
     When the client calls that procedure
     Then the tRPC error carries `data.domainError`
-    And the domain error has kind "evaluation_not_found"
+    And the handled error has code "evaluation_not_found"
     And its meta contains the requested id
     And its httpStatus is 404
 
   @bdd @domain-errors
   Scenario: A known failure is normalised by Hono to a client-safe body
-    Given a service route throws a DomainError of kind "conversation_not_owned" with httpStatus 403
+    Given a service route throws a HandledError of code "conversation_not_owned" with httpStatus 403
     When the client calls that route
     Then the HTTP status is 403
     And the response body is { error: "conversation_not_owned", message, ...meta }
@@ -50,13 +50,13 @@ Feature: Domain errors — the handled-error boundary
 
   @bdd @domain-errors
   Scenario: httpStatus follows the failure class
-    Given a NotFoundError, a ValidationError, a conflict, and a rate-limit domain error
+    Given a NotFoundError, a ValidationError, a conflict, and a rate-limit handled error
     Then their httpStatus values are 404, 422, 409, and 429 respectively
 
   @bdd @domain-errors
   Scenario: Telemetry is captured from the active span
-    Given a DomainError is constructed inside an active OTel span
-    Then its telemetry carries that span's traceId and spanId
+    Given a HandledError is constructed inside an active OTel span
+    Then it carries that span's traceId and spanId
     And the client can link the error to its trace
 
   # ==========================================================================
@@ -75,14 +75,14 @@ Feature: Domain errors — the handled-error boundary
   Scenario: An unhandled reason inside a handled error is masked, not leaked
     Given an EvaluationNotFoundError is thrown with a plain database Error in its reasons
     When it is serialised
-    Then the top-level kind is "evaluation_not_found"
-    And the database Error appears in reasons only as { kind: "unknown" }
+    Then the top-level code is "evaluation_not_found"
+    And the database Error appears in reasons only as { code: "unknown" }
     And no database detail reaches the client
 
   @bdd @domain-errors
-  Scenario: We never invent a domain error for an unknown cause
+  Scenario: We never invent a handled error for an unknown cause
     Given a failure we cannot name (an unexpected bug)
-    Then the code throws a plain Error, not a DomainError subclass
+    Then the code throws a plain Error, not a HandledError subclass
     And it correctly degrades to "unknown" at the boundary
 
   # ==========================================================================
@@ -90,11 +90,11 @@ Feature: Domain errors — the handled-error boundary
   # ==========================================================================
 
   @bdd @domain-errors @unimplemented
-  Scenario: A Go herr proxied by the control plane arrives as a domain error
+  Scenario: A Go herr proxied by the control plane arrives as a handled error
     Given a Go service returns an herr.E with Code "github_unreachable" and a trace id
     When the control plane proxies that failure to the client
-    Then it is adapted into a DomainError (Code→kind, meta→meta, trace_id→telemetry)
-    And the client receives kind "github_unreachable" with its meta and trace link
+    Then it is adapted into a HandledError (Code → code, meta→meta, trace_id/span_id→traceId/spanId)
+    And the client receives code "github_unreachable" with its meta and trace link
 
   @bdd @domain-errors @unimplemented
   Scenario: A plain Go error proxied by the control plane becomes unknown
@@ -108,24 +108,24 @@ Feature: Domain errors — the handled-error boundary
   # ==========================================================================
 
   @bdd @domain-errors @unimplemented
-  Scenario: A streamed response carries the serialised domain error on its error event
+  Scenario: A streamed response carries the serialised handled error on its error event
     Given a streamed endpoint (e.g. the Langy chat stream) hits a known failure mid-stream
-    Then its error event carries the SerializedDomainError, not a plain string
+    Then its error event carries the SerializedHandledError, not a plain string
     And the client applies the same handled/unknown logic as for a tRPC error
 
   # ==========================================================================
-  # Client presentation is decided in one place, keyed on kind
+  # Client presentation is decided in one place, keyed on code
   # ==========================================================================
 
   @bdd @domain-errors
   Scenario: The client renders a handled error usefully and an unknown one generically
-    Given a client receives a domain error of a known kind
-    Then a kind-keyed explainer maps it to user-facing copy and an optional action
+    Given a client receives a handled error of a known code
+    Then a code-keyed explainer maps it to user-facing copy and an optional action
     And when the error has no domain payload
     Then the client shows a single generic "something went wrong" plus a trace id
 
   @bdd @domain-errors
-  Scenario: kind is the discriminant across process and serialisation boundaries
-    Given a serialised domain error crosses a worker or process boundary
-    Then consumers branch on `error.kind`, not `instanceof`
+  Scenario: code is the discriminant across process and serialisation boundaries
+    Given a serialised handled error crosses a worker or process boundary
+    Then consumers branch on `error.code`, not `instanceof`
     And identity survives the boundary intact


### PR DESCRIPTION
## What

Renames the app-layer `DomainError` base class to **`HandledError`** and lines its shape up with the Go `herr.E` it mirrors (`pkg/herr`), so the same concept reads the same in both languages instead of being `DomainError { kind, telemetry }` on one side and `herr.E { Code, TraceID, SpanID }` on the other.

## Shape changes

| Go `herr.E` | before (TS) | after (TS) |
|---|---|---|
| `Code` | `kind` | `code` |
| `Meta` | `meta` | `meta` |
| `TraceID` / `SpanID` | `telemetry: { traceId, spanId }` | `traceId` / `spanId` (flat) |
| `Reasons` | `reasons` | `reasons` |

- `DomainError` → `HandledError` (class + `domain-error.ts` → `handled-error.ts`), done with LSP rename so all 89 references + imports move safely.
- `kind` → `code` everywhere: the class, `SerializedHandledError`, the wire bodies, the frontend readers/guards, and tests. This includes **25 `declare readonly kind` subclass narrowings** — typecheck can't flag those (a `declare` just asserts the property exists), so left unrenamed they'd read `undefined` at runtime.
- The whole vocabulary follows: `SerializedHandledError`, `readHandledError`/`explainHandledError`, `handledErrorMiddleware`, `handledErrorToTRPCCode`, `isHandledErrorLike`, `NlpgoHandledError`, …

## Wire impact

The tRPC `data.domainError` payload and the `packages/api` versioned HTTP error body now carry `code` / `traceId` / `spanId` instead of `kind` / `telemetry`. No external SDK reads these; every in-repo consumer (the automations error explainer, the trace-drawer classifier, the lite-member interceptor, the scenario-generate reader) is updated in the same change.

## Kept deliberately

- **`httpStatus`** and the Grafana **`traceUrl`** — TS-side conveniences with no `herr.E` equivalent (Go maps code→status via a registry and builds the trace link elsewhere). Dropping them would be a much bigger, worse change.
- The **`data.domainError` tRPC envelope key** — it names the payload slot, not the error's shape. Renaming it is higher blast radius and out of scope for "match the error shape".
- Legacy hand-rolled **external** endpoints (evaluations-legacy, resource-limit) keep their published wire field names; only the value access moves to `.code`.
- DDD-sense *"domain error"* types that are **not** the boundary class are left alone: `SuiteDomainError extends Error`, and the dataset `DOMAIN_ERROR_HTTP` name→status map (all its errors extend `Error`, not `HandledError`).

## Docs

Updated ADR-045, the `domain-error-contract` spec, and the `packages/api` README to the new names/shape.

## Verification

- `pnpm typecheck` clean.
- All affected unit tests pass: langwatch app (102), `packages/api` (56), translate (5) — covering the serialize→wire path, the Hono handler, and the tRPC extractor.

## Deployment Impact

**No operator impact.** Env vars: none added or changed. Helm values: none added or changed. Default `helm install` with no overrides: unchanged — this is a pure in-repo TypeScript/Go rename of an error-shape contract with no infra, config, or schema surface. BYOC dataplane: no impact — the Go `herr` shape is unchanged; only the TS side is aligned to it. No data migration, no schema change, no ordered rollout, safe to roll back.

### Runtime risk

**Low — no data migration, no schema change, no ordered rollout, safe to roll back.**

The only runtime-visible change is the *shape* of two error-path payloads: the tRPC `data.domainError` envelope and the `packages/api` HTTP error body (`kind` → `code`, `telemetry: { traceId, spanId }` → flat `traceId` / `spanId`). Both are read exclusively on the error path, and every reader validates the shape and returns `null` on mismatch (`if (typeof value.code !== "string") return null;`) rather than throwing — a malformed/unexpected payload degrades gracefully to the generic error handling instead of crashing the UI.

**Rolling-deploy window** (old + new instances coexisting; browser tabs still holding pre-deploy JS):

- Old JS ← new backend: the `kind`-based reader finds no `kind`, returns `null`, and the toast falls back to the generic message. No crash.
- New JS ← old backend: symmetric — the `code`-based reader returns `null`, same generic fallback.
- Self-healing: the mismatch only affects error-message *specificity* (field-targeted toast vs. generic), never happy-path traffic, and clears the moment rollout completes or the tab reloads.

**Blast radius if wrong:** during the rollout window some error toasts show a generic message instead of a field-targeted one. No functional, auth, or data impact.

**External consumers:** none — no external SDK reads `data.domainError` or the versioned HTTP error body; every in-repo consumer is updated in this same change. Legacy external endpoints keep their published wire field names.

**Rollback:** the reverse rename is equally graceful (readers reject unknown shapes either direction), so a revert carries the same low risk. No flag gating or deploy ordering required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized API “handled” error responses using stable `code` plus consistent `meta` and flattened tracing fields.
  * Improved client-side decoding and explanations for handled errors.
* **Bug Fixes**
  * Prevented leakage of unknown/sensitive causes by masking nested failures as `code: "unknown"`.
  * Aligned HTTP/status and error typing across prompts, API key, impersonation, validation, and scenario limits.
* **Documentation**
  * Updated ADRs and API docs to reflect the `HandledError`/`code` contract (and deprecated `kind` alias).
* **Tests**
  * Updated unit/integration coverage to assert `code`-based payloads instead of `kind`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->