### PR TITLE
fix: tighten tenant isolation across nested references

### DIFF
--- a/langwatch/src/app/api/graphs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/graphs/[[...route]]/app.ts
@@ -5,6 +5,7 @@ import { resolver, validator as zValidator } from "hono-openapi/zod";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { badRequestSchema } from "~/app/api/shared/schemas";
+import { dashboardBelongsToProject } from "~/server/analytics/dashboardBelongsToProject";
 import { createProjectApp, requires } from "~/server/api/security";
 import { prisma } from "~/server/db";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
@@ -167,6 +168,17 @@ secured.access(requires("analytics:manage")).post(
       const project = c.get("project");
       const body = c.req.valid("json");
       logger.info({ projectId: project.id }, "Creating graph");
+
+      if (
+        body.dashboardId &&
+        !(await dashboardBelongsToProject(
+          prisma,
+          body.dashboardId,
+          project.id,
+        ))
+      ) {
+        return c.json({ error: "Dashboard not found" }, 404);
+      }
 
       let gridRow = body.gridRow;
       if (gridRow === undefined && body.dashboardId) {

--- a/langwatch/src/server/analytics/dashboardBelongsToProject.ts
+++ b/langwatch/src/server/analytics/dashboardBelongsToProject.ts
@@ -1,0 +1,13 @@
+import type { PrismaClient } from "@prisma/client";
+
+export async function dashboardBelongsToProject(
+  prisma: PrismaClient,
+  dashboardId: string,
+  projectId: string,
+): Promise<boolean> {
+  const dashboard = await prisma.dashboard.findFirst({
+    where: { id: dashboardId, projectId },
+    select: { id: true },
+  });
+  return dashboard !== null;
+}

--- a/langwatch/src/server/annotations/annotation.repository.ts
+++ b/langwatch/src/server/annotations/annotation.repository.ts
@@ -82,4 +82,72 @@ export class AnnotationRepository {
       },
     });
   }
+
+  /**
+   * Resolves the organization that owns a project, or null when the project
+   * does not exist.
+   */
+  async findProjectOrganizationId({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<string | null> {
+    const project = await this.prisma.project.findUnique({
+      where: { id: projectId },
+      select: { team: { select: { organizationId: true } } },
+    });
+
+    return project?.team.organizationId ?? null;
+  }
+
+  /**
+   * Counts how many of the given users belong to the organization.
+   */
+  async countOrganizationUsers({
+    organizationId,
+    userIds,
+  }: {
+    organizationId: string;
+    userIds: string[];
+  }): Promise<number> {
+    if (userIds.length === 0) return 0;
+
+    return await this.prisma.organizationUser.count({
+      where: { organizationId, userId: { in: userIds } },
+    });
+  }
+
+  /**
+   * Counts how many of the given annotation scores belong to the project.
+   */
+  async countAnnotationScores({
+    projectId,
+    scoreTypeIds,
+  }: {
+    projectId: string;
+    scoreTypeIds: string[];
+  }): Promise<number> {
+    if (scoreTypeIds.length === 0) return 0;
+
+    return await this.prisma.annotationScore.count({
+      where: { projectId, id: { in: scoreTypeIds } },
+    });
+  }
+
+  /**
+   * Counts how many of the given annotation queues belong to the project.
+   */
+  async countAnnotationQueues({
+    projectId,
+    queueIds,
+  }: {
+    projectId: string;
+    queueIds: string[];
+  }): Promise<number> {
+    if (queueIds.length === 0) return 0;
+
+    return await this.prisma.annotationQueue.count({
+      where: { id: { in: queueIds }, projectId },
+    });
+  }
 }

--- a/langwatch/src/server/annotations/annotation.service.ts
+++ b/langwatch/src/server/annotations/annotation.service.ts
@@ -1,4 +1,5 @@
 import type { Annotation, PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
 import {
   AnnotationRepository,
   type CreateAnnotationInput,
@@ -23,5 +24,102 @@ export class AnnotationService {
 
   async delete(input: DeleteAnnotationInput): Promise<Annotation> {
     return this.repository.delete(input);
+  }
+
+  async getProjectOrganizationId({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<string> {
+    const organizationId = await this.repository.findProjectOrganizationId({
+      projectId,
+    });
+
+    if (organizationId === null) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Project not found" });
+    }
+
+    return organizationId;
+  }
+
+  /**
+   * Guards a queue's configuration against cross-tenant references: members
+   * must belong to the project's organization and scores to the project.
+   */
+  async assertQueueConfigurationReferences({
+    projectId,
+    userIds,
+    scoreTypeIds,
+  }: {
+    projectId: string;
+    userIds: string[];
+    scoreTypeIds: string[];
+  }): Promise<void> {
+    const organizationId = await this.getProjectOrganizationId({ projectId });
+    const uniqueUserIds = [...new Set(userIds)];
+    const uniqueScoreTypeIds = [...new Set(scoreTypeIds)];
+
+    const [userCount, scoreCount] = await Promise.all([
+      this.repository.countOrganizationUsers({
+        organizationId,
+        userIds: uniqueUserIds,
+      }),
+      this.repository.countAnnotationScores({
+        projectId,
+        scoreTypeIds: uniqueScoreTypeIds,
+      }),
+    ]);
+
+    if (userCount !== uniqueUserIds.length) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "One or more queue members are not in this organization",
+      });
+    }
+    if (scoreCount !== uniqueScoreTypeIds.length) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "One or more annotation scores are not in this project",
+      });
+    }
+  }
+
+  /**
+   * Guards queue-item annotators against cross-tenant references: queues must
+   * belong to the project and users to the project's organization.
+   */
+  async assertAnnotatorReferences({
+    projectId,
+    queueIds,
+    userIds,
+  }: {
+    projectId: string;
+    queueIds: string[];
+    userIds: string[];
+  }): Promise<void> {
+    const organizationId = await this.getProjectOrganizationId({ projectId });
+    const uniqueQueueIds = [...new Set(queueIds)];
+    const uniqueUserIds = [...new Set(userIds)];
+
+    const [queueCount, userCount] = await Promise.all([
+      this.repository.countAnnotationQueues({
+        projectId,
+        queueIds: uniqueQueueIds,
+      }),
+      this.repository.countOrganizationUsers({
+        organizationId,
+        userIds: uniqueUserIds,
+      }),
+    ]);
+
+    if (
+      queueCount !== uniqueQueueIds.length ||
+      userCount !== uniqueUserIds.length
+    ) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "One or more annotators are not available in this project",
+      });
+    }
   }
 }

--- a/langwatch/src/server/api/__tests__/custom-roles.test.ts
+++ b/langwatch/src/server/api/__tests__/custom-roles.test.ts
@@ -36,9 +36,6 @@ const mockProjectResult = {
   team: {
     id: "team-123",
     organizationId: "org-123",
-    organization: {
-      members: [{ role: OrganizationUserRole.MEMBER }],
-    },
   },
 };
 
@@ -83,8 +80,13 @@ const mockSession = {
 describe("Custom Role Functionality Tests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default setup for every test: project returns team info, no group memberships
+    // Default setup for every test: project returns team info, the caller is a
+    // current org member (resolveProjectPermission fails closed otherwise), and
+    // there are no group memberships.
     mockPrisma.project.findUnique.mockResolvedValue(mockProjectResult);
+    mockPrisma.organizationUser.findFirst.mockResolvedValue({
+      role: OrganizationUserRole.MEMBER,
+    });
     mockPrisma.groupMembership.findMany.mockResolvedValue([]);
   });
 

--- a/langwatch/src/server/api/__tests__/demo-public-sharing.test.ts
+++ b/langwatch/src/server/api/__tests__/demo-public-sharing.test.ts
@@ -13,6 +13,9 @@ const mockPrisma = {
   project: {
     findUnique: vi.fn(),
   },
+  organizationUser: {
+    findFirst: vi.fn(),
+  },
   publicShare: {
     findFirst: vi.fn(),
   },
@@ -246,11 +249,10 @@ describe("Demo Project and Public Sharing Tests", () => {
 
     it("should allow access when user has permission", async () => {
       mockPrisma.project.findUnique.mockResolvedValue({
-        team: {
-          id: "team-123",
-          organizationId: "org-123",
-          organization: { members: [{ role: "MEMBER" }] },
-        },
+        team: { id: "team-123", organizationId: "org-123" },
+      });
+      mockPrisma.organizationUser.findFirst.mockResolvedValue({
+        role: "MEMBER",
       });
       mockPrisma.roleBinding.findMany.mockResolvedValue([
         { role: TeamUserRole.ADMIN, customRoleId: null },

--- a/langwatch/src/server/api/__tests__/rbac-integration.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac-integration.test.ts
@@ -63,7 +63,14 @@ const mockSession = {
 describe("RBAC Integration Tests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: no group memberships, no role bindings, no team user (falls through to denied)
+    // Default: the caller IS a current member of the owning org — scoped
+    // resolution fails closed on membership, so every test that exercises a
+    // binding/group path needs one. Tests about non-members override this with
+    // null. Beyond that: no group memberships, no role bindings, no team user
+    // (falls through to denied).
+    mockPrisma.organizationUser.findFirst.mockResolvedValue({
+      role: OrganizationUserRole.MEMBER,
+    });
     mockPrisma.groupMembership.findMany.mockResolvedValue([]);
     mockPrisma.roleBinding.findMany.mockResolvedValue([]);
     mockPrisma.teamUser.findFirst.mockResolvedValue(null);
@@ -996,14 +1003,12 @@ describe("RBAC Integration Tests", () => {
       hasTeamMember?: boolean;
     }) {
       mockPrisma.project.findUnique.mockResolvedValue({
-        team: {
-          id: "team-1",
-          organizationId: "org-1",
-          organization: {
-            members: orgRole ? [{ role: orgRole }] : [],
-          },
-        },
+        team: { id: "team-1", organizationId: "org-1" },
       });
+      // No orgRole => no OrganizationUser row => not a current member.
+      mockPrisma.organizationUser.findFirst.mockResolvedValue(
+        orgRole ? { role: orgRole } : null,
+      );
       if (hasTeamMember && teamRole) {
         mockPrisma.roleBinding.findMany.mockResolvedValue([
           { role: teamRole, customRoleId: null },
@@ -1655,13 +1660,13 @@ describe("RBAC Integration Tests", () => {
       teamRole?: TeamUserRole;
       assignedRoleId?: string;
     } = {}) {
+      mockPrisma.organizationUser.findFirst.mockResolvedValue({
+        role: OrganizationUserRole.EXTERNAL,
+      });
       mockPrisma.project.findUnique.mockResolvedValue({
         team: {
           id: "team-1",
           organizationId: "org-1",
-          organization: {
-            members: [{ role: OrganizationUserRole.EXTERNAL }],
-          },
         },
       });
       mockPrisma.roleBinding.findMany.mockResolvedValue([
@@ -1893,14 +1898,11 @@ describe("RBAC Integration Tests", () => {
 
     describe("when non-EXTERNAL user (ADMIN org role) accesses resources", () => {
       it("grants full team-role-based access", async () => {
+        mockPrisma.organizationUser.findFirst.mockResolvedValue({
+          role: OrganizationUserRole.ADMIN,
+        });
         mockPrisma.project.findUnique.mockResolvedValue({
-          team: {
-            id: "team-1",
-            organizationId: "org-1",
-            organization: {
-              members: [{ role: OrganizationUserRole.ADMIN }],
-            },
-          },
+          team: { id: "team-1", organizationId: "org-1" },
         });
         mockPrisma.groupMembership.findMany.mockResolvedValue([]);
         mockPrisma.roleBinding.findMany.mockResolvedValue([

--- a/langwatch/src/server/api/__tests__/rbac.tenant-isolation.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac.tenant-isolation.unit.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import type { Session } from "next-auth";
+import type { Session } from "~/server/auth";
 
 import { hasProjectPermission, hasTeamPermission } from "../rbac";
 

--- a/langwatch/src/server/api/__tests__/rbac.tenant-isolation.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac.tenant-isolation.unit.test.ts
@@ -7,7 +7,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { Session } from "~/server/auth";
 
-import { hasProjectPermission, hasTeamPermission } from "../rbac";
+import {
+  batchScopePermissions,
+  hasProjectPermission,
+  hasTeamPermission,
+} from "../rbac";
 
 // A pre-existing cross-org binding: user_B is named at a scope in org_A but is
 // NOT an OrganizationUser of org_A (the row survives from a since-closed path).
@@ -122,6 +126,77 @@ describe("read-path tenant isolation", () => {
       );
 
       expect(permitted).toBe(true);
+    });
+  });
+
+  // The batched resolver answers the same question for many scopes at once, so
+  // it needs the same membership gate. It resolves through `loadScopeResolution`
+  // rather than the per-call helpers, which is a separate query path and a
+  // separate chance to regress.
+  describe("batchScopePermissions() with a stale cross-org binding", () => {
+    it("denies every scope for a non-member", async () => {
+      const roleBindingFindMany = vi.fn().mockResolvedValue([
+        grantingProjectBinding,
+        {
+          role: TeamUserRole.ADMIN,
+          customRoleId: null,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: TEAM_A,
+        },
+      ]);
+      const prisma = {
+        // user_B is not an OrganizationUser of org_A.
+        organizationUser: { findFirst: vi.fn().mockResolvedValue(null) },
+        groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
+        roleBinding: { findMany: roleBindingFindMany },
+        customRole: { findMany: vi.fn().mockResolvedValue([]) },
+        teamUser: { findMany: vi.fn().mockResolvedValue([]) },
+      } as unknown as Parameters<typeof batchScopePermissions>[0]["prisma"];
+
+      const { teams, projects } = await batchScopePermissions(
+        { prisma, session: sessionForUserB },
+        {
+          organizationId: ORG_A,
+          teamIds: [TEAM_A],
+          projectIds: [PROJECT_A],
+          projectTeamId: { [PROJECT_A]: TEAM_A },
+          permission: "project:view",
+        },
+      );
+
+      expect(projects.get(PROJECT_A)).toBe(false);
+      expect(teams.get(TEAM_A)).toBe(false);
+      // Membership short-circuits before any binding is loaded.
+      expect(roleBindingFindMany).not.toHaveBeenCalled();
+    });
+
+    it("still grants a genuine member", async () => {
+      const prisma = {
+        organizationUser: {
+          findFirst: vi
+            .fn()
+            .mockResolvedValue({ role: OrganizationUserRole.MEMBER }),
+        },
+        groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
+        roleBinding: {
+          findMany: vi.fn().mockResolvedValue([grantingProjectBinding]),
+        },
+        customRole: { findMany: vi.fn().mockResolvedValue([]) },
+        teamUser: { findMany: vi.fn().mockResolvedValue([]) },
+      } as unknown as Parameters<typeof batchScopePermissions>[0]["prisma"];
+
+      const { projects } = await batchScopePermissions(
+        { prisma, session: sessionForUserB },
+        {
+          organizationId: ORG_A,
+          teamIds: [],
+          projectIds: [PROJECT_A],
+          projectTeamId: { [PROJECT_A]: TEAM_A },
+          permission: "project:view",
+        },
+      );
+
+      expect(projects.get(PROJECT_A)).toBe(true);
     });
   });
 });

--- a/langwatch/src/server/api/__tests__/rbac.tenant-isolation.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac.tenant-isolation.unit.test.ts
@@ -1,0 +1,132 @@
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Session } from "next-auth";
+
+import { hasProjectPermission, hasTeamPermission } from "../rbac";
+
+// A pre-existing cross-org binding: user_B is named at a scope in org_A but is
+// NOT an OrganizationUser of org_A (the row survives from a since-closed path).
+// These tests prove the read path fails closed on current org membership rather
+// than trusting the stale binding.
+
+const ORG_A = "org_a";
+const TEAM_A = "team_a";
+const PROJECT_A = "project_a";
+const USER_B = "user_b";
+
+const sessionForUserB = {
+  user: { id: USER_B },
+} as unknown as Session;
+
+const grantingProjectBinding = {
+  role: TeamUserRole.ADMIN,
+  customRoleId: null,
+  scopeType: RoleBindingScopeType.PROJECT,
+  scopeId: PROJECT_A,
+};
+
+describe("read-path tenant isolation", () => {
+  describe("when a non-member has a stale project-scoped binding", () => {
+    it("denies project access before consulting the binding", async () => {
+      const roleBindingFindMany = vi
+        .fn()
+        .mockResolvedValue([grantingProjectBinding]);
+      const prisma = {
+        project: {
+          findUnique: vi.fn().mockResolvedValue({
+            // organization.members filtered by userId is empty → user_B is not a
+            // member → organizationRole resolves to null.
+            team: {
+              id: TEAM_A,
+              organizationId: ORG_A,
+              organization: { members: [] },
+            },
+          }),
+        },
+        groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
+        roleBinding: { findMany: roleBindingFindMany },
+        teamUser: { findFirst: vi.fn().mockResolvedValue(null) },
+      } as unknown as Parameters<typeof hasProjectPermission>[0]["prisma"];
+
+      const permitted = await hasProjectPermission(
+        { prisma, session: sessionForUserB },
+        PROJECT_A,
+        "project:view",
+      );
+
+      expect(permitted).toBe(false);
+      // Fail-closed happens on membership, before any binding lookup runs.
+      expect(roleBindingFindMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a non-member has a stale team-scoped binding", () => {
+    it("denies team access before consulting the binding", async () => {
+      const roleBindingFindMany = vi.fn().mockResolvedValue([
+        {
+          role: TeamUserRole.ADMIN,
+          customRoleId: null,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: TEAM_A,
+        },
+      ]);
+      const prisma = {
+        team: {
+          findUnique: vi
+            .fn()
+            .mockResolvedValue({ id: TEAM_A, organizationId: ORG_A }),
+        },
+        // user_B is not an OrganizationUser of org_A.
+        organizationUser: { findFirst: vi.fn().mockResolvedValue(null) },
+        groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
+        roleBinding: { findMany: roleBindingFindMany },
+        teamUser: { findFirst: vi.fn().mockResolvedValue(null) },
+      } as unknown as Parameters<typeof hasTeamPermission>[0]["prisma"];
+
+      const permitted = await hasTeamPermission(
+        { prisma, session: sessionForUserB },
+        TEAM_A,
+        "team:view",
+      );
+
+      expect(permitted).toBe(false);
+      expect(roleBindingFindMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the caller is a current member", () => {
+    it("still resolves the binding for a genuine member", async () => {
+      const prisma = {
+        project: {
+          findUnique: vi.fn().mockResolvedValue({
+            team: {
+              id: TEAM_A,
+              organizationId: ORG_A,
+              organization: {
+                members: [{ role: OrganizationUserRole.MEMBER }],
+              },
+            },
+          }),
+        },
+        groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
+        roleBinding: {
+          findMany: vi.fn().mockResolvedValue([grantingProjectBinding]),
+        },
+        teamUser: { findFirst: vi.fn().mockResolvedValue(null) },
+      } as unknown as Parameters<typeof hasProjectPermission>[0]["prisma"];
+
+      const permitted = await hasProjectPermission(
+        { prisma, session: sessionForUserB },
+        PROJECT_A,
+        "project:view",
+      );
+
+      expect(permitted).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/server/api/__tests__/rbac.tenant-isolation.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac.tenant-isolation.unit.test.ts
@@ -39,15 +39,11 @@ describe("read-path tenant isolation", () => {
       const prisma = {
         project: {
           findUnique: vi.fn().mockResolvedValue({
-            // organization.members filtered by userId is empty → user_B is not a
-            // member → organizationRole resolves to null.
-            team: {
-              id: TEAM_A,
-              organizationId: ORG_A,
-              organization: { members: [] },
-            },
+            team: { id: TEAM_A, organizationId: ORG_A },
           }),
         },
+        // No OrganizationUser row → user_B is not a member of org_A.
+        organizationUser: { findFirst: vi.fn().mockResolvedValue(null) },
         groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
         roleBinding: { findMany: roleBindingFindMany },
         teamUser: { findFirst: vi.fn().mockResolvedValue(null) },
@@ -104,14 +100,13 @@ describe("read-path tenant isolation", () => {
       const prisma = {
         project: {
           findUnique: vi.fn().mockResolvedValue({
-            team: {
-              id: TEAM_A,
-              organizationId: ORG_A,
-              organization: {
-                members: [{ role: OrganizationUserRole.MEMBER }],
-              },
-            },
+            team: { id: TEAM_A, organizationId: ORG_A },
           }),
+        },
+        organizationUser: {
+          findFirst: vi
+            .fn()
+            .mockResolvedValue({ role: OrganizationUserRole.MEMBER }),
         },
         groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
         roleBinding: {

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -749,13 +749,17 @@ async function checkPermissionFromBindings({
   });
   const groupIds = groupMemberships.map((m) => m.groupId);
 
-  // Fetch all matching RoleBindings for this user (direct + via groups) across all scopes
+  // Fetch all matching RoleBindings for this user (direct + via groups) across all scopes.
+  // The direct-binding branch is gated on current organization membership so a
+  // stale cross-org binding (one naming this user at a scope in an org they no
+  // longer/never belonged to) is never selected. Membership — not the binding
+  // row — is the tenancy boundary.
   const bindings = await prisma.roleBinding.findMany({
     where: {
       organizationId,
       scopeId: { in: scopeIds },
       OR: [
-        { userId },
+        { userId, user: { orgMemberships: { some: { organizationId } } } },
         ...(groupIds.length > 0 ? [{ groupId: { in: groupIds } }] : []),
       ],
     },
@@ -770,7 +774,13 @@ async function checkPermissionFromBindings({
     if (!teamScope) return false;
 
     const teamUser = await prisma.teamUser.findFirst({
-      where: { userId, teamId: teamScope.scopeId },
+      // Gate the legacy fallback on org membership too: a stale cross-org
+      // TeamUser row must not confer access any more than a stale RoleBinding.
+      where: {
+        userId,
+        teamId: teamScope.scopeId,
+        team: { organization: { members: { some: { userId } } } },
+      },
       select: { role: true, assignedRoleId: true },
     });
 
@@ -907,6 +917,16 @@ export async function resolveProjectPermission(
     return { permitted: false, organizationRole };
   }
 
+  // Fail closed on current organization membership. A user who is not an
+  // OrganizationUser of the owning org is denied outright, even if a stale
+  // RoleBinding (created through a since-closed cross-org path) still names them
+  // at this project/team scope. The membership check — not the binding row — is
+  // the authoritative tenancy boundary. See the same gate in resolveTeamPermission
+  // and batchScopePermissions, and the direct-binding predicate below.
+  if (organizationRole === null) {
+    return { permitted: false, organizationRole: null };
+  }
+
   const permitted = await checkPermissionFromBindings({
     prisma: ctx.prisma,
     userId: ctx.session.user.id,
@@ -963,6 +983,13 @@ export async function resolveTeamPermission(
   });
 
   const organizationRole = organizationUser?.role ?? null;
+
+  // Fail closed on current organization membership — a non-member is denied even
+  // if a stale cross-org binding names them at this team scope. See the matching
+  // gate in resolveProjectPermission.
+  if (organizationRole === null) {
+    return { permitted: false, organizationRole: null };
+  }
 
   const permitted = await checkPermissionFromBindings({
     prisma: ctx.prisma,
@@ -1199,8 +1226,16 @@ async function loadScopeResolution(
           where: {
             organizationId: args.organizationId,
             scopeId: { in: scopeIds },
+            // Non-membership already short-circuits above, but gate the direct
+            // branch on membership too so this query is safe on its own if the
+            // early return is ever refactored away.
             OR: [
-              { userId },
+              {
+                userId,
+                user: {
+                  orgMemberships: { some: { organizationId: args.organizationId } },
+                },
+              },
               ...(groupIds.length > 0 ? [{ groupId: { in: groupIds } }] : []),
             ],
           },

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -1297,7 +1297,7 @@ async function loadScopeResolution(
     : [];
 
   return {
-    organizationRole: orgMember.role,
+    organizationRole,
     bindingsByScope,
     customRoleById: new Map(customRoles.map((c) => [c.id, c])),
     needsLegacyFallback,

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -871,6 +871,31 @@ async function resolveBindingPermission(
 }
 
 /**
+ * The single source of truth for "is this user a CURRENT member of this org,
+ * and with what role". `null` means no `OrganizationUser` row — the caller must
+ * fail closed rather than fall through to bindings, because a stale cross-org
+ * RoleBinding can still name a non-member at a project/team scope.
+ *
+ * Every scoped permission path derives membership through here so a future
+ * tenancy fix lands once instead of in each resolver.
+ */
+async function getCurrentOrganizationRole({
+  prisma,
+  userId,
+  organizationId,
+}: {
+  prisma: PrismaClient;
+  userId: string;
+  organizationId: string;
+}): Promise<OrganizationUserRole | null> {
+  const member = await prisma.organizationUser?.findFirst({
+    where: { userId, organizationId },
+    select: { role: true },
+  });
+  return member?.role ?? null;
+}
+
+/**
  * Resolve a project permission check, returning the permission decision
  * along with the user's organization role.
  */
@@ -890,32 +915,21 @@ export async function resolveProjectPermission(
 
   const projectTeam = await ctx.prisma.project.findUnique?.({
     where: { id: projectId },
-    select: {
-      team: {
-        select: {
-          id: true,
-          organizationId: true,
-          organization: {
-            select: {
-              members: {
-                where: { userId: ctx.session.user.id },
-                select: { role: true },
-              },
-            },
-          },
-        },
-      },
-    },
+    select: { team: { select: { id: true, organizationId: true } } },
   });
 
   const teamId = projectTeam?.team.id;
   const organizationId = projectTeam?.team.organizationId;
-  const organizationRole =
-    projectTeam?.team.organization?.members[0]?.role ?? null;
 
   if (!teamId || !organizationId) {
-    return { permitted: false, organizationRole };
+    return { permitted: false, organizationRole: null };
   }
+
+  const organizationRole = await getCurrentOrganizationRole({
+    prisma: ctx.prisma,
+    userId: ctx.session.user.id,
+    organizationId,
+  });
 
   // Fail closed on current organization membership. A user who is not an
   // OrganizationUser of the owning org is denied outright, even if a stale
@@ -977,12 +991,11 @@ export async function resolveTeamPermission(
     return { permitted: false, organizationRole: null };
   }
 
-  const organizationUser = await ctx.prisma.organizationUser?.findFirst({
-    where: { userId: ctx.session.user.id, organizationId: team.organizationId },
-    select: { role: true },
+  const organizationRole = await getCurrentOrganizationRole({
+    prisma: ctx.prisma,
+    userId: ctx.session.user.id,
+    organizationId: team.organizationId,
   });
-
-  const organizationRole = organizationUser?.role ?? null;
 
   // Fail closed on current organization membership — a non-member is denied even
   // if a stale cross-org binding names them at this team scope. See the matching
@@ -1207,11 +1220,14 @@ async function loadScopeResolution(
   const userId = ctx.session?.user?.id;
   if (!userId) return null;
 
-  const orgMember = await ctx.prisma.organizationUser?.findFirst({
-    where: { userId, organizationId: args.organizationId },
-    select: { role: true },
+  const organizationRole = await getCurrentOrganizationRole({
+    prisma: ctx.prisma,
+    userId,
+    organizationId: args.organizationId,
   });
-  if (!orgMember) return null;
+  // Fail closed on current membership — a non-member gets nothing, even if a
+  // stale cross-org binding names them at one of these scopes.
+  if (organizationRole === null) return null;
 
   const groupMemberships = await ctx.prisma.groupMembership.findMany({
     where: { userId, group: { organizationId: args.organizationId } },

--- a/langwatch/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -28,6 +28,8 @@ const { mockCreate, mockGetTracesWithSpans, mockBuildDeps, BLOB_DEPS } =
     };
   });
 
+const mockAnnotationFindMany = vi.fn().mockResolvedValue([]);
+
 vi.mock("~/server/traces/trace.service", () => ({
   TraceService: { create: mockCreate },
 }));
@@ -83,7 +85,7 @@ function makePrismaStub(): PrismaClient {
       count: vi.fn().mockResolvedValue(1),
     },
     annotation: {
-      findMany: vi.fn().mockResolvedValue([]),
+      findMany: mockAnnotationFindMany,
     },
     annotationQueue: {
       findMany: vi.fn().mockResolvedValue([]),
@@ -139,5 +141,28 @@ describe("annotation router — #4991 AC3 annotation-queue reads", () => {
       });
       expectFullResolution();
     });
+  });
+});
+
+describe("annotation router public reads", () => {
+  it("only selects public profile fields for annotation users", async () => {
+    await caller.getByTraceId({
+      projectId: "project_123",
+      traceId: "t1",
+    });
+
+    expect(mockAnnotationFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              image: true,
+            },
+          },
+        },
+      }),
+    );
   });
 });

--- a/langwatch/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/annotation.4991-full-resolution.unit.test.ts
@@ -29,6 +29,8 @@ const { mockCreate, mockGetTracesWithSpans, mockBuildDeps, BLOB_DEPS } =
   });
 
 const mockAnnotationFindMany = vi.fn().mockResolvedValue([]);
+const mockQueueItemFindMany = vi.fn();
+const mockQueueItemCount = vi.fn().mockResolvedValue(1);
 
 vi.mock("~/server/traces/trace.service", () => ({
   TraceService: { create: mockCreate },
@@ -79,16 +81,22 @@ function makePrismaStub(): PrismaClient {
     createdByUser: null,
     annotationQueue: null,
   };
+  mockQueueItemFindMany.mockResolvedValue([queueItem]);
   return {
     annotationQueueItem: {
-      findMany: vi.fn().mockResolvedValue([queueItem]),
-      count: vi.fn().mockResolvedValue(1),
+      findMany: mockQueueItemFindMany,
+      count: mockQueueItemCount,
     },
     annotation: {
       findMany: mockAnnotationFindMany,
     },
     annotationQueue: {
       findMany: vi.fn().mockResolvedValue([]),
+    },
+    project: {
+      findUnique: vi.fn().mockResolvedValue({
+        team: { organizationId: "org_123" },
+      }),
     },
   } as unknown as PrismaClient;
 }
@@ -128,6 +136,33 @@ describe("annotation router — #4991 AC3 annotation-queue reads", () => {
     it("constructs with deps and resolves trace IO full", async () => {
       await caller.getQueueItems({ projectId: "project_123" });
       expectFullResolution();
+      expect(mockQueueItemFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            projectId: "project_123",
+            AND: expect.arrayContaining([
+              {
+                OR: [
+                  { annotationQueueId: null },
+                  { annotationQueue: { projectId: "project_123" } },
+                ],
+              },
+              {
+                OR: [
+                  { userId: null },
+                  {
+                    user: {
+                      orgMemberships: {
+                        some: { organizationId: "org_123" },
+                      },
+                    },
+                  },
+                ],
+              },
+            ]),
+          }),
+        }),
+      );
     });
   });
 
@@ -140,6 +175,29 @@ describe("annotation router — #4991 AC3 annotation-queue reads", () => {
         pageOffset: 0,
       });
       expectFullResolution();
+    });
+
+    it("scopes an explicit queue to the project", async () => {
+      await caller.getOptimizedAnnotationQueues({
+        projectId: "project_123",
+        selectedAnnotations: "pending",
+        pageSize: 10,
+        pageOffset: 0,
+        queueId: "queue_123",
+      });
+
+      expect(mockQueueItemCount).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          AND: expect.arrayContaining([
+            {
+              annotationQueue: {
+                id: "queue_123",
+                projectId: "project_123",
+              },
+            },
+          ]),
+        }),
+      });
     });
   });
 });

--- a/langwatch/src/server/api/routers/__tests__/annotation.tenant-references.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/annotation.tenant-references.unit.test.ts
@@ -80,6 +80,9 @@ describe("annotation queue references", () => {
       code: "BAD_REQUEST",
     });
 
+    expect(organizationUserCount).toHaveBeenCalledWith({
+      where: { organizationId: "org_1", userId: { in: ["user_1"] } },
+    });
     expect(annotationQueueCreate).not.toHaveBeenCalled();
   });
 
@@ -92,6 +95,9 @@ describe("annotation queue references", () => {
       code: "BAD_REQUEST",
     });
 
+    expect(annotationScoreCount).toHaveBeenCalledWith({
+      where: { projectId: "project_1", id: { in: ["score_1"] } },
+    });
     expect(annotationQueueCreate).not.toHaveBeenCalled();
   });
 
@@ -108,6 +114,9 @@ describe("annotation queue references", () => {
       }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
+    expect(annotationQueueCount).toHaveBeenCalledWith({
+      where: { id: { in: ["foreign-queue"] }, projectId: "project_1" },
+    });
     expect(queueItemUpsert).not.toHaveBeenCalled();
   });
 
@@ -124,6 +133,9 @@ describe("annotation queue references", () => {
       }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
+    expect(organizationUserCount).toHaveBeenCalledWith({
+      where: { organizationId: "org_1", userId: { in: ["foreign-user"] } },
+    });
     expect(queueItemUpsert).not.toHaveBeenCalled();
   });
 

--- a/langwatch/src/server/api/routers/__tests__/annotation.tenant-references.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/annotation.tenant-references.unit.test.ts
@@ -1,0 +1,148 @@
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInnerTRPCContext } from "../../trpc";
+import { annotationRouter, createOrUpdateQueueItems } from "../annotation";
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    checkProjectPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+const projectFindUnique = vi.fn();
+const organizationUserCount = vi.fn();
+const annotationScoreCount = vi.fn();
+const annotationQueueCount = vi.fn();
+const annotationQueueFindFirst = vi.fn();
+const annotationQueueCreate = vi.fn();
+const queueItemUpsert = vi.fn();
+
+const prisma = {
+  project: { findUnique: projectFindUnique },
+  organizationUser: { count: organizationUserCount },
+  annotationScore: { count: annotationScoreCount },
+  annotationQueue: {
+    count: annotationQueueCount,
+    findFirst: annotationQueueFindFirst,
+    create: annotationQueueCreate,
+  },
+  annotationQueueItem: { upsert: queueItemUpsert },
+} as unknown as PrismaClient;
+
+const queueInput = {
+  projectId: "project_1",
+  name: "Review queue",
+  description: "",
+  userIds: ["user_1"],
+  scoreTypeIds: ["score_1"],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  projectFindUnique.mockResolvedValue({
+    team: { organizationId: "org_1" },
+  });
+  organizationUserCount.mockResolvedValue(1);
+  annotationScoreCount.mockResolvedValue(1);
+  annotationQueueCount.mockResolvedValue(1);
+  annotationQueueFindFirst.mockResolvedValue(null);
+  annotationQueueCreate.mockResolvedValue({ id: "queue_1" });
+  queueItemUpsert.mockResolvedValue({ id: "item_1" });
+});
+
+const createCaller = () => {
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: "creator_1" }, expires: "1" },
+    permissionChecked: true,
+  });
+  ctx.prisma = prisma;
+  return annotationRouter.createCaller(ctx);
+};
+
+describe("annotation queue references", () => {
+  it("rejects queue members from another organization", async () => {
+    organizationUserCount.mockResolvedValue(0);
+
+    await expect(
+      createCaller().createOrUpdateQueue(queueInput),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+
+    expect(annotationQueueCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects annotation scores from another project", async () => {
+    annotationScoreCount.mockResolvedValue(0);
+
+    await expect(
+      createCaller().createOrUpdateQueue(queueInput),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+
+    expect(annotationQueueCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects queue assignments from another project", async () => {
+    annotationQueueCount.mockResolvedValue(0);
+
+    await expect(
+      createOrUpdateQueueItems({
+        traceIds: ["trace_1"],
+        projectId: "project_1",
+        annotators: ["queue-foreign-queue"],
+        userId: "creator_1",
+        prisma,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(queueItemUpsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects user assignments from another organization", async () => {
+    organizationUserCount.mockResolvedValue(0);
+
+    await expect(
+      createOrUpdateQueueItems({
+        traceIds: ["trace_1"],
+        projectId: "project_1",
+        annotators: ["user-foreign-user"],
+        userId: "creator_1",
+        prisma,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(queueItemUpsert).not.toHaveBeenCalled();
+  });
+
+  it("keeps hyphens in validated annotator IDs", async () => {
+    await createOrUpdateQueueItems({
+      traceIds: ["trace_1"],
+      projectId: "project_1",
+      annotators: ["queue-queue-with-hyphens", "user-user-with-hyphens"],
+      userId: "creator_1",
+      prisma,
+    });
+
+    expect(queueItemUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          annotationQueueId: "queue-with-hyphens",
+        }),
+      }),
+    );
+    expect(queueItemUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ userId: "user-with-hyphens" }),
+      }),
+    );
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/annotation.tenant-references.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/annotation.tenant-references.unit.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createInnerTRPCContext } from "../../trpc";
 import { annotationRouter, createOrUpdateQueueItems } from "../annotation";
 
+vi.mock("../../../auditLog", () => ({
+  auditLog: vi.fn(() => Promise.resolve()),
+}));
+
 vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {

--- a/langwatch/src/server/api/routers/__tests__/evaluators.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/evaluators.integration.test.ts
@@ -22,6 +22,8 @@ vi.mock("../../../license-enforcement", async (importOriginal) => {
 
 describe("Evaluators Endpoints", () => {
   const projectId = "test-project-id";
+  const scorerWorkflowId = "workflow_scorer_123";
+  const uniqueWorkflowId = "workflow_unique_test_456";
   let caller: ReturnType<typeof appRouter.createCaller>;
 
   beforeAll(async () => {
@@ -30,6 +32,19 @@ describe("Evaluators Endpoints", () => {
     await prisma.evaluator.deleteMany({
       where: { projectId },
     });
+    for (const id of [scorerWorkflowId, uniqueWorkflowId]) {
+      await prisma.workflow.upsert({
+        where: { id },
+        create: {
+          id,
+          projectId,
+          name: id,
+          icon: "",
+          description: "",
+        },
+        update: { projectId, archivedAt: null },
+      });
+    }
 
     const user = await getTestUser();
     const ctx = createInnerTRPCContext({
@@ -124,15 +139,15 @@ describe("Evaluators Endpoints", () => {
         name: "Custom Scorer",
         type: "workflow",
         config: {},
-        workflowId: "workflow_scorer_123",
+        workflowId: scorerWorkflowId,
       });
 
       expect(result.type).toBe("workflow");
-      expect(result.workflowId).toBe("workflow_scorer_123");
+      expect(result.workflowId).toBe(scorerWorkflowId);
     });
 
     it("prevents creating duplicate evaluators for the same workflow", async () => {
-      const workflowId = "workflow_unique_test_456";
+      const workflowId = uniqueWorkflowId;
 
       // Create first evaluator for this workflow
       await caller.evaluators.create({

--- a/langwatch/src/server/api/routers/__tests__/evaluators.tenant-workflow.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/evaluators.tenant-workflow.unit.test.ts
@@ -1,0 +1,100 @@
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInnerTRPCContext } from "../../trpc";
+import { evaluatorsRouter } from "../evaluators";
+
+vi.mock("../../../license-enforcement", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../license-enforcement")>();
+  return { ...actual, enforceLicenseLimit: vi.fn() };
+});
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    checkProjectPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+const workflowFindFirst = vi.fn();
+const evaluatorFindFirst = vi.fn();
+const evaluatorCreate = vi.fn();
+
+const prisma = {
+  workflow: { findFirst: workflowFindFirst },
+  evaluator: {
+    findFirst: evaluatorFindFirst,
+    create: evaluatorCreate,
+  },
+} as unknown as PrismaClient;
+
+const createCaller = () => {
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: "user_1" }, expires: "1" },
+    permissionChecked: true,
+  });
+  ctx.prisma = prisma;
+  return evaluatorsRouter.createCaller(ctx);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  workflowFindFirst.mockResolvedValue(null);
+  evaluatorFindFirst.mockResolvedValue(null);
+});
+
+describe("evaluator workflow references", () => {
+  it("rejects a workflow from another project on create", async () => {
+    await expect(
+      createCaller().create({
+        projectId: "project_1",
+        name: "Foreign workflow",
+        type: "workflow",
+        config: {},
+        workflowId: "workflow_2",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(evaluatorCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a workflow from another project on update", async () => {
+    await expect(
+      createCaller().update({
+        id: "evaluator_1",
+        projectId: "project_1",
+        workflowId: "workflow_2",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("does not follow a stale foreign workflow on read", async () => {
+    evaluatorFindFirst.mockResolvedValue({
+      id: "evaluator_1",
+      projectId: "project_1",
+      type: "workflow",
+      workflowId: "workflow_2",
+    });
+
+    const result = await createCaller().getWorkflowFields({
+      id: "evaluator_1",
+      projectId: "project_1",
+    });
+
+    expect(result.fields).toEqual([]);
+    expect(workflowFindFirst).toHaveBeenCalledWith({
+      where: {
+        id: "workflow_2",
+        projectId: "project_1",
+        archivedAt: null,
+      },
+      include: { currentVersion: true },
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/graphs.tenant-dashboard.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/graphs.tenant-dashboard.unit.test.ts
@@ -1,0 +1,62 @@
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInnerTRPCContext } from "../../trpc";
+import { graphsRouter } from "../graphs";
+
+vi.mock("../../../license-enforcement", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../license-enforcement")>();
+  return { ...actual, enforceLicenseLimit: vi.fn() };
+});
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    checkProjectPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+const dashboardFindFirst = vi.fn();
+const graphCreate = vi.fn();
+
+const createCaller = () => {
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: "user_1" }, expires: "1" },
+    permissionChecked: true,
+  });
+  ctx.prisma = {
+    dashboard: { findFirst: dashboardFindFirst },
+    customGraph: { create: graphCreate },
+  } as unknown as PrismaClient;
+  return graphsRouter.createCaller(ctx);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dashboardFindFirst.mockResolvedValue(null);
+});
+
+describe("graph dashboard references", () => {
+  it("rejects a dashboard from another project", async () => {
+    await expect(
+      createCaller().create({
+        projectId: "project_1",
+        name: "Graph",
+        graph: "{}",
+        dashboardId: "dashboard_2",
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(dashboardFindFirst).toHaveBeenCalledWith({
+      where: { id: "dashboard_2", projectId: "project_1" },
+      select: { id: true },
+    });
+    expect(graphCreate).not.toHaveBeenCalled();
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/graphs.tenant-dashboard.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/graphs.tenant-dashboard.unit.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createInnerTRPCContext } from "../../trpc";
 import { graphsRouter } from "../graphs";
 
+vi.mock("../../../auditLog", () => ({
+  auditLog: vi.fn(() => Promise.resolve()),
+}));
+
 vi.mock("../../../license-enforcement", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../../../license-enforcement")>();

--- a/langwatch/src/server/api/routers/__tests__/monitors.copy.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/monitors.copy.integration.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../../license-enforcement", async (importOriginal) => {
 describe("monitors.copy", () => {
   const sourceProjectId = "test-project-id";
   const targetProjectId = "test-project-id-monitor-copy-target";
+  const workflowNoVersionId = "workflow_no_version_qatest";
   let caller: ReturnType<typeof appRouter.createCaller>;
 
   beforeAll(async () => {
@@ -83,6 +84,9 @@ describe("monitors.copy", () => {
     });
     await prisma.evaluator.deleteMany({
       where: { projectId: sourceProjectId },
+    });
+    await prisma.workflow.deleteMany({
+      where: { id: workflowNoVersionId, projectId: sourceProjectId },
     });
   });
 
@@ -175,12 +179,23 @@ describe("monitors.copy", () => {
         // workflow has no saved version, copying would leave an evaluator with no
         // workflow, so the copy is refused. (The happy workflow-copy path is
         // covered by workflows.copyWorkflowWithDatasets.integration.test.ts.)
+        await prisma.workflow.create({
+          data: {
+            id: workflowNoVersionId,
+            projectId: sourceProjectId,
+            name: "Workflow With No Version",
+            icon: "",
+            description: "",
+            isEvaluator: true,
+          },
+        });
+
         const evaluator = await caller.evaluators.create({
           projectId: sourceProjectId,
           name: "Workflow Evaluator No Version",
           type: "workflow",
           config: {},
-          workflowId: "workflow_no_version_qatest",
+          workflowId: workflowNoVersionId,
         });
 
         const source = await caller.monitors.create({

--- a/langwatch/src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts
@@ -35,12 +35,14 @@ describe("team.update", () => {
   let deleteMany: ReturnType<typeof vi.fn>;
   let update: ReturnType<typeof vi.fn>;
   let create: ReturnType<typeof vi.fn>;
+  let organizationUserCount: ReturnType<typeof vi.fn>;
   let caller: ReturnType<typeof teamRouter.createCaller>;
 
   beforeEach(() => {
     deleteMany = vi.fn().mockResolvedValue({ count: 0 });
     update = vi.fn().mockResolvedValue({});
     create = vi.fn().mockResolvedValue({});
+    organizationUserCount = vi.fn().mockResolvedValue(1);
 
     const tx = {
       team: { update: vi.fn().mockResolvedValue({}) },
@@ -59,6 +61,7 @@ describe("team.update", () => {
 
     const prisma = {
       team: { findUnique: vi.fn().mockResolvedValue({ organizationId: ORG_ID }) },
+      organizationUser: { count: organizationUserCount },
       $transaction: (fn: (tx: unknown) => unknown) => fn(tx),
     } as unknown as PrismaClient;
 
@@ -104,6 +107,23 @@ describe("team.update", () => {
       expect(deleteMany).toHaveBeenCalledWith({
         where: { id: { in: [MEMBER_BINDING_ID, CUSTOM_BINDING_ID] } },
       });
+    });
+  });
+
+  describe("when a submitted user belongs to another organization", () => {
+    it("rejects the update before writing bindings", async () => {
+      organizationUserCount.mockResolvedValue(0);
+
+      await expect(
+        caller.update({
+          teamId: TEAM_ID,
+          name: "Team",
+          members: [{ userId: "foreign_user", role: TeamUserRole.ADMIN }],
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+      expect(create).not.toHaveBeenCalled();
+      expect(update).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/server/api/routers/__tests__/user.deactivation.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/user.deactivation.unit.test.ts
@@ -10,6 +10,12 @@ vi.mock("../../../auditLog", () => ({
   auditLog: vi.fn(() => Promise.resolve()),
 }));
 
+vi.mock("../../../../../ee/admin/isAdmin", () => ({
+  isAdmin: vi.fn(
+    ({ email }: { email: string }) => email === "admin@example.com",
+  ),
+}));
+
 // Mock the redis connection so the revoke helper called by
 // UserService.deactivate doesn't try to talk to a real Redis from a unit test.
 vi.mock("~/server/redis", () => ({ connection: undefined }));
@@ -33,10 +39,10 @@ describe("userRouter", () => {
     prismaUpdateMock = vi.fn().mockResolvedValue({ id: "user-1" });
   });
 
-  const createCaller = () => {
+  const createCaller = (email = "admin@example.com") => {
     const ctx = createInnerTRPCContext({
       session: {
-        user: { id: "caller-1", name: "Caller", email: "any@example.com" },
+        user: { id: "caller-1", name: "Caller", email },
         expires: "2099-01-01",
       },
     });
@@ -62,7 +68,29 @@ describe("userRouter", () => {
         const callArgs = prismaUpdateMock.mock.calls[0]![0];
         expect(callArgs.where).toEqual({ id: "user-1" });
         expect(callArgs.data.deactivatedAt).toBeInstanceOf(Date);
-        expect(callArgs.data.deactivatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+        expect(callArgs.data.deactivatedAt.getTime()).toBeGreaterThanOrEqual(
+          before.getTime(),
+        );
+      });
+    });
+
+    describe("when called by a non-admin", () => {
+      it("allows users to deactivate themselves", async () => {
+        await createCaller("member@example.com").deactivate({
+          userId: "caller-1",
+        });
+
+        expect(prismaUpdateMock).toHaveBeenCalledWith(
+          expect.objectContaining({ where: { id: "caller-1" } }),
+        );
+      });
+
+      it("rejects the request", async () => {
+        await expect(
+          createCaller("member@example.com").deactivate({ userId: "user-1" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(prismaUpdateMock).not.toHaveBeenCalled();
       });
     });
   });
@@ -76,6 +104,16 @@ describe("userRouter", () => {
         const callArgs = prismaUpdateMock.mock.calls[0]![0];
         expect(callArgs.where).toEqual({ id: "user-1" });
         expect(callArgs.data.deactivatedAt).toBeNull();
+      });
+    });
+
+    describe("when called by a non-admin", () => {
+      it("rejects the request", async () => {
+        await expect(
+          createCaller("member@example.com").reactivate({ userId: "user-1" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(prismaUpdateMock).not.toHaveBeenCalled();
       });
     });
   });

--- a/langwatch/src/server/api/routers/__tests__/workflows.tenant-metadata.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.tenant-metadata.unit.test.ts
@@ -1,0 +1,82 @@
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createInnerTRPCContext } from "../../trpc";
+import { workflowRouter } from "../workflows";
+
+const { hasProjectPermission } = vi.hoisted(() => ({
+  hasProjectPermission: vi.fn(),
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    hasProjectPermission,
+    checkProjectPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+const findMany = vi.fn();
+
+const createCaller = () => {
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: "user_1" }, expires: "1" },
+    permissionChecked: true,
+  });
+  ctx.prisma = {
+    workflow: { findMany },
+  } as unknown as PrismaClient;
+  return workflowRouter.createCaller(ctx);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hasProjectPermission.mockImplementation(
+    async (_ctx, projectId) => projectId === "project_visible",
+  );
+  findMany.mockResolvedValue([
+    {
+      id: "workflow_copy",
+      projectId: "project_1",
+      copiedFromWorkflowId: "workflow_source",
+      copiedFrom: {
+        id: "workflow_source",
+        name: "Private source",
+        projectId: "project_private",
+        project: {
+          id: "project_private",
+          name: "Private project",
+          team: {
+            id: "team_private",
+            name: "Private team",
+            organization: { id: "org_private", name: "Private org" },
+          },
+        },
+      },
+      copiedWorkflows: [
+        { projectId: "project_private" },
+        { projectId: "project_visible" },
+      ],
+    },
+  ]);
+});
+
+describe("workflow list tenant metadata", () => {
+  it("hides source metadata without source-project access", async () => {
+    const [workflow] = await createCaller().getAll({ projectId: "project_1" });
+
+    expect(workflow?.copiedFromWorkflowId).toBeNull();
+    expect(workflow?.copiedFrom).toBeNull();
+  });
+
+  it("only counts copies in projects the caller can view", async () => {
+    const [workflow] = await createCaller().getAll({ projectId: "project_1" });
+
+    expect(workflow?._count.copiedWorkflows).toBe(1);
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/workflows.tenant-metadata.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.tenant-metadata.unit.test.ts
@@ -37,7 +37,10 @@ const createCaller = () => {
 beforeEach(() => {
   vi.clearAllMocks();
   hasProjectPermission.mockImplementation(
-    async (_ctx, projectId) => projectId === "project_visible",
+    async (_ctx, projectId, permission) => {
+      expect(permission).toBe("workflows:view");
+      return projectId === "project_visible";
+    },
   );
   findMany.mockResolvedValue([
     {

--- a/langwatch/src/server/api/routers/annotation.ts
+++ b/langwatch/src/server/api/routers/annotation.ts
@@ -205,7 +205,13 @@ export const annotationRouter = createTRPCRouter({
           projectId: input.projectId,
         },
         include: {
-          user: true,
+          user: {
+            select: {
+              id: true,
+              name: true,
+              image: true,
+            },
+          },
         },
         orderBy: {
           createdAt: "asc",

--- a/langwatch/src/server/api/routers/annotation.ts
+++ b/langwatch/src/server/api/routers/annotation.ts
@@ -109,67 +109,26 @@ const getEnrichedItems = <T extends { id: string }>(
     .filter((item): item is NonNullable<typeof item> => item !== undefined);
 };
 
-const getProjectOrganizationId = async (
-  prisma: PrismaClient,
-  projectId: string,
-): Promise<string> => {
-  const project = await prisma.project.findUnique({
-    where: { id: projectId },
-    select: { team: { select: { organizationId: true } } },
-  });
-
-  if (!project) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Project not found" });
+const annotatorReferenceSchema = z.string().transform((annotator, ctx) => {
+  if (annotator.startsWith("queue-") && annotator.length > 6) {
+    return { type: "queue" as const, id: annotator.slice(6) };
   }
+  if (annotator.startsWith("user-") && annotator.length > 5) {
+    return { type: "user" as const, id: annotator.slice(5) };
+  }
+  ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Invalid annotator" });
+  return z.NEVER;
+});
 
-  return project.team.organizationId;
-};
+type AnnotatorReference = z.infer<typeof annotatorReferenceSchema>;
 
-const assertQueueConfigurationReferences = async ({
-  prisma,
+const queueItemReferenceFilter = ({
   projectId,
-  userIds,
-  scoreTypeIds,
+  organizationId,
 }: {
-  prisma: PrismaClient;
   projectId: string;
-  userIds: string[];
-  scoreTypeIds: string[];
-}) => {
-  const organizationId = await getProjectOrganizationId(prisma, projectId);
-  const uniqueUserIds = [...new Set(userIds)];
-  const uniqueScoreTypeIds = [...new Set(scoreTypeIds)];
-  const [userCount, scoreCount] = await Promise.all([
-    uniqueUserIds.length
-      ? prisma.organizationUser.count({
-          where: { organizationId, userId: { in: uniqueUserIds } },
-        })
-      : 0,
-    uniqueScoreTypeIds.length
-      ? prisma.annotationScore.count({
-          where: { projectId, id: { in: uniqueScoreTypeIds } },
-        })
-      : 0,
-  ]);
-
-  if (userCount !== uniqueUserIds.length) {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: "One or more queue members are not in this organization",
-    });
-  }
-  if (scoreCount !== uniqueScoreTypeIds.length) {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: "One or more annotation scores are not in this project",
-    });
-  }
-};
-
-const queueItemReferenceFilter = (
-  projectId: string,
-  organizationId: string,
-) => ({
+  organizationId: string;
+}) => ({
   projectId,
   AND: [
     {
@@ -405,8 +364,8 @@ export const annotationRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("annotations:create"))
     .mutation(async ({ ctx, input }) => {
-      await assertQueueConfigurationReferences({
-        prisma: ctx.prisma,
+      const service = AnnotationService.create({ prisma: ctx.prisma });
+      await service.assertQueueConfigurationReferences({
         projectId: input.projectId,
         userIds: input.userIds,
         scoreTypeIds: input.scoreTypeIds,
@@ -503,12 +462,15 @@ export const annotationRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string() }))
     .use(checkProjectPermission("annotations:view"))
     .query(async ({ ctx, input }) => {
-      const organizationId = await getProjectOrganizationId(
-        ctx.prisma,
-        input.projectId,
-      );
+      const service = AnnotationService.create({ prisma: ctx.prisma });
+      const organizationId = await service.getProjectOrganizationId({
+        projectId: input.projectId,
+      });
       const queueItems = await ctx.prisma.annotationQueueItem.findMany({
-        where: queueItemReferenceFilter(input.projectId, organizationId),
+        where: queueItemReferenceFilter({
+          projectId: input.projectId,
+          organizationId,
+        }),
         include: {
           user: true,
           createdByUser: true,
@@ -690,10 +652,10 @@ export const annotationRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("annotations:view"))
     .query(async ({ ctx, input }) => {
-      const organizationId = await getProjectOrganizationId(
-        ctx.prisma,
-        input.projectId,
-      );
+      const service = AnnotationService.create({ prisma: ctx.prisma });
+      const organizationId = await service.getProjectOrganizationId({
+        projectId: input.projectId,
+      });
       return ctx.prisma.annotationQueue.findUnique({
         where: input.queueId
           ? { id: input.queueId, projectId: input.projectId }
@@ -735,10 +697,10 @@ export const annotationRouter = createTRPCRouter({
     .use(checkProjectPermission("annotations:view"))
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-      const organizationId = await getProjectOrganizationId(
-        ctx.prisma,
-        input.projectId,
-      );
+      const service = AnnotationService.create({ prisma: ctx.prisma });
+      const organizationId = await service.getProjectOrganizationId({
+        projectId: input.projectId,
+      });
       let userQueueIds: string[] = [];
 
       // If a queue is selected, we don't need to check for user queues
@@ -763,7 +725,10 @@ export const annotationRouter = createTRPCRouter({
 
       // Build the where condition based on the scenario
       const whereCondition: any = {
-        ...queueItemReferenceFilter(input.projectId, organizationId),
+        ...queueItemReferenceFilter({
+          projectId: input.projectId,
+          organizationId,
+        }),
         doneAt:
           input.selectedAnnotations === "pending"
             ? null
@@ -773,7 +738,8 @@ export const annotationRouter = createTRPCRouter({
       };
 
       if (input.queueId) {
-        // Specific queue selected - keep the queue on the current project
+        // Pin the requested queue to the caller's project so a queue id from
+        // another tenant cannot surface its items here.
         whereCondition.AND.push({
           annotationQueue: {
             id: input.queueId,
@@ -781,7 +747,8 @@ export const annotationRouter = createTRPCRouter({
           },
         });
       } else if (userQueueIds.length > 0) {
-        // All annotations - check if annotationQueueId is in user's queue IDs
+        // No specific queue requested: include items from the queues the caller
+        // belongs to, plus items assigned directly to them.
         whereCondition.AND.push({
           OR: [
             {
@@ -937,52 +904,25 @@ export async function createOrUpdateQueueItems({
   userId: string;
   prisma: PrismaClient;
 }) {
-  const parsedAnnotators = annotators.map((annotator) => {
-    if (annotator.startsWith("queue-") && annotator.length > 6) {
-      return { type: "queue", id: annotator.slice(6) } as const;
+  const parsedAnnotators: AnnotatorReference[] = annotators.map((annotator) => {
+    const parsed = annotatorReferenceSchema.safeParse(annotator);
+    if (!parsed.success) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Invalid annotator",
+      });
     }
-    if (annotator.startsWith("user-") && annotator.length > 5) {
-      return { type: "user", id: annotator.slice(5) } as const;
-    }
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: "Invalid annotator",
-    });
+    return parsed.data;
   });
-  const organizationId = await getProjectOrganizationId(prisma, projectId);
-  const queueIds = [
-    ...new Set(
-      parsedAnnotators
-        .filter((annotator) => annotator.type === "queue")
-        .map((annotator) => annotator.id),
-    ),
-  ];
-  const userIds = [
-    ...new Set(
-      parsedAnnotators
-        .filter((annotator) => annotator.type === "user")
-        .map((annotator) => annotator.id),
-    ),
-  ];
-  const [queueCount, userCount] = await Promise.all([
-    queueIds.length
-      ? prisma.annotationQueue.count({
-          where: { id: { in: queueIds }, projectId },
-        })
-      : 0,
-    userIds.length
-      ? prisma.organizationUser.count({
-          where: { organizationId, userId: { in: userIds } },
-        })
-      : 0,
-  ]);
+  const queueIds = parsedAnnotators
+    .filter((annotator) => annotator.type === "queue")
+    .map((annotator) => annotator.id);
+  const userIds = parsedAnnotators
+    .filter((annotator) => annotator.type === "user")
+    .map((annotator) => annotator.id);
 
-  if (queueCount !== queueIds.length || userCount !== userIds.length) {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: "One or more annotators are not available in this project",
-    });
-  }
+  const service = AnnotationService.create({ prisma });
+  await service.assertAnnotatorReferences({ projectId, queueIds, userIds });
 
   for (const traceId of traceIds) {
     for (const annotator of parsedAnnotators) {

--- a/langwatch/src/server/api/routers/annotation.ts
+++ b/langwatch/src/server/api/routers/annotation.ts
@@ -109,6 +109,85 @@ const getEnrichedItems = <T extends { id: string }>(
     .filter((item): item is NonNullable<typeof item> => item !== undefined);
 };
 
+const getProjectOrganizationId = async (
+  prisma: PrismaClient,
+  projectId: string,
+): Promise<string> => {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { team: { select: { organizationId: true } } },
+  });
+
+  if (!project) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Project not found" });
+  }
+
+  return project.team.organizationId;
+};
+
+const assertQueueConfigurationReferences = async ({
+  prisma,
+  projectId,
+  userIds,
+  scoreTypeIds,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+  userIds: string[];
+  scoreTypeIds: string[];
+}) => {
+  const organizationId = await getProjectOrganizationId(prisma, projectId);
+  const uniqueUserIds = [...new Set(userIds)];
+  const uniqueScoreTypeIds = [...new Set(scoreTypeIds)];
+  const [userCount, scoreCount] = await Promise.all([
+    uniqueUserIds.length
+      ? prisma.organizationUser.count({
+          where: { organizationId, userId: { in: uniqueUserIds } },
+        })
+      : 0,
+    uniqueScoreTypeIds.length
+      ? prisma.annotationScore.count({
+          where: { projectId, id: { in: uniqueScoreTypeIds } },
+        })
+      : 0,
+  ]);
+
+  if (userCount !== uniqueUserIds.length) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "One or more queue members are not in this organization",
+    });
+  }
+  if (scoreCount !== uniqueScoreTypeIds.length) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "One or more annotation scores are not in this project",
+    });
+  }
+};
+
+const queueItemReferenceFilter = (
+  projectId: string,
+  organizationId: string,
+) => ({
+  projectId,
+  AND: [
+    {
+      OR: [{ annotationQueueId: null }, { annotationQueue: { projectId } }],
+    },
+    {
+      OR: [
+        { userId: null },
+        {
+          user: {
+            orgMemberships: { some: { organizationId } },
+          },
+        },
+      ],
+    },
+  ],
+});
+
 export const annotationRouter = createTRPCRouter({
   create: protectedProcedure
     .input(
@@ -326,6 +405,13 @@ export const annotationRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("annotations:create"))
     .mutation(async ({ ctx, input }) => {
+      await assertQueueConfigurationReferences({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        userIds: input.userIds,
+        scoreTypeIds: input.scoreTypeIds,
+      });
+
       const slug = slugify(input.name.replace("_", "-"), {
         lower: true,
         strict: true,
@@ -417,14 +503,24 @@ export const annotationRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string() }))
     .use(checkProjectPermission("annotations:view"))
     .query(async ({ ctx, input }) => {
+      const organizationId = await getProjectOrganizationId(
+        ctx.prisma,
+        input.projectId,
+      );
       const queueItems = await ctx.prisma.annotationQueueItem.findMany({
-        where: { projectId: input.projectId },
+        where: queueItemReferenceFilter(input.projectId, organizationId),
         include: {
           user: true,
           createdByUser: true,
           annotationQueue: {
             include: {
-              members: true,
+              members: {
+                where: {
+                  user: {
+                    orgMemberships: { some: { organizationId } },
+                  },
+                },
+              },
             },
           },
         },
@@ -470,6 +566,7 @@ export const annotationRouter = createTRPCRouter({
             },
             {
               annotationQueue: {
+                projectId: input.projectId,
                 members: {
                   some: {
                     userId: ctx.session.user.id,
@@ -593,6 +690,10 @@ export const annotationRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("annotations:view"))
     .query(async ({ ctx, input }) => {
+      const organizationId = await getProjectOrganizationId(
+        ctx.prisma,
+        input.projectId,
+      );
       return ctx.prisma.annotationQueue.findUnique({
         where: input.queueId
           ? { id: input.queueId, projectId: input.projectId }
@@ -601,11 +702,17 @@ export const annotationRouter = createTRPCRouter({
             },
         include: {
           members: {
+            where: {
+              user: {
+                orgMemberships: { some: { organizationId } },
+              },
+            },
             include: {
               user: true,
             },
           },
           AnnotationQueueScores: {
+            where: { annotationScore: { projectId: input.projectId } },
             include: {
               annotationScore: true,
             },
@@ -628,6 +735,10 @@ export const annotationRouter = createTRPCRouter({
     .use(checkProjectPermission("annotations:view"))
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
+      const organizationId = await getProjectOrganizationId(
+        ctx.prisma,
+        input.projectId,
+      );
       let userQueueIds: string[] = [];
 
       // If a queue is selected, we don't need to check for user queues
@@ -652,7 +763,7 @@ export const annotationRouter = createTRPCRouter({
 
       // Build the where condition based on the scenario
       const whereCondition: any = {
-        projectId: input.projectId,
+        ...queueItemReferenceFilter(input.projectId, organizationId),
         doneAt:
           input.selectedAnnotations === "pending"
             ? null
@@ -662,20 +773,27 @@ export const annotationRouter = createTRPCRouter({
       };
 
       if (input.queueId) {
-        // Specific queue selected - only filter by annotationQueueId
-        whereCondition.annotationQueueId = input.queueId;
+        // Specific queue selected - keep the queue on the current project
+        whereCondition.AND.push({
+          annotationQueue: {
+            id: input.queueId,
+            projectId: input.projectId,
+          },
+        });
       } else if (userQueueIds.length > 0) {
         // All annotations - check if annotationQueueId is in user's queue IDs
-        whereCondition.OR = [
-          {
-            annotationQueueId: {
-              in: userQueueIds,
+        whereCondition.AND.push({
+          OR: [
+            {
+              annotationQueueId: {
+                in: userQueueIds,
+              },
             },
-          },
-          {
-            userId: userId,
-          },
-        ];
+            {
+              userId: userId,
+            },
+          ],
+        });
       } else {
         // Default case - just user's items
         whereCondition.userId = userId;
@@ -698,11 +816,17 @@ export const annotationRouter = createTRPCRouter({
           annotationQueue: {
             include: {
               members: {
+                where: {
+                  user: {
+                    orgMemberships: { some: { organizationId } },
+                  },
+                },
                 include: {
                   user: true,
                 },
               },
               AnnotationQueueScores: {
+                where: { annotationScore: { projectId: input.projectId } },
                 include: {
                   annotationScore: true,
                 },
@@ -732,16 +856,33 @@ export const annotationRouter = createTRPCRouter({
         },
         include: {
           members: {
+            where: {
+              user: {
+                orgMemberships: { some: { organizationId } },
+              },
+            },
             include: {
               user: true,
             },
           },
           AnnotationQueueScores: {
+            where: { annotationScore: { projectId: input.projectId } },
             include: {
               annotationScore: true,
             },
           },
           AnnotationQueueItems: {
+            where: {
+              projectId: input.projectId,
+              OR: [
+                { userId: null },
+                {
+                  user: {
+                    orgMemberships: { some: { organizationId } },
+                  },
+                },
+              ],
+            },
             include: {
               user: true,
               annotationQueue: true,
@@ -794,28 +935,75 @@ export async function createOrUpdateQueueItems({
   projectId: string;
   annotators: string[];
   userId: string;
-  prisma: any;
+  prisma: PrismaClient;
 }) {
+  const parsedAnnotators = annotators.map((annotator) => {
+    if (annotator.startsWith("queue-") && annotator.length > 6) {
+      return { type: "queue", id: annotator.slice(6) } as const;
+    }
+    if (annotator.startsWith("user-") && annotator.length > 5) {
+      return { type: "user", id: annotator.slice(5) } as const;
+    }
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid annotator",
+    });
+  });
+  const organizationId = await getProjectOrganizationId(prisma, projectId);
+  const queueIds = [
+    ...new Set(
+      parsedAnnotators
+        .filter((annotator) => annotator.type === "queue")
+        .map((annotator) => annotator.id),
+    ),
+  ];
+  const userIds = [
+    ...new Set(
+      parsedAnnotators
+        .filter((annotator) => annotator.type === "user")
+        .map((annotator) => annotator.id),
+    ),
+  ];
+  const [queueCount, userCount] = await Promise.all([
+    queueIds.length
+      ? prisma.annotationQueue.count({
+          where: { id: { in: queueIds }, projectId },
+        })
+      : 0,
+    userIds.length
+      ? prisma.organizationUser.count({
+          where: { organizationId, userId: { in: userIds } },
+        })
+      : 0,
+  ]);
+
+  if (queueCount !== queueIds.length || userCount !== userIds.length) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "One or more annotators are not available in this project",
+    });
+  }
+
   for (const traceId of traceIds) {
-    for (const annotator of annotators) {
-      if (annotator.startsWith("queue")) {
+    for (const annotator of parsedAnnotators) {
+      if (annotator.type === "queue") {
         await prisma.annotationQueueItem.upsert({
           where: {
             projectId: projectId,
             traceId_annotationQueueId_projectId: {
               traceId: traceId,
-              annotationQueueId: annotator.replace("queue-", ""),
+              annotationQueueId: annotator.id,
               projectId: projectId,
             },
           },
           create: {
-            annotationQueueId: annotator.replace("queue-", ""),
+            annotationQueueId: annotator.id,
             traceId: traceId,
             projectId: projectId,
             createdByUserId: userId,
           },
           update: {
-            annotationQueueId: annotator.replace("queue-", ""),
+            annotationQueueId: annotator.id,
             doneAt: null,
           },
         });
@@ -825,18 +1013,18 @@ export async function createOrUpdateQueueItems({
             projectId: projectId,
             traceId_userId_projectId: {
               traceId: traceId,
-              userId: annotator.replace("user-", ""),
+              userId: annotator.id,
               projectId: projectId,
             },
           },
           create: {
-            userId: annotator.replace("user-", ""),
+            userId: annotator.id,
             traceId: traceId,
             projectId: projectId,
             createdByUserId: userId,
           },
           update: {
-            userId: annotator.replace("user-", ""),
+            userId: annotator.id,
             doneAt: null,
           },
         });

--- a/langwatch/src/server/api/routers/evaluators.ts
+++ b/langwatch/src/server/api/routers/evaluators.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -15,6 +15,23 @@ import { copyEvaluatorToProject } from "./copyEvaluatorToProject";
  * Evaluator type enum for validation
  */
 const evaluatorTypeSchema = z.enum(["evaluator", "code", "workflow"]);
+
+const assertWorkflowInProject = async (
+  prisma: PrismaClient,
+  projectId: string,
+  workflowId: string,
+) => {
+  const workflow = await prisma.workflow.findFirst({
+    where: { id: workflowId, projectId, archivedAt: null },
+    select: { id: true },
+  });
+  if (!workflow) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Workflow is not available in this project",
+    });
+  }
+};
 
 /**
  * Evaluator Router - Manages evaluator CRUD operations
@@ -99,6 +116,11 @@ export const evaluatorsRouter = createTRPCRouter({
 
       // If workflowId is provided, check if an evaluator already exists for this workflow
       if (input.workflowId) {
+        await assertWorkflowInProject(
+          ctx.prisma,
+          input.projectId,
+          input.workflowId,
+        );
         const existingEvaluator = await ctx.prisma.evaluator.findFirst({
           where: {
             workflowId: input.workflowId,
@@ -150,6 +172,13 @@ export const evaluatorsRouter = createTRPCRouter({
             message: "Code evaluators need code, inputs, and outputs",
           });
         }
+      }
+      if (input.workflowId) {
+        await assertWorkflowInProject(
+          ctx.prisma,
+          input.projectId,
+          input.workflowId,
+        );
       }
       const evaluatorService = EvaluatorService.create(ctx.prisma);
       return await evaluatorService.update({
@@ -290,19 +319,12 @@ export const evaluatorsRouter = createTRPCRouter({
     .input(z.object({ id: z.string(), projectId: z.string() }))
     .use(checkProjectPermission("evaluations:view"))
     .query(async ({ ctx, input }) => {
-      // Fetch the evaluator with its workflow
+      // Fetch the evaluator first, then scope its workflow to the same project.
       const evaluator = await ctx.prisma.evaluator.findFirst({
         where: {
           id: input.id,
           projectId: input.projectId,
           archivedAt: null,
-        },
-        include: {
-          workflow: {
-            include: {
-              currentVersion: true,
-            },
-          },
         },
       });
 
@@ -313,8 +335,19 @@ export const evaluatorsRouter = createTRPCRouter({
         });
       }
 
+      const workflow = evaluator.workflowId
+        ? await ctx.prisma.workflow.findFirst({
+            where: {
+              id: evaluator.workflowId,
+              projectId: input.projectId,
+              archivedAt: null,
+            },
+            include: { currentVersion: true },
+          })
+        : null;
+
       // If not a workflow evaluator, return empty fields
-      if (evaluator.type !== "workflow" || !evaluator.workflow) {
+      if (evaluator.type !== "workflow" || !workflow) {
         return {
           evaluatorId: evaluator.id,
           evaluatorType: evaluator.type,
@@ -323,7 +356,7 @@ export const evaluatorsRouter = createTRPCRouter({
       }
 
       // Get the workflow DSL from the current version
-      const dsl = evaluator.workflow.currentVersion?.dsl as unknown as
+      const dsl = workflow.currentVersion?.dsl as unknown as
         | Workflow
         | undefined;
 
@@ -334,10 +367,9 @@ export const evaluatorsRouter = createTRPCRouter({
         evaluatorId: evaluator.id,
         evaluatorType: evaluator.type,
         workflowId: evaluator.workflowId,
-        workflowName: evaluator.workflow.name,
-        workflowIcon: (
-          evaluator.workflow.currentVersion?.dsl as { icon?: string } | null
-        )?.icon,
+        workflowName: workflow.name,
+        workflowIcon: (workflow.currentVersion?.dsl as { icon?: string } | null)
+          ?.icon,
         fields,
       };
     }),

--- a/langwatch/src/server/api/routers/graphs.ts
+++ b/langwatch/src/server/api/routers/graphs.ts
@@ -1,8 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import { redactSlackActionParams } from "~/automations/providers/definitions/slack/secret";
-import { type SlackActionParams } from "~/automations/providers/definitions/slack/shared";
 import { dashboardBelongsToProject } from "~/server/analytics/dashboardBelongsToProject";
 import { redactActionParamsFor } from "~/server/app-layer/automations/providers/registry";
 import { type FilterField, filterFieldsEnum } from "../../filters/types";

--- a/langwatch/src/server/api/routers/graphs.ts
+++ b/langwatch/src/server/api/routers/graphs.ts
@@ -1,6 +1,9 @@
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import { redactSlackActionParams } from "~/automations/providers/definitions/slack/secret";
+import { type SlackActionParams } from "~/automations/providers/definitions/slack/shared";
+import { dashboardBelongsToProject } from "~/server/analytics/dashboardBelongsToProject";
 import { redactActionParamsFor } from "~/server/app-layer/automations/providers/registry";
 import { type FilterField, filterFieldsEnum } from "../../filters/types";
 import { enforceLicenseLimit } from "../../license-enforcement";
@@ -38,6 +41,20 @@ export const graphsRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       await enforceLicenseLimit(ctx, input.projectId, "customGraphs");
       const graph = JSON.parse(input.graph);
+
+      if (
+        input.dashboardId &&
+        !(await dashboardBelongsToProject(
+          ctx.prisma,
+          input.dashboardId,
+          input.projectId,
+        ))
+      ) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Dashboard not found",
+        });
+      }
 
       // If no gridRow provided, find the next available row
       let gridRow = input.gridRow;

--- a/langwatch/src/server/api/routers/group.ts
+++ b/langwatch/src/server/api/routers/group.ts
@@ -13,6 +13,7 @@ import { RoleService } from "~/server/role/role.service";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { slugify } from "~/utils/slugify";
 import { KSUID_RESOURCES } from "~/utils/constants";
+import { assertUsersInOrganization } from "~/server/organizations/assertUsersInOrganization";
 
 async function findUniqueGroupSlug(
   prisma: Pick<PrismaClient, "group">,
@@ -99,7 +100,19 @@ export const groupRouter = createTRPCRouter({
           roleBindings: {
             include: { customRole: { select: { id: true, name: true } } },
           },
-          _count: { select: { members: true } },
+          _count: {
+            select: {
+              members: {
+                where: {
+                  user: {
+                    orgMemberships: {
+                      some: { organizationId: input.organizationId },
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
         orderBy: { name: "asc" },
       });
@@ -147,6 +160,13 @@ export const groupRouter = createTRPCRouter({
             include: { customRole: { select: { id: true, name: true } } },
           },
           members: {
+            where: {
+              user: {
+                orgMemberships: {
+                  some: { organizationId: input.organizationId },
+                },
+              },
+            },
             include: { user: { select: { id: true, name: true, email: true } } },
           },
         },
@@ -211,6 +231,12 @@ export const groupRouter = createTRPCRouter({
       });
 
       const baseSlug = slugify(input.name, { lower: true, strict: true });
+
+      await assertUsersInOrganization(
+        ctx.prisma,
+        input.organizationId,
+        input.memberIds ?? [],
+      );
 
       // Validate all binding scopes belong to this org before starting the transaction
       if (input.bindings?.length) {

--- a/langwatch/src/server/api/routers/share.ts
+++ b/langwatch/src/server/api/routers/share.ts
@@ -39,6 +39,7 @@ export const shareRouter = createTRPCRouter({
     )
     .query(async ({ input }) => {
       return getApp().share.getStateForResource({
+        projectId: input.projectId,
         resourceType: input.resourceType,
         resourceId: input.resourceId,
       });

--- a/langwatch/src/server/api/routers/team.ts
+++ b/langwatch/src/server/api/routers/team.ts
@@ -23,6 +23,7 @@ import {
   hasOrganizationPermission,
 } from "../rbac";
 import { TeamService, TEAM_ROLE_PRIORITY } from "~/server/teams/team.service";
+import { assertUsersInOrganization } from "~/server/organizations/assertUsersInOrganization";
 
 // Reusable schema for team member role validation
 const teamMemberRoleSchema = z
@@ -219,6 +220,11 @@ export const teamRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Team not found" });
       }
       const { organizationId } = teamRecord;
+      await assertUsersInOrganization(
+        prisma,
+        organizationId,
+        input.members.map((member) => member.userId),
+      );
 
       // Validate custom roles belong to this org
       if (input.members.some((m) => isCustomRole(m.role))) {
@@ -406,6 +412,12 @@ export const teamRouter = createTRPCRouter({
         slugify(input.name, { lower: true, strict: true }) +
         "-" +
         teamNanoId.substring(0, 6);
+
+      await assertUsersInOrganization(
+        prisma,
+        input.organizationId,
+        input.members.map((member) => member.userId),
+      );
 
       return await prisma.$transaction(async (tx) => {
         const team = await tx.team.create({

--- a/langwatch/src/server/api/routers/user.ts
+++ b/langwatch/src/server/api/routers/user.ts
@@ -424,6 +424,14 @@ export const userRouter = createTRPCRouter({
     .input(z.object({ userId: z.string() }))
     .use(skipPermissionCheck)
     .mutation(async ({ ctx, input }) => {
+      const user = ctx.session.user.impersonator ?? ctx.session.user;
+      if (
+        input.userId !== ctx.session.user.id &&
+        !checkIsAdmin({ email: user.email })
+      ) {
+        throw new TRPCError({ code: "FORBIDDEN" });
+      }
+
       // UserService.deactivate also force-revokes all the user's sessions
       // (Redis cache + DB) — see iter-24 progress notes for why.
       await UserService.create(ctx.prisma).deactivate({ id: input.userId });
@@ -433,6 +441,11 @@ export const userRouter = createTRPCRouter({
     .input(z.object({ userId: z.string() }))
     .use(skipPermissionCheck)
     .mutation(async ({ ctx, input }) => {
+      const user = ctx.session.user.impersonator ?? ctx.session.user;
+      if (!checkIsAdmin({ email: user.email })) {
+        throw new TRPCError({ code: "FORBIDDEN" });
+      }
+
       await UserService.create(ctx.prisma).reactivate({ id: input.userId });
       return { success: true };
     }),

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -27,6 +27,7 @@ import { wrapAiCall } from "../../modelProviders/aiCallFailedError";
 import { featureByKey } from "../../modelProviders/featureRegistry";
 import { getVercelAIModel } from "../../modelProviders/utils";
 import { autoComputeAgentMappings } from "../../workflows/auto-compute-agent-mappings";
+import { pMapLimited } from "../../event-sourcing/replay/pMapLimited";
 import { materializeNodeLlmConfigs } from "../../workflows/materializeNodeLlmConfigs";
 import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
@@ -261,22 +262,19 @@ export const workflowRouter = createTRPCRouter({
           ]),
         ),
       ];
-      const visibleProjects = new Map(
-        await Promise.all(
-          relatedProjectIds.map(
-            async (projectId) =>
-              [
-                projectId,
-                projectId === input.projectId ||
-                  (await hasProjectPermission(
-                    ctx,
-                    projectId,
-                    "workflows:view",
-                  )),
-              ] as const,
-          ),
-        ),
-      );
+      // Each related project needs its own RBAC check; cap concurrency so a
+      // workflow with many copies can't exhaust the DB connection pool.
+      const visibleProjects = new Map<string, boolean>();
+      await pMapLimited({
+        items: relatedProjectIds,
+        concurrency: 5,
+        fn: async (projectId) => {
+          const isVisible =
+            projectId === input.projectId ||
+            (await hasProjectPermission(ctx, projectId, "workflows:view"));
+          visibleProjects.set(projectId, isVisible);
+        },
+      });
 
       return workflows.map(({ copiedWorkflows, ...workflow }) => {
         const canSeeSource =

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -202,7 +202,7 @@ export const workflowRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string() }))
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ ctx, input }) => {
-      return ctx.prisma.workflow.findMany({
+      const workflows = await ctx.prisma.workflow.findMany({
         where: { projectId: input.projectId, archivedAt: null },
         orderBy: { updatedAt: "desc" },
         select: {
@@ -246,16 +246,54 @@ export const workflowRouter = createTRPCRouter({
               },
             },
           },
-          _count: {
-            select: {
-              copiedWorkflows: {
-                where: {
-                  archivedAt: null,
-                },
-              },
-            },
+          copiedWorkflows: {
+            where: { archivedAt: null },
+            select: { projectId: true },
           },
         },
+      });
+
+      const relatedProjectIds = [
+        ...new Set(
+          workflows.flatMap((workflow) => [
+            ...(workflow.copiedFrom ? [workflow.copiedFrom.projectId] : []),
+            ...workflow.copiedWorkflows.map((copy) => copy.projectId),
+          ]),
+        ),
+      ];
+      const visibleProjects = new Map(
+        await Promise.all(
+          relatedProjectIds.map(
+            async (projectId) =>
+              [
+                projectId,
+                projectId === input.projectId ||
+                  (await hasProjectPermission(
+                    ctx,
+                    projectId,
+                    "workflows:view",
+                  )),
+              ] as const,
+          ),
+        ),
+      );
+
+      return workflows.map(({ copiedWorkflows, ...workflow }) => {
+        const canSeeSource =
+          workflow.copiedFrom &&
+          visibleProjects.get(workflow.copiedFrom.projectId);
+        return {
+          ...workflow,
+          copiedFromWorkflowId: canSeeSource
+            ? workflow.copiedFromWorkflowId
+            : null,
+          copiedFrom: canSeeSource ? workflow.copiedFrom : null,
+          _count: {
+            copiedWorkflows: copiedWorkflows.filter((copy) =>
+              visibleProjects.get(copy.projectId),
+            ).length,
+          },
+        };
       });
     }),
 

--- a/langwatch/src/server/app-layer/groups/__tests__/group.service.tenant.unit.test.ts
+++ b/langwatch/src/server/app-layer/groups/__tests__/group.service.tenant.unit.test.ts
@@ -3,22 +3,30 @@ import type { GroupRepository } from "../repositories/group.repository";
 import { GroupRestService, UserNotInOrganizationError } from "../group.service";
 
 describe("GroupRestService.create", () => {
-  it("rejects members from another organization", async () => {
-    const createAtomic = vi.fn();
-    const repository = {
-      isUserInOrganization: vi.fn().mockResolvedValue(false),
-      createAtomic,
-    } as unknown as GroupRepository;
-    const service = new GroupRestService(repository);
+  describe("when a requested member is not in the organization", () => {
+    it("rejects the whole group in a single membership query", async () => {
+      const createAtomic = vi.fn();
+      const areUsersInOrganization = vi.fn().mockResolvedValue(false);
+      const repository = {
+        areUsersInOrganization,
+        createAtomic,
+      } as unknown as GroupRepository;
+      const service = new GroupRestService(repository);
 
-    await expect(
-      service.create({
+      await expect(
+        service.create({
+          organizationId: "org_1",
+          name: "Reviewers",
+          memberIds: ["member_1", "foreign_user", "member_1"],
+        }),
+      ).rejects.toBeInstanceOf(UserNotInOrganizationError);
+
+      expect(areUsersInOrganization).toHaveBeenCalledTimes(1);
+      expect(areUsersInOrganization).toHaveBeenCalledWith({
         organizationId: "org_1",
-        name: "Reviewers",
-        memberIds: ["foreign_user"],
-      }),
-    ).rejects.toBeInstanceOf(UserNotInOrganizationError);
-
-    expect(createAtomic).not.toHaveBeenCalled();
+        userIds: ["member_1", "foreign_user"],
+      });
+      expect(createAtomic).not.toHaveBeenCalled();
+    });
   });
 });

--- a/langwatch/src/server/app-layer/groups/__tests__/group.service.tenant.unit.test.ts
+++ b/langwatch/src/server/app-layer/groups/__tests__/group.service.tenant.unit.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GroupRepository } from "../repositories/group.repository";
+import { GroupRestService, UserNotInOrganizationError } from "../group.service";
+
+describe("GroupRestService.create", () => {
+  it("rejects members from another organization", async () => {
+    const createAtomic = vi.fn();
+    const repository = {
+      isUserInOrganization: vi.fn().mockResolvedValue(false),
+      createAtomic,
+    } as unknown as GroupRepository;
+    const service = new GroupRestService(repository);
+
+    await expect(
+      service.create({
+        organizationId: "org_1",
+        name: "Reviewers",
+        memberIds: ["foreign_user"],
+      }),
+    ).rejects.toBeInstanceOf(UserNotInOrganizationError);
+
+    expect(createAtomic).not.toHaveBeenCalled();
+  });
+});

--- a/langwatch/src/server/app-layer/groups/group.service.ts
+++ b/langwatch/src/server/app-layer/groups/group.service.ts
@@ -76,6 +76,17 @@ export class GroupRestService {
     }>;
     memberIds?: string[];
   }): Promise<Group> {
+    const uniqueMemberIds = [...new Set(memberIds ?? [])];
+    const memberships = await Promise.all(
+      uniqueMemberIds.map((userId) =>
+        this.repo.isUserInOrganization({ organizationId, userId }),
+      ),
+    );
+    if (memberships.some((isMember) => !isMember)) {
+      throw new UserNotInOrganizationError(
+        "All users must belong to the organization before joining a group",
+      );
+    }
     const baseSlug = slugify(name, { lower: true, strict: true });
     const slug = await this.repo.findUniqueSlug({
       organizationId,

--- a/langwatch/src/server/app-layer/groups/group.service.ts
+++ b/langwatch/src/server/app-layer/groups/group.service.ts
@@ -77,12 +77,11 @@ export class GroupRestService {
     memberIds?: string[];
   }): Promise<Group> {
     const uniqueMemberIds = [...new Set(memberIds ?? [])];
-    const memberships = await Promise.all(
-      uniqueMemberIds.map((userId) =>
-        this.repo.isUserInOrganization({ organizationId, userId }),
-      ),
-    );
-    if (memberships.some((isMember) => !isMember)) {
+    const allMembersInOrganization = await this.repo.areUsersInOrganization({
+      organizationId,
+      userIds: uniqueMemberIds,
+    });
+    if (!allMembersInOrganization) {
       throw new UserNotInOrganizationError(
         "All users must belong to the organization before joining a group",
       );

--- a/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
@@ -227,6 +227,21 @@ export class PrismaGroupRepository implements GroupRepository {
     return !!member;
   }
 
+  async areUsersInOrganization({
+    organizationId,
+    userIds,
+  }: {
+    organizationId: string;
+    userIds: string[];
+  }): Promise<boolean> {
+    if (userIds.length === 0) return true;
+
+    const count = await this.prisma.organizationUser.count({
+      where: { organizationId, userId: { in: userIds } },
+    });
+    return count === userIds.length;
+  }
+
   async validateScopeInOrganization({
     organizationId,
     scopeType,

--- a/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
@@ -28,7 +28,17 @@ export class PrismaGroupRepository implements GroupRepository {
           roleBindings: {
             include: { customRole: { select: { id: true, name: true } } },
           },
-          _count: { select: { members: true } },
+          _count: {
+            select: {
+              members: {
+                where: {
+                  user: {
+                    orgMemberships: { some: { organizationId } },
+                  },
+                },
+              },
+            },
+          },
         },
         orderBy: { name: "asc" },
         skip: (page - 1) * limit,
@@ -53,6 +63,11 @@ export class PrismaGroupRepository implements GroupRepository {
           include: { customRole: { select: { id: true, name: true } } },
         },
         members: {
+          where: {
+            user: {
+              orgMemberships: { some: { organizationId } },
+            },
+          },
           include: {
             user: { select: { id: true, name: true, email: true } },
           },

--- a/langwatch/src/server/app-layer/groups/repositories/group.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.repository.ts
@@ -119,6 +119,16 @@ export interface GroupRepository {
     organizationId: string;
   }): Promise<boolean>;
 
+  /**
+   * Returns true only when every given user belongs to the organization.
+   * `userIds` is expected to be deduplicated by the caller and is resolved in a
+   * single query.
+   */
+  areUsersInOrganization(params: {
+    organizationId: string;
+    userIds: string[];
+  }): Promise<boolean>;
+
   validateScopeInOrganization(params: {
     organizationId: string;
     scopeType: RoleBindingScopeType;

--- a/langwatch/src/server/app-layer/role-bindings/__tests__/role-binding.prisma.repository.tenant.unit.test.ts
+++ b/langwatch/src/server/app-layer/role-bindings/__tests__/role-binding.prisma.repository.tenant.unit.test.ts
@@ -1,0 +1,55 @@
+import {
+  RoleBindingScopeType,
+  TeamUserRole,
+  type PrismaClient,
+} from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+import { PrismaRoleBindingRepository } from "../repositories/role-binding.prisma.repository";
+
+describe("PrismaRoleBindingRepository tenant references", () => {
+  it("drops a group binding whose group belongs to another organization", async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      {
+        organizationId: "org_1",
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: "team_1",
+        role: TeamUserRole.MEMBER,
+        customRoleId: null,
+        customRole: null,
+        group: { organizationId: "org_2" },
+      },
+    ]);
+    const repository = new PrismaRoleBindingRepository({
+      roleBinding: { findMany },
+    } as unknown as PrismaClient);
+
+    const bindings = await repository.listForOrganizationsAndUser({
+      orgIds: ["org_1", "org_2"],
+      userId: "user_1",
+    });
+
+    expect(bindings).toEqual([]);
+  });
+
+  it("requires team binding users to belong to the organization", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const repository = new PrismaRoleBindingRepository({
+      roleBinding: { findMany },
+    } as unknown as PrismaClient);
+
+    await repository.listTeamScopedUserBindingsByTeamIds({
+      organizationId: "org_1",
+      teamIds: ["team_1"],
+    });
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user: {
+            orgMemberships: { some: { organizationId: "org_1" } },
+          },
+        }),
+      }),
+    );
+  });
+});

--- a/langwatch/src/server/app-layer/role-bindings/repositories/role-binding.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/role-bindings/repositories/role-binding.prisma.repository.ts
@@ -16,7 +16,7 @@ export class PrismaRoleBindingRepository implements RoleBindingRepository {
     orgIds: string[];
     userId: string;
   }): Promise<RoleBindingForSynthesis[]> {
-    return this.prisma.roleBinding.findMany({
+    const bindings = await this.prisma.roleBinding.findMany({
       where: {
         organizationId: { in: orgIds },
         OR: [
@@ -48,8 +48,15 @@ export class PrismaRoleBindingRepository implements RoleBindingRepository {
             updatedAt: true,
           },
         },
+        group: { select: { organizationId: true } },
       },
     });
+
+    return bindings.filter(
+      (binding) =>
+        !binding.group ||
+        binding.group.organizationId === binding.organizationId,
+    );
   }
 
   async listTeamScopedUserBindingsByTeamIds({
@@ -72,6 +79,7 @@ export class PrismaRoleBindingRepository implements RoleBindingRepository {
         scopeType: RoleBindingScopeType.TEAM,
         scopeId: { in: teamIds },
         userId: { not: null },
+        user: { orgMemberships: { some: { organizationId } } },
       },
       include: { user: true, customRole: true },
     });

--- a/langwatch/src/server/app-layer/share/__tests__/share.prisma.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/share/__tests__/share.prisma.repository.unit.test.ts
@@ -1,0 +1,26 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+import { PrismaShareRepository } from "../repositories/share.prisma.repository";
+
+describe("PrismaShareRepository.findByResourceType", () => {
+  it("includes the project in the share lookup", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const repository = new PrismaShareRepository({
+      publicShare: { findFirst },
+    } as unknown as PrismaClient);
+
+    await repository.findByResourceType({
+      projectId: "project_1",
+      resourceType: "TRACE",
+      resourceId: "trace_1",
+    });
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        projectId: "project_1",
+        resourceType: "TRACE",
+        resourceId: "trace_1",
+      },
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/share/__tests__/share.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/share/__tests__/share.service.unit.test.ts
@@ -25,6 +25,22 @@ describe("ShareService.revokeAllTraceShares", () => {
     service = new ShareService(repo, pinnedTraces as PinnedTraceService);
   });
 
+  describe("getStateForResource", () => {
+    it("passes the project to the repository", async () => {
+      await service.getStateForResource({
+        projectId: "project_1",
+        resourceType: "TRACE",
+        resourceId: "trace_1",
+      });
+
+      expect(repo.findByResourceType).toHaveBeenCalledWith({
+        projectId: "project_1",
+        resourceType: "TRACE",
+        resourceId: "trace_1",
+      });
+    });
+  });
+
   describe("regression: source=share pins must be cleared when bulk-revoking", () => {
     /**
      * Disabling trace sharing via project settings calls `revokeAllTraceShares`

--- a/langwatch/src/server/app-layer/share/repositories/share.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/share/repositories/share.prisma.repository.ts
@@ -30,14 +30,16 @@ export class PrismaShareRepository implements ShareRepository {
   }
 
   async findByResourceType({
+    projectId,
     resourceType,
     resourceId,
   }: {
+    projectId: string;
     resourceType: ShareResourceType;
     resourceId: string;
   }): Promise<PublicShare | null> {
     return this.prisma.publicShare.findFirst({
-      where: { resourceType, resourceId },
+      where: { projectId, resourceType, resourceId },
     });
   }
 

--- a/langwatch/src/server/app-layer/share/repositories/share.repository.ts
+++ b/langwatch/src/server/app-layer/share/repositories/share.repository.ts
@@ -16,6 +16,7 @@ export interface ShareRepository {
   }): Promise<PublicShare | null>;
 
   findByResourceType(params: {
+    projectId: string;
     resourceType: ShareResourceType;
     resourceId: string;
   }): Promise<PublicShare | null>;

--- a/langwatch/src/server/app-layer/share/share.service.ts
+++ b/langwatch/src/server/app-layer/share/share.service.ts
@@ -24,6 +24,7 @@ export class ShareService {
   }
 
   async getStateForResource(params: {
+    projectId: string;
     resourceType: ShareResourceType;
     resourceId: string;
   }): Promise<PublicShare | null> {

--- a/langwatch/src/server/evaluators/__tests__/evaluator.service.test.ts
+++ b/langwatch/src/server/evaluators/__tests__/evaluator.service.test.ts
@@ -295,33 +295,35 @@ describe("EvaluatorService", () => {
 
   describe("field computation for workflow evaluators", () => {
     it("computes fields from workflow entry node outputs", async () => {
+      const findFirst = vi.fn().mockResolvedValue({
+        id: "wf-1",
+        currentVersion: {
+          dsl: {
+            nodes: [
+              {
+                id: "entry",
+                type: "entry",
+                data: {
+                  outputs: [
+                    { identifier: "question", type: "str" },
+                    { identifier: "context", type: "str" },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      });
       const mockPrisma = {
         workflow: {
-          findUnique: vi.fn().mockResolvedValue({
-            id: "wf-1",
-            currentVersion: {
-              dsl: {
-                nodes: [
-                  {
-                    id: "entry",
-                    type: "entry",
-                    data: {
-                      outputs: [
-                        { identifier: "question", type: "str" },
-                        { identifier: "context", type: "str" },
-                      ],
-                    },
-                  },
-                ],
-              },
-            },
-          }),
+          findFirst,
         },
       } as unknown as PrismaClient;
 
       const mockRepository = {
         findById: vi.fn().mockResolvedValue({
           id: "eval-wf",
+          projectId: "proj-1",
           type: "workflow",
           workflowId: "wf-1",
           config: {},
@@ -340,12 +342,20 @@ describe("EvaluatorService", () => {
         { identifier: "question", type: "str" },
         { identifier: "context", type: "str" },
       ]);
+      expect(findFirst).toHaveBeenCalledWith({
+        where: {
+          id: "wf-1",
+          projectId: "proj-1",
+          archivedAt: null,
+        },
+        include: { currentVersion: true },
+      });
     });
 
     it("returns empty fields for workflow without DSL", async () => {
       const mockPrisma = {
         workflow: {
-          findUnique: vi.fn().mockResolvedValue({
+          findFirst: vi.fn().mockResolvedValue({
             id: "wf-2",
             currentVersion: null,
           }),
@@ -355,6 +365,7 @@ describe("EvaluatorService", () => {
       const mockRepository = {
         findById: vi.fn().mockResolvedValue({
           id: "eval-wf-2",
+          projectId: "proj-1",
           type: "workflow",
           workflowId: "wf-2",
           config: {},
@@ -374,13 +385,14 @@ describe("EvaluatorService", () => {
     it("returns empty fields for non-existent workflow", async () => {
       const mockPrisma = {
         workflow: {
-          findUnique: vi.fn().mockResolvedValue(null),
+          findFirst: vi.fn().mockResolvedValue(null),
         },
       } as unknown as PrismaClient;
 
       const mockRepository = {
         findById: vi.fn().mockResolvedValue({
           id: "eval-wf-3",
+          projectId: "proj-1",
           type: "workflow",
           workflowId: "non-existent-wf",
           config: {},

--- a/langwatch/src/server/evaluators/evaluator.service.ts
+++ b/langwatch/src/server/evaluators/evaluator.service.ts
@@ -123,14 +123,17 @@ export class EvaluatorService {
   /**
    * Result from computing workflow fields, includes metadata about the workflow.
    */
-  private async computeWorkflowFieldsWithMeta(workflowId: string): Promise<{
+  private async computeWorkflowFieldsWithMeta(
+    workflowId: string,
+    projectId: string,
+  ): Promise<{
     fields: EvaluatorField[];
     outputFields: EvaluatorField[];
     workflowName?: string;
     workflowIcon?: string;
   }> {
-    const workflow = await this.prisma.workflow.findUnique({
-      where: { id: workflowId },
+    const workflow = await this.prisma.workflow.findFirst({
+      where: { id: workflowId, projectId, archivedAt: null },
       include: { currentVersion: true },
     });
 
@@ -195,7 +198,10 @@ export class EvaluatorService {
   async enrichWithFields(evaluator: Evaluator): Promise<EvaluatorWithFields> {
     if (evaluator.type === "workflow" && evaluator.workflowId) {
       const { fields, outputFields, workflowName, workflowIcon } =
-        await this.computeWorkflowFieldsWithMeta(evaluator.workflowId);
+        await this.computeWorkflowFieldsWithMeta(
+          evaluator.workflowId,
+          evaluator.projectId,
+        );
       return { ...evaluator, fields, outputFields, workflowName, workflowIcon };
     }
 

--- a/langwatch/src/server/organizations/assertUsersInOrganization.ts
+++ b/langwatch/src/server/organizations/assertUsersInOrganization.ts
@@ -1,0 +1,21 @@
+import type { PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+
+export async function assertUsersInOrganization(
+  prisma: PrismaClient,
+  organizationId: string,
+  userIds: string[],
+): Promise<void> {
+  const uniqueUserIds = [...new Set(userIds)];
+  if (uniqueUserIds.length === 0) return;
+
+  const count = await prisma.organizationUser.count({
+    where: { organizationId, userId: { in: uniqueUserIds } },
+  });
+  if (count !== uniqueUserIds.length) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "One or more users are not in this organization",
+    });
+  }
+}

--- a/langwatch/src/server/rbac/__tests__/role-binding-resolver.tenant-isolation.unit.test.ts
+++ b/langwatch/src/server/rbac/__tests__/role-binding-resolver.tenant-isolation.unit.test.ts
@@ -1,0 +1,87 @@
+import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  checkRoleBindingPermission,
+  type ScopeRef,
+} from "../role-binding-resolver";
+
+// The API-key ceiling path (resolveApiKeyPermission → checkRoleBindingPermission
+// for the owning user) resolves the user's bindings through collectBindingsForUser.
+// A stale cross-org binding for a user who is not a current OrganizationUser of
+// the org must not confer access.
+
+const ORG_A = "org_a";
+const TEAM_A = "team_a";
+const PROJECT_A = "project_a";
+const USER_B = "user_b";
+
+const projectScope: ScopeRef = {
+  type: "project",
+  id: PROJECT_A,
+  teamId: TEAM_A,
+};
+
+const staleBinding = {
+  role: TeamUserRole.ADMIN,
+  customRoleId: null,
+  scopeType: RoleBindingScopeType.PROJECT,
+  scopeId: PROJECT_A,
+};
+
+// Fake that models the org-membership predicate the direct-binding query is
+// expected to carry: the seeded binding is only visible to a current member.
+// When `isMember` is false the binding must be filtered out by the predicate;
+// if the predicate is absent (the vulnerable shape) the binding leaks and the
+// test fails — which is exactly what makes this a regression test.
+function makePrisma({ isMember }: { isMember: boolean }) {
+  return {
+    roleBinding: {
+      findMany: vi.fn().mockImplementation(async ({ where }: any) => {
+        // The group-binding query carries `where.group`; there are no groups here.
+        if (where.group) return [];
+        const gatesOnMembership =
+          where.user?.orgMemberships?.some?.organizationId === ORG_A;
+        if (gatesOnMembership) return isMember ? [staleBinding] : [];
+        // Predicate missing → stale binding leaks (pre-fix behavior).
+        return [staleBinding];
+      }),
+    },
+    customRole: { findUnique: vi.fn().mockResolvedValue(null) },
+    teamUser: { findFirst: vi.fn().mockResolvedValue(null) },
+  } as unknown as Parameters<typeof checkRoleBindingPermission>[0]["prisma"];
+}
+
+describe("checkRoleBindingPermission() tenant isolation", () => {
+  describe("when the user is not a current member of the org", () => {
+    it("denies despite a pre-existing cross-org binding", async () => {
+      const prisma = makePrisma({ isMember: false });
+
+      const allowed = await checkRoleBindingPermission({
+        prisma,
+        userId: USER_B,
+        organizationId: ORG_A,
+        scope: projectScope,
+        permission: "project:view",
+      });
+
+      expect(allowed).toBe(false);
+    });
+  });
+
+  describe("when the user is a current member of the org", () => {
+    it("resolves the binding for a genuine member", async () => {
+      const prisma = makePrisma({ isMember: true });
+
+      const allowed = await checkRoleBindingPermission({
+        prisma,
+        userId: USER_B,
+        organizationId: ORG_A,
+        scope: projectScope,
+        permission: "project:view",
+      });
+
+      expect(allowed).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/server/rbac/role-binding-resolver.ts
+++ b/langwatch/src/server/rbac/role-binding-resolver.ts
@@ -112,7 +112,15 @@ async function collectBindingsForUser({
 }): Promise<ResolvedBinding[]> {
   const [directBindings, groupBindings] = await Promise.all([
     prisma.roleBinding.findMany({
-      where: { organizationId, userId },
+      // Gate the direct binding on current organization membership so a stale
+      // cross-org binding does not confer access — this is the API-key ceiling
+      // path (resolveApiKeyPermission checks the owning user's bindings here),
+      // and it must fail closed on membership just like the tRPC resolver.
+      where: {
+        organizationId,
+        userId,
+        user: { orgMemberships: { some: { organizationId } } },
+      },
       select: { role: true, customRoleId: true, scopeType: true, scopeId: true },
     }),
     prisma.roleBinding.findMany({

--- a/langwatch/src/server/role-bindings/__tests__/role-binding.service.tenant.unit.test.ts
+++ b/langwatch/src/server/role-bindings/__tests__/role-binding.service.tenant.unit.test.ts
@@ -1,0 +1,120 @@
+import {
+  RoleBindingScopeType,
+  TeamUserRole,
+  type PrismaClient,
+} from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RoleBindingRepository } from "~/server/app-layer/role-bindings/repositories/role-binding.repository";
+import type { RoleService } from "~/server/role/role.service";
+import { RoleBindingService } from "../role-binding.service";
+
+const validateScopeInOrg = vi.fn();
+const validateRolesAssignable = vi.fn();
+const organizationUserCount = vi.fn();
+const groupFindFirst = vi.fn();
+const bindingCreate = vi.fn();
+const bindingFindMany = vi.fn();
+const groupMembershipFindMany = vi.fn();
+
+const prisma = {
+  organizationUser: { count: organizationUserCount },
+  group: { findFirst: groupFindFirst },
+  roleBinding: {
+    create: bindingCreate,
+    findMany: bindingFindMany,
+  },
+  groupMembership: { findMany: groupMembershipFindMany },
+  $transaction: vi.fn(),
+} as unknown as PrismaClient;
+
+const repository = {
+  validateScopeInOrg,
+} as unknown as RoleBindingRepository;
+
+const roleService = {
+  validateRolesAssignable,
+} as unknown as RoleService;
+
+let service: RoleBindingService;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateScopeInOrg.mockResolvedValue(undefined);
+  validateRolesAssignable.mockResolvedValue(undefined);
+  organizationUserCount.mockResolvedValue(1);
+  groupFindFirst.mockResolvedValue({ id: "group_1" });
+  bindingCreate.mockResolvedValue({ id: "binding_1" });
+  bindingFindMany.mockResolvedValue([]);
+  groupMembershipFindMany.mockResolvedValue([]);
+  service = new RoleBindingService(prisma, repository, roleService);
+});
+
+const bindingInput = {
+  organizationId: "org_1",
+  role: TeamUserRole.MEMBER,
+  scopeType: RoleBindingScopeType.TEAM,
+  scopeId: "team_1",
+};
+
+describe("RoleBindingService tenant references", () => {
+  it("rejects a user principal from another organization", async () => {
+    organizationUserCount.mockResolvedValue(0);
+
+    await expect(
+      service.create({ ...bindingInput, userId: "foreign_user" }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(bindingCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a group principal from another organization", async () => {
+    groupFindFirst.mockResolvedValue(null);
+
+    await expect(
+      service.create({ ...bindingInput, groupId: "foreign_group" }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(bindingCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects batch bindings for a user from another organization", async () => {
+    organizationUserCount.mockResolvedValue(0);
+
+    await expect(
+      service.applyMemberBindings({
+        organizationId: "org_1",
+        userId: "foreign_user",
+        bindingIdsToDelete: [],
+        bindingsToCreate: [],
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("filters stale foreign principals from organization reads", async () => {
+    await service.listForOrg({ organizationId: "org_1" });
+
+    expect(bindingFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          organizationId: "org_1",
+          OR: [
+            {
+              userId: { not: null },
+              user: {
+                orgMemberships: { some: { organizationId: "org_1" } },
+              },
+            },
+            {
+              groupId: { not: null },
+              group: { organizationId: "org_1" },
+            },
+            {
+              apiKeyId: { not: null },
+              apiKey: { organizationId: "org_1" },
+            },
+          ],
+        },
+      }),
+    );
+  });
+});

--- a/langwatch/src/server/role-bindings/role-binding.service.ts
+++ b/langwatch/src/server/role-bindings/role-binding.service.ts
@@ -13,6 +13,7 @@ import {
   getTeamRolePermissions,
 } from "~/server/api/rbac";
 import type { RoleService } from "~/server/role/role.service";
+import { assertUsersInOrganization } from "~/server/organizations/assertUsersInOrganization";
 
 export class RoleBindingService {
   constructor(
@@ -48,6 +49,32 @@ export class RoleBindingService {
       roleIds: customRoleIds,
       organizationId,
     });
+  }
+
+  private async validatePrincipalInOrganization({
+    organizationId,
+    userId,
+    groupId,
+  }: {
+    organizationId: string;
+    userId?: string;
+    groupId?: string;
+  }): Promise<void> {
+    if (userId) {
+      await assertUsersInOrganization(this.prisma, organizationId, [userId]);
+    }
+    if (groupId) {
+      const group = await this.prisma.group.findFirst({
+        where: { id: groupId, organizationId },
+        select: { id: true },
+      });
+      if (!group) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Group is not in this organization",
+        });
+      }
+    }
   }
 
   async listForUser({ organizationId, userId }: { organizationId: string; userId: string }) {
@@ -95,7 +122,17 @@ export class RoleBindingService {
 
   async listForOrg({ organizationId }: { organizationId: string }) {
     const bindings = await this.prisma.roleBinding.findMany({
-      where: { organizationId },
+      where: {
+        organizationId,
+        OR: [
+          {
+            userId: { not: null },
+            user: { orgMemberships: { some: { organizationId } } },
+          },
+          { groupId: { not: null }, group: { organizationId } },
+          { apiKeyId: { not: null }, apiKey: { organizationId } },
+        ],
+      },
       include: {
         user: { select: { id: true, name: true, email: true } },
         group: { select: { id: true, name: true, scimSource: true } },
@@ -140,7 +177,11 @@ export class RoleBindingService {
     const groupMemberships =
       groupIds.length > 0
         ? await this.prisma.groupMembership.findMany({
-            where: { groupId: { in: groupIds } },
+            where: {
+              groupId: { in: groupIds },
+              group: { organizationId },
+              user: { orgMemberships: { some: { organizationId } } },
+            },
             select: { groupId: true, userId: true },
           })
         : [];
@@ -356,6 +397,11 @@ export class RoleBindingService {
     }
 
     await this.repo.validateScopeInOrg({ organizationId, scopeType, scopeId });
+    await this.validatePrincipalInOrganization({
+      organizationId,
+      userId,
+      groupId,
+    });
     await this.validateCustomRolesAssignable({
       organizationId,
       bindings: [{ role, customRoleId }],
@@ -445,6 +491,7 @@ export class RoleBindingService {
   }) {
     // Validate scopes and role assignability up front so a bad input fails
     // the whole batch before we open the transaction.
+    await assertUsersInOrganization(this.prisma, organizationId, [userId]);
     for (const b of bindingsToCreate) {
       await this.repo.validateScopeInOrg({
         organizationId,

--- a/langwatch/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
@@ -29,6 +29,15 @@ const { mockPrisma, mockRedis, SESSION } = vi.hoisted(() => {
     SESSION: { user: { id: "member_rolebinding_only" }, expires: "1" },
     mockRedis: { set: vi.fn().mockResolvedValue("OK") },
     mockPrisma: {
+      // resolveProjectPermission fails closed on current org membership before
+      // it ever looks at bindings: a genuine team member is always an
+      // OrganizationUser of the owning org (invite acceptance creates both in
+      // one transaction — see invite.service.ts). Model that here with an
+      // org-level MEMBER role. The MEMBER org role alone grants no project-level
+      // permission, so authorization still hinges on the TEAM binding below.
+      organizationUser: {
+        findFirst: vi.fn().mockResolvedValue({ role: "MEMBER" }),
+      },
       // checkPermissionFromBindings: user belongs to no groups …
       groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
       // … but has a TEAM-scoped ADMIN RoleBinding (project:view is granted).
@@ -50,7 +59,6 @@ const { mockPrisma, mockRedis, SESSION } = vi.hoisted(() => {
                 team: {
                   id: TEAM_ID,
                   organizationId: ORG_ID,
-                  organization: { members: [] }, // no OrganizationUser row either
                 },
               })
             : Promise.resolve({

--- a/langwatch/src/server/teams/team.service.ts
+++ b/langwatch/src/server/teams/team.service.ts
@@ -15,6 +15,19 @@ export const TEAM_ROLE_PRIORITY: Record<TeamUserRole, number> = {
   [TeamUserRole.CUSTOM]: 3,
 };
 
+const principalInOrganizationWhere = (
+  organizationId: string,
+): Prisma.RoleBindingWhereInput => ({
+  OR: [
+    {
+      userId: { not: null },
+      user: { orgMemberships: { some: { organizationId } } },
+    },
+    { groupId: { not: null }, group: { organizationId } },
+    { apiKeyId: { not: null }, apiKey: { organizationId } },
+  ],
+});
+
 // Ascending, nulls last — matches Postgres `ORDER BY col ASC` (the ordering the
 // previous Prisma `orderBy` produced before members were resolved in memory).
 function compareNullsLast(a: string | null, b: string | null): number {
@@ -282,6 +295,7 @@ export class TeamService {
               organizationId,
               scopeType: RoleBindingScopeType.TEAM,
               scopeId: team.id,
+              ...principalInOrganizationWhere(organizationId),
             },
             include: {
               user: { select: { id: true, name: true, email: true } },
@@ -296,6 +310,7 @@ export class TeamService {
                   organizationId,
                   scopeType: RoleBindingScopeType.PROJECT,
                   scopeId: { in: projectIds },
+                  ...principalInOrganizationWhere(organizationId),
                 },
                 include: {
                   user: { select: { id: true, name: true, email: true } },
@@ -322,7 +337,11 @@ export class TeamService {
         );
         const groupMemberships = allGroupIds.length > 0
           ? await this.prisma.groupMembership.findMany({
-              where: { groupId: { in: allGroupIds } },
+              where: {
+                groupId: { in: allGroupIds },
+                group: { organizationId },
+                user: { orgMemberships: { some: { organizationId } } },
+              },
               include: { user: { select: { id: true, name: true, email: true } } },
             })
           : [];


### PR DESCRIPTION
## Why

Several lookups trusted a resource ID alongside the current project or organisation without proving the resource belonged there. A valid user could use that mismatch to expose metadata, attach foreign references, or inherit access from another tenant.

## What changed

Account deactivation is limited to platform admins and the user themselves. Reactivation remains platform-admin only.

Share state, evaluator workflows, graph dashboards and copied workflow metadata are now scoped through the current project. Annotation queues, scores and authors are checked before writes, with defensive filters on existing rows.

Role bindings, teams and groups now reject principals from another organisation. Public annotation responses only return the author fields the page needs.

## How it works

Nested references are resolved through their owning project or organisation before use. Read paths also discard stale foreign links, so an old malformed row cannot expose metadata or grant access after the write checks land.

## Test plan

- [x] 57 focused regression tests across 14 files
- [x] Application typecheck
- [x] Test typecheck
- [x] Clean diff check

## Anything surprising?

This deliberately leaves `traceSharingEnabled` alone. That setting is being removed separately.

Biome was not run because the installed 2.5.1 binary rejects the repository's 2.4.14 configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Access Control**
  * Added project/organization ownership validation for graph creation from dashboards and for evaluator creation/update from workflows.
  * Enforced fail-closed tenant isolation across RBAC and organization membership checks for role bindings, teams/groups, annotation queue operations, and shared-state access (now project-aware).
  * Hardened user deactivation/reactivation so non-admins can only act on themselves.
* **Bug Fixes**
  * Corrected annotation queue/item queries and counts, group member counts/rosters, role-binding visibility, and workflow copy metadata so results reflect only permitted organization/project scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->