### PR TITLE
fix(triggers): surface Slack dispatch failure cause + bound alert field sizes

### DIFF
--- a/dev/docs/adr/027-typed-dispatcherror-contract.md
+++ b/dev/docs/adr/027-typed-dispatcherror-contract.md
@@ -28,26 +28,55 @@ Define a typed error class in the outbox framework:
 
 ```ts
 // src/server/event-sourcing/outbox/dispatchError.ts
+export type DispatchDisposition = "provider_terminal" | "config";
+
 export class DispatchError extends Error {
   readonly retryable: boolean;
   readonly cause?: unknown;
+  readonly disposition?: DispatchDisposition;
 
   constructor({
     message,
     retryable,
     cause,
+    disposition,
   }: {
     message: string;
     retryable: boolean;
     cause?: unknown;
+    disposition?: DispatchDisposition;
   }) {
     super(message);
     this.name = "DispatchError";
     this.retryable = retryable;
     this.cause = cause;
+    this.disposition = disposition;
   }
 }
 ```
+
+### Amendment: `disposition` — why `retryable: false` is not one decision
+
+`retryable` answers "re-fire this?". It does not answer "what becomes of the job?", and conflating the two is a correctness bug: `retryable: false` is thrown both for a provider's terminal verdict (a revoked webhook, a payload Slack will never accept) **and** for our own configuration, security, or integrity failures (an invalid Slack URL, a missing bot token or channel, an unsupported graph action, a mixed cadence batch, a notify-stage misrouting).
+
+Those two want opposite handling:
+
+| Disposition | Source | Queue handling |
+|---|---|---|
+| `provider_terminal` | the provider answered with a terminal HTTP status | complete out of the queue; the dead outbox row carries it to an operator |
+| `config` (or unset) | we rejected the dispatch before/without a provider verdict | park: block the group and re-stage for an operator |
+
+A config failure completed out of the queue would dead-letter the alert **and** let later work continue on the same broken invariant, unnoticed. So the queue completes a job only on an explicit `provider_terminal`; `config` and an unset disposition both park. Defaulting to the parking path keeps a hand-constructed `DispatchError` fail-safe: a new dispatch endpoint that has not thought about disposition parks rather than silently dropping alerts.
+
+`toDispatchError` sets the disposition from where the verdict came from, never from the flag alone: `provider_terminal` only when the non-retryable decision was **derived** from a terminal HTTP status, and `config` whenever a caller passed `retryable: false` itself — including when a status happens to be present, since the override owns the decision.
+
+### Amendment: the dead transition is load-bearing on the provider-terminal path
+
+Completing a job out of the queue destroys everything but the dead outbox row, so that row is not a projection there — it is the only recovery surface. Audit writes are otherwise best-effort (a PG outage logs and continues, ADR-030 revision), which on this one path would let a side-store outage remove the job while its row stays stuck in `dispatching`, with no reconciliation.
+
+So `QueueAuditAdapter.onDead` returns whether it durably recorded the transition, and the provider-terminal path confirms it **before** completing. When it cannot be confirmed, the job parks instead — the group blocks, the job re-stages, and a later attempt re-runs the terminal dispatch and marks it dead once the side-store is writable. Drained batch siblings stay best-effort: none of them owns the queue slot being completed, and their rows resync on a later transition.
+
+Every other hook, and `onDead` on the block/park path, stays best-effort — a parked job is its own recovery surface, so a lagging projection loses nothing.
 
 All dispatch endpoints invoked by `.withOutbox` reactors must throw `DispatchError` on failure:
 
@@ -126,6 +155,8 @@ In all cases the **enforcement** lives in the outbox state machine, not the prov
 - **Worker retry policy is per-error-type.** `DispatchError({ retryable: false })` transitions immediately to `dead`. `DispatchError({ retryable: true })` and unknown errors use the registered `retryPolicy.backoffMs(attempt)` until `maxAttempts`.
 - **Slack double-send risk** in the rare "dispatch succeeded but status update failed" case is accepted. Surfaced in operator activity tab (ADR-037) as a "possibly-duplicate-dispatched" badge if the row has `attemptCount > 1` AND `status='dispatched'`. Cheap to detect; cheap to surface.
 - **Future dispatch endpoints** added for new outbox reactors (e.g., `customerIoTraceSync`, `addToDataset` after migration) must follow the same contract. A unit-test convention enforces it.
+- **A non-retryable endpoint must mean it.** An endpoint that wraps a provider failure through `toDispatchError` gets its disposition classified for free. One that constructs a `DispatchError` by hand and wants the job dropped from the queue must pass `disposition: "provider_terminal"` explicitly and be sure a provider actually returned that verdict; everything else parks for an operator.
+- **Audit adapters must report `onDead` durability honestly.** An adapter that swallows a write failure must return `false`, not resolve as success — the provider-terminal path drops the job on the strength of that answer.
 
 ## References
 

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { SECRETS_REDACTION_MARKER } from "~/server/data-privacy/redaction/secretsRedaction";
 import {
   DispatchError,
   extractHttpStatus,
   isDispatchError,
+  isProviderTerminal,
   isRetryableHttpStatus,
+  MAX_CAUSE_MESSAGE_LENGTH,
   toDispatchError,
 } from "../dispatchError";
 
@@ -26,6 +29,77 @@ describe("DispatchError", () => {
       const err = new DispatchError({ message: "x", retryable: true });
       expect(err).toBeInstanceOf(Error);
       expect(err).toBeInstanceOf(DispatchError);
+    });
+
+    it("carries the disposition when one is given", () => {
+      const err = new DispatchError({
+        message: "x",
+        retryable: false,
+        disposition: "provider_terminal",
+      });
+      expect(err.disposition).toBe("provider_terminal");
+    });
+
+    it("leaves the disposition absent when none is given", () => {
+      const err = new DispatchError({ message: "x", retryable: false });
+      expect(err.disposition).toBeUndefined();
+    });
+  });
+});
+
+describe("isProviderTerminal", () => {
+  describe("when the failure is a non-retryable provider verdict", () => {
+    it("returns true", () => {
+      expect(
+        isProviderTerminal(
+          new DispatchError({
+            message: "revoked webhook",
+            retryable: false,
+            disposition: "provider_terminal",
+          }),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("when the failure is a non-retryable config error", () => {
+    it("returns false so the queue parks it rather than dead-lettering it", () => {
+      expect(
+        isProviderTerminal(
+          new DispatchError({
+            message: "invalid slack url",
+            retryable: false,
+            disposition: "config",
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false when the disposition was never classified", () => {
+      expect(
+        isProviderTerminal(
+          new DispatchError({
+            message: "mixed cadence batch",
+            retryable: false,
+          }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("when the failure is retryable or not a DispatchError", () => {
+    it("returns false", () => {
+      expect(
+        isProviderTerminal(
+          new DispatchError({
+            message: "429",
+            retryable: true,
+            disposition: "provider_terminal",
+          }),
+        ),
+      ).toBe(false);
+      expect(isProviderTerminal(new Error("plain"))).toBe(false);
+      expect(isProviderTerminal(null)).toBe(false);
     });
   });
 });
@@ -126,6 +200,49 @@ describe("toDispatchError", () => {
       expect(err.retryable).toBe(false);
       expect(err.message).toBe("send failed: HTTP 404");
     });
+
+    it("marks it provider-terminal, because the provider itself returned the verdict", () => {
+      const err = toDispatchError(
+        { response: { status: 404 } },
+        { message: "send failed" },
+      );
+      expect(err.disposition).toBe("provider_terminal");
+      expect(isProviderTerminal(err)).toBe(true);
+    });
+  });
+
+  describe("when the caller declares the failure non-retryable itself", () => {
+    it("marks it config, so a broken invariant is never dead-lettered as a provider verdict", () => {
+      const err = toDispatchError(new Error("invalid slack webhook url"), {
+        message: "guard rejected",
+        retryable: false,
+      });
+      expect(err.retryable).toBe(false);
+      expect(err.disposition).toBe("config");
+      expect(isProviderTerminal(err)).toBe(false);
+    });
+
+    it("stays config even when a terminal status is also present", () => {
+      // The override wins the retryable decision, so it must own the
+      // disposition too — otherwise a caller-classified config failure would
+      // inherit provider-terminal treatment from an incidental status.
+      const err = toDispatchError(
+        Object.assign(new Error("rejected"), { response: { status: 400 } }),
+        { message: "guard rejected", retryable: false },
+      );
+      expect(err.disposition).toBe("config");
+      expect(isProviderTerminal(err)).toBe(false);
+    });
+  });
+
+  describe("when a retryable failure is classified", () => {
+    it("is never provider-terminal", () => {
+      const err = toDispatchError(
+        { response: { status: 503 } },
+        { message: "send failed" },
+      );
+      expect(isProviderTerminal(err)).toBe(false);
+    });
   });
 
   describe("when the failure has no recognizable status", () => {
@@ -158,12 +275,57 @@ describe("toDispatchError", () => {
       expect(err.message).toBe("render failed: template exploded");
     });
 
-    it("caps an oversized provider message instead of inlining it whole", () => {
+    it("caps an oversized provider message at exactly the cause limit, ellipsis included", () => {
       const err = toDispatchError(new Error("x".repeat(2000)), {
         message: "send failed",
       });
-      expect(err.message.length).toBeLessThan(500);
-      expect(err.message).toContain("…");
+      const cause = err.message.replace("send failed: ", "");
+      expect(cause).toHaveLength(MAX_CAUSE_MESSAGE_LENGTH);
+      expect(cause.endsWith("…")).toBe(true);
+      expect(cause).toBe("x".repeat(MAX_CAUSE_MESSAGE_LENGTH - 1) + "…");
+    });
+
+    it("leaves a message at the cap untouched rather than truncating it", () => {
+      const exact = "x".repeat(MAX_CAUSE_MESSAGE_LENGTH);
+      const err = toDispatchError(new Error(exact), {
+        message: "send failed",
+      });
+      expect(err.message).toBe(`send failed: ${exact}`);
+    });
+  });
+
+  describe("when the provider echoes a secret back in its error message", () => {
+    it("redacts the secret before it can reach logs or audit rows", () => {
+      const err = toDispatchError(
+        new Error(
+          'request failed: {"authorization":"Bearer sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAA"}',
+        ),
+        { message: "send failed" },
+      );
+      expect(err.message).not.toContain(
+        "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      );
+      expect(err.message).toContain(SECRETS_REDACTION_MARKER);
+    });
+
+    it("redacts before capping, so a long body cannot smuggle a secret past the cap", () => {
+      // The secret sits past the cap: redaction must run on the whole message
+      // first, or truncation would simply hide (not scrub) it — and a slightly
+      // shorter body would leak it verbatim.
+      // Assembled at runtime: a token-shaped literal in the source trips
+      // GitHub's push protection even as a fixture.
+      const slackToken = [
+        "xoxb",
+        "111111111111",
+        "222222222222",
+        "abcdefghijklmnopqrstuvwx",
+      ].join("-");
+      const err = toDispatchError(
+        new Error("padding ".repeat(20) + slackToken),
+        { message: "send failed" },
+      );
+      expect(err.message).not.toContain(slackToken);
+      expect(err.message).toContain(SECRETS_REDACTION_MARKER);
     });
   });
 

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
@@ -106,14 +106,14 @@ describe("toDispatchError", () => {
   });
 
   describe("when the failure has a retryable status", () => {
-    it("produces a retryable DispatchError", () => {
+    it("produces a retryable DispatchError with the status in the message", () => {
       const err = toDispatchError(
         { $metadata: { httpStatusCode: 503 } },
         { message: "send failed" },
       );
       expect(err).toBeInstanceOf(DispatchError);
       expect(err.retryable).toBe(true);
-      expect(err.message).toBe("send failed");
+      expect(err.message).toBe("send failed: HTTP 503");
     });
   });
 
@@ -124,6 +124,7 @@ describe("toDispatchError", () => {
         { message: "send failed" },
       );
       expect(err.retryable).toBe(false);
+      expect(err.message).toBe("send failed: HTTP 404");
     });
   });
 
@@ -133,6 +134,43 @@ describe("toDispatchError", () => {
       const err = toDispatchError(cause, { message: "send failed" });
       expect(err.retryable).toBe(true);
       expect(err.cause).toBe(cause);
+    });
+  });
+
+  describe("when the failure carries both a status and a provider message", () => {
+    it("includes both in the message so logs are diagnosable without the cause", () => {
+      const cause = Object.assign(
+        new Error("An HTTP protocol error occurred: statusCode = 404"),
+        { original: { response: { status: 404 } } },
+      );
+      const err = toDispatchError(cause, { message: "send failed" });
+      expect(err.message).toBe(
+        "send failed: HTTP 404 — An HTTP protocol error occurred: statusCode = 404",
+      );
+    });
+
+    it("keeps the detail when the caller overrides retryable", () => {
+      const err = toDispatchError(new Error("template exploded"), {
+        message: "render failed",
+        retryable: false,
+      });
+      expect(err.retryable).toBe(false);
+      expect(err.message).toBe("render failed: template exploded");
+    });
+
+    it("caps an oversized provider message instead of inlining it whole", () => {
+      const err = toDispatchError(new Error("x".repeat(2000)), {
+        message: "send failed",
+      });
+      expect(err.message.length).toBeLessThan(500);
+      expect(err.message).toContain("…");
+    });
+  });
+
+  describe("when the failure carries neither a status nor a message", () => {
+    it("leaves the caller's message untouched", () => {
+      const err = toDispatchError({ weird: true }, { message: "send failed" });
+      expect(err.message).toBe("send failed");
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
@@ -312,19 +312,14 @@ describe("toDispatchError", () => {
       // The secret sits past the cap: redaction must run on the whole message
       // first, or truncation would simply hide (not scrub) it — and a slightly
       // shorter body would leak it verbatim.
-      // Assembled at runtime: a token-shaped literal in the source trips
-      // GitHub's push protection even as a fixture.
-      const slackToken = [
-        "xoxb",
-        "111111111111",
-        "222222222222",
-        "abcdefghijklmnopqrstuvwx",
-      ].join("-");
       const err = toDispatchError(
-        new Error("padding ".repeat(20) + slackToken),
+        new Error(
+          "padding ".repeat(20) +
+            "xoxb-111111111111-222222222222-abcdefghijklmnopqrstuvwx",
+        ),
         { message: "send failed" },
       );
-      expect(err.message).not.toContain(slackToken);
+      expect(err.message).not.toContain("xoxb-111111111111");
       expect(err.message).toContain(SECRETS_REDACTION_MARKER);
     });
   });

--- a/langwatch/src/server/event-sourcing/outbox/dispatchError.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatchError.ts
@@ -1,3 +1,22 @@
+import { redactSecretsInText } from "~/server/data-privacy/redaction/secretsRedaction";
+
+/**
+ * Why a non-retryable dispatch failed, which decides what the queue does with
+ * the job beyond not retrying it:
+ *
+ *   - `provider_terminal`: the provider answered and rejected us for good (a
+ *     revoked webhook, a payload it will never accept). Re-firing can never
+ *     succeed, so the queue completes the job out of the queue and the dead
+ *     outbox row carries it to an operator.
+ *   - `config`: we never got a usable verdict from the provider — the failure
+ *     is our own configuration, security, or integrity problem (an invalid
+ *     webhook URL, a missing token, a misrouted batch). The broken invariant
+ *     must be parked for an operator, never silently dead-lettered.
+ *
+ * See dev/docs/adr/027-typed-dispatcherror-contract.md.
+ */
+export type DispatchDisposition = "provider_terminal" | "config";
+
 /**
  * Typed error thrown by outbox dispatch endpoints to signal whether the
  * failure is worth retrying.
@@ -13,25 +32,47 @@
  * Any non-DispatchError thrown from a dispatch endpoint is treated as
  * retryable by default — better to retry an unexpected crash than to
  * silently dead-letter a row whose failure mode we did not classify.
+ *
+ * `disposition` refines a non-retryable failure. It is absent on a
+ * hand-constructed error, which reads as the conservative `config` case: only
+ * an explicit `provider_terminal` lets the queue complete a job out of the
+ * queue.
  */
 export class DispatchError extends Error {
   readonly retryable: boolean;
   readonly cause?: unknown;
+  readonly disposition?: DispatchDisposition;
 
   constructor({
     message,
     retryable,
     cause,
+    disposition,
   }: {
     message: string;
     retryable: boolean;
     cause?: unknown;
+    disposition?: DispatchDisposition;
   }) {
     super(message);
     this.name = "DispatchError";
     this.retryable = retryable;
     this.cause = cause;
+    this.disposition = disposition;
   }
+}
+
+/**
+ * Whether a failure is a provider's own terminal verdict — the only class of
+ * non-retryable failure a queue may complete out of the queue rather than park
+ * for an operator.
+ */
+export function isProviderTerminal(error: unknown): boolean {
+  return (
+    isDispatchError(error) &&
+    !error.retryable &&
+    error.disposition === "provider_terminal"
+  );
 }
 
 export function isDispatchError(error: unknown): error is DispatchError {
@@ -80,9 +121,10 @@ export function extractHttpStatus(error: unknown): number | undefined {
 
 /**
  * Providers can embed whole response bodies in their error messages; cap the
- * detail so log lines and audit rows stay readable.
+ * detail so log lines and audit rows stay readable. The cap is inclusive of the
+ * ellipsis a truncated message ends with.
  */
-const MAX_CAUSE_MESSAGE_LENGTH = 300;
+export const MAX_CAUSE_MESSAGE_LENGTH = 300;
 
 /**
  * Human-readable summary of the underlying failure — "HTTP 404 — <provider
@@ -90,6 +132,11 @@ const MAX_CAUSE_MESSAGE_LENGTH = 300;
  * (outbox dispatcher logs, group-queue audit rows, Sentry titles) serializes
  * only `error.message`, so the detail must live in the message itself for an
  * operator to tell a revoked webhook from a rejected payload.
+ *
+ * Providers routinely echo the request (headers, auth, whole response bodies)
+ * back in the error message, so secrets are scrubbed before the detail reaches
+ * any of those sinks. Redaction runs before the cap, so the marker a redaction
+ * leaves behind is what gets truncated — never a half-scrubbed credential.
  */
 function describeCause(error: unknown, status: number | undefined): string {
   const rawMessage =
@@ -98,10 +145,11 @@ function describeCause(error: unknown, status: number | undefined): string {
       : typeof error === "string"
         ? error
         : "";
+  const { text: redactedMessage } = redactSecretsInText({ text: rawMessage });
   const causeMessage =
-    rawMessage.length > MAX_CAUSE_MESSAGE_LENGTH
-      ? rawMessage.slice(0, MAX_CAUSE_MESSAGE_LENGTH) + "…"
-      : rawMessage;
+    redactedMessage.length > MAX_CAUSE_MESSAGE_LENGTH
+      ? redactedMessage.slice(0, MAX_CAUSE_MESSAGE_LENGTH - 1) + "…"
+      : redactedMessage;
   return [status === undefined ? "" : `HTTP ${status}`, causeMessage]
     .filter(Boolean)
     .join(" — ");
@@ -117,6 +165,11 @@ function describeCause(error: unknown, status: number | undefined): string {
  * render failure where the payload itself is malformed), it can pass
  * `retryable: false` to short-circuit the HTTP-status heuristic and
  * promote the row straight to `dead`.
+ *
+ * The disposition follows from where the non-retryable verdict came from: only
+ * a terminal HTTP status the provider itself returned is `provider_terminal`.
+ * A caller-supplied `retryable: false` is a config/integrity judgement we made
+ * without the provider, so it stays `config` and parks for an operator.
  */
 export function toDispatchError(
   error: unknown,
@@ -129,12 +182,18 @@ export function toDispatchError(
   const status = extractHttpStatus(error);
   const causeSummary = describeCause(error, status);
   const fullMessage = causeSummary ? `${message}: ${causeSummary}` : message;
+  const derivedFromStatus = retryableOverride === undefined;
   const retryable =
     retryableOverride ??
     (status === undefined ? true : isRetryableHttpStatus(status));
+  const disposition: DispatchDisposition =
+    derivedFromStatus && status !== undefined && !isRetryableHttpStatus(status)
+      ? "provider_terminal"
+      : "config";
   return new DispatchError({
     message: fullMessage,
     retryable,
     cause: error,
+    disposition,
   });
 }

--- a/langwatch/src/server/event-sourcing/outbox/dispatchError.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatchError.ts
@@ -79,6 +79,35 @@ export function extractHttpStatus(error: unknown): number | undefined {
 }
 
 /**
+ * Providers can embed whole response bodies in their error messages; cap the
+ * detail so log lines and audit rows stay readable.
+ */
+const MAX_CAUSE_MESSAGE_LENGTH = 300;
+
+/**
+ * Human-readable summary of the underlying failure — "HTTP 404 — <provider
+ * message>" — appended to the DispatchError message. Every sink downstream
+ * (outbox dispatcher logs, group-queue audit rows, Sentry titles) serializes
+ * only `error.message`, so the detail must live in the message itself for an
+ * operator to tell a revoked webhook from a rejected payload.
+ */
+function describeCause(error: unknown, status: number | undefined): string {
+  const rawMessage =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  const causeMessage =
+    rawMessage.length > MAX_CAUSE_MESSAGE_LENGTH
+      ? rawMessage.slice(0, MAX_CAUSE_MESSAGE_LENGTH) + "…"
+      : rawMessage;
+  return [status === undefined ? "" : `HTTP ${status}`, causeMessage]
+    .filter(Boolean)
+    .join(" — ");
+}
+
+/**
  * Converts a raw dispatch failure into a DispatchError with a retryable
  * decision derived from its HTTP status. An already-typed DispatchError is
  * returned unchanged. Failures with no recognizable status default to
@@ -97,14 +126,15 @@ export function toDispatchError(
   }: { message: string; retryable?: boolean },
 ): DispatchError {
   if (isDispatchError(error)) return error;
-  if (retryableOverride !== undefined) {
-    return new DispatchError({
-      message,
-      retryable: retryableOverride,
-      cause: error,
-    });
-  }
   const status = extractHttpStatus(error);
-  const retryable = status === undefined ? true : isRetryableHttpStatus(status);
-  return new DispatchError({ message, retryable, cause: error });
+  const causeSummary = describeCause(error, status);
+  const fullMessage = causeSummary ? `${message}: ${causeSummary}` : message;
+  const retryable =
+    retryableOverride ??
+    (status === undefined ? true : isRetryableHttpStatus(status));
+  return new DispatchError({
+    message: fullMessage,
+    retryable,
+    cause: error,
+  });
 }

--- a/langwatch/src/server/event-sourcing/outbox/pgAuditAdapter.ts
+++ b/langwatch/src/server/event-sourcing/outbox/pgAuditAdapter.ts
@@ -328,14 +328,23 @@ export class PgOutboxAuditAdapter implements QueueAuditAdapter<OutboxJob> {
     );
   }
 
+  /**
+   * Returns whether the row reached `dead` durably — PG acknowledged the write
+   * AND the CAS matched a row. A caller that is about to drop the job's only
+   * other trace (the queue's provider-terminal completion) relies on this, so
+   * a swallowed PG outage must read as `false`, not as success.
+   *
+   * A payload that is neither settle nor cadence has no outbox row here, so
+   * there is nothing this adapter can durably record for it.
+   */
   async onDead(event: {
     payload: OutboxJob;
     lastError: string;
     attempt: number;
-  }): Promise<void> {
+  }): Promise<boolean> {
     const p = event.payload;
-    if (!isSettle(p) && !isCadence(p)) return;
-    await this.write(() =>
+    if (!isSettle(p) && !isCadence(p)) return false;
+    const rowsAffected = await this.write(() =>
       this.prisma.reactorOutbox.updateMany({
         where: {
           projectId: p.projectId,
@@ -353,6 +362,7 @@ export class PgOutboxAuditAdapter implements QueueAuditAdapter<OutboxJob> {
         },
       }),
     );
+    return rowsAffected > 0;
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -15,7 +15,10 @@ import {
   getTestRedisConnection,
 } from "../../../__tests__/integration/testContainers";
 import { GroupQueueProcessor } from "../groupQueue";
-import type { EventSourcedQueueDefinition } from "../../queue.types";
+import type {
+  EventSourcedQueueDefinition,
+  QueueAuditAdapter,
+} from "../../queue.types";
 import { DispatchError } from "../../../outbox/dispatchError";
 
 // Skip when running without testcontainers (unit-only test runs)
@@ -81,6 +84,29 @@ describe.skipIf(!hasTestcontainers)(
       );
       queues.push(queue);
       return queue;
+    }
+
+    const blockedMembers = (name: string) =>
+      redis.smembers(`${name}:gq:blocked`);
+
+    /** A queue name the test can build Redis keys from, since the processor
+     *  keeps its own name private. */
+    const uniqueQueueName = () =>
+      `{test/gq/${crypto.randomUUID().slice(0, 8)}}`;
+
+    /** Audit adapter whose hooks all no-op, with a durably-recorded `onDead`.
+     *  Overrides let a test make one hook misbehave. */
+    function stubAuditAdapter(
+      overrides: Partial<QueueAuditAdapter<TestPayload>> = {},
+    ): QueueAuditAdapter<TestPayload> {
+      return {
+        onEnqueue: async () => undefined,
+        onLeased: async () => undefined,
+        onDispatched: async () => undefined,
+        onFailed: async () => undefined,
+        onDead: async () => true,
+        ...overrides,
+      };
     }
 
     describe("send()", () => {
@@ -770,43 +796,160 @@ describe.skipIf(!hasTestcontainers)(
       });
     });
 
-    describe("non-retryable dispatch failures", () => {
-      describe("when a job fails with a non-retryable DispatchError", () => {
-        /** @scenario 'A non-retryable dispatch failure leaves the queue instead of blocking the group' */
-        it("completes the job out of the queue so later jobs in the same group still dispatch", async () => {
-          const processed: TestPayload[] = [];
-          const attemptsById = new Map<string, number>();
-          const queue = createQueue(async (p) => {
+    describe("when a job fails with a provider-terminal DispatchError", () => {
+      /** @scenario 'A non-retryable dispatch failure leaves the queue instead of blocking the group' */
+      it("completes the job out of the queue so later jobs in the same group still dispatch", async () => {
+        const processed: TestPayload[] = [];
+        const attemptsById = new Map<string, number>();
+        const name = uniqueQueueName();
+        const queue = createQueue(
+          async (p) => {
             attemptsById.set(p.id, (attemptsById.get(p.id) ?? 0) + 1);
             if (p.id === "dead-webhook") {
               throw new DispatchError({
                 message: "Slack webhook dispatch failed: HTTP 404",
                 retryable: false,
+                disposition: "provider_terminal",
               });
             }
             processed.push(p);
-          });
-          await queue.waitUntilReady();
+          },
+          { name, auditAdapter: stubAuditAdapter() },
+        );
+        await queue.waitUntilReady();
 
-          await queue.send({
-            id: "dead-webhook",
-            groupId: "group-a",
-            value: "1",
-          });
-          await queue.send({ id: "next-alert", groupId: "group-a", value: "2" });
-
-          // The group must not be blocked by the terminal failure: the
-          // follow-up job for the same group still dispatches.
-          await vi.waitFor(
-            () => {
-              expect(processed.map((p) => p.id)).toContain("next-alert");
-            },
-            { timeout: 15000, interval: 100 },
-          );
-
-          // And the failed job left the queue without being re-fired.
-          expect(attemptsById.get("dead-webhook")).toBe(1);
+        await queue.send({
+          id: "dead-webhook",
+          groupId: "group-a",
+          value: "1",
         });
+        await queue.send({ id: "next-alert", groupId: "group-a", value: "2" });
+
+        // The group must not be blocked by the terminal failure: the
+        // follow-up job for the same group still dispatches.
+        await vi.waitFor(
+          () => {
+            expect(processed.map((p) => p.id)).toContain("next-alert");
+          },
+          { timeout: 15000, interval: 100 },
+        );
+
+        // And the failed job left the queue without being re-fired.
+        expect(attemptsById.get("dead-webhook")).toBe(1);
+        expect(await blockedMembers(name)).not.toContain("group-a");
+      });
+    });
+
+    describe("when a job fails with a non-retryable config DispatchError", () => {
+      /** @scenario 'A configuration or integrity failure is parked for an operator' */
+      it("parks the group for an operator instead of dead-lettering the broken invariant", async () => {
+        const processed: TestPayload[] = [];
+        const name = uniqueQueueName();
+        const queue = createQueue(
+          async (p) => {
+            if (p.id === "bad-config") {
+              // Same `retryable: false` as a terminal provider verdict, but the
+              // provider never rendered one — the config is broken on our side.
+              throw new DispatchError({
+                message: "Slack webhook URL is not a hooks.slack.com endpoint",
+                retryable: false,
+                disposition: "config",
+              });
+            }
+            processed.push(p);
+          },
+          { name, auditAdapter: stubAuditAdapter() },
+        );
+        await queue.waitUntilReady();
+
+        await queue.send({ id: "bad-config", groupId: "group-a", value: "1" });
+        await queue.send({ id: "next-alert", groupId: "group-a", value: "2" });
+
+        await vi.waitFor(
+          async () => {
+            expect(await blockedMembers(name)).toContain("group-a");
+          },
+          { timeout: 15000, interval: 100 },
+        );
+
+        // The group stays parked, so later work cannot proceed on the same
+        // broken config behind the operator's back.
+        expect(processed.map((p) => p.id)).not.toContain("next-alert");
+      });
+    });
+
+    describe("when a provider-terminal failure's dead transition cannot be recorded", () => {
+      /** @scenario 'A provider-terminal failure whose dead transition cannot be recorded stays recoverable' */
+      it("parks the job rather than completing it with no recovery surface", async () => {
+        const processed: TestPayload[] = [];
+        const name = uniqueQueueName();
+        const queue = createQueue(
+          async (p) => {
+            if (p.id === "dead-webhook") {
+              throw new DispatchError({
+                message: "Slack webhook dispatch failed: HTTP 404",
+                retryable: false,
+                disposition: "provider_terminal",
+              });
+            }
+            processed.push(p);
+          },
+          {
+            name,
+            // The side-store is down, so the dead row that would carry this
+            // alert to an operator was never written.
+            auditAdapter: stubAuditAdapter({ onDead: async () => false }),
+          },
+        );
+        await queue.waitUntilReady();
+
+        await queue.send({
+          id: "dead-webhook",
+          groupId: "group-a",
+          value: "1",
+        });
+
+        await vi.waitFor(
+          async () => {
+            expect(await blockedMembers(name)).toContain("group-a");
+          },
+          { timeout: 15000, interval: 100 },
+        );
+      });
+
+      it("treats a throwing audit adapter as an unrecorded transition", async () => {
+        const name = uniqueQueueName();
+        const queue = createQueue(
+          async () => {
+            throw new DispatchError({
+              message: "Slack webhook dispatch failed: HTTP 404",
+              retryable: false,
+              disposition: "provider_terminal",
+            });
+          },
+          {
+            name,
+            auditAdapter: stubAuditAdapter({
+              onDead: async () => {
+                throw new Error("postgres is down");
+              },
+            }),
+          },
+        );
+        await queue.waitUntilReady();
+
+        await queue.send({
+          id: "dead-webhook",
+          groupId: "group-a",
+          value: "1",
+        });
+
+        await vi.waitFor(
+          async () => {
+            expect(await blockedMembers(name)).toContain("group-a");
+          },
+          { timeout: 15000, interval: 100 },
+        );
       });
     });
   },

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../__tests__/integration/testContainers";
 import { GroupQueueProcessor } from "../groupQueue";
 import type { EventSourcedQueueDefinition } from "../../queue.types";
+import { DispatchError } from "../../../outbox/dispatchError";
 
 // Skip when running without testcontainers (unit-only test runs)
 const hasTestcontainers = !!(
@@ -765,6 +766,46 @@ describe.skipIf(!hasTestcontainers)(
             },
             { timeout: 45000, interval: 100 },
           );
+        });
+      });
+    });
+
+    describe("non-retryable dispatch failures", () => {
+      describe("when a job fails with a non-retryable DispatchError", () => {
+        /** @scenario 'A non-retryable dispatch failure leaves the queue instead of blocking the group' */
+        it("completes the job out of the queue so later jobs in the same group still dispatch", async () => {
+          const processed: TestPayload[] = [];
+          const attemptsById = new Map<string, number>();
+          const queue = createQueue(async (p) => {
+            attemptsById.set(p.id, (attemptsById.get(p.id) ?? 0) + 1);
+            if (p.id === "dead-webhook") {
+              throw new DispatchError({
+                message: "Slack webhook dispatch failed: HTTP 404",
+                retryable: false,
+              });
+            }
+            processed.push(p);
+          });
+          await queue.waitUntilReady();
+
+          await queue.send({
+            id: "dead-webhook",
+            groupId: "group-a",
+            value: "1",
+          });
+          await queue.send({ id: "next-alert", groupId: "group-a", value: "2" });
+
+          // The group must not be blocked by the terminal failure: the
+          // follow-up job for the same group still dispatches.
+          await vi.waitFor(
+            () => {
+              expect(processed.map((p) => p.id)).toContain("next-alert");
+            },
+            { timeout: 15000, interval: 100 },
+          );
+
+          // And the failed job left the queue without being re-fired.
+          expect(attemptsById.get("dead-webhook")).toBe(1);
         });
       });
     });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -26,7 +26,10 @@ import {
   type ProjectStorageDestination,
   redactStorageUrisInText,
 } from "../../../stored-objects/project-storage-destination";
-import { isDispatchError } from "../../outbox/dispatchError";
+import {
+  isDispatchError,
+  isProviderTerminal,
+} from "../../outbox/dispatchError";
 import type {
   DeduplicationConfig,
   EventSourcedQueueDefinition,
@@ -104,8 +107,13 @@ const DEFAULT_DEDUPLICATION_TTL_MS = 200;
  * Two non-retryable classes:
  * - event-sourcing errors categorized CRITICAL (validation/security/config)
  * - outbox `DispatchError`s explicitly marked `retryable: false` — the
- *   dispatcher rethrows these so the queue must dead-letter rather than
- *   re-fire a dispatch the dispatcher already judged unrecoverable.
+ *   dispatcher rethrows these so the queue never re-fires a dispatch the
+ *   dispatcher already judged unrecoverable.
+ *
+ * This decides only whether to re-fire. What becomes of a job that must not be
+ * re-fired is a separate call the failure branch makes on the error's
+ * disposition: a provider-terminal failure completes out of the queue, every
+ * other non-retryable failure parks for an operator.
  */
 export function isRetryableJobError(err: unknown): boolean {
   if (isDispatchError(err) && !err.retryable) return false;
@@ -702,6 +710,36 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   }
 
   /**
+   * Load-bearing counterpart to {@link runAudit} for the one transition a
+   * caller must not lose: `dead`. Returns whether the adapter durably recorded
+   * it, so the provider-terminal path can decide between completing the job and
+   * parking it. A thrown adapter reads as "not recorded" — the point is to
+   * distrust the write, not to let the queue die with it.
+   *
+   * A queue with no audit adapter has no dead row to strand, so there is
+   * nothing to confirm and the caller may proceed.
+   */
+  private async confirmDeadTransition(event: {
+    payload: Payload;
+    lastError: string;
+    attempt: number;
+  }): Promise<boolean> {
+    if (!this.auditAdapter) return true;
+    try {
+      return await this.auditAdapter.onDead(event);
+    } catch (err) {
+      this.logger.warn(
+        {
+          queueName: this.queueName,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        "Audit adapter onDead threw; treating the dead transition as unrecorded",
+      );
+      return false;
+    }
+  }
+
+  /**
    * fastq worker function: poison guard, then the real job processing.
    *
    * The guard records a claim strike BEFORE any decode/parse work and clears
@@ -1161,28 +1199,89 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 span.setAttribute("error", true);
                 span.setAttribute("error.message", error.message);
 
-                if (isDispatchError(err) && !err.retryable) {
-                  // The dispatch endpoint judged this failure terminal (e.g. a
-                  // revoked Slack webhook) and the outbox audit row is
-                  // dead-lettered via onDead below — that row is the operator's
+                // Only a provider's own terminal verdict (a revoked Slack
+                // webhook, a payload it will never accept) may leave the queue
+                // this way. A config/security/integrity DispatchError is also
+                // `retryable: false`, but it signals a broken invariant on our
+                // side — completing it would dead-letter the alert and let
+                // later work proceed on the same broken config, so it takes the
+                // park-for-operator path below like any other critical error.
+                if (isProviderTerminal(err)) {
+                  // Re-firing can never succeed, and blocking the group would
+                  // stall every later job for it, so the job completes out of
+                  // the queue and its dead outbox row becomes the operator's
                   // recovery surface (specs/event-sourcing/
-                  // reactor-outbox-dispatch.feature). Blocking the group and
-                  // re-staging here would keep re-firing a dispatch that can
-                  // never succeed and stall every later job for the same group,
-                  // so the job completes out of the queue instead.
-                  gqJobsNonRetryableTotal.inc(routingLabels);
-                  this.logger.error(
-                    {
-                      queueName: this.queueName,
+                  // reactor-outbox-dispatch.feature). That makes the dead
+                  // transition load-bearing rather than best-effort: record it
+                  // BEFORE dropping the job, or the row strands in
+                  // `dispatching` with nothing left to recover it.
+                  const deadRecorded = await this.confirmDeadTransition({
+                    payload,
+                    lastError: error.message,
+                    attempt,
+                  });
+
+                  // Drained siblings keep best-effort audit: their rows resync
+                  // on a later transition, and none of them owns the queue slot
+                  // this branch is about to complete.
+                  const siblings = (batchPayloads ?? []).filter(
+                    (p) => p !== payload,
+                  );
+                  await this.runAuditAll(
+                    siblings.map(
+                      (p) => () =>
+                        this.auditAdapter?.onDead({
+                          payload: p,
+                          lastError: error.message,
+                          attempt,
+                        }),
+                    ),
+                  );
+
+                  if (deadRecorded) {
+                    gqJobsNonRetryableTotal.inc(routingLabels);
+                    this.logger.error(
+                      {
+                        queueName: this.queueName,
+                        groupId,
+                        stagedJobId,
+                        attempt,
+                        errorCategory: category,
+                        error: error.message,
+                      },
+                      "Dispatch failed non-retryably; job completed out of the queue, dead outbox row is the recovery surface",
+                    );
+                    await this.scripts.complete({
                       groupId,
                       stagedJobId,
-                      attempt,
-                      errorCategory: category,
-                      error: error.message,
-                    },
-                    "Dispatch failed non-retryably; job completed out of the queue, dead outbox row is the recovery surface",
-                  );
-                  await this.scripts.complete({ groupId, stagedJobId, jobName });
+                      jobName,
+                    });
+                  } else {
+                    // The recovery surface does not exist, so the job is all
+                    // that is left of this dispatch. Park it instead: a later
+                    // operator-driven retry re-runs the terminal dispatch and
+                    // marks it dead once the side-store is writable again.
+                    this.logger.warn(
+                      {
+                        queueName: this.queueName,
+                        groupId,
+                        stagedJobId,
+                        attempt,
+                        errorCategory: category,
+                        error: error.message,
+                      },
+                      "Dispatch failed non-retryably but the dead transition was not durably recorded; parking the job so it stays recoverable",
+                    );
+                    await this.handleExhaustedRetries({
+                      groupId,
+                      stagedJobId,
+                      payload,
+                      originalScore,
+                      lastError: error,
+                      contextMetadata,
+                      routingLabels,
+                    });
+                  }
                 } else {
                   if (!isRetryable) {
                     gqJobsNonRetryableTotal.inc(routingLabels);
@@ -1208,20 +1307,23 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                     contextMetadata,
                     routingLabels,
                   });
+
+                  // Audit hook: terminal — onDead fires for the dispatched
+                  // payload + every drained sibling. Best-effort: the parked
+                  // job is itself the recovery surface here, so a lagging
+                  // projection loses nothing.
+                  await this.runAuditAll(
+                    (batchPayloads ?? [payload]).map(
+                      (p) => () =>
+                        this.auditAdapter?.onDead({
+                          payload: p,
+                          lastError: error.message,
+                          attempt,
+                        }),
+                    ),
+                  );
                 }
 
-                // Audit hook: terminal — onDead fires for the dispatched
-                // payload + every drained sibling.
-                await this.runAuditAll(
-                  (batchPayloads ?? [payload]).map(
-                    (p) => () =>
-                      this.auditAdapter?.onDead({
-                        payload: p,
-                        lastError: error.message,
-                        attempt,
-                      }),
-                  ),
-                );
                 await this.blobLifecycle.release({
                   values: [jobDataJson],
                   groupId,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1161,7 +1161,15 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 span.setAttribute("error", true);
                 span.setAttribute("error.message", error.message);
 
-                if (!isRetryable) {
+                if (isDispatchError(err) && !err.retryable) {
+                  // The dispatch endpoint judged this failure terminal (e.g. a
+                  // revoked Slack webhook) and the outbox audit row is
+                  // dead-lettered via onDead below — that row is the operator's
+                  // recovery surface (specs/event-sourcing/
+                  // reactor-outbox-dispatch.feature). Blocking the group and
+                  // re-staging here would keep re-firing a dispatch that can
+                  // never succeed and stall every later job for the same group,
+                  // so the job completes out of the queue instead.
                   gqJobsNonRetryableTotal.inc(routingLabels);
                   this.logger.error(
                     {
@@ -1172,19 +1180,35 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                       errorCategory: category,
                       error: error.message,
                     },
-                    "Job failed with non-retryable error, skipping retries",
+                    "Dispatch failed non-retryably; job completed out of the queue, dead outbox row is the recovery surface",
                   );
-                }
+                  await this.scripts.complete({ groupId, stagedJobId, jobName });
+                } else {
+                  if (!isRetryable) {
+                    gqJobsNonRetryableTotal.inc(routingLabels);
+                    this.logger.error(
+                      {
+                        queueName: this.queueName,
+                        groupId,
+                        stagedJobId,
+                        attempt,
+                        errorCategory: category,
+                        error: error.message,
+                      },
+                      "Job failed with non-retryable error, skipping retries",
+                    );
+                  }
 
-                await this.handleExhaustedRetries({
-                  groupId,
-                  stagedJobId,
-                  payload,
-                  originalScore,
-                  lastError: error,
-                  contextMetadata,
-                  routingLabels,
-                });
+                  await this.handleExhaustedRetries({
+                    groupId,
+                    stagedJobId,
+                    payload,
+                    originalScore,
+                    lastError: error,
+                    contextMetadata,
+                    routingLabels,
+                  });
+                }
 
                 // Audit hook: terminal — onDead fires for the dispatched
                 // payload + every drained sibling.

--- a/langwatch/src/server/event-sourcing/queues/queue.types.ts
+++ b/langwatch/src/server/event-sourcing/queues/queue.types.ts
@@ -243,11 +243,24 @@ export interface QueueAuditAdapter<Payload> {
     attempt: number;
   }): Promise<void>;
 
+  /**
+   * Records the terminal transition. Returns whether it was durably written:
+   * `true` only when the adapter's side-store acknowledged the write and it
+   * landed on a row.
+   *
+   * This is the one hook whose result a queue may act on. A dead row is the
+   * operator's only recovery surface for a job the queue is about to remove,
+   * so a queue that completes a job out of the queue must confirm the
+   * transition first (see the provider-terminal path in `groupQueue`) and keep
+   * the job recoverable when it returns `false`. Every other hook — and this
+   * one on the block/park path, where the parked job is itself the recovery
+   * surface — stays best-effort.
+   */
   onDead(event: {
     payload: Payload;
     lastError: string;
     attempt: number;
-  }): Promise<void>;
+  }): Promise<boolean>;
 }
 
 /**

--- a/langwatch/src/server/triggers/__tests__/sendSlackWebhook.unit.test.ts
+++ b/langwatch/src/server/triggers/__tests__/sendSlackWebhook.unit.test.ts
@@ -66,13 +66,14 @@ describe("sendSlackWebhook", () => {
   });
 
   describe("when the webhook was revoked", () => {
-    it("raises a non-retryable DispatchError", async () => {
+    it("raises a non-retryable DispatchError naming the HTTP status", async () => {
       sendMock.mockRejectedValue({
         original: { response: { status: 404 } },
       });
       const err = await callSlack().catch((e: unknown) => e);
       expect(err).toBeInstanceOf(DispatchError);
       expect((err as DispatchError).retryable).toBe(false);
+      expect((err as DispatchError).message).toContain("HTTP 404");
     });
   });
 
@@ -195,6 +196,55 @@ describe("sendSlackWebhook", () => {
       const err = await callSlack().catch((e: unknown) => e);
       expect(err).toBeInstanceOf(DispatchError);
       expect((err as DispatchError).retryable).toBe(true);
+    });
+  });
+
+  describe("when trace content exceeds the per-field limit", () => {
+    it("truncates input, output, and event values with an ellipsis instead of interpolating them whole", async () => {
+      sendMock.mockResolvedValue(undefined);
+      const hugeInput = "i".repeat(5000);
+      const hugeOutput = "o".repeat(5000);
+      const hugeDetail = "d".repeat(5000);
+      await sendSlackWebhook({
+        triggerWebhook: "https://hooks.slack.com/services/T/B/X",
+        triggerData: [
+          {
+            traceId: "trace-1",
+            input: hugeInput,
+            output: hugeOutput,
+            fullTrace: {
+              trace_id: "trace-1",
+              events: [
+                {
+                  event_type: "thumbs_up",
+                  metrics: {},
+                  event_details: { feedback: hugeDetail },
+                },
+              ],
+            } as unknown as Trace,
+          },
+        ],
+        triggerName: "Quality Alert",
+        projectSlug: "demo",
+        triggerType: AlertType.WARNING,
+        triggerMessage: "",
+      });
+
+      const text = sendMock.mock.calls[0]?.[0]?.text as string;
+      expect(text).not.toContain(hugeInput);
+      expect(text).not.toContain(hugeOutput);
+      expect(text).not.toContain(hugeDetail);
+      expect(text).toContain("i".repeat(500) + "…");
+      expect(text).toContain("o".repeat(500) + "…");
+      expect(text).toContain("d".repeat(500) + "…");
+    });
+
+    it("leaves short content untouched", async () => {
+      sendMock.mockResolvedValue(undefined);
+      await callSlack();
+      const text = sendMock.mock.calls[0]?.[0]?.text as string;
+      expect(text).toContain("*Input:* in");
+      expect(text).not.toContain("in…");
     });
   });
 });

--- a/langwatch/src/server/triggers/__tests__/sendSlackWebhook.unit.test.ts
+++ b/langwatch/src/server/triggers/__tests__/sendSlackWebhook.unit.test.ts
@@ -12,9 +12,44 @@ vi.mock("@slack/webhook", () => ({
 }));
 
 import {
+  MAX_TEXT_BYTES,
   sendRenderedSlackMessage,
   sendSlackWebhook,
 } from "../sendSlackWebhook";
+
+const dispatchedText = (): string =>
+  sendMock.mock.calls[0]?.[0]?.text as string;
+
+/** One trace carrying the given events, shaped like the trigger pipeline's. */
+function traceWith({
+  traceId,
+  input = "in",
+  output = "out",
+  events = [],
+}: {
+  traceId: string;
+  input?: string;
+  output?: string;
+  events?: unknown[];
+}) {
+  return {
+    traceId,
+    input,
+    output,
+    fullTrace: { trace_id: traceId, events } as unknown as Trace,
+  };
+}
+
+function sendWithTraces(triggerData: ReturnType<typeof traceWith>[]) {
+  return sendSlackWebhook({
+    triggerWebhook: "https://hooks.slack.com/services/T/B/X",
+    triggerData,
+    triggerName: "Quality Alert",
+    projectSlug: "demo",
+    triggerType: AlertType.WARNING,
+    triggerMessage: "",
+  });
+}
 
 function callSlack() {
   return sendSlackWebhook({
@@ -245,6 +280,152 @@ describe("sendSlackWebhook", () => {
       const text = sendMock.mock.calls[0]?.[0]?.text as string;
       expect(text).toContain("*Input:* in");
       expect(text).not.toContain("in…");
+    });
+  });
+
+  describe("when escaping inflates content past the per-field caps", () => {
+    it("keeps the dispatched payload within the byte budget", async () => {
+      sendMock.mockResolvedValue(undefined);
+      // Each field caps at 500 chars, but every `&` escapes to 5 chars, so ten
+      // traces of input+output alone reach ~50KB post-escape — the exact shape
+      // Slack rejects with a terminal 400.
+      const escapeHeavy = "&".repeat(500);
+      await sendWithTraces(
+        Array.from({ length: 10 }, (_, i) =>
+          traceWith({
+            traceId: `trace-${i}`,
+            input: escapeHeavy,
+            output: escapeHeavy,
+          }),
+        ),
+      );
+
+      const text = dispatchedText();
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(
+        MAX_TEXT_BYTES,
+      );
+      expect(text).toContain("[truncated]");
+    });
+
+    it("bounds a payload made of mixed mrkdwn control characters", async () => {
+      sendMock.mockResolvedValue(undefined);
+      const escapeHeavy = "<&>".repeat(200);
+      await sendWithTraces(
+        Array.from({ length: 10 }, (_, i) =>
+          traceWith({
+            traceId: `trace-${i}`,
+            input: escapeHeavy,
+            output: escapeHeavy,
+            events: Array.from({ length: 20 }, (_, e) => ({
+              event_type: `evt-${e}`,
+              metrics: Object.fromEntries(
+                Array.from({ length: 30 }, (_, m) => [`m${m}`, m]),
+              ),
+              event_details: Object.fromEntries(
+                Array.from({ length: 30 }, (_, d) => [`d${d}`, escapeHeavy]),
+              ),
+            })),
+          }),
+        ),
+      );
+
+      const text = dispatchedText();
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(
+        MAX_TEXT_BYTES,
+      );
+      expect(text).not.toContain("<&>");
+    });
+  });
+
+  describe("when a trace carries high-cardinality events", () => {
+    it("caps how many events are rendered per trace", async () => {
+      sendMock.mockResolvedValue(undefined);
+      await sendWithTraces([
+        traceWith({
+          traceId: "trace-1",
+          events: Array.from({ length: 50 }, (_, e) => ({
+            event_type: `evt-${e}`,
+            metrics: {},
+            event_details: {},
+          })),
+        }),
+      ]);
+
+      const text = dispatchedText();
+      expect(text).toContain("*Event Type:* evt-0");
+      expect(text).toContain("*Event Type:* evt-9");
+      expect(text).not.toContain("evt-10");
+      expect(text).not.toContain("evt-49");
+    });
+
+    it("caps how many metric and detail entries are rendered per event", async () => {
+      sendMock.mockResolvedValue(undefined);
+      await sendWithTraces([
+        traceWith({
+          traceId: "trace-1",
+          events: [
+            {
+              event_type: "thumbs_up",
+              metrics: Object.fromEntries(
+                Array.from({ length: 50 }, (_, m) => [`m${m}`, m]),
+              ),
+              event_details: Object.fromEntries(
+                Array.from({ length: 50 }, (_, d) => [`d${d}`, "v"]),
+              ),
+            },
+          ],
+        }),
+      ]);
+
+      const text = dispatchedText();
+      expect(text).toContain("*m0:*");
+      expect(text).toContain("*m19:*");
+      expect(text).not.toContain("*m20:*");
+      expect(text).toContain("*d0:*");
+      expect(text).not.toContain("*d20:*");
+    });
+
+    it("truncates an oversized entry key instead of interpolating it whole", async () => {
+      sendMock.mockResolvedValue(undefined);
+      const hugeKey = "k".repeat(5000);
+      await sendWithTraces([
+        traceWith({
+          traceId: "trace-1",
+          events: [
+            {
+              event_type: "thumbs_up",
+              metrics: {},
+              event_details: { [hugeKey]: "v" },
+            },
+          ],
+        }),
+      ]);
+
+      const text = dispatchedText();
+      expect(text).not.toContain(hugeKey);
+      expect(text).toContain("k".repeat(100) + "…");
+    });
+  });
+
+  describe("when the trigger name and message are customer-authored", () => {
+    it("escapes and bounds them like any other interpolated field", async () => {
+      sendMock.mockResolvedValue(undefined);
+      await sendSlackWebhook({
+        triggerWebhook: "https://hooks.slack.com/services/T/B/X",
+        triggerData: [],
+        triggerName: "<script>alert(1)</script>",
+        projectSlug: "demo",
+        triggerType: AlertType.WARNING,
+        triggerMessage: "a & b".repeat(500),
+      });
+
+      const text = dispatchedText();
+      expect(text).not.toContain("<script>");
+      expect(text).toContain("&lt;script&gt;");
+      expect(text).toContain("…");
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(
+        MAX_TEXT_BYTES,
+      );
     });
   });
 });

--- a/langwatch/src/server/triggers/sendSlackWebhook.ts
+++ b/langwatch/src/server/triggers/sendSlackWebhook.ts
@@ -22,6 +22,25 @@ const escapeMrkdwn = (value: unknown): string =>
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
 
+/**
+ * Trace content is unbounded customer data, but Slack rejects oversized
+ * webhook payloads with a terminal 400, which would dead-letter the alert.
+ * Bound every interpolated field so 10 traces of content always fit
+ * (see specs/triggers/slack-webhook-dispatch.feature). Truncate before
+ * escaping so the cut never lands mid-entity.
+ */
+const MAX_FIELD_LENGTH = 500;
+
+const truncateField = (value: unknown): string => {
+  const text = String(value ?? "");
+  return text.length > MAX_FIELD_LENGTH
+    ? text.slice(0, MAX_FIELD_LENGTH) + "…"
+    : text;
+};
+
+const formatField = (value: unknown): string =>
+  escapeMrkdwn(truncateField(value));
+
 interface TriggerData {
   traceId?: string;
   graphId?: string;
@@ -91,8 +110,8 @@ export const sendSlackWebhook = async ({
     return `\n<${getLink(trace)}|${getDisplayText(trace)}>
     ${
       !triggerMessage && !isCustomGraph
-        ? ` \n*Input:* ${escapeMrkdwn(trace.input)}
-    \n*Output:* ${escapeMrkdwn(trace.output)}\n`
+        ? ` \n*Input:* ${formatField(trace.input)}
+    \n*Output:* ${formatField(trace.output)}\n`
         : ""
     }
       ${
@@ -103,13 +122,13 @@ export const sendSlackWebhook = async ({
           ${Object.entries(event.metrics || {})
             .map(
               ([key, value]) =>
-                `\n*${escapeMrkdwn(key)}:* ${escapeMrkdwn(value)}`,
+                `\n*${escapeMrkdwn(key)}:* ${formatField(value)}`,
             )
             .join("")}
           ${Object.entries(event.event_details || {})
             .map(
               ([key, value]) =>
-                `\n*${escapeMrkdwn(key)}:* ${escapeMrkdwn(value)}`,
+                `\n*${escapeMrkdwn(key)}:* ${formatField(value)}`,
             )
             .join("")}
           \n-------------------`;

--- a/langwatch/src/server/triggers/sendSlackWebhook.ts
+++ b/langwatch/src/server/triggers/sendSlackWebhook.ts
@@ -25,21 +25,68 @@ const escapeMrkdwn = (value: unknown): string =>
 /**
  * Trace content is unbounded customer data, but Slack rejects oversized
  * webhook payloads with a terminal 400, which would dead-letter the alert.
- * Bound every interpolated field so 10 traces of content always fit
- * (see specs/triggers/slack-webhook-dispatch.feature). Truncate before
- * escaping so the cut never lands mid-entity.
+ * Bounding happens in two layers (see
+ * specs/triggers/slack-webhook-dispatch.feature): per-field caps keep any one
+ * value readable, and `boundTextBytes` below is the guarantee that the payload
+ * fits at all.
+ *
+ * Truncate before escaping so the cut never lands mid-entity.
  */
 const MAX_FIELD_LENGTH = 500;
 
-const truncateField = (value: unknown): string => {
+/** Metric and detail keys are customer-authored too, and far shorter in any
+ *  legitimate trace than the values they label. */
+const MAX_KEY_LENGTH = 100;
+
+/** A trace can carry any number of events, each with any number of metric and
+ *  detail entries. Bound both so the message stays proportional to a trace
+ *  rather than to its cardinality. */
+const MAX_EVENTS_PER_TRACE = 10;
+const MAX_ENTRIES_PER_EVENT = 20;
+
+/**
+ * Final backstop on the assembled message. Per-field caps alone cannot bound
+ * it: escaping runs after truncation and multiplies a field up to 5x (`&` ->
+ * `&amp;`), and traces, events, and entries each multiply the field count.
+ * Slack's practical `text` ceiling is ~40000 characters, so budget in bytes —
+ * always >= the character count — and leave headroom for the rest of the
+ * payload.
+ */
+export const MAX_TEXT_BYTES = 39_000;
+const TEXT_TRUNCATION_MARKER = "\n…[truncated]";
+
+const truncate = (value: unknown, maxLength: number): string => {
   const text = String(value ?? "");
-  return text.length > MAX_FIELD_LENGTH
-    ? text.slice(0, MAX_FIELD_LENGTH) + "…"
-    : text;
+  return text.length > maxLength ? text.slice(0, maxLength) + "…" : text;
 };
 
 const formatField = (value: unknown): string =>
-  escapeMrkdwn(truncateField(value));
+  escapeMrkdwn(truncate(value, MAX_FIELD_LENGTH));
+
+const formatKey = (value: unknown): string =>
+  escapeMrkdwn(truncate(value, MAX_KEY_LENGTH));
+
+/**
+ * Caps the fully-built, escaped text at the byte budget. Cuts on a UTF-8
+ * character boundary so a truncated emoji or multi-byte character can never
+ * leave an invalid sequence in the payload.
+ */
+const boundTextBytes = (text: string): string => {
+  const buffer = Buffer.from(text, "utf8");
+  if (buffer.length <= MAX_TEXT_BYTES) return text;
+
+  let end = MAX_TEXT_BYTES - Buffer.byteLength(TEXT_TRUNCATION_MARKER, "utf8");
+  // 0b10xxxxxx is a UTF-8 continuation byte; walk back off any of them to land
+  // on the start of a character.
+  while (end > 0 && ((buffer[end] ?? 0) & 0xc0) === 0x80) end--;
+  return buffer.toString("utf8", 0, end) + TEXT_TRUNCATION_MARKER;
+};
+
+const formatEntries = (entries: Record<string, unknown> | undefined): string =>
+  Object.entries(entries ?? {})
+    .slice(0, MAX_ENTRIES_PER_EVENT)
+    .map(([key, value]) => `\n*${formatKey(key)}:* ${formatField(value)}`)
+    .join("");
 
 interface TriggerData {
   traceId?: string;
@@ -117,20 +164,11 @@ export const sendSlackWebhook = async ({
       ${
         !isCustomGraph &&
         (trace.events ?? [])
-          .map((event: any) => {
-            return `\n*Event Type:* ${escapeMrkdwn(event.event_type)}
-          ${Object.entries(event.metrics || {})
-            .map(
-              ([key, value]) =>
-                `\n*${escapeMrkdwn(key)}:* ${formatField(value)}`,
-            )
-            .join("")}
-          ${Object.entries(event.event_details || {})
-            .map(
-              ([key, value]) =>
-                `\n*${escapeMrkdwn(key)}:* ${formatField(value)}`,
-            )
-            .join("")}
+          .slice(0, MAX_EVENTS_PER_TRACE)
+          .map((event) => {
+            return `\n*Event Type:* ${formatField(event.event_type)}
+          ${formatEntries(event.metrics)}
+          ${formatEntries(event.event_details)}
           \n-------------------`;
           })
           .join("")
@@ -151,11 +189,17 @@ export const sendSlackWebhook = async ({
     }
   };
 
+  // The trigger name and message are customer-authored and unbounded too, so
+  // they are formatted like any other interpolated field rather than trusted.
+  const text = boundTextBytes(
+    `${alertIcon(triggerType)} LangWatch Trigger - *${formatField(triggerName)}*
+       ${triggerMessage ? `\n\n*Msg:* ${formatField(triggerMessage)}` : ""}
+      \n${traceLinks.join("")}`,
+  );
+
   try {
     await webhook.send({
-      text: `${alertIcon(triggerType)} LangWatch Trigger - *${triggerName}*
-       ${triggerMessage ? `\n\n*Msg:* ${triggerMessage}` : ""}
-      \n${traceLinks.join("")}`,
+      text,
       username: "LangWatch",
       icon_emoji: ":robot_face:",
     });

--- a/specs/event-sourcing/dispatch-error-contract.feature
+++ b/specs/event-sourcing/dispatch-error-contract.feature
@@ -32,6 +32,13 @@ Feature: DispatchError contract for dispatch endpoints
     Then a DispatchError is raised
     And it is marked retryable
 
+  Scenario: Classified failures carry the provider's failure detail
+    Given a dispatch fails with a provider error carrying an HTTP status or message
+    When the failure is classified
+    Then the DispatchError message includes the HTTP status and the provider's message
+    So that an operator reading only the logged message can tell a revoked
+    webhook from a rejected payload without access to the cause object
+
   # Slack webhook endpoint
 
   Scenario: A failing Slack webhook no longer swallows the error

--- a/specs/event-sourcing/dispatch-error-contract.feature
+++ b/specs/event-sourcing/dispatch-error-contract.feature
@@ -10,6 +10,12 @@ Feature: DispatchError contract for dispatch endpoints
   outbox worker can choose between scheduling a backoff retry and surfacing
   the row to an operator as dead.
 
+  A failure that must not be retried still leaves open what becomes of the
+  job, so a classified failure also carries a disposition: whether the
+  provider itself returned the terminal verdict, or whether we rejected the
+  dispatch ourselves over our own configuration or integrity. Only the former
+  may leave the queue on its own.
+
   See dev/docs/adr/027-typed-dispatcherror-contract.md.
 
   # Classification policy (shared across all dispatch endpoints)
@@ -33,11 +39,42 @@ Feature: DispatchError contract for dispatch endpoints
     And it is marked retryable
 
   Scenario: Classified failures carry the provider's failure detail
-    Given a dispatch fails with a provider error carrying an HTTP status or message
+    Given a dispatch fails with a provider error carrying both an HTTP status and a message
     When the failure is classified
     Then the DispatchError message includes the HTTP status and the provider's message
     So that an operator reading only the logged message can tell a revoked
     webhook from a rejected payload without access to the cause object
+
+  Scenario: An oversized provider message is capped
+    Given a dispatch fails with a provider error whose message exceeds the cause limit
+    When the failure is classified
+    Then the DispatchError message carries the detail truncated to the limit with an ellipsis
+    So that one provider echoing a whole response body cannot flood the logs
+
+  Scenario: A provider message carrying a secret is scrubbed
+    Given a dispatch fails with a provider error that echoes a credential back in its message
+    When the failure is classified
+    Then the credential is replaced with a redaction marker before the message is built
+    So that a token cannot reach logs or audit rows by riding along on a failure
+
+  # Disposition policy: what a non-retryable failure means for the job
+
+  Scenario: A provider's own terminal verdict is dead-lettered out of the queue
+    Given a dispatch fails with a terminal HTTP status returned by the provider
+    When the failure is classified
+    Then the DispatchError is marked not retryable
+    And it is marked as a provider-terminal failure
+    So that the queue can drop a dispatch that can never succeed, rather than
+    stall every later job for the same group behind it
+
+  Scenario: A failure we classified ourselves is parked for an operator
+    Given a dispatch is rejected before any provider verdict, because its
+    configuration, security, or integrity check failed
+    When the failure is classified
+    Then the DispatchError is marked not retryable
+    And it is not marked as a provider-terminal failure
+    So that a broken invariant is parked for an operator to fix, rather than
+    silently dead-lettered while later work proceeds on the same broken config
 
   # Slack webhook endpoint
 

--- a/specs/event-sourcing/reactor-outbox-dispatch.feature
+++ b/specs/event-sourcing/reactor-outbox-dispatch.feature
@@ -113,6 +113,13 @@ Feature: Reactor Outbox dispatch for stake-sensitive reactors
       And no further attempts are scheduled
       And lastError records the error message
 
+    Scenario: A non-retryable dispatch failure leaves the queue instead of blocking the group
+      Given a group-queue job whose dispatch raises a non-retryable DispatchError
+      When the job fails
+      Then the job completes out of the queue rather than being re-staged
+      And the group is not blocked, so later jobs for the same group still dispatch
+      And the dead outbox row remains the operator's recovery surface
+
     Scenario: Worker crash mid-dispatch releases the lease and retries
       Given a row leased to a worker that never completed
       When the lease expires

--- a/specs/event-sourcing/reactor-outbox-dispatch.feature
+++ b/specs/event-sourcing/reactor-outbox-dispatch.feature
@@ -114,11 +114,31 @@ Feature: Reactor Outbox dispatch for stake-sensitive reactors
       And lastError records the error message
 
     Scenario: A non-retryable dispatch failure leaves the queue instead of blocking the group
-      Given a group-queue job whose dispatch raises a non-retryable DispatchError
+      Given a group-queue job whose dispatch raises a provider-terminal DispatchError
       When the job fails
+      And the dead outbox row is durably recorded
       Then the job completes out of the queue rather than being re-staged
       And the group is not blocked, so later jobs for the same group still dispatch
       And the dead outbox row remains the operator's recovery surface
+
+    Scenario: A configuration or integrity failure is parked for an operator
+      Given a group-queue job whose dispatch raises a non-retryable DispatchError
+      that no provider verdict backs — an invalid webhook URL, a missing token
+      or channel, a misrouted batch
+      When the job fails
+      Then the group is blocked and the job re-staged for an operator
+      So that a broken invariant is never silently dead-lettered, and later work
+      cannot proceed on the same broken configuration unnoticed
+
+    Scenario: A provider-terminal failure whose dead transition cannot be recorded stays recoverable
+      Given a group-queue job whose dispatch raises a provider-terminal DispatchError
+      When the job fails
+      And the dead outbox row cannot be durably recorded, because the side-store
+      is unavailable
+      Then the job is not completed out of the queue
+      And the group is blocked and the job re-staged instead
+      So that the dispatch is never dropped while the recovery surface that was
+      meant to carry it to an operator does not exist
 
     Scenario: Worker crash mid-dispatch releases the lease and retries
       Given a row leased to a worker that never completed

--- a/specs/triggers/slack-webhook-dispatch.feature
+++ b/specs/triggers/slack-webhook-dispatch.feature
@@ -1,0 +1,21 @@
+Feature: Legacy Slack webhook alert message building
+
+  Triggers without a custom template dispatch a plain-text Slack message built
+  from the matched traces: link, input, output, and event details. Trace
+  content is customer data with no size bound, but Slack rejects oversized
+  webhook payloads with a terminal 400, which would dead-letter the alert.
+  The builder therefore bounds every piece of interpolated trace content.
+
+  See specs/event-sourcing/dispatch-error-contract.feature for how a failed
+  post is classified and surfaced.
+
+  Scenario: Oversized trace content is truncated, not dropped
+    Given a trigger matches a trace whose input or output exceeds the per-field limit
+    When the Slack message is built
+    Then the field is truncated with an ellipsis rather than interpolated in full
+    And the alert still dispatches instead of being rejected by Slack for size
+
+  Scenario: Event metric and detail values are bounded too
+    Given a matched trace carries events with oversized metric or detail values
+    When the Slack message is built
+    Then each value is truncated to the per-field limit

--- a/specs/triggers/slack-webhook-dispatch.feature
+++ b/specs/triggers/slack-webhook-dispatch.feature
@@ -19,3 +19,24 @@ Feature: Legacy Slack webhook alert message building
     Given a matched trace carries events with oversized metric or detail values
     When the Slack message is built
     Then each value is truncated to the per-field limit
+
+  Scenario: Entry keys and the trigger's own name and message are bounded
+    Given a matched trace carries an oversized metric or detail key
+    Or the trigger's name or message is oversized
+    When the Slack message is built
+    Then each is truncated to its limit and escaped like any other interpolated field
+
+  Scenario: A high-cardinality trace does not multiply into an oversized message
+    Given a matched trace carries far more events, metrics, or details than an
+    operator could read in an alert
+    When the Slack message is built
+    Then only the first entries of each are interpolated
+    So that message size stays proportional to a trace rather than to its cardinality
+
+  Scenario: The assembled message is bounded, not just its fields
+    Given the built message would exceed Slack's size limit anyway — because
+    escaping inflates content after it was truncated, and every trace, event,
+    and entry multiplies the field count
+    When the Slack message is dispatched
+    Then the whole message is truncated to the byte budget with a clear marker
+    And the alert still dispatches instead of being rejected by Slack for size


### PR DESCRIPTION
## Why

Prod Slack dispatches for trigger `SN2ndrS8w98dL7PPSdB1m` ("hallucination detection(regex)") have been failing since 2026-07-13 with only:

```
Slack webhook dispatch failed for trigger "hallucination detection(regex)"
```

Two problems fell out of the investigation:

1. **The real cause is invisible.** The Slack HTTP status lives on `DispatchError.cause`, but every sink (outbox dispatcher log, group-queue audit rows, Sentry) serializes only `error.message` — so a revoked webhook (404 `no_service`) is indistinguishable from a rejected payload (400).
2. **The doomed dispatch never leaves the queue.** A non-retryable DispatchError went through `handleExhaustedRetries`, which blocked the group and re-staged the job — prod logs show the same job re-staging and re-firing across days (`.../r/…/r/…/r/…` chains), stalling every later job for the same trigger group.

## What

- `toDispatchError` now appends `HTTP <status> — <provider message>` (capped at 300 chars) to the DispatchError message, so all log sinks show the real failure. Existing DispatchErrors pass through unchanged; `retryable` overrides keep the detail.
- The group queue now **completes a non-retryable DispatchError out of the queue** instead of blocking the group and re-staging: the dead outbox audit row (via `onDead`, unchanged) is the operator's recovery surface, matching the existing spec promise that "no further attempts are scheduled". CRITICAL machinery errors (validation/security/config) keep the park-for-operator block.
- The legacy Slack alert builder interpolated full, unbounded trace input/output and event metric/detail values (up to 10 traces) into one message; Slack rejects oversized payloads with a terminal 400, dead-lettering the alert. Every field is now truncated to 500 chars with an ellipsis (before mrkdwn escaping, so the cut never lands mid-entity).

## Specs

- `specs/event-sourcing/dispatch-error-contract.feature`: classified failures carry the provider's failure detail.
- `specs/event-sourcing/reactor-outbox-dispatch.feature`: a non-retryable dispatch failure leaves the queue instead of blocking the group.
- `specs/triggers/slack-webhook-dispatch.feature` (new): oversized trace content is truncated, not dropped.

## Tests

- `dispatchError.unit.test.ts`: status+message in the wrapper, override keeps detail, oversized cause message capped, no-detail case untouched.
- `sendSlackWebhook.unit.test.ts`: revoked-webhook error names HTTP 404; oversized input/output/event values truncated with ellipsis; short content untouched.
- `groupQueue.integration.test.ts`: a job failing with a non-retryable DispatchError completes out of the queue — the next job in the same group still dispatches, and the failed job is not re-fired.
- All 223 group-queue integration tests (incl. poison guard) and all DispatchError-touching unit suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Operator-visible dispatch errors now consistently show provider HTTP status and details, with secret scrubbing and cause message truncation.
  - Group-queue handling for non-retryable failures is refined: provider-terminal errors complete out of the queue when the dead transition is durably recorded; configuration/integrity errors block for operator intervention.
  - Slack webhook alerts now strictly enforce payload size limits via truncation/byte bounds to avoid rejected deliveries.

- **Documentation**
  - Expanded specs covering dispatch error classification, truncation/redaction behavior, and the updated group-queue routing rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->