### PR TITLE
fix(scenarios): restore pino as direct dep so child bundle resolves it in prod

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -213,6 +213,8 @@
     "openai": "^6.45.0",
     "papaparse": "^5.5.4",
     "path-to-regexp": "^8.4.2",
+    "pino": "^10.3.1",
+    "pino-pretty": "^13.1.3",
     "posthog-js": "^1.396.9",
     "posthog-node": "^5.39.4",
     "prism-react-renderer": "^2.4.1",

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -508,6 +508,12 @@ importers:
       path-to-regexp:
         specifier: ^8.4.2
         version: 8.4.2
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
       posthog-js:
         specifier: ^1.396.9
         version: 1.396.9
@@ -1122,21 +1128,25 @@ packages:
     resolution: {integrity: sha512-Rw/lMbvoIUhum95LJz5nH/texhfZr1/5tbdd9O3gaeK+J7GFTlz1SJNN6JTPFl9TvGUiaItE7ImmnIV8brdBUg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@anthropic-ai/claude-code-linux-arm64@2.1.202':
     resolution: {integrity: sha512-9UBnDApKhqiUT3iX3i4hU8P4BztWvQkM5ZiLNBXPS4B9yBRrTc68fYG/I3WxC7Gt/+cV5ekTSGf8GUmMVpoERQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@anthropic-ai/claude-code-linux-x64-musl@2.1.202':
     resolution: {integrity: sha512-Vqt4PCWM04OCI8xQnVEIReT2ay/P2TUjCyeGadjcm2tndE5hdJBdqPHKYhAI9ON/VjjWHBt6bYjsuZNWOGmuBA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@anthropic-ai/claude-code-linux-x64@2.1.202':
     resolution: {integrity: sha512-R1nOSR/F0KkASK5rob/MQPpTmHi8/JvSrSbEDH29xlMWZCfwfeJyFsxhDY6qPG3fnKZFqpS1SMC8rohCiPwIxQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@anthropic-ai/claude-code-win32-arm64@2.1.202':
     resolution: {integrity: sha512-rEt9CcM0288tDW7QDZhV4udigP5Iz2EEklIlyns1yzZVrOZDIK/uGUSofJJ8Cv4eqbhNEA4R6dEXB+ErQ7AMsw==}
@@ -1581,24 +1591,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.5.1':
     resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.5.1':
     resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.5.1':
     resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
@@ -3799,36 +3813,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -4240,72 +4260,84 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.1.5':
     resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.3':
     resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.3':
     resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.3':
     resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.3':
     resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.3':
     resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.3':
     resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
@@ -4390,71 +4422,85 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -8530,24 +8576,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/langwatch/src/server/scenarios/execution/__tests__/child-process-bundle.integration.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/child-process-bundle.integration.test.ts
@@ -7,6 +7,7 @@
 
 import { execSync, spawnSync, spawn } from "child_process";
 import fs from "fs";
+import { isBuiltin } from "module";
 import path from "path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -115,5 +116,50 @@ describe("Pre-compiled Scenario Child Process", () => {
       // Exit code 1 = it started, read stdin, failed to parse (expected behavior)
       expect(result.exitCode).toBe(1);
     }, 8000);
+
+    // Regression guard for #5855: the bundle keeps some deps external (see the
+    // `external` list in scripts/build-scenario-child-process.mjs), so it emits
+    // runtime require("x") calls that MUST resolve from the bundle's own
+    // directory — the exact resolution root prod uses. An external that is only
+    // a transitive dep of a workspace package (e.g. pino via
+    // @langwatch/observability) is NOT top-linked into langwatch/node_modules by
+    // pnpm, so its require throws MODULE_NOT_FOUND at prod boot. #2404 caused
+    // exactly this by moving the pino family out of the app manifest.
+    it("resolves every externalized npm require() from a prod-shaped layout", () => {
+      const content = fs.readFileSync(BUNDLE_PATH, "utf8");
+      const distDir = path.dirname(BUNDLE_PATH);
+
+      // Externalized deps appear as bare `require("x")` in the CJS bundle.
+      const emitted = new Set<string>();
+      const re = /require\("([^".][^"]*)"\)/g;
+      for (const match of content.matchAll(re)) {
+        const name = match[1];
+        if (name) {
+          emitted.add(name);
+        }
+      }
+
+      const externalPkgs = [...emitted].filter(
+        (name) => !name.startsWith(".") && !isBuiltin(name),
+      );
+
+      // Sanity: the logger dep whose absence broke prod must be one of them —
+      // if it ever stops being emitted, this guard would silently pass empty.
+      expect(externalPkgs).toContain("pino");
+
+      // Every external npm package the bundle require()s at runtime MUST resolve
+      // from the bundle's directory. If any doesn't, it is not a *direct* app
+      // dep and prod boots into MODULE_NOT_FOUND (the #5855 crash).
+      const unresolved = externalPkgs.filter((name) => {
+        try {
+          require.resolve(name, { paths: [distDir] });
+          return false;
+        } catch {
+          return true;
+        }
+      });
+
+      expect(unresolved).toEqual([]);
+    });
   });
 });

--- a/langwatch/src/server/scenarios/execution/__tests__/child-process-bundle.integration.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/child-process-bundle.integration.test.ts
@@ -125,7 +125,7 @@ describe("Pre-compiled Scenario Child Process", () => {
     // @langwatch/observability) is NOT top-linked into langwatch/node_modules by
     // pnpm, so its require throws MODULE_NOT_FOUND at prod boot. #2404 caused
     // exactly this by moving the pino family out of the app manifest.
-    it("resolves every externalized npm require() from a prod-shaped layout", () => {
+    it("boots without MODULE_NOT_FOUND — every externalized require() resolves in a prod-shaped layout", () => {
       const content = fs.readFileSync(BUNDLE_PATH, "utf8");
       const distDir = path.dirname(BUNDLE_PATH);
 
@@ -147,9 +147,33 @@ describe("Pre-compiled Scenario Child Process", () => {
       // if it ever stops being emitted, this guard would silently pass empty.
       expect(externalPkgs).toContain("pino");
 
-      // Every external npm package the bundle require()s at runtime MUST resolve
-      // from the bundle's directory. If any doesn't, it is not a *direct* app
-      // dep and prod boots into MODULE_NOT_FOUND (the #5855 crash).
+      // PRIMARY — EXECUTE the affected code path (coding guideline: runtime
+      // regression tests must run the code and observe the crash, not just assert
+      // strings). #5855 was a top-level require("pino") throwing MODULE_NOT_FOUND
+      // at boot. Node resolves the bundle's externals relative to the bundle file
+      // (dist/) — the exact prod root — so spawning it here reproduces the crash
+      // if any external is unresolvable. Empty stdin makes it fail fast on job
+      // parsing AFTER module load, so any module error is a real regression.
+      const boot = spawnSync("node", [BUNDLE_PATH], {
+        cwd: distDir,
+        input: "",
+        stdio: "pipe",
+        env: {
+          ...process.env,
+          NODE_ENV: "test",
+          SKIP_ENV_VALIDATION: "1",
+          LANGWATCH_API_KEY: "test-key",
+          LANGWATCH_ENDPOINT: "http://localhost:9999",
+        },
+        timeout: 15000,
+      });
+      const bootStderr = boot.stderr?.toString() ?? "";
+      expect(bootStderr).not.toContain("MODULE_NOT_FOUND");
+      expect(bootStderr).not.toContain("Cannot find module");
+
+      // SUPPLEMENTARY — resolve each external from the prod-shaped root so a
+      // failure NAMES the exact unresolved module (the runtime check above only
+      // reports that *something* failed). Execute-the-path + precise attribution.
       const unresolved = externalPkgs.filter((name) => {
         try {
           require.resolve(name, { paths: [distDir] });


### PR DESCRIPTION
> **Reviewer cockpit**
> - **Scariest thing** — a runtime dependency-resolution fix. The existing `child-process-bundle.integration.test.ts` already *would* fail without pino, yet #2404 shipped this break green — so **the real risk is CI not running these integration tests in the merge gate**. The added guard is what makes the regression catchable; confirm it executes in CI or the next dep move silently re-breaks prod.
> - **Start here** — `langwatch/package.json` (+2 lines) and `scripts/build-scenario-child-process.mjs:34-42` (the `external` list). The invariant: every external the child bundle emits a `require()` for must be a **direct** app dep so pnpm top-links it into `langwatch/node_modules/`.

## Why

Closes #5855

**Customer-down P0.** Every production scenario run crashed at child-process boot with `Error: Cannot find module 'pino'` (`dist/scenario-child-process.js:80978`), so every run was reported verdict `failure`.

## What changed

Re-add **`pino`** and **`pino-pretty`** to the langwatch app's direct `dependencies` (+2 lines in `package.json`, +50 lines of importer edges in `pnpm-lock.yaml` — zero deletions, no other version changes), plus a **falsifiable regression guard test**.

## How it works

**Root cause is structural, not a code regression in the deploy range.**

- The scenario child runs in prod as a **pre-compiled esbuild bundle** that marks `pino` **external** → the bundle emits a runtime `require("pino")`.
- pino reaches the child only via `scenario-child-process.ts → child-logger → @langwatch/observability`. Commit **#2404 (`5fc087619`)** moved the pino family *out* of the app manifest *into* that workspace package.
- pino was then **neither a direct langwatch dep nor public-hoisted**, so pnpm stopped symlinking it into `langwatch/node_modules/pino`. Node resolving `require("pino")` from `dist/` finds it in **none** of `dist → langwatch/node_modules → /app/langwatch/node_modules` → `MODULE_NOT_FOUND`. `pnpm prune --prod` (Dockerfile:50) removes any last chance.
- Re-adding pino/pino-pretty as **direct deps** makes pnpm top-link them into `langwatch/node_modules/`, where the external `require()` resolves — surviving `pnpm prune --prod` (they're `dependencies`, not `devDependencies`; verified all four bundle externals — `pino`, `pino-pretty`, `@opentelemetry/api`, `@langwatch/scenario` — are prod deps).

**Why not rollback:** the delta (#2404) **predates** the last clean image pins, so rolling the deploy back does NOT fix it — fix-forward is the only durable option.

## Test plan

Guard test in `child-process-bundle.integration.test.ts`: builds the bundle, extracts every externalized bare `require("…")` it emits, asserts each resolves from a **prod-shaped** root. Proven RED→GREEN below.

## How I can prove I was successful

- **`proven` — RED/GREEN on the REAL prod artifact** (`node dist/scenario-child-process.js`, the exact command from `child-process-spawn.ts:53`). Toggling only the pino top-link this fix adds:
  ```
  RED  (pino de-linked / prod state): Error: Cannot find module 'pino'
                                        at Object.<anonymous> (…/dist/scenario-child-process.js:80978:27)  <-- SAME line as the #5855 stack trace
  GREEN (fix present):                 child boots past the require; pino's logger emits; fails only on the
                                        deliberately-invalid stdin I fed it.
  ```
- **`proven` — the REAL prod code path (transport worker), which the guard's `NODE_ENV=test` run does NOT exercise:**
  ```
  CASE 1  NODE_ENV=production, OTel off  -> pino/file transport worker runs, JSON logs emit, no MODULE_NOT_FOUND
  CASE 2  NODE_ENV=production, PINO_OTEL_ENABLED=true -> pino-opentelemetry-transport unresolved, but logger.ts:104
          try/catch catches it and falls back to stdout: "Failed to create pino transport, falling back to stdout".
          NO second crash — graceful degradation.
  ```
  (No deploy manifest sets `PINO_OTEL_ENABLED`; only a commented example in `.env.example:132`, so prod takes CASE 1.)
- **`proven` — guard test falsifiable:** 5 pass with the fix → 2 fail without (`expected ['pino'] to deeply equal []`).
- **`proven` — CI green:** `build`, `Analyze (js-ts/go/python)`, `changes`, `ci-scripts-test`, semantic-PR all passing; zero failures.
- **`proven` — a REAL scenario run PASSING on the fixed bundle.** Ran the fixed `dist/scenario-child-process.js` under `NODE_ENV=production` with valid job data; a local OpenAI-compatible stub stood in ONLY for the model provider (the `${nlpServiceUrl}/go/proxy/v1` NLP proxy — infra, not the fix). The real `@langwatch/scenario` runner executed the full **simulator → agent → judge** loop and the child emitted the exact result the parent processor consumes off stdout:
  ```
  model calls seen by stub: [ simulator(no tools), agent(no tools), judge(continue_test, finish_test) ]
  result: {"success":true,"reasoning":"stub: all criteria met"}
  PINO MODULE_NOT_FOUND in stderr? NO      SCENARIO PASSED? YES ✅
  ```
  The stub read the judge's real `finish_test` JSON-schema from its own request (`{criteria, reasoning, verdict:enum[success/failure/inconclusive]}`) and returned valid success args. Before the fix the child crashed at boot — **no scenario could run at all**; after it, a scenario runs end-to-end to a PASS. Model *content* is stubbed (irrelevant to a module-resolution fix); a full Docker-image run is the owner's post-merge deploy check (pino is a prod dep → survives `pnpm prune --prod`).

## Anything surprising?

- **OTLP-log export (not a crash):** with `PINO_OTEL_ENABLED=true`, `pino-opentelemetry-transport` (also dropped by #2404, still bundled not external) can't load in the worker, but it degrades to stdout (proven above). Restoring it as a direct dep would re-enable OTLP log export — an optional follow-up, **not** part of this crash fix.
- **CI coverage gap:** the *existing* boot test also reddens without pino, so #2404 should have been caught — strong signal these integration tests aren't in the merge-blocking gate. Worth a follow-up.
- **Do not merge on my behalf** — draft; the owner drives this to ready.


<!-- no-ui-surface -->

## Human verification
Backend-only change (module resolution in the scenario child-process bundle) — no user-facing UI surface; end-to-end proof of the fix working is in "How I can prove I was successful" above (real prod-artifact RED/GREEN + a passing simulator→agent→judge scenario run on the fixed bundle).

Reviewer steps:
1. Confirm `pino` and `pino-pretty` are restored as direct deps in `langwatch/package.json` and present in `pnpm-lock.yaml`.
2. Run the guard test `child-process-bundle.integration.test.ts`: 5 pass with the fix; reverting the pino top-link makes 2 fail (`expected ['pino'] to deeply equal []`).
3. Post-merge deploy check (owner): build the prod image and run a real scenario — confirm no `Cannot find module 'pino'` crash at child-process boot (pino is a prod dep → survives `pnpm prune --prod`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured required logging modules are explicitly included so production runtime has the dependencies it needs.
  * Added a regression test that verifies compiled server bundles resolve externals correctly, preventing `MODULE_NOT_FOUND` failures at startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->