### PR TITLE
fix(langy): constrain worker processes

### DIFF
--- a/Dockerfile.langyagent
+++ b/Dockerfile.langyagent
@@ -161,7 +161,7 @@ FROM debian:bookworm-slim
 # services/langyagent/internal/assets/AGENTS.md.
 ARG LANGWATCH_CLI_VERSION=0.31.0
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl git ca-certificates python3 \
+    curl git ca-certificates python3 util-linux \
     && rm -rf /var/lib/apt/lists/*
 # NOTE: `iptables` is no longer installed. The old loopback OWNER-match DROP
 # rule (services/langyagent/iptables.go) that closed the sibling-worker

--- a/services/langyagent/adapters/opencode/provision.go
+++ b/services/langyagent/adapters/opencode/provision.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -259,7 +258,7 @@ func (a *Agent) Provision(in ProvisionInput) error {
 // the turn that spawned it and only dies on idle/shutdown, but binding to the pool
 // context means a pool Shutdown / deadline still propagates to the subprocess.
 func (a *Agent) Spawn(ctx context.Context, in SpawnInput) (*exec.Cmd, error) {
-	cmd := exec.CommandContext(ctx, in.BinaryPath,
+	cmd := in.Runner.CommandContext(ctx, in.BinaryPath,
 		"serve", "--port", strconv.Itoa(in.Port), "--hostname", "127.0.0.1",
 	)
 	cmd.Env = buildWorkerEnv(in.ConversationID, in.Home, in.Creds, in.OpenCodePassword, in.EgressPort, in.Mediation, in.Capabilities)
@@ -289,68 +288,31 @@ func skillsDir(workerHome string) string {
 	return filepath.Join(workerHome, ".config", "opencode", "skills")
 }
 
-// sensitiveEnvPattern matches env names that must never reach a worker. The JS
-// manager listed these by name; the Go version mirrors that policy and extends
-// it with two suffix classes so arbitrary provider keys inherited from a
-// local-dev .env (OPENAI_API_KEY, ANTHROPIC_API_KEY, GROQ_API_KEY,
-// API_TOKEN_JWT_SECRET, ...) cannot reach a per-conversation OpenCode
-// subprocess. The worker still receives its own llmVirtualKey + langwatch API
-// key via Credentials.* — those are written into the env explicitly after this
-// filter, so blocking the inherited variants is the desired posture (only the
-// per-project Langy VK reaches the model, never the human's personal provider
-// key).
-//
-// This stays a DENYLIST for compatibility. ACKNOWLEDGED SUFFIX-GAP (ADR-047,
-// left as a comment ONLY — not widened in this PR): a denylist can never be
-// exhaustive; a var like `MY_APIKEY` (no separator before KEY) or a novel
-// secret prefix slips through. A true ALLOWLIST (PATH, HOME, LANG, USER, TZ +
-// the OTEL_/LANGY_/OPENCODE_ vars actually needed) is the more secure
-// long-term shape but requires testing every var an OpenCode subprocess might
-// legitimately read. Add new prefixes here when introducing manager-only
-// secrets; the allowlist migration is tracked separately.
-var sensitiveEnvPattern = regexp.MustCompile(
-	`^(LANGY_INTERNAL_SECRET$|GITHUB_LANGY_|CREDENTIALS_SECRET$|NEXTAUTH_|DATABASE_URL$|AWS_SECRET_|LW_GATEWAY_|LW_VIRTUAL_KEY_)` +
-		// `AWS_ACCESS_KEY_ID` ends in `_ID`, NOT `_KEY` — the suffix rules below
-		// would miss it. Anchor an explicit literal so the access-key half of an
-		// AWS credential pair can't leak.
-		`|^AWS_ACCESS_KEY_ID$` +
-		`|_(API_)?KEY$` +
-		`|_SECRET(_|$)` +
-		// `_TOKEN(_|$)` catches `GH_TOKEN`, `GITHUB_TOKEN`, `API_TOKEN_*`, etc. —
-		// the worker still receives an explicit `GH_TOKEN=` from buildWorkerEnv
-		// AFTER this filter, so blocking the inherited variant is correct (it
-		// would shadow the per-conversation creds otherwise). `_PASSWORD(_|$)`
-		// catches `POSTGRES_PASSWORD`/`REDIS_PASSWORD` and anything else an
-		// `envFrom: secretRef` mounts under that convention.
-		`|_TOKEN(_|$)` +
-		`|_PASSWORD(_|$)` +
-		// `_URL$` / `_URI$` block credential-bearing connection strings
-		// (`REDIS_URL=redis://user:pass@host:6379/0`, `POSTGRES_URL`,
-		// `MONGODB_URI`, `CLICKHOUSE_URL`, ...). The worker runs model-driven
-		// shell with HTTPS egress, so a prompt-injected turn could otherwise
-		// `env | grep -iE 'redis|postgres'` and exfiltrate the password embedded
-		// in the URL userinfo. `_DSN$` covers `SENTRY_DSN` and similar telemetry
-		// creds (DSNs embed the project key in the URL).
-		`|_URL$` +
-		`|_URI$` +
-		`|_DSN$`,
-)
+// workerInheritedEnvKeys is the complete set of manager environment variables
+// a worker may inherit. Everything security-sensitive is injected explicitly
+// below from the turn's scoped Credentials/Capabilities instead of relying on
+// naming conventions. An allowlist means a newly introduced manager secret is
+// private by default, regardless of its name.
+var workerInheritedEnvKeys = []string{
+	"PATH",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"TZ",
+	"TERM",
+	"COLORTERM",
+	"NO_COLOR",
+	"FORCE_COLOR",
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
+}
 
-// filterSensitiveEnv returns the process env minus anything matching
-// sensitiveEnvPattern. The worker gets its own credentials injected explicitly
-// after this filter.
-func filterSensitiveEnv() []string {
-	env := os.Environ()
-	out := make([]string, 0, len(env))
-	for _, kv := range env {
-		eq := strings.IndexByte(kv, '=')
-		if eq < 0 {
-			continue
+func workerBaseEnv() []string {
+	out := make([]string, 0, len(workerInheritedEnvKeys))
+	for _, key := range workerInheritedEnvKeys {
+		if value, ok := os.LookupEnv(key); ok {
+			out = append(out, key+"="+value)
 		}
-		if sensitiveEnvPattern.MatchString(kv[:eq]) {
-			continue
-		}
-		out = append(out, kv)
 	}
 	return out
 }
@@ -362,7 +324,7 @@ func filterSensitiveEnv() []string {
 const mediatedLLMPlaceholderKey = "langy-mediated"
 
 // buildWorkerEnv assembles the environment for a worker's opencode subprocess:
-// the filtered inherited env plus per-worker credentials and the per-worker
+// the allowlisted inherited env plus per-worker credentials and the per-worker
 // OPENCODE_SERVER_PASSWORD. Pure and side-effect free — factored out of Spawn so
 // it's unit-testable without spawning a real subprocess.
 //
@@ -376,7 +338,7 @@ const mediatedLLMPlaceholderKey = "langy-mediated"
 // rules; routing them through the per-worker proxy would add a hop and expose
 // LLM streaming to the throttle).
 func buildWorkerEnv(conversationID, workerHome string, creds domain.Credentials, openCodePassword string, egressPort int, med Mediation, caps []app.Capability) []string {
-	env := filterSensitiveEnv()
+	env := workerBaseEnv()
 
 	// LLM wiring. Mediated (phase 2): OPENAI_BASE_URL points at the manager's
 	// loopback relay, which injects the REAL virtual key + the turn's traceparent

--- a/services/langyagent/adapters/opencode/provision_test.go
+++ b/services/langyagent/adapters/opencode/provision_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/langwatch/langwatch/services/langyagent/domain"
 )
 
-func TestFilterSensitiveEnv_RemovesManagerSecrets(t *testing.T) {
+func TestWorkerBaseEnv_AllowsOnlyExplicitKeys(t *testing.T) {
 	for k, v := range map[string]string{
 		"LANGY_INTERNAL_SECRET": "must-not-leak",
 		"GITHUB_LANGY_APP_ID":   "must-not-leak",
@@ -44,15 +44,19 @@ func TestFilterSensitiveEnv_RemovesManagerSecrets(t *testing.T) {
 		"GH_TOKEN":          "ghp_inherited_must_not_leak",
 		"GITHUB_TOKEN":      "ghp_ci_token_must_not_leak",
 		"POSTGRES_PASSWORD": "must-not-leak",
+		// A novel secret-looking name and innocuous manager tuning are both
+		// absent: inheritance is allowlisted, not classified by name.
+		"MY_APIKEY":         "must-not-leak",
+		"LANGY_MAX_WORKERS": "must-not-leak",
+		"HOME":              "must-not-leak",
 		// PASS-THROUGH cases.
-		"LANGY_MAX_WORKERS":       "keep-me", // LANGY_ prefix but not the secret one
-		"HOME":                    "keep-me",
-		"LANGWATCH_API_KEY_OUTER": "keep-me", // worker injects its own after; _OUTER is neither _KEY nor _SECRET
+		"PATH": "/safe/bin",
+		"LANG": "C.UTF-8",
 	} {
 		t.Setenv(k, v)
 	}
 
-	env := filterSensitiveEnv()
+	env := workerBaseEnv()
 
 	mustBeAbsent := []string{
 		"LANGY_INTERNAL_SECRET=",
@@ -80,6 +84,9 @@ func TestFilterSensitiveEnv_RemovesManagerSecrets(t *testing.T) {
 		"GH_TOKEN=",
 		"GITHUB_TOKEN=",
 		"POSTGRES_PASSWORD=",
+		"MY_APIKEY=",
+		"LANGY_MAX_WORKERS=",
+		"HOME=",
 	}
 	for _, prefix := range mustBeAbsent {
 		for _, kv := range env {
@@ -89,10 +96,7 @@ func TestFilterSensitiveEnv_RemovesManagerSecrets(t *testing.T) {
 		}
 	}
 
-	mustBePresent := []string{
-		"LANGY_MAX_WORKERS=keep-me",
-		"LANGWATCH_API_KEY_OUTER=keep-me",
-	}
+	mustBePresent := []string{"PATH=/safe/bin", "LANG=C.UTF-8"}
 	for _, want := range mustBePresent {
 		found := false
 		for _, kv := range env {
@@ -106,8 +110,15 @@ func TestFilterSensitiveEnv_RemovesManagerSecrets(t *testing.T) {
 		}
 	}
 
-	if len(env) == 0 {
-		t.Fatalf("filterSensitiveEnv returned empty slice; PATH was %q", os.Getenv("PATH"))
+	allowed := make(map[string]bool, len(workerInheritedEnvKeys))
+	for _, key := range workerInheritedEnvKeys {
+		allowed[key] = true
+	}
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		if !allowed[key] {
+			t.Fatalf("workerBaseEnv inherited non-allowlisted key %q", key)
+		}
 	}
 }
 

--- a/services/langyagent/adapters/runner/localunsafe/localunsafe.go
+++ b/services/langyagent/adapters/runner/localunsafe/localunsafe.go
@@ -8,7 +8,9 @@
 package localunsafe
 
 import (
+	"context"
 	"fmt"
+	"os/exec"
 	"strings"
 	"syscall"
 
@@ -45,6 +47,10 @@ func New(environment string) (Runner, error) {
 
 // Name identifies the runner in logs and telemetry.
 func (Runner) Name() string { return "local-unsafe" }
+
+func (Runner) CommandContext(ctx context.Context, binary string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, binary, args...)
+}
 
 // Chown is a no-op: the unprivileged manager already owns the files it wrote, and
 // mode 0700 alone gates them (there is no sibling-UID separation in this mode).

--- a/services/langyagent/adapters/runner/localunsafe/localunsafe_test.go
+++ b/services/langyagent/adapters/runner/localunsafe/localunsafe_test.go
@@ -1,9 +1,21 @@
 package localunsafe
 
 import (
+	"context"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
+
+func TestCommandContext_ExecutesBinaryDirectly(t *testing.T) {
+	cmd := Runner{}.CommandContext(context.Background(), "/tmp/opencode", "serve")
+	if cmd.Path != "/tmp/opencode" {
+		t.Fatalf("command path = %q, want direct binary", cmd.Path)
+	}
+	if want := []string{"/tmp/opencode", "serve"}; !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("command args = %#v, want %#v", cmd.Args, want)
+	}
+}
 
 // SysProcAttr must omit the setuid Credential (opencode runs as the manager's own
 // user) but keep Setpgid so the manager can group-signal it on shutdown.

--- a/services/langyagent/adapters/runner/sandboxed/sandboxed.go
+++ b/services/langyagent/adapters/runner/sandboxed/sandboxed.go
@@ -8,7 +8,9 @@
 package sandboxed
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"syscall"
 
 	"github.com/langwatch/langwatch/services/langyagent/app"
@@ -27,6 +29,22 @@ func New() Runner { return Runner{} }
 
 // Name identifies the runner in logs and telemetry.
 func (Runner) Name() string { return "sandboxed" }
+
+// CommandContext applies per-worker process/file limits before execing
+// OpenCode. RLIMIT_NPROC is accounted per UID, which matches this runner's
+// per-conversation identity boundary. Memory remains a pod-level cgroup limit;
+// Bun's large virtual address reservation makes RLIMIT_AS unsuitable.
+func (Runner) CommandContext(ctx context.Context, binary string, args ...string) *exec.Cmd {
+	limitArgs := []string{
+		"--nproc=64:64",
+		"--nofile=1024:1024",
+		"--fsize=1073741824:1073741824",
+		"--core=0:0",
+		"--",
+		binary,
+	}
+	return exec.CommandContext(ctx, "/usr/bin/prlimit", append(limitArgs, args...)...)
+}
 
 // Chown gives path to the per-conversation UID. Explicit chown is what makes
 // "only the worker UID can read this" literal — without it the root manager

--- a/services/langyagent/adapters/runner/sandboxed/sandboxed_test.go
+++ b/services/langyagent/adapters/runner/sandboxed/sandboxed_test.go
@@ -1,9 +1,26 @@
 package sandboxed
 
 import (
+	"context"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
+
+func TestCommandContext_AppliesPerWorkerRlimits(t *testing.T) {
+	cmd := Runner{}.CommandContext(context.Background(), "/usr/local/bin/opencode", "serve")
+	if cmd.Path != "/usr/bin/prlimit" {
+		t.Fatalf("command path = %q, want prlimit", cmd.Path)
+	}
+	want := []string{
+		"/usr/bin/prlimit", "--nproc=64:64", "--nofile=1024:1024",
+		"--fsize=1073741824:1073741824", "--core=0:0", "--",
+		"/usr/local/bin/opencode", "serve",
+	}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("command args = %#v, want %#v", cmd.Args, want)
+	}
+}
 
 // SysProcAttr must drop the child into the per-conversation UID (setuid
 // Credential + empty supplementary groups) and keep Setpgid so the manager can

--- a/services/langyagent/app/runner.go
+++ b/services/langyagent/app/runner.go
@@ -1,6 +1,10 @@
 package app
 
-import "syscall"
+import (
+	"context"
+	"os/exec"
+	"syscall"
+)
 
 // Runner is the isolation substrate a worker's coding-agent process runs in —
 // the ADR-033 secure-vs-local seam, chosen ONCE at the composition root instead
@@ -15,6 +19,9 @@ import "syscall"
 // Implemented by adapters/runner/sandboxed and adapters/runner/localunsafe. The three
 // methods are precisely the operations that used to branch on the bool.
 type Runner interface {
+	// CommandContext builds the coding-agent command. Production wraps the
+	// binary with prlimit; local development executes it directly.
+	CommandContext(ctx context.Context, binary string, args ...string) *exec.Cmd
 	// Chown gives a provisioned file to the worker's per-conversation UID so a
 	// sibling worker cannot read it. A no-op in local mode (mode 0700 alone gates
 	// there, since the manager owns the files).


### PR DESCRIPTION
## What changed

- replace inherited manager environment filtering with an explicit worker allowlist
- start production OpenCode workers through `prlimit` with per-UID process and file ceilings
- keep local development portable by executing workers directly there
- install the small `util-linux` runtime dependency that provides `prlimit`

## Why

Langy workers execute model-driven shell commands. A denylist could leak newly introduced manager secrets, while an individual worker could otherwise fork without bound, exhaust descriptors, write very large files, or produce credential-bearing core dumps.

This is defense in depth for the current process-pool architecture. Hard per-worker memory and CPU isolation remains part of the future one-worker-per-gVisor-pod design.

## Deployment Impact

The Langy Agent runtime image adds Debian's `util-linux` package to provide `/usr/bin/prlimit`. No environment variables, Helm values, APIs, or default feature behavior change. Existing Langy workers restart with the next image deployment and then receive the new per-process limits. Vanilla Helm installs and BYOC dataplanes are otherwise unchanged.

## Validation

- `go test ./services/langyagent/...`
- exercised the exact `prlimit` invocation in the Debian runtime image
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Worker processes now receive only explicitly approved environment variables, reducing accidental exposure of secrets and manager settings.

* **Reliability**
  * Worker commands now honor context cancellation and timeouts.
  * Sandboxed workers continue to run with enforced per-process resource limits.

* **Maintenance**
  * Added required runtime support for process and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->