### PR TITLE
feat: batch map projection writes

### DIFF
--- a/langwatch/src/server/event-sourcing/__tests__/mapCommands.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/mapCommands.unit.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import { mapCommands } from "../mapCommands";
 import type { EventSourcedQueueProcessor } from "../queues";
 
-function createMockProcessor<P extends Record<string, unknown>>(): EventSourcedQueueProcessor<P> {
+function createMockProcessor<
+  P extends Record<string, unknown>,
+>(): EventSourcedQueueProcessor<P> {
   return {
     send: vi.fn().mockResolvedValue(undefined),
     sendBatch: vi.fn().mockResolvedValue(undefined),
@@ -39,6 +41,19 @@ describe("mapCommands", () => {
       await mapped.myCommand({ foo: "bar" }, options);
 
       expect(processor.send).toHaveBeenCalledWith({ foo: "bar" }, options);
+    });
+  });
+
+  describe("when called as a batch", () => {
+    it("delegates to processor.sendBatch", async () => {
+      const processor = createMockProcessor();
+      const mapped = mapCommands({ myCommand: processor });
+      const data = [{ foo: "one" }, { foo: "two" }];
+
+      await mapped.myCommand.sendBatch!(data);
+
+      expect(processor.sendBatch).toHaveBeenCalledWith(data, undefined);
+      expect(processor.send).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/mapCommands.ts
+++ b/langwatch/src/server/event-sourcing/mapCommands.ts
@@ -1,20 +1,28 @@
 import type { EventSourcedQueueProcessor, QueueSendOptions } from "./queues";
 
 /** Convert pipeline command dispatchers to plain async functions. */
+export type MappedCommand<P> = {
+  (data: P, options?: QueueSendOptions<P>): Promise<void>;
+  sendBatch?: (data: P[], options?: QueueSendOptions<P>) => Promise<void>;
+};
+
 export type MapCommands<
   T extends Record<string, EventSourcedQueueProcessor<any>>,
 > = {
   [K in keyof T]: T[K] extends EventSourcedQueueProcessor<infer P>
-    ? (data: P, options?: QueueSendOptions<P>) => Promise<void>
+    ? MappedCommand<P>
     : never;
 };
 
 export function mapCommands<
   T extends Record<string, EventSourcedQueueProcessor<any>>,
 >(commands: T): MapCommands<T> {
-  const result = {} as Record<string, (data: any, options?: QueueSendOptions<any>) => Promise<void>>;
+  const result = {} as Record<string, MappedCommand<any>>;
   for (const [name, processor] of Object.entries(commands)) {
-    result[name] = (data, options) => processor.send(data, options);
+    const command = ((data, options) =>
+      processor.send(data, options)) as MappedCommand<any>;
+    command.sendBatch = (data, options) => processor.sendBatch(data, options);
+    result[name] = command;
   }
   return result as MapCommands<T>;
 }

--- a/langwatch/src/server/event-sourcing/projections/__tests__/mapProjectionExecutor.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/mapProjectionExecutor.test.ts
@@ -176,4 +176,31 @@ describe("MapProjectionExecutor.executeBatch", () => {
     );
     expect(store.append).not.toHaveBeenCalled();
   });
+
+  describe("when the store has no bulkAppend", () => {
+    it("refuses the batch instead of appending record by record", async () => {
+      const executor = new MapProjectionExecutor();
+      const store = createMockAppendStore<{ aggregateId: string }>();
+      const mapDef = createMockMapProjectionDefinition("mapper", {
+        store,
+        map: (event) => ({ aggregateId: String(event.aggregateId) }),
+      });
+      const events = ["one", "two"].map((aggregateId) =>
+        createTestEvent(aggregateId, TEST_CONSTANTS.AGGREGATE_TYPE, tenantId),
+      );
+      const contexts = events.map((event) => ({
+        aggregateId: String(event.aggregateId),
+        tenantId,
+        retentionPolicy: { traces: 49, scenarios: 49, experiments: 49 },
+      }));
+
+      await expect(
+        executor.executeBatch(mapDef, events, contexts),
+      ).rejects.toThrow(/no bulkAppend/);
+
+      // The point of refusing: a sequential loop that committed "one" and then
+      // threw on "two" would append "one" twice when the queue retried.
+      expect(store.append).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/projections/__tests__/mapProjectionExecutor.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/mapProjectionExecutor.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MapProjectionExecutor } from "../mapProjectionExecutor";
 import {
   createMockAppendStore,
   createMockMapProjectionDefinition,
@@ -7,6 +6,7 @@ import {
   createTestTenantId,
   TEST_CONSTANTS,
 } from "../../services/__tests__/testHelpers";
+import { MapProjectionExecutor } from "../mapProjectionExecutor";
 import type { ProjectionStoreContext } from "../projectionStoreContext";
 
 describe("MapProjectionExecutor.execute", () => {
@@ -103,9 +103,9 @@ describe("MapProjectionExecutor.execute", () => {
         tenantId,
       };
 
-      await expect(
-        executor.execute(mapDef, event, context),
-      ).rejects.toThrow("map failed");
+      await expect(executor.execute(mapDef, event, context)).rejects.toThrow(
+        "map failed",
+      );
     });
   });
 
@@ -132,9 +132,48 @@ describe("MapProjectionExecutor.execute", () => {
         tenantId,
       };
 
-      await expect(
-        executor.execute(mapDef, event, context),
-      ).rejects.toThrow("append failed");
+      await expect(executor.execute(mapDef, event, context)).rejects.toThrow(
+        "append failed",
+      );
     });
+  });
+});
+
+describe("MapProjectionExecutor.executeBatch", () => {
+  const tenantId = createTestTenantId();
+
+  it("persists mapped records with one tenant-scoped bulk append", async () => {
+    const executor = new MapProjectionExecutor();
+    const store = createMockAppendStore<{ aggregateId: string }>();
+    const bulkAppend = vi.fn(async () => undefined);
+    store.bulkAppend = bulkAppend;
+    const mapDef = createMockMapProjectionDefinition("mapper", {
+      store,
+      map: (event) => ({ aggregateId: String(event.aggregateId) }),
+    });
+    const events = ["one", "two"].map((aggregateId) =>
+      createTestEvent(aggregateId, TEST_CONSTANTS.AGGREGATE_TYPE, tenantId),
+    );
+    const contexts = events.map((event) => ({
+      aggregateId: String(event.aggregateId),
+      tenantId,
+      retentionPolicy: { traces: 49, scenarios: 49, experiments: 49 },
+    }));
+
+    const result = await executor.executeBatch(mapDef, events, contexts);
+
+    expect(result.map(({ record }) => record)).toEqual([
+      { aggregateId: "one" },
+      { aggregateId: "two" },
+    ]);
+    expect(bulkAppend).toHaveBeenCalledTimes(1);
+    expect(bulkAppend).toHaveBeenCalledWith(
+      [{ aggregateId: "one" }, { aggregateId: "two" }],
+      {
+        tenantId,
+        retentionPolicy: { traces: 49, scenarios: 49, experiments: 49 },
+      },
+    );
+    expect(store.append).not.toHaveBeenCalled();
   });
 });

--- a/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
@@ -1045,6 +1045,52 @@ describe("ProjectionRouter", () => {
     });
   });
 
+  describe("initializeMapQueues (coalescing gate)", () => {
+    const registerAndInitialize = (
+      store: ReturnType<typeof createMockAppendStore<{ id: string }>>,
+    ) => {
+      const queueManager = createMockQueueManager();
+      const router = new ProjectionRouter(
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        TEST_CONSTANTS.PIPELINE_NAME,
+        queueManager,
+      );
+      router.registerMapProjection(
+        createMockMapProjectionDefinition("mapper", {
+          store,
+          eventTypes: [TEST_CONSTANTS.EVENT_TYPE_1],
+          options: { coalesceMaxBatch: 256 },
+        }),
+      );
+
+      router.initializeMapQueues();
+
+      const [handlerDefs] = (
+        queueManager.initializeHandlerQueues as ReturnType<typeof vi.fn>
+      ).mock.calls[0]!;
+      return handlerDefs.mapper.options;
+    };
+
+    describe("when the store implements bulkAppend", () => {
+      it("passes the configured batch size to the queue", () => {
+        const store = createMockAppendStore<{ id: string }>();
+        store.bulkAppend = vi.fn(async () => undefined);
+
+        expect(registerAndInitialize(store).coalesceMaxBatch).toBe(256);
+      });
+    });
+
+    describe("when the store has no bulkAppend", () => {
+      it("drops the batch size so the queue keeps per-event delivery", () => {
+        // Without an all-or-nothing write, a batch that failed part-way would
+        // be re-dispatched whole and duplicate its committed prefix.
+        const store = createMockAppendStore<{ id: string }>();
+
+        expect(registerAndInitialize(store).coalesceMaxBatch).toBeUndefined();
+      });
+    });
+  });
+
   describe("replay marker on map projections", () => {
     describe("when marker returns 'skip'", () => {
       it("does not invoke map.append for that event", async () => {

--- a/langwatch/src/server/event-sourcing/projections/mapProjection.types.ts
+++ b/langwatch/src/server/event-sourcing/projections/mapProjection.types.ts
@@ -1,6 +1,6 @@
 import type { ResolvedRetention } from "../../data-retention/retentionPolicy.schema";
-import type { Event } from "../domain/types";
 import type { TenantId } from "../domain/tenantId";
+import type { Event } from "../domain/types";
 import type { KillSwitchOptions } from "../pipeline/staticBuilder.types";
 import type { ProjectionStoreContext } from "./projectionStoreContext";
 
@@ -25,10 +25,7 @@ import type { ProjectionStoreContext } from "./projectionStoreContext";
  * };
  * ```
  */
-export interface MapProjectionDefinition<
-  Record,
-  E extends Event = Event,
-> {
+export interface MapProjectionDefinition<Record, E extends Event = Event> {
   /** Unique name for this projection within the pipeline. */
   name: string;
 
@@ -78,6 +75,13 @@ export interface MapProjectionOptions {
 
   /** Custom group key function for queue routing. Enables per-item parallelism instead of per-aggregate serialization. */
   groupKeyFn?: (event: any) => string;
+
+  /**
+   * Maximum same-group events to persist through one `bulkAppend` call.
+   * Requires the store to implement `bulkAppend`; the queue keeps the batch
+   * tenant-scoped because tenant identity is always part of its group key.
+   */
+  coalesceMaxBatch?: number;
 
   /**
    * Skip events that are DUPLICATE deliveries of an earlier event with the

--- a/langwatch/src/server/event-sourcing/projections/mapProjection.types.ts
+++ b/langwatch/src/server/event-sourcing/projections/mapProjection.types.ts
@@ -78,8 +78,16 @@ export interface MapProjectionOptions {
 
   /**
    * Maximum same-group events to persist through one `bulkAppend` call.
-   * Requires the store to implement `bulkAppend`; the queue keeps the batch
-   * tenant-scoped because tenant identity is always part of its group key.
+   *
+   * Only honoured when the store implements `bulkAppend`. A store without it
+   * keeps per-event delivery and this option is ignored, with a warning at
+   * registration. That is a correctness requirement rather than an
+   * optimisation: queue delivery is at-least-once, so a batch that failed
+   * half-way through a per-record loop would duplicate its already-committed
+   * prefix when the queue re-ran it.
+   *
+   * The queue keeps the batch tenant-scoped because tenant identity is always
+   * part of its group key.
    */
   coalesceMaxBatch?: number;
 

--- a/langwatch/src/server/event-sourcing/projections/mapProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/mapProjectionExecutor.ts
@@ -53,8 +53,16 @@ export class MapProjectionExecutor {
   }
 
   /**
-   * Maps a same-tenant queue batch and persists it with one store operation
-   * when the projection exposes `bulkAppend`.
+   * Maps a same-tenant queue batch and persists it with ONE `bulkAppend` call.
+   *
+   * `bulkAppend` is required, not preferred. Queue delivery is at-least-once:
+   * a batch that throws part-way is re-dispatched in full, so persistence has
+   * to be all-or-nothing for the retry to be safe. A per-record `append` loop
+   * would commit records 1..N, fail on N+1, and duplicate that prefix on the
+   * retry — and map projections write to additive stores, where a duplicate is
+   * an extra row rather than an overwrite. `ProjectionRouter` enforces this by
+   * refusing to enable coalescing for a store without `bulkAppend`; the throw
+   * below is the backstop for any other caller.
    */
   async executeBatch<Record, E extends Event>(
     projection: MapProjectionDefinition<Record, E>,
@@ -63,6 +71,13 @@ export class MapProjectionExecutor {
   ): Promise<Array<{ event: E; record: Record }>> {
     if (events.length !== contexts.length) {
       throw new Error("Map projection batch events and contexts must align");
+    }
+
+    const bulkAppend = projection.store.bulkAppend;
+    if (!bulkAppend) {
+      throw new Error(
+        `Map projection "${projection.name}" cannot be batched: its store has no bulkAppend, and a partially-committed batch would duplicate records when the queue retries it`,
+      );
     }
 
     const mapped: Array<{
@@ -85,26 +100,21 @@ export class MapProjectionExecutor {
 
     if (mapped.length === 0) return [];
 
-    if (projection.store.bulkAppend) {
-      const first = mapped[0]!.context;
-      const bulkContext: BulkAppendContext = {
-        tenantId: first.tenantId,
-        retentionPolicy: first.retentionPolicy,
-      };
-      for (const item of mapped) {
-        if (item.context.tenantId !== bulkContext.tenantId) {
-          throw new Error("Map projection batches cannot cross tenants");
-        }
-      }
-      await projection.store.bulkAppend(
-        mapped.map(({ record }) => record),
-        bulkContext,
-      );
-    } else {
-      for (const { record, context } of mapped) {
-        await projection.store.append(record, context);
+    const first = mapped[0]!.context;
+    const bulkContext: BulkAppendContext = {
+      tenantId: first.tenantId,
+      retentionPolicy: first.retentionPolicy,
+    };
+    for (const item of mapped) {
+      if (item.context.tenantId !== bulkContext.tenantId) {
+        throw new Error("Map projection batches cannot cross tenants");
       }
     }
+    await bulkAppend.call(
+      projection.store,
+      mapped.map(({ record }) => record),
+      bulkContext,
+    );
 
     return mapped.map(({ event, record }) => ({ event, record }));
   }

--- a/langwatch/src/server/event-sourcing/projections/mapProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/mapProjectionExecutor.ts
@@ -1,6 +1,9 @@
 import { createLogger } from "@langwatch/observability";
 import type { Event } from "../domain/types";
-import type { MapProjectionDefinition } from "./mapProjection.types";
+import type {
+  BulkAppendContext,
+  MapProjectionDefinition,
+} from "./mapProjection.types";
 import type { ProjectionStoreContext } from "./projectionStoreContext";
 
 const logger = createLogger("langwatch:event-sourcing:map-executor");
@@ -47,6 +50,63 @@ export class MapProjectionExecutor {
     await projection.store.append(record, context);
 
     return record;
+  }
+
+  /**
+   * Maps a same-tenant queue batch and persists it with one store operation
+   * when the projection exposes `bulkAppend`.
+   */
+  async executeBatch<Record, E extends Event>(
+    projection: MapProjectionDefinition<Record, E>,
+    events: readonly E[],
+    contexts: readonly ProjectionStoreContext[],
+  ): Promise<Array<{ event: E; record: Record }>> {
+    if (events.length !== contexts.length) {
+      throw new Error("Map projection batch events and contexts must align");
+    }
+
+    const mapped: Array<{
+      event: E;
+      record: Record;
+      context: ProjectionStoreContext;
+    }> = [];
+    for (let index = 0; index < events.length; index++) {
+      const event = events[index]!;
+      const context = contexts[index]!;
+      if (
+        projection.options?.dedupeByIdempotencyKey &&
+        (await this.isDuplicateDelivery(projection, event, context))
+      ) {
+        continue;
+      }
+      const record = projection.map(event);
+      if (record !== null) mapped.push({ event, record, context });
+    }
+
+    if (mapped.length === 0) return [];
+
+    if (projection.store.bulkAppend) {
+      const first = mapped[0]!.context;
+      const bulkContext: BulkAppendContext = {
+        tenantId: first.tenantId,
+        retentionPolicy: first.retentionPolicy,
+      };
+      for (const item of mapped) {
+        if (item.context.tenantId !== bulkContext.tenantId) {
+          throw new Error("Map projection batches cannot cross tenants");
+        }
+      }
+      await projection.store.bulkAppend(
+        mapped.map(({ record }) => record),
+        bulkContext,
+      );
+    } else {
+      for (const { record, context } of mapped) {
+        await projection.store.append(record, context);
+      }
+    }
+
+    return mapped.map(({ event, record }) => ({ event, record }));
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -686,7 +686,7 @@ export class ProjectionRouter<
           concurrency: mapProj.options?.concurrency,
           disabled: mapProj.options?.disabled,
           groupKeyFn: mapProj.options?.groupKeyFn,
-          coalesceMaxBatch: mapProj.options?.coalesceMaxBatch,
+          coalesceMaxBatch: this.resolveCoalesceMaxBatch(mapProj),
         },
       };
     }
@@ -716,6 +716,41 @@ export class ProjectionRouter<
         await handlerDef.handler.handleBatch(events);
       },
     );
+  }
+
+  /**
+   * Resolves the coalescing batch size the queue may use for a map projection.
+   *
+   * Coalescing is only safe when the store can persist the whole batch in ONE
+   * operation. Queue delivery is at-least-once: if a batch throws part-way, the
+   * GroupQueue re-stages the dispatched job AND every drained sibling and runs
+   * the whole batch again. A per-record loop that already committed records
+   * 1..N before failing on N+1 would therefore append that prefix twice, and
+   * the additive stores behind map projections (ClickHouse spans, logs,
+   * metrics) turn a double append into duplicate rows, not an overwrite.
+   *
+   * `bulkAppend` is all-or-nothing, so a retry re-runs a batch that committed
+   * nothing. Without it we drop back to per-event delivery, where each event is
+   * its own retryable unit — slower, but never duplicating.
+   */
+  private resolveCoalesceMaxBatch(
+    mapProj: MapProjectionDefinition<any, EventType>,
+  ): number | undefined {
+    const configured = mapProj.options?.coalesceMaxBatch;
+    if (!configured || configured <= 1) return undefined;
+
+    if (!mapProj.store.bulkAppend) {
+      this.logger.warn(
+        {
+          projection: mapProj.name,
+          coalesceMaxBatch: configured,
+        },
+        "Ignoring coalesceMaxBatch — the projection store has no bulkAppend, and a partially-committed sequential batch would duplicate records on retry. Falling back to per-event delivery.",
+      );
+      return undefined;
+    }
+
+    return configured;
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -568,7 +568,10 @@ export class ProjectionRouter<
       string,
       {
         name: string;
-        handler: { handle: (event: EventType) => Promise<void> };
+        handler: {
+          handle: (event: EventType) => Promise<void>;
+          handleBatch: (events: EventType[]) => Promise<void>;
+        };
         options: any;
       }
     > = {};
@@ -620,6 +623,62 @@ export class ProjectionRouter<
               });
             }
           },
+          handleBatch: async (events: EventType[]) => {
+            const toApply: EventType[] = [];
+            for (const event of events) {
+              if (this.replayMarkerChecker) {
+                const decision = await this.replayMarkerChecker.check(
+                  name,
+                  event,
+                );
+                if (decision === "skip") continue;
+              }
+              toApply.push(event);
+            }
+            if (toApply.length === 0) return;
+
+            const firstContext = await this.buildStoreContext(toApply[0]!);
+            const contexts = toApply.map((event) => ({
+              ...firstContext,
+              aggregateId: String(event.aggregateId),
+            }));
+            const mapped = await withMetrics({
+              fn: () =>
+                this.mapExecutor.executeBatch(mapProj, toApply, contexts),
+              onComplete: (ms) => {
+                for (const _event of toApply) {
+                  incrementEsMapProjectionTotal(
+                    this.pipelineName,
+                    name,
+                    "completed",
+                  );
+                }
+                observeEsMapProjectionDuration(this.pipelineName, name, ms);
+              },
+              onFail: (ms) => {
+                for (const _event of toApply) {
+                  incrementEsMapProjectionTotal(
+                    this.pipelineName,
+                    name,
+                    "failed",
+                  );
+                }
+                observeEsMapProjectionDuration(this.pipelineName, name, ms);
+              },
+            });
+
+            const mapReactors = this.reactorsForMap.get(name);
+            if (mapReactors && mapReactors.length > 0) {
+              for (const { event, record } of mapped) {
+                await this.dispatchToReactors({
+                  foldName: name,
+                  reactors: mapReactors,
+                  events: [event],
+                  foldState: record,
+                });
+              }
+            }
+          },
         },
         options: {
           eventTypes: mapProj.eventTypes as readonly string[],
@@ -627,6 +686,7 @@ export class ProjectionRouter<
           concurrency: mapProj.options?.concurrency,
           disabled: mapProj.options?.disabled,
           groupKeyFn: mapProj.options?.groupKeyFn,
+          coalesceMaxBatch: mapProj.options?.coalesceMaxBatch,
         },
       };
     }
@@ -643,6 +703,17 @@ export class ProjectionRouter<
           );
         }
         await handlerDef.handler.handle(event);
+      },
+      async (handlerName, events, _context) => {
+        const handlerDef = handlerDefs[handlerName];
+        if (!handlerDef) {
+          throw new ConfigurationError(
+            "ProjectionRouter",
+            `Map projection handler "${handlerName}" not found`,
+            { handlerName },
+          );
+        }
+        await handlerDef.handler.handleBatch(events);
       },
     );
   }
@@ -1465,7 +1536,6 @@ export class ProjectionRouter<
         reactor.name,
         events.length - survivors.length,
       );
-      // biome-ignore lint/style/noNonNullAssertion: every index came from `events`.
       return survivors.map((index) => events[index]!);
     } catch (error) {
       // Fail open, like `shouldReact`: a throwing job-id function must never

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -733,8 +733,8 @@ export class ProjectionRouter<
    * nothing. Without it we drop back to per-event delivery, where each event is
    * its own retryable unit — slower, but never duplicating.
    */
-  private resolveCoalesceMaxBatch(
-    mapProj: MapProjectionDefinition<any, EventType>,
+  private resolveCoalesceMaxBatch<Record>(
+    mapProj: MapProjectionDefinition<Record, EventType>,
   ): number | undefined {
     const configured = mapProj.options?.coalesceMaxBatch;
     if (!configured || configured <= 1) return undefined;

--- a/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.test.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.test.ts
@@ -6,8 +6,10 @@ import { defineCommandSchema } from "../../../commands/commandSchema";
 import type { CommandType } from "../../../domain/commandType";
 import { EVENT_TYPES } from "../../../domain/eventType";
 import type { Event } from "../../../domain/types";
-import type { DeduplicationStrategy } from "../../../queues";
-import type { EventSourcedQueueProcessor } from "../../../queues";
+import type {
+  DeduplicationStrategy,
+  EventSourcedQueueProcessor,
+} from "../../../queues";
 import {
   createTestAggregateType,
   createTestEvent,
@@ -28,8 +30,11 @@ function createMockEventHandlerDefinition(
     delay?: number;
     deduplication?: DeduplicationStrategy<Event>;
     concurrency?: number;
-    spanAttributes?: (event: Event) => Record<string, string | number | boolean>;
+    spanAttributes?: (
+      event: Event,
+    ) => Record<string, string | number | boolean>;
     disabled?: boolean;
+    coalesceMaxBatch?: number;
   },
 ) {
   return {
@@ -59,7 +64,9 @@ function createMockProjectionDefinition(
     // here because the registry guard lives on the public service
     // signature, not on the queue-manager input shape.
     options: options?.killSwitch
-      ? ({ killSwitch: options.killSwitch } as { killSwitch: { customKey?: any } })
+      ? ({ killSwitch: options.killSwitch } as {
+          killSwitch: { customKey?: any };
+        })
       : undefined,
   };
 }
@@ -244,7 +251,9 @@ describe("QueueManager", () => {
       );
 
       // Projection job groupKey — hierarchical: tenantId/fold/name/domainKey
-      const projectionEntry = globalJobRegistry.get("test-pipeline:projection:p1");
+      const projectionEntry = globalJobRegistry.get(
+        "test-pipeline:projection:p1",
+      );
       const projectionGroupKey = projectionEntry?.groupKeyFn(event);
       expect(projectionGroupKey).toBe(
         `${tenantId}/fold/p1/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
@@ -339,7 +348,9 @@ describe("QueueManager", () => {
         tenantId,
       );
 
-      const projectionEntry = globalJobRegistry.get("test-pipeline:projection:p1");
+      const projectionEntry = globalJobRegistry.get(
+        "test-pipeline:projection:p1",
+      );
       const attrs = projectionEntry?.spanAttributes?.(event);
       expect(attrs).toEqual(
         expect.objectContaining({
@@ -366,7 +377,9 @@ describe("QueueManager", () => {
       );
 
       // Verify that a nonexistent key is not in the registry
-      expect(globalJobRegistry.has("test-pipeline:handler:nonexistent")).toBe(false);
+      expect(globalJobRegistry.has("test-pipeline:handler:nonexistent")).toBe(
+        false,
+      );
     });
   });
 
@@ -407,11 +420,46 @@ describe("QueueManager", () => {
       manager.initializeHandlerQueues(handlers, handleEventCallback);
 
       // Registry entries exist for each handler
-      expect(globalJobRegistry.has("test-pipeline:handler:handler1")).toBe(true);
-      expect(globalJobRegistry.has("test-pipeline:handler:handler2")).toBe(true);
+      expect(globalJobRegistry.has("test-pipeline:handler:handler1")).toBe(
+        true,
+      );
+      expect(globalJobRegistry.has("test-pipeline:handler:handler2")).toBe(
+        true,
+      );
       // Facades exist for each handler
       expect(manager.getHandlerQueue("handler1")).toBeDefined();
       expect(manager.getHandlerQueue("handler2")).toBeDefined();
+    });
+
+    it("registers an opted-in handler batch processor", async () => {
+      const mockQueueProcessor = createMockSharedQueue();
+      const globalJobRegistry = new Map<string, JobRegistryEntry>();
+      const manager = new QueueManager({
+        aggregateType,
+        pipelineName: "test-pipeline",
+        globalQueue: mockQueueProcessor,
+        globalJobRegistry,
+      });
+      const onBatch = vi.fn(async () => undefined);
+      manager.initializeHandlerQueues(
+        {
+          handler1: createMockEventHandlerDefinition("handler1", undefined, {
+            coalesceMaxBatch: 256,
+          }),
+        },
+        vi.fn(),
+        onBatch,
+      );
+      const entry = globalJobRegistry.get("test-pipeline:handler:handler1")!;
+      const events = [
+        createTestEvent("one", aggregateType, tenantId),
+        createTestEvent("two", aggregateType, tenantId),
+      ];
+
+      await entry.processBatch!(events);
+
+      expect(entry.coalesceMaxBatch).toBe(256);
+      expect(onBatch).toHaveBeenCalledWith("handler1", events, { tenantId });
     });
 
     it("facade injects __pipelineName, __jobType and __jobName on send", async () => {
@@ -471,8 +519,16 @@ describe("QueueManager", () => {
 
       expect(mockQueueProcessor.sendBatch).toHaveBeenCalledWith(
         expect.arrayContaining([
-          expect.objectContaining({ __pipelineName: "test-pipeline", __jobType: "handler", __jobName: "handler1" }),
-          expect.objectContaining({ __pipelineName: "test-pipeline", __jobType: "handler", __jobName: "handler1" }),
+          expect.objectContaining({
+            __pipelineName: "test-pipeline",
+            __jobType: "handler",
+            __jobName: "handler1",
+          }),
+          expect.objectContaining({
+            __pipelineName: "test-pipeline",
+            __jobType: "handler",
+            __jobName: "handler1",
+          }),
         ]),
         expect.any(Object),
       );
@@ -670,8 +726,12 @@ describe("QueueManager", () => {
       );
 
       // Registry entries exist for each projection
-      expect(globalJobRegistry.has("test-pipeline:projection:projection1")).toBe(true);
-      expect(globalJobRegistry.has("test-pipeline:projection:projection2")).toBe(true);
+      expect(
+        globalJobRegistry.has("test-pipeline:projection:projection1"),
+      ).toBe(true);
+      expect(
+        globalJobRegistry.has("test-pipeline:projection:projection2"),
+      ).toBe(true);
       // Facades exist for each projection
       expect(manager.getProjectionQueue("projection1")).toBeDefined();
       expect(manager.getProjectionQueue("projection2")).toBeDefined();
@@ -727,7 +787,9 @@ describe("QueueManager", () => {
         vi.fn(),
       );
 
-      const entry = globalJobRegistry.get("test-pipeline:projection:projection1");
+      const entry = globalJobRegistry.get(
+        "test-pipeline:projection:projection1",
+      );
       expect(entry?.groupKeyFn).toBeDefined();
 
       const event = createTestEvent(
@@ -796,8 +858,12 @@ describe("QueueManager", () => {
       );
 
       // Registry entries exist for each command
-      expect(globalJobRegistry.has("test-pipeline:command:command1")).toBe(true);
-      expect(globalJobRegistry.has("test-pipeline:command:command2")).toBe(true);
+      expect(globalJobRegistry.has("test-pipeline:command:command1")).toBe(
+        true,
+      );
+      expect(globalJobRegistry.has("test-pipeline:command:command2")).toBe(
+        true,
+      );
       // Facades exist for each command
       expect(manager.getCommandQueues().size).toBe(2);
       const command1Processor = manager.getCommandQueue("command1");
@@ -965,8 +1031,12 @@ describe("QueueManager", () => {
         vi.fn(),
       );
 
-      expect(globalJobRegistry.has("test-pipeline:reactor:reactor1")).toBe(true);
-      expect(globalJobRegistry.has("test-pipeline:reactor:reactor2")).toBe(true);
+      expect(globalJobRegistry.has("test-pipeline:reactor:reactor1")).toBe(
+        true,
+      );
+      expect(globalJobRegistry.has("test-pipeline:reactor:reactor2")).toBe(
+        true,
+      );
       expect(manager.getReactorQueue("reactor1")).toBeDefined();
       expect(manager.getReactorQueue("reactor2")).toBeDefined();
       expect(manager.hasReactorQueues()).toBe(true);
@@ -1022,7 +1092,12 @@ describe("QueueManager", () => {
       });
 
       manager.initializeReactorQueues(
-        { reactor1: createMockReactorDefinition("reactor1", undefined, { parentProjection: "traceSummary", parentType: "fold" }) },
+        {
+          reactor1: createMockReactorDefinition("reactor1", undefined, {
+            parentProjection: "traceSummary",
+            parentType: "fold",
+          }),
+        },
         vi.fn(),
       );
 

--- a/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
@@ -61,6 +61,7 @@ interface QueuedEventConsumerDefinition<E extends Event> {
     disabled?: boolean;
     killSwitch?: KillSwitchOptions;
     groupKeyFn?: (event: E) => string;
+    coalesceMaxBatch?: number;
   };
 }
 
@@ -238,7 +239,7 @@ export class QueueManager<EventType extends Event = Event> {
         );
       },
       // Global queue lifecycle is owned by EventSourcing — facade close is a no-op
-      close: async () => {},
+      close: async () => undefined,
       waitUntilReady: () => globalQueue.waitUntilReady(),
     };
 
@@ -252,10 +253,16 @@ export class QueueManager<EventType extends Event = Event> {
       event: EventType,
       context: EventStoreReadContext<EventType>,
     ) => Promise<void>,
+    onEventBatch?: (
+      handlerName: string,
+      events: EventType[],
+      context: EventStoreReadContext<EventType>,
+    ) => Promise<void>,
   ): void {
     this.initializeEventConsumerQueues({
       definitions: mapProjections,
       onEvent,
+      onEventBatch,
       jobType: "handler",
       jobPath: "map",
       incrementCount: () => this.handlerCount++,
@@ -282,6 +289,7 @@ export class QueueManager<EventType extends Event = Event> {
   private initializeEventConsumerQueues({
     definitions,
     onEvent,
+    onEventBatch,
     jobType,
     jobPath,
     incrementCount,
@@ -290,6 +298,11 @@ export class QueueManager<EventType extends Event = Event> {
     onEvent: (
       consumerName: string,
       event: EventType,
+      context: EventStoreReadContext<EventType>,
+    ) => Promise<void>;
+    onEventBatch?: (
+      consumerName: string,
+      events: EventType[],
       context: EventStoreReadContext<EventType>,
     ) => Promise<void>;
     jobType: "handler" | "subscriber";
@@ -321,6 +334,17 @@ export class QueueManager<EventType extends Event = Event> {
             tenantId: event.tenantId,
           });
         },
+        processBatch:
+          onEventBatch &&
+          handlerDef.options.coalesceMaxBatch &&
+          handlerDef.options.coalesceMaxBatch > 1
+            ? async (events: any[]) => {
+                await onEventBatch(handlerName, events, {
+                  tenantId: events[0]?.tenantId,
+                });
+              }
+            : undefined,
+        coalesceMaxBatch: handlerDef.options.coalesceMaxBatch,
         delay: handlerDef.options.delay,
         deduplication: resolveDeduplicationStrategy(
           handlerDef.options.deduplication,


### PR DESCRIPTION
## What changed

Adds opt-in batching to the generic event-sourcing map projection path.

- Exposes `sendBatch` through mapped commands.
- Coalesces same-group map events and persists them through one `bulkAppend` call.
- Keeps retention context, replay markers, deduplication, metrics, and map reactors intact.
- Requires `bulkAppend`: `ProjectionRouter` refuses to enable coalescing for a store without it (warning at registration), and those projections keep per-event delivery.

## Why

`bulkAppend` already existed, but live map projections only used it during replay. Metrics and logs would otherwise enqueue and write every record separately even when the store supports a single insert-many operation.

This keeps batching reusable and opt-in, without changing existing projection behavior.

### Why `bulkAppend` is required, not preferred

An earlier revision fell back to a sequential `append` loop for stores without `bulkAppend`. That was unsafe, and review (@langwatch-agent, CodeRabbit) caught it: queue delivery is at-least-once, so a batch that throws part-way is re-dispatched in full — dispatched job *and* every drained sibling. A loop that committed records 1..N before failing on N+1 would append that prefix twice on the retry, and map projections write to additive ClickHouse stores, where a duplicate is an extra row rather than an overwrite.

`bulkAppend` is all-or-nothing, so a retry re-runs a batch that committed nothing. Without it, per-event delivery makes each event its own retryable unit — slower, never duplicating. `executeBatch` now throws rather than looping, as a backstop for any caller that bypasses the router gate.

No production map projection sets `coalesceMaxBatch` yet, so this gate has no live behaviour change today.

## Validation

- 166 event-sourcing projection tests pass (`vitest run src/server/event-sourcing/projections/`), including two added for the gate:
  - `projectionRouter.test.ts` — "initializeMapQueues (coalescing gate)": `coalesceMaxBatch` passes through with `bulkAppend`, is dropped without it. Fails on the pre-fix commit.
  - `mapProjectionExecutor.test.ts` — "when the store has no bulkAppend": `executeBatch` rejects, `store.append` never called.
- tslsp diagnostics clean on the touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch execution for event-driven projections to improve throughput and reactor dispatch consistency.
  * Introduced optional `coalesceMaxBatch` support for map projections and queued handler processing.
  * Enhanced command mapping to expose optional batch sending when available.
* **Bug Fixes**
  * Improved replay/skip and idempotency duplicate handling during batch projection execution.
  * Strengthened error-path assertions for batch and non-batch projection processing.
* **Tests**
  * Expanded coverage for batch commands, batch projection execution, and queue coalescing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
