### PR TITLE
feat(group-queue): make batching observable and safer

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.decodeDrop.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.decodeDrop.integration.test.ts
@@ -17,17 +17,17 @@ import {
   stopTestContainers,
 } from "../../../__tests__/integration/testContainers";
 import type { EventSourcedQueueDefinition } from "../../queue.types";
-import { GroupQueueProcessor } from "../groupQueue";
 import { EnvelopeBlobLifecycle } from "../envelopeBlobLifecycle";
+import { GroupQueueProcessor } from "../groupQueue";
 import { encodeJobEnvelope, readEnvelopeHold } from "../jobEnvelope";
 import { gqJobsDroppedTotal } from "../metrics";
 import { GroupStagingScripts } from "../scripts";
 import { TieredBlobStore } from "../tieredBlobStore";
 import {
   FlakyObjectStore,
-  incompressible,
   InMemoryJobBlobStore,
   InMemoryObjectStore,
+  incompressible,
 } from "./blobTestDoubles";
 
 // Skip outside testcontainers (e.g. plain unit runs) — mirrors the other
@@ -54,8 +54,10 @@ type TestPayload = {
 // offload activates — see jobEnvelope.ts's projectIdFor / tenantIdFromGroupId.
 const TENANT = "proj1";
 const PROJECT = createTenantId(TENANT);
-const STORAGE_DESTINATION = async () =>
-  ({ kind: "s3" as const, bucket: "test-bucket" });
+const STORAGE_DESTINATION = async () => ({
+  kind: "s3" as const,
+  bucket: "test-bucket",
+});
 
 // > the 256 KiB s3 threshold once gzipped (see groupQueue.gq2.integration.test.ts).
 const OFFLOADABLE_S3_VALUE = () => incompressible(768 * 1024);
@@ -97,18 +99,24 @@ describe.skipIf(!hasTestcontainers)(
     function newQueue({
       name,
       processFn,
+      processBatch,
       consumerEnabled,
       objectStore,
+      score,
     }: {
       name: string;
       processFn: (payload: TestPayload) => Promise<void>;
+      processBatch?: (payloads: TestPayload[]) => Promise<void>;
       consumerEnabled: boolean;
       objectStore: InMemoryObjectStore;
+      score?: (payload: TestPayload) => number;
     }): GroupQueueProcessor<TestPayload> {
       const definition: EventSourcedQueueDefinition<TestPayload> = {
         name,
         groupKey: (p) => p.groupId,
         process: processFn,
+        ...(processBatch ? { processBatch, coalesceMaxBatch: () => 50 } : {}),
+        ...(score ? { score } : {}),
       };
       const queue = new GroupQueueProcessor<TestPayload>(definition, redis, {
         consumerEnabled,
@@ -119,10 +127,12 @@ describe.skipIf(!hasTestcontainers)(
       return queue;
     }
 
-    const blockedMembers = (name: string) => redis.smembers(`${name}:gq:blocked`);
+    const blockedMembers = (name: string) =>
+      redis.smembers(`${name}:gq:blocked`);
     const storedErrorMessage = (name: string, groupId: string) =>
       redis.hget(`${name}:gq:group:${groupId}:error`, "message");
-    const completedStat = (name: string) => redis.get(`${name}:gq:stats:completed`);
+    const completedStat = (name: string) =>
+      redis.get(`${name}:gq:stats:completed`);
 
     /** All `gq_jobs_dropped_total` samples recorded for this test's queue. */
     async function dropsFor(name: string) {
@@ -164,6 +174,38 @@ describe.skipIf(!hasTestcontainers)(
       });
     }
 
+    async function stageOffloadedBatch({
+      name,
+      groupId,
+      objectStore,
+    }: {
+      name: string;
+      groupId: string;
+      objectStore: InMemoryObjectStore;
+    }): Promise<void> {
+      const staging = newQueue({
+        name,
+        processFn: async () => {},
+        consumerEnabled: false,
+        objectStore,
+        score: (payload) => payload.id.charCodeAt(0),
+      });
+      await staging.waitUntilReady();
+      for (const id of ["A", "B", "C"]) {
+        await staging.send({
+          id,
+          groupId,
+          value: OFFLOADABLE_S3_VALUE(),
+        });
+      }
+    }
+
+    async function bodyUnreadableDropCount(name: string): Promise<number> {
+      return (await dropsFor(name))
+        .filter((entry) => entry.labels.reason === "body_unreadable")
+        .reduce((sum, entry) => sum + entry.value, 0);
+    }
+
     /**
      * Serves and stores normally, but starts rejecting `put` after N writes — so
      * the initial stage succeeds and a LATER re-encode fails. That is the only
@@ -176,11 +218,107 @@ describe.skipIf(!hasTestcontainers)(
         this.putsLeft = putsBeforeFailing;
       }
       override async put(uri: string, bytes: Buffer): Promise<void> {
-        if (this.putsLeft <= 0) throw new Error("blob store unavailable on write");
+        if (this.putsLeft <= 0)
+          throw new Error("blob store unavailable on write");
         this.putsLeft--;
         return super.put(uri, bytes);
       }
     }
+
+    class SelectiveFlakyObjectStore extends InMemoryObjectStore {
+      transientUri?: string;
+      private failed = false;
+
+      override async get(uri: string) {
+        if (uri === this.transientUri && !this.failed) {
+          this.failed = true;
+          throw new Error("transient ECONNRESET");
+        }
+        return super.get(uri);
+      }
+    }
+
+    describe("given a coalesced batch with a terminally dropped sibling", () => {
+      describe("when the handler fails after sibling parsing", () => {
+        it("re-stages healthy siblings without resurrecting the dropped sibling", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/batch-handler-failure`;
+          const objectStore = new InMemoryObjectStore();
+          await stageOffloadedBatch({ name, groupId, objectStore });
+
+          const uris = [...objectStore.store.keys()];
+          expect(uris).toHaveLength(3);
+          objectStore.store.set(uris[1]!, Buffer.from("not a valid gzip body"));
+
+          let batchAttempts = 0;
+          const succeeded = new Set<string>();
+          const consumer = newQueue({
+            name,
+            processFn: async (payload) => {
+              succeeded.add(payload.id);
+            },
+            processBatch: async (payloads) => {
+              batchAttempts++;
+              if (batchAttempts === 1) {
+                throw new Error("simulated batch failure");
+              }
+              for (const payload of payloads) {
+                succeeded.add(payload.id);
+              }
+            },
+            consumerEnabled: true,
+            objectStore,
+          });
+          await consumer.waitUntilReady();
+
+          await vi.waitFor(
+            () => {
+              expect(succeeded).toEqual(new Set(["A", "C"]));
+            },
+            { timeout: 45000, interval: 100 },
+          );
+          expect(await bodyUnreadableDropCount(name)).toBe(1);
+        });
+      });
+
+      describe("when another sibling has a transient parse failure", () => {
+        it("settles every parse before re-staging only the retryable siblings", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/mixed-parse-failures`;
+          const objectStore = new SelectiveFlakyObjectStore();
+          await stageOffloadedBatch({ name, groupId, objectStore });
+
+          const uris = [...objectStore.store.keys()];
+          expect(uris).toHaveLength(3);
+          objectStore.store.set(uris[1]!, Buffer.from("not a valid gzip body"));
+          objectStore.transientUri = uris[2]!;
+
+          const succeeded = new Set<string>();
+          const consumer = newQueue({
+            name,
+            processFn: async (payload) => {
+              succeeded.add(payload.id);
+            },
+            processBatch: async (payloads) => {
+              for (const payload of payloads) {
+                succeeded.add(payload.id);
+              }
+            },
+            consumerEnabled: true,
+            objectStore,
+          });
+          await consumer.waitUntilReady();
+
+          await vi.waitFor(
+            () => {
+              expect(succeeded).toEqual(new Set(["A", "C"]));
+            },
+            { timeout: 45000, interval: 100 },
+          );
+          expect(await bodyUnreadableDropCount(name)).toBe(1);
+        });
+      });
+    });
 
     describe("given a job whose retry cannot re-encode its payload", () => {
       describe("when the retry's re-encode fails", () => {
@@ -561,77 +699,69 @@ describe.skipIf(!hasTestcontainers)(
     describe("given a staged job whose blob store is temporarily unreachable", () => {
       describe("when a worker claims the group and the decode fails", () => {
         /** @scenario a transient blob-store error still retries instead of dropping */
-        it(
-          "re-stages the job for retry instead of completing it",
-          async () => {
-            const name = freshName();
-            const groupId = `${TENANT}/transient-retries`;
-            const flaky = new FlakyObjectStore(1); // fails once, then serves
-            const received: TestPayload[] = [];
-            newQueue({
-              name,
-              processFn: async (p) => {
-                received.push(p);
-              },
-              consumerEnabled: true,
-              objectStore: flaky,
-            });
+        it("re-stages the job for retry instead of completing it", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/transient-retries`;
+          const flaky = new FlakyObjectStore(1); // fails once, then serves
+          const received: TestPayload[] = [];
+          newQueue({
+            name,
+            processFn: async (p) => {
+              received.push(p);
+            },
+            consumerEnabled: true,
+            objectStore: flaky,
+          });
 
-            await queues[0]!.waitUntilReady();
-            await queues[0]!.send({
-              id: "s1",
-              groupId,
-              value: OFFLOADABLE_S3_VALUE(),
-            });
+          await queues[0]!.waitUntilReady();
+          await queues[0]!.send({
+            id: "s1",
+            groupId,
+            value: OFFLOADABLE_S3_VALUE(),
+          });
 
-            // The handler eventually runs despite the first transient
-            // failure — it could only get here via a re-stage, since a drop
-            // would never call the handler at all.
-            await vi.waitFor(() => expect(received).toHaveLength(1), {
-              timeout: 15000,
-              interval: 100,
-            });
-          },
-          20000,
-        );
+          // The handler eventually runs despite the first transient
+          // failure — it could only get here via a re-stage, since a drop
+          // would never call the handler at all.
+          await vi.waitFor(() => expect(received).toHaveLength(1), {
+            timeout: 15000,
+            interval: 100,
+          });
+        }, 20000);
 
-        it(
-          "does not increment the drop counter",
-          async () => {
-            const name = freshName();
-            const groupId = `${TENANT}/transient-no-drop`;
-            const flaky = new FlakyObjectStore(1);
-            const received: TestPayload[] = [];
-            newQueue({
-              name,
-              processFn: async (p) => {
-                received.push(p);
-              },
-              consumerEnabled: true,
-              objectStore: flaky,
-            });
+        it("does not increment the drop counter", async () => {
+          const name = freshName();
+          const groupId = `${TENANT}/transient-no-drop`;
+          const flaky = new FlakyObjectStore(1);
+          const received: TestPayload[] = [];
+          newQueue({
+            name,
+            processFn: async (p) => {
+              received.push(p);
+            },
+            consumerEnabled: true,
+            objectStore: flaky,
+          });
 
-            await queues[0]!.waitUntilReady();
-            await queues[0]!.send({
-              id: "s1",
-              groupId,
-              value: OFFLOADABLE_S3_VALUE(),
-            });
+          await queues[0]!.waitUntilReady();
+          await queues[0]!.send({
+            id: "s1",
+            groupId,
+            value: OFFLOADABLE_S3_VALUE(),
+          });
 
-            await vi.waitFor(() => expect(received).toHaveLength(1), {
-              timeout: 15000,
-              interval: 100,
-            });
+          await vi.waitFor(() => expect(received).toHaveLength(1), {
+            timeout: 15000,
+            interval: 100,
+          });
 
-            // Revert-check: pre-fix, TransientBlobStoreError still routed
-            // through handleTransientDecode (this was already correct before
-            // #5538 — see ADR-030 §2), so this specific assertion mainly
-            // guards against a regression that widens the drop path to catch
-            // transient errors too.
-            expect(await dropsFor(name)).toHaveLength(0);
-          },
-          20000,
-        );
+          // Revert-check: pre-fix, TransientBlobStoreError still routed
+          // through handleTransientDecode (this was already correct before
+          // #5538 — see ADR-030 §2), so this specific assertion mainly
+          // guards against a regression that widens the drop path to catch
+          // transient errors too.
+          expect(await dropsFor(name)).toHaveLength(0);
+        }, 20000);
       });
     });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -30,6 +30,8 @@ type TestPayload = {
   id: string;
   groupId: string;
   value: string;
+  /** Caller-set routing metadata; stripped before the handler sees the payload. */
+  __jobName?: string;
 };
 
 function createQueueDefinition(
@@ -790,6 +792,64 @@ describe.skipIf(!hasTestcontainers)(
           // One producer stage plus one atomic sibling re-stage. The failed
           // coalesced handler does not issue one Redis stage call per sibling.
           expect(stageBatch).toHaveBeenCalledTimes(2);
+        });
+      });
+
+      describe("when a coalesced batch completes successfully", () => {
+        /** @scenario 'A coalesced batch counts every event it completed' */
+        it("advances the Redis completed counters by the number of events", async () => {
+          const queueName = `{test/gq/count-${crypto.randomUUID().slice(0, 8)}}`;
+          const batches: TestPayload[][] = [];
+          const singles: TestPayload[] = [];
+          const queue = createQueue(
+            async (p) => {
+              singles.push(p);
+            },
+            {
+              name: queueName,
+              processBatch: async (ps) => {
+                batches.push(ps as TestPayload[]);
+              },
+              coalesceMaxBatch: () => 50,
+              score: (p) => Number(p.value) * 1000,
+            },
+          );
+          await queue.waitUntilReady();
+
+          const eventCount = 12;
+          await queue.sendBatch(
+            Array.from({ length: eventCount }, (_, i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: String(i),
+              __jobName: "recordSpan",
+            })),
+          );
+
+          const statAt = async (key: string) =>
+            Number((await redis.get(`${queueName}:gq:${key}`)) ?? 0);
+
+          // The counters are written by COMPLETE_LUA after the handler returns,
+          // so wait on the counter itself rather than on the handler calls.
+          await vi.waitFor(
+            async () => {
+              expect(await statAt("stats:completed")).toBe(eventCount);
+            },
+            { timeout: 30000, interval: 50 },
+          );
+
+          // Per-job-name total (the metrics collector reads this one per job).
+          expect(await statAt("stats:completed:recordSpan")).toBe(eventCount);
+
+          // The counters only mean something here if coalescing actually
+          // happened — without a multi-event batch this would pass even when
+          // completions are counted per handler call.
+          expect(Math.max(...batches.map((b) => b.length), 0)).toBeGreaterThan(
+            1,
+          );
+          // And every event really was handled exactly once.
+          const allIds = [...batches.flat(), ...singles].map((p) => p.id);
+          expect(new Set(allIds).size).toBe(eventCount);
         });
       });
     });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -1,3 +1,4 @@
+import type { Redis } from "ioredis";
 import {
   afterAll,
   afterEach,
@@ -8,14 +9,14 @@ import {
   it,
   vi,
 } from "vitest";
-import type { Redis } from "ioredis";
 import {
+  getTestRedisConnection,
   startTestContainers,
   stopTestContainers,
-  getTestRedisConnection,
 } from "../../../__tests__/integration/testContainers";
-import { GroupQueueProcessor } from "../groupQueue";
 import type { EventSourcedQueueDefinition } from "../../queue.types";
+import { GroupQueueProcessor } from "../groupQueue";
+import { GroupStagingScripts } from "../scripts";
 
 // Skip when running without testcontainers (unit-only test runs)
 const hasTestcontainers = !!(
@@ -59,10 +60,9 @@ describe.skipIf(!hasTestcontainers)(
     });
 
     afterEach(async () => {
+      vi.restoreAllMocks();
       // Close all queues created during the test
-      await Promise.all(
-        queues.map((q) => q.close().catch(() => {})),
-      );
+      await Promise.all(queues.map((q) => q.close().catch(() => {})));
       await redis.flushall();
     });
 
@@ -333,9 +333,9 @@ describe.skipIf(!hasTestcontainers)(
               { timeout: 5000, interval: 50 },
             );
             // Staging holds exactly the one squashed job, referencing the new blob.
-            expect(
-              await redis.hlen(`${queueName}:gq:group:group-a:data`),
-            ).toBe(1);
+            expect(await redis.hlen(`${queueName}:gq:group:group-a:data`)).toBe(
+              1,
+            );
           } finally {
             vi.unstubAllEnvs();
           }
@@ -373,9 +373,9 @@ describe.skipIf(!hasTestcontainers)(
               },
               { timeout: 5000, interval: 50 },
             );
-            expect(
-              await redis.hlen(`${queueName}:gq:group:group-a:data`),
-            ).toBe(1);
+            expect(await redis.hlen(`${queueName}:gq:group:group-a:data`)).toBe(
+              1,
+            );
           } finally {
             vi.unstubAllEnvs();
           }
@@ -616,7 +616,8 @@ describe.skipIf(!hasTestcontainers)(
 
           await vi.waitFor(
             () => {
-              const total = batches.reduce((n, b) => n + b.length, 0) + singles.length;
+              const total =
+                batches.reduce((n, b) => n + b.length, 0) + singles.length;
               expect(total).toBe(10);
             },
             { timeout: 30000, interval: 50 },
@@ -643,7 +644,11 @@ describe.skipIf(!hasTestcontainers)(
 
           // Send shuffled; the queue must still fold them in score order.
           await queue.sendBatch(
-            [4, 2, 0, 3, 1].map((n) => ({ id: `j${n}`, groupId: "group-a", value: String(n) })),
+            [4, 2, 0, 3, 1].map((n) => ({
+              id: `j${n}`,
+              groupId: "group-a",
+              value: String(n),
+            })),
           );
 
           await vi.waitFor(
@@ -674,12 +679,17 @@ describe.skipIf(!hasTestcontainers)(
           await queue.waitUntilReady();
 
           await queue.sendBatch(
-            Array.from({ length: 9 }, (_, i) => ({ id: `j${i}`, groupId: "group-a", value: String(i) })),
+            Array.from({ length: 9 }, (_, i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: String(i),
+            })),
           );
 
           await vi.waitFor(
             () => {
-              const total = batches.reduce((n, b) => n + b.length, 0) + singles.length;
+              const total =
+                batches.reduce((n, b) => n + b.length, 0) + singles.length;
               expect(total).toBe(9);
             },
             { timeout: 30000, interval: 50 },
@@ -713,7 +723,11 @@ describe.skipIf(!hasTestcontainers)(
           await queue.waitUntilReady();
 
           await queue.sendBatch(
-            Array.from({ length: 5 }, (_, i) => ({ id: `j${i}`, groupId: "group-a", value: String(i) })),
+            Array.from({ length: 5 }, (_, i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: String(i),
+            })),
           );
 
           await vi.waitFor(
@@ -729,6 +743,10 @@ describe.skipIf(!hasTestcontainers)(
       describe("when a coalesced batch fails", () => {
         /** @scenario 'A failed coalesced batch re-stages its drained siblings' */
         it("re-stages drained siblings so none are lost", async () => {
+          const stageBatch = vi.spyOn(
+            GroupStagingScripts.prototype,
+            "stageBatch",
+          );
           let attempts = 0;
           const succeeded: TestPayload[] = [];
           const queue = createQueue(
@@ -750,7 +768,11 @@ describe.skipIf(!hasTestcontainers)(
           await queue.waitUntilReady();
 
           await queue.sendBatch(
-            Array.from({ length: 4 }, (_, i) => ({ id: `j${i}`, groupId: "group-a", value: String(i) })),
+            Array.from({ length: 4 }, (_, i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: String(i),
+            })),
           );
 
           // Despite the first batch throwing, every event is eventually
@@ -765,6 +787,9 @@ describe.skipIf(!hasTestcontainers)(
             },
             { timeout: 45000, interval: 100 },
           );
+          // One producer stage plus one atomic sibling re-stage. The failed
+          // coalesced handler does not issue one Redis stage call per sibling.
+          expect(stageBatch).toHaveBeenCalledTimes(2);
         });
       });
     });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts
@@ -1,20 +1,22 @@
-import { describe, it, expect, beforeEach } from "vitest";
 import { register } from "prom-client";
+import { beforeEach, describe, expect, it } from "vitest";
 
 // Import to trigger metric registration
 import {
-  gqJobsDelayedTotal,
+  gqBlockedGroups,
+  gqGroupsBlockedTotal,
+  gqHandlerBatchSize,
+  gqHandlerInvocationsTotal,
   gqJobDelayMilliseconds,
-  gqRetryAttempt,
-  gqRetryBackoffMilliseconds,
   gqJobDurationMilliseconds,
-  gqOldestPendingAgeMilliseconds,
   gqJobsCompletedTotal,
-  gqJobsRetriedTotal,
+  gqJobsDelayedTotal,
   gqJobsExhaustedTotal,
   gqJobsNonRetryableTotal,
-  gqGroupsBlockedTotal,
-  gqBlockedGroups,
+  gqJobsRetriedTotal,
+  gqOldestPendingAgeMilliseconds,
+  gqRetryAttempt,
+  gqRetryBackoffMilliseconds,
 } from "../metrics";
 
 const routingLabels = {
@@ -46,17 +48,20 @@ describe("GroupQueue metrics", () => {
     });
 
     it("registers gq_retry_backoff_milliseconds histogram", () => {
-      const metric = register.getSingleMetric(
-        "gq_retry_backoff_milliseconds",
-      );
+      const metric = register.getSingleMetric("gq_retry_backoff_milliseconds");
       expect(metric).toBeDefined();
     });
 
     it("registers gq_job_duration_milliseconds histogram", () => {
-      const metric = register.getSingleMetric(
-        "gq_job_duration_milliseconds",
-      );
+      const metric = register.getSingleMetric("gq_job_duration_milliseconds");
       expect(metric).toBeDefined();
+    });
+
+    it("registers handler invocation and batch-size metrics", () => {
+      expect(
+        register.getSingleMetric("gq_handler_invocations_total"),
+      ).toBeDefined();
+      expect(register.getSingleMetric("gq_handler_batch_size")).toBeDefined();
     });
 
     it("registers gq_oldest_pending_age_milliseconds gauge", () => {
@@ -100,8 +105,7 @@ describe("GroupQueue metrics", () => {
     it("records retry attempt with routing labels", async () => {
       gqRetryAttempt.observe(routingLabels, 3);
 
-      const lines =
-        await register.getSingleMetricAsString("gq_retry_attempt");
+      const lines = await register.getSingleMetricAsString("gq_retry_attempt");
       expect(lines).toContain('pipeline_name="test-pipeline"');
       expect(lines).toContain('job_name="traceSummary"');
     });
@@ -131,9 +135,29 @@ describe("GroupQueue metrics", () => {
     });
   });
 
+  describe("when a coalesced handler is observed", () => {
+    it("records one invocation and the payload count", async () => {
+      gqHandlerInvocationsTotal.inc(routingLabels);
+      gqHandlerBatchSize.observe(routingLabels, 32);
+
+      const invocations = await register.getSingleMetricAsString(
+        "gq_handler_invocations_total",
+      );
+      const batchSize = await register.getSingleMetricAsString(
+        "gq_handler_batch_size",
+      );
+      expect(invocations).toContain(
+        'gq_handler_invocations_total{queue_name="test-queue",pipeline_name="test-pipeline",job_type="fold",job_name="traceSummary"} 1',
+      );
+      expect(batchSize).toContain(
+        'gq_handler_batch_size_sum{queue_name="test-queue",pipeline_name="test-pipeline",job_type="fold",job_name="traceSummary"} 32',
+      );
+    });
+  });
+
   describe("when processing counters are recorded with routing labels", () => {
     it("records completed total with routing labels", async () => {
-      gqJobsCompletedTotal.inc(routingLabels);
+      gqJobsCompletedTotal.inc(routingLabels, 4);
 
       const lines = await register.getSingleMetricAsString(
         "gq_jobs_completed_total",
@@ -141,6 +165,9 @@ describe("GroupQueue metrics", () => {
       expect(lines).toContain('pipeline_name="test-pipeline"');
       expect(lines).toContain('job_type="fold"');
       expect(lines).toContain('job_name="traceSummary"');
+      expect(lines).toContain(
+        'gq_jobs_completed_total{queue_name="test-queue",pipeline_name="test-pipeline",job_type="fold",job_name="traceSummary"} 4',
+      );
     });
 
     it("records retried total with routing labels", async () => {
@@ -187,10 +214,7 @@ describe("GroupQueue metrics", () => {
   describe("when oldest pending age is set", () => {
     it("sets gauge value without throwing", () => {
       expect(() =>
-        gqOldestPendingAgeMilliseconds.set(
-          { queue_name: "test-queue" },
-          1500,
-        ),
+        gqOldestPendingAgeMilliseconds.set({ queue_name: "test-queue" }, 1500),
       ).not.toThrow();
     });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1805,6 +1805,7 @@ describe("GroupStagingScripts", () => {
       });
 
       describe("when the job was dropped", () => {
+        /** @scenario 'A discarded event still counts no completions' */
         it("leaves both counters untouched whatever the payload count", async () => {
           const dispatched = await stageAndDispatch({ stagedJobId: "j1" });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1761,6 +1761,66 @@ describe("GroupStagingScripts", () => {
         );
       });
     });
+
+    // These counters drive metrics-collector.ts (completed throughput and the
+    // per-job-name totals). A coalesced batch completes N payloads in ONE call,
+    // so counting calls would make them fall as batching improves.
+    describe("completed counters", () => {
+      const completedTotal = async () =>
+        Number((await redis.get(`${keyPrefix()}stats:completed`)) ?? 0);
+      const completedForJob = async (jobName: string) =>
+        Number(
+          (await redis.get(`${keyPrefix()}stats:completed:${jobName}`)) ?? 0,
+        );
+
+      describe("when a completion accounts for a coalesced batch", () => {
+        it("advances both counters by the payload count", async () => {
+          const dispatched = await stageAndDispatch({ stagedJobId: "j1" });
+
+          await scripts.complete({
+            groupId: dispatched.groupId,
+            stagedJobId: dispatched.stagedJobId,
+            jobName: "recordSpan",
+            payloadCount: 7,
+          });
+
+          expect(await completedTotal()).toBe(7);
+          expect(await completedForJob("recordSpan")).toBe(7);
+        });
+      });
+
+      describe("when payloadCount is omitted", () => {
+        it("advances both counters by one", async () => {
+          const dispatched = await stageAndDispatch({ stagedJobId: "j1" });
+
+          await scripts.complete({
+            groupId: dispatched.groupId,
+            stagedJobId: dispatched.stagedJobId,
+            jobName: "recordSpan",
+          });
+
+          expect(await completedTotal()).toBe(1);
+          expect(await completedForJob("recordSpan")).toBe(1);
+        });
+      });
+
+      describe("when the job was dropped", () => {
+        it("leaves both counters untouched whatever the payload count", async () => {
+          const dispatched = await stageAndDispatch({ stagedJobId: "j1" });
+
+          await scripts.complete({
+            groupId: dispatched.groupId,
+            stagedJobId: dispatched.stagedJobId,
+            jobName: "recordSpan",
+            payloadCount: 7,
+            dropped: true,
+          });
+
+          expect(await completedTotal()).toBe(0);
+          expect(await completedForJob("recordSpan")).toBe(0);
+        });
+      });
+    });
   });
 
   describe("refreshActiveKey", () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1055,8 +1055,16 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
               // Success — complete the group slot. Drained siblings were
               // removed from staging during the drain, so completing the
-              // dispatched job is enough to free the group.
-              await this.scripts.complete({ groupId, stagedJobId, jobName });
+              // dispatched job is enough to free the group. It is also the only
+              // completion the siblings get, hence payloadCount: the Redis
+              // counters ops reads must advance per payload, like the Prometheus
+              // one below, not once per handler call.
+              await this.scripts.complete({
+                groupId,
+                stagedJobId,
+                jobName,
+                payloadCount: handlerPayloadCount,
+              });
               await this.blobLifecycle.release({
                 values: [
                   jobDataJson,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -55,11 +55,14 @@ import {
 import {
   gqGroupsBlockedTotal,
   gqGroupsPoisonParkedTotal,
+  gqHandlerBatchSize,
+  gqHandlerInvocationsTotal,
   gqJobDelayMilliseconds,
   gqJobDurationMilliseconds,
   gqJobsCompletedTotal,
   gqJobsDedupedTotal,
   gqJobsDelayedTotal,
+  gqJobsDispatchedTotal,
   gqJobsDroppedTotal,
   gqJobsExhaustedTotal,
   gqJobsNonRetryableTotal,
@@ -861,6 +864,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           nowMs: Date.now(),
           maxJobs: maxBatch - 1,
         });
+        if (drainedSiblings.length > 0) {
+          gqJobsDispatchedTotal.inc(
+            { queue_name: this.queueName },
+            drainedSiblings.length,
+          );
+        }
       } catch (err) {
         this.logger.warn(
           {
@@ -874,10 +883,22 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       }
       if (drainedSiblings.length > 0) {
         try {
-          const parsedSiblings = await Promise.all(
+          const parseResults = await Promise.allSettled(
             drainedSiblings.map((sibling) =>
               this.parseDrainedPayload({ sibling, groupId }),
             ),
+          );
+          // Wait for every parse to settle before handling a transient or
+          // oversized sibling. A terminal parse marks its sibling as dropped;
+          // short-circuiting here could re-stage it before that mark is set.
+          const rejected = parseResults.find(
+            (result) => result.status === "rejected",
+          );
+          if (rejected) {
+            throw rejected.reason;
+          }
+          const parsedSiblings = parseResults.flatMap((result) =>
+            result.status === "fulfilled" ? [result.value] : [],
           );
           const siblingPayloads = parsedSiblings.filter(
             (parsed) => parsed !== null,
@@ -1017,6 +1038,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
               // Run the actual handler with request context propagation
               const requestContext = createContextFromJobData(contextMetadata);
+              const handlerPayloadCount = batchPayloads?.length ?? 1;
+              gqHandlerInvocationsTotal.inc(routingLabels);
+              gqHandlerBatchSize.observe(routingLabels, handlerPayloadCount);
               await runWithContext(requestContext, async () => {
                 if (batchPayloads && this.processBatch) {
                   span.setAttribute(
@@ -1040,7 +1064,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 ],
                 groupId,
               });
-              gqJobsCompletedTotal.inc(routingLabels);
+              gqJobsCompletedTotal.inc(routingLabels, handlerPayloadCount);
 
               // Audit hook: onDispatched fires once per dispatched payload
               // (dispatched + every drained sibling on success).
@@ -1070,10 +1094,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               const category = categorizeError(err);
               const isRetryable = isRetryableJobError(err);
 
-              // The batch stores its fold state only once, at the very end, so a
-              // failure means nothing was persisted for the drained siblings.
-              // Re-stage them so they are re-dispatched (and re-coalesced) on the
-              // dispatched job's retry, rather than lost until an event replay.
+              // Re-stage drained siblings so they are re-dispatched (and
+              // re-coalesced) on the active job's retry. Batch handlers are
+              // at-least-once: stores must tolerate a partial side effect before
+              // throwing, just as they must tolerate a single-job retry.
               if (drainedSiblings.length > 0) {
                 await this.restageDrainedSiblings(groupId, drainedSiblings);
               }
@@ -1334,36 +1358,40 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           ? err.reason === "missing_blob"
           : false),
       });
+      sibling.dropped = true;
       return null;
     }
   }
 
   /**
    * Re-stages siblings drained for a batch that ultimately failed, so they are
-   * re-dispatched instead of lost. Each is staged with its original score and
-   * raw job data (context metadata preserved). Best-effort: a re-stage failure
-   * is logged, not thrown, so it never masks the original processing error.
+   * re-dispatched instead of lost. One atomic stageBatch call restores every
+   * sibling with its original score and raw job data. Their blob holds survive
+   * the drain, so no per-sibling hold acquisition is needed.
    */
   private async restageDrainedSiblings(
     groupId: string,
     siblings: DrainedJob[],
   ): Promise<void> {
-    for (const sibling of siblings) {
-      try {
-        await this.scripts.stage({
+    const restageableSiblings = siblings.filter((sibling) => !sibling.dropped);
+    if (restageableSiblings.length === 0) {
+      return;
+    }
+    try {
+      await this.scripts.stageBatch(
+        restageableSiblings.map((sibling) => ({
           stagedJobId: sibling.stagedJobId,
           groupId,
           dispatchAfterMs: sibling.originalScore,
           dedupId: "",
           dedupTtlMs: 0,
           jobDataJson: sibling.jobDataJson,
-        });
-        // Re-acquire the sibling's hold (idempotent: it kept its hold through
-        // the drain, and its value — hence token — is unchanged).
-        await this.blobLifecycle.acquire(sibling.jobDataJson);
-      } catch (err) {
-        // The sibling never made it back into staging, so nothing will dispatch
-        // it again — that is a discard, whatever the re-stage intended (#5538).
+        })),
+      );
+    } catch (err) {
+      // Redis applies the script atomically, so it cannot leave only a subset
+      // restored. Record the failed re-stage per payload for drop accounting.
+      for (const sibling of restageableSiblings) {
         this.recordDrop({
           groupId,
           stagedJobId: sibling.stagedJobId,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -10,6 +10,8 @@ const metricNames = [
   "gq_jobs_staged_total",
   "gq_jobs_dispatched_total",
   "gq_jobs_completed_total",
+  "gq_handler_invocations_total",
+  "gq_handler_batch_size",
   "gq_jobs_deduped_total",
   "gq_jobs_retried_total",
   "gq_jobs_exhausted_total",
@@ -81,8 +83,21 @@ export const gqJobsDispatchedTotal = new Counter({
 
 export const gqJobsCompletedTotal = new Counter({
   name: "gq_jobs_completed_total",
-  help: "Total number of jobs completed successfully",
+  help: "Total number of payloads completed successfully, including every payload in a coalesced handler batch",
   labelNames: ["queue_name", "pipeline_name", "job_type", "job_name"] as const,
+});
+
+export const gqHandlerInvocationsTotal = new Counter({
+  name: "gq_handler_invocations_total",
+  help: "Total number of handler attempts; one coalesced batch is one invocation",
+  labelNames: ["queue_name", "pipeline_name", "job_type", "job_name"] as const,
+});
+
+export const gqHandlerBatchSize = new Histogram({
+  name: "gq_handler_batch_size",
+  help: "Number of payloads passed to each handler attempt, including singleton invocations",
+  labelNames: ["queue_name", "pipeline_name", "job_type", "job_name"] as const,
+  buckets: [1, 2, 4, 8, 16, 32, 64, 128, 256, 500],
 });
 
 export const gqJobsDedupedTotal = new Counter({
@@ -150,10 +165,10 @@ export const gqRetryBackoffMilliseconds = new Histogram({
   buckets: [100, 500, 1000, 2000, 5000, 10000, 30000, 60000],
 });
 
-// --- Per-job duration metric ---
+// --- Per-handler-invocation duration metric ---
 export const gqJobDurationMilliseconds = new Histogram({
   name: "gq_job_duration_milliseconds",
-  help: "Duration of individual job processing in milliseconds",
+  help: "Duration of one handler invocation in milliseconds; a coalesced batch produces one observation",
   labelNames: ["queue_name", "pipeline_name", "job_type", "job_name"] as const,
   buckets: [
     1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1,8 +1,7 @@
 import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
-
-import { CachedLuaScript } from "./cachedLuaScript";
 import { BLOB_HOLDER_TTL_SECONDS } from "./blobConstants";
+import { CachedLuaScript } from "./cachedLuaScript";
 
 // Lua scripts inlined as string constants.
 // This avoids loader incompatibilities across turbopack, webpack, vitest, and tsx.
@@ -1557,6 +1556,8 @@ export interface DrainedJob {
   stagedJobId: string;
   jobDataJson: string;
   originalScore: number;
+  /** Set after this worker has terminally dropped the drained job. */
+  dropped?: boolean;
 }
 
 /**
@@ -1905,7 +1906,11 @@ export class GroupStagingScripts {
           : [],
       };
     }
-    return { newStagedCount: Number(result), orphanedValues: [], reclaimS3Flags: [] };
+    return {
+      newStagedCount: Number(result),
+      orphanedValues: [],
+      reclaimS3Flags: [],
+    };
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1283,6 +1283,15 @@ local nowMs = tonumber(ARGV[6])
 -- counters and must not clear the group's stored error. Absent/"" = a genuine
 -- success, so older call sites keep their exact behaviour.
 local isDropped = ARGV[7] == "1"
+-- How many payloads this completion accounts for. A coalesced batch drains its
+-- siblings out of staging and frees the group with ONE complete() call, so
+-- counting calls here would make these counters fall as batching improves —
+-- and disagree with the per-payload Prometheus counter the same run reports.
+-- Absent / unparseable / < 1 = 1, so single-job call sites keep their behaviour.
+local payloadCount = tonumber(ARGV[8]) or 1
+if payloadCount < 1 then
+  payloadCount = 1
+end
 
 local currentActive = redis.call("GET", activeKey)
 if currentActive ~= stagedJobId then
@@ -1339,11 +1348,11 @@ redis.call("LTRIM", signalKey, 0, 999)
 -- error, so ops saw a win where an event had just been thrown away (#5538).
 if not isDropped then
   -- Increment completed counter for Skynet
-  redis.call("INCR", statsKey)
+  redis.call("INCRBY", statsKey, payloadCount)
 
   -- Increment per-job-name completed counter
   if jobName and jobName ~= "" then
-    redis.call("INCR", statsKey .. ":" .. jobName)
+    redis.call("INCRBY", statsKey .. ":" .. jobName, payloadCount)
   end
 
   -- Clear any leftover error from previous failures now that the job succeeded
@@ -2022,6 +2031,7 @@ export class GroupStagingScripts {
     stagedJobId,
     jobName,
     dropped = false,
+    payloadCount = 1,
   }: {
     groupId: string;
     stagedJobId: string;
@@ -2033,6 +2043,15 @@ export class GroupStagingScripts {
      * a successful one. Defaults false — a plain `complete()` is still a success.
      */
     dropped?: boolean;
+    /**
+     * How many payloads this completion accounts for. A coalesced batch drains
+     * its siblings out of staging and frees the group in a single call, so the
+     * Skynet counters must advance by the batch size to stay comparable with
+     * `gq_jobs_completed_total` (which counts payloads) and to keep the
+     * operational throughput view from falling as batching improves. Defaults
+     * to 1 — the single-job path is unchanged. Ignored when `dropped`.
+     */
+    payloadCount?: number;
   }): Promise<boolean> {
     const activeKey = `${this.keyPrefix}group:${groupId}:active`;
     const jobsKey = `${this.keyPrefix}group:${groupId}:jobs`;
@@ -2057,6 +2076,7 @@ export class GroupStagingScripts {
       String(readTenantCap()),
       String(Date.now()),
       dropped ? "1" : "",
+      String(payloadCount),
     );
 
     return result === 1;

--- a/specs/event-sourcing/fold-coalescing.feature
+++ b/specs/event-sourcing/fold-coalescing.feature
@@ -130,6 +130,24 @@ Feature: Group-coalesced fold projections
     When the group is retried
     Then every event is eventually processed and none are lost
 
+  # Coalescing frees the group with ONE completion call however many events the
+  # handler folded. Counting that as a single completion makes throughput and
+  # per-job-name totals fall as batching improves — the operational dashboards
+  # would read the improvement as a regression, and disagree with the payload
+  # counter the same run reports.
+  @integration @coalescing @observability
+  Scenario: A coalesced batch counts every event it completed
+    Given a group with several queued events folded into one batch
+    When the batch is processed successfully
+    Then the completed throughput counter advances by the number of events
+    And the per-job-name completed counter advances by the same number
+
+  @integration @coalescing @observability
+  Scenario: A discarded event still counts no completions
+    Given a staged event that cannot be decoded
+    When it is discarded to free the group
+    Then the completed counters do not advance
+
   @integration @coalescing @pipeline
   Scenario: Coalesced folding produces the correct accumulated state through the pipeline
     Given many spans recorded for one trace in quick succession


### PR DESCRIPTION
## Summary

- count dispatched and completed payloads correctly when one handler processes a batch
- expose handler invocation count and an actual batch-size histogram
- re-stage failed coalesced siblings with one atomic Redis operation
- never resurrect a sibling that was already dropped during parsing
- settle all sibling parses before deciding what can safely be re-staged

## Why

Batching is reducing handler work, but the existing metrics count handler calls as jobs and do not show the batch-size distribution. The failure path also turns one failed batch into one Redis write per sibling and can re-stage work that was already terminally dropped.

This makes the batching efficiency measurable and keeps recovery to one Redis operation without changing group ordering or at-least-once delivery.

## Checks

- 61 focused unit tests
- test TypeScript check
- repository-pinned Biome check
- Redis integration: atomic sibling re-stage
- Redis integration: handler failure after terminal sibling drop
- Redis integration: mixed terminal and transient sibling parse failures