### PR TITLE
fix(observability): per-job root traces for event-sourcing jobs + cut the ioredis span flood

### DIFF
--- a/langwatch/src/instrumentation.node.ts
+++ b/langwatch/src/instrumentation.node.ts
@@ -83,6 +83,18 @@ if (
       detectors: [awsEksDetector, envDetector],
     }),
     advanced: {},
+    // Cap per-span payload growth. OTel's defaults are unbounded
+    // (`attributeValueLengthLimit: Infinity`, `attributeCountLimit: 128` only
+    // in newer SDKs) — a single span carrying an oversized `db.statement` or a
+    // huge attribute bag can bloat a trace and, in bulk, pressure the
+    // collector's WAL. These caps bound each span's attribute footprint:
+    // values are truncated at 12k chars and no more than 128 attributes are
+    // kept per span. This is defense-in-depth alongside the per-job root-trace
+    // scoping and ioredis `requireParentSpan` scoping.
+    spanLimits: {
+      attributeValueLengthLimit: 12_000,
+      attributeCountLimit: 128,
+    },
     spanProcessors: spanProcessors,
     logRecordProcessors: logRecordProcessors,
     textMapPropagator: new CompositePropagator({
@@ -121,9 +133,25 @@ if (
         "@opentelemetry/instrumentation-cucumber": { enabled: false },
         "@opentelemetry/instrumentation-router": { enabled: false },
 
-        // Truncate ioredis db.statement to command + first key
-        // (avoid logging content + large attributes)
+        // ioredis auto-instrumentation emits one span PER Redis command. The
+        // event-sourcing GroupQueue worker runs continuous background loops on
+        // Redis — BRPOP signal polling, Lua-script leasing (evalsha), holder-set
+        // bookkeeping (sadd/srem), active-key heartbeats (expire), and stats
+        // pushes (lpush) — none of which sit under any application span. Left
+        // unscoped, those loops produced an unbounded per-command span flood
+        // that (together with the mega-trace bug fixed in the GroupQueue) OOM
+        // crash-looped the self-observability Tempo.
+        //
+        // `requireParentSpan: true` scopes ioredis so a command is only traced
+        // when it already runs inside an application span (an HTTP request, a
+        // per-job CONSUMER span, etc.). The queue's own plumbing loops — which
+        // have no active parent span — stop creating spans entirely, while
+        // Redis calls made inside real request/job work are still captured
+        // (and remain bounded now that each job is its own root trace).
         "@opentelemetry/instrumentation-ioredis": {
+          requireParentSpan: true,
+          // Truncate ioredis db.statement to command + first key
+          // (avoid logging content + large attributes)
           dbStatementSerializer: (
             cmdName: string,
             cmdArgs: Array<string | Buffer | number | unknown[]>,

--- a/langwatch/src/instrumentation.node.ts
+++ b/langwatch/src/instrumentation.node.ts
@@ -83,14 +83,18 @@ if (
       detectors: [awsEksDetector, envDetector],
     }),
     advanced: {},
-    // Cap per-span payload growth. OTel's defaults are unbounded
-    // (`attributeValueLengthLimit: Infinity`, `attributeCountLimit: 128` only
-    // in newer SDKs) — a single span carrying an oversized `db.statement` or a
-    // huge attribute bag can bloat a trace and, in bulk, pressure the
-    // collector's WAL. These caps bound each span's attribute footprint:
-    // values are truncated at 12k chars and no more than 128 attributes are
-    // kept per span. This is defense-in-depth alongside the per-job root-trace
-    // scoping and ioredis `requireParentSpan` scoping.
+    // Cap per-span payload growth, as defense-in-depth behind the per-job
+    // root-trace scoping below: a single span carrying an oversized
+    // `db.statement` or a huge attribute bag bloats a trace and, in bulk,
+    // pressures the collector's WAL.
+    //
+    // `attributeValueLengthLimit` is the one that actually changes behaviour —
+    // sdk-trace-base defaults it to Infinity, so values were previously
+    // exported whole. `attributeCountLimit` already defaults to 128; it is
+    // restated so both halves of the budget are visible in one place and an
+    // upstream default change shows up as a diff. Note that setting either
+    // here takes precedence over the OTEL_SPAN_ATTRIBUTE_* env vars, which the
+    // SDK only consults when the value is left unset.
     spanLimits: {
       attributeValueLengthLimit: 12_000,
       attributeCountLimit: 128,
@@ -133,21 +137,25 @@ if (
         "@opentelemetry/instrumentation-cucumber": { enabled: false },
         "@opentelemetry/instrumentation-router": { enabled: false },
 
-        // ioredis auto-instrumentation emits one span PER Redis command. The
-        // event-sourcing GroupQueue worker runs continuous background loops on
-        // Redis — BRPOP signal polling, Lua-script leasing (evalsha), holder-set
-        // bookkeeping (sadd/srem), active-key heartbeats (expire), and stats
-        // pushes (lpush) — none of which sit under any application span. Left
-        // unscoped, those loops produced an unbounded per-command span flood
-        // that (together with the mega-trace bug fixed in the GroupQueue) OOM
-        // crash-looped the self-observability Tempo.
+        // ioredis auto-instrumentation emits one span PER Redis command, so
+        // the event-sourcing GroupQueue's Redis chatter (Lua leasing via
+        // evalsha, holder-set bookkeeping, active-key heartbeats, stats pushes)
+        // shows up span-for-span whenever it runs inside an application span.
+        // That is what filled the empty-root mega-trace this PR's GroupQueue
+        // change fixes — the commands were traced because they ran under the
+        // job span, and the job span was parented into the originating
+        // command's trace. Rooting each job bounds them; there is nothing to
+        // turn off here.
         //
-        // `requireParentSpan: true` scopes ioredis so a command is only traced
-        // when it already runs inside an application span (an HTTP request, a
-        // per-job CONSUMER span, etc.). The queue's own plumbing loops — which
-        // have no active parent span — stop creating spans entirely, while
-        // Redis calls made inside real request/job work are still captured
-        // (and remain bounded now that each job is its own root trace).
+        // `requireParentSpan: true` is therefore an EXPLICIT PIN, not a
+        // behaviour change. @opentelemetry/instrumentation-ioredis already
+        // defaults it to true (its README: "default when unset is true"; its
+        // DEFAULT_CONFIG is spread under the caller's config by both the
+        // constructor and setConfig), and we rely on that to keep unparented
+        // background Redis I/O — the queue's BRPOP signal polling, connection
+        // health pings — out of the exporter entirely. Stating it here means an
+        // upstream default flip surfaces as a diff to review rather than a
+        // silent span flood.
         "@opentelemetry/instrumentation-ioredis": {
           requireParentSpan: true,
           // Truncate ioredis db.statement to command + first key

--- a/langwatch/src/server/event-sourcing/queues/__tests__/memory.rootTrace.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/__tests__/memory.rootTrace.unit.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression guard for the per-job root-trace scoping fix.
+ *
+ * The event-sourcing queue workers used to run each job inside the originating
+ * command's (remote) span context, so every job a single command produced
+ * accreted into one shared trace. A high-fan-out command (e.g. an OTLP ingest
+ * with hundreds of thousands of spans) collapsed into a single ~6-minute,
+ * empty-root mega-trace that OOM-crash-looped the self-observability collector.
+ *
+ * The fix roots the per-job span (`root: true`) so each job is its own bounded
+ * trace regardless of the ambient context. This test proves that invariant on
+ * the in-memory queue (the Redis-free path that shares the exact same
+ * `withActiveSpan(..., { root: true }, ...)` call), using a real
+ * TracerProvider + in-memory exporter.
+ */
+import { context, trace } from "@opentelemetry/api";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("@langwatch/observability", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  })),
+}));
+
+import type { EventSourcedQueueDefinition } from "../../queues";
+import { EventSourcedQueueProcessorMemory } from "../memory";
+
+describe("EventSourcedQueueProcessorMemory root-trace scoping", () => {
+  let provider: NodeTracerProvider;
+  let exporter: InMemorySpanExporter;
+
+  beforeAll(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+  });
+
+  afterAll(async () => {
+    await provider.shutdown();
+    trace.disable();
+    context.disable();
+  });
+
+  afterEach(() => {
+    exporter.reset();
+  });
+
+  it("processes each job as its own root trace even inside an active parent span", async () => {
+    const processor = new EventSourcedQueueProcessorMemory<{ id: string }>({
+      name: "test-queue",
+      process: vi.fn().mockResolvedValue(void 0),
+    } as EventSourcedQueueDefinition<{ id: string }>);
+
+    // Simulate the originating command / request context: an active span whose
+    // trace the job must NOT be pulled into.
+    const ambientTracer = trace.getTracer("test-ambient");
+    const ambientTraceId = await ambientTracer.startActiveSpan(
+      "originating-command",
+      async (ambient) => {
+        try {
+          await processor.send({ id: "job-1" });
+          return ambient.spanContext().traceId;
+        } finally {
+          ambient.end();
+        }
+      },
+    );
+
+    const jobSpan = exporter
+      .getFinishedSpans()
+      .find((span) => span.name === "pipeline.process");
+
+    expect(jobSpan).toBeDefined();
+    // Root span: no parent, and a brand-new trace id distinct from the
+    // originating command's trace — never accreting into a shared trace.
+    expect(jobSpan!.parentSpanContext).toBeUndefined();
+    expect(jobSpan!.spanContext().traceId).not.toBe(ambientTraceId);
+  });
+
+  it("gives sibling jobs from the same parent independent traces", async () => {
+    const processor = new EventSourcedQueueProcessorMemory<{ id: string }>({
+      name: "test-queue",
+      process: vi.fn().mockResolvedValue(void 0),
+    } as EventSourcedQueueDefinition<{ id: string }>);
+
+    const ambientTracer = trace.getTracer("test-ambient");
+    await ambientTracer.startActiveSpan("originating-command", async (ambient) => {
+      try {
+        await processor.send({ id: "job-a" });
+        await processor.send({ id: "job-b" });
+      } finally {
+        ambient.end();
+      }
+    });
+
+    const jobTraceIds = exporter
+      .getFinishedSpans()
+      .filter((span) => span.name === "pipeline.process")
+      .map((span) => span.spanContext().traceId);
+
+    expect(jobTraceIds).toHaveLength(2);
+    // Two jobs from the same originating context land in two distinct traces,
+    // rather than piling into one unbounded mega-trace.
+    expect(new Set(jobTraceIds).size).toBe(2);
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1,11 +1,6 @@
 import { performance } from "node:perf_hooks";
 import { createLogger } from "@langwatch/observability";
-import {
-  context as otelContext,
-  SpanKind,
-  TraceFlags,
-  trace,
-} from "@opentelemetry/api";
+import { SpanKind, TraceFlags, trace } from "@opentelemetry/api";
 import fastq from "fastq";
 import { Cluster, Redis as IORedis } from "ioredis";
 import { getLangWatchTracer } from "langwatch";
@@ -965,6 +960,21 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           spanName,
           {
             kind: SpanKind.CONSUMER,
+            // Force a NEW root trace for every job. A single command can stage
+            // hundreds of thousands of jobs (e.g. one OTLP ingest with 330k+
+            // spans), all carrying the SAME originating trace context. If the
+            // job span inherited that context as its parent — as it did when
+            // the originating span context was restored as the active context
+            // below — every one of those jobs collapsed into one shared
+            // traceId whose (remote) root was never exported, producing the
+            // ~6-minute, empty-root mega-trace (330k–413k spans) that
+            // OOM-crash-looped the self-observability Tempo on WAL replay.
+            // `root: true` guarantees each job is its own bounded trace;
+            // causality back to the originating command is preserved as a span
+            // LINK (added below), not by sharing a traceId. The full
+            // producer→consumer links redesign is tracked in
+            // langwatch/langwatch#5894.
+            root: true,
             attributes: spanAttributes,
           },
           async (span) => {
@@ -1234,18 +1244,14 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         );
       };
 
-      // Restore parent OTEL context if available
-      if (contextMetadata?.traceId && contextMetadata?.parentSpanId) {
-        const parentContext = trace.setSpanContext(otelContext.active(), {
-          traceId: contextMetadata.traceId,
-          spanId: contextMetadata.parentSpanId,
-          traceFlags: TraceFlags.SAMPLED,
-          isRemote: true,
-        });
-        await otelContext.with(parentContext, executeWithSpan);
-      } else {
-        await executeWithSpan();
-      }
+      // Each job runs as its own root trace (`root: true` on the span above).
+      // We deliberately do NOT restore the originating command's remote span
+      // context as the job's parent: doing so merged every job produced by a
+      // single command into one unbounded trace (the empty-root mega-trace).
+      // Causality to the originating command is preserved as a span LINK
+      // (added inside the span callback), which references the command's trace
+      // without merging into it.
+      await executeWithSpan();
     } finally {
       clearInterval(heartbeat);
       this.activeJobCount--;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -926,7 +926,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     this.activeJobCount++;
 
     try {
-      // Restore OTEL trace context and wrap in a span
+      // Wrap job execution in its own isolated root span
       const spanName = `${this.queueName}/${this.jobName}`;
       const spanAttributes: Record<string, string | number | boolean> = {
         "queue.name": this.queueName,
@@ -962,11 +962,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
             kind: SpanKind.CONSUMER,
             // Force a NEW root trace for every job. A single command can stage
             // hundreds of thousands of jobs (e.g. one OTLP ingest with 330k+
-            // spans), all carrying the SAME originating trace context. If the
-            // job span inherited that context as its parent — as it did when
-            // the originating span context was restored as the active context
-            // below — every one of those jobs collapsed into one shared
-            // traceId whose (remote) root was never exported, producing the
+            // spans), all carrying the SAME originating trace context. This
+            // processor used to restore that context as the active one before
+            // opening the job span, so every one of those jobs inherited it as
+            // a parent and collapsed into one shared traceId whose (remote)
+            // root was never exported, producing the
             // ~6-minute, empty-root mega-trace (330k–413k spans) that
             // OOM-crash-looped the self-observability Tempo on WAL replay.
             // `root: true` guarantees each job is its own bounded trace;

--- a/langwatch/src/server/event-sourcing/queues/memory.ts
+++ b/langwatch/src/server/event-sourcing/queues/memory.ts
@@ -222,6 +222,10 @@ export class EventSourcedQueueProcessorMemory<
         "pipeline.process",
         {
           kind: SpanKind.INTERNAL,
+          // Root the span per job, mirroring the Redis-backed GroupQueue: each
+          // processed job is its own bounded trace rather than a child of any
+          // ambient context, so dev/test traces never chain into one another.
+          root: true,
           attributes,
         },
         async () => {


### PR DESCRIPTION
> **Draft.** Base is `main` — this is the immediate instrumentation fix and does not depend on any other PR.

## What

The internal self-observability Tempo was OOM-crash-looping (OOMKilled while replaying its WAL). Root cause, verified against prod trace blocks: `langwatch-workers` was emitting a handful of traces with **330,000–413,000 spans each**, ~360s long, with an **empty root span name** — four such traces held 1.47M of a block's 1.47M spans (normal traces are 11–24 spans).

The cause is one app-side bug, fixed here:

1. **The event-sourcing queue worker reparented every job into the originating command's trace.** Each processed job restored the command's remote span context as the job span's parent, so all jobs sharing one originating trace landed on one `traceId`. A single high-fan-out command — one OTLP ingest with 330k+ spans stages 330k+ jobs — collapsed into one unbounded trace whose remote root was never exported (hence the empty root name), spanning the worker's whole ~6-minute processing window.

The traced Redis commands that padded those traces (`db.statement`, `db.connection_string`, `net.peer.*` per command — the queue's Lua leasing, holder-set bookkeeping, active-key heartbeats, stats pushes) were a symptom of the same bug, not a second one: they were traced because they ran *inside* the per-job span, and that span was parented into the command's trace. Rooting each job bounds them. An earlier revision of this PR claimed `requireParentSpan: true` was a second fix — it is not, see below.

## How

- **Per-job root trace (`groupQueue.ts`, `memory.ts`).** The per-job span is now created with `root: true`, so each job is its own bounded trace regardless of ambient/remote context. The reparenting block (`trace.setSpanContext(...)` + `context.with(...)`) is removed. The existing **span LINK** from the job span back to the originating command's span context is kept, so causality is preserved without merging traces.
- **Pin ioredis `requireParentSpan` (`instrumentation.node.ts`).** Set explicitly to `true`, but this is an **upgrade guard, not a mitigation**: `@opentelemetry/instrumentation-ioredis@0.67.0` already defaults it to true (`DEFAULT_CONFIG`, spread under the caller's config in both the constructor and `setConfig`; its README says "default when unset is true"). We depend on that default to keep genuinely unparented background Redis I/O out of the exporter, so stating it means an upstream flip surfaces as a diff to review. It changes nothing about the incident. `dbStatementSerializer` truncation is retained. (Caught in review by @langwatch-agent.)
- **`spanLimits` (`instrumentation.node.ts`).** `setupObservability(...)` was called with no `spanLimits`. Added `attributeValueLengthLimit: 12000` — the one that changes behaviour, since sdk-trace-base defaults it to `Infinity` — plus `attributeCountLimit: 128`, which restates the existing default so both halves of the budget are visible in one place. Defense-in-depth behind the root-trace scoping. Note that setting these takes precedence over the `OTEL_SPAN_ATTRIBUTE_*` env vars, which the SDK only consults when a value is left unset.

### What this means for the end-to-end trace view

Within a single job the waterfall is unchanged: the job's root CONSUMER span still parents the `fold`/`map`/`reactor` INTERNAL spans, so `job-root -> fold -> reactor / reactor / reactor` is one clean nested trace. What changes is the async hop from the originating request/command to the job: it is now an **OTel span link** (navigable in Grafana/Tempo's trace + service-graph views) rather than an inline parent edge. Inlining that hop is exactly what produced the unbounded mega-trace for high-fan-out commands. Restoring a *seamless-but-bounded* `request -> ... -> reactor` waterfall (e.g. inline for low fan-out, link for high fan-out) is the causality redesign tracked in **#5894**.

## bullmq-otel's role / BullMQ removability (verified, not changed here)

The mega-trace is **not** from BullMQ. The event-sourcing queue is the in-house Redis+Lua **GroupQueue** (see `event-sourcing/queues/groupQueue/ARCHITECTURE.md` — "Not BullMQ"); the mega-trace's child spans (`{event-sourcing/jobs}/queue`) are the GroupQueue's own per-job spans. `bullmq-otel` (`BullMQOtel`) is confined to **topic clustering** (`queueWithFallback.ts`, `topicClusteringWorker.ts`) and does not contribute.

BullMQ on `main` remains live in:
- **Topic clustering** — `topicClusteringWorker.ts` (`new Worker` + `BullMQOtel`) + `topicClusteringQueue.ts` (`QueueWithFallback`); helpers `queueWithFallback.ts`, `withJobContext.ts`.
- **Gateway ingestion puller** — `ee/governance/services/pullers/pullerQueue.ts` / `pullerWorker.ts` (being migrated off BullMQ separately in #4990).

None of this is provably dead, so **nothing is removed here and no deps are dropped** — topic clustering still executes on BullMQ, so removal is a migration, not this PR. Tracked in **#5893**.

## Out of scope (deferred follow-ups)

- Full command->event span-link causality redesign — **#5894**.
- BullMQ deletion / dropping `bullmq` + `bullmq-otel` deps — **#5893**.
- Tempo-side defense-in-depth (collector limits) — **langwatch/langwatch-saas#753**.

## Tests

- Review follow-up d3b5031 is **comment-only** (no non-comment lines in the diff), correcting the three comments that overstated the above.
- New unit test `memory.rootTrace.unit.test.ts`: with a real `NodeTracerProvider` + `InMemorySpanExporter`, proves a job processed inside an active parent span produces a **root** span (no parent, new `traceId`), and that two jobs from the same parent get two distinct traces.
- `pnpm typecheck` (tsgo): passes.
- `vitest run src/server/event-sourcing/queues/` : 152 passed (16 files). Redis/ClickHouse integration tests were not run in this environment.

_Lint note: local biome (2.5.1) errors on the pinned 2.4.14 config schema for all files, unrelated to this change — CI pins the matching version._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Observability**
  * Added stricter telemetry caps to keep span attributes bounded.
  * Tightened Redis tracing behavior to better respect parent span scoping, while reducing verbose command details captured.

* **Bug Fixes**
  * Isolated per-job tracing so each job starts its own independent root trace (no ambient/parent context chaining).

* **Tests**
  * Added a regression suite to verify correct “root span” scoping and trace-id separation across queued jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
