### PR TITLE
fix(model-providers): sync newly-added providers across tabs instantly

### DIFF
--- a/langwatch/src/components/prompts/PromptEditorDrawer.tsx
+++ b/langwatch/src/components/prompts/PromptEditorDrawer.tsx
@@ -544,6 +544,40 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
     resolvedDefaultModel,
   ]);
 
+  // Backfill the model once resolvedDefaultModel arrives AFTER the init
+  // effect above already ran with an empty model — e.g. this drawer first
+  // opened on a project with zero providers (getResolvedDefault had
+  // nothing to resolve), and a provider was added in another tab since
+  // (#5827: the cache now refreshes cross-tab, but the init effect is a
+  // one-shot gated by isFormInitialized and never re-fires). Scoped to
+  // brand-new/not-found prompts only, and only while the model field is
+  // still the unresolved empty placeholder, so it can never clobber a
+  // real user edit or server value.
+  const isNewOrNotFoundPrompt =
+    !promptId || (!promptQuery.data && !promptQuery.isLoading);
+  useEffect(() => {
+    if (!isFormInitialized) return;
+    if (!isNewOrNotFoundPrompt) return;
+    if (!resolvedDefaultModel) return;
+    if (methods.getValues("version.configData.llm.model")) return;
+
+    methods.setValue("version.configData.llm.model", resolvedDefaultModel, {
+      shouldDirty: false,
+    });
+    const maxTokens = getMaxTokenLimit(modelMetadata?.[resolvedDefaultModel]);
+    if (maxTokens) {
+      methods.setValue("version.configData.llm.maxTokens", maxTokens, {
+        shouldDirty: false,
+      });
+    }
+  }, [
+    isFormInitialized,
+    isNewOrNotFoundPrompt,
+    resolvedDefaultModel,
+    modelMetadata,
+    methods,
+  ]);
+
   // Reset when drawer closes
   useEffect(() => {
     if (!isOpen) {

--- a/langwatch/src/components/prompts/PromptEditorDrawer.tsx
+++ b/langwatch/src/components/prompts/PromptEditorDrawer.tsx
@@ -564,8 +564,15 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
     methods.setValue("version.configData.llm.model", resolvedDefaultModel, {
       shouldDirty: false,
     });
+    // Only backfill maxTokens alongside the model if the user hasn't
+    // already edited it — a manual token-limit change must survive the
+    // late-arriving default same as it would survive anything else.
+    const maxTokensIsDirty = methods.getFieldState(
+      "version.configData.llm.maxTokens",
+      methods.formState,
+    ).isDirty;
     const maxTokens = getMaxTokenLimit(modelMetadata?.[resolvedDefaultModel]);
-    if (maxTokens) {
+    if (maxTokens && !maxTokensIsDirty) {
       methods.setValue("version.configData.llm.maxTokens", maxTokens, {
         shouldDirty: false,
       });

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from "react";
 import { useForm, useFormContext } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getMaxTokenLimit } from "~/components/llmPromptConfigs/utils/tokenUtils";
+import type { ModelMetadataForFrontend } from "~/hooks/useModelProvidersSettings";
 
 // All mocks need to be set up before any imports
 const mockCloseDrawer = vi.fn();
@@ -588,7 +589,9 @@ describe("PromptEditorDrawer", () => {
         // leaving the model half intact) still fails this test.
         const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
         expect(methods.getValues("version.configData.llm.maxTokens")).toBe(
-          getMaxTokenLimit(mockModelMetadata["openai/gpt-4o"]),
+          getMaxTokenLimit(
+            mockModelMetadata["openai/gpt-4o"] as unknown as ModelMetadataForFrontend,
+          ),
         );
       });
 

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -6,8 +6,9 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { FormProvider, useForm, useFormContext } from "react-hook-form";
+import { useForm, useFormContext } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMaxTokenLimit } from "~/components/llmPromptConfigs/utils/tokenUtils";
 
 // All mocks need to be set up before any imports
 const mockCloseDrawer = vi.fn();
@@ -71,15 +72,17 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
   }),
 }));
 
+const mockModelMetadata = {
+  "openai/gpt-4o": {
+    name: "gpt-4o",
+    max_tokens: 128000,
+    max_output_tokens: 16384,
+  },
+};
+
 vi.mock("~/hooks/useModelProvidersSettings", () => ({
   useModelProvidersSettings: () => ({
-    modelMetadata: {
-      "openai/gpt-4o": {
-        name: "gpt-4o",
-        max_tokens: 128000,
-        max_output_tokens: 16384,
-      },
-    },
+    modelMetadata: mockModelMetadata,
     isLoading: false,
   }),
 }));
@@ -580,6 +583,13 @@ describe("PromptEditorDrawer", () => {
             "openai/gpt-4o",
           );
         });
+        // The maxTokens write is paired with the model write — assert it
+        // too, so removing just the maxTokens half of the backfill (while
+        // leaving the model half intact) still fails this test.
+        const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
+        expect(methods.getValues("version.configData.llm.maxTokens")).toBe(
+          getMaxTokenLimit(mockModelMetadata["openai/gpt-4o"]),
+        );
       });
 
       it("does not clobber a model the user already picked in the rendered selector", async () => {

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -179,6 +179,7 @@ const mockPromptDataWithMessages = {
 };
 
 const mockGetByIdOrHandle = vi.fn();
+const mockGetResolvedDefault = vi.fn();
 const mockCreate = vi.fn();
 const mockUpdate = vi.fn();
 
@@ -194,10 +195,7 @@ vi.mock("~/utils/api", () => ({
     },
     modelProvider: {
       getResolvedDefault: {
-        useQuery: () => ({
-          data: { model: "openai/gpt-4", source: "test", scope: "PROJECT" },
-          isLoading: false,
-        }),
+        useQuery: () => mockGetResolvedDefault(),
       },
     },
     prompts: {
@@ -350,6 +348,10 @@ describe("PromptEditorDrawer", () => {
     capturedInitialConfigValues.length = 0;
     capturedFormMethods.length = 0;
     mockGetByIdOrHandle.mockReturnValue({ data: undefined, isLoading: false });
+    mockGetResolvedDefault.mockReturnValue({
+      data: { model: "openai/gpt-4", source: "test", scope: "PROJECT" },
+      isLoading: false,
+    });
     // Default: form values equal saved values (no changes)
     mockAreFormValuesEqual.mockReturnValue(true);
     // Reset drawer params
@@ -520,6 +522,100 @@ describe("PromptEditorDrawer", () => {
     it("Save button is disabled when no handle entered", () => {
       renderWithProviders(<PromptEditorDrawer open={true} />);
       expect(screen.getByTestId("save-prompt-button")).toBeDisabled();
+    });
+  });
+
+  describe("given a project with zero enabled providers when the drawer first opens (#5827 continuation)", () => {
+    /**
+     * @scenario The drawer's init effect runs once and locks in
+     * model: "" when getResolvedDefault has nothing to resolve yet. A
+     * provider gets added in another tab; the cross-tab BroadcastChannel
+     * fix (#5827) refreshes getResolvedDefault here too — but the init
+     * effect is one-shot and never re-fires, so without a dedicated
+     * backfill the form stayed stuck on a blank model forever, showing
+     * an empty selector even though isEmpty had already flipped false.
+     */
+    it("adopts the model once getResolvedDefault resolves after initial mount", async () => {
+      mockGetResolvedDefault.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+      });
+
+      const { rerender } = renderWithProviders(
+        <PromptEditorDrawer open={true} />,
+      );
+
+      await waitFor(() => {
+        expect(capturedFormMethods.length).toBeGreaterThan(0);
+      });
+      await waitFor(() => {
+        const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
+        expect(methods.getValues("version.configData.llm.model")).toBe("");
+      });
+
+      // A provider was added in another tab; getResolvedDefault now
+      // resolves on refetch (simulated here via a re-render with new
+      // mock data, since the query itself is mocked out).
+      mockGetResolvedDefault.mockReturnValue({
+        data: { model: "openai/gpt-4o", source: "provider", scope: "PROJECT" },
+        isLoading: false,
+      });
+      rerender(
+        <ChakraProvider value={defaultSystem}>
+          <PromptEditorDrawer open={true} />
+        </ChakraProvider>,
+      );
+
+      await waitFor(() => {
+        const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
+        expect(methods.getValues("version.configData.llm.model")).toBe(
+          "openai/gpt-4o",
+        );
+      });
+    });
+
+    it("does not clobber a model the user already picked before resolution arrived", async () => {
+      mockGetResolvedDefault.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+      });
+
+      const { rerender } = renderWithProviders(
+        <PromptEditorDrawer open={true} />,
+      );
+
+      await waitFor(() => {
+        const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
+        expect(methods.getValues("version.configData.llm.model")).toBe("");
+      });
+
+      // User manually picks a model before any provider resolves.
+      const methodsBeforeBackfill =
+        capturedFormMethods[capturedFormMethods.length - 1]!;
+      methodsBeforeBackfill.setValue(
+        "version.configData.llm.model",
+        "anthropic/claude-3-5-sonnet",
+      );
+
+      mockGetResolvedDefault.mockReturnValue({
+        data: { model: "openai/gpt-4o", source: "provider", scope: "PROJECT" },
+        isLoading: false,
+      });
+      rerender(
+        <ChakraProvider value={defaultSystem}>
+          <PromptEditorDrawer open={true} />
+        </ChakraProvider>,
+      );
+
+      // The backfill only fills a genuinely empty model — it must never
+      // overwrite a real (even if not yet saved) user selection.
+      await waitFor(() => {
+        expect(capturedFormMethods.length).toBeGreaterThan(0);
+      });
+      const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
+      expect(methods.getValues("version.configData.llm.model")).toBe(
+        "anthropic/claude-3-5-sonnet",
+      );
     });
   });
 

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -6,7 +6,7 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // All mocks need to be set up before any imports
@@ -237,11 +237,17 @@ vi.mock("~/components/ui/toaster", () => ({
   toaster: { create: vi.fn() },
 }));
 
-// Mock the form components since they're complex
+// Mock the form components since they're complex. Reads the live model
+// value via useFormContext (not mocked) rather than a hardcoded string, so
+// tests can assert on rendered output instead of only inspecting captured
+// form methods directly.
 vi.mock("~/prompts/forms/fields/ModelSelectFieldMini", () => ({
-  ModelSelectFieldMini: () => (
-    <button data-testid="model-select">gpt-4o</button>
-  ),
+  ModelSelectFieldMini: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { watch } = useFormContext();
+    const model = watch("version.configData.llm.model");
+    return <button data-testid="model-select">{model || "(no model)"}</button>;
+  },
 }));
 
 vi.mock(
@@ -525,97 +531,158 @@ describe("PromptEditorDrawer", () => {
     });
   });
 
-  describe("given a project with zero enabled providers when the drawer first opens (#5827 continuation)", () => {
-    /**
-     * @scenario The drawer's init effect runs once and locks in
-     * model: "" when getResolvedDefault has nothing to resolve yet. A
-     * provider gets added in another tab; the cross-tab BroadcastChannel
-     * fix (#5827) refreshes getResolvedDefault here too — but the init
-     * effect is one-shot and never re-fires, so without a dedicated
-     * backfill the form stayed stuck on a blank model forever, showing
-     * an empty selector even though isEmpty had already flipped false.
-     */
-    it("adopts the model once getResolvedDefault resolves after initial mount", async () => {
-      mockGetResolvedDefault.mockReturnValue({
-        data: undefined,
-        isLoading: false,
+  describe("given a project with zero enabled providers", () => {
+    describe("when getResolvedDefault resolves after the drawer already opened (#5827 continuation)", () => {
+      /**
+       * @scenario The drawer's init effect runs once and locks in
+       * model: "" when getResolvedDefault has nothing to resolve yet. A
+       * provider gets added in another tab; the cross-tab BroadcastChannel
+       * fix (#5827) refreshes getResolvedDefault here too — but the init
+       * effect is one-shot and never re-fires, so without a dedicated
+       * backfill the form stayed stuck on a blank model forever, showing
+       * an empty selector even though isEmpty had already flipped false.
+       */
+      it("adopts the model in the rendered selector once getResolvedDefault resolves", async () => {
+        mockGetResolvedDefault.mockReturnValue({
+          data: undefined,
+          isLoading: false,
+        });
+
+        const { rerender } = renderWithProviders(
+          <PromptEditorDrawer open={true} />,
+        );
+
+        await waitFor(() => {
+          expect(screen.getByTestId("model-select")).toHaveTextContent(
+            "(no model)",
+          );
+        });
+
+        // A provider was added in another tab; getResolvedDefault now
+        // resolves on refetch (simulated here via a re-render with new
+        // mock data, since the query itself is mocked out).
+        mockGetResolvedDefault.mockReturnValue({
+          data: {
+            model: "openai/gpt-4o",
+            source: "provider",
+            scope: "PROJECT",
+          },
+          isLoading: false,
+        });
+        rerender(
+          <ChakraProvider value={defaultSystem}>
+            <PromptEditorDrawer open={true} />
+          </ChakraProvider>,
+        );
+
+        await waitFor(() => {
+          expect(screen.getByTestId("model-select")).toHaveTextContent(
+            "openai/gpt-4o",
+          );
+        });
       });
 
-      const { rerender } = renderWithProviders(
-        <PromptEditorDrawer open={true} />,
-      );
+      it("does not clobber a model the user already picked in the rendered selector", async () => {
+        mockGetResolvedDefault.mockReturnValue({
+          data: undefined,
+          isLoading: false,
+        });
 
-      await waitFor(() => {
-        expect(capturedFormMethods.length).toBeGreaterThan(0);
-      });
-      await waitFor(() => {
-        const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
-        expect(methods.getValues("version.configData.llm.model")).toBe("");
-      });
+        const { rerender } = renderWithProviders(
+          <PromptEditorDrawer open={true} />,
+        );
 
-      // A provider was added in another tab; getResolvedDefault now
-      // resolves on refetch (simulated here via a re-render with new
-      // mock data, since the query itself is mocked out).
-      mockGetResolvedDefault.mockReturnValue({
-        data: { model: "openai/gpt-4o", source: "provider", scope: "PROJECT" },
-        isLoading: false,
-      });
-      rerender(
-        <ChakraProvider value={defaultSystem}>
-          <PromptEditorDrawer open={true} />
-        </ChakraProvider>,
-      );
+        await waitFor(() => {
+          expect(screen.getByTestId("model-select")).toHaveTextContent(
+            "(no model)",
+          );
+        });
 
-      await waitFor(() => {
-        const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
-        expect(methods.getValues("version.configData.llm.model")).toBe(
-          "openai/gpt-4o",
+        // User manually picks a model before any provider resolves.
+        const methodsBeforeBackfill =
+          capturedFormMethods[capturedFormMethods.length - 1]!;
+        methodsBeforeBackfill.setValue(
+          "version.configData.llm.model",
+          "anthropic/claude-3-5-sonnet",
+        );
+        await waitFor(() => {
+          expect(screen.getByTestId("model-select")).toHaveTextContent(
+            "anthropic/claude-3-5-sonnet",
+          );
+        });
+
+        mockGetResolvedDefault.mockReturnValue({
+          data: {
+            model: "openai/gpt-4o",
+            source: "provider",
+            scope: "PROJECT",
+          },
+          isLoading: false,
+        });
+        rerender(
+          <ChakraProvider value={defaultSystem}>
+            <PromptEditorDrawer open={true} />
+          </ChakraProvider>,
+        );
+
+        // The backfill only fills a genuinely empty model — it must never
+        // overwrite a real (even if not yet saved) user selection.
+        expect(screen.getByTestId("model-select")).toHaveTextContent(
+          "anthropic/claude-3-5-sonnet",
         );
       });
-    });
 
-    it("does not clobber a model the user already picked before resolution arrived", async () => {
-      mockGetResolvedDefault.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-      });
+      it("does not clobber a maxTokens value the user already edited", async () => {
+        mockGetResolvedDefault.mockReturnValue({
+          data: undefined,
+          isLoading: false,
+        });
 
-      const { rerender } = renderWithProviders(
-        <PromptEditorDrawer open={true} />,
-      );
+        const { rerender } = renderWithProviders(
+          <PromptEditorDrawer open={true} />,
+        );
 
-      await waitFor(() => {
+        await waitFor(() => {
+          expect(screen.getByTestId("model-select")).toHaveTextContent(
+            "(no model)",
+          );
+        });
+
+        // User edits the token limit before any provider resolves.
+        const methodsBeforeBackfill =
+          capturedFormMethods[capturedFormMethods.length - 1]!;
+        methodsBeforeBackfill.setValue(
+          "version.configData.llm.maxTokens",
+          777,
+          { shouldDirty: true },
+        );
+
+        mockGetResolvedDefault.mockReturnValue({
+          data: {
+            model: "openai/gpt-4o",
+            source: "provider",
+            scope: "PROJECT",
+          },
+          isLoading: false,
+        });
+        rerender(
+          <ChakraProvider value={defaultSystem}>
+            <PromptEditorDrawer open={true} />
+          </ChakraProvider>,
+        );
+
+        // The model still backfills (it was never dirtied)...
+        await waitFor(() => {
+          expect(screen.getByTestId("model-select")).toHaveTextContent(
+            "openai/gpt-4o",
+          );
+        });
+        // ...but the user's manually-edited token limit survives.
         const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
-        expect(methods.getValues("version.configData.llm.model")).toBe("");
+        expect(methods.getValues("version.configData.llm.maxTokens")).toBe(
+          777,
+        );
       });
-
-      // User manually picks a model before any provider resolves.
-      const methodsBeforeBackfill =
-        capturedFormMethods[capturedFormMethods.length - 1]!;
-      methodsBeforeBackfill.setValue(
-        "version.configData.llm.model",
-        "anthropic/claude-3-5-sonnet",
-      );
-
-      mockGetResolvedDefault.mockReturnValue({
-        data: { model: "openai/gpt-4o", source: "provider", scope: "PROJECT" },
-        isLoading: false,
-      });
-      rerender(
-        <ChakraProvider value={defaultSystem}>
-          <PromptEditorDrawer open={true} />
-        </ChakraProvider>,
-      );
-
-      // The backfill only fills a genuinely empty model — it must never
-      // overwrite a real (even if not yet saved) user selection.
-      await waitFor(() => {
-        expect(capturedFormMethods.length).toBeGreaterThan(0);
-      });
-      const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
-      expect(methods.getValues("version.configData.llm.model")).toBe(
-        "anthropic/claude-3-5-sonnet",
-      );
     });
   });
 

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -76,8 +76,12 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
 const mockModelMetadata = {
   "openai/gpt-4o": {
     name: "gpt-4o",
-    max_tokens: 128000,
-    max_output_tokens: 16384,
+    // Real ModelMetadataForFrontend field names — getMaxTokenLimit reads
+    // these two specifically. Wrong names here would make the backfill
+    // test silently pass via FALLBACK_MAX_TOKENS instead of exercising
+    // the actual extraction path.
+    contextLength: 128000,
+    maxCompletionTokens: 16384,
   },
 };
 

--- a/langwatch/src/hooks/useProviderFormSubmit.ts
+++ b/langwatch/src/hooks/useProviderFormSubmit.ts
@@ -13,6 +13,10 @@ import {
   hasUserEnteredNewApiKey,
   hasUserModifiedNonApiKeyFields,
 } from "../utils/modelProviderHelpers";
+import {
+  broadcastModelProvidersUpdated,
+  invalidateModelProviderQueries,
+} from "../utils/modelProviderSync";
 import type { ExtraHeader } from "./useExtraHeaders";
 
 /** Snapshot of all form state needed at submission time. */
@@ -115,6 +119,8 @@ export function useProviderFormSubmit({
           customEmbeddingsModels:
             snapshot.provider.customEmbeddingsModels ?? [],
         });
+        await invalidateModelProviderQueries(utils);
+        broadcastModelProvidersUpdated();
         onSuccess?.();
       } catch (err) {
         onError?.(err);
@@ -127,7 +133,7 @@ export function useProviderFormSubmit({
         });
       }
     },
-    [getFormSnapshot, onSuccess, onError, updateMutation],
+    [getFormSnapshot, onSuccess, onError, updateMutation, utils],
   );
 
   const submit = useCallback(async () => {
@@ -440,14 +446,13 @@ export function useProviderFormSubmit({
       // affordance), which reads as "the save didn't take" and drives
       // users to re-add the same provider (the other duplicate-row path
       // in #5380).
-      await Promise.all([
-        utils.modelProvider.getAllForProject.invalidate(),
-        utils.modelProvider.getAllForProjectForFrontend.invalidate(),
-        utils.modelProvider.listAllForProjectForFrontend.invalidate(),
-        utils.modelProvider.listAllForOrganizationForFrontend.invalidate(),
-        utils.modelProvider.getResolvedDefault.invalidate(),
-        utils.modelProvider.getDefaultModelsForProject.invalidate(),
-      ]);
+      await invalidateModelProviderQueries(utils);
+      // This save may have happened in a tab opened by
+      // NoModelsConfiguredCallout's "Set up" link — broadcast so the
+      // opener tab's picker (a different QueryClient instance) refreshes
+      // immediately instead of waiting on a window-focus event that,
+      // for a window.open'd tab pair, often never reliably fires (#5827).
+      broadcastModelProvidersUpdated();
 
       toaster.create({
         title: "Model Provider Updated",

--- a/langwatch/src/utils/__tests__/modelProviderSync.unit.test.ts
+++ b/langwatch/src/utils/__tests__/modelProviderSync.unit.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  broadcastModelProvidersUpdated,
+  invalidateModelProviderQueries,
+  subscribeToModelProvidersUpdated,
+} from "../modelProviderSync";
+
+/**
+ * jsdom doesn't implement real cross-instance BroadcastChannel delivery, so
+ * exercising the actual browser API here would test jsdom's fidelity, not
+ * our wiring. This fake reproduces just the piece our module depends on
+ * (same-name instances see each other's postMessage, synchronously — real
+ * BroadcastChannel is async, but that distinction doesn't matter for
+ * asserting delivery/no-delivery contracts).
+ */
+class FakeBroadcastChannel {
+  static channels = new Map<string, Set<FakeBroadcastChannel>>();
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  constructor(public name: string) {
+    const peers = FakeBroadcastChannel.channels.get(name) ?? new Set();
+    peers.add(this);
+    FakeBroadcastChannel.channels.set(name, peers);
+  }
+  postMessage(data: unknown) {
+    for (const peer of FakeBroadcastChannel.channels.get(this.name) ?? []) {
+      if (peer !== this) peer.onmessage?.({ data });
+    }
+  }
+  close() {
+    FakeBroadcastChannel.channels.get(this.name)?.delete(this);
+  }
+}
+
+describe("modelProviderSync", () => {
+  beforeEach(() => {
+    FakeBroadcastChannel.channels.clear();
+    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("given a tab opened NoModelsConfiguredCallout's settings link", () => {
+    it("delivers a broadcast from one BroadcastChannel handle to another", () => {
+      const onUpdate = vi.fn();
+      const unsubscribe = subscribeToModelProvidersUpdated(onUpdate);
+
+      broadcastModelProvidersUpdated();
+
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      unsubscribe();
+    });
+
+    it("stops delivering messages after unsubscribe", () => {
+      const onUpdate = vi.fn();
+      const unsubscribe = subscribeToModelProvidersUpdated(onUpdate);
+      unsubscribe();
+
+      broadcastModelProvidersUpdated();
+
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when BroadcastChannel is unavailable", () => {
+    it("no-ops instead of throwing", () => {
+      vi.stubGlobal("BroadcastChannel", undefined);
+
+      expect(() => broadcastModelProvidersUpdated()).not.toThrow();
+      const unsubscribe = subscribeToModelProvidersUpdated(vi.fn());
+      expect(() => unsubscribe()).not.toThrow();
+    });
+  });
+
+  describe("invalidateModelProviderQueries", () => {
+    it("invalidates every query surface that reads stored provider/default-model state", async () => {
+      const invalidate = vi.fn().mockResolvedValue(undefined);
+      const utils = {
+        modelProvider: {
+          getAllForProject: { invalidate },
+          getAllForProjectForFrontend: { invalidate },
+          listAllForProjectForFrontend: { invalidate },
+          listAllForOrganizationForFrontend: { invalidate },
+          getResolvedDefault: { invalidate },
+          getDefaultModelsForProject: { invalidate },
+        },
+      } as any;
+
+      await invalidateModelProviderQueries(utils);
+
+      expect(invalidate).toHaveBeenCalledTimes(6);
+    });
+  });
+});

--- a/langwatch/src/utils/api.tsx
+++ b/langwatch/src/utils/api.tsx
@@ -23,7 +23,7 @@ import {
 } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import superjson from "superjson";
 import type { AppRouter } from "~/server/api/root";
 import {
@@ -31,6 +31,10 @@ import {
   showMissingModelToast,
   showProviderDisabledToast,
 } from "../components/MissingModelToast";
+import {
+  invalidateModelProviderQueries,
+  subscribeToModelProvidersUpdated,
+} from "./modelProviderSync";
 import { useUpgradeModalStore } from "../stores/upgradeModalStore";
 import { sseLink } from "./sseLink";
 import {
@@ -336,6 +340,26 @@ export const trpcClient = createTRPCClient<AppRouter>({
 });
 
 /**
+ * Mounted once inside the provider tree. Listens for model-provider saves
+ * broadcast by OTHER tabs (see modelProviderSync.ts — a tab opened via
+ * `window.open`, e.g. from NoModelsConfiguredCallout, has its own
+ * QueryClient and can't reach this one directly) and invalidates this
+ * tab's cache immediately, rather than waiting on a window-focus event.
+ */
+function ModelProviderCrossTabSync() {
+  const utils = api.useContext();
+
+  useEffect(
+    () => subscribeToModelProvidersUpdated(() => {
+      void invalidateModelProviderQueries(utils);
+    }),
+    [utils],
+  );
+
+  return null;
+}
+
+/**
  * TRPCProvider component that replaces the old api.withTRPC() HOC from @trpc/next.
  * Provides QueryClient and tRPC client to the React tree.
  */
@@ -352,7 +376,10 @@ export function TRPCProvider({ children }: { children: ReactNode }) {
 
   return (
     <api.Provider client={trpcClientInstance} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <ModelProviderCrossTabSync />
+        {children}
+      </QueryClientProvider>
     </api.Provider>
   );
 }

--- a/langwatch/src/utils/modelProviderSync.ts
+++ b/langwatch/src/utils/modelProviderSync.ts
@@ -1,0 +1,71 @@
+import type { api } from "./api";
+
+/**
+ * BroadcastChannel name for cross-tab model-provider sync.
+ *
+ * NoModelsConfiguredCallout opens /settings/model-providers via
+ * `window.open(..., "_blank")` rather than an in-app navigation, so the
+ * settings page runs in its own tab with its own QueryClient instance.
+ * Saving a provider there invalidates that tab's cache just fine, but the
+ * ORIGINAL tab (e.g. a still-open "New Prompt" dialog) has no route back to
+ * that cache and previously depended on `refetchOnWindowFocus` alone to
+ * notice — which doesn't fire until the user manually refocuses the
+ * original tab, and in practice left the picker stuck empty until a hard
+ * refresh (#5827). Posting here on save lets every other open tab
+ * invalidate immediately, focus or no focus.
+ */
+const MODEL_PROVIDER_SYNC_CHANNEL = "langwatch:model-providers-updated";
+
+function getChannel(): BroadcastChannel | null {
+  if (
+    typeof window === "undefined" ||
+    typeof BroadcastChannel === "undefined"
+  ) {
+    return null;
+  }
+  return new BroadcastChannel(MODEL_PROVIDER_SYNC_CHANNEL);
+}
+
+/** Call once a model-provider create/update/enable mutation has succeeded
+ *  (and this tab's own queries are already invalidated) so every other open
+ *  tab picks up the change too. No-ops in SSR or browsers without
+ *  BroadcastChannel — those still fall back to focus refetch. */
+export function broadcastModelProvidersUpdated() {
+  const channel = getChannel();
+  if (!channel) return;
+  channel.postMessage({ type: "model-providers-updated" });
+  channel.close();
+}
+
+/** Subscribes `onUpdate` to saves broadcast by other tabs. Returns a cleanup
+ *  function (or a no-op where BroadcastChannel isn't available) — call from
+ *  a `useEffect`. */
+export function subscribeToModelProvidersUpdated(
+  onUpdate: () => void,
+): () => void {
+  const channel = getChannel();
+  if (!channel) return () => {};
+  channel.onmessage = onUpdate;
+  return () => channel.close();
+}
+
+type ModelProviderUtils = Pick<
+  ReturnType<typeof api.useContext>,
+  "modelProvider"
+>;
+
+/** Every tRPC query surface whose freshness depends on the stored
+ *  ModelProvider/ModelDefault rows. Shared by the same-tab mutation success
+ *  path (useProviderFormSubmit) and the cross-tab listener
+ *  (useModelProviderCrossTabSync) so the two invalidation lists can never
+ *  drift apart. */
+export function invalidateModelProviderQueries(utils: ModelProviderUtils) {
+  return Promise.all([
+    utils.modelProvider.getAllForProject.invalidate(),
+    utils.modelProvider.getAllForProjectForFrontend.invalidate(),
+    utils.modelProvider.listAllForProjectForFrontend.invalidate(),
+    utils.modelProvider.listAllForOrganizationForFrontend.invalidate(),
+    utils.modelProvider.getResolvedDefault.invalidate(),
+    utils.modelProvider.getDefaultModelsForProject.invalidate(),
+  ]);
+}

--- a/langwatch/src/utils/modelProviderSync.ts
+++ b/langwatch/src/utils/modelProviderSync.ts
@@ -14,7 +14,7 @@ import type { api } from "./api";
  * refresh (#5827). Posting here on save lets every other open tab
  * invalidate immediately, focus or no focus.
  */
-const MODEL_PROVIDER_SYNC_CHANNEL = "langwatch:model-providers-updated";
+const MODEL_PROVIDER_SYNC_CHANNEL = "langwatch:model-providers-updated" as const;
 
 function getChannel(): BroadcastChannel | null {
   if (
@@ -23,7 +23,15 @@ function getChannel(): BroadcastChannel | null {
   ) {
     return null;
   }
-  return new BroadcastChannel(MODEL_PROVIDER_SYNC_CHANNEL);
+  try {
+    return new BroadcastChannel(MODEL_PROVIDER_SYNC_CHANNEL);
+  } catch {
+    // Some browsers throw (e.g. SecurityError) in restricted contexts —
+    // opaque-origin iframes, strict privacy modes. This runs on a
+    // mutation's success path, so degrade to null (falls back to focus
+    // refetch) rather than let it surface as a save-failed toast.
+    return null;
+  }
 }
 
 /** Call once a model-provider create/update/enable mutation has succeeded
@@ -57,8 +65,8 @@ type ModelProviderUtils = Pick<
 /** Every tRPC query surface whose freshness depends on the stored
  *  ModelProvider/ModelDefault rows. Shared by the same-tab mutation success
  *  path (useProviderFormSubmit) and the cross-tab listener
- *  (useModelProviderCrossTabSync) so the two invalidation lists can never
- *  drift apart. */
+ *  (ModelProviderCrossTabSync in api.tsx) so the two invalidation lists
+ *  can never drift apart. */
 export function invalidateModelProviderQueries(utils: ModelProviderUtils) {
   return Promise.all([
     utils.modelProvider.getAllForProject.invalidate(),


### PR DESCRIPTION
## Summary
- `NoModelsConfiguredCallout` opens `/settings/model-providers` via `window.open(..., "_blank")`, which spins up a brand-new `QueryClient`. Saving a provider there invalidated only that new tab's cache — the original tab (e.g. a still-open "New Prompt" dialog) had no route back to it and depended entirely on `refetchOnWindowFocus`, which doesn't reliably fire for a `window.open`'d tab pair. Result: the model selector stayed empty until a manual hard refresh, even though a working provider + default models had just been saved.
- Adds a `BroadcastChannel`-based cross-tab sync (`src/utils/modelProviderSync.ts`): `useProviderFormSubmit` broadcasts once its own tab's invalidation succeeds, and a listener mounted once in `TRPCProvider` invalidates every other open tab's provider/default-model queries immediately — no focus event required. Falls back gracefully (no-op) in the rare case `BroadcastChannel` is unavailable.
- The invalidation query list used to live inline in `useProviderFormSubmit`; it's now a shared `invalidateModelProviderQueries()` helper used by both the same-tab success path and the new cross-tab listener, so the two can't drift apart.
- **Second bug found while verifying the first fix live** (see "The follow-up bug" below): the query cache refreshing correctly wasn't enough on its own — the Experiments Workbench's New Prompt drawer had a separate one-shot form-hydration bug that left the selector showing *blank* instead of a real model, even after the cache updated. Fixed in `PromptEditorDrawer.tsx`.

## Root cause vs. fix
| | Before | After |
|---|---|---|
| Same-tab save | Invalidates local cache ✅ | Same, unchanged ✅ |
| Cross-tab (opener) | Waits on `refetchOnWindowFocus`, unreliable for `window.open` tabs ❌ | `BroadcastChannel` message triggers immediate invalidation ✅ |

## Live verification (bug #1 — cross-tab cache staleness)
Reproduced end-to-end against a fresh account + real OpenAI key, driven via Playwright against the local dev server (native Postgres/ClickHouse/Redis):

1. Fresh project, `/settings/model-providers` — no project-scoped provider, "No default models configured":

   ![before](https://raw.githubusercontent.com/langwatch/langwatch/assets/model-selector-crosstab-screenshots/docs/model-selector-crosstab-fix/01-before-no-project-provider.png)

2. In a second tab, added an OpenAI key at project scope and saved:

   ![add provider](https://raw.githubusercontent.com/langwatch/langwatch/assets/model-selector-crosstab-screenshots/docs/model-selector-crosstab-fix/02-adding-openai-key-in-new-tab.png)

3. Switched back to the **first tab, never reloaded** — OpenAI now shows at project scope and Default Models is populated automatically:

   ![after, no refresh](https://raw.githubusercontent.com/langwatch/langwatch/assets/model-selector-crosstab-screenshots/docs/model-selector-crosstab-fix/03-original-tab-auto-updated.png)

The first tab's console log confirms this wasn't a focus-refetch coincidence: only the `modelProvider.*` queries refired (a generic focus refetch would have refired every active query on the page — `organization.getAll`, `featureFlag.isEnabled`, `limits.getUsage`, etc. — none of which refired).

## The follow-up bug: blank selector in the Experiments Workbench

The original report was specifically about the **New Prompt drawer inside the Experiments Workbench** (`Add to Evaluation` → `Prompt` → `Create your first prompt`), not the standalone Prompt Playground. Reproducing that exact surface — with a **brand new account and zero provider keys anywhere** (including no server-side fallback keys, to match what a real fresh signup sees) — showed that bug #1's fix alone wasn't enough: the "No models configured" callout correctly disappeared once the cache refreshed, but the model field underneath it was **blank**, not populated with a real model.

Root cause: `PromptEditorDrawer`'s form-initialization effect is a **one-shot** effect (guarded by `isFormInitialized`). When the drawer first opens on a project with zero providers, `getResolvedDefault` has nothing to resolve, so the effect locks in `model: ""` and never runs again — even though its dependency array includes `resolvedDefaultModel`, the `isFormInitialized` guard makes every subsequent re-run a no-op. So when bug #1's fix correctly refreshes `getResolvedDefault` in the background after a provider is added elsewhere, nothing picks the new value up. This is a "stale hydration" bug the user correctly diagnosed by ear: the empty-state gate reacts to fresh data, but the actual form value was captured once and never re-synced.

Fixed with a narrow, additive backfill effect in `PromptEditorDrawer.tsx`: once the drawer has initialized, for a new/not-found prompt only, if the model field is still the unresolved empty placeholder, adopt `resolvedDefaultModel` (and its max-token limit) the moment it arrives. It never touches a model the user already picked or a loaded prompt's real value — covered by a dedicated regression test for both cases.

### Live verification (bug #2 — blank selector after cache refresh)
Fresh account again (`hydration-repro-qa@langwatch.ai`), this time with **all server-side provider keys removed** for the run so the empty state is genuine (not masked by a dev-only fallback):

4. New Prompt drawer inside the Experiments Workbench, zero providers anywhere — genuine empty state:

   ![workbench empty](https://raw.githubusercontent.com/langwatch/langwatch/assets/model-selector-crosstab-screenshots/docs/model-selector-crosstab-fix/04-workbench-new-prompt-empty.png)

5. Confirmed at the settings level too — no System-scoped fallback providers, genuinely zero:

   ![settings zero providers](https://raw.githubusercontent.com/langwatch/langwatch/assets/model-selector-crosstab-screenshots/docs/model-selector-crosstab-fix/05-settings-genuinely-zero-providers.png)

6. In a second tab, added a real OpenAI key:

   ![adding key](https://raw.githubusercontent.com/langwatch/langwatch/assets/model-selector-crosstab-screenshots/docs/model-selector-crosstab-fix/06-adding-openai-key-second-tab.png)

7. Back in the **first tab, still never reloaded** — the drawer now shows a real, correctly-populated model (not blank):

   ![workbench populated](https://raw.githubusercontent.com/langwatch/langwatch/assets/model-selector-crosstab-screenshots/docs/model-selector-crosstab-fix/07-workbench-first-tab-populated-no-refresh.png)

I also verified this regression test actually catches the bug: temporarily reverted just the `PromptEditorDrawer.tsx` backfill effect and reran the new test — it failed exactly as expected (model stayed `""` instead of adopting the resolved value), then restored the fix and confirmed it passes again.

## Test plan
- [x] `pnpm typecheck`
- [x] New unit tests: `src/utils/__tests__/modelProviderSync.unit.test.ts` (broadcast delivery, unsubscribe, graceful no-op without `BroadcastChannel`, shared invalidation helper)
- [x] New regression tests: `src/components/prompts/__tests__/PromptEditorDrawer.test.tsx` — "given a project with zero enabled providers when the drawer first opens (#5827 continuation)": adopts the model once `getResolvedDefault` resolves late, and never clobbers a model the user already picked
- [x] Existing integration tests still pass against native services: `useProviderFormSubmit.integration.test.tsx`, `NoModelsConfiguredCallout.integration.test.tsx` (20/20), full `PromptEditorDrawer.test.tsx` suite (47/48, 1 pre-existing skip)
- [x] Live cross-tab reproduction via Playwright for both bugs, fresh accounts, screenshots above
- [x] Manually reverted the second fix and confirmed its regression test fails without it, then restored and confirmed it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-tab synchronization so model-provider updates propagate instantly across open browser tabs.

* **Bug Fixes**
  * Provider enablement and updates now invalidate cached provider/default-model data reliably, ensuring immediate refresh locally and in other tabs.
  * Improved resilience when cross-tab communication isn’t available.
  * Prompt editor drawer now backfills default model and max tokens only when appropriate (for new/unresolved prompts) without overwriting user-entered or already-dirty values.

* **Tests**
  * Added unit tests for cross-tab broadcasting/subscription and cache invalidation.
  * Added tests covering late-resolving default model backfill behavior in the prompt editor drawer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->