### PR TITLE
fix(governance): enable the governance flag by default so self-hosted device login works out of the box

### DIFF
--- a/dev/docs/adr/038-intent-forked-onboarding-governance-vs-llmops.md
+++ b/dev/docs/adr/038-intent-forked-onboarding-governance-vs-llmops.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-08
 
-**Status:** Accepted (locked 2026-07-08)
+**Status:** Accepted (locked 2026-07-08; Decision 7 self-hosted GA pair executed 2026-07-17: registry default and auth-cli fallback flipped to true, SaaS rollout remains a PostHog action)
 
 > One-line: New signups pick **Track AI coding agents** or **Monitor & evaluate my LLM app** on **screen 2**; the choice is persisted as a **first-class `Organization.primaryIntent` enum** (editable in org settings) that **always decides the `/` landing** — `AGENT_GOVERNANCE` → `/me`, `LLM_OPS` → `/{project-slug}`, `NULL` (every pre-existing org) → today's resolver behavior unchanged; the governance track goes **straight to CLI setup**; governance goes **GA via flag rollout** with the CLI 403 kept as a flag-armed safety net; **no CLI changes**.
 

--- a/dev/docs/adr/038-intent-forked-onboarding-governance-vs-llmops.md
+++ b/dev/docs/adr/038-intent-forked-onboarding-governance-vs-llmops.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-08
 
-**Status:** Accepted (locked 2026-07-08; Decision 7 self-hosted GA pair executed 2026-07-17: registry default and auth-cli fallback flipped to true, SaaS rollout remains a PostHog action)
+**Status:** Accepted (locked 2026-07-08)
 
 > One-line: New signups pick **Track AI coding agents** or **Monitor & evaluate my LLM app** on **screen 2**; the choice is persisted as a **first-class `Organization.primaryIntent` enum** (editable in org settings) that **always decides the `/` landing** — `AGENT_GOVERNANCE` → `/me`, `LLM_OPS` → `/{project-slug}`, `NULL` (every pre-existing org) → today's resolver behavior unchanged; the governance track goes **straight to CLI setup**; governance goes **GA via flag rollout** with the CLI 403 kept as a flag-armed safety net; **no CLI changes**.
 
@@ -65,6 +65,7 @@ Numbered choices; each traces to a locked question round (R1–R3) or a constrai
    - SaaS: the gate at `server/routes/auth-cli.ts:1666` consults PostHog live per org — GA = roll `release_ui_ai_governance_enabled` to 100% in PostHog; switching an org off in PostHog **re-arms the 403 for that org automatically**. Zero gate code deleted.
    - Registry `defaultValue: false → true` (`server/featureFlag/registry.ts:146`) and the auth-cli call site's hardcoded fallback `defaultValue: false → true` — this pair is what lifts the gate on **self-hosted** (memory flag service resolves from the call-site default) and during PostHog outages.
    - Residual risk, accepted and documented: with the gate open, a user who explicitly chooses AI-tools/device mode in the CLI gets a personal workspace + VK; the CLI's existing Where/How prompts (`specs/ai-governance/cli-onboarding/login-unified.feature`) are the consent step. The original silent-capture incident predates those prompts.
+   - Executed 2026-07-17 for the self-hosted pair (#5901): registry default and auth-cli fallback are both `true`; the SaaS PostHog rollout remains a separate action.
 
 8. **Org intent is editable in the organization settings page, shipped in this ADR** (R3-Q4). A "Primary use" field (org-admin only) on the existing org settings surface, so a wrong pick is self-serviceable and legacy orgs can adopt intent-based landing without support/SQL.
    Two honest limits of "self-serviceable" (red-team v2 F9, strategy S1):

--- a/docs/ai-gateway/governance/admin-setup.mdx
+++ b/docs/ai-gateway/governance/admin-setup.mdx
@@ -44,14 +44,14 @@ skip to §1 below.
   Google Workspace, Auth0).
 
 <Note>
-  **Governance is currently behind a preview flag.** The `/governance` UI surface (and the **Govern** main-menu entry) require the `release_ui_ai_governance_enabled` flag enabled for your org.
+  **Governance visibility rides the `release_ui_ai_governance_enabled` flag.** The `/governance` UI surface (and the **Govern** main-menu entry) require it enabled for your org.
 
-  - **Self-hosted**: set `FEATURE_FLAG_FORCE_ENABLE=release_ui_ai_governance_enabled` in your LangWatch app environment, restart, and the menu + routes are visible to every admin.
-  - **SaaS**: contact your LangWatch account rep — we'll enable the flag for your org.
+  - **Self-hosted**: enabled by default, nothing to configure. To hide governance instead, set `RELEASE_UI_AI_GOVERNANCE_ENABLED=0` in your LangWatch app environment and restart.
+  - **SaaS**: rollout is managed per organization. If you don't see the **Govern** menu, contact your LangWatch account rep.
 
-  The CLI surface (`langwatch login`, `langwatch open`, `langwatch claude`, etc.) is always available once you install the CLI — no env flag needed. Server-side authorization handles per-account governance entitlement.
+  The CLI surface (`langwatch login`, `langwatch open`, `langwatch claude`, etc.) is always available once you install the CLI, no env flag needed. Server-side authorization handles per-account governance entitlement.
 
-  Once the flag is on, fresh admins can reach `/governance` even with no project created yet — governance is org-scoped, not project-scoped.
+  With the flag on, fresh admins can reach `/governance` even with no project created yet: governance is org-scoped, not project-scoped.
 </Note>
 
 ## 1. Connect SSO
@@ -286,14 +286,17 @@ dashboard before rolling out to your team? The repo ships dogfood
 helpers that mint a personal virtual key and fire a real completion
 through your local Go gateway.
 
-Both feature flags must be force-enabled in `langwatch/.env`
-(`.env.example` ships them in the default block as of `e303ec709`):
+Both feature flags are enabled by default on self-hosted, so there is
+nothing to configure in `langwatch/.env`. If either was switched off
+(env override or an operator store row), turn it back on before
+dogfooding:
 
 ```env
-FEATURE_FLAG_FORCE_ENABLE=release_ui_ai_gateway_menu_enabled,release_ui_ai_governance_enabled
+RELEASE_UI_AI_GATEWAY_MENU_ENABLED=1
+RELEASE_UI_AI_GOVERNANCE_ENABLED=1
 ```
 
-Without `release_ui_ai_governance_enabled`, `/governance` and
+With `release_ui_ai_governance_enabled` off, `/governance` and
 `/settings/governance/{ingestion-sources,anomaly-rules}` render
 `NotFoundScene` even for an ORG ADMIN.
 

--- a/docs/ai-gateway/governance/admin-setup.mdx
+++ b/docs/ai-gateway/governance/admin-setup.mdx
@@ -44,7 +44,7 @@ skip to §1 below.
   Google Workspace, Auth0).
 
 <Note>
-  On SaaS, governance rollout is managed per organization: if you don't see the **Govern** menu, contact your LangWatch account rep.
+  On SaaS, governance rollout is managed per organization: if you don't see the **Govern** menu, or AI-tools device login is refused with a governance error, contact your LangWatch account rep.
 
   You can reach `/governance` with no project created yet: governance is org-scoped, not project-scoped.
 </Note>

--- a/docs/ai-gateway/governance/admin-setup.mdx
+++ b/docs/ai-gateway/governance/admin-setup.mdx
@@ -44,14 +44,11 @@ skip to §1 below.
   Google Workspace, Auth0).
 
 <Note>
-  **Governance visibility rides the `release_ui_ai_governance_enabled` flag.** The `/governance` UI surface (and the **Govern** main-menu entry) require it enabled for your org.
-
-  - **Self-hosted**: enabled by default, nothing to configure. To hide governance instead, set `RELEASE_UI_AI_GOVERNANCE_ENABLED=0` in your LangWatch app environment and restart.
-  - **SaaS**: rollout is managed per organization. If you don't see the **Govern** menu, contact your LangWatch account rep.
+  **Availability.** Self-hosted installations get the `/governance` UI surface (and the **Govern** main-menu entry) out of the box. On SaaS, rollout is managed per organization: if you don't see the **Govern** menu, contact your LangWatch account rep.
 
   The CLI surface (`langwatch login`, `langwatch open`, `langwatch claude`, etc.) is always available once you install the CLI, no env flag needed. Server-side authorization handles per-account governance entitlement.
 
-  With the flag on, fresh admins can reach `/governance` even with no project created yet: governance is org-scoped, not project-scoped.
+  Fresh admins can reach `/governance` even with no project created yet: governance is org-scoped, not project-scoped.
 </Note>
 
 ## 1. Connect SSO
@@ -286,19 +283,8 @@ dashboard before rolling out to your team? The repo ships dogfood
 helpers that mint a personal virtual key and fire a real completion
 through your local Go gateway.
 
-Both feature flags are enabled by default on self-hosted, so there is
-nothing to configure in `langwatch/.env`. If either was switched off
-(env override or an operator store row), turn it back on before
-dogfooding:
-
-```env
-RELEASE_UI_AI_GATEWAY_MENU_ENABLED=1
-RELEASE_UI_AI_GOVERNANCE_ENABLED=1
-```
-
-With `release_ui_ai_governance_enabled` off, `/governance` and
-`/settings/governance/{ingestion-sources,anomaly-rules}` render
-`NotFoundScene` even for an ORG ADMIN.
+The gateway and governance surfaces are enabled by default on
+self-hosted, nothing to configure in `langwatch/.env`.
 
 ```bash
 # 1. Bring up the stack (postgres + redis + app + gateway)

--- a/docs/ai-gateway/governance/admin-setup.mdx
+++ b/docs/ai-gateway/governance/admin-setup.mdx
@@ -44,11 +44,9 @@ skip to §1 below.
   Google Workspace, Auth0).
 
 <Note>
-  **Availability.** Self-hosted installations get the `/governance` UI surface (and the **Govern** main-menu entry) out of the box. On SaaS, rollout is managed per organization: if you don't see the **Govern** menu, contact your LangWatch account rep.
+  On SaaS, governance rollout is managed per organization: if you don't see the **Govern** menu, contact your LangWatch account rep.
 
-  The CLI surface (`langwatch login`, `langwatch open`, `langwatch claude`, etc.) is always available once you install the CLI, no env flag needed. Server-side authorization handles per-account governance entitlement.
-
-  Fresh admins can reach `/governance` even with no project created yet: governance is org-scoped, not project-scoped.
+  You can reach `/governance` with no project created yet: governance is org-scoped, not project-scoped.
 </Note>
 
 ## 1. Connect SSO
@@ -282,9 +280,6 @@ Want to see real spend land in `/me/usage` and the governance
 dashboard before rolling out to your team? The repo ships dogfood
 helpers that mint a personal virtual key and fire a real completion
 through your local Go gateway.
-
-The gateway and governance surfaces are enabled by default on
-self-hosted, nothing to configure in `langwatch/.env`.
 
 ```bash
 # 1. Bring up the stack (postgres + redis + app + gateway)

--- a/docs/ai-gateway/governance/overview.mdx
+++ b/docs/ai-gateway/governance/overview.mdx
@@ -117,9 +117,7 @@ independently:
   export.
 
 Both flags are enabled by default on self-hosted; on SaaS, PostHog
-release conditions decide per organization. Self-hosted deployers can
-switch either one off with an env override, e.g.
-`RELEASE_UI_AI_GOVERNANCE_ENABLED=0` in `langwatch/.env`.
+release conditions decide per organization.
 
 When a gateway is wired up, the chrome is **persona-aware**: admins
 land on the org switcher + governance KPIs; engineers using a CLI

--- a/docs/ai-gateway/governance/overview.mdx
+++ b/docs/ai-gateway/governance/overview.mdx
@@ -106,18 +106,10 @@ attribute usage to the right person without leaking tokens.
 
 ## Rollout & permissions
 
-Governance ships on two independent feature flags so the data plane
-(gateway) and the governance UI surface can be controlled
-independently:
-
-- `release_ui_ai_gateway_menu_enabled`: exposes the AI Gateway nav
-  surface (virtual keys, providers, routing policies).
-- `release_ui_ai_governance_enabled`: unlocks the Governance home
-  (`/governance`), ingestion sources, anomaly rules, compliance
-  export.
-
-Both flags are enabled by default on self-hosted; on SaaS, PostHog
-release conditions decide per organization.
+On SaaS, the AI Gateway nav surface (virtual keys, providers, routing
+policies) and the Governance surface (`/governance`, ingestion
+sources, anomaly rules, compliance export) roll out per organization,
+independently of each other.
 
 When a gateway is wired up, the chrome is **persona-aware**: admins
 land on the org switcher + governance KPIs; engineers using a CLI

--- a/docs/ai-gateway/governance/overview.mdx
+++ b/docs/ai-gateway/governance/overview.mdx
@@ -106,19 +106,20 @@ attribute usage to the right person without leaking tokens.
 
 ## Rollout & permissions
 
-Governance ships behind two independent feature flags so pilots can
-turn on the data plane (gateway) without committing to the full
-governance UI surface:
+Governance ships on two independent feature flags so the data plane
+(gateway) and the governance UI surface can be controlled
+independently:
 
-- `release_ui_ai_gateway_menu_enabled` — exposes the AI Gateway nav
-  surface (virtual keys, providers, routing policies). Ships first.
-- `release_ui_ai_governance_enabled` — unlocks the Governance home
+- `release_ui_ai_gateway_menu_enabled`: exposes the AI Gateway nav
+  surface (virtual keys, providers, routing policies).
+- `release_ui_ai_governance_enabled`: unlocks the Governance home
   (`/governance`), ingestion sources, anomaly rules, compliance
-  export. Ships after gateway adoption is proven in the org.
+  export.
 
-Both flags are PostHog-controlled. Self-hosted deployers can force
-either one on with `FEATURE_FLAG_FORCE_ENABLE=release_ui_ai_gateway_menu_enabled`
-in `langwatch/.env`.
+Both flags are enabled by default on self-hosted; on SaaS, PostHog
+release conditions decide per organization. Self-hosted deployers can
+switch either one off with an env override, e.g.
+`RELEASE_UI_AI_GOVERNANCE_ENABLED=0` in `langwatch/.env`.
 
 When a gateway is wired up, the chrome is **persona-aware**: admins
 land on the org switcher + governance KPIs; engineers using a CLI

--- a/docs/ai-gateway/governance/personal-keys.mdx
+++ b/docs/ai-gateway/governance/personal-keys.mdx
@@ -12,7 +12,7 @@ all of those tools share.
 This page is the **end-user** flow. If you're an admin setting it up
 for your organization, see [Admin setup](/ai-gateway/governance/admin-setup).
 
-<Note>**Governance availability.** The web flag `release_ui_ai_governance_enabled` controls UI visibility. It is enabled by default on self-hosted installations; on SaaS, rollout is managed per organization, so ask your admin if you don't see the surfaces. The CLI surface is always available once the CLI is installed.</Note>
+<Note>On SaaS, governance rollout is managed per organization: ask your admin if you don't see these surfaces.</Note>
 
 ## Why this exists (40-second pitch)
 

--- a/docs/ai-gateway/governance/personal-keys.mdx
+++ b/docs/ai-gateway/governance/personal-keys.mdx
@@ -12,7 +12,7 @@ all of those tools share.
 This page is the **end-user** flow. If you're an admin setting it up
 for your organization, see [Admin setup](/ai-gateway/governance/admin-setup).
 
-<Note>On SaaS, governance rollout is managed per organization: ask your admin if you don't see these surfaces.</Note>
+<Note>On SaaS, governance rollout is managed per organization: if you don't see these surfaces, or `langwatch login --device` is refused with a governance error, ask your admin.</Note>
 
 ## Why this exists (40-second pitch)
 

--- a/docs/ai-gateway/governance/personal-keys.mdx
+++ b/docs/ai-gateway/governance/personal-keys.mdx
@@ -12,7 +12,7 @@ all of those tools share.
 This page is the **end-user** flow. If you're an admin setting it up
 for your organization, see [Admin setup](/ai-gateway/governance/admin-setup).
 
-<Note>**Governance is currently a preview**. The web flag `release_ui_ai_governance_enabled` controls UI visibility — ask your admin to confirm it's on for your org. The CLI surface is always available once the CLI is installed.</Note>
+<Note>**Governance availability.** The web flag `release_ui_ai_governance_enabled` controls UI visibility. It is enabled by default on self-hosted installations; on SaaS, rollout is managed per organization, so ask your admin if you don't see the surfaces. The CLI surface is always available once the CLI is installed.</Note>
 
 ## Why this exists (40-second pitch)
 

--- a/docs/ai-governance/cli.mdx
+++ b/docs/ai-governance/cli.mdx
@@ -18,7 +18,7 @@ LangWatch already has top-level CLI commands for trace ingestion (`langwatch ing
 
 ## Availability
 
-Once you install the CLI, the `governance` subcommand is available out of the box, no env flag needed. Per-account governance entitlement is enforced server-side: if your account doesn't have governance enabled, the server returns a clear error pointing you at your admin.
+Per-account governance entitlement is enforced server-side: if your account doesn't have governance enabled, `governance` commands return a clear error pointing you at your admin.
 
 ```bash
 langwatch governance --help

--- a/docs/ai-governance/control-plane.mdx
+++ b/docs/ai-governance/control-plane.mdx
@@ -466,14 +466,14 @@ renders live cards + per-user table + source-health strip.
 Tier 2, Tier 5 are deferred; the architecture doesn't preclude them
 and the control-plane primitives already accommodate them.
 
-## Feature-flag gates (preview)
+## Feature-flag gates
 
-The governance preview is opt-in until the long-lived branch lands
-behind a single fence on each surface:
+Governance sits behind a single fence on each surface:
 
-- **Web app:** PostHog flag `release_ui_ai_governance_enabled`.
-  Off by default. Force-enable with
-  `FEATURE_FLAG_FORCE_ENABLE=release_ui_ai_governance_enabled`.
+- **Web app:** the `release_ui_ai_governance_enabled` flag.
+  Enabled by default on self-hosted; on SaaS, PostHog release
+  conditions decide per organization. Switch it off with
+  `RELEASE_UI_AI_GOVERNANCE_ENABLED=0`.
   Existing AI Gateway menu surface stays on the unrelated
   `release_ui_ai_gateway_menu_enabled` flag, they ship
   independently.

--- a/docs/ai-governance/control-plane.mdx
+++ b/docs/ai-governance/control-plane.mdx
@@ -472,8 +472,7 @@ Governance sits behind a single fence on each surface:
 
 - **Web app:** the `release_ui_ai_governance_enabled` flag.
   Enabled by default on self-hosted; on SaaS, PostHog release
-  conditions decide per organization. Switch it off with
-  `RELEASE_UI_AI_GOVERNANCE_ENABLED=0`.
+  conditions decide per organization.
   Existing AI Gateway menu surface stays on the unrelated
   `release_ui_ai_gateway_menu_enabled` flag, they ship
   independently.

--- a/docs/ai-governance/track-your-claude-code-usage.mdx
+++ b/docs/ai-governance/track-your-claude-code-usage.mdx
@@ -285,6 +285,8 @@ For self-hosted (`npx @langwatch/server`), nothing leaves your machine. Postgres
 
 ## Troubleshooting
 
+**Device login approval fails with "AI-tools (device) login needs governance enabled" (self-hosted).** Your server runs a LangWatch version that ships governance off by default. Update it (`npx @langwatch/server@latest`) or set `RELEASE_UI_AI_GOVERNANCE_ENABLED=1` in `~/.langwatch/.env` and restart the server, then re-run `langwatch login --device`.
+
 **Nothing in Recent activity after 30 seconds.** Confirm the wrapper spawned with the right env. Open `~/.langwatch/config.json`: Path 1 needs a `default_personal_vk` block, Path 2 needs the wrapper to have minted an ingestion key (`sk-lw-…`) on first run. If neither shows up, re-run `langwatch login --device` and then `langwatch claude` again. `langwatch init-shell` prints the eval-able shell snippet showing exactly which env vars the wrapper injects.
 
 **401 from the gateway (Path 1).** Your Virtual Key probably rotated. Re-run `langwatch login --device` or re-mint the Virtual Key from `/me` → Model providers.

--- a/langwatch/src/features/onboarding/constants/onboarding-flow.ts
+++ b/langwatch/src/features/onboarding/constants/onboarding-flow.ts
@@ -21,9 +21,9 @@ function buildConfig(
  * ADR-038: the flow branches on the declared intent, recomputed from state —
  * the generic navigator itself stays linear (constraint C1).
  *
- * The whole intent fork ships dark behind release_ui_ai_governance_enabled
- * (v5): with the flag off (or still loading) the flow is exactly the
- * pre-fork one — no intent screen at all. False-while-loading is safe:
+ * The intent fork rides release_ui_ai_governance_enabled (v5, on by
+ * default): with the flag off (or still loading) the flow is exactly the
+ * pre-fork one, no intent screen at all. False-while-loading is safe:
  * both shapes start at ORGANIZATION, so a late flag flip only inserts
  * screens ahead of the user.
  *

--- a/langwatch/src/features/onboarding/hooks/use-onboarding-flow.ts
+++ b/langwatch/src/features/onboarding/hooks/use-onboarding-flow.ts
@@ -38,7 +38,7 @@ export const useOnboardingFlow = () => {
   const [selectedDesires, setDesires] = useState<DesireType[]>([]);
   const [role, setRole] = useState<RoleType | undefined>(void 0);
 
-  // The whole intent fork ships dark behind the governance flag (ADR-038
+  // The intent fork rides the governance flag, on by default (ADR-038
   // v5): flag off (or loading, which reports enabled=false) = the exact
   // pre-fork flow. User-level evaluation — there is no org yet during
   // onboarding.

--- a/langwatch/src/pages/settings.tsx
+++ b/langwatch/src/pages/settings.tsx
@@ -104,8 +104,8 @@ function SettingsForm({
   const { hasPermission } = useOrganizationTeamProject();
   const { isLiteMember } = useLiteMemberGuard();
   const { openDrawer } = useDrawer();
-  // ADR-038 ships dark: the Primary use setting only exists where the
-  // governance surface it routes to is reachable.
+  // ADR-038: the Primary use setting only exists where the governance
+  // surface it routes to is reachable (flag on, which is the default).
   const { enabled: governanceEnabled } = useFeatureFlag(
     "release_ui_ai_governance_enabled",
     { organizationId: organization.id },

--- a/langwatch/src/server/featureFlag/__tests__/governanceGaDefaults.unit.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/governanceGaDefaults.unit.test.ts
@@ -4,24 +4,25 @@ import { describe, expect, it } from "vitest";
 import { FEATURE_FLAGS } from "../registry";
 
 /**
- * ADR-038 Decision 7 pins the flag pair that holds governance behind the
- * wall: the registry default and the auth-cli device-login gate's
- * call-site fallback. They must move TOGETHER — GA is flipping both to
- * true in one commit. These tests fail loudly if either literal drifts
- * independently.
+ * ADR-038 Decision 7 pins the flag pair that controls the governance
+ * gate: the registry default and the auth-cli device-login gate's
+ * call-site fallback. They must move TOGETHER: both true means
+ * governance ships open (self-hosted works with zero configuration;
+ * per-org kill switches in PostHog or the operator store re-arm the
+ * gate). These tests fail loudly if either literal drifts independently.
  */
-describe("governance flag defaults (ADR-038, pre-GA: ships dark)", () => {
+describe("governance flag defaults (ADR-038, GA: ships open)", () => {
   describe("when the registry resolves release_ui_ai_governance_enabled", () => {
-    it("defaults to disabled until GA", () => {
+    it("defaults to enabled so self-hosted installations need no configuration", () => {
       const flag = FEATURE_FLAGS.find(
         (f) => f.key === "release_ui_ai_governance_enabled",
       );
-      expect(flag?.defaultValue).toBe(false);
+      expect(flag?.defaultValue).toBe(true);
     });
   });
 
   describe("when the CLI device-login gate evaluates its fallback", () => {
-    it("defaults closed at every call site, matching the registry", () => {
+    it("defaults open at every call site, matching the registry", () => {
       // The gate lives in a 1700-line Hono route file; asserting on the
       // source keeps the pin without spinning up the whole route (the
       // gate's runtime behavior is covered by
@@ -41,7 +42,7 @@ describe("governance flag defaults (ADR-038, pre-GA: ships dark)", () => {
         const defaultLine = windowAfter
           .split("\n")
           .find((line) => line.includes("defaultValue:"));
-        expect(defaultLine).toContain("defaultValue: false");
+        expect(defaultLine).toContain("defaultValue: true");
       }
     });
   });

--- a/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
@@ -51,12 +51,12 @@
  */
 export const FRONTEND_FEATURE_FLAGS = [
   "release_ui_ai_gateway_menu_enabled",
-  // Governance preview — gates the personal-keys / admin oversight /
-  // RoutingPolicy / IngestionSource UI surfaces on this long-lived
-  // branch. Default off until rchaves flips it for an org. Distinct
-  // from `release_ui_ai_gateway_menu_enabled` because the existing
-  // gateway product ships unblocked while governance keeps cooking.
-  // Force-enable in dev: `FEATURE_FLAG_FORCE_ENABLE=release_ui_ai_governance_enabled`.
+  // Governance: gates the personal-keys / admin oversight /
+  // RoutingPolicy / IngestionSource UI surfaces. On by default
+  // (ADR-038 Decision 7); SaaS rollout and per-org kill switches live
+  // in PostHog. Distinct from `release_ui_ai_gateway_menu_enabled`
+  // because the gateway product ships on its own flag.
+  // Force off in dev: `RELEASE_UI_AI_GOVERNANCE_ENABLED=0`.
   "release_ui_ai_governance_enabled",
   "release_langy_enabled",
   "release_langy_promo_enabled",

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -151,12 +151,17 @@ export const FEATURE_FLAGS = [
   {
     key: "release_ui_ai_governance_enabled",
     scope: "PRODUCT",
-    // ADR-038 ships dark behind this flag: it additionally gates the
-    // onboarding intent fork and the org "Primary use" setting. GA is a
-    // later PostHog rollout (SaaS) + flipping this default (self-hosted).
-    defaultValue: false,
+    // On by default (ADR-038 Decision 7): self-hosted installations get
+    // governance (AI-tools device login, /me, admin surfaces, the
+    // onboarding intent fork, the org "Primary use" setting) with zero
+    // configuration. SaaS stays PostHog-governed: a per-org off-condition
+    // (or an operator store row / RELEASE_UI_AI_GOVERNANCE_ENABLED=0)
+    // re-arms every gate for that org. This default and the auth-cli
+    // device-login fallback are a pinned pair, move them together
+    // (governanceGaDefaults.unit.test.ts enforces it).
+    defaultValue: true,
     description:
-      "Gates the personal keys, admin oversight, RoutingPolicy, IngestionSource UI surfaces, the onboarding intent fork, and the org Primary use setting (ADR-038). Distinct from release_ui_ai_gateway_menu_enabled — the existing gateway product ships unblocked while governance keeps cooking.",
+      "Gates the personal keys, admin oversight, RoutingPolicy, IngestionSource UI surfaces, the onboarding intent fork, and the org Primary use setting (ADR-038). On by default; switch off per org via PostHog or the operator store to hide governance and refuse AI-tools device login. Distinct from release_ui_ai_gateway_menu_enabled: the gateway product ships on its own flag.",
   },
   // ADR-034 Phase 3 — routes analytics getTimeseries reads to the slim
   // `trace_analytics` / rollup `trace_analytics_rollup` tables (Phases 1+2)

--- a/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -4,9 +4,10 @@
  * Integration coverage for the CLI login personal-project guards on
  * `POST /api/auth/cli/approve` (real Redis + real Prisma):
  *
- *   1. device-session (AI-tools) login is refused when governance is not
- *      enabled for the org, since it would otherwise provision a personal
- *      workspace + VK and capture the user's evaluations (customer report).
+ *   1. device-session (AI-tools) login works by default (the governance flag
+ *      ships on, ADR-038 Decision 7) and is refused for an org whose flag is
+ *      switched off, since it would otherwise provision a personal workspace
+ *      + VK and capture the user's evaluations (customer report).
  *   2. project-login (project_api_key) refuses a personal project id and only
  *      hands back a shared project's key.
  *
@@ -16,7 +17,15 @@
  *
  * Spec: specs/ai-gateway/governance/cli-login-personal-guard.feature
  */
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 // vi.mock is hoisted above every top-level const, so the values the session
 // mock needs must come from vi.hoisted (hoisted alongside it). Math.random,
@@ -44,8 +53,8 @@ vi.mock("~/server/api/rbac", async (importActual) => {
   return { ...actual, hasProjectPermission: vi.fn().mockResolvedValue(true) };
 });
 
-import { prisma } from "~/server/db";
 import { hasProjectPermission } from "~/server/api/rbac";
+import { prisma } from "~/server/db";
 import {
   startTestContainers,
   stopTestContainers,
@@ -84,45 +93,80 @@ async function approve(body: Record<string, unknown>) {
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ organization_id: ORG_ID, ...body }),
   });
-  return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+  return {
+    status: res.status,
+    json: (await res.json()) as Record<string, unknown>,
+  };
 }
 
 describe("CLI login personal-project guards", () => {
   beforeAll(async () => {
     await startTestContainers();
     await prisma.organization.create({
-      data: { id: ORG_ID, name: `Guard Org ${suffix}`, slug: `guard-${suffix}` },
+      data: {
+        id: ORG_ID,
+        name: `Guard Org ${suffix}`,
+        slug: `guard-${suffix}`,
+      },
     });
     await prisma.user.create({
-      data: { id: USER_ID, email: `guard-${suffix}@example.com`, name: `Guard ${suffix}` },
+      data: {
+        id: USER_ID,
+        email: `guard-${suffix}@example.com`,
+        name: `Guard ${suffix}`,
+      },
     });
     await prisma.organizationUser.create({
       data: { userId: USER_ID, organizationId: ORG_ID, role: "ADMIN" },
     });
     // Shared (team) project + a personal-workspace project for the same user.
     await prisma.team.create({
-      data: { id: TEAM_ID, name: `Team ${suffix}`, slug: `team-${suffix}`, organizationId: ORG_ID },
+      data: {
+        id: TEAM_ID,
+        name: `Team ${suffix}`,
+        slug: `team-${suffix}`,
+        organizationId: ORG_ID,
+      },
     });
-    await prisma.teamUser.create({ data: { userId: USER_ID, teamId: TEAM_ID, role: "ADMIN" } });
+    await prisma.teamUser.create({
+      data: { userId: USER_ID, teamId: TEAM_ID, role: "ADMIN" },
+    });
     await prisma.project.create({
       data: {
-        id: SHARED_PROJECT_ID, name: `Shared ${suffix}`, slug: `shared-${suffix}`,
-        apiKey: SHARED_API_KEY, teamId: TEAM_ID, language: "typescript", framework: "openai",
+        id: SHARED_PROJECT_ID,
+        name: `Shared ${suffix}`,
+        slug: `shared-${suffix}`,
+        apiKey: SHARED_API_KEY,
+        teamId: TEAM_ID,
+        language: "typescript",
+        framework: "openai",
         isPersonal: false,
       },
     });
     await prisma.team.create({
       data: {
-        id: PTEAM_ID, name: `Personal ${suffix}`, slug: `pteam-${suffix}`,
-        organizationId: ORG_ID, isPersonal: true, ownerUserId: USER_ID,
+        id: PTEAM_ID,
+        name: `Personal ${suffix}`,
+        slug: `pteam-${suffix}`,
+        organizationId: ORG_ID,
+        isPersonal: true,
+        ownerUserId: USER_ID,
       },
     });
-    await prisma.teamUser.create({ data: { userId: USER_ID, teamId: PTEAM_ID, role: "ADMIN" } });
+    await prisma.teamUser.create({
+      data: { userId: USER_ID, teamId: PTEAM_ID, role: "ADMIN" },
+    });
     await prisma.project.create({
       data: {
-        id: PERSONAL_PROJECT_ID, name: `My Workspace ${suffix}`, slug: `personal-${suffix}`,
-        apiKey: PERSONAL_API_KEY, teamId: PTEAM_ID, language: "typescript", framework: "openai",
-        isPersonal: true, ownerUserId: USER_ID,
+        id: PERSONAL_PROJECT_ID,
+        name: `My Workspace ${suffix}`,
+        slug: `personal-${suffix}`,
+        apiKey: PERSONAL_API_KEY,
+        teamId: PTEAM_ID,
+        language: "typescript",
+        framework: "openai",
+        isPersonal: true,
+        ownerUserId: USER_ID,
       },
     });
     // A shared project on a team the user is NOT a direct member of. The user
@@ -131,56 +175,98 @@ describe("CLI login personal-project guards", () => {
     // but there is deliberately no TeamUser row for them on this team.
     await prisma.team.create({
       data: {
-        id: OTHER_TEAM_ID, name: `Other ${suffix}`, slug: `oteam-${suffix}`,
+        id: OTHER_TEAM_ID,
+        name: `Other ${suffix}`,
+        slug: `oteam-${suffix}`,
         organizationId: ORG_ID,
       },
     });
     await prisma.project.create({
       data: {
-        id: OTHER_TEAM_PROJECT_ID, name: `Other ${suffix}`, slug: `other-${suffix}`,
-        apiKey: OTHER_TEAM_API_KEY, teamId: OTHER_TEAM_ID, language: "typescript",
-        framework: "openai", isPersonal: false,
+        id: OTHER_TEAM_PROJECT_ID,
+        name: `Other ${suffix}`,
+        slug: `other-${suffix}`,
+        apiKey: OTHER_TEAM_API_KEY,
+        teamId: OTHER_TEAM_ID,
+        language: "typescript",
+        framework: "openai",
+        isPersonal: false,
       },
     });
   });
 
-  // Reset the governance baseline (off) before every test: the dev .env
-  // force-enables the flag, so clearing it BEFORE each case is what guarantees
-  // isolation, and a failed assertion can never leak the forced flag forward.
-  // The one governance-on case opts in explicitly in its own body.
+  // Clear flag overrides before every test: the dev .env may force-enable the
+  // flag and a prior case forces it off, so clearing BOTH before each case is
+  // what guarantees isolation: a failed assertion can never leak an override
+  // forward. Cases that need a non-default state opt in explicitly in their
+  // own body.
   beforeEach(() => {
     delete process.env.FEATURE_FLAG_FORCE_ENABLE;
+    delete process.env.RELEASE_UI_AI_GOVERNANCE_ENABLED;
   });
 
   afterAll(async () => {
     delete process.env.FEATURE_FLAG_FORCE_ENABLE;
-    await prisma.virtualKey.deleteMany({ where: { principalUserId: USER_ID } }).catch(() => {});
-    await prisma.project.deleteMany({ where: { teamId: { in: [TEAM_ID, PTEAM_ID, OTHER_TEAM_ID] } } }).catch(() => {});
-    await prisma.teamUser.deleteMany({ where: { userId: USER_ID } }).catch(() => {});
-    await prisma.team.deleteMany({ where: { id: { in: [TEAM_ID, PTEAM_ID, OTHER_TEAM_ID] } } }).catch(() => {});
-    await prisma.organizationUser.deleteMany({ where: { userId: USER_ID } }).catch(() => {});
+    delete process.env.RELEASE_UI_AI_GOVERNANCE_ENABLED;
+    await prisma.virtualKey
+      .deleteMany({ where: { principalUserId: USER_ID } })
+      .catch(() => {});
+    await prisma.project
+      .deleteMany({
+        where: { teamId: { in: [TEAM_ID, PTEAM_ID, OTHER_TEAM_ID] } },
+      })
+      .catch(() => {});
+    await prisma.teamUser
+      .deleteMany({ where: { userId: USER_ID } })
+      .catch(() => {});
+    await prisma.team
+      .deleteMany({ where: { id: { in: [TEAM_ID, PTEAM_ID, OTHER_TEAM_ID] } } })
+      .catch(() => {});
+    await prisma.organizationUser
+      .deleteMany({ where: { userId: USER_ID } })
+      .catch(() => {});
     await prisma.user.deleteMany({ where: { id: USER_ID } }).catch(() => {});
-    await prisma.organization.deleteMany({ where: { id: ORG_ID } }).catch(() => {});
+    await prisma.organization
+      .deleteMany({ where: { id: ORG_ID } })
+      .catch(() => {});
     await stopTestContainers().catch(() => {});
   });
 
-  describe("given an organization without governance enabled", () => {
+  describe("given an organization with governance switched off", () => {
     describe("when a device-session approval is requested", () => {
       /** @scenario device-session approval is refused when governance is disabled */
       it("refuses it with governance_required and mints no personal VK", async () => {
+        process.env.RELEASE_UI_AI_GOVERNANCE_ENABLED = "0";
         const userCode = await mintDeviceCode("device_session");
 
         const { status, json } = await approve({ user_code: userCode });
 
         expect(status).toBe(403);
         expect(json.error).toBe("governance_required");
-        const vks = await prisma.virtualKey.findMany({ where: { principalUserId: USER_ID } });
+        const vks = await prisma.virtualKey.findMany({
+          where: { principalUserId: USER_ID },
+        });
         expect(vks).toHaveLength(0);
       });
     });
   });
 
-  describe("given an organization with governance enabled", () => {
+  describe("given a default installation with no flag overrides", () => {
+    describe("when a device-session approval is requested", () => {
+      /** @scenario device-session approval succeeds on a default installation */
+      it("does not refuse it through the governance gate", async () => {
+        const userCode = await mintDeviceCode("device_session");
+
+        const { status } = await approve({ user_code: userCode });
+
+        // Either a VK is issued (200) or the no-provider graceful fallback (200);
+        // the gate must NOT block it.
+        expect(status).not.toBe(403);
+      });
+    });
+  });
+
+  describe("given an organization with governance force-enabled", () => {
     describe("when a device-session approval is requested", () => {
       /** @scenario device-session approval succeeds when governance is enabled */
       it("does not refuse the device-session approval", async () => {

--- a/langwatch/src/server/routes/auth-cli.ts
+++ b/langwatch/src/server/routes/auth-cli.ts
@@ -1659,21 +1659,22 @@ secured.access(CLI_POLICY).post("/approve", async (c: Context) => {
 
   // Governance gate: the device-session flow provisions a personal
   // workspace (Team + Project) and a personal virtual key for the user.
-  // That is a governance-plane capability; for an org without governance
-  // enabled it silently created a personal project that then captured the
-  // user's evaluations (customer report). Refuse it and point at project
-  // login, which writes a real project's API key to `.env`.
-  //
-  // ADR-038 GA note: at GA this fallback flips to true together with the
-  // registry default; the gate then only fires for orgs kill-switched off
-  // in PostHog, where /me is a 404 and refusing device login is correct.
+  // That is a governance-plane capability. The flag defaults on (ADR-038
+  // Decision 7: this fallback and the registry default are a pinned
+  // pair, enforced by governanceGaDefaults.unit.test.ts), so the gate
+  // fires only for orgs whose flag evaluates false (switched off in
+  // PostHog or via an operator override), where /me is a 404 and
+  // refusing device login is correct. The refusal points at project
+  // login, which writes a real project's API key to `.env`; the
+  // device-session flow silently capturing evaluations into a personal
+  // project (customer report) stays impossible for gated orgs.
   const governanceEnabled = await featureFlagService
     .isEnabled("release_ui_ai_governance_enabled", {
       distinctId: session.user.id,
       organizationId: organization_id,
-      defaultValue: false,
+      defaultValue: true,
     })
-    .catch(() => false);
+    .catch(() => true);
   if (!governanceEnabled) {
     return c.json(
       {

--- a/specs/ai-gateway/governance/cli-login-personal-guard.feature
+++ b/specs/ai-gateway/governance/cli-login-personal-guard.feature
@@ -7,8 +7,10 @@ Feature: CLI login never lands a user on a personal project
   the CLI-side default-to-project behavior:
 
     1. The device-session (AI-tools) login provisions a personal workspace + personal
-       virtual key. That is a governance-plane feature; for an organization without
-       governance enabled it must be refused, with a message pointing at project login.
+       virtual key. That is a governance-plane feature. Governance ships enabled by
+       default (ADR-038 Decision 7), so the approval works out of the box on a fresh
+       installation; for an organization whose governance flag has been switched off
+       it must be refused, with a message pointing at project login.
     2. The project-login (project_api_key) flow must target a real, shared project. The
        browser picker hides personal projects, the approval endpoint rejects a personal
        project id, and the picker defaults to the last project the user worked in.
@@ -20,12 +22,20 @@ Feature: CLI login never lands a user on a personal project
     Given a user who is a member of an organization
     And the CLI device-code approval endpoint `POST /api/auth/cli/approve`
     And governance for an organization is gated by the `release_ui_ai_governance_enabled` feature flag
+    And the flag is enabled by default and can be switched off per organization
 
   Rule: device-session (AI-tools) login requires governance enabled
 
     @integration @governance-gate
+    Scenario: device-session approval succeeds on a default installation
+      Given no governance flag override is configured
+      And a pending device code with credential_type "device_session"
+      When the user approves it
+      Then the approval is not refused by the governance gate
+
+    @integration @governance-gate
     Scenario: device-session approval is refused when governance is disabled
-      Given governance is disabled for the organization
+      Given governance has been switched off for the organization
       And a pending device code with credential_type "device_session"
       When the user approves it
       Then the response is 403 with error "governance_required"

--- a/specs/ai-gateway/governance/feature-flag-gating.feature
+++ b/specs/ai-gateway/governance/feature-flag-gating.feature
@@ -50,7 +50,7 @@ Feature: Governance visibility rides a single feature flag
     And the existing AI Gateway menu still renders (different flag)
 
   Scenario: Operators force the flag off via env override
-    Given an operator sets `RELEASE_UI_AI_GOVERNANCE_ENABLED=0` on the app environment
+    Given an operator disables governance for the whole installation via env override
     When users log in
     Then every governance surface above is hidden
     And AI-tools (device) CLI login approvals are refused with a pointer at project login

--- a/specs/ai-gateway/governance/feature-flag-gating.feature
+++ b/specs/ai-gateway/governance/feature-flag-gating.feature
@@ -1,16 +1,23 @@
-Feature: Governance preview hides behind a single feature flag
+Feature: Governance visibility rides a single feature flag
   The governance plane (personal keys, admin oversight, RoutingPolicy
-  admin, IngestionSource setup, Activity Monitor) is being built out on a
-  long-lived branch while existing customers continue using the shipping
-  product. To let this branch merge into main without exposing in-progress
-  surfaces, all user-visible governance UI is gated behind ONE app feature
-  flag. The unified `langwatch` CLI carries no preview gate — once
+  admin, IngestionSource setup, Activity Monitor) is controlled by ONE app
+  feature flag, and that flag ships enabled by default: a fresh
+  self-hosted installation (`npx @langwatch/server`, docker compose,
+  `pnpm dev`) renders the governance surfaces and accepts AI-tools
+  (device) CLI login with zero flag configuration. On SaaS, PostHog
+  release conditions decide per organization, and switching an
+  organization off re-arms every gate for it: UI hidden, device login
+  refused. The unified `langwatch` CLI carries no preview gate: once
   installed the commands are always available, with per-account
   entitlement enforced server-side on the underlying API.
 
   Spec scope: the gating contract itself — what's hidden, when, and how
-  to enable it for development. Implementation lives in
-  `langwatch/src/server/featureFlag/frontendFeatureFlags.ts`.
+  operators control it. The default lives in
+  `langwatch/src/server/featureFlag/registry.ts`; frontend exposure in
+  `langwatch/src/server/featureFlag/frontendFeatureFlags.ts`; the CLI
+  device-login gate in `langwatch/src/server/routes/auth-cli.ts`
+  (ADR-038 Decision 7 pins the registry default and the gate fallback as
+  a pair that moves together).
 
   Background:
     Given the canonical name is locked:
@@ -19,11 +26,17 @@ Feature: Governance preview hides behind a single feature flag
     And the AI Gateway product itself ships unblocked on its own flag
       `release_ui_ai_gateway_menu_enabled` (separate concern, not gated)
 
-  Scenario: The single app flag gates every new governance UI surface
+  Scenario: A default installation enables governance without configuration
+    Given a self-hosted installation with no PostHog key and no flag overrides
+    When a user logs in and navigates the product
+    Then the governance surfaces render (sidebar Govern section, /me)
+    And an AI-tools (device) CLI login approval is not refused by the governance gate
+
+  Scenario: The single app flag gates every governance UI surface when off
     Given a user logged into LangWatch
     And `release_ui_ai_governance_enabled` evaluates to false for them
     When they navigate the product
-    Then none of the governance preview surfaces are reachable from the UI:
+    Then none of the governance surfaces are reachable from the UI:
       | surface                            | path                              |
       | My Workspace dashboard             | /me                               |
       | My Workspace settings              | /me/settings                      |
@@ -36,18 +49,19 @@ Feature: Governance preview hides behind a single feature flag
     And no governance API calls fire from the client
     And the existing AI Gateway menu still renders (different flag)
 
-  Scenario: Force-enable in dev via env override
-    Given a developer is running `pnpm dev`
-    When they set `FEATURE_FLAG_FORCE_ENABLE=release_ui_ai_governance_enabled`
-    Then every governance surface above renders
-    And the standard PostHog evaluation path is bypassed
-    And no PostHog connection is required for the override to work
+  Scenario: Operators force the flag off via env override
+    Given an operator sets `RELEASE_UI_AI_GOVERNANCE_ENABLED=0` on the app environment
+    When users log in
+    Then every governance surface above is hidden
+    And AI-tools (device) CLI login approvals are refused with a pointer at project login
+    And no PostHog connection is required for the override to apply
 
-  Scenario: Per-org rollout via PostHog release condition
-    Given an admin enables the governance preview for one customer org via PostHog
+  Scenario: Per-org kill switch via PostHog release condition
+    Given an admin switches the governance flag off for one customer org via PostHog
     When users in that org log in
-    Then the governance surfaces render only for them
-    And users in other orgs continue to see the existing product unchanged
+    Then the governance surfaces are hidden only for them
+    And their AI-tools (device) CLI login approvals are refused
+    And users in other orgs continue with governance enabled unchanged
 
   Scenario: CLI surface is always available once installed
     Given a user has installed the unified `langwatch` CLI
@@ -66,8 +80,9 @@ Feature: Governance preview hides behind a single feature flag
 
   Scenario: Gating contract documented for downstream contributors
     Given a contributor is adding a new governance UI page
-    When they read docs/ai-gateway/governance/feature-flag.md
-    Then it explains:
+    When they read `dev/docs/adr/038-intent-forked-onboarding-governance-vs-llmops.md`
+      and the flag's entry in `langwatch/src/server/featureFlag/registry.ts`
+    Then they explain:
       | concern                                                        |
       | which flag to use (release_ui_ai_governance_enabled, not gateway) |
       | how to gate a page (useFeatureFlag hook + redirect/empty state) |


### PR DESCRIPTION
## What

`langwatch login --device` on a fresh self-hosted install failed at the browser approval step with:

> Approval failed. AI-tools (device) login needs governance enabled for your organization.

Reported by a user setting up local Claude Code session tracking with `npx @langwatch/server`, following docs that mention no flag at all. `release_ui_ai_governance_enabled` shipped dark (`defaultValue: false`), and a local install has no PostHog, so the registry default was the final word: device login refused and `/me` a 404 until you discover the env override by reading source.

## How

Executes the self-hosted half of ADR-038 Decision 7 exactly as written there:

- Registry `defaultValue: false -> true` for `release_ui_ai_governance_enabled`
- The auth-cli device-login gate fallback `false -> true` (both the `defaultValue` literal and the `.catch`)
- `governanceGaDefaults.unit.test.ts`, which pins the two literals as a pair, now pins them both `true`

SaaS behavior is unchanged: PostHog is always configured there and its release conditions keep deciding per organization. Switching an org off in PostHog (or an operator store row, or `RELEASE_UI_AI_GOVERNANCE_ENABLED=0`) still hides every governance surface and re-arms the device-login 403. Rolling SaaS to 100% remains a PostHog action, not code.

## Tests

- Specs first: `feature-flag-gating.feature` rewritten to the default-on contract (force-off override, per-org kill switch), `cli-login-personal-guard.feature` gains a "succeeds on a default installation" scenario
- `auth-cli-personal-guard.integration.test.ts`: new default-installation case proves approve is not 403 with zero flag configuration; the refusal case now forces the flag off via `RELEASE_UI_AI_GOVERNANCE_ENABLED=0` and still gets `governance_required` with no VK minted
- Ran locally: featureFlag unit suite (53 passed), auth-cli integration suites (7 + 2 passed), typecheck clean

## Docs

- `track-your-claude-code-usage.mdx`: troubleshooting entry for servers still running an older version (update, or set `RELEASE_UI_AI_GOVERNANCE_ENABLED=1` in `~/.langwatch/.env` and restart)
- Governance `admin-setup` / `overview` / `personal-keys` / `control-plane`: replaced the "preview flag, force-enable it" guidance with the current contract (on by default self-hosted, PostHog-rolled on SaaS)
- ADR-038 status line records that Decision 7's self-hosted pair is executed

## Deployment Impact

- App-only change, no schema migrations, no chart or infra changes, no new env vars.
- Self-hosted: after updating, governance surfaces (Govern menu, `/me`, admin pages) and AI-tools device login become available by default. Operators who want the old hidden state set `RELEASE_UI_AI_GOVERNANCE_ENABLED=0` (or an ops feature-flag row) before or after rollout; the gate re-arms immediately.
- SaaS: no behavior change while PostHog serves the flag; release conditions keep deciding per organization. The flipped registry default only applies if PostHog is unreachable or the flag is deleted there (fails open to governance visible, per ADR-038 Decision 7). Rolling SaaS to 100% remains a PostHog action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Governance UI now ships enabled by default on self-hosted; SaaS rollout is controlled per organization.
  * AI-tools (device) login approval behavior is aligned to the governance enabled-by-default setting.
  * AI Gateway menu and Governance UI roll out independently.
* **Bug Fixes**
  * If feature-flag evaluation fails, governance is treated as enabled (not blocked).
* **Documentation**
  * Updated governance setup, rollout/permissions, availability notes, and self-hosted troubleshooting guidance.
* **Tests**
  * Updated unit/integration and BDD scenarios to reflect GA “open” defaults and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->