### PR TITLE
fix(misc): guard against empty-string OPENAI_API_KEY in hotel bot client

### DIFF
--- a/langwatch/src/server/routes/misc.ts
+++ b/langwatch/src/server/routes/misc.ts
@@ -170,8 +170,12 @@ secured
 // =============================================
 // POST /api/demo/hotel_bot
 // =============================================
+// `||` (not `??`) so an empty OPENAI_API_KEY from a stock .env.example
+// falls through to the bogus default. `??` only guards null/undefined;
+// the OpenAI SDK rejects empty-string apiKey at client construction
+// with "Missing credentials" (see issue #5826).
 const hotelBotOpenai = new OpenAI({
-  apiKey: env.OPENAI_API_KEY ?? "bogus",
+  apiKey: env.OPENAI_API_KEY || "bogus",
 });
 
 const guestQueries = [


### PR DESCRIPTION
## What

Swaps `??` for `||` in the `hotelBotOpenai` client construction in `src/server/routes/misc.ts` (line 173-179).

## Why

Fixes #5826.

The stock `.env.example` ships `OPENAI_API_KEY=` (empty string, not unset). `env.OPENAI_API_KEY ?? "bogus"` only guards `null`/`undefined`, so it resolves to `""`, and `new OpenAI({ apiKey: "" })` throws `OpenAIError: Missing credentials` at module load — the API process never finishes booting. `||` treats `""` as falsy and falls through to the bogus demo default, which is the original intent of the fallback (the hotel bot is a demo fixture that should never block API startup).

## Approach

One-character change: `??` -> `||`, plus a 4-line comment explaining the operator choice. No other call sites in the codebase have this exact shape (env var that allows empty string + downstream SDK that throws on empty string + sentinel fallback), so the fix is intentionally narrow. Verified by searching the repo for `` ?? "bogus" `` patterns — only this one matches.

## Out of scope

The same `.env.example` ships `LW_VIRTUAL_KEY_PEPPER="REPLACE_ME"`, `LW_GATEWAY_INTERNAL_SECRET="REPLACE_ME"`, `LW_GATEWAY_JWT_SECRET="REPLACE_ME"` (11 chars each), which fail `z.string().min(32).optional()` in `env-create.mjs`. That's a separate failure mode (zod validation, not SDK construction) and warrants its own issue/PR. Happy to file that separately if useful.

## Testing

- Confirmed `env.OPENAI_API_KEY` is typed as `z.string().optional()` (no `min()` constraint) in `src/env-create.mjs` — so empty string is a valid value at runtime.
- Confirmed `.env.example:203` ships `OPENAI_API_KEY=` empty on `main`.
- Confirmed no other `?? "bogus"` patterns exist in the codebase.
- Did not add a regression test: the fix is a 1-character operator change with a clear root cause and comment. A test that doesn't import the production code would be a tautology; a test that does would require mocking the entire Hono/Prisma app-layer for a 1-character fix. The crash on regression is loud (API won't boot). Open to adding one if reviewers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved demo hotel bot startup behavior when the OpenAI API key is empty or missing.
  * Prevented an immediate credentials error during client initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->