### PR TITLE
feat(event-sourcing): make store-miss re-folds and cache lifecycle visible

### DIFF
--- a/langwatch/src/server/__tests__/metrics-instrumentation.unit.test.ts
+++ b/langwatch/src/server/__tests__/metrics-instrumentation.unit.test.ts
@@ -6,7 +6,9 @@ import {
   incrementEsCommandTotal,
   observeEsCommandDuration,
   incrementEsFoldProjectionTotal,
+  incrementEsFoldStoreMissRefoldTotal,
   observeEsFoldProjectionDuration,
+  observeEsFoldStoreMissRefoldEvents,
   incrementEsMapProjectionTotal,
   observeEsMapProjectionDuration,
   incrementEsReactorTotal,
@@ -44,6 +46,20 @@ describe("ES pipeline metrics", () => {
     it("registers es_fold_projection_duration_milliseconds histogram", () => {
       const metric = register.getSingleMetric(
         "es_fold_projection_duration_milliseconds",
+      );
+      expect(metric).toBeDefined();
+    });
+
+    it("registers es_fold_store_miss_refold_total counter", () => {
+      const metric = register.getSingleMetric(
+        "es_fold_store_miss_refold_total",
+      );
+      expect(metric).toBeDefined();
+    });
+
+    it("registers es_fold_store_miss_refold_events histogram", () => {
+      const metric = register.getSingleMetric(
+        "es_fold_store_miss_refold_events",
       );
       expect(metric).toBeDefined();
     });
@@ -170,6 +186,51 @@ describe("ES pipeline metrics", () => {
       expect(lines).toContain('pipeline_name="test-pipeline"');
       expect(lines).toContain('projection_name="traceSummary"');
     });
+
+    it("increments store-miss re-fold totals with kind labels", async () => {
+      incrementEsFoldStoreMissRefoldTotal({
+        projectionName: "traceAnalytics",
+        kind: "first_touch",
+      });
+      incrementEsFoldStoreMissRefoldTotal({
+        projectionName: "traceAnalytics",
+        kind: "resumed",
+      });
+
+      const lines = await register.getSingleMetricAsString(
+        "es_fold_store_miss_refold_total",
+      );
+      expect(lines).toContain('projection_name="traceAnalytics"');
+      expect(lines).toContain('kind="first_touch"');
+      expect(lines).toContain('kind="resumed"');
+    });
+
+    it("records store-miss replay counts in the configured buckets", async () => {
+      observeEsFoldStoreMissRefoldEvents({
+        projectionName: "traceAnalytics",
+        eventCount: 5,
+      });
+
+      const lines = await register.getSingleMetricAsString(
+        "es_fold_store_miss_refold_events",
+      );
+      expect(lines).toContain('projection_name="traceAnalytics"');
+      const buckets = [...lines.matchAll(/_bucket\{le="([^"]+)"/g)].map(
+        (match) => match[1],
+      );
+      expect(buckets).toEqual([
+        "1",
+        "2",
+        "5",
+        "10",
+        "25",
+        "50",
+        "100",
+        "250",
+        "1000",
+        "+Inf",
+      ]);
+    });
   });
 
   describe("when map projection metrics are recorded", () => {
@@ -263,6 +324,7 @@ describe("ES pipeline metrics", () => {
     it("increments redis error total with operation labels", async () => {
       incrementEsFoldCacheRedisError("traceSummary", "get");
       incrementEsFoldCacheRedisError("traceSummary", "set");
+      incrementEsFoldCacheRedisError("traceSummary", "del");
 
       const lines = await register.getSingleMetricAsString(
         "es_fold_cache_redis_error_total",
@@ -270,6 +332,7 @@ describe("ES pipeline metrics", () => {
       expect(lines).toContain('projection_name="traceSummary"');
       expect(lines).toContain('operation="get"');
       expect(lines).toContain('operation="set"');
+      expect(lines).toContain('operation="del"');
     });
   });
 

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refoldOnMiss.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refoldOnMiss.unit.test.ts
@@ -1,4 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  incrementEsFoldStoreMissRefoldTotal,
+  observeEsFoldStoreMissRefoldEvents,
+} from "~/server/metrics";
+
+vi.mock("~/server/metrics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/server/metrics")>();
+  return {
+    ...actual,
+    incrementEsFoldStoreMissRefoldTotal: vi.fn(),
+    observeEsFoldStoreMissRefoldEvents: vi.fn(),
+  };
+});
+
 import type { Event } from "../../domain/types";
 import {
   createMockFoldProjectionDefinition,
@@ -53,6 +67,7 @@ describe("FoldProjectionExecutor refoldOnStoreMiss", () => {
   }
 
   beforeEach(() => {
+    vi.clearAllMocks();
     executor = new FoldProjectionExecutor();
   });
 
@@ -85,6 +100,14 @@ describe("FoldProjectionExecutor refoldOnStoreMiss", () => {
         upToEvent: e2,
       });
       expect(store.store).toHaveBeenCalledWith(result, context);
+      expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledWith({
+        projectionName: "slim",
+        kind: "resumed",
+      });
+      expect(observeEsFoldStoreMissRefoldEvents).toHaveBeenCalledWith({
+        projectionName: "slim",
+        eventCount: 2,
+      });
     });
 
     it("does not double-apply the delivered event when the history already contains it", async () => {
@@ -107,6 +130,14 @@ describe("FoldProjectionExecutor refoldOnStoreMiss", () => {
       )) as CountState;
 
       expect(result.ids).toEqual(["e1"]);
+      expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledWith({
+        projectionName: "slim",
+        kind: "first_touch",
+      });
+      expect(observeEsFoldStoreMissRefoldEvents).toHaveBeenCalledWith({
+        projectionName: "slim",
+        eventCount: 1,
+      });
     });
 
     it("applies the delivered event on top when the history read lags behind it", async () => {

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refoldOnMiss.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refoldOnMiss.unit.test.ts
@@ -320,6 +320,40 @@ describe("FoldProjectionExecutor refoldOnStoreMiss", () => {
       });
       expect(result.ids).toEqual(["e1", "e2", "e3"]);
       expect(store.store).toHaveBeenCalledWith(result, context);
+      expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledWith({
+        projectionName: "slim",
+        kind: "resumed",
+      });
+      expect(observeEsFoldStoreMissRefoldEvents).toHaveBeenCalledWith({
+        projectionName: "slim",
+        eventCount: 3,
+      });
+    });
+
+    it("records first-touch when history contains exactly the delivered batch", async () => {
+      const e1 = makeEvent("e1", 1000);
+      const e2 = makeEvent("e2", 2000);
+      const store = createMockFoldProjectionStore<CountState>();
+      (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const foldDef = createMockFoldProjectionDefinition("slim", {
+        store,
+        init,
+        apply,
+        options: { refoldOnStoreMiss: true },
+      });
+      foldDef.eventLoaderUpTo = vi.fn().mockResolvedValue([e1, e2]);
+
+      await executor.executeBatch(foldDef, [e1, e2], context);
+
+      expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledWith({
+        projectionName: "slim",
+        kind: "first_touch",
+      });
+      expect(observeEsFoldStoreMissRefoldEvents).toHaveBeenCalledWith({
+        projectionName: "slim",
+        eventCount: 2,
+      });
     });
 
     it("merges a delivered event missing from the middle of the history back into occurredAt order", async () => {

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refoldOnMiss.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.refoldOnMiss.unit.test.ts
@@ -162,6 +162,10 @@ describe("FoldProjectionExecutor refoldOnStoreMiss", () => {
       )) as CountState;
 
       expect(result.ids).toEqual(["e1", "e2"]);
+      expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledWith({
+        projectionName: "slim",
+        kind: "resumed",
+      });
     });
 
     it("falls through to plain init+apply when the history read returns nothing", async () => {

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.streamingRefold.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.streamingRefold.unit.test.ts
@@ -1,4 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  incrementEsFoldStoreMissRefoldTotal,
+  observeEsFoldStoreMissRefoldEvents,
+} from "~/server/metrics";
+
+vi.mock("~/server/metrics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/server/metrics")>();
+  return {
+    ...actual,
+    incrementEsFoldStoreMissRefoldTotal: vi.fn(),
+    observeEsFoldStoreMissRefoldEvents: vi.fn(),
+  };
+});
+
 import type { Event } from "../../domain/types";
 import {
   createMockFoldProjectionDefinition,
@@ -123,6 +137,34 @@ describe("FoldProjectionExecutor streaming store-miss re-fold", () => {
         expect(loader).toHaveBeenCalledTimes(3);
         expect(foldDef.eventLoaderUpTo).not.toHaveBeenCalled();
         expect(store.store).toHaveBeenCalledWith(result, context);
+        expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledWith({
+          projectionName: "slim",
+          kind: "resumed",
+        });
+        expect(observeEsFoldStoreMissRefoldEvents).toHaveBeenCalledWith({
+          projectionName: "slim",
+          eventCount: 5,
+        });
+      });
+    });
+
+    describe("when the history contains only the delivered event", () => {
+      it("records a first-touch re-fold and its replayed event count", async () => {
+        const delivered = ev("e1", 1);
+        const loader = pagedLoaderFrom([delivered]);
+        const { foldDef } = makeFold(loader);
+        const executor = new FoldProjectionExecutor(2);
+
+        await executor.execute(foldDef, delivered, context);
+
+        expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledWith({
+          projectionName: "slim",
+          kind: "first_touch",
+        });
+        expect(observeEsFoldStoreMissRefoldEvents).toHaveBeenCalledWith({
+          projectionName: "slim",
+          eventCount: 1,
+        });
       });
     });
 

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.streamingRefold.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.streamingRefold.unit.test.ts
@@ -195,6 +195,51 @@ describe("FoldProjectionExecutor streaming store-miss re-fold", () => {
       });
     });
 
+    describe("when a delivered retry shares an idempotencyKey with an earlier event", () => {
+      // The two loader routes must agree on resumed-vs-first_touch for the same
+      // persisted history. The classification keys on event id, not idempotency
+      // key: a retry carries a new id but repeats an earlier event's key, so
+      // keying on the key would read that earlier event as one of the delivered
+      // ones and report first_touch for work that is plainly resumed.
+      const earlier = () => ev("e1", 1, "K");
+      const deliveredRetry = () => ev("e2", 2, "K");
+
+      it("reports resumed on the streamed path", async () => {
+        const loader = pagedLoaderFrom([earlier(), deliveredRetry()]);
+        const { foldDef } = makeFold(loader);
+        const executor = new FoldProjectionExecutor(2);
+
+        await executor.execute(foldDef, deliveredRetry(), context);
+
+        expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledWith({
+          projectionName: "slim",
+          kind: "resumed",
+        });
+      });
+
+      it("reports resumed on the array path too", async () => {
+        // Same persisted history via the unbounded loader, which applies the
+        // store's first-occurrence dedup and so surfaces only the earlier event.
+        const store = createMockFoldProjectionStore<CountState>();
+        (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+        const foldDef = createMockFoldProjectionDefinition("slim", {
+          store,
+          init,
+          apply,
+          options: { refoldOnStoreMiss: true },
+        });
+        foldDef.eventLoaderUpTo = vi.fn(async () => [earlier()]);
+        const executor = new FoldProjectionExecutor();
+
+        await executor.execute(foldDef, deliveredRetry(), context);
+
+        expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledWith({
+          projectionName: "slim",
+          kind: "resumed",
+        });
+      });
+    });
+
     describe("when the history read has not caught up to the delivered event", () => {
       it("applies the delivered event on top", async () => {
         const history = [ev("e1", 1)];

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.streamingRefold.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.streamingRefold.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   incrementEsFoldStoreMissRefoldTotal,
   observeEsFoldStoreMissRefoldEvents,
@@ -54,6 +54,10 @@ describe("FoldProjectionExecutor streaming store-miss re-fold", () => {
     aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
     tenantId,
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   function ev(id: string, createdAt: number, idempotencyKey?: string): Event {
     const base = createTestEvent(
@@ -145,6 +149,8 @@ describe("FoldProjectionExecutor streaming store-miss re-fold", () => {
           projectionName: "slim",
           eventCount: 5,
         });
+        expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledTimes(1);
+        expect(observeEsFoldStoreMissRefoldEvents).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -165,6 +171,8 @@ describe("FoldProjectionExecutor streaming store-miss re-fold", () => {
           projectionName: "slim",
           eventCount: 1,
         });
+        expect(incrementEsFoldStoreMissRefoldTotal).toHaveBeenCalledTimes(1);
+        expect(observeEsFoldStoreMissRefoldEvents).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
@@ -183,7 +183,7 @@ describe("RedisCachedFoldStore", () => {
 
     describe("given Redis SET and DEL both fail", () => {
       describe("when storing state", () => {
-        it("throws and records the SET failure metric", async () => {
+        it("throws and records the SET and DEL failure metrics", async () => {
           const redis = createMockRedis();
           redis.set.mockRejectedValueOnce(new Error("SET failed"));
           redis.del.mockRejectedValueOnce(new Error("DEL failed"));
@@ -203,6 +203,10 @@ describe("RedisCachedFoldStore", () => {
           expect(incrementEsFoldCacheRedisError).toHaveBeenCalledWith(
             "test_table",
             "set",
+          );
+          expect(incrementEsFoldCacheRedisError).toHaveBeenCalledWith(
+            "test_table",
+            "del",
           );
         });
       });

--- a/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -63,6 +63,26 @@ function withOccurredAtHint(
   return { ...context, occurredAtMs: occurredAt };
 }
 
+/**
+ * Whether a re-folded history event pre-dates this delivery — i.e. the fold is
+ * RESUMING an aggregate that already had events, rather than touching it for
+ * the first time.
+ *
+ * Keyed on `event.id`, deliberately, and never on `idempotencyKey`. A retry
+ * delivery carries a NEW id but the SAME idempotency key as the earlier event
+ * it repeats, so keying on the idempotency key would read that earlier event as
+ * "one of the ones we just delivered" and mislabel resumed work as first touch.
+ * Both re-fold paths must share this predicate or the same persisted history
+ * reports different kinds depending on which loader the projection happens to
+ * use.
+ *
+ * This is distinct from the DEDUP key (`idempotencyKey || id`), which the
+ * streamed path still needs to collapse a raw, undeduplicated page.
+ */
+function isPreExisting(event: Event, deliveredIds: ReadonlySet<string>): boolean {
+  return !deliveredIds.has(event.id);
+}
+
 function recordStoreMissRefoldMetrics({
   projectionName,
   refoldEventCount,
@@ -388,8 +408,8 @@ export class FoldProjectionExecutor {
     if (history.length === 0) return null;
 
     const deliveredIds = new Set(delivered.map((event) => event.id));
-    const sawPreExisting = history.some(
-      (event) => !deliveredIds.has(event.id),
+    const sawPreExisting = history.some((event) =>
+      isPreExisting(event, deliveredIds),
     );
     recordStoreMissRefoldMetrics({
       projectionName: projection.name,
@@ -455,9 +475,10 @@ export class FoldProjectionExecutor {
     // instead of hanging the fold worker for the aggregate indefinitely.
     // 100k pages * 1000/page default covers a 100M-event aggregate.
     const MAX_PAGES = 100_000;
-    const deliveredDedupKeys = new Set(
-      delivered.map((event) => event.idempotencyKey || event.id),
-    );
+    // Two different keyings, on purpose — see `isPreExisting`. Dedup collapses
+    // a raw page by idempotency key; the resumed/first-touch classification
+    // keys on id so it matches the array path.
+    const deliveredIds = new Set(delivered.map((event) => event.id));
     const seen = new Set<string>();
     let state = projection.init();
     let after: { timestamp: number; eventId: string } | undefined;
@@ -485,7 +506,7 @@ export class FoldProjectionExecutor {
         const dedupKey = event.idempotencyKey || event.id;
         if (seen.has(dedupKey)) continue;
         seen.add(dedupKey);
-        if (!deliveredDedupKeys.has(dedupKey)) sawPreExisting = true;
+        if (isPreExisting(event, deliveredIds)) sawPreExisting = true;
         state = projection.apply(state, event as E);
         refoldEventCount++;
       }

--- a/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -1,5 +1,9 @@
 import { createLogger } from "@langwatch/observability";
-import { incrementEsFoldRefoldTotal } from "~/server/metrics";
+import {
+  incrementEsFoldRefoldTotal,
+  incrementEsFoldStoreMissRefoldTotal,
+  observeEsFoldStoreMissRefoldEvents,
+} from "~/server/metrics";
 import type { Event } from "../domain/types";
 import type { FoldProjectionDefinition } from "./foldProjection.types";
 import type { ProjectionStoreContext } from "./projectionStoreContext";
@@ -57,6 +61,25 @@ function withOccurredAtHint(
   const occurredAt = (event as Record<string, unknown>).occurredAt;
   if (typeof occurredAt !== "number" || occurredAt <= 0) return context;
   return { ...context, occurredAtMs: occurredAt };
+}
+
+function recordStoreMissRefoldMetrics({
+  projectionName,
+  refoldEventCount,
+  deliveredCount,
+}: {
+  projectionName: string;
+  refoldEventCount: number;
+  deliveredCount: number;
+}): void {
+  incrementEsFoldStoreMissRefoldTotal({
+    projectionName,
+    kind: refoldEventCount > deliveredCount ? "resumed" : "first_touch",
+  });
+  observeEsFoldStoreMissRefoldEvents({
+    projectionName,
+    eventCount: refoldEventCount,
+  });
 }
 
 /**
@@ -364,6 +387,12 @@ export class FoldProjectionExecutor {
     });
     if (history.length === 0) return null;
 
+    recordStoreMissRefoldMetrics({
+      projectionName: projection.name,
+      refoldEventCount: history.length,
+      deliveredCount: delivered.length,
+    });
+
     logger.info(
       {
         projection: projection.name,
@@ -458,6 +487,12 @@ export class FoldProjectionExecutor {
     }
 
     if (refoldEventCount === 0) return null;
+
+    recordStoreMissRefoldMetrics({
+      projectionName: projection.name,
+      refoldEventCount,
+      deliveredCount: delivered.length,
+    });
 
     logger.info(
       {

--- a/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -66,15 +66,15 @@ function withOccurredAtHint(
 function recordStoreMissRefoldMetrics({
   projectionName,
   refoldEventCount,
-  deliveredCount,
+  sawPreExisting,
 }: {
   projectionName: string;
   refoldEventCount: number;
-  deliveredCount: number;
+  sawPreExisting: boolean;
 }): void {
   incrementEsFoldStoreMissRefoldTotal({
     projectionName,
-    kind: refoldEventCount > deliveredCount ? "resumed" : "first_touch",
+    kind: sawPreExisting ? "resumed" : "first_touch",
   });
   observeEsFoldStoreMissRefoldEvents({
     projectionName,
@@ -387,10 +387,14 @@ export class FoldProjectionExecutor {
     });
     if (history.length === 0) return null;
 
+    const deliveredIds = new Set(delivered.map((event) => event.id));
+    const sawPreExisting = history.some(
+      (event) => !deliveredIds.has(event.id),
+    );
     recordStoreMissRefoldMetrics({
       projectionName: projection.name,
       refoldEventCount: history.length,
-      deliveredCount: delivered.length,
+      sawPreExisting,
     });
 
     logger.info(
@@ -407,8 +411,8 @@ export class FoldProjectionExecutor {
     // Merge delivered events the history read missed back into the fold's
     // declared order before folding — a tail append could let an event that
     // belongs in the middle overwrite last-write-wins fields.
-    const seen = new Set(history.map((e) => e.id));
-    const missing = delivered.filter((e) => !seen.has(e.id));
+    for (const event of history) deliveredIds.delete(event.id);
+    const missing = delivered.filter((event) => deliveredIds.has(event.id));
     const combined = [...(history as E[]), ...missing].sort((a, b) =>
       compareFoldEvents(projection, a, b),
     );
@@ -451,10 +455,14 @@ export class FoldProjectionExecutor {
     // instead of hanging the fold worker for the aggregate indefinitely.
     // 100k pages * 1000/page default covers a 100M-event aggregate.
     const MAX_PAGES = 100_000;
+    const deliveredDedupKeys = new Set(
+      delivered.map((event) => event.idempotencyKey || event.id),
+    );
     const seen = new Set<string>();
     let state = projection.init();
     let after: { timestamp: number; eventId: string } | undefined;
     let refoldEventCount = 0;
+    let sawPreExisting = false;
     let pageCount = 0;
 
     for (;;) {
@@ -477,6 +485,7 @@ export class FoldProjectionExecutor {
         const dedupKey = event.idempotencyKey || event.id;
         if (seen.has(dedupKey)) continue;
         seen.add(dedupKey);
+        if (!deliveredDedupKeys.has(dedupKey)) sawPreExisting = true;
         state = projection.apply(state, event as E);
         refoldEventCount++;
       }
@@ -491,7 +500,7 @@ export class FoldProjectionExecutor {
     recordStoreMissRefoldMetrics({
       projectionName: projection.name,
       refoldEventCount,
-      deliveredCount: delivered.length,
+      sawPreExisting,
     });
 
     logger.info(

--- a/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
+++ b/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
@@ -123,6 +123,7 @@ export class RedisCachedFoldStore<State> implements FoldProjectionStore<State> {
       try {
         await this.redis.del(key);
       } catch (deleteError) {
+        incrementEsFoldCacheRedisError(this.keyPrefix, "del");
         logger.warn(
           { aggregateId, error: String(deleteError) },
           "Redis DEL failed after SET failure",

--- a/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
+++ b/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
@@ -130,7 +130,7 @@ export class RedisCachedFoldStore<State> implements FoldProjectionStore<State> {
         );
       }
 
-      logger.warn(
+      logger.error(
         { aggregateId, error: String(error) },
         "Redis SET failed after CH write — fold will retry",
       );

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -438,6 +438,37 @@ export const incrementEsFoldRefoldTotal = (
   outcome: "performed" | "declined" | "unavailable",
 ) => esFoldRefoldTotal.labels(projectionName, outcome).inc();
 
+register.removeSingleMetric("es_fold_store_miss_refold_total");
+const esFoldStoreMissRefoldTotal = new Counter({
+  name: "es_fold_store_miss_refold_total",
+  help: "Store-miss fold re-folds by whether history contained events before the delivered batch",
+  labelNames: ["projection_name", "kind"] as const,
+});
+
+export const incrementEsFoldStoreMissRefoldTotal = ({
+  projectionName,
+  kind,
+}: {
+  projectionName: string;
+  kind: "first_touch" | "resumed";
+}) => esFoldStoreMissRefoldTotal.labels(projectionName, kind).inc();
+
+register.removeSingleMetric("es_fold_store_miss_refold_events");
+const esFoldStoreMissRefoldEvents = new Histogram({
+  name: "es_fold_store_miss_refold_events",
+  help: "Number of events replayed per store-miss fold re-fold",
+  labelNames: ["projection_name"] as const,
+  buckets: [1, 2, 5, 10, 25, 50, 100, 250, 1000],
+});
+
+export const observeEsFoldStoreMissRefoldEvents = ({
+  projectionName,
+  eventCount,
+}: {
+  projectionName: string;
+  eventCount: number;
+}) => esFoldStoreMissRefoldEvents.labels(projectionName).observe(eventCount);
+
 register.removeSingleMetric("es_reactor_collapsed_total");
 const esReactorCollapsedTotal = new Counter({
   name: "es_reactor_collapsed_total",
@@ -565,7 +596,7 @@ const esFoldCacheRedisErrorTotal = new Counter({
 
 export const incrementEsFoldCacheRedisError = (
   projectionName: string,
-  operation: "get" | "set",
+  operation: "get" | "set" | "del",
 ) => esFoldCacheRedisErrorTotal.labels(projectionName, operation).inc();
 
 // ============================================================================

--- a/specs/event-sourcing/fold-observability.feature
+++ b/specs/event-sourcing/fold-observability.feature
@@ -1,0 +1,30 @@
+Feature: Fold projection observability
+
+  Operators need durable metrics for store-miss re-folds and cache failures so
+  they can distinguish expected first-touch work from replays caused by gaps.
+
+  Scenario: First-touch store miss is visible
+    Given a fold projection store has no state for an aggregate
+    And the event history contains only the delivered events
+    When the projection rebuilds the aggregate from the event history
+    Then the rebuild is counted as a first-touch store-miss re-fold
+    And the number of replayed history events is recorded
+
+  Scenario: Resumed store miss is visible
+    Given a fold projection store has no state for an aggregate
+    And the event history contains events beyond the delivered batch
+    When the projection rebuilds the aggregate from the event history
+    Then the rebuild is counted as a resumed store-miss re-fold
+    And the number of replayed history events is recorded
+
+  Scenario: Streamed store-miss re-folds have the same visibility
+    Given an order-insensitive fold streams its event history in pages
+    When the projection rebuilds after a store miss
+    Then the rebuild kind is derived from the full streamed history
+    And the total number of replayed history events is recorded
+
+  Scenario: Redis cleanup failure is visible
+    Given writing new fold state to Redis fails
+    When deleting the stale Redis cache entry also fails
+    Then the Redis delete failure is counted separately
+    And the original write failure is still propagated for retry

--- a/specs/event-sourcing/redis-fold-cache.feature
+++ b/specs/event-sourcing/redis-fold-cache.feature
@@ -25,7 +25,7 @@ Feature: Redis write-through cache for fold projections
   Scenario: Store commits to ClickHouse first then updates the Redis cache
     When the fold stores new state for aggregate "trace-1"
     Then the state is written to ClickHouse first (throwing on failure so the event is retried)
-    And only then must be cached in Redis with a 300-second TTL
+    And the state is cached in Redis only after the durable write succeeds
 
   Scenario: Redis write failure discards stale cache state and retries the fold
     Given the fold stores new state for aggregate "trace-1" in ClickHouse


### PR DESCRIPTION
## What changed

- added durable store-miss re-fold counters split into `first_touch` and `resumed`
- added a replay-size histogram with buckets `[1, 2, 5, 10, 25, 50, 100, 250, 1000]`
- instrumented both array and streamed store-miss re-fold paths without changing their existing logs or behavior
- counted Redis `DEL` failures after failed fold-cache `SET` operations
- added Gherkin coverage plus executor, cache, coalesced-batch, and real Prometheus registry tests

## Why

Store-miss re-folds dominate production re-fold cost but were only visible in short-lived logs. These metrics make the work trendable and distinguish expected first-touch rebuilds from resumed history replays, while exposing failed Redis cleanup separately.

## Validation

- `pnpm test:unit src/server/__tests__/metrics-instrumentation.unit.test.ts` — 33 tests passed
- focused fold executor and Redis cache unit suite — 43 tests passed
- `nice -n 19 ./node_modules/.bin/tsgo --noEmit --project ./tsconfig.tsgo.json` — passed
- `git diff --check 83129e09b...HEAD` — passed
- Biome check could not start because the checked-in 2.4.14 config is incompatible with the installed 2.5.1 CLI; this mismatch exists on the base branch

https://claude.ai/code/session_01Rxp9AeY1d18xEW7KnNCEt1
