### PR TITLE
fix: keep process failure diagnostics generic

### DIFF
--- a/langwatch/src/server/event-sourcing/process-manager/__tests__/failureDiagnostic.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/process-manager/__tests__/failureDiagnostic.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { toSafeFailureDiagnostic } from "../failureDiagnostic";
+
+describe("toSafeFailureDiagnostic", () => {
+  it.each([
+    "Authorization: Bearer sk-live-secret-token",
+    "prompt-derived customer text: tell me my medical history",
+    "password=hunter2 upstream request failed",
+  ])("omits untrusted error content: %s", (sensitiveMessage) => {
+    const error = new Error(sensitiveMessage);
+    error.name = `CustomError-${sensitiveMessage}`;
+
+    const diagnostic = toSafeFailureDiagnostic(error);
+    const serialized = JSON.stringify(diagnostic);
+
+    expect(diagnostic).toEqual({
+      errorType: "Error",
+      errorMessage: "Operation failed; sensitive details were omitted",
+    });
+    expect(serialized).not.toContain(sensitiveMessage);
+    expect(serialized).not.toContain("sk-live-secret-token");
+    expect(serialized).not.toContain("medical history");
+    expect(serialized).not.toContain("hunter2");
+  });
+
+  it("retains only a trusted built-in failure category", () => {
+    expect(toSafeFailureDiagnostic(new TypeError("customer content"))).toEqual({
+      errorType: "TypeError",
+      errorMessage: "Operation failed; sensitive details were omitted",
+    });
+    expect(toSafeFailureDiagnostic({ secret: "sk-live" })).toEqual({
+      errorType: "NonErrorThrown",
+      errorMessage: "Operation failed; sensitive details were omitted",
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/process-manager/__tests__/traceContinuity.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/process-manager/__tests__/traceContinuity.unit.test.ts
@@ -32,14 +32,15 @@ import { OutboxDispatcherService } from "../outbox/outboxDispatcherService";
 import { ProcessManagerService } from "../processManagerService";
 import { InMemoryProcessStore } from "../stores/inMemoryProcessStore";
 import {
+  type PilotState,
   pilotDefinition,
   pilotEvent,
   pilotRef,
   T0,
-  type PilotState,
 } from "./helpers/pilotProcess.fixture";
 
-const W3C_TRACEPARENT_REGEX = /^00-([a-f0-9]{32})-([a-f0-9]{16})-([0-9a-f]{2})$/;
+const W3C_TRACEPARENT_REGEX =
+  /^00-([a-f0-9]{32})-([a-f0-9]{16})-([0-9a-f]{2})$/;
 
 describe("process-manager trace continuity", () => {
   let provider: NodeTracerProvider;
@@ -135,6 +136,44 @@ describe("process-manager trace continuity", () => {
     });
   });
 
+  describe("when process evolution fails", () => {
+    it("exports a generic exception without customer content or credentials", async () => {
+      const sensitiveFailure =
+        "Authorization: Bearer sk-live-secret prompt-derived customer text";
+      const failingService = new ProcessManagerService({
+        definition: {
+          ...pilotDefinition,
+          name: "failingProcess",
+          evolve: () => {
+            throw new Error(sensitiveFailure);
+          },
+        },
+        store,
+      });
+
+      await expect(
+        failingService.handleEvent({
+          envelope: pilotEvent({ eventId: "evt_sensitive_failure" }),
+          now: T0,
+        }),
+      ).rejects.toThrow();
+
+      const evolveSpan = exporter
+        .getFinishedSpans()
+        .find((span) => span.name === "process failingProcess evolve");
+      const exceptionEvent = evolveSpan?.events.find(
+        (event) => event.name === "exception",
+      );
+      expect(exceptionEvent?.attributes).toMatchObject({
+        "exception.type": "Error",
+        "exception.message": "Operation failed; sensitive details were omitted",
+      });
+      expect(JSON.stringify(exceptionEvent)).not.toContain(sensitiveFailure);
+      expect(JSON.stringify(exceptionEvent)).not.toContain("sk-live-secret");
+      expect(JSON.stringify(exceptionEvent)).not.toContain("customer text");
+    });
+  });
+
   describe("when the outbox dispatches the persisted intent in a fresh context", () => {
     it("continues the original trace as a consumer span parented on the persisted carrier", async () => {
       const { producerTraceId } = await handleStartedTurnInsideProducerSpan();
@@ -176,9 +215,11 @@ describe("process-manager trace continuity", () => {
     it("records every retry attempt as a consumer span in the same trace", async () => {
       const { producerTraceId } = await handleStartedTurnInsideProducerSpan();
 
+      const sensitiveFailure =
+        "Authorization: Bearer sk-live-secret prompt-derived customer text";
       const handler = vi
         .fn()
-        .mockRejectedValueOnce(new Error("worker unavailable"))
+        .mockRejectedValueOnce(new Error(sensitiveFailure))
         .mockResolvedValue(undefined);
       const dispatcher = new OutboxDispatcherService({
         store,
@@ -203,6 +244,16 @@ describe("process-manager trace continuity", () => {
       expect(
         consumerSpans[0]!.events.some((event) => event.name === "exception"),
       ).toBe(true);
+      const exceptionEvent = consumerSpans[0]!.events.find(
+        (event) => event.name === "exception",
+      );
+      expect(exceptionEvent?.attributes).toMatchObject({
+        "exception.type": "Error",
+        "exception.message": "Operation failed; sensitive details were omitted",
+      });
+      expect(JSON.stringify(exceptionEvent)).not.toContain(sensitiveFailure);
+      expect(JSON.stringify(exceptionEvent)).not.toContain("sk-live-secret");
+      expect(JSON.stringify(exceptionEvent)).not.toContain("customer text");
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/process-manager/failureDiagnostic.ts
+++ b/langwatch/src/server/event-sourcing/process-manager/failureDiagnostic.ts
@@ -1,0 +1,34 @@
+const GENERIC_FAILURE_MESSAGE =
+  "Operation failed; sensitive details were omitted";
+
+/**
+ * Returns a bounded diagnostic that is safe for logs and exported telemetry.
+ * Error messages and custom names are untrusted because process inputs and
+ * provider failures can copy customer content or credentials into either.
+ */
+export function toSafeFailureDiagnostic(error: unknown): {
+  errorType: string;
+  errorMessage: string;
+} {
+  let errorType = "NonErrorThrown";
+
+  if (error instanceof AggregateError) {
+    errorType = "AggregateError";
+  } else if (error instanceof TypeError) {
+    errorType = "TypeError";
+  } else if (error instanceof RangeError) {
+    errorType = "RangeError";
+  } else if (error instanceof ReferenceError) {
+    errorType = "ReferenceError";
+  } else if (error instanceof SyntaxError) {
+    errorType = "SyntaxError";
+  } else if (error instanceof URIError) {
+    errorType = "URIError";
+  } else if (error instanceof EvalError) {
+    errorType = "EvalError";
+  } else if (error instanceof Error) {
+    errorType = "Error";
+  }
+
+  return { errorType, errorMessage: GENERIC_FAILURE_MESSAGE };
+}

--- a/langwatch/src/server/event-sourcing/process-manager/outbox/outboxDispatcherService.ts
+++ b/langwatch/src/server/event-sourcing/process-manager/outbox/outboxDispatcherService.ts
@@ -12,7 +12,7 @@ import {
   incrementEsProcessOutboxTotal,
   observeEsProcessOutboxDuration,
 } from "~/server/metrics";
-
+import { toSafeFailureDiagnostic } from "../failureDiagnostic";
 import type { JsonValue } from "../json";
 import type {
   LeasedOutboxMessageRecord,
@@ -184,17 +184,7 @@ export class OutboxDispatcherService {
             status: "dispatched",
           });
         } catch (error) {
-          const errorType =
-            error instanceof Error ? error.name : "NonErrorThrown";
-          const errorMessage =
-            error instanceof Error
-              ? error.message
-                  .replace(
-                    /\b(api[_-]?key|token|password|secret|authorization)\b\s*[:=]\s*\S+/gi,
-                    "$1=[REDACTED]",
-                  )
-                  .slice(0, 500)
-              : "A non-Error value was thrown";
+          const { errorType, errorMessage } = toSafeFailureDiagnostic(error);
           span.recordException({
             name: errorType,
             message: errorMessage,

--- a/langwatch/src/server/event-sourcing/process-manager/processManagerService.ts
+++ b/langwatch/src/server/event-sourcing/process-manager/processManagerService.ts
@@ -13,7 +13,7 @@ import {
   incrementEsProcessManagerTotal,
   observeEsProcessManagerDuration,
 } from "~/server/metrics";
-
+import { toSafeFailureDiagnostic } from "./failureDiagnostic";
 import { ensureJsonSafe } from "./json";
 import type {
   ProcessDefinition,
@@ -266,17 +266,7 @@ export class ProcessManagerService<State> {
             inputKind: params.inputKind,
             outcome: "failed",
           });
-          const errorType =
-            error instanceof Error ? error.name : "NonErrorThrown";
-          const errorMessage =
-            error instanceof Error
-              ? error.message
-                  .replace(
-                    /\b(api[_-]?key|token|password|secret|authorization)\b\s*[:=]\s*\S+/gi,
-                    "$1=[REDACTED]",
-                  )
-                  .slice(0, 500)
-              : "A non-Error value was thrown";
+          const { errorType, errorMessage } = toSafeFailureDiagnostic(error);
           span.recordException({
             name: errorType,
             message: errorMessage,


### PR DESCRIPTION
## Summary

- replace blacklist-based process-manager/outbox error-message handling with one allowlist-based generic diagnostic
- retain only trusted built-in error categories; omit raw exception text and custom names from logs and OpenTelemetry
- add unit and real-span regressions for bearer tokens, prompt-derived content, password text, custom error names, and non-Error throws

## Why

Follow-up to #5907. The resolved diagnostic-preservation feedback led to raw `error.message` being exported. A later P1 review demonstrated that an `Authorization: Bearer ...` value survived the blacklist and that arbitrary customer or prompt content could reach logs and OpenTelemetry. This PR fixes that exposure without changing process retry or throw behavior.

## Original feedback traceability

- P1 diagnostic exposure (`PRRT_kwDOKRXhvM6SATl8`): fixed by `toSafeFailureDiagnostic` and both process-manager/outbox call sites.
- Outside-diff metrics call-site coverage: current `main` still has helper-level coverage only in `metrics-instrumentation.unit.test.ts`; intentionally unchanged per the current scope.
- DNS rebinding/dial-time feedback: intentionally deferred per the current scope for a dedicated design.

## Validation

- focused Vitest suite: 4 files, 32 tests passed
- `pnpm run typecheck`
- `pnpm run typecheck:tests`
- `pnpm dlx @biomejs/biome@2.4.14 check` on the five touched files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Sensitive error details are now consistently removed from diagnostics, logs, and telemetry.
  * Failure messages use a safe, standardized description instead of exposing secrets or customer information.

* **Reliability**
  * Error categories remain available for trusted built-in failure types.
  * Retry and process-evolution failure reporting now preserves sanitized exception details while maintaining trace continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->