### PR TITLE
fix(telemetry): stop cross-tenant trace export, and trace our own planes without the content

### DIFF
--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -14,6 +14,10 @@ data:
   LOG_LEVEL: {{ .Values.logging.level | quote }}
   LW_GATEWAY_BASE_URL: {{ .Values.controlPlane.baseUrl | quote }}
   {{- if .Values.otel.endpoint }}
+  # Official OpenTelemetry name, plus the deprecated LangWatch-only name so
+  # older gateway images keep reading their endpoint during upgrades. The
+  # service accepts both being set as long as the values are equal.
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.otel.endpoint | quote }}
   OTEL_OTLP_ENDPOINT: {{ .Values.otel.endpoint | quote }}
   {{- end }}
   SERVER_MAX_REQUEST_BODY_BYTES: {{ printf "%d" (int64 .Values.security.maxRequestBodyBytes) | quote }}

--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -150,9 +150,12 @@ SENTRY_DSN=
 # observability-connect` sets all of this up for you. See
 # dev/docs/best_practices/local-observability.md.
 #
-# Base OTLP/HTTP collector URL. Exporters append /v1/traces, /v1/logs,
-# /v1/metrics. Set to http://localhost:4318 for the local stack. When set, the
-# TS app exports TRACES.
+# Base OTLP/HTTP collector URL for LangWatch's OWN telemetry — the official
+# OpenTelemetry env var, read by the TS app AND the Go services (aigateway,
+# langyagent). Exporters append /v1/traces, /v1/logs, /v1/metrics. Set to
+# http://localhost:4318 for the local stack. Never a customer destination:
+# customer traces ride product config (project tokens, LANGWATCH_ENDPOINT).
+# nlpgo routes spans per-tenant and ignores this (it warns if set).
 OTEL_EXPORTER_OTLP_ENDPOINT=
 # Optional auth headers ("key=value,key2=value2", e.g. "Authorization=Bearer x").
 # Leave empty for the local stack (no auth).
@@ -173,10 +176,12 @@ OTEL_EXPORTER_OTLP_ENDPOINT=
 # (CPU, memory, event loop, GC). Requires OTEL_EXPORTER_OTLP_ENDPOINT.
 #OTEL_METRICS_ENABLED=true
 
-# Go services (nlpgo, aigateway) dual-export: their OWN telemetry (traces +
-# logs + metrics) goes to this collector IN ADDITION to the product/customer
-# traces they already send to the LangWatch app. Empty = unchanged (default).
-# Set to http://localhost:4318 for the local stack.
+# Go services: OPTIONAL second collector for local development (LangWatch
+# extension — no official OTel name exists for a second destination). Must be
+# on this machine (localhost / *.localhost / host.docker.internal) — boot
+# refuses anything off-box. OTLP LOG export from Go services rides this;
+# span + metric export automatically dedupes when it equals
+# OTEL_EXPORTER_OTLP_ENDPOINT, so setting both to the local stack is correct.
 #OTEL_DEBUG_COLLECTOR_ENDPOINT=
 #OTEL_DEBUG_COLLECTOR_HEADERS=
 

--- a/langwatch/src/instrumentation.node.ts
+++ b/langwatch/src/instrumentation.node.ts
@@ -75,6 +75,11 @@ if (
     attributes: {
       "service.name": process.env.OTEL_SERVICE_NAME ?? "langwatch-app",
       "deployment.environment.name": process.env.ENVIRONMENT,
+      // Provenance marker shared with the Go services (pkg/otelsetup):
+      // everything the platform emits about ITSELF is identifiable as
+      // internal wherever it lands, so a misrouted payload can be
+      // recognised and refused. Customer traces never carry it.
+      "langwatch.origin": "platform_internal",
     },
     // envDetector merges OTEL_RESOURCE_ATTRIBUTES (e.g. langwatch.worktree=<name>,
     // set by `make observability-connect`) so telemetry from each worktree is

--- a/pkg/config/otel.go
+++ b/pkg/config/otel.go
@@ -368,10 +368,13 @@ func withTracesPath(endpoint string) string {
 // cannot forge one; a name allowlist would hand the switch to anyone who set
 // ENVIRONMENT=test.
 //
-// Loopback forms only: `localhost` and any `*.localhost` (the portless dev
-// hostnames, which resolve to loopback natively), literal 127.0.0.0/8 and ::1,
-// and `host.docker.internal` for containerised dev stacks. Private ranges are
-// NOT accepted — 10.x and 192.168.x are ordinary in-cluster addresses, so
+// Loopback forms only: `localhost`, literal 127.0.0.0/8 and ::1, `*.localhost`
+// (the portless dev hostnames) — which is additionally RESOLVED and required
+// to answer with loopback addresses only, because RFC 6761 recommends but does
+// not guarantee that resolvers keep .localhost on-box — and
+// `host.docker.internal` for containerised dev stacks (inherently the host's
+// gateway address; the escape hatch's whole point). Private ranges are NOT
+// accepted — 10.x and 192.168.x are ordinary in-cluster addresses, so
 // allowing them would readmit the deployment this check exists to refuse.
 func debugCollectorMustBeLocal(endpoint string) error {
 	u, err := url.Parse(endpoint)
@@ -379,7 +382,25 @@ func debugCollectorMustBeLocal(endpoint string) error {
 		return fmt.Errorf("OTEL_DEBUG_COLLECTOR_ENDPOINT is not a valid URL: %w", err)
 	}
 	host := strings.ToLower(u.Hostname())
-	if host == "localhost" || strings.HasSuffix(host, ".localhost") || host == "host.docker.internal" {
+	if host == "localhost" || host == "host.docker.internal" {
+		return nil
+	}
+	if strings.HasSuffix(host, ".localhost") {
+		ips, err := lookupHostIPs(host)
+		if err != nil || len(ips) == 0 {
+			return fmt.Errorf(
+				"OTEL_DEBUG_COLLECTOR_ENDPOINT host %q did not resolve (%v) — use localhost or 127.0.0.1 instead",
+				host, err,
+			)
+		}
+		for _, ip := range ips {
+			if !ip.IsLoopback() {
+				return fmt.Errorf(
+					"OTEL_DEBUG_COLLECTOR_ENDPOINT host %q resolves to the non-loopback address %s — a .localhost name must stay on this machine",
+					host, ip,
+				)
+			}
+		}
 		return nil
 	}
 	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
@@ -390,6 +411,10 @@ func debugCollectorMustBeLocal(endpoint string) error {
 		u.Host,
 	)
 }
+
+// lookupHostIPs is indirected so tests can pin resolver behavior instead of
+// depending on the machine's DNS handling of .localhost names.
+var lookupHostIPs = net.LookupIP
 
 // mustBeResolved guards every accessor that reads resolved state. A missing
 // Resolve call is a programming error that would otherwise export telemetry

--- a/pkg/config/otel.go
+++ b/pkg/config/otel.go
@@ -63,6 +63,14 @@ func (o *OTel) DebugCollector() (endpoint string, headers map[string]string) {
 	return o.DebugCollectorEndpoint, parseHeaders(o.DebugCollectorHeaders)
 }
 
+// PrimaryOTLP returns the primary collector's base endpoint (no signal path)
+// and its parsed headers. Exposed for callers that forward OTLP payloads
+// directly rather than through the SDK exporter — e.g. the Langy relay shipping
+// LangWatch's own copy of worker telemetry.
+func (o *OTel) PrimaryOTLP() (endpoint string, headers map[string]string) {
+	return o.OTLPEndpoint, parseHeaders(o.OTLPHeaders)
+}
+
 // Configure initializes the OTel provider from the config, parsing headers and
 // returning a Provider whose Shutdown method flushes pending telemetry.
 func (o *OTel) Configure(ctx context.Context, nodeID string) (*otelsetup.Provider, error) {

--- a/pkg/config/otel.go
+++ b/pkg/config/otel.go
@@ -387,10 +387,16 @@ func debugCollectorMustBeLocal(endpoint string) error {
 	}
 	if strings.HasSuffix(host, ".localhost") {
 		ips, err := lookupHostIPs(host)
-		if err != nil || len(ips) == 0 {
+		if err != nil {
 			return fmt.Errorf(
-				"OTEL_DEBUG_COLLECTOR_ENDPOINT host %q did not resolve (%v) — use localhost or 127.0.0.1 instead",
+				"OTEL_DEBUG_COLLECTOR_ENDPOINT host %q did not resolve — use localhost or 127.0.0.1 instead: %w",
 				host, err,
+			)
+		}
+		if len(ips) == 0 {
+			return fmt.Errorf(
+				"OTEL_DEBUG_COLLECTOR_ENDPOINT host %q resolved to no addresses — use localhost or 127.0.0.1 instead",
+				host,
 			)
 		}
 		for _, ip := range ips {

--- a/pkg/config/otel.go
+++ b/pkg/config/otel.go
@@ -171,8 +171,15 @@ func (o *OTel) Resolve(environment string) error {
 
 	r := resolvedOTel{set: true, headers: headers, sampler: sampler}
 	if !o.SDKDisabled {
-		r.baseEndpoint = baseEndpoint
-		if !strings.EqualFold(strings.TrimSpace(o.TracesExporter), "none") {
+		if strings.EqualFold(strings.TrimSpace(o.TracesExporter), "none") {
+			// Span export is off, so no span-carrying endpoint may survive.
+			// baseEndpoint is what PrimaryOTLP hands to callers that POST
+			// spans themselves (the langy relay), and those bypass the SDK
+			// exporter entirely — leaving it set would keep shipping spans
+			// after the operator asked for none. Leaving both empty is the
+			// whole mechanism: no field here carries a span destination.
+		} else {
+			r.baseEndpoint = baseEndpoint
 			if tracesOverride := strings.TrimSpace(o.ExporterTracesEndpoint); tracesOverride != "" {
 				r.tracesEndpoint = tracesOverride
 			} else {
@@ -454,6 +461,10 @@ func (o *OTel) DebugCollector() (endpoint string, headers map[string]string) {
 // LangWatch's own copy of worker telemetry. Requires Resolve. Note the
 // signal-specific OTEL_EXPORTER_OTLP_TRACES_ENDPOINT override does NOT feed
 // this path — direct forwarders compose their own signal URL from the base.
+//
+// Every consumer today POSTs spans, so OTEL_TRACES_EXPORTER=none empties this
+// too: an operator who turned span export off must not keep receiving spans
+// from a forwarder that never touches the SDK exporter.
 func (o *OTel) PrimaryOTLP() (endpoint string, headers map[string]string) {
 	o.mustBeResolved()
 	return o.resolved.baseEndpoint, o.resolved.headers

--- a/pkg/config/otel.go
+++ b/pkg/config/otel.go
@@ -12,6 +12,10 @@ type OTel struct {
 	OTLPEndpoint string  `env:"OTLP_ENDPOINT"`
 	OTLPHeaders  string  `env:"OTLP_HEADERS"`
 	SampleRatio  float64 `env:"SAMPLE_RATIO"`
+	// SampleRatioSet distinguishes an explicit 0 from an omitted environment
+	// variable. It is set by service LoadConfig after Hydrate, because the
+	// generic env hydrator intentionally skips empty values.
+	SampleRatioSet bool
 
 	// DebugCollectorEndpoint is an OPTIONAL second OTLP/HTTP endpoint —
 	// typically a developer's local observability stack (OTel Collector
@@ -29,12 +33,9 @@ type OTel struct {
 	DebugCollectorHeaders string `env:"DEBUG_COLLECTOR_HEADERS"`
 }
 
-// UnsetSampleRatio is the zero value meaning no SAMPLE_RATIO was configured.
-// Telling "unset" apart from an explicit value is the whole point: services
-// previously defaulted the field to 1.0 and then rewrote it with
-// `if SampleRatio == 1.0 && environment != "local"`, which cannot distinguish an
-// operator who deliberately asked for 100% in production from one who asked for
-// nothing — and silently gave both of them 10%.
+// UnsetSampleRatio is retained for default configuration literals. Use
+// SampleRatioSet to distinguish it from an explicit 0 read from the
+// OTEL_SAMPLE_RATIO environment variable.
 const UnsetSampleRatio = 0
 
 // DefaultNonLocalSampleRatio is the trace sample ratio applied outside local
@@ -42,10 +43,10 @@ const UnsetSampleRatio = 0
 const DefaultNonLocalSampleRatio = 0.1
 
 // ResolveSampleRatio fills in the environment-aware default when no ratio was
-// configured, and otherwise honours exactly what was asked for. Call once,
+// configured, and otherwise honors exactly what was asked for. Call once,
 // before Validate.
 func (o *OTel) ResolveSampleRatio(environment string) {
-	if o.SampleRatio != UnsetSampleRatio {
+	if o.SampleRatioSet || o.SampleRatio != UnsetSampleRatio {
 		return
 	}
 	if environment == "local" {

--- a/pkg/config/otel.go
+++ b/pkg/config/otel.go
@@ -29,6 +29,32 @@ type OTel struct {
 	DebugCollectorHeaders string `env:"DEBUG_COLLECTOR_HEADERS"`
 }
 
+// UnsetSampleRatio is the zero value meaning no SAMPLE_RATIO was configured.
+// Telling "unset" apart from an explicit value is the whole point: services
+// previously defaulted the field to 1.0 and then rewrote it with
+// `if SampleRatio == 1.0 && environment != "local"`, which cannot distinguish an
+// operator who deliberately asked for 100% in production from one who asked for
+// nothing — and silently gave both of them 10%.
+const UnsetSampleRatio = 0
+
+// DefaultNonLocalSampleRatio is the trace sample ratio applied outside local
+// development when the operator did not choose one.
+const DefaultNonLocalSampleRatio = 0.1
+
+// ResolveSampleRatio fills in the environment-aware default when no ratio was
+// configured, and otherwise honours exactly what was asked for. Call once,
+// before Validate.
+func (o *OTel) ResolveSampleRatio(environment string) {
+	if o.SampleRatio != UnsetSampleRatio {
+		return
+	}
+	if environment == "local" {
+		o.SampleRatio = 1.0
+		return
+	}
+	o.SampleRatio = DefaultNonLocalSampleRatio
+}
+
 // DebugCollector returns the debug-collector base endpoint (no signal
 // path) and its parsed headers. An empty endpoint means the debug
 // collector is disabled. Exposed for services (e.g. nlpgo) that build

--- a/pkg/config/otel.go
+++ b/pkg/config/otel.go
@@ -3,16 +3,80 @@ package config
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"math"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/langwatch/langwatch/pkg/otelsetup"
 )
 
-// OTel holds OpenTelemetry exporter configuration.
+// OTel holds the OpenTelemetry configuration for a service's OWN operational
+// telemetry, hydrated from the OFFICIAL OpenTelemetry environment variables.
+// The embedding tag `env:"OTEL"` plus the field tags below resolve to the
+// real names — e.g. OTEL_EXPORTER_OTLP_ENDPOINT — so a single shell or pod
+// env block configures every LangWatch process (Go services and the TS app)
+// identically.
+//
+// The LangWatch-only names that predate this scheme (OTEL_OTLP_ENDPOINT,
+// OTEL_OTLP_HEADERS, OTEL_SAMPLE_RATIO) remain readable as DEPRECATED
+// fallbacks. An official name and its fallback set to DIFFERENT values is a
+// boot error: precedence between two live values is never silently guessed.
+//
+// The OTEL_* namespace configures LangWatch telemetry ONLY. Customer trace
+// destinations are product configuration — per-project OTLP tokens, the
+// customer trace bridge, LANGWATCH_ENDPOINT — and must never be sourced from
+// these variables. That split is what bounds the blast radius of a config
+// mistake: a bad OTEL_* value can misroute OUR spans, never a tenant's.
 type OTel struct {
+	// ExporterEndpoint is OTEL_EXPORTER_OTLP_ENDPOINT: the base URL of the
+	// collector for LangWatch's own telemetry. Per-signal paths (/v1/traces,
+	// /v1/metrics) are appended. Empty — and no fallback set — means the
+	// exporter is OFF: we never fall back to the SDK's localhost default,
+	// because "where does our telemetry go" must always be an explicit answer.
+	ExporterEndpoint string `env:"EXPORTER_OTLP_ENDPOINT"`
+	// ExporterHeaders is OTEL_EXPORTER_OTLP_HEADERS ("k=v,k2=v2", values may
+	// be percent-encoded per the W3C baggage format).
+	ExporterHeaders string `env:"EXPORTER_OTLP_HEADERS"`
+	// ExporterTracesEndpoint is the signal-specific
+	// OTEL_EXPORTER_OTLP_TRACES_ENDPOINT. Per spec it is used AS-IS (no path
+	// appended) and wins over ExporterEndpoint for traces.
+	ExporterTracesEndpoint string `env:"EXPORTER_OTLP_TRACES_ENDPOINT"`
+	// ExporterTracesHeaders is OTEL_EXPORTER_OTLP_TRACES_HEADERS; wins over
+	// ExporterHeaders for traces.
+	ExporterTracesHeaders string `env:"EXPORTER_OTLP_TRACES_HEADERS"`
+	// ExporterProtocol is OTEL_EXPORTER_OTLP_PROTOCOL. LangWatch exporters
+	// speak http/protobuf only; any other value is a boot error rather than a
+	// silently ignored intent.
+	ExporterProtocol string `env:"EXPORTER_OTLP_PROTOCOL"`
+	// ExporterMetricsEndpoint / ExporterLogsEndpoint are the remaining
+	// signal-specific official names. They are read solely so a set value can
+	// be WARNED about instead of silently ignored — per-signal destination
+	// overrides beyond traces are not supported.
+	ExporterMetricsEndpoint string `env:"EXPORTER_OTLP_METRICS_ENDPOINT"`
+	ExporterLogsEndpoint    string `env:"EXPORTER_OTLP_LOGS_ENDPOINT"`
+	// TracesExporter is OTEL_TRACES_EXPORTER: "otlp" (the default) or "none"
+	// to turn span export off while keeping metrics.
+	TracesExporter string `env:"TRACES_EXPORTER"`
+	// TracesSampler + TracesSamplerArg are OTEL_TRACES_SAMPLER /
+	// OTEL_TRACES_SAMPLER_ARG. Supported kinds: always_on, always_off,
+	// traceidratio, parentbased_always_on, parentbased_always_off,
+	// parentbased_traceidratio. The ratio kinds REQUIRE the arg — relying on
+	// an implementation-defined default ratio is exactly the kind of luck
+	// this config refuses.
+	TracesSampler    string `env:"TRACES_SAMPLER"`
+	TracesSamplerArg string `env:"TRACES_SAMPLER_ARG"`
+	// SDKDisabled is OTEL_SDK_DISABLED: true turns every exporter (primary
+	// and debug) off. Other values are still validated — a disabled SDK is
+	// not a license to keep broken telemetry config around.
+	SDKDisabled bool `env:"SDK_DISABLED"`
+
+	// OTLPEndpoint / OTLPHeaders / SampleRatio are the DEPRECATED
+	// LangWatch-only names (OTEL_OTLP_ENDPOINT, OTEL_OTLP_HEADERS,
+	// OTEL_SAMPLE_RATIO). Still honored so existing deployments keep tracing;
+	// each use logs a rename warning at boot.
 	OTLPEndpoint string  `env:"OTLP_ENDPOINT"`
 	OTLPHeaders  string  `env:"OTLP_HEADERS"`
 	SampleRatio  float64 `env:"SAMPLE_RATIO"`
@@ -30,17 +94,268 @@ type OTel struct {
 	// logs and OTLP metrics. This is the base URL only — the per-signal
 	// paths (/v1/traces, /v1/logs, /v1/metrics) are appended by
 	// otelsetup. Empty (the default everywhere, prod included) means
-	// none of the debug-collector behavior is installed.
+	// none of the debug-collector behavior is installed. A LangWatch
+	// extension: there is no official OTel name for a second collector.
 	DebugCollectorEndpoint string `env:"DEBUG_COLLECTOR_ENDPOINT"`
 	// DebugCollectorHeaders carries optional auth headers for the debug
 	// collector, in the OTEL_EXPORTER_OTLP_HEADERS "k=v,k2=v2" format.
 	DebugCollectorHeaders string `env:"DEBUG_COLLECTOR_HEADERS"`
+
+	// resolved is populated by Resolve. Accessors panic when it is unset so a
+	// missing Resolve call fails the first test that touches telemetry,
+	// instead of silently exporting with half-applied configuration.
+	resolved resolvedOTel
+}
+
+type resolvedOTel struct {
+	set bool
+	// baseEndpoint is the collector base URL (no signal path); feeds
+	// PrimaryOTLP for callers that POST OTLP payloads directly.
+	baseEndpoint string
+	// tracesEndpoint / metricsEndpoint are full per-signal URLs. Empty means
+	// that signal's primary exporter is off.
+	tracesEndpoint  string
+	metricsEndpoint string
+	headers         map[string]string
+	sampler         otelsetup.SamplerChoice
 }
 
 // UnsetSampleRatio is retained for default configuration literals. Use
 // SampleRatioSet to distinguish it from an explicit 0 read from the
 // OTEL_SAMPLE_RATIO environment variable.
 const UnsetSampleRatio = 0
+
+// DefaultNonLocalSampleRatio is the trace sample ratio applied outside local
+// development when the operator did not choose one.
+const DefaultNonLocalSampleRatio = 0.1
+
+// Resolve reconciles the official OpenTelemetry environment variables with
+// the deprecated LangWatch names and the environment-aware defaults, then
+// validates the result. Call exactly once from LoadConfig, after Hydrate and
+// after SampleRatioSet is stamped; every telemetry accessor below requires it.
+//
+// Everything here fails closed at boot rather than at the first exported
+// span: a conflicting or out-of-range value is not discoverable from inside
+// the running service, so the only place it can be caught is the place it is
+// read.
+func (o *OTel) Resolve(environment string) error {
+	baseEndpoint, err := o.resolveBaseEndpoint()
+	if err != nil {
+		return err
+	}
+	headers, err := o.resolveHeaders()
+	if err != nil {
+		return err
+	}
+	sampler, err := o.resolveSampler(environment)
+	if err != nil {
+		return err
+	}
+	if err := o.validateFixedVocabulary(); err != nil {
+		return err
+	}
+	// The debug collector is a tenant-agnostic dual export: every span the
+	// service produces is copied there, including spans the per-tenant router
+	// would otherwise route by the originating project's key (nlpgo) or drop
+	// for lack of one. That is exactly what makes it useful on a laptop and
+	// unacceptable anywhere customer data flows. ADR-042 specifies it as
+	// local-only; this makes that specification enforceable.
+	if o.DebugCollectorEndpoint != "" {
+		if err := debugCollectorMustBeLocal(o.DebugCollectorEndpoint); err != nil {
+			return err
+		}
+	}
+	for _, warning := range o.unsupportedVarWarnings() {
+		slog.Warn("otel config", "warning", warning)
+	}
+
+	r := resolvedOTel{set: true, headers: headers, sampler: sampler}
+	if !o.SDKDisabled {
+		r.baseEndpoint = baseEndpoint
+		if !strings.EqualFold(strings.TrimSpace(o.TracesExporter), "none") {
+			if tracesOverride := strings.TrimSpace(o.ExporterTracesEndpoint); tracesOverride != "" {
+				r.tracesEndpoint = tracesOverride
+			} else {
+				r.tracesEndpoint = withTracesPath(baseEndpoint)
+			}
+		}
+		if baseEndpoint != "" {
+			r.metricsEndpoint = strings.TrimRight(baseEndpoint, "/") + "/v1/metrics"
+		}
+	}
+	o.resolved = r
+	return nil
+}
+
+// resolveBaseEndpoint reconciles OTEL_EXPORTER_OTLP_ENDPOINT with the
+// deprecated OTEL_OTLP_ENDPOINT.
+func (o *OTel) resolveBaseEndpoint() (string, error) {
+	official := strings.TrimSpace(o.ExporterEndpoint)
+	legacy := strings.TrimSpace(o.OTLPEndpoint)
+	switch {
+	case official != "" && legacy != "" && !equalEndpoint(official, legacy):
+		return "", fmt.Errorf(
+			"OTEL_EXPORTER_OTLP_ENDPOINT (%q) and deprecated OTEL_OTLP_ENDPOINT (%q) disagree — remove the deprecated one",
+			official, legacy,
+		)
+	case official != "":
+		return official, nil
+	case legacy != "":
+		slog.Warn("otel config", "warning",
+			"OTEL_OTLP_ENDPOINT is deprecated — rename to the official OTEL_EXPORTER_OTLP_ENDPOINT")
+		return legacy, nil
+	}
+	return "", nil
+}
+
+// resolveHeaders reconciles the official headers pair with the deprecated
+// OTEL_OTLP_HEADERS.
+func (o *OTel) resolveHeaders() (map[string]string, error) {
+	official := strings.TrimSpace(o.ExporterHeaders)
+	if tracesOverride := strings.TrimSpace(o.ExporterTracesHeaders); tracesOverride != "" {
+		official = tracesOverride
+	}
+	legacy := strings.TrimSpace(o.OTLPHeaders)
+	switch {
+	case official != "" && legacy != "" && official != legacy:
+		return nil, fmt.Errorf(
+			"OTEL_EXPORTER_OTLP_HEADERS and deprecated OTEL_OTLP_HEADERS are both set with different values — remove the deprecated one",
+		)
+	case official != "":
+		return parseHeaders(official), nil
+	case legacy != "":
+		slog.Warn("otel config", "warning",
+			"OTEL_OTLP_HEADERS is deprecated — rename to the official OTEL_EXPORTER_OTLP_HEADERS")
+		return parseHeaders(legacy), nil
+	}
+	return nil, nil
+}
+
+// officialSamplerKinds is the supported subset of the official
+// OTEL_TRACES_SAMPLER vocabulary, mapped onto (parentBased, needsArg).
+var officialSamplerKinds = map[string]struct {
+	parentBased bool
+	needsArg    bool
+	fixedRatio  float64
+}{
+	"always_on":                {parentBased: false, needsArg: false, fixedRatio: 1},
+	"always_off":               {parentBased: false, needsArg: false, fixedRatio: 0},
+	"traceidratio":             {parentBased: false, needsArg: true},
+	"parentbased_always_on":    {parentBased: true, needsArg: false, fixedRatio: 1},
+	"parentbased_always_off":   {parentBased: true, needsArg: false, fixedRatio: 0},
+	"parentbased_traceidratio": {parentBased: true, needsArg: true},
+}
+
+// resolveSampler reconciles OTEL_TRACES_SAMPLER(+ARG) with the deprecated
+// OTEL_SAMPLE_RATIO and the environment-aware default.
+func (o *OTel) resolveSampler(environment string) (otelsetup.SamplerChoice, error) {
+	legacySet := o.SampleRatioSet || o.SampleRatio != UnsetSampleRatio
+	if kind := strings.ToLower(strings.TrimSpace(o.TracesSampler)); kind != "" {
+		if legacySet {
+			return otelsetup.SamplerChoice{}, fmt.Errorf(
+				"OTEL_TRACES_SAMPLER and deprecated OTEL_SAMPLE_RATIO are both set — remove the deprecated one",
+			)
+		}
+		spec, ok := officialSamplerKinds[kind]
+		if !ok {
+			return otelsetup.SamplerChoice{}, fmt.Errorf(
+				"OTEL_TRACES_SAMPLER %q is not supported — use one of always_on, always_off, traceidratio, parentbased_always_on, parentbased_always_off, parentbased_traceidratio",
+				o.TracesSampler,
+			)
+		}
+		ratio := spec.fixedRatio
+		if spec.needsArg {
+			arg := strings.TrimSpace(o.TracesSamplerArg)
+			if arg == "" {
+				return otelsetup.SamplerChoice{}, fmt.Errorf(
+					"OTEL_TRACES_SAMPLER=%s requires OTEL_TRACES_SAMPLER_ARG (a ratio between 0 and 1)", kind,
+				)
+			}
+			parsed, err := strconv.ParseFloat(arg, 64)
+			if err != nil {
+				return otelsetup.SamplerChoice{}, fmt.Errorf("OTEL_TRACES_SAMPLER_ARG %q is not a number", arg)
+			}
+			if err := validRatio(parsed, "OTEL_TRACES_SAMPLER_ARG"); err != nil {
+				return otelsetup.SamplerChoice{}, err
+			}
+			ratio = parsed
+		}
+		return otelsetup.SamplerChoice{ParentBased: spec.parentBased, Ratio: ratio}, nil
+	}
+
+	if legacySet {
+		if o.SampleRatioSet {
+			slog.Warn("otel config", "warning",
+				"OTEL_SAMPLE_RATIO is deprecated — use OTEL_TRACES_SAMPLER=parentbased_traceidratio with OTEL_TRACES_SAMPLER_ARG")
+		}
+		if err := validRatio(o.SampleRatio, "OTEL_SAMPLE_RATIO"); err != nil {
+			return otelsetup.SamplerChoice{}, err
+		}
+		return otelsetup.SamplerChoice{ParentBased: true, Ratio: o.SampleRatio}, nil
+	}
+
+	// Environment-aware default: trace everything on a laptop, a tenth of
+	// requests everywhere else.
+	ratio := DefaultNonLocalSampleRatio
+	if environment == "local" {
+		ratio = 1.0
+	}
+	return otelsetup.SamplerChoice{ParentBased: true, Ratio: ratio}, nil
+}
+
+// validRatio rejects ratios outside [0,1]. NaN needs the explicit check:
+// strconv.ParseFloat accepts the literal "NaN", and every NaN comparison is
+// false, so it would sail through the range check and silently land on
+// NeverSample — all tracing off, no error anywhere.
+func validRatio(ratio float64, name string) error {
+	if math.IsNaN(ratio) || ratio < 0 || ratio > 1 {
+		return fmt.Errorf("%s must be between 0 and 1, got %v — 0 exports no traces, 1 exports all of them", name, ratio)
+	}
+	return nil
+}
+
+// validateFixedVocabulary rejects values of supported official vars outside
+// what LangWatch exporters implement. A stated-but-unfulfillable intent (e.g.
+// protocol grpc) is an error; see unsupportedVarWarnings for the vars whose
+// setting merely has no effect.
+func (o *OTel) validateFixedVocabulary() error {
+	if p := strings.TrimSpace(o.ExporterProtocol); p != "" && !strings.EqualFold(p, "http/protobuf") {
+		return fmt.Errorf(
+			"OTEL_EXPORTER_OTLP_PROTOCOL %q is not supported — LangWatch exporters speak http/protobuf only", p,
+		)
+	}
+	if t := strings.ToLower(strings.TrimSpace(o.TracesExporter)); t != "" && t != "otlp" && t != "none" {
+		return fmt.Errorf("OTEL_TRACES_EXPORTER %q is not supported — use \"otlp\" or \"none\"", o.TracesExporter)
+	}
+	return nil
+}
+
+// unsupportedVarWarnings lists set-but-ineffective official vars, so a value
+// someone expects to matter never disappears silently.
+func (o *OTel) unsupportedVarWarnings() []string {
+	var warnings []string
+	if strings.TrimSpace(o.ExporterMetricsEndpoint) != "" {
+		warnings = append(warnings,
+			"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT is not supported and ignored — metrics go to OTEL_EXPORTER_OTLP_ENDPOINT + /v1/metrics")
+	}
+	if strings.TrimSpace(o.ExporterLogsEndpoint) != "" {
+		warnings = append(warnings,
+			"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT is not supported and ignored — OTLP logs ship only to the debug collector")
+	}
+	return warnings
+}
+
+func equalEndpoint(a, b string) bool {
+	return strings.EqualFold(strings.TrimRight(a, "/"), strings.TrimRight(b, "/"))
+}
+
+// withTracesPath appends /v1/traces to a base endpoint unless already present.
+func withTracesPath(endpoint string) string {
+	if endpoint == "" || strings.HasSuffix(endpoint, "/v1/traces") {
+		return endpoint
+	}
+	return strings.TrimRight(endpoint, "/") + "/v1/traces"
+}
 
 // debugCollectorMustBeLocal rejects a debug-collector endpoint that is not on
 // the machine running the service.
@@ -76,56 +391,19 @@ func debugCollectorMustBeLocal(endpoint string) error {
 	)
 }
 
-// Validate rejects OTel configuration that would silently invert a telemetry
-// boundary. Call after ResolveSampleRatio, which fills in the unset default.
-//
-// Both checks fail closed at boot rather than at the first exported span: a
-// misconfigured collector is not discoverable from inside the running service,
-// so the only place it can be caught is the place it is read.
-func (o *OTel) Validate() error {
-	// An out-of-range ratio must not reach the sampler, where it would resolve
-	// to one of the extremes: a typo like -1 or "10" (meaning 10%) lands on
-	// NeverSample or AlwaysSample instead of erroring. NaN is reachable too —
-	// strconv.ParseFloat accepts the literal string "NaN" — and every NaN
-	// comparison is false, so without the explicit check it would sail through
-	// this guard and silently disable all tracing.
-	if math.IsNaN(o.SampleRatio) || o.SampleRatio < 0 || o.SampleRatio > 1 {
-		return fmt.Errorf(
-			"OTEL_SAMPLE_RATIO must be between 0 and 1, got %v — 0 exports no traces, 1 exports all of them",
-			o.SampleRatio,
-		)
+// mustBeResolved guards every accessor that reads resolved state. A missing
+// Resolve call is a programming error that would otherwise export telemetry
+// with half-applied configuration — panic so it cannot survive a test run.
+func (o *OTel) mustBeResolved() {
+	if !o.resolved.set {
+		panic("config.OTel: Resolve was not called before reading telemetry configuration")
 	}
-	// The debug collector is a tenant-agnostic dual export: every span the
-	// service produces is copied there, including spans the per-tenant router
-	// would otherwise route by the originating project's key (nlpgo) or drop
-	// for lack of one. That is exactly what makes it useful on a laptop and
-	// unacceptable anywhere customer data flows, where it would pool every
-	// tenant's telemetry into one destination. ADR-042 specifies it as
-	// local-only; this makes that specification enforceable.
-	if o.DebugCollectorEndpoint != "" {
-		if err := debugCollectorMustBeLocal(o.DebugCollectorEndpoint); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
-// DefaultNonLocalSampleRatio is the trace sample ratio applied outside local
-// development when the operator did not choose one.
-const DefaultNonLocalSampleRatio = 0.1
-
-// ResolveSampleRatio fills in the environment-aware default when no ratio was
-// configured, and otherwise honors exactly what was asked for. Call once,
-// before Validate.
-func (o *OTel) ResolveSampleRatio(environment string) {
-	if o.SampleRatioSet || o.SampleRatio != UnsetSampleRatio {
-		return
-	}
-	if environment == "local" {
-		o.SampleRatio = 1.0
-		return
-	}
-	o.SampleRatio = DefaultNonLocalSampleRatio
+// SamplerChoice returns the resolved sampling decision. Requires Resolve.
+func (o *OTel) SamplerChoice() otelsetup.SamplerChoice {
+	o.mustBeResolved()
+	return o.resolved.sampler
 }
 
 // DebugCollector returns the debug-collector base endpoint (no signal
@@ -133,37 +411,42 @@ func (o *OTel) ResolveSampleRatio(environment string) {
 // collector is disabled. Exposed for services (e.g. nlpgo) that build
 // otelsetup.Options directly instead of going through Configure.
 func (o *OTel) DebugCollector() (endpoint string, headers map[string]string) {
+	if o.SDKDisabled {
+		return "", nil
+	}
 	return o.DebugCollectorEndpoint, parseHeaders(o.DebugCollectorHeaders)
 }
 
-// PrimaryOTLP returns the primary collector's base endpoint (no signal path)
-// and its parsed headers. Exposed for callers that forward OTLP payloads
+// PrimaryOTLP returns the resolved primary collector base endpoint (no signal
+// path) and its parsed headers. Exposed for callers that forward OTLP payloads
 // directly rather than through the SDK exporter — e.g. the Langy relay shipping
-// LangWatch's own copy of worker telemetry.
+// LangWatch's own copy of worker telemetry. Requires Resolve. Note the
+// signal-specific OTEL_EXPORTER_OTLP_TRACES_ENDPOINT override does NOT feed
+// this path — direct forwarders compose their own signal URL from the base.
 func (o *OTel) PrimaryOTLP() (endpoint string, headers map[string]string) {
-	return o.OTLPEndpoint, parseHeaders(o.OTLPHeaders)
+	o.mustBeResolved()
+	return o.resolved.baseEndpoint, o.resolved.headers
 }
 
-// Configure initializes the OTel provider from the config, parsing headers and
-// returning a Provider whose Shutdown method flushes pending telemetry.
+// Configure initializes the OTel provider from the resolved config, returning
+// a Provider whose Shutdown method flushes pending telemetry. Requires Resolve.
 func (o *OTel) Configure(ctx context.Context, nodeID string) (*otelsetup.Provider, error) {
-	endpoint := o.OTLPEndpoint
-	if endpoint != "" && !strings.HasSuffix(endpoint, "/v1/traces") {
-		endpoint = strings.TrimRight(endpoint, "/") + "/v1/traces"
-	}
+	o.mustBeResolved()
 	debugEndpoint, debugHeaders := o.DebugCollector()
 	return otelsetup.New(ctx, otelsetup.Options{
 		NodeID:                 nodeID,
-		OTLPEndpoint:           endpoint,
-		OTLPHeaders:            parseHeaders(o.OTLPHeaders),
-		SampleRatio:            o.SampleRatio,
+		OTLPEndpoint:           o.resolved.tracesEndpoint,
+		MetricsEndpoint:        o.resolved.metricsEndpoint,
+		OTLPHeaders:            o.resolved.headers,
+		Sampler:                o.resolved.sampler,
 		DebugCollectorEndpoint: debugEndpoint,
 		DebugCollectorHeaders:  debugHeaders,
 	})
 }
 
-// parseHeaders parses an OTLP headers string ("key=value,key2=value2") into a map.
-// Follows the W3C Baggage / OTEL_EXPORTER_OTLP_HEADERS format.
+// parseHeaders parses an OTLP headers string ("key=value,key2=value2") into a
+// map. Follows the W3C Baggage / OTEL_EXPORTER_OTLP_HEADERS format; values may
+// be percent-encoded (a value that is not valid percent-encoding is kept raw).
 func parseHeaders(raw string) map[string]string {
 	if raw == "" {
 		return nil
@@ -174,7 +457,11 @@ func parseHeaders(raw string) map[string]string {
 		if !ok {
 			continue
 		}
-		headers[strings.TrimSpace(k)] = strings.TrimSpace(v)
+		v = strings.TrimSpace(v)
+		if decoded, err := url.PathUnescape(v); err == nil {
+			v = decoded
+		}
+		headers[strings.TrimSpace(k)] = v
 	}
 	if len(headers) == 0 {
 		return nil

--- a/pkg/config/otel.go
+++ b/pkg/config/otel.go
@@ -2,6 +2,10 @@ package config
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"net"
+	"net/url"
 	"strings"
 
 	"github.com/langwatch/langwatch/pkg/otelsetup"
@@ -37,6 +41,74 @@ type OTel struct {
 // SampleRatioSet to distinguish it from an explicit 0 read from the
 // OTEL_SAMPLE_RATIO environment variable.
 const UnsetSampleRatio = 0
+
+// debugCollectorMustBeLocal rejects a debug-collector endpoint that is not on
+// the machine running the service.
+//
+// The check is deliberately on the DESTINATION, not on ENVIRONMENT. What makes
+// the debug collector safe is not what an environment is named — a name is a
+// free-text env var, and "dev"/"test" are exactly the values a shared cluster
+// holding real customer data is most likely to carry — but that the spans
+// cannot leave the developer's own machine. A hostname is checkable and a typo
+// cannot forge one; a name allowlist would hand the switch to anyone who set
+// ENVIRONMENT=test.
+//
+// Loopback forms only: `localhost` and any `*.localhost` (the portless dev
+// hostnames, which resolve to loopback natively), literal 127.0.0.0/8 and ::1,
+// and `host.docker.internal` for containerised dev stacks. Private ranges are
+// NOT accepted — 10.x and 192.168.x are ordinary in-cluster addresses, so
+// allowing them would readmit the deployment this check exists to refuse.
+func debugCollectorMustBeLocal(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("OTEL_DEBUG_COLLECTOR_ENDPOINT is not a valid URL: %w", err)
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") || host == "host.docker.internal" {
+		return nil
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf(
+		"OTEL_DEBUG_COLLECTOR_ENDPOINT must point at a collector on this machine (localhost, 127.0.0.1, ::1, *.localhost, or host.docker.internal), got %q — the debug collector receives every tenant's spans with no per-tenant routing, so it must never ship them off-box",
+		u.Host,
+	)
+}
+
+// Validate rejects OTel configuration that would silently invert a telemetry
+// boundary. Call after ResolveSampleRatio, which fills in the unset default.
+//
+// Both checks fail closed at boot rather than at the first exported span: a
+// misconfigured collector is not discoverable from inside the running service,
+// so the only place it can be caught is the place it is read.
+func (o *OTel) Validate() error {
+	// An out-of-range ratio must not reach the sampler, where it would resolve
+	// to one of the extremes: a typo like -1 or "10" (meaning 10%) lands on
+	// NeverSample or AlwaysSample instead of erroring. NaN is reachable too —
+	// strconv.ParseFloat accepts the literal string "NaN" — and every NaN
+	// comparison is false, so without the explicit check it would sail through
+	// this guard and silently disable all tracing.
+	if math.IsNaN(o.SampleRatio) || o.SampleRatio < 0 || o.SampleRatio > 1 {
+		return fmt.Errorf(
+			"OTEL_SAMPLE_RATIO must be between 0 and 1, got %v — 0 exports no traces, 1 exports all of them",
+			o.SampleRatio,
+		)
+	}
+	// The debug collector is a tenant-agnostic dual export: every span the
+	// service produces is copied there, including spans the per-tenant router
+	// would otherwise route by the originating project's key (nlpgo) or drop
+	// for lack of one. That is exactly what makes it useful on a laptop and
+	// unacceptable anywhere customer data flows, where it would pool every
+	// tenant's telemetry into one destination. ADR-042 specifies it as
+	// local-only; this makes that specification enforceable.
+	if o.DebugCollectorEndpoint != "" {
+		if err := debugCollectorMustBeLocal(o.DebugCollectorEndpoint); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // DefaultNonLocalSampleRatio is the trace sample ratio applied outside local
 // development when the operator did not choose one.

--- a/pkg/config/otel_sample_ratio_test.go
+++ b/pkg/config/otel_sample_ratio_test.go
@@ -15,7 +15,7 @@ func TestResolveSampleRatio_HonoursExplicitFullSampling(t *testing.T) {
 
 	o.ResolveSampleRatio("production")
 
-	assert.Equal(t, 1.0, o.SampleRatio, "an explicit 100% must survive in production")
+	assert.InDelta(t, 1.0, o.SampleRatio, 0, "an explicit 100% must survive in production")
 }
 
 func TestResolveSampleRatio_HonoursExplicitPartialSampling(t *testing.T) {
@@ -23,7 +23,7 @@ func TestResolveSampleRatio_HonoursExplicitPartialSampling(t *testing.T) {
 
 	o.ResolveSampleRatio("production")
 
-	assert.Equal(t, 0.25, o.SampleRatio)
+	assert.InDelta(t, 0.25, o.SampleRatio, 0)
 }
 
 func TestResolveSampleRatio_DefaultsOutsideLocal(t *testing.T) {
@@ -31,7 +31,7 @@ func TestResolveSampleRatio_DefaultsOutsideLocal(t *testing.T) {
 
 	o.ResolveSampleRatio("production")
 
-	assert.Equal(t, DefaultNonLocalSampleRatio, o.SampleRatio)
+	assert.InDelta(t, DefaultNonLocalSampleRatio, o.SampleRatio, 0)
 }
 
 func TestResolveSampleRatio_DefaultsToFullLocally(t *testing.T) {
@@ -39,5 +39,13 @@ func TestResolveSampleRatio_DefaultsToFullLocally(t *testing.T) {
 
 	o.ResolveSampleRatio("local")
 
-	assert.Equal(t, 1.0, o.SampleRatio, "local development traces everything")
+	assert.InDelta(t, 1.0, o.SampleRatio, 0, "local development traces everything")
+}
+
+func TestResolveSampleRatio_HonoursExplicitZeroSampling(t *testing.T) {
+	o := OTel{SampleRatioSet: true, SampleRatio: 0}
+
+	o.ResolveSampleRatio("production")
+
+	assert.Zero(t, o.SampleRatio, "an explicit 0% must not become the default")
 }

--- a/pkg/config/otel_sample_ratio_test.go
+++ b/pkg/config/otel_sample_ratio_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The regression this guards: services defaulted SampleRatio to 1.0 and then
+// rewrote any 1.0 outside local development to 0.1. An operator who explicitly
+// asked for full sampling in production got 10% and no warning — the setting
+// was silently unusable at its most important value.
+func TestResolveSampleRatio_HonoursExplicitFullSampling(t *testing.T) {
+	o := OTel{SampleRatio: 1.0}
+
+	o.ResolveSampleRatio("production")
+
+	assert.Equal(t, 1.0, o.SampleRatio, "an explicit 100% must survive in production")
+}
+
+func TestResolveSampleRatio_HonoursExplicitPartialSampling(t *testing.T) {
+	o := OTel{SampleRatio: 0.25}
+
+	o.ResolveSampleRatio("production")
+
+	assert.Equal(t, 0.25, o.SampleRatio)
+}
+
+func TestResolveSampleRatio_DefaultsOutsideLocal(t *testing.T) {
+	o := OTel{SampleRatio: UnsetSampleRatio}
+
+	o.ResolveSampleRatio("production")
+
+	assert.Equal(t, DefaultNonLocalSampleRatio, o.SampleRatio)
+}
+
+func TestResolveSampleRatio_DefaultsToFullLocally(t *testing.T) {
+	o := OTel{SampleRatio: UnsetSampleRatio}
+
+	o.ResolveSampleRatio("local")
+
+	assert.Equal(t, 1.0, o.SampleRatio, "local development traces everything")
+}

--- a/pkg/config/otel_sample_ratio_test.go
+++ b/pkg/config/otel_sample_ratio_test.go
@@ -4,48 +4,110 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/pkg/otelsetup"
 )
+
+func mustResolveSampler(t *testing.T, o OTel, environment string) otelsetup.SamplerChoice {
+	t.Helper()
+	require.NoError(t, o.Resolve(environment))
+	return o.SamplerChoice()
+}
 
 // The regression this guards: services defaulted SampleRatio to 1.0 and then
 // rewrote any 1.0 outside local development to 0.1. An operator who explicitly
 // asked for full sampling in production got 10% and no warning — the setting
 // was silently unusable at its most important value.
-func TestResolveSampleRatio_HonoursExplicitFullSampling(t *testing.T) {
-	o := OTel{SampleRatio: 1.0}
+func TestResolveSampler_HonoursExplicitFullLegacyRatio(t *testing.T) {
+	got := mustResolveSampler(t, OTel{SampleRatio: 1.0}, "production")
 
-	o.ResolveSampleRatio("production")
-
-	assert.InDelta(t, 1.0, o.SampleRatio, 0, "an explicit 100% must survive in production")
+	assert.InDelta(t, 1.0, got.Ratio, 0, "an explicit 100% must survive in production")
+	assert.True(t, got.ParentBased)
 }
 
-func TestResolveSampleRatio_HonoursExplicitPartialSampling(t *testing.T) {
-	o := OTel{SampleRatio: 0.25}
+func TestResolveSampler_HonoursExplicitPartialLegacyRatio(t *testing.T) {
+	got := mustResolveSampler(t, OTel{SampleRatio: 0.25}, "production")
 
-	o.ResolveSampleRatio("production")
-
-	assert.InDelta(t, 0.25, o.SampleRatio, 0)
+	assert.InDelta(t, 0.25, got.Ratio, 0)
 }
 
-func TestResolveSampleRatio_DefaultsOutsideLocal(t *testing.T) {
-	o := OTel{SampleRatio: UnsetSampleRatio}
+func TestResolveSampler_DefaultsOutsideLocal(t *testing.T) {
+	got := mustResolveSampler(t, OTel{SampleRatio: UnsetSampleRatio}, "production")
 
-	o.ResolveSampleRatio("production")
-
-	assert.InDelta(t, DefaultNonLocalSampleRatio, o.SampleRatio, 0)
+	assert.InDelta(t, DefaultNonLocalSampleRatio, got.Ratio, 0)
+	assert.True(t, got.ParentBased)
 }
 
-func TestResolveSampleRatio_DefaultsToFullLocally(t *testing.T) {
-	o := OTel{SampleRatio: UnsetSampleRatio}
+func TestResolveSampler_DefaultsToFullLocally(t *testing.T) {
+	got := mustResolveSampler(t, OTel{SampleRatio: UnsetSampleRatio}, "local")
 
-	o.ResolveSampleRatio("local")
-
-	assert.InDelta(t, 1.0, o.SampleRatio, 0, "local development traces everything")
+	assert.InDelta(t, 1.0, got.Ratio, 0, "local development traces everything")
 }
 
-func TestResolveSampleRatio_HonoursExplicitZeroSampling(t *testing.T) {
-	o := OTel{SampleRatioSet: true, SampleRatio: 0}
+func TestResolveSampler_HonoursExplicitZeroLegacyRatio(t *testing.T) {
+	got := mustResolveSampler(t, OTel{SampleRatioSet: true, SampleRatio: 0}, "production")
 
-	o.ResolveSampleRatio("production")
+	assert.Zero(t, got.Ratio, "an explicit 0% must not become the default")
+}
 
-	assert.Zero(t, o.SampleRatio, "an explicit 0% must not become the default")
+// The official OTEL_TRACES_SAMPLER vocabulary, mapped faithfully: parentbased_*
+// keeps a sampled upstream parent's children, the bare kinds decide per span.
+func TestResolveSampler_MapsTheOfficialVocabulary(t *testing.T) {
+	for _, tt := range []struct {
+		sampler     string
+		arg         string
+		ratio       float64
+		parentBased bool
+	}{
+		{sampler: "always_on", ratio: 1, parentBased: false},
+		{sampler: "always_off", ratio: 0, parentBased: false},
+		{sampler: "traceidratio", arg: "0.5", ratio: 0.5, parentBased: false},
+		{sampler: "parentbased_always_on", ratio: 1, parentBased: true},
+		{sampler: "parentbased_always_off", ratio: 0, parentBased: true},
+		{sampler: "parentbased_traceidratio", arg: "0.25", ratio: 0.25, parentBased: true},
+	} {
+		t.Run(tt.sampler, func(t *testing.T) {
+			got := mustResolveSampler(t, OTel{TracesSampler: tt.sampler, TracesSamplerArg: tt.arg}, "production")
+
+			assert.InDelta(t, tt.ratio, got.Ratio, 0)
+			assert.Equal(t, tt.parentBased, got.ParentBased)
+		})
+	}
+}
+
+func TestResolveSampler_AcceptsMixedCaseKind(t *testing.T) {
+	got := mustResolveSampler(t, OTel{TracesSampler: "Parentbased_TraceIdRatio", TracesSamplerArg: "0.3"}, "production")
+
+	assert.InDelta(t, 0.3, got.Ratio, 0)
+	assert.True(t, got.ParentBased)
+}
+
+// The ratio kinds REQUIRE the arg: falling back to an implementation-defined
+// default ratio is exactly the kind of luck this configuration refuses.
+func TestResolveSampler_RequiresTheArgForRatioKinds(t *testing.T) {
+	o := OTel{TracesSampler: "parentbased_traceidratio"}
+
+	assert.Error(t, o.Resolve("production"))
+}
+
+func TestResolveSampler_RejectsBadSamplerArgs(t *testing.T) {
+	for _, arg := range []string{"NaN", "-1", "2", "abc", "0.5.1"} {
+		o := OTel{TracesSampler: "traceidratio", TracesSamplerArg: arg}
+		assert.Error(t, o.Resolve("production"), "arg %q must be refused at boot", arg)
+	}
+}
+
+func TestResolveSampler_RejectsUnknownKinds(t *testing.T) {
+	o := OTel{TracesSampler: "jaeger_remote"}
+
+	assert.Error(t, o.Resolve("production"))
+}
+
+// Two live sampling instructions with different vocabularies is ambiguity,
+// and ambiguity is resolved by the operator, not by silent precedence.
+func TestResolveSampler_RefusesOfficialAndLegacyTogether(t *testing.T) {
+	o := OTel{TracesSampler: "always_on", SampleRatioSet: true, SampleRatio: 0.1}
+
+	assert.Error(t, o.Resolve("production"))
 }

--- a/pkg/config/otel_validate_test.go
+++ b/pkg/config/otel_validate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // The debug collector is a tenant-agnostic copy of every span the service
@@ -12,7 +13,7 @@ import (
 // destination cannot be anything but the developer's own machine — so the
 // guard is on the destination address, never on what an environment calls
 // itself.
-func TestOTelValidate_AcceptsOnMachineDebugCollectors(t *testing.T) {
+func TestResolve_AcceptsOnMachineDebugCollectors(t *testing.T) {
 	for _, endpoint := range []string{
 		"http://localhost:4318",
 		"http://LocalHost:4318",
@@ -23,12 +24,12 @@ func TestOTelValidate_AcceptsOnMachineDebugCollectors(t *testing.T) {
 		"https://telemetry.mystack.localhost:4318",
 		"http://host.docker.internal:4318",
 	} {
-		o := OTel{SampleRatio: 1, DebugCollectorEndpoint: endpoint}
-		assert.NoError(t, o.Validate(), "on-machine endpoint %q must be accepted", endpoint)
+		o := OTel{DebugCollectorEndpoint: endpoint}
+		assert.NoError(t, o.Resolve("local"), "on-machine endpoint %q must be accepted", endpoint)
 	}
 }
 
-func TestOTelValidate_RejectsOffBoxDebugCollectors(t *testing.T) {
+func TestResolve_RejectsOffBoxDebugCollectors(t *testing.T) {
 	for _, endpoint := range []string{
 		"http://collector.observability.svc.cluster.local:4318",
 		"https://otlp.grafana.net",
@@ -39,31 +40,204 @@ func TestOTelValidate_RejectsOffBoxDebugCollectors(t *testing.T) {
 		"http://notlocalhost:4318",
 		"http://[fe80::1]:4318",
 	} {
-		o := OTel{SampleRatio: 1, DebugCollectorEndpoint: endpoint}
-		assert.Error(t, o.Validate(), "off-box endpoint %q must be refused at boot", endpoint)
+		o := OTel{DebugCollectorEndpoint: endpoint}
+		assert.Error(t, o.Resolve("local"), "off-box endpoint %q must be refused at boot", endpoint)
 	}
-}
-
-func TestOTelValidate_AcceptsAbsentDebugCollector(t *testing.T) {
-	o := OTel{SampleRatio: DefaultNonLocalSampleRatio}
-
-	assert.NoError(t, o.Validate(), "the prod default — no debug collector — must validate")
 }
 
 // A ratio outside [0,1] resolves to a sampler extreme instead of erroring;
 // NaN is reachable because strconv.ParseFloat accepts the literal "NaN" and
 // compares false against everything. All of them must die at boot, before the
 // sampler quietly inverts what the operator asked for.
-func TestOTelValidate_RejectsOutOfRangeSampleRatio(t *testing.T) {
-	for _, ratio := range []float64{-1, -0.001, 1.001, 10, math.NaN()} {
+func TestResolve_RejectsOutOfRangeLegacySampleRatio(t *testing.T) {
+	for _, ratio := range []float64{-1, -0.001, 1.001, 10} {
 		o := OTel{SampleRatio: ratio}
-		assert.Error(t, o.Validate(), "ratio %v must be refused before it reaches the sampler", ratio)
+		assert.Error(t, o.Resolve("production"), "ratio %v must be refused before it reaches the sampler", ratio)
+	}
+	nan := OTel{SampleRatioSet: true, SampleRatio: math.NaN()}
+	assert.Error(t, nan.Resolve("production"), "NaN must be refused before it reaches the sampler")
+}
+
+func TestResolve_AcceptsTheFullLegacySampleRatioRange(t *testing.T) {
+	for _, ratio := range []float64{0, 0.1, 0.5, 1} {
+		o := OTel{SampleRatioSet: true, SampleRatio: ratio}
+		assert.NoError(t, o.Resolve("production"), "ratio %v is a legitimate operator choice", ratio)
 	}
 }
 
-func TestOTelValidate_AcceptsTheFullSampleRatioRange(t *testing.T) {
-	for _, ratio := range []float64{0, 0.1, 0.5, 1} {
-		o := OTel{SampleRatio: ratio}
-		assert.NoError(t, o.Validate(), "ratio %v is a legitimate operator choice", ratio)
+// ---- Endpoint resolution: official name, deprecated fallback, conflicts ----
+
+func TestResolve_UsesTheOfficialEndpoint(t *testing.T) {
+	o := OTel{ExporterEndpoint: "http://collector:4318"}
+	require.NoError(t, o.Resolve("production"))
+
+	base, _ := o.PrimaryOTLP()
+	assert.Equal(t, "http://collector:4318", base)
+	assert.Equal(t, "http://collector:4318/v1/traces", o.resolved.tracesEndpoint)
+	assert.Equal(t, "http://collector:4318/v1/metrics", o.resolved.metricsEndpoint)
+}
+
+func TestResolve_HonoursTheDeprecatedEndpointName(t *testing.T) {
+	o := OTel{OTLPEndpoint: "http://collector:4318"}
+	require.NoError(t, o.Resolve("production"))
+
+	base, _ := o.PrimaryOTLP()
+	assert.Equal(t, "http://collector:4318", base, "existing deployments must keep tracing through the rename")
+}
+
+func TestResolve_AcceptsBothEndpointNamesWhenEqual(t *testing.T) {
+	// The transition state: charts emit the same value under both names.
+	o := OTel{
+		ExporterEndpoint: "http://collector:4318/",
+		OTLPEndpoint:     "http://collector:4318",
 	}
+
+	assert.NoError(t, o.Resolve("production"), "equal values (modulo trailing slash) are not a conflict")
+}
+
+// Two different live values is ambiguity; precedence is never silently
+// guessed, because whichever guess is wrong ships our telemetry to the
+// wrong place with no error anywhere.
+func TestResolve_RefusesConflictingEndpointNames(t *testing.T) {
+	o := OTel{
+		ExporterEndpoint: "http://collector:4318",
+		OTLPEndpoint:     "http://other:4318",
+	}
+
+	assert.Error(t, o.Resolve("production"))
+}
+
+func TestResolve_LeavesTheExporterOffWhenNothingIsConfigured(t *testing.T) {
+	o := OTel{}
+	require.NoError(t, o.Resolve("production"))
+
+	base, headers := o.PrimaryOTLP()
+	assert.Empty(t, base, "no endpoint must mean OFF — never the SDK's localhost default")
+	assert.Nil(t, headers)
+	assert.Empty(t, o.resolved.tracesEndpoint)
+	assert.Empty(t, o.resolved.metricsEndpoint)
+}
+
+func TestResolve_UsesTheSignalSpecificTracesEndpointAsIs(t *testing.T) {
+	o := OTel{
+		ExporterEndpoint:       "http://collector:4318",
+		ExporterTracesEndpoint: "http://collector:4318/custom/traces",
+	}
+	require.NoError(t, o.Resolve("production"))
+
+	assert.Equal(t, "http://collector:4318/custom/traces", o.resolved.tracesEndpoint,
+		"per spec the signal-specific endpoint is used verbatim, no path appended")
+	base, _ := o.PrimaryOTLP()
+	assert.Equal(t, "http://collector:4318", base,
+		"direct OTLP forwarders keep composing from the base endpoint")
+}
+
+// ---- Headers ----
+
+func TestResolve_ParsesOfficialHeaders(t *testing.T) {
+	o := OTel{ExporterHeaders: "X-Auth-Token=tok,X-Team=obs"}
+	require.NoError(t, o.Resolve("production"))
+
+	_, headers := o.PrimaryOTLP()
+	assert.Equal(t, map[string]string{"X-Auth-Token": "tok", "X-Team": "obs"}, headers)
+}
+
+func TestResolve_DecodesPercentEncodedHeaderValues(t *testing.T) {
+	// The W3C baggage format used by OTEL_EXPORTER_OTLP_HEADERS percent-encodes
+	// values; Grafana Cloud's copy-paste examples rely on it.
+	o := OTel{ExporterHeaders: "Authorization=Basic%20dXNlcjp0b2tlbg=="}
+	require.NoError(t, o.Resolve("production"))
+
+	_, headers := o.PrimaryOTLP()
+	assert.Equal(t, "Basic dXNlcjp0b2tlbg==", headers["Authorization"])
+}
+
+func TestResolve_TracesSpecificHeadersWin(t *testing.T) {
+	o := OTel{
+		ExporterHeaders:       "X-Auth-Token=base",
+		ExporterTracesHeaders: "X-Auth-Token=traces",
+	}
+	require.NoError(t, o.Resolve("production"))
+
+	_, headers := o.PrimaryOTLP()
+	assert.Equal(t, "traces", headers["X-Auth-Token"])
+}
+
+func TestResolve_RefusesConflictingHeaderNames(t *testing.T) {
+	o := OTel{
+		ExporterHeaders: "X-Auth-Token=a",
+		OTLPHeaders:     "X-Auth-Token=b",
+	}
+
+	assert.Error(t, o.Resolve("production"))
+}
+
+func TestResolve_HonoursTheDeprecatedHeadersName(t *testing.T) {
+	o := OTel{OTLPHeaders: "X-Auth-Token=tok"}
+	require.NoError(t, o.Resolve("production"))
+
+	_, headers := o.PrimaryOTLP()
+	assert.Equal(t, "tok", headers["X-Auth-Token"])
+}
+
+// ---- Fixed vocabularies ----
+
+func TestResolve_RefusesUnsupportedProtocols(t *testing.T) {
+	for _, protocol := range []string{"grpc", "http/json"} {
+		o := OTel{ExporterProtocol: protocol}
+		assert.Error(t, o.Resolve("production"),
+			"protocol %q states an intent our exporters cannot fulfil — silence would be a lie", protocol)
+	}
+}
+
+func TestResolve_AcceptsTheSupportedProtocol(t *testing.T) {
+	for _, protocol := range []string{"", "http/protobuf", "HTTP/Protobuf"} {
+		o := OTel{ExporterProtocol: protocol}
+		assert.NoError(t, o.Resolve("production"))
+	}
+}
+
+func TestResolve_TracesExporterNoneTurnsOnlySpansOff(t *testing.T) {
+	o := OTel{ExporterEndpoint: "http://collector:4318", TracesExporter: "none"}
+	require.NoError(t, o.Resolve("production"))
+
+	assert.Empty(t, o.resolved.tracesEndpoint)
+	assert.Equal(t, "http://collector:4318/v1/metrics", o.resolved.metricsEndpoint,
+		"OTEL_TRACES_EXPORTER governs traces, not metrics")
+}
+
+func TestResolve_RefusesUnknownTracesExporters(t *testing.T) {
+	o := OTel{TracesExporter: "console"}
+
+	assert.Error(t, o.Resolve("production"))
+}
+
+// ---- OTEL_SDK_DISABLED ----
+
+func TestResolve_SDKDisabledTurnsEverythingOff(t *testing.T) {
+	o := OTel{
+		SDKDisabled:            true,
+		ExporterEndpoint:       "http://collector:4318",
+		DebugCollectorEndpoint: "http://localhost:4318",
+	}
+	require.NoError(t, o.Resolve("local"))
+
+	base, _ := o.PrimaryOTLP()
+	assert.Empty(t, base)
+	assert.Empty(t, o.resolved.tracesEndpoint)
+	assert.Empty(t, o.resolved.metricsEndpoint)
+	debugEndpoint, _ := o.DebugCollector()
+	assert.Empty(t, debugEndpoint)
+}
+
+// ---- Ordering guard ----
+
+// Reading telemetry configuration before Resolve is a programming error that
+// would otherwise export with half-applied settings. It must not survive the
+// first test that touches it.
+func TestAccessorsPanicBeforeResolve(t *testing.T) {
+	o := OTel{ExporterEndpoint: "http://collector:4318"}
+
+	assert.Panics(t, func() { o.SamplerChoice() })
+	assert.Panics(t, func() { o.PrimaryOTLP() })
 }

--- a/pkg/config/otel_validate_test.go
+++ b/pkg/config/otel_validate_test.go
@@ -1,12 +1,24 @@
 package config
 
 import (
+	"errors"
 	"math"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubLocalhostDNS pins the .localhost resolver so these tests don't depend
+// on the machine's DNS handling of the .localhost TLD (native loopback on
+// macOS/systemd-resolved, NXDOMAIN elsewhere).
+func stubLocalhostDNS(t *testing.T, ips []net.IP, err error) {
+	t.Helper()
+	prev := lookupHostIPs
+	lookupHostIPs = func(string) ([]net.IP, error) { return ips, err }
+	t.Cleanup(func() { lookupHostIPs = prev })
+}
 
 // The debug collector is a tenant-agnostic copy of every span the service
 // produces. The only deployments where that is acceptable are ones where the
@@ -14,6 +26,7 @@ import (
 // guard is on the destination address, never on what an environment calls
 // itself.
 func TestResolve_AcceptsOnMachineDebugCollectors(t *testing.T) {
+	stubLocalhostDNS(t, []net.IP{net.ParseIP("127.0.0.1")}, nil)
 	for _, endpoint := range []string{
 		"http://localhost:4318",
 		"http://LocalHost:4318",
@@ -29,7 +42,27 @@ func TestResolve_AcceptsOnMachineDebugCollectors(t *testing.T) {
 	}
 }
 
+// RFC 6761 recommends but does not guarantee that .localhost stays on-box: a
+// corporate wildcard, a search domain, or an /etc/hosts entry can point one
+// off the machine. The name is therefore resolved and every answer must be
+// loopback — and a name that does not resolve at all is refused rather than
+// trusted on suffix.
+func TestResolve_RejectsLocalhostNamesThatResolveOffBox(t *testing.T) {
+	stubLocalhostDNS(t, []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("10.0.12.3")}, nil)
+	o := OTel{DebugCollectorEndpoint: "http://observability.langwatch.localhost:4318"}
+
+	assert.Error(t, o.Resolve("local"))
+}
+
+func TestResolve_RejectsLocalhostNamesThatDoNotResolve(t *testing.T) {
+	stubLocalhostDNS(t, nil, errors.New("no such host"))
+	o := OTel{DebugCollectorEndpoint: "http://observability.langwatch.localhost:4318"}
+
+	assert.Error(t, o.Resolve("local"))
+}
+
 func TestResolve_RejectsOffBoxDebugCollectors(t *testing.T) {
+	stubLocalhostDNS(t, []net.IP{net.ParseIP("127.0.0.1")}, nil)
 	for _, endpoint := range []string{
 		"http://collector.observability.svc.cluster.local:4318",
 		"https://otlp.grafana.net",

--- a/pkg/config/otel_validate_test.go
+++ b/pkg/config/otel_validate_test.go
@@ -237,6 +237,12 @@ func TestResolve_TracesExporterNoneTurnsOnlySpansOff(t *testing.T) {
 	assert.Empty(t, o.resolved.tracesEndpoint)
 	assert.Equal(t, "http://collector:4318/v1/metrics", o.resolved.metricsEndpoint,
 		"OTEL_TRACES_EXPORTER governs traces, not metrics")
+
+	// PrimaryOTLP feeds the langy relay's direct span POST. Leaving it live
+	// here would keep shipping spans after the operator turned span export
+	// off — an off-switch that does not switch off.
+	base, _ := o.PrimaryOTLP()
+	assert.Empty(t, base, "no span-carrying endpoint may survive OTEL_TRACES_EXPORTER=none")
 }
 
 func TestResolve_RefusesUnknownTracesExporters(t *testing.T) {

--- a/pkg/config/otel_validate_test.go
+++ b/pkg/config/otel_validate_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The debug collector is a tenant-agnostic copy of every span the service
+// produces. The only deployments where that is acceptable are ones where the
+// destination cannot be anything but the developer's own machine — so the
+// guard is on the destination address, never on what an environment calls
+// itself.
+func TestOTelValidate_AcceptsOnMachineDebugCollectors(t *testing.T) {
+	for _, endpoint := range []string{
+		"http://localhost:4318",
+		"http://LocalHost:4318",
+		"http://127.0.0.1:4318",
+		"http://127.0.0.2:4318",
+		"http://[::1]:4318",
+		"http://observability.langwatch.localhost",
+		"https://telemetry.mystack.localhost:4318",
+		"http://host.docker.internal:4318",
+	} {
+		o := OTel{SampleRatio: 1, DebugCollectorEndpoint: endpoint}
+		assert.NoError(t, o.Validate(), "on-machine endpoint %q must be accepted", endpoint)
+	}
+}
+
+func TestOTelValidate_RejectsOffBoxDebugCollectors(t *testing.T) {
+	for _, endpoint := range []string{
+		"http://collector.observability.svc.cluster.local:4318",
+		"https://otlp.grafana.net",
+		"http://10.0.12.3:4318",
+		"http://192.168.1.20:4318",
+		"http://172.16.0.5:4318",
+		"http://localhost.evil.com:4318",
+		"http://notlocalhost:4318",
+		"http://[fe80::1]:4318",
+	} {
+		o := OTel{SampleRatio: 1, DebugCollectorEndpoint: endpoint}
+		assert.Error(t, o.Validate(), "off-box endpoint %q must be refused at boot", endpoint)
+	}
+}
+
+func TestOTelValidate_AcceptsAbsentDebugCollector(t *testing.T) {
+	o := OTel{SampleRatio: DefaultNonLocalSampleRatio}
+
+	assert.NoError(t, o.Validate(), "the prod default — no debug collector — must validate")
+}
+
+// A ratio outside [0,1] resolves to a sampler extreme instead of erroring;
+// NaN is reachable because strconv.ParseFloat accepts the literal "NaN" and
+// compares false against everything. All of them must die at boot, before the
+// sampler quietly inverts what the operator asked for.
+func TestOTelValidate_RejectsOutOfRangeSampleRatio(t *testing.T) {
+	for _, ratio := range []float64{-1, -0.001, 1.001, 10, math.NaN()} {
+		o := OTel{SampleRatio: ratio}
+		assert.Error(t, o.Validate(), "ratio %v must be refused before it reaches the sampler", ratio)
+	}
+}
+
+func TestOTelValidate_AcceptsTheFullSampleRatioRange(t *testing.T) {
+	for _, ratio := range []float64{0, 0.1, 0.5, 1} {
+		o := OTel{SampleRatio: ratio}
+		assert.NoError(t, o.Validate(), "ratio %v is a legitimate operator choice", ratio)
+	}
+}

--- a/pkg/config/otel_validate_test.go
+++ b/pkg/config/otel_validate_test.go
@@ -85,10 +85,10 @@ func TestResolve_RejectsOffBoxDebugCollectors(t *testing.T) {
 func TestResolve_RejectsOutOfRangeLegacySampleRatio(t *testing.T) {
 	for _, ratio := range []float64{-1, -0.001, 1.001, 10} {
 		o := OTel{SampleRatio: ratio}
-		assert.Error(t, o.Resolve("production"), "ratio %v must be refused before it reaches the sampler", ratio)
+		require.Error(t, o.Resolve("production"), "ratio %v must be refused before it reaches the sampler", ratio)
 	}
 	nan := OTel{SampleRatioSet: true, SampleRatio: math.NaN()}
-	assert.Error(t, nan.Resolve("production"), "NaN must be refused before it reaches the sampler")
+	require.Error(t, nan.Resolve("production"), "NaN must be refused before it reaches the sampler")
 }
 
 func TestResolve_AcceptsTheFullLegacySampleRatioRange(t *testing.T) {
@@ -218,8 +218,8 @@ func TestResolve_HonoursTheDeprecatedHeadersName(t *testing.T) {
 func TestResolve_RefusesUnsupportedProtocols(t *testing.T) {
 	for _, protocol := range []string{"grpc", "http/json"} {
 		o := OTel{ExporterProtocol: protocol}
-		assert.Error(t, o.Resolve("production"),
-			"protocol %q states an intent our exporters cannot fulfil — silence would be a lie", protocol)
+		require.Error(t, o.Resolve("production"),
+			"protocol %q states an intent our exporters cannot satisfy — silence would be a lie", protocol)
 	}
 }
 

--- a/pkg/otelsetup/internal_origin_test.go
+++ b/pkg/otelsetup/internal_origin_test.go
@@ -1,0 +1,57 @@
+package otelsetup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The internal-origin marker travels IN the telemetry, so it survives what no
+// destination check can: a valid-but-wrong endpoint. Single-tenant providers
+// carry only LangWatch's own telemetry and are marked; the multi-tenant
+// provider's resource reaches customer projects through the tenant router and
+// must never be.
+func TestBuildResourceAttrs_MarksSingleTenantResourcesAsInternal(t *testing.T) {
+	attrs := buildResourceAttrs("langwatch-aigateway", "dev", "production", "node-1", true)
+
+	found := ""
+	for _, kv := range attrs {
+		if string(kv.Key) == AttrLangWatchOrigin {
+			found = kv.Value.AsString()
+		}
+	}
+	assert.Equal(t, OriginPlatformInternal, found)
+}
+
+func TestBuildResourceAttrs_NeverMarksMultiTenantResources(t *testing.T) {
+	attrs := buildResourceAttrs("langwatch-nlp", "dev", "production", "node-1", false)
+
+	for _, kv := range attrs {
+		assert.NotEqual(t, AttrLangWatchOrigin, string(kv.Key),
+			"a multi-tenant resource reaches customer projects — marking it internal would brand their traces")
+	}
+}
+
+// The debug collector dual-export is skipped when it IS the primary
+// collector: with the official env vars a dev shell points both names at the
+// local stack, and a second processor would duplicate every span.
+func TestSameCollectorBase(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		primary string
+		debug   string
+		same    bool
+	}{
+		{name: "identical base", primary: "http://localhost:4318", debug: "http://localhost:4318", same: true},
+		{name: "primary carries the traces path", primary: "http://localhost:4318/v1/traces", debug: "http://localhost:4318", same: true},
+		{name: "trailing slash", primary: "http://localhost:4318/v1/traces", debug: "http://localhost:4318/", same: true},
+		{name: "case-insensitive host", primary: "http://LocalHost:4318/v1/traces", debug: "http://localhost:4318", same: true},
+		{name: "different port", primary: "http://localhost:4318/v1/traces", debug: "http://localhost:4319", same: false},
+		{name: "different host", primary: "http://collector:4318/v1/traces", debug: "http://localhost:4318", same: false},
+		{name: "empty primary never matches", primary: "", debug: "http://localhost:4318", same: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.same, sameCollectorBase(tt.primary, tt.debug))
+		})
+	}
+}

--- a/pkg/otelsetup/otelsetup.go
+++ b/pkg/otelsetup/otelsetup.go
@@ -127,8 +127,12 @@ type Options struct {
 	OTLPHeaders  map[string]string // auth headers for the collector
 	BatchTimeout time.Duration
 	MaxQueueSize int
-	// SampleRatio controls the fraction of traces sampled (0.0–1.0).
-	// 0 means "use default" (AlwaysSample). Set explicitly via config.
+	// SampleRatio controls the fraction of traces sampled, 0.0–1.0. 0 means
+	// sample nothing; 1 means sample everything. The environment-aware default
+	// for an unset ratio is applied upstream by config.OTel.ResolveSampleRatio,
+	// which is also where out-of-range values are rejected — by the time a
+	// ratio reaches here it is expected to be in range, and anything outside
+	// it is clamped to NeverSample rather than assumed to mean "all".
 	SampleRatio float64
 	// MultiTenant=true installs a per-request, per-tenant span router
 	// (TenantRouter) instead of the standard static-headers exporter.
@@ -263,14 +267,21 @@ func New(ctx context.Context, opts Options) (*Provider, error) {
 
 	res := buildResource(serviceName, serviceVersion, environment, opts.NodeID)
 
+	// Ordered so that only a ratio of 1.0 or above means "sample everything".
+	// The previous arrangement made AlwaysSample the default branch, which put
+	// every out-of-range value — a negative typo, or 10 meaning "10%" — onto
+	// full export, maximising exactly what the operator was trying to reduce.
+	// config.OTel.Validate rejects those at boot; this fails toward exporting
+	// nothing for callers that construct Options directly. NaN lands here too:
+	// it compares false against both bounds.
 	var rootSampler sdktrace.Sampler
 	switch {
-	case opts.SampleRatio == 0:
-		rootSampler = sdktrace.NeverSample()
-	case opts.SampleRatio > 0 && opts.SampleRatio < 1.0:
+	case opts.SampleRatio >= 1.0:
+		rootSampler = sdktrace.AlwaysSample()
+	case opts.SampleRatio > 0:
 		rootSampler = sdktrace.TraceIDRatioBased(opts.SampleRatio)
 	default:
-		rootSampler = sdktrace.AlwaysSample()
+		rootSampler = sdktrace.NeverSample()
 	}
 
 	tpOpts := []sdktrace.TracerProviderOption{

--- a/pkg/otelsetup/otelsetup.go
+++ b/pkg/otelsetup/otelsetup.go
@@ -119,21 +119,52 @@ var AutoStampedBaggageKeys = []string{
 // This stays BATCH export (async, no per-span latency) — NOT synchronous export.
 const BatchScheduledDelay = 2 * time.Second
 
+// AttrLangWatchOrigin marks telemetry that belongs to LangWatch's own
+// operational planes, so a payload arriving at the wrong destination is
+// identifiable as ours by inspection. This is the one guard that survives a
+// valid-but-wrong endpoint: it rides in the data, not in the config. The
+// Langy relay stamps the same key (value "langy_worker") on its
+// content-stripped internal copies; ingest-side enforcement can key on the
+// attribute's presence.
+const AttrLangWatchOrigin = "langwatch.origin"
+
+// OriginPlatformInternal is the AttrLangWatchOrigin value for a service's own
+// spans, metrics, and logs. It is NEVER stamped on a multi-tenant pipeline:
+// nlpgo's provider resource reaches customer projects through the tenant
+// router, so marking it would brand legitimate customer traces as internal.
+const OriginPlatformInternal = "platform_internal"
+
+// SamplerChoice is the resolved sampling decision, collapsed from the official
+// OTEL_TRACES_SAMPLER vocabulary: always_on ≡ Ratio 1, always_off ≡ Ratio 0,
+// traceidratio carries its argument, and the parentbased_* variants set
+// ParentBased so a sampled upstream parent keeps its children.
+type SamplerChoice struct {
+	// ParentBased wraps the root sampler so the parent span's sampled flag
+	// wins for child spans.
+	ParentBased bool
+	// Ratio is the root sampling fraction in [0,1]. >=1 samples everything;
+	// 0 — including the zero value — samples nothing.
+	Ratio float64
+}
+
 // Options configures the telemetry provider. Fields left empty are filled from
 // the context's ServiceInfo when available.
 type Options struct {
 	NodeID       string
-	OTLPEndpoint string            // OTLP HTTP endpoint (empty = noop)
+	OTLPEndpoint string            // FULL OTLP/HTTP traces URL (empty = no primary span exporter)
 	OTLPHeaders  map[string]string // auth headers for the collector
-	BatchTimeout time.Duration
-	MaxQueueSize int
-	// SampleRatio controls the fraction of traces sampled, 0.0–1.0. 0 means
-	// sample nothing; 1 means sample everything. The environment-aware default
-	// for an unset ratio is applied upstream by config.OTel.ResolveSampleRatio,
-	// which is also where out-of-range values are rejected — by the time a
-	// ratio reaches here it is expected to be in range, and anything outside
-	// it is clamped to NeverSample rather than assumed to mean "all".
-	SampleRatio float64
+	// MetricsEndpoint is the FULL /v1/metrics URL for the primary metric
+	// reader. Empty = derived from OTLPEndpoint (strip /v1/traces, append
+	// /v1/metrics), which is correct whenever both signals share a collector.
+	MetricsEndpoint string
+	BatchTimeout    time.Duration
+	MaxQueueSize    int
+	// Sampler selects the trace sampler. The zero value samples nothing —
+	// callers are expected to pass the choice resolved by config.OTel.Resolve,
+	// which maps the official OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG
+	// pair (or the deprecated OTEL_SAMPLE_RATIO, or the environment-aware
+	// default) onto this struct and rejects out-of-range values at boot.
+	Sampler SamplerChoice
 	// MultiTenant=true installs a per-request, per-tenant span router
 	// (TenantRouter) instead of the standard static-headers exporter.
 	// Required for nlpgo: each Studio event arrives with its own
@@ -193,7 +224,7 @@ func (p *Provider) LoggerProvider() *sdklog.LoggerProvider {
 // resource attributes used by both the static and multi-tenant span
 // pipelines. Kept as a helper so the two branches in New() stay in
 // lockstep without copy-paste drift.
-func buildResourceAttrs(serviceName, serviceVersion, environment, nodeID string) []attribute.KeyValue {
+func buildResourceAttrs(serviceName, serviceVersion, environment, nodeID string, internalOrigin bool) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		semconv.ServiceName(serviceName),
 		semconv.ServiceVersion(serviceVersion),
@@ -204,6 +235,9 @@ func buildResourceAttrs(serviceName, serviceVersion, environment, nodeID string)
 	if nodeID != "" {
 		attrs = append(attrs, attribute.String("node.id", nodeID))
 	}
+	if internalOrigin {
+		attrs = append(attrs, attribute.String(AttrLangWatchOrigin, OriginPlatformInternal))
+	}
 	return attrs
 }
 
@@ -213,13 +247,24 @@ func buildResourceAttrs(serviceName, serviceVersion, environment, nodeID string)
 // signal. Merge failure (schema-URL mismatch) is impossible here — all
 // attrs use the same semconv schema — so the error is discarded, matching
 // the existing trace-path call sites.
-func buildResource(serviceName, serviceVersion, environment, nodeID string) *resource.Resource {
-	attrs := buildResourceAttrs(serviceName, serviceVersion, environment, nodeID)
+func buildResource(serviceName, serviceVersion, environment, nodeID string, internalOrigin bool) *resource.Resource {
+	attrs := buildResourceAttrs(serviceName, serviceVersion, environment, nodeID, internalOrigin)
 	res, _ := resource.Merge(
 		resource.Default(),
 		resource.NewWithAttributes(semconv.SchemaURL, attrs...),
 	)
 	return res
+}
+
+// sameCollectorBase reports whether the primary traces endpoint (a full
+// per-signal URL or a base) and a debug-collector base URL address the same
+// collector — compared as base URLs, modulo the /v1/traces suffix and
+// trailing slashes.
+func sameCollectorBase(primaryTracesEndpoint, debugBase string) bool {
+	a := strings.TrimRight(primaryTracesEndpoint, "/")
+	a = strings.TrimRight(strings.TrimSuffix(a, "/v1/traces"), "/")
+	b := strings.TrimRight(debugBase, "/")
+	return a != "" && strings.EqualFold(a, b)
 }
 
 // withSignalPath appends the OTLP per-signal path (e.g. "/v1/traces")
@@ -265,29 +310,37 @@ func New(ctx context.Context, opts Options) (*Provider, error) {
 		return &Provider{}, nil
 	}
 
-	res := buildResource(serviceName, serviceVersion, environment, opts.NodeID)
+	// The internal-origin marker goes on every single-tenant resource: those
+	// providers carry exclusively LangWatch's own telemetry. Multi-tenant
+	// providers (nlpgo) are excluded — their resource reaches customer
+	// projects through the tenant router.
+	res := buildResource(serviceName, serviceVersion, environment, opts.NodeID, !opts.MultiTenant)
 
 	// Ordered so that only a ratio of 1.0 or above means "sample everything".
 	// The previous arrangement made AlwaysSample the default branch, which put
 	// every out-of-range value — a negative typo, or 10 meaning "10%" — onto
 	// full export, maximising exactly what the operator was trying to reduce.
-	// config.OTel.Validate rejects those at boot; this fails toward exporting
+	// config.OTel.Resolve rejects those at boot; this fails toward exporting
 	// nothing for callers that construct Options directly. NaN lands here too:
 	// it compares false against both bounds.
 	var rootSampler sdktrace.Sampler
 	switch {
-	case opts.SampleRatio >= 1.0:
+	case opts.Sampler.Ratio >= 1.0:
 		rootSampler = sdktrace.AlwaysSample()
-	case opts.SampleRatio > 0:
-		rootSampler = sdktrace.TraceIDRatioBased(opts.SampleRatio)
+	case opts.Sampler.Ratio > 0:
+		rootSampler = sdktrace.TraceIDRatioBased(opts.Sampler.Ratio)
 	default:
 		rootSampler = sdktrace.NeverSample()
+	}
+	sampler := rootSampler
+	if opts.Sampler.ParentBased {
+		sampler = sdktrace.ParentBased(rootSampler)
 	}
 
 	tpOpts := []sdktrace.TracerProviderOption{
 		sdktrace.WithResource(res),
 		sdktrace.WithSpanProcessor(NewBaggageAttributeProcessor(AutoStampedBaggageKeys...)),
-		sdktrace.WithSampler(sdktrace.ParentBased(rootSampler)),
+		sdktrace.WithSampler(sampler),
 		sdktrace.WithIDGenerator(NewIDGenerator()),
 	}
 
@@ -353,7 +406,16 @@ func New(ctx context.Context, opts Options) (*Provider, error) {
 	// Additive debug-collector span exporter — dual export. Every span
 	// (on both paths) is also batched to the developer's local collector.
 	// This never diverts spans from the primary pipeline above.
-	if opts.DebugCollectorEndpoint != "" {
+	//
+	// Skipped when the debug collector IS the primary collector: with the
+	// official env vars a dev shell exports OTEL_EXPORTER_OTLP_ENDPOINT and
+	// OTEL_DEBUG_COLLECTOR_ENDPOINT both at the local stack, and a second
+	// processor would just duplicate every span. (The debug LOG pipeline
+	// below is NOT skipped — there is no primary log pipeline to duplicate.)
+	debugDuplicatesPrimary := opts.OTLPEndpoint != "" &&
+		opts.DebugCollectorEndpoint != "" &&
+		sameCollectorBase(opts.OTLPEndpoint, opts.DebugCollectorEndpoint)
+	if opts.DebugCollectorEndpoint != "" && !debugDuplicatesPrimary {
 		debugProc, err := newDebugSpanProcessor(ctx, opts.DebugCollectorEndpoint, opts.DebugCollectorHeaders)
 		if err != nil {
 			return nil, err
@@ -407,18 +469,29 @@ func installDebugLogs(ctx context.Context, opts Options, res *resource.Resource,
 func installMetrics(ctx context.Context, opts Options, res *resource.Resource, provider *Provider) error {
 	var readers []sdkmetric.Reader
 	if opts.OTLPEndpoint != "" && !opts.MultiTenant {
-		r, err := newMetricReader(ctx, metricsEndpointFromTraces(opts.OTLPEndpoint), opts.OTLPHeaders)
+		metricsURL := opts.MetricsEndpoint
+		if metricsURL == "" {
+			metricsURL = metricsEndpointFromTraces(opts.OTLPEndpoint)
+		}
+		r, err := newMetricReader(ctx, metricsURL, opts.OTLPHeaders)
 		if err != nil {
 			return err
 		}
 		readers = append(readers, r)
 	}
 	if opts.DebugCollectorEndpoint != "" {
-		r, err := newMetricReader(ctx, withSignalPath(opts.DebugCollectorEndpoint, "/v1/metrics"), opts.DebugCollectorHeaders)
-		if err != nil {
-			return err
+		// When the primary reader above already targets the same collector,
+		// a debug reader would double every metric. Multi-tenant services
+		// install no primary reader, so their debug reader always survives.
+		primaryCoversDebug := len(readers) > 0 &&
+			sameCollectorBase(opts.OTLPEndpoint, opts.DebugCollectorEndpoint)
+		if !primaryCoversDebug {
+			r, err := newMetricReader(ctx, withSignalPath(opts.DebugCollectorEndpoint, "/v1/metrics"), opts.DebugCollectorHeaders)
+			if err != nil {
+				return err
+			}
+			readers = append(readers, r)
 		}
-		readers = append(readers, r)
 	}
 	if len(readers) == 0 {
 		return nil

--- a/pkg/otelsetup/otelsetup.go
+++ b/pkg/otelsetup/otelsetup.go
@@ -264,9 +264,12 @@ func New(ctx context.Context, opts Options) (*Provider, error) {
 	res := buildResource(serviceName, serviceVersion, environment, opts.NodeID)
 
 	var rootSampler sdktrace.Sampler
-	if opts.SampleRatio > 0 && opts.SampleRatio < 1.0 {
+	switch {
+	case opts.SampleRatio == 0:
+		rootSampler = sdktrace.NeverSample()
+	case opts.SampleRatio > 0 && opts.SampleRatio < 1.0:
 		rootSampler = sdktrace.TraceIDRatioBased(opts.SampleRatio)
-	} else {
+	default:
 		rootSampler = sdktrace.AlwaysSample()
 	}
 

--- a/pkg/otelsetup/otelsetup.go
+++ b/pkg/otelsetup/otelsetup.go
@@ -319,7 +319,7 @@ func New(ctx context.Context, opts Options) (*Provider, error) {
 	// Ordered so that only a ratio of 1.0 or above means "sample everything".
 	// The previous arrangement made AlwaysSample the default branch, which put
 	// every out-of-range value — a negative typo, or 10 meaning "10%" — onto
-	// full export, maximising exactly what the operator was trying to reduce.
+	// full export, amplifying exactly what the operator was trying to reduce.
 	// config.OTel.Resolve rejects those at boot; this fails toward exporting
 	// nothing for callers that construct Options directly. NaN lands here too:
 	// it compares false against both bounds.

--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -527,7 +527,7 @@ func (s *Service) changeFeedLoop(ctx context.Context) {
 				return true
 			}
 			for _, ch := range changes {
-				s.applyChange(ch)
+				s.applyChange(orgID, ch)
 			}
 			if nextRev != "" {
 				cursor.since = nextRev
@@ -557,7 +557,7 @@ func (s *Service) changeFeedLoop(ctx context.Context) {
 // once with a kind-specific predicate and removes matching entries; the
 // next request for those VKs takes a cold miss and re-resolves with the
 // fresh control-plane state.
-func (s *Service) applyChange(ch CacheChange) {
+func (s *Service) applyChange(organizationID string, ch CacheChange) {
 	switch ch.Kind {
 	case ChangeKindProviderBindingUpdated:
 		// The control plane emits ModelProvider.id. Config materialization puts
@@ -575,17 +575,18 @@ func (s *Service) applyChange(ch CacheChange) {
 			return false
 		}, "model_provider_updated", ch.ModelProviderID)
 	case ChangeKindBudgetCreated, ChangeKindBudgetUpdated, ChangeKindBudgetDeleted:
-		// BUDGET_UPDATED's project_id is the only stable join key
-		// (budget_id alone doesn't appear in the bundle; budgets nest
-		// under scopes). Evicting all bundles for the affected project
-		// is conservative but correct — the next request re-fetches
-		// the fresh limit/spent pair from the control plane.
-		if ch.ProjectID == "" {
+		// Only PROJECT-scoped creates carry project_id. Updates, deletes, and
+		// every other scope omit it, so invalidate the polled organization in
+		// those cases rather than leaving a stale budget enforced until TTL.
+		if ch.ProjectID != "" {
+			s.evictWhere(func(b *domain.Bundle) bool {
+				return b.ProjectID == ch.ProjectID
+			}, "budget_updated", ch.ProjectID)
 			return
 		}
 		s.evictWhere(func(b *domain.Bundle) bool {
-			return b.ProjectID == ch.ProjectID
-		}, "budget_updated", ch.ProjectID)
+			return b.OrganizationID == organizationID
+		}, "budget_updated", organizationID)
 	case ChangeKindVirtualKeyConfigUpdate, ChangeKindVirtualKeyRotated, ChangeKindVirtualKeyRevoked:
 		if ch.VirtualKeyID == "" {
 			return

--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -59,13 +59,12 @@ const (
 // CacheChange is one cache-invalidation hint surfaced by ChangePoller.
 // Mirrors the wire shape from the control plane's /changes endpoint.
 type CacheChange struct {
-	Kind                 string
-	VirtualKeyID         string
-	BudgetID             string
-	ProviderCredentialID string
-	ModelProviderID      string
-	ProjectID            string
-	Revision             string
+	Kind            string
+	VirtualKeyID    string
+	BudgetID        string
+	ModelProviderID string
+	ProjectID       string
+	Revision        string
 }
 
 // ChangePoller is the upstream that streams cache-invalidation events
@@ -561,21 +560,20 @@ func (s *Service) changeFeedLoop(ctx context.Context) {
 func (s *Service) applyChange(ch CacheChange) {
 	switch ch.Kind {
 	case ChangeKindProviderBindingUpdated:
-		providerID := ch.ModelProviderID
-		if providerID == "" {
-			providerID = ch.ProviderCredentialID
-		}
-		if providerID == "" {
+		// The control plane emits ModelProvider.id. Config materialization puts
+		// that same ID in Credential.ID; ProviderID is only the provider type
+		// (for example "openai") and is not a cache invalidation join key.
+		if ch.ModelProviderID == "" {
 			return
 		}
 		s.evictWhere(func(b *domain.Bundle) bool {
 			for _, c := range b.Config.Credentials {
-				if c.ID == providerID {
+				if c.ID == ch.ModelProviderID {
 					return true
 				}
 			}
 			return false
-		}, "model_provider_updated", providerID)
+		}, "model_provider_updated", ch.ModelProviderID)
 	case ChangeKindBudgetCreated, ChangeKindBudgetUpdated, ChangeKindBudgetDeleted:
 		// BUDGET_UPDATED's project_id is the only stable join key
 		// (budget_id alone doesn't appear in the bundle; budgets nest

--- a/services/aigateway/adapters/authresolver/service.go
+++ b/services/aigateway/adapters/authresolver/service.go
@@ -46,9 +46,14 @@ type ConfigFetcher interface {
 // listens for. Kept as a sealed string set so callers can switch
 // exhaustively without leaking control-plane internals into this package.
 const (
-	ChangeKindProviderBindingUpdated = "PROVIDER_BINDING_UPDATED"
+	ChangeKindProviderBindingUpdated = "MODEL_PROVIDER_UPDATED"
+	ChangeKindBudgetCreated          = "BUDGET_CREATED"
 	ChangeKindBudgetUpdated          = "BUDGET_UPDATED"
-	ChangeKindVirtualKeyUpdated      = "VIRTUAL_KEY_UPDATED"
+	ChangeKindBudgetDeleted          = "BUDGET_DELETED"
+	ChangeKindVirtualKeyCreated      = "VK_CREATED"
+	ChangeKindVirtualKeyConfigUpdate = "VK_CONFIG_UPDATED"
+	ChangeKindVirtualKeyRotated      = "VK_ROTATED"
+	ChangeKindVirtualKeyRevoked      = "VK_REVOKED"
 )
 
 // CacheChange is one cache-invalidation hint surfaced by ChangePoller.
@@ -58,6 +63,7 @@ type CacheChange struct {
 	VirtualKeyID         string
 	BudgetID             string
 	ProviderCredentialID string
+	ModelProviderID      string
 	ProjectID            string
 	Revision             string
 }
@@ -555,18 +561,22 @@ func (s *Service) changeFeedLoop(ctx context.Context) {
 func (s *Service) applyChange(ch CacheChange) {
 	switch ch.Kind {
 	case ChangeKindProviderBindingUpdated:
-		if ch.ProviderCredentialID == "" {
+		providerID := ch.ModelProviderID
+		if providerID == "" {
+			providerID = ch.ProviderCredentialID
+		}
+		if providerID == "" {
 			return
 		}
 		s.evictWhere(func(b *domain.Bundle) bool {
 			for _, c := range b.Config.Credentials {
-				if c.ID == ch.ProviderCredentialID {
+				if c.ID == providerID {
 					return true
 				}
 			}
 			return false
-		}, "provider_binding_updated", ch.ProviderCredentialID)
-	case ChangeKindBudgetUpdated:
+		}, "model_provider_updated", providerID)
+	case ChangeKindBudgetCreated, ChangeKindBudgetUpdated, ChangeKindBudgetDeleted:
 		// BUDGET_UPDATED's project_id is the only stable join key
 		// (budget_id alone doesn't appear in the bundle; budgets nest
 		// under scopes). Evicting all bundles for the affected project
@@ -578,13 +588,13 @@ func (s *Service) applyChange(ch CacheChange) {
 		s.evictWhere(func(b *domain.Bundle) bool {
 			return b.ProjectID == ch.ProjectID
 		}, "budget_updated", ch.ProjectID)
-	case ChangeKindVirtualKeyUpdated:
+	case ChangeKindVirtualKeyConfigUpdate, ChangeKindVirtualKeyRotated, ChangeKindVirtualKeyRevoked:
 		if ch.VirtualKeyID == "" {
 			return
 		}
 		s.evictWhere(func(b *domain.Bundle) bool {
 			return b.VirtualKeyID == ch.VirtualKeyID
-		}, "virtual_key_updated", ch.VirtualKeyID)
+		}, "virtual_key_config_updated", ch.VirtualKeyID)
 	}
 }
 

--- a/services/aigateway/adapters/authresolver/service_test.go
+++ b/services/aigateway/adapters/authresolver/service_test.go
@@ -261,6 +261,42 @@ func TestResolve_StaleEntry_RecoveryReplacesEntryWithFreshBundle(t *testing.T) {
 	}
 }
 
+func TestApplyChange_ModelProviderUpdatedEvictsMatchingModelProvider(t *testing.T) {
+	resolver := &fakeResolver{}
+	svc, _ := newService(t, Options{Resolver: resolver, ConfigFetcher: resolver})
+
+	matchingKey := hashKey("vk-lw-matching-provider")
+	otherKey := hashKey("vk-lw-other-provider")
+	svc.storeL1(matchingKey, &domain.Bundle{
+		VirtualKeyID: "vk-matching",
+		Config: domain.BundleConfig{Credentials: []domain.Credential{{
+			ID:         "model-provider-1",
+			ProviderID: domain.ProviderOpenAI,
+		}}},
+	})
+	svc.storeL1(otherKey, &domain.Bundle{
+		VirtualKeyID: "vk-other",
+		Config: domain.BundleConfig{Credentials: []domain.Credential{{
+			ID:         "model-provider-2",
+			ProviderID: domain.ProviderOpenAI,
+		}}},
+	})
+
+	svc.applyChange(CacheChange{
+		Kind:            ChangeKindProviderBindingUpdated,
+		ModelProviderID: "model-provider-1",
+	})
+
+	_, matchingPresent := svc.l1.Get(matchingKey)
+	_, otherPresent := svc.l1.Get(otherKey)
+	if matchingPresent {
+		t.Fatal("the changed model provider must be evicted")
+	}
+	if !otherPresent {
+		t.Fatal("other provider bindings must stay cached")
+	}
+}
+
 // --- Background refresh classification --------------------------------------
 
 func TestRefreshBackground_TransportFailure_BumpsSoft(t *testing.T) {

--- a/services/aigateway/adapters/authresolver/service_test.go
+++ b/services/aigateway/adapters/authresolver/service_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
@@ -282,18 +283,43 @@ func TestApplyChange_ModelProviderUpdatedEvictsMatchingModelProvider(t *testing.
 		}}},
 	})
 
-	svc.applyChange(CacheChange{
+	svc.applyChange("", CacheChange{
 		Kind:            ChangeKindProviderBindingUpdated,
 		ModelProviderID: "model-provider-1",
 	})
 
-	_, matchingPresent := svc.l1.Get(matchingKey)
-	_, otherPresent := svc.l1.Get(otherKey)
-	if matchingPresent {
+	_, isMatchingPresent := svc.l1.Get(matchingKey)
+	_, isOtherPresent := svc.l1.Get(otherKey)
+	if isMatchingPresent {
 		t.Fatal("the changed model provider must be evicted")
 	}
-	if !otherPresent {
+	if !isOtherPresent {
 		t.Fatal("other provider bindings must stay cached")
+	}
+}
+
+func TestApplyChange_BudgetMutationWithoutProjectIDEvictsOrganization(t *testing.T) {
+	resolver := &fakeResolver{}
+	svc, _ := newService(t, Options{Resolver: resolver, ConfigFetcher: resolver})
+
+	for _, kind := range []string{
+		ChangeKindBudgetCreated,
+		ChangeKindBudgetUpdated,
+		ChangeKindBudgetDeleted,
+	} {
+		t.Run(kind, func(t *testing.T) {
+			matchingKey := hashKey("vk-lw-budget-matching-" + kind)
+			otherKey := hashKey("vk-lw-budget-other-" + kind)
+			svc.storeL1(matchingKey, &domain.Bundle{OrganizationID: "org-1"})
+			svc.storeL1(otherKey, &domain.Bundle{OrganizationID: "org-2"})
+
+			svc.applyChange("org-1", CacheChange{Kind: kind})
+
+			_, isMatchingPresent := svc.l1.Get(matchingKey)
+			_, isOtherPresent := svc.l1.Get(otherKey)
+			assert.False(t, isMatchingPresent, "budget changes must evict the polled organization")
+			assert.True(t, isOtherPresent, "other organizations must remain cached")
+		})
 	}
 }
 

--- a/services/aigateway/adapters/controlplane/client.go
+++ b/services/aigateway/adapters/controlplane/client.go
@@ -146,13 +146,12 @@ func (c *Client) ResolveKey(ctx context.Context, rawKey string) (*domain.Bundle,
 // must react to (cache invalidation, in practice). Mirrors the wire shape
 // emitted by GET /api/internal/gateway/changes.
 type Change struct {
-	Kind                 string
-	VirtualKeyID         string
-	BudgetID             string
-	ProviderCredentialID string
-	ModelProviderID      string
-	ProjectID            string
-	Revision             string
+	Kind            string
+	VirtualKeyID    string
+	BudgetID        string
+	ModelProviderID string
+	ProjectID       string
+	Revision        string
 }
 
 // Change kinds — keep in sync with the control-plane ChangeEventKind enum
@@ -233,13 +232,12 @@ func (c *Client) PollChanges(ctx context.Context, organizationID, since string) 
 	var wire struct {
 		CurrentRevision string `json:"current_revision"`
 		Changes         []struct {
-			Kind                 string `json:"kind"`
-			VirtualKeyID         string `json:"virtual_key_id"`
-			BudgetID             string `json:"budget_id"`
-			ProviderCredentialID string `json:"provider_credential_id"`
-			ModelProviderID      string `json:"model_provider_id"`
-			ProjectID            string `json:"project_id"`
-			Revision             string `json:"revision"`
+			Kind            string `json:"kind"`
+			VirtualKeyID    string `json:"virtual_key_id"`
+			BudgetID        string `json:"budget_id"`
+			ModelProviderID string `json:"model_provider_id"`
+			ProjectID       string `json:"project_id"`
+			Revision        string `json:"revision"`
 		} `json:"changes"`
 	}
 	if err := json.Unmarshal(body, &wire); err != nil {
@@ -248,13 +246,12 @@ func (c *Client) PollChanges(ctx context.Context, organizationID, since string) 
 	out := make([]Change, len(wire.Changes))
 	for i, ch := range wire.Changes {
 		out[i] = Change{
-			Kind:                 ch.Kind,
-			VirtualKeyID:         ch.VirtualKeyID,
-			BudgetID:             ch.BudgetID,
-			ProviderCredentialID: ch.ProviderCredentialID,
-			ModelProviderID:      ch.ModelProviderID,
-			ProjectID:            ch.ProjectID,
-			Revision:             ch.Revision,
+			Kind:            ch.Kind,
+			VirtualKeyID:    ch.VirtualKeyID,
+			BudgetID:        ch.BudgetID,
+			ModelProviderID: ch.ModelProviderID,
+			ProjectID:       ch.ProjectID,
+			Revision:        ch.Revision,
 		}
 	}
 	return out, wire.CurrentRevision, nil

--- a/services/aigateway/adapters/controlplane/client.go
+++ b/services/aigateway/adapters/controlplane/client.go
@@ -150,6 +150,7 @@ type Change struct {
 	VirtualKeyID         string
 	BudgetID             string
 	ProviderCredentialID string
+	ModelProviderID      string
 	ProjectID            string
 	Revision             string
 }
@@ -157,9 +158,14 @@ type Change struct {
 // Change kinds — keep in sync with the control-plane ChangeEventKind enum
 // in langwatch/src/server/gateway/changeEvent.repository.ts.
 const (
-	ChangeKindProviderBindingUpdated = "PROVIDER_BINDING_UPDATED"
+	ChangeKindProviderBindingUpdated = "MODEL_PROVIDER_UPDATED"
+	ChangeKindBudgetCreated          = "BUDGET_CREATED"
 	ChangeKindBudgetUpdated          = "BUDGET_UPDATED"
-	ChangeKindVirtualKeyUpdated      = "VIRTUAL_KEY_UPDATED"
+	ChangeKindBudgetDeleted          = "BUDGET_DELETED"
+	ChangeKindVirtualKeyCreated      = "VK_CREATED"
+	ChangeKindVirtualKeyConfigUpdate = "VK_CONFIG_UPDATED"
+	ChangeKindVirtualKeyRotated      = "VK_ROTATED"
+	ChangeKindVirtualKeyRevoked      = "VK_REVOKED"
 )
 
 // PollChanges does one /changes long-poll. Returns the events the control
@@ -231,6 +237,7 @@ func (c *Client) PollChanges(ctx context.Context, organizationID, since string) 
 			VirtualKeyID         string `json:"virtual_key_id"`
 			BudgetID             string `json:"budget_id"`
 			ProviderCredentialID string `json:"provider_credential_id"`
+			ModelProviderID      string `json:"model_provider_id"`
 			ProjectID            string `json:"project_id"`
 			Revision             string `json:"revision"`
 		} `json:"changes"`
@@ -245,6 +252,7 @@ func (c *Client) PollChanges(ctx context.Context, organizationID, since string) 
 			VirtualKeyID:         ch.VirtualKeyID,
 			BudgetID:             ch.BudgetID,
 			ProviderCredentialID: ch.ProviderCredentialID,
+			ModelProviderID:      ch.ModelProviderID,
 			ProjectID:            ch.ProjectID,
 			Revision:             ch.Revision,
 		}

--- a/services/aigateway/adapters/controlplane/config_wire.go
+++ b/services/aigateway/adapters/controlplane/config_wire.go
@@ -4,6 +4,11 @@ import "github.com/langwatch/langwatch/services/aigateway/domain"
 
 // configWire matches the JSON shape returned by GET /api/internal/gateway/config/:vk_id.
 type configWire struct {
+	// ProjectID is the trace-export project, emitted by the control-plane
+	// materialiser as the sibling of project_otlp_token and resolved from the
+	// same object (config.materialiser.ts). The pair must travel together —
+	// see domain.BundleConfig.TraceProjectID.
+	ProjectID        string             `json:"project_id"`
 	ProjectOTLPToken string             `json:"project_otlp_token"`
 	DisplayPrefix    string             `json:"display_prefix"`
 	Providers        []providerSlotWire `json:"providers"`
@@ -126,6 +131,7 @@ func (w *configWire) toDomain() domain.BundleConfig {
 
 	cfg := domain.BundleConfig{
 		Credentials:      creds,
+		TraceProjectID:   w.ProjectID,
 		ProjectOTLPToken: w.ProjectOTLPToken,
 		VKDisplayPrefix:  w.DisplayPrefix,
 		AllowedModels:    w.ModelsAllowed,

--- a/services/aigateway/adapters/controlplane/config_wire_test.go
+++ b/services/aigateway/adapters/controlplane/config_wire_test.go
@@ -1,9 +1,11 @@
 package controlplane
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/langwatch/langwatch/services/aigateway/domain"
 )
@@ -172,15 +174,19 @@ func TestProviderSlotToCredential_BaseURL(t *testing.T) {
 	})
 }
 
-// The trace-export project id and its OTLP token are materialised together by
+// The trace-export project id and its OTLP token are materialized together by
 // the control plane and must survive decoding as a pair. Dropping project_id
 // here is what forced the middleware to reach for the auth JWT's project id
 // instead — a field on a different refresh clock, whose skew exported one
 // project's prompts and completions under another project's ingest token.
 func TestConfigWire_TraceProjectIDTravelsWithToken(t *testing.T) {
-	w := &configWire{ProjectID: "proj-trace", ProjectOTLPToken: "tok-trace"}
+	var wire configWire
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"project_id":"proj-trace","project_otlp_token":"tok-trace"}`),
+		&wire,
+	))
 
-	cfg := w.toDomain()
+	cfg := wire.toDomain()
 
 	assert.Equal(t, "proj-trace", cfg.TraceProjectID)
 	assert.Equal(t, "tok-trace", cfg.ProjectOTLPToken)
@@ -190,7 +196,12 @@ func TestConfigWire_TraceProjectIDTravelsWithToken(t *testing.T) {
 // empty rather than to some other project's id — the middleware fails closed on
 // empty and exports nothing, which is the safe outcome.
 func TestConfigWire_AbsentTraceProjectIDIsEmpty(t *testing.T) {
-	cfg := (&configWire{ProjectOTLPToken: "tok"}).toDomain()
+	var wire configWire
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"project_id":null,"project_otlp_token":"tok"}`),
+		&wire,
+	))
+	cfg := wire.toDomain()
 
 	assert.Empty(t, cfg.TraceProjectID)
 }

--- a/services/aigateway/adapters/controlplane/config_wire_test.go
+++ b/services/aigateway/adapters/controlplane/config_wire_test.go
@@ -171,3 +171,26 @@ func TestProviderSlotToCredential_BaseURL(t *testing.T) {
 		assert.Empty(t, cred.Extra["base_url"])
 	})
 }
+
+// The trace-export project id and its OTLP token are materialised together by
+// the control plane and must survive decoding as a pair. Dropping project_id
+// here is what forced the middleware to reach for the auth JWT's project id
+// instead — a field on a different refresh clock, whose skew exported one
+// project's prompts and completions under another project's ingest token.
+func TestConfigWire_TraceProjectIDTravelsWithToken(t *testing.T) {
+	w := &configWire{ProjectID: "proj-trace", ProjectOTLPToken: "tok-trace"}
+
+	cfg := w.toDomain()
+
+	assert.Equal(t, "proj-trace", cfg.TraceProjectID)
+	assert.Equal(t, "tok-trace", cfg.ProjectOTLPToken)
+}
+
+// A null project_id (org without an internal_governance project) must decode to
+// empty rather than to some other project's id — the middleware fails closed on
+// empty and exports nothing, which is the safe outcome.
+func TestConfigWire_AbsentTraceProjectIDIsEmpty(t *testing.T) {
+	cfg := (&configWire{ProjectOTLPToken: "tok"}).toDomain()
+
+	assert.Empty(t, cfg.TraceProjectID)
+}

--- a/services/aigateway/adapters/customertracebridge/emitter.go
+++ b/services/aigateway/adapters/customertracebridge/emitter.go
@@ -53,7 +53,10 @@ type dropFilterExporter struct {
 }
 
 func (d dropFilterExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
-	kept := spans[:0]
+	// Own slice, never spans[:0]: compacting in place writes into the batch
+	// processor's backing array, which the SpanExporter contract does not permit
+	// an exporter to mutate.
+	kept := make([]sdktrace.ReadOnlySpan, 0, len(spans))
 	for _, s := range spans {
 		drop := false
 		for _, a := range s.Attributes() {
@@ -89,7 +92,7 @@ func NewEmitter(ctx context.Context, opts EmitterOptions) (*Emitter, error) {
 		opts.Registry = NewRegistry()
 	}
 
-	router := dropFilterExporter{inner: newRouterExporter(opts.Registry)}
+	router := dropFilterExporter{inner: newRouterExporter(ctx, opts.Registry)}
 
 	batchTimeout := opts.BatchTimeout
 	if batchTimeout == 0 {

--- a/services/aigateway/adapters/customertracebridge/emitter_test.go
+++ b/services/aigateway/adapters/customertracebridge/emitter_test.go
@@ -82,6 +82,48 @@ func TestRegistry_Set_ClearsWithEmpty(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestRegistry_SetFromBundle_RegistersTokenAsAuthHeader(t *testing.T) {
+	r := NewRegistry()
+
+	assert.NoError(t, r.SetFromBundle("proj-1", "tok-1", "http://app:5560/api/otel"))
+
+	endpoint, headers, ok := r.Lookup("proj-1")
+	assert.True(t, ok)
+	assert.Equal(t, "http://app:5560/api/otel", endpoint)
+	assert.Equal(t, "tok-1", headers["X-Auth-Token"])
+}
+
+// A bundle whose OTLP token is gone means the control plane revoked or rotated
+// it. The cached entry must go WITH it — otherwise the bridge keeps exporting
+// this project's spans under the dead token until LRU pressure happens to
+// evict it, which on a quiet gateway is never.
+func TestRegistry_SetFromBundle_ClearedTokenRevokesTheCachedEntry(t *testing.T) {
+	r := NewRegistry()
+	assert.NoError(t, r.SetFromBundle("proj-1", "tok-1", "http://app:5560/api/otel"))
+
+	assert.NoError(t, r.SetFromBundle("proj-1", "", "http://app:5560/api/otel"))
+
+	_, _, ok := r.Lookup("proj-1")
+	assert.False(t, ok, "a revoked token must stop trace export immediately, not on LRU eviction")
+}
+
+func TestRegistry_SetFromBundle_ClearedEndpointRevokesTheCachedEntry(t *testing.T) {
+	r := NewRegistry()
+	assert.NoError(t, r.SetFromBundle("proj-1", "tok-1", "http://app:5560/api/otel"))
+
+	assert.NoError(t, r.SetFromBundle("proj-1", "tok-1", ""))
+
+	_, _, ok := r.Lookup("proj-1")
+	assert.False(t, ok)
+}
+
+func TestRegistry_SetFromBundle_IgnoresEmptyProject(t *testing.T) {
+	r := NewRegistry()
+
+	assert.NoError(t, r.SetFromBundle("", "tok-1", "http://app:5560/api/otel"))
+	assert.NoError(t, r.SetFromBundle("", "", ""))
+}
+
 func hexEncode(b []byte) string {
 	const hexChars = "0123456789abcdef"
 	out := make([]byte, len(b)*2)

--- a/services/aigateway/adapters/customertracebridge/emitter_test.go
+++ b/services/aigateway/adapters/customertracebridge/emitter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseTraceparent_valid(t *testing.T) {
@@ -85,7 +86,7 @@ func TestRegistry_Set_ClearsWithEmpty(t *testing.T) {
 func TestRegistry_SetFromBundle_RegistersTokenAsAuthHeader(t *testing.T) {
 	r := NewRegistry()
 
-	assert.NoError(t, r.SetFromBundle("proj-1", "tok-1", "http://app:5560/api/otel"))
+	require.NoError(t, r.SetFromBundle("proj-1", "tok-1", "http://app:5560/api/otel"))
 
 	endpoint, headers, ok := r.Lookup("proj-1")
 	assert.True(t, ok)

--- a/services/aigateway/adapters/customertracebridge/registry.go
+++ b/services/aigateway/adapters/customertracebridge/registry.go
@@ -51,9 +51,16 @@ func (r *Registry) Set(projectID, endpoint string, headers map[string]string) er
 }
 
 // SetFromBundle registers the project's OTLP endpoint from a resolved bundle.
-// No-op if any required field is empty.
+// A bundle that carries the project but no token (or no endpoint) is a
+// REVOCATION: the cached entry is removed so the bridge stops exporting with a
+// credential the control plane no longer vouches for. Leaving the entry in
+// place would keep shipping spans under the stale token until LRU eviction.
 func (r *Registry) SetFromBundle(projectID, otlpToken, defaultEndpoint string) error {
-	if projectID == "" || otlpToken == "" || defaultEndpoint == "" {
+	if projectID == "" {
+		return nil
+	}
+	if otlpToken == "" || defaultEndpoint == "" {
+		r.cache.Remove(projectID)
 		return nil
 	}
 	return r.Set(projectID, defaultEndpoint, map[string]string{"X-Auth-Token": otlpToken})

--- a/services/aigateway/adapters/customertracebridge/transport.go
+++ b/services/aigateway/adapters/customertracebridge/transport.go
@@ -2,95 +2,185 @@ package customertracebridge
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/pkg/clog"
 )
 
 const defaultExporterCacheSize = 10_000
 
-// routerExporter is an OTel SpanExporter that routes spans to per-project OTLP
-// endpoints based on the langwatch.project_id attribute. Exporters are cached
-// in a bounded LRU; evicted exporters are shut down gracefully.
-type routerExporter struct {
-	registry  *Registry
-	mu        sync.Mutex
-	byProject *lru.Cache[string, *otlptrace.Exporter]
+// cachedExporter records WHERE a cached exporter sends, so a later export can
+// tell whether the registry still names that destination. Caching the exporter
+// alone is what allowed a rotated token to keep shipping to a stale endpoint
+// for the lifetime of the process.
+type cachedExporter struct {
+	exp      *otlptrace.Exporter
+	endpoint string
+	headers  map[string]string
 }
 
-func newRouterExporter(registry *Registry) *routerExporter {
-	r := &routerExporter{registry: registry}
-	cache, _ := lru.NewWithEvict[string, *otlptrace.Exporter](
+// serves reports whether this cached exporter still targets the given
+// destination — same endpoint AND same auth headers.
+func (c cachedExporter) serves(endpoint string, headers map[string]string) bool {
+	return c.endpoint == endpoint && headersEqual(c.headers, headers)
+}
+
+// routerExporter is an OTel SpanExporter that routes spans to per-project OTLP
+// endpoints based on the langwatch.project_id attribute. Exporters are cached
+// in a bounded LRU; evicted and superseded exporters are shut down gracefully.
+type routerExporter struct {
+	baseCtx   context.Context
+	registry  *Registry
+	mu        sync.Mutex
+	byProject *lru.Cache[string, cachedExporter]
+
+	spansExported metric.Int64Counter
+	spansDropped  metric.Int64Counter
+}
+
+func newRouterExporter(ctx context.Context, registry *Registry) *routerExporter {
+	r := &routerExporter{baseCtx: ctx, registry: registry}
+	cache, _ := lru.NewWithEvict(
 		defaultExporterCacheSize,
-		func(_ string, exp *otlptrace.Exporter) {
-			// Best-effort shutdown on eviction.
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			_ = exp.Shutdown(ctx)
-		},
+		func(_ string, c cachedExporter) { shutdownDetached(c.exp) },
 	)
 	r.byProject = cache
+
+	const scope = "langwatch-ai-gateway"
+	meter := otel.Meter(scope)
+	fallback := noop.NewMeterProvider().Meter(scope)
+	var err error
+	if r.spansExported, err = meter.Int64Counter(
+		"langwatch.gateway.customer_trace.spans_exported",
+		metric.WithDescription("Customer trace spans delivered to a project's OTLP ingest."),
+	); err != nil {
+		r.spansExported, _ = fallback.Int64Counter("langwatch.gateway.customer_trace.spans_exported")
+	}
+	if r.spansDropped, err = meter.Int64Counter(
+		"langwatch.gateway.customer_trace.spans_dropped",
+		metric.WithDescription("Customer trace spans that never reached a project, tagged by reason."),
+	); err != nil {
+		r.spansDropped, _ = fallback.Int64Counter("langwatch.gateway.customer_trace.spans_dropped")
+	}
 	return r
+}
+
+// shutdownDetached retires a superseded or evicted exporter without blocking
+// the caller. The LRU evict callback runs inside Add/Remove while r.mu is held,
+// and a blocking 5s Shutdown there would stall the single export goroutine for
+// every other tenant.
+func shutdownDetached(exp *otlptrace.Exporter) {
+	if exp == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = exp.Shutdown(ctx)
+	}()
 }
 
 func (r *routerExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
 	buckets := make(map[string][]sdktrace.ReadOnlySpan)
+	unrouted := 0
 	for _, s := range spans {
 		pid := readAttr(s, string(attrProjectID))
 		if pid == "" {
+			unrouted++
 			continue
 		}
 		buckets[pid] = append(buckets[pid], s)
 	}
+	if unrouted > 0 {
+		r.dropped(ctx, "no_project_id", unrouted)
+		clog.Get(r.baseCtx).Warn("customer_trace_spans_unrouted", zap.Int("spans", unrouted))
+	}
 
+	var errs []error
 	for pid, batch := range buckets {
 		exp := r.exporterFor(ctx, pid)
 		if exp == nil {
+			r.dropped(ctx, "no_endpoint", len(batch))
+			clog.Get(r.baseCtx).Warn("customer_trace_no_endpoint",
+				zap.String("project_id", pid), zap.Int("spans", len(batch)))
 			continue
 		}
-		_ = exp.ExportSpans(ctx, batch)
+		if err := exp.ExportSpans(ctx, batch); err != nil {
+			// Surfaced, not swallowed: a customer receiving nothing — revoked or
+			// rotated token, ingest outage — must be visible from the gateway.
+			r.dropped(ctx, "export_failed", len(batch))
+			clog.Get(r.baseCtx).Warn("customer_trace_export_failed",
+				zap.String("project_id", pid), zap.Int("spans", len(batch)), zap.Error(err))
+			errs = append(errs, fmt.Errorf("project %s: %w", pid, err))
+			continue
+		}
+		r.spansExported.Add(ctx, int64(len(batch)))
 	}
-	return nil
+	return errors.Join(errs...)
+}
+
+func (r *routerExporter) dropped(ctx context.Context, reason string, n int) {
+	r.spansDropped.Add(ctx, int64(n), metric.WithAttributes(attribute.String("reason", reason)))
 }
 
 func (r *routerExporter) Shutdown(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	keys := r.byProject.Keys()
-	for _, k := range keys {
-		if exp, ok := r.byProject.Get(k); ok {
-			_ = exp.Shutdown(ctx)
+	for _, k := range r.byProject.Keys() {
+		if c, ok := r.byProject.Peek(k); ok {
+			_ = c.exp.Shutdown(ctx)
 		}
 	}
 	r.byProject.Purge()
 	return nil
 }
 
+// exporterFor returns the exporter for a project, rebuilding it whenever the
+// registry names a destination the cached one does not serve.
+//
+// The registry is consulted BEFORE the cache on purpose. Returning a cached
+// exporter without checking the registry means an endpoint or auth-token change
+// never takes effect: a rotated key keeps 401-ing with the old token, and a
+// token corrected after a mispairing keeps shipping to the wrong project.
 func (r *routerExporter) exporterFor(ctx context.Context, projectID string) *otlptrace.Exporter {
-	// Fast path: already cached (LRU Get promotes to front).
-	if exp, ok := r.byProject.Get(projectID); ok {
-		return exp
-	}
-
 	endpoint, headers, ok := r.registry.Lookup(projectID)
 	if !ok || endpoint == "" {
 		return nil
 	}
+	endpoint = normalizeEndpoint(endpoint)
+
+	if c, hit := r.byProject.Get(projectID); hit && c.serves(endpoint, headers) {
+		return c.exp
+	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	// Double-check after lock.
-	if exp, ok := r.byProject.Get(projectID); ok {
-		return exp
+	// Double-check after lock: another goroutine may have rebuilt it.
+	if c, hit := r.byProject.Get(projectID); hit {
+		if c.serves(endpoint, headers) {
+			return c.exp
+		}
+		// Destination changed under us — retire the stale exporter. Remove fires
+		// the evict callback, which detaches the shutdown.
+		r.byProject.Remove(projectID)
 	}
 
 	copts := []otlptracehttp.Option{
-		otlptracehttp.WithEndpointURL(normalizeEndpoint(endpoint)),
+		otlptracehttp.WithEndpointURL(endpoint),
 		otlptracehttp.WithTimeout(5 * time.Second),
 	}
 	if len(headers) > 0 {
@@ -98,10 +188,24 @@ func (r *routerExporter) exporterFor(ctx context.Context, projectID string) *otl
 	}
 	exp, err := otlptracehttp.New(ctx, copts...)
 	if err != nil {
+		clog.Get(r.baseCtx).Warn("customer_trace_exporter_build_failed",
+			zap.String("project_id", projectID), zap.Error(err))
 		return nil
 	}
-	r.byProject.Add(projectID, exp)
+	r.byProject.Add(projectID, cachedExporter{exp: exp, endpoint: endpoint, headers: headers})
 	return exp
+}
+
+func headersEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
 }
 
 func readAttr(s sdktrace.ReadOnlySpan, key string) string {

--- a/services/aigateway/adapters/customertracebridge/transport.go
+++ b/services/aigateway/adapters/customertracebridge/transport.go
@@ -112,7 +112,14 @@ func (r *routerExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadO
 
 	var errs []error
 	for pid, batch := range buckets {
-		exp := r.exporterFor(ctx, pid)
+		exp, buildErr := r.exporterFor(ctx, pid)
+		if buildErr != nil {
+			r.dropped(ctx, "exporter_build_failed", len(batch))
+			clog.Get(r.baseCtx).Warn("customer_trace_exporter_build_failed",
+				zap.String("project_id", pid), zap.Int("spans", len(batch)), zap.Error(buildErr))
+			errs = append(errs, fmt.Errorf("project %s: %w", pid, buildErr))
+			continue
+		}
 		if exp == nil {
 			r.dropped(ctx, "no_endpoint", len(batch))
 			clog.Get(r.baseCtx).Warn("customer_trace_no_endpoint",
@@ -156,15 +163,18 @@ func (r *routerExporter) Shutdown(ctx context.Context) error {
 // exporter without checking the registry means an endpoint or auth-token change
 // never takes effect: a rotated key keeps 401-ing with the old token, and a
 // token corrected after a mispairing keeps shipping to the wrong project.
-func (r *routerExporter) exporterFor(ctx context.Context, projectID string) *otlptrace.Exporter {
+func (r *routerExporter) exporterFor(
+	ctx context.Context,
+	projectID string,
+) (*otlptrace.Exporter, error) {
 	endpoint, headers, ok := r.registry.Lookup(projectID)
 	if !ok || endpoint == "" {
-		return nil
+		return nil, nil
 	}
 	endpoint = normalizeEndpoint(endpoint)
 
 	if c, hit := r.byProject.Get(projectID); hit && c.serves(endpoint, headers) {
-		return c.exp
+		return c.exp, nil
 	}
 
 	r.mu.Lock()
@@ -172,7 +182,7 @@ func (r *routerExporter) exporterFor(ctx context.Context, projectID string) *otl
 	// Double-check after lock: another goroutine may have rebuilt it.
 	if c, hit := r.byProject.Get(projectID); hit {
 		if c.serves(endpoint, headers) {
-			return c.exp
+			return c.exp, nil
 		}
 		// Destination changed under us — retire the stale exporter. Remove fires
 		// the evict callback, which detaches the shutdown.
@@ -188,12 +198,10 @@ func (r *routerExporter) exporterFor(ctx context.Context, projectID string) *otl
 	}
 	exp, err := otlptracehttp.New(ctx, copts...)
 	if err != nil {
-		clog.Get(r.baseCtx).Warn("customer_trace_exporter_build_failed",
-			zap.String("project_id", projectID), zap.Error(err))
-		return nil
+		return nil, fmt.Errorf("build OTLP exporter: %w", err)
 	}
 	r.byProject.Add(projectID, cachedExporter{exp: exp, endpoint: endpoint, headers: headers})
-	return exp
+	return exp, nil
 }
 
 func headersEqual(a, b map[string]string) bool {

--- a/services/aigateway/adapters/customertracebridge/transport_test.go
+++ b/services/aigateway/adapters/customertracebridge/transport_test.go
@@ -2,6 +2,7 @@ package customertracebridge
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -17,21 +19,55 @@ import (
 // spans are stored under.
 type ingest struct {
 	*httptest.Server
-	mu     sync.Mutex
-	tokens []string
+	mu       sync.Mutex
+	tokens   []string
+	projects []string
 }
 
 func newIngest(t *testing.T) *ingest {
 	t.Helper()
 	in := &ingest{}
 	in.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read OTLP body: %v", err)
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		traces, err := (&ptrace.ProtoUnmarshaler{}).UnmarshalTraces(body)
+		if err != nil {
+			t.Errorf("unmarshal OTLP body: %v", err)
+			http.Error(w, "unmarshal body", http.StatusBadRequest)
+			return
+		}
+
 		in.mu.Lock()
 		in.tokens = append(in.tokens, r.Header.Get("X-Auth-Token"))
+		resources := traces.ResourceSpans()
+		for i := 0; i < resources.Len(); i++ {
+			scopes := resources.At(i).ScopeSpans()
+			for j := 0; j < scopes.Len(); j++ {
+				spans := scopes.At(j).Spans()
+				for k := 0; k < spans.Len(); k++ {
+					projectID := ""
+					if value, ok := spans.At(k).Attributes().Get(string(attrProjectID)); ok {
+						projectID = value.Str()
+					}
+					in.projects = append(in.projects, projectID)
+				}
+			}
+		}
 		in.mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(in.Close)
 	return in
+}
+
+func (i *ingest) receivedProjects() []string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return append([]string(nil), i.projects...)
 }
 
 func (i *ingest) received() []string {
@@ -54,9 +90,9 @@ func (c *captureExporter) Shutdown(context.Context) error { return nil }
 // with no langwatch.project_id attribute at all.
 func spansFor(t *testing.T, projectIDs ...string) []sdktrace.ReadOnlySpan {
 	t.Helper()
-	cap := &captureExporter{}
+	collector := &captureExporter{}
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSyncer(cap),
+		sdktrace.WithSyncer(collector),
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 	)
 	tr := tp.Tracer("test")
@@ -68,7 +104,7 @@ func spansFor(t *testing.T, projectIDs ...string) []sdktrace.ReadOnlySpan {
 		span.End()
 	}
 	require.NoError(t, tp.Shutdown(context.Background()))
-	return cap.spans
+	return collector.spans
 }
 
 func TestRouterExporter_RoutesEachProjectToItsOwnIngestOnly(t *testing.T) {
@@ -85,6 +121,10 @@ func TestRouterExporter_RoutesEachProjectToItsOwnIngestOnly(t *testing.T) {
 		"alpha's ingest must only ever be handed alpha's token")
 	assert.Equal(t, []string{"tok-beta"}, beta.received(),
 		"beta's ingest must only ever be handed beta's token")
+	assert.Equal(t, []string{"proj-alpha", "proj-alpha"}, alpha.receivedProjects(),
+		"alpha must receive only alpha's span bodies")
+	assert.Equal(t, []string{"proj-beta"}, beta.receivedProjects(),
+		"beta must receive only beta's span bodies")
 }
 
 // The regression that matters: before this, exporterFor returned the cached
@@ -174,6 +214,21 @@ func TestRouterExporter_SurfacesExportFailure(t *testing.T) {
 	err := router.ExportSpans(context.Background(), spansFor(t, "proj-1"))
 
 	assert.Error(t, err, "a rejected export must not be silently discarded")
+}
+
+func TestRouterExporter_SurfacesExporterBuildFailure(t *testing.T) {
+	in := newIngest(t)
+	reg := NewRegistry()
+	require.NoError(t, reg.Set("proj-1", in.URL, map[string]string{"X-Auth-Token": "tok"}))
+	router := newRouterExporter(context.Background(), reg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := router.ExportSpans(ctx, spansFor(t, "proj-1"))
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, in.received(), "a failed exporter build must not report a successful delivery")
 }
 
 func TestHeadersEqual(t *testing.T) {

--- a/services/aigateway/adapters/customertracebridge/transport_test.go
+++ b/services/aigateway/adapters/customertracebridge/transport_test.go
@@ -1,0 +1,184 @@
+package customertracebridge
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// ingest is a stand-in for a project's OTLP ingest. It records the auth token
+// on every request it receives, which is what actually decides the tenant the
+// spans are stored under.
+type ingest struct {
+	*httptest.Server
+	mu     sync.Mutex
+	tokens []string
+}
+
+func newIngest(t *testing.T) *ingest {
+	t.Helper()
+	in := &ingest{}
+	in.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		in.mu.Lock()
+		in.tokens = append(in.tokens, r.Header.Get("X-Auth-Token"))
+		in.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(in.Close)
+	return in
+}
+
+func (i *ingest) received() []string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return append([]string(nil), i.tokens...)
+}
+
+// captureExporter collects finished spans so tests can hand real
+// ReadOnlySpans to the router.
+type captureExporter struct{ spans []sdktrace.ReadOnlySpan }
+
+func (c *captureExporter) ExportSpans(_ context.Context, s []sdktrace.ReadOnlySpan) error {
+	c.spans = append(c.spans, s...)
+	return nil
+}
+func (c *captureExporter) Shutdown(context.Context) error { return nil }
+
+// spansFor builds one finished span per project id. An empty id produces a span
+// with no langwatch.project_id attribute at all.
+func spansFor(t *testing.T, projectIDs ...string) []sdktrace.ReadOnlySpan {
+	t.Helper()
+	cap := &captureExporter{}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(cap),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	tr := tp.Tracer("test")
+	for _, pid := range projectIDs {
+		_, span := tr.Start(context.Background(), "gen_ai.chat")
+		if pid != "" {
+			span.SetAttributes(attrProjectID.String(pid))
+		}
+		span.End()
+	}
+	require.NoError(t, tp.Shutdown(context.Background()))
+	return cap.spans
+}
+
+func TestRouterExporter_RoutesEachProjectToItsOwnIngestOnly(t *testing.T) {
+	alpha, beta := newIngest(t), newIngest(t)
+	reg := NewRegistry()
+	require.NoError(t, reg.Set("proj-alpha", alpha.URL, map[string]string{"X-Auth-Token": "tok-alpha"}))
+	require.NoError(t, reg.Set("proj-beta", beta.URL, map[string]string{"X-Auth-Token": "tok-beta"}))
+
+	router := newRouterExporter(context.Background(), reg)
+	require.NoError(t, router.ExportSpans(context.Background(),
+		spansFor(t, "proj-alpha", "proj-beta", "proj-alpha")))
+
+	assert.Equal(t, []string{"tok-alpha"}, alpha.received(),
+		"alpha's ingest must only ever be handed alpha's token")
+	assert.Equal(t, []string{"tok-beta"}, beta.received(),
+		"beta's ingest must only ever be handed beta's token")
+}
+
+// The regression that matters: before this, exporterFor returned the cached
+// exporter without consulting the registry, so a rotated token kept shipping
+// under the old credential for the lifetime of the process.
+func TestRouterExporter_RebuildsAfterTokenRotation(t *testing.T) {
+	in := newIngest(t)
+	reg := NewRegistry()
+	require.NoError(t, reg.Set("proj-1", in.URL, map[string]string{"X-Auth-Token": "old-token"}))
+
+	router := newRouterExporter(context.Background(), reg)
+	require.NoError(t, router.ExportSpans(context.Background(), spansFor(t, "proj-1")))
+
+	require.NoError(t, reg.Set("proj-1", in.URL, map[string]string{"X-Auth-Token": "new-token"}))
+	require.NoError(t, router.ExportSpans(context.Background(), spansFor(t, "proj-1")))
+
+	assert.Equal(t, []string{"old-token", "new-token"}, in.received(),
+		"the export after rotation must carry the new token, not the cached one")
+}
+
+// A project reassigned to a different destination must stop being delivered to
+// the previous one — the shape a mispaired registry entry takes once corrected.
+func TestRouterExporter_RebuildsAfterEndpointChange(t *testing.T) {
+	first, second := newIngest(t), newIngest(t)
+	reg := NewRegistry()
+	require.NoError(t, reg.Set("proj-1", first.URL, map[string]string{"X-Auth-Token": "tok"}))
+
+	router := newRouterExporter(context.Background(), reg)
+	require.NoError(t, router.ExportSpans(context.Background(), spansFor(t, "proj-1")))
+
+	require.NoError(t, reg.Set("proj-1", second.URL, map[string]string{"X-Auth-Token": "tok"}))
+	require.NoError(t, router.ExportSpans(context.Background(), spansFor(t, "proj-1")))
+
+	assert.Len(t, first.received(), 1, "the retired endpoint must receive nothing further")
+	assert.Len(t, second.received(), 1, "the new endpoint must receive the later batch")
+}
+
+// Fail closed: a span with no project id has no provable owner, so it must not
+// be delivered to anyone rather than being routed to a default.
+func TestRouterExporter_DropsSpansWithoutProjectID(t *testing.T) {
+	in := newIngest(t)
+	reg := NewRegistry()
+	require.NoError(t, reg.Set("proj-1", in.URL, map[string]string{"X-Auth-Token": "tok"}))
+
+	router := newRouterExporter(context.Background(), reg)
+	require.NoError(t, router.ExportSpans(context.Background(), spansFor(t, "")))
+
+	assert.Empty(t, in.received(), "an unattributed span must not reach any project")
+}
+
+func TestRouterExporter_DropsSpansForUnregisteredProject(t *testing.T) {
+	in := newIngest(t)
+	reg := NewRegistry()
+	require.NoError(t, reg.Set("proj-1", in.URL, map[string]string{"X-Auth-Token": "tok"}))
+
+	router := newRouterExporter(context.Background(), reg)
+	require.NoError(t, router.ExportSpans(context.Background(), spansFor(t, "proj-unknown")))
+
+	assert.Empty(t, in.received(), "a project with no registry entry must not borrow another's exporter")
+}
+
+// Clearing a project's entry must take effect immediately, not at LRU eviction.
+func TestRouterExporter_StopsExportingAfterRegistryCleared(t *testing.T) {
+	in := newIngest(t)
+	reg := NewRegistry()
+	require.NoError(t, reg.Set("proj-1", in.URL, map[string]string{"X-Auth-Token": "tok"}))
+
+	router := newRouterExporter(context.Background(), reg)
+	require.NoError(t, router.ExportSpans(context.Background(), spansFor(t, "proj-1")))
+
+	require.NoError(t, reg.Set("proj-1", "", nil))
+	require.NoError(t, router.ExportSpans(context.Background(), spansFor(t, "proj-1")))
+
+	assert.Len(t, in.received(), 1, "no export may follow a cleared registry entry")
+}
+
+func TestRouterExporter_SurfacesExportFailure(t *testing.T) {
+	failing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(failing.Close)
+
+	reg := NewRegistry()
+	require.NoError(t, reg.Set("proj-1", failing.URL, map[string]string{"X-Auth-Token": "revoked"}))
+
+	router := newRouterExporter(context.Background(), reg)
+	err := router.ExportSpans(context.Background(), spansFor(t, "proj-1"))
+
+	assert.Error(t, err, "a rejected export must not be silently discarded")
+}
+
+func TestHeadersEqual(t *testing.T) {
+	assert.True(t, headersEqual(map[string]string{"a": "1"}, map[string]string{"a": "1"}))
+	assert.False(t, headersEqual(map[string]string{"a": "1"}, map[string]string{"a": "2"}))
+	assert.False(t, headersEqual(map[string]string{"a": "1"}, map[string]string{"a": "1", "b": "2"}))
+	assert.True(t, headersEqual(nil, nil))
+}

--- a/services/aigateway/adapters/gatewaytracer/attrs.go
+++ b/services/aigateway/adapters/gatewaytracer/attrs.go
@@ -25,4 +25,6 @@ const (
 	AttrFallbackWinningProvider   = "langwatch.fallback.winning_provider"
 	AttrFallbackWinningCredential = "langwatch.fallback.winning_credential"
 	AttrThreadID                  = "langwatch.thread_id"
+	AttrErrorType                 = "error.type"
+	AttrUpstreamStatusCode        = "langwatch.upstream.status_code"
 )

--- a/services/aigateway/adapters/gatewaytracer/attrs_genai.go
+++ b/services/aigateway/adapters/gatewaytracer/attrs_genai.go
@@ -1,5 +1,15 @@
 package gatewaytracer
 
+// These are the gen_ai keys the GATEWAY'S OWN operational span may carry:
+// shape and cost metadata only — which model, how many tokens, what finished.
+//
+// The content keys (gen_ai.input.messages, gen_ai.output.messages,
+// gen_ai.system_instructions) are deliberately ABSENT and must not be added
+// back. Prompt and completion bodies belong to the customer and are set only by
+// the customer trace bridge, on spans bound for the customer's own project,
+// using that package's private keys. A constant declared here is one autocomplete
+// away from being stamped on internal telemetry, so the key names do not exist
+// in this package at all. InternalSpanAttributeAllowlist pins the boundary.
 const (
 	AttrGenAIOperationName      = "gen_ai.operation.name"
 	AttrGenAISystem             = "gen_ai.system"
@@ -13,9 +23,6 @@ const (
 	AttrGenAIResponseID         = "gen_ai.response.id"
 	AttrGenAIResponseModel      = "gen_ai.response.model"
 	AttrGenAIResponseFinish     = "gen_ai.response.finish_reasons"
-	AttrGenAIInputMessages      = "gen_ai.input.messages"
-	AttrGenAIOutputMessages     = "gen_ai.output.messages"
-	AttrGenAISystemInstructions = "gen_ai.system_instructions"
 	AttrGenAIUsageIn            = "gen_ai.usage.input_tokens"
 	AttrGenAIUsageOut           = "gen_ai.usage.output_tokens"
 	AttrGenAIUsageTotal         = "gen_ai.usage.total_tokens"

--- a/services/aigateway/adapters/gatewaytracer/attrs_genai.go
+++ b/services/aigateway/adapters/gatewaytracer/attrs_genai.go
@@ -9,25 +9,26 @@ package gatewaytracer
 // the customer trace bridge, on spans bound for the customer's own project,
 // using that package's private keys. A constant declared here is one autocomplete
 // away from being stamped on internal telemetry, so the key names do not exist
-// in this package at all. InternalSpanAttributeAllowlist pins the boundary.
+// in this package at all. ForbiddenInternalSpanAttrs and the tests in
+// internal_span_test.go pin the boundary.
 const (
-	AttrGenAIOperationName      = "gen_ai.operation.name"
-	AttrGenAISystem             = "gen_ai.system"
-	AttrGenAIRequestModel       = "gen_ai.request.model"
-	AttrGenAIRequestTemp        = "gen_ai.request.temperature"
-	AttrGenAIRequestMaxTokens   = "gen_ai.request.max_tokens"
-	AttrGenAIRequestTopP        = "gen_ai.request.top_p"
-	AttrGenAIRequestFreqPen     = "gen_ai.request.frequency_penalty"
-	AttrGenAIRequestPresPen     = "gen_ai.request.presence_penalty"
-	AttrGenAIRequestStopSeqs    = "gen_ai.request.stop_sequences"
-	AttrGenAIResponseID         = "gen_ai.response.id"
-	AttrGenAIResponseModel      = "gen_ai.response.model"
-	AttrGenAIResponseFinish     = "gen_ai.response.finish_reasons"
-	AttrGenAIUsageIn            = "gen_ai.usage.input_tokens"
-	AttrGenAIUsageOut           = "gen_ai.usage.output_tokens"
-	AttrGenAIUsageTotal         = "gen_ai.usage.total_tokens"
-	AttrGenAIUsageCacheRead     = "gen_ai.usage.cache_read.input_tokens"
-	AttrGenAIUsageCacheCreate   = "gen_ai.usage.cache_creation.input_tokens"
+	AttrGenAIOperationName    = "gen_ai.operation.name"
+	AttrGenAISystem           = "gen_ai.system"
+	AttrGenAIRequestModel     = "gen_ai.request.model"
+	AttrGenAIRequestTemp      = "gen_ai.request.temperature"
+	AttrGenAIRequestMaxTokens = "gen_ai.request.max_tokens"
+	AttrGenAIRequestTopP      = "gen_ai.request.top_p"
+	AttrGenAIRequestFreqPen   = "gen_ai.request.frequency_penalty"
+	AttrGenAIRequestPresPen   = "gen_ai.request.presence_penalty"
+	AttrGenAIRequestStopSeqs  = "gen_ai.request.stop_sequences"
+	AttrGenAIResponseID       = "gen_ai.response.id"
+	AttrGenAIResponseModel    = "gen_ai.response.model"
+	AttrGenAIResponseFinish   = "gen_ai.response.finish_reasons"
+	AttrGenAIUsageIn          = "gen_ai.usage.input_tokens"
+	AttrGenAIUsageOut         = "gen_ai.usage.output_tokens"
+	AttrGenAIUsageTotal       = "gen_ai.usage.total_tokens"
+	AttrGenAIUsageCacheRead   = "gen_ai.usage.cache_read.input_tokens"
+	AttrGenAIUsageCacheCreate = "gen_ai.usage.cache_creation.input_tokens"
 	// AttrGenAIConversationID is the wrapped tool's own session / thread id,
 	// lifted from a request header (claude-code / codex / opencode) so the
 	// gateway-path trace carries a real conversation id the fold groups on.

--- a/services/aigateway/adapters/gatewaytracer/internal_span.go
+++ b/services/aigateway/adapters/gatewaytracer/internal_span.go
@@ -1,0 +1,122 @@
+package gatewaytracer
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// ForbiddenInternalSpanAttrs are keys that must NEVER appear on the gateway's
+// own operational span. They carry prompt and completion bodies, which belong
+// to the customer's project and reach it through the customer trace bridge.
+//
+// Exported so the boundary is testable rather than a matter of care: see
+// internal_span_test.go, which stamps a span from params holding real bodies
+// and asserts neither these keys nor the body text survive.
+var ForbiddenInternalSpanAttrs = []string{
+	"gen_ai.input.messages",
+	"gen_ai.output.messages",
+	"gen_ai.system_instructions",
+	"gen_ai.prompt",
+	"gen_ai.completion",
+}
+
+// aiTraceEmitter is the customer-trace port this package decorates. Declared
+// here rather than imported so the adapter does not depend on app/.
+type aiTraceEmitter interface {
+	BeginSpan(ctx context.Context, projectID string, reqType domain.RequestType) (context.Context, string)
+	EndSpan(ctx context.Context, params domain.AITraceParams)
+}
+
+// StampingEmitter decorates the customer trace emitter so that ending a
+// customer span ALSO stamps the gateway's own operational span with the safe
+// gen_ai metadata.
+//
+// The two destinations stay separate: the customer's project receives the
+// content-bearing span built by the bridge, LangWatch's own backend receives
+// shape and cost on the gateway span. This decorator is the only thing that
+// connects them, and it copies scalars in one direction only.
+type StampingEmitter struct{ Inner aiTraceEmitter }
+
+// WithInternalStamping wraps an emitter so the gateway's own span is enriched
+// alongside the customer's.
+func WithInternalStamping(inner aiTraceEmitter) StampingEmitter {
+	return StampingEmitter{Inner: inner}
+}
+
+func (s StampingEmitter) BeginSpan(ctx context.Context, projectID string, reqType domain.RequestType) (context.Context, string) {
+	return s.Inner.BeginSpan(ctx, projectID, reqType)
+}
+
+func (s StampingEmitter) EndSpan(ctx context.Context, params domain.AITraceParams) {
+	StampInternalGenAI(ctx, params)
+	s.Inner.EndSpan(ctx, params)
+}
+
+// StampInternalGenAI enriches the gateway's OWN span — the one started by
+// Middleware, on the globally-registered provider — with the gen_ai metadata an
+// operator needs: which model, which provider, how many tokens, what it cost,
+// how it ended.
+//
+// params carries RequestBody and ResponseBody. They are deliberately not read.
+// Everything stamped here is a scalar the gateway computed about the call, never
+// a byte of what the customer sent or the model returned. This is the only place
+// gen_ai metadata reaches internal telemetry, which is what makes the boundary
+// pinnable by a single test.
+//
+// Safe to call with any context: a context with no recording span is a no-op.
+func StampInternalGenAI(ctx context.Context, params domain.AITraceParams) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	attrs := make([]attribute.KeyValue, 0, 12)
+	if params.RequestType != "" {
+		attrs = append(attrs, attribute.String(AttrGenAIOperationName, string(params.RequestType)))
+	}
+	if params.ProviderID != "" {
+		attrs = append(attrs, attribute.String(AttrGenAISystem, string(params.ProviderID)))
+	}
+	if params.Model != "" {
+		attrs = append(attrs, attribute.String(AttrGenAIRequestModel, params.Model))
+	}
+	if params.Usage.Model != "" {
+		attrs = append(attrs, attribute.String(AttrGenAIResponseModel, params.Usage.Model))
+	}
+	if params.Usage.PromptTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageIn, params.Usage.PromptTokens))
+	}
+	if params.Usage.CompletionTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageOut, params.Usage.CompletionTokens))
+	}
+	if params.Usage.TotalTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageTotal, params.Usage.TotalTokens))
+	}
+	if params.Usage.CacheReadTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageCacheRead, params.Usage.CacheReadTokens))
+	}
+	if params.Usage.CacheCreationTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageCacheCreate, params.Usage.CacheCreationTokens))
+	}
+	if params.Usage.CostMicroUSD > 0 {
+		attrs = append(attrs, attribute.Float64(AttrCostUSD, float64(params.Usage.CostMicroUSD)/1_000_000))
+	}
+	if params.VirtualKeyID != "" {
+		attrs = append(attrs, attribute.String(AttrVirtualKeyID, params.VirtualKeyID))
+	}
+	if params.GatewayRequestID != "" {
+		attrs = append(attrs, attribute.String(AttrGatewayReqID, params.GatewayRequestID))
+	}
+	if params.UpstreamErrorType != "" {
+		attrs = append(attrs, attribute.String(AttrErrorType, params.UpstreamErrorType))
+	}
+	if params.UpstreamStatusCode != 0 {
+		attrs = append(attrs, attribute.Int(AttrUpstreamStatusCode, params.UpstreamStatusCode))
+	}
+
+	span.SetAttributes(attrs...)
+}

--- a/services/aigateway/adapters/gatewaytracer/internal_span.go
+++ b/services/aigateway/adapters/gatewaytracer/internal_span.go
@@ -78,11 +78,11 @@ func StampInternalGenAI(ctx context.Context, params domain.AITraceParams) {
 	if params.RequestType != "" {
 		attrs = append(attrs, attribute.String(AttrGenAIOperationName, string(params.RequestType)))
 	}
-	if params.ProviderID != "" {
-		attrs = append(attrs, attribute.String(AttrGenAISystem, string(params.ProviderID)))
+	if params.InternalProviderID != "" {
+		attrs = append(attrs, attribute.String(AttrGenAISystem, string(params.InternalProviderID)))
 	}
-	if params.Model != "" {
-		attrs = append(attrs, attribute.String(AttrGenAIRequestModel, params.Model))
+	if params.InternalModel != "" {
+		attrs = append(attrs, attribute.String(AttrGenAIRequestModel, params.InternalModel))
 	}
 	attrs = append(attrs, usageAttributes(params.Usage)...)
 	if params.VirtualKeyID != "" {
@@ -105,9 +105,6 @@ func StampInternalGenAI(ctx context.Context, params domain.AITraceParams) {
 // intentionally contains no request or response body fields.
 func usageAttributes(usage domain.Usage) []attribute.KeyValue {
 	attrs := make([]attribute.KeyValue, 0, 7)
-	if usage.Model != "" {
-		attrs = append(attrs, attribute.String(AttrGenAIResponseModel, usage.Model))
-	}
 	if usage.PromptTokens > 0 {
 		attrs = append(attrs, attribute.Int(AttrGenAIUsageIn, usage.PromptTokens))
 	}

--- a/services/aigateway/adapters/gatewaytracer/internal_span.go
+++ b/services/aigateway/adapters/gatewaytracer/internal_span.go
@@ -84,27 +84,7 @@ func StampInternalGenAI(ctx context.Context, params domain.AITraceParams) {
 	if params.Model != "" {
 		attrs = append(attrs, attribute.String(AttrGenAIRequestModel, params.Model))
 	}
-	if params.Usage.Model != "" {
-		attrs = append(attrs, attribute.String(AttrGenAIResponseModel, params.Usage.Model))
-	}
-	if params.Usage.PromptTokens > 0 {
-		attrs = append(attrs, attribute.Int(AttrGenAIUsageIn, params.Usage.PromptTokens))
-	}
-	if params.Usage.CompletionTokens > 0 {
-		attrs = append(attrs, attribute.Int(AttrGenAIUsageOut, params.Usage.CompletionTokens))
-	}
-	if params.Usage.TotalTokens > 0 {
-		attrs = append(attrs, attribute.Int(AttrGenAIUsageTotal, params.Usage.TotalTokens))
-	}
-	if params.Usage.CacheReadTokens > 0 {
-		attrs = append(attrs, attribute.Int(AttrGenAIUsageCacheRead, params.Usage.CacheReadTokens))
-	}
-	if params.Usage.CacheCreationTokens > 0 {
-		attrs = append(attrs, attribute.Int(AttrGenAIUsageCacheCreate, params.Usage.CacheCreationTokens))
-	}
-	if params.Usage.CostMicroUSD > 0 {
-		attrs = append(attrs, attribute.Float64(AttrCostUSD, float64(params.Usage.CostMicroUSD)/1_000_000))
-	}
+	attrs = append(attrs, usageAttributes(params.Usage)...)
 	if params.VirtualKeyID != "" {
 		attrs = append(attrs, attribute.String(AttrVirtualKeyID, params.VirtualKeyID))
 	}
@@ -119,4 +99,32 @@ func StampInternalGenAI(ctx context.Context, params domain.AITraceParams) {
 	}
 
 	span.SetAttributes(attrs...)
+}
+
+// usageAttributes returns the operational usage values that are present. It
+// intentionally contains no request or response body fields.
+func usageAttributes(usage domain.Usage) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 7)
+	if usage.Model != "" {
+		attrs = append(attrs, attribute.String(AttrGenAIResponseModel, usage.Model))
+	}
+	if usage.PromptTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageIn, usage.PromptTokens))
+	}
+	if usage.CompletionTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageOut, usage.CompletionTokens))
+	}
+	if usage.TotalTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageTotal, usage.TotalTokens))
+	}
+	if usage.CacheReadTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageCacheRead, usage.CacheReadTokens))
+	}
+	if usage.CacheCreationTokens > 0 {
+		attrs = append(attrs, attribute.Int(AttrGenAIUsageCacheCreate, usage.CacheCreationTokens))
+	}
+	if usage.CostMicroUSD > 0 {
+		attrs = append(attrs, attribute.Float64(AttrCostUSD, float64(usage.CostMicroUSD)/1_000_000))
+	}
+	return attrs
 }

--- a/services/aigateway/adapters/gatewaytracer/internal_span_test.go
+++ b/services/aigateway/adapters/gatewaytracer/internal_span_test.go
@@ -47,18 +47,20 @@ func stampedSpan(t *testing.T, params domain.AITraceParams) sdktrace.ReadOnlySpa
 // response bodies present, exactly as the pipeline assembles them.
 func paramsWithBodies() domain.AITraceParams {
 	return domain.AITraceParams{
-		ProjectID:        "proj-1",
-		Model:            "gpt-5-mini",
-		ProviderID:       domain.ProviderID("openai"),
-		RequestType:      domain.RequestType("chat"),
-		VirtualKeyID:     "vk-1",
-		GatewayRequestID: "req-1",
+		ProjectID:          "proj-1",
+		Model:              "customer-controlled-request-model",
+		ProviderID:         domain.ProviderID("customer-controlled-provider"),
+		InternalModel:      "gpt-5-mini",
+		InternalProviderID: domain.ProviderID("openai"),
+		RequestType:        domain.RequestType("chat"),
+		VirtualKeyID:       "vk-1",
+		GatewayRequestID:   "req-1",
 		Usage: domain.Usage{
 			PromptTokens:     120,
 			CompletionTokens: 34,
 			TotalTokens:      154,
 			CostMicroUSD:     2500,
-			Model:            "gpt-5-mini-2025",
+			Model:            "customer-controlled-response-model",
 		},
 		RequestBody:  []byte(`{"messages":[{"role":"system","content":"` + secretSystem + `"},{"role":"user","content":"` + secretPrompt + `"}]}`),
 		ResponseBody: []byte(`{"choices":[{"message":{"content":"` + secretCompletion + `"}}]}`),
@@ -109,12 +111,28 @@ func TestStampInternalGenAI_KeepsOperationalMetadata(t *testing.T) {
 	assert.Equal(t, "chat", got[AttrGenAIOperationName])
 	assert.Equal(t, "openai", got[AttrGenAISystem])
 	assert.Equal(t, "gpt-5-mini", got[AttrGenAIRequestModel])
-	assert.Equal(t, "gpt-5-mini-2025", got[AttrGenAIResponseModel])
+	assert.NotContains(t, got, AttrGenAIResponseModel)
 	assert.Equal(t, "120", got[AttrGenAIUsageIn])
 	assert.Equal(t, "34", got[AttrGenAIUsageOut])
 	assert.Equal(t, "154", got[AttrGenAIUsageTotal])
 	assert.Equal(t, "vk-1", got[AttrVirtualKeyID])
 	assert.Equal(t, "req-1", got[AttrGatewayReqID])
+}
+
+func TestStampInternalGenAI_OmitsUntrustedModelMetadata(t *testing.T) {
+	const secret = "customer-secret-in-model-field"
+	params := paramsWithBodies()
+	params.Model = secret
+	params.ProviderID = domain.ProviderID(secret)
+	params.Usage.Model = secret
+	params.InternalModel = ""
+	params.InternalProviderID = ""
+
+	span := stampedSpan(t, params)
+	for _, kv := range span.Attributes() {
+		assert.NotContains(t, kv.Value.Emit(), secret,
+			"attribute %q leaked a customer-controlled model value", kv.Key)
+	}
 }
 
 func TestStampInternalGenAI_RecordsUpstreamFailure(t *testing.T) {

--- a/services/aigateway/adapters/gatewaytracer/internal_span_test.go
+++ b/services/aigateway/adapters/gatewaytracer/internal_span_test.go
@@ -1,0 +1,168 @@
+package gatewaytracer
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+const (
+	secretPrompt     = "my database password is hunter2, summarise the attached patient record"
+	secretCompletion = "Certainly — the patient record for Jane Doe indicates a diagnosis of"
+	secretSystem     = "You are an assistant for ACME Corp. The internal API key is sk-live-abc123."
+)
+
+// stampedSpan runs StampInternalGenAI over a real recording span and returns
+// the finished span as the exporter would see it.
+func stampedSpan(t *testing.T, params domain.AITraceParams) sdktrace.ReadOnlySpan {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	ctx, span := tp.Tracer("test").Start(context.Background(), "lw_gateway.chat_completions")
+	StampInternalGenAI(ctx, params)
+	// SimpleSpanProcessor exports on End. Do NOT Shutdown the provider before
+	// reading: InMemoryExporter.Shutdown resets the recorder, which would leave
+	// every assertion below iterating an empty attribute set and passing
+	// vacuously.
+	span.End()
+
+	spans := exp.GetSpans().Snapshots()
+	require.Len(t, spans, 1)
+	// Guard the guards: the leak assertions below are loops over attributes, so
+	// they only mean something if attributes were actually stamped.
+	require.NotEmpty(t, spans[0].Attributes(), "no attributes stamped — assertions would be vacuous")
+	return spans[0]
+}
+
+// paramsWithBodies is a realistic end-of-request params: full request and
+// response bodies present, exactly as the pipeline assembles them.
+func paramsWithBodies() domain.AITraceParams {
+	return domain.AITraceParams{
+		ProjectID:        "proj-1",
+		Model:            "gpt-5-mini",
+		ProviderID:       domain.ProviderID("openai"),
+		RequestType:      domain.RequestType("chat"),
+		VirtualKeyID:     "vk-1",
+		GatewayRequestID: "req-1",
+		Usage: domain.Usage{
+			PromptTokens:     120,
+			CompletionTokens: 34,
+			TotalTokens:      154,
+			CostMicroUSD:     2500,
+			Model:            "gpt-5-mini-2025",
+		},
+		RequestBody:  []byte(`{"messages":[{"role":"system","content":"` + secretSystem + `"},{"role":"user","content":"` + secretPrompt + `"}]}`),
+		ResponseBody: []byte(`{"choices":[{"message":{"content":"` + secretCompletion + `"}}]}`),
+	}
+}
+
+func TestStampInternalGenAI_OmitsPromptAndCompletionContent(t *testing.T) {
+	span := stampedSpan(t, paramsWithBodies())
+
+	for _, kv := range span.Attributes() {
+		value := kv.Value.Emit()
+		for _, secret := range []string{secretPrompt, secretCompletion, secretSystem} {
+			assert.NotContains(t, value, secret,
+				"attribute %q leaked message content onto the gateway's own span", kv.Key)
+		}
+		// Nothing should carry a raw JSON body either, whatever the key.
+		assert.NotContains(t, value, `"messages"`,
+			"attribute %q looks like a raw request body", kv.Key)
+		assert.NotContains(t, value, `"choices"`,
+			"attribute %q looks like a raw response body", kv.Key)
+	}
+}
+
+func TestStampInternalGenAI_SetsNoForbiddenKey(t *testing.T) {
+	span := stampedSpan(t, paramsWithBodies())
+
+	present := make(map[string]struct{}, len(span.Attributes()))
+	for _, kv := range span.Attributes() {
+		present[string(kv.Key)] = struct{}{}
+	}
+	for _, forbidden := range ForbiddenInternalSpanAttrs {
+		assert.NotContains(t, present, forbidden,
+			"content-carrying key %q must never be stamped on internal telemetry", forbidden)
+	}
+}
+
+// The other half of the requirement: we need the gateway traced, so the
+// operational metadata must actually be there. A span stripped of content but
+// also stripped of model and usage would be useless.
+func TestStampInternalGenAI_KeepsOperationalMetadata(t *testing.T) {
+	span := stampedSpan(t, paramsWithBodies())
+
+	got := make(map[string]string, len(span.Attributes()))
+	for _, kv := range span.Attributes() {
+		got[string(kv.Key)] = kv.Value.Emit()
+	}
+
+	assert.Equal(t, "chat", got[AttrGenAIOperationName])
+	assert.Equal(t, "openai", got[AttrGenAISystem])
+	assert.Equal(t, "gpt-5-mini", got[AttrGenAIRequestModel])
+	assert.Equal(t, "gpt-5-mini-2025", got[AttrGenAIResponseModel])
+	assert.Equal(t, "120", got[AttrGenAIUsageIn])
+	assert.Equal(t, "34", got[AttrGenAIUsageOut])
+	assert.Equal(t, "154", got[AttrGenAIUsageTotal])
+	assert.Equal(t, "vk-1", got[AttrVirtualKeyID])
+	assert.Equal(t, "req-1", got[AttrGatewayReqID])
+}
+
+func TestStampInternalGenAI_RecordsUpstreamFailure(t *testing.T) {
+	params := paramsWithBodies()
+	params.UpstreamErrorType = "provider_timeout"
+	params.UpstreamStatusCode = 504
+
+	span := stampedSpan(t, params)
+
+	got := make(map[string]string, len(span.Attributes()))
+	for _, kv := range span.Attributes() {
+		got[string(kv.Key)] = kv.Value.Emit()
+	}
+	assert.Equal(t, "provider_timeout", got[AttrErrorType])
+	assert.Equal(t, "504", got[AttrUpstreamStatusCode])
+}
+
+// The classifier token is a fixed vocabulary, never raw provider text — the
+// shape that let an Authorization header reach telemetry elsewhere.
+func TestStampInternalGenAI_ErrorTypeCarriesNoProviderText(t *testing.T) {
+	params := paramsWithBodies()
+	params.UpstreamErrorType = "provider_error"
+
+	span := stampedSpan(t, params)
+
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) != AttrErrorType {
+			continue
+		}
+		assert.False(t, strings.Contains(kv.Value.Emit(), " "),
+			"error.type must stay a classifier token, not a message")
+	}
+}
+
+// The content keys must not even exist as constants in this package: a
+// declared key is one autocomplete away from being stamped.
+func TestPackageDeclaresNoContentAttributeConstants(t *testing.T) {
+	declared := []string{
+		AttrGenAIOperationName, AttrGenAISystem, AttrGenAIRequestModel,
+		AttrGenAIRequestTemp, AttrGenAIRequestMaxTokens, AttrGenAIRequestTopP,
+		AttrGenAIRequestFreqPen, AttrGenAIRequestPresPen, AttrGenAIRequestStopSeqs,
+		AttrGenAIResponseID, AttrGenAIResponseModel, AttrGenAIResponseFinish,
+		AttrGenAIUsageIn, AttrGenAIUsageOut, AttrGenAIUsageTotal,
+		AttrGenAIUsageCacheRead, AttrGenAIUsageCacheCreate, AttrGenAIConversationID,
+	}
+	for _, key := range declared {
+		assert.NotContains(t, ForbiddenInternalSpanAttrs, key,
+			"this package declares a content-carrying key: %q", key)
+	}
+}

--- a/services/aigateway/adapters/gatewaytracer/internal_span_test.go
+++ b/services/aigateway/adapters/gatewaytracer/internal_span_test.go
@@ -2,7 +2,6 @@ package gatewaytracer
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +13,7 @@ import (
 )
 
 const (
-	secretPrompt     = "my database password is hunter2, summarise the attached patient record"
+	secretPrompt     = "my database password is hunter2, summarize the attached patient record"
 	secretCompletion = "Certainly — the patient record for Jane Doe indicates a diagnosis of"
 	secretSystem     = "You are an assistant for ACME Corp. The internal API key is sk-live-abc123."
 )
@@ -145,7 +144,7 @@ func TestStampInternalGenAI_ErrorTypeCarriesNoProviderText(t *testing.T) {
 		if string(kv.Key) != AttrErrorType {
 			continue
 		}
-		assert.False(t, strings.Contains(kv.Value.Emit(), " "),
+		assert.NotContains(t, kv.Value.Emit(), " ",
 			"error.type must stay a classifier token, not a message")
 	}
 }

--- a/services/aigateway/adapters/gatewaytracer/internal_span_test.go
+++ b/services/aigateway/adapters/gatewaytracer/internal_span_test.go
@@ -167,6 +167,42 @@ func TestStampInternalGenAI_ErrorTypeCarriesNoProviderText(t *testing.T) {
 	}
 }
 
+// The full key set is pinned, not just the forbidden keys: a new attribute on
+// the internal span has to show up in THIS list to land, which is the review
+// moment where "can it carry content?" gets asked. Forbidden-key checks alone
+// only catch the leaks someone already predicted.
+func TestStampInternalGenAI_StampsOnlyTheAllowedKeySet(t *testing.T) {
+	params := paramsWithBodies()
+	params.UpstreamErrorType = "provider_timeout"
+	params.UpstreamStatusCode = 504
+	params.Usage.CacheReadTokens = 12
+	params.Usage.CacheCreationTokens = 7
+
+	span := stampedSpan(t, params)
+
+	got := make([]string, 0, len(span.Attributes()))
+	for _, kv := range span.Attributes() {
+		got = append(got, string(kv.Key))
+	}
+	assert.ElementsMatch(t, []string{
+		AttrGenAIOperationName, AttrGenAISystem, AttrGenAIRequestModel,
+		AttrGenAIUsageIn, AttrGenAIUsageOut, AttrGenAIUsageTotal,
+		AttrGenAIUsageCacheRead, AttrGenAIUsageCacheCreate, AttrCostUSD,
+		AttrVirtualKeyID, AttrGatewayReqID,
+		AttrErrorType, AttrUpstreamStatusCode,
+	}, got, "the internal span's key set changed — review whether the new key can carry content before extending this list")
+}
+
+// Attributes are not the only channel out of a span: events and the status
+// description are free-text too, and neither is covered by an attribute-key
+// allowlist. The stamp must leave both untouched.
+func TestStampInternalGenAI_AddsNoEventsOrStatusText(t *testing.T) {
+	span := stampedSpan(t, paramsWithBodies())
+
+	assert.Empty(t, span.Events(), "span events would bypass the attribute allowlist")
+	assert.Empty(t, span.Status().Description, "status text would bypass the attribute allowlist")
+}
+
 // The content keys must not even exist as constants in this package: a
 // declared key is one autocomplete away from being stamped.
 func TestPackageDeclaresNoContentAttributeConstants(t *testing.T) {

--- a/services/aigateway/adapters/httpapi/middleware.go
+++ b/services/aigateway/adapters/httpapi/middleware.go
@@ -68,11 +68,22 @@ func TraceRegistryMiddleware(registry *customertracebridge.Registry, defaultEndp
 				return
 			}
 			if registry != nil {
+				// Both halves come from Config so they are always the pair the
+				// control plane materialised together. Bundle.ProjectID rides the
+				// auth JWT on a slower refresh clock; pairing it with the config's
+				// token exports one project's traces under another's ingest token.
+				traceProjectID := bundle.Config.TraceProjectID
+				if traceProjectID == "" && bundle.Config.ProjectOTLPToken != "" {
+					// Inconsistent payload: fail closed rather than guess an id.
+					// Guessing is what leaks; dropping only costs telemetry.
+					clog.Get(r.Context()).Warn("otlp_trace_project_missing",
+						zap.String("vk_id", bundle.VirtualKeyID))
+				}
 				if err := registry.SetFromBundle(
-					bundle.ProjectID, bundle.Config.ProjectOTLPToken, defaultEndpoint,
+					traceProjectID, bundle.Config.ProjectOTLPToken, defaultEndpoint,
 				); err != nil {
 					clog.Get(r.Context()).Warn("otlp_endpoint_rejected",
-						zap.String("project_id", bundle.ProjectID), zap.Error(err))
+						zap.String("project_id", traceProjectID), zap.Error(err))
 				}
 			}
 			next.ServeHTTP(w, r)

--- a/services/aigateway/adapters/httpapi/middleware.go
+++ b/services/aigateway/adapters/httpapi/middleware.go
@@ -69,7 +69,7 @@ func TraceRegistryMiddleware(registry *customertracebridge.Registry, defaultEndp
 			}
 			if registry != nil {
 				// Both halves come from Config so they are always the pair the
-				// control plane materialised together. Bundle.ProjectID rides the
+				// control plane materialized together. Bundle.ProjectID rides the
 				// auth JWT on a slower refresh clock; pairing it with the config's
 				// token exports one project's traces under another's ingest token.
 				traceProjectID := bundle.Config.TraceProjectID

--- a/services/aigateway/adapters/httpapi/middleware_trace_registry_test.go
+++ b/services/aigateway/adapters/httpapi/middleware_trace_registry_test.go
@@ -1,0 +1,42 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/aigateway/adapters/customertracebridge"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+func TestTraceRegistryMiddleware_PairsConfigProjectWithConfigToken(t *testing.T) {
+	registry := customertracebridge.NewRegistry()
+	bundle := &domain.Bundle{
+		ProjectID: "project-from-stale-jwt",
+		Config: domain.BundleConfig{
+			TraceProjectID:   "project-from-fresh-config",
+			ProjectOTLPToken: "token-from-fresh-config",
+		},
+	}
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	handler := TraceRegistryMiddleware(registry, "https://ingest.example.com")(next)
+	request := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	request = request.WithContext(context.WithValue(request.Context(), bundleCtxKey{}, bundle))
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+	endpoint, headers, ok := registry.Lookup("project-from-fresh-config")
+	require.True(t, ok)
+	assert.Equal(t, "https://ingest.example.com", endpoint)
+	assert.Equal(t, map[string]string{"X-Auth-Token": "token-from-fresh-config"}, headers)
+	_, _, staleRegistered := registry.Lookup("project-from-stale-jwt")
+	assert.False(t, staleRegistered, "the JWT project must never be paired with the config token")
+}

--- a/services/aigateway/app/pipeline/trace.go
+++ b/services/aigateway/app/pipeline/trace.go
@@ -49,7 +49,7 @@ func Trace(begin BeginSpanFunc, end EndSpanFunc) Interceptor {
 		Name: "traces",
 		Sync: func(next DispatchFunc) DispatchFunc {
 			return func(ctx context.Context, call *Call) (*domain.Response, error) {
-				spanCtx, tp := begin(ctx, call.Bundle.ProjectID, call.Request.Type)
+				spanCtx, tp := begin(ctx, call.Bundle.Config.TraceProjectID, call.Request.Type)
 				call.Meta.CustomerTraceparent = tp
 
 				resp, err := next(spanCtx, call)
@@ -91,7 +91,7 @@ func Trace(begin BeginSpanFunc, end EndSpanFunc) Interceptor {
 		},
 		Stream: func(next StreamFunc) StreamFunc {
 			return func(ctx context.Context, call *Call) (domain.StreamIterator, error) {
-				spanCtx, tp := begin(ctx, call.Bundle.ProjectID, call.Request.Type)
+				spanCtx, tp := begin(ctx, call.Bundle.Config.TraceProjectID, call.Request.Type)
 				call.Meta.CustomerTraceparent = tp
 
 				iter, err := next(spanCtx, call)

--- a/services/aigateway/app/pipeline/trace.go
+++ b/services/aigateway/app/pipeline/trace.go
@@ -51,6 +51,7 @@ func Trace(begin BeginSpanFunc, end EndSpanFunc) Interceptor {
 			return func(ctx context.Context, call *Call) (*domain.Response, error) {
 				spanCtx, tp := begin(ctx, call.Bundle.Config.TraceProjectID, call.Request.Type)
 				call.Meta.CustomerTraceparent = tp
+				internalModel, internalProviderID := internalTraceMetadata(call.Bundle.Config, call.Request.Model)
 
 				resp, err := next(spanCtx, call)
 				if err != nil {
@@ -63,6 +64,8 @@ func Trace(begin BeginSpanFunc, end EndSpanFunc) Interceptor {
 							ProjectID:          call.Bundle.ProjectID,
 							Model:              call.Request.Resolved.ModelID,
 							ProviderID:         call.Request.Resolved.ProviderID,
+							InternalModel:      internalModel,
+							InternalProviderID: internalProviderID,
 							RequestType:        call.Request.Type,
 							VirtualKeyID:       call.Bundle.VirtualKeyID,
 							GatewayRequestID:   call.Meta.GatewayRequestID,
@@ -75,15 +78,17 @@ func Trace(begin BeginSpanFunc, end EndSpanFunc) Interceptor {
 				}
 				if call.Request.Resolved != nil {
 					end(spanCtx, domain.AITraceParams{
-						ProjectID:        call.Bundle.ProjectID,
-						Model:            call.Request.Resolved.ModelID,
-						ProviderID:       call.Request.Resolved.ProviderID,
-						Usage:            resp.Usage,
-						RequestType:      call.Request.Type,
-						VirtualKeyID:     call.Bundle.VirtualKeyID,
-						GatewayRequestID: call.Meta.GatewayRequestID,
-						RequestBody:      call.Request.Body,
-						ResponseBody:     resp.Body,
+						ProjectID:          call.Bundle.ProjectID,
+						Model:              call.Request.Resolved.ModelID,
+						ProviderID:         call.Request.Resolved.ProviderID,
+						InternalModel:      internalModel,
+						InternalProviderID: internalProviderID,
+						Usage:              resp.Usage,
+						RequestType:        call.Request.Type,
+						VirtualKeyID:       call.Bundle.VirtualKeyID,
+						GatewayRequestID:   call.Meta.GatewayRequestID,
+						RequestBody:        call.Request.Body,
+						ResponseBody:       resp.Body,
 					})
 				}
 				return resp, nil
@@ -93,6 +98,7 @@ func Trace(begin BeginSpanFunc, end EndSpanFunc) Interceptor {
 			return func(ctx context.Context, call *Call) (domain.StreamIterator, error) {
 				spanCtx, tp := begin(ctx, call.Bundle.Config.TraceProjectID, call.Request.Type)
 				call.Meta.CustomerTraceparent = tp
+				internalModel, internalProviderID := internalTraceMetadata(call.Bundle.Config, call.Request.Model)
 
 				iter, err := next(spanCtx, call)
 				if err != nil {
@@ -105,6 +111,8 @@ func Trace(begin BeginSpanFunc, end EndSpanFunc) Interceptor {
 							ProjectID:          call.Bundle.ProjectID,
 							Model:              call.Request.Resolved.ModelID,
 							ProviderID:         call.Request.Resolved.ProviderID,
+							InternalModel:      internalModel,
+							InternalProviderID: internalProviderID,
 							RequestType:        call.Request.Type,
 							VirtualKeyID:       call.Bundle.VirtualKeyID,
 							GatewayRequestID:   call.Meta.GatewayRequestID,
@@ -119,16 +127,33 @@ func Trace(begin BeginSpanFunc, end EndSpanFunc) Interceptor {
 					return iter, nil
 				}
 				return &traceStreamWrapper{
-					inner:   iter,
-					end:     end,
-					bundle:  call.Bundle,
-					req:     call.Request,
-					meta:    call.Meta,
-					spanCtx: spanCtx,
+					inner:              iter,
+					end:                end,
+					bundle:             call.Bundle,
+					req:                call.Request,
+					meta:               call.Meta,
+					spanCtx:            spanCtx,
+					internalModel:      internalModel,
+					internalProviderID: internalProviderID,
 				}, nil
 			}
 		},
 	}
+}
+
+// internalTraceMetadata selects model metadata that is safe for LangWatch's
+// operational span. A raw request model is arbitrary customer input unless it
+// exactly names a control-plane alias or a finite allowed-model entry.
+func internalTraceMetadata(config domain.BundleConfig, rawModel string) (string, domain.ProviderID) {
+	if alias, ok := config.ModelAliases[rawModel]; ok {
+		return alias.Model, alias.ProviderID
+	}
+	for _, allowed := range config.AllowedModels {
+		if allowed == rawModel {
+			return allowed, ""
+		}
+	}
+	return "", ""
 }
 
 // responseBodyCap bounds the per-stream response accumulator at 8 MiB so a
@@ -146,16 +171,18 @@ const responseBodyCap = 8 * 1024 * 1024
 // extractOutputMessages return "" for every streamed Path A trace — the
 // gen_ai.output.messages key was simply absent from every streaming span.
 type traceStreamWrapper struct {
-	inner       domain.StreamIterator
-	end         EndSpanFunc
-	bundle      *domain.Bundle
-	req         *domain.Request
-	meta        *Meta
-	spanCtx     context.Context
-	closeOnce   sync.Once
-	bodyMu      sync.Mutex
-	body        []byte
-	bodyDropped bool
+	inner              domain.StreamIterator
+	end                EndSpanFunc
+	bundle             *domain.Bundle
+	req                *domain.Request
+	meta               *Meta
+	spanCtx            context.Context
+	internalModel      string
+	internalProviderID domain.ProviderID
+	closeOnce          sync.Once
+	bodyMu             sync.Mutex
+	body               []byte
+	bodyDropped        bool
 }
 
 func (w *traceStreamWrapper) Next(ctx context.Context) bool {
@@ -233,6 +260,8 @@ func (w *traceStreamWrapper) onClose() {
 				ProjectID:          w.bundle.ProjectID,
 				Model:              w.req.Resolved.ModelID,
 				ProviderID:         w.req.Resolved.ProviderID,
+				InternalModel:      w.internalModel,
+				InternalProviderID: w.internalProviderID,
 				Usage:              w.inner.Usage(),
 				RequestType:        w.req.Type,
 				VirtualKeyID:       w.bundle.VirtualKeyID,

--- a/services/aigateway/app/pipeline/trace.go
+++ b/services/aigateway/app/pipeline/trace.go
@@ -182,7 +182,7 @@ type traceStreamWrapper struct {
 	closeOnce          sync.Once
 	bodyMu             sync.Mutex
 	body               []byte
-	bodyDropped        bool
+	isBodyDropped      bool
 }
 
 func (w *traceStreamWrapper) Next(ctx context.Context) bool {
@@ -201,7 +201,7 @@ func (w *traceStreamWrapper) Err() error          { return w.inner.Err() }
 // captureChunk appends chunk to the body accumulator under the cap.
 // Called from Next() after the inner iterator advances, so we capture
 // exactly once per chunk regardless of how many times the caller reads
-// Chunk(). bodyDropped flips once we've truncated so onClose can stamp
+// Chunk(). isBodyDropped flips once we've truncated so onClose can stamp
 // a langwatch.reserved.trace_body_truncated marker downstream.
 func (w *traceStreamWrapper) captureChunk(chunk []byte) {
 	if len(chunk) == 0 {
@@ -209,17 +209,17 @@ func (w *traceStreamWrapper) captureChunk(chunk []byte) {
 	}
 	w.bodyMu.Lock()
 	defer w.bodyMu.Unlock()
-	if w.bodyDropped {
+	if w.isBodyDropped {
 		return
 	}
 	remaining := responseBodyCap - len(w.body)
 	if remaining <= 0 {
-		w.bodyDropped = true
+		w.isBodyDropped = true
 		return
 	}
 	if len(chunk) > remaining {
 		w.body = append(w.body, chunk[:remaining]...)
-		w.bodyDropped = true
+		w.isBodyDropped = true
 		return
 	}
 	w.body = append(w.body, chunk...)

--- a/services/aigateway/app/pipeline/trace_project_test.go
+++ b/services/aigateway/app/pipeline/trace_project_test.go
@@ -66,3 +66,25 @@ func TestTraceBeginsSyncAndStreamSpansUnderConfigProject(t *testing.T) {
 		assert.Equal(t, "project-from-fresh-config", beganFor)
 	})
 }
+
+func TestInternalTraceMetadataOnlyUsesConfiguredValues(t *testing.T) {
+	model, provider := internalTraceMetadata(domain.BundleConfig{
+		ModelAliases: map[string]domain.ModelAlias{
+			"safe-alias": {Model: "gpt-5-mini", ProviderID: domain.ProviderOpenAI},
+		},
+	}, "safe-alias")
+	assert.Equal(t, "gpt-5-mini", model)
+	assert.Equal(t, domain.ProviderOpenAI, provider)
+
+	model, provider = internalTraceMetadata(domain.BundleConfig{
+		AllowedModels: []string{"gpt-5-mini", "claude-*"},
+	}, "gpt-5-mini")
+	assert.Equal(t, "gpt-5-mini", model)
+	assert.Empty(t, provider)
+
+	model, provider = internalTraceMetadata(domain.BundleConfig{
+		AllowedModels: []string{"gpt-*"},
+	}, "customer-secret-in-model-field")
+	assert.Empty(t, model)
+	assert.Empty(t, provider)
+}

--- a/services/aigateway/app/pipeline/trace_project_test.go
+++ b/services/aigateway/app/pipeline/trace_project_test.go
@@ -1,0 +1,68 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+func TestTraceBeginsSyncAndStreamSpansUnderConfigProject(t *testing.T) {
+	bundle := &domain.Bundle{
+		ProjectID: "project-from-stale-jwt",
+		Config: domain.BundleConfig{
+			TraceProjectID:   "project-from-fresh-config",
+			ProjectOTLPToken: "token-from-fresh-config",
+		},
+	}
+	request := &domain.Request{Type: domain.RequestTypeChat}
+
+	t.Run("sync", func(t *testing.T) {
+		var beganFor string
+		interceptor := Trace(
+			func(ctx context.Context, projectID string, _ domain.RequestType) (context.Context, string) {
+				beganFor = projectID
+				return ctx, "traceparent"
+			},
+			func(context.Context, domain.AITraceParams) {},
+		)
+		next := func(context.Context, *Call) (*domain.Response, error) {
+			return &domain.Response{}, nil
+		}
+
+		_, err := interceptor.Sync(next)(context.Background(), &Call{
+			Bundle:  bundle,
+			Request: request,
+			Meta:    &Meta{},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "project-from-fresh-config", beganFor)
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		var beganFor string
+		interceptor := Trace(
+			func(ctx context.Context, projectID string, _ domain.RequestType) (context.Context, string) {
+				beganFor = projectID
+				return ctx, "traceparent"
+			},
+			func(context.Context, domain.AITraceParams) {},
+		)
+		next := func(context.Context, *Call) (domain.StreamIterator, error) {
+			return newChunkedStub(nil), nil
+		}
+
+		_, err := interceptor.Stream(next)(context.Background(), &Call{
+			Bundle:  bundle,
+			Request: request,
+			Meta:    &Meta{},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "project-from-fresh-config", beganFor)
+	})
+}

--- a/services/aigateway/cmd/root.go
+++ b/services/aigateway/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/langwatch/langwatch/pkg/contexts"
 	"github.com/langwatch/langwatch/services/aigateway"
+	"github.com/langwatch/langwatch/services/aigateway/adapters/gatewaytracer"
 	"github.com/langwatch/langwatch/services/aigateway/app"
 )
 
@@ -35,7 +36,9 @@ func Root(ctx context.Context, _ []string) error {
 		app.WithPolicy(deps.Policy),
 		app.WithCache(deps.Cache),
 		app.WithModels(deps.Models),
-		app.WithTraces(deps.TraceBridge),
+		// Wrapped so the gateway's own span gets the model/usage/outcome
+		// metadata too — content stays on the customer-bound span only.
+		app.WithTraces(gatewaytracer.WithInternalStamping(deps.TraceBridge)),
 		app.WithLogger(deps.Logger),
 	)
 

--- a/services/aigateway/config.go
+++ b/services/aigateway/config.go
@@ -98,6 +98,9 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	}
 	// Apply environment-aware sample ratio default when not explicitly set.
 	cfg.OTel.ResolveSampleRatio(cfg.Environment)
+	if err := cfg.OTel.Validate(); err != nil {
+		return Config{}, err
+	}
 	if err := config.Validate(ctx, cfg); err != nil {
 		return Config{}, err
 	}

--- a/services/aigateway/config.go
+++ b/services/aigateway/config.go
@@ -96,9 +96,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	if cfg.CustomerTraceBridge.BaseURL == "" {
 		cfg.CustomerTraceBridge.BaseURL = cfg.ControlPlane.BaseURL
 	}
-	// Apply environment-aware sample ratio default when not explicitly set.
-	cfg.OTel.ResolveSampleRatio(cfg.Environment)
-	if err := cfg.OTel.Validate(); err != nil {
+	if err := cfg.OTel.Resolve(cfg.Environment); err != nil {
 		return Config{}, err
 	}
 	if err := config.Validate(ctx, cfg); err != nil {

--- a/services/aigateway/config.go
+++ b/services/aigateway/config.go
@@ -71,7 +71,9 @@ func defaultConfig() Config {
 			BaseURL: "http://localhost:5560",
 		},
 		OTel: config.OTel{
-			SampleRatio: 1.0, // overridden to 0.1 for non-local in LoadConfig
+			// Left unset so an operator-supplied ratio is distinguishable from
+			// the default; resolved in LoadConfig.
+			SampleRatio: config.UnsetSampleRatio,
 		},
 	}
 }
@@ -94,9 +96,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 		cfg.CustomerTraceBridge.BaseURL = cfg.ControlPlane.BaseURL
 	}
 	// Apply environment-aware sample ratio default when not explicitly set.
-	if cfg.OTel.SampleRatio == 1.0 && cfg.Environment != "local" {
-		cfg.OTel.SampleRatio = 0.1
-	}
+	cfg.OTel.ResolveSampleRatio(cfg.Environment)
 	if err := config.Validate(ctx, cfg); err != nil {
 		return Config{}, err
 	}

--- a/services/aigateway/config.go
+++ b/services/aigateway/config.go
@@ -91,6 +91,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	if err := config.Hydrate(&cfg); err != nil {
 		return Config{}, err
 	}
+	cfg.OTel.SampleRatioSet = os.Getenv("OTEL_SAMPLE_RATIO") != ""
 	applyLegacyEnvAliases(&cfg)
 	if cfg.CustomerTraceBridge.BaseURL == "" {
 		cfg.CustomerTraceBridge.BaseURL = cfg.ControlPlane.BaseURL

--- a/services/aigateway/config_test.go
+++ b/services/aigateway/config_test.go
@@ -114,6 +114,40 @@ func TestLoadConfig_CanonicalBeatsLegacy(t *testing.T) {
 	}
 }
 
+// The official OpenTelemetry name is the canonical way in; the LangWatch-only
+// OTEL_OTLP_ENDPOINT and the chart-era GATEWAY_OTEL_DEFAULT_ENDPOINT stay as
+// deprecated fallbacks behind it.
+func TestLoadConfig_OfficialOTelEndpointIsHonoured(t *testing.T) {
+	clearGatewayEnv(t)
+	t.Setenv("LW_GATEWAY_INTERNAL_SECRET", "internal-1")
+	t.Setenv("LW_GATEWAY_JWT_SECRET", "jwt-1")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://official.otel.example.com")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	base, _ := cfg.OTel.PrimaryOTLP()
+	if base != "http://official.otel.example.com" {
+		t.Errorf("PrimaryOTLP base = %q, want the official env var's value", base)
+	}
+}
+
+// Both names live with different values is ambiguity — whichever silent
+// precedence pick is wrong ships telemetry to the wrong place with no error
+// anywhere, so boot refuses instead.
+func TestLoadConfig_RefusesConflictingOTelEndpointNames(t *testing.T) {
+	clearGatewayEnv(t)
+	t.Setenv("LW_GATEWAY_INTERNAL_SECRET", "internal-1")
+	t.Setenv("LW_GATEWAY_JWT_SECRET", "jwt-1")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://official.otel.example.com")
+	t.Setenv("OTEL_OTLP_ENDPOINT", "http://legacy.otel.example.com")
+
+	if _, err := LoadConfig(context.Background()); err == nil {
+		t.Fatal("expected LoadConfig to reject two different endpoint values")
+	}
+}
+
 // clearGatewayEnv unsets every env var the alias layer or Hydrate inspects,
 // so each test starts from a clean slate. t.Setenv handles per-test scope on
 // what we explicitly set; this clears the bleed-through from the harness env.
@@ -134,6 +168,19 @@ func clearGatewayEnv(t *testing.T) {
 		"OTEL_OTLP_ENDPOINT",
 		"OTEL_OTLP_HEADERS",
 		"OTEL_SAMPLE_RATIO",
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_HEADERS",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_PROTOCOL",
+		"OTEL_TRACES_SAMPLER",
+		"OTEL_TRACES_SAMPLER_ARG",
+		"OTEL_TRACES_EXPORTER",
+		"OTEL_SDK_DISABLED",
+		"OTEL_DEBUG_COLLECTOR_ENDPOINT",
+		"OTEL_DEBUG_COLLECTOR_HEADERS",
 		"ENVIRONMENT",
 		"BLOCK_LOCAL_HTTP_CALLS",
 		"REQUIRE_HTTPS_CUSTOM_ENDPOINTS",

--- a/services/aigateway/deps.go
+++ b/services/aigateway/deps.go
@@ -194,12 +194,12 @@ func (a changePollerAdapter) PollChanges(ctx context.Context, organizationID, si
 	out := make([]authresolver.CacheChange, len(cs))
 	for i, c := range cs {
 		out[i] = authresolver.CacheChange{
-			Kind:                 c.Kind,
-			VirtualKeyID:         c.VirtualKeyID,
-			BudgetID:             c.BudgetID,
-			ProviderCredentialID: c.ProviderCredentialID,
-			ProjectID:            c.ProjectID,
-			Revision:             c.Revision,
+			Kind:            c.Kind,
+			VirtualKeyID:    c.VirtualKeyID,
+			BudgetID:        c.BudgetID,
+			ModelProviderID: c.ModelProviderID,
+			ProjectID:       c.ProjectID,
+			Revision:        c.Revision,
 		}
 	}
 	return out, next, nil

--- a/services/aigateway/domain/bundle.go
+++ b/services/aigateway/domain/bundle.go
@@ -49,7 +49,20 @@ type BundleConfig struct {
 	// CacheRules lists priority-ordered cache control rules.
 	CacheRules []CacheRule
 
-	// ProjectOTLPToken is the project's auth token for AI trace export.
+	// TraceProjectID is the project customer traces are EXPORTED to. It is NOT
+	// necessarily the VK's own project: resolveTraceProject (control plane) falls
+	// back to the organization's internal_governance project whenever the VK is
+	// not scoped to exactly one project, so this can name a different project on
+	// a different team than Bundle.ProjectID.
+	//
+	// It is materialised in the SAME config payload as ProjectOTLPToken, so the
+	// two always describe one project. Pair the token with THIS field and never
+	// with Bundle.ProjectID: that one is carried on the auth JWT, refreshed on a
+	// different clock, and a skew between the two clocks exports one project's
+	// prompts and completions under another project's ingest token.
+	TraceProjectID string
+
+	// ProjectOTLPToken is the auth token for AI trace export into TraceProjectID.
 	ProjectOTLPToken string
 
 	// VKDisplayPrefix is the VK's public display prefix (e.g. "vk-lw-…").

--- a/services/aigateway/domain/bundle.go
+++ b/services/aigateway/domain/bundle.go
@@ -55,7 +55,7 @@ type BundleConfig struct {
 	// not scoped to exactly one project, so this can name a different project on
 	// a different team than Bundle.ProjectID.
 	//
-	// It is materialised in the SAME config payload as ProjectOTLPToken, so the
+	// It is materialized in the SAME config payload as ProjectOTLPToken, so the
 	// two always describe one project. Pair the token with THIS field and never
 	// with Bundle.ProjectID: that one is carried on the auth JWT, refreshed on a
 	// different clock, and a skew between the two clocks exports one project's

--- a/services/aigateway/domain/verdict.go
+++ b/services/aigateway/domain/verdict.go
@@ -32,11 +32,17 @@ type CacheDecision struct {
 
 // AITraceParams holds data for a customer AI trace.
 type AITraceParams struct {
-	ProjectID   string
-	Model       string
-	ProviderID  ProviderID
-	Usage       Usage
-	RequestType RequestType
+	ProjectID  string
+	Model      string
+	ProviderID ProviderID
+	// InternalModel and InternalProviderID are safe to copy to LangWatch's
+	// operational span because they came from manager-owned gateway config.
+	// Model and ProviderID above remain customer-trace fields: callers can
+	// control them when a virtual key permits arbitrary model names.
+	InternalModel      string
+	InternalProviderID ProviderID
+	Usage              Usage
+	RequestType        RequestType
 
 	// VirtualKeyID is the id of the VK that authorized this request. Stamped
 	// on the customer span so the control plane's trace-processing pipeline

--- a/services/langyagent/adapters/otelrelay/dual_export_test.go
+++ b/services/langyagent/adapters/otelrelay/dual_export_test.go
@@ -1,0 +1,155 @@
+package otelrelay
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+const workerSecret = "my api key is sk-live-abc123 and the patient is Jane Doe"
+
+// signallingIngest records one OTLP body and announces its arrival, so a test
+// can wait on the detached internal export instead of sleeping.
+type signallingIngest struct {
+	srv  *httptest.Server
+	got  chan []byte
+	auth chan string
+}
+
+func startSignallingIngest(t *testing.T) *signallingIngest {
+	t.Helper()
+	si := &signallingIngest{got: make(chan []byte, 4), auth: make(chan string, 4)}
+	si.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		si.got <- body
+		si.auth <- req.Header.Get("X-Auth-Token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(si.srv.Close)
+	return si
+}
+
+func (s *signallingIngest) await(t *testing.T) []byte {
+	t.Helper()
+	select {
+	case body := <-s.got:
+		return body
+	case <-time.After(3 * time.Second):
+		t.Fatal("no export arrived")
+		return nil
+	}
+}
+
+// contentBatch is a worker batch whose spans carry prompt/completion bodies.
+func contentBatch(t *testing.T) []byte {
+	t.Helper()
+	td := ptrace.NewTraces()
+	ss := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("llm.call")
+	span.SetTraceID(pcommon.TraceID{9})
+	span.SetSpanID(pcommon.SpanID{1})
+	span.Attributes().PutStr("gen_ai.request.model", "gpt-5-mini")
+	span.Attributes().PutStr("gen_ai.input.messages", workerSecret)
+
+	payload, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return payload
+}
+
+func relayWithInternal(t *testing.T, internalURL string) *Relay {
+	t.Helper()
+	r, err := New(context.Background(), Options{InternalOTLPEndpoint: internalURL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = r.Shutdown(ctx)
+	})
+	return r
+}
+
+func TestDualExport(t *testing.T) {
+	t.Run("when a worker exports spans carrying prompt content", func(t *testing.T) {
+		customer := startSignallingIngest(t)
+		internal := startSignallingIngest(t)
+		relay := relayWithInternal(t, internal.srv.URL)
+
+		token, err := relay.Register(WorkerInfo{
+			ConversationID:    "conv-1",
+			LangwatchEndpoint: customer.srv.URL,
+			LangwatchAPIKey:   "sk-session",
+		})
+		if err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+
+		resp, err := http.Post(
+			relay.OTLPEndpointFor(token)+"/v1/traces",
+			"application/x-protobuf",
+			bytes.NewReader(contentBatch(t)),
+		)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("relay answered %d", resp.StatusCode)
+		}
+
+		t.Run("the customer's project receives the content", func(t *testing.T) {
+			if !bytes.Contains(customer.await(t), []byte(workerSecret)) {
+				t.Fatal("the customer's own agent output must reach their project")
+			}
+		})
+
+		t.Run("LangWatch's own collector receives none of it", func(t *testing.T) {
+			body := internal.await(t)
+			if bytes.Contains(body, []byte(workerSecret)) {
+				t.Fatal("worker prompt content reached LangWatch's internal collector")
+			}
+			if !bytes.Contains(body, []byte("gpt-5-mini")) {
+				t.Fatal("operational metadata was stripped along with the content")
+			}
+		})
+	})
+
+	t.Run("when no internal collector is configured", func(t *testing.T) {
+		customer := startSignallingIngest(t)
+		relay := relayWithInternal(t, "")
+
+		token, err := relay.Register(WorkerInfo{
+			ConversationID:    "conv-2",
+			LangwatchEndpoint: customer.srv.URL,
+			LangwatchAPIKey:   "sk-session",
+		})
+		if err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+
+		resp, err := http.Post(
+			relay.OTLPEndpointFor(token)+"/v1/traces",
+			"application/x-protobuf",
+			bytes.NewReader(contentBatch(t)),
+		)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if !bytes.Contains(customer.await(t), []byte(workerSecret)) {
+			t.Fatal("the customer path must be unaffected by the second export being off")
+		}
+	})
+}

--- a/services/langyagent/adapters/otelrelay/dual_export_test.go
+++ b/services/langyagent/adapters/otelrelay/dual_export_test.go
@@ -25,23 +25,26 @@ const (
 // signallingIngest records one OTLP body and announces its arrival, so a test
 // can wait on the detached internal export instead of sleeping.
 type signallingIngest struct {
-	srv  *httptest.Server
-	got  chan []byte
-	auth chan string
-	path chan string
+	srv   *httptest.Server
+	got   chan []byte
+	auth  chan string
+	authz chan string
+	path  chan string
 }
 
 func startSignallingIngest(t *testing.T) *signallingIngest {
 	t.Helper()
 	si := &signallingIngest{
-		got:  make(chan []byte, 4),
-		auth: make(chan string, 4),
-		path: make(chan string, 4),
+		got:   make(chan []byte, 4),
+		auth:  make(chan string, 4),
+		authz: make(chan string, 4),
+		path:  make(chan string, 4),
 	}
 	si.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		body, _ := io.ReadAll(req.Body)
 		si.got <- body
 		si.auth <- req.Header.Get("X-Auth-Token")
+		si.authz <- req.Header.Get("Authorization")
 		si.path <- req.URL.Path
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -139,6 +142,15 @@ func TestDualExport(t *testing.T) {
 					t.Fatalf("the customer's own agent content %q must reach their project", content)
 				}
 			}
+			if got := <-customer.authz; got != "Bearer sk-session" {
+				t.Fatalf("customer forward Authorization = %q, want the session key", got)
+			}
+			if got := <-customer.auth; got != "" {
+				t.Fatalf("LangWatch's internal collector credential crossed onto the customer forward: X-Auth-Token=%q", got)
+			}
+			if got := <-customer.path; got != "/api/otel/v1/traces" {
+				t.Fatalf("customer path = %q", got)
+			}
 		})
 
 		t.Run("LangWatch's own collector receives none of it", func(t *testing.T) {
@@ -153,6 +165,9 @@ func TestDualExport(t *testing.T) {
 			}
 			if got := <-internal.auth; got != "internal-secret" {
 				t.Fatalf("internal auth header = %q", got)
+			}
+			if got := <-internal.authz; got != "" {
+				t.Fatalf("the customer's session key crossed onto the internal export: Authorization=%q", got)
 			}
 			if got := <-internal.path; got != "/v1/traces" {
 				t.Fatalf("internal path = %q", got)

--- a/services/langyagent/adapters/otelrelay/dual_export_test.go
+++ b/services/langyagent/adapters/otelrelay/dual_export_test.go
@@ -205,6 +205,54 @@ func TestDualExport(t *testing.T) {
 	})
 }
 
+// The worker is a model-driven, prompt-injectable process. Whatever it puts in
+// its OTLP resource, it must not be able to brand its spans with LangWatch's
+// provenance marker in the customer's project — ingest-side enforcement keyed
+// on langwatch.origin must never trust a worker-supplied value.
+func TestCustomerForwardStripsForgedOriginMarker(t *testing.T) {
+	customer := startSignallingIngest(t)
+	relay := relayWithInternal(t, "")
+
+	token, err := relay.Register(WorkerInfo{
+		ConversationID:    "conv-forge",
+		LangwatchEndpoint: customer.srv.URL,
+		LangwatchAPIKey:   "sk-session",
+		Model:             "gpt-5-mini",
+	})
+	require.NoError(t, err)
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("langwatch.origin", "platform_internal")
+	rs.Resource().Attributes().PutStr("service.name", "opencode")
+	span := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("forged")
+	span.SetTraceID(pcommon.TraceID{7})
+	span.SetSpanID(pcommon.SpanID{2})
+	payload, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
+	require.NoError(t, err)
+
+	resp, err := http.Post(
+		relay.OTLPEndpointFor(token)+"/v1/traces",
+		"application/x-protobuf",
+		bytes.NewReader(payload),
+	)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	forwarded, err := (&ptrace.ProtoUnmarshaler{}).UnmarshalTraces(customer.await(t))
+	require.NoError(t, err)
+	require.Equal(t, 1, forwarded.ResourceSpans().Len())
+	attrs := forwarded.ResourceSpans().At(0).Resource().Attributes()
+	if _, found := attrs.Get("langwatch.origin"); found {
+		t.Fatal("a worker-forged langwatch.origin survived onto the customer forward")
+	}
+	serviceName, ok := attrs.Get("service.name")
+	require.True(t, ok)
+	assert.Equal(t, "opencode", serviceName.Str(), "legitimate worker resource attributes must survive the strip")
+}
+
 func TestInternalExportIsBoundedDuringCollectorOutage(t *testing.T) {
 	started := make(chan struct{}, internalExportWorkers+1)
 	release := make(chan struct{})

--- a/services/langyagent/adapters/otelrelay/dual_export_test.go
+++ b/services/langyagent/adapters/otelrelay/dual_export_test.go
@@ -16,7 +16,11 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-const workerSecret = "my api key is sk-live-abc123 and the patient is Jane Doe"
+const (
+	workerPrompt     = "my api key is sk-live-abc123 and the patient is Jane Doe"
+	workerCompletion = "the patient record has been summarized"
+	workerToolOutput = "tool result: customer database backup is complete"
+)
 
 // signallingIngest records one OTLP body and announces its arrival, so a test
 // can wait on the detached internal export instead of sleeping.
@@ -66,7 +70,9 @@ func contentBatch(t *testing.T) []byte {
 	span.SetTraceID(pcommon.TraceID{9})
 	span.SetSpanID(pcommon.SpanID{1})
 	span.Attributes().PutStr("gen_ai.request.model", "gpt-5-mini")
-	span.Attributes().PutStr("gen_ai.input.messages", workerSecret)
+	span.Attributes().PutStr("gen_ai.input.messages", workerPrompt)
+	span.Attributes().PutStr("gen_ai.output.messages", workerCompletion)
+	span.Attributes().PutStr("gen_ai.tool.result", workerToolOutput)
 
 	payload, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
 	if err != nil {
@@ -127,15 +133,20 @@ func TestDualExport(t *testing.T) {
 		}
 
 		t.Run("the customer's project receives the content", func(t *testing.T) {
-			if !bytes.Contains(customer.await(t), []byte(workerSecret)) {
-				t.Fatal("the customer's own agent output must reach their project")
+			body := customer.await(t)
+			for _, content := range []string{workerPrompt, workerCompletion, workerToolOutput} {
+				if !bytes.Contains(body, []byte(content)) {
+					t.Fatalf("the customer's own agent content %q must reach their project", content)
+				}
 			}
 		})
 
 		t.Run("LangWatch's own collector receives none of it", func(t *testing.T) {
 			body := internal.await(t)
-			if bytes.Contains(body, []byte(workerSecret)) {
-				t.Fatal("worker prompt content reached LangWatch's internal collector")
+			for _, content := range []string{workerPrompt, workerCompletion, workerToolOutput} {
+				if bytes.Contains(body, []byte(content)) {
+					t.Fatalf("worker content %q reached LangWatch's internal collector", content)
+				}
 			}
 			if !bytes.Contains(body, []byte("gpt-5-mini")) {
 				t.Fatal("operational metadata was stripped along with the content")
@@ -173,7 +184,7 @@ func TestDualExport(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		if !bytes.Contains(customer.await(t), []byte(workerSecret)) {
+		if !bytes.Contains(customer.await(t), []byte(workerPrompt)) {
 			t.Fatal("the customer path must be unaffected by the second export being off")
 		}
 	})

--- a/services/langyagent/adapters/otelrelay/dual_export_test.go
+++ b/services/langyagent/adapters/otelrelay/dual_export_test.go
@@ -6,9 +6,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
@@ -21,15 +24,21 @@ type signallingIngest struct {
 	srv  *httptest.Server
 	got  chan []byte
 	auth chan string
+	path chan string
 }
 
 func startSignallingIngest(t *testing.T) *signallingIngest {
 	t.Helper()
-	si := &signallingIngest{got: make(chan []byte, 4), auth: make(chan string, 4)}
+	si := &signallingIngest{
+		got:  make(chan []byte, 4),
+		auth: make(chan string, 4),
+		path: make(chan string, 4),
+	}
 	si.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		body, _ := io.ReadAll(req.Body)
 		si.got <- body
 		si.auth <- req.Header.Get("X-Auth-Token")
+		si.path <- req.URL.Path
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(si.srv.Close)
@@ -68,7 +77,12 @@ func contentBatch(t *testing.T) []byte {
 
 func relayWithInternal(t *testing.T, internalURL string) *Relay {
 	t.Helper()
-	r, err := New(context.Background(), Options{InternalOTLPEndpoint: internalURL})
+	return relayWithOptions(t, Options{InternalOTLPEndpoint: internalURL})
+}
+
+func relayWithOptions(t *testing.T, options Options) *Relay {
+	t.Helper()
+	r, err := New(context.Background(), options)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -84,12 +98,16 @@ func TestDualExport(t *testing.T) {
 	t.Run("when a worker exports spans carrying prompt content", func(t *testing.T) {
 		customer := startSignallingIngest(t)
 		internal := startSignallingIngest(t)
-		relay := relayWithInternal(t, internal.srv.URL)
+		relay := relayWithOptions(t, Options{
+			InternalOTLPEndpoint: internal.srv.URL,
+			InternalOTLPHeaders:  map[string]string{"X-Auth-Token": "internal-secret"},
+		})
 
 		token, err := relay.Register(WorkerInfo{
 			ConversationID:    "conv-1",
 			LangwatchEndpoint: customer.srv.URL,
 			LangwatchAPIKey:   "sk-session",
+			Model:             "gpt-5-mini",
 		})
 		if err != nil {
 			t.Fatalf("Register: %v", err)
@@ -122,6 +140,12 @@ func TestDualExport(t *testing.T) {
 			if !bytes.Contains(body, []byte("gpt-5-mini")) {
 				t.Fatal("operational metadata was stripped along with the content")
 			}
+			if got := <-internal.auth; got != "internal-secret" {
+				t.Fatalf("internal auth header = %q", got)
+			}
+			if got := <-internal.path; got != "/v1/traces" {
+				t.Fatalf("internal path = %q", got)
+			}
 		})
 	})
 
@@ -133,6 +157,7 @@ func TestDualExport(t *testing.T) {
 			ConversationID:    "conv-2",
 			LangwatchEndpoint: customer.srv.URL,
 			LangwatchAPIKey:   "sk-session",
+			Model:             "gpt-5-mini",
 		})
 		if err != nil {
 			t.Fatalf("Register: %v", err)
@@ -152,4 +177,63 @@ func TestDualExport(t *testing.T) {
 			t.Fatal("the customer path must be unaffected by the second export being off")
 		}
 	})
+}
+
+func TestInternalExportIsBoundedDuringCollectorOutage(t *testing.T) {
+	started := make(chan struct{}, internalExportWorkers+1)
+	release := make(chan struct{})
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		started <- struct{}{}
+		select {
+		case <-release:
+			w.WriteHeader(http.StatusOK)
+		case <-req.Context().Done():
+		}
+	}))
+	t.Cleanup(internal.Close)
+
+	var customerRequests atomic.Int64
+	customer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		customerRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(customer.Close)
+
+	relay := relayWithInternal(t, internal.URL)
+	token, err := relay.Register(WorkerInfo{
+		ConversationID:    "conv-outage",
+		LangwatchEndpoint: customer.URL,
+		LangwatchAPIKey:   "sk-session",
+		Model:             "gpt-5-mini",
+	})
+	require.NoError(t, err)
+
+	total := internalExportWorkers + internalExportQueueSize + 6
+	payload := contentBatch(t)
+	for range total {
+		resp, postErr := http.Post(
+			relay.OTLPEndpointFor(token)+"/v1/traces",
+			"application/x-protobuf",
+			bytes.NewReader(payload),
+		)
+		require.NoError(t, postErr)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	for range internalExportWorkers {
+		select {
+		case <-started:
+		case <-time.After(3 * time.Second):
+			t.Fatal("internal export worker did not start")
+		}
+	}
+	select {
+	case <-started:
+		t.Fatalf("more than %d internal exports ran concurrently", internalExportWorkers)
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.Equal(t, int64(total), customerRequests.Load(), "internal outage delayed customer forwarding")
+	assert.LessOrEqual(t, len(relay.internalJobs), internalExportQueueSize)
+	close(release)
 }

--- a/services/langyagent/adapters/otelrelay/otelrelay.go
+++ b/services/langyagent/adapters/otelrelay/otelrelay.go
@@ -35,10 +35,12 @@
 package otelrelay
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -48,6 +50,10 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -64,12 +70,25 @@ const maxOTLPBodyBytes = 16 * 1024 * 1024
 // a slow customer ingest must not pile up relay handlers.
 const forwardTimeout = 30 * time.Second
 
+// Internal exports are deliberately small and bounded. At the maximum accepted
+// OTLP body size this caps retained queued payloads at 128 MiB, plus at most two
+// in-flight requests. When full, internal observability is dropped so customer
+// forwarding keeps its memory and latency budget.
+const (
+	internalExportQueueSize = 8
+	internalExportWorkers   = 2
+)
+
 // WorkerInfo is everything the relay needs to mediate one worker's telemetry
 // and LLM traffic. Captured at spawn (the only moment the manager sees the
 // credentials) and dropped at Unregister.
 type WorkerInfo struct {
 	ConversationID    string
 	LangwatchEndpoint string
+	// Model comes from manager-owned worker configuration. The relay uses this
+	// trusted value in LangWatch's internal trace instead of the worker-supplied
+	// OTLP model attribute, which is an arbitrary string and may carry content.
+	Model string
 	// LangwatchAPIKey authenticates the trace forward into the customer's
 	// project. Held by the relay, never by the worker.
 	LangwatchAPIKey string
@@ -144,9 +163,21 @@ type Relay struct {
 	// entirely — the customer path is unaffected either way.
 	internalEndpoint string
 	internalHeaders  map[string]string
+	internalCtx      context.Context
+	internalCancel   context.CancelFunc
+	internalJobs     chan internalExportJob
+	internalWG       sync.WaitGroup
+	internalDropped  metric.Int64Counter
 
 	mu      sync.Mutex
 	workers map[string]*workerEntry
+}
+
+type internalExportJob struct {
+	conversationID string
+	model          string
+	turn           trace.SpanContext
+	payload        []byte
 }
 
 // Options configures the relay. The zero value is valid: no internal export.
@@ -179,6 +210,16 @@ func New(ctx context.Context, opts Options) (*Relay, error) {
 				IdleConnTimeout:     60 * time.Second,
 			},
 		},
+	}
+	if r.internalEndpoint != "" {
+		// The cancel function is invoked by Shutdown after the workers stop.
+		r.internalCtx, r.internalCancel = context.WithCancel(ctx) //nolint:gosec // lifecycle-owned by Relay.Shutdown
+		r.internalJobs = make(chan internalExportJob, internalExportQueueSize)
+		r.internalDropped = newInternalDropCounter()
+		for range internalExportWorkers {
+			r.internalWG.Add(1)
+			go r.runInternalExporter()
+		}
 	}
 
 	mux := http.NewServeMux()
@@ -216,7 +257,24 @@ func (r *Relay) Port() int { return r.port }
 // Shutdown stops the listener. In-flight forwards are cut; telemetry is
 // best-effort by design.
 func (r *Relay) Shutdown(ctx context.Context) error {
-	return r.srv.Shutdown(ctx)
+	if r.internalCancel != nil {
+		r.internalCancel()
+	}
+	serverErr := r.srv.Shutdown(ctx)
+	if r.internalCancel == nil {
+		return serverErr
+	}
+	done := make(chan struct{})
+	go func() {
+		r.internalWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return serverErr
+	case <-ctx.Done():
+		return errors.Join(serverErr, ctx.Err())
+	}
 }
 
 // Register mints an unguessable routing token for a worker and retains its
@@ -331,7 +389,7 @@ func (r *Relay) handleTraces(w http.ResponseWriter, req *http.Request) {
 	// LangWatch's own copy, content-stripped, built from the batch BEFORE it is
 	// re-parented in place for the customer. Best-effort and detached: our
 	// observability must never delay or fail the customer's telemetry.
-	r.exportInternal(conversationID, turn, td)
+	r.exportInternal(conversationID, entry.info.Model, turn, body)
 
 	ReparentTraces(td, conversationID, turn)
 	out, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
@@ -375,31 +433,98 @@ func readOTLPBody(req *http.Request) ([]byte, error) {
 // exportInternal ships LangWatch's content-stripped copy of a worker batch to
 // its own collector. No-op when no internal endpoint is configured.
 //
-// Detached on purpose: this is LangWatch's operational telemetry, and the
-// customer's export must not wait on it or fail with it. The copy is built
-// synchronously (it reads td, which the caller mutates immediately after) and
-// only the HTTP round trip is deferred.
-func (r *Relay) exportInternal(conversationID string, turn trace.SpanContext, td ptrace.Traces) {
+// The original immutable protobuf body is queued rather than the mutable pdata
+// tree. Copying, sanitizing, marshaling, and HTTP all happen behind the bounded
+// worker pool, so internal observability never delays customer forwarding.
+func (r *Relay) exportInternal(
+	conversationID string,
+	model string,
+	turn trace.SpanContext,
+	payload []byte,
+) {
 	if r.internalEndpoint == "" {
 		return
 	}
+	if r.internalCtx.Err() != nil {
+		return
+	}
+	job := internalExportJob{
+		conversationID: conversationID,
+		model:          model,
+		turn:           turn,
+		payload:        payload,
+	}
+	select {
+	case r.internalJobs <- job:
+	default:
+		r.internalDropped.Add(r.baseCtx, 1, metric.WithAttributes(
+			attribute.String("reason", "queue_full"),
+		))
+		clog.Get(r.baseCtx).Warn("otelrelay internal trace dropped",
+			zap.String("conversation", conversationID),
+			zap.String("reason", "queue_full"),
+		)
+	}
+}
+
+func (r *Relay) runInternalExporter() {
+	defer r.internalWG.Done()
+	defer clog.HandlePanic(r.baseCtx, false)
+	for {
+		select {
+		case <-r.internalCtx.Done():
+			return
+		case job := <-r.internalJobs:
+			if r.internalCtx.Err() != nil {
+				return
+			}
+			r.processInternalJobSafely(job)
+		}
+	}
+}
+
+// processInternalJobSafely contains a panic to one best-effort batch. Recovering
+// at the worker-loop boundary alone would keep the process alive but permanently
+// shrink the fixed-size pool after a single malformed batch.
+func (r *Relay) processInternalJobSafely(job internalExportJob) {
+	defer clog.HandlePanic(r.baseCtx, false)
+	r.processInternalJob(job)
+}
+
+func (r *Relay) processInternalJob(job internalExportJob) {
+	td, err := (&ptrace.ProtoUnmarshaler{}).UnmarshalTraces(job.payload)
+	if err != nil {
+		clog.Get(r.baseCtx).Warn("otelrelay internal copy unmarshal failed",
+			zap.String("conversation", job.conversationID), zap.Error(err))
+		return
+	}
 	payload, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(
-		langyotel.InternalCopy(td, conversationID, turn),
+		langyotel.InternalCopy(td, job.conversationID, job.model, job.turn),
 	)
 	if err != nil {
 		clog.Get(r.baseCtx).Warn("otelrelay internal copy marshal failed",
-			zap.String("conversation", conversationID), zap.Error(err))
+			zap.String("conversation", job.conversationID), zap.Error(err))
 		return
 	}
-	go func() {
-		defer clog.HandlePanic(r.baseCtx, false)
-		ctx, cancel := context.WithTimeout(r.baseCtx, forwardTimeout)
-		defer cancel()
-		if err := r.postInternal(ctx, payload); err != nil {
-			clog.Get(r.baseCtx).Warn("otelrelay internal trace forward failed",
-				zap.String("conversation", conversationID), zap.Error(err))
-		}
-	}()
+	ctx, cancel := context.WithTimeout(r.internalCtx, forwardTimeout)
+	defer cancel()
+	if err := r.postInternal(ctx, payload); err != nil && r.internalCtx.Err() == nil {
+		clog.Get(r.baseCtx).Warn("otelrelay internal trace forward failed",
+			zap.String("conversation", job.conversationID), zap.Error(err))
+	}
+}
+
+func newInternalDropCounter() metric.Int64Counter {
+	const name = "langwatch.langy.internal_trace.batches_dropped"
+	counter, err := otel.Meter("langwatch-langyagent").Int64Counter(
+		name,
+		metric.WithDescription("Internal worker trace batches dropped before export."),
+	)
+	if err == nil {
+		return counter
+	}
+	fallback, _ := noop.NewMeterProvider().Meter("langwatch-langyagent").Int64Counter(name)
+	return fallback
 }
 
 func (r *Relay) postInternal(ctx context.Context, payload []byte) error {
@@ -407,7 +532,7 @@ func (r *Relay) postInternal(ctx context.Context, payload []byte) error {
 	if !strings.HasSuffix(url, "/v1/traces") {
 		url += "/v1/traces"
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(payload)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -431,7 +556,7 @@ func (r *Relay) postInternal(ctx context.Context, payload []byte) error {
 // LangWatch OTLP ingest, authenticated with the session key.
 func (r *Relay) forwardTraces(ctx context.Context, info WorkerInfo, payload []byte) error {
 	url := strings.TrimRight(info.LangwatchEndpoint, "/") + "/api/otel/v1/traces"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(payload)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -442,9 +567,9 @@ func (r *Relay) forwardTraces(ctx context.Context, info WorkerInfo, payload []by
 		return err
 	}
 	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 	if resp.StatusCode >= 300 {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-		return fmt.Errorf("ingest answered %d: %s", resp.StatusCode, string(b))
+		return fmt.Errorf("ingest answered %d: %s", resp.StatusCode, string(body))
 	}
 	return nil
 }

--- a/services/langyagent/adapters/otelrelay/otelrelay.go
+++ b/services/langyagent/adapters/otelrelay/otelrelay.go
@@ -567,9 +567,9 @@ func (r *Relay) forwardTraces(ctx context.Context, info WorkerInfo, payload []by
 		return err
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 2048))
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("ingest answered %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("ingest answered %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/services/langyagent/adapters/otelrelay/otelrelay.go
+++ b/services/langyagent/adapters/otelrelay/otelrelay.go
@@ -47,11 +47,13 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/langwatch/langwatch/pkg/clog"
 	"github.com/langwatch/langwatch/pkg/herr"
+	langyotel "github.com/langwatch/langwatch/services/langyagent/otel"
 )
 
 // maxOTLPBodyBytes caps a worker's OTLP export body. Batches from one opencode
@@ -136,22 +138,40 @@ type Relay struct {
 	port     int
 	upstream *http.Client
 
+	// internalEndpoint/internalHeaders address LangWatch's OWN collector. When
+	// set, each worker batch is ALSO delivered there in content-stripped form
+	// (see services/langyagent/otel). Empty disables the second export
+	// entirely — the customer path is unaffected either way.
+	internalEndpoint string
+	internalHeaders  map[string]string
+
 	mu      sync.Mutex
 	workers map[string]*workerEntry
+}
+
+// Options configures the relay. The zero value is valid: no internal export.
+type Options struct {
+	// InternalOTLPEndpoint is the base URL of LangWatch's own OTLP collector
+	// ("/v1/traces" is appended). Empty means the manager keeps no copy of
+	// worker telemetry.
+	InternalOTLPEndpoint string
+	InternalOTLPHeaders  map[string]string
 }
 
 // New binds a loopback listener on an ephemeral port and starts serving.
 // ctx is the manager-lifetime context (carries the logger); Shutdown stops the
 // listener.
-func New(ctx context.Context) (*Relay, error) {
+func New(ctx context.Context, opts Options) (*Relay, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, fmt.Errorf("otelrelay listen: %w", err)
 	}
 	r := &Relay{
-		baseCtx: ctx,
-		port:    ln.Addr().(*net.TCPAddr).Port,
-		workers: map[string]*workerEntry{},
+		baseCtx:          ctx,
+		port:             ln.Addr().(*net.TCPAddr).Port,
+		internalEndpoint: opts.InternalOTLPEndpoint,
+		internalHeaders:  opts.InternalOTLPHeaders,
+		workers:          map[string]*workerEntry{},
 		upstream: &http.Client{
 			Timeout: forwardTimeout,
 			Transport: &http.Transport{
@@ -301,7 +321,20 @@ func (r *Relay) handleTraces(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	out, err := ReparentOTLP(body, entry.info.ConversationID, entry.turnContext())
+	td, err := (&ptrace.ProtoUnmarshaler{}).UnmarshalTraces(body)
+	if err != nil {
+		http.Error(w, "invalid OTLP payload", http.StatusBadRequest)
+		return
+	}
+	conversationID, turn := entry.info.ConversationID, entry.turnContext()
+
+	// LangWatch's own copy, content-stripped, built from the batch BEFORE it is
+	// re-parented in place for the customer. Best-effort and detached: our
+	// observability must never delay or fail the customer's telemetry.
+	r.exportInternal(conversationID, turn, td)
+
+	ReparentTraces(td, conversationID, turn)
+	out, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
 	if err != nil {
 		http.Error(w, "invalid OTLP payload", http.StatusBadRequest)
 		return
@@ -337,6 +370,61 @@ func readOTLPBody(req *http.Request) ([]byte, error) {
 		return nil, fmt.Errorf("read body: %w", err)
 	}
 	return body, nil
+}
+
+// exportInternal ships LangWatch's content-stripped copy of a worker batch to
+// its own collector. No-op when no internal endpoint is configured.
+//
+// Detached on purpose: this is LangWatch's operational telemetry, and the
+// customer's export must not wait on it or fail with it. The copy is built
+// synchronously (it reads td, which the caller mutates immediately after) and
+// only the HTTP round trip is deferred.
+func (r *Relay) exportInternal(conversationID string, turn trace.SpanContext, td ptrace.Traces) {
+	if r.internalEndpoint == "" {
+		return
+	}
+	payload, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(
+		langyotel.InternalCopy(td, conversationID, turn),
+	)
+	if err != nil {
+		clog.Get(r.baseCtx).Warn("otelrelay internal copy marshal failed",
+			zap.String("conversation", conversationID), zap.Error(err))
+		return
+	}
+	go func() {
+		defer clog.HandlePanic(r.baseCtx, false)
+		ctx, cancel := context.WithTimeout(r.baseCtx, forwardTimeout)
+		defer cancel()
+		if err := r.postInternal(ctx, payload); err != nil {
+			clog.Get(r.baseCtx).Warn("otelrelay internal trace forward failed",
+				zap.String("conversation", conversationID), zap.Error(err))
+		}
+	}()
+}
+
+func (r *Relay) postInternal(ctx context.Context, payload []byte) error {
+	url := strings.TrimRight(r.internalEndpoint, "/")
+	if !strings.HasSuffix(url, "/v1/traces") {
+		url += "/v1/traces"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(payload)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	for k, v := range r.internalHeaders {
+		req.Header.Set(k, v)
+	}
+	resp, err := r.upstream.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 2048))
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("internal collector answered %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // forwardTraces POSTs the re-parented protobuf batch to the customer's

--- a/services/langyagent/adapters/otelrelay/otelrelay_test.go
+++ b/services/langyagent/adapters/otelrelay/otelrelay_test.go
@@ -17,7 +17,7 @@ import (
 // startRelay boots a relay on loopback and tears it down with the test.
 func startRelay(t *testing.T) *Relay {
 	t.Helper()
-	r, err := New(context.Background())
+	r, err := New(context.Background(), Options{})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/services/langyagent/adapters/otelrelay/reparent.go
+++ b/services/langyagent/adapters/otelrelay/reparent.go
@@ -76,7 +76,15 @@ func ReparentTraces(td ptrace.Traces, conversationID string, turn trace.SpanCont
 // stampResource sets the reserved LangWatch keys, appending "langy" to any
 // existing tag.tags value (comma-separated, the shape the ingest accepts)
 // rather than clobbering a tag the worker legitimately set.
+//
+// It also REMOVES langwatch.origin: that key is LangWatch's provenance marker
+// (pkg/otelsetup stamps platform_internal, the relay's internal copy stamps
+// langy_worker) and the worker — a model-driven, prompt-injectable process —
+// must not be able to brand its spans with it in the customer's project.
+// Ingest-side enforcement keyed on the marker must never trust a
+// worker-supplied value.
 func stampResource(attrs pcommon.Map, conversationID string) {
+	attrs.Remove("langwatch.origin")
 	attrs.PutStr(attrThreadID, conversationID)
 	if existing, ok := attrs.Get(attrTags); ok {
 		tags := existing.AsString()

--- a/services/langyagent/adapters/otelrelay/reparent.go
+++ b/services/langyagent/adapters/otelrelay/reparent.go
@@ -14,6 +14,7 @@ import (
 const (
 	attrTags     = "tag.tags"
 	attrThreadID = "langwatch.thread.id"
+	attrOrigin   = "langwatch.origin"
 	langyTag     = "langy"
 )
 
@@ -51,19 +52,27 @@ func ReparentOTLP(payload []byte, conversationID string, turn trace.SpanContext)
 // id-rewriting logic unit-tests against pdata values without codec round-trips.
 func ReparentTraces(td ptrace.Traces, conversationID string, turn trace.SpanContext) {
 	rss := td.ResourceSpans()
+	isTurnValid := turn.IsValid()
+	turnTraceID := pcommon.TraceID(turn.TraceID())
+	turnSpanID := pcommon.SpanID(turn.SpanID())
 	for i := 0; i < rss.Len(); i++ {
 		rs := rss.At(i)
 		stampResource(rs.Resource().Attributes(), conversationID)
-		if !turn.IsValid() {
-			continue
-		}
-		turnTraceID := pcommon.TraceID(turn.TraceID())
-		turnSpanID := pcommon.SpanID(turn.SpanID())
 		sss := rs.ScopeSpans()
 		for j := 0; j < sss.Len(); j++ {
-			spans := sss.At(j).Spans()
+			ss := sss.At(j)
+			// The provenance strip runs for every batch, including one that
+			// arrives before the turn exists: an unreparented batch is still
+			// forwarded to the customer, so skipping it here would leave the
+			// forgery open on precisely that path.
+			stripForgedOrigin(ss.Scope().Attributes())
+			spans := ss.Spans()
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
+				stripForgedOrigin(span.Attributes())
+				if !isTurnValid {
+					continue
+				}
 				span.SetTraceID(turnTraceID)
 				if span.ParentSpanID().IsEmpty() {
 					span.SetParentSpanID(turnSpanID)
@@ -83,20 +92,53 @@ func ReparentTraces(td ptrace.Traces, conversationID string, turn trace.SpanCont
 // must not be able to brand its spans with it in the customer's project.
 // Ingest-side enforcement keyed on the marker must never trust a
 // worker-supplied value.
+//
+// Every removal here sweeps ALL entries for the key, never just the first.
+// The worker writes its own OTLP bytes, and the wire format is a repeated
+// list of key/value pairs that the unmarshaler preserves verbatim — so a key
+// present twice survives a first-match Remove, and Get/PutStr would read and
+// overwrite only the leading copy while the worker's twin rode through
+// untouched.
 func stampResource(attrs pcommon.Map, conversationID string) {
-	attrs.Remove("langwatch.origin")
+	removeAll(attrs, attrOrigin)
+
+	tags := firstValue(attrs, attrTags)
+	removeAll(attrs, attrThreadID)
+	removeAll(attrs, attrTags)
+
 	attrs.PutStr(attrThreadID, conversationID)
-	if existing, ok := attrs.Get(attrTags); ok {
-		tags := existing.AsString()
-		if tags != "" && !containsTag(tags, langyTag) {
-			attrs.PutStr(attrTags, tags+","+langyTag)
-			return
-		}
-		if tags != "" {
-			return
-		}
+	switch {
+	case tags == "":
+		attrs.PutStr(attrTags, langyTag)
+	case containsTag(tags, langyTag):
+		attrs.PutStr(attrTags, tags)
+	default:
+		attrs.PutStr(attrTags, tags+","+langyTag)
 	}
-	attrs.PutStr(attrTags, langyTag)
+}
+
+// stripForgedOrigin removes the provenance marker from a span or scope. Ingest
+// resolves a span-level langwatch.origin BEFORE falling back to the resource
+// (see trace-origin.service.ts), so stripping the resource alone would leave
+// the higher-precedence claim in place.
+func stripForgedOrigin(attrs pcommon.Map) {
+	removeAll(attrs, attrOrigin)
+}
+
+// removeAll deletes every entry for key, unlike Map.Remove which returns after
+// the first match.
+func removeAll(attrs pcommon.Map, key string) {
+	attrs.RemoveIf(func(k string, _ pcommon.Value) bool { return k == key })
+}
+
+// firstValue returns the leading value for key, or "" when absent. The leading
+// copy is the one ingest would have read, so it is the one whose legitimate
+// content is preserved when the key is rewritten.
+func firstValue(attrs pcommon.Map, key string) string {
+	if v, ok := attrs.Get(key); ok {
+		return v.AsString()
+	}
+	return ""
 }
 
 func containsTag(csv, tag string) bool {

--- a/services/langyagent/adapters/otelrelay/reparent_forgery_test.go
+++ b/services/langyagent/adapters/otelrelay/reparent_forgery_test.go
@@ -1,0 +1,125 @@
+package otelrelay
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/trace"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// The worker writes the OTLP bytes it POSTs, so it is not restricted to the
+// shapes pdata's Map API can express: it can repeat a key, and it can put a
+// key on a span instead of the resource. These helpers build those payloads
+// directly, because a test that reaches for attrs.PutStr can only ever
+// exercise the deduplicated case and would pass against the forgeable code.
+
+func kvStr(k, v string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{
+		Key:   k,
+		Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: v}},
+	}
+}
+
+func wirePayload(t *testing.T, resourceAttrs, spanAttrs []*commonpb.KeyValue) []byte {
+	t.Helper()
+	payload := &tracepb.TracesData{
+		ResourceSpans: []*tracepb.ResourceSpans{{
+			Resource: &resourcepb.Resource{Attributes: resourceAttrs},
+			ScopeSpans: []*tracepb.ScopeSpans{{
+				Spans: []*tracepb.Span{{Name: "worker-span", Attributes: spanAttrs}},
+			}},
+		}},
+	}
+	wire, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal worker payload: %v", err)
+	}
+	return wire
+}
+
+func forward(t *testing.T, wire []byte) ptrace.Traces {
+	t.Helper()
+	out, err := ReparentOTLP(wire, "conv-1", trace.SpanContext{})
+	if err != nil {
+		t.Fatalf("ReparentOTLP: %v", err)
+	}
+	td, err := (&ptrace.ProtoUnmarshaler{}).UnmarshalTraces(out)
+	if err != nil {
+		t.Fatalf("unmarshal forwarded payload: %v", err)
+	}
+	return td
+}
+
+// countResourceAttr reports how many entries with key k survive on the
+// resource — Get() alone would stop at the first and hide a smuggled twin.
+func countResourceAttr(td ptrace.Traces, k string) int {
+	n := 0
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		rss.At(i).Resource().Attributes().Range(func(key string, _ pcommon.Value) bool {
+			if key == k {
+				n++
+			}
+			return true
+		})
+	}
+	return n
+}
+
+func TestReparent_StripsForgedOriginRepeatedOnTheResource(t *testing.T) {
+	wire := wirePayload(t, []*commonpb.KeyValue{
+		kvStr(attrOrigin, "platform_internal"),
+		kvStr("service.name", "worker"),
+		kvStr(attrOrigin, "platform_internal"),
+	}, nil)
+
+	td := forward(t, wire)
+
+	if got := countResourceAttr(td, attrOrigin); got != 0 {
+		t.Fatalf("a worker-forged %s survived onto the customer forward (%d copies remain)", attrOrigin, got)
+	}
+}
+
+func TestReparent_StripsForgedOriginFromSpans(t *testing.T) {
+	// Ingest resolves span origin before resource origin, so a span-level
+	// claim overrides whatever the resource says.
+	wire := wirePayload(t,
+		[]*commonpb.KeyValue{kvStr("service.name", "worker")},
+		[]*commonpb.KeyValue{
+			kvStr(attrOrigin, "platform_internal"),
+			kvStr(attrOrigin, "platform_internal"),
+		},
+	)
+
+	td := forward(t, wire)
+
+	spans := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	for i := 0; i < spans.Len(); i++ {
+		if v, ok := spans.At(i).Attributes().Get(attrOrigin); ok {
+			t.Fatalf("a worker-forged span-level %s survived onto the customer forward: %q", attrOrigin, v.AsString())
+		}
+	}
+}
+
+func TestReparent_ReservedKeysCannotBeSmuggledByRepetition(t *testing.T) {
+	wire := wirePayload(t, []*commonpb.KeyValue{
+		kvStr(attrThreadID, "attacker-thread"),
+		kvStr("service.name", "worker"),
+		kvStr(attrThreadID, "attacker-thread"),
+	}, nil)
+
+	td := forward(t, wire)
+
+	if got := countResourceAttr(td, attrThreadID); got != 1 {
+		t.Fatalf("expected exactly one %s after the stamp, found %d", attrThreadID, got)
+	}
+	v, ok := td.ResourceSpans().At(0).Resource().Attributes().Get(attrThreadID)
+	if !ok || v.AsString() != "conv-1" {
+		t.Fatalf("worker value survived for %s: got %q", attrThreadID, v.AsString())
+	}
+}

--- a/services/langyagent/app/workerpool/pool.go
+++ b/services/langyagent/app/workerpool/pool.go
@@ -667,6 +667,7 @@ func (p *Pool) spawnInner(ctx context.Context, conversationID string, creds doma
 			ConversationID:    conversationID,
 			LangwatchEndpoint: creds.LangwatchEndpoint,
 			LangwatchAPIKey:   creds.LangwatchAPIKey,
+			Model:             creds.Model,
 			GatewayBaseURL:    creds.GatewayBaseURL,
 			LLMVirtualKey:     creds.LLMVirtualKey,
 		})

--- a/services/langyagent/config.go
+++ b/services/langyagent/config.go
@@ -34,6 +34,7 @@ package langyagent
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -191,6 +192,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	if err := config.Hydrate(&cfg); err != nil {
 		return Config{}, err
 	}
+	cfg.OTel.SampleRatioSet = os.Getenv("OTEL_SAMPLE_RATIO") != ""
 	// Derive the listen address from PORT (kept as its own env var). Set after
 	// Hydrate so PORT always wins over any stray SERVER_ADDR.
 	cfg.Server.Addr = fmt.Sprintf(":%d", cfg.Port)

--- a/services/langyagent/config.go
+++ b/services/langyagent/config.go
@@ -196,8 +196,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	// Derive the listen address from PORT (kept as its own env var). Set after
 	// Hydrate so PORT always wins over any stray SERVER_ADDR.
 	cfg.Server.Addr = fmt.Sprintf(":%d", cfg.Port)
-	cfg.OTel.ResolveSampleRatio(cfg.Environment)
-	if err := cfg.OTel.Validate(); err != nil {
+	if err := cfg.OTel.Resolve(cfg.Environment); err != nil {
 		return Config{}, err
 	}
 	if err := cfg.Log.Validate(); err != nil {

--- a/services/langyagent/config.go
+++ b/services/langyagent/config.go
@@ -197,6 +197,9 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	// Hydrate so PORT always wins over any stray SERVER_ADDR.
 	cfg.Server.Addr = fmt.Sprintf(":%d", cfg.Port)
 	cfg.OTel.ResolveSampleRatio(cfg.Environment)
+	if err := cfg.OTel.Validate(); err != nil {
+		return Config{}, err
+	}
 	if err := cfg.Log.Validate(); err != nil {
 		return Config{}, err
 	}

--- a/services/langyagent/config.go
+++ b/services/langyagent/config.go
@@ -178,7 +178,9 @@ func defaultConfig() Config {
 		EgressRequireTLS:    true,
 		EgressSNICrossCheck: true,
 		OTel: config.OTel{
-			SampleRatio: 1.0, // overridden to 0.1 for non-local in LoadConfig
+			// Left unset so an operator-supplied ratio is distinguishable
+			// from the default; resolved in LoadConfig.
+			SampleRatio: config.UnsetSampleRatio,
 		},
 	}
 }
@@ -192,9 +194,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	// Derive the listen address from PORT (kept as its own env var). Set after
 	// Hydrate so PORT always wins over any stray SERVER_ADDR.
 	cfg.Server.Addr = fmt.Sprintf(":%d", cfg.Port)
-	if cfg.OTel.SampleRatio == 1.0 && cfg.Environment != "local" {
-		cfg.OTel.SampleRatio = 0.1
-	}
+	cfg.OTel.ResolveSampleRatio(cfg.Environment)
 	if err := cfg.Log.Validate(); err != nil {
 		return Config{}, err
 	}

--- a/services/langyagent/config_test.go
+++ b/services/langyagent/config_test.go
@@ -16,7 +16,13 @@ func clearLangyEnv(t *testing.T) {
 		"LANGY_WORKER_IDLE_MS", "LANGY_REAPER_INTERVAL_MS", "LANGY_READINESS_TIMEOUT_MS", "SESSIONS_ROOT",
 		"LANGY_WORKSPACE_ROOT", "LANGY_UNSAFE_DEV_DISABLE_ISOLATION",
 		"LOG_LEVEL", "LOG_FORMAT",
-		"OTEL_OTLP_ENDPOINT", "OTEL_SAMPLE_RATIO",
+		"OTEL_OTLP_ENDPOINT", "OTEL_OTLP_HEADERS", "OTEL_SAMPLE_RATIO",
+		"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_HEADERS",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_PROTOCOL", "OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG",
+		"OTEL_TRACES_EXPORTER", "OTEL_SDK_DISABLED",
+		"OTEL_DEBUG_COLLECTOR_ENDPOINT", "OTEL_DEBUG_COLLECTOR_HEADERS",
 		"LANGY_SHUTDOWN_HANDOFF_DEADLINE_MS", "LANGY_SHUTDOWN_DRAIN_BUDGET_MS",
 	} {
 		t.Setenv(k, "")
@@ -127,8 +133,8 @@ func TestLoadConfig_NonLocalLowersSampleRatio(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if cfg.OTel.SampleRatio != 0.1 {
-		t.Errorf("non-local SampleRatio = %v, want 0.1", cfg.OTel.SampleRatio)
+	if got := cfg.OTel.SamplerChoice().Ratio; got != 0.1 {
+		t.Errorf("non-local sampler ratio = %v, want 0.1", got)
 	}
 }
 
@@ -142,8 +148,39 @@ func TestLoadConfig_ExplicitZeroSampleRatioIsPreserved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if cfg.OTel.SampleRatio != 0 || !cfg.OTel.SampleRatioSet {
-		t.Fatalf("explicit zero sample ratio = %v (set=%v), want 0 (set=true)", cfg.OTel.SampleRatio, cfg.OTel.SampleRatioSet)
+	if got := cfg.OTel.SamplerChoice().Ratio; got != 0 {
+		t.Fatalf("explicit zero sample ratio resolved to %v, want 0", got)
+	}
+}
+
+func TestLoadConfig_OfficialSamplerVarsAreHonoured(t *testing.T) {
+	clearLangyEnv(t)
+	t.Setenv("LANGY_INTERNAL_SECRET", "secret")
+	t.Setenv("ENVIRONMENT", "production")
+	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "0.25")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got := cfg.OTel.SamplerChoice().Ratio; got != 0.25 {
+		t.Fatalf("official sampler ratio = %v, want 0.25", got)
+	}
+}
+
+func TestLoadConfig_OfficialEndpointNameIsHonoured(t *testing.T) {
+	clearLangyEnv(t)
+	t.Setenv("LANGY_INTERNAL_SECRET", "secret")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	base, _ := cfg.OTel.PrimaryOTLP()
+	if base != "http://localhost:4318" {
+		t.Fatalf("PrimaryOTLP base = %q, want the official env var's value", base)
 	}
 }
 

--- a/services/langyagent/config_test.go
+++ b/services/langyagent/config_test.go
@@ -132,6 +132,21 @@ func TestLoadConfig_NonLocalLowersSampleRatio(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_ExplicitZeroSampleRatioIsPreserved(t *testing.T) {
+	clearLangyEnv(t)
+	t.Setenv("LANGY_INTERNAL_SECRET", "secret")
+	t.Setenv("ENVIRONMENT", "production")
+	t.Setenv("OTEL_SAMPLE_RATIO", "0")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.OTel.SampleRatio != 0 || !cfg.OTel.SampleRatioSet {
+		t.Fatalf("explicit zero sample ratio = %v (set=%v), want 0 (set=true)", cfg.OTel.SampleRatio, cfg.OTel.SampleRatioSet)
+	}
+}
+
 func TestLoadConfig_UnsafeDevDisableIsolationAllowedInLocalEnvs(t *testing.T) {
 	for _, env := range []string{"local", "dev", "development", "test", "LOCAL", "  dev  "} {
 		t.Run(env, func(t *testing.T) {

--- a/services/langyagent/deps.go
+++ b/services/langyagent/deps.go
@@ -52,7 +52,14 @@ func NewDeps(ctx context.Context, cfg Config) (context.Context, *Deps, error) {
 	// The loopback relay for host-mediated worker telemetry + LLM traffic. Binds
 	// an ephemeral 127.0.0.1 port immediately; workers get token-scoped URLs on
 	// it at spawn. Failing to bind loopback is a broken host — fail fast.
-	relay, err := otelrelay.New(ctx)
+	// The relay also keeps LangWatch's own content-stripped copy of worker
+	// telemetry, shipped to the same collector the manager's spans go to. With
+	// no collector configured the second export is simply not installed.
+	internalEndpoint, internalHeaders := cfg.OTel.PrimaryOTLP()
+	relay, err := otelrelay.New(ctx, otelrelay.Options{
+		InternalOTLPEndpoint: internalEndpoint,
+		InternalOTLPHeaders:  internalHeaders,
+	})
 	if err != nil {
 		return ctx, nil, fmt.Errorf("otelrelay init: %w", err)
 	}

--- a/services/langyagent/otel/angelinajolie.go
+++ b/services/langyagent/otel/angelinajolie.go
@@ -2,12 +2,18 @@
 package otel
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"strings"
+	"sync/atomic"
+	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/trace"
 )
+
+var fallbackIDCounter atomic.Uint64
 
 const (
 	attrServiceName  = "service.name"
@@ -74,6 +80,12 @@ func InternalCopy(
 	turn trace.SpanContext,
 ) ptrace.Traces {
 	out := ptrace.NewTraces()
+	traceID := newTraceID()
+	parentSpanID := pcommon.NewSpanIDEmpty()
+	if turn.IsValid() {
+		traceID = pcommon.TraceID(turn.TraceID())
+		parentSpanID = pcommon.SpanID(turn.SpanID())
+	}
 	sourceResources := td.ResourceSpans()
 	for i := 0; i < sourceResources.Len(); i++ {
 		sourceResource := sourceResources.At(i)
@@ -92,7 +104,8 @@ func InternalCopy(
 					sourceSpans.At(k),
 					destinationScope.Spans().AppendEmpty(),
 					trustedModel,
-					turn,
+					traceID,
+					parentSpanID,
 				)
 			}
 		}
@@ -106,11 +119,16 @@ func stampInternalResource(attrs pcommon.Map, conversationID string) {
 	attrs.PutStr(attrConversation, conversationID)
 }
 
-func copySafeSpan(source, destination ptrace.Span, trustedModel string, turn trace.SpanContext) {
+func copySafeSpan(
+	source, destination ptrace.Span,
+	trustedModel string,
+	traceID pcommon.TraceID,
+	parentSpanID pcommon.SpanID,
+) {
 	destination.SetName(internalSpanName)
-	destination.SetTraceID(source.TraceID())
-	destination.SetSpanID(source.SpanID())
-	destination.SetParentSpanID(source.ParentSpanID())
+	destination.SetTraceID(traceID)
+	destination.SetSpanID(newSpanID())
+	destination.SetParentSpanID(parentSpanID)
 	destination.SetStartTimestamp(source.StartTimestamp())
 	destination.SetEndTimestamp(source.EndTimestamp())
 	destination.SetKind(source.Kind())
@@ -118,14 +136,6 @@ func copySafeSpan(source, destination ptrace.Span, trustedModel string, turn tra
 	destination.Status().SetCode(source.Status().Code())
 
 	copySafeAttributes(source.Attributes(), destination.Attributes(), trustedModel)
-	copySafeLinks(source.Links(), destination.Links())
-
-	if turn.IsValid() {
-		destination.SetTraceID(pcommon.TraceID(turn.TraceID()))
-		if destination.ParentSpanID().IsEmpty() {
-			destination.SetParentSpanID(pcommon.SpanID(turn.SpanID()))
-		}
-	}
 }
 
 func copySafeAttributes(source, destination pcommon.Map, trustedModel string) {
@@ -204,12 +214,21 @@ func copySafeEnumSlice(
 	}
 }
 
-func copySafeLinks(source, destination ptrace.SpanLinkSlice) {
-	for i := 0; i < source.Len(); i++ {
-		sourceLink := source.At(i)
-		destinationLink := destination.AppendEmpty()
-		destinationLink.SetTraceID(sourceLink.TraceID())
-		destinationLink.SetSpanID(sourceLink.SpanID())
-		destinationLink.SetFlags(sourceLink.Flags())
+func newTraceID() pcommon.TraceID {
+	var id pcommon.TraceID
+	if _, err := rand.Read(id[:]); err == nil && !id.IsEmpty() {
+		return id
 	}
+	binary.BigEndian.PutUint64(id[:8], uint64(time.Now().UnixNano()))
+	binary.BigEndian.PutUint64(id[8:], fallbackIDCounter.Add(1))
+	return id
+}
+
+func newSpanID() pcommon.SpanID {
+	var id pcommon.SpanID
+	if _, err := rand.Read(id[:]); err == nil && !id.IsEmpty() {
+		return id
+	}
+	binary.BigEndian.PutUint64(id[:], fallbackIDCounter.Add(1))
+	return id
 }

--- a/services/langyagent/otel/angelinajolie.go
+++ b/services/langyagent/otel/angelinajolie.go
@@ -1,147 +1,215 @@
-// Package otel builds LangWatch's OWN copy of a Langy worker's telemetry.
-//
-// A worker's OTLP batch goes to the customer's project verbatim — it is their
-// agent, their prompts, their project. That path is untouched by this package.
-//
-// LangWatch also needs operational visibility into workers it runs: which model,
-// how many tokens, how long, what failed. It must NOT receive the content. The
-// worker is an opencode subprocess and its spans are the highest-density
-// prompt/completion surface in the system — the relay already accepts-and-drops
-// worker LOGS and METRICS for exactly that reason, but spans were never filtered
-// because they only ever went to the customer.
-//
-// InternalCopy is the boundary. It deep-copies the batch, keeps a strict
-// allowlist of shape-and-cost attributes, drops every span event (the classic
-// carrier: exception.message, exception.stacktrace, gen_ai prompt/completion
-// events), clears status descriptions (provider error text), and replaces the
-// worker's resource with LangWatch's own service identity.
-//
-// The allowlist is deliberate: a denylist fails open on the next key opencode's
-// instrumentation invents, and the whole point is that unknown keys are assumed
-// to carry content.
+// Package otel builds LangWatch's own content-free copy of Langy worker traces.
 package otel
 
 import (
+	"strings"
+
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Resource keys stamped on LangWatch's copy. The worker's own resource
-// attributes are discarded wholesale rather than filtered — they describe the
-// customer's agent, and we are re-attributing this batch to our own service.
 const (
 	attrServiceName  = "service.name"
 	attrOrigin       = "langwatch.origin"
 	attrConversation = "langy.conversation_id"
 
-	serviceName  = "langwatch-langyworker"
-	originWorker = "langy_worker"
+	serviceName       = "langwatch-langyworker"
+	originWorker      = "langy_worker"
+	internalScopeName = "langwatch.langyworker"
+	internalSpanName  = "langy.worker"
 )
 
-// spanAttributeAllowlist is the complete set of span attributes LangWatch's
-// copy may carry. Everything absent here is dropped, including keys that look
-// harmless — an unrecognised key is assumed to carry content until someone
-// deliberately adds it, with a test.
-//
-// Note what is NOT here: gen_ai.input.messages, gen_ai.output.messages,
-// gen_ai.system_instructions, gen_ai.prompt, gen_ai.completion, and every tool
-// argument or result key. Those are the customer's.
-var spanAttributeAllowlist = map[string]struct{}{
-	// Shape of the call.
-	"gen_ai.operation.name":  {},
-	"gen_ai.system":          {},
-	"gen_ai.request.model":   {},
-	"gen_ai.response.model":  {},
-	"gen_ai.conversation.id": {},
-
-	// Cost and size. Counts, never content.
+// Numeric attributes cannot carry customer text. Their values are copied only
+// when the worker used the expected numeric type and supplied a non-negative
+// value. Everything else is omitted from LangWatch's copy.
+var safeIntSpanAttributes = map[string]struct{}{
 	"gen_ai.usage.input_tokens":                {},
 	"gen_ai.usage.output_tokens":               {},
 	"gen_ai.usage.total_tokens":                {},
 	"gen_ai.usage.cache_read.input_tokens":     {},
 	"gen_ai.usage.cache_creation.input_tokens": {},
-
-	// Outcome. finish_reasons is a fixed vocabulary ("stop", "length", ...);
-	// error.type is a classifier token, not a message.
-	"gen_ai.response.finish_reasons": {},
-	"error.type":                     {},
-
-	// Tool identity — which tool ran, never what it was called with or returned.
-	"gen_ai.tool.name":    {},
-	"gen_ai.tool.type":    {},
-	"gen_ai.tool.call.id": {},
-
-	// Transport shape. url.full and query strings are excluded on purpose:
-	// agent traffic routinely carries content in them.
-	"http.request.method":       {},
-	"http.response.status_code": {},
-	"server.address":            {},
+	"http.response.status_code":                {},
 }
 
-// InternalCopy returns LangWatch's content-stripped copy of a worker OTLP
-// batch, re-parented under the turn so it joins the manager's own trace.
+// String metadata is retained only when it belongs to a closed operational
+// vocabulary. Open-ended strings such as model ids and tool names are never
+// trusted from the worker; the model is stamped from manager-owned config.
+var safeEnumSpanAttributes = map[string]map[string]struct{}{
+	"gen_ai.operation.name": enumSet(
+		"chat", "text_completion", "embeddings", "execute_tool", "generate_content",
+	),
+	"gen_ai.system": enumSet(
+		"anthropic", "aws.bedrock", "azure.ai.openai", "gcp.vertex_ai", "openai",
+	),
+	"gen_ai.tool.type": enumSet("datastore", "extension", "function"),
+	"http.request.method": enumSet(
+		"CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE",
+	),
+}
+
+var safeFinishReasons = enumSet(
+	"content_filter", "error", "length", "stop", "tool_calls", "unknown",
+)
+
+func enumSet(values ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+// InternalCopy returns a new trace batch containing only operational metadata
+// that is safe for LangWatch's collector. It deliberately constructs a blank
+// OTLP tree instead of cloning the worker payload: newly-added pdata string
+// fields therefore stay empty until explicitly reviewed here.
 //
-// td is NOT modified — the caller's batch stays intact for the customer path.
-// Re-parenting onto the turn is legitimate here in a way it is not for the
-// customer copy: this trace lives in LangWatch's backend, where the turn's
-// parent span actually exists.
-func InternalCopy(td ptrace.Traces, conversationID string, turn trace.SpanContext) ptrace.Traces {
+// trustedModel and conversationID come from manager-owned worker registration,
+// never from the worker's OTLP payload. td is not modified.
+func InternalCopy(
+	td ptrace.Traces,
+	conversationID string,
+	trustedModel string,
+	turn trace.SpanContext,
+) ptrace.Traces {
 	out := ptrace.NewTraces()
-	td.CopyTo(out)
+	sourceResources := td.ResourceSpans()
+	for i := 0; i < sourceResources.Len(); i++ {
+		sourceResource := sourceResources.At(i)
+		destinationResource := out.ResourceSpans().AppendEmpty()
+		stampInternalResource(destinationResource.Resource().Attributes(), conversationID)
 
-	rss := out.ResourceSpans()
-	for i := 0; i < rss.Len(); i++ {
-		rs := rss.At(i)
-		stampInternalResource(rs.Resource().Attributes(), conversationID)
+		sourceScopes := sourceResource.ScopeSpans()
+		for j := 0; j < sourceScopes.Len(); j++ {
+			sourceScope := sourceScopes.At(j)
+			destinationScope := destinationResource.ScopeSpans().AppendEmpty()
+			destinationScope.Scope().SetName(internalScopeName)
 
-		sss := rs.ScopeSpans()
-		for j := 0; j < sss.Len(); j++ {
-			spans := sss.At(j).Spans()
-			for k := 0; k < spans.Len(); k++ {
-				sanitizeSpan(spans.At(k), turn)
+			sourceSpans := sourceScope.Spans()
+			for k := 0; k < sourceSpans.Len(); k++ {
+				copySafeSpan(
+					sourceSpans.At(k),
+					destinationScope.Spans().AppendEmpty(),
+					trustedModel,
+					turn,
+				)
 			}
 		}
 	}
 	return out
 }
 
-// stampInternalResource discards the worker's resource attributes and replaces
-// them with LangWatch's service identity. Clearing rather than filtering keeps
-// customer-set resource attributes (which opencode lets the agent influence)
-// out of our backend entirely.
 func stampInternalResource(attrs pcommon.Map, conversationID string) {
-	attrs.Clear()
 	attrs.PutStr(attrServiceName, serviceName)
 	attrs.PutStr(attrOrigin, originWorker)
 	attrs.PutStr(attrConversation, conversationID)
 }
 
-func sanitizeSpan(span ptrace.Span, turn trace.SpanContext) {
-	span.Attributes().RemoveIf(func(k string, _ pcommon.Value) bool {
-		_, allowed := spanAttributeAllowlist[k]
-		return !allowed
-	})
+func copySafeSpan(source, destination ptrace.Span, trustedModel string, turn trace.SpanContext) {
+	destination.SetName(internalSpanName)
+	destination.SetTraceID(source.TraceID())
+	destination.SetSpanID(source.SpanID())
+	destination.SetParentSpanID(source.ParentSpanID())
+	destination.SetStartTimestamp(source.StartTimestamp())
+	destination.SetEndTimestamp(source.EndTimestamp())
+	destination.SetKind(source.Kind())
+	destination.SetFlags(source.Flags())
+	destination.Status().SetCode(source.Status().Code())
 
-	// Events carry exception.message / exception.stacktrace and, in several
-	// gen_ai instrumentations, the prompt and completion bodies themselves.
-	// None of it is worth the risk operationally.
-	span.Events().RemoveIf(func(ptrace.SpanEvent) bool { return true })
-
-	// Link attributes are attacker-influenced the same way span attributes are;
-	// the link's trace/span ids are the useful part.
-	links := span.Links()
-	for i := 0; i < links.Len(); i++ {
-		links.At(i).Attributes().Clear()
-	}
-
-	// Status descriptions are raw provider/runtime error text. Keep the code.
-	span.Status().SetMessage("")
+	copySafeAttributes(source.Attributes(), destination.Attributes(), trustedModel)
+	copySafeLinks(source.Links(), destination.Links())
 
 	if turn.IsValid() {
-		span.SetTraceID(pcommon.TraceID(turn.TraceID()))
-		if span.ParentSpanID().IsEmpty() {
-			span.SetParentSpanID(pcommon.SpanID(turn.SpanID()))
+		destination.SetTraceID(pcommon.TraceID(turn.TraceID()))
+		if destination.ParentSpanID().IsEmpty() {
+			destination.SetParentSpanID(pcommon.SpanID(turn.SpanID()))
 		}
+	}
+}
+
+func copySafeAttributes(source, destination pcommon.Map, trustedModel string) {
+	source.Range(func(key string, value pcommon.Value) bool {
+		if _, ok := safeIntSpanAttributes[key]; ok {
+			copySafeInt(destination, key, value)
+			return true
+		}
+		if vocabulary, ok := safeEnumSpanAttributes[key]; ok {
+			copySafeEnum(destination, key, value, vocabulary)
+			return true
+		}
+		if key == "gen_ai.response.finish_reasons" {
+			copySafeEnumSlice(destination, key, value, safeFinishReasons)
+			return true
+		}
+		if (key == "gen_ai.request.model" || key == "gen_ai.response.model") && trustedModel != "" {
+			destination.PutStr(key, trustedModel)
+		}
+		return true
+	})
+}
+
+func copySafeInt(destination pcommon.Map, key string, value pcommon.Value) {
+	if value.Type() != pcommon.ValueTypeInt || value.Int() < 0 {
+		return
+	}
+	if key == "http.response.status_code" && (value.Int() < 100 || value.Int() > 599) {
+		return
+	}
+	destination.PutInt(key, value.Int())
+}
+
+func copySafeEnum(
+	destination pcommon.Map,
+	key string,
+	value pcommon.Value,
+	vocabulary map[string]struct{},
+) {
+	if value.Type() != pcommon.ValueTypeStr {
+		return
+	}
+	canonical := strings.TrimSpace(value.Str())
+	if _, ok := vocabulary[canonical]; ok {
+		destination.PutStr(key, canonical)
+	}
+}
+
+func copySafeEnumSlice(
+	destination pcommon.Map,
+	key string,
+	value pcommon.Value,
+	vocabulary map[string]struct{},
+) {
+	if value.Type() != pcommon.ValueTypeSlice {
+		return
+	}
+	source := value.Slice()
+	safe := make([]string, 0, source.Len())
+	for i := 0; i < source.Len(); i++ {
+		item := source.At(i)
+		if item.Type() != pcommon.ValueTypeStr {
+			return
+		}
+		if _, ok := vocabulary[item.Str()]; !ok {
+			return
+		}
+		safe = append(safe, item.Str())
+	}
+	if len(safe) == 0 {
+		return
+	}
+	destinationSlice := destination.PutEmptySlice(key)
+	for _, item := range safe {
+		destinationSlice.AppendEmpty().SetStr(item)
+	}
+}
+
+func copySafeLinks(source, destination ptrace.SpanLinkSlice) {
+	for i := 0; i < source.Len(); i++ {
+		sourceLink := source.At(i)
+		destinationLink := destination.AppendEmpty()
+		destinationLink.SetTraceID(sourceLink.TraceID())
+		destinationLink.SetSpanID(sourceLink.SpanID())
+		destinationLink.SetFlags(sourceLink.Flags())
 	}
 }

--- a/services/langyagent/otel/angelinajolie.go
+++ b/services/langyagent/otel/angelinajolie.go
@@ -1,0 +1,147 @@
+// Package otel builds LangWatch's OWN copy of a Langy worker's telemetry.
+//
+// A worker's OTLP batch goes to the customer's project verbatim — it is their
+// agent, their prompts, their project. That path is untouched by this package.
+//
+// LangWatch also needs operational visibility into workers it runs: which model,
+// how many tokens, how long, what failed. It must NOT receive the content. The
+// worker is an opencode subprocess and its spans are the highest-density
+// prompt/completion surface in the system — the relay already accepts-and-drops
+// worker LOGS and METRICS for exactly that reason, but spans were never filtered
+// because they only ever went to the customer.
+//
+// InternalCopy is the boundary. It deep-copies the batch, keeps a strict
+// allowlist of shape-and-cost attributes, drops every span event (the classic
+// carrier: exception.message, exception.stacktrace, gen_ai prompt/completion
+// events), clears status descriptions (provider error text), and replaces the
+// worker's resource with LangWatch's own service identity.
+//
+// The allowlist is deliberate: a denylist fails open on the next key opencode's
+// instrumentation invents, and the whole point is that unknown keys are assumed
+// to carry content.
+package otel
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Resource keys stamped on LangWatch's copy. The worker's own resource
+// attributes are discarded wholesale rather than filtered — they describe the
+// customer's agent, and we are re-attributing this batch to our own service.
+const (
+	attrServiceName  = "service.name"
+	attrOrigin       = "langwatch.origin"
+	attrConversation = "langy.conversation_id"
+
+	serviceName  = "langwatch-langyworker"
+	originWorker = "langy_worker"
+)
+
+// spanAttributeAllowlist is the complete set of span attributes LangWatch's
+// copy may carry. Everything absent here is dropped, including keys that look
+// harmless — an unrecognised key is assumed to carry content until someone
+// deliberately adds it, with a test.
+//
+// Note what is NOT here: gen_ai.input.messages, gen_ai.output.messages,
+// gen_ai.system_instructions, gen_ai.prompt, gen_ai.completion, and every tool
+// argument or result key. Those are the customer's.
+var spanAttributeAllowlist = map[string]struct{}{
+	// Shape of the call.
+	"gen_ai.operation.name":  {},
+	"gen_ai.system":          {},
+	"gen_ai.request.model":   {},
+	"gen_ai.response.model":  {},
+	"gen_ai.conversation.id": {},
+
+	// Cost and size. Counts, never content.
+	"gen_ai.usage.input_tokens":                {},
+	"gen_ai.usage.output_tokens":               {},
+	"gen_ai.usage.total_tokens":                {},
+	"gen_ai.usage.cache_read.input_tokens":     {},
+	"gen_ai.usage.cache_creation.input_tokens": {},
+
+	// Outcome. finish_reasons is a fixed vocabulary ("stop", "length", ...);
+	// error.type is a classifier token, not a message.
+	"gen_ai.response.finish_reasons": {},
+	"error.type":                     {},
+
+	// Tool identity — which tool ran, never what it was called with or returned.
+	"gen_ai.tool.name":    {},
+	"gen_ai.tool.type":    {},
+	"gen_ai.tool.call.id": {},
+
+	// Transport shape. url.full and query strings are excluded on purpose:
+	// agent traffic routinely carries content in them.
+	"http.request.method":       {},
+	"http.response.status_code": {},
+	"server.address":            {},
+}
+
+// InternalCopy returns LangWatch's content-stripped copy of a worker OTLP
+// batch, re-parented under the turn so it joins the manager's own trace.
+//
+// td is NOT modified — the caller's batch stays intact for the customer path.
+// Re-parenting onto the turn is legitimate here in a way it is not for the
+// customer copy: this trace lives in LangWatch's backend, where the turn's
+// parent span actually exists.
+func InternalCopy(td ptrace.Traces, conversationID string, turn trace.SpanContext) ptrace.Traces {
+	out := ptrace.NewTraces()
+	td.CopyTo(out)
+
+	rss := out.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		rs := rss.At(i)
+		stampInternalResource(rs.Resource().Attributes(), conversationID)
+
+		sss := rs.ScopeSpans()
+		for j := 0; j < sss.Len(); j++ {
+			spans := sss.At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				sanitizeSpan(spans.At(k), turn)
+			}
+		}
+	}
+	return out
+}
+
+// stampInternalResource discards the worker's resource attributes and replaces
+// them with LangWatch's service identity. Clearing rather than filtering keeps
+// customer-set resource attributes (which opencode lets the agent influence)
+// out of our backend entirely.
+func stampInternalResource(attrs pcommon.Map, conversationID string) {
+	attrs.Clear()
+	attrs.PutStr(attrServiceName, serviceName)
+	attrs.PutStr(attrOrigin, originWorker)
+	attrs.PutStr(attrConversation, conversationID)
+}
+
+func sanitizeSpan(span ptrace.Span, turn trace.SpanContext) {
+	span.Attributes().RemoveIf(func(k string, _ pcommon.Value) bool {
+		_, allowed := spanAttributeAllowlist[k]
+		return !allowed
+	})
+
+	// Events carry exception.message / exception.stacktrace and, in several
+	// gen_ai instrumentations, the prompt and completion bodies themselves.
+	// None of it is worth the risk operationally.
+	span.Events().RemoveIf(func(ptrace.SpanEvent) bool { return true })
+
+	// Link attributes are attacker-influenced the same way span attributes are;
+	// the link's trace/span ids are the useful part.
+	links := span.Links()
+	for i := 0; i < links.Len(); i++ {
+		links.At(i).Attributes().Clear()
+	}
+
+	// Status descriptions are raw provider/runtime error text. Keep the code.
+	span.Status().SetMessage("")
+
+	if turn.IsValid() {
+		span.SetTraceID(pcommon.TraceID(turn.TraceID()))
+		if span.ParentSpanID().IsEmpty() {
+			span.SetParentSpanID(pcommon.SpanID(turn.SpanID()))
+		}
+	}
+}

--- a/services/langyagent/otel/angelinajolie_test.go
+++ b/services/langyagent/otel/angelinajolie_test.go
@@ -1,0 +1,231 @@
+package otel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	userPrompt = "here is my AWS secret AKIAIOSFODNN7EXAMPLE, deploy the staging stack"
+	modelReply = "I have deployed the stack. The admin password is correct-horse-battery."
+	toolOutput = "cat /etc/passwd -> root:x:0:0:root:/root:/bin/bash"
+)
+
+// workerBatch is a realistic opencode export: a gen_ai span carrying prompt and
+// completion bodies, a tool span carrying its arguments and result, an exception
+// event, a status description, and worker-set resource attributes.
+func workerBatch(t *testing.T) ptrace.Traces {
+	t.Helper()
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "opencode")
+	rs.Resource().Attributes().PutStr("customer.internal.hostname", "acme-laptop-01")
+
+	spans := rs.ScopeSpans().AppendEmpty().Spans()
+
+	chat := spans.AppendEmpty()
+	chat.SetName("chat gpt-5-mini")
+	chat.SetTraceID(pcommon.TraceID([16]byte{9}))
+	chat.SetSpanID(pcommon.SpanID([8]byte{1}))
+	chat.Attributes().PutStr("gen_ai.request.model", "gpt-5-mini")
+	chat.Attributes().PutInt("gen_ai.usage.input_tokens", 42)
+	chat.Attributes().PutStr("gen_ai.input.messages", userPrompt)
+	chat.Attributes().PutStr("gen_ai.output.messages", modelReply)
+	chat.Attributes().PutStr("gen_ai.system_instructions", "You are ACME's agent.")
+	chat.Status().SetMessage("upstream said: " + modelReply)
+	ev := chat.Events().AppendEmpty()
+	ev.SetName("exception")
+	ev.Attributes().PutStr("exception.message", "failed processing "+userPrompt)
+
+	tool := spans.AppendEmpty()
+	tool.SetName("tool.bash")
+	tool.SetTraceID(pcommon.TraceID([16]byte{9}))
+	tool.SetSpanID(pcommon.SpanID([8]byte{2}))
+	tool.SetParentSpanID(pcommon.SpanID([8]byte{1}))
+	tool.Attributes().PutStr("gen_ai.tool.name", "bash")
+	tool.Attributes().PutStr("gen_ai.tool.arguments", "cat /etc/passwd")
+	tool.Attributes().PutStr("gen_ai.tool.result", toolOutput)
+
+	return td
+}
+
+func turnContext(t *testing.T) trace.SpanContext {
+	t.Helper()
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID([16]byte{7}),
+		SpanID:  trace.SpanID([8]byte{7}),
+	})
+}
+
+// allValues returns every attribute value in the batch, flattened, so a test
+// can assert on content regardless of which key it hid under.
+func allValues(td ptrace.Traces) []string {
+	var out []string
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		rs := rss.At(i)
+		rs.Resource().Attributes().Range(func(_ string, v pcommon.Value) bool {
+			out = append(out, v.AsString())
+			return true
+		})
+		sss := rs.ScopeSpans()
+		for j := 0; j < sss.Len(); j++ {
+			spans := sss.At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+				out = append(out, span.Name(), span.Status().Message())
+				span.Attributes().Range(func(_ string, v pcommon.Value) bool {
+					out = append(out, v.AsString())
+					return true
+				})
+				evs := span.Events()
+				for e := 0; e < evs.Len(); e++ {
+					evs.At(e).Attributes().Range(func(_ string, v pcommon.Value) bool {
+						out = append(out, v.AsString())
+						return true
+					})
+				}
+			}
+		}
+	}
+	return out
+}
+
+func spanAttrs(td ptrace.Traces, name string) map[string]string {
+	got := map[string]string{}
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		sss := rss.At(i).ScopeSpans()
+		for j := 0; j < sss.Len(); j++ {
+			spans := sss.At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				if spans.At(k).Name() != name {
+					continue
+				}
+				spans.At(k).Attributes().Range(func(key string, v pcommon.Value) bool {
+					got[key] = v.AsString()
+					return true
+				})
+			}
+		}
+	}
+	return got
+}
+
+func TestInternalCopy_StripsPromptCompletionAndToolContent(t *testing.T) {
+	out := InternalCopy(workerBatch(t), "conv-1", turnContext(t))
+
+	for _, value := range allValues(out) {
+		for _, secret := range []string{userPrompt, modelReply, toolOutput} {
+			assert.NotContains(t, value, secret,
+				"worker content reached LangWatch's own copy")
+		}
+	}
+}
+
+// The fail-closed property. A key nobody anticipated must be dropped, not kept:
+// a denylist would ship it.
+func TestInternalCopy_DropsUnrecognisedAttributes(t *testing.T) {
+	td := workerBatch(t)
+	td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).
+		Attributes().PutStr("gen_ai.some.future.key", userPrompt)
+
+	out := InternalCopy(td, "conv-1", turnContext(t))
+
+	assert.NotContains(t, spanAttrs(out, "chat gpt-5-mini"), "gen_ai.some.future.key",
+		"an unrecognised key must be dropped, not forwarded")
+}
+
+func TestInternalCopy_KeepsOperationalMetadata(t *testing.T) {
+	out := InternalCopy(workerBatch(t), "conv-1", turnContext(t))
+
+	chat := spanAttrs(out, "chat gpt-5-mini")
+	assert.Equal(t, "gpt-5-mini", chat["gen_ai.request.model"])
+	assert.Equal(t, "42", chat["gen_ai.usage.input_tokens"])
+
+	tool := spanAttrs(out, "tool.bash")
+	assert.Equal(t, "bash", tool["gen_ai.tool.name"], "which tool ran is operational")
+	assert.NotContains(t, tool, "gen_ai.tool.arguments", "what it ran is content")
+	assert.NotContains(t, tool, "gen_ai.tool.result", "what it returned is content")
+}
+
+func TestInternalCopy_DropsAllSpanEvents(t *testing.T) {
+	out := InternalCopy(workerBatch(t), "conv-1", turnContext(t))
+
+	spans := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	for i := 0; i < spans.Len(); i++ {
+		assert.Zero(t, spans.At(i).Events().Len(),
+			"span events carry exception text and prompt bodies")
+	}
+}
+
+func TestInternalCopy_ClearsStatusMessage(t *testing.T) {
+	out := InternalCopy(workerBatch(t), "conv-1", turnContext(t))
+
+	spans := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	for i := 0; i < spans.Len(); i++ {
+		assert.Empty(t, spans.At(i).Status().Message(),
+			"status descriptions are raw provider text")
+	}
+}
+
+func TestInternalCopy_ReplacesWorkerResourceWithOurIdentity(t *testing.T) {
+	out := InternalCopy(workerBatch(t), "conv-1", turnContext(t))
+
+	attrs := out.ResourceSpans().At(0).Resource().Attributes()
+	got := map[string]string{}
+	attrs.Range(func(k string, v pcommon.Value) bool { got[k] = v.AsString(); return true })
+
+	assert.Equal(t, serviceName, got[attrServiceName])
+	assert.Equal(t, originWorker, got[attrOrigin])
+	assert.Equal(t, "conv-1", got[attrConversation])
+	assert.NotContains(t, got, "customer.internal.hostname",
+		"worker-set resource attributes must not reach our backend")
+}
+
+// The customer's batch must be byte-for-byte what it was before — their path is
+// not degraded by our copy existing.
+func TestInternalCopy_DoesNotMutateTheCustomerBatch(t *testing.T) {
+	td := workerBatch(t)
+	before, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
+	require.NoError(t, err)
+
+	_ = InternalCopy(td, "conv-1", turnContext(t))
+
+	after, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "the customer-bound batch was mutated by our copy")
+}
+
+func TestInternalCopy_ReparentsOntoTheTurn(t *testing.T) {
+	turn := turnContext(t)
+
+	out := InternalCopy(workerBatch(t), "conv-1", turn)
+
+	spans := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	for i := 0; i < spans.Len(); i++ {
+		assert.Equal(t, pcommon.TraceID(turn.TraceID()), spans.At(i).TraceID())
+	}
+	// The root span adopts the turn span; the child keeps its own parent.
+	assert.Equal(t, pcommon.SpanID(turn.SpanID()), spans.At(0).ParentSpanID())
+	assert.Equal(t, pcommon.SpanID([8]byte{1}), spans.At(1).ParentSpanID(),
+		"the worker's internal hierarchy must survive")
+}
+
+func TestInternalCopy_LeavesIDsAloneWithoutATurn(t *testing.T) {
+	out := InternalCopy(workerBatch(t), "conv-1", trace.SpanContext{})
+
+	span := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	assert.Equal(t, pcommon.TraceID([16]byte{9}), span.TraceID())
+	// Stripping still happened even though re-parenting did not.
+	for _, value := range allValues(out) {
+		assert.False(t, strings.Contains(value, userPrompt),
+			"content must be stripped regardless of turn validity")
+	}
+}

--- a/services/langyagent/otel/angelinajolie_test.go
+++ b/services/langyagent/otel/angelinajolie_test.go
@@ -116,6 +116,26 @@ func TestInternalCopy_KeepsOnlyTrustedOperationalMetadata(t *testing.T) {
 	assert.NotContains(t, tool, "gen_ai.tool.result")
 }
 
+func TestInternalCopy_PreservesHTTPSpanLatencyMetadata(t *testing.T) {
+	td := workerBatch(t)
+	source := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1)
+	source.SetKind(ptrace.SpanKindClient)
+	source.SetStartTimestamp(pcommon.Timestamp(1_000_000_000))
+	source.SetEndTimestamp(pcommon.Timestamp(1_350_000_000))
+	source.Attributes().PutStr("http.request.method", "POST")
+	source.Attributes().PutInt("http.response.status_code", 201)
+
+	out := InternalCopy(td, "conv-1", trustedModel, turnContext(t))
+	span := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1)
+	attrs := spanAttrsAt(out, 1)
+
+	assert.Equal(t, ptrace.SpanKindClient, span.Kind())
+	assert.Equal(t, source.StartTimestamp(), span.StartTimestamp())
+	assert.Equal(t, source.EndTimestamp(), span.EndTimestamp())
+	assert.Equal(t, "POST", attrs["http.request.method"])
+	assert.Equal(t, "201", attrs["http.response.status_code"])
+}
+
 func TestInternalCopy_RejectsEveryFreeFormOTLPCarrier(t *testing.T) {
 	const secret = "customer-secret-abcdef"
 	td := workerBatch(t)
@@ -160,9 +180,7 @@ func TestInternalCopy_RejectsEveryFreeFormOTLPCarrier(t *testing.T) {
 	assert.Empty(t, outSpan.TraceState().AsRaw())
 	assert.Zero(t, outSpan.Events().Len())
 	assert.Empty(t, outSpan.Status().Message())
-	require.Equal(t, 1, outSpan.Links().Len())
-	assert.Empty(t, outSpan.Links().At(0).TraceState().AsRaw())
-	assert.Zero(t, outSpan.Links().At(0).Attributes().Len())
+	assert.Zero(t, outSpan.Links().Len(), "worker-controlled links must not cross the boundary")
 }
 
 func TestInternalCopy_ReplacesWorkerResourceWithOurIdentity(t *testing.T) {
@@ -197,15 +215,21 @@ func TestInternalCopy_ReparentsOntoTheTurn(t *testing.T) {
 	spans := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
 	for i := 0; i < spans.Len(); i++ {
 		assert.Equal(t, pcommon.TraceID(turn.TraceID()), spans.At(i).TraceID())
+		assert.Equal(t, pcommon.SpanID(turn.SpanID()), spans.At(i).ParentSpanID())
 	}
-	assert.Equal(t, pcommon.SpanID(turn.SpanID()), spans.At(0).ParentSpanID())
-	assert.Equal(t, pcommon.SpanID([8]byte{1}), spans.At(1).ParentSpanID())
+	assert.NotEqual(t, pcommon.SpanID([8]byte{1}), spans.At(0).SpanID())
+	assert.NotEqual(t, pcommon.SpanID([8]byte{2}), spans.At(1).SpanID())
 }
 
-func TestInternalCopy_LeavesIDsAloneWithoutATurn(t *testing.T) {
+func TestInternalCopy_RegeneratesWorkerIDsWithoutATurn(t *testing.T) {
 	out := InternalCopy(workerBatch(t), "conv-1", trustedModel, trace.SpanContext{})
 
-	span := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-	assert.Equal(t, pcommon.TraceID([16]byte{9}), span.TraceID())
+	spans := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	assert.NotEqual(t, pcommon.TraceID([16]byte{9}), spans.At(0).TraceID())
+	assert.NotEqual(t, pcommon.SpanID([8]byte{1}), spans.At(0).SpanID())
+	assert.NotEqual(t, pcommon.SpanID([8]byte{2}), spans.At(1).SpanID())
+	assert.Equal(t, spans.At(0).TraceID(), spans.At(1).TraceID())
+	assert.Empty(t, spans.At(0).ParentSpanID())
+	assert.Empty(t, spans.At(1).ParentSpanID())
 	assert.NotContains(t, string(marshalTraces(t, out)), userPrompt)
 }

--- a/services/langyagent/otel/angelinajolie_test.go
+++ b/services/langyagent/otel/angelinajolie_test.go
@@ -104,10 +104,12 @@ func TestInternalCopy_KeepsOnlyTrustedOperationalMetadata(t *testing.T) {
 	out := InternalCopy(workerBatch(t), "conv-1", trustedModel, turnContext(t))
 
 	chat := spanAttrsAt(out, 0)
+	chatSpan := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	assert.Equal(t, trustedModel, chat["gen_ai.request.model"])
 	assert.Equal(t, "42", chat["gen_ai.usage.input_tokens"])
 	assert.Equal(t, "chat", chat["gen_ai.operation.name"])
 	assert.Equal(t, "openai", chat["gen_ai.system"])
+	assert.Equal(t, ptrace.StatusCodeError, chatSpan.Status().Code())
 
 	tool := spanAttrsAt(out, 1)
 	assert.Equal(t, "function", tool["gen_ai.tool.type"])

--- a/services/langyagent/otel/angelinajolie_test.go
+++ b/services/langyagent/otel/angelinajolie_test.go
@@ -1,7 +1,7 @@
 package otel
 
 import (
-	"strings"
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,14 +12,12 @@ import (
 )
 
 const (
-	userPrompt = "here is my AWS secret AKIAIOSFODNN7EXAMPLE, deploy the staging stack"
-	modelReply = "I have deployed the stack. The admin password is correct-horse-battery."
-	toolOutput = "cat /etc/passwd -> root:x:0:0:root:/root:/bin/bash"
+	userPrompt   = "here is my AWS secret AKIAIOSFODNN7EXAMPLE, deploy the staging stack"
+	modelReply   = "I have deployed the stack. The admin password is correct-horse-battery."
+	toolOutput   = "cat /etc/passwd -> root:x:0:0:root:/root:/bin/bash"
+	trustedModel = "gpt-5-mini"
 )
 
-// workerBatch is a realistic opencode export: a gen_ai span carrying prompt and
-// completion bodies, a tool span carrying its arguments and result, an exception
-// event, a status description, and worker-set resource attributes.
 func workerBatch(t *testing.T) ptrace.Traces {
 	t.Helper()
 	td := ptrace.NewTraces()
@@ -28,20 +26,22 @@ func workerBatch(t *testing.T) ptrace.Traces {
 	rs.Resource().Attributes().PutStr("customer.internal.hostname", "acme-laptop-01")
 
 	spans := rs.ScopeSpans().AppendEmpty().Spans()
-
 	chat := spans.AppendEmpty()
-	chat.SetName("chat gpt-5-mini")
+	chat.SetName("chat worker-supplied-model")
 	chat.SetTraceID(pcommon.TraceID([16]byte{9}))
 	chat.SetSpanID(pcommon.SpanID([8]byte{1}))
-	chat.Attributes().PutStr("gen_ai.request.model", "gpt-5-mini")
+	chat.Attributes().PutStr("gen_ai.operation.name", "chat")
+	chat.Attributes().PutStr("gen_ai.system", "openai")
+	chat.Attributes().PutStr("gen_ai.request.model", "worker-supplied-model")
 	chat.Attributes().PutInt("gen_ai.usage.input_tokens", 42)
 	chat.Attributes().PutStr("gen_ai.input.messages", userPrompt)
 	chat.Attributes().PutStr("gen_ai.output.messages", modelReply)
 	chat.Attributes().PutStr("gen_ai.system_instructions", "You are ACME's agent.")
+	chat.Status().SetCode(ptrace.StatusCodeError)
 	chat.Status().SetMessage("upstream said: " + modelReply)
-	ev := chat.Events().AppendEmpty()
-	ev.SetName("exception")
-	ev.Attributes().PutStr("exception.message", "failed processing "+userPrompt)
+	event := chat.Events().AppendEmpty()
+	event.SetName("exception")
+	event.Attributes().PutStr("exception.message", "failed processing "+userPrompt)
 
 	tool := spans.AppendEmpty()
 	tool.SetName("tool.bash")
@@ -49,6 +49,7 @@ func workerBatch(t *testing.T) ptrace.Traces {
 	tool.SetSpanID(pcommon.SpanID([8]byte{2}))
 	tool.SetParentSpanID(pcommon.SpanID([8]byte{1}))
 	tool.Attributes().PutStr("gen_ai.tool.name", "bash")
+	tool.Attributes().PutStr("gen_ai.tool.type", "function")
 	tool.Attributes().PutStr("gen_ai.tool.arguments", "cat /etc/passwd")
 	tool.Attributes().PutStr("gen_ai.tool.result", toolOutput)
 
@@ -63,169 +64,148 @@ func turnContext(t *testing.T) trace.SpanContext {
 	})
 }
 
-// allValues returns every attribute value in the batch, flattened, so a test
-// can assert on content regardless of which key it hid under.
-func allValues(td ptrace.Traces) []string {
-	var out []string
-	rss := td.ResourceSpans()
-	for i := 0; i < rss.Len(); i++ {
-		rs := rss.At(i)
-		rs.Resource().Attributes().Range(func(_ string, v pcommon.Value) bool {
-			out = append(out, v.AsString())
-			return true
-		})
-		sss := rs.ScopeSpans()
-		for j := 0; j < sss.Len(); j++ {
-			spans := sss.At(j).Spans()
-			for k := 0; k < spans.Len(); k++ {
-				span := spans.At(k)
-				out = append(out, span.Name(), span.Status().Message())
-				span.Attributes().Range(func(_ string, v pcommon.Value) bool {
-					out = append(out, v.AsString())
-					return true
-				})
-				evs := span.Events()
-				for e := 0; e < evs.Len(); e++ {
-					evs.At(e).Attributes().Range(func(_ string, v pcommon.Value) bool {
-						out = append(out, v.AsString())
-						return true
-					})
-				}
-			}
-		}
-	}
-	return out
-}
-
-func spanAttrs(td ptrace.Traces, name string) map[string]string {
+func spanAttrsAt(td ptrace.Traces, index int) map[string]string {
 	got := map[string]string{}
-	rss := td.ResourceSpans()
-	for i := 0; i < rss.Len(); i++ {
-		sss := rss.At(i).ScopeSpans()
-		for j := 0; j < sss.Len(); j++ {
-			spans := sss.At(j).Spans()
-			for k := 0; k < spans.Len(); k++ {
-				if spans.At(k).Name() != name {
-					continue
-				}
-				spans.At(k).Attributes().Range(func(key string, v pcommon.Value) bool {
-					got[key] = v.AsString()
-					return true
-				})
-			}
-		}
-	}
+	span := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(index)
+	span.Attributes().Range(func(key string, value pcommon.Value) bool {
+		got[key] = value.AsString()
+		return true
+	})
 	return got
 }
 
-func TestInternalCopy_StripsPromptCompletionAndToolContent(t *testing.T) {
-	out := InternalCopy(workerBatch(t), "conv-1", turnContext(t))
+func marshalTraces(t *testing.T, td ptrace.Traces) []byte {
+	t.Helper()
+	payload, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
+	require.NoError(t, err)
+	return payload
+}
 
-	for _, value := range allValues(out) {
-		for _, secret := range []string{userPrompt, modelReply, toolOutput} {
-			assert.NotContains(t, value, secret,
-				"worker content reached LangWatch's own copy")
-		}
+func TestInternalCopy_StripsPromptCompletionAndToolContent(t *testing.T) {
+	out := InternalCopy(workerBatch(t), "conv-1", trustedModel, turnContext(t))
+	payload := marshalTraces(t, out)
+
+	for _, secret := range []string{userPrompt, modelReply, toolOutput} {
+		assert.NotContains(t, string(payload), secret, "worker content reached LangWatch's copy")
 	}
 }
 
-// The fail-closed property. A key nobody anticipated must be dropped, not kept:
-// a denylist would ship it.
 func TestInternalCopy_DropsUnrecognisedAttributes(t *testing.T) {
 	td := workerBatch(t)
 	td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).
 		Attributes().PutStr("gen_ai.some.future.key", userPrompt)
 
-	out := InternalCopy(td, "conv-1", turnContext(t))
+	out := InternalCopy(td, "conv-1", trustedModel, turnContext(t))
 
-	assert.NotContains(t, spanAttrs(out, "chat gpt-5-mini"), "gen_ai.some.future.key",
-		"an unrecognised key must be dropped, not forwarded")
+	assert.NotContains(t, spanAttrsAt(out, 0), "gen_ai.some.future.key")
 }
 
-func TestInternalCopy_KeepsOperationalMetadata(t *testing.T) {
-	out := InternalCopy(workerBatch(t), "conv-1", turnContext(t))
+func TestInternalCopy_KeepsOnlyTrustedOperationalMetadata(t *testing.T) {
+	out := InternalCopy(workerBatch(t), "conv-1", trustedModel, turnContext(t))
 
-	chat := spanAttrs(out, "chat gpt-5-mini")
-	assert.Equal(t, "gpt-5-mini", chat["gen_ai.request.model"])
+	chat := spanAttrsAt(out, 0)
+	assert.Equal(t, trustedModel, chat["gen_ai.request.model"])
 	assert.Equal(t, "42", chat["gen_ai.usage.input_tokens"])
+	assert.Equal(t, "chat", chat["gen_ai.operation.name"])
+	assert.Equal(t, "openai", chat["gen_ai.system"])
 
-	tool := spanAttrs(out, "tool.bash")
-	assert.Equal(t, "bash", tool["gen_ai.tool.name"], "which tool ran is operational")
-	assert.NotContains(t, tool, "gen_ai.tool.arguments", "what it ran is content")
-	assert.NotContains(t, tool, "gen_ai.tool.result", "what it returned is content")
+	tool := spanAttrsAt(out, 1)
+	assert.Equal(t, "function", tool["gen_ai.tool.type"])
+	assert.NotContains(t, tool, "gen_ai.tool.name", "worker-controlled tool names are content carriers")
+	assert.NotContains(t, tool, "gen_ai.tool.arguments")
+	assert.NotContains(t, tool, "gen_ai.tool.result")
 }
 
-func TestInternalCopy_DropsAllSpanEvents(t *testing.T) {
-	out := InternalCopy(workerBatch(t), "conv-1", turnContext(t))
+func TestInternalCopy_RejectsEveryFreeFormOTLPCarrier(t *testing.T) {
+	const secret = "customer-secret-abcdef"
+	td := workerBatch(t)
+	rs := td.ResourceSpans().At(0)
+	rs.SetSchemaUrl("https://" + secret + "/resource")
+	rs.Resource().Attributes().PutStr("secret.resource", secret)
 
-	spans := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
-	for i := 0; i < spans.Len(); i++ {
-		assert.Zero(t, spans.At(i).Events().Len(),
-			"span events carry exception text and prompt bodies")
-	}
-}
+	ss := rs.ScopeSpans().At(0)
+	ss.SetSchemaUrl("https://" + secret + "/scope")
+	ss.Scope().SetName(secret)
+	ss.Scope().SetVersion(secret)
+	ss.Scope().Attributes().PutStr("secret.scope", secret)
 
-func TestInternalCopy_ClearsStatusMessage(t *testing.T) {
-	out := InternalCopy(workerBatch(t), "conv-1", turnContext(t))
+	span := ss.Spans().At(0)
+	span.SetName(secret)
+	span.TraceState().FromRaw("vendor=" + secret)
+	span.Attributes().PutStr("gen_ai.request.model", secret)
+	span.Attributes().PutStr("gen_ai.system", secret)
+	span.Status().SetMessage(secret)
+	event := span.Events().AppendEmpty()
+	event.SetName(secret)
+	event.Attributes().PutStr("secret.event", secret)
+	link := span.Links().AppendEmpty()
+	link.SetTraceID(pcommon.TraceID([16]byte{3}))
+	link.SetSpanID(pcommon.SpanID([8]byte{4}))
+	link.TraceState().FromRaw("vendor=" + secret)
+	link.Attributes().PutStr("secret.link", secret)
 
-	spans := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
-	for i := 0; i < spans.Len(); i++ {
-		assert.Empty(t, spans.At(i).Status().Message(),
-			"status descriptions are raw provider text")
-	}
+	out := InternalCopy(td, "conv-safe", trustedModel, turnContext(t))
+	payload := marshalTraces(t, out)
+	assert.False(t, bytes.Contains(payload, []byte(secret)), "a worker-controlled string survived the boundary")
+
+	outRS := out.ResourceSpans().At(0)
+	outSS := outRS.ScopeSpans().At(0)
+	outSpan := outSS.Spans().At(0)
+	assert.Empty(t, outRS.SchemaUrl())
+	assert.Empty(t, outSS.SchemaUrl())
+	assert.Equal(t, internalScopeName, outSS.Scope().Name())
+	assert.Empty(t, outSS.Scope().Version())
+	assert.Zero(t, outSS.Scope().Attributes().Len())
+	assert.Equal(t, internalSpanName, outSpan.Name())
+	assert.Empty(t, outSpan.TraceState().AsRaw())
+	assert.Zero(t, outSpan.Events().Len())
+	assert.Empty(t, outSpan.Status().Message())
+	require.Equal(t, 1, outSpan.Links().Len())
+	assert.Empty(t, outSpan.Links().At(0).TraceState().AsRaw())
+	assert.Zero(t, outSpan.Links().At(0).Attributes().Len())
 }
 
 func TestInternalCopy_ReplacesWorkerResourceWithOurIdentity(t *testing.T) {
-	out := InternalCopy(workerBatch(t), "conv-1", turnContext(t))
+	out := InternalCopy(workerBatch(t), "conv-1", trustedModel, turnContext(t))
 
 	attrs := out.ResourceSpans().At(0).Resource().Attributes()
 	got := map[string]string{}
-	attrs.Range(func(k string, v pcommon.Value) bool { got[k] = v.AsString(); return true })
+	attrs.Range(func(key string, value pcommon.Value) bool {
+		got[key] = value.AsString()
+		return true
+	})
 
 	assert.Equal(t, serviceName, got[attrServiceName])
 	assert.Equal(t, originWorker, got[attrOrigin])
 	assert.Equal(t, "conv-1", got[attrConversation])
-	assert.NotContains(t, got, "customer.internal.hostname",
-		"worker-set resource attributes must not reach our backend")
+	assert.NotContains(t, got, "customer.internal.hostname")
 }
 
-// The customer's batch must be byte-for-byte what it was before — their path is
-// not degraded by our copy existing.
 func TestInternalCopy_DoesNotMutateTheCustomerBatch(t *testing.T) {
 	td := workerBatch(t)
-	before, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
-	require.NoError(t, err)
+	before := marshalTraces(t, td)
 
-	_ = InternalCopy(td, "conv-1", turnContext(t))
+	_ = InternalCopy(td, "conv-1", trustedModel, turnContext(t))
 
-	after, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
-	require.NoError(t, err)
-	assert.Equal(t, before, after, "the customer-bound batch was mutated by our copy")
+	assert.Equal(t, before, marshalTraces(t, td))
 }
 
 func TestInternalCopy_ReparentsOntoTheTurn(t *testing.T) {
 	turn := turnContext(t)
-
-	out := InternalCopy(workerBatch(t), "conv-1", turn)
+	out := InternalCopy(workerBatch(t), "conv-1", trustedModel, turn)
 
 	spans := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
 	for i := 0; i < spans.Len(); i++ {
 		assert.Equal(t, pcommon.TraceID(turn.TraceID()), spans.At(i).TraceID())
 	}
-	// The root span adopts the turn span; the child keeps its own parent.
 	assert.Equal(t, pcommon.SpanID(turn.SpanID()), spans.At(0).ParentSpanID())
-	assert.Equal(t, pcommon.SpanID([8]byte{1}), spans.At(1).ParentSpanID(),
-		"the worker's internal hierarchy must survive")
+	assert.Equal(t, pcommon.SpanID([8]byte{1}), spans.At(1).ParentSpanID())
 }
 
 func TestInternalCopy_LeavesIDsAloneWithoutATurn(t *testing.T) {
-	out := InternalCopy(workerBatch(t), "conv-1", trace.SpanContext{})
+	out := InternalCopy(workerBatch(t), "conv-1", trustedModel, trace.SpanContext{})
 
 	span := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	assert.Equal(t, pcommon.TraceID([16]byte{9}), span.TraceID())
-	// Stripping still happened even though re-parenting did not.
-	for _, value := range allValues(out) {
-		assert.False(t, strings.Contains(value, userPrompt),
-			"content must be stripped regardless of turn validity")
-	}
+	assert.NotContains(t, string(marshalTraces(t, out)), userPrompt)
 }

--- a/services/nlpgo/config.go
+++ b/services/nlpgo/config.go
@@ -85,6 +85,9 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	}
 	cfg.OTel.SampleRatioSet = os.Getenv("OTEL_SAMPLE_RATIO") != ""
 	cfg.OTel.ResolveSampleRatio(cfg.Environment)
+	if err := cfg.OTel.Validate(); err != nil {
+		return Config{}, err
+	}
 	if err := config.Validate(ctx, cfg); err != nil {
 		return Config{}, err
 	}

--- a/services/nlpgo/config.go
+++ b/services/nlpgo/config.go
@@ -7,6 +7,7 @@ package nlpgo
 
 import (
 	"context"
+	"os"
 
 	"github.com/langwatch/langwatch/pkg/clog"
 	"github.com/langwatch/langwatch/pkg/config"
@@ -82,6 +83,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	if err := config.Hydrate(&cfg); err != nil {
 		return Config{}, err
 	}
+	cfg.OTel.SampleRatioSet = os.Getenv("OTEL_SAMPLE_RATIO") != ""
 	cfg.OTel.ResolveSampleRatio(cfg.Environment)
 	if err := config.Validate(ctx, cfg); err != nil {
 		return Config{}, err

--- a/services/nlpgo/config.go
+++ b/services/nlpgo/config.go
@@ -69,7 +69,9 @@ func defaultConfig() Config {
 			SandboxPython:            "python3",
 		},
 		OTel: config.OTel{
-			SampleRatio: 1.0, // overridden to 0.1 for non-local in LoadConfig
+			// Left unset so an operator-supplied ratio is distinguishable
+			// from the default; resolved in LoadConfig.
+			SampleRatio: config.UnsetSampleRatio,
 		},
 	}
 }
@@ -80,9 +82,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	if err := config.Hydrate(&cfg); err != nil {
 		return Config{}, err
 	}
-	if cfg.OTel.SampleRatio == 1.0 && cfg.Environment != "local" {
-		cfg.OTel.SampleRatio = 0.1
-	}
+	cfg.OTel.ResolveSampleRatio(cfg.Environment)
 	if err := config.Validate(ctx, cfg); err != nil {
 		return Config{}, err
 	}

--- a/services/nlpgo/config.go
+++ b/services/nlpgo/config.go
@@ -84,8 +84,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 		return Config{}, err
 	}
 	cfg.OTel.SampleRatioSet = os.Getenv("OTEL_SAMPLE_RATIO") != ""
-	cfg.OTel.ResolveSampleRatio(cfg.Environment)
-	if err := cfg.OTel.Validate(); err != nil {
+	if err := cfg.OTel.Resolve(cfg.Environment); err != nil {
 		return Config{}, err
 	}
 	if err := config.Validate(ctx, cfg); err != nil {

--- a/services/nlpgo/deps.go
+++ b/services/nlpgo/deps.go
@@ -21,11 +21,14 @@ import (
 // can't end up in one another's traces even when the same Lambda
 // container handles both.
 //
-// Endpoint resolution mirrors the legacy Python service: read
-// `LANGWATCH_ENDPOINT` (the universal LangWatch URL env var), append
-// the OTLP traces path. Falls back to the generic `OTEL_OTLP_ENDPOINT`
-// only when LANGWATCH_ENDPOINT is unset, for environments that wire
-// OTel via the standard OTel env vars.
+// The router's destination is CUSTOMER trace routing, which is product
+// configuration — `LANGWATCH_ENDPOINT` (the universal LangWatch URL env
+// var) + the OTLP ingest path — and deliberately NOT the official
+// OTEL_EXPORTER_OTLP_* namespace: in a dev shell that namespace points
+// every service's OWN telemetry at the local observability stack, and
+// reading it here would silently divert customer studio traces into it.
+// The deprecated `OTEL_OTLP_ENDPOINT` fallback is kept for environments
+// that predate LANGWATCH_ENDPOINT wiring.
 func configureNLPGoOTel(ctx context.Context, cfg Config, nodeID string) (*otelsetup.Provider, error) {
 	endpoint := strings.TrimSpace(os.Getenv("LANGWATCH_ENDPOINT"))
 	if endpoint != "" {
@@ -35,6 +38,12 @@ func configureNLPGoOTel(ctx context.Context, cfg Config, nodeID string) (*otelse
 		if endpoint != "" && !strings.HasSuffix(endpoint, "/v1/traces") {
 			endpoint = strings.TrimRight(endpoint, "/") + "/v1/traces"
 		}
+	}
+	if cfg.OTel.ExporterEndpoint != "" || cfg.OTel.ExporterTracesEndpoint != "" {
+		// Loud, not silent: the official exporter vars have no effect on
+		// nlpgo until it grows an ops-span pipeline with a content
+		// allowlist (like aigateway's). Tracked as follow-up work.
+		clog.Get(ctx).Warn("nlpgo ignores OTEL_EXPORTER_OTLP_ENDPOINT: spans are routed per-tenant to the LangWatch ingest derived from LANGWATCH_ENDPOINT; the debug collector still applies for local development")
 	}
 	// NLPGO_SPAN_SYNC=1 swaps the per-tenant BatchSpanProcessor for a
 	// SimpleSpanProcessor — every span.End() blocks on the OTLP
@@ -50,7 +59,7 @@ func configureNLPGoOTel(ctx context.Context, cfg Config, nodeID string) (*otelse
 	return otelsetup.New(ctx, otelsetup.Options{
 		NodeID:                 nodeID,
 		OTLPEndpoint:           endpoint,
-		SampleRatio:            cfg.OTel.SampleRatio,
+		Sampler:                cfg.OTel.SamplerChoice(),
 		MultiTenant:            true,
 		SyncExport:             syncExport,
 		DebugCollectorEndpoint: debugEndpoint,

--- a/services/nlpgo/deps.go
+++ b/services/nlpgo/deps.go
@@ -30,20 +30,20 @@ import (
 // The deprecated `OTEL_OTLP_ENDPOINT` fallback is kept for environments
 // that predate LANGWATCH_ENDPOINT wiring.
 func configureNLPGoOTel(ctx context.Context, cfg Config, nodeID string) (*otelsetup.Provider, error) {
+	// LANGWATCH_ENDPOINT is the ONLY source for the customer router. The
+	// pre-unification fallback to OTEL_OTLP_ENDPOINT was removed when that
+	// name became the deprecated alias for the INTERNAL collector: one var
+	// carrying both meanings is exactly how a config mistake inverts a
+	// tenant boundary silently — an operator pointing "nlpgo's own
+	// telemetry" at the internal stack would have routed customer studio
+	// content there instead. Losing telemetry is recoverable; misrouting it
+	// is not, so an unset LANGWATCH_ENDPOINT fails toward exporting nothing,
+	// loudly.
 	endpoint := strings.TrimSpace(os.Getenv("LANGWATCH_ENDPOINT"))
 	if endpoint != "" {
 		endpoint = strings.TrimRight(endpoint, "/") + "/api/otel/v1/traces"
-	} else {
-		endpoint = cfg.OTel.OTLPEndpoint
-		if endpoint != "" && !strings.HasSuffix(endpoint, "/v1/traces") {
-			endpoint = strings.TrimRight(endpoint, "/") + "/v1/traces"
-		}
-	}
-	if cfg.OTel.ExporterEndpoint != "" || cfg.OTel.ExporterTracesEndpoint != "" {
-		// Loud, not silent: the official exporter vars have no effect on
-		// nlpgo until it grows an ops-span pipeline with a content
-		// allowlist (like aigateway's). Tracked as follow-up work.
-		clog.Get(ctx).Warn("nlpgo ignores OTEL_EXPORTER_OTLP_ENDPOINT: spans are routed per-tenant to the LangWatch ingest derived from LANGWATCH_ENDPOINT; the debug collector still applies for local development")
+	} else if cfg.OTel.OTLPEndpoint != "" || cfg.OTel.ExporterEndpoint != "" || cfg.OTel.ExporterTracesEndpoint != "" {
+		clog.Get(ctx).Warn("nlpgo customer trace export is OFF: set LANGWATCH_ENDPOINT — the OTEL_* endpoints configure LangWatch's own telemetry and never route customer traces (an nlpgo ops-span pipeline is tracked as follow-up; the debug collector still applies for local development)")
 	}
 	// NLPGO_SPAN_SYNC=1 swaps the per-tenant BatchSpanProcessor for a
 	// SimpleSpanProcessor — every span.End() blocks on the OTLP

--- a/specs/langy/langy-otel-tracing.feature
+++ b/specs/langy/langy-otel-tracing.feature
@@ -79,6 +79,52 @@ Feature: Langy agent activity is traced into the user's project
     Then the manager rejects it and forwards nothing
 
   # ============================================================================
+  # LangWatch's own copy of worker telemetry
+  #
+  # The customer's project gets the worker's spans verbatim — their agent, their
+  # prompts. LangWatch also needs to see how its own workers behave, but must
+  # not receive the content, so a SECOND, content-stripped copy goes to
+  # LangWatch's collector. Worker logs and metrics are already dropped outright
+  # for the same reason; spans are filtered per attribute instead, because their
+  # shape and cost data is the operational signal.
+  # ============================================================================
+
+  Scenario: LangWatch keeps an operational copy of worker telemetry
+    Given the manager is configured with its own OTLP collector
+    When the worker exports a span batch
+    Then the batch is forwarded to the customer's project unchanged
+    And a second copy is delivered to LangWatch's own collector
+
+  Scenario: LangWatch's copy carries no prompt or completion content
+    When the worker exports a span batch containing prompts, completions and tool output
+    Then LangWatch's copy contains none of that content
+    And LangWatch's copy still reports the model and token usage
+
+  Scenario: An unrecognised span attribute is dropped from LangWatch's copy
+    Given the worker emits a span attribute LangWatch does not recognise
+    When the batch is copied for LangWatch's collector
+    Then the unrecognised attribute is dropped
+    # Fail closed: a new key from the agent's instrumentation is assumed to
+    # carry content until it is deliberately allowlisted.
+
+  Scenario: Span events and status descriptions are removed from LangWatch's copy
+    Given a worker span carries an exception event and a status description
+    When the batch is copied for LangWatch's collector
+    Then the copy carries no span events
+    And the copy carries no status description
+
+  Scenario: The worker's resource identity is replaced in LangWatch's copy
+    When the batch is copied for LangWatch's collector
+    Then the resource names LangWatch's own worker service and the conversation
+    And no worker-set resource attribute survives
+
+  Scenario: The customer's export is unaffected by the second copy
+    Given the manager has no OTLP collector of its own configured
+    When the worker exports a span batch
+    Then the batch still reaches the customer's project
+    And no second copy is sent anywhere
+
+  # ============================================================================
   # Manager-mediated LLM calls (phase 2)
   # ============================================================================
 

--- a/specs/langy/langy-otel-tracing.feature
+++ b/specs/langy/langy-otel-tracing.feature
@@ -89,40 +89,38 @@ Feature: Langy agent activity is traced into the user's project
   # shape and cost data is the operational signal.
   # ============================================================================
 
-  Scenario: LangWatch keeps an operational copy of worker telemetry
-    Given the manager is configured with its own OTLP collector
-    When the worker exports a span batch
-    Then the batch is forwarded to the customer's project unchanged
-    And a second copy is delivered to LangWatch's own collector
+  Scenario: Worker telemetry remains complete for the customer
+    Given the manager is running a worker for a customer conversation
+    When the worker reports its activity
+    Then the customer's trace contains the worker's complete activity
+    And the worker's prompts, completions and tool output remain visible there
 
-  Scenario: LangWatch's copy carries no prompt or completion content
-    When the worker exports a span batch containing prompts, completions and tool output
-    Then LangWatch's copy contains none of that content
-    And LangWatch's copy still reports the model and token usage
+  Scenario: Operators retain useful worker health signals without customer content
+    Given the worker reports model usage and an upstream failure
+    When LangWatch records operational worker telemetry
+    Then operators can see the model, token usage and failure outcome
+    And LangWatch cannot see the customer's prompts, completions or tool output
 
-  Scenario: An unrecognised span attribute is dropped from LangWatch's copy
-    Given the worker emits a span attribute LangWatch does not recognise
-    When the batch is copied for LangWatch's collector
-    Then the unrecognised attribute is dropped
-    # Fail closed: a new key from the agent's instrumentation is assumed to
-    # carry content until it is deliberately allowlisted.
+  Scenario: Newly introduced worker metadata cannot expose customer content
+    Given the worker reports an unrecognised metadata value
+    When LangWatch records operational worker telemetry
+    Then the unrecognised value is absent from LangWatch's operational view
 
-  Scenario: Span events and status descriptions are removed from LangWatch's copy
-    Given a worker span carries an exception event and a status description
-    When the batch is copied for LangWatch's collector
-    Then the copy carries no span events
-    And the copy carries no status description
+  Scenario: Worker diagnostics do not expose raw error text
+    Given a worker reports an exception and a provider error description
+    When LangWatch records operational worker telemetry
+    Then operators can see that the worker failed
+    And raw exception and provider error text is absent
 
-  Scenario: The worker's resource identity is replaced in LangWatch's copy
-    When the batch is copied for LangWatch's collector
-    Then the resource names LangWatch's own worker service and the conversation
-    And no worker-set resource attribute survives
+  Scenario: Worker identity is not presented as customer identity
+    When LangWatch records operational worker telemetry
+    Then it identifies the LangWatch worker and conversation
+    And customer-controlled worker resource metadata is absent
 
-  Scenario: The customer's export is unaffected by the second copy
-    Given the manager has no OTLP collector of its own configured
-    When the worker exports a span batch
-    Then the batch still reaches the customer's project
-    And no second copy is sent anywhere
+  Scenario: Customer telemetry is unaffected when operational recording is unavailable
+    Given LangWatch cannot record operational worker telemetry
+    When the worker reports its activity
+    Then the customer's trace still contains the worker's complete activity
 
   # ============================================================================
   # Manager-mediated LLM calls (phase 2)

--- a/specs/langy/langy-otel-tracing.feature
+++ b/specs/langy/langy-otel-tracing.feature
@@ -123,6 +123,36 @@ Feature: Langy agent activity is traced into the user's project
     Then the customer's trace still contains the worker's complete activity
 
   # ============================================================================
+  # Provenance cannot be forged by the worker
+  #
+  # The worker is model-driven and prompt-injectable, so anything it says about
+  # who it is must be treated as a claim, not a fact. LangWatch marks its own
+  # telemetry as platform-internal; a worker that brands its spans the same way
+  # would launder customer content into LangWatch's own view, so the claim is
+  # removed on the way to the customer's project no matter how it is dressed up.
+  # ============================================================================
+
+  Scenario: A worker cannot claim its telemetry is LangWatch's own
+    Given the worker claims its telemetry is LangWatch's own
+    When the manager forwards that activity to the customer's project
+    Then the provenance claim is absent from the forwarded trace
+
+  Scenario: Repeating the provenance claim does not smuggle it through
+    Given the worker repeats its provenance claim several times in one batch
+    When the manager forwards that activity to the customer's project
+    Then no copy of the provenance claim survives in the forwarded trace
+
+  Scenario: Moving the provenance claim onto individual spans does not smuggle it through
+    Given the worker attaches its provenance claim to individual spans
+    When the manager forwards that activity to the customer's project
+    Then the provenance claim is absent from every forwarded span
+
+  Scenario: Repeating a reserved grouping key does not override the manager's value
+    Given the worker repeats a reserved grouping key several times in one batch
+    When the manager forwards that activity to the customer's project
+    Then the forwarded trace carries only the manager's value for that key
+
+  # ============================================================================
   # Manager-mediated LLM calls (phase 2)
   # ============================================================================
 

--- a/tools/thuishaven/domain/overlay.go
+++ b/tools/thuishaven/domain/overlay.go
@@ -159,8 +159,8 @@ func (s Stack) observabilityEnv() []string {
 	}
 	otlp := fmt.Sprintf("http://127.0.0.1:%d", s.ObservabilityOTLPPort)
 	env := []string{
-		"OTEL_EXPORTER_OTLP_ENDPOINT=" + otlp,   // TS: traces + logs + metrics
-		"OTEL_DEBUG_COLLECTOR_ENDPOINT=" + otlp, // Go: dual-export, additive to the product trace path
+		"OTEL_EXPORTER_OTLP_ENDPOINT=" + otlp,   // official name — TS app AND Go services (their own telemetry)
+		"OTEL_DEBUG_COLLECTOR_ENDPOINT=" + otlp, // Go OTLP logs ride this; span/metric export dedupes when equal to the official endpoint
 		"PINO_OTEL_ENABLED=true",
 		"OTEL_METRICS_ENABLED=true",
 		"LOG_OTEL_LEVEL=debug",


### PR DESCRIPTION
## Why

The audit of langwatch/langwatch#5907 turned up a tenant boundary that could invert. The gateway resolved a customer's trace-project ID and its OTLP token from two different reads of the control-plane config, so a snapshot that changed between them could pair one tenant's token with another tenant's destination — a customer's spans exported into someone else's project.

The same audit exposed the other half of the problem. We had almost no operational visibility into our own data planes, because the only way to trace them was to trace the customer payloads flowing through them. So we didn't, and debugging the gateway and the Langy workers meant guessing.

Both halves are the same question — *whose telemetry is this, and where is it allowed to go* — and neither was answerable from the config.

## What changed

**Stopped the cross-tenant export.** Trace-project IDs and OTLP tokens now come from a single config snapshot, so they cannot be paired across tenants. Customer exporters get rebuilt when credentials or destinations change instead of holding a stale pairing, and export failures surface rather than being swallowed as success. A missing, cleared, or unregistered destination fails closed.

**Started tracing our own planes, without the content.** The gateway emits internal spans about itself, and Langy keeps a bounded, content-stripped operational copy of worker telemetry. Customers' own telemetry stays complete and unchanged — the internal copy is a separate, additional export that carries operational shape only. Gateway-internal model and provider metadata is limited to values the control plane configured, so a worker cannot smuggle content through it.

**Made the telemetry config say what it means.** Every Go service and the TS app now read the official OpenTelemetry environment variables — `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG`, and the rest — through one resolver (`pkg/config.OTel.Resolve`). One pod env block configures every LangWatch process identically.

**Made bad telemetry config fail at boot rather than at runtime.** An explicitly configured sampling ratio is now honoured exactly, including `0` and `1` (previously an out-of-range or NaN value could land on always-sample, maximising precisely what the operator was trying to reduce). A protocol we cannot speak, a ratio outside `[0,1]`, an old and new env name set to conflicting values, or a debug collector pointed off-box are all boot errors. An unset endpoint means the exporter is **off** — never the SDK's localhost default.

## How it works

The load-bearing rule is a namespace split: **`OTEL_*` configures LangWatch's own telemetry and nothing else.** Customer trace destinations are product configuration — per-project OTLP tokens, the customer trace bridge, `LANGWATCH_ENDPOINT` — and are never sourced from an `OTEL_*` variable. That is what bounds the blast radius: a wrong `OTEL_*` value can misroute *our* spans, never a tenant's.

Provenance is stamped in the payload rather than inferred from the environment. `langwatch.origin=platform_internal` goes on single-tenant resources only — never on the multi-tenant or nlpgo resource, which reaches customers — and is stripped from worker payloads on the Langy customer forward, because a worker can forge it.

## Test plan

- `go test ./services/aigateway/... ./services/langyagent/... ./pkg/config/... ./pkg/otelsetup/...`
- `golangci-lint v2.11.4 run ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/... ./tools/migrationorder/...` — 0 issues
- New coverage pins the boundaries directly: `pkg/config/otel_validate_test.go` (every fail-closed refusal), `pkg/otelsetup/internal_origin_test.go` (the marker never lands on a multi-tenant resource), `services/aigateway/app/pipeline/trace_project_test.go` and `middleware_trace_registry_test.go` (token/destination pairing), `services/langyagent/adapters/otelrelay/dual_export_test.go` (customer telemetry stays complete while the internal copy stays stripped), `services/langyagent/otel/angelinajolie_test.go` (exact-key-set assertions on internal span attributes).
- `specs/langy/langy-otel-tracing.feature` updated for the observable contract.

## Deployment impact

**A vanilla install is unchanged.** If you do not configure OTLP export, nothing here turns on.

**The old names still work, but they now warn.** `OTEL_OTLP_ENDPOINT`, `OTEL_OTLP_HEADERS`, and `OTEL_SAMPLE_RATIO` are read as deprecated fallbacks and log a rename warning at boot. Setting an official name *and* its deprecated fallback to **different** values is a boot error — precedence between two live values is never silently guessed. Set one or the other.

**Two behaviours changed for existing deployments:**

1. An explicitly set sampling ratio is now honoured exactly. If you were relying on an out-of-range value being clamped upward, your sample rate will drop to what you actually asked for.
2. Telemetry config that was previously ignored is now a boot error. Most relevant to self-hosters: **if a Kubernetes OTel Operator injects `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` into these pods, they will now refuse to start**, where before they ignored it and exported over http/protobuf anyway. See "Anything surprising".

For BYOC dataplanes, Langy sends the content-stripped operational worker copy to the internal OTLP collector you have already configured. No collector configured means that export stays off and customer telemetry behaviour is unchanged.

No new environment variables, Helm values, or migrations.

## Anything surprising?

**The injected-env question is deliberately unresolved.** Hard-failing on an unsupported `OTEL_EXPORTER_OTLP_PROTOCOL` is correct for a value that states an intent our exporters cannot satisfy — silence would be a lie. But operator-injected env is common, and this turns a previously-ignored variable into a crash loop. The two options are to keep the hard fail and carry a self-hoster release note, or to soften only the failures that cannot invert a tenant boundary (protocol and sampler → warn and degrade) while keeping conflicts and off-box debug collectors hard. **This PR ships the hard fail; the call is worth making explicitly before merge.**

**Known gaps, deliberately not handled here:**

- Ingest does not yet reject `langwatch.origin`-marked payloads addressed to a non-internal project. That needs a project flag and is the belt to this PR's braces.
- nlpgo's official exporter variables are warn-and-ignore; it has no ops-span pipeline with a content allowlist yet.
- The TS app reads the same variables but has no fail-closed validation, so the guarantee is currently asymmetric between the Go services and the app.
- Umbrella-chart docs still point at the deprecated header names.

**On CI:** `sdk-python-ci` fails on `tests/test_examples.py::test_example[examples/distributed_tracing.py]` with an OpenAI `insufficient_quota` 429. That is an exhausted API key, unrelated to this change.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional internal OTLP telemetry mirroring with content-stripped operational spans, bounded queueing, and best-effort delivery.
  * Improved per-project trace routing to the correct ingest endpoint/token, with safer trace-project credential selection and rebuild on changes.
  * Enhanced gateway tracing with additional upstream error/status attributes and internal span stamping for operational metadata.

* **Bug Fixes**
  * Fail-closed behavior for missing/cleared/unregistered destinations; span export failures are now surfaced instead of suppressed.
  * Updated OpenTelemetry sampling so an explicitly configured `0` is preserved, with environment-aware defaults for unset values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->