### PR TITLE
fix(nlpgo): withhold pod environment from code-block subprocess

### DIFF
--- a/services/nlpgo/app/engine/blocks/codeblock/codeblock.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/codeblock.go
@@ -43,6 +43,46 @@ type Options struct {
 	RunnerPath string
 	// DefaultTimeout caps execution when the request doesn't specify one.
 	DefaultTimeout time.Duration
+	// EnvAllowlist names the environment variables propagated into the
+	// user-code subprocess. Anything not named here is withheld — the
+	// runner never inherits the pod environment, so AWS credentials, the
+	// projected service-account token path, LANGWATCH_* internals, and
+	// DB/Redis/ClickHouse secrets stay out of reach of user code.
+	//
+	// Semantics:
+	//   - nil            → defaultEnvAllowlist (secure default)
+	//   - non-nil empty  → pass nothing (maximally locked down)
+	//   - populated      → pass exactly those names, when present
+	//
+	// A project's own secrets reach user code via Request.Secrets (piped
+	// over stdin into the `secrets` namespace), never via the environment,
+	// so withholding the environment does not break the secrets contract.
+	EnvAllowlist []string
+}
+
+// defaultEnvAllowlist is the environment passed into the code-block
+// subprocess when Options.EnvAllowlist is nil. It carries only what the
+// Python runner legitimately needs — interpreter/locale/TLS-trust plumbing —
+// and deliberately excludes every credential-bearing variable in the pod.
+// Being an allowlist, any secret env var added to the deployment in future
+// is withheld automatically without a code change here.
+var defaultEnvAllowlist = []string{
+	"PATH",
+	"HOME",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"TMPDIR",
+	"PYTHONPATH",
+	"PYTHONHOME",
+	"PYTHONHASHSEED",
+	"PYTHONIOENCODING",
+	"PYTHONUNBUFFERED",
+	"PYTHONDONTWRITEBYTECODE",
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
+	"REQUESTS_CA_BUNDLE",
+	"CURL_CA_BUNDLE",
 }
 
 // Executor runs code blocks via a Python subprocess.
@@ -59,6 +99,12 @@ func New(opts Options) (*Executor, error) {
 	}
 	if opts.DefaultTimeout == 0 {
 		opts.DefaultTimeout = 60 * time.Second
+	}
+	// Secure default: a nil allowlist means "the caller didn't opt out of
+	// the safe default", NOT "inherit everything". A non-nil empty slice is
+	// respected as an explicit "pass nothing".
+	if opts.EnvAllowlist == nil {
+		opts.EnvAllowlist = defaultEnvAllowlist
 	}
 	runnerPath := opts.RunnerPath
 	if runnerPath == "" {
@@ -114,6 +160,25 @@ type Error struct {
 
 func (e *Error) String() string { return fmt.Sprintf("%s: %s", e.Type, e.Message) }
 
+// childEnv builds the environment handed to the user-code subprocess from
+// the configured allowlist. It always returns a non-nil slice — even when
+// no allowlisted variable is present — so the caller can assign it to
+// cmd.Env without risk of exec inheriting the full parent environment
+// (which is what a nil cmd.Env would do).
+func (e *Executor) childEnv() []string {
+	allow := e.opts.EnvAllowlist
+	if allow == nil {
+		allow = defaultEnvAllowlist
+	}
+	env := make([]string, 0, len(allow))
+	for _, name := range allow {
+		if v, ok := os.LookupEnv(name); ok {
+			env = append(env, name+"="+v)
+		}
+	}
+	return env
+}
+
 // Execute runs the request. Wall-clock timeout kills the subprocess.
 func (e *Executor) Execute(ctx context.Context, req Request) (*Result, error) {
 	timeout := req.Timeout
@@ -142,6 +207,10 @@ func (e *Executor) Execute(ctx context.Context, req Request) (*Result, error) {
 	}
 
 	cmd := exec.CommandContext(runCtx, e.opts.Python, e.runnerPath, resultPath) //nolint:gosec // runnerPath is operator-controlled
+	// Withhold the pod environment from user code. cmd.Env is always set to
+	// a non-nil slice so exec never falls back to inheriting os.Environ();
+	// see childEnv. Project secrets travel via the request payload, not here.
+	cmd.Env = e.childEnv()
 	cmd.Stdin = bytes.NewReader(payload)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	var stderrBuf bytes.Buffer

--- a/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
@@ -84,6 +84,60 @@ func TestCodeBlock_ExtraOutputKeysPreserved(t *testing.T) {
 	assert.Equal(t, []any{float64(1), float64(2), float64(3)}, scratch)
 }
 
+// TestCodeBlock_WithholdsPodEnvironment is the regression guard for the
+// env-exfiltration hotfix: user code must NOT see credential-bearing
+// variables from the pod environment, while the interpreter still receives
+// the allowlisted plumbing it needs. A secret set in the parent process
+// must be invisible to the subprocess; PATH (allowlisted) must be visible.
+func TestCodeBlock_WithholdsPodEnvironment(t *testing.T) {
+	requirePython(t)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "super-secret-should-not-leak")
+	t.Setenv("LANGWATCH_INTERNAL_TOKEN", "also-secret")
+
+	res, err := newExec(t).Execute(context.Background(), codeblock.Request{
+		Code: "import os\n" +
+			"def execute():\n" +
+			"    return {\n" +
+			"        'aws': os.environ.get('AWS_SECRET_ACCESS_KEY', '<absent>'),\n" +
+			"        'token': os.environ.get('LANGWATCH_INTERNAL_TOKEN', '<absent>'),\n" +
+			"        'has_path': bool(os.environ.get('PATH')),\n" +
+			"    }\n",
+		DeclaredOutputs: []string{"aws", "token", "has_path"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, res.Error, "expected no error, got %+v", res.Error)
+	assert.Equal(t, "<absent>", res.Outputs["aws"], "AWS secret leaked into user code env")
+	assert.Equal(t, "<absent>", res.Outputs["token"], "internal token leaked into user code env")
+	assert.Equal(t, true, res.Outputs["has_path"], "allowlisted PATH should still be present")
+}
+
+// TestCodeBlock_EmptyAllowlistPassesNothing verifies the explicit
+// lock-everything-down configuration: a non-nil empty allowlist yields a
+// subprocess with no environment at all (not an inherited one).
+func TestCodeBlock_EmptyAllowlistPassesNothing(t *testing.T) {
+	requirePython(t)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "super-secret-should-not-leak")
+
+	e, err := codeblock.New(codeblock.Options{EnvAllowlist: []string{}})
+	require.NoError(t, err)
+	res, err := e.Execute(context.Background(), codeblock.Request{
+		// PATH is allowlisted by the default set but NOT by an explicit
+		// empty allowlist, so its absence proves nothing from the parent
+		// environment (allowlisted or otherwise) was propagated.
+		Code: "import os\n" +
+			"def execute():\n" +
+			"    return {\n" +
+			"        'aws': os.environ.get('AWS_SECRET_ACCESS_KEY', '<absent>'),\n" +
+			"        'path': os.environ.get('PATH', '<absent>'),\n" +
+			"    }\n",
+		DeclaredOutputs: []string{"aws", "path"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, res.Error, "expected no error, got %+v", res.Error)
+	assert.Equal(t, "<absent>", res.Outputs["aws"], "secret must not leak under empty allowlist")
+	assert.Equal(t, "<absent>", res.Outputs["path"], "empty allowlist must pass no parent env vars, not even PATH")
+}
+
 func TestCodeBlock_RaisesAreStructured(t *testing.T) {
 	requirePython(t)
 	res, err := newExec(t).Execute(context.Background(), codeblock.Request{


### PR DESCRIPTION
## Summary

The code-block executor spawned the Python runner with `cmd.Env` **unset**. In Go a nil `cmd.Env` means the child **inherits the full parent environment** (`os.Environ()`), so any `os.environ` read in user code could see **every variable in the nlpgo pod** — AWS credentials, service-account token paths, `LANGWATCH_*` internals, and DB/Redis/ClickHouse secrets.

This wires `cmd.Env` from a **secure-by-default allowlist** carrying only what the Python runner legitimately needs (interpreter / locale / TLS-trust plumbing). `cmd.Env` is always assigned a non-nil slice, so exec can never silently fall back to inheriting `os.Environ()`.

Project secrets are unaffected: they already reach user code via `Request.Secrets` piped over stdin into the `secrets` namespace — never via the process environment — so withholding the environment does not break the secrets contract.

## Semantics of `Options.EnvAllowlist`
- `nil` → `defaultEnvAllowlist` (secure default)
- non-nil empty → pass nothing (maximally locked down)
- populated → pass exactly those names, when present

Being an allowlist, any secret env var added to the deployment in future is withheld automatically without a code change here.

## Tests
- `TestCodeBlock_WithholdsPodEnvironment` — a parent-set `AWS_SECRET_ACCESS_KEY` / `LANGWATCH_INTERNAL_TOKEN` is invisible to user code, while allowlisted `PATH` remains visible.
- `TestCodeBlock_EmptyAllowlistPassesNothing` — an explicit empty allowlist passes no parent env at all.
- Full `codeblock` package suite passes.

## Scope / follow-ups
- Covers the **in-process Go `codeblock`** path only.
- The **per-project Lambda** execution path (`langwatch-nlp-role`) injects credentials as env vars into the function's own process — there is no subprocess boundary there, so it needs a separate mitigation (run user code in a scrubbed subprocess inside the function, and/or keep the role near-zero-privilege). Tracked separately.
- Complementary infra hardening (egress NetworkPolicy on `langwatch-nlp`, `automount_service_account_token = false`) is in flight separately; env allowlisting does not remove token **files** from the pod filesystem — only OS-level sandboxing does.

https://claude.ai/code/session_013EZb3uXpGq34e1GyDbQoPk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved isolation for user code by restricting which environment variables are available to subprocesses.
  * Prevented credential-bearing environment variables from being exposed.
  * Added support for explicitly passing no environment variables when configured.

* **Tests**
  * Added coverage verifying environment secrets are withheld and allowlist behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->