### PR TITLE
feat(event-sourcing): count fold failures that left durable state behind

### DIFF
--- a/langwatch/src/server/__tests__/metrics-instrumentation.unit.test.ts
+++ b/langwatch/src/server/__tests__/metrics-instrumentation.unit.test.ts
@@ -118,6 +118,18 @@ describe("ES pipeline metrics", () => {
       );
       expect(metric).toBeDefined();
     });
+
+    /**
+     * Pinned by name: a rename or accidental removal would break the redelivery
+     * dashboard silently, and this counter is the only signal that separates a
+     * fold failure that left durable state behind from one that did not.
+     */
+    it("registers es_fold_post_store_failure_total counter", () => {
+      const metric = register.getSingleMetric(
+        "es_fold_post_store_failure_total",
+      );
+      expect(metric).toBeDefined();
+    });
   });
 
   describe("when deprecated metrics are removed", () => {

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldPostStoreFailure.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldPostStoreFailure.unit.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/metrics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/server/metrics")>();
+  return {
+    ...actual,
+    incrementEsFoldPostStoreFailure: vi.fn(),
+    incrementEsFoldProjectionTotal: vi.fn(),
+    observeEsFoldProjectionDuration: vi.fn(),
+    incrementEsFoldRefoldTotal: vi.fn(),
+    incrementEsReactorTotal: vi.fn(),
+    incrementEsReactorCollapsedTotal: vi.fn(),
+  };
+});
+
+import { incrementEsFoldPostStoreFailure } from "~/server/metrics";
+import type { Event } from "../../domain/types";
+import type { ReactorDefinition } from "../../reactors/reactor.types";
+import {
+  createMockFoldProjectionDefinition,
+  createMockFoldProjectionStore,
+  createMockQueueManager,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../services/__tests__/testHelpers";
+import { ProjectionRouter } from "../projectionRouter";
+
+/**
+ * A fold's state is written durably before its reactors are dispatched, so a
+ * reactor failure fails the job without un-writing it and the queue redelivers
+ * events the store already holds. Folds accumulate (trace summary does
+ * `spanCount + 1` and sums cost), so the re-apply double-counts.
+ *
+ * These pin the signal that separates that failure from one thrown *before* the
+ * write, which is harmless to retry and otherwise looks identical.
+ */
+describe("fold failures after the state was stored", () => {
+  const tenantId = createTestTenantId();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  const events = (count: number): Event[] =>
+    Array.from({ length: count }, (_, i) =>
+      createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        tenantId,
+        undefined,
+        1_000 + i,
+        undefined,
+        undefined,
+        `event-${i}`,
+      ),
+    );
+
+  /**
+   * No reactor queues, so the router runs the reactor inline; a rejecting
+   * handle is collected and rethrown as an AggregateError — the same shape a
+   * Redis blip on queue send produces, since both funnel into the same errors[].
+   */
+  async function dispatchBatch({
+    batch,
+    reactorFails,
+  }: {
+    batch: Event[];
+    reactorFails: boolean;
+  }): Promise<unknown> {
+    const queueManager = createMockQueueManager({ hasReactorQueues: false });
+    const router = new ProjectionRouter<Event>(
+      TEST_CONSTANTS.AGGREGATE_TYPE,
+      TEST_CONSTANTS.PIPELINE_NAME,
+      queueManager,
+    );
+
+    const store = createMockFoldProjectionStore<{ count: number }>();
+    (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const fold = createMockFoldProjectionDefinition("counter", {
+      store,
+      init: () => ({ count: 0 }),
+      apply: (state: { count: number }) => ({ count: state.count + 1 }),
+    });
+
+    const reactor: ReactorDefinition<Event> = {
+      name: "flakyReactor",
+      handle: reactorFails
+        ? vi.fn().mockRejectedValue(new Error("reactor boom"))
+        : vi.fn().mockResolvedValue(undefined),
+    };
+
+    router.registerFoldProjection(fold);
+    router.registerReactor("counter", reactor);
+    router.initializeFoldQueues();
+
+    const initialize = queueManager.initializeProjectionQueues as ReturnType<
+      typeof vi.fn
+    >;
+    const onEventBatch = initialize.mock.calls[0]?.[2] as (
+      projectionName: string,
+      events: Event[],
+      context: unknown,
+    ) => Promise<void>;
+
+    return await onEventBatch("counter", batch, { tenantId }).catch(
+      (error: unknown) => error,
+    );
+  }
+
+  describe("when a reactor throws after the fold state was stored", () => {
+    it("counts the failure as post-store, labelled by stage", async () => {
+      await dispatchBatch({ batch: events(3), reactorFails: true });
+
+      expect(incrementEsFoldPostStoreFailure).toHaveBeenCalledWith(
+        "counter",
+        "reactor_dispatch",
+      );
+    });
+
+    it("rethrows so the queue still retries the job", async () => {
+      const error = await dispatchBatch({
+        batch: events(3),
+        reactorFails: true,
+      });
+
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("when every reactor succeeds", () => {
+    it("counts nothing, because no state was left behind a failed job", async () => {
+      await dispatchBatch({ batch: events(3), reactorFails: false });
+
+      expect(incrementEsFoldPostStoreFailure).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldPostStoreFailure.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldPostStoreFailure.unit.test.ts
@@ -67,13 +67,13 @@ describe("fold failures after the state was stored", () => {
    * handle is collected and rethrown as an AggregateError — the same shape a
    * Redis blip on queue send produces, since both funnel into the same errors[].
    */
-  async function dispatchBatch({
-    batch,
-    shouldReactorFail,
+  function buildFoldQueues({
+    shouldReactorFail = false,
+    shouldStoreFail = false,
   }: {
-    batch: Event[];
-    shouldReactorFail: boolean;
-  }): Promise<unknown> {
+    shouldReactorFail?: boolean;
+    shouldStoreFail?: boolean;
+  }): ReturnType<typeof vi.fn> {
     const queueManager = createMockQueueManager({ hasReactorQueues: false });
     const router = new ProjectionRouter<Event>(
       TEST_CONSTANTS.AGGREGATE_TYPE,
@@ -83,6 +83,12 @@ describe("fold failures after the state was stored", () => {
 
     const store = createMockFoldProjectionStore<{ count: number }>();
     (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    if (shouldStoreFail) {
+      (store.store as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("store boom"),
+      );
+    }
+
     const fold = createMockFoldProjectionDefinition("counter", {
       store,
       init: () => ({ count: 0 }),
@@ -100,16 +106,39 @@ describe("fold failures after the state was stored", () => {
     router.registerReactor("counter", reactor);
     router.initializeFoldQueues();
 
-    const initialize = queueManager.initializeProjectionQueues as ReturnType<
-      typeof vi.fn
-    >;
-    const onEventBatch = initialize.mock.calls[0]?.[2] as (
+    return queueManager.initializeProjectionQueues as ReturnType<typeof vi.fn>;
+  }
+
+  /** The coalesced path — `processFoldProjectionBatch`. */
+  async function dispatchBatch(options: {
+    batch: Event[];
+    shouldReactorFail?: boolean;
+    shouldStoreFail?: boolean;
+  }): Promise<unknown> {
+    const onEventBatch = buildFoldQueues(options).mock.calls[0]?.[2] as (
       projectionName: string,
       events: Event[],
       context: unknown,
     ) => Promise<void>;
 
-    return await onEventBatch("counter", batch, { tenantId }).catch(
+    return await onEventBatch("counter", options.batch, { tenantId }).catch(
+      (error: unknown) => error,
+    );
+  }
+
+  /** The single-event path — `processFoldProjectionEvent`, same wrapper. */
+  async function dispatchSingle(options: {
+    event: Event;
+    shouldReactorFail?: boolean;
+    shouldStoreFail?: boolean;
+  }): Promise<unknown> {
+    const onEvent = buildFoldQueues(options).mock.calls[0]?.[1] as (
+      projectionName: string,
+      event: Event,
+      context: unknown,
+    ) => Promise<void>;
+
+    return await onEvent("counter", options.event, { tenantId }).catch(
       (error: unknown) => error,
     );
   }
@@ -132,12 +161,33 @@ describe("fold failures after the state was stored", () => {
 
       expect(error).toBeInstanceOf(Error);
     });
+
+    it("counts it on the single-event path too, not only the batch path", async () => {
+      await dispatchSingle({ event: events(1)[0]!, shouldReactorFail: true });
+
+      expect(incrementEsFoldPostStoreFailure).toHaveBeenCalledWith({
+        projectionName: "counter",
+        stage: "reactor_dispatch",
+      });
+    });
   });
 
   describe("when every reactor succeeds", () => {
     it("counts nothing, because no state was left behind a failed job", async () => {
       await dispatchBatch({ batch: events(3), shouldReactorFail: false });
 
+      expect(incrementEsFoldPostStoreFailure).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the fold throws before its state was stored", () => {
+    it("counts nothing, because the retry re-applies against unchanged state", async () => {
+      const error = await dispatchBatch({
+        batch: events(3),
+        shouldStoreFail: true,
+      });
+
+      expect(error).toBeInstanceOf(Error);
       expect(incrementEsFoldPostStoreFailure).not.toHaveBeenCalled();
     });
   });

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldPostStoreFailure.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldPostStoreFailure.unit.test.ts
@@ -69,10 +69,10 @@ describe("fold failures after the state was stored", () => {
    */
   async function dispatchBatch({
     batch,
-    reactorFails,
+    shouldReactorFail,
   }: {
     batch: Event[];
-    reactorFails: boolean;
+    shouldReactorFail: boolean;
   }): Promise<unknown> {
     const queueManager = createMockQueueManager({ hasReactorQueues: false });
     const router = new ProjectionRouter<Event>(
@@ -91,7 +91,7 @@ describe("fold failures after the state was stored", () => {
 
     const reactor: ReactorDefinition<Event> = {
       name: "flakyReactor",
-      handle: reactorFails
+      handle: shouldReactorFail
         ? vi.fn().mockRejectedValue(new Error("reactor boom"))
         : vi.fn().mockResolvedValue(undefined),
     };
@@ -116,18 +116,18 @@ describe("fold failures after the state was stored", () => {
 
   describe("when a reactor throws after the fold state was stored", () => {
     it("counts the failure as post-store, labelled by stage", async () => {
-      await dispatchBatch({ batch: events(3), reactorFails: true });
+      await dispatchBatch({ batch: events(3), shouldReactorFail: true });
 
-      expect(incrementEsFoldPostStoreFailure).toHaveBeenCalledWith(
-        "counter",
-        "reactor_dispatch",
-      );
+      expect(incrementEsFoldPostStoreFailure).toHaveBeenCalledWith({
+        projectionName: "counter",
+        stage: "reactor_dispatch",
+      });
     });
 
     it("rethrows so the queue still retries the job", async () => {
       const error = await dispatchBatch({
         batch: events(3),
-        reactorFails: true,
+        shouldReactorFail: true,
       });
 
       expect(error).toBeInstanceOf(Error);
@@ -136,7 +136,7 @@ describe("fold failures after the state was stored", () => {
 
   describe("when every reactor succeeds", () => {
     it("counts nothing, because no state was left behind a failed job", async () => {
-      await dispatchBatch({ batch: events(3), reactorFails: false });
+      await dispatchBatch({ batch: events(3), shouldReactorFail: false });
 
       expect(incrementEsFoldPostStoreFailure).not.toHaveBeenCalled();
     });

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -1495,7 +1495,7 @@ export class ProjectionRouter<
     events: EventType[];
     error: unknown;
   }): void {
-    incrementEsFoldPostStoreFailure(projectionName, stage);
+    incrementEsFoldPostStoreFailure({ projectionName, stage });
     const first = events[0];
     this.logger.warn(
       {

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -1444,32 +1444,54 @@ export class ProjectionRouter<
           },
         });
 
-        // After fold succeeds, dispatch to reactors for this fold.
-        //
-        // The fold state is durable by this point. Anything that throws from
-        // here on fails the job without un-writing it, so the queue redelivers
-        // events the store already contains — see recordPostStoreFailure.
-        const reactors = this.reactorsForFold.get(projectionName);
-        if (reactors && reactors.length > 0) {
-          try {
-            await this.dispatchToReactors({
-              foldName: projectionName,
-              reactors,
-              events: [event],
-              foldState,
-            });
-          } catch (error) {
-            this.recordPostStoreFailure({
-              projectionName,
-              stage: "reactor_dispatch",
-              events: [event],
-              error,
-            });
-            throw error;
-          }
-        }
+        // After fold succeeds, dispatch to reactors for this fold. The fold
+        // state is durable by this point, so a throw from here redelivers
+        // events the store already contains.
+        await this.dispatchReactorsAfterStore({
+          projectionName,
+          events: [event],
+          foldState,
+        });
       },
     );
+  }
+
+  /**
+   * Dispatches a fold's reactors once its state is already durable.
+   *
+   * Anything that throws from here fails the job without un-writing the state,
+   * so the queue redelivers events the store already holds — see
+   * {@link recordPostStoreFailure}. Shared by the single-event and batch paths
+   * so the two cannot drift on the exact path this counter measures.
+   */
+  private async dispatchReactorsAfterStore({
+    projectionName,
+    events,
+    foldState,
+  }: {
+    projectionName: string;
+    events: EventType[];
+    foldState: unknown;
+  }): Promise<void> {
+    const reactors = this.reactorsForFold.get(projectionName);
+    if (!reactors || reactors.length === 0) return;
+
+    try {
+      await this.dispatchToReactors({
+        foldName: projectionName,
+        reactors,
+        events,
+        foldState,
+      });
+    } catch (error) {
+      this.recordPostStoreFailure({
+        projectionName,
+        stage: "reactor_dispatch",
+        events,
+        error,
+      });
+      throw error;
+    }
   }
 
   /**
@@ -1617,28 +1639,15 @@ export class ProjectionRouter<
         // to one job by the queue's dedup anyway, so dispatchToReactors collapses
         // them here instead of paying N serialize+gzip+blob round-trips to reach
         // the same state. See ProjectionRouter.collapseByJobId.
-        const reactors = this.reactorsForFold.get(projectionName);
-        if (reactors && reactors.length > 0) {
-          try {
-            await this.dispatchToReactors({
-              foldName: projectionName,
-              reactors,
-              events: toApply,
-              foldState,
-            });
-          } catch (error) {
-            // Worse here than on the single-event path: the whole coalesced
-            // batch is re-applied, so one failure can double-count up to
-            // DEFAULT_FOLD_COALESCE_MAX_BATCH events against one aggregate.
-            this.recordPostStoreFailure({
-              projectionName,
-              stage: "reactor_dispatch",
-              events: toApply,
-              error,
-            });
-            throw error;
-          }
-        }
+        //
+        // A post-store failure is worse here than on the single-event path: the
+        // whole coalesced batch is re-applied, so one failure can double-count
+        // up to DEFAULT_FOLD_COALESCE_MAX_BATCH events against one aggregate.
+        await this.dispatchReactorsAfterStore({
+          projectionName,
+          events: toApply,
+          foldState,
+        });
       },
     );
   }

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -7,6 +7,7 @@ import {
 } from "~/server/app-layer/config";
 import type { FeatureFlagServiceInterface } from "~/server/featureFlag/types";
 import {
+  incrementEsFoldPostStoreFailure,
   incrementEsFoldProjectionTotal,
   incrementEsMapProjectionTotal,
   incrementEsProjectionTotal,
@@ -65,6 +66,14 @@ import type { ReplayMarkerChecker } from "./replayMarkerCheck";
  */
 const DEFAULT_FOLD_COALESCE_MAX_BATCH = 500;
 const SLOW_PROJECTION_OPERATION_MS = 5_000;
+
+/**
+ * Event ids carried in a post-store-failure log line. A coalesced batch holds
+ * up to DEFAULT_FOLD_COALESCE_MAX_BATCH events and the whole line would be
+ * unreadable; the ids exist to locate the affected aggregate for reconciliation,
+ * and the aggregate id already narrows it. eventCount reports the true size.
+ */
+const MAX_LOGGED_EVENT_IDS = 10;
 
 /**
  * The router only ever dispatches reactors on the live event path — the
@@ -1435,17 +1444,70 @@ export class ProjectionRouter<
           },
         });
 
-        // After fold succeeds, dispatch to reactors for this fold
+        // After fold succeeds, dispatch to reactors for this fold.
+        //
+        // The fold state is durable by this point. Anything that throws from
+        // here on fails the job without un-writing it, so the queue redelivers
+        // events the store already contains — see recordPostStoreFailure.
         const reactors = this.reactorsForFold.get(projectionName);
         if (reactors && reactors.length > 0) {
-          await this.dispatchToReactors({
-            foldName: projectionName,
-            reactors,
-            events: [event],
-            foldState,
-          });
+          try {
+            await this.dispatchToReactors({
+              foldName: projectionName,
+              reactors,
+              events: [event],
+              foldState,
+            });
+          } catch (error) {
+            this.recordPostStoreFailure({
+              projectionName,
+              stage: "reactor_dispatch",
+              events: [event],
+              error,
+            });
+            throw error;
+          }
         }
       },
+    );
+  }
+
+  /**
+   * Records a failure that happened after the fold's state was durably stored.
+   *
+   * Distinct from a plain fold failure: the store already holds this batch, so
+   * the retry re-applies it. Accumulating folds (spanCount + 1, cost sums, id
+   * appends) double-count as a result — nothing on this path deduplicates by
+   * event id.
+   *
+   * Logged at warn with the aggregate and event ids so the affected traces can
+   * be identified and reconciled after an incident — the metric says how often,
+   * the log says which.
+   */
+  private recordPostStoreFailure({
+    projectionName,
+    stage,
+    events,
+    error,
+  }: {
+    projectionName: string;
+    stage: "reactor_dispatch";
+    events: EventType[];
+    error: unknown;
+  }): void {
+    incrementEsFoldPostStoreFailure(projectionName, stage);
+    const first = events[0];
+    this.logger.warn(
+      {
+        projection: projectionName,
+        stage,
+        tenantId: first ? String(first.tenantId) : undefined,
+        aggregateId: first ? String(first.aggregateId) : undefined,
+        eventCount: events.length,
+        eventIds: events.slice(0, MAX_LOGGED_EVENT_IDS).map((e) => e.id),
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Fold failed after its state was stored — the retry will re-apply events the store already holds",
     );
   }
 
@@ -1557,12 +1619,25 @@ export class ProjectionRouter<
         // the same state. See ProjectionRouter.collapseByJobId.
         const reactors = this.reactorsForFold.get(projectionName);
         if (reactors && reactors.length > 0) {
-          await this.dispatchToReactors({
-            foldName: projectionName,
-            reactors,
-            events: toApply,
-            foldState,
-          });
+          try {
+            await this.dispatchToReactors({
+              foldName: projectionName,
+              reactors,
+              events: toApply,
+              foldState,
+            });
+          } catch (error) {
+            // Worse here than on the single-event path: the whole coalesced
+            // batch is re-applied, so one failure can double-count up to
+            // DEFAULT_FOLD_COALESCE_MAX_BATCH events against one aggregate.
+            this.recordPostStoreFailure({
+              projectionName,
+              stage: "reactor_dispatch",
+              events: toApply,
+              error,
+            });
+            throw error;
+          }
         }
       },
     );

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -932,6 +932,39 @@ export const getLangyRateLimitCounter = (outcome: "rejected" | "fail_open") =>
   langyRateLimitTotal.labels(outcome);
 
 // ============================================================================
+// Fold redelivery
+// ============================================================================
+
+register.removeSingleMetric("es_fold_post_store_failure_total");
+const esFoldPostStoreFailure = new Counter({
+  name: "es_fold_post_store_failure_total",
+  help: "Fold deliveries that threw after their state was durably stored, by stage",
+  labelNames: ["projection_name", "stage"] as const,
+});
+
+/**
+ * A fold threw *after* its state was already written durably.
+ *
+ * Queue delivery is at-least-once and the fold's state is stored before
+ * reactors are dispatched, so anything that throws from that point fails the
+ * job without un-writing it: the queue re-delivers events the store already
+ * holds. Folds accumulate rather than being idempotent (trace summary does
+ * `spanCount + 1` and sums cost), so the re-apply double-counts.
+ *
+ * Every other fold signal reports this as a plain failure, which is
+ * indistinguishable from one that threw *before* the write and is therefore
+ * harmless to retry. The two need opposite responses, so they need separate
+ * counters.
+ *
+ * Rate against `es_fold_projection_total{status="failed"}` for the share of
+ * fold failures that land in the dangerous half.
+ */
+export const incrementEsFoldPostStoreFailure = (
+  projectionName: string,
+  stage: "reactor_dispatch",
+) => esFoldPostStoreFailure.labels(projectionName, stage).inc();
+
+// ============================================================================
 // Stored Objects Metrics
 // ============================================================================
 

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -959,10 +959,13 @@ const esFoldPostStoreFailure = new Counter({
  * Rate against `es_fold_projection_total{status="failed"}` for the share of
  * fold failures that land in the dangerous half.
  */
-export const incrementEsFoldPostStoreFailure = (
-  projectionName: string,
-  stage: "reactor_dispatch",
-) => esFoldPostStoreFailure.labels(projectionName, stage).inc();
+export const incrementEsFoldPostStoreFailure = ({
+  projectionName,
+  stage,
+}: {
+  projectionName: string;
+  stage: "reactor_dispatch";
+}) => esFoldPostStoreFailure.labels(projectionName, stage).inc();
 
 // ============================================================================
 // Stored Objects Metrics


### PR DESCRIPTION
A fold's state is written durably before its reactors are dispatched, so anything that throws from that point fails the job without un-writing it, and the queue redelivers events the store already holds. The folds accumulate — `traceSummary` does `spanCount + 1` and sums cost — so the re-apply double-counts.

Every existing signal reports this as a plain fold failure, which is indistinguishable from one thrown *before* the write and therefore harmless to retry. The two want opposite responses, so they get separate counters.

## What this adds

- `es_fold_post_store_failure_total{projection_name, stage}` — rated against `es_fold_projection_total{status="failed"}` to give the share of failures landing in the dangerous half.
- A warn log carrying tenant, aggregate and event ids: the counter says how often, the log says which traces need reconciling.

## What this does not change

Measurement only. The dispatch is wrapped and the error rethrown, so retry behaviour is identical. The fix for the underlying non-idempotency is separate — see #5918.

## Testing

- `foldPostStoreFailure.unit.test.ts` — covers the post-store failure path and the pre-store path that must *not* count.
- `metrics-instrumentation.unit.test.ts` — asserts the new counter is registered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring for failures that occur after event state has been stored.
  * Failed reactor processing continues to be retried correctly.
  * Warning logs now include relevant projection, tenant, event count, and event ID details.

* **Tests**
  * Added coverage for post-storage reactor failures and successful processing.
  * Added validation that the new failure metric is registered correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->