### PR TITLE
fix(observability): default ClickHouse backup metrics ON, opt out where there are no backups

### DIFF
--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -528,16 +528,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 - name: CLICKHOUSE_COLD_STORAGE_DEFAULT_TTL_DAYS
   value: {{ $chCold.defaultTtlDays | default "49" | quote }}
 {{- end }}
-{{/* Backup-status gauges (system.backup_log) are opt-in — the app/worker only
-     queries the backup log when CLICKHOUSE_BACKUP_METRICS_ENABLED=true. Couple
-     that to the backup config so the "Backup Reporting Absent" signal can never
-     drift from whether backups actually run: on whenever chart-managed backups
-     are enabled, or when an operator forces it for out-of-band backups. */}}
+{{/* Backup-status gauges (system.backup_log) are opt-OUT in the app/worker: an
+     unset CLICKHOUSE_BACKUP_METRICS_ENABLED collects, so no deployment can lose
+     the "Backup Reporting Absent" signal just by not knowing about the flag.
+     The chart states it explicitly in both directions, coupled to the backup
+     config: "true" wherever chart-managed backups run (or an operator forces it
+     for out-of-band backups), "false" where this chart knows there are no
+     backups and system.backup_log would not exist. */}}
 {{- $chBackup := (.Values.clickhouse).backup }}
-{{- if or ($chBackup).enabled ($chBackup).metricsEnabled }}
 - name: CLICKHOUSE_BACKUP_METRICS_ENABLED
-  value: "true"
-{{- end }}
+  value: {{ if or ($chBackup).enabled ($chBackup).metricsEnabled }}"true"{{ else }}"false"{{ end }}
 
 # Credentials encryption key
 {{- if .Values.app.credentialsEncryptionKey.secretKeyRef.name }}

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -219,11 +219,16 @@ test_backup_metrics_gate() {
 
   local backup_flags="--set autogen.enabled=true --set clickhouse.objectStorage.bucket=b --set clickhouse.objectStorage.region=us-east-1"
 
-  # Off by default: no backups configured -> no backup-log querying.
+  # No backups configured -> the chart opts OUT explicitly. The app defaults to
+  # collecting (an unset var must never disarm production monitoring), so the
+  # chart has to say "false" to stop the workers querying a table that this
+  # deployment does not have.
   local off
-  off=$(tmpl_only "templates/workers/deployment.yaml" --set autogen.enabled=true)
-  assert_not_contains "default: workers do not set backup metrics" \
-    "$off" "CLICKHOUSE_BACKUP_METRICS_ENABLED"
+  off=$(tmpl_only "templates/workers/deployment.yaml" --set autogen.enabled=true \
+    | grep -A1 "name: CLICKHOUSE_BACKUP_METRICS_ENABLED")
+  assert_contains "default: workers opt out of backup metrics" \
+    "$off" "name: CLICKHOUSE_BACKUP_METRICS_ENABLED"
+  assert_contains "default: backup metrics value false" "$off" '"false"'
 
   # Chart-managed backups on -> metrics auto-enabled on the workers (which emit
   # the gauges), so the alert never fires spuriously against a live backup setup.
@@ -243,6 +248,7 @@ test_backup_metrics_gate() {
     | grep -A1 "name: CLICKHOUSE_BACKUP_METRICS_ENABLED")
   assert_contains "metricsEnabled override: workers set backup metrics" \
     "$forced" "name: CLICKHOUSE_BACKUP_METRICS_ENABLED"
+  assert_contains "metricsEnabled override: backup metrics value true" "$forced" '"true"'
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/compose.yml
+++ b/compose.yml
@@ -5,6 +5,12 @@ services:
       SKIP_ENV_VALIDATION: true
       DATABASE_URL: postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
       CLICKHOUSE_URL: http://default:langwatch@clickhouse:8123/langwatch
+      # This compose stack runs a plain ClickHouse with no backups, so
+      # system.backup_log does not exist here. Backup-status collection is on by
+      # default (an unset flag must not disarm the alerts that read those gauges
+      # in deployments that do have backups), so opt out explicitly rather than
+      # failing the query on every stats tick.
+      CLICKHOUSE_BACKUP_METRICS_ENABLED: "false"
       REDIS_URL: redis://redis:6379
       LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
       LANGEVALS_ENDPOINT: http://langevals:5562
@@ -32,6 +38,12 @@ services:
       SKIP_ENV_VALIDATION: true
       DATABASE_URL: postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
       CLICKHOUSE_URL: http://default:langwatch@clickhouse:8123/langwatch
+      # This compose stack runs a plain ClickHouse with no backups, so
+      # system.backup_log does not exist here. Backup-status collection is on by
+      # default (an unset flag must not disarm the alerts that read those gauges
+      # in deployments that do have backups), so opt out explicitly rather than
+      # failing the query on every stats tick.
+      CLICKHOUSE_BACKUP_METRICS_ENABLED: "false"
       REDIS_URL: redis://redis:6379
       LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
       LANGEVALS_ENDPOINT: http://langevals:5562

--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -110,13 +110,16 @@ DATABASE_URL="postgresql://postgres@localhost:5432/langwatch_db?schema=langwatch
 
 # ClickHouse for analytics, trace indexing, and time-series data
 CLICKHOUSE_URL="http://localhost:8123/langwatch"
-# Opt in to backup-status gauges (queries system.backup_log every stats tick).
-# Only set this on deployments where ClickHouse backups are actually configured
-# (see charts/clickhouse-serverless) — everywhere else the table doesn't exist.
-# The langwatch Helm chart wires this automatically from clickhouse.backup.enabled
-# (override: clickhouse.backup.metricsEnabled), so operators using the chart never
-# set it by hand — this var is for non-chart deployments.
-#CLICKHOUSE_BACKUP_METRICS_ENABLED=true
+# Backup-status gauges (queries system.backup_log every stats tick) are ON by
+# default: production alerts read those gauges from deployments that set nothing,
+# so an unset value must never disarm them. Set this to false where ClickHouse
+# backups are NOT configured (local dev, CI, self-hosted without backups) — the
+# table doesn't exist there and the query fails on every tick for nothing.
+# Accepted opt-out values: false/0/no/off; anything else collects.
+# The langwatch Helm chart sets this in both directions from clickhouse.backup.enabled
+# (override: clickhouse.backup.metricsEnabled), and haven sets false for local
+# worktrees, so this var is for hand-rolled deployments.
+#CLICKHOUSE_BACKUP_METRICS_ENABLED=false
 
 # Redis for queues
 REDIS_URL=""

--- a/langwatch/packages/observability/src/__tests__/logger.unit.test.ts
+++ b/langwatch/packages/observability/src/__tests__/logger.unit.test.ts
@@ -3,7 +3,11 @@ import superjson from "superjson";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runWithContext } from "../context";
 import { getLogContext } from "../context/logging";
-import { consoleIgnoreFields, createLogger } from "../logger";
+import {
+  consoleIgnoreFields,
+  createLogger,
+  prettyConsoleOptions,
+} from "../logger";
 
 vi.mock("@opentelemetry/api", () => ({
   context: { active: vi.fn(() => ({})) },
@@ -195,6 +199,29 @@ describe("createLogger", () => {
 
     it("keeps business context when the console is the only output", () => {
       expect(consoleIgnoreFields(false)).toBe("pid,hostname");
+    });
+  });
+
+  describe("pretty console format", () => {
+    // A haven terminal interleaves this lane with the Go services' clog lane, so
+    // the two pretty formats have to agree. These pin the JS half; the Go half is
+    // prettyEncoderConfig in pkg/clog/clog.go.
+    it("prints a 24h wall-clock timestamp with milliseconds", () => {
+      expect(prettyConsoleOptions(false, "info").translateTime).toBe(
+        "SYS:HH:MM:ss.l",
+      );
+    });
+
+    it("never hides the log level", () => {
+      const ignored = String(prettyConsoleOptions(true, "warn").ignore).split(
+        ",",
+      );
+
+      expect(ignored).not.toContain("level");
+    });
+
+    it("honours the console level floor", () => {
+      expect(prettyConsoleOptions(false, "warn").minimumLevel).toBe("warn");
     });
   });
 });

--- a/langwatch/packages/observability/src/logger.ts
+++ b/langwatch/packages/observability/src/logger.ts
@@ -219,6 +219,39 @@ export function consoleIgnoreFields(isOtelExportEnabled: boolean): string {
     : BASE_CONSOLE_IGNORE;
 }
 
+/**
+ * The 24h wall-clock timestamp the pretty console prints: `[HH:MM:ss.mmm]`.
+ *
+ * Pinned rather than left to pino-pretty's default so it cannot drift, and
+ * because the Go services' clog encoder is configured to the same layout — a
+ * haven terminal interleaves both lanes, and two clock formats in one scrollback
+ * is unreadable. Change one side and you must change the other
+ * (pkg/clog/clog.go, prettyEncoderConfig).
+ */
+const PRETTY_TIME_FORMAT = "SYS:HH:MM:ss.l";
+
+/**
+ * Options for the pino-pretty console target, producing
+ * `[12:19:00.616] INFO (langwatch:api): message key=value`.
+ *
+ * The level is always shown and never in `ignore`: it is the first thing anyone
+ * scans a log for, and it is what tells a reader whether the line in front of
+ * them is the whole story or just the part loud enough to reach the console
+ * (under haven, info and below go to Grafana and only warn+ reaches here).
+ */
+export function prettyConsoleOptions(
+  isOtelExportEnabled: boolean,
+  level: string,
+): Record<string, unknown> {
+  return {
+    colorize: true,
+    singleLine: true,
+    translateTime: PRETTY_TIME_FORMAT,
+    ignore: consoleIgnoreFields(isOtelExportEnabled),
+    minimumLevel: level,
+  };
+}
+
 function buildConsoleTransport({
   usePretty,
   level,
@@ -231,12 +264,7 @@ function buildConsoleTransport({
   if (usePretty) {
     return {
       target: "pino-pretty",
-      options: {
-        colorize: true,
-        singleLine: true,
-        ignore: consoleIgnoreFields(isOtelExportEnabled),
-        minimumLevel: level,
-      },
+      options: prettyConsoleOptions(isOtelExportEnabled, level),
       level,
     };
   }

--- a/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
@@ -487,11 +487,37 @@ describe("ClickHouse metrics", () => {
       });
     });
 
-    describe("when backup metrics are not enabled (the default)", () => {
-      // system.backup_log only exists where backups are configured, so anywhere
-      // that hasn't opted in the collector must skip it entirely, leaving only
-      // parts + disks.
+    describe("when CLICKHOUSE_BACKUP_METRICS_ENABLED is unset (the default)", () => {
+      // Production workers never set this variable and live Grafana alerts read
+      // the gauges it feeds, so the default MUST keep collecting — a default-off
+      // flag would silently disarm backup monitoring on the next deploy.
+      beforeEach(() => {
+        delete process.env.CLICKHOUSE_BACKUP_METRICS_ENABLED;
+      });
+
+      it("still queries system.backup_log", async () => {
+        const client = buildMockClient(() => false);
+
+        await metrics.collectStorageStats(client);
+
+        expect(client.query).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: expect.stringContaining("system.backup_log"),
+          }),
+        );
+      });
+    });
+
+    describe("when backup metrics are explicitly disabled", () => {
+      // system.backup_log only exists where backups are configured, so the
+      // environments without them (local dev, CI, self-hosted) opt out and the
+      // collector skips it entirely, leaving only parts + disks.
+      afterEach(() => {
+        delete process.env.CLICKHOUSE_BACKUP_METRICS_ENABLED;
+      });
+
       it("skips the system.backup_log query entirely", async () => {
+        process.env.CLICKHOUSE_BACKUP_METRICS_ENABLED = "false";
         const client = buildMockClient(() => false);
 
         await metrics.collectStorageStats(client);
@@ -502,6 +528,42 @@ describe("ClickHouse metrics", () => {
           }),
         );
       });
+    });
+  });
+
+  describe("shouldCollectBackupMetrics", () => {
+    // The whole point of the inversion: absence of configuration means the
+    // existing (collecting) behaviour, never a silent opt-out.
+    const collectingCases: [string, NodeJS.ProcessEnv][] = [
+      ["unset", {}],
+      ["empty", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "" }],
+      ["whitespace", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "   " }],
+      ["true", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "true" }],
+      ["TRUE", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "TRUE" }],
+      ["padded true", { CLICKHOUSE_BACKUP_METRICS_ENABLED: " true " }],
+      ["1", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "1" }],
+      ["unparseable", { CLICKHOUSE_BACKUP_METRICS_ENABLED: "banana" }],
+    ];
+
+    it.each(collectingCases)("collects when %s", (_label, env) => {
+      expect(metrics.shouldCollectBackupMetrics(env)).toBe(true);
+    });
+
+    const optedOutValues: string[] = [
+      "false",
+      "FALSE",
+      "  false  ",
+      "0",
+      "no",
+      "off",
+    ];
+
+    it.each(optedOutValues)("skips when explicitly %s", (value) => {
+      expect(
+        metrics.shouldCollectBackupMetrics({
+          CLICKHOUSE_BACKUP_METRICS_ENABLED: value,
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/langwatch/src/server/clickhouse/metrics.ts
+++ b/langwatch/src/server/clickhouse/metrics.ts
@@ -231,10 +231,41 @@ const MONITORED_TABLES = [
   "stored_objects",
 ];
 
+/** Values of CLICKHOUSE_BACKUP_METRICS_ENABLED that turn backup collection off. */
+const BACKUP_METRICS_OFF_VALUES = new Set(["false", "0", "no", "off"]);
+
+/**
+ * Whether this deployment should collect backup-status gauges from
+ * system.backup_log.
+ *
+ * Collection is ON unless explicitly disabled. The gauges predate this flag and
+ * production alerts (clickhouse_backup_last_success_timestamp_seconds,
+ * clickhouse_backup_status_total, and the "Backup Reporting Absent" rule built on
+ * them) already depend on them, while the deployments that emit them do not set
+ * the variable. Defaulting to off would silently disarm live backup monitoring on
+ * the next deploy, so an unset — or unparseable — value keeps the existing
+ * behaviour and only a deliberate opt-OUT stops collection.
+ *
+ * Opting out is for environments where backups genuinely do not exist (local dev
+ * under haven, CI, self-hosted installs without backups), where the table is
+ * missing and the query would fail on every 15s tick for nothing.
+ *
+ * See specs/ops/clickhouse-backup-metrics.feature.
+ */
+export function shouldCollectBackupMetrics(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const raw = env.CLICKHOUSE_BACKUP_METRICS_ENABLED;
+  if (typeof raw !== "string") return true;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "") return true;
+  return !BACKUP_METRICS_OFF_VALUES.has(normalized);
+}
+
 /**
  * Collects ClickHouse backup status from system.backup_log into the backup gauges.
- * Extracted so collectStorageStats can gate it behind the explicit opt-in (see the
- * call site).
+ * Extracted so collectStorageStats can gate it behind the opt-out (see the call
+ * site).
  *
  * We deliberately query system.backup_log instead of system.backups: system.backups
  * is an in-memory table that gets wiped on CH restart, which happens on every app
@@ -351,12 +382,13 @@ export async function collectStorageStats(
     // Backup status only exists where backups are configured (the production
     // cluster, via clickhouse-serverless's backup cronjobs) — everywhere else this
     // query just fails on every 15s tick for nothing, and NODE_ENV can't tell
-    // "has backups" from "staging/self-hosted production build". So the deployment
-    // that has backups opts in explicitly (set on the worker alongside the backup
-    // cronjobs). Gating here (not at one call site) covers both the app under
+    // "has backups" from "staging/self-hosted production build". So the
+    // deployments WITHOUT backups opt out explicitly; unset stays on, because
+    // production already emits these gauges and alerts on them without setting
+    // anything. Gating here (not at one call site) covers both the app under
     // haven's in-process workers and the standalone worker.
     // See specs/ops/clickhouse-backup-metrics.feature.
-    if (process.env.CLICKHOUSE_BACKUP_METRICS_ENABLED === "true") {
+    if (shouldCollectBackupMetrics()) {
       await collectBackupStats(client);
     }
 

--- a/pkg/clog/clog.go
+++ b/pkg/clog/clog.go
@@ -138,14 +138,34 @@ func buildConsoleCore(format string, level zapcore.Level) zapcore.Core {
 
 // prettyEncoderConfig aligns the Go pretty console with the TS app's
 // pino-pretty lane, so a terminal interleaving Go and JS services reads as one
-// format: a 24h HH:MM:SS.mmm timestamp (prettyconsole's default is 12h with no
-// seconds) and a full-word capital level (INFO, not INF) — matching
-// pino-pretty's "[12:19:00.616] INFO (name): msg".
+// format. pino-pretty's line is:
+//
+//	[12:19:00.616] INFO (langwatch:api): message key=value
+//
+// so this config matches it piece by piece: a bracketed 24h HH:MM:SS.mmm
+// timestamp (prettyconsole's default is an unbracketed 12h clock with no
+// seconds), a full-word capital level (INFO, not INF — the level is the first
+// thing anyone scans a log for, so it has to be legible in both lanes), and a
+// parenthesised logger name for services that call Named.
+//
+// One difference is left standing: prettyconsole hardcodes " > " between the
+// name and the message where pino-pretty writes ": ". That separator is not
+// configurable without forking the encoder, and the prefix that actually gets
+// scanned — time, level, name — now lines up.
 func prettyEncoderConfig() zapcore.EncoderConfig {
 	cfg := prettyconsole.NewEncoderConfig()
-	cfg.EncodeTime = prettyconsole.DefaultTimeEncoder("15:04:05.000")
+	// Go's time layouts only substitute reference values, so the brackets pass
+	// through literally.
+	cfg.EncodeTime = prettyconsole.DefaultTimeEncoder("[15:04:05.000]")
 	cfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	cfg.EncodeName = prettyNameEncoder
 	return cfg
+}
+
+// prettyNameEncoder renders a logger name the way pino-pretty does, "(name)".
+// Loggers that never call Named emit nothing, exactly as before.
+func prettyNameEncoder(name string, enc zapcore.PrimitiveArrayEncoder) {
+	enc.AppendString("(" + name + ")")
 }
 
 // leveledCore gates an inner core to a minimum level. Used to hold the otelzap

--- a/pkg/clog/clog_test.go
+++ b/pkg/clog/clog_test.go
@@ -2,11 +2,15 @@ package clog
 
 import (
 	"context"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	prettyconsole "github.com/thessem/zap-prettyconsole"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/langwatch/langwatch/pkg/contexts"
 )
@@ -54,3 +58,58 @@ func TestNew_StampsServiceInfo(t *testing.T) {
 	bare := New(context.Background(), Config{Level: "info"})
 	assert.NotSame(t, bare, logger)
 }
+
+// The pretty console is read by a human in a haven terminal that interleaves
+// this lane with the TS app's pino-pretty lane, so the two formats have to
+// agree. pino-pretty writes:
+//
+//	[12:19:00.616] INFO (langwatch:api): message key=value
+//
+// These pin the Go half of that; the JS half is prettyConsoleOptions in
+// langwatch/packages/observability/src/logger.ts.
+func TestPrettyEncoder_MatchesPinoPrettyPrefix(t *testing.T) {
+	enc := prettyconsole.NewEncoder(prettyEncoderConfig())
+	entry := zapcore.Entry{
+		Level:      zapcore.WarnLevel,
+		Time:       time.Date(2026, 7, 15, 14, 9, 5, 616_000_000, time.UTC),
+		LoggerName: "langwatch:gateway",
+		Message:    "disk filling up",
+	}
+
+	buf, err := enc.EncodeEntry(entry, nil)
+	require.NoError(t, err)
+	line := stripANSI(buf.String())
+
+	// A 24h wall-clock timestamp with milliseconds, bracketed — prettyconsole's
+	// own default is an unbracketed 12h clock with no seconds.
+	assert.Contains(t, line, "[14:09:05.616]")
+	// The level, spelled out in full. Whether a line is a warning is the first
+	// thing anyone scans for, and "WRN" (prettyconsole's default) does not match
+	// what the JS lane prints two lines above it.
+	assert.Contains(t, line, "WARN")
+	// The logger name, parenthesised like pino's "(name)".
+	assert.Contains(t, line, "(langwatch:gateway)")
+	assert.Contains(t, line, "disk filling up")
+}
+
+func TestPrettyEncoder_UnnamedLoggerHasNoEmptyParens(t *testing.T) {
+	enc := prettyconsole.NewEncoder(prettyEncoderConfig())
+	entry := zapcore.Entry{
+		Level:   zapcore.InfoLevel,
+		Time:    time.Date(2026, 7, 15, 14, 9, 5, 0, time.UTC),
+		Message: "listening",
+	}
+
+	buf, err := enc.EncodeEntry(entry, nil)
+	require.NoError(t, err)
+
+	assert.NotContains(t, stripANSI(buf.String()), "()")
+}
+
+// stripANSI removes the colour escapes prettyconsole writes, so assertions read
+// against the text a human sees rather than the bytes a terminal consumes.
+func stripANSI(s string) string {
+	return ansiEscape.ReplaceAllString(s, "")
+}
+
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)

--- a/pkg/clog/clog_test.go
+++ b/pkg/clog/clog_test.go
@@ -106,7 +106,7 @@ func TestPrettyEncoder_UnnamedLoggerHasNoEmptyParens(t *testing.T) {
 	assert.NotContains(t, stripANSI(buf.String()), "()")
 }
 
-// stripANSI removes the colour escapes prettyconsole writes, so assertions read
+// stripANSI removes the color escapes prettyconsole writes, so assertions read
 // against the text a human sees rather than the bytes a terminal consumes.
 func stripANSI(s string) string {
 	return ansiEscape.ReplaceAllString(s, "")

--- a/specs/ops/clickhouse-backup-metrics.feature
+++ b/specs/ops/clickhouse-backup-metrics.feature
@@ -1,22 +1,40 @@
-Feature: ClickHouse backup status metrics are opt-in
+Feature: ClickHouse backup status metrics are opt-out
   Backup monitoring only makes sense where ClickHouse backups are actually
   configured (the production cluster, backed by the clickhouse-serverless
   chart's backup cronjobs). Everywhere else — local dev, CI, self-hosted
   installs without backups — querying system.backup_log would fail on every
   collection tick for nothing. NODE_ENV is not a reliable signal for "backups
   exist here" (staging and self-hosted also run production builds), so the
-  deployment that has backups opts in explicitly.
+  environments WITHOUT backups say so explicitly.
 
-  Scenario: deployment with backups opts in to backup monitoring
+  The gate defaults to ON, not off. The gauges predate the flag and live Grafana
+  alerts (clickhouse_backup_last_success_timestamp_seconds,
+  clickhouse_backup_status_total, and the "Backup Reporting Absent" rule built on
+  them) already read them from deployments that set nothing. A default-off flag
+  would silently disarm production backup monitoring the moment it shipped, so
+  absence of configuration keeps the existing behaviour and only a deliberate
+  opt-out stops collection.
+
+  Scenario: a deployment that says nothing keeps collecting backup status
+    Given CLICKHOUSE_BACKUP_METRICS_ENABLED is not set
+    When the storage stats collector ticks
+    Then backup status is collected from the ClickHouse backup log
+
+  Scenario: a deployment with backups collects backup status
     Given backup metrics collection is enabled for the deployment
     When the storage stats collector ticks
     Then backup status is collected from the ClickHouse backup log
 
-  Scenario: deployment without backups never queries the backup log
-    Given backup metrics collection is not enabled
+  Scenario: a deployment without backups opts out of the backup log query
+    Given backup metrics collection is explicitly disabled
     When the storage stats collector ticks
     Then the ClickHouse backup log is never queried
     And table and disk storage stats are still collected
+
+  Scenario: an unrecognised value is treated as enabled
+    Given CLICKHOUSE_BACKUP_METRICS_ENABLED is set to an unparseable value
+    When the storage stats collector ticks
+    Then backup status is collected from the ClickHouse backup log
 
   Scenario: transient backup-log failure warns once until recovery
     Given backup metrics collection is enabled
@@ -24,9 +42,8 @@ Feature: ClickHouse backup status metrics are opt-in
     Then a single warning is logged for the failure streak
     And a recovery is logged once collection succeeds again
 
-  # The opt-in must not let production silently stop emitting the gauges the
-  # "Backup Reporting Absent" alert depends on. The Helm chart couples the toggle
-  # to the backup config so the signal can never drift from whether backups run.
+  # The Helm chart states the toggle explicitly in both directions, coupled to
+  # the backup config, so a chart deployment never depends on the app's default.
   Scenario: the Helm chart enables backup metrics wherever it runs backups
     Given the langwatch chart is deployed with clickhouse.backup.enabled true
     When the app and worker deployments are rendered
@@ -37,3 +54,13 @@ Feature: ClickHouse backup status metrics are opt-in
     And chart-managed backups are disabled
     When the app and worker deployments are rendered
     Then CLICKHOUSE_BACKUP_METRICS_ENABLED is set to true on them
+
+  Scenario: the Helm chart opts out where it knows there are no backups
+    Given the langwatch chart is deployed with clickhouse backups disabled
+    When the app and worker deployments are rendered
+    Then CLICKHOUSE_BACKUP_METRICS_ENABLED is set to false on them
+
+  Scenario: haven opts local worktrees out
+    Given a haven stack manages its own ClickHouse
+    When the portless overlay is rendered
+    Then CLICKHOUSE_BACKUP_METRICS_ENABLED is set to false in it

--- a/tools/thuishaven/domain/domain_test.go
+++ b/tools/thuishaven/domain/domain_test.go
@@ -148,6 +148,25 @@ func TestOverlayEmitsClickHouseURLOnlyWhenManaged(t *testing.T) {
 	}
 }
 
+// The app collects ClickHouse backup-status gauges by default (an unset flag must
+// not disarm the production alerts that read them), so haven's own container —
+// which has no backups and therefore no system.backup_log — has to opt out, or
+// every 15s stats tick fails on a missing table.
+func TestOverlayOptsOutOfBackupMetricsWhenManagingClickHouse(t *testing.T) {
+	base := Stack{Slug: "brave-otter", APIPort: 1, Services: []Service{
+		{Name: "app", URL: "https://app.brave-otter.langwatch.localhost"},
+	}}
+	if hasKey(base.OverlayEnv(), "CLICKHOUSE_BACKUP_METRICS_ENABLED") {
+		t.Fatalf("unmanaged stack must leave backup metrics to the worktree's own .env")
+	}
+	managed := base
+	managed.ClickHouseHTTPPort = 18123
+	managed.ClickHouseDatabase = "lw_brave_otter"
+	if got := valueOf(managed.OverlayEnv(), "CLICKHOUSE_BACKUP_METRICS_ENABLED"); got != "false" {
+		t.Errorf("CLICKHOUSE_BACKUP_METRICS_ENABLED = %q, want %q", got, "false")
+	}
+}
+
 func TestOverlayEmitsPostgresURLOnlyWhenManaged(t *testing.T) {
 	base := Stack{Slug: "brave-otter", APIPort: 1, Services: []Service{
 		{Name: "app", URL: "https://app.brave-otter.langwatch.localhost"},

--- a/tools/thuishaven/domain/overlay.go
+++ b/tools/thuishaven/domain/overlay.go
@@ -124,6 +124,12 @@ func (s Stack) OverlayEnv() []string {
 	if s.ClickHouseHTTPPort != 0 && s.ClickHouseDatabase != "" {
 		env = append(env, fmt.Sprintf("CLICKHOUSE_URL=http://%s:%s@127.0.0.1:%d/%s",
 			ClickHouseUser, ClickHousePassword, s.ClickHouseHTTPPort, s.ClickHouseDatabase))
+		// Backup-status gauges query system.backup_log, which only exists once
+		// backups are configured — a production concern. The app collects them by
+		// default (unset must not disarm the production alerts that read them), so
+		// haven's container, which has no backups, opts out explicitly. Otherwise
+		// every 15s stats tick would fail on a missing table for nothing.
+		env = append(env, "CLICKHOUSE_BACKUP_METRICS_ENABLED=false")
 	}
 	// Same story for Postgres: one shared brew-managed server, a database per
 	// slug, connected straight to loopback.


### PR DESCRIPTION
## Why

Backup monitoring is currently disarmed on `main`.

`metrics.ts:359` gates `system.backup_log` collection on `CLICKHOUSE_BACKUP_METRICS_ENABLED === "true"`. The deployments that actually have backups — the production workers — never set that variable, so the gauges stop being emitted. Two live Grafana alerts depend on them:

- `clickhouse_backup_last_success_timestamp_seconds`
- `clickhouse_backup_status_total`

Net effect on the next deploy: the "Backup Reporting Absent" rule fires spuriously, and — the part that matters — genuine backup failures and staleness stop being monitored at all.

This was raised on #5814 but only the Helm half landed with that merge; the app-side default was never corrected.

## What changed

Inverted the default. Collection is ON unless something explicitly opts out:

- `shouldCollectBackupMetrics()` treats unset, empty, whitespace and unrecognised values as ON. Only `false` / `0` / `no` / `off` (trimmed, case-insensitive) turn it off.
- The places that genuinely have no backups now say so rather than relying on a default: the Helm helper renders the flag in both directions, haven's overlay emits `false`, and `compose.yml` opts out.
- `.env.example` and the ops spec follow.

Also folded in the pretty-logger alignment from the same review: Go's encoder now brackets its `HH:MM:SS.mmm` timestamp and parenthesises the logger name to match pino-pretty's `[12:19:00.616] INFO (name):`. Both sides pinned by tests.

## How it works

The failure mode this protects against is asymmetric, which is why unset means ON. If an environment without backups defaults to ON, the cost is a failing query on a 15s tick — noisy and cheap. If an environment *with* backups defaults to OFF, the cost is silent loss of backup monitoring, which is exactly what happened here. So the safe default is the one that keeps observing, and only a deliberate opt-out stops it.

## Test plan

- `metrics.unit.test.ts` — unset / empty / unrecognised all collect; each opt-out value does not. This is the regression: at the previous default the unset case failed.
- `logger.unit.test.ts` + `pkg/clog/clog_test.go` — pretty format pinned on both sides.
- `go build ./pkg/... ./tools/...`, `go vet`, `gofmt` clean; Go tests pass.
- `vitest run` on the two touched test files: 61 passed.
- `helm lint` clean; all three flag cases verified via `helm template` (`"false"` default, `"true"` on `backup.enabled`, `"true"` on override).

## Anything surprising?

- **Worth landing promptly** — this is a live gap on `main`, not review cleanup.
- The Helm `e2e-overlays.sh` suite needs a kind cluster and Docker wasn't available, so the templates were validated by rendering directly rather than through that suite.
- One pretty-format difference is left unresolved: `prettyconsole` hardcodes `" > "` where pino writes `": "`. Not configurable without forking the encoder, so the formats are aligned but not byte-identical.

## Deployment Impact

**Behaviour change on deploy: backup metrics collection turns back ON by default.**

- **Production workers** — currently emit no backup gauges because `CLICKHOUSE_BACKUP_METRICS_ENABLED` is unset. After this deploys they resume emitting `clickhouse_backup_last_success_timestamp_seconds` and `clickhouse_backup_status_total`. The existing "Backup Reporting Absent" Grafana rule stops firing spuriously, and genuine backup failures become visible again. This restores prior behaviour; it is the point of the change.
- **Deployments without backups** — now opt out explicitly rather than relying on the default. Helm renders the flag in both directions, haven's overlay sets `false`, and `compose.yml` opts out. Self-hosted installs that template via the chart inherit the correct value with no action.
- **Self-hosted installs NOT using the chart** — will start querying `system.backup_log` on the 15s stats tick. Where the table is absent that query fails and is logged, with no other effect. To silence it, set `CLICKHOUSE_BACKUP_METRICS_ENABLED=false` (documented in `.env.example`).
- **No migrations, no schema changes, no API surface changes.** Rollback is a straight revert; no data or state is touched.
- **Config keys:** `CLICKHOUSE_BACKUP_METRICS_ENABLED` — accepted off-values are `false`/`0`/`no`/`off` (trimmed, case-insensitive). Any other value, including unset or empty, means ON.