### PR TITLE
fix(errors): make HandledError boundary guards survive class duplication

### DIFF
--- a/langwatch/src/app/api/middleware/error-handler.ts
+++ b/langwatch/src/app/api/middleware/error-handler.ts
@@ -80,7 +80,10 @@ function determineErrorResponse(
   // we only read fields off it below, never call its methods.
   if (
     HandledError.isHandled(error) ||
-    ("code" in error && "httpStatus" in error)
+    (typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      "httpStatus" in error)
   ) {
     const { code, message, httpStatus, meta } = error as HandledError;
     const { tips, docsUrl, fault } = error as HandledError;

--- a/langwatch/src/app/api/middleware/error-handler.ts
+++ b/langwatch/src/app/api/middleware/error-handler.ts
@@ -74,11 +74,14 @@ function determineErrorResponse(
   },
 ): { statusCode: ContentfulStatusCode; response: object } {
   // HandledErrors are handled first — normalize to client-safe shape.
-  // Use code + httpStatus check instead of instanceof to handle
-  // module-boundary class identity mismatches (a bundler can load two
-  // copies of the same module).
-  // See handled-error.ts: "use code instead of instanceof in cross-process cases"
-  if (HandledError.is(error) || ("code" in error && "httpStatus" in error)) {
+  // isHandled covers real instances plus ones from a second copy of the
+  // module, which bare `instanceof` misses. The code + httpStatus tail
+  // additionally accepts an already-serialised payload reaching this handler;
+  // we only read fields off it below, never call its methods.
+  if (
+    HandledError.isHandled(error) ||
+    ("code" in error && "httpStatus" in error)
+  ) {
     const { code, message, httpStatus, meta } = error as HandledError;
     const { tips, docsUrl, fault } = error as HandledError;
     return {

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -202,7 +202,7 @@ function toTemplateTRPCError(err: unknown): TRPCError {
   // as a DispatchError with an already-actionable message — lift it onto the
   // typed HandledError channel so the UI shows a clean 4xx, not a generic 500.
   const domainError =
-    err instanceof HandledError
+    HandledError.isHandled(err)
       ? err
       : isDispatchError(err)
         ? new NotificationDeliveryError(err.message)

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -53,7 +53,7 @@ type TRPCContext = ReturnType<typeof createInnerTRPCContext>;
 
 /** Maps experiment handled errors to TRPCError using the code discriminant. */
 const mapExperimentError = (error: unknown): never => {
-  if (error instanceof HandledError && error.code === "experiment_not_found") {
+  if (HandledError.isHandled(error) && error.code === "experiment_not_found") {
     throw new TRPCError({ code: "NOT_FOUND", message: error.message });
   }
   throw error;

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -146,7 +146,7 @@ export function errorFormatterForTesting({
     : null;
 
   const domainError =
-    error.cause instanceof HandledError ? error.cause.serialize() : null;
+    HandledError.isHandled(error.cause) ? error.cause.serialize() : null;
 
   // Surface ModelNotConfiguredError on the wire so the frontend
   // interceptor in `utils/trpcError.ts::extractMissingModelInfo` can
@@ -198,11 +198,11 @@ export function errorFormatterForTesting({
     error.code === "INTERNAL_SERVER_ERROR" ||
     shape?.data?.code === "INTERNAL_SERVER_ERROR";
   const message =
-    isInternalServerError && !(error.cause instanceof HandledError)
+    isInternalServerError && !HandledError.isHandled(error.cause)
       ? HandledError.toUserMessage(error.cause)
       : shape.message;
   const shapeData = { ...shape.data };
-  if (isInternalServerError && !(error.cause instanceof HandledError)) {
+  if (isInternalServerError && !HandledError.isHandled(error.cause)) {
     // tRPC includes stacks in development error shapes. Local callers should
     // exercise the same safe wire contract as production callers.
     delete shapeData.stack;
@@ -518,7 +518,7 @@ function handledErrorToTRPCCode(error: HandledError): TRPCError["code"] {
  */
 const handledErrorMiddleware = t.middleware(async ({ next }) => {
   const result = await next();
-  if (!result.ok && result.error.cause instanceof HandledError) {
+  if (!result.ok && HandledError.isHandled(result.error.cause)) {
     const domainError = result.error.cause;
     throw new TRPCError({
       code: handledErrorToTRPCCode(domainError),
@@ -606,16 +606,9 @@ export function handleTrpcCallLogging({
 
     const cause =
       result.error instanceof TRPCError ? result.error.cause : undefined;
-    // Duck-typed alongside instanceof: a bundler can load a second copy of
-    // the package (see error-handler.ts).
-    const handledCause =
-      cause instanceof HandledError ||
-      (cause &&
-        typeof cause === "object" &&
-        "code" in cause &&
-        "httpStatus" in cause)
-        ? (cause as HandledError)
-        : undefined;
+    // isHandled also matches an instance from a second copy of the package,
+    // which bare `instanceof` misses — see its brand check.
+    const handledCause = HandledError.isHandled(cause) ? cause : undefined;
 
     // Include handled error code + fault in log data for structured
     // filtering (and spike alerting on handledErrorCode).

--- a/langwatch/src/server/app-layer/langy/execution/langy-turn-errors.ts
+++ b/langwatch/src/server/app-layer/langy/execution/langy-turn-errors.ts
@@ -269,7 +269,7 @@ export class LangyWorkerRestartingError extends HandledError {
  */
 /** Walk a HandledError chain (the error + its reasons, depth-first) for a kind. */
 function domainErrorChainHas(error: Error, code: string): boolean {
-  if (!(error instanceof HandledError)) return false;
+  if (!HandledError.isHandled(error)) return false;
   if (error.code === code) return true;
   return error.reasons.some((r) => domainErrorChainHas(r, code));
 }
@@ -420,7 +420,7 @@ function unhandledShape(): SerializedHandledError {
  * that — falls through to `unknown`.
  */
 export function classifyLangyTurnError(error: unknown): SerializedHandledError {
-  if (error instanceof HandledError) return error.serialize();
+  if (HandledError.isHandled(error)) return error.serialize();
   // fetch/AbortSignal failures arrive as DOMException/TypeError, never as ours.
   if (isTimeout(error)) {
     return new LangyTurnTimeoutError(AGENT_CHAT_TIMEOUT_MS).serialize();

--- a/langwatch/src/server/event-sourcing/services/errorHandling.ts
+++ b/langwatch/src/server/event-sourcing/services/errorHandling.ts
@@ -470,7 +470,7 @@ export function classifyClickHouseError(error: unknown): ErrorCategory {
   // shell. Single shallow pass: the translation wraps the driver error
   // directly, no deep recursion needed.
   const candidates =
-    error instanceof HandledError && (error.reasons ?? []).length > 0
+    HandledError.isHandled(error) && (error.reasons ?? []).length > 0
       ? error.reasons
       : [error];
 

--- a/langwatch/src/server/routes/sse.ts
+++ b/langwatch/src/server/routes/sse.ts
@@ -264,7 +264,9 @@ secured.access(
           writeData({ type: "complete" });
           end();
         } catch (error) {
-          logSseError(error, { error, path, input }, "SSE handler error");
+          // No `input` here: it is the raw request payload, which may carry
+          // PII — same contract as the observable error path above.
+          logSseError(error, { error, path }, "SSE handler error");
           writeData(sseErrorFrame(error));
           end();
         }

--- a/langwatch/src/server/routes/sse.ts
+++ b/langwatch/src/server/routes/sse.ts
@@ -59,19 +59,9 @@ export function sseErrorFrame(err: unknown): Record<string, unknown> {
 /** The HandledError behind a stream failure, if there is one. */
 function handledCauseOf(err: unknown): HandledError | undefined {
   const candidate = err instanceof TRPCError ? err.cause : err;
-  if (candidate instanceof HandledError) return candidate;
-  // A bundler can load a second copy of the package — duck-type like the
-  // Hono error handler does (see error-handler.ts).
-  if (
-    candidate &&
-    typeof candidate === "object" &&
-    "code" in candidate &&
-    "httpStatus" in candidate &&
-    typeof (candidate as { serialize?: unknown }).serialize === "function"
-  ) {
-    return candidate as HandledError;
-  }
-  return undefined;
+  // isHandled also matches an instance from a second copy of the package,
+  // which bare `instanceof` misses — see its brand check.
+  return HandledError.isHandled(candidate) ? candidate : undefined;
 }
 
 /**

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -3315,7 +3315,7 @@ export function isClickHouseMemoryLimitError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   // The resilient client translates the raw driver error into a handled
   // `query_memory_exceeded`, wrapping the original in `reasons`.
-  if (error instanceof HandledError) {
+  if (HandledError.isHandled(error)) {
     return (
       error.code === "query_memory_exceeded" ||
       (error.reasons ?? []).some(isClickHouseMemoryLimitError)

--- a/packages/handled-error/src/handled-error.test.ts
+++ b/packages/handled-error/src/handled-error.test.ts
@@ -177,6 +177,9 @@ describe("HandledError.isHandled", () => {
   it.each([
     ["a plain Error", new Error("boom")],
     ["a serialised payload with no brand", { code: "x", httpStatus: 500 }],
+    // A structured clone / JSON round-trip keeps the brand but loses the
+    // prototype, so `.serialize()` would not exist — must not match.
+    ["a cloned payload carrying the brand", { isHandled: true, code: "x" }],
     ["a non-true brand", { isHandled: "yes" }],
     ["null", null],
     ["undefined", undefined],

--- a/packages/handled-error/src/handled-error.test.ts
+++ b/packages/handled-error/src/handled-error.test.ts
@@ -6,6 +6,7 @@ import {
   handledErrorFromHerr,
   setTraceUrlProvider,
 } from "./index";
+import type { HandledErrorFault } from "./index";
 
 class TestError extends HandledError {
   declare readonly code: "test_error";
@@ -130,5 +131,127 @@ describe("NotFoundError", () => {
     expect(err.httpStatus).toBe(404);
     expect(err.meta).toMatchObject({ id: "abc" });
     expect(err.serialize().tips).toEqual(["Check the trace id"]);
+  });
+});
+
+/**
+ * Stand-in for a HandledError raised from a second copy of this package: same
+ * brand, same fields, same `serialize` — but not an instance of *this* copy's
+ * HandledError, exactly as a duplicated bundle produces. Next.js/turbopack does
+ * this across route and server boundaries, and bare `instanceof` misses it,
+ * which silently downgrades a handled 4xx to an unhandled 500.
+ */
+class DuplicatedHandledError extends Error {
+  readonly isHandled = true as const;
+  readonly meta: Record<string, unknown> = {};
+  readonly traceId: string | undefined = undefined;
+  readonly spanId: string | undefined = undefined;
+  readonly reasons: readonly Error[] = [];
+  readonly tips: readonly string[] = [];
+  readonly docsUrl: string | undefined = undefined;
+  readonly fault: HandledErrorFault = "customer";
+
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly httpStatus = 404,
+  ) {
+    super(message);
+    this.name = code;
+  }
+}
+
+describe("HandledError.isHandled", () => {
+  it("matches a real HandledError instance", () => {
+    expect(HandledError.isHandled(new TestError())).toBe(true);
+  });
+
+  it("matches an instance whose class identity the bundler duplicated", () => {
+    const duplicate = new DuplicatedHandledError("span_not_found", "gone");
+
+    // The premise: bare instanceof does not see it.
+    expect(duplicate instanceof HandledError).toBe(false);
+    expect(HandledError.isHandled(duplicate)).toBe(true);
+  });
+
+  it.each([
+    ["a plain Error", new Error("boom")],
+    ["a serialised payload with no brand", { code: "x", httpStatus: 500 }],
+    ["a non-true brand", { isHandled: "yes" }],
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "span_not_found"],
+  ])("rejects %s", (_label, value) => {
+    expect(HandledError.isHandled(value)).toBe(false);
+  });
+});
+
+describe("HandledError.isUnhandled", () => {
+  it("does not treat a duplicated HandledError as infrastructure failure", () => {
+    const duplicate = new DuplicatedHandledError("span_not_found", "gone");
+    expect(HandledError.isUnhandled(duplicate)).toBe(false);
+  });
+
+  it("still treats a plain Error as unhandled", () => {
+    expect(HandledError.isUnhandled(new Error("db exploded"))).toBe(true);
+  });
+});
+
+describe("HandledError.is", () => {
+  it("narrows to the concrete subclass within one module graph", () => {
+    expect(TestError.is(new TestError())).toBe(true);
+    expect(NotFoundError.is(new TestError())).toBe(false);
+  });
+
+  it("stays instanceof-only, so a duplicated identity does not match", () => {
+    // Subclass narrowing cannot be brand-based — the brand says "handled", not
+    // "which subclass". Cross-boundary callers compare `code` instead.
+    const duplicate = new DuplicatedHandledError("test_error", "gone");
+    expect(TestError.is(duplicate)).toBe(false);
+    expect(duplicate.code).toBe("test_error");
+  });
+});
+
+describe("HandledError.toUserMessage", () => {
+  it("forwards the message of a duplicated HandledError", () => {
+    const duplicate = new DuplicatedHandledError(
+      "span_not_found",
+      "That span no longer exists",
+    );
+    expect(HandledError.toUserMessage(duplicate)).toBe(
+      "That span no longer exists",
+    );
+  });
+
+  it("masks an unhandled error and reports it to the log callback", () => {
+    const unhandled = new Error("connection reset by peer");
+    const logged: unknown[] = [];
+
+    expect(HandledError.toUserMessage(unhandled, (e) => logged.push(e))).toBe(
+      "An unknown error occurred",
+    );
+    expect(logged).toEqual([unhandled]);
+  });
+});
+
+describe("serialising a reason chain", () => {
+  it("keeps the code of a duplicated nested reason instead of masking it", () => {
+    const error = new TestError("could not build preview", {
+      reasons: [new DuplicatedHandledError("span_not_found", "no span")],
+    });
+
+    expect(error.serialize().reasons).toEqual([
+      { code: "span_not_found", kind: "span_not_found", fault: "customer" },
+    ]);
+  });
+
+  it("still masks a genuinely unknown reason", () => {
+    const error = new TestError("could not build preview", {
+      reasons: [new Error("connection reset by peer")],
+    });
+
+    expect(error.serialize().reasons).toEqual([
+      { code: "unknown", kind: "unknown" },
+    ]);
   });
 });

--- a/packages/handled-error/src/handled-error.ts
+++ b/packages/handled-error/src/handled-error.ts
@@ -280,15 +280,18 @@ export abstract class HandledError extends Error {
  * `isHandled` brand as an own property, so matching on that recognises those
  * duplicates while still rejecting unrelated objects.
  *
- * Deliberately does not match a deserialised wire payload: that is a plain
- * object with no prototype, so the methods this guard promises (`serialize`)
- * would not exist. Wire payloads go through the boundary schema instead —
+ * The `instanceof Error` requirement is load-bearing, not belt-and-braces: the
+ * brand is an own *enumerable* field, so `JSON.parse(JSON.stringify(err))` — or
+ * a worker `postMessage` structured clone — produces a plain object that still
+ * carries `isHandled: true` but has no prototype, and therefore none of the
+ * methods this guard promises (`serialize`). Requiring a real `Error` rejects
+ * those while still admitting bundler duplicates, since `Error` is the realm's
+ * shared global. Wire payloads go through the boundary schema instead —
  * `handledErrorFromHerr` here, or `isHandledErrorLike` in `packages/api`.
  */
 function hasHandledErrorBrand(error: unknown): error is HandledError {
   return (
-    typeof error === "object" &&
-    error !== null &&
+    error instanceof Error &&
     (error as { isHandled?: unknown }).isHandled === true
   );
 }

--- a/packages/handled-error/src/handled-error.ts
+++ b/packages/handled-error/src/handled-error.ts
@@ -120,6 +120,11 @@ export function setTraceUrlProvider(provider: TraceUrlProvider): void {
  * if (err instanceof EvaluationNotFoundError) { ...}  // same-process only
  * ```
  *
+ * For the broader "is this handled at all?" question, call
+ * {@link HandledError.isHandled} rather than `instanceof HandledError`: it also
+ * matches instances whose class identity a bundler duplicated, which bare
+ * `instanceof` misses (see {@link hasHandledErrorBrand}).
+ *
  * `meta` carries domain-specific context (e.g. `{ spanId }`) included in the
  * serialised shape. `httpStatus` is the suggested HTTP response code (defaults
  * to 500; subclasses set appropriate defaults). `traceId` / `spanId` are
@@ -211,12 +216,14 @@ export abstract class HandledError extends Error {
   }
 
   /**
-   * Type-safe guard: narrows `error` to the concrete subclass.
+   * Narrows `error` to the concrete subclass this is called on:
    *
-   * Usage:
    *   EvaluationNotFoundError.is(err)   // error is EvaluationNotFoundError
    *   NotFoundError.is(err)             // error is NotFoundError
-   *   HandledError.is(err)              // error is HandledError
+   *
+   * This is a plain `instanceof`, so it only holds within one module graph.
+   * At a boundary, ask {@link HandledError.isHandled} instead ("is this
+   * handled at all?"), or compare `err.code` to pick out one subclass.
    */
   static is<T extends HandledError>(
     this: abstract new (...args: never) => T,
@@ -225,14 +232,19 @@ export abstract class HandledError extends Error {
     return error instanceof this;
   }
 
-  /** Returns true when `error` is a known, handled HandledError. */
+  /**
+   * True when `error` is a handled error, including one whose class identity a
+   * bundler duplicated — see {@link hasHandledErrorBrand}. Prefer this over
+   * `instanceof HandledError` anywhere an error may have crossed a module
+   * boundary (route handlers, tRPC middleware, error formatters).
+   */
   static isHandled(error: unknown): error is HandledError {
-    return error instanceof HandledError;
+    return error instanceof HandledError || hasHandledErrorBrand(error);
   }
 
-  /** Returns true when `error` is an unhandled infrastructure Error. */
+  /** True when `error` is an unhandled infrastructure Error. */
   static isUnhandled(error: unknown): boolean {
-    return error instanceof Error && !(error instanceof HandledError);
+    return error instanceof Error && !HandledError.isHandled(error);
   }
 
   /**
@@ -252,10 +264,33 @@ export abstract class HandledError extends Error {
     error: unknown,
     log?: (error: unknown) => void,
   ): string {
-    if (error instanceof HandledError) return error.message;
+    if (HandledError.isHandled(error)) return error.message;
     log?.(error);
     return "An unknown error occurred";
   }
+}
+
+/**
+ * Structural test for the `isHandled` brand.
+ *
+ * `instanceof` compares class identity, which breaks when a bundler includes
+ * this module twice — Next.js/turbopack does this across route and server
+ * boundaries, so an error can be a genuine HandledError raised from a *second*
+ * copy of this class and still fail `instanceof`. Every instance carries the
+ * `isHandled` brand as an own property, so matching on that recognises those
+ * duplicates while still rejecting unrelated objects.
+ *
+ * Deliberately does not match a deserialised wire payload: that is a plain
+ * object with no prototype, so the methods this guard promises (`serialize`)
+ * would not exist. Wire payloads go through the boundary schema instead —
+ * `handledErrorFromHerr` here, or `isHandledErrorLike` in `packages/api`.
+ */
+function hasHandledErrorBrand(error: unknown): error is HandledError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { isHandled?: unknown }).isHandled === true
+  );
 }
 
 /**
@@ -288,7 +323,7 @@ export function handledErrorFromHerr(
 }
 
 function serializeReason(error: Error): SerializedReason {
-  if (error instanceof HandledError) {
+  if (HandledError.isHandled(error)) {
     return {
       code: error.code,
       // Deprecated back-compat alias — see SerializedReason.kind.


### PR DESCRIPTION
## What

`instanceof` compares **class identity**, so it breaks when a bundler includes the handled-error module twice — Next.js/turbopack does exactly this across route and server boundaries. An error raised from the second copy is a genuine `HandledError`, but `instanceof HandledError` returns `false`.

The consequence is user-visible: a handled 4xx silently downgrades to an unhandled 500, and `toUserMessage` replaces the vetted copy with *"An unknown error occurred"*.

**This is already a live problem, not a theoretical one.** #5917 hit it and hand-rolled duck-typed workarounds in two places, both commented *"a bundler can load a second copy of the package"* (`sse.ts`, `trpc.ts`). This PR centralises that fix instead of letting it spread further.

Rebased onto `main` after #5917 moved `HandledError` into `packages/handled-error`.

## How

Every instance already carries a `readonly isHandled = true` brand, which survives duplication. Matching on that fixes **every call site at once**:

- `isHandled` → `instanceof` **OR** the brand
- `isUnhandled` / `toUserMessage` / `serializeReason` route through `isHandled`
- **12 call sites** updated across `trpc`, `sse`, `langy`, `automations`, `experiments`, `clickhouse-trace`, `event-sourcing`, `error-handler`
- The two ad-hoc duck-typed blocks from #5917 collapse into it

**Exactly one `instanceof HandledError` now remains repo-wide** — the canonical one inside `isHandled` itself.

## Deliberately unchanged

- **`is()` stays instanceof-only.** Subclass narrowing can't be brand-based — the brand says *"handled"*, not *"which subclass"*. Cross-boundary callers compare `code`.
- **The brand does not match a deserialised wire payload.** That's a plain object with no prototype, so the methods this guard promises (`serialize`) wouldn't exist. Those go through `handledErrorFromHerr` / `isHandledErrorLike`.
- **`error-handler.ts` keeps its `code`+`httpStatus` tail** so the accepted-error set doesn't narrow; it only reads fields there, never calls methods.

## Verification

- 12 new tests in `packages/handled-error`. Confirmed meaningful: the 4 duplication tests **fail** against the old bare-instanceof guard and pass after.
- Package `tsc --noEmit` clean; app `tsgo` typecheck clean.
- 3363 tests / 262 files pass. (An earlier run showed 5 failures in timing-sensitive streaming tests; reproduced clean on re-run and confirmed identical on pristine `main` — CPU contention from a concurrent typecheck, not a regression.)

https://claude.ai/code/session_01GofbFj1QUWFKdeZmTBDEhp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handled-error detection across the API, streaming/SSE, automations, experiments, tracing, and error classification.
  * Ensured handled errors are serialized, mapped to TRPC responses, and chained correctly even when duplicated across module/bundle boundaries.
  * Kept user-facing codes/messages and metadata consistent, and reduced logged SSE error details (removed request input).
* **Tests**
  * Added scenarios covering duplicated handled errors and deeper nested reason-chain serialization.
* **Documentation**
  * Documented the recommended handled-error detection approach for cross-boundary safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->