### PR TITLE
fix(cli): address review of #5921 — output port, daemon trust, honest errors

### DIFF
--- a/.github/workflows/cli-binary-publish.yml
+++ b/.github/workflows/cli-binary-publish.yml
@@ -1,12 +1,21 @@
 # Builds the standalone `langwatch` CLI binary (Bun --compile, bytecode +
 # minify — see typescript-sdk/scripts/build-cli-binary.ts) for every supported
-# platform and attaches it (with sha256 sidecars) to the typescript-sdk
-# GitHub release, so users can install the CLI without npm.
+# platform and attaches it (with sha256 sidecars, a signed SHA256SUMS and a
+# build-provenance attestation) to the typescript-sdk GitHub release, so users
+# can install the CLI without npm.
 #
 # One ubuntu job builds ALL targets: `bun build --compile --target=<triple>`
 # cross-compiles from any host (Bun ≥1.1), so per-OS runners would only burn
 # minutes. The pattern (matrix + sha256 sidecars + publish) is cribbed from
 # embedded-binaries-publish.yml.
+#
+# SHAPE: build (matrix, `contents: read`) → publish (single job, the ONLY job
+# with `contents: write`). The matrix legs never hold a write-scoped token and
+# never touch the release; they hand binaries over as workflow artifacts. The
+# publish job runs no third-party code at all — no checkout, no `pnpm install`
+# — and attaches all five assets in one go. This is what makes a release
+# atomic: `needs: build` means one failed leg blocks the whole attach, instead
+# of leaving a release advertising three of five binaries.
 #
 # Trigger policy:
 # - release published with a `typescript-sdk@*` tag (same event as
@@ -33,28 +42,109 @@ on:
         required: false
         type: string
 
+# Read-only by default. Only the `publish` job widens to `contents: write`,
+# and it is the one job that executes no third-party code.
 permissions:
-  # `gh release upload` needs to write release assets.
-  contents: write
+  contents: read
 
 concurrency:
-  # Two runs attaching the same asset names to the same release would race.
-  group: ${{ github.workflow }}
+  # Two runs attaching the same asset names to the SAME release would race, so
+  # the group is scoped to the release tag — NOT to the workflow. A global
+  # group makes two releases cut back-to-back cancel each other, and a
+  # cancelled run leaves a release with no binaries while reporting
+  # "cancelled" rather than "failed".
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
   cancel-in-progress: false
 
 env:
   # Pinned to the same Bun as the langyagent image build
   # (Dockerfile.langyagent's oven/bun:1.3.13-cli-builder stage).
   BUN_VERSION: 1.3.13
+  # sha256 of bun-linux-x64.zip from
+  # https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/SHASUMS256.txt
+  # Bump this in the same commit as BUN_VERSION — the install step hard-fails
+  # on a mismatch, so a stale value fails loudly rather than silently
+  # installing an unverified toolchain.
+  BUN_LINUX_X64_SHA256: 79c0771fa8b92c33aae41e15a0e0d307ea99d0e2f00317c71c6c53237a78e25a
 
 jobs:
+  # Resolves the tag / version / git ref / publish decision ONCE, in shell,
+  # from environment variables rather than from a GitHub expression. The
+  # expression form (`if: ${{ !inputs.dry_run }}`) relies on `inputs` being
+  # null on a `release` event — an untested assumption whose failure mode is
+  # silent: every release would produce a green workflow with zero attached
+  # binaries. Branching on `github.event_name` first in shell removes the
+  # guesswork entirely.
+  resolve:
+    name: resolve release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: startsWith(github.event.release.tag_name, 'typescript-sdk@') || github.event_name == 'workflow_dispatch'
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+      release_tag: ${{ steps.resolve.outputs.release_tag }}
+      version: ${{ steps.resolve.outputs.version }}
+      publish: ${{ steps.resolve.outputs.publish }}
+    steps:
+      - name: Resolve tag, version, ref and publish decision
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG_EVENT: ${{ github.event.release.tag_name }}
+          RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          DEFAULT_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "release" ]; then
+            RELEASE_TAG="${RELEASE_TAG_EVENT}"
+            # A release is never a dry run — the assets are the point.
+            PUBLISH="true"
+          else
+            RELEASE_TAG="${RELEASE_TAG_INPUT}"
+            # workflow_dispatch booleans arrive as the strings "true"/"false".
+            if [ "${DRY_RUN}" = "false" ]; then PUBLISH="true"; else PUBLISH="false"; fi
+          fi
+
+          # Build from the RELEASE TAG, not from the default branch. Without an
+          # explicit ref, a workflow_dispatch re-attach builds current main and
+          # uploads it under the old release's filenames.
+          if [ -n "${RELEASE_TAG}" ]; then
+            REF="refs/tags/${RELEASE_TAG}"
+            VERSION="${RELEASE_TAG#typescript-sdk@v}"
+            VERSION="${VERSION#typescript-sdk@}"
+          else
+            if [ "${PUBLISH}" = "true" ]; then
+              echo "dry_run is off but no release_tag was given — refusing to publish binaries built from ${DEFAULT_REF}" >&2
+              exit 1
+            fi
+            echo "no release tag (dry-run dispatch without release_tag) — building ${DEFAULT_REF} with unversioned asset names"
+            REF="${DEFAULT_REF}"
+            VERSION="dev"
+          fi
+
+          {
+            echo "ref=${REF}"
+            echo "release_tag=${RELEASE_TAG}"
+            echo "version=${VERSION}"
+            echo "publish=${PUBLISH}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "ref=${REF} version=${VERSION} publish=${PUBLISH}"
+
   build:
     name: build langwatch ${{ matrix.target }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: startsWith(github.event.release.tag_name, 'typescript-sdk@') || github.event_name == 'workflow_dispatch'
+    needs: resolve
+    permissions:
+      contents: read
 
     strategy:
+      # fail-fast stays off so one broken target still reports the state of the
+      # other four. This is only safe because nothing here touches the release:
+      # `publish` needs ALL legs green before a single asset is attached.
       fail-fast: false
       matrix:
         target:
@@ -67,6 +157,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+          # This job runs `pnpm install` (arbitrary lifecycle scripts) and a
+          # Bun compile over the checked-out tree. Without this the GITHUB_TOKEN
+          # is written into .git/config and stays readable by all of it. Nothing
+          # here pushes or fetches with git credentials, and the release upload
+          # lives in a different job entirely.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
@@ -80,12 +178,25 @@ jobs:
           cache-dependency-path: "typescript-sdk/pnpm-lock.yaml"
 
       - name: Install Bun
-        # The official install script, pinned by version, instead of
-        # oven-sh/setup-bun so this workflow keeps the repo's
-        # no-floating-third-party-actions convention.
+        # The pinned, checksummed release artifact — NOT `curl
+        # https://bun.sh/install | bash`. That pipeline fetches an unpinned,
+        # unchecksummed HEAD-of-main script and executes it; the `-s bun-v<ver>`
+        # argument pins which Bun the script installs, never the script itself.
+        # This is the same "no floating third-party code" principle the rest of
+        # the file applies to actions, applied to the installer too.
         run: |
-          curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          curl -fsSL --retry 3 --retry-all-errors -o "${tmp}/bun.zip" \
+            "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip"
+          echo "${BUN_LINUX_X64_SHA256}  ${tmp}/bun.zip" | sha256sum -c -
+          unzip -q "${tmp}/bun.zip" -d "${tmp}"
+          mkdir -p "${HOME}/.bun/bin"
+          mv "${tmp}/bun-linux-x64/bun" "${HOME}/.bun/bin/bun"
+          chmod +x "${HOME}/.bun/bin/bun"
+          rm -rf "${tmp}"
           echo "${HOME}/.bun/bin" >> "$GITHUB_PATH"
+          "${HOME}/.bun/bin/bun" --version
 
       - name: Install dependencies
         # Full monorepo checkout: `prepare` (run by install) generates
@@ -95,26 +206,33 @@ jobs:
         working-directory: typescript-sdk
         run: pnpm install --frozen-lockfile
 
-      - name: Resolve version and asset names
+      - name: Resolve asset name
         id: names
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
           TARGET: ${{ matrix.target }}
+          VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           set -euo pipefail
-          if [ -z "${RELEASE_TAG}" ]; then
-            echo "no release tag (dry-run dispatch without release_tag) — building unversioned asset names"
-            VERSION="dev"
-          else
-            VERSION="${RELEASE_TAG#typescript-sdk@v}"
-            VERSION="${VERSION#typescript-sdk@}"
-          fi
           platform="${TARGET#bun-}"
           ext=""
           if [ "${TARGET}" = "bun-windows-x64" ]; then ext=".exe"; fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "asset=langwatch-${VERSION}-${platform}${ext}" >> "$GITHUB_OUTPUT"
 
+      # TODO(macos-signing): the two darwin binaries are neither codesigned nor
+      # notarized, so Gatekeeper refuses to run them ("cannot be opened because
+      # the developer cannot be verified") until the user strips the quarantine
+      # xattr — documented in docs/integration/cli.mdx#macos-gatekeeper.
+      # Fixing this properly needs an Apple Developer Program membership plus
+      # these repository secrets, none of which exist today:
+      #   APPLE_DEVELOPER_ID_APPLICATION_CERT  (base64 .p12, Developer ID Application)
+      #   APPLE_DEVELOPER_ID_CERT_PASSWORD     (.p12 password)
+      #   APPLE_NOTARY_ISSUER_ID               (App Store Connect API issuer UUID)
+      #   APPLE_NOTARY_KEY_ID                  (App Store Connect API key id)
+      #   APPLE_NOTARY_PRIVATE_KEY             (App Store Connect .p8 contents)
+      # With those in place the darwin legs would need a macos-* runner to run
+      # `codesign --options runtime --timestamp` + `xcrun notarytool submit`,
+      # since neither tool exists on ubuntu. Until then, do NOT claim the
+      # darwin assets are signed anywhere in the docs or release notes.
       - name: Build binary
         working-directory: typescript-sdk
         env:
@@ -130,11 +248,16 @@ jobs:
         # ubuntu x64 runner — their correctness rests on Bun's cross-compile
         # and on the npm-published CLI's CI tests. Only the native target is
         # executed here.
+        #
+        # This is also the only check that the checked-out ref actually matches
+        # the release tag. It gates the whole publish job (via `needs: build`),
+        # so a version mismatch now blocks ALL five uploads rather than being
+        # noticed after four of them already landed.
         if: matrix.target == 'bun-linux-x64'
         working-directory: typescript-sdk
         env:
           ASSET: ${{ steps.names.outputs.asset }}
-          VERSION: ${{ steps.names.outputs.version }}
+          VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           set -euo pipefail
           out="$(LANGWATCH_NO_DAEMON=1 "./dist/bin/${ASSET}" --version)"
@@ -154,18 +277,158 @@ jobs:
           sha256sum "${ASSET}" > "${ASSET}.sha256"
           cat "${ASSET}.sha256"
 
-      - name: Attach to GitHub release
-        if: ${{ !inputs.dry_run }}
-        working-directory: typescript-sdk
+      - name: Upload build artifact
+        # The sidecar travels WITH the binary so the publish job can re-verify
+        # it after the artifact round-trip, rather than trusting the transport.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cli-binary-${{ matrix.target }}
+          path: |
+            typescript-sdk/dist/bin/${{ steps.names.outputs.asset }}
+            typescript-sdk/dist/bin/${{ steps.names.outputs.asset }}.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: attest and attach release assets
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Default `needs` semantics: this job does not run unless EVERY matrix leg
+    # succeeded. That is the whole point of the split — no partial release.
+    needs: [resolve, build]
+    if: needs.resolve.outputs.publish == 'true'
+    permissions:
+      contents: write # gh release upload
+      id-token: write # sigstore OIDC for provenance
+      attestations: write # store the attestation on the repo
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: bin
+          pattern: cli-binary-*
+          merge-multiple: true
+
+      - name: Verify checksums and expected asset set
+        id: assets
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
-          ASSET: ${{ steps.names.outputs.asset }}
+          VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           set -euo pipefail
-          if [ -z "${RELEASE_TAG}" ]; then
-            echo "dry_run is off but no release tag is known (pass release_tag)" >&2
+          cd bin
+          ls -lh
+
+          # Re-verify every sidecar against the artifact that arrived, so a
+          # corrupted upload/download can never reach the release.
+          for sidecar in *.sha256; do
+            sha256sum -c "${sidecar}"
+          done
+
+          # Every platform must be present before anything is attached. The
+          # list is spelled out rather than derived from the matrix so a
+          # silently-dropped matrix entry is a failure, not a smaller release.
+          missing=0
+          binaries=()
+          for platform in linux-x64 linux-arm64 darwin-x64 darwin-arm64 windows-x64.exe; do
+            asset="langwatch-${VERSION}-${platform}"
+            if [ ! -f "${asset}" ] || [ ! -f "${asset}.sha256" ]; then
+              echo "missing expected asset: ${asset} (or its .sha256)" >&2
+              missing=1
+            else
+              binaries+=("${asset}")
+            fi
+          done
+          if [ "${missing}" -ne 0 ]; then
+            echo "refusing to publish an incomplete set of binaries" >&2
             exit 1
           fi
-          cd dist/bin
-          gh release upload "${RELEASE_TAG}" "${ASSET}" "${ASSET}.sha256" --clobber
+
+          # One aggregate manifest, in the conventional `sha256sum -c` format,
+          # so a user can verify every asset with a single command. Built from
+          # the explicit list, NOT a glob — a glob would fold the .sha256
+          # sidecars into the manifest that is supposed to cover the binaries.
+          sha256sum "${binaries[@]}" > SHA256SUMS
+          cat SHA256SUMS
+
+          # Stage just the binaries for the attestation step.
+          mkdir -p ../attest
+          cp "${binaries[@]}" ../attest/
+
+      - name: Attest build provenance
+        # The .sha256 sidecars prove integrity only: they are produced by the
+        # same run that produces the binaries, so they say nothing about
+        # authenticity. This signs a provenance statement (sigstore, keyless)
+        # binding each binary to this workflow, this repo and this commit —
+        # verifiable with `gh attestation verify <file> --repo <owner>/<repo>`.
+        # Brings the binary channel up to the guarantee the npm channel already
+        # has via `pnpm publish --provenance` (sdk-javascript-cd.yml).
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          # `attest/` holds ONLY the five binaries (see the step above). Using a
+          # dedicated directory rather than a negated glob over `bin/` keeps the
+          # subject set obvious and impossible to widen by accident.
+          subject-path: "attest/*"
+
+      - name: Attach to GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd bin
+          # The glob covers the five binaries and their five .sha256 sidecars;
+          # SHA256SUMS is named explicitly.
+          gh release upload "${RELEASE_TAG}" \
+            langwatch-"${VERSION}"-* SHA256SUMS --clobber
+
+      - name: Verify the release advertises every asset
+        # Belt and braces: `gh release upload` is not transactional, so read the
+        # release back and confirm each expected name is really attached. A
+        # green workflow must mean a complete release.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release view "${RELEASE_TAG}" --json assets --jq '.assets[].name' | sort > /tmp/attached.txt
+          cat /tmp/attached.txt
+
+          missing=0
+          for platform in linux-x64 linux-arm64 darwin-x64 darwin-arm64 windows-x64.exe; do
+            for name in "langwatch-${VERSION}-${platform}" "langwatch-${VERSION}-${platform}.sha256"; do
+              if ! grep -Fxq "${name}" /tmp/attached.txt; then
+                echo "release ${RELEASE_TAG} is missing asset: ${name}" >&2
+                missing=1
+              fi
+            done
+          done
+          if ! grep -Fxq "SHA256SUMS" /tmp/attached.txt; then
+            echo "release ${RELEASE_TAG} is missing SHA256SUMS" >&2
+            missing=1
+          fi
+          if [ "${missing}" -ne 0 ]; then
+            echo "release ${RELEASE_TAG} is incomplete" >&2
+            exit 1
+          fi
+          echo "release ${RELEASE_TAG} advertises all expected assets"
+
+  # One terminal status for the whole workflow. `needs:` treats a SKIPPED
+  # dependency as satisfied, so without this a failed matrix leg could leave
+  # the run looking benign; alls-green distinguishes "legitimately skipped"
+  # from "failed". Same pattern as sdk-javascript-ci.yml / sdk-python-ci.yml.
+  cli-binary-publish-complete:
+    name: cli-binary-publish complete
+    needs: [resolve, build, publish]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}
+          # resolve/build skip for a non-typescript-sdk release; publish skips
+          # on a dry-run dispatch. A FAILURE in any of them is still red.
+          allowed-skips: resolve, build, publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ specs/               # BDD feature specs
 | Hono routes calling repositories directly | Routes must go through a service layer — never instantiate or import from repositories. Business logic (validation, guards) belongs in the service, not the route |
 | Using `list` or `get` for repository methods | Repositories use `findAll`/`findById`. Services use `getAll`/`getById`. Routes call services only |
 | Setting up a Monitor / sleep that *can* take more than 5 minutes | Anthropic's prompt cache TTL is 5min, so any wait that crosses it forces an uncached re-read of the full conversation on wake-up (slower + double-pays for tokens). Cap each poll cycle at **4.5 min (270s)** — re-check, then re-arm. If the work is obviously hours away (long deploy, overnight run), don't sit on a Monitor at all — drop it and hand control back to the user |
-| Using inline `import("...")` anywhere | Never use inline `import()` — always use top-level `import` / `import type` statements |
+| Using inline `import("...")` anywhere | Never use inline `import()` — always use top-level `import` / `import type` statements. **One exception: the CLI startup path** (`typescript-sdk/src/cli/**` and `typescript-sdk/tsup.config.ts`), where lazy `import()` is load-bearing — it is what keeps commander, chalk, zod, js-yaml, the command modules and the command catalog off the boot graph and the cold start at ~30ms. There, defer at the seam (command actions, format branches) and keep the boot graph pinned by `src/cli/__tests__/index-boot.unit.test.ts`. Everywhere else the ban stands |
 
 ## TypeScript
 

--- a/dev/docs/lw-cli-compat-matrix.md
+++ b/dev/docs/lw-cli-compat-matrix.md
@@ -26,7 +26,7 @@ P1 output contract & agent mode · P2 HandledError-driven errors · P3 discovera
 | 9 | Docs as markdown from the CLI (llms.txt index + pages) | ❌ | ❌ | ✅ `commands/docs.ts` (`docs`, `scenario-docs`) — ahead of both | — |
 | 10 | Non-interactive auth for agents (token/device flow) | ✅ | ✅ | ✅ device flow + `--api-key` (`utils/governance/device-flow.ts`, `commands/login.ts`) | — |
 | 11 | Fast cold start for agent shell-outs | ✅ (Go binary) | ✅ | ✅ warm daemon (`daemon/`) + bun-compiled binary (`scripts/build-cli-binary.ts`) | — |
-| 12 | Help topics (`gh help formatting`, `environment`, `exit-codes`) | ❌ | ✅ | ✅ `lw help agent` (`typescript-sdk/src/cli/commands/help.ts`) — registered as a real `help [topic]` command, which suppresses commander's implicit help command (its dispatch is internal and could never reach a topic page); `help <command>` still prints that command's help, unknown topics exit 1. The `agent` page covers: agent mode + the 7 env vars, the output contract with examples, the structured-error document, discovery (`commands`/`help-tree`/`status`/`docs`), skills, the daemon, and piping rules | ~~P5~~ done |
+| 12 | Help topics (`gh help formatting`, `environment`, `exit-codes`) | ❌ | ✅ | ✅ `lw help agent-mode` (`typescript-sdk/src/cli/commands/help.ts`) — registered as a real `help [topic]` command, which suppresses commander's implicit help command (its dispatch is internal and could never reach a topic page); `help <command>` still prints that command's help (commands are resolved before topics, so a topic can never shadow a command), unknown topics exit 1. The `agent-mode` page covers: agent mode + the 7 env vars, the output contract with examples, the structured-error document, discovery (`commands`/`help-tree`/`status`/`docs`), skills, the daemon, and piping rules | ~~P5~~ done |
 
 ## Notes per row
 
@@ -173,9 +173,11 @@ P1 output contract & agent mode · P2 HandledError-driven errors · P3 discovera
 ### 12. Help topics (P5) — DONE
 - `help` is registered as a REAL command (`help [topic]`): a command named
   `help` suppresses commander's lazily-created implicit one, so
-  `lw help agent` reaches our action while `lw help` / `lw help <command>`
+  `lw help agent-mode` reaches our action while `lw help` / `lw help <command>`
   keep the stock behavior (root help / the named command's help, aliases
-  included). Added to `PLUMBING_COMMANDS` (SDK drift test + status summary)
+  included). Commands are resolved BEFORE topics, and no topic may be named
+  after a command — the topic is `agent-mode`, not `agent`, because `agent` is
+  a real top-level group. Added to `PLUMBING_COMMANDS` (SDK drift test + status summary)
   and the mirror `EXCLUDED_COMMANDS` in the app-side capabilityCatalog
   coverage test.
 

--- a/docs/integration/cli.mdx
+++ b/docs/integration/cli.mdx
@@ -24,6 +24,41 @@ npx langwatch --help
 
 `pnpm install -g langwatch` and `yarn global add langwatch` work the same way; the package is identical across all three package managers.
 
+### Standalone binary (no Node.js required)
+
+Each release also attaches a self-contained binary for Linux, macOS, and Windows — useful in containers, CI images, and anywhere you'd rather not install Node.js. Download the one for your platform from the [releases page](https://github.com/langwatch/langwatch/releases), then:
+
+```bash
+# Verify the download against the release's SHA256SUMS, then install it
+sha256sum --check --ignore-missing SHA256SUMS
+chmod +x langwatch-<version>-<platform>
+sudo mv langwatch-<version>-<platform> /usr/local/bin/langwatch
+```
+
+Every binary is published with a signed [build provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds), so you can confirm it really was built by LangWatch's release workflow from this repository:
+
+```bash
+gh attestation verify langwatch-<version>-<platform> --repo langwatch/langwatch
+```
+
+#### macOS: clearing Gatekeeper
+
+<Warning>
+The macOS binaries are **not yet codesigned or notarized**. Gatekeeper will refuse to run them with *"langwatch cannot be opened because the developer cannot be verified"*.
+</Warning>
+
+macOS attaches a `com.apple.quarantine` attribute to anything downloaded from the internet. After verifying the checksum above, remove it:
+
+```bash
+xattr -d com.apple.quarantine langwatch-<version>-darwin-arm64
+```
+
+Then run the binary as normal. (If `xattr` reports *"No such xattr"*, the attribute was never set — nothing to do.)
+
+<Note>
+Only clear quarantine on a binary whose checksum you have verified against the release's `SHA256SUMS`. Signing and notarization are tracked as follow-up work; until then, `npm install -g langwatch` avoids Gatekeeper entirely and is the smoother path on macOS.
+</Note>
+
 ## Authenticate
 
 `langwatch login` is interactive by default, it asks where (cloud vs self-hosted) and how (AI tools vs project SDK), opens your browser to approve, and the credential flows back to the CLI automatically. **No copy-paste of keys**:
@@ -456,7 +491,7 @@ See the [public REST API reference](/ai-gateway/api/chat-completions) for direct
 
 ## Agent usage
 
-The CLI is human-first (tables, colour, spinners in a terminal) and agent-perfect: driven by an AI coding assistant it switches to machine output automatically. Everything an agent needs to know is also built into the CLI itself — `langwatch help agent` prints the condensed version of this section.
+The CLI is human-first (tables, colour, spinners in a terminal) and agent-perfect: driven by an AI coding assistant it switches to machine output automatically. Everything an agent needs to know is also built into the CLI itself — `langwatch help agent-mode` prints the condensed version of this section.
 
 ### Agent mode
 
@@ -499,7 +534,7 @@ An agent can learn the whole CLI without reading these docs:
 ```bash
 langwatch commands --flat --jq '.commands[].path'   # machine catalog: args, flags, hints, token costs
 langwatch help-tree                                  # compact annotated tree for context injection
-langwatch help agent                                 # the agent-mode guide, from the CLI itself
+langwatch help agent-mode                            # the agent-mode guide, from the CLI itself
 langwatch status                                     # project overview + what needs attention
 ```
 

--- a/docs/scripts/sync-prompts.sh
+++ b/docs/scripts/sync-prompts.sh
@@ -1,15 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Regenerate docs/snippets/prompts-data.jsx from compiled skill prompts.
 # Run from the repo root: bash docs/scripts/sync-prompts.sh
-
-set -e
+#
+# `env bash`, not /bin/bash: this script uses `declare -A` (associative
+# arrays), which needs bash >= 4. macOS still ships bash 3.2 at /bin/bash, so
+# a hard-coded interpreter silently picks the one version that cannot run it.
+#
+# `pipefail` matters as much as `-e` here: the generation below is built from
+# pipelines, and without it a failure in any stage but the last is swallowed
+# and an EMPTY prompt body gets written into the committed .jsx.
+set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 # Step 1: Compile the skill sources into .txt files
-echo "Running skills/_compiled/generate.sh..."
-bash skills/_compiled/generate.sh
+GENERATE="skills/_compiled/generate.sh"
+if [ ! -f "$GENERATE" ]; then
+  echo "ERROR: missing $GENERATE — run from a full checkout" >&2
+  exit 1
+fi
+echo "Running $GENERATE..."
+bash "$GENERATE"
 
 # Step 2: Convert compiled .txt files into prompts-data.jsx
 OUT="docs/snippets/prompts-data.jsx"
@@ -55,12 +67,17 @@ DOCS_ORDER="tracing evaluations scenarios prompts analytics datasets level-up re
 
 for stem in $DOCS_ORDER; do
   file="$COMPILED_DIR/${stem}.docs.txt"
-  key="${DOCS_KEY_MAP[$stem]}"
-  if [ -f "$file" ] && [ -n "$key" ]; then
+  # `:-` because `set -u` makes a missing associative-array key a hard bash
+  # error, which would pre-empt the explicit message below.
+  key="${DOCS_KEY_MAP[$stem]:-}"
+  # -s, not -f: an existing-but-empty compiled file is the exact failure this
+  # script must not commit — it would write an empty prompt body that looks
+  # like a legitimate diff.
+  if [ -s "$file" ] && [ -n "$key" ]; then
     content=$(escape_for_template_literal < "$file")
     printf '  %s: `%s`,\n\n' "$key" "$content" >> "$OUT"
   else
-    echo "ERROR: Missing file or key for $stem" >&2; exit 1
+    echo "ERROR: Missing, empty, or unkeyed compiled file for $stem ($file)" >&2; exit 1
   fi
 done
 
@@ -81,12 +98,12 @@ PLATFORM_ORDER="analytics scenarios evaluations"
 
 for stem in $PLATFORM_ORDER; do
   file="$COMPILED_DIR/${stem}.platform.txt"
-  key="${PLATFORM_KEY_MAP[$stem]}"
-  if [ -f "$file" ] && [ -n "$key" ]; then
+  key="${PLATFORM_KEY_MAP[$stem]:-}"
+  if [ -s "$file" ] && [ -n "$key" ]; then
     content=$(escape_for_template_literal < "$file")
     printf '  %s: `%s`,\n\n' "$key" "$content" >> "$OUT"
   else
-    echo "ERROR: Missing platform file or key for $stem" >&2; exit 1
+    echo "ERROR: Missing, empty, or unkeyed platform file for $stem ($file)" >&2; exit 1
   fi
 done
 

--- a/docs/scripts/sync-prompts.sh
+++ b/docs/scripts/sync-prompts.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Regenerate docs/snippets/prompts-data.jsx from compiled skill prompts.
-# Run from the repo root: bash docs/scripts/sync-prompts.sh
+# Run from the repo root: ./docs/scripts/sync-prompts.sh
+# (invoke directly, NOT via `bash …` — the shebang selects a bash 4+ from PATH,
+#  and macOS ships bash 3.2, which cannot do the `declare -A` used below)
 #
 # `env bash`, not /bin/bash: this script uses `declare -A` (associative
 # arrays), which needs bash >= 4. macOS still ships bash 3.2 at /bin/bash, so
@@ -34,7 +36,7 @@ escape_for_template_literal() {
 
 cat > "$OUT" <<'HEADER'
 // Auto-generated — do not edit manually.
-// Regenerate with: bash docs/scripts/sync-prompts.sh
+// Regenerate with: ./docs/scripts/sync-prompts.sh
 
 export const PROMPTS = {
 HEADER

--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -1,5 +1,5 @@
 // Auto-generated — do not edit manually.
-// Regenerate with: bash docs/scripts/sync-prompts.sh
+// Regenerate with: ./docs/scripts/sync-prompts.sh
 
 export const PROMPTS = {
   tracing: `Instrument my code with LangWatch

--- a/packages/cli-cards/src/domain-error.test.ts
+++ b/packages/cli-cards/src/domain-error.test.ts
@@ -342,3 +342,192 @@ describe("domainErrorFromThrown", () => {
     expect(parsed).toMatchObject({ isDomain: false, message: "fetch failed" });
   });
 });
+
+/**
+ * The shape `fetch` ACTUALLY throws when the transport fails: a
+ * `TypeError("fetch failed")` whose `cause` is the libuv system error. Its own
+ * enumerable keys are `{ errno, code, syscall, address, port }`, so it carries a
+ * top-level `code` — `ECONNREFUSED`, `ENOTFOUND`, a TLS cert code — that is not
+ * a discriminant the platform ever chose.
+ *
+ * A hand-rolled `new Error("fetch failed")` with no `cause` cannot stand in for
+ * this: it is the `cause` that carries the `code`, and the `code` is the whole
+ * hazard. Read as a domain error, a dead socket renders as though the USER had
+ * done something wrong, and the local address and port ride along in `meta`.
+ */
+const systemError = ({
+  message,
+  code,
+  errno,
+  syscall,
+  extra = {},
+}: {
+  message: string;
+  code: string;
+  errno: number;
+  syscall: string;
+  extra?: Record<string, unknown>;
+}) =>
+  Object.assign(new TypeError("fetch failed"), {
+    cause: Object.assign(new Error(message), {
+      errno,
+      code,
+      syscall,
+      ...extra,
+    }),
+  });
+
+describe("domainErrorFromThrown, given a transport failure fetch threw", () => {
+  describe("when the socket was refused", () => {
+    const refused = () =>
+      systemError({
+        message: "connect ECONNREFUSED 127.0.0.1:5560",
+        code: "ECONNREFUSED",
+        errno: -61,
+        syscall: "connect",
+        extra: { address: "127.0.0.1", port: 5560 },
+      });
+
+    it("classifies a refused connection as infrastructure", () => {
+      const parsed = domainErrorFromThrown(refused());
+
+      expect(parsed).toMatchObject({ code: "network_error", isDomain: false });
+    });
+
+    it("never claims the libuv code as a domain discriminant", () => {
+      const parsed = domainErrorFromThrown(refused());
+
+      expect(parsed.code).not.toBe("ECONNREFUSED");
+      expect(parsed.kind).not.toBe("ECONNREFUSED");
+    });
+
+    it("keeps the local address and port out of the rendered document", () => {
+      const rendered = JSON.stringify(
+        toCliErrorDocument(domainErrorFromThrown(refused())),
+      );
+
+      expect(rendered).not.toContain("127.0.0.1");
+      expect(rendered).not.toContain("5560");
+      expect(rendered).not.toContain("syscall");
+      expect(rendered).not.toContain("errno");
+    });
+
+    it("reports the failure with status 0, not a fabricated one", () => {
+      expect(domainErrorFromThrown(refused()).httpStatus).toBe(0);
+    });
+  });
+
+  describe("when DNS could not resolve the host", () => {
+    it("classifies an unresolvable host as infrastructure", () => {
+      const parsed = domainErrorFromThrown(
+        systemError({
+          message: "getaddrinfo ENOTFOUND app.langwatch.invalid",
+          code: "ENOTFOUND",
+          errno: -3008,
+          syscall: "getaddrinfo",
+          extra: { hostname: "app.langwatch.invalid" },
+        }),
+      );
+
+      expect(parsed).toMatchObject({ code: "network_error", isDomain: false });
+    });
+
+    it("classifies a DNS timeout as infrastructure", () => {
+      const parsed = domainErrorFromThrown(
+        systemError({
+          message: "getaddrinfo EAI_AGAIN app.langwatch.ai",
+          code: "EAI_AGAIN",
+          errno: -3001,
+          syscall: "getaddrinfo",
+        }),
+      );
+
+      expect(parsed).toMatchObject({ code: "network_error", isDomain: false });
+    });
+  });
+
+  describe("when TLS could not verify the certificate", () => {
+    it("classifies a self-signed certificate as infrastructure", () => {
+      const parsed = domainErrorFromThrown(
+        systemError({
+          message: "self signed certificate in certificate chain",
+          code: "SELF_SIGNED_CERT_IN_CHAIN",
+          errno: -1,
+          syscall: "connect",
+        }),
+      );
+
+      expect(parsed).toMatchObject({ code: "network_error", isDomain: false });
+    });
+
+    it("classifies an unverifiable leaf certificate as infrastructure", () => {
+      const parsed = domainErrorFromThrown(
+        systemError({
+          message: "unable to verify the first certificate",
+          code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+          errno: -1,
+          syscall: "connect",
+        }),
+      );
+
+      expect(parsed).toMatchObject({ code: "network_error", isDomain: false });
+    });
+  });
+
+  describe("when the connection died mid-flight", () => {
+    it.each([
+      ["ETIMEDOUT", -60, "connect ETIMEDOUT 10.0.0.1:443"],
+      ["ECONNRESET", -54, "read ECONNRESET"],
+      ["EPIPE", -32, "write EPIPE"],
+    ])("classifies %s as infrastructure", (code, errno, message) => {
+      const parsed = domainErrorFromThrown(
+        systemError({ message, code, errno, syscall: "connect" }),
+      );
+
+      expect(parsed).toMatchObject({ code: "network_error", isDomain: false });
+    });
+  });
+
+  it("keeps the transport's own sentence, so the user still learns what broke", () => {
+    const parsed = domainErrorFromThrown(
+      systemError({
+        message: "connect ECONNREFUSED 127.0.0.1:5560",
+        code: "ECONNREFUSED",
+        errno: -61,
+        syscall: "connect",
+      }),
+    );
+
+    expect(parsed.message).toBe("fetch failed");
+  });
+});
+
+describe("parseDomainError, given a bare `code` with nothing else", () => {
+  it("refuses to read a lone code as a domain discriminant", () => {
+    const parsed = parseDomainError({ status: 0, body: { code: "ECONNREFUSED" } });
+
+    expect(parsed).toMatchObject({ code: "network_error", isDomain: false });
+  });
+
+  it("still reads a code that arrives with the envelope's sentence", () => {
+    const parsed = parseDomainError({
+      status: 0,
+      body: { code: "dataset_not_found", message: "Dataset not found" },
+    });
+
+    expect(parsed).toMatchObject({ code: "dataset_not_found", isDomain: true });
+  });
+
+  it("still reads a code that arrives with the envelope's meta bag", () => {
+    const parsed = parseDomainError({
+      status: 404,
+      body: { code: "dataset_not_found", meta: { id: "sales-q3" } },
+    });
+
+    expect(parsed).toMatchObject({
+      code: "dataset_not_found",
+      meta: { id: "sales-q3" },
+      isDomain: true,
+    });
+  });
+});

--- a/packages/cli-cards/src/domain-error.ts
+++ b/packages/cli-cards/src/domain-error.ts
@@ -135,6 +135,35 @@ const asReasons = (value: unknown): CliDomainErrorReason[] | undefined => {
   return reasons.length > 0 ? reasons : undefined;
 };
 
+/**
+ * A libuv/Node system error, not a platform error body.
+ *
+ * `fetch` reports a transport failure by throwing a `TypeError("fetch failed")`
+ * whose `cause` is the system error, and `domainErrorFromThrown` unwraps to that
+ * cause. Its own enumerable keys are `{ errno, code, syscall, address, port }` —
+ * so its `code` is `ECONNREFUSED`/`ENOTFOUND`/`ETIMEDOUT`/a TLS cert code, NOT a
+ * discriminant the platform ever chose. Reading one as a domain error is the
+ * worst kind of wrong: it blames the user for the network being down, and it
+ * lifts the local `address`/`port` into `meta` as though they were domain
+ * context. `errno`/`syscall` are the tell, and no platform envelope carries
+ * them, so their presence disqualifies the record outright — a transport
+ * failure is infrastructure, always.
+ */
+const isSystemError = (record: Record<string, unknown>): boolean =>
+  "errno" in record || "syscall" in record;
+
+/**
+ * Does this record look like the platform's envelope at all?
+ *
+ * Only asked of a BARE top-level `code` — the one field a system error shares
+ * with dialect 3. The platform never sends a lone `code`: its envelope always
+ * carries the sentence, the meta bag, or the deprecated `kind` alongside it. So
+ * a `code` with none of them is not the platform speaking, and is not trusted to
+ * name a domain failure.
+ */
+const looksLikeErrorEnvelope = (record: Record<string, unknown>): boolean =>
+  "message" in record || "meta" in record || "kind" in record;
+
 /** Next steps, defensively: only real strings survive. */
 const asSuggestions = (value: unknown): string[] | undefined => {
   if (!Array.isArray(value)) return undefined;
@@ -172,7 +201,7 @@ interface ErrorBody {
  *      `{ error: <sentence>, domainError: { code, kind, meta, traceId, reasons } }`.
  *
  *   3. THE FRAMEWORK ONE, from the new API framework
- *      (`packages/api/src/errors.ts`): the envelope top-level —
+ *      (`langwatch/packages/api/src/errors.ts`): the envelope top-level —
  *      `{ code, kind, message, meta, reasons, traceId, spanId, traceUrl }`,
  *      with `error` carrying the HTTP status text on unversioned routes.
  *
@@ -183,6 +212,12 @@ interface ErrorBody {
 const asErrorBody = (value: unknown): ErrorBody | null => {
   const record = asRecord(value);
   if (!record) return null;
+
+  // A libuv system error is a transport failure wearing a `code`. It is never
+  // any of the three dialects, whatever else it carries, so it never gets to
+  // name a domain failure — it falls through to the status-derived reading,
+  // which calls it `network_error` and means it.
+  if (isSystemError(record)) return null;
 
   // Dialect 2: the serialised HandledError, carried whole under `domainError`.
   const serialized = asRecord(record.domainError);
@@ -228,7 +263,9 @@ const asErrorBody = (value: unknown): ErrorBody | null => {
   // if `code` were read first. Dialect 3 always emits `kind` alongside `code`,
   // so a `kind` present means `code` is the envelope's own and wins; with no
   // `kind`, `error` is the dialect-1 discriminant and a bare `code` is only
-  // trusted when nothing else named the failure.
+  // trusted when nothing else named the failure — and only then if the record
+  // looks like the platform's envelope at all, so a stray `code` on some other
+  // object cannot pass itself off as a discriminant the platform chose.
   const named =
     typeof record.kind === "string"
       ? typeof record.code === "string"
@@ -236,7 +273,7 @@ const asErrorBody = (value: unknown): ErrorBody | null => {
         : record.kind
       : typeof record.error === "string"
         ? record.error
-        : typeof record.code === "string"
+        : typeof record.code === "string" && looksLikeErrorEnvelope(record)
           ? record.code
           : null;
   if (named === null) return null;

--- a/typescript-sdk/copy-types.sh
+++ b/typescript-sdk/copy-types.sh
@@ -1,6 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+# `pipefail` and `-u` alongside `-e`: this script generates files that are
+# compiled into the published tarball and into all five release binaries, so a
+# silently-swallowed failure here ships broken generated code.
+set -euo pipefail
 
 # Tracer types are Zod-first in the platform: the schemas in types.ts are the
 # source of truth and the TypeScript types are inferred with z.infer. Copy the

--- a/typescript-sdk/eslint.config.mjs
+++ b/typescript-sdk/eslint.config.mjs
@@ -42,7 +42,25 @@ const config = tseslint.config(
             ecmaVersion: "latest",
             sourceType: "module",
             parserOptions: { project: false, projectService: false },
-            globals: { console: "readonly", process: "readonly" },
+            // Listed explicitly rather than via the `globals` package, which is
+            // not a direct dependency here. Covers what a build script actually
+            // reaches for — without these, a script using Buffer/URL/__dirname
+            // would fail CI lint with a bogus no-undef rather than a real finding.
+            globals: {
+                console: "readonly",
+                process: "readonly",
+                Buffer: "readonly",
+                URL: "readonly",
+                URLSearchParams: "readonly",
+                TextEncoder: "readonly",
+                TextDecoder: "readonly",
+                __dirname: "readonly",
+                __filename: "readonly",
+                fetch: "readonly",
+                structuredClone: "readonly",
+                setTimeout: "readonly",
+                clearTimeout: "readonly",
+            },
         },
     },
     {

--- a/typescript-sdk/eslint.config.mjs
+++ b/typescript-sdk/eslint.config.mjs
@@ -9,12 +9,14 @@ const config = tseslint.config(
             "coverage/**",
             "examples/**",
             "**/generated/**",
-            // Plain-node build scripts run by copy-types.sh — outside the
-            // eslint tsconfig project, like the shell script that calls them.
-            "scripts/**/*.mjs",
-            // Startup profiling preload hook — plain CJS, likewise outside
-            // the tsconfig project.
-            "scripts/**/*.cjs",
+            // Dev-only helpers, ignored BY NAME rather than by a
+            // `scripts/**/*.mjs` glob. That glob also silenced
+            // scripts/generate-skills-bundle.mjs, which is build-critical:
+            // copy-types.sh runs it on every install and build, and its output
+            // is compiled into the published tarball and all five release
+            // binaries. It is linted (untyped) by the block below instead.
+            "scripts/profile-startup.mjs",
+            "scripts/startup-require-hook.cjs",
         ],
     },
     eslint.configs.recommended,
@@ -26,6 +28,21 @@ const config = tseslint.config(
                 project: "./tsconfig.eslint.json",
                 tsconfigRootDir: import.meta.dirname,
             },
+        },
+    },
+    {
+        // Plain-node build scripts (scripts/generate-skills-bundle.mjs). They
+        // are outside tsconfig.eslint.json, so type-aware rules cannot run —
+        // but the untyped ones (no-undef, no-unused-vars, no-fallthrough) can,
+        // and those are the ones that catch a broken codegen script before it
+        // ships generated code into the tarball.
+        files: ["scripts/**/*.mjs"],
+        ...tseslint.configs.disableTypeChecked,
+        languageOptions: {
+            ecmaVersion: "latest",
+            sourceType: "module",
+            parserOptions: { project: false, projectService: false },
+            globals: { console: "readonly", process: "readonly" },
         },
     },
     {

--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -14,6 +14,7 @@
   "files": [
     "dist",
     "!dist/bin",
+    "!dist/cli/*.map",
     "README.md",
     "LICENSE"
   ],
@@ -59,11 +60,12 @@
     "test:seed": "dotenv -e .env.test -- bash -c 'cd ../langwatch && pnpm prisma:seed'",
     "prebuild": "pnpm run prepare",
     "build": "tsc --noEmit && rm -rf dist && tsup",
+    "postbuild": "node -e \"const{statSync}=require('node:fs'),{execFileSync}=require('node:child_process');const f='dist/cli/index.js',want=require('./package.json').version;const s=statSync(f);if(!(s.mode&0o111))throw new Error(f+' is not executable');const got=execFileSync(process.execPath,[f,'--version'],{encoding:'utf8',env:{...process.env,LANGWATCH_NO_DAEMON:'1'}}).trim();if(got!==want)throw new Error('version mismatch: '+f+' reports '+got+', package.json says '+want);console.log('postbuild: '+f+' ok ('+got+')')\"",
     "build:binary": "bun run scripts/build-cli-binary.ts",
     "tarball": "pnpm build && pnpm pack",
     "typecheck": "tsc --noEmit",
     "prepublish": "pnpm run build",
-    "generate:openapi-types": "pnpx openapi-typescript ../langwatch/src/app/api/openapiLangWatch.json -o ./src/internal/generated/openapi/api-client.ts",
+    "generate:openapi-types": "pnpm exec openapi-typescript ../langwatch/src/app/api/openapiLangWatch.json -o ./src/internal/generated/openapi/api-client.ts",
     "generate:server-types": "./copy-types.sh"
   },
   "devDependencies": {
@@ -91,6 +93,7 @@
     "msw": "^2.10.4",
     "nock": "^14.0.8",
     "openapi-msw": "^1.2.0",
+    "openapi-typescript": "7.13.0",
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.38.0",

--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -60,7 +60,7 @@
     "test:seed": "dotenv -e .env.test -- bash -c 'cd ../langwatch && pnpm prisma:seed'",
     "prebuild": "pnpm run prepare",
     "build": "tsc --noEmit && rm -rf dist && tsup",
-    "postbuild": "node -e \"const{statSync}=require('node:fs'),{execFileSync}=require('node:child_process');const f='dist/cli/index.js',want=require('./package.json').version;const s=statSync(f);if(!(s.mode&0o111))throw new Error(f+' is not executable');const got=execFileSync(process.execPath,[f,'--version'],{encoding:'utf8',env:{...process.env,LANGWATCH_NO_DAEMON:'1'}}).trim();if(got!==want)throw new Error('version mismatch: '+f+' reports '+got+', package.json says '+want);console.log('postbuild: '+f+' ok ('+got+')')\"",
+    "postbuild": "node -e \"const{statSync}=require('node:fs'),{execFileSync}=require('node:child_process');const f='dist/cli/index.js',want=require('./package.json').version;const s=statSync(f);if(process.platform!=='win32'&&!(s.mode&0o111))throw new Error(f+' is not executable');const got=execFileSync(process.execPath,[f,'--version'],{encoding:'utf8',env:{...process.env,LANGWATCH_NO_DAEMON:'1'}}).trim();if(got!==want)throw new Error('version mismatch: '+f+' reports '+got+', package.json says '+want);console.log('postbuild: '+f+' ok ('+got+')')\"",
     "build:binary": "bun run scripts/build-cli-binary.ts",
     "tarball": "pnpm build && pnpm pack",
     "typecheck": "tsc --noEmit",

--- a/typescript-sdk/pnpm-lock.yaml
+++ b/typescript-sdk/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       openapi-msw:
         specifier: ^1.2.0
         version: 1.3.0(msw@2.14.6(@types/node@24.5.2)(typescript@5.9.3))
+      openapi-typescript:
+        specifier: 7.13.0
+        version: 7.13.0(typescript@5.9.3)
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
@@ -225,6 +228,10 @@ packages:
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
     engines: {node: '>=18'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -800,6 +807,16 @@ packages:
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
 
+  '@redocly/ajv@8.11.2':
+    resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
+
+  '@redocly/config@0.22.0':
+    resolution: {integrity: sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==}
+
+  '@redocly/openapi-core@1.34.17':
+    resolution: {integrity: sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==}
+    engines: {node: '>=18.17.0', npm: '>=9.5.0'}
+
   '@rollup/rollup-android-arm-eabi@4.61.1':
     resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
     cpu: [arm]
@@ -1321,8 +1338,16 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1411,6 +1436,9 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -1440,6 +1468,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -1740,6 +1771,10 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1759,6 +1794,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -1824,11 +1863,22 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-levenshtein@1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
+
   js-tiktoken@1.0.21:
     resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
@@ -1847,6 +1897,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -2015,6 +2068,10 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2110,6 +2167,12 @@ packages:
   openapi-typescript-helpers@0.1.0:
     resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
 
+  openapi-typescript@7.13.0:
+    resolution: {integrity: sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.x
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2149,6 +2212,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2180,6 +2247,10 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -2240,6 +2311,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   require-in-the-middle@8.0.1:
@@ -2383,6 +2458,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2484,6 +2563,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-fest@5.7.0:
     resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
     engines: {node: '>=20'}
@@ -2508,6 +2591,9 @@ packages:
 
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
+
+  uri-js-replace@1.0.1:
+    resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -2635,6 +2721,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yaml-ast-parser@0.0.43:
+    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -2685,6 +2774,12 @@ snapshots:
   '@ai-sdk/provider@2.0.0':
     dependencies:
       json-schema: 0.4.0
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -2798,7 +2893,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -2812,7 +2907,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -3255,6 +3350,29 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
 
+  '@redocly/ajv@8.11.2':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js-replace: 1.0.1
+
+  '@redocly/config@0.22.0': {}
+
+  '@redocly/openapi-core@1.34.17(supports-color@10.2.2)':
+    dependencies:
+      '@redocly/ajv': 8.11.2
+      '@redocly/config': 0.22.0
+      colorette: 1.4.0
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      js-levenshtein: 1.1.6
+      js-yaml: 4.2.0
+      minimatch: 5.1.9
+      pluralize: 8.0.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - supports-color
+
   '@rollup/rollup-android-arm-eabi@4.61.1':
     optional: true
 
@@ -3470,7 +3588,7 @@ snapshots:
       '@typescript-eslint/types': 8.44.0
       '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.44.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.36.0
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3480,7 +3598,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.44.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3499,7 +3617,7 @@ snapshots:
       '@typescript-eslint/types': 8.44.0
       '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.44.0(eslint@9.36.0)(typescript@5.9.3)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.36.0
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -3514,7 +3632,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.44.0
       '@typescript-eslint/visitor-keys': 8.44.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.9
@@ -3683,12 +3801,16 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
 
@@ -3763,6 +3885,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  change-case@5.4.4: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -3789,6 +3913,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@1.4.0: {}
+
   commander@10.0.1: {}
 
   commander@15.0.0: {}
@@ -3811,9 +3937,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   decamelize@1.2.0: {}
 
@@ -3921,7 +4049,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -4105,6 +4233,13 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -4122,6 +4257,8 @@ snapshots:
       module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
+
+  index-to-position@1.2.0: {}
 
   is-docker@3.0.0: {}
 
@@ -4168,11 +4305,19 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-levenshtein@1.1.6: {}
+
   js-tiktoken@1.0.21:
     dependencies:
       base64-js: 1.5.1
 
   js-tokens@10.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
 
   js-yaml@4.3.0:
     dependencies:
@@ -4190,6 +4335,8 @@ snapshots:
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-schema@0.4.0: {}
 
@@ -4296,6 +4443,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.0.2
@@ -4393,6 +4544,16 @@ snapshots:
 
   openapi-typescript-helpers@0.1.0: {}
 
+  openapi-typescript@7.13.0(typescript@5.9.3):
+    dependencies:
+      '@redocly/openapi-core': 1.34.17(supports-color@10.2.2)
+      ansi-colors: 4.1.3
+      change-case: 5.4.4
+      parse-json: 8.3.0
+      supports-color: 10.2.2
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -4443,6 +4604,12 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -4464,6 +4631,8 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  pluralize@8.0.0: {}
 
   postcss-load-config@6.0.1(postcss@8.5.16)(yaml@2.9.0):
     dependencies:
@@ -4505,9 +4674,11 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -4686,6 +4857,8 @@ snapshots:
       tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -4751,7 +4924,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       esbuild: 0.28.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -4777,6 +4950,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@4.41.0: {}
+
   type-fest@5.7.0:
     dependencies:
       tagged-tag: 1.0.0
@@ -4799,6 +4974,8 @@ snapshots:
   undici-types@7.12.0: {}
 
   until-async@3.0.2: {}
+
+  uri-js-replace@1.0.1: {}
 
   uri-js@4.4.1:
     dependencies:
@@ -4881,6 +5058,8 @@ snapshots:
   xksuid@0.0.4: {}
 
   y18n@5.0.8: {}
+
+  yaml-ast-parser@0.0.43: {}
 
   yaml@2.9.0: {}
 

--- a/typescript-sdk/scripts/generate-skills-bundle.mjs
+++ b/typescript-sdk/scripts/generate-skills-bundle.mjs
@@ -84,7 +84,21 @@ function splitFrontmatter(raw) {
   const fm = {};
   for (const line of m[1].split("\n")) {
     const kv = line.match(/^(\w[\w-]*?):\s*(.+)$/);
-    if (kv) fm[kv[1]] = kv[2].trim();
+    if (!kv) continue;
+    const value = kv[2].trim();
+    // A YAML block/folded scalar (`description: >-`, `: |`, `: >2`) puts the
+    // real value on the following INDENTED lines, which this single-line
+    // reader never sees — it would capture the literal ">-" instead. The
+    // `if (!description) throw` guard downstream cannot catch that, because
+    // ">-" is perfectly truthy: the bundle would ship, with every agent
+    // reading ">-" as the skill's description. Fail here, loudly, instead.
+    if (/^[>|][-+0-9]*$/.test(value)) {
+      throw new Error(
+        `Frontmatter key "${kv[1]}" uses a YAML block scalar ("${value}"), which this minimal reader cannot parse.\n` +
+          `Rewrite it as a single-line "${kv[1]}: value" (quote the value if it contains a colon).`,
+      );
+    }
+    fm[kv[1]] = value;
   }
   return { frontmatter: fm, body: m[2] };
 }

--- a/typescript-sdk/specs/cli/daemon.feature
+++ b/typescript-sdk/specs/cli/daemon.feature
@@ -104,6 +104,34 @@ Feature: CLI daemon mode
       When a daemon starts
       Then its socket is created with 0600 permissions inside a 0700 directory
 
+    Scenario: A socket owned by another user is not used
+      Given a socket exists at the path my identity resolves to
+      But it is owned by another user
+      When I run a command
+      Then nothing is sent to it — not my arguments, my working directory
+      or my forwarded credentials
+      And the command runs in-process
+      And "langwatch daemon status" reports no daemon running
+
+    Scenario Outline: A socket that is not demonstrably private is not used
+      Given a socket exists at the path my identity resolves to
+      But <looseness>
+      When I run a command
+      Then the socket is not connected to
+      And the command runs in-process
+
+      Examples:
+        | looseness                                        |
+        | its directory is writable by other users         |
+        | the socket itself is connectable by other users  |
+        | it is a symlink rather than a socket             |
+
+    Scenario: The socket directory cannot be made private
+      Given the directory my socket would live in is owned by another user
+      When I run a command
+      Then no daemon is spawned, because its socket could never be private
+      And the command runs in-process
+
     Scenario: A daemon rejects a request from a different identity
       Given a daemon is warm for identity A
       When a client presents a fingerprint for identity B
@@ -154,8 +182,39 @@ Feature: CLI daemon mode
     Scenario: A command that hangs
       Given the daemon is running my command
       When the command exceeds the per-request timeout
-      Then the request is abandoned with exit code 124
-      And its execution window is released for other callers
+      Then the request is abandoned with exit code 124 without waiting for it
+      And no further output from it reaches me
+      But its execution window is still held, because the work is still running
+      And the next caller waits rather than having the working directory
+      changed underneath the abandoned command
+
+    Scenario: Abandoned work finishes on its own
+      Given a command was abandoned at the per-request timeout
+      And another caller is waiting for a different working directory
+      When the abandoned command finally finishes
+      Then it resolved its files against its OWN working directory throughout
+      And only then is the waiting caller admitted
+
+    Scenario: Abandoned work never finishes at all
+      Given a command was abandoned at the per-request timeout
+      When it has still not finished after the abandon grace period
+      Then the daemon exits rather than hand its execution window to anyone
+      And every command runs in-process, exactly as with no daemon installed
+
+  Rule: The daemon never hands a result computed under the wrong environment
+
+    Scenario: The daemon is stopped while it is still serving
+      Given a daemon is serving my command
+      When the daemon is asked to stop
+      Then it waits for my command to finish before restoring its own
+      working directory and environment
+
+    Scenario: An in-flight command outlasts the shutdown grace period
+      Given a daemon is serving a command that will not finish
+      When the daemon is asked to stop
+      And the shutdown grace period elapses
+      Then the connection is dropped before any exit code is sent
+      And the command is retried in-process
 
   Rule: The daemon is managed explicitly
 

--- a/typescript-sdk/specs/cli/daemon.feature
+++ b/typescript-sdk/specs/cli/daemon.feature
@@ -211,10 +211,19 @@ Feature: CLI daemon mode
 
     Scenario: An in-flight command outlasts the shutdown grace period
       Given a daemon is serving a command that will not finish
+      And none of its output has reached me yet
       When the daemon is asked to stop
       And the shutdown grace period elapses
-      Then the connection is dropped before any exit code is sent
+      Then I am told the daemon declined the command before any exit code is sent
       And the command is retried in-process
+
+    Scenario: An in-flight command outlasts the shutdown grace period after printing
+      Given a daemon is serving a command whose output is too large to hold back
+      And part of that output has already been printed to me
+      When the daemon is asked to stop
+      And the shutdown grace period elapses
+      Then the command is NOT retried, because that would print the same output twice
+      And I am told the output is incomplete and the exit status is not the command's
 
   Rule: The daemon is managed explicitly
 

--- a/typescript-sdk/src/cli/__tests__/help-topic.unit.test.ts
+++ b/typescript-sdk/src/cli/__tests__/help-topic.unit.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { buildProgram } from "../program";
-import { renderAgentHelpTopic } from "../commands/help";
+import {
+  HELP_TOPIC_NAMES,
+  renderAgentHelpTopic,
+} from "../commands/help";
 import { AGENT_MODE_ENV_VARS } from "../utils/output";
 
 // buildProgram() reads the tsup-injected __CLI_VERSION__ build constant —
@@ -73,14 +76,81 @@ describe("`langwatch help` command", () => {
       .map((chunk: unknown) => String(chunk))
       .join("");
 
-  it("`help agent` prints the agent topic page", async () => {
-    await buildProgram().parseAsync(["node", "langwatch", "help", "agent"]);
+  it("`help agent-mode` prints the agent topic page", async () => {
+    await buildProgram().parseAsync([
+      "node",
+      "langwatch",
+      "help",
+      "agent-mode",
+    ]);
 
     const out = consoleLogSpy.mock.calls.flat().join("\n");
     expect(out).toContain("AGENT MODE");
     expect(out).toContain("OUTPUT CONTRACT");
     expect(out).toContain("PIPING RULES");
     expect(process.exitCode).toBe(0);
+  });
+
+  describe("when a word names both a real command and could name a topic", () => {
+    it("resolves a real command before a help topic", async () => {
+      // `agent` is a REAL top-level group (agent definitions). It used to be
+      // swallowed by the agent-mode topic, leaving the group's help
+      // unreachable through `help` entirely.
+      await buildProgram().parseAsync(["node", "langwatch", "help", "agent"]);
+
+      expect(stdoutText()).toContain("Usage: langwatch agent");
+      expect(consoleLogSpy.mock.calls.flat().join("\n")).not.toContain(
+        "AGENT MODE",
+      );
+      expect(process.exitCode).toBe(0);
+    });
+
+    it("walks into the real command's subcommands rather than discarding them", async () => {
+      // `help agent list` previously printed the topic page and silently
+      // dropped `list`.
+      await buildProgram().parseAsync([
+        "node",
+        "langwatch",
+        "help",
+        "agent",
+        "list",
+      ]);
+
+      expect(stdoutText()).toContain("Usage: langwatch agent list");
+      expect(process.exitCode).toBe(0);
+    });
+
+    it("keeps every help topic clear of the registered command tree", () => {
+      const program = buildProgram();
+      const registered = new Set(
+        program.commands.flatMap((cmd) => [cmd.name(), ...cmd.aliases()]),
+      );
+
+      const collisions = HELP_TOPIC_NAMES.filter((name) =>
+        registered.has(name),
+      );
+
+      expect(
+        collisions,
+        `Help topic(s) ${collisions.join(", ")} share a name with a registered command. ` +
+          "Commands win the lookup, so these topics are unreachable — rename the topic.",
+      ).toEqual([]);
+    });
+  });
+
+  it("rejects a topic given extra words instead of silently discarding them", async () => {
+    await buildProgram().parseAsync([
+      "node",
+      "langwatch",
+      "help",
+      "agent-mode",
+      "list",
+    ]);
+
+    expect(consoleErrorSpy.mock.calls.flat().join("\n")).toContain(
+      "unknown command or help topic 'agent-mode list'",
+    );
+    expect(process.exitCode).toBe(1);
   });
 
   it("`help <command>` still prints that command's help", async () => {

--- a/typescript-sdk/src/cli/__tests__/index-boot.unit.test.ts
+++ b/typescript-sdk/src/cli/__tests__/index-boot.unit.test.ts
@@ -1,17 +1,48 @@
 /**
- * The CLI entrypoint loads .env BEFORE anything else — except when the
- * process being booted IS the daemon server. That boot runs with cwd=$HOME
- * (daemon/spawn.ts), and its process env becomes the baseline every request
- * resets to, so loading ~/.env there would drop home-directory secrets into
- * every caller's execution window.
+ * Two invariants of the CLI entrypoint.
+ *
+ * 1. .env loading. The entrypoint loads .env before dispatching — except when
+ *    the process being booted IS the daemon server. That boot runs with
+ *    cwd=$HOME (daemon/spawn.ts), and its process env becomes the baseline
+ *    every request resets to, so loading ~/.env there would drop
+ *    home-directory secrets into every caller's execution window.
+ *
+ * 2. The boot module graph. The CLI's ~30ms cold start exists ONLY because
+ *    commander, chalk, zod, js-yaml, the command modules and the command
+ *    catalog are reached through lazy `import()`, never a top-level `import`.
+ *    Nothing about that is enforced by the type system: a single innocuous
+ *    `import { something } from "../utils/output"` added to a module on the
+ *    boot path drags its whole transitive graph into every invocation, and no
+ *    test fails. The graph guard below pins the set so it fails loudly.
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
 
-const dotenvConfigMock = vi.hoisted(() => vi.fn());
+/**
+ * Append-only across the whole file — never cleared. It records when the
+ * dispatch MODULE is evaluated relative to when dotenv's config() is CALLED,
+ * which is the ordering that actually matters and the one the entrypoint's
+ * source order misrepresents. Deliberately not reset per test: vitest
+ * evaluates a mock factory once, so only the first boot in the file produces
+ * the module-evaluation entry, and the assertion is written to hold whichever
+ * test ran first.
+ */
+const bootEvents = vi.hoisted(() => [] as string[]);
+
+const dotenvConfigMock = vi.hoisted(() =>
+  vi.fn(() => {
+    bootEvents.push("dotenv config() called");
+    return {};
+  }),
+);
 vi.mock("dotenv", () => ({ config: dotenvConfigMock }));
 
 const runCliMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-vi.mock("../daemon/dispatch", () => ({ runCli: runCliMock }));
+vi.mock("../daemon/dispatch", () => {
+  bootEvents.push("dispatch module evaluated");
+  return { runCli: runCliMock };
+});
 
 describe("the CLI boot (index.ts)", () => {
   const savedArgv = process.argv;
@@ -38,6 +69,26 @@ describe("the CLI boot (index.ts)", () => {
 
       expect(dotenvConfigMock).toHaveBeenCalled();
       expect(runCliMock).toHaveBeenCalled();
+      // The real ordering guarantee: config() runs before runCli() is called,
+      // so dispatch sees a populated process.env.
+      expect(dotenvConfigMock.mock.invocationCallOrder[0]).toBeLessThan(
+        runCliMock.mock.invocationCallOrder[0]!,
+      );
+    });
+
+    it("evaluates the dispatch module before config() despite the source order", async () => {
+      await boot(["node", "cli.js", "trace", "search"]);
+
+      // index.ts reads as though config() precedes `import { runCli } from
+      // "./daemon/dispatch"`, but ES module semantics (and esbuild's bundling)
+      // hoist every static import above the module body. dispatch's
+      // MODULE-LEVEL side effects therefore run FIRST; only its function
+      // bodies see the loaded .env. Pinned here so the entrypoint's comment
+      // and reality cannot drift apart again.
+      expect(bootEvents[0]).toBe("dispatch module evaluated");
+      expect(bootEvents.indexOf("dispatch module evaluated")).toBeLessThan(
+        bootEvents.indexOf("dotenv config() called"),
+      );
     });
   });
 
@@ -47,6 +98,137 @@ describe("the CLI boot (index.ts)", () => {
 
       expect(dotenvConfigMock).not.toHaveBeenCalled();
       expect(runCliMock).toHaveBeenCalled();
+    });
+  });
+});
+
+/**
+ * Static-import graph reachable from src/cli/index.ts.
+ *
+ * Source-level rather than runtime: the shipped CLI is a single tsup bundle
+ * with `splitting: false`, so a require-hook (scripts/startup-require-hook.cjs)
+ * can only observe the EXTERNAL deps — it cannot see an in-bundle module being
+ * pulled onto the boot path, which is exactly the regression that matters.
+ * Reading the imports is what catches it, and it needs no build to run.
+ */
+// `__dirname`, not `import.meta.url`: this package type-checks against a
+// CommonJS target, where `import.meta` is a compile error (TS1470). The
+// sibling feature-map-drift suite resolves paths the same way.
+const SRC_ROOT = resolve(__dirname, "..", "..");
+
+const resolveImport = (spec: string, importer: string): string | null => {
+  let base: string;
+  if (spec.startsWith("@/")) base = join(SRC_ROOT, spec.slice(2));
+  else if (spec.startsWith(".")) base = resolve(dirname(importer), spec);
+  else return null; // bare package or node builtin — not traversed
+
+  if (base.endsWith(".js")) base = base.slice(0, -3);
+  for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, "index.ts")]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+};
+
+/**
+ * Top-level static imports only. `import type` is skipped (erased at compile
+ * time); dynamic `import()` is skipped by construction because the pattern is
+ * anchored to the start of a line. `[^;]*?` keeps the optional `… from` clause
+ * from running past a side-effect import (`import "./compileCache";`) and
+ * stealing the next statement's specifier.
+ */
+const STATIC_IMPORT = /^import\s+(?!type\s)(?:[^;]*?\sfrom\s+)?["']([^"']+)["']/gm;
+
+const collectBootGraph = (): { local: string[]; bare: string[] } => {
+  const local = new Set<string>();
+  const bare = new Set<string>();
+
+  const walk = (file: string): void => {
+    if (local.has(file)) return;
+    local.add(file);
+    const source = readFileSync(file, "utf8");
+    for (const [, spec] of source.matchAll(STATIC_IMPORT)) {
+      const resolved = resolveImport(spec!, file);
+      if (resolved) walk(resolved);
+      else bare.add(spec!);
+    }
+  };
+
+  walk(join(SRC_ROOT, "cli", "index.ts"));
+  return {
+    local: [...local].map((f) => relative(SRC_ROOT, f)).sort(),
+    bare: [...bare].sort(),
+  };
+};
+
+describe("the CLI boot module graph", () => {
+  const WHY =
+    "The CLI's ~30ms cold start depends on this graph staying tiny: everything else " +
+    "is reached through lazy import(). If you added a top-level import to a module on " +
+    "the boot path, move it to a lazy import() inside the function that needs it. " +
+    "If the new module genuinely belongs at boot, update this list deliberately.";
+
+  describe("given the entrypoint's transitive static imports", () => {
+    it("pins the exact set of first-party modules loaded at boot", () => {
+      const { local } = collectBootGraph();
+
+      expect(local, `Boot module graph changed. ${WHY}`).toEqual([
+        "cli/compileCache.ts",
+        "cli/daemon/client.ts",
+        "cli/daemon/dispatch.ts",
+        "cli/daemon/eligibility.ts",
+        "cli/daemon/identity.ts",
+        "cli/daemon/protocol.ts",
+        "cli/daemon/spawn-hint.ts",
+        "cli/daemon/spawn.ts",
+        "cli/index.ts",
+        "cli/utils/governance/config.ts",
+        "cli/utils/governance/resolveEndpoint.ts",
+        "internal/constants.ts",
+        "internal/runtime.ts",
+      ]);
+    });
+
+    it("loads no third-party package at boot except dotenv", () => {
+      const { bare } = collectBootGraph();
+      const thirdParty = bare.filter(
+        (spec) => !spec.startsWith("node:") && !spec.endsWith(".json"),
+      );
+
+      expect(
+        thirdParty,
+        `A third-party package reached the boot path. ${WHY}`,
+      ).toEqual(["dotenv"]);
+    });
+
+    it("keeps the known-heavy modules off the boot path", () => {
+      const { local, bare } = collectBootGraph();
+      const graph = [...local, ...bare];
+
+      // Each of these costs real milliseconds to parse+evaluate, and each is
+      // needed by only a fraction of invocations.
+      const heavy = [
+        "chalk",
+        "commander",
+        "js-yaml",
+        "zod",
+        "ora",
+        "@langwatch/cli-cards",
+        "cli/program.ts",
+        "cli/utils/commandCatalog.ts",
+      ];
+
+      for (const module of heavy) {
+        expect(
+          graph.some((entry) => entry === module || entry.startsWith(`${module}/`)),
+          `"${module}" is now statically imported on the CLI boot path. ${WHY}`,
+        ).toBe(false);
+      }
+
+      // No command module at all — the command tree is built lazily.
+      expect(
+        local.filter((f) => f.startsWith("cli/commands/")),
+        `A command module reached the boot path. ${WHY}`,
+      ).toEqual([]);
     });
   });
 });

--- a/typescript-sdk/src/cli/commands/__tests__/status.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/__tests__/status.unit.test.ts
@@ -624,16 +624,124 @@ describe("statusCommand", () => {
     });
 
     describe("when the project has virtual keys the budgets endpoint cannot cover", () => {
-      it("declares the virtual-key and principal scope unchecked", async () => {
+      it("declares the scope uncovered as a note without withholding the all-clear", async () => {
         mockAllSuccess();
-        // GET /budgets returns org/team/project scope only. With keys present,
-        // a VK budget at 100% could be blocking traffic entirely unseen.
+        // GET /budgets returns org/team/project scope only, on every project
+        // forever — a standing limit of the API, not a check that failed. It is
+        // told to the user, but a healthy project still reads as healthy.
         global.fetch = mockGatewayFetch({ virtualKeys: [{ id: "vk_1" }] });
 
         await statusCommand();
 
         const out = consoleLogSpy.mock.calls.flat().join("\n");
         expect(out).toContain("virtual-key and principal budgets were not checked");
+        expect(out).toContain("(note — gateway budgets:");
+        expect(out).not.toContain("could not check gateway budgets");
+        expect(out).toContain("nothing needs your attention");
+      });
+
+      it("reports the key count from pagination rather than the page-1 length", async () => {
+        mockAllSuccess();
+        global.fetch = vi.fn().mockImplementation(async (input: unknown) => {
+          const url = String(input);
+          if (url.includes("/api/gateway/v1/budgets")) {
+            return { ok: true, status: 200, json: async () => ({ data: [] }) };
+          }
+          if (url.includes("/api/gateway/v1/virtual-keys")) {
+            // 300 keys behind pagination — page 1 carries 3 of them.
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                data: [{ id: "vk_1" }, { id: "vk_2" }, { id: "vk_3" }],
+                pagination: { totalHits: 300 },
+              }),
+            };
+          }
+          return { ok: true, status: 200, json: async () => [{ id: "1" }] };
+        }) as unknown as typeof fetch;
+
+        await statusCommand();
+
+        const out = consoleLogSpy.mock.calls.flat().join("\n");
+        expect(out).toContain("300 virtual keys");
+        expect(out).not.toContain("3 virtual keys");
+      });
+
+      it("keeps a failed virtual-keys probe an error that withholds the all-clear", async () => {
+        mockAllSuccess();
+        const baseFetch = global.fetch;
+        global.fetch = vi.fn().mockImplementation(async (input: unknown) => {
+          const url = String(input);
+          if (url.includes("/api/gateway/v1/virtual-keys")) {
+            // A probe that 403s is a check that did NOT run — unlike the
+            // structural blind spot, this one must still gate the tick.
+            return {
+              ok: false,
+              status: 403,
+              statusText: "Forbidden",
+              json: async () => ({ error: "Forbidden" }),
+            };
+          }
+          return baseFetch(input as Parameters<typeof fetch>[0]);
+        }) as unknown as typeof fetch;
+
+        await statusCommand();
+
+        const out = consoleLogSpy.mock.calls.flat().join("\n");
+        expect(out).toContain("could not check gateway budgets");
+        expect(out).toContain("could not list virtual keys");
+        expect(out).not.toContain("nothing needs your attention");
+      });
+    });
+
+    describe("when many experiments have run but none is running now", () => {
+      it("reaches the all-clear rather than reporting the candidate cap as a gap", async () => {
+        // Every experiment that ever ran has a non-null lastRunAt, so "there
+        // are more than 5 candidates" describes nearly every real project.
+        // Treating that as an incomplete scan makes the ✓ unreachable.
+        mockExperiments({
+          experiments: Array.from({ length: 8 }, (_unused, index) =>
+            experimentFixture({ id: `exp_${index}`, slug: `eval-${index}` }),
+          ),
+          pagination: { page: 1, pageSize: 50, totalHits: 8, hasMore: false },
+          runs: {
+            runs: [
+              {
+                experimentId: "exp_1",
+                runId: "run_1",
+                workflowVersion: null,
+                timestamps: { createdAt: 1, updatedAt: 2, finishedAt: 3, stoppedAt: null },
+                progress: 10,
+                total: 10,
+                summary: { evaluations: {} },
+              },
+            ],
+            pagination: { page: 1, pageSize: 1, totalHits: 1, hasMore: false },
+          },
+        });
+
+        await statusCommand();
+
+        const out = consoleLogSpy.mock.calls.flat().join("\n");
+        expect(out).not.toContain("could not check running experiments");
+        expect(out).toContain("nothing needs your attention");
+      });
+
+      it("still records the cap once the sample itself turns up a live run", async () => {
+        // A running experiment in the top 5 IS evidence the untested tail may
+        // hold more — the cap becomes a real gap again.
+        mockExperiments({
+          experiments: Array.from({ length: 8 }, (_unused, index) =>
+            experimentFixture({ id: `exp_${index}`, slug: `eval-${index}` }),
+          ),
+          pagination: { page: 1, pageSize: 50, totalHits: 8, hasMore: false },
+        });
+
+        await statusCommand();
+
+        const out = consoleLogSpy.mock.calls.flat().join("\n");
+        expect(out).toContain("of 8 candidate experiments were checked");
         expect(out).not.toContain("nothing needs your attention");
       });
     });
@@ -648,7 +756,10 @@ describe("statusCommand", () => {
           mockPOST.mockReturnValue(new Promise(() => undefined));
 
           const pending = statusCommand({ output: "json" });
-          await vi.advanceTimersByTimeAsync(6_000);
+          // Past the 30s section ceiling — the sections get a far higher one
+          // than the cheap list endpoints, a ClickHouse COUNT being routinely
+          // slower than the 5s that would have called a healthy backend hung.
+          await vi.advanceTimersByTimeAsync(31_000);
           await pending;
 
           const doc = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string);

--- a/typescript-sdk/src/cli/commands/__tests__/status.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/__tests__/status.unit.test.ts
@@ -60,6 +60,45 @@ const noExperiments = {
   pagination: { page: 1, pageSize: 50, totalHits: 0, hasMore: false },
 };
 
+/** A budget row with sane defaults — override just the field under test. */
+const budgetFixture = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id: "bud_1",
+  organization_id: "org_1",
+  scope_type: "PROJECT",
+  scope_id: "proj_1",
+  name: "prod",
+  description: null,
+  window: "MONTH",
+  on_breach: "BLOCK",
+  limit_usd: "100",
+  spent_usd: "92",
+  timezone: null,
+  current_period_started_at: new Date().toISOString(),
+  resets_at: new Date().toISOString(),
+  last_reset_at: null,
+  archived_at: null,
+  created_at: new Date().toISOString(),
+  ...overrides,
+});
+
+/** The budgets endpoint can only see org/team/project scope, so status probes
+ * virtual keys to decide whether the VK/principal blind spot has anything
+ * behind it. A project with no keys has nothing hiding there. */
+const mockGatewayFetch = ({
+  budgets = [] as unknown[],
+  virtualKeys = [] as unknown[],
+}: { budgets?: unknown[]; virtualKeys?: unknown[] } = {}) =>
+  vi.fn().mockImplementation(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/api/gateway/v1/budgets")) {
+      return { ok: true, status: 200, json: async () => ({ data: budgets }) };
+    }
+    if (url.includes("/api/gateway/v1/virtual-keys")) {
+      return { ok: true, status: 200, json: async () => ({ data: virtualKeys }) };
+    }
+    return { ok: true, status: 200, json: async () => [{ id: "1" }] };
+  }) as unknown as typeof fetch;
+
 /** Routing mocks where every resource + attention section succeeds clean:
  * zero errored traces, no experiments, no budgets. */
 const mockAllSuccess = (): void => {
@@ -74,21 +113,20 @@ const mockAllSuccess = (): void => {
     error: undefined,
     response: { status: 200 },
   });
-  global.fetch = vi.fn().mockImplementation(async (input: unknown) => {
-    const url = String(input);
-    if (url.includes("/api/gateway/v1/budgets")) {
-      return { ok: true, status: 200, json: async () => ({ data: [] }) };
-    }
-    return { ok: true, status: 200, json: async () => [{ id: "1" }] };
-  }) as unknown as typeof fetch;
+  global.fetch = mockGatewayFetch();
 };
 
 describe("statusCommand", () => {
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let savedAgentEnv: Record<string, string | undefined>;
   const originalFetch = global.fetch;
 
   beforeEach(() => {
+    // Cleared for the whole suite, not per-describe: these tests are routinely
+    // run BY an agent, and an inherited CLAUDECODE would silently flip status
+    // to compact JSON and skip every human-output assertion below.
+    savedAgentEnv = clearAgentEnv();
     vi.clearAllMocks();
     vi.spyOn(process, "exit").mockImplementation((code) => {
       throw new ProcessExitError((code as number) ?? 0);
@@ -104,6 +142,7 @@ describe("statusCommand", () => {
   afterEach(() => {
     global.fetch = originalFetch;
     vi.restoreAllMocks();
+    restoreAgentEnv(savedAgentEnv);
   });
 
   describe("when every resource fetch fails with 401", () => {
@@ -226,15 +265,8 @@ describe("statusCommand", () => {
   });
 
   describe("when every resource fetch succeeds", () => {
-    let savedAgentEnv: Record<string, string | undefined>;
-
     beforeEach(() => {
       mockAllSuccess();
-      savedAgentEnv = clearAgentEnv();
-    });
-
-    afterEach(() => {
-      restoreAgentEnv(savedAgentEnv);
     });
 
     it("prints the generated command cheat-sheet (resource groups, no plumbing)", async () => {
@@ -264,16 +296,6 @@ describe("statusCommand", () => {
   });
 
   describe("attention sections", () => {
-    let savedAgentEnv: Record<string, string | undefined>;
-
-    beforeEach(() => {
-      savedAgentEnv = clearAgentEnv();
-    });
-
-    afterEach(() => {
-      restoreAgentEnv(savedAgentEnv);
-    });
-
     it("flags errored traces, a running experiment and an at-risk budget", async () => {
       mockGET.mockImplementation(async (path: string) => {
         if (path.startsWith("/api/experiments/runs")) {
@@ -326,38 +348,7 @@ describe("statusCommand", () => {
         error: undefined,
         response: { status: 200 },
       });
-      global.fetch = vi.fn().mockImplementation(async (input: unknown) => {
-        const url = String(input);
-        if (url.includes("/api/gateway/v1/budgets")) {
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              data: [
-                {
-                  id: "bud_1",
-                  organization_id: "org_1",
-                  scope_type: "PROJECT",
-                  scope_id: "proj_1",
-                  name: "prod",
-                  description: null,
-                  window: "MONTH",
-                  on_breach: "BLOCK",
-                  limit_usd: "100",
-                  spent_usd: "92",
-                  timezone: null,
-                  current_period_started_at: new Date().toISOString(),
-                  resets_at: new Date().toISOString(),
-                  last_reset_at: null,
-                  archived_at: null,
-                  created_at: new Date().toISOString(),
-                },
-              ],
-            }),
-          };
-        }
-        return { ok: true, status: 200, json: async () => [{ id: "1" }] };
-      }) as unknown as typeof fetch;
+      global.fetch = mockGatewayFetch({ budgets: [budgetFixture()] });
 
       await statusCommand();
 
@@ -434,13 +425,7 @@ describe("statusCommand", () => {
         error: undefined,
         response: { status: 200 },
       });
-      global.fetch = vi.fn().mockImplementation(async (input: unknown) => {
-        const url = String(input);
-        if (url.includes("/api/gateway/v1/budgets")) {
-          return { ok: true, status: 200, json: async () => ({ data: [] }) };
-        }
-        return { ok: true, status: 200, json: async () => [{ id: "1" }] };
-      }) as unknown as typeof fetch;
+      global.fetch = mockGatewayFetch();
 
       await statusCommand();
 
@@ -485,6 +470,194 @@ describe("statusCommand", () => {
       expect(doc.attention.errors.erroredTraces24h).toBeUndefined();
       // The resource counts moved under `resources` but kept their shape.
       expect(doc.resources.evaluators).toEqual({ count: 2 });
+    });
+  });
+
+  // Every one of these covers a way status used to print a green all-clear over
+  // a scan it knew was partial — the failure mode the `errors` map exists to
+  // prevent. The load-bearing assertion in each is the NEGATIVE one.
+  describe("false all-clear regressions", () => {
+    const experimentFixture = (overrides: Record<string, unknown> = {}) => ({
+      id: "exp_1",
+      slug: "eval-x",
+      name: "Eval X",
+      type: "EVALUATIONS_V3",
+      workflowId: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      runsCount: 3,
+      lastRunAt: new Date().toISOString(),
+      ...overrides,
+    });
+
+    /** A run with no finishedAt/stoppedAt — i.e. still running. */
+    const runningRun = {
+      runs: [
+        {
+          experimentId: "exp_1",
+          runId: "run_1",
+          workflowVersion: null,
+          timestamps: { createdAt: 1, updatedAt: 2, finishedAt: null, stoppedAt: null },
+          progress: 5,
+          total: 10,
+          summary: { evaluations: {} },
+        },
+      ],
+      pagination: { page: 1, pageSize: 1, totalHits: 1, hasMore: false },
+    };
+
+    const mockExperiments = ({
+      experiments,
+      pagination,
+      runs = runningRun,
+    }: {
+      experiments: unknown[];
+      pagination: Record<string, unknown>;
+      runs?: unknown;
+    }): void => {
+      mockGET.mockImplementation(async (path: string) => {
+        if (path.startsWith("/api/experiments/runs")) {
+          return { data: runs, error: undefined, response: { status: 200 } };
+        }
+        if (path.startsWith("/api/experiments")) {
+          return {
+            data: { experiments, pagination },
+            error: undefined,
+            response: { status: 200 },
+          };
+        }
+        return { data: [{ id: "1" }], error: undefined };
+      });
+      mockPOST.mockResolvedValue({
+        data: { traces: [], pagination: { totalHits: 0 } },
+        error: undefined,
+        response: { status: 200 },
+      });
+      global.fetch = mockGatewayFetch();
+    };
+
+    describe("when the experiment list is truncated by pagination", () => {
+      it("records the unread experiments as a gap and withholds the all-clear", async () => {
+        // `GET /api/experiments` sorts by updatedAt, not lastRunAt — so a
+        // running experiment can sit past the page boundary and never be seen.
+        mockExperiments({
+          experiments: [experimentFixture()],
+          pagination: { page: 1, pageSize: 50, totalHits: 120, hasMore: true },
+          runs: {
+            runs: [
+              {
+                experimentId: "exp_1",
+                runId: "run_1",
+                workflowVersion: null,
+                timestamps: { createdAt: 1, updatedAt: 2, finishedAt: 3, stoppedAt: null },
+                progress: 10,
+                total: 10,
+                summary: { evaluations: {} },
+              },
+            ],
+            pagination: { page: 1, pageSize: 1, totalHits: 1, hasMore: false },
+          },
+        });
+
+        await statusCommand();
+
+        const out = consoleLogSpy.mock.calls.flat().join("\n");
+        expect(out).toContain("of 120 experiments");
+        expect(out).toContain("could not check running experiments");
+        expect(out).not.toContain("nothing needs your attention");
+      });
+    });
+
+    describe("when a running experiment last ran outside the 24h window", () => {
+      it("surfaces the experiment that has been running for two days", async () => {
+        // `running` has no bounded duration — a 48h-old lastRunAt on an
+        // unfinished run is the most alarming state, not the least relevant.
+        mockExperiments({
+          experiments: [
+            experimentFixture({
+              lastRunAt: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+            }),
+          ],
+          pagination: { page: 1, pageSize: 50, totalHits: 1, hasMore: false },
+        });
+
+        await statusCommand();
+
+        const out = consoleLogSpy.mock.calls.flat().join("\n");
+        expect(out).toContain('experiment "Eval X" is still running (5/10)');
+        expect(out).not.toContain("nothing needs your attention");
+      });
+    });
+
+    describe("when a BLOCK budget has a zero limit", () => {
+      it("reports the zero-limit budget as fully breached", async () => {
+        mockAllSuccess();
+        // A limit of 0 admits no spend at all: maximally breached, not 0%.
+        global.fetch = mockGatewayFetch({
+          budgets: [budgetFixture({ limit_usd: "0", spent_usd: "0", on_breach: "BLOCK" })],
+        });
+
+        await statusCommand();
+
+        const out = consoleLogSpy.mock.calls.flat().join("\n");
+        expect(out).toContain('budget "prod"');
+        expect(out).toContain("at 100%");
+        expect(out).toContain("blocks on breach");
+        expect(out).not.toContain("nothing needs your attention");
+      });
+    });
+
+    describe("when a budget's limit cannot be parsed", () => {
+      it("records the unreadable budget rather than scoring it zero", async () => {
+        mockAllSuccess();
+        global.fetch = mockGatewayFetch({
+          budgets: [budgetFixture({ name: "garbled", limit_usd: "n/a" })],
+        });
+
+        await statusCommand();
+
+        const out = consoleLogSpy.mock.calls.flat().join("\n");
+        expect(out).toContain("could not check gateway budgets");
+        expect(out).toContain("garbled");
+        expect(out).not.toContain("nothing needs your attention");
+      });
+    });
+
+    describe("when the project has virtual keys the budgets endpoint cannot cover", () => {
+      it("declares the virtual-key and principal scope unchecked", async () => {
+        mockAllSuccess();
+        // GET /budgets returns org/team/project scope only. With keys present,
+        // a VK budget at 100% could be blocking traffic entirely unseen.
+        global.fetch = mockGatewayFetch({ virtualKeys: [{ id: "vk_1" }] });
+
+        await statusCommand();
+
+        const out = consoleLogSpy.mock.calls.flat().join("\n");
+        expect(out).toContain("virtual-key and principal budgets were not checked");
+        expect(out).not.toContain("nothing needs your attention");
+      });
+    });
+
+    describe("when a section fetcher hangs", () => {
+      it("times the section out instead of blocking status forever", async () => {
+        vi.useFakeTimers({ toFake: ["setTimeout"] });
+        try {
+          mockAllSuccess();
+          // The trace-search POST runs a ClickHouse COUNT over a 24h partition
+          // and can hang indefinitely; allSettled would never settle.
+          mockPOST.mockReturnValue(new Promise(() => undefined));
+
+          const pending = statusCommand({ output: "json" });
+          await vi.advanceTimersByTimeAsync(6_000);
+          await pending;
+
+          const doc = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string);
+          expect(doc.attention.erroredTraces24h).toBeNull();
+          expect(doc.attention.errors.erroredTraces24h).toContain("timed out");
+        } finally {
+          vi.useRealTimers();
+        }
+      });
     });
   });
 });

--- a/typescript-sdk/src/cli/commands/agents/__tests__/agent-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/agents/__tests__/agent-commands.unit.test.ts
@@ -99,19 +99,20 @@ describe("listAgentsCommand()", () => {
     });
   });
 
-  describe("when format is json", () => {
-    it("outputs raw JSON", async () => {
-      const result = {
+  describe("when a machine format is requested", () => {
+    it("returns the raw listing as the payload instead of printing", async () => {
+      const listing = {
         data: [makeAgent()],
         pagination: { page: 1, limit: 100, total: 1, totalPages: 1 },
       };
-      mockList.mockResolvedValue(result);
+      mockList.mockResolvedValue(listing);
 
-      await listAgentsCommand({ format: "json" });
+      const result = await listAgentsCommand();
 
-      expect(console.log).toHaveBeenCalledWith(
-        JSON.stringify(result, null, 2),
-      );
+      // The command no longer decides the format — it hands the payload to
+      // the output port, which renders json/yaml/agents/--jq from this value.
+      expect(result?.data).toEqual(listing);
+      expect(console.log).not.toHaveBeenCalled();
     });
   });
 

--- a/typescript-sdk/src/cli/commands/agents/create.ts
+++ b/typescript-sdk/src/cli/commands/agents/create.ts
@@ -4,11 +4,16 @@ import { AgentsApiService } from "@/client-sdk/services/agents/agents-api.servic
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError } from "../../utils/errorOutput";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the created agent rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts).
+ */
 export const createAgentCommand = async (
   name: string,
-  options: { type: string; config?: string; format?: string },
-): Promise<void> => {
+  options: { type: string; config?: string },
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AgentsApiService();
@@ -29,11 +34,14 @@ export const createAgentCommand = async (
       `Created agent "${chalk.cyan(agent.name)}" ${chalk.gray(`(id: ${agent.id})`)}`,
     );
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(agent, null, 2));
-    } else if (agent.platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(agent.platformUrl)}`);
-    }
+    return {
+      data: agent,
+      table: () => {
+        if (agent.platformUrl) {
+          console.log(`  ${chalk.bold("View:")}  ${chalk.underline(agent.platformUrl)}`);
+        }
+      },
+    };
   } catch (error) {
     // Route BOTH failure kinds through failSpinner: a direct spinner.fail()
     // prints nothing in --json/--jq/agent mode (spinners are silent there).

--- a/typescript-sdk/src/cli/commands/agents/delete.ts
+++ b/typescript-sdk/src/cli/commands/agents/delete.ts
@@ -3,8 +3,13 @@ import { createSpinner } from "../../utils/spinner";
 import { AgentsApiService } from "@/client-sdk/services/agents/agents-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const deleteAgentCommand = async (id: string, options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the archival outcome rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
+export const deleteAgentCommand = async (id: string): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AgentsApiService();
@@ -16,9 +21,12 @@ export const deleteAgentCommand = async (id: string, options?: { format?: string
       `Archived agent "${chalk.cyan(result.name)}" ${chalk.gray(`(id: ${result.id})`)}`,
     );
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-    }
+    return {
+      data: result,
+      table: () => {
+        // The spinner's success line is the human output.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "archive agent" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/agents/get.ts
+++ b/typescript-sdk/src/cli/commands/agents/get.ts
@@ -3,8 +3,14 @@ import { createSpinner } from "../../utils/spinner";
 import { AgentsApiService } from "@/client-sdk/services/agents/agents-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const getAgentCommand = async (id: string, options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the agent rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). The `table` closure
+ * is the human form, byte-identical to what this command printed before.
+ */
+export const getAgentCommand = async (id: string): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AgentsApiService();
@@ -14,30 +20,30 @@ export const getAgentCommand = async (id: string, options?: { format?: string })
     const agent = await service.get(id);
     spinner.succeed(`Found agent "${agent.name}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(agent, null, 2));
-      return;
-    }
+    return {
+      data: agent,
+      table: () => {
+        console.log();
+        console.log(chalk.bold.cyan(agent.name));
+        console.log(chalk.gray("─".repeat(40)));
+        console.log(`  ${chalk.gray("ID:")}      ${agent.id}`);
+        console.log(`  ${chalk.gray("Type:")}    ${chalk.yellow(agent.type)}`);
+        console.log(`  ${chalk.gray("Created:")} ${new Date(agent.createdAt).toLocaleString()}`);
+        console.log(`  ${chalk.gray("Updated:")} ${new Date(agent.updatedAt).toLocaleString()}`);
 
-    console.log();
-    console.log(chalk.bold.cyan(agent.name));
-    console.log(chalk.gray("─".repeat(40)));
-    console.log(`  ${chalk.gray("ID:")}      ${agent.id}`);
-    console.log(`  ${chalk.gray("Type:")}    ${chalk.yellow(agent.type)}`);
-    console.log(`  ${chalk.gray("Created:")} ${new Date(agent.createdAt).toLocaleString()}`);
-    console.log(`  ${chalk.gray("Updated:")} ${new Date(agent.updatedAt).toLocaleString()}`);
+        if (agent.platformUrl) {
+          console.log(`  ${chalk.bold("View:")}  ${chalk.underline(agent.platformUrl)}`);
+        }
 
-    if (agent.platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(agent.platformUrl)}`);
-    }
+        if (agent.config && Object.keys(agent.config).length > 0) {
+          console.log();
+          console.log(chalk.bold("  Config:"));
+          console.log(`    ${JSON.stringify(agent.config, null, 2).split("\n").join("\n    ")}`);
+        }
 
-    if (agent.config && Object.keys(agent.config).length > 0) {
-      console.log();
-      console.log(chalk.bold("  Config:"));
-      console.log(`    ${JSON.stringify(agent.config, null, 2).split("\n").join("\n    ")}`);
-    }
-
-    console.log();
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch agent" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/agents/list.ts
+++ b/typescript-sdk/src/cli/commands/agents/list.ts
@@ -4,8 +4,14 @@ import { AgentsApiService } from "@/client-sdk/services/agents/agents-api.servic
 import { checkApiKey } from "../../utils/apiKey";
 import { formatTable, formatRelativeTime } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const listAgentsCommand = async (options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). The `table` closure
+ * is the human form, byte-identical to what this command printed before.
+ */
+export const listAgentsCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AgentsApiService();
@@ -19,48 +25,48 @@ export const listAgentsCommand = async (options?: { format?: string }): Promise<
       `Found ${result.pagination.total} agent${result.pagination.total !== 1 ? "s" : ""}`,
     );
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-      return;
-    }
+    return {
+      data: result,
+      table: () => {
+        if (agents.length === 0) {
+          console.log();
+          console.log(chalk.gray("No agents found in this project."));
+          console.log(chalk.gray("Create your first agent with:"));
+          console.log(
+            chalk.cyan(
+              '  langwatch agent create "My Agent" --type http --config \'{"url":"https://..."}\'',
+            ),
+          );
+          return;
+        }
 
-    if (agents.length === 0) {
-      console.log();
-      console.log(chalk.gray("No agents found in this project."));
-      console.log(chalk.gray("Create your first agent with:"));
-      console.log(
-        chalk.cyan(
-          '  langwatch agent create "My Agent" --type http --config \'{"url":"https://..."}\'',
-        ),
-      );
-      return;
-    }
+        console.log();
 
-    console.log();
+        const tableData = agents.map((agent) => ({
+          Name: agent.name,
+          ID: agent.id,
+          Type: agent.type,
+          Updated: formatRelativeTime(agent.updatedAt),
+        }));
 
-    const tableData = agents.map((agent) => ({
-      Name: agent.name,
-      ID: agent.id,
-      Type: agent.type,
-      Updated: formatRelativeTime(agent.updatedAt),
-    }));
+        formatTable({
+          data: tableData,
+          headers: ["Name", "ID", "Type", "Updated"],
+          colorMap: {
+            Name: chalk.cyan,
+            ID: chalk.green,
+            Type: chalk.yellow,
+          },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["Name", "ID", "Type", "Updated"],
-      colorMap: {
-        Name: chalk.cyan,
-        ID: chalk.green,
-        Type: chalk.yellow,
+        console.log();
+        console.log(
+          chalk.gray(
+            `Use ${chalk.cyan("langwatch agent get <id>")} to view agent details`,
+          ),
+        );
       },
-    });
-
-    console.log();
-    console.log(
-      chalk.gray(
-        `Use ${chalk.cyan("langwatch agent get <id>")} to view agent details`,
-      ),
-    );
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch agents" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/agents/run.ts
+++ b/typescript-sdk/src/cli/commands/agents/run.ts
@@ -5,12 +5,18 @@ import { checkApiKey } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
+import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+/**
+ * Returns the run's response rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts). Both execution
+ * paths (direct HTTP agent, workflow-linked agent) return their own result.
+ */
 export const runAgentCommand = async (
   id: string,
-  options: { input?: string; format?: string },
-): Promise<void> => {
+  options: { input?: string },
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AgentsApiService();
@@ -62,14 +68,15 @@ export const runAgentCommand = async (
       const result = await response.json() as Record<string, unknown>;
       runSpinner.succeed(`HTTP agent responded (${response.status})`);
 
-      if (options.format === "json") {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log();
-        console.log(chalk.bold("  Response:"));
-        console.log(`    ${JSON.stringify(result, null, 2).split("\n").join("\n    ")}`);
-        console.log();
-      }
+      return {
+        data: result,
+        table: () => {
+          console.log();
+          console.log(chalk.bold("  Response:"));
+          console.log(`    ${JSON.stringify(result, null, 2).split("\n").join("\n    ")}`);
+          console.log();
+        },
+      };
     } catch (error) {
       failSpinner({ spinner: runSpinner, error, action: "call HTTP agent" });
       process.exit(1);
@@ -113,22 +120,23 @@ export const runAgentCommand = async (
       const result = await response.json() as Record<string, unknown>;
       runSpinner.succeed(`Agent "${agent.name}" executed successfully`);
 
-      if (options.format === "json") {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log();
-        if (result.output !== undefined) {
-          console.log(chalk.bold("  Output:"));
-          const output = typeof result.output === "string"
-            ? result.output
-            : JSON.stringify(result.output, null, 2);
-          console.log(`    ${output.split("\n").join("\n    ")}`);
-        } else {
-          console.log(chalk.bold("  Result:"));
-          console.log(`    ${JSON.stringify(result, null, 2).split("\n").join("\n    ")}`);
-        }
-        console.log();
-      }
+      return {
+        data: result,
+        table: () => {
+          console.log();
+          if (result.output !== undefined) {
+            console.log(chalk.bold("  Output:"));
+            const output = typeof result.output === "string"
+              ? result.output
+              : JSON.stringify(result.output, null, 2);
+            console.log(`    ${output.split("\n").join("\n    ")}`);
+          } else {
+            console.log(chalk.bold("  Result:"));
+            console.log(`    ${JSON.stringify(result, null, 2).split("\n").join("\n    ")}`);
+          }
+          console.log();
+        },
+      };
     } catch (error) {
       failSpinner({
         spinner: runSpinner,

--- a/typescript-sdk/src/cli/commands/agents/update.ts
+++ b/typescript-sdk/src/cli/commands/agents/update.ts
@@ -4,11 +4,16 @@ import { AgentsApiService } from "@/client-sdk/services/agents/agents-api.servic
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError } from "../../utils/errorOutput";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the updated agent rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts).
+ */
 export const updateAgentCommand = async (
   id: string,
-  options: { name?: string; type?: string; config?: string; format?: string },
-): Promise<void> => {
+  options: { name?: string; type?: string; config?: string },
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AgentsApiService();
@@ -28,9 +33,12 @@ export const updateAgentCommand = async (
       `Updated agent "${chalk.cyan(agent.name)}" ${chalk.gray(`(id: ${agent.id})`)}`,
     );
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(agent, null, 2));
-    }
+    return {
+      data: agent,
+      table: () => {
+        // The spinner's success line is the human output.
+      },
+    };
   } catch (error) {
     // Route BOTH failure kinds through failSpinner: a direct spinner.fail()
     // prints nothing in --json/--jq/agent mode (spinners are silent there).

--- a/typescript-sdk/src/cli/commands/analytics/__tests__/analytics-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/analytics/__tests__/analytics-commands.unit.test.ts
@@ -107,23 +107,25 @@ describe("queryAnalyticsCommand()", () => {
     });
   });
 
-  describe("when format is json", () => {
-    it("outputs raw JSON", async () => {
+  describe("when a machine format is requested", () => {
+    it("returns the timeseries labelled with the resolved series as the payload", async () => {
       const result = {
         currentPeriod: [{ date: 123, val: 1 }],
         previousPeriod: [],
       };
       mockTimeseries.mockResolvedValue(result);
 
-      await queryAnalyticsCommand({ format: "json" });
+      const commandResult = await queryAnalyticsCommand({});
 
-      expect(console.log).toHaveBeenCalledWith(
-        JSON.stringify(
-          { ...result, metric: "metadata.trace_id", aggregation: "cardinality" },
-          null,
-          2,
-        ),
-      );
+      // The command no longer decides the format — it hands the payload to
+      // the output port. The resolved metric/aggregation ride along so a
+      // consumer can label the result without guessing from numeric keys.
+      expect(commandResult?.data).toEqual({
+        ...result,
+        metric: "metadata.trace_id",
+        aggregation: "cardinality",
+      });
+      expect(console.log).not.toHaveBeenCalled();
     });
   });
 

--- a/typescript-sdk/src/cli/commands/analytics/query.ts
+++ b/typescript-sdk/src/cli/commands/analytics/query.ts
@@ -3,6 +3,7 @@ import { createSpinner } from "../../utils/spinner";
 import { AnalyticsApiService } from "@/client-sdk/services/analytics/analytics-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
 const METRIC_PRESETS: Record<string, { metric: string; aggregation: string }> = {
   "trace-count": { metric: "metadata.trace_id", aggregation: "cardinality" },
@@ -28,6 +29,13 @@ const METRIC_ALIASES: Record<string, keyof typeof METRIC_PRESETS> = {
   "pass-rate": "eval-pass-rate",
 };
 
+/**
+ * Returns the timeseries rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts). `data` keeps the
+ * shape the previous `--format json` branch established — the raw result with
+ * the RESOLVED `metric`/`aggregation` attached, so Langy and other consumers
+ * can label a result without guessing from the numeric keys.
+ */
 export const queryAnalyticsCommand = async (options: {
   metric?: string;
   aggregation?: string;
@@ -35,8 +43,7 @@ export const queryAnalyticsCommand = async (options: {
   endDate?: string;
   groupBy?: string;
   timeScale?: string;
-  format?: string;
-}): Promise<void> => {
+}): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AnalyticsApiService();
@@ -88,67 +95,63 @@ export const queryAnalyticsCommand = async (options: {
 
     spinner.succeed("Analytics query complete");
 
-    if (options.format === "json") {
-      // Keep the requested series alongside the timeseries so Langy and other
-      // consumers can label a result without guessing from the numeric keys.
-      console.log(
-        JSON.stringify({ ...result, metric, aggregation }, null, 2),
-      );
-      return;
-    }
+    return {
+      data: { ...result, metric, aggregation },
+      table: () => {
+        console.log();
+        console.log(chalk.bold("Current Period:"));
 
-    console.log();
-    console.log(chalk.bold("Current Period:"));
-
-    if (result.currentPeriod.length === 0) {
-      console.log(chalk.gray("  No data for the current period."));
-    } else {
-      for (const dataPoint of result.currentPeriod) {
-        const entries = Object.entries(dataPoint).filter(
-          ([key]) => key !== "date",
-        );
-        const dateStr = dataPoint.date
-          ? new Date(dataPoint.date as number).toLocaleDateString()
-          : "—";
-
-        if (entries.length === 0) {
-          console.log(`  ${chalk.gray(dateStr)}: ${chalk.gray("no data")}`);
+        if (result.currentPeriod.length === 0) {
+          console.log(chalk.gray("  No data for the current period."));
         } else {
-          const values = entries
-            .map(([key, value]) => `${chalk.cyan(key)}: ${formatValue(value)}`)
-            .join(", ");
-          console.log(`  ${chalk.gray(dateStr)}: ${values}`);
-        }
-      }
-    }
+          for (const dataPoint of result.currentPeriod) {
+            const entries = Object.entries(dataPoint).filter(
+              ([key]) => key !== "date",
+            );
+            const dateStr = dataPoint.date
+              ? new Date(dataPoint.date as number).toLocaleDateString()
+              : "—";
 
-    if (result.previousPeriod.length > 0) {
-      console.log();
-      console.log(chalk.bold("Previous Period:"));
-      for (const dataPoint of result.previousPeriod) {
-        const entries = Object.entries(dataPoint).filter(
-          ([key]) => key !== "date",
+            if (entries.length === 0) {
+              console.log(`  ${chalk.gray(dateStr)}: ${chalk.gray("no data")}`);
+            } else {
+              const values = entries
+                .map(([key, value]) => `${chalk.cyan(key)}: ${formatValue(value)}`)
+                .join(", ");
+              console.log(`  ${chalk.gray(dateStr)}: ${values}`);
+            }
+          }
+        }
+
+        if (result.previousPeriod.length > 0) {
+          console.log();
+          console.log(chalk.bold("Previous Period:"));
+          for (const dataPoint of result.previousPeriod) {
+            const entries = Object.entries(dataPoint).filter(
+              ([key]) => key !== "date",
+            );
+            const dateStr = dataPoint.date
+              ? new Date(dataPoint.date as number).toLocaleDateString()
+              : "—";
+
+            if (entries.length > 0) {
+              const values = entries
+                .map(([key, value]) => `${chalk.cyan(key)}: ${formatValue(value)}`)
+                .join(", ");
+              console.log(`  ${chalk.gray(dateStr)}: ${values}`);
+            }
+          }
+        }
+
+        console.log();
+        console.log(chalk.gray("Available presets: " + Object.keys(METRIC_PRESETS).join(", ")));
+        console.log(
+          chalk.gray(
+            `Use ${chalk.cyan("langwatch analytics query --metric <preset> -f json")} for raw data`,
+          ),
         );
-        const dateStr = dataPoint.date
-          ? new Date(dataPoint.date as number).toLocaleDateString()
-          : "—";
-
-        if (entries.length > 0) {
-          const values = entries
-            .map(([key, value]) => `${chalk.cyan(key)}: ${formatValue(value)}`)
-            .join(", ");
-          console.log(`  ${chalk.gray(dateStr)}: ${values}`);
-        }
-      }
-    }
-
-    console.log();
-    console.log(chalk.gray("Available presets: " + Object.keys(METRIC_PRESETS).join(", ")));
-    console.log(
-      chalk.gray(
-        `Use ${chalk.cyan("langwatch analytics query --metric <preset> -f json")} for raw data`,
-      ),
-    );
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "query analytics" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/annotations/__tests__/annotation-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/annotations/__tests__/annotation-commands.unit.test.ts
@@ -82,16 +82,17 @@ describe("listAnnotationsCommand()", () => {
     });
   });
 
-  describe("when format is json", () => {
-    it("outputs raw JSON", async () => {
+  describe("when a machine format is requested", () => {
+    it("returns the raw annotation list as the payload instead of printing", async () => {
       const annotations = [makeAnnotation()];
       mockGetAll.mockResolvedValue(annotations);
 
-      await listAnnotationsCommand({ format: "json" });
+      const result = await listAnnotationsCommand({});
 
-      expect(console.log).toHaveBeenCalledWith(
-        JSON.stringify(annotations, null, 2),
-      );
+      // The command no longer decides the format — it hands the payload to
+      // the output port, which renders json/yaml/agents/--jq from this value.
+      expect(result?.data).toEqual(annotations);
+      expect(console.log).not.toHaveBeenCalled();
     });
   });
 

--- a/typescript-sdk/src/cli/commands/annotations/create.ts
+++ b/typescript-sdk/src/cli/commands/annotations/create.ts
@@ -3,11 +3,16 @@ import { createSpinner } from "../../utils/spinner";
 import { AnnotationsApiService } from "@/client-sdk/services/annotations/annotations-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the created annotation rather than printing it: the output port
+ * renders it in whatever format the caller asked for (utils/output.ts).
+ */
 export const createAnnotationCommand = async (
   traceId: string,
-  options: { comment?: string; thumbsUp?: boolean; thumbsDown?: boolean; email?: string; format?: string },
-): Promise<void> => {
+  options: { comment?: string; thumbsUp?: boolean; thumbsDown?: boolean; email?: string },
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AnnotationsApiService();
@@ -34,9 +39,12 @@ export const createAnnotationCommand = async (
       `Created annotation${ratingStr} ${chalk.gray(`(id: ${annotation.id ?? "—"})`)}`,
     );
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(annotation, null, 2));
-    }
+    return {
+      data: annotation,
+      table: () => {
+        // The spinner's success line is the human output.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "create annotation" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/annotations/delete.ts
+++ b/typescript-sdk/src/cli/commands/annotations/delete.ts
@@ -3,8 +3,13 @@ import { createSpinner } from "../../utils/spinner";
 import { AnnotationsApiService } from "@/client-sdk/services/annotations/annotations-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const deleteAnnotationCommand = async (id: string, options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the deletion outcome rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
+export const deleteAnnotationCommand = async (id: string): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AnnotationsApiService();
@@ -14,9 +19,12 @@ export const deleteAnnotationCommand = async (id: string, options?: { format?: s
     await service.delete(id);
     spinner.succeed(`Deleted annotation "${chalk.cyan(id)}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify({ id, deleted: true }, null, 2));
-    }
+    return {
+      data: { id, deleted: true },
+      table: () => {
+        // The spinner's success line is the human output.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "delete annotation" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/annotations/get.ts
+++ b/typescript-sdk/src/cli/commands/annotations/get.ts
@@ -3,8 +3,13 @@ import { createSpinner } from "../../utils/spinner";
 import { AnnotationsApiService } from "@/client-sdk/services/annotations/annotations-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const getAnnotationCommand = async (id: string, options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the annotation rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts).
+ */
+export const getAnnotationCommand = async (id: string): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AnnotationsApiService();
@@ -14,40 +19,40 @@ export const getAnnotationCommand = async (id: string, options?: { format?: stri
     const annotation = await service.get(id);
     spinner.succeed(`Found annotation "${id}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(annotation, null, 2));
-      return;
-    }
+    return {
+      data: annotation,
+      table: () => {
+        console.log();
+        console.log(chalk.bold.cyan(`Annotation ${annotation.id ?? id}`));
+        console.log(chalk.gray("─".repeat(40)));
+        console.log(`  ${chalk.gray("ID:")}        ${annotation.id ?? "—"}`);
+        console.log(`  ${chalk.gray("Trace ID:")} ${annotation.traceId ?? "—"}`);
+        console.log(
+          `  ${chalk.gray("Rating:")}   ${annotation.isThumbsUp === true ? "👍 Thumbs Up" : annotation.isThumbsUp === false ? "👎 Thumbs Down" : "—"}`,
+        );
+        if (annotation.email) {
+          console.log(`  ${chalk.gray("Email:")}    ${annotation.email}`);
+        }
+        if (annotation.createdAt) {
+          console.log(
+            `  ${chalk.gray("Created:")}  ${new Date(annotation.createdAt).toLocaleString()}`,
+          );
+        }
+        if (annotation.updatedAt) {
+          console.log(
+            `  ${chalk.gray("Updated:")}  ${new Date(annotation.updatedAt).toLocaleString()}`,
+          );
+        }
 
-    console.log();
-    console.log(chalk.bold.cyan(`Annotation ${annotation.id ?? id}`));
-    console.log(chalk.gray("─".repeat(40)));
-    console.log(`  ${chalk.gray("ID:")}        ${annotation.id ?? "—"}`);
-    console.log(`  ${chalk.gray("Trace ID:")} ${annotation.traceId ?? "—"}`);
-    console.log(
-      `  ${chalk.gray("Rating:")}   ${annotation.isThumbsUp === true ? "👍 Thumbs Up" : annotation.isThumbsUp === false ? "👎 Thumbs Down" : "—"}`,
-    );
-    if (annotation.email) {
-      console.log(`  ${chalk.gray("Email:")}    ${annotation.email}`);
-    }
-    if (annotation.createdAt) {
-      console.log(
-        `  ${chalk.gray("Created:")}  ${new Date(annotation.createdAt).toLocaleString()}`,
-      );
-    }
-    if (annotation.updatedAt) {
-      console.log(
-        `  ${chalk.gray("Updated:")}  ${new Date(annotation.updatedAt).toLocaleString()}`,
-      );
-    }
+        if (annotation.comment) {
+          console.log();
+          console.log(chalk.bold("  Comment:"));
+          console.log(`    ${annotation.comment}`);
+        }
 
-    if (annotation.comment) {
-      console.log();
-      console.log(chalk.bold("  Comment:"));
-      console.log(`    ${annotation.comment}`);
-    }
-
-    console.log();
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch annotation" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/annotations/list.ts
+++ b/typescript-sdk/src/cli/commands/annotations/list.ts
@@ -4,11 +4,16 @@ import { AnnotationsApiService } from "@/client-sdk/services/annotations/annotat
 import { checkApiKey } from "../../utils/apiKey";
 import { formatTable, formatRelativeTime } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). The `table` closure
+ * is the human form, byte-identical to what this command printed before.
+ */
 export const listAnnotationsCommand = async (options: {
   traceId?: string;
-  format?: string;
-}): Promise<void> => {
+}): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new AnnotationsApiService();
@@ -31,48 +36,48 @@ export const listAnnotationsCommand = async (options: {
       `Found ${annotations.length} annotation${annotations.length !== 1 ? "s" : ""}`,
     );
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(annotations, null, 2));
-      return;
-    }
+    return {
+      data: annotations,
+      table: () => {
+        if (annotations.length === 0) {
+          console.log();
+          console.log(chalk.gray("No annotations found."));
+          console.log(chalk.gray("Create one with:"));
+          console.log(
+            chalk.cyan(
+              '  langwatch annotation create <traceId> --comment "Great response!"',
+            ),
+          );
+          return;
+        }
 
-    if (annotations.length === 0) {
-      console.log();
-      console.log(chalk.gray("No annotations found."));
-      console.log(chalk.gray("Create one with:"));
-      console.log(
-        chalk.cyan(
-          '  langwatch annotation create <traceId> --comment "Great response!"',
-        ),
-      );
-      return;
-    }
+        console.log();
 
-    console.log();
+        const tableData = annotations.map((a) => ({
+          ID: a.id ?? "—",
+          "Trace ID": a.traceId ? a.traceId.substring(0, 20) : "—",
+          Comment: truncate(a.comment ?? "—", 40),
+          Rating: a.isThumbsUp === true ? "👍" : a.isThumbsUp === false ? "👎" : "—",
+          Created: a.createdAt ? formatRelativeTime(a.createdAt) : "—",
+        }));
 
-    const tableData = annotations.map((a) => ({
-      ID: a.id ?? "—",
-      "Trace ID": a.traceId ? a.traceId.substring(0, 20) : "—",
-      Comment: truncate(a.comment ?? "—", 40),
-      Rating: a.isThumbsUp === true ? "👍" : a.isThumbsUp === false ? "👎" : "—",
-      Created: a.createdAt ? formatRelativeTime(a.createdAt) : "—",
-    }));
+        formatTable({
+          data: tableData,
+          headers: ["ID", "Trace ID", "Comment", "Rating", "Created"],
+          colorMap: {
+            ID: chalk.green,
+            "Trace ID": chalk.cyan,
+          },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["ID", "Trace ID", "Comment", "Rating", "Created"],
-      colorMap: {
-        ID: chalk.green,
-        "Trace ID": chalk.cyan,
+        console.log();
+        console.log(
+          chalk.gray(
+            `Use ${chalk.cyan("langwatch annotation get <id>")} to view full details`,
+          ),
+        );
       },
-    });
-
-    console.log();
-    console.log(
-      chalk.gray(
-        `Use ${chalk.cyan("langwatch annotation get <id>")} to view full details`,
-      ),
-    );
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch annotations" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/api-keys/create.ts
+++ b/typescript-sdk/src/cli/commands/api-keys/create.ts
@@ -3,6 +3,7 @@ import { createSpinner } from "../../utils/spinner";
 import { ApiKeysApiService } from "@/client-sdk/services/api-keys/api-keys-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
 export interface CreateApiKeyOptions {
   name: string;
@@ -10,10 +11,21 @@ export interface CreateApiKeyOptions {
   description?: string;
   expiresAt?: string;
   projectId?: string[];
-  format?: string;
 }
 
-export const createApiKeyCommand = async (options: CreateApiKeyOptions): Promise<void> => {
+/**
+ * Returns the created key rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts).
+ *
+ * `data` deliberately includes `result.token`. This is the ONE moment the token
+ * exists — the server never returns it again — and the human output prints it
+ * in full for exactly that reason, as did the previous `--format json` branch.
+ * Withholding it from the machine payload would make `api-key create -o json`
+ * useless for the scripted case it exists to serve.
+ */
+export const createApiKeyCommand = async (
+  options: CreateApiKeyOptions,
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   if (!options.name) {
@@ -36,19 +48,19 @@ export const createApiKeyCommand = async (options: CreateApiKeyOptions): Promise
 
     spinner.succeed(`Created ${keyType} API key "${chalk.cyan(result.apiKey.name)}"`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(chalk.bold.yellow("⚠  Save the token below NOW. It will not be shown again."));
-    console.log();
-    console.log(`  ${chalk.green(result.token)}`);
-    console.log();
-    console.log(chalk.gray("API key id: ") + result.apiKey.id);
-    console.log(chalk.gray("Created:    ") + new Date(result.apiKey.createdAt).toLocaleString());
-    console.log();
+    return {
+      data: result,
+      table: () => {
+        console.log();
+        console.log(chalk.bold.yellow("⚠  Save the token below NOW. It will not be shown again."));
+        console.log();
+        console.log(`  ${chalk.green(result.token)}`);
+        console.log();
+        console.log(chalk.gray("API key id: ") + result.apiKey.id);
+        console.log(chalk.gray("Created:    ") + new Date(result.apiKey.createdAt).toLocaleString());
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "create API key" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/api-keys/list.ts
+++ b/typescript-sdk/src/cli/commands/api-keys/list.ts
@@ -4,8 +4,15 @@ import { ApiKeysApiService } from "@/client-sdk/services/api-keys/api-keys-api.s
 import { checkApiKey } from "../../utils/apiKey";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const listApiKeysCommand = async (options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). `ApiKeyInfo` carries
+ * no token material — a token exists only in the create response — so the raw
+ * list is safe to hand to a machine caller.
+ */
+export const listApiKeysCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new ApiKeysApiService();
@@ -16,51 +23,51 @@ export const listApiKeysCommand = async (options?: { format?: string }): Promise
 
     spinner.succeed(`Found ${keys.length} API key${keys.length !== 1 ? "s" : ""}`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(keys, null, 2));
-      return;
-    }
+    return {
+      data: keys,
+      table: () => {
+        if (keys.length === 0) {
+          console.log();
+          console.log(chalk.gray("No API keys found."));
+          console.log(chalk.gray("Create one with:"));
+          console.log(chalk.cyan('  langwatch api-keys create --name "my-key"'));
+          return;
+        }
 
-    if (keys.length === 0) {
-      console.log();
-      console.log(chalk.gray("No API keys found."));
-      console.log(chalk.gray("Create one with:"));
-      console.log(chalk.cyan('  langwatch api-keys create --name "my-key"'));
-      return;
-    }
+        console.log();
 
-    console.log();
+        const now = Date.now();
+        const tableData = keys.map((k) => {
+          const isExpired = !!k.expiresAt && new Date(k.expiresAt).getTime() <= now;
+          const status = k.revokedAt
+            ? chalk.red("revoked")
+            : isExpired
+              ? chalk.yellow("expired")
+              : chalk.green("active");
 
-    const now = Date.now();
-    const tableData = keys.map((k) => {
-      const isExpired = !!k.expiresAt && new Date(k.expiresAt).getTime() <= now;
-      const status = k.revokedAt
-        ? chalk.red("revoked")
-        : isExpired
-          ? chalk.yellow("expired")
-          : chalk.green("active");
+          return {
+            ID: k.id,
+            Name: k.name,
+            Status: status,
+            Bindings: String(k.roleBindings.length),
+            Expires: k.expiresAt ? new Date(k.expiresAt).toLocaleDateString() : chalk.gray("never"),
+            "Last used": k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleDateString() : chalk.gray("—"),
+            Created: new Date(k.createdAt).toLocaleDateString(),
+          };
+        });
 
-      return {
-        ID: k.id,
-        Name: k.name,
-        Status: status,
-        Bindings: String(k.roleBindings.length),
-        Expires: k.expiresAt ? new Date(k.expiresAt).toLocaleDateString() : chalk.gray("never"),
-        "Last used": k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleDateString() : chalk.gray("—"),
-        Created: new Date(k.createdAt).toLocaleDateString(),
-      };
-    });
+        formatTable({
+          data: tableData,
+          headers: ["ID", "Name", "Status", "Bindings", "Expires", "Last used", "Created"],
+          colorMap: {
+            Name: chalk.cyan,
+            ID: chalk.gray,
+          },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["ID", "Name", "Status", "Bindings", "Expires", "Last used", "Created"],
-      colorMap: {
-        Name: chalk.cyan,
-        ID: chalk.gray,
+        console.log();
       },
-    });
-
-    console.log();
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch API keys" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/api-keys/revoke.ts
+++ b/typescript-sdk/src/cli/commands/api-keys/revoke.ts
@@ -3,11 +3,18 @@ import { createSpinner } from "../../utils/spinner";
 import { ApiKeysApiService } from "@/client-sdk/services/api-keys/api-keys-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the revocation result rather than printing it: the output port
+ * renders it in whatever format the caller asked for (utils/output.ts).
+ *
+ * The service answers a bare `{ success }`, which tells a machine caller
+ * nothing about WHICH key was revoked, so the id is carried alongside it.
+ */
 export const revokeApiKeyCommand = async (
   id: string,
-  options?: { format?: string },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new ApiKeysApiService();
@@ -18,14 +25,14 @@ export const revokeApiKeyCommand = async (
 
     spinner.succeed(`Revoked API key "${id}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(chalk.gray("API key has been revoked and can no longer be used."));
-    console.log();
+    return {
+      data: { id, ...result },
+      table: () => {
+        console.log();
+        console.log(chalk.gray("API key has been revoked and can no longer be used."));
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "revoke API key" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/daemon.ts
+++ b/typescript-sdk/src/cli/commands/daemon.ts
@@ -14,9 +14,12 @@ import {
   type DaemonStatus,
 } from "../daemon/client";
 import {
+  inspectSocketTrust,
   isDaemonSupported,
   resolveBuildId,
   resolveIdentity,
+  UntrustedSocketDirError,
+  type SocketTrustProblem,
 } from "../daemon/identity";
 import {
   cleanStaleSocket,
@@ -46,6 +49,64 @@ function resolveIdleTimeout(option?: string): number {
   return DEFAULT_IDLE_TIMEOUT_MS;
 }
 
+/**
+ * The trust problems that mean "something is WRONG", as opposed to the two that
+ * simply mean "no daemon is running here yet".
+ *
+ * `requestStatus`/`requestStop` collapse every problem into `null`/`false`,
+ * which is right for them — an untrusted socket is exactly "no daemon" on the
+ * hot path. It is wrong for these commands: the user explicitly asked about the
+ * daemon, so silently reporting "not running" (or worse, "starting in the
+ * background" for a daemon that will immediately die) hides the one fact they
+ * need. `socket-missing` and `socket-dir-missing` are the ordinary empty state
+ * and are deliberately NOT in here.
+ */
+function describeTrustProblem(
+  problem: SocketTrustProblem,
+): string | null {
+  switch (problem) {
+    case "socket-missing":
+    case "socket-dir-missing":
+      return null;
+    case "socket-dir-not-a-directory":
+      return "its socket directory is not a directory";
+    case "socket-dir-foreign-owner":
+      return "its socket directory is owned by another user";
+    case "socket-dir-loose-mode":
+      return "its socket directory is readable or writable by other users";
+    case "socket-not-a-socket":
+      return "another file is sitting at the socket path";
+    case "socket-foreign-owner":
+      return "the socket is owned by another user";
+    case "socket-loose-mode":
+      return "the socket is readable or writable by other users";
+  }
+}
+
+/**
+ * Print the blocking trust problem, if there is one. Returns true when the
+ * caller must stop: a daemon whose socket cannot be trusted must not be
+ * reported as running, started, or stopped.
+ */
+function reportUntrustedSocket(socketPath: string): boolean {
+  const problem = inspectSocketTrust(socketPath);
+  if (!problem) return false;
+  const description = describeTrustProblem(problem);
+  if (description === null) return false;
+
+  console.error(
+    chalk.red(`Refusing to use the langwatch daemon: ${description}.`),
+  );
+  console.error(chalk.gray(`  socket: ${socketPath}`));
+  console.error(
+    chalk.gray(
+      "  Commands will keep working — they run in-process. Remove or fix the path above, " +
+        "or point LANGWATCH_DAEMON_DIR at a directory you own, to use the daemon again.",
+    ),
+  );
+  return true;
+}
+
 function requireSupport(): void {
   if (isDaemonSupported()) return;
   console.error(
@@ -66,6 +127,16 @@ export async function daemonStartCommand(options: {
   const idleTimeoutMs = resolveIdleTimeout(options.idleTimeout);
 
   if (!options.foreground) {
+    // Before anything else: `requestStatus` returns null for an untrusted
+    // socket, so without this we would skip the "already running" branch,
+    // spawn a child that dies on UntrustedSocketDirError, and cheerfully print
+    // "Daemon starting in the background." No daemon would start, and every
+    // later invocation would silently run in-process with no explanation.
+    if (reportUntrustedSocket(identity.socketPath)) {
+      process.exitCode = 1;
+      return;
+    }
+
     const existing = await requestStatus(identity.socketPath);
     if (existing) {
       console.log(
@@ -107,6 +178,20 @@ export async function daemonStartCommand(options: {
       // Two invocations raced to spawn one. Losing that race is a no-op.
       return;
     }
+    if (error instanceof UntrustedSocketDirError) {
+      // `ensureSocketDir` fails closed on a directory we cannot make private.
+      // The error already carries the actionable sentence; a stack trace on top
+      // of it would only bury the one line the user needs.
+      console.error(chalk.red(error.message));
+      console.error(
+        chalk.gray(
+          "  Commands still work — they run in-process. Point LANGWATCH_DAEMON_DIR " +
+            "at a directory you own to use the daemon.",
+        ),
+      );
+      process.exitCode = 1;
+      return;
+    }
     throw error;
   }
 
@@ -120,6 +205,15 @@ export async function daemonStopCommand(): Promise<void> {
   requireSupport();
 
   const identity = resolveIdentity(process.env);
+
+  // `requestStop` returns false for an untrusted socket, which would otherwise
+  // surface as a flat "No daemon running." — and the user would have no idea
+  // why their daemon keeps not existing.
+  if (reportUntrustedSocket(identity.socketPath)) {
+    process.exitCode = 1;
+    return;
+  }
+
   const stopped = await requestStop(identity.socketPath);
 
   if (stopped) {

--- a/typescript-sdk/src/cli/commands/dashboards/create.ts
+++ b/typescript-sdk/src/cli/commands/dashboards/create.ts
@@ -3,8 +3,13 @@ import { createSpinner } from "../../utils/spinner";
 import { DashboardsApiService } from "@/client-sdk/services/dashboards/dashboards-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const createDashboardCommand = async (name: string, options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the created dashboard rather than printing it: the output port
+ * renders it in whatever format the caller asked for (utils/output.ts).
+ */
+export const createDashboardCommand = async (name: string): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new DashboardsApiService();
@@ -17,11 +22,14 @@ export const createDashboardCommand = async (name: string, options?: { format?: 
       `Created dashboard "${chalk.cyan(dashboard.name)}" ${chalk.gray(`(id: ${dashboard.id})`)}`,
     );
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(dashboard, null, 2));
-    } else if (dashboard.platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(dashboard.platformUrl)}`);
-    }
+    return {
+      data: dashboard,
+      table: () => {
+        if (dashboard.platformUrl) {
+          console.log(`  ${chalk.bold("View:")}  ${chalk.underline(dashboard.platformUrl)}`);
+        }
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "create dashboard" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/dashboards/delete.ts
+++ b/typescript-sdk/src/cli/commands/dashboards/delete.ts
@@ -3,8 +3,13 @@ import { createSpinner } from "../../utils/spinner";
 import { DashboardsApiService } from "@/client-sdk/services/dashboards/dashboards-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const deleteDashboardCommand = async (id: string, options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the deletion outcome rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
+export const deleteDashboardCommand = async (id: string): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new DashboardsApiService();
@@ -14,9 +19,12 @@ export const deleteDashboardCommand = async (id: string, options?: { format?: st
     const result = await service.delete(id);
     spinner.succeed(`Deleted dashboard "${chalk.cyan(result.name)}" ${chalk.gray(`(id: ${result.id})`)}`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-    }
+    return {
+      data: result,
+      table: () => {
+        // The spinner's success line is the human output.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "delete dashboard" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/dashboards/get.ts
+++ b/typescript-sdk/src/cli/commands/dashboards/get.ts
@@ -3,11 +3,15 @@ import { createSpinner } from "../../utils/spinner";
 import { DashboardsApiService } from "@/client-sdk/services/dashboards/dashboards-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the dashboard rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts).
+ */
 export const getDashboardCommand = async (
   id: string,
-  options?: { format?: string },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new DashboardsApiService();
@@ -18,22 +22,22 @@ export const getDashboardCommand = async (
 
     spinner.succeed(`Found dashboard "${dashboard.name}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(dashboard, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(chalk.bold("  Dashboard Details:"));
-    console.log(`    ${chalk.gray("ID:")}      ${chalk.green(dashboard.id)}`);
-    console.log(`    ${chalk.gray("Name:")}    ${chalk.cyan(dashboard.name)}`);
-    console.log(`    ${chalk.gray("Graphs:")}  ${Array.isArray(dashboard.graphs) ? dashboard.graphs.length : 0}`);
-    console.log(`    ${chalk.gray("Created:")} ${new Date(dashboard.createdAt).toLocaleString()}`);
-    console.log(`    ${chalk.gray("Updated:")} ${new Date(dashboard.updatedAt).toLocaleString()}`);
-    if (dashboard.platformUrl) {
-      console.log(`    ${chalk.bold("View:")}   ${chalk.underline(dashboard.platformUrl)}`);
-    }
-    console.log();
+    return {
+      data: dashboard,
+      table: () => {
+        console.log();
+        console.log(chalk.bold("  Dashboard Details:"));
+        console.log(`    ${chalk.gray("ID:")}      ${chalk.green(dashboard.id)}`);
+        console.log(`    ${chalk.gray("Name:")}    ${chalk.cyan(dashboard.name)}`);
+        console.log(`    ${chalk.gray("Graphs:")}  ${Array.isArray(dashboard.graphs) ? dashboard.graphs.length : 0}`);
+        console.log(`    ${chalk.gray("Created:")} ${new Date(dashboard.createdAt).toLocaleString()}`);
+        console.log(`    ${chalk.gray("Updated:")} ${new Date(dashboard.updatedAt).toLocaleString()}`);
+        if (dashboard.platformUrl) {
+          console.log(`    ${chalk.bold("View:")}   ${chalk.underline(dashboard.platformUrl)}`);
+        }
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch dashboard" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/dashboards/list.ts
+++ b/typescript-sdk/src/cli/commands/dashboards/list.ts
@@ -4,8 +4,14 @@ import { DashboardsApiService } from "@/client-sdk/services/dashboards/dashboard
 import { checkApiKey } from "../../utils/apiKey";
 import { formatTable, formatRelativeTime } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const listDashboardsCommand = async (options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). The `table` closure
+ * is the human form, byte-identical to what this command printed before.
+ */
+export const listDashboardsCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new DashboardsApiService();
@@ -19,43 +25,43 @@ export const listDashboardsCommand = async (options?: { format?: string }): Prom
       `Found ${dashboards.length} dashboard${dashboards.length !== 1 ? "s" : ""}`,
     );
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-      return;
-    }
+    return {
+      data: result,
+      table: () => {
+        if (dashboards.length === 0) {
+          console.log();
+          console.log(chalk.gray("No dashboards found."));
+          console.log(chalk.gray("Create one with:"));
+          console.log(chalk.cyan('  langwatch dashboard create "My Dashboard"'));
+          return;
+        }
 
-    if (dashboards.length === 0) {
-      console.log();
-      console.log(chalk.gray("No dashboards found."));
-      console.log(chalk.gray("Create one with:"));
-      console.log(chalk.cyan('  langwatch dashboard create "My Dashboard"'));
-      return;
-    }
+        console.log();
 
-    console.log();
+        const tableData = dashboards.map((d) => ({
+          Name: d.name,
+          ID: d.id,
+          Graphs: String(d.graphCount),
+          Updated: formatRelativeTime(d.updatedAt),
+        }));
 
-    const tableData = dashboards.map((d) => ({
-      Name: d.name,
-      ID: d.id,
-      Graphs: String(d.graphCount),
-      Updated: formatRelativeTime(d.updatedAt),
-    }));
+        formatTable({
+          data: tableData,
+          headers: ["Name", "ID", "Graphs", "Updated"],
+          colorMap: {
+            Name: chalk.cyan,
+            ID: chalk.green,
+          },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["Name", "ID", "Graphs", "Updated"],
-      colorMap: {
-        Name: chalk.cyan,
-        ID: chalk.green,
+        console.log();
+        console.log(
+          chalk.gray(
+            `Use ${chalk.cyan("langwatch dashboard get <id>")} to view dashboard details`,
+          ),
+        );
       },
-    });
-
-    console.log();
-    console.log(
-      chalk.gray(
-        `Use ${chalk.cyan("langwatch dashboard get <id>")} to view dashboard details`,
-      ),
-    );
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch dashboards" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/dashboards/update.ts
+++ b/typescript-sdk/src/cli/commands/dashboards/update.ts
@@ -3,11 +3,16 @@ import { createSpinner } from "../../utils/spinner";
 import { DashboardsApiService } from "@/client-sdk/services/dashboards/dashboards-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the renamed dashboard rather than printing it: the output port
+ * renders it in whatever format the caller asked for (utils/output.ts).
+ */
 export const updateDashboardCommand = async (
   id: string,
-  options: { name?: string; format?: string },
-): Promise<void> => {
+  options: { name?: string },
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   if (!options.name) {
@@ -23,15 +28,15 @@ export const updateDashboardCommand = async (
 
     spinner.succeed(`Dashboard renamed to "${dashboard.name}"`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(dashboard, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`  ${chalk.gray("ID:")}   ${chalk.green(dashboard.id)}`);
-    console.log(`  ${chalk.gray("Name:")} ${chalk.cyan(dashboard.name)}`);
-    console.log();
+    return {
+      data: dashboard,
+      table: () => {
+        console.log();
+        console.log(`  ${chalk.gray("ID:")}   ${chalk.green(dashboard.id)}`);
+        console.log(`  ${chalk.gray("Name:")} ${chalk.cyan(dashboard.name)}`);
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "update dashboard" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/evaluators/__tests__/evaluator-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/__tests__/evaluator-commands.unit.test.ts
@@ -294,9 +294,7 @@ describe("listEvaluatorsCommand() failure shape under machine formats", () => {
     // the same options object and must not win.
     await applyOutputContext(resolveOutputOptions({ output: "json", format: "table" }, {}));
 
-    await expect(
-      listEvaluatorsCommand({ output: "json", format: "table" }),
-    ).rejects.toThrow(ProcessExitError);
+    await expect(listEvaluatorsCommand()).rejects.toThrow(ProcessExitError);
 
     const doc = JSON.parse(printedStdout()) as { ok: boolean; error: { message: string } };
     expect(doc.ok).toBe(false);
@@ -306,9 +304,7 @@ describe("listEvaluatorsCommand() failure shape under machine formats", () => {
   it("emits the structured JSON error document under --agent, despite the -f commander default", async () => {
     await applyOutputContext(resolveOutputOptions({ agent: true, format: "table" }, {}));
 
-    await expect(
-      listEvaluatorsCommand({ agent: true, format: "table" }),
-    ).rejects.toThrow(ProcessExitError);
+    await expect(listEvaluatorsCommand()).rejects.toThrow(ProcessExitError);
 
     const doc = JSON.parse(printedStdout()) as { ok: boolean };
     expect(doc.ok).toBe(false);
@@ -317,9 +313,7 @@ describe("listEvaluatorsCommand() failure shape under machine formats", () => {
   it("still emits JSON errors when a human passes -f json explicitly", async () => {
     await applyOutputContext(resolveOutputOptions({ format: "json" }, {}));
 
-    await expect(
-      listEvaluatorsCommand({ format: "json" }),
-    ).rejects.toThrow(ProcessExitError);
+    await expect(listEvaluatorsCommand()).rejects.toThrow(ProcessExitError);
 
     const doc = JSON.parse(printedStdout()) as { ok: boolean };
     expect(doc.ok).toBe(false);
@@ -328,9 +322,7 @@ describe("listEvaluatorsCommand() failure shape under machine formats", () => {
   it("keeps the human error block when no machine format was asked for", async () => {
     await applyOutputContext(resolveOutputOptions({ format: "table" }, {}));
 
-    await expect(
-      listEvaluatorsCommand({ format: "table" }),
-    ).rejects.toThrow(ProcessExitError);
+    await expect(listEvaluatorsCommand()).rejects.toThrow(ProcessExitError);
 
     expect(() => JSON.parse(printedStdout())).toThrow();
   });

--- a/typescript-sdk/src/cli/commands/evaluators/create.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/create.ts
@@ -3,12 +3,16 @@ import { createSpinner } from "../../utils/spinner";
 import { EvaluatorsApiService } from "@/client-sdk/services/evaluators";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
-import { printResult, type RawOutputFlags } from "../../utils/output";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the created evaluator rather than printing it: the output port
+ * renders it in whatever format the caller asked for (utils/output.ts).
+ */
 export const createEvaluatorCommand = async (
   name: string,
-  options: { type: string } & RawOutputFlags,
-): Promise<void> => {
+  options: { type: string },
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new EvaluatorsApiService();
@@ -33,14 +37,12 @@ export const createEvaluatorCommand = async (
     process.exit(1);
   }
 
-  // Rendering stays OUTSIDE the create try: a printResult rejection (invalid
-  // --jq) must not report an already-created evaluator as a create failure.
-  await printResult(evaluator, {
-    ...options,
+  return {
+    data: evaluator,
     table: () => {
       if (evaluator.platformUrl) {
         console.log(`  ${chalk.bold("View:")}  ${chalk.underline(evaluator.platformUrl)}`);
       }
     },
-  });
+  };
 };

--- a/typescript-sdk/src/cli/commands/evaluators/delete.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/delete.ts
@@ -3,12 +3,15 @@ import { createSpinner } from "../../utils/spinner";
 import { EvaluatorsApiService } from "@/client-sdk/services/evaluators";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
-import { printResult, type RawOutputFlags } from "../../utils/output";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the archival outcome rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const deleteEvaluatorCommand = async (
   idOrSlug: string,
-  options?: RawOutputFlags,
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new EvaluatorsApiService();
@@ -47,15 +50,10 @@ export const deleteEvaluatorCommand = async (
     process.exit(1);
   }
 
-  // Rendering stays OUTSIDE the deletion try: a printResult rejection (invalid
-  // --jq) must not report an already-archived evaluator as an archive failure.
-  await printResult(
-    { id: evaluatorId, name: evaluatorName, archived: true },
-    {
-      ...options,
-      table: () => {
-        // The spinner's success line is the human output.
-      },
+  return {
+    data: { id: evaluatorId, name: evaluatorName, archived: true },
+    table: () => {
+      // The spinner's success line is the human output.
     },
-  );
+  };
 };

--- a/typescript-sdk/src/cli/commands/evaluators/get.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/get.ts
@@ -4,7 +4,7 @@ import { EvaluatorsApiService } from "@/client-sdk/services/evaluators";
 import type { EvaluatorResponse } from "@/client-sdk/services/evaluators";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
-import { printResult, type RawOutputFlags } from "../../utils/output";
+import type { CommandResult } from "../../utils/output";
 
 const formatEvaluatorDetails = (evaluator: EvaluatorResponse): void => {
   const config = evaluator.config as
@@ -64,7 +64,11 @@ const formatEvaluatorDetails = (evaluator: EvaluatorResponse): void => {
   console.log();
 };
 
-export const getEvaluatorCommand = async (idOrSlug: string, options?: RawOutputFlags): Promise<void> => {
+/**
+ * Returns the evaluator rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts).
+ */
+export const getEvaluatorCommand = async (idOrSlug: string): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new EvaluatorsApiService();
@@ -81,10 +85,8 @@ export const getEvaluatorCommand = async (idOrSlug: string, options?: RawOutputF
     process.exit(1);
   }
 
-  // Rendering stays OUTSIDE the fetch try: a printResult rejection (invalid
-  // --jq) is a rendering failure, not a fetch failure.
-  await printResult(evaluator, {
-    ...options,
+  return {
+    data: evaluator,
     table: () => formatEvaluatorDetails(evaluator),
-  });
+  };
 };

--- a/typescript-sdk/src/cli/commands/evaluators/list.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/list.ts
@@ -4,9 +4,14 @@ import { EvaluatorsApiService } from "@/client-sdk/services/evaluators";
 import { checkApiKey } from "../../utils/apiKey";
 import { formatTable, formatRelativeTime } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
-import { printResult, type RawOutputFlags } from "../../utils/output";
+import type { CommandResult } from "../../utils/output";
 
-export const listEvaluatorsCommand = async (options?: RawOutputFlags): Promise<void> => {
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). The `table` closure
+ * is the human form, byte-identical to what this command printed before.
+ */
+export const listEvaluatorsCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new EvaluatorsApiService();
@@ -26,10 +31,8 @@ export const listEvaluatorsCommand = async (options?: RawOutputFlags): Promise<v
     process.exit(1);
   }
 
-  // Rendering stays OUTSIDE the fetch try: a printResult rejection (invalid
-  // --jq) is a rendering failure, not a fetch failure.
-  await printResult(evaluators, {
-    ...options,
+  return {
+    data: evaluators,
     table: () => {
       if (evaluators.length === 0) {
         console.log();
@@ -75,5 +78,5 @@ export const listEvaluatorsCommand = async (options?: RawOutputFlags): Promise<v
         ),
       );
     },
-  });
+  };
 };

--- a/typescript-sdk/src/cli/commands/evaluators/update.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/update.ts
@@ -5,12 +5,16 @@ import type { EvaluatorResponse, UpdateEvaluatorBody } from "@/client-sdk/servic
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError } from "../../utils/errorOutput";
-import { printResult, type RawOutputFlags } from "../../utils/output";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the updated evaluator rather than printing it: the output port
+ * renders it in whatever format the caller asked for (utils/output.ts).
+ */
 export const updateEvaluatorCommand = async (
   idOrSlug: string,
-  options: { name?: string; settings?: string } & RawOutputFlags,
-): Promise<void> => {
+  options: { name?: string; settings?: string },
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new EvaluatorsApiService();
@@ -63,12 +67,10 @@ export const updateEvaluatorCommand = async (
     process.exit(1);
   }
 
-  // Rendering stays OUTSIDE the update try: a printResult rejection (invalid
-  // --jq) must not report an already-updated evaluator as an update failure.
-  await printResult(updated, {
-    ...options,
+  return {
+    data: updated,
     table: () => {
       // The spinner's success line is the human output.
     },
-  });
+  };
 };

--- a/typescript-sdk/src/cli/commands/gateway-budgets/archive.ts
+++ b/typescript-sdk/src/cli/commands/gateway-budgets/archive.ts
@@ -3,11 +3,15 @@ import { createSpinner } from "../../utils/spinner";
 import { GatewayBudgetsApiService } from "@/client-sdk/services/gateway-budgets/gateway-budgets-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the archived budget rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const archiveGatewayBudgetCommand = async (
   id: string,
-  options?: { format?: string },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new GatewayBudgetsApiService();
@@ -18,14 +22,14 @@ export const archiveGatewayBudgetCommand = async (
 
     spinner.succeed(`Archived budget "${chalk.cyan(budget.name)}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(budget, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(chalk.gray("Archived at: ") + (budget.archived_at ? new Date(budget.archived_at).toLocaleString() : chalk.gray("—")));
-    console.log();
+    return {
+      data: budget,
+      table: () => {
+        console.log();
+        console.log(chalk.gray("Archived at: ") + (budget.archived_at ? new Date(budget.archived_at).toLocaleString() : chalk.gray("—")));
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "archive gateway budget" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/gateway-budgets/create.ts
+++ b/typescript-sdk/src/cli/commands/gateway-budgets/create.ts
@@ -8,6 +8,7 @@ import {
 } from "@/client-sdk/services/gateway-budgets/gateway-budgets-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
 export interface CreateGatewayBudgetOptions {
   name: string;
@@ -22,7 +23,6 @@ export interface CreateGatewayBudgetOptions {
   limit: string;
   onBreach?: "block" | "warn";
   timezone?: string;
-  format?: string;
 }
 
 const ALLOWED_WINDOWS: BudgetWindow[] = ["MINUTE", "HOUR", "DAY", "WEEK", "MONTH", "TOTAL"];
@@ -49,9 +49,13 @@ function buildScope(options: CreateGatewayBudgetOptions): CreateGatewayBudgetSco
   }
 }
 
+/**
+ * Returns the created budget rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const createGatewayBudgetCommand = async (
   options: CreateGatewayBudgetOptions,
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const upperWindow = options.window.toUpperCase() as BudgetWindow;
@@ -90,19 +94,19 @@ export const createGatewayBudgetCommand = async (
 
     spinner.succeed(`Created budget "${chalk.cyan(budget.name)}"`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(budget, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`${chalk.bold("ID:")}       ${budget.id}`);
-    console.log(`${chalk.bold("Scope:")}    ${budget.scope_type.toLowerCase()}:${budget.scope_id}`);
-    console.log(`${chalk.bold("Window:")}   ${budget.window.toLowerCase()}`);
-    console.log(`${chalk.bold("Limit:")}    $${budget.limit_usd}`);
-    console.log(`${chalk.bold("Breach:")}   ${budget.on_breach.toLowerCase()}`);
-    console.log(`${chalk.bold("Resets:")}   ${new Date(budget.resets_at).toLocaleString()}`);
-    console.log();
+    return {
+      data: budget,
+      table: () => {
+        console.log();
+        console.log(`${chalk.bold("ID:")}       ${budget.id}`);
+        console.log(`${chalk.bold("Scope:")}    ${budget.scope_type.toLowerCase()}:${budget.scope_id}`);
+        console.log(`${chalk.bold("Window:")}   ${budget.window.toLowerCase()}`);
+        console.log(`${chalk.bold("Limit:")}    $${budget.limit_usd}`);
+        console.log(`${chalk.bold("Breach:")}   ${budget.on_breach.toLowerCase()}`);
+        console.log(`${chalk.bold("Resets:")}   ${new Date(budget.resets_at).toLocaleString()}`);
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "create gateway budget" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/gateway-budgets/list.ts
+++ b/typescript-sdk/src/cli/commands/gateway-budgets/list.ts
@@ -4,8 +4,15 @@ import { GatewayBudgetsApiService } from "@/client-sdk/services/gateway-budgets/
 import { checkApiKey } from "../../utils/apiKey";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const listGatewayBudgetsCommand = async (options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). `data` is the raw
+ * budget list, so a machine caller keeps the full scope ids the table
+ * truncates and the exact decimal amounts it rounds for display.
+ */
+export const listGatewayBudgetsCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new GatewayBudgetsApiService();
@@ -16,49 +23,49 @@ export const listGatewayBudgetsCommand = async (options?: { format?: string }): 
 
     spinner.succeed(`Found ${budgets.length} budget${budgets.length !== 1 ? "s" : ""}`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(budgets, null, 2));
-      return;
-    }
+    return {
+      data: budgets,
+      table: () => {
+        if (budgets.length === 0) {
+          console.log();
+          console.log(chalk.gray("No gateway budgets configured."));
+          console.log(chalk.gray("Create one with:"));
+          console.log(
+            chalk.cyan('  langwatch gateway-budgets create --scope project --project <id> --window day --limit 100 --name "daily cap"'),
+          );
+          return;
+        }
 
-    if (budgets.length === 0) {
-      console.log();
-      console.log(chalk.gray("No gateway budgets configured."));
-      console.log(chalk.gray("Create one with:"));
-      console.log(
-        chalk.cyan('  langwatch gateway-budgets create --scope project --project <id> --window day --limit 100 --name "daily cap"'),
-      );
-      return;
-    }
+        console.log();
 
-    console.log();
+        const tableData = budgets.map((b) => {
+          const limit = Number.parseFloat(b.limit_usd);
+          const spent = Number.parseFloat(b.spent_usd);
+          const pct = limit > 0 ? (spent / limit) * 100 : 0;
+          const pctLabel = `${pct.toFixed(0)}%`;
+          const coloredPct = pct >= 100 ? chalk.red(pctLabel) : pct >= 80 ? chalk.yellow(pctLabel) : chalk.green(pctLabel);
+          return {
+            ID: b.id,
+            Name: b.name,
+            Scope: `${b.scope_type.toLowerCase()}:${b.scope_id.slice(0, 10)}...`,
+            Window: b.window.toLowerCase(),
+            Breach: b.on_breach === "BLOCK" ? chalk.red("block") : chalk.yellow("warn"),
+            Limit: `$${limit.toFixed(2)}`,
+            Spent: `$${spent.toFixed(2)} (${coloredPct})`,
+            Resets: new Date(b.resets_at).toLocaleString(),
+            Archived: b.archived_at ? chalk.gray("yes") : "",
+          };
+        });
 
-    const tableData = budgets.map((b) => {
-      const limit = Number.parseFloat(b.limit_usd);
-      const spent = Number.parseFloat(b.spent_usd);
-      const pct = limit > 0 ? (spent / limit) * 100 : 0;
-      const pctLabel = `${pct.toFixed(0)}%`;
-      const coloredPct = pct >= 100 ? chalk.red(pctLabel) : pct >= 80 ? chalk.yellow(pctLabel) : chalk.green(pctLabel);
-      return {
-        ID: b.id,
-        Name: b.name,
-        Scope: `${b.scope_type.toLowerCase()}:${b.scope_id.slice(0, 10)}...`,
-        Window: b.window.toLowerCase(),
-        Breach: b.on_breach === "BLOCK" ? chalk.red("block") : chalk.yellow("warn"),
-        Limit: `$${limit.toFixed(2)}`,
-        Spent: `$${spent.toFixed(2)} (${coloredPct})`,
-        Resets: new Date(b.resets_at).toLocaleString(),
-        Archived: b.archived_at ? chalk.gray("yes") : "",
-      };
-    });
+        formatTable({
+          data: tableData,
+          headers: ["ID", "Name", "Scope", "Window", "Breach", "Limit", "Spent", "Resets", "Archived"],
+          colorMap: { Name: chalk.cyan, ID: chalk.gray },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["ID", "Name", "Scope", "Window", "Breach", "Limit", "Spent", "Resets", "Archived"],
-      colorMap: { Name: chalk.cyan, ID: chalk.gray },
-    });
-
-    console.log();
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch gateway budgets" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/gateway-budgets/update.ts
+++ b/typescript-sdk/src/cli/commands/gateway-budgets/update.ts
@@ -6,6 +6,7 @@ import {
 } from "@/client-sdk/services/gateway-budgets/gateway-budgets-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
 export interface UpdateGatewayBudgetOptions {
   name?: string;
@@ -15,13 +16,16 @@ export interface UpdateGatewayBudgetOptions {
   onBreach?: "block" | "warn";
   timezone?: string;
   clearTimezone?: boolean;
-  format?: string;
 }
 
+/**
+ * Returns the updated budget rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const updateGatewayBudgetCommand = async (
   id: string,
   options: UpdateGatewayBudgetOptions,
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const onBreach: BudgetOnBreach | undefined = options.onBreach
@@ -60,19 +64,19 @@ export const updateGatewayBudgetCommand = async (
 
     spinner.succeed(`Updated budget "${chalk.cyan(budget.name)}"`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(budget, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`${chalk.bold("ID:")}       ${budget.id}`);
-    console.log(`${chalk.bold("Scope:")}    ${budget.scope_type.toLowerCase()}:${budget.scope_id}`);
-    console.log(`${chalk.bold("Window:")}   ${budget.window.toLowerCase()}`);
-    console.log(`${chalk.bold("Limit:")}    $${budget.limit_usd}`);
-    console.log(`${chalk.bold("Breach:")}   ${budget.on_breach.toLowerCase()}`);
-    console.log(`${chalk.bold("Timezone:")} ${budget.timezone ?? chalk.gray("—")}`);
-    console.log();
+    return {
+      data: budget,
+      table: () => {
+        console.log();
+        console.log(`${chalk.bold("ID:")}       ${budget.id}`);
+        console.log(`${chalk.bold("Scope:")}    ${budget.scope_type.toLowerCase()}:${budget.scope_id}`);
+        console.log(`${chalk.bold("Window:")}   ${budget.window.toLowerCase()}`);
+        console.log(`${chalk.bold("Limit:")}    $${budget.limit_usd}`);
+        console.log(`${chalk.bold("Breach:")}   ${budget.on_breach.toLowerCase()}`);
+        console.log(`${chalk.bold("Timezone:")} ${budget.timezone ?? chalk.gray("—")}`);
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "update gateway budget" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/graphs/create.ts
+++ b/typescript-sdk/src/cli/commands/graphs/create.ts
@@ -5,8 +5,13 @@ import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError } from "../../utils/errorOutput";
 import { buildAuthHeaders } from "@/internal/api/auth";
+import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+/**
+ * Returns the created graph rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts).
+ */
 export const createGraphCommand = async (
   name: string,
   options: {
@@ -15,9 +20,8 @@ export const createGraphCommand = async (
     filters?: string;
     colSpan?: string;
     rowSpan?: string;
-    format?: string;
   },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -56,15 +60,15 @@ export const createGraphCommand = async (
     const graph = await response.json() as { id: string; name: string; dashboardId: string | null };
     spinner.succeed(`Graph "${graph.name}" created (${graph.id})`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(graph, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`  ${chalk.gray("ID:")}        ${chalk.green(graph.id)}`);
-    console.log(`  ${chalk.gray("Dashboard:")} ${graph.dashboardId ?? chalk.gray("—")}`);
-    console.log();
+    return {
+      data: graph,
+      table: () => {
+        console.log();
+        console.log(`  ${chalk.gray("ID:")}        ${chalk.green(graph.id)}`);
+        console.log(`  ${chalk.gray("Dashboard:")} ${graph.dashboardId ?? chalk.gray("—")}`);
+        console.log();
+      },
+    };
   } catch (error) {
     // Route BOTH failure kinds through failSpinner: a direct spinner.fail()
     // prints nothing in --json/--jq/agent mode (spinners are silent there).

--- a/typescript-sdk/src/cli/commands/graphs/delete.ts
+++ b/typescript-sdk/src/cli/commands/graphs/delete.ts
@@ -3,12 +3,16 @@ import { checkApiKey } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
+import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+/**
+ * Returns the deletion outcome rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const deleteGraphCommand = async (
   id: string,
-  options?: { format?: string },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -31,9 +35,12 @@ export const deleteGraphCommand = async (
     const result = await response.json() as { id: string; deleted: boolean };
     spinner.succeed(`Graph "${id}" deleted`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-    }
+    return {
+      data: result,
+      table: () => {
+        // The spinner's success line is the human output.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "delete graph" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/graphs/get.ts
+++ b/typescript-sdk/src/cli/commands/graphs/get.ts
@@ -4,12 +4,16 @@ import { checkApiKey } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
+import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+/**
+ * Returns the graph rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts).
+ */
 export const getGraphCommand = async (
-  id: string,
-  options?: { format?: string }
-): Promise<void> => {
+  id: string
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -45,29 +49,29 @@ export const getGraphCommand = async (
 
     spinner.succeed(`Graph "${graph.name}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(graph, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`  ${chalk.gray("ID:")}        ${chalk.green(graph.id)}`);
-    console.log(`  ${chalk.gray("Name:")}      ${chalk.cyan(graph.name)}`);
-    console.log(
-      `  ${chalk.gray("Dashboard:")} ${graph.dashboardId ?? chalk.gray("—")}`
-    );
-    console.log(
-      `  ${chalk.gray("Position:")}  (${graph.gridColumn}, ${graph.gridRow})`
-    );
-    console.log(`  ${chalk.gray("Size:")}      ${graph.colSpan}x${graph.rowSpan}`);
-    if (graph.graph) {
-      const graphType = typeof graph.graph.type === "string" ? graph.graph.type : "custom";
-      console.log(`  ${chalk.gray("Type:")}      ${graphType}`);
-    }
-    console.log(
-      `  ${chalk.gray("Created:")}   ${new Date(graph.createdAt).toLocaleString()}`
-    );
-    console.log();
+    return {
+      data: graph,
+      table: () => {
+        console.log();
+        console.log(`  ${chalk.gray("ID:")}        ${chalk.green(graph.id)}`);
+        console.log(`  ${chalk.gray("Name:")}      ${chalk.cyan(graph.name)}`);
+        console.log(
+          `  ${chalk.gray("Dashboard:")} ${graph.dashboardId ?? chalk.gray("—")}`
+        );
+        console.log(
+          `  ${chalk.gray("Position:")}  (${graph.gridColumn}, ${graph.gridRow})`
+        );
+        console.log(`  ${chalk.gray("Size:")}      ${graph.colSpan}x${graph.rowSpan}`);
+        if (graph.graph) {
+          const graphType = typeof graph.graph.type === "string" ? graph.graph.type : "custom";
+          console.log(`  ${chalk.gray("Type:")}      ${graphType}`);
+        }
+        console.log(
+          `  ${chalk.gray("Created:")}   ${new Date(graph.createdAt).toLocaleString()}`
+        );
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch graph" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/graphs/list.ts
+++ b/typescript-sdk/src/cli/commands/graphs/list.ts
@@ -5,12 +5,17 @@ import { formatFetchError } from "../../utils/formatFetchError";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
+import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). The `table` closure
+ * is the human form, byte-identical to what this command printed before.
+ */
 export const listGraphsCommand = async (options: {
   dashboardId?: string;
-  format?: string;
-}): Promise<void> => {
+}): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -45,39 +50,39 @@ export const listGraphsCommand = async (options: {
 
     spinner.succeed(`Found ${graphs.length} graph${graphs.length !== 1 ? "s" : ""}`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(graphs, null, 2));
-      return;
-    }
+    return {
+      data: graphs,
+      table: () => {
+        if (graphs.length === 0) {
+          console.log();
+          console.log(chalk.gray("No graphs found."));
+          console.log(chalk.gray("Create one with:"));
+          console.log(chalk.cyan('  langwatch graph create "My Graph" --dashboard-id <id> --graph \'{"type":"line"}\''));
+          return;
+        }
 
-    if (graphs.length === 0) {
-      console.log();
-      console.log(chalk.gray("No graphs found."));
-      console.log(chalk.gray("Create one with:"));
-      console.log(chalk.cyan('  langwatch graph create "My Graph" --dashboard-id <id> --graph \'{"type":"line"}\''));
-      return;
-    }
+        console.log();
 
-    console.log();
+        const tableData = graphs.map((g) => ({
+          Name: g.name,
+          ID: g.id,
+          Dashboard: g.dashboardId ?? chalk.gray("—"),
+          Position: `(${g.gridColumn},${g.gridRow})`,
+          Size: `${g.colSpan}x${g.rowSpan}`,
+        }));
 
-    const tableData = graphs.map((g) => ({
-      Name: g.name,
-      ID: g.id,
-      Dashboard: g.dashboardId ?? chalk.gray("—"),
-      Position: `(${g.gridColumn},${g.gridRow})`,
-      Size: `${g.colSpan}x${g.rowSpan}`,
-    }));
+        formatTable({
+          data: tableData,
+          headers: ["Name", "ID", "Dashboard", "Position", "Size"],
+          colorMap: {
+            Name: chalk.cyan,
+            ID: chalk.green,
+          },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["Name", "ID", "Dashboard", "Position", "Size"],
-      colorMap: {
-        Name: chalk.cyan,
-        ID: chalk.green,
+        console.log();
       },
-    });
-
-    console.log();
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch graphs" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/graphs/update.ts
+++ b/typescript-sdk/src/cli/commands/graphs/update.ts
@@ -5,17 +5,21 @@ import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
 import { buildAuthHeaders } from "@/internal/api/auth";
+import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+/**
+ * Returns the updated graph rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts).
+ */
 export const updateGraphCommand = async (
   id: string,
   options: {
     name?: string;
     graph?: string;
     filters?: string;
-    format?: string;
   }
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   if (!options.name && !options.graph && !options.filters) {
@@ -64,15 +68,15 @@ export const updateGraphCommand = async (
     };
     spinner.succeed(`Graph "${graph.name}" updated`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(graph, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`  ${chalk.gray("ID:")}   ${chalk.green(graph.id)}`);
-    console.log(`  ${chalk.gray("Name:")} ${chalk.cyan(graph.name)}`);
-    console.log();
+    return {
+      data: graph,
+      table: () => {
+        console.log();
+        console.log(`  ${chalk.gray("ID:")}   ${chalk.green(graph.id)}`);
+        console.log(`  ${chalk.gray("Name:")} ${chalk.cyan(graph.name)}`);
+        console.log();
+      },
+    };
   } catch (error) {
     // Route BOTH failure kinds through failSpinner: a direct spinner.fail()
     // prints nothing in --json/--jq/agent mode (spinners are silent there).

--- a/typescript-sdk/src/cli/commands/help.ts
+++ b/typescript-sdk/src/cli/commands/help.ts
@@ -4,10 +4,17 @@
  * Commander's built-in help command is intercepted internally (it never runs
  * an action of ours), so program.ts registers this as a REAL `help` command:
  * a registered `help` suppresses the implicit one, and `help <word>` then
- * reaches this action. The only topic so far is `agent` — the page an AI
- * agent (or the person driving one) reads to learn how to drive this CLI
- * without human docs. Anything else delegates to the named command's own
- * help, which is what the built-in command did.
+ * reaches this action.
+ *
+ * Resolution order is COMMANDS FIRST, topics second — the same rule `gh`
+ * follows. A help topic must never be able to shadow a real command: the CLI
+ * registers a top-level `agent` group (agent definitions), so a topic also
+ * named `agent` made `langwatch help agent` unreachable for the group and
+ * silently swallowed `langwatch help agent list`. The topic is therefore
+ * `agent-mode`, and the lookup order makes the same mistake impossible for
+ * any topic added later. `HELP_TOPIC_NAMES` is asserted against the
+ * registered command tree in the unit test, so a future collision fails CI
+ * rather than shipping.
  */
 import type { Command } from "commander";
 import { AGENT_MODE_ENV_VARS } from "../utils/output";
@@ -71,17 +78,30 @@ PIPING RULES
 };
 
 /**
- * The `help` command action: the `agent` topic, or the named command's help.
+ * The help topics, keyed by the word the user types after `help`.
+ *
+ * Every name here MUST NOT match a registered command name or alias — a topic
+ * that collides is unreachable-by-design for the command it shadows. The unit
+ * test walks `buildProgram()` and fails on any overlap.
+ */
+export const HELP_TOPICS: Record<string, () => string> = {
+  "agent-mode": renderAgentHelpTopic,
+};
+
+export const HELP_TOPIC_NAMES = Object.keys(HELP_TOPICS);
+
+/**
+ * The `help` command action: the named command's help, else a help topic.
  * Extra words walk into nested commands, so `help trace search` shows the
  * search command's help (stock commander showed only the top level; `gh help
  * issue list` shows the nested one — we follow gh).
+ *
+ * Commands are resolved BEFORE topics so a real command can never be shadowed
+ * by a topic page. Topics are single-word only: `help agent-mode list` is an
+ * error, not a page with `list` quietly discarded.
  */
 export const helpCommand = (program: Command, topics: string[]): void => {
   const [topic, ...rest] = topics;
-  if (topic === "agent") {
-    console.log(renderAgentHelpTopic());
-    return;
-  }
   if (topic === undefined) {
     program.outputHelp();
     return;
@@ -93,6 +113,13 @@ export const helpCommand = (program: Command, topics: string[]): void => {
     target = target?.commands.find(
       (cmd) => cmd.name() === word || cmd.aliases().includes(word),
     );
+  }
+  if (!target && rest.length === 0) {
+    const renderTopic = HELP_TOPICS[topic];
+    if (renderTopic) {
+      console.log(renderTopic());
+      return;
+    }
   }
   if (!target) {
     // Mirror commander's own unknown-command error so scripts that probe

--- a/typescript-sdk/src/cli/commands/model-defaults/list.ts
+++ b/typescript-sdk/src/cli/commands/model-defaults/list.ts
@@ -6,10 +6,15 @@ import { ModelDefaultsApiService } from "@/client-sdk/services/model-defaults/mo
 import { checkApiKey } from "../../utils/apiKey";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const listModelDefaultsCommand = async (options?: {
-  format?: string;
-}): Promise<void> => {
+/**
+ * Returns the snapshot rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). `data` is the whole
+ * snapshot — effective resolution, configs AND the scope block the human view
+ * only shows in its spinner line.
+ */
+export const listModelDefaultsCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new ModelDefaultsApiService();
@@ -22,57 +27,57 @@ export const listModelDefaultsCommand = async (options?: {
       `Default-model snapshot for project ${chalk.cyan(snapshot.scope.projectId)}`,
     );
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(snapshot, null, 2));
-      return;
-    }
+    return {
+      data: snapshot,
+      table: () => {
+        console.log();
+        console.log(chalk.bold("Effective resolution"));
+        const effectiveRows = (
+          ["DEFAULT", "FAST", "EMBEDDINGS"] as const
+        ).map((role) => {
+          const hit = snapshot.effective[role];
+          return {
+            Role: role,
+            Model: hit ? chalk.green(hit.model) : chalk.gray("(unresolved)"),
+            From: hit?.scope ?? chalk.gray("—"),
+            Source: hit?.source ?? chalk.gray("—"),
+          };
+        });
+        formatTable({
+          data: effectiveRows,
+          headers: ["Role", "Model", "From", "Source"],
+        });
 
-    console.log();
-    console.log(chalk.bold("Effective resolution"));
-    const effectiveRows = (
-      ["DEFAULT", "FAST", "EMBEDDINGS"] as const
-    ).map((role) => {
-      const hit = snapshot.effective[role];
-      return {
-        Role: role,
-        Model: hit ? chalk.green(hit.model) : chalk.gray("(unresolved)"),
-        From: hit?.scope ?? chalk.gray("—"),
-        Source: hit?.source ?? chalk.gray("—"),
-      };
-    });
-    formatTable({
-      data: effectiveRows,
-      headers: ["Role", "Model", "From", "Source"],
-    });
+        console.log();
+        console.log(chalk.bold(`Configs (${snapshot.configs.length})`));
+        if (snapshot.configs.length === 0) {
+          console.log(
+            chalk.gray(
+              "  No configs at any readable scope. Set one with:",
+            ),
+          );
+          console.log(
+            chalk.cyan("    langwatch model-default set DEFAULT openai/gpt-5"),
+          );
+          console.log();
+          return;
+        }
 
-    console.log();
-    console.log(chalk.bold(`Configs (${snapshot.configs.length})`));
-    if (snapshot.configs.length === 0) {
-      console.log(
-        chalk.gray(
-          "  No configs at any readable scope. Set one with:",
-        ),
-      );
-      console.log(
-        chalk.cyan("    langwatch model-default set DEFAULT openai/gpt-5"),
-      );
-      console.log();
-      return;
-    }
-
-    for (const c of snapshot.configs) {
-      const scopesStr = c.scopes
-        .map((s) => `${s.type.toLowerCase()}:${s.name}`)
-        .join(", ");
-      console.log();
-      console.log(`  ${chalk.gray("ID:")}     ${chalk.green(c.id)}`);
-      console.log(`  ${chalk.gray("Scopes:")} ${scopesStr}`);
-      console.log(`  ${chalk.gray("Keys:")}`);
-      for (const [key, value] of Object.entries(c.config)) {
-        console.log(`    ${chalk.cyan(key.padEnd(20))} ${value}`);
-      }
-    }
-    console.log();
+        for (const c of snapshot.configs) {
+          const scopesStr = c.scopes
+            .map((s) => `${s.type.toLowerCase()}:${s.name}`)
+            .join(", ");
+          console.log();
+          console.log(`  ${chalk.gray("ID:")}     ${chalk.green(c.id)}`);
+          console.log(`  ${chalk.gray("Scopes:")} ${scopesStr}`);
+          console.log(`  ${chalk.gray("Keys:")}`);
+          for (const [key, value] of Object.entries(c.config)) {
+            console.log(`    ${chalk.cyan(key.padEnd(20))} ${value}`);
+          }
+        }
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch default models" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/model-defaults/set.ts
+++ b/typescript-sdk/src/cli/commands/model-defaults/set.ts
@@ -8,13 +8,13 @@ import {
 
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
 type ScopeKind = "project" | "team" | "organization";
 
 export interface SetModelDefaultOptions {
   scope?: ScopeKind;
   scopeId?: string;
-  format?: string;
 }
 
 function resolveScope(
@@ -56,12 +56,18 @@ function resolveScope(
  * key, or creates a new config when nothing is attached. Mirrors the
  * server-side `setRoleAtScope` upsert so CLI and UI converge on the
  * same single-config-per-scope shape.
+ *
+ * Returns what it did rather than printing it: the output port renders the
+ * result in whatever format the caller asked for (utils/output.ts). Both paths
+ * keep the shape the previous `--format json` branch established — including
+ * the `created` discriminator, which is the only way a machine caller can tell
+ * an upsert from a fresh config.
  */
 export const setModelDefaultCommand = async (
   key: string,
   model: string,
   options: SetModelDefaultOptions,
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new ModelDefaultsApiService();
@@ -91,16 +97,13 @@ export const setModelDefaultCommand = async (
       spinner.succeed(
         `Updated config ${chalk.green(current.id)} at ${target.scopeType.toLowerCase()}:${target.scopeId}`,
       );
-      if (options.format === "json") {
-        console.log(
-          JSON.stringify(
-            { id: current.id, key, model, scope: target, created: false },
-            null,
-            2,
-          ),
-        );
-      }
-      return;
+      return {
+        data: { id: current.id, key, model, scope: target, created: false },
+        table: () => {
+          // Nothing further to print: the spinner line above was the whole
+          // human output before the migration, and stays so.
+        },
+      };
     }
 
     const created = await service.createConfig({
@@ -110,15 +113,13 @@ export const setModelDefaultCommand = async (
     spinner.succeed(
       `Created config ${chalk.green(created.id)} at ${target.scopeType.toLowerCase()}:${target.scopeId}`,
     );
-    if (options.format === "json") {
-      console.log(
-        JSON.stringify(
-          { id: created.id, key, model, scope: target, created: true },
-          null,
-          2,
-        ),
-      );
-    }
+    return {
+      data: { id: created.id, key, model, scope: target, created: true },
+      table: () => {
+        // Nothing further to print: the spinner line above was the whole
+        // human output before the migration, and stays so.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "set default model" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/model-defaults/unset.ts
+++ b/typescript-sdk/src/cli/commands/model-defaults/unset.ts
@@ -8,13 +8,13 @@ import {
 
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
 type ScopeKind = "project" | "team" | "organization";
 
 export interface UnsetModelDefaultOptions {
   scope?: ScopeKind;
   scopeId?: string;
-  format?: string;
 }
 
 function resolveScope(
@@ -54,11 +54,18 @@ function resolveScope(
  * If the config has no other keys left, deletes it outright — an empty
  * config doesn't carry any cascade signal and occupies the same-scope
  * tiebreak slot.
+ *
+ * Returns what it did rather than printing it: the output port renders the
+ * result in whatever format the caller asked for (utils/output.ts). The two
+ * mutating paths keep the shape the previous `--format json` branch
+ * established. The no-op path used to emit NOTHING in json mode — a silent
+ * exit 0 that a machine caller could not distinguish from a successful
+ * removal — so it now answers the same shape carrying `noop: true`.
  */
 export const unsetModelDefaultCommand = async (
   key: string,
   options: UnsetModelDefaultOptions,
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new ModelDefaultsApiService();
@@ -78,7 +85,13 @@ export const unsetModelDefaultCommand = async (
       spinner.succeed(
         `No ${chalk.cyan(key)} entry at ${target.scopeType.toLowerCase()}:${target.scopeId}; nothing to do.`,
       );
-      return;
+      return {
+        data: { id: null, key, scope: target, deleted: false, noop: true },
+        table: () => {
+          // Nothing further to print: the spinner line above was the whole
+          // human output before the migration, and stays so.
+        },
+      };
     }
 
     const sorted = [...existing].sort((a, b) =>
@@ -93,31 +106,26 @@ export const unsetModelDefaultCommand = async (
       spinner.succeed(
         `Deleted config ${chalk.green(current.id)} (no keys left) at ${target.scopeType.toLowerCase()}:${target.scopeId}`,
       );
-      if (options.format === "json") {
-        console.log(
-          JSON.stringify(
-            { id: current.id, key, scope: target, deleted: true },
-            null,
-            2,
-          ),
-        );
-      }
-      return;
+      return {
+        data: { id: current.id, key, scope: target, deleted: true, noop: false },
+        table: () => {
+          // Nothing further to print: the spinner line above was the whole
+          // human output before the migration, and stays so.
+        },
+      };
     }
 
     await service.updateConfig(current.id, { config: nextPayload });
     spinner.succeed(
       `Removed ${chalk.cyan(key)} from config ${chalk.green(current.id)} at ${target.scopeType.toLowerCase()}:${target.scopeId}`,
     );
-    if (options.format === "json") {
-      console.log(
-        JSON.stringify(
-          { id: current.id, key, scope: target, deleted: false },
-          null,
-          2,
-        ),
-      );
-    }
+    return {
+      data: { id: current.id, key, scope: target, deleted: false, noop: false },
+      table: () => {
+        // Nothing further to print: the spinner line above was the whole
+        // human output before the migration, and stays so.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "unset default model" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/model-providers/__tests__/model-provider-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/model-providers/__tests__/model-provider-commands.unit.test.ts
@@ -80,16 +80,17 @@ describe("listModelProvidersCommand()", () => {
     });
   });
 
-  describe("when format is json", () => {
-    it("outputs raw JSON", async () => {
+  describe("when a machine format is requested", () => {
+    it("returns the raw provider map as the payload instead of printing", async () => {
       const providers = { openai: { provider: "openai", enabled: true, customKeys: {} } };
       mockList.mockResolvedValue(providers);
 
-      await listModelProvidersCommand({ format: "json" });
+      const result = await listModelProvidersCommand();
 
-      expect(console.log).toHaveBeenCalledWith(
-        JSON.stringify(providers, null, 2),
-      );
+      // The command no longer decides the format — it hands the payload to
+      // the output port, which renders json/yaml/agents/--jq from this value.
+      expect(result?.data).toEqual(providers);
+      expect(console.log).not.toHaveBeenCalled();
     });
   });
 

--- a/typescript-sdk/src/cli/commands/model-providers/list.ts
+++ b/typescript-sdk/src/cli/commands/model-providers/list.ts
@@ -4,8 +4,19 @@ import { ModelProvidersApiService } from "@/client-sdk/services/model-providers/
 import { checkApiKey } from "../../utils/apiKey";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const listModelProvidersCommand = async (options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the provider map rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts).
+ *
+ * `customKeys` reaches us already masked — `GET /api/model-providers` answers
+ * from `getProjectModelProvidersForFrontend`, which runs `maskApiKeys` before
+ * serialising — so the raw response carries no key material and needs no
+ * further redaction here. The human table only says whether keys EXIST, and
+ * that stays true of the machine payload.
+ */
+export const listModelProvidersCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new ModelProvidersApiService();
@@ -19,44 +30,44 @@ export const listModelProvidersCommand = async (options?: { format?: string }): 
 
     spinner.succeed(`Found ${providerEntries.length} model provider${providerEntries.length !== 1 ? "s" : ""}`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(providers, null, 2));
-      return;
-    }
+    return {
+      data: providers,
+      table: () => {
+        if (providerEntries.length === 0) {
+          console.log();
+          console.log(chalk.gray("No model providers configured."));
+          console.log(chalk.gray("Set one up with:"));
+          console.log(
+            chalk.cyan('  langwatch model-provider set openai --enabled true'),
+          );
+          return;
+        }
 
-    if (providerEntries.length === 0) {
-      console.log();
-      console.log(chalk.gray("No model providers configured."));
-      console.log(chalk.gray("Set one up with:"));
-      console.log(
-        chalk.cyan('  langwatch model-provider set openai --enabled true'),
-      );
-      return;
-    }
+        console.log();
 
-    console.log();
+        const tableData = providerEntries.map(([key, p]) => ({
+          Provider: p.provider ?? key,
+          Enabled: p.enabled ? chalk.green("✓") : chalk.red("✗"),
+          "Default Model": "—",
+          "Has Keys": p.customKeys && Object.keys(p.customKeys).length > 0 ? chalk.green("✓") : chalk.gray("—"),
+        }));
 
-    const tableData = providerEntries.map(([key, p]) => ({
-      Provider: p.provider ?? key,
-      Enabled: p.enabled ? chalk.green("✓") : chalk.red("✗"),
-      "Default Model": "—",
-      "Has Keys": p.customKeys && Object.keys(p.customKeys).length > 0 ? chalk.green("✓") : chalk.gray("—"),
-    }));
+        formatTable({
+          data: tableData,
+          headers: ["Provider", "Enabled", "Default Model", "Has Keys"],
+          colorMap: {
+            Provider: chalk.cyan,
+          },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["Provider", "Enabled", "Default Model", "Has Keys"],
-      colorMap: {
-        Provider: chalk.cyan,
+        console.log();
+        console.log(
+          chalk.gray(
+            `Use ${chalk.cyan("langwatch model-provider set <provider> --enabled true")} to configure a provider`,
+          ),
+        );
       },
-    });
-
-    console.log();
-    console.log(
-      chalk.gray(
-        `Use ${chalk.cyan("langwatch model-provider set <provider> --enabled true")} to configure a provider`,
-      ),
-    );
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch model providers" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/model-providers/set.ts
+++ b/typescript-sdk/src/cli/commands/model-providers/set.ts
@@ -3,11 +3,24 @@ import { createSpinner } from "../../utils/spinner";
 import { ModelProvidersApiService } from "@/client-sdk/services/model-providers/model-providers-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns what was configured rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ *
+ * `data` keeps the shape the previous `--format json` branch established, which
+ * deliberately does NOT echo `options.apiKey`. That value is key material the
+ * caller supplied on the command line; the human output never showed it, and a
+ * machine payload — far more likely to be logged or piped into an agent's
+ * context — must not reintroduce it. The service's own response is not used
+ * for the same reason: it is the whole provider map, and re-emitting every
+ * provider's entry is more than this command was asked about.
+ */
 export const setModelProviderCommand = async (
   provider: string,
-  options: { enabled?: boolean; apiKey?: string; defaultModel?: string; format?: string },
-): Promise<void> => {
+  options: { enabled?: boolean; apiKey?: string; defaultModel?: string },
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new ModelProvidersApiService();
@@ -39,9 +52,17 @@ export const setModelProviderCommand = async (
       `Configured model provider "${chalk.cyan(provider)}"`,
     );
 
-    if (options.format === "json") {
-      console.log(JSON.stringify({ provider, enabled: options.enabled ?? true, defaultModel: options.defaultModel ?? null }, null, 2));
-    }
+    return {
+      data: {
+        provider,
+        enabled: options.enabled ?? true,
+        defaultModel: options.defaultModel ?? null,
+      },
+      table: () => {
+        // Nothing further to print: the spinner line above was the whole
+        // human output before the migration, and stays so.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "configure model provider" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/monitors/__tests__/monitor-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/monitors/__tests__/monitor-commands.unit.test.ts
@@ -77,16 +77,21 @@ describe("listMonitorsCommand()", () => {
     );
   });
 
-  it("outputs JSON when format is json", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => [makeMonitor()],
-    });
+  describe("when a machine format is requested", () => {
+    it("returns the raw monitor list as the payload instead of printing", async () => {
+      const monitors = [makeMonitor()];
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => monitors,
+      });
 
-    await listMonitorsCommand({ format: "json" });
-    expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining("Toxicity Check")
-    );
+      const result = await listMonitorsCommand();
+
+      // The command no longer decides the format — it hands the payload to
+      // the output port, which renders json/yaml/agents/--jq from this value.
+      expect(result?.data).toEqual(monitors);
+      expect(console.log).not.toHaveBeenCalled();
+    });
   });
 
   it("exits on API error", async () => {

--- a/typescript-sdk/src/cli/commands/monitors/create.ts
+++ b/typescript-sdk/src/cli/commands/monitors/create.ts
@@ -4,10 +4,14 @@ import { checkApiKey } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
-import { printResult, type RawOutputFlags } from "../../utils/output";
+import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+/**
+ * Returns the created monitor rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const createMonitorCommand = async (
   name: string,
   options: {
@@ -17,8 +21,8 @@ export const createMonitorCommand = async (
     evaluatorId?: string;
     level?: string;
     parameters?: string;
-  } & RawOutputFlags
-): Promise<void> => {
+  }
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const validModes = ["ON_MESSAGE", "AS_GUARDRAIL", "MANUALLY"];
@@ -100,10 +104,8 @@ export const createMonitorCommand = async (
     process.exit(1);
   }
 
-  // Rendering stays OUTSIDE the create try: a printResult rejection (invalid
-  // --jq) must not report an already-created monitor as a create failure.
-  await printResult(monitor, {
-    ...options,
+  return {
+    data: monitor,
     table: () => {
       console.log();
       console.log(`  ${chalk.gray("ID:")}   ${chalk.green(monitor.id)}`);
@@ -114,5 +116,5 @@ export const createMonitorCommand = async (
       }
       console.log();
     },
-  });
+  };
 };

--- a/typescript-sdk/src/cli/commands/monitors/delete.ts
+++ b/typescript-sdk/src/cli/commands/monitors/delete.ts
@@ -2,14 +2,17 @@ import { createSpinner } from "../../utils/spinner";
 import { checkApiKey } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { printResult, type RawOutputFlags } from "../../utils/output";
+import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+/**
+ * Returns the deletion outcome rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const deleteMonitorCommand = async (
-  id: string,
-  options?: RawOutputFlags
-): Promise<void> => {
+  id: string
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -47,12 +50,10 @@ export const deleteMonitorCommand = async (
     process.exit(1);
   }
 
-  // Rendering stays OUTSIDE the delete try: a printResult rejection (invalid
-  // --jq) must not report an already-deleted monitor as a delete failure.
-  await printResult(result, {
-    ...options,
+  return {
+    data: result,
     table: () => {
       // The spinner's success line is the human output.
     },
-  });
+  };
 };

--- a/typescript-sdk/src/cli/commands/monitors/get.ts
+++ b/typescript-sdk/src/cli/commands/monitors/get.ts
@@ -3,14 +3,17 @@ import { createSpinner } from "../../utils/spinner";
 import { checkApiKey } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { printResult, type RawOutputFlags } from "../../utils/output";
+import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+/**
+ * Returns the monitor rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts).
+ */
 export const getMonitorCommand = async (
-  id: string,
-  options?: RawOutputFlags
-): Promise<void> => {
+  id: string
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -67,34 +70,32 @@ export const getMonitorCommand = async (
     process.exit(1);
   }
 
-  // Rendering stays OUTSIDE the fetch try: a printResult rejection (invalid
-  // --jq) is a rendering failure, not a fetch failure.
-  await printResult(monitor, {
-      ...options,
-      table: () => {
-        console.log();
-        console.log(`  ${chalk.gray("ID:")}        ${chalk.green(monitor.id)}`);
-        console.log(`  ${chalk.gray("Name:")}      ${chalk.cyan(monitor.name)}`);
-        console.log(`  ${chalk.gray("Slug:")}      ${monitor.slug}`);
-        console.log(`  ${chalk.gray("Type:")}      ${monitor.checkType}`);
+  return {
+    data: monitor,
+    table: () => {
+      console.log();
+      console.log(`  ${chalk.gray("ID:")}        ${chalk.green(monitor.id)}`);
+      console.log(`  ${chalk.gray("Name:")}      ${chalk.cyan(monitor.name)}`);
+      console.log(`  ${chalk.gray("Slug:")}      ${monitor.slug}`);
+      console.log(`  ${chalk.gray("Type:")}      ${monitor.checkType}`);
+      console.log(
+        `  ${chalk.gray("Status:")}    ${monitor.enabled ? chalk.green("enabled") : chalk.gray("disabled")}`
+      );
+      console.log(`  ${chalk.gray("Mode:")}      ${monitor.executionMode}`);
+      console.log(`  ${chalk.gray("Sample:")}    ${Math.round(monitor.sample * 100)}%`);
+      console.log(`  ${chalk.gray("Level:")}     ${monitor.level}`);
+      if (monitor.evaluatorId) {
         console.log(
-          `  ${chalk.gray("Status:")}    ${monitor.enabled ? chalk.green("enabled") : chalk.gray("disabled")}`
+          `  ${chalk.gray("Evaluator:")} ${monitor.evaluatorId}`
         );
-        console.log(`  ${chalk.gray("Mode:")}      ${monitor.executionMode}`);
-        console.log(`  ${chalk.gray("Sample:")}    ${Math.round(monitor.sample * 100)}%`);
-        console.log(`  ${chalk.gray("Level:")}     ${monitor.level}`);
-        if (monitor.evaluatorId) {
-          console.log(
-            `  ${chalk.gray("Evaluator:")} ${monitor.evaluatorId}`
-          );
-        }
-        console.log(
-          `  ${chalk.gray("Created:")}   ${new Date(monitor.createdAt).toLocaleString()}`
-        );
-        if (monitor.platformUrl) {
-          console.log(`  ${chalk.bold("View:")}     ${chalk.underline(monitor.platformUrl)}`);
-        }
-        console.log();
-      },
-    });
+      }
+      console.log(
+        `  ${chalk.gray("Created:")}   ${new Date(monitor.createdAt).toLocaleString()}`
+      );
+      if (monitor.platformUrl) {
+        console.log(`  ${chalk.bold("View:")}     ${chalk.underline(monitor.platformUrl)}`);
+      }
+      console.log();
+    },
+  };
 };

--- a/typescript-sdk/src/cli/commands/monitors/list.ts
+++ b/typescript-sdk/src/cli/commands/monitors/list.ts
@@ -4,11 +4,16 @@ import { checkApiKey } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
-import { printResult, type RawOutputFlags } from "../../utils/output";
+import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
-export const listMonitorsCommand = async (options?: RawOutputFlags): Promise<void> => {
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). The `table` closure
+ * is the human form, byte-identical to what this command printed before.
+ */
+export const listMonitorsCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -55,44 +60,42 @@ export const listMonitorsCommand = async (options?: RawOutputFlags): Promise<voi
     process.exit(1);
   }
 
-  // Rendering stays OUTSIDE the fetch try: a printResult rejection (invalid
-  // --jq) is a rendering failure, not a fetch failure.
-  await printResult(monitors, {
-      ...options,
-      table: () => {
-        if (monitors.length === 0) {
-          console.log();
-          console.log(chalk.gray("No monitors found."));
-          console.log(chalk.gray("Create one with:"));
-          console.log(
-            chalk.cyan(
-              '  langwatch monitor create "Toxicity Check" --check-type ragas/toxicity'
-            )
-          );
-          return;
-        }
-
+  return {
+    data: monitors,
+    table: () => {
+      if (monitors.length === 0) {
         console.log();
+        console.log(chalk.gray("No monitors found."));
+        console.log(chalk.gray("Create one with:"));
+        console.log(
+          chalk.cyan(
+            '  langwatch monitor create "Toxicity Check" --check-type ragas/toxicity'
+          )
+        );
+        return;
+      }
 
-        const tableData = monitors.map((m) => ({
-          Name: m.name,
-          ID: m.id,
-          Type: m.checkType,
-          Mode: m.executionMode,
-          Status: m.enabled ? chalk.green("enabled") : chalk.gray("disabled"),
-          Sample: `${Math.round(m.sample * 100)}%`,
-        }));
+      console.log();
 
-        formatTable({
-          data: tableData,
-          headers: ["Name", "ID", "Type", "Mode", "Status", "Sample"],
-          colorMap: {
-            Name: chalk.cyan,
-            ID: chalk.green,
-          },
-        });
+      const tableData = monitors.map((m) => ({
+        Name: m.name,
+        ID: m.id,
+        Type: m.checkType,
+        Mode: m.executionMode,
+        Status: m.enabled ? chalk.green("enabled") : chalk.gray("disabled"),
+        Sample: `${Math.round(m.sample * 100)}%`,
+      }));
 
-        console.log();
-      },
-    });
+      formatTable({
+        data: tableData,
+        headers: ["Name", "ID", "Type", "Mode", "Status", "Sample"],
+        colorMap: {
+          Name: chalk.cyan,
+          ID: chalk.green,
+        },
+      });
+
+      console.log();
+    },
+  };
 };

--- a/typescript-sdk/src/cli/commands/monitors/update.ts
+++ b/typescript-sdk/src/cli/commands/monitors/update.ts
@@ -4,10 +4,14 @@ import { checkApiKey } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError } from "../../utils/errorOutput";
-import { printResult, type RawOutputFlags } from "../../utils/output";
+import type { CommandResult } from "../../utils/output";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+/**
+ * Returns the updated monitor rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const updateMonitorCommand = async (
   id: string,
   options: {
@@ -16,8 +20,8 @@ export const updateMonitorCommand = async (
     executionMode?: string;
     sample?: string;
     parameters?: string;
-  } & RawOutputFlags
-): Promise<void> => {
+  }
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -84,10 +88,8 @@ export const updateMonitorCommand = async (
     process.exit(1);
   }
 
-  // Rendering stays OUTSIDE the update try: a printResult rejection (invalid
-  // --jq) must not report an already-updated monitor as an update failure.
-  await printResult(monitor, {
-    ...options,
+  return {
+    data: monitor,
     table: () => {
       console.log();
       console.log(`  ${chalk.gray("ID:")}      ${chalk.green(monitor.id)}`);
@@ -97,5 +99,5 @@ export const updateMonitorCommand = async (
       );
       console.log();
     },
-  });
+  };
 };

--- a/typescript-sdk/src/cli/commands/projects/create.ts
+++ b/typescript-sdk/src/cli/commands/projects/create.ts
@@ -3,6 +3,7 @@ import { createSpinner } from "../../utils/spinner";
 import { ProjectsApiService } from "@/client-sdk/services/projects/projects-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
 export interface CreateProjectOptions {
   name: string;
@@ -10,10 +11,20 @@ export interface CreateProjectOptions {
   framework: string;
   teamId?: string;
   newTeamName?: string;
-  format?: string;
 }
 
-export const createProjectCommand = async (options: CreateProjectOptions): Promise<void> => {
+/**
+ * Returns the created project rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ *
+ * `data` is the raw project, which includes the one-time `serviceApiKey`. That
+ * is the whole point of the create response — the server never returns the key
+ * again — so both the human output and the previous `--format json` branch
+ * emitted it in full, and a scripted caller needs it to be usable at all.
+ */
+export const createProjectCommand = async (
+  options: CreateProjectOptions,
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   if (!options.name) {
@@ -47,23 +58,23 @@ export const createProjectCommand = async (options: CreateProjectOptions): Promi
 
     spinner.succeed(`Created project "${chalk.cyan(project.name)}"`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(project, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(chalk.bold.yellow("⚠  Save the service API key below NOW. It will not be shown again."));
-    console.log();
-    console.log(`  ${chalk.green(project.serviceApiKey)}`);
-    console.log();
-    console.log(chalk.gray("Use it to authenticate project-scoped operations:"));
-    console.log(chalk.cyan(`  export LANGWATCH_API_KEY="${project.serviceApiKey}"`));
-    console.log();
-    console.log(chalk.gray("Project id:         ") + project.id);
-    console.log(chalk.gray("Slug:               ") + project.slug);
-    console.log(chalk.gray("Service API key id: ") + project.serviceApiKeyId);
-    console.log();
+    return {
+      data: project,
+      table: () => {
+        console.log();
+        console.log(chalk.bold.yellow("⚠  Save the service API key below NOW. It will not be shown again."));
+        console.log();
+        console.log(`  ${chalk.green(project.serviceApiKey)}`);
+        console.log();
+        console.log(chalk.gray("Use it to authenticate project-scoped operations:"));
+        console.log(chalk.cyan(`  export LANGWATCH_API_KEY="${project.serviceApiKey}"`));
+        console.log();
+        console.log(chalk.gray("Project id:         ") + project.id);
+        console.log(chalk.gray("Slug:               ") + project.slug);
+        console.log(chalk.gray("Service API key id: ") + project.serviceApiKeyId);
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "create project" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/projects/create.ts
+++ b/typescript-sdk/src/cli/commands/projects/create.ts
@@ -58,6 +58,14 @@ export const createProjectCommand = async (
 
     spinner.succeed(`Created project "${chalk.cyan(project.name)}"`);
 
+    // The service API key is one-time — the server never returns it again — so
+    // the warning must reach the caller in EVERY format, not only the table.
+    // stderr keeps it outside the machine document, so a parser reading stdout
+    // is unaffected while the human still gets told.
+    process.stderr.write(
+      "warning: the service API key is shown once and cannot be retrieved again — save it now.\n",
+    );
+
     return {
       data: project,
       table: () => {

--- a/typescript-sdk/src/cli/commands/projects/delete.ts
+++ b/typescript-sdk/src/cli/commands/projects/delete.ts
@@ -3,11 +3,15 @@ import { createSpinner } from "../../utils/spinner";
 import { ProjectsApiService } from "@/client-sdk/services/projects/projects-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the archived project rather than printing it: the output port
+ * renders it in whatever format the caller asked for (utils/output.ts).
+ */
 export const deleteProjectCommand = async (
   id: string,
-  options?: { format?: string },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new ProjectsApiService();
@@ -18,15 +22,15 @@ export const deleteProjectCommand = async (
 
     spinner.succeed(`Archived project "${chalk.cyan(result.name)}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(chalk.gray("Project has been archived (soft-deleted)."));
-    console.log(chalk.gray("Archived at: ") + new Date(result.archivedAt).toLocaleString());
-    console.log();
+    return {
+      data: result,
+      table: () => {
+        console.log();
+        console.log(chalk.gray("Project has been archived (soft-deleted)."));
+        console.log(chalk.gray("Archived at: ") + new Date(result.archivedAt).toLocaleString());
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "archive project" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/projects/get.ts
+++ b/typescript-sdk/src/cli/commands/projects/get.ts
@@ -3,8 +3,15 @@ import { createSpinner } from "../../utils/spinner";
 import { ProjectsApiService } from "@/client-sdk/services/projects/projects-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
-export const getProjectCommand = async (id: string, options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the project rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts).
+ */
+export const getProjectCommand = async (
+  id: string,
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new ProjectsApiService();
@@ -15,22 +22,22 @@ export const getProjectCommand = async (id: string, options?: { format?: string 
 
     spinner.succeed(`Fetched project "${chalk.cyan(project.name)}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(project, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`${chalk.bold("ID:")}              ${project.id}`);
-    console.log(`${chalk.bold("Name:")}            ${chalk.cyan(project.name)}`);
-    console.log(`${chalk.bold("Slug:")}            ${project.slug}`);
-    console.log(`${chalk.bold("Language:")}        ${project.language}`);
-    console.log(`${chalk.bold("Framework:")}       ${project.framework}`);
-    console.log(`${chalk.bold("Team ID:")}         ${project.teamId}`);
-    console.log(`${chalk.bold("PII Redaction:")}   ${project.piiRedactionLevel}`);
-    console.log(`${chalk.bold("Created:")}         ${new Date(project.createdAt).toLocaleString()}`);
-    console.log(`${chalk.bold("Updated:")}         ${new Date(project.updatedAt).toLocaleString()}`);
-    console.log();
+    return {
+      data: project,
+      table: () => {
+        console.log();
+        console.log(`${chalk.bold("ID:")}              ${project.id}`);
+        console.log(`${chalk.bold("Name:")}            ${chalk.cyan(project.name)}`);
+        console.log(`${chalk.bold("Slug:")}            ${project.slug}`);
+        console.log(`${chalk.bold("Language:")}        ${project.language}`);
+        console.log(`${chalk.bold("Framework:")}       ${project.framework}`);
+        console.log(`${chalk.bold("Team ID:")}         ${project.teamId}`);
+        console.log(`${chalk.bold("PII Redaction:")}   ${project.piiRedactionLevel}`);
+        console.log(`${chalk.bold("Created:")}         ${new Date(project.createdAt).toLocaleString()}`);
+        console.log(`${chalk.bold("Updated:")}         ${new Date(project.updatedAt).toLocaleString()}`);
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch project" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/projects/list.ts
+++ b/typescript-sdk/src/cli/commands/projects/list.ts
@@ -4,12 +4,18 @@ import { ProjectsApiService } from "@/client-sdk/services/projects/projects-api.
 import { checkApiKey } from "../../utils/apiKey";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). `data` is the full
+ * paginated response, so a machine caller keeps the pagination cursor the
+ * table only summarises in its spinner line.
+ */
 export const listProjectsCommand = async (options?: {
   page?: number;
   limit?: number;
-  format?: string;
-}): Promise<void> => {
+}): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new ProjectsApiService();
@@ -20,45 +26,45 @@ export const listProjectsCommand = async (options?: {
 
     spinner.succeed(`Found ${result.data.length} project${result.data.length !== 1 ? "s" : ""} (page ${result.pagination.page}/${result.pagination.totalPages})`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-      return;
-    }
+    return {
+      data: result,
+      table: () => {
+        if (result.data.length === 0) {
+          console.log();
+          console.log(chalk.gray("No projects yet."));
+          console.log(chalk.gray("Create one with:"));
+          console.log(chalk.cyan('  langwatch projects create --name "my-project" --language python --framework langchain --new-team-name "my-team"'));
+          return;
+        }
 
-    if (result.data.length === 0) {
-      console.log();
-      console.log(chalk.gray("No projects yet."));
-      console.log(chalk.gray("Create one with:"));
-      console.log(chalk.cyan('  langwatch projects create --name "my-project" --language python --framework langchain --new-team-name "my-team"'));
-      return;
-    }
+        console.log();
 
-    console.log();
+        const tableData = result.data.map((p) => ({
+          ID: p.id,
+          Name: p.name,
+          Slug: p.slug,
+          Language: p.language,
+          Framework: p.framework,
+          Created: new Date(p.createdAt).toLocaleDateString(),
+        }));
 
-    const tableData = result.data.map((p) => ({
-      ID: p.id,
-      Name: p.name,
-      Slug: p.slug,
-      Language: p.language,
-      Framework: p.framework,
-      Created: new Date(p.createdAt).toLocaleDateString(),
-    }));
+        formatTable({
+          data: tableData,
+          headers: ["ID", "Name", "Slug", "Language", "Framework", "Created"],
+          colorMap: {
+            Name: chalk.cyan,
+            ID: chalk.gray,
+          },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["ID", "Name", "Slug", "Language", "Framework", "Created"],
-      colorMap: {
-        Name: chalk.cyan,
-        ID: chalk.gray,
+        console.log();
+        console.log(
+          chalk.gray(
+            `Use ${chalk.cyan("langwatch projects get <id>")} to see full project details.`,
+          ),
+        );
       },
-    });
-
-    console.log();
-    console.log(
-      chalk.gray(
-        `Use ${chalk.cyan("langwatch projects get <id>")} to see full project details.`,
-      ),
-    );
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch projects" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/projects/update.ts
+++ b/typescript-sdk/src/cli/commands/projects/update.ts
@@ -3,19 +3,23 @@ import { createSpinner } from "../../utils/spinner";
 import { ProjectsApiService } from "@/client-sdk/services/projects/projects-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
 export interface UpdateProjectOptions {
   name?: string;
   language?: string;
   framework?: string;
   piiRedactionLevel?: "STRICT" | "ESSENTIAL" | "DISABLED";
-  format?: string;
 }
 
+/**
+ * Returns the updated project rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const updateProjectCommand = async (
   id: string,
   options: UpdateProjectOptions,
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const noFieldsProvided =
@@ -46,20 +50,20 @@ export const updateProjectCommand = async (
 
     spinner.succeed(`Updated project "${chalk.cyan(updated.name)}"`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(updated, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`${chalk.bold("ID:")}              ${updated.id}`);
-    console.log(`${chalk.bold("Name:")}            ${chalk.cyan(updated.name)}`);
-    console.log(`${chalk.bold("Slug:")}            ${updated.slug}`);
-    console.log(`${chalk.bold("Language:")}        ${updated.language}`);
-    console.log(`${chalk.bold("Framework:")}       ${updated.framework}`);
-    console.log(`${chalk.bold("PII Redaction:")}   ${updated.piiRedactionLevel}`);
-    console.log(`${chalk.bold("Updated:")}         ${new Date(updated.updatedAt).toLocaleString()}`);
-    console.log();
+    return {
+      data: updated,
+      table: () => {
+        console.log();
+        console.log(`${chalk.bold("ID:")}              ${updated.id}`);
+        console.log(`${chalk.bold("Name:")}            ${chalk.cyan(updated.name)}`);
+        console.log(`${chalk.bold("Slug:")}            ${updated.slug}`);
+        console.log(`${chalk.bold("Language:")}        ${updated.language}`);
+        console.log(`${chalk.bold("Framework:")}       ${updated.framework}`);
+        console.log(`${chalk.bold("PII Redaction:")}   ${updated.piiRedactionLevel}`);
+        console.log(`${chalk.bold("Updated:")}         ${new Date(updated.updatedAt).toLocaleString()}`);
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "update project" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/secrets/__tests__/secret-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/secrets/__tests__/secret-commands.unit.test.ts
@@ -68,16 +68,19 @@ describe("listSecretsCommand()", () => {
     );
   });
 
-  it("outputs JSON when format is json", async () => {
+  it("returns the raw secret list as the machine payload", async () => {
+    const secrets = [makeSecret()];
     mockFetch.mockResolvedValue({
       ok: true,
-      json: async () => [makeSecret()],
+      json: async () => secrets,
     });
 
-    await listSecretsCommand({ format: "json" });
-    expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining("MY_API_KEY")
-    );
+    const result = await listSecretsCommand();
+
+    // The command no longer decides the format — it hands the payload to the
+    // output port, which renders json/yaml/agents/--jq from this one value.
+    expect(result?.data).toEqual(secrets);
+    expect(console.log).not.toHaveBeenCalled();
   });
 
   it("exits on API error", async () => {

--- a/typescript-sdk/src/cli/commands/secrets/create.ts
+++ b/typescript-sdk/src/cli/commands/secrets/create.ts
@@ -7,10 +7,22 @@ import { commandValidationError, reportCommandError } from "../../utils/errorOut
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the created secret's metadata rather than printing it: the output
+ * port renders it in whatever format the caller asked for (utils/output.ts).
+ *
+ * `data` is `{ id, name }` — the whole create response. The VALUE the caller
+ * passed in `--value` is never echoed back by the server and is never put in
+ * the payload here: unlike an API key or virtual key, the caller already holds
+ * this secret, so there is nothing a machine caller gains from re-emitting it
+ * and a great deal it risks.
+ */
 export const createSecretCommand = async (
   name: string,
-  options: { value: string; format?: string }
-): Promise<void> => {
+  options: { value: string }
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   if (!/^[A-Z][A-Z0-9_]*$/.test(name)) {
@@ -51,15 +63,15 @@ export const createSecretCommand = async (
 
     spinner.succeed(`Secret "${secret.name}" created (${secret.id})`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(secret, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`  ${chalk.gray("ID:")}   ${chalk.green(secret.id)}`);
-    console.log(`  ${chalk.gray("Name:")} ${chalk.cyan(secret.name)}`);
-    console.log();
+    return {
+      data: secret,
+      table: () => {
+        console.log();
+        console.log(`  ${chalk.gray("ID:")}   ${chalk.green(secret.id)}`);
+        console.log(`  ${chalk.gray("Name:")} ${chalk.cyan(secret.name)}`);
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "create secret" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/secrets/delete.ts
+++ b/typescript-sdk/src/cli/commands/secrets/delete.ts
@@ -5,10 +5,15 @@ import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the deletion result rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const deleteSecretCommand = async (
   id: string,
-  options?: { format?: string }
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -36,9 +41,13 @@ export const deleteSecretCommand = async (
 
     spinner.succeed(`Secret deleted (${result.id})`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-    }
+    return {
+      data: result,
+      table: () => {
+        // Nothing further to print: the spinner line above was the whole
+        // human output before the migration, and stays so.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "delete secret" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/secrets/get.ts
+++ b/typescript-sdk/src/cli/commands/secrets/get.ts
@@ -6,10 +6,17 @@ import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the secret's metadata rather than printing it: the output port
+ * renders it in whatever format the caller asked for (utils/output.ts). The
+ * endpoint never returns the VALUE — that is what the human view's closing
+ * note says — so the raw record is metadata only and safe as a payload.
+ */
 export const getSecretCommand = async (
   id: string,
-  options?: { format?: string }
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -39,25 +46,25 @@ export const getSecretCommand = async (
 
     spinner.succeed(`Secret "${secret.name}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(secret, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`  ${chalk.gray("ID:")}      ${chalk.green(secret.id)}`);
-    console.log(`  ${chalk.gray("Name:")}    ${chalk.cyan(secret.name)}`);
-    console.log(
-      `  ${chalk.gray("Created:")} ${new Date(secret.createdAt).toLocaleString()}`
-    );
-    console.log(
-      `  ${chalk.gray("Updated:")} ${new Date(secret.updatedAt).toLocaleString()}`
-    );
-    console.log();
-    console.log(
-      chalk.gray("  (Secret values are never returned for security)")
-    );
-    console.log();
+    return {
+      data: secret,
+      table: () => {
+        console.log();
+        console.log(`  ${chalk.gray("ID:")}      ${chalk.green(secret.id)}`);
+        console.log(`  ${chalk.gray("Name:")}    ${chalk.cyan(secret.name)}`);
+        console.log(
+          `  ${chalk.gray("Created:")} ${new Date(secret.createdAt).toLocaleString()}`
+        );
+        console.log(
+          `  ${chalk.gray("Updated:")} ${new Date(secret.updatedAt).toLocaleString()}`
+        );
+        console.log();
+        console.log(
+          chalk.gray("  (Secret values are never returned for security)")
+        );
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch secret" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/secrets/list.ts
+++ b/typescript-sdk/src/cli/commands/secrets/list.ts
@@ -7,9 +7,14 @@ import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
-export const listSecretsCommand = async (options?: {
-  format?: string;
-}): Promise<void> => {
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). The endpoint returns
+ * metadata only — never a secret VALUE — so the raw list is safe as a payload.
+ */
+export const listSecretsCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -40,39 +45,39 @@ export const listSecretsCommand = async (options?: {
       `Found ${secrets.length} secret${secrets.length !== 1 ? "s" : ""}`
     );
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(secrets, null, 2));
-      return;
-    }
+    return {
+      data: secrets,
+      table: () => {
+        if (secrets.length === 0) {
+          console.log();
+          console.log(chalk.gray("No secrets found."));
+          console.log(chalk.gray("Create one with:"));
+          console.log(
+            chalk.cyan('  langwatch secret create MY_API_KEY --value "sk-..."')
+          );
+          return;
+        }
 
-    if (secrets.length === 0) {
-      console.log();
-      console.log(chalk.gray("No secrets found."));
-      console.log(chalk.gray("Create one with:"));
-      console.log(
-        chalk.cyan('  langwatch secret create MY_API_KEY --value "sk-..."')
-      );
-      return;
-    }
+        console.log();
 
-    console.log();
+        const tableData = secrets.map((s) => ({
+          Name: s.name,
+          ID: s.id,
+          Updated: new Date(s.updatedAt).toLocaleDateString(),
+        }));
 
-    const tableData = secrets.map((s) => ({
-      Name: s.name,
-      ID: s.id,
-      Updated: new Date(s.updatedAt).toLocaleDateString(),
-    }));
+        formatTable({
+          data: tableData,
+          headers: ["Name", "ID", "Updated"],
+          colorMap: {
+            Name: chalk.cyan,
+            ID: chalk.green,
+          },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["Name", "ID", "Updated"],
-      colorMap: {
-        Name: chalk.cyan,
-        ID: chalk.green,
+        console.log();
       },
-    });
-
-    console.log();
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch secrets" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/secrets/update.ts
+++ b/typescript-sdk/src/cli/commands/secrets/update.ts
@@ -6,10 +6,19 @@ import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the updated secret's metadata rather than printing it: the output
+ * port renders it in whatever format the caller asked for (utils/output.ts).
+ * The new VALUE the caller passed in `--value` is not echoed into the payload
+ * — the server does not return it, and a machine payload must not reintroduce
+ * key material the human output never showed.
+ */
 export const updateSecretCommand = async (
   id: string,
-  options: { value: string; format?: string }
-): Promise<void> => {
+  options: { value: string }
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -41,15 +50,15 @@ export const updateSecretCommand = async (
 
     spinner.succeed(`Secret "${secret.name}" updated`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(secret, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`  ${chalk.gray("ID:")}   ${chalk.green(secret.id)}`);
-    console.log(`  ${chalk.gray("Name:")} ${chalk.cyan(secret.name)}`);
-    console.log();
+    return {
+      data: secret,
+      table: () => {
+        console.log();
+        console.log(`  ${chalk.gray("ID:")}   ${chalk.green(secret.id)}`);
+        console.log(`  ${chalk.gray("Name:")} ${chalk.cyan(secret.name)}`);
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "update secret" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/skills/__tests__/skills-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/skills/__tests__/skills-commands.unit.test.ts
@@ -31,8 +31,10 @@ describe("the skills commands", () => {
   let root: string;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   const savedEnv: Record<string, string | undefined> = {};
+  let savedExitCode: typeof process.exitCode;
 
   beforeEach(() => {
+    savedExitCode = process.exitCode;
     root = fs.mkdtempSync(path.join(os.tmpdir(), "lw-skills-cmd-"));
     consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
@@ -43,6 +45,7 @@ describe("the skills commands", () => {
   });
 
   afterEach(() => {
+    process.exitCode = savedExitCode;
     fs.rmSync(root, { recursive: true, force: true });
     vi.restoreAllMocks();
     for (const name of AGENT_MODE_ENV_VARS) {
@@ -161,5 +164,114 @@ describe("the skills commands", () => {
     expect(
       fs.existsSync(path.join(root, "skills", "tracing", "SKILL.md")),
     ).toBe(true);
+  });
+
+  describe("when --force would overwrite content the bundle does not manage", () => {
+    // The team's hand-written skill sitting exactly where the bundle's would
+    // go — the file `install --all --force` used to truncate without a word.
+    const HAND_WRITTEN = "# the team's own tracing skill\n";
+    let target: string;
+
+    beforeEach(() => {
+      target = path.join(root, "skills", "tracing", "SKILL.md");
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, HAND_WRITTEN, "utf8");
+    });
+
+    it("refuses to clobber unmanaged content without -y, writing nothing", async () => {
+      expect(process.stdin.isTTY).toBeFalsy(); // vitest: never promptable
+      await expect(
+        skillsInstallCommand(["tracing"], { dir: root, force: true }),
+      ).rejects.toMatchObject({
+        code: "validation_error",
+        message: expect.stringContaining("-y"),
+      });
+      expect(fs.readFileSync(target, "utf8")).toBe(HAND_WRITTEN);
+    });
+
+    it("names every path it would clobber before refusing", async () => {
+      await expect(
+        skillsInstallCommand([], { dir: root, all: true, force: true }),
+      ).rejects.toMatchObject({ code: "validation_error" });
+      expect(logged()).toContain(target);
+    });
+
+    it("overwrites once -y is given", async () => {
+      await skillsInstallCommand(["tracing"], { dir: root, force: true, yes: true });
+      expect(fs.readFileSync(target, "utf8")).toContain(MANAGED_MARKER);
+    });
+
+    it("reports the clobber under --dry-run without needing -y or writing", async () => {
+      await skillsInstallCommand(["tracing"], {
+        dir: root,
+        force: true,
+        dryRun: true,
+      });
+      expect(fs.readFileSync(target, "utf8")).toBe(HAND_WRITTEN);
+    });
+
+    it("refuses update --force over unmanaged content too", async () => {
+      await expect(
+        skillsUpdateCommand(["tracing"], { dir: root, force: true }),
+      ).rejects.toMatchObject({ code: "validation_error" });
+      expect(fs.readFileSync(target, "utf8")).toBe(HAND_WRITTEN);
+    });
+  });
+
+  describe("when --force only touches files the bundle already manages", () => {
+    it("overwrites without asking for -y", async () => {
+      const installed = installSkill(skill("tracing"), root, {});
+      fs.writeFileSync(
+        installed.path,
+        `# stale\n\n<!-- managed-by: langwatch-skills v0.0.1 -->\n`,
+        "utf8",
+      );
+
+      await skillsInstallCommand(["tracing"], { dir: root, force: true, output: "json" });
+      const parsed = JSON.parse(logged()) as { results: { action: string }[] };
+      expect(parsed.results[0]!.action).toBe("updated");
+      expect(fs.readFileSync(installed.path, "utf8")).toContain(MANAGED_MARKER);
+    });
+  });
+
+  describe("when one file in a batch cannot be written", () => {
+    it("reports every file and exits non-zero after the report", async () => {
+      // A directory where tracing's SKILL.md belongs: EISDIR on read.
+      fs.mkdirSync(path.join(root, "skills", "tracing", "SKILL.md"), {
+        recursive: true,
+      });
+
+      await skillsInstallCommand(["tracing", "prompts"], {
+        dir: root,
+        output: "json",
+      });
+      const parsed = JSON.parse(logged()) as {
+        results: { slug: string; action: string; reason?: string; failed?: boolean }[];
+      };
+
+      const tracing = parsed.results.find((r) => r.slug === "tracing")!;
+      expect(tracing.action).toBe("skipped");
+      expect(tracing.failed).toBe(true);
+      expect(tracing.reason).toContain("EISDIR");
+
+      const prompts = parsed.results.find((r) => r.slug === "prompts")!;
+      expect(prompts.action).toBe("created");
+      expect(
+        fs.existsSync(path.join(root, "skills", "prompts", "SKILL.md")),
+      ).toBe(true);
+
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  it("install echoes the resolved root before writing", async () => {
+    await skillsInstallCommand(["tracing"], { dir: root });
+    expect(logged()).toContain(`Install root: ${root}`);
+  });
+
+  it("install rejects an empty --dir instead of writing into the cwd", async () => {
+    await expect(
+      skillsInstallCommand(["tracing"], { dir: "  " }),
+    ).rejects.toMatchObject({ code: "validation_error" });
   });
 });

--- a/typescript-sdk/src/cli/commands/skills/__tests__/skills-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/skills/__tests__/skills-commands.unit.test.ts
@@ -11,6 +11,7 @@ import {
   findSkill,
   installSkill,
   MANAGED_MARKER,
+  skillFilePath,
   SKILLS_BUNDLE,
   type BundledSkill,
 } from "../installer";
@@ -164,6 +165,41 @@ describe("the skills commands", () => {
     expect(
       fs.existsSync(path.join(root, "skills", "tracing", "SKILL.md")),
     ).toBe(true);
+  });
+
+  describe("when one skill's path cannot be read during uninstall --all", () => {
+    // A directory sitting where a SKILL.md belongs makes the plan's read throw
+    // EISDIR. That must not abort the batch: the other skills still get
+    // removed, and the caller still gets a full report of what happened.
+    it("removes the readable skills, reports the failure, and exits non-zero", async () => {
+      installSkill(skill("tracing"), root, {});
+      const blocked = skillFilePath(root, skill("prompts"));
+      fs.mkdirSync(blocked, { recursive: true });
+
+      await skillsUninstallCommand([], {
+        dir: root,
+        all: true,
+        yes: true,
+        output: "json",
+      });
+
+      const parsed = JSON.parse(logged()) as {
+        results: { slug: string; action: string; reason?: string; failed?: boolean }[];
+      };
+      const tracing = parsed.results.find((r) => r.slug === "tracing")!;
+      const prompts = parsed.results.find((r) => r.slug === "prompts")!;
+
+      expect(tracing.action).toBe("removed");
+      expect(
+        fs.existsSync(path.join(root, "skills", "tracing", "SKILL.md")),
+      ).toBe(false);
+
+      expect(prompts.action).toBe("skipped");
+      expect(prompts.failed).toBe(true);
+      expect(prompts.reason).toContain("EISDIR");
+
+      expect(process.exitCode).toBe(1);
+    });
   });
 
   describe("when --force would overwrite content the bundle does not manage", () => {

--- a/typescript-sdk/src/cli/commands/skills/__tests__/skills-installer.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/skills/__tests__/skills-installer.unit.test.ts
@@ -11,7 +11,9 @@ import {
   applyUninstall,
   findSkill,
   installSkill,
+  isManagedContent,
   MANAGED_MARKER,
+  planForcedClobbers,
   planUninstall,
   renderSkillFile,
   resolveSkillsRoot,
@@ -24,6 +26,26 @@ const skill = (slug: string): BundledSkill => {
   const found = findSkill(slug);
   if (!found) throw new Error(`test setup: no bundled skill ${slug}`);
   return found;
+};
+
+/**
+ * A local edit the way a user actually makes one: change the skill's PROSE,
+ * leaving the managed-by footer where the installer put it (last). Appending
+ * below the footer is a different case with different semantics — see the
+ * "given a marker that is not the file's last line" block.
+ */
+const editBody = (filePath: string): void => {
+  const content = fs.readFileSync(filePath, "utf8");
+  fs.writeFileSync(
+    filePath,
+    content.replace(MANAGED_MARKER, `user notes\n\n${MANAGED_MARKER}`),
+    "utf8",
+  );
+};
+
+const writeFile = (filePath: string, content: string): void => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
 };
 
 describe("the skills installer, given a temp install root", () => {
@@ -128,7 +150,7 @@ describe("the skills installer, given a temp install root", () => {
 
   it("keeps a locally modified managed file unless -y is given", () => {
     const { path: managed } = installSkill(skill("tracing"), root, {});
-    fs.appendFileSync(managed, "\nuser notes\n", "utf8");
+    editBody(managed);
 
     expect(planUninstall(skill("tracing"), root).action).toBe("skipped");
     expect(planUninstall(skill("tracing"), root, { yes: true }).action).toBe("removed");
@@ -165,7 +187,7 @@ describe("the skills installer, given a temp install root", () => {
   it("update skips a locally modified managed file without --force, overwrites with it", () => {
     // Current-version marker but edited content = the user's own changes.
     const { path: managed } = installSkill(skill("tracing"), root, {});
-    fs.appendFileSync(managed, "\nuser notes\n", "utf8");
+    editBody(managed);
 
     const skipped = updateSkill(skill("tracing"), root, {});
     expect(skipped.action).toBe("skipped");
@@ -194,5 +216,257 @@ describe("the skills installer, given a temp install root", () => {
     expect(fs.readFileSync(target, "utf8")).toBe(
       renderSkillFile(skill("tracing")),
     );
+  });
+
+  describe("given a marker that is not the file's last line", () => {
+    // The marker proves authorship only where this installer puts it: last.
+    // An unanchored match believes any occurrence anywhere, which is how a
+    // user's own file gets silently overwritten by `update`.
+    const QUOTED_FOOTER = [
+      "# our team's own tracing skill",
+      "",
+      "Installs from the LangWatch bundle end with a footer like:",
+      "",
+      "```markdown",
+      "<!-- managed-by: langwatch-skills v0.0.1 -->",
+      "```",
+      "",
+      "Ours does not, because we wrote it by hand.",
+      "",
+    ].join("\n");
+
+    it("does not treat a quoted footer earlier in the file as proof of ownership", () => {
+      expect(isManagedContent(QUOTED_FOOTER)).toBe(false);
+    });
+
+    it("refuses to update a hand-written file that merely quotes an old footer", () => {
+      const target = skillFilePath(root, skill("tracing"));
+      writeFile(target, QUOTED_FOOTER);
+
+      const result = updateSkill(skill("tracing"), root, {});
+      expect(result.action).toBe("skipped");
+      expect(result.reason).toContain("not managed by `langwatch skills`");
+      expect(fs.readFileSync(target, "utf8")).toBe(QUOTED_FOOTER);
+    });
+
+    it("refuses to uninstall a hand-written file that merely quotes an old footer", () => {
+      const target = skillFilePath(root, skill("tracing"));
+      writeFile(target, QUOTED_FOOTER);
+
+      const plan = planUninstall(skill("tracing"), root, { yes: true });
+      expect(plan.action).toBe("skipped");
+      expect(plan.reason).toContain("not managed by `langwatch skills`");
+    });
+
+    it("reads the version from the trailing marker, not an earlier stale one", () => {
+      // Quoted v0.0.1 up top, genuine CURRENT footer at the end: this IS ours,
+      // and it carries local edits — so it needs --force, not a silent refresh.
+      const target = skillFilePath(root, skill("tracing"));
+      writeFile(target, `${QUOTED_FOOTER}\n${MANAGED_MARKER}\n`);
+
+      const result = updateSkill(skill("tracing"), root, {});
+      expect(result.action).toBe("skipped");
+      expect(result.reason).toBe("locally modified; pass --force");
+    });
+
+    it("stops treating a managed file as ours once content is appended below the footer", () => {
+      // Deliberately conservative: text after the footer means the last bytes
+      // are no longer ours, so the safe answer is to leave the file alone.
+      const { path: managed } = installSkill(skill("tracing"), root, {});
+      fs.appendFileSync(managed, "\nuser notes\n", "utf8");
+
+      expect(planUninstall(skill("tracing"), root, { yes: true }).action).toBe(
+        "skipped",
+      );
+      expect(updateSkill(skill("tracing"), root, { force: true }).action).toBe(
+        "skipped",
+      );
+      expect(fs.readFileSync(managed, "utf8")).toContain("user notes");
+    });
+
+    it("still recognises a managed file with trailing blank lines", () => {
+      const { path: managed } = installSkill(skill("tracing"), root, {});
+      fs.appendFileSync(managed, "\n\n", "utf8");
+
+      expect(planUninstall(skill("tracing"), root, { yes: true }).action).toBe(
+        "removed",
+      );
+    });
+  });
+
+  describe("when a skill path is a symbolic link", () => {
+    it("refuses to write through it, leaving the link's target untouched", () => {
+      const outside = path.join(root, "outside.md");
+      fs.writeFileSync(outside, "# somebody else's file\n", "utf8");
+
+      const target = skillFilePath(root, skill("tracing"));
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.symlinkSync(outside, target);
+
+      const result = installSkill(skill("tracing"), root, { force: true });
+      expect(result.action).toBe("skipped");
+      expect(result.failed).toBe(true);
+      expect(result.reason).toContain("symbolic link");
+      expect(fs.readFileSync(outside, "utf8")).toBe("# somebody else's file\n");
+      expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    });
+
+    it("refuses a dangling link too, rather than creating the file it points at", () => {
+      const outside = path.join(root, "not-there-yet.md");
+      const target = skillFilePath(root, skill("tracing"));
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.symlinkSync(outside, target);
+
+      const result = installSkill(skill("tracing"), root, {});
+      expect(result.action).toBe("skipped");
+      expect(result.failed).toBe(true);
+      expect(fs.existsSync(outside)).toBe(false);
+    });
+  });
+
+  describe("when a write cannot complete", () => {
+    // Root ignores directory permissions, so the write would succeed and the
+    // assertions below would be meaningless rather than wrong.
+    const asNonRoot = it.skipIf(process.getuid?.() === 0);
+
+    asNonRoot("leaves the existing file whole, and no temp file behind", () => {
+      const { path: managed } = installSkill(skill("tracing"), root, {});
+      const stale = `# stale\n\n<!-- managed-by: langwatch-skills v0.0.1 -->\n`;
+      writeFile(managed, stale);
+
+      // A read-only directory: the temp write fails, exactly where a crash or
+      // a full disk would leave a plain writeFileSync half-done.
+      const dir = path.dirname(managed);
+      fs.chmodSync(dir, 0o555);
+      let result;
+      try {
+        result = updateSkill(skill("tracing"), root, {});
+      } finally {
+        fs.chmodSync(dir, 0o755);
+      }
+
+      expect(result.action).toBe("skipped");
+      expect(result.failed).toBe(true);
+      expect(result.reason).toMatch(/EACCES|EPERM|EROFS/);
+
+      // The file still holds COMPLETE, marker-carrying content — never the
+      // truncated remains that would make the CLI disown its own file.
+      const after = fs.readFileSync(managed, "utf8");
+      expect(after).toBe(stale);
+      expect(isManagedContent(after)).toBe(true);
+      expect(fs.readdirSync(dir)).toEqual(["SKILL.md"]);
+    });
+
+    it("leaves no temp files behind on a successful write", () => {
+      const { path: managed } = installSkill(skill("tracing"), root, {});
+      expect(fs.readdirSync(path.dirname(managed))).toEqual(["SKILL.md"]);
+
+      updateSkill(skill("tracing"), root, { force: true });
+      expect(fs.readdirSync(path.dirname(managed))).toEqual(["SKILL.md"]);
+    });
+  });
+
+  describe("when the filesystem refuses one file in a batch", () => {
+    it("reports the errno as a skip and still processes the rest", () => {
+      // A directory where the SKILL.md should be: readFileSync raises EISDIR.
+      const blocked = skillFilePath(root, skill("tracing"));
+      fs.mkdirSync(blocked, { recursive: true });
+
+      const results = [skill("tracing"), skill("prompts")].map((entry) =>
+        installSkill(entry, root, {}),
+      );
+
+      expect(results[0]!.action).toBe("skipped");
+      expect(results[0]!.failed).toBe(true);
+      expect(results[0]!.reason).toContain("EISDIR");
+      expect(results[1]!.action).toBe("created");
+      expect(fs.existsSync(results[1]!.path)).toBe(true);
+    });
+
+    it("reports a failed removal instead of aborting the uninstall loop", () => {
+      const first = installSkill(skill("tracing"), root, {});
+      const second = installSkill(skill("prompts"), root, {});
+      const plan = [
+        planUninstall(skill("tracing"), root),
+        planUninstall(skill("prompts"), root),
+      ];
+      expect(plan.map((p) => p.action)).toEqual(["removed", "removed"]);
+
+      // The path turns into a non-empty directory between plan and apply, so
+      // the unlink raises for real (EISDIR) — the race a long-running install
+      // and an impatient user genuinely produce.
+      fs.rmSync(first.path);
+      fs.mkdirSync(first.path);
+      fs.writeFileSync(path.join(first.path, "keep.md"), "x", "utf8");
+
+      const applied = applyUninstall(plan);
+
+      expect(applied[0]!.action).toBe("skipped");
+      expect(applied[0]!.failed).toBe(true);
+      expect(applied[0]!.reason).toMatch(/EISDIR|ERR_FS_EISDIR/);
+      expect(fs.existsSync(first.path)).toBe(true);
+
+      // The rest of the batch still ran.
+      expect(applied[1]!.action).toBe("removed");
+      expect(fs.existsSync(second.path)).toBe(false);
+    });
+  });
+
+  describe("when planning what --force would clobber", () => {
+    it("lists only files carrying content the installer did not write", () => {
+      const foreign = skillFilePath(root, skill("tracing"));
+      writeFile(foreign, "# the team's own tracing skill\n");
+
+      const { path: managed } = installSkill(skill("prompts"), root, {});
+      editBody(managed); // ours, locally edited — still ours
+      installSkill(skill("scenarios"), root, {}); // ours, byte-identical
+      // skill("evaluations") is not installed at all
+
+      const clobbers = planForcedClobbers(
+        [skill("tracing"), skill("prompts"), skill("scenarios")],
+        root,
+      );
+      expect(clobbers.map((c) => c.path)).toEqual([foreign]);
+    });
+  });
+
+  describe("given a --dir value no shell expanded", () => {
+    it("expands a leading ~ against the home directory", () => {
+      expect(resolveSkillsRoot("~/.agents")).toBe(
+        path.join(os.homedir(), ".agents"),
+      );
+      expect(resolveSkillsRoot("~")).toBe(os.homedir());
+      expect(resolveSkillsRoot("  ~/.agents  ")).toBe(
+        path.join(os.homedir(), ".agents"),
+      );
+    });
+
+    it("never creates a directory literally named ~", () => {
+      expect(resolveSkillsRoot("~/.agents")).not.toContain(`${path.sep}~`);
+    });
+
+    it("rejects an empty or whitespace --dir rather than using the cwd", () => {
+      expect(() => resolveSkillsRoot("")).toThrow(/--dir needs a path/);
+      expect(() => resolveSkillsRoot("   ")).toThrow(/--dir needs a path/);
+    });
+
+    it("leaves a ~ that is not a leading path segment alone", () => {
+      expect(resolveSkillsRoot("./tmp/~backup")).toBe(
+        path.resolve("./tmp/~backup"),
+      );
+    });
+  });
+
+  describe("given a slug that is not a single path segment", () => {
+    it("refuses to build a path that could escape the install root", () => {
+      const traversal: BundledSkill = {
+        ...skill("tracing"),
+        slug: "../../../etc/evil",
+      };
+      expect(() => skillFilePath(root, traversal)).toThrow(/single path segment/);
+
+      const nested: BundledSkill = { ...skill("tracing"), slug: "a/b" };
+      expect(() => skillFilePath(root, nested)).toThrow(/single path segment/);
+    });
   });
 });

--- a/typescript-sdk/src/cli/commands/skills/get.ts
+++ b/typescript-sdk/src/cli/commands/skills/get.ts
@@ -13,7 +13,7 @@ import {
   type RawOutputFlags,
 } from "../../utils/output";
 import { findSkill, SKILLS_BUNDLE } from "./installer";
-import { throwValidationError } from "./shared";
+import { throwValidationError } from "./validation";
 
 export const skillsGetCommand = async (
   name: string,

--- a/typescript-sdk/src/cli/commands/skills/install.ts
+++ b/typescript-sdk/src/cli/commands/skills/install.ts
@@ -1,17 +1,28 @@
 /**
- * `langwatch skills install [names...] [--all] [--dir] [--dry-run] [--force]`
+ * `langwatch skills install [names...] [--all] [--dir] [--dry-run] [--force] [-y]`
  * — write bundle skills to <root>/skills/<slug>/SKILL.md (recipes nested
  * under recipes/<slug>/), default root ~/.agents. Differing existing files
  * are left alone unless --force; every file action is reported as structured
  * data via printResult.
+ *
+ * `--force` truncates whatever is at the target path, so it goes through the
+ * same confirmation `uninstall` demands whenever the content it would destroy
+ * is not ours: refused non-interactively without -y, prompted on a TTY. See
+ * `confirmForcedOverwrite`.
  */
 import { printResult, type RawOutputFlags } from "../../utils/output";
 import {
   installSkill,
+  planForcedClobbers,
   resolveSkillsRoot,
   SKILLS_BUNDLE_VERSION,
 } from "./installer";
-import { renderSkillFileResults, resolveTargets } from "./shared";
+import {
+  announceRoot,
+  confirmForcedOverwrite,
+  renderSkillFileResults,
+  resolveTargets,
+} from "./shared";
 
 export interface SkillsInstallOptions extends RawOutputFlags {
   /** Install every skill in the bundle. */
@@ -22,6 +33,8 @@ export interface SkillsInstallOptions extends RawOutputFlags {
   dryRun?: boolean;
   /** Overwrite files that differ from the bundle. */
   force?: boolean;
+  /** Skip the --force confirmation (required in non-TTY/agent contexts). */
+  yes?: boolean;
 }
 
 export const skillsInstallCommand = async (
@@ -31,9 +44,23 @@ export const skillsInstallCommand = async (
   const root = resolveSkillsRoot(options.dir);
   const targets = resolveTargets(names, { all: options.all });
   const dryRun = options.dryRun === true;
+  const force = options.force === true;
+
+  announceRoot(root, options);
+
+  if (force) {
+    const proceed = await confirmForcedOverwrite(
+      planForcedClobbers(targets, root),
+      { yes: options.yes === true, dryRun, options },
+    );
+    if (!proceed) {
+      console.log("Aborted. Nothing was written.");
+      return;
+    }
+  }
 
   const results = targets.map((skill) =>
-    installSkill(skill, root, { dryRun, force: options.force }),
+    installSkill(skill, root, { dryRun, force }),
   );
 
   await printResult(
@@ -43,4 +70,8 @@ export const skillsInstallCommand = async (
       table: () => renderSkillFileResults(results, { dryRun }),
     },
   );
+
+  // Non-zero only AFTER the report: the caller needs to know which files
+  // changed even when one of them could not be written.
+  if (results.some((result) => result.failed)) process.exitCode = 1;
 };

--- a/typescript-sdk/src/cli/commands/skills/installer.ts
+++ b/typescript-sdk/src/cli/commands/skills/installer.ts
@@ -19,6 +19,7 @@
  * This module plans and executes; it never prints and never exits — the
  * command wrappers own output (printResult) and exit codes.
  */
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -27,32 +28,88 @@ import {
   SKILLS_BUNDLE_VERSION,
   type BundledSkill,
 } from "@/internal/generated/cli/skills.generated";
+import { throwValidationError } from "./validation";
 
 export { SKILLS_BUNDLE, SKILLS_BUNDLE_VERSION, type BundledSkill };
 
-/** The install root: --dir when given, else ~/.agents. */
-export const resolveSkillsRoot = (dir?: string): string =>
-  dir !== undefined ? path.resolve(dir) : path.join(os.homedir(), ".agents");
+/**
+ * The install root: --dir when given, else ~/.agents.
+ *
+ * `--dir` is a path a HUMAN typed or a config file supplied, so it gets the
+ * two expansions a shell would otherwise have done and this process cannot
+ * assume happened. A quoted `--dir "~/.agents"` — or a value an agent put
+ * straight into argv, where no shell ever ran — resolves to `$CWD/~/.agents`
+ * and silently creates a directory literally named `~`; an empty `--dir ""`
+ * resolves to `$CWD` and scatters skills/ into whatever the caller was
+ * standing in. Both are refused or corrected here, not discovered later.
+ */
+export const resolveSkillsRoot = (dir?: string): string => {
+  if (dir === undefined) return path.join(os.homedir(), ".agents");
+
+  const trimmed = dir.trim();
+  if (trimmed === "") {
+    return throwValidationError(
+      "--dir needs a path (an empty value would install into the current directory).",
+    );
+  }
+  const expanded =
+    trimmed === "~"
+      ? os.homedir()
+      : trimmed.startsWith("~/")
+        ? path.join(os.homedir(), trimmed.slice(2))
+        : trimmed;
+  return path.resolve(expanded);
+};
 
 /** The marker every installed file ends with (bundle version included). */
 export const MANAGED_MARKER = `<!-- managed-by: langwatch-skills v${SKILLS_BUNDLE_VERSION} -->`;
 
-/** Matches the marker from ANY bundle version, so older installs stay managed. */
-const MANAGED_MARKER_RE = /<!-- managed-by: langwatch-skills v(\S+?) -->/;
+/**
+ * Matches the marker from ANY bundle version, so older installs stay managed —
+ * anchored to the END of the file, because that is the only place this
+ * installer ever writes it.
+ *
+ * The anchor is load-bearing, not tidiness. An unanchored match believes any
+ * occurrence anywhere: a user who pastes a fenced code block quoting an older
+ * install's footer into their own hand-written skill hands `update` a stale
+ * version string, and `update` then overwrites their file with no --force and
+ * no prompt. The symmetric failure has `install` mislabel a locally edited
+ * file as a stale install. One trailing match answers both questions.
+ */
+const MANAGED_MARKER_RE = /(?:^|\n)<!-- managed-by: langwatch-skills v(\S+) -->\s*$/;
 
-export const skillFilePath = (root: string, skill: BundledSkill): string =>
-  path.join(
+/**
+ * Defence in depth: a slug becomes a path segment, so it must not be able to
+ * escape the install root. Runtime traversal is not currently reachable —
+ * every slug is exact-matched against the compiled bundle by `findSkill` — but
+ * nothing in the type system says so, and `BundledSkill` is a plain interface
+ * any future caller can construct. A violated invariant throws; it is a bug in
+ * the bundle, not a per-file condition to report.
+ */
+const assertPathSafeSlug = (slug: string): void => {
+  if (slug === "" || slug.includes("/") || slug.includes("\\") || slug.includes("..")) {
+    throw new Error(
+      `Refusing to build a skill path from slug ${JSON.stringify(slug)}: slugs must be a single path segment with no "/" or "..".`,
+    );
+  }
+};
+
+export const skillFilePath = (root: string, skill: BundledSkill): string => {
+  assertPathSafeSlug(skill.slug);
+  return path.join(
     root,
     "skills",
     ...(skill.isRecipe ? ["recipes", skill.slug] : [skill.slug]),
     "SKILL.md",
   );
+};
 
 /** The exact file content `install` writes: skill body + managed-by marker. */
 export const renderSkillFile = (skill: BundledSkill): string =>
   `${skill.body.trimEnd()}\n\n${MANAGED_MARKER}\n`;
 
-const isManagedContent = (content: string): boolean =>
+/** Whether this file's LAST bytes are our marker — i.e. we wrote it. */
+export const isManagedContent = (content: string): boolean =>
   MANAGED_MARKER_RE.test(content);
 
 /** The bundle version a managed file was installed from, if the marker says. */
@@ -100,11 +157,92 @@ export interface SkillFileResult {
   path: string;
   action: SkillFileAction;
   reason?: string;
+  /**
+   * This entry is a FAILURE, not a deliberate skip — the filesystem refused
+   * the operation. Commands report every result and then exit non-zero if any
+   * carries this, so one EACCES never hides the rest of the batch.
+   */
+  failed?: true;
 }
 
+/** `EACCES: permission denied, open '…'` — the errno, said once. */
+const fsErrorReason = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code: unknown }).code)
+      : undefined;
+  if (code === undefined || message.startsWith(code)) return message;
+  return `${code}: ${message}`;
+};
+
+/**
+ * Turn a filesystem refusal into a reported skip.
+ *
+ * Without this a single EACCES/EPERM/EISDIR anywhere in a batch throws out of
+ * the `.map()`, `printResult` is never reached, and the caller is told the
+ * command failed but not WHICH files were already written — the worst possible
+ * report for a half-applied change.
+ */
+const asFileResult = (
+  skill: BundledSkill,
+  filePath: string,
+  operation: () => SkillFileResult,
+): SkillFileResult => {
+  try {
+    return operation();
+  } catch (error) {
+    return {
+      slug: skill.slug,
+      path: filePath,
+      action: "skipped",
+      reason: fsErrorReason(error),
+      failed: true,
+    };
+  }
+};
+
+/**
+ * Write a skill file so that it is either fully there or not there at all,
+ * and never through a symlink.
+ *
+ * Atomicity is not a nicety here: the managed-by marker is the LAST bytes of
+ * the file, so any interrupted plain write deterministically produces a file
+ * that no longer looks managed — `update` and `uninstall` would both then
+ * refuse it as somebody else's, and the tool would have bricked its own file
+ * with `--force` as the only way back. Writing a sibling temp file and
+ * `rename`-ing it (atomic within a filesystem on POSIX) removes that state.
+ *
+ * The same rename closes a second hole: `writeFileSync` FOLLOWS symlinks, so
+ * on a shared install root (`--dir /tmp/shared`, a CI cache, a container
+ * volume) a pre-planted symlink at a skill path would let this truncate a file
+ * outside the root entirely. `lstat` sees the link itself, and refuses.
+ */
 const writeSkill = (filePath: string, content: string): void => {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, content, "utf8");
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const link = fs.lstatSync(filePath, { throwIfNoEntry: false });
+  if (link?.isSymbolicLink()) {
+    throw Object.assign(
+      new Error(
+        `${filePath} is a symbolic link; refusing to write through it (remove the link and re-run).`,
+      ),
+      { code: "ESYMLINK" },
+    );
+  }
+
+  const temp = path.join(
+    dir,
+    `.${path.basename(filePath)}.${process.pid}-${crypto.randomUUID()}.tmp`,
+  );
+  try {
+    fs.writeFileSync(temp, content, "utf8");
+    fs.renameSync(temp, filePath);
+  } catch (error) {
+    fs.rmSync(temp, { force: true });
+    throw error;
+  }
 };
 
 /**
@@ -120,28 +258,72 @@ export const installSkill = (
   { dryRun = false, force = false }: { dryRun?: boolean; force?: boolean },
 ): SkillFileResult => {
   const filePath = skillFilePath(root, skill);
-  const wanted = renderSkillFile(skill);
-  const existing = readIfExists(filePath);
+  return asFileResult(skill, filePath, () => {
+    const wanted = renderSkillFile(skill);
+    const existing = readIfExists(filePath);
 
-  if (existing === undefined) {
+    if (existing === undefined) {
+      if (!dryRun) writeSkill(filePath, wanted);
+      return { slug: skill.slug, path: filePath, action: "created" };
+    }
+    if (existing === wanted) {
+      return { slug: skill.slug, path: filePath, action: "unchanged" };
+    }
+    if (!force) {
+      const installedVersion = managedVersion(existing);
+      const reason =
+        installedVersion === undefined
+          ? "differs from the bundle; pass --force to overwrite"
+          : installedVersion !== SKILLS_BUNDLE_VERSION
+            ? `installed from bundle v${installedVersion}; run \`langwatch skills update\` (or pass --force to overwrite)`
+            : "locally modified; pass --force to overwrite";
+      return { slug: skill.slug, path: filePath, action: "skipped", reason };
+    }
     if (!dryRun) writeSkill(filePath, wanted);
-    return { slug: skill.slug, path: filePath, action: "created" };
+    return { slug: skill.slug, path: filePath, action: "updated" };
+  });
+};
+
+/** A file `--force` would truncate that this installer did not write. */
+export interface ForcedClobber {
+  slug: string;
+  path: string;
+}
+
+/**
+ * Plan which of these skills' targets `--force` would destroy content in.
+ *
+ * `--force` is the one flag that reasons about nothing — it skips the marker
+ * and version checks entirely and truncates whatever is at the path. That is
+ * fine for a file we wrote; it is not fine for the team's hand-written
+ * `.agents/skills/tracing/SKILL.md`, which `install --all --force` would
+ * silently replace. So the commands gate on THIS list — files with content we
+ * do not manage — exactly the way `uninstall` gates on removals, and leave
+ * overwriting our own files frictionless.
+ *
+ * A file we cannot even read counts as a clobber: unreadable is not the same
+ * as ours.
+ */
+export const planForcedClobbers = (
+  skills: BundledSkill[],
+  root: string,
+): ForcedClobber[] => {
+  const clobbers: ForcedClobber[] = [];
+  for (const skill of skills) {
+    const filePath = skillFilePath(root, skill);
+    let existing: string | undefined;
+    try {
+      existing = readIfExists(filePath);
+    } catch {
+      clobbers.push({ slug: skill.slug, path: filePath });
+      continue;
+    }
+    if (existing === undefined) continue;
+    if (existing === renderSkillFile(skill)) continue;
+    if (isManagedContent(existing)) continue;
+    clobbers.push({ slug: skill.slug, path: filePath });
   }
-  if (existing === wanted) {
-    return { slug: skill.slug, path: filePath, action: "unchanged" };
-  }
-  if (!force) {
-    const installedVersion = managedVersion(existing);
-    const reason =
-      installedVersion === undefined
-        ? "differs from the bundle; pass --force to overwrite"
-        : installedVersion !== SKILLS_BUNDLE_VERSION
-          ? `installed from bundle v${installedVersion}; run \`langwatch skills update\` (or pass --force to overwrite)`
-          : "locally modified; pass --force to overwrite";
-    return { slug: skill.slug, path: filePath, action: "skipped", reason };
-  }
-  if (!dryRun) writeSkill(filePath, wanted);
-  return { slug: skill.slug, path: filePath, action: "updated" };
+  return clobbers;
 };
 
 /**
@@ -191,15 +373,32 @@ export const planUninstall = (
   };
 };
 
-/** Execute a confirmed uninstall plan. */
+/**
+ * Execute a confirmed uninstall plan, returning the plan as it actually
+ * turned out: a removal the filesystem refused comes back as a failed skip
+ * rather than throwing out of the loop and stranding the caller with no
+ * record of which files were already gone.
+ */
 export const applyUninstall = (
   results: SkillFileResult[],
   { dryRun = false }: { dryRun?: boolean } = {},
-): void => {
-  if (dryRun) return;
-  for (const result of results) {
-    if (result.action === "removed") fs.rmSync(result.path, { force: true });
-  }
+): SkillFileResult[] => {
+  if (dryRun) return results;
+  return results.map((result) => {
+    if (result.action !== "removed") return result;
+    try {
+      fs.rmSync(result.path, { force: true });
+      return result;
+    } catch (error) {
+      return {
+        slug: result.slug,
+        path: result.path,
+        action: "skipped",
+        reason: fsErrorReason(error),
+        failed: true,
+      };
+    }
+  });
 };
 
 /**
@@ -219,37 +418,39 @@ export const updateSkill = (
   { dryRun = false, force = false }: { dryRun?: boolean; force?: boolean } = {},
 ): SkillFileResult => {
   const filePath = skillFilePath(root, skill);
-  const wanted = renderSkillFile(skill);
-  const existing = readIfExists(filePath);
+  return asFileResult(skill, filePath, () => {
+    const wanted = renderSkillFile(skill);
+    const existing = readIfExists(filePath);
 
-  if (existing === undefined) {
-    return {
-      slug: skill.slug,
-      path: filePath,
-      action: "skipped",
-      reason: "not installed; use `langwatch skills install`",
-    };
-  }
-  if (existing === wanted) {
-    return { slug: skill.slug, path: filePath, action: "unchanged" };
-  }
-  const installedVersion = managedVersion(existing);
-  if (installedVersion === undefined) {
-    return {
-      slug: skill.slug,
-      path: filePath,
-      action: "skipped",
-      reason: "not managed by `langwatch skills`; use `install --force`",
-    };
-  }
-  if (installedVersion === SKILLS_BUNDLE_VERSION && !force) {
-    return {
-      slug: skill.slug,
-      path: filePath,
-      action: "skipped",
-      reason: "locally modified; pass --force",
-    };
-  }
-  if (!dryRun) writeSkill(filePath, wanted);
-  return { slug: skill.slug, path: filePath, action: "updated" };
+    if (existing === undefined) {
+      return {
+        slug: skill.slug,
+        path: filePath,
+        action: "skipped",
+        reason: "not installed; use `langwatch skills install`",
+      };
+    }
+    if (existing === wanted) {
+      return { slug: skill.slug, path: filePath, action: "unchanged" };
+    }
+    const installedVersion = managedVersion(existing);
+    if (installedVersion === undefined) {
+      return {
+        slug: skill.slug,
+        path: filePath,
+        action: "skipped",
+        reason: "not managed by `langwatch skills`; use `install --force`",
+      };
+    }
+    if (installedVersion === SKILLS_BUNDLE_VERSION && !force) {
+      return {
+        slug: skill.slug,
+        path: filePath,
+        action: "skipped",
+        reason: "locally modified; pass --force",
+      };
+    }
+    if (!dryRun) writeSkill(filePath, wanted);
+    return { slug: skill.slug, path: filePath, action: "updated" };
+  });
 };

--- a/typescript-sdk/src/cli/commands/skills/installer.ts
+++ b/typescript-sdk/src/cli/commands/skills/installer.ts
@@ -75,6 +75,17 @@ export const MANAGED_MARKER = `<!-- managed-by: langwatch-skills v${SKILLS_BUNDL
  * version string, and `update` then overwrites their file with no --force and
  * no prompt. The symmetric failure has `install` mislabel a locally edited
  * file as a stale install. One trailing match answers both questions.
+ *
+ * The accepted cost: a user who APPENDS their own notes below the footer of a
+ * file we installed drops it out of managed status. They will see `update` say
+ * "not managed by `langwatch skills`; use `install --force`" and `uninstall`
+ * say "remove it by hand" — friction, and confusing friction given the file
+ * plainly carries our marker. It is not data loss: `planForcedClobbers`
+ * classifies such a file as a clobber, so even `--force` prompts or refuses
+ * rather than silently eating the appended notes. The trade is deliberate and
+ * runs in the safe direction — we would rather decline to touch a file that is
+ * ours than touch one that is not. Moving the notes ABOVE the footer, or
+ * removing the footer entirely, restores the expected behaviour.
  */
 const MANAGED_MARKER_RE = /(?:^|\n)<!-- managed-by: langwatch-skills v(\S+) -->\s*$/;
 
@@ -218,9 +229,39 @@ const asFileResult = (
  * volume) a pre-planted symlink at a skill path would let this truncate a file
  * outside the root entirely. `lstat` sees the link itself, and refuses.
  */
+/**
+ * Delete temp files THIS process orphaned in `dir` on an earlier run.
+ *
+ * The write below is crash-safe for the skill file but not for its own temp:
+ * a signal or hard kill between `writeFileSync` and `renameSync` skips the
+ * catch and strands `.SKILL.md.<pid>-<uuid>.tmp` forever, one per Ctrl-C'd
+ * `skills install --all`.
+ *
+ * The sweep is scoped to this process's OWN pid rather than an age threshold
+ * because pid is the only signal here that is exact. An age cutoff has to
+ * guess how slow a legitimate write can be, and guessing wrong deletes a
+ * concurrent installer's in-flight temp out from under it — a corrupted
+ * install to tidy up litter. A recycled pid is the one false positive, and it
+ * can only ever hit a temp the recycled owner already abandoned. Temps left by
+ * OTHER pids stay: harmless, and not ours to judge.
+ */
+const sweepOrphanedTemps = (dir: string, fileName: string): void => {
+  const prefix = `.${fileName}.${process.pid}-`;
+  try {
+    for (const entry of fs.readdirSync(dir)) {
+      if (entry.startsWith(prefix) && entry.endsWith(".tmp")) {
+        fs.rmSync(path.join(dir, entry), { force: true });
+      }
+    }
+  } catch {
+    // Best-effort tidying: never fail an install over leftover litter.
+  }
+};
+
 const writeSkill = (filePath: string, content: string): void => {
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
+  sweepOrphanedTemps(dir, path.basename(filePath));
 
   const link = fs.lstatSync(filePath, { throwIfNoEntry: false });
   if (link?.isSymbolicLink()) {
@@ -240,7 +281,14 @@ const writeSkill = (filePath: string, content: string): void => {
     fs.writeFileSync(temp, content, "utf8");
     fs.renameSync(temp, filePath);
   } catch (error) {
-    fs.rmSync(temp, { force: true });
+    // The cleanup gets its own try/catch so it can never REPLACE the failure
+    // being handled: an EACCES on unlink surfacing instead of the ENOSPC that
+    // actually stopped the write sends the user to debug the wrong thing.
+    try {
+      fs.rmSync(temp, { force: true });
+    } catch {
+      // Leave the temp behind; the sweep above reclaims it next run.
+    }
     throw error;
   }
 };
@@ -330,6 +378,10 @@ export const planForcedClobbers = (
  * Plan an uninstall without touching the disk, so the command can ask for
  * confirmation (or refuse, non-TTY) before anything is removed.
  *
+ * A path the filesystem refuses to even READ (EISDIR, EACCES) becomes a failed
+ * skip like everywhere else — planning a bundle must not abort halfway on one
+ * bad path, leaving the other skills' fate unreported.
+ *
  * Only files the bundle manages are ever removed: byte-identical installs,
  * or marker-carrying files — a modified managed file additionally needs -y
  * (it may carry the user's edits). A file with no marker and different
@@ -341,36 +393,38 @@ export const planUninstall = (
   { yes = false }: { yes?: boolean } = {},
 ): SkillFileResult => {
   const filePath = skillFilePath(root, skill);
-  const existing = readIfExists(filePath);
+  return asFileResult(skill, filePath, () => {
+    const existing = readIfExists(filePath);
 
-  if (existing === undefined) {
-    return {
-      slug: skill.slug,
-      path: filePath,
-      action: "skipped",
-      reason: "not installed",
-    };
-  }
-  if (existing === renderSkillFile(skill)) {
-    return { slug: skill.slug, path: filePath, action: "removed" };
-  }
-  if (isManagedContent(existing)) {
-    if (!yes) {
+    if (existing === undefined) {
       return {
         slug: skill.slug,
         path: filePath,
         action: "skipped",
-        reason: "locally modified; pass -y to remove anyway",
+        reason: "not installed",
       };
     }
-    return { slug: skill.slug, path: filePath, action: "removed" };
-  }
-  return {
-    slug: skill.slug,
-    path: filePath,
-    action: "skipped",
-    reason: "not managed by `langwatch skills`; remove it by hand",
-  };
+    if (existing === renderSkillFile(skill)) {
+      return { slug: skill.slug, path: filePath, action: "removed" };
+    }
+    if (isManagedContent(existing)) {
+      if (!yes) {
+        return {
+          slug: skill.slug,
+          path: filePath,
+          action: "skipped",
+          reason: "locally modified; pass -y to remove anyway",
+        };
+      }
+      return { slug: skill.slug, path: filePath, action: "removed" };
+    }
+    return {
+      slug: skill.slug,
+      path: filePath,
+      action: "skipped",
+      reason: "not managed by `langwatch skills`; remove it by hand",
+    };
+  });
 };
 
 /**

--- a/typescript-sdk/src/cli/commands/skills/shared.ts
+++ b/typescript-sdk/src/cli/commands/skills/shared.ts
@@ -1,33 +1,20 @@
 /**
- * Shared plumbing for the `langwatch skills` mutating commands: turning
- * name arguments into bundle skills (with a loud error on typos) and the
- * human rendering of the per-file result list.
+ * Shared plumbing for the `langwatch skills` mutating commands: turning name
+ * arguments into bundle skills (with a loud error on typos), the human
+ * rendering of the per-file result list, and the one confirmation gate every
+ * destructive path goes through.
  */
+import * as readline from "node:readline";
 import chalk from "chalk";
-import { commandValidationError } from "../../utils/errorOutput";
+import { resolveOutputOptions, type RawOutputFlags } from "../../utils/output";
 import {
   resolveSkills,
   SKILLS_BUNDLE,
   type BundledSkill,
+  type ForcedClobber,
   type SkillFileResult,
 } from "./installer";
-
-/**
- * Throw a validation failure as a real Error that still carries the domain
- * brand — eslint's only-throw-error demands an Error instance, while
- * `domainErrorFromThrown` recognises the failure by the brand on the thrown
- * value itself (it reads those fields before unwrapping anything).
- *
- * Call it as `return throwValidationError(...)`: a bare call compiles but
- * TypeScript's control-flow analysis does not treat it as exiting the block,
- * so narrowing after it is lost.
- */
-export const throwValidationError = (
-  message: string,
-  meta: Record<string, unknown> = {},
-): never => {
-  throw Object.assign(new Error(message), commandValidationError(message, meta));
-};
+import { throwValidationError } from "./validation";
 
 /**
  * The skills a mutating command acts on: the whole bundle with --all, else
@@ -87,4 +74,86 @@ export const renderSkillFileResults = (
     const reason = result.reason !== undefined ? chalk.gray(` — ${result.reason}`) : "";
     console.log(`  ${color(action.padEnd(14))}${result.path}${reason}`);
   }
+};
+
+/** Whether this command's output is the human table (never a parsed document). */
+const isTableOutput = (options: RawOutputFlags): boolean =>
+  resolveOutputOptions({ ...options }).format === "table";
+
+/**
+ * Whether it is safe to PROMPT.
+ *
+ * Interactive confirmation is for humans at a terminal ONLY. A TTY stdin does
+ * not make prompting safe: with `-o json`/`--jq`/`--agent` (or agent env vars)
+ * the caller is a machine — a prompt blocks it like a hang, and the
+ * pre-confirmation preview would corrupt the structured document it is about
+ * to read. Machine callers get a -y/--yes error instead, always.
+ */
+export const isInteractiveConsole = (options: RawOutputFlags): boolean => {
+  const resolved = resolveOutputOptions({ ...options });
+  return (
+    process.stdin.isTTY === true && resolved.format === "table" && !resolved.agent
+  );
+};
+
+/** Ask a yes/no question on the terminal. Only ever called when interactive. */
+export const confirm = async (question: string): Promise<boolean> => {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(`${question} [y/N] `, (a) => resolve(a));
+  });
+  rl.close();
+  const norm = answer.trim().toLowerCase();
+  return norm === "y" || norm === "yes";
+};
+
+/** Say which root is about to be written to, before anything is written. */
+export const announceRoot = (root: string, options: RawOutputFlags): void => {
+  if (isTableOutput(options)) console.log(chalk.gray(`Install root: ${root}`));
+};
+
+/**
+ * The `--force` gate: the same confirmation `uninstall` demands, applied to
+ * the strictly MORE destructive act of truncating a file.
+ *
+ * `uninstall` refuses non-interactively without -y before removing a file it
+ * has already proven it owns; `--force` used to overwrite files it has proven
+ * it does NOT own, with no prompt and no TTY check at all. This closes that,
+ * and only that: clobbers here are files carrying content we did not write, so
+ * forcing over our own installs stays frictionless.
+ *
+ * Returns whether to proceed; throws (never prompts) for machine callers.
+ */
+export const confirmForcedOverwrite = async (
+  clobbers: ForcedClobber[],
+  {
+    yes = false,
+    dryRun = false,
+    options = {},
+  }: { yes?: boolean; dryRun?: boolean; options?: RawOutputFlags } = {},
+): Promise<boolean> => {
+  if (clobbers.length === 0) return true;
+
+  const plural = clobbers.length === 1 ? "" : "s";
+  if (isTableOutput(options)) {
+    console.log(
+      chalk.yellow(
+        `--force will overwrite ${clobbers.length} file${plural} not managed by \`langwatch skills\`:`,
+      ),
+    );
+    for (const clobber of clobbers) console.log(`  ${chalk.red(clobber.path)}`);
+  }
+
+  if (dryRun || yes) return true;
+
+  if (!isInteractiveConsole(options)) {
+    return throwValidationError(
+      `--force would overwrite ${clobbers.length} file${plural} not managed by \`langwatch skills\` and needs confirmation. Re-run with -y (non-interactive callers are never prompted).`,
+      { clobbers: clobbers.map((clobber) => clobber.path) },
+    );
+  }
+  return await confirm("Overwrite these files?");
 };

--- a/typescript-sdk/src/cli/commands/skills/uninstall.ts
+++ b/typescript-sdk/src/cli/commands/skills/uninstall.ts
@@ -9,19 +9,20 @@
  * non-TTY/agent caller is NEVER prompted — without -y it gets a structured
  * error instead, because a blocked prompt reads to a script as a hang.
  */
-import * as readline from "node:readline";
-import {
-  printResult,
-  resolveOutputOptions,
-  type RawOutputFlags,
-} from "../../utils/output";
+import { printResult, type RawOutputFlags } from "../../utils/output";
 import {
   applyUninstall,
   planUninstall,
   resolveSkillsRoot,
   SKILLS_BUNDLE_VERSION,
 } from "./installer";
-import { renderSkillFileResults, resolveTargets, throwValidationError } from "./shared";
+import {
+  confirm,
+  isInteractiveConsole,
+  renderSkillFileResults,
+  resolveTargets,
+} from "./shared";
+import { throwValidationError } from "./validation";
 
 export interface SkillsUninstallOptions extends RawOutputFlags {
   /** Uninstall every skill in the bundle. */
@@ -33,19 +34,6 @@ export interface SkillsUninstallOptions extends RawOutputFlags {
   /** Skip the confirmation prompt (required in non-TTY/agent contexts). */
   yes?: boolean;
 }
-
-const confirmRemoval = async (question: string): Promise<boolean> => {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  const answer = await new Promise<string>((resolve) => {
-    rl.question(`${question} [y/N] `, (a) => resolve(a));
-  });
-  rl.close();
-  const norm = answer.trim().toLowerCase();
-  return norm === "y" || norm === "yes";
-};
 
 export const skillsUninstallCommand = async (
   names: string[],
@@ -59,24 +47,16 @@ export const skillsUninstallCommand = async (
   const results = targets.map((skill) => planUninstall(skill, root, { yes }));
   const removals = results.filter((result) => result.action === "removed");
 
-  // Interactive confirmation is for humans at a terminal ONLY. A TTY stdin
-  // does not make prompting safe: with `-o json`/`--jq`/`--agent` (or agent
-  // env vars) the caller is a machine — a prompt blocks it like a hang, and
-  // the pre-confirmation preview would corrupt the structured document it is
-  // about to read. Machine callers get the -y error instead, always.
-  const resolved = resolveOutputOptions({ ...options });
-  const interactive = process.stdin.isTTY === true && resolved.format === "table" && !resolved.agent;
-
   let confirmed = false;
   if (removals.length > 0 && !yes && !dryRun) {
-    if (!interactive) {
+    if (!isInteractiveConsole(options)) {
       return throwValidationError(
         `uninstall would remove ${removals.length} file${removals.length === 1 ? "" : "s"} and needs confirmation. Re-run with -y (non-interactive callers are never prompted).`,
         { removals: removals.map((result) => result.path) },
       );
     }
     renderSkillFileResults(results);
-    const ok = await confirmRemoval("Remove these files?");
+    const ok = await confirm("Remove these files?");
     if (!ok) {
       console.log("Aborted. Nothing was removed.");
       return;
@@ -84,17 +64,24 @@ export const skillsUninstallCommand = async (
     confirmed = true;
   }
 
-  applyUninstall(results, { dryRun });
+  const applied = applyUninstall(results, { dryRun });
+  const failures = applied.filter((result) => result.failed);
 
   await printResult(
-    { dir: root, bundleVersion: SKILLS_BUNDLE_VERSION, dryRun, results },
+    { dir: root, bundleVersion: SKILLS_BUNDLE_VERSION, dryRun, results: applied },
     {
       ...options,
       table: () => {
         // The confirmed path already printed the list as the prompt preview —
-        // rendering it again would say the same thing twice.
-        if (!confirmed) renderSkillFileResults(results, { dryRun });
+        // rendering it again would say the same thing twice. A file the
+        // filesystem then refused is news, though, so those are always shown.
+        if (!confirmed) renderSkillFileResults(applied, { dryRun });
+        else if (failures.length > 0) renderSkillFileResults(failures);
       },
     },
   );
+
+  // Non-zero only AFTER the report: the caller needs to know which files were
+  // removed even when one of them could not be.
+  if (failures.length > 0) process.exitCode = 1;
 };

--- a/typescript-sdk/src/cli/commands/skills/update.ts
+++ b/typescript-sdk/src/cli/commands/skills/update.ts
@@ -7,13 +7,19 @@
 import * as fs from "node:fs";
 import { printResult, type RawOutputFlags } from "../../utils/output";
 import {
+  planForcedClobbers,
   resolveSkillsRoot,
   skillFilePath,
   updateSkill,
   SKILLS_BUNDLE,
   SKILLS_BUNDLE_VERSION,
 } from "./installer";
-import { renderSkillFileResults, resolveTargets } from "./shared";
+import {
+  announceRoot,
+  confirmForcedOverwrite,
+  renderSkillFileResults,
+  resolveTargets,
+} from "./shared";
 
 export interface SkillsUpdateOptions extends RawOutputFlags {
   /** Install root (default ~/.agents). */
@@ -22,6 +28,8 @@ export interface SkillsUpdateOptions extends RawOutputFlags {
   dryRun?: boolean;
   /** Overwrite managed files that carry local edits. */
   force?: boolean;
+  /** Skip the --force confirmation (required in non-TTY/agent contexts). */
+  yes?: boolean;
 }
 
 export const skillsUpdateCommand = async (
@@ -30,6 +38,7 @@ export const skillsUpdateCommand = async (
 ): Promise<void> => {
   const root = resolveSkillsRoot(options.dir);
   const dryRun = options.dryRun === true;
+  const force = options.force === true;
 
   // No names: every INSTALLED bundle skill is a candidate — update never
   // installs anything new (that is `install`'s job).
@@ -40,8 +49,25 @@ export const skillsUpdateCommand = async (
           fs.existsSync(skillFilePath(root, skill)),
         );
 
+  announceRoot(root, options);
+
+  // `update` already refuses unmanaged files on its own, so this gate is
+  // normally a no-op — it is here so that the ONE rule ("--force never
+  // destroys content we did not write without confirmation") holds for every
+  // forcing path, not just the one that happens to need it today.
+  if (force) {
+    const proceed = await confirmForcedOverwrite(
+      planForcedClobbers(targets, root),
+      { yes: options.yes === true, dryRun, options },
+    );
+    if (!proceed) {
+      console.log("Aborted. Nothing was written.");
+      return;
+    }
+  }
+
   const results = targets.map((skill) =>
-    updateSkill(skill, root, { dryRun, force: options.force }),
+    updateSkill(skill, root, { dryRun, force }),
   );
 
   await printResult(
@@ -57,4 +83,8 @@ export const skillsUpdateCommand = async (
       },
     },
   );
+
+  // Non-zero only AFTER the report: the caller needs to know which files
+  // changed even when one of them could not be written.
+  if (results.some((result) => result.failed)) process.exitCode = 1;
 };

--- a/typescript-sdk/src/cli/commands/skills/validation.ts
+++ b/typescript-sdk/src/cli/commands/skills/validation.ts
@@ -1,0 +1,25 @@
+/**
+ * The one way a `langwatch skills …` command rejects bad input.
+ *
+ * It lives in its own module rather than in `shared.ts` because the installer
+ * validates `--dir` too, and `shared.ts` already imports the installer — a
+ * cycle the module graph does not need.
+ */
+import { commandValidationError } from "../../utils/errorOutput";
+
+/**
+ * Throw a validation failure as a real Error that still carries the domain
+ * brand — eslint's only-throw-error demands an Error instance, while
+ * `domainErrorFromThrown` recognises the failure by the brand on the thrown
+ * value itself (it reads those fields before unwrapping anything).
+ *
+ * Call it as `return throwValidationError(...)`: a bare call compiles but
+ * TypeScript's control-flow analysis does not treat it as exiting the block,
+ * so narrowing after it is lost.
+ */
+export const throwValidationError = (
+  message: string,
+  meta: Record<string, unknown> = {},
+): never => {
+  throw Object.assign(new Error(message), commandValidationError(message, meta));
+};

--- a/typescript-sdk/src/cli/commands/status.ts
+++ b/typescript-sdk/src/cli/commands/status.ts
@@ -23,10 +23,36 @@ const RUNNING_EXPERIMENT_CANDIDATES = 5;
 /** How many experiments the first page can carry. Anything past this is unseen
  * by the running-experiments scan and must be declared as a gap. */
 const EXPERIMENT_PAGE_SIZE = 50;
-/** Per-call ceiling. `status` is the most-run command in the CLI and often the
- * first thing an agent does in a session, so no single backend call may hold it
- * open indefinitely — see `withTimeout`. */
-const CALL_TIMEOUT_MS = 5_000;
+/** Per-call ceiling for the cheap resource LIST endpoints. These are indexed
+ * Postgres reads behind a single page; anything past a few seconds is a real
+ * problem, not load. */
+const LIST_CALL_TIMEOUT_MS = 5_000;
+/** Per-call ceiling for the attention sections. `fetchErroredTraces24h` is a
+ * ClickHouse COUNT over a 24h partition and `fetchRunningExperiments` fans out
+ * to N run-list calls — 5-15s is routine on a busy project, so a 5s ceiling
+ * would report "timed out" about a perfectly healthy backend. 30s is still far
+ * below "blocks the session", while leaving genuine hangs bounded. */
+const SECTION_CALL_TIMEOUT_MS = 30_000;
+
+/** The resource rows status fetches, in display order. Single source of truth
+ * for both the fetcher table's key type and the rendering order below. */
+const RESOURCE_KEYS = [
+  "evaluators",
+  "scenarios",
+  "suites",
+  "datasets",
+  "agents",
+  "workflows",
+  "dashboards",
+  "triggers",
+  "monitors",
+  "secrets",
+] as const;
+type ResourceKey = (typeof RESOURCE_KEYS)[number];
+
+/** The attention sections, which are exactly the non-map fields of
+ * `AttentionReport` — so a typo'd key cannot write a junk field onto it. */
+type AttentionSectionKey = keyof Omit<AttentionReport, "errors" | "advisories">;
 
 class CallTimeoutError extends Error {
   constructor(ms: number) {
@@ -44,13 +70,13 @@ class CallTimeoutError extends Error {
  * settle. A timeout is reported the same way any other section failure is —
  * as an `errors` entry — so it withholds the all-clear rather than hiding.
  */
-async function withTimeout<T>(operation: () => Promise<T>): Promise<T> {
+async function withTimeout<T>(operation: () => Promise<T>, ms: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
       operation(),
       new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(() => reject(new CallTimeoutError(CALL_TIMEOUT_MS)), CALL_TIMEOUT_MS);
+        timer = setTimeout(() => reject(new CallTimeoutError(ms)), ms);
         // Never hold the process open just to fire a timeout that no longer matters.
         (timer as { unref?: () => void }).unref?.();
       }),
@@ -101,6 +127,11 @@ export interface AttentionReport {
   /** Section key → why it could not be fetched, or was only partially checked.
    * Empty when everything worked — the green all-clear keys off this. */
   errors: Record<string, string>;
+  /** Section key → a scope this API structurally cannot cover, on any project,
+   * however healthy. Told to the user, but deliberately NOT gating the
+   * all-clear: a permanent caveat that suppresses the tick forever is as
+   * useless as a tick that lies, and trains the reader to ignore the section. */
+  advisories: Record<string, string>;
 }
 
 export interface StatusDocument {
@@ -122,6 +153,7 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
     runningExperiments: null,
     budgetsAtRisk: null,
     errors: {},
+    advisories: {},
   };
 
   async function fetchCount(url: string): Promise<{ data: unknown; error?: unknown; status?: number }> {
@@ -213,7 +245,18 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
         `only the first ${list.experiments.length} of ${list.pagination.totalHits} experiments were listed`,
       );
     }
-    if (recent.length > candidates.length) {
+    const running = checks.flatMap((check) =>
+      check.status === "fulfilled" && check.value !== null ? [check.value] : [],
+    );
+    // Only a gap when the cap plausibly HID something. Every experiment that
+    // ever ran has a non-null `lastRunAt`, so "there are more than 5 of them"
+    // describes almost every real project and would suppress the all-clear
+    // permanently. The candidates are ranked most-recently-active first: if
+    // every one we checked came back finished, the older, less-recently-active
+    // tail behind them is not evidence of anything running. It is only when the
+    // sample itself turned up a live run that the cap is hiding a population we
+    // have concrete reason to believe contains more.
+    if (running.length > 0 && recent.length > candidates.length) {
       gaps.push(
         `only the ${RUNNING_EXPERIMENT_CANDIDATES} most recently active of ${recent.length} candidate experiments were checked`,
       );
@@ -227,9 +270,7 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
       attention.errors.runningExperiments = `incomplete scan: ${gaps.join("; ")}`;
     }
 
-    return checks.flatMap((check) =>
-      check.status === "fulfilled" && check.value !== null ? [check.value] : [],
-    );
+    return running;
   }
 
   /**
@@ -244,27 +285,50 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
    * That blind spot only has anything behind it if this project routes through
    * the gateway at all: with no virtual keys there is no VK or principal
    * traffic to block, and the scopes we CAN see are the whole picture. So probe
-   * for keys, and whenever there are any — or we cannot tell — put the
-   * uncovered scope on the record instead of claiming an all-clear over it.
+   * for keys, and whenever there are any, put the uncovered scope on the
+   * record.
+   *
+   * But record it as an ADVISORY, not an error. It is not a failed check and
+   * not something the user can fix: any project that routes through the gateway
+   * would carry it on every single run, and an error that never clears is an
+   * error the reader learns to skip. A failed PROBE is different — that IS a
+   * check that did not run, so it stays an error and withholds the tick.
    */
-  async function uncoveredBudgetScopeGap(): Promise<string | null> {
+  async function uncoveredBudgetScopeGap(): Promise<
+    { kind: "error" | "advisory"; message: string } | null
+  > {
     const unchecked = "virtual-key and principal budgets were not checked";
     let payload: unknown;
     try {
       const { data, error, status } = await fetchCount("/api/gateway/v1/virtual-keys");
       if (error) {
-        return `${unchecked} (could not list virtual keys: ${formatApiErrorMessage({ error, options: { status } })})`;
+        return {
+          kind: "error",
+          message: `${unchecked} (could not list virtual keys: ${formatApiErrorMessage({ error, options: { status } })})`,
+        };
       }
       payload = data;
     } catch (err) {
-      return `${unchecked} (could not list virtual keys: ${describeFailure(err)})`;
+      return {
+        kind: "error",
+        message: `${unchecked} (could not list virtual keys: ${describeFailure(err)})`,
+      };
     }
-    const keys = Array.isArray(payload)
-      ? payload
-      : (payload as { data?: unknown } | null)?.data;
-    const count = Array.isArray(keys) ? keys.length : 0;
-    if (count === 0) return null;
-    return `${unchecked} — this API cannot list them, and ${count} virtual key${count === 1 ? "" : "s"} in this project could carry them`;
+    const body = payload as { data?: unknown; pagination?: { totalHits?: number } } | null;
+    const keys = Array.isArray(payload) ? payload : body?.data;
+    if (!Array.isArray(keys) || keys.length === 0) return null;
+    // The page-1 length is NOT the key count — 300 keys behind pagination would
+    // print "3". Use the reported total when there is one, and otherwise say
+    // nothing numeric rather than something false.
+    const total = body?.pagination?.totalHits;
+    const scale =
+      typeof total === "number"
+        ? `${total} virtual key${total === 1 ? "" : "s"} in this project could`
+        : "virtual keys in this project could";
+    return {
+      kind: "advisory",
+      message: `${unchecked} — this API cannot list them, and ${scale} carry them`,
+    };
   }
 
   async function fetchBudgetsAtRisk(): Promise<BudgetAtRisk[]> {
@@ -302,7 +366,11 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
       });
 
     const gaps: string[] = [];
-    if (scopeGap) gaps.push(scopeGap);
+    if (scopeGap?.kind === "advisory") {
+      attention.advisories.budgetsAtRisk = scopeGap.message;
+    } else if (scopeGap) {
+      gaps.push(scopeGap.message);
+    }
     if (unreadable.length > 0) {
       gaps.push(
         `the limit or spend of ${unreadable.length} budget${unreadable.length === 1 ? "" : "s"} could not be read (${unreadable.join(", ")})`,
@@ -323,8 +391,11 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
   // FetchResponse is a DIFFERENT structural type per path) with `fetchCount`,
   // so an inferred `fn` is a union of thunks that `withTimeout<T>` cannot
   // unify. This is the shape the counting below actually reads.
+  // The annotation is what pins `fn` (see above), but `keyof typeof results` on
+  // a `Record<string, …>` is just `string` — it looks like key safety and isn't,
+  // so a typo'd key type-checks and emits a bogus row. Spell the keys out.
   const fetchers: {
-    key: keyof typeof results;
+    key: ResourceKey;
     fn: () => Promise<{
       data?: unknown;
       error?: unknown;
@@ -348,7 +419,7 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
   // RunningExperiment[] | BudgetAtRisk[], so an inferred `fn` is a union of
   // thunks. The result is assigned through a keyed cast below, which is where
   // the per-key types are reconciled.
-  const sectionFetchers: { key: string; fn: () => Promise<unknown> }[] = [
+  const sectionFetchers: { key: AttentionSectionKey; fn: () => Promise<unknown> }[] = [
     { key: "erroredTraces24h", fn: fetchErroredTraces24h },
     { key: "runningExperiments", fn: fetchRunningExperiments },
     { key: "budgetsAtRisk", fn: fetchBudgetsAtRisk },
@@ -357,7 +428,7 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
   await Promise.allSettled([
     ...fetchers.map(async ({ key, fn }) => {
       try {
-        const result = await withTimeout(fn);
+        const result = await withTimeout(fn, LIST_CALL_TIMEOUT_MS);
         const { data, error } = result;
         const status = (result as { status?: number; response?: { status?: number } }).status
           ?? (result as { response?: { status?: number } }).response?.status;
@@ -388,7 +459,8 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
       try {
         // The three section fetchers return number | RunningExperiment[] |
         // BudgetAtRisk[]; the AttentionReport field types line up by key.
-        (attention as unknown as Record<string, unknown>)[key] = await withTimeout(fn);
+        (attention as unknown as Record<AttentionSectionKey, unknown>)[key] =
+          await withTimeout(fn, SECTION_CALL_TIMEOUT_MS);
       } catch (err) {
         // Soft-fail: the section reads null and the reason lives in `errors`
         // (rendered dimly in human mode, verbatim in machine output). A timeout
@@ -496,12 +568,16 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
       for (const [key, message] of Object.entries(attention.errors)) {
         console.log(chalk.gray(`    (could not check ${sectionLabels[key] ?? key}: ${message})`));
       }
+      // Advisories read differently on purpose: "note" is a standing limit of
+      // the API, not a check that failed this run, and it does not gate the ✓.
+      for (const [key, message] of Object.entries(attention.advisories)) {
+        console.log(chalk.gray(`    (note — ${sectionLabels[key] ?? key}: ${message})`));
+      }
 
       console.log();
       console.log(chalk.bold("  Resource Counts:"));
 
-      const order = ["evaluators", "scenarios", "suites", "datasets", "agents", "workflows", "dashboards", "triggers", "monitors", "secrets"];
-      for (const key of order) {
+      for (const key of RESOURCE_KEYS) {
         const r = results[key];
         if (!r) continue;
         const countStr = r.error

--- a/typescript-sdk/src/cli/commands/status.ts
+++ b/typescript-sdk/src/cli/commands/status.ts
@@ -20,6 +20,50 @@ const BUDGET_ATTENTION_THRESHOLD_PCT = 80;
 /** Running state is per-RUN and runs list per experiment, so the "is anything
  * still running" check only re-queries the most recently active experiments. */
 const RUNNING_EXPERIMENT_CANDIDATES = 5;
+/** How many experiments the first page can carry. Anything past this is unseen
+ * by the running-experiments scan and must be declared as a gap. */
+const EXPERIMENT_PAGE_SIZE = 50;
+/** Per-call ceiling. `status` is the most-run command in the CLI and often the
+ * first thing an agent does in a session, so no single backend call may hold it
+ * open indefinitely — see `withTimeout`. */
+const CALL_TIMEOUT_MS = 5_000;
+
+class CallTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`timed out after ${Math.round(ms / 1000)}s`);
+    this.name = "CallTimeoutError";
+  }
+}
+
+/**
+ * Puts a hard floor under every network call status makes.
+ *
+ * `Promise.allSettled` never rejects, so without this there is no upper bound
+ * on how long status blocks: the trace-search POST runs a ClickHouse COUNT over
+ * a 24h partition and can hang indefinitely, and a hung call would simply never
+ * settle. A timeout is reported the same way any other section failure is —
+ * as an `errors` entry — so it withholds the all-clear rather than hiding.
+ */
+async function withTimeout<T>(operation: () => Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new CallTimeoutError(CALL_TIMEOUT_MS)), CALL_TIMEOUT_MS);
+        // Never hold the process open just to fire a timeout that no longer matters.
+        (timer as { unref?: () => void }).unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** A timeout is a first-class, self-explanatory reason — don't run it through
+ * the API-body formatter, which has nothing to add to it. */
+const describeFailure = (error: unknown): string =>
+  error instanceof CallTimeoutError ? error.message : formatApiErrorMessage({ error });
 
 export interface RunningExperiment {
   slug: string;
@@ -116,16 +160,17 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
 
   async function fetchRunningExperiments(): Promise<RunningExperiment[]> {
     const service = new ExperimentsApiService();
-    const list = await service.listExperiments({ pageSize: 50 });
+    const list = await service.listExperiments({ pageSize: EXPERIMENT_PAGE_SIZE });
     // "Running" is a property of a run, and runs are only listed per
     // experiment — so check the latest run of just the most recently active
     // experiments rather than fanning out over all of them.
+    //
+    // Deliberately NOT windowed to the last 24h. `running` has no bounded
+    // duration: an experiment wedged in `running` for three days has a 72h-old
+    // `lastRunAt`, and those are precisely the ones worth surfacing. Recency is
+    // used to RANK candidates, never to filter them out.
     const recent = list.experiments
-      .filter(
-        (experiment) =>
-          experiment.lastRunAt !== null &&
-          Date.now() - new Date(experiment.lastRunAt).getTime() < DAY_MS,
-      )
+      .filter((experiment) => experiment.lastRunAt !== null)
       .sort(
         (a, b) =>
           new Date(b.lastRunAt ?? 0).getTime() - new Date(a.lastRunAt ?? 0).getTime(),
@@ -159,6 +204,15 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
     // "nothing needs your attention".
     const failedChecks = checks.filter((check) => check.status === "rejected").length;
     const gaps: string[] = [];
+    // `GET /api/experiments` is ordered by `updatedAt desc`, NOT by `lastRunAt`
+    // — so a running experiment whose row has a stale `updatedAt` can sit past
+    // the page boundary and never be seen at all. An unread page is the single
+    // biggest hole in this scan; it goes on the record first.
+    if (list.pagination.hasMore) {
+      gaps.push(
+        `only the first ${list.experiments.length} of ${list.pagination.totalHits} experiments were listed`,
+      );
+    }
     if (recent.length > candidates.length) {
       gaps.push(
         `only the ${RUNNING_EXPERIMENT_CANDIDATES} most recently active of ${recent.length} candidate experiments were checked`,
@@ -178,32 +232,106 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
     );
   }
 
+  /**
+   * `GET /api/gateway/v1/budgets` returns org-, team- and project-scoped
+   * budgets only — it documents that VK- and principal-scoped budgets come from
+   * "their detail pages", and no REST endpoint serves those: the org-wide
+   * listing that does include every scope is a session-authenticated tRPC
+   * procedure, the virtual-key DTO carries no budget fields, and there is no
+   * `GET /budgets/:id`. So a virtual-key budget at 100% with `on_breach: BLOCK`
+   * — actively rejecting production traffic — is structurally invisible here.
+   *
+   * That blind spot only has anything behind it if this project routes through
+   * the gateway at all: with no virtual keys there is no VK or principal
+   * traffic to block, and the scopes we CAN see are the whole picture. So probe
+   * for keys, and whenever there are any — or we cannot tell — put the
+   * uncovered scope on the record instead of claiming an all-clear over it.
+   */
+  async function uncoveredBudgetScopeGap(): Promise<string | null> {
+    const unchecked = "virtual-key and principal budgets were not checked";
+    let payload: unknown;
+    try {
+      const { data, error, status } = await fetchCount("/api/gateway/v1/virtual-keys");
+      if (error) {
+        return `${unchecked} (could not list virtual keys: ${formatApiErrorMessage({ error, options: { status } })})`;
+      }
+      payload = data;
+    } catch (err) {
+      return `${unchecked} (could not list virtual keys: ${describeFailure(err)})`;
+    }
+    const keys = Array.isArray(payload)
+      ? payload
+      : (payload as { data?: unknown } | null)?.data;
+    const count = Array.isArray(keys) ? keys.length : 0;
+    if (count === 0) return null;
+    return `${unchecked} — this API cannot list them, and ${count} virtual key${count === 1 ? "" : "s"} in this project could carry them`;
+  }
+
   async function fetchBudgetsAtRisk(): Promise<BudgetAtRisk[]> {
-    const budgets = await new GatewayBudgetsApiService({ endpoint, apiKey }).list();
-    return budgets
+    const [budgets, scopeGap] = await Promise.all([
+      new GatewayBudgetsApiService({ endpoint, apiKey }).list(),
+      uncoveredBudgetScopeGap(),
+    ]);
+
+    const unreadable: string[] = [];
+    const scored = budgets
       .filter((budget) => budget.archived_at === null)
-      .map((budget) => {
+      .flatMap((budget): BudgetAtRisk[] => {
         const limit = Number(budget.limit_usd);
         const spent = Number(budget.spent_usd);
-        return {
-          name: budget.name,
-          scope: budget.scope_type,
-          window: budget.window,
-          utilizationPct:
-            Number.isFinite(limit) && limit > 0 && Number.isFinite(spent)
-              ? Math.round((spent / limit) * 100)
-              : 0,
-          spentUsd: budget.spent_usd,
-          limitUsd: budget.limit_usd,
-          onBreach: budget.on_breach,
-        };
-      })
+        // Neither "at risk" nor "fine" — we cannot say which, so say that.
+        if (!Number.isFinite(limit) || !Number.isFinite(spent)) {
+          unreadable.push(budget.name);
+          return [];
+        }
+        return [
+          {
+            name: budget.name,
+            scope: budget.scope_type,
+            window: budget.window,
+            // A limit of zero admits no spend at all: it is the maximally
+            // breached state, not a 0%-utilized one. Scoring it 0 and dropping
+            // it below the threshold is how a BLOCK budget that rejects every
+            // single request turns into a green tick.
+            utilizationPct: limit <= 0 ? 100 : Math.round((spent / limit) * 100),
+            spentUsd: budget.spent_usd,
+            limitUsd: budget.limit_usd,
+            onBreach: budget.on_breach,
+          },
+        ];
+      });
+
+    const gaps: string[] = [];
+    if (scopeGap) gaps.push(scopeGap);
+    if (unreadable.length > 0) {
+      gaps.push(
+        `the limit or spend of ${unreadable.length} budget${unreadable.length === 1 ? "" : "s"} could not be read (${unreadable.join(", ")})`,
+      );
+    }
+    if (gaps.length > 0) {
+      attention.errors.budgetsAtRisk = `incomplete scan: ${gaps.join("; ")}`;
+    }
+
+    return scored
       .filter((budget) => budget.utilizationPct >= BUDGET_ATTENTION_THRESHOLD_PCT)
       .sort((a, b) => b.utilizationPct - a.utilizationPct);
   }
 
-  // Fetch counts for all major resources in parallel
-  const fetchers = [
+  // Fetch counts for all major resources in parallel.
+  //
+  // Annotated rather than inferred: the array mixes `apiClient.GET` (whose
+  // FetchResponse is a DIFFERENT structural type per path) with `fetchCount`,
+  // so an inferred `fn` is a union of thunks that `withTimeout<T>` cannot
+  // unify. This is the shape the counting below actually reads.
+  const fetchers: {
+    key: keyof typeof results;
+    fn: () => Promise<{
+      data?: unknown;
+      error?: unknown;
+      status?: number;
+      response?: { status?: number };
+    }>;
+  }[] = [
     { key: "evaluators", fn: () => apiClient.GET("/api/evaluators") },
     { key: "scenarios", fn: () => apiClient.GET("/api/scenarios") },
     { key: "suites", fn: () => fetchCount("/api/suites") },
@@ -216,16 +344,20 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
     { key: "secrets", fn: () => fetchCount("/api/secrets") },
   ];
 
-  const sectionFetchers = [
+  // Same reason as `fetchers` above: the three return number |
+  // RunningExperiment[] | BudgetAtRisk[], so an inferred `fn` is a union of
+  // thunks. The result is assigned through a keyed cast below, which is where
+  // the per-key types are reconciled.
+  const sectionFetchers: { key: string; fn: () => Promise<unknown> }[] = [
     { key: "erroredTraces24h", fn: fetchErroredTraces24h },
     { key: "runningExperiments", fn: fetchRunningExperiments },
     { key: "budgetsAtRisk", fn: fetchBudgetsAtRisk },
-  ] as const;
+  ];
 
   await Promise.allSettled([
     ...fetchers.map(async ({ key, fn }) => {
       try {
-        const result = await fn();
+        const result = await withTimeout(fn);
         const { data, error } = result;
         const status = (result as { status?: number; response?: { status?: number } }).status
           ?? (result as { response?: { status?: number } }).response?.status;
@@ -249,18 +381,20 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
           results[key] = { count: 0 };
         }
       } catch (err) {
-        results[key] = { count: 0, error: formatApiErrorMessage({ error: err }) };
+        results[key] = { count: 0, error: describeFailure(err) };
       }
     }),
     ...sectionFetchers.map(async ({ key, fn }) => {
       try {
         // The three section fetchers return number | RunningExperiment[] |
         // BudgetAtRisk[]; the AttentionReport field types line up by key.
-        (attention as unknown as Record<string, unknown>)[key] = await fn();
+        (attention as unknown as Record<string, unknown>)[key] = await withTimeout(fn);
       } catch (err) {
         // Soft-fail: the section reads null and the reason lives in `errors`
-        // (rendered dimly in human mode, verbatim in machine output).
-        attention.errors[key] = formatApiErrorMessage({ error: err });
+        // (rendered dimly in human mode, verbatim in machine output). A timeout
+        // lands here too, so a hung backend withholds the all-clear like any
+        // other unfinished check.
+        attention.errors[key] = describeFailure(err);
       }
     }),
   ]);
@@ -341,9 +475,11 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
         );
       }
       if (flagged === 0) {
-        // All-clear only means something when every section actually loaded —
-        // don't print a green ✓ next to a list of sections we couldn't check.
-        if (Object.keys(attention.errors).length === 0) {
+        // All-clear only means something when the whole scan actually ran —
+        // don't print a green ✓ next to a list of sections we couldn't check,
+        // and don't print one directly above a grid of red 403s either. A
+        // resource we could not read is a resource we cannot vouch for.
+        if (Object.keys(attention.errors).length === 0 && errorCount === 0) {
           console.log(chalk.green("    ✓ nothing needs your attention"));
         } else {
           console.log(

--- a/typescript-sdk/src/cli/commands/triggers/__tests__/redact.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/triggers/__tests__/redact.unit.test.ts
@@ -1,0 +1,94 @@
+/**
+ * `actionParams` must never reach machine output.
+ *
+ * `/api/triggers` returns delivery credentials — Slack webhook URLs, custom
+ * endpoint URLs and their headers — in plaintext, and the human "Trigger
+ * Details" block has always omitted them. Machine output is the MORE exposed
+ * surface (it gets logged, piped, and pasted into agent context, and agent mode
+ * auto-activates from CLAUDECODE), so it must not be the one place the secret
+ * appears. These tests fail loudly if that ever regresses.
+ */
+import { describe, it, expect } from "vitest";
+import { redactTriggerSecrets, redactTriggerListSecrets } from "../redact";
+
+const WEBHOOK = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXX";
+
+const trigger = () => ({
+  id: "trg_1",
+  name: "alert me",
+  action: "SEND_SLACK_MESSAGE",
+  actionParams: { slackWebhook: WEBHOOK, headers: { Authorization: "Bearer sk-live-abc" } },
+  active: true,
+});
+
+describe("redactTriggerSecrets", () => {
+  describe("given a trigger carrying delivery credentials", () => {
+    it("removes every actionParams value from the payload", () => {
+      const serialized = JSON.stringify(redactTriggerSecrets(trigger()));
+
+      expect(serialized).not.toContain(WEBHOOK);
+      expect(serialized).not.toContain("hooks.slack.com");
+      expect(serialized).not.toContain("sk-live-abc");
+    });
+
+    // An agent needs to know a trigger HAS a slack webhook configured to reason
+    // about it; it never needs the value.
+    it("keeps the key names so the shape stays readable", () => {
+      const redacted = redactTriggerSecrets(trigger());
+
+      expect(Object.keys(redacted.actionParams)).toEqual(["slackWebhook", "headers"]);
+    });
+
+    it("leaves every non-secret field untouched", () => {
+      const redacted = redactTriggerSecrets(trigger());
+
+      expect(redacted.id).toBe("trg_1");
+      expect(redacted.name).toBe("alert me");
+      expect(redacted.action).toBe("SEND_SLACK_MESSAGE");
+      expect(redacted.active).toBe(true);
+    });
+
+    // The `table` closure renders from the original, so mutating it would
+    // corrupt human output too.
+    it("does not mutate the input", () => {
+      const original = trigger();
+      redactTriggerSecrets(original);
+
+      expect(original.actionParams.slackWebhook).toBe(WEBHOOK);
+    });
+  });
+
+  describe("given a trigger with no actionParams", () => {
+    it.each([[null], [undefined], [{}]])("returns it unharmed for %s", (params) => {
+      const input = { id: "trg_2", actionParams: params as Record<string, unknown> | null };
+
+      expect(() => redactTriggerSecrets(input)).not.toThrow();
+      expect(redactTriggerSecrets(input).id).toBe("trg_2");
+    });
+  });
+
+  // list.ts and create.ts cast the response to types that OMIT actionParams,
+  // but the cast is compile-time only and the payload really carries it. If the
+  // redactor were typed to require the field, those call sites could not use it
+  // and the secret would ship.
+  describe("given a payload whose declared type omits actionParams", () => {
+    it("still strips the field the API actually returned", () => {
+      const declared: { id: string; name: string } = JSON.parse(
+        JSON.stringify({ id: "trg_3", name: "x", actionParams: { slackWebhook: WEBHOOK } }),
+      );
+
+      expect(JSON.stringify(redactTriggerSecrets(declared))).not.toContain(WEBHOOK);
+    });
+  });
+});
+
+describe("redactTriggerListSecrets", () => {
+  it("redacts every element, not just the first", () => {
+    const serialized = JSON.stringify(
+      redactTriggerListSecrets([trigger(), { ...trigger(), id: "trg_2" }]),
+    );
+
+    expect(serialized).not.toContain(WEBHOOK);
+    expect(serialized.match(/redacted/g)).toHaveLength(4);
+  });
+});

--- a/typescript-sdk/src/cli/commands/triggers/__tests__/trigger-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/triggers/__tests__/trigger-commands.unit.test.ts
@@ -83,17 +83,20 @@ describe("listTriggersCommand()", () => {
     });
   });
 
-  describe("when format is json", () => {
-    it("outputs raw JSON", async () => {
+  describe("when a machine format is requested", () => {
+    it("returns the raw trigger list as the payload instead of printing", async () => {
       const triggers = [makeTrigger()];
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => triggers,
       });
 
-      await listTriggersCommand({ format: "json" });
+      const result = await listTriggersCommand();
 
-      expect(console.log).toHaveBeenCalledWith(JSON.stringify(triggers, null, 2));
+      // The command no longer decides the format — it hands the payload to
+      // the output port, which renders json/yaml/agents/--jq from this value.
+      expect(result?.data).toEqual(triggers);
+      expect(console.log).not.toHaveBeenCalled();
     });
   });
 });

--- a/typescript-sdk/src/cli/commands/triggers/create.ts
+++ b/typescript-sdk/src/cli/commands/triggers/create.ts
@@ -7,6 +7,12 @@ import { commandValidationError, reportCommandError } from "../../utils/errorOut
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the created trigger rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const createTriggerCommand = async (
   name: string,
   options: {
@@ -15,9 +21,8 @@ export const createTriggerCommand = async (
     message?: string;
     alertType?: string;
     slackWebhook?: string;
-    format?: string;
   },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const validActions = ["SEND_EMAIL", "ADD_TO_DATASET", "ADD_TO_ANNOTATION_QUEUE", "SEND_SLACK_MESSAGE"];
@@ -69,18 +74,18 @@ export const createTriggerCommand = async (
     const trigger = await response.json() as { id: string; name: string; action: string; platformUrl?: string };
     spinner.succeed(`Trigger "${trigger.name}" created (${trigger.id})`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(trigger, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`  ${chalk.gray("ID:")}     ${chalk.green(trigger.id)}`);
-    console.log(`  ${chalk.gray("Action:")} ${trigger.action}`);
-    if (trigger.platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(trigger.platformUrl)}`);
-    }
-    console.log();
+    return {
+      data: trigger,
+      table: () => {
+        console.log();
+        console.log(`  ${chalk.gray("ID:")}     ${chalk.green(trigger.id)}`);
+        console.log(`  ${chalk.gray("Action:")} ${trigger.action}`);
+        if (trigger.platformUrl) {
+          console.log(`  ${chalk.bold("View:")}  ${chalk.underline(trigger.platformUrl)}`);
+        }
+        console.log();
+      },
+    };
   } catch (error) {
     // Route BOTH failure kinds through failSpinner: a direct spinner.fail()
     // prints nothing in --json/--jq/agent mode (spinners are silent there).

--- a/typescript-sdk/src/cli/commands/triggers/create.ts
+++ b/typescript-sdk/src/cli/commands/triggers/create.ts
@@ -8,6 +8,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { redactTriggerSecrets } from "./redact";
 
 /**
  * Returns the created trigger rather than printing it: the output port renders
@@ -75,7 +76,8 @@ export const createTriggerCommand = async (
     spinner.succeed(`Trigger "${trigger.name}" created (${trigger.id})`);
 
     return {
-      data: trigger,
+      // See ./redact.ts — actionParams is plaintext and never shown to humans.
+      data: redactTriggerSecrets(trigger),
       table: () => {
         console.log();
         console.log(`  ${chalk.gray("ID:")}     ${chalk.green(trigger.id)}`);

--- a/typescript-sdk/src/cli/commands/triggers/delete.ts
+++ b/typescript-sdk/src/cli/commands/triggers/delete.ts
@@ -5,10 +5,15 @@ import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the deletion result rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const deleteTriggerCommand = async (
   id: string,
-  options?: { format?: string },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -31,9 +36,13 @@ export const deleteTriggerCommand = async (
     const result = await response.json() as { id: string; deleted: boolean };
     spinner.succeed(`Trigger "${id}" deleted`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(result, null, 2));
-    }
+    return {
+      data: result,
+      table: () => {
+        // Nothing further to print: the spinner line above was the whole
+        // human output before the migration, and stays so.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "delete trigger" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/triggers/get.ts
+++ b/typescript-sdk/src/cli/commands/triggers/get.ts
@@ -7,6 +7,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { redactTriggerSecrets } from "./redact";
 
 /**
  * Returns the trigger rather than printing it: the output port renders it in
@@ -52,7 +53,9 @@ export const getTriggerCommand = async (
     spinner.succeed(`Found trigger "${trigger.name}"`);
 
     return {
-      data: trigger,
+      // actionParams holds plaintext webhook URLs and delivery secrets that
+      // the human block never prints — see ./redact.ts.
+      data: redactTriggerSecrets(trigger),
       table: () => {
         console.log();
         console.log(chalk.bold("  Trigger Details:"));

--- a/typescript-sdk/src/cli/commands/triggers/get.ts
+++ b/typescript-sdk/src/cli/commands/triggers/get.ts
@@ -6,10 +6,17 @@ import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the trigger rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). `data` is the raw
+ * record, so a machine caller keeps `actionParams` and `updatedAt`, which the
+ * human view omits.
+ */
 export const getTriggerCommand = async (
   id: string,
-  options?: { format?: string },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -44,31 +51,31 @@ export const getTriggerCommand = async (
 
     spinner.succeed(`Found trigger "${trigger.name}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(trigger, null, 2));
-      return;
-    }
+    return {
+      data: trigger,
+      table: () => {
+        console.log();
+        console.log(chalk.bold("  Trigger Details:"));
+        console.log(`    ${chalk.gray("ID:")}      ${chalk.green(trigger.id)}`);
+        console.log(`    ${chalk.gray("Name:")}    ${chalk.cyan(trigger.name)}`);
+        console.log(`    ${chalk.gray("Action:")}  ${trigger.action}`);
+        console.log(`    ${chalk.gray("Status:")}  ${trigger.active ? chalk.green("active") : chalk.gray("inactive")}`);
+        console.log(`    ${chalk.gray("Alert:")}   ${trigger.alertType ?? chalk.gray("—")}`);
+        console.log(`    ${chalk.gray("Message:")} ${trigger.message ?? chalk.gray("—")}`);
+        console.log(`    ${chalk.gray("Created:")} ${new Date(trigger.createdAt).toLocaleString()}`);
+        if (trigger.platformUrl) {
+          console.log(`    ${chalk.bold("View:")}   ${chalk.underline(trigger.platformUrl)}`);
+        }
 
-    console.log();
-    console.log(chalk.bold("  Trigger Details:"));
-    console.log(`    ${chalk.gray("ID:")}      ${chalk.green(trigger.id)}`);
-    console.log(`    ${chalk.gray("Name:")}    ${chalk.cyan(trigger.name)}`);
-    console.log(`    ${chalk.gray("Action:")}  ${trigger.action}`);
-    console.log(`    ${chalk.gray("Status:")}  ${trigger.active ? chalk.green("active") : chalk.gray("inactive")}`);
-    console.log(`    ${chalk.gray("Alert:")}   ${trigger.alertType ?? chalk.gray("—")}`);
-    console.log(`    ${chalk.gray("Message:")} ${trigger.message ?? chalk.gray("—")}`);
-    console.log(`    ${chalk.gray("Created:")} ${new Date(trigger.createdAt).toLocaleString()}`);
-    if (trigger.platformUrl) {
-      console.log(`    ${chalk.bold("View:")}   ${chalk.underline(trigger.platformUrl)}`);
-    }
+        if (Object.keys(trigger.filters).length > 0) {
+          console.log();
+          console.log(chalk.bold("  Filters:"));
+          console.log(`    ${JSON.stringify(trigger.filters, null, 2).split("\n").join("\n    ")}`);
+        }
 
-    if (Object.keys(trigger.filters).length > 0) {
-      console.log();
-      console.log(chalk.bold("  Filters:"));
-      console.log(`    ${JSON.stringify(trigger.filters, null, 2).split("\n").join("\n    ")}`);
-    }
-
-    console.log();
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch trigger" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/triggers/list.ts
+++ b/typescript-sdk/src/cli/commands/triggers/list.ts
@@ -7,7 +7,13 @@ import { failSpinner } from "../../utils/spinnerError";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
-export const listTriggersCommand = async (options?: { format?: string }): Promise<void> => {
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts).
+ */
+export const listTriggersCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -36,39 +42,39 @@ export const listTriggersCommand = async (options?: { format?: string }): Promis
 
     spinner.succeed(`Found ${triggers.length} trigger${triggers.length !== 1 ? "s" : ""}`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(triggers, null, 2));
-      return;
-    }
+    return {
+      data: triggers,
+      table: () => {
+        if (triggers.length === 0) {
+          console.log();
+          console.log(chalk.gray("No triggers found."));
+          console.log(chalk.gray("Create one with:"));
+          console.log(chalk.cyan('  langwatch trigger create "My Alert" --action SEND_EMAIL'));
+          return;
+        }
 
-    if (triggers.length === 0) {
-      console.log();
-      console.log(chalk.gray("No triggers found."));
-      console.log(chalk.gray("Create one with:"));
-      console.log(chalk.cyan('  langwatch trigger create "My Alert" --action SEND_EMAIL'));
-      return;
-    }
+        console.log();
 
-    console.log();
+        const tableData = triggers.map((t) => ({
+          Name: t.name,
+          ID: t.id,
+          Action: t.action,
+          Status: t.active ? chalk.green("active") : chalk.gray("inactive"),
+          Alert: t.alertType ?? chalk.gray("—"),
+        }));
 
-    const tableData = triggers.map((t) => ({
-      Name: t.name,
-      ID: t.id,
-      Action: t.action,
-      Status: t.active ? chalk.green("active") : chalk.gray("inactive"),
-      Alert: t.alertType ?? chalk.gray("—"),
-    }));
+        formatTable({
+          data: tableData,
+          headers: ["Name", "ID", "Action", "Status", "Alert"],
+          colorMap: {
+            Name: chalk.cyan,
+            ID: chalk.green,
+          },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["Name", "ID", "Action", "Status", "Alert"],
-      colorMap: {
-        Name: chalk.cyan,
-        ID: chalk.green,
+        console.log();
       },
-    });
-
-    console.log();
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch triggers" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/triggers/list.ts
+++ b/typescript-sdk/src/cli/commands/triggers/list.ts
@@ -8,6 +8,7 @@ import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
+import { redactTriggerListSecrets } from "./redact";
 
 /**
  * Returns the listing rather than printing it: the output port renders it in
@@ -43,7 +44,8 @@ export const listTriggersCommand = async (): Promise<CommandResult | void> => {
     spinner.succeed(`Found ${triggers.length} trigger${triggers.length !== 1 ? "s" : ""}`);
 
     return {
-      data: triggers,
+      // See ./redact.ts — actionParams is plaintext and never shown to humans.
+      data: redactTriggerListSecrets(triggers),
       table: () => {
         if (triggers.length === 0) {
           console.log();

--- a/typescript-sdk/src/cli/commands/triggers/redact.ts
+++ b/typescript-sdk/src/cli/commands/triggers/redact.ts
@@ -1,0 +1,44 @@
+/**
+ * `actionParams` carries the trigger's delivery credentials — Slack webhook
+ * URLs, custom-endpoint URLs and their headers — and `/api/triggers` returns
+ * them in PLAINTEXT, unredacted. The human "Trigger Details" block has always
+ * deliberately omitted them.
+ *
+ * That was survivable while the raw payload needed an explicit `-f json`. It is
+ * not survivable now: agent mode auto-activates from `CLAUDECODE` and friends,
+ * so a bare `lw trigger get <id>` inside any Claude Code session would print a
+ * live webhook URL straight into the transcript. Machine output is the MORE
+ * exposed surface — it gets logged, piped and pasted into agent context — so it
+ * cannot be the one place a secret appears.
+ *
+ * Key names are kept: an agent needs to know a trigger HAS a `slackWebhook`
+ * configured to reason about it; it never needs the value. Fetch the real thing
+ * from the platform UI.
+ */
+const REDACTED = "[redacted — fetch from the LangWatch UI]";
+
+/**
+ * Constrained to `object`, NOT to a shape declaring `actionParams`.
+ *
+ * `triggers/list.ts` and `create.ts` cast the response to types that omit
+ * `actionParams` — but the cast is compile-time only, the REST payload really
+ * does carry the field, and `JSON.stringify` really does emit it. Requiring the
+ * field in the type would make those two call sites un-typeable and leave the
+ * secret in the payload, which is the bug this module exists to fix. So the
+ * check is a runtime one, deliberately.
+ */
+export const redactTriggerSecrets = <T extends object>(trigger: T): T => {
+  const params = (trigger as { actionParams?: unknown }).actionParams;
+  if (!params || typeof params !== "object") return trigger;
+
+  return {
+    ...trigger,
+    actionParams: Object.fromEntries(
+      Object.keys(params as Record<string, unknown>).map((key) => [key, REDACTED]),
+    ),
+  };
+};
+
+/** The list form: redacts every element. */
+export const redactTriggerListSecrets = <T extends object>(triggers: T[]): T[] =>
+  triggers.map(redactTriggerSecrets);

--- a/typescript-sdk/src/cli/commands/triggers/update.ts
+++ b/typescript-sdk/src/cli/commands/triggers/update.ts
@@ -6,6 +6,12 @@ import { commandValidationError } from "../../utils/errorOutput";
 import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
+import type { CommandResult } from "../../utils/output";
+
+/**
+ * Returns the updated trigger rather than printing it: the output port renders
+ * it in whatever format the caller asked for (utils/output.ts).
+ */
 export const updateTriggerCommand = async (
   id: string,
   options: {
@@ -13,9 +19,8 @@ export const updateTriggerCommand = async (
     active?: string;
     message?: string;
     alertType?: string;
-    format?: string;
   },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const apiKey = process.env.LANGWATCH_API_KEY ?? "";
@@ -59,9 +64,13 @@ export const updateTriggerCommand = async (
     const trigger = await response.json() as { id: string; name: string; active: boolean };
     spinner.succeed(`Trigger "${trigger.name}" updated`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(trigger, null, 2));
-    }
+    return {
+      data: trigger,
+      table: () => {
+        // Nothing further to print: the spinner line above was the whole
+        // human output before the migration, and stays so.
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "update trigger" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/virtual-keys/create.ts
+++ b/typescript-sdk/src/cli/commands/virtual-keys/create.ts
@@ -4,6 +4,7 @@ import { VirtualKeysApiService } from "@/client-sdk/services/virtual-keys/virtua
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
 import { formatScope, parseScopeArg, virtualKeyDetailUrl } from "./_shared";
+import type { CommandResult } from "../../utils/output";
 
 export interface CreateVirtualKeyOptions {
   name: string;
@@ -12,10 +13,21 @@ export interface CreateVirtualKeyOptions {
   scope?: string[];
   routingPolicy?: string;
   principalUser?: string;
-  format?: string;
 }
 
-export const createVirtualKeyCommand = async (options: CreateVirtualKeyOptions): Promise<void> => {
+/**
+ * Returns the created key rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts).
+ *
+ * `data` deliberately includes `secret`. This is the ONE moment the secret
+ * exists — the server stores only its hash and never returns it again — so the
+ * human output prints it in full, as did the previous `--format json` branch.
+ * A `virtual-key create -o json` that withheld it would produce a key nobody
+ * could ever use.
+ */
+export const createVirtualKeyCommand = async (
+  options: CreateVirtualKeyOptions,
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   if (!options.name) {
@@ -56,34 +68,34 @@ export const createVirtualKeyCommand = async (options: CreateVirtualKeyOptions):
 
     spinner.succeed(`Created virtual key "${chalk.cyan(virtual_key.name)}"`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify({ virtual_key, secret }, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(chalk.bold.yellow("⚠  Save the secret below NOW. It will not be shown again."));
-    console.log();
-    console.log(`  ${chalk.green(secret)}`);
-    console.log();
-    console.log(chalk.gray("Use it as the API key in OpenAI-compatible clients:"));
-    console.log(chalk.cyan("  export OPENAI_API_KEY=\"" + secret + "\""));
-    console.log(chalk.cyan("  export OPENAI_BASE_URL=\"https://gateway.langwatch.ai/v1\""));
-    console.log();
-    console.log(chalk.gray("Virtual key id: ") + virtual_key.id);
-    console.log(chalk.gray("Prefix:         ") + `${virtual_key.prefix}...${virtual_key.last_four}`);
-    console.log(chalk.gray("Scopes:         ") + virtual_key.scopes.map(formatScope).join(", "));
-    if (virtual_key.routing_policy_id) {
-      console.log(chalk.gray("Routing policy: ") + virtual_key.routing_policy_id);
-    }
-    if (virtual_key.principal_user_id) {
-      console.log(chalk.gray("Principal:      ") + virtual_key.principal_user_id);
-    }
-    const detailUrl = virtualKeyDetailUrl(virtual_key.id);
-    if (detailUrl) {
-      console.log(chalk.gray("View in UI:     ") + chalk.cyan(detailUrl));
-    }
-    console.log();
+    return {
+      data: { virtual_key, secret },
+      table: () => {
+        console.log();
+        console.log(chalk.bold.yellow("⚠  Save the secret below NOW. It will not be shown again."));
+        console.log();
+        console.log(`  ${chalk.green(secret)}`);
+        console.log();
+        console.log(chalk.gray("Use it as the API key in OpenAI-compatible clients:"));
+        console.log(chalk.cyan("  export OPENAI_API_KEY=\"" + secret + "\""));
+        console.log(chalk.cyan("  export OPENAI_BASE_URL=\"https://gateway.langwatch.ai/v1\""));
+        console.log();
+        console.log(chalk.gray("Virtual key id: ") + virtual_key.id);
+        console.log(chalk.gray("Prefix:         ") + `${virtual_key.prefix}...${virtual_key.last_four}`);
+        console.log(chalk.gray("Scopes:         ") + virtual_key.scopes.map(formatScope).join(", "));
+        if (virtual_key.routing_policy_id) {
+          console.log(chalk.gray("Routing policy: ") + virtual_key.routing_policy_id);
+        }
+        if (virtual_key.principal_user_id) {
+          console.log(chalk.gray("Principal:      ") + virtual_key.principal_user_id);
+        }
+        const detailUrl = virtualKeyDetailUrl(virtual_key.id);
+        if (detailUrl) {
+          console.log(chalk.gray("View in UI:     ") + chalk.cyan(detailUrl));
+        }
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "create virtual key" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/virtual-keys/get.ts
+++ b/typescript-sdk/src/cli/commands/virtual-keys/get.ts
@@ -4,8 +4,17 @@ import { VirtualKeysApiService } from "@/client-sdk/services/virtual-keys/virtua
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
 import { formatScope, virtualKeyDetailUrl } from "./_shared";
+import type { CommandResult } from "../../utils/output";
 
-export const getVirtualKeyCommand = async (id: string, options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the virtual key rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts). The read model
+ * carries no secret — only `prefix`/`last_four`, exactly what the human view
+ * shows — so the raw record is safe to hand to a machine caller.
+ */
+export const getVirtualKeyCommand = async (
+  id: string,
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new VirtualKeysApiService();
@@ -16,38 +25,38 @@ export const getVirtualKeyCommand = async (id: string, options?: { format?: stri
 
     spinner.succeed(`Fetched virtual key "${chalk.cyan(vk.name)}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(vk, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`${chalk.bold("ID:")}           ${vk.id}`);
-    console.log(`${chalk.bold("Name:")}         ${chalk.cyan(vk.name)}`);
-    if (vk.description) {
-      console.log(`${chalk.bold("Description:")}  ${vk.description}`);
-    }
-    console.log(`${chalk.bold("Environment:")}  ${vk.environment === "live" ? chalk.yellow("live") : chalk.gray("test")}`);
-    console.log(`${chalk.bold("Status:")}       ${vk.status === "ACTIVE" ? chalk.green("active") : chalk.red("revoked")}`);
-    console.log(`${chalk.bold("Prefix:")}       ${vk.prefix}...${vk.last_four}`);
-    console.log(`${chalk.bold("Principal:")}    ${vk.principal_user_id ?? chalk.gray("—")}`);
-    console.log(`${chalk.bold("Scopes:")}       ${vk.scopes.map(formatScope).join(", ") || chalk.gray("—")}`);
-    console.log(`${chalk.bold("Routing pol.:")} ${vk.routing_policy_id ?? chalk.gray("(default)")}`);
-    console.log(`${chalk.bold("Created:")}      ${new Date(vk.created_at).toLocaleString()}`);
-    if (vk.last_used_at) {
-      console.log(`${chalk.bold("Last used:")}    ${new Date(vk.last_used_at).toLocaleString()}`);
-    }
-    if (vk.revoked_at) {
-      console.log(`${chalk.bold("Revoked:")}      ${chalk.red(new Date(vk.revoked_at).toLocaleString())}`);
-    }
-    const detailUrl = virtualKeyDetailUrl(vk.id);
-    if (detailUrl) {
-      console.log(`${chalk.bold("View in UI:")}  ${chalk.cyan(detailUrl)}`);
-    }
-    console.log();
-    console.log(chalk.bold("Config:"));
-    console.log(JSON.stringify(vk.config, null, 2));
-    console.log();
+    return {
+      data: vk,
+      table: () => {
+        console.log();
+        console.log(`${chalk.bold("ID:")}           ${vk.id}`);
+        console.log(`${chalk.bold("Name:")}         ${chalk.cyan(vk.name)}`);
+        if (vk.description) {
+          console.log(`${chalk.bold("Description:")}  ${vk.description}`);
+        }
+        console.log(`${chalk.bold("Environment:")}  ${vk.environment === "live" ? chalk.yellow("live") : chalk.gray("test")}`);
+        console.log(`${chalk.bold("Status:")}       ${vk.status === "ACTIVE" ? chalk.green("active") : chalk.red("revoked")}`);
+        console.log(`${chalk.bold("Prefix:")}       ${vk.prefix}...${vk.last_four}`);
+        console.log(`${chalk.bold("Principal:")}    ${vk.principal_user_id ?? chalk.gray("—")}`);
+        console.log(`${chalk.bold("Scopes:")}       ${vk.scopes.map(formatScope).join(", ") || chalk.gray("—")}`);
+        console.log(`${chalk.bold("Routing pol.:")} ${vk.routing_policy_id ?? chalk.gray("(default)")}`);
+        console.log(`${chalk.bold("Created:")}      ${new Date(vk.created_at).toLocaleString()}`);
+        if (vk.last_used_at) {
+          console.log(`${chalk.bold("Last used:")}    ${new Date(vk.last_used_at).toLocaleString()}`);
+        }
+        if (vk.revoked_at) {
+          console.log(`${chalk.bold("Revoked:")}      ${chalk.red(new Date(vk.revoked_at).toLocaleString())}`);
+        }
+        const detailUrl = virtualKeyDetailUrl(vk.id);
+        if (detailUrl) {
+          console.log(`${chalk.bold("View in UI:")}  ${chalk.cyan(detailUrl)}`);
+        }
+        console.log();
+        console.log(chalk.bold("Config:"));
+        console.log(JSON.stringify(vk.config, null, 2));
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch virtual key" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/virtual-keys/list.ts
+++ b/typescript-sdk/src/cli/commands/virtual-keys/list.ts
@@ -5,8 +5,15 @@ import { checkApiKey } from "../../utils/apiKey";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
 import { formatScope } from "./_shared";
+import type { CommandResult } from "../../utils/output";
 
-export const listVirtualKeysCommand = async (options?: { format?: string }): Promise<void> => {
+/**
+ * Returns the listing rather than printing it: the output port renders it in
+ * whatever format the caller asked for (utils/output.ts). The list model
+ * carries no secrets — only `prefix`/`last_four`, exactly what the human table
+ * shows — so the raw list is safe to hand to a machine caller.
+ */
+export const listVirtualKeysCommand = async (): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new VirtualKeysApiService();
@@ -17,46 +24,46 @@ export const listVirtualKeysCommand = async (options?: { format?: string }): Pro
 
     spinner.succeed(`Found ${keys.length} virtual key${keys.length !== 1 ? "s" : ""}`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(keys, null, 2));
-      return;
-    }
+    return {
+      data: keys,
+      table: () => {
+        if (keys.length === 0) {
+          console.log();
+          console.log(chalk.gray("No virtual keys yet."));
+          console.log(chalk.gray("Create one with:"));
+          console.log(chalk.cyan('  langwatch virtual-keys create --name "my-key" --scope ORG:<slug>'));
+          return;
+        }
 
-    if (keys.length === 0) {
-      console.log();
-      console.log(chalk.gray("No virtual keys yet."));
-      console.log(chalk.gray("Create one with:"));
-      console.log(chalk.cyan('  langwatch virtual-keys create --name "my-key" --scope ORG:<slug>'));
-      return;
-    }
+        console.log();
 
-    console.log();
+        const tableData = keys.map((vk) => ({
+          ID: vk.id,
+          Name: vk.name,
+          Env: vk.environment === "live" ? chalk.yellow("live") : chalk.gray("test"),
+          Status: vk.status === "ACTIVE" ? chalk.green("active") : chalk.red("revoked"),
+          Prefix: `${vk.prefix}...${vk.last_four}`,
+          Scopes: vk.scopes.map(formatScope).join(", ") || chalk.gray("—"),
+          "Last used": vk.last_used_at ? new Date(vk.last_used_at).toLocaleDateString() : chalk.gray("—"),
+        }));
 
-    const tableData = keys.map((vk) => ({
-      ID: vk.id,
-      Name: vk.name,
-      Env: vk.environment === "live" ? chalk.yellow("live") : chalk.gray("test"),
-      Status: vk.status === "ACTIVE" ? chalk.green("active") : chalk.red("revoked"),
-      Prefix: `${vk.prefix}...${vk.last_four}`,
-      Scopes: vk.scopes.map(formatScope).join(", ") || chalk.gray("—"),
-      "Last used": vk.last_used_at ? new Date(vk.last_used_at).toLocaleDateString() : chalk.gray("—"),
-    }));
+        formatTable({
+          data: tableData,
+          headers: ["ID", "Name", "Env", "Status", "Prefix", "Scopes", "Last used"],
+          colorMap: {
+            Name: chalk.cyan,
+            ID: chalk.gray,
+          },
+        });
 
-    formatTable({
-      data: tableData,
-      headers: ["ID", "Name", "Env", "Status", "Prefix", "Scopes", "Last used"],
-      colorMap: {
-        Name: chalk.cyan,
-        ID: chalk.gray,
+        console.log();
+        console.log(
+          chalk.gray(
+            `Use ${chalk.cyan("langwatch virtual-keys get <id>")} to see scopes, routing policy, and config.`,
+          ),
+        );
       },
-    });
-
-    console.log();
-    console.log(
-      chalk.gray(
-        `Use ${chalk.cyan("langwatch virtual-keys get <id>")} to see scopes, routing policy, and config.`,
-      ),
-    );
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "fetch virtual keys" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/virtual-keys/revoke.ts
+++ b/typescript-sdk/src/cli/commands/virtual-keys/revoke.ts
@@ -3,11 +3,15 @@ import { createSpinner } from "../../utils/spinner";
 import { VirtualKeysApiService } from "@/client-sdk/services/virtual-keys/virtual-keys-api.service";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the revoked key rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts).
+ */
 export const revokeVirtualKeyCommand = async (
   id: string,
-  options?: { format?: string },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new VirtualKeysApiService();
@@ -18,17 +22,17 @@ export const revokeVirtualKeyCommand = async (
 
     spinner.succeed(`Revoked virtual key "${chalk.cyan(vk.name)}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify(vk, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(chalk.gray("Status: ") + chalk.red(vk.status));
-    if (vk.revoked_at) {
-      console.log(chalk.gray("Revoked at: ") + new Date(vk.revoked_at).toLocaleString());
-    }
-    console.log();
+    return {
+      data: vk,
+      table: () => {
+        console.log();
+        console.log(chalk.gray("Status: ") + chalk.red(vk.status));
+        if (vk.revoked_at) {
+          console.log(chalk.gray("Revoked at: ") + new Date(vk.revoked_at).toLocaleString());
+        }
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "revoke virtual key" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/virtual-keys/rotate.ts
+++ b/typescript-sdk/src/cli/commands/virtual-keys/rotate.ts
@@ -4,11 +4,21 @@ import { VirtualKeysApiService } from "@/client-sdk/services/virtual-keys/virtua
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
 import { virtualKeyDetailUrl } from "./_shared";
+import type { CommandResult } from "../../utils/output";
 
+/**
+ * Returns the rotated key rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts).
+ *
+ * `data` deliberately includes the new `secret`, for the same reason create
+ * does: rotation is the only moment it exists, the old secret stops working
+ * immediately, and the human output already prints it in full — as did the
+ * previous `--format json` branch. A rotate that withheld the new secret from
+ * a scripted caller would break the very deployment it was rotating.
+ */
 export const rotateVirtualKeyCommand = async (
   id: string,
-  options?: { format?: string },
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   const service = new VirtualKeysApiService();
@@ -19,22 +29,22 @@ export const rotateVirtualKeyCommand = async (
 
     spinner.succeed(`Rotated virtual key "${chalk.cyan(virtual_key.name)}"`);
 
-    if (options?.format === "json") {
-      console.log(JSON.stringify({ virtual_key, secret }, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(chalk.bold.yellow("⚠  New secret — save it NOW. The old secret stops working immediately."));
-    console.log();
-    console.log(`  ${chalk.green(secret)}`);
-    console.log();
-    console.log(chalk.gray("Prefix: ") + `${virtual_key.prefix}...${virtual_key.last_four}`);
-    const detailUrl = virtualKeyDetailUrl(virtual_key.id);
-    if (detailUrl) {
-      console.log(chalk.gray("View in UI: ") + chalk.cyan(detailUrl));
-    }
-    console.log();
+    return {
+      data: { virtual_key, secret },
+      table: () => {
+        console.log();
+        console.log(chalk.bold.yellow("⚠  New secret — save it NOW. The old secret stops working immediately."));
+        console.log();
+        console.log(`  ${chalk.green(secret)}`);
+        console.log();
+        console.log(chalk.gray("Prefix: ") + `${virtual_key.prefix}...${virtual_key.last_four}`);
+        const detailUrl = virtualKeyDetailUrl(virtual_key.id);
+        if (detailUrl) {
+          console.log(chalk.gray("View in UI: ") + chalk.cyan(detailUrl));
+        }
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "rotate virtual key" });
     process.exit(1);

--- a/typescript-sdk/src/cli/commands/virtual-keys/update.ts
+++ b/typescript-sdk/src/cli/commands/virtual-keys/update.ts
@@ -5,6 +5,7 @@ import { VirtualKeysApiService } from "@/client-sdk/services/virtual-keys/virtua
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
 import { formatScope, parseScopeArg } from "./_shared";
+import type { CommandResult } from "../../utils/output";
 
 export interface UpdateVirtualKeyOptions {
   name?: string;
@@ -15,7 +16,6 @@ export interface UpdateVirtualKeyOptions {
   clearRoutingPolicy?: boolean;
   configJson?: string;
   configFile?: string;
-  format?: string;
 }
 
 function parseConfig(options: UpdateVirtualKeyOptions): Record<string, unknown> | undefined {
@@ -41,10 +41,15 @@ function parseConfig(options: UpdateVirtualKeyOptions): Record<string, unknown> 
   return undefined;
 }
 
+/**
+ * Returns the updated key rather than printing it: the output port renders it
+ * in whatever format the caller asked for (utils/output.ts). The update
+ * response carries no secret, only the record and its config.
+ */
 export const updateVirtualKeyCommand = async (
   id: string,
   options: UpdateVirtualKeyOptions,
-): Promise<void> => {
+): Promise<CommandResult | void> => {
   checkApiKey();
 
   let config: Record<string, unknown> | undefined;
@@ -97,22 +102,22 @@ export const updateVirtualKeyCommand = async (
 
     spinner.succeed(`Updated virtual key "${chalk.cyan(updated.name)}"`);
 
-    if (options.format === "json") {
-      console.log(JSON.stringify(updated, null, 2));
-      return;
-    }
-
-    console.log();
-    console.log(`${chalk.bold("ID:")}           ${updated.id}`);
-    console.log(`${chalk.bold("Name:")}         ${chalk.cyan(updated.name)}`);
-    if (updated.description) console.log(`${chalk.bold("Description:")}  ${updated.description}`);
-    console.log(`${chalk.bold("Scopes:")}       ${updated.scopes.map(formatScope).join(", ") || chalk.gray("—")}`);
-    console.log(`${chalk.bold("Routing pol.:")} ${updated.routing_policy_id ?? chalk.gray("(default)")}`);
-    console.log(`${chalk.bold("Updated:")}      ${new Date(updated.updated_at).toLocaleString()}`);
-    console.log();
-    console.log(chalk.gray("Config after update:"));
-    console.log(JSON.stringify(updated.config, null, 2));
-    console.log();
+    return {
+      data: updated,
+      table: () => {
+        console.log();
+        console.log(`${chalk.bold("ID:")}           ${updated.id}`);
+        console.log(`${chalk.bold("Name:")}         ${chalk.cyan(updated.name)}`);
+        if (updated.description) console.log(`${chalk.bold("Description:")}  ${updated.description}`);
+        console.log(`${chalk.bold("Scopes:")}       ${updated.scopes.map(formatScope).join(", ") || chalk.gray("—")}`);
+        console.log(`${chalk.bold("Routing pol.:")} ${updated.routing_policy_id ?? chalk.gray("(default)")}`);
+        console.log(`${chalk.bold("Updated:")}      ${new Date(updated.updated_at).toLocaleString()}`);
+        console.log();
+        console.log(chalk.gray("Config after update:"));
+        console.log(JSON.stringify(updated.config, null, 2));
+        console.log();
+      },
+    };
   } catch (error) {
     failSpinner({ spinner, error, action: "update virtual key" });
     process.exit(1);

--- a/typescript-sdk/src/cli/daemon/__tests__/daemon-server.integration.test.ts
+++ b/typescript-sdk/src/cli/daemon/__tests__/daemon-server.integration.test.ts
@@ -21,6 +21,7 @@ import * as path from "node:path";
 import { Writable } from "node:stream";
 
 import { execViaDaemon, requestStatus, requestStop } from "../client";
+import { secureSocketFile } from "../identity";
 import {
   cleanStaleSocket,
   createDaemonServer,
@@ -135,6 +136,7 @@ describe("daemon over a unix socket", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await server?.stop("stop-requested");
     server = undefined;
     fs.rmSync(dir, { recursive: true, force: true });
@@ -613,6 +615,127 @@ describe("daemon over a unix socket", () => {
     });
   });
 
+  /**
+   * The daemon's whole trust model is filesystem permissions. The server half
+   * (0600 socket in a 0700 directory) is worthless if the CLIENT will talk to
+   * any socket at that path — it pipelines `exec` before the handshake is
+   * answered, so a squatter is handed the caller's args, cwd and forwarded
+   * LANGWATCH_* env, API key included.
+   */
+  describe("given a socket the caller cannot trust", () => {
+    describe("when its directory is writable by other users", () => {
+      it("refuses to connect and reports not-served, so the CLI runs in-process", async () => {
+        const executor = vi.fn(scriptedExecutor(() => ({ stdout: "leaked\n" })));
+        await startDaemon({ executor });
+
+        // Anyone who can write the directory can unlink our socket and bind
+        // their own in its place.
+        fs.chmodSync(dir, 0o777);
+
+        const { outcome, stdout } = await exec(["trace", "search"]);
+
+        expect(outcome).toEqual({
+          served: false,
+          reason: "socket-dir-loose-mode",
+        });
+        expect(stdout).toBe("");
+        expect(executor).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the socket itself is world-connectable", () => {
+      it("refuses it rather than drive a daemon anyone else can drive too", async () => {
+        const executor = vi.fn(scriptedExecutor(() => ({ stdout: "leaked\n" })));
+        await startDaemon({ executor });
+
+        fs.chmodSync(socketPath, 0o666);
+
+        const { outcome } = await exec(["trace", "search"]);
+
+        expect(outcome).toEqual({ served: false, reason: "socket-loose-mode" });
+        expect(executor).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when it is owned by another user", () => {
+      it("refuses it, and reports no daemon for status and stop as well", async () => {
+        const executor = vi.fn(scriptedExecutor(() => ({ stdout: "leaked\n" })));
+        await startDaemon({ executor });
+
+        // chown needs root; moving OUR uid makes the same comparison fail.
+        vi.spyOn(process, "getuid").mockReturnValue(
+          (process.getuid?.() ?? 0) + 1,
+        );
+
+        const { outcome, stdout } = await exec(["trace", "search"]);
+
+        expect(outcome).toEqual({
+          served: false,
+          reason: "socket-dir-foreign-owner",
+        });
+        expect(stdout).toBe("");
+        expect(executor).not.toHaveBeenCalled();
+        // A stranger's listener is not our daemon: nothing to report, and
+        // nothing to send an unauthenticated `stop` to.
+        expect(await requestStatus(socketPath)).toBeNull();
+        expect(await requestStop(socketPath)).toBe(false);
+
+        vi.restoreAllMocks();
+      });
+    });
+  });
+
+  describe("given a daemon asked to stop while it is still serving", () => {
+    describe("when a request is in flight", () => {
+      it("waits for it before tearing the execution window down", async () => {
+        const running = await startDaemon({
+          shutdownGraceMs: 5_000,
+          executor: scriptedExecutor(() => ({
+            stdout: "finished\n",
+            delayMs: 60,
+          })),
+        });
+
+        const inFlight = exec(["slow"]);
+        // Let the exec frame land so the request is genuinely counted.
+        await vi.waitFor(() => expect(running.stats().inflight).toBe(1));
+
+        await running.stop("stop-requested");
+
+        // Version-skew eviction makes this a routine dev-loop event; the
+        // request must not finish against the daemon's restored globals.
+        expect(running.stats().inflight).toBe(0);
+
+        const { outcome, stdout } = await inFlight;
+        expect(outcome).toEqual({ served: true, exitCode: 0 });
+        expect(stdout).toBe("finished\n");
+      });
+    });
+
+    describe("when the in-flight request will not finish in time", () => {
+      it("cuts the connection so the client falls back instead of trusting the result", async () => {
+        const running = await startDaemon({
+          shutdownGraceMs: 30,
+          executor: (): CommandExecution => ({
+            completed: new Promise<number>(() => undefined),
+            cancel: () => undefined,
+          }),
+        });
+
+        const inFlight = exec(["forever"]);
+        await vi.waitFor(() => expect(running.stats().inflight).toBe(1));
+
+        await running.stop("stop-requested");
+
+        // No `exit` frame ever reached the client, and nothing was committed to
+        // its stdout, so re-running in-process is safe and correct.
+        const { outcome, stdout } = await inFlight;
+        expect(outcome).toMatchObject({ served: false });
+        expect(stdout).toBe("");
+      });
+    });
+  });
+
   describe("given a daemon that declines the request", () => {
     describe("when the caller's working directory no longer exists", () => {
       it("tells the client to run it in-process, having emitted no output", async () => {
@@ -684,6 +807,11 @@ describe("given a daemon that dies mid-command", () => {
       });
     });
     await new Promise<void>((resolve) => rogue.listen(socketPath, resolve));
+    // A real daemon tightens its socket to 0600 the moment it binds; the client
+    // will not talk to one that has not (see inspectSocketTrust), so the rogue
+    // has to look like a genuine daemon for these tests to exercise the
+    // mid-command death they are actually about.
+    secureSocketFile(socketPath);
   };
 
   describe("when it dies before any output reaches the caller", () => {

--- a/typescript-sdk/src/cli/daemon/__tests__/daemon-server.integration.test.ts
+++ b/typescript-sdk/src/cli/daemon/__tests__/daemon-server.integration.test.ts
@@ -21,11 +21,12 @@ import * as path from "node:path";
 import { Writable } from "node:stream";
 
 import { execViaDaemon, requestStatus, requestStop } from "../client";
-import { secureSocketFile } from "../identity";
+import { secureSocketFile, UntrustedSocketDirError } from "../identity";
 import {
   cleanStaleSocket,
   createDaemonServer,
   DaemonAlreadyRunningError,
+  isSocketAlive,
   type DaemonServer,
 } from "../server";
 import { encodeFrame, FrameDecoder, PROTOCOL_VERSION, type ClientFrame } from "../protocol";
@@ -685,15 +686,93 @@ describe("daemon over a unix socket", () => {
     });
   });
 
+  describe("given somebody else already holds the socket path", () => {
+    describe("when the real daemon tries to start", () => {
+      it("names the squat instead of reporting a daemon that is already running", async () => {
+        // The DoS the trust check has to prevent. `isSocketAlive` used to
+        // connect blind, so a squatter binding the path first — reachable via
+        // LANGWATCH_DAEMON_DIR, XDG_RUNTIME_DIR or the tmp fallback — made
+        // `listen()` throw DaemonAlreadyRunningError, forever. Nothing is
+        // disclosed (no bytes are sent), but the daemon could never start again
+        // and nothing would ever say why: a permanent, silent denial of service.
+        // A stranger's listener, bound to our socket path first.
+        const squatter = net.createServer();
+        await new Promise<void>((resolve) =>
+          squatter.listen(socketPath, resolve),
+        );
+        secureSocketFile(socketPath);
+
+        // chown needs root; moving OUR uid makes the same comparison fail.
+        vi.spyOn(process, "getuid").mockReturnValue(
+          (process.getuid?.() ?? 0) + 1,
+        );
+
+        // A foreign socket is not "alive", because it is not ours...
+        expect(await isSocketAlive(socketPath)).toBe(false);
+
+        // ...and starting reports the actual problem, actionably.
+        const created = createDaemonServer({
+          socketPath,
+          socketDir: dir,
+          fingerprint: FINGERPRINT,
+          cliVersion: CLI_VERSION,
+          build: BUILD,
+          idleTimeoutMs: 60_000,
+          executor: scriptedExecutor(() => ({ stdout: "ok\n" })),
+        });
+
+        const failure = await created.listen().catch((error: unknown) => error);
+        expect(failure).toBeInstanceOf(UntrustedSocketDirError);
+        // The distinction that matters: NOT "already running", which is the
+        // misdiagnosis no amount of restarting could ever clear.
+        expect(failure).not.toBeInstanceOf(DaemonAlreadyRunningError);
+        // (`ensureSocketDir` is what fires here — under a foreign uid the
+        // containing directory fails first. The socket-level check in
+        // `listen()` covers the narrower window where the directory was
+        // repaired but the squatter's socket file survived inside it.)
+        expect((failure as Error).message).toContain("owned by another user");
+
+        vi.restoreAllMocks();
+        await new Promise<void>((resolve) => squatter.close(() => resolve()));
+      });
+    });
+  });
+
   describe("given a daemon asked to stop while it is still serving", () => {
     describe("when a request is in flight", () => {
       it("waits for it before tearing the execution window down", async () => {
+        // What actually goes wrong without the drain is NOT a missing exit
+        // frame — the frame still arrives, and the client still reports exit 0.
+        // It is that `window.reset()` restores the daemon's OWN cwd and
+        // environment underneath a command that has not finished, so the
+        // command resolves its remaining paths and reads its credentials
+        // against the wrong globals and then reports a status the client
+        // trusts. That is invisible to the transcript, so the transcript is not
+        // what this asserts on: the executor records what it SEES at the moment
+        // it completes, the way `resumableProgram` does in the runner tests.
+        const seen: { cwd?: string; token?: string } = {};
+        const savedCwd = process.cwd();
+        const callerCwd = fs.realpathSync(dir);
+
         const running = await startDaemon({
           shutdownGraceMs: 5_000,
-          executor: scriptedExecutor(() => ({
-            stdout: "finished\n",
-            delayMs: 60,
-          })),
+          executor: (request): CommandExecution => {
+            // Stand in for ExecutionWindow.applyWindow, which the real executor
+            // would have run: put the process into the caller's window.
+            process.chdir(request.cwd);
+            process.env.LW_TEST_WINDOW_TOKEN = "caller";
+            return {
+              completed: new Promise<number>((resolve) => {
+                setTimeout(() => {
+                  seen.cwd = process.cwd();
+                  seen.token = process.env.LW_TEST_WINDOW_TOKEN;
+                  request.sink("stdout", Buffer.from("finished\n"));
+                  resolve(0);
+                }, 60);
+              }),
+              cancel: () => undefined,
+            };
+          },
         });
 
         const inFlight = exec(["slow"]);
@@ -709,6 +788,14 @@ describe("daemon over a unix socket", () => {
         const { outcome, stdout } = await inFlight;
         expect(outcome).toEqual({ served: true, exitCode: 0 });
         expect(stdout).toBe("finished\n");
+
+        // The load-bearing assertions: the command finished inside its OWN
+        // window, not the daemon's restored one.
+        expect(seen.cwd).toBe(callerCwd);
+        expect(seen.token).toBe("caller");
+
+        process.chdir(savedCwd);
+        delete process.env.LW_TEST_WINDOW_TOKEN;
       });
     });
 
@@ -732,6 +819,55 @@ describe("daemon over a unix socket", () => {
         const { outcome, stdout } = await inFlight;
         expect(outcome).toMatchObject({ served: false });
         expect(stdout).toBe("");
+      });
+    });
+
+    describe("when the in-flight request has already flushed output to the caller", () => {
+      it("reports the truncation honestly instead of pretending it can re-run", async () => {
+        // The case the drain-timeout guarantee does NOT cover. Once output
+        // crosses the client's buffer cap it is on the caller's real stdout,
+        // so the clean in-process re-run is off the table — re-running would
+        // print it twice. `trace search`, `analytics query` and any large
+        // `--format json` land here, and routine version-skew eviction
+        // (dispatch.ts requestStop) is what triggers it.
+        const running = await startDaemon({
+          shutdownGraceMs: 30,
+          executor: (request): CommandExecution => {
+            request.sink("stdout", Buffer.from("partial results\n"));
+            return {
+              completed: new Promise<number>(() => undefined),
+              cancel: () => undefined,
+            };
+          },
+        });
+
+        const out = collector();
+        const err = collector();
+        const inFlight = execViaDaemon({
+          socketPath,
+          fingerprint: FINGERPRINT,
+          cliVersion: CLI_VERSION,
+          build: BUILD,
+          args: ["trace", "search"],
+          cwd: dir,
+          env: {},
+          colorLevel: 0,
+          // Commit on the first byte, as a real large-output command would.
+          maxBufferBytes: 1,
+          stdout: out.stream,
+          stderr: err.stream,
+        });
+        await vi.waitFor(() => expect(running.stats().inflight).toBe(1));
+
+        await running.stop("stop-requested");
+
+        // NOT `served: false`: a re-run would duplicate what is already printed.
+        expect(await inFlight).toEqual({ served: true, exitCode: 1 });
+        expect(out.text()).toBe("partial results\n");
+        // And the caller is told plainly that both halves of what they got are
+        // untrustworthy — the output is cut short, and the status is ours.
+        expect(err.text()).toContain("incomplete");
+        expect(err.text()).toContain("not the command's");
       });
     });
   });

--- a/typescript-sdk/src/cli/daemon/__tests__/identity.unit.test.ts
+++ b/typescript-sdk/src/cli/daemon/__tests__/identity.unit.test.ts
@@ -1,15 +1,30 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
+import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 
 import {
   daemonSocketDir,
   ensureSocketDir,
+  inspectSocketTrust,
   isSocketPathUsable,
   resolveIdentity,
   secureSocketFile,
+  UntrustedSocketDirError,
 } from "../identity";
+
+/**
+ * Restore IN PLACE. Assigning `process.env = {...}` swaps the real environment
+ * object for a plain one, after which native readers (`os.homedir`,
+ * `os.tmpdir`) no longer see anything the tests set.
+ */
+const restoreEnv = (saved: NodeJS.ProcessEnv): void => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in saved)) delete process.env[key];
+  }
+  Object.assign(process.env, saved);
+};
 
 describe("resolveIdentity", () => {
   const saved = { ...process.env };
@@ -21,7 +36,7 @@ describe("resolveIdentity", () => {
   });
 
   afterEach(() => {
-    process.env = { ...saved };
+    restoreEnv(saved);
   });
 
   describe("given the same endpoint and API key", () => {
@@ -86,7 +101,7 @@ describe("daemonSocketDir", () => {
   const saved = { ...process.env };
 
   afterEach(() => {
-    process.env = { ...saved };
+    restoreEnv(saved);
   });
 
   describe("when XDG_RUNTIME_DIR is set", () => {
@@ -99,10 +114,28 @@ describe("daemonSocketDir", () => {
   });
 
   describe("when XDG_RUNTIME_DIR is absent", () => {
-    it("falls back to the OS temp dir, namespaced by uid", () => {
+    it("falls back to a directory under HOME, namespaced by uid", () => {
       delete process.env.XDG_RUNTIME_DIR;
       delete process.env.LANGWATCH_DAEMON_DIR;
 
+      const dir = daemonSocketDir();
+
+      // NOT the OS temp dir: on Linux that is /tmp, mode 1777, so another user
+      // can pre-create langwatch-<uid>, own it, and leave us unable to secure
+      // the socket. Nobody but us can create a directory under $HOME.
+      expect(dir).toBe(
+        path.join(os.homedir(), ".langwatch", "run", path.basename(dir)),
+      );
+      expect(path.basename(dir)).toMatch(/^langwatch-\d+$/);
+    });
+
+    it("still uses the temp dir when HOME is too long for a unix socket", () => {
+      delete process.env.XDG_RUNTIME_DIR;
+      delete process.env.LANGWATCH_DAEMON_DIR;
+      process.env.HOME = "/" + "h".repeat(90);
+
+      // A daemon in a directory we validate on every connect beats a socket
+      // path that overflows sockaddr_un and disables the daemon outright.
       const dir = daemonSocketDir();
       expect(dir.startsWith(os.tmpdir())).toBe(true);
       expect(path.basename(dir)).toMatch(/^langwatch-\d+$/);
@@ -159,6 +192,144 @@ describe("socket permissions", () => {
       secureSocketFile(socketPath);
 
       expect((fs.statSync(socketPath).mode & 0o777).toString(8)).toBe("600");
+    });
+  });
+});
+
+/**
+ * The client-side half of the trust model. Server-side chmod only makes OUR
+ * socket private; it says nothing about a socket somebody else bound first.
+ */
+describe("inspectSocketTrust", () => {
+  let dir: string;
+  let socketPath: string;
+  let listener: net.Server | undefined;
+
+  /** Bind a real unix socket, secured exactly as a real daemon secures its own. */
+  const bindSocket = async (): Promise<void> => {
+    listener = net.createServer();
+    await new Promise<void>((resolve) => listener!.listen(socketPath, resolve));
+    secureSocketFile(socketPath);
+  };
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "lw-trust-"));
+    fs.chmodSync(dir, 0o700);
+    socketPath = path.join(dir, "d.sock");
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (listener) {
+      await new Promise<void>((resolve) => listener!.close(() => resolve()));
+      listener = undefined;
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("given our own daemon's socket", () => {
+    it("trusts a 0600 socket inside a 0700 directory we own", async () => {
+      await bindSocket();
+
+      expect(inspectSocketTrust(socketPath)).toBeNull();
+    });
+  });
+
+  describe("given a socket owned by another user", () => {
+    it("refuses it, so we never hand our args and API key to a stranger", async () => {
+      await bindSocket();
+      // We cannot chown without root; moving OUR uid is the same comparison.
+      vi.spyOn(process, "getuid").mockReturnValue(
+        (process.getuid?.() ?? 0) + 1,
+      );
+
+      expect(inspectSocketTrust(socketPath)).toBe("socket-dir-foreign-owner");
+    });
+  });
+
+  describe("given a directory another user can write", () => {
+    it("refuses it, because they could unlink our socket and bind their own", async () => {
+      await bindSocket();
+      fs.chmodSync(dir, 0o777);
+
+      expect(inspectSocketTrust(socketPath)).toBe("socket-dir-loose-mode");
+    });
+  });
+
+  describe("given a socket other users can connect to", () => {
+    it("refuses it rather than driving a daemon anyone can also drive", async () => {
+      await bindSocket();
+      fs.chmodSync(socketPath, 0o666);
+
+      expect(inspectSocketTrust(socketPath)).toBe("socket-loose-mode");
+    });
+  });
+
+  describe("given a symlink standing in for the socket", () => {
+    it("refuses it rather than following it somewhere we did not choose", async () => {
+      const elsewhere = path.join(dir, "real.sock");
+      listener = net.createServer();
+      await new Promise<void>((resolve) => listener!.listen(elsewhere, resolve));
+      secureSocketFile(elsewhere);
+      fs.symlinkSync(elsewhere, socketPath);
+
+      expect(inspectSocketTrust(socketPath)).toBe("socket-not-a-socket");
+    });
+  });
+
+  describe("given a regular file where the socket should be", () => {
+    it("refuses it", () => {
+      fs.writeFileSync(socketPath, "corpse", { mode: 0o600 });
+
+      expect(inspectSocketTrust(socketPath)).toBe("socket-not-a-socket");
+    });
+  });
+
+  describe("given nothing is listening at all", () => {
+    it("reports the ordinary no-daemon case", () => {
+      expect(inspectSocketTrust(socketPath)).toBe("socket-missing");
+    });
+
+    it("reports a missing directory rather than throwing", () => {
+      expect(inspectSocketTrust(path.join(dir, "gone", "d.sock"))).toBe(
+        "socket-dir-missing",
+      );
+    });
+  });
+});
+
+describe("ensureSocketDir", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "lw-ensure-"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  describe("given a directory pre-created by another user", () => {
+    it("fails closed instead of continuing with a socket it cannot make private", () => {
+      const squatted = path.join(root, "langwatch-501");
+      fs.mkdirSync(squatted, { mode: 0o777 });
+      vi.spyOn(process, "getuid").mockReturnValue(
+        (process.getuid?.() ?? 0) + 1,
+      );
+
+      expect(() => ensureSocketDir(squatted)).toThrow(UntrustedSocketDirError);
+    });
+  });
+
+  describe("given a symlink where the socket directory should be", () => {
+    it("refuses it rather than trusting whatever it points at", () => {
+      const target = path.join(root, "target");
+      fs.mkdirSync(target, { mode: 0o700 });
+      const link = path.join(root, "link");
+      fs.symlinkSync(target, link);
+
+      expect(() => ensureSocketDir(link)).toThrow(UntrustedSocketDirError);
     });
   });
 });

--- a/typescript-sdk/src/cli/daemon/__tests__/runner.unit.test.ts
+++ b/typescript-sdk/src/cli/daemon/__tests__/runner.unit.test.ts
@@ -1,9 +1,13 @@
 /**
- * Hung and cancelled commands must not pin their execution window: a request
- * that never finishes would otherwise hold its (cwd, env, colour) tuple
- * forever — blocking every caller whose tuple differs, and suppressing the
- * daemon's idle exit (server.ts never arms the idle timer while a request is
- * in flight).
+ * What happens to the execution window when a command is abandoned.
+ *
+ * The caller of a hung or cancelled command is settled AT ONCE (124/130) — a
+ * timeout or a Ctrl-C must never make anybody wait. The window, though, stays
+ * held until the abandoned work actually settles: node cannot unwind its
+ * promise chain, so it is still running, and the next request's `applyWindow`
+ * would chdir and rewrite `process.env` underneath it. A command that never
+ * settles at all is bounded by the abandon grace, after which the daemon stops
+ * being a daemon rather than corrupt anybody.
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
@@ -30,6 +34,36 @@ const hungProgram = (): never =>
 /** A program whose command succeeds immediately. */
 const okProgram = (): never =>
   ({ parseAsync: vi.fn(() => Promise.resolve()) }) as never;
+
+/**
+ * A program that hangs until the test resumes it, recording what the process
+ * globals looked like at the moment it continued — which is what an abandoned
+ * command would actually resolve its relative paths against.
+ */
+const resumableProgram = (): {
+  program: never;
+  resume: () => void;
+  cwdOnResume: () => string | undefined;
+} => {
+  let release: (() => void) | undefined;
+  let cwdOnResume: string | undefined;
+  const program = {
+    parseAsync: vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = () => {
+            cwdOnResume = process.cwd();
+            resolve();
+          };
+        }),
+    ),
+  } as never;
+  return {
+    program,
+    resume: () => release?.(),
+    cwdOnResume: () => cwdOnResume,
+  };
+};
 
 const collect = (): {
   sink: (stream: "stdout" | "stderr", chunk: Buffer) => void;
@@ -104,12 +138,14 @@ describe("createCommandExecutor", () => {
   });
 
   describe("when a command never finishes", () => {
-    it("times out with 124 and releases its window for other callers", async () => {
+    it("settles its caller at 124 without waiting for the work", async () => {
       mockedBuildProgram.mockReturnValue(hungProgram());
       const executor = createCommandExecutor({
         window,
         telemetry: noopTelemetry,
         requestTimeoutMs: 30,
+        abandonGraceMs: 60_000,
+        onWedged: vi.fn(),
       });
       const out = collect();
 
@@ -118,23 +154,73 @@ describe("createCommandExecutor", () => {
 
       expect(code).toBe(124);
       expect(out.stderr()).toContain("timed out");
-      expect(window.inflightCount).toBe(0);
-
-      // A caller with a DIFFERENT window tuple is admitted immediately: the
-      // hung request is no longer holding the process globals.
-      mockedBuildProgram.mockReturnValue(okProgram());
-      const second = executor(request("r2", dirB, collect().sink));
-      await expect(second.completed).resolves.toBe(0);
     });
-  });
 
-  describe("when the client cancels a hung command", () => {
-    it("settles immediately and releases the window", async () => {
+    it("keeps holding its window, because the abandoned work is still running", async () => {
       mockedBuildProgram.mockReturnValue(hungProgram());
       const executor = createCommandExecutor({
         window,
         telemetry: noopTelemetry,
+        requestTimeoutMs: 30,
+        abandonGraceMs: 60_000,
+        onWedged: vi.fn(),
+      });
+
+      await expect(
+        executor(request("r1", dirA, collect().sink)).completed,
+      ).resolves.toBe(124);
+
+      // Releasing here would admit the next caller and chdir underneath work
+      // that has not stopped running.
+      expect(window.inflightCount).toBe(1);
+    });
+  });
+
+  describe("when timed-out work resumes after another caller has arrived", () => {
+    it("still sees its OWN working directory, not the next caller's", async () => {
+      // The bug this guards: releasing the window on timeout let the next
+      // request's applyWindow chdir + rewrite process.env, so an abandoned
+      // `workflows run --output results.json` wrote into ANOTHER caller's
+      // directory, under another caller's credentials.
+      const hung = resumableProgram();
+      mockedBuildProgram.mockReturnValue(hung.program);
+      const executor = createCommandExecutor({
+        window,
+        telemetry: noopTelemetry,
+        requestTimeoutMs: 30,
+        abandonGraceMs: 60_000,
+        onWedged: vi.fn(),
+      });
+
+      const first = executor(request("r1", dirA, collect().sink));
+      await expect(first.completed).resolves.toBe(124);
+
+      // A different-tuple caller arrives while the abandoned work runs on.
+      mockedBuildProgram.mockReturnValue(okProgram());
+      const second = executor(request("r2", dirB, collect().sink));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // It waits its turn rather than moving the ground under r1.
+      expect(window.queuedCount).toBe(1);
+
+      hung.resume();
+      await expect(second.completed).resolves.toBe(0);
+
+      expect(hung.cwdOnResume()).toBe(fs.realpathSync(dirA));
+      expect(hung.cwdOnResume()).not.toBe(fs.realpathSync(dirB));
+    });
+  });
+
+  describe("when the client cancels a hung command", () => {
+    it("settles the caller at 130 at once, and hands the window back only when the work settles", async () => {
+      const hung = resumableProgram();
+      mockedBuildProgram.mockReturnValue(hung.program);
+      const executor = createCommandExecutor({
+        window,
+        telemetry: noopTelemetry,
         requestTimeoutMs: 60_000,
+        abandonGraceMs: 60_000,
+        onWedged: vi.fn(),
       });
 
       const running = executor(request("r1", dirA, collect().sink));
@@ -145,21 +231,54 @@ describe("createCommandExecutor", () => {
       running.cancel(130);
 
       await expect(running.completed).resolves.toBe(130);
-      expect(window.inflightCount).toBe(0);
+      expect(window.inflightCount).toBe(1);
 
-      // A different-tuple caller no longer queues behind the corpse.
+      hung.resume();
+      await vi.waitFor(() => expect(window.inflightCount).toBe(0));
+
+      // ...and only now can a different-tuple caller take the window.
       const releaseB = await window.acquire({ cwd: dirB, env: {}, colorLevel: 0 });
       releaseB();
     });
   });
 
-  describe("when a QUEUED request is cancelled", () => {
-    it("leaves the queue rather than being admitted after its caller is gone", async () => {
+  describe("when abandoned work never settles at all", () => {
+    it("stops being a daemon rather than release a window it cannot make safe", async () => {
+      const wedged = vi.fn();
       mockedBuildProgram.mockReturnValue(hungProgram());
       const executor = createCommandExecutor({
         window,
         telemetry: noopTelemetry,
+        requestTimeoutMs: 20,
+        abandonGraceMs: 40,
+        onWedged: wedged,
+      });
+
+      await expect(
+        executor(request("r1", dirA, collect().sink)).completed,
+      ).resolves.toBe(124);
+
+      await vi.waitFor(() =>
+        expect(wedged).toHaveBeenCalledWith({
+          requestId: "r1",
+          graceMs: 40,
+        }),
+      );
+      // Never quietly released: the whole point is that this window is unsafe.
+      expect(window.inflightCount).toBe(1);
+    });
+  });
+
+  describe("when a QUEUED request is cancelled", () => {
+    it("leaves the queue rather than being admitted after its caller is gone", async () => {
+      const hung = resumableProgram();
+      mockedBuildProgram.mockReturnValue(hung.program);
+      const executor = createCommandExecutor({
+        window,
+        telemetry: noopTelemetry,
         requestTimeoutMs: 60_000,
+        abandonGraceMs: 60_000,
+        onWedged: vi.fn(),
       });
 
       const first = executor(request("r1", dirA, collect().sink));
@@ -179,7 +298,13 @@ describe("createCommandExecutor", () => {
       first.cancel(130);
       await expect(first.completed).resolves.toBe(130);
 
-      // The queue drained cleanly: window B can be taken now.
+      // r1's abandoned work still holds window A — that is fix #2's contract —
+      // so the queue draining is what this test is about, and it drained.
+      expect(window.queuedCount).toBe(0);
+
+      // Once r1's work finally settles, window B is takeable again.
+      hung.resume();
+      await vi.waitFor(() => expect(window.inflightCount).toBe(0));
       const releaseB = await window.acquire({ cwd: dirB, env: {}, colorLevel: 0 });
       releaseB();
     });

--- a/typescript-sdk/src/cli/daemon/__tests__/runner.unit.test.ts
+++ b/typescript-sdk/src/cli/daemon/__tests__/runner.unit.test.ts
@@ -269,6 +269,65 @@ describe("createCommandExecutor", () => {
     });
   });
 
+  describe("when the cancel lands between admission and taking the window", () => {
+    it("hands the window straight back instead of holding it forever", async () => {
+      // The narrowest interleaving there is: `drain()` has already resolved this
+      // request's acquire — so ExecutionWindow's abort listener sees an admitted
+      // waiter and does nothing — but the continuation that assigns
+      // `releaseWindow` has not run yet, so `armAbandonGrace` has nothing to arm.
+      //
+      // A window is genuinely held at that instant with no grace timer bounding
+      // it. If the continuation did not re-check `cancelled` and release, the
+      // daemon would sit at inflight 1 forever: the work never starts, so
+      // nothing ever settles, so `releaseOnce` never runs — and the idle timer
+      // cannot fire either, because a request is in flight. That is exactly the
+      // state `exitWhenWedged` exists to prevent, and it would be unreachable.
+      //
+      // A stub window is the only way to hold the resolution open across the
+      // single microtask that separates the two.
+      mockedBuildProgram.mockReturnValue(hungProgram());
+
+      let admit!: (release: () => void) => void;
+      let released = false;
+      const stubWindow = {
+        acquire: () =>
+          new Promise<() => void>((resolve) => {
+            admit = resolve;
+          }),
+      } as unknown as ExecutionWindow;
+
+      const wedged = vi.fn();
+      const executor = createCommandExecutor({
+        window: stubWindow,
+        telemetry: noopTelemetry,
+        requestTimeoutMs: 60_000,
+        abandonGraceMs: 30,
+        onWedged: wedged,
+      });
+
+      const running = executor(request("r1", dirA, collect().sink));
+      // Let the executor reach its `await window.acquire(...)`.
+      await Promise.resolve();
+
+      // Admitted...
+      admit(() => {
+        released = true;
+      });
+      // ...and cancelled before the continuation can assign `releaseWindow`.
+      running.cancel(130);
+
+      await expect(running.completed).resolves.toBe(130);
+
+      // The window came back, and the command never ran under it.
+      expect(released).toBe(true);
+      expect(mockedBuildProgram).not.toHaveBeenCalled();
+
+      // Released cleanly, so nothing was abandoned and the grace never fires.
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      expect(wedged).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when a QUEUED request is cancelled", () => {
     it("leaves the queue rather than being admitted after its caller is gone", async () => {
       const hung = resumableProgram();

--- a/typescript-sdk/src/cli/daemon/__tests__/spawn-hint.unit.test.ts
+++ b/typescript-sdk/src/cli/daemon/__tests__/spawn-hint.unit.test.ts
@@ -21,6 +21,7 @@ describe("recordMissAndDecideToSpawn", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
     fs.rmSync(root, { recursive: true, force: true });
   });
@@ -88,6 +89,23 @@ describe("recordMissAndDecideToSpawn", () => {
 
         expect(recordMissAndDecideToSpawn(identity)).toBe(false);
         expect(recordMissAndDecideToSpawn(other)).toBe(false);
+      });
+    });
+  });
+
+  describe("given a socket directory owned by another user", () => {
+    describe("when a miss is recorded", () => {
+      it("refuses to spawn, because that daemon's socket could never be private", () => {
+        fs.mkdirSync(identity.socketDir, { recursive: true, mode: 0o777 });
+        // chown needs root; moving OUR uid makes the same comparison fail.
+        vi.spyOn(process, "getuid").mockReturnValue(
+          (process.getuid?.() ?? 0) + 1,
+        );
+
+        expect(recordMissAndDecideToSpawn(identity)).toBe(false);
+        expect(recordMissAndDecideToSpawn(identity)).toBe(false);
+        // Not even the bookkeeping: nothing of ours goes into that directory.
+        expect(fs.readdirSync(identity.socketDir)).toEqual([]);
       });
     });
   });

--- a/typescript-sdk/src/cli/daemon/client.ts
+++ b/typescript-sdk/src/cli/daemon/client.ts
@@ -219,6 +219,20 @@ export async function execViaDaemon(
             break;
           }
           case "fallback": {
+            if (committed) {
+              // The daemon declined AFTER our output crossed the buffer cap and
+              // was flushed. Re-running would print everything the caller has
+              // already seen a second time, so we cannot — the honest report is
+              // that the output is incomplete and this status is ours, not the
+              // command's. (In practice only the shutdown-grace path can reach
+              // here: every other `fallback` is sent before any output at all.)
+              stderr.write(
+                `langwatch: daemon stopped mid-command (${frame.reason}); ` +
+                  `the output above is incomplete and this exit status is not the command's — please re-run\n`,
+              );
+              settle({ served: true, exitCode: 1 });
+              break;
+            }
             settle({ served: false, reason: `daemon-declined:${frame.reason}` });
             break;
           }

--- a/typescript-sdk/src/cli/daemon/client.ts
+++ b/typescript-sdk/src/cli/daemon/client.ts
@@ -2,11 +2,13 @@
  * The thin client: talk to the daemon if it is there, and never, ever break if
  * it is not.
  *
- * Loaded on every CLI invocation, so it imports node builtins and nothing else.
+ * Loaded on every CLI invocation, so it imports node builtins and its own
+ * sibling modules and nothing else.
  */
 
 import * as net from "node:net";
 
+import { inspectSocketTrust } from "./identity";
 import {
   encodeFrame,
   FrameDecoder,
@@ -73,6 +75,14 @@ export async function execViaDaemon(
   const stdout = options.stdout ?? process.stdout;
   const stderr = options.stderr ?? process.stderr;
   const maxBufferBytes = options.maxBufferBytes ?? DEFAULT_MAX_BUFFER_BYTES;
+
+  // BEFORE connect, and above all before the pipelined `exec` hands over args,
+  // cwd and the forwarded LANGWATCH_* env: the socket must be ours. See
+  // identity.ts inspectSocketTrust. Not being able to trust the socket is
+  // exactly "no daemon available" — the command runs in-process, as it would
+  // if nothing were listening at all.
+  const untrusted = inspectSocketTrust(options.socketPath);
+  if (untrusted) return { served: false, reason: untrusted };
 
   return new Promise<DaemonExecOutcome>((resolve) => {
     const socket = net.connect(options.socketPath);
@@ -258,6 +268,9 @@ export interface DaemonStatus {
 export async function requestStatus(
   socketPath: string,
 ): Promise<DaemonStatus | null> {
+  // A socket we do not own is not our daemon, so there is nothing to report.
+  if (inspectSocketTrust(socketPath)) return null;
+
   return new Promise<DaemonStatus | null>((resolve) => {
     const socket = net.connect(socketPath);
     const decoder = new FrameDecoder<ServerFrame>();
@@ -302,6 +315,11 @@ export async function requestStatus(
  * evicts an OLDER daemon, which by definition cannot agree on the version.
  */
 export async function requestStop(socketPath: string): Promise<boolean> {
+  // Deliberately does not require a handshake — but it still requires a socket
+  // that is ours. `stop` is an unauthenticated command; sending it to a
+  // stranger's listener tells them we are here and nothing else useful.
+  if (inspectSocketTrust(socketPath)) return false;
+
   return new Promise<boolean>((resolve) => {
     const socket = net.connect(socketPath);
     let connected = false;

--- a/typescript-sdk/src/cli/daemon/identity.ts
+++ b/typescript-sdk/src/cli/daemon/identity.ts
@@ -103,9 +103,12 @@ export function isDaemonSupported(): boolean {
  * then cannot chmod a directory it does not own, so the real daemon can never
  * bind — and the squatter is free to bind the socket itself and be handed the
  * caller's args, cwd and forwarded `LANGWATCH_*` env. A directory under `$HOME`
- * cannot be pre-created by another user, which removes the squat entirely
- * rather than merely detecting it. (`inspectSocketTrust` still detects it, for
- * `$XDG_RUNTIME_DIR`, `LANGWATCH_DAEMON_DIR` and the temp-dir fallback.)
+ * cannot be pre-created by another user, which removes the squat for the LEAF
+ * rather than merely detecting it — on a correctly-permissioned `$HOME`. It does
+ * NOT remove it for the path's ancestors, which nothing here checks; see the
+ * boundary note on `inspectSocketTrust`. (`inspectSocketTrust` remains the only
+ * defence for `$XDG_RUNTIME_DIR`, `LANGWATCH_DAEMON_DIR` and the temp-dir
+ * fallback, where pre-creation IS possible.)
  */
 export function daemonSocketDir(): string {
   const override = process.env.LANGWATCH_DAEMON_DIR;
@@ -266,6 +269,23 @@ function hasLooseMode(mode: number): boolean {
  * Every problem is soft — the caller falls back to running the command
  * in-process. A squatted socket must degrade the CLI to its pre-daemon
  * behaviour, never break it.
+ *
+ * THE BOUNDARY, precisely. This checks the socket and its IMMEDIATE parent, and
+ * nothing above that: `~/.langwatch`, `~/.langwatch/run`'s own ancestors and
+ * `$HOME` itself are not stat'd. So preferring `$HOME` over `/tmp` removes the
+ * squat for the LEAF — an attacker cannot create or replace the socket or its
+ * directory — but it does not remove it for the CHAIN. On a misconfigured
+ * group-writable `$HOME`, a peer can rename an ancestor and point the whole path
+ * somewhere they control.
+ *
+ * That residual case is deliberately left to fail the checks above rather than
+ * be pre-empted by an ancestor walk. The outcome is refuse-and-degrade, not
+ * disclosure: the substituted directory is theirs, so `socket-dir-foreign-owner`
+ * fires and no bytes are ever sent. A full walk to the filesystem root would add
+ * a stat per level to the hot path of every invocation and still not close the
+ * race (any ancestor can be renamed between our stat and our connect); a
+ * group-writable `$HOME` is a broken machine, and one this CLI degrades safely
+ * on rather than pretends to fix.
  */
 export function inspectSocketTrust(
   socketPath: string,

--- a/typescript-sdk/src/cli/daemon/identity.ts
+++ b/typescript-sdk/src/cli/daemon/identity.ts
@@ -61,6 +61,13 @@ import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
  */
 const MAX_SOCKET_PATH_BYTES = 100;
 
+/**
+ * What `resolveIdentity` appends to the base directory: a separator, 16 hex
+ * characters of fingerprint and `.sock`. Known here so `daemonSocketDir` can
+ * tell whether a candidate base leaves room for the socket at all.
+ */
+const SOCKET_FILE_BYTES = 1 + 16 + ".sock".length;
+
 export interface DaemonIdentity {
   /** Full sha256 hex of the identity tuple. Presented in the handshake. */
   fingerprint: string;
@@ -87,20 +94,45 @@ export function isDaemonSupported(): boolean {
  * Base directory for daemon sockets.
  *
  * `$XDG_RUNTIME_DIR` when set (Linux; already per-user and 0700, and cleaned
- * on logout), otherwise `os.tmpdir()`. We never use a fixed world-writable
- * path like `/tmp/langwatch.sock` — this process holds credentials.
+ * on logout), otherwise `$HOME/.langwatch/run` — the same dot-directory the
+ * CLI already keeps its config in.
+ *
+ * `os.tmpdir()` is the LAST resort, and deliberately so. On Linux without
+ * `$XDG_RUNTIME_DIR` it is `/tmp`, mode 1777: any local user can PRE-CREATE
+ * `/tmp/langwatch-<uid>`, own it, and leave it 0777. Our `ensureSocketDir`
+ * then cannot chmod a directory it does not own, so the real daemon can never
+ * bind — and the squatter is free to bind the socket itself and be handed the
+ * caller's args, cwd and forwarded `LANGWATCH_*` env. A directory under `$HOME`
+ * cannot be pre-created by another user, which removes the squat entirely
+ * rather than merely detecting it. (`inspectSocketTrust` still detects it, for
+ * `$XDG_RUNTIME_DIR`, `LANGWATCH_DAEMON_DIR` and the temp-dir fallback.)
  */
 export function daemonSocketDir(): string {
   const override = process.env.LANGWATCH_DAEMON_DIR;
   if (override) return override;
 
-  const runtimeDir = process.env.XDG_RUNTIME_DIR;
-  const base =
-    runtimeDir && runtimeDir.trim() !== "" ? runtimeDir : os.tmpdir();
   // The uid is in the directory name so two users on one box never contend for
   // the same directory (whose 0700 mode would make the loser fail to enter).
   const uid = typeof process.getuid === "function" ? process.getuid() : 0;
-  return path.join(base, `langwatch-${uid}`);
+  const leaf = `langwatch-${uid}`;
+
+  const runtimeDir = process.env.XDG_RUNTIME_DIR;
+  if (runtimeDir && runtimeDir.trim() !== "") return path.join(runtimeDir, leaf);
+
+  const home = os.homedir();
+  if (home !== "") {
+    const underHome = path.join(home, ".langwatch", "run", leaf);
+    // A very long $HOME would push the socket past sockaddr_un and disable the
+    // daemon outright. The temp dir is shorter; a daemon whose directory we
+    // validate on every connect beats no daemon at all.
+    if (
+      Buffer.byteLength(underHome, "utf8") + SOCKET_FILE_BYTES <=
+      MAX_SOCKET_PATH_BYTES
+    ) {
+      return underHome;
+    }
+  }
+  return path.join(os.tmpdir(), leaf);
 }
 
 /**
@@ -197,14 +229,112 @@ export function isSocketPathUsable(socketPath: string): boolean {
 }
 
 /**
+ * Why a socket path must not be connected to. `null` means it is safe.
+ *
+ * These are the CLIENT-side half of the trust model. `ensureSocketDir` and
+ * `secureSocketFile` make the socket private when WE create it; they say
+ * nothing about a socket somebody else created first. Without this check a
+ * squatted socket is indistinguishable from our own daemon, and the client
+ * pipelines `exec` — args, cwd and the forwarded `LANGWATCH_*` env, API key
+ * included — before it has seen a single byte back.
+ */
+export type SocketTrustProblem =
+  | "socket-dir-missing"
+  | "socket-dir-not-a-directory"
+  | "socket-dir-foreign-owner"
+  | "socket-dir-loose-mode"
+  | "socket-missing"
+  | "socket-not-a-socket"
+  | "socket-foreign-owner"
+  | "socket-loose-mode";
+
+/** No group or other bits at all — the 0600/0700 half of the trust model. */
+function hasLooseMode(mode: number): boolean {
+  return (mode & 0o077) !== 0;
+}
+
+/**
+ * Decide whether this socket path may be connected to.
+ *
+ * Both the socket AND its parent directory must be owned by us and carry no
+ * group/other bits: a private socket inside a directory somebody else can
+ * write is not private, because they can unlink it and bind their own.
+ *
+ * `lstat`, never `stat`: a symlink standing in for the socket (or for the
+ * directory) must be REJECTED, not followed to whatever it points at.
+ *
+ * Every problem is soft — the caller falls back to running the command
+ * in-process. A squatted socket must degrade the CLI to its pre-daemon
+ * behaviour, never break it.
+ */
+export function inspectSocketTrust(
+  socketPath: string,
+): SocketTrustProblem | null {
+  // No POSIX ownership to check (and the daemon is disabled there anyway).
+  if (typeof process.getuid !== "function") return null;
+  const uid = process.getuid();
+
+  let dirStat: fs.Stats;
+  try {
+    dirStat = fs.lstatSync(path.dirname(socketPath));
+  } catch {
+    return "socket-dir-missing";
+  }
+  if (!dirStat.isDirectory()) return "socket-dir-not-a-directory";
+  if (dirStat.uid !== uid) return "socket-dir-foreign-owner";
+  if (hasLooseMode(dirStat.mode)) return "socket-dir-loose-mode";
+
+  let socketStat: fs.Stats;
+  try {
+    socketStat = fs.lstatSync(socketPath);
+  } catch {
+    // The ordinary "no daemon running" case, and by far the most common.
+    return "socket-missing";
+  }
+  if (!socketStat.isSocket()) return "socket-not-a-socket";
+  if (socketStat.uid !== uid) return "socket-foreign-owner";
+  if (hasLooseMode(socketStat.mode)) return "socket-loose-mode";
+
+  return null;
+}
+
+/** A socket directory we cannot own, and therefore cannot make private. */
+export class UntrustedSocketDirError extends Error {
+  constructor(
+    readonly socketDir: string,
+    readonly problem: string,
+  ) {
+    super(`refusing to use socket directory ${socketDir}: ${problem}`);
+    this.name = "UntrustedSocketDirError";
+  }
+}
+
+/**
  * Create the socket directory with 0700. Also repairs the mode if the
  * directory already exists with looser permissions — a world-readable
  * directory would let another user stat (though not connect to) the socket.
+ *
+ * Fails CLOSED when the directory is not ours. `mkdirSync`'s `mode` is subject
+ * to umask and ignored outright when the directory already exists, and
+ * `chmodSync` cannot repair a directory owned by somebody else — so a
+ * pre-created, attacker-owned directory (the classic 1777 `/tmp` squat) leaves
+ * us with a socket we can never make private. Callers must treat that as "no
+ * daemon", not as a warning: a daemon whose socket cannot be made private must
+ * not exist.
  */
 export function ensureSocketDir(socketDir: string): void {
   fs.mkdirSync(socketDir, { recursive: true, mode: 0o700 });
-  // mkdirSync's `mode` is subject to umask and is ignored entirely when the
-  // directory already exists, so assert the mode explicitly.
+
+  // lstat, so a symlink pointing at a directory we DO own cannot launder a
+  // path an attacker controls into one that passes this check.
+  const stat = fs.lstatSync(socketDir);
+  if (!stat.isDirectory()) {
+    throw new UntrustedSocketDirError(socketDir, "not a directory");
+  }
+  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+    throw new UntrustedSocketDirError(socketDir, "owned by another user");
+  }
+
   fs.chmodSync(socketDir, 0o700);
 }
 

--- a/typescript-sdk/src/cli/daemon/runner.ts
+++ b/typescript-sdk/src/cli/daemon/runner.ts
@@ -179,8 +179,23 @@ export function createCommandExecutor({
      * for nobody, and turns "forever" into "the daemon goes away".
      */
     const armAbandonGrace = (): void => {
-      // No window was ever taken (cancelled while still queued): nothing to
-      // protect and nothing to wedge.
+      // No window is held YET, so there is nothing to bound. Two situations
+      // reach here, and NEITHER can wedge — but only because of the
+      // post-acquire `cancelled` check below, which is load-bearing:
+      //
+      //   - Cancelled while still queued. `abortController.abort()` removes the
+      //     waiter, acquire rejects, no window is ever taken.
+      //   - Cancelled in the gap between admission and the assignment of
+      //     `releaseWindow` — i.e. `drain()` already called `resolve()`, so the
+      //     abort listener sees an admitted waiter and does nothing. A window
+      //     IS held here, and nothing has armed a timer for it. What saves it is
+      //     that the continuation re-reads `cancelled` the moment it resumes and
+      //     calls `releaseOnce()` without ever starting the work: the window
+      //     goes back immediately, which is safe precisely because no command
+      //     ever ran under it.
+      //
+      // Delete that check and this early return becomes the permanent-wedge bug
+      // it looks like. `runner.unit.test.ts` drives the interleaving directly.
       if (releaseWindow === undefined || abandonTimer) return;
       abandonTimer = setTimeout(() => {
         abandonTimer = undefined;

--- a/typescript-sdk/src/cli/daemon/runner.ts
+++ b/typescript-sdk/src/cli/daemon/runner.ts
@@ -36,6 +36,9 @@ export interface CommandExecution {
    * guarantee is what the caller observes: no further output, an immediate exit
    * code, and a released connection. The abandoned work finishes on its own
    * (it is a single HTTP call) and its output is discarded.
+   *
+   * What we must NOT do is hand its execution window to somebody else while it
+   * is still running — see the note on `abort` in createCommandExecutor.
    */
   cancel(code: number): void;
 }
@@ -50,17 +53,68 @@ export type CommandExecutor = (request: ExecuteRequest) => CommandExecution;
  */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 
+/**
+ * How long an ABANDONED command may keep holding its execution window after
+ * its caller has already been settled at 124/130.
+ *
+ * 60s is generous for the thing an abandoned command is actually waiting on —
+ * an HTTP request that will fail or time out on its own. Past that we assume it
+ * will never settle, and the window can never be handed over safely.
+ */
+export const DEFAULT_ABANDON_GRACE_MS = 60 * 1000;
+
 /** Operator override: LANGWATCH_DAEMON_REQUEST_TIMEOUT_MS, else the default. */
 function resolveRequestTimeoutMs(): number {
-  const fromEnv = process.env.LANGWATCH_DAEMON_REQUEST_TIMEOUT_MS;
-  if (fromEnv) {
+  return positiveIntFromEnv(
+    process.env.LANGWATCH_DAEMON_REQUEST_TIMEOUT_MS,
+    DEFAULT_REQUEST_TIMEOUT_MS,
+  );
+}
+
+/** Operator override: LANGWATCH_DAEMON_ABANDON_GRACE_MS, else the default. */
+function resolveAbandonGraceMs(): number {
+  return positiveIntFromEnv(
+    process.env.LANGWATCH_DAEMON_ABANDON_GRACE_MS,
+    DEFAULT_ABANDON_GRACE_MS,
+  );
+}
+
+function positiveIntFromEnv(value: string | undefined, fallback: number): number {
+  if (value) {
     // A complete positive integer only: parseInt would accept "5000ms" and
     // truncate "1.5", and the documented contract is a millisecond count.
-    const parsed = Number(fromEnv);
+    const parsed = Number(value);
     if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
   }
-  return DEFAULT_REQUEST_TIMEOUT_MS;
+  return fallback;
 }
+
+/** What the daemon does when an abandoned command never settles. */
+export type WedgedHandler = (details: {
+  requestId: string;
+  graceMs: number;
+}) => void;
+
+/**
+ * The default: stop being a daemon.
+ *
+ * There is no third option here. Releasing the window would let the next
+ * caller's `applyWindow` chdir and rewrite `process.env` underneath work that
+ * is still running. Holding it forever would wedge the daemon into refusing
+ * every caller whose window differs, silently, until its idle timeout — which
+ * never fires, because the request is still in flight. Exiting is the only
+ * outcome that cannot corrupt anybody: the socket goes away, the next
+ * invocation finds nothing, and every command runs in-process exactly as it
+ * does with no daemon installed.
+ */
+const exitWhenWedged: WedgedHandler = ({ requestId, graceMs }) => {
+  process.stderr.write(
+    `langwatch: daemon exiting — abandoned request ${requestId} did not settle ` +
+      `within ${Math.round(graceMs / 1000)}s, so its execution window can never be reused safely\n`,
+  );
+  // EX_SOFTWARE. Not a crash: a deliberate, documented refusal to continue.
+  process.exit(70);
+};
 
 /**
  * Build the executor the daemon serves requests with.
@@ -72,13 +126,20 @@ export function createCommandExecutor({
   window,
   telemetry,
   requestTimeoutMs,
+  abandonGraceMs,
+  onWedged = exitWhenWedged,
 }: {
   window: ExecutionWindow;
   telemetry: DaemonTelemetry;
   /** Injectable for tests; defaults to LANGWATCH_DAEMON_REQUEST_TIMEOUT_MS. */
   requestTimeoutMs?: number;
+  /** Injectable for tests; defaults to LANGWATCH_DAEMON_ABANDON_GRACE_MS. */
+  abandonGraceMs?: number;
+  /** Injectable for tests; defaults to exiting the process. */
+  onWedged?: WedgedHandler;
 }): CommandExecutor {
   const timeoutMs = requestTimeoutMs ?? resolveRequestTimeoutMs();
+  const graceMs = abandonGraceMs ?? resolveAbandonGraceMs();
 
   return (request: ExecuteRequest): CommandExecution => {
     const context = new ExecutionContext(request.requestId, (stream, chunk) => {
@@ -93,20 +154,39 @@ export function createCommandExecutor({
     let cancelled = false;
     let settle: ((code: number) => void) | undefined;
     let releaseWindow: (() => void) | undefined;
+    let abandonTimer: NodeJS.Timeout | undefined;
     const abortController = new AbortController();
 
-    // Releasing the window is deliberately decoupled from the command's own
-    // completion. The command's promise chain cannot be killed from the
-    // outside, so a command that hangs forever would otherwise hold its
-    // working-directory window forever too — blocking every caller whose
-    // (cwd, env, colour) tuple differs, and suppressing the daemon's idle
-    // exit. On cancel/timeout the window is freed immediately; the abandoned
-    // work finishes (or doesn't) on its own and its `finally` release is a
-    // no-op.
+    /**
+     * Hand the execution window back. Exactly once, and only ever from a point
+     * at which the command's own promise chain has actually settled.
+     */
     const releaseOnce = (): void => {
+      if (abandonTimer) {
+        clearTimeout(abandonTimer);
+        abandonTimer = undefined;
+      }
       const release = releaseWindow;
       releaseWindow = undefined;
       release?.();
+    };
+
+    /**
+     * The abandoned command still holds the window. Bound how long it may.
+     *
+     * Nothing here waits on the CALLER — they already have their 124/130. This
+     * bounds how long a command that never settles may keep the daemon usable
+     * for nobody, and turns "forever" into "the daemon goes away".
+     */
+    const armAbandonGrace = (): void => {
+      // No window was ever taken (cancelled while still queued): nothing to
+      // protect and nothing to wedge.
+      if (releaseWindow === undefined || abandonTimer) return;
+      abandonTimer = setTimeout(() => {
+        abandonTimer = undefined;
+        onWedged({ requestId: request.requestId, graceMs });
+      }, graceMs);
+      abandonTimer.unref();
     };
 
     const abort = (code: number, note?: string): void => {
@@ -120,8 +200,21 @@ export function createCommandExecutor({
       context.finalize(code);
       // Wakes a request still QUEUED for its window; a no-op otherwise.
       abortController.abort();
-      releaseOnce();
+      // The caller is settled NOW — a timeout or a Ctrl-C must never make
+      // anybody wait. The WINDOW, though, is deliberately NOT released here.
+      //
+      // Node cannot unwind the abandoned promise chain, so the command is
+      // still running: when it resumes it will resolve relative paths against
+      // `process.cwd()` and read credentials out of `process.env` as they are
+      // AT THAT MOMENT. Releasing the window admits the next request, whose
+      // `applyWindow` (execution.ts) chdirs and rewrites the whole
+      // environment — so an abandoned `workflows run --output results.json`
+      // would write its file into ANOTHER caller's directory, under another
+      // caller's credentials. The window is released by the `finally` below,
+      // i.e. when the abandoned work genuinely settles; `armAbandonGrace`
+      // bounds the case where it never does.
       settle?.(code);
+      armAbandonGrace();
     };
 
     // 124, the `timeout(1)` convention, so scripts can tell a timeout apart
@@ -200,6 +293,9 @@ export function createCommandExecutor({
           context.finalize(1);
         }
       } finally {
+        // The ONLY place a window taken by a running command is handed back —
+        // including for a command that was abandoned long ago, whose caller is
+        // already gone. See the note in `abort`.
         releaseOnce();
       }
 

--- a/typescript-sdk/src/cli/daemon/server.ts
+++ b/typescript-sdk/src/cli/daemon/server.ts
@@ -26,6 +26,20 @@ import { noopTelemetry, type DaemonTelemetry } from "./telemetry";
 /** 10 minutes: long enough to span an agent's think-time, short enough to never feel like a leak. */
 export const DEFAULT_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 
+/**
+ * How long `stop()` waits for in-flight requests before tearing the execution
+ * window down underneath them.
+ *
+ * Shutdown restores the daemon's own cwd and environment (ExecutionWindow.reset),
+ * so a request still running when that happens would finish against the WRONG
+ * globals — and version-skew eviction makes shutdown-while-serving a routine
+ * dev-loop event, not an exotic one. 5s covers any command close enough to
+ * finishing to be worth waiting for; past that the connections are destroyed so
+ * the client sees a transport failure and re-runs in-process, which is the one
+ * outcome that is always correct.
+ */
+export const DEFAULT_SHUTDOWN_GRACE_MS = 5_000;
+
 export interface DaemonServerOptions {
   socketPath: string;
   socketDir: string;
@@ -35,6 +49,8 @@ export interface DaemonServerOptions {
   /** Identity of the code this daemon actually loaded. See resolveBuildId. */
   build: string;
   idleTimeoutMs?: number;
+  /** How long `stop()` lets in-flight requests finish. Injectable for tests. */
+  shutdownGraceMs?: number;
   telemetry?: DaemonTelemetry;
   /** Injectable for tests; defaults to really running commander. */
   executor?: CommandExecutor;
@@ -100,6 +116,7 @@ export async function cleanStaleSocket(socketPath: string): Promise<boolean> {
 export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
   const telemetry = options.telemetry ?? noopTelemetry;
   const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+  const shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
   const startedAt = Date.now();
 
   const window = new ExecutionWindow();
@@ -111,6 +128,10 @@ export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
   let stopping = false;
   let idleTimer: NodeJS.Timeout | undefined;
   let uninstallInterceptors: (() => void) | undefined;
+  /** Live client connections, so shutdown can cut them if a drain times out. */
+  const connections = new Set<net.Socket>();
+  /** Woken when `inflight` reaches zero. Only `stop()` ever waits on this. */
+  let drainWaiters: (() => void)[] = [];
 
   const server = net.createServer();
   let resolveClosed: () => void;
@@ -126,6 +147,27 @@ export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
     }, idleTimeoutMs);
     // Never let the idle timer alone hold the process open.
     idleTimer.unref();
+  };
+
+  /** Called on every request completion; wakes a shutdown waiting to drain. */
+  const noteRequestSettled = (): void => {
+    if (inflight > 0) return;
+    const waiters = drainWaiters;
+    drainWaiters = [];
+    for (const wake of waiters) wake();
+  };
+
+  /** Resolves true if everything finished in time, false if the grace ran out. */
+  const drainInflight = async (graceMs: number): Promise<boolean> => {
+    if (inflight === 0) return true;
+    return new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => resolve(false), graceMs);
+      timer.unref();
+      drainWaiters.push(() => {
+        clearTimeout(timer);
+        resolve(true);
+      });
+    });
   };
 
   const stop = async (
@@ -152,6 +194,19 @@ export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
       // Already gone — someone cleaned up a stale file, or we never bound.
     }
 
+    // `window.reset()` below restores the daemon's OWN cwd and environment. A
+    // request still executing when that lands would resolve its paths and read
+    // its credentials against the daemon's globals instead of its caller's, and
+    // would then report an exit code the client trusts. So: let them finish.
+    if (!(await drainInflight(shutdownGraceMs))) {
+      // They did not. Cut the connections instead of letting the clients
+      // believe a result computed under a rewritten environment: a transport
+      // failure before the `exit` frame is a clean in-process re-run (nothing
+      // has been committed to their stdout), which is always correct.
+      for (const connection of connections) connection.destroy();
+      connections.clear();
+    }
+
     // The one place a telemetry flush is both necessary and possible.
     await telemetry.shutdown();
     uninstallInterceptors?.();
@@ -167,6 +222,17 @@ export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
     let handshaken = false;
     let execution: { cancel: (code: number) => void } | undefined;
     let counted = false;
+
+    connections.add(socket);
+
+    /** This connection's request is done: uncount it and wake any drain. */
+    const endRequest = (): void => {
+      if (!counted) return;
+      counted = false;
+      inflight--;
+      armIdleTimer();
+      noteRequestSettled();
+    };
 
     const send = (frame: ServerFrame): void => {
       if (socket.destroyed) return;
@@ -184,6 +250,7 @@ export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
     });
 
     socket.on("close", () => {
+      connections.delete(socket);
       execution?.cancel(130);
     });
 
@@ -309,9 +376,7 @@ export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
             (code) => {
               send({ t: "exit", code });
               finish();
-              inflight--;
-              counted = false;
-              armIdleTimer();
+              endRequest();
             },
             (error: unknown) => {
               // The window could not be applied — almost always because the
@@ -323,9 +388,7 @@ export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
                   error instanceof Error ? error.message : "execution-failed",
               });
               finish();
-              inflight--;
-              counted = false;
-              armIdleTimer();
+              endRequest();
             },
           );
           return;
@@ -345,11 +408,7 @@ export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
         try {
           handleFrame(frame);
         } catch {
-          if (counted) {
-            inflight--;
-            counted = false;
-            armIdleTimer();
-          }
+          endRequest();
           send({ t: "fallback", reason: "daemon-error" });
           finish();
         }

--- a/typescript-sdk/src/cli/daemon/server.ts
+++ b/typescript-sdk/src/cli/daemon/server.ts
@@ -9,8 +9,10 @@ import * as net from "node:net";
 
 import {
   ensureSocketDir,
+  inspectSocketTrust,
   isSocketPathUsable,
   secureSocketFile,
+  UntrustedSocketDirError,
 } from "./identity";
 import {
   encodeFrame,
@@ -34,9 +36,12 @@ export const DEFAULT_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
  * so a request still running when that happens would finish against the WRONG
  * globals — and version-skew eviction makes shutdown-while-serving a routine
  * dev-loop event, not an exotic one. 5s covers any command close enough to
- * finishing to be worth waiting for; past that the connections are destroyed so
- * the client sees a transport failure and re-runs in-process, which is the one
- * outcome that is always correct.
+ * finishing to be worth waiting for; past that the client is told to fall back
+ * and the connection is cut.
+ *
+ * For a client that has not committed output — everything under the client's
+ * buffer cap, which is very nearly everything — that is a clean in-process
+ * re-run. For one that HAS committed, it is not: see the note in `stop()`.
  */
 export const DEFAULT_SHUTDOWN_GRACE_MS = 5_000;
 
@@ -69,6 +74,25 @@ export interface DaemonServer {
   };
 }
 
+/**
+ * The trust problems that mean somebody ELSE holds this path, as opposed to the
+ * ones that just mean we left debris behind.
+ *
+ * `socket-missing` is the ordinary empty state, and `socket-not-a-socket` is a
+ * corpse `cleanStaleSocket` will unlink — neither is a squat. (A non-socket we
+ * do NOT own cannot occur past `ensureSocketDir`: the directory is ours and
+ * 0700 by then, so nobody else can create a file inside it, and a foreign
+ * directory has already thrown.) Everything left is an ownership or mode
+ * problem, i.e. a path we can neither trust nor repair.
+ */
+const SQUATTED_SOCKET_PROBLEMS: ReadonlySet<string> = new Set([
+  "socket-dir-not-a-directory",
+  "socket-dir-foreign-owner",
+  "socket-dir-loose-mode",
+  "socket-foreign-owner",
+  "socket-loose-mode",
+]);
+
 export class DaemonAlreadyRunningError extends Error {
   constructor(readonly socketPath: string) {
     super(`a langwatch daemon is already listening on ${socketPath}`);
@@ -83,9 +107,20 @@ export class DaemonAlreadyRunningError extends Error {
  * file behind. Binding on top of it fails with EADDRINUSE, and connecting to it
  * fails with ECONNREFUSED. Distinguishing the two is what keeps a crashed
  * daemon from wedging every future invocation.
+ *
+ * A socket owned by somebody else is neither: it is not OUR daemon, so "alive"
+ * would be a lie with teeth. `listen()` turns a true here into
+ * DaemonAlreadyRunningError, so a squatter who binds the path first — reachable
+ * via LANGWATCH_DAEMON_DIR, XDG_RUNTIME_DIR or the tmp fallback — would stop
+ * the real daemon from EVER starting. Nothing is disclosed (we send no bytes),
+ * but the old credential-theft vector would become a permanent, silent denial
+ * of service. So: a foreign socket is not alive, and it is not silent either —
+ * `cleanStaleSocket` will not unlink it (it cannot), and `listen()` reports the
+ * squat instead of misattributing it to a daemon that is already running.
  */
 export async function isSocketAlive(socketPath: string): Promise<boolean> {
   if (!fs.existsSync(socketPath)) return false;
+  if (inspectSocketTrust(socketPath) !== null) return false;
 
   return new Promise<boolean>((resolve) => {
     const socket = net.connect(socketPath);
@@ -199,11 +234,39 @@ export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
     // its credentials against the daemon's globals instead of its caller's, and
     // would then report an exit code the client trusts. So: let them finish.
     if (!(await drainInflight(shutdownGraceMs))) {
-      // They did not. Cut the connections instead of letting the clients
-      // believe a result computed under a rewritten environment: a transport
-      // failure before the `exit` frame is a clean in-process re-run (nothing
-      // has been committed to their stdout), which is always correct.
-      for (const connection of connections) connection.destroy();
+      // They did not. Cut the connections rather than let the clients believe a
+      // result computed under a rewritten environment.
+      //
+      // The `fallback` frame goes first so the outcome is DIAGNOSED rather than
+      // inferred from a dead socket. What the client can do with it depends on
+      // whether it has committed output yet, and the two cases are genuinely
+      // different — this is not a uniformly clean re-run:
+      //
+      //   - Not committed (the overwhelming majority: everything under
+      //     DEFAULT_MAX_BUFFER_BYTES is still sitting in the client's buffer).
+      //     Nothing has reached the caller's stdout, so the client re-runs the
+      //     command in-process and the outcome is indistinguishable from having
+      //     no daemon at all. This case IS always correct.
+      //
+      //   - Committed (`trace search`, `analytics query`, a large
+      //     `--format json` — anything whose output crossed the buffer cap and
+      //     was flushed to the real stdout). Re-running would duplicate what the
+      //     caller has already seen, so the client cannot. It reports truncated
+      //     output and a non-zero status that is NOT the command's own. That is
+      //     a real, if rare, loss of fidelity, and routine version-skew eviction
+      //     (dispatch.ts requestStop) can trigger it. The frame at least lets
+      //     the client say so accurately instead of guessing from a socket close.
+      for (const connection of connections) {
+        if (connection.destroyed) continue;
+        // `end`, not `write`+`destroy`: destroy() discards anything still in the
+        // write buffer, which would throw away the very frame being sent. The
+        // callback fires once it is flushed, and destroying there bounds the
+        // teardown instead of leaving a half-closed socket holding the loop open.
+        connection.end(
+          encodeFrame({ t: "fallback", reason: "shutting-down-mid-command" }),
+          () => connection.destroy(),
+        );
+      }
       connections.clear();
     }
 
@@ -424,6 +487,17 @@ export function createDaemonServer(options: DaemonServerOptions): DaemonServer {
     }
 
     ensureSocketDir(options.socketDir);
+
+    // ensureSocketDir repairs the DIRECTORY's mode, but a squatter who got
+    // there while it was still loose has already left their socket file inside
+    // it, and that file is still theirs. Refusing loudly here — rather than
+    // letting `isSocketAlive` report it and `listen()` misread it as
+    // DaemonAlreadyRunningError — is what keeps the squat from reading as "a
+    // daemon is already running" forever, which no amount of restarting fixes.
+    const trust = inspectSocketTrust(options.socketPath);
+    if (trust !== null && SQUATTED_SOCKET_PROBLEMS.has(trust)) {
+      throw new UntrustedSocketDirError(options.socketPath, trust);
+    }
 
     if (await isSocketAlive(options.socketPath)) {
       throw new DaemonAlreadyRunningError(options.socketPath);

--- a/typescript-sdk/src/cli/daemon/spawn-hint.ts
+++ b/typescript-sdk/src/cli/daemon/spawn-hint.ts
@@ -44,9 +44,18 @@ export function recordMissAndDecideToSpawn(identity: DaemonIdentity): boolean {
   const file = hintPath(identity);
   const now = Date.now();
 
+  // Deliberately OUTSIDE the swallow-everything block below. A socket
+  // directory we cannot own (identity.ts UntrustedSocketDirError) is not a
+  // bookkeeping hiccup to shrug off and retry — it means the socket can never
+  // be made private, so there must be no daemon at all. Fail closed: no hint,
+  // no spawn, every command runs in-process exactly as it does today.
   try {
     ensureSocketDir(identity.socketDir);
+  } catch {
+    return false;
+  }
 
+  try {
     let recent: number[] = [];
     try {
       const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf8"));

--- a/typescript-sdk/src/cli/index.ts
+++ b/typescript-sdk/src/cli/index.ts
@@ -5,7 +5,13 @@
 // runs. Must precede every other import — see compileCache.ts.
 import "./compileCache";
 
-// Load environment variables BEFORE any other imports
+// Load environment variables before we DISPATCH. Note the limit of that
+// promise: static imports are hoisted above this module's body (by ES module
+// semantics, and by esbuild when tsup bundles), so `./daemon/dispatch` below
+// is already evaluated by the time config() runs. Only function bodies called
+// after this point see the loaded .env — never module-level side effects.
+// Anything that must read env at module scope has to be lazily imported.
+// Asserted in __tests__/index-boot.unit.test.ts.
 import { config } from "dotenv";
 
 /**

--- a/typescript-sdk/src/cli/program.ts
+++ b/typescript-sdk/src/cli/program.ts
@@ -20,8 +20,10 @@ import { parsePromptSpec } from "./types";
 import { formatApiErrorMessage } from "../client-sdk/services/_shared/format-api-error";
 import {
   applyOutputContext,
+  assertFormatIsSupported,
   registerOutputOptions,
   resolveActionOutputOptions,
+  emitsResult,
   type RawOutputFlags,
 } from "./utils/output";
 
@@ -101,32 +103,6 @@ const createCommand = async (name: string, options: { format?: string }): Promis
   return createCommandImpl(name, options);
 };
 
-// Evaluator commands
-const listEvaluatorsCommand = async (options?: { format?: string }): Promise<void> => {
-  const { listEvaluatorsCommand: impl } = await import("./commands/evaluators/list.js");
-  return impl(options);
-};
-
-const getEvaluatorCommand = async (idOrSlug: string, options?: { format?: string }): Promise<void> => {
-  const { getEvaluatorCommand: impl } = await import("./commands/evaluators/get.js");
-  return impl(idOrSlug, options);
-};
-
-const createEvaluatorCommand = async (name: string, options: { type: string; format?: string }): Promise<void> => {
-  const { createEvaluatorCommand: impl } = await import("./commands/evaluators/create.js");
-  return impl(name, options);
-};
-
-const updateEvaluatorCommand = async (idOrSlug: string, options: { name?: string; settings?: string; format?: string }): Promise<void> => {
-  const { updateEvaluatorCommand: impl } = await import("./commands/evaluators/update.js");
-  return impl(idOrSlug, options);
-};
-
-const deleteEvaluatorCommand = async (idOrSlug: string, options?: { format?: string }): Promise<void> => {
-  const { deleteEvaluatorCommand: impl } = await import("./commands/evaluators/delete.js");
-  return impl(idOrSlug, options);
-};
-
 export function buildProgram(): Command {
   const program = new Command();
 
@@ -163,8 +139,16 @@ export function buildProgram(): Command {
   // resolveOutputOptions. resolveActionOutputOptions additionally keeps a
   // command's OWN `--json <json>` payload option (dataset records add/update)
   // from being misread as machine-output intent.
+  //
+  // `assertFormatIsSupported` runs first: a command that has not been migrated
+  // to `emitsResult` cannot honour `-o json`, and answering it with a chalk
+  // table at exit 0 is the one failure a machine caller cannot detect. An
+  // explicit request there is an error; agent mode merely detected from the
+  // environment falls back to the table with a warning (see utils/output.ts).
   program.hook("preAction", async (_thisCommand, actionCommand) => {
-    await applyOutputContext(resolveActionOutputOptions(actionCommand));
+    const requested = resolveActionOutputOptions(actionCommand);
+    const effective = await assertFormatIsSupported(actionCommand, requested);
+    await applyOutputContext(effective);
   });
 
   // Top-level commands
@@ -836,12 +820,14 @@ export function buildProgram(): Command {
 
   // Help TOPICS (`gh help formatting` style). Registered as a real command:
   // a command named `help` suppresses commander's implicit one (whose dispatch
-  // is internal and could never reach a topic page), so `langwatch help agent`
-  // lands in this action. `help <command>` still prints that command's help.
+  // is internal and could never reach a topic page), so `langwatch help
+  // agent-mode` lands in this action. A REAL command always wins the lookup —
+  // `help agent` reaches the `agent` group — and topics are never named after
+  // a command (asserted in commands/__tests__); see commands/help.ts.
   program
     .command("help [topic...]")
     .description(
-      "Show help for a command or a help topic (`langwatch help agent` is the agent-mode guide)",
+      "Show help for a command or a help topic (`langwatch help agent-mode` is the agent-mode guide)",
     )
     .action(async (topic: string[] = []) => {
       const { helpCommand: impl } = await import("./commands/help.js");
@@ -894,7 +880,8 @@ export function buildProgram(): Command {
     .option("--dir <root>", "Install root (default ~/.agents)")
     .option("--dry-run", "Report what would happen without writing anything")
     .option("--force", "Overwrite files that differ from the bundle")
-    .action(async (names: string[], options: { all?: boolean; dir?: string; dryRun?: boolean; force?: boolean } & RawOutputFlags) => {
+    .option("-y, --yes", "Confirm overwriting files the bundle does not manage (required in non-TTY/agent contexts)")
+    .action(async (names: string[], options: { all?: boolean; dir?: string; dryRun?: boolean; force?: boolean; yes?: boolean } & RawOutputFlags) => {
       try {
         const { skillsInstallCommand: impl } = await import("./commands/skills/install.js");
         await impl(names, options);
@@ -929,7 +916,8 @@ export function buildProgram(): Command {
     .option("--dir <root>", "Install root (default ~/.agents)")
     .option("--dry-run", "Report what would happen without writing anything")
     .option("--force", "Overwrite managed files that carry local edits")
-    .action(async (names: string[], options: { dir?: string; dryRun?: boolean; force?: boolean } & RawOutputFlags) => {
+    .option("-y, --yes", "Confirm overwriting files the bundle does not manage (required in non-TTY/agent contexts)")
+    .action(async (names: string[], options: { dir?: string; dryRun?: boolean; force?: boolean; yes?: boolean } & RawOutputFlags) => {
       try {
         const { skillsUpdateCommand: impl } = await import("./commands/skills/update.js");
         await impl(names, options);
@@ -976,73 +964,88 @@ export function buildProgram(): Command {
     .command("evaluator")
     .description("Manage evaluator definitions");
 
-  evaluatorCmd
-    .command("list")
-    .description("List all evaluators in the project")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    evaluatorCmd
+      .command("list")
+      .description("List all evaluators in the project")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       try {
-        await listEvaluatorsCommand(options);
+        const { listEvaluatorsCommand: impl } = await import("./commands/evaluators/list.js");
+        return await impl();
       } catch (error) {
         console.error(`Error: ${formatApiErrorMessage({ error })}`);
         process.exit(1);
       }
-    });
+    },
+  );
 
-  evaluatorCmd
-    .command("get <idOrSlug>")
-    .description("Get evaluator details by ID or slug")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (idOrSlug: string, options: { format?: string }) => {
+  emitsResult(
+    evaluatorCmd
+      .command("get <idOrSlug>")
+      .description("Get evaluator details by ID or slug")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (idOrSlug: string) => {
       try {
-        await getEvaluatorCommand(idOrSlug, options);
+        const { getEvaluatorCommand: impl } = await import("./commands/evaluators/get.js");
+        return await impl(idOrSlug);
       } catch (error) {
         console.error(`Error: ${formatApiErrorMessage({ error })}`);
         process.exit(1);
       }
-    });
+    },
+  );
 
-  evaluatorCmd
-    .command("create <name>")
-    .description("Create a new evaluator")
-    .requiredOption("--type <evaluatorType>", "Evaluator type (e.g. langevals/llm_judge)")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (name: string, options: { type: string; format?: string }) => {
+  emitsResult(
+    evaluatorCmd
+      .command("create <name>")
+      .description("Create a new evaluator")
+      .requiredOption("--type <evaluatorType>", "Evaluator type (e.g. langevals/llm_judge)")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (name: string, options: { type: string }) => {
       try {
-        await createEvaluatorCommand(name, options);
+        const { createEvaluatorCommand: impl } = await import("./commands/evaluators/create.js");
+        return await impl(name, options);
       } catch (error) {
         console.error(`Error: ${formatApiErrorMessage({ error })}`);
         process.exit(1);
       }
-    });
+    },
+  );
 
-  evaluatorCmd
-    .command("update <idOrSlug>")
-    .description("Update an evaluator name or settings")
-    .option("--name <name>", "New evaluator name")
-    .option("--settings <json>", "Evaluator config settings as JSON")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (idOrSlug: string, options: { name?: string; settings?: string; format?: string }) => {
+  emitsResult(
+    evaluatorCmd
+      .command("update <idOrSlug>")
+      .description("Update an evaluator name or settings")
+      .option("--name <name>", "New evaluator name")
+      .option("--settings <json>", "Evaluator config settings as JSON")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (idOrSlug: string, options: { name?: string; settings?: string }) => {
       try {
-        await updateEvaluatorCommand(idOrSlug, options);
+        const { updateEvaluatorCommand: impl } = await import("./commands/evaluators/update.js");
+        return await impl(idOrSlug, options);
       } catch (error) {
         console.error(`Error: ${formatApiErrorMessage({ error })}`);
         process.exit(1);
       }
-    });
+    },
+  );
 
-  evaluatorCmd
-    .command("delete <idOrSlug>")
-    .description("Archive (soft-delete) an evaluator")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (idOrSlug: string, options: { format?: string }) => {
+  emitsResult(
+    evaluatorCmd
+      .command("delete <idOrSlug>")
+      .description("Archive (soft-delete) an evaluator")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (idOrSlug: string) => {
       try {
-        await deleteEvaluatorCommand(idOrSlug, options);
+        const { deleteEvaluatorCommand: impl } = await import("./commands/evaluators/delete.js");
+        return await impl(idOrSlug);
       } catch (error) {
         console.error(`Error: ${formatApiErrorMessage({ error })}`);
         process.exit(1);
       }
-    });
+    },
+  );
 
   // Add experiment command group — run, monitor, list, and inspect experiments
   const experimentCmd = program
@@ -1183,142 +1186,168 @@ export function buildProgram(): Command {
     .command("agent")
     .description("Manage agent definitions");
 
-  agentCmd
-    .command("list")
-    .description("List all agents in the project")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    agentCmd
+      .command("list")
+      .description("List all agents in the project")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       const { listAgentsCommand: impl } = await import("./commands/agents/list.js");
-      await impl(options);
-    });
+      return impl();
+    },
+  );
 
-  agentCmd
-    .command("get <id>")
-    .description("Get agent details by ID")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    agentCmd
+      .command("get <id>")
+      .description("Get agent details by ID")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { getAgentCommand: impl } = await import("./commands/agents/get.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
-  agentCmd
-    .command("create <name>")
-    .description("Create a new agent")
-    .requiredOption("--type <type>", "Agent type: signature, code, workflow, or http")
-    .option("--config <json>", "Agent config as JSON")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (name: string, options: { type: string; config?: string; format?: string }) => {
+  emitsResult(
+    agentCmd
+      .command("create <name>")
+      .description("Create a new agent")
+      .requiredOption("--type <type>", "Agent type: signature, code, workflow, or http")
+      .option("--config <json>", "Agent config as JSON")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (name: string, options: { type: string; config?: string }) => {
       const { createAgentCommand: impl } = await import("./commands/agents/create.js");
-      await impl(name, options);
-    });
+      return impl(name, options);
+    },
+  );
 
-  agentCmd
-    .command("run <id>")
-    .description("Execute an agent with JSON input (HTTP agents call URL directly, others use workflow engine)")
-    .option("--input <json>", "Input data as JSON string")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { input?: string; format?: string }) => {
+  emitsResult(
+    agentCmd
+      .command("run <id>")
+      .description("Execute an agent with JSON input (HTTP agents call URL directly, others use workflow engine)")
+      .option("--input <json>", "Input data as JSON string")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string, options: { input?: string }) => {
       const { runAgentCommand: impl } = await import("./commands/agents/run.js");
-      await impl(id, options);
-    });
+      return impl(id, options);
+    },
+  );
 
-  agentCmd
-    .command("update <id>")
-    .description("Update an agent name, type, or configuration")
-    .option("--name <name>", "New agent name")
-    .option("--type <type>", "New agent type: signature, code, workflow, or http")
-    .option("--config <json>", "Updated configuration as JSON")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { name?: string; type?: string; config?: string; format?: string }) => {
+  emitsResult(
+    agentCmd
+      .command("update <id>")
+      .description("Update an agent name, type, or configuration")
+      .option("--name <name>", "New agent name")
+      .option("--type <type>", "New agent type: signature, code, workflow, or http")
+      .option("--config <json>", "Updated configuration as JSON")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string, options: { name?: string; type?: string; config?: string }) => {
       const { updateAgentCommand: impl } = await import("./commands/agents/update.js");
-      await impl(id, options);
-    });
+      return impl(id, options);
+    },
+  );
 
-  agentCmd
-    .command("delete <id>")
-    .description("Archive (soft-delete) an agent")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    agentCmd
+      .command("delete <id>")
+      .description("Archive (soft-delete) an agent")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { deleteAgentCommand: impl } = await import("./commands/agents/delete.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   // Add dashboard command group
   const dashboardCmd = program
     .command("dashboard")
     .description("Manage analytics dashboards");
 
-  dashboardCmd
-    .command("list")
-    .description("List all dashboards in the project")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    dashboardCmd
+      .command("list")
+      .description("List all dashboards in the project")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       const { listDashboardsCommand: impl } = await import("./commands/dashboards/list.js");
-      await impl(options);
-    });
+      return impl();
+    },
+  );
 
-  dashboardCmd
-    .command("get <id>")
-    .description("Get dashboard details by ID")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    dashboardCmd
+      .command("get <id>")
+      .description("Get dashboard details by ID")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { getDashboardCommand: impl } = await import("./commands/dashboards/get.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
-  dashboardCmd
-    .command("update <id>")
-    .description("Rename a dashboard")
-    .requiredOption("--name <name>", "New dashboard name")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { name?: string; format?: string }) => {
+  emitsResult(
+    dashboardCmd
+      .command("update <id>")
+      .description("Rename a dashboard")
+      .requiredOption("--name <name>", "New dashboard name")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string, options: { name?: string }) => {
       const { updateDashboardCommand: impl } = await import("./commands/dashboards/update.js");
-      await impl(id, options);
-    });
+      return impl(id, options);
+    },
+  );
 
-  dashboardCmd
-    .command("create <name>")
-    .description("Create a new dashboard")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (name: string, options: { format?: string }) => {
+  emitsResult(
+    dashboardCmd
+      .command("create <name>")
+      .description("Create a new dashboard")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (name: string) => {
       const { createDashboardCommand: impl } = await import("./commands/dashboards/create.js");
-      await impl(name, options);
-    });
+      return impl(name);
+    },
+  );
 
-  dashboardCmd
-    .command("delete <id>")
-    .description("Delete a dashboard and its graphs")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    dashboardCmd
+      .command("delete <id>")
+      .description("Delete a dashboard and its graphs")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { deleteDashboardCommand: impl } = await import("./commands/dashboards/delete.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   // Add model-provider command group
   const modelProviderCmd = program
     .command("model-provider")
     .description("Manage LLM model provider configurations");
 
-  modelProviderCmd
-    .command("list")
-    .description("List all configured model providers")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    modelProviderCmd
+      .command("list")
+      .description("List all configured model providers")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       const { listModelProvidersCommand: impl } = await import("./commands/model-providers/list.js");
-      await impl(options);
-    });
+      return impl();
+    },
+  );
 
-  modelProviderCmd
-    .command("set <provider>")
-    .description("Configure a model provider (e.g. openai, anthropic)")
-    .option("--enabled <boolean>", "Enable or disable the provider", (v) => v === "true")
-    .option("--api-key <key>", "API key for the provider")
-    .option("--default-model <model>", "Default model to use (e.g. gpt-5-mini)")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (provider: string, options: { enabled?: boolean; apiKey?: string; defaultModel?: string; format?: string }) => {
+  emitsResult(
+    modelProviderCmd
+      .command("set <provider>")
+      .description("Configure a model provider (e.g. openai, anthropic)")
+      .option("--enabled <boolean>", "Enable or disable the provider", (v) => v === "true")
+      .option("--api-key <key>", "API key for the provider")
+      .option("--default-model <model>", "Default model to use (e.g. gpt-5-mini)")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (provider: string, options: { enabled?: boolean; apiKey?: string; defaultModel?: string }) => {
       const { setModelProviderCommand: impl } = await import("./commands/model-providers/set.js");
-      await impl(provider, options);
-    });
+      return impl(provider, options);
+    },
+  );
 
   // Add model-default command group (cascading default models)
   const modelDefaultCmd = program
@@ -1327,61 +1356,63 @@ export function buildProgram(): Command {
       "Manage cascading default models (per role/feature, per scope: project/team/organization)",
     );
 
-  modelDefaultCmd
-    .command("list")
-    .description("Show the effective resolution + every config you can read")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    modelDefaultCmd
+      .command("list")
+      .description("Show the effective resolution + every config you can read")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       const { listModelDefaultsCommand: impl } = await import(
         "./commands/model-defaults/list.js"
       );
-      await impl(options);
-    });
+      return impl();
+    },
+  );
 
-  modelDefaultCmd
-    .command("set <key> <model>")
-    .description(
-      "Set a default model for a role (DEFAULT|FAST|EMBEDDINGS) or registered feature key. Defaults to project scope; pass --scope team|organization for higher tiers.",
-    )
-    .option("--scope <scope>", "Scope tier: project (default), team, or organization", "project")
-    .option(
-      "--scope-id <id>",
-      "Explicit scope id. Defaults to the API key's project / its team / its organization.",
-    )
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(
-      async (
-        key: string,
-        model: string,
-        options: { scope?: "project" | "team" | "organization"; scopeId?: string; format?: string },
-      ) => {
-        const { setModelDefaultCommand: impl } = await import(
-          "./commands/model-defaults/set.js"
-        );
-        await impl(key, model, options);
-      },
-    );
+  emitsResult(
+    modelDefaultCmd
+      .command("set <key> <model>")
+      .description(
+        "Set a default model for a role (DEFAULT|FAST|EMBEDDINGS) or registered feature key. Defaults to project scope; pass --scope team|organization for higher tiers.",
+      )
+      .option("--scope <scope>", "Scope tier: project (default), team, or organization", "project")
+      .option(
+        "--scope-id <id>",
+        "Explicit scope id. Defaults to the API key's project / its team / its organization.",
+      )
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (
+      key: string,
+      model: string,
+      options: { scope?: "project" | "team" | "organization"; scopeId?: string },
+    ) => {
+      const { setModelDefaultCommand: impl } = await import(
+        "./commands/model-defaults/set.js"
+      );
+      return impl(key, model, options);
+    },
+  );
 
-  modelDefaultCmd
-    .command("unset <key>")
-    .description("Remove a default model for a role or feature key at the chosen scope")
-    .option("--scope <scope>", "Scope tier: project (default), team, or organization", "project")
-    .option(
-      "--scope-id <id>",
-      "Explicit scope id. Defaults to the API key's project / its team / its organization.",
-    )
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(
-      async (
-        key: string,
-        options: { scope?: "project" | "team" | "organization"; scopeId?: string; format?: string },
-      ) => {
-        const { unsetModelDefaultCommand: impl } = await import(
-          "./commands/model-defaults/unset.js"
-        );
-        await impl(key, options);
-      },
-    );
+  emitsResult(
+    modelDefaultCmd
+      .command("unset <key>")
+      .description("Remove a default model for a role or feature key at the chosen scope")
+      .option("--scope <scope>", "Scope tier: project (default), team, or organization", "project")
+      .option(
+        "--scope-id <id>",
+        "Explicit scope id. Defaults to the API key's project / its team / its organization.",
+      )
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (
+      key: string,
+      options: { scope?: "project" | "team" | "organization"; scopeId?: string },
+    ) => {
+      const { unsetModelDefaultCommand: impl } = await import(
+        "./commands/model-defaults/unset.js"
+      );
+      return impl(key, options);
+    },
+  );
 
   // Add virtual-keys command group (AI Gateway)
   const virtualKeysCmd = program
@@ -1389,52 +1420,59 @@ export function buildProgram(): Command {
     .alias("vk")
     .description("Manage AI Gateway virtual keys (list, create, rotate, revoke)");
 
-  virtualKeysCmd
-    .command("list")
-    .description("List all virtual keys for the current project")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    virtualKeysCmd
+      .command("list")
+      .description("List all virtual keys for the current project")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       const { listVirtualKeysCommand: impl } = await import("./commands/virtual-keys/list.js");
-      await impl(options);
-    });
+      return impl();
+    },
+  );
 
-  virtualKeysCmd
-    .command("get <id>")
-    .description("Show details for a single virtual key")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    virtualKeysCmd
+      .command("get <id>")
+      .description("Show details for a single virtual key")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (id: string) => {
       const { getVirtualKeyCommand: impl } = await import("./commands/virtual-keys/get.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
-  virtualKeysCmd
-    .command("create")
-    .description("Create a new virtual key (secret is shown once)")
-    .requiredOption("--name <name>", "Human-readable name for the key")
-    .option("--description <desc>", "Optional description")
-    .option("--env <env>", "Environment: live or test", "live")
-    .option("--scope <typeAndId...>", "Scope row in TYPE:id form (repeatable). Types: ORG | TEAM | PROJECT. Example: --scope ORG:acme --scope TEAM:platform")
-    .option("--routing-policy <id>", "RoutingPolicy id to pin (otherwise uses the org's default policy)")
-    .option("--principal-user <userId>", "Mark this VK as personal and attribute spend to the named principal user")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (options: { name: string; description?: string; env?: "live" | "test"; scope?: string[]; routingPolicy?: string; principalUser?: string; format?: string }) => {
+  emitsResult(
+    virtualKeysCmd
+      .command("create")
+      .description("Create a new virtual key (secret is shown once)")
+      .requiredOption("--name <name>", "Human-readable name for the key")
+      .option("--description <desc>", "Optional description")
+      .option("--env <env>", "Environment: live or test", "live")
+      .option("--scope <typeAndId...>", "Scope row in TYPE:id form (repeatable). Types: ORG | TEAM | PROJECT. Example: --scope ORG:acme --scope TEAM:platform")
+      .option("--routing-policy <id>", "RoutingPolicy id to pin (otherwise uses the org's default policy)")
+      .option("--principal-user <userId>", "Mark this VK as personal and attribute spend to the named principal user")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (options: { name: string; description?: string; env?: "live" | "test"; scope?: string[]; routingPolicy?: string; principalUser?: string }) => {
       const { createVirtualKeyCommand: impl } = await import("./commands/virtual-keys/create.js");
-      await impl(options);
-    });
+      return impl(options);
+    },
+  );
 
-  virtualKeysCmd
-    .command("update <id>")
-    .description("Update a virtual key's name/description/scopes/routing-policy/config")
-    .option("--name <name>", "New display name")
-    .option("--description <desc>", "New description")
-    .option("--clear-description", "Clear the description")
-    .option("--scope <typeAndId...>", "Replace the scope set (repeatable; supplies the full set). Same TYPE:id form as create.")
-    .option("--routing-policy <id>", "Switch to a different RoutingPolicy (pass id)")
-    .option("--clear-routing-policy", "Unpin the routing policy; VK falls back to the org default ordering")
-    .option("--config-json <json>", "Inline partial config JSON (model_aliases/cache/fallback/rate_limits/policy_rules). Merges with existing config")
-    .option("--config-file <path>", "Read partial config JSON from a file")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (id: string, options: {
+  emitsResult(
+    virtualKeysCmd
+      .command("update <id>")
+      .description("Update a virtual key's name/description/scopes/routing-policy/config")
+      .option("--name <name>", "New display name")
+      .option("--description <desc>", "New description")
+      .option("--clear-description", "Clear the description")
+      .option("--scope <typeAndId...>", "Replace the scope set (repeatable; supplies the full set). Same TYPE:id form as create.")
+      .option("--routing-policy <id>", "Switch to a different RoutingPolicy (pass id)")
+      .option("--clear-routing-policy", "Unpin the routing policy; VK falls back to the org default ordering")
+      .option("--config-json <json>", "Inline partial config JSON (model_aliases/cache/fallback/rate_limits/policy_rules). Merges with existing config")
+      .option("--config-file <path>", "Read partial config JSON from a file")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (id: string, options: {
       name?: string;
       description?: string;
       clearDescription?: boolean;
@@ -1443,61 +1481,68 @@ export function buildProgram(): Command {
       clearRoutingPolicy?: boolean;
       configJson?: string;
       configFile?: string;
-      format?: string;
     }) => {
       const { updateVirtualKeyCommand: impl } = await import("./commands/virtual-keys/update.js");
-      await impl(id, options);
-    });
+      return impl(id, options);
+    },
+  );
 
-  virtualKeysCmd
-    .command("rotate <id>")
-    .description("Rotate a virtual key's secret (old secret stops working immediately)")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    virtualKeysCmd
+      .command("rotate <id>")
+      .description("Rotate a virtual key's secret (old secret stops working immediately)")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (id: string) => {
       const { rotateVirtualKeyCommand: impl } = await import("./commands/virtual-keys/rotate.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
-  virtualKeysCmd
-    .command("revoke <id>")
-    .description("Revoke a virtual key (cannot be reactivated)")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    virtualKeysCmd
+      .command("revoke <id>")
+      .description("Revoke a virtual key (cannot be reactivated)")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (id: string) => {
       const { revokeVirtualKeyCommand: impl } = await import("./commands/virtual-keys/revoke.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   // Add gateway-budgets command group (AI Gateway)
   const gatewayBudgetsCmd = program
     .command("gateway-budgets")
     .description("Manage AI Gateway spend budgets (hierarchical scopes)");
 
-  gatewayBudgetsCmd
-    .command("list")
-    .description("List all budgets across scopes")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    gatewayBudgetsCmd
+      .command("list")
+      .description("List all budgets across scopes")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       const { listGatewayBudgetsCommand: impl } = await import("./commands/gateway-budgets/list.js");
-      await impl(options);
-    });
+      return impl();
+    },
+  );
 
-  gatewayBudgetsCmd
-    .command("create")
-    .description("Create a new budget (scope + window + limit)")
-    .requiredOption("--name <name>", "Human-readable budget name")
-    .option("--description <desc>", "Optional description")
-    .requiredOption("--scope <kind>", "Budget scope: organization|team|project|virtual-key|principal")
-    .option("--organization <id>", "Organization id (for scope=organization)")
-    .option("--team <id>", "Team id (for scope=team)")
-    .option("--project <id>", "Project id (for scope=project)")
-    .option("--virtual-key <id>", "Virtual key id (for scope=virtual-key)")
-    .option("--principal <id>", "Principal user id (for scope=principal)")
-    .requiredOption("--window <w>", "Budget window: minute|hour|day|week|month|total")
-    .requiredOption("--limit <usd>", "Hard cap in USD (e.g. 100 or 49.99)")
-    .option("--on-breach <action>", "block (default) or warn", "block")
-    .option("--timezone <tz>", "IANA timezone for window boundaries (e.g. Europe/Amsterdam)")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (options: {
+  emitsResult(
+    gatewayBudgetsCmd
+      .command("create")
+      .description("Create a new budget (scope + window + limit)")
+      .requiredOption("--name <name>", "Human-readable budget name")
+      .option("--description <desc>", "Optional description")
+      .requiredOption("--scope <kind>", "Budget scope: organization|team|project|virtual-key|principal")
+      .option("--organization <id>", "Organization id (for scope=organization)")
+      .option("--team <id>", "Team id (for scope=team)")
+      .option("--project <id>", "Project id (for scope=project)")
+      .option("--virtual-key <id>", "Virtual key id (for scope=virtual-key)")
+      .option("--principal <id>", "Principal user id (for scope=principal)")
+      .requiredOption("--window <w>", "Budget window: minute|hour|day|week|month|total")
+      .requiredOption("--limit <usd>", "Hard cap in USD (e.g. 100 or 49.99)")
+      .option("--on-breach <action>", "block (default) or warn", "block")
+      .option("--timezone <tz>", "IANA timezone for window boundaries (e.g. Europe/Amsterdam)")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (options: {
       name: string;
       description?: string;
       scope: "organization" | "team" | "project" | "virtual-key" | "principal";
@@ -1510,24 +1555,25 @@ export function buildProgram(): Command {
       limit: string;
       onBreach?: "block" | "warn";
       timezone?: string;
-      format?: string;
     }) => {
       const { createGatewayBudgetCommand: impl } = await import("./commands/gateway-budgets/create.js");
-      await impl(options);
-    });
+      return impl(options);
+    },
+  );
 
-  gatewayBudgetsCmd
-    .command("update <id>")
-    .description("Update a budget's name/description/limit/on-breach/timezone")
-    .option("--name <name>", "New display name")
-    .option("--description <desc>", "New description")
-    .option("--clear-description", "Clear the description")
-    .option("--limit <usd>", "New hard-cap in USD")
-    .option("--on-breach <action>", "block or warn")
-    .option("--timezone <tz>", "New IANA timezone")
-    .option("--clear-timezone", "Clear the timezone override")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (id: string, options: {
+  emitsResult(
+    gatewayBudgetsCmd
+      .command("update <id>")
+      .description("Update a budget's name/description/limit/on-breach/timezone")
+      .option("--name <name>", "New display name")
+      .option("--description <desc>", "New description")
+      .option("--clear-description", "Clear the description")
+      .option("--limit <usd>", "New hard-cap in USD")
+      .option("--on-breach <action>", "block or warn")
+      .option("--timezone <tz>", "New IANA timezone")
+      .option("--clear-timezone", "Clear the timezone override")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (id: string, options: {
       name?: string;
       description?: string;
       clearDescription?: boolean;
@@ -1535,86 +1581,98 @@ export function buildProgram(): Command {
       onBreach?: "block" | "warn";
       timezone?: string;
       clearTimezone?: boolean;
-      format?: string;
     }) => {
       const { updateGatewayBudgetCommand: impl } = await import("./commands/gateway-budgets/update.js");
-      await impl(id, options);
-    });
+      return impl(id, options);
+    },
+  );
 
-  gatewayBudgetsCmd
-    .command("archive <id>")
-    .description("Archive a budget (stops enforcement; does not delete history)")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    gatewayBudgetsCmd
+      .command("archive <id>")
+      .description("Archive a budget (stops enforcement; does not delete history)")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (id: string) => {
       const { archiveGatewayBudgetCommand: impl } = await import("./commands/gateway-budgets/archive.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   // Add annotation command group
   const annotationCmd = program
     .command("annotation")
     .description("Manage trace annotations");
 
-  annotationCmd
-    .command("list")
-    .description("List all annotations (optionally filtered by trace)")
-    .option("--trace-id <traceId>", "Filter by trace ID")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { traceId?: string; format?: string }) => {
+  emitsResult(
+    annotationCmd
+      .command("list")
+      .description("List all annotations (optionally filtered by trace)")
+      .option("--trace-id <traceId>", "Filter by trace ID")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (options: { traceId?: string }) => {
       const { listAnnotationsCommand: impl } = await import("./commands/annotations/list.js");
-      await impl(options);
-    });
+      return impl(options);
+    },
+  );
 
-  annotationCmd
-    .command("get <id>")
-    .description("Get annotation details by ID")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    annotationCmd
+      .command("get <id>")
+      .description("Get annotation details by ID")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { getAnnotationCommand: impl } = await import("./commands/annotations/get.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
-  annotationCmd
-    .command("create <traceId>")
-    .description("Create an annotation for a trace")
-    .option("--comment <comment>", "Annotation comment")
-    .option("--thumbs-up", "Mark as thumbs up")
-    .option("--thumbs-down", "Mark as thumbs down")
-    .option("--email <email>", "Email of the annotator")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (traceId: string, options: { comment?: string; thumbsUp?: boolean; thumbsDown?: boolean; email?: string; format?: string }) => {
+  emitsResult(
+    annotationCmd
+      .command("create <traceId>")
+      .description("Create an annotation for a trace")
+      .option("--comment <comment>", "Annotation comment")
+      .option("--thumbs-up", "Mark as thumbs up")
+      .option("--thumbs-down", "Mark as thumbs down")
+      .option("--email <email>", "Email of the annotator")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (traceId: string, options: { comment?: string; thumbsUp?: boolean; thumbsDown?: boolean; email?: string }) => {
       const { createAnnotationCommand: impl } = await import("./commands/annotations/create.js");
-      await impl(traceId, options);
-    });
+      return impl(traceId, options);
+    },
+  );
 
-  annotationCmd
-    .command("delete <id>")
-    .description("Delete an annotation")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    annotationCmd
+      .command("delete <id>")
+      .description("Delete an annotation")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { deleteAnnotationCommand: impl } = await import("./commands/annotations/delete.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   // Add analytics command group
   const analyticsCmd = program
     .command("analytics")
     .description("Query analytics and metrics");
 
-  analyticsCmd
-    .command("query")
-    .description("Query timeseries analytics (costs, latency, token usage, etc.)")
-    .option("-m, --metric <metric>", "Metric to query (preset name or raw metric path, default: trace-count)")
-    .option("-a, --aggregation <aggregation>", "Aggregation type: cardinality, avg, sum, min, max, p95, p99")
-    .option("--start-date <date>", "Start date (ISO string, default: 7 days ago)")
-    .option("--end-date <date>", "End date (ISO string, default: now)")
-    .option("--group-by <field>", "Group by field (e.g. metadata.model)")
-    .option("--time-scale <scale>", "Time scale: 'full' for aggregate, or interval in seconds")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { metric?: string; aggregation?: string; startDate?: string; endDate?: string; groupBy?: string; timeScale?: string; format?: string }) => {
+  emitsResult(
+    analyticsCmd
+      .command("query")
+      .description("Query timeseries analytics (costs, latency, token usage, etc.)")
+      .option("-m, --metric <metric>", "Metric to query (preset name or raw metric path, default: trace-count)")
+      .option("-a, --aggregation <aggregation>", "Aggregation type: cardinality, avg, sum, min, max, p95, p99")
+      .option("--start-date <date>", "Start date (ISO string, default: 7 days ago)")
+      .option("--end-date <date>", "End date (ISO string, default: now)")
+      .option("--group-by <field>", "Group by field (e.g. metadata.model)")
+      .option("--time-scale <scale>", "Time scale: 'full' for aggregate, or interval in seconds")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (options: { metric?: string; aggregation?: string; startDate?: string; endDate?: string; groupBy?: string; timeScale?: string }) => {
       const { queryAnalyticsCommand: impl } = await import("./commands/analytics/query.js");
-      await impl(options);
-    });
+      return impl(options);
+    },
+  );
 
   // Add trace command group
   const traceCmd = program
@@ -1810,231 +1868,271 @@ export function buildProgram(): Command {
     .command("graph")
     .description("Manage custom graphs on dashboards");
 
-  graphCmd
-    .command("list")
-    .description("List all custom graphs (optionally filter by dashboard)")
-    .option("--dashboard-id <id>", "Filter by dashboard ID")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { dashboardId?: string; format?: string }) => {
+  emitsResult(
+    graphCmd
+      .command("list")
+      .description("List all custom graphs (optionally filter by dashboard)")
+      .option("--dashboard-id <id>", "Filter by dashboard ID")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (options: { dashboardId?: string }) => {
       const { listGraphsCommand: impl } = await import("./commands/graphs/list.js");
-      await impl(options);
-    });
+      return impl(options);
+    },
+  );
 
-  graphCmd
-    .command("get <id>")
-    .description("Get a custom graph by ID")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    graphCmd
+      .command("get <id>")
+      .description("Get a custom graph by ID")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { getGraphCommand: impl } = await import("./commands/graphs/get.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
-  graphCmd
-    .command("create <name>")
-    .description("Create a custom graph")
-    .option("--dashboard-id <id>", "Dashboard to add the graph to")
-    .option("--graph <json>", "Graph definition as JSON")
-    .option("--filters <json>", "Filter conditions as JSON")
-    .option("--col-span <n>", "Column span (1-2)")
-    .option("--row-span <n>", "Row span (1-2)")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (name: string, options: { dashboardId?: string; graph?: string; filters?: string; colSpan?: string; rowSpan?: string; format?: string }) => {
+  emitsResult(
+    graphCmd
+      .command("create <name>")
+      .description("Create a custom graph")
+      .option("--dashboard-id <id>", "Dashboard to add the graph to")
+      .option("--graph <json>", "Graph definition as JSON")
+      .option("--filters <json>", "Filter conditions as JSON")
+      .option("--col-span <n>", "Column span (1-2)")
+      .option("--row-span <n>", "Row span (1-2)")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (name: string, options: { dashboardId?: string; graph?: string; filters?: string; colSpan?: string; rowSpan?: string }) => {
       const { createGraphCommand: impl } = await import("./commands/graphs/create.js");
-      await impl(name, options);
-    });
+      return impl(name, options);
+    },
+  );
 
-  graphCmd
-    .command("update <id>")
-    .description("Update a custom graph")
-    .option("--name <name>", "New graph name")
-    .option("--graph <json>", "New graph definition as JSON")
-    .option("--filters <json>", "New filter conditions as JSON")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { name?: string; graph?: string; filters?: string; format?: string }) => {
+  emitsResult(
+    graphCmd
+      .command("update <id>")
+      .description("Update a custom graph")
+      .option("--name <name>", "New graph name")
+      .option("--graph <json>", "New graph definition as JSON")
+      .option("--filters <json>", "New filter conditions as JSON")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string, options: { name?: string; graph?: string; filters?: string }) => {
       const { updateGraphCommand: impl } = await import("./commands/graphs/update.js");
-      await impl(id, options);
-    });
+      return impl(id, options);
+    },
+  );
 
-  graphCmd
-    .command("delete <id>")
-    .description("Delete a custom graph")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    graphCmd
+      .command("delete <id>")
+      .description("Delete a custom graph")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { deleteGraphCommand: impl } = await import("./commands/graphs/delete.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   // Add trigger (automation) command group
   const triggerCmd = program
     .command("trigger")
     .description("Manage triggers (automations) — alerts, webhooks, and dataset actions");
 
-  triggerCmd
-    .command("list")
-    .description("List all triggers in the project")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    triggerCmd
+      .command("list")
+      .description("List all triggers in the project")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       const { listTriggersCommand: impl } = await import("./commands/triggers/list.js");
-      await impl(options);
-    });
+      return impl();
+    },
+  );
 
-  triggerCmd
-    .command("get <id>")
-    .description("Get trigger details by ID")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    triggerCmd
+      .command("get <id>")
+      .description("Get trigger details by ID")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { getTriggerCommand: impl } = await import("./commands/triggers/get.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
-  triggerCmd
-    .command("create <name>")
-    .description("Create a new trigger (automation)")
-    .requiredOption("--action <action>", "Trigger action: SEND_EMAIL, ADD_TO_DATASET, ADD_TO_ANNOTATION_QUEUE, SEND_SLACK_MESSAGE")
-    .option("--filters <json>", "Trigger filter conditions as JSON")
-    .option("--message <text>", "Custom alert message")
-    .option("--alert-type <type>", "Alert severity: CRITICAL, WARNING, INFO")
-    .option("--slack-webhook <url>", "Slack webhook URL (for SEND_SLACK_MESSAGE action)")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (name: string, options: { action: string; filters?: string; message?: string; alertType?: string; slackWebhook?: string; format?: string }) => {
+  emitsResult(
+    triggerCmd
+      .command("create <name>")
+      .description("Create a new trigger (automation)")
+      .requiredOption("--action <action>", "Trigger action: SEND_EMAIL, ADD_TO_DATASET, ADD_TO_ANNOTATION_QUEUE, SEND_SLACK_MESSAGE")
+      .option("--filters <json>", "Trigger filter conditions as JSON")
+      .option("--message <text>", "Custom alert message")
+      .option("--alert-type <type>", "Alert severity: CRITICAL, WARNING, INFO")
+      .option("--slack-webhook <url>", "Slack webhook URL (for SEND_SLACK_MESSAGE action)")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (name: string, options: { action: string; filters?: string; message?: string; alertType?: string; slackWebhook?: string }) => {
       const { createTriggerCommand: impl } = await import("./commands/triggers/create.js");
-      await impl(name, options);
-    });
+      return impl(name, options);
+    },
+  );
 
-  triggerCmd
-    .command("update <id>")
-    .description("Update a trigger")
-    .option("--name <name>", "New trigger name")
-    .option("--active <boolean>", "Enable or disable the trigger (true/false)")
-    .option("--message <text>", "New alert message")
-    .option("--alert-type <type>", "New alert severity")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { name?: string; active?: string; message?: string; alertType?: string; format?: string }) => {
+  emitsResult(
+    triggerCmd
+      .command("update <id>")
+      .description("Update a trigger")
+      .option("--name <name>", "New trigger name")
+      .option("--active <boolean>", "Enable or disable the trigger (true/false)")
+      .option("--message <text>", "New alert message")
+      .option("--alert-type <type>", "New alert severity")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string, options: { name?: string; active?: string; message?: string; alertType?: string }) => {
       const { updateTriggerCommand: impl } = await import("./commands/triggers/update.js");
-      await impl(id, options);
-    });
+      return impl(id, options);
+    },
+  );
 
-  triggerCmd
-    .command("delete <id>")
-    .description("Delete a trigger")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    triggerCmd
+      .command("delete <id>")
+      .description("Delete a trigger")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { deleteTriggerCommand: impl } = await import("./commands/triggers/delete.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   // Add secret command group
   const secretCmd = program
     .command("secret")
     .description("Manage project secrets — encrypted environment variables for agents");
 
-  secretCmd
-    .command("list")
-    .description("List all secrets in the project (values are never shown)")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    secretCmd
+      .command("list")
+      .description("List all secrets in the project (values are never shown)")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       const { listSecretsCommand: impl } = await import("./commands/secrets/list.js");
-      await impl(options);
-    });
+      return impl();
+    },
+  );
 
-  secretCmd
-    .command("get <id>")
-    .description("Get secret metadata by ID (value is never shown)")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    secretCmd
+      .command("get <id>")
+      .description("Get secret metadata by ID (value is never shown)")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { getSecretCommand: impl } = await import("./commands/secrets/get.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
-  secretCmd
-    .command("create <name>")
-    .description("Create a new secret (name must be UPPER_SNAKE_CASE)")
-    .requiredOption("--value <value>", "The secret value (will be encrypted)")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (name: string, options: { value: string; format?: string }) => {
+  emitsResult(
+    secretCmd
+      .command("create <name>")
+      .description("Create a new secret (name must be UPPER_SNAKE_CASE)")
+      .requiredOption("--value <value>", "The secret value (will be encrypted)")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (name: string, options: { value: string }) => {
       const { createSecretCommand: impl } = await import("./commands/secrets/create.js");
-      await impl(name, options);
-    });
+      return impl(name, options);
+    },
+  );
 
-  secretCmd
-    .command("update <id>")
-    .description("Update a secret's value")
-    .requiredOption("--value <value>", "The new secret value (will be encrypted)")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { value: string; format?: string }) => {
+  emitsResult(
+    secretCmd
+      .command("update <id>")
+      .description("Update a secret's value")
+      .requiredOption("--value <value>", "The new secret value (will be encrypted)")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string, options: { value: string }) => {
       const { updateSecretCommand: impl } = await import("./commands/secrets/update.js");
-      await impl(id, options);
-    });
+      return impl(id, options);
+    },
+  );
 
-  secretCmd
-    .command("delete <id>")
-    .description("Delete a secret")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    secretCmd
+      .command("delete <id>")
+      .description("Delete a secret")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { deleteSecretCommand: impl } = await import("./commands/secrets/delete.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   // Add monitor (online evaluation) command group
   const monitorCmd = program
     .command("monitor")
     .description("Manage online evaluation monitors — evaluators running on incoming traces");
 
-  monitorCmd
-    .command("list")
-    .description("List all monitors in the project")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    monitorCmd
+      .command("list")
+      .description("List all monitors in the project")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       const { listMonitorsCommand: impl } = await import("./commands/monitors/list.js");
-      await impl(options);
-    });
+      return impl();
+    },
+  );
 
-  monitorCmd
-    .command("get <id>")
-    .description("Get monitor details by ID")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    monitorCmd
+      .command("get <id>")
+      .description("Get monitor details by ID")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { getMonitorCommand: impl } = await import("./commands/monitors/get.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
-  monitorCmd
-    .command("create <name>")
-    .description("Create a new online evaluation monitor")
-    .requiredOption("--check-type <type>", "Evaluator check type (e.g. ragas/toxicity, custom/my-eval)")
-    .option("--execution-mode <mode>", "Execution mode: ON_MESSAGE (default), AS_GUARDRAIL, MANUALLY", "ON_MESSAGE")
-    .option("--sample <rate>", "Sampling rate 0.0-1.0 (default: 1.0)")
-    .option("--evaluator-id <id>", "Link to a saved evaluator")
-    .option("--level <level>", "Evaluation level: trace (default) or thread")
-    .option("--parameters <json>", "Evaluator settings as JSON")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (name: string, options: { checkType: string; executionMode?: string; sample?: string; evaluatorId?: string; level?: string; parameters?: string; format?: string }) => {
+  emitsResult(
+    monitorCmd
+      .command("create <name>")
+      .description("Create a new online evaluation monitor")
+      .requiredOption("--check-type <type>", "Evaluator check type (e.g. ragas/toxicity, custom/my-eval)")
+      .option("--execution-mode <mode>", "Execution mode: ON_MESSAGE (default), AS_GUARDRAIL, MANUALLY", "ON_MESSAGE")
+      .option("--sample <rate>", "Sampling rate 0.0-1.0 (default: 1.0)")
+      .option("--evaluator-id <id>", "Link to a saved evaluator")
+      .option("--level <level>", "Evaluation level: trace (default) or thread")
+      .option("--parameters <json>", "Evaluator settings as JSON")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (name: string, options: { checkType: string; executionMode?: string; sample?: string; evaluatorId?: string; level?: string; parameters?: string }) => {
       const { createMonitorCommand: impl } = await import("./commands/monitors/create.js");
-      await impl(name, options);
-    });
+      return impl(name, options);
+    },
+  );
 
-  monitorCmd
-    .command("update <id>")
-    .description("Update a monitor")
-    .option("--name <name>", "New monitor name")
-    .option("--enabled <boolean>", "Enable or disable the monitor (true/false)")
-    .option("--execution-mode <mode>", "Execution mode: ON_MESSAGE, AS_GUARDRAIL, MANUALLY")
-    .option("--sample <rate>", "Sampling rate 0.0-1.0")
-    .option("--parameters <json>", "Updated evaluator settings as JSON")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { name?: string; enabled?: string; executionMode?: string; sample?: string; parameters?: string; format?: string }) => {
+  emitsResult(
+    monitorCmd
+      .command("update <id>")
+      .description("Update a monitor")
+      .option("--name <name>", "New monitor name")
+      .option("--enabled <boolean>", "Enable or disable the monitor (true/false)")
+      .option("--execution-mode <mode>", "Execution mode: ON_MESSAGE, AS_GUARDRAIL, MANUALLY")
+      .option("--sample <rate>", "Sampling rate 0.0-1.0")
+      .option("--parameters <json>", "Updated evaluator settings as JSON")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string, options: { name?: string; enabled?: string; executionMode?: string; sample?: string; parameters?: string }) => {
       const { updateMonitorCommand: impl } = await import("./commands/monitors/update.js");
-      await impl(id, options);
-    });
+      return impl(id, options);
+    },
+  );
 
-  monitorCmd
-    .command("delete <id>")
-    .description("Delete a monitor")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    monitorCmd
+      .command("delete <id>")
+      .description("Delete a monitor")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (id: string) => {
       const { deleteMonitorCommand: impl } = await import("./commands/monitors/delete.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   // Add simulation-run command group
   const simulationRunCmd = program
@@ -2186,121 +2284,133 @@ export function buildProgram(): Command {
     .command("projects")
     .description("Manage organization projects");
 
-  projectsCmd
-    .command("list")
-    .description("List all projects in the organization")
-    .option("--page <page>", "Page number", "1")
-    .option("--limit <limit>", "Items per page", "50")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { page?: string; limit?: string; format?: string }) => {
+  emitsResult(
+    projectsCmd
+      .command("list")
+      .description("List all projects in the organization")
+      .option("--page <page>", "Page number", "1")
+      .option("--limit <limit>", "Items per page", "50")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async (options: { page?: string; limit?: string }) => {
       const { listProjectsCommand: impl } = await import("./commands/projects/list.js");
-      await impl({
+      return impl({
         page: options.page ? Number(options.page) : undefined,
         limit: options.limit ? Number(options.limit) : undefined,
-        format: options.format,
       });
-    });
+    },
+  );
 
-  projectsCmd
-    .command("get <id>")
-    .description("Show details for a project")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    projectsCmd
+      .command("get <id>")
+      .description("Show details for a project")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (id: string) => {
       const { getProjectCommand: impl } = await import("./commands/projects/get.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
-  projectsCmd
-    .command("create")
-    .description("Create a new project (returns a one-time service API key)")
-    .requiredOption("--name <name>", "Project name")
-    .requiredOption("--language <lang>", "Programming language (e.g. python, typescript)")
-    .requiredOption("--framework <fw>", "Framework (e.g. langchain, openai, vercel-ai)")
-    .option("--team-id <id>", "Existing team ID to assign the project to")
-    .option("--new-team-name <name>", "Create a new team with this name")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (options: {
+  emitsResult(
+    projectsCmd
+      .command("create")
+      .description("Create a new project (returns a one-time service API key)")
+      .requiredOption("--name <name>", "Project name")
+      .requiredOption("--language <lang>", "Programming language (e.g. python, typescript)")
+      .requiredOption("--framework <fw>", "Framework (e.g. langchain, openai, vercel-ai)")
+      .option("--team-id <id>", "Existing team ID to assign the project to")
+      .option("--new-team-name <name>", "Create a new team with this name")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (options: {
       name: string;
       language: string;
       framework: string;
       teamId?: string;
       newTeamName?: string;
-      format?: string;
     }) => {
       const { createProjectCommand: impl } = await import("./commands/projects/create.js");
-      await impl(options);
-    });
+      return impl(options);
+    },
+  );
 
-  projectsCmd
-    .command("update <id>")
-    .description("Update a project's metadata")
-    .option("--name <name>", "New project name")
-    .option("--language <lang>", "New language")
-    .option("--framework <fw>", "New framework")
-    .option("--pii-redaction-level <level>", "PII redaction: STRICT, ESSENTIAL, or DISABLED")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (id: string, options: {
+  emitsResult(
+    projectsCmd
+      .command("update <id>")
+      .description("Update a project's metadata")
+      .option("--name <name>", "New project name")
+      .option("--language <lang>", "New language")
+      .option("--framework <fw>", "New framework")
+      .option("--pii-redaction-level <level>", "PII redaction: STRICT, ESSENTIAL, or DISABLED")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (id: string, options: {
       name?: string;
       language?: string;
       framework?: string;
       piiRedactionLevel?: "STRICT" | "ESSENTIAL" | "DISABLED";
-      format?: string;
     }) => {
       const { updateProjectCommand: impl } = await import("./commands/projects/update.js");
-      await impl(id, options);
-    });
+      return impl(id, options);
+    },
+  );
 
-  projectsCmd
-    .command("delete <id>")
-    .description("Archive a project (soft-delete)")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    projectsCmd
+      .command("delete <id>")
+      .description("Archive a project (soft-delete)")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (id: string) => {
       const { deleteProjectCommand: impl } = await import("./commands/projects/delete.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   const apiKeysCmd = program
     .command("api-keys")
     .description("Manage organization API keys");
 
-  apiKeysCmd
-    .command("list")
-    .description("List all API keys in the organization")
-    .option("-f, --format <format>", "Output format: table (default) or json", "table")
-    .action(async (options: { format?: string }) => {
+  emitsResult(
+    apiKeysCmd
+      .command("list")
+      .description("List all API keys in the organization")
+      .option("-f, --format <format>", "Output format: table (default) or json", "table"),
+    async () => {
       const { listApiKeysCommand: impl } = await import("./commands/api-keys/list.js");
-      await impl(options);
-    });
+      return impl();
+    },
+  );
 
-  apiKeysCmd
-    .command("create")
-    .description("Create a new API key (token is shown once)")
-    .requiredOption("--name <name>", "Human-readable name for the key")
-    .option("--key-type <type>", "Key type: personal or service", "service")
-    .option("--description <desc>", "Optional description")
-    .option("--expires-at <date>", "Expiration date (ISO 8601)")
-    .option("--project-id <id...>", "Project IDs to scope the key to (service keys only, repeatable)")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (options: {
+  emitsResult(
+    apiKeysCmd
+      .command("create")
+      .description("Create a new API key (token is shown once)")
+      .requiredOption("--name <name>", "Human-readable name for the key")
+      .option("--key-type <type>", "Key type: personal or service", "service")
+      .option("--description <desc>", "Optional description")
+      .option("--expires-at <date>", "Expiration date (ISO 8601)")
+      .option("--project-id <id...>", "Project IDs to scope the key to (service keys only, repeatable)")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (options: {
       name: string;
       keyType?: "personal" | "service";
       description?: string;
       expiresAt?: string;
       projectId?: string[];
-      format?: string;
     }) => {
       const { createApiKeyCommand: impl } = await import("./commands/api-keys/create.js");
-      await impl(options);
-    });
+      return impl(options);
+    },
+  );
 
-  apiKeysCmd
-    .command("revoke <id>")
-    .description("Revoke an API key (cannot be reactivated)")
-    .option("-f, --format <format>", "Output format: text (default) or json", "text")
-    .action(async (id: string, options: { format?: string }) => {
+  emitsResult(
+    apiKeysCmd
+      .command("revoke <id>")
+      .description("Revoke an API key (cannot be reactivated)")
+      .option("-f, --format <format>", "Output format: text (default) or json", "text"),
+    async (id: string) => {
       const { revokeApiKeyCommand: impl } = await import("./commands/api-keys/revoke.js");
-      await impl(id, options);
-    });
+      return impl(id);
+    },
+  );
 
   // `langwatch daemon *` — the warm background process that serves commands
   // over a private Unix socket. Normally invisible: it is auto-spawned on first

--- a/typescript-sdk/src/cli/utils/__tests__/output-port.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/__tests__/output-port.unit.test.ts
@@ -1,0 +1,392 @@
+/**
+ * The output PORT, pinned: a command returns data, the port picks the format.
+ *
+ * Every test here covers a way the CLI could answer a machine caller with
+ * human text — or with a fabricated value — at exit 0. That class of bug is
+ * invisible to the caller by construction, so it has to be invisible to the
+ * test suite too or it comes straight back.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import {
+  AGENT_MODE_ENV_VARS,
+  applyJq,
+  assertFormatIsSupported,
+  isOutputAware,
+  registerOutputOptions,
+  resolveActionOutputOptions,
+  emitsResult,
+} from "../output";
+
+let savedAgentEnv: Record<string, string | undefined> = {};
+let logged: string[] = [];
+let warned: string[] = [];
+let exited: number[] = [];
+
+beforeEach(() => {
+  savedAgentEnv = Object.fromEntries(
+    AGENT_MODE_ENV_VARS.map((name) => [name, process.env[name]]),
+  );
+  for (const name of AGENT_MODE_ENV_VARS) delete process.env[name];
+  logged = [];
+  warned = [];
+  exited = [];
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    exited.push(code ?? 0);
+    return undefined as never;
+  }) as never);
+  vi.spyOn(console, "log").mockImplementation((line: unknown) => {
+    logged.push(String(line));
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    warned.push(String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  for (const name of AGENT_MODE_ENV_VARS) {
+    const value = savedAgentEnv[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  vi.restoreAllMocks();
+});
+
+/** A program shaped like the real one: positional options, globals registered. */
+const buildProgram = (
+  register: (program: Command) => void,
+): Command => {
+  const program = new Command();
+  program.exitOverride().enablePositionalOptions().passThroughOptions();
+  register(program);
+  registerOutputOptions(program);
+  return program;
+};
+
+describe("emitsResult", () => {
+  const PAYLOAD = [
+    { id: "a1", name: "first", config: { evaluatorType: "llm" } },
+    { id: "b2", name: "second", config: { evaluatorType: "regex" } },
+  ];
+
+  const registerListing = (program: Command): void => {
+    emitsResult(program.command("list"), () => ({
+      data: PAYLOAD,
+      table: () => console.log("HUMAN TABLE"),
+    }));
+  };
+
+  describe("when no format is requested", () => {
+    it("renders the human table", async () => {
+      const program = buildProgram(registerListing);
+      await program.parseAsync(["list"], { from: "user" });
+      expect(logged).toEqual(["HUMAN TABLE"]);
+    });
+  });
+
+  describe("when a machine format is requested after the subcommand", () => {
+    it("serializes the data instead of the table", async () => {
+      const program = buildProgram(registerListing);
+      await program.parseAsync(["list", "--output", "json"], { from: "user" });
+      expect(logged.join("")).not.toContain("HUMAN TABLE");
+      expect(JSON.parse(logged[0]!)).toEqual(PAYLOAD);
+    });
+  });
+
+  // The regression that motivated the port: commander only puts root-position
+  // globals on the ROOT command, so anything reading the leaf's opts() drops
+  // them — and `lw --output json monitor list` is the spelling the help text
+  // teaches, since the root's copies are what render under "Global Options:".
+  describe("when a machine format is requested BEFORE the subcommand", () => {
+    it("serializes the data, exactly as the trailing spelling does", async () => {
+      const program = buildProgram(registerListing);
+      await program.parseAsync(["--output", "json", "list"], { from: "user" });
+      expect(logged.join("")).not.toContain("HUMAN TABLE");
+      expect(JSON.parse(logged[0]!)).toEqual(PAYLOAD);
+    });
+
+    it("honours a root-position --agent with compact single-line JSON", async () => {
+      const program = buildProgram(registerListing);
+      await program.parseAsync(["--agent", "list"], { from: "user" });
+      expect(logged).toHaveLength(1);
+      expect(logged[0]).not.toContain("\n");
+      expect(JSON.parse(logged[0]!)).toEqual(PAYLOAD);
+    });
+  });
+
+  describe("when --json selects fields", () => {
+    it("projects dotted paths rather than null-filling them", async () => {
+      const program = buildProgram(registerListing);
+      await program.parseAsync(["list", "--json", "name,config.evaluatorType"], {
+        from: "user",
+      });
+      expect(JSON.parse(logged[0]!)).toEqual([
+        { name: "first", "config.evaluatorType": "llm" },
+        { name: "second", "config.evaluatorType": "regex" },
+      ]);
+    });
+  });
+
+  describe("when the handler returns nothing", () => {
+    it("prints nothing and does not throw", async () => {
+      const program = buildProgram((p) => {
+        emitsResult(p.command("noop"), () => undefined);
+      });
+      await program.parseAsync(["noop"], { from: "user" });
+      expect(logged).toEqual([]);
+    });
+  });
+});
+
+describe("isOutputAware", () => {
+  it("tells a migrated command from one that prints its own output", () => {
+    const program = new Command();
+    const migrated = emitsResult(program.command("migrated"), () => ({
+      data: {},
+      table: () => undefined,
+    }));
+    const legacy = program.command("legacy").action(() => undefined);
+
+    expect(isOutputAware(migrated)).toBe(true);
+    expect(isOutputAware(legacy)).toBe(false);
+  });
+});
+
+describe("assertFormatIsSupported", () => {
+  const legacyCommand = (): Command => {
+    const program = new Command();
+    program.enablePositionalOptions().passThroughOptions();
+    const legacy = program.command("legacy").action(() => undefined);
+    registerOutputOptions(program);
+    return legacy;
+  };
+
+  describe("given a command that does not emit structured output", () => {
+    describe("when a machine format was explicitly requested", () => {
+      it("refuses instead of answering with a human table", async () => {
+        const legacy = legacyCommand();
+        legacy.setOptionValue("output", "json");
+
+        await assertFormatIsSupported(legacy, resolveActionOutputOptions(legacy));
+
+        expect(exited).toEqual([1]);
+        // Rendered as the human block on stderr here: no output scope has been
+        // applied in this unit, so errorOutput takes its non-machine path.
+        expect(warned.join("") + logged.join("")).toContain("does not emit structured output");
+      });
+
+      it("refuses a --jq expression it would otherwise never parse", async () => {
+        const legacy = legacyCommand();
+        legacy.setOptionValue("jq", ".anything[0]");
+
+        await assertFormatIsSupported(legacy, resolveActionOutputOptions(legacy));
+
+        expect(exited).toEqual([1]);
+      });
+
+      // Legacy `-f/--format json` predates the contract and unmigrated
+      // commands implement it themselves, so refusing it would break a
+      // spelling that has always worked.
+      it("still honours the legacy --format json it has always supported", async () => {
+        const legacy = legacyCommand();
+        legacy.setOptionValue("format", "json");
+
+        const effective = await assertFormatIsSupported(
+          legacy,
+          resolveActionOutputOptions(legacy),
+        );
+
+        expect(exited).toEqual([]);
+        expect(effective.format).toBe("json");
+      });
+
+      // daemon status / ingest / governance own a boolean --json and emit
+      // machine output through it.
+      it("passes through a command that owns its own --json flag", async () => {
+        const program = new Command();
+        program.enablePositionalOptions().passThroughOptions();
+        const owner = program
+          .command("owner")
+          .option("--json", "emit machine-readable JSON")
+          .action(() => undefined);
+        registerOutputOptions(program);
+        owner.setOptionValue("json", true);
+
+        const effective = await assertFormatIsSupported(
+          owner,
+          resolveActionOutputOptions(owner),
+        );
+
+        expect(exited).toEqual([]);
+        expect(effective.format).toBe("json");
+      });
+    });
+
+    // Erroring here would break every unmigrated command the moment it runs
+    // under Claude Code, which sets CLAUDECODE unconditionally.
+    describe("when agent mode was only detected from the environment", () => {
+      it("keeps the human table but warns it is not machine-readable", async () => {
+        process.env.CLAUDECODE = "1";
+        const legacy = legacyCommand();
+        const resolved = resolveActionOutputOptions(legacy);
+
+        const effective = await assertFormatIsSupported(legacy, resolved);
+
+        expect(resolved.format).toBe("agents");
+        expect(effective.format).toBe("table");
+        expect(warned.join("")).toContain("not machine-readable");
+      });
+    });
+  });
+
+  describe("given a migrated command", () => {
+    it("passes the requested format through untouched", async () => {
+      const program = new Command();
+      program.enablePositionalOptions().passThroughOptions();
+      const migrated = emitsResult(program.command("migrated"), () => ({
+        data: {},
+        table: () => undefined,
+      }));
+      registerOutputOptions(program);
+      migrated.setOptionValue("output", "json");
+
+      const resolved = resolveActionOutputOptions(migrated);
+      const effective = await assertFormatIsSupported(migrated, resolved);
+
+      expect(effective.format).toBe("json");
+      expect(warned).toEqual([]);
+    });
+  });
+});
+
+describe("applyJq", () => {
+  const DATA = {
+    traces: [
+      { traceId: "t1", spans: [{ id: "s1" }, { id: "s2" }] },
+      { traceId: "t2", spans: [{ id: "s3" }] },
+    ],
+  };
+
+  describe("when the expression is supported", () => {
+    it("walks a dot path", () => {
+      expect(applyJq(".traces", DATA)).toEqual(DATA.traces);
+    });
+
+    it("collects an iterated field", () => {
+      expect(applyJq(".traces[].traceId", DATA)).toEqual(["t1", "t2"]);
+    });
+
+    // jq's `[ .a[].b[] ]` collects; it does not nest.
+    it("flattens chained iteration rather than nesting it", () => {
+      expect(applyJq(".traces[].spans[].id", DATA)).toEqual(["s1", "s2", "s3"]);
+    });
+
+    it("counts with a terminal length pipe", () => {
+      expect(applyJq(".traces | length", DATA)).toBe(2);
+    });
+  });
+
+  // Each of these previously walked as a literal key, missed, and returned
+  // null at exit 0 — a fabricated answer the caller then builds on. Array
+  // indexing is the first thing anyone tries after reading the flag's own
+  // `.traces[].traceId` example, so it must fail loudly.
+  describe("when the expression uses syntax this subset does not implement", () => {
+    it.each([
+      [".traces[0]"],
+      [".traces[0].traceId"],
+      ['.["traces"]'],
+      [".traces[]?"],
+      [".[0]"],
+      [".traces[].spans[0]"],
+    ])("throws rather than answering null for %s", (expression) => {
+      expect(() => applyJq(expression, DATA)).toThrow(/unsupported syntax|must start with/);
+    });
+  });
+
+  describe("when a key is genuinely absent", () => {
+    it("still answers null, the way jq does", () => {
+      expect(applyJq(".nope", DATA)).toBeNull();
+    });
+  });
+});
+
+/**
+ * The port wired into the REAL command tree. The unit tests above prove the
+ * mechanism; this proves it is actually connected — a migration that converts
+ * an implementation but forgets its `emitsResult` registration would leave the
+ * command silently unmigrated, which is precisely the state this work exists
+ * to end.
+ */
+describe("the real command tree", () => {
+  // buildProgram() reads the tsup-injected __CLI_VERSION__ build constant,
+  // which no test runner defines (see help-topic.unit.test.ts).
+  (globalThis as Record<string, unknown>).__CLI_VERSION__ ??= "0.0.0-test";
+
+  const findCommand = (root: Command, path: string[]): Command | undefined =>
+    path.reduce<Command | undefined>(
+      (cmd, name) => cmd?.commands.find((child) => child.name() === name),
+      root,
+    );
+
+  it("marks a migrated command as speaking the output contract", async () => {
+    const { buildProgram } = await import("../../program.js");
+    const listing = findCommand(buildProgram(), ["agent", "list"]);
+
+    expect(listing).toBeDefined();
+    expect(isOutputAware(listing!)).toBe(true);
+  });
+
+  /**
+   * The registration is the ONLY thing that marks a command output-aware —
+   * migrating an implementation to return a CommandResult does nothing on its
+   * own, and a registration left on `.action(` fails silently for `table`
+   * callers while refusing `-o json`. So the wiring is asserted here, per
+   * group, rather than trusted.
+   */
+  describe("when a command group has been wired to the port", () => {
+    const wired = [
+      ["monitor", "list"],
+      ["monitor", "create"],
+      ["evaluator", "get"],
+      ["graph", "update"],
+      ["agent", "run"],
+      ["dashboard", "create"],
+      ["annotation", "create"],
+      ["api-keys", "revoke"],
+      ["projects", "update"],
+      ["model-provider", "set"],
+      ["model-default", "unset"],
+      ["gateway-budgets", "archive"],
+      ["virtual-keys", "rotate"],
+      ["analytics", "query"],
+      ["trigger", "delete"],
+      ["secret", "update"],
+    ];
+
+    it.each(wired)("marks `%s %s` as speaking the output contract", async (group, name) => {
+      const { buildProgram } = await import("../../program.js");
+      const command = findCommand(buildProgram(), [group, name]);
+
+      expect(command).toBeDefined();
+      expect(isOutputAware(command!)).toBe(true);
+    });
+  });
+
+  describe("when a command still prints its own output", () => {
+    const unmigrated = [
+      ["prompt", "list"],
+      ["dataset", "list"],
+      ["workflow", "list"],
+      ["experiment", "list"],
+    ];
+
+    it.each(unmigrated)("leaves `%s %s` unmarked", async (group, name) => {
+      const { buildProgram } = await import("../../program.js");
+      const command = findCommand(buildProgram(), [group, name]);
+
+      expect(command).toBeDefined();
+      expect(isOutputAware(command!)).toBe(false);
+    });
+  });
+});

--- a/typescript-sdk/src/cli/utils/__tests__/output-port.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/__tests__/output-port.unit.test.ts
@@ -201,6 +201,63 @@ describe("assertFormatIsSupported", () => {
         expect(effective.format).toBe("json");
       });
 
+      // Owning `--json` proves the command can emit ITS json — not that it can
+      // honour every format. Without this narrowing, `daemon status -o yaml`
+      // and `dataset records add --json '{..}' -o yaml` both answered with a
+      // chalk table at exit 0 for a caller who explicitly asked for YAML.
+      it.each([
+        ["output", "yaml"],
+        ["jq", ".foo"],
+      ])("still refuses --%s from a command that only owns --json", async (flag, value) => {
+        const program = new Command();
+        program.enablePositionalOptions().passThroughOptions();
+        const owner = program
+          .command("owner")
+          .option("--json", "emit machine-readable JSON")
+          .action(() => undefined);
+        registerOutputOptions(program);
+        owner.setOptionValue(flag, value);
+
+        await assertFormatIsSupported(owner, resolveActionOutputOptions(owner));
+
+        expect(exited).toEqual([1]);
+      });
+
+      // `--json <payload>` on dataset records add/update is DATA, not an
+      // output-capability claim, so an explicit -o must still be refused.
+      it("refuses an explicit format when --json is the command's payload flag", async () => {
+        const program = new Command();
+        program.enablePositionalOptions().passThroughOptions();
+        const payload = program
+          .command("records-add")
+          .option("--json <json>", "the records to add")
+          .action(() => undefined);
+        registerOutputOptions(program);
+        payload.setOptionValue("json", '{"a":1}');
+        payload.setOptionValue("output", "yaml");
+
+        await assertFormatIsSupported(payload, resolveActionOutputOptions(payload));
+
+        expect(exited).toEqual([1]);
+      });
+
+      // `--agent` is a MODE (no colour, no spinners), not a format demand, so
+      // it degrades with a warning instead of failing. Pins the deliberate
+      // omission of `raw.agent` from the refusal check.
+      it("degrades rather than refusing an explicit --agent", async () => {
+        const legacy = legacyCommand();
+        legacy.setOptionValue("agent", true);
+
+        const effective = await assertFormatIsSupported(
+          legacy,
+          resolveActionOutputOptions(legacy),
+        );
+
+        expect(exited).toEqual([]);
+        expect(effective.format).toBe("table");
+        expect(warned.join("")).toContain("not machine-readable");
+      });
+
       // daemon status / ingest / governance own a boolean --json and emit
       // machine output through it.
       it("passes through a command that owns its own --json flag", async () => {
@@ -299,8 +356,28 @@ describe("applyJq", () => {
       [".traces[]?"],
       [".[0]"],
       [".traces[].spans[0]"],
+      // Operators: a denylist missed these and answered `null` silently.
+      [".traces - 1"],
+      [".traces,.other"],
+      [".traces + 1"],
+      [".traces(x)"],
     ])("throws rather than answering null for %s", (expression) => {
       expect(() => applyJq(expression, DATA)).toThrow(/unsupported syntax|must start with/);
+    });
+  });
+
+  // Root-level iteration has an empty key by design; the allowlist must not
+  // mistake that for invalid syntax (it did, briefly).
+  describe("when iterating at the root", () => {
+    it("iterates a top-level array with .[]", () => {
+      expect(applyJq(".[]", [{ id: "a" }, { id: "b" }])).toEqual([
+        { id: "a" },
+        { id: "b" },
+      ]);
+    });
+
+    it("selects a field under root iteration with .[].id", () => {
+      expect(applyJq(".[].id", [{ id: "a" }, { id: "b" }])).toEqual(["a", "b"]);
     });
   });
 

--- a/typescript-sdk/src/cli/utils/output.ts
+++ b/typescript-sdk/src/cli/utils/output.ts
@@ -205,6 +205,17 @@ const descend = (value: unknown, key: string): unknown => {
 };
 
 /**
+ * Syntax this subset does NOT implement. It must be REJECTED rather than
+ * walked as a literal key: `descend` answers `null` for any key it cannot
+ * resolve, so `.traces[0]` would otherwise look up a property literally named
+ * `traces[0]`, miss, and print `null` at exit 0 — a fabricated answer an agent
+ * then builds on. Array indexing in particular is the first thing anyone tries
+ * after reading this flag's own `.traces[].traceId` example, so it has to fail
+ * loudly. A trailing `[]` is stripped before this test (that IS supported).
+ */
+const UNSUPPORTED_SEGMENT_RE = /[[\]"'?*]/;
+
+/**
  * The tiny built-in jq subset: `.`, `.a.b`, `.items[]`, `.items[].name`, and a
  * terminal `| length` (arrays, strings, objects). Iteration collects into an
  * array, the way `jq '[ .items[].name ]'` reads. Anything else throws — a
@@ -252,6 +263,12 @@ export const applyJq = (expression: string, data: unknown): unknown => {
     if (key === "" && !iterate) {
       throw new Error(`Invalid --jq expression "${expression}": empty segment at "${path}"`);
     }
+    if (UNSUPPORTED_SEGMENT_RE.test(key)) {
+      throw new Error(
+        `Invalid --jq expression "${expression}": unsupported syntax at "${path}.${head}" ` +
+          `(supported: dot paths, .items[], .items[].field, | length — no indexing, quoting or optionals)`,
+      );
+    }
 
     const descended = key === "" ? value : descend(value, key);
     const at = `${path}.${head}`;
@@ -266,20 +283,40 @@ export const applyJq = (expression: string, data: unknown): unknown => {
         `Invalid --jq expression "${expression}": "${at}" iterates over a non-array value`,
       );
     }
-    return descended.map((item) => apply(item, tail, at));
+    const mapped = descended.map((item) => apply(item, tail, at));
+    // Chained iteration COLLECTS, it does not nest: `.traces[].spans[].id` is
+    // `["s1","s2","s3"]`, matching `jq '[ .traces[].spans[].id ]'`, not
+    // `[["s1","s2"],["s3"]]`. Each nested level has already flattened itself,
+    // so exactly one flatten per iterating segment is correct.
+    return tail.some((segment) => segment.endsWith("[]")) ? mapped.flat() : mapped;
   };
 
   return apply(data, segments, "");
 };
 
-/** `--json <fields>`: pick top-level fields, per item when data is an array. */
+/**
+ * `--json <fields>`: pick fields, per item when data is an array.
+ *
+ * Fields may be dotted paths (`config.evaluatorType`). A flat property lookup
+ * would treat that as a literal key, miss, and null-fill — reporting "this
+ * record has no such field" for a field it does have, which is a lie a machine
+ * caller cannot detect. The resulting key keeps the dotted spelling the caller
+ * asked for, so the projection round-trips.
+ */
 const selectFields = (data: unknown, fields: string[]): unknown => {
+  const valueAt = (item: unknown, field: string): unknown => {
+    let cursor = item;
+    for (const segment of field.split(".")) {
+      cursor = descend(cursor, segment);
+      if (cursor === null) return null;
+    }
+    return cursor;
+  };
   const pick = (item: unknown): unknown => {
     if (item === null || typeof item !== "object" || Array.isArray(item)) {
       return item;
     }
-    const record = item as Record<string, unknown>;
-    return Object.fromEntries(fields.map((field) => [field, record[field] ?? null]));
+    return Object.fromEntries(fields.map((field) => [field, valueAt(item, field)]));
   };
   return Array.isArray(data) ? data.map(pick) : pick(data);
 };
@@ -327,6 +364,156 @@ export const printResult = async (
   if (resolved.jq) out = applyJq(resolved.jq, out);
 
   console.log(await serialize(out, resolved.format));
+};
+
+/**
+ * What a command SAYS, as opposed to what it PRINTS.
+ *
+ * A command action returns this instead of writing to stdout itself: `data` is
+ * the raw payload — the single source of truth every machine format projects
+ * from — and `table` renders the human form. The command never learns which
+ * format was asked for; the port below decides. That is the whole point: when
+ * format resolution lives in 150 command files, 129 of them get it wrong and
+ * nothing detects it, because a chalk table on stdout at exit 0 looks exactly
+ * like success.
+ */
+export interface CommandResult {
+  /** The payload. `-o json|yaml|agents`, `--json <fields>` and `--jq` all project from this. */
+  data: unknown;
+  /** Renders the human form. Only invoked when the resolved format is `table`. */
+  table: () => void;
+}
+
+/**
+ * Commands whose action speaks the output contract.
+ *
+ * Marked at registration by `emitsResult` rather than sniffed off the handler:
+ * commander's `.action(fn)` stores its OWN listener wrapping `fn`, so anything
+ * we tag `fn` with is sealed inside that closure and unreachable. A WeakSet
+ * keyed on the command is both simpler and free of commander private API.
+ */
+const OUTPUT_AWARE_COMMANDS = new WeakSet<Command>();
+
+/**
+ * The output PORT: register a command's action so whatever it RETURNS is
+ * rendered in the caller's format, once, here.
+ *
+ *     emitsResult(
+ *       program.command("list").description("…"),
+ *       async (options) => ({ data: agents, table: () => { … } }),
+ *     );
+ *
+ * Resolution reads `optsWithGlobals()` off the running command, so a
+ * root-position flag (`lw --output json monitor list` — the spelling the help
+ * text teaches, since the root's copies are what render under "Global
+ * Options:") resolves the same as a trailing one. Commander only puts
+ * root-position globals on the ROOT command, so anything reading the leaf's
+ * `opts()` silently drops them.
+ *
+ * A handler returning nothing is fine — commands that legitimately own their
+ * own output (interactive login, the gateway wrappers) just return void.
+ */
+export const emitsResult = <Args extends unknown[]>(
+  command: Command,
+  handler: (...args: Args) => Promise<CommandResult | void> | CommandResult | void,
+): Command => {
+  OUTPUT_AWARE_COMMANDS.add(command);
+  return command.action(async (...args: unknown[]): Promise<void> => {
+    const actionCommand = args[args.length - 1] as Command;
+    const result = await handler(...(args as unknown as Args));
+    if (!result) return;
+
+    const resolved = resolveActionOutputOptions(actionCommand);
+    if (resolved.format === "table") {
+      result.table();
+      return;
+    }
+    let out = result.data;
+    if (resolved.fields) out = selectFields(out, resolved.fields);
+    if (resolved.jq) out = applyJq(resolved.jq, out);
+    console.log(await serialize(out, resolved.format));
+  });
+};
+
+/** Whether this command's action speaks the output contract. */
+export const isOutputAware = (command: Command): boolean =>
+  OUTPUT_AWARE_COMMANDS.has(command);
+
+/**
+ * Refuse to answer a machine format we cannot actually produce.
+ *
+ * `registerOutputOptions` puts `-o/--output` on EVERY command, and `choices()`
+ * makes a typo fail loudly at parse time. Until a command is migrated to
+ * `withOutput`, a VALID value is the more dangerous case: the flag validates,
+ * the command prints its chalk table anyway, and the caller gets human text at
+ * exit 0 having explicitly asked for JSON. `--jq` is worse still — the
+ * expression is never parsed, so a malformed one also exits 0.
+ *
+ * So: an EXPLICIT machine format on an unmigrated command is an error, not a
+ * table. Agent mode merely detected from the environment is not explicit — the
+ * caller asked for nothing, and erroring there would break every unmigrated
+ * command the moment it runs under Claude Code — so that case keeps the table
+ * and warns on stderr that the output is not machine-readable.
+ *
+ * Returns the format the request should actually run as.
+ */
+export const assertFormatIsSupported = async (
+  actionCommand: Command,
+  resolved: ResolvedOutput,
+): Promise<ResolvedOutput> => {
+  if (resolved.format === "table" || isOutputAware(actionCommand)) return resolved;
+
+  // A command that defines its OWN non-hidden `--json` (daemon status, the
+  // ingest and governance groups) already emits machine output through that
+  // flag — it just predates the port. Refusing it would break a working
+  // spelling, so it passes through. The contract's own copy is `hideHelp()`'d
+  // wherever it is injected, which is what makes a non-hidden one distinctive.
+  const ownsJsonFlag = actionCommand.options.some(
+    (option) => option.long === "--json" && !option.hidden,
+  );
+  if (ownsJsonFlag) return resolved;
+
+  const raw: RawOutputFlags = actionCommand.optsWithGlobals();
+  const name = actionCommand.name();
+
+  // Only the NEW contract flags are refusable. Legacy `-f/--format json` is
+  // NOT: unmigrated commands implement it themselves (`if (options.format ===
+  // "json")`), so refusing it would break a spelling that has always worked —
+  // which is why `hasExplicitFormatRequest` (which counts it) is the wrong
+  // predicate here. `-o` and `--jq` never existed before this contract, so a
+  // command that cannot honour them has nothing to break.
+  const requestedNewContractFlag =
+    raw.output !== undefined || raw.jq !== undefined || raw.json !== undefined;
+
+  if (requestedNewContractFlag) {
+    const { commandValidationError, reportCommandError } = await import(
+      "./errorOutput.js"
+    );
+    // Reported here rather than thrown: `preAction` runs OUTSIDE each
+    // registration's try/catch, so a throw escapes to the dependency-free net
+    // in index.ts and renders as `Error: [object Object]` — prose at a parser,
+    // the exact failure this contract exists to end.
+    reportCommandError({
+      error: commandValidationError(
+        `\`${name}\` does not emit structured output yet, so --output/--json/--jq cannot be honoured. ` +
+          `Re-run without them for the human table, or use \`lw commands\` to find a command that does.`,
+        { command: name, requestedFormat: resolved.format },
+      ),
+    });
+    process.exit(1);
+  }
+
+  // Legacy `-f/--format json`: the command renders this itself, so pass it
+  // through untouched. Falling into the downgrade below would rewrite it to
+  // `table` and break output that has always worked.
+  if (raw.format === "json") return resolved;
+
+  // Auto-detected agent mode: keep the human table, but never let a caller
+  // believe it is parsing structured output.
+  process.stderr.write(
+    `note: \`${name}\` does not emit structured output yet — the table below is not machine-readable.\n`,
+  );
+  return { ...resolved, format: "table" };
 };
 
 /**

--- a/typescript-sdk/src/cli/utils/output.ts
+++ b/typescript-sdk/src/cli/utils/output.ts
@@ -180,17 +180,26 @@ export const resolveOutputOptions = (
  * not define its own, so a NON-hidden `--json` on the action command means
  * "this command owns the flag".
  */
+/**
+ * Whether the command declares its OWN `--json`, as opposed to the contract's
+ * injected copy.
+ *
+ * `registerOutputOptions` `hideHelp()`s every copy it injects, so a NON-hidden
+ * `--json` means the command declared it. Two callers ask this question and
+ * want different things from the answer — the payload-vs-fields
+ * disambiguation below, and `assertFormatIsSupported`'s narrow bypass — so it
+ * lives here once rather than being hand-rolled at each site with its own
+ * subtly different meaning.
+ */
+const ownsOwnJsonFlag = (command: Command): boolean =>
+  command.options.some((option) => option.long === "--json" && !option.hidden);
+
 export const resolveActionOutputOptions = (
   actionCommand: Command,
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedOutput => {
   const raw: RawOutputFlags = actionCommand.optsWithGlobals();
-  if (
-    typeof raw.json === "string" &&
-    actionCommand.options.some(
-      (option) => option.long === "--json" && !option.hidden,
-    )
-  ) {
+  if (typeof raw.json === "string" && ownsOwnJsonFlag(actionCommand)) {
     delete raw.json;
   }
   return resolveOutputOptions(raw, env);
@@ -205,15 +214,24 @@ const descend = (value: unknown, key: string): unknown => {
 };
 
 /**
- * Syntax this subset does NOT implement. It must be REJECTED rather than
- * walked as a literal key: `descend` answers `null` for any key it cannot
- * resolve, so `.traces[0]` would otherwise look up a property literally named
- * `traces[0]`, miss, and print `null` at exit 0 — a fabricated answer an agent
- * then builds on. Array indexing in particular is the first thing anyone tries
- * after reading this flag's own `.traces[].traceId` example, so it has to fail
- * loudly. A trailing `[]` is stripped before this test (that IS supported).
+ * What a path segment may look like. An ALLOWLIST, deliberately.
+ *
+ * Anything not matching is REJECTED rather than walked as a literal key:
+ * `descend` answers `null` for any key it cannot resolve, so `.traces[0]`
+ * would otherwise look up a property literally named `traces[0]`, miss, and
+ * print `null` at exit 0 — a fabricated answer an agent then builds on. Array
+ * indexing is the first thing anyone tries after reading this flag's own
+ * `.traces[].traceId` example, so it has to fail loudly.
+ *
+ * A denylist was tried first and leaked: it caught brackets and quotes but not
+ * operators, so `.n - 1` and `.n,.s` still answered `null` silently. Since the
+ * grammar here is tiny and closed, the safe default is to name what IS legal
+ * and reject the rest — being too strict costs a clear error message, being
+ * too loose costs a wrong answer nobody can detect.
+ *
+ * A trailing `[]` is stripped before this test (that IS supported).
  */
-const UNSUPPORTED_SEGMENT_RE = /[[\]"'?*]/;
+const SUPPORTED_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 
 /**
  * The tiny built-in jq subset: `.`, `.a.b`, `.items[]`, `.items[].name`, and a
@@ -263,10 +281,14 @@ export const applyJq = (expression: string, data: unknown): unknown => {
     if (key === "" && !iterate) {
       throw new Error(`Invalid --jq expression "${expression}": empty segment at "${path}"`);
     }
-    if (UNSUPPORTED_SEGMENT_RE.test(key)) {
+    // `key === ""` reaching here means root-level iteration (`.[]`, `.[].name`):
+    // there is no key to validate, and the non-iterating empty segment was
+    // already rejected above. Everything else must be a plain identifier.
+    if (key !== "" && !SUPPORTED_SEGMENT_RE.test(key)) {
       throw new Error(
         `Invalid --jq expression "${expression}": unsupported syntax at "${path}.${head}" ` +
-          `(supported: dot paths, .items[], .items[].field, | length — no indexing, quoting or optionals)`,
+          `(supported: dot paths, .items[], .items[].field, | length — no indexing, ` +
+          `quoting, optionals or operators)`,
       );
     }
 
@@ -466,12 +488,22 @@ export const assertFormatIsSupported = async (
   // A command that defines its OWN non-hidden `--json` (daemon status, the
   // ingest and governance groups) already emits machine output through that
   // flag — it just predates the port. Refusing it would break a working
-  // spelling, so it passes through. The contract's own copy is `hideHelp()`'d
-  // wherever it is injected, which is what makes a non-hidden one distinctive.
-  const ownsJsonFlag = actionCommand.options.some(
-    (option) => option.long === "--json" && !option.hidden,
-  );
-  if (ownsJsonFlag) return resolved;
+  // spelling, so bare `--json` passes through.
+  //
+  // Narrowly, though: owning `--json` proves the command can emit ITS json, not
+  // that it can honour every format. `-o yaml` and `--jq` are still beyond it —
+  // `daemon status -o yaml` would print JSON, and a `--jq` expression would
+  // never be parsed — so those stay refusable. Without this narrowing the
+  // bypass also swallows `dataset records add --json '{payload}' -o yaml`,
+  // where `--json` is a PAYLOAD flag and nothing about it implies output
+  // capability at all.
+  if (
+    ownsOwnJsonFlag(actionCommand) &&
+    actionCommand.optsWithGlobals().output === undefined &&
+    actionCommand.optsWithGlobals().jq === undefined
+  ) {
+    return resolved;
+  }
 
   const raw: RawOutputFlags = actionCommand.optsWithGlobals();
   const name = actionCommand.name();
@@ -482,6 +514,13 @@ export const assertFormatIsSupported = async (
   // which is why `hasExplicitFormatRequest` (which counts it) is the wrong
   // predicate here. `-o` and `--jq` never existed before this contract, so a
   // command that cannot honour them has nothing to break.
+  //
+  // `raw.agent` is deliberately NOT in this list. `--agent` is a MODE, not a
+  // format demand — it also means no colour and no spinners, which every
+  // command honours whether migrated or not — so it degrades with a warning
+  // rather than failing. Adding it here would harden `--agent` into a refusal
+  // and break every unmigrated command for the callers most likely to pass it.
+  // Pinned by a test; do not "fix" this into the list.
   const requestedNewContractFlag =
     raw.output !== undefined || raw.jq !== undefined || raw.json !== undefined;
 

--- a/typescript-sdk/tsup.config.ts
+++ b/typescript-sdk/tsup.config.ts
@@ -64,7 +64,18 @@ export default defineConfig([
     format: ["cjs"],
     minify: true,
     dts: false,
-    sourcemap: false,
+    // Minified WITHOUT a sourcemap, every user-reported stack trace reads
+    // `at t (bundle.js:1:284119)` and is unresolvable even for us. So the map
+    // is generated — but it is excluded from the published tarball via
+    // package.json `files` (`!dist/cli/*.map`), which keeps the npm weight win
+    // the minify+no-dts decision above was after. Node only reads maps under
+    // `--enable-source-maps`, so shipping the reference without the map costs
+    // nothing at runtime.
+    //
+    // To decode a trace from a released version: check out that tag, run
+    // `pnpm build`, and use the local dist/cli/bundle.js.map — esbuild output
+    // is deterministic for a given input, so it matches what shipped.
+    sourcemap: true,
     noExternal,
     define,
     onSuccess: async () => {


### PR DESCRIPTION
Stacked on `feat/agentix-cli` (#5921). Targets that branch, not `main`, so it can be reviewed and merged into the PR rather than force-pushed over it.

## Why

A seven-slice review of #5921 found nine blocking issues that all shared one failure mode: **wrong output at exit 0**. No exception, no non-zero code, nothing a machine caller can detect:

- `lw agent list -o json` → chalk table, exit 0
- `--jq '.traces[0]'` → `null`, exit 0
- `lw status` → `✓ nothing needs your attention` over three unchecked scans
- connection-refused → a domain error blaming the user
- a release → zero attached binaries, green check

For a CLI whose thesis is "an agent can trust this", that is the one bug class that matters most. Everything here is aimed at converting silent-wrong into loud-correct.

## The output port (the headline gap)

Review found only **21 of 150** command files honoured the contract; 94 still gated on `options.format === "json"`. `registerOutputOptions` put `-o/--output` on all of them with `choices()` validation — so a *valid* value validated and was then ignored. Meanwhile the spinner/error half of the contract activated everywhere, so success and failure paths disagreed on format.

Rather than fix 129 call sites, format resolution moved out of commands entirely:

```ts
emitsResult(
  agentCmd.command("list").description("List all agents"),
  async () => ({ data: result, table: () => { /* human output */ } }),
);
```

Commands return data; the port picks the format. **63 commands across 15 groups migrated.**

Two things fall out of this:

- **Root-position flags now work.** `lw --output json monitor list` — the spelling the help text teaches under "Global Options:" — silently dropped the flag, because commander only puts root-position globals on the root command and `printResult` read the leaf's `opts()`.
- **Unmigrated commands fail loudly.** A *new*-contract flag (`-o`/`--jq`/`--json <fields>`) on a command that cannot honour it is now a structured error. Legacy `-f/--format json` and command-owned boolean `--json` (daemon/ingest/governance) pass through untouched, and env-detected agent mode keeps the table plus a stderr warning — so nothing breaks under Claude Code. This kills the fail-green class immediately, without waiting for the migration to finish.

### jq subset

`.traces[0]`, `.["traces"]`, `.[0]`, `.traces[]?` all walked as literal keys, missed, and answered `null` at exit 0 — a fabricated value an agent then builds on. Array indexing is the first thing anyone tries after reading the flag's own `.traces[].traceId` example. Now rejected with a message naming the supported grammar. Chained iteration flattens like jq's collect (`[["s1","s2"],["s3"]]` → `["s1","s2","s3"]`), and `--json config.evaluatorType` resolves dotted paths instead of null-filling a field that exists.

## Daemon

**Socket squat (not previously reported).** The trust model is filesystem permissions — but `chmod` was enforced *server-side only*; the client `net.connect`ed without checking. On Linux without `XDG_RUNTIME_DIR` the path fell back to `/tmp/langwatch-<uid>/`, and for device-flow logins the fingerprint is `sha256(endpoint\0\0uid\0)` — guessable, so the socket filename is computable. The client sends `exec` before awaiting `hello-ok`, so args, cwd and forwarded `LANGWATCH_*` env (including the API key) are harvested without the attacker replying.

Fixed on both sides: the client `lstat`s socket and parent (owner + mode, symlink-rejecting) and degrades to in-process on any mismatch; `ensureSocketDir` fails closed; and the socket directory moved to `$HOME/.langwatch/run/`, which **removes** the world-writable-parent vector rather than just detecting it.

**Window released under running work** (CodeRabbit's Critical, independently confirmed). `abortController.signal` reached only `window.acquire`, never the command — so on timeout the window was freed while the work continued, and the next request's `chdir`/env rewrite landed underneath it. A timed-out `--output results.json` could write into the next caller's directory. The window is now held until abandoned work settles, bounded by a wedge timeout that exits rather than release a window it cannot make safe. `stop()` drains inflight first.

The daemon spec scenario asserting "its execution window is released for other callers" codified the bug and has been rewritten.

## Honest errors

`domainErrorFromThrown` read a bare top-level `code`, and a real `fetch` rejection's `.cause` carries `{errno, code: "ECONNREFUSED", syscall, address, port}`. So connection-refused rendered as a *domain* error blaming the user, with `isDomain: true`, leaking local address/port into `meta`, and the honest `network_error` was never produced. **This was a regression against the base commit**, verified side-by-side. Now guarded two ways: a bare `code` is only trusted alongside a platform envelope, and anything carrying `errno`/`syscall` is transport, never domain.

## `lw status`

The soft-fail machinery was right; the invariant it exists to enforce was upheld on only one path. Six false all-clears fixed — unchecked `pagination.hasMore` (experiments are ordered by `updatedAt`, not `lastRunAt`), the 24h filter that excluded exactly the long-wedged experiments worth surfacing, uncovered VK/principal budget scopes, zero-limit budgets scored as healthy, an unbounded 18-call fan-out, and a green tick printed above failed resource fetches. All six confirmed **red-then-green**; five literally printed the all-clear on the old code.

## Skills, help, release, build

- `install/update --force` truncated user files with no prompt, no TTY gate, no `-y` — while `uninstall` gated the strictly *less* destructive operation. Now behind the same confirmation. Marker anchored to EOF, atomic temp-file writes, symlinked targets refused, per-file error handling, `--dir` validated.
- `help agent` shadowed the real `agent` command group entirely. Commands now always win the lookup; topic renamed `agent-mode`; a test asserts no topic can ever collide again.
- Release workflow split: build (`contents: read`, matrix) → publish (`contents: write`, no checkout, no install). **No third-party code ever runs beside the write token** — stronger than `persist-credentials: false`. Plus pinned bun tarball with verified checksum, `openapi-typescript` pinned as a devDependency (it was an unpinned network `pnpx` at publish time), provenance attestation, per-tag concurrency, explicit `ref:` on dispatch, and a publish gate that makes a partial release structurally impossible.
- `postbuild` asserts `dist/cli/index.js` exists, is executable, and reports the right version — it was the sole producer of the file both `bin` entries point at, and could silently vanish.
- CLAUDE.md now allows lazy `import()` on the CLI boot path (it is what buys the ~30ms cold start), pinned by a boot-graph guard test — verified to fail on a stray `chalk` import.

## Behaviour changes worth a look

1. **Skill files edited *below* the managed footer now read as unmanaged** — the unavoidable cost of anchoring the marker. Safe direction (refuse to touch), but it is a change.
2. **`status` probes `GET /virtual-keys`** to decide whether the VK-budget blind spot can contain anything. There is genuinely no REST surface for VK/principal budgets, so the alternative was a permanent gap making the green tick unreachable forever.
3. **One-time secrets appear in machine output** for `api-key create`, `project create`, `virtual-key create|rotate` — preserving the existing `--format json` contract (the server never re-issues them and the human table already prints them). Say the word if you want them masked.
4. **`model-default unset` carries `noop: true`** on its no-op path, which previously printed nothing in json mode — indistinguishable from a real removal.

## Verification

- **118 files / 1435 tests green**; cli-cards 36/36
- `tsc --noEmit` clean; `pnpm lint` 0 errors; `pnpm build` green with postbuild passing
- Release workflow: actionlint + shellcheck clean; bun checksum verified against Bun's published `SHASUMS256.txt`. It has still never executed — a `dry_run=true` dispatch is the cheap rehearsal.

## Not done

The remaining ~66 unmigrated commands (`prompt`, `dataset`, `trace`, `workflow`, `experiment`, `scenario`, `suite`, `tag`, `simulation-run`) still print their own output. They now **refuse** new-contract flags rather than lying, so this is incremental rather than a correctness cliff. `assertFormatIsSupported` is where they graduate.