### PR TITLE
fix(trace-processing): guard against empty traceId reaching trigger match

### DIFF
--- a/langwatch/ee/governance/subscribers/traceAlertTriggerMatch.subscriber.ts
+++ b/langwatch/ee/governance/subscribers/traceAlertTriggerMatch.subscriber.ts
@@ -19,6 +19,11 @@ export function createTraceAlertTriggerMatchHandler(deps: {
     context: TriggerContext<TraceSummaryData>,
   ): Promise<void> => {
     if (!passesTraceOriginGuards(event, context.state)) return;
+    // Events already committed with an empty aggregateId (see the traceId
+    // guard in originGate.reactor) would fail recordTriggerMatch validation
+    // and poison the reactor job. There is no trace to match a trigger
+    // against, so skip rather than throw.
+    if (!context.aggregateId) return;
     const triggers = await deps.triggers.getActiveTraceTriggersForProject(
       context.tenantId,
     );

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/originGate.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/originGate.reactor.unit.test.ts
@@ -79,11 +79,13 @@ function createEvent(
 
 function createContext(
   foldState: TraceSummaryData,
+  overrides: Partial<ReactorContext<TraceSummaryData>> = {},
 ): ReactorContext<TraceSummaryData> {
   return {
     tenantId: "tenant-1",
     aggregateId: "trace-1",
     foldState,
+    ...overrides,
   };
 }
 
@@ -169,6 +171,21 @@ describe("originGate reactor", () => {
         tenantId: "tenant-1",
         traceId: "trace-1",
       });
+    });
+  });
+
+  describe("when the trace aggregate has an empty id", () => {
+    it("skips without scheduling", async () => {
+      const deps = createDeps();
+      const reactor = createOriginGateReactor(deps);
+      const state = createFoldState({ attributes: {} });
+
+      await reactor.handle(
+        createEvent({ aggregateId: "" }),
+        createContext(state, { aggregateId: "" }),
+      );
+
+      expect(deps.scheduleDeferred).not.toHaveBeenCalled();
     });
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/originGate.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/originGate.reactor.ts
@@ -68,6 +68,17 @@ export function createOriginGateReactor(
 
       if (!needsOriginResolution(event, foldState)) return;
 
+      // Defensive: a trace aggregate with an empty ID can't be resolved, and
+      // scheduling one produces an OriginResolvedEvent with an empty
+      // aggregateId that blows up the automations pipeline later.
+      if (!traceId) {
+        logger.warn(
+          { tenantId, eventId: event.id, eventType: event.type },
+          "Skipping deferred origin resolution: empty traceId on trace event",
+        );
+        return;
+      }
+
       // No origin — schedule deferred resolution (5-min delay)
       logger.debug(
         { tenantId, traceId },

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/commands.ts
@@ -86,7 +86,11 @@ export type RecordMetricCommandData = z.infer<
 
 export const resolveOriginCommandDataSchema = z.object({
   tenantId: z.string(),
-  traceId: z.string(),
+  // Must be non-empty: an empty traceId becomes an empty aggregateId on the
+  // resulting OriginResolvedEvent, which then fails validation downstream in
+  // the automations pipeline (recordTriggerMatch requires a non-empty traceId).
+  // Reject here so the bad value never reaches the event store.
+  traceId: z.string().min(1),
   origin: z.string(),
   reason: z.string(),
   occurredAt: z.number(),


### PR DESCRIPTION
## Problem

Production error poisoning the `triggerMatch` reactor job:

```
[VALIDATION] Invalid payload for command type "lw.automation.trigger.record_match". Validation failed. (field: payload)
```

The failing job carried an `lw.obs.trace.origin_resolved` event with `aggregateId: ""` (and `reason: "deferred_fallback"`). `traceAlertTriggerMatch.subscriber` passes `context.aggregateId` through as `traceId`, and `triggerMatchRecordedEventDataSchema` requires `traceId: z.string().min(1)` — so the send threw and the job kept retrying.

## Chain

`originGate.reactor` scheduled deferred origin resolution using an empty `context.aggregateId` → `createDeferredOriginHandler` dispatched `resolveOrigin` with `traceId: ""` → `ResolveOriginCommand` built an event with `aggregateId: ""` → automations pipeline rejected it downstream.

## Fix

Guards at three points, source-first:

- `resolveOriginCommandDataSchema.traceId` is now `.min(1)` — the bad value can't reach the event store.
- `originGate.reactor` skips (and warns) when the trace aggregate id is empty, rather than scheduling an unresolvable job.
- `traceAlertTriggerMatch.subscriber` skips events with an empty `aggregateId` instead of throwing, so events already committed with the bad shape drain rather than poisoning the reactor.

## Verification

- Added a regression test covering the empty-aggregate-id skip in the origin gate.
- `vitest run src/server/event-sourcing/pipelines/trace-processing/` — 59 files, 696 tests, all passing.
- `tsc --noEmit` clean on the touched files.

https://claude.ai/code/session_01W3C3yCw3dLrERt5tEnc3iD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented processing of trace events with missing identifiers.
  * Blocked invalid origin-resolution requests before they enter downstream workflows.
  * Improved resilience by skipping malformed events instead of allowing processing failures.
  * Added safeguards to prevent unnecessary deferred processing for incomplete traces.

* **Tests**
  * Added coverage confirming incomplete trace events are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->