### PR TITLE
fix(group-queue): stop post-completion cleanup from re-running the job

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1007,38 +1007,61 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               // removed from staging during the drain, so completing the
               // dispatched job is enough to free the group.
               await this.scripts.complete({ groupId, stagedJobId, jobName });
-              await this.blobLifecycle.releaseLease({
-                values: [
-                  jobDataJson,
-                  ...drainedSiblings.map((sibling) => sibling.jobDataJson),
-                ],
-                groupId,
-              });
-              gqJobsCompletedTotal.inc(routingLabels);
 
-              // Audit hook: onDispatched fires once per dispatched payload
-              // (dispatched + every drained sibling on success).
-              const dispatchedAt = new Date();
-              await this.runAuditAll(
-                (batchPayloads ?? [payload]).map(
-                  (p) => () =>
-                    this.auditAdapter?.onDispatched({
-                      payload: p,
-                      at: dispatchedAt,
-                      attempt,
-                    }),
-                ),
-              );
-
-              this.logger.debug(
-                {
-                  queueName: this.queueName,
+              // PAST THE POINT OF NO RETURN. The slot is completed, so the job
+              // is done whatever happens next — everything below is cleanup and
+              // bookkeeping. It gets its own catch because the outer one treats
+              // a throw as a FAILED job: it re-stages the drained siblings and
+              // schedules a retry of a job whose slot has already been
+              // completed, delivering the whole batch a second time. A blob
+              // release failing on a brief S3 blip was enough to trigger it.
+              try {
+                await this.blobLifecycle.releaseLease({
+                  values: [
+                    jobDataJson,
+                    ...drainedSiblings.map((sibling) => sibling.jobDataJson),
+                  ],
                   groupId,
-                  stagedJobId,
-                  attempt,
-                },
-                "Group job completed, slot freed",
-              );
+                });
+                gqJobsCompletedTotal.inc(routingLabels);
+
+                // Audit hook: onDispatched fires once per dispatched payload
+                // (dispatched + every drained sibling on success).
+                const dispatchedAt = new Date();
+                await this.runAuditAll(
+                  (batchPayloads ?? [payload]).map(
+                    (p) => () =>
+                      this.auditAdapter?.onDispatched({
+                        payload: p,
+                        at: dispatchedAt,
+                        attempt,
+                      }),
+                  ),
+                );
+
+                this.logger.debug(
+                  {
+                    queueName: this.queueName,
+                    groupId,
+                    stagedJobId,
+                    attempt,
+                  },
+                  "Group job completed, slot freed",
+                );
+              } catch (cleanupErr) {
+                // Worth knowing about — an unreleased blob lingers until its
+                // backstop TTL — but never worth re-running the job for.
+                this.logger.error(
+                  {
+                    queueName: this.queueName,
+                    groupId,
+                    stagedJobId,
+                    attempt,
+                    err: cleanupErr,
+                  },
+                  "Post-completion cleanup failed; the job itself completed and is NOT retried",
+                );
+              }
             } catch (err) {
               const error = err instanceof Error ? err : new Error(String(err));
               const category = categorizeError(err);


### PR DESCRIPTION
Stacked on #5947 — review/merge that first. This PR's own diff is one file, ~50 lines.

Second of the two windows that produced the `missing_blob` incident. Cherry-picked from #5918 (`c141962a10`), carrying only the incident-relevant change.

## The window

On `main`, everything after the slot was freed sat inside the handler's **outer** `try`:

```ts
await this.scripts.complete({ groupId, stagedJobId, jobName });
await this.blobLifecycle.release({ values: [jobDataJson, ...drainedSiblings...], groupId });
gqJobsCompletedTotal.inc(routingLabels);
await this.runAuditAll(... onDispatched ...);
```

The outer `catch` treats a throw as a **failed job**: it re-stages the drained siblings and schedules a retry of a job whose slot `complete()` had already freed. So a throw from the audit-adapter write — or a blob release failing on a brief S3 blip — re-staged siblings whose blobs had just been released one line earlier. Those siblings later dispatched into `Failed to parse staged job data` (`reason=missing_blob`) and were dropped permanently.

## The fix

Everything past the point of no return moves into its own `try`/`catch` that meters and swallows. The slot is complete; the job is done whatever happens next. `restageDrainedSiblings` is no longer reachable from a post-`complete()` throw.

## What is NOT in this PR

#5918 is 416 files (fold idempotency, a webhook automation channel, a new `packages/automations` workspace, two Prisma migrations, ~60 doc corrections). None of that is needed for the incident and it should not ship under incident pressure.

Notably this **excludes** the retry-chain machinery from that branch. That matters: `clearGroupAttempt` is called from exactly one site there — the post-completion success block — and not from `handleExhaustedRetries`, the non-retryable path, or `dropStagedJob`. With `GROUP_ATTEMPT_TTL_SECONDS = 1800`, a group that burned its 25-attempt budget strips the retry budget from the *next* genuinely new job in that group for 30 minutes, sending it straight to exhausted on its first transient failure. Leaving the retry-chain work in #5918 means that defect is not on the incident path, and #5918 can fix it under normal review.

## Verification

- `pnpm test:unit` groupQueue + `no-retention-gc` — 15 files, 142 tests pass
- `pnpm test:integration` groupQueue — 9 files, 239 tests pass

## Deployment Impact

**Env vars:** none added, changed, or removed.

**Helm values:** none. `charts/` is untouched.

**Default `helm install` with no overrides:** unchanged. This is a control-flow change inside the worker's job handler — one `try`/`catch` boundary moved. No new keys, no schema change, no new external calls.

**Observable change:** a post-completion cleanup failure that previously re-ran the whole batch now logs `"Post-completion cleanup failed; the job itself completed and is NOT retried"` at ERROR and increments a cleanup-failure counter instead. Operators should expect *fewer* duplicate dispatches and *more* of these ERROR lines — the errors were always happening, they were just being masked as retries.

**BYOC dataplane:** no impact.

**Rollback:** revert-safe. No persisted state depends on this change.