### PR TITLE
perf(clickhouse): make the Claude-Code marked-log filter index-eligible

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.integration.test.ts
@@ -31,12 +31,19 @@ async function insertMarkedLog({
   spanId,
   agoSec,
   marked,
+  kindValue,
 }: {
   tenantId: string;
   traceId: string;
   spanId: string;
   agoSec: number;
   marked: boolean;
+  /**
+   * Explicit value for the kind attribute, so a test can set the key with an
+   * EMPTY value. That row has the key present (mapContains matches) but must
+   * still be excluded by the `!= ''` test.
+   */
+  kindValue?: string;
 }) {
   await ch.command({
     query: `
@@ -47,7 +54,13 @@ async function insertMarkedLog({
       VALUES
         ({pid:String}, {tenantId:String}, {traceId:String}, {spanId:String},
          now64(3) - {agoSec:UInt32}, 9, 'INFO', '{}',
-         ${marked ? `map('${CLAUDE_CODE_KIND_ATTR}', 'model')` : `map()`},
+         ${
+           kindValue !== undefined
+             ? `map('${CLAUDE_CODE_KIND_ATTR}', {kindValue:String})`
+             : marked
+               ? `map('${CLAUDE_CODE_KIND_ATTR}', 'model')`
+               : `map()`
+         },
          map(), 'com.anthropic.claude_code.events', NULL, now64(3), now64(3), 30)
     `,
     query_params: {
@@ -56,6 +69,7 @@ async function insertMarkedLog({
       traceId,
       spanId,
       agoSec,
+      ...(kindValue !== undefined ? { kindValue } : {}),
     },
   });
 }
@@ -103,6 +117,17 @@ describe("getMarkedClaudeCodeLogsByTrace partition hint", () => {
       agoSec: 5,
       marked: false,
     });
+    // The kind key present but EMPTY. The read pairs a mapContains index hint
+    // with the `!= ''` value test; mapContains alone would match this row, so
+    // this pins that the value test still excludes it.
+    await insertMarkedLog({
+      tenantId,
+      traceId,
+      spanId: `${tag}-d`,
+      agoSec: 5,
+      marked: true,
+      kindValue: "",
+    });
   });
 
   describe("when a TimeUnixMs hint around the turn is supplied", () => {
@@ -122,6 +147,28 @@ describe("getMarkedClaudeCodeLogsByTrace partition hint", () => {
       const rows = await repo.getMarkedClaudeCodeLogsByTrace(tenantId, traceId);
 
       expect(rows.map((r) => r.spanId)).toEqual([`${tag}-a`, `${tag}-b`]);
+    });
+  });
+
+  describe("when a record carries the kind key with an empty value", () => {
+    it("excludes it, so the mapContains index hint does not widen the result", async () => {
+      const rows = await repo.getMarkedClaudeCodeLogsByTrace(
+        tenantId,
+        traceId,
+        Date.now(),
+      );
+
+      expect(rows.map((r) => r.spanId)).not.toContain(`${tag}-d`);
+    });
+
+    it("excludes it from the count too, so count matches the get", async () => {
+      const count = await repo.countMarkedClaudeCodeLogsByTrace(
+        tenantId,
+        traceId,
+        Date.now(),
+      );
+
+      expect(count).toBe(2);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
@@ -170,4 +170,36 @@ describe("LogRecordStorageClickHouseRepository.getMarkedClaudeCodeLogsByTrace", 
       expect(toMs - fromMs).toBe(sevenCcRetentionMs + partitionWindowMs);
     });
   });
+
+  // stored_log_records carries an idx_attr_key bloom over mapKeys(Attributes)
+  // (migration 00034). ClickHouse only consults it for an explicit
+  // key-existence test, so `Attributes[key] != ''` on its own reads the heavy
+  // Attributes Map for every candidate granule.
+  describe("when selecting the Claude-Code-marked records", () => {
+    it("pairs the kind test with a mapContains so the attribute-key index is used", async () => {
+      const { repo, query } = repoCapturingQuery();
+
+      await repo.getMarkedClaudeCodeLogsByTrace("project_test", "trace-1");
+
+      const { query: sql, query_params } = capturedQuery(query);
+      expect(sql).toContain("mapContains(Attributes, {kindKey:String})");
+      // The original value test is kept: mapContains alone would also match a
+      // key present with an empty value.
+      expect(sql).toContain("Attributes[{kindKey:String}] != ''");
+      expect(query_params.kindKey).toBe(CLAUDE_CODE_KIND_ATTR);
+    });
+  });
+});
+
+describe("LogRecordStorageClickHouseRepository.countMarkedClaudeCodeLogsByTrace", () => {
+  it("uses the same index-eligible kind predicate as the get, so the count matches", async () => {
+    const { repo, query } = repoCapturingQuery();
+
+    await repo.countMarkedClaudeCodeLogsByTrace("project_test", "trace-1");
+
+    const { query: sql, query_params } = capturedQuery(query);
+    expect(sql).toContain("mapContains(Attributes, {kindKey:String})");
+    expect(sql).toContain("Attributes[{kindKey:String}] != ''");
+    expect(query_params.kindKey).toBe(CLAUDE_CODE_KIND_ATTR);
+  });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
@@ -15,6 +15,26 @@ import type {
 
 const TABLE_NAME = "stored_log_records" as const;
 
+/**
+ * Predicate selecting the Claude-Code-marked log records of a trace.
+ *
+ * `mapContains` is redundant with the `!= ''` test on its own — a non-empty
+ * value implies the key is present, so it can never exclude a row the second
+ * test would keep. It is here purely so the predicate becomes index-eligible:
+ * `stored_log_records` carries an `idx_attr_key` bloom filter over
+ * `mapKeys(Attributes)` (migration 00034), and ClickHouse only consults it for
+ * an explicit key-existence test. `Attributes[key] != ''` alone reads the heavy
+ * `Attributes` Map for every candidate granule; EXPLAIN INDEXES confirms the
+ * index is not consulted at all without `mapContains`, and prunes granules that
+ * cannot hold the key once it is present.
+ *
+ * Both marked-log reads share this so their WHERE clauses stay identical and
+ * the count keeps matching the set the get would return.
+ */
+const MARKED_KIND_FILTER =
+  "AND mapContains(Attributes, {kindKey:String}) " +
+  "AND Attributes[{kindKey:String}] != ''";
+
 const logger = createLogger(
   "langwatch:app-layer:traces:log-record-storage-repository",
 );
@@ -195,7 +215,7 @@ export class LogRecordStorageClickHouseRepository
               ${timeFilter}
             GROUP BY TenantId, TraceId, SpanId, ProjectionId
           )
-          AND Attributes[{kindKey:String}] != ''
+          ${MARKED_KIND_FILTER}
         ${orderBy}
         ${limitClause}
       `,
@@ -267,7 +287,7 @@ export class LogRecordStorageClickHouseRepository
               ${timeFilter}
             GROUP BY TenantId, TraceId, SpanId, ProjectionId
           )
-          AND Attributes[{kindKey:String}] != ''
+          ${MARKED_KIND_FILTER}
       `,
       query_params: {
         tenantId,


### PR DESCRIPTION
## Evidence

Aggregating the last 24h of app slow-query warns by shape, the Claude-Code marked-log read on `stored_log_records` is the third-largest ClickHouse read cost in the product, and by far the heaviest per call of the high-volume shapes:

| | |
| --- | --- |
| calls / 24h | 21,608 |
| p50 read | **207 MB** |
| p90 read | 224 MB |
| total | **~3,172 GB/day** |

It is already time-bounded and is **not** a cold scan, so the cost is not partition fan-out; it is reading the heavy `Attributes` Map for far more rows than it returns.

(Redacted; this shape was under-reported in my earlier runs because the log stream it arrives on changed — see the note at the end.)

## Suspected cause

Both marked-log reads (`getMarkedClaudeCodeLogsByTrace` and its companion `countMarkedClaudeCodeLogsByTrace`) select the records whose `Attributes` map carries the Claude Code kind key, written as:

```sql
AND Attributes[{kindKey:String}] != ''
```

`stored_log_records` carries an `idx_attr_key` bloom filter over `mapKeys(Attributes)` (migration 00034), which is exactly the index for this question. But ClickHouse only consults it for an explicit **key-existence** test. A subscript-plus-value comparison is not recognised as one, so the index is skipped and the engine reads the `Attributes` Map for every candidate granule in the trace's time window.

`EXPLAIN INDEXES` on live prod, same query with and without an explicit existence test (tenant redacted):

```
A) Attributes[key] != ''                       -- idx_attr_key not consulted at all

B) mapContains(Attributes, key)                -- Name: idx_attr_key
   AND Attributes[key] != ''                      Description: bloom_filter GRANULARITY 4
                                                  Parts: 0/6      <- prunes granules
```

## Proposed fix

Pair the value test with a `mapContains` key-existence test, in a shared constant used by both reads so their WHERE clauses stay identical (the count is documented to match the set the get would return):

```sql
AND mapContains(Attributes, {kindKey:String})
AND Attributes[{kindKey:String}] != ''
```

**This cannot change which rows match.** `mapContains` is implied by the value test: a non-empty value requires the key to be present, so the added conjunct is true for every row the existing predicate keeps. It is a pure index hint. The `!= ''` test is deliberately kept, because `mapContains` alone would also match a record carrying the key with an empty value.

## Expected impact

Granules in the trace's window that hold no Claude-Code-marked records can be skipped instead of having their `Attributes` Map read. The reactor calls this per turn, and each call currently re-reads the trace's marked-log set, so the saving compounds over a long session.

Unlike the two index PRs I have open (#5810, #5847), this one needs **no backfill to take effect**: `idx_attr_key` has existed since migration 00034, so every part inside this read's window (±2 days around the turn, or a retention-bounded fallback) already carries it. See #5864 for why that distinction matters.

This does not address the deeper shape — each turn re-reading the whole trace's marked-log history, which is O(turns x logs) — that would need a per-turn cursor in the reactor and is a larger behavioural change I have not attempted here.

## Test plan

- Unit tests asserting both reads emit `mapContains(...)` alongside the retained `!= ''` test, with the kind key still bound as a parameter.
- Integration tests (testcontainers + real ClickHouse) extended with a record carrying the kind key set to an **empty value** — the exact row `mapContains` alone would wrongly admit. Pins that the get still excludes it and that the count still matches the get (2, not 3).
- Existing integration coverage ("returns exactly the marked logs, ordered by time", and the same via the no-hint fallback) continues to pass unchanged, which is the correctness property that matters for a predicate that must be a no-op.
- All 8 unit + 4 integration tests pass locally against a real ClickHouse container. `tsgo` typecheck clean.

## Note on the measurement

This shape was previously under-reported in my daily analysis. The app pods' logs moved from the `langwatch*` CloudWatch streams to the `default` stream on 2026-07-15, so a stream-name filter I was using silently stopped matching the web-app traffic. Filtering on message content instead surfaced it. Flagging in case anything else keys off those stream names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of marked Claude Code logs so records with empty kind values are excluded consistently.
  * Aligned log retrieval and count results for more accurate marked-log reporting.

* **Performance**
  * Improved ClickHouse query filtering to better support indexed lookups when searching marked Claude Code logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->