### PR TITLE
fix(aigateway): keep non-streaming connections warm during slow dispatch

### DIFF
--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -39,16 +39,6 @@ type Server struct {
 	Addr                string `env:"ADDR"`
 	GracefulSeconds     int    `env:"GRACEFUL_SECONDS"`
 	MaxRequestBodyBytes int64  `env:"MAX_REQUEST_BODY_BYTES"`
-	// NonStreamingHeartbeatIntervalSeconds sets how often (in seconds) a
-	// non-streaming response writes a keep-alive byte while dispatch is
-	// still in flight. 0 falls back to DefaultNonStreamingHeartbeatInterval;
-	// negative disables heartbeating entirely. Plain seconds, not a Go
-	// duration string ("45s") — config.Hydrate parses time.Duration fields
-	// as raw nanosecond integers (setField's int64 branch), not via
-	// time.ParseDuration, so "45s" would fail to parse and a correct value
-	// would have to be an opaque nanosecond count. Plain seconds sidesteps
-	// that trap entirely.
-	NonStreamingHeartbeatIntervalSeconds int64 `env:"NON_STREAMING_HEARTBEAT_INTERVAL_SECONDS"`
 }
 
 // ListenAndServe starts the server and handles graceful shutdown on SIGTERM/SIGINT.

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -22,6 +22,16 @@ const (
 	// headroom over a 10M-token request. Deployments that send multi-hundred-MB
 	// media or run tighter memory should override MAX_REQUEST_BODY_BYTES.
 	DefaultMaxRequestBodyBytes = 128 * 1024 * 1024
+	// DefaultNonStreamingHeartbeatInterval bounds how long a non-streaming
+	// response can go completely silent while a large-context completion
+	// is still in flight. Edge proxies in front of the gateway (Cloudflare's
+	// default is ~100s) kill a connection that receives zero response bytes
+	// within their idle window, even though the origin is healthy and still
+	// working — see https://github.com/langwatch/langwatch/issues/4806.
+	// 45s leaves better than 2x margin under Cloudflare's default while
+	// leaving fast requests (the overwhelming majority) completely
+	// unaffected: only a dispatch slower than this ever emits a heartbeat.
+	DefaultNonStreamingHeartbeatInterval = 45 * time.Second
 )
 
 // Server configures HTTP listen address, graceful shutdown, and request body cap.
@@ -29,6 +39,11 @@ type Server struct {
 	Addr                string `env:"ADDR"`
 	GracefulSeconds     int    `env:"GRACEFUL_SECONDS"`
 	MaxRequestBodyBytes int64  `env:"MAX_REQUEST_BODY_BYTES"`
+	// NonStreamingHeartbeatInterval sets how often a non-streaming response
+	// writes a keep-alive byte while dispatch is still in flight. 0 falls
+	// back to DefaultNonStreamingHeartbeatInterval; negative disables
+	// heartbeating entirely.
+	NonStreamingHeartbeatInterval time.Duration `env:"NON_STREAMING_HEARTBEAT_INTERVAL"`
 }
 
 // ListenAndServe starts the server and handles graceful shutdown on SIGTERM/SIGINT.

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -39,11 +39,16 @@ type Server struct {
 	Addr                string `env:"ADDR"`
 	GracefulSeconds     int    `env:"GRACEFUL_SECONDS"`
 	MaxRequestBodyBytes int64  `env:"MAX_REQUEST_BODY_BYTES"`
-	// NonStreamingHeartbeatInterval sets how often a non-streaming response
-	// writes a keep-alive byte while dispatch is still in flight. 0 falls
-	// back to DefaultNonStreamingHeartbeatInterval; negative disables
-	// heartbeating entirely.
-	NonStreamingHeartbeatInterval time.Duration `env:"NON_STREAMING_HEARTBEAT_INTERVAL"`
+	// NonStreamingHeartbeatIntervalSeconds sets how often (in seconds) a
+	// non-streaming response writes a keep-alive byte while dispatch is
+	// still in flight. 0 falls back to DefaultNonStreamingHeartbeatInterval;
+	// negative disables heartbeating entirely. Plain seconds, not a Go
+	// duration string ("45s") — config.Hydrate parses time.Duration fields
+	// as raw nanosecond integers (setField's int64 branch), not via
+	// time.ParseDuration, so "45s" would fail to parse and a correct value
+	// would have to be an opaque nanosecond count. Plain seconds sidesteps
+	// that trap entirely.
+	NonStreamingHeartbeatIntervalSeconds int64 `env:"NON_STREAMING_HEARTBEAT_INTERVAL_SECONDS"`
 }
 
 // ListenAndServe starts the server and handles graceful shutdown on SIGTERM/SIGINT.

--- a/services/aigateway/adapters/httpapi/nonstreaming_ttfb_realsocket_test.go
+++ b/services/aigateway/adapters/httpapi/nonstreaming_ttfb_realsocket_test.go
@@ -60,19 +60,20 @@ func TestRouter_NonStreaming_HeartbeatKeepsRealSocketWarm(t *testing.T) {
 
 	waitOrFatal(t, providerEntered, "provider was never dialed")
 
-	// Generously longer than several 20ms ticks so at least one heartbeat
-	// has definitely reached the real client before we check.
-	time.Sleep(80 * time.Millisecond)
+	// Poll instead of a fixed sleep — a hardcoded wait is either too short
+	// (flakes on a loaded CI runner) or wastes time on a fast one.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return !firstByteAt.IsZero()
+	}, 2*time.Second, 5*time.Millisecond,
+		"a real HTTP client on a real socket should see GotFirstResponseByte from a heartbeat before the still-in-flight provider call returns")
+
 	mu.Lock()
-	gotFirstByte := !firstByteAt.IsZero()
 	elapsed := firstByteAt.Sub(start)
 	mu.Unlock()
-	assert.True(t, gotFirstByte,
-		"a real HTTP client on a real socket should see GotFirstResponseByte from a heartbeat before the still-in-flight provider call returns")
-	if gotFirstByte {
-		assert.Less(t, elapsed, 200*time.Millisecond,
-			"the first byte over the real socket should arrive within a couple heartbeat ticks, not only once the provider call eventually returns")
-	}
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"the first byte over the real socket should arrive within a couple heartbeat ticks, not only once the provider call eventually returns")
 
 	close(releaseProvider)
 

--- a/services/aigateway/adapters/httpapi/nonstreaming_ttfb_realsocket_test.go
+++ b/services/aigateway/adapters/httpapi/nonstreaming_ttfb_realsocket_test.go
@@ -1,0 +1,93 @@
+package httpapi
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouter_NonStreaming_HeartbeatKeepsRealSocketWarm is the one test that
+// isn't in-process: every test in nonstreaming_ttfb_test.go drives the
+// router through httptest.ResponseRecorder, an in-memory buffer that never
+// proves bytes actually cross a real transport. This one puts the router
+// behind httptest.NewServer (a real net/http.Server on a real loopback TCP
+// port) and a real *http.Client, using httptrace to capture the client's
+// actual GotFirstResponseByte — the same signal a real proxy in front of
+// the gateway would be watching to decide whether the connection has gone
+// idle. If chunked-transfer framing or flush semantics only worked inside
+// Go's in-memory recorder abstraction and not over a real socket, this is
+// the test that would catch it.
+func TestRouter_NonStreaming_HeartbeatKeepsRealSocketWarm(t *testing.T) {
+	providerEntered := make(chan struct{})
+	releaseProvider := make(chan struct{})
+	router := newHeartbeatRouter(slowSuccessProvider(providerEntered, releaseProvider), 20*time.Millisecond)
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	var mu sync.Mutex
+	var firstByteAt time.Time
+	trace := &httptrace.ClientTrace{
+		GotFirstResponseByte: func() {
+			mu.Lock()
+			firstByteAt = time.Now()
+			mu.Unlock()
+		},
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/chat/completions", bytes.NewReader(chatBody()))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+
+	start := time.Now()
+	type result struct {
+		resp *http.Response
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		resp, err := http.DefaultClient.Do(req)
+		resultCh <- result{resp, err}
+	}()
+
+	waitOrFatal(t, providerEntered, "provider was never dialed")
+
+	// Generously longer than several 20ms ticks so at least one heartbeat
+	// has definitely reached the real client before we check.
+	time.Sleep(80 * time.Millisecond)
+	mu.Lock()
+	gotFirstByte := !firstByteAt.IsZero()
+	elapsed := firstByteAt.Sub(start)
+	mu.Unlock()
+	assert.True(t, gotFirstByte,
+		"a real HTTP client on a real socket should see GotFirstResponseByte from a heartbeat before the still-in-flight provider call returns")
+	if gotFirstByte {
+		assert.Less(t, elapsed, 200*time.Millisecond,
+			"the first byte over the real socket should arrive within a couple heartbeat ticks, not only once the provider call eventually returns")
+	}
+
+	close(releaseProvider)
+
+	var res result
+	select {
+	case res = <-resultCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("real HTTP client never received a response")
+	}
+	require.NoError(t, res.err)
+	defer res.resp.Body.Close()
+
+	body, err := io.ReadAll(res.resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.resp.StatusCode)
+	assert.Contains(t, string(body), "choices")
+	assert.Equal(t, "true", res.resp.Header.Get("X-LangWatch-Heartbeat-Active"))
+}

--- a/services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
+++ b/services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
@@ -1,0 +1,593 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/pkg/health"
+	"github.com/langwatch/langwatch/pkg/herr"
+	"github.com/langwatch/langwatch/services/aigateway/app"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// ttfbSpyWriter records whether anything has actually been flushed to the
+// transport — WriteHeader or Write. Go's net/http buffers header-map
+// mutations (w.Header().Set(...)) client-side and does not put a single
+// byte on the wire until the first real WriteHeader/Write call, so
+// inspecting httptest.ResponseRecorder's header map or its Code field
+// (pre-seeded to 200) cannot distinguish "nothing sent yet" from "sent."
+// This spy answers the only question that matters for an edge proxy's
+// idle-connection timeout: has the origin emitted any bytes at all.
+//
+// wroteAny is an atomic.Bool, not a plain bool: ServeHTTP runs on a
+// goroutine the test spawns explicitly, while the test's main goroutine
+// polls this field via require.Eventually — a plain bool there is a real
+// data race caught by `go test -race` (this is a test-harness concern
+// only; the production heartbeatWriter.started field below is never
+// touched by more than one goroutine, since the background dispatch
+// goroutine never accesses the ResponseWriter).
+type ttfbSpyWriter struct {
+	http.ResponseWriter
+	wroteAny atomic.Bool
+}
+
+func (s *ttfbSpyWriter) WriteHeader(statusCode int) {
+	s.wroteAny.Store(true)
+	s.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (s *ttfbSpyWriter) Write(p []byte) (int, error) {
+	s.wroteAny.Store(true)
+	return s.ResponseWriter.Write(p)
+}
+
+// TestRouter_NonStreaming_NoBytesReachClientWhileProviderIsSlow documents the
+// baseline behind https://github.com/langwatch/langwatch/issues/4806: with
+// no explicit HeartbeatInterval configured (buildRouter's default —
+// resolves to config.DefaultNonStreamingHeartbeatInterval, 45s), a dispatch
+// that finishes well inside that window is byte-for-byte identical to
+// before the fix — nothing reaches the client until the provider call
+// returns. This is intentional: only dispatches slower than the interval
+// (see TestRouter_NonStreaming_HeartbeatKeepsConnectionWarm below) pay the
+// heartbeat's status-commitment trade-off; everything else, including
+// every fast error response, is completely unaffected.
+//
+// See specs/ai-gateway/non-streaming-time-to-first-byte.feature.
+//
+// @scenario "non-streaming client receives zero response bytes for dispatch faster than the heartbeat interval"
+func TestRouter_NonStreaming_NoBytesReachClientWhileProviderIsSlow(t *testing.T) {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+
+	providerEntered := make(chan struct{})
+	releaseProvider := make(chan struct{})
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			close(providerEntered)
+			<-releaseProvider // held open to stand in for a slow, large-context completion
+			return successResponse(), nil
+		},
+	}
+
+	router := buildRouter(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithLogger(zap.NewNop()),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(chatBody()))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	spy := &ttfbSpyWriter{ResponseWriter: rec}
+
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(spy, req)
+		close(done)
+	}()
+
+	select {
+	case <-providerEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider was never dialed")
+	}
+
+	// The provider call is deliberately still in flight here. If the
+	// gateway had any mechanism to keep the connection warm (streaming,
+	// heartbeat bytes, early headers), something would have hit the wire
+	// by now — it has not.
+	assert.False(t, spy.wroteAny.Load(), "no bytes should reach the client transport while the provider call is still in flight")
+
+	close(releaseProvider)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never completed after the provider call returned")
+	}
+
+	// Once the (slow) provider finally returns, the full response arrives
+	// as a single burst — this isn't a hang, just an all-or-nothing
+	// delivery with no mechanism to bridge a proxy's idle-connection
+	// timeout while the burst is being assembled.
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotZero(t, rec.Body.Len())
+}
+
+// TestRouter_NonStreaming_HeartbeatKeepsConnectionWarm proves the fix for
+// #4806: once a non-streaming dispatch runs longer than HeartbeatInterval,
+// the gateway starts writing keep-alive bytes to the client — resetting any
+// edge proxy's idle-connection timer — while the provider call is still
+// running, and still delivers the exact correct response, with the correct
+// Content-Type, once the provider call finally returns.
+//
+// @scenario "dispatch slower than the heartbeat interval keeps the connection warm and still delivers the correct response"
+func TestRouter_NonStreaming_HeartbeatKeepsConnectionWarm(t *testing.T) {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+
+	providerEntered := make(chan struct{})
+	releaseProvider := make(chan struct{})
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			close(providerEntered)
+			<-releaseProvider
+			return successResponse(), nil
+		},
+	}
+
+	reg := health.New("test")
+	reg.MarkStarted()
+	application := app.New(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithLogger(zap.NewNop()),
+	)
+	router := NewRouter(RouterDeps{
+		App:               application,
+		Logger:            zap.NewNop(),
+		Health:            reg,
+		HeartbeatInterval: 5 * time.Millisecond,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(chatBody()))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	spy := &ttfbSpyWriter{ResponseWriter: rec}
+
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(spy, req)
+		close(done)
+	}()
+
+	select {
+	case <-providerEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider was never dialed")
+	}
+
+	require.Eventually(t, func() bool { return spy.wroteAny.Load() }, 2*time.Second, 5*time.Millisecond,
+		"a heartbeat byte should reach the client while the provider call is still in flight")
+
+	// The connection is warm, but dispatch is still genuinely running in
+	// the background — the heartbeat doesn't short-circuit it.
+	select {
+	case <-done:
+		t.Fatal("handler completed before the provider call returned")
+	default:
+	}
+
+	close(releaseProvider)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never completed after the provider call returned")
+	}
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	// The body is prefixed by one or more heartbeat bytes (insignificant
+	// JSON whitespace, RFC 8259 §2) ahead of the real payload — proving
+	// Go's own json.Unmarshal, not just a claim in a comment, still parses
+	// it correctly is the point of this assertion.
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Contains(t, body, "choices")
+}
+
+// TestRouter_NonStreaming_HeartbeatThenError_StillDeliversStructuredErrorBody
+// documents the one bounded trade-off of the #4806 fix: once a heartbeat
+// has flushed, the HTTP status is irrevocably committed to 200 (net/http
+// sends it implicitly on the first Write) — the same trade-off the
+// streaming path already accepts for errors that surface mid-stream (see
+// streaming.feature). If dispatch ultimately errors after heartbeating has
+// started, the wire status can no longer become the real 4xx/5xx, but the
+// body still carries the exact same structured error a fast failure would
+// have produced, so a client inspecting the body (not just the status)
+// still gets the accurate error — a strict improvement over today's
+// 524 with no body at all.
+//
+// @scenario "dispatch that errors after heartbeating has started still delivers a structured error body"
+func TestRouter_NonStreaming_HeartbeatThenError_StillDeliversStructuredErrorBody(t *testing.T) {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+
+	providerEntered := make(chan struct{})
+	releaseProvider := make(chan struct{})
+	provider := &mockProvider{
+		dispatchFn: func(ctx context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			close(providerEntered)
+			<-releaseProvider
+			return nil, herr.New(ctx, domain.ErrProviderError, nil)
+		},
+	}
+
+	reg := health.New("test")
+	reg.MarkStarted()
+	application := app.New(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithLogger(zap.NewNop()),
+	)
+	router := NewRouter(RouterDeps{
+		App:               application,
+		Logger:            zap.NewNop(),
+		Health:            reg,
+		HeartbeatInterval: 5 * time.Millisecond,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(chatBody()))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	spy := &ttfbSpyWriter{ResponseWriter: rec}
+
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(spy, req)
+		close(done)
+	}()
+
+	select {
+	case <-providerEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider was never dialed")
+	}
+
+	require.Eventually(t, func() bool { return spy.wroteAny.Load() }, 2*time.Second, 5*time.Millisecond,
+		"a heartbeat byte should reach the client before the provider call errors")
+
+	close(releaseProvider)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never completed after the provider call returned")
+	}
+
+	// Status is stuck at 200 — already committed by the heartbeat — but the
+	// body still carries the real, structured error.
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var errResp herr.ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	assert.Equal(t, "provider_error", errResp.Error.Type)
+}
+
+// TestRouter_NonStreaming_HeartbeatDisabled proves the negative-interval
+// escape hatch: no heartbeat byte is ever written, matching pre-fix
+// behavior exactly, for operators who need to turn the mechanism off
+// without a redeploy (e.g. NON_STREAMING_HEARTBEAT_INTERVAL=-1s).
+//
+// @scenario "a negative heartbeat interval disables the mechanism entirely"
+func TestRouter_NonStreaming_HeartbeatDisabled(t *testing.T) {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+
+	providerEntered := make(chan struct{})
+	releaseProvider := make(chan struct{})
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			close(providerEntered)
+			<-releaseProvider
+			return successResponse(), nil
+		},
+	}
+
+	reg := health.New("test")
+	reg.MarkStarted()
+	application := app.New(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithLogger(zap.NewNop()),
+	)
+	router := NewRouter(RouterDeps{
+		App:               application,
+		Logger:            zap.NewNop(),
+		Health:            reg,
+		HeartbeatInterval: -1 * time.Millisecond,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(chatBody()))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+	spy := &ttfbSpyWriter{ResponseWriter: rec}
+
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(spy, req)
+		close(done)
+	}()
+
+	select {
+	case <-providerEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider was never dialed")
+	}
+
+	// Generously longer than several would-be 5ms ticks — with
+	// heartbeating disabled, nothing should ever fire.
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, spy.wroteAny.Load(), "a negative HeartbeatInterval must disable heartbeating entirely")
+
+	close(releaseProvider)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never completed after the provider call returned")
+	}
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestRouter_NonStreaming_HeartbeatFiresAcrossEveryRoute proves the fix is
+// wired correctly at all five non-streaming call sites — chat, messages,
+// responses, embeddings, and the Gemini passthrough — not just chat
+// completions. A copy-paste mistake at any one of the five withHeartbeat
+// call sites in router.go would silently leave that specific route exposed
+// to #4806 again while every test targeting only /v1/chat/completions kept
+// passing, so each route gets its own pass through the exact same
+// slow-provider-then-release choreography.
+func TestRouter_NonStreaming_HeartbeatFiresAcrossEveryRoute(t *testing.T) {
+	cases := []struct {
+		name       string
+		method     string
+		path       string
+		body       []byte
+		respBody   []byte
+		bodyMarker string
+	}{
+		{
+			name:       "chat_completions",
+			method:     http.MethodPost,
+			path:       "/v1/chat/completions",
+			body:       chatBody(),
+			bodyMarker: "choices",
+		},
+		{
+			name:       "messages",
+			method:     http.MethodPost,
+			path:       "/v1/messages",
+			body:       chatBody(),
+			bodyMarker: "choices",
+		},
+		{
+			name:       "responses",
+			method:     http.MethodPost,
+			path:       "/v1/responses",
+			body:       chatBody(),
+			bodyMarker: "choices",
+		},
+		{
+			name:       "embeddings",
+			method:     http.MethodPost,
+			path:       "/v1/embeddings",
+			body:       chatBody(),
+			bodyMarker: "choices",
+		},
+		{
+			name:       "gemini_passthrough",
+			method:     http.MethodPost,
+			path:       "/v1beta/models/gemini-2.5-flash:generateContent",
+			body:       []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`),
+			respBody:   []byte(`{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}`),
+			bodyMarker: "candidates",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &mockAuth{
+				resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+					return testBundle(), nil
+				},
+			}
+
+			providerEntered := make(chan struct{})
+			releaseProvider := make(chan struct{})
+			provider := &mockProvider{
+				dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+					close(providerEntered)
+					<-releaseProvider
+					if tc.respBody != nil {
+						return &domain.Response{Body: tc.respBody, StatusCode: 200}, nil
+					}
+					return successResponse(), nil
+				},
+			}
+
+			reg := health.New("test")
+			reg.MarkStarted()
+			application := app.New(
+				app.WithAuth(auth),
+				app.WithProviders(provider),
+				app.WithLogger(zap.NewNop()),
+			)
+			router := NewRouter(RouterDeps{
+				App:               application,
+				Logger:            zap.NewNop(),
+				Health:            reg,
+				HeartbeatInterval: 5 * time.Millisecond,
+			})
+
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer vk-lw-test")
+			req.Header.Set("X-Goog-Api-Key", "vk-lw-test") // gemini passthrough auth path
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			spy := &ttfbSpyWriter{ResponseWriter: rec}
+
+			done := make(chan struct{})
+			go func() {
+				router.ServeHTTP(spy, req)
+				close(done)
+			}()
+
+			select {
+			case <-providerEntered:
+			case <-time.After(2 * time.Second):
+				t.Fatal("provider was never dialed")
+			}
+
+			require.Eventually(t, func() bool { return spy.wroteAny.Load() }, 2*time.Second, 5*time.Millisecond,
+				"a heartbeat byte should reach the client on this route while dispatch is in flight")
+
+			close(releaseProvider)
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("handler never completed after dispatch returned")
+			}
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Contains(t, rec.Body.String(), tc.bodyMarker)
+		})
+	}
+}
+
+// TestRouter_NonStreaming_ConcurrentSlowRequestsDoNotInterfere runs two
+// slow, heartbeating requests side by side and proves neither leaks state
+// into the other — each withHeartbeat call owns its own ticker, goroutine,
+// and wrapped writer, so nothing is shared across concurrent requests.
+func TestRouter_NonStreaming_ConcurrentSlowRequestsDoNotInterfere(t *testing.T) {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+
+	type reqState struct {
+		entered chan struct{}
+		release chan struct{}
+	}
+	states := map[string]*reqState{
+		"req-a": {entered: make(chan struct{}), release: make(chan struct{})},
+		"req-b": {entered: make(chan struct{}), release: make(chan struct{})},
+	}
+
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, req *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			// The model name threads the two concurrent requests apart —
+			// both hit the same handler and the same mock, so this is the
+			// only signal available to tell them apart from inside dispatch.
+			st := states[req.Model]
+			close(st.entered)
+			<-st.release
+			return successResponse(), nil
+		},
+	}
+
+	reg := health.New("test")
+	reg.MarkStarted()
+	application := app.New(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithLogger(zap.NewNop()),
+	)
+	router := NewRouter(RouterDeps{
+		App:               application,
+		Logger:            zap.NewNop(),
+		Health:            reg,
+		HeartbeatInterval: 5 * time.Millisecond,
+	})
+
+	recA, recB := httptest.NewRecorder(), httptest.NewRecorder()
+	spyA := &ttfbSpyWriter{ResponseWriter: recA}
+	spyB := &ttfbSpyWriter{ResponseWriter: recB}
+
+	bodyFor := func(model string) []byte {
+		return []byte(`{"model":"` + model + `","messages":[{"role":"user","content":"hi"}]}`)
+	}
+	reqA := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(bodyFor("req-a")))
+	reqA.Header.Set("Authorization", "Bearer vk-lw-test")
+	reqB := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(bodyFor("req-b")))
+	reqB.Header.Set("Authorization", "Bearer vk-lw-test")
+
+	doneA, doneB := make(chan struct{}), make(chan struct{})
+	go func() { router.ServeHTTP(spyA, reqA); close(doneA) }()
+	go func() { router.ServeHTTP(spyB, reqB); close(doneB) }()
+
+	for _, st := range states {
+		select {
+		case <-st.entered:
+		case <-time.After(2 * time.Second):
+			t.Fatal("a provider call was never dialed")
+		}
+	}
+
+	require.Eventually(t, func() bool { return spyA.wroteAny.Load() }, 2*time.Second, 5*time.Millisecond, "req-a should have heartbeat bytes")
+	require.Eventually(t, func() bool { return spyB.wroteAny.Load() }, 2*time.Second, 5*time.Millisecond, "req-b should have heartbeat bytes")
+
+	// Release only req-a; req-b must keep running independently — proves
+	// the two heartbeat loops (goroutine + ticker each) aren't sharing
+	// state that would let releasing one affect the other.
+	close(states["req-a"].release)
+	select {
+	case <-doneA:
+	case <-time.After(2 * time.Second):
+		t.Fatal("req-a never completed")
+	}
+	select {
+	case <-doneB:
+		t.Fatal("req-b completed before its own provider call was released")
+	default:
+	}
+
+	close(states["req-b"].release)
+	select {
+	case <-doneB:
+	case <-time.After(2 * time.Second):
+		t.Fatal("req-b never completed")
+	}
+
+	assert.Equal(t, http.StatusOK, recA.Code)
+	assert.Equal(t, http.StatusOK, recB.Code)
+	assert.Contains(t, recA.Body.String(), "choices")
+	assert.Contains(t, recB.Body.String(), "choices")
+}

--- a/services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
+++ b/services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
@@ -51,6 +51,69 @@ func (s *ttfbSpyWriter) Write(p []byte) (int, error) {
 	return s.ResponseWriter.Write(p)
 }
 
+// newHeartbeatRouter builds a router wired with the standard passthrough
+// auth (always resolves to testBundle()), the given provider, and an
+// explicit HeartbeatInterval — the one knob every heartbeat test needs to
+// set that buildRouter (router_test.go's shared helper) doesn't expose.
+func newHeartbeatRouter(provider *mockProvider, interval time.Duration) http.Handler {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+	reg := health.New("test")
+	reg.MarkStarted()
+	application := app.New(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithLogger(zap.NewNop()),
+	)
+	return NewRouter(RouterDeps{
+		App:               application,
+		Logger:            zap.NewNop(),
+		Health:            reg,
+		HeartbeatInterval: interval,
+	})
+}
+
+// serveAsync runs router.ServeHTTP on its own goroutine and returns a
+// channel that closes when it's done. The heartbeat mechanism runs
+// concurrently with the caller by design, so every test needs to observe
+// the response from outside the goroutine that produces it.
+func serveAsync(router http.Handler, w http.ResponseWriter, req *http.Request) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(w, req)
+		close(done)
+	}()
+	return done
+}
+
+// waitOrFatal blocks on ch for up to 2s, failing the test instead of
+// hanging the suite if the fix regresses into a deadlock.
+func waitOrFatal(t *testing.T, ch <-chan struct{}, timeoutMsg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal(timeoutMsg)
+	}
+}
+
+// slowSuccessProvider returns a mockProvider whose dispatch blocks until
+// release is closed, then returns a fixed success response. entered is
+// closed the moment dispatch is called — the standard "still in flight"
+// choreography most of these tests need and don't otherwise differ on.
+func slowSuccessProvider(entered, release chan struct{}) *mockProvider {
+	return &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			close(entered)
+			<-release
+			return successResponse(), nil
+		},
+	}
+}
+
 // TestRouter_NonStreaming_NoBytesReachClientWhileProviderIsSlow documents the
 // baseline behind https://github.com/langwatch/langwatch/issues/4806: with
 // no explicit HeartbeatInterval configured (buildRouter's default —
@@ -74,13 +137,7 @@ func TestRouter_NonStreaming_NoBytesReachClientWhileProviderIsSlow(t *testing.T)
 
 	providerEntered := make(chan struct{})
 	releaseProvider := make(chan struct{})
-	provider := &mockProvider{
-		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
-			close(providerEntered)
-			<-releaseProvider // held open to stand in for a slow, large-context completion
-			return successResponse(), nil
-		},
-	}
+	provider := slowSuccessProvider(providerEntered, releaseProvider)
 
 	router := buildRouter(
 		app.WithAuth(auth),
@@ -93,17 +150,8 @@ func TestRouter_NonStreaming_NoBytesReachClientWhileProviderIsSlow(t *testing.T)
 	rec := httptest.NewRecorder()
 	spy := &ttfbSpyWriter{ResponseWriter: rec}
 
-	done := make(chan struct{})
-	go func() {
-		router.ServeHTTP(spy, req)
-		close(done)
-	}()
-
-	select {
-	case <-providerEntered:
-	case <-time.After(2 * time.Second):
-		t.Fatal("provider was never dialed")
-	}
+	done := serveAsync(router, spy, req)
+	waitOrFatal(t, providerEntered, "provider was never dialed")
 
 	// The provider call is deliberately still in flight here. If the
 	// gateway had any mechanism to keep the connection warm (streaming,
@@ -112,12 +160,7 @@ func TestRouter_NonStreaming_NoBytesReachClientWhileProviderIsSlow(t *testing.T)
 	assert.False(t, spy.wroteAny.Load(), "no bytes should reach the client transport while the provider call is still in flight")
 
 	close(releaseProvider)
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("handler never completed after the provider call returned")
-	}
+	waitOrFatal(t, done, "handler never completed after the provider call returned")
 
 	// Once the (slow) provider finally returns, the full response arrives
 	// as a single burst — this isn't a hang, just an all-or-nothing
@@ -136,52 +179,17 @@ func TestRouter_NonStreaming_NoBytesReachClientWhileProviderIsSlow(t *testing.T)
 //
 // @scenario "dispatch slower than the heartbeat interval keeps the connection warm and still delivers the correct response"
 func TestRouter_NonStreaming_HeartbeatKeepsConnectionWarm(t *testing.T) {
-	auth := &mockAuth{
-		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			return testBundle(), nil
-		},
-	}
-
 	providerEntered := make(chan struct{})
 	releaseProvider := make(chan struct{})
-	provider := &mockProvider{
-		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
-			close(providerEntered)
-			<-releaseProvider
-			return successResponse(), nil
-		},
-	}
-
-	reg := health.New("test")
-	reg.MarkStarted()
-	application := app.New(
-		app.WithAuth(auth),
-		app.WithProviders(provider),
-		app.WithLogger(zap.NewNop()),
-	)
-	router := NewRouter(RouterDeps{
-		App:               application,
-		Logger:            zap.NewNop(),
-		Health:            reg,
-		HeartbeatInterval: 5 * time.Millisecond,
-	})
+	router := newHeartbeatRouter(slowSuccessProvider(providerEntered, releaseProvider), 5*time.Millisecond)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(chatBody()))
 	req.Header.Set("Authorization", "Bearer vk-lw-test")
 	rec := httptest.NewRecorder()
 	spy := &ttfbSpyWriter{ResponseWriter: rec}
 
-	done := make(chan struct{})
-	go func() {
-		router.ServeHTTP(spy, req)
-		close(done)
-	}()
-
-	select {
-	case <-providerEntered:
-	case <-time.After(2 * time.Second):
-		t.Fatal("provider was never dialed")
-	}
+	done := serveAsync(router, spy, req)
+	waitOrFatal(t, providerEntered, "provider was never dialed")
 
 	require.Eventually(t, func() bool { return spy.wroteAny.Load() }, 2*time.Second, 5*time.Millisecond,
 		"a heartbeat byte should reach the client while the provider call is still in flight")
@@ -195,12 +203,7 @@ func TestRouter_NonStreaming_HeartbeatKeepsConnectionWarm(t *testing.T) {
 	}
 
 	close(releaseProvider)
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("handler never completed after the provider call returned")
-	}
+	waitOrFatal(t, done, "handler never completed after the provider call returned")
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
@@ -228,12 +231,6 @@ func TestRouter_NonStreaming_HeartbeatKeepsConnectionWarm(t *testing.T) {
 //
 // @scenario "dispatch that errors after heartbeating has started still delivers a structured error body"
 func TestRouter_NonStreaming_HeartbeatThenError_StillDeliversStructuredErrorBody(t *testing.T) {
-	auth := &mockAuth{
-		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			return testBundle(), nil
-		},
-	}
-
 	providerEntered := make(chan struct{})
 	releaseProvider := make(chan struct{})
 	provider := &mockProvider{
@@ -243,48 +240,21 @@ func TestRouter_NonStreaming_HeartbeatThenError_StillDeliversStructuredErrorBody
 			return nil, herr.New(ctx, domain.ErrProviderError, nil)
 		},
 	}
-
-	reg := health.New("test")
-	reg.MarkStarted()
-	application := app.New(
-		app.WithAuth(auth),
-		app.WithProviders(provider),
-		app.WithLogger(zap.NewNop()),
-	)
-	router := NewRouter(RouterDeps{
-		App:               application,
-		Logger:            zap.NewNop(),
-		Health:            reg,
-		HeartbeatInterval: 5 * time.Millisecond,
-	})
+	router := newHeartbeatRouter(provider, 5*time.Millisecond)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(chatBody()))
 	req.Header.Set("Authorization", "Bearer vk-lw-test")
 	rec := httptest.NewRecorder()
 	spy := &ttfbSpyWriter{ResponseWriter: rec}
 
-	done := make(chan struct{})
-	go func() {
-		router.ServeHTTP(spy, req)
-		close(done)
-	}()
-
-	select {
-	case <-providerEntered:
-	case <-time.After(2 * time.Second):
-		t.Fatal("provider was never dialed")
-	}
+	done := serveAsync(router, spy, req)
+	waitOrFatal(t, providerEntered, "provider was never dialed")
 
 	require.Eventually(t, func() bool { return spy.wroteAny.Load() }, 2*time.Second, 5*time.Millisecond,
 		"a heartbeat byte should reach the client before the provider call errors")
 
 	close(releaseProvider)
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("handler never completed after the provider call returned")
-	}
+	waitOrFatal(t, done, "handler never completed after the provider call returned")
 
 	// Status is stuck at 200 — already committed by the heartbeat — but the
 	// body still carries the real, structured error.
@@ -298,56 +268,21 @@ func TestRouter_NonStreaming_HeartbeatThenError_StillDeliversStructuredErrorBody
 // TestRouter_NonStreaming_HeartbeatDisabled proves the negative-interval
 // escape hatch: no heartbeat byte is ever written, matching pre-fix
 // behavior exactly, for operators who need to turn the mechanism off
-// without a redeploy (e.g. NON_STREAMING_HEARTBEAT_INTERVAL=-1s).
+// without a redeploy (e.g. NON_STREAMING_HEARTBEAT_INTERVAL_SECONDS=-1).
 //
 // @scenario "a negative heartbeat interval disables the mechanism entirely"
 func TestRouter_NonStreaming_HeartbeatDisabled(t *testing.T) {
-	auth := &mockAuth{
-		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			return testBundle(), nil
-		},
-	}
-
 	providerEntered := make(chan struct{})
 	releaseProvider := make(chan struct{})
-	provider := &mockProvider{
-		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
-			close(providerEntered)
-			<-releaseProvider
-			return successResponse(), nil
-		},
-	}
-
-	reg := health.New("test")
-	reg.MarkStarted()
-	application := app.New(
-		app.WithAuth(auth),
-		app.WithProviders(provider),
-		app.WithLogger(zap.NewNop()),
-	)
-	router := NewRouter(RouterDeps{
-		App:               application,
-		Logger:            zap.NewNop(),
-		Health:            reg,
-		HeartbeatInterval: -1 * time.Millisecond,
-	})
+	router := newHeartbeatRouter(slowSuccessProvider(providerEntered, releaseProvider), -1*time.Millisecond)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(chatBody()))
 	req.Header.Set("Authorization", "Bearer vk-lw-test")
 	rec := httptest.NewRecorder()
 	spy := &ttfbSpyWriter{ResponseWriter: rec}
 
-	done := make(chan struct{})
-	go func() {
-		router.ServeHTTP(spy, req)
-		close(done)
-	}()
-
-	select {
-	case <-providerEntered:
-	case <-time.After(2 * time.Second):
-		t.Fatal("provider was never dialed")
-	}
+	done := serveAsync(router, spy, req)
+	waitOrFatal(t, providerEntered, "provider was never dialed")
 
 	// Generously longer than several would-be 5ms ticks — with
 	// heartbeating disabled, nothing should ever fire.
@@ -355,12 +290,7 @@ func TestRouter_NonStreaming_HeartbeatDisabled(t *testing.T) {
 	assert.False(t, spy.wroteAny.Load(), "a negative HeartbeatInterval must disable heartbeating entirely")
 
 	close(releaseProvider)
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("handler never completed after the provider call returned")
-	}
+	waitOrFatal(t, done, "handler never completed after the provider call returned")
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
@@ -382,34 +312,10 @@ func TestRouter_NonStreaming_HeartbeatFiresAcrossEveryRoute(t *testing.T) {
 		respBody   []byte
 		bodyMarker string
 	}{
-		{
-			name:       "chat_completions",
-			method:     http.MethodPost,
-			path:       "/v1/chat/completions",
-			body:       chatBody(),
-			bodyMarker: "choices",
-		},
-		{
-			name:       "messages",
-			method:     http.MethodPost,
-			path:       "/v1/messages",
-			body:       chatBody(),
-			bodyMarker: "choices",
-		},
-		{
-			name:       "responses",
-			method:     http.MethodPost,
-			path:       "/v1/responses",
-			body:       chatBody(),
-			bodyMarker: "choices",
-		},
-		{
-			name:       "embeddings",
-			method:     http.MethodPost,
-			path:       "/v1/embeddings",
-			body:       chatBody(),
-			bodyMarker: "choices",
-		},
+		{name: "chat_completions", method: http.MethodPost, path: "/v1/chat/completions", body: chatBody(), bodyMarker: "choices"},
+		{name: "messages", method: http.MethodPost, path: "/v1/messages", body: chatBody(), bodyMarker: "choices"},
+		{name: "responses", method: http.MethodPost, path: "/v1/responses", body: chatBody(), bodyMarker: "choices"},
+		{name: "embeddings", method: http.MethodPost, path: "/v1/embeddings", body: chatBody(), bodyMarker: "choices"},
 		{
 			name:       "gemini_passthrough",
 			method:     http.MethodPost,
@@ -422,12 +328,6 @@ func TestRouter_NonStreaming_HeartbeatFiresAcrossEveryRoute(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			auth := &mockAuth{
-				resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-					return testBundle(), nil
-				},
-			}
-
 			providerEntered := make(chan struct{})
 			releaseProvider := make(chan struct{})
 			provider := &mockProvider{
@@ -440,20 +340,7 @@ func TestRouter_NonStreaming_HeartbeatFiresAcrossEveryRoute(t *testing.T) {
 					return successResponse(), nil
 				},
 			}
-
-			reg := health.New("test")
-			reg.MarkStarted()
-			application := app.New(
-				app.WithAuth(auth),
-				app.WithProviders(provider),
-				app.WithLogger(zap.NewNop()),
-			)
-			router := NewRouter(RouterDeps{
-				App:               application,
-				Logger:            zap.NewNop(),
-				Health:            reg,
-				HeartbeatInterval: 5 * time.Millisecond,
-			})
+			router := newHeartbeatRouter(provider, 5*time.Millisecond)
 
 			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader(tc.body))
 			req.Header.Set("Authorization", "Bearer vk-lw-test")
@@ -462,28 +349,14 @@ func TestRouter_NonStreaming_HeartbeatFiresAcrossEveryRoute(t *testing.T) {
 			rec := httptest.NewRecorder()
 			spy := &ttfbSpyWriter{ResponseWriter: rec}
 
-			done := make(chan struct{})
-			go func() {
-				router.ServeHTTP(spy, req)
-				close(done)
-			}()
-
-			select {
-			case <-providerEntered:
-			case <-time.After(2 * time.Second):
-				t.Fatal("provider was never dialed")
-			}
+			done := serveAsync(router, spy, req)
+			waitOrFatal(t, providerEntered, "provider was never dialed")
 
 			require.Eventually(t, func() bool { return spy.wroteAny.Load() }, 2*time.Second, 5*time.Millisecond,
 				"a heartbeat byte should reach the client on this route while dispatch is in flight")
 
 			close(releaseProvider)
-
-			select {
-			case <-done:
-			case <-time.After(2 * time.Second):
-				t.Fatal("handler never completed after dispatch returned")
-			}
+			waitOrFatal(t, done, "handler never completed after dispatch returned")
 
 			assert.Equal(t, http.StatusOK, rec.Code)
 			assert.Contains(t, rec.Body.String(), tc.bodyMarker)
@@ -496,12 +369,6 @@ func TestRouter_NonStreaming_HeartbeatFiresAcrossEveryRoute(t *testing.T) {
 // into the other — each withHeartbeat call owns its own ticker, goroutine,
 // and wrapped writer, so nothing is shared across concurrent requests.
 func TestRouter_NonStreaming_ConcurrentSlowRequestsDoNotInterfere(t *testing.T) {
-	auth := &mockAuth{
-		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
-			return testBundle(), nil
-		},
-	}
-
 	type reqState struct {
 		entered chan struct{}
 		release chan struct{}
@@ -522,20 +389,7 @@ func TestRouter_NonStreaming_ConcurrentSlowRequestsDoNotInterfere(t *testing.T) 
 			return successResponse(), nil
 		},
 	}
-
-	reg := health.New("test")
-	reg.MarkStarted()
-	application := app.New(
-		app.WithAuth(auth),
-		app.WithProviders(provider),
-		app.WithLogger(zap.NewNop()),
-	)
-	router := NewRouter(RouterDeps{
-		App:               application,
-		Logger:            zap.NewNop(),
-		Health:            reg,
-		HeartbeatInterval: 5 * time.Millisecond,
-	})
+	router := newHeartbeatRouter(provider, 5*time.Millisecond)
 
 	recA, recB := httptest.NewRecorder(), httptest.NewRecorder()
 	spyA := &ttfbSpyWriter{ResponseWriter: recA}
@@ -549,16 +403,11 @@ func TestRouter_NonStreaming_ConcurrentSlowRequestsDoNotInterfere(t *testing.T) 
 	reqB := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(bodyFor("req-b")))
 	reqB.Header.Set("Authorization", "Bearer vk-lw-test")
 
-	doneA, doneB := make(chan struct{}), make(chan struct{})
-	go func() { router.ServeHTTP(spyA, reqA); close(doneA) }()
-	go func() { router.ServeHTTP(spyB, reqB); close(doneB) }()
+	doneA := serveAsync(router, spyA, reqA)
+	doneB := serveAsync(router, spyB, reqB)
 
 	for _, st := range states {
-		select {
-		case <-st.entered:
-		case <-time.After(2 * time.Second):
-			t.Fatal("a provider call was never dialed")
-		}
+		waitOrFatal(t, st.entered, "a provider call was never dialed")
 	}
 
 	require.Eventually(t, func() bool { return spyA.wroteAny.Load() }, 2*time.Second, 5*time.Millisecond, "req-a should have heartbeat bytes")
@@ -568,11 +417,7 @@ func TestRouter_NonStreaming_ConcurrentSlowRequestsDoNotInterfere(t *testing.T) 
 	// the two heartbeat loops (goroutine + ticker each) aren't sharing
 	// state that would let releasing one affect the other.
 	close(states["req-a"].release)
-	select {
-	case <-doneA:
-	case <-time.After(2 * time.Second):
-		t.Fatal("req-a never completed")
-	}
+	waitOrFatal(t, doneA, "req-a never completed")
 	select {
 	case <-doneB:
 		t.Fatal("req-b completed before its own provider call was released")
@@ -580,11 +425,7 @@ func TestRouter_NonStreaming_ConcurrentSlowRequestsDoNotInterfere(t *testing.T) 
 	}
 
 	close(states["req-b"].release)
-	select {
-	case <-doneB:
-	case <-time.After(2 * time.Second):
-		t.Fatal("req-b never completed")
-	}
+	waitOrFatal(t, doneB, "req-b never completed")
 
 	assert.Equal(t, http.StatusOK, recA.Code)
 	assert.Equal(t, http.StatusOK, recB.Code)
@@ -624,17 +465,8 @@ func TestRouter_NonStreaming_PanicInDispatchDoesNotCrashProcess(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer vk-lw-test")
 	rec := httptest.NewRecorder()
 
-	done := make(chan struct{})
-	go func() {
-		router.ServeHTTP(rec, req)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("handler never completed — a panic in the background dispatch goroutine likely hung resultCh instead of surfacing an error")
-	}
+	done := serveAsync(router, rec, req)
+	waitOrFatal(t, done, "handler never completed — a panic in the background dispatch goroutine likely hung resultCh instead of surfacing an error")
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 

--- a/services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
+++ b/services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
@@ -168,6 +168,7 @@ func TestRouter_NonStreaming_NoBytesReachClientWhileProviderIsSlow(t *testing.T)
 	// timeout while the burst is being assembled.
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.NotZero(t, rec.Body.Len())
+	assert.Empty(t, rec.Header().Get("X-LangWatch-Heartbeat-Active"), "no heartbeat fired, so the header that flags a possibly-stale status must be absent")
 }
 
 // TestRouter_NonStreaming_HeartbeatKeepsConnectionWarm proves the fix for
@@ -207,6 +208,8 @@ func TestRouter_NonStreaming_HeartbeatKeepsConnectionWarm(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "true", rec.Header().Get("X-LangWatch-Heartbeat-Active"),
+		"a client should be able to tell this response took the heartbeat path from headers alone")
 
 	// The body is prefixed by one or more heartbeat bytes (insignificant
 	// JSON whitespace, RFC 8259 §2) ahead of the real payload — proving
@@ -227,7 +230,9 @@ func TestRouter_NonStreaming_HeartbeatKeepsConnectionWarm(t *testing.T) {
 // body still carries the exact same structured error a fast failure would
 // have produced, so a client inspecting the body (not just the status)
 // still gets the accurate error — a strict improvement over today's
-// 524 with no body at all.
+// 524 with no body at all. X-LangWatch-Heartbeat-Active on the response is
+// the mitigation for clients that only check status: its presence on a
+// 200 is the signal to check the body for an error key first.
 //
 // @scenario "dispatch that errors after heartbeating has started still delivers a structured error body"
 func TestRouter_NonStreaming_HeartbeatThenError_StillDeliversStructuredErrorBody(t *testing.T) {
@@ -257,8 +262,10 @@ func TestRouter_NonStreaming_HeartbeatThenError_StillDeliversStructuredErrorBody
 	waitOrFatal(t, done, "handler never completed after the provider call returned")
 
 	// Status is stuck at 200 — already committed by the heartbeat — but the
-	// body still carries the real, structured error.
+	// body still carries the real, structured error, and the header flags
+	// that this specific 200 needs a body check before being trusted.
 	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "true", rec.Header().Get("X-LangWatch-Heartbeat-Active"))
 
 	var errResp herr.ErrorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
@@ -293,6 +300,7 @@ func TestRouter_NonStreaming_HeartbeatDisabled(t *testing.T) {
 	waitOrFatal(t, done, "handler never completed after the provider call returned")
 
 	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get("X-LangWatch-Heartbeat-Active"), "disabled means no heartbeat ever fires, so the header must never be set")
 }
 
 // TestRouter_NonStreaming_HeartbeatFiresAcrossEveryRoute proves the fix is
@@ -360,6 +368,7 @@ func TestRouter_NonStreaming_HeartbeatFiresAcrossEveryRoute(t *testing.T) {
 
 			assert.Equal(t, http.StatusOK, rec.Code)
 			assert.Contains(t, rec.Body.String(), tc.bodyMarker)
+			assert.Equal(t, "true", rec.Header().Get("X-LangWatch-Heartbeat-Active"))
 		})
 	}
 }

--- a/services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
+++ b/services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
@@ -591,3 +591,54 @@ func TestRouter_NonStreaming_ConcurrentSlowRequestsDoNotInterfere(t *testing.T) 
 	assert.Contains(t, recA.Body.String(), "choices")
 	assert.Contains(t, recB.Body.String(), "choices")
 }
+
+// TestRouter_NonStreaming_PanicInDispatchDoesNotCrashProcess is the
+// regression test for a bug caught in review of the heartbeat fix itself:
+// dispatch runs on a background goroutine (withHeartbeat) so the heartbeat
+// loop can keep writing to the client while it's in flight. That goroutine
+// sits outside httpmiddleware.Recover()'s reach — Recover's defer/recover
+// is scoped to the goroutine that calls ServeHTTP, not one spawned inside a
+// handler — so an unrecovered panic there would take down the whole
+// process instead of producing a 500 for the one bad request. If this test
+// method itself doesn't complete (the test binary crashes instead of
+// reporting pass/fail), that IS the regression.
+func TestRouter_NonStreaming_PanicInDispatchDoesNotCrashProcess(t *testing.T) {
+	auth := &mockAuth{
+		resolveFn: func(_ context.Context, _ string) (*domain.Bundle, error) {
+			return testBundle(), nil
+		},
+	}
+	provider := &mockProvider{
+		dispatchFn: func(_ context.Context, _ *domain.Request, _ domain.Credential) (*domain.Response, error) {
+			panic("simulated panic deep in dispatch")
+		},
+	}
+
+	router := buildRouter(
+		app.WithAuth(auth),
+		app.WithProviders(provider),
+		app.WithLogger(zap.NewNop()),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(chatBody()))
+	req.Header.Set("Authorization", "Bearer vk-lw-test")
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never completed — a panic in the background dispatch goroutine likely hung resultCh instead of surfacing an error")
+	}
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	var errResp herr.ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
+	assert.Equal(t, "internal_error", errResp.Error.Type)
+}

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/go-chi/chi/v5"
@@ -51,6 +52,16 @@ type RouterDeps struct {
 	// that send full-context multi-image / media payloads; lower on public
 	// edge deployments to tighten DDoS protection.
 	MaxRequestBodyBytes int64
+	// HeartbeatInterval sets how often a non-streaming response writes a
+	// keep-alive byte while dispatch is still in flight, so a large-context
+	// completion that legitimately runs long doesn't sit silent long enough
+	// for an edge proxy (e.g. Cloudflare's ~100s default) to kill the
+	// connection with a 524 — see
+	// specs/ai-gateway/non-streaming-time-to-first-byte.feature and
+	// https://github.com/langwatch/langwatch/issues/4806. 0 falls back to
+	// config.DefaultNonStreamingHeartbeatInterval (45s); negative disables
+	// heartbeating entirely.
+	HeartbeatInterval time.Duration
 }
 
 // NewRouter creates the chi router with all gateway routes mounted.
@@ -147,13 +158,15 @@ func chatHandler(deps RouterDeps) http.HandlerFunc {
 			setMetaHeaders(w, result.Meta)
 			writeSSE(r.Context(), w, result.Iterator)
 		} else {
-			result, err := deps.App.HandleChat(r.Context(), bundle, bytes.NewReader(body), model)
+			result, hw, err := withHeartbeat(w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+				return deps.App.HandleChat(r.Context(), bundle, bytes.NewReader(body), model)
+			})
 			if err != nil {
-				writeError(deps.Logger, w, r.Context(), err)
+				writeError(deps.Logger, hw, r.Context(), err)
 				return
 			}
-			setMetaHeaders(w, result.Meta)
-			writeJSONResponse(w, result.Response)
+			setMetaHeaders(hw, result.Meta)
+			writeJSONResponse(hw, result.Response)
 		}
 	}
 }
@@ -194,13 +207,15 @@ func messagesHandler(deps RouterDeps) http.HandlerFunc {
 			setMetaHeaders(w, result.Meta)
 			writeSSE(r.Context(), w, result.Iterator)
 		} else {
-			result, err := deps.App.HandleMessages(r.Context(), bundle, bytes.NewReader(body), model)
+			result, hw, err := withHeartbeat(w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+				return deps.App.HandleMessages(r.Context(), bundle, bytes.NewReader(body), model)
+			})
 			if err != nil {
-				writeError(deps.Logger, w, r.Context(), err)
+				writeError(deps.Logger, hw, r.Context(), err)
 				return
 			}
-			setMetaHeaders(w, result.Meta)
-			writeJSONResponse(w, result.Response)
+			setMetaHeaders(hw, result.Meta)
+			writeJSONResponse(hw, result.Response)
 		}
 	}
 }
@@ -251,13 +266,15 @@ func responsesHandler(deps RouterDeps) http.HandlerFunc {
 			setMetaHeaders(w, result.Meta)
 			writeSSE(r.Context(), w, result.Iterator)
 		} else {
-			result, err := deps.App.HandleResponses(r.Context(), bundle, bytes.NewReader(body), model)
+			result, hw, err := withHeartbeat(w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+				return deps.App.HandleResponses(r.Context(), bundle, bytes.NewReader(body), model)
+			})
 			if err != nil {
-				writeError(deps.Logger, w, r.Context(), err)
+				writeError(deps.Logger, hw, r.Context(), err)
 				return
 			}
-			setMetaHeaders(w, result.Meta)
-			writeJSONResponse(w, result.Response)
+			setMetaHeaders(hw, result.Meta)
+			writeJSONResponse(hw, result.Response)
 		}
 	}
 }
@@ -275,13 +292,15 @@ func embeddingsHandler(deps RouterDeps) http.HandlerFunc {
 		}
 		defer release()
 
-		result, err := deps.App.HandleEmbeddings(r.Context(), bundle, body, app.PeekModel(peek))
+		result, hw, err := withHeartbeat(w, deps.HeartbeatInterval, func() (*app.EmbeddingResult, error) {
+			return deps.App.HandleEmbeddings(r.Context(), bundle, body, app.PeekModel(peek))
+		})
 		if err != nil {
-			writeError(deps.Logger, w, r.Context(), err)
+			writeError(deps.Logger, hw, r.Context(), err)
 			return
 		}
-		setMetaHeaders(w, result.Meta)
-		writeJSONResponse(w, result.Response)
+		setMetaHeaders(hw, result.Meta)
+		writeJSONResponse(hw, result.Response)
 	}
 }
 
@@ -339,13 +358,15 @@ func geminiPassthroughHandler(deps RouterDeps) http.HandlerFunc {
 			return
 		}
 
-		result, err := deps.App.HandlePassthrough(r.Context(), bundle, body, model, meta)
+		result, hw, err := withHeartbeat(w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+			return deps.App.HandlePassthrough(r.Context(), bundle, body, model, meta)
+		})
 		if err != nil {
-			writeError(deps.Logger, w, r.Context(), err)
+			writeError(deps.Logger, hw, r.Context(), err)
 			return
 		}
-		setMetaHeaders(w, result.Meta)
-		writeJSONResponse(w, result.Response)
+		setMetaHeaders(hw, result.Meta)
+		writeJSONResponse(hw, result.Response)
 	}
 }
 
@@ -541,6 +562,108 @@ func (l *lazyPooledBody) Read(p []byte) (n int, err error) {
 		l.buf.Write(p[:n])
 	}
 	return n, err
+}
+
+// heartbeatByte is a single RFC 8259 §2 insignificant-whitespace byte.
+// Every conformant JSON parser skips whitespace before the top-level
+// value, so writing one periodically keeps the connection producing bytes
+// without corrupting the eventual response body.
+var heartbeatByte = []byte{' '}
+
+// heartbeatWriter tracks whether anything has reached the transport yet.
+// Once a heartbeat has flushed, the HTTP status is irrevocably committed
+// (net/http sends an implicit 200 on the first Write); a later real
+// WriteHeader call from writeError/writeJSONResponse would otherwise log a
+// "superfluous WriteHeader" warning for no effect, so it's turned into a
+// harmless no-op here — the body write immediately after it still goes
+// through and reaches the client normally.
+type heartbeatWriter struct {
+	http.ResponseWriter
+	started bool
+}
+
+func (h *heartbeatWriter) WriteHeader(statusCode int) {
+	if h.started {
+		return
+	}
+	h.started = true
+	h.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (h *heartbeatWriter) Write(p []byte) (int, error) {
+	h.started = true
+	return h.ResponseWriter.Write(p)
+}
+
+func (h *heartbeatWriter) Flush() {
+	if f, ok := h.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (h *heartbeatWriter) Unwrap() http.ResponseWriter {
+	return h.ResponseWriter
+}
+
+// withHeartbeat runs dispatch on a background goroutine and, while it is
+// still in flight, periodically writes a heartbeat byte to w and flushes
+// it. This resets the idle-connection timer of any proxy/CDN sitting in
+// front of the gateway (e.g. Cloudflare's ~100s default) so a large-context
+// completion that legitimately runs long doesn't go silent long enough to
+// get killed before it can finish. See
+// specs/ai-gateway/non-streaming-time-to-first-byte.feature and
+// https://github.com/langwatch/langwatch/issues/4806.
+//
+// Requests that finish inside the first interval are byte-for-byte
+// unaffected — the returned writer just proxies to w. Once a heartbeat has
+// fired, the HTTP status is irrevocably committed to 200 (the same
+// trade-off the streaming path already accepts for errors that surface
+// mid-stream — see streaming.feature): if dispatch ultimately errors after
+// heartbeating has started, the caller's writeError call still produces
+// the correct structured error body via the returned writer, but the wire
+// status can no longer be changed to the real 4xx/5xx. A client that
+// checks the response body (not just the status) still gets the accurate
+// error. interval of zero resolves to config.DefaultNonStreamingHeartbeatInterval;
+// negative disables heartbeating entirely.
+func withHeartbeat[T any](w http.ResponseWriter, interval time.Duration, dispatch func() (T, error)) (T, http.ResponseWriter, error) {
+	hw := &heartbeatWriter{ResponseWriter: w}
+
+	type outcome struct {
+		val T
+		err error
+	}
+	resultCh := make(chan outcome, 1)
+	go func() {
+		val, err := dispatch()
+		resultCh <- outcome{val, err}
+	}()
+
+	if interval == 0 {
+		interval = config.DefaultNonStreamingHeartbeatInterval
+	}
+	if interval <= 0 {
+		r := <-resultCh
+		return r.val, hw, r.err
+	}
+
+	// Every non-streaming JSON response is application/json whatever the
+	// eventual outcome — set it before the first possible heartbeat write
+	// so it's still part of the header block if a heartbeat commits the
+	// response early. writeJSONResponse still overwrites this with the
+	// more precise upstream content type for the common (fast) case.
+	hw.Header().Set("Content-Type", "application/json")
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case r := <-resultCh:
+			return r.val, hw, r.err
+		case <-ticker.C:
+			_, _ = hw.Write(heartbeatByte)
+			hw.Flush()
+		}
+	}
 }
 
 func writeJSONResponse(w http.ResponseWriter, resp *domain.Response) {

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
 
+	"github.com/langwatch/langwatch/pkg/clog"
 	"github.com/langwatch/langwatch/pkg/config"
 	"github.com/langwatch/langwatch/pkg/health"
 	"github.com/langwatch/langwatch/pkg/herr"
@@ -158,7 +159,7 @@ func chatHandler(deps RouterDeps) http.HandlerFunc {
 			setMetaHeaders(w, result.Meta)
 			writeSSE(r.Context(), w, result.Iterator)
 		} else {
-			result, hw, err := withHeartbeat(w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+			result, hw, err := withHeartbeat(r.Context(), w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
 				return deps.App.HandleChat(r.Context(), bundle, bytes.NewReader(body), model)
 			})
 			if err != nil {
@@ -207,7 +208,7 @@ func messagesHandler(deps RouterDeps) http.HandlerFunc {
 			setMetaHeaders(w, result.Meta)
 			writeSSE(r.Context(), w, result.Iterator)
 		} else {
-			result, hw, err := withHeartbeat(w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+			result, hw, err := withHeartbeat(r.Context(), w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
 				return deps.App.HandleMessages(r.Context(), bundle, bytes.NewReader(body), model)
 			})
 			if err != nil {
@@ -266,7 +267,7 @@ func responsesHandler(deps RouterDeps) http.HandlerFunc {
 			setMetaHeaders(w, result.Meta)
 			writeSSE(r.Context(), w, result.Iterator)
 		} else {
-			result, hw, err := withHeartbeat(w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+			result, hw, err := withHeartbeat(r.Context(), w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
 				return deps.App.HandleResponses(r.Context(), bundle, bytes.NewReader(body), model)
 			})
 			if err != nil {
@@ -292,7 +293,7 @@ func embeddingsHandler(deps RouterDeps) http.HandlerFunc {
 		}
 		defer release()
 
-		result, hw, err := withHeartbeat(w, deps.HeartbeatInterval, func() (*app.EmbeddingResult, error) {
+		result, hw, err := withHeartbeat(r.Context(), w, deps.HeartbeatInterval, func() (*app.EmbeddingResult, error) {
 			return deps.App.HandleEmbeddings(r.Context(), bundle, body, app.PeekModel(peek))
 		})
 		if err != nil {
@@ -358,7 +359,7 @@ func geminiPassthroughHandler(deps RouterDeps) http.HandlerFunc {
 			return
 		}
 
-		result, hw, err := withHeartbeat(w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
+		result, hw, err := withHeartbeat(r.Context(), w, deps.HeartbeatInterval, func() (*app.CompletionResult, error) {
 			return deps.App.HandlePassthrough(r.Context(), bundle, body, model, meta)
 		})
 		if err != nil {
@@ -625,7 +626,15 @@ func (h *heartbeatWriter) Unwrap() http.ResponseWriter {
 // checks the response body (not just the status) still gets the accurate
 // error. interval of zero resolves to config.DefaultNonStreamingHeartbeatInterval;
 // negative disables heartbeating entirely.
-func withHeartbeat[T any](w http.ResponseWriter, interval time.Duration, dispatch func() (T, error)) (T, http.ResponseWriter, error) {
+//
+// dispatch runs on a background goroutine so the select loop below stays
+// free to write heartbeats while it's in flight. That goroutine is outside
+// httpmiddleware.Recover()'s reach — Recover's defer/recover only guards
+// the goroutine that calls ServeHTTP, not one spawned from inside a
+// handler — so a panic in dispatch is recovered here explicitly and turned
+// into the same internal_error 500 Recover() would have produced for a
+// synchronous panic, instead of crashing the whole process.
+func withHeartbeat[T any](ctx context.Context, w http.ResponseWriter, interval time.Duration, dispatch func() (T, error)) (T, http.ResponseWriter, error) {
 	hw := &heartbeatWriter{ResponseWriter: w}
 
 	type outcome struct {
@@ -634,6 +643,13 @@ func withHeartbeat[T any](w http.ResponseWriter, interval time.Duration, dispatc
 	}
 	resultCh := make(chan outcome, 1)
 	go func() {
+		defer func() {
+			if v := recover(); v != nil {
+				clog.LogPanic(ctx, v)
+				var zero T
+				resultCh <- outcome{val: zero, err: herr.New(ctx, domain.ErrInternal, nil)}
+			}
+		}()
 		val, err := dispatch()
 		resultCh <- outcome{val, err}
 	}()

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -662,20 +662,36 @@ func withHeartbeat[T any](ctx context.Context, w http.ResponseWriter, interval t
 		return r.val, hw, r.err
 	}
 
-	// Every non-streaming JSON response is application/json whatever the
-	// eventual outcome — set it before the first possible heartbeat write
-	// so it's still part of the header block if a heartbeat commits the
-	// response early. writeJSONResponse still overwrites this with the
-	// more precise upstream content type for the common (fast) case.
-	hw.Header().Set("Content-Type", "application/json")
-
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	heartbeatFired := false
 	for {
 		select {
 		case r := <-resultCh:
 			return r.val, hw, r.err
 		case <-ticker.C:
+			if !heartbeatFired {
+				heartbeatFired = true
+				// Every non-streaming JSON response is application/json
+				// whatever the eventual outcome — set it before the first
+				// heartbeat write so it's still part of the header block if
+				// this response commits early. writeJSONResponse still
+				// overwrites this with the more precise upstream content
+				// type for the common (fast, no-heartbeat) case.
+				hw.Header().Set("Content-Type", "application/json")
+				// Once a heartbeat fires, status 200 is committed even if
+				// dispatch later errors — there is no way to change it
+				// after bytes are on the wire. This header is the only way
+				// a client can distinguish "this 200 is real" from "this
+				// 200 is a committed-early status masking a later error,
+				// check the body for an error key." Tied to the first
+				// actual heartbeat tick, not just to heartbeating being
+				// enabled — every request has interval > 0 by default, so
+				// setting this any earlier would put it on every response
+				// regardless of whether a heartbeat ever fired, making it
+				// useless as a signal.
+				hw.Header().Set("X-LangWatch-Heartbeat-Active", "true")
+			}
 			_, _ = hw.Write(heartbeatByte)
 			hw.Flush()
 		}

--- a/services/aigateway/config.go
+++ b/services/aigateway/config.go
@@ -64,10 +64,10 @@ func defaultConfig() Config {
 	return Config{
 		Environment: "local",
 		Server: config.Server{
-			Addr:                          ":5563",
-			GracefulSeconds:               10,
-			MaxRequestBodyBytes:           config.DefaultMaxRequestBodyBytes,
-			NonStreamingHeartbeatInterval: config.DefaultNonStreamingHeartbeatInterval,
+			Addr:                                 ":5563",
+			GracefulSeconds:                      10,
+			MaxRequestBodyBytes:                  config.DefaultMaxRequestBodyBytes,
+			NonStreamingHeartbeatIntervalSeconds: int64(config.DefaultNonStreamingHeartbeatInterval / time.Second),
 		},
 		ControlPlane: ControlPlaneConfig{
 			BaseURL: "http://localhost:5560",

--- a/services/aigateway/config.go
+++ b/services/aigateway/config.go
@@ -64,9 +64,10 @@ func defaultConfig() Config {
 	return Config{
 		Environment: "local",
 		Server: config.Server{
-			Addr:                ":5563",
-			GracefulSeconds:     10,
-			MaxRequestBodyBytes: config.DefaultMaxRequestBodyBytes,
+			Addr:                          ":5563",
+			GracefulSeconds:               10,
+			MaxRequestBodyBytes:           config.DefaultMaxRequestBodyBytes,
+			NonStreamingHeartbeatInterval: config.DefaultNonStreamingHeartbeatInterval,
 		},
 		ControlPlane: ControlPlaneConfig{
 			BaseURL: "http://localhost:5560",

--- a/services/aigateway/config.go
+++ b/services/aigateway/config.go
@@ -23,6 +23,20 @@ type Config struct {
 	AuthCache                     AuthCacheConfig           `env:"LW_GATEWAY_AUTH_CACHE"`
 	CustomerTraceBridge           CustomerTraceBridgeConfig `env:"CUSTOMER_TRACE_BRIDGE"`
 	OTel                          config.OTel               `env:"OTEL"`
+	// NonStreamingHeartbeatIntervalSeconds sets how often (in seconds) a
+	// non-streaming response writes a keep-alive byte while dispatch is
+	// still in flight. 0 falls back to config.DefaultNonStreamingHeartbeatInterval;
+	// negative disables heartbeating entirely. Plain seconds, not a Go
+	// duration string ("45s") — config.Hydrate parses time.Duration fields
+	// as raw nanosecond integers, not via time.ParseDuration, so "45s"
+	// would fail to parse. Plain seconds sidesteps that trap entirely.
+	//
+	// Lives on Config directly rather than the shared config.Server (unlike
+	// MaxRequestBodyBytes, which every config.Server-embedding service
+	// wires up) because this concept is specific to the gateway's
+	// non-streaming HTTP surface — services/langyagent and services/nlpgo
+	// both embed config.Server too but have no use for this field.
+	NonStreamingHeartbeatIntervalSeconds int64 `env:"NON_STREAMING_HEARTBEAT_INTERVAL_SECONDS"`
 }
 
 // ControlPlaneConfig holds control plane connection settings.
@@ -64,11 +78,11 @@ func defaultConfig() Config {
 	return Config{
 		Environment: "local",
 		Server: config.Server{
-			Addr:                                 ":5563",
-			GracefulSeconds:                      10,
-			MaxRequestBodyBytes:                  config.DefaultMaxRequestBodyBytes,
-			NonStreamingHeartbeatIntervalSeconds: int64(config.DefaultNonStreamingHeartbeatInterval / time.Second),
+			Addr:                ":5563",
+			GracefulSeconds:     10,
+			MaxRequestBodyBytes: config.DefaultMaxRequestBodyBytes,
 		},
+		NonStreamingHeartbeatIntervalSeconds: int64(config.DefaultNonStreamingHeartbeatInterval / time.Second),
 		ControlPlane: ControlPlaneConfig{
 			BaseURL: "http://localhost:5560",
 		},

--- a/services/aigateway/serve.go
+++ b/services/aigateway/serve.go
@@ -36,7 +36,7 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config) er
 		OTTLServer:            ottlSrv,
 		InternalSecret:        cfg.ControlPlane.InternalSecret,
 		MaxRequestBodyBytes:   cfg.Server.MaxRequestBodyBytes,
-		HeartbeatInterval:     cfg.Server.NonStreamingHeartbeatInterval,
+		HeartbeatInterval:     time.Duration(cfg.Server.NonStreamingHeartbeatIntervalSeconds) * time.Second,
 	})
 
 	srv := &http.Server{Handler: handler, Addr: cfg.Server.Addr, ReadHeaderTimeout: 10 * time.Second}

--- a/services/aigateway/serve.go
+++ b/services/aigateway/serve.go
@@ -36,7 +36,7 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config) er
 		OTTLServer:            ottlSrv,
 		InternalSecret:        cfg.ControlPlane.InternalSecret,
 		MaxRequestBodyBytes:   cfg.Server.MaxRequestBodyBytes,
-		HeartbeatInterval:     time.Duration(cfg.Server.NonStreamingHeartbeatIntervalSeconds) * time.Second,
+		HeartbeatInterval:     time.Duration(cfg.NonStreamingHeartbeatIntervalSeconds) * time.Second,
 	})
 
 	srv := &http.Server{Handler: handler, Addr: cfg.Server.Addr, ReadHeaderTimeout: 10 * time.Second}

--- a/services/aigateway/serve.go
+++ b/services/aigateway/serve.go
@@ -36,6 +36,7 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config) er
 		OTTLServer:            ottlSrv,
 		InternalSecret:        cfg.ControlPlane.InternalSecret,
 		MaxRequestBodyBytes:   cfg.Server.MaxRequestBodyBytes,
+		HeartbeatInterval:     cfg.Server.NonStreamingHeartbeatInterval,
 	})
 
 	srv := &http.Server{Handler: handler, Addr: cfg.Server.Addr, ReadHeaderTimeout: 10 * time.Second}

--- a/specs/ai-gateway/non-streaming-time-to-first-byte.feature
+++ b/specs/ai-gateway/non-streaming-time-to-first-byte.feature
@@ -27,6 +27,7 @@ Feature: Non-streaming responses stay warm during slow dispatch
     And dispatch finishes before HeartbeatInterval elapses
     Then no response bytes, including headers, have reached the client before dispatch finished
     And the full response is delivered exactly as it always was
+    And the response does not carry an X-LangWatch-Heartbeat-Active header
     # Fast requests — the overwhelming majority — are byte-for-byte
     # unaffected by the heartbeat mechanism below.
 
@@ -37,6 +38,7 @@ Feature: Non-streaming responses stay warm during slow dispatch
     Then a keep-alive byte reaches the client while dispatch is still in flight
     And the client's JSON parser still parses the eventual response correctly
     And once dispatch finishes, the full response is delivered with status 200 and Content-Type application/json
+    And the response carries an X-LangWatch-Heartbeat-Active header
     # This is the fix for #4806: a large-context completion that legitimately
     # runs long now keeps producing bytes, so it never goes silent long
     # enough for an edge proxy to kill the connection.
@@ -48,11 +50,14 @@ Feature: Non-streaming responses stay warm during slow dispatch
     Then a keep-alive byte reaches the client while dispatch is still in flight
     And once dispatch fails, the response status is still 200
     And the response body is the same structured error envelope a fast failure would have produced
+    And the response carries an X-LangWatch-Heartbeat-Active header
     # Once any byte is on the wire the HTTP status is irrevocably committed
     # to 200 — the same trade-off the streaming path already accepts for
-    # errors that surface mid-stream (see streaming.feature). A client that
-    # inspects the body, not just the status, still gets the accurate
-    # error — a strict improvement over today's 524 with no body at all.
+    # errors that surface mid-stream (see streaming.feature). The header is
+    # the mitigation: its presence on a 200 is the signal for a client that
+    # only checks status to check the body for an error key instead of
+    # trusting the status at face value — a strict improvement over today's
+    # 524 with no body at all.
 
   @unit @regression
   Scenario: a negative heartbeat interval disables the mechanism entirely
@@ -60,5 +65,6 @@ Feature: Non-streaming responses stay warm during slow dispatch
     And a provider that takes longer than a would-be heartbeat tick to complete
     When a client sends a non-streaming chat completion request
     Then no keep-alive byte ever reaches the client before dispatch finishes
-    # Operator kill switch (NON_STREAMING_HEARTBEAT_INTERVAL=-1s) to roll the
-    # fix back without a redeploy.
+    And the response never carries an X-LangWatch-Heartbeat-Active header
+    # Operator kill switch (NON_STREAMING_HEARTBEAT_INTERVAL_SECONDS=-1) to
+    # roll the fix back without a redeploy.

--- a/specs/ai-gateway/non-streaming-time-to-first-byte.feature
+++ b/specs/ai-gateway/non-streaming-time-to-first-byte.feature
@@ -1,0 +1,64 @@
+Feature: Non-streaming responses stay warm during slow dispatch
+  As an operator running the AI Gateway behind an edge proxy (e.g. Cloudflare)
+  I want a slow non-streaming completion to keep the client connection alive
+  So that large-context requests aren't blindsided by the edge's
+  idle-connection timeout (HTTP 524)
+
+  Background:
+    Cloudflare (and similar edge proxies) return HTTP 524 when a connection
+    to the origin is established but receives no response bytes within its
+    idle-connection window (~100s), even though the origin is healthy and
+    still working. The gateway's own timeouts are tuned for minutes-long
+    completions (14 minute upstream ceiling, no WriteTimeout on the Go
+    server — see provider-request-timeout.feature), but that budget alone
+    says nothing about what the *client* sees while dispatch is running: a
+    non-streaming request that takes longer than HeartbeatInterval now gets
+    a keep-alive byte (RFC 8259 §2 insignificant whitespace) written and
+    flushed periodically until dispatch completes.
+
+    # Issue: https://github.com/langwatch/langwatch/issues/4806
+    # Bindings: services/aigateway/adapters/httpapi/nonstreaming_ttfb_test.go
+    # Sender: services/aigateway/adapters/httpapi/router.go (withHeartbeat, writeJSONResponse)
+
+  @unit @regression
+  Scenario: non-streaming client receives zero response bytes for dispatch faster than the heartbeat interval
+    Given a provider that has not yet returned a completion
+    When a client sends a non-streaming chat completion request
+    And dispatch finishes before HeartbeatInterval elapses
+    Then no response bytes, including headers, have reached the client before dispatch finished
+    And the full response is delivered exactly as it always was
+    # Fast requests — the overwhelming majority — are byte-for-byte
+    # unaffected by the heartbeat mechanism below.
+
+  @unit @regression
+  Scenario: dispatch slower than the heartbeat interval keeps the connection warm and still delivers the correct response
+    Given a provider that takes longer than HeartbeatInterval to complete
+    When a client sends a non-streaming chat completion request
+    Then a keep-alive byte reaches the client while dispatch is still in flight
+    And the client's JSON parser still parses the eventual response correctly
+    And once dispatch finishes, the full response is delivered with status 200 and Content-Type application/json
+    # This is the fix for #4806: a large-context completion that legitimately
+    # runs long now keeps producing bytes, so it never goes silent long
+    # enough for an edge proxy to kill the connection.
+
+  @unit @regression
+  Scenario: dispatch that errors after heartbeating has started still delivers a structured error body
+    Given a provider that takes longer than HeartbeatInterval and then fails
+    When a client sends a non-streaming chat completion request
+    Then a keep-alive byte reaches the client while dispatch is still in flight
+    And once dispatch fails, the response status is still 200
+    And the response body is the same structured error envelope a fast failure would have produced
+    # Once any byte is on the wire the HTTP status is irrevocably committed
+    # to 200 — the same trade-off the streaming path already accepts for
+    # errors that surface mid-stream (see streaming.feature). A client that
+    # inspects the body, not just the status, still gets the accurate
+    # error — a strict improvement over today's 524 with no body at all.
+
+  @unit @regression
+  Scenario: a negative heartbeat interval disables the mechanism entirely
+    Given HeartbeatInterval is configured to a negative duration
+    And a provider that takes longer than a would-be heartbeat tick to complete
+    When a client sends a non-streaming chat completion request
+    Then no keep-alive byte ever reaches the client before dispatch finishes
+    # Operator kill switch (NON_STREAMING_HEARTBEAT_INTERVAL=-1s) to roll the
+    # fix back without a redeploy.


### PR DESCRIPTION
## Summary

Large-context requests intermittently return HTTP 524 (Cloudflare edge idle-connection timeout, ~100s) — traced in #4806 to the non-streaming dispatch path (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`, `/v1/embeddings`, and the Gemini `/v1beta` passthrough): the gateway buffers the *entire* response and writes zero bytes — not even headers — to the client until dispatch fully completes. A completion that legitimately takes longer than the edge's idle window has no way to keep the connection alive, even though every backend timeout (14min upstream, 3600s ingress) is already generous.

- Once a dispatch runs longer than `HeartbeatInterval` (default 45s, ~2x margin under Cloudflare's default), the gateway now writes a periodic RFC 8259 §2 insignificant-whitespace byte and flushes it — resetting the edge's idle timer without corrupting the eventual JSON body (every conformant JSON parser skips leading whitespace).
- Requests that finish inside the interval — the overwhelming majority — are byte-for-byte unaffected.
- **Documented trade-off, now mitigated**: once a heartbeat has fired, the HTTP status is irrevocably committed to 200 (net/http sends it implicitly on the first `Write`). If dispatch later errors, the wire status can no longer become the real 4xx/5xx, but the structured error body still reaches the client correctly — the same trade-off the streaming path already accepts for errors that surface mid-stream. The response now also carries `X-LangWatch-Heartbeat-Active: true` (set before the first heartbeat byte, so it survives regardless of outcome) — a client that only checks `response.status` can use its presence on a 200 as the signal to check the body for an `error` key first.
- `NON_STREAMING_HEARTBEAT_INTERVAL_SECONDS=-1` disables the mechanism entirely as an operator kill switch, no redeploy needed.

Closes #4806.

## Deployment Impact

- **Env vars added**: `NON_STREAMING_HEARTBEAT_INTERVAL_SECONDS` (int, seconds) on the AI Gateway service only. Optional — not required in any environment.
- **Helm values**: none added or changed. `charts/gateway/values.yaml` is untouched; this mirrors the existing `MAX_REQUEST_BODY_BYTES` tunable, which also isn't chart-wired, only env-var-configurable with a Go-side default.
- **Default behavior on a vanilla `helm install` / fresh deployment with no overrides**: the heartbeat mechanism is **on by default** at 45s. Any non-streaming chat/messages/responses/embeddings/Gemini-passthrough request that takes longer than 45s to complete will now emit periodic single-byte keep-alive writes to the client before delivering the real response, and the response will carry `X-LangWatch-Heartbeat-Active: true` — this is the actual behavior change operators should know about. It requires no config to get the fix; no action needed on upgrade.
- **BYOC / self-hosted dataplane impact**: self-hosted gateway operators get this fix automatically on upgrade with zero config. The only operator-visible knob is the new env var, which is a rollback lever (`NON_STREAMING_HEARTBEAT_INTERVAL_SECONDS=-1` fully reverts to pre-fix buffering behavior without a redeploy) rather than something anyone needs to set to get the benefit.
- **Client-visible behavior change**: any client that trusts only `response.status` (not the body, not headers) on a request that runs past 45s and then fails will see status 200 with an error-shaped body instead of the real 4xx/5xx. `X-LangWatch-Heartbeat-Active: true` on the response is the mitigation — its presence is a reliable signal to check the body before trusting the status.

## Test plan

- [x] New spec: `specs/ai-gateway/non-streaming-time-to-first-byte.feature` (4 scenarios, all bound)
- [x] `TestRouter_NonStreaming_NoBytesReachClientWhileProviderIsSlow` — documents the fast-path baseline is untouched, including that the new header is absent
- [x] `TestRouter_NonStreaming_HeartbeatKeepsConnectionWarm` — heartbeat fires mid-dispatch, correct final response + Content-Type + `X-LangWatch-Heartbeat-Active`, leading-whitespace body still parses via real `json.Unmarshal`
- [x] `TestRouter_NonStreaming_HeartbeatThenError_StillDeliversStructuredErrorBody` — proves the committed-200 trade-off delivers the correct structured error body plus the mitigating header
- [x] `TestRouter_NonStreaming_HeartbeatDisabled` — negative interval kill switch, including that the header is never set
- [x] `TestRouter_NonStreaming_HeartbeatFiresAcrossEveryRoute` — table test across all 5 non-streaming routes (chat/messages/responses/embeddings/gemini passthrough), catching any per-handler wiring mistake
- [x] `TestRouter_NonStreaming_ConcurrentSlowRequestsDoNotInterfere` — two concurrent slow requests don't leak state into each other
- [x] `TestRouter_NonStreaming_PanicInDispatchDoesNotCrashProcess` — a panic anywhere in dispatch is recovered and surfaced as a 500, not a process crash (caught in independent review, see PR comments)
- [x] `TestRouter_NonStreaming_HeartbeatKeepsRealSocketWarm` — every test above drives the router through `httptest.ResponseRecorder` (in-memory); this one puts it behind `httptest.NewServer` (a real `net/http.Server` on a real loopback TCP port) and a real `*http.Client`, using `httptrace.ClientTrace.GotFirstResponseByte` to capture actual wall-clock time-to-first-byte over the wire while the provider call is still deliberately held open
- [x] Full suite green under `go test -race -count=5`
- [x] `withHeartbeat` and every `heartbeatWriter` method: 100% statement coverage (`go tool cover -func`), verified directly, not just claimed
- [x] `gofmt`, `go vet` clean
- [x] `pnpm check:feature-parity` — all new scenarios bound
- [x] All required merge checks green, including `sdk-python-complete` — its one failure earlier in this PR's history was a transient `insufficient_quota` on CI's OpenAI key (unrelated to this diff), confirmed by watching it pass on retry with no code changes needed

**Caught during review of this PR's own diff**: the header mitigation above shipped with a real bug on its first pass — it was set whenever heartbeating was simply *enabled* (`interval > 0`, true for every request by default) instead of when a heartbeat actually *fired*, which would have put it on every response and made it useless as a signal. Caught immediately by the test suite, fixed to tie it to the first real tick instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable heartbeat keep-alives for slow, non-streaming HTTP requests to improve time-to-first-byte.
  - Gateway now periodically sends a whitespace keep-alive while dispatch is running (default 45s; `0` uses default; negative disables), configurable via `NON_STREAMING_HEARTBEAT_INTERVAL_SECONDS`.
  - Applies to chat, messages, responses, embeddings, and Gemini non-streaming routes; includes `X-LangWatch-Heartbeat-Active`.
- **Tests**
  - Expanded coverage for fast/slow behavior, heartbeat-then-error (structured error delivery), disabled mode, concurrent isolation, and dispatch panic resilience; added real-socket verification.
- **Documentation**
  - Added non-streaming TTFB feature scenarios describing expected keep-alive and configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

