### PR TITLE
fix(docker): ship @langwatch/handled-error in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,16 +67,23 @@ WORKDIR /app
 # Copy built artifacts from builder.
 # mcp-server must be copied alongside langwatch because pnpm workspace
 # symlinks langwatch/node_modules/@langwatch/mcp-server -> ../../../mcp-server.
-# cli-cards is another root workspace package linked the same way and is loaded
-# by migration tasks as well as the running server.
+# cli-cards and handled-error are other root workspace packages linked the same
+# way. Both are loaded by migration tasks as well as the running server —
+# handled-error is imported for side effects by the server and worker entry
+# points, so omitting it fails the boot outright.
 COPY --from=builder /app/langwatch ./langwatch
 COPY --from=builder /app/mcp-server ./mcp-server
 COPY --from=builder /app/packages/cli-cards/package.json ./packages/cli-cards/package.json
 COPY --from=builder /app/packages/cli-cards/src ./packages/cli-cards/src
-# cli-cards deliberately declares zod as a peer. Because the workspace package
-# lives outside /app/langwatch, expose the app's production zod at the nearest
-# shared node_modules boundary after dev dependencies have been pruned.
-RUN mkdir -p ./node_modules && ln -s ../langwatch/node_modules/zod ./node_modules/zod
+COPY --from=builder /app/packages/handled-error/package.json ./packages/handled-error/package.json
+COPY --from=builder /app/packages/handled-error/src ./packages/handled-error/src
+# cli-cards and handled-error deliberately declare zod / @opentelemetry/api as
+# peers. Because the workspace packages live outside /app/langwatch, expose the
+# app's production copies at the nearest shared node_modules boundary after dev
+# dependencies have been pruned.
+RUN mkdir -p ./node_modules/@opentelemetry \
+  && ln -s ../langwatch/node_modules/zod ./node_modules/zod \
+  && ln -s ../../langwatch/node_modules/@opentelemetry/api ./node_modules/@opentelemetry/api
 COPY --from=builder /app/langevals/ts-integration/evaluators.generated.ts ./langevals/ts-integration/evaluators.generated.ts
 COPY --from=builder /app/feature-map.json ./feature-map.json
 

--- a/langwatch/src/__tests__/dockerfile-runtime-workspace-packages.unit.test.ts
+++ b/langwatch/src/__tests__/dockerfile-runtime-workspace-packages.unit.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression guard: the runtime image must ship every root-level workspace
+ * package the app depends on at runtime.
+ *
+ * The builder stage does `COPY packages ./packages`, but the runtime stage
+ * cherry-picks individual packages to keep the image slim. pnpm links these as
+ * `langwatch/node_modules/@langwatch/<name> -> ../../../packages/<name>`, and
+ * that symlink is copied along with `langwatch/`. If the package it points at
+ * is not also copied, the link dangles and the process dies at boot with
+ * `Cannot find module '@langwatch/<name>'` — which is exactly how
+ * `@langwatch/handled-error` broke the workers entry point after it was added
+ * as a root workspace package but never added to the runtime stage.
+ *
+ * Packages under `langwatch/packages/*` are exempt: they ride along with
+ * `COPY --from=builder /app/langwatch ./langwatch`.
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// src/__tests__/ -> ../../ = langwatch/ -> ../../../ = repo root
+const LANGWATCH_DIR = path.join(__dirname, "../..");
+const REPO_ROOT = path.join(LANGWATCH_DIR, "..");
+const DOCKERFILE_PATH = path.join(REPO_ROOT, "Dockerfile");
+const ROOT_PACKAGES_DIR = path.join(REPO_ROOT, "packages");
+
+interface PackageJson {
+  name?: string;
+  dependencies?: Record<string, string>;
+}
+
+const appPkg: PackageJson = JSON.parse(
+  readFileSync(path.join(LANGWATCH_DIR, "package.json"), "utf-8"),
+);
+
+/**
+ * Maps each root-level `packages/<dir>` to its declared package name, so the
+ * dependency list can be matched by name rather than by assuming dir === name.
+ */
+function rootPackagesByName(): Map<string, string> {
+  const byName = new Map<string, string>();
+  for (const dir of readdirSync(ROOT_PACKAGES_DIR)) {
+    const manifest = path.join(ROOT_PACKAGES_DIR, dir, "package.json");
+    if (!existsSync(manifest)) continue;
+    const { name }: PackageJson = JSON.parse(readFileSync(manifest, "utf-8"));
+    if (name) byName.set(name, dir);
+  }
+  return byName;
+}
+
+/**
+ * The runtime stage is everything after the final `FROM` — the builder stages
+ * copy the whole `packages` tree and are not what ships.
+ */
+function runtimeStage(dockerfile: string): string {
+  const lastFrom = [...dockerfile.matchAll(/^FROM .*$/gm)].at(-1);
+  if (lastFrom?.index === undefined) {
+    throw new Error("no FROM instruction found in Dockerfile");
+  }
+  return dockerfile.slice(lastFrom.index);
+}
+
+const stage = runtimeStage(readFileSync(DOCKERFILE_PATH, "utf-8"));
+const rootPackages = rootPackagesByName();
+
+/** Root-level workspace packages the app needs at runtime (prod deps only). */
+const requiredDirs = Object.entries(appPkg.dependencies ?? {})
+  .filter(([, spec]) => spec.startsWith("workspace:"))
+  .map(([name]) => rootPackages.get(name))
+  .filter((dir): dir is string => dir !== undefined);
+
+describe("Dockerfile runtime stage", () => {
+  describe("when the app depends on a root-level workspace package", () => {
+    it("finds the root workspace packages the app depends on", () => {
+      // Guards the guard: if this list ever empties, the assertions below
+      // would vacuously pass and stop protecting anything.
+      expect(requiredDirs).toContain("handled-error");
+      expect(requiredDirs).toContain("cli-cards");
+    });
+
+    it.each(requiredDirs)("copies packages/%s into the runtime image", (dir) => {
+      expect(
+        stage.includes(`/app/packages/${dir}`),
+        `The runtime stage must COPY /app/packages/${dir} — langwatch/node_modules/@langwatch/* symlinks into it, so omitting it makes the app fail at boot with "Cannot find module".`,
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## The bug

Every entry point that imports `handled-error-wiring` dies at boot in the built image:

```
Error: Cannot find module '@langwatch/handled-error'
Require stack:
- /app/langwatch/langwatch/src/server/handled-error-wiring.ts
- /app/langwatch/langwatch/src/workers.ts
```

## Why

The runtime stage cherry-picks root workspace packages to keep the image slim (#5696), copying only `packages/cli-cards`. When #5917 added `packages/handled-error` as a root workspace package, the runtime stage was never updated.

pnpm links it as `langwatch/node_modules/@langwatch/handled-error -> ../../../packages/handled-error`. That symlink **does** ship, because it rides along with `COPY --from=builder /app/langwatch ./langwatch` — so the failure is a dangling link, not a missing one. The builder stage is fine (`COPY packages ./packages`), which is why this only shows up at runtime.

## The fix

- Copy `packages/handled-error/{package.json,src}` into the runtime stage.
- Hoist `@opentelemetry/api` into `/app/node_modules` beside the existing `zod` symlink. `handled-error` declares it as a peer, and since the package lives outside `/app/langwatch`, Node walks up to `/app/node_modules` to find it — the same trick already used for cli-cards' `zod` peer.

## Verification

- Simulated the image layout and confirmed all three links resolve, and that Node actually resolves `@opentelemetry/api` from inside `packages/handled-error` via the hoisted symlink.
- Added `dockerfile-runtime-workspace-packages.unit.test.ts`. It derives the required set from langwatch's own `workspace:*` prod dependencies mapped to root `packages/*` dirs — not a hardcoded list — so the next root workspace package can't silently repeat this. Packages under `langwatch/packages/*` are correctly exempt.
- Confirmed the test **fails** against the pre-fix Dockerfile and passes after, rather than just asserting it goes green.

A full image build was not run locally; CI's build is the remaining end-to-end check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime packaging to include all required workspace packages, preventing missing-package errors in deployed environments.
  * Added support for resolving OpenTelemetry API dependencies alongside existing shared dependencies.

* **Tests**
  * Added regression coverage to verify that all workspace dependencies are included in the runtime image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->