### PR TITLE
fix(tests): stop analytics fixtures aging past the retention TTL

### DIFF
--- a/langwatch/src/server/app-layer/analytics/__tests__/evaluation-analytics.integration.test.ts
+++ b/langwatch/src/server/app-layer/analytics/__tests__/evaluation-analytics.integration.test.ts
@@ -29,7 +29,11 @@ import type { EvaluationAnalyticsRollupRow } from "~/server/event-sourcing/pipel
 
 const tenantId = `test-eval-${nanoid()}`;
 
-const bucketMs = new Date("2026-06-15T12:00:00.000Z").getTime();
+// Minute-aligned "yesterday", never a fixed calendar date: inserts are stamped
+// with PLATFORM_DEFAULT_RETENTION_DAYS (49) and the tables TTL-delete rows
+// `_retention_days` after BucketStart/OccurredAt, so a fixed date eventually
+// ages past the horizon and the fixtures silently vanish before the reads.
+const bucketMs = Math.floor((Date.now() - 24 * 60 * 60 * 1000) / 60_000) * 60_000;
 const bucketStart = new Date(bucketMs);
 
 let ch: ClickHouseClient;

--- a/langwatch/src/server/app-layer/analytics/__tests__/route-table.integration.test.ts
+++ b/langwatch/src/server/app-layer/analytics/__tests__/route-table.integration.test.ts
@@ -39,7 +39,11 @@ import type { AnalyticsTimeseriesBuilderInput } from "../types";
 const tenantId = `test-router-${generate("tenant").toString()}`;
 
 // All seeded rows land in one minute bucket so the rollup collapses cleanly.
-const bucketMs = new Date("2026-06-15T12:00:00.000Z").getTime();
+// Minute-aligned "yesterday", never a fixed calendar date: inserts are stamped
+// with PLATFORM_DEFAULT_RETENTION_DAYS (49) and the tables TTL-delete rows
+// `_retention_days` after BucketStart/OccurredAt, so a fixed date eventually
+// ages past the horizon and the fixtures silently vanish before the reads.
+const bucketMs = Math.floor((Date.now() - 24 * 60 * 60 * 1000) / 60_000) * 60_000;
 const bucketStart = new Date(bucketMs);
 
 let ch: ClickHouseClient;

--- a/langwatch/src/server/clickhouse/__tests__/trace-analytics-rollup.integration.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/trace-analytics-rollup.integration.test.ts
@@ -36,7 +36,11 @@ import type { TraceAnalyticsRollupRow } from "~/server/event-sourcing/pipelines/
 const tenantId = `test-rollup-${generate("tenant").toString()}`;
 // All spans below land in one minute bucket so the rollup collapses to a
 // single (TenantId, BucketStart, Model, SpanType) group per distinct dim pair.
-const baseMs = new Date("2026-06-01T12:00:00.000Z").getTime();
+// Minute-aligned "yesterday", never a fixed calendar date: inserts are stamped
+// with PLATFORM_DEFAULT_RETENTION_DAYS (49) and the table TTL-deletes rows
+// `_retention_days` after BucketStart, so a fixed date eventually ages past
+// the horizon and the fixtures silently vanish before the reads.
+const baseMs = Math.floor((Date.now() - 24 * 60 * 60 * 1000) / 60_000) * 60_000;
 const bucketStart = new Date(baseMs);
 
 let ch: ClickHouseClient;

--- a/langwatch/src/server/clickhouse/__tests__/trace-analytics.integration.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/trace-analytics.integration.test.ts
@@ -46,7 +46,11 @@ let ch: ClickHouseClient;
 let analyticsRepo: TraceAnalyticsClickHouseRepository;
 let summaryRepo: TraceSummaryClickHouseRepository;
 
-const baseMs = new Date("2026-06-15T12:00:00.000Z").getTime();
+// Minute-aligned "yesterday", never a fixed calendar date: inserts are stamped
+// with PLATFORM_DEFAULT_RETENTION_DAYS (49) and the table TTL-deletes rows
+// `_retention_days` after OccurredAt, so a fixed date eventually ages past the
+// horizon and the fixtures silently vanish before the reads.
+const baseMs = Math.floor((Date.now() - 24 * 60 * 60 * 1000) / 60_000) * 60_000;
 
 function makeAnalyticsRow(
   overrides: Partial<TraceAnalyticsRow> = {},


### PR DESCRIPTION
## What broke

`langwatch-app-ci` → `test-integration (6)` started failing on main (and every branch, including #5930) today at exactly 12:00 UTC, with `trace-analytics-rollup.integration.test.ts` reading back `costSum: 0` / `spanCount: 0`.

Nothing that merged today caused it — main was green at 10:27 UTC and red at 12:36 UTC with only a Dockerfile-only change (#5967) in between. In particular the OTLP metric/log pipelines PR (#5945) is unrelated; its own merge commit ran green.

## Root cause

The test pins its fixture bucket to a fixed calendar date:

```ts
const baseMs = new Date("2026-06-01T12:00:00.000Z").getTime();
```

`TraceAnalyticsRollupClickHouseRepository` stamps inserts with `PLATFORM_DEFAULT_RETENTION_DAYS = 49`, and migration 00038 gives the table a per-row TTL of `BucketStart + _retention_days` days.

**2026-06-01T12:00Z + 49 days = 2026-07-20T12:00Z** — today at noon UTC the fixture crossed its own TTL horizon. Rows now insert already expired, ClickHouse drops them when the part merges, and the reads sum to zero. The calendar pulled the trigger, not a commit.

## Fix

Switch the base timestamp in the four analytics integration tests that write into TTL-managed tables to a minute-aligned "yesterday" (`Date.now()` minus a day, floored to the minute), so fixtures can never age out. All in-file offsets are relative, and no assertion depends on an absolute date.

- `trace-analytics-rollup.integration.test.ts` — the one failing now (pinned 2026-06-01)
- `trace-analytics.integration.test.ts`, `evaluation-analytics.integration.test.ts`, `route-table.integration.test.ts` — pinned 2026-06-15; same bomb, fuse runs out **2026-08-03**

Left alone: `monitor-pass-rate.integration.test.ts` pins July 2026 dates but inserts raw JSONEachRow without `_retention_days`, so it rides the 308-day column default (safe until ~May 2027). Governance KPI tests insert into a table with no TTL.

## Verification

All four files run green locally against the real ClickHouse testcontainer: **4 files, 17 tests passed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved analytics integration test reliability by using runtime-relative, minute-aligned timestamps instead of fixed calendar dates.
  * Ensured test data remains available during validation while still exercising retention behavior consistently over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->