### PR TITLE
fix(ci): pre-warm the Go toolchain in e2e-ci so the API lane isn't starved at boot

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -178,6 +178,23 @@ jobs:
             agentic-e2e-tests/pnpm-lock.yaml
             mcp-server/pnpm-lock.yaml
 
+      # start.sh auto-starts the aigateway + nlpgo Go services via
+      # `go run ./cmd/service`. Without a Go toolchain + warm caches, both
+      # lanes cold-download the toolchain and the full module graph while
+      # tsx is booting the API server — starving it past global-setup's
+      # 60s readiness window on the 2-core runner (intermittent
+      # "API not ready ... backend never served publicEnv" failures).
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      # Compile the service dispatcher (imports both aigateway and nlpgo)
+      # up front so the auto-start lanes' `go run` during `pnpm start` is a
+      # warm-cache no-op and the API lane keeps the CPU while it boots.
+      - name: Pre-build Go services
+        run: go build -o /dev/null ./cmd/service
+
       # node-pty@1.1.0 only ships prebuilds for darwin/win32, so on Linux
       # its postinstall always falls back to `node-gyp rebuild`. With
       # pnpm/action-setup v6's npm-bootstrap path, node-gyp isn't on PATH


### PR DESCRIPTION
## Problem

e2e-ci fails intermittently across unrelated branches with:

```
❌ API not ready at http://localhost:5570/api/trpc/publicEnv?... after 30 attempts.
The app shell loaded but the backend never served publicEnv.
```

Example: [run 29744900589](https://github.com/langwatch/langwatch/actions/runs/29744900589/job/88360416986) on `rebase-5902-port`; same-day identical failures on `feat/agent-skills-revamp` (green on retry) and `fix/analytics-test-ttl-timebomb`.

## Root cause

The job starts the app with `NODE_ENV=development pnpm start`, so start.sh auto-starts the **aigateway** and **nlpgo** lanes via `make service` → `go run ./cmd/service`. The workflow has no `setup-go` step and no Go cache, so both lanes simultaneously cold-download the go1.26.2 toolchain plus the entire module graph (Bifrost, AWS SDK, OTel collector, …) and compile it — right while `tsx src/server.mts` is doing a cold transpile of the server on the same 2-core runner. On unlucky runs the `[api]` lane never gets a slot: the failing log has **zero** `[api]` output across the whole 60s readiness window (30 × 2s in `agentic-e2e-tests/tests/global-setup.ts`), and vite's `/api` proxy returns 502/ECONNREFUSED until the check gives up.

## Fix

Two steps added before the app boots:

1. **Setup Go** — `actions/setup-go` (SHA-pinned, v7.0.0) with `go-version-file: go.mod`; its built-in cache (keyed on the root `go.sum`) persists the module + build caches across runs.
2. **Pre-build Go services** — `go build -o /dev/null ./cmd/service`. The dispatcher imports both `services/aigateway` and `services/nlpgo`, so this single build warms everything. Even on a cache-miss run the download/compile now happens *before* `pnpm start`, not during the API readiness race.

No test-code changes; `global-setup.ts`'s 60s window is untouched (can be bumped separately if starvation ever reappears in another form).