### PR TITLE
fix(langy): refresh open conversation on turns it did not initiate

### DIFF
--- a/langwatch/src/features/langy/components/LangyPanel.tsx
+++ b/langwatch/src/features/langy/components/LangyPanel.tsx
@@ -76,6 +76,7 @@ import { useLangyConversationCommands } from "../data/useLangyConversationComman
 import { useLangyMessages } from "../data/useLangyMessages";
 import type { LangyMessageDto } from "../data/langy.dtos";
 import { useLangyFreshness } from "../hooks/useLangyFreshness";
+import { shouldRehydrateEngineFromDurable } from "../logic/foreignTurnRehydration";
 import {
   createLangyChatTransport,
   type LangyTurnRequestContext,
@@ -756,6 +757,45 @@ function LangyPanel({
       applyHistoryToEngine([]);
     }
   }, [activeConversationId, applyHistoryToEngine]);
+
+  // Foreign-turn re-hydration. A turn this client did NOT drive (another tab, a
+  // recovered/again-driven turn, a programmatic caller) grows the open
+  // conversation's durable history; `useLangyFreshness` invalidates the
+  // `langy.messages` query on the id-only signal. Reflect that growth in the
+  // engine so the open thread updates without a manual refresh — the engine is
+  // what renders, and the user-selection gate above only re-hydrates on an
+  // explicit open. Three guards keep it from clobbering the live path:
+  //   - a pending user selection owns the engine — let that effect apply it;
+  //   - a live self-driven turn (submitted/streaming) owns the engine;
+  //   - apply ONLY when durable is AHEAD of the engine, never shrinking it, so a
+  //     momentarily-stale refetch at a turn's settle boundary can't flash the
+  //     pre-answer history.
+  useEffect(() => {
+    const durableCount = historyMessages.filter(
+      (m) => m.role === "user" || m.role === "assistant",
+    ).length;
+    if (
+      !shouldRehydrateEngineFromDurable({
+        historyLoadPending: historyLoadConversationId !== null,
+        isStreaming: status === "submitted" || status === "streaming",
+        isFetchingHistory,
+        hasActiveConversation: activeConversationId !== null,
+        durableMessageCount: durableCount,
+        engineMessageCount: messages.length,
+      })
+    ) {
+      return;
+    }
+    applyHistoryToEngine(historyMessages);
+  }, [
+    historyLoadConversationId,
+    status,
+    isFetchingHistory,
+    activeConversationId,
+    historyMessages,
+    messages.length,
+    applyHistoryToEngine,
+  ]);
 
   // A failed recents list surfaces INSIDE the panel as a dismissable Langy
   // domain-error card — never a toast: the panel is open (a closed panel

--- a/langwatch/src/features/langy/components/LangyPanel.tsx
+++ b/langwatch/src/features/langy/components/LangyPanel.tsx
@@ -758,15 +758,18 @@ function LangyPanel({
     }
   }, [activeConversationId, applyHistoryToEngine]);
 
+  const isBusy = status === "submitted" || status === "streaming";
+
   // Foreign-turn re-hydration. A turn this client did NOT drive (another tab, a
   // recovered/again-driven turn, a programmatic caller) grows the open
   // conversation's durable history; `useLangyFreshness` invalidates the
   // `langy.messages` query on the id-only signal. Reflect that growth in the
   // engine so the open thread updates without a manual refresh — the engine is
   // what renders, and the user-selection gate above only re-hydrates on an
-  // explicit open. Three guards keep it from clobbering the live path:
+  // explicit open. Four guards keep it from clobbering the live path:
   //   - a pending user selection owns the engine — let that effect apply it;
   //   - a live self-driven turn (submitted/streaming) owns the engine;
+  //   - a refetch in flight (isFetchingHistory) — wait for it to settle;
   //   - apply ONLY when durable is AHEAD of the engine, never shrinking it, so a
   //     momentarily-stale refetch at a turn's settle boundary can't flash the
   //     pre-answer history.
@@ -777,7 +780,7 @@ function LangyPanel({
     if (
       !shouldRehydrateEngineFromDurable({
         isHistoryLoadPending: historyLoadConversationId !== null,
-        isStreaming: status === "submitted" || status === "streaming",
+        isStreaming: isBusy,
         isFetchingHistory,
         hasActiveConversation: activeConversationId !== null,
         durableMessageCount: durableCount,
@@ -789,7 +792,7 @@ function LangyPanel({
     applyHistoryToEngine(historyMessages);
   }, [
     historyLoadConversationId,
-    status,
+    isBusy,
     isFetchingHistory,
     activeConversationId,
     historyMessages,
@@ -825,7 +828,6 @@ function LangyPanel({
   // and the open conversation's status stay fresh without heavy polling.
   useLangyFreshness(activeConversationId);
 
-  const isBusy = status === "submitted" || status === "streaming";
   const [queuedMessages, setQueuedMessages] = useState<string[]>([]);
   const canDrainQueuedMessages = !isBusy && !serverTurnInFlight;
   const isEmpty = messages.length === 0;

--- a/langwatch/src/features/langy/components/LangyPanel.tsx
+++ b/langwatch/src/features/langy/components/LangyPanel.tsx
@@ -776,7 +776,7 @@ function LangyPanel({
     ).length;
     if (
       !shouldRehydrateEngineFromDurable({
-        historyLoadPending: historyLoadConversationId !== null,
+        isHistoryLoadPending: historyLoadConversationId !== null,
         isStreaming: status === "submitted" || status === "streaming",
         isFetchingHistory,
         hasActiveConversation: activeConversationId !== null,

--- a/langwatch/src/features/langy/hooks/__tests__/useLangyFreshness.unit.test.ts
+++ b/langwatch/src/features/langy/hooks/__tests__/useLangyFreshness.unit.test.ts
@@ -75,6 +75,7 @@ describe("useLangyFreshness", () => {
         renderHook(() => useLangyFreshness("conv_open"));
         capturedOnUpdate?.([signal("conv_open")]);
 
+        expect(listCancel).toHaveBeenCalledTimes(1);
         expect(listInvalidate).toHaveBeenCalledTimes(1);
       });
     });
@@ -91,6 +92,7 @@ describe("useLangyFreshness", () => {
         renderHook(() => useLangyFreshness("conv_open"));
         capturedOnUpdate?.([signal("conv_other")]);
 
+        expect(listCancel).toHaveBeenCalledTimes(1);
         expect(listInvalidate).toHaveBeenCalledTimes(1);
       });
     });
@@ -103,6 +105,7 @@ describe("useLangyFreshness", () => {
         capturedOnUpdate?.([signal("conv_any")]);
 
         expect(messagesInvalidate).not.toHaveBeenCalled();
+        expect(listCancel).toHaveBeenCalledTimes(1);
         expect(listInvalidate).toHaveBeenCalledTimes(1);
       });
     });

--- a/langwatch/src/features/langy/hooks/__tests__/useLangyFreshness.unit.test.ts
+++ b/langwatch/src/features/langy/hooks/__tests__/useLangyFreshness.unit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The freshness coordinator's contract: the broadcast signal is ID-ONLY, so a
+ * signal naming the OPEN conversation must invalidate its `langy.messages`
+ * query (the durable fold the panel re-hydrates from) — the only wake-up a tab
+ * with no live turn stream gets for a turn it did not initiate. The recents
+ * list always refetches through the server visibility gate.
+ */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LangyConversationUpdateSignal } from "../../data/langy.dtos";
+
+const PROJECT_ID = "project_test";
+
+const messagesInvalidate = vi.fn(() => Promise.resolve());
+const listInvalidate = vi.fn(() => Promise.resolve());
+const listCancel = vi.fn(() => Promise.resolve());
+
+// Capture the callback the hook hands to the SSE listener so a test can drive a
+// signal batch through the real hook logic.
+let capturedOnUpdate:
+  | ((signals: LangyConversationUpdateSignal[]) => void)
+  | null = null;
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { id: PROJECT_ID } }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({
+      langy: {
+        messages: { invalidate: messagesInvalidate },
+        list: { cancel: listCancel, invalidate: listInvalidate },
+      },
+    }),
+  },
+}));
+
+vi.mock("../useLangyConversationUpdateListener", () => ({
+  useLangyConversationUpdateListener: (opts: {
+    onConversationUpdated: (s: LangyConversationUpdateSignal[]) => void;
+  }) => {
+    capturedOnUpdate = opts.onConversationUpdated;
+  },
+}));
+
+import { useLangyFreshness } from "../useLangyFreshness";
+
+const signal = (conversationId: string): LangyConversationUpdateSignal =>
+  ({ conversationId }) as LangyConversationUpdateSignal;
+
+describe("useLangyFreshness", () => {
+  beforeEach(() => {
+    messagesInvalidate.mockClear();
+    listInvalidate.mockClear();
+    listCancel.mockClear();
+    capturedOnUpdate = null;
+  });
+
+  describe("given a conversation is open", () => {
+    describe("when a signal names the open conversation", () => {
+      it("invalidates that conversation's messages", () => {
+        renderHook(() => useLangyFreshness("conv_open"));
+        capturedOnUpdate?.([signal("conv_open")]);
+
+        expect(messagesInvalidate).toHaveBeenCalledWith({
+          projectId: PROJECT_ID,
+          conversationId: "conv_open",
+        });
+      });
+
+      it("also refetches the recents list", () => {
+        renderHook(() => useLangyFreshness("conv_open"));
+        capturedOnUpdate?.([signal("conv_open")]);
+
+        expect(listInvalidate).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when a signal names a different conversation", () => {
+      it("does not invalidate the open conversation's messages", () => {
+        renderHook(() => useLangyFreshness("conv_open"));
+        capturedOnUpdate?.([signal("conv_other")]);
+
+        expect(messagesInvalidate).not.toHaveBeenCalled();
+      });
+
+      it("still refetches the recents list", () => {
+        renderHook(() => useLangyFreshness("conv_open"));
+        capturedOnUpdate?.([signal("conv_other")]);
+
+        expect(listInvalidate).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("given no conversation is open", () => {
+    describe("when a signal arrives", () => {
+      it("refetches the list without invalidating any messages", () => {
+        renderHook(() => useLangyFreshness(null));
+        capturedOnUpdate?.([signal("conv_any")]);
+
+        expect(messagesInvalidate).not.toHaveBeenCalled();
+        expect(listInvalidate).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/langwatch/src/features/langy/hooks/useLangyFreshness.ts
+++ b/langwatch/src/features/langy/hooks/useLangyFreshness.ts
@@ -1,11 +1,7 @@
 import { useCallback } from "react";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
-import type {
-  LangyConversationListItemDto,
-  LangyConversationUpdateSignal,
-} from "../data/langy.dtos";
-import { getLangyConversationListInput } from "../data/useLangyConversationListQuery";
+import type { LangyConversationUpdateSignal } from "../data/langy.dtos";
 import { useLangyConversationUpdateListener } from "./useLangyConversationUpdateListener";
 
 /**
@@ -14,16 +10,23 @@ import { useLangyConversationUpdateListener } from "./useLangyConversationUpdate
  * / detail consumer (tRPC subscriptions aren't deduped across hook instances —
  * one-per-consumer would starve the browser's connection pool).
  *
- * Perceived-latency optimization (per product direction): the freshness signal
- * carries the low-sensitivity operational spine the worker already holds, so we
- * APPLY it in place with `setInfiniteData` and skip a database round-trip. We only
- * fall back to cancel()+invalidate() when:
- *   - the conversation isn't already in the (server-filtered) list cache — a
- *     new/foreign conversation must go through the server visibility gate, or
- *   - the signal carries no operational payload.
- * The result: instant for the conversation you're looking at, correct for
- * everything else. Content-derived fields (title, messages) are never on the
- * wire, so a title change also routes through invalidate.
+ * Contract: the freshness signal is ID-ONLY. The broadcast subscriber
+ * (`langy-conversation-update-broadcast.subscriber.ts`) deliberately lets "no
+ * folded conversation state cross" its port — no status, no counts, no content
+ * ride the wire, only the `conversationId`. So this coordinator is pure
+ * signal-then-refetch (`specs/langy/langy-frontend-realtime.feature`): a signal
+ * says "conversation X changed", and we invalidate the queries it affects and
+ * let the server re-decide visibility. We never try to apply pushed state in
+ * place — there is none to apply.
+ *
+ * Two queries are affected by a signal:
+ *   - the recents LIST (title / counts / ordering) — always refetched, once per
+ *     debounced batch, through the server visibility gate;
+ *   - the OPEN conversation's MESSAGES, when a signal names it — refetched so a
+ *     turn it did not itself initiate (another tab, a recovered/again-driven
+ *     turn, a programmatic caller) still lands. Without this the open thread has
+ *     no live turn stream to attach to and stays stale until a remount. The
+ *     panel re-hydrates its engine from this query when it is not mid-stream.
  */
 export function useLangyFreshness(activeConversationId: string | null): void {
   const { project } = useOrganizationTeamProject();
@@ -34,86 +37,19 @@ export function useLangyFreshness(activeConversationId: string | null): void {
       const projectId = project?.id;
       if (!projectId) return;
 
-      const listInput = getLangyConversationListInput(projectId);
-      const known = new Set(
-        (
-          trpcUtils.langy.list
-            .getInfiniteData(listInput)
-            ?.pages.flatMap((page) => page.items) ?? []
-        ).map((item) => item.id),
-      );
-
-      let needsListRefetch = false;
-
       for (const signal of signals) {
-        const hasOperationalPayload =
-          signal.status !== undefined ||
-          signal.messageCount !== undefined ||
-          signal.lastActivityAtMs !== undefined;
-
-        // A title change carries no title text on the wire (privacy), so an
-        // in-place apply can't pick it up — force a visibility-gated refetch
-        // that re-reads the new title from the server.
-        if (
-          known.has(signal.conversationId) &&
-          hasOperationalPayload &&
-          !signal.titleChanged
-        ) {
-          // Apply in place — no network round-trip.
-          trpcUtils.langy.list.setInfiniteData(listInput, (old) => {
-            if (!old) return old;
-            return {
-              ...old,
-              pages: old.pages.map((page) => ({
-                ...page,
-                items: page.items.map((item) =>
-                  item.id === signal.conversationId
-                    ? applySignal(item, signal)
-                    : item,
-                ),
-              })),
-            };
+        if (signal.conversationId === activeConversationId) {
+          void trpcUtils.langy.messages.invalidate({
+            projectId,
+            conversationId: signal.conversationId,
           });
-
-          // Patch the open conversation's detail cache too so its status
-          // (running/idle/failed) reflects immediately.
-          if (signal.conversationId === activeConversationId) {
-            // A terminal status must also refresh the MESSAGES query — its
-            // `isTurnInFlight` keeps the thinking line mounted, and this
-            // signal is the only wake-up a tab with no live turn stream gets
-            // (e.g. reloaded mid-turn). Invalidate, not setData: the durable
-            // answer parts ride the same query.
-            if (signal.status === "idle" || signal.status === "failed") {
-              void trpcUtils.langy.messages.invalidate({
-                projectId,
-                conversationId: signal.conversationId,
-              });
-            }
-            trpcUtils.langy.detail.setData(
-              { projectId, conversationId: signal.conversationId },
-              (old) =>
-                old
-                  ? {
-                      ...old,
-                      status: signal.status ?? old.status,
-                      messageCount: signal.messageCount ?? old.messageCount,
-                      lastActivityAtMs:
-                        signal.lastActivityAtMs ?? old.lastActivityAtMs,
-                    }
-                  : old,
-            );
-          }
-        } else {
-          // Unknown conversation (new / foreign) or no payload — let the
-          // server re-decide visibility via a refetch.
-          needsListRefetch = true;
         }
       }
 
-      if (needsListRefetch) {
-        void trpcUtils.langy.list.cancel();
-        void trpcUtils.langy.list.invalidate();
-      }
+      // The list carries no content and the signal no spine, so a change always
+      // routes through a single server-gated refetch per debounced batch.
+      void trpcUtils.langy.list.cancel();
+      void trpcUtils.langy.list.invalidate();
     },
     [trpcUtils, project?.id, activeConversationId],
   );
@@ -125,16 +61,4 @@ export function useLangyFreshness(activeConversationId: string | null): void {
     debounceMs: 1500,
     maxWaitMs: 1500,
   });
-}
-
-/** Patch a list item with a freshness signal's operational fields. */
-function applySignal(
-  item: LangyConversationListItemDto,
-  signal: LangyConversationUpdateSignal,
-): LangyConversationListItemDto {
-  return {
-    ...item,
-    messageCount: signal.messageCount ?? item.messageCount,
-    lastActivityAtMs: signal.lastActivityAtMs ?? item.lastActivityAtMs,
-  };
 }

--- a/langwatch/src/features/langy/logic/__tests__/foreignTurnRehydration.unit.test.ts
+++ b/langwatch/src/features/langy/logic/__tests__/foreignTurnRehydration.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { shouldRehydrateEngineFromDurable } from "../foreignTurnRehydration";
+
+// A steady-state, idle, active conversation whose durable fold has grown past
+// the engine — the case that MUST re-hydrate. Each test overrides one field to
+// prove a single guard.
+const rehydrating = {
+  historyLoadPending: false,
+  isStreaming: false,
+  isFetchingHistory: false,
+  hasActiveConversation: true,
+  durableMessageCount: 2,
+  engineMessageCount: 0,
+} as const;
+
+describe("shouldRehydrateEngineFromDurable", () => {
+  describe("given an idle open conversation whose durable fold has grown", () => {
+    it("re-hydrates the engine", () => {
+      expect(shouldRehydrateEngineFromDurable(rehydrating)).toBe(true);
+    });
+  });
+
+  describe("when a user selection is loading", () => {
+    it("defers to the selection effect and does not re-hydrate", () => {
+      expect(
+        shouldRehydrateEngineFromDurable({
+          ...rehydrating,
+          historyLoadPending: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("when a live self-driven turn is streaming", () => {
+    it("leaves the engine to the live stream", () => {
+      expect(
+        shouldRehydrateEngineFromDurable({
+          ...rehydrating,
+          isStreaming: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("when the durable messages query is mid-refetch", () => {
+    it("waits for fresh data before comparing", () => {
+      expect(
+        shouldRehydrateEngineFromDurable({
+          ...rehydrating,
+          isFetchingHistory: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("when no conversation is open", () => {
+    it("does not re-hydrate", () => {
+      expect(
+        shouldRehydrateEngineFromDurable({
+          ...rehydrating,
+          hasActiveConversation: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("given the durable fold is not ahead of the engine", () => {
+    describe("when the counts are equal", () => {
+      it("does not re-hydrate", () => {
+        expect(
+          shouldRehydrateEngineFromDurable({
+            ...rehydrating,
+            durableMessageCount: 2,
+            engineMessageCount: 2,
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe("when the durable fold is momentarily behind the engine", () => {
+      it("never shrinks the engine, avoiding the settle-boundary flash", () => {
+        expect(
+          shouldRehydrateEngineFromDurable({
+            ...rehydrating,
+            durableMessageCount: 1,
+            engineMessageCount: 2,
+          }),
+        ).toBe(false);
+      });
+    });
+  });
+});

--- a/langwatch/src/features/langy/logic/__tests__/foreignTurnRehydration.unit.test.ts
+++ b/langwatch/src/features/langy/logic/__tests__/foreignTurnRehydration.unit.test.ts
@@ -5,7 +5,7 @@ import { shouldRehydrateEngineFromDurable } from "../foreignTurnRehydration";
 // the engine — the case that MUST re-hydrate. Each test overrides one field to
 // prove a single guard.
 const rehydrating = {
-  historyLoadPending: false,
+  isHistoryLoadPending: false,
   isStreaming: false,
   isFetchingHistory: false,
   hasActiveConversation: true,
@@ -25,7 +25,7 @@ describe("shouldRehydrateEngineFromDurable", () => {
       expect(
         shouldRehydrateEngineFromDurable({
           ...rehydrating,
-          historyLoadPending: true,
+          isHistoryLoadPending: true,
         }),
       ).toBe(false);
     });

--- a/langwatch/src/features/langy/logic/foreignTurnRehydration.ts
+++ b/langwatch/src/features/langy/logic/foreignTurnRehydration.ts
@@ -22,7 +22,7 @@
  */
 export function shouldRehydrateEngineFromDurable(params: {
   /** A user selection/switch is loading — that effect owns the engine. */
-  historyLoadPending: boolean;
+  isHistoryLoadPending: boolean;
   /** A live self-driven turn (useChat submitted/streaming) owns the engine. */
   isStreaming: boolean;
   /** The durable messages query is mid-refetch; wait for fresh data. */
@@ -33,7 +33,7 @@ export function shouldRehydrateEngineFromDurable(params: {
   /** messages currently held by the useChat engine. */
   engineMessageCount: number;
 }): boolean {
-  if (params.historyLoadPending) return false;
+  if (params.isHistoryLoadPending) return false;
   if (params.isStreaming) return false;
   if (params.isFetchingHistory) return false;
   if (!params.hasActiveConversation) return false;

--- a/langwatch/src/features/langy/logic/foreignTurnRehydration.ts
+++ b/langwatch/src/features/langy/logic/foreignTurnRehydration.ts
@@ -1,0 +1,41 @@
+/**
+ * Decides whether the Langy panel should re-hydrate its useChat engine from the
+ * durable `langy.messages` fold.
+ *
+ * The rendered thread IS the engine, and it is normally hydrated only on an
+ * explicit user selection so a background refetch can never clobber a live
+ * in-flight stream. That leaves a gap: a turn this client did NOT drive (another
+ * tab, a recovered/again-driven turn, a programmatic caller) grows the durable
+ * fold — via the id-only freshness signal that invalidates `langy.messages` —
+ * but nothing pushes that growth into the engine, so the open thread stays stale
+ * until a remount.
+ *
+ * This predicate closes that gap safely. It returns true only when it is certain
+ * the engine is NOT owned by the live path and the durable fold genuinely has
+ * more to show:
+ *   - a pending user selection owns the engine — that effect will apply it;
+ *   - a live self-driven turn (submitted/streaming) owns the engine;
+ *   - a refetch in flight — wait for it to settle before comparing;
+ *   - AHEAD-ONLY: apply only when durable has more messages than the engine,
+ *     never shrinking it. A momentarily-stale refetch at a turn's settle
+ *     boundary would otherwise flash the pre-answer history.
+ */
+export function shouldRehydrateEngineFromDurable(params: {
+  /** A user selection/switch is loading — that effect owns the engine. */
+  historyLoadPending: boolean;
+  /** A live self-driven turn (useChat submitted/streaming) owns the engine. */
+  isStreaming: boolean;
+  /** The durable messages query is mid-refetch; wait for fresh data. */
+  isFetchingHistory: boolean;
+  hasActiveConversation: boolean;
+  /** user+assistant messages in the durable fold. */
+  durableMessageCount: number;
+  /** messages currently held by the useChat engine. */
+  engineMessageCount: number;
+}): boolean {
+  if (params.historyLoadPending) return false;
+  if (params.isStreaming) return false;
+  if (params.isFetchingHistory) return false;
+  if (!params.hasActiveConversation) return false;
+  return params.durableMessageCount > params.engineMessageCount;
+}

--- a/langwatch/src/server/app-layer/langy/__tests__/langy-conversation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-conversation.service.unit.test.ts
@@ -33,6 +33,7 @@ function makeRepo(
     findActiveOwnedIds: vi.fn(async () => []),
     findPendingHandoff: vi.fn(async () => null),
     findRunToken: vi.fn(async () => null),
+    turnExists: vi.fn(async () => false),
   };
   return { ...defaults, ...overrides };
 }


### PR DESCRIPTION
Fixes #5974

## Problem

An open Langy conversation did not refresh when a turn it did not itself initiate landed — the message thread stayed stale until a full page refresh. The sidebar list updated; only the open thread went stale.

## Root cause

A client/server contract mismatch on the freshness signal.

- The broadcast is **id-only by design**: `langy-conversation-update-broadcast.subscriber.ts` deliberately lets *"no folded conversation state cross"* its port — the payload is just `{conversationId}`.
- `useLangyFreshness` was written expecting an operational **spine** (`status`/`messageCount`/`lastActivityAtMs`) on that signal. Since the server never sends it, `hasOperationalPayload` was always false and the branch that refreshed the open thread was dead — every signal fell through to a list-only refetch.
- The rendered thread is the **useChat engine**, hydrated only on an explicit user selection (to protect a live stream), so even invalidating `langy.messages` would not repaint it.

## Fix (client-only, no server change)

1. **`useLangyFreshness`** — honor the id-only contract: on a signal naming the open conversation, invalidate `langy.messages` unconditionally; the list always refetches through the server visibility gate. Removed the dead spine path.
2. **`LangyPanel`** — a guarded re-hydration effect applies the durable fold to the engine when neither a user selection nor a live self-driven turn owns it, and **only when the fold is ahead of the engine** (never shrinking it — this avoids a settle-boundary flash of pre-answer history). The decision is an extracted pure predicate, `shouldRehydrateEngineFromDurable`.

Aligned with the event-driven architecture: the projection-independent broadcast (ADR-049) and the `signal-then-refetch` contract (`specs/langy/langy-frontend-realtime.feature`) stay intact; this makes the client honor them.

## Scope

Covers every client that watches a turn it did not drive: multi-tab (same user), stream reconnect, recovered / again-driven turns, and programmatic callers. One defect, one path.

## Tests

- `foreignTurnRehydration.unit.test.ts` — the predicate's guards (idle+ahead → apply; streaming / pending-selection / mid-refetch / behind-or-equal / no-conversation → skip).
- `useLangyFreshness.unit.test.ts` — a signal for the open conversation invalidates its messages; other/none only refetch the list.
- Existing Langy panel integration tests (history, threading, inline-model) still green.

## Not included

The broadcast dedup key still omits event-kind (`subscriber.ts`), so a sub-15s turn's terminal signal can be collapsed into its start signal within the 15s window. Narrow edge (turns run ~30s–3min, clearing the window) and it would be a server change — left as a possible follow-up to keep this PR client-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic “foreign-turn” rehydration from durable message history to the chat engine when appropriate.
  * Rehydration is guarded to avoid interfering with loading/streaming, only applying when durable history is ahead (preventing older history “shrinks”/flash).

* **Bug Fixes**
  * Improved freshness handling by treating broadcasts as ID-only signals.
  * Active conversation messages are invalidated by conversation target, and the recents list is always cancel+invalidated for re-evaluation.

* **Tests**
  * Added/updated unit tests covering rehydration decision logic and freshness invalidation/refetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Also in this PR

One unrelated one-line fix surfaced by rebasing onto latest main: `langy-conversation.service.unit.test.ts` was missing `turnExists` on its repository mock (the method was added to `LangyConversationRepository` by #5966), which had left `typecheck:tests` red on main. Added the property with a `false` default to match the mock's other empty defaults.