### PR TITLE
fix(topic-clustering): let the boot topic-model seed actually run

### DIFF
--- a/langwatch/src/server/app-layer/topic-clustering/__tests__/bootSeeds.unit.test.ts
+++ b/langwatch/src/server/app-layer/topic-clustering/__tests__/bootSeeds.unit.test.ts
@@ -11,6 +11,10 @@ import { startTopicClusteringBootSeeds } from "../bootSeeds";
 
 const emptyPrisma = () =>
   ({
+    // The topic-model seed enumerates projectIds with a raw cross-tenant
+    // walk (the tenancy guard rejects a bare page off project-scoped
+    // `Topic`); the per-project read still goes through the model API.
+    $queryRaw: vi.fn().mockResolvedValue([]),
     topic: { findMany: vi.fn().mockResolvedValue([]) },
     topicModelProjection: { findMany: vi.fn().mockResolvedValue([]) },
     project: { findMany: vi.fn().mockResolvedValue([]) },
@@ -35,7 +39,7 @@ describe("startTopicClusteringBootSeeds", () => {
 
       await vi.waitFor(() => {
         // Topic-model seed pages distinct projectIds off the Topic table…
-        expect(prisma.topic.findMany).toHaveBeenCalled();
+        expect(prisma.$queryRaw).toHaveBeenCalled();
         // …and the schedule seed pages eligible projects.
         expect(prisma.project.findMany).toHaveBeenCalled();
       });
@@ -45,6 +49,7 @@ describe("startTopicClusteringBootSeeds", () => {
   describe("when every query rejects", () => {
     it("returns without throwing and surfaces nothing to the boot path", async () => {
       const prisma = {
+        $queryRaw: vi.fn().mockRejectedValue(new Error("pg down")),
         topic: { findMany: vi.fn().mockRejectedValue(new Error("pg down")) },
         topicModelProjection: {
           findMany: vi.fn().mockRejectedValue(new Error("pg down")),
@@ -65,7 +70,7 @@ describe("startTopicClusteringBootSeeds", () => {
 
       // Both rejections must have been consumed (no unhandled rejection).
       await vi.waitFor(() => {
-        expect(prisma.topic.findMany).toHaveBeenCalled();
+        expect(prisma.$queryRaw).toHaveBeenCalled();
         expect(prisma.project.findMany).toHaveBeenCalled();
       });
       await new Promise((resolve) => setImmediate(resolve));

--- a/langwatch/src/server/app-layer/topic-clustering/__tests__/seedTopicModel.unit.test.ts
+++ b/langwatch/src/server/app-layer/topic-clustering/__tests__/seedTopicModel.unit.test.ts
@@ -1,0 +1,232 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { guardProjectId } from "~/utils/dbMultiTenancyProtection";
+import { seedTopicModelHistory } from "../seedTopicModel";
+
+/**
+ * Unit tests for the ADR-051 one-time topic-model seed.
+ *
+ * The Prisma stub here routes EVERY call through the real `guardProjectId`
+ * middleware rather than answering blindly. That is the point: the seed
+ * shipped in #5930 paged over the project-scoped `Topic` model with no
+ * projectId predicate on its first page, so the guard threw on every worker
+ * boot and no project was ever seeded ("Topic model seed pass failed; the
+ * next boot retries", forever). A stub that skips the guard cannot observe
+ * that failure, so these tests run it for real.
+ */
+
+/** The middleware params Prisma hands the guard for a model-API call. */
+const modelParams = (model: string, action: string, args: unknown) => ({
+  model,
+  action,
+  args,
+  dataPath: [],
+  runInTransaction: false,
+});
+
+/**
+ * Prisma exposes raw SQL to the middleware as a `query` string; the guard
+ * reads the tenancy predicate (or the `-- @tenancy:` opt-out) out of it.
+ */
+const rawParams = (sql: Prisma.Sql) => ({
+  model: undefined,
+  action: "queryRaw",
+  args: { query: sql.text },
+  dataPath: [],
+  runInTransaction: false,
+});
+
+const guard = (params: unknown) =>
+  guardProjectId(params as never, async () => undefined);
+
+const topicRow = (id: string, projectId: string) => ({
+  id,
+  projectId,
+  name: `topic-${id}`,
+  parentId: null,
+  embeddings_model: "openai/text-embedding-3-small",
+  centroid: [0.1, 0.2],
+  p95Distance: 0.5,
+  automaticallyGenerated: true,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+});
+
+/**
+ * A Prisma stub that enforces the real tenancy guard on every call and
+ * serves `topicPages` to the cross-tenant projectId walk in order.
+ */
+const guardedPrismaStub = ({
+  topicPages,
+  topicsByProject,
+  ownedProjectIds = new Set<string>(),
+}: {
+  topicPages: string[][];
+  topicsByProject: Record<string, ReturnType<typeof topicRow>[]>;
+  ownedProjectIds?: Set<string>;
+}) => {
+  const rawQueries: string[] = [];
+  let pageIndex = 0;
+
+  const prisma = {
+    $queryRaw: async (sql: Prisma.Sql) => {
+      rawQueries.push(sql.text);
+      await guard(rawParams(sql));
+      const page = topicPages[pageIndex] ?? [];
+      pageIndex++;
+      return page.map((projectId) => ({ projectId }));
+    },
+    topic: {
+      findMany: async (args: { where: { projectId: string } }) => {
+        await guard(modelParams("Topic", "findMany", args));
+        return topicsByProject[args.where.projectId] ?? [];
+      },
+    },
+    topicModelProjection: {
+      findUnique: async (args: { where: { projectId: string } }) => {
+        await guard(modelParams("TopicModelProjection", "findUnique", args));
+        return ownedProjectIds.has(args.where.projectId)
+          ? { id: `cursor-${args.where.projectId}` }
+          : null;
+      },
+      findMany: async (args: { where: { projectId: { in: string[] } } }) => {
+        await guard(modelParams("TopicModelProjection", "findMany", args));
+        return args.where.projectId.in
+          .filter((projectId) => ownedProjectIds.has(projectId))
+          .map((projectId) => ({ projectId }));
+      },
+    },
+  } as unknown as PrismaClient;
+
+  return { prisma, rawQueries };
+};
+
+describe("seedTopicModelHistory", () => {
+  describe("given projects still hold pre-ownership Topic rows", () => {
+    describe("when the boot seed pass runs", () => {
+      it("walks the fleet without tripping the multitenancy guard", async () => {
+        const recordTopics = vi.fn().mockResolvedValue(undefined);
+        const { prisma } = guardedPrismaStub({
+          topicPages: [["p1", "p2"], []],
+          topicsByProject: {
+            p1: [topicRow("t1", "p1")],
+            p2: [topicRow("t2", "p2")],
+          },
+        });
+
+        const summary = await seedTopicModelHistory({
+          prisma,
+          redis: null,
+          recordTopics,
+        });
+
+        expect(summary).toEqual({ seeded: 2, skipped: 0 });
+        expect(recordTopics).toHaveBeenCalledTimes(2);
+      });
+
+      it("records each project's topics against its own tenant", async () => {
+        const recordTopics = vi.fn().mockResolvedValue(undefined);
+        const { prisma } = guardedPrismaStub({
+          topicPages: [["p1"], []],
+          topicsByProject: { p1: [topicRow("t1", "p1")] },
+        });
+
+        await seedTopicModelHistory({ prisma, redis: null, recordTopics });
+
+        expect(recordTopics).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId: "p1",
+            mode: "replace",
+            source: "seed",
+            dedupeKey: "seed:v1",
+          }),
+        );
+      });
+
+      it("carries the guard's opt-out marker on the cross-tenant walk", async () => {
+        const { prisma, rawQueries } = guardedPrismaStub({
+          topicPages: [[]],
+          topicsByProject: {},
+        });
+
+        await seedTopicModelHistory({
+          prisma,
+          redis: null,
+          recordTopics: vi.fn().mockResolvedValue(undefined),
+        });
+
+        expect(rawQueries[0]).toContain("@tenancy:");
+      });
+    });
+  });
+
+  describe("given the fleet spans more than one page", () => {
+    describe("when the walk advances", () => {
+      it("pages on a projectId cursor the guard accepts", async () => {
+        const recordTopics = vi.fn().mockResolvedValue(undefined);
+        const { prisma, rawQueries } = guardedPrismaStub({
+          topicPages: [["p1"], ["p2"], []],
+          topicsByProject: {
+            p1: [topicRow("t1", "p1")],
+            p2: [topicRow("t2", "p2")],
+          },
+        });
+
+        const summary = await seedTopicModelHistory({
+          prisma,
+          redis: null,
+          recordTopics,
+        });
+
+        expect(summary.seeded).toBe(2);
+        expect(rawQueries).toHaveLength(3);
+        expect(rawQueries[1]).toContain('"projectId" >');
+      });
+    });
+  });
+
+  describe("given the projection already owns a project's model", () => {
+    describe("when the pass reaches it", () => {
+      it("skips that project instead of re-seeding it", async () => {
+        const recordTopics = vi.fn().mockResolvedValue(undefined);
+        const { prisma } = guardedPrismaStub({
+          topicPages: [["p1", "p2"], []],
+          topicsByProject: {
+            p1: [topicRow("t1", "p1")],
+            p2: [topicRow("t2", "p2")],
+          },
+          ownedProjectIds: new Set(["p1"]),
+        });
+
+        const summary = await seedTopicModelHistory({
+          prisma,
+          redis: null,
+          recordTopics,
+        });
+
+        expect(summary).toEqual({ seeded: 1, skipped: 1 });
+        expect(recordTopics).toHaveBeenCalledTimes(1);
+        expect(recordTopics).toHaveBeenCalledWith(
+          expect.objectContaining({ tenantId: "p2" }),
+        );
+      });
+    });
+  });
+
+  describe("given the guard sees the unscoped page query the seed used to issue", () => {
+    describe("when that query is validated", () => {
+      it("rejects it, which is why the seed failed on every boot", async () => {
+        await expect(
+          guard(
+            modelParams("Topic", "findMany", {
+              distinct: ["projectId"],
+              select: { projectId: true },
+              orderBy: { projectId: "asc" },
+              take: 200,
+            }),
+          ),
+        ).rejects.toThrow(/requires a 'projectId' or 'projectId.in'/);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/topic-clustering/seedTopicModel.ts
+++ b/langwatch/src/server/app-layer/topic-clustering/seedTopicModel.ts
@@ -122,7 +122,9 @@ async function runSeedPass(
     // due-scan uses it. Each project's rows are still READ back through the
     // guarded model API in seedProjectTopicModel, which carries its
     // projectId — only this projectId enumeration is cross-tenant.
-    const page = await deps.prisma.$queryRaw<Array<{ projectId: string }>>(
+    const page: Array<{ projectId: string }> = await deps.prisma.$queryRaw<
+      Array<{ projectId: string }>
+    >(
       Prisma.sql`
         SELECT DISTINCT "projectId"
         FROM "Topic"

--- a/langwatch/src/server/app-layer/topic-clustering/seedTopicModel.ts
+++ b/langwatch/src/server/app-layer/topic-clustering/seedTopicModel.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "@langwatch/observability";
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import type { Cluster, Redis } from "ioredis";
 
 import type { TopicModelEntry } from "~/server/event-sourcing/pipelines/topic-clustering-processing/schemas/events";
@@ -113,14 +113,25 @@ async function runSeedPass(
   let cursor: string | null = null;
 
   for (;;) {
-    const page: Array<{ projectId: string }> =
-      await deps.prisma.topic.findMany({
-        distinct: ["projectId"],
-        select: { projectId: true },
-        orderBy: { projectId: "asc" },
-        take: PAGE_SIZE,
-        ...(cursor ? { where: { projectId: { gt: cursor } } } : {}),
-      });
+    // Fleet-wide walk over the projects that still hold pre-ownership Topic
+    // rows. `Topic` is project-scoped, so the tenancy guard rejects the bare
+    // first page of a `findMany` walk (no projectId predicate) — and this
+    // seed is cross-tenant by definition: it is the one-time migration that
+    // hands every project's model to the event stream. `-- @tenancy:` is the
+    // guard's sanctioned opt-out, used here exactly as the scheduler's
+    // due-scan uses it. Each project's rows are still READ back through the
+    // guarded model API in seedProjectTopicModel, which carries its
+    // projectId — only this projectId enumeration is cross-tenant.
+    const page = await deps.prisma.$queryRaw<Array<{ projectId: string }>>(
+      Prisma.sql`
+        SELECT DISTINCT "projectId"
+        FROM "Topic"
+        ${cursor ? Prisma.sql`WHERE "projectId" > ${cursor}` : Prisma.empty}
+        ORDER BY "projectId" ASC
+        LIMIT ${PAGE_SIZE}
+        -- @tenancy: one-time topic-model seed, cross-tenant by design (worker boot)
+      `,
+    );
     if (page.length === 0) break;
     cursor = page[page.length - 1]!.projectId;
 

--- a/specs/topic-clustering/topics-source-of-truth.feature
+++ b/specs/topic-clustering/topics-source-of-truth.feature
@@ -39,6 +39,12 @@ Feature: Topic clustering owns the topic model
     And their ids, names, and hierarchy are preserved exactly
     And re-running the seed changes nothing
 
+  Scenario: Seeding reaches every project that predates ownership
+    Given many projects whose topics predate event-sourced ownership
+    When the worker service starts
+    Then every one of those projects is seeded, not just the first page
+    And a project the projection already owns is left untouched
+
   Scenario: A late duplicate seed can never remove recorded topics
     Given a project whose topics were seeded and then extended by clustering
     When a duplicate seed carrying only the original topics arrives late


### PR DESCRIPTION
## What's wrong

Found while monitoring prod after #5930 merged. Every `langwatch-workers` replica logs this on boot:

```
ERROR langwatch:topic-clustering:seed
  "Topic model seed pass failed; the next boot retries"
  error: "The findMany action on the Topic model requires a 'projectId' or 'projectId.in' in the where clause"
```

`runSeedPass` pages distinct projectIds straight off `Topic`:

```ts
await deps.prisma.topic.findMany({
  distinct: ["projectId"],
  select: { projectId: true },
  orderBy: { projectId: "asc" },
  take: PAGE_SIZE,
  ...(cursor ? { where: { projectId: { gt: cursor } } } : {}),   // only set AFTER page 1
});
```

`Topic` is project-scoped, so the multitenancy guard requires a projectId predicate. The cursored pages would pass (`where.projectId` is a truthy object), but the **first** page carries no `where` at all and throws — so the loop dies before it reaches any project.

`bootSeeds` catches the rejection into "the next boot retries", and every subsequent boot fails identically. The retry message reads like transient recovery; it is actually a permanent stall.

**Impact:** no legacy project's topics were ever recorded onto the event stream. The projection never took ownership, so the ADR-051 source-of-truth migration has not run for anyone. The `seed:v1` done-marker is never written either, so this is stuck rather than half-applied — the fix picks up cleanly on next boot.

## The fix

Enumerate the fleet by paging the **global `Project` model** — which the tenancy guard exempts (it *is* the tenant, addressed by its own id) — filtered to the projects that own Topic rows via a `topics: { some }` EXISTS relation filter. `Topic.projectId` is a FK to `Project.id`, so that is the same project set as a distinct-projectId scan of `Topic`, with the same keyset pagination. No raw SQL and no tenancy opt-out — the whole seed stays on the guarded Prisma model API, mirroring the sibling schedule seed's `findEligibleProjectsPage`, which already pages `Project`.

Each project's rows are still read back through the guarded model API in `seedProjectTopicModel`, which carries its `projectId`. Only the fleet-wide enumeration is cross-tenant.

> Approach adopted from @0xdeafcafe's review (#6002) — the raw-SQL-free alternative to this PR's original `$queryRaw` + `-- @tenancy:` version.

## Why it shipped

`seedTopicModel.ts` had no test at all. And `bootSeeds.unit.test.ts` asserted only that the walk was *called* — never that it succeeded — so it stayed green throughout.

The new `seedTopicModel.unit.test.ts` routes its Prisma stub through the **real `guardProjectId` middleware** rather than answering blindly, so it executes the failing path instead of asserting on query strings. Verified it catches the regression: reverting the fix fails 5 of its cases with the exact production message.

## Testing

- `pnpm test:unit src/server/app-layer/topic-clustering/` — 12 files, 87 passed
- `pnpm typecheck` and `pnpm typecheck:tests` — clean on the changed files (the `typecheck (tests)` job is red only from `langy-conversation.service.unit.test.ts`'s missing `turnExists` mock, inherited from main via #5966 — not this PR)

## Follow-up (not in this PR)

Prod app logs all ship under `service_name="fluent-bit"` with the pod only in the JSON `hostname` field, so there is no per-service Loki label — every query is a full-firehose scan. Worth adding proper service labels, but the fluent-bit config isn't in this repo.