### PR TITLE
fix(langy): add turnExists to the conversation-repo test double

### DIFF
--- a/langwatch/src/server/app-layer/langy/__tests__/langy-conversation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-conversation.service.unit.test.ts
@@ -33,6 +33,7 @@ function makeRepo(
     findActiveOwnedIds: vi.fn(async () => []),
     findPendingHandoff: vi.fn(async () => null),
     findRunToken: vi.fn(async () => null),
+    turnExists: vi.fn(async () => false),
   };
   return { ...defaults, ...overrides };
 }


### PR DESCRIPTION
## What

Adds the missing `turnExists` mock to the `makeRepo` test double in `langy-conversation.service.unit.test.ts`.

## Why

#5966 grew `LangyConversationRepository` a required `turnExists` method (the durable result-ingest triple check) but was merged before CI finished; its `typecheck:tests` job then failed on main:

```
src/server/app-layer/langy/__tests__/langy-conversation.service.unit.test.ts(29,9): error TS2741: Property 'turnExists' is missing in type '{ ... }' but required in type 'LangyConversationRepository'.
```

The runtime tests were unaffected (21/21 pass); only the tests typecheck was red.

## Verification

- `pnpm test:unit src/server/app-layer/langy/__tests__/langy-conversation.service.unit.test.ts` — 21/21 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated conversation service test mocks to support turn-existence checks, improving test coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->