### PR TITLE
fix(mcp-server): surface evaluation results in search_traces

### DIFF
--- a/mcp-server/src/__tests__/all-tools.integration.test.ts
+++ b/mcp-server/src/__tests__/all-tools.integration.test.ts
@@ -985,7 +985,7 @@ describe("All MCP tools integration", () => {
       });
     });
 
-    describe("when a trace has evaluation results", () => {
+    describe("given a trace has evaluation results", () => {
       /** @scenario Agent searches traces and sees evaluation results without a follow-up call */
       it("includes evaluation status in the digest without a follow-up call", async () => {
         const { handleSearchTraces } = await import(

--- a/mcp-server/src/__tests__/all-tools.integration.test.ts
+++ b/mcp-server/src/__tests__/all-tools.integration.test.ts
@@ -14,6 +14,14 @@ const CANNED_TRACES_SEARCH = {
       output: { value: "I am fine, thank you!" },
       timestamps: { started_at: 1700000000000 },
       metadata: { user_id: "user-42", thread_id: "thread-1" },
+      evaluations: [
+        {
+          evaluator_id: "eval-1",
+          name: "Faithfulness",
+          score: 0.95,
+          passed: true,
+        },
+      ],
     },
   ],
   pagination: { totalHits: 1 },
@@ -974,6 +982,21 @@ describe("All MCP tools integration", () => {
         expect(parsed.filters).toEqual({
           "metadata.user_id": ["user-42"],
         });
+      });
+    });
+
+    describe("when a trace has evaluation results", () => {
+      /** @scenario Agent searches traces and sees evaluation results without a follow-up call */
+      it("includes evaluation status in the digest without a follow-up call", async () => {
+        const { handleSearchTraces } = await import(
+          "../tools/search-traces.js"
+        );
+        const result = await handleSearchTraces({
+          startDate: "24h",
+          endDate: "now",
+        });
+
+        expect(result).toContain("- **Faithfulness**: PASSED (score: 0.95)");
       });
     });
   });

--- a/mcp-server/src/__tests__/tools.unit.test.ts
+++ b/mcp-server/src/__tests__/tools.unit.test.ts
@@ -168,6 +168,30 @@ describe("handleSearchTraces()", () => {
     expect(result).toContain("timeout");
   });
 
+  describe("when a trace has evaluation results", () => {
+    it("shows pass/fail status per evaluation without requiring get_trace", async () => {
+      mockSearchTraces.mockResolvedValue({
+        traces: [
+          {
+            trace_id: "trace-eval",
+            input: { value: "" },
+            output: { value: "" },
+            evaluations: [
+              { name: "faithfulness", passed: true, score: 0.92 },
+              { evaluator_id: "toxicity-check", passed: false, label: "flagged" },
+            ],
+          },
+        ],
+        pagination: { totalHits: 1 },
+      });
+
+      const result = await handleSearchTraces({});
+
+      expect(result).toContain("**faithfulness**: PASSED (score: 0.92)");
+      expect(result).toContain("**toxicity-check**: FAILED [flagged]");
+    });
+  });
+
   describe("when no traces are found", () => {
     it("returns a no-results message", async () => {
       mockSearchTraces.mockResolvedValue({ traces: [] });

--- a/mcp-server/src/langwatch-api.ts
+++ b/mcp-server/src/langwatch-api.ts
@@ -1,5 +1,6 @@
 import type { HandledErrorFault } from "@langwatch/handled-error";
 import { getConfig, requireApiKey } from "./config.js";
+import type { EvaluationSummary } from "./utils/format-evaluations.js";
 
 // --- Response types ---
 
@@ -11,6 +12,7 @@ export interface TraceSearchResult {
   timestamps?: { started_at?: string | number };
   metadata?: Record<string, unknown>;
   error?: Record<string, unknown>;
+  evaluations?: EvaluationSummary[];
 }
 
 export interface SearchTracesResponse {
@@ -40,13 +42,7 @@ export interface TraceDetailResponse {
   };
   error?: Record<string, unknown>;
   ascii_tree?: string;
-  evaluations?: Array<{
-    evaluator_id?: string;
-    name?: string;
-    score?: number;
-    passed?: boolean;
-    label?: string;
-  }>;
+  evaluations?: EvaluationSummary[];
   spans?: Array<{
     span_id: string;
     name?: string;

--- a/mcp-server/src/tools/get-trace.ts
+++ b/mcp-server/src/tools/get-trace.ts
@@ -1,4 +1,5 @@
 import { getTraceById as apiGetTraceById } from "../langwatch-api.js";
+import { formatEvaluationLines } from "../utils/format-evaluations.js";
 
 /**
  * Handles the get_trace MCP tool invocation.
@@ -35,18 +36,7 @@ export async function handleGetTrace(params: {
   }
 
   if (result.evaluations && result.evaluations.length > 0) {
-    lines.push("\n## Evaluations");
-    for (const evaluation of result.evaluations) {
-      const status =
-        evaluation.passed === true
-          ? "PASSED"
-          : evaluation.passed === false
-            ? "FAILED"
-            : "N/A";
-      lines.push(
-        `- **${evaluation.name || evaluation.evaluator_id}**: ${status}${evaluation.score != null ? ` (score: ${evaluation.score})` : ""}${evaluation.label ? ` [${evaluation.label}]` : ""}`
-      );
-    }
+    lines.push("\n## Evaluations", ...formatEvaluationLines(result.evaluations));
   }
 
   if (result.formatted_trace) {

--- a/mcp-server/src/tools/search-traces.ts
+++ b/mcp-server/src/tools/search-traces.ts
@@ -1,5 +1,6 @@
 import { searchTraces as apiSearchTraces } from "../langwatch-api.js";
 import { parseRelativeDate } from "../utils/date-parsing.js";
+import { formatEvaluationLines } from "../utils/format-evaluations.js";
 
 /**
  * Handles the search_traces MCP tool invocation.
@@ -73,6 +74,9 @@ export async function handleSearchTraces(params: {
     }
     if (trace.error) {
       lines.push(`- **Error**: ${JSON.stringify(trace.error)}`);
+    }
+    if (trace.evaluations && trace.evaluations.length > 0) {
+      lines.push(...formatEvaluationLines(trace.evaluations));
     }
     lines.push("");
   }

--- a/mcp-server/src/utils/format-evaluations.ts
+++ b/mcp-server/src/utils/format-evaluations.ts
@@ -1,0 +1,20 @@
+export interface EvaluationSummary {
+  evaluator_id?: string;
+  name?: string;
+  score?: number;
+  passed?: boolean;
+  label?: string;
+}
+
+/** Formats a trace's evaluation results as markdown bullet lines, one per evaluation. */
+export function formatEvaluationLines(evaluations: EvaluationSummary[]): string[] {
+  return evaluations.map((evaluation) => {
+    const status =
+      evaluation.passed === true
+        ? "PASSED"
+        : evaluation.passed === false
+          ? "FAILED"
+          : "N/A";
+    return `- **${evaluation.name || evaluation.evaluator_id}**: ${status}${evaluation.score != null ? ` (score: ${evaluation.score})` : ""}${evaluation.label ? ` [${evaluation.label}]` : ""}`;
+  });
+}

--- a/specs/mcp-server/trace-tools.feature
+++ b/specs/mcp-server/trace-tools.feature
@@ -25,6 +25,12 @@ Feature: MCP Trace Tools
     When the agent calls search_traces with the returned scrollId
     Then the response contains the next page of results
 
+  Scenario: Agent searches traces and sees evaluation results without a follow-up call
+    Given a trace exists with an evaluation result
+    When the agent calls search_traces with a query matching that trace
+    Then the trace summary includes evaluation pass/fail status, score, and label
+    And the agent does not need to call get_trace to see the evaluation results
+
   Scenario: Agent gets a single trace by ID in AI-readable format
     Given a trace exists with id "trace-abc-123"
     When the agent calls get_trace with traceId "trace-abc-123"

--- a/specs/mcp-server/trace-tools.feature
+++ b/specs/mcp-server/trace-tools.feature
@@ -25,6 +25,9 @@ Feature: MCP Trace Tools
     When the agent calls search_traces with the returned scrollId
     Then the response contains the next page of results
 
+  # Implementation:
+  #   mcp-server/src/tools/search-traces.ts
+  #   mcp-server/src/utils/format-evaluations.ts  (formatEvaluationLines)
   Scenario: Agent searches traces and sees evaluation results without a follow-up call
     Given a trace exists with an evaluation result
     When the agent calls search_traces with a query matching that trace


### PR DESCRIPTION
## Summary

Real fix for the "bug 3" report (Sennder/Bruno support thread): "reading our own evals was easier via raw trace data than via LangWatch." Confirmed this is a genuine gap distinct from the MCP-connection issue fixed in #5965/#5976, not just a downstream symptom.

## The gap

The backend's `POST /api/traces/search` response, in digest mode, already attaches `evaluations` per trace (`app.v1.ts`, via `enrichTracesWithEvaluations`) — but `mcp-server`'s `TraceSearchResult` type never declared that field, and `search_traces`'s digest formatter silently dropped it. `get_trace` (single trace) already surfaced evaluations correctly; `search_traces` (the list view an agent actually uses to scan many traces) did not — forcing N `get_trace` calls to check eval status across N traces instead of one `search_traces` call. That's exactly the ergonomics gap a coding-agent workflow would hit and give up on in favor of reading its own raw data.

## Fix

- Extracted the evaluation-formatting logic (previously inlined in `get-trace.ts`) into a shared `formatEvaluationLines()` util + `EvaluationSummary` type (DRY — now two real call sites).
- Added `evaluations?: EvaluationSummary[]` to `TraceSearchResult` (mirrors `TraceDetailResponse`, which already had it).
- `search_traces`'s digest formatter now renders eval pass/fail/score per trace, same format as `get_trace`.

## Verification

- Unit test added (`tools.unit.test.ts`): asserts `search_traces` shows `PASSED`/`FAILED` status, score, and label per evaluation.
- Full suite: 397/398 (same 1 pre-existing, unrelated, skip-in-CI failure as #5965/#5976 — see those PRs for why).
- **Verified live against a real account**, not just unit-tested: sent a real trace + evaluation via `/api/collector`, confirmed `search_traces` now shows `**faithfulness**: PASSED (score: 0.92)` directly in the list output with no follow-up `get_trace` call needed.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 397/398 pass
- [x] Live verification against a real account with a real evaluation result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace search digests now include evaluation details inline (evaluator name/ID, pass/fail status, optional score, and optional label) when evaluations are present.
  * Evaluation formatting is consistent between trace search and trace detail views.
* **Bug Fixes**
  * Evaluation information is available directly from search results, avoiding unnecessary follow-up trace lookups.
* **Tests**
  * Added/updated unit and integration coverage to validate evaluation rendering (including score/label) in trace search output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->