### PR TITLE
fix(errors): the wire message is the code, on every transport

### DIFF
--- a/dev/docs/adr/045-domain-errors-handled-boundary.md
+++ b/dev/docs/adr/045-domain-errors-handled-boundary.md
@@ -29,7 +29,7 @@ abstract `Error` subclass carrying a serialisable `code`, `meta`,
 - **tRPC** (`src/server/api/trpc.ts`): a `handledErrorMiddleware` converts a
   `HandledError` thrown in a procedure into a correctly-coded `TRPCError` (via
   `handledErrorToTRPCCode`), and the `errorFormatter` calls `.serialize()` and
-  attaches the result to the error's `data.domainError`.
+  attaches the result to the error's `data.error`.
 - **Hono** (`src/app/api/middleware/error-handler.ts`, wired by every
   `createServiceApp` at `SecuredApp.onError`): a `HandledError` becomes
   `{ error: code, message, ...meta }` at its `httpStatus`.
@@ -71,10 +71,10 @@ Concretely:
 
 3. **The boundary only serialises handled errors.** The presence of a serialised
    domain payload IS the signal of "handled":
-   - tRPC: `data.domainError` is the `SerializedHandledError`, or `null`.
+   - tRPC: `data.error` is the `SerializedHandledError`, or `null`.
    - Hono: a `HandledError` yields `{ error: code, message, ...meta }`; an
      unhandled error yields a generic internal response.
-   - An unhandled error carries **no** `domainError` payload. Its raw detail is
+   - An unhandled error carries **no** `error` payload. Its raw detail is
      **logged server-side with the trace id**, never presented to the client as
      an actionable error. Clients render it as a single generic "something went
      wrong" plus the trace id for support (`HandledError.toUserMessage` already
@@ -100,7 +100,7 @@ Concretely:
 
 7. **The client is the single place that decides presentation.** A shared reader
    (`readHandledError`, already used by
-   `src/features/automations/logic/errorExplainer.ts`) lifts `data.domainError`;
+   `src/features/automations/logic/errorExplainer.ts`) lifts `data.error`;
    an `explain*`-style mapping keyed on `code` turns it into user-facing copy and
    an optional action/render choice. The server never dictates UI; it emits the
    typed fact, the client renders it. Absence of a domain payload → the generic
@@ -210,7 +210,7 @@ trace-link builder via `src/server/handled-error-wiring.ts`, loaded by
 in tool error text. All remediation copy lives in one registry
 (`src/server/app-layer/error-remediation.ts`), with a CI test asserting every
 docs link resolves to a real page. SSE error frames
-(`server/routes/sse.ts`) carry the serialized `domainError` alongside
+(`server/routes/sse.ts`) carry the serialized handled error alongside
 the message; non-handled stream failures now degrade to the generic unknown
 message instead of leaking raw error text onto an already-200 stream.
 Log levels follow the fault axis on every boundary: tRPC, Hono REST
@@ -218,6 +218,67 @@ Log levels follow the fault axis on every boundary: tRPC, Hono REST
 design: TS defaults `fault` to `"customer"`, while Go `herr` leaves it unset
 (only explicitly annotated codes get one) — an unset Go fault logs at info,
 matching the pre-existing Go behavior for expected control-flow errors.
+
+## Amendment 2026-07-20: the wire message is the code, and one `error` object
+
+The boundary was sanitising the *payload* but not the *message*. A
+`HandledError`'s message was treated as vetted user copy and passed straight
+through, so `langy.createConversation` returned
+`"LW_GATEWAY_BASE_URL is not configured on the control plane."` as the wire
+message next to a perfectly clean serialised payload. That message is written
+for whoever is reading the logs — it names env vars, hostnames and internal
+services — and it was reaching browsers, REST callers and the chat stream.
+
+**A handled error's free-text message never crosses a boundary.** Every
+transport sends the stable `code` where a message is required:
+
+- **tRPC** — `message` is the code; `data.error` is the `SerializedHandledError`
+  (renamed from `data.domainError`), or `null`.
+- **Hono** — `message` is the code; the code, `meta`, `reasons`, `tips`,
+  `docsUrl` and `fault` carry everything a caller needs.
+- **Streams** (`sse.ts`, `scenario-generate.ts`) — the frame's `message` /
+  `error` string is the code, with the serialised payload beside it.
+- **Go `herr`** — already correct: `toErrorBody` defaults `Message` to the code,
+  and free text appears only when a caller explicitly sets `Meta["message"]`.
+
+`SerializedHandledError` has no `message` field, and that is deliberate — the
+structured payload IS the contract, and presentation stays client-side (point 7
+above). Consumers with no explainer (CLI, API, MCP, agents) read `tips` and
+`docsUrl`, which exist precisely to be safe, authored remediation copy. **If an
+error needs prose for those consumers, add tips — never widen the message.**
+
+**`data.zodError` is gone.** A `ZodError` is promoted to the shared
+`ValidationError` (mirroring what Hono already did), so validation travels the
+one handled-error channel and its issues ride in `meta.fieldErrors` /
+`meta.formErrors` like every other domain fact. It had no client consumers.
+
+### Two deliberate asymmetries
+
+Consistency stops where an external contract begins. Both of these are load
+bearing, not oversights:
+
+1. **Go keeps `type`, not `code`.** The AI Gateway's envelope is
+   OpenAI-compatible (`docs/ai-gateway/api/errors.mdx`) so that the `openai` and
+   Anthropic SDKs raise their usual typed exceptions unchanged. `type` is their
+   field name; renaming it breaks every SDK pointed at the gateway.
+2. **Hono stays flat at the root.** Nesting the body under an `error` key would
+   read better, but `error` is already a string there, and the Python SDK
+   (`better_raise_for_status`), the TS SDK's legacy path and `directUpload.ts`
+   all read it as one. Changing it is a breaking change to published SDKs and
+   needs its own migration, not a drive-by.
+
+### Known follow-up
+
+`data.cause` is still a parallel channel for `ModelNotConfiguredError`,
+`AiCallFailedError`, `ModelProviderDisabledError` and limit info, because those
+are plain `Error`s rather than `HandledError`s. Converting them collapses that
+channel into `data.error.meta` and deletes the three special cases in
+`handledErrorMiddleware`. Worth doing; out of scope here.
+
+Roughly 150 UI sites render a tRPC error's `.message` straight into a toast.
+For unhandled errors that is unchanged, but a handled one now shows its code
+slug. Each is a missing explainer entry — the fix is copy at the call site, and
+never re-widening the wire.
 
 ## References
 

--- a/dev/docs/adr/045-domain-errors-handled-boundary.md
+++ b/dev/docs/adr/045-domain-errors-handled-boundary.md
@@ -252,20 +252,41 @@ error needs prose for those consumers, add tips — never widen the message.**
 one handled-error channel and its issues ride in `meta.fieldErrors` /
 `meta.formErrors` like every other domain fact. It had no client consumers.
 
-### Two deliberate asymmetries
+### Every producer emits both `type` and `code`
 
-Consistency stops where an external contract begins. Both of these are load
-bearing, not oversights:
+Rather than pick a winner, Go and the Hono body now emit **both names with the
+same value**: `type` because the AI Gateway's envelope is OpenAI-compatible
+(`docs/ai-gateway/api/errors.mdx` — the `openai` and Anthropic SDKs parse it and
+must keep raising their usual typed exceptions), and `code` because that is the
+name the TypeScript side uses everywhere. Readers resolve `code` → `kind` →
+`type`, so a consumer gets the same answer whichever name its transport taught
+it, and neither ecosystem has to be broken to satisfy the other. `kind` remains
+the deprecated pre-`HandledError` alias.
 
-1. **Go keeps `type`, not `code`.** The AI Gateway's envelope is
-   OpenAI-compatible (`docs/ai-gateway/api/errors.mdx`) so that the `openai` and
-   Anthropic SDKs raise their usual typed exceptions unchanged. `type` is their
-   field name; renaming it breaks every SDK pointed at the gateway.
-2. **Hono stays flat at the root.** Nesting the body under an `error` key would
-   read better, but `error` is already a string there, and the Python SDK
-   (`better_raise_for_status`), the TS SDK's legacy path and `directUpload.ts`
-   all read it as one. Changing it is a breaking change to published SDKs and
-   needs its own migration, not a drive-by.
+### Reading a message for display
+
+A handled error carries no message on the wire, so anything rendering one reads,
+in order: **`meta.message` → `message` → `code`**.
+
+- `meta.message` is prose the server *deliberately* authored to be shown. It is
+  the only channel that carries a sentence, and it is opt-in per error — which
+  is what keeps the leak closed: the constructor's `message` stays server-side.
+  `herr.FromBody` populates it, so proxied Go errors explain themselves.
+- `message` is the code for a handled error, but real copy for a plain
+  `TRPCError` a procedure authored — still exactly what to show.
+- `code` is the last resort, so a caller never gets an empty string.
+
+`errorDisplayMessage` (`src/utils/trpcError.ts`) implements this for the app; the
+CLI does it in `asErrorBody`, and the Python SDK in `extract_api_error_detail`
+(which also appends `tips` and `docsUrl`, since those exist to be shown).
+
+### One deliberate asymmetry
+
+**The Hono body stays flat at the root.** Nesting it under an `error` key would
+read better, but `error` is already a *string* there, and the Python SDK
+(`better_raise_for_status`), the TS SDK's legacy path and `directUpload.ts` all
+read it as one. Changing it is a breaking change to published SDKs and needs its
+own migration, not a drive-by.
 
 ### Known follow-up
 

--- a/langwatch/packages/api/src/__tests__/builder.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/builder.unit.test.ts
@@ -398,6 +398,8 @@ describe("output validation", () => {
         code: "internal_error",
         // Deprecated back-compat alias of `code` (see ErrorResponseBody.kind).
         kind: "internal_error",
+        // The Go envelope's name for the same value (see ErrorResponseBody.type).
+        type: "internal_error",
         message: "An unknown error occurred",
       });
     });

--- a/langwatch/packages/api/src/__tests__/errors.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/errors.unit.test.ts
@@ -56,7 +56,10 @@ describe("formatError", () => {
 
         expect(status).toBe(404);
         expect(body.code).toBe("not_found");
-        expect(body.message).toBe("Resource not found: abc");
+        // The code, never the handled error's own message: that is server copy
+        // and can name internals (ADR-045). Identifying context is in `meta`.
+        expect(body.message).toBe("not_found");
+        expect(JSON.stringify(body)).not.toContain("Resource not found: abc");
         expect(body.meta).toEqual({ id: "abc" });
         expect(body.error).toBeUndefined();
       });
@@ -150,7 +153,7 @@ describe("formatError", () => {
 
       expect(status).toBe(422);
       expect(body.code).toBe("validation_error");
-      expect(body.message).toBe("Validation error");
+      expect(body.message).toBe("validation_error");
       expect(body.reasons).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/langwatch/packages/api/src/errors.ts
+++ b/langwatch/packages/api/src/errors.ts
@@ -59,6 +59,13 @@ interface ErrorResponseBody {
   error?: string;
   code: string;
   /**
+   * Always equal to `code`. The Go envelope calls the discriminant `type`
+   * (OpenAI-compatible — see pkg/herr/http.go), so both names are emitted here
+   * too: a consumer can read whichever its transport taught it and get the
+   * same answer either way.
+   */
+  type?: string;
+  /**
    * @deprecated Back-compat alias of `code`, emitted during the
    * `DomainError` → `HandledError` transition so clients still reading the old
    * `kind` discriminant keep working. Read `code` in new code; removed once no
@@ -88,8 +95,10 @@ function finalizeErrorResponse({
   if (!isVersioned) body.error = httpStatusText(status);
   // Emit the deprecated `kind` alias alongside `code` so clients still reading
   // the old discriminant keep working through the transition. See
-  // ErrorResponseBody.kind.
+  // ErrorResponseBody.kind. `type` mirrors the Go envelope's name for the same
+  // value — see ErrorResponseBody.type.
   body.kind = body.code;
+  body.type = body.code;
   return { status, body };
 }
 

--- a/langwatch/packages/api/src/errors.ts
+++ b/langwatch/packages/api/src/errors.ts
@@ -106,7 +106,11 @@ function handledErrorToResponse({
     isVersioned,
     body: {
       code: serialized.code,
-      message: err.message ?? serialized.code,
+      // The code, never `err.message`. A HandledError's message is server copy
+      // — it can name env vars, hostnames or internal services (ADR-045) — and
+      // this body goes to external API callers. Consumers that need prose read
+      // `tips` / `docsUrl`, which are authored for exactly that.
+      message: serialized.code,
       meta: serialized.meta,
       reasons: serialized.reasons,
       traceId: serialized.traceId,

--- a/langwatch/src/features/automations/AutomationDrawer.tsx
+++ b/langwatch/src/features/automations/AutomationDrawer.tsx
@@ -57,7 +57,10 @@ import {
   type TemplateContext,
 } from "@langwatch/automations/templating/templateContext";
 import { api } from "~/utils/api";
-import { isHandledByGlobalHandler } from "~/utils/trpcError";
+import {
+  errorDisplayMessage,
+  isHandledByGlobalHandler,
+} from "~/utils/trpcError";
 import { MainSectionList } from "./components/MainSectionList";
 import { ConfigurationSecondaryDrawer } from "./components/secondaries/ConfigurationSecondaryDrawer";
 import { ALERT_TEMPLATE_VARIABLES } from "./editors/alertVariables";
@@ -778,18 +781,18 @@ export function AutomationDrawer({
           const domain = readHandledError(err);
           const { title, description } = domain
             ? explainHandledError(domain)
-            : { title: "Test fire failed", description: err.message };
+            : { title: "Test fire failed", description: errorDisplayMessage(err) };
           pushAttempt({
             at: Date.now(),
             channel,
             status: "failure",
             errorTitle: title,
-            errorDetail: description || err.message,
+            errorDetail: description || errorDisplayMessage(err),
           });
           toaster.create({
             title,
             type: "error",
-            description: description || err.message,
+            description: description || errorDisplayMessage(err),
             meta: { closable: true },
           });
         },
@@ -863,11 +866,14 @@ export function AutomationDrawer({
           const domain = readHandledError(err);
           const { title, description } = domain
             ? explainHandledError(domain)
-            : { title: "Could not save automation", description: err.message };
+            : {
+                title: "Could not save automation",
+                description: errorDisplayMessage(err),
+              };
           toaster.create({
             title,
             type: "error",
-            description: description || err.message,
+            description: description || errorDisplayMessage(err),
             meta: { closable: true },
           });
         },

--- a/langwatch/src/features/automations/logic/errorExplainer.ts
+++ b/langwatch/src/features/automations/logic/errorExplainer.ts
@@ -12,15 +12,14 @@ export interface HandledErrorShape {
   httpStatus: number;
 }
 
-/** Reads `error.data.domainError` from any tRPC client error, returning null
+/** Reads `error.data.error` from any tRPC client error, returning null
  *  when the cause was not one of our handled errors (e.g. an infrastructure
- *  failure or a Zod parse error). Validates the shape before returning so a
+ *  failure). Validates the shape before returning so a
  *  malformed payload can't crash `explainHandledError` on `domain.meta.*`
  *  access — the helper trusts `unknown` input and a misconfigured server
  *  shouldn't take the UI with it. */
 export function readHandledError(err: unknown): HandledErrorShape | null {
-  const candidate = (err as { data?: { domainError?: unknown } })?.data
-    ?.domainError;
+  const candidate = (err as { data?: { error?: unknown } })?.data?.error;
   if (!candidate || typeof candidate !== "object") return null;
 
   const value = candidate as {

--- a/langwatch/src/features/automations/logic/errorExplainer.ts
+++ b/langwatch/src/features/automations/logic/errorExplainer.ts
@@ -97,7 +97,16 @@ export function explainHandledError(
     }
     case "project_not_found":
       return { title: "Project not found", description: "" };
-    default:
-      return { title: "Something went wrong", description: "" };
+    default: {
+      // No bespoke copy for this code yet. If the server deliberately authored
+      // a user-facing sentence it rides in `meta.message` (the only channel
+      // that carries prose — see ADR-045); otherwise say something calm rather
+      // than showing a raw code slug.
+      const authored = domain.meta.message;
+      return {
+        title: "Something went wrong",
+        description: typeof authored === "string" ? authored : "",
+      };
+    }
   }
 }

--- a/langwatch/src/features/langy/components/LangyPanel.tsx
+++ b/langwatch/src/features/langy/components/LangyPanel.tsx
@@ -1116,7 +1116,7 @@ function LangyPanel({
   const turnError = useMemo(() => {
     // The LIVE failure. Two roads reach `error`, and BOTH must be classified:
     //  - a turn-START rejection from the create/continue MUTATION carries the
-    //    domain error on `error.data.domainError` → readLangyTrpcError;
+    //    domain error on `error.data.error` → readLangyTrpcError;
     //  - a mid-turn failure off the STREAM carries it as a JSON message →
     //    readLangyStreamError.
     // Reading only the stream shape (as this once did) collapsed EVERY mutation

--- a/langwatch/src/features/langy/logic/langyErrorExplainer.ts
+++ b/langwatch/src/features/langy/logic/langyErrorExplainer.ts
@@ -163,17 +163,17 @@ export function readLangyStreamError(
   };
 }
 
-/** Read a Langy domain error off a tRPC client error (`error.data.domainError`). */
+/** Read a Langy domain error off a tRPC client error (`error.data.error`). */
 export function readLangyTrpcError(err: unknown): LangyDomainError | null {
   const domain = readHandledError(err);
   if (!domain) return null;
   const serialized = (
     err as {
       data?: {
-        domainError?: { traceId?: unknown; reasons?: unknown };
+        error?: { traceId?: unknown; reasons?: unknown };
       };
     }
-  )?.data?.domainError;
+  )?.data?.error;
   const traceId = serialized?.traceId;
   return {
     ...domain,

--- a/langwatch/src/features/langy/logic/langyErrorExplainer.ts
+++ b/langwatch/src/features/langy/logic/langyErrorExplainer.ts
@@ -425,17 +425,25 @@ export function explainLangyError(
         ...debug,
       };
 
-    default:
+    default: {
       // A handled kind we don't have bespoke copy for yet: still useful, never
-      // a raw string, and its meta + reasons are surfaced for debugging.
+      // a raw string, and its meta + reasons are surfaced for debugging. A
+      // server-authored sentence in `meta.message` wins over the stock line —
+      // that is the only channel carrying prose (ADR-045), and it is how a
+      // proxied Go herr explains itself before we write copy for its code.
+      const authored = domain.meta?.message;
       return {
         kind: domain.code,
         title: "Langy couldn't finish that",
-        description: "The request was rejected. Try rephrasing or start again.",
+        description:
+          typeof authored === "string" && authored.length > 0
+            ? authored
+            : "The request was rejected. Try rephrasing or start again.",
         render: "card",
         action: { label: "Try again", kind: "retry" },
         traceId: domain.traceId,
         ...debug,
       };
+    }
   }
 }

--- a/langwatch/src/features/langy/logic/langyErrorExplainer.ts
+++ b/langwatch/src/features/langy/logic/langyErrorExplainer.ts
@@ -7,7 +7,7 @@ import {
  * Langy error explainer (ADR-045).
  *
  * The platform serializes handled `HandledError`s to `{ code, kind, meta,
- * httpStatus, traceId, spanId, reasons }` — over tRPC as `error.data.domainError`, and (new in
+ * httpStatus, traceId, spanId, reasons }` — over tRPC as `error.data.error`, and (new in
  * this PR) over the chat stream as a JSON-encoded string in the error part.
  * This module turns either into a keyed presentation the UI renders:
  *

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerEmptyState.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerEmptyState.tsx
@@ -44,11 +44,11 @@ function classifyError(error: unknown, traceId: string | undefined): ErrorKind {
         code?: string;
         // `kind` is the deprecated pre-`HandledError` discriminant, read as a
         // fallback so this resolves across the transition.
-        domainError?: { code?: string; kind?: string };
+        error?: { code?: string; kind?: string };
       };
     }
   )?.data;
-  const domainCode = data?.domainError?.code ?? data?.domainError?.kind;
+  const domainCode = data?.error?.code ?? data?.error?.kind;
   if (domainCode === "trace_not_found") return "not-found";
   if (data?.code === "NOT_FOUND") return "not-found";
   return "load-failed";

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerEmptyState.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerEmptyState.tsx
@@ -23,7 +23,7 @@ import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 interface TraceDrawerEmptyStateProps {
   /**
    * Loose shape so we can read the tRPC error envelope (`data.code`,
-   * `data.domainError`) or a plain `Error` without coupling to tRPC
+   * `data.error`) or a plain `Error` without coupling to tRPC
    * client types — whatever `useQuery().error` returns.
    */
   error: unknown;

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/EditableTraceName.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/EditableTraceName.tsx
@@ -70,15 +70,17 @@ export function EditableTraceName({
       setIsEditing(false);
     },
     onError: (error) => {
-      // The server attaches the serialised HandledError to error.data so
-      // we can show the rich message + meta — falls back to error.message
-      // for unhandled cases.
-      const dErr = error.data?.domainError;
-      const meta = (dErr?.meta ?? {}) as Record<string, unknown>;
+      // The server sends only the handled error's code + meta — never
+      // server-authored prose (ADR-045) — so the copy is written here. A
+      // too-long name is the one case worth spelling out, using the limit the
+      // server reported; everything else gets one calm generic line.
+      const meta = (error.data?.error?.meta ?? {}) as Record<string, unknown>;
       const description =
         typeof meta.field === "string" && typeof meta.maxLength === "number"
-          ? `${error.message} (got ${String(meta.receivedLength ?? "?")} chars)`
-          : error.message;
+          ? `Trace names are limited to ${meta.maxLength} characters (you used ${String(
+              meta.receivedLength ?? "?",
+            )}).`
+          : "That name couldn't be saved. Try again.";
       toaster.error({
         title: "Couldn't rename trace",
         description,

--- a/langwatch/src/server/api/__tests__/trpc-error-formatter.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/trpc-error-formatter.unit.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
 
 import { HandledError, NotFoundError } from "@langwatch/handled-error";
 import { errorFormatterForTesting } from "../trpc";
@@ -57,7 +58,7 @@ describe("tRPC error response boundary", () => {
     expect(JSON.stringify(formatted)).not.toContain(
       "Conversation not found: conversation-1",
     );
-    expect(formatted.data.domainError).toMatchObject({
+    expect(formatted.data.error).toMatchObject({
       code: "langy_conversation_not_found",
       httpStatus: 404,
     });
@@ -66,7 +67,7 @@ describe("tRPC error response boundary", () => {
   it("never leaks server configuration named in a handled error's message", () => {
     // Mirrors the reported leak: langy.createConversation returned
     // "LW_GATEWAY_BASE_URL is not configured on the control plane." as the
-    // wire message alongside the sanitised domainError payload.
+    // wire message alongside the sanitised error payload.
     class CredentialResolutionError extends HandledError {
       constructor(message: string) {
         super("langy_credential_resolution", message, { httpStatus: 409 });
@@ -86,10 +87,39 @@ describe("tRPC error response boundary", () => {
     expect(JSON.stringify(formatted)).not.toContain("LW_GATEWAY_BASE_URL");
     expect(JSON.stringify(formatted)).not.toContain("db.internal");
     expect(formatted.message).toBe("langy_credential_resolution");
-    expect(formatted.data.domainError).toMatchObject({
+    expect(formatted.data.error).toMatchObject({
       code: "langy_credential_resolution",
       httpStatus: 409,
       fault: "customer",
+    });
+  });
+
+  it("carries validation failures as a handled error with the issues in meta", () => {
+    // There is no sidecar `zodError` field any more: a ZodError is promoted to
+    // the shared ValidationError so it travels the one handled-error channel,
+    // and its issues ride in meta like every other domain fact.
+    const cause = new ZodError([
+      {
+        code: "too_small",
+        minimum: 1,
+        type: "string",
+        inclusive: true,
+        path: ["name"],
+        message: "String must contain at least 1 character(s)",
+      },
+    ]);
+    const error = new TRPCError({
+      code: "BAD_REQUEST",
+      message: cause.message,
+      cause,
+    });
+
+    const formatted = format(error);
+
+    expect(formatted.data).not.toHaveProperty("zodError");
+    expect(formatted.data.error).toMatchObject({
+      code: "validation_error",
+      meta: { fieldErrors: { name: expect.any(Array) } },
     });
   });
 

--- a/langwatch/src/server/api/__tests__/trpc-error-formatter.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/trpc-error-formatter.unit.test.ts
@@ -2,7 +2,7 @@
 import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 
-import { NotFoundError } from "@langwatch/handled-error";
+import { HandledError, NotFoundError } from "@langwatch/handled-error";
 import { errorFormatterForTesting } from "../trpc";
 
 function format(error: TRPCError) {
@@ -39,24 +39,57 @@ describe("tRPC error response boundary", () => {
     expect(error.cause).toBe(cause);
   });
 
-  it("keeps explicitly handled domain copy and its structured envelope", () => {
+  it("replaces a handled error's free-text message with its stable code, keeping the structured envelope", () => {
     const cause = new NotFoundError(
       "langy_conversation_not_found",
       "Conversation",
       "conversation-1",
     );
     const error = new TRPCError({
-      code: "INTERNAL_SERVER_ERROR",
+      code: "NOT_FOUND",
       message: cause.message,
       cause,
     });
 
     const formatted = format(error);
 
-    expect(formatted.message).toBe("Conversation not found: conversation-1");
+    expect(formatted.message).toBe("langy_conversation_not_found");
+    expect(JSON.stringify(formatted)).not.toContain(
+      "Conversation not found: conversation-1",
+    );
     expect(formatted.data.domainError).toMatchObject({
       code: "langy_conversation_not_found",
       httpStatus: 404,
+    });
+  });
+
+  it("never leaks server configuration named in a handled error's message", () => {
+    // Mirrors the reported leak: langy.createConversation returned
+    // "LW_GATEWAY_BASE_URL is not configured on the control plane." as the
+    // wire message alongside the sanitised domainError payload.
+    class CredentialResolutionError extends HandledError {
+      constructor(message: string) {
+        super("langy_credential_resolution", message, { httpStatus: 409 });
+      }
+    }
+    const cause = new CredentialResolutionError(
+      "LW_GATEWAY_BASE_URL is not configured on the control plane.",
+    );
+    const error = new TRPCError({
+      code: "CONFLICT",
+      message: cause.message,
+      cause,
+    });
+
+    const formatted = format(error);
+
+    expect(JSON.stringify(formatted)).not.toContain("LW_GATEWAY_BASE_URL");
+    expect(JSON.stringify(formatted)).not.toContain("db.internal");
+    expect(formatted.message).toBe("langy_credential_resolution");
+    expect(formatted.data.domainError).toMatchObject({
+      code: "langy_credential_resolution",
+      httpStatus: 409,
+      fault: "customer",
     });
   });
 

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -192,7 +192,7 @@ function httpStatusToTRPCCode(httpStatus: number): TRPCErrorCode {
 /**
  * Wraps any thrown value as a `TRPCError` whose `cause` is preserved when the
  * value is a `HandledError`. The shared `errorFormatter` in `trpc.ts` serialises
- * that cause as `error.data.domainError = { code, meta, traceId, spanId, … }` so the
+ * that cause as `error.data.error = { code, meta, traceId, spanId, … }` so the
  * client gets the full structured payload — that is the "incredibly good error
  * handling" surface (see ADR-036 follow-up).
  */

--- a/langwatch/src/server/api/routers/langy.ts
+++ b/langwatch/src/server/api/routers/langy.ts
@@ -212,7 +212,7 @@ async function canWatchTurn({
  * the SAME operation — `isNewConversation` is the only difference (it emits the
  * semantically-first `conversation_started`). The service throws DomainErrors,
  * which the shared `domainErrorMiddleware` maps to coded TRPCErrors carrying
- * `data.domainError` (read by the client's `readLangyTrpcError`).
+ * `data.error` (read by the client's `readLangyTrpcError`).
  */
 async function acceptTurn({
   input,

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -188,21 +188,25 @@ export function errorFormatterForTesting({
       ? error.cause.toResponseBody()
       : null;
 
-  // A 5xx is an implementation failure, not user-facing copy. tRPC defaults
-  // the response message to the thrown Error's message, which can contain
-  // Prisma models, SQL, hostnames, or other platform internals. HandledError is
-  // the only exception: its message is explicitly authored as safe domain
-  // copy. The original error remains on the TRPCError for loggerMiddleware,
+  // Free-text error messages never cross the tRPC boundary. `data.domainError`
+  // (code, meta, tips, docsUrl — see SerializedHandledError, which deliberately
+  // has no message field) is the entire client contract for handled errors, and
+  // presentation is decided client-side by the code-keyed explainers. A
+  // HandledError's message is server copy — it can name env vars or internal
+  // services — so the wire carries only its stable code. Unhandled 5xx messages
+  // can contain Prisma models, SQL, or hostnames and collapse to a generic
+  // string. The original error remains on the TRPCError for loggerMiddleware,
   // exception capture, and OTel span recording.
   const isInternalServerError =
     error.code === "INTERNAL_SERVER_ERROR" ||
     shape?.data?.code === "INTERNAL_SERVER_ERROR";
-  const message =
-    isInternalServerError && !HandledError.isHandled(error.cause)
+  const message = HandledError.isHandled(error.cause)
+    ? error.cause.code
+    : isInternalServerError
       ? HandledError.toUserMessage(error.cause)
       : shape.message;
   const shapeData = { ...shape.data };
-  if (isInternalServerError && !HandledError.isHandled(error.cause)) {
+  if (isInternalServerError || HandledError.isHandled(error.cause)) {
     // tRPC includes stacks in development error shapes. Local callers should
     // exercise the same safe wire contract as production callers.
     delete shapeData.stack;

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -30,7 +30,7 @@ interface CreateNextContextOptions {
   res: any;
 }
 
-import { HandledError } from "@langwatch/handled-error";
+import { HandledError, ValidationError } from "@langwatch/handled-error";
 import { createLogger } from "@langwatch/observability";
 import { getLogLevelFromStatusCode } from "@langwatch/observability/request";
 import type { OrganizationUserRole } from "@prisma/client";
@@ -145,8 +145,19 @@ export function errorFormatterForTesting({
       }
     : null;
 
-  const domainError =
-    HandledError.isHandled(error.cause) ? error.cause.serialize() : null;
+  // Input validation arrives as a ZodError cause. Promote it to the shared
+  // ValidationError so it travels the one handled-error channel like every
+  // other failure: `fromZodError` flattens the issues into
+  // `meta.fieldErrors` / `meta.formErrors`, which is where the contents of the
+  // old sidecar `data.zodError` field now live. Mirrors what the Hono handler
+  // already does (packages/api/src/errors.ts::validationErrorFromZod).
+  const handled = HandledError.isHandled(error.cause)
+    ? error.cause
+    : error.cause instanceof ZodError
+      ? ValidationError.fromZodError(error.cause)
+      : null;
+
+  const domainError = handled?.serialize() ?? null;
 
   // Surface ModelNotConfiguredError on the wire so the frontend
   // interceptor in `utils/trpcError.ts::extractMissingModelInfo` can
@@ -188,25 +199,30 @@ export function errorFormatterForTesting({
       ? error.cause.toResponseBody()
       : null;
 
-  // Free-text error messages never cross the tRPC boundary. `data.domainError`
-  // (code, meta, tips, docsUrl — see SerializedHandledError, which deliberately
-  // has no message field) is the entire client contract for handled errors, and
+  // Free-text error messages never cross the tRPC boundary. `data.error` (code,
+  // meta, tips, docsUrl — see SerializedHandledError, which deliberately has no
+  // message field) is the entire client contract for handled errors, and
   // presentation is decided client-side by the code-keyed explainers. A
   // HandledError's message is server copy — it can name env vars or internal
   // services — so the wire carries only its stable code. Unhandled 5xx messages
   // can contain Prisma models, SQL, or hostnames and collapse to a generic
   // string. The original error remains on the TRPCError for loggerMiddleware,
   // exception capture, and OTel span recording.
+  //
+  // `message` and `code` stay at the top level because they are JSON-RPC
+  // envelope fields the tRPC client itself runtime-checks (`isTRPCErrorResponse`
+  // requires a string message and a numeric code, and discards `data` entirely
+  // when either is missing) — not fields we chose.
   const isInternalServerError =
     error.code === "INTERNAL_SERVER_ERROR" ||
     shape?.data?.code === "INTERNAL_SERVER_ERROR";
-  const message = HandledError.isHandled(error.cause)
-    ? error.cause.code
+  const message = handled
+    ? handled.code
     : isInternalServerError
       ? HandledError.toUserMessage(error.cause)
       : shape.message;
   const shapeData = { ...shape.data };
-  if (isInternalServerError || HandledError.isHandled(error.cause)) {
+  if (isInternalServerError || handled) {
     // tRPC includes stacks in development error shapes. Local callers should
     // exercise the same safe wire contract as production callers.
     delete shapeData.stack;
@@ -217,13 +233,12 @@ export function errorFormatterForTesting({
     message,
     data: {
       ...shapeData,
-      zodError: error.cause instanceof ZodError ? error.cause.flatten() : null,
       cause:
         missingModelCause ??
         providerDisabledCause ??
         aiCallFailedCause ??
         limitInfo,
-      domainError,
+      error: domainError,
     },
   };
 }

--- a/langwatch/src/server/app-layer/automations/errors.ts
+++ b/langwatch/src/server/app-layer/automations/errors.ts
@@ -3,7 +3,7 @@ import { HandledError } from "@langwatch/handled-error";
 /**
  * Domain errors raised by the automation authoring path (ADR-036). Each is a
  * concrete `HandledError` subclass so the existing tRPC `errorFormatter`
- * serialises it onto the wire as `error.data.domainError` with the `code`
+ * serialises it onto the wire as `error.data.error` with the `code`
  * discriminator plus structured `meta`. The client matches on `code` and
  * renders field-targeted, actionable errors (highlight the offending field,
  * list the offending recipient, etc.) rather than a generic toast.

--- a/langwatch/src/server/routes/__tests__/sse-error-frame.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/sse-error-frame.unit.test.ts
@@ -21,8 +21,11 @@ describe("sseErrorFrame", () => {
     const frame = sseErrorFrame(new TestHandledError());
 
     expect(frame.type).toBe("error");
-    expect(frame.message).toBe("a fixable failure");
-    expect(frame.domainError).toMatchObject({
+    // The code, not the handled error's own message — server copy never
+    // reaches the stream (ADR-045).
+    expect(frame.message).toBe("test_handled");
+    expect(JSON.stringify(frame)).not.toContain("a fixable failure");
+    expect(frame.error).toMatchObject({
       code: "test_handled",
       httpStatus: 422,
       tips: ["Do the thing"],
@@ -40,8 +43,9 @@ describe("sseErrorFrame", () => {
       }),
     );
 
-    expect(frame.message).toBe("a fixable failure");
-    expect(frame.domainError).toMatchObject({ code: "test_handled" });
+    expect(frame.message).toBe("test_handled");
+    expect(JSON.stringify(frame)).not.toContain("a fixable failure");
+    expect(frame.error).toMatchObject({ code: "test_handled" });
   });
 
   it("keeps the message of a client-safe TRPCError without a domain payload", () => {
@@ -72,6 +76,6 @@ describe("sseErrorFrame", () => {
     );
 
     expect(frame.message).toBe("An unknown error occurred");
-    expect(frame.domainError).toBeUndefined();
+    expect(frame.error).toBeUndefined();
   });
 });

--- a/langwatch/src/server/routes/scenario-generate.ts
+++ b/langwatch/src/server/routes/scenario-generate.ts
@@ -167,8 +167,10 @@ secured.access(
         { error: handled.serialize() },
         "Scenario generation rejected by LLM gateway",
       );
+      // The code, never `handled.message` — server copy stays server-side
+      // (ADR-045); the client keys its copy off `error.code`.
       return c.json(
-        { error: handled.message, domainError: handled.serialize() },
+        { error: handled.code, domainError: handled.serialize() },
         { status: handled.httpStatus as 400 },
       );
     }

--- a/langwatch/src/server/routes/sse.ts
+++ b/langwatch/src/server/routes/sse.ts
@@ -46,8 +46,11 @@ export function sseErrorFrame(err: unknown): Record<string, unknown> {
   if (handled) {
     return {
       type: "error",
-      message: handled.message,
-      domainError: handled.serialize(),
+      // The code, never the handled error's own message — that is server copy
+      // and can name internal configuration (ADR-045). The client keys its
+      // presentation off `error.code` via the explainers.
+      message: handled.code,
+      error: handled.serialize(),
     };
   }
   if (err instanceof TRPCError && err.code !== "INTERNAL_SERVER_ERROR") {

--- a/langwatch/src/utils/__tests__/api.unit.test.ts
+++ b/langwatch/src/utils/__tests__/api.unit.test.ts
@@ -218,7 +218,7 @@ describe("Global mutation error handler", () => {
       expect(extractLiteMemberRestrictionInfo(error)).toBeNull();
     });
 
-    it("returns null for UNAUTHORIZED without domainError", () => {
+    it("returns null for UNAUTHORIZED without a handled error", () => {
       const error = new TRPCClientError("Unauthorized", {
         result: {
           error: {
@@ -229,14 +229,14 @@ describe("Global mutation error handler", () => {
       expect(extractLiteMemberRestrictionInfo(error)).toBeNull();
     });
 
-    it("returns null for UNAUTHORIZED with wrong domainError code", () => {
+    it("returns null for UNAUTHORIZED with wrong handled error code", () => {
       const error = new TRPCClientError("Unauthorized", {
         result: {
           error: {
             data: {
               code: "UNAUTHORIZED",
               httpStatus: 401,
-              domainError: { code: "some_other_error" },
+              error: { code: "some_other_error" },
             },
           },
         },
@@ -244,14 +244,14 @@ describe("Global mutation error handler", () => {
       expect(extractLiteMemberRestrictionInfo(error)).toBeNull();
     });
 
-    it("extracts resource from lite_member_restricted domainError", () => {
+    it("extracts resource from lite_member_restricted handled error", () => {
       const error = new TRPCClientError("Unauthorized", {
         result: {
           error: {
             data: {
               code: "UNAUTHORIZED",
               httpStatus: 401,
-              domainError: {
+              error: {
                 code: "lite_member_restricted",
                 meta: { resource: "prompts" },
               },
@@ -271,7 +271,7 @@ describe("Global mutation error handler", () => {
             data: {
               code: "UNAUTHORIZED",
               httpStatus: 401,
-              domainError: {
+              error: {
                 code: "lite_member_restricted",
                 meta: {},
               },
@@ -292,7 +292,7 @@ describe("Global mutation error handler", () => {
               code: "UNAUTHORIZED",
               httpStatus: 401,
               // A pre-HandledError server serialises the discriminant as `kind`.
-              domainError: {
+              error: {
                 kind: "lite_member_restricted",
                 meta: { resource: "prompts" },
               },
@@ -389,7 +389,7 @@ describe("Global mutation error handler", () => {
             data: {
               code: "UNAUTHORIZED",
               httpStatus: 401,
-              domainError: {
+              error: {
                 code: "lite_member_restricted",
                 meta: { resource: "prompts" },
               },
@@ -444,7 +444,7 @@ describe("Global mutation error handler", () => {
             data: {
               code: "UNAUTHORIZED",
               httpStatus: 401,
-              domainError: {
+              error: {
                 code: "lite_member_restricted",
                 meta: { resource: "datasets" },
               },
@@ -485,7 +485,7 @@ describe("Global mutation error handler", () => {
             data: {
               code: "UNAUTHORIZED",
               httpStatus: 401,
-              domainError: {
+              error: {
                 code: "lite_member_restricted",
                 meta: { resource: "datasets" },
               },

--- a/langwatch/src/utils/__tests__/trpcError.errorDisplayMessage.unit.test.ts
+++ b/langwatch/src/utils/__tests__/trpcError.errorDisplayMessage.unit.test.ts
@@ -1,0 +1,61 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { errorDisplayMessage } from "../trpcError";
+
+describe("errorDisplayMessage", () => {
+  describe("when the server authored prose in meta.message", () => {
+    it("shows that prose ahead of the wire message", () => {
+      expect(
+        errorDisplayMessage({
+          message: "query_memory_exceeded",
+          data: {
+            error: {
+              code: "query_memory_exceeded",
+              meta: { message: "That query needed too much memory." },
+            },
+          },
+        }),
+      ).toBe("That query needed too much memory.");
+    });
+  });
+
+  describe("when a plain TRPCError carries copy the procedure authored", () => {
+    it("shows the wire message", () => {
+      expect(
+        errorDisplayMessage({
+          message: "Choose a project first",
+          data: { code: "BAD_REQUEST", error: null },
+        }),
+      ).toBe("Choose a project first");
+    });
+  });
+
+  describe("when a handled error carries no prose at all", () => {
+    it("falls back to the stable code rather than an empty toast", () => {
+      // The wire message IS the code here, so this is what the user sees until
+      // an explainer entry or `meta.message` exists for it.
+      expect(
+        errorDisplayMessage({
+          message: "langy_credential_resolution",
+          data: { error: { code: "langy_credential_resolution", meta: {} } },
+        }),
+      ).toBe("langy_credential_resolution");
+    });
+
+    it("uses the code when the wire message is missing entirely", () => {
+      expect(
+        errorDisplayMessage({
+          data: { error: { code: "dataset_not_found", meta: {} } },
+        }),
+      ).toBe("dataset_not_found");
+    });
+  });
+
+  describe("when given something that is not an error shape", () => {
+    it("never renders empty", () => {
+      expect(errorDisplayMessage(null)).toBe("An unknown error occurred");
+      expect(errorDisplayMessage({})).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/langwatch/src/utils/trpcError.ts
+++ b/langwatch/src/utils/trpcError.ts
@@ -1,4 +1,5 @@
 import { TRPCClientError, type TRPCClientErrorLike } from "@trpc/client";
+import type { AppRouter } from "../server/api/root";
 import type { LimitType } from "../server/license-enforcement";
 
 /**
@@ -35,7 +36,7 @@ export function errorDisplayMessage(error: unknown): string {
     : "An unknown error occurred";
 }
 
-export const isNotFound = (error: TRPCClientErrorLike<any> | null) => {
+export const isNotFound = (error: TRPCClientErrorLike<AppRouter> | null) => {
   if (
     error &&
     error instanceof TRPCClientError &&

--- a/langwatch/src/utils/trpcError.ts
+++ b/langwatch/src/utils/trpcError.ts
@@ -1,6 +1,40 @@
 import { TRPCClientError, type TRPCClientErrorLike } from "@trpc/client";
 import type { LimitType } from "../server/license-enforcement";
 
+/**
+ * The best display string for any error, in the order the wire can be trusted:
+ *
+ *   1. `data.error.meta.message` — prose that was deliberately authored to be
+ *      shown. This is the only channel that carries a user-facing sentence for
+ *      a handled error: `SerializedHandledError` has no `message` field, and a
+ *      HandledError's own `message` is server copy that never crosses the
+ *      boundary (ADR-045). Go populates it via `herr.FromBody`.
+ *   2. `error.message` — for a handled error this is now its code; for a plain
+ *      `TRPCError` it is the copy the procedure authored ("Choose a project
+ *      first"), which is still exactly what to show.
+ *   3. `data.error.code` — last resort, so the user always gets the stable
+ *      identifier rather than an empty toast.
+ *
+ * Prefer a code-keyed explainer (`explainHandledError`, `explainLangyError`)
+ * where one exists — this is the generic fallback for the surfaces that don't
+ * have bespoke copy yet.
+ */
+export function errorDisplayMessage(error: unknown): string {
+  const domain = (error as { data?: { error?: unknown } })?.data?.error as
+    | { code?: unknown; meta?: { message?: unknown } }
+    | undefined;
+
+  const authored = domain?.meta?.message;
+  if (typeof authored === "string" && authored.length > 0) return authored;
+
+  const wire = (error as { message?: unknown })?.message;
+  if (typeof wire === "string" && wire.length > 0) return wire;
+
+  return typeof domain?.code === "string"
+    ? domain.code
+    : "An unknown error occurred";
+}
+
 export const isNotFound = (error: TRPCClientErrorLike<any> | null) => {
   if (
     error &&

--- a/langwatch/src/utils/trpcError.ts
+++ b/langwatch/src/utils/trpcError.ts
@@ -97,7 +97,7 @@ export function extractLiteMemberRestrictionInfo(
   if (!(error instanceof TRPCClientError)) return null;
   if (error.data?.code !== "UNAUTHORIZED") return null;
 
-  const handledError = error.data?.domainError as
+  const handledError = error.data?.error as
     | { code?: string; kind?: string; meta?: { resource?: string } }
     | undefined;
 

--- a/packages/cli-cards/src/domain-error.test.ts
+++ b/packages/cli-cards/src/domain-error.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { parseDomainError } from "./domain-error.js";
+
+/**
+ * The platform speaks several error dialects (see `asErrorBody`). These pin the
+ * reading of the versioned `packages/api` one, where `meta` is a nested object
+ * and `message` is the code rather than a sentence — a handled error's own
+ * message is server copy and never crosses the boundary (ADR-045).
+ */
+describe("parseDomainError", () => {
+  describe("given the versioned body from packages/api", () => {
+    const versioned = (overrides: Record<string, unknown> = {}) => ({
+      code: "dataset_not_found",
+      type: "dataset_not_found",
+      kind: "dataset_not_found",
+      message: "dataset_not_found",
+      meta: { id: "ds_1" },
+      fault: "customer",
+      ...overrides,
+    });
+
+    it("reads the discriminant and keeps meta nested rather than lifting the envelope", () => {
+      const parsed = parseDomainError({ status: 404, body: versioned() });
+
+      expect(parsed.kind).toBe("dataset_not_found");
+      expect(parsed.httpStatus).toBe(404);
+      expect(parsed.isDomain).toBe(true);
+      expect(parsed.meta).toEqual({ id: "ds_1" });
+    });
+
+    it("falls back to the code when the server authored no prose", () => {
+      // `CliDomainError.message` is non-optional, so it degrades to the code
+      // rather than inventing a sentence. The handled error's own message is
+      // server copy and never reaches us (ADR-045); prose only arrives when the
+      // server put it in `meta.message`.
+      expect(parseDomainError({ status: 404, body: versioned() }).message).toBe(
+        "dataset_not_found",
+      );
+    });
+
+    it("prefers server-authored prose from meta.message", () => {
+      const parsed = parseDomainError({
+        status: 404,
+        body: versioned({
+          meta: { id: "ds_1", message: "That dataset was deleted." },
+        }),
+      });
+
+      expect(parsed.message).toBe("That dataset was deleted.");
+    });
+
+    it("resolves the discriminant from type alone when code is absent", () => {
+      // Go emits `type` (OpenAI-compatible); both names carry the same value.
+      const { code: _dropped, kind: _alsoDropped, ...typeOnly } = versioned();
+
+      expect(parseDomainError({ status: 404, body: typeOnly }).kind).toBe("dataset_not_found");
+    });
+  });
+
+  describe("given the legacy flat body", () => {
+    it("still reads the kind from error and the sentence from message", () => {
+      const parsed = parseDomainError({
+        status: 403,
+        body: {
+          error: "lite_member_restricted",
+          message: "You need a full seat.",
+        },
+      });
+
+      expect(parsed.kind).toBe("lite_member_restricted");
+      expect(parsed.message).toBe("You need a full seat.");
+      expect(parsed.isDomain).toBe(true);
+    });
+  });
+
+  describe("given a server failure", () => {
+    it("is not treated as a domain error the user caused", () => {
+      const parsed = parseDomainError({
+        status: 500,
+        body: { code: "internal_error", message: "internal_error", meta: {} },
+      });
+
+      expect(parsed.isDomain).toBe(false);
+    });
+  });
+});

--- a/packages/cli-cards/src/domain-error.ts
+++ b/packages/cli-cards/src/domain-error.ts
@@ -141,10 +141,50 @@ interface ErrorBody {
  * A route that names the kind explicitly (`{ error: <sentence>, kind, meta }`,
  * as `routes/evaluations-legacy.ts` does) is read correctly too: an explicit
  * `kind` always wins, which means `error` is free to be the sentence.
+ *
+ *   3. THE VERSIONED ONE, from `packages/api`: `{ code, type, kind,
+ *      message: <code>, meta: {…}, reasons, fault, tips, docsUrl }` — meta is a
+ *      NESTED object here, not spread, and `message` is the code rather than a
+ *      sentence (a handled error's own message is server copy and never crosses
+ *      the boundary — ADR-045). Prose, when the server deliberately authored
+ *      some, arrives as `meta.message`.
+ *
+ * The discriminant is read as `code` → `kind` → `type` → `error`. `code` is the
+ * name TypeScript uses, `type` the OpenAI-compatible name Go emits; the
+ * platform sets them to the same value, so the order only decides which one
+ * answers first.
  */
 const asErrorBody = (value: unknown): ErrorBody | null => {
   const record = asRecord(value);
   if (!record) return null;
+
+  // Dialect 3: nested `meta` means the body is already structured — read it
+  // directly instead of lifting the envelope's own fields into meta.
+  const nestedMeta = asRecord(record.meta);
+  const structuredCode =
+    typeof record.code === "string"
+      ? record.code
+      : typeof record.type === "string"
+        ? record.type
+        : null;
+  if (nestedMeta && structuredCode !== null) {
+    // `message` equal to the code carries no information; treat it as absent so
+    // callers fall through to their own copy.
+    const authored = nestedMeta.message;
+    const sentence =
+      typeof authored === "string" && authored.length > 0
+        ? authored
+        : typeof record.message === "string" && record.message !== structuredCode
+          ? record.message
+          : undefined;
+    return {
+      kind: structuredCode,
+      message: sentence,
+      meta: nestedMeta,
+      traceId: typeof record.traceId === "string" ? record.traceId : undefined,
+      reasons: asReasons(record.reasons),
+    };
+  }
 
   // Dialect 2: the serialised DomainError, carried whole under `domainError`.
   const serialized = asRecord(record.domainError);
@@ -165,25 +205,41 @@ const asErrorBody = (value: unknown): ErrorBody | null => {
     };
   }
 
-  // Dialect 1 (and the explicit-`kind` variant). One of the two must name the
-  // failure; without either, this is not the platform's shape at all.
+  // Dialect 1 (and the explicit-`kind` variant). One of these must name the
+  // failure; without any, this is not the platform's shape at all.
   const named =
-    typeof record.kind === "string"
-      ? record.kind
-      : typeof record.error === "string"
-        ? record.error
-        : null;
+    typeof record.code === "string"
+      ? record.code
+      : typeof record.kind === "string"
+        ? record.kind
+        : typeof record.type === "string"
+          ? record.type
+          : typeof record.error === "string"
+            ? record.error
+            : null;
   if (named === null) return null;
 
   // Everything the platform did NOT put in meta gets lifted out, so the flat
   // spread does not smuggle the envelope's own fields back in as domain context.
-  const { error, message, kind, telemetry, reasons, traceId, ...rest } = record;
+  // `code`/`type` are discriminants, not context — they belong here too.
+  const {
+    error,
+    message,
+    kind,
+    code,
+    type,
+    telemetry,
+    reasons,
+    traceId,
+    ...rest
+  } = record;
 
-  // When `kind` named the failure, `error` is free to be the sentence.
+  // When the failure was named by something other than `error`, `error` is free
+  // to be the sentence. A `message` equal to the code carries no information.
   const sentence =
-    typeof message === "string"
+    typeof message === "string" && message !== named
       ? message
-      : typeof kind === "string" && typeof error === "string"
+      : typeof error === "string" && error !== named
         ? error
         : undefined;
 

--- a/packages/handled-error/src/handled-error.ts
+++ b/packages/handled-error/src/handled-error.ts
@@ -78,7 +78,14 @@ export interface SerializedHandledError {
  * pre-collapsed to type "unknown".
  */
 export interface HerrEnvelope {
+  /**
+   * The discriminant, OpenAI-compatible name. Go emits this and `code` with
+   * the same value; `type` stays required here so an envelope from a writer
+   * that only sets it still parses.
+   */
   type: string;
+  /** Always equal to `type` when Go wrote the envelope. Preferred when present. */
+  code?: string;
   message: string;
   meta?: Record<string, unknown>;
   trace_id?: string;
@@ -308,9 +315,12 @@ export function handledErrorFromHerr(
   body: HerrEnvelope,
   options: { httpStatus?: number } = {},
 ): HandledError {
+  // Go emits `code` and `type` with the same value; prefer `code` and fall back
+  // to `type` so an envelope from an older writer resolves identically.
+  const code = body.code ?? body.type;
   return new (class extends HandledError {
     constructor() {
-      super(body.type, body.message, {
+      super(code, body.message, {
         meta: body.meta,
         httpStatus: options.httpStatus,
         fault: body.fault,
@@ -320,7 +330,7 @@ export function handledErrorFromHerr(
         spanId: body.span_id,
         reasons: (body.reasons ?? []).map((r) => handledErrorFromHerr(r)),
       });
-      this.name = body.type;
+      this.name = code;
     }
   })();
 }

--- a/pkg/herr/http.go
+++ b/pkg/herr/http.go
@@ -36,8 +36,15 @@ type ErrorResponse struct {
 }
 
 // ErrorBody is the error detail within the envelope.
+//
+// Type and Code always carry the same value. Type is the OpenAI-compatible
+// discriminant (see docs/ai-gateway/api/errors.mdx — provider SDKs parse it and
+// must keep raising their usual typed exceptions), and Code is the name the
+// TypeScript side uses everywhere. Emitting both means a consumer can read
+// whichever its transport taught it and always get the same answer.
 type ErrorBody struct {
 	Type    string      `json:"type"`
+	Code    string      `json:"code"`
 	Message string      `json:"message"`
 	Meta    M           `json:"meta,omitempty"`
 	TraceID string      `json:"trace_id,omitempty"`
@@ -112,11 +119,19 @@ func Body(err error) ErrorBody {
 // (message rides Meta["message"], exactly where toErrorBody promotes it from).
 // Stacks don't cross the wire; TraceID/SpanID survive when parseable.
 func FromBody(body ErrorBody) E {
+	// Code and Type always agree when we produced the envelope; prefer Code and
+	// fall back to Type so a body from an older writer (Type only) still
+	// resolves to the same error.
+	code := body.Code
+	if code == "" {
+		code = body.Type
+	}
+
 	meta := M{}
 	for k, v := range body.Meta {
 		meta[k] = v
 	}
-	if body.Message != "" && body.Message != body.Type {
+	if body.Message != "" && body.Message != code {
 		meta["message"] = body.Message
 	}
 	if len(body.Tips) > 0 {
@@ -128,7 +143,7 @@ func FromBody(body ErrorBody) E {
 	if body.Fault != "" {
 		meta["fault"] = body.Fault
 	}
-	e := E{Code: Code(body.Type), Meta: meta}
+	e := E{Code: Code(code), Meta: meta}
 	if tid, err := trace.TraceIDFromHex(body.TraceID); err == nil {
 		e.TraceID = tid
 	}
@@ -175,6 +190,7 @@ func metaStrings(m M, key string) []string {
 func toErrorBody(e E) ErrorBody {
 	body := ErrorBody{
 		Type:    string(e.Code),
+		Code:    string(e.Code),
 		Message: string(e.Code),
 	}
 

--- a/pkg/herr/http_test.go
+++ b/pkg/herr/http_test.go
@@ -12,6 +12,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBody_CarriesTypeAndCode(t *testing.T) {
+	// Both are always emitted and always agree: `type` for OpenAI-compatible
+	// consumers, `code` for everyone reading the TypeScript-side name.
+	body := Body(New(context.Background(), Code("conversation_busy"), nil))
+	assert.Equal(t, "conversation_busy", body.Type)
+	assert.Equal(t, "conversation_busy", body.Code)
+
+	// A writer that only set `type` still resolves to the same error.
+	legacy := FromBody(ErrorBody{Type: "conversation_busy", Message: "conversation_busy"})
+	assert.Equal(t, Code("conversation_busy"), legacy.Code)
+	assert.NotContains(t, legacy.Meta, "message",
+		"a message equal to the code must not be promoted into meta")
+}
+
 func TestWriteHTTP_ExposesMetaTraceAndReasons(t *testing.T) {
 	RegisterStatus("chain_exhausted", http.StatusBadGateway)
 	RegisterStatus("provider_error", http.StatusBadGateway)

--- a/python-sdk/src/langwatch/agents.py
+++ b/python-sdk/src/langwatch/agents.py
@@ -15,6 +15,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -26,7 +27,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/analytics.py
+++ b/python-sdk/src/langwatch/analytics.py
@@ -14,6 +14,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -25,7 +26,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/annotations.py
+++ b/python-sdk/src/langwatch/annotations.py
@@ -16,6 +16,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -27,7 +28,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/dashboards.py
+++ b/python-sdk/src/langwatch/dashboards.py
@@ -16,6 +16,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -27,7 +28,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/dataset/dataset_api_service.py
+++ b/python-sdk/src/langwatch/dataset/dataset_api_service.py
@@ -19,6 +19,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
     Client as LangWatchRestApiClient,
 )
 from .errors import DatasetApiError, DatasetNotFoundError, DatasetPlanLimitError
+from langwatch.utils.exceptions import extract_api_error_detail
 
 _tracer = trace.get_tracer(__name__)
 
@@ -43,7 +44,7 @@ def _raise_for_api_status(
     body: dict = {}
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/graphs.py
+++ b/python-sdk/src/langwatch/graphs.py
@@ -16,6 +16,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -27,7 +28,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/model_providers.py
+++ b/python-sdk/src/langwatch/model_providers.py
@@ -15,6 +15,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -26,7 +27,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/monitors.py
+++ b/python-sdk/src/langwatch/monitors.py
@@ -15,6 +15,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -24,7 +25,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
     if status == 404:

--- a/python-sdk/src/langwatch/scenarios.py
+++ b/python-sdk/src/langwatch/scenarios.py
@@ -15,6 +15,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -26,7 +27,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/secrets.py
+++ b/python-sdk/src/langwatch/secrets.py
@@ -15,6 +15,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -24,7 +25,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
     if status == 404:

--- a/python-sdk/src/langwatch/suites.py
+++ b/python-sdk/src/langwatch/suites.py
@@ -15,6 +15,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -26,7 +27,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/traces.py
+++ b/python-sdk/src/langwatch/traces.py
@@ -15,6 +15,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -26,7 +27,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/triggers.py
+++ b/python-sdk/src/langwatch/triggers.py
@@ -15,6 +15,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -26,7 +27,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/python-sdk/src/langwatch/utils/exceptions.py
+++ b/python-sdk/src/langwatch/utils/exceptions.py
@@ -1,8 +1,59 @@
 import traceback
-from typing import List, cast, Type
+from typing import Any, List, Mapping, Optional, cast, Type
 
 from langwatch.domain import ErrorCapture
 import httpx
+
+
+def _first_string(*candidates: Any) -> Optional[str]:
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def extract_api_error_detail(body: Any) -> str:
+    """Build a readable detail line from a LangWatch API error body.
+
+    The API never sends a handled error's own message: that text is written for
+    the server's logs and can name internal configuration, so the wire carries
+    the stable ``code`` instead. Prose appears only when the server deliberately
+    authored some, as ``meta.message``. Remediation (``tips``, ``docsUrl``) is
+    written to be shown, so it is appended when present -- that channel exists
+    precisely so callers without a UI can still self-diagnose.
+
+    Reads the discriminant as ``code`` -> ``type`` -> ``kind``; the platform
+    sets all three to the same value (``type`` is the OpenAI-compatible name
+    Go emits), so the order only decides which answers first.
+    """
+    if not isinstance(body, Mapping):
+        return ""
+
+    code = _first_string(body.get("code"), body.get("type"), body.get("kind"))
+
+    meta = body.get("meta")
+    authored = meta.get("message") if isinstance(meta, Mapping) else None
+
+    message = body.get("message")
+    if isinstance(message, str) and message == code:
+        # Equal to the code, so it adds nothing.
+        message = None
+
+    # `error` is the code on some legacy routes and the HTTP status text on
+    # unversioned ones -- only useful when nothing better named the failure.
+    detail = _first_string(authored, message, code, body.get("error")) or ""
+
+    tips = body.get("tips")
+    if isinstance(tips, list):
+        for tip in tips:
+            if isinstance(tip, str) and tip:
+                detail = f"{detail}\n  tip: {tip}" if detail else f"tip: {tip}"
+
+    docs_url = _first_string(body.get("docsUrl"), body.get("docs_url"))
+    if docs_url:
+        detail = f"{detail}\n  docs: {docs_url}" if detail else f"docs: {docs_url}"
+
+    return detail
 
 
 def capture_exception(err: BaseException):
@@ -28,9 +79,13 @@ def better_raise_for_status(response: httpx.Response, cls: Type[BaseException] =
         except Exception:
             raise http_err
 
-        if "error" in json:
-            error = json["error"]
-            message = f"{response.status_code} {error}"
+        if "error" in json or "code" in json:
+            detail = extract_api_error_detail(json)
+            message = (
+                f"{response.status_code} {detail}"
+                if detail
+                else str(response.status_code)
+            )
             # httpx.HTTPStatusError (the default cls) has request/response as
             # required keyword-only args; constructing it with only a message
             # raises a TypeError that masks the real server error. Pass them

--- a/python-sdk/src/langwatch/workflows.py
+++ b/python-sdk/src/langwatch/workflows.py
@@ -15,6 +15,7 @@ from langwatch.generated.langwatch_rest_api_client.client import (
 )
 from langwatch.utils.initialization import ensure_setup
 from langwatch.state import get_instance
+from langwatch.utils.exceptions import extract_api_error_detail
 
 
 def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
@@ -26,7 +27,7 @@ def _raise_for_status(response: httpx.Response, *, operation: str = "") -> None:
     detail = ""
     try:
         body = response.json()
-        detail = body.get("message") or body.get("error") or ""
+        detail = extract_api_error_detail(body)
     except Exception:
         detail = response.text or ""
 

--- a/services/langyagent/adapters/otelrelay/llmproxy.go
+++ b/services/langyagent/adapters/otelrelay/llmproxy.go
@@ -97,7 +97,8 @@ func (r *Relay) handleLLM(w http.ResponseWriter, req *http.Request) {
 				return nil // capture is best-effort; the proxied response stands.
 			}
 			var envelope herr.ErrorResponse
-			if json.Unmarshal(peeked, &envelope) != nil || envelope.Error.Type == "" {
+			if json.Unmarshal(peeked, &envelope) != nil ||
+				(envelope.Error.Type == "" && envelope.Error.Code == "") {
 				return nil // not a herr envelope (e.g. a raw provider body) — skip.
 			}
 			e := herr.FromBody(envelope.Error)

--- a/services/langyagent/internal/frames/frames.go
+++ b/services/langyagent/internal/frames/frames.go
@@ -244,7 +244,7 @@ func Error(message, code string) (Frame, error) {
 // that read only those.
 func ErrorFromHerr(e herr.E) (Frame, error) {
 	body := herr.Body(e)
-	return marshal(errorFrame{Type: "error", Error: body.Message, Code: body.Type, Herr: &body})
+	return marshal(errorFrame{Type: "error", Error: body.Message, Code: body.Code, Herr: &body})
 }
 
 type handoffFrame struct {

--- a/specs/features/domain-error-contract.feature
+++ b/specs/features/domain-error-contract.feature
@@ -69,10 +69,23 @@ Feature: Handled errors — the handled-error boundary
     So clients read validation detail exactly where they read every other fact
 
   @bdd @domain-errors
+  Scenario: Producers emit both names for the discriminant
+    Given a handled error is serialised by Go or by the REST layer
+    Then the body carries "type" and "code" with the same value
+    And readers resolve the discriminant as code, then kind, then type
+    So an OpenAI-compatible consumer and a LangWatch one both read it natively
+
+  @bdd @domain-errors
+  Scenario: A displayed message prefers copy that was authored to be shown
+    Given a client needs one line to show a user
+    Then it reads meta.message, then message, then code
+    And meta.message is the only channel carrying server-authored prose
+    And a handled error's own message stays server-side and is never a source
+
+  @bdd @domain-errors
   Scenario: An external contract wins over cross-transport symmetry
-    Given the AI Gateway's envelope is OpenAI-compatible
-    Then its discriminant stays "type" so provider SDKs keep raising typed errors
-    And the REST body stays flat at the root while published SDKs read `error` as a string
+    Given published SDKs read the REST body's `error` field as a string
+    Then that body stays flat at the root rather than nesting under `error`
     So consistency is pursued only where no caller contract forbids it
 
   @bdd @domain-errors

--- a/specs/features/domain-error-contract.feature
+++ b/specs/features/domain-error-contract.feature
@@ -43,6 +43,15 @@ Feature: Handled errors — the handled-error boundary
     And its httpStatus is 404
 
   @bdd @domain-errors
+  Scenario: A handled error's free-text message never crosses the tRPC boundary
+    Given a procedure throws a HandledError whose message names server configuration
+    When the client calls that procedure
+    Then the tRPC wire message is the error's stable code, not the free-text message
+    And no part of the response contains the free-text message
+    And `data.domainError` (code, meta, tips, docsUrl) is the entire client contract
+    So client copy comes from the code-keyed explainers, never from server-authored strings
+
+  @bdd @domain-errors
   Scenario: A known failure is normalised by Hono to a client-safe body
     Given a service route throws a HandledError of code "conversation_not_owned" with httpStatus 403
     When the client calls that route

--- a/specs/features/domain-error-contract.feature
+++ b/specs/features/domain-error-contract.feature
@@ -26,8 +26,8 @@ Feature: Handled errors — the handled-error boundary
 
   Background:
     Given the HandledError base and its serialisation are available in the app layer
-    And tRPC attaches a serialised handled error to `data.domainError`
-    And Hono's `onError` normalises a HandledError to `{ error: code, message, ...meta }`
+    And tRPC attaches a serialised handled error to `data.error`
+    And Hono's `onError` normalises a HandledError to `{ code, message: code, ...meta }`
 
   # ==========================================================================
   # Handled: known, user-relevant failures cross the boundary with meaning
@@ -37,7 +37,7 @@ Feature: Handled errors — the handled-error boundary
   Scenario: A known failure is serialised as a handled error over tRPC
     Given a procedure throws a NotFoundError of code "evaluation_not_found" with meta { id }
     When the client calls that procedure
-    Then the tRPC error carries `data.domainError`
+    Then the tRPC error carries `data.error`
     And the handled error has code "evaluation_not_found"
     And its meta contains the requested id
     And its httpStatus is 404
@@ -48,7 +48,7 @@ Feature: Handled errors — the handled-error boundary
     When the client calls that procedure
     Then the tRPC wire message is the error's stable code, not the free-text message
     And no part of the response contains the free-text message
-    And `data.domainError` (code, meta, tips, docsUrl) is the entire client contract
+    And `data.error` (code, meta, tips, docsUrl) is the entire client contract
     So client copy comes from the code-keyed explainers, never from server-authored strings
 
   @bdd @domain-errors
@@ -56,8 +56,24 @@ Feature: Handled errors — the handled-error boundary
     Given a service route throws a HandledError of code "conversation_not_owned" with httpStatus 403
     When the client calls that route
     Then the HTTP status is 403
-    And the response body is { error: "conversation_not_owned", message, ...meta }
+    And the response body carries code "conversation_not_owned" with its meta
+    And the body's message is that code, not the error's own free text
     And no stack trace or internal detail is present
+
+  @bdd @domain-errors
+  Scenario: Validation failures travel the one handled-error channel
+    Given a request fails input validation
+    When the error is serialised for any transport
+    Then it is a handled error of code "validation_error"
+    And the failing fields ride in its meta, not a separate zodError field
+    So clients read validation detail exactly where they read every other fact
+
+  @bdd @domain-errors
+  Scenario: An external contract wins over cross-transport symmetry
+    Given the AI Gateway's envelope is OpenAI-compatible
+    Then its discriminant stays "type" so provider SDKs keep raising typed errors
+    And the REST body stays flat at the root while published SDKs read `error` as a string
+    So consistency is pursued only where no caller contract forbids it
 
   @bdd @domain-errors
   Scenario: httpStatus follows the failure class
@@ -78,7 +94,7 @@ Feature: Handled errors — the handled-error boundary
   Scenario: A database crash is reported to the client as unknown
     Given a procedure throws a plain Error because the database connection dropped
     When the client calls that procedure
-    Then `data.domainError` is null
+    Then `data.error` is null
     And the caller sees a generic "unknown" / internal error, not the raw message
     And the underlying error is logged server-side with the trace id
 
@@ -122,6 +138,7 @@ Feature: Handled errors — the handled-error boundary
   Scenario: A streamed response carries the serialised handled error on its error event
     Given a streamed endpoint (e.g. the Langy chat stream) hits a known failure mid-stream
     Then its error event carries the SerializedHandledError, not a plain string
+    And the frame's message is the error's code, never its free text
     And the client applies the same handled/unknown logic as for a tRPC error
 
   # ==========================================================================
@@ -189,6 +206,6 @@ Feature: Handled errors — the handled-error boundary
 
   @bdd @domain-errors
   Scenario: A client resolves a handled error from either discriminant field
-    Given a client reads the discriminant off `data.domainError`
+    Given a client reads the discriminant off `data.error`
     When the payload carries only the deprecated `kind` (an older server)
     Then the client resolves the same handled error as if it had read `code`


### PR DESCRIPTION
## Problem

A `HandledError`'s message was treated as vetted user copy and passed straight through the boundary, so `langy.createConversation` returned this next to a perfectly clean serialised payload:

```json
{ "message": "LW_GATEWAY_BASE_URL is not configured on the control plane.",
  "data": { "domainError": { "code": "langy_credential_resolution", ... } } }
```

That message is written for whoever reads the logs — it names env vars, hostnames and internal services — and it was reaching browsers, REST callers and the chat stream.

## Four surfaces leaked it

Auditing every transport rather than only the reported one found three more:

| Transport | Before | After |
|---|---|---|
| tRPC | `message` = free text | `message` = code; `data.domainError` → `data.error` |
| Hono REST | `message: err.message` | `message` = code |
| SSE stream | `message: handled.message` | `message` = code; `domainError` → `error` |
| scenario-generate | `error: handled.message` | `error` = code |
| Go `herr` | already correct | unchanged |

Go was already right: `toErrorBody` defaults `Message` to the code, and free text appears only when a caller explicitly sets `Meta["message"]`.

## Both discriminant names, everywhere

Rather than break one ecosystem to satisfy the other, Go and the REST body now emit **`type` and `code` with the same value** — `type` because the gateway envelope is OpenAI-compatible (`docs/ai-gateway/api/errors.mdx`; the `openai` and Anthropic SDKs parse it and must keep raising their usual typed exceptions), `code` because that is the name TypeScript uses. Readers resolve `code` → `kind` → `type`, so a consumer gets the same answer whichever name its transport taught it. `herr.FromBody` prefers `Code` and falls back to `Type`, so an older type-only writer still round-trips.

## One rule for showing a message

`meta.message` → `message` → `code`.

- **`meta.message`** is prose the server *deliberately* authored to be shown. It is the only channel carrying a sentence, opt-in per error — which is what keeps the leak closed, since the constructor's `message` stays server-side. `herr.FromBody` populates it, so a proxied Go error explains itself.
- **`message`** is the code for a handled error, but real copy for a plain `TRPCError` a procedure authored ("Choose a project first") — still exactly what to show.
- **`code`** last, so nothing ever renders an empty string.

Implemented as `errorDisplayMessage` (app), `asErrorBody` (CLI) and `extract_api_error_detail` (Python SDK), plus both explainers' generic branches and the two `AutomationDrawer` handlers.

To answer the obvious question: `message` **is** set on `HandledError` (it is the inherited `Error.message`), but `serialize()` never emits it — `SerializedHandledError` has no `message` field by design.

## SDK / CLI

- **TS SDK + CLI** (`cli-cards`): learns the versioned `packages/api` dialect, where `meta` is nested rather than spread. Previously it lifted the envelope's own fields (`code`, `type`, `fault`, `tips`) into `meta` as domain context. Prefers `meta.message` for the sentence and ignores a `message` equal to the code.
- **Python SDK**: stops printing `f"{status} {error}"`, which since the leak fix would have shown the HTTP status text (`"409 Conflict"`). It now reads the discriminant, prefers authored prose, and appends `tips`/`docsUrl` — that channel exists precisely so a caller with no UI can self-diagnose. One helper replaces the same two-line snippet duplicated across **15** modules.

## `data.zodError` removed

A `ZodError` is promoted to the shared `ValidationError` the way Hono already did, so validation travels the one handled-error channel and its issues ride in `meta.fieldErrors`/`meta.formErrors`. It had **zero** client consumers — dead payload.

## Deployment Impact

**None.** No schema, migration, chart, env var or infrastructure change; no new service or dependency. Purely the shape of error responses.

Two behavioural notes for reviewers:

1. **Wire contract change.** Handled errors now send their code where a message used to be, on tRPC, REST and the streams. Anything downstream that string-matched an error *message* would break — nothing in-repo does (`GuardrailAttachmentsSection` matches on `"missing_perm"`, which is a code and still matches). External consumers that parsed our prose would be affected; parsing prose was never a supported contract, and `code`/`tips`/`docsUrl` are the supported replacements.
2. **`type` is additive** on both producers — no field was removed or renamed on the Go or REST wire, so existing readers are unaffected.

Rollback is a plain revert; there is no persisted state.

## Follow-ups (not in this PR)

- `data.cause` is still a parallel channel for `ModelNotConfiguredError`/`AiCallFailedError`/`ModelProviderDisabledError`/limit info, because those are plain `Error`s. Converting them to `HandledError`s collapses it into `data.error.meta` and deletes three special cases in `handledErrorMiddleware`.
- ~150 UI sites render a tRPC error's `.message` into a toast. Unhandled errors are unchanged; a **handled** one now shows its code slug unless `meta.message` is set. Each is a missing explainer entry — fixed with copy at the call site, never by re-widening the wire. `EditableTraceName` and `AutomationDrawer` are fixed here.
- **Tooling bug worth its own issue:** *any* content change to `packages/cli-cards/src/domain-error.ts` — including appending a bare comment to the pristine committed file on `main` — makes ~8 app suites fail at collection with a bogus `Cannot find module '/@fs/…/domain-error.ts'` under vitest's `vmThreads` pool. Reproduced 3/3 both ways; the module is clean under `tsc`, esbuild and `vite.ssrLoadModule`, and `cli-cards`' own 43 tests pass on the edited file.

## Testing

- Regression tests asserting `LW_GATEWAY_BASE_URL` appears nowhere in the tRPC response, plus equivalents for the Hono body and the SSE frame.
- New tests for: zod issues landing in `error.meta` with no `zodError` key; `type`+`code` agreeing and a type-only body still round-tripping (Go); the `meta.message` → `message` → `code` chain; and the CLI's versioned-dialect reading.
- `pnpm test:unit` across the affected trees: **189 files, 2401 passed**. `packages/api`: 92. `cli-cards`: 43. `handled-error`: 24. `go test ./pkg/herr/... ./services/...`: ok.
- ADR-045 amended and `domain-error-contract.feature` updated with scenarios for the dual discriminant, the display chain and the remaining asymmetry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized handled error responses now consistently use a stable `code`/`type` discriminator across API, streaming, REST, Go, and SDK clients.
  * Clients can surface server-authored `meta.message`, plus optional `tips` and documentation links; validation failures now return structured field/form error details.

* **Bug Fixes**
  * Prevented handled-error free-text and server configuration details from leaking to clients; handled transport frames now report `message` as the error `code` and carry the structured payload under `data.error`/`error`.
  * Improved error messaging consistency in automations and trace views, and updated Python SDK exceptions to derive error details via a shared extractor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->