### PR TITLE
feat(home): put the signal-focused home behind its own feature flag

### DIFF
--- a/langwatch/src/components/home/HomePage.tsx
+++ b/langwatch/src/components/home/HomePage.tsx
@@ -28,6 +28,7 @@ import { OnboardingProgress } from "./OnboardingProgress";
 import { RecentItemsSection } from "./RecentItemsSection";
 import { TimeOfDayAura } from "./TimeOfDayAura";
 import { TracesOverview } from "./TracesOverview";
+import { useShowSignalFocusedHome } from "./useShowSignalFocusedHome";
 import { useTimeOfDay, WelcomeHeader } from "./WelcomeHeader";
 
 /**
@@ -36,16 +37,22 @@ import { useTimeOfDay, WelcomeHeader } from "./WelcomeHeader";
  * lists the feature areas, so home never repeats it as cards. Onboarding
  * shows only while incomplete; resources are a quiet footer.
  *
- * Exactly two compositions, decided by the Langy gate (useShowLangy):
+ * Exactly two compositions, decided by the signal-focused-home rollout
+ * (useShowSignalFocusedHome) — NOT by Langy access:
  *
- *   - WITH Langy: the generated briefing sheet leads — LangWatch's read of
- *     the project's agentic signals, with the status figures folded in —
+ *   - SIGNAL-FOCUSED: the generated briefing sheet leads — LangWatch's read
+ *     of the project's agentic signals, with the status figures folded in —
  *     then the announcement note, recent work, and setup as a hairline.
- *   - WITHOUT Langy: the classic home — announcements, the traces overview,
- *     recent work, and the onboarding checklist (whose steps don't assume a
- *     panel the user doesn't have).
+ *   - CLASSIC: announcements, the traces overview, recent work, and the
+ *     onboarding checklist.
+ *
+ * Langy access (useShowLangy) decides only the Langy affordances within
+ * either composition: the sheet's hand-to-Langy controls gate themselves
+ * (HomeBriefingSection / QuietHeadline), and the classic traces overview
+ * shows its investigate signal only for Langy users.
  */
 export function HomePage() {
+  const showSignalFocusedHome = useShowSignalFocusedHome();
   const showLangy = useShowLangy();
   const timeOfDay = useTimeOfDay();
 
@@ -104,7 +111,7 @@ export function HomePage() {
               </HStack>
             </HStack>
 
-            {showLangy ? (
+            {showSignalFocusedHome ? (
               <>
                 <HomeBriefingSection />
                 {/* The chrome grid: two equal-height columns whose interior

--- a/langwatch/src/components/home/useShowSignalFocusedHome.ts
+++ b/langwatch/src/components/home/useShowSignalFocusedHome.ts
@@ -1,0 +1,33 @@
+import { useFeatureFlag } from "~/hooks/useFeatureFlag";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+
+/**
+ * The rollout flag the signal-focused home hangs off, and the only lever
+ * that switches the composition. Registered with `defaultValue: false`, so
+ * every project keeps the classic home until the flag is explicitly turned
+ * on for a project, an organization, or a user.
+ */
+export const SIGNAL_FOCUSED_HOME_FLAG =
+  "release_ui_home_signal_focused_enabled" as const;
+
+/**
+ * The home composition gate — "does this user get the signal-focused home?"
+ * (spec: specs/home/signal-focused-home-rollout.feature). Purely the rollout
+ * flag, evaluated for the current project: page access is already
+ * DashboardLayout's job, and Langy access is deliberately NOT part of the
+ * answer — the redesigned home rolls out on its own schedule. Langy access
+ * still gates the hand-to-Langy affordances INSIDE the sheet (useShowLangy
+ * in HomeBriefingSection and QuietHeadline), so the two rollouts compose
+ * without either implying the other.
+ */
+export function useShowSignalFocusedHome(): boolean {
+  const { project } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+  const { enabled } = useFeatureFlag(SIGNAL_FOCUSED_HOME_FLAG, {
+    projectId: project?.id,
+    enabled: !!project,
+  });
+  return enabled;
+}

--- a/langwatch/src/features/briefing/components/HomeBriefingSection.tsx
+++ b/langwatch/src/features/briefing/components/HomeBriefingSection.tsx
@@ -1,5 +1,6 @@
 import { Box, HStack, Skeleton, Text, VStack } from "@chakra-ui/react";
 import { LangyPanelSurface } from "~/features/asaplangy";
+import { useShowLangy } from "~/features/langy/hooks/useShowLangy";
 import { useLangyStore } from "~/features/langy/stores/langyStore";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { HomeOverviewCard } from "./HomeOverviewCard";
@@ -27,6 +28,11 @@ export function HomeBriefingSection() {
   const { data, statusCells, isLoading, isAnalyticsLoading, isRefreshing } =
     useLangyBriefing();
   const { project } = useOrganizationTeamProject();
+  // The sheet renders wherever the signal-focused home is rolled out — with
+  // or without Langy (spec: specs/home/signal-focused-home-rollout.feature).
+  // Without Langy, every hand-to-Langy handler stays undefined so the sheet
+  // offers only its own evidence links, never a panel that won't mount.
+  const showLangy = useShowLangy();
   const openPanel = useLangyStore((s) => s.openPanel);
   const askLangy = useLangyStore((s) => s.askLangy);
   const attachContext = useLangyStore((s) => s.attachContext);
@@ -92,10 +98,10 @@ export function HomeBriefingSection() {
   return (
     <LangyBriefing
       data={data}
-      onAsk={openPanel}
-      onAskSubmit={handleAskSubmit}
-      onFeedback={handleSignalFeedback}
-      onInvestigateReceipt={handleInvestigateReceipt}
+      onAsk={showLangy ? openPanel : undefined}
+      onAskSubmit={showLangy ? handleAskSubmit : undefined}
+      onFeedback={showLangy ? handleSignalFeedback : undefined}
+      onInvestigateReceipt={showLangy ? handleInvestigateReceipt : undefined}
       status={
         <HomeOverviewCard
           bare

--- a/langwatch/src/features/briefing/components/LangyBriefing.tsx
+++ b/langwatch/src/features/briefing/components/LangyBriefing.tsx
@@ -300,70 +300,84 @@ export function LangyBriefing({
           </VStack>
         ) : null}
 
-        <HStack
-          justify="space-between"
-          align="center"
-          gap={3}
-          wrap="wrap"
-          marginTop="auto"
-          paddingTop={2}
-        >
-          <HStack gap={2} wrap="wrap" align="center" minWidth={0}>
-            <chakra.button
-              type="button"
-              onClick={onAsk}
-              display="inline-flex"
-              alignItems="center"
-              gap={2}
-              fontFamily="mono"
-              fontSize="12.5px"
-              color="fg.muted"
-              cursor="pointer"
-              _hover={{ color: "fg" }}
-              transition="color 130ms ease"
-            >
-              Investigate
-              <Box
-                as="kbd"
-                borderWidth="1px"
-                borderColor="border.emphasized"
-                borderRadius="6px"
-                paddingX="6px"
-                paddingY="1px"
-                fontSize="10.5px"
-                color="fg.subtle"
-              >
-                ⌘I
-              </Box>
-            </chakra.button>
-            {/* One-click asks built from the project's own data — a chip is a
-                question already answered by the time the panel opens. */}
-            {data.suggestions?.map((question) => (
-              <chakra.button
-                key={question}
-                type="button"
-                onClick={() => onAskSubmit?.(question)}
-                fontFamily="mono"
-                fontSize="11.5px"
-                color="fg.muted"
-                borderWidth="1px"
-                borderColor="border.muted"
-                borderRadius="full"
-                paddingX={2.5}
-                paddingY="3px"
-                cursor="pointer"
-                whiteSpace="nowrap"
-                transition="color 130ms ease, border-color 130ms ease"
-                _hover={{ color: "orange.fg", borderColor: "orange.emphasized" }}
-              >
-                {question}
-              </chakra.button>
-            ))}
+        {/* The ask row exists to hand the sheet to Langy, so its controls
+            render only when their handlers do — without Langy the sheet
+            closes on the status figures (or the session link) instead of a
+            row of buttons that would open a panel that never mounts. */}
+        {onAsk || (onAskSubmit && data.suggestions?.length) ||
+        data.sessionHref ? (
+          <HStack
+            justify="space-between"
+            align="center"
+            gap={3}
+            wrap="wrap"
+            marginTop="auto"
+            paddingTop={2}
+          >
+            <HStack gap={2} wrap="wrap" align="center" minWidth={0}>
+              {onAsk ? (
+                <chakra.button
+                  type="button"
+                  onClick={onAsk}
+                  display="inline-flex"
+                  alignItems="center"
+                  gap={2}
+                  fontFamily="mono"
+                  fontSize="12.5px"
+                  color="fg.muted"
+                  cursor="pointer"
+                  _hover={{ color: "fg" }}
+                  transition="color 130ms ease"
+                >
+                  Investigate
+                  <Box
+                    as="kbd"
+                    borderWidth="1px"
+                    borderColor="border.emphasized"
+                    borderRadius="6px"
+                    paddingX="6px"
+                    paddingY="1px"
+                    fontSize="10.5px"
+                    color="fg.subtle"
+                  >
+                    ⌘I
+                  </Box>
+                </chakra.button>
+              ) : null}
+              {/* One-click asks built from the project's own data — a chip is a
+                  question already answered by the time the panel opens. */}
+              {onAskSubmit
+                ? data.suggestions?.map((question) => (
+                    <chakra.button
+                      key={question}
+                      type="button"
+                      onClick={() => onAskSubmit(question)}
+                      fontFamily="mono"
+                      fontSize="11.5px"
+                      color="fg.muted"
+                      borderWidth="1px"
+                      borderColor="border.muted"
+                      borderRadius="full"
+                      paddingX={2.5}
+                      paddingY="3px"
+                      cursor="pointer"
+                      whiteSpace="nowrap"
+                      transition="color 130ms ease, border-color 130ms ease"
+                      _hover={{
+                        color: "orange.fg",
+                        borderColor: "orange.emphasized",
+                      }}
+                    >
+                      {question}
+                    </chakra.button>
+                  ))
+                : null}
+            </HStack>
+            {data.sessionHref ? (
+              <BriefingLink label="Open session" href={data.sessionHref} />
+            ) : null}
           </HStack>
-          {data.sessionHref ? (
-            <BriefingLink label="Open session" href={data.sessionHref} />
-          ) : null}
-        </HStack>
+        ) : null}
       </VStack>
     </LangyPanelSurface>
   );

--- a/langwatch/src/features/briefing/components/LangyBriefing.unit.test.tsx
+++ b/langwatch/src/features/briefing/components/LangyBriefing.unit.test.tsx
@@ -28,10 +28,14 @@ const data: BriefingData = {
   headline: "1 signal needs attention.",
   receiptsLabel: "Attention inbox",
   receipts: [receipt],
+  suggestions: ["Why did errors spike?"],
 };
 
 function renderBriefing(props: {
   onInvestigateReceipt?: (item: BriefingReceipt) => void;
+  onAsk?: () => void;
+  onAskSubmit?: (question: string) => void;
+  onFeedback?: () => void;
 }) {
   return render(
     <ChakraProvider value={defaultSystem}>
@@ -70,5 +74,45 @@ describe("LangyBriefing attention inbox actions", () => {
     expect(
       screen.queryByRole("button", { name: /Ask Langy about/ }),
     ).toBeNull();
+  });
+});
+
+describe("LangyBriefing without Langy", () => {
+  describe("when no Langy handlers are provided", () => {
+    it("keeps the row's Trace Explorer evidence link working", () => {
+      renderBriefing({});
+
+      expect(
+        screen
+          .getByRole("link", { name: "Open traces for New error shape" })
+          .getAttribute("href"),
+      ).toBe(receipt.link?.href);
+    });
+
+    it("offers no control that hands a signal to Langy", () => {
+      renderBriefing({});
+
+      expect(screen.queryByRole("button", { name: /in Langy/ })).toBeNull();
+      expect(screen.queryByRole("button", { name: /Investigate/ })).toBeNull();
+      expect(screen.queryByText("⌘I")).toBeNull();
+      expect(
+        screen.queryByRole("button", { name: "Why did errors spike?" }),
+      ).toBeNull();
+      expect(screen.queryByText("Missing a signal? Tell us")).toBeNull();
+    });
+  });
+
+  describe("when Langy handlers are provided", () => {
+    it("renders the ask row and sends the clicked suggestion chip", () => {
+      const onAskSubmit = vi.fn();
+      renderBriefing({ onAsk: vi.fn(), onAskSubmit });
+
+      expect(screen.getByText("⌘I")).toBeDefined();
+      fireEvent.click(
+        screen.getByRole("button", { name: "Why did errors spike?" }),
+      );
+
+      expect(onAskSubmit).toHaveBeenCalledWith("Why did errors spike?");
+    });
   });
 });

--- a/langwatch/src/features/briefing/components/QuietHeadline.tsx
+++ b/langwatch/src/features/briefing/components/QuietHeadline.tsx
@@ -3,6 +3,7 @@ import { Sparkles } from "lucide-react";
 import { motion } from "motion/react";
 import { useEffect, useState } from "react";
 import type { MouseEvent } from "react";
+import { useShowLangy } from "~/features/langy/hooks/useShowLangy";
 import { useLangyStore } from "~/features/langy/stores/langyStore";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useReducedMotion } from "~/hooks/useReducedMotion";
@@ -66,6 +67,11 @@ export function QuietHeadline() {
   const router = useRouter();
   const { project } = useOrganizationTeamProject();
   const askLangy = useLangyStore((s) => s.askLangy);
+  // The invitation renders wherever the signal-focused home does, which no
+  // longer implies Langy (spec: specs/home/signal-focused-home-rollout.feature).
+  // Without Langy, the typed phrase opens the feature surface instead of a
+  // conversation, and the hand-to-Langy action disappears.
+  const showLangy = useShowLangy();
 
   // One tiny state machine: grow to the full phrase, hold, shrink to zero,
   // step to the next phrase. Each transition schedules exactly one timeout,
@@ -109,6 +115,17 @@ export function QuietHeadline() {
     void router.push(action.href(project.slug));
   };
 
+  // The typed phrase's click: hand the suggestion to Langy when the user has
+  // it, otherwise open the surface that teaches the step — the phrase is
+  // never a dead control.
+  const onPhrase = () => {
+    if (showLangy) {
+      askLangy(action.ask);
+    } else if (project) {
+      void router.push(action.href(project.slug));
+    }
+  };
+
   return (
     <chakra.div>
       <Text
@@ -125,8 +142,12 @@ export function QuietHeadline() {
             suggestion to Langy, question already sent. */}
         <chakra.button
           type="button"
-          onClick={() => askLangy(action.ask)}
-          aria-label={`Ask Langy: ${action.phrase}`}
+          onClick={onPhrase}
+          aria-label={
+            showLangy
+              ? `Ask Langy: ${action.phrase}`
+              : `Learn more: ${action.phrase}`
+          }
           fontFamily="inherit"
           fontSize="inherit"
           letterSpacing="inherit"
@@ -172,25 +193,27 @@ export function QuietHeadline() {
         >
           Learn more →
         </chakra.a>
-        <chakra.button
-          type="button"
-          onClick={() => askLangy(action.ask)}
-          display="inline-flex"
-          alignItems="center"
-          gap={1}
-          fontFamily="mono"
-          fontSize="12px"
-          color="orange.fg"
-          cursor="pointer"
-          whiteSpace="nowrap"
-          borderBottomWidth="1px"
-          borderColor="transparent"
-          transition="border-color 130ms ease"
-          _hover={{ borderColor: "orange.fg" }}
-        >
-          <Sparkles size={12} />
-          Do it with Langy
-        </chakra.button>
+        {showLangy ? (
+          <chakra.button
+            type="button"
+            onClick={() => askLangy(action.ask)}
+            display="inline-flex"
+            alignItems="center"
+            gap={1}
+            fontFamily="mono"
+            fontSize="12px"
+            color="orange.fg"
+            cursor="pointer"
+            whiteSpace="nowrap"
+            borderBottomWidth="1px"
+            borderColor="transparent"
+            transition="border-color 130ms ease"
+            _hover={{ borderColor: "orange.fg" }}
+          >
+            <Sparkles size={12} />
+            Do it with Langy
+          </chakra.button>
+        ) : null}
       </HStack>
     </chakra.div>
   );

--- a/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
@@ -60,6 +60,10 @@ export const FRONTEND_FEATURE_FLAGS = [
   "release_ui_ai_governance_enabled",
   "release_langy_enabled",
   "release_langy_promo_enabled",
+  // The signal-focused home composition (briefing sheet leads). Decides
+  // the homepage's layout ONLY — Langy access separately gates the
+  // sheet's hand-to-Langy affordances. See useShowSignalFocusedHome.
+  "release_ui_home_signal_focused_enabled",
   "release_webhook_automations",
 ] as const;
 

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -205,6 +205,13 @@ export const FEATURE_FLAGS = [
       "Shows the Langy teaser banner on the home page to users who do NOT have Langy yet (spec: specs/home/langy-home-banner.feature). Purely promotional — it never grants access; users who already have Langy (staff or release_langy_enabled) see the activation banner instead, regardless of this flag. Target the promo audience via a PostHog rule.",
   },
   {
+    key: "release_ui_home_signal_focused_enabled",
+    scope: "PRODUCT",
+    defaultValue: false,
+    description:
+      "Switches the project home to the signal-focused composition — the briefing sheet leads, the chrome grid and recent work follow (spec: specs/home/signal-focused-home-rollout.feature). Deliberately decoupled from release_langy_enabled: this flag alone decides the home's composition, while Langy access only decides whether the sheet's hand-to-Langy affordances render. Default off = classic home. Force-enable in dev via FEATURE_FLAG_FORCE_ENABLE=release_ui_home_signal_focused_enabled.",
+  },
+  {
     key: "release_webhook_automations",
     scope: "PRODUCT",
     defaultValue: false,

--- a/specs/home/signal-focused-home-rollout.feature
+++ b/specs/home/signal-focused-home-rollout.feature
@@ -1,0 +1,50 @@
+@unit
+Feature: Signal-focused home rollout
+  As a returning project member
+  I want the signal-focused home rolled out on its own switch
+  So that the homepage redesign reaches users independently of the Langy
+  assistant's own rollout
+
+  The homepage has exactly two compositions: the signal-focused home — the
+  briefing sheet leads, the chrome grid and recent work follow — and the
+  classic home — banners, the traces overview, recent work, onboarding.
+  Which one renders is decided only by the signal-focused-home rollout,
+  never by Langy access. Langy access decides exactly one thing inside the
+  page: whether the sheet's hand-to-Langy affordances render.
+
+  Scenario: The rollout decides the composition, not Langy
+    Given the signal-focused home is enabled for me
+    But I do not have Langy
+    When the home page renders
+    Then the briefing sheet leads the page
+    And the classic traces overview and onboarding checklist are not shown
+
+  Scenario: Langy alone no longer switches the home
+    Given I have Langy
+    But the signal-focused home is not enabled for me
+    When the home page renders
+    Then the classic home renders with banners, the traces overview, recent items, and onboarding
+    And the Langy panel itself stays available
+
+  Scenario: Without Langy the sheet keeps working, quietly
+    Given the signal-focused home is enabled for me
+    But I do not have Langy
+    When the briefing sheet renders
+    Then each attention-inbox row still opens its Trace Explorer evidence
+    And no control offers to hand a signal to Langy
+    And the ask row and its suggestion chips are not shown
+
+  Scenario: With Langy the sheet keeps its hand-offs
+    Given the signal-focused home is enabled for me
+    And I have Langy
+    When the briefing sheet renders
+    Then each attention-inbox row can hand its evidence to Langy
+    And the ask row opens Langy with the composer focused
+
+  Scenario: The quiet invitation adapts to Langy's absence
+    Given the signal-focused home is enabled for me
+    But I do not have Langy
+    And the project is quiet
+    When the briefing sheet renders its invitation
+    Then the typed first step opens the feature surface that teaches it
+    And no action offers to do it with Langy


### PR DESCRIPTION
## What

The redesigned homepage (the signal-focused composition — briefing sheet leads, chrome grid + recents follow) was gated on `release_langy_enabled`. It now hangs off its own flag, **`release_ui_home_signal_focused_enabled`**, so the home redesign rolls out independently of the Langy assistant.

## How the two flags now compose

- **`release_ui_home_signal_focused_enabled`** decides the home's *composition* (signal-focused vs classic) — nothing else. New hook: `useShowSignalFocusedHome` (`src/components/home/useShowSignalFocusedHome.ts`).
- **`release_langy_enabled`** (`useShowLangy`) decides only the *hand-to-Langy affordances* inside either composition:
  - `HomeBriefingSection` withholds its four Langy handlers without Langy, so the sheet offers only its own Trace Explorer evidence links.
  - `LangyBriefing` hides the per-row Investigate buttons, the ⌘I ask row, and the suggestion chips when their handlers are absent (previously the ⌘I button and chips rendered unconditionally — they'd have been dead controls).
  - `QuietHeadline`'s typed invitation opens the feature surface instead of a Langy conversation, and drops "Do it with Langy".
  - The classic home's `TracesOverview` investigate signal stays tied to Langy — a Langy user on the classic home now actually gets it (it was previously unreachable dead code in that branch).

## Rollout note (operators)

The new flag defaults **off**. Any cohort currently seeing the new home via `release_langy_enabled` falls back to the classic home on deploy until `release_ui_home_signal_focused_enabled` is flipped for the same cohort (PostHog rule / ops row / `FEATURE_FLAG_FORCE_ENABLE=release_ui_home_signal_focused_enabled` in dev). The Langy panel itself is unaffected.

## Spec

`specs/home/signal-focused-home-rollout.feature`

## Tests

- `LangyBriefing.unit.test.tsx`: new cases locking the without-Langy sheet (evidence links keep working; no control hands a signal to Langy) and the with-Langy ask row/chips.
- Ran: briefing + home + featureFlag unit suites (98 tests), home/briefing/langy integration suites (69 tests) — all green. Touched files clean under tslsp diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a signal-focused home layout that can be enabled independently from Langy access.
  * Updated home content to adapt based on rollout settings, including briefing, recent work, onboarding, and traces views.
  * Langy actions now appear only when available, while non-Langy users retain access to relevant Trace Explorer links.
  * Quiet-mode suggestions now provide an appropriate alternative action when Langy is unavailable.

* **Bug Fixes**
  * Prevented unavailable Langy controls, prompts, and suggestion actions from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->