### PR TITLE
fix(workflows): throw NotFoundError/ValidationError from runWorkflow, not plain Error

### DIFF
--- a/langwatch/src/server/routes/__tests__/workflows-run-not-found.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/workflows-run-not-found.integration.test.ts
@@ -73,7 +73,7 @@ describe.skipIf(isTestcontainersOnly)(
       await prisma.organization.delete({ where: { id: organizationId } });
     });
 
-    /** @scenario Running a nonexistent workflow returns 404, not a raw 500 */
+    /** @scenario Running a nonexistent workflow returns 404 */
     it("returns 404 for a nonexistent workflow id", async () => {
       const { app } = await import("../misc");
 
@@ -91,7 +91,7 @@ describe.skipIf(isTestcontainersOnly)(
       expect(body.error).toBe("workflow_not_found");
     });
 
-    /** @scenario Running a never-published workflow returns 422, not a raw 500 */
+    /** @scenario Running a workflow that has never been published returns 422 */
     it("returns 422 for a workflow that has never been published", async () => {
       const { app } = await import("../misc");
 

--- a/langwatch/src/server/routes/__tests__/workflows-run-not-found.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/workflows-run-not-found.integration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment node
+ *
+ * POST /api/workflows/:workflowId/run must surface a 404/422 through the
+ * real HTTP path, not the raw 500 `handleWorkflowRun` used to hard-code —
+ * a review comment on the runWorkflow.ts unit-level fix flagged that the
+ * route's own try/catch swallowed the newly typed errors before they ever
+ * reached the app's onError(handleError) middleware. This proves the fix
+ * end-to-end through the actual Hono route, not just runWorkflow() in
+ * isolation (see runWorkflow.not-found.unit.test.ts for that).
+ *
+ * Requires: PostgreSQL database (Prisma)
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+
+const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+
+describe.skipIf(isTestcontainersOnly)(
+  "POST /api/workflows/:workflowId/run",
+  () => {
+    const testNamespace = `workflow-run-${nanoid(8)}`;
+    let organizationId: string;
+    let teamId: string;
+    let projectId: string;
+    let apiKey: string;
+    let unpublishedWorkflowId: string;
+
+    beforeAll(async () => {
+      const organization = await prisma.organization.create({
+        data: { name: "Test Org", slug: `--test-org-${testNamespace}` },
+      });
+      organizationId = organization.id;
+      const team = await prisma.team.create({
+        data: {
+          name: "Test Team",
+          slug: `--test-team-${testNamespace}`,
+          organizationId,
+        },
+      });
+      teamId = team.id;
+      apiKey = `sk-lw-test-${nanoid()}`;
+      const project = await prisma.project.create({
+        data: {
+          name: "Test Project",
+          slug: `--test-project-${testNamespace}`,
+          apiKey,
+          teamId,
+          language: "en",
+          framework: "test",
+        },
+      });
+      projectId = project.id;
+
+      const workflow = await prisma.workflow.create({
+        data: {
+          projectId,
+          name: "Unpublished Workflow",
+          icon: "🧩",
+          description: "",
+          publishedId: null,
+        },
+      });
+      unpublishedWorkflowId = workflow.id;
+    });
+
+    afterAll(async () => {
+      await prisma.workflow.delete({ where: { id: unpublishedWorkflowId } });
+      await prisma.project.delete({ where: { id: projectId } });
+      await prisma.team.delete({ where: { id: teamId } });
+      await prisma.organization.delete({ where: { id: organizationId } });
+    });
+
+    /** @scenario Running a nonexistent workflow returns 404, not a raw 500 */
+    it("returns 404 for a nonexistent workflow id", async () => {
+      const { app } = await import("../misc");
+
+      const res = await app.request("/api/workflows/nonexistent-workflow/run", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Auth-Token": apiKey,
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error: string; message: string };
+      expect(body.error).toBe("workflow_not_found");
+    });
+
+    /** @scenario Running a never-published workflow returns 422, not a raw 500 */
+    it("returns 422 for a workflow that has never been published", async () => {
+      const { app } = await import("../misc");
+
+      const res = await app.request(
+        `/api/workflows/${unpublishedWorkflowId}/run`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Auth-Token": apiKey,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      expect(res.status).toBe(422);
+      const body = (await res.json()) as { error: string; message: string };
+      expect(body.message).toBe("Workflow not published");
+    });
+  },
+);

--- a/langwatch/src/server/routes/__tests__/workflows-run-not-found.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/workflows-run-not-found.integration.test.ts
@@ -12,13 +12,17 @@
  * Requires: PostgreSQL database (Prisma)
  */
 import { nanoid } from "nanoid";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { prisma } from "~/server/db";
 
-const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
-
-describe.skipIf(isTestcontainersOnly)(
+// This suite only needs Postgres — every harness (CI's testcontainers,
+// native local services) provides that, so it runs unconditionally. Do NOT
+// add an `isTestcontainersOnly`/`TEST_CLICKHOUSE_URL` skip guard here: CI
+// always sets TEST_CLICKHOUSE_URL for the ClickHouse-dependent suites in
+// this same integration run, so that guard would permanently skip this
+// file everywhere it matters (caught in review — see PR #5988).
+describe(
   "POST /api/workflows/:workflowId/run",
   () => {
     const testNamespace = `workflow-run-${nanoid(8)}`;
@@ -41,6 +45,10 @@ describe.skipIf(isTestcontainersOnly)(
         },
       });
       teamId = team.id;
+      // The "sk-lw-test-" shape deliberately fails the scoped-API-key regex
+      // (api-key-token.utils.ts), so auth falls back to legacyProjectKey —
+      // which bypasses the RBAC ceiling check entirely (auth-middleware.ts).
+      // A realistic sk-lw-{16}_{48} key would 401 here instead.
       apiKey = `sk-lw-test-${nanoid()}`;
       const project = await prisma.project.create({
         data: {
@@ -67,10 +75,20 @@ describe.skipIf(isTestcontainersOnly)(
     });
 
     afterAll(async () => {
-      await prisma.workflow.delete({ where: { id: unpublishedWorkflowId } });
-      await prisma.project.delete({ where: { id: projectId } });
-      await prisma.team.delete({ where: { id: teamId } });
-      await prisma.organization.delete({ where: { id: organizationId } });
+      // Each delete guarded independently: a partial beforeAll failure must
+      // not orphan the rows it did manage to create in the shared test DB.
+      if (unpublishedWorkflowId) {
+        await prisma.workflow.delete({ where: { id: unpublishedWorkflowId } });
+      }
+      if (projectId) {
+        await prisma.project.delete({ where: { id: projectId } });
+      }
+      if (teamId) {
+        await prisma.team.delete({ where: { id: teamId } });
+      }
+      if (organizationId) {
+        await prisma.organization.delete({ where: { id: organizationId } });
+      }
     });
 
     /** @scenario Running a nonexistent workflow returns 404 */
@@ -110,6 +128,41 @@ describe.skipIf(isTestcontainersOnly)(
       expect(res.status).toBe(422);
       const body = (await res.json()) as { error: string; message: string };
       expect(body.message).toBe("Workflow not published");
+    });
+
+    describe("when runWorkflow throws an untyped error", () => {
+      afterEach(() => {
+        vi.doUnmock("~/server/workflows/runWorkflow");
+        vi.resetModules();
+      });
+
+      /** @scenario An untyped runWorkflow error still returns a safe 500, not a leaked message */
+      it("returns a generic 500 without leaking the internal error message", async () => {
+        vi.resetModules();
+        vi.doMock("~/server/workflows/runWorkflow", () => ({
+          runWorkflow: vi
+            .fn()
+            .mockRejectedValue(new Error("db connection refused at 10.0.0.5")),
+        }));
+        const { app } = await import("../misc");
+
+        const res = await app.request(
+          `/api/workflows/${unpublishedWorkflowId}/run`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-Auth-Token": apiKey,
+            },
+            body: JSON.stringify({}),
+          },
+        );
+
+        expect(res.status).toBe(500);
+        const body = (await res.json()) as { error: string; message: string };
+        expect(body.message).toBe("An unknown error occurred");
+        expect(JSON.stringify(body)).not.toContain("10.0.0.5");
+      });
     });
   },
 );

--- a/langwatch/src/server/routes/misc.ts
+++ b/langwatch/src/server/routes/misc.ts
@@ -660,34 +660,15 @@ secured
     authMiddleware,
     requireWorkflowsManage,
     async (c) => {
-      const workflowId = c.req.param("workflowId");
-      const versionId = c.req.param("versionId");
-
-      const contentType = c.req.header("content-type");
-      if (!contentType?.includes("application/json")) {
-        return c.json({ message: "Invalid body, expecting json" }, 400);
-      }
-
-      const project = c.get("project");
-
-      let body: Record<string, any>;
-      try {
-        body = await c.req.json();
-      } catch {
-        return c.json({ message: "Invalid body" }, 400);
-      }
-
-      try {
-        const result = await runWorkflowFn(
-          workflowId,
-          project.id,
-          body,
-          versionId,
-        );
-        return c.json(result);
-      } catch (error) {
-        return c.json({ message: (error as Error).message }, 500);
-      }
+      // Delegates to the same handler as POST /workflows/:workflowId/:versionId/run
+      // (below) — this route used to duplicate that logic with its own
+      // catch-and-flatten-to-500, which had drifted to disagree with the
+      // canonical route on the status code for identical failures.
+      return handleWorkflowRun(
+        c,
+        c.req.param("workflowId"),
+        c.req.param("versionId"),
+      );
     },
   );
 

--- a/langwatch/src/server/routes/misc.ts
+++ b/langwatch/src/server/routes/misc.ts
@@ -1019,12 +1019,12 @@ async function handleWorkflowRun(
     return c.json({ message: "Invalid body" }, 400);
   }
 
-  try {
-    const result = await runWorkflowFn(workflowId, project.id, body, versionId);
-    return c.json(result);
-  } catch (error) {
-    return c.json({ message: (error as Error).message }, 500);
-  }
+  // Let errors propagate to the app's onError(handleError) middleware — it
+  // already knows how to map HandledError subclasses (e.g. runWorkflow's
+  // NotFoundError/ValidationError) to the right status code. Catching here
+  // and hard-coding 500 was masking those as raw 500s regardless of type.
+  const result = await runWorkflowFn(workflowId, project.id, body, versionId);
+  return c.json(result);
 }
 
 // =============================================

--- a/langwatch/src/server/workflows/__tests__/runWorkflow.not-found.unit.test.ts
+++ b/langwatch/src/server/workflows/__tests__/runWorkflow.not-found.unit.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Found via a systematic MCP tool sweep: platform_run_workflow on a
+ * nonexistent workflow ID returned a raw 500 ("Workflow not found.") while
+ * platform_get_workflow/platform_delete_workflow on the exact same ID
+ * correctly returned 404. runWorkflow() threw a plain Error, which falls
+ * through every case in error-handler.ts's determineErrorResponse() and
+ * lands in the generic 500 catch-all -- the same bug class as
+ * ModelNotConfiguredError (see fix/model-not-configured-error-500).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+const findUniqueMock = vi.fn();
+vi.mock("../../db", () => ({
+  prisma: {
+    workflow: { findUnique: (...args: unknown[]) => findUniqueMock(...args) },
+  },
+}));
+
+import { NotFoundError, UnprocessableEntityError } from "~/app/api/shared/errors";
+import { runWorkflow } from "../runWorkflow";
+
+describe("runWorkflow()", () => {
+  describe("when the workflow does not exist", () => {
+    it("throws NotFoundError instead of a plain Error", async () => {
+      findUniqueMock.mockResolvedValue(null);
+
+      await expect(
+        runWorkflow("nonexistent-workflow", "project_123", {}),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+  });
+
+  describe("when the workflow exists but has never been published", () => {
+    it("throws UnprocessableEntityError instead of a plain Error", async () => {
+      findUniqueMock.mockResolvedValue({ id: "wf_1", publishedId: null });
+
+      await expect(
+        runWorkflow("wf_1", "project_123", {}),
+      ).rejects.toBeInstanceOf(UnprocessableEntityError);
+    });
+  });
+});

--- a/langwatch/src/server/workflows/__tests__/runWorkflow.not-found.unit.test.ts
+++ b/langwatch/src/server/workflows/__tests__/runWorkflow.not-found.unit.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-const findUniqueMock = vi.fn();
+const { findUniqueMock } = vi.hoisted(() => ({ findUniqueMock: vi.fn() }));
 vi.mock("../../db", () => ({
   prisma: {
     workflow: { findUnique: (...args: unknown[]) => findUniqueMock(...args) },

--- a/langwatch/src/server/workflows/__tests__/runWorkflow.not-found.unit.test.ts
+++ b/langwatch/src/server/workflows/__tests__/runWorkflow.not-found.unit.test.ts
@@ -16,12 +16,12 @@ vi.mock("../../db", () => ({
   },
 }));
 
-import { NotFoundError, UnprocessableEntityError } from "~/app/api/shared/errors";
+import { NotFoundError, ValidationError } from "@langwatch/handled-error";
 import { runWorkflow } from "../runWorkflow";
 
 describe("runWorkflow()", () => {
   describe("when the workflow does not exist", () => {
-    it("throws NotFoundError instead of a plain Error", async () => {
+    it("throws a HandledError NotFoundError instead of a plain Error", async () => {
       findUniqueMock.mockResolvedValue(null);
 
       await expect(
@@ -31,12 +31,12 @@ describe("runWorkflow()", () => {
   });
 
   describe("when the workflow exists but has never been published", () => {
-    it("throws UnprocessableEntityError instead of a plain Error", async () => {
+    it("throws a HandledError ValidationError instead of a plain Error", async () => {
       findUniqueMock.mockResolvedValue({ id: "wf_1", publishedId: null });
 
       await expect(
         runWorkflow("wf_1", "project_123", {}),
-      ).rejects.toBeInstanceOf(UnprocessableEntityError);
+      ).rejects.toBeInstanceOf(ValidationError);
     });
   });
 });

--- a/langwatch/src/server/workflows/errors.ts
+++ b/langwatch/src/server/workflows/errors.ts
@@ -1,0 +1,22 @@
+import { HandledError } from "@langwatch/handled-error";
+
+/**
+ * nlpgo (the Go execution engine) responded with a non-OK HTTP status while
+ * running the workflow. The response's `statusText` can carry upstream
+ * implementation detail, so it stays server-side (log it at the throw site)
+ * — the client only gets this safe, generic message.
+ */
+export class WorkflowExecutionFailedError extends HandledError {
+  declare readonly code: "workflow_execution_failed";
+
+  constructor(options: { reasons?: readonly Error[] } = {}) {
+    super("workflow_execution_failed", "The workflow failed to run.", {
+      httpStatus: 502,
+      // The execution engine is our own infra — a non-OK response from it
+      // is an incident, not a caller mistake.
+      fault: "platform",
+      ...options,
+    });
+    this.name = "WorkflowExecutionFailedError";
+  }
+}

--- a/langwatch/src/server/workflows/runWorkflow.ts
+++ b/langwatch/src/server/workflows/runWorkflow.ts
@@ -1,6 +1,10 @@
 import { createLogger } from "@langwatch/observability";
 import type { Node } from "@xyflow/react";
 import { nanoid } from "nanoid";
+import {
+  NotFoundError,
+  UnprocessableEntityError,
+} from "~/app/api/shared/errors";
 import { addEnvs } from "../../optimization_studio/server/addEnvs";
 import type {
   ExecutionStatus,
@@ -191,10 +195,10 @@ export async function runWorkflow(
   });
 
   if (!workflow) {
-    throw new Error("Workflow not found.");
+    throw new NotFoundError("Workflow not found.");
   }
   if (!workflow.publishedId) {
-    throw new Error("Workflow not published");
+    throw new UnprocessableEntityError("Workflow not published");
   }
 
   const publishedWorkflowVersion = await prisma.workflowVersion.findUnique({

--- a/langwatch/src/server/workflows/runWorkflow.ts
+++ b/langwatch/src/server/workflows/runWorkflow.ts
@@ -1,10 +1,7 @@
+import { NotFoundError, ValidationError } from "@langwatch/handled-error";
 import { createLogger } from "@langwatch/observability";
 import type { Node } from "@xyflow/react";
 import { nanoid } from "nanoid";
-import {
-  NotFoundError,
-  UnprocessableEntityError,
-} from "~/app/api/shared/errors";
 import { addEnvs } from "../../optimization_studio/server/addEnvs";
 import type {
   ExecutionStatus,
@@ -195,10 +192,12 @@ export async function runWorkflow(
   });
 
   if (!workflow) {
-    throw new NotFoundError("Workflow not found.");
+    throw new NotFoundError("workflow_not_found", "Workflow", workflowId);
   }
   if (!workflow.publishedId) {
-    throw new UnprocessableEntityError("Workflow not published");
+    throw new ValidationError("Workflow not published", {
+      meta: { workflowId },
+    });
   }
 
   const publishedWorkflowVersion = await prisma.workflowVersion.findUnique({

--- a/langwatch/src/server/workflows/runWorkflow.ts
+++ b/langwatch/src/server/workflows/runWorkflow.ts
@@ -15,6 +15,7 @@ import { prisma } from "../db";
 import type { SingleEvaluationResult } from "../evaluations/evaluators";
 import type { MaybeStoredModelProvider } from "../modelProviders/registry";
 import { type NLPOrigin, nlpgoFetch } from "../nlpgo/nlpgoFetch";
+import { WorkflowExecutionFailedError } from "./errors";
 import { stripUnsupportedLLMParamsFromWorkflow } from "./stripUnsupportedLLMParams";
 
 const logger = createLogger("langwatch:workflows:runWorkflow");
@@ -56,7 +57,9 @@ const checkForRequiredInputs = (
 
   requiredInputs.forEach((input) => {
     if (!bodyInputs.includes(input)) {
-      throw new Error(`Missing required input: ${input}`);
+      throw new ValidationError(`Missing required input: ${input}`, {
+        meta: { input },
+      });
     }
   });
   return true;
@@ -98,8 +101,9 @@ const checkForRequiredLLMKeys = (
     llmModelsNeeded.includes(key),
   );
   if (missingKey) {
-    throw new Error(
+    throw new ValidationError(
       `Missing required LLM key: ${missingKey}. Please set the LLM key in the project settings`,
+      { meta: { missingKey } },
     );
   }
   return true;
@@ -200,15 +204,20 @@ export async function runWorkflow(
     });
   }
 
+  const resolvedVersionId = versionId ?? workflow.publishedId;
   const publishedWorkflowVersion = await prisma.workflowVersion.findUnique({
     where: {
-      id: versionId ?? workflow.publishedId,
+      id: resolvedVersionId,
       projectId,
     },
   });
 
   if (!publishedWorkflowVersion) {
-    throw new Error("Published workflow version not found.");
+    throw new NotFoundError(
+      "published_workflow_version_not_found",
+      "Published workflow version",
+      resolvedVersionId,
+    );
   }
 
   // Published versions can predate the node-owned LLM config migration
@@ -288,7 +297,11 @@ export async function runWorkflow(
   });
 
   if (!response.ok) {
-    throw new Error(`Error running workflow: ${response.statusText}`);
+    logger.error(
+      { status: response.status, statusText: response.statusText, projectId, workflowId },
+      "nlpgo execute_sync returned a non-OK response",
+    );
+    throw new WorkflowExecutionFailedError();
   }
 
   return await response.json();

--- a/specs/run-via-api/run-workflow-typed-errors.feature
+++ b/specs/run-via-api/run-workflow-typed-errors.feature
@@ -1,0 +1,22 @@
+@integration
+Feature: Running a workflow via the API surfaces typed errors
+  As an agent or script calling POST /api/workflows/:workflowId/run
+  I want a 404 for a missing workflow and a 422 for an unpublished one
+  So that I can tell "fix your request" apart from "something broke on your end"
+
+  # Implementation:
+  #   langwatch/src/server/workflows/runWorkflow.ts
+  #   langwatch/src/server/routes/misc.ts  (handleWorkflowRun — must not
+  #     swallow the typed error into a flat 500)
+
+  Scenario: Running a nonexistent workflow returns 404
+    Given no workflow exists with the given id
+    When the agent calls POST /api/workflows/:workflowId/run
+    Then the response status is 404
+    And the response is not a generic 500
+
+  Scenario: Running a workflow that has never been published returns 422
+    Given a workflow exists but has never been published
+    When the agent calls POST /api/workflows/:workflowId/run
+    Then the response status is 422
+    And the response is not a generic 500

--- a/specs/run-via-api/run-workflow-typed-errors.feature
+++ b/specs/run-via-api/run-workflow-typed-errors.feature
@@ -20,3 +20,9 @@ Feature: Running a workflow via the API surfaces typed errors
     When the agent calls POST /api/workflows/:workflowId/run
     Then the response status is 422
     And the response is not a generic 500
+
+  Scenario: An untyped runWorkflow error still returns a safe 500, not a leaked message
+    Given runWorkflow throws an error that isn't one of the typed error classes
+    When the agent calls POST /api/workflows/:workflowId/run
+    Then the response status is 500
+    And the response does not contain the internal error message


### PR DESCRIPTION
## Summary

Found via a systematic MCP tool sweep testing every LangWatch MCP tool against a real fresh account: `platform_run_workflow` on a nonexistent workflow ID returns a raw 500 (`"Workflow not found."`) while `platform_get_workflow` / `platform_delete_workflow` on the exact same ID correctly return 404. Confirmed directly against production.

## Root cause

Two layered bugs:

1. `runWorkflow()` threw plain `new Error(...)` for every precondition/failure case (not found, not published, missing required input, missing LLM key, published-version missing, execution-service failure) — a plain `Error` has no `.status` and isn't a `HandledError`, so it falls through every case in `error-handler.ts`'s `determineErrorResponse()` and lands in the generic 500 catch-all, even for ordinary client errors.
2. The REST route (`misc.ts`'s `handleWorkflowRun`) wrapped the call in its own `try/catch` and unconditionally returned `c.json({ message }, 500)` — so even after (1) is fixed, the newly typed errors never reached the app's `onError(handleError)` middleware. Caught in review by `langwatch-agent`.

## Fix

- `runWorkflow()` now throws `@langwatch/handled-error`'s `NotFoundError`/`ValidationError` (plus a new `WorkflowExecutionFailedError` for the execution-service-failure case) for **every** throw site, not just the two originally reported — a "ruthless review" round caught that only converting two of six sites turned the other four into opaque, message-less 500s.
- `handleWorkflowRun` no longer swallows errors into a flat 500 — it lets them propagate to the already-wired global `onError(handleError)` middleware, which knows how to map `HandledError` subclasses to the right status code.
- The deprecated sibling route `POST /api/optimization/:workflowId/:versionId` now delegates to `handleWorkflowRun` too, instead of duplicating the same (buggy) try/catch — the two routes had started disagreeing on the status code for identical failures.

## Verification

- Unit test (`runWorkflow.not-found.unit.test.ts`) mocking `prisma.workflow.findUnique`: asserts `NotFoundError`/`ValidationError` for the not-found/not-published cases.
- Endpoint-level integration test (`workflows-run-not-found.integration.test.ts`) hitting the real `POST /api/workflows/:workflowId/run` route end-to-end (real Postgres, real auth) for 404, 422, and — pinning the untyped-error path — a mocked untyped `Error` still returns a safe generic 500 without leaking the internal message.
- `pnpm typecheck` / `pnpm run typecheck:tests`: clean.
- Reproduced the original 500 directly against production before writing the fix.

## Test plan

- [x] Reproduced the 500 directly against production first
- [x] Unit test added and passing (2/2)
- [x] Endpoint-level integration test added, covering 404 / 422 / untyped-error passthrough
- [x] `pnpm typecheck` / `pnpm run typecheck:tests` clean
- [x] All remaining plain-`Error` throw sites in `runWorkflow()` converted to typed `HandledError`s
- [x] Sibling deprecated route deduplicated onto the same handler
- [ ] Manual re-check of `platform_run_workflow` on a nonexistent ID once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)