### PR TITLE
fix(langy): complete the turnExists mock in langy-message.service test

### DIFF
--- a/langwatch/src/server/app-layer/langy/__tests__/langy-message.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-message.service.unit.test.ts
@@ -43,8 +43,9 @@ function makeConversationRepo(
     findActiveOwnedIds: vi.fn().mockResolvedValue([]),
     findPendingHandoff: vi.fn().mockResolvedValue(null),
     findRunToken: vi.fn().mockResolvedValue(null),
+    turnExists: vi.fn().mockResolvedValue(false),
     ...overrides,
-  } as LangyConversationRepository;
+  };
 }
 
 describe("LangyMessageService", () => {


### PR DESCRIPTION
## Summary

Follow-up to the typecheck break introduced by #5978 (added `LangyConversationRepository.turnExists()` without updating every mock). One instance of that gap (`langy-conversation.service.unit.test.ts`) had already been fixed independently on `main` by the time I got here — confirmed via `git diff origin/main -- <path>` returning empty, so that file isn't touched in this PR.

This PR fixes a **second, silent instance of the same gap** in `langy-message.service.unit.test.ts`.

## Root cause

`makeConversationRepo()` in this test file was also missing `turnExists`, but the object literal was force-cast with `as LangyConversationRepository`, which bypasses TypeScript's structural excess/missing-property check. So unlike the sibling file, this one never showed up as a `pnpm run typecheck:tests` error — it would only have broken at runtime if any test path actually invoked `turnExists()` through the mock (a `TypeError: ... is not a function`).

## Fix

- Added `turnExists: vi.fn().mockResolvedValue(false)` to `makeConversationRepo()`, matching the real `NullLangyConversationRepository`'s default.
- Removed the now-unnecessary `as LangyConversationRepository` unsafe cast, so the object literal is checked structurally against the interface again (this is what would have caught the gap in the first place).

## Verification

- `pnpm run typecheck:tests` — clean (uses the object literal's real structural check now, no cast masking it)
- `NODE_ENV=test PINO_LOG_LEVEL=warn npx vitest run src/server/app-layer/langy/__tests__/langy-message.service.unit.test.ts` — 6/6 passed

## Test plan

- [x] CI typecheck:tests job green
- [x] CI unit test job green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the conversation repository test fixture to include default turn-existence behavior, ensuring consistent unit-test coverage.
  * Existing message service test assertions remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->