### PR TITLE
fix(otel): backend services default to full sampling in every environment

### DIFF
--- a/pkg/config/otel.go
+++ b/pkg/config/otel.go
@@ -126,7 +126,7 @@ type resolvedOTel struct {
 const UnsetSampleRatio = 0
 
 // Resolve reconciles the official OpenTelemetry environment variables with
-// the deprecated LangWatch names and the environment-aware defaults, then
+// the deprecated LangWatch names and the service defaults, then
 // validates the result. Call exactly once from LoadConfig, after Hydrate and
 // after SampleRatioSet is stamped; every telemetry accessor below requires it.
 //
@@ -134,7 +134,7 @@ const UnsetSampleRatio = 0
 // span: a conflicting or out-of-range value is not discoverable from inside
 // the running service, so the only place it can be caught is the place it is
 // read.
-func (o *OTel) Resolve(environment string) error {
+func (o *OTel) Resolve() error {
 	baseEndpoint, err := o.resolveBaseEndpoint()
 	if err != nil {
 		return err
@@ -143,7 +143,7 @@ func (o *OTel) Resolve(environment string) error {
 	if err != nil {
 		return err
 	}
-	sampler, err := o.resolveSampler(environment)
+	sampler, err := o.resolveSampler()
 	if err != nil {
 		return err
 	}
@@ -250,8 +250,8 @@ var officialSamplerKinds = map[string]struct {
 }
 
 // resolveSampler reconciles OTEL_TRACES_SAMPLER(+ARG) with the deprecated
-// OTEL_SAMPLE_RATIO and the environment-aware default.
-func (o *OTel) resolveSampler(environment string) (otelsetup.SamplerChoice, error) {
+// OTEL_SAMPLE_RATIO and the full-sampling default.
+func (o *OTel) resolveSampler() (otelsetup.SamplerChoice, error) {
 	legacySet := o.SampleRatioSet || o.SampleRatio != UnsetSampleRatio
 	if kind := strings.ToLower(strings.TrimSpace(o.TracesSampler)); kind != "" {
 		if legacySet {

--- a/pkg/config/otel.go
+++ b/pkg/config/otel.go
@@ -125,10 +125,6 @@ type resolvedOTel struct {
 // OTEL_SAMPLE_RATIO environment variable.
 const UnsetSampleRatio = 0
 
-// DefaultNonLocalSampleRatio is the trace sample ratio applied outside local
-// development when the operator did not choose one.
-const DefaultNonLocalSampleRatio = 0.1
-
 // Resolve reconciles the official OpenTelemetry environment variables with
 // the deprecated LangWatch names and the environment-aware defaults, then
 // validates the result. Call exactly once from LoadConfig, after Hydrate and
@@ -301,13 +297,13 @@ func (o *OTel) resolveSampler(environment string) (otelsetup.SamplerChoice, erro
 		return otelsetup.SamplerChoice{ParentBased: true, Ratio: o.SampleRatio}, nil
 	}
 
-	// Environment-aware default: trace everything on a laptop, a tenth of
-	// requests everywhere else.
-	ratio := DefaultNonLocalSampleRatio
-	if environment == "local" {
-		ratio = 1.0
-	}
-	return otelsetup.SamplerChoice{ParentBased: true, Ratio: ratio}, nil
+	// Default: parent-based, sample everything — the OTel spec default
+	// (parentbased_always_on), in every environment. A lowered default is
+	// indistinguishable from a broken exporter on quiet services, and on the
+	// multi-tenant customer path (nlpgo) anything less than full sampling
+	// silently drops customer trace data. Operators opt into downsampling
+	// explicitly with OTEL_TRACES_SAMPLER(+_ARG).
+	return otelsetup.SamplerChoice{ParentBased: true, Ratio: 1.0}, nil
 }
 
 // validRatio rejects ratios outside [0,1]. NaN needs the explicit check:

--- a/pkg/config/otel_sample_ratio_test.go
+++ b/pkg/config/otel_sample_ratio_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/langwatch/langwatch/pkg/otelsetup"
 )
 
-func mustResolveSampler(t *testing.T, o OTel, environment string) otelsetup.SamplerChoice {
+func mustResolveSampler(t *testing.T, o OTel) otelsetup.SamplerChoice {
 	t.Helper()
-	require.NoError(t, o.Resolve(environment))
+	require.NoError(t, o.Resolve())
 	return o.SamplerChoice()
 }
 
@@ -20,37 +20,32 @@ func mustResolveSampler(t *testing.T, o OTel, environment string) otelsetup.Samp
 // asked for full sampling in production got 10% and no warning — the setting
 // was silently unusable at its most important value.
 func TestResolveSampler_HonoursExplicitFullLegacyRatio(t *testing.T) {
-	got := mustResolveSampler(t, OTel{SampleRatio: 1.0}, "production")
+	got := mustResolveSampler(t, OTel{SampleRatio: 1.0})
 
 	assert.InDelta(t, 1.0, got.Ratio, 0, "an explicit 100% must survive in production")
 	assert.True(t, got.ParentBased)
 }
 
 func TestResolveSampler_HonoursExplicitPartialLegacyRatio(t *testing.T) {
-	got := mustResolveSampler(t, OTel{SampleRatio: 0.25}, "production")
+	got := mustResolveSampler(t, OTel{SampleRatio: 0.25})
 
 	assert.InDelta(t, 0.25, got.Ratio, 0)
 }
 
-// No environment lowers the default: a backend service that says nothing
-// about sampling exports everything, in production too. A lowered default
-// reads as a broken exporter on quiet services, and would silently drop
-// customer data on the multi-tenant path.
-func TestResolveSampler_DefaultsToFullEverywhere(t *testing.T) {
-	got := mustResolveSampler(t, OTel{SampleRatio: UnsetSampleRatio}, "production")
+// Nothing lowers the default: a backend service that says nothing about
+// sampling exports everything, in production too. A lowered default reads
+// as a broken exporter on quiet services, and would silently drop customer
+// data on the multi-tenant path. The environment no longer even reaches the
+// sampler — Resolve takes no environment argument.
+func TestResolveSampler_DefaultsToFullSampling(t *testing.T) {
+	got := mustResolveSampler(t, OTel{SampleRatio: UnsetSampleRatio})
 
 	assert.InDelta(t, 1.0, got.Ratio, 0)
 	assert.True(t, got.ParentBased)
 }
 
-func TestResolveSampler_DefaultsToFullLocally(t *testing.T) {
-	got := mustResolveSampler(t, OTel{SampleRatio: UnsetSampleRatio}, "local")
-
-	assert.InDelta(t, 1.0, got.Ratio, 0, "local development traces everything")
-}
-
 func TestResolveSampler_HonoursExplicitZeroLegacyRatio(t *testing.T) {
-	got := mustResolveSampler(t, OTel{SampleRatioSet: true, SampleRatio: 0}, "production")
+	got := mustResolveSampler(t, OTel{SampleRatioSet: true, SampleRatio: 0})
 
 	assert.Zero(t, got.Ratio, "an explicit 0% must not become the default")
 }
@@ -72,7 +67,7 @@ func TestResolveSampler_MapsTheOfficialVocabulary(t *testing.T) {
 		{sampler: "parentbased_traceidratio", arg: "0.25", ratio: 0.25, parentBased: true},
 	} {
 		t.Run(tt.sampler, func(t *testing.T) {
-			got := mustResolveSampler(t, OTel{TracesSampler: tt.sampler, TracesSamplerArg: tt.arg}, "production")
+			got := mustResolveSampler(t, OTel{TracesSampler: tt.sampler, TracesSamplerArg: tt.arg})
 
 			assert.InDelta(t, tt.ratio, got.Ratio, 0)
 			assert.Equal(t, tt.parentBased, got.ParentBased)
@@ -81,7 +76,7 @@ func TestResolveSampler_MapsTheOfficialVocabulary(t *testing.T) {
 }
 
 func TestResolveSampler_AcceptsMixedCaseKind(t *testing.T) {
-	got := mustResolveSampler(t, OTel{TracesSampler: "Parentbased_TraceIdRatio", TracesSamplerArg: "0.3"}, "production")
+	got := mustResolveSampler(t, OTel{TracesSampler: "Parentbased_TraceIdRatio", TracesSamplerArg: "0.3"})
 
 	assert.InDelta(t, 0.3, got.Ratio, 0)
 	assert.True(t, got.ParentBased)
@@ -92,20 +87,20 @@ func TestResolveSampler_AcceptsMixedCaseKind(t *testing.T) {
 func TestResolveSampler_RequiresTheArgForRatioKinds(t *testing.T) {
 	o := OTel{TracesSampler: "parentbased_traceidratio"}
 
-	assert.Error(t, o.Resolve("production"))
+	assert.Error(t, o.Resolve())
 }
 
 func TestResolveSampler_RejectsBadSamplerArgs(t *testing.T) {
 	for _, arg := range []string{"NaN", "-1", "2", "abc", "0.5.1"} {
 		o := OTel{TracesSampler: "traceidratio", TracesSamplerArg: arg}
-		assert.Error(t, o.Resolve("production"), "arg %q must be refused at boot", arg)
+		assert.Error(t, o.Resolve(), "arg %q must be refused at boot", arg)
 	}
 }
 
 func TestResolveSampler_RejectsUnknownKinds(t *testing.T) {
 	o := OTel{TracesSampler: "jaeger_remote"}
 
-	assert.Error(t, o.Resolve("production"))
+	assert.Error(t, o.Resolve())
 }
 
 // Two live sampling instructions with different vocabularies is ambiguity,
@@ -113,5 +108,5 @@ func TestResolveSampler_RejectsUnknownKinds(t *testing.T) {
 func TestResolveSampler_RefusesOfficialAndLegacyTogether(t *testing.T) {
 	o := OTel{TracesSampler: "always_on", SampleRatioSet: true, SampleRatio: 0.1}
 
-	assert.Error(t, o.Resolve("production"))
+	assert.Error(t, o.Resolve())
 }

--- a/pkg/config/otel_sample_ratio_test.go
+++ b/pkg/config/otel_sample_ratio_test.go
@@ -32,10 +32,14 @@ func TestResolveSampler_HonoursExplicitPartialLegacyRatio(t *testing.T) {
 	assert.InDelta(t, 0.25, got.Ratio, 0)
 }
 
-func TestResolveSampler_DefaultsOutsideLocal(t *testing.T) {
+// No environment lowers the default: a backend service that says nothing
+// about sampling exports everything, in production too. A lowered default
+// reads as a broken exporter on quiet services, and would silently drop
+// customer data on the multi-tenant path.
+func TestResolveSampler_DefaultsToFullEverywhere(t *testing.T) {
 	got := mustResolveSampler(t, OTel{SampleRatio: UnsetSampleRatio}, "production")
 
-	assert.InDelta(t, DefaultNonLocalSampleRatio, got.Ratio, 0)
+	assert.InDelta(t, 1.0, got.Ratio, 0)
 	assert.True(t, got.ParentBased)
 }
 

--- a/pkg/config/otel_validate_test.go
+++ b/pkg/config/otel_validate_test.go
@@ -38,7 +38,7 @@ func TestResolve_AcceptsOnMachineDebugCollectors(t *testing.T) {
 		"http://host.docker.internal:4318",
 	} {
 		o := OTel{DebugCollectorEndpoint: endpoint}
-		assert.NoError(t, o.Resolve("local"), "on-machine endpoint %q must be accepted", endpoint)
+		assert.NoError(t, o.Resolve(), "on-machine endpoint %q must be accepted", endpoint)
 	}
 }
 
@@ -51,14 +51,14 @@ func TestResolve_RejectsLocalhostNamesThatResolveOffBox(t *testing.T) {
 	stubLocalhostDNS(t, []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("10.0.12.3")}, nil)
 	o := OTel{DebugCollectorEndpoint: "http://observability.langwatch.localhost:4318"}
 
-	assert.Error(t, o.Resolve("local"))
+	assert.Error(t, o.Resolve())
 }
 
 func TestResolve_RejectsLocalhostNamesThatDoNotResolve(t *testing.T) {
 	stubLocalhostDNS(t, nil, errors.New("no such host"))
 	o := OTel{DebugCollectorEndpoint: "http://observability.langwatch.localhost:4318"}
 
-	assert.Error(t, o.Resolve("local"))
+	assert.Error(t, o.Resolve())
 }
 
 func TestResolve_RejectsOffBoxDebugCollectors(t *testing.T) {
@@ -74,7 +74,7 @@ func TestResolve_RejectsOffBoxDebugCollectors(t *testing.T) {
 		"http://[fe80::1]:4318",
 	} {
 		o := OTel{DebugCollectorEndpoint: endpoint}
-		assert.Error(t, o.Resolve("local"), "off-box endpoint %q must be refused at boot", endpoint)
+		assert.Error(t, o.Resolve(), "off-box endpoint %q must be refused at boot", endpoint)
 	}
 }
 
@@ -85,16 +85,16 @@ func TestResolve_RejectsOffBoxDebugCollectors(t *testing.T) {
 func TestResolve_RejectsOutOfRangeLegacySampleRatio(t *testing.T) {
 	for _, ratio := range []float64{-1, -0.001, 1.001, 10} {
 		o := OTel{SampleRatio: ratio}
-		require.Error(t, o.Resolve("production"), "ratio %v must be refused before it reaches the sampler", ratio)
+		require.Error(t, o.Resolve(), "ratio %v must be refused before it reaches the sampler", ratio)
 	}
 	nan := OTel{SampleRatioSet: true, SampleRatio: math.NaN()}
-	require.Error(t, nan.Resolve("production"), "NaN must be refused before it reaches the sampler")
+	require.Error(t, nan.Resolve(), "NaN must be refused before it reaches the sampler")
 }
 
 func TestResolve_AcceptsTheFullLegacySampleRatioRange(t *testing.T) {
 	for _, ratio := range []float64{0, 0.1, 0.5, 1} {
 		o := OTel{SampleRatioSet: true, SampleRatio: ratio}
-		assert.NoError(t, o.Resolve("production"), "ratio %v is a legitimate operator choice", ratio)
+		assert.NoError(t, o.Resolve(), "ratio %v is a legitimate operator choice", ratio)
 	}
 }
 
@@ -102,7 +102,7 @@ func TestResolve_AcceptsTheFullLegacySampleRatioRange(t *testing.T) {
 
 func TestResolve_UsesTheOfficialEndpoint(t *testing.T) {
 	o := OTel{ExporterEndpoint: "http://collector:4318"}
-	require.NoError(t, o.Resolve("production"))
+	require.NoError(t, o.Resolve())
 
 	base, _ := o.PrimaryOTLP()
 	assert.Equal(t, "http://collector:4318", base)
@@ -112,7 +112,7 @@ func TestResolve_UsesTheOfficialEndpoint(t *testing.T) {
 
 func TestResolve_HonoursTheDeprecatedEndpointName(t *testing.T) {
 	o := OTel{OTLPEndpoint: "http://collector:4318"}
-	require.NoError(t, o.Resolve("production"))
+	require.NoError(t, o.Resolve())
 
 	base, _ := o.PrimaryOTLP()
 	assert.Equal(t, "http://collector:4318", base, "existing deployments must keep tracing through the rename")
@@ -125,7 +125,7 @@ func TestResolve_AcceptsBothEndpointNamesWhenEqual(t *testing.T) {
 		OTLPEndpoint:     "http://collector:4318",
 	}
 
-	assert.NoError(t, o.Resolve("production"), "equal values (modulo trailing slash) are not a conflict")
+	assert.NoError(t, o.Resolve(), "equal values (modulo trailing slash) are not a conflict")
 }
 
 // Two different live values is ambiguity; precedence is never silently
@@ -137,12 +137,12 @@ func TestResolve_RefusesConflictingEndpointNames(t *testing.T) {
 		OTLPEndpoint:     "http://other:4318",
 	}
 
-	assert.Error(t, o.Resolve("production"))
+	assert.Error(t, o.Resolve())
 }
 
 func TestResolve_LeavesTheExporterOffWhenNothingIsConfigured(t *testing.T) {
 	o := OTel{}
-	require.NoError(t, o.Resolve("production"))
+	require.NoError(t, o.Resolve())
 
 	base, headers := o.PrimaryOTLP()
 	assert.Empty(t, base, "no endpoint must mean OFF — never the SDK's localhost default")
@@ -156,7 +156,7 @@ func TestResolve_UsesTheSignalSpecificTracesEndpointAsIs(t *testing.T) {
 		ExporterEndpoint:       "http://collector:4318",
 		ExporterTracesEndpoint: "http://collector:4318/custom/traces",
 	}
-	require.NoError(t, o.Resolve("production"))
+	require.NoError(t, o.Resolve())
 
 	assert.Equal(t, "http://collector:4318/custom/traces", o.resolved.tracesEndpoint,
 		"per spec the signal-specific endpoint is used verbatim, no path appended")
@@ -169,7 +169,7 @@ func TestResolve_UsesTheSignalSpecificTracesEndpointAsIs(t *testing.T) {
 
 func TestResolve_ParsesOfficialHeaders(t *testing.T) {
 	o := OTel{ExporterHeaders: "X-Auth-Token=tok,X-Team=obs"}
-	require.NoError(t, o.Resolve("production"))
+	require.NoError(t, o.Resolve())
 
 	_, headers := o.PrimaryOTLP()
 	assert.Equal(t, map[string]string{"X-Auth-Token": "tok", "X-Team": "obs"}, headers)
@@ -179,7 +179,7 @@ func TestResolve_DecodesPercentEncodedHeaderValues(t *testing.T) {
 	// The W3C baggage format used by OTEL_EXPORTER_OTLP_HEADERS percent-encodes
 	// values; Grafana Cloud's copy-paste examples rely on it.
 	o := OTel{ExporterHeaders: "Authorization=Basic%20dXNlcjp0b2tlbg=="}
-	require.NoError(t, o.Resolve("production"))
+	require.NoError(t, o.Resolve())
 
 	_, headers := o.PrimaryOTLP()
 	assert.Equal(t, "Basic dXNlcjp0b2tlbg==", headers["Authorization"])
@@ -190,7 +190,7 @@ func TestResolve_TracesSpecificHeadersWin(t *testing.T) {
 		ExporterHeaders:       "X-Auth-Token=base",
 		ExporterTracesHeaders: "X-Auth-Token=traces",
 	}
-	require.NoError(t, o.Resolve("production"))
+	require.NoError(t, o.Resolve())
 
 	_, headers := o.PrimaryOTLP()
 	assert.Equal(t, "traces", headers["X-Auth-Token"])
@@ -202,12 +202,12 @@ func TestResolve_RefusesConflictingHeaderNames(t *testing.T) {
 		OTLPHeaders:     "X-Auth-Token=b",
 	}
 
-	assert.Error(t, o.Resolve("production"))
+	assert.Error(t, o.Resolve())
 }
 
 func TestResolve_HonoursTheDeprecatedHeadersName(t *testing.T) {
 	o := OTel{OTLPHeaders: "X-Auth-Token=tok"}
-	require.NoError(t, o.Resolve("production"))
+	require.NoError(t, o.Resolve())
 
 	_, headers := o.PrimaryOTLP()
 	assert.Equal(t, "tok", headers["X-Auth-Token"])
@@ -218,7 +218,7 @@ func TestResolve_HonoursTheDeprecatedHeadersName(t *testing.T) {
 func TestResolve_RefusesUnsupportedProtocols(t *testing.T) {
 	for _, protocol := range []string{"grpc", "http/json"} {
 		o := OTel{ExporterProtocol: protocol}
-		require.Error(t, o.Resolve("production"),
+		require.Error(t, o.Resolve(),
 			"protocol %q states an intent our exporters cannot satisfy — silence would be a lie", protocol)
 	}
 }
@@ -226,13 +226,13 @@ func TestResolve_RefusesUnsupportedProtocols(t *testing.T) {
 func TestResolve_AcceptsTheSupportedProtocol(t *testing.T) {
 	for _, protocol := range []string{"", "http/protobuf", "HTTP/Protobuf"} {
 		o := OTel{ExporterProtocol: protocol}
-		assert.NoError(t, o.Resolve("production"))
+		assert.NoError(t, o.Resolve())
 	}
 }
 
 func TestResolve_TracesExporterNoneTurnsOnlySpansOff(t *testing.T) {
 	o := OTel{ExporterEndpoint: "http://collector:4318", TracesExporter: "none"}
-	require.NoError(t, o.Resolve("production"))
+	require.NoError(t, o.Resolve())
 
 	assert.Empty(t, o.resolved.tracesEndpoint)
 	assert.Equal(t, "http://collector:4318/v1/metrics", o.resolved.metricsEndpoint,
@@ -248,7 +248,7 @@ func TestResolve_TracesExporterNoneTurnsOnlySpansOff(t *testing.T) {
 func TestResolve_RefusesUnknownTracesExporters(t *testing.T) {
 	o := OTel{TracesExporter: "console"}
 
-	assert.Error(t, o.Resolve("production"))
+	assert.Error(t, o.Resolve())
 }
 
 // ---- OTEL_SDK_DISABLED ----
@@ -259,7 +259,7 @@ func TestResolve_SDKDisabledTurnsEverythingOff(t *testing.T) {
 		ExporterEndpoint:       "http://collector:4318",
 		DebugCollectorEndpoint: "http://localhost:4318",
 	}
-	require.NoError(t, o.Resolve("local"))
+	require.NoError(t, o.Resolve())
 
 	base, _ := o.PrimaryOTLP()
 	assert.Empty(t, base)

--- a/services/aigateway/config.go
+++ b/services/aigateway/config.go
@@ -115,7 +115,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	if cfg.CustomerTraceBridge.BaseURL == "" {
 		cfg.CustomerTraceBridge.BaseURL = cfg.ControlPlane.BaseURL
 	}
-	if err := cfg.OTel.Resolve(cfg.Environment); err != nil {
+	if err := cfg.OTel.Resolve(); err != nil {
 		return Config{}, err
 	}
 	if err := config.Validate(ctx, cfg); err != nil {

--- a/services/langyagent/config.go
+++ b/services/langyagent/config.go
@@ -196,7 +196,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	// Derive the listen address from PORT (kept as its own env var). Set after
 	// Hydrate so PORT always wins over any stray SERVER_ADDR.
 	cfg.Server.Addr = fmt.Sprintf(":%d", cfg.Port)
-	if err := cfg.OTel.Resolve(cfg.Environment); err != nil {
+	if err := cfg.OTel.Resolve(); err != nil {
 		return Config{}, err
 	}
 	if err := cfg.Log.Validate(); err != nil {

--- a/services/langyagent/config_test.go
+++ b/services/langyagent/config_test.go
@@ -124,7 +124,9 @@ func TestLoadConfig_InvalidPortFailsFast(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_NonLocalLowersSampleRatio(t *testing.T) {
+// No environment lowers the default for backend services: full sampling holds
+// in production too, unless an operator says otherwise.
+func TestLoadConfig_NonLocalStillSamplesEverything(t *testing.T) {
 	clearLangyEnv(t)
 	t.Setenv("LANGY_INTERNAL_SECRET", "secret")
 	t.Setenv("ENVIRONMENT", "production")
@@ -133,8 +135,8 @@ func TestLoadConfig_NonLocalLowersSampleRatio(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if got := cfg.OTel.SamplerChoice().Ratio; got != 0.1 {
-		t.Errorf("non-local sampler ratio = %v, want 0.1", got)
+	if got := cfg.OTel.SamplerChoice().Ratio; got != 1.0 {
+		t.Errorf("non-local sampler ratio = %v, want 1.0 (backend services sample everything by default)", got)
 	}
 }
 
@@ -270,5 +272,35 @@ func TestLoadConfig_ShutdownHandoffBudgetsWithinGracefulAccepted(t *testing.T) {
 	}
 	if cfg.ShutdownHandoffDeadline() != 4*time.Second {
 		t.Errorf("ShutdownHandoffDeadline = %s, want 4s", cfg.ShutdownHandoffDeadline())
+	}
+}
+
+func TestLoadConfig_SamplerDefaultsToFullParentBased(t *testing.T) {
+	clearLangyEnv(t)
+	t.Setenv("LANGY_INTERNAL_SECRET", "secret")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	choice := cfg.OTel.SamplerChoice()
+	if !choice.ParentBased || choice.Ratio != 1.0 {
+		t.Fatalf("ops telemetry must default to full parent-based sampling, got %+v", choice)
+	}
+}
+
+func TestLoadConfig_SamplerEnvStillWins(t *testing.T) {
+	clearLangyEnv(t)
+	t.Setenv("LANGY_INTERNAL_SECRET", "secret")
+	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "0.2")
+
+	cfg, err := LoadConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	choice := cfg.OTel.SamplerChoice()
+	if !choice.ParentBased || choice.Ratio != 0.2 {
+		t.Fatalf("operator sampler must win over the service default, got %+v", choice)
 	}
 }

--- a/services/nlpgo/config.go
+++ b/services/nlpgo/config.go
@@ -99,7 +99,7 @@ func LoadConfig(ctx context.Context) (Config, error) {
 		return Config{}, err
 	}
 	cfg.OTel.SampleRatioSet = os.Getenv("OTEL_SAMPLE_RATIO") != ""
-	if err := cfg.OTel.Resolve(cfg.Environment); err != nil {
+	if err := cfg.OTel.Resolve(); err != nil {
 		return Config{}, err
 	}
 	if err := config.Validate(ctx, cfg); err != nil {


### PR DESCRIPTION
Focused extraction from #5990 so the Go trace-visibility fix can review and deploy on its own.

## Problem

Prod Tempo shows no traces from the AI gateway and no `langy.turn` spans from the langyagent manager, despite both services having correct endpoint config (verified: `withSignalPath` is idempotent, so even the legacy `/v1/traces`-suffixed endpoint value is fine).

They aren't broken — they're sampled to nothing. `pkg/config`'s unset-sampler default was `ParentBased(0.1)` outside local, which on quiet services is indistinguishable from a dead exporter.

Worse, nlpgo's multi-tenant **customer** trace path resolves its sampler through the same default — a silent 10% drop of customer trace data is never an acceptable default.

## Change

The unset default becomes `parentbased_always_on` — the OTel spec default — in **every** environment, for every backend service. No environment-aware lowering.

- Every explicit operator choice still wins: `OTEL_TRACES_SAMPLER`(+`_ARG`), or the deprecated `OTEL_SAMPLE_RATIO` including an explicit `0`.
- **No deployment sets either var today** — checked the live infra lineage (root + `runtime/`) and the charts — so nothing needs removing and the default takes effect on deploy.
- With no environment-aware sampling left, `OTel.Resolve` no longer takes an `environment` argument at all — sampling was its only consumer (the debug-collector guard is deliberately destination-based, not name-based).

## Deployment Impact

- **Env vars**: none added or removed. `OTEL_TRACES_SAMPLER`(+`_ARG`) and the deprecated `OTEL_SAMPLE_RATIO` keep their exact semantics and still override the default; no live deployment sets either today (checked infra lineage root + `runtime/`, and the charts).
- **Helm values**: none added or changed; the charts don't template a sampler value.
- **Vanilla `helm install`** (no overrides): backend services (aigateway, nlpgo, langyagent) go from sampling 10% of traces to 100% on their ops-telemetry and nlpgo's per-tenant customer trace path. This is the OTel spec default. Trace export volume rises accordingly on high-throughput installs; operators who want downsampling set `OTEL_TRACES_SAMPLER=parentbased_traceidratio` + `OTEL_TRACES_SAMPLER_ARG`.
- **BYOC dataplane**: same behavior change — customer-controlled collectors receive all traces instead of 10%; any operator-set sampler env vars continue to win unchanged.

## Verification

- `pkg/config` + `services/langyagent` test suites pass; the old `NonLocalLowersSampleRatio` test is rewritten as `NonLocalStillSamplesEverything` to document the new contract.
- After deploy: `gcx traces query '{ resource.service.name = "langwatch-service-aigateway" }'` and `'{ name = "langy.turn" }'` should return data.

Note: #5990 currently carries the same change in its history; whichever merges first makes the other a no-op for these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated OpenTelemetry tracing sampling defaults to sample all traces by default (including non-local environments such as production) when no sampling configuration is provided.
  * Kept parent-based sampling enabled for consistent trace decisions across services.
  * Ensured operator-provided sampling settings (OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG) still take precedence over defaults.
* **Tests**
  * Updated and expanded configuration and sampler-resolution test coverage to reflect the new defaulting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
