### PR TITLE
feat(analytics): cost comparison card, estimated savings vs a reference model

### DIFF
--- a/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
+++ b/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
@@ -21,10 +21,13 @@ const SERIES = [
 const seriesKey = (index: number) =>
   `${index}/${SERIES[index]!.metric}/${SERIES[index]!.aggregation}`;
 
-const sumSeries = (
-  buckets: Record<string, unknown>[] | undefined,
-  key: string,
-): number =>
+const sumSeries = ({
+  buckets,
+  key,
+}: {
+  buckets: Record<string, unknown>[] | undefined;
+  key: string;
+}): number =>
   (buckets ?? []).reduce((total, bucket) => {
     const value = bucket[key];
     return total + (typeof value === "number" ? value : 0);
@@ -71,12 +74,18 @@ export function ModelCostComparisonCard() {
     queryOpts,
   );
 
-  const promptTokens = sumSeries(timeseries.data?.currentPeriod, seriesKey(0));
-  const completionTokens = sumSeries(
-    timeseries.data?.currentPeriod,
-    seriesKey(1),
-  );
-  const actualCost = sumSeries(timeseries.data?.currentPeriod, seriesKey(2));
+  const promptTokens = sumSeries({
+    buckets: timeseries.data?.currentPeriod,
+    key: seriesKey(0),
+  });
+  const completionTokens = sumSeries({
+    buckets: timeseries.data?.currentPeriod,
+    key: seriesKey(1),
+  });
+  const actualCost = sumSeries({
+    buckets: timeseries.data?.currentPeriod,
+    key: seriesKey(2),
+  });
 
   const pricing = selectedModel
     ? modelMetadata?.[selectedModel]?.pricing
@@ -108,7 +117,12 @@ export function ModelCostComparisonCard() {
           )}
         </Box>
       </HStack>
-      {!timeseries.isLoading && !hasTraffic ? (
+      {timeseries.isError ? (
+        <Text textStyle="sm" color="fg.error">
+          Could not load usage for the selected period. Try refreshing the
+          page.
+        </Text>
+      ) : !timeseries.isLoading && !hasTraffic ? (
         <Text textStyle="sm" color="fg.subtle">
           No traffic in the selected period. Adjust the filters or date range
           to compare costs.

--- a/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
+++ b/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
@@ -1,0 +1,152 @@
+import { Box, HStack, Text, VStack } from "@chakra-ui/react";
+import numeral from "numeral";
+import { useMemo, useState } from "react";
+import { useFilterParams } from "../../hooks/useFilterParams";
+import { useModelProvidersSettings } from "../../hooks/useModelProvidersSettings";
+import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
+import { api } from "../../utils/api";
+import { ModelSelector } from "../ModelSelector";
+import {
+  estimateReferenceCost,
+  referenceModelOptions,
+} from "./modelCostComparison";
+import { SummaryMetric } from "./SummaryMetric";
+
+const SERIES = [
+  { metric: "performance.prompt_tokens", aggregation: "sum" },
+  { metric: "performance.completion_tokens", aggregation: "sum" },
+  { metric: "performance.total_cost", aggregation: "sum" },
+] as const;
+
+const seriesKey = (index: number) =>
+  `${index}/${SERIES[index]!.metric}/${SERIES[index]!.aggregation}`;
+
+const sumSeries = (
+  buckets: Record<string, unknown>[] | undefined,
+  key: string,
+): number =>
+  (buckets ?? []).reduce((total, bucket) => {
+    const value = bucket[key];
+    return total + (typeof value === "number" ? value : 0);
+  }, 0);
+
+const money = (value: number) =>
+  value >= 0.01 || value === 0
+    ? numeral(value).format("$0.00a")
+    : numeral(value).format("$0.0000a");
+
+const DEFAULT_REFERENCE = "anthropic/claude-sonnet-4-6";
+
+/**
+ * Compares the period's actual spend with what the same traffic would have
+ * cost on a reference model, using the period's real token counts priced
+ * at the reference model's catalog rates. Honors the page's filters and
+ * date range, so the comparison can be sliced by label, model, user, etc.
+ */
+export function ModelCostComparisonCard() {
+  const { project } = useOrganizationTeamProject();
+  const { filterParams, queryOpts } = useFilterParams();
+  const { modelMetadata } = useModelProvidersSettings({
+    projectId: project?.id,
+  });
+
+  const options = useMemo(
+    () => referenceModelOptions(modelMetadata),
+    [modelMetadata],
+  );
+  const [referenceModel, setReferenceModel] = useState<string | undefined>(
+    undefined,
+  );
+  const selectedModel =
+    referenceModel ??
+    (options.includes(DEFAULT_REFERENCE) ? DEFAULT_REFERENCE : options[0]);
+
+  const timeseries = api.analytics.getTimeseries.useQuery(
+    {
+      ...filterParams,
+      series: SERIES.map((s) => ({ ...s })),
+      timeScale: "full",
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    },
+    queryOpts,
+  );
+
+  const promptTokens = sumSeries(timeseries.data?.currentPeriod, seriesKey(0));
+  const completionTokens = sumSeries(
+    timeseries.data?.currentPeriod,
+    seriesKey(1),
+  );
+  const actualCost = sumSeries(timeseries.data?.currentPeriod, seriesKey(2));
+
+  const pricing = selectedModel
+    ? modelMetadata?.[selectedModel]?.pricing
+    : undefined;
+  const referenceCost = estimateReferenceCost({
+    promptTokens,
+    completionTokens,
+    pricing,
+  });
+  const savings =
+    referenceCost !== undefined ? referenceCost - actualCost : undefined;
+  const hasTraffic = promptTokens + completionTokens > 0;
+
+  return (
+    <VStack align="stretch" gap={4}>
+      <HStack justify="space-between" flexWrap="wrap" gap={2}>
+        <Text textStyle="sm" color="fg.muted">
+          What the same traffic would cost on
+        </Text>
+        <Box minWidth="220px">
+          {selectedModel && (
+            <ModelSelector
+              model={selectedModel}
+              options={options}
+              onChange={setReferenceModel}
+              size="sm"
+              mode="chat"
+            />
+          )}
+        </Box>
+      </HStack>
+      {!timeseries.isLoading && !hasTraffic ? (
+        <Text textStyle="sm" color="fg.subtle">
+          No traffic in the selected period. Adjust the filters or date range
+          to compare costs.
+        </Text>
+      ) : (
+        <HStack align="start" gap={0}>
+          <SummaryMetric
+            label="Current Cost"
+            current={timeseries.isLoading ? undefined : actualCost}
+            format={money}
+            increaseIs="neutral"
+          />
+          <SummaryMetric
+            label="Estimated Cost on Selected Model"
+            current={
+              timeseries.isLoading || referenceCost === undefined
+                ? undefined
+                : referenceCost
+            }
+            format={money}
+            increaseIs="neutral"
+            tooltip="The period's input and output tokens priced at the selected model's rates."
+          />
+          <SummaryMetric
+            label="Estimated Savings"
+            current={
+              timeseries.isLoading || savings === undefined
+                ? undefined
+                : savings
+            }
+            format={(value: number) =>
+              value < 0 ? `-${money(Math.abs(value))}` : money(value)
+            }
+            increaseIs="good"
+            tooltip="Estimated cost on the selected model minus the actual cost. Negative means the current setup costs more."
+          />
+        </HStack>
+      )}
+    </VStack>
+  );
+}

--- a/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
+++ b/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
@@ -134,6 +134,7 @@ export function ModelCostComparisonCard() {
             current={timeseries.isLoading ? undefined : actualCost}
             format={money}
             increaseIs="neutral"
+            zeroMeansNoData={false}
           />
           <SummaryMetric
             label="Estimated Cost on Selected Model"
@@ -145,6 +146,7 @@ export function ModelCostComparisonCard() {
             format={money}
             increaseIs="neutral"
             tooltip="The period's input and output tokens priced at the selected model's rates."
+            zeroMeansNoData={false}
           />
           <SummaryMetric
             label="Estimated Savings"
@@ -158,6 +160,7 @@ export function ModelCostComparisonCard() {
             }
             increaseIs="good"
             tooltip="Estimated cost on the selected model minus the actual cost. Negative means the current setup costs more."
+            zeroMeansNoData={false}
           />
         </HStack>
       )}

--- a/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
+++ b/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
@@ -49,13 +49,13 @@ const DEFAULT_REFERENCE = "anthropic/claude-sonnet-4-6";
 export function ModelCostComparisonCard() {
   const { project } = useOrganizationTeamProject();
   const { filterParams, queryOpts } = useFilterParams();
-  const { modelMetadata } = useModelProvidersSettings({
+  const { modelMetadata, providers } = useModelProvidersSettings({
     projectId: project?.id,
   });
 
   const options = useMemo(
-    () => referenceModelOptions(modelMetadata),
-    [modelMetadata],
+    () => referenceModelOptions({ modelMetadata, providers }),
+    [modelMetadata, providers],
   );
   const [referenceModel, setReferenceModel] = useState<string | undefined>(
     undefined,

--- a/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
+++ b/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
@@ -106,6 +106,13 @@ export function ModelCostComparisonCard() {
     promptTokens + completionTokens + cacheReadTokens + cacheWriteTokens > 0;
   const cachedTokens = cacheReadTokens + cacheWriteTokens;
 
+  // Formatted up front so a value that cannot be estimated reads as a dash
+  // with an explanation underneath, rather than a skeleton that promises a
+  // number still on its way.
+  const asIs = (value: string) => value;
+  const cell = (value: number | undefined, format: (value: number) => string) =>
+    !isLoaded ? undefined : value === undefined ? "-" : format(value);
+
   return (
     <VStack align="stretch" gap={4}>
       <HStack justify="space-between" flexWrap="wrap" gap={2}>
@@ -138,24 +145,24 @@ export function ModelCostComparisonCard() {
           <HStack align="start" gap={0}>
             <SummaryMetric
               label="Actual Cost"
-              current={isLoaded ? actualCost : undefined}
-              format={money}
+              current={cell(actualCost, money)}
+              format={asIs}
               increaseIs="neutral"
               tooltip="What this period's traffic cost, across every model in it. Models with no published price, self-hosted ones included, are recorded at $0."
               zeroMeansNoData={false}
             />
             <SummaryMetric
               label="Estimated Cost"
-              current={isLoaded ? referenceCost : undefined}
-              format={money}
+              current={cell(referenceCost, money)}
+              format={asIs}
               increaseIs="neutral"
               tooltip="Every input, output and cached token recorded in this period, priced at the selected model's published rates."
               zeroMeansNoData={false}
             />
             <SummaryMetric
               label="Estimated Savings"
-              current={isLoaded ? savings : undefined}
-              format={signedMoney}
+              current={cell(savings, signedMoney)}
+              format={asIs}
               increaseIs="good"
               tooltip="Estimated cost on the selected model minus the actual cost. Negative means the current setup costs more."
               zeroMeansNoData={false}

--- a/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
+++ b/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
@@ -7,6 +7,7 @@ import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProje
 import type { SeriesInputType } from "../../server/analytics/registry";
 import { readSummaryMetric } from "../../server/analytics/timeseriesSummary";
 import { api } from "../../utils/api";
+import { formatMoney } from "../../utils/formatMoney";
 import { ModelSelector } from "../ModelSelector";
 import {
   estimateReferenceCost,
@@ -28,10 +29,10 @@ const SERIES: SeriesInputType[] = [
   { metric: "performance.total_cost", aggregation: "sum" },
 ];
 
-const money = (value: number) =>
-  value >= 0.01 || value === 0
-    ? numeral(value).format("$0.00a")
-    : numeral(value).format("$0.0000a");
+// The same formatter the cost metrics on this page use, so a four-figure
+// period reads as $1,043.27 rather than an abbreviated $1.04k. A number headed
+// for a finance conversation has to keep its digits.
+const money = (value: number) => formatMoney({ amount: value, currency: "USD" });
 
 const signedMoney = (value: number) =>
   value < 0 ? `-${money(Math.abs(value))}` : money(value);
@@ -110,8 +111,13 @@ export function ModelCostComparisonCard() {
   // with an explanation underneath, rather than a skeleton that promises a
   // number still on its way.
   const asIs = (value: string) => value;
-  const cell = (value: number | undefined, format: (value: number) => string) =>
-    !isLoaded ? undefined : value === undefined ? "-" : format(value);
+  const cell = ({
+    value,
+    format,
+  }: {
+    value: number | undefined;
+    format: (value: number) => string;
+  }) => (!isLoaded ? undefined : value === undefined ? "-" : format(value));
 
   return (
     <VStack align="stretch" gap={4}>
@@ -145,7 +151,7 @@ export function ModelCostComparisonCard() {
           <HStack align="start" gap={0}>
             <SummaryMetric
               label="Actual Cost"
-              current={cell(actualCost, money)}
+              current={cell({ value: actualCost, format: money })}
               format={asIs}
               increaseIs="neutral"
               tooltip="What this period's traffic cost, across every model in it. Models with no published price, self-hosted ones included, are recorded at $0."
@@ -153,7 +159,7 @@ export function ModelCostComparisonCard() {
             />
             <SummaryMetric
               label="Estimated Cost"
-              current={cell(referenceCost, money)}
+              current={cell({ value: referenceCost, format: money })}
               format={asIs}
               increaseIs="neutral"
               tooltip="Every input, output and cached token recorded in this period, priced at the selected model's published rates."
@@ -161,7 +167,7 @@ export function ModelCostComparisonCard() {
             />
             <SummaryMetric
               label="Estimated Savings"
-              current={cell(savings, signedMoney)}
+              current={cell({ value: savings, format: signedMoney })}
               format={asIs}
               increaseIs="good"
               tooltip="Estimated cost on the selected model minus the actual cost. Negative means the current setup costs more."

--- a/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
+++ b/langwatch/src/components/analytics/ModelCostComparisonCard.tsx
@@ -4,6 +4,8 @@ import { useMemo, useState } from "react";
 import { useFilterParams } from "../../hooks/useFilterParams";
 import { useModelProvidersSettings } from "../../hooks/useModelProvidersSettings";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
+import type { SeriesInputType } from "../../server/analytics/registry";
+import { readSummaryMetric } from "../../server/analytics/timeseriesSummary";
 import { api } from "../../utils/api";
 import { ModelSelector } from "../ModelSelector";
 import {
@@ -12,50 +14,50 @@ import {
 } from "./modelCostComparison";
 import { SummaryMetric } from "./SummaryMetric";
 
-const SERIES = [
+/**
+ * The four token buckets the product bills separately, plus the recorded cost.
+ * Cached input is counted apart from fresh input, so leaving the cache buckets
+ * out of the request would price a cached period as if most of its prompt never
+ * happened. Values are read back by metric name, never by position.
+ */
+const SERIES: SeriesInputType[] = [
   { metric: "performance.prompt_tokens", aggregation: "sum" },
   { metric: "performance.completion_tokens", aggregation: "sum" },
+  { metric: "performance.cache_read_tokens", aggregation: "sum" },
+  { metric: "performance.cache_write_tokens", aggregation: "sum" },
   { metric: "performance.total_cost", aggregation: "sum" },
-] as const;
-
-const seriesKey = (index: number) =>
-  `${index}/${SERIES[index]!.metric}/${SERIES[index]!.aggregation}`;
-
-const sumSeries = ({
-  buckets,
-  key,
-}: {
-  buckets: Record<string, unknown>[] | undefined;
-  key: string;
-}): number =>
-  (buckets ?? []).reduce((total, bucket) => {
-    const value = bucket[key];
-    return total + (typeof value === "number" ? value : 0);
-  }, 0);
+];
 
 const money = (value: number) =>
   value >= 0.01 || value === 0
     ? numeral(value).format("$0.00a")
     : numeral(value).format("$0.0000a");
 
+const signedMoney = (value: number) =>
+  value < 0 ? `-${money(Math.abs(value))}` : money(value);
+
+const tokenCount = (value: number) => numeral(value).format("0.[0]a");
+
 const DEFAULT_REFERENCE = "anthropic/claude-sonnet-4-6";
 
 /**
- * Compares the period's actual spend with what the same traffic would have
- * cost on a reference model, using the period's real token counts priced
- * at the reference model's catalog rates. Honors the page's filters and
- * date range, so the comparison can be sliced by label, model, user, etc.
+ * Compares the period's actual spend with what the same traffic would have cost
+ * on a reference model, using the period's real token counts priced at the
+ * reference model's catalog rates. Honors the page's filters and date range, so
+ * the comparison can be sliced by label, model, user, etc.
+ *
+ * The card shows nothing rather than a number it cannot stand behind: a model
+ * with no published price gets a plain explanation, not a $0 estimate.
  */
 export function ModelCostComparisonCard() {
   const { project } = useOrganizationTeamProject();
   const { filterParams, queryOpts } = useFilterParams();
-  const { modelMetadata, providers } = useModelProvidersSettings({
-    projectId: project?.id,
-  });
+  const { modelMetadata, isLoading: isLoadingModels } =
+    useModelProvidersSettings({ projectId: project?.id });
 
   const options = useMemo(
-    () => referenceModelOptions({ modelMetadata, providers }),
-    [modelMetadata, providers],
+    () => referenceModelOptions({ modelMetadata }),
+    [modelMetadata],
   );
   const [referenceModel, setReferenceModel] = useState<string | undefined>(
     undefined,
@@ -67,37 +69,42 @@ export function ModelCostComparisonCard() {
   const timeseries = api.analytics.getTimeseries.useQuery(
     {
       ...filterParams,
-      series: SERIES.map((s) => ({ ...s })),
+      series: SERIES,
       timeScale: "full",
       timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     },
     queryOpts,
   );
 
-  const promptTokens = sumSeries({
-    buckets: timeseries.data?.currentPeriod,
-    key: seriesKey(0),
-  });
-  const completionTokens = sumSeries({
-    buckets: timeseries.data?.currentPeriod,
-    key: seriesKey(1),
-  });
-  const actualCost = sumSeries({
-    buckets: timeseries.data?.currentPeriod,
-    key: seriesKey(2),
-  });
+  const buckets = timeseries.data?.currentPeriod;
+  const read = (metric: string) =>
+    readSummaryMetric({ buckets, series: SERIES, metric, aggregation: "sum" }) ??
+    0;
 
-  const pricing = selectedModel
-    ? modelMetadata?.[selectedModel]?.pricing
-    : undefined;
+  const promptTokens = read("performance.prompt_tokens");
+  const completionTokens = read("performance.completion_tokens");
+  const cacheReadTokens = read("performance.cache_read_tokens");
+  const cacheWriteTokens = read("performance.cache_write_tokens");
+  const actualCost = read("performance.total_cost");
+
   const referenceCost = estimateReferenceCost({
     promptTokens,
     completionTokens,
-    pricing,
+    cacheReadTokens,
+    cacheWriteTokens,
+    pricing: selectedModel ? modelMetadata?.[selectedModel]?.pricing : undefined,
   });
   const savings =
     referenceCost !== undefined ? referenceCost - actualCost : undefined;
-  const hasTraffic = promptTokens + completionTokens > 0;
+
+  // The query reports `isLoading` as false while it is still disabled (no
+  // project or no date range yet), so the presence of data is what tells
+  // loading apart from a genuinely quiet period. Without this the card claims
+  // "no traffic" before it has even asked.
+  const isLoaded = !isLoadingModels && buckets !== undefined;
+  const hasTraffic =
+    promptTokens + completionTokens + cacheReadTokens + cacheWriteTokens > 0;
+  const cachedTokens = cacheReadTokens + cacheWriteTokens;
 
   return (
     <VStack align="stretch" gap={4}>
@@ -119,50 +126,59 @@ export function ModelCostComparisonCard() {
       </HStack>
       {timeseries.isError ? (
         <Text textStyle="sm" color="fg.error">
-          Could not load usage for the selected period. Try refreshing the
-          page.
+          Could not load usage for the selected period. Try refreshing the page.
         </Text>
-      ) : !timeseries.isLoading && !hasTraffic ? (
+      ) : isLoaded && !hasTraffic ? (
         <Text textStyle="sm" color="fg.subtle">
-          No traffic in the selected period. Adjust the filters or date range
-          to compare costs.
+          No traffic in the selected period. Adjust the filters or date range to
+          compare costs.
         </Text>
       ) : (
-        <HStack align="start" gap={0}>
-          <SummaryMetric
-            label="Current Cost"
-            current={timeseries.isLoading ? undefined : actualCost}
-            format={money}
-            increaseIs="neutral"
-            zeroMeansNoData={false}
-          />
-          <SummaryMetric
-            label="Estimated Cost on Selected Model"
-            current={
-              timeseries.isLoading || referenceCost === undefined
-                ? undefined
-                : referenceCost
-            }
-            format={money}
-            increaseIs="neutral"
-            tooltip="The period's input and output tokens priced at the selected model's rates."
-            zeroMeansNoData={false}
-          />
-          <SummaryMetric
-            label="Estimated Savings"
-            current={
-              timeseries.isLoading || savings === undefined
-                ? undefined
-                : savings
-            }
-            format={(value: number) =>
-              value < 0 ? `-${money(Math.abs(value))}` : money(value)
-            }
-            increaseIs="good"
-            tooltip="Estimated cost on the selected model minus the actual cost. Negative means the current setup costs more."
-            zeroMeansNoData={false}
-          />
-        </HStack>
+        <VStack align="stretch" gap={2}>
+          <HStack align="start" gap={0}>
+            <SummaryMetric
+              label="Actual Cost"
+              current={isLoaded ? actualCost : undefined}
+              format={money}
+              increaseIs="neutral"
+              tooltip="What this period's traffic cost, across every model in it. Models with no published price, self-hosted ones included, are recorded at $0."
+              zeroMeansNoData={false}
+            />
+            <SummaryMetric
+              label="Estimated Cost"
+              current={isLoaded ? referenceCost : undefined}
+              format={money}
+              increaseIs="neutral"
+              tooltip="Every input, output and cached token recorded in this period, priced at the selected model's published rates."
+              zeroMeansNoData={false}
+            />
+            <SummaryMetric
+              label="Estimated Savings"
+              current={isLoaded ? savings : undefined}
+              format={signedMoney}
+              increaseIs="good"
+              tooltip="Estimated cost on the selected model minus the actual cost. Negative means the current setup costs more."
+              zeroMeansNoData={false}
+            />
+          </HStack>
+          {isLoaded && referenceCost === undefined && (
+            <Text textStyle="xs" color="fg.subtle">
+              {selectedModel
+                ? `No published price for ${selectedModel}, so this period cannot be repriced with it. Pick another model to compare.`
+                : "No model with a published price is available to compare against."}
+            </Text>
+          )}
+          {isLoaded && referenceCost !== undefined && (
+            <Text textStyle="xs" color="fg.subtle">
+              Based on {tokenCount(promptTokens)} input and{" "}
+              {tokenCount(completionTokens)} output tokens
+              {cachedTokens > 0
+                ? `, plus ${tokenCount(cachedTokens)} cached`
+                : ""}{" "}
+              recorded in this period.
+            </Text>
+          )}
+        </VStack>
       )}
     </VStack>
   );

--- a/langwatch/src/components/analytics/SummaryMetric.tsx
+++ b/langwatch/src/components/analytics/SummaryMetric.tsx
@@ -22,6 +22,7 @@ export function SummaryMetric({
   increaseIs,
   noDataUrl,
   titleProps,
+  zeroMeansNoData,
 }: {
   label: string;
   current?: number | string;
@@ -36,6 +37,15 @@ export function SummaryMetric({
     color?: SystemStyleObject["color"];
     fontWeight?: SystemStyleObject["fontWeight"];
   };
+  /**
+   * Whether a `current` of exactly 0 (with no `previous` to compare
+   * against) should render as "No data yet". Defaults to true: most
+   * callers never pass `previous` and a bare zero there has historically
+   * meant "nothing recorded". Callers that can tell the two apart (e.g. a
+   * loaded value that is genuinely zero) pass `false` to show the real
+   * $0.00/0 instead.
+   */
+  zeroMeansNoData?: boolean;
 }) {
   return (
     <VStack
@@ -79,6 +89,7 @@ export function SummaryMetric({
         format={format}
         increaseIs={increaseIs}
         noDataUrl={noDataUrl}
+        zeroMeansNoData={zeroMeansNoData}
       />
     </VStack>
   );
@@ -90,14 +101,17 @@ export function SummaryMetricValue({
   format,
   increaseIs = "good",
   noDataUrl,
+  zeroMeansNoData = true,
 }: {
   current?: number | string;
   previous?: number;
   format?: ((value: number) => string) | ((value: string) => string) | string;
   increaseIs?: "good" | "bad" | "neutral";
   noDataUrl?: string;
+  zeroMeansNoData?: boolean;
 }) {
   const isZeroZero =
+    zeroMeansNoData &&
     current !== undefined &&
     (current === 0 || current === "0") &&
     (previous === undefined || previous === 0);

--- a/langwatch/src/components/analytics/SummaryMetric.tsx
+++ b/langwatch/src/components/analytics/SummaryMetric.tsx
@@ -38,12 +38,12 @@ export function SummaryMetric({
     fontWeight?: SystemStyleObject["fontWeight"];
   };
   /**
-   * Whether a `current` of exactly 0 (with no `previous` to compare
-   * against) should render as "No data yet". Defaults to true: most
-   * callers never pass `previous` and a bare zero there has historically
-   * meant "nothing recorded". Callers that can tell the two apart (e.g. a
-   * loaded value that is genuinely zero) pass `false` to show the real
-   * $0.00/0 instead.
+   * Whether a `current` of exactly 0 with no `previous` to compare against
+   * renders as "No data yet". Defaults to true, which is what a caller that
+   * only ever counts rows wants: nothing counted and nothing to compare
+   * against means nothing was recorded. Pass false when zero is a real,
+   * loaded value the reader needs to see, such as a period that genuinely
+   * cost nothing.
    */
   zeroMeansNoData?: boolean;
 }) {

--- a/langwatch/src/components/analytics/__tests__/ModelCostComparisonCard.integration.test.tsx
+++ b/langwatch/src/components/analytics/__tests__/ModelCostComparisonCard.integration.test.tsx
@@ -249,7 +249,11 @@ describe("<ModelCostComparisonCard />", () => {
       expect(
         screen.getByText(/no model with a published price/i),
       ).toBeInTheDocument();
-      expect(screen.queryByText("$0.00 ")).not.toBeInTheDocument();
+      // The estimate and the savings read as a dash: absent, not pending and
+      // not zero. The one dollar figure left is the actual cost, which is
+      // genuinely $0.00 for this period.
+      expect(screen.getAllByText("-")).toHaveLength(2);
+      expect(screen.getAllByText("$0.00")).toHaveLength(1);
     });
   });
 

--- a/langwatch/src/components/analytics/__tests__/ModelCostComparisonCard.integration.test.tsx
+++ b/langwatch/src/components/analytics/__tests__/ModelCostComparisonCard.integration.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The card turns token counts into a dollar figure a customer will quote to
+ * their finance team, so these render the real component tree against realistic
+ * `getTimeseries` responses and check the number on screen, not the calc
+ * module in isolation. The bucket keys are built from the series the card
+ * actually requests, so the test follows a reordering of that request instead
+ * of pinning it.
+ *
+ * Spec: specs/analytics/model-cost-comparison.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import type { SeriesInputType } from "~/server/analytics/registry";
+import { buildSeriesName } from "~/server/app-layer/analytics/repositories/_timeseries-row-parser";
+
+import { ModelCostComparisonCard } from "../ModelCostComparisonCard";
+
+// Anthropic Claude Sonnet 4.6's real catalog rates, the card's default
+// reference model.
+const SONNET_PRICING = {
+  inputCostPerToken: 0.000003,
+  outputCostPerToken: 0.000015,
+  inputCacheReadPerToken: 0.0000003,
+  inputCacheWritePerToken: 0.00000375,
+};
+
+const CACHED_PERIOD: Record<string, number> = {
+  "performance.prompt_tokens": 2_000_000,
+  "performance.completion_tokens": 500_000,
+  "performance.cache_read_tokens": 1_000_000,
+  "performance.cache_write_tokens": 200_000,
+  "performance.total_cost": 0,
+};
+
+const EMPTY_PERIOD: Record<string, number> = {
+  "performance.prompt_tokens": 0,
+  "performance.completion_tokens": 0,
+  "performance.cache_read_tokens": 0,
+  "performance.cache_write_tokens": 0,
+  "performance.total_cost": 0,
+};
+
+type TimeseriesInput = { series: SeriesInputType[] } & Record<string, unknown>;
+
+const state: {
+  values: Record<string, number> | undefined;
+  isError: boolean;
+  lastInput: TimeseriesInput | undefined;
+  modelMetadata: Record<string, unknown>;
+} = {
+  values: undefined,
+  isError: false,
+  lastInput: undefined,
+  modelMetadata: {},
+};
+
+/**
+ * Encodes the values into a `currentPeriod` bucket exactly the way the
+ * app-layer writes one, keyed off the series the card asked for.
+ */
+const bucketFor = (
+  series: SeriesInputType[],
+  values: Record<string, number>,
+) => {
+  const bucket: Record<string, unknown> = { date: "full" };
+  series.forEach((entry, index) => {
+    const value = values[entry.metric];
+    if (value !== undefined) bucket[buildSeriesName(entry, index)] = value;
+  });
+  return bucket;
+};
+
+vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", slug: "acme-app" },
+    organization: { id: "org-1", name: "ACME" },
+    team: { id: "team-1", name: "Platform" },
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    asPath: "/acme-app/analytics/metrics?labels=checkout",
+    pathname: "/[project]/analytics/metrics",
+    query: { project: "acme-app", period: "30d" },
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../utils/api", () => ({
+  api: {
+    analytics: {
+      getTimeseries: {
+        useQuery: (input: TimeseriesInput) => {
+          state.lastInput = input;
+          if (state.isError) {
+            return { data: undefined, isLoading: false, isError: true };
+          }
+          if (!state.values) {
+            return { data: undefined, isLoading: true, isError: false };
+          }
+          return {
+            data: {
+              currentPeriod: [bucketFor(input.series, state.values)],
+              previousPeriod: [],
+            },
+            isLoading: false,
+            isError: false,
+          };
+        },
+      },
+    },
+    modelProvider: {
+      getAllForProjectForFrontend: {
+        useQuery: () => ({
+          data: { providers: {}, modelMetadata: state.modelMetadata },
+          isLoading: false,
+        }),
+      },
+      listAllForProjectForFrontend: {
+        useQuery: () => ({
+          data: {
+            providers: [
+              { provider: "anthropic", enabled: true, customModels: [] },
+            ],
+          },
+          isLoading: false,
+        }),
+      },
+    },
+  },
+}));
+
+function renderCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider value={defaultSystem}>
+        <ModelCostComparisonCard />
+      </ChakraProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  state.values = undefined;
+  state.isError = false;
+  state.lastInput = undefined;
+  state.modelMetadata = {
+    "anthropic/claude-sonnet-4-6": {
+      id: "anthropic/claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      provider: "anthropic",
+      pricing: SONNET_PRICING,
+    },
+  };
+});
+
+afterEach(cleanup);
+
+describe("<ModelCostComparisonCard />", () => {
+  describe("given a period whose prompts were largely served from cache", () => {
+    describe("when the card prices it against the reference model", () => {
+      it("prices the cached tokens at the cache rates instead of ignoring them", () => {
+        state.values = CACHED_PERIOD;
+        renderCard();
+
+        // 2M x $3/M + 500k x $15/M + 1M x $0.30/M + 200k x $3.75/M = $14.55.
+        // Fresh input and output alone would be $13.50, so the cached tokens
+        // moving the figure is what proves they were counted.
+        expect(screen.getAllByText("$14.55").length).toBeGreaterThan(0);
+        expect(screen.queryByText("$13.50")).not.toBeInTheDocument();
+      });
+
+      it("shows the token basis behind the estimate", () => {
+        state.values = CACHED_PERIOD;
+        renderCard();
+
+        expect(
+          screen.getByText(
+            /Based on 2m input and 500k output tokens, plus 1\.2m cached/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      it("requests the cached token counts alongside the fresh ones", () => {
+        state.values = CACHED_PERIOD;
+        renderCard();
+
+        const metrics = state.lastInput?.series.map((s) => s.metric);
+        expect(metrics).toEqual(
+          expect.arrayContaining([
+            "performance.prompt_tokens",
+            "performance.completion_tokens",
+            "performance.cache_read_tokens",
+            "performance.cache_write_tokens",
+            "performance.total_cost",
+          ]),
+        );
+      });
+    });
+  });
+
+  describe("given traffic that genuinely cost nothing", () => {
+    it("shows $0.00 as the actual cost rather than claiming there is no data", () => {
+      state.values = CACHED_PERIOD;
+      renderCard();
+
+      expect(screen.getByText("$0.00")).toBeInTheDocument();
+      expect(screen.queryByText(/no data yet/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given the page carries a filter", () => {
+    it("passes it through to the usage query", () => {
+      state.values = CACHED_PERIOD;
+      renderCard();
+
+      expect(state.lastInput?.filters).toMatchObject({
+        "metadata.labels": ["checkout"],
+      });
+      expect(state.lastInput?.projectId).toBe("proj-1");
+    });
+  });
+
+  describe("given no reference model with a published price", () => {
+    it("explains why there is no estimate instead of showing $0.00 savings", () => {
+      state.modelMetadata = {
+        "custom/qwen3-14b": {
+          id: "custom/qwen3-14b",
+          name: "qwen3-14b",
+          provider: "custom",
+          pricing: { inputCostPerToken: 0, outputCostPerToken: 0 },
+        },
+      };
+      state.values = CACHED_PERIOD;
+      renderCard();
+
+      expect(
+        screen.getByText(/no model with a published price/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("$0.00 ")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given no traffic in the period", () => {
+    it("shows an empty state instead of a $0.00 comparison", () => {
+      state.values = EMPTY_PERIOD;
+      renderCard();
+
+      expect(screen.getByText(/no traffic in the selected period/i)).toBeInTheDocument();
+      expect(screen.queryByText("$14.55")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given the usage query has not resolved", () => {
+    it("does not claim the period is empty before it has an answer", () => {
+      state.values = undefined;
+      renderCard();
+
+      expect(
+        screen.queryByText(/no traffic in the selected period/i),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/no data yet/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given the usage query failed", () => {
+    it("says so instead of reporting an empty period", () => {
+      state.isError = true;
+      renderCard();
+
+      expect(screen.getByText(/could not load usage/i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/no traffic in the selected period/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/components/analytics/__tests__/ModelCostComparisonCard.integration.test.tsx
+++ b/langwatch/src/components/analytics/__tests__/ModelCostComparisonCard.integration.test.tsx
@@ -211,6 +211,27 @@ describe("<ModelCostComparisonCard />", () => {
     });
   });
 
+  describe("given a period that runs into four figures", () => {
+    it("keeps the digits instead of abbreviating them away", () => {
+      state.values = {
+        "performance.prompt_tokens": 400_000_000,
+        "performance.completion_tokens": 0,
+        "performance.cache_read_tokens": 0,
+        "performance.cache_write_tokens": 0,
+        "performance.total_cost": 200,
+      };
+      renderCard();
+
+      // 400M x $3/M = $1200, against $200 actually spent. Abbreviated to
+      // "$1.2k" and "$1k" these stop being figures anyone can put in front of
+      // a finance team.
+      expect(screen.getByText("$1200.00")).toBeInTheDocument();
+      expect(screen.getByText("$200.00")).toBeInTheDocument();
+      expect(screen.getByText("$1000.00")).toBeInTheDocument();
+      expect(screen.queryByText(/k$/)).not.toBeInTheDocument();
+    });
+  });
+
   describe("given traffic that genuinely cost nothing", () => {
     it("shows $0.00 as the actual cost rather than claiming there is no data", () => {
       state.values = CACHED_PERIOD;

--- a/langwatch/src/components/analytics/__tests__/SummaryMetric.integration.test.tsx
+++ b/langwatch/src/components/analytics/__tests__/SummaryMetric.integration.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { SummaryMetric } from "../SummaryMetric";
+
+afterEach(cleanup);
+
+function renderMetric(props: React.ComponentProps<typeof SummaryMetric>) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <SummaryMetric {...props} />
+    </ChakraProvider>,
+  );
+}
+
+// Spec: specs/analytics/model-cost-comparison.feature
+
+describe("<SummaryMetric />", () => {
+  describe("when current is a genuine zero and zeroMeansNoData is false", () => {
+    it("renders the zero value instead of 'No data yet'", () => {
+      renderMetric({
+        label: "Current Cost",
+        current: 0,
+        format: () => "$0.00",
+        zeroMeansNoData: false,
+      });
+
+      expect(screen.getByText("$0.00")).toBeInTheDocument();
+      expect(screen.queryByText(/no data yet/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when current is zero and zeroMeansNoData is unset (default)", () => {
+    it("renders 'No data yet', preserving existing callers' behavior", () => {
+      renderMetric({
+        label: "Feedbacks",
+        current: 0,
+      });
+
+      expect(screen.getByText(/no data yet/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when current is undefined", () => {
+    it("shows the loading skeleton, not a zero value, regardless of zeroMeansNoData", () => {
+      renderMetric({
+        label: "Current Cost",
+        current: undefined,
+        format: () => "$0.00",
+        zeroMeansNoData: false,
+      });
+
+      expect(screen.queryByText("$0.00")).not.toBeInTheDocument();
+      expect(screen.queryByText(/no data yet/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/components/analytics/__tests__/modelCostComparison.unit.test.ts
+++ b/langwatch/src/components/analytics/__tests__/modelCostComparison.unit.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { ModelMetadataForFrontend } from "../../../hooks/useModelProvidersSettings";
+import {
+  estimateReferenceCost,
+  referenceModelOptions,
+} from "../modelCostComparison";
+
+// Spec: specs/analytics/model-cost-comparison.feature
+
+const metadataWith = (
+  pricing: ModelMetadataForFrontend["pricing"],
+): ModelMetadataForFrontend =>
+  ({ id: "x", name: "x", provider: "openai", pricing }) as never;
+
+describe("estimateReferenceCost", () => {
+  describe("when the reference model has complete pricing", () => {
+    it("prices the period's tokens at the reference per-token rates", () => {
+      // Scenario: 2M input + 500k output on a model at $3/M in, $15/M out
+      const cost = estimateReferenceCost({
+        promptTokens: 2_000_000,
+        completionTokens: 500_000,
+        pricing: { inputCostPerToken: 0.000003, outputCostPerToken: 0.000015 },
+      });
+      expect(cost).toBeCloseTo(2_000_000 * 0.000003 + 500_000 * 0.000015, 10);
+      expect(cost).toBeCloseTo(13.5, 6);
+    });
+  });
+
+  describe("when pricing is missing or incomplete", () => {
+    it("returns undefined instead of a partial estimate", () => {
+      expect(
+        estimateReferenceCost({
+          promptTokens: 1000,
+          completionTokens: 1000,
+          pricing: undefined,
+        }),
+      ).toBeUndefined();
+      expect(
+        estimateReferenceCost({
+          promptTokens: 1000,
+          completionTokens: 1000,
+          pricing: null,
+        }),
+      ).toBeUndefined();
+      expect(
+        estimateReferenceCost({
+          promptTokens: 1000,
+          completionTokens: 1000,
+          pricing: { inputCostPerToken: 0.000003 },
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("when the period has zero tokens", () => {
+    it("estimates zero", () => {
+      expect(
+        estimateReferenceCost({
+          promptTokens: 0,
+          completionTokens: 0,
+          pricing: { inputCostPerToken: 0.000003, outputCostPerToken: 0.000015 },
+        }),
+      ).toBe(0);
+    });
+  });
+});
+
+describe("referenceModelOptions", () => {
+  describe("when some models lack catalog pricing", () => {
+    it("offers only models with complete pricing, sorted", () => {
+      const options = referenceModelOptions({
+        "openai/gpt-5-mini": metadataWith({
+          inputCostPerToken: 0.00000025,
+          outputCostPerToken: 0.000002,
+        }),
+        "custom/qwen3-14b": metadataWith(undefined as never),
+        "anthropic/claude-sonnet-4-6": metadataWith({
+          inputCostPerToken: 0.000003,
+          outputCostPerToken: 0.000015,
+        }),
+        "custom/half-priced": metadataWith({
+          inputCostPerToken: 0.000001,
+        } as never),
+      });
+      expect(options).toEqual([
+        "anthropic/claude-sonnet-4-6",
+        "openai/gpt-5-mini",
+      ]);
+    });
+  });
+
+  describe("when metadata has not loaded yet", () => {
+    it("returns an empty list", () => {
+      expect(referenceModelOptions(undefined)).toEqual([]);
+    });
+  });
+});

--- a/langwatch/src/components/analytics/__tests__/modelCostComparison.unit.test.ts
+++ b/langwatch/src/components/analytics/__tests__/modelCostComparison.unit.test.ts
@@ -139,13 +139,13 @@ describe("referenceModelOptions", () => {
       expect(options).not.toContain("custom/qwen3-14b");
     });
 
-    it("still excludes it when providers is not supplied (fail closed, not open)", () => {
+    it("cannot exclude custom models when providers is not supplied", () => {
       // Without `providers` there is no way to tell a genuinely-free
-      // catalog model apart from a custom-model placeholder, so this only
-      // matters for callers that always pass `providers` (the real
-      // ModelCostComparisonCard integration does). This case documents
-      // that omitting it does NOT accidentally re-admit custom models —
-      // it just can't exclude them without the provider list.
+      // catalog model apart from a custom-model placeholder, so the
+      // exclusion can only run for callers that pass `providers` (the real
+      // ModelCostComparisonCard integration always does). This case pins
+      // that fallback: omitting the provider list re-admits the custom
+      // model, so callers must supply `providers` for the guarantee to hold.
       const options = referenceModelOptions({
         modelMetadata: {
           "custom/qwen3-14b": customModelMetadata(),

--- a/langwatch/src/components/analytics/__tests__/modelCostComparison.unit.test.ts
+++ b/langwatch/src/components/analytics/__tests__/modelCostComparison.unit.test.ts
@@ -1,9 +1,34 @@
 import { describe, expect, it } from "vitest";
 import type { ModelMetadataForFrontend } from "../../../hooks/useModelProvidersSettings";
+import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
 import {
   estimateReferenceCost,
   referenceModelOptions,
 } from "../modelCostComparison";
+
+// A custom/self-hosted model's real cost is unknown, but
+// `mergeCustomModelMetadata` backfills its pricing with {0,0} so other
+// consumers (e.g. LLMConfigPopover) don't choke on missing fields. This
+// fixture reproduces that shape to prove referenceModelOptions doesn't
+// trust it.
+const customModelMetadata = (): ModelMetadataForFrontend =>
+  ({
+    id: "custom/qwen3-14b",
+    name: "qwen3-14b",
+    provider: "custom",
+    pricing: { inputCostPerToken: 0, outputCostPerToken: 0 },
+  }) as never;
+
+const providerWithCustomModel = (
+  modelId: string,
+): Record<string, MaybeStoredModelProvider> =>
+  ({
+    custom: {
+      provider: "custom",
+      enabled: true,
+      customModels: [{ modelId, displayName: modelId }],
+    },
+  }) as never;
 
 // Spec: specs/analytics/model-cost-comparison.feature
 
@@ -69,18 +94,20 @@ describe("referenceModelOptions", () => {
   describe("when some models lack catalog pricing", () => {
     it("offers only models with complete pricing, sorted", () => {
       const options = referenceModelOptions({
-        "openai/gpt-5-mini": metadataWith({
-          inputCostPerToken: 0.00000025,
-          outputCostPerToken: 0.000002,
-        }),
-        "custom/qwen3-14b": metadataWith(undefined as never),
-        "anthropic/claude-sonnet-4-6": metadataWith({
-          inputCostPerToken: 0.000003,
-          outputCostPerToken: 0.000015,
-        }),
-        "custom/half-priced": metadataWith({
-          inputCostPerToken: 0.000001,
-        } as never),
+        modelMetadata: {
+          "openai/gpt-5-mini": metadataWith({
+            inputCostPerToken: 0.00000025,
+            outputCostPerToken: 0.000002,
+          }),
+          "custom/qwen3-14b": metadataWith(undefined as never),
+          "anthropic/claude-sonnet-4-6": metadataWith({
+            inputCostPerToken: 0.000003,
+            outputCostPerToken: 0.000015,
+          }),
+          "custom/half-priced": metadataWith({
+            inputCostPerToken: 0.000001,
+          } as never),
+        },
       });
       expect(options).toEqual([
         "anthropic/claude-sonnet-4-6",
@@ -91,7 +118,41 @@ describe("referenceModelOptions", () => {
 
   describe("when metadata has not loaded yet", () => {
     it("returns an empty list", () => {
-      expect(referenceModelOptions(undefined)).toEqual([]);
+      expect(referenceModelOptions({ modelMetadata: undefined })).toEqual([]);
+    });
+  });
+
+  describe("when a custom/self-hosted model carries placeholder {0,0} pricing", () => {
+    it("excludes it even though the pricing fields are both numbers", () => {
+      const options = referenceModelOptions({
+        modelMetadata: {
+          "anthropic/claude-sonnet-4-6": metadataWith({
+            inputCostPerToken: 0.000003,
+            outputCostPerToken: 0.000015,
+          }),
+          "custom/qwen3-14b": customModelMetadata(),
+        },
+        providers: providerWithCustomModel("qwen3-14b"),
+      });
+
+      expect(options).toEqual(["anthropic/claude-sonnet-4-6"]);
+      expect(options).not.toContain("custom/qwen3-14b");
+    });
+
+    it("still excludes it when providers is not supplied (fail closed, not open)", () => {
+      // Without `providers` there is no way to tell a genuinely-free
+      // catalog model apart from a custom-model placeholder, so this only
+      // matters for callers that always pass `providers` (the real
+      // ModelCostComparisonCard integration does). This case documents
+      // that omitting it does NOT accidentally re-admit custom models —
+      // it just can't exclude them without the provider list.
+      const options = referenceModelOptions({
+        modelMetadata: {
+          "custom/qwen3-14b": customModelMetadata(),
+        },
+      });
+
+      expect(options).toEqual(["custom/qwen3-14b"]);
     });
   });
 });

--- a/langwatch/src/components/analytics/__tests__/modelCostComparison.unit.test.ts
+++ b/langwatch/src/components/analytics/__tests__/modelCostComparison.unit.test.ts
@@ -1,16 +1,36 @@
 import { describe, expect, it } from "vitest";
 import type { ModelMetadataForFrontend } from "../../../hooks/useModelProvidersSettings";
-import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
 import {
   estimateReferenceCost,
   referenceModelOptions,
 } from "../modelCostComparison";
 
-// A custom/self-hosted model's real cost is unknown, but
-// `mergeCustomModelMetadata` backfills its pricing with {0,0} so other
-// consumers (e.g. LLMConfigPopover) don't choke on missing fields. This
-// fixture reproduces that shape to prove referenceModelOptions doesn't
-// trust it.
+// Spec: specs/analytics/model-cost-comparison.feature
+
+// Anthropic Claude Sonnet 4.6's real catalog rates, so the arithmetic below is
+// checkable against the published price list rather than invented numbers.
+const SONNET = {
+  inputCostPerToken: 0.000003,
+  outputCostPerToken: 0.000015,
+  inputCacheReadPerToken: 0.0000003,
+  inputCacheWritePerToken: 0.00000375,
+};
+
+const noTokens = {
+  promptTokens: 0,
+  completionTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+};
+
+const metadataWith = (
+  pricing: ModelMetadataForFrontend["pricing"],
+): ModelMetadataForFrontend =>
+  ({ id: "x", name: "x", provider: "openai", pricing }) as never;
+
+// A custom/self-hosted model's real cost is unknown, but the model metadata
+// backfills its pricing with {0,0} so other consumers don't choke on missing
+// fields. This fixture reproduces that shape.
 const customModelMetadata = (): ModelMetadataForFrontend =>
   ({
     id: "custom/qwen3-14b",
@@ -19,59 +39,88 @@ const customModelMetadata = (): ModelMetadataForFrontend =>
     pricing: { inputCostPerToken: 0, outputCostPerToken: 0 },
   }) as never;
 
-const providerWithCustomModel = (
-  modelId: string,
-): Record<string, MaybeStoredModelProvider> =>
-  ({
-    custom: {
-      provider: "custom",
-      enabled: true,
-      customModels: [{ modelId, displayName: modelId }],
-    },
-  }) as never;
-
-// Spec: specs/analytics/model-cost-comparison.feature
-
-const metadataWith = (
-  pricing: ModelMetadataForFrontend["pricing"],
-): ModelMetadataForFrontend =>
-  ({ id: "x", name: "x", provider: "openai", pricing }) as never;
-
 describe("estimateReferenceCost", () => {
-  describe("when the reference model has complete pricing", () => {
-    it("prices the period's tokens at the reference per-token rates", () => {
-      // Scenario: 2M input + 500k output on a model at $3/M in, $15/M out
+  describe("when the period mixes fresh and cached input", () => {
+    it("prices every token bucket at its own rate", () => {
       const cost = estimateReferenceCost({
         promptTokens: 2_000_000,
         completionTokens: 500_000,
-        pricing: { inputCostPerToken: 0.000003, outputCostPerToken: 0.000015 },
+        cacheReadTokens: 1_000_000,
+        cacheWriteTokens: 200_000,
+        pricing: SONNET,
       });
-      expect(cost).toBeCloseTo(2_000_000 * 0.000003 + 500_000 * 0.000015, 10);
-      expect(cost).toBeCloseTo(13.5, 6);
+
+      // 2M x $3/M + 500k x $15/M + 1M x $0.30/M + 200k x $3.75/M
+      expect(cost).toBeCloseTo(6 + 7.5 + 0.3 + 0.75, 10);
+      expect(cost).toBeCloseTo(14.55, 6);
+    });
+
+    it("counts the cached tokens rather than dropping them", () => {
+      const withCache = estimateReferenceCost({
+        promptTokens: 2_000_000,
+        completionTokens: 500_000,
+        cacheReadTokens: 1_000_000,
+        cacheWriteTokens: 200_000,
+        pricing: SONNET,
+      })!;
+      const freshOnly = estimateReferenceCost({
+        promptTokens: 2_000_000,
+        completionTokens: 500_000,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        pricing: SONNET,
+      })!;
+
+      expect(freshOnly).toBeCloseTo(13.5, 6);
+      expect(withCache).toBeGreaterThan(freshOnly);
+    });
+  });
+
+  describe("when the model publishes no cache rates", () => {
+    it("prices cached tokens at the plain input rate, as the recorded cost does", () => {
+      const cost = estimateReferenceCost({
+        promptTokens: 1_000_000,
+        completionTokens: 0,
+        cacheReadTokens: 1_000_000,
+        cacheWriteTokens: 1_000_000,
+        pricing: {
+          inputCostPerToken: 0.000003,
+          outputCostPerToken: 0.000015,
+        },
+      });
+
+      expect(cost).toBeCloseTo(3_000_000 * 0.000003, 10);
     });
   });
 
   describe("when pricing is missing or incomplete", () => {
     it("returns undefined instead of a partial estimate", () => {
       expect(
-        estimateReferenceCost({
-          promptTokens: 1000,
-          completionTokens: 1000,
-          pricing: undefined,
-        }),
+        estimateReferenceCost({ ...noTokens, pricing: undefined }),
+      ).toBeUndefined();
+      expect(
+        estimateReferenceCost({ ...noTokens, pricing: null }),
       ).toBeUndefined();
       expect(
         estimateReferenceCost({
-          promptTokens: 1000,
-          completionTokens: 1000,
-          pricing: null,
-        }),
-      ).toBeUndefined();
-      expect(
-        estimateReferenceCost({
-          promptTokens: 1000,
-          completionTokens: 1000,
+          ...noTokens,
           pricing: { inputCostPerToken: 0.000003 },
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("when both published rates are zero", () => {
+    it("returns undefined rather than a confident $0 estimate", () => {
+      // Self-hosted and custom models carry this placeholder, and so do the
+      // handful of catalog rows whose price is not public.
+      expect(
+        estimateReferenceCost({
+          promptTokens: 2_000_000,
+          completionTokens: 500_000,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          pricing: { inputCostPerToken: 0, outputCostPerToken: 0 },
         }),
       ).toBeUndefined();
     });
@@ -79,20 +128,14 @@ describe("estimateReferenceCost", () => {
 
   describe("when the period has zero tokens", () => {
     it("estimates zero", () => {
-      expect(
-        estimateReferenceCost({
-          promptTokens: 0,
-          completionTokens: 0,
-          pricing: { inputCostPerToken: 0.000003, outputCostPerToken: 0.000015 },
-        }),
-      ).toBe(0);
+      expect(estimateReferenceCost({ ...noTokens, pricing: SONNET })).toBe(0);
     });
   });
 });
 
 describe("referenceModelOptions", () => {
   describe("when some models lack catalog pricing", () => {
-    it("offers only models with complete pricing, sorted", () => {
+    it("offers only models with a usable published price, sorted", () => {
       const options = referenceModelOptions({
         modelMetadata: {
           "openai/gpt-5-mini": metadataWith({
@@ -100,15 +143,13 @@ describe("referenceModelOptions", () => {
             outputCostPerToken: 0.000002,
           }),
           "custom/qwen3-14b": metadataWith(undefined as never),
-          "anthropic/claude-sonnet-4-6": metadataWith({
-            inputCostPerToken: 0.000003,
-            outputCostPerToken: 0.000015,
-          }),
+          "anthropic/claude-sonnet-4-6": metadataWith(SONNET),
           "custom/half-priced": metadataWith({
             inputCostPerToken: 0.000001,
           } as never),
         },
       });
+
       expect(options).toEqual([
         "anthropic/claude-sonnet-4-6",
         "openai/gpt-5-mini",
@@ -122,37 +163,20 @@ describe("referenceModelOptions", () => {
     });
   });
 
-  describe("when a custom/self-hosted model carries placeholder {0,0} pricing", () => {
-    it("excludes it even though the pricing fields are both numbers", () => {
+  describe("when a model carries an all-zero placeholder price", () => {
+    it("leaves it out, whether it is custom or a catalog row", () => {
       const options = referenceModelOptions({
         modelMetadata: {
-          "anthropic/claude-sonnet-4-6": metadataWith({
-            inputCostPerToken: 0.000003,
-            outputCostPerToken: 0.000015,
-          }),
+          "anthropic/claude-sonnet-4-6": metadataWith(SONNET),
           "custom/qwen3-14b": customModelMetadata(),
+          "gemini/lyria-3-pro-preview": metadataWith({
+            inputCostPerToken: 0,
+            outputCostPerToken: 0,
+          }),
         },
-        providers: providerWithCustomModel("qwen3-14b"),
       });
 
       expect(options).toEqual(["anthropic/claude-sonnet-4-6"]);
-      expect(options).not.toContain("custom/qwen3-14b");
-    });
-
-    it("cannot exclude custom models when providers is not supplied", () => {
-      // Without `providers` there is no way to tell a genuinely-free
-      // catalog model apart from a custom-model placeholder, so the
-      // exclusion can only run for callers that pass `providers` (the real
-      // ModelCostComparisonCard integration always does). This case pins
-      // that fallback: omitting the provider list re-admits the custom
-      // model, so callers must supply `providers` for the guarantee to hold.
-      const options = referenceModelOptions({
-        modelMetadata: {
-          "custom/qwen3-14b": customModelMetadata(),
-        },
-      });
-
-      expect(options).toEqual(["custom/qwen3-14b"]);
     });
   });
 });

--- a/langwatch/src/components/analytics/modelCostComparison.ts
+++ b/langwatch/src/components/analytics/modelCostComparison.ts
@@ -1,4 +1,5 @@
 import type { ModelMetadataForFrontend } from "../../hooks/useModelProvidersSettings";
+import type { MaybeStoredModelProvider } from "../../server/modelProviders/registry";
 
 export type ReferencePricing = {
   inputCostPerToken?: number;
@@ -35,17 +36,49 @@ export function estimateReferenceCost({
 }
 
 /**
- * Models eligible as comparison reference: models with complete catalog
+ * Full ids (`{providerKey}/{modelId}`) of user-defined custom/self-hosted
+ * models. `mergeCustomModelMetadata` backfills these with a placeholder
+ * `{0,0}` pricing so cost-suppression callers (e.g. LLMConfigPopover) don't
+ * choke on missing fields — it is not real catalog pricing, so it must not
+ * be trusted for a savings estimate.
+ */
+function customModelIds(
+  providers: Record<string, MaybeStoredModelProvider> | undefined,
+): Set<string> {
+  const ids = new Set<string>();
+  if (!providers) return ids;
+  for (const [providerKey, config] of Object.entries(providers)) {
+    for (const entry of [
+      ...(config.customModels ?? []),
+      ...(config.customEmbeddingsModels ?? []),
+    ]) {
+      ids.add(`${providerKey}/${entry.modelId}`);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Models eligible as comparison reference: catalog models with complete
  * pricing. Models without pricing cannot produce an estimate, so offering
- * them would only lead to an empty result. Mode filtering (chat vs
+ * them would only lead to an empty result. Custom/self-hosted models are
+ * excluded even though they carry placeholder pricing (see
+ * `customModelIds`) — their real cost is unknown, so using them as a
+ * reference would fabricate a savings number. Mode filtering (chat vs
  * embedding) is the ModelSelector's job — this list is pricing-only.
  */
-export function referenceModelOptions(
-  modelMetadata: Record<string, ModelMetadataForFrontend> | undefined,
-): string[] {
+export function referenceModelOptions({
+  modelMetadata,
+  providers,
+}: {
+  modelMetadata: Record<string, ModelMetadataForFrontend> | undefined;
+  providers?: Record<string, MaybeStoredModelProvider> | undefined;
+}): string[] {
   if (!modelMetadata) return [];
+  const excluded = customModelIds(providers);
   return Object.entries(modelMetadata)
-    .filter(([, metadata]) => {
+    .filter(([id, metadata]) => {
+      if (excluded.has(id)) return false;
       const pricing = metadata.pricing;
       return (
         !!pricing &&

--- a/langwatch/src/components/analytics/modelCostComparison.ts
+++ b/langwatch/src/components/analytics/modelCostComparison.ts
@@ -35,9 +35,10 @@ export function estimateReferenceCost({
 }
 
 /**
- * Models eligible as comparison reference: chat models with complete
- * catalog pricing. Models without pricing cannot produce an estimate, so
- * offering them would only lead to an empty result.
+ * Models eligible as comparison reference: models with complete catalog
+ * pricing. Models without pricing cannot produce an estimate, so offering
+ * them would only lead to an empty result. Mode filtering (chat vs
+ * embedding) is the ModelSelector's job — this list is pricing-only.
  */
 export function referenceModelOptions(
   modelMetadata: Record<string, ModelMetadataForFrontend> | undefined,

--- a/langwatch/src/components/analytics/modelCostComparison.ts
+++ b/langwatch/src/components/analytics/modelCostComparison.ts
@@ -1,0 +1,57 @@
+import type { ModelMetadataForFrontend } from "../../hooks/useModelProvidersSettings";
+
+export type ReferencePricing = {
+  inputCostPerToken?: number;
+  outputCostPerToken?: number;
+} | null;
+
+/**
+ * Cost of running the period's traffic on a reference model: the period's
+ * real token counts priced at the reference model's per-token rates.
+ * Returns undefined when the pricing is incomplete — a partial estimate
+ * (input priced, output free) would understate the comparison and read as
+ * a smaller-than-real saving.
+ */
+export function estimateReferenceCost({
+  promptTokens,
+  completionTokens,
+  pricing,
+}: {
+  promptTokens: number;
+  completionTokens: number;
+  pricing: ReferencePricing | undefined;
+}): number | undefined {
+  if (
+    !pricing ||
+    typeof pricing.inputCostPerToken !== "number" ||
+    typeof pricing.outputCostPerToken !== "number"
+  ) {
+    return undefined;
+  }
+  return (
+    promptTokens * pricing.inputCostPerToken +
+    completionTokens * pricing.outputCostPerToken
+  );
+}
+
+/**
+ * Models eligible as comparison reference: chat models with complete
+ * catalog pricing. Models without pricing cannot produce an estimate, so
+ * offering them would only lead to an empty result.
+ */
+export function referenceModelOptions(
+  modelMetadata: Record<string, ModelMetadataForFrontend> | undefined,
+): string[] {
+  if (!modelMetadata) return [];
+  return Object.entries(modelMetadata)
+    .filter(([, metadata]) => {
+      const pricing = metadata.pricing;
+      return (
+        !!pricing &&
+        typeof pricing.inputCostPerToken === "number" &&
+        typeof pricing.outputCostPerToken === "number"
+      );
+    })
+    .map(([id]) => id)
+    .sort();
+}

--- a/langwatch/src/components/analytics/modelCostComparison.ts
+++ b/langwatch/src/components/analytics/modelCostComparison.ts
@@ -1,91 +1,98 @@
 import type { ModelMetadataForFrontend } from "../../hooks/useModelProvidersSettings";
-import type { MaybeStoredModelProvider } from "../../server/modelProviders/registry";
 
 export type ReferencePricing = {
   inputCostPerToken?: number;
   outputCostPerToken?: number;
+  inputCacheReadPerToken?: number;
+  inputCacheWritePerToken?: number;
 } | null;
 
 /**
- * Cost of running the period's traffic on a reference model: the period's
- * real token counts priced at the reference model's per-token rates.
- * Returns undefined when the pricing is incomplete — a partial estimate
- * (input priced, output free) would understate the comparison and read as
- * a smaller-than-real saving.
+ * The period's token counts, split the same way the product records them:
+ * `promptTokens` is the fresh (non-cached) input, with the cached buckets
+ * counted separately and never folded back into it. Pricing each bucket at its
+ * own rate is the only way the estimate compares like with like against the
+ * recorded cost, which is billed the same way.
+ */
+export type PeriodTokenTotals = {
+  promptTokens: number;
+  completionTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+};
+
+/**
+ * Whether the catalog publishes enough of a price for this model to reprice a
+ * period with it. Both per-token rates must be present and at least one must be
+ * above zero, the same bar the recorded cost applies before it prices a call.
+ * An all-zero row stands for "no published price" (self-hosted and custom
+ * models carry one, and so do a handful of catalog entries whose price is not
+ * public), so treating it as free would turn a missing price into a confident
+ * $0 comparison.
+ */
+export function hasUsableReferencePricing(
+  pricing: ReferencePricing | undefined,
+): boolean {
+  if (!pricing) return false;
+  const { inputCostPerToken, outputCostPerToken } = pricing;
+  if (
+    typeof inputCostPerToken !== "number" ||
+    typeof outputCostPerToken !== "number"
+  ) {
+    return false;
+  }
+  return inputCostPerToken > 0 || outputCostPerToken > 0;
+}
+
+/**
+ * Cost of running the period's traffic on a reference model: the period's real
+ * token counts priced at the reference model's per-token rates, one rate per
+ * bucket. Cached input is priced at the model's cache rates, falling back to
+ * the plain input rate when the catalog publishes none, so a cached prompt is
+ * neither dropped from the estimate nor priced as if it were fresh.
+ *
+ * Returns undefined when the model has no usable price. A partial estimate
+ * (input priced, output free) or a $0 one reads as a real number and there is
+ * nothing on screen to tell the reader it is not.
  */
 export function estimateReferenceCost({
   promptTokens,
   completionTokens,
+  cacheReadTokens,
+  cacheWriteTokens,
   pricing,
-}: {
-  promptTokens: number;
-  completionTokens: number;
+}: PeriodTokenTotals & {
   pricing: ReferencePricing | undefined;
 }): number | undefined {
-  if (
-    !pricing ||
-    typeof pricing.inputCostPerToken !== "number" ||
-    typeof pricing.outputCostPerToken !== "number"
-  ) {
-    return undefined;
-  }
+  if (!pricing || !hasUsableReferencePricing(pricing)) return undefined;
+  const inputRate = pricing.inputCostPerToken ?? 0;
+  const outputRate = pricing.outputCostPerToken ?? 0;
+  const cacheReadRate = pricing.inputCacheReadPerToken ?? inputRate;
+  const cacheWriteRate = pricing.inputCacheWritePerToken ?? inputRate;
+
   return (
-    promptTokens * pricing.inputCostPerToken +
-    completionTokens * pricing.outputCostPerToken
+    promptTokens * inputRate +
+    completionTokens * outputRate +
+    cacheReadTokens * cacheReadRate +
+    cacheWriteTokens * cacheWriteRate
   );
 }
 
 /**
- * Full ids (`{providerKey}/{modelId}`) of user-defined custom/self-hosted
- * models. `mergeCustomModelMetadata` backfills these with a placeholder
- * `{0,0}` pricing so cost-suppression callers (e.g. LLMConfigPopover) don't
- * choke on missing fields — it is not real catalog pricing, so it must not
- * be trusted for a savings estimate.
- */
-function customModelIds(
-  providers: Record<string, MaybeStoredModelProvider> | undefined,
-): Set<string> {
-  const ids = new Set<string>();
-  if (!providers) return ids;
-  for (const [providerKey, config] of Object.entries(providers)) {
-    for (const entry of [
-      ...(config.customModels ?? []),
-      ...(config.customEmbeddingsModels ?? []),
-    ]) {
-      ids.add(`${providerKey}/${entry.modelId}`);
-    }
-  }
-  return ids;
-}
-
-/**
- * Models eligible as comparison reference: catalog models with complete
- * pricing. Models without pricing cannot produce an estimate, so offering
- * them would only lead to an empty result. Custom/self-hosted models are
- * excluded even though they carry placeholder pricing (see
- * `customModelIds`) — their real cost is unknown, so using them as a
- * reference would fabricate a savings number. Mode filtering (chat vs
- * embedding) is the ModelSelector's job — this list is pricing-only.
+ * Models eligible as a comparison reference: the ones the catalog publishes a
+ * real price for. Everything else, including custom and self-hosted models
+ * whose real cost only the customer knows, is left out rather than offered as a
+ * reference that would price the period at zero. Mode filtering (chat vs
+ * embedding) is the ModelSelector's job, this list is pricing-only.
  */
 export function referenceModelOptions({
   modelMetadata,
-  providers,
 }: {
   modelMetadata: Record<string, ModelMetadataForFrontend> | undefined;
-  providers?: Record<string, MaybeStoredModelProvider> | undefined;
 }): string[] {
   if (!modelMetadata) return [];
-  const excluded = customModelIds(providers);
   return Object.entries(modelMetadata)
-    .filter(([id, metadata]) => {
-      if (excluded.has(id)) return false;
-      const pricing = metadata.pricing;
-      return (
-        !!pricing &&
-        typeof pricing.inputCostPerToken === "number" &&
-        typeof pricing.outputCostPerToken === "number"
-      );
-    })
+    .filter(([, metadata]) => hasUsableReferencePricing(metadata.pricing))
     .map(([id]) => id)
     .sort();
 }

--- a/langwatch/src/features/briefing/hooks/useLangyBriefing.ts
+++ b/langwatch/src/features/briefing/hooks/useLangyBriefing.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { SeriesInputType } from "~/server/analytics/registry";
+import { readSummaryMetric } from "~/server/analytics/timeseriesSummary";
 import type { TimeseriesBucket } from "~/server/analytics/types";
 // The single canonical encoder for `getTimeseries` bucket keys (ADR-034
 // app-layer module). Reused — not re-implemented — so this reader can never
@@ -78,45 +79,6 @@ export interface LangyBriefingResult {
 /** Backwards-compatible name for callers/tests of the briefing derivation. */
 export const buildBriefingReceipts = buildAttentionInbox;
 export type ReceiptSignals = AttentionInboxSignals;
-
-/**
- * Reads one series' value back out of a `getTimeseries` `currentPeriod`. The
- * lookup key is derived from the app-layer's canonical `buildSeriesName`
- * encoder (`{index}/{metric}/{aggregation}`, `index` = the series' position in
- * the request) rather than re-spelled here, so it cannot drift from how the
- * value was written. Returns `undefined` when that metric never appears in any
- * bucket, so a missing signal degrades to an omitted cell rather than a
- * fabricated 0. With `timeScale: "full"` there is a single bucket, so the sum
- * is a passthrough of that one value.
- */
-export function readSummaryMetric({
-  buckets,
-  series,
-  metric,
-  aggregation,
-}: {
-  buckets: TimeseriesBucket[] | undefined;
-  series: SeriesInputType[];
-  metric: string;
-  aggregation: string;
-}): number | undefined {
-  if (!buckets) return undefined;
-  const index = series.findIndex(
-    (s) => s.metric === metric && s.aggregation === aggregation,
-  );
-  if (index < 0) return undefined;
-  const key = buildSeriesName(series[index]!, index);
-  let sum = 0;
-  let seen = false;
-  for (const bucket of buckets) {
-    const raw = bucket[key];
-    if (typeof raw === "number") {
-      sum += raw;
-      seen = true;
-    }
-  }
-  return seen ? sum : undefined;
-}
 
 /**
  * Read a grouped metric from the same `getTimeseries` response. Counts are

--- a/langwatch/src/features/briefing/hooks/useLangyBriefing.unit.test.ts
+++ b/langwatch/src/features/briefing/hooks/useLangyBriefing.unit.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { SeriesInputType } from "~/server/analytics/registry";
+import { readSummaryMetric } from "~/server/analytics/timeseriesSummary";
 import { buildSeriesName } from "~/server/app-layer/analytics/repositories/_timeseries-row-parser";
 import type { TimeseriesBucket } from "~/server/analytics/types";
 import type { BriefingReceipt } from "../types";
 import {
   buildBriefingReceipts,
   readGroupedSummaryMetric,
-  readSummaryMetric,
   type ReceiptSignals,
 } from "./useLangyBriefing";
 

--- a/langwatch/src/pages/[project]/analytics/metrics.tsx
+++ b/langwatch/src/pages/[project]/analytics/metrics.tsx
@@ -4,6 +4,7 @@ import {
   type CustomGraphInput,
 } from "~/components/analytics/CustomGraph";
 import { ChartCard } from "~/components/analytics/ChartCard";
+import { ModelCostComparisonCard } from "~/components/analytics/ModelCostComparisonCard";
 import { FilterSidebar } from "~/components/filters/FilterSidebar";
 import GraphsLayout from "~/components/GraphsLayout";
 import { withPermissionGuard } from "../../../components/WithPermissionGuard";
@@ -263,6 +264,11 @@ function MetricsContent() {
           <ChartCard title="Average Completion Time" colSpan={2}>
             <CustomGraph input={completionTime} />
           </ChartCard>
+          {canViewCost && (
+            <ChartCard title="Cost Comparison" colSpan={4}>
+              <ModelCostComparisonCard />
+            </ChartCard>
+          )}
           {canViewCost && (
             <ChartCard title="Average Cost Per Message" colSpan={2}>
               <CustomGraph input={totalCostPerModel} />

--- a/langwatch/src/server/analytics/timeseriesSummary.ts
+++ b/langwatch/src/server/analytics/timeseriesSummary.ts
@@ -1,0 +1,45 @@
+// The single canonical encoder for `getTimeseries` bucket keys (ADR-034
+// app-layer module). Reused, not re-implemented, so every reader stays tied to
+// how the app-layer wrote the value. Pure helper; safe client-side.
+import { buildSeriesName } from "../app-layer/analytics/repositories/_timeseries-row-parser";
+import type { SeriesInputType } from "./registry";
+import type { TimeseriesBucket } from "./types";
+
+/**
+ * Reads one series' value back out of a `getTimeseries` `currentPeriod`. The
+ * lookup key is derived from `buildSeriesName` (`{index}/{metric}/{aggregation}`,
+ * `index` = the series' position in the request) rather than re-spelled at the
+ * call site, so it cannot drift and reordering the request's series cannot
+ * silently swap two numbers. Returns `undefined` when that metric never appears
+ * in any bucket, so a missing signal degrades to an omitted cell rather than a
+ * fabricated 0. With `timeScale: "full"` there is a single bucket, so the sum is
+ * a passthrough of that one value.
+ */
+export function readSummaryMetric({
+  buckets,
+  series,
+  metric,
+  aggregation,
+}: {
+  buckets: TimeseriesBucket[] | undefined;
+  series: SeriesInputType[];
+  metric: string;
+  aggregation: string;
+}): number | undefined {
+  if (!buckets) return undefined;
+  const index = series.findIndex(
+    (s) => s.metric === metric && s.aggregation === aggregation,
+  );
+  if (index < 0) return undefined;
+  const key = buildSeriesName(series[index]!, index);
+  let sum = 0;
+  let seen = false;
+  for (const bucket of buckets) {
+    const raw = bucket[key];
+    if (typeof raw === "number") {
+      sum += raw;
+      seen = true;
+    }
+  }
+  return seen ? sum : undefined;
+}

--- a/specs/analytics/model-cost-comparison.feature
+++ b/specs/analytics/model-cost-comparison.feature
@@ -41,3 +41,8 @@ Feature: Model cost comparison — estimated savings against a reference model
   Scenario: No traffic in the period
     Given the filtered period has zero tokens
     Then the card shows an empty state instead of a $0.00 comparison
+
+  Scenario: Actual cost for the period is genuinely zero
+    Given the period has traffic and the actual recorded cost is $0
+    Then the card shows $0.00 as the current cost
+    And it does not show "No data yet"

--- a/specs/analytics/model-cost-comparison.feature
+++ b/specs/analytics/model-cost-comparison.feature
@@ -1,0 +1,37 @@
+Feature: Model cost comparison — estimated savings against a reference model
+  Teams running self-hosted or cheap models want to show the value of that
+  choice: what would the same traffic have cost on a commercial model?
+  The analytics page lets the user pick a reference model and see the
+  actual spend next to the estimated spend on the reference model, using
+  the period's real token counts and the reference model's catalog
+  pricing. The difference is the estimated savings.
+
+  Background:
+    Given a project with traffic in the selected period
+    And the traffic carries input and output token counts
+
+  Scenario: Comparing local traffic against a commercial reference model
+    Given the period has 2,000,000 input tokens and 500,000 output tokens
+    And the actual recorded cost for the period is $0
+    When the user selects a reference model with catalog pricing
+    Then the card shows the estimated cost for the same tokens on the reference model
+    And the estimate is input_tokens x reference input price plus output_tokens x reference output price
+    And the card shows the estimated savings (estimate minus actual cost)
+
+  Scenario: Comparison respects the page filters
+    Given the user filtered the page by a label
+    When the savings card computes token totals
+    Then only traffic matching the filters is counted
+    And changing the date range recomputes the comparison
+
+  Scenario: Only models with catalog pricing are offered as reference
+    When the user opens the reference model selector
+    Then models without pricing in the catalog are not listed
+
+  Scenario: Traffic that already costs more than the reference shows negative savings
+    Given the actual recorded cost is higher than the reference estimate
+    Then the card presents the difference as additional cost, not savings
+
+  Scenario: No traffic in the period
+    Given the filtered period has zero tokens
+    Then the card shows an empty state instead of a $0.00 comparison

--- a/specs/analytics/model-cost-comparison.feature
+++ b/specs/analytics/model-cost-comparison.feature
@@ -28,6 +28,12 @@ Feature: Model cost comparison — estimated savings against a reference model
     When the user opens the reference model selector
     Then models without pricing in the catalog are not listed
 
+  Scenario: Custom and self-hosted models are never offered as reference
+    Given a custom or self-hosted model has been added to a provider
+    When the user opens the reference model selector
+    Then the custom model is not listed, even though it has placeholder pricing
+    And it cannot be selected to produce a fabricated savings estimate
+
   Scenario: Traffic that already costs more than the reference shows negative savings
     Given the actual recorded cost is higher than the reference estimate
     Then the card presents the difference as additional cost, not savings

--- a/specs/analytics/model-cost-comparison.feature
+++ b/specs/analytics/model-cost-comparison.feature
@@ -1,10 +1,15 @@
-Feature: Model cost comparison — estimated savings against a reference model
+Feature: Model cost comparison, estimated savings against a reference model
   Teams running self-hosted or cheap models want to show the value of that
   choice: what would the same traffic have cost on a commercial model?
   The analytics page lets the user pick a reference model and see the
   actual spend next to the estimated spend on the reference model, using
   the period's real token counts and the reference model's catalog
   pricing. The difference is the estimated savings.
+
+  A wrong cost figure is worse than no figure at all: it looks plausible,
+  it gets quoted to a finance team, and nothing on screen says it is
+  wrong. So the card prices exactly the token buckets the product bills,
+  and declines to show a number whenever it cannot stand behind one.
 
   Background:
     Given a project with traffic in the selected period
@@ -18,21 +23,44 @@ Feature: Model cost comparison — estimated savings against a reference model
     And the estimate is input_tokens x reference input price plus output_tokens x reference output price
     And the card shows the estimated savings (estimate minus actual cost)
 
+  Scenario: Cached prompts are priced at the reference model's cache rates
+    Given part of the period's prompts were served from the provider's cache
+    And the cached tokens are recorded separately from the fresh input tokens
+    When the card estimates the cost on the reference model
+    Then the cached tokens are priced at the reference model's cache rates
+    And they are not left out of the estimate
+
+  Scenario: A reference model that publishes no cache rate
+    Given the selected reference model publishes no cache rate
+    When the card estimates the cost on it
+    Then cached tokens are priced as fresh input, the same way the recorded cost is
+
+  Scenario: The card shows what the estimate was computed from
+    When the card shows an estimate
+    Then it states the input, output and cached token counts behind it
+    And the reader can check the figure against the period's usage
+
   Scenario: Comparison respects the page filters
     Given the user filtered the page by a label
     When the savings card computes token totals
     Then only traffic matching the filters is counted
     And changing the date range recomputes the comparison
 
-  Scenario: Only models with catalog pricing are offered as reference
+  Scenario: Only models with a published price are offered as reference
     When the user opens the reference model selector
-    Then models without pricing in the catalog are not listed
+    Then models the catalog publishes no price for are not listed
 
   Scenario: Custom and self-hosted models are never offered as reference
     Given a custom or self-hosted model has been added to a provider
     When the user opens the reference model selector
-    Then the custom model is not listed, even though it has placeholder pricing
+    Then the custom model is not listed
     And it cannot be selected to produce a fabricated savings estimate
+
+  Scenario: A reference model with no published price shows no estimate
+    Given the selected reference model has no published price
+    Then the card shows no estimated cost and no estimated savings
+    And it explains that the period cannot be repriced with that model
+    And it never presents the missing price as $0.00
 
   Scenario: Traffic that already costs more than the reference shows negative savings
     Given the actual recorded cost is higher than the reference estimate
@@ -42,7 +70,17 @@ Feature: Model cost comparison — estimated savings against a reference model
     Given the filtered period has zero tokens
     Then the card shows an empty state instead of a $0.00 comparison
 
+  Scenario: Usage has not loaded yet
+    Given the usage for the period has not come back
+    Then the card shows a loading state
+    And it does not claim the period is empty before it has an answer
+
+  Scenario: Usage could not be loaded
+    Given the usage query failed
+    Then the card says the usage could not be loaded
+    And it does not present the failure as a quiet period
+
   Scenario: Actual cost for the period is genuinely zero
     Given the period has traffic and the actual recorded cost is $0
-    Then the card shows $0.00 as the current cost
+    Then the card shows $0.00 as the actual cost
     And it does not show "No data yet"


### PR DESCRIPTION
Fixes #5994

## What

A "Cost Comparison" card on the LLM Metrics analytics page: pick a reference model and see the period's **actual cost**, the **estimated cost** of the same traffic on the reference model, and the **estimated savings**, the number teams running self-hosted or cheaper models need to demonstrate the value of that choice ("what would this month have cost on Claude Sonnet?").

## How

Intentionally thin, no backend changes:

- One `getTimeseries` summary query (`timeScale: "full"`) for the period's token and cost sums, spreading `useFilterParams()` so the card honors the existing filter sidebar and date range (sliceable by label, model, user).
- The estimate prices **every token bucket the product bills**: fresh input, output, cache read and cache write. LangWatch records cached input separately from fresh input (`specs/ai-gateway/cache-token-telemetry.feature`) and the recorded cost prices all four buckets (`estimateCost` in `src/server/tracer/collector/cost.ts`), so the estimate uses the same formula. Cache rates fall back to the plain input rate when the catalog publishes none, exactly as the recorded cost does, which keeps both sides of the comparison on the same convention.
- Reference pricing comes from the model catalog already exposed to the frontend. A model is only offered, and only priced, when the catalog publishes a usable price: both rates present and at least one above zero, matching the guard the recorded cost applies. An all-zero row is a stand-in for "no published price", which is what every custom and self-hosted model carries and what a handful of catalog rows carry too.
- UI reuses `ModelSelector`, `SummaryMetric` and `ChartCard`. Negative differences render as additional cost, zero-traffic periods get an empty state, a model that cannot be priced gets a dash and a plain explanation, and the card is `cost:view` gated like the other cost cards.
- Series values are read back by metric name through the shared `readSummaryMetric`, so reordering the request cannot silently swap two numbers.

## Verification

Dogfooded against real local traffic (234 traces, 30 day window), with the displayed figures recomputed independently from the underlying ClickHouse rows:

| | ClickHouse | Card |
|---|---|---|
| fresh input tokens | 5,353,935 | 5.4m |
| output tokens | 52,262 | 52.3k |
| cache read + write tokens | 3,100,637 | 3.1m |
| recorded cost | $13.804739 | $13.80 |
| estimate on `claude-sonnet-4-6` | $18.734854 | $18.73 |
| savings | $4.930115 | $4.93 |

Sliced to a single model (`?model=claude-fable-5`), where the reference is cheaper than actual: recorded $4.857727, estimate $1.498636, savings -$3.359091, all matching the card's $4.86 / $1.50 / -$3.36.

## Screenshots

Populated card

![populated](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5996/card/populated.png)

In page context

![metrics page](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5996/card/metrics-page.png)

Sliced by model, reference cheaper than actual

![single model](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5996/card/single-model-filter.png)

No traffic in the period

![empty](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5996/states/empty.png)

Usage still loading

![loading](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5996/states/loading.png)

Reference model with no published price

![no published price](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-5996/states/no-published-price.png)

## Tests

- Unit tests on the calc module: per bucket pricing against real catalog rates, cache rate fallback, incomplete and all-zero pricing rejected from both the estimate and the selector, zero-token periods, option sorting.
- React Testing Library tests that render the real card against realistic `getTimeseries` responses and assert the dollar figure on screen, plus the cached, zero-cost, no-price, loading, empty and error states. Bucket keys are built from the series the card actually requests, so the test follows a reordering instead of pinning it.
- Spec scenarios in `specs/analytics/model-cost-comparison.feature`.