### PR TITLE
fix(topic-clustering): let the boot topic-model seed actually run (no raw SQL)

### DIFF
--- a/langwatch/src/server/app-layer/topic-clustering/__tests__/bootSeeds.unit.test.ts
+++ b/langwatch/src/server/app-layer/topic-clustering/__tests__/bootSeeds.unit.test.ts
@@ -7,6 +7,11 @@ import { startTopicClusteringBootSeeds } from "../bootSeeds";
  * both seeds in the background and never lets a failure escape to the boot
  * path. The seed walks themselves are tested in seedTopicModel /
  * seedClusteringSchedules unit tests; here only the composition is real.
+ *
+ * Both seeds page the GLOBAL `Project` model (the tenancy guard exempts it),
+ * so they are told apart by their where-clause: the topic-model seed keeps
+ * projects that own Topic rows (`topics: { some }`), the schedule seed keeps
+ * projects past their first message (`firstMessage: true`).
  */
 
 const emptyPrisma = () =>
@@ -22,6 +27,9 @@ const commands = () => ({
   requestClustering: vi.fn().mockResolvedValue(undefined),
 });
 
+const pageWheres = (findMany: { mock: { calls: any[][] } }) =>
+  findMany.mock.calls.map((call) => call[0]?.where);
+
 describe("startTopicClusteringBootSeeds", () => {
   describe("when a worker boots", () => {
     it("fires both seed walks in the background", async () => {
@@ -34,10 +42,11 @@ describe("startTopicClusteringBootSeeds", () => {
       });
 
       await vi.waitFor(() => {
-        // Topic-model seed pages distinct projectIds off the Topic table…
-        expect(prisma.topic.findMany).toHaveBeenCalled();
+        const wheres = pageWheres(prisma.project.findMany);
+        // Topic-model seed pages the projects that own Topic rows…
+        expect(wheres.some((where) => where?.topics)).toBe(true);
         // …and the schedule seed pages eligible projects.
-        expect(prisma.project.findMany).toHaveBeenCalled();
+        expect(wheres.some((where) => where?.firstMessage === true)).toBe(true);
       });
     });
   });
@@ -63,9 +72,9 @@ describe("startTopicClusteringBootSeeds", () => {
         }),
       ).not.toThrow();
 
-      // Both rejections must have been consumed (no unhandled rejection).
+      // Both seeds' page walk rejects; both rejections must be consumed
+      // (no unhandled rejection escapes to the boot path).
       await vi.waitFor(() => {
-        expect(prisma.topic.findMany).toHaveBeenCalled();
         expect(prisma.project.findMany).toHaveBeenCalled();
       });
       await new Promise((resolve) => setImmediate(resolve));

--- a/langwatch/src/server/app-layer/topic-clustering/__tests__/seedTopicModel.unit.test.ts
+++ b/langwatch/src/server/app-layer/topic-clustering/__tests__/seedTopicModel.unit.test.ts
@@ -45,6 +45,26 @@ const topicRow = (id: string, projectId: string) => ({
 });
 
 /**
+ * The projection-ownership reads, shared by both stubs below: the per-project
+ * `findUnique` the seed uses to decide "already owned?" and the per-page
+ * `findMany` batch that front-runs it. Both still run the real guard.
+ */
+const topicModelProjectionMock = (ownedProjectIds: Set<string>) => ({
+  findUnique: async (args: { where: { projectId: string } }) => {
+    await guard(modelParams("TopicModelProjection", "findUnique", args));
+    return ownedProjectIds.has(args.where.projectId)
+      ? { id: `cursor-${args.where.projectId}` }
+      : null;
+  },
+  findMany: async (args: { where: { projectId: { in: string[] } } }) => {
+    await guard(modelParams("TopicModelProjection", "findMany", args));
+    return args.where.projectId.in
+      .filter((projectId) => ownedProjectIds.has(projectId))
+      .map((projectId) => ({ projectId }));
+  },
+});
+
+/**
  * A Prisma stub that enforces the real tenancy guard on every call and
  * serves `topicPages` to the fleet-wide Project walk in order.
  */
@@ -77,20 +97,7 @@ const guardedPrismaStub = ({
         return topicsByProject[args.where.projectId] ?? [];
       },
     },
-    topicModelProjection: {
-      findUnique: async (args: { where: { projectId: string } }) => {
-        await guard(modelParams("TopicModelProjection", "findUnique", args));
-        return ownedProjectIds.has(args.where.projectId)
-          ? { id: `cursor-${args.where.projectId}` }
-          : null;
-      },
-      findMany: async (args: { where: { projectId: { in: string[] } } }) => {
-        await guard(modelParams("TopicModelProjection", "findMany", args));
-        return args.where.projectId.in
-          .filter((projectId) => ownedProjectIds.has(projectId))
-          .map((projectId) => ({ projectId }));
-      },
-    },
+    topicModelProjection: topicModelProjectionMock(ownedProjectIds),
   } as unknown as PrismaClient;
 
   return { prisma, pageArgs };
@@ -140,20 +147,7 @@ const fakeDbStub = ({
         return topicsByProject.get(args.where.projectId) ?? [];
       },
     },
-    topicModelProjection: {
-      findUnique: async (args: { where: { projectId: string } }) => {
-        await guard(modelParams("TopicModelProjection", "findUnique", args));
-        return ownedProjectIds.has(args.where.projectId)
-          ? { id: `cursor-${args.where.projectId}` }
-          : null;
-      },
-      findMany: async (args: { where: { projectId: { in: string[] } } }) => {
-        await guard(modelParams("TopicModelProjection", "findMany", args));
-        return args.where.projectId.in
-          .filter((projectId) => ownedProjectIds.has(projectId))
-          .map((projectId) => ({ projectId }));
-      },
-    },
+    topicModelProjection: topicModelProjectionMock(ownedProjectIds),
   } as unknown as PrismaClient;
 
   return { prisma };

--- a/langwatch/src/server/app-layer/topic-clustering/__tests__/seedTopicModel.unit.test.ts
+++ b/langwatch/src/server/app-layer/topic-clustering/__tests__/seedTopicModel.unit.test.ts
@@ -96,6 +96,69 @@ const guardedPrismaStub = ({
   return { prisma, pageArgs };
 };
 
+/**
+ * A faithful in-memory Postgres for Project/Topic: `project.findMany`
+ * implements the exact contract the seed relies on — the `topics: { some }`
+ * EXISTS filter, keyset pagination by `id`, ascending order, and `take`. Ids
+ * are compared lexically, as Postgres compares the nanoid PK. This lets a test
+ * drive the seed over the real PAGE_SIZE walk and assert it enumerates every
+ * project that owns topics, exactly once: a botched cursor (a skipped or
+ * double-counted boundary row) fails it. Every call still runs the real guard.
+ */
+const fakeDbStub = ({
+  projectsWithTopics,
+  projectsWithoutTopics = [],
+  ownedProjectIds = new Set<string>(),
+}: {
+  projectsWithTopics: string[];
+  projectsWithoutTopics?: string[];
+  ownedProjectIds?: Set<string>;
+}) => {
+  const topicsByProject = new Map<string, ReturnType<typeof topicRow>[]>(
+    projectsWithTopics.map((id) => [id, [topicRow(`t-${id}`, id)]]),
+  );
+  const allIds = [...projectsWithTopics, ...projectsWithoutTopics];
+
+  const prisma = {
+    project: {
+      findMany: async (args: any) => {
+        await guard(modelParams("Project", "findMany", args));
+        const gt: string | undefined = args?.where?.id?.gt;
+        const requireTopics = Boolean(args?.where?.topics);
+        const matched = allIds
+          .filter((id) => (requireTopics ? topicsByProject.has(id) : true))
+          .filter((id) => gt === undefined || id > gt)
+          .sort();
+        return matched
+          .slice(0, args?.take ?? matched.length)
+          .map((id) => ({ id }));
+      },
+    },
+    topic: {
+      findMany: async (args: { where: { projectId: string } }) => {
+        await guard(modelParams("Topic", "findMany", args));
+        return topicsByProject.get(args.where.projectId) ?? [];
+      },
+    },
+    topicModelProjection: {
+      findUnique: async (args: { where: { projectId: string } }) => {
+        await guard(modelParams("TopicModelProjection", "findUnique", args));
+        return ownedProjectIds.has(args.where.projectId)
+          ? { id: `cursor-${args.where.projectId}` }
+          : null;
+      },
+      findMany: async (args: { where: { projectId: { in: string[] } } }) => {
+        await guard(modelParams("TopicModelProjection", "findMany", args));
+        return args.where.projectId.in
+          .filter((projectId) => ownedProjectIds.has(projectId))
+          .map((projectId) => ({ projectId }));
+      },
+    },
+  } as unknown as PrismaClient;
+
+  return { prisma };
+};
+
 describe("seedTopicModelHistory", () => {
   describe("given projects still hold pre-ownership Topic rows", () => {
     describe("when the boot seed pass runs", () => {
@@ -184,6 +247,46 @@ describe("seedTopicModelHistory", () => {
         expect(pageArgs).toHaveLength(3);
         // The second page cursors past the last id of the first.
         expect(pageArgs[1]?.where?.id).toEqual({ gt: "p1" });
+      });
+    });
+  });
+
+  describe("given a fleet larger than one page", () => {
+    describe("when the boot seed pass walks it end to end", () => {
+      it("records every project that owns topics, exactly once, and skips the rest", async () => {
+        // 450 topic-owning projects + 50 topic-less, ids zero-padded so their
+        // lexical order is the keyset order the seed pages by. 450 > PAGE_SIZE
+        // (200), so the walk must cross page boundaries and still terminate —
+        // exactly where a botched cursor would skip or double-count a project.
+        const withTopics: string[] = [];
+        const withoutTopics: string[] = [];
+        for (let i = 0; i < 500; i++) {
+          const id = `p${String(i).padStart(4, "0")}`;
+          (i % 10 === 0 ? withoutTopics : withTopics).push(id);
+        }
+
+        const recorded: string[] = [];
+        const recordTopics = vi.fn(async (cmd: { tenantId: string }) => {
+          recorded.push(cmd.tenantId);
+        });
+        const { prisma } = fakeDbStub({
+          projectsWithTopics: withTopics,
+          projectsWithoutTopics: withoutTopics,
+        });
+
+        const summary = await seedTopicModelHistory({
+          prisma,
+          redis: null,
+          recordTopics,
+        });
+
+        // Nothing skipped: exactly the topic-owning projects, all of them.
+        expect([...recorded].sort()).toEqual([...withTopics].sort());
+        // No duplicates — a cursor that re-served a boundary row trips this.
+        expect(new Set(recorded).size).toBe(recorded.length);
+        // No topic-less project leaked in.
+        expect(recorded.filter((id) => withoutTopics.includes(id))).toEqual([]);
+        expect(summary).toEqual({ seeded: withTopics.length, skipped: 0 });
       });
     });
   });

--- a/langwatch/src/server/app-layer/topic-clustering/__tests__/seedTopicModel.unit.test.ts
+++ b/langwatch/src/server/app-layer/topic-clustering/__tests__/seedTopicModel.unit.test.ts
@@ -1,0 +1,250 @@
+import { type PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { guardProjectId } from "~/utils/dbMultiTenancyProtection";
+import { seedTopicModelHistory } from "../seedTopicModel";
+
+/**
+ * Unit tests for the ADR-051 one-time topic-model seed.
+ *
+ * The Prisma stub here routes EVERY call through the real `guardProjectId`
+ * middleware rather than answering blindly. That is the point: the seed
+ * shipped in #5930 paged over the project-scoped `Topic` model with no
+ * projectId predicate on its first page, so the guard threw on every worker
+ * boot and no project was ever seeded ("Topic model seed pass failed; the
+ * next boot retries", forever). A stub that skips the guard cannot observe
+ * that failure, so these tests run it for real.
+ *
+ * The fix enumerates the fleet by paging the GLOBAL `Project` model — which
+ * the guard exempts — filtered to the projects that own Topic rows. No raw
+ * SQL and no tenancy opt-out: the whole seed stays on the guarded model API.
+ */
+
+/** The middleware params Prisma hands the guard for a model-API call. */
+const modelParams = (model: string, action: string, args: unknown) => ({
+  model,
+  action,
+  args,
+  dataPath: [],
+  runInTransaction: false,
+});
+
+const guard = (params: unknown) =>
+  guardProjectId(params as never, async () => undefined);
+
+const topicRow = (id: string, projectId: string) => ({
+  id,
+  projectId,
+  name: `topic-${id}`,
+  parentId: null,
+  embeddings_model: "openai/text-embedding-3-small",
+  centroid: [0.1, 0.2],
+  p95Distance: 0.5,
+  automaticallyGenerated: true,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+});
+
+/**
+ * A Prisma stub that enforces the real tenancy guard on every call and
+ * serves `topicPages` to the fleet-wide Project walk in order.
+ */
+const guardedPrismaStub = ({
+  topicPages,
+  topicsByProject,
+  ownedProjectIds = new Set<string>(),
+}: {
+  topicPages: string[][];
+  topicsByProject: Record<string, ReturnType<typeof topicRow>[]>;
+  ownedProjectIds?: Set<string>;
+}) => {
+  const pageArgs: Array<{ where?: any }> = [];
+  let pageIndex = 0;
+
+  const prisma = {
+    project: {
+      findMany: async (args: { where?: any }) => {
+        pageArgs.push(args);
+        await guard(modelParams("Project", "findMany", args));
+        const page = topicPages[pageIndex] ?? [];
+        pageIndex++;
+        // `select: { id: true }` shape — the seed maps these to projectIds.
+        return page.map((id) => ({ id }));
+      },
+    },
+    topic: {
+      findMany: async (args: { where: { projectId: string } }) => {
+        await guard(modelParams("Topic", "findMany", args));
+        return topicsByProject[args.where.projectId] ?? [];
+      },
+    },
+    topicModelProjection: {
+      findUnique: async (args: { where: { projectId: string } }) => {
+        await guard(modelParams("TopicModelProjection", "findUnique", args));
+        return ownedProjectIds.has(args.where.projectId)
+          ? { id: `cursor-${args.where.projectId}` }
+          : null;
+      },
+      findMany: async (args: { where: { projectId: { in: string[] } } }) => {
+        await guard(modelParams("TopicModelProjection", "findMany", args));
+        return args.where.projectId.in
+          .filter((projectId) => ownedProjectIds.has(projectId))
+          .map((projectId) => ({ projectId }));
+      },
+    },
+  } as unknown as PrismaClient;
+
+  return { prisma, pageArgs };
+};
+
+describe("seedTopicModelHistory", () => {
+  describe("given projects still hold pre-ownership Topic rows", () => {
+    describe("when the boot seed pass runs", () => {
+      it("walks the fleet without tripping the multitenancy guard", async () => {
+        const recordTopics = vi.fn().mockResolvedValue(undefined);
+        const { prisma } = guardedPrismaStub({
+          topicPages: [["p1", "p2"], []],
+          topicsByProject: {
+            p1: [topicRow("t1", "p1")],
+            p2: [topicRow("t2", "p2")],
+          },
+        });
+
+        const summary = await seedTopicModelHistory({
+          prisma,
+          redis: null,
+          recordTopics,
+        });
+
+        expect(summary).toEqual({ seeded: 2, skipped: 0 });
+        expect(recordTopics).toHaveBeenCalledTimes(2);
+      });
+
+      it("records each project's topics against its own tenant", async () => {
+        const recordTopics = vi.fn().mockResolvedValue(undefined);
+        const { prisma } = guardedPrismaStub({
+          topicPages: [["p1"], []],
+          topicsByProject: { p1: [topicRow("t1", "p1")] },
+        });
+
+        await seedTopicModelHistory({ prisma, redis: null, recordTopics });
+
+        expect(recordTopics).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId: "p1",
+            mode: "replace",
+            source: "seed",
+            dedupeKey: "seed:v1",
+          }),
+        );
+      });
+
+      it("pages the global Project model, keeping only projects that own topics", async () => {
+        const { prisma, pageArgs } = guardedPrismaStub({
+          topicPages: [[]],
+          topicsByProject: {},
+        });
+
+        await seedTopicModelHistory({
+          prisma,
+          redis: null,
+          recordTopics: vi.fn().mockResolvedValue(undefined),
+        });
+
+        // A `topics: { some }` EXISTS filter selects the fleet — the same set
+        // as a distinct-projectId scan of Topic, but off the global model…
+        expect(pageArgs[0]?.where).toEqual(
+          expect.objectContaining({ topics: { some: {} } }),
+        );
+        // …and it carries no projectId of its own: Project is global, so the
+        // guard never asks for one (that is the whole reason this walk works).
+        expect(pageArgs[0]?.where?.projectId).toBeUndefined();
+      });
+    });
+  });
+
+  describe("given the fleet spans more than one page", () => {
+    describe("when the walk advances", () => {
+      it("pages on a projectId cursor the guard accepts", async () => {
+        const recordTopics = vi.fn().mockResolvedValue(undefined);
+        const { prisma, pageArgs } = guardedPrismaStub({
+          topicPages: [["p1"], ["p2"], []],
+          topicsByProject: {
+            p1: [topicRow("t1", "p1")],
+            p2: [topicRow("t2", "p2")],
+          },
+        });
+
+        const summary = await seedTopicModelHistory({
+          prisma,
+          redis: null,
+          recordTopics,
+        });
+
+        expect(summary.seeded).toBe(2);
+        expect(pageArgs).toHaveLength(3);
+        // The second page cursors past the last id of the first.
+        expect(pageArgs[1]?.where?.id).toEqual({ gt: "p1" });
+      });
+    });
+  });
+
+  describe("given the projection already owns a project's model", () => {
+    describe("when the pass reaches it", () => {
+      it("skips that project instead of re-seeding it", async () => {
+        const recordTopics = vi.fn().mockResolvedValue(undefined);
+        const { prisma } = guardedPrismaStub({
+          topicPages: [["p1", "p2"], []],
+          topicsByProject: {
+            p1: [topicRow("t1", "p1")],
+            p2: [topicRow("t2", "p2")],
+          },
+          ownedProjectIds: new Set(["p1"]),
+        });
+
+        const summary = await seedTopicModelHistory({
+          prisma,
+          redis: null,
+          recordTopics,
+        });
+
+        expect(summary).toEqual({ seeded: 1, skipped: 1 });
+        expect(recordTopics).toHaveBeenCalledTimes(1);
+        expect(recordTopics).toHaveBeenCalledWith(
+          expect.objectContaining({ tenantId: "p2" }),
+        );
+      });
+    });
+  });
+
+  describe("given the tenancy guard validates the page query", () => {
+    describe("when it is the unscoped Topic walk the seed used to issue", () => {
+      it("rejects it, which is why the seed failed on every boot", async () => {
+        await expect(
+          guard(
+            modelParams("Topic", "findMany", {
+              distinct: ["projectId"],
+              select: { projectId: true },
+              orderBy: { projectId: "asc" },
+              take: 200,
+            }),
+          ),
+        ).rejects.toThrow(/requires a 'projectId' or 'projectId.in'/);
+      });
+    });
+
+    describe("when it is the global Project page the seed now issues", () => {
+      it("accepts it, because Project is a guard-exempt global model", async () => {
+        await expect(
+          guard(
+            modelParams("Project", "findMany", {
+              where: { topics: { some: {} } },
+              select: { id: true },
+              orderBy: { id: "asc" },
+              take: 200,
+            }),
+          ),
+        ).resolves.toBeUndefined();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/topic-clustering/seedTopicModel.ts
+++ b/langwatch/src/server/app-layer/topic-clustering/seedTopicModel.ts
@@ -113,14 +113,28 @@ async function runSeedPass(
   let cursor: string | null = null;
 
   for (;;) {
-    const page: Array<{ projectId: string }> =
-      await deps.prisma.topic.findMany({
-        distinct: ["projectId"],
-        select: { projectId: true },
-        orderBy: { projectId: "asc" },
+    // Fleet-wide walk over the projects that still hold pre-ownership Topic
+    // rows. A distinct-projectId scan straight off `Topic` trips the tenancy
+    // guard: `Topic` is project-scoped and the first page carries no projectId
+    // predicate. Instead we page the GLOBAL `Project` model — which the guard
+    // exempts (it IS the tenant, addressed by its own id), exactly as the
+    // sibling schedule seed's `findEligibleProjectsPage` does — and keep only
+    // the projects that own Topic rows via a `topics: { some }` EXISTS filter.
+    // Topic.projectId is a FK, so that is the same set as a distinct-projectId
+    // scan of `Topic`. Each project's rows are still READ back through the
+    // guarded model API in seedProjectTopicModel, which carries its projectId —
+    // only this fleet-wide enumeration is cross-tenant.
+    const page: Array<{ projectId: string }> = (
+      await deps.prisma.project.findMany({
+        where: {
+          topics: { some: {} },
+          ...(cursor ? { id: { gt: cursor } } : {}),
+        },
+        select: { id: true },
+        orderBy: { id: "asc" },
         take: PAGE_SIZE,
-        ...(cursor ? { where: { projectId: { gt: cursor } } } : {}),
-      });
+      })
+    ).map((project) => ({ projectId: project.id }));
     if (page.length === 0) break;
     cursor = page[page.length - 1]!.projectId;
 

--- a/specs/topic-clustering/topics-source-of-truth.feature
+++ b/specs/topic-clustering/topics-source-of-truth.feature
@@ -39,6 +39,12 @@ Feature: Topic clustering owns the topic model
     And their ids, names, and hierarchy are preserved exactly
     And re-running the seed changes nothing
 
+  Scenario: Seeding reaches every project that predates ownership
+    Given many projects whose topics predate event-sourced ownership
+    When the worker service starts
+    Then every one of those projects is seeded, not just the first page
+    And a project the projection already owns is left untouched
+
   Scenario: A late duplicate seed can never remove recorded topics
     Given a project whose topics were seeded and then extended by clustering
     When a duplicate seed carrying only the original topics arrives late


### PR DESCRIPTION
Raw-SQL-free alternative to #5979 — same bug, same behaviour, but the whole seed stays on the guarded Prisma model API. Adopt this and close #5979, or cherry-pick the one-file swap onto that branch.

## The bug (identical to #5979)

The topic-model seed shipped in #5930 pages distinct projectIds straight off the project-scoped `Topic` model:

```ts
await deps.prisma.topic.findMany({
  distinct: ["projectId"],
  select: { projectId: true },
  orderBy: { projectId: "asc" },
  take: PAGE_SIZE,
  ...(cursor ? { where: { projectId: { gt: cursor } } } : {}),   // only set AFTER page 1
});
```

`Topic` is project-scoped, so the multitenancy guard requires a projectId predicate. The **first** page carries no `where` at all and throws, so the loop dies before it reaches any project. `bootSeeds` catches it into "the next boot retries", and every subsequent boot fails identically — a permanent stall dressed as transient recovery.

**Impact:** no legacy project's topics were ever recorded onto the event stream; the ADR-051 source-of-truth migration never ran for anyone. The `seed:v1` done-marker is never written either, so it's stuck rather than half-applied and picks up cleanly on next boot.

## The fix — page the global `Project` model, no raw SQL

#5979 reaches for a raw cross-tenant `$queryRaw` carrying the `-- @tenancy:` opt-out. We don't need to leave the model API to do this.

`Project` is a **`GLOBAL_MODEL`** in the tenancy guard (it *is* the tenant, addressed by its own id), so a fleet-wide page over it carries no projectId predicate by design. The **sibling schedule seed in the same file** (`prismaScheduleSeedPorts.findEligibleProjectsPage`) already does exactly this. So instead of a raw distinct-scan of `Topic`, page `Project` and keep only the projects that own Topic rows via a `topics: { some }` EXISTS filter:

```ts
const page = (
  await deps.prisma.project.findMany({
    where: {
      topics: { some: {} },
      ...(cursor ? { id: { gt: cursor } } : {}),
    },
    select: { id: true },
    orderBy: { id: "asc" },
    take: PAGE_SIZE,
  })
).map((project) => ({ projectId: project.id }));
```

`Topic.projectId` is a FK, so `topics: { some: {} }` returns exactly the same set as `SELECT DISTINCT "projectId" FROM "Topic"` — the guard's `EXISTS` subquery uses the existing `@@index([projectId])` on `Topic`. The guard only ever inspects the top-level `params.model` (`Project` → exempt); it never recurses into the nested relation filter. Paging, cursor, idempotency, and the per-project read (still through the guarded model API in `seedProjectTopicModel`, carrying its projectId) are all unchanged. The two boot seeds are now **symmetric** instead of one-model-API / one-raw.

## Why it shipped, and the tests

`seedTopicModel.ts` had no test, and `bootSeeds.unit.test.ts` asserted only that the walk was *called*, never that it succeeded.

`seedTopicModel.unit.test.ts` (new) routes its Prisma stub through the **real `guardProjectId` middleware** rather than answering blindly, so it executes the failing path instead of asserting on query strings. It:

- walks the fleet green through the real guard (would throw if reverted to the `Topic` distinct-scan),
- pins the page query to the global `Project` model with the `topics: { some }` filter and no projectId,
- proves the **old** unscoped `Topic` walk is *rejected* by the guard and the **new** `Project` page is *accepted*,
- covers cursor pagination, per-tenant recording, and skip-when-already-owned.

`bootSeeds.unit.test.ts` now tells the two seeds apart by their where-clause (`topics` vs `firstMessage`) since both page `Project`.

## Testing

- `pnpm test:unit src/server/app-layer/topic-clustering/` — 12 files, 87 passed (2 pre-existing skips)
- `dbMultiTenancyProtection` — 46 passed

## Trade-off vs #5979

The `Project` walk visits projects in `id` order and the `EXISTS` filter drops those without topics, so on a fleet with many topic-less projects it scans more `Project` rows than a raw distinct-scan of `Topic` would. This is a one-time boot migration gated by the `seed:v1` done-marker (one Redis GET on every boot thereafter), so the cost is bounded and paid at most until the first full pass completes. Correctness and staying on the guarded API win here.

## Does the new enumeration skip anything? No.

The completeness guarantee rests on two independent pillars:

1. **Set equality.** `topics: { some: {} }` returns exactly the projects with at least one `Topic`. `Topic.projectId` is a **FK to `Project.id`**, so no Topic can reference a missing Project — the set is identical to `SELECT DISTINCT "projectId" FROM "Topic"`. This is a schema invariant, and it's the *only* thing the refactor changed vs #5979.
2. **Pagination exhaustiveness.** Keyset pagination (`orderBy id asc`, `where id > cursor`, `take`) over the unique PK visits every match exactly once — the same keyset structure #5979 used, over the same value space.

`seedTopicModel.unit.test.ts` locks pillar 2 by driving the seed over a faithful in-memory Postgres (real `topics: { some }` filter + keyset paging) across a **450-owning + 50-topic-less fleet, larger than `PAGE_SIZE` (200)** — so the walk crosses real page boundaries — and asserts every topic-owning project is recorded **exactly once** and the topic-less ones are excluded. A skipped or double-counted boundary row fails it. (Concurrent-insert behaviour is identical to #5979: a project gaining its *first* topic mid-walk is the write path's job, which also seeds it and writes the projection cursor.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topic-model seeding to ensure every eligible project is processed, including when project lists span multiple pages.
  * Preserved tenant isolation during the seeding pass.
  * Avoided re-seeding projects that already have a topic-model projection.

* **Tests**
  * Tightened unit coverage for startup seeding page composition and failure-path handling.
  * Added a new unit test suite covering multi-tenant guard behavior and multi-page pagination.
  * Extended the topic-clustering acceptance spec to confirm complete startup seeding across all projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->