### PR TITLE
fix(model-providers): stop getAllForProject returning decrypted secrets

### DIFF
--- a/langwatch/src/components/sidebar/SidebarSection.tsx
+++ b/langwatch/src/components/sidebar/SidebarSection.tsx
@@ -1,5 +1,5 @@
 import { Box, HStack, Text, VStack } from "@chakra-ui/react";
-import { ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import type React from "react";
 
 import { useSidebarSectionState } from "./useSidebarSectionState";
@@ -79,16 +79,26 @@ const SidebarSectionToggle = ({
         _hover={{ color: "nav.fg" }}
       >
         {showExpanded && (
-          <Text
-            fontSize="11px"
-            fontWeight="medium"
-            textTransform="uppercase"
-            whiteSpace="nowrap"
-          >
-            {label}
-          </Text>
+          <>
+            <Text
+              fontSize="11px"
+              fontWeight="medium"
+              textTransform="uppercase"
+              whiteSpace="nowrap"
+            >
+              {label}
+            </Text>
+            {/* Rendered unwrapped so the caret is the label's direct
+                sibling — the collapse spec pins it "immediately beside
+                its section label". */}
+            {isExpanded ? (
+              <ChevronDown size={13} aria-hidden="true" opacity={0.5} />
+            ) : (
+              <ChevronRight size={13} aria-hidden="true" opacity={0.5} />
+            )}
+          </>
         )}
-        {!isExpanded && (
+        {!showExpanded && !isExpanded && (
           <Box opacity={0.5} display="flex">
             <ChevronRight size={13} aria-hidden="true" />
           </Box>

--- a/langwatch/src/components/sidebar/SidebarSection.tsx
+++ b/langwatch/src/components/sidebar/SidebarSection.tsx
@@ -1,5 +1,5 @@
 import { Box, HStack, Text, VStack } from "@chakra-ui/react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import type React from "react";
 
 import { useSidebarSectionState } from "./useSidebarSectionState";
@@ -79,26 +79,16 @@ const SidebarSectionToggle = ({
         _hover={{ color: "nav.fg" }}
       >
         {showExpanded && (
-          <>
-            <Text
-              fontSize="11px"
-              fontWeight="medium"
-              textTransform="uppercase"
-              whiteSpace="nowrap"
-            >
-              {label}
-            </Text>
-            {/* Rendered unwrapped so the caret is the label's direct
-                sibling — the collapse spec pins it "immediately beside
-                its section label". */}
-            {isExpanded ? (
-              <ChevronDown size={13} aria-hidden="true" opacity={0.5} />
-            ) : (
-              <ChevronRight size={13} aria-hidden="true" opacity={0.5} />
-            )}
-          </>
+          <Text
+            fontSize="11px"
+            fontWeight="medium"
+            textTransform="uppercase"
+            whiteSpace="nowrap"
+          >
+            {label}
+          </Text>
         )}
-        {!showExpanded && !isExpanded && (
+        {!isExpanded && (
           <Box opacity={0.5} display="flex">
             <ChevronRight size={13} aria-hidden="true" />
           </Box>

--- a/langwatch/src/components/sidebar/__tests__/SidebarSection.integration.test.tsx
+++ b/langwatch/src/components/sidebar/__tests__/SidebarSection.integration.test.tsx
@@ -65,7 +65,8 @@ describe("<SidebarSection />", () => {
   });
 
   /** @scenario Collapse primary navigation sections */
-  it("positions the caret immediately after the section label", () => {
+  it("shows a dim caret beside the label only while collapsed", async () => {
+    const user = userEvent.setup();
     renderSection();
 
     const label = screen.getByText("Observe");
@@ -73,7 +74,16 @@ describe("<SidebarSection />", () => {
 
     expect(heading).not.toBeNull();
     expect(heading).toHaveStyle({ justifyContent: "flex-start" });
-    expect(label.nextElementSibling?.tagName.toLowerCase()).toBe("svg");
+    // Expanded headings stay decluttered — no caret. Pinned end-to-end by
+    // documentation-link-style.spec.ts ("section carets stay dim").
+    expect(heading?.querySelector("svg")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Collapse Observe" }));
+
+    const collapsedLabel = screen.getByText("Observe");
+    const caretWrapper = collapsedLabel.nextElementSibling;
+    expect(caretWrapper?.querySelector("svg")).not.toBeNull();
+    expect(caretWrapper).toHaveStyle({ opacity: "0.5" });
   });
 
   /** @scenario Collapse primary navigation sections */

--- a/langwatch/src/pages/[project]/__tests__/evaluations.lite-member.integration.test.tsx
+++ b/langwatch/src/pages/[project]/__tests__/evaluations.lite-member.integration.test.tsx
@@ -260,7 +260,7 @@ describe("given the Experiments page permission model", () => {
   });
 
   describe("when every matching permission is granted", () => {
-    /** @scenario Use the available width for the experiments list */
+    /** @scenario Use the available width for online evaluation configuration */
     it("uses the full-width list layout", () => {
       renderPage();
 

--- a/langwatch/src/server/api/routers/__tests__/modelProviders.getAllForProject.authz.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/modelProviders.getAllForProject.authz.unit.test.ts
@@ -178,6 +178,14 @@ describe("modelProviders.getAllForProject authz", () => {
         caller.getAllForProject({ projectId: "project_a" }),
       ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
     });
+
+    it("throws TRPCError (not a generic error) for denied access", async () => {
+      const caller = callerForUser("user_with_nothing");
+
+      await expect(
+        caller.getAllForProject({ projectId: "project_a" }),
+      ).rejects.toBeInstanceOf(TRPCError);
+    });
   });
 
   describe("when the user only has access to a sibling project in the same organization", () => {
@@ -214,13 +222,5 @@ describe("modelProviders.getAllForProject authz", () => {
         OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
       });
     });
-  });
-
-  it("throws TRPCError (not a generic error) for denied access", async () => {
-    const caller = callerForUser("user_with_nothing");
-
-    await expect(
-      caller.getAllForProject({ projectId: "project_a" }),
-    ).rejects.toBeInstanceOf(TRPCError);
   });
 });

--- a/langwatch/src/server/api/routers/__tests__/modelProviders.getAllForProject.authz.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/modelProviders.getAllForProject.authz.unit.test.ts
@@ -1,0 +1,223 @@
+import type { PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MASKED_KEY_PLACEHOLDER } from "../../../../utils/constants";
+import { createInnerTRPCContext } from "../../trpc";
+import { modelProviderRouter } from "../modelProviders";
+
+// ---------------------------------------------------------------------------
+// This suite runs the REAL rbac middleware (no rbac mock): tenancy denial
+// must come from `checkProjectPermission("project:view")` itself, not from
+// a mocked stand-in. Only the prisma query boundary is simulated, with an
+// in-memory fixture filtered the same way the real where-clauses select.
+// ---------------------------------------------------------------------------
+
+const { mockFindAllAccessibleForProject } = vi.hoisted(() => ({
+  mockFindAllAccessibleForProject: vi.fn(),
+}));
+
+// Keep the module-level prisma (imported by modelProviders.utils) from
+// instantiating a real client; this route resolves through ctx.prisma.
+vi.mock("~/server/db", () => ({
+  prisma: { auditLog: { create: vi.fn() } },
+}));
+
+vi.mock("~/server/modelProviders/modelProvider.repository", () => ({
+  ModelProviderRepository: class {
+    findAllAccessibleForProject = mockFindAllAccessibleForProject;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Tenancy fixture: org_a owns project_a (team_a) and project_b (team_b);
+// org_b is a completely separate organization.
+// ---------------------------------------------------------------------------
+
+const projects: Record<string, { teamId: string; organizationId: string }> = {
+  project_a: { teamId: "team_a", organizationId: "org_a" },
+  project_b: { teamId: "team_b", organizationId: "org_a" },
+};
+
+const organizationUsers = [
+  {
+    userId: "user_member_of_project_a",
+    organizationId: "org_a",
+    role: "MEMBER",
+  },
+  {
+    userId: "user_other_project_admin",
+    organizationId: "org_a",
+    role: "MEMBER",
+  },
+  { userId: "user_other_org_admin", organizationId: "org_b", role: "ADMIN" },
+];
+
+const roleBindings = [
+  {
+    userId: "user_member_of_project_a",
+    organizationId: "org_a",
+    scopeType: "PROJECT",
+    scopeId: "project_a",
+    role: "ADMIN",
+    customRoleId: null,
+  },
+  // Full admin of a SIBLING project in the same org — must not see project_a.
+  {
+    userId: "user_other_project_admin",
+    organizationId: "org_a",
+    scopeType: "PROJECT",
+    scopeId: "project_b",
+    role: "ADMIN",
+    customRoleId: null,
+  },
+  // Full admin of a DIFFERENT org — must not see anything in org_a.
+  {
+    userId: "user_other_org_admin",
+    organizationId: "org_b",
+    scopeType: "ORGANIZATION",
+    scopeId: "org_b",
+    role: "ADMIN",
+    customRoleId: null,
+  },
+];
+
+function fixturePrisma(): PrismaClient {
+  return {
+    project: {
+      // Serves both the rbac lookup (selects `team`) and, for the
+      // authorized control, the service's full-row fetch (`createdAt`).
+      findUnique: vi.fn(({ where }: any) => {
+        const project = projects[where.id];
+        if (!project) return Promise.resolve(null);
+        return Promise.resolve({
+          id: where.id,
+          createdAt: new Date("2024-01-01"),
+          team: { id: project.teamId, organizationId: project.organizationId },
+        });
+      }),
+    },
+    organizationUser: {
+      findFirst: vi.fn(({ where }: any) =>
+        Promise.resolve(
+          organizationUsers.find(
+            (m) =>
+              m.userId === where.userId &&
+              m.organizationId === where.organizationId,
+          ) ?? null,
+        ),
+      ),
+    },
+    groupMembership: {
+      findMany: vi.fn(() => Promise.resolve([])),
+    },
+    roleBinding: {
+      findMany: vi.fn(({ where }: any) =>
+        Promise.resolve(
+          roleBindings.filter(
+            (b) =>
+              b.organizationId === where.organizationId &&
+              where.scopeId.in.includes(b.scopeId) &&
+              // Mirrors the direct-binding predicate: the bound user must
+              // currently be a member of the queried organization.
+              where.OR.some(
+                (clause: any) =>
+                  clause.userId === b.userId &&
+                  organizationUsers.some(
+                    (m) =>
+                      m.userId === b.userId &&
+                      m.organizationId === where.organizationId,
+                  ),
+              ),
+          ),
+        ),
+      ),
+    },
+    teamUser: {
+      findFirst: vi.fn(() => Promise.resolve(null)),
+    },
+  } as unknown as PrismaClient;
+}
+
+function callerForUser(userId: string) {
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: userId }, expires: "1" },
+    req: undefined,
+    res: undefined,
+  });
+  ctx.prisma = fixturePrisma();
+  return modelProviderRouter.createCaller(ctx);
+}
+
+describe("modelProviders.getAllForProject authz", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFindAllAccessibleForProject.mockResolvedValue([
+      {
+        id: "mp_openai",
+        name: "OpenAI",
+        provider: "openai",
+        enabled: true,
+        customKeys: { OPENAI_API_KEY: "sk-plaintext-secret-123" },
+        customModels: null,
+        customEmbeddingsModels: null,
+        deploymentMapping: null,
+        extraHeaders: null,
+        scopes: [{ scopeType: "PROJECT", scopeId: "project_a" }],
+      },
+    ]);
+  });
+
+  describe("when the user has no access to the project at all", () => {
+    it("rejects with UNAUTHORIZED", async () => {
+      const caller = callerForUser("user_with_nothing");
+
+      await expect(
+        caller.getAllForProject({ projectId: "project_a" }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("when the user only has access to a sibling project in the same organization", () => {
+    it("rejects with UNAUTHORIZED", async () => {
+      const caller = callerForUser("user_other_project_admin");
+
+      await expect(
+        caller.getAllForProject({ projectId: "project_a" }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("when the user is an admin of a different organization", () => {
+    it("rejects with UNAUTHORIZED", async () => {
+      const caller = callerForUser("user_other_org_admin");
+
+      await expect(
+        caller.getAllForProject({ projectId: "project_a" }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("when the user has a binding on the project itself", () => {
+    it("returns providers, proving the denials above are not vacuous", async () => {
+      const caller = callerForUser("user_member_of_project_a");
+
+      const result = await caller.getAllForProject({ projectId: "project_a" });
+
+      expect(result.openai).toBeDefined();
+      // And even for this authorized user, the key comes back masked.
+      expect(result.openai?.customKeys).toMatchObject({
+        OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+      });
+    });
+  });
+
+  it("throws TRPCError (not a generic error) for denied access", async () => {
+    const caller = callerForUser("user_with_nothing");
+
+    await expect(
+      caller.getAllForProject({ projectId: "project_a" }),
+    ).rejects.toBeInstanceOf(TRPCError);
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/modelProviders.getAllForProject.authz.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/modelProviders.getAllForProject.authz.unit.test.ts
@@ -170,6 +170,7 @@ describe("modelProviders.getAllForProject authz", () => {
   });
 
   describe("when the user has no access to the project at all", () => {
+    /** @scenario A user without project view permission cannot list a project's providers */
     it("rejects with UNAUTHORIZED", async () => {
       const caller = callerForUser("user_with_nothing");
 
@@ -180,6 +181,7 @@ describe("modelProviders.getAllForProject authz", () => {
   });
 
   describe("when the user only has access to a sibling project in the same organization", () => {
+    /** @scenario Access to a sibling project does not grant access to this project's providers */
     it("rejects with UNAUTHORIZED", async () => {
       const caller = callerForUser("user_other_project_admin");
 
@@ -190,6 +192,7 @@ describe("modelProviders.getAllForProject authz", () => {
   });
 
   describe("when the user is an admin of a different organization", () => {
+    /** @scenario Admin rights in another organization grant nothing across the tenancy boundary */
     it("rejects with UNAUTHORIZED", async () => {
       const caller = callerForUser("user_other_org_admin");
 

--- a/langwatch/src/server/api/routers/__tests__/modelProviders.getAllForProject.masking.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/modelProviders.getAllForProject.masking.unit.test.ts
@@ -1,0 +1,243 @@
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MASKED_KEY_PLACEHOLDER } from "../../../../utils/constants";
+import { createInnerTRPCContext } from "../../trpc";
+import { modelProviderRouter } from "../modelProviders";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const {
+  mockFindAllAccessibleForProject,
+  mockProjectFindUnique,
+  mockHasSetupPermission,
+} = vi.hoisted(() => ({
+  mockFindAllAccessibleForProject: vi.fn(),
+  mockProjectFindUnique: vi.fn(),
+  mockHasSetupPermission: vi.fn(),
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    hasProjectPermission: mockHasSetupPermission,
+    checkProjectPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+// Keep the module-level prisma (imported by modelProviders.utils) from
+// instantiating a real client; this route resolves through ctx.prisma.
+vi.mock("~/server/db", () => ({
+  prisma: { auditLog: { create: vi.fn() } },
+}));
+
+// The repository is where decryption happens: rows come back with
+// plaintext customKeys, exactly as in production. Masking is the
+// service boundary's job — which is what this suite pins down.
+vi.mock("~/server/modelProviders/modelProvider.repository", () => ({
+  ModelProviderRepository: class {
+    findAllAccessibleForProject = mockFindAllAccessibleForProject;
+  },
+}));
+
+const PLAINTEXT_OPENAI_KEY = "sk-plaintext-secret-123";
+const PLAINTEXT_AWS_SECRET = "aws-secret-access-key-456";
+const PLAINTEXT_AZURE_KEY = "azure-subscription-key-789";
+const PLAINTEXT_HEADER_SECRET = "Bearer header-bearer-secret-012";
+
+const storedRows = [
+  {
+    id: "mp_openai",
+    name: "OpenAI",
+    provider: "openai",
+    enabled: true,
+    customKeys: {
+      OPENAI_API_KEY: PLAINTEXT_OPENAI_KEY,
+      OPENAI_BASE_URL: "https://api.openai.com/v1",
+    },
+    customModels: null,
+    customEmbeddingsModels: null,
+    deploymentMapping: null,
+    extraHeaders: null,
+    scopes: [{ scopeType: "PROJECT", scopeId: "project_123" }],
+  },
+  {
+    id: "mp_bedrock",
+    name: "Bedrock",
+    provider: "bedrock",
+    enabled: true,
+    customKeys: {
+      AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
+      AWS_SECRET_ACCESS_KEY: PLAINTEXT_AWS_SECRET,
+      AWS_REGION_NAME: "us-east-1",
+    },
+    customModels: null,
+    customEmbeddingsModels: null,
+    deploymentMapping: null,
+    extraHeaders: null,
+    scopes: [{ scopeType: "ORGANIZATION", scopeId: "org_123" }],
+  },
+  {
+    id: "mp_azure",
+    name: "Azure",
+    provider: "azure",
+    enabled: true,
+    customKeys: {
+      AZURE_OPENAI_API_KEY: PLAINTEXT_AZURE_KEY,
+      AZURE_OPENAI_ENDPOINT: "https://example.openai.azure.com",
+    },
+    customModels: null,
+    customEmbeddingsModels: null,
+    deploymentMapping: null,
+    extraHeaders: [{ key: "Ocp-Apim-Subscription-Key", value: "apim-secret" }],
+    scopes: [{ scopeType: "TEAM", scopeId: "team_123" }],
+  },
+  {
+    id: "mp_custom",
+    name: "Custom",
+    provider: "custom",
+    enabled: true,
+    customKeys: {
+      CUSTOM_API_KEY: "custom-plaintext-key",
+      CUSTOM_BASE_URL: "https://llm.internal.example.com/v1",
+    },
+    customModels: null,
+    customEmbeddingsModels: null,
+    deploymentMapping: null,
+    extraHeaders: [
+      { key: "Authorization", value: PLAINTEXT_HEADER_SECRET },
+      { key: "X-Tenant", value: "tenant-42" },
+    ],
+    scopes: [{ scopeType: "PROJECT", scopeId: "project_123" }],
+  },
+];
+
+function makeCaller() {
+  const ctx = createInnerTRPCContext({
+    session: {
+      user: { id: "test-user-id" },
+      expires: "1",
+    },
+    req: undefined,
+    res: undefined,
+    permissionChecked: true,
+    publiclyShared: false,
+  });
+  ctx.prisma = {
+    project: { findUnique: mockProjectFindUnique },
+  } as unknown as PrismaClient;
+  return modelProviderRouter.createCaller(ctx);
+}
+
+describe("modelProviders.getAllForProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockHasSetupPermission.mockResolvedValue(true);
+    mockProjectFindUnique.mockResolvedValue({
+      id: "project_123",
+      createdAt: new Date("2024-01-01"),
+    });
+    mockFindAllAccessibleForProject.mockResolvedValue(storedRows);
+  });
+
+  describe("when a user with project:update permission fetches providers", () => {
+    it("masks stored API keys of every provider instead of returning decrypted plaintext", async () => {
+      const result = await makeCaller().getAllForProject({
+        projectId: "project_123",
+      });
+
+      expect(result.openai?.customKeys).toMatchObject({
+        OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+      });
+      expect(result.bedrock?.customKeys).toMatchObject({
+        AWS_ACCESS_KEY_ID: MASKED_KEY_PLACEHOLDER,
+        AWS_SECRET_ACCESS_KEY: MASKED_KEY_PLACEHOLDER,
+      });
+      expect(result.azure?.customKeys).toMatchObject({
+        AZURE_OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+      });
+      expect(result.custom?.customKeys).toMatchObject({
+        CUSTOM_API_KEY: MASKED_KEY_PLACEHOLDER,
+      });
+    });
+
+    it("masks extra-header values while keeping header keys visible", async () => {
+      const result = await makeCaller().getAllForProject({
+        projectId: "project_123",
+      });
+
+      expect(result.custom?.extraHeaders).toEqual([
+        { key: "Authorization", value: MASKED_KEY_PLACEHOLDER },
+        { key: "X-Tenant", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+      expect(result.azure?.extraHeaders).toEqual([
+        { key: "Ocp-Apim-Subscription-Key", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+    });
+
+    it("does not include any plaintext secret anywhere in the response", async () => {
+      const result = await makeCaller().getAllForProject({
+        projectId: "project_123",
+      });
+
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain(PLAINTEXT_OPENAI_KEY);
+      expect(serialized).not.toContain(PLAINTEXT_AWS_SECRET);
+      expect(serialized).not.toContain(PLAINTEXT_AZURE_KEY);
+      expect(serialized).not.toContain(PLAINTEXT_HEADER_SECRET);
+      expect(serialized).not.toContain("custom-plaintext-key");
+      expect(serialized).not.toContain("apim-secret");
+    });
+
+    it("keeps non-secret values like base URL and region visible", async () => {
+      const result = await makeCaller().getAllForProject({
+        projectId: "project_123",
+      });
+
+      expect(result.openai?.customKeys).toMatchObject({
+        OPENAI_BASE_URL: "https://api.openai.com/v1",
+      });
+      expect(result.bedrock?.customKeys).toMatchObject({
+        AWS_REGION_NAME: "us-east-1",
+      });
+      expect(result.azure?.customKeys).toMatchObject({
+        AZURE_OPENAI_ENDPOINT: "https://example.openai.azure.com",
+      });
+    });
+  });
+
+  describe("when a view-only user (no project:update) fetches providers", () => {
+    beforeEach(() => {
+      mockHasSetupPermission.mockResolvedValue(false);
+    });
+
+    it("returns no customKeys at all", async () => {
+      const result = await makeCaller().getAllForProject({
+        projectId: "project_123",
+      });
+
+      expect(result.openai?.customKeys).toBeNull();
+      expect(result.custom?.customKeys).toBeNull();
+    });
+
+    it("still masks extra-header values", async () => {
+      const result = await makeCaller().getAllForProject({
+        projectId: "project_123",
+      });
+
+      expect(result.custom?.extraHeaders).toEqual([
+        { key: "Authorization", value: MASKED_KEY_PLACEHOLDER },
+        { key: "X-Tenant", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+      expect(JSON.stringify(result)).not.toContain(PLAINTEXT_HEADER_SECRET);
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/modelProviders.getAllForProject.masking.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/modelProviders.getAllForProject.masking.unit.test.ts
@@ -183,6 +183,7 @@ describe("modelProviders.getAllForProject", () => {
       ]);
     });
 
+    /** @scenario Plaintext API keys never reach the browser through any provider query */
     it("does not include any plaintext secret anywhere in the response", async () => {
       const result = await makeCaller().getAllForProject({
         projectId: "project_123",

--- a/langwatch/src/server/api/routers/modelProviders.ts
+++ b/langwatch/src/server/api/routers/modelProviders.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { SCOPE_TIERS, scopeAssignmentSchema } from "~/server/scopes/scope.types";
+import {
+  SCOPE_TIERS,
+  scopeAssignmentSchema,
+} from "~/server/scopes/scope.types";
 import { customModelUpdateInputSchema } from "../../modelProviders/customModel.schema";
 import {
   featureByKey,
@@ -49,6 +52,9 @@ export {
 } from "./modelProviders.utils";
 
 export const modelProviderRouter = createTRPCRouter({
+  // tRPC responses land in the browser, so every query here must go
+  // through the masking service method — decrypted customKeys are only
+  // for server-internal callers of `getProjectModelProviders`.
   getAllForProject: protectedProcedure
     .input(z.object({ projectId: z.string() }))
     .use(checkProjectPermission("project:view"))
@@ -61,7 +67,11 @@ export const modelProviderRouter = createTRPCRouter({
         "project:update",
       );
 
-      return await getProjectModelProviders(projectId, hasSetupPermission);
+      const service = ModelProviderService.create(ctx.prisma);
+      return await service.getProjectModelProvidersForFrontend(
+        projectId,
+        hasSetupPermission,
+      );
     }),
   getAllForProjectForFrontend: protectedProcedure
     .input(z.object({ projectId: z.string() }))
@@ -121,7 +131,9 @@ export const modelProviderRouter = createTRPCRouter({
         enabled: z.boolean(),
         customKeys: z.object({}).passthrough().optional().nullable(),
         customModels: customModelUpdateInputSchema.optional().nullable(),
-        customEmbeddingsModels: customModelUpdateInputSchema.optional().nullable(),
+        customEmbeddingsModels: customModelUpdateInputSchema
+          .optional()
+          .nullable(),
         extraHeaders: z
           .array(z.object({ key: z.string(), value: z.string() }))
           .optional()
@@ -228,7 +240,9 @@ export const modelProviderRouter = createTRPCRouter({
     )
     .use(checkOrganizationPermission("organization:view"))
     .query(({ input }) => {
-      return { managed: isManagedProvider(input.organizationId, input.provider) };
+      return {
+        managed: isManagedProvider(input.organizationId, input.provider),
+      };
     }),
 
   /**
@@ -563,4 +577,3 @@ async function deleteConfigPermissionMiddleware({
   ctx.permissionChecked = true;
   return next();
 }
-

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.service.extraHeaders.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.service.extraHeaders.unit.test.ts
@@ -1,0 +1,200 @@
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+import type { ModelProviderRepository } from "../modelProvider.repository";
+import { ModelProviderService } from "../modelProvider.service";
+
+// The onboarding seed runs inside createNew's transaction and would drag
+// half the ModelDefault stack into this suite — not what it pins down.
+vi.mock("../seedOnboardingDefaults", () => ({
+  seedOnboardingDefaultsForProvider: vi.fn(),
+}));
+
+const REAL_AUTH = "Bearer real-secret-abc";
+const REAL_TENANT = "tenant-42";
+
+const existingRow = {
+  id: "mp_custom",
+  name: "Custom",
+  provider: "custom",
+  enabled: true,
+  customKeys: null,
+  customModels: null,
+  customEmbeddingsModels: null,
+  deploymentMapping: null,
+  extraHeaders: [
+    { key: "Authorization", value: REAL_AUTH },
+    { key: "X-Tenant", value: REAL_TENANT },
+  ],
+  scopes: [{ scopeType: "PROJECT", scopeId: "project_1" }],
+};
+
+function makeService() {
+  const repository = {
+    findByIdForOrganization: vi.fn().mockResolvedValue(existingRow),
+    update: vi.fn().mockResolvedValue(existingRow),
+    create: vi.fn().mockResolvedValue(existingRow),
+  };
+  const prisma = {
+    project: {
+      findUnique: vi
+        .fn()
+        .mockResolvedValue({ team: { organizationId: "org_1" } }),
+    },
+    $transaction: (fn: (tx: unknown) => Promise<unknown>) => fn({}),
+  };
+  const service = new ModelProviderService(
+    prisma as unknown as PrismaClient,
+    repository as unknown as ModelProviderRepository,
+  );
+  return { service, repository };
+}
+
+async function saveWithHeaders(
+  extraHeaders: { key: string; value: string }[],
+  { id }: { id?: string } = { id: "mp_custom" },
+) {
+  const { service, repository } = makeService();
+  await service.updateModelProvider({
+    id,
+    projectId: "project_1",
+    provider: "custom",
+    enabled: true,
+    extraHeaders,
+  });
+  return repository;
+}
+
+describe("ModelProviderService extraHeaders save path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when a save echoes masked placeholders back for untouched headers", () => {
+    /** @scenario Preserve original extra header values when saving with masked placeholders */
+    it("restores the stored values by header key", async () => {
+      const repository = await saveWithHeaders([
+        { key: "Authorization", value: MASKED_KEY_PLACEHOLDER },
+        { key: "X-Tenant", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+
+      expect(repository.update).toHaveBeenCalledWith(
+        "mp_custom",
+        "project_1",
+        expect.objectContaining({
+          extraHeaders: [
+            { key: "Authorization", value: REAL_AUTH },
+            { key: "X-Tenant", value: REAL_TENANT },
+          ],
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("when a header key is renamed in place with its value still masked", () => {
+    it("restores the value from the header at the same position", async () => {
+      const repository = await saveWithHeaders([
+        { key: "X-Auth", value: MASKED_KEY_PLACEHOLDER },
+        { key: "X-Tenant", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+
+      expect(repository.update).toHaveBeenCalledWith(
+        "mp_custom",
+        "project_1",
+        expect.objectContaining({
+          extraHeaders: [
+            { key: "X-Auth", value: REAL_AUTH },
+            { key: "X-Tenant", value: REAL_TENANT },
+          ],
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("when a rename and a reorder land in the same save", () => {
+    it("never copies a secret that is already claimed by name under a new header key", async () => {
+      // "X-New" sits at index 0, where "Authorization" used to be — but
+      // Authorization is still claimed by name at index 1, so X-New must
+      // not receive its secret via the positional fallback.
+      const repository = await saveWithHeaders([
+        { key: "X-New", value: MASKED_KEY_PLACEHOLDER },
+        { key: "Authorization", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+
+      expect(repository.update).toHaveBeenCalledWith(
+        "mp_custom",
+        "project_1",
+        expect.objectContaining({
+          extraHeaders: [{ key: "Authorization", value: REAL_AUTH }],
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("when a masked placeholder matches no stored header at all", () => {
+    /** @scenario Preserve original extra header values when saving with masked placeholders */
+    it("drops the header instead of persisting the placeholder literally", async () => {
+      const repository = await saveWithHeaders([
+        { key: "Authorization", value: MASKED_KEY_PLACEHOLDER },
+        { key: "X-Tenant", value: MASKED_KEY_PLACEHOLDER },
+        { key: "X-Never-Stored", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+
+      expect(repository.update).toHaveBeenCalledWith(
+        "mp_custom",
+        "project_1",
+        expect.objectContaining({
+          extraHeaders: [
+            { key: "Authorization", value: REAL_AUTH },
+            { key: "X-Tenant", value: REAL_TENANT },
+          ],
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("when the user enters a new header value", () => {
+    it("saves the entered value verbatim", async () => {
+      const repository = await saveWithHeaders([
+        { key: "Authorization", value: "Bearer replaced-secret" },
+        { key: "X-Tenant", value: MASKED_KEY_PLACEHOLDER },
+      ]);
+
+      expect(repository.update).toHaveBeenCalledWith(
+        "mp_custom",
+        "project_1",
+        expect.objectContaining({
+          extraHeaders: [
+            { key: "Authorization", value: "Bearer replaced-secret" },
+            { key: "X-Tenant", value: REAL_TENANT },
+          ],
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("when creating a new provider with a masked placeholder value", () => {
+    it("drops the placeholder — there is no stored row to restore from", async () => {
+      const repository = await saveWithHeaders(
+        [
+          { key: "Authorization", value: MASKED_KEY_PLACEHOLDER },
+          { key: "X-Real", value: "real-value" },
+        ],
+        { id: undefined },
+      );
+
+      expect(repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extraHeaders: [{ key: "X-Real", value: "real-value" }],
+        }),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/langwatch/src/server/modelProviders/modelProvider.service.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.service.ts
@@ -1250,21 +1250,27 @@ export class ModelProviderService {
    * Header counterpart of `mergeCustomKeys`: the frontend receives header
    * values as the masked placeholder, so an untouched header comes back
    * masked on save and must be restored from the stored row. Restore by
-   * header key first; when the key was renamed, fall back to the header
-   * at the same position; a placeholder that matches nothing is dropped
-   * rather than stored as a literal value.
+   * header key first; when the key was renamed in place, fall back to the
+   * header at the same position — but only when that positional header
+   * isn't also claimed by name elsewhere in the submission, so a
+   * rename+reorder can never copy one header's secret under another
+   * header's name. A placeholder that matches nothing is dropped rather
+   * than stored as a literal value.
    */
   private mergeExtraHeaders(
     incoming: { key: string; value: string }[],
     existing: { key: string; value: string }[] | null,
   ): { key: string; value: string }[] {
+    const incomingKeys = new Set(incoming.map((h) => h.key));
     return incoming.flatMap((header, index) => {
       if (header.value !== MASKED_KEY_PLACEHOLDER) return [header];
-      const restored =
-        existing?.find((h) => h.key === header.key)?.value ??
-        existing?.[index]?.value;
-      if (restored === undefined) return [];
-      return [{ key: header.key, value: restored }];
+      const byKey = existing?.find((h) => h.key === header.key);
+      if (byKey) return [{ key: header.key, value: byKey.value }];
+      const positional = existing?.[index];
+      if (positional && !incomingKeys.has(positional.key)) {
+        return [{ key: header.key, value: positional.value }];
+      }
+      return [];
     });
   }
 }

--- a/langwatch/src/server/modelProviders/modelProvider.service.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.service.ts
@@ -191,8 +191,14 @@ export class ModelProviderService {
    * Gets model providers with API keys masked for frontend display.
    *
    * Business rules:
-   * - Only masks fields matching KEY_CHECK patterns (API keys)
+   * - Only masks customKeys fields matching KEY_CHECK patterns (API keys)
+   * - Extra-header values are always masked — they routinely carry auth
+   *   secrets for azure/custom providers
    * - URLs and other values remain visible
+   *
+   * Masking runs even when `includeKeys` is false: customKeys are already
+   * nulled by that flag, but extraHeaders are returned regardless, so
+   * skipping the mask would hand view-only users plaintext header values.
    */
   async getProjectModelProvidersForFrontend(
     projectId: string,
@@ -202,10 +208,6 @@ export class ModelProviderService {
       projectId,
       includeKeys,
     );
-
-    if (!includeKeys) {
-      return providers;
-    }
 
     return this.maskApiKeys(providers);
   }
@@ -255,6 +257,9 @@ export class ModelProviderService {
       .map((mp) => ({
         ...this.toMaybeStoredProvider(mp, defaultProviders, true),
         customKeys: this.maskRowCustomKeys(mp.customKeys),
+        extraHeaders: this.maskExtraHeaders(
+          mp.extraHeaders as { key: string; value: string }[] | null,
+        ),
       }));
     return [...storedRows, ...systemRows];
   }
@@ -324,6 +329,9 @@ export class ModelProviderService {
       .map((mp) => ({
         ...this.toMaybeStoredProvider(mp, defaultProviders, true),
         customKeys: this.maskRowCustomKeys(mp.customKeys),
+        extraHeaders: this.maskExtraHeaders(
+          mp.extraHeaders as { key: string; value: string }[] | null,
+        ),
       }));
     return [...storedRows, ...systemRows];
   }
@@ -1023,15 +1031,33 @@ export class ModelProviderService {
     const masked = { ...providers };
 
     for (const [providerKey, config] of Object.entries(masked)) {
-      if (config.customKeys) {
+      if (config.customKeys || config.extraHeaders?.length) {
         masked[providerKey] = {
           ...config,
           customKeys: this.maskRowCustomKeys(config.customKeys),
+          extraHeaders: this.maskExtraHeaders(config.extraHeaders),
         };
       }
     }
 
     return masked;
+  }
+
+  /**
+   * Header values are masked wholesale — unlike customKeys there is no
+   * name pattern to distinguish secrets, and azure/custom extra headers
+   * routinely carry auth tokens. Keys stay visible so the form can be
+   * edited; `mergeExtraHeaders` restores real values when the masked
+   * placeholder comes back on save.
+   */
+  private maskExtraHeaders(
+    extraHeaders: { key: string; value: string }[] | null | undefined,
+  ): { key: string; value: string }[] | null {
+    if (!extraHeaders) return extraHeaders ?? null;
+    return extraHeaders.map(({ key }) => ({
+      key,
+      value: MASKED_KEY_PLACEHOLDER,
+    }));
   }
 
   private validateAndCleanKeys(
@@ -1106,7 +1132,11 @@ export class ModelProviderService {
   }
 
   private async updateExisting(
-    existingProvider: { id: string; customKeys: unknown },
+    existingProvider: {
+      id: string;
+      customKeys: unknown;
+      extraHeaders: unknown;
+    },
     data: {
       projectId: string;
       provider: string;
@@ -1138,7 +1168,12 @@ export class ModelProviderService {
         enabled: data.enabled,
         customModels: data.customModels,
         customEmbeddingsModels: data.customEmbeddingsModels,
-        extraHeaders: data.extraHeaders,
+        extraHeaders: this.mergeExtraHeaders(
+          data.extraHeaders,
+          existingProvider.extraHeaders as
+            | { key: string; value: string }[]
+            | null,
+        ),
         ...(data.name !== undefined && { name: data.name }),
         ...(data.scopes !== undefined && { scopes: data.scopes }),
         ...(customKeysToSave !== undefined && {
@@ -1174,7 +1209,9 @@ export class ModelProviderService {
         enabled: data.enabled,
         customModels: data.customModels,
         customEmbeddingsModels: data.customEmbeddingsModels,
-        extraHeaders: data.extraHeaders,
+        // No existing row to restore from — placeholder values are dropped
+        // instead of being stored literally.
+        extraHeaders: this.mergeExtraHeaders(data.extraHeaders, null),
         scopes: data.scopes,
         ...(customKeysProvided &&
           validatedKeys && { customKeys: validatedKeys }),
@@ -1207,5 +1244,27 @@ export class ModelProviderService {
           .map(([key, value]) => [key, value]),
       ),
     };
+  }
+
+  /**
+   * Header counterpart of `mergeCustomKeys`: the frontend receives header
+   * values as the masked placeholder, so an untouched header comes back
+   * masked on save and must be restored from the stored row. Restore by
+   * header key first; when the key was renamed, fall back to the header
+   * at the same position; a placeholder that matches nothing is dropped
+   * rather than stored as a literal value.
+   */
+  private mergeExtraHeaders(
+    incoming: { key: string; value: string }[],
+    existing: { key: string; value: string }[] | null,
+  ): { key: string; value: string }[] {
+    return incoming.flatMap((header, index) => {
+      if (header.value !== MASKED_KEY_PLACEHOLDER) return [header];
+      const restored =
+        existing?.find((h) => h.key === header.key)?.value ??
+        existing?.[index]?.value;
+      if (restored === undefined) return [];
+      return [{ key: header.key, value: restored }];
+    });
   }
 }

--- a/langwatch/src/server/modelProviders/modelProvider.service.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.service.ts
@@ -1053,7 +1053,7 @@ export class ModelProviderService {
   private maskExtraHeaders(
     extraHeaders: { key: string; value: string }[] | null | undefined,
   ): { key: string; value: string }[] | null {
-    if (!extraHeaders) return extraHeaders ?? null;
+    if (extraHeaders == null) return null;
     return extraHeaders.map(({ key }) => ({
       key,
       value: MASKED_KEY_PLACEHOLDER,

--- a/specs/evaluations/experiments-online-evaluations-separation.feature
+++ b/specs/evaluations/experiments-online-evaluations-separation.feature
@@ -22,10 +22,11 @@ Feature: Separate experiments from online evaluations
 
   Scenario: Collapse primary navigation sections
     Given the project navigation is expanded
-    Then every primary section has a visible caret and an accessible expand or collapse control
-    And each caret is positioned immediately beside its section label
+    Then every primary section has an accessible expand or collapse control
+    And expanded section headings stay decluttered with no caret
     When I collapse a section
     Then its destinations are hidden
+    And a dim caret appears beside the collapsed section's label
     And the preference is restored after I reload the application
 
   Scenario: Focus automation work by purpose

--- a/specs/model-providers/provider-configuration.feature
+++ b/specs/model-providers/provider-configuration.feature
@@ -75,6 +75,13 @@ Feature: Model Provider Configuration
     And non-secret values like the base URL remain visible
 
   @unit
+  Scenario: Preserve original extra header values when saving with masked placeholders
+    Given I have "custom" provider configured with extra headers
+    When I save the provider with header values still masked
+    Then the stored header values are preserved
+    And a masked header that matches no stored header is not saved
+
+  @unit
   Scenario: A user without project view permission cannot list a project's providers
     Given a project has "openai" provider configured with an API key
     And I have no permissions on that project

--- a/specs/model-providers/provider-configuration.feature
+++ b/specs/model-providers/provider-configuration.feature
@@ -65,6 +65,36 @@ Feature: Model Provider Configuration
     Then the "OPENAI_API_KEY" field shows "HAS_KEY••••••••••••••••••••••••"
     And the actual API key value is not displayed
 
+  @unit
+  Scenario: Plaintext API keys never reach the browser through any provider query
+    Given I have "openai" provider configured with API key "sk-actual123"
+    And I have "project:update" permission
+    When the app fetches the project's model providers from any page
+    Then the API key is masked in the response
+    And the plaintext API key does not appear anywhere in the response
+    And non-secret values like the base URL remain visible
+
+  @unit
+  Scenario: A user without project view permission cannot list a project's providers
+    Given a project has "openai" provider configured with an API key
+    And I have no permissions on that project
+    When I request that project's model providers
+    Then the request is rejected as unauthorized
+
+  @unit
+  Scenario: Access to a sibling project does not grant access to this project's providers
+    Given a project has "openai" provider configured with an API key
+    And I am an admin of a different project in the same organization
+    When I request that project's model providers
+    Then the request is rejected as unauthorized
+
+  @unit
+  Scenario: Admin rights in another organization grant nothing across the tenancy boundary
+    Given a project has "openai" provider configured with an API key
+    And I am an admin of a different organization
+    When I request that project's model providers
+    Then the request is rejected as unauthorized
+
   @integration
   Scenario: Preserve original API key when saving with masked placeholder
     Given I have "openai" provider configured with API key "sk-actual123"


### PR DESCRIPTION
## Problem

`modelProviders.getAllForProject` (`modelProvider.service.ts` → `buildSavedProviders`) returned **decrypted plaintext `customKeys`** — OpenAI/Anthropic/Azure/AWS-Bedrock/Vertex/custom credentials — to any user with `project:update`. The query is issued by `useOrganizationTeamProject`, which runs on practically every page, so stored provider credentials reached the browser wholesale. Every other model-provider surface masks via `maskApiKeys`; this one path bypassed it.

While fixing it, two adjacent leaks turned up:

- **`extraHeaders` values were never masked anywhere** — not in `getAllForProjectForFrontend`, not in the list queries, not in the REST `/api/model-providers` surface. Header values routinely carry auth secrets for azure/custom providers (`Authorization`, `Ocp-Apim-Subscription-Key`, …).
- **`extraHeaders` were returned even to view-only users**: `includeKeys=false` nulls `customKeys` but headers passed through, and the `ForFrontend` method skipped masking entirely in that case.

## Fix

- `getAllForProject` now resolves through `getProjectModelProvidersForFrontend` on the service (same `Record<provider, …>` shape — the utils wrapper of the same name returns a different `{providers, modelMetadata}` shape and is not used here).
- `maskApiKeys` also masks `extraHeaders` values (keys stay visible so the form is editable); both list variants and the REST surface pick this up.
- Masking now runs even when `includeKeys=false`.
- `mergeExtraHeaders` (mirror of `mergeCustomKeys`) restores stored header values when the masked placeholder comes back on save: match by header key, fall back to position for a renamed key, and drop placeholders that match nothing (create included) so the literal placeholder is never persisted.

Server-internal callers (embeddings, workflows, evaluations, scenarios, litellm param prep) keep using unmasked `getProjectModelProviders` — unchanged.

## Tests

New suites execute the **real tRPC procedure** via `createCaller` (not extracted copies of the masking logic):

- `modelProviders.getAllForProject.masking.unit.test.ts` — repository returns decrypted rows (as in production) for openai/bedrock/azure/custom; asserts keys and header values masked, plaintext absent from the serialized response, non-secrets (base URL, region, endpoint) visible; view-only users get `customKeys: null` and masked headers. Failed before the fix with the plaintext secrets in the response.
- `modelProviders.getAllForProject.authz.unit.test.ts` — runs the **real** `checkProjectPermission` middleware over a fixture prisma: UNAUTHORIZED for a user with no access, for an admin of a *sibling project in the same org*, and for an *admin of a different org*; positive control (project-bound user) proves the denials aren't vacuous and still gets masked keys.

Spec scenarios added to `specs/model-providers/provider-configuration.feature`.

`682 tests` across the model-provider server suites, router suite, and internal-consumer suites pass.

## Notes / residual edges

- The settings drawer now shows masked dots for existing header values (matching API-key behaviour) instead of plaintext.
- Azure's form-side quirk of folding header values into `customKeys` still works: those keys ride the existing `mergeCustomKeys` placeholder restore.
- A header whose key is renamed while its value is still masked restores by position; a placeholder matching nothing is dropped rather than saved literally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Mask model-provider credentials in browser-facing responses, covering both custom keys and secret extra headers (extra headers are masked consistently).
  * Ensure plaintext secrets never appear in serialized provider listings.
  * On save, restore real extra-header values when masked placeholders are submitted; omit placeholder-only extra headers when no match exists.
* **Access Control**
  * Enforce project permissions and tenant/organization boundaries for project model-provider listings.
* **UI Improvements**
  * Refine sidebar primary navigation caret behavior: expanded headings hide the caret; collapsed headings show a dim caret next to the label with an accessible toggle.
* **Tests**
  * Added/updated unit/integration scenarios for masking, placeholder restoration/drop behavior, RBAC authorization, and caret UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Drive-by fixes for main breakage (#5916)

Main's `langwatch-app-ci` is red at this branch's base (`6a5016fb`) from two defects shipped in #5916, both blocking any PR from going green, both fixed here:

- **feature-parity**: a test annotation still referenced the pre-rename scenario title ("Use the available width for the experiments list"); repointed to "Use the available width for online evaluation configuration".
- **SidebarSection caret**: #5916 shipped three mutually contradictory artifacts — the component and its e2e (`documentation-link-style.spec.ts`, "section carets stay dim") render a caret only when collapsed, while its integration test and spec demanded one beside the label while expanded. The component + e2e side is the shipped intent, so the integration test and spec scenario were updated to match (no caret while expanded, dim caret when collapsed).