### PR TITLE
fix(event-sourcing): bound claude-span-sync visibility retry + quarantine runaway groups

### DIFF
--- a/langwatch/src/server/app-layer/traces/claude-code-log-to-span.ts
+++ b/langwatch/src/server/app-layer/traces/claude-code-log-to-span.ts
@@ -212,6 +212,48 @@ export function resolveClaudeTurnLogCap(raw: string | undefined): number {
 }
 
 /**
+ * How long the span-sync reactor keeps retrying a log CONTRIBUTION whose
+ * canonical log records are not visible in ClickHouse yet, before it gives up.
+ *
+ * The canonical log and its compact trace contribution travel through separate
+ * durable pipelines, so a contribution can reach the reactor a beat before the
+ * log projection lands — the reactor throws to retry until it does. But if the
+ * records NEVER materialize (dropped upstream, or a partition-window miss), that
+ * throw is a poison pill: every re-emitted contribution for the trace burns the
+ * full 25-attempt retry ladder, and a pathological turn re-emits thousands,
+ * wedging the per-trace group and burning a large share of the shared
+ * event-sourcing queue (prod incident 2026-07-20). This deadline bounds it: once
+ * a contribution has been unfoldable for this long — measured from the log's
+ * ingest time (`event.occurredAt`) — the reactor stops retrying and completes
+ * the job so the group drains. Generous enough that the normal cross-pipeline
+ * race (seconds) never trips it; tune via
+ * `LANGWATCH_CLAUDE_LOG_VISIBILITY_DEADLINE_MS`.
+ */
+export const CLAUDE_LOG_VISIBILITY_DEADLINE_MS = 10 * 60 * 1000;
+
+/**
+ * Upper bound on the visibility-retry deadline, so an operator-supplied
+ * `LANGWATCH_CLAUDE_LOG_VISIBILITY_DEADLINE_MS` can't re-open the unbounded-retry
+ * poison-pill failure mode this deadline exists to close.
+ */
+export const MAX_CLAUDE_LOG_VISIBILITY_DEADLINE_MS = 60 * 60 * 1000;
+
+/**
+ * Resolve the operator-configured visibility-retry deadline (ms) from an env
+ * value, clamped to `[1, MAX_CLAUDE_LOG_VISIBILITY_DEADLINE_MS]`. Absent,
+ * non-numeric, or below-one values fall back to
+ * {@link CLAUDE_LOG_VISIBILITY_DEADLINE_MS}. Mirrors {@link resolveClaudeTurnLogCap}.
+ */
+export function resolveClaudeLogVisibilityDeadlineMs(
+  raw: string | undefined,
+): number {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1)
+    return CLAUDE_LOG_VISIBILITY_DEADLINE_MS;
+  return Math.min(parsed, MAX_CLAUDE_LOG_VISIBILITY_DEADLINE_MS);
+}
+
+/**
  * The span kind a claude_code log event feeds, or null when the event is not
  * folded into a span (so it stays a plain, visible log). The receiver marks +
  * saves every event with a non-null kind; the reactor folds them; the read path

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -22,7 +22,10 @@ import { createOrUpdateQueueItems } from "~/server/api/routers/annotation";
 import { createManyDatasetRecords } from "~/server/api/routers/datasetRecord.utils";
 import { getProtectionsForProject } from "~/server/api/utils";
 import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
-import { resolveClaudeTurnLogCap } from "~/server/app-layer/traces/claude-code-log-to-span";
+import {
+  resolveClaudeLogVisibilityDeadlineMs,
+  resolveClaudeTurnLogCap,
+} from "~/server/app-layer/traces/claude-code-log-to-span";
 import { DatasetRepository } from "~/server/datasets/dataset.repository";
 import {
   createDatasetNormalizeHandler,
@@ -889,6 +892,16 @@ export class PipelineRegistry {
       // seize the worker; the root span is marked truncated when the cap bites.
       turnLogCap: resolveClaudeTurnLogCap(
         process.env.LANGWATCH_CLAUDE_TURN_LOG_CAP,
+      ),
+      // Bound the retry-until-visible gate: once a contribution has been
+      // unfoldable for this long, its canonical logs are never coming (dropped
+      // upstream / partition-window miss), so the reactor gives up instead of
+      // re-burning the retry ladder and wedging the per-trace group while
+      // starving the shared queue (prod incident 2026-07-20). Env
+      // LANGWATCH_CLAUDE_LOG_VISIBILITY_DEADLINE_MS, default
+      // CLAUDE_LOG_VISIBILITY_DEADLINE_MS.
+      visibilityDeadlineMs: resolveClaudeLogVisibilityDeadlineMs(
+        process.env.LANGWATCH_CLAUDE_LOG_VISIBILITY_DEADLINE_MS,
       ),
       recordSpan: recordSpanDispatch.fn,
     });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/claudeCodeSpanSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/claudeCodeSpanSync.reactor.unit.test.ts
@@ -298,7 +298,10 @@ function capSetup(
   };
 }
 
-function setup(rows: StoredLogRecordRow[]) {
+function setup(
+  rows: StoredLogRecordRow[],
+  opts?: { now?: () => number; visibilityDeadlineMs?: number },
+) {
   const getMarkedClaudeCodeLogs = vi.fn(async () => rows);
   const countMarkedClaudeCodeLogs = vi.fn(async () => rows.length);
   const recorded: RecordSpanCommandData[] = [];
@@ -309,6 +312,10 @@ function setup(rows: StoredLogRecordRow[]) {
     getMarkedClaudeCodeLogs,
     countMarkedClaudeCodeLogs,
     recordSpan,
+    ...(opts?.now ? { now: opts.now } : {}),
+    ...(opts?.visibilityDeadlineMs !== undefined
+      ? { visibilityDeadlineMs: opts.visibilityDeadlineMs }
+      : {}),
   });
   return {
     reactor,
@@ -390,6 +397,60 @@ describe("createClaudeCodeSpanSyncReactor", () => {
         1_700_000_000_000,
         expect.any(Number),
       );
+    });
+
+    describe("when the canonical logs never become visible", () => {
+      // contributionEvent().occurredAt — the log's ingest wall-clock, which the
+      // deadline measures age from.
+      const CONTRIBUTION_AT = 1_800_000_000_000;
+      const DEADLINE_MS = 600_000;
+
+      it("keeps retrying while the contribution is younger than the deadline", async () => {
+        const { reactor, recordSpan } = setup([], {
+          visibilityDeadlineMs: DEADLINE_MS,
+          now: () => CONTRIBUTION_AT + DEADLINE_MS - 1,
+        });
+        await expect(
+          reactor.handle(contributionEvent(), {
+            tenantId: TENANT,
+            aggregateId: TRACE,
+            foldState: undefined,
+          }),
+        ).rejects.toThrow("not visible yet");
+        expect(recordSpan).not.toHaveBeenCalled();
+      });
+
+      it("still retries at exactly the deadline (inclusive boundary)", async () => {
+        const { reactor } = setup([], {
+          visibilityDeadlineMs: DEADLINE_MS,
+          now: () => CONTRIBUTION_AT + DEADLINE_MS,
+        });
+        await expect(
+          reactor.handle(contributionEvent(), {
+            tenantId: TENANT,
+            aggregateId: TRACE,
+            foldState: undefined,
+          }),
+        ).rejects.toThrow("not visible yet");
+      });
+
+      it("gives up without retrying once the contribution outlives the deadline, so the poison group drains", async () => {
+        const { reactor, recordSpan, getMarkedClaudeCodeLogs } = setup([], {
+          visibilityDeadlineMs: DEADLINE_MS,
+          now: () => CONTRIBUTION_AT + DEADLINE_MS + 1,
+        });
+        // Resolves — NOT a throw — so the group-queue completes the job instead
+        // of re-staging it forever (prod incident 2026-07-20).
+        await expect(
+          reactor.handle(contributionEvent(), {
+            tenantId: TENANT,
+            aggregateId: TRACE,
+            foldState: undefined,
+          }),
+        ).resolves.toBeUndefined();
+        expect(getMarkedClaudeCodeLogs).toHaveBeenCalled();
+        expect(recordSpan).not.toHaveBeenCalled();
+      });
     });
 
     it("ignores non-log events so the spans it emits never re-trigger it", async () => {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/claudeCodeSpanSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/claudeCodeSpanSync.reactor.unit.test.ts
@@ -434,6 +434,7 @@ describe("createClaudeCodeSpanSyncReactor", () => {
         ).rejects.toThrow("not visible yet");
       });
 
+      /** @scenario the retry-until-visible gate gives up once a contribution outlives the deadline */
       it("gives up without retrying once the contribution outlives the deadline, so the poison group drains", async () => {
         const { reactor, recordSpan, getMarkedClaudeCodeLogs } = setup([], {
           visibilityDeadlineMs: DEADLINE_MS,

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/claudeCodeSpanSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/claudeCodeSpanSync.reactor.ts
@@ -2,6 +2,7 @@ import { createLogger } from "@langwatch/observability";
 import {
   CLAUDE_CODE_EVENT_SCOPE,
   CLAUDE_CODE_PII_ATTR,
+  CLAUDE_LOG_VISIBILITY_DEADLINE_MS,
   CLAUDE_TURN_LOG_CAP,
   type ClaudeCodeLogRecordInput,
   convertClaudeCodeTurnToSpans,
@@ -56,6 +57,18 @@ export interface ClaudeCodeSpanSyncReactorDeps {
    * override from `LANGWATCH_CLAUDE_TURN_LOG_CAP`.
    */
   turnLogCap?: number;
+  /**
+   * How long (ms) to keep retrying a contribution whose canonical logs are not
+   * visible yet before giving up on it. Defaults to
+   * {@link CLAUDE_LOG_VISIBILITY_DEADLINE_MS}; the composition root resolves the
+   * operator override from `LANGWATCH_CLAUDE_LOG_VISIBILITY_DEADLINE_MS`.
+   */
+  visibilityDeadlineMs?: number;
+  /**
+   * Clock backing the visibility deadline. Injectable so tests can drive the
+   * deadline deterministically; defaults to `Date.now`.
+   */
+  now?: () => number;
 }
 
 /**
@@ -134,9 +147,34 @@ export function createClaudeCodeSpanSyncReactor(
           // before the log projection is visible in ClickHouse. Throwing lets
           // the reactor queue retry instead of permanently missing the turn.
           if (isLogContributedEvent(event)) {
-            throw new CanonicalLogNotVisibleError(
-              `Canonical Claude logs are not visible yet for trace ${traceId}`,
+            const deadlineMs =
+              deps.visibilityDeadlineMs ?? CLAUDE_LOG_VISIBILITY_DEADLINE_MS;
+            const nowMs = deps.now?.() ?? Date.now();
+            // event.occurredAt is the log's ingest wall-clock (the receiver's
+            // acceptedAt), so this is how long the contribution has been
+            // unfoldable — stable across retries of the same event.
+            const ageMs = nowMs - event.occurredAt;
+            if (ageMs <= deadlineMs) {
+              throw new CanonicalLogNotVisibleError(
+                `Canonical Claude logs are not visible yet for trace ${traceId}`,
+              );
+            }
+            // Past the deadline the records are never going to appear (dropped
+            // upstream, or a partition-window miss). Stop retrying: returning
+            // completes the job so the per-trace group DRAINS, instead of a
+            // poison pill that re-burns the 25-attempt retry ladder on every
+            // re-emitted contribution and starves the shared event-sourcing
+            // queue (prod incident 2026-07-20).
+            logger.warn(
+              {
+                tenantId,
+                traceId,
+                ageMs,
+                deadlineMs,
+              },
+              "Canonical Claude logs never became visible within the deadline; giving up on span sync for this contribution",
             );
+            return;
           }
           return;
         }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
@@ -232,6 +232,121 @@ describe.skipIf(!hasTestcontainers)(
       });
     });
 
+    describe("given the failure-streak quarantine breaker", () => {
+      const failStreakKey = (name: string, groupId: string) =>
+        `${name}:gq:group:${groupId}:failstreak`;
+      const ENV = "LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD";
+
+      describe("when one group's jobs keep failing with no success", () => {
+        /** @scenario a runaway group is quarantined once its failure streak crosses the threshold */
+        it("blocks the group so one poison producer can't monopolise the shared queue", async () => {
+          const previous = process.env[ENV];
+          process.env[ENV] = "2";
+          try {
+            const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+            processed.mockRejectedValue(new Error("downstream always down"));
+            const { queue, name } = createQueue(processed);
+            await queue.waitUntilReady();
+
+            // Distinct jobs for ONE group, none of which can succeed. Each
+            // failure adds to the group's streak; once it exceeds 2 the group is
+            // blocked (via the exhausted-retry path) instead of churning — the
+            // per-JOB maxAttempts cap never fires because these are fresh jobs.
+            // (A generous timeout: failures accrue at the group's re-dispatch
+            // cadence, not instantly.)
+            for (let i = 0; i < 10; i++) {
+              await queue.send({
+                id: `job-${i}`,
+                groupId: "runaway",
+                value: "x",
+              });
+            }
+
+            await vi.waitFor(
+              async () => {
+                expect(await blockedMembers(name)).toContain("runaway");
+              },
+              { timeout: 25000, interval: 100 },
+            );
+
+            const error = await storedError(name, "runaway");
+            expect(error).toContain("quarantined");
+            // The job is re-staged for inspection, not dropped.
+            expect(
+              await redis.zcard(`${name}:gq:group:runaway:jobs`),
+            ).toBeGreaterThan(0);
+          } finally {
+            if (previous === undefined) delete process.env[ENV];
+            else process.env[ENV] = previous;
+          }
+        });
+      });
+
+      describe("given the quarantine kill switch is set to 0", () => {
+        /** @scenario the failure-streak breaker is disabled by setting the threshold to 0 */
+        it("keeps dispatching a persistently-failing group instead of quarantining it", async () => {
+          const previous = process.env[ENV];
+          process.env[ENV] = "0";
+          try {
+            const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+            processed.mockRejectedValue(new Error("downstream always down"));
+            const { queue, name } = createQueue(processed);
+            await queue.waitUntilReady();
+
+            // Pre-seed a streak far above the old default; with the breaker off
+            // it is never consulted and never enforced.
+            await redis.set(failStreakKey(name, "runaway"), "999");
+            for (let i = 0; i < 4; i++) {
+              await queue.send({
+                id: `job-${i}`,
+                groupId: "runaway",
+                value: "x",
+              });
+            }
+
+            await vi.waitFor(
+              () => {
+                expect(processed).toHaveBeenCalled();
+              },
+              { timeout: 5000, interval: 50 },
+            );
+            // The group is retried, never parked into the blocked set.
+            expect(await blockedMembers(name)).not.toContain("runaway");
+          } finally {
+            if (previous === undefined) delete process.env[ENV];
+            else process.env[ENV] = previous;
+          }
+        });
+      });
+
+      describe("when a group's job succeeds", () => {
+        /** @scenario a success clears the group's failure streak so blips never accumulate to quarantine */
+        it("clears the failure streak", async () => {
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+          const { queue, name } = createQueue(processed);
+          await queue.waitUntilReady();
+
+          // A streak left by earlier failures, below the (default) threshold.
+          await redis.set(failStreakKey(name, "group-a"), "2");
+          await queue.send({ id: "job-1", groupId: "group-a", value: "x" });
+
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(1);
+            },
+            { timeout: 5000, interval: 50 },
+          );
+          await vi.waitFor(
+            async () => {
+              expect(await redis.get(failStreakKey(name, "group-a"))).toBeNull();
+            },
+            { timeout: 5000, interval: 50 },
+          );
+        });
+      });
+    });
+
     describe("given a group whose job always throws", () => {
       describe("when an attempt fails with the process alive", () => {
         /** @scenario a failing-but-not-crashing job does not accumulate claim strikes */

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
@@ -271,6 +271,9 @@ describe.skipIf(!hasTestcontainers)(
 
             const error = await storedError(name, "runaway");
             expect(error).toContain("quarantined");
+            // Cleared as the group parks, so an operator's unblock gets a fresh
+            // run rather than re-quarantining on the very next failure.
+            expect(await redis.get(failStreakKey(name, "runaway"))).toBeNull();
             // The job is re-staged for inspection, not dropped.
             expect(
               await redis.zcard(`${name}:gq:group:runaway:jobs`),

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
@@ -238,7 +238,7 @@ describe.skipIf(!hasTestcontainers)(
       const ENV = "LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD";
 
       describe("when one group's jobs keep failing with no success", () => {
-        /** @scenario a runaway group is quarantined once its failure streak crosses the threshold */
+        /** @scenario a group that fails on every attempt without draining is quarantined */
         it("blocks the group so one poison producer can't monopolise the shared queue", async () => {
           const previous = process.env[ENV];
           process.env[ENV] = "2";
@@ -283,7 +283,7 @@ describe.skipIf(!hasTestcontainers)(
       });
 
       describe("given the quarantine kill switch is set to 0", () => {
-        /** @scenario the failure-streak breaker is disabled by setting the threshold to 0 */
+        /** @scenario the failure-streak quarantine is disabled by setting the threshold to 0 */
         it("keeps dispatching a persistently-failing group instead of quarantining it", async () => {
           const previous = process.env[ENV];
           process.env[ENV] = "0";
@@ -320,7 +320,7 @@ describe.skipIf(!hasTestcontainers)(
       });
 
       describe("when a group's job succeeds", () => {
-        /** @scenario a success clears the group's failure streak so blips never accumulate to quarantine */
+        /** @scenario a group's success clears its failure streak */
         it("clears the failure streak", async () => {
           const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
           processed.mockResolvedValue(undefined);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.quarantineThreshold.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.quarantineThreshold.unit.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_GROUP_QUARANTINE_THRESHOLD,
+  readGroupQuarantineThreshold,
+} from "../scripts";
+
+const ENV = "LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD";
+
+describe("readGroupQuarantineThreshold", () => {
+  const previous = process.env[ENV];
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env[ENV];
+    else process.env[ENV] = previous;
+  });
+
+  describe("when the env var is unset", () => {
+    it("falls back to the default threshold", () => {
+      delete process.env[ENV];
+      expect(readGroupQuarantineThreshold()).toBe(
+        DEFAULT_GROUP_QUARANTINE_THRESHOLD,
+      );
+    });
+  });
+
+  describe("when the env var is the kill switch 0", () => {
+    it("returns 0 so the breaker is disabled", () => {
+      process.env[ENV] = "0";
+      expect(readGroupQuarantineThreshold()).toBe(0);
+    });
+  });
+
+  describe("when the env var is a positive integer", () => {
+    it("returns that integer", () => {
+      process.env[ENV] = "42";
+      expect(readGroupQuarantineThreshold()).toBe(42);
+    });
+  });
+
+  describe("when the env var is non-numeric or negative", () => {
+    it("falls back to the default rather than disabling the breaker", () => {
+      process.env[ENV] = "not-a-number";
+      expect(readGroupQuarantineThreshold()).toBe(
+        DEFAULT_GROUP_QUARANTINE_THRESHOLD,
+      );
+      process.env[ENV] = "-5";
+      expect(readGroupQuarantineThreshold()).toBe(
+        DEFAULT_GROUP_QUARANTINE_THRESHOLD,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1115,6 +1115,15 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   await this.scripts.recordGroupFailure(groupId);
                 if (failStreak > this.quarantineFailStreakThreshold) {
                   quarantined = true;
+                  // Clear the streak as we park. Every ops recovery path
+                  // (unblock / drain / dead-letter) resets the poison guard's
+                  // claim strikes so a recovered group gets a FRESH run; the
+                  // failure streak must not outlive the park either, or an
+                  // operator who unblocks would see the group re-quarantine on
+                  // its very next failure instead of getting that fresh run.
+                  // Best-effort: we are already on the failure path, so a blip
+                  // clearing it must not derail parking the group.
+                  await this.scripts.clearGroupFailures(groupId).catch(() => {});
                   // Carried into handleExhaustedRetries as the group's stored
                   // error so /ops shows WHY it was blocked (a run of failures),
                   // not just the last job's error.

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -76,6 +76,7 @@ import {
   type DrainedJob,
   GroupStagingScripts,
   readClaimStrikeThreshold,
+  readGroupQuarantineThreshold,
 } from "./scripts";
 import { type ObjectStore, TransientBlobStoreError } from "./tieredBlobStore";
 
@@ -235,6 +236,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   private readonly consumerEnabled: boolean;
   private readonly dispatcher: GroupQueueDispatcher | null;
   private readonly metricsCollector: GroupQueueMetricsCollector | null;
+  /**
+   * Consecutive-failure count that quarantines (blocks) a group. Read once at
+   * construction; 0 disables the breaker. See {@link readGroupQuarantineThreshold}.
+   */
+  private readonly quarantineFailStreakThreshold = readGroupQuarantineThreshold();
 
   private shutdownRequested = false;
   /** Tracks in-flight jobs for active count metrics. */
@@ -1051,6 +1057,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               });
               gqJobsCompletedTotal.inc(routingLabels);
 
+              // A success means the group is draining, so it must not carry a
+              // stale failure streak toward the quarantine threshold.
+              if (this.quarantineFailStreakThreshold > 0) {
+                await this.scripts.clearGroupFailures(groupId);
+              }
+
               // Audit hook: onDispatched fires once per dispatched payload
               // (dispatched + every drained sibling on success).
               const dispatchedAt = new Date();
@@ -1087,7 +1099,52 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 await this.restageDrainedSiblings(groupId, drainedSiblings);
               }
 
-              if (isRetryable && attempt < JOB_RETRY_CONFIG.maxAttempts) {
+              // Group-quarantine circuit breaker (prod incident 2026-07-20). A
+              // producer that mints fresh jobs for ONE group faster than they
+              // drain never trips the per-JOB `maxAttempts` cap — every failure
+              // is a new attempt-1 job — so the group churns indefinitely and can
+              // starve the shared queue. Count consecutive retryable failures
+              // across the group's jobs (cleared on any success); once the streak
+              // crosses the threshold, route this job through the SAME
+              // exhausted-retry path that blocks the group, so it stops
+              // dispatching and an operator can inspect + drain it.
+              let quarantined = false;
+              let quarantineError: Error | undefined;
+              if (isRetryable && this.quarantineFailStreakThreshold > 0) {
+                const failStreak =
+                  await this.scripts.recordGroupFailure(groupId);
+                if (failStreak > this.quarantineFailStreakThreshold) {
+                  quarantined = true;
+                  // Carried into handleExhaustedRetries as the group's stored
+                  // error so /ops shows WHY it was blocked (a run of failures),
+                  // not just the last job's error.
+                  quarantineError = new Error(
+                    `Poison guard: group quarantined after ${failStreak} consecutive failures (threshold ${this.quarantineFailStreakThreshold}) with no success. Last error: ${error.message}. Inspect the staged jobs, then unblock the group.`,
+                  );
+                  gqGroupsPoisonParkedTotal.inc({
+                    queue_name: this.queueName,
+                    reason: "failure_streak",
+                  });
+                  this.logger.error(
+                    {
+                      queueName: this.queueName,
+                      projectId: tenantIdFromGroupId(groupId),
+                      groupId,
+                      stagedJobId,
+                      failStreak,
+                      threshold: this.quarantineFailStreakThreshold,
+                      error: error.message,
+                    },
+                    "Group quarantined after a run of failures with no success; blocking it to protect the shared queue",
+                  );
+                }
+              }
+
+              if (
+                isRetryable &&
+                attempt < JOB_RETRY_CONFIG.maxAttempts &&
+                !quarantined
+              ) {
                 // Re-stage with backoff — frees the worker slot immediately
                 gqJobsRetriedTotal.inc(routingLabels);
 
@@ -1220,7 +1277,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   stagedJobId,
                   payload,
                   originalScore,
-                  lastError: error,
+                  // When the group tripped the quarantine breaker, block it with
+                  // the descriptive quarantine error rather than the raw job
+                  // error, so /ops shows why the group is blocked.
+                  lastError: quarantineError ?? error,
                   contextMetadata,
                   routingLabels,
                 });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -206,7 +206,7 @@ export const gqPayloadTooLargeTotal = new Counter({
  */
 export const gqGroupsPoisonParkedTotal = new Counter({
   name: "gq_groups_poison_parked_total",
-  help: "Groups parked into the blocked set by the claim-side poison guard",
+  help: "Groups parked into the blocked set by a poison guard (reason: claim_strikes | oversized_payload | failure_streak)",
   labelNames: ["queue_name", "reason"] as const,
 });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1663,6 +1663,42 @@ export function readClaimStrikeThreshold(): number {
 }
 
 /**
+ * Default consecutive-failure count that quarantines (blocks) a group.
+ *
+ * Deliberately high: a single group failing this many times inside the TTL
+ * window with ZERO interleaved successes is unambiguously a runaway — a producer
+ * minting fresh jobs for one group faster than they drain — not a healthy group
+ * riding out a transient downstream blip. Prod incident 2026-07-20: one trace's
+ * span-sync group churned ~5 fresh jobs/min for 14h against an unmet
+ * precondition, taking ~a quarter of the shared queue, yet never tripped the
+ * per-JOB `maxAttempts` cap because every failure was a NEW attempt-1 job. This
+ * breaker counts failures ACROSS a group's jobs so the group itself terminates.
+ */
+export const DEFAULT_GROUP_QUARANTINE_THRESHOLD = 500;
+
+/**
+ * The failure streak self-expires so a group that fails sparsely (well below its
+ * success rate) never accumulates to the threshold from blips hours apart.
+ * Refreshed on every failure, so an actively-churning group keeps its count; the
+ * group's next success clears it outright.
+ */
+export const GROUP_QUARANTINE_TTL_SECONDS = 15 * 60;
+
+/**
+ * Read the group-quarantine failure-streak threshold from the environment.
+ * Mirrors {@link readClaimStrikeThreshold}:
+ *   - unset / empty / non-numeric / negative → DEFAULT_GROUP_QUARANTINE_THRESHOLD
+ *   - "0" → 0 (explicit kill switch — the breaker is disabled)
+ *   - positive integer → that integer
+ */
+export function readGroupQuarantineThreshold(): number {
+  return readNonNegativeIntEnv({
+    name: "LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD",
+    fallback: DEFAULT_GROUP_QUARANTINE_THRESHOLD,
+  });
+}
+
+/**
  * Global in-flight budget for the dynamic water-level cap (option C, 2026-05-29).
  * 0 (the default) disables the dynamic cap: dispatch falls back to the fixed
  * per-tenant `readTenantCap()` and behaves exactly as before — the feature ships
@@ -2280,6 +2316,35 @@ export class GroupStagingScripts {
     const raw = await this.redis.get(this.claimStrikesKey(groupId));
     const n = raw === null ? 0 : Number.parseInt(raw, 10);
     return Number.isFinite(n) ? n : 0;
+  }
+
+  private failStreakKey(groupId: string): string {
+    return `${this.keyPrefix}group:${groupId}:failstreak`;
+  }
+
+  /**
+   * Group-quarantine failure streak (specs/event-sourcing/poison-group-park-guard.feature).
+   * INCR'd on every RETRYABLE job failure in a group and cleared on the group's
+   * next success (see {@link clearGroupFailures}), so it counts consecutive
+   * failures ACROSS a group's jobs — the runaway signal the per-job `maxAttempts`
+   * cap misses when each failure is a fresh attempt-1 job. The TTL keeps a
+   * sparsely-failing group from accumulating a count from blips hours apart.
+   *
+   * @returns the streak count including this failure
+   */
+  async recordGroupFailure(groupId: string): Promise<number> {
+    const key = this.failStreakKey(groupId);
+    const results = await this.redis
+      .multi()
+      .incr(key)
+      .expire(key, GROUP_QUARANTINE_TTL_SECONDS)
+      .exec();
+    const count = results?.[0]?.[1];
+    return typeof count === "number" ? count : 0;
+  }
+
+  async clearGroupFailures(groupId: string): Promise<void> {
+    await this.redis.del(this.failStreakKey(groupId));
   }
 
   /**

--- a/specs/claude/telemetry-turn-bounding.feature
+++ b/specs/claude/telemetry-turn-bounding.feature
@@ -72,6 +72,26 @@ Feature: Claude Code telemetry turn bounding
     And the produced trace is marked as truncated in an observable way
     And the workers remain responsive while the turn is live
 
+  # Incident 2026-07-20: a compact log contribution and its canonical log records
+  # travel through separate durable pipelines, so the span-sync reactor throws
+  # CanonicalLogNotVisibleError to retry until the records land in ClickHouse.
+  # When the records NEVER land (dropped upstream, or the ±2-day partition window
+  # misses them), that throw is a poison pill: every re-emitted contribution for
+  # the trace burns the full 25-attempt retry ladder, and one pathological turn
+  # re-emits thousands, wedging the per-trace group and taking ~a quarter of the
+  # shared queue. CLAUDE_LOG_VISIBILITY_DEADLINE_MS (default 10m, env
+  # LANGWATCH_CLAUDE_LOG_VISIBILITY_DEADLINE_MS) bounds the retry: age is measured
+  # from the log's ingest time (event.occurredAt), stable across retries.
+  # Covered by claudeCodeSpanSync.reactor.unit.test.ts.
+  @bounding @unit
+  Scenario: the retry-until-visible gate gives up once a contribution outlives the deadline
+    Given a log contribution whose canonical logs are not visible in ClickHouse
+    When the contribution is younger than the visibility deadline
+    Then the reactor throws to retry until the records land
+    But once the contribution has been unfoldable past the deadline
+    Then the reactor gives up and completes the job instead of retrying
+    And the per-trace group drains rather than churning the retry ladder forever
+
   # The structural guarantee is covered by logCommandSharding.test.ts (the fold
   # stays keyed per trace, not per shard; the event aggregate is the bare trace)
   # and recordLogCommand.sharding.integration (unsharded collapses to the single

--- a/specs/event-sourcing/poison-group-park-guard.feature
+++ b/specs/event-sourcing/poison-group-park-guard.feature
@@ -1,9 +1,10 @@
 Feature: GroupQueue poison-group park guard
   As the LangWatch event-sourcing queue processing per-aggregate FIFO groups
-  I want groups that repeatedly kill the worker process, and staged payloads
-  too large to parse safely, to be parked into the blocked set at claim time
+  I want groups that repeatedly kill the worker process, staged payloads too
+  large to parse safely, and groups that fail on every attempt without ever
+  draining, to be parked into the blocked set
   So that one poisoned group degrades only itself instead of crash-looping
-  every worker replica and stalling all tenants' queues.
+  every worker replica or starving all tenants' queues.
 
   # Incident 2026-07-10: a single group accumulated ~2,000 recordLog jobs for
   # one trace. Processing it seized the worker event loop, the liveness probe
@@ -28,6 +29,23 @@ Feature: GroupQueue poison-group park guard
   #     compressed bomb cannot balloon past the cap either.
   #   - Parked groups use the existing ops surface (getBlockedSummary,
   #     unblockGroup, drainGroup) - no new operator concepts.
+  #
+  # Incident 2026-07-20: a claudeCodeSpanSync reactor group for one trace churned
+  # ~5 fresh jobs/min for 14h against a precondition that never became true, and
+  # took ~a quarter of the shared {event-sourcing/jobs} queue's retry capacity.
+  # The per-JOB retry cap (JOB_RETRY_CONFIG.maxAttempts) never fired because
+  # every failure was a NEW attempt-1 job, not one job grinding to exhaustion, so
+  # the group was immortal. This adds a THIRD guard:
+  #   - Failure-streak quarantine: a per-group counter (recordGroupFailure)
+  #     INCR'd on every retryable job failure and cleared on the group's next
+  #     success. Counting failures ACROSS a group's jobs catches the runaway the
+  #     per-job cap misses. Once the streak exceeds
+  #     LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD (default 500, 0 = disabled)
+  #     the job is routed through the SAME exhausted-retries path that blocks the
+  #     group, with a stored error naming the streak. High default: only a group
+  #     failing this many times inside the TTL window with zero interleaved
+  #     successes is an unambiguous runaway, never a healthy group riding out a
+  #     transient blip.
 
   Background:
     Given a GroupQueue with jobs routed through queue-manager facades
@@ -52,6 +70,28 @@ Feature: GroupQueue poison-group park guard
     When the job exhausts its retry budget
     Then the group is parked by the existing exhausted-retries path
     And the claim strikes recorded for the group have been cleared on each surviving attempt
+
+  Scenario: a group that fails on every attempt without draining is quarantined
+    Given a group receiving a stream of fresh jobs that each fail on every attempt
+    And no job in the group ever completes successfully
+    When the group's consecutive-failure streak exceeds the quarantine threshold
+    Then the group is moved to the blocked set via the exhausted-retries path
+    And the stored group error explains it was quarantined after a run of failures
+    And the staged job remains staged for operator inspection or replay
+    And other groups continue to dispatch and process normally
+
+  Scenario: a group's success clears its failure streak
+    Given a group that has accumulated a failure streak below the quarantine threshold
+    When one of the group's jobs completes successfully
+    Then the group's failure streak is cleared
+    And a later transient failure starts the streak from zero rather than compounding
+
+  Scenario: the failure-streak quarantine is disabled by setting the threshold to 0
+    Given the quarantine kill switch is set to 0
+    And a group whose jobs fail on every attempt far beyond the former threshold
+    When the group is dispatched repeatedly
+    Then the group is retried under the normal per-job budget instead of being quarantined
+    And the group is never parked into the blocked set by the failure-streak guard
 
   @unimplemented
   # The clear-on-survival semantics is exercised by the completion/failure

--- a/specs/event-sourcing/poison-group-park-guard.feature
+++ b/specs/event-sourcing/poison-group-park-guard.feature
@@ -79,6 +79,8 @@ Feature: GroupQueue poison-group park guard
     And the stored group error explains it was quarantined after a run of failures
     And the staged job remains staged for operator inspection or replay
     And other groups continue to dispatch and process normally
+    And the group's failure streak is cleared as it is parked, so an operator's
+      unblock gets a fresh run instead of re-quarantining on the next failure
 
   Scenario: a group's success clears its failure streak
     Given a group that has accumulated a failure streak below the quarantine threshold


### PR DESCRIPTION
## Problem (prod incident 2026-07-20)

A single trace's `claudeCodeSpanSync` reactor group
(`project_00056…/fold/traceSummary/reactor/claudeCodeSpanSync/trace:6c3b7139…`)
sat in the `{event-sourcing/jobs}` queue for **14h**, not draining, at a flat
**~8,000 pending** — and was consuming **~25% of the entire shared queue's retry
churn** (565/hr of 2,299/hr), degrading trace processing for every tenant.

### Root cause

The reactor re-reads a Claude Code turn's canonical log records from ClickHouse
to fold them into spans. The compact log *contribution* and the full canonical
*log records* travel through separate durable pipelines, so when a `logContributed`
event arrives before the records are visible, the reactor throws
`CanonicalLogNotVisibleError` to **retry until they land**.

For this trace the records were **never findable** — either never stored (dropped
upstream) or outside the visibility query's **±2-day partition window**. So:

1. Every retry burned the full **25-attempt** ladder (~2h37m each), and
2. because a pathological turn re-emits **thousands** of contributions (each a
   *fresh* `attempt-1` job), the per-job `maxAttempts` cap **never terminated the
   group** — measured max attempt was 16, and **zero** jobs ever dead-lettered.

The group was effectively immortal. Full investigation write-up in the linked issue/thread.

## Fixes

**1. Visibility-retry deadline** (`claudeCodeSpanSync.reactor.ts`)
Once a contribution has been unfoldable for `CLAUDE_LOG_VISIBILITY_DEADLINE_MS`
(default **10m**, measured from the log's ingest time `event.occurredAt`, which is
stable across retries), the reactor **gives up and completes the job** — so the
per-trace group *drains* instead of re-burning the ladder forever. Generous enough
that the normal cross-pipeline race (seconds) never trips it. Env override:
`LANGWATCH_CLAUDE_LOG_VISIBILITY_DEADLINE_MS`.

**2. Group failure-streak quarantine** (`groupQueue.ts` / `scripts.ts`)
A per-group counter, INCR'd on each **retryable** job failure and **cleared on the
group's next success**, catches the runaway the per-job cap misses (failures
*across* a group's jobs). Once the streak exceeds
`LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD` (default **500**, `0` disables), the
job is routed through the **existing exhausted-retries path** that blocks the group
— reusing the proven blob-hold + block machinery rather than inventing a new park.
The blocked group carries a descriptive stored error so `/ops` shows *why*.

The two compose: fix 1 makes the incident's group drain (jobs succeed-by-giving-up,
so the streak resets and quarantine never fires); fix 2 is the general backstop for
*any* reactor that fails hard with no give-up path.

## Config / rollout

| Env | Default | Effect |
|---|---|---|
| `LANGWATCH_CLAUDE_LOG_VISIBILITY_DEADLINE_MS` | `600000` (10m) | give-up deadline; clamped to ≤ 1h |
| `LANGWATCH_GQ_QUARANTINE_FAILSTREAK_THRESHOLD` | `500` | consecutive failures → quarantine; `0` = off |

The quarantine defaults **on** at a deliberately high threshold (a single group
failing 500× in a 15-min window with **zero** interleaved successes is an
unambiguous runaway, never a healthy group riding out a transient blip). If
reviewers prefer it ship inert, set the default to `0` — one line in `scripts.ts`.

## Testing

- `claudeCodeSpanSync.reactor.unit.test.ts` — **14 pass** (+3: retries within
  deadline, inclusive boundary, gives-up past deadline).
- `scripts.quarantineThreshold.unit.test.ts` — **4 pass** (default / kill-switch /
  positive / garbage-fallback).
- `groupQueue.poisonGuard.integration.test.ts` — **13 pass** (+3: quarantine on
  sustained failures, kill switch, clear-on-success) against real Redis.
- Full groupQueue unit suite (**40**) green — no regressions.

## Immediate mitigation (separate from this PR)

The already-wedged prod group won't clear on deploy on its own; drain it from
`/ops` (`drainGroup`) and confirm whether trace `6c3b7139…` has canonical log rows
in ClickHouse (never-stored vs partition-window-miss) to pin the upstream cause.

## Risk

Fix 1 is narrow (one reactor branch). Fix 2 touches the shared group-queue failure
path — mitigated by reusing the existing exhausted-retries/block machinery,
gating cheaply on a construction-time threshold, clearing on success, and the
`0` kill switch. Highest-blast-radius change; please scrutinise the failure-path
edits in `groupQueue.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Added configurable deadlines for Claude Code log visibility retries, preventing prolonged processing when logs never appear.
  * Added a failure-streak quarantine guard for repeatedly failing queue groups, isolating affected work while allowing other processing to continue.
  * Successful jobs now clear accumulated group failure streaks.
* **Configuration**
  * Added environment settings to customize retry deadlines and quarantine thresholds, including an option to disable the quarantine guard.
* **Tests**
  * Added coverage for retry boundaries, quarantine behavior, recovery, and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->