### PR TITLE
fix(langy): stop the relay dropping progress frames and hanging on reconnect

### DIFF
--- a/langwatch/src/server/api/routers/langy.ts
+++ b/langwatch/src/server/api/routers/langy.ts
@@ -230,6 +230,71 @@ function abortableDelay(ms: number, signal: AbortSignal): Promise<boolean> {
   });
 }
 
+/** How often the settlement watcher consults the durable fold + heartbeat. */
+const SETTLEMENT_POLL_MS = 5_000;
+/**
+ * Consecutive settled reads required before synthesizing a terminal, so a single
+ * projection blip can never end a live stream.
+ */
+const SETTLEMENT_CONFIRM_POLLS = 2;
+
+/**
+ * Poll a turn's durable fold + per-turn heartbeat while its live edge is being
+ * tailed, and resolve to the terminal entry the buffer never received — or null
+ * if the stream ended first (aborted) or the turn never settled.
+ *
+ * Split out of `onTurnStream` so the subscription body stays at the orchestration
+ * level and this confirmation loop is independently testable. The safety gate
+ * itself lives in {@link decideSyntheticTerminal}.
+ */
+async function watchForMissedTerminal({
+  projectId,
+  conversationId,
+  turnId,
+  userId,
+  buffer,
+  signal,
+}: {
+  projectId: string;
+  conversationId: string;
+  turnId: string;
+  userId: string;
+  buffer: {
+    liveness(a: {
+      conversationId: string;
+      turnId: string;
+    }): Promise<{ stale: boolean }>;
+  };
+  signal: AbortSignal;
+}): Promise<LangyStreamEntry | null> {
+  let settledStreak = 0;
+  while (!signal.aborted) {
+    if (!(await abortableDelay(SETTLEMENT_POLL_MS, signal))) return null;
+    const [conversation, liveness] = await Promise.all([
+      getApp()
+        .langy.conversations.getById({ id: conversationId, projectId, userId })
+        .catch(() => null),
+      buffer.liveness({ conversationId, turnId }).catch(() => null),
+    ]);
+    if (!conversation || !liveness) {
+      settledStreak = 0;
+      continue;
+    }
+    const decision = decideSyntheticTerminal({
+      status: conversation.status,
+      lastError: conversation.lastError,
+      heartbeatStale: liveness.stale,
+    });
+    if (!decision) {
+      settledStreak = 0;
+      continue;
+    }
+    settledStreak += 1;
+    if (settledStreak >= SETTLEMENT_CONFIRM_POLLS) return decision;
+  }
+  return null;
+}
+
 /**
  * Dispatch a turn through the app-layer turn service. Create and Continue are
  * the SAME operation — `isNewConversation` is the only difference (it emits the
@@ -739,49 +804,22 @@ export const langyRouter = createTRPCRouter({
           // though the turn already finished. While we tail the live edge, watch
           // the durable fold + per-turn heartbeat; if the turn has settled with
           // no terminal in the buffer, synthesize one so the client resolves.
-          const POLL_MS = 5_000;
-          const CONFIRM_POLLS = 2; // consecutive settled reads before we act
           const settle = new AbortController();
           const followSignal = AbortSignal.any([signal, settle.signal]);
           let synthesized: LangyStreamEntry | null = null;
 
-          const watcher = (async () => {
-            let settledStreak = 0;
-            while (!followSignal.aborted) {
-              if (!(await abortableDelay(POLL_MS, followSignal))) return;
-              const [conversation, liveness] = await Promise.all([
-                getApp()
-                  .langy.conversations.getById({
-                    id: conversationId,
-                    projectId,
-                    userId,
-                  })
-                  .catch(() => null),
-                buffer.liveness({ conversationId, turnId }).catch(() => null),
-              ]);
-              if (!conversation || !liveness) {
-                settledStreak = 0;
-                continue;
-              }
-              const decision = decideSyntheticTerminal({
-                status: conversation.status,
-                lastError: conversation.lastError,
-                heartbeatStale: liveness.stale,
-              });
-              if (!decision) {
-                settledStreak = 0;
-                continue;
-              }
-              // Require two consecutive settled reads so a single projection blip
-              // can't end a live stream.
-              settledStreak += 1;
-              if (settledStreak >= CONFIRM_POLLS) {
-                synthesized = decision;
-                settle.abort(); // unblock follow() below
-                return;
-              }
-            }
-          })();
+          const watcher = watchForMissedTerminal({
+            projectId,
+            conversationId,
+            turnId,
+            userId,
+            buffer,
+            signal: followSignal,
+          }).then((entry) => {
+            if (!entry) return;
+            synthesized = entry;
+            settle.abort(); // unblock the follow() below
+          });
 
           try {
             for await (const { entry } of buffer.follow({

--- a/langwatch/src/server/api/routers/langy.ts
+++ b/langwatch/src/server/api/routers/langy.ts
@@ -15,7 +15,11 @@ import {
   type LangyTurnContext,
   langyTurnContextSchema,
 } from "~/server/app-layer/langy/langyTurnContext.schema";
-import { createLangyTokenBuffer } from "~/server/app-layer/langy/streaming/langyTokenBuffer";
+import {
+  createLangyTokenBuffer,
+  type LangyStreamEntry,
+} from "~/server/app-layer/langy/streaming/langyTokenBuffer";
+import { decideSyntheticTerminal } from "~/server/app-layer/langy/streaming/langyTurnSettlement";
 import { createLangyTurnAccessStore } from "~/server/app-layer/langy/streaming/langyTurnAccess";
 
 import type { Session } from "~/server/auth";
@@ -205,6 +209,25 @@ async function canWatchTurn({
     userId,
   });
   return !!conv;
+}
+
+/**
+ * Sleep for `ms`, resolving early to `false` when the signal aborts — so a
+ * watcher loop unblocks promptly the moment its follow() ends — otherwise `true`.
+ */
+function abortableDelay(ms: number, signal: AbortSignal): Promise<boolean> {
+  if (signal.aborted) return Promise.resolve(false);
+  return new Promise<boolean>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve(false);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /**
@@ -710,15 +733,80 @@ export const langyRouter = createTRPCRouter({
           if (entry.type === "end" || entry.type === "error") terminal = true;
         }
         if (!terminal) {
-          for await (const { entry } of buffer.follow({
-            conversationId,
-            turnId,
-            fromId: lastId,
-            signal,
-          })) {
-            yield entry;
-            if (entry.type === "end" || entry.type === "error") break;
+          // A refresh mid-turn can miss the worker's terminal frame (its relay
+          // connection dropped before it). follow() would then block until the
+          // hard per-turn deadline, leaving the UI on "Starting up…" for minutes
+          // though the turn already finished. While we tail the live edge, watch
+          // the durable fold + per-turn heartbeat; if the turn has settled with
+          // no terminal in the buffer, synthesize one so the client resolves.
+          const POLL_MS = 5_000;
+          const CONFIRM_POLLS = 2; // consecutive settled reads before we act
+          const settle = new AbortController();
+          const followSignal = AbortSignal.any([signal, settle.signal]);
+          let synthesized: LangyStreamEntry | null = null;
+
+          const watcher = (async () => {
+            let settledStreak = 0;
+            while (!followSignal.aborted) {
+              if (!(await abortableDelay(POLL_MS, followSignal))) return;
+              const [conversation, liveness] = await Promise.all([
+                getApp()
+                  .langy.conversations.getById({
+                    id: conversationId,
+                    projectId,
+                    userId,
+                  })
+                  .catch(() => null),
+                buffer.liveness({ conversationId, turnId }).catch(() => null),
+              ]);
+              if (!conversation || !liveness) {
+                settledStreak = 0;
+                continue;
+              }
+              const decision = decideSyntheticTerminal({
+                status: conversation.status,
+                lastError: conversation.lastError,
+                heartbeatStale: liveness.stale,
+              });
+              if (!decision) {
+                settledStreak = 0;
+                continue;
+              }
+              // Require two consecutive settled reads so a single projection blip
+              // can't end a live stream.
+              settledStreak += 1;
+              if (settledStreak >= CONFIRM_POLLS) {
+                synthesized = decision;
+                settle.abort(); // unblock follow() below
+                return;
+              }
+            }
+          })();
+
+          try {
+            for await (const { entry } of buffer.follow({
+              conversationId,
+              turnId,
+              fromId: lastId,
+              signal: followSignal,
+            })) {
+              yield entry;
+              if (entry.type === "end" || entry.type === "error") {
+                // A real terminal reached the buffer — never override it.
+                synthesized = null;
+                return;
+              }
+            }
+          } finally {
+            settle.abort();
+            await watcher.catch(() => {});
           }
+
+          // follow() ended with no buffered terminal. If the watcher proved the
+          // turn settled, deliver the synthesized terminal so the UI resolves
+          // instead of hanging; the client reconciles the transcript via
+          // langy.messages.
+          if (synthesized) yield synthesized;
         }
       } finally {
         blocking.disconnect();

--- a/langwatch/src/server/api/routers/langy.ts
+++ b/langwatch/src/server/api/routers/langy.ts
@@ -815,11 +815,17 @@ export const langyRouter = createTRPCRouter({
             userId,
             buffer,
             signal: followSignal,
-          }).then((entry) => {
-            if (!entry) return;
-            synthesized = entry;
-            settle.abort(); // unblock the follow() below
-          });
+          })
+            .then((entry) => {
+              if (!entry) return;
+              synthesized = entry;
+              settle.abort(); // unblock the follow() below
+            })
+            // Attached HERE, not in the finally below: follow() can block for
+            // minutes, so a rejection would sit unhandled until then — and Node's
+            // default --unhandled-rejections=throw would take the process down
+            // first. A failed watcher just means no synthesized terminal.
+            .catch(() => {});
 
           try {
             for await (const { entry } of buffer.follow({
@@ -837,7 +843,7 @@ export const langyRouter = createTRPCRouter({
             }
           } finally {
             settle.abort();
-            await watcher.catch(() => {});
+            await watcher; // already has its own .catch()
           }
 
           // follow() ended with no buffered terminal. If the watcher proved the

--- a/langwatch/src/server/app-layer/langy/streaming/__tests__/langyTurnRelay.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/__tests__/langyTurnRelay.unit.test.ts
@@ -51,6 +51,10 @@ function makeRelay(
   over: {
     conversations?: ReturnType<typeof fakeConversations>;
     fresh?: boolean;
+    readHandoffRunToken?: (a: {
+      conversationId: string;
+      turnId: string;
+    }) => Promise<string | null>;
   } = {},
 ) {
   const buffer = fakeBuffer();
@@ -60,6 +64,9 @@ function makeRelay(
     buffer,
     conversations,
     reserveFrameNonce,
+    ...(over.readHandoffRunToken
+      ? { readHandoffRunToken: over.readHandoffRunToken }
+      : {}),
   });
   return { relay, buffer, conversations, reserveFrameNonce };
 }
@@ -466,6 +473,50 @@ describe("LangyTurnRelay", () => {
       await relay.handle(frame({ type: "delta", text: "b" }));
       await relay.handle(frame({ type: "final", text: "done" }));
       expect(conversations.getRunToken).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given the run-token handoff races the projection", () => {
+    it("authenticates against the handoff token before the RunToken projection lands", async () => {
+      // First-turn reality: the async RunToken projection is still queued (null),
+      // but the synchronous handoff carries the token the worker signed with.
+      const conversations = fakeConversations(null);
+      const readHandoffRunToken = vi.fn(async () => RUN_TOKEN);
+      const { relay, buffer } = makeRelay({ conversations, readHandoffRunToken });
+
+      const out = await relay.handle(frame({ type: "delta", text: "hi" }));
+
+      expect(out).toEqual({ status: "applied" });
+      expect(buffer.appendChunk).toHaveBeenCalledTimes(1);
+      expect(readHandoffRunToken).toHaveBeenCalledWith({
+        conversationId: "conv-1",
+        turnId: "turn-1",
+      });
+      // The lagging projection is never consulted once the handoff has the token.
+      expect(conversations.getRunToken).not.toHaveBeenCalled();
+    });
+
+    it("does not cache a transient null, so a later frame authenticates once the token appears", async () => {
+      // No handoff wired; the projection is null on the first read, then lands.
+      const getRunToken = vi
+        .fn(
+          async (_a: {
+            projectId: string;
+            conversationId: string;
+          }): Promise<string | null> => RUN_TOKEN,
+        )
+        .mockResolvedValueOnce(null);
+      const conversations = { ...fakeConversations(), getRunToken };
+      const { relay, buffer } = makeRelay({ conversations });
+
+      const first = await relay.handle(frame({ type: "delta", text: "one" }));
+      expect(first).toEqual({ status: "rejected", reason: "no-run-token" });
+
+      const second = await relay.handle(frame({ type: "delta", text: "two" }));
+      expect(second).toEqual({ status: "applied" });
+      expect(buffer.appendChunk).toHaveBeenCalledTimes(1);
+      // Re-queried because the first null was NOT cached (the bug this fixes).
+      expect(getRunToken).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/langwatch/src/server/app-layer/langy/streaming/__tests__/langyTurnRelay.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/__tests__/langyTurnRelay.unit.test.ts
@@ -52,6 +52,7 @@ function makeRelay(
     conversations?: ReturnType<typeof fakeConversations>;
     fresh?: boolean;
     readHandoffRunToken?: (a: {
+      projectId: string;
       conversationId: string;
       turnId: string;
     }) => Promise<string | null>;
@@ -477,39 +478,71 @@ describe("LangyTurnRelay", () => {
   });
 
   describe("given the run-token handoff races the projection", () => {
-    it("authenticates against the handoff token before the RunToken projection lands", async () => {
-      // First-turn reality: the async RunToken projection is still queued (null),
-      // but the synchronous handoff carries the token the worker signed with.
-      const conversations = fakeConversations(null);
-      const readHandoffRunToken = vi.fn(async () => RUN_TOKEN);
-      const { relay, buffer } = makeRelay({ conversations, readHandoffRunToken });
+    describe("when a frame arrives before the projection has landed", () => {
+      it("authenticates it against the handoff token", async () => {
+        // First-turn reality: the async RunToken projection is still queued
+        // (null), but the synchronous handoff carries the token the worker
+        // signed with.
+        const conversations = fakeConversations(null);
+        const readHandoffRunToken = vi.fn(async () => RUN_TOKEN);
+        const { relay, buffer } = makeRelay({
+          conversations,
+          readHandoffRunToken,
+        });
 
-      const out = await relay.handle(frame({ type: "delta", text: "hi" }));
+        const out = await relay.handle(frame({ type: "delta", text: "hi" }));
 
-      expect(out).toEqual({ status: "applied" });
-      expect(buffer.appendChunk).toHaveBeenCalledTimes(1);
-      expect(readHandoffRunToken).toHaveBeenCalledWith({
-        conversationId: "conv-1",
-        turnId: "turn-1",
+        expect(out).toEqual({ status: "applied" });
+        expect(buffer.appendChunk).toHaveBeenCalledTimes(1);
+        // projectId is passed so the handoff read can refuse a handoff stashed
+        // under another project (conversation ids are project-scoped).
+        expect(readHandoffRunToken).toHaveBeenCalledWith({
+          projectId: "proj-1",
+          conversationId: "conv-1",
+          turnId: "turn-1",
+        });
+        // The lagging projection is never consulted once the handoff has it.
+        expect(conversations.getRunToken).not.toHaveBeenCalled();
       });
-      // The lagging projection is never consulted once the handoff has the token.
-      expect(conversations.getRunToken).not.toHaveBeenCalled();
     });
 
-    it("does not cache a transient null, so a later frame authenticates once the token appears", async () => {
-      // No handoff wired; the projection is null on the first read, then lands.
-      const conversations = fakeConversations();
-      conversations.getRunToken.mockResolvedValueOnce(null);
-      const { relay, buffer } = makeRelay({ conversations });
+    describe("when the handoff read fails transiently", () => {
+      it("falls back to the projection instead of tearing down the stream", async () => {
+        const conversations = fakeConversations();
+        const readHandoffRunToken = vi.fn(async () => {
+          throw new Error("redis unreachable");
+        });
+        const { relay, buffer } = makeRelay({
+          conversations,
+          readHandoffRunToken,
+        });
 
-      const first = await relay.handle(frame({ type: "delta", text: "one" }));
-      expect(first).toEqual({ status: "rejected", reason: "no-run-token" });
+        const out = await relay.handle(frame({ type: "delta", text: "hi" }));
 
-      const second = await relay.handle(frame({ type: "delta", text: "two" }));
-      expect(second).toEqual({ status: "applied" });
-      expect(buffer.appendChunk).toHaveBeenCalledTimes(1);
-      // Re-queried because the first null was NOT cached (the bug this fixes).
-      expect(conversations.getRunToken).toHaveBeenCalledTimes(2);
+        // The throw must NOT propagate out of handle() and end the relay stream:
+        // falling through to the projection is the point of the two-stage lookup.
+        expect(out).toEqual({ status: "applied" });
+        expect(buffer.appendChunk).toHaveBeenCalledTimes(1);
+        expect(conversations.getRunToken).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when the first lookup misses and a later frame arrives", () => {
+      it("re-reads the token instead of reusing the cached miss", async () => {
+        // No handoff wired; the projection is null on the first read, then lands.
+        const conversations = fakeConversations();
+        conversations.getRunToken.mockResolvedValueOnce(null);
+        const { relay, buffer } = makeRelay({ conversations });
+
+        const first = await relay.handle(frame({ type: "delta", text: "one" }));
+        expect(first).toEqual({ status: "rejected", reason: "no-run-token" });
+
+        const second = await relay.handle(frame({ type: "delta", text: "two" }));
+        expect(second).toEqual({ status: "applied" });
+        expect(buffer.appendChunk).toHaveBeenCalledTimes(1);
+        // Re-queried because the first null was NOT cached (the bug this fixes).
+        expect(conversations.getRunToken).toHaveBeenCalledTimes(2);
+      });
     });
   });
 });

--- a/langwatch/src/server/app-layer/langy/streaming/__tests__/langyTurnRelay.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/__tests__/langyTurnRelay.unit.test.ts
@@ -498,15 +498,8 @@ describe("LangyTurnRelay", () => {
 
     it("does not cache a transient null, so a later frame authenticates once the token appears", async () => {
       // No handoff wired; the projection is null on the first read, then lands.
-      const getRunToken = vi
-        .fn(
-          async (_a: {
-            projectId: string;
-            conversationId: string;
-          }): Promise<string | null> => RUN_TOKEN,
-        )
-        .mockResolvedValueOnce(null);
-      const conversations = { ...fakeConversations(), getRunToken };
+      const conversations = fakeConversations();
+      conversations.getRunToken.mockResolvedValueOnce(null);
       const { relay, buffer } = makeRelay({ conversations });
 
       const first = await relay.handle(frame({ type: "delta", text: "one" }));
@@ -516,7 +509,7 @@ describe("LangyTurnRelay", () => {
       expect(second).toEqual({ status: "applied" });
       expect(buffer.appendChunk).toHaveBeenCalledTimes(1);
       // Re-queried because the first null was NOT cached (the bug this fixes).
-      expect(getRunToken).toHaveBeenCalledTimes(2);
+      expect(conversations.getRunToken).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/langwatch/src/server/app-layer/langy/streaming/__tests__/langyTurnSettlement.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/__tests__/langyTurnSettlement.unit.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { LANGY_CONVERSATION_STATUS } from "~/server/event-sourcing/pipelines/langy-conversation-processing/schemas/constants";
+import { decideSyntheticTerminal } from "../langyTurnSettlement";
+
+describe("decideSyntheticTerminal", () => {
+  describe("when the turn's heartbeat is still fresh", () => {
+    it("never synthesizes a terminal, even if the fold looks settled", () => {
+      expect(
+        decideSyntheticTerminal({
+          status: LANGY_CONVERSATION_STATUS.IDLE,
+          lastError: null,
+          heartbeatStale: false,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("when the heartbeat is stale but the fold is still in flight", () => {
+    it("stays patient for an ACTIVE turn (a cold start reads in-flight)", () => {
+      expect(
+        decideSyntheticTerminal({
+          status: LANGY_CONVERSATION_STATUS.ACTIVE,
+          lastError: null,
+          heartbeatStale: true,
+        }),
+      ).toBeNull();
+    });
+
+    it("stays patient for a RUNNING turn", () => {
+      expect(
+        decideSyntheticTerminal({
+          status: LANGY_CONVERSATION_STATUS.RUNNING,
+          lastError: null,
+          heartbeatStale: true,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("when the heartbeat is stale and the fold has settled", () => {
+    it("synthesizes an end for a completed (idle) turn", () => {
+      expect(
+        decideSyntheticTerminal({
+          status: LANGY_CONVERSATION_STATUS.IDLE,
+          lastError: null,
+          heartbeatStale: true,
+        }),
+      ).toEqual({ type: "end" });
+    });
+
+    it("synthesizes an error carrying lastError for a failed turn", () => {
+      expect(
+        decideSyntheticTerminal({
+          status: LANGY_CONVERSATION_STATUS.FAILED,
+          lastError: "worker died",
+          heartbeatStale: true,
+        }),
+      ).toEqual({ type: "error", error: "worker died" });
+    });
+
+    it("falls back to a generic error message when a failed turn has none", () => {
+      expect(
+        decideSyntheticTerminal({
+          status: LANGY_CONVERSATION_STATUS.FAILED,
+          lastError: null,
+          heartbeatStale: true,
+        }),
+      ).toEqual({ type: "error", error: "Turn failed" });
+    });
+  });
+
+  describe("when the status is unknown or transitional", () => {
+    it("does not guess a terminal", () => {
+      expect(
+        decideSyntheticTerminal({
+          status: "some-future-status",
+          lastError: null,
+          heartbeatStale: true,
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/langy/streaming/langyTurnRelay.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/langyTurnRelay.ts
@@ -142,14 +142,21 @@ export interface LangyTurnRelayDeps {
   }): Promise<boolean>;
   /**
    * Read the runToken the worker was handed at dispatch, straight from the
-   * synchronous per-turn Redis handoff (keyed by conversation+turn). This is the
-   * EXACT token the manager signs its frames with, written before dispatch — so
-   * a first frame that outruns the async `RunToken` projection is authenticated
-   * instead of dropped as `no-run-token`. Returns null when no handoff exists
-   * (aged out past its TTL, or a legacy conversation with no token). Optional so
-   * unit tests can exercise the projection fallback in isolation.
+   * synchronous per-turn Redis handoff. This is the EXACT token the manager
+   * signs its frames with, written before dispatch — so a first frame that
+   * outruns the async `RunToken` projection is authenticated instead of dropped
+   * as `no-run-token`. Returns null when no handoff exists (aged out past its
+   * TTL, or a legacy conversation with no token).
+   *
+   * `projectId` is REQUIRED, not decorative: the handoff key is
+   * conversation+turn scoped, but conversation identity is project-scoped
+   * (`@@unique([projectId, ConversationId])`), so the implementation must refuse
+   * a handoff stashed under a different project rather than hand this stream
+   * another tenant's runToken. Optional dep so unit tests can exercise the
+   * projection fallback in isolation.
    */
   readHandoffRunToken?(a: {
+    projectId: string;
     conversationId: string;
     turnId: string;
   }): Promise<string | null>;
@@ -215,11 +222,11 @@ export class LangyTurnRelay {
     // Authenticity FIRST — no field is trusted until the MAC checks out. The
     // runToken is looked up by the (as-yet-unverified) conversationId; a wrong
     // conversationId simply yields a token the MAC won't match against.
-    const runToken = await this.loadRunToken(
-      envelope.conversationId,
-      envelope.projectId,
-      envelope.turnId,
-    );
+    const runToken = await this.loadRunToken({
+      conversationId: envelope.conversationId,
+      projectId: envelope.projectId,
+      turnId: envelope.turnId,
+    });
     if (runToken === null) {
       return this.reject({ reason: "no-run-token", envelope });
     }
@@ -250,11 +257,15 @@ export class LangyTurnRelay {
     return this.apply(envelope, frameParse.data);
   }
 
-  private async loadRunToken(
-    conversationId: string,
-    projectId: string,
-    turnId: string,
-  ): Promise<string | null> {
+  private async loadRunToken({
+    conversationId,
+    projectId,
+    turnId,
+  }: {
+    conversationId: string;
+    projectId: string;
+    turnId: string;
+  }): Promise<string | null> {
     // Cache only a REAL token. A null from a transient projection lag must NOT
     // be cached: the old `=== undefined` guard cached the null and dropped every
     // subsequent frame on the connection as no-run-token (prod: a first turn lost
@@ -265,10 +276,28 @@ export class LangyTurnRelay {
     // worker signed with, written before dispatch — so the first frames of a
     // brand-new conversation (whose RunToken projection is still queued) are
     // authenticated instead of dropped.
-    const fromHandoff = await this.deps.readHandoffRunToken?.({
-      conversationId,
-      turnId,
-    });
+    let fromHandoff: string | null | undefined;
+    try {
+      fromHandoff = await this.deps.readHandoffRunToken?.({
+        projectId,
+        conversationId,
+        turnId,
+      });
+    } catch (error) {
+      // Falling THROUGH to the projection is the entire point of the two-stage
+      // lookup, so a transient Redis blip on this hot path must not propagate
+      // out of handle() and tear down the whole relay stream.
+      this.deps.logger?.warn(
+        {
+          projectId,
+          conversationId,
+          turnId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "langy relay handoff runToken read failed; falling back to the projection",
+      );
+      fromHandoff = null;
+    }
     if (fromHandoff) {
       this.runToken = fromHandoff;
       return fromHandoff;

--- a/langwatch/src/server/app-layer/langy/streaming/langyTurnRelay.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/langyTurnRelay.ts
@@ -140,6 +140,19 @@ export interface LangyTurnRelayDeps {
     turnId: string;
     frameNonce: string;
   }): Promise<boolean>;
+  /**
+   * Read the runToken the worker was handed at dispatch, straight from the
+   * synchronous per-turn Redis handoff (keyed by conversation+turn). This is the
+   * EXACT token the manager signs its frames with, written before dispatch — so
+   * a first frame that outruns the async `RunToken` projection is authenticated
+   * instead of dropped as `no-run-token`. Returns null when no handoff exists
+   * (aged out past its TTL, or a legacy conversation with no token). Optional so
+   * unit tests can exercise the projection fallback in isolation.
+   */
+  readHandoffRunToken?(a: {
+    conversationId: string;
+    turnId: string;
+  }): Promise<string | null>;
   logger?: { warn(o: unknown, m: string): void; debug?(o: unknown, m: string): void };
 }
 
@@ -202,7 +215,11 @@ export class LangyTurnRelay {
     // Authenticity FIRST — no field is trusted until the MAC checks out. The
     // runToken is looked up by the (as-yet-unverified) conversationId; a wrong
     // conversationId simply yields a token the MAC won't match against.
-    const runToken = await this.loadRunToken(envelope.conversationId, envelope.projectId);
+    const runToken = await this.loadRunToken(
+      envelope.conversationId,
+      envelope.projectId,
+      envelope.turnId,
+    );
     if (runToken === null) {
       return this.reject({ reason: "no-run-token", envelope });
     }
@@ -236,14 +253,36 @@ export class LangyTurnRelay {
   private async loadRunToken(
     conversationId: string,
     projectId: string,
+    turnId: string,
   ): Promise<string | null> {
-    if (this.runToken === undefined) {
-      this.runToken = await this.deps.conversations.getRunToken({
-        projectId,
-        conversationId,
-      });
+    // Cache only a REAL token. A null from a transient projection lag must NOT
+    // be cached: the old `=== undefined` guard cached the null and dropped every
+    // subsequent frame on the connection as no-run-token (prod: a first turn lost
+    // its whole first ~5 minutes of progress frames).
+    if (this.runToken != null) return this.runToken;
+
+    // Synchronous source first: the per-turn handoff carries the EXACT token the
+    // worker signed with, written before dispatch — so the first frames of a
+    // brand-new conversation (whose RunToken projection is still queued) are
+    // authenticated instead of dropped.
+    const fromHandoff = await this.deps.readHandoffRunToken?.({
+      conversationId,
+      turnId,
+    });
+    if (fromHandoff) {
+      this.runToken = fromHandoff;
+      return fromHandoff;
     }
-    return this.runToken ?? null;
+
+    // Fallback: the durable RunToken projection. Covers a handoff that aged out
+    // past its TTL on a very long turn, and keeps working when no handoff dep is
+    // wired (unit tests).
+    const fromProjection = await this.deps.conversations.getRunToken({
+      projectId,
+      conversationId,
+    });
+    if (fromProjection) this.runToken = fromProjection;
+    return fromProjection;
   }
 
   private checkTurn(envelope: LangyFrameEnvelope): boolean {

--- a/langwatch/src/server/app-layer/langy/streaming/langyTurnSettlement.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/langyTurnSettlement.ts
@@ -20,7 +20,16 @@ import type { LangyStreamEntry } from "./langyTokenBuffer";
  *     settled.
  *
  * FAILED → `error` (carrying lastError); IDLE (completed) → `end`. Any other or
- * transitional status yields null (stay patient — do not guess a terminal).
+ * transitional status — including ARCHIVED and anything added later — yields
+ * null (stay patient; never guess a terminal).
+ *
+ * `status` is deliberately `string`, not the `LANGY_CONVERSATION_STATUS` union:
+ * it arrives from the conversation projection's bare string column
+ * (`getById(): { status: string }`), so narrowing here would only buy a cast at
+ * the call site that asserts something the data does not guarantee. Typo safety
+ * is already structural — every comparison below is against the exported
+ * constant, so a renamed or removed status fails to compile here, and an
+ * unrecognised value falls through to the safe `null`.
  */
 export function decideSyntheticTerminal({
   status,

--- a/langwatch/src/server/app-layer/langy/streaming/langyTurnSettlement.ts
+++ b/langwatch/src/server/app-layer/langy/streaming/langyTurnSettlement.ts
@@ -1,0 +1,50 @@
+import { LANGY_CONVERSATION_STATUS } from "~/server/event-sourcing/pipelines/langy-conversation-processing/schemas/constants";
+import type { LangyStreamEntry } from "./langyTokenBuffer";
+
+/**
+ * Decide whether to synthesize a terminal stream entry for a turn whose live
+ * terminal frame the durable buffer never received.
+ *
+ * `onTurnStream` tails the token buffer; when a refresh mid-turn misses the
+ * worker's terminal frame (its relay connection dropped before it), the buffer
+ * has no `end`/`error` and `follow()` would block until the hard per-turn
+ * deadline — leaving the UI on "Starting up…" for minutes though the turn already
+ * finished server-side.
+ *
+ * We synthesize a terminal ONLY when BOTH hold, so a live or still-starting turn
+ * is never cut off:
+ *   - the per-turn heartbeat is STALE — a running turn keeps a fresh one; AND
+ *   - the durable fold says the turn is no longer in flight. Its status flips to
+ *     ACTIVE/RUNNING at `agent_turn_accepted`, BEFORE any output, so even a cold
+ *     start (which streams nothing for its first ~10-20s) reads as in-flight, not
+ *     settled.
+ *
+ * FAILED → `error` (carrying lastError); IDLE (completed) → `end`. Any other or
+ * transitional status yields null (stay patient — do not guess a terminal).
+ */
+export function decideSyntheticTerminal({
+  status,
+  lastError,
+  heartbeatStale,
+}: {
+  status: string;
+  lastError: string | null;
+  heartbeatStale: boolean;
+}): LangyStreamEntry | null {
+  // A live turn keeps a fresh heartbeat — never synthesize over one.
+  if (!heartbeatStale) return null;
+
+  if (
+    status === LANGY_CONVERSATION_STATUS.ACTIVE ||
+    status === LANGY_CONVERSATION_STATUS.RUNNING
+  ) {
+    return null;
+  }
+  if (status === LANGY_CONVERSATION_STATUS.FAILED) {
+    return { type: "error", error: lastError ?? "Turn failed" };
+  }
+  if (status === LANGY_CONVERSATION_STATUS.IDLE) {
+    return { type: "end" };
+  }
+  return null;
+}

--- a/langwatch/src/server/routes/langy-relay.ts
+++ b/langwatch/src/server/routes/langy-relay.ts
@@ -20,6 +20,7 @@ import { getApp } from "~/server/app-layer/app";
 import { connection } from "~/server/redis";
 import { createLangyFrameDedup } from "~/server/app-layer/langy/streaming/langyFrameDedup";
 import { createLangyTokenBuffer } from "~/server/app-layer/langy/streaming/langyTokenBuffer";
+import { createLangyTurnHandoffStore } from "~/server/app-layer/langy/streaming/langyTurnHandoff";
 import { LangyTurnRelay } from "~/server/app-layer/langy/streaming/langyTurnRelay";
 import { createLogger } from "@langwatch/observability";
 import { getLangyRelayFramesCounter } from "~/server/metrics";
@@ -60,11 +61,18 @@ secured.access(relayPolicy()).post("/relay/frames", async (c) => {
   const body = c.req.raw.body;
   if (!body) return c.json({ error: "missing body" }, 400);
 
+  const handoffStore = createLangyTurnHandoffStore({ redis: connection });
   const relay = new LangyTurnRelay({
     conversations: getApp().langy.conversations,
     buffer: createLangyTokenBuffer({ redis: connection }),
     reserveFrameNonce: createLangyFrameDedup({ redis: connection })
       .reserveFrameNonce,
+    // Authenticate frames against the synchronous per-turn handoff token first
+    // (the exact one the worker signs with), so a first turn whose RunToken
+    // projection is still landing isn't dropped as no-run-token. Empty token
+    // (legacy conversation) falls through to the projection.
+    readHandoffRunToken: async ({ conversationId, turnId }) =>
+      (await handoffStore.read({ conversationId, turnId }))?.runToken || null,
     logger,
   });
 

--- a/langwatch/src/server/routes/langy-relay.ts
+++ b/langwatch/src/server/routes/langy-relay.ts
@@ -71,8 +71,15 @@ secured.access(relayPolicy()).post("/relay/frames", async (c) => {
     // (the exact one the worker signs with), so a first turn whose RunToken
     // projection is still landing isn't dropped as no-run-token. Empty token
     // (legacy conversation) falls through to the projection.
-    readHandoffRunToken: async ({ conversationId, turnId }) =>
-      (await handoffStore.read({ conversationId, turnId }))?.runToken || null,
+    readHandoffRunToken: async ({ projectId, conversationId, turnId }) => {
+      const handoff = await handoffStore.read({ conversationId, turnId });
+      // The handoff key is conversation+turn scoped, but conversation identity
+      // is project-scoped (`@@unique([projectId, ConversationId])`). Refuse a
+      // handoff stashed under a different project so a colliding conversation
+      // id can never hand this stream another tenant's runToken.
+      if (!handoff || handoff.projectId !== projectId) return null;
+      return handoff.runToken || null;
+    },
     logger,
   });
 

--- a/specs/langy/langy-dual-stream.feature
+++ b/specs/langy/langy-dual-stream.feature
@@ -140,6 +140,28 @@ Feature: Langy dual-stream — a raw token fast-path beside the durable event-so
     Then the relay handles that frame before the next frame is even sent
     And non-streaming request bodies are still delivered whole, exactly as before
 
+  # The worker signs its relay frames with the runToken it got synchronously from
+  # the per-turn handoff at dispatch, but the relay used to VERIFY them against the
+  # async `RunToken` projection — which, on a brand-new conversation, has not landed
+  # when the first frames arrive. The relay looked the token up once, cached the
+  # null, and dropped EVERY frame of that turn as `no-run-token` (prod: a first turn
+  # showed nothing for ~5 minutes while it was actually working). The relay now
+  # reads the handoff token first, and never caches a null.
+  @unit
+  Scenario: The first frames of a new turn authenticate against the handoff before the projection lands
+    Given a brand-new conversation whose worker is pushing frames
+    And the durable runToken projection has not landed yet
+    When the worker's first frame reaches the relay
+    Then the relay authenticates it against the synchronous handoff token
+    And the frame is applied to the durable buffer instead of dropped as no-run-token
+
+  @unit
+  Scenario: A transient runToken miss does not poison the whole connection
+    Given the relay's first runToken lookup for a turn returns nothing
+    When a later frame arrives after the token has become readable
+    Then the relay re-reads the token instead of reusing the cached miss
+    And the later frame is authenticated and applied
+
   # The durable token buffer used to hold tokens until ~64 words accumulated,
   # so short answers rendered nothing until the turn was nearly over.
   @unit

--- a/specs/langy/langy-dual-stream.feature
+++ b/specs/langy/langy-dual-stream.feature
@@ -125,6 +125,27 @@ Feature: Langy dual-stream — a raw token fast-path beside the durable event-so
     Then the optimistic Stream B text is gone
     And Stream A replays the buffered token tail so no work is lost
 
+  # A refresh that lands just as the turn finishes can miss the worker's terminal
+  # frame (its relay connection dropped before it), so the buffer has no end/error
+  # and the reconnected Stream A used to block until the hard per-turn deadline —
+  # the UI sat on "Starting up…" for minutes though the turn had finished. Stream A
+  # now watches the durable fold + per-turn heartbeat and synthesizes the missed
+  # terminal, but ONLY once the turn is provably settled so a live or cold-starting
+  # turn is never cut off.
+  @unit
+  Scenario: Stream A synthesizes the terminal a reconnect missed once the turn has settled
+    Given I reconnect to a turn whose terminal frame never reached the buffer
+    And the turn's durable fold has settled and its heartbeat has gone stale
+    When the reconnected Stream A finds no terminal on the live edge
+    Then it yields a synthesized end (or error, carrying the failure) and closes
+    And the client reconciles the full transcript from langy.messages
+
+  Scenario: Stream A stays patient while a turn is still live or cold-starting
+    Given I am watching a turn whose durable fold still reports it in flight
+    When no tokens arrive on the live edge for a while
+    Then Stream A keeps following and does not synthesize a terminal
+    And a turn that keeps a fresh heartbeat is never cut off
+
   # ---------------------------------------------------------------------------
   # Transport honesty: streaming must actually stream, end to end
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes both halves of the Langy relay problem behind the "Langy takes forever to load" report.

## Symptom A — a working turn looks frozen for minutes

A turn ran for **9.4 minutes** doing ~50 tool calls, and the UI showed **nothing**
the whole time. The turn completed fine server-side; the relay had **dropped all of
its progress frames as `no-run-token`**.

**Root cause.** The worker signs each relay frame with the per-conversation
`runToken` it got **synchronously from the Redis handoff** at dispatch. The relay
VERIFIED frames against the **async Prisma `RunToken` projection**, which on a
brand-new conversation hasn't landed when the first frames arrive — so `getRunToken`
returned `null`, and `loadRunToken` **cached that null** and dropped every frame on
the connection.

**Fix** (`langyTurnRelay.ts`, `langy-relay.ts`):
- Read the runToken from the **synchronous per-turn handoff first** (the exact token
  the worker signed with), falling back to the projection. Mirrors what
  `langyTurnAccess` already does for the browser side.
- **Never cache a null** — a transient miss is retried on the next frame.

## Symptom B — "Starting up…" hangs after a refresh

A refresh that lands as the turn finishes can miss the worker's terminal frame, so
the durable buffer has no `end`/`error`. The reconnected `onTurnStream` then blocks
in `follow()` until the hard `AGENT_CHAT_TIMEOUT_MS` deadline — the UI sits on
"Starting up…" for minutes though the turn already finished.

**Fix** (`langy.ts` `onTurnStream`, `langyTurnSettlement.ts`): while it tails the
live edge, a concurrent watcher polls the durable fold (`getById`) + the per-turn
heartbeat (`buffer.liveness`). When the turn is provably settled with no terminal in
the buffer, it aborts the follow and yields a **synthesized terminal** so the client
resolves (it reconciles the transcript via `langy.messages`).

**Safe by construction** — `decideSyntheticTerminal` synthesizes ONLY when BOTH:
- the per-turn heartbeat is **stale** (a live turn keeps a fresh one), AND
- the fold is **settled** (`IDLE`→`end`, `FAILED`→`error` with `lastError`).

The fold flips to `ACTIVE`/`RUNNING` at `agent_turn_accepted` — *before* any output —
so even a cold start (silent for its first ~10-20s) reads in-flight, never settled,
and can't be cut off. Two consecutive settled reads (~10s) are required so a
projection blip can't end a live stream; a real terminal on the buffer always wins.

## Tests

- `langyTurnRelay.unit.test.ts` — **25** (+2: handoff auth when the projection lags;
  transient null re-queried not cached).
- `langyTurnSettlement.unit.test.ts` — **7** (heartbeat-fresh / in-flight / idle /
  failed±lastError / unknown-status).
- Full langy streaming suite — **64** green.
- Specs: `langy-dual-stream.feature` (+4 scenarios).

The `onTurnStream` generator wiring (concurrent watcher + abort + cleanup) isn't
unit-imported by the suite; the type-check runs in CI. The settlement *decision* is
fully unit-tested in isolation, and a real terminal always takes precedence over a
synthesized one.

## Risk

Symptom A: small, contained (auth source + caching fix + route wiring; no schema
change; frame verification unchanged). Symptom B touches the `onTurnStream` streaming
generator — mitigated by the double-gate (heartbeat-stale AND fold-settled), the
two-poll confirmation, real-terminal precedence, and always awaiting the watcher
before the request ends. Worth a close look at the generator lifecycle in `langy.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Langy streaming reliability by synthesizing an end/error when a reconnect misses a terminal frame, without affecting turns that are still live or have fresh heartbeats.
  * Strengthened relay authentication by using a synchronous per-turn handoff run token when available, with fallback when it’s unavailable.
  * Adjusted run-token caching to avoid permanently rejecting transient “token not ready” states, allowing later frames to authenticate.
* **Tests**
  * Added unit coverage for synthetic terminal decisions and reconnect/settlement, plus handoff run-token timing and run-token retry/caching edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->