### PR TITLE
feat(ui): unify section navigation layouts

### DIFF
--- a/agentic-e2e-tests/tests/automations/automation-navigation.spec.ts
+++ b/agentic-e2e-tests/tests/automations/automation-navigation.spec.ts
@@ -11,9 +11,7 @@ test("automation overview keeps activity and setup guidance", async ({
 
   await page.goto(basePath);
   await expect(page.locator("h1", { hasText: "Overview" })).toBeVisible();
-  await expect(
-    page.locator(`a[href="${basePath}/alerts"]`),
-  ).toBeVisible();
+  await expect(page.locator(`a[href="${basePath}/alerts"]`)).toBeVisible();
   await expect(
     page.getByRole("link", { name: "Overview", exact: true }),
   ).toBeVisible();
@@ -24,7 +22,7 @@ test("automation overview keeps activity and setup guidance", async ({
   await expect(page.getByText("Flag failing evaluations")).toBeVisible();
   await expect(page.getByText("Build a dataset from errors")).toBeVisible();
   await expect(page.getByText("Queue for review")).toBeVisible();
-  await page.getByRole("button", { name: "Expand Library" }).click();
+  await page.getByRole("button", { name: "Expand Build" }).click();
   await expect(
     page.locator(`a[href="${basePath}"]`, { hasText: "Automations" }),
   ).toBeVisible();
@@ -49,10 +47,11 @@ test("automation overview keeps activity and setup guidance", async ({
   ).toBeVisible();
   await page.screenshot({ path: testInfo.outputPath("schedules.png") });
 
-  await page.getByRole("link", { name: "Automations", exact: true }).last().click();
+  await page
+    .getByRole("link", { name: "Automations", exact: true })
+    .last()
+    .click();
   await expect(page).toHaveURL(`${basePath}/automations`);
-  await expect(
-    page.locator("h1", { hasText: "Automations" }),
-  ).toBeVisible();
+  await expect(page.locator("h1", { hasText: "Automations" })).toBeVisible();
   await page.screenshot({ path: testInfo.outputPath("activity.png") });
 });

--- a/agentic-e2e-tests/tests/automations/automation-navigation.spec.ts
+++ b/agentic-e2e-tests/tests/automations/automation-navigation.spec.ts
@@ -31,9 +31,7 @@ test("automation overview keeps activity and setup guidance", async ({
   await page.getByRole("link", { name: "Alerts", exact: true }).last().click();
   await expect(page).toHaveURL(`${basePath}/alerts`);
   await expect(page.locator("h1", { hasText: "Alerts" })).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: "New alert" }).first(),
-  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "New alert" })).toHaveCount(1);
   await expect(page.getByText("Error spike")).toBeVisible();
   await expect(page.getByText("Traffic drop")).toBeVisible();
   await expect(page.getByText("Cost spike")).toBeVisible();
@@ -42,9 +40,9 @@ test("automation overview keeps activity and setup guidance", async ({
   await page.getByRole("link", { name: "Schedules", exact: true }).click();
   await expect(page).toHaveURL(`${basePath}/schedules`);
   await expect(page.locator("h1", { hasText: "Schedules" })).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: "New schedule" }).first(),
-  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "New schedule" })).toHaveCount(
+    1,
+  );
   await page.screenshot({ path: testInfo.outputPath("schedules.png") });
 
   await page
@@ -53,5 +51,8 @@ test("automation overview keeps activity and setup guidance", async ({
     .click();
   await expect(page).toHaveURL(`${basePath}/automations`);
   await expect(page.locator("h1", { hasText: "Automations" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "New automation" }),
+  ).toHaveCount(1);
   await page.screenshot({ path: testInfo.outputPath("activity.png") });
 });

--- a/agentic-e2e-tests/tests/navigation/shared-section-layout.spec.ts
+++ b/agentic-e2e-tests/tests/navigation/shared-section-layout.spec.ts
@@ -103,6 +103,22 @@ test("complex product areas share one local navigation layout", async ({
     expect(borderColor).not.toBe("rgba(0, 0, 0, 0)");
   }
 
+  const governanceNavigation = page.getByRole("navigation", {
+    name: "AI Governance navigation",
+  });
+  await governanceNavigation
+    .getByRole("link", { name: "Ingestion Sources", exact: true })
+    .click();
+  await expect(page).toHaveURL("/settings/governance/ingestion-sources");
+
+  const overviewBackground = await governanceNavigation
+    .getByRole("link", { name: "Overview", exact: true })
+    .evaluate((element) => getComputedStyle(element).backgroundColor);
+  const activeBackground = await governanceNavigation
+    .getByRole("link", { name: "Ingestion Sources", exact: true })
+    .evaluate((element) => getComputedStyle(element).backgroundColor);
+  expect(overviewBackground).not.toBe(activeBackground);
+
   await page.goto(sections[0]!.path(projectSlug));
   await page.getByRole("radio", { name: "Set theme to dark" }).click();
   await expect(

--- a/agentic-e2e-tests/tests/navigation/shared-section-layout.spec.ts
+++ b/agentic-e2e-tests/tests/navigation/shared-section-layout.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+
+import { getProjectSlug } from "../helpers";
+
+interface SectionCase {
+  name: string;
+  path: (projectSlug: string) => string;
+  sectionLabel: string;
+  pageHeading: string;
+  screenshot: string;
+}
+
+const sections: SectionCase[] = [
+  {
+    name: "Automations",
+    path: (projectSlug) => `/${projectSlug}/automations`,
+    sectionLabel: "Automations",
+    pageHeading: "Overview",
+    screenshot: "automations-shared-layout.png",
+  },
+  {
+    name: "AI Gateway",
+    path: () => "/settings/gateway/virtual-keys",
+    sectionLabel: "AI Gateway",
+    pageHeading: "Virtual Keys",
+    screenshot: "gateway-shared-layout.png",
+  },
+  {
+    name: "AI Governance",
+    path: () => "/governance",
+    sectionLabel: "AI Governance",
+    pageHeading: "AI Governance",
+    screenshot: "governance-shared-layout.png",
+  },
+];
+
+test("complex product areas share one local navigation layout", async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 2048, height: 1200 });
+  const projectSlug = await getProjectSlug(page);
+  const measurements: Array<{
+    name: string;
+    navigationWidth: number;
+    containerWidth: number;
+    borderColor: string;
+  }> = [];
+
+  for (const section of sections) {
+    await page.goto(section.path(projectSlug));
+
+    const navigation = page.getByRole("navigation", {
+      name: `${section.sectionLabel} navigation`,
+    });
+    const content = page.getByTestId("section-navigation-content");
+    const container = page.getByTestId("section-navigation-container");
+    const heading = page.getByRole("heading", {
+      name: section.pageHeading,
+      exact: true,
+    });
+
+    await expect(navigation).toBeVisible();
+    await expect(heading).toBeVisible();
+    await expect(navigation.getByTestId("section-navigation-title")).toHaveText(
+      section.sectionLabel,
+    );
+
+    const navigationBox = await navigation.boundingBox();
+    const contentBox = await content.boundingBox();
+    const containerBox = await container.boundingBox();
+    expect(navigationBox).not.toBeNull();
+    expect(contentBox).not.toBeNull();
+    expect(containerBox).not.toBeNull();
+    expect(navigationBox!.x).toBeLessThan(contentBox!.x);
+    expect(containerBox!.width).toBeLessThanOrEqual(1600);
+
+    measurements.push({
+      name: section.name,
+      navigationWidth: navigationBox!.width,
+      containerWidth: containerBox!.width,
+      borderColor: await navigation.evaluate(
+        (element) => getComputedStyle(element).borderRightColor,
+      ),
+    });
+
+    await page.screenshot({
+      path: testInfo.outputPath(section.screenshot),
+      fullPage: true,
+    });
+  }
+
+  expect(measurements.map(({ navigationWidth }) => navigationWidth)).toEqual([
+    220, 220, 220,
+  ]);
+  expect(
+    new Set(measurements.map(({ containerWidth }) => containerWidth)).size,
+  ).toBe(1);
+  expect(new Set(measurements.map(({ borderColor }) => borderColor)).size).toBe(
+    1,
+  );
+  for (const { borderColor } of measurements) {
+    expect(borderColor).not.toBe("rgb(0, 0, 0)");
+    expect(borderColor).not.toBe("rgba(0, 0, 0, 0)");
+  }
+
+  await page.goto(sections[0]!.path(projectSlug));
+  await page.getByRole("radio", { name: "Set theme to dark" }).click();
+  await expect(
+    page.getByRole("navigation", { name: "Automations navigation" }),
+  ).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath("automations-shared-layout-dark.png"),
+    fullPage: true,
+  });
+});

--- a/langwatch/src/components/MainMenu.tsx
+++ b/langwatch/src/components/MainMenu.tsx
@@ -220,7 +220,7 @@ export const MainMenu = React.memo(function MainMenu({
 
             <SidebarSection
               id="library"
-              label="Library"
+              label="Build"
               showExpanded={showExpanded}
               defaultExpanded={false}
               projectId={project?.id}

--- a/langwatch/src/components/__tests__/MainMenu.navigation.integration.test.tsx
+++ b/langwatch/src/components/__tests__/MainMenu.navigation.integration.test.tsx
@@ -106,7 +106,7 @@ describe("<MainMenu /> navigation", () => {
     expect(sectionControls).toEqual([
       "Collapse Observe",
       "Collapse Test",
-      "Expand Library",
+      "Expand Build",
       "Expand Govern",
     ]);
 
@@ -124,13 +124,13 @@ describe("<MainMenu /> navigation", () => {
   });
 
   /** @scenario Use sensible section defaults without a saved preference */
-  it("reveals the Library destinations in their existing order", async () => {
+  it("reveals the Build destinations in their existing order", async () => {
     const user = userEvent.setup();
     render(<MainMenu />, { wrapper: Wrapper });
 
     expect(screen.queryByRole("link", { name: "Prompts" })).toBeNull();
 
-    await user.click(screen.getByRole("button", { name: "Expand Library" }));
+    await user.click(screen.getByRole("button", { name: "Expand Build" }));
 
     const labels = visibleLinkLabels();
     const libraryStart = labels.indexOf("Prompts");

--- a/langwatch/src/components/gateway/AiGatewayLayout.tsx
+++ b/langwatch/src/components/gateway/AiGatewayLayout.tsx
@@ -1,12 +1,4 @@
 import {
-  Box,
-  Container,
-  HStack,
-  Spacer,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
-import {
   Brain,
   ExternalLink,
   Gauge,
@@ -17,10 +9,7 @@ import {
   Zap,
 } from "lucide-react";
 import { type PropsWithChildren } from "react";
-
-import { DashboardLayout } from "~/components/DashboardLayout";
-
-import { MenuLink } from "../MenuLink";
+import { SectionNavigationLayout } from "~/components/ui/layouts/SectionNavigationLayout";
 
 /**
  * Layout for `/ai-gateway/*` — mirrors GovernanceLayout pattern:
@@ -40,89 +29,58 @@ export default function AiGatewayLayout({
   pageTitle,
 }: PropsWithChildren<{ pageTitle?: string }>) {
   return (
-    <DashboardLayout orgScope pageTitle={pageTitle}>
-      <Box width="full" paddingY={4} paddingX={4}>
-        <Container maxW="container.xl" paddingX={0}>
-          <HStack alignItems="start" gap={6} width="full">
-            <Box
-              width="220px"
-              minWidth="220px"
-              borderRight="1px solid"
-              borderColor="border.muted"
-              paddingRight={4}
-            >
-              <VStack align="stretch" gap={1}>
-                <Text
-                  fontSize="xs"
-                  fontWeight="semibold"
-                  color="fg.muted"
-                  paddingX={3}
-                  paddingTop={1}
-                  paddingBottom={2}
-                  textTransform="uppercase"
-                  letterSpacing="wider"
-                >
-                  AI Gateway
-                </Text>
-                <MenuLink
-                  href={`/settings/gateway/virtual-keys`}
-                  includePath={`/settings/gateway/virtual-keys`}
-                  icon={<KeyRound size={14} />}
-                >
-                  Virtual Keys
-                </MenuLink>
-                <MenuLink
-                  href={`/settings/model-providers`}
-                  includePath={`/settings/model-providers`}
-                  icon={<Brain size={14} />}
-                  menuEnd={<ExternalLink size={12} aria-hidden />}
-                  target="_blank"
-                >
-                  Model Providers
-                </MenuLink>
-                <MenuLink
-                  href={`/settings/gateway/budgets`}
-                  includePath={`/settings/gateway/budgets`}
-                  icon={<Gauge size={14} />}
-                >
-                  Budgets
-                </MenuLink>
-                <MenuLink
-                  href={`/settings/gateway/cache-rules`}
-                  includePath={`/settings/gateway/cache-rules`}
-                  icon={<Zap size={14} />}
-                >
-                  Cache Rules
-                </MenuLink>
-                <MenuLink
-                  href={`/settings/gateway/guardrails`}
-                  includePath={`/settings/gateway/guardrails`}
-                  icon={<Shield size={14} />}
-                >
-                  Guardrails
-                </MenuLink>
-                <MenuLink
-                  href={`/settings/gateway/usage`}
-                  includePath={`/settings/gateway/usage`}
-                  icon={<LineChart size={14} />}
-                >
-                  Usage
-                </MenuLink>
-                <MenuLink
-                  href={`/settings/routing-policies`}
-                  includePath={`/settings/routing-policies`}
-                  icon={<Route size={14} />}
-                >
-                  Routing Policies
-                </MenuLink>
-              </VStack>
-            </Box>
-
-            <Box flex={1} minWidth={0}>{children}</Box>
-          </HStack>
-          <Spacer />
-        </Container>
-      </Box>
-    </DashboardLayout>
+    <SectionNavigationLayout
+      sectionLabel="AI Gateway"
+      orgScope
+      pageTitle={pageTitle}
+      navigationItems={[
+        {
+          label: "Virtual Keys",
+          href: "/settings/gateway/virtual-keys",
+          includePath: "/settings/gateway/virtual-keys",
+          icon: <KeyRound size={14} />,
+        },
+        {
+          label: "Model Providers",
+          href: "/settings/model-providers",
+          includePath: "/settings/model-providers",
+          icon: <Brain size={14} />,
+          menuEnd: <ExternalLink size={12} aria-hidden />,
+          target: "_blank",
+        },
+        {
+          label: "Budgets",
+          href: "/settings/gateway/budgets",
+          includePath: "/settings/gateway/budgets",
+          icon: <Gauge size={14} />,
+        },
+        {
+          label: "Cache Rules",
+          href: "/settings/gateway/cache-rules",
+          includePath: "/settings/gateway/cache-rules",
+          icon: <Zap size={14} />,
+        },
+        {
+          label: "Guardrails",
+          href: "/settings/gateway/guardrails",
+          includePath: "/settings/gateway/guardrails",
+          icon: <Shield size={14} />,
+        },
+        {
+          label: "Usage",
+          href: "/settings/gateway/usage",
+          includePath: "/settings/gateway/usage",
+          icon: <LineChart size={14} />,
+        },
+        {
+          label: "Routing Policies",
+          href: "/settings/routing-policies",
+          includePath: "/settings/routing-policies",
+          icon: <Route size={14} />,
+        },
+      ]}
+    >
+      {children}
+    </SectionNavigationLayout>
   );
 }

--- a/langwatch/src/components/governance/GovernanceLayout.tsx
+++ b/langwatch/src/components/governance/GovernanceLayout.tsx
@@ -37,7 +37,6 @@ export default function GovernanceLayout({
         {
           label: "Overview",
           href: "/governance",
-          includePath: "/governance",
           icon: <Eye size={14} />,
         },
         {

--- a/langwatch/src/components/governance/GovernanceLayout.tsx
+++ b/langwatch/src/components/governance/GovernanceLayout.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Container,
-  HStack,
-  Spacer,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
+import { Box, Text } from "@chakra-ui/react";
 import {
   AlertTriangle,
   Eye,
@@ -15,10 +8,7 @@ import {
   Wallet,
 } from "lucide-react";
 import { type PropsWithChildren } from "react";
-
-import { DashboardLayout } from "~/components/DashboardLayout";
-
-import { MenuLink } from "../MenuLink";
+import { SectionNavigationLayout } from "~/components/ui/layouts/SectionNavigationLayout";
 
 /**
  * Layout for `/governance` - wraps DashboardLayout in `orgScope` mode
@@ -39,90 +29,59 @@ export default function GovernanceLayout({
   pageTitle,
 }: PropsWithChildren<{ pageTitle?: string }>) {
   return (
-    <DashboardLayout orgScope pageTitle={pageTitle}>
-      <Box width="full" paddingY={4} paddingX={4}>
-        <Container maxW="container.xl" paddingX={0}>
-          <HStack alignItems="start" gap={6} width="full">
-            <Box
-              width="220px"
-              minWidth="220px"
-              borderRight="1px solid"
-              borderColor="border.muted"
-              paddingRight={4}
-            >
-              <VStack align="stretch" gap={1}>
-                <Text
-                  fontSize="xs"
-                  fontWeight="semibold"
-                  color="fg.muted"
-                  paddingX={3}
-                  paddingTop={1}
-                  paddingBottom={2}
-                  textTransform="uppercase"
-                  letterSpacing="wider"
-                >
-                  AI Governance
-                </Text>
-                <MenuLink
-                  href="/governance"
-                  includePath="/governance"
-                  icon={<Eye size={14} />}
-                >
-                  Overview
-                </MenuLink>
-                <MenuLink
-                  href="/settings/governance/ingestion-sources"
-                  includePath="/settings/governance/ingestion-sources"
-                  icon={<PlugZap size={14} />}
-                >
-                  Ingestion Sources
-                </MenuLink>
-                <MenuLink
-                  href="/settings/governance/anomaly-rules"
-                  includePath="/settings/governance/anomaly-rules"
-                  icon={<AlertTriangle size={14} />}
-                >
-                  Anomaly Rules
-                </MenuLink>
-                <MenuLink
-                  href="/settings/routing-policies"
-                  includePath="/settings/routing-policies"
-                  icon={<Route size={14} />}
-                >
-                  Routing Policies
-                </MenuLink>
-                <MenuLink
-                  href="/settings/governance/tool-catalog"
-                  includePath="/settings/governance/tool-catalog"
-                  icon={<PackageOpen size={14} />}
-                >
-                  Tool Catalog
-                </MenuLink>
-                <MenuLink
-                  href="/settings/governance/departments"
-                  includePath="/settings/governance/departments"
-                  icon={<Wallet size={14} />}
-                >
-                  Departments
-                </MenuLink>
-              </VStack>
-              <Box paddingX={3} paddingTop={4}>
-                <Text fontSize="xs" color="fg.subtle" lineHeight="1.5">
-                  Sub-pages above are admin-config surfaces under
-                  Settings. This Overview is the daily-use home,
-                  plus a few lightweight org-policy toggles at the
-                  bottom.
-                </Text>
-              </Box>
-            </Box>
-
-            <Box flex={1} minWidth={0}>
-              {children}
-            </Box>
-          </HStack>
-          <Spacer />
-        </Container>
-      </Box>
-    </DashboardLayout>
+    <SectionNavigationLayout
+      sectionLabel="AI Governance"
+      orgScope
+      pageTitle={pageTitle}
+      navigationItems={[
+        {
+          label: "Overview",
+          href: "/governance",
+          includePath: "/governance",
+          icon: <Eye size={14} />,
+        },
+        {
+          label: "Ingestion Sources",
+          href: "/settings/governance/ingestion-sources",
+          includePath: "/settings/governance/ingestion-sources",
+          icon: <PlugZap size={14} />,
+        },
+        {
+          label: "Anomaly Rules",
+          href: "/settings/governance/anomaly-rules",
+          includePath: "/settings/governance/anomaly-rules",
+          icon: <AlertTriangle size={14} />,
+        },
+        {
+          label: "Routing Policies",
+          href: "/settings/routing-policies",
+          includePath: "/settings/routing-policies",
+          icon: <Route size={14} />,
+        },
+        {
+          label: "Tool Catalog",
+          href: "/settings/governance/tool-catalog",
+          includePath: "/settings/governance/tool-catalog",
+          icon: <PackageOpen size={14} />,
+        },
+        {
+          label: "Departments",
+          href: "/settings/governance/departments",
+          includePath: "/settings/governance/departments",
+          icon: <Wallet size={14} />,
+        },
+      ]}
+      sidebarFooter={
+        <Box paddingX={3} paddingTop={4}>
+          <Text fontSize="xs" color="fg.subtle" lineHeight="1.5">
+            Sub-pages above are admin-config surfaces under Settings. This
+            Overview is the daily-use home, plus a few lightweight org-policy
+            toggles at the bottom.
+          </Text>
+        </Box>
+      }
+    >
+      {children}
+    </SectionNavigationLayout>
   );
 }

--- a/langwatch/src/components/sidebar/__tests__/SidebarSection.integration.test.tsx
+++ b/langwatch/src/components/sidebar/__tests__/SidebarSection.integration.test.tsx
@@ -99,16 +99,16 @@ describe("<SidebarSection />", () => {
   });
 
   /** @scenario Use sensible section defaults without a saved preference */
-  it("supports Library being collapsed by default", () => {
+  it("supports Build being collapsed by default", () => {
     renderSection({
       id: "library",
-      label: "Library",
+      label: "Build",
       defaultExpanded: false,
     });
 
     expect(screen.queryByText("Section destination")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Expand Library" }),
+      screen.getByRole("button", { name: "Expand Build" }),
     ).toBeInTheDocument();
   });
 
@@ -118,13 +118,13 @@ describe("<SidebarSection />", () => {
 
     renderSection({
       id: "library",
-      label: "Library",
+      label: "Build",
       defaultExpanded: false,
     });
 
     expect(screen.getByText("Section destination")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Collapse Library" }),
+      screen.getByRole("button", { name: "Collapse Build" }),
     ).toBeInTheDocument();
   });
 });

--- a/langwatch/src/components/ui/layouts/SectionNavigationLayout.tsx
+++ b/langwatch/src/components/ui/layouts/SectionNavigationLayout.tsx
@@ -1,0 +1,114 @@
+import { Box, Container, HStack, Text, VStack } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+import { DashboardLayout } from "~/components/DashboardLayout";
+import { MenuLink } from "~/components/MenuLink";
+
+export interface SectionNavigationItem {
+  label: string;
+  href: string;
+  includePath?: string;
+  icon?: ReactNode;
+  menuEnd?: ReactNode;
+  target?: string;
+}
+
+interface SectionNavigationFrameProps {
+  children: ReactNode;
+  sectionLabel: string;
+  navigationItems: SectionNavigationItem[];
+  sidebarFooter?: ReactNode;
+}
+
+interface SectionNavigationLayoutProps extends SectionNavigationFrameProps {
+  pageTitle?: string;
+  orgScope?: boolean;
+}
+
+/**
+ * Shared shell for product areas with their own local navigation. Keeping the
+ * width, divider, title placement, and content constraint here prevents these
+ * workspaces from drifting into subtly different layouts.
+ */
+export function SectionNavigationLayout({
+  children,
+  sectionLabel,
+  navigationItems,
+  sidebarFooter,
+  pageTitle,
+  orgScope = false,
+}: SectionNavigationLayoutProps) {
+  return (
+    <DashboardLayout orgScope={orgScope} pageTitle={pageTitle}>
+      <SectionNavigationFrame
+        sectionLabel={sectionLabel}
+        navigationItems={navigationItems}
+        sidebarFooter={sidebarFooter}
+      >
+        {children}
+      </SectionNavigationFrame>
+    </DashboardLayout>
+  );
+}
+
+export function SectionNavigationFrame({
+  children,
+  sectionLabel,
+  navigationItems,
+  sidebarFooter,
+}: SectionNavigationFrameProps) {
+  return (
+    <Box width="full" padding={4} data-testid="section-navigation-layout">
+      <Container
+        maxW="1600px"
+        paddingX={0}
+        data-testid="section-navigation-container"
+      >
+        <HStack alignItems="start" gap={6} width="full">
+          <Box
+            as="nav"
+            aria-label={`${sectionLabel} navigation`}
+            width="220px"
+            minWidth="220px"
+            flexShrink={0}
+            borderRightWidth="1px"
+            borderRightColor="border.muted"
+            paddingRight={4}
+          >
+            <VStack align="stretch" gap={1}>
+              <Text
+                data-testid="section-navigation-title"
+                fontSize="xs"
+                fontWeight="semibold"
+                color="fg.muted"
+                paddingX={3}
+                paddingTop={1}
+                paddingBottom={2}
+                textTransform="uppercase"
+                letterSpacing="wider"
+              >
+                {sectionLabel}
+              </Text>
+              {navigationItems.map((item) => (
+                <MenuLink
+                  key={`${item.href}:${item.label}`}
+                  href={item.href}
+                  includePath={item.includePath}
+                  icon={item.icon}
+                  menuEnd={item.menuEnd}
+                  target={item.target}
+                >
+                  {item.label}
+                </MenuLink>
+              ))}
+            </VStack>
+            {sidebarFooter}
+          </Box>
+
+          <Box flex={1} minWidth={0} data-testid="section-navigation-content">
+            {children}
+          </Box>
+        </HStack>
+      </Container>
+    </Box>
+  );
+}

--- a/langwatch/src/components/ui/layouts/SectionNavigationLayout.tsx
+++ b/langwatch/src/components/ui/layouts/SectionNavigationLayout.tsx
@@ -50,6 +50,10 @@ export function SectionNavigationLayout({
   );
 }
 
+/**
+ * Renders the shared navigation rail and adjacent content without the outer
+ * dashboard chrome.
+ */
 export function SectionNavigationFrame({
   children,
   sectionLabel,

--- a/langwatch/src/components/ui/layouts/__tests__/SectionNavigationLayout.integration.test.tsx
+++ b/langwatch/src/components/ui/layouts/__tests__/SectionNavigationLayout.integration.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * @see specs/navigation/shared-section-navigation-layout.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+import { SectionNavigationFrame } from "../SectionNavigationLayout";
+
+describe("SectionNavigationFrame", () => {
+  it("keeps the section title and links beside the page content", () => {
+    render(
+      <MemoryRouter initialEntries={["/automations"]}>
+        <ChakraProvider value={defaultSystem}>
+          <SectionNavigationFrame
+            sectionLabel="Automations"
+            navigationItems={[
+              { label: "Overview", href: "/automations" },
+              { label: "Alerts", href: "/automations/alerts" },
+            ]}
+          >
+            <h1>Overview</h1>
+          </SectionNavigationFrame>
+        </ChakraProvider>
+      </MemoryRouter>,
+    );
+
+    const navigation = screen.getByRole("navigation", {
+      name: "Automations navigation",
+    });
+    const content = screen.getByTestId("section-navigation-content");
+
+    expect(within(navigation).getByText("Automations")).toBeInTheDocument();
+    expect(
+      within(navigation).getByRole("link", { name: "Overview" }),
+    ).toHaveAttribute("href", "/automations");
+    expect(
+      within(content).getByRole("heading", { name: "Overview" }),
+    ).toBeInTheDocument();
+    expect(navigation.nextElementSibling).toBe(content);
+  });
+});

--- a/langwatch/src/pages/[project]/automations.tsx
+++ b/langwatch/src/pages/[project]/automations.tsx
@@ -4,7 +4,6 @@ import {
   Code,
   HStack,
   SimpleGrid,
-  Spacer,
   Table,
   Text,
   VStack,
@@ -17,7 +16,6 @@ import {
   Eye,
   Filter,
   MoreVertical,
-  Plus,
   Trash,
   TrendingUp,
   Zap,
@@ -62,7 +60,7 @@ type AutomationSection = "overview" | "automations" | "alerts" | "schedules";
 
 const sectionDetails: Record<
   AutomationSection,
-  { title: string; description: string; newLabel?: string }
+  { title: string; description: string }
 > = {
   overview: {
     title: "Overview",
@@ -72,19 +70,16 @@ const sectionDetails: Record<
   automations: {
     title: "Automations",
     description: "Act on every incoming trace that matches your filters.",
-    newLabel: "New automation",
   },
   alerts: {
     title: "Alerts",
     description:
       "Get told when a metric crosses a threshold and when it recovers.",
-    newLabel: "New alert",
   },
   schedules: {
     title: "Schedules",
     description:
       "Send a dashboard, graph, or trace table on a recurring cadence.",
-    newLabel: "New schedule",
   },
 };
 
@@ -503,25 +498,6 @@ function AutomationsPage() {
     >
       <PageLayout.Header>
         <PageLayout.Heading>{details.title}</PageLayout.Heading>
-        <Spacer />
-        {section !== "overview" && (
-          <Button
-            colorPalette="orange"
-            size="sm"
-            onClick={() =>
-              openDrawer(
-                "automation",
-                section === "alerts"
-                  ? { initialSource: "customGraph" }
-                  : section === "schedules"
-                    ? { initialSource: "report" }
-                    : {},
-              )
-            }
-          >
-            <Plus size={16} /> {details.newLabel}
-          </Button>
-        )}
       </PageLayout.Header>
       <Box padding={6} width="full">
         <VStack align="stretch" gap={6} width="full">

--- a/langwatch/src/pages/[project]/automations.tsx
+++ b/langwatch/src/pages/[project]/automations.tsx
@@ -25,8 +25,8 @@ import {
 import { FilterDisplay } from "~/components/automations/FilterDisplay";
 import { DashboardLayout } from "~/components/DashboardLayout";
 import { HoverableBigText } from "~/components/HoverableBigText";
-import { MenuLink } from "~/components/MenuLink";
 import { PageLayout } from "~/components/ui/layouts/PageLayout";
+import { SectionNavigationLayout } from "~/components/ui/layouts/SectionNavigationLayout";
 import { Link } from "~/components/ui/link";
 import { Menu } from "~/components/ui/menu";
 import { Switch } from "~/components/ui/switch";
@@ -476,7 +476,31 @@ function AutomationsPage() {
   }, [reportSchedules.data, statsByTriggerId, triggers.data]);
 
   return (
-    <DashboardLayout>
+    <SectionNavigationLayout
+      sectionLabel="Automations"
+      navigationItems={[
+        {
+          label: "Overview",
+          href: basePath,
+          icon: <Eye size={14} />,
+        },
+        {
+          label: "Automations",
+          href: `${basePath}/automations`,
+          icon: <Zap size={14} />,
+        },
+        {
+          label: "Alerts",
+          href: `${basePath}/alerts`,
+          icon: <TrendingUp size={14} />,
+        },
+        {
+          label: "Schedules",
+          href: `${basePath}/schedules`,
+          icon: <Calendar size={14} />,
+        },
+      ]}
+    >
       <PageLayout.Header>
         <PageLayout.Heading>{details.title}</PageLayout.Heading>
         <Spacer />
@@ -499,511 +523,435 @@ function AutomationsPage() {
           </Button>
         )}
       </PageLayout.Header>
-      <Box padding={{ base: 4, md: 6 }} width="full">
-        <HStack
-          align="start"
-          gap={6}
-          width="full"
-          flexWrap={{ base: "wrap", md: "nowrap" }}
-        >
-          <Box
-            width={{ base: "full", md: "220px" }}
-            minWidth={{ md: "220px" }}
-            borderRight={{ md: "1px solid" }}
-            borderColor="border.muted"
-            paddingRight={{ md: 4 }}
-          >
-            <VStack align="stretch" gap={1}>
-              <Text
-                fontSize="xs"
-                fontWeight="semibold"
-                color="fg.muted"
-                paddingX={3}
-                paddingTop={1}
-                paddingBottom={2}
-                textTransform="uppercase"
-                letterSpacing="wider"
-              >
-                Automations
-              </Text>
-              <MenuLink href={basePath} icon={<Eye size={14} />}>
-                Overview
-              </MenuLink>
-              <MenuLink
-                href={`${basePath}/automations`}
-                icon={<Zap size={14} />}
-              >
-                Automations
-              </MenuLink>
-              <MenuLink
-                href={`${basePath}/alerts`}
-                icon={<TrendingUp size={14} />}
-              >
-                Alerts
-              </MenuLink>
-              <MenuLink
-                href={`${basePath}/schedules`}
-                icon={<Calendar size={14} />}
-              >
-                Schedules
-              </MenuLink>
-            </VStack>
-          </Box>
-          <Box flex={1} minWidth={0} maxWidth="1200px" marginX="auto">
-            <VStack align="stretch" gap={6} width="full">
-              <Text textStyle="sm" color="fg.muted">
-                {details.description}
-              </Text>
+      <Box padding={6} width="full">
+        <VStack align="stretch" gap={6} width="full">
+          <Text textStyle="sm" color="fg.muted">
+            {details.description}
+          </Text>
 
-              {isLoading ? (
-                <Text textStyle="sm" color="fg.muted">
-                  Loading...
-                </Text>
-              ) : (
-                <>
-                  {section === "alerts" && (
-                    <VStack align="stretch" gap={4}>
-                      <SectionHeader
-                        icon={<TrendingUp size={18} />}
-                        accent="orange"
-                        title="Alerts"
-                        count={alerts.length}
-                        summary="Get told when a metric crosses a threshold, and again when it recovers."
-                        details="An alert watches one series on an analytics graph. When the value crosses your threshold it notifies your channel; when it returns to normal it sends a recovery notice."
-                        addLabel="New alert"
-                        onAdd={() =>
-                          openDrawer("automation", {
-                            initialSource: "customGraph",
-                          })
-                        }
-                      />
-                      {alerts.length === 0 ? (
-                        <UseCaseStrip
-                          kind="alert"
-                          onOpen={(prefill) =>
-                            openDrawer("automation", prefill)
-                          }
-                        />
-                      ) : (
-                        <TableShell>
-                          <Table.Root variant="line" width="full">
-                            <Table.Header>
-                              <Table.Row>
-                                <Table.ColumnHeader>Name</Table.ColumnHeader>
-                                <Table.ColumnHeader>Watches</Table.ColumnHeader>
-                                <Table.ColumnHeader whiteSpace="nowrap">
-                                  Fires when
-                                </Table.ColumnHeader>
-                                <Table.ColumnHeader>
-                                  Notifies
-                                </Table.ColumnHeader>
-                                <Table.ColumnHeader whiteSpace="nowrap">
-                                  <MetricHeader
-                                    label="Last fired"
-                                    help="When this alert last crossed its threshold and notified you."
+          {isLoading ? (
+            <Text textStyle="sm" color="fg.muted">
+              Loading...
+            </Text>
+          ) : (
+            <>
+              {section === "alerts" && (
+                <VStack align="stretch" gap={4}>
+                  <SectionHeader
+                    icon={<TrendingUp size={18} />}
+                    accent="orange"
+                    title="Alerts"
+                    count={alerts.length}
+                    summary="Get told when a metric crosses a threshold, and again when it recovers."
+                    details="An alert watches one series on an analytics graph. When the value crosses your threshold it notifies your channel; when it returns to normal it sends a recovery notice."
+                    addLabel="New alert"
+                    onAdd={() =>
+                      openDrawer("automation", {
+                        initialSource: "customGraph",
+                      })
+                    }
+                  />
+                  {alerts.length === 0 ? (
+                    <UseCaseStrip
+                      kind="alert"
+                      onOpen={(prefill) => openDrawer("automation", prefill)}
+                    />
+                  ) : (
+                    <TableShell>
+                      <Table.Root variant="line" width="full">
+                        <Table.Header>
+                          <Table.Row>
+                            <Table.ColumnHeader>Name</Table.ColumnHeader>
+                            <Table.ColumnHeader>Watches</Table.ColumnHeader>
+                            <Table.ColumnHeader whiteSpace="nowrap">
+                              Fires when
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader>Notifies</Table.ColumnHeader>
+                            <Table.ColumnHeader whiteSpace="nowrap">
+                              <MetricHeader
+                                label="Last fired"
+                                help="When this alert last crossed its threshold and notified you."
+                              />
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader whiteSpace="nowrap">
+                              <MetricHeader
+                                label="Status"
+                                help="Firing while the metric is past its threshold, back to OK when it recovers."
+                              />
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader>Active</Table.ColumnHeader>
+                            <Table.ColumnHeader />
+                          </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                          {alerts.map((trigger) => {
+                            const actionParams =
+                              trigger.actionParams as TriggerActionParams;
+                            const stats = statsByTriggerId.get(trigger.id);
+                            return (
+                              <Table.Row {...sharedRowProps(trigger)}>
+                                <Table.Cell fontWeight="medium">
+                                  {trigger.name}
+                                </Table.Cell>
+                                <Table.Cell maxWidth="260px">
+                                  <AlertSubjectCell
+                                    graphName={
+                                      trigger.customGraph?.name ?? null
+                                    }
+                                    graph={graphJsonById.get(
+                                      trigger.customGraphId ?? "",
+                                    )}
+                                    seriesName={actionParams.seriesName}
                                   />
-                                </Table.ColumnHeader>
-                                <Table.ColumnHeader whiteSpace="nowrap">
-                                  <MetricHeader
-                                    label="Status"
-                                    help="Firing while the metric is past its threshold, back to OK when it recovers."
+                                </Table.Cell>
+                                <Table.Cell whiteSpace="nowrap">
+                                  <AlertRuleCell actionParams={actionParams} />
+                                </Table.Cell>
+                                <Table.Cell>
+                                  {actionItems(trigger.action, actionParams)}
+                                </Table.Cell>
+                                <Table.Cell whiteSpace="nowrap">
+                                  <LastFiredCell
+                                    trigger={trigger}
+                                    stats={stats}
                                   />
-                                </Table.ColumnHeader>
-                                <Table.ColumnHeader>Active</Table.ColumnHeader>
-                                <Table.ColumnHeader />
+                                </Table.Cell>
+                                <Table.Cell whiteSpace="nowrap">
+                                  <FiringStatus
+                                    firing={!!stats?.currentlyFiring}
+                                  />
+                                </Table.Cell>
+                                {activeCell(trigger)}
+                                <Table.Cell>
+                                  {rowActionsMenu(trigger)}
+                                </Table.Cell>
                               </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                              {alerts.map((trigger) => {
-                                const actionParams =
-                                  trigger.actionParams as TriggerActionParams;
-                                const stats = statsByTriggerId.get(trigger.id);
-                                return (
-                                  <Table.Row {...sharedRowProps(trigger)}>
-                                    <Table.Cell fontWeight="medium">
-                                      {trigger.name}
-                                    </Table.Cell>
-                                    <Table.Cell maxWidth="260px">
-                                      <AlertSubjectCell
-                                        graphName={
-                                          trigger.customGraph?.name ?? null
-                                        }
-                                        graph={graphJsonById.get(
-                                          trigger.customGraphId ?? "",
-                                        )}
-                                        seriesName={actionParams.seriesName}
+                            );
+                          })}
+                        </Table.Body>
+                      </Table.Root>
+                    </TableShell>
+                  )}
+                </VStack>
+              )}
+
+              {section === "overview" && (
+                <VStack align="stretch" gap={8} width="full">
+                  <SimpleGrid columns={{ base: 1, md: 3 }} gap={4}>
+                    <StatTile
+                      label="Firing now"
+                      value={overview.firingNow}
+                      sub={
+                        overview.firingNow > 0
+                          ? "alerts over their threshold"
+                          : "all clear"
+                      }
+                      alert={overview.firingNow > 0}
+                    />
+                    <StatTile
+                      label="Fired (30 days)"
+                      value={overview.fired30d.toLocaleString()}
+                      sub="across every automation"
+                    />
+                    <StatTile
+                      label="Next scheduled"
+                      value={
+                        overview.next
+                          ? (formatTimeAgo(overview.next.at) ?? "—")
+                          : "—"
+                      }
+                      sub={overview.nextName ?? "no schedules queued"}
+                    />
+                  </SimpleGrid>
+
+                  <VStack align="stretch" gap={3} width="full">
+                    <OverviewSectionHeading
+                      title="Recent activity"
+                      summary="See what alerts, schedules, and automations have done recently."
+                    />
+                    <AutomationsHistory
+                      fires={activity.data ?? []}
+                      triggers={triggers.data ?? []}
+                      isLoading={activity.isLoading}
+                      onOpenAutomation={(triggerId) =>
+                        openDrawer("viewAutomation", {
+                          automationId: triggerId,
+                        })
+                      }
+                    />
+                  </VStack>
+
+                  <VStack align="stretch" gap={4} width="full">
+                    <OverviewSectionHeading
+                      title="Popular uses"
+                      summary="Start from a common workflow and tailor it to your project."
+                    />
+                    <VStack align="stretch" gap={2}>
+                      <Text
+                        textStyle="xs"
+                        fontWeight="semibold"
+                        color="fg.muted"
+                      >
+                        Alerts
+                      </Text>
+                      <UseCaseStrip
+                        kind="alert"
+                        showLabel={false}
+                        onOpen={(prefill) => openDrawer("automation", prefill)}
+                      />
+                    </VStack>
+                    <VStack align="stretch" gap={2}>
+                      <Text
+                        textStyle="xs"
+                        fontWeight="semibold"
+                        color="fg.muted"
+                      >
+                        Automations
+                      </Text>
+                      <UseCaseStrip
+                        kind="automation"
+                        showLabel={false}
+                        onOpen={(prefill) => openDrawer("automation", prefill)}
+                      />
+                    </VStack>
+                  </VStack>
+                </VStack>
+              )}
+
+              {section === "schedules" && (
+                <VStack align="stretch" gap={4}>
+                  <SectionHeader
+                    icon={<Calendar size={18} />}
+                    accent="purple"
+                    title="Schedules"
+                    count={reports.length}
+                    summary="Send a dashboard, a graph, or a table of traces on a recurring schedule."
+                    details="A schedule bundles a dashboard, a single graph, or a top-N trace table into a Slack or email digest on the schedule you set."
+                    addLabel="New schedule"
+                    onAdd={() =>
+                      openDrawer("automation", { initialSource: "report" })
+                    }
+                  />
+                  {reports.length === 0 ? (
+                    <EmptyHint>
+                      No schedules yet. Create one for a recurring Slack or
+                      email digest.
+                    </EmptyHint>
+                  ) : (
+                    <TableShell>
+                      <Table.Root variant="line" width="full">
+                        <Table.Header>
+                          <Table.Row>
+                            <Table.ColumnHeader>Name</Table.ColumnHeader>
+                            <Table.ColumnHeader>Sends</Table.ColumnHeader>
+                            <Table.ColumnHeader whiteSpace="nowrap">
+                              Schedule
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader whiteSpace="nowrap">
+                              <MetricHeader
+                                label="Next run"
+                                help="When this next goes out, straight from the scheduler. A paused schedule has no next run."
+                              />
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader whiteSpace="nowrap">
+                              <MetricHeader
+                                label="Last run"
+                                help="The last time this was sent."
+                              />
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader>Delivery</Table.ColumnHeader>
+                            <Table.ColumnHeader>Active</Table.ColumnHeader>
+                            <Table.ColumnHeader />
+                          </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                          {reports.map((trigger) => {
+                            const actionParams =
+                              trigger.actionParams as TriggerActionParams;
+                            const schedule = (
+                              actionParams as {
+                                schedule?: {
+                                  cron?: string;
+                                  timezone?: string;
+                                };
+                              }
+                            ).schedule;
+                            return (
+                              <Table.Row
+                                key={trigger.id}
+                                data-trigger-id={trigger.id}
+                                cursor="pointer"
+                                _hover={{ bg: "bg.muted" }}
+                                onClick={() =>
+                                  openDrawer("automation", {
+                                    automationId: trigger.id,
+                                  })
+                                }
+                              >
+                                <Table.Cell fontWeight="medium">
+                                  {trigger.name}
+                                </Table.Cell>
+                                <Table.Cell>
+                                  <ReportSubjectCell
+                                    actionParams={actionParams}
+                                    graphNameById={graphNameById}
+                                  />
+                                </Table.Cell>
+                                <Table.Cell whiteSpace="nowrap">
+                                  <Text textStyle="sm">
+                                    {schedule?.cron
+                                      ? describeSchedule(
+                                          schedule.cron,
+                                          schedule.timezone ?? "UTC",
+                                        )
+                                      : "Not set"}
+                                  </Text>
+                                </Table.Cell>
+                                <ReportRunCells
+                                  schedule={scheduleByTriggerId.get(trigger.id)}
+                                  loading={reportSchedules.isLoading}
+                                />
+                                <Table.Cell>
+                                  {trigger.action === "SEND_SLACK_MESSAGE"
+                                    ? "Slack"
+                                    : "Email"}
+                                </Table.Cell>
+                                {activeCell(trigger)}
+                                <Table.Cell>
+                                  {rowActionsMenu(trigger)}
+                                </Table.Cell>
+                              </Table.Row>
+                            );
+                          })}
+                        </Table.Body>
+                      </Table.Root>
+                    </TableShell>
+                  )}
+                </VStack>
+              )}
+
+              {section === "automations" && (
+                <VStack align="stretch" gap={4}>
+                  <SectionHeader
+                    icon={<Zap size={18} />}
+                    accent="blue"
+                    title="Automations"
+                    count={traceAutomations.length}
+                    summary="Act on every incoming trace that matches your filters."
+                    details="An automation runs on each trace matching your filters: post to Slack or email, add rows to a dataset, or queue traces for annotation."
+                    addLabel="New automation"
+                    onAdd={() => openDrawer("automation", {})}
+                  />
+                  {traceAutomations.length === 0 ? (
+                    <UseCaseStrip
+                      kind="automation"
+                      onOpen={(prefill) => openDrawer("automation", prefill)}
+                    />
+                  ) : (
+                    <TableShell>
+                      <Table.Root variant="line" width="full">
+                        <Table.Header>
+                          <Table.Row>
+                            <Table.ColumnHeader>Name</Table.ColumnHeader>
+                            <Table.ColumnHeader>Acts on</Table.ColumnHeader>
+                            <Table.ColumnHeader>Then</Table.ColumnHeader>
+                            <Table.ColumnHeader whiteSpace="nowrap">
+                              <MetricHeader
+                                label="Last fired"
+                                help="When this automation last matched a trace and ran its action. Automations on a digest schedule also show when the next bundled send is due."
+                              />
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader whiteSpace="nowrap">
+                              <MetricHeader
+                                label="Fires (30d)"
+                                help="Times this automation fired in the last 30 days."
+                              />
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader>Active</Table.ColumnHeader>
+                            <Table.ColumnHeader />
+                          </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                          {traceAutomations.map((trigger) => {
+                            const actionParams =
+                              trigger.actionParams as TriggerActionParams;
+                            const stats = statsByTriggerId.get(trigger.id);
+                            return (
+                              <Table.Row {...sharedRowProps(trigger)}>
+                                <Table.Cell fontWeight="medium">
+                                  {trigger.name}
+                                </Table.Cell>
+                                <Table.Cell maxWidth="360px">
+                                  <VStack gap={2} align="stretch">
+                                    {applyChecks(
+                                      trigger.checks?.filter(
+                                        (check): check is Monitor => !!check,
+                                      ) ?? [],
+                                    )}
+
+                                    {trigger.filterQuery ? (
+                                      // ADR-043: a trace-subject automation shows
+                                      // its search query.
+                                      <Code
+                                        size="sm"
+                                        variant="surface"
+                                        whiteSpace="pre-wrap"
+                                        wordBreak="break-word"
+                                      >
+                                        {trigger.filterQuery}
+                                      </Code>
+                                    ) : trigger.filters &&
+                                      typeof trigger.filters === "string" &&
+                                      trigger.filters !== "{}" ? (
+                                      <FilterDisplay
+                                        filters={trigger.filters}
+                                        hasBorder={true}
                                       />
-                                    </Table.Cell>
-                                    <Table.Cell whiteSpace="nowrap">
-                                      <AlertRuleCell
-                                        actionParams={actionParams}
-                                      />
-                                    </Table.Cell>
-                                    <Table.Cell>
+                                    ) : null}
+                                  </VStack>
+                                </Table.Cell>
+                                <Table.Cell>
+                                  <VStack align="start" gap={0}>
+                                    <Text textStyle="sm" fontWeight="medium">
+                                      {triggerActionName(trigger.action)}
+                                    </Text>
+                                    <Box textStyle="xs" color="fg.muted">
                                       {actionItems(
                                         trigger.action,
                                         actionParams,
                                       )}
-                                    </Table.Cell>
-                                    <Table.Cell whiteSpace="nowrap">
-                                      <LastFiredCell
-                                        trigger={trigger}
-                                        stats={stats}
-                                      />
-                                    </Table.Cell>
-                                    <Table.Cell whiteSpace="nowrap">
-                                      <FiringStatus
-                                        firing={!!stats?.currentlyFiring}
-                                      />
-                                    </Table.Cell>
-                                    {activeCell(trigger)}
-                                    <Table.Cell>
-                                      {rowActionsMenu(trigger)}
-                                    </Table.Cell>
-                                  </Table.Row>
-                                );
-                              })}
-                            </Table.Body>
-                          </Table.Root>
-                        </TableShell>
-                      )}
-                    </VStack>
-                  )}
-
-                  {section === "overview" && (
-                    <VStack align="stretch" gap={8} width="full">
-                      <SimpleGrid columns={{ base: 1, md: 3 }} gap={4}>
-                        <StatTile
-                          label="Firing now"
-                          value={overview.firingNow}
-                          sub={
-                            overview.firingNow > 0
-                              ? "alerts over their threshold"
-                              : "all clear"
-                          }
-                          alert={overview.firingNow > 0}
-                        />
-                        <StatTile
-                          label="Fired (30 days)"
-                          value={overview.fired30d.toLocaleString()}
-                          sub="across every automation"
-                        />
-                        <StatTile
-                          label="Next scheduled"
-                          value={
-                            overview.next
-                              ? (formatTimeAgo(overview.next.at) ?? "—")
-                              : "—"
-                          }
-                          sub={overview.nextName ?? "no schedules queued"}
-                        />
-                      </SimpleGrid>
-
-                      <VStack align="stretch" gap={3} width="full">
-                        <OverviewSectionHeading
-                          title="Recent activity"
-                          summary="See what alerts, schedules, and automations have done recently."
-                        />
-                        <AutomationsHistory
-                          fires={activity.data ?? []}
-                          triggers={triggers.data ?? []}
-                          isLoading={activity.isLoading}
-                          onOpenAutomation={(triggerId) =>
-                            openDrawer("viewAutomation", {
-                              automationId: triggerId,
-                            })
-                          }
-                        />
-                      </VStack>
-
-                      <VStack align="stretch" gap={4} width="full">
-                        <OverviewSectionHeading
-                          title="Popular uses"
-                          summary="Start from a common workflow and tailor it to your project."
-                        />
-                        <VStack align="stretch" gap={2}>
-                          <Text
-                            textStyle="xs"
-                            fontWeight="semibold"
-                            color="fg.muted"
-                          >
-                            Alerts
-                          </Text>
-                          <UseCaseStrip
-                            kind="alert"
-                            showLabel={false}
-                            onOpen={(prefill) =>
-                              openDrawer("automation", prefill)
-                            }
-                          />
-                        </VStack>
-                        <VStack align="stretch" gap={2}>
-                          <Text
-                            textStyle="xs"
-                            fontWeight="semibold"
-                            color="fg.muted"
-                          >
-                            Automations
-                          </Text>
-                          <UseCaseStrip
-                            kind="automation"
-                            showLabel={false}
-                            onOpen={(prefill) =>
-                              openDrawer("automation", prefill)
-                            }
-                          />
-                        </VStack>
-                      </VStack>
-                    </VStack>
-                  )}
-
-                  {section === "schedules" && (
-                    <VStack align="stretch" gap={4}>
-                      <SectionHeader
-                        icon={<Calendar size={18} />}
-                        accent="purple"
-                        title="Schedules"
-                        count={reports.length}
-                        summary="Send a dashboard, a graph, or a table of traces on a recurring schedule."
-                        details="A schedule bundles a dashboard, a single graph, or a top-N trace table into a Slack or email digest on the schedule you set."
-                        addLabel="New schedule"
-                        onAdd={() =>
-                          openDrawer("automation", { initialSource: "report" })
-                        }
-                      />
-                      {reports.length === 0 ? (
-                        <EmptyHint>
-                          No schedules yet. Create one for a recurring Slack or
-                          email digest.
-                        </EmptyHint>
-                      ) : (
-                        <TableShell>
-                          <Table.Root variant="line" width="full">
-                            <Table.Header>
-                              <Table.Row>
-                                <Table.ColumnHeader>Name</Table.ColumnHeader>
-                                <Table.ColumnHeader>Sends</Table.ColumnHeader>
-                                <Table.ColumnHeader whiteSpace="nowrap">
-                                  Schedule
-                                </Table.ColumnHeader>
-                                <Table.ColumnHeader whiteSpace="nowrap">
-                                  <MetricHeader
-                                    label="Next run"
-                                    help="When this next goes out, straight from the scheduler. A paused schedule has no next run."
+                                    </Box>
+                                  </VStack>
+                                </Table.Cell>
+                                <Table.Cell whiteSpace="nowrap">
+                                  <LastFiredCell
+                                    trigger={trigger}
+                                    stats={stats}
                                   />
-                                </Table.ColumnHeader>
-                                <Table.ColumnHeader whiteSpace="nowrap">
-                                  <MetricHeader
-                                    label="Last run"
-                                    help="The last time this was sent."
-                                  />
-                                </Table.ColumnHeader>
-                                <Table.ColumnHeader>
-                                  Delivery
-                                </Table.ColumnHeader>
-                                <Table.ColumnHeader>Active</Table.ColumnHeader>
-                                <Table.ColumnHeader />
+                                </Table.Cell>
+                                <Table.Cell>
+                                  <Text as="span" color="fg.muted">
+                                    {stats?.recentFireCount ?? 0}
+                                  </Text>
+                                </Table.Cell>
+                                {activeCell(trigger)}
+                                <Table.Cell>
+                                  {rowActionsMenu(trigger)}
+                                </Table.Cell>
                               </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                              {reports.map((trigger) => {
-                                const actionParams =
-                                  trigger.actionParams as TriggerActionParams;
-                                const schedule = (
-                                  actionParams as {
-                                    schedule?: {
-                                      cron?: string;
-                                      timezone?: string;
-                                    };
-                                  }
-                                ).schedule;
-                                return (
-                                  <Table.Row
-                                    key={trigger.id}
-                                    data-trigger-id={trigger.id}
-                                    cursor="pointer"
-                                    _hover={{ bg: "bg.muted" }}
-                                    onClick={() =>
-                                      openDrawer("automation", {
-                                        automationId: trigger.id,
-                                      })
-                                    }
-                                  >
-                                    <Table.Cell fontWeight="medium">
-                                      {trigger.name}
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                      <ReportSubjectCell
-                                        actionParams={actionParams}
-                                        graphNameById={graphNameById}
-                                      />
-                                    </Table.Cell>
-                                    <Table.Cell whiteSpace="nowrap">
-                                      <Text textStyle="sm">
-                                        {schedule?.cron
-                                          ? describeSchedule(
-                                              schedule.cron,
-                                              schedule.timezone ?? "UTC",
-                                            )
-                                          : "Not set"}
-                                      </Text>
-                                    </Table.Cell>
-                                    <ReportRunCells
-                                      schedule={scheduleByTriggerId.get(
-                                        trigger.id,
-                                      )}
-                                      loading={reportSchedules.isLoading}
-                                    />
-                                    <Table.Cell>
-                                      {trigger.action === "SEND_SLACK_MESSAGE"
-                                        ? "Slack"
-                                        : "Email"}
-                                    </Table.Cell>
-                                    {activeCell(trigger)}
-                                    <Table.Cell>
-                                      {rowActionsMenu(trigger)}
-                                    </Table.Cell>
-                                  </Table.Row>
-                                );
-                              })}
-                            </Table.Body>
-                          </Table.Root>
-                        </TableShell>
-                      )}
-                    </VStack>
+                            );
+                          })}
+                        </Table.Body>
+                      </Table.Root>
+                    </TableShell>
                   )}
-
-                  {section === "automations" && (
-                    <VStack align="stretch" gap={4}>
-                      <SectionHeader
-                        icon={<Zap size={18} />}
-                        accent="blue"
-                        title="Automations"
-                        count={traceAutomations.length}
-                        summary="Act on every incoming trace that matches your filters."
-                        details="An automation runs on each trace matching your filters: post to Slack or email, add rows to a dataset, or queue traces for annotation."
-                        addLabel="New automation"
-                        onAdd={() => openDrawer("automation", {})}
-                      />
-                      {traceAutomations.length === 0 ? (
-                        <UseCaseStrip
-                          kind="automation"
-                          onOpen={(prefill) =>
-                            openDrawer("automation", prefill)
-                          }
-                        />
-                      ) : (
-                        <TableShell>
-                          <Table.Root variant="line" width="full">
-                            <Table.Header>
-                              <Table.Row>
-                                <Table.ColumnHeader>Name</Table.ColumnHeader>
-                                <Table.ColumnHeader>Acts on</Table.ColumnHeader>
-                                <Table.ColumnHeader>Then</Table.ColumnHeader>
-                                <Table.ColumnHeader whiteSpace="nowrap">
-                                  <MetricHeader
-                                    label="Last fired"
-                                    help="When this automation last matched a trace and ran its action. Automations on a digest schedule also show when the next bundled send is due."
-                                  />
-                                </Table.ColumnHeader>
-                                <Table.ColumnHeader whiteSpace="nowrap">
-                                  <MetricHeader
-                                    label="Fires (30d)"
-                                    help="Times this automation fired in the last 30 days."
-                                  />
-                                </Table.ColumnHeader>
-                                <Table.ColumnHeader>Active</Table.ColumnHeader>
-                                <Table.ColumnHeader />
-                              </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                              {traceAutomations.map((trigger) => {
-                                const actionParams =
-                                  trigger.actionParams as TriggerActionParams;
-                                const stats = statsByTriggerId.get(trigger.id);
-                                return (
-                                  <Table.Row {...sharedRowProps(trigger)}>
-                                    <Table.Cell fontWeight="medium">
-                                      {trigger.name}
-                                    </Table.Cell>
-                                    <Table.Cell maxWidth="360px">
-                                      <VStack gap={2} align="stretch">
-                                        {applyChecks(
-                                          trigger.checks?.filter(
-                                            (check): check is Monitor =>
-                                              !!check,
-                                          ) ?? [],
-                                        )}
-
-                                        {trigger.filterQuery ? (
-                                          // ADR-043: a trace-subject automation shows
-                                          // its search query.
-                                          <Code
-                                            size="sm"
-                                            variant="surface"
-                                            whiteSpace="pre-wrap"
-                                            wordBreak="break-word"
-                                          >
-                                            {trigger.filterQuery}
-                                          </Code>
-                                        ) : trigger.filters &&
-                                          typeof trigger.filters === "string" &&
-                                          trigger.filters !== "{}" ? (
-                                          <FilterDisplay
-                                            filters={trigger.filters}
-                                            hasBorder={true}
-                                          />
-                                        ) : null}
-                                      </VStack>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                      <VStack align="start" gap={0}>
-                                        <Text
-                                          textStyle="sm"
-                                          fontWeight="medium"
-                                        >
-                                          {triggerActionName(trigger.action)}
-                                        </Text>
-                                        <Box textStyle="xs" color="fg.muted">
-                                          {actionItems(
-                                            trigger.action,
-                                            actionParams,
-                                          )}
-                                        </Box>
-                                      </VStack>
-                                    </Table.Cell>
-                                    <Table.Cell whiteSpace="nowrap">
-                                      <LastFiredCell
-                                        trigger={trigger}
-                                        stats={stats}
-                                      />
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                      <Text as="span" color="fg.muted">
-                                        {stats?.recentFireCount ?? 0}
-                                      </Text>
-                                    </Table.Cell>
-                                    {activeCell(trigger)}
-                                    <Table.Cell>
-                                      {rowActionsMenu(trigger)}
-                                    </Table.Cell>
-                                  </Table.Row>
-                                );
-                              })}
-                            </Table.Body>
-                          </Table.Root>
-                        </TableShell>
-                      )}
-                    </VStack>
-                  )}
-
-                </>
+                </VStack>
               )}
-            </VStack>
-          </Box>
-        </HStack>
+            </>
+          )}
+        </VStack>
       </Box>
-    </DashboardLayout>
+    </SectionNavigationLayout>
   );
 }
 

--- a/specs/evaluations/experiments-online-evaluations-separation.feature
+++ b/specs/evaluations/experiments-online-evaluations-separation.feature
@@ -13,8 +13,8 @@ Feature: Separate experiments from online evaluations
     Given I open a project's primary navigation
     Then the existing "Evaluate" section is named "Test"
     And "Test" contains "Simulations", "Experiments", and "Annotations" in that order
-    And the existing "Build" section is named "Library"
-    And "Library" contains "Prompts", "Agents", "Workflows", "Evaluators", "Datasets", and "Automations" in that order
+    And the existing section is named "Build"
+    And "Build" contains "Prompts", "Agents", "Workflows", "Evaluators", "Datasets", and "Automations" in that order
     And "Observe" contains its existing destinations followed by the menu label "Online Evals" after "Traces"
     And the destination page and product copy keep the full name "Online Evaluations"
     And "Automations" is not listed in "Observe"
@@ -30,8 +30,8 @@ Feature: Separate experiments from online evaluations
     And the preference is restored after I reload the application
 
   Scenario: Focus automation work by purpose
-    Given I open Automations from "Library"
-    Then I can use a local navigation to open "Automations", "Alerts", "Schedules", or "Recent activity"
+    Given I open Automations from "Build"
+    Then I can use a local navigation to open "Overview", "Automations", "Alerts", or "Schedules"
     And each destination has its own URL
     And each destination shows only the controls and records for that purpose
     And the automation content uses a readable maximum width instead of stretching across the page
@@ -40,7 +40,7 @@ Feature: Separate experiments from online evaluations
     Given I have no saved primary navigation preferences
     When I open a project
     Then "Observe" and "Test" are expanded
-    And "Library" and "Govern" are collapsed
+    And "Build" and "Govern" are collapsed
 
   Scenario: Discover experiments as a distinct testing workflow
     Given I want to test or compare an application before deployment

--- a/specs/navigation/shared-section-navigation-layout.feature
+++ b/specs/navigation/shared-section-navigation-layout.feature
@@ -1,0 +1,26 @@
+Feature: Shared section navigation layout
+  As a LangWatch user
+  I want complex product areas to use the same local navigation shell
+  So that their hierarchy, spacing, and dividers remain visually consistent
+
+  Scenario Outline: Render a consistent local navigation shell
+    Given I open the <section> workspace
+    Then its section title appears above the local navigation in the left column
+    And its page title appears in the content column beside the local navigation
+    And the local navigation divider uses the shared muted border color
+    And the workspace is constrained to the shared readable maximum width
+    And the content column uses only the space remaining beside the local navigation
+
+    Examples:
+      | section       |
+      | Automations   |
+      | AI Gateway    |
+      | AI Governance |
+
+  Scenario: Keep product-level and local navigation labels distinct
+    Given I open the primary project navigation
+    Then the expandable product section is named "Build"
+    And its Automations destination is named "Automations"
+    When I open the Automations destination
+    Then the first local navigation item is named "Overview"
+    And the page heading is named "Overview"


### PR DESCRIPTION
## Summary

- use one shared local navigation shell for Automations, AI Gateway, and AI Governance
- place section titles and page headings side by side with a shared 220px rail, muted divider, and 1600px content cap
- rename the primary navigation section from Library back to Build while preserving its saved expansion state

## Verification

- `pnpm --dir langwatch typecheck`
- `pnpm --dir langwatch exec vitest -c vitest.integration.config.ts run src/components/ui/layouts/__tests__/SectionNavigationLayout.integration.test.tsx src/components/__tests__/MainMenu.navigation.integration.test.tsx src/components/sidebar/__tests__/SidebarSection.integration.test.tsx`
- `BASE_URL=http://localhost:5560 E2E_BROWSER_CHANNEL=chrome pnpm --dir agentic-e2e-tests exec playwright test tests/navigation/shared-section-layout.spec.ts tests/automations/automation-navigation.spec.ts --reporter=line`

## Screenshots

### Automations

![Automations using the shared section navigation layout](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6009/shared-section-layout/automations-shared-layout.png)

### AI Gateway

![AI Gateway using the shared section navigation layout](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6009/shared-section-layout/gateway-shared-layout.png)

### AI Governance

![AI Governance using the shared section navigation layout](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6009/shared-section-layout/governance-shared-layout.png)

### Dark mode

![Automations dark mode using the shared section navigation layout](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6009/shared-section-layout/automations-shared-layout-dark.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared sectioned navigation layout used across Automations, AI Gateway, and Governance.
  * Added “Routing Policies” to AI Gateway navigation.
* **Improvements**
  * Renamed the primary navigation section from “Library” to “Build”.
  * Reworked Automations to use local Overview/Automations/Alerts/Schedules navigation with section-specific action buttons.
  * Improved consistency of section navigation layout and dark-mode presentation.
* **Tests**
  * Updated and added end-to-end and integration coverage for the new “Build”/local navigation behavior and layout rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->