### PR TITLE
feat(feature-flags): gate Langy by the internal feature flag only

### DIFF
--- a/langwatch/src/server/featureFlag/__tests__/featureFlag.service.resolver.unit.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/featureFlag.service.resolver.unit.test.ts
@@ -35,6 +35,7 @@ import type { FeatureFlagServiceInterface } from "../types";
 const SYSTEM_FLAG = "ops_es_causality_loop_guard_disabled";
 const FAMILY_FLAG = "es-trace-projection-spanstorage-killswitch";
 const PRODUCT_FLAG = "release_ui_ai_gateway_menu_enabled";
+const NON_ENV_OVERRIDABLE_FLAG = "release_langy_enabled";
 const UNREGISTERED_FLAG = "experiment_some_adhoc_posthog_flag";
 
 class InMemoryStore {
@@ -88,10 +89,24 @@ describe("FeatureFlagService", () => {
     delete process.env.RELEASE_NLP_GO_ENGINE_ENABLED;
     delete process.env.ES_TRACE_PROJECTION_SPANSTORAGE_KILLSWITCH;
     delete process.env.FEATURE_FLAG_FORCE_ENABLE;
+    delete process.env[NON_ENV_OVERRIDABLE_FLAG.toUpperCase()];
   });
 
   afterEach(() => {
     process.env = originalEnv;
+  });
+
+  describe("given a flag registered with envOverridable false", () => {
+    describe("when its uppercase env variable is set", () => {
+      it("ignores the env variable and resolves from the store", async () => {
+        const { service, store, legacy } = buildService();
+        await store.set(NON_ENV_OVERRIDABLE_FLAG, false);
+        process.env[NON_ENV_OVERRIDABLE_FLAG.toUpperCase()] = "1";
+        const enabled = await service.isEnabled(NON_ENV_OVERRIDABLE_FLAG, { distinctId: "user-1", defaultValue: false });
+        expect(enabled).toBe(false);
+        expect(legacy.isEnabled).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("given a SYSTEM-scoped flag", () => {

--- a/langwatch/src/server/featureFlag/featureFlag.service.ts
+++ b/langwatch/src/server/featureFlag/featureFlag.service.ts
@@ -90,9 +90,14 @@ export class FeatureFlagService implements FeatureFlagServiceInterface {
     const { distinctId, defaultValue = false } = opts;
     const definition = resolveFlagDefinition(flagKey);
 
-    const envOverride = checkFlagEnvOverride(flagKey, definition?.legacyEnvVar);
-    if (envOverride !== undefined) {
-      return envOverride;
+    if (definition?.envOverridable !== false) {
+      const envOverride = checkFlagEnvOverride(
+        flagKey,
+        definition?.legacyEnvVar,
+      );
+      if (envOverride !== undefined) {
+        return envOverride;
+      }
     }
     const forceOn = (process.env.FEATURE_FLAG_FORCE_ENABLE ?? "")
       .split(",")

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -48,6 +48,12 @@ export interface FeatureFlagDefinition {
    * setups to keep working.
    */
   legacyEnvVar?: string;
+  /**
+   * Set to `false` to opt the flag out of the auto-derived
+   * UPPERCASE(key) env-var override, leaving the operator store (and,
+   * for PRODUCT flags, PostHog) as the only runtime levers.
+   */
+  envOverridable?: false;
 }
 
 export interface FeatureFlagFamily {
@@ -190,12 +196,18 @@ export const FEATURE_FLAGS = [
   // NOTE: `release_es_graph_triggers_firing` (ADR-034 Phase 5) was retired —
   // the event-sourced graph-alert path is now unconditional and the K8s cron
   // was removed, so there is no longer a cron/ES choice to gate.
+  // SYSTEM on purpose despite being a product surface: the Langy rollout is
+  // decided solely by the internal flag store — never PostHog, never an env
+  // var (envOverridable: false) — so the /ops/feature-flags toggle is the one
+  // authoritative lever.
   {
     key: "release_langy_enabled",
-    scope: "PRODUCT",
+    scope: "SYSTEM",
     defaultValue: false,
+    envOverridable: false,
+    family: "Langy",
     description:
-      "Opens the Langy in-product assistant, and is the only lever that does — there is no staff or other identity bypass, so this is a true kill switch. Default off, so Langy is dark until someone is explicitly opted in. To open it for a project or organization, add an operator-store row via /ops/feature-flags; to open it for one user, use a PostHog rule keyed on the user id (the operator store matches only projectId/organizationId, never a user). For local dev use FEATURE_FLAG_FORCE_ENABLE=release_langy_enabled.",
+      "Opens the Langy in-product assistant, and is the only lever that does — there is no staff or other identity bypass, so this is a true kill switch. Default off, so Langy is dark until someone is explicitly opted in. Managed only from the internal flag store: toggle it, or add per-project/per-org targeting rules, via /ops/feature-flags. PostHog and the RELEASE_LANGY_ENABLED env var are deliberately not consulted. For local dev use FEATURE_FLAG_FORCE_ENABLE=release_langy_enabled.",
   },
   {
     key: "release_langy_promo_enabled",

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -195,7 +195,7 @@ export const FEATURE_FLAGS = [
     scope: "PRODUCT",
     defaultValue: false,
     description:
-      "Opens the Langy in-product assistant, and is the only lever that does — there is no staff or other identity bypass, so this is a true kill switch. Default off, so Langy is dark until someone is explicitly opted in. To open it for a project or organization, add an operator-store row via /ops/feature-flags; to open it for one user, use a PostHog rule keyed on the user id (the operator store matches only projectId/organizationId, never a user). RELEASE_LANGY_ENABLED=1 is a blanket on — the env override parses ONLY 1 or 0, so RELEASE_LANGY_ENABLED=true is silently ignored. For local dev use FEATURE_FLAG_FORCE_ENABLE=release_langy_enabled.",
+      "Opens the Langy in-product assistant, and is the only lever that does — there is no staff or other identity bypass, so this is a true kill switch. Default off, so Langy is dark until someone is explicitly opted in. To open it for a project or organization, add an operator-store row via /ops/feature-flags; to open it for one user, use a PostHog rule keyed on the user id (the operator store matches only projectId/organizationId, never a user). For local dev use FEATURE_FLAG_FORCE_ENABLE=release_langy_enabled.",
   },
   {
     key: "release_langy_promo_enabled",


### PR DESCRIPTION
Langy is now gated solely by the internal feature-flag system:

- `release_langy_enabled` flipped to SYSTEM scope — PostHog is never consulted; resolution is operator store (/ops/feature-flags, incl. per-project/per-org rules) → registry default (off).
- New generic `envOverridable: false` registry option — the auto-derived `RELEASE_LANGY_ENABLED` env override is skipped for this flag. `FEATURE_FLAG_FORCE_ENABLE` still works for local dev.
- Removed the env-var mention from the flag description shown in /ops/feature-flags.

Behavior: flag on in the ops UI → Langy panel shows and endpoints answer; flag off → panel hidden and endpoints 404. Frontend (`useShowLangy`) and backend (`hasLangyAccess`) both read the same flag through `featureFlagService.isEnabled`, so no other change was needed.

Pairs with langwatch-saas#780, which drops the `RELEASE_LANGY_ENABLED=1` pin from the workers terraform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Certain feature flags can no longer be overridden by environment variables when explicitly configured as non-overridable.
  - Updated the language release flag to use the internal feature-flag controls as its authoritative source.
  - Added coverage to ensure non-overridable flags resolve correctly without relying on legacy flag services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->