### PR TITLE
docs(claude): guard against unbounded ad-hoc vitest runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,11 @@ specs/               # BDD feature specs
 | Shared types in `types.ts` | Colocate unless truly shared |
 | Duplicating Zod + TS types | When you need both validation AND types, use Zod only with `infer`. For internal constants (no external input), `as const` is sufficient |
 | Skipping test run after edits | Always run tests after any code change to catch regressions immediately |
+| Running `npx vitest` / `npm exec vitest` directly | Always go through the package scripts: `pnpm test:unit run <path>`, `pnpm test:integration run <path>`. Only they carry the repo's RAM guardrails (`pool: "vmThreads"`, `maxWorkers: "50%"`, `vmMemoryLimit: "512MB"`; integration adds `pool: "forks"` + `fileParallelism: false`) |
+| Hand-rolling a throwaway `vitest.*.config.ts` (in `/tmp` or a worktree) | Never. A bare config inherits none of the guardrails above, so vitest defaults to the `forks` pool at `availableParallelism - 1` workers (10 on an 11-core laptop) at ~200-500MB each — several GB per run, multiplied by every parallel agent worktree. Use an existing config |
+| Writing a jsdom config because the repo "has no jsdom environment" | It is per-file on purpose — neither config declares a global `environment`; 515 test files set `// @vitest-environment jsdom` in a docblock. Add the docblock to your test file |
+| Reaching for `--maxWorkers=1` to be gentle on RAM | It serializes the run so it stays resident far longer, overlapping every other agent's run. Scope the run down instead — pass a narrower path |
+| Leaving a killed vitest run behind | Interrupting vitest orphans its forked workers (they reparent to `ppid 1` and keep holding RAM). After an interrupted run, sweep with `pkill -f "vitest/dist/workers"` |
 | Writing tests in the incorrect order | Outside-In TDD: integration tests first, then unit tests |
 | Defining BDD specs on the end of the TODO list | BDD specs should come before any other tasks to guide them, not the other way around |
 | `gh pr edit --body` | Use `gh api repos/OWNER/REPO/pulls/N -X PATCH -f body="..."` (avoids Projects classic deprecation warning) |


### PR DESCRIPTION
## Why

Agents burn several GB of RAM on the dev laptop by bypassing the package scripts. Two patterns, both observed live:

1. `npx vitest run --reporter=dot --maxWorkers=1 src/prompts` — bare invocation instead of `pnpm test:unit run src/prompts`. Across the local session transcripts: **1502** `npx vitest run` invocations vs **7** `pnpm exec vitest`.
2. A hand-rolled `vitest.jsdom-integration.config.ts` written into `/tmp`, because the agent believed the repo had no jsdom environment.

The RAM guardrails only exist in the checked-in configs:

| config | guardrails |
|---|---|
| `vitest.config.ts` | `pool: "vmThreads"`, `maxWorkers: "50%"`, `vmMemoryLimit: "512MB"` |
| `vitest.integration.config.ts` | `pool: "forks"`, `fileParallelism: false` |

A hand-rolled config inherits **none** of them, so vitest falls back to its defaults: the `forks` pool at `availableParallelism - 1` workers. On an 11-core laptop that is **10 forked child processes at ~200-500MB each**.

Measured on one box, two ad-hoc-config runs overlapping: **21 fork workers, 3.7 GB resident**, against 18 GB RAM and 2 GB of swap (1.58 GB already used). The run that used the repo config spawned zero forks, as designed.

Two secondary traps are covered too:

- **`--maxWorkers=1` is not a safe substitute.** It serializes the run so it stays resident far longer, overlapping every other agent's run rather than getting out of the way.
- **Killing a vitest run orphans its workers.** They reparent to `ppid 1` and keep holding RAM; one was observed alive 9+ minutes after its parent died.

## What

Five rows in the CLAUDE.md General table. Docs only — no code, config, or test changes.

jsdom needs no config: neither repo config declares a global `environment` because it is per-file by design, and **515** test files already carry a `// @vitest-environment jsdom` docblock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance with recommended Vitest workflows.
  * Clarified use of repository-provided test commands and per-file browser-environment settings.
  * Added guidance against temporary test configurations and unnecessary single-worker options.
  * Documented cleanup steps for interrupted test runs to prevent leftover processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->