### PR TITLE
fix(cli): agent-output follow-ups from the #5921 review

### DIFF
--- a/.github/workflows/cli-binary-publish.yml
+++ b/.github/workflows/cli-binary-publish.yml
@@ -174,8 +174,11 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: "typescript-sdk/pnpm-lock.yaml"
+          # No dependency cache on purpose. These legs build the binaries that
+          # the publish job uploads to the release, so a poisoned cache entry
+          # would become a shipped artifact. Restoring a shared store into a
+          # release-triggered build is the cache-poisoning surface zizmor flags;
+          # a cold install costs seconds and removes it.
 
       - name: Install Bun
         # The pinned, checksummed release artifact — NOT `curl

--- a/typescript-sdk/src/cli/commands/suites/__tests__/suite-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/suites/__tests__/suite-commands.unit.test.ts
@@ -390,6 +390,28 @@ describe("runSuiteCommand()", () => {
     });
   });
 
+  // A run that scheduled nothing can never see a completion arrive, so the
+  // poll loop ran the full 10-minute timeout and then reported a TIMEOUT for a
+  // run that was already over. Asserting on `fetch` is what makes this a real
+  // regression test: it is the poll itself that must not happen.
+  describe("when the run scheduled no jobs and --wait was passed", () => {
+    it("returns without polling instead of waiting out the timeout", async () => {
+      mockRun.mockResolvedValue(
+        makeRunResult({
+          jobCount: 0,
+          skippedArchived: { scenarios: ["archived_scenario"], targets: [] },
+        }),
+      );
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response("{}", { status: 200 }));
+
+      await runSuiteCommand("suite_abc123", { wait: true });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when API call fails", () => {
     it("exits with code 1", async () => {
       mockRun.mockRejectedValue(

--- a/typescript-sdk/src/cli/commands/suites/run.ts
+++ b/typescript-sdk/src/cli/commands/suites/run.ts
@@ -59,6 +59,16 @@ export const runSuiteCommand = async (
       return;
     }
 
+    // Nothing was scheduled — every scenario or target was archived, and the
+    // skip notice above says which. No completion can ever arrive, so polling
+    // would run out the full timeout and report a timeout for a run that is
+    // already over.
+    if (result.jobCount === 0) {
+      console.log();
+      console.log(chalk.yellow("  No jobs were scheduled — nothing to wait for."));
+      return;
+    }
+
     // Poll for completion
     console.log();
     const pollSpinner = createSpinner("Waiting for suite run to complete...").start();

--- a/typescript-sdk/src/cli/commands/tag/create.ts
+++ b/typescript-sdk/src/cli/commands/tag/create.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import { PromptsApiService } from "@/client-sdk/services/prompts";
 import { checkApiKey } from "../../utils/apiKey";
 import { validateTagName } from "./validation";
+import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
 import type { CommandResult } from "../../utils/output";
 
 /**
@@ -11,7 +12,7 @@ import type { CommandResult } from "../../utils/output";
 export const tagCreateCommand = async (name: string): Promise<CommandResult | void> => {
   const validationError = validateTagName(name);
   if (validationError) {
-    console.error(chalk.red(`Error: ${validationError}`));
+    reportCommandError({ error: commandValidationError(validationError) });
     process.exit(1);
   }
 

--- a/typescript-sdk/src/cli/commands/tag/rename.ts
+++ b/typescript-sdk/src/cli/commands/tag/rename.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import { PromptsApiService } from "@/client-sdk/services/prompts";
 import { checkApiKey } from "../../utils/apiKey";
 import { validateTagName } from "./validation";
+import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
 import type { CommandResult } from "../../utils/output";
 
 /**
@@ -12,7 +13,7 @@ import type { CommandResult } from "../../utils/output";
 export const tagRenameCommand = async (oldName: string, newName: string): Promise<CommandResult | void> => {
   const validationError = validateTagName(newName);
   if (validationError) {
-    console.error(chalk.red(`Error: ${validationError}`));
+    reportCommandError({ error: commandValidationError(validationError) });
     process.exit(1);
   }
 

--- a/typescript-sdk/src/cli/commands/workflows/__tests__/run.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/workflows/__tests__/run.unit.test.ts
@@ -1,0 +1,96 @@
+/**
+ * `workflow run` has two things that can throw a `SyntaxError`, and they belong
+ * to opposite parties: `JSON.parse(options.input)` is the CALLER's mistake, and
+ * `await response.json()` is the SERVER's. They used to share one `try`, whose
+ * catch mapped every `SyntaxError` to `--input must be valid JSON` — so a
+ * malformed 200-body told the caller to fix an input that was already valid.
+ *
+ * That is worse than an unhelpful message: it sends the caller (or the agent
+ * driving them) to debug the wrong side of the wire, and it is invisible unless
+ * the two paths are exercised separately. So they are, here.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../../utils/apiKey", () => ({ checkApiKey: vi.fn() }));
+
+vi.mock("ora", () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+    text: "",
+  }),
+}));
+
+const failSpinner = vi.fn();
+vi.mock("../../../utils/spinnerError", () => ({
+  failSpinner: (args: unknown) => failSpinner(args),
+}));
+
+const reportCommandError = vi.fn();
+vi.mock("../../../utils/errorOutput", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    reportCommandError: (args: unknown) => reportCommandError(args),
+  };
+});
+
+import { runWorkflowCommand } from "../run";
+
+class ProcessExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.LANGWATCH_API_KEY = "sk-test";
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new ProcessExitError(code as number);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("runWorkflowCommand()", () => {
+  describe("when --input is not valid JSON", () => {
+    it("blames the input, and never reaches the network", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      await expect(
+        runWorkflowCommand("wf_1", { input: "{not json" }),
+      ).rejects.toThrow(ProcessExitError);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(reportCommandError).toHaveBeenCalledOnce();
+      const { error } = reportCommandError.mock.calls[0]![0] as { error: Error };
+      expect(error.message).toContain("--input must be valid JSON");
+    });
+  });
+
+  describe("when the server answers 200 with a body that is not JSON", () => {
+    it("does not blame --input for the server's malformed reply", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("<html>gateway</html>", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await expect(
+        runWorkflowCommand("wf_1", { input: '{"valid":true}' }),
+      ).rejects.toThrow(ProcessExitError);
+
+      expect(reportCommandError).not.toHaveBeenCalled();
+      expect(failSpinner).toHaveBeenCalledOnce();
+      const { error } = failSpinner.mock.calls[0]![0] as { error: Error };
+      expect(error).toBeInstanceOf(SyntaxError);
+      expect(error.message).not.toContain("--input");
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/workflows/run.ts
+++ b/typescript-sdk/src/cli/commands/workflows/run.ts
@@ -3,7 +3,7 @@ import { createSpinner } from "../../utils/spinner";
 import { checkApiKey } from "../../utils/apiKey";
 import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { commandValidationError } from "../../utils/errorOutput";
+import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
 import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
@@ -14,14 +14,24 @@ export const runWorkflowCommand = async (
 ): Promise<CommandResult | void> => {
   checkApiKey();
 
+  // Parsed before the request, and outside its try: `await response.json()`
+  // throws SyntaxError too, so sharing one catch reported a malformed SERVER
+  // body as `--input must be valid JSON` — an input error the caller never made.
+  let input: Record<string, unknown> = {};
+  if (options.input) {
+    try {
+      input = JSON.parse(options.input) as Record<string, unknown>;
+    } catch {
+      reportCommandError({
+        error: commandValidationError("--input must be valid JSON"),
+      });
+      process.exit(1);
+    }
+  }
+
   const spinner = createSpinner(`Running workflow "${id}"...`).start();
 
   try {
-    let input: Record<string, unknown> = {};
-    if (options.input) {
-      input = JSON.parse(options.input) as Record<string, unknown>;
-    }
-
     // Workflow run API is on the pages API, not the Hono app API
     const apiKey = process.env.LANGWATCH_API_KEY ?? "";
     const endpoint = resolveControlPlaneUrl();
@@ -63,16 +73,9 @@ export const runWorkflowCommand = async (
       },
     };
   } catch (error) {
-    // Route BOTH failure kinds through failSpinner: a direct spinner.fail()
-    // prints nothing in --json/--jq/agent mode (spinners are silent there).
-    failSpinner({
-      spinner,
-      error:
-        error instanceof SyntaxError
-          ? commandValidationError("--input must be valid JSON")
-          : error,
-      action: "run workflow",
-    });
+    // failSpinner, not spinner.fail(): a direct spinner.fail() prints nothing
+    // in --json/--jq/agent mode (spinners are silent there).
+    failSpinner({ spinner, error, action: "run workflow" });
     process.exit(1);
   }
 };

--- a/typescript-sdk/src/cli/utils/commandCatalog.ts
+++ b/typescript-sdk/src/cli/utils/commandCatalog.ts
@@ -81,6 +81,9 @@ export const PLUMBING_COMMANDS: ReadonlySet<string> = new Set([
   "opencode",
   // The CLI's own background process management.
   "daemon",
+  // Local agent-skill installer: manages files under ~/.agents, not platform
+  // data. Excluded app-side too (capabilityCatalog.coverage.unit.test.ts).
+  "skills",
   // The catalog itself — self-referential.
   "commands",
   "help-tree",


### PR DESCRIPTION
## Why

The tail of the review on #5921, landed separately now that it has merged. CodeRabbit's last pass posted its 14 findings into the review *body* rather than as inline comments (GitHub refused them — the diff was three times its ceiling), so they were never actioned on the PR itself. This picks up the ones that were real defects and drops the rest.

Three of these are the same shape as the bug #5921 exists to fix: the command answered, exited, and told the caller something that was not true.

## What changed

**`suite run --wait` hung for the full timeout on an empty run.** The completion guard was `completedCount >= total && total > 0`, which is false forever when `total === 0` — the state you land in when every scenario or target in the suite is archived (the command already prints a "skipped archived" notice on the way there). So it polled for the full 10 minutes and then reported a **timeout** for a run that was over before polling started.

Guarded on `result.jobCount` from the scheduling response rather than on the polled total, which is what the review suggested. The status endpoint can report `totalCount: 0` transiently before it has registered the batch, and completing on that would report **success for a run that never started** — trading a hang for a lie.

**`workflow run` blamed the caller for the server's malformed reply.** `JSON.parse(options.input)` and `await response.json()` sat in one `try`, whose catch mapped every `SyntaxError` to `--input must be valid JSON`. A bad 200-body therefore sent the caller (or the agent driving them) to debug an input that was already valid. Input is now parsed before the request and outside its catch.

**`tag create` / `tag rename` printed ANSI prose on failed validation.** Both return a `CommandResult`, so they advertise the output contract, but their validation branch predated it — `--output json` got colour codes instead of a parseable error. Both now use `reportCommandError`/`commandValidationError`, matching `triggers create`.

**`PLUMBING_COMMANDS` was out of sync with the app.** Its own docstring says it mirrors the app-side capability exclusion list, but `skills` was only in the app's. It installs files under `~/.agents` rather than returning platform data, so it belongs in both.

**The binary build legs cached dependencies.** They run on release publish and their artifacts are what the publish job uploads, so a poisoned cache entry becomes a shipped binary — the cache-poisoning surface `zizmor` flags. The existing privilege split (build is `contents: read`, only publish is `contents: write`) does not cover this, because it is the artifact that carries the payload, not the token. Cold install costs seconds.

## Test plan

- `typescript-sdk`: **124 files / 1468 tests green**, `tsc --noEmit` clean, `eslint src/cli` clean, `pnpm build` green (including the postbuild binary/version check).
- Two new regression tests, both **verified failing against the pre-fix code** rather than only passing against the new:
  - the zero-job suite run fails by *timing out* — which is the bug itself;
  - `workflow run` gets one test per `SyntaxError` source, so the input case and the server-body case cannot be satisfied by the same wrong mapping.
- Workflow YAML re-parsed after the edit; the `build` job's `setup-node` is left with `node-version` only.

## Anything surprising?

- **Two of the review's findings were wrong and are not actioned here.** It reported a duplicate `const seen` that would stop `daemon-server.integration.test.ts` compiling — there is one declaration in that scope, the other is ~500 lines away in a different `it`. And it reported a `CommandResult | void` union breaking `result?.table()` across seven tag tests — those files are in the type-checked program and `tsc` is clean. Both were rebutted with evidence on #5921.
- **Not done: splitting `utils/output.ts`.** It is 324 source lines against a 300-line convention, and it is the module every command's output path runs through. The review marked it "poor tradeoff" itself. Worth doing deliberately, not as a review-cleanup afterthought.
- **Not done: the boolean-prefix renames** (`archived`, `truncate`, `created`, `renamed`). `archived` is on the `-o json` payload of `scenario delete`, so it is a wire contract worth settling — but as one consistent pass over every command's payload, not four scattered renames.
- There is an **intermittent single-test failure** in the CLI suite, seen twice in roughly nine full runs and not reproducible in three consecutive ones. It is not in a file this PR touches and it predates this branch; flagging it rather than claiming a clean deterministic suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Suite runs with no scheduled jobs now finish immediately instead of timing out.
  - Workflow commands correctly distinguish invalid input JSON from malformed server responses.
  - Tag creation and renaming now provide consistent validation error messages.
  - CLI error handling is more reliable and consistent across commands.

- **Improvements**
  - The CLI status cheat sheet now appropriately excludes the `skills` plumbing command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->