### PR TITLE
fix(docker): copy feature-map.json + skills/ into langyagent cli-builder

### DIFF
--- a/Dockerfile.langyagent
+++ b/Dockerfile.langyagent
@@ -129,6 +129,13 @@ COPY langwatch/src/server/evaluations/types.ts        /src/langwatch/src/server/
 COPY langwatch/src/server/modelProviders/llmModels.json /src/langwatch/src/server/modelProviders/llmModels.json
 COPY langwatch/src/app/api/openapiLangWatch.json      /src/langwatch/src/app/api/openapiLangWatch.json
 COPY langevals/ts-integration/evaluators.generated.ts /src/langevals/ts-integration/evaluators.generated.ts
+# copy-types.sh also embeds the repo-root feature-map.json (feature-map.generated.ts),
+# and generate-skills-bundle.mjs walks the whole skills/ tree (feature-skills.ts,
+# each published SKILL.mdx, recipes/, version.txt, and the committed _compiled/native
+# renders). Bring both in at the ../ paths those generators expect relative to
+# /src/typescript-sdk, or `pnpm run prepare` dies with `Cannot find module '../feature-map.json'`.
+COPY feature-map.json                                 /src/feature-map.json
+COPY skills                                            /src/skills
 RUN pnpm run prepare
 
 # BuildKit fills TARGETARCH from the target platform. Map it to Bun's target


### PR DESCRIPTION
## What

The `langy-agent` image build in **langwatch-saas** (`build-and-push-artifacts`) is failing at `RUN pnpm run prepare`:

```
Wrote src/internal/generated/cli/default-prompt-model.generated.ts ...
Error: Cannot find module '../feature-map.json'
...
ERROR: process "/bin/sh -c pnpm run prepare" did not complete successfully: exit code: 1
```
([failed run](https://github.com/langwatch/langwatch-saas/actions/runs/29835209136/job/88649871223))

## Why

#5921 (`feat(cli): agent-first lw CLI`) added two new codegen steps to `typescript-sdk/copy-types.sh`:

- embeds the **repo-root `feature-map.json`** → `feature-map.generated.ts`
- runs `scripts/generate-skills-bundle.mjs`, which walks the whole **`skills/` tree** (`_lib/feature-skills.ts`, each published `SKILL.mdx`, `recipes/`, `version.txt`, and the committed `_compiled/native` renders) → `skills.generated.ts`

`Dockerfile.langyagent`'s `cli-builder` stage copies a *curated* list of generator inputs (for layer caching) rather than the whole repo, and #5921 didn't add either new input. So `pnpm run prepare` can't find `../feature-map.json` and the image build breaks.

## Fix

Copy both new inputs into the cli-builder stage at the `../` paths the generators expect relative to `/src/typescript-sdk`:

```dockerfile
COPY feature-map.json /src/feature-map.json
COPY skills           /src/skills
```

## Verification

Ran the real `copy-types.sh` against a staged `/src` layout (uses only Node built-ins, no install needed):

```
Wrote .../default-prompt-model.generated.ts (DEFAULT_PROMPT_MODEL=openai/gpt-5.5)
Wrote .../feature-map.generated.ts (9 top-level features)
Wrote .../skills.generated.ts (19 skills, bundle v0.6.1)
--- exit code: 0 ---
```

## Note for the release

`Dockerfile.langyagent` lives in this monorepo but is built by **langwatch-saas** against its pinned `langwatch` submodule. Once this merges, bump the langwatch submodule in langwatch-saas to pick it up and re-run the build.

https://claude.ai/code/session_014wKWDe5JXkWRBRWncfUdt1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the LangWatch CLI build process so required feature and skills resources are included correctly.
  * Prevented build preparation issues caused by missing compilation inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->