### PR TITLE
fix(langy): honor org-scoped rollout rules in the UI visibility gate

### DIFF
--- a/.github/workflows/go-services.yaml
+++ b/.github/workflows/go-services.yaml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       service: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.service }}
       chart: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.chart }}
+      langyagent: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.langyagent }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -38,6 +39,33 @@ jobs:
               - '.github/workflows/go-services.yaml'
             chart:
               - 'charts/gateway/**'
+              - '.github/workflows/go-services.yaml'
+            langyagent:
+              # The langyagent image bakes in the langwatch CLI, and that CLI is
+              # generated AT IMAGE-BUILD TIME from inputs OUTSIDE the Go tree:
+              # typescript-sdk/ + skills/ + feature-map.json + a handful of
+              # langwatch/langevals source files (typescript-sdk/copy-types.sh +
+              # generate-skills-bundle.mjs). A change to any of those can break
+              # `docker build -f Dockerfile.langyagent` with no Go source
+              # touched — exactly the gap that shipped a broken build once
+              # (a new copy-types.sh input was never COPYed into the image).
+              # Validate the image build whenever any build input moves.
+              - 'services/langyagent/**'
+              - 'pkg/**'
+              - 'cmd/**'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Dockerfile.langyagent'
+              - 'typescript-sdk/**'
+              - 'packages/cli-cards/**'
+              - 'skills/**'
+              - 'feature-map.json'
+              - 'langwatch/src/server/tracer/types.ts'
+              - 'langwatch/src/server/filters/types.ts'
+              - 'langwatch/src/server/evaluations/types.ts'
+              - 'langwatch/src/server/modelProviders/llmModels.json'
+              - 'langwatch/src/app/api/openapiLangWatch.json'
+              - 'langevals/ts-integration/evaluators.generated.ts'
               - '.github/workflows/go-services.yaml'
 
   docker:
@@ -87,6 +115,39 @@ jobs:
             ${{ steps.meta.outputs.image }}:latest
           cache-from: type=gha,scope=gateway
           cache-to: type=gha,scope=gateway,mode=max
+
+  langyagent:
+    needs: changes
+    if: ${{ needs.changes.outputs.langyagent == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          driver-opts: image=moby/buildkit:buildx-stable-1
+
+      # Build-only guard: this image is NEVER pushed from here. The langyagent
+      # image is published solely by publish-docker-app.yml on a `langwatch@*`
+      # release; this job exists to fail a PR fast when a build input breaks the
+      # image, not to produce an artifact. amd64 only — the failure modes we're
+      # guarding (a missing copy-types.sh input, an unresolved generated import,
+      # a broken Go compile) are arch-independent, so an emulated arm64 build
+      # would triple the runtime for no extra signal. Shares the release
+      # workflow's amd64 cache scope so PR builds warm from it.
+      - name: Build langyagent image (no push)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v6
+        with:
+          context: .
+          file: Dockerfile.langyagent
+          push: false
+          platforms: linux/amd64
+          build-args: |
+            SERVICE_VERSION=${{ github.sha }}
+          cache-from: type=gha,scope=langyagent-amd64
+          cache-to: type=gha,scope=langyagent-amd64,mode=max
 
   helm:
     needs: changes

--- a/Dockerfile.langyagent
+++ b/Dockerfile.langyagent
@@ -129,6 +129,13 @@ COPY langwatch/src/server/evaluations/types.ts        /src/langwatch/src/server/
 COPY langwatch/src/server/modelProviders/llmModels.json /src/langwatch/src/server/modelProviders/llmModels.json
 COPY langwatch/src/app/api/openapiLangWatch.json      /src/langwatch/src/app/api/openapiLangWatch.json
 COPY langevals/ts-integration/evaluators.generated.ts /src/langevals/ts-integration/evaluators.generated.ts
+# copy-types.sh also embeds the repo-root feature-map.json (feature-map.generated.ts),
+# and generate-skills-bundle.mjs walks the whole skills/ tree (feature-skills.ts,
+# each published SKILL.mdx, recipes/, version.txt, and the committed _compiled/native
+# renders). Bring both in at the ../ paths those generators expect relative to
+# /src/typescript-sdk, or `pnpm run prepare` dies with `Cannot find module '../feature-map.json'`.
+COPY feature-map.json                                 /src/feature-map.json
+COPY skills                                            /src/skills
 RUN pnpm run prepare
 
 # BuildKit fills TARGETARCH from the target platform. Map it to Bun's target

--- a/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
+++ b/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useShowLangy is Langy's UI visibility gate. #5966 made access flag-only (no
+ * identity bypass), which means the gate must resolve `release_langy_enabled`
+ * with the SAME project + organization context the server-side hasLangyAccess
+ * gate uses. Otherwise an org-wide rollout authorizes the tRPC procedures while
+ * the handle stays hidden — the exact asymmetry this test locks out.
+ *
+ * The `useFeatureFlag` mock reproduces the flag store's rule matcher
+ * (server/featureFlag/rules.ts): a targeting rule only matches when every id it
+ * constrains is present in, and equal to, the evaluation context.
+ *
+ * Spec: specs/langy/langy-baseline.feature ("Access and rollout gating")
+ */
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type FlagOptions = {
+  projectId?: string;
+  organizationId?: string;
+  enabled?: boolean;
+};
+
+// Boundary state, set per test. A `null` rule means "no rollout"; a rule with
+// only organizationId is an org-wide rollout, with only projectId a per-project
+// rollout.
+const gate: {
+  rule: { projectId?: string; organizationId?: string } | null;
+  lastFlagOptions: FlagOptions | undefined;
+} = {
+  rule: null,
+  lastFlagOptions: undefined,
+};
+
+vi.mock("~/hooks/useRequiredSession", () => ({
+  useRequiredSession: () => ({ data: { user: { id: "user-1" } } }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project-1", slug: "acme" },
+    team: {
+      isPersonal: false,
+      ownerUserId: "someone-else",
+      members: [{ userId: "user-1" }],
+    },
+    organization: { id: "org-1" },
+    organizationRole: "MEMBER",
+    hasPermission: (permission: string) => permission === "langy:view",
+  }),
+}));
+
+vi.mock("~/hooks/usePublicEnv", () => ({
+  // A demo slug that does NOT match the active project, so the demo-refusal
+  // branch stays out of the way and the rollout is what decides visibility.
+  usePublicEnv: () => ({ data: { DEMO_PROJECT_SLUG: "not-this-project" } }),
+}));
+
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: (_flag: string, options: FlagOptions) => {
+    gate.lastFlagOptions = options;
+    // Callers gated out upstream disable the query — mirror that short-circuit.
+    if (options?.enabled === false) return { enabled: false, isLoading: false };
+    const rule = gate.rule;
+    const matches =
+      rule !== null &&
+      (rule.projectId === undefined ||
+        rule.projectId === options?.projectId) &&
+      (rule.organizationId === undefined ||
+        rule.organizationId === options?.organizationId);
+    return { enabled: matches, isLoading: false };
+  },
+}));
+
+import { useShowLangy } from "../useShowLangy";
+
+afterEach(() => {
+  cleanup();
+  gate.rule = null;
+  gate.lastFlagOptions = undefined;
+});
+
+describe("useShowLangy", () => {
+  describe("given a team member with langy:view on a non-demo project", () => {
+    describe("when the rollout targets the whole organization and no project rule applies", () => {
+      it("reveals the panel by resolving the flag with organization context", () => {
+        gate.rule = { organizationId: "org-1" };
+
+        const { result } = renderHook(() => useShowLangy());
+
+        expect(result.current).toBe(true);
+        expect(gate.lastFlagOptions?.organizationId).toBe("org-1");
+      });
+    });
+
+    describe("when the rollout targets only the current project", () => {
+      it("reveals the panel", () => {
+        gate.rule = { projectId: "project-1" };
+
+        const { result } = renderHook(() => useShowLangy());
+
+        expect(result.current).toBe(true);
+      });
+    });
+
+    describe("when the rollout targets a different organization", () => {
+      it("keeps the panel hidden", () => {
+        gate.rule = { organizationId: "other-org" };
+
+        const { result } = renderHook(() => useShowLangy());
+
+        expect(result.current).toBe(false);
+      });
+    });
+
+    describe("when nothing has been rolled out", () => {
+      it("keeps the panel hidden", () => {
+        gate.rule = null;
+
+        const { result } = renderHook(() => useShowLangy());
+
+        expect(result.current).toBe(false);
+      });
+    });
+  });
+});

--- a/langwatch/src/features/langy/hooks/useShowLangy.ts
+++ b/langwatch/src/features/langy/hooks/useShowLangy.ts
@@ -21,10 +21,14 @@ import { LANGY_RELEASE_FLAG } from "~/utils/langyReleaseFlag";
  *    rather than this hook.
  * 3. Rollout — the `release_langy_enabled` flag must be on for this user.
  *    Defaults off in the registry, so everyone is dark until explicitly
- *    opted in; there is no identity-based bypass. This is UI hiding only;
- *    the authoritative check is the server-side `hasLangyAccess` gate on the
- *    Langy tRPC routers. Both read the same `LANGY_RELEASE_FLAG` key so the
- *    panel can't render against procedures that would 404 anyway.
+ *    opted in; there is no identity-based bypass. The flag is resolved with
+ *    the same project *and* organization context the server gate uses, so a
+ *    rollout targeted at the whole org reveals the panel too — not only a
+ *    per-project rule. This is UI hiding only; the authoritative check is the
+ *    server-side `hasLangyAccess` gate on the Langy tRPC routers. Both read the
+ *    same `LANGY_RELEASE_FLAG` key with the same context, so the panel can't
+ *    render against procedures that would 404 — nor stay hidden while those
+ *    procedures would happily answer.
  *
  * Consumed by ProjectLangyLayout (mounts the panel) and HomePageBanners
  * (picks the Langy activation banner over the promo teaser) — one gate,
@@ -32,7 +36,7 @@ import { LANGY_RELEASE_FLAG } from "~/utils/langyReleaseFlag";
  */
 export function useShowLangy(): boolean {
   const { data: session } = useRequiredSession();
-  const { team, project, organizationRole, hasPermission } =
+  const { team, project, organization, organizationRole, hasPermission } =
     useOrganizationTeamProject({
       redirectToOnboarding: false,
       redirectToProjectOnboarding: false,
@@ -53,9 +57,14 @@ export function useShowLangy(): boolean {
     userIsPartOfTeam && !isDemoProject && hasPermission("langy:view");
 
   // Skip the flag query entirely for callers who are already excluded; the
-  // answer is decided without a round-trip.
+  // answer is decided without a round-trip. Forward BOTH project and org ids,
+  // exactly like the server-side `hasLangyAccess` gate: a targeting rule scoped
+  // to an organization only matches when organizationId is in the evaluation
+  // context, so omitting it would hide the panel for an org that has actually
+  // been rolled out.
   const { enabled: releaseLangy } = useFeatureFlag(LANGY_RELEASE_FLAG, {
     projectId: project?.id,
+    organizationId: organization?.id,
     enabled: mayReadLangy,
   });
 

--- a/specs/langy/langy-baseline.feature
+++ b/specs/langy/langy-baseline.feature
@@ -49,8 +49,9 @@ Feature: Langy in-product AI assistant — baseline (v1)
 
   # ============================================================================
   # Access and rollout gating
-  # Covered by src/server/app-layer/langy/__tests__/langyAccessGate.unit.test.ts
-  # and src/features/langy/__tests__/ProjectLangyLayout.integration.test.tsx
+  # Covered by src/server/app-layer/langy/__tests__/langyAccessGate.unit.test.ts,
+  # src/features/langy/__tests__/ProjectLangyLayout.integration.test.tsx, and
+  # src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
   # ============================================================================
 
   Scenario: Without a rollout, Langy stays closed
@@ -62,6 +63,16 @@ Feature: Langy in-product AI assistant — baseline (v1)
     Given Langy has been rolled out to my account
     When I send a message to Langy in project "demo"
     Then the request is not rejected by the rollout gate
+
+  # A rollout can target a whole organization, not only a single project. The
+  # panel's visibility gate must honor an org-wide rollout the same way the API
+  # gate does — otherwise the org is authorized server-side but the handle never
+  # appears, because the gate resolved the flag with project context alone.
+  Scenario: An organization-wide rollout reveals the handle, not just the API
+    Given Langy has been rolled out to my whole organization
+    And no project-level rollout applies to project "demo"
+    When I navigate to any "/[project]/*" route in project "demo"
+    Then the Langy handle is visible
 
   # There is no identity that grants Langy on its own — no staff bypass, no
   # allowlisted address. The rollout is the only way in, so it also works as a


### PR DESCRIPTION
## Symptom

Langy doesn't appear in the UI for a user whose **organization** has `release_langy_enabled` turned on — even though they're a member with `langy:view`.

## Root cause

Two things compound on current `main`:

1. **#5966** (`feat(langy): flag-only access…`) removed the identity-based staff bypass entirely — access is now purely `release_langy_enabled`. So everyone depends on that flag resolving `true` for *their* evaluation context; there's no longer an `@langwatch.ai` shortcut.
2. **`useShowLangy` resolved the flag with `projectId` only**, never `organizationId`. The flag store's rule matcher (`server/featureFlag/rules.ts`) fails closed when a rule constrains an id the context doesn't carry, so an **org-scoped** targeting rule can never match client-side.

The server gate `hasLangyAccess` (`server/app-layer/langy/langyAccessGate.ts`) *does* forward `organizationId`. Net effect: an org-wide rollout **authorizes the tRPC procedures** while the **UI keeps the handle hidden** — the API would answer, but there's no way in.

## Fix

Forward `organizationId` (from `useOrganizationTeamProject`) into the `useFeatureFlag` call in `useShowLangy`, mirroring the server gate. The hook's options type already accepts it. This is purely additive — it can only let an *already-authorized* org rule surface the panel; it never grants beyond what the server allows.

```diff
 const { enabled: releaseLangy } = useFeatureFlag(LANGY_RELEASE_FLAG, {
   projectId: project?.id,
+  organizationId: organization?.id,
   enabled: mayReadLangy,
 });
```

## Tests

`src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx` — the `useFeatureFlag` mock reproduces the store's rule matcher, so the cases mean what they say:

- org-wide rollout (no project rule) → **panel visible** (the regression guard; **verified red without the fix**, green with it)
- project-scoped rollout → visible
- rollout for a *different* org → hidden
- no rollout → hidden

Ran the suite through the configured runner: **4 passed**.

Also adds an "organization-wide rollout reveals the handle, not just the API" scenario to `specs/langy/langy-baseline.feature` (Access and rollout gating).

## Immediate workaround (no deploy)

Until this ships, enable `release_langy_enabled` in `/ops/feature-flags` via a **per-project rule** (or a plain global toggle) rather than a per-org rule — the client already sends `projectId`, so those match today.

> Note: full `pnpm typecheck` intentionally not run (pins the machine on this monorepo per repo convention); the change is type-trivial (an already-declared optional field) and the tests exercise the compiled hook.

https://claude.ai/code/session_014wKWDe5JXkWRBRWncfUdt1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Langy panel visibility to match rollout targeting for both organization and project contexts.
  - Organization-wide rollouts now correctly reveal the Langy handle across eligible project routes.
  - The panel remains hidden when rollout rules target a different organization or no matching rollout applies.

- **Tests**
  - Added integration test coverage for Langy visibility behavior under org-level rollout, project-level rollout, mismatched org targeting, and missing rollout rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->