### PR TITLE
perf(test): vmForks + isolate:false for the unit suite (~4.5x less RAM)

### DIFF
--- a/langwatch/dev/docs/best_practices/vitest-performance.md
+++ b/langwatch/dev/docs/best_practices/vitest-performance.md
@@ -1,0 +1,53 @@
+# Vitest performance & memory
+
+Why the unit config (`langwatch/vitest.config.ts`) is shaped the way it is, and
+what we tried from <https://vitest.dev/guide/improving-performance> that did NOT
+pay off. Numbers are from a controlled benchmark (2026-07-21) on
+`src/features/traces-v2` (68 files, 705 tests) unless noted, `maxWorkers: 50%`.
+
+## The pool: `vmForks`, not `vmThreads`
+
+| pool | peak RSS | wall | notes |
+|---|---|---|---|
+| `vmThreads` (old) | **2.56 GB** | 8.2s | VM context leaks into the shared process heap |
+| `vmForks` (now) | **573 MB** | 9.5s | child process reclaims everything on exit |
+
+A VM pool (`vm*`) reuses a Node `vm` context, which is fast but leaks by design —
+that's why `vmMemoryLimit` exists (recycle a worker before it grows unbounded).
+Under `vmThreads` the leak lands in ONE shared process heap, so peak RSS climbs
+with the number of concurrent workers. Under `vmForks` each worker is its own
+process; when `vmMemoryLimit` recycles it, the OS reclaims 100% of it. ~4.5x less
+peak RSS for ~15% more wall-clock — the right trade on laptops juggling several
+worktrees. (Integration stays `pool: forks` — non-VM — for an unrelated reason:
+`@prisma/client` panics constructing inside a worker thread. See that config.)
+
+## `isolate: false`
+
+Reuses one VM context across the files in a worker instead of a fresh module
+registry per file. Verified correct across 172 sampled files (traces-v2 + a broad
+`src/server` slice, 0 failures) because the suite already resets shared state
+between tests. Small marginal RAM win on top of `vmForks` (~40 MB on the subset).
+The full-suite CI `test-unit` shards are the real scale check; **if a shard ever
+flakes, drop `isolate: false` first** — it is the only setting here that trades
+isolation for speed.
+
+## What we rejected
+
+- **`deps.optimizer` (esbuild pre-bundle of deps).** Measured a **~2x wall-clock
+  regression** (9.3s → 16.8s) with negligible RAM benefit, and it did NOT
+  amortize on a warm second run. The blanket form bundles everything, adding
+  transform overhead this ESM-first, 686-`vi.mock` suite doesn't recover. A
+  narrowly-scoped `optimizer.*.include` list of specific CJS-heavy deps might
+  help, but that's a per-dep investigation, not a blanket win — do not enable it
+  blanket.
+- **`isolate: false` on integration.** Integration runs `fileParallelism: false`
+  with heavy per-file container state; reusing a context there is high-risk and
+  low-reward. Left isolated.
+
+## Rules that still stand
+
+- Never hand-roll a throwaway config or run bare `npx vitest` — you drop
+  `maxWorkers`/`vmMemoryLimit` and spawn a fork per core. Go through
+  `pnpm test:unit run <path>` / `pnpm test:integration run <path>`.
+- Scope the run to a path instead of reaching for `--maxWorkers=1` (which
+  serialises and keeps memory resident far longer).

--- a/langwatch/vitest.config.ts
+++ b/langwatch/vitest.config.ts
@@ -7,9 +7,23 @@ config();
 export default defineConfig({
   test: {
     watch: false,
-    pool: "vmThreads",
+    // vmForks over vmThreads: the VM context leaks memory by design, but a
+    // forked child reclaims ALL of it on exit, whereas a worker THREAD's leak
+    // accumulates in the shared process heap. Measured on src/features/traces-v2
+    // (68 files): peak RSS 2.56GB (vmThreads) -> 573MB (vmForks), ~4.5x, for
+    // ~15% more wall-clock. vmMemoryLimit still recycles a worker before its
+    // context grows unbounded. See dev/docs/best_practices/vitest-performance.md.
+    pool: "vmForks",
     maxWorkers: "50%", // Low default for local dev; CI overrides with VITEST_MAX_WORKERS
-    vmMemoryLimit: "512MB", // Recycle workers aggressively — vmThreads leaks memory by design
+    vmMemoryLimit: "512MB", // Recycle a worker once its reused VM context hits this
+    // isolate:false reuses one VM context across the files in a worker instead
+    // of building a fresh module registry per file. Safe here because the suite
+    // resets shared state between tests (test-setup.ts + clearMocks-style
+    // cleanup), so cross-file leakage doesn't change results — verified across
+    // 172 sampled files (traces-v2 + a broad server slice) with zero failures.
+    // The full-suite CI test-unit shards are the scale check; if isolate:false
+    // ever flakes a shard, drop this line first.
+    isolate: false,
     testTimeout: 30000, // 30s default to handle slower CI runners
     // Global setup runs once before all tests. Unit needs no containers; this
     // only carries a CI-gated hard-floor that mirrors the integration


### PR DESCRIPTION
## What

Cuts the unit suite's peak memory ~4.5x by switching the pool from `vmThreads`
to `vmForks`, plus `isolate: false`. From <https://vitest.dev/guide/improving-performance>.

Measured on `src/features/traces-v2` (68 files, 705 tests), `maxWorkers: 50%`:

| config | peak RSS | wall | correct |
|---|---|---|---|
| `vmThreads` (old) | **2.56 GB** | 8.2s | ✓ |
| `vmForks` | **573 MB** | 9.5s | ✓ |
| `vmForks` + `isolate:false` | 535 MB | 9.3s | ✓ |

The VM context leaks by design (hence `vmMemoryLimit`); under `vmThreads` that
leak lands in one shared process heap so peak RSS scales with worker count.
`vmForks` gives each worker its own process, fully reclaimed on exit — the local
OOM fix for laptops running several worktrees' suites, at ~15% more wall-clock.
`isolate: false` reuses a worker's VM context across files; verified across 172
sampled files (0 failures). The full-suite CI `test-unit` shards are the scale
check — **if a shard flakes, dropping `isolate: false` is the first move**.

Integration config untouched (`pool: forks` is required — `@prisma/client`
panics constructing in a worker thread).

## Rejected (measured, not guessed)

**`deps.optimizer`** (the "bundle heavy deps once" lever) was a **~2x wall-clock
regression** (9.3s → 16.8s) with negligible RAM benefit and no warm-run
amortization on this ESM-first, 686-`vi.mock` suite. Not enabled. A narrowly
scoped `optimizer.*.include` list might help specific CJS deps, but that's a
separate per-dep investigation.

Rationale + method: `langwatch/dev/docs/best_practices/vitest-performance.md`.

## Validation

- Correctness: 172 sampled files across traces-v2 + a broad `src/server` slice, 0 failures.
- The real scale check is this PR's own CI `test-unit` shards — please confirm green before merge.

Independent of #6018 (the type-graph split); kept on its own branch so the
`isolate: false` change is validated by CI in isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved test execution stability and memory usage by switching the test runner’s VM pool strategy to process-based execution.
  * Enabled reuse of the VM context across files within a worker to reduce per-file overhead, with safeguards for state resetting.
* **Documentation**
  * Added best-practice guidance for Vitest performance and memory configuration, including recommended test-running commands and guidance for diagnosing and reverting flaky test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->