### PR TITLE
fix(langy): honor org-scoped rollout rules in the UI visibility gate

### DIFF
--- a/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
+++ b/langwatch/src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useShowLangy is Langy's UI visibility gate. #5966 made access flag-only (no
+ * identity bypass), which means the gate must resolve `release_langy_enabled`
+ * with the SAME project + organization context the server-side hasLangyAccess
+ * gate uses. Otherwise an org-wide rollout authorizes the tRPC procedures while
+ * the handle stays hidden — the exact asymmetry this test locks out.
+ *
+ * The `useFeatureFlag` mock reproduces the flag store's rule matcher
+ * (server/featureFlag/rules.ts): a targeting rule only matches when every id it
+ * constrains is present in, and equal to, the evaluation context.
+ *
+ * Spec: specs/langy/langy-baseline.feature ("Access and rollout gating")
+ */
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type FlagOptions = {
+  projectId?: string;
+  organizationId?: string;
+  enabled?: boolean;
+};
+
+// Boundary state, set per test. A `null` rule means "no rollout"; a rule with
+// only organizationId is an org-wide rollout, with only projectId a per-project
+// rollout.
+const gate: {
+  rule: { projectId?: string; organizationId?: string } | null;
+  lastFlagOptions: FlagOptions | undefined;
+} = {
+  rule: null,
+  lastFlagOptions: undefined,
+};
+
+vi.mock("~/hooks/useRequiredSession", () => ({
+  useRequiredSession: () => ({ data: { user: { id: "user-1" } } }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project-1", slug: "acme" },
+    team: {
+      isPersonal: false,
+      ownerUserId: "someone-else",
+      members: [{ userId: "user-1" }],
+    },
+    organization: { id: "org-1" },
+    organizationRole: "MEMBER",
+    hasPermission: (permission: string) => permission === "langy:view",
+  }),
+}));
+
+vi.mock("~/hooks/usePublicEnv", () => ({
+  // A demo slug that does NOT match the active project, so the demo-refusal
+  // branch stays out of the way and the rollout is what decides visibility.
+  usePublicEnv: () => ({ data: { DEMO_PROJECT_SLUG: "not-this-project" } }),
+}));
+
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: (_flag: string, options: FlagOptions) => {
+    gate.lastFlagOptions = options;
+    // Callers gated out upstream disable the query — mirror that short-circuit.
+    if (options?.enabled === false) return { enabled: false, isLoading: false };
+    const rule = gate.rule;
+    const matches =
+      rule !== null &&
+      (rule.projectId === undefined ||
+        rule.projectId === options?.projectId) &&
+      (rule.organizationId === undefined ||
+        rule.organizationId === options?.organizationId);
+    return { enabled: matches, isLoading: false };
+  },
+}));
+
+import { useShowLangy } from "../useShowLangy";
+
+afterEach(() => {
+  cleanup();
+  gate.rule = null;
+  gate.lastFlagOptions = undefined;
+});
+
+describe("useShowLangy", () => {
+  describe("given a team member with langy:view on a non-demo project", () => {
+    describe("when the rollout targets the whole organization and no project rule applies", () => {
+      it("reveals the panel by resolving the flag with organization context", () => {
+        gate.rule = { organizationId: "org-1" };
+
+        const { result } = renderHook(() => useShowLangy());
+
+        expect(result.current).toBe(true);
+        expect(gate.lastFlagOptions?.organizationId).toBe("org-1");
+      });
+    });
+
+    describe("when the rollout targets only the current project", () => {
+      it("reveals the panel", () => {
+        gate.rule = { projectId: "project-1" };
+
+        const { result } = renderHook(() => useShowLangy());
+
+        expect(result.current).toBe(true);
+      });
+    });
+
+    describe("when the rollout targets a different organization", () => {
+      it("keeps the panel hidden", () => {
+        gate.rule = { organizationId: "other-org" };
+
+        const { result } = renderHook(() => useShowLangy());
+
+        expect(result.current).toBe(false);
+      });
+    });
+
+    describe("when nothing has been rolled out", () => {
+      it("keeps the panel hidden", () => {
+        gate.rule = null;
+
+        const { result } = renderHook(() => useShowLangy());
+
+        expect(result.current).toBe(false);
+      });
+    });
+  });
+});

--- a/langwatch/src/features/langy/hooks/useShowLangy.ts
+++ b/langwatch/src/features/langy/hooks/useShowLangy.ts
@@ -21,10 +21,14 @@ import { LANGY_RELEASE_FLAG } from "~/utils/langyReleaseFlag";
  *    rather than this hook.
  * 3. Rollout — the `release_langy_enabled` flag must be on for this user.
  *    Defaults off in the registry, so everyone is dark until explicitly
- *    opted in; there is no identity-based bypass. This is UI hiding only;
- *    the authoritative check is the server-side `hasLangyAccess` gate on the
- *    Langy tRPC routers. Both read the same `LANGY_RELEASE_FLAG` key so the
- *    panel can't render against procedures that would 404 anyway.
+ *    opted in; there is no identity-based bypass. The flag is resolved with
+ *    the same project *and* organization context the server gate uses, so a
+ *    rollout targeted at the whole org reveals the panel too — not only a
+ *    per-project rule. This is UI hiding only; the authoritative check is the
+ *    server-side `hasLangyAccess` gate on the Langy tRPC routers. Both read the
+ *    same `LANGY_RELEASE_FLAG` key with the same context, so the panel can't
+ *    render against procedures that would 404 — nor stay hidden while those
+ *    procedures would happily answer.
  *
  * Consumed by ProjectLangyLayout (mounts the panel) and HomePageBanners
  * (picks the Langy activation banner over the promo teaser) — one gate,
@@ -32,7 +36,7 @@ import { LANGY_RELEASE_FLAG } from "~/utils/langyReleaseFlag";
  */
 export function useShowLangy(): boolean {
   const { data: session } = useRequiredSession();
-  const { team, project, organizationRole, hasPermission } =
+  const { team, project, organization, organizationRole, hasPermission } =
     useOrganizationTeamProject({
       redirectToOnboarding: false,
       redirectToProjectOnboarding: false,
@@ -53,9 +57,14 @@ export function useShowLangy(): boolean {
     userIsPartOfTeam && !isDemoProject && hasPermission("langy:view");
 
   // Skip the flag query entirely for callers who are already excluded; the
-  // answer is decided without a round-trip.
+  // answer is decided without a round-trip. Forward BOTH project and org ids,
+  // exactly like the server-side `hasLangyAccess` gate: a targeting rule scoped
+  // to an organization only matches when organizationId is in the evaluation
+  // context, so omitting it would hide the panel for an org that has actually
+  // been rolled out.
   const { enabled: releaseLangy } = useFeatureFlag(LANGY_RELEASE_FLAG, {
     projectId: project?.id,
+    organizationId: organization?.id,
     enabled: mayReadLangy,
   });
 

--- a/specs/langy/langy-baseline.feature
+++ b/specs/langy/langy-baseline.feature
@@ -49,8 +49,9 @@ Feature: Langy in-product AI assistant — baseline (v1)
 
   # ============================================================================
   # Access and rollout gating
-  # Covered by src/server/app-layer/langy/__tests__/langyAccessGate.unit.test.ts
-  # and src/features/langy/__tests__/ProjectLangyLayout.integration.test.tsx
+  # Covered by src/server/app-layer/langy/__tests__/langyAccessGate.unit.test.ts,
+  # src/features/langy/__tests__/ProjectLangyLayout.integration.test.tsx, and
+  # src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx
   # ============================================================================
 
   Scenario: Without a rollout, Langy stays closed
@@ -62,6 +63,16 @@ Feature: Langy in-product AI assistant — baseline (v1)
     Given Langy has been rolled out to my account
     When I send a message to Langy in project "demo"
     Then the request is not rejected by the rollout gate
+
+  # A rollout can target a whole organization, not only a single project. The
+  # panel's visibility gate must honor an org-wide rollout the same way the API
+  # gate does — otherwise the org is authorized server-side but the handle never
+  # appears, because the gate resolved the flag with project context alone.
+  Scenario: An organization-wide rollout reveals the handle, not just the API
+    Given Langy has been rolled out to my whole organization
+    And no project-level rollout applies to project "demo"
+    When I navigate to any "/[project]/*" route in project "demo"
+    Then the Langy handle is visible
 
   # There is no identity that grants Langy on its own — no staff bypass, no
   # allowlisted address. The rollout is the only way in, so it also works as a


### PR DESCRIPTION
## Symptom

Langy doesn't appear in the UI for a user whose **organization** has `release_langy_enabled` turned on — even though they're a member with `langy:view`.

## Root cause

Two things compound on current `main`:

1. **#5966** (`feat(langy): flag-only access…`) removed the identity-based staff bypass entirely — access is now purely `release_langy_enabled`. So everyone depends on that flag resolving `true` for *their* evaluation context; there's no longer an `@langwatch.ai` shortcut.
2. **`useShowLangy` resolved the flag with `projectId` only**, never `organizationId`. The flag store's rule matcher (`server/featureFlag/rules.ts`) fails closed when a rule constrains an id the context doesn't carry, so an **org-scoped** targeting rule can never match client-side.

The server gate `hasLangyAccess` (`server/app-layer/langy/langyAccessGate.ts`) *does* forward `organizationId`. Net effect: an org-wide rollout **authorizes the tRPC procedures** while the **UI keeps the handle hidden** — the API would answer, but there's no way in.

## Fix

Forward `organizationId` (from `useOrganizationTeamProject`) into the `useFeatureFlag` call in `useShowLangy`, mirroring the server gate. The hook's options type already accepts it. This is purely additive — it can only let an *already-authorized* org rule surface the panel; it never grants beyond what the server allows.

```diff
 const { enabled: releaseLangy } = useFeatureFlag(LANGY_RELEASE_FLAG, {
   projectId: project?.id,
+  organizationId: organization?.id,
   enabled: mayReadLangy,
 });
```

## Tests

`src/features/langy/hooks/__tests__/useShowLangy.integration.test.tsx` — the `useFeatureFlag` mock reproduces the store's rule matcher, so the cases mean what they say:

- org-wide rollout (no project rule) → **panel visible** (the regression guard; **verified red without the fix**, green with it)
- project-scoped rollout → visible
- rollout for a *different* org → hidden
- no rollout → hidden

Ran the suite through the configured runner: **4 passed**.

Also adds an "organization-wide rollout reveals the handle, not just the API" scenario to `specs/langy/langy-baseline.feature` (Access and rollout gating).

## Immediate workaround (no deploy)

Until this ships, enable `release_langy_enabled` in `/ops/feature-flags` via a **per-project rule** (or a plain global toggle) rather than a per-org rule — the client already sends `projectId`, so those match today.

> Note: full `pnpm typecheck` intentionally not run (pins the machine on this monorepo per repo convention); the change is type-trivial (an already-declared optional field) and the tests exercise the compiled hook.

https://claude.ai/code/session_014wKWDe5JXkWRBRWncfUdt1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Langy visibility to honor organization-level rollout settings alongside project-level settings.
  * Ensured the Langy handle appears on eligible project routes when organization-wide access is enabled.

* **Tests**
  * Added integration coverage for matching and non-matching organization/project rollout contexts.
  * Updated baseline scenarios for permission and rollout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
