### PR TITLE
fix(docker): repair + CI-guard the langyagent image build

### DIFF
--- a/.github/workflows/go-services.yaml
+++ b/.github/workflows/go-services.yaml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       service: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.service }}
       chart: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.chart }}
+      langyagent: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.langyagent }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -38,6 +39,34 @@ jobs:
               - '.github/workflows/go-services.yaml'
             chart:
               - 'charts/gateway/**'
+              - '.github/workflows/go-services.yaml'
+            langyagent:
+              # The langyagent image bakes in the langwatch CLI, and that CLI is
+              # generated AT IMAGE-BUILD TIME from inputs OUTSIDE the Go tree:
+              # typescript-sdk/ + skills/ + feature-map.json + a handful of
+              # langwatch/langevals source files (typescript-sdk/copy-types.sh +
+              # generate-skills-bundle.mjs). A change to any of those can break
+              # `docker build -f Dockerfile.langyagent` with no Go source
+              # touched — exactly the gap that shipped a broken build once
+              # (a new copy-types.sh input was never COPYed into the image).
+              # Validate the image build whenever any build input moves.
+              - 'services/langyagent/**'
+              - 'pkg/**'
+              - 'cmd/**'
+              - 'sdk-go/**'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Dockerfile.langyagent'
+              - 'typescript-sdk/**'
+              - 'packages/cli-cards/**'
+              - 'skills/**'
+              - 'feature-map.json'
+              - 'langwatch/src/server/tracer/types.ts'
+              - 'langwatch/src/server/filters/types.ts'
+              - 'langwatch/src/server/evaluations/types.ts'
+              - 'langwatch/src/server/modelProviders/llmModels.json'
+              - 'langwatch/src/app/api/openapiLangWatch.json'
+              - 'langevals/ts-integration/evaluators.generated.ts'
               - '.github/workflows/go-services.yaml'
 
   docker:
@@ -87,6 +116,39 @@ jobs:
             ${{ steps.meta.outputs.image }}:latest
           cache-from: type=gha,scope=gateway
           cache-to: type=gha,scope=gateway,mode=max
+
+  langyagent:
+    needs: changes
+    if: ${{ needs.changes.outputs.langyagent == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          driver-opts: image=moby/buildkit:buildx-stable-1
+
+      # Build-only guard: this image is NEVER pushed from here. The langyagent
+      # image is published solely by publish-docker-app.yml on a `langwatch@*`
+      # release; this job exists to fail a PR fast when a build input breaks the
+      # image, not to produce an artifact. amd64 only — the failure modes we're
+      # guarding (a missing copy-types.sh input, an unresolved generated import,
+      # a broken Go compile) are arch-independent, so an emulated arm64 build
+      # would triple the runtime for no extra signal. Shares the release
+      # workflow's amd64 cache scope so PR builds warm from it.
+      - name: Build langyagent image (no push)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v6
+        with:
+          context: .
+          file: Dockerfile.langyagent
+          push: false
+          platforms: linux/amd64
+          build-args: |
+            SERVICE_VERSION=${{ github.sha }}
+          cache-from: type=gha,scope=langyagent-amd64
+          cache-to: type=gha,scope=langyagent-amd64,mode=max
 
   helm:
     needs: changes

--- a/Dockerfile.langyagent
+++ b/Dockerfile.langyagent
@@ -129,6 +129,13 @@ COPY langwatch/src/server/evaluations/types.ts        /src/langwatch/src/server/
 COPY langwatch/src/server/modelProviders/llmModels.json /src/langwatch/src/server/modelProviders/llmModels.json
 COPY langwatch/src/app/api/openapiLangWatch.json      /src/langwatch/src/app/api/openapiLangWatch.json
 COPY langevals/ts-integration/evaluators.generated.ts /src/langevals/ts-integration/evaluators.generated.ts
+# copy-types.sh also embeds the repo-root feature-map.json (feature-map.generated.ts),
+# and generate-skills-bundle.mjs walks the whole skills/ tree (feature-skills.ts,
+# each published SKILL.mdx, recipes/, version.txt, and the committed _compiled/native
+# renders). Bring both in at the ../ paths those generators expect relative to
+# /src/typescript-sdk, or `pnpm run prepare` dies with `Cannot find module '../feature-map.json'`.
+COPY feature-map.json                                 /src/feature-map.json
+COPY skills                                            /src/skills
 RUN pnpm run prepare
 
 # BuildKit fills TARGETARCH from the target platform. Map it to Bun's target


### PR DESCRIPTION
## What

The single langwatch-side PR for the **langyagent** image build. Two changes (docker-only — the langy org-rollout UI fix landed separately on `main` via #6022):

1. **Repair the image build.** `Dockerfile.langyagent`'s `cli-builder` stage COPYs a *curated* list of the inputs `typescript-sdk/copy-types.sh` reads. That script gained two it reads from **outside** `typescript-sdk/` — the repo-root `feature-map.json`, and the whole `skills/` tree (walked by `generate-skills-bundle.mjs`) — but the COPY list was never updated, so `RUN pnpm run prepare` died with `Cannot find module '../feature-map.json'`. Add the two missing COPYs.

2. **Guard it in CI.** Add a build-only (`push: false`, amd64) `langyagent` job to `go-services.yaml`, gated by a paths-filter covering every langyagent build input — the Go tree, `Dockerfile.langyagent`, `typescript-sdk/`, `packages/cli-cards/`, `skills/`, `feature-map.json`, and the `langwatch/`+`langevals/` sources `copy-types.sh` reads. A PR that moves any of those now rebuilds the image in the monorepo's own CI and fails fast; previously this class of breakage surfaced only in langwatch-saas CI.

## Verification

- **Local:** `docker build -f Dockerfile.langyagent -t langyagent:dev .` → 807MB image (in-image `langwatch --version` = 0.34.0, `opencode --version` OK); `cd typescript-sdk && pnpm install && pnpm run build:binary` → `dist/bin/langwatch` (61.7MB, bun; `langwatch skills list` → 19-skill bundle).
- **CI:** the new `go-services / langyagent` job built the image green in 3m54s.

## Related

- **Supersedes #6019** (same COPY fix, no CI guard) and **#6020** (had these two files folded into the langy commit before the langy fix landed via #6022) — both now closed.
- **Companion:** langwatch-saas#782 adds `feature-map.json` to the saas `langy-agent` change-detection filter (the saas mirror of the guard here).
- ⚠️ **Submodule caution:** monorepo `main` already carries the `feature-map.json` codegen but not this COPY fix, so the langwatch-saas `langwatch` submodule must not be bumped to current main until this merges — doing so breaks the langy image build.

https://claude.ai/code/session_014wKWDe5JXkWRBRWncfUdt1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Langyagent image builds by including required feature and skills resources during preparation.
  * Added automated build validation for Langyagent changes, helping detect image build failures before publishing.

* **Chores**
  * Expanded build change detection to cover all relevant Langyagent image inputs.
  * Enabled cached, architecture-specific build validation for faster checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->