### PR TITLE
fix(api): gate project base-key reads on project:update

### DIFF
--- a/langwatch/src/app/api/middleware/org-auth.ts
+++ b/langwatch/src/app/api/middleware/org-auth.ts
@@ -14,8 +14,65 @@ export type OrgAuthMiddlewareVariables = {
   orgResolvedToken: OrgResolvedToken;
 };
 
-export const orgAuthMiddleware: MiddlewareHandler =
-  createOrgAuthMiddleware({ prisma });
+export const orgAuthMiddleware: MiddlewareHandler = createOrgAuthMiddleware({
+  prisma,
+});
+
+/**
+ * Authorizes an org-app route against the project it names, rather than the
+ * organization. Org-scoped bindings still pass — they are ancestors of project
+ * scope — while a team- or project-scoped grant reaches only its own projects.
+ *
+ * A project outside the caller's organization is reported as not found: its
+ * existence is not the caller's to learn.
+ */
+export function requireProjectPermission({
+  permission,
+  param,
+}: {
+  permission: Permission;
+  param: string;
+}): MiddlewareHandler {
+  return async (c, next) => {
+    const organization = c.get("organization") as Organization;
+    const projectId = c.req.param(param);
+
+    const project = projectId
+      ? await prisma.project.findUnique({
+          where: { id: projectId },
+          select: {
+            id: true,
+            team: { select: { id: true, organizationId: true } },
+          },
+        })
+      : null;
+
+    if (!project || project.team.organizationId !== organization.id) {
+      return c.json({ error: "Not Found", message: "Project not found" }, 404);
+    }
+
+    const allowed = await resolveApiKeyPermission({
+      prisma,
+      apiKeyId: c.get("apiKeyId") as string,
+      userId: c.get("apiKeyUserId") as string | null,
+      organizationId: organization.id,
+      scope: { type: "project", id: project.id, teamId: project.team.id },
+      permission,
+    });
+
+    if (!allowed) {
+      return c.json(
+        {
+          error: "Forbidden",
+          message: `Insufficient permissions. Required: ${permission}`,
+        },
+        403,
+      );
+    }
+
+    await next();
+  };
+}
 
 export function requireOrgPermission(
   permission: Permission,

--- a/langwatch/src/app/api/projects/[[...route]]/app.ts
+++ b/langwatch/src/app/api/projects/[[...route]]/app.ts
@@ -2,7 +2,11 @@ import type { Organization } from "@prisma/client";
 import { describeRoute } from "hono-openapi";
 import { validator as zValidator } from "hono-openapi/zod";
 import { z } from "zod";
-import { createOrgApp, requires } from "~/server/api/security";
+import {
+  createOrgApp,
+  requires,
+  requiresOnProject,
+} from "~/server/api/security";
 import type { ApiKeyService } from "~/server/api-key/api-key.service";
 import {
   DestinationTeamNotFoundError,
@@ -282,8 +286,14 @@ secured.access(requires("project:delete")).delete(
 
 // ── API Key management ───────────────────────────────────────────────────────
 
+/**
+ * The base key is a project-level write credential, so reading it is gated
+ * with `project:update` to match the access it grants — not `project:view`.
+ * `requiresOnProject` resolves that at the named project's scope rather than
+ * the organization's, so one org-wide grant does not reach every project.
+ */
 secured
-  .access(requires("project:view"))
+  .access(requiresOnProject("project:update"))
   .get(
     "/:id/api-key",
     projectServiceMiddleware,

--- a/langwatch/src/app/api/projects/__tests__/projects-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/projects/__tests__/projects-rest-api.integration.test.ts
@@ -27,8 +27,7 @@ describe("Feature: Projects REST API", () => {
   });
 
   const api = {
-    get: (path: string) =>
-      app.request(path, { headers: authHeaders() }),
+    get: (path: string) => app.request(path, { headers: authHeaders() }),
     post: (path: string, body: unknown) =>
       app.request(path, {
         method: "POST",
@@ -115,27 +114,41 @@ describe("Feature: Projects REST API", () => {
   });
 
   afterAll(async () => {
-    await prisma.project.deleteMany({
-      where: { team: { organizationId: testOrganization.id } },
-    }).catch(() => {});
-    await prisma.roleBinding.deleteMany({
-      where: { organizationId: testOrganization.id },
-    }).catch(() => {});
-    await prisma.apiKey.deleteMany({
-      where: { organizationId: testOrganization.id },
-    }).catch(() => {});
-    await prisma.teamUser.deleteMany({
-      where: { userId },
-    }).catch(() => {});
-    await prisma.organizationUser.deleteMany({
-      where: { organizationId: testOrganization.id },
-    }).catch(() => {});
-    await prisma.team.deleteMany({
-      where: { organizationId: testOrganization.id },
-    }).catch(() => {});
-    await prisma.organization.delete({
-      where: { id: testOrganization.id },
-    }).catch(() => {});
+    await prisma.project
+      .deleteMany({
+        where: { team: { organizationId: testOrganization.id } },
+      })
+      .catch(() => {});
+    await prisma.roleBinding
+      .deleteMany({
+        where: { organizationId: testOrganization.id },
+      })
+      .catch(() => {});
+    await prisma.apiKey
+      .deleteMany({
+        where: { organizationId: testOrganization.id },
+      })
+      .catch(() => {});
+    await prisma.teamUser
+      .deleteMany({
+        where: { userId },
+      })
+      .catch(() => {});
+    await prisma.organizationUser
+      .deleteMany({
+        where: { organizationId: testOrganization.id },
+      })
+      .catch(() => {});
+    await prisma.team
+      .deleteMany({
+        where: { organizationId: testOrganization.id },
+      })
+      .catch(() => {});
+    await prisma.organization
+      .delete({
+        where: { id: testOrganization.id },
+      })
+      .catch(() => {});
   });
 
   describe("Authentication", () => {
@@ -224,8 +237,7 @@ describe("Feature: Projects REST API", () => {
       });
       expect(res.status).toBe(400);
     });
-
-});
+  });
 
   describe("GET /api/projects", () => {
     it("lists non-archived projects for the organization", async () => {
@@ -406,8 +418,12 @@ describe("Feature: Projects REST API", () => {
         });
         expect(res.status).toBe(400);
 
-        await prisma.team.delete({ where: { id: otherTeam.id } }).catch(() => {});
-        await prisma.organization.delete({ where: { id: otherOrg.id } }).catch(() => {});
+        await prisma.team
+          .delete({ where: { id: otherTeam.id } })
+          .catch(() => {});
+        await prisma.organization
+          .delete({ where: { id: otherOrg.id } })
+          .catch(() => {});
       });
 
       /** @scenario PATCH with teamId and name is atomic */
@@ -465,6 +481,125 @@ describe("Feature: Projects REST API", () => {
     it("returns 404 for non-existent project", async () => {
       const res = await api.delete("/api/projects/project_nope");
       expect(res.status).toBe(404);
+    });
+  });
+
+  /**
+   * @see specs/api-keys/project-key-read-access.feature
+   *
+   * The base key is a project-level write credential, so reading it needs
+   * `project:update` on the project being asked for.
+   */
+  describe("GET /api/projects/:id/api-key", () => {
+    const getAs = (path: string, token: string) =>
+      app.request(path, { headers: { Authorization: `Bearer ${token}` } });
+
+    const mintKey = async (permissions: string[], scopeId: string) =>
+      (
+        await ApiKeyService.create(prisma).create({
+          name: `scoped-${nanoid(6)}`,
+          userId,
+          createdByUserId: userId,
+          organizationId: testOrganization.id,
+          permissionMode: "restricted",
+          permissions,
+          bindings: [
+            {
+              role: TeamUserRole.CUSTOM,
+              scopeType:
+                scopeId === testOrganization.id
+                  ? RoleBindingScopeType.ORGANIZATION
+                  : RoleBindingScopeType.PROJECT,
+              scopeId,
+            },
+          ],
+        })
+      ).token;
+
+    const createProject = async () => {
+      const res = await api.post("/api/projects", {
+        name: `Key Test ${nanoid(6)}`,
+        teamId: testTeam.id,
+        language: "python",
+        framework: "langchain",
+      });
+      return (await res.json()).id as string;
+    };
+
+    let projectId: string;
+    beforeAll(async () => {
+      projectId = await createProject();
+    });
+
+    it("returns the base key to a caller who can update the project", async () => {
+      const res = await api.get(`/api/projects/${projectId}/api-key`);
+      expect(res.status).toBe(200);
+      expect((await res.json()).apiKey).toBeTruthy();
+    });
+
+    it("refuses a caller who can only view the project", async () => {
+      const token = await mintKey(["project:view"], testOrganization.id);
+
+      const res = await getAs(`/api/projects/${projectId}/api-key`, token);
+
+      expect(res.status).toBe(403);
+      const stored = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { apiKey: true },
+      });
+      expect(await res.text()).not.toContain(stored!.apiKey);
+    });
+
+    it("refuses a project-scoped caller asking about a sibling project", async () => {
+      const sibling = await createProject();
+      const token = await mintKey(["project:update"], projectId);
+
+      const own = await getAs(`/api/projects/${projectId}/api-key`, token);
+      expect(own.status).toBe(200);
+
+      const other = await getAs(`/api/projects/${sibling}/api-key`, token);
+      expect(other.status).toBe(403);
+
+      const stored = await prisma.project.findUnique({
+        where: { id: sibling },
+        select: { apiKey: true },
+      });
+      expect(await other.text()).not.toContain(stored!.apiKey);
+    });
+
+    it("reports a project in another organization as not found", async () => {
+      const otherOrg = await prisma.organization.create({
+        data: { name: "Other Org", slug: `--test-other-${nanoid(8)}` },
+      });
+      const otherTeam = await prisma.team.create({
+        data: {
+          name: "Other Team",
+          slug: `--test-other-team-${nanoid(8)}`,
+          organizationId: otherOrg.id,
+        },
+      });
+      const foreign = await prisma.project.create({
+        data: {
+          name: "Foreign",
+          slug: `--test-foreign-${nanoid(8)}`,
+          apiKey: `test-foreign-${nanoid(16)}`,
+          teamId: otherTeam.id,
+          language: "python",
+          framework: "langchain",
+        },
+      });
+
+      const res = await api.get(`/api/projects/${foreign.id}/api-key`);
+      expect(res.status).toBe(404);
+      expect(await res.text()).not.toContain(foreign.apiKey);
+
+      await prisma.project
+        .delete({ where: { id: foreign.id } })
+        .catch(() => {});
+      await prisma.team.delete({ where: { id: otherTeam.id } }).catch(() => {});
+      await prisma.organization
+        .delete({ where: { id: otherOrg.id } })
+        .catch(() => {});
     });
   });
 });

--- a/langwatch/src/app/api/projects/__tests__/projects-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/projects/__tests__/projects-rest-api.integration.test.ts
@@ -250,6 +250,7 @@ describe("Feature: Projects REST API", () => {
       expect(body.pagination.page).toBe(1);
     });
 
+    /** @scenario Listing projects never discloses base keys */
     it("does not include apiKey in list response", async () => {
       await api.post("/api/projects", {
         name: `List Test ${nanoid(6)}`,
@@ -275,6 +276,7 @@ describe("Feature: Projects REST API", () => {
   });
 
   describe("GET /api/projects/:id", () => {
+    /** @scenario Reading a project never discloses its base key */
     it("returns a project without apiKey", async () => {
       const createRes = await api.post("/api/projects", {
         name: `Get Test ${nanoid(6)}`,
@@ -531,12 +533,20 @@ describe("Feature: Projects REST API", () => {
       projectId = await createProject();
     });
 
+    /** @scenario A caller who can change the project reads the base key */
     it("returns the base key to a caller who can update the project", async () => {
+      const stored = await prisma.project.findUnique({
+        where: { id: projectId },
+        select: { apiKey: true },
+      });
+
       const res = await api.get(`/api/projects/${projectId}/api-key`);
+
       expect(res.status).toBe(200);
-      expect((await res.json()).apiKey).toBeTruthy();
+      expect((await res.json()).apiKey).toBe(stored!.apiKey);
     });
 
+    /** @scenario A read-only credential cannot read the base key */
     it("refuses a caller who can only view the project", async () => {
       const token = await mintKey(["project:view"], testOrganization.id);
 
@@ -550,6 +560,7 @@ describe("Feature: Projects REST API", () => {
       expect(await res.text()).not.toContain(stored!.apiKey);
     });
 
+    /** @scenario Permission is checked against the requested project */
     it("refuses a project-scoped caller asking about a sibling project", async () => {
       const sibling = await createProject();
       const token = await mintKey(["project:update"], projectId);
@@ -567,6 +578,7 @@ describe("Feature: Projects REST API", () => {
       expect(await other.text()).not.toContain(stored!.apiKey);
     });
 
+    /** @scenario A project in another organization is not disclosed */
     it("reports a project in another organization as not found", async () => {
       const otherOrg = await prisma.organization.create({
         data: { name: "Other Org", slug: `--test-other-${nanoid(8)}` },

--- a/langwatch/src/server/api-key/__tests__/api-key.verify.integration.test.ts
+++ b/langwatch/src/server/api-key/__tests__/api-key.verify.integration.test.ts
@@ -1,0 +1,217 @@
+import { generate } from "@langwatch/ksuid";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+import { KSUID_RESOURCES } from "~/utils/constants";
+import { ApiKeyService } from "../api-key.service";
+
+/**
+ * Authentication-time rejection of keys that should no longer work.
+ *
+ * These run against a real database on purpose: the deactivated-owner guard
+ * lives in the lookup's `where` clause, so a mocked repository would only
+ * hand back whatever the test told it to.
+ *
+ * @see specs/api-keys/unified-api-keys.feature
+ */
+describe("Feature: API key verification", () => {
+  const ns = `apikey-verify-${nanoid(8)}`;
+  const service = ApiKeyService.create(prisma);
+
+  let organizationId: string;
+  let userId: string;
+
+  /** The minting ceiling reads role bindings, not OrganizationUser rows. */
+  const grantOrgAdmin = async (id: string) => {
+    await prisma.roleBinding.create({
+      data: {
+        id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+        organizationId,
+        userId: id,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: organizationId,
+      },
+    });
+  };
+
+  const mintKey = async () => {
+    const created = await service.create({
+      name: `verify-${nanoid(6)}`,
+      userId,
+      createdByUserId: userId,
+      organizationId,
+      permissionMode: "all",
+      bindings: [
+        {
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: organizationId,
+        },
+      ],
+    });
+    return created;
+  };
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: "Verify Test Org", slug: `--test-org-${ns}` },
+    });
+    organizationId = organization.id;
+
+    const user = await prisma.user.create({
+      data: { name: "Verify Test User", email: `test-${ns}@example.com` },
+    });
+    userId = user.id;
+
+    await prisma.organizationUser.create({
+      data: {
+        userId,
+        organizationId,
+        role: OrganizationUserRole.ADMIN,
+      },
+    });
+    await grantOrgAdmin(userId);
+  });
+
+  afterAll(async () => {
+    await prisma.roleBinding
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.apiKey
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.organizationUser
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.organization
+      .delete({ where: { id: organizationId } })
+      .catch(() => {});
+    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+  });
+
+  describe("given a freshly minted key", () => {
+    it("verifies the token", async () => {
+      const { token, apiKey } = await mintKey();
+
+      const verified = await service.verify({ token });
+
+      expect(verified?.id).toBe(apiKey.id);
+    });
+
+    describe("when the token has been tampered with", () => {
+      it("rejects it", async () => {
+        const { token } = await mintKey();
+
+        const verified = await service.verify({ token: `${token}x` });
+
+        expect(verified).toBeNull();
+      });
+    });
+  });
+
+  describe("given the key has been revoked", () => {
+    it("rejects it at authentication", async () => {
+      const { token, apiKey } = await mintKey();
+      await expect(service.verify({ token })).resolves.not.toBeNull();
+
+      await prisma.apiKey.update({
+        where: { id: apiKey.id },
+        data: { revokedAt: new Date() },
+      });
+
+      await expect(service.verify({ token })).resolves.toBeNull();
+    });
+  });
+
+  describe("given the key has expired", () => {
+    it("rejects it at authentication", async () => {
+      const { token, apiKey } = await mintKey();
+
+      await prisma.apiKey.update({
+        where: { id: apiKey.id },
+        data: { expiresAt: new Date(Date.now() - 60_000) },
+      });
+
+      await expect(service.verify({ token })).resolves.toBeNull();
+    });
+
+    describe("when the expiry is still in the future", () => {
+      it("verifies the token", async () => {
+        const { token, apiKey } = await mintKey();
+
+        await prisma.apiKey.update({
+          where: { id: apiKey.id },
+          data: { expiresAt: new Date(Date.now() + 3_600_000) },
+        });
+
+        await expect(service.verify({ token })).resolves.not.toBeNull();
+      });
+    });
+  });
+
+  describe("given the owning user has been deactivated", () => {
+    /**
+     * Offboarding a person must take their keys with them, without anyone
+     * having to revoke each one by hand.
+     */
+    it("rejects the key at authentication", async () => {
+      const deactivated = await prisma.user.create({
+        data: {
+          name: "Deactivated User",
+          email: `deactivated-${ns}@example.com`,
+        },
+      });
+      await prisma.organizationUser.create({
+        data: {
+          userId: deactivated.id,
+          organizationId,
+          role: OrganizationUserRole.MEMBER,
+        },
+      });
+      await grantOrgAdmin(deactivated.id);
+
+      const { token } = await service.create({
+        name: `deactivated-${nanoid(6)}`,
+        userId: deactivated.id,
+        createdByUserId: deactivated.id,
+        organizationId,
+        permissionMode: "all",
+        bindings: [
+          {
+            role: TeamUserRole.ADMIN,
+            scopeType: RoleBindingScopeType.ORGANIZATION,
+            scopeId: organizationId,
+          },
+        ],
+      });
+      await expect(service.verify({ token })).resolves.not.toBeNull();
+
+      await prisma.user.update({
+        where: { id: deactivated.id },
+        data: { deactivatedAt: new Date() },
+      });
+
+      await expect(service.verify({ token })).resolves.toBeNull();
+
+      await prisma.roleBinding
+        .deleteMany({ where: { userId: deactivated.id } })
+        .catch(() => {});
+      await prisma.apiKey
+        .deleteMany({ where: { userId: deactivated.id } })
+        .catch(() => {});
+      await prisma.organizationUser
+        .deleteMany({ where: { userId: deactivated.id } })
+        .catch(() => {});
+      await prisma.user
+        .delete({ where: { id: deactivated.id } })
+        .catch(() => {});
+    });
+  });
+});

--- a/langwatch/src/server/api-key/__tests__/auth-middleware.ceiling.unit.test.ts
+++ b/langwatch/src/server/api-key/__tests__/auth-middleware.ceiling.unit.test.ts
@@ -1,0 +1,216 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resolveApiKeyPermission } from "~/server/rbac/role-binding-resolver";
+import type { ResolvedToken } from "../token-resolver";
+import {
+  apiKeyCeilingDenialResponse,
+  enforceApiKeyCeiling,
+  requireApiKeyPermission,
+} from "../auth-middleware";
+
+/**
+ * Enforcement side of the API-key ceiling — the middleware and the guard it
+ * wraps. The resolver itself is covered by
+ * `role-binding-resolver.ceiling.unit.test.ts`; here it is stubbed so each
+ * branch of the enforcement path can be steered directly.
+ *
+ * @see specs/api-keys/scope-based-permissions.feature
+ */
+
+vi.mock("~/server/rbac/role-binding-resolver", () => ({
+  resolveApiKeyPermission: vi.fn(),
+}));
+
+const resolveMock = vi.mocked(resolveApiKeyPermission);
+
+const prisma = {} as never;
+
+const project = {
+  id: "proj1",
+  team: { id: "team1", organizationId: "org1" },
+} as unknown as ResolvedToken["project"];
+
+const apiKeyToken: ResolvedToken = {
+  type: "apiKey",
+  apiKeyId: "apikey1",
+  userId: "user1",
+  organizationId: "org1",
+  ingestSourceType: null,
+  ingestionTemplateId: null,
+  project,
+};
+
+const legacyProjectKeyToken: ResolvedToken = {
+  type: "legacyProjectKey",
+  project,
+};
+
+/**
+ * Mounts the middleware behind a stub that seeds `resolvedToken`, so the test
+ * drives it through a real Hono request rather than a hand-built context.
+ */
+function appWith(resolved: ResolvedToken | undefined) {
+  const handler = vi.fn((c: { text: (body: string) => Response }) =>
+    c.text("reached"),
+  );
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    if (resolved) c.set("resolvedToken" as never, resolved as never);
+    await next();
+  });
+  app.use(
+    "*",
+    requireApiKeyPermission({ prisma, permission: "project:update" }),
+  );
+  app.get("/", handler as never);
+  return { app, handler };
+}
+
+beforeEach(() => {
+  resolveMock.mockReset();
+});
+
+describe("enforceApiKeyCeiling()", () => {
+  describe("given a scoped API key", () => {
+    describe("when the ceiling grants the permission", () => {
+      it("returns without throwing", async () => {
+        resolveMock.mockResolvedValue(true);
+
+        await expect(
+          enforceApiKeyCeiling({
+            prisma,
+            resolved: apiKeyToken,
+            permission: "project:update",
+          }),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe("when the ceiling denies the permission", () => {
+      it("throws a permission-denied error naming the permission", async () => {
+        resolveMock.mockResolvedValue(false);
+
+        await expect(
+          enforceApiKeyCeiling({
+            prisma,
+            resolved: apiKeyToken,
+            permission: "project:update",
+          }),
+        ).rejects.toMatchObject({ code: "api_key_permission_denied" });
+      });
+    });
+
+    describe("when resolving the permission", () => {
+      it("scopes the check to the token's own project and team", async () => {
+        resolveMock.mockResolvedValue(true);
+
+        await enforceApiKeyCeiling({
+          prisma,
+          resolved: apiKeyToken,
+          permission: "project:update",
+        });
+
+        expect(resolveMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            apiKeyId: "apikey1",
+            userId: "user1",
+            organizationId: "org1",
+            permission: "project:update",
+            scope: { type: "project", id: "proj1", teamId: "team1" },
+          }),
+        );
+      });
+    });
+  });
+
+  describe("given a legacy project key", () => {
+    /**
+     * Characterization, not endorsement: legacy project keys are exempt from
+     * the ceiling and reach every permission on their project. Pinned so that
+     * narrowing this later is a deliberate, visible change rather than a
+     * silent one.
+     */
+    it("skips the ceiling entirely", async () => {
+      await expect(
+        enforceApiKeyCeiling({
+          prisma,
+          resolved: legacyProjectKeyToken,
+          permission: "project:update",
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(resolveMock).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("requireApiKeyPermission()", () => {
+  describe("given a scoped API key", () => {
+    describe("when the ceiling grants the permission", () => {
+      it("runs the route handler", async () => {
+        resolveMock.mockResolvedValue(true);
+        const { app, handler } = appWith(apiKeyToken);
+
+        const res = await app.request("/");
+
+        expect(res.status).toBe(200);
+        expect(handler).toHaveBeenCalled();
+      });
+    });
+
+    describe("when the ceiling denies the permission", () => {
+      it("answers 403 and never reaches the handler", async () => {
+        resolveMock.mockResolvedValue(false);
+        const { app, handler } = appWith(apiKeyToken);
+
+        const res = await app.request("/");
+
+        expect(res.status).toBe(403);
+        await expect(res.json()).resolves.toMatchObject({ error: "Forbidden" });
+        expect(handler).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given a legacy project key", () => {
+    it("runs the route handler without consulting the ceiling", async () => {
+      const { app, handler } = appWith(legacyProjectKeyToken);
+
+      const res = await app.request("/");
+
+      expect(res.status).toBe(200);
+      expect(handler).toHaveBeenCalled();
+      expect(resolveMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given no token was resolved onto the context", () => {
+    /**
+     * The middleware passes the request through when nothing authenticated it.
+     * That is safe only while it is chained behind the unified auth middleware,
+     * which rejects unauthenticated callers first — mounted alone, this gate
+     * does nothing. Pinned so the fail-open is an asserted decision and any
+     * future mis-wiring has to change a test to land.
+     */
+    it("passes the request through without any permission check", async () => {
+      const { app, handler } = appWith(undefined);
+
+      const res = await app.request("/");
+
+      expect(res.status).toBe(200);
+      expect(handler).toHaveBeenCalled();
+      expect(resolveMock).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("apiKeyCeilingDenialResponse()", () => {
+  describe("when handed an unrelated error", () => {
+    it("re-throws it rather than reporting a denial", () => {
+      const boom = new Error("connection reset");
+
+      expect(() => apiKeyCeilingDenialResponse(boom)).toThrow(boom);
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/organization.base-key-redaction.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.base-key-redaction.integration.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @vitest-environment node
+ *
+ * @see specs/api-keys/project-key-read-access.feature
+ *
+ * The project base key travels inside the payload the app loads on every page,
+ * so gating the endpoints that return it is only half the job — what the
+ * session already holds has to be gated too.
+ */
+import { generate } from "@langwatch/ksuid";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { prisma } from "~/server/db";
+import { KSUID_RESOURCES } from "~/utils/constants";
+import { globalForApp, resetApp } from "../../../app-layer/app";
+import { OrganizationService } from "../../../app-layer/organizations/organization.service";
+import { PrismaOrganizationRepository } from "../../../app-layer/organizations/repositories/organization.prisma.repository";
+import { createTestApp } from "../../../app-layer/presets";
+import { PlanProviderService } from "../../../app-layer/subscription/plan-provider";
+import { appRouter } from "../../root";
+import { createInnerTRPCContext } from "../../trpc";
+
+const { mockGetActivePlan } = vi.hoisted(() => ({
+  mockGetActivePlan: vi.fn(),
+}));
+
+const ns = `basekey-redaction-${nanoid(8)}`;
+
+const callerFor = (userId: string) =>
+  appRouter.createCaller(
+    createInnerTRPCContext({ session: { user: { id: userId }, expires: "1" } }),
+  );
+
+const projectApiKeyFor = async (
+  caller: ReturnType<typeof callerFor>,
+  projectId: string,
+) => {
+  const organizations = await caller.organization.getAll({});
+  const projects = organizations.flatMap((organization) =>
+    organization.teams.flatMap((team) => team.projects),
+  );
+  return projects.find((project) => project.id === projectId)?.apiKey;
+};
+
+describe("Feature: base key in the organizations payload", () => {
+  let organizationId: string;
+  let teamId: string;
+  let projectId: string;
+  let baseApiKey: string;
+
+  let updaterCaller: ReturnType<typeof callerFor>;
+  let viewerCaller: ReturnType<typeof callerFor>;
+
+  /**
+   * Bound at TEAM scope: an organization-scoped MEMBER binding carries only
+   * org-level permissions, so it would not grant `project:update` however the
+   * redaction behaved.
+   */
+  const makeUser = async (label: string, teamRole: TeamUserRole) => {
+    const user = await prisma.user.create({
+      data: { name: `${label} ${ns}`, email: `${label}-${ns}@example.com` },
+    });
+    await prisma.organizationUser.create({
+      data: {
+        userId: user.id,
+        organizationId,
+        role: OrganizationUserRole.MEMBER,
+      },
+    });
+    await prisma.teamUser.create({
+      data: { userId: user.id, teamId, role: teamRole },
+    });
+    await prisma.roleBinding.create({
+      data: {
+        id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+        organizationId,
+        userId: user.id,
+        role: teamRole,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: teamId,
+      },
+    });
+    return user.id;
+  };
+
+  beforeAll(async () => {
+    mockGetActivePlan.mockResolvedValue({
+      planSource: "subscription" as const,
+      type: "ENTERPRISE",
+      name: "Enterprise",
+      free: false,
+      maxMembers: 100,
+      maxMembersLite: 100,
+      maxTeams: 50,
+      maxProjects: 100,
+      maxMessagesPerMonth: 1_000_000,
+      maxWorkflows: 50,
+      maxPrompts: 50,
+      maxEvaluators: 50,
+      maxScenarios: 50,
+      maxAgents: 50,
+      maxExperiments: 50,
+      maxOnlineEvaluations: 50,
+      maxDatasets: 50,
+      maxDashboards: 50,
+      maxCustomGraphs: 50,
+      maxAutomations: 50,
+      canPublish: true,
+      prices: { USD: 0, EUR: 0 },
+      overrideAddingLimitations: false,
+    });
+    globalForApp.__langwatch_app = createTestApp({
+      organizations: new OrganizationService(
+        new PrismaOrganizationRepository(prisma),
+        // Not exercised here; the constructor just needs something.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { seedForOrg: async () => {} } as any,
+      ),
+      planProvider: PlanProviderService.create({
+        getActivePlan: mockGetActivePlan,
+      }),
+    });
+
+    const organization = await prisma.organization.create({
+      data: { name: `Base Key Org ${ns}`, slug: `--test-org-${ns}` },
+    });
+    organizationId = organization.id;
+
+    const team = await prisma.team.create({
+      data: {
+        name: `Base Key Team ${ns}`,
+        slug: `--test-team-${ns}`,
+        organizationId,
+      },
+    });
+    teamId = team.id;
+
+    baseApiKey = `test-base-key-${ns}`;
+    const project = await prisma.project.create({
+      data: {
+        name: `Base Key Project ${ns}`,
+        slug: `--test-project-${ns}`,
+        apiKey: baseApiKey,
+        teamId: team.id,
+        language: "python",
+        framework: "openai",
+      },
+    });
+    projectId = project.id;
+
+    const updaterId = await makeUser("updater", TeamUserRole.MEMBER);
+    const viewerId = await makeUser("viewer", TeamUserRole.VIEWER);
+
+    updaterCaller = callerFor(updaterId);
+    viewerCaller = callerFor(viewerId);
+  });
+
+  afterAll(async () => {
+    resetApp();
+    await prisma.roleBinding
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.teamUser
+      .deleteMany({ where: { team: { organizationId } } })
+      .catch(() => {});
+    await prisma.project
+      .deleteMany({ where: { team: { organizationId } } })
+      .catch(() => {});
+    await prisma.team.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.organizationUser
+      .deleteMany({ where: { organizationId } })
+      .catch(() => {});
+    await prisma.organization
+      .delete({ where: { id: organizationId } })
+      .catch(() => {});
+    await prisma.user
+      .deleteMany({ where: { email: { contains: ns } } })
+      .catch(() => {});
+  });
+
+  describe("given a caller who can change the project", () => {
+    /** @scenario The base key stays in the session payload for those who can change the project */
+    it("includes the base key in the payload", async () => {
+      const apiKey = await projectApiKeyFor(updaterCaller, projectId);
+
+      expect(apiKey).toBe(baseApiKey);
+    });
+  });
+
+  describe("given a caller who can only view the project", () => {
+    /** @scenario The base key is withheld from the session payload for read-only roles */
+    it("withholds the base key from the payload", async () => {
+      const apiKey = await projectApiKeyFor(viewerCaller, projectId);
+
+      expect(apiKey).toBe("");
+      expect(apiKey).not.toBe(baseApiKey);
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/role.authorization.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/role.authorization.integration.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @vitest-environment node
+ *
+ * Caller authorization for the role router.
+ *
+ * `role-api.test.ts` covers what the service does once it is called; nothing
+ * covered who is allowed to call it. Role definition and assignment is a
+ * privilege-escalation surface — whoever can write roles can write their own
+ * permissions — so each mutation is exercised from a caller who must not reach
+ * it, and from another organization's admin.
+ *
+ * Every case here is a denial in the router's own middleware, which runs ahead
+ * of the plan check and the resolver, so no App or plan wiring is needed.
+ */
+import { generate } from "@langwatch/ksuid";
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+import { KSUID_RESOURCES } from "~/utils/constants";
+import { appRouter } from "../../root";
+import { createInnerTRPCContext } from "../../trpc";
+
+const ns = `role-authz-${nanoid(8)}`;
+
+const callerFor = (userId: string) =>
+  appRouter.createCaller(
+    createInnerTRPCContext({ session: { user: { id: userId }, expires: "1" } }),
+  );
+
+describe("Feature: role router caller authorization", () => {
+  let organizationId: string;
+  let teamId: string;
+  let otherOrganizationId: string;
+  let customRoleId: string;
+  let memberUserId: string;
+
+  let adminCaller: ReturnType<typeof callerFor>;
+  let memberCaller: ReturnType<typeof callerFor>;
+  let outsiderAdminCaller: ReturnType<typeof callerFor>;
+
+  const makeUser = async (
+    label: string,
+    orgId: string,
+    role: OrganizationUserRole,
+    bindingRole: TeamUserRole,
+  ) => {
+    const user = await prisma.user.create({
+      data: { name: `${label} ${ns}`, email: `${label}-${ns}@example.com` },
+    });
+    await prisma.organizationUser.create({
+      data: { userId: user.id, organizationId: orgId, role },
+    });
+    await prisma.roleBinding.create({
+      data: {
+        id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+        organizationId: orgId,
+        userId: user.id,
+        role: bindingRole,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: orgId,
+      },
+    });
+    return user.id;
+  };
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: `Role Authz Org ${ns}`, slug: `--test-org-${ns}` },
+    });
+    organizationId = organization.id;
+
+    const team = await prisma.team.create({
+      data: {
+        name: `Role Authz Team ${ns}`,
+        slug: `--test-team-${ns}`,
+        organizationId,
+      },
+    });
+    teamId = team.id;
+
+    const other = await prisma.organization.create({
+      data: { name: `Other Org ${ns}`, slug: `--test-other-org-${ns}` },
+    });
+    otherOrganizationId = other.id;
+
+    const adminUserId = await makeUser(
+      "admin",
+      organizationId,
+      OrganizationUserRole.ADMIN,
+      TeamUserRole.ADMIN,
+    );
+    memberUserId = await makeUser(
+      "member",
+      organizationId,
+      OrganizationUserRole.MEMBER,
+      TeamUserRole.MEMBER,
+    );
+    const outsiderAdminUserId = await makeUser(
+      "outsider",
+      otherOrganizationId,
+      OrganizationUserRole.ADMIN,
+      TeamUserRole.ADMIN,
+    );
+
+    const customRole = await prisma.customRole.create({
+      data: {
+        organizationId,
+        name: `Role ${ns}`,
+        permissions: ["traces:view"],
+      },
+    });
+    customRoleId = customRole.id;
+
+    adminCaller = callerFor(adminUserId);
+    memberCaller = callerFor(memberUserId);
+    outsiderAdminCaller = callerFor(outsiderAdminUserId);
+  });
+
+  afterAll(async () => {
+    for (const orgId of [organizationId, otherOrganizationId]) {
+      await prisma.roleBinding
+        .deleteMany({ where: { organizationId: orgId } })
+        .catch(() => {});
+      await prisma.customRole
+        .deleteMany({ where: { organizationId: orgId } })
+        .catch(() => {});
+      await prisma.teamUser
+        .deleteMany({ where: { team: { organizationId: orgId } } })
+        .catch(() => {});
+      await prisma.team
+        .deleteMany({ where: { organizationId: orgId } })
+        .catch(() => {});
+      await prisma.organizationUser
+        .deleteMany({ where: { organizationId: orgId } })
+        .catch(() => {});
+      await prisma.organization
+        .delete({ where: { id: orgId } })
+        .catch(() => {});
+    }
+    await prisma.user
+      .deleteMany({ where: { email: { contains: ns } } })
+      .catch(() => {});
+  });
+
+  describe("given a caller who can only view the organization", () => {
+    it("refuses to list the organization's roles", async () => {
+      await expect(
+        memberCaller.role.getAll({ organizationId }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    /** A member who could mint roles could mint themselves any permission. */
+    it("refuses to create a role", async () => {
+      await expect(
+        memberCaller.role.create({
+          organizationId,
+          name: `Escalated ${ns}`,
+          permissions: ["organization:manage"],
+        }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    it("refuses to delete a role", async () => {
+      await expect(
+        memberCaller.role.delete({ roleId: customRoleId }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    it("refuses to assign a role to a user", async () => {
+      await expect(
+        memberCaller.role.assignToUser({
+          userId: memberUserId,
+          teamId,
+          customRoleId,
+        }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    it("refuses to remove a role from a user", async () => {
+      await expect(
+        memberCaller.role.removeFromUser({
+          userId: memberUserId,
+          teamId,
+          customRoleId,
+        }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    it("leaves the role untouched after the refused calls", async () => {
+      const role = await prisma.customRole.findUnique({
+        where: { id: customRoleId },
+      });
+
+      expect(role).not.toBeNull();
+      expect(role?.permissions).toEqual(["traces:view"]);
+    });
+  });
+
+  describe("given an administrator of a different organization", () => {
+    it("refuses to list this organization's roles", async () => {
+      await expect(
+        outsiderAdminCaller.role.getAll({ organizationId }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    it("refuses to read one of its roles by id", async () => {
+      await expect(
+        outsiderAdminCaller.role.getById({ roleId: customRoleId }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    it("refuses to delete one of its roles", async () => {
+      await expect(
+        outsiderAdminCaller.role.delete({ roleId: customRoleId }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("given an administrator of the organization", () => {
+    /** Control: the refusals above are about authority, not a broken router. */
+    it("lists the organization's roles", async () => {
+      const roles = await adminCaller.role.getAll({ organizationId });
+
+      expect(roles.map((role) => role.id)).toContain(customRoleId);
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -47,6 +47,7 @@ import {
   isCustomRole,
 } from "../enterprise";
 import {
+  batchScopePermissions,
   checkOrganizationPermission,
   checkTeamPermission,
   hasOrganizationPermission,
@@ -152,6 +153,10 @@ export const organizationRouter = createTRPCRouter({
       // must not hand the decrypted secret to lite/viewer members just
       // because the UI happens not to render it.
       const manageableOrgIds = new Set<string>();
+      // Decides the base-key redaction below. One batched resolution per org,
+      // not one check per project — a scoped check is ~4 queries, so a
+      // per-project fan-out would scale with the org's project count.
+      const updatableProjectsByOrg = new Map<string, Map<string, boolean>>();
       for (const organization of organizations) {
         const canManage = await hasOrganizationPermission(
           ctx,
@@ -159,6 +164,27 @@ export const organizationRouter = createTRPCRouter({
           "organization:manage",
         );
         if (canManage) manageableOrgIds.add(organization.id);
+
+        const projectTeamId: Record<string, string> = {};
+        for (const team of organization.teams) {
+          for (const project of team.projects) {
+            projectTeamId[project.id] = team.id;
+          }
+        }
+        const projectIds = Object.keys(projectTeamId);
+        if (projectIds.length === 0) continue;
+
+        const { projects: updatableProjects } = await batchScopePermissions(
+          ctx,
+          {
+            organizationId: organization.id,
+            teamIds: [],
+            projectIds,
+            projectTeamId,
+            permission: "project:update",
+          },
+        );
+        updatableProjectsByOrg.set(organization.id, updatableProjects);
       }
 
       for (const organization of organizations) {
@@ -176,7 +202,14 @@ export const organizationRouter = createTRPCRouter({
           if (project.s3Endpoint) {
             project.s3Endpoint = decrypt(project.s3Endpoint);
           }
-          if (isDemo) {
+          // The base key is a project-level write credential. Same rule as the
+          // S3 secret above: send it only to those who can change the project,
+          // rather than relying on the UI not to render it. Demo projects
+          // expose it to no one.
+          const canUpdateProject =
+            updatableProjectsByOrg.get(organization.id)?.get(project.id) ??
+            false;
+          if (isDemo || !canUpdateProject) {
             project.apiKey = "";
           }
         }

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -239,9 +239,14 @@ export const projectRouter = createTRPCRouter({
 
       return { success: true, projectSlug: project.slug };
     }),
+  /**
+   * The base key is a project-level write credential, so reading it is gated
+   * with `project:update` to match the access it grants. Rotation stays at
+   * `project:manage`.
+   */
   getProjectAPIKey: protectedProcedure
     .input(z.object({ projectId: z.string() }))
-    .use(checkProjectPermission("project:view"))
+    .use(checkProjectPermission("project:update"))
     .query(async ({ input, ctx }) => {
       const prisma = ctx.prisma;
 

--- a/langwatch/src/server/api/security/__tests__/secured-apps-rbac.integration.test.ts
+++ b/langwatch/src/server/api/security/__tests__/secured-apps-rbac.integration.test.ts
@@ -291,7 +291,9 @@ describe("Feature: migrated Hono apps enforce RBAC + tenant isolation", () => {
           body: JSON.stringify({ enabled: true }),
         });
 
-      expect((await writeRequest()).status).not.toBe(403);
+      // 200, not merely 'not 403': a 4xx/5xx here would satisfy the
+      // before/after contrast without the write ever having worked.
+      expect((await writeRequest()).status).toBe(200);
 
       await prisma.roleBinding.updateMany({
         where: { organizationId: orgA.id, userId: owner.id },

--- a/langwatch/src/server/api/security/__tests__/secured-apps-rbac.integration.test.ts
+++ b/langwatch/src/server/api/security/__tests__/secured-apps-rbac.integration.test.ts
@@ -37,6 +37,7 @@ import { app as modelProvidersApp } from "~/app/api/model-providers/[[...route]]
 const ns = `secured-rbac-${nanoid(8)}`;
 
 let orgA: Organization;
+let teamA: Team;
 let projectA1: Project;
 let orgB: Organization;
 let projectB1: Project;
@@ -100,6 +101,7 @@ async function makeAdminUser(organization: Organization, team: Team) {
 beforeAll(async () => {
   const a = await makeOrgWithProject("A");
   orgA = a.organization;
+  teamA = a.team;
   projectA1 = a.project;
   const b = await makeOrgWithProject("B");
   orgB = b.organization;
@@ -130,7 +132,11 @@ beforeAll(async () => {
     permissionMode: "restricted",
     permissions: ["traces:view"], // deliberately lacks project/analytics/evaluations/prompts view
     bindings: [
-      { role: TeamUserRole.CUSTOM, scopeType: "PROJECT", scopeId: projectA1.id },
+      {
+        role: TeamUserRole.CUSTOM,
+        scopeType: "PROJECT",
+        scopeId: projectA1.id,
+      },
     ],
   });
   readOnlyTokenA = readOnly.token;
@@ -143,7 +149,11 @@ beforeAll(async () => {
     permissionMode: "restricted",
     permissions: ["workflows:view"], // workflows only — no experiments access anymore
     bindings: [
-      { role: TeamUserRole.CUSTOM, scopeType: "PROJECT", scopeId: projectA1.id },
+      {
+        role: TeamUserRole.CUSTOM,
+        scopeType: "PROJECT",
+        scopeId: projectA1.id,
+      },
     ],
   });
   workflowsViewerTokenA = workflowsViewer.token;
@@ -156,7 +166,11 @@ beforeAll(async () => {
     permissionMode: "restricted",
     permissions: ["experiments:view"], // experiments only — no workflows access
     bindings: [
-      { role: TeamUserRole.CUSTOM, scopeType: "PROJECT", scopeId: projectA1.id },
+      {
+        role: TeamUserRole.CUSTOM,
+        scopeType: "PROJECT",
+        scopeId: projectA1.id,
+      },
     ],
   });
   experimentsViewerTokenA = experimentsViewer.token;
@@ -242,6 +256,49 @@ describe("Feature: migrated Hono apps enforce RBAC + tenant isolation", () => {
         headers: headers(readOnlyTokenA, projectA1.id),
       });
       expect(res.status).toBe(403);
+    });
+  });
+
+  describe("when the key's owning user is demoted after the key was minted", () => {
+    /**
+     * The ceiling's promise, end to end: an admin key keeps its own bindings
+     * but stops working the moment its owner can no longer do the thing —
+     * without anyone revoking or re-issuing the key.
+     *
+     * Uses its own user so the demotion cannot disturb the other cases.
+     */
+    it("stops honouring the key on a write route the owner can no longer reach", async () => {
+      const owner = await makeAdminUser(orgA, teamA);
+      const { token } = await ApiKeyService.create(prisma).create({
+        name: `degrading-${nanoid(6)}`,
+        userId: owner.id,
+        createdByUserId: owner.id,
+        organizationId: orgA.id,
+        permissionMode: "all",
+        bindings: [
+          {
+            role: TeamUserRole.ADMIN,
+            scopeType: RoleBindingScopeType.PROJECT,
+            scopeId: projectA1.id,
+          },
+        ],
+      });
+
+      const writeRequest = () =>
+        modelProvidersApp.request("/api/model-providers/openai", {
+          method: "PUT",
+          headers: headers(token, projectA1.id),
+          body: JSON.stringify({ enabled: true }),
+        });
+
+      expect((await writeRequest()).status).not.toBe(403);
+
+      await prisma.roleBinding.updateMany({
+        where: { organizationId: orgA.id, userId: owner.id },
+        data: { role: TeamUserRole.VIEWER },
+      });
+
+      expect((await writeRequest()).status).toBe(403);
     });
   });
 

--- a/langwatch/src/server/api/security/access-policy.ts
+++ b/langwatch/src/server/api/security/access-policy.ts
@@ -14,6 +14,12 @@ import type { Permission } from "~/server/api/rbac";
  *                        Use for the public REST surface (gateway-platform,
  *                        governance) so the registry records the real
  *                        permission instead of a blanket "any authenticated".
+ *   - projectPermission — for org apps addressing one project: the permission
+ *                        is resolved at the scope of the project named in the
+ *                        route, not the organization. An org-wide grant still
+ *                        passes (org bindings are ancestors of project scope);
+ *                        a team- or project-scoped grant reaches only the
+ *                        projects it was actually given.
  *   - anyAuthenticated — any valid credential for the app's scope; no specific
  *                        permission. Use sparingly and only when the handler
  *                        itself does no privileged read/write.
@@ -27,6 +33,12 @@ import type { Permission } from "~/server/api/rbac";
 export type AccessPolicy =
   | { readonly kind: "permission"; readonly permission: Permission }
   | { readonly kind: "apiKeyPermission"; readonly permission: Permission }
+  | {
+      readonly kind: "projectPermission";
+      readonly permission: Permission;
+      /** Route param naming the project. Defaults to `id`. */
+      readonly param: string;
+    }
   | { readonly kind: "anyAuthenticated" }
   | { readonly kind: "public"; readonly reason: string }
   | { readonly kind: "internal"; readonly reason: string }
@@ -51,6 +63,23 @@ export function requires(permission: Permission): AccessPolicy {
  */
 export function apiKeyPermission(permission: Permission): AccessPolicy {
   return { kind: "apiKeyPermission", permission };
+}
+
+/**
+ * Require an RBAC permission at the scope of the project the route addresses,
+ * for org apps that operate on one project at a time. `requires(...)` would
+ * resolve at organization scope there, so a single org-wide grant would reach
+ * every project in the org.
+ */
+export function requiresOnProject(
+  permission: Permission,
+  options: { param?: string } = {},
+): AccessPolicy {
+  return {
+    kind: "projectPermission",
+    permission,
+    param: options.param ?? "id",
+  };
 }
 
 /**
@@ -110,6 +139,8 @@ export function describeAccessPolicy(policy: AccessPolicy): string {
       return `requires ${policy.permission}`;
     case "apiKeyPermission":
       return `requires ${policy.permission} (API-key ceiling; legacy project keys bypass)`;
+    case "projectPermission":
+      return `requires ${policy.permission} on the project in :${policy.param}`;
     case "anyAuthenticated":
       return "any authenticated credential";
     case "public":

--- a/langwatch/src/server/api/security/index.ts
+++ b/langwatch/src/server/api/security/index.ts
@@ -7,6 +7,7 @@ export {
   internalSecret,
   publicEndpoint,
   requires,
+  requiresOnProject,
 } from "./access-policy";
 export {
   allRegisteredRoutes,

--- a/langwatch/src/server/api/security/secured-app.ts
+++ b/langwatch/src/server/api/security/secured-app.ts
@@ -12,6 +12,7 @@ import {
   type OrgAuthMiddlewareVariables,
   orgAuthMiddleware,
   requireOrgPermission,
+  requireProjectPermission,
 } from "~/app/api/middleware/org-auth";
 import { tracerMiddleware } from "~/app/api/middleware/tracer";
 import { requireApiKeyPermission } from "~/server/api-key/auth-middleware";
@@ -99,10 +100,7 @@ export class SecuredApp<E extends Env> {
   private readonly family: string;
   private readonly strategy: AuthStrategy;
 
-  constructor(args: {
-    basePath: string;
-    strategy: AuthStrategy;
-  }) {
+  constructor(args: { basePath: string; strategy: AuthStrategy }) {
     this.basePath = args.basePath;
     this.family = familyFromBasePath(args.basePath);
     this.strategy = args.strategy;
@@ -221,6 +219,14 @@ const orgStrategy: AuthStrategy = {
     switch (policy.kind) {
       case "permission":
         return [orgAuthMiddleware, requireOrgPermission(policy.permission)];
+      case "projectPermission":
+        return [
+          orgAuthMiddleware,
+          requireProjectPermission({
+            permission: policy.permission,
+            param: policy.param,
+          }),
+        ];
       case "anyAuthenticated":
         return [orgAuthMiddleware];
       default:

--- a/langwatch/src/server/rbac/__tests__/role-binding-resolver.ceiling.unit.test.ts
+++ b/langwatch/src/server/rbac/__tests__/role-binding-resolver.ceiling.unit.test.ts
@@ -1,0 +1,236 @@
+import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+import {
+  resolveApiKeyPermission,
+  type ScopeRef,
+} from "../role-binding-resolver";
+
+/**
+ * The API-key ceiling: `effective = ApiKey.bindings ∩ user.bindings`.
+ *
+ * The sibling suites exercise `checkRoleBindingPermission` — the single
+ * principal check. This one covers the two-principal intersection on top of
+ * it, which is what makes a key unable to outlive or outrank its owner.
+ *
+ * @see specs/api-keys/scope-based-permissions.feature
+ */
+
+type BindingRecord = {
+  role: TeamUserRole;
+  customRoleId: string | null;
+  scopeType: RoleBindingScopeType;
+  scopeId: string;
+};
+
+const ORG_ID = "org1";
+const USER_ID = "user1";
+const API_KEY_ID = "apikey1";
+const TEAM_ID = "team1";
+const PROJECT_ID = "proj1";
+
+const projectScope: ScopeRef = {
+  type: "project",
+  id: PROJECT_ID,
+  teamId: TEAM_ID,
+};
+
+const teamBinding = (role: TeamUserRole): BindingRecord => ({
+  role,
+  customRoleId: null,
+  scopeType: RoleBindingScopeType.TEAM,
+  scopeId: TEAM_ID,
+});
+
+/**
+ * Dispatches on the `where` clause rather than call order: the owning user's
+ * bindings are fetched as two parallel queries (direct + group), so an
+ * order-based mock would be answering the wrong question.
+ */
+function makePrisma({
+  apiKeyBindings = [] as BindingRecord[],
+  userBindings = [] as BindingRecord[],
+  groupBindings = [] as BindingRecord[],
+} = {}) {
+  const findMany = vi.fn(
+    async ({ where }: { where: Record<string, unknown> }) => {
+      if (where.apiKeyId) return apiKeyBindings;
+      if (where.group) return groupBindings;
+      if (where.userId) return userBindings;
+      return [];
+    },
+  );
+
+  return {
+    prisma: {
+      roleBinding: { findMany },
+      teamUser: { findFirst: vi.fn().mockResolvedValue(null) },
+      customRole: { findUnique: vi.fn().mockResolvedValue(null) },
+    } as unknown as Parameters<typeof resolveApiKeyPermission>[0]["prisma"],
+    findMany,
+  };
+}
+
+const resolve = ({
+  prisma,
+  userId = USER_ID as string | null,
+}: {
+  prisma: Parameters<typeof resolveApiKeyPermission>[0]["prisma"];
+  userId?: string | null;
+}) =>
+  resolveApiKeyPermission({
+    prisma,
+    apiKeyId: API_KEY_ID,
+    userId,
+    organizationId: ORG_ID,
+    scope: projectScope,
+    permission: "project:update",
+  });
+
+describe("resolveApiKeyPermission()", () => {
+  describe("given a key owned by a user", () => {
+    describe("when both the key and the owner grant the permission", () => {
+      it("permits the request", async () => {
+        const { prisma } = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.ADMIN)],
+          userBindings: [teamBinding(TeamUserRole.ADMIN)],
+        });
+
+        await expect(resolve({ prisma })).resolves.toBe(true);
+      });
+    });
+
+    describe("when the key grants it but the owner does not", () => {
+      /**
+       * The reason the ceiling exists: a key must never exceed the person it
+       * belongs to, however it was minted.
+       */
+      it("denies the request", async () => {
+        const { prisma } = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.ADMIN)],
+          userBindings: [teamBinding(TeamUserRole.VIEWER)],
+        });
+
+        await expect(resolve({ prisma })).resolves.toBe(false);
+      });
+    });
+
+    describe("when the owner grants it but the key does not", () => {
+      it("denies the request", async () => {
+        const { prisma } = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.VIEWER)],
+          userBindings: [teamBinding(TeamUserRole.ADMIN)],
+        });
+
+        await expect(resolve({ prisma })).resolves.toBe(false);
+      });
+    });
+
+    describe("when neither grants the permission", () => {
+      it("denies the request", async () => {
+        const { prisma } = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.VIEWER)],
+          userBindings: [teamBinding(TeamUserRole.VIEWER)],
+        });
+
+        await expect(resolve({ prisma })).resolves.toBe(false);
+      });
+    });
+
+    describe("when the owner has been demoted since the key was minted", () => {
+      /** The auto-degradation the ceiling promises, at the resolver level. */
+      it("stops honouring the key's own grant", async () => {
+        const minted = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.ADMIN)],
+          userBindings: [teamBinding(TeamUserRole.ADMIN)],
+        });
+        await expect(resolve({ prisma: minted.prisma })).resolves.toBe(true);
+
+        const demoted = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.ADMIN)],
+          userBindings: [teamBinding(TeamUserRole.VIEWER)],
+        });
+        await expect(resolve({ prisma: demoted.prisma })).resolves.toBe(false);
+      });
+    });
+
+    describe("when the owner has left the organization", () => {
+      /**
+       * The direct-binding query is gated on current org membership, so an
+       * offboarded owner returns no bindings at all — the key goes with them.
+       */
+      it("denies the request", async () => {
+        const { prisma } = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.ADMIN)],
+          userBindings: [],
+        });
+
+        await expect(resolve({ prisma })).resolves.toBe(false);
+      });
+    });
+
+    describe("when the owner's only grant comes through a group", () => {
+      it("permits the request", async () => {
+        const { prisma } = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.ADMIN)],
+          groupBindings: [teamBinding(TeamUserRole.ADMIN)],
+        });
+
+        await expect(resolve({ prisma })).resolves.toBe(true);
+      });
+    });
+
+    describe("when the key is denied", () => {
+      /**
+       * The owner is never consulted for a key that already fails on its own
+       * bindings — an over-privileged owner cannot rescue an under-privileged
+       * key.
+       */
+      it("does not consult the owner's bindings", async () => {
+        const { prisma, findMany } = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.VIEWER)],
+          userBindings: [teamBinding(TeamUserRole.ADMIN)],
+        });
+
+        await resolve({ prisma });
+
+        const queried = findMany.mock.calls.map(([args]) => args.where);
+        expect(queried.some((where) => where.apiKeyId)).toBe(true);
+        expect(queried.some((where) => where.userId ?? where.group)).toBe(
+          false,
+        );
+      });
+    });
+  });
+
+  describe("given a service key with no owning user", () => {
+    describe("when the key's own bindings grant the permission", () => {
+      /**
+       * There is no user to intersect with, so the key's bindings are the
+       * whole ceiling. Pinned because it is the one path that skips the
+       * intersection entirely.
+       */
+      it("permits the request without a user check", async () => {
+        const { prisma, findMany } = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.ADMIN)],
+        });
+
+        await expect(resolve({ prisma, userId: null })).resolves.toBe(true);
+
+        const queried = findMany.mock.calls.map(([args]) => args.where);
+        expect(queried.some((where) => where.userId ?? where.group)).toBe(
+          false,
+        );
+      });
+    });
+
+    describe("when the key's own bindings do not grant the permission", () => {
+      it("denies the request", async () => {
+        const { prisma } = makePrisma({
+          apiKeyBindings: [teamBinding(TeamUserRole.VIEWER)],
+        });
+
+        await expect(resolve({ prisma, userId: null })).resolves.toBe(false);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/rbac/__tests__/role-binding-resolver.integration.test.ts
+++ b/langwatch/src/server/rbac/__tests__/role-binding-resolver.integration.test.ts
@@ -48,10 +48,18 @@ describe("checkRoleBindingPermission() scope hierarchy integration", () => {
     });
 
     teamA = await prisma.team.create({
-      data: { name: `${NS}-client-a`, slug: `${NS}-client-a`, organizationId: org.id },
+      data: {
+        name: `${NS}-client-a`,
+        slug: `${NS}-client-a`,
+        organizationId: org.id,
+      },
     });
     teamB = await prisma.team.create({
-      data: { name: `${NS}-client-b`, slug: `${NS}-client-b`, organizationId: org.id },
+      data: {
+        name: `${NS}-client-b`,
+        slug: `${NS}-client-b`,
+        organizationId: org.id,
+      },
     });
 
     devProject = await prisma.project.create({
@@ -114,8 +122,12 @@ describe("checkRoleBindingPermission() scope hierarchy integration", () => {
     await prisma.teamUser.deleteMany({
       where: { teamId: { in: [teamA.id, teamB.id] } },
     });
-    await prisma.organizationUser.deleteMany({ where: { organizationId: org.id } });
-    await prisma.project.deleteMany({ where: { teamId: { in: [teamA.id, teamB.id] } } });
+    await prisma.organizationUser.deleteMany({
+      where: { organizationId: org.id },
+    });
+    await prisma.project.deleteMany({
+      where: { teamId: { in: [teamA.id, teamB.id] } },
+    });
     await prisma.team.deleteMany({ where: { organizationId: org.id } });
     await prisma.organization.delete({ where: { id: org.id } });
     await prisma.user.deleteMany({
@@ -316,6 +328,180 @@ describe("checkRoleBindingPermission() scope hierarchy integration", () => {
       });
 
       expect(result).toBe(true);
+    });
+
+    it("denies analytics:view once the user is removed from the group", async () => {
+      const group = await prisma.group.create({
+        data: {
+          organizationId: org.id,
+          name: `${NS}-leavers`,
+          slug: `${NS}-leavers`,
+        },
+      });
+      const membership = await prisma.groupMembership.create({
+        data: { userId: bob.id, groupId: group.id },
+      });
+      await prisma.roleBinding.create({
+        data: {
+          organizationId: org.id,
+          groupId: group.id,
+          role: TeamUserRole.VIEWER,
+          scopeType: RoleBindingScopeType.PROJECT,
+          scopeId: devProject.id,
+        },
+      });
+
+      const scope: ScopeRef = {
+        type: "project",
+        id: devProject.id,
+        teamId: teamA.id,
+      };
+      const check = () =>
+        checkRoleBindingPermission({
+          prisma,
+          userId: bob.id,
+          organizationId: org.id,
+          scope,
+          permission: "analytics:view",
+        });
+
+      await expect(check()).resolves.toBe(true);
+
+      await prisma.groupMembership.delete({
+        where: {
+          userId_groupId: { userId: bob.id, groupId: membership.groupId },
+        },
+      });
+
+      await expect(check()).resolves.toBe(false);
+    });
+
+    it("does not grant through a group after the user leaves the organization", async () => {
+      const existing = await prisma.organizationUser.findFirst({
+        where: { userId: bob.id, organizationId: org.id },
+      });
+      const group = await prisma.group.create({
+        data: {
+          organizationId: org.id,
+          name: `${NS}-offboarded`,
+          slug: `${NS}-offboarded`,
+        },
+      });
+      await prisma.groupMembership.create({
+        data: { userId: bob.id, groupId: group.id },
+      });
+      await prisma.roleBinding.create({
+        data: {
+          organizationId: org.id,
+          groupId: group.id,
+          role: TeamUserRole.VIEWER,
+          scopeType: RoleBindingScopeType.PROJECT,
+          scopeId: devProject.id,
+        },
+      });
+
+      const check = () =>
+        checkRoleBindingPermission({
+          prisma,
+          userId: bob.id,
+          organizationId: org.id,
+          scope: { type: "project", id: devProject.id, teamId: teamA.id },
+          permission: "analytics:view",
+        });
+
+      await expect(check()).resolves.toBe(true);
+
+      await prisma.organizationUser.deleteMany({
+        where: { userId: bob.id, organizationId: org.id },
+      });
+
+      try {
+        await expect(check()).resolves.toBe(false);
+      } finally {
+        if (existing) {
+          await prisma.organizationUser.create({
+            data: {
+              userId: bob.id,
+              organizationId: org.id,
+              role: existing.role,
+            },
+          });
+        }
+      }
+    });
+
+    it("denies a permission the group's role does not carry", async () => {
+      const group = await prisma.group.create({
+        data: {
+          organizationId: org.id,
+          name: `${NS}-readers`,
+          slug: `${NS}-readers`,
+        },
+      });
+      await prisma.groupMembership.create({
+        data: { userId: bob.id, groupId: group.id },
+      });
+      await prisma.roleBinding.create({
+        data: {
+          organizationId: org.id,
+          groupId: group.id,
+          role: TeamUserRole.VIEWER,
+          scopeType: RoleBindingScopeType.PROJECT,
+          scopeId: devProject.id,
+        },
+      });
+
+      const result = await checkRoleBindingPermission({
+        prisma,
+        userId: bob.id,
+        organizationId: org.id,
+        scope: { type: "project", id: devProject.id, teamId: teamA.id },
+        permission: "datasets:manage",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("does not grant through a group belonging to another organization", async () => {
+      const otherOrg = await prisma.organization.create({
+        data: { name: `${NS}-other`, slug: `${NS}-other` },
+      });
+      const group = await prisma.group.create({
+        data: {
+          organizationId: otherOrg.id,
+          name: `${NS}-outsiders`,
+          slug: `${NS}-outsiders`,
+        },
+      });
+      await prisma.groupMembership.create({
+        data: { userId: bob.id, groupId: group.id },
+      });
+      await prisma.roleBinding.create({
+        data: {
+          organizationId: otherOrg.id,
+          groupId: group.id,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.PROJECT,
+          scopeId: devProject.id,
+        },
+      });
+
+      const result = await checkRoleBindingPermission({
+        prisma,
+        userId: bob.id,
+        organizationId: org.id,
+        scope: { type: "project", id: devProject.id, teamId: teamA.id },
+        permission: "analytics:view",
+      });
+
+      expect(result).toBe(false);
+
+      await prisma.groupMembership.deleteMany({ where: { groupId: group.id } });
+      await prisma.roleBinding.deleteMany({
+        where: { organizationId: otherOrg.id },
+      });
+      await prisma.group.delete({ where: { id: group.id } });
+      await prisma.organization.delete({ where: { id: otherOrg.id } });
     });
 
     it("grants datasets:manage when user is in multiple groups and one grants MEMBER at the same scope", async () => {
@@ -560,7 +746,9 @@ describe("checkRoleBindingPermission() integration", () => {
 
   afterAll(async () => {
     await prisma.roleBinding.deleteMany({ where: { organizationId: org.id } });
-    await prisma.organizationUser.deleteMany({ where: { organizationId: org.id } });
+    await prisma.organizationUser.deleteMany({
+      where: { organizationId: org.id },
+    });
     await prisma.project.deleteMany({ where: { teamId: team.id } });
     await prisma.team.delete({ where: { id: team.id } });
     await prisma.organization.delete({ where: { id: org.id } });

--- a/langwatch/src/server/rbac/role-binding-resolver.ts
+++ b/langwatch/src/server/rbac/role-binding-resolver.ts
@@ -93,10 +93,20 @@ async function collectBindingsForScope({
   scope: ScopeRef;
 }): Promise<ResolvedBinding[]> {
   if (principal.type === "apiKey") {
-    return collectBindingsForApiKey({ prisma, apiKeyId: principal.id, organizationId, scope });
+    return collectBindingsForApiKey({
+      prisma,
+      apiKeyId: principal.id,
+      organizationId,
+      scope,
+    });
   }
 
-  return collectBindingsForUser({ prisma, userId: principal.id, organizationId, scope });
+  return collectBindingsForUser({
+    prisma,
+    userId: principal.id,
+    organizationId,
+    scope,
+  });
 }
 
 async function collectBindingsForUser({
@@ -121,14 +131,35 @@ async function collectBindingsForUser({
         userId,
         user: { orgMemberships: { some: { organizationId } } },
       },
-      select: { role: true, customRoleId: true, scopeType: true, scopeId: true },
+      select: {
+        role: true,
+        customRoleId: true,
+        scopeType: true,
+        scopeId: true,
+      },
     }),
     prisma.roleBinding.findMany({
+      // Group-derived bindings carry the same current-membership gate as the
+      // direct bindings above. A GroupMembership row outlives removal from the
+      // organization, so without this an offboarded user keeps whatever their
+      // groups granted.
       where: {
         organizationId,
-        group: { members: { some: { userId } } },
+        group: {
+          members: {
+            some: {
+              userId,
+              user: { orgMemberships: { some: { organizationId } } },
+            },
+          },
+        },
       },
-      select: { role: true, customRoleId: true, scopeType: true, scopeId: true },
+      select: {
+        role: true,
+        customRoleId: true,
+        scopeType: true,
+        scopeId: true,
+      },
     }),
   ]);
 
@@ -136,12 +167,23 @@ async function collectBindingsForUser({
 
   const ancestorScopeList = ancestorScopes(scope);
   if (scope.type !== "org") {
-    ancestorScopeList.push({ type: RoleBindingScopeType.ORGANIZATION, id: organizationId });
+    ancestorScopeList.push({
+      type: RoleBindingScopeType.ORGANIZATION,
+      id: organizationId,
+    });
   }
 
   return allOrgBindings
-    .filter((b) => ancestorScopeList.some((s) => s.type === b.scopeType && s.id === b.scopeId))
-    .map((b) => ({ role: b.role, customRoleId: b.customRoleId, scopeType: b.scopeType }));
+    .filter((b) =>
+      ancestorScopeList.some(
+        (s) => s.type === b.scopeType && s.id === b.scopeId,
+      ),
+    )
+    .map((b) => ({
+      role: b.role,
+      customRoleId: b.customRoleId,
+      scopeType: b.scopeType,
+    }));
 }
 
 async function collectBindingsForApiKey({
@@ -164,12 +206,23 @@ async function collectBindingsForApiKey({
 
   const ancestorScopeList = ancestorScopes(scope);
   if (scope.type !== "org") {
-    ancestorScopeList.push({ type: RoleBindingScopeType.ORGANIZATION, id: organizationId });
+    ancestorScopeList.push({
+      type: RoleBindingScopeType.ORGANIZATION,
+      id: organizationId,
+    });
   }
 
   return bindings
-    .filter((b) => ancestorScopeList.some((s) => s.type === b.scopeType && s.id === b.scopeId))
-    .map((b) => ({ role: b.role, customRoleId: b.customRoleId, scopeType: b.scopeType }));
+    .filter((b) =>
+      ancestorScopeList.some(
+        (s) => s.type === b.scopeType && s.id === b.scopeId,
+      ),
+    )
+    .map((b) => ({
+      role: b.role,
+      customRoleId: b.customRoleId,
+      scopeType: b.scopeType,
+    }));
 }
 
 // ============================================================================
@@ -200,9 +253,17 @@ export async function checkRoleBindingPermission({
   scope: ScopeRef;
   permission: Permission;
 }): Promise<boolean> {
-  const resolvedPrincipal: Principal = principal ?? { type: "user", id: userId! };
+  const resolvedPrincipal: Principal = principal ?? {
+    type: "user",
+    id: userId!,
+  };
 
-  const bindings = await collectBindingsForScope({ prisma, principal: resolvedPrincipal, organizationId, scope });
+  const bindings = await collectBindingsForScope({
+    prisma,
+    principal: resolvedPrincipal,
+    organizationId,
+    scope,
+  });
 
   for (const binding of bindings) {
     // A team/project binding can never grant an org-exclusive permission,
@@ -260,7 +321,10 @@ export async function checkRoleBindingPermission({
       binding.role !== TeamUserRole.CUSTOM
     ) {
       if (binding.role === TeamUserRole.ADMIN) return true;
-      if (organizationRoleHasPermission(OrganizationUserRole.MEMBER, permission)) return true;
+      if (
+        organizationRoleHasPermission(OrganizationUserRole.MEMBER, permission)
+      )
+        return true;
       continue;
     }
 

--- a/specs/api-keys/project-key-read-access.feature
+++ b/specs/api-keys/project-key-read-access.feature
@@ -9,42 +9,30 @@ Feature: Read the project base API key
   gated alongside changing the project (`project:update`) rather than alongside
   viewing it (`project:view`), and rotation stays at `project:manage`.
 
+  It also travels inside the payload the application loads on every page, so
+  that copy is gated on the same permission — otherwise the endpoint gates
+  would decide nothing about what a client actually holds.
+
   Background:
     Given a project that has a base API key
 
-  Scenario: A member who can change the project reads the base key
+  Scenario: A caller who can change the project reads the base key
     Given I have permission to update the project
     When I request the project's base API key
     Then the base API key is returned to me
 
-  Scenario: A viewer cannot read the base key
-    Given I can view the project but not update it
-    When I request the project's base API key
-    Then the request is rejected as forbidden
-    And no base API key is disclosed to me
-
-  Scenario: A lite member cannot read the base key
-    Given I am an external member who can view the project
-    When I request the project's base API key
-    Then the request is rejected as forbidden
-    And no base API key is disclosed to me
-
-  Scenario: A read-scoped API key cannot read the base key
-    Given an API key granting only read access to projects
-    When that key requests a project's base API key
+  Scenario: A read-only credential cannot read the base key
+    Given a credential granting only permission to view projects
+    When it requests the project's base API key
     Then the request is rejected as forbidden
     And no base API key is disclosed
 
   Scenario: Permission is checked against the requested project
-    Given I can update project "alpha" but only view project "beta"
-    When I request the base API key for project "beta"
+    Given I may update one project but not another in the same organization
+    When I request the base API key for the project I may not update
     Then the request is rejected as forbidden
     And no base API key is disclosed to me
-
-  Scenario: An organization-wide grant still reaches every project
-    Given I hold permission to update projects across the whole organization
-    When I request the base API key for any project in that organization
-    Then the base API key is returned to me
+    And the base API key for the project I may update is still returned
 
   Scenario: A project in another organization is not disclosed
     Given a project belonging to an organization I am not a member of
@@ -52,18 +40,23 @@ Feature: Read the project base API key
     Then the project is reported as not found
     And no base API key is disclosed to me
 
-  Scenario: The base key is withheld from the session payload for read-only roles
-    Given I can view the project but not update it
-    When the application loads my organizations and projects
-    Then the project's base API key is not included in the payload
-
   Scenario: The base key stays in the session payload for those who can change the project
     Given I have permission to update the project
     When the application loads my organizations and projects
     Then the project's base API key is included in the payload
 
+  Scenario: The base key is withheld from the session payload for read-only roles
+    Given I can view the project but not update it
+    When the application loads my organizations and projects
+    Then the project carries no base API key in the payload
+
   Scenario: Listing projects never discloses base keys
     Given I have permission to update the project
     When I list the projects over the API
     Then no base API key appears in the listing
-    And reading a single project over the API discloses no base API key
+
+  Scenario: Reading a project never discloses its base key
+    Given I have permission to update the project
+    When I read that single project over the API
+    Then the project is returned without its base API key
+    And without its service API key

--- a/specs/api-keys/project-key-read-access.feature
+++ b/specs/api-keys/project-key-read-access.feature
@@ -1,0 +1,69 @@
+@integration
+Feature: Read the project base API key
+  As a project admin
+  I want the project's base (legacy) API key to be readable only by people who
+  can change the project, and only for the project they were granted
+  So that access to it lines up with the access it grants
+
+  The base key is a project-level write credential. Reading it is therefore
+  gated alongside changing the project (`project:update`) rather than alongside
+  viewing it (`project:view`), and rotation stays at `project:manage`.
+
+  Background:
+    Given a project that has a base API key
+
+  Scenario: A member who can change the project reads the base key
+    Given I have permission to update the project
+    When I request the project's base API key
+    Then the base API key is returned to me
+
+  Scenario: A viewer cannot read the base key
+    Given I can view the project but not update it
+    When I request the project's base API key
+    Then the request is rejected as forbidden
+    And no base API key is disclosed to me
+
+  Scenario: A lite member cannot read the base key
+    Given I am an external member who can view the project
+    When I request the project's base API key
+    Then the request is rejected as forbidden
+    And no base API key is disclosed to me
+
+  Scenario: A read-scoped API key cannot read the base key
+    Given an API key granting only read access to projects
+    When that key requests a project's base API key
+    Then the request is rejected as forbidden
+    And no base API key is disclosed
+
+  Scenario: Permission is checked against the requested project
+    Given I can update project "alpha" but only view project "beta"
+    When I request the base API key for project "beta"
+    Then the request is rejected as forbidden
+    And no base API key is disclosed to me
+
+  Scenario: An organization-wide grant still reaches every project
+    Given I hold permission to update projects across the whole organization
+    When I request the base API key for any project in that organization
+    Then the base API key is returned to me
+
+  Scenario: A project in another organization is not disclosed
+    Given a project belonging to an organization I am not a member of
+    When I request that project's base API key
+    Then the project is reported as not found
+    And no base API key is disclosed to me
+
+  Scenario: The base key is withheld from the session payload for read-only roles
+    Given I can view the project but not update it
+    When the application loads my organizations and projects
+    Then the project's base API key is not included in the payload
+
+  Scenario: The base key stays in the session payload for those who can change the project
+    Given I have permission to update the project
+    When the application loads my organizations and projects
+    Then the project's base API key is included in the payload
+
+  Scenario: Listing projects never discloses base keys
+    Given I have permission to update the project
+    When I list the projects over the API
+    Then no base API key appears in the listing
+    And reading a single project over the API discloses no base API key


### PR DESCRIPTION
## What

Two related commits.

### 1. Project base-key reads require `project:update`

The project base (legacy) API key is a project-level write credential. Reading it was gated on `project:view`; it now requires `project:update`, lining the read up with the access the key grants. Rotation is unchanged at `project:manage`.

| Surface | Before | After |
|---|---|---|
| `GET /api/projects/:id/api-key` | `project:view`, org scope | `project:update`, project scope |
| `project.getProjectAPIKey` (tRPC) | `project:view` | `project:update` |
| `organization.getAll` payload | sent to every member | sent only to callers who can change the project |

The payload is now redacted the same way the S3 secret beside it already was, so all three surfaces agree on who may see the key.

**New: `requiresOnProject(...)`** — `/api/projects` is an org app, where `requires(...)` resolves at organization scope. `requiresOnProject(permission)` resolves at the scope of the project named in the route instead. Org-wide grants still pass (org bindings are ancestors of project scope); team- and project-scoped grants reach only their own projects.

### 2. Adversarial coverage for the API-key ceiling

A survey of the auth/RBAC suites found the permission-*evaluation* layer well exercised from both sides (~44% of cases negative), while the *enforcement* layer around it had almost none. This adds the missing negative cases:

- **`resolveApiKeyPermission`** — the full `ApiKey ∩ user` truth table, previously untested. Includes a key whose owner no longer holds the permission, and the service-key path with no user to intersect with.
- **`requireApiKeyPermission` / `enforceApiKeyCeiling`** — allow, deny, and the pass-through taken when nothing authenticated the request, pinned so it stays a deliberate choice. The legacy project key exemption is characterized rather than left implicit.
- **`ApiKeyService.verify`** — revoked, expired and deactivated-owner keys are rejected at authentication.
- **role router** — every mutation refused for a caller who can only view the organization, and for another organization's administrator. Previously only the service behind it was tested, never who may call it.
- **secured apps** — an admin key stops working once its owner is demoted, end to end.

**One fix came out of it:** group-derived bindings now carry the same current-membership gate as the direct bindings beside them. A `GroupMembership` row outlives removal from the organization, so group-granted access could outlive it too on the API-key path.

## Compatibility

`project:update` is held by team MEMBER and ADMIN, so onboarding and SDK integration are unaffected. VIEWER, EXTERNAL and read-scoped keys no longer receive the base key, and can use scoped API keys — which the UI already recommends for new integrations.

The group-binding change removes access for anyone whose grant came via a group *without* current organization membership.

## Tests

`specs/api-keys/project-key-read-access.feature`, plus:

- 552 unit / 13 skipped across `rbac`, `api-key`, `api`, `security`
- 82 integration across `rbac`, `api-key`, `security`, role router, projects

## Follow-up

Narrowing the scope of legacy project keys is tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Tightened project API key read access to require `project:update` (with project-scoped authorization).
  * Added project-scoped permission handling to ensure denied/unknown projects return 403/404 without leaking base key material.
  * Updated RBAC to prevent access via offboarded users or stale group-derived bindings.
  * Refined session/organization payload redaction so base keys are included only when the caller can update the specific project.
* **Bug Fixes**
  * Further reduced the risk of cross-project and cross-organization credential leakage.
* **Tests**
  * Expanded integration/unit coverage for API key verification, permission ceilings, RBAC changes, and cross-scope access boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->