### PR TITLE
feat(langy): minimise sinks the panel to an edge peek (behind a rollout flag)

### DIFF
--- a/langwatch/src/features/langy/__tests__/LangyConversationHistory.integration.test.tsx
+++ b/langwatch/src/features/langy/__tests__/LangyConversationHistory.integration.test.tsx
@@ -129,6 +129,14 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
   useOrganizationTeamProject: () => ({ project: projectRef.current }),
 }));
 
+// The minimised affordance is flag-gated (LangySidecar reads
+// release_ui_langy_peek_dock_enabled). This suite is about conversation
+// history, not the closed state, so pin the flag off (the classic launcher) —
+// the same render path this suite had before the flag landed.
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
+}));
+
 vi.mock("~/components/ui/toaster", () => ({
   toaster: { create: vi.fn() },
 }));

--- a/langwatch/src/features/langy/__tests__/LangyConversationThreading.integration.test.tsx
+++ b/langwatch/src/features/langy/__tests__/LangyConversationThreading.integration.test.tsx
@@ -31,6 +31,14 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
   useOrganizationTeamProject: () => ({ project: projectRef.current }),
 }));
 
+// The minimised affordance is flag-gated (LangySidecar reads
+// release_ui_langy_peek_dock_enabled). This suite is about conversation
+// threading, not the closed state, so pin the flag off (the classic
+// launcher) — the same render path this suite had before the flag landed.
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
+}));
+
 vi.mock("~/components/ui/toaster", () => ({
   toaster: { create: vi.fn() },
 }));

--- a/langwatch/src/features/langy/__tests__/LangyInlineModelSetup.integration.test.tsx
+++ b/langwatch/src/features/langy/__tests__/LangyInlineModelSetup.integration.test.tsx
@@ -40,6 +40,14 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
   useOrganizationTeamProject: () => ({ project: projectRef.current }),
 }));
 
+// The minimised affordance is flag-gated (LangySidecar reads
+// release_ui_langy_peek_dock_enabled). This suite is about the inline model
+// setup, not the closed state, so pin the flag off (the classic launcher) —
+// the same render path this suite had before the flag landed.
+vi.mock("~/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
+}));
+
 // The panel reads `currentDrawer` to decide whether it is riding beside a
 // drawer as the floating companion. Defaults to no drawer (the dock/floating
 // cases); the companion-header test flips it. The rest of the hook's surface is

--- a/langwatch/src/features/langy/__tests__/LangyPeekDock.integration.test.tsx
+++ b/langwatch/src/features/langy/__tests__/LangyPeekDock.integration.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration test for the minimised peek — the panel's closed state.
+ *
+ * Spec: specs/langy/langy-peek-dock.feature
+ *
+ * Boundary mocks: useDrawer (whether a right-anchored drawer holds the edge).
+ * The zustand store is REAL — the peek's whole contract is that it drives and
+ * follows `isOpen`, so the open transition is asserted through the store,
+ * exactly as LangySidecar wires it.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const drawerState = { current: null as string | null };
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ currentDrawer: drawerState.current }),
+}));
+
+// A controllable crash INSIDE the peek, on the real render path: the
+// proximity hook throwing during render is exactly the shape of failure the
+// error boundary exists for. Real behaviour everywhere else.
+const proximityState = { shouldThrow: false };
+vi.mock("../hooks/useLangyPeekProximity", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../hooks/useLangyPeekProximity")
+    >();
+  return {
+    useLangyPeekProximity: (
+      args: Parameters<typeof actual.useLangyPeekProximity>[0],
+    ) => {
+      if (proximityState.shouldThrow) throw new Error("peek exploded");
+      return actual.useLangyPeekProximity(args);
+    },
+  };
+});
+
+import { LangyPeekDock } from "../components/LangyPeekDock";
+import { useLangyStore } from "../stores/langyStore";
+
+/** The peek exactly as LangySidecar mounts it: prop-fed from the real store. */
+function Harness() {
+  const isOpen = useLangyStore((s) => s.isOpen);
+  const openPanel = useLangyStore((s) => s.openPanel);
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <LangyPeekDock isOpen={isOpen} onOpen={openPanel} />
+    </ChakraProvider>
+  );
+}
+
+const peek = () =>
+  screen.queryByRole("button", { name: "Open Langy assistant" });
+
+/** A pointer move the proximity listener can read (jsdom has no PointerEvent). */
+const movePointer = (clientX: number, clientY: number) => {
+  const event = new Event("pointermove");
+  Object.assign(event, { clientX, clientY });
+  act(() => {
+    window.dispatchEvent(event);
+  });
+};
+
+beforeEach(() => {
+  drawerState.current = null;
+  proximityState.shouldThrow = false;
+  useLangyStore.setState({ isOpen: false, panelMode: "floating" });
+});
+
+afterEach(() => cleanup());
+
+describe("LangyPeekDock", () => {
+  describe("given the panel is minimised in floating mode", () => {
+    it("rests as the bottom-edge peek, overlaying rather than reserving room", () => {
+      render(<Harness />);
+      const button = peek();
+      expect(button).not.toBeNull();
+      expect(button?.getAttribute("data-peek-mode")).toBe("floating");
+      expect(button?.getAttribute("data-peek-phase")).toBe("rest");
+      // Overlay, never a push: the store's dock reservation stays off.
+      expect(useLangyStore.getState().dockShifted).toBe(false);
+    });
+
+    /** @scenario Clicking the peek opens the panel */
+    it("opens the panel on click and stands down", async () => {
+      render(<Harness />);
+      await userEvent.click(peek()!);
+      expect(useLangyStore.getState().isOpen).toBe(true);
+      expect(peek()).toBeNull();
+    });
+
+    /** @scenario The peek is a keyboard citizen */
+    it("rises on keyboard focus and opens on Enter", async () => {
+      render(<Harness />);
+      await userEvent.tab();
+      expect(peek()?.getAttribute("data-peek-phase")).toBe("near");
+      await userEvent.keyboard("{Enter}");
+      expect(useLangyStore.getState().isOpen).toBe(true);
+    });
+
+    /** @scenario The peek pops closer as the pointer approaches */
+    it("pops to the near phase when the pointer enters the edge region", async () => {
+      render(<Harness />);
+      // jsdom viewport is 1024x768: just above the resting sliver.
+      movePointer(800, 740);
+      await waitFor(() =>
+        expect(peek()?.getAttribute("data-peek-phase")).toBe("near"),
+      );
+      // ...and settles back once the pointer leaves (past the exit radius).
+      movePointer(100, 100);
+      await waitFor(() =>
+        expect(peek()?.getAttribute("data-peek-phase")).toBe("rest"),
+      );
+    });
+
+    it("also rises on direct hover, pointer-proximity aside", async () => {
+      render(<Harness />);
+      await userEvent.hover(peek()!);
+      expect(peek()?.getAttribute("data-peek-phase")).toBe("near");
+      await userEvent.unhover(peek()!);
+      expect(peek()?.getAttribute("data-peek-phase")).toBe("rest");
+    });
+
+    /** @scenario A drawer moves the floating peek out of its way */
+    it("dodges to the bottom-left while a drawer holds the corner", () => {
+      drawerState.current = "traceV2Details";
+      render(<Harness />);
+      expect(peek()?.getAttribute("data-peek-dodge")).toBe("left");
+    });
+  });
+
+  describe("given the panel is minimised in sidebar mode", () => {
+    beforeEach(() => {
+      useLangyStore.setState({ panelMode: "sidebar" });
+    });
+
+    it("rests as the right-edge sliver", () => {
+      render(<Harness />);
+      expect(peek()?.getAttribute("data-peek-mode")).toBe("sidebar");
+      expect(peek()?.getAttribute("data-peek-phase")).toBe("rest");
+    });
+
+    /** @scenario The sidebar peek holds the right edge above an open drawer */
+    it("holds the right edge rather than dodging when a drawer opens", () => {
+      drawerState.current = "traceV2Details";
+      render(<Harness />);
+      expect(peek()?.getAttribute("data-peek-mode")).toBe("sidebar");
+      expect(peek()?.getAttribute("data-peek-dodge")).toBeNull();
+    });
+
+    it("opens the dock on click", async () => {
+      render(<Harness />);
+      await userEvent.click(peek()!);
+      expect(useLangyStore.getState().isOpen).toBe(true);
+    });
+  });
+
+  describe("given the panel is open", () => {
+    it("renders no peek at all — the panel owns the open surface", () => {
+      useLangyStore.setState({ isOpen: true });
+      render(<Harness />);
+      expect(peek()).toBeNull();
+    });
+
+    it("appears when the panel minimises", async () => {
+      useLangyStore.setState({ isOpen: true });
+      render(<Harness />);
+      act(() => {
+        useLangyStore.getState().closePanel();
+      });
+      expect(peek()).not.toBeNull();
+    });
+  });
+
+  describe("given the peek crashes while rendering", () => {
+    it("contains the crash in its own boundary instead of blanking the page", () => {
+      proximityState.shouldThrow = true;
+      // React reports the caught error to console.error — expected here.
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        // The render itself must not throw past the boundary...
+        render(<Harness />);
+        // ...the peek is gone, the inline error card stands in its place...
+        expect(peek()).toBeNull();
+        expect(screen.getByRole("alert")).toBeTruthy();
+        // ...and the panel state is untouched: Cmd/Ctrl+I (wired above this
+        // subtree) can still open the panel.
+        expect(useLangyStore.getState().isOpen).toBe(false);
+        act(() => {
+          useLangyStore.getState().togglePanel();
+        });
+        expect(useLangyStore.getState().isOpen).toBe(true);
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+  });
+
+  describe("given the user prefers reduced motion", () => {
+    beforeEach(() => {
+      vi.stubGlobal(
+        "matchMedia",
+        vi.fn().mockImplementation((query: string) => ({
+          matches: query === "(prefers-reduced-motion: reduce)",
+          media: query,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        })),
+      );
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    /** @scenario Reduced motion trades the pop for a plain hover state */
+    it("ignores pointer proximity but still rises on its own hover", async () => {
+      render(<Harness />);
+      movePointer(800, 740);
+      // No proximity tracking runs at all: the phase never leaves rest.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(peek()?.getAttribute("data-peek-phase")).toBe("rest");
+      await userEvent.hover(peek()!);
+      expect(peek()?.getAttribute("data-peek-phase")).toBe("near");
+    });
+
+    it("fades instead of sliding", () => {
+      render(<Harness />);
+      const style = peek()!.style;
+      expect(style.transition).toContain("opacity");
+      expect(style.transition).not.toContain("transform");
+    });
+  });
+});

--- a/langwatch/src/features/langy/__tests__/langyPeekDock.unit.test.ts
+++ b/langwatch/src/features/langy/__tests__/langyPeekDock.unit.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  FLOATING_PEEK_CARD_HEIGHT,
+  FLOATING_PEEK_NEAR_PX,
+  FLOATING_PEEK_REST_PX,
+  PEEK_PROXIMITY_ENTER_PX,
+  PEEK_PROXIMITY_EXIT_PX,
+  resolvePeekHiddenTransform,
+  resolvePeekProximity,
+  resolvePeekTransform,
+  resolvePeekVisiblePx,
+  SIDEBAR_PEEK_CARD_WIDTH,
+  SIDEBAR_PEEK_NEAR_PX,
+  SIDEBAR_PEEK_REST_PX,
+} from "../logic/langyPeekDock";
+
+/**
+ * The minimised peek's pure maths: how much sliver each phase shows, the
+ * transform that produces it, and the pointer-proximity verdict with its
+ * hysteresis. Spec: specs/langy/langy-peek-dock.feature
+ */
+describe("langyPeekDock geometry", () => {
+  describe("given the floating card is minimised", () => {
+    it("rests as a subtler sliver than it rises to", () => {
+      const rest = resolvePeekVisiblePx({ mode: "floating", phase: "rest" });
+      const near = resolvePeekVisiblePx({ mode: "floating", phase: "near" });
+      expect(rest).toBeLessThan(near);
+      // The whole point of "more hidden than the screenshot": the resting
+      // sliver is a lip, not a title bar.
+      expect(rest).toBeLessThan(near / 2);
+    });
+
+    it("translates the sunk card so exactly the sliver stays above the edge", () => {
+      expect(resolvePeekTransform({ mode: "floating", phase: "rest" })).toBe(
+        `translateY(${FLOATING_PEEK_CARD_HEIGHT - FLOATING_PEEK_REST_PX}px)`,
+      );
+      expect(resolvePeekTransform({ mode: "floating", phase: "near" })).toBe(
+        `translateY(${FLOATING_PEEK_CARD_HEIGHT - FLOATING_PEEK_NEAR_PX}px)`,
+      );
+    });
+
+    it("starts its entrance fully sunk below the edge", () => {
+      expect(resolvePeekHiddenTransform("floating")).toBe(
+        `translateY(${FLOATING_PEEK_CARD_HEIGHT}px)`,
+      );
+    });
+  });
+
+  describe("given the sidebar dock is minimised", () => {
+    it("rests as a thinner sliver than it rises to", () => {
+      const rest = resolvePeekVisiblePx({ mode: "sidebar", phase: "rest" });
+      const near = resolvePeekVisiblePx({ mode: "sidebar", phase: "near" });
+      expect(rest).toBeLessThan(near);
+    });
+
+    it("translates off the right edge and keeps its own vertical centring", () => {
+      expect(resolvePeekTransform({ mode: "sidebar", phase: "rest" })).toBe(
+        `translate(${SIDEBAR_PEEK_CARD_WIDTH - SIDEBAR_PEEK_REST_PX}px, -50%)`,
+      );
+      expect(resolvePeekTransform({ mode: "sidebar", phase: "near" })).toBe(
+        `translate(${SIDEBAR_PEEK_CARD_WIDTH - SIDEBAR_PEEK_NEAR_PX}px, -50%)`,
+      );
+      expect(resolvePeekHiddenTransform("sidebar")).toBe(
+        `translate(${SIDEBAR_PEEK_CARD_WIDTH}px, -50%)`,
+      );
+    });
+  });
+});
+
+describe("langyPeekDock proximity", () => {
+  const viewport = { viewportWidth: 1440, viewportHeight: 900 };
+
+  describe("given the floating peek rests bottom-right", () => {
+    const base = {
+      ...viewport,
+      mode: "floating" as const,
+      dodgeLeft: false,
+      wasNear: false,
+    };
+
+    it("stays at rest while the pointer works elsewhere on the page", () => {
+      expect(
+        resolvePeekProximity({ ...base, pointerX: 200, pointerY: 200 }),
+      ).toBe(false);
+    });
+
+    it("pops when the pointer nears the bottom-right region", () => {
+      // Just above the resting sliver, inside the enter radius.
+      expect(
+        resolvePeekProximity({
+          ...base,
+          pointerX: 1200,
+          pointerY: 900 - PEEK_PROXIMITY_ENTER_PX + 10,
+        }),
+      ).toBe(true);
+    });
+
+    it("does not pop for a pointer at the bottom-LEFT of the viewport", () => {
+      expect(
+        resolvePeekProximity({ ...base, pointerX: 60, pointerY: 890 }),
+      ).toBe(false);
+    });
+
+    describe("when a drawer holds the corner and the peek dodged left", () => {
+      it("the zone follows it to the bottom-left", () => {
+        const dodged = { ...base, dodgeLeft: true };
+        expect(
+          resolvePeekProximity({ ...dodged, pointerX: 60, pointerY: 890 }),
+        ).toBe(true);
+        expect(
+          resolvePeekProximity({ ...dodged, pointerX: 1400, pointerY: 890 }),
+        ).toBe(false);
+      });
+    });
+
+    describe("when the pointer hovers right on the boundary", () => {
+      it("holds its verdict — enter and exit radii differ (hysteresis)", () => {
+        // Between the two thresholds: distance ~170px above the sliver.
+        const betweenY =
+          900 -
+          (PEEK_PROXIMITY_ENTER_PX + PEEK_PROXIMITY_EXIT_PX) / 2;
+        const between = { ...base, pointerX: 1200, pointerY: betweenY };
+        // Approaching from afar: not yet near.
+        expect(resolvePeekProximity({ ...between, wasNear: false })).toBe(
+          false,
+        );
+        // Retreating from near: still near.
+        expect(resolvePeekProximity({ ...between, wasNear: true })).toBe(true);
+      });
+    });
+  });
+
+  describe("given the sidebar peek rests mid-height on the right edge", () => {
+    const base = {
+      ...viewport,
+      mode: "sidebar" as const,
+      dodgeLeft: false,
+      wasNear: false,
+    };
+
+    it("pops for a pointer drifting toward the right edge, mid-height", () => {
+      expect(
+        resolvePeekProximity({ ...base, pointerX: 1350, pointerY: 450 }),
+      ).toBe(true);
+    });
+
+    it("stays at rest for a pointer at the right edge's far corners", () => {
+      // Same edge, but far above the sliver's band — nowhere near the peek.
+      expect(
+        resolvePeekProximity({ ...base, pointerX: 1430, pointerY: 40 }),
+      ).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/features/langy/__tests__/langyPeekMinimize.unit.test.ts
+++ b/langwatch/src/features/langy/__tests__/langyPeekMinimize.unit.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { useLangyStore } from "../stores/langyStore";
+
+/**
+ * Minimise-to-peek is a MINIMISE, not a close: `isOpen: false` sinks the
+ * panel to its edge peek with everything underneath intact, and opening from
+ * the peek (click, Enter, or the Cmd/Ctrl+I toggle) brings the same surface
+ * back. These pin the store transitions the peek stands on.
+ *
+ * Spec: specs/langy/langy-peek-dock.feature
+ */
+describe("Langy minimise-to-peek store transitions", () => {
+  beforeEach(() => {
+    useLangyStore.getState().resetForProject("project-peek");
+    useLangyStore.getState().openPanel();
+  });
+
+  describe("given an open panel holding a conversation and a draft", () => {
+    beforeEach(() => {
+      useLangyStore.getState().selectConversation("conv-1");
+      useLangyStore.getState().consumeHistoryLoad();
+      useLangyStore.getState().setDraft("half a question");
+    });
+
+    describe("when the user minimises the panel", () => {
+      beforeEach(() => {
+        useLangyStore.getState().closePanel();
+      });
+
+      it("sinks to the peek — minimised, not gone", () => {
+        expect(useLangyStore.getState().isOpen).toBe(false);
+      });
+
+      it("keeps the conversation pointer untouched underneath", () => {
+        expect(useLangyStore.getState().activeConversationId).toBe("conv-1");
+      });
+
+      it("keeps the half-typed draft untouched underneath", () => {
+        expect(useLangyStore.getState().draft).toBe("half a question");
+      });
+
+      it("keeps the user's layout choice", () => {
+        useLangyStore.getState().openPanel();
+        useLangyStore.getState().setPanelMode("sidebar");
+        useLangyStore.getState().closePanel();
+        expect(useLangyStore.getState().panelMode).toBe("sidebar");
+      });
+
+      describe("when the peek is activated", () => {
+        it("opens the same surface back up — conversation and draft intact", () => {
+          useLangyStore.getState().openPanel();
+          const state = useLangyStore.getState();
+          expect(state.isOpen).toBe(true);
+          expect(state.activeConversationId).toBe("conv-1");
+          expect(state.draft).toBe("half a question");
+        });
+      });
+    });
+  });
+
+  describe("given the panel is minimised", () => {
+    beforeEach(() => {
+      useLangyStore.getState().closePanel();
+    });
+
+    describe("when the keyboard toggle fires", () => {
+      it("opens the panel — the command activation never depends on the pointer", () => {
+        useLangyStore.getState().togglePanel();
+        expect(useLangyStore.getState().isOpen).toBe(true);
+      });
+    });
+
+    describe("when a question arrives via askLangy", () => {
+      it("opens the panel over the peek and queues the question", () => {
+        useLangyStore.getState().askLangy("why are my traces failing");
+        const state = useLangyStore.getState();
+        expect(state.isOpen).toBe(true);
+        expect(state.pendingPrompt).toBe("why are my traces failing");
+      });
+    });
+  });
+
+  describe("given the panel is open", () => {
+    describe("when the keyboard toggle fires", () => {
+      it("minimises to the peek", () => {
+        useLangyStore.getState().togglePanel();
+        expect(useLangyStore.getState().isOpen).toBe(false);
+      });
+    });
+  });
+});

--- a/langwatch/src/features/langy/components/EmptyState.tsx
+++ b/langwatch/src/features/langy/components/EmptyState.tsx
@@ -218,7 +218,7 @@ export function EmptyState({
         marginBottom={`${metrics.heroMarginBottom}px`}
       >
         {/* The LangWatch mark, in the brand gradient — and the ONLY place it
-            appears inside the panel (the launcher is the other). Bare, no tile:
+            appears inside the panel (the minimised peek is the other). Bare, no tile:
             the orange chip that used to box it in was old-brand chrome, a
             saturated block competing with the display line right under it. It
             shrinks with the card but never below 34px, the smallest size at

--- a/langwatch/src/features/langy/components/LangyPanel.tsx
+++ b/langwatch/src/features/langy/components/LangyPanel.tsx
@@ -51,6 +51,7 @@ import { toaster } from "~/components/ui/toaster";
 import { Tooltip } from "~/components/ui/tooltip";
 import { ModelProviderScreen } from "~/features/onboarding/components/sections/ModelProviderScreen";
 import { useDrawer } from "~/hooks/useDrawer";
+import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useProjectReach } from "~/components/home/useProjectReach";
 import { useReducedMotion } from "~/hooks/useReducedMotion";
@@ -132,6 +133,7 @@ import { LangyContextTargetLayer } from "./LangyContextTargetLayer";
 import { LangyError } from "./LangyError";
 import { LangyExternalLinkDialog } from "./LangyExternalLinkDialog";
 import { LangyMark, LangyMarkGradientDefs } from "./LangyMark";
+import { LangyPeekDock } from "./LangyPeekDock";
 import { LangyRecoveringLine } from "./LangyRecoveringLine";
 import { RecentChatsView } from "./RecentChatsView";
 import { LangyThinkingLine } from "./LangyThinkingLine";
@@ -155,8 +157,8 @@ const LANGY_GATE_FEATURE_KEY = "prompt.create_default";
 
 // The floating card's symmetric viewport inset: a rounded card with a small,
 // SYMMETRIC inset on every side (a soft brand glow + shadow behind it).
-// Shared with the inspector drawer via langyPanelLayout, so the two can
-// never drift apart by a pixel.
+// Shared via langyPanelLayout with the inspector drawer and the minimised
+// peek, so none of the three can drift apart by a pixel.
 const PANEL_INSET = FLOATING_PANEL_INSET;
 
 // A Chakra Box that also takes framer-motion props — used for the thinking
@@ -190,10 +192,11 @@ const FLOATING_MAX_VIEWPORT_DVH = 90;
 const FLOATING_EDGE_GUTTER_PX = 12;
 const FLOATING_MAX_HEIGHT = `calc(${FLOATING_MAX_VIEWPORT_DVH}dvh - ${FLOATING_EDGE_GUTTER_PX}px)`;
 
-// Floating grows OUT OF the launcher it replaces: scaled down and offset toward
+// Floating grows OUT OF the peek it replaces: scaled down and offset toward
 // the bottom-right corner, then springing up to rest — the card feels like it
-// unfolds from the button you just pressed rather than sliding in from off-canvas.
-// Sidebar is a dock, so it does the honest thing and slides in from the edge.
+// rises out of the sliver you just clicked rather than sliding in from
+// off-canvas. Sidebar is a dock, so it does the honest thing and slides in
+// from the edge — exactly where its own peek sliver rests.
 const FLOATING_CLOSED = { opacity: 0, scale: 0.92, x: 10, y: 18 } as const;
 const SIDEBAR_CLOSED = {
   opacity: 0,
@@ -263,12 +266,23 @@ interface LangySidecarProps {
 export function LangySidecar({ proposalHandlersRef }: LangySidecarProps) {
   const isOpen = useLangyStore((s) => s.isOpen);
   const toggle = useLangyStore((s) => s.togglePanel);
+  const openPanel = useLangyStore((s) => s.openPanel);
   useGlobalLangyShortcut(toggle);
+  // The minimised affordance is mid-rollout: flag ON, minimise sinks the
+  // panel to an edge peek of itself (LangyPeekDock); flag OFF keeps the
+  // classic corner launcher orb. ONE renders at a time — never both — and
+  // only the closed state differs: opening, the panel and Cmd/Ctrl+I are
+  // identical on either side of the flag.
+  const peekDock = useFeatureFlag("release_ui_langy_peek_dock_enabled");
 
   return (
     <>
       <LangyMarkGradientDefs />
-      <LangyLauncher isOpen={isOpen} onOpen={toggle} />
+      {peekDock.enabled ? (
+        <LangyPeekDock isOpen={isOpen} onOpen={openPanel} />
+      ) : (
+        <LangyLauncher isOpen={isOpen} onOpen={toggle} />
+      )}
       <LangyContextTargetLayer />
       <LangyPanel proposalHandlersRef={proposalHandlersRef} />
     </>
@@ -276,11 +290,12 @@ export function LangySidecar({ proposalHandlersRef }: LangySidecarProps) {
 }
 
 /**
- * The closed-state opener — a single circular launcher in the bottom-right
- * corner (the Notion-AI model), NOT an edge chip. There is no reserved gutter
- * and no collapse tab: opening is this button, collapsing is the panel header's
- * Minimise. Restrained on purpose — the LangWatch mark on a plain surface with a soft
- * neutral shadow, no mesh, no loud colour. Hidden while the panel is open.
+ * The FLAG-OFF closed-state opener — a single circular launcher in the
+ * bottom-right corner (the Notion-AI model). Retires in favour of the edge
+ * peek (LangyPeekDock, `release_ui_langy_peek_dock_enabled`); until that
+ * flag ships, this remains the minimised affordance. Restrained on purpose —
+ * the LangWatch mark on a plain surface with a soft neutral shadow, no mesh,
+ * no loud colour. Hidden while the panel is open.
  */
 function LangyLauncher({
   isOpen,
@@ -1781,8 +1796,8 @@ function LangyPanel({
         // transform on exactly this element — so it needs to be able to find
         // it and suppress it for one synchronous read.
         {...{ [PANEL_ROOT_ATTR]: "" }}
-        // Floating unfolds from the launcher's corner; sidebar slides from the
-        // edge it docks to.
+        // Floating rises from the peek's corner; sidebar slides from the
+        // edge its peek sliver rests on.
         transformOrigin={floating ? "bottom right" : "right center"}
         initial={false}
         animate={isOpen ? "open" : "closed"}
@@ -2677,9 +2692,10 @@ function PanelHeader({
               It says MINIMISE, because that is what it does. The panel stays
               mounted (unmounting would tear down the in-flight stream), the
               conversation is untouched, `isOpen` persists across a reload, and
-              the launcher orb comes back — so the honest word is minimise, and
-              a second "minimise" control beside a "close" that did the same
-              thing would only be two names for one behaviour. */}
+              the panel sinks to its edge peek (see LangyPeekDock) — so the
+              honest word is minimise, and a second "minimise" control beside
+              a "close" that did the same thing would only be two names for
+              one behaviour. */}
           {hideClose ? null : (
             <>
               <Box

--- a/langwatch/src/features/langy/components/LangyPeekDock.tsx
+++ b/langwatch/src/features/langy/components/LangyPeekDock.tsx
@@ -1,0 +1,241 @@
+import { Box, chakra, HStack, Text } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { Kbd } from "~/components/ops/shared/Kbd";
+import { IsolatedErrorBoundary } from "~/components/ui/IsolatedErrorBoundary";
+import { Tooltip } from "~/components/ui/tooltip";
+import { useDrawer } from "~/hooks/useDrawer";
+import { useReducedMotion } from "~/hooks/useReducedMotion";
+import { useLangyPeekProximity } from "../hooks/useLangyPeekProximity";
+import {
+  FLOATING_PANEL_CSS_WIDTH,
+  FLOATING_PANEL_INSET,
+  LANGY_TRANSITION,
+} from "../logic/langyPanelLayout";
+import {
+  FLOATING_PEEK_CARD_HEIGHT,
+  type LangyPeekPhase,
+  resolvePeekHiddenTransform,
+  resolvePeekTransform,
+  SIDEBAR_PEEK_CARD_WIDTH,
+  SIDEBAR_PEEK_HEIGHT,
+} from "../logic/langyPeekDock";
+import { useLangyStore } from "../stores/langyStore";
+import { LangyMark } from "./LangyMark";
+
+/**
+ * The minimised state — a PEEK of the panel itself, not a separate launcher.
+ *
+ * Floating mode: the card sinks below the bottom viewport edge, bottom-right
+ * where it lives, leaving a sliver of its header lip. Sidebar mode: the
+ * dock's spine peeks in from the right edge as a thin vertical sliver,
+ * mid-height. Both rise a little as the pointer approaches (or on keyboard
+ * focus), and open fully on click / Enter / Space — or the global Cmd/Ctrl+I,
+ * which never depended on this surface at all.
+ *
+ * The peek wears the panel's own material (surface, hairline, brand seam)
+ * and moves on the panel's own curve (LANGY_TRANSITION), so minimise reads
+ * as the card sinking out of the way rather than being swapped for a button.
+ * While a turn is still running underneath, the seam breathes on the fold's
+ * own pulse period — the creature is minimised, not gone.
+ *
+ * Reduced motion: no proximity tracking runs; the peek's own hover/focus
+ * swaps it to the raised state without animation, and its entrance is a
+ * fade instead of a slide.
+ *
+ * Spec: specs/langy/langy-peek-dock.feature
+ */
+export function LangyPeekDock({
+  isOpen,
+  onOpen,
+}: {
+  isOpen: boolean;
+  onOpen: () => void;
+}) {
+  // Render nothing while open — and REMOUNT on minimise, which is what arms
+  // the entrance slide from fully-sunk to the resting sliver.
+  if (isOpen) return null;
+  return (
+    // The peek mounts at the app-layout level (LangySidecar), a sibling of
+    // the whole routed page — so a render crash in here must stay in here.
+    // The boundary swaps a broken peek for the repo's inline error card
+    // instead of blanking the page, and Cmd/Ctrl+I still opens the panel
+    // (the shortcut lives above this subtree).
+    <IsolatedErrorBoundary scope="Langy couldn't show its minimised panel">
+      <LangyPeek onOpen={onOpen} />
+    </IsolatedErrorBoundary>
+  );
+}
+
+/**
+ * Hold the entrance until the panel's close animation (160ms) has mostly
+ * cleared, so the sinking card and the rising sliver read as one hand-off
+ * rather than two things moving at once.
+ */
+const PEEK_ENTRANCE_DELAY_MS = 140;
+
+function LangyPeek({ onOpen }: { onOpen: () => void }) {
+  const panelMode = useLangyStore((s) => s.panelMode);
+  // The turn phase, not isBusy: the durable machine keeps this true across a
+  // silent worker and another tab's turn — exactly the work someone minimised
+  // the panel to wait out.
+  const turnActive = useLangyStore((s) => s.turnPhase !== "idle");
+  const reduceMotion = useReducedMotion();
+  // A right-anchored drawer owns the bottom-right corner while it is open, so
+  // the floating peek rests along the bottom-LEFT edge instead (the same
+  // dodge the floating panel itself makes). The sidebar sliver HOLDS its
+  // right edge — it rides above the drawer's card (z, mirroring the drawer
+  // companion) and is thin enough at rest to sit on the drawer's rim.
+  const { currentDrawer } = useDrawer();
+  const hasDrawer = !!currentDrawer;
+  const floating = panelMode === "floating";
+  const dodgeLeft = hasDrawer && floating;
+
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const near = useLangyPeekProximity({
+    enabled: !reduceMotion,
+    mode: panelMode,
+    dodgeLeft,
+  });
+  const phase: LangyPeekPhase = near || hovered || focused ? "near" : "rest";
+
+  const [entered, setEntered] = useState(false);
+  useEffect(() => {
+    const timer = window.setTimeout(
+      () => setEntered(true),
+      PEEK_ENTRANCE_DELAY_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  // Slide on transform (compositor-friendly, the panel's own curve); under
+  // reduced motion the transform pins to the phase and only opacity fades.
+  const transform =
+    reduceMotion || entered
+      ? resolvePeekTransform({ mode: panelMode, phase })
+      : resolvePeekHiddenTransform(panelMode);
+  const opacity = reduceMotion && !entered ? 0 : 1;
+  const transition = reduceMotion
+    ? "opacity 160ms linear"
+    : `transform ${LANGY_TRANSITION}`;
+
+  return (
+    <Tooltip
+      content={
+        <HStack gap={2}>
+          <Text>Chat with Langy</Text>
+          <HStack gap={1}>
+            <Kbd>⌘</Kbd>
+            <Kbd>I</Kbd>
+          </HStack>
+        </HStack>
+      }
+      positioning={{ placement: floating ? "top" : "left" }}
+      openDelay={200}
+    >
+      <chakra.button
+        type="button"
+        className={`langy-root langy-peek${turnActive ? " langy-peek-working" : ""}`}
+        data-peek-mode={panelMode}
+        data-peek-phase={phase}
+        {...(dodgeLeft ? { "data-peek-dodge": "left" } : {})}
+        onClick={onOpen}
+        onPointerEnter={() => setHovered(true)}
+        onPointerLeave={() => setHovered(false)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        aria-label="Open Langy assistant"
+        aria-keyshortcuts="Meta+I Control+I"
+        position="fixed"
+        cursor="pointer"
+        overflow="hidden"
+        borderStyle="solid"
+        borderColor="border"
+        style={{ transform, opacity, transition }}
+        _focusVisible={{
+          outline: "2px solid",
+          outlineColor: "orange.emphasized",
+          outlineOffset: "2px",
+        }}
+        {...(floating
+          ? {
+              // The card's own footprint, sunk: same width, same horizontal
+              // inset, same glass, same hairline — laid out flush with the
+              // bottom edge and translated below it.
+              bottom: 0,
+              ...(dodgeLeft
+                ? { left: `${FLOATING_PANEL_INSET}px` }
+                : { right: `${FLOATING_PANEL_INSET}px` }),
+              width: FLOATING_PANEL_CSS_WIDTH,
+              height: `${FLOATING_PEEK_CARD_HEIGHT}px`,
+              zIndex: 1200,
+              borderWidth: "1px",
+              borderRadius: "20px",
+              background: "bg.surface/85",
+              backdropFilter: "blur(8px)",
+              boxShadow:
+                "0 -1px 2px rgba(20,20,23,0.04), 0 -8px 24px rgba(20,20,23,0.10)",
+              _dark: {
+                background: "bg.surface/88",
+                boxShadow:
+                  "0 -1px 2px rgba(0,0,0,0.4), 0 -10px 28px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.12)",
+              },
+            }
+          : {
+              // The dock's spine: a rounded-left sliver holding the right
+              // edge, opaque like the dock it stands for. Above the drawer
+              // card while one is open (the drawer companion's own z).
+              top: "50%",
+              right: 0,
+              width: `${SIDEBAR_PEEK_CARD_WIDTH}px`,
+              height: `${SIDEBAR_PEEK_HEIGHT}px`,
+              zIndex: hasDrawer ? 1600 : 1200,
+              borderWidth: "1px",
+              borderRightWidth: 0,
+              borderTopLeftRadius: "12px",
+              borderBottomLeftRadius: "12px",
+              background: "bg.surface",
+              boxShadow:
+                "-1px 0 2px rgba(20,20,23,0.04), -8px 0 24px rgba(20,20,23,0.10)",
+              _dark: {
+                boxShadow:
+                  "-1px 0 2px rgba(0,0,0,0.4), -10px 0 28px rgba(0,0,0,0.5), inset 1px 0 0 rgba(255,255,255,0.12)",
+              },
+            })}
+      >
+        {floating ? (
+          // The header lip — laid out at the card's top so the risen peek
+          // shows exactly the line the open panel's header shows.
+          <HStack gap={2} paddingX="14px" height="36px" alignItems="center">
+            <LangyMark size={15} />
+            <Text
+              textStyle="sm"
+              fontWeight="600"
+              letterSpacing="-0.01em"
+              color="fg"
+            >
+              Langy
+            </Text>
+            <Box flex={1} />
+            <HStack gap={1} opacity={phase === "near" ? 0.9 : 0}>
+              <Kbd>⌘</Kbd>
+              <Kbd>I</Kbd>
+            </HStack>
+          </HStack>
+        ) : (
+          // The mark sits by the sliver's left rim: clipped at rest, fully
+          // revealed at the proximity width.
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="flex-start"
+            paddingLeft="3px"
+            height="full"
+          >
+            <LangyMark size={14} />
+          </Box>
+        )}
+      </chakra.button>
+    </Tooltip>
+  );
+}

--- a/langwatch/src/features/langy/hooks/useLangyPeekProximity.ts
+++ b/langwatch/src/features/langy/hooks/useLangyPeekProximity.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import { resolvePeekProximity } from "../logic/langyPeekDock";
+
+/**
+ * Does the pointer stand near the minimised peek's edge region?
+ *
+ * One passive `pointermove` listener, throttled through rAF, evaluating the
+ * pure hysteresis test in `langyPeekDock.ts`. NOT an invisible hover strip on
+ * purpose: a strip needs `pointer-events: auto` to feel the pointer, which
+ * makes it swallow clicks on whatever sits under it — and the bottom-right
+ * corner is contested ground (the table pager lives there; the retired
+ * launcher orb fought that exact collision twice). A passive listener
+ * touches nothing it doesn't own, and it keeps the orb's discipline:
+ * imperative reads, React state only at the boundary — `setNear` with an
+ * unchanged boolean is a React bail-out, so a moving pointer renders
+ * nothing until the verdict actually flips.
+ *
+ * Mounted only while the peek shows and motion is allowed; under reduced
+ * motion the peek's own :hover/:focus does the job (spec: the pop becomes a
+ * plain hover state).
+ */
+export function useLangyPeekProximity({
+  enabled,
+  mode,
+  dodgeLeft,
+}: {
+  enabled: boolean;
+  mode: "floating" | "sidebar";
+  dodgeLeft: boolean;
+}): boolean {
+  const [near, setNear] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setNear(false);
+      return;
+    }
+    let raf = 0;
+    let pointerX = 0;
+    let pointerY = 0;
+
+    const evaluate = () => {
+      raf = 0;
+      setNear((wasNear) =>
+        resolvePeekProximity({
+          pointerX,
+          pointerY,
+          viewportWidth: window.innerWidth,
+          viewportHeight: window.innerHeight,
+          mode,
+          dodgeLeft,
+          wasNear,
+        }),
+      );
+    };
+    const onMove = (event: PointerEvent) => {
+      pointerX = event.clientX;
+      pointerY = event.clientY;
+      if (!raf) raf = requestAnimationFrame(evaluate);
+    };
+    // The pointer left the page (or the window lost focus): nothing is
+    // approaching anything.
+    const onLeave = () => {
+      if (raf) cancelAnimationFrame(raf);
+      raf = 0;
+      setNear(false);
+    };
+
+    window.addEventListener("pointermove", onMove, { passive: true });
+    document.addEventListener("mouseleave", onLeave);
+    window.addEventListener("blur", onLeave);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      document.removeEventListener("mouseleave", onLeave);
+      window.removeEventListener("blur", onLeave);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [enabled, mode, dodgeLeft]);
+
+  return near;
+}

--- a/langwatch/src/features/langy/langyTheme.css
+++ b/langwatch/src/features/langy/langyTheme.css
@@ -559,13 +559,14 @@
   fill: currentColor;
 }
 
-/* ── The closed orb's proximity glow ───────────────────────────────────────
+/* ── The closed orb's proximity glow (flag-off launcher) ───────────────────
    A soft warm field that bleeds out around the launcher orb and leans toward
    the cursor as it approaches. `z-index: -1` tucks it behind the orb's opaque
    body, so only the part reaching PAST the orb edge (toward the pointer) shows
    — light spilling out, not a disc under the button. Opacity + transform are
    driven imperatively by useLangyOrbProximity (0 at rest). Light panel: warm
-   amber; dark panel: a warm-white that screen-blends onto the page corner. */
+   amber; dark panel: a warm-white that screen-blends onto the page corner.
+   Retires with the orb once release_ui_langy_peek_dock_enabled ships. */
 .langy-root .langy-orb-glow {
   position: absolute;
   inset: -30px;
@@ -598,7 +599,7 @@
   }
 }
 
-/* ── The orb click bloom ───────────────────────────────────────────────────
+/* ── The orb click bloom (flag-off launcher) ───────────────────────────────
    A quick warm bloom that expands and fades from the orb's centre on the click
    that opens the panel — the "it heard you" beat. Spawned as a detached element
    on <body> by useLangyOrbProximity (so it survives the orb unmounting) and
@@ -643,6 +644,98 @@
 @media (prefers-reduced-motion: reduce) {
   .langy-orb-burst {
     display: none;
+  }
+}
+
+/* ── The minimised peek's brand seam ───────────────────────────────────────
+   The minimised panel is a PEEK of itself at the viewport edge (see
+   LangyPeekDock): a sliver of the card's header lip along the bottom in
+   floating mode, a sliver of the dock's spine on the right edge in sidebar
+   mode. The seam is the sliver's identity — a faint warm line along the
+   exposed edge, the fold's own tones, so the 6–10px at rest read as Langy
+   rather than as stray chrome. It brightens with the proximity pop, and
+   BREATHES on the fold's pulse period while a turn is still running under
+   the minimised panel — the creature is sunk, not gone. */
+.langy-peek::before {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  opacity: 0.55;
+  transition: opacity 240ms ease;
+}
+.langy-peek[data-peek-mode="floating"]::before {
+  top: 0;
+  left: 18px;
+  right: 18px;
+  height: 2px;
+  border-radius: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(214, 140, 74, 0.5) 30%,
+    rgba(201, 123, 58, 0.55) 70%,
+    transparent
+  );
+}
+.langy-peek[data-peek-mode="sidebar"]::before {
+  left: 0;
+  top: 14px;
+  bottom: 14px;
+  width: 2px;
+  border-radius: 2px;
+  background: linear-gradient(
+    180deg,
+    transparent,
+    rgba(214, 140, 74, 0.5) 30%,
+    rgba(201, 123, 58, 0.55) 70%,
+    transparent
+  );
+}
+.dark .langy-peek[data-peek-mode="floating"]::before,
+:root.dark .langy-peek[data-peek-mode="floating"]::before {
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 214, 165, 0.4) 30%,
+    rgba(255, 180, 120, 0.45) 70%,
+    transparent
+  );
+}
+.dark .langy-peek[data-peek-mode="sidebar"]::before,
+:root.dark .langy-peek[data-peek-mode="sidebar"]::before {
+  background: linear-gradient(
+    180deg,
+    transparent,
+    rgba(255, 214, 165, 0.4) 30%,
+    rgba(255, 180, 120, 0.45) 70%,
+    transparent
+  );
+}
+.langy-peek[data-peek-phase="near"]::before {
+  opacity: 1;
+}
+/* A turn is in flight under the minimised panel: the seam breathes on the
+   fold's own pulse period (WAVE_PULSE_PERIOD_S), the same clock the open
+   panel's tool pulse keeps. */
+.langy-peek-working::before {
+  animation: langy-peek-breathe 2.6s ease-in-out infinite;
+}
+@keyframes langy-peek-breathe {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.95;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .langy-peek::before {
+    transition: none;
+  }
+  .langy-peek-working::before {
+    animation: none;
+    opacity: 0.9;
   }
 }
 
@@ -798,6 +891,46 @@
       color(display-p3 1 0.839 0.647 / 0.5) 0%,
       color(display-p3 1 0.706 0.471 / 0.24) 45%,
       transparent 70%
+    );
+  }
+
+  /* The minimised peek's brand seam — the fold's warm tones on wide gamuts. */
+  .langy-peek[data-peek-mode="floating"]::before {
+    background: linear-gradient(
+      90deg,
+      transparent,
+      color(display-p3 0.839 0.549 0.29 / 0.5) 30%,
+      color(display-p3 0.788 0.482 0.227 / 0.55) 70%,
+      transparent
+    );
+  }
+  .langy-peek[data-peek-mode="sidebar"]::before {
+    background: linear-gradient(
+      180deg,
+      transparent,
+      color(display-p3 0.839 0.549 0.29 / 0.5) 30%,
+      color(display-p3 0.788 0.482 0.227 / 0.55) 70%,
+      transparent
+    );
+  }
+  .dark .langy-peek[data-peek-mode="floating"]::before,
+  :root.dark .langy-peek[data-peek-mode="floating"]::before {
+    background: linear-gradient(
+      90deg,
+      transparent,
+      color(display-p3 1 0.839 0.647 / 0.4) 30%,
+      color(display-p3 1 0.706 0.471 / 0.45) 70%,
+      transparent
+    );
+  }
+  .dark .langy-peek[data-peek-mode="sidebar"]::before,
+  :root.dark .langy-peek[data-peek-mode="sidebar"]::before {
+    background: linear-gradient(
+      180deg,
+      transparent,
+      color(display-p3 1 0.839 0.647 / 0.4) 30%,
+      color(display-p3 1 0.706 0.471 / 0.45) 70%,
+      transparent
     );
   }
 }

--- a/langwatch/src/features/langy/logic/langyPanelLayout.ts
+++ b/langwatch/src/features/langy/logic/langyPanelLayout.ts
@@ -51,6 +51,15 @@ export const PANEL_LAYOUT_TRANSITION = {
   mass: 0.82,
 } as const;
 
+/**
+ * The floating card's symmetric viewport inset (a rounded card with a small,
+ * SYMMETRIC inset on every side). One definition, shared by everything that
+ * hangs off the card's edge: the inspector drawer (so the two can't drift a
+ * pixel apart) and the minimised peek (which rests on the same horizontal
+ * position, so sinking and rising never side-step).
+ */
+export const FLOATING_PANEL_INSET = 12;
+
 /** Desktop ceiling for the floating companion. */
 export const FLOATING_PANEL_MAX_WIDTH = 432;
 
@@ -80,14 +89,6 @@ export function resolveFloatingPanelWidth(viewportWidth: number): number {
 }
 
 export const FLOATING_PANEL_CSS_WIDTH = `min(${FLOATING_PANEL_MAX_WIDTH}px, max(${FLOATING_PANEL_MIN_WIDTH}px, ${FLOATING_PANEL_VIEWPORT_SHARE * 100}vw), calc(100vw - ${FLOATING_PANEL_VIEWPORT_GUTTER}px))`;
-
-/**
- * The floating card's symmetric viewport inset: a rounded card with a small,
- * SYMMETRIC inset on every side. One definition — the panel and the inspector
- * drawer both hang their geometry off it, and a one-pixel drift between the
- * two is exactly the kind of seam the eye catches.
- */
-export const FLOATING_PANEL_INSET = 12;
 
 /** The inspector drawer's visible width. */
 export const INSPECTOR_WIDTH = 380;

--- a/langwatch/src/features/langy/logic/langyPeekDock.ts
+++ b/langwatch/src/features/langy/logic/langyPeekDock.ts
@@ -1,0 +1,177 @@
+import {
+  FLOATING_PANEL_INSET,
+  resolveFloatingPanelWidth,
+} from "./langyPanelLayout";
+
+/**
+ * The minimised peek's geometry and proximity maths — all of it pure, all of
+ * it here, so the component only ever renders what these functions resolve.
+ *
+ * Minimising Langy used to swap the panel for a corner orb. Now the panel
+ * sinks to a PEEK of itself: floating mode leaves a sliver of the card's
+ * header lip above the bottom viewport edge; sidebar mode leaves a thin
+ * vertical sliver of the dock's spine on the right edge. Three states:
+ *
+ *   rest   — the sliver. Deliberately subtler than a title bar: present
+ *            enough to find, quiet enough to forget.
+ *   near   — the pointer is approaching the peek's edge region (or the peek
+ *            holds keyboard focus): it rises a little further. An invitation,
+ *            not an opening.
+ *   open   — the panel is open; the peek stands down entirely (the component
+ *            renders nothing — LangyPanel owns the open surface).
+ *
+ * Spec: specs/langy/langy-peek-dock.feature
+ */
+
+export type LangyPeekPhase = "rest" | "near";
+
+// ── Floating mode: the card sinks below the bottom edge ────────────────────
+/**
+ * The sunk card's total height. Tall enough that its side hairlines visibly
+ * run OFF the bottom of the viewport — which is what sells "the card sank"
+ * rather than "a chip appeared" — and no taller, because everything below
+ * the sliver is paint nobody sees.
+ */
+export const FLOATING_PEEK_CARD_HEIGHT = 76;
+/** Sliver above the bottom edge at rest — the card's rounded top lip. */
+export const FLOATING_PEEK_REST_PX = 10;
+/** Risen height on proximity/focus — the full header line reads. */
+export const FLOATING_PEEK_NEAR_PX = 36;
+
+// ── Sidebar mode: the dock's spine peeks from the right edge ───────────────
+/** The sliver card's full width (mostly offscreen right). */
+export const SIDEBAR_PEEK_CARD_WIDTH = 44;
+/** Visible spine at rest — a rim, not a control. */
+export const SIDEBAR_PEEK_REST_PX = 6;
+/** Risen width on proximity/focus — enough to show the mark. */
+export const SIDEBAR_PEEK_NEAR_PX = 20;
+/** The sliver's height, centred on the viewport's vertical middle. */
+export const SIDEBAR_PEEK_HEIGHT = 128;
+
+/**
+ * How many px of the peek are visible above/inside the viewport edge for a
+ * phase. One lookup, so the transform and the proximity hit zone can never
+ * disagree about where the peek is.
+ */
+export function resolvePeekVisiblePx({
+  mode,
+  phase,
+}: {
+  mode: "floating" | "sidebar";
+  phase: LangyPeekPhase;
+}): number {
+  if (mode === "floating") {
+    return phase === "near" ? FLOATING_PEEK_NEAR_PX : FLOATING_PEEK_REST_PX;
+  }
+  return phase === "near" ? SIDEBAR_PEEK_NEAR_PX : SIDEBAR_PEEK_REST_PX;
+}
+
+/**
+ * The CSS transform for a phase. The peek is laid out fully visible at the
+ * viewport edge and TRANSLATED off it — transforms animate on the compositor,
+ * and the same element slides between all three positions (entrance, rest,
+ * near) on one property. Sidebar carries its own -50% Y centring so the
+ * caller never has to compose transforms.
+ */
+export function resolvePeekTransform({
+  mode,
+  phase,
+}: {
+  mode: "floating" | "sidebar";
+  phase: LangyPeekPhase;
+}): string {
+  const visible = resolvePeekVisiblePx({ mode, phase });
+  if (mode === "floating") {
+    return `translateY(${FLOATING_PEEK_CARD_HEIGHT - visible}px)`;
+  }
+  return `translate(${SIDEBAR_PEEK_CARD_WIDTH - visible}px, -50%)`;
+}
+
+/** Where the peek starts from (fully sunk) so its entrance can slide to rest. */
+export function resolvePeekHiddenTransform(mode: "floating" | "sidebar"): string {
+  if (mode === "floating") {
+    return `translateY(${FLOATING_PEEK_CARD_HEIGHT}px)`;
+  }
+  return `translate(${SIDEBAR_PEEK_CARD_WIDTH}px, -50%)`;
+}
+
+// ── Proximity ───────────────────────────────────────────────────────────────
+/**
+ * The pop arms when the pointer comes within ENTER px of the resting sliver,
+ * and disarms only past EXIT px — hysteresis, so a pointer hovering right on
+ * the boundary can't strobe the peek up and down.
+ */
+export const PEEK_PROXIMITY_ENTER_PX = 140;
+export const PEEK_PROXIMITY_EXIT_PX = 200;
+
+interface PeekProximityInput {
+  pointerX: number;
+  pointerY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  mode: "floating" | "sidebar";
+  /** Floating only: a right-anchored drawer holds the corner, peek went left. */
+  dodgeLeft: boolean;
+  /** The previous verdict — what the hysteresis pivots on. */
+  wasNear: boolean;
+}
+
+/**
+ * Is the pointer near the peek? Pure — the hook feeds it pointer + viewport
+ * and the previous verdict; distance is measured to the RESTING sliver's
+ * rectangle (the thing the user is aiming at), not to the risen one, so the
+ * zone doesn't grow the moment the peek rises.
+ */
+export function resolvePeekProximity({
+  pointerX,
+  pointerY,
+  viewportWidth,
+  viewportHeight,
+  mode,
+  dodgeLeft,
+  wasNear,
+}: PeekProximityInput): boolean {
+  const rect = restingPeekRect({
+    viewportWidth,
+    viewportHeight,
+    mode,
+    dodgeLeft,
+  });
+  const dx = Math.max(rect.left - pointerX, 0, pointerX - rect.right);
+  const dy = Math.max(rect.top - pointerY, 0, pointerY - rect.bottom);
+  const distance = Math.hypot(dx, dy);
+  const threshold = wasNear ? PEEK_PROXIMITY_EXIT_PX : PEEK_PROXIMITY_ENTER_PX;
+  return distance <= threshold;
+}
+
+/** The resting sliver's viewport rectangle — the proximity zone's anchor. */
+function restingPeekRect({
+  viewportWidth,
+  viewportHeight,
+  mode,
+  dodgeLeft,
+}: {
+  viewportWidth: number;
+  viewportHeight: number;
+  mode: "floating" | "sidebar";
+  dodgeLeft: boolean;
+}): { left: number; right: number; top: number; bottom: number } {
+  if (mode === "floating") {
+    const width = resolveFloatingPanelWidth(viewportWidth);
+    const left = dodgeLeft
+      ? FLOATING_PANEL_INSET
+      : viewportWidth - FLOATING_PANEL_INSET - width;
+    return {
+      left,
+      right: left + width,
+      top: viewportHeight - FLOATING_PEEK_REST_PX,
+      bottom: viewportHeight,
+    };
+  }
+  return {
+    left: viewportWidth - SIDEBAR_PEEK_REST_PX,
+    right: viewportWidth,
+    top: viewportHeight / 2 - SIDEBAR_PEEK_HEIGHT / 2,
+    bottom: viewportHeight / 2 + SIDEBAR_PEEK_HEIGHT / 2,
+  };
+}

--- a/langwatch/src/features/langy/stores/langyStore.ts
+++ b/langwatch/src/features/langy/stores/langyStore.ts
@@ -189,7 +189,15 @@ export interface LangyProgressSample {
 }
 
 interface LangyState extends TurnPhaseState {
-  // Panel visibility
+  // Panel visibility. `false` is MINIMISED, not gone: the panel sinks to its
+  // edge peek (see LangyPeekDock — a sliver of the card at the bottom edge in
+  // floating mode, of the dock's spine on the right edge in sidebar mode)
+  // with the conversation, draft and layout choice untouched underneath.
+  // `openPanel` — the peek's click/Enter, the Cmd/Ctrl+I toggle, an askLangy
+  // handoff — brings the same surface back. Exactly ONE minimised affordance
+  // renders at a time: the peek behind release_ui_langy_peek_dock_enabled,
+  // the classic launcher orb while that flag is off (see LangySidecar).
+  // Spec: specs/langy/langy-peek-dock.feature
   isOpen: boolean;
   openPanel: () => void;
   closePanel: () => void;

--- a/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
@@ -70,6 +70,11 @@ export const FRONTEND_FEATURE_FLAGS = [
   // the homepage's layout ONLY — Langy access separately gates the
   // sheet's hand-to-Langy affordances. See useShowSignalFocusedHome.
   "release_ui_home_signal_focused_enabled",
+  // Langy's minimised state as an edge peek of the panel itself (spec:
+  // specs/langy/langy-peek-dock.feature). Flag off = the classic corner
+  // launcher orb. Swaps only the CLOSED-state affordance; opening, the
+  // panel and Cmd/Ctrl+I are identical either way.
+  "release_ui_langy_peek_dock_enabled",
   "release_webhook_automations",
 ] as const;
 

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -224,6 +224,14 @@ export const FEATURE_FLAGS = [
       "Switches the project home to the signal-focused composition — the briefing sheet leads, the chrome grid and recent work follow (spec: specs/home/signal-focused-home-rollout.feature). Deliberately decoupled from release_langy_enabled: this flag alone decides the home's composition, while Langy access only decides whether the sheet's hand-to-Langy affordances render. Default off = classic home. Force-enable in dev via FEATURE_FLAG_FORCE_ENABLE=release_ui_home_signal_focused_enabled.",
   },
   {
+    key: "release_ui_langy_peek_dock_enabled",
+    scope: "PRODUCT",
+    defaultValue: false,
+    family: "Langy",
+    description:
+      "Minimising Langy sinks the panel to an edge peek of itself — a sliver of the card at the bottom edge (floating) or of the dock's spine at the right edge (sidebar) that rises on pointer proximity and opens on click (spec: specs/langy/langy-peek-dock.feature). Off = the classic corner launcher orb. Only the closed-state affordance changes; the panel and its Cmd/Ctrl+I activation are the same either way. Force-enable in dev via FEATURE_FLAG_FORCE_ENABLE=release_ui_langy_peek_dock_enabled.",
+  },
+  {
     key: "release_webhook_automations",
     scope: "PRODUCT",
     defaultValue: false,

--- a/specs/langy/langy-panel-layout.feature
+++ b/specs/langy/langy-panel-layout.feature
@@ -114,6 +114,8 @@ Feature: Langy panel layout modes
     And the drawer's own close is the only X on screen
     So closing the drawer, not Langy, is the obvious action
 
-  Scenario: The closed-panel launcher dodges the drawer
-    Given the Langy panel is closed and a right-anchored drawer is open
-    Then the launcher orb sits in the bottom-LEFT corner, clear of the drawer and the table pager
+  # The closed state is a PEEK of the panel itself, not a separate launcher —
+  # see specs/langy/langy-peek-dock.feature for its states and geometry.
+  Scenario: The minimised peek dodges the drawer
+    Given the Langy panel is minimised in floating mode and a right-anchored drawer is open
+    Then the peek sliver rests along the bottom-LEFT edge, clear of the drawer and the table pager

--- a/specs/langy/langy-peek-dock.feature
+++ b/specs/langy/langy-peek-dock.feature
@@ -1,0 +1,90 @@
+Feature: Langy minimised peek
+
+  Minimising Langy no longer collapses it to a corner orb. The panel sinks to
+  a PEEK: in floating mode the card slips below the bottom viewport edge with
+  just a sliver of its header lip showing, bottom-right where the card lives;
+  in sidebar mode the dock's spine peeks in from the right edge as a thin
+  vertical sliver, mid-height. The peek is the SAME creature at rest — it
+  wears the panel's surface, hairline and brand seam, and rises on the
+  panel's own motion curve — so minimise reads as the card sinking out of
+  the way, not as the panel being swapped for a button.
+
+  Three states, one direction of travel:
+    rest       a small sliver at the viewport edge; overlays the page, never
+               reserves room, never shifts layout.
+    proximity  the pointer nears the peek's edge region (or the peek takes
+               keyboard focus): it rises a little further — an invitation,
+               not an opening.
+    open       a click, Enter/Space on the focused peek, or the existing
+               Cmd/Ctrl+I activation: the panel opens fully on its existing
+               spring; the peek stands down.
+
+  # Rollout: the peek replaces the corner launcher orb behind
+  # release_ui_langy_peek_dock_enabled. Flag off keeps the orb; exactly one
+  # minimised affordance renders at a time, and only the closed state
+  # differs — the open panel and the Cmd/Ctrl+I activation are identical on
+  # either side of the flag.
+
+  Background:
+    Given I am signed in with access to a project that has Langy
+    And the Langy peek rollout flag is enabled for me
+
+  Scenario: Minimising the floating panel sinks it to a bottom peek
+    Given the Langy panel is open in floating mode
+    When I minimise the panel
+    Then a sliver of the card's header lip rests above the bottom viewport edge, bottom-right
+    And the conversation, draft and layout choice are untouched underneath
+    And the page shifts by nothing — the peek overlays, it never pushes
+
+  Scenario: Minimising the docked panel leaves a sliver on the right edge
+    Given the Langy panel is open in sidebar mode
+    When I minimise the panel
+    Then the dock's room is released and page content reclaims the full width
+    And a thin vertical sliver of the dock's spine peeks in from the right edge, mid-height
+
+  Scenario: The peek pops closer as the pointer approaches
+    Given the Langy panel is minimised
+    When the pointer nears the peek's edge region
+    Then the peek rises further into view, inviting the click
+    And it settles back to its resting sliver when the pointer moves away
+
+  Scenario: Clicking the peek opens the panel
+    Given the Langy panel is minimised
+    When I click the peek
+    Then the panel opens fully in whichever layout I use
+    And the open rides the panel's existing motion, rising from where the peek rested
+
+  Scenario: The peek is a keyboard citizen
+    Given the Langy panel is minimised
+    When I Tab to the peek
+    Then it rises to its proximity height so I can see what I focused
+    And Enter or Space opens the panel
+
+  Scenario: The command activation works regardless of the pointer
+    Given the Langy panel is minimised
+    When I press the Langy keyboard activation
+    Then the panel opens fully, exactly as it does from the peek's own click
+
+  Scenario: Reduced motion trades the pop for a plain hover state
+    Given I prefer reduced motion
+    And the Langy panel is minimised
+    Then no pointer-proximity tracking runs at all
+    And hovering or focusing the peek itself swaps it to the raised state without animation
+    And minimise and open cross-fade instead of sliding
+
+  Scenario: The peek shows the turn still running under it
+    Given a Langy turn is in flight
+    When I minimise the panel
+    Then the peek's brand seam breathes quietly until the turn settles
+    So the work I walked away from is visibly still alive
+
+  Scenario: A drawer moves the floating peek out of its way
+    Given the Langy panel is minimised in floating mode
+    When a right-anchored drawer opens
+    Then the peek rests along the bottom-LEFT edge, clear of the drawer and the table pager
+
+  Scenario: The sidebar peek holds the right edge above an open drawer
+    Given the Langy panel is minimised in sidebar mode
+    When a right-anchored drawer opens
+    Then the sliver stays on the right edge, riding above the drawer's card
+    And at rest it is thin enough to sit on the drawer's rim without hiding content


### PR DESCRIPTION
Minimising Langy can now sink the panel to a **peek of itself** instead of swapping it for the corner launcher orb. Floating mode leaves a sliver of the card's header lip above the bottom viewport edge; sidebar mode leaves the dock's spine peeking in from the right edge. Pointer proximity makes it rise a little (an invitation); click / Enter / Space / the existing Cmd+I opens the panel on its existing spring, rising from exactly where the sliver rested.

**Rollout.** Gated behind `release_ui_langy_peek_dock_enabled` (default off). Flag on → the peek; flag off → the classic launcher orb, untouched. Exactly **one** minimised affordance renders at a time (`LangySidecar` picks on the flag), and only the *closed* state differs — the open panel and its Cmd/Ctrl+I activation are identical either way, so the rollout can flip live to A/B them. Force-enable in dev: `FEATURE_FLAG_FORCE_ENABLE=release_ui_langy_peek_dock_enabled`.

Spec: `specs/langy/langy-peek-dock.feature` (and the launcher scenario in `langy-panel-layout.feature` updated to match).

## Design note

**States** — `rest` → `proximity` → `open`, one direction of travel:

| | rest | proximity / focus | open |
|---|---|---|---|
| **Floating** (bottom edge) | 10px of the card's top lip | 36px — the header line (mark + "Langy" + ⌘I hint) reads | panel opens on its existing unfold spring from the same corner |
| **Sidebar** (right edge) | 6px spine, 128px tall, mid-height | 20px — the mark shows | dock slides in on its existing spring, from the edge the sliver rests on |

**Geometry.** The floating peek is a real 76px-tall card, full floating-panel width, on the panel's own 12px inset (`FLOATING_PANEL_INSET`, now shared) — laid out flush with the bottom edge and translated below it, so its side hairlines visibly run off-screen: it reads as the card *sunk*, not a chip. The screenshot's title-bar-peek is the proximity state; rest is deliberately "more hidden ofc". The sidebar peek is a 44px rounded-left card translated off the right edge, vertically centred.

**Motion.** Everything slides on `transform` with the panel's own curve — `240ms cubic-bezier(0.32, 0.72, 0, 1)` (`LANGY_TRANSITION`). The peek's entrance is delayed 140ms so the panel's 160ms close finishes first: sink, then the sliver surfaces — one hand-off. While a turn is still running under the minimised panel, the peek's warm brand seam breathes on the fold's own pulse period (2.6s, `WAVE_PULSE_PERIOD_S`) — the same creature, still working.

**Proximity.** One passive `pointermove` listener, rAF-throttled, evaluating a pure hit test with a hysteresis band (enter ≤ 140px, exit > 200px, measured to the *resting* sliver). Not the invisible hover strip: a strip needs `pointer-events: auto` to feel the pointer, which swallows clicks on whatever is under it — and the bottom-right corner is contested (the table pager; the launcher orb fought that collision twice). `setNear` with an unchanged boolean is a React bail-out, so pointer movement renders nothing until the verdict flips.

**Reduced motion.** No proximity tracking runs at all. The peek's own hover/focus swaps it to the raised state (a plain hover state, no transition), and minimise/open cross-fade (`opacity 160ms`) instead of sliding.

**Keyboard.** The peek is a real `<button>` — Tab reaches it, focus rises it to the proximity height so you can see what you focused, Enter/Space opens. `aria-keyshortcuts="Meta+I Control+I"`; the global Cmd/Ctrl+I toggle is wired above this subtree and never depended on the pointer.

**Error containment.** The peek mounts beside the whole routed page (LangySidecar), so it renders inside `IsolatedErrorBoundary`: a render crash shows the repo's inline error card in place, never a blank page, and Cmd+I still opens the panel (pinned by test).

## The sidebar-mode answer

The natural mirror of "the card sinks below the bottom edge" is "the dock slides behind the right edge": a thin vertical sliver of the dock's spine, mid-height, partially offscreen right, popping toward the viewport on proximity and sliding fully in on activation — the dock's existing open animation already enters from exactly there, so the peek and the open are one gesture.

- **No layout shift at rest.** The peek is `position: fixed` overlay; the dock's page reservation (`LangyShiftedRoot` / `dockShifted`) only engages while the panel is *open* in sidebar mode — minimised reserves nothing, pinned by test.
- **When a drawer is open.** The open dock becomes the drawer's companion (existing behaviour, untouched). The *minimised* sliver holds its right edge and rides **above** the drawer's card (z 1600, the companion's own layer), mid-height — clear of the drawer's header controls and the table pager, and at 6px thin enough to sit on the drawer's rim without hiding content. The floating peek instead **dodges to the bottom-left** while a drawer holds its corner, the same dodge the floating panel itself makes.

## The one thing to look at live

Flip `release_ui_langy_peek_dock_enabled` on and watch the **minimise → peek hand-off in floating mode**: the panel's 160ms sink, the 140ms beat, then the sliver surfacing — does it read as one object going down and resting, and is 10px at rest *findable* enough on a busy page (the warm seam is doing that work)? If it feels too hidden, the knob is one constant (`FLOATING_PEEK_REST_PX`).

## Tests

- `langyPeekDock.unit.test.ts` — geometry + proximity hysteresis (pure), 12 tests
- `langyPeekMinimize.unit.test.ts` — store transitions: minimise keeps conversation/draft/layout; peek, toggle and askLangy all reopen, 8 tests
- `LangyPeekDock.integration.test.tsx` (jsdom) — peek → click → open, keyboard focus/Enter, proximity pop via dispatched pointermove, hover, drawer dodge, sidebar sliver, reduced-motion (no tracking, fade), error-boundary containment, 14 tests
- `featureFlag.service.test.ts` — the new flag registers and force-enables, existing suite green
- Regression: the three integration files that mount `LangySidecar` (`LangyConversationThreading`, `LangyInlineModelSetup`, `LangyConversationHistory`) now stub `useFeatureFlag` (flag off = the launcher path they had before); `ProjectLangyLayout` green. Note: `LangyConversationHistory` has **2 pre-existing failures on the base branch** (stop-turn dispatch assertions) — reproduced with this change stashed; not introduced here.

Rebased onto `a73c8cc0d` (current base tip); clean, no conflicts.
