### PR TITLE
feat(ops): show event subscribers and the per-aggregate manager state machine in DejaView

### DIFF
--- a/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
+++ b/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
@@ -18,6 +18,7 @@ import { EventTimeline } from "./EventTimeline";
 import { buildFragment, parseFragment } from "./fragment";
 import { KeyboardHints } from "./KeyboardHints";
 import { LeftPanel } from "./LeftPanel";
+import { ManagerPanel } from "./ManagerPanel";
 import { ReplayHeader } from "./ReplayHeader";
 import { RightPanel } from "./RightPanel";
 import { SearchHeader } from "./SearchHeader";
@@ -392,6 +393,12 @@ export function DejaViewContent() {
               {selectedProjection && showEventDetail && currentEvent && (
                 <RightPanel event={currentEvent} />
               )}
+
+              <ManagerPanel
+                aggregateType={currentAggregateType ?? ""}
+                tenantId={selectedAggregate?.tenantId ?? ""}
+                aggregateId={selectedAggregate?.aggregateId ?? ""}
+              />
             </Box>
 
             <EventTimeline

--- a/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
+++ b/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
@@ -149,10 +149,10 @@ export function DejaViewContent() {
     );
   }, [projectionsQuery.data, currentAggregateType]);
 
-  const matchingReactors = useMemo(() => {
+  const matchingEventSubscribers = useMemo(() => {
     if (!projectionsQuery.data || !currentAggregateType) return [];
-    return projectionsQuery.data.reactors.filter(
-      (r) => r.aggregateType === currentAggregateType,
+    return projectionsQuery.data.eventSubscribers.filter(
+      (s) => s.aggregateType === currentAggregateType,
     );
   }, [projectionsQuery.data, currentAggregateType]);
 
@@ -372,7 +372,7 @@ export function DejaViewContent() {
             <Box display="flex" flex={1} overflow="hidden" minH={0} w="full">
               <LeftPanel
                 projections={matchingProjections}
-                reactors={matchingReactors}
+                eventSubscribers={matchingEventSubscribers}
                 selectedProjection={selectedProjection}
                 onSelectProjection={setSelectedProjection}
                 currentEventType={currentEvent?.eventType ?? null}

--- a/langwatch/src/components/ops/dejaview/LeftPanel.tsx
+++ b/langwatch/src/components/ops/dejaview/LeftPanel.tsx
@@ -3,7 +3,7 @@ import { Circle } from "lucide-react";
 
 export function LeftPanel({
   projections,
-  reactors,
+  eventSubscribers,
   selectedProjection,
   onSelectProjection,
   currentEventType,
@@ -13,11 +13,11 @@ export function LeftPanel({
     pipelineName: string;
     aggregateType: string;
   }>;
-  reactors: Array<{
-    reactorName: string;
+  eventSubscribers: Array<{
+    subscriberName: string;
     pipelineName: string;
     aggregateType: string;
-    afterProjection: string;
+    eventTypes: readonly string[];
   }>;
   selectedProjection: string | null;
   onSelectProjection: (name: string | null) => void;
@@ -92,19 +92,19 @@ export function LeftPanel({
           marginTop={2}
         >
           <Text textStyle="xs" fontWeight="semibold" color="fg.muted" textTransform="uppercase" letterSpacing="wider">
-            Reactors
+            Event Subscribers
           </Text>
         </Box>
-        {reactors.length === 0 ? (
+        {eventSubscribers.length === 0 ? (
           <Box paddingX={3} paddingY={4}>
             <Text textStyle="xs" color="fg.muted">
-              No reactors for this aggregate type.
+              No event subscribers for this aggregate type.
             </Text>
           </Box>
         ) : (
-          reactors.map((reactor) => (
+          eventSubscribers.map((subscriber) => (
             <Box
-              key={reactor.reactorName}
+              key={subscriber.subscriberName}
               paddingX={3}
               paddingY={2}
               borderBottom="1px solid"
@@ -114,14 +114,16 @@ export function LeftPanel({
                 <Circle
                   size={8}
                   fill="currentColor"
-                  color="purple.500"
+                  color="cyan.500"
                 />
-                <VStack align="start" gap={0}>
+                <VStack align="start" gap={0} minW={0}>
                   <Text textStyle="xs" fontWeight="medium">
-                    {reactor.reactorName}
+                    {subscriber.subscriberName}
                   </Text>
-                  <Text textStyle="xs" color="fg.muted">
-                    after {reactor.afterProjection}
+                  <Text textStyle="xs" color="fg.muted" truncate>
+                    {subscriber.eventTypes.length > 0
+                      ? `on ${subscriber.eventTypes.join(", ")}`
+                      : subscriber.pipelineName}
                   </Text>
                 </VStack>
               </HStack>

--- a/langwatch/src/components/ops/dejaview/ManagerCard.tsx
+++ b/langwatch/src/components/ops/dejaview/ManagerCard.tsx
@@ -1,0 +1,141 @@
+import { Badge, Box, HStack, Spacer, Text, VStack, Wrap } from "@chakra-ui/react";
+
+import { JsonViewer } from "~/components/ops/JsonViewer";
+import { formatTimeAgo } from "~/components/ops/shared/formatters";
+import type {
+  AggregateProcessManager,
+  AggregateProcessManagerInstance,
+  AggregateProcessManagerOutboxMessage,
+} from "~/server/app-layer/ops/manager-explorer.service";
+
+const OUTBOX_PALETTE: Record<
+  AggregateProcessManagerOutboxMessage["status"],
+  string
+> = {
+  pending: "yellow",
+  dispatched: "green",
+  dead: "red",
+};
+
+function instanceStatus(instance: AggregateProcessManagerInstance | null): {
+  label: string;
+  palette: string;
+} {
+  if (!instance) return { label: "Not started", palette: "gray" };
+  if (instance.nextWakeAt !== null && instance.nextWakeAt > Date.now()) {
+    return { label: "Waiting to wake", palette: "blue" };
+  }
+  return { label: "Active", palette: "green" };
+}
+
+function Chips({ items, palette }: { items: readonly string[]; palette: string }) {
+  return (
+    <Wrap gap={1}>
+      {items.map((item) => (
+        <Badge key={item} colorPalette={palette} variant="subtle" size="sm">
+          {item}
+        </Badge>
+      ))}
+    </Wrap>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <Box>
+      <Text
+        textStyle="2xs"
+        color="fg.muted"
+        textTransform="uppercase"
+        letterSpacing="wider"
+        marginBottom={1}
+      >
+        {label}
+      </Text>
+      {children}
+    </Box>
+  );
+}
+
+function EmittedCommands({
+  outbox,
+}: {
+  outbox: AggregateProcessManagerOutboxMessage[];
+}) {
+  return (
+    <Field label="Emitted commands">
+      <VStack align="stretch" gap={1}>
+        {outbox.map((msg) => (
+          <HStack key={msg.messageKey} gap={2}>
+            <Text textStyle="xs" fontFamily="mono" truncate>
+              {msg.intentType}
+            </Text>
+            <Spacer />
+            {msg.attempts > 0 && (
+              <Text textStyle="2xs" color="fg.muted">
+                ×{msg.attempts}
+              </Text>
+            )}
+            <Badge colorPalette={OUTBOX_PALETTE[msg.status]} variant="subtle" size="sm">
+              {msg.status}
+            </Badge>
+          </HStack>
+        ))}
+      </VStack>
+    </Field>
+  );
+}
+
+export function ManagerCard({ manager }: { manager: AggregateProcessManager }) {
+  const status = instanceStatus(manager.instance);
+  const { instance } = manager;
+
+  return (
+    <Box borderWidth="1px" borderColor="border" borderRadius="md" padding={3}>
+      <VStack align="stretch" gap={3}>
+        <HStack gap={2}>
+          <Text fontWeight="semibold" textStyle="sm" truncate>
+            {manager.processName}
+          </Text>
+          <Spacer />
+          <Badge colorPalette={status.palette} variant="subtle">
+            {status.label}
+          </Badge>
+        </HStack>
+
+        <Field label="Triggers">
+          <Chips items={manager.eventTypes} palette="blue" />
+        </Field>
+        {manager.intentTypes.length > 0 && (
+          <Field label="Emits">
+            <Chips items={manager.intentTypes} palette="purple" />
+          </Field>
+        )}
+
+        {instance ? (
+          <>
+            <HStack gap={4} flexWrap="wrap">
+              <Text textStyle="xs" color="fg.muted">
+                rev {instance.revision}
+              </Text>
+              <Text textStyle="xs" color="fg.muted">
+                updated {formatTimeAgo(instance.updatedAt)}
+              </Text>
+              <Text textStyle="xs" color="fg.muted">
+                next wake {formatTimeAgo(instance.nextWakeAt)}
+              </Text>
+            </HStack>
+            <Field label="State">
+              <JsonViewer data={instance.state} maxHeight="220px" />
+            </Field>
+            {manager.outbox.length > 0 && <EmittedCommands outbox={manager.outbox} />}
+          </>
+        ) : (
+          <Text textStyle="xs" color="fg.muted">
+            This machine has not started for this aggregate.
+          </Text>
+        )}
+      </VStack>
+    </Box>
+  );
+}

--- a/langwatch/src/components/ops/dejaview/ManagerPanel.tsx
+++ b/langwatch/src/components/ops/dejaview/ManagerPanel.tsx
@@ -31,7 +31,10 @@ export function ManagerPanel({
   );
 
   const managers = query.data ?? [];
-  if (query.isLoading || managers.length === 0) return null;
+  if (query.isLoading) return null;
+  // A failed fetch must not collapse the panel the way "no managers" does —
+  // this is a debugging tool, so its own failures have to be visible.
+  if (!query.error && managers.length === 0) return null;
 
   return (
     <Box
@@ -58,11 +61,19 @@ export function ManagerPanel({
           Process Managers
         </Text>
       </Box>
-      <VStack align="stretch" gap={3} padding={3}>
-        {managers.map((manager) => (
-          <ManagerCard key={manager.processName} manager={manager} />
-        ))}
-      </VStack>
+      {query.error ? (
+        <Box paddingX={3} paddingY={4}>
+          <Text textStyle="xs" color="red.500">
+            Could not load process managers: {query.error.message}
+          </Text>
+        </Box>
+      ) : (
+        <VStack align="stretch" gap={3} padding={3}>
+          {managers.map((manager) => (
+            <ManagerCard key={manager.processName} manager={manager} />
+          ))}
+        </VStack>
+      )}
     </Box>
   );
 }

--- a/langwatch/src/components/ops/dejaview/ManagerPanel.tsx
+++ b/langwatch/src/components/ops/dejaview/ManagerPanel.tsx
@@ -1,0 +1,68 @@
+import { Box, Text, VStack } from "@chakra-ui/react";
+
+import { api } from "~/utils/api";
+
+import { ManagerCard } from "./ManagerCard";
+
+/**
+ * The process-manager state machines for the aggregate on screen: each machine
+ * with its definition and this aggregate's current position (state, revision,
+ * next wake) plus the commands it has emitted.
+ *
+ * Only per-aggregate machines apply, so most aggregate types have none — the
+ * panel collapses entirely rather than take a column when there is nothing to
+ * show.
+ */
+export function ManagerPanel({
+  aggregateType,
+  tenantId,
+  aggregateId,
+}: {
+  aggregateType: string;
+  tenantId: string;
+  aggregateId: string;
+}) {
+  const query = api.ops.getAggregateProcessManagers.useQuery(
+    { aggregateType, tenantId, aggregateId },
+    {
+      enabled: !!aggregateType && !!tenantId && !!aggregateId,
+      refetchInterval: 15_000,
+    },
+  );
+
+  const managers = query.data ?? [];
+  if (query.isLoading || managers.length === 0) return null;
+
+  return (
+    <Box
+      width="360px"
+      minWidth="360px"
+      borderLeft="1px solid"
+      borderLeftColor="border"
+      overflowY="auto"
+      bg="bg.surface"
+    >
+      <Box
+        paddingX={3}
+        paddingY={2}
+        borderBottom="1px solid"
+        borderBottomColor="border"
+      >
+        <Text
+          textStyle="xs"
+          fontWeight="semibold"
+          color="fg.muted"
+          textTransform="uppercase"
+          letterSpacing="wider"
+        >
+          Process Managers
+        </Text>
+      </Box>
+      <VStack align="stretch" gap={3} padding={3}>
+        {managers.map((manager) => (
+          <ManagerCard key={manager.processName} manager={manager} />
+        ))}
+      </VStack>
+    </Box>
+  );
+}

--- a/langwatch/src/components/ops/dejaview/__tests__/LeftPanel.integration.test.tsx
+++ b/langwatch/src/components/ops/dejaview/__tests__/LeftPanel.integration.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * DejaView's left rail lists what processes an aggregate's events. It now shows
+ * event subscribers rather than reactors — the raw-event consumers, keyed by
+ * the event types they react to.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LeftPanel } from "../LeftPanel";
+
+const projection = {
+  projectionName: "traceSummary",
+  pipelineName: "trace-processing",
+  aggregateType: "trace",
+};
+
+const subscriber = {
+  subscriberName: "graphTriggerActivity",
+  pipelineName: "trace-processing",
+  aggregateType: "trace",
+  eventTypes: ["trace.received", "trace.updated"] as const,
+};
+
+const renderPanel = ({
+  projections = [projection],
+  eventSubscribers = [subscriber],
+  selectedProjection = null as string | null,
+  onSelectProjection = vi.fn(),
+} = {}) => {
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <LeftPanel
+        projections={projections}
+        eventSubscribers={eventSubscribers}
+        selectedProjection={selectedProjection}
+        onSelectProjection={onSelectProjection}
+        currentEventType={null}
+      />
+    </ChakraProvider>,
+  );
+  return { onSelectProjection };
+};
+
+afterEach(cleanup);
+
+describe("LeftPanel", () => {
+  describe("given an aggregate with subscribers", () => {
+    describe("when the rail renders", () => {
+      it("lists event subscribers, not reactors", () => {
+        renderPanel();
+        expect(screen.getByText("Event Subscribers")).toBeDefined();
+        expect(screen.queryByText("Reactors")).toBeNull();
+        expect(screen.getByText("graphTriggerActivity")).toBeDefined();
+      });
+
+      it("names the event types a subscriber reacts to", () => {
+        renderPanel();
+        expect(
+          screen.getByText("on trace.received, trace.updated"),
+        ).toBeDefined();
+      });
+    });
+  });
+
+  describe("given no subscribers for the aggregate type", () => {
+    describe("when the rail renders", () => {
+      it("says so instead of showing an empty section", () => {
+        renderPanel({ eventSubscribers: [] });
+        expect(
+          screen.getByText("No event subscribers for this aggregate type."),
+        ).toBeDefined();
+      });
+    });
+  });
+
+  describe("given a projection in the list", () => {
+    describe("when it is clicked", () => {
+      it("selects it", () => {
+        const { onSelectProjection } = renderPanel();
+        fireEvent.click(screen.getByText("traceSummary"));
+        expect(onSelectProjection).toHaveBeenCalledWith("traceSummary");
+      });
+    });
+  });
+});

--- a/langwatch/src/components/ops/dejaview/__tests__/ManagerCard.integration.test.tsx
+++ b/langwatch/src/components/ops/dejaview/__tests__/ManagerCard.integration.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The process-manager card is DejaView's "state machine for a single aggregate":
+ * the machine's triggers and emitted commands, plus this aggregate's current
+ * position (state, revision) and the commands it has sent.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AggregateProcessManager } from "~/server/app-layer/ops/manager-explorer.service";
+
+import { ManagerCard } from "../ManagerCard";
+
+const running: AggregateProcessManager = {
+  processName: "langyConversation",
+  pipelineName: "langy-conversation-processing",
+  eventTypes: ["langy.turn.started"],
+  intentTypes: ["dispatchTurn"],
+  hasWake: false,
+  instance: {
+    state: { turnStatus: "running" },
+    revision: 2,
+    nextWakeAt: null,
+    updatedAt: 1_700_000_000_000,
+  },
+  outbox: [
+    {
+      messageKey: "k1",
+      intentType: "dispatchTurn",
+      status: "pending",
+      attempts: 0,
+      nextAttemptAt: 0,
+      createdAt: 1_700_000_000_000,
+      sourceEventId: "e1",
+    },
+  ],
+};
+
+const renderCard = (manager: AggregateProcessManager) =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <ManagerCard manager={manager} />
+    </ChakraProvider>,
+  );
+
+afterEach(cleanup);
+
+describe("ManagerCard", () => {
+  describe("given a machine running for the aggregate", () => {
+    describe("when the card renders", () => {
+      it("names the machine and marks it active", () => {
+        renderCard(running);
+        expect(screen.getByText("langyConversation")).toBeDefined();
+        expect(screen.getByText("Active")).toBeDefined();
+      });
+
+      it("shows the trigger event types and the current state", () => {
+        renderCard(running);
+        expect(screen.getByText("langy.turn.started")).toBeDefined();
+        expect(screen.getByText("State")).toBeDefined();
+        expect(screen.getAllByText(/running/).length).toBeGreaterThan(0);
+      });
+
+      it("lists the commands the machine has emitted", () => {
+        renderCard(running);
+        expect(screen.getByText("Emitted commands")).toBeDefined();
+        expect(screen.getByText("pending")).toBeDefined();
+      });
+    });
+  });
+
+  describe("given a machine that has not started for the aggregate", () => {
+    describe("when the card renders", () => {
+      it("says so instead of showing empty state", () => {
+        renderCard({ ...running, instance: null, outbox: [] });
+        expect(screen.getByText("Not started")).toBeDefined();
+        expect(
+          screen.getByText("This machine has not started for this aggregate."),
+        ).toBeDefined();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -11,9 +11,9 @@ import {
   TABLE_TTL_CONFIG,
 } from "~/server/clickhouse/ttlReconciler";
 import {
+  getEventSubscriberMetadata,
   getKillSwitchDescriptors,
   getProjectionMetadata,
-  getReactorMetadata,
 } from "~/server/event-sourcing/pipelineRegistry";
 import {
   getFeatureFlagStore,
@@ -314,7 +314,7 @@ export const opsRouter = createTRPCRouter({
   listProjections: protectedProcedure.use(opsViewPermission).query(() => {
     return {
       projections: getProjectionMetadata(),
-      reactors: getReactorMetadata(),
+      eventSubscribers: getEventSubscriberMetadata(),
     };
   }),
 

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -318,6 +318,29 @@ export const opsRouter = createTRPCRouter({
     };
   }),
 
+  /**
+   * The per-aggregate process-manager state machines for one aggregate: each
+   * machine's definition (triggers, intents, wake) joined to this aggregate's
+   * current instance state and the intents it has emitted. Scheduled singletons
+   * are excluded — they are not keyed by aggregate id.
+   */
+  getAggregateProcessManagers: protectedProcedure
+    .use(opsViewPermission)
+    .input(
+      z.object({
+        aggregateType: z.string().min(1).max(200),
+        tenantId: z.string().min(1).max(200),
+        aggregateId: z.string().min(1).max(500),
+      }),
+    )
+    .query(async ({ input }) => {
+      return requireOps().managerExplorer.getForAggregate({
+        aggregateType: input.aggregateType,
+        projectId: input.tenantId,
+        aggregateId: input.aggregateId,
+      });
+    }),
+
   discoverAggregates: protectedProcedure
     .use(opsViewPermission)
     .input(

--- a/langwatch/src/server/app-layer/dependencies.ts
+++ b/langwatch/src/server/app-layer/dependencies.ts
@@ -17,6 +17,7 @@ import type { DspyStepService } from "./dspy-steps/dspy-step.service";
 import type { EvaluationExecutionService } from "./evaluations/evaluation-execution.service";
 import type { EvaluationRunService } from "./evaluations/evaluation-run.service";
 import type { EventExplorerService } from "./ops/event-explorer.service";
+import type { ManagerExplorerService } from "./ops/manager-explorer.service";
 import type { OpsMetricsCollector } from "./ops/metrics-collector";
 import type { QueueService } from "./ops/queue.service";
 import type { SchedulerOpsService } from "./ops/scheduler-ops.service";
@@ -64,6 +65,7 @@ export interface OpsDependencies {
   queues: QueueService;
   scheduler: SchedulerOpsService;
   eventExplorer: EventExplorerService;
+  managerExplorer: ManagerExplorerService;
   replay: ReplayService;
   metricsCollector: OpsMetricsCollector | null;
 }

--- a/langwatch/src/server/app-layer/ops/__tests__/manager-explorer.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/manager-explorer.service.unit.test.ts
@@ -46,7 +46,10 @@ const otherAggregate = {
 const metadataMock = vi.mocked(getProcessManagerMetadata);
 
 function fakeStore(
-  overrides: Partial<Pick<ProcessStore, "findByRef" | "findMessagesByRef">> = {},
+  overrides: {
+    findByRef?: () => Promise<unknown>;
+    findMessagesByRef?: () => Promise<unknown[]>;
+  } = {},
 ): ProcessStore {
   return {
     findByRef: vi.fn(async () => null),

--- a/langwatch/src/server/app-layer/ops/__tests__/manager-explorer.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/manager-explorer.service.unit.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ProcessStore } from "~/server/event-sourcing/process-manager/stores/processStore.types";
+
+import { ManagerExplorerService } from "../manager-explorer.service";
+
+vi.mock("~/server/event-sourcing/pipelineRegistry", () => ({
+  getProcessManagerMetadata: vi.fn(),
+}));
+
+import { getProcessManagerMetadata } from "~/server/event-sourcing/pipelineRegistry";
+
+const perAggregate = {
+  processName: "triggerSettlement",
+  pipelineName: "automations",
+  aggregateType: "trigger",
+  eventTypes: ["trigger.matchRecorded"] as const,
+  intentTypes: ["persist", "notify"],
+  scheduled: false,
+  everyMs: null,
+  hasWake: true,
+};
+
+const scheduledSingleton = {
+  processName: "graphAlertSweep",
+  pipelineName: "automations",
+  aggregateType: "trigger",
+  eventTypes: [] as const,
+  intentTypes: [],
+  scheduled: true,
+  everyMs: 30_000,
+  hasWake: true,
+};
+
+const otherAggregate = {
+  processName: "langyConversation",
+  pipelineName: "langy",
+  aggregateType: "langy_conversation",
+  eventTypes: [] as const,
+  intentTypes: [],
+  scheduled: false,
+  everyMs: null,
+  hasWake: false,
+};
+
+const metadataMock = vi.mocked(getProcessManagerMetadata);
+
+function fakeStore(
+  overrides: Partial<Pick<ProcessStore, "findByRef" | "findMessagesByRef">> = {},
+): ProcessStore {
+  return {
+    findByRef: vi.fn(async () => null),
+    findMessagesByRef: vi.fn(async () => []),
+    commit: vi.fn(),
+    leaseDueMessages: vi.fn(),
+    markDispatched: vi.fn(),
+    markFailed: vi.fn(),
+    findDueWakes: vi.fn(),
+    deleteDispatchedBefore: vi.fn(),
+    ...overrides,
+  } as unknown as ProcessStore;
+}
+
+describe("ManagerExplorerService", () => {
+  beforeEach(() => {
+    metadataMock.mockReset();
+  });
+
+  describe("given managers of mixed kinds share an aggregate type", () => {
+    describe("when the aggregate's managers are requested", () => {
+      it("returns only the per-aggregate machines, not scheduled singletons or other types", async () => {
+        metadataMock.mockReturnValue([
+          perAggregate,
+          scheduledSingleton,
+          otherAggregate,
+        ]);
+        const service = new ManagerExplorerService(fakeStore());
+
+        const result = await service.getForAggregate({
+          aggregateType: "trigger",
+          projectId: "project-1",
+          aggregateId: "trigger-42",
+        });
+
+        expect(result.map((m) => m.processName)).toEqual(["triggerSettlement"]);
+      });
+    });
+  });
+
+  describe("given a per-aggregate manager", () => {
+    describe("when its instance is read", () => {
+      it("keys the store by processName + projectId + aggregateId", async () => {
+        metadataMock.mockReturnValue([perAggregate]);
+        const store = fakeStore();
+        const service = new ManagerExplorerService(store);
+
+        await service.getForAggregate({
+          aggregateType: "trigger",
+          projectId: "project-1",
+          aggregateId: "trigger-42",
+        });
+
+        expect(store.findByRef).toHaveBeenCalledWith({
+          ref: {
+            processName: "triggerSettlement",
+            projectId: "project-1",
+            processKey: "trigger-42",
+          },
+        });
+      });
+    });
+  });
+
+  describe("given the machine has never started for this aggregate", () => {
+    describe("when it is read", () => {
+      it("reports a null instance rather than fabricating state", async () => {
+        metadataMock.mockReturnValue([perAggregate]);
+        const service = new ManagerExplorerService(
+          fakeStore({ findByRef: vi.fn(async () => null) }),
+        );
+
+        const [manager] = await service.getForAggregate({
+          aggregateType: "trigger",
+          projectId: "project-1",
+          aggregateId: "trigger-42",
+        });
+
+        expect(manager?.instance).toBeNull();
+      });
+    });
+  });
+
+  describe("given a running machine with an emitted intent", () => {
+    describe("when it is read", () => {
+      it("surfaces the current position and the emitted command", async () => {
+        metadataMock.mockReturnValue([perAggregate]);
+        const service = new ManagerExplorerService(
+          fakeStore({
+            findByRef: vi.fn(async () => ({
+              ref: {
+                processName: "triggerSettlement",
+                projectId: "project-1",
+                processKey: "trigger-42",
+              },
+              tenantId: "project-1",
+              state: { pendingMatches: {}, overflowFlushed: 0 },
+              revision: 3,
+              nextWakeAt: 1_800_000_000_000,
+              updatedAt: 1_700_000_000_000,
+            })),
+            findMessagesByRef: vi.fn(async () => [
+              {
+                messageKey: "k1",
+                intentType: "persist",
+                payload: {},
+                traceCarrier: {},
+                processName: "triggerSettlement",
+                projectId: "project-1",
+                processKey: "trigger-42",
+                tenantId: "project-1",
+                sourceEventId: "evt-1",
+                status: "dispatched" as const,
+                attempts: 1,
+                nextAttemptAt: 0,
+                leaseToken: null,
+                createdAt: 1_700_000_000_000,
+              },
+            ]),
+          }),
+        );
+
+        const [manager] = await service.getForAggregate({
+          aggregateType: "trigger",
+          projectId: "project-1",
+          aggregateId: "trigger-42",
+        });
+
+        expect(manager?.instance?.revision).toBe(3);
+        expect(manager?.outbox).toHaveLength(1);
+        expect(manager?.outbox[0]).toMatchObject({
+          intentType: "persist",
+          status: "dispatched",
+          sourceEventId: "evt-1",
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/manager-explorer.service.ts
+++ b/langwatch/src/server/app-layer/ops/manager-explorer.service.ts
@@ -1,0 +1,110 @@
+import { getProcessManagerMetadata } from "~/server/event-sourcing/pipelineRegistry";
+import type { ProcessRef } from "~/server/event-sourcing/process-manager/processManager.types";
+import type { ProcessStore } from "~/server/event-sourcing/process-manager/stores/processStore.types";
+
+/** The aggregate's current position in one manager's machine. */
+export interface AggregateProcessManagerInstance {
+  /**
+   * The persisted state JSON. Deliberately identities-and-flags only — the
+   * content boundary (`toPayload`) keeps customer payload out of it — so it is
+   * safe to render directly.
+   */
+  state: unknown;
+  /** Optimistic-concurrency counter; 1 after the first commit. */
+  revision: number;
+  /** Epoch ms of the next due wake-up, or null when none is scheduled. */
+  nextWakeAt: number | null;
+  updatedAt: number;
+}
+
+/** One cross-aggregate command this instance emitted, via the transactional outbox. */
+export interface AggregateProcessManagerOutboxMessage {
+  messageKey: string;
+  intentType: string;
+  status: "pending" | "dispatched" | "dead";
+  attempts: number;
+  nextAttemptAt: number;
+  createdAt: number;
+  /** The event that produced this intent; null for a wake-driven commit. */
+  sourceEventId: string | null;
+}
+
+/** One process-manager state machine as it stands for a single aggregate. */
+export interface AggregateProcessManager {
+  processName: string;
+  pipelineName: string;
+  /** Event types that drive the machine's transitions. */
+  eventTypes: readonly string[];
+  /** Intent types the machine can emit — the commands it sends to other aggregates. */
+  intentTypes: string[];
+  hasWake: boolean;
+  /** The aggregate's current position, or null if the machine never started for it. */
+  instance: AggregateProcessManagerInstance | null;
+  outbox: AggregateProcessManagerOutboxMessage[];
+}
+
+/**
+ * Reads the process-manager state machines for a single aggregate: the machine
+ * definition (from the live pipeline introspection) joined to this aggregate's
+ * persisted instance and the intents it has emitted.
+ *
+ * The machine itself is implicit in `evolve` (no declared state set), so the
+ * "state machine" shown is the definition surface plus the instance's current
+ * position — its state JSON, revision, and next wake.
+ */
+export class ManagerExplorerService {
+  constructor(private readonly store: ProcessStore) {}
+
+  /**
+   * The per-aggregate managers for one aggregate. Scheduled singletons are
+   * excluded — they are keyed by process name, not aggregate id, so "this
+   * aggregate's instance" does not apply to them.
+   */
+  async getForAggregate(params: {
+    aggregateType: string;
+    projectId: string;
+    aggregateId: string;
+  }): Promise<AggregateProcessManager[]> {
+    const managers = getProcessManagerMetadata().filter(
+      (m) => m.aggregateType === params.aggregateType && !m.scheduled,
+    );
+
+    return Promise.all(
+      managers.map(async (m) => {
+        const ref: ProcessRef = {
+          processName: m.processName,
+          projectId: params.projectId,
+          processKey: params.aggregateId,
+        };
+        const [instance, messages] = await Promise.all([
+          this.store.findByRef({ ref }),
+          this.store.findMessagesByRef({ ref }),
+        ]);
+        return {
+          processName: m.processName,
+          pipelineName: m.pipelineName,
+          eventTypes: m.eventTypes,
+          intentTypes: m.intentTypes,
+          hasWake: m.hasWake,
+          instance: instance
+            ? {
+                state: instance.state,
+                revision: instance.revision,
+                nextWakeAt: instance.nextWakeAt,
+                updatedAt: instance.updatedAt,
+              }
+            : null,
+          outbox: messages.map((msg) => ({
+            messageKey: msg.messageKey,
+            intentType: msg.intentType,
+            status: msg.status,
+            attempts: msg.attempts,
+            nextAttemptAt: msg.nextAttemptAt,
+            createdAt: msg.createdAt,
+            sourceEventId: msg.sourceEventId,
+          })),
+        };
+      }),
+    );
+  }
+}

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -178,6 +178,9 @@ import { NullCanonicalLogRecordRepository } from "./logs/repositories/canonical-
 import { MonitorService } from "./monitors/monitor.service";
 import { PrismaMonitorRepository } from "./monitors/repositories/monitor.prisma.repository";
 import { EventExplorerService } from "./ops/event-explorer.service";
+import { ManagerExplorerService } from "./ops/manager-explorer.service";
+import { InMemoryProcessStore } from "~/server/event-sourcing/process-manager/stores/inMemoryProcessStore";
+import { PrismaProcessStore } from "~/server/event-sourcing/process-manager/stores/prismaProcessStore";
 import { getOpsMetricsCollector } from "./ops/metrics-collector";
 import { QueueService } from "./ops/queue.service";
 import { SchedulerOpsService } from "./ops/scheduler-ops.service";
@@ -1171,6 +1174,7 @@ export function initializeDefaultApp(options?: {
       new PrismaScheduledJobRepository(prisma),
     ),
     eventExplorer: new EventExplorerService(eventExplorerRepo),
+    managerExplorer: new ManagerExplorerService(new PrismaProcessStore(prisma)),
     replay: new ReplayService(replayRepo),
     metricsCollector: redis
       ? getOpsMetricsCollector({ redis, queueRepo })
@@ -1470,6 +1474,7 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
       eventExplorer: new EventExplorerService(
         new NullEventExplorerRepository(),
       ),
+      managerExplorer: new ManagerExplorerService(new InMemoryProcessStore()),
       replay: new ReplayService(new NullReplayRepository()),
       metricsCollector: null,
     },

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -115,7 +115,10 @@ import { NullLangyTurnAdmissionRepository } from "./langy/repositories/langy-tur
 import { ClickHouseLangyAnalyticsEventRepository } from "./langy/repositories/langy-analytics-event.clickhouse.repository";
 import { NullLangyAnalyticsEventRepository } from "./langy/repositories/langy-analytics-event.repository";
 import { LangyAnalyticsEventAppendStore } from "../event-sourcing/pipelines/langy-conversation-processing/projections/langyAnalyticsEvent.store";
-import { PrismaProcessStore } from "../event-sourcing/process-manager";
+import {
+  InMemoryProcessStore,
+  PrismaProcessStore,
+} from "../event-sourcing/process-manager";
 import { PrismaTopicClusteringRunHistoryProjectionRepository } from "./topic-clustering/repositories/topic-clustering-run-history-projection.prisma.repository";
 import { PrismaTopicClusteringRunProjectionRepository } from "./topic-clustering/repositories/topic-clustering-run-projection.prisma.repository";
 import { PrismaTopicModelProjectionRepository } from "./topic-clustering/repositories/topic-model-projection.prisma.repository";
@@ -179,8 +182,6 @@ import { MonitorService } from "./monitors/monitor.service";
 import { PrismaMonitorRepository } from "./monitors/repositories/monitor.prisma.repository";
 import { EventExplorerService } from "./ops/event-explorer.service";
 import { ManagerExplorerService } from "./ops/manager-explorer.service";
-import { InMemoryProcessStore } from "~/server/event-sourcing/process-manager/stores/inMemoryProcessStore";
-import { PrismaProcessStore } from "~/server/event-sourcing/process-manager/stores/prismaProcessStore";
 import { getOpsMetricsCollector } from "./ops/metrics-collector";
 import { QueueService } from "./ops/queue.service";
 import { SchedulerOpsService } from "./ops/scheduler-ops.service";

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -1175,7 +1175,7 @@ export function initializeDefaultApp(options?: {
       new PrismaScheduledJobRepository(prisma),
     ),
     eventExplorer: new EventExplorerService(eventExplorerRepo),
-    managerExplorer: new ManagerExplorerService(new PrismaProcessStore(prisma)),
+    managerExplorer: new ManagerExplorerService(repositories.processStore),
     replay: new ReplayService(replayRepo),
     metricsCollector: redis
       ? getOpsMetricsCollector({ redis, queueRepo })

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -1360,6 +1360,14 @@ export interface ReactorMetadata {
   afterProjection: string;
 }
 
+export interface EventSubscriberMetadata {
+  subscriberName: string;
+  pipelineName: string;
+  aggregateType: string;
+  /** The event types this subscriber reacts to — its transition triggers. */
+  eventTypes: readonly string[];
+}
+
 export interface DejaViewProjection {
   projectionName: string;
   eventTypes: readonly string[];
@@ -1413,6 +1421,25 @@ export function getReactorMetadata(): ReactorMetadata[] {
         afterProjection: projectionName,
       }),
     );
+  });
+}
+
+/**
+ * Event subscribers registered on each pipeline — live consumers of committed
+ * events that carry no projection state. This is the DejaView-facing view of
+ * the `.withEventSubscriber` / `.withSubscriber({ events })` seam; the
+ * process-manager runtime's generated `pm:<name>` subscribers are internal
+ * plumbing and are not part of the static definition, so they are not listed.
+ */
+export function getEventSubscriberMetadata(): EventSubscriberMetadata[] {
+  return getDefinitions().flatMap((def) => {
+    const { name: pipelineName, aggregateType } = def.metadata;
+    return Array.from(def.eventSubscribers.values()).map((definition) => ({
+      subscriberName: definition.name,
+      pipelineName,
+      aggregateType,
+      eventTypes: definition.eventTypes,
+    }));
   });
 }
 

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -1443,6 +1443,53 @@ export function getEventSubscriberMetadata(): EventSubscriberMetadata[] {
   });
 }
 
+export interface ProcessManagerMetadata {
+  processName: string;
+  pipelineName: string;
+  aggregateType: string;
+  /** Event types that drive the machine's transitions. */
+  eventTypes: readonly string[];
+  /**
+   * Intent types the machine can emit — its cross-aggregate commands, dispatched
+   * through the transactional outbox.
+   */
+  intentTypes: string[];
+  /**
+   * True for a fixed-interval singleton (one instance, project `__global__`);
+   * false for a per-aggregate machine keyed by aggregate id.
+   */
+  scheduled: boolean;
+  /** Fixed wake interval in ms for a scheduled singleton, else null. */
+  everyMs: number | null;
+  /** True when the machine computes its own wake-ups from within `evolve`. */
+  hasWake: boolean;
+}
+
+/**
+ * The process-manager state machines mounted across the pipelines.
+ *
+ * The machine itself is implicit in each manager's `evolve` — there is no
+ * declared state set or transition table — so what is introspectable is the
+ * definition surface: which event types trigger it, which intents it can emit,
+ * and how it wakes. The per-aggregate *position* in the machine lives in the
+ * persisted instance, read separately by ref.
+ */
+export function getProcessManagerMetadata(): ProcessManagerMetadata[] {
+  return getDefinitions().flatMap((def) => {
+    const { name: pipelineName, aggregateType } = def.metadata;
+    return Array.from(def.processManagers.values()).map(({ config }) => ({
+      processName: config.name,
+      pipelineName,
+      aggregateType,
+      eventTypes: config.eventTypes,
+      intentTypes: Object.keys(config.intents ?? {}),
+      scheduled: Boolean(config.schedule),
+      everyMs: config.schedule?.everyMs ?? null,
+      hasWake: Boolean(config.onWake),
+    }));
+  });
+}
+
 /**
  * One descriptor per ES kill-switch key that the registered pipelines
  * will generate at runtime. Used by the Ops Feature Flags page to list


### PR DESCRIPTION
## What

Two DejaView (ops event explorer) changes toward the managers/event-subscribers model:

1. **The left rail lists event subscribers instead of reactors.**
2. **A new right column shows the process-manager state machine for the aggregate on screen.**

## Why

DejaView reflected the reactor model — projection-tied side effects. The direction is event subscribers (raw-event consumers) and process managers (durable state machines), so the explorer should show those instead. This is the additive, observable first step of that initiative; it does not touch the reactor runtime (reactors still run — only the DejaView surface changes).

## Event subscribers

`getEventSubscriberMetadata()` joins the existing projection/reactor introspection — it walks each pipeline definition's `eventSubscribers` map (the `.withEventSubscriber` / `.withSubscriber({ events })` seam) and reports each subscriber's name, pipeline, aggregate type, and the event types it reacts to. `listProjections` returns `eventSubscribers` in place of `reactors`; the `LeftPanel` renders them keyed by those event types. Process-manager-generated `pm:<name>` subscribers are runtime plumbing, not part of the static definition, so they are excluded.

## Process-manager state machine (per aggregate)

The state machine is **implicit in each manager's `evolve()`** — there is no declared state set or transition table. So what a machine can advertise is its *definition surface* (the event types that trigger it, the intents it can emit, whether it wakes itself), and the aggregate's *position* is read from the persisted instance.

- `getProcessManagerMetadata()` introspects the definition surface, mirroring the projection/subscriber pattern.
- `ManagerExplorerService` reads the position by ref (`processKey == aggregateId`) through the existing `ProcessStore` port — `findByRef` for state/revision/next-wake, `findMessagesByRef` for the emitted-intent outbox — reusing `PrismaProcessStore` rather than duplicating queries. Scheduled singletons are excluded: they key by process name, not aggregate id.
- `getAggregateProcessManagers` (ops:view) returns, for `{ aggregateType, tenantId, aggregateId }`, each machine with its definition, this aggregate's instance (or null if it never started), and the outbox.
- `ManagerPanel` is a self-hiding right column — most aggregate types have no per-aggregate machine, so it collapses rather than take space. Each card shows triggers, emitted commands, and (when started) the current state JSON, revision, next wake, and the outbox with per-message status + attempts. State payloads are content-stripped at the `toPayload` boundary, so they are safe to render directly.

Which aggregates have a machine: `trigger` (triggerSettlement), `langy_conversation` (langyConversation), `topic_clustering` (topicClustering), `ingestion_pull` (ingestionPull). Others show no panel.

## Testing

- `ManagerExplorerService` unit test: filters to per-aggregate machines (excludes scheduled singletons + other aggregate types), keys the store by `processName + projectId + aggregateId`, reports a null instance when the machine never started, and surfaces the current position + emitted intent.
- `LeftPanel` integration test: lists subscribers (not reactors) keyed by event types; empty state.
- `ManagerCard` integration test: active vs not-started, triggers, state, emitted commands.

## Notes

- `getReactorMetadata` stays — reactors still run; only the DejaView surface changed. Removing the reactor substrate is a separate, ADR-gated migration.
- Reuses the `ProcessStore` port; no new Prisma queries. `managerExplorer` is wired behind `requireOps()`, with an in-memory store on the null-app path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Event Subscribers” section replacing “Reactors”, including subscribed event types and pipeline details.
  * Added a “Process Managers” panel with per-manager status, triggers, current state, and emitted command details.
  * Automatically refreshes process-manager data every 15 seconds.
* **Bug Fixes**
  * Improved empty-state messaging when there are no event subscribers or no active process-manager instance.
* **Tests**
  * Added and updated integration tests for event subscribers and process-manager cards, including started vs. not-started scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->