### PR TITLE
docs(adr-063): automations domain packages, RPC customer API, and the agent-first surface

### DIFF
--- a/dev/docs/adr/037-automation-operator-surfaces.md
+++ b/dev/docs/adr/037-automation-operator-surfaces.md
@@ -160,3 +160,15 @@ We do not block the management surface on the deferred dispatch wiring: the alwa
 - [ADR-026](./026-per-trigger-dispatch-timing.md) — cadence + debounce columns the cadence secondary edits
 - [ADR-036](./036-liquid-templates-for-trigger-notifications.md) — Liquid templates + test-fire banner the Configuration secondary edits
 - Code touched: `src/components/AddAutomationDrawer.tsx`, `src/components/EditTriggerTemplatesDrawer.tsx`, `src/pages/[project]/automations.tsx`, `src/server/api/routers/automations.ts`, `src/server/app-layer/automations/trigger-template.service.ts`, `src/automations/**`, `src/features/automations/**`
+
+## Amendment 2026-07-22 (ADR-063)
+
+The staged drawer is no longer the primary creation path: creation starts
+in the composing flow of the four-state automations page
+([ADR-063](./063-automations-domain-packages-customer-api-and-agent-surface.md)),
+and the drawer remains as the "Edit details" escape hatch and the editor
+for existing automations. The "automations list page becomes the operator
+activity surface" consequence is likewise replaced by that page. Everything
+else here stands — the staged sections, stateless preview, test-fire
+contract, provider model, and fire-history surfaces are unchanged and are
+consumed by ADR-063's surfaces.

--- a/dev/docs/adr/043-automation-facet-model.md
+++ b/dev/docs/adr/043-automation-facet-model.md
@@ -67,3 +67,14 @@ being scattered across "conditions" and "schedule."
    it touches the same alert render path.
 4. Cadence consolidation — fold re-notify / debounce / quiet-hours into the one
    Cadence facet over subsequent slices.
+
+## Amendment 2026-07-22 (ADR-063)
+
+The facet model stands, and its entities move into the
+`@langwatch/automations` domain package
+([ADR-063](./063-automations-domain-packages-customer-api-and-agent-surface.md)).
+Superseded: the drawer entry — "Picking Type first fixes which later facets
+show" and Rollout §2's facet-order drawer as *the* authoring surface.
+Creation is now intent-first composing that derives the kind; the staged
+drawer becomes the "Edit details" escape hatch, its sections still mapping
+onto the facets.

--- a/dev/docs/adr/044-scheduled-reports-automation-kind.md
+++ b/dev/docs/adr/044-scheduled-reports-automation-kind.md
@@ -593,3 +593,14 @@ for the other kinds.
 - `ee/governance/services/pullers/pullerQueue.ts` + `IngestionSource.pullSchedule` —
   the one existing per-entity cron primitive (BullMQ `repeat.pattern`, no timezone)
   the report scheduler's representation learns from and improves on.
+
+## Amendment 2026-07-22 (ADR-063)
+
+The taxonomy, `triggerKind` discriminator, schedule model, and scheduler
+all stand. Superseded
+([ADR-063](./063-automations-domain-packages-customer-api-and-agent-surface.md)):
+§1's recommendation to "surface the three kinds as first-class cards in the
+type picker" and §6's type-picker card — creation is intent-first (three
+outcome cards; the kind is derived). On the wire, the customer API names
+the discriminator `kind` (`automation` | `alert` | `report`), mapping 1:1
+onto `triggerKind`; the data layer renames nothing, as decided here.

--- a/dev/docs/adr/052-automations-on-process-manager-substrate.md
+++ b/dev/docs/adr/052-automations-on-process-manager-substrate.md
@@ -221,3 +221,17 @@ observability are outside this decision.
 - ADR-051 (event-sourced topic clustering scheduling — introduces the durable
   revision-fenced wake pattern this ADR generalises; in flight on PR #5902,
   not yet on main)
+
+## Amendment 2026-07-22 (ADR-063)
+
+The consolidation locations are superseded
+([ADR-063](./063-automations-domain-packages-customer-api-and-agent-surface.md)):
+services, dispatch helpers, delivery senders, and the provider server
+halves move from `server/app-layer/automations` into the
+`@langwatch/automations-server` workspace package, along with the pure
+evolve/wake logic and event/intent schemas. `server/app-layer/automations`
+retains only the Prisma and ClickHouse repository implementations, and
+`server/event-sourcing/pipelines/automations` retains the pipeline wiring
+that mounts the package's process logic. Every behavioral contract in this
+ADR — GroupQueue ordering, the transactional inbox, the leased outbox,
+evolve-handler purity, replay safety — is unchanged.

--- a/dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md
+++ b/dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md
@@ -294,10 +294,12 @@ export function buildAutomationsApi(deps: {
   webhook or installed app + channel), HTTP webhook (ADR-040 semantics),
   email, dataset, annotation queue.
 - **Auth is the project API key.** Every operation authenticates with the
-  existing project-scoped API-key middleware (`X-Auth-Token`), the same
-  convention as the other customer REST surfaces (ADR-032's precedent). The
-  key grants the project's full automations surface; finer-grained key
-  scopes are a platform-wide follow-up, not invented here.
+  existing project-scoped API-key middleware (`X-Auth-Token`) — the same
+  key the SDKs and the existing customer REST surfaces already use. No ADR
+  owns that mechanism (it predates the corpus); this ADR adopts it rather
+  than originates it. The key grants the project's full automations
+  surface; finer-grained key scopes are a platform-wide follow-up, not
+  invented here.
 - **Secrets are write-only.** Read DTOs in `contracts/` structurally exclude
   secret material: webhook URLs and tokens return masked
   (`"https://hooks.slack.com/…/••••"`, header values as `"••••"`), reusing

--- a/dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md
+++ b/dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md
@@ -91,20 +91,123 @@ packages/automations/src/
 Depends on `@langwatch/automations`, `@langwatch/api`,
 `@langwatch/handled-error`, `@langwatch/observability`, `@langwatch/ssrf`.
 Still no Prisma and no React: it consumes the repository interfaces and
-receives implementations by injection.
+receives implementations by injection. The full structure — every current
+`app-layer/automations` module has a named destination here:
 
 ```
-packages/automations-server/src/
-  services/        # AutomationService, SilenceService, SuggestionService,
-                   #   TemplateService, FireHistoryService, SlackIntegrationService
-  clients/         # slack (incoming webhook + Web API), http webhook
-                   #   (SSRF-guarded), email sender port
-  event-sourcing/  # event/command/intent Zod schemas + pure evolve/wake
-                   #   functions for the ADR-052 process managers
-  api/             # the versioned customer API: a dependency-injected
-                   #   factory built with @langwatch/api's createService
-  errors.ts        # HandledError subclasses for the domain (ADR-045)
+packages/automations-server/
+  package.json          # exports: "." (build + deps contract), "./api",
+                        #   "./services", "./clients", "./dispatch",
+                        #   "./event-sourcing", "./testing"
+  tsconfig.json         # incremental + its own tsBuildInfoFile (repo rule)
+  vitest.config.ts
+  src/
+    index.ts            # buildAutomationsServices(deps) — the one composition
+                        #   entry; app + tests construct everything through it
+    deps.ts             # the injected-dependency contract (see below)
+    errors.ts           # HandledError subclasses: stable code, httpStatus,
+                        #   fault, tips/docsUrl (ADR-045)
+
+    services/           # transport-independent use cases; depend on ports +
+                        #   domain contracts only, never on clients directly
+      automation.service.ts        # rule CRUD, kind/facet validation,
+                                   #   enable/disable (today: trigger.service.ts)
+      silence.service.ts           # silence/unsilence, expiry semantics (§4)
+      suggestion.service.ts        # the deterministic detectors (§5)
+      fire-history.service.ts      # (today: trigger-fire-history.service.ts)
+      template.service.ts          # render, preview, test-fire
+                                   #   (today: trigger-template.service.ts)
+      webhook-delivery.service.ts  # delivery-log reads + prune policy
+      email-suppression.service.ts
+      graph-evaluation.service.ts  # threshold eval over the analytics port
+                                   #   (today: graph-trigger-evaluation +
+                                   #   evaluate-custom-graph-threshold)
+      slack-integration.service.ts # OAuth exchange, sealed token storage,
+                                   #   channel listing (§6)
+      report-schedule.service.ts   # ScheduledJob sync for REPORT rules
+                                   #   (today: TriggerService.syncReportSchedule)
+
+    dispatch/           # effect orchestration between the process managers
+                        #   and the clients; owns notify-vs-persist classing
+      action-dispatch.ts           # (today: triggerActionDispatch.ts)
+      graph-alert-dispatch.ts      # (today: graphAlertActionDispatch.ts)
+      email-caps.ts                # ADR-031 caps + suppression
+      confirm-settled-match.ts     # settled-fold reconfirmation
+      notifier.ts                  # (today: triggerNotifier.ts)
+
+    clients/            # outbound edges; import ports + platform packages,
+                        #   never services (no cycles back up the stack)
+      slack/
+        incoming-webhook.client.ts # (today: sendSlackWebhook.ts)
+        web-api.client.ts          # chat.postMessage, conversations.list
+                                   #   (today: slackWebApi.ts)
+        webhook-guard.ts           # hooks.slack.com host lock
+      http/
+        webhook.client.ts          # ADR-040 delivery (today: sendWebhook +
+                                   #   deliverWebhook)
+        destination.ts             # SSRF / redirect / timeout guards over
+                                   #   @langwatch/ssrf (today: httpDestination)
+
+    providers/          # server halves of the provider registry, one module
+                        #   per channel (today: app-layer providers/<name>/server.ts)
+      registry.ts
+      slack.ts  webhook.ts  email.ts  dataset.ts  annotation-queue.ts
+
+    event-sourcing/     # everything the ADR-052 pipeline mounts, minus the
+                        #   mounting itself; evolve/wake stay pure (no IO,
+                        #   no clocks — ctx.at only)
+      events.ts                    # event type constants + Zod schemas
+      commands/
+        record-trigger-match.ts
+      settle-window.ts             # deterministic settle-window buckets
+      processes/
+        trigger-settlement.ts      # state, evolve, onWake, intent schemas
+        graph-alert-sweep.ts
+        webhook-delivery-prune.ts
+      intents/
+        handlers.ts                # intent executors over dispatch/ + services/
+
+    api/                # the customer API (§2); depends on services only
+      service.ts                   # buildAutomationsApi(deps)
+      versions/
+        2026-08-01.ts              # registers the version's operations
+      operations/                  # one module per operation: input schema,
+        create-rule.ts             #   output schema, handler — the unit an
+        list-rules.ts              #   agent tool binds to
+        …                          #   (one file per §2 operation)
+
+    testing/            # exported fakes so every consumer tests against the
+      fakes.ts          #   same in-memory repository + port implementations
 ```
+
+**The injected-dependency contract (`deps.ts`).** Everything the package
+cannot own arrives as a port, typed here and constructed at the app's
+composition root:
+
+- The repository interfaces from `@langwatch/automations` (trigger,
+  fire-history, webhook-delivery, custom-graph, email-suppression,
+  scheduled-job, slack-integration, suggestion-dismissal, audit).
+- `AnalyticsPort` — `getTimeseries` for graph evaluation, reports, and the
+  suggestion detectors (the app adapts its analytics service).
+- `DatasetPort` and `AnnotationQueuePort` — the persist-class actions write
+  through these, not through app imports.
+- `MailerPort` — outbound email delivery.
+- `SecretSealPort` — encrypt/decrypt for stored Slack tokens and webhook
+  secrets.
+- `Clock` — services and dispatch never read wall time directly, which is
+  what keeps silence expiry and settle windows testable (evolve/wake
+  functions already get `ctx.at` from the substrate).
+
+**Dependency rules, enforced.** `api → services → (ports, dispatch)`;
+`dispatch → clients`; `clients` import nothing above themselves;
+`event-sourcing/processes` import only domain contracts and stay pure. The
+package's `package.json` must never grow `@prisma/client`, `next`, or
+`react` — pinned by a unit test on the dependency list, the same way enum
+parity is pinned today.
+
+**Builders move to the domain package.** `report.builder.ts` and
+`graph-alert.builder.ts` are pure row→shape translations and land in
+`@langwatch/automations/domain`, not here.
 
 **What stays in the app** (`langwatch/src/`):
 

--- a/dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md
+++ b/dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md
@@ -1,0 +1,415 @@
+# ADR-063: Automations domain packages, versioned customer API, and the agent-first operator surface
+
+**Date:** 2026-07-22
+
+**Status:** Proposed
+
+**Builds on:** ADR-037 (operator surfaces), ADR-040 (webhook channel), ADR-041
+(Block Kit templates), ADR-043 (facet model), ADR-044 (scheduled reports),
+ADR-045 (handled errors), ADR-052 (process-manager substrate), ADR-060
+(model-emitted blocks).
+
+## Context
+
+The automations *engine* is done. ADR-052's process-manager pipeline, the
+ADR-044 durable scheduler, reports, graph alerts, the five delivery actions
+(Slack, HTTP webhook, email, dataset, annotation queue), Liquid templating,
+and the at-most-once dispatch contracts are all implemented and running. What
+is fragmented is everything *around* the engine:
+
+- **The domain code has no single home.** Pure vocabulary lives in
+  `@langwatch/automations` (providers, cadences, templating, enums); services,
+  repositories, delivery senders, and dispatch live in
+  `src/server/app-layer/automations`; pure evolve/wake logic is interleaved
+  with pipeline wiring in `src/server/event-sourcing/pipelines/automations`.
+  Nothing outside the app can reuse the services, and the app's typecheck
+  graph pays for the tangle.
+- **The customer-facing REST surface is the worst code in the domain.**
+  `/api/triggers` predates the service layer: it calls Prisma inline, its
+  action enum is missing `SEND_WEBHOOK`, it is unversioned, and it returns
+  `actionParams` secrets (Slack webhook URLs, bot tokens, webhook auth
+  headers) unredacted on read — the tRPC surface redacts, the REST surface
+  never did.
+- **The versioned API framework has no adopters.** `@langwatch/api`
+  (`langwatch/packages/api`) — the Hono builder with date versioning,
+  input/output Zod validation, OpenAPI generation, and `HandledError`
+  serialization — shipped with no consumers. Automations is the natural first
+  adopter.
+- **The operator page is three feature landing pages stacked.** The current
+  `/automations` page splits one list across tabs, leads with stat cards that
+  read zero, and makes the user pick the taxonomy (Automation vs Alert vs
+  Schedule) before they can express an intent. The redesign spec (four page
+  states: empty → composing → populated → firing) inverts this: the user
+  states an outcome, the system derives the kind.
+- **Nothing composes automations for the user.** There is no natural-language
+  authoring, no suggestions engine, no silence primitive, and Slack app
+  delivery requires manually pasting a bot token.
+
+See the behavioural contracts this decision supports:
+[`specs/automations/customer-api.feature`](../../../specs/automations/customer-api.feature),
+[`specs/automations/page-states.feature`](../../../specs/automations/page-states.feature),
+[`specs/automations/agent-composing.feature`](../../../specs/automations/agent-composing.feature),
+[`specs/automations/suggestions.feature`](../../../specs/automations/suggestions.feature),
+[`specs/automations/silence.feature`](../../../specs/automations/silence.feature),
+[`specs/automations/slack-app-install.feature`](../../../specs/automations/slack-app-install.feature).
+
+## Decision
+
+Consolidate the automations domain into two workspace packages, expose it to
+customers through a versioned API built on `@langwatch/api`, rebuild the
+operator page around the four-state redesign with Langy as the composer, and
+add the three missing primitives (silence, suggestions, Slack app install).
+The tRPC router remains the UI's transport; REST is for customers and agents.
+Both become thin transports over one package-owned service layer.
+
+### 1. Two packages, one dependency direction
+
+Two packages rather than one so the dependency graph stays acyclic: light
+consumers (web UI, CLI, MCP server, SDKs) import contracts without pulling in
+services, and the server package depends downward only.
+
+**`@langwatch/automations`** (existing, extended) — the pure domain and
+contracts package. No database, no React, no server-only dependencies.
+
+```
+packages/automations/src/
+  domain/          # entities + invariants: Rule (kind: automation|alert|report),
+                   #   facets (ADR-043), status model, silence state
+  contracts/       # strict Zod DTOs: create/update/list/read shapes as
+                   #   kind-discriminated unions; redacted read schemas
+  repositories/    # repository INTERFACES only (TriggerRepository,
+                   #   FireHistoryRepository, WebhookDeliveryRepository,
+                   #   ScheduledJobPort, SlackIntegrationRepository, …)
+  providers/       # (existing) per-channel shared definitions
+  templating/      # (existing) Liquid engine, renderers, defaults
+  cadences.ts      # (existing)
+  enums.ts         # (existing) Prisma enum mirrors, parity-test pinned
+  utils/
+```
+
+**`@langwatch/automations-server`** (new) — services and outbound edges.
+Depends on `@langwatch/automations`, `@langwatch/api`,
+`@langwatch/handled-error`, `@langwatch/observability`, `@langwatch/ssrf`.
+Still no Prisma and no React: it consumes the repository interfaces and
+receives implementations by injection.
+
+```
+packages/automations-server/src/
+  services/        # AutomationService, SilenceService, SuggestionService,
+                   #   TemplateService, FireHistoryService, SlackIntegrationService
+  clients/         # slack (incoming webhook + Web API), http webhook
+                   #   (SSRF-guarded), email sender port
+  event-sourcing/  # event/command/intent Zod schemas + pure evolve/wake
+                   #   functions for the ADR-052 process managers
+  api/             # the versioned customer API: a dependency-injected
+                   #   factory built with @langwatch/api's createService
+  errors.ts        # HandledError subclasses for the domain (ADR-045)
+```
+
+**What stays in the app** (`langwatch/src/`):
+
+- `server/app-layer/automations/repositories/*.prisma.repository.ts` and the
+  ClickHouse audit repository — the only code that knows the database.
+- `server/event-sourcing/pipelines/automations/` — pipeline *wiring* only
+  (`.withProcessManager`, subscribers, composition root); the evolve/wake
+  logic and schemas it mounts come from the server package.
+- The tRPC `automation` router — reduced to a thin transport over the
+  package services.
+- `features/automations/` — the React UI and the client halves of providers.
+- The app's composition root (`app-layer/presets.ts`) constructs the services
+  with the Prisma implementations and passes them to both transports.
+
+Langy's layering (`app-layer/langy/repositories|execution|streaming` +
+pipeline wiring) is the precedent; this takes it one step further by moving
+the transport-independent layers out of `src/server` entirely. Both packages
+follow the repo tsconfig rules (`incremental` + per-package
+`tsBuildInfoFile`), which also advances the measured package-split typecheck
+plan.
+
+### 2. The customer API — RPC-shaped, first adopter of `@langwatch/api`
+
+A versioned service at `/api/automations/{version}/…`, defined in
+`@langwatch/automations-server/api` as a factory the app route mounts:
+
+```ts
+// packages/automations-server/src/api/service.ts
+export function buildAutomationsApi(deps: {
+  auth: MiddlewareHandler;
+  services: AutomationsServices;   // constructed at the app composition root
+}) {
+  return createService({ name: "automations", auth: deps.auth })
+    .provide({ automations: () => deps.services })
+    .version("2026-08-01", (v) => {
+      v.post("/create_rule", { input: createRuleInput, output: ruleRead, status: 201 }, …);
+      v.post("/list_rules",  { input: listRulesInput, output: ruleList }, …);
+      // … one POST per operation
+    })
+    .build();
+}
+```
+
+- **RPC operations, not REST resources.** Every operation is a verb-named
+  `POST /{version}/{operation}` with exactly one input schema and one output
+  schema — the shape of an agent tool call. OpenAPI operation ids are the
+  snake_case operation names, so MCP tools, CLI commands, and customer
+  agents map onto the API 1:1 with no route/verb/path-param inference. v1
+  operations:
+  - `create_rule` · `get_rule` · `list_rules` · `update_rule` ·
+    `delete_rule`
+  - `enable_rule` · `disable_rule` · `silence_rule` · `unsilence_rule` (§4)
+  - `test_fire_rule` (banner-marked test dispatch, per the ADR-037
+    contract)
+  - `get_rule_status` (health, firing, last fired, next run) ·
+    `list_rule_fires` (fire history) · `list_rule_deliveries` (webhook
+    delivery log)
+  - `list_suggestions` · `dismiss_suggestion` (§5)
+  - `list_slack_channels` (channel picker for app-mode delivery, §6)
+- **One rule shape, kind-discriminated.** Rule payloads are a Zod
+  discriminated union on `kind: "automation" | "alert" | "report"` — the
+  ADR-043 facet model on the wire. Kind-specific facets (threshold +
+  severity for alerts, cron + timezone + content source for reports,
+  filters + digest window for trace automations) are members of the union,
+  not optional soup.
+- **All five channels** are expressible in `delivery`: Slack (incoming
+  webhook or installed app + channel), HTTP webhook (ADR-040 semantics),
+  email, dataset, annotation queue.
+- **Secrets are write-only.** Read DTOs in `contracts/` structurally exclude
+  secret material: webhook URLs and tokens return masked
+  (`"https://hooks.slack.com/…/••••"`, header values as `"••••"`), reusing
+  the existing `redactActionParamsFor` logic, now owned by the contracts
+  package and enforced by the API's `output` schemas. This closes the
+  `/api/triggers` leak by construction — the read schema cannot represent
+  the secret.
+- **Strict handled errors, built for agents.** Every failure is a typed
+  `HandledError` per ADR-045 — stable `code`, `meta`, `fault`, and, on every
+  customer-actionable error, `tips` and `docsUrl` from the remediation
+  registry. Agents driving the API (Langy, MCP, CLI, customer agents) get
+  machine-readable causes and authored remediation instead of prose. The
+  OpenAPI document is complete — schemas, error envelopes, and descriptions
+  — because for agent consumers the docs are the integration.
+- **Deprecation of `/api/triggers`.** The legacy route immediately gains
+  `Deprecation` + `Sunset` headers and a docs pointer, stops being
+  documented, and is removed after a migration window. Its secret leak is
+  not patched in place — the replacement is the fix, and the window is
+  short.
+
+### 3. tRPC stays, but thins
+
+The UI keeps tRPC (session auth, React Query integration, no reason to
+churn). The 1,263-line `automation` router is reduced to parameter parsing +
+service calls using the same contracts and services as the REST API. One
+service layer, two transports; behaviour cannot drift between surfaces
+because neither surface owns behaviour.
+
+### 4. Silence — a first-class primitive
+
+`Trigger.silencedUntil DateTime?` (additive migration). Semantics:
+
+- While `now < silencedUntil`, dispatch suppresses the rule's *effects* —
+  notifications are not sent, persist-class actions do not write. Evaluation
+  and incident tracking continue: matches are still recorded, an alert's
+  breach/recover state still moves, fire history notes suppressed fires.
+- Silence is temporary by construction (a timestamp, not a flag); `active`
+  remains the permanent off-switch.
+- Exposed on both transports (`POST /:id/silence { until }` REST;
+  tRPC mutation for the UI's "Silence 1h") and rendered in list/status
+  surfaces ("Silenced · 43 min left").
+
+### 5. Suggestions — deterministic detectors
+
+A `SuggestionService` in the server package computes suggestions from
+project telemetry and existing rules — no LLM in the loop. v1 detectors:
+
+1. **Error spike without an alert** — error-rate breaches in the last 30
+   days with no active error alert.
+2. **Failed evaluations going nowhere** — failing eval traces with no
+   dataset/annotation-queue rule collecting them.
+3. **Spend growth without a cost alert** — month-over-month token cost
+   growth beyond a threshold with no cost alert.
+
+Each suggestion carries the facts (counts, period) and a pre-filled draft
+rule the UI or Langy can open. Dismissals persist per project + detector.
+The populated page shows at most one suggestion row (the artifact's "earns
+attention by being right" rule); the empty page may show more.
+
+### 6. Slack app install
+
+Replace manual bot-token pasting with a proper OAuth v2 install flow. The
+delivery machinery already exists (`chat.postMessage`, `conversations.list`,
+retryable-error classification, scope remediation copy); what is missing is
+acquisition and storage of the token.
+
+- **`SlackIntegration`** model: one per organization (projects select a
+  channel against the org install), storing the encrypted bot token, team
+  id/name, granted scopes, and installer. Encrypted at rest with the
+  existing secrets encryption; the token is never returned by any read
+  API (same write-only rule as §2).
+- **Install flow:** settings-initiated OAuth redirect → callback exchanges
+  the code, stores the integration, returns to settings. Scopes:
+  `chat:write`, `chat:write.public`, `channels:read`.
+- **Channel picker** backed by `conversations.list` under the stored token —
+  the drawer and the agent both use it.
+- **Delivery config union** widens: `slack` delivery is `{ mode: "webhook",
+  url }` or `{ mode: "app", channelId }`. Incoming webhooks remain fully
+  supported; the manual-token path folds into the integration as an
+  import.
+- This also unblocks the ADR-041/044 deferred bot-token paths (threaded
+  dashboard reports, `data_visualization` blocks) — not built here, but the
+  token they were waiting for now exists.
+
+### 7. The operator page — four states, taxonomy derived
+
+Rebuild `/automations` (flag: `release_automations_redesign`) per the
+redesign spec:
+
+- **Empty:** one question ("What should happen automatically?"), three
+  outcome cards in plain language (tell me when… / send me… / do something
+  when…), an NL input, and detector-seeded suggestions. No stat cards, no
+  tabs, no taxonomy picker.
+- **Composing:** the NL intent produces a Langy plan card (§8). Outcome
+  cards open the same flow with the intent pre-framed.
+- **Populated, quiet:** one list; every rule reads as a sentence
+  ("Error rate above 5% → Slack #oncall"), status dot leading, kind badge
+  trailing (Alert / Schedule / On trace), filter pills, a one-line prose
+  header ("All quiet — nothing firing, next digest Monday 09:00"), at most
+  one suggestion row. Sorting: status severity, then activity recency.
+- **Firing:** the firing rule takes over the top as an incident row —
+  current value, duration, notified-where, recurrence count — with **View
+  traces** and **Silence 1h**. Healthy rules dim below a "everything else is
+  healthy" strip. Recovery returns the page to quiet automatically.
+- **Copy:** the page is **Automations**; individual rows are **rules**
+  ("+ New rule", "1 rule firing"). Kind badges say Alert / Schedule / On
+  trace — the internal enum names never surface.
+- The staged authoring drawer (ADR-037/043, `authoring-drawer.feature`)
+  remains as the **Edit details** escape hatch, pre-filled from a plan or an
+  existing rule. It is no longer the primary creation path.
+
+Status derives from data that already exists (`getTriggerStats` firing
+state, `TriggerSent` incidents, `ScheduledJob.nextRunAt`); the page-level
+prose header and incident takeover are presentation, not new state.
+
+### 8. Langy composes; the human approves
+
+The composing state is Langy with automation-authoring tools:
+
+- **Tools over the same services:** draft-rule (validate a candidate rule
+  against contracts without saving), inspect prerequisites (does the cost
+  graph this alert needs exist?), create prerequisite (create the custom
+  graph), create/update rule, list existing rules + suggestions. Every
+  mutation goes through the same package services with the same validation
+  — the agent cannot reach around the domain.
+- **The plan card is an ADR-060 derived card:** Watch / Trigger / Notify
+  lines plus an "Also" line for prerequisites the agent will create.
+  Approve / Edit details / Cancel are the card's actions; approve executes
+  the plan (prerequisites first, then the rule), Edit details opens the
+  drawer pre-filled, and a correction ("use email instead") is just another
+  turn that re-emits the card.
+- Nothing is created before approval. The plan card states everything the
+  approve will do; a failed step surfaces as a handled error on the card.
+
+### 9. Phasing
+
+| Phase | Ships | Depends on |
+|-------|-------|------------|
+| P1 | Package restructure: contracts/domain/interfaces into `@langwatch/automations`; services/clients/event-sourcing/api-factory into `@langwatch/automations-server`; app keeps impls + wiring; tRPC delegates. No behaviour change. | — |
+| P2 | Customer API v1 (`2026-08-01`) + OpenAPI + deprecation headers on `/api/triggers`. | P1 |
+| P3 | Silence primitive (migration, dispatch honor, both transports). | P1 |
+| P4 | Four-state page behind `release_automations_redesign` (states 00/02/03; composing opens the drawer until P7). | P3 |
+| P5 | Suggestion detectors + feed. | P1 |
+| P6 | Slack app install + channel picker + `mode: "app"` delivery. | P1 |
+| P7 | Langy composing (tools + plan cards). | P4, ADR-060 blocks |
+| P8 | `/api/triggers` removal after the migration window. | P2 |
+
+P2–P6 are parallelizable after P1. Riskiest first: the restructure is a
+large mechanical move that must land with zero behaviour change — it is
+deliberately its own PR with the parity test suite as the gate.
+
+## Rationale / Trade-offs
+
+- **Why two packages instead of one.** A single package holding contracts
+  *and* services forces every light consumer (UI, CLI, MCP) to compile the
+  service layer, and invites cycles the moment another domain package needs
+  automations contracts while automations services need that domain's
+  client. Contracts-only packages are leaves; server packages depend on
+  leaves; the app depends on both. The cost — one more package — is small
+  and the repo already runs a multi-package layout.
+- **Why repository interfaces in the domain package but implementations in
+  the app.** The interfaces are part of the domain's language; the
+  implementations are bound to Prisma's generated client and the app's
+  database lifecycle. Keeping implementations app-side avoids making the
+  packages depend on generated artifacts and keeps `pnpm typecheck` graphs
+  honest.
+- **Why the API factory lives in the server package, not an app route
+  file.** The service definition *is* domain surface — its schemas, error
+  mapping, and versioning policy belong with the services it fronts. The
+  app contributes exactly what it owns: auth middleware and constructed
+  dependencies. This also makes the API testable without Next.js.
+- **Why an RPC-shaped API rather than REST resources.** The primary
+  consumers are agents, and an agent integrates by binding tools to
+  operations: `create_rule` with one input schema is a tool; `PATCH
+  /rules/:id` with path params, partial bodies, and verb semantics is an
+  exercise in inference. Verb-named POSTs also make the OpenAPI document
+  self-describing per operation and keep every call's contract to exactly
+  one input and one output schema. We give up HTTP caching and RESTful
+  affordances that none of the intended consumers use.
+- **Why an HTTP API for customers and tRPC for the UI, not one transport.**
+  The API's consumers are agents and integrations that need versioning,
+  OpenAPI, and stable errors; the UI needs session auth and React Query.
+  Forcing either onto the other's transport buys churn, not convergence —
+  convergence comes from the shared service layer.
+- **Why deprecate `/api/triggers` rather than patch it.** Patching
+  redaction into an unversioned, service-less route spends effort making
+  the wrong surface safer to keep. The replacement exists in the same
+  release; a short window with `Deprecation` headers is the cheaper and
+  cleaner path. (Public copy for this describes the rule now in force —
+  reads are redacted, secrets are write-only — not the historic hole.)
+- **Why deterministic suggestions, not Langy-generated.** Detector output
+  must be cheap, explainable, and always-on (it renders on page load).
+  Three detectors with clear predicates beat an LLM sweep on cost and
+  trust; Langy still gets the detector facts as tool output and can narrate
+  or extend them in conversation.
+- **Why silence keeps evaluating.** Suppressing effects while tracking
+  state means un-silencing shows the truth ("still firing, 7.8%") instead
+  of a blind spot, and fire history stays honest about what was suppressed.
+- **What we compromise.** The restructure is a big diff with no user-visible
+  payoff of its own; the Slack OAuth flow adds a real credential store we
+  must encrypt and audit; and running the redesigned page and the legacy
+  page behind a flag doubles the surface until GA. Judged worth it against
+  building the customer API on top of the current tangle and hand-rolling a
+  fourth bespoke REST route.
+
+## Consequences
+
+- `@langwatch/automations` becomes the single source of truth for domain
+  models, contracts, and repository interfaces; `@langwatch/automations-server`
+  for services, clients, event-sourcing logic, and the customer API. The
+  app-layer automations directory shrinks to implementations + wiring.
+- `@langwatch/api` gains its first production adopter, validating the
+  builder (versioning, OpenAPI, error formatting) against a real domain.
+- Customers and agents get a versioned, documented, strictly-typed
+  automations API whose reads cannot leak secrets; `/api/triggers` is
+  deprecated and later removed.
+- The `Trigger` model gains `silencedUntil`; a `SlackIntegration` model and
+  OAuth flow enter the platform; a `SuggestionDismissal` store appears.
+- The operator page becomes the four-state surface; the staged drawer
+  demotes to the escape hatch; "rule" enters the product vocabulary for
+  rows.
+- Langy gains automation-authoring tools and its first ADR-060 derived-card
+  consumer in production.
+- Follow-ups deliberately out of scope: threaded Slack dashboard reports and
+  `data_visualization` blocks over the bot token (ADR-041/044 deferrals),
+  idempotency keys on API writes, per-severity throttling and quiet hours
+  (the ADR-043 cadence growth points), and MCP/CLI automation commands over
+  the new API.
+
+## References
+
+- Redesign artifact: "Automations, redesigned — state spec" (four page
+  states; one creation entry point; taxonomy derived, not chosen; status
+  leads; prose over stat cards; agent proposes, human approves).
+- ADR-037, ADR-040, ADR-041, ADR-043, ADR-044, ADR-045, ADR-052, ADR-060.
+- `langwatch/packages/api/README.md` — the versioned service builder.
+- `src/server/app-layer/automations/` — the service layer being moved.
+- `src/server/app-layer/automations/delivery/slackWebApi.ts` — the existing
+  bot-token delivery path the install flow feeds.
+- Specs: see Context.

--- a/dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md
+++ b/dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md
@@ -4,10 +4,24 @@
 
 **Status:** Proposed
 
-**Builds on:** ADR-037 (operator surfaces), ADR-040 (webhook channel), ADR-041
-(Block Kit templates), ADR-043 (facet model), ADR-044 (scheduled reports),
-ADR-045 (handled errors), ADR-052 (process-manager substrate), ADR-060
-(model-emitted blocks).
+**Builds on:** ADR-021 (tenancy), ADR-030 (transactional outbox), ADR-031
+(email abuse protections), ADR-034 (analytics materialization), ADR-035
+(persist-class debounce), ADR-036 (Liquid templates), ADR-037 (operator
+surfaces), ADR-040 (webhook channel), ADR-041 (Block Kit templates), ADR-043
+(facet model), ADR-044 (scheduled reports), ADR-045 (handled errors), ADR-052
+(process-manager substrate), ADR-053 (tenant-aware egress), ADR-058 (Langy
+user-turn controls), ADR-059 (deterministic card selection), ADR-060
+(model-emitted blocks — **in flight, not yet on main**; §8 and phase P7
+depend on it, so this ADR must not be accepted ahead of it; ADR-059 is the
+accepted foundation the plan card stands on either way).
+
+**Supersedes (in part):** ADR-037's drawer-as-primary authoring path and
+settings-list-as-operator-surface; ADR-043's Type-first drawer entry
+(Rollout §2); ADR-044's type-picker-first creation (§1 naming
+recommendation, §6); ADR-052's placement of services, dispatch helpers,
+delivery senders, and provider server halves under
+`server/app-layer/automations`. Each carries a dated amendment pointing
+here; every other contract in those ADRs stands.
 
 ## Context
 
@@ -261,7 +275,10 @@ export function buildAutomationsApi(deps: {
     `delete_rule`
   - `enable_rule` · `disable_rule` · `silence_rule` · `unsilence_rule` (§4)
   - `test_fire_rule` (banner-marked test dispatch, per the ADR-037
-    contract)
+    contract — except email: an API key carries no requester inbox, and
+    ADR-031's requester-only rule forbids sending test mail to configured
+    recipients, so email test fires are refused with a handled error whose
+    tips point at the in-app test fire)
   - `get_rule_status` (health, firing, last fired, next run) ·
     `list_rule_fires` (fire history) · `list_rule_deliveries` (webhook
     delivery log)
@@ -276,13 +293,21 @@ export function buildAutomationsApi(deps: {
 - **All five channels** are expressible in `delivery`: Slack (incoming
   webhook or installed app + channel), HTTP webhook (ADR-040 semantics),
   email, dataset, annotation queue.
+- **Auth is the project API key.** Every operation authenticates with the
+  existing project-scoped API-key middleware (`X-Auth-Token`), the same
+  convention as the other customer REST surfaces (ADR-032's precedent). The
+  key grants the project's full automations surface; finer-grained key
+  scopes are a platform-wide follow-up, not invented here.
 - **Secrets are write-only.** Read DTOs in `contracts/` structurally exclude
   secret material: webhook URLs and tokens return masked
   (`"https://hooks.slack.com/…/••••"`, header values as `"••••"`), reusing
   the existing `redactActionParamsFor` logic, now owned by the contracts
   package and enforced by the API's `output` schemas. This closes the
   `/api/triggers` leak by construction — the read schema cannot represent
-  the secret.
+  the secret. Scope note: this governs *configuration* reads. ADR-040's
+  webhook delivery log deliberately stores receiver **responses** verbatim
+  (and never persists request secrets); that split is unchanged and is not
+  overridden by this rule.
 - **Strict handled errors, built for agents.** Every failure is a typed
   `HandledError` per ADR-045 — stable `code`, `meta`, `fault`, and, on every
   customer-actionable error, `tips` and `docsUrl` from the remediation
@@ -314,6 +339,11 @@ because neither surface owns behaviour.
   breach/recover state still moves, fire history notes suppressed fires.
 - Silence is temporary by construction (a timestamp, not a flag); `active`
   remains the permanent off-switch.
+- Placement follows ADR-030's reservation ("notify-side mute … belongs
+  between match and dispatch — not inside the outbox state machine itself,
+  not inside the dispatch handler"): the suppression gate sits in the
+  dispatch layer's classing step, before any effect executes — outside the
+  process managers' state machines and outside the channel senders.
 - Exposed on both transports (`POST /:id/silence { until }` REST;
   tRPC mutation for the UI's "Silence 1h") and rendered in list/status
   surfaces ("Silenced · 43 min left").
@@ -335,6 +365,12 @@ rule the UI or Langy can open. Dismissals persist per project + detector.
 The populated page shows at most one suggestion row (the artifact's "earns
 attention by being right" rule); the empty page may show more.
 
+Detectors read the ADR-034 analytics surfaces through `AnalyticsPort`
+(rollups preferred). They are a second entry point into the same composing
+flow that Langy's trace-card suggestions
+(`specs/langy/langy-followup-suggestions.feature`) already target — both
+pre-fill a plan; neither owns a separate creation path.
+
 ### 6. Slack app install
 
 Replace manual bot-token pasting with a proper OAuth v2 install flow. The
@@ -342,11 +378,18 @@ delivery machinery already exists (`chat.postMessage`, `conversations.list`,
 retryable-error classification, scope remediation copy); what is missing is
 acquisition and storage of the token.
 
-- **`SlackIntegration`** model: one per organization (projects select a
+- **`SlackIntegration`** model: **one per organization** (projects select a
   channel against the org install), storing the encrypted bot token, team
-  id/name, granted scopes, and installer. Encrypted at rest with the
-  existing secrets encryption; the token is never returned by any read
-  API (same write-only rule as §2).
+  id/name, granted scopes, and installer. Org-level is a deliberate tenancy
+  decision (ADR-021): a workspace connection is an organization asset — one
+  workspace, many projects — and per-project installs would demand N
+  authorizations of the same app for the same workspace. It does not weaken
+  ADR-031's per-project protections, which stay keyed on the project.
+  Installing and disconnecting require organization-admin permission; the
+  `installer` field records who. Tokens are sealed with the AES-256-GCM
+  secrets encryption ADR-040 established (`SecretSealPort` is the
+  package-side port over it); the token is never returned by any read API
+  (same write-only rule as §2).
 - **Install flow:** settings-initiated OAuth redirect → callback exchanges
   the code, stores the integration, returns to settings. Scopes:
   `chat:write`, `chat:write.public`, `channels:read`.
@@ -359,6 +402,11 @@ acquisition and storage of the token.
 - This also unblocks the ADR-041/044 deferred bot-token paths (threaded
   dashboard reports, `data_visualization` blocks) — not built here, but the
   token they were waiting for now exists.
+- **Egress note (ADR-053).** Slack Web API calls and webhook deliveries are
+  tenant-directed egress. The `clients/` module is the seam ADR-053's
+  isolated egress plane will take over when it ships; this ADR moves that
+  work neither forward nor backward, but the package boundary is drawn so
+  the relocation is a wiring change, not a rewrite.
 
 ### 7. The operator page — four states, taxonomy derived
 
@@ -382,7 +430,12 @@ redesign spec:
   healthy" strip. Recovery returns the page to quiet automatically.
 - **Copy:** the page is **Automations**; individual rows are **rules**
   ("+ New rule", "1 rule firing"). Kind badges say Alert / Schedule / On
-  trace — the internal enum names never surface.
+  trace — the internal enum names never surface. The vocabulary is
+  deliberately three-layered: the data layer keeps `Trigger`/`triggerKind`
+  (ADR-044's "rename nothing in the data layer" stands), the domain
+  package's entity is `Rule` with wire discriminator `kind`
+  (`automation`/`alert`/`report` ↔ `AUTOMATION`/`ALERT`/`REPORT`), and
+  product copy says rule / Alert / Schedule / On trace.
 - The staged authoring drawer (ADR-037/043, `authoring-drawer.feature`)
   remains as the **Edit details** escape hatch, pre-filled from a plan or an
   existing rule. It is no longer the primary creation path.
@@ -502,15 +555,19 @@ deliberately its own PR with the parity test suite as the gate.
 - Follow-ups deliberately out of scope: threaded Slack dashboard reports and
   `data_visualization` blocks over the bot token (ADR-041/044 deferrals),
   idempotency keys on API writes, per-severity throttling and quiet hours
-  (the ADR-043 cadence growth points), and MCP/CLI automation commands over
-  the new API.
+  (the ADR-043 cadence growth points), MCP/CLI automation commands over the
+  new API, and an ADR for `@langwatch/api` itself — this ADR originates
+  versioning/deprecation policy on a framework documented only by its
+  README, and that policy deserves its own decision record.
 
 ## References
 
 - Redesign artifact: "Automations, redesigned — state spec" (four page
   states; one creation entry point; taxonomy derived, not chosen; status
   leads; prose over stat cards; agent proposes, human approves).
-- ADR-037, ADR-040, ADR-041, ADR-043, ADR-044, ADR-045, ADR-052, ADR-060.
+- ADR-021, ADR-030, ADR-031, ADR-034, ADR-035, ADR-036, ADR-037, ADR-040,
+  ADR-041, ADR-043, ADR-044, ADR-045, ADR-052, ADR-053, ADR-058, ADR-059,
+  ADR-060 (in flight).
 - `langwatch/packages/api/README.md` — the versioned service builder.
 - `src/server/app-layer/automations/` — the service layer being moved.
 - `src/server/app-layer/automations/delivery/slackWebApi.ts` — the existing

--- a/langwatch/specs/automations/automations-list.feature
+++ b/langwatch/specs/automations/automations-list.feature
@@ -3,6 +3,12 @@ Feature: Seeing what your automations are doing
   I want to see what runs on a schedule, what reacts to events, and what already happened
   So that I can trust they still work — without opening each one
 
+  # Redesign note (ADR-063): the list presentation this file describes is
+  # being redesigned as the four-state page in
+  # specs/automations/page-states.feature ("rule" rows, prose header,
+  # incident takeover). The per-row facts and the global history surface
+  # specified here carry forward.
+
   Background:
     Given an automation fires when something matches
     And an alert fires when a metric crosses a threshold

--- a/langwatch/specs/monitors/slack-bot-delivery.feature
+++ b/langwatch/specs/monitors/slack-bot-delivery.feature
@@ -3,6 +3,11 @@ Feature: Slack delivery via a bot connection (Web API)
   I want to deliver via a Slack app (bot token), not only an incoming webhook
   So that the richer Block Kit blocks (charts, tables, alerts) actually render
 
+  # Acquisition note (ADR-063): manual bot-token entry is superseded by the
+  # Slack app install flow (specs/automations/slack-app-install.feature);
+  # existing tokens fold into the managed integration. Delivery semantics
+  # below are unchanged.
+
   Background:
     Given the incoming-webhook surface renders only a subset of Block Kit
     And the Web API (chat.postMessage) surface renders the newer blocks

--- a/specs/automations/agent-composing.feature
+++ b/specs/automations/agent-composing.feature
@@ -1,0 +1,72 @@
+Feature: Composing a rule from natural language
+
+  The user describes an outcome in their own words; the agent inspects the
+  project, fills the blanks, and answers with a plan that states the whole
+  rule in a few lines — including anything it must create along the way.
+  Nothing exists until the user approves. The unit of interaction is the
+  plan, not a form.
+
+  See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+
+  Background:
+    Given a user composing on the automations page
+
+  Rule: An intent becomes a reviewable plan
+
+    Scenario: A described intent produces a plan card
+      When the user describes wanting a Slack ping when daily model cost passes a limit
+      Then the agent answers with a plan stating what it will watch, what makes it fire, and where it notifies
+      And the plan offers approve, edit details, and cancel
+
+    Scenario: The plan derives the kind from the intent
+      When the user asks for a weekly quality digest to a Slack channel
+      Then the plan describes a scheduled digest
+      And the user is never asked to pick a rule kind
+
+    Scenario: Prerequisites are part of the plan, not homework
+      Given the metric the intent needs has no saved graph in the project
+      When the plan is presented
+      Then it states that the missing graph will be created as part of setup
+
+  Rule: Nothing is created before approval
+
+    Scenario: Approving executes the whole plan
+      Given a plan that includes creating a prerequisite graph
+      When the user approves
+      Then the prerequisite is created, then the rule
+      And the new rule appears in the list
+
+    Scenario: Cancelling leaves no trace
+      Given a presented plan
+      When the user cancels
+      Then no rule and no prerequisite is created
+
+    Scenario: A failing step surfaces as an explained error on the plan
+      Given a plan whose execution fails on a step
+      When the user approves
+      Then the plan shows which step failed and why in actionable terms
+      And nothing beyond the completed steps was created
+
+  Rule: The plan is a conversation, not a contract
+
+    Scenario: A correction updates the plan in place
+      Given a plan that notifies a Slack channel
+      When the user says to use email instead
+      Then the plan updates to notify by email and awaits approval again
+
+    Scenario: Edit details opens the full form pre-filled from the plan
+      Given a presented plan
+      When the user chooses edit details
+      Then the detailed form opens pre-filled with the plan's choices
+      And saving from the form creates the rule
+
+  Rule: The agent works within the same rules as the user
+
+    Scenario: The agent cannot exceed the user's permissions
+      Given the user cannot manage automations in this project
+      Then composing does not offer to create rules
+
+    Scenario: An approved plan validates like any other creation
+      Given a plan whose rule would be invalid
+      When the user approves
+      Then creation fails with the same validation behavior as the form

--- a/specs/automations/agent-composing.feature
+++ b/specs/automations/agent-composing.feature
@@ -7,6 +7,8 @@ Feature: Composing a rule from natural language
   plan, not a form.
 
   See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+  Related: specs/automations/authoring-drawer.feature — "edit details" opens
+  that staged form, and save-time validation is shared between both paths.
 
   Background:
     Given a user composing on the automations page
@@ -27,6 +29,12 @@ Feature: Composing a rule from natural language
       Given the metric the intent needs has no saved graph in the project
       When the plan is presented
       Then it states that the missing graph will be created as part of setup
+
+    Scenario: The plan states the delivery cadence before approval
+      Given an intent that results in a notification rule
+      When the plan is presented
+      Then it states how often the notification can fire
+      And approving the plan counts as having reviewed the cadence
 
   Rule: Nothing is created before approval
 

--- a/specs/automations/authoring-drawer.feature
+++ b/specs/automations/authoring-drawer.feature
@@ -14,6 +14,14 @@ Feature: Staged automation authoring drawer
 
   See dev/docs/adr/037-automation-operator-surfaces.md.
 
+  Scope note (ADR-063): this drawer is no longer the primary creation path.
+  Creation starts in the composing flow (specs/automations/page-states.feature,
+  specs/automations/agent-composing.feature); this staged form is the
+  "Edit details" escape hatch and the editor for existing automations. The
+  scenarios below — including the type picker and the cadence-review save
+  gate — describe the form path; a plan approved in composing states its
+  cadence on the plan card instead.
+
   Background:
     Given a user authoring an automation in a project
 

--- a/specs/automations/authoring-drawer.feature
+++ b/specs/automations/authoring-drawer.feature
@@ -20,7 +20,9 @@ Feature: Staged automation authoring drawer
   "Edit details" escape hatch and the editor for existing automations. The
   scenarios below — including the type picker and the cadence-review save
   gate — describe the form path; a plan approved in composing states its
-  cadence on the plan card instead.
+  cadence on the plan card instead. The settings- and traces-view entries
+  below remain as secondary creation shortcuts straight into this form,
+  pre-filled where noted; the page's own new-rule action opens composing.
 
   Background:
     Given a user authoring an automation in a project

--- a/specs/automations/customer-api.feature
+++ b/specs/automations/customer-api.feature
@@ -1,0 +1,113 @@
+Feature: Versioned automations customer API
+
+  Customers and their agents manage automation rules through a versioned,
+  RPC-shaped API: every operation is a verb-named call with exactly one
+  input and one output contract, so an agent binds tools to operations
+  one-to-one. The three rule kinds (on-trace automation, alert, scheduled
+  report) share one rule shape discriminated by kind. Reads can never
+  return secret material, and every failure is a typed handled error with
+  remediation the caller can act on.
+
+  See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+
+  Background:
+    Given a project with a valid API key
+
+  Rule: Operations are versioned and self-describing
+
+    Scenario: Calling a pinned version keeps working after newer versions ship
+      Given a rule was created through a dated API version
+      When a newer API version is released
+      Then calls pinned to the original version behave as they did before
+
+    Scenario: The API documents every operation
+      When the caller fetches the API's reference document
+      Then every operation appears with its input contract, output contract, and error envelope
+      And each operation is named after the action it performs
+
+  Rule: One rule shape covers the three kinds
+
+    Scenario: Creating an alert rule
+      When the caller creates a rule of kind alert watching a metric with a threshold and severity
+      Then the rule is created and listed with its kind
+
+    Scenario: Creating a scheduled report rule
+      When the caller creates a rule of kind report with a calendar schedule, timezone, and content source
+      Then the rule is created and its next run time is available
+
+    Scenario: Creating an on-trace rule that collects into a dataset
+      When the caller creates a rule of kind automation with trace conditions and a dataset destination
+      Then the rule is created and matching traces are added to the dataset
+
+    Scenario: Facets from the wrong kind are rejected
+      When the caller creates a rule of kind report carrying an alert threshold
+      Then the call fails as a validation error naming the offending field
+
+  Rule: Delivery covers every channel
+
+    Scenario Outline: A rule can deliver to any supported channel
+      When the caller creates a rule delivering to <channel>
+      Then the rule is created and fires deliver to <channel>
+
+      Examples:
+        | channel                |
+        | a Slack channel        |
+        | an HTTP webhook        |
+        | email recipients       |
+        | a dataset              |
+        | an annotation queue    |
+
+  Rule: Secrets are write-only
+
+    Scenario: Reading a rule masks its delivery secrets
+      Given a rule delivering to a Slack incoming webhook
+      When the caller reads the rule
+      Then the webhook address is masked
+      And no operation returns the stored secret in full
+
+    Scenario: Updating a rule without resending a secret keeps it
+      Given a rule with a stored webhook secret
+      When the caller updates the rule's name without providing the secret
+      Then the stored secret is unchanged and deliveries keep working
+
+  Rule: Failures are handled errors with remediation
+
+    Scenario: Operating on a rule that does not exist
+      When the caller reads a rule id that does not exist in the project
+      Then the call fails with a stable not-found code
+
+    Scenario: A rule from another project is not reachable
+      Given a rule that belongs to a different project
+      When the caller reads that rule id
+      Then the call fails with the same not-found code as a missing rule
+
+    Scenario: Customer-actionable failures explain themselves
+      When a call fails for a reason the caller can fix
+      Then the error carries a stable code, remediation tips, and a documentation link
+
+  Rule: Runtime state is queryable
+
+    Scenario: Checking a rule's health
+      Given an alert rule that is currently firing
+      When the caller asks for the rule's status
+      Then the status reports it as firing with when it last fired
+
+    Scenario: Listing a rule's fire history
+      Given a rule that has fired
+      When the caller lists the rule's fires
+      Then each fire shows when it fired and where it delivered
+
+    Scenario: A test fire is unmistakably a test
+      When the caller test-fires a rule
+      Then a delivery arrives at the configured destination marked as a test
+
+  Rule: The legacy triggers API is deprecated
+
+    Scenario: Legacy calls are told to migrate
+      When a caller uses the legacy triggers API
+      Then the response signals deprecation and points at the replacement
+
+    Scenario: The legacy API is removed after the migration window
+      Given the migration window has passed
+      When a caller uses the legacy triggers API
+      Then the call fails as gone

--- a/specs/automations/customer-api.feature
+++ b/specs/automations/customer-api.feature
@@ -9,6 +9,11 @@ Feature: Versioned automations customer API
   remediation the caller can act on.
 
   See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+  Related: specs/features/domain-error-contract.feature (the error contract
+  these scenarios conform to), specs/automations/dispatch-timing.feature and
+  specs/automations/spam-prevention.feature (channel timing and abuse caps),
+  and specs/features/trigger-cli.feature (a consumer of the legacy surface
+  this replaces).
 
   Background:
     Given a project with a valid API key
@@ -98,8 +103,14 @@ Feature: Versioned automations customer API
       Then each fire shows when it fired and where it delivered
 
     Scenario: A test fire is unmistakably a test
-      When the caller test-fires a rule
+      When the caller test-fires a rule delivering to Slack or a webhook
       Then a delivery arrives at the configured destination marked as a test
+
+    Scenario: An email test fire is refused over the API
+      Given a rule delivering to email recipients
+      When the caller test-fires it
+      Then the call fails with a stable code saying email test fires are app-only
+      And the error's tips point at the in-app test fire, which delivers only to the requesting user's own inbox
 
   Rule: The legacy triggers API is deprecated
 

--- a/specs/automations/dispatch-timing.feature
+++ b/specs/automations/dispatch-timing.feature
@@ -20,6 +20,11 @@ Feature: Per-trigger dispatch timing — cadence and trace-readiness debounce
   See dev/docs/adr/026-per-trigger-dispatch-timing.md and
   dev/docs/adr/052-automations-on-process-manager-substrate.md.
 
+  Silence note (ADR-063): specs/automations/silence.feature adds a temporary
+  suppression gate in front of every effect below — a silenced trigger's
+  notify and persist dispatches are suppressed while the silence lasts. The
+  scenarios in this file assume an unsilenced trigger.
+
   Background:
     Given a project with automations enabled
 

--- a/specs/automations/page-states.feature
+++ b/specs/automations/page-states.feature
@@ -7,6 +7,10 @@ Feature: Automations page — one page, four states
   rules.
 
   See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+  Related: specs/automations/authoring-drawer.feature (the detailed form the
+  page links to as "Edit details") and
+  langwatch/specs/automations/automations-list.feature (the prior list spec;
+  its per-row facts and global fire-history surface carry forward).
 
   Background:
     Given a user on the automations page of their project

--- a/specs/automations/page-states.feature
+++ b/specs/automations/page-states.feature
@@ -74,7 +74,7 @@ Feature: Automations page — one page, four states
       Then the incident presentation clears without user action
       And the header returns to the quiet summary
 
-  Rule: Creation always starts from one entry point
+  Rule: The new-rule entry always opens composing
 
     Scenario: The new-rule action opens composing regardless of state
       When the user chooses to create a new rule

--- a/specs/automations/page-states.feature
+++ b/specs/automations/page-states.feature
@@ -1,0 +1,83 @@
+Feature: Automations page — one page, four states
+
+  The automations page is a single lifecycle surface: describe an intent,
+  approve a plan, manage one list, respond to fires. Which state the page
+  is in is derived from the project's rules — the user never picks a tab
+  or a taxonomy. The page is called Automations; individual rows are
+  rules.
+
+  See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+
+  Background:
+    Given a user on the automations page of their project
+
+  Rule: The empty state asks for intent, not taxonomy
+
+    Scenario: A project with no rules sees one question
+      Given the project has no rules
+      Then the page asks what should happen automatically
+      And offers three outcomes in plain language: be told when a metric crosses a line, receive a recurring digest, and act on matching traces
+      And offers a free-text way to describe the intent
+      And no statistics, tabs, or kind pickers are shown
+
+    Scenario: An outcome card starts a composing flow with the intent framed
+      Given the project has no rules
+      When the user picks the recurring-digest outcome
+      Then composing starts already framed as a scheduled digest
+
+  Rule: The populated state is one list where every rule reads as a sentence
+
+    Scenario: All kinds live in one list
+      Given the project has alert, schedule, and on-trace rules
+      Then all rules appear in one list
+      And each row leads with a status indicator and reads as a condition and its outcome
+      And each row trails with its kind badge: Alert, Schedule, or On trace
+
+    Scenario: The header summarizes health as prose
+      Given no rule is firing
+      Then the page header says all is quiet and names the next scheduled run
+      And no stat cards are shown
+
+    Scenario: Rows carry the detail that matters for their kind
+      Then an alert row shows its health and when it last fired
+      And a schedule row shows its next run
+      And an on-trace row shows how many traces it matched recently
+
+    Scenario: Filtering by kind
+      When the user filters the list to alerts
+      Then only alert rules are shown with their count
+
+    Scenario: Sorting leads with what needs attention
+      Given one rule is unhealthy and others are quiet
+      Then the unhealthy rule sorts above the quiet ones
+      And ties break by most recent activity
+
+  Rule: The firing state turns the page into an incident view
+
+    Scenario: A firing alert takes over the top of the page
+      Given an alert rule is firing
+      Then the firing rule is promoted above the list as an incident
+      And the incident shows the current value, how long it has been firing, where it notified, and how often it fired recently
+      And the incident offers to view the matching traces
+      And the incident offers to silence the rule for an hour
+
+    Scenario: Healthy rules step back during an incident
+      Given an alert rule is firing
+      Then the remaining rules are visually de-emphasized under a note that everything else is healthy
+
+    Scenario: Recovery returns the page to quiet on its own
+      Given the firing alert recovers
+      Then the incident presentation clears without user action
+      And the header returns to the quiet summary
+
+  Rule: Creation always starts from one entry point
+
+    Scenario: The new-rule action opens composing regardless of state
+      When the user chooses to create a new rule
+      Then the composing flow opens
+      And the detailed form remains reachable from composing for users who want every control
+
+    Scenario: Editing an existing rule opens the detailed form pre-filled
+      Given an existing rule
+      When the user edits it
+      Then the detailed form opens with every section pre-filled

--- a/specs/automations/process-manager-dispatch.feature
+++ b/specs/automations/process-manager-dispatch.feature
@@ -6,6 +6,10 @@ Feature: Automation dispatch on the process-manager substrate
   ADR-031, graph alerts per ADR-034, persist class per ADR-035, templates per
   ADR-036/041, and webhook delivery per ADR-040.)
 
+  Silence note (ADR-063): specs/automations/silence.feature adds a
+  suppression gate ahead of intent effects — these scenarios assume an
+  unsilenced automation.
+
   Background:
     Given a project with active automations
 

--- a/specs/automations/silence.feature
+++ b/specs/automations/silence.feature
@@ -1,0 +1,65 @@
+Feature: Silencing a rule
+
+  Silence is a temporary mute: the rule keeps evaluating and keeps its
+  history honest, but its effects — notifications and persist actions —
+  are suppressed until the silence expires. It is the incident view's
+  "shut it up for a bit", distinct from disabling, which is the permanent
+  off-switch.
+
+  See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+
+  Background:
+    Given a project with an alert rule that is firing
+
+  Rule: Silence suppresses effects, not evaluation
+
+    Scenario: A silenced alert stops notifying
+      When the user silences the rule for an hour
+      Then no notifications are delivered while the silence lasts
+
+    Scenario: A silenced rule still tracks what happened
+      Given the rule is silenced
+      When matching activity continues
+      Then the rule's firing state stays current
+      And the history records that fires were suppressed by the silence
+
+    Scenario: A silenced on-trace rule stops acting
+      Given an on-trace rule that adds traces to a dataset is silenced
+      When a matching trace arrives
+      Then nothing is added to the dataset while the silence lasts
+
+  Rule: Silence expires on its own
+
+    Scenario: Effects resume when the silence ends
+      Given the rule was silenced for an hour
+      When the hour passes and the condition still holds
+      Then notifications resume without user action
+
+    Scenario: Un-silencing early restores effects immediately
+      Given the rule is silenced
+      When the user removes the silence
+      Then effects resume immediately
+
+  Rule: Silence is visible everywhere the rule is
+
+    Scenario: The list shows the silence and its remaining time
+      Given the rule is silenced
+      Then the rule's row shows it is silenced and roughly how long remains
+
+    Scenario: Silence is available to API callers
+      Given a caller using the customer API
+      When the caller silences the rule until a stated time
+      Then the rule reports itself silenced until that time
+      And the caller can remove the silence
+
+  Rule: Silence and disable stay distinct
+
+    Scenario: Disabling is not silencing
+      Given the rule is disabled
+      Then it does not evaluate at all
+      And it is presented as off, not silenced
+
+    Scenario: A silence does not outlive its purpose
+      Given the rule is silenced
+      When the rule is edited
+      Then the silence remains in force until it expires or is removed

--- a/specs/automations/silence.feature
+++ b/specs/automations/silence.feature
@@ -7,6 +7,11 @@ Feature: Silencing a rule
   off-switch.
 
   See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+  Related: specs/automations/dispatch-timing.feature,
+  specs/automations/process-manager-dispatch.feature, and
+  specs/triggers/event-sourced-graph-triggers.feature — their dispatch and
+  notify scenarios assume an unsilenced rule; silence adds a suppression
+  gate in front of every effect they describe.
 
   Background:
     Given a project with an alert rule that is firing

--- a/specs/automations/slack-app-install.feature
+++ b/specs/automations/slack-app-install.feature
@@ -7,6 +7,10 @@ Feature: Slack app install for automations delivery
   the platform and can never be read back.
 
   See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+  Related: langwatch/specs/monitors/slack-bot-delivery.feature (the manual
+  bot-token model this install flow supersedes for acquisition — delivery
+  semantics are unchanged) and
+  specs/automations/notification-templates.feature.
 
   Background:
     Given an organization admin in integration settings

--- a/specs/automations/slack-app-install.feature
+++ b/specs/automations/slack-app-install.feature
@@ -1,0 +1,68 @@
+Feature: Slack app install for automations delivery
+
+  Installing the LangWatch Slack app connects an organization's workspace
+  once, so rules deliver by picking a channel instead of pasting webhook
+  addresses or tokens. Incoming webhooks keep working; the app is the
+  easier path, not a forced migration. The workspace credential is held by
+  the platform and can never be read back.
+
+  See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+
+  Background:
+    Given an organization admin in integration settings
+
+  Rule: Installing connects the workspace once
+
+    Scenario: Installing the Slack app
+      When the admin installs the Slack app and authorizes it in their workspace
+      Then settings show the connected workspace by name
+      And projects in the organization can deliver rules to its channels
+
+    Scenario: A failed authorization leaves nothing connected
+      When the admin abandons or fails the Slack authorization
+      Then no workspace is connected
+      And settings explain that the install did not complete
+
+    Scenario: The workspace credential is write-only
+      Given a connected workspace
+      Then no surface returns the workspace credential
+      And settings show only the workspace identity and granted permissions
+
+  Rule: Rules deliver by channel
+
+    Scenario: Configuring delivery by picking a channel
+      Given a connected workspace
+      When a user configures a rule's Slack delivery
+      Then they pick from the workspace's channels by name
+      And the rule delivers to the picked channel
+
+    Scenario: Incoming webhooks remain supported
+      Given no connected workspace
+      When a user configures a rule's Slack delivery
+      Then delivery by incoming webhook is available as before
+
+    Scenario: A previously pasted token folds into the integration
+      Given the organization previously used a manually provided workspace token
+      Then existing rules keep delivering
+      And settings offer the app install as the managed replacement
+
+  Rule: Delivery failures explain what to fix
+
+    Scenario: The app is not in the channel
+      Given a rule delivering to a channel the app cannot post to
+      When the rule fires
+      Then the delivery failure explains how to let the app post there
+
+    Scenario: A revoked install stops deliveries with a clear reason
+      Given the workspace authorization was revoked in Slack
+      When a rule fires
+      Then the delivery failure explains the workspace must be reconnected
+      And settings show the integration needs attention
+
+  Rule: Disconnecting is deliberate
+
+    Scenario: Disconnecting the workspace
+      Given a connected workspace with rules delivering to its channels
+      When the admin disconnects it
+      Then they are warned which rules will stop delivering
+      And after confirming, those rules report a delivery configuration problem

--- a/specs/automations/spam-prevention.feature
+++ b/specs/automations/spam-prevention.feature
@@ -9,6 +9,11 @@ Feature: Trigger email spam prevention
 
   See dev/docs/adr/031-trigger-email-abuse-protections.md.
 
+  API surface note (ADR-063): the customer API refuses email test fires
+  outright — an API key carries no requester inbox to deliver to (see
+  specs/automations/customer-api.feature). The requester-inbox rule below
+  is the in-app behavior.
+
   Background:
     Given a project with automations enabled
 

--- a/specs/automations/suggestions.feature
+++ b/specs/automations/suggestions.feature
@@ -1,0 +1,58 @@
+Feature: Automation suggestions from project activity
+
+  The page seeds itself with suggestions computed from what actually
+  happened in the project — gaps between recent activity and the rules
+  that exist. Suggestions are deterministic facts with a pre-filled rule
+  attached, so accepting one is a review, not a chore. Suggestions earn
+  attention by being right: they are few, dismissible, and never louder
+  than the user's own rules.
+
+  See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+
+  Background:
+    Given a project with recent traffic
+
+  Rule: Suggestions surface real gaps
+
+    Scenario: An error spike with no alert suggests an error alert
+      Given error rates spiked in the recent period
+      And no active rule alerts on errors
+      Then the page suggests an error alert citing how often it spiked
+
+    Scenario: Failing evaluations going nowhere suggest a collection rule
+      Given traces failed evaluations in the recent period
+      And no rule collects failing traces into a dataset or review queue
+      Then the page suggests collecting them, citing the count
+
+    Scenario: Growing spend with no cost alert suggests one
+      Given model spend grew substantially against the previous period
+      And no active rule alerts on cost
+      Then the page suggests a cost alert
+
+    Scenario: A covered gap is not suggested
+      Given error rates spiked in the recent period
+      And an active rule already alerts on errors
+      Then no error-alert suggestion is shown
+
+  Rule: Suggestions stay quiet
+
+    Scenario: The populated page shows at most one suggestion
+      Given several suggestions apply to the project
+      When the user views the populated page
+      Then only one suggestion row is shown
+
+    Scenario: The empty page may show more
+      Given the project has no rules and several suggestions apply
+      Then up to a few suggestions are shown beneath the outcome cards
+
+    Scenario: Dismissing a suggestion keeps it away
+      When the user dismisses a suggestion
+      Then it does not return on later visits
+      And other suggestions may take its place
+
+  Rule: Accepting a suggestion is a review, not a blank form
+
+    Scenario: Setting up a suggestion opens a pre-filled plan
+      When the user sets up a suggestion
+      Then composing opens with the suggested rule already filled in
+      And the user approves or adjusts it like any composed plan

--- a/specs/automations/suggestions.feature
+++ b/specs/automations/suggestions.feature
@@ -8,6 +8,8 @@ Feature: Automation suggestions from project activity
   than the user's own rules.
 
   See dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md.
+  Related: specs/langy/langy-followup-suggestions.feature — Langy's trace
+  cards are a second path into the same pre-filled composing flow.
 
   Background:
     Given a project with recent traffic

--- a/specs/features/trigger-cli.feature
+++ b/specs/features/trigger-cli.feature
@@ -3,6 +3,11 @@ Feature: Trigger (Automation) CLI Commands
   I want to manage triggers via CLI commands
   So that I can set up automated alerts and actions without using the UI
 
+  # Deprecation note (ADR-063): these commands drive the legacy /api/triggers
+  # surface, which is deprecated and will be removed after a migration
+  # window. The CLI migrates to the versioned automations API
+  # (specs/automations/customer-api.feature).
+
   Background:
     Given I have a valid LANGWATCH_API_KEY configured
 

--- a/specs/triggers/event-sourced-graph-triggers.feature
+++ b/specs/triggers/event-sourced-graph-triggers.feature
@@ -7,6 +7,11 @@ Feature: Event-sourced custom-graph threshold alerts
   # reactor fires on fold updates and the 30s heartbeat covers no-data and
   # resolve. The K8s cron that used to share this work was removed once every
   # project had cut over (ADR-034).
+  #
+  # Silence (ADR-063, specs/automations/silence.feature): a silenced trigger
+  # keeps evaluating and recording incidents, but its notifications are
+  # suppressed until the silence expires. These scenarios assume an
+  # unsilenced trigger.
 
   Background:
     Given a project owns active custom-graph triggers


### PR DESCRIPTION
## What

Planning documents for the automations rework: one umbrella ADR, six new behavioural specs, and corpus reconciliation (amendments + cross-links) from a full `/review-spec` audit. No code changes.

- **ADR-063** (`dev/docs/adr/063-automations-domain-packages-customer-api-and-agent-surface.md`) — includes the complete `@langwatch/automations-server` package structure (every current `app-layer/automations` module has a named destination), the injected-ports contract, and enforced dependency rules
- **New specs** (`specs/automations/`): `customer-api`, `page-states`, `agent-composing`, `suggestions`, `silence`, `slack-app-install`
- **Supersession amendments** on ADR-037/043/044/052 (dated, partial — every other contract in those ADRs stands)
- **Scope/silence/deprecation notes** on 8 corpus specs (authoring-drawer, dispatch-timing, process-manager-dispatch, spam-prevention, event-sourced-graph-triggers, automations-list, slack-bot-delivery, trigger-cli)

## The decision, in short

The automations engine (ADR-052 substrate, scheduler, reports, five delivery actions) is built; what's fragmented is everything around it. This ADR:

1. **Two packages, one dependency direction** — `@langwatch/automations` (domain models, contracts, repository interfaces, providers, templating) stays pure and light; new `@langwatch/automations-server` (services, dispatch, clients, event-sourcing logic, the customer API factory) depends on it. The app keeps only DB implementations, pipeline wiring, a thinned tRPC router, and React.
2. **RPC-shaped versioned customer API** — first `@langwatch/api` adopter at `/api/automations/2026-08-01/…`. Verb-named operations (`create_rule`, `silence_rule`, `test_fire_rule`, …), one input + one output schema each, so agents bind tools to operations 1:1. Kind-discriminated rule union, secrets write-only with masked reads, HandledError + tips/docsUrl on every failure (ADR-045). Auth is the existing project API key. `/api/triggers` deprecated, removed after a window.
3. **New primitives** — `silencedUntil` (suppresses effects incl. persist actions, keeps evaluating — placement per ADR-030's reservation), deterministic suggestion detectors over the ADR-034 analytics port, Slack app OAuth install (org-level per ADR-021 tenancy, AES-256-GCM-sealed token per ADR-040, channel picker; manual bot-token path folds in).
4. **Four-state operator page** — empty / composing / populated / firing; taxonomy derived, not chosen; "rule" rows; incident takeover with Silence 1h; the staged drawer demotes to the Edit-details escape hatch (settings/traces-view entries stay as secondary shortcuts).
5. **Langy composes, the human approves** — NL intent → derived plan card (ADR-059 lineage; ADR-060 is the in-flight dependency, and this ADR must not be accepted ahead of it) → approve executes, prerequisites included. The plan card states the notification cadence, so approval counts as the cadence review.

Phasing P1–P8 in the ADR: package restructure first (zero behaviour change), then API / silence / page / suggestions / Slack OAuth in parallel, Langy composing last, legacy removal at the end.

## Review

Audited with `/review-spec` (two corpus sweeps) + an adversarial verify round. All P0 findings resolved in-branch: creation-entry and cadence-gate conflicts (composing plans state their cadence; drawer re-scoped), email test-fire policy (API refuses email test fires — ADR-031's requester-inbox rule needs a session user), supersessions made explicit, ADR-032 mis-citation dropped, all 18 cross-link paths verified.

## Judgment calls worth attention

Silence also pauses persist-class actions; all API operations are POSTs (including reads) for the tool-call shape; Slack integration is org-scoped with org-admin install; numbered 063 because 056/057/060–062 are claimed by in-flight work.

## Deployment Impact

No deployment impact — docs-only. This PR adds/amends ADRs and Gherkin specs (planning documents); no code, charts, services, migrations, or env changes ship here. The deployment-relevant work (new packages, customer API route, Prisma migrations for silence/Slack integration) lands in the P1–P8 implementation PRs, each of which will carry its own impact section.

## Program task list (P2–P8, each its own PR per ADR-063 §9)

P1 restructure is in flight on #6054 — file-level checklist lives there.
- [ ] **P2 — customer API v1** (`2026-08-01`): `contracts/` DTO unions with redacted read schemas; `api/service.ts` factory + one module per RPC operation (`create_rule` … `list_slack_channels`); mount at `src/app/api/automations/[[...route]]`; `Deprecation`+`Sunset` headers on `/api/triggers`; OpenAPI complete; HandledError with tips/docsUrl on every failure
- [ ] **P3 — silence**: `silencedUntil` migration; dispatch-layer suppression gate (before effects, per ADR-030's placement); both transports; suppressed fires recorded in history
- [ ] **P4 — four-state page** behind `release_automations_redesign`: empty/composing(→drawer until P7)/populated/firing; sentence rows; incident takeover; Silence 1h; drawer demoted to Edit details
- [ ] **P5 — suggestions**: three deterministic detectors over AnalyticsPort; SuggestionDismissal store; one-row cap populated, more on empty
- [ ] **P6 — Slack app OAuth**: SlackIntegration model (org-level, AES-256-GCM-sealed token); install/callback flow; channel picker; `slack: {mode}` delivery union; manual-token fold-in
- [ ] **P7 — Langy composing**: authoring tools over the domain services; ADR-060 plan cards (merge-order dependency!); approve-executes with prerequisites
- [ ] **P8 — `/api/triggers` removal** after the migration window (+ CLI migration off it, `trigger-cli.feature` update)

### Standing items (outside the PR chain)
- [ ] Rotate the expired `OPENAI_API_KEY` CI secret (org admin — sdk-python-ci red on main too)
- [ ] ADR-060 must merge before #6052 is accepted (plan-card dependency)
- [ ] MCP/CLI automation commands over the new API (deferred follow-up per ADR)
