### PR TITLE
fix(ci): pin the ClickHouse image so a rolled `latest` can't break e2e

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -108,7 +108,7 @@ jobs:
           --health-retries 5
 
       clickhouse:
-        image: clickhouse/clickhouse-server:latest
+        image: clickhouse/clickhouse-server:25.10.2.65
         ports:
           - 8123:8123
         env:

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -107,7 +107,7 @@ jobs:
 
     services:
       clickhouse:
-        image: clickhouse/clickhouse-server:latest
+        image: clickhouse/clickhouse-server:25.10.2.65
         ports:
           - 8123:8123
         env:


### PR DESCRIPTION
## Symptom

`e2e` began failing on every branch a few hours after passing on `main` (green at 19:59 on `73f73d7fe`), with no migration diff in between. It dies in DB setup, before any test runs:

```
goose run: ERROR 00017_create_gateway_budget_ledger.sql: failed to run SQL migration:
Code: 36. DB::Exception: Column(s) UpdatedAt of the AggregatingMergeTree table are
neither part of the sorting key nor aggregate measures ... (BAD_ARGUMENTS)
(version 26.7.1.1315)
```

## Cause

`e2e-ci.yml` and `sdk-javascript-ci.yml` pull `clickhouse/clickhouse-server:**latest**`. That tag rolled to **26.7.1.1315**, which tightened `AggregatingMergeTree` validation: a non-key column that isn't an aggregate state is now a hard error, where older servers allowed it. `00017_create_gateway_budget_ledger.sql` (shipped in #3327, unchanged since) has exactly that shape (`UpdatedAt` outside `ORDER BY`), so goose fails and the whole job dies.

Nothing in the repo changed — the server image under the workflow did. An unpinned server image makes CI a function of whatever Docker Hub serves that hour.

## Fix

Pin both workflows to `clickhouse/clickhouse-server:25.10.2.65` — the version the integration suite already builds its container from (`event-sourcing/__tests__/integration/globalSetup.ts:290`) and migrates `00017` against green. This only narrows CI to a version the repo **already trusts**; it introduces no new dependency.

Bumping ClickHouse — and making `00017` compatible with a stricter server (add `UpdatedAt` to `ORDER BY`, or `allow_dimensions_outside_sorting_key=1`, in a **new** migration since 00017 is deployed) — becomes a deliberate PR instead of a surprise from a moving tag.

## Deployment Impact

CI-only. Touches two GitHub Actions workflow files; no product code, no runtime image, no migration. It pins a test-time service image to a version already used elsewhere in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the test environment by pinning the database service to a specific version.
  * Improved consistency and reproducibility across end-to-end test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->