### PR TITLE
fix(langy): harden GitHub App installation binding at /setup

### DIFF
--- a/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
@@ -23,6 +23,7 @@ function makeRepo(
   rows: LangyGithubInstallationRow[] = [],
 ): LangyGithubInstallationsRepository & {
   upsert: ReturnType<typeof vi.fn>;
+  insertOrGetExisting: ReturnType<typeof vi.fn>;
   deleteByInstallationId: ReturnType<typeof vi.fn>;
   setSuspended: ReturnType<typeof vi.fn>;
   setRepositories: ReturnType<typeof vi.fn>;
@@ -36,6 +37,25 @@ function makeRepo(
       async (id: string) => byId.get(id) ?? null,
     ),
     upsert: vi.fn(async (_i: UpsertLangyGithubInstallationInput) => {}),
+    // Mirrors the real unique-index semantics: the read (`byId.get`) and the
+    // write (`byId.set`) below have no `await` between them, so this function
+    // body runs to completion in one microtask turn — exactly like a DB
+    // unique-constraint `INSERT` — which is what makes the race test below a
+    // real regression test rather than a coincidence of mock timing.
+    insertOrGetExisting: vi.fn(
+      async (input: UpsertLangyGithubInstallationInput) => {
+        const existing = byId.get(input.installationId);
+        if (existing) return { inserted: false, row: existing };
+        const created: LangyGithubInstallationRow = {
+          ...input,
+          suspendedAt: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        byId.set(input.installationId, created);
+        return { inserted: true, row: created };
+      },
+    ),
     setRepositories: vi.fn(async () => {}),
     setSuspended: vi.fn(async () => {}),
     deleteByInstallationId: vi.fn(async () => 1),
@@ -94,7 +114,7 @@ function makeAppTokens(
 }
 
 describe("recordInstallation", () => {
-  it("maps GitHub's installation metadata onto the upsert", async () => {
+  it("maps GitHub's installation metadata onto the atomic insert", async () => {
     const repo = makeRepo();
     const svc = new LangyGithubInstallationsService(repo, makeAppTokens());
     const result = await svc.recordInstallation({
@@ -102,7 +122,7 @@ describe("recordInstallation", () => {
       organizationId: "org-1",
     });
     expect(result.accountLogin).toBe("acme");
-    expect(repo.upsert).toHaveBeenCalledWith(
+    expect(repo.insertOrGetExisting).toHaveBeenCalledWith(
       expect.objectContaining({
         installationId: "inst-1",
         organizationId: "org-1",
@@ -111,6 +131,9 @@ describe("recordInstallation", () => {
         repositorySelection: "all",
       }),
     );
+    // A brand-new installation is claimed by the atomic insert alone — the
+    // same-org refresh path (`upsert`) never runs.
+    expect(repo.upsert).not.toHaveBeenCalled();
   });
 
   describe("when the installation is already owned by a different organization", () => {
@@ -127,6 +150,58 @@ describe("recordInstallation", () => {
         }),
       ).rejects.toBeInstanceOf(LangyGithubInstallationConflictError);
 
+      expect(repo.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when two organizations race for the same fresh installation", () => {
+    it("lets only the first writer claim it; the second sees the committed org and rejects", async () => {
+      // Regression test for the TOCTOU the old check-then-upsert code had:
+      // a separate `findByInstallationId` read followed by a later `upsert`
+      // left an await-gap where two concurrent /setup calls could both
+      // observe "unclaimed" and both write, the second silently overwriting
+      // the first's org. `insertOrGetExisting` closes that gap by making the
+      // claim atomic (see the fake repo's comment above) — this test would
+      // have failed (both promises fulfilling, no rejection) under the old
+      // read-then-write code.
+      const repo = makeRepo();
+      // The stub must echo back the requested id — the default stub returns a
+      // fixed "inst-1" regardless of input, which would key both calls' rows
+      // under the same constant and hide the race this test exists to catch.
+      const appTokens = makeAppTokens({
+        getInstallation: vi.fn(async (installationId: string) => ({
+          installationId,
+          accountLogin: "acme",
+          accountType: "Organization",
+          accountId: "9000",
+          repositorySelection: "all",
+        })),
+      });
+      const svc = new LangyGithubInstallationsService(repo, appTokens);
+
+      const results = await Promise.allSettled([
+        svc.recordInstallation({
+          installationId: "inst-race",
+          organizationId: "org-a",
+        }),
+        svc.recordInstallation({
+          installationId: "inst-race",
+          organizationId: "org-b",
+        }),
+      ]);
+
+      const fulfilled = results.filter((r) => r.status === "fulfilled");
+      const rejected = results.filter((r) => r.status === "rejected");
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+        LangyGithubInstallationConflictError,
+      );
+
+      // Exactly one org ends up owning the installation — never both, never
+      // neither.
+      const winner = await repo.findByInstallationId("inst-race");
+      expect(["org-a", "org-b"]).toContain(winner?.organizationId);
       expect(repo.upsert).not.toHaveBeenCalled();
     });
   });

--- a/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
@@ -156,14 +156,14 @@ describe("recordInstallation", () => {
 
   describe("when two organizations race for the same fresh installation", () => {
     it("lets only the first writer claim it; the second sees the committed org and rejects", async () => {
-      // Regression test for the TOCTOU the old check-then-upsert code had:
-      // a separate `findByInstallationId` read followed by a later `upsert`
-      // left an await-gap where two concurrent /setup calls could both
-      // observe "unclaimed" and both write, the second silently overwriting
-      // the first's org. `insertOrGetExisting` closes that gap by making the
-      // claim atomic (see the fake repo's comment above) — this test would
-      // have failed (both promises fulfilling, no rejection) under the old
-      // read-then-write code.
+      // Pins the SERVICE's interpretation of an atomic repo result: given a
+      // repo that reports "claimed" for exactly one caller, the service must
+      // reject the other with the conflict error rather than, say, both
+      // succeeding or both throwing. The fake models atomicity synchronously
+      // (see its comment above) to exercise that branch — it does NOT prove
+      // Postgres actually serializes the concurrent writes; that guarantee is
+      // proven against a real database in
+      // langy-github-installations.prisma.repository.integration.test.ts.
       const repo = makeRepo();
       // The stub must echo back the requested id — the default stub returns a
       // fixed "inst-1" regardless of input, which would key both calls' rows

--- a/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
@@ -45,7 +45,7 @@ function makeRepo(
     insertOrGetExisting: vi.fn(
       async (input: UpsertLangyGithubInstallationInput) => {
         const existing = byId.get(input.installationId);
-        if (existing) return { inserted: false, row: existing };
+        if (existing) return { wasInserted: false, row: existing };
         const created: LangyGithubInstallationRow = {
           ...input,
           suspendedAt: null,
@@ -53,7 +53,7 @@ function makeRepo(
           updatedAt: new Date(),
         };
         byId.set(input.installationId, created);
-        return { inserted: true, row: created };
+        return { wasInserted: true, row: created };
       },
     ),
     setRepositories: vi.fn(async () => {}),

--- a/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/langy-github-installations.service.unit.test.ts
@@ -8,7 +8,10 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-import { LangyGithubInstallationsService } from "../langy-github-installations.service";
+import {
+  LangyGithubInstallationConflictError,
+  LangyGithubInstallationsService,
+} from "../langy-github-installations.service";
 import { computeRepoScopeKey } from "../langyGithubAppToken";
 import type {
   LangyGithubInstallationRow,
@@ -108,6 +111,43 @@ describe("recordInstallation", () => {
         repositorySelection: "all",
       }),
     );
+  });
+
+  describe("when the installation is already owned by a different organization", () => {
+    it("rejects the rebind and never upserts (cross-tenant takeover guard)", async () => {
+      // inst-1 already belongs to org-1; a /setup call bound to org-2 (an
+      // attacker's own org, with a valid signed state) must not steal it.
+      const repo = makeRepo([row({ installationId: "inst-1", organizationId: "org-1" })]);
+      const svc = new LangyGithubInstallationsService(repo, makeAppTokens());
+
+      await expect(
+        svc.recordInstallation({
+          installationId: "inst-1",
+          organizationId: "org-2",
+        }),
+      ).rejects.toBeInstanceOf(LangyGithubInstallationConflictError);
+
+      expect(repo.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the same organization re-installs the same installation", () => {
+    it("upserts cleanly (no conflict on a genuine re-install)", async () => {
+      const repo = makeRepo([row({ installationId: "inst-1", organizationId: "org-1" })]);
+      const svc = new LangyGithubInstallationsService(repo, makeAppTokens());
+
+      await svc.recordInstallation({
+        installationId: "inst-1",
+        organizationId: "org-1",
+      });
+
+      expect(repo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          installationId: "inst-1",
+          organizationId: "org-1",
+        }),
+      );
+    });
   });
 });
 

--- a/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
+++ b/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
@@ -56,15 +56,26 @@ export type LangyGithubWebhookAction =
  * attacker learns nothing about whether the id exists.
  */
 export class LangyGithubInstallationConflictError extends Error {
-  constructor(
-    public readonly installationId: string,
-    public readonly existingOrganizationId: string,
-    public readonly attemptedOrganizationId: string,
-  ) {
+  public readonly installationId: string;
+  public readonly existingOrganizationId: string;
+  public readonly attemptedOrganizationId: string;
+
+  constructor({
+    installationId,
+    existingOrganizationId,
+    attemptedOrganizationId,
+  }: {
+    installationId: string;
+    existingOrganizationId: string;
+    attemptedOrganizationId: string;
+  }) {
     super(
       `GitHub installation ${installationId} is already connected to a different organization`,
     );
     this.name = "LangyGithubInstallationConflictError";
+    this.installationId = installationId;
+    this.existingOrganizationId = existingOrganizationId;
+    this.attemptedOrganizationId = attemptedOrganizationId;
   }
 }
 
@@ -114,22 +125,6 @@ export class LangyGithubInstallationsService {
   }): Promise<{ accountLogin: string }> {
     const details = await this.appTokens.getInstallation(installationId);
 
-    // Cross-tenant takeover guard: never let a `/setup` call rebind an
-    // installation another org already owns. `installationId` is unique, so an
-    // upsert would otherwise overwrite the existing row's `organizationId`. A
-    // genuine re-install of the same account under the SAME org still upserts
-    // cleanly (same org → no conflict). See LangyGithubInstallationConflictError.
-    const existing = await this.repo.findByInstallationId(
-      details.installationId,
-    );
-    if (existing && existing.organizationId !== organizationId) {
-      throw new LangyGithubInstallationConflictError(
-        details.installationId,
-        existing.organizationId,
-        organizationId,
-      );
-    }
-
     let repositories: LangyGithubRepositoryRef[] | null = null;
     if (details.repositorySelection === "selected") {
       // Best-effort: cache the selected repo list so settings can show it
@@ -145,7 +140,8 @@ export class LangyGithubInstallationsService {
         );
       }
     }
-    await this.repo.upsert({
+
+    const input = {
       installationId: details.installationId,
       organizationId,
       accountLogin: details.accountLogin,
@@ -153,7 +149,28 @@ export class LangyGithubInstallationsService {
       accountId: details.accountId,
       repositorySelection: details.repositorySelection,
       repositories,
-    });
+    };
+
+    // Cross-tenant takeover guard, made race-safe: `insertOrGetExisting`
+    // claims the installation atomically via the DB's unique index rather
+    // than this code checking-then-writing across two awaits, so two
+    // concurrent `/setup` calls racing for the same fresh installation id can
+    // never both observe "unclaimed". Whichever loses the race always sees
+    // the winner's committed org here.
+    const { inserted, row } = await this.repo.insertOrGetExisting(input);
+    if (!inserted) {
+      if (row.organizationId !== organizationId) {
+        throw new LangyGithubInstallationConflictError({
+          installationId: details.installationId,
+          existingOrganizationId: row.organizationId,
+          attemptedOrganizationId: organizationId,
+        });
+      }
+      // Genuine re-install under the SAME org: refresh the cached account +
+      // repo fields (the initial insert attempt above never landed).
+      await this.repo.upsert(input);
+    }
+
     return { accountLogin: details.accountLogin };
   }
 

--- a/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
+++ b/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
@@ -157,8 +157,8 @@ export class LangyGithubInstallationsService {
     // concurrent `/setup` calls racing for the same fresh installation id can
     // never both observe "unclaimed". Whichever loses the race always sees
     // the winner's committed org here.
-    const { inserted, row } = await this.repo.insertOrGetExisting(input);
-    if (!inserted) {
+    const { wasInserted, row } = await this.repo.insertOrGetExisting(input);
+    if (!wasInserted) {
       if (row.organizationId !== organizationId) {
         throw new LangyGithubInstallationConflictError({
           installationId: details.installationId,

--- a/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
+++ b/langwatch/src/server/app-layer/langy/langy-github-installations.service.ts
@@ -41,6 +41,33 @@ export type LangyGithubWebhookAction =
   | "added"
   | "removed";
 
+/**
+ * Thrown when a `/setup` callback tries to bind an installation that another
+ * organization already owns — the cross-tenant installation-takeover guard.
+ *
+ * The `installation_id` at `/setup` is an attacker-controllable query param that
+ * is NOT part of the signed state, and `getInstallation` authenticates as the
+ * App (so it returns metadata for ANY installation of this App, on ANY account).
+ * Without this guard, a caller holding a valid signed state for their OWN org
+ * could point `/setup` at a victim org's installation id and have the upsert
+ * rebind that unique-`installationId` row to their org — silently stealing
+ * 1h `contents:write`/`pull_requests:write` tokens on the victim's private
+ * repos. The route maps this to the generic install-failed message so a blocked
+ * attacker learns nothing about whether the id exists.
+ */
+export class LangyGithubInstallationConflictError extends Error {
+  constructor(
+    public readonly installationId: string,
+    public readonly existingOrganizationId: string,
+    public readonly attemptedOrganizationId: string,
+  ) {
+    super(
+      `GitHub installation ${installationId} is already connected to a different organization`,
+    );
+    this.name = "LangyGithubInstallationConflictError";
+  }
+}
+
 export class LangyGithubInstallationsService {
   constructor(
     private readonly repo: LangyGithubInstallationsRepository,
@@ -86,6 +113,23 @@ export class LangyGithubInstallationsService {
     organizationId: string;
   }): Promise<{ accountLogin: string }> {
     const details = await this.appTokens.getInstallation(installationId);
+
+    // Cross-tenant takeover guard: never let a `/setup` call rebind an
+    // installation another org already owns. `installationId` is unique, so an
+    // upsert would otherwise overwrite the existing row's `organizationId`. A
+    // genuine re-install of the same account under the SAME org still upserts
+    // cleanly (same org → no conflict). See LangyGithubInstallationConflictError.
+    const existing = await this.repo.findByInstallationId(
+      details.installationId,
+    );
+    if (existing && existing.organizationId !== organizationId) {
+      throw new LangyGithubInstallationConflictError(
+        details.installationId,
+        existing.organizationId,
+        organizationId,
+      );
+    }
+
     let repositories: LangyGithubRepositoryRef[] | null = null;
     if (details.repositorySelection === "selected") {
       // Best-effort: cache the selected repo list so settings can show it

--- a/langwatch/src/server/app-layer/langy/repositories/__tests__/langy-github-installations.prisma.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/langy/repositories/__tests__/langy-github-installations.prisma.repository.integration.test.ts
@@ -1,0 +1,116 @@
+import { nanoid } from "nanoid";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+import { PrismaLangyGithubInstallationsRepository } from "../langy-github-installations.prisma.repository";
+import type { UpsertLangyGithubInstallationInput } from "../langy-github-installations.repository";
+
+/**
+ * `insertOrGetExisting`'s whole point is that a real Postgres unique-index
+ * violation — not application-level timing — resolves the race between two
+ * organizations claiming the same installation id. The service/route unit
+ * tests mock this repository, so they can only prove the SERVICE correctly
+ * interprets whatever the repo returns; they can't prove Postgres actually
+ * serializes the concurrent writes the way the fix assumes. This exercises
+ * the real Prisma path against the real test database.
+ */
+const namespace = `langy-install-${nanoid(10)}`;
+const repository = new PrismaLangyGithubInstallationsRepository(prisma);
+
+function input(
+  installationId: string,
+  organizationId: string,
+): UpsertLangyGithubInstallationInput {
+  return {
+    installationId,
+    organizationId,
+    accountLogin: "acme",
+    accountType: "Organization",
+    accountId: "9000",
+    repositorySelection: "all",
+    repositories: null,
+  };
+}
+
+// The tenancy guard on LangyGithubInstallation only recognises an exact-string
+// `installationId` (or `organizationId`) in a WHERE clause, not a `startsWith`/
+// `in` filter — see dbOrganizationIdProtection.ts's `extraBound` check — so
+// cleanup deletes each known id by exact match rather than by prefix.
+const installationIds = [
+  `${namespace}-fresh`,
+  `${namespace}-race`,
+  `${namespace}-existing`,
+];
+
+afterEach(async () => {
+  for (const installationId of installationIds) {
+    await prisma.langyGithubInstallation.deleteMany({
+      where: { installationId },
+    });
+  }
+});
+
+describe("PrismaLangyGithubInstallationsRepository.insertOrGetExisting", () => {
+  describe("when the installation id is fresh", () => {
+    it("inserts and reports inserted: true", async () => {
+      const installationId = `${namespace}-fresh`;
+      const orgId = `${namespace}-org-a`;
+
+      const result = await repository.insertOrGetExisting(
+        input(installationId, orgId),
+      );
+
+      expect(result.inserted).toBe(true);
+      expect(result.row.organizationId).toBe(orgId);
+    });
+  });
+
+  describe("when two organizations race for the same fresh installation id", () => {
+    it("lets Postgres's unique constraint pick exactly one winner", async () => {
+      const installationId = `${namespace}-race`;
+      const orgA = `${namespace}-org-a`;
+      const orgB = `${namespace}-org-b`;
+
+      const [resultA, resultB] = await Promise.all([
+        repository.insertOrGetExisting(input(installationId, orgA)),
+        repository.insertOrGetExisting(input(installationId, orgB)),
+      ]);
+
+      const inserted = [resultA, resultB].filter((r) => r.inserted);
+      const conflicted = [resultA, resultB].filter((r) => !r.inserted);
+      expect(inserted).toHaveLength(1);
+      expect(conflicted).toHaveLength(1);
+      // The loser's "existing" read is the winner's committed row — never a
+      // stale/absent value — proving the unique index, not call ordering,
+      // resolved the race.
+      expect(conflicted[0]!.row.organizationId).toBe(
+        inserted[0]!.row.organizationId,
+      );
+
+      const stored = await prisma.langyGithubInstallation.findUnique({
+        where: { installationId },
+      });
+      expect(stored?.organizationId).toBe(inserted[0]!.row.organizationId);
+    });
+  });
+
+  describe("when the installation id already exists", () => {
+    it("reports inserted: false with the existing row, and never overwrites it", async () => {
+      const installationId = `${namespace}-existing`;
+      const orgA = `${namespace}-org-a`;
+      const orgB = `${namespace}-org-b`;
+      await repository.insertOrGetExisting(input(installationId, orgA));
+
+      const result = await repository.insertOrGetExisting(
+        input(installationId, orgB),
+      );
+
+      expect(result.inserted).toBe(false);
+      expect(result.row.organizationId).toBe(orgA);
+      const stored = await prisma.langyGithubInstallation.findUnique({
+        where: { installationId },
+      });
+      expect(stored?.organizationId).toBe(orgA);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/langy/repositories/__tests__/langy-github-installations.prisma.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/langy/repositories/__tests__/langy-github-installations.prisma.repository.integration.test.ts
@@ -52,7 +52,7 @@ afterEach(async () => {
 
 describe("PrismaLangyGithubInstallationsRepository.insertOrGetExisting", () => {
   describe("when the installation id is fresh", () => {
-    it("inserts and reports inserted: true", async () => {
+    it("inserts and reports wasInserted: true", async () => {
       const installationId = `${namespace}-fresh`;
       const orgId = `${namespace}-org-a`;
 
@@ -60,7 +60,7 @@ describe("PrismaLangyGithubInstallationsRepository.insertOrGetExisting", () => {
         input(installationId, orgId),
       );
 
-      expect(result.inserted).toBe(true);
+      expect(result.wasInserted).toBe(true);
       expect(result.row.organizationId).toBe(orgId);
     });
   });
@@ -76,8 +76,8 @@ describe("PrismaLangyGithubInstallationsRepository.insertOrGetExisting", () => {
         repository.insertOrGetExisting(input(installationId, orgB)),
       ]);
 
-      const inserted = [resultA, resultB].filter((r) => r.inserted);
-      const conflicted = [resultA, resultB].filter((r) => !r.inserted);
+      const inserted = [resultA, resultB].filter((r) => r.wasInserted);
+      const conflicted = [resultA, resultB].filter((r) => !r.wasInserted);
       expect(inserted).toHaveLength(1);
       expect(conflicted).toHaveLength(1);
       // The loser's "existing" read is the winner's committed row — never a
@@ -95,7 +95,7 @@ describe("PrismaLangyGithubInstallationsRepository.insertOrGetExisting", () => {
   });
 
   describe("when the installation id already exists", () => {
-    it("reports inserted: false with the existing row, and never overwrites it", async () => {
+    it("reports wasInserted: false with the existing row, and never overwrites it", async () => {
       const installationId = `${namespace}-existing`;
       const orgA = `${namespace}-org-a`;
       const orgB = `${namespace}-org-b`;
@@ -105,7 +105,7 @@ describe("PrismaLangyGithubInstallationsRepository.insertOrGetExisting", () => {
         input(installationId, orgB),
       );
 
-      expect(result.inserted).toBe(false);
+      expect(result.wasInserted).toBe(false);
       expect(result.row.organizationId).toBe(orgA);
       const stored = await prisma.langyGithubInstallation.findUnique({
         where: { installationId },

--- a/langwatch/src/server/app-layer/langy/repositories/langy-github-installations.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/langy/repositories/langy-github-installations.prisma.repository.ts
@@ -113,6 +113,40 @@ export class PrismaLangyGithubInstallationsRepository
     });
   }
 
+  async insertOrGetExisting(
+    input: UpsertLangyGithubInstallationInput,
+  ): Promise<{ inserted: boolean; row: LangyGithubInstallationRow }> {
+    try {
+      const created = await this.prisma.langyGithubInstallation.create({
+        data: {
+          installationId: input.installationId,
+          organizationId: input.organizationId,
+          accountLogin: input.accountLogin,
+          accountType: input.accountType,
+          accountId: input.accountId,
+          repositorySelection: input.repositorySelection,
+          repositories: reposToJson(input.repositories),
+          suspendedAt: null,
+        },
+      });
+      return { inserted: true, row: toRow(created) };
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        // Another request already committed this installationId first — the
+        // unique index is the atomicity guarantee, not a check we ran
+        // ourselves, so this read always sees the winner's committed row.
+        const existing = await this.prisma.langyGithubInstallation.findUnique(
+          { where: { installationId: input.installationId } },
+        );
+        if (existing) return { inserted: false, row: toRow(existing) };
+      }
+      throw error;
+    }
+  }
+
   async setRepositories({
     installationId,
     repositorySelection,

--- a/langwatch/src/server/app-layer/langy/repositories/langy-github-installations.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/langy/repositories/langy-github-installations.prisma.repository.ts
@@ -115,7 +115,7 @@ export class PrismaLangyGithubInstallationsRepository
 
   async insertOrGetExisting(
     input: UpsertLangyGithubInstallationInput,
-  ): Promise<{ inserted: boolean; row: LangyGithubInstallationRow }> {
+  ): Promise<{ wasInserted: boolean; row: LangyGithubInstallationRow }> {
     try {
       const created = await this.prisma.langyGithubInstallation.create({
         data: {
@@ -129,7 +129,7 @@ export class PrismaLangyGithubInstallationsRepository
           suspendedAt: null,
         },
       });
-      return { inserted: true, row: toRow(created) };
+      return { wasInserted: true, row: toRow(created) };
     } catch (error) {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
@@ -141,7 +141,7 @@ export class PrismaLangyGithubInstallationsRepository
         const existing = await this.prisma.langyGithubInstallation.findUnique(
           { where: { installationId: input.installationId } },
         );
-        if (existing) return { inserted: false, row: toRow(existing) };
+        if (existing) return { wasInserted: false, row: toRow(existing) };
       }
       throw error;
     }

--- a/langwatch/src/server/app-layer/langy/repositories/langy-github-installations.repository.ts
+++ b/langwatch/src/server/app-layer/langy/repositories/langy-github-installations.repository.ts
@@ -59,7 +59,7 @@ export interface LangyGithubInstallationsRepository {
    */
   insertOrGetExisting(
     input: UpsertLangyGithubInstallationInput,
-  ): Promise<{ inserted: boolean; row: LangyGithubInstallationRow }>;
+  ): Promise<{ wasInserted: boolean; row: LangyGithubInstallationRow }>;
 
   setRepositories(params: {
     installationId: string;
@@ -92,10 +92,10 @@ export class NullLangyGithubInstallationsRepository
   async upsert(): Promise<void> {}
   async insertOrGetExisting(
     input: UpsertLangyGithubInstallationInput,
-  ): Promise<{ inserted: boolean; row: LangyGithubInstallationRow }> {
+  ): Promise<{ wasInserted: boolean; row: LangyGithubInstallationRow }> {
     const now = new Date();
     return {
-      inserted: true,
+      wasInserted: true,
       row: { ...input, suspendedAt: null, createdAt: now, updatedAt: now },
     };
   }

--- a/langwatch/src/server/app-layer/langy/repositories/langy-github-installations.repository.ts
+++ b/langwatch/src/server/app-layer/langy/repositories/langy-github-installations.repository.ts
@@ -48,6 +48,19 @@ export interface LangyGithubInstallationsRepository {
 
   upsert(input: UpsertLangyGithubInstallationInput): Promise<void>;
 
+  /**
+   * Atomically claims `installationId` for `input.organizationId`, or reports
+   * who already holds it. The unique index on `installationId` — not a
+   * read-then-write check the caller does itself — is what makes this
+   * race-safe: two concurrent callers racing for the same fresh installation
+   * id can never both see "absent" and both write, because only one `create`
+   * can win the unique constraint. The loser always observes the winner's
+   * committed row here, never a stale null.
+   */
+  insertOrGetExisting(
+    input: UpsertLangyGithubInstallationInput,
+  ): Promise<{ inserted: boolean; row: LangyGithubInstallationRow }>;
+
   setRepositories(params: {
     installationId: string;
     repositorySelection: string;
@@ -77,6 +90,15 @@ export class NullLangyGithubInstallationsRepository
     return null;
   }
   async upsert(): Promise<void> {}
+  async insertOrGetExisting(
+    input: UpsertLangyGithubInstallationInput,
+  ): Promise<{ inserted: boolean; row: LangyGithubInstallationRow }> {
+    const now = new Date();
+    return {
+      inserted: true,
+      row: { ...input, suspendedAt: null, createdAt: now, updatedAt: now },
+    };
+  }
   async setRepositories(): Promise<void> {}
   async setSuspended(): Promise<void> {}
   async deleteByInstallationId(): Promise<number> {

--- a/langwatch/src/server/routes/__tests__/github-langy-install.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/github-langy-install.integration.test.ts
@@ -290,17 +290,25 @@ describe("GET /api/github-langy/setup", () => {
   });
 
   describe("when the installation is already owned by another organization", () => {
-    it("returns the generic failure and audits the blocked cross-tenant rebind", async () => {
-      // The attack: a caller with a valid signed state for their OWN org points
-      // installation_id at a victim org's installation. recordInstallation now
-      // throws the conflict guard; the route must not leak that the id exists
-      // (generic message) but must record the attempt for detection.
+    async function mockConflictRejection() {
       const { LangyGithubInstallationConflictError } = await import(
         "~/server/app-layer/langy/langy-github-installations.service"
       );
       recordInstallation.mockRejectedValue(
-        new LangyGithubInstallationConflictError("555", "victim-org", "org1"),
+        new LangyGithubInstallationConflictError({
+          installationId: "555",
+          existingOrganizationId: "victim-org",
+          attemptedOrganizationId: "org1",
+        }),
       );
+    }
+
+    it("returns the generic failure and audits the blocked cross-tenant rebind (redirect)", async () => {
+      // The attack: a caller with a valid signed state for their OWN org points
+      // installation_id at a victim org's installation. recordInstallation now
+      // throws the conflict guard; the route must not leak that the id exists
+      // (generic message) but must record the attempt for detection.
+      await mockConflictRejection();
       const state = await makeState({ mode: "redirect" });
 
       const res = await request(
@@ -311,6 +319,31 @@ describe("GET /api/github-langy/setup", () => {
       expect(res.status).toBe(302);
       expect(res.headers.get("location")).toContain("githubError=");
       // The success audit must NOT fire; the rejection audit must.
+      expect(auditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "langy.github.install.rejected_cross_tenant",
+        }),
+      );
+      expect(auditLog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: "langy.github.install" }),
+      );
+    });
+
+    it("returns the generic failure via the popup postMessage shim, not a redirect", async () => {
+      await mockConflictRejection();
+      const state = await makeState({ mode: "popup" });
+
+      const res = await request(
+        `http://localhost/api/github-langy/setup?installation_id=555&state=${encodeURIComponent(state)}`,
+      );
+
+      // Popup mode never redirects — the failure comes back as an HTML shim
+      // that postMessages the opener, same generic wording as the redirect
+      // path (no leak of victim-org / existence either way).
+      expect(res.status).toBe(502);
+      expect(res.headers.get("location")).toBeNull();
+      const body = await res.text();
+      expect(body).not.toContain("victim-org");
       expect(auditLog).toHaveBeenCalledWith(
         expect.objectContaining({
           action: "langy.github.install.rejected_cross_tenant",

--- a/langwatch/src/server/routes/__tests__/github-langy-install.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/github-langy-install.unit.test.ts
@@ -289,6 +289,39 @@ describe("GET /api/github-langy/setup", () => {
     });
   });
 
+  describe("when the installation is already owned by another organization", () => {
+    it("returns the generic failure and audits the blocked cross-tenant rebind", async () => {
+      // The attack: a caller with a valid signed state for their OWN org points
+      // installation_id at a victim org's installation. recordInstallation now
+      // throws the conflict guard; the route must not leak that the id exists
+      // (generic message) but must record the attempt for detection.
+      const { LangyGithubInstallationConflictError } = await import(
+        "~/server/app-layer/langy/langy-github-installations.service"
+      );
+      recordInstallation.mockRejectedValue(
+        new LangyGithubInstallationConflictError("555", "victim-org", "org1"),
+      );
+      const state = await makeState({ mode: "redirect" });
+
+      const res = await request(
+        `http://localhost/api/github-langy/setup?installation_id=555&state=${encodeURIComponent(state)}`,
+      );
+
+      // Generic failure surfaced via the returnTo redirect — no leak.
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toContain("githubError=");
+      // The success audit must NOT fire; the rejection audit must.
+      expect(auditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "langy.github.install.rejected_cross_tenant",
+        }),
+      );
+      expect(auditLog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: "langy.github.install" }),
+      );
+    });
+  });
+
   describe("when Langy access was revoked after the install began", () => {
     it("re-checks the gate and refuses to persist the installation", async () => {
       // Install started while allowed; the rollout is now off for this

--- a/langwatch/src/server/routes/github-langy.ts
+++ b/langwatch/src/server/routes/github-langy.ts
@@ -34,6 +34,7 @@ import {
 import { hasOrganizationPermission } from "~/server/api/rbac";
 import { getApp } from "~/server/app-layer";
 import { hasLangyAccess } from "~/server/app-layer/langy/langyAccessGate";
+import { LangyGithubInstallationConflictError } from "~/server/app-layer/langy/langy-github-installations.service";
 import { auditLog } from "~/server/auditLog";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
@@ -338,7 +339,32 @@ secured
           organizationId: state.organizationId,
         }));
     } catch (err) {
-      logger.warn({ err }, "github installation record failed");
+      // A cross-tenant takeover attempt (installation already owned by another
+      // org) is a security event, not an ordinary failure: audit it against the
+      // acting user/org so it is visible, but still return the generic message
+      // so the caller learns nothing about whether the installation id exists.
+      if (err instanceof LangyGithubInstallationConflictError) {
+        logger.warn(
+          {
+            installationId: err.installationId,
+            attemptedOrganizationId: err.attemptedOrganizationId,
+            userId: state.userId,
+          },
+          "blocked cross-tenant github installation rebind attempt",
+        );
+        try {
+          await auditLog({
+            userId: state.userId,
+            organizationId: state.organizationId,
+            action: "langy.github.install.rejected_cross_tenant",
+            args: { installationId: err.installationId },
+          });
+        } catch (auditErr) {
+          logger.warn({ err: auditErr }, "audit log write failed after blocked rebind");
+        }
+      } else {
+        logger.warn({ err }, "github installation record failed");
+      }
       const publicMsg = publicGithubErrorMessage();
       return state.mode === "popup"
         ? popupHtml(c, popupErrorHtml(publicMsg), 502)


### PR DESCRIPTION
## Summary
- `recordInstallation` now rejects rebinding a GitHub App installation that's already connected to a different organization, instead of silently overwriting the existing mapping.
- Genuine same-org re-installs still upsert cleanly.
- Blocked rebind attempts are audit-logged; the caller always sees the same generic install-failed message either way.

## Test plan
- [x] `langy-github-installations.service.unit.test.ts` — 12 tests passing, including the new conflict-guard cases
- [x] `github-langy-install.unit.test.ts` — 19 tests passing, including the new route-level rejection case
- [x] `pnpm typecheck` clean on all touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented GitHub installations from being reassigned across organizations.
  * Added race-safe installation claiming so only one organization can successfully record an installation.
  * Same-organization reinstalls refresh stored installation details.
  * Cross-organization setup failures continue to return a generic error without exposing ownership details.

* **Audit & Monitoring**
  * Added an audit event for rejected cross-organization installation attempts.

* **Tests**
  * Extended unit and integration coverage for cross-tenant conflicts and concurrent setup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->