### PR TITLE
fix(mcp): validate redirect_uri against registered OAuth clients

### DIFF
--- a/langwatch/src/mcp/__tests__/mcp-handler.integration.test.ts
+++ b/langwatch/src/mcp/__tests__/mcp-handler.integration.test.ts
@@ -542,6 +542,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
     });
 
   describe("when the token exchange omits redirect_uri", () => {
+    /** @scenario Token exchange is rejected when redirect_uri is missing */
     it("returns 400 with invalid_request error", async () => {
       const addr = server.address();
       const port = typeof addr === "object" && addr ? addr.port : 0;
@@ -559,6 +560,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when the token exchange omits client_id", () => {
+    /** @scenario Token exchange is rejected when client_id is missing */
     it("returns 400 with invalid_request error", async () => {
       const addr = server.address();
       const port = typeof addr === "object" && addr ? addr.port : 0;
@@ -576,6 +578,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when the token exchange presents a different redirect_uri than the one bound at authorize", () => {
+    /** @scenario Token exchange is rejected when redirect_uri does not match the authorization request */
     it("returns 400 with invalid_grant and never issues a token", async () => {
       const code = randomUUID();
       const { codeVerifier, codeChallenge } = createPkceChallenge();
@@ -598,6 +601,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when the token exchange presents a different client_id than the one bound at authorize", () => {
+    /** @scenario Token exchange is rejected when client_id does not match the authorization request */
     it("returns 400 with invalid_grant and never issues a token", async () => {
       const code = randomUUID();
       const { codeVerifier, codeChallenge } = createPkceChallenge();
@@ -622,6 +626,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   // --- Security: dynamic client registration persistence (RFC 7591) ---
 
   describe("when a new OAuth client registers", () => {
+    /** @scenario Dynamic client registration persists the redirect_uris binding */
     it("persists the client_id -> redirect_uris binding to Redis", async () => {
       const addr = server.address();
       const port = typeof addr === "object" && addr ? addr.port : 0;
@@ -653,6 +658,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when OAuth client registration is missing redirect_uris", () => {
+    /** @scenario Dynamic client registration rejects a request with no redirect_uris */
     it("returns 400 with invalid_client_metadata", async () => {
       const addr = server.address();
       const port = typeof addr === "object" && addr ? addr.port : 0;

--- a/langwatch/src/mcp/__tests__/mcp-handler.integration.test.ts
+++ b/langwatch/src/mcp/__tests__/mcp-handler.integration.test.ts
@@ -166,6 +166,12 @@ function createPkceChallenge() {
   return { codeVerifier, codeChallenge };
 }
 
+// Matches TEST_REDIRECT_URI / TEST_CLIENT_ID below — the values every
+// /oauth/token test request in this file sends, since the token endpoint now
+// requires them to match what /mcp/authorize bound to the code.
+const TEST_REDIRECT_URI = "http://localhost/callback";
+const TEST_CLIENT_ID = "test_client";
+
 /**
  * Stores a mock auth code in the Redis mock that the handler can retrieve.
  */
@@ -174,17 +180,23 @@ function mockAuthCodeInRedis({
   codeChallenge,
   apiKey = VALID_API_KEY,
   expiresAt,
+  redirectUri = TEST_REDIRECT_URI,
+  clientId = TEST_CLIENT_ID,
 }: {
   code: string;
   codeChallenge: string;
   apiKey?: string;
   expiresAt?: number;
+  redirectUri?: string;
+  clientId?: string;
 }) {
   const entry = JSON.stringify({
     projectId: PROJECT_ID,
     encryptedApiKey: `encrypted:${apiKey}`,
     codeChallenge,
     codeChallengeMethod: "S256",
+    redirectUri,
+    clientId,
     expiresAt: expiresAt ?? Date.now() + 600_000,
   });
 
@@ -401,7 +413,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=http://localhost/callback`,
+        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
       });
 
       expect(res.status).toBe(200);
@@ -427,7 +439,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${code}&code_verifier=wrong-verifier`,
+        body: `grant_type=authorization_code&code=${code}&code_verifier=wrong-verifier&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
       });
 
       expect(res.status).toBe(400);
@@ -495,7 +507,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=invalid-code&code_verifier=some-verifier`,
+        body: `grant_type=authorization_code&code=invalid-code&code_verifier=some-verifier&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
       });
 
       expect(res.status).toBe(400);
@@ -503,6 +515,159 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       expect(body.error).toBe("invalid_grant");
     });
   });
+
+  // --- Security: redirect_uri / client_id binding (RFC 6749 §10.6, §4.1.3),
+  //     and dynamic client registration persistence (RFC 7591) ---
+  //
+  // /mcp/authorize binds an issued code to the exact client_id + redirect_uri
+  // it validated (see mcp-authorize.rolebinding.unit.test.ts for the
+  // authorize-side registered-client check). The exchange below re-validates
+  // that binding — a code minted for one redirect_uri/client_id must never be
+  // redeemable with a different one, otherwise whoever crafted the original
+  // authorization request (not necessarily the user who approved it) could
+  // exfiltrate the code to a URI they control.
+  //
+  // Wrapped in its own rate-limiter reset: /oauth/token and /oauth/register
+  // share one IP-keyed limiter (10/min) across this whole file's ~30 other
+  // tests, several of which also hit these endpoints. Without resetting
+  // before AND after, this block's extra calls would push later tests (or
+  // get pushed by earlier ones) over the shared budget and 429 instead of
+  // exercising what they're actually testing.
+  describe("OAuth security: redirect_uri/client_id binding + registration", () => {
+    beforeEach(() => {
+      handler.clearRateLimiters();
+    });
+    afterEach(() => {
+      handler.clearRateLimiters();
+    });
+
+  describe("when the token exchange omits redirect_uri", () => {
+    it("returns 400 with invalid_request error", async () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: `grant_type=authorization_code&code=${randomUUID()}&code_verifier=some-verifier&client_id=${TEST_CLIENT_ID}`,
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toContain("redirect_uri is required");
+    });
+  });
+
+  describe("when the token exchange omits client_id", () => {
+    it("returns 400 with invalid_request error", async () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: `grant_type=authorization_code&code=${randomUUID()}&code_verifier=some-verifier&redirect_uri=${TEST_REDIRECT_URI}`,
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toContain("client_id is required");
+    });
+  });
+
+  describe("when the token exchange presents a different redirect_uri than the one bound at authorize", () => {
+    it("returns 400 with invalid_grant and never issues a token", async () => {
+      const code = randomUUID();
+      const { codeVerifier, codeChallenge } = createPkceChallenge();
+      mockAuthCodeInRedis({ code, codeChallenge });
+
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=https://attacker.invalid/callback&client_id=${TEST_CLIENT_ID}`,
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_grant");
+      expect(body.error_description).toContain("redirect_uri");
+      expect(body.access_token).toBeUndefined();
+    });
+  });
+
+  describe("when the token exchange presents a different client_id than the one bound at authorize", () => {
+    it("returns 400 with invalid_grant and never issues a token", async () => {
+      const code = randomUUID();
+      const { codeVerifier, codeChallenge } = createPkceChallenge();
+      mockAuthCodeInRedis({ code, codeChallenge });
+
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}&client_id=mcp_someone_elses_client`,
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_grant");
+      expect(body.error_description).toContain("client_id");
+      expect(body.access_token).toBeUndefined();
+    });
+  });
+
+  // --- Security: dynamic client registration persistence (RFC 7591) ---
+
+  describe("when a new OAuth client registers", () => {
+    it("persists the client_id -> redirect_uris binding to Redis", async () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const res = await fetch(`http://127.0.0.1:${port}/oauth/register`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "test-client",
+          redirect_uris: ["https://registered.example/callback"],
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.client_id).toMatch(/^mcp_/);
+
+      // The whole point: this registration must be durably retrievable by
+      // /mcp/authorize later, not just echoed back in this response.
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        `mcp:oauth:client:${body.client_id}`,
+        JSON.stringify({
+          redirectUris: ["https://registered.example/callback"],
+          clientName: "test-client",
+        }),
+        "EX",
+        expect.any(Number),
+      );
+    });
+  });
+
+  describe("when OAuth client registration is missing redirect_uris", () => {
+    it("returns 400 with invalid_client_metadata", async () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const res = await fetch(`http://127.0.0.1:${port}/oauth/register`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ client_name: "test-client" }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_client_metadata");
+    });
+  });
+  }); // end "OAuth security: redirect_uri/client_id binding + registration"
 
   // --- Bearer Token DB Validation ---
 
@@ -552,7 +717,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const tokenRes = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=http://localhost/callback`,
+        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
       });
       const tokenBody = await tokenRes.json();
       const accessToken = tokenBody.access_token;
@@ -594,7 +759,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const tokenRes = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=http://localhost/callback`,
+        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
       });
       const tokenBody = await tokenRes.json();
       const accessToken = tokenBody.access_token;
@@ -1013,7 +1178,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const tokenRes = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=http://localhost/callback`,
+        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${TEST_REDIRECT_URI}&client_id=${TEST_CLIENT_ID}`,
       });
       const tokenBody = (await tokenRes.json()) as { access_token: string };
       const accessToken = tokenBody.access_token;

--- a/langwatch/src/mcp/__tests__/oauthClientRegistry.integration.test.ts
+++ b/langwatch/src/mcp/__tests__/oauthClientRegistry.integration.test.ts
@@ -30,57 +30,70 @@ describe("OAuth client registry", () => {
     await stopTestContainers();
   }, 60_000);
 
-  describe("when a client is registered then looked up", () => {
-    /** @scenario Dynamic client registration persists the redirect_uris binding */
-    it("round-trips the exact redirect_uris and client_name", async () => {
-      const clientId = `mcp_${nanoid(12)}`;
-      await registerOAuthClient(clientId, {
-        redirectUris: ["https://registered.example/callback"],
-        clientName: "Round-trip client",
+  describe("given a client is registered", () => {
+    describe("when it is looked up", () => {
+      /** @scenario Dynamic client registration persists the redirect_uris binding */
+      it("round-trips the exact redirect_uris and client_name", async () => {
+        const clientId = `mcp_${nanoid(12)}`;
+        await registerOAuthClient({
+          clientId,
+          client: {
+            redirectUris: ["https://registered.example/callback"],
+            clientName: "Round-trip client",
+          },
+        });
+
+        const found = await getOAuthClient(clientId);
+
+        expect(found).toEqual({
+          redirectUris: ["https://registered.example/callback"],
+          clientName: "Round-trip client",
+        });
       });
+    });
+  });
 
-      const found = await getOAuthClient(clientId);
-
-      expect(found).toEqual({
-        redirectUris: ["https://registered.example/callback"],
-        clientName: "Round-trip client",
+  describe("given no client was ever registered with a client_id", () => {
+    describe("when it is looked up", () => {
+      it("returns null", async () => {
+        const found = await getOAuthClient(
+          `mcp_${nanoid(12)}_never_registered`,
+        );
+        expect(found).toBeNull();
       });
     });
   });
 
-  describe("when the client_id was never registered", () => {
-    it("returns null", async () => {
-      const found = await getOAuthClient(`mcp_${nanoid(12)}_never_registered`);
-      expect(found).toBeNull();
+  describe("given the stored registration is corrupted JSON", () => {
+    describe("when it is looked up", () => {
+      it("returns null instead of throwing", async () => {
+        const clientId = `mcp_${nanoid(12)}`;
+        if (!redis) throw new Error("Redis required");
+        await redis.set(`mcp:oauth:client:${clientId}`, "{not json", "EX", 60);
+
+        const found = await getOAuthClient(clientId);
+
+        expect(found).toBeNull();
+      });
     });
   });
 
-  describe("when the stored registration is corrupted JSON", () => {
-    it("returns null instead of throwing", async () => {
-      const clientId = `mcp_${nanoid(12)}`;
-      if (!redis) throw new Error("Redis required");
-      await redis.set(`mcp:oauth:client:${clientId}`, "{not json", "EX", 60);
+  describe("given the stored registration has a non-array redirectUris", () => {
+    describe("when it is looked up", () => {
+      it("returns null instead of trusting the malformed shape", async () => {
+        const clientId = `mcp_${nanoid(12)}`;
+        if (!redis) throw new Error("Redis required");
+        await redis.set(
+          `mcp:oauth:client:${clientId}`,
+          JSON.stringify({ redirectUris: "not-an-array", clientName: "x" }),
+          "EX",
+          60,
+        );
 
-      const found = await getOAuthClient(clientId);
+        const found = await getOAuthClient(clientId);
 
-      expect(found).toBeNull();
-    });
-  });
-
-  describe("when the stored registration has a non-array redirectUris", () => {
-    it("returns null instead of trusting the malformed shape", async () => {
-      const clientId = `mcp_${nanoid(12)}`;
-      if (!redis) throw new Error("Redis required");
-      await redis.set(
-        `mcp:oauth:client:${clientId}`,
-        JSON.stringify({ redirectUris: "not-an-array", clientName: "x" }),
-        "EX",
-        60,
-      );
-
-      const found = await getOAuthClient(clientId);
-
-      expect(found).toBeNull();
+        expect(found).toBeNull();
+      });
     });
   });
 });

--- a/langwatch/src/mcp/__tests__/oauthClientRegistry.integration.test.ts
+++ b/langwatch/src/mcp/__tests__/oauthClientRegistry.integration.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment node
+ *
+ * Repository-level coverage for the MCP OAuth client registry — the
+ * client_id -> redirect_uris binding /mcp/authorize validates against
+ * (RFC 6749 §10.6 / RFC 7591). Hits real Redis (testcontainers), no mocks:
+ * per dev/docs/best_practices/repository-service.md, "avoid mocking
+ * repositories — it tests implementation details. If the service works with
+ * a real database, it works."
+ *
+ * Spec: specs/mcp-server/mcp-in-app.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { connection as redis } from "~/server/redis";
+
+import { getOAuthClient, registerOAuthClient } from "../oauthClientRegistry";
+
+describe("OAuth client registry", () => {
+  beforeAll(async () => {
+    await startTestContainers();
+  }, 60_000);
+
+  afterAll(async () => {
+    await stopTestContainers();
+  }, 60_000);
+
+  describe("when a client is registered then looked up", () => {
+    /** @scenario Dynamic client registration persists the redirect_uris binding */
+    it("round-trips the exact redirect_uris and client_name", async () => {
+      const clientId = `mcp_${nanoid(12)}`;
+      await registerOAuthClient(clientId, {
+        redirectUris: ["https://registered.example/callback"],
+        clientName: "Round-trip client",
+      });
+
+      const found = await getOAuthClient(clientId);
+
+      expect(found).toEqual({
+        redirectUris: ["https://registered.example/callback"],
+        clientName: "Round-trip client",
+      });
+    });
+  });
+
+  describe("when the client_id was never registered", () => {
+    it("returns null", async () => {
+      const found = await getOAuthClient(`mcp_${nanoid(12)}_never_registered`);
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("when the stored registration is corrupted JSON", () => {
+    it("returns null instead of throwing", async () => {
+      const clientId = `mcp_${nanoid(12)}`;
+      if (!redis) throw new Error("Redis required");
+      await redis.set(`mcp:oauth:client:${clientId}`, "{not json", "EX", 60);
+
+      const found = await getOAuthClient(clientId);
+
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("when the stored registration has a non-array redirectUris", () => {
+    it("returns null instead of trusting the malformed shape", async () => {
+      const clientId = `mcp_${nanoid(12)}`;
+      if (!redis) throw new Error("Redis required");
+      await redis.set(
+        `mcp:oauth:client:${clientId}`,
+        JSON.stringify({ redirectUris: "not-an-array", clientName: "x" }),
+        "EX",
+        60,
+      );
+
+      const found = await getOAuthClient(clientId);
+
+      expect(found).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/mcp/handler.ts
+++ b/langwatch/src/mcp/handler.ts
@@ -26,6 +26,7 @@ import { prisma } from "../server/db";
 import { connection as redis } from "../server/redis";
 import { decrypt, encrypt } from "../utils/encryption";
 import { registerGovernanceMcpTools } from "./governance-tools";
+import { registerOAuthClient } from "./oauthClientRegistry";
 
 const logger = createLogger("langwatch:mcp");
 
@@ -101,6 +102,10 @@ function createRateLimiter({
         }
       }
     },
+    /** Drop every tracked entry (for testing). */
+    clear() {
+      entries.clear();
+    },
   };
 }
 
@@ -149,6 +154,8 @@ export interface McpHandler {
   isMcpRoute: (pathname: string) => boolean;
   /** Clear the in-memory OAuth token cache (for testing). */
   clearTokenCache: () => void;
+  /** Clear the in-memory OAuth/auth-failure rate limiter state (for testing). */
+  clearRateLimiters: () => void;
   /** Close all active sessions (for graceful shutdown). */
   closeAllSessions: () => void;
 }
@@ -731,13 +738,27 @@ export function createMcpHandler(): McpHandler {
     }
 
     // Generate a client_id — we don't restrict which clients can use the
-    // OAuth flow, so any registration succeeds. The real authorization
-    // happens at the consent page where the user picks a project.
+    // OAuth flow, so any registration succeeds. What DOES matter is binding
+    // this client_id to the redirect_uris it registered with, so /mcp/authorize
+    // can reject a request that later shows up with a different one.
     const clientId = `mcp_${randomUUID().replace(/-/g, "")}`;
+    const clientName =
+      typeof body.client_name === "string" ? body.client_name : "MCP Client";
+
+    try {
+      await registerOAuthClient(clientId, {
+        redirectUris: body.redirect_uris,
+        clientName,
+      });
+    } catch (err) {
+      logger.error({ error: err }, "Failed to persist OAuth client registration");
+      sendJson(res, 500, { error: "server_error" });
+      return;
+    }
 
     sendJson(res, 201, {
       client_id: clientId,
-      client_name: body.client_name ?? "MCP Client",
+      client_name: clientName,
       redirect_uris: body.redirect_uris,
       grant_types: ["authorization_code"],
       response_types: ["code"],
@@ -796,6 +817,28 @@ export function createMcpHandler(): McpHandler {
       return;
     }
 
+    // RFC 6749 §4.1.3: redirect_uri MUST be present here and MUST be
+    // identical to the one used at the authorization request. §3.2.1: a
+    // public client (this one — token_endpoint_auth_method "none") MUST
+    // include client_id. Both are re-checked against what /mcp/authorize
+    // bound to the code below, once it's decoded.
+    const redirectUriParam = params.redirect_uri;
+    if (!redirectUriParam) {
+      sendJson(res, 400, {
+        error: "invalid_request",
+        error_description: "redirect_uri is required",
+      });
+      return;
+    }
+    const clientIdParam = params.client_id;
+    if (!clientIdParam) {
+      sendJson(res, 400, {
+        error: "invalid_request",
+        error_description: "client_id is required",
+      });
+      return;
+    }
+
     // Look up auth code from Redis
     if (!redis) {
       sendJson(res, 500, { error: "server_error" });
@@ -831,6 +874,8 @@ export function createMcpHandler(): McpHandler {
       userId?: string;
       codeChallenge: string;
       codeChallengeMethod: string;
+      redirectUri: string;
+      clientId: string;
       expiresAt: number;
     };
     try {
@@ -839,6 +884,25 @@ export function createMcpHandler(): McpHandler {
       sendJson(res, 400, {
         error: "invalid_grant",
         error_description: "Corrupted authorization code",
+      });
+      return;
+    }
+
+    // Bind the exchange to the exact client_id + redirect_uri /mcp/authorize
+    // validated and recorded for this code — a code minted for one client's
+    // registered URI must never be redeemable against a different one.
+    if (stored.redirectUri !== redirectUriParam) {
+      sendJson(res, 400, {
+        error: "invalid_grant",
+        error_description:
+          "redirect_uri does not match the authorization request",
+      });
+      return;
+    }
+    if (stored.clientId !== clientIdParam) {
+      sendJson(res, 400, {
+        error: "invalid_grant",
+        error_description: "client_id does not match the authorization request",
       });
       return;
     }
@@ -1336,6 +1400,11 @@ export function createMcpHandler(): McpHandler {
     oauthTokens.clear();
   }
 
+  function clearRateLimiters(): void {
+    oauthRateLimiter.clear();
+    authFailRateLimiter.clear();
+  }
+
   function closeAllSessions(): void {
     clearInterval(reaper);
     for (const [id, session] of sessions) {
@@ -1352,6 +1421,7 @@ export function createMcpHandler(): McpHandler {
     handleRequest,
     isMcpRoute,
     clearTokenCache,
+    clearRateLimiters,
     closeAllSessions,
   };
 }

--- a/langwatch/src/mcp/handler.ts
+++ b/langwatch/src/mcp/handler.ts
@@ -746,9 +746,9 @@ export function createMcpHandler(): McpHandler {
       typeof body.client_name === "string" ? body.client_name : "MCP Client";
 
     try {
-      await registerOAuthClient(clientId, {
-        redirectUris: body.redirect_uris,
-        clientName,
+      await registerOAuthClient({
+        clientId,
+        client: { redirectUris: body.redirect_uris, clientName },
       });
     } catch (err) {
       logger.error({ error: err }, "Failed to persist OAuth client registration");

--- a/langwatch/src/mcp/oauthClientRegistry.ts
+++ b/langwatch/src/mcp/oauthClientRegistry.ts
@@ -27,10 +27,13 @@ export interface RegisteredOAuthClient {
   clientName: string;
 }
 
-export async function registerOAuthClient(
-  clientId: string,
-  client: RegisteredOAuthClient,
-): Promise<void> {
+export async function registerOAuthClient({
+  clientId,
+  client,
+}: {
+  clientId: string;
+  client: RegisteredOAuthClient;
+}): Promise<void> {
   if (!redis) {
     throw new Error("Redis is not available");
   }

--- a/langwatch/src/mcp/oauthClientRegistry.ts
+++ b/langwatch/src/mcp/oauthClientRegistry.ts
@@ -1,0 +1,58 @@
+/**
+ * Redis-backed registry binding an MCP OAuth `client_id` (RFC 7591 dynamic
+ * client registration) to the `redirect_uris` it registered with.
+ *
+ * `/mcp/authorize` must validate the caller's `redirect_uri` against this
+ * registry with an exact string match before it ever issues an authorization
+ * code — an authorization server that accepts any `redirect_uri` lets an
+ * attacker who controls the authorization request (and its own PKCE
+ * `code_challenge`) redirect a victim's approved code to a domain they
+ * control (RFC 6749 §10.6). PKCE does not defend against this: PKCE proves
+ * the token-exchanger holds the verifier for the challenge in the code, and
+ * an attacker who authored the request holds both.
+ */
+import { connection as redis } from "~/server/redis";
+
+const REDIS_CLIENT_PREFIX = "mcp:oauth:client:";
+
+// Long enough that a real integration (Claude Desktop, Cursor, …) never sees
+// its registration expire between ordinary uses. Bounded rather than
+// unbounded so an abandoned registration eventually falls out of Redis
+// instead of accumulating forever; a client that outlives this window is
+// expected to re-register (that's what dynamic client registration is for).
+const CLIENT_TTL_SECONDS = 180 * 24 * 60 * 60;
+
+export interface RegisteredOAuthClient {
+  redirectUris: string[];
+  clientName: string;
+}
+
+export async function registerOAuthClient(
+  clientId: string,
+  client: RegisteredOAuthClient,
+): Promise<void> {
+  if (!redis) {
+    throw new Error("Redis is not available");
+  }
+  await redis.set(
+    `${REDIS_CLIENT_PREFIX}${clientId}`,
+    JSON.stringify(client),
+    "EX",
+    CLIENT_TTL_SECONDS,
+  );
+}
+
+export async function getOAuthClient(
+  clientId: string,
+): Promise<RegisteredOAuthClient | null> {
+  if (!redis) return null;
+  const raw = await redis.get(`${REDIS_CLIENT_PREFIX}${clientId}`);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as RegisteredOAuthClient;
+    if (!Array.isArray(parsed.redirectUris)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/langwatch/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.integration.test.ts
@@ -102,6 +102,7 @@ describe("POST /api/mcp/authorize — redirect_uri binding", () => {
   });
 
   describe("when redirect_uri exactly matches a registered URI for client_id", () => {
+    /** @scenario Authorization succeeds when redirect_uri exactly matches the registered client */
     it("issues an authorization code", async () => {
       mockRedis.get.mockResolvedValueOnce(registeredClient());
 
@@ -115,6 +116,7 @@ describe("POST /api/mcp/authorize — redirect_uri binding", () => {
   });
 
   describe("when redirect_uri does not match any URI registered for client_id (the exfiltration attempt)", () => {
+    /** @scenario Authorization is rejected when redirect_uri does not match the registered client */
     it("rejects with 400 and never mints an authorization code", async () => {
       // client_id genuinely registered — just with a DIFFERENT redirect_uri
       // than the one this request supplies. This is the exact reported
@@ -136,6 +138,7 @@ describe("POST /api/mcp/authorize — redirect_uri binding", () => {
   });
 
   describe("when client_id was never registered via /oauth/register", () => {
+    /** @scenario Authorization is rejected for an unregistered client_id */
     it("rejects with 400 and never mints an authorization code", async () => {
       mockRedis.get.mockResolvedValueOnce(null);
 
@@ -149,6 +152,7 @@ describe("POST /api/mcp/authorize — redirect_uri binding", () => {
   });
 
   describe("when client_id is omitted", () => {
+    /** @scenario Authorization is rejected when client_id is missing */
     it("rejects with 400 before ever looking up a registration", async () => {
       const res = await authorize({ client_id: undefined });
       const json = (await res.json()) as { error?: string };

--- a/langwatch/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/mcp-authorize.redirect-uri-binding.unit.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression guard for the MCP OAuth authorization-code exfiltration
+ * vulnerability (RFC 6749 §10.6): POST /api/mcp/authorize used to accept ANY
+ * redirect_uri, regardless of what the client_id registered via
+ * POST /oauth/register. A caller who crafts the authorization request (not
+ * necessarily the user who clicks Allow) could point redirect_uri at a
+ * domain they control and have the approved code delivered there — PKCE does
+ * not defend against this, since the attacker who authored the request also
+ * controls the code_challenge/code_verifier pair.
+ *
+ * The fix: /oauth/register persists client_id -> redirect_uris (see
+ * oauthClientRegistry.ts); /mcp/authorize now requires client_id, looks up
+ * that registration, and rejects unless redirect_uri is an exact string
+ * match against one of the registered URIs.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as ServerRedis from "~/server/redis";
+import { app } from "../misc";
+
+const PROJECT_ID = "project_1";
+const TEAM_ID = "team_1";
+const ORG_ID = "org_1";
+const REGISTERED_REDIRECT_URI = "https://registered.example/callback";
+
+const { mockPrisma, mockRedis, SESSION } = vi.hoisted(() => {
+  return {
+    SESSION: { user: { id: "member_1" }, expires: "1" },
+    mockRedis: {
+      set: vi.fn().mockResolvedValue("OK"),
+      get: vi.fn(),
+    },
+    mockPrisma: {
+      organizationUser: {
+        findFirst: vi.fn().mockResolvedValue({ role: "MEMBER" }),
+      },
+      groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
+      roleBinding: {
+        findMany: vi.fn().mockResolvedValue([
+          { role: "ADMIN", customRoleId: null, scopeType: "TEAM" },
+        ]),
+      },
+      customRole: { findUnique: vi.fn().mockResolvedValue(null) },
+      teamUser: { findFirst: vi.fn().mockResolvedValue(null) },
+      project: {
+        findUnique: vi.fn(({ select }: { select?: { team?: unknown } }) =>
+          select?.team
+            ? Promise.resolve({
+                team: { id: TEAM_ID, organizationId: ORG_ID },
+              })
+            : Promise.resolve({
+                id: PROJECT_ID,
+                apiKey: "lw_test_key",
+                archivedAt: null as Date | null,
+              }),
+        ),
+      },
+    },
+  };
+});
+
+vi.mock("~/server/auth", () => ({
+  getServerAuthSession: vi.fn().mockResolvedValue(SESSION),
+}));
+vi.mock("~/server/db", () => ({ prisma: mockPrisma }));
+vi.mock("~/server/redis", async (importOriginal) => {
+  const actual = await importOriginal<typeof ServerRedis>();
+  return { ...actual, connection: mockRedis };
+});
+vi.mock("~/utils/encryption", () => ({
+  encrypt: (text: string) => `encrypted:${text}`,
+  decrypt: (text: string) =>
+    text.startsWith("encrypted:") ? text.slice(10) : text,
+}));
+
+function registeredClient(redirectUris = [REGISTERED_REDIRECT_URI]) {
+  return JSON.stringify({ redirectUris, clientName: "Legit client" });
+}
+
+async function authorize(overrides: Record<string, unknown> = {}) {
+  return app.request("http://localhost/api/mcp/authorize", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      projectId: PROJECT_ID,
+      redirect_uri: REGISTERED_REDIRECT_URI,
+      code_challenge: "challenge123",
+      code_challenge_method: "S256",
+      client_id: "mcp_legit_client",
+      state: "xyz",
+      ...overrides,
+    }),
+  });
+}
+
+describe("POST /api/mcp/authorize — redirect_uri binding", () => {
+  beforeEach(() => {
+    mockRedis.set.mockClear();
+    mockRedis.get.mockClear();
+  });
+
+  describe("when redirect_uri exactly matches a registered URI for client_id", () => {
+    it("issues an authorization code", async () => {
+      mockRedis.get.mockResolvedValueOnce(registeredClient());
+
+      const res = await authorize();
+      const json = (await res.json()) as { redirect?: string; error?: string };
+
+      expect(res.status).toBe(200);
+      expect(json.error).toBeUndefined();
+      expect(json.redirect).toContain("code=");
+    });
+  });
+
+  describe("when redirect_uri does not match any URI registered for client_id (the exfiltration attempt)", () => {
+    it("rejects with 400 and never mints an authorization code", async () => {
+      // client_id genuinely registered — just with a DIFFERENT redirect_uri
+      // than the one this request supplies. This is the exact reported
+      // exploit: register with a legitimate URI, then authorize against an
+      // attacker-controlled one.
+      mockRedis.get.mockResolvedValueOnce(registeredClient());
+
+      const res = await authorize({
+        redirect_uri: "https://attacker.invalid/callback",
+      });
+      const json = (await res.json()) as { redirect?: string; error?: string };
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain("redirect_uri does not match");
+      expect(json.redirect).toBeUndefined();
+      // No auth code was ever written to Redis for this request.
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when client_id was never registered via /oauth/register", () => {
+    it("rejects with 400 and never mints an authorization code", async () => {
+      mockRedis.get.mockResolvedValueOnce(null);
+
+      const res = await authorize({ client_id: "mcp_never_registered" });
+      const json = (await res.json()) as { redirect?: string; error?: string };
+
+      expect(res.status).toBe(400);
+      expect(json.error).toBe("Unknown or unregistered client_id");
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when client_id is omitted", () => {
+    it("rejects with 400 before ever looking up a registration", async () => {
+      const res = await authorize({ client_id: undefined });
+      const json = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain("client_id");
+      expect(mockRedis.get).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
@@ -27,7 +27,17 @@ const ERROR = "Project not found or you don't have access";
 const { mockPrisma, mockRedis, SESSION } = vi.hoisted(() => {
   return {
     SESSION: { user: { id: "member_rolebinding_only" }, expires: "1" },
-    mockRedis: { set: vi.fn().mockResolvedValue("OK") },
+    // get() stands in for the OAuth client registry lookup: client_1 is
+    // "registered" with exactly the redirect_uri validBody uses below.
+    mockRedis: {
+      set: vi.fn().mockResolvedValue("OK"),
+      get: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          redirectUris: ["https://example.com/callback"],
+          clientName: "Test client",
+        }),
+      ),
+    },
     mockPrisma: {
       // resolveProjectPermission fails closed on current org membership before
       // it ever looks at bindings: a genuine team member is always an

--- a/langwatch/src/server/routes/misc.ts
+++ b/langwatch/src/server/routes/misc.ts
@@ -56,6 +56,7 @@ import {
 } from "~/server/app-layer/events/track-event.service";
 import { ProjectService } from "~/server/app-layer/projects/project.service";
 import { PrismaProjectRepository } from "~/server/app-layer/projects/repositories/project.prisma.repository";
+import { getOAuthClient } from "~/mcp/oauthClientRegistry";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
 import {
@@ -512,8 +513,11 @@ secured
       client_id,
     } = body;
 
-    if (!projectId || !redirect_uri) {
-      return c.json({ error: "projectId and redirect_uri are required" }, 400);
+    if (!projectId || !redirect_uri || !client_id) {
+      return c.json(
+        { error: "projectId, redirect_uri and client_id are required" },
+        400,
+      );
     }
 
     try {
@@ -527,6 +531,33 @@ secured
       }
     } catch {
       return c.json({ error: "Invalid redirect_uri" }, 400);
+    }
+
+    // RFC 6749 §10.6: an authorization server must only ever issue a code to
+    // a redirect_uri that was registered for this client_id — otherwise
+    // whoever crafts the authorization request (which can be an attacker,
+    // not the approving user) can point it at a URI they control and the
+    // approved code is exfiltrated there. PKCE does not defend against this:
+    // it proves the token-exchanger holds the verifier for the challenge in
+    // the code, and an attacker who authored the request holds both. Exact
+    // string match against the client's /oauth/register'd redirect_uris —
+    // no scheme/host-only comparison, which a subdomain or path trick could
+    // slip past.
+    const registeredClient = await getOAuthClient(client_id);
+    if (!registeredClient) {
+      return c.json(
+        { error: "Unknown or unregistered client_id" },
+        400,
+      );
+    }
+    if (!registeredClient.redirectUris.includes(redirect_uri)) {
+      return c.json(
+        {
+          error:
+            "redirect_uri does not match any redirect URI registered for this client_id",
+        },
+        400,
+      );
     }
 
     if (!code_challenge) {
@@ -592,7 +623,12 @@ secured
       userId: session.user.id,
       codeChallenge: code_challenge,
       codeChallengeMethod: code_challenge_method ?? "S256",
-      clientId: client_id ?? "",
+      // Bound here so /oauth/token can require the exchange to present the
+      // exact same client_id + redirect_uri this authorization was validated
+      // and approved against (RFC 6749 §4.1.3 / §3.2.1) — a code minted for
+      // one client's registered URI must never be redeemable against another.
+      clientId: client_id,
+      redirectUri: redirect_uri,
       expiresAt: Date.now() + AUTH_CODE_TTL_SECONDS * 1000,
     });
 

--- a/langwatch/vite.config.ts
+++ b/langwatch/vite.config.ts
@@ -276,7 +276,15 @@ export default defineConfig(async (): Promise<UserConfig> => {
         // No-op when API is on plain HTTP.
         secure: false,
       },
-      "/mcp": {
+      // Exact-match only ("^...$") — a plain "/mcp" prefix also swallows the
+      // /mcp/authorize frontend page route (src/pages/mcp/authorize.tsx),
+      // sending it to the API server, which has no dev-mode page fallback.
+      "^/mcp$": {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+      "^/mcp/health$": {
         target: API_TARGET,
         changeOrigin: true,
         secure: false,

--- a/langwatch/vite.config.ts
+++ b/langwatch/vite.config.ts
@@ -279,12 +279,15 @@ export default defineConfig(async (): Promise<UserConfig> => {
       // Exact-match only ("^...$") — a plain "/mcp" prefix also swallows the
       // /mcp/authorize frontend page route (src/pages/mcp/authorize.tsx),
       // sending it to the API server, which has no dev-mode page fallback.
-      "^/mcp$": {
+      // server.proxy regexes test against the full req.url (path + query),
+      // so the optional "(?:\?.*)?" is required or a query-bearing request
+      // like "/mcp?sessionId=..." falls through to the frontend instead.
+      "^/mcp(?:\\?.*)?$": {
         target: API_TARGET,
         changeOrigin: true,
         secure: false,
       },
-      "^/mcp/health$": {
+      "^/mcp/health(?:\\?.*)?$": {
         target: API_TARGET,
         changeOrigin: true,
         secure: false,

--- a/specs/mcp-server/mcp-in-app.feature
+++ b/specs/mcp-server/mcp-in-app.feature
@@ -130,14 +130,6 @@ Feature: MCP HTTP Server In-App Integration (Phase 1)
     And it does not import any main app server or database modules
 
   # --- OAuth Authorization Code + PKCE: redirect_uri / client_id binding ---
-  #
-  # RFC 6749 §10.6 / §4.1.3 / §3.2.1 + RFC 7591 dynamic client registration.
-  # Regression class: /oauth/register did not persist a client's
-  # redirect_uris, so /mcp/authorize accepted ANY redirect_uri regardless of
-  # what the client_id had registered, and /oauth/token never re-checked
-  # redirect_uri or client_id at exchange time either. PKCE alone does not
-  # defend against this — whoever crafts the authorization request controls
-  # the code_challenge/code_verifier pair too, not just the approving user.
 
   @regression @integration
   Scenario: Dynamic client registration persists the redirect_uris binding

--- a/specs/mcp-server/mcp-in-app.feature
+++ b/specs/mcp-server/mcp-in-app.feature
@@ -129,6 +129,79 @@ Feature: MCP HTTP Server In-App Integration (Phase 1)
     Then it communicates via stdin/stdout
     And it does not import any main app server or database modules
 
+  # --- OAuth Authorization Code + PKCE: redirect_uri / client_id binding ---
+  #
+  # RFC 6749 §10.6 / §4.1.3 / §3.2.1 + RFC 7591 dynamic client registration.
+  # Regression class: /oauth/register did not persist a client's
+  # redirect_uris, so /mcp/authorize accepted ANY redirect_uri regardless of
+  # what the client_id had registered, and /oauth/token never re-checked
+  # redirect_uri or client_id at exchange time either. PKCE alone does not
+  # defend against this — whoever crafts the authorization request controls
+  # the code_challenge/code_verifier pair too, not just the approving user.
+
+  @regression @integration
+  Scenario: Dynamic client registration persists the redirect_uris binding
+    Given a client posts client_name and redirect_uris to /oauth/register
+    When the registration succeeds
+    Then the client_id is durably bound to those redirect_uris for later lookup
+
+  @regression @integration
+  Scenario: Dynamic client registration rejects a request with no redirect_uris
+    Given a client posts to /oauth/register with no redirect_uris
+    Then the response status is 400
+    And the response error is "invalid_client_metadata"
+
+  @regression @integration
+  Scenario: Authorization succeeds when redirect_uri exactly matches the registered client
+    Given a client registered with redirect_uri "https://registered.example/callback"
+    When an authorization request for that client_id supplies the exact same redirect_uri
+    Then an authorization code is issued
+
+  @regression @integration
+  Scenario: Authorization is rejected when redirect_uri does not match the registered client
+    Given a client registered with redirect_uri "https://registered.example/callback"
+    When an authorization request for that client_id supplies a different redirect_uri
+    Then the response status is 400
+    And no authorization code is issued
+
+  @regression @integration
+  Scenario: Authorization is rejected for an unregistered client_id
+    Given no client is registered with client_id "mcp_never_registered"
+    When an authorization request is made with that client_id
+    Then the response status is 400
+    And the response error is "Unknown or unregistered client_id"
+
+  @regression @integration
+  Scenario: Authorization is rejected when client_id is missing
+    When an authorization request omits client_id
+    Then the response status is 400 before any registration lookup happens
+
+  @regression @integration
+  Scenario: Token exchange is rejected when redirect_uri is missing
+    Given an authorization code exists
+    When the token exchange omits redirect_uri
+    Then the response status is 400 with error "invalid_request"
+
+  @regression @integration
+  Scenario: Token exchange is rejected when client_id is missing
+    Given an authorization code exists
+    When the token exchange omits client_id
+    Then the response status is 400 with error "invalid_request"
+
+  @regression @integration
+  Scenario: Token exchange is rejected when redirect_uri does not match the authorization request
+    Given an authorization code was issued for a specific client_id and redirect_uri
+    When the token exchange presents a different redirect_uri
+    Then the response status is 400 with error "invalid_grant"
+    And no access token is issued
+
+  @regression @integration
+  Scenario: Token exchange is rejected when client_id does not match the authorization request
+    Given an authorization code was issued for a specific client_id and redirect_uri
+    When the token exchange presents a different client_id
+    Then the response status is 400 with error "invalid_grant"
+    And no access token is issued
+
   # --- Tool Availability ---
 
   @integration @unimplemented


### PR DESCRIPTION
## Summary
- `/oauth/register` now persists each client's `redirect_uris` (Redis-backed registry) instead of only echoing them back in the response.
- `/mcp/authorize` requires an exact match against a client's registered `redirect_uris` before issuing an authorization code, and binds the issued code to the exact `client_id` + `redirect_uri` it validated.
- `/oauth/token` now requires both `redirect_uri` and `client_id` at exchange time, and rejects the exchange unless they match what was bound to the code at authorization.

## Rollout consideration
Any MCP client that registered via `/oauth/register` **before** this ships has no entry in the new registry. Its next `/mcp/authorize` attempt will get `Unknown or unregistered client_id` until it re-registers. RFC 7591 doesn't guarantee a client reacts to that by re-registering automatically — most MCP client implementations do, since a fresh client_id is exactly what dynamic registration is for, but this is worth a quick check against whatever's actually connected before this merges.

## Test plan
- [x] `mcp-authorize.redirect-uri-binding.integration.test.ts` — registered vs. mismatched vs. unregistered vs. missing `client_id`, driving the full route with only DB/Redis mocked (moved from `.unit.test.ts` — it isn't pure-logic-in-isolation)
- [x] `mcp-authorize.rolebinding.unit.test.ts` — updated for the now-mandatory client lookup, still passing
- [x] `mcp-handler.integration.test.ts` — extended with end-to-end token-exchange binding checks and `/oauth/register` persistence coverage
- [x] `oauthClientRegistry.integration.test.ts` (new) — register→get round trip and defensive-parsing branches against **real Redis** (testcontainers), not mocks, per `dev/docs/best_practices/repository-service.md`
- [x] New `@regression @integration` scenarios in `specs/mcp-server/mcp-in-app.feature`, bound to the tests above via `@scenario` JSDoc annotations — `pnpm check:feature-parity` passes (10/10 bound)
- [x] `pnpm typecheck` and `pnpm typecheck:tests` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Hardened MCP OAuth flows with stricter validation for `/api/mcp/authorize` and `/oauth/token`.
  * Authorization and token exchange now require both `client_id` and an exact `redirect_uri` match bound to the original registration; missing or mismatched details return `400` without issuing tokens.
* **New Features**
  * Added Redis-backed persistence for dynamically registered OAuth clients and their allowed redirect URIs.
  * OAuth client registration now returns a normalized client name.
* **Tests**
  * Added integration/regression coverage for redirect URI binding, error cases, and registry behavior.
  * Improved test determinism via test-only rate-limiter cleanup.
* **Chores**
  * Tightened MCP dev-server proxy routing to avoid intercepting the authorize UI route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->