### PR TITLE
fix(traces): keep lone UTF-16 surrogate spans via ClickHouse safe-escape insert setting

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -878,3 +878,107 @@ describe("SpanStorageClickHouseRepository langwatch signals read (integration)",
     });
   });
 });
+
+// A lone (unpaired) UTF-16 surrogate half — the shape a string takes when it is
+// truncated mid-emoji, or an SDK captured binary/garbage text as a string.
+// `JSONEachRow` serialises it as a `\uD83D`-style escape with no second part,
+// which ClickHouse's JSON parser rejects by default ("missing second part of
+// surrogate pair") — failing the whole insert, exhausting retries, and
+// dead-lettering the span forever. `SPAN_INSERT_SETTINGS` disables that throw
+// (`input_format_json_throw_on_bad_escape_sequence: 0`) so the byte is kept as
+// text and the span survives. This suite drives the real production write path
+// against real ClickHouse: with the setting removed, `insertSpans` throws here
+// and the round-trip read finds nothing.
+const LONE_HIGH_SURROGATE = "\uD83D";
+const LONE_LOW_SURROGATE = "\uDC00";
+
+function spanWithLoneSurrogates(
+  surrogateTenantId: string,
+  surrogateTraceId: string,
+): SpanInsertData {
+  return {
+    id: `proj-${nanoid()}`,
+    tenantId: surrogateTenantId,
+    traceId: surrogateTraceId,
+    spanId: "surrogate-span",
+    parentSpanId: null,
+    parentTraceId: null,
+    parentIsRemote: null,
+    sampled: true,
+    startTimeUnixMs: base,
+    endTimeUnixMs: base + 100,
+    durationMs: 100,
+    name: `span name ${LONE_HIGH_SURROGATE}`,
+    kind: 0,
+    resourceAttributes: {
+      [`res.key.${LONE_HIGH_SURROGATE}`]: `res.val.${LONE_LOW_SURROGATE}`,
+    },
+    spanAttributes: {
+      clean: "kept-verbatim",
+      [`attr.key.${LONE_HIGH_SURROGATE}`]: `attr.val.${LONE_LOW_SURROGATE}`,
+      nested: { text: `deep ${LONE_HIGH_SURROGATE}` },
+    },
+    statusCode: 2,
+    statusMessage: `error: ${LONE_LOW_SURROGATE}`,
+    instrumentationScope: {
+      name: `scope ${LONE_HIGH_SURROGATE}`,
+      version: `v1 ${LONE_LOW_SURROGATE}`,
+    },
+    events: [
+      {
+        name: `event ${LONE_HIGH_SURROGATE}`,
+        timeUnixMs: base + 50,
+        attributes: {
+          [`ev.key.${LONE_HIGH_SURROGATE}`]: `ev.val.${LONE_LOW_SURROGATE}`,
+        },
+      },
+    ],
+    links: [],
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+    cost: null,
+    nonBilledCost: null,
+    retentionDays: 0,
+  };
+}
+
+describe("SpanStorageClickHouseRepository lone-surrogate span insert (integration)", () => {
+  const surrogateTenantId = `test-span-surrogate-${nanoid()}`;
+  const surrogateTraceId = `trace-${nanoid()}`;
+
+  afterAll(async () => {
+    if (ch) {
+      await ch.exec({
+        query:
+          "ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}",
+        query_params: { tenantId: surrogateTenantId },
+      });
+    }
+  });
+
+  describe("given a span whose name, status, scope, events and attributes carry lone UTF-16 surrogates", () => {
+    describe("when the repository inserts it through the JSONEachRow write path", () => {
+      it("does not throw the surrogate-pair parse error that dead-letters the span", async () => {
+        await expect(
+          repo.insertSpans([
+            spanWithLoneSurrogates(surrogateTenantId, surrogateTraceId),
+          ]),
+        ).resolves.toBeUndefined();
+      });
+
+      it("persists the span so it reads back instead of being lost", async () => {
+        const spans = await repo.getNormalizedSpansByTraceId({
+          tenantId: surrogateTenantId,
+          traceId: surrogateTraceId,
+        });
+
+        const span = spans.find((s) => s.spanId === "surrogate-span");
+        expect(span).toBeDefined();
+        // Valid data on the same span is untouched — the insert stored the row
+        // whole, it did not drop the malformed fields or the clean ones.
+        expect(String(span?.spanAttributes.clean)).toBe("kept-verbatim");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -886,21 +886,26 @@ describe("SpanStorageClickHouseRepository langwatch signals read (integration)",
 // surrogate pair") — failing the whole insert, exhausting retries, and
 // dead-lettering the span forever. `SPAN_INSERT_SETTINGS` disables that throw
 // (`input_format_json_throw_on_bad_escape_sequence: 0`) so the byte is kept as
-// text and the span survives. This suite drives the real production write path
-// against real ClickHouse: with the setting removed, `insertSpans` throws here
-// and the round-trip read finds nothing.
+// text and the span survives. This suite drives the real production write paths
+// (`insertSpan` and `insertSpans`) against real ClickHouse: with the setting
+// removed, the insert throws here and the round-trip read finds nothing.
 const LONE_HIGH_SURROGATE = "\uD83D";
 const LONE_LOW_SURROGATE = "\uDC00";
 
-function spanWithLoneSurrogates(
-  surrogateTenantId: string,
-  surrogateTraceId: string,
-): SpanInsertData {
+function spanWithLoneSurrogates({
+  tenantId: surrogateTenantId,
+  traceId: surrogateTraceId,
+  spanId,
+}: {
+  tenantId: string;
+  traceId: string;
+  spanId: string;
+}): SpanInsertData {
   return {
     id: `proj-${nanoid()}`,
     tenantId: surrogateTenantId,
     traceId: surrogateTraceId,
-    spanId: "surrogate-span",
+    spanId,
     parentSpanId: null,
     parentTraceId: null,
     parentIsRemote: null,
@@ -945,7 +950,6 @@ function spanWithLoneSurrogates(
 
 describe("SpanStorageClickHouseRepository lone-surrogate span insert (integration)", () => {
   const surrogateTenantId = `test-span-surrogate-${nanoid()}`;
-  const surrogateTraceId = `trace-${nanoid()}`;
 
   afterAll(async () => {
     if (ch) {
@@ -957,27 +961,55 @@ describe("SpanStorageClickHouseRepository lone-surrogate span insert (integratio
     }
   });
 
+  // Each test inserts its own span under a fresh traceId and reads it back
+  // within the same test — so it exercises the full write→read path on its own
+  // (no ordering dependency on a sibling test) and covers both repository write
+  // methods. Without `SPAN_INSERT_SETTINGS`, the insert throws the surrogate-
+  // pair parse error and the read-back finds nothing.
   describe("given a span whose name, status, scope, events and attributes carry lone UTF-16 surrogates", () => {
-    describe("when the repository inserts it through the JSONEachRow write path", () => {
-      it("does not throw the surrogate-pair parse error that dead-letters the span", async () => {
+    describe("when it is inserted through the bulk insertSpans write path", () => {
+      it("stores the span whole instead of throwing the surrogate-pair error that dead-letters it", async () => {
+        const traceId = `trace-${nanoid()}`;
         await expect(
           repo.insertSpans([
-            spanWithLoneSurrogates(surrogateTenantId, surrogateTraceId),
+            spanWithLoneSurrogates({
+              tenantId: surrogateTenantId,
+              traceId,
+              spanId: "surrogate-bulk",
+            }),
           ]),
         ).resolves.toBeUndefined();
-      });
 
-      it("persists the span so it reads back instead of being lost", async () => {
         const spans = await repo.getNormalizedSpansByTraceId({
           tenantId: surrogateTenantId,
-          traceId: surrogateTraceId,
+          traceId,
         });
+        const stored = spans.find((s) => s.spanId === "surrogate-bulk");
+        expect(stored).toBeDefined();
+        expect(String(stored?.spanAttributes.clean)).toBe("kept-verbatim");
+      });
+    });
 
-        const span = spans.find((s) => s.spanId === "surrogate-span");
-        expect(span).toBeDefined();
-        // Valid data on the same span is untouched — the insert stored the row
-        // whole, it did not drop the malformed fields or the clean ones.
-        expect(String(span?.spanAttributes.clean)).toBe("kept-verbatim");
+    describe("when it is inserted through the single insertSpan write path", () => {
+      it("stores the span whole instead of throwing the surrogate-pair error that dead-letters it", async () => {
+        const traceId = `trace-${nanoid()}`;
+        await expect(
+          repo.insertSpan(
+            spanWithLoneSurrogates({
+              tenantId: surrogateTenantId,
+              traceId,
+              spanId: "surrogate-single",
+            }),
+          ),
+        ).resolves.toBeUndefined();
+
+        const spans = await repo.getNormalizedSpansByTraceId({
+          tenantId: surrogateTenantId,
+          traceId,
+        });
+        const stored = spans.find((s) => s.spanId === "surrogate-single");
+        expect(stored).toBeDefined();
+        expect(String(stored?.spanAttributes.clean)).toBe("kept-verbatim");
       });
     });
   });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { SpanInsertData } from "../../types";
 import {
   deserializeAttributes,
   mapSpanSummaryRow,
@@ -11,6 +12,29 @@ import {
   MAX_DERIVATION_SPANS,
   MAX_LIGHT_SPAN_READ_ROWS,
 } from "../span-storage.repository";
+
+// A lone (unpaired) UTF-16 surrogate half — the shape a string takes when it is
+// truncated mid-emoji or an SDK captured binary/garbage text. `JSONEachRow`
+// serialises it as a `\uD83D`-style escape with no second part, which is what
+// ClickHouse's JSON parser rejects ("missing second part of surrogate pair"),
+// dead-lettering the span forever.
+const LONE_HIGH_SURROGATE = "\uD83D";
+const LONE_LOW_SURROGATE = "\uDC00";
+
+/** Recursively collects every string (object keys included) from a value. */
+function collectStrings(value: unknown, out: string[] = []): string[] {
+  if (typeof value === "string") {
+    out.push(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, out);
+  } else if (value && typeof value === "object") {
+    for (const [key, val] of Object.entries(value)) {
+      out.push(key);
+      collectStrings(val, out);
+    }
+  }
+  return out;
+}
 
 describe("serializeAttributes", () => {
   describe("when given string values", () => {
@@ -71,6 +95,56 @@ describe("serializeAttributes", () => {
       circular.self = circular;
       const result = serializeAttributes({ ok: "yes", bad: circular });
       expect(result).toEqual({ ok: "yes" });
+    });
+  });
+
+  describe("given an attribute key or value with a lone UTF-16 surrogate", () => {
+    describe("when serializing for the ClickHouse write boundary", () => {
+      it("replaces a lone surrogate in a string value with U+FFFD", () => {
+        const result = serializeAttributes({
+          key: `bad${LONE_HIGH_SURROGATE}`,
+        });
+        expect(result.key!.isWellFormed()).toBe(true);
+        expect(result.key).toBe("bad�");
+      });
+
+      it("replaces a lone surrogate in a map key with U+FFFD", () => {
+        const result = serializeAttributes({
+          [`k${LONE_LOW_SURROGATE}`]: "value",
+        });
+        const keys = Object.keys(result);
+        expect(keys).toHaveLength(1);
+        expect(keys[0]!.isWellFormed()).toBe(true);
+        expect(keys[0]).toBe("k�");
+      });
+
+      it("produces keys and values that survive a JSON encode/decode round-trip well-formed", () => {
+        // JSONEachRow encodes the map with JSON; a strict consumer (ClickHouse)
+        // decodes it. A lone surrogate would survive the encode as a `\uXXXX`
+        // escape and blow up the decode — sanitising leaves nothing to reject.
+        const result = serializeAttributes({
+          [`k${LONE_HIGH_SURROGATE}`]: `v${LONE_LOW_SURROGATE}`,
+        });
+        const reparsed = JSON.parse(JSON.stringify(result)) as Record<
+          string,
+          string
+        >;
+        for (const [key, value] of Object.entries(reparsed)) {
+          expect(key.isWellFormed()).toBe(true);
+          expect(value.isWellFormed()).toBe(true);
+        }
+      });
+
+      it("emits a well-formed map value when a lone surrogate is nested inside a JSON-serialized object", () => {
+        // `JSON.stringify` escapes the lone surrogate to a literal `\uXXXX`
+        // sequence, so the map-value string handed to ClickHouse carries no
+        // lone surrogate code unit — and the outer JSONEachRow encode
+        // double-escapes it, so ClickHouse's parser accepts it as text.
+        const result = serializeAttributes({
+          nested: { text: `deep${LONE_HIGH_SURROGATE}` },
+        });
+        expect(result.nested!.isWellFormed()).toBe(true);
+      });
     });
   });
 });
@@ -710,6 +784,120 @@ describe("mapSpanSummaryRow", () => {
         }),
       );
       expect(result.cost).toBeCloseTo(1000 * 0.001 + 1000 * 0.0001, 10);
+    });
+  });
+});
+
+describe("SpanStorageClickHouseRepository ClickHouse record building", () => {
+  function repoWithInsertSpy() {
+    const insert = vi.fn().mockResolvedValue(undefined);
+    const repo = new SpanStorageClickHouseRepository((async () => ({
+      insert,
+    })) as unknown as ConstructorParameters<
+      typeof SpanStorageClickHouseRepository
+    >[0]);
+    return { repo, insert };
+  }
+
+  function spanWithLoneSurrogates(): SpanInsertData {
+    return {
+      id: "proj-1",
+      tenantId: "proj-1",
+      traceId: "t-1",
+      spanId: "s-1",
+      parentSpanId: null,
+      parentTraceId: null,
+      parentIsRemote: null,
+      sampled: true,
+      startTimeUnixMs: 1_700_000_000_000,
+      endTimeUnixMs: 1_700_000_000_100,
+      durationMs: 100,
+      name: `span name ${LONE_HIGH_SURROGATE}`,
+      kind: 0,
+      resourceAttributes: {
+        [`res.key.${LONE_HIGH_SURROGATE}`]: `res.val.${LONE_LOW_SURROGATE}`,
+      },
+      spanAttributes: {
+        [`attr.key.${LONE_HIGH_SURROGATE}`]: `attr.val.${LONE_LOW_SURROGATE}`,
+        nested: { text: `deep ${LONE_HIGH_SURROGATE}` },
+      },
+      statusCode: 2,
+      statusMessage: `error: ${LONE_LOW_SURROGATE}`,
+      instrumentationScope: {
+        name: `scope ${LONE_HIGH_SURROGATE}`,
+        version: `v1 ${LONE_LOW_SURROGATE}`,
+      },
+      events: [
+        {
+          name: `event ${LONE_HIGH_SURROGATE}`,
+          timeUnixMs: 1_700_000_000_050,
+          attributes: {
+            [`ev.key.${LONE_HIGH_SURROGATE}`]: `ev.val.${LONE_LOW_SURROGATE}`,
+          },
+        },
+      ],
+      links: [
+        {
+          traceId: "lt-1",
+          spanId: "ls-1",
+          attributes: {
+            [`ln.key.${LONE_HIGH_SURROGATE}`]: `ln.val.${LONE_LOW_SURROGATE}`,
+          },
+        },
+      ],
+      droppedAttributesCount: 0,
+      droppedEventsCount: 0,
+      droppedLinksCount: 0,
+      cost: null,
+      nonBilledCost: null,
+      retentionDays: 0,
+    };
+  }
+
+  describe("given a span whose name, status, scope, events and attributes carry lone UTF-16 surrogates", () => {
+    describe("when the repository builds the record for the JSONEachRow insert", () => {
+      it("sanitises every string in the record to well-formed UTF-16", async () => {
+        const { repo, insert } = repoWithInsertSpy();
+
+        await repo.insertSpans([spanWithLoneSurrogates()]);
+
+        const record = insert.mock.calls[0]?.[0]?.values?.[0];
+        expect(record).toBeDefined();
+        for (const s of collectStrings(record)) {
+          expect(s.isWellFormed()).toBe(true);
+        }
+      });
+
+      it("replaces the lone surrogates with U+FFFD instead of dropping the fields", async () => {
+        const { repo, insert } = repoWithInsertSpy();
+
+        await repo.insertSpans([spanWithLoneSurrogates()]);
+
+        const record = insert.mock.calls[0]?.[0]?.values?.[0];
+        // Assert the marker landed so the test cannot pass vacuously against an
+        // unsanitised record — the fix must actually have run on each field.
+        expect(record.SpanName).toContain("�");
+        expect(record.StatusMessage).toContain("�");
+        expect(record.ScopeName).toContain("�");
+        expect(record.ScopeVersion).toContain("�");
+        expect(record["Events.Name"][0]).toContain("�");
+      });
+
+      it("emits a record that survives a JSON encode/decode round-trip well-formed, which a lone surrogate would not", async () => {
+        const { repo, insert } = repoWithInsertSpy();
+
+        await repo.insertSpans([spanWithLoneSurrogates()]);
+
+        const record = insert.mock.calls[0]?.[0]?.values?.[0];
+        // The client sends the record as JSON (JSONEachRow); ClickHouse decodes
+        // it strictly. A lone surrogate would survive JSON.stringify as a
+        // `\uD83D`-style escape and reconstruct as an unpaired half on decode —
+        // the exact input ClickHouse rejects. A well-formed record cannot.
+        const reparsed = JSON.parse(JSON.stringify(record));
+        for (const s of collectStrings(reparsed)) {
+          expect(s.isWellFormed()).toBe(true);
+        }
+      });
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import type { SpanInsertData } from "../../types";
 import {
   deserializeAttributes,
   mapSpanSummaryRow,
@@ -12,29 +11,6 @@ import {
   MAX_DERIVATION_SPANS,
   MAX_LIGHT_SPAN_READ_ROWS,
 } from "../span-storage.repository";
-
-// A lone (unpaired) UTF-16 surrogate half — the shape a string takes when it is
-// truncated mid-emoji or an SDK captured binary/garbage text. `JSONEachRow`
-// serialises it as a `\uD83D`-style escape with no second part, which is what
-// ClickHouse's JSON parser rejects ("missing second part of surrogate pair"),
-// dead-lettering the span forever.
-const LONE_HIGH_SURROGATE = "\uD83D";
-const LONE_LOW_SURROGATE = "\uDC00";
-
-/** Recursively collects every string (object keys included) from a value. */
-function collectStrings(value: unknown, out: string[] = []): string[] {
-  if (typeof value === "string") {
-    out.push(value);
-  } else if (Array.isArray(value)) {
-    for (const item of value) collectStrings(item, out);
-  } else if (value && typeof value === "object") {
-    for (const [key, val] of Object.entries(value)) {
-      out.push(key);
-      collectStrings(val, out);
-    }
-  }
-  return out;
-}
 
 describe("serializeAttributes", () => {
   describe("when given string values", () => {
@@ -95,56 +71,6 @@ describe("serializeAttributes", () => {
       circular.self = circular;
       const result = serializeAttributes({ ok: "yes", bad: circular });
       expect(result).toEqual({ ok: "yes" });
-    });
-  });
-
-  describe("given an attribute key or value with a lone UTF-16 surrogate", () => {
-    describe("when serializing for the ClickHouse write boundary", () => {
-      it("replaces a lone surrogate in a string value with U+FFFD", () => {
-        const result = serializeAttributes({
-          key: `bad${LONE_HIGH_SURROGATE}`,
-        });
-        expect(result.key!.isWellFormed()).toBe(true);
-        expect(result.key).toBe("bad�");
-      });
-
-      it("replaces a lone surrogate in a map key with U+FFFD", () => {
-        const result = serializeAttributes({
-          [`k${LONE_LOW_SURROGATE}`]: "value",
-        });
-        const keys = Object.keys(result);
-        expect(keys).toHaveLength(1);
-        expect(keys[0]!.isWellFormed()).toBe(true);
-        expect(keys[0]).toBe("k�");
-      });
-
-      it("produces keys and values that survive a JSON encode/decode round-trip well-formed", () => {
-        // JSONEachRow encodes the map with JSON; a strict consumer (ClickHouse)
-        // decodes it. A lone surrogate would survive the encode as a `\uXXXX`
-        // escape and blow up the decode — sanitising leaves nothing to reject.
-        const result = serializeAttributes({
-          [`k${LONE_HIGH_SURROGATE}`]: `v${LONE_LOW_SURROGATE}`,
-        });
-        const reparsed = JSON.parse(JSON.stringify(result)) as Record<
-          string,
-          string
-        >;
-        for (const [key, value] of Object.entries(reparsed)) {
-          expect(key.isWellFormed()).toBe(true);
-          expect(value.isWellFormed()).toBe(true);
-        }
-      });
-
-      it("emits a well-formed map value when a lone surrogate is nested inside a JSON-serialized object", () => {
-        // `JSON.stringify` escapes the lone surrogate to a literal `\uXXXX`
-        // sequence, so the map-value string handed to ClickHouse carries no
-        // lone surrogate code unit — and the outer JSONEachRow encode
-        // double-escapes it, so ClickHouse's parser accepts it as text.
-        const result = serializeAttributes({
-          nested: { text: `deep${LONE_HIGH_SURROGATE}` },
-        });
-        expect(result.nested!.isWellFormed()).toBe(true);
-      });
     });
   });
 });
@@ -784,120 +710,6 @@ describe("mapSpanSummaryRow", () => {
         }),
       );
       expect(result.cost).toBeCloseTo(1000 * 0.001 + 1000 * 0.0001, 10);
-    });
-  });
-});
-
-describe("SpanStorageClickHouseRepository ClickHouse record building", () => {
-  function repoWithInsertSpy() {
-    const insert = vi.fn().mockResolvedValue(undefined);
-    const repo = new SpanStorageClickHouseRepository((async () => ({
-      insert,
-    })) as unknown as ConstructorParameters<
-      typeof SpanStorageClickHouseRepository
-    >[0]);
-    return { repo, insert };
-  }
-
-  function spanWithLoneSurrogates(): SpanInsertData {
-    return {
-      id: "proj-1",
-      tenantId: "proj-1",
-      traceId: "t-1",
-      spanId: "s-1",
-      parentSpanId: null,
-      parentTraceId: null,
-      parentIsRemote: null,
-      sampled: true,
-      startTimeUnixMs: 1_700_000_000_000,
-      endTimeUnixMs: 1_700_000_000_100,
-      durationMs: 100,
-      name: `span name ${LONE_HIGH_SURROGATE}`,
-      kind: 0,
-      resourceAttributes: {
-        [`res.key.${LONE_HIGH_SURROGATE}`]: `res.val.${LONE_LOW_SURROGATE}`,
-      },
-      spanAttributes: {
-        [`attr.key.${LONE_HIGH_SURROGATE}`]: `attr.val.${LONE_LOW_SURROGATE}`,
-        nested: { text: `deep ${LONE_HIGH_SURROGATE}` },
-      },
-      statusCode: 2,
-      statusMessage: `error: ${LONE_LOW_SURROGATE}`,
-      instrumentationScope: {
-        name: `scope ${LONE_HIGH_SURROGATE}`,
-        version: `v1 ${LONE_LOW_SURROGATE}`,
-      },
-      events: [
-        {
-          name: `event ${LONE_HIGH_SURROGATE}`,
-          timeUnixMs: 1_700_000_000_050,
-          attributes: {
-            [`ev.key.${LONE_HIGH_SURROGATE}`]: `ev.val.${LONE_LOW_SURROGATE}`,
-          },
-        },
-      ],
-      links: [
-        {
-          traceId: "lt-1",
-          spanId: "ls-1",
-          attributes: {
-            [`ln.key.${LONE_HIGH_SURROGATE}`]: `ln.val.${LONE_LOW_SURROGATE}`,
-          },
-        },
-      ],
-      droppedAttributesCount: 0,
-      droppedEventsCount: 0,
-      droppedLinksCount: 0,
-      cost: null,
-      nonBilledCost: null,
-      retentionDays: 0,
-    };
-  }
-
-  describe("given a span whose name, status, scope, events and attributes carry lone UTF-16 surrogates", () => {
-    describe("when the repository builds the record for the JSONEachRow insert", () => {
-      it("sanitises every string in the record to well-formed UTF-16", async () => {
-        const { repo, insert } = repoWithInsertSpy();
-
-        await repo.insertSpans([spanWithLoneSurrogates()]);
-
-        const record = insert.mock.calls[0]?.[0]?.values?.[0];
-        expect(record).toBeDefined();
-        for (const s of collectStrings(record)) {
-          expect(s.isWellFormed()).toBe(true);
-        }
-      });
-
-      it("replaces the lone surrogates with U+FFFD instead of dropping the fields", async () => {
-        const { repo, insert } = repoWithInsertSpy();
-
-        await repo.insertSpans([spanWithLoneSurrogates()]);
-
-        const record = insert.mock.calls[0]?.[0]?.values?.[0];
-        // Assert the marker landed so the test cannot pass vacuously against an
-        // unsanitised record — the fix must actually have run on each field.
-        expect(record.SpanName).toContain("�");
-        expect(record.StatusMessage).toContain("�");
-        expect(record.ScopeName).toContain("�");
-        expect(record.ScopeVersion).toContain("�");
-        expect(record["Events.Name"][0]).toContain("�");
-      });
-
-      it("emits a record that survives a JSON encode/decode round-trip well-formed, which a lone surrogate would not", async () => {
-        const { repo, insert } = repoWithInsertSpy();
-
-        await repo.insertSpans([spanWithLoneSurrogates()]);
-
-        const record = insert.mock.calls[0]?.[0]?.values?.[0];
-        // The client sends the record as JSON (JSONEachRow); ClickHouse decodes
-        // it strictly. A lone surrogate would survive JSON.stringify as a
-        // `\uD83D`-style escape and reconstruct as an unpaired half on decode —
-        // the exact input ClickHouse rejects. A well-formed record cannot.
-        const reparsed = JSON.parse(JSON.stringify(record));
-        for (const s of collectStrings(reparsed)) {
-          expect(s.isWellFormed()).toBe(true);
-        }
-      });
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -38,6 +38,32 @@ import {
 const TABLE_NAME = "stored_spans" as const;
 
 /**
+ * Settings for every `stored_spans` insert.
+ *
+ * `input_format_json_throw_on_bad_escape_sequence: 0` is load-bearing.
+ * Span strings originate as JS UTF-16 and can carry a lone (unpaired) surrogate
+ * half (`\uD800`–`\uDFFF`) — a value truncated mid-emoji, or binary/garbage text
+ * an SDK captured as a string. `JSONEachRow` serializes such a half as a bare
+ * `\uD800`-style escape with no second part, which ClickHouse's JSON parser
+ * rejects by default ("missing second part of surrogate pair"), failing the
+ * whole insert. The pipeline then retries and dead-letters, and the span is lost
+ * forever (13 groups dead-lettered for one project in prod).
+ *
+ * With the setting at 0, ClickHouse keeps the bad escape sequence as-is instead
+ * of throwing — exactly what its own error message recommends. This is done at
+ * the insert boundary, per-batch and O(1), rather than walking and rewriting
+ * every string of every span (attribute keys/values, names, statuses, event
+ * names — unbounded per-span payload) on the hot ingest path just to pre-empt
+ * the parser. The rare malformed string is stored verbatim; every valid string
+ * is untouched.
+ */
+const SPAN_INSERT_SETTINGS = {
+  async_insert: 1,
+  wait_for_async_insert: 1,
+  input_format_json_throw_on_bad_escape_sequence: 0,
+} as const;
+
+/**
  * `stored_spans` is partitioned by `toYearWeek(StartTime)`. When the caller
  * passes an approximate trace timestamp we narrow the scan to a ±2-day
  * window around it — this keeps drawer reads on the warm partition tier
@@ -610,39 +636,8 @@ export function deserializeAttributes(
 }
 
 /**
- * Sanitizes a string to well-formed UTF-16 before it crosses the ClickHouse
- * write boundary.
- *
- * JS strings are UTF-16 and can hold a lone (unpaired) surrogate half
- * (`\uD800`–`\uDFFF`) — e.g. a value truncated mid-emoji, or binary/garbage
- * text captured by an SDK. `JSONEachRow` serializes such a half as a `\uD800`-
- * style escape with no second part, and ClickHouse's JSON parser rejects it
- * ("missing second part of surrogate pair"), failing the whole insert. Because
- * the pipeline retries and then dead-letters, that span is lost forever.
- *
- * `String.prototype.toWellFormed()` replaces each lone surrogate with U+FFFD
- * (the Unicode replacement character) and leaves every valid string untouched,
- * so it is lossless for well-formed input and the correct, minimal fix here.
- * Applied once, at the write boundary, to every string a span contributes to a
- * `stored_spans` row.
- */
-function toWellFormedString(value: string): string {
-  return value.toWellFormed();
-}
-
-/** Nullable variant of {@link toWellFormedString} for optional string columns. */
-function toWellFormedStringOrNull(value: string | null): string | null {
-  return value === null ? null : value.toWellFormed();
-}
-
-/**
  * Serializes attribute values for ClickHouse Map(String, String) columns.
  * Non-scalar values are JSON-stringified at the write boundary.
- *
- * Every map KEY and every string VALUE is passed through
- * {@link toWellFormedString}: a lone UTF-16 surrogate in either half triggers
- * the same ClickHouse insert rejection, so both are sanitized here at the
- * write boundary.
  *
  * @internal Exported for unit testing
  */
@@ -650,11 +645,10 @@ export function serializeAttributes(
   attrs: Record<string, unknown>,
 ): Record<string, string> {
   const result: Record<string, string> = {};
-  for (const [rawKey, value] of Object.entries(attrs)) {
+  for (const [key, value] of Object.entries(attrs)) {
     if (value === null || value === undefined) continue;
-    const key = toWellFormedString(rawKey);
     if (typeof value === "string") {
-      result[key] = toWellFormedString(value);
+      result[key] = value;
     } else if (
       typeof value === "number" ||
       typeof value === "boolean" ||
@@ -665,9 +659,6 @@ export function serializeAttributes(
       try {
         const serialized = JSON.stringify(value);
         if (typeof serialized === "string") {
-          // `JSON.stringify` already escapes any lone surrogate inside the
-          // value as a `\uXXXX` sequence, so its output is well-formed UTF-16
-          // as-is — no further sanitization needed on this branch.
           result[key] = serialized;
         }
       } catch {
@@ -816,7 +807,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         table: TABLE_NAME,
         values: [record],
         format: "JSONEachRow",
-        clickhouse_settings: { async_insert: 1, wait_for_async_insert: 1 },
+        clickhouse_settings: SPAN_INSERT_SETTINGS,
       });
     } catch (error) {
       logger.error(
@@ -865,7 +856,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         table: TABLE_NAME,
         values: records,
         format: "JSONEachRow",
-        clickhouse_settings: { async_insert: 1, wait_for_async_insert: 1 },
+        clickhouse_settings: SPAN_INSERT_SETTINGS,
       });
     } catch (error) {
       logger.error(
@@ -2052,24 +2043,17 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       StartTime: new Date(span.startTimeUnixMs),
       EndTime: new Date(span.endTimeUnixMs),
       DurationMs: Math.round(span.durationMs),
-      // Every free-text string below is sanitized to well-formed UTF-16: a lone
-      // surrogate in any of them fails the JSONEachRow insert identically to one
-      // in SpanAttributes (see toWellFormedString). Attribute maps are handled
-      // inside serializeAttributes (keys + values); Links.TraceId/SpanId are
-      // structural OTel ids, not free text, so they are left as-is.
-      SpanName: toWellFormedString(span.name),
+      SpanName: span.name,
       SpanKind: span.kind,
-      ServiceName: toWellFormedString(serviceName),
+      ServiceName: serviceName,
       ResourceAttributes: serializeAttributes(span.resourceAttributes),
       SpanAttributes: serializeAttributes(span.spanAttributes),
       StatusCode: span.statusCode,
-      StatusMessage: toWellFormedStringOrNull(span.statusMessage),
-      ScopeName: toWellFormedString(span.instrumentationScope.name),
-      ScopeVersion: toWellFormedStringOrNull(
-        span.instrumentationScope.version ?? null,
-      ),
+      StatusMessage: span.statusMessage,
+      ScopeName: span.instrumentationScope.name,
+      ScopeVersion: span.instrumentationScope.version ?? null,
       "Events.Timestamp": span.events.map((e) => new Date(e.timeUnixMs)),
-      "Events.Name": span.events.map((e) => toWellFormedString(e.name)),
+      "Events.Name": span.events.map((e) => e.name),
       "Events.Attributes": span.events.map((e) =>
         serializeAttributes(e.attributes),
       ),

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -610,8 +610,39 @@ export function deserializeAttributes(
 }
 
 /**
+ * Sanitizes a string to well-formed UTF-16 before it crosses the ClickHouse
+ * write boundary.
+ *
+ * JS strings are UTF-16 and can hold a lone (unpaired) surrogate half
+ * (`\uD800`–`\uDFFF`) — e.g. a value truncated mid-emoji, or binary/garbage
+ * text captured by an SDK. `JSONEachRow` serializes such a half as a `\uD800`-
+ * style escape with no second part, and ClickHouse's JSON parser rejects it
+ * ("missing second part of surrogate pair"), failing the whole insert. Because
+ * the pipeline retries and then dead-letters, that span is lost forever.
+ *
+ * `String.prototype.toWellFormed()` replaces each lone surrogate with U+FFFD
+ * (the Unicode replacement character) and leaves every valid string untouched,
+ * so it is lossless for well-formed input and the correct, minimal fix here.
+ * Applied once, at the write boundary, to every string a span contributes to a
+ * `stored_spans` row.
+ */
+function toWellFormedString(value: string): string {
+  return value.toWellFormed();
+}
+
+/** Nullable variant of {@link toWellFormedString} for optional string columns. */
+function toWellFormedStringOrNull(value: string | null): string | null {
+  return value === null ? null : value.toWellFormed();
+}
+
+/**
  * Serializes attribute values for ClickHouse Map(String, String) columns.
  * Non-scalar values are JSON-stringified at the write boundary.
+ *
+ * Every map KEY and every string VALUE is passed through
+ * {@link toWellFormedString}: a lone UTF-16 surrogate in either half triggers
+ * the same ClickHouse insert rejection, so both are sanitized here at the
+ * write boundary.
  *
  * @internal Exported for unit testing
  */
@@ -619,10 +650,11 @@ export function serializeAttributes(
   attrs: Record<string, unknown>,
 ): Record<string, string> {
   const result: Record<string, string> = {};
-  for (const [key, value] of Object.entries(attrs)) {
+  for (const [rawKey, value] of Object.entries(attrs)) {
     if (value === null || value === undefined) continue;
+    const key = toWellFormedString(rawKey);
     if (typeof value === "string") {
-      result[key] = value;
+      result[key] = toWellFormedString(value);
     } else if (
       typeof value === "number" ||
       typeof value === "boolean" ||
@@ -633,6 +665,9 @@ export function serializeAttributes(
       try {
         const serialized = JSON.stringify(value);
         if (typeof serialized === "string") {
+          // `JSON.stringify` already escapes any lone surrogate inside the
+          // value as a `\uXXXX` sequence, so its output is well-formed UTF-16
+          // as-is — no further sanitization needed on this branch.
           result[key] = serialized;
         }
       } catch {
@@ -2017,17 +2052,24 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       StartTime: new Date(span.startTimeUnixMs),
       EndTime: new Date(span.endTimeUnixMs),
       DurationMs: Math.round(span.durationMs),
-      SpanName: span.name,
+      // Every free-text string below is sanitized to well-formed UTF-16: a lone
+      // surrogate in any of them fails the JSONEachRow insert identically to one
+      // in SpanAttributes (see toWellFormedString). Attribute maps are handled
+      // inside serializeAttributes (keys + values); Links.TraceId/SpanId are
+      // structural OTel ids, not free text, so they are left as-is.
+      SpanName: toWellFormedString(span.name),
       SpanKind: span.kind,
-      ServiceName: serviceName,
+      ServiceName: toWellFormedString(serviceName),
       ResourceAttributes: serializeAttributes(span.resourceAttributes),
       SpanAttributes: serializeAttributes(span.spanAttributes),
       StatusCode: span.statusCode,
-      StatusMessage: span.statusMessage,
-      ScopeName: span.instrumentationScope.name,
-      ScopeVersion: span.instrumentationScope.version ?? null,
+      StatusMessage: toWellFormedStringOrNull(span.statusMessage),
+      ScopeName: toWellFormedString(span.instrumentationScope.name),
+      ScopeVersion: toWellFormedStringOrNull(
+        span.instrumentationScope.version ?? null,
+      ),
       "Events.Timestamp": span.events.map((e) => new Date(e.timeUnixMs)),
-      "Events.Name": span.events.map((e) => e.name),
+      "Events.Name": span.events.map((e) => toWellFormedString(e.name)),
       "Events.Attributes": span.events.map((e) =>
         serializeAttributes(e.attributes),
       ),

--- a/specs/traces/span-attribute-unicode-sanitisation.feature
+++ b/specs/traces/span-attribute-unicode-sanitisation.feature
@@ -1,7 +1,7 @@
 Feature: Malformed unicode in a span never permanently fails ClickHouse ingest
   As an operator running the LangWatch trace-ingest pipeline
-  I want span strings that contain lone (unpaired) UTF-16 surrogate halves to be
-  sanitised at the ClickHouse write boundary
+  I want a span that contains a lone (unpaired) UTF-16 surrogate half to still be
+  stored
   So that a single garbage character in one span can never dead-letter a whole
   batch of spans and lose them forever
 
@@ -16,7 +16,7 @@ Feature: Malformed unicode in a span never permanently fails ClickHouse ingest
   # truncated mid-emoji, or binary / garbage text an SDK captured as a string.
   #
   # `JSONEachRow` serialises such a half as a `\uD800`-style escape with no
-  # second part. ClickHouse's JSON parser rejects it with:
+  # second part. By default ClickHouse's JSON parser rejects it with:
   #
   #   Cannot parse escape sequence: missing second part of surrogate pair.
   #   ... (while reading the value of key SpanAttributes) ...
@@ -25,43 +25,31 @@ Feature: Malformed unicode in a span never permanently fails ClickHouse ingest
   # dead-lettered. In production this dead-lettered 13 groups for one project on
   # a single bad character.
   #
-  # The fix sanitises every string a span contributes to a row to well-formed
-  # UTF-16 (`String.prototype.toWellFormed()`, which replaces each lone surrogate
-  # with U+FFFD, the Unicode replacement character) before it reaches ClickHouse.
-  # This is lossless for every valid string and only ever touches genuinely
-  # malformed input. It deliberately does NOT use ClickHouse's
-  # `input_format_json_throw_on_bad_escape_sequence=0` setting, which would
-  # persist the garbage instead of normalising it.
+  # The fix sets `input_format_json_throw_on_bad_escape_sequence: 0` on the span
+  # insert — exactly what ClickHouse's own error message recommends. ClickHouse
+  # then keeps the bad escape sequence as text instead of throwing, so the span
+  # is stored. This is handled once, at the insert boundary, per batch and O(1),
+  # rather than walking and rewriting every string of every span (attribute
+  # keys/values, names, statuses, event names — an unbounded per-span payload) on
+  # the hot ingest path just to pre-empt the parser. Valid strings are never
+  # touched; only the rare malformed one is stored verbatim.
   # =========================================================================
 
   Background:
     Given a span is being written to the ClickHouse span store
 
-  Rule: A lone surrogate in a span attribute is sanitised, not rejected
+  Rule: A span carrying a lone surrogate is stored, not dead-lettered
 
-    Scenario: An attribute value truncated mid-emoji is stored
+    Scenario: An attribute value truncated mid-emoji does not fail the insert
       Given a span attribute value that ends in a lone UTF-16 surrogate
-      When the span is serialised for the ClickHouse insert
-      Then the stored value is well-formed UTF-16 with the lone half replaced
-      And the insert is accepted instead of being dead-lettered
-
-    Scenario: An attribute key containing a lone surrogate is sanitised
-      Given a span attribute whose key contains a lone UTF-16 surrogate
-      When the span is serialised for the ClickHouse insert
-      Then the stored key is well-formed UTF-16
-
-    Scenario: A lone surrogate nested inside a JSON-serialised attribute is safe
-      Given a span attribute whose value is an object containing a lone surrogate
-      When the span is serialised for the ClickHouse insert
-      Then the serialised JSON value is well-formed UTF-16
-
-  Rule: Every free-text string on a span is sanitised, not only attributes
+      When the span is inserted into the ClickHouse span store
+      Then the insert is accepted instead of throwing a surrogate-pair error
+      And the span can be read back instead of being lost to the dead-letter queue
 
     Scenario: Lone surrogates anywhere on the span cannot fail the insert
-      Given a span whose name, status message, scope name and version, service
-        name, event names, and event / resource attribute keys and values each
+      Given a span whose name, status message, scope name and version, event
+        names, and event / resource / span attribute keys and values each
         contain a lone UTF-16 surrogate
-      When the repository builds the ClickHouse record for the insert
-      Then every string in the record is well-formed UTF-16
-      And the record survives a JSON encode/decode round-trip with no unpaired
-        surrogate for ClickHouse to reject
+      When the span is inserted into the ClickHouse span store
+      Then the insert is accepted for the whole batch
+      And the span reads back with its valid data untouched

--- a/specs/traces/span-attribute-unicode-sanitisation.feature
+++ b/specs/traces/span-attribute-unicode-sanitisation.feature
@@ -1,0 +1,67 @@
+Feature: Malformed unicode in a span never permanently fails ClickHouse ingest
+  As an operator running the LangWatch trace-ingest pipeline
+  I want span strings that contain lone (unpaired) UTF-16 surrogate halves to be
+  sanitised at the ClickHouse write boundary
+  So that a single garbage character in one span can never dead-letter a whole
+  batch of spans and lose them forever
+
+  # =========================================================================
+  # Why this exists
+  # =========================================================================
+  #
+  # Span attribute values (and other free-text span strings) are serialised into
+  # ClickHouse Map(String, String) / String columns and inserted with
+  # `format: JSONEachRow`. JS strings are UTF-16 and can carry a lone surrogate
+  # half (`\uD800`–`\uDFFF` with no matching pair) — for example a value
+  # truncated mid-emoji, or binary / garbage text an SDK captured as a string.
+  #
+  # `JSONEachRow` serialises such a half as a `\uD800`-style escape with no
+  # second part. ClickHouse's JSON parser rejects it with:
+  #
+  #   Cannot parse escape sequence: missing second part of surrogate pair.
+  #   ... (while reading the value of key SpanAttributes) ...
+  #
+  # The insert throws, the pipeline retries, retries exhaust, and the span is
+  # dead-lettered. In production this dead-lettered 13 groups for one project on
+  # a single bad character.
+  #
+  # The fix sanitises every string a span contributes to a row to well-formed
+  # UTF-16 (`String.prototype.toWellFormed()`, which replaces each lone surrogate
+  # with U+FFFD, the Unicode replacement character) before it reaches ClickHouse.
+  # This is lossless for every valid string and only ever touches genuinely
+  # malformed input. It deliberately does NOT use ClickHouse's
+  # `input_format_json_throw_on_bad_escape_sequence=0` setting, which would
+  # persist the garbage instead of normalising it.
+  # =========================================================================
+
+  Background:
+    Given a span is being written to the ClickHouse span store
+
+  Rule: A lone surrogate in a span attribute is sanitised, not rejected
+
+    Scenario: An attribute value truncated mid-emoji is stored
+      Given a span attribute value that ends in a lone UTF-16 surrogate
+      When the span is serialised for the ClickHouse insert
+      Then the stored value is well-formed UTF-16 with the lone half replaced
+      And the insert is accepted instead of being dead-lettered
+
+    Scenario: An attribute key containing a lone surrogate is sanitised
+      Given a span attribute whose key contains a lone UTF-16 surrogate
+      When the span is serialised for the ClickHouse insert
+      Then the stored key is well-formed UTF-16
+
+    Scenario: A lone surrogate nested inside a JSON-serialised attribute is safe
+      Given a span attribute whose value is an object containing a lone surrogate
+      When the span is serialised for the ClickHouse insert
+      Then the serialised JSON value is well-formed UTF-16
+
+  Rule: Every free-text string on a span is sanitised, not only attributes
+
+    Scenario: Lone surrogates anywhere on the span cannot fail the insert
+      Given a span whose name, status message, scope name and version, service
+        name, event names, and event / resource attribute keys and values each
+        contain a lone UTF-16 surrogate
+      When the repository builds the ClickHouse record for the insert
+      Then every string in the record is well-formed UTF-16
+      And the record survives a JSON encode/decode round-trip with no unpaired
+        surrogate for ClickHouse to reject


### PR DESCRIPTION
## What was failing in production

ClickHouse span inserts were permanently failing for any span whose strings contained a **lone (unpaired) UTF-16 surrogate half** (`\uD800`–`\uDFFF`) — a string truncated mid-emoji, or binary/garbage text an SDK captured as a string. The exact prod error, which **dead-lettered 13 groups for one project**:

> Cannot parse escape sequence: missing second part of surrogate pair. In JSON input formats you can disable setting input_format_json_throw_on_bad_escape_sequence to save bad escape sequences as is: (while reading the value of key SpanAttributes): (at row 1) : While executing WaitForAsyncInsert.

## Mechanism

The `stored_spans` insert uses `format: "JSONEachRow"` with `{ async_insert: 1, wait_for_async_insert: 1 }`. JS strings are UTF-16 and can hold a lone surrogate; `JSONEachRow` serialises such a half as a `\uD800`-style escape with **no second part**. ClickHouse's JSON parser rejects the unpaired escape by default → the insert throws → retries exhaust → DLQ. The span is lost forever.

## The fix

Set **`input_format_json_throw_on_bad_escape_sequence: 0`** on the `stored_spans` inserts (both `insertSpan` and `insertSpans`, via one shared `SPAN_INSERT_SETTINGS`). This is **exactly what ClickHouse's own error message recommends** — with it off, ClickHouse keeps the bad escape sequence as text instead of throwing, so the span is stored.

The fix lives at the insert boundary: **per batch, O(1), zero per-row work**. It does **not** walk and rewrite every string of every span. Valid strings are never touched; only the rare malformed one is stored verbatim.

### Why not JS-side sanitisation

The first cut of this PR passed every string a span contributes (attribute keys/values, `SpanName`, `StatusMessage`, scope, service, event names — an **unbounded per-span payload**) through `String.prototype.toWellFormed()` on the hot ingest path, replacing each lone surrogate with U+FFFD. That put an unbounded-size string sweep on every span write to pre-empt a parser check that ClickHouse already exposes a setting for, and it mutated customer data (U+FFFD) rather than storing it. Reverted in favour of the DB setting.

## Tests

- **Unit** (`span-storage.clickhouse.repository.unit.test.ts`): reverted the in-process sanitisation assertions — the behaviour no longer lives in JS, so asserting it there (or echoing the setting value back at itself) would be a non-behavioural test.
- **Integration** (`span-storage.clickhouse.repository.integration.test.ts`): a real-ClickHouse regression. Two self-contained tests each insert a span whose name, status, scope, event names and attribute keys/values all carry lone surrogates — one **through the bulk `insertSpans` write path**, one **through the single `insertSpan` write path** — and assert the insert **does not throw** the surrogate-pair error and the span **reads back** (valid data intact) instead of being dead-lettered. Without the setting these throw on insert and the read finds nothing.

Spec `specs/traces/span-attribute-unicode-sanitisation.feature` rewritten to the store-not-reject behaviour.

## Note

This is **one of two fixes from a single prod incident**. The other — the `event_log` refold memory issue — is being handled separately and is not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace ingestion to accept spans containing malformed Unicode lone surrogate halves.
  * Prevented affected spans from being rejected or sent to the dead-letter queue.
  * Ensured valid span data remains readable after ingestion for both single-span and bulk inserts.
* **Tests**
  * Added integration and feature coverage for lone surrogate handling across span names, attributes (including nested text), events, and status/scope fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->