### PR TITLE
fix(langy): scope GitHub tokens to the project's bound repo

### DIFF
--- a/langwatch/prisma/migrations/20260723120000_add_project_repository_full_name/migration.sql
+++ b/langwatch/prisma/migrations/20260723120000_add_project_repository_full_name/migration.sql
@@ -3,3 +3,7 @@
 -- bound yet, so tokens fall back to full-installation scope. See
 -- LangyGithubInstallationsService.mintTurnToken.
 ALTER TABLE "Project" ADD COLUMN "repositoryFullName" TEXT;
+
+-- Down (reversible — additive, nullable column). Commented out to avoid
+-- accidental data loss; to roll back, uncomment and run manually:
+-- ALTER TABLE "Project" DROP COLUMN "repositoryFullName";

--- a/langwatch/prisma/migrations/20260723120000_add_project_repository_full_name/migration.sql
+++ b/langwatch/prisma/migrations/20260723120000_add_project_repository_full_name/migration.sql
@@ -1,0 +1,5 @@
+-- Scopes Langy's minted GitHub installation tokens to a project's bound repo
+-- instead of the whole installation (issue #790). Null means no repo is
+-- bound yet, so tokens fall back to full-installation scope. See
+-- LangyGithubInstallationsService.mintTurnToken.
+ALTER TABLE "Project" ADD COLUMN "repositoryFullName" TEXT;

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -447,6 +447,13 @@ model Project {
   /// per-request credentials envelope. See specs/langy/langy-egress-enforcement.feature.
   langyEgressAllowlist Json?
 
+  /// The GitHub repository (owner/repo) this project is bound to, used to scope
+  /// Langy's minted GitHub installation tokens to just this repo instead of the
+  /// whole installation. Null means no repo is bound yet, so tokens fall back to
+  /// full-installation scope. See LangyGithubInstallationsService.mintTurnToken
+  /// and issue #790.
+  repositoryFullName String?
+
   @@index([teamId])
   @@index([isPersonal])
   @@index([ownerUserId])

--- a/langwatch/src/factories/project.factory.ts
+++ b/langwatch/src/factories/project.factory.ts
@@ -24,6 +24,7 @@ export const projectFactory = Factory.define<
     createdAt: new Date(),
     updatedAt: new Date(),
     userLinkTemplate: null,
+    repositoryFullName: null,
     traceSharingEnabled: true,
     s3Endpoint: null,
     s3AccessKeyId: null,

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -134,6 +134,9 @@ export const useOrganizationTeamProject = (
         // the fail-closed side of ADR-053. A share viewer never runs Langy, so
         // this is inert either way; null keeps it inert AND safe.
         langyEgressAllowlist: null,
+        // Public share viewers never mint Langy GitHub tokens, so an unbound
+        // repo is inert here — same rationale as langyEgressAllowlist above.
+        repositoryFullName: null,
         departmentId: null,
       }
     : undefined;

--- a/langwatch/src/pages/settings.tsx
+++ b/langwatch/src/pages/settings.tsx
@@ -14,7 +14,7 @@ import {
 } from "@chakra-ui/react";
 import type { OrganizationIntent, Project } from "@prisma/client";
 import isEqual from "lodash-es/isEqual";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Lock } from "react-feather";
 import { Controller, type SubmitHandler, useForm } from "react-hook-form";
 import { HorizontalFormControl } from "~/components/HorizontalFormControl";
@@ -570,6 +570,7 @@ type ProjectFormData = {
   language: string;
   framework: string;
   userLinkTemplate?: string;
+  repositoryFullName?: string;
   s3Endpoint?: string;
   s3AccessKeyId?: string;
   s3SecretAccessKey?: string;
@@ -577,6 +578,11 @@ type ProjectFormData = {
   traceSharingEnabled: boolean;
   presenceEnabled: boolean;
 };
+
+/** Sentinel for "no repository bound" in the GitHub repository select — Chakra's
+ * Select doesn't take an empty-string item value cleanly, so `NONE` stands in
+ * for "unset" and is translated back to `null` at submit time. */
+const NO_REPOSITORY_VALUE = "__none__";
 
 function ProjectSettingsForm({ project }: { project: Project }) {
   const { organization, organizations } = useOrganizationTeamProject();
@@ -592,6 +598,7 @@ function ProjectSettingsForm({ project }: { project: Project }) {
     language: project.language,
     framework: project.framework,
     userLinkTemplate: project.userLinkTemplate ?? "",
+    repositoryFullName: project.repositoryFullName ?? NO_REPOSITORY_VALUE,
     s3Endpoint: project.s3Endpoint ?? "",
     s3AccessKeyId: project.s3AccessKeyId ?? "",
     s3SecretAccessKey: project.s3SecretAccessKey ?? "",
@@ -609,6 +616,24 @@ function ProjectSettingsForm({ project }: { project: Project }) {
   const apiContext = api.useContext();
   const [changeLanguageFramework, setChangeLanguageFramework] = useState(false);
   const [showTraceSharingDialog, setShowTraceSharingDialog] = useState(false);
+
+  // The repo Langy's minted GitHub installation tokens get scoped to (#790).
+  // Empty when the org has no GitHub App installation — the query still
+  // resolves gracefully (empty list) rather than gating the field's render.
+  const githubRepos = api.langyGithub.listRepos.useQuery(
+    { organizationId: organization?.id ?? "" },
+    { enabled: !!organization?.id },
+  );
+  const repositoryCollection = useMemo(() => {
+    const items = [
+      { label: "No repository bound", value: NO_REPOSITORY_VALUE },
+      ...(githubRepos.data ?? []).map((repo) => ({
+        label: repo.fullName,
+        value: repo.fullName,
+      })),
+    ];
+    return createListCollection({ items });
+  }, [githubRepos.data]);
 
   const handleTraceSharingChange = (newValue: boolean) => {
     // Directly update the form value
@@ -645,6 +670,10 @@ function ProjectSettingsForm({ project }: { project: Project }) {
         projectId: project.id,
         ...data,
         userLinkTemplate: data.userLinkTemplate ?? "",
+        repositoryFullName:
+          data.repositoryFullName && data.repositoryFullName !== NO_REPOSITORY_VALUE
+            ? data.repositoryFullName
+            : null,
         s3Endpoint: data.s3Endpoint ?? "",
         s3AccessKeyId: data.s3AccessKeyId ?? "",
         s3SecretAccessKey: data.s3SecretAccessKey ?? "",
@@ -750,6 +779,39 @@ function ProjectSettingsForm({ project }: { project: Project }) {
                 </Button>
               </HStack>
             )}
+          </HorizontalFormControl>
+          <HorizontalFormControl
+            label="GitHub repository"
+            helper="The repository Langy is bound to for this project. Bot-authored PRs and its GitHub installation token are scoped to just this repo instead of the whole GitHub App installation."
+          >
+            <Controller
+              control={control}
+              name="repositoryFullName"
+              render={({ field }) => (
+                <Select.Root
+                  collection={repositoryCollection}
+                  value={[field.value ?? NO_REPOSITORY_VALUE]}
+                  width="full"
+                  onValueChange={(d) =>
+                    field.onChange(d.value[0] ?? NO_REPOSITORY_VALUE)
+                  }
+                >
+                  <Select.Trigger
+                    background="bg"
+                    aria-label="GitHub repository"
+                  >
+                    <Select.ValueText placeholder="No repository bound" />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {repositoryCollection.items.map((item) => (
+                      <Select.Item key={item.value} item={item}>
+                        {item.label}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+              )}
+            />
           </HorizontalFormControl>
           <HorizontalFormControl
             label="Live presence"

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -286,6 +286,7 @@ export const projectRouter = createTRPCRouter({
           traceSharingEnabled: z.boolean().optional(),
           presenceEnabled: z.boolean().optional(),
           userLinkTemplate: z.string().optional(),
+          repositoryFullName: z.string().nullable().optional(),
           s3Endpoint: z.string().optional(),
           s3AccessKeyId: z.string().optional(),
           s3SecretAccessKey: z.string().optional(),
@@ -345,6 +346,9 @@ export const projectRouter = createTRPCRouter({
           ...(input.framework !== undefined && { framework: input.framework }),
           ...(input.userLinkTemplate !== undefined && {
             userLinkTemplate: input.userLinkTemplate,
+          }),
+          ...(input.repositoryFullName !== undefined && {
+            repositoryFullName: input.repositoryFullName,
           }),
           ...(input.teamId && { teamId: input.teamId }),
           traceSharingEnabled:

--- a/langwatch/src/server/app-layer/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/app-layer/langy/LangyCredentialService.ts
@@ -301,7 +301,10 @@ export class LangyCredentialService {
     /**
      * The explicit repository the turn targets, when known (a future repo
      * context chip). Present ⇒ the installation token is scoped to only that
-     * repo; absent ⇒ scoped to the installation's full repository set.
+     * repo; absent ⇒ falls back to the project's bound
+     * `repositoryFullName` (set via project settings), and if that's also
+     * unset, to the installation's full repository set. Precedence: explicit
+     * arg > project default > full-installation fallback.
      */
     repositoryFullName?: string;
   }): Promise<LangyCredentials> {
@@ -313,6 +316,12 @@ export class LangyCredentialService {
         `Project ${projectId} not found.`,
       );
     }
+    // #790: no caller passes an explicit override today, so every turn used
+    // to mint a full-installation-scoped token even for a project bound to
+    // one specific repo. Default from the project's stored binding — an
+    // explicit turn-level override (when one exists) still wins.
+    const effectiveRepositoryFullName =
+      repositoryFullName ?? project.repositoryFullName ?? undefined;
 
     // The worker's callback origin + gateway. Both prefer the container-worker
     // overrides (LANGY_WORKER_CALLBACK_URL / LANGY_WORKER_GATEWAY_URL) that haven
@@ -390,7 +399,9 @@ export class LangyCredentialService {
         const minted =
           await getApp().langy.githubInstallations.mintTurnToken({
             organizationId: project.organizationId,
-            ...(repositoryFullName ? { repositoryFullName } : {}),
+            ...(effectiveRepositoryFullName
+              ? { repositoryFullName: effectiveRepositoryFullName }
+              : {}),
           });
         if (minted) {
           githubToken = minted.token;

--- a/langwatch/src/server/app-layer/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -50,6 +50,21 @@ vi.mock("../langyApiKey", () => ({
   LangySessionKeyScopeError,
 }));
 
+// The GitHub installation-token mint (LANGY_GITHUB_ENABLED is a hard `true`
+// constant, so getOrProvision always calls this). Hoisted so the vi.mock
+// factory can reference it. Default resolves null (mirrors the pre-existing
+// behaviour of an uninitialized real App throwing and getOrProvision's
+// try/catch swallowing it) so every test above that doesn't care about GitHub
+// keeps passing unchanged; only the regression test below configures it.
+const { mintTurnToken } = vi.hoisted(() => ({ mintTurnToken: vi.fn() }));
+vi.mock("~/server/app-layer", () => ({
+  getApp: () => ({
+    langy: { githubInstallations: { mintTurnToken } },
+  }),
+}));
+
+import { ProjectRepository } from "~/server/projects/project.repository";
+
 import {
   LangyCredentialResolutionError,
   LangyCredentialService,
@@ -90,6 +105,8 @@ beforeEach(() => {
     token: "sk-lw-test-langy-token",
     apiKeyId: "key-1",
   });
+  mintTurnToken.mockReset();
+  mintTurnToken.mockResolvedValue(null);
   process.env.LANGWATCH_API_URL = "https://api.langwatch.test";
   // The endpoint prefers LANGWATCH_ENDPOINT over LANGWATCH_API_URL; clear it so
   // the default cases below exercise the LANGWATCH_API_URL fallback path
@@ -240,6 +257,125 @@ describe("LangyCredentialService", () => {
             updatedById: "u1",
           }),
         });
+      });
+    });
+  });
+
+  // Regression for #790: every Langy turn minted a GitHub installation token
+  // scoped to the WHOLE installation, even for a project bound to one
+  // specific repo, because getOrProvision never defaulted
+  // `repositoryFullName` from the project when no explicit override was
+  // passed — it only forwarded an override the caller happened to supply,
+  // and nothing does today. getOrProvision now falls back to
+  // `project.repositoryFullName` when no explicit argument is given.
+  describe("given a project bound to a specific GitHub repository", () => {
+    describe("when getOrProvision is called without an explicit repositoryFullName override", () => {
+      it("scopes the minted GitHub installation token to the project's bound repository", async () => {
+        const prisma = makePrisma();
+        vi.spyOn(
+          ProjectRepository.prototype,
+          "findForLangyCredentials",
+        ).mockResolvedValueOnce({
+          apiKey: "sk-lw-test-project-key",
+          organizationId: "org-1",
+          repositoryFullName: "acme/widgets",
+        });
+        mintTurnToken.mockResolvedValueOnce({
+          token: "ghs_scoped_to_widgets",
+          repoScopeKey: "repo:acme/widgets",
+          installationId: "inst-1",
+        });
+        const svc = new LangyCredentialService(prisma);
+
+        await svc.getOrProvision({
+          projectId: "p1",
+          session: SESSION,
+          mintSessionKey: false,
+        });
+
+        // No caller passes an explicit `repositoryFullName` override — the
+        // service must default it from the project it just resolved.
+        expect(mintTurnToken).toHaveBeenCalledWith(
+          expect.objectContaining({
+            organizationId: "org-1",
+            repositoryFullName: "acme/widgets",
+          }),
+        );
+      });
+    });
+  });
+
+  describe("given a project with no bound GitHub repository", () => {
+    describe("when getOrProvision is called", () => {
+      it("mints a token scoped to the whole installation", async () => {
+        const prisma = makePrisma();
+        vi.spyOn(
+          ProjectRepository.prototype,
+          "findForLangyCredentials",
+        ).mockResolvedValueOnce({
+          apiKey: "sk-lw-test-project-key",
+          organizationId: "org-1",
+          repositoryFullName: null,
+        });
+        mintTurnToken.mockResolvedValueOnce({
+          token: "ghs_whole_installation",
+          repoScopeKey: null,
+          installationId: "inst-1",
+        });
+        const svc = new LangyCredentialService(prisma);
+
+        await svc.getOrProvision({
+          projectId: "p1",
+          session: SESSION,
+          mintSessionKey: false,
+        });
+
+        // No project-bound repo and no explicit override — the
+        // `repositoryFullName` key must be absent entirely (not `undefined`
+        // or `null`), preserving the pre-fix full-installation behaviour.
+        expect(mintTurnToken).toHaveBeenCalledWith(
+          expect.not.objectContaining({
+            repositoryFullName: expect.anything(),
+          }),
+        );
+      });
+    });
+  });
+
+  describe("given a project bound to a specific GitHub repository, but the turn passes an explicit override", () => {
+    describe("when getOrProvision is called with a repositoryFullName that differs from the project's bound repo", () => {
+      it("scopes the minted GitHub installation token to the explicit override, not the project's bound repository", async () => {
+        const prisma = makePrisma();
+        vi.spyOn(
+          ProjectRepository.prototype,
+          "findForLangyCredentials",
+        ).mockResolvedValueOnce({
+          apiKey: "sk-lw-test-project-key",
+          organizationId: "org-1",
+          repositoryFullName: "acme/widgets",
+        });
+        mintTurnToken.mockResolvedValueOnce({
+          token: "ghs_scoped_to_override",
+          repoScopeKey: "repo:explicit/override",
+          installationId: "inst-1",
+        });
+        const svc = new LangyCredentialService(prisma);
+
+        await svc.getOrProvision({
+          projectId: "p1",
+          session: SESSION,
+          mintSessionKey: false,
+          repositoryFullName: "explicit/override",
+        });
+
+        // Explicit turn-level override wins over the project-level default
+        // even though the project has its own bound repo.
+        expect(mintTurnToken).toHaveBeenCalledWith(
+          expect.objectContaining({
+            organizationId: "org-1",
+            repositoryFullName: "explicit/override",
+          }),
+        );
       });
     });
   });

--- a/langwatch/src/server/app-layer/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/langwatch/src/server/app-layer/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -333,11 +333,13 @@ describe("LangyCredentialService", () => {
         // No project-bound repo and no explicit override — the
         // `repositoryFullName` key must be absent entirely (not `undefined`
         // or `null`), preserving the pre-fix full-installation behaviour.
-        expect(mintTurnToken).toHaveBeenCalledWith(
-          expect.not.objectContaining({
-            repositoryFullName: expect.anything(),
-          }),
-        );
+        // `expect.anything()` excludes null/undefined, so a `not.objectContaining`
+        // check on it wouldn't actually catch the key being present-but-undefined;
+        // asserting directly on the recorded call argument does.
+        const [mintArgs] = mintTurnToken.mock.calls[0] as [
+          Record<string, unknown>,
+        ];
+        expect(mintArgs).not.toHaveProperty("repositoryFullName");
       });
     });
   });

--- a/langwatch/src/server/projects/project.repository.ts
+++ b/langwatch/src/server/projects/project.repository.ts
@@ -22,17 +22,24 @@ export class ProjectRepository {
     return project?.team?.organizationId ?? null;
   }
 
-  async findForLangyCredentials(
-    projectId: string,
-  ): Promise<{ apiKey: string; organizationId: string } | null> {
+  async findForLangyCredentials(projectId: string): Promise<{
+    apiKey: string;
+    organizationId: string;
+    repositoryFullName: string | null;
+  } | null> {
     const project = await this.prisma.project.findUnique({
       where: { id: projectId },
-      select: { apiKey: true, team: { select: { organizationId: true } } },
+      select: {
+        apiKey: true,
+        repositoryFullName: true,
+        team: { select: { organizationId: true } },
+      },
     });
     if (!project?.team) return null;
     return {
       apiKey: project.apiKey,
       organizationId: project.team.organizationId,
+      repositoryFullName: project.repositoryFullName,
     };
   }
 }


### PR DESCRIPTION
## Why

Every Langy turn minted a GitHub App installation token scoped to the **entire** installation's repository set, never to the single repo the conversation is actually about. `LangyGithubInstallationsService.mintTurnToken` and `LangyCredentialService.getOrProvision` already accepted an optional `repositoryFullName` to narrow the mint, but nothing ever supplied one — there was no mechanism anywhere to know which repo a turn was about, so every mint fell through to full-installation scope for the token's full 1h lifetime.

Fixes langwatch/langwatch-saas#790. (Note: that issue lives in the `langwatch-saas` repo, not this one — this branch's `issue790/` prefix collided with an unrelated, already-merged issue #790 in this repo; do not let this PR auto-close that one.)

## What changed

Implements the issue's recommended interim mitigation ("Option A"): give a project an optional bound GitHub repository, and default the token scope to it whenever the project has one set.

- Added a nullable `Project.repositoryFullName` column.
- `ProjectRepository.findForLangyCredentials` now also returns it.
- `LangyCredentialService.getOrProvision` now defaults its mint's `repositoryFullName` to the project's bound repo when no explicit per-turn override is passed (an explicit override, once one exists, still wins).
- Project settings gained a "GitHub repository" dropdown, populated from the org's already-installed GitHub repos (`langyGithub.listRepos`, unchanged), that writes to the new column via the existing `project.update` mutation.
- Projects with no repo bound keep today's behavior exactly (full-installation scope) — this only narrows scope for projects that opt in.

## How it works

Precedence when minting a turn's token: **explicit per-turn override > project's bound repo > full-installation fallback**. The explicit-override path doesn't exist yet (that's the turn-context-chip design the issue defers to a follow-up); this PR only wires up the project-level default, which needs no turn-context/UI-chip changes at all.

## Test plan

- Regression test in `LangyCredentialService.unit.test.ts`: given a project with `repositoryFullName: "acme/widgets"`, calling `getOrProvision` with no explicit override asserts the underlying mint call receives `repositoryFullName: "acme/widgets"`. Confirmed it fails against the pre-fix code (mint called with only `organizationId`, no repo) and passes after the fix.
- Two additional precedence tests: (a) an unbound project (`repositoryFullName: null`) still mints with no `repositoryFullName` key at all — full-installation scope preserved; (b) an explicit per-turn override wins over the project's stored default.
- Full `langy` unit suite (36 files / 434 tests) passes.
- `tslsp-cli diagnostics` clean on every touched file.
- Swept the codebase for the same "no explicit scope → full access" pattern elsewhere: confirmed `mintTurnToken`/`getOrProvision` is the only GitHub-token-minting mechanism in the app with a single caller, now fixed — nothing else to fix.

## Anything surprising?

Scope is intentionally limited to the project-bound-repo case, per the issue's own recommendation to ship the smaller mitigation first. Per-turn agent-inferred repo scoping (the issue's "Option B", a clone-time credential-helper callback) is a separate, larger design the issue explicitly defers — not attempted here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-project “GitHub repository” binding in project settings.
  * When set, minted GitHub installation access is scoped to that repository; when unset, it uses the broader installation scope.
* **Bug Fixes**
  * Repository scoping precedence is now consistent: an explicit selection at request time overrides the stored project binding.
  * Public project share viewers remain non-token-minting, treating unbound repositories as inert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->