### PR TITLE
fix(coding-agent): read session fold state back from ClickHouse instead of refolding event_log (ADR-066)

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/sessionView/__tests__/sessionSignals.unit.test.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/sessionView/__tests__/sessionSignals.unit.test.ts
@@ -15,6 +15,7 @@ function session(
     traceIds: ["trace-1"],
     version: "2026-07-11",
     startedAtMs: 1_700_000_000_000,
+    state: "{}",
     agent: "claude-code",
     agentVersion: "2.0.0",
     sessionId: "session-1",

--- a/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
@@ -39,6 +39,7 @@ function sessionRow(
     sessionKeySource: "provider",
     version: "2026-07-21",
     startedAtMs: baseMs,
+    state: "{}",
     agent: "claude_code",
     agentVersion: "2.0.0",
     traceIds: [`${tag}-t1`],
@@ -168,6 +169,39 @@ describe("coding_agent_sessions round-trip (migration 00051)", () => {
     expect(read!.sessionKeySource).toBe("provider");
     expect(read!.costUsd).toBeCloseTo(1.25);
     expect(read!.commits).toBe(2);
+  });
+
+  it("round-trips the lossless State resume blob (migration 00053)", async () => {
+    // The blob carries the fields the analytics columns drop — the read-back
+    // path (ADR-066) depends on it surviving verbatim.
+    const state = JSON.stringify({
+      sessionId: `${tag}-blob`,
+      subAgentIds: ["sub-1", "sub-2"],
+      previousCallContextTokens: 7_000,
+      metricSeries: {
+        "removed-1": { metricName: "claude_code.lines_of_code.count", value: 10 },
+      },
+    });
+    const row = sessionRow({ sessionId: `${tag}-blob`, state });
+    await sessions.upsert(row, 30);
+
+    const read = await sessions.findBySessionId({
+      tenantId,
+      sessionId: `${tag}-blob`,
+      startedAtMs: baseMs,
+    });
+
+    expect(read).not.toBeNull();
+    expect(read!.state).toBe(state);
+    // And it parses back into the bookkeeping the read-back store relies on.
+    const parsed = JSON.parse(read!.state) as {
+      subAgentIds: string[];
+      previousCallContextTokens: number;
+      metricSeries: Record<string, unknown>;
+    };
+    expect(parsed.subAgentIds).toEqual(["sub-1", "sub-2"]);
+    expect(parsed.previousCallContextTokens).toBe(7_000);
+    expect(Object.keys(parsed.metricSeries)).toEqual(["removed-1"]);
   });
 
   it("dedups a re-folded session to one row (ReplacingMergeTree, no FINAL)", async () => {

--- a/langwatch/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
@@ -29,6 +29,8 @@ interface ClickHouseWriteRecord {
   StartedAt: Date;
   CreatedAt: Date;
   UpdatedAt: Date;
+  /** The lossless JSON fold-state blob — the read-back path (ADR-066). */
+  State: string;
 
   Agent: string;
   AgentVersion: string;
@@ -129,6 +131,7 @@ function toRecord(
     StartedAt: new Date(row.startedAtMs),
     CreatedAt: now,
     UpdatedAt: now,
+    State: row.state ?? "",
 
     Agent: row.agent,
     AgentVersion: row.agentVersion,
@@ -258,6 +261,12 @@ export class CodingAgentSessionClickHouseRepository
    * hours, and a late signal can move StartedAt backwards, so the hint is
    * widened ±7 days rather than pinned to the exact ms — the window keeps
    * this a partition-pruned point read instead of a full-table scan.
+   *
+   * `startedAtMs` is ABSENT on the fold read-back path (ADR-066): the store's
+   * `get()` knows only tenantId + sessionId, so that read is unpruned. It is
+   * still bounded — one small row per session, keyed on (TenantId, SessionId) —
+   * and it is fronted by the Redis cache, so it runs only on a cache miss. Far
+   * cheaper than the event_log replay it replaces.
    */
   async findBySessionId({
     tenantId,
@@ -448,6 +457,7 @@ function fromRecord(record: Record<string, unknown>): CodingAgentSessionRow {
     sessionKeySource: String(record.SessionKeySource ?? ""),
     version: String(record.Version ?? ""),
     startedAtMs: new Date(String(record.StartedAt)).getTime(),
+    state: typeof record.State === "string" ? record.State : "",
 
     agent: String(record.Agent ?? ""),
     agentVersion: String(record.AgentVersion ?? ""),

--- a/langwatch/src/server/clickhouse/migrations/00053_add_coding_agent_session_state.sql
+++ b/langwatch/src/server/clickhouse/migrations/00053_add_coding_agent_session_state.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ============================================================================
+-- coding_agent_sessions.State — ADR-066.
+--
+-- The row that migration 00051 created has "two faces": the queryable analytics
+-- columns (a LOSSY aggregate — counters, bounded sets, ids that reach the heavy
+-- data) AND, from here on, a LOSSLESS resume blob. `State` carries the full
+-- JSON-serialized fold state, including the three bookkeeping fields the
+-- analytics columns deliberately drop (`subAgentIds`, `previousCallContextTokens`,
+-- `metricSeries`).
+--
+-- Why: the coding-agent session fold's store used to return null from get(),
+-- because the analytics row cannot reconstruct fold state. That forced the
+-- executor to refold the aggregate's ENTIRE history from event_log on every
+-- cache miss and every out-of-order delivery. On a large session (the key falls
+-- back to a trace id, so one big trace is one huge aggregate) those refolds are
+-- 20-100 MB S3-walking event_log reads; on 2026-07-23 they starved ClickHouse
+-- merges into TOO_MANY_PARTS and took the platform down.
+--
+-- With this column the store reads its OWN last committed state back (a bounded
+-- one-row read, fronted by the Redis cache) instead of refolding. The blob must
+-- round-trip the working state exactly — that completeness is the whole point.
+--
+-- ZSTD(3): the blob is repetitive JSON and cold once written; a higher level
+-- than the analytics columns' ZSTD(1) pays for itself on a resume-only column.
+-- ============================================================================
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+    ADD COLUMN IF NOT EXISTS State String DEFAULT '' CODEC(ZSTD(3));
+-- +goose StatementEnd
+
+-- +goose Down
+-- Down migrations are commented out to prevent accidental data loss.
+-- To roll back, uncomment and run manually.
+--
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions DROP COLUMN IF EXISTS State;

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.store.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.store.unit.test.ts
@@ -1,0 +1,328 @@
+/**
+ * The coding-agent session fold STORE reads its own last committed state back
+ * from ClickHouse instead of returning null (ADR-066). These tests execute the
+ * real serialize → record → deserialize path, so the round-trip is exact and a
+ * contribution applied after a cache miss lands on the full prior session.
+ *
+ * @see specs/coding-agent/session-aggregate.feature
+ *   ("a session resumes from its own stored state after its cache is lost")
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { describe, expect, it } from "vitest";
+import { createTenantId } from "~/server/event-sourcing";
+import { CodingAgentSessionClickHouseRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository";
+import type {
+  CodingAgentSessionRepository,
+  CodingAgentSessionRow,
+} from "~/server/app-layer/coding-agent/repositories/coding-agent-session.repository";
+import {
+  METRIC_FACTS_CONTRIBUTED_EVENT_TYPE,
+  SPAN_FACTS_CONTRIBUTED_EVENT_TYPE,
+} from "../../schemas/constants";
+import type {
+  MetricFactsContributedEvent,
+  SpanFactsContributedEvent,
+} from "../../schemas/events";
+import {
+  CodingAgentSessionFoldProjection,
+  type CodingAgentSessionState,
+  projectCodingAgentSessionToRow,
+} from "../codingAgentSession.foldProjection";
+import { CodingAgentSessionStore } from "../codingAgentSession.store";
+import type { ProjectionStoreContext } from "../../../../projections/projectionStoreContext";
+
+const SESSION_ID = "8f2c9a1e-4711-4e0f-9d2e-session";
+const TRACE_A = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
+const TRACE_B = "b1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d7";
+
+function makeProjection(): CodingAgentSessionFoldProjection {
+  return new CodingAgentSessionFoldProjection({
+    store: { store: async () => {}, get: async () => null },
+  });
+}
+
+/** `initState` is protected; the cast names the REAL state type on purpose. */
+function initStateOf(
+  projection: CodingAgentSessionFoldProjection,
+): CodingAgentSessionState {
+  return (
+    projection as unknown as { initState: () => CodingAgentSessionState }
+  ).initState();
+}
+
+function spanEvent({
+  name,
+  spanId,
+  traceId = TRACE_A,
+  facts = {},
+  startMs = 1_000,
+  endMs = 2_000,
+  statusCode = 0,
+}: {
+  name: string;
+  spanId: string;
+  traceId?: string;
+  facts?: Record<string, string | number | boolean>;
+  startMs?: number;
+  endMs?: number;
+  statusCode?: number;
+}): SpanFactsContributedEvent {
+  return {
+    tenantId: createTenantId("tenant-1"),
+    type: SPAN_FACTS_CONTRIBUTED_EVENT_TYPE,
+    data: {
+      tenantId: "tenant-1",
+      sessionId: SESSION_ID,
+      sessionKeySource: "provider",
+      agent: "claude_code",
+      occurredAt: startMs,
+      traceId,
+      spanId,
+      name,
+      startTimeUnixMs: startMs,
+      endTimeUnixMs: endMs,
+      statusCode,
+      facts,
+      scopeName: "com.anthropic.claude_code.tracing",
+    },
+  } as unknown as SpanFactsContributedEvent;
+}
+
+function metricEvent({
+  seriesId,
+  metricName,
+  attributes = {},
+  value,
+  asOfMs = 1_500,
+}: {
+  seriesId: string;
+  metricName: string;
+  attributes?: Record<string, string | number | boolean>;
+  value: number;
+  asOfMs?: number;
+}): MetricFactsContributedEvent {
+  return {
+    tenantId: createTenantId("tenant-1"),
+    type: METRIC_FACTS_CONTRIBUTED_EVENT_TYPE,
+    data: {
+      tenantId: "tenant-1",
+      sessionId: SESSION_ID,
+      sessionKeySource: "provider",
+      agent: "claude_code",
+      occurredAt: asOfMs,
+      seriesId,
+      metricName,
+      unit: null,
+      attributes,
+      value,
+      dataPointCount: 1,
+      asOfUnixMs: asOfMs,
+    },
+  } as unknown as MetricFactsContributedEvent;
+}
+
+/**
+ * A realistic session that exercises the three bookkeeping fields the analytics
+ * columns drop: `subAgentIds` (two distinct sub-agents), `metricSeries` (two
+ * delta units + one cumulative unit) and `previousCallContextTokens` (the last
+ * model call's context size).
+ */
+function buildSession(): CodingAgentSessionState {
+  const projection = makeProjection();
+  let state = initStateOf(projection);
+
+  // A model call from a sub-agent, carrying cache tokens → sets subAgentIds and
+  // previousCallContextTokens.
+  state = projection.handleCodingAgentSessionSpanFactsContributed(
+    spanEvent({
+      name: "claude_code.llm_request",
+      spanId: "llm-1",
+      facts: {
+        input_tokens: 100,
+        cache_read_tokens: 5_000,
+        cache_creation_tokens: 2_000,
+        agent_id: "sub-1",
+        request_id: "req_1",
+        stop_reason: "end_turn",
+      },
+    }),
+    state,
+  );
+  // A tool span from a SECOND sub-agent → subAgentIds grows to two.
+  state = projection.handleCodingAgentSessionSpanFactsContributed(
+    spanEvent({
+      name: "claude_code.tool",
+      spanId: "tool-1",
+      traceId: TRACE_B,
+      facts: { tool_name: "Read", agent_id: "sub-2" },
+    }),
+    state,
+  );
+  // Two DELTA line-removed units and one CUMULATIVE line-added unit.
+  state = projection.handleCodingAgentSessionMetricFactsContributed(
+    metricEvent({
+      seriesId: "removed-1",
+      metricName: "claude_code.lines_of_code.count",
+      attributes: { type: "removed" },
+      value: 10,
+    }),
+    state,
+  );
+  state = projection.handleCodingAgentSessionMetricFactsContributed(
+    metricEvent({
+      seriesId: "removed-2",
+      metricName: "claude_code.lines_of_code.count",
+      attributes: { type: "removed" },
+      value: 5,
+    }),
+    state,
+  );
+  state = projection.handleCodingAgentSessionMetricFactsContributed(
+    metricEvent({
+      seriesId: "added-cumulative",
+      metricName: "claude_code.lines_of_code.count",
+      attributes: { type: "added" },
+      value: 120,
+    }),
+    state,
+  );
+
+  return state;
+}
+
+/**
+ * A fake ClickHouse client that captures the inserted record and serves it back
+ * from `query()`. Paired with the REAL repository, this drives the actual
+ * `toRecord` → `fromRecord` mapping without a container — the `State` column is
+ * a plain String, so it round-trips losslessly (the integration test proves the
+ * whole-row contract against real ClickHouse).
+ */
+function makeFakeClickHouse(): { client: ClickHouseClient } {
+  let stored: Record<string, unknown> | null = null;
+  const client = {
+    async insert({ values }: { values: Record<string, unknown>[] }) {
+      stored = values[0] ?? null;
+    },
+    async query() {
+      return { async json() {
+        return stored ? [stored] : [];
+      } };
+    },
+  };
+  return { client: client as unknown as ClickHouseClient };
+}
+
+function makeStoreWithFakeClickHouse(): CodingAgentSessionStore {
+  const { client } = makeFakeClickHouse();
+  const repo = new CodingAgentSessionClickHouseRepository(async () => client);
+  return new CodingAgentSessionStore(repo);
+}
+
+const context: ProjectionStoreContext = {
+  aggregateId: SESSION_ID,
+  tenantId: createTenantId("tenant-1"),
+};
+
+/** A minimal repo that serves one row, for the null / empty / corrupt cases. */
+class SingleRowRepo implements CodingAgentSessionRepository {
+  constructor(private readonly row: CodingAgentSessionRow | null) {}
+  async upsert(): Promise<void> {}
+  async findBySessionId(): Promise<CodingAgentSessionRow | null> {
+    return this.row;
+  }
+  async findManyRecent(): Promise<CodingAgentSessionRow[]> {
+    return [];
+  }
+}
+
+function rowWithState(state: string): CodingAgentSessionRow {
+  const row = projectCodingAgentSessionToRow({
+    state: initStateOf(makeProjection()),
+    tenantId: "tenant-1",
+    sessionId: SESSION_ID,
+    version: "2026-07-21",
+  });
+  return { ...row, state };
+}
+
+describe("CodingAgentSessionStore", () => {
+  describe("when the cache misses and the store reads its own state back", () => {
+    it("round-trips the full fold state, bookkeeping fields included", async () => {
+      const original = buildSession();
+      const store = makeStoreWithFakeClickHouse();
+
+      await store.store(original, context);
+      const readBack = await store.get(SESSION_ID, context);
+
+      // The whole state survives — not just the analytics columns.
+      expect(readBack).toEqual(original);
+      // The three fields the analytics columns deliberately drop are present.
+      expect(readBack!.subAgentIds).toEqual(["sub-1", "sub-2"]);
+      expect(readBack!.previousCallContextTokens).toBe(7_000);
+      expect(Object.keys(readBack!.metricSeries)).toEqual([
+        "removed-1",
+        "removed-2",
+        "added-cumulative",
+      ]);
+    });
+
+    it("resumes the metric map so a later contribution does not double-count", async () => {
+      const store = makeStoreWithFakeClickHouse();
+      await store.store(buildSession(), context);
+
+      const resumed = await store.get(SESSION_ID, context);
+      expect(resumed).not.toBeNull();
+      // The read-back carried the converged delta units forward.
+      expect(resumed!.linesRemoved).toBe(15);
+
+      const projection = makeProjection();
+      // Re-delivering an already-counted DELTA unit must REPLACE it, not add —
+      // only possible because its metricSeries entry survived the read-back.
+      const afterRedelivery =
+        projection.handleCodingAgentSessionMetricFactsContributed(
+          metricEvent({
+            seriesId: "removed-1",
+            metricName: "claude_code.lines_of_code.count",
+            attributes: { type: "removed" },
+            value: 10,
+          }),
+          resumed!,
+        );
+      expect(afterRedelivery.linesRemoved).toBe(15);
+
+      // A genuinely new delta unit adds on top of the resumed 15.
+      const afterNew =
+        projection.handleCodingAgentSessionMetricFactsContributed(
+          metricEvent({
+            seriesId: "removed-3",
+            metricName: "claude_code.lines_of_code.count",
+            attributes: { type: "removed" },
+            value: 7,
+          }),
+          afterRedelivery,
+        );
+      expect(afterNew.linesRemoved).toBe(22);
+    });
+  });
+
+  describe("when there is no usable stored state", () => {
+    it("returns null for a genuinely new aggregate so the framework inits", async () => {
+      const store = new CodingAgentSessionStore(new SingleRowRepo(null));
+      expect(await store.get(SESSION_ID, context)).toBeNull();
+    });
+
+    it("returns null when the stored blob is empty", async () => {
+      const store = new CodingAgentSessionStore(
+        new SingleRowRepo(rowWithState("")),
+      );
+      expect(await store.get(SESSION_ID, context)).toBeNull();
+    });
+
+    it("degrades to init on a corrupt blob rather than throwing", async () => {
+      const store = new CodingAgentSessionStore(
+        new SingleRowRepo(rowWithState("{not valid json")),
+      );
+      await expect(store.get(SESSION_ID, context)).resolves.toBeNull();
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection.ts
@@ -85,13 +85,20 @@ export class CodingAgentSessionFoldProjection
   protected readonly events = codingAgentSessionEvents;
 
   /**
-   * The row is an aggregate, not a copy, so it cannot be read back into state
-   * (the counters are there, but the step ordering and the "first seen" identity
-   * rules are not reconstructable from it). On a cache miss the executor must
-   * rebuild from the event log, or a partial batch would overwrite a complete
-   * session with only the events in that batch.
+   * The derivation is ORDER-INSENSITIVE: `appendStep` inserts each step by its
+   * own `startedAtMs` (not arrival order), the bounded sets are first-seen and
+   * idempotent, the counters are additive, and every metric unit converges by
+   * its series id. The fold therefore reaches the same state whichever order it
+   * sees events in, so an out-of-order delivery needs no replay (ADR-066).
+   *
+   * A cache miss needs no replay either: the store now reads its OWN last
+   * committed state back from the lossless `State` blob (ADR-066), so it returns
+   * the real prior state instead of null — the executor applies the delivered
+   * events on top of it. The old `refoldOnStoreMiss` refold from event_log (a
+   * 20-100 MB S3 walk on a large session) is what took the platform down on
+   * 2026-07-23; the read-back replaces it with a bounded one-row read.
    */
-  override options: FoldProjectionOptions = { refoldOnStoreMiss: true };
+  override options: FoldProjectionOptions = { refoldOnOutOfOrder: false };
 
   constructor(deps: { store: FoldProjectionStore<CodingAgentSessionState> }) {
     super({
@@ -214,6 +221,15 @@ export interface CodingAgentSessionRow {
   sessionKeySource: string;
   version: string;
   startedAtMs: number;
+  /**
+   * The full JSON-serialized fold state — the LOSSLESS resume blob (ADR-066).
+   * Distinct from the analytics columns below, which are a lossy aggregate: this
+   * carries the whole `CodingAgentSessionState`, including the three bookkeeping
+   * fields the columns drop (`subAgentIds`, `previousCallContextTokens`,
+   * `metricSeries`), so the store can read its own state back exactly instead of
+   * refolding the aggregate's event_log history on a cache miss.
+   */
+  state: string;
 
   agent: string;
   agentVersion: string;
@@ -321,6 +337,9 @@ export function projectCodingAgentSessionToRow({
     sessionKeySource: state.sessionKeySource,
     version,
     startedAtMs: state.startedAtMs,
+    // The lossless resume blob: the whole state, including the fields the
+    // analytics columns drop. Read back verbatim by the store on a cache miss.
+    state: JSON.stringify(state),
 
     agent: state.agent ?? "",
     agentVersion: state.agentVersion ?? "",

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.store.ts
@@ -1,3 +1,4 @@
+import { createLogger } from "@langwatch/observability";
 import type { CodingAgentSessionRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-session.repository";
 import { PLATFORM_DEFAULT_RETENTION_DAYS } from "~/server/data-retention/retentionPolicy.schema";
 import type { FoldProjectionStore } from "../../../projections/foldProjection.types";
@@ -7,6 +8,10 @@ import {
   type CodingAgentSessionState,
   projectCodingAgentSessionToRow,
 } from "./codingAgentSession.foldProjection";
+
+const logger = createLogger(
+  "langwatch:coding-agent:session-fold-store",
+);
 
 /**
  * FoldProjectionStore adapter for the coding-agent session fold (ADR-056).
@@ -73,18 +78,40 @@ export class CodingAgentSessionStore
   }
 
   /**
-   * No read-back: the row is an AGGREGATE, not a copy. The counters survive a
-   * round-trip but the fold's ordering rules and first-seen identity semantics
-   * do not, so rebuilding state from the row would quietly produce a different
-   * session than replaying the events does.
+   * Read the last committed state back (ADR-066). Dumb read/write — the `State`
+   * column IS the data: the row's analytics columns are a lossy aggregate, but
+   * `State` carries the whole serialized fold state (including `subAgentIds`,
+   * `previousCallContextTokens` and `metricSeries`, which the columns drop), so
+   * the read-back is EXACT — no ordering rule or first-seen identity is lost.
    *
-   * State continuity therefore comes from the two layers above this store: the
-   * Redis cache it is wrapped in at registration, and the fold's
-   * `refoldOnStoreMiss` option, which rebuilds from the event log on a miss.
-   * Without BOTH, a delivery would fold only its own batch and a partial row
-   * would overwrite a complete one.
+   * This is what makes the fold's `refoldOnStoreMiss` unnecessary: a cache miss
+   * returns the real prior state, not null, so the executor applies the
+   * delivered events on top of it instead of walking the aggregate's entire
+   * event_log history (the 2026-07-23 outage). A genuinely new aggregate has no
+   * row (or an empty blob) → return null so the framework calls `init()`.
+   *
+   * A corrupt blob degrades to init rather than throwing: a parse failure must
+   * not wedge the group. It re-derives from the delivered events onward — lossy
+   * for that one session, but the group keeps moving.
    */
-  async get(): Promise<CodingAgentSessionState | null> {
-    return null;
+  async get(
+    aggregateId: string,
+    context: ProjectionStoreContext,
+  ): Promise<CodingAgentSessionState | null> {
+    const row = await this.repo.findBySessionId({
+      tenantId: String(context.tenantId),
+      sessionId: aggregateId,
+    });
+    if (!row || !row.state) return null;
+
+    try {
+      return JSON.parse(row.state) as CodingAgentSessionState;
+    } catch (error) {
+      logger.warn(
+        { error, tenantId: String(context.tenantId), sessionId: aggregateId },
+        "failed to parse stored coding-agent session state; degrading to init",
+      );
+      return null;
+    }
   }
 }

--- a/specs/coding-agent/session-aggregate.feature
+++ b/specs/coding-agent/session-aggregate.feature
@@ -46,3 +46,12 @@ Feature: Coding-agent sessions
   Scenario: a session without a session id is not lost
     When a coding-agent trace arrives whose telemetry carries no session id
     Then it appears as a single-trace session of its own
+
+  Scenario: a session resumes from its own stored state after its cache is lost
+    Given a session that has already recorded its work, including its sub-agents,
+      its converged metrics and its per-call context bookkeeping
+    And the in-memory copy of that session has been dropped
+    When more telemetry arrives for the session
+    Then the session resumes from its last stored state without re-reading its history
+    And the new telemetry adds to the totals already recorded, not to an empty session
+    And re-delivered telemetry the session had already counted does not inflate its totals


### PR DESCRIPTION
First adopter of **ADR-066** (\"event_log off the per-item hot path\", PR #6079) and the durable fix for the **2026-07-23 production outage**.

## The outage mechanism
The \`codingAgentSession\` fold's store returned \`null\` from \`get()\` by design: it persists a *lossy* analytics row that cannot reconstruct fold state. That forced the executor to refold the aggregate's **entire** \`event_log\` history on **every cache miss** *and* **every out-of-order delivery**. On large coding-agent sessions the session key falls back to the traceId, so one big trace is one huge aggregate — those refolds are 20–100 MB S3-walking \`event_log\` reads. They starved ClickHouse merges, produced \`TOO_MANY_PARTS\`, and took the platform down.

## The read-back fix
Make the store read its **own last committed state** back from ClickHouse (a bounded one-row read, fronted by the Redis cache) instead of refolding, and stop treating out-of-order delivery as a reason to replay (the derivation is order-insensitive).

## What changed
- **Migration `00053_add_coding_agent_session_state.sql`** — adds one lossless column to `coding_agent_sessions`:
  \`\`\`
  State String DEFAULT '' CODEC(ZSTD(3))
  \`\`\`
  The row now has \"two faces\": the queryable analytics columns **and** a full serialized fold-state resume blob. The blob carries the three fields the analytics columns deliberately drop — \`subAgentIds\`, \`previousCallContextTokens\`, \`metricSeries\` — so it round-trips the working state exactly. 00051/00052 are untouched (deployed, immutable).
- **Persist the full state** — \`CodingAgentSessionRow\` gains \`state: string\`; \`projectCodingAgentSessionToRow\` sets \`state: JSON.stringify(state)\`.
- **Write + read the column** — the ClickHouse repo maps \`State\` in \`toRecord\`/\`fromRecord\`; \`findBySessionId\` (already \`SELECT *\` with IN-tuple latest-version dedup) now returns it. The fold read-back path knows only tenantId+sessionId, so that read is unpruned but bounded (one small row) and cache-fronted — far cheaper than the \`event_log\` replay it replaces.
- **`get()` reads back** — \`findBySessionId\` → \`JSON.parse\` the blob into \`CodingAgentSessionState\`; empty/missing blob → \`null\` (framework calls \`init()\`); a corrupt blob logs a warning and degrades to init rather than wedging the group. Mirrors \`experimentRunState.store.ts\` (\"dumb read/write — state IS the data\").
- **`refoldOnOutOfOrder: false`** — replaces \`refoldOnStoreMiss: true\`. The derivation is order-insensitive (\`appendStep\` inserts by \`startedAtMs\`; sets are first-seen-bounded; counters additive; metrics converge by series id), so out-of-order needs no replay and a miss now needs no refold.

## Tests
- **Spec** — \`specs/coding-agent/session-aggregate.feature\` gains a resume-after-cache-loss scenario (resumes from stored state without re-reading history; totals accumulate; re-delivered telemetry does not inflate).
- **Unit** (colocated) — round-trips a state exercising all three bookkeeping fields through the real \`projectCodingAgentSessionToRow → toRecord → fromRecord → store.get()\` path and asserts deep-equality; a metric applied after read-back does not double-count (proves \`metricSeries\` survived); plus null / empty / corrupt-blob cases.
- **Integration** — \`coding-agent-session.clickhouse.repository.integration.test.ts\` round-trips the \`State\` blob through real ClickHouse (migration auto-applied by the goose harness).

## Test commands + results
\`\`\`
pnpm test:unit run src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.store.unit.test.ts          # 5 passed
pnpm test:unit run .../codingAgentSession.foldProjection.unit.test.ts .../sessionSignals.unit.test.ts .../coding-agent-session.service.unit.test.ts  # 32 passed
pnpm test:integration run src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts    # 5 passed
\`\`\`

A separate tiny relief PR may also set \`refoldOnOutOfOrder: false\`; the change is idempotent, so a later merge conflict there is harmless.