### PR TITLE
feat(coding-agent): read-back store for the session fold (ADR-066, closes the refold outage)

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/sessionView/__tests__/SessionView.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/sessionView/__tests__/SessionView.integration.test.tsx
@@ -113,6 +113,13 @@ const REAL_SESSION: CodingAgentSessionRow = {
   atMentions: 0,
   stopReason: "tool_use",
   truncated: false,
+  subAgentIds: [],
+  stepStartedAt: [],
+  previousCallContextTokens: 0,
+  metricSeries: [],
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+  lastEventOccurredAt: 0,
 };
 
 function renderSession(

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/sessionView/__tests__/sessionSignals.unit.test.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/sessionView/__tests__/sessionSignals.unit.test.ts
@@ -86,6 +86,13 @@ function session(
     atMentions: 0,
     stopReason: "end_turn",
     truncated: false,
+    subAgentIds: [],
+    stepStartedAt: [],
+    previousCallContextTokens: 0,
+    metricSeries: [],
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    lastEventOccurredAt: 0,
     ...over,
   };
 }

--- a/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
@@ -112,6 +112,30 @@ function sessionRow(
     atMentions: 0,
     stopReason: "end_turn",
     truncated: false,
+    subAgentIds: [`${tag}-sub-a`, `${tag}-sub-b`],
+    stepStartedAt: [baseMs + 10, baseMs + 20],
+    previousCallContextTokens: 9_000_000_000,
+    metricSeries: [
+      {
+        seriesId: `${tag}-loc-added`,
+        metricName: "lines_of_code.count",
+        type: "added",
+        decision: "",
+        language: "",
+        value: 120,
+      },
+      {
+        seriesId: `${tag}-edits`,
+        metricName: "code_edit_tool.decision",
+        type: "",
+        decision: "accept",
+        language: "typescript",
+        value: 4,
+      },
+    ],
+    createdAt: baseMs,
+    updatedAt: baseMs,
+    lastEventOccurredAt: baseMs + 20,
     ...over,
   };
 }
@@ -168,6 +192,33 @@ describe("coding_agent_sessions round-trip (migration 00051)", () => {
     expect(read!.sessionKeySource).toBe("provider");
     expect(read!.costUsd).toBeCloseTo(1.25);
     expect(read!.commits).toBe(2);
+
+    // Read-back columns (migration 00053, ADR-066) survive the trip so
+    // store.get() can reconstruct working state without touching event_log.
+    expect(read!.subAgentIds).toEqual([`${tag}-sub-a`, `${tag}-sub-b`]);
+    expect(read!.stepStartedAt).toEqual([baseMs + 10, baseMs + 20]);
+    expect(read!.previousCallContextTokens).toBe(9_000_000_000);
+    expect(read!.metricSeries).toEqual([
+      {
+        seriesId: `${tag}-loc-added`,
+        metricName: "lines_of_code.count",
+        type: "added",
+        decision: "",
+        language: "",
+        value: 120,
+      },
+      {
+        seriesId: `${tag}-edits`,
+        metricName: "code_edit_tool.decision",
+        type: "",
+        decision: "accept",
+        language: "typescript",
+        value: 4,
+      },
+    ]);
+    // DateTime64 columns come back without a timezone, so exact-equality is
+    // machine-dependent; assert the column is populated and roughly right.
+    expect(read!.lastEventOccurredAt).toBeGreaterThan(0);
   });
 
   it("dedups a re-folded session to one row (ReplacingMergeTree, no FINAL)", async () => {

--- a/langwatch/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
@@ -1,7 +1,10 @@
 import { createLogger } from "@langwatch/observability";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { PLATFORM_DEFAULT_RETENTION_DAYS } from "~/server/data-retention/retentionPolicy.schema";
-import type { CodingAgentSessionRow } from "~/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection";
+import type {
+  CodingAgentSessionMetricSeriesRow,
+  CodingAgentSessionRow,
+} from "~/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection";
 import { SecurityError } from "~/server/event-sourcing/services/errorHandling";
 import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
 import type { CodingAgentSessionRepository } from "./coding-agent-session.repository";
@@ -110,6 +113,15 @@ interface ClickHouseWriteRecord {
   StopReason: string;
   Truncated: boolean;
 
+  // ── Read-back state (ADR-066, migration 00053) ─────────────────────────
+  SubAgentIds: string[];
+  // UInt64 arrays / scalars ride as strings, like the other UInt64 columns.
+  StepStartedAt: string[];
+  PreviousCallContextTokens: string;
+  // Array(Tuple(SeriesId, MetricName, Type, Decision, Language, Value)).
+  MetricSeries: [string, string, string, string, string, number][];
+  LastEventOccurredAt: Date;
+
   _retention_days: number;
 }
 
@@ -127,7 +139,9 @@ function toRecord(
     SessionKeySource: row.sessionKeySource,
     Version: row.version,
     StartedAt: new Date(row.startedAtMs),
-    CreatedAt: now,
+    // Preserve first-seen creation across re-folds; UpdatedAt is the RMT
+    // version and must be the write time so the latest version wins.
+    CreatedAt: row.createdAt > 0 ? new Date(row.createdAt) : now,
     UpdatedAt: now,
 
     Agent: row.agent,
@@ -211,6 +225,19 @@ function toRecord(
 
     StopReason: row.stopReason,
     Truncated: row.truncated,
+
+    SubAgentIds: row.subAgentIds,
+    StepStartedAt: row.stepStartedAt.map(big),
+    PreviousCallContextTokens: big(row.previousCallContextTokens),
+    MetricSeries: row.metricSeries.map((unit) => [
+      unit.seriesId,
+      unit.metricName,
+      unit.type,
+      unit.decision,
+      unit.language,
+      unit.value,
+    ]),
+    LastEventOccurredAt: new Date(row.lastEventOccurredAt),
 
     _retention_days: retentionDays ?? PLATFORM_DEFAULT_RETENTION_DAYS,
   };
@@ -430,6 +457,34 @@ const asStringArray = (value: unknown): string[] =>
     ? value.filter((v): v is string => typeof v === "string")
     : [];
 
+const asNumberArray = (value: unknown): number[] =>
+  Array.isArray(value) ? value.map(asNumber) : [];
+
+/** Parse the `MetricSeries` Array(Tuple(...)), read as an array of arrays. */
+const asMetricSeriesRows = (
+  value: unknown,
+): CodingAgentSessionMetricSeriesRow[] =>
+  Array.isArray(value)
+    ? value.map((unit) => {
+        const tuple = unit as [
+          unknown,
+          unknown,
+          unknown,
+          unknown,
+          unknown,
+          unknown,
+        ];
+        return {
+          seriesId: String(tuple[0] ?? ""),
+          metricName: String(tuple[1] ?? ""),
+          type: String(tuple[2] ?? ""),
+          decision: String(tuple[3] ?? ""),
+          language: String(tuple[4] ?? ""),
+          value: asNumber(tuple[5]),
+        };
+      })
+    : [];
+
 const asNumberMap = (value: unknown): Record<string, number> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
     ? Object.fromEntries(
@@ -535,5 +590,13 @@ function fromRecord(record: Record<string, unknown>): CodingAgentSessionRow {
 
     stopReason: String(record.StopReason ?? ""),
     truncated: Boolean(record.Truncated),
+
+    subAgentIds: asStringArray(record.SubAgentIds),
+    stepStartedAt: asNumberArray(record.StepStartedAt),
+    previousCallContextTokens: asNumber(record.PreviousCallContextTokens),
+    metricSeries: asMetricSeriesRows(record.MetricSeries),
+    createdAt: new Date(String(record.CreatedAt)).getTime(),
+    updatedAt: new Date(String(record.UpdatedAt)).getTime(),
+    lastEventOccurredAt: new Date(String(record.LastEventOccurredAt)).getTime(),
   };
 }

--- a/langwatch/src/server/clickhouse/migrations/00053_coding_agent_sessions_read_back.sql
+++ b/langwatch/src/server/clickhouse/migrations/00053_coding_agent_sessions_read_back.sql
@@ -1,0 +1,76 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ============================================================================
+-- coding_agent_sessions — read-back columns (ADR-066, Pillar 1 adopter #1).
+--
+-- The session fold's store.get() returned null by design, so every cache miss
+-- and every out-of-order delivery refolded the aggregate's WHOLE history from
+-- event_log. On a large session that is a 20-100 MB S3-walking read; enough of
+-- them starved ClickHouse merges into OOM, stalled event_log part merges, and
+-- tripped TOO_MANY_PARTS platform-wide (2026-07-23 outage).
+--
+-- ADR-066 makes the fold read back its own last committed state instead. The
+-- row already carries almost the whole state as typed columns; these five close
+-- the round-trip gap so store.get() can reconstruct working state WITHOUT ever
+-- reading event_log:
+--
+--   SubAgentIds               — the dedup set behind the SubAgents count; the
+--                               row carried the count + types, not the ids.
+--   PreviousCallContextTokens — the previous model call's context size, used to
+--                               detect the NEXT call's cache rebuild.
+--   StepStartedAt             — per-step start times, parallel to Steps. Steps
+--                               dropped these on projection, which is the real
+--                               reason a read-back step could not be re-ordered.
+--   MetricSeries              — the converged metric units the metric-fed fields
+--                               are recomputed from (replace-not-increment,
+--                               ADR-056 §5). Persisting the map makes the pure
+--                               overlay reproduce every metric-fed field on
+--                               read-back with no read-path change. (Transitional
+--                               per ADR-066 step 2: this map later leaves the
+--                               fold for session_metric_series.)
+--   LastEventOccurredAt       — the fold's out-of-order checkpoint. CreatedAt /
+--                               UpdatedAt already exist (UpdatedAt is the RMT
+--                               version), so only this one is new.
+--
+-- Each ALTER is its own statement block — ClickHouse does not support
+-- multi-statement queries.
+-- ============================================================================
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  ADD COLUMN IF NOT EXISTS SubAgentIds Array(String) CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  ADD COLUMN IF NOT EXISTS PreviousCallContextTokens UInt64 CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  ADD COLUMN IF NOT EXISTS StepStartedAt Array(UInt64) CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- (SeriesId, MetricName, Type, Decision, Language, Value). Unnamed tuple so it
+-- serialises as a JSON array over JSONEachRow, exactly like the Steps column.
+-- Nullable attribute fields ride as empty strings and map back to null.
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  ADD COLUMN IF NOT EXISTS MetricSeries Array(Tuple(String, String, String, String, String, Float64)) CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  ADD COLUMN IF NOT EXISTS LastEventOccurredAt DateTime64(3) DEFAULT 0 CODEC(Delta(8), ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose Down
+-- Down migrations are commented out to prevent accidental data loss.
+-- To roll back, uncomment and run manually.
+--
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions DROP COLUMN IF EXISTS SubAgentIds;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions DROP COLUMN IF EXISTS PreviousCallContextTokens;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions DROP COLUMN IF EXISTS StepStartedAt;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions DROP COLUMN IF EXISTS MetricSeries;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions DROP COLUMN IF EXISTS LastEventOccurredAt;

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -739,10 +739,10 @@ export class PipelineRegistry {
   private registerCodingAgentPipeline() {
     return this.deps.eventSourcing.register(
       createCodingAgentProcessingPipeline({
-        // Redis cache is this fold's ONLY warm read path — its store's get()
-        // returns null by design (the row is an aggregate, not a copy), and
-        // on a cache miss the fold's refoldOnStoreMiss option rebuilds state
-        // from the event log. Same wiring as trace_summaries.
+        // Read-through store (ADR-066): Redis is the warm read tier; on a miss
+        // the store reads its own last committed state back from
+        // coding_agent_sessions (store.get() → findBySessionId → rebuild). The
+        // delivery path never reads event_log. Same wiring as trace_summaries.
         codingAgentSessionStore: this.cached<CodingAgentSessionState>(
           new CodingAgentSessionStore(
             this.deps.repositories.codingAgentSession,

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -741,8 +741,8 @@ export class PipelineRegistry {
       createCodingAgentProcessingPipeline({
         // Read-through store (ADR-066): Redis is the warm read tier; on a miss
         // the store reads its own last committed state back from
-        // coding_agent_sessions (store.get() → findBySessionId → rebuild). The
-        // delivery path never reads event_log. Same wiring as trace_summaries.
+        // coding_agent_sessions (store.get() → findBySessionId → decode row).
+        // The delivery path never reads event_log. Same wiring as trace_summaries.
         codingAgentSessionStore: this.cached<CodingAgentSessionState>(
           new CodingAgentSessionStore(
             this.deps.repositories.codingAgentSession,

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
@@ -17,9 +17,11 @@ import type {
   SpanFactsContributedEvent,
 } from "../../schemas/events";
 import {
+  CODING_AGENT_SESSION_PROJECTION_VERSION_LATEST,
   CodingAgentSessionFoldProjection,
   type CodingAgentSessionState,
   projectCodingAgentSessionToRow,
+  rebuildCodingAgentSessionStateFromRow,
 } from "../codingAgentSession.foldProjection";
 
 const SESSION_ID = "8f2c9a1e-4711-4e0f-9d2e-session";
@@ -463,6 +465,84 @@ describe("CodingAgentSessionFoldProjection", () => {
       expect(row.sessionKeySource).toBe("provider");
       expect(row.traceIds).toEqual([TRACE_A]);
       expect(row.inputTokens).toBe(10);
+    });
+  });
+});
+
+describe("read-back losslessness (ADR-066)", () => {
+  describe("when a folded session is projected to a row and rebuilt", () => {
+    /**
+     * The outage fix depends on this exactly: store.get() reconstructs working
+     * state from the row instead of replaying event_log. If any field the fold
+     * needs fails to round-trip, a cache miss would silently fold onto partial
+     * state — so this asserts the WHOLE state survives, and calls out the
+     * previously-lossy bookkeeping fields by name.
+     */
+    it("recovers the identical working state, including the bookkeeping the old row dropped", () => {
+      const projection = makeProjection();
+      let state = projection.init();
+
+      // A model call: tokens, a sub-agent id (the dedup set), the previous-call
+      // context that drives cache-rebuild detection, the final request id.
+      state = projection.apply(
+        state,
+        spanFactsEvent({
+          name: "claude_code.llm_request",
+          spanId: "llm-1",
+          startMs: 1_000,
+          endMs: 2_000,
+          facts: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_tokens: 800,
+            cache_creation_tokens: 200,
+            agent_id: "sub-agent-1",
+            request_id: "req_final",
+            stop_reason: "end_turn",
+          },
+        }),
+      );
+      // A tool span: a step that carries its own start time (the parallel array
+      // the 3-tuple row column used to drop).
+      state = projection.apply(
+        state,
+        spanFactsEvent({
+          name: "claude_code.tool",
+          spanId: "tool-1",
+          startMs: 3_000,
+          endMs: 3_500,
+          facts: { tool_name: "Read", file_path: "/a.ts" },
+        }),
+      );
+      // A metric contribution: a converged unit in metricSeries + a metric-fed
+      // field recomputed from it.
+      state = projection.apply(
+        state,
+        metricFactsEvent({
+          seriesId: "loc-added",
+          metricName: "claude_code.lines_of_code.count",
+          attributes: { type: "added" },
+          value: 42,
+        }),
+      );
+
+      // The fields the pre-ADR-066 row could not represent are actually populated.
+      expect(state.subAgentIds).toEqual(["sub-agent-1"]);
+      expect(state.previousCallContextTokens).toBe(1_000);
+      expect(state.steps[0]?.startedAtMs).toBe(3_000);
+      expect(Object.keys(state.metricSeries)).toContain("loc-added");
+      expect(state.linesAdded).toBe(42);
+
+      const row = projectCodingAgentSessionToRow({
+        state,
+        tenantId: "tenant-1",
+        sessionId: SESSION_ID,
+        version: CODING_AGENT_SESSION_PROJECTION_VERSION_LATEST,
+      });
+
+      const rebuilt = rebuildCodingAgentSessionStateFromRow(row);
+
+      expect(rebuilt).toEqual(state);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
@@ -20,8 +20,8 @@ import {
   CODING_AGENT_SESSION_PROJECTION_VERSION_LATEST,
   CodingAgentSessionFoldProjection,
   type CodingAgentSessionState,
+  codingAgentSessionStateFromRow,
   projectCodingAgentSessionToRow,
-  rebuildCodingAgentSessionStateFromRow,
 } from "../codingAgentSession.foldProjection";
 
 const SESSION_ID = "8f2c9a1e-4711-4e0f-9d2e-session";
@@ -472,10 +472,10 @@ describe("CodingAgentSessionFoldProjection", () => {
 describe("read-back losslessness (ADR-066)", () => {
   describe("when a folded session is projected to a row and rebuilt", () => {
     /**
-     * The outage fix depends on this exactly: store.get() reconstructs working
-     * state from the row instead of replaying event_log. If any field the fold
-     * needs fails to round-trip, a cache miss would silently fold onto partial
-     * state — so this asserts the WHOLE state survives, and calls out the
+     * The outage fix depends on this exactly: store.get() reads working state
+     * back by decoding the row, instead of replaying event_log. If any field the
+     * fold needs fails to round-trip, a cache miss would silently fold onto
+     * partial state — so this asserts the WHOLE state survives, and calls out the
      * previously-lossy bookkeeping fields by name.
      */
     it("recovers the identical working state, including the bookkeeping the old row dropped", () => {
@@ -540,9 +540,9 @@ describe("read-back losslessness (ADR-066)", () => {
         version: CODING_AGENT_SESSION_PROJECTION_VERSION_LATEST,
       });
 
-      const rebuilt = rebuildCodingAgentSessionStateFromRow(row);
+      const decoded = codingAgentSessionStateFromRow(row);
 
-      expect(rebuilt).toEqual(state);
+      expect(decoded).toEqual(state);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection.ts
@@ -21,7 +21,10 @@ import {
   applySpanToCodingAgentSession,
   createInitCodingAgentSession,
 } from "../services/coding-agent-session.derivation";
-import type { CodingAgentSessionData } from "../services/coding-agent-session.types";
+import type {
+  CodingAgentSessionData,
+  MetricSeriesFact,
+} from "../services/coding-agent-session.types";
 
 /**
  * The coding-agent session fold (ADR-056).
@@ -85,13 +88,19 @@ export class CodingAgentSessionFoldProjection
   protected readonly events = codingAgentSessionEvents;
 
   /**
-   * The row is an aggregate, not a copy, so it cannot be read back into state
-   * (the counters are there, but the step ordering and the "first seen" identity
-   * rules are not reconstructable from it). On a cache miss the executor must
-   * rebuild from the event log, or a partial batch would overwrite a complete
-   * session with only the events in that batch.
+   * The store reads its own last committed state back (ADR-066): the row now
+   * round-trips the full working state, so `get()` returns it and nothing on
+   * the delivery path reads `event_log`.
+   *
+   * `refoldOnStoreMiss` is gone — there is no null-returning miss to refold.
+   * `refoldOnOutOfOrder` is off because the derivation is order-insensitive:
+   * accumulators commute (sums, counters, min/max, bounded first-seen sets),
+   * steps are inserted by their own `startedAtMs`, and the metric overlay
+   * replaces per series. A late event folds onto the loaded state in place; no
+   * history replay derives anything. (See the 2026-07-23 outage: unbounded
+   * refolds starved ClickHouse merges into a platform-wide `TOO_MANY_PARTS`.)
    */
-  override options: FoldProjectionOptions = { refoldOnStoreMiss: true };
+  override options: FoldProjectionOptions = { refoldOnOutOfOrder: false };
 
   constructor(deps: { store: FoldProjectionStore<CodingAgentSessionState> }) {
     super({
@@ -204,9 +213,24 @@ export class CodingAgentSessionFoldProjection
 }
 
 /**
- * The row that lands in `coding_agent_sessions` (migration 00051). Field names
- * mirror the ClickHouse columns 1:1 so the repository's record literal is a
- * straight mapping.
+ * One converged metric unit, as it rides in the row's `MetricSeries` column
+ * (migration 00053). Mirrors {@link MetricSeriesFact} but with the nullable
+ * attribute fields flattened to empty strings for the ClickHouse tuple; they
+ * map back to null on read-back.
+ */
+export interface CodingAgentSessionMetricSeriesRow {
+  seriesId: string;
+  metricName: string;
+  type: string;
+  decision: string;
+  language: string;
+  value: number;
+}
+
+/**
+ * The row that lands in `coding_agent_sessions` (migration 00051, extended by
+ * 00053). Field names mirror the ClickHouse columns 1:1 so the repository's
+ * record literal is a straight mapping.
  */
 export interface CodingAgentSessionRow {
   tenantId: string;
@@ -296,12 +320,29 @@ export interface CodingAgentSessionRow {
 
   stopReason: string;
   truncated: boolean;
+
+  // ── Read-back state (ADR-066, migration 00053) ─────────────────────────
+  // Not analytics columns — these round-trip the fold's working state so
+  // store.get() can reconstruct it without replaying event_log.
+  /** The dedup set behind `subAgents`; the row keeps count + types, plus this. */
+  subAgentIds: string[];
+  /** Per-step start times, index-aligned with `steps` (dropped by the 3-tuple). */
+  stepStartedAt: number[];
+  /** Previous model call's context size, to detect the next cache rebuild. */
+  previousCallContextTokens: number;
+  /** The converged metric units the metric-fed fields are recomputed from. */
+  metricSeries: CodingAgentSessionMetricSeriesRow[];
+  /** Fold bookkeeping timestamps (createdAt/updatedAt map to CreatedAt/UpdatedAt). */
+  createdAt: number;
+  updatedAt: number;
+  lastEventOccurredAt: number;
 }
 
 /**
  * Project the fold state into the row. Every heavy thing stays out: the row
  * carries counters, bounded sets, and the IDS that reach the spans, the logs and
- * the response body — never their contents.
+ * the response body — never their contents. The read-back columns (ADR-066)
+ * carry the fold's working-state bookkeeping so `store.get()` round-trips.
  */
 export function projectCodingAgentSessionToRow({
   state,
@@ -401,5 +442,151 @@ export function projectCodingAgentSessionToRow({
 
     stopReason: state.stopReason ?? "",
     truncated: state.truncated,
+
+    subAgentIds: state.subAgentIds,
+    stepStartedAt: state.steps.map((s) => s.startedAtMs),
+    previousCallContextTokens: state.previousCallContextTokens,
+    metricSeries: Object.entries(state.metricSeries).map(
+      ([seriesId, fact]) => ({
+        seriesId,
+        metricName: fact.metricName,
+        type: fact.type ?? "",
+        decision: fact.decision ?? "",
+        language: fact.language ?? "",
+        value: fact.value,
+      }),
+    ),
+    createdAt: state.createdAt,
+    updatedAt: state.updatedAt,
+    lastEventOccurredAt: state.LastEventOccurredAt,
+  };
+}
+
+/** An empty string in a row column reads back as "unset" (null) in state. */
+const nullIfEmpty = (value: string): string | null =>
+  value === "" ? null : value;
+
+/**
+ * Rebuild the fold's working state from its persisted row — the inverse of
+ * {@link projectCodingAgentSessionToRow} (ADR-066). This is what makes
+ * `store.get()` lossless, so a cache miss reads one row back into state instead
+ * of replaying the aggregate's history from `event_log`.
+ *
+ * The row mirrors the state field-for-field; the only conversions are the
+ * nullable identity fields (stored as "" ) mapping back to null, `steps`
+ * zipping with the parallel `stepStartedAt`, and `metricSeries` re-keying by
+ * series id.
+ */
+export function rebuildCodingAgentSessionStateFromRow(
+  row: CodingAgentSessionRow,
+): CodingAgentSessionState {
+  const metricSeries: Record<string, MetricSeriesFact> = Object.fromEntries(
+    row.metricSeries.map((unit) => [
+      unit.seriesId,
+      {
+        metricName: unit.metricName,
+        type: nullIfEmpty(unit.type),
+        decision: nullIfEmpty(unit.decision),
+        language: nullIfEmpty(unit.language),
+        value: unit.value,
+      },
+    ]),
+  );
+
+  return {
+    agent: nullIfEmpty(row.agent),
+    sessionId: nullIfEmpty(row.sessionId),
+    agentVersion: nullIfEmpty(row.agentVersion),
+    terminalType: nullIfEmpty(row.terminalType),
+    entrypoint: nullIfEmpty(row.entrypoint),
+    finalRequestId: nullIfEmpty(row.finalRequestId),
+    userId: nullIfEmpty(row.userId),
+
+    modelCalls: row.modelCalls,
+    toolCalls: row.toolCalls,
+    subAgents: row.subAgents,
+    subAgentIds: row.subAgentIds,
+    steps: row.steps.map((step, index) => ({
+      name: step[0],
+      count: step[1],
+      failed: step[2],
+      startedAtMs: row.stepStartedAt[index] ?? 0,
+    })),
+    prompts: row.prompts,
+    promptChars: row.promptChars,
+    responseChars: row.responseChars,
+
+    toolCounts: row.toolCounts,
+    toolDurationMs: row.toolDurationMs,
+    filesTouched: row.filesTouched,
+    skills: row.skills,
+    subAgentTypes: row.subAgentTypes,
+    slashCommands: row.slashCommands,
+    models: row.models,
+    mcpServers: row.mcpServers,
+    mcpTools: row.mcpTools,
+
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    cacheReadTokens: row.cacheReadTokens,
+    cacheCreationTokens: row.cacheCreationTokens,
+    costUsd: row.costUsd,
+
+    modelCallMs: row.modelCallMs,
+    toolMs: row.toolMs,
+    ttftMsTotal: row.ttftMsTotal,
+    ttftSamples: row.ttftSamples,
+    blockedOnUserMs: row.blockedOnUserMs,
+    activeTimeUserSec: row.activeTimeUserSec,
+    activeTimeCliSec: row.activeTimeCliSec,
+
+    toolResultBytes: row.toolResultBytes,
+    toolInputBytes: row.toolInputBytes,
+    compactions: row.compactions,
+    compactionTokensBefore: row.compactionTokensBefore,
+    compactionTokensAfter: row.compactionTokensAfter,
+    peakContextTokens: row.peakContextTokens,
+    cacheRebuildCount: row.cacheRebuildCount,
+    largestCacheRebuildTokens: row.largestCacheRebuildTokens,
+    previousCallContextTokens: row.previousCallContextTokens,
+
+    failedTools: row.failedTools,
+    errorTypes: row.errorTypes,
+    apiErrors: row.apiErrors,
+    rateLimited: row.rateLimited,
+    retriesExhausted: row.retriesExhausted,
+    retryMs: row.retryMs,
+    attempts: row.attempts,
+    refusals: row.refusals,
+    refusalCategories: row.refusalCategories,
+    internalErrors: row.internalErrors,
+
+    toolsDenied: row.toolsDenied,
+    toolsAborted: row.toolsAborted,
+    permissionMode: nullIfEmpty(row.permissionMode),
+    permissionChanges: row.permissionChanges,
+    hooksBlocked: row.hooksBlocked,
+    hooksCancelled: row.hooksCancelled,
+    hookMs: row.hookMs,
+
+    metricSeries,
+    linesAdded: row.linesAdded,
+    linesRemoved: row.linesRemoved,
+    commits: row.commits,
+    pullRequests: row.pullRequests,
+    editsAccepted: row.editsAccepted,
+    editsRejected: row.editsRejected,
+    languagesEdited: row.languagesEdited,
+    atMentions: row.atMentions,
+
+    stopReason: nullIfEmpty(row.stopReason),
+    truncated: row.truncated,
+
+    sessionKeySource: row.sessionKeySource,
+    traceIds: row.traceIds,
+    startedAtMs: row.startedAtMs,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    LastEventOccurredAt: row.lastEventOccurredAt,
   };
 }

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection.ts
@@ -323,7 +323,7 @@ export interface CodingAgentSessionRow {
 
   // ── Read-back state (ADR-066, migration 00053) ─────────────────────────
   // Not analytics columns — these round-trip the fold's working state so
-  // store.get() can reconstruct it without replaying event_log.
+  // store.get() can read it back (decode the row) without replaying event_log.
   /** The dedup set behind `subAgents`; the row keeps count + types, plus this. */
   subAgentIds: string[];
   /** Per-step start times, index-aligned with `steps` (dropped by the 3-tuple). */
@@ -467,17 +467,20 @@ const nullIfEmpty = (value: string): string | null =>
   value === "" ? null : value;
 
 /**
- * Rebuild the fold's working state from its persisted row — the inverse of
- * {@link projectCodingAgentSessionToRow} (ADR-066). This is what makes
- * `store.get()` lossless, so a cache miss reads one row back into state instead
- * of replaying the aggregate's history from `event_log`.
+ * Decode the fold's working state from its persisted row — the `fromRow`
+ * inverse of {@link projectCodingAgentSessionToRow}'s `toRow` (ADR-066).
+ *
+ * This is a deserialize, NOT a rebuild. A rebuild replays the aggregate's
+ * history from `event_log`; this only maps the columns of the last committed
+ * projection back into the state shape, so `store.get()` can return the state
+ * that Redis (or, on a miss, ClickHouse) already holds. It derives nothing.
  *
  * The row mirrors the state field-for-field; the only conversions are the
  * nullable identity fields (stored as "" ) mapping back to null, `steps`
  * zipping with the parallel `stepStartedAt`, and `metricSeries` re-keying by
  * series id.
  */
-export function rebuildCodingAgentSessionStateFromRow(
+export function codingAgentSessionStateFromRow(
   row: CodingAgentSessionRow,
 ): CodingAgentSessionState {
   const metricSeries: Record<string, MetricSeriesFact> = Object.fromEntries(

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.store.ts
@@ -5,8 +5,8 @@ import type { ProjectionStoreContext } from "../../../projections/projectionStor
 import {
   CODING_AGENT_SESSION_PROJECTION_VERSION_LATEST,
   type CodingAgentSessionState,
+  codingAgentSessionStateFromRow,
   projectCodingAgentSessionToRow,
-  rebuildCodingAgentSessionStateFromRow,
 } from "./codingAgentSession.foldProjection";
 
 /**
@@ -74,11 +74,13 @@ export class CodingAgentSessionStore
   }
 
   /**
-   * Read the session's last committed state back (ADR-066). The row round-trips
-   * the full working state — counters, ordered steps (with their start times),
-   * the sub-agent dedup set, the previous-call context size, and the converged
-   * metric units — so a cache miss reconstructs state from ONE point read
-   * instead of replaying the aggregate's history from `event_log`.
+   * Read the session's last committed state back (ADR-066) — the CH-fallthrough
+   * side of the read path: `RedisCachedFoldStore` serves the warm cache and only
+   * calls this on a miss. The row round-trips the full working state — counters,
+   * ordered steps (with their start times), the sub-agent dedup set, the
+   * previous-call context size, and the converged metric units — so a miss reads
+   * ONE point row and decodes it. It never replays `event_log`; that is the
+   * offline rebuild path, not this one.
    *
    * `context.occurredAtMs` prunes the read to a window of partitions around the
    * event being folded; absent, the repository scans (still keyed, still
@@ -93,6 +95,6 @@ export class CodingAgentSessionStore
       sessionId: aggregateId,
       startedAtMs: context.occurredAtMs,
     });
-    return row ? rebuildCodingAgentSessionStateFromRow(row) : null;
+    return row ? codingAgentSessionStateFromRow(row) : null;
   }
 }

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.store.ts
@@ -6,6 +6,7 @@ import {
   CODING_AGENT_SESSION_PROJECTION_VERSION_LATEST,
   type CodingAgentSessionState,
   projectCodingAgentSessionToRow,
+  rebuildCodingAgentSessionStateFromRow,
 } from "./codingAgentSession.foldProjection";
 
 /**
@@ -73,18 +74,25 @@ export class CodingAgentSessionStore
   }
 
   /**
-   * No read-back: the row is an AGGREGATE, not a copy. The counters survive a
-   * round-trip but the fold's ordering rules and first-seen identity semantics
-   * do not, so rebuilding state from the row would quietly produce a different
-   * session than replaying the events does.
+   * Read the session's last committed state back (ADR-066). The row round-trips
+   * the full working state — counters, ordered steps (with their start times),
+   * the sub-agent dedup set, the previous-call context size, and the converged
+   * metric units — so a cache miss reconstructs state from ONE point read
+   * instead of replaying the aggregate's history from `event_log`.
    *
-   * State continuity therefore comes from the two layers above this store: the
-   * Redis cache it is wrapped in at registration, and the fold's
-   * `refoldOnStoreMiss` option, which rebuilds from the event log on a miss.
-   * Without BOTH, a delivery would fold only its own batch and a partial row
-   * would overwrite a complete one.
+   * `context.occurredAtMs` prunes the read to a window of partitions around the
+   * event being folded; absent, the repository scans (still keyed, still
+   * correct — just not partition-pruned).
    */
-  async get(): Promise<CodingAgentSessionState | null> {
-    return null;
+  async get(
+    aggregateId: string,
+    context: ProjectionStoreContext,
+  ): Promise<CodingAgentSessionState | null> {
+    const row = await this.repo.findBySessionId({
+      tenantId: String(context.tenantId),
+      sessionId: aggregateId,
+      startedAtMs: context.occurredAtMs,
+    });
+    return row ? rebuildCodingAgentSessionStateFromRow(row) : null;
   }
 }


### PR DESCRIPTION
First adopter of **ADR-066** (stacked on #6079) — the durable fix for the 2026-07-23 `event_log` `TOO_MANY_PARTS` outage.

## Problem
`codingAgentSession`'s store `get()` returned `null` by design (lossy analytics row), so every cache miss and every out-of-order delivery refolded the aggregate's **whole history from `event_log`** — 20–100 MB S3-walking reads that starved ClickHouse background merges into OOM, stalled `event_log` part merges, and tripped `TOO_MANY_PARTS` for every pipeline at once.

## Fix — the fold reads back its own last committed state
- **Migration 00053** adds five *typed* read-back columns so the row round-trips the full working state (no blob; every column stays queryable): `SubAgentIds`, `PreviousCallContextTokens`, `StepStartedAt` (the per-step start times the 3-tuple `Steps` column dropped — the real ordering gap), `MetricSeries`, `LastEventOccurredAt`.
- **`codingAgentSessionStateFromRow`** inverts `projectCodingAgentSessionToRow` — a decode, not a rebuild (no event_log replay). The store's `get()` now does one point read (partition-pruned by the event's `occurredAt`) and reads its state back — **never reads `event_log`**.
- **Drop `refoldOnStoreMiss`; set `refoldOnOutOfOrder: false`.** The derivation is order-insensitive (commuting accumulators, business-time step insertion, replace-not-increment metric overlay), so a late event folds in place.

Persisting the `metricSeries` map lets the pure `recomputeMetricOverlay` reproduce all **nine** metric-fed fields on read-back with **zero read-path change**. Per ADR-066 that map later leaves the fold for `session_metric_series` (step 2) — sequenced separately because it moves user-facing numbers and needs its own validation.

Supersedes the bespoke per-projection read-back of #6081.

## Tests
- `codingAgentSession.foldProjection.unit.test.ts`: new **losslessness** test — `codingAgentSessionStateFromRow(projectCodingAgentSessionToRow(state))` deep-equals a folded state, asserting the previously-lossy bookkeeping (`subAgentIds`, `previousCallContextTokens`, step `startedAtMs`, `metricSeries`) is populated and survives.
- `coding-agent-session.clickhouse.repository.integration.test.ts`: extended the round-trip to write+read the five new columns through real ClickHouse (proves the DDL↔repository contract). Could not run locally (no container runtime in the sandbox); confirmed green in CI across all 3 shards.
- 99 unit tests green across the touched areas (fold, store, repository, service, sessionView).

## Not in this PR (follow-ups per ADR-066)
- Step 2: subtract `metricSeries` + `recomputeMetricOverlay` + the nine columns from the fold; serve them from `session_metric_series` via the existing `withMetricTotals` overlay (extended to bucket by `decision`/`language`). Number-changing → own PR.
- Pillar 2: `recordTriggerMatch` append coalescing (count- **and** byte-bounded drain).
- Infra (separate repo): `async_insert_busy_timeout_ms` 200→1000; `max_bytes_to_merge_at_max_space_in_pool` sizing.

## Deployment Impact

- **ClickHouse migration 00053** — additive only: five new columns on `coding_agent_sessions` (`SubAgentIds`, `PreviousCallContextTokens`, `StepStartedAt`, `MetricSeries`, `LastEventOccurredAt`), all `ADD COLUMN IF NOT EXISTS` with defaults. No column drop, no type change, no rewrite; existing rows read back with empty/zero defaults until re-folded. Backward-compatible with the running writer.
- **Deploy order:** migration must land before the app rollout (the writer references the new columns). Standard forward-migrate-then-deploy; no backfill required — the fold repopulates on the next event per session.
- **Behavioural change:** the `codingAgentSession` fold stops refolding from `event_log` (drops `refoldOnStoreMiss`, sets `refoldOnOutOfOrder: false`) and reads its state back from the row. This removes the `event_log` read load that caused the 2026-07-23 outage.
- No chart, env, or self-hosting change. Related ADR: 066 (PR #6079). Supersedes #6081.
