### PR TITLE
fix(prompts): show who authored each prompt version

### DIFF
--- a/langwatch/src/prompts/VersionHistoryListPopover.tsx
+++ b/langwatch/src/prompts/VersionHistoryListPopover.tsx
@@ -13,7 +13,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { createLogger } from "@langwatch/observability";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { LuChevronRight } from "react-icons/lu";
 import { HistoryIcon } from "~/components/icons/History";
 import { Popover } from "~/components/ui/popover";
@@ -36,6 +36,8 @@ interface VersionHistoryItemData {
   commitMessage?: string;
   author?: {
     name: string | null;
+    email?: string | null;
+    image?: string | null;
   } | null;
 }
 
@@ -69,6 +71,75 @@ const VersionNumberBox = ({
     </Box>
   );
 };
+
+/**
+ * Author line for a version: an avatar (SSO/OAuth photo → initials → generic
+ * silhouette), the author's display name, and a tooltip revealing who it is.
+ *
+ * The name falls back to the author's email, then to "Unknown author", so the
+ * row is never a bare, unlabelled icon. Versions created through the SDK/API
+ * have no author on record; that is stated in the tooltip rather than left
+ * blank (which previously rendered as a nameless silhouette with no hover).
+ */
+function VersionAuthor({
+  author,
+}: {
+  author?: VersionHistoryItemData["author"];
+}) {
+  const [brokenImageUrl, setBrokenImageUrl] = useState<string | null>(null);
+
+  const name = author?.name?.trim() ? author.name.trim() : null;
+  const email = author?.email?.trim() ? author.email.trim() : null;
+  const image = author?.image ?? null;
+
+  const label = name ?? email ?? "Unknown author";
+  const isKnown = Boolean(name ?? email);
+  // OAuth/SSO image URLs can 404 or be CORS-blocked; fall back to initials
+  // instead of the browser's broken-image glyph (see PresenceAvatar).
+  const showImage = Boolean(image) && image !== brokenImageUrl;
+
+  const tooltipContent = !author ? (
+    "No author recorded for this version"
+  ) : (
+    <VStack gap={0} align="start">
+      <Text fontWeight={600}>{name ?? email ?? "Unknown author"}</Text>
+      {name && email && (
+        <Text fontSize="11px" opacity={0.8}>
+          {email}
+        </Text>
+      )}
+    </VStack>
+  );
+
+  return (
+    <Tooltip
+      content={tooltipContent}
+      positioning={{ placement: "top" }}
+      showArrow
+    >
+      <HStack fontSize="12px" gap={1.5} minWidth={0} cursor="default">
+        <Avatar.Root
+          size="2xs"
+          backgroundColor="orange.solid"
+          color="white"
+          width="16px"
+          height="16px"
+        >
+          {showImage && image && (
+            <Avatar.Image
+              src={image}
+              onError={() => setBrokenImageUrl(image)}
+            />
+          )}
+          <Avatar.Fallback name={name ?? ""} fontSize="6.4px" />
+        </Avatar.Root>
+        <Text lineClamp={1} color={isKnown ? "fg.muted" : "fg.subtle"}>
+          {label}
+        </Text>
+      </HStack>
+    </Tooltip>
+  );
+}
 
 /**
  * Individual version history item showing commit message, author and restore button
@@ -125,21 +196,7 @@ function VersionHistoryItem({
               </Button>
             )}
           </HStack>
-          <HStack fontSize="12px">
-            <Avatar.Root
-              size="2xs"
-              backgroundColor="orange.solid"
-              color="white"
-              width="16px"
-              height="16px"
-            >
-              <Avatar.Fallback
-                name={data.author?.name ?? ""}
-                fontSize="6.4px"
-              />
-            </Avatar.Root>
-            {data.author?.name}
-          </HStack>
+          <VersionAuthor author={data.author} />
         </VStack>
         {!isCurrent && (
           <Tooltip

--- a/langwatch/src/prompts/__tests__/VersionHistoryListPopover.test.tsx
+++ b/langwatch/src/prompts/__tests__/VersionHistoryListPopover.test.tsx
@@ -306,7 +306,7 @@ describe("VersionHistoryListPopover", () => {
     });
   });
 
-  describe("when displaying the author of a version", () => {
+  describe("author of a version", () => {
     const openPopover = async () => {
       const historyButton = screen.getAllByTestId("version-history-button")[0]!;
       fireEvent.click(historyButton);
@@ -331,29 +331,105 @@ describe("VersionHistoryListPopover", () => {
       renderWithChakra(<VersionHistoryListPopover configId="config-1" />);
     };
 
-    it("shows the author's name when present", async () => {
-      renderWithAuthor({
-        id: "u1",
-        name: "Ada Lovelace",
-        email: "ada@example.com",
+    // Chakra tooltips open on a pointer gesture; pointerMove bubbles to the
+    // trigger so zag registers the hover.
+    const hover = (element: HTMLElement) => {
+      fireEvent.pointerEnter(element, { pointerType: "mouse" });
+      fireEvent.pointerMove(element, { pointerType: "mouse" });
+    };
+
+    describe("given the author has a display name", () => {
+      describe("when displaying the version history", () => {
+        /** @scenario "Author with a display name is shown by name" */
+        it("shows the author's name", async () => {
+          renderWithAuthor({
+            id: "u1",
+            name: "Ada Lovelace",
+            email: "ada@example.com",
+          });
+          await openPopover();
+
+          expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+        });
+
+        it("reveals the author's name and email in a tooltip on hover", async () => {
+          renderWithAuthor({
+            id: "u1",
+            name: "Ada Lovelace",
+            email: "ada@example.com",
+          });
+          await openPopover();
+
+          hover(screen.getByText("Ada Lovelace"));
+
+          await waitFor(
+            () =>
+              expect(
+                screen.getAllByText("ada@example.com").length,
+              ).toBeGreaterThan(0),
+            { timeout: 3000 },
+          );
+        });
       });
-      await openPopover();
-
-      expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
     });
 
-    it("falls back to the email when the author has no name", async () => {
-      renderWithAuthor({ id: "u1", name: null, email: "grace@example.com" });
-      await openPopover();
+    describe("given the author has no display name", () => {
+      describe("when displaying the version history", () => {
+        /** @scenario "Author without a display name falls back to their email" */
+        it("shows the author's email instead", async () => {
+          renderWithAuthor({ id: "u1", name: null, email: "grace@example.com" });
+          await openPopover();
 
-      expect(screen.getByText("grace@example.com")).toBeInTheDocument();
+          expect(screen.getByText("grace@example.com")).toBeInTheDocument();
+        });
+      });
     });
 
-    it("labels the row 'Unknown author' when no author is recorded", async () => {
-      renderWithAuthor(null);
-      await openPopover();
+    describe("given the version has no author on record", () => {
+      describe("when displaying the version history", () => {
+        /** @scenario "Version created outside the app shows Unknown author" */
+        it("labels the row 'Unknown author'", async () => {
+          renderWithAuthor(null);
+          await openPopover();
 
-      expect(screen.getByText("Unknown author")).toBeInTheDocument();
+          expect(screen.getByText("Unknown author")).toBeInTheDocument();
+        });
+
+        it("explains in a tooltip that no author was recorded", async () => {
+          renderWithAuthor(null);
+          await openPopover();
+
+          hover(screen.getByText("Unknown author"));
+
+          await waitFor(
+            () =>
+              expect(
+                screen.getAllByText("No author recorded for this version")
+                  .length,
+              ).toBeGreaterThan(0),
+            { timeout: 3000 },
+          );
+        });
+      });
+    });
+
+    describe("given the author signed in with a profile photo", () => {
+      describe("when displaying the version history", () => {
+        /** @scenario "A signed-in author's profile photo is used as the avatar" */
+        it("shows the photo as the avatar", async () => {
+          renderWithAuthor({
+            id: "u1",
+            name: "Ada Lovelace",
+            email: "ada@example.com",
+            image: "https://example.com/ada.png",
+          });
+          await openPopover();
+
+          expect(
+            document.querySelector('img[src="https://example.com/ada.png"]'),
+          ).not.toBeNull();
+        });
+      });
     });
   });
 });

--- a/langwatch/src/prompts/__tests__/VersionHistoryListPopover.test.tsx
+++ b/langwatch/src/prompts/__tests__/VersionHistoryListPopover.test.tsx
@@ -305,4 +305,55 @@ describe("VersionHistoryListPopover", () => {
       });
     });
   });
+
+  describe("when displaying the author of a version", () => {
+    const openPopover = async () => {
+      const historyButton = screen.getAllByTestId("version-history-button")[0]!;
+      fireEvent.click(historyButton);
+      await waitFor(() => {
+        expect(screen.getByText("Prompt Version History")).toBeInTheDocument();
+      });
+    };
+
+    const renderWithAuthor = (author: unknown) => {
+      mockUseQuery.mockReturnValue({
+        data: [
+          {
+            id: "config-1",
+            versionId: "version-1",
+            version: 1,
+            commitMessage: "Initial version",
+            author,
+          },
+        ] as unknown as VersionedPrompt[],
+        isLoading: false,
+      });
+      renderWithChakra(<VersionHistoryListPopover configId="config-1" />);
+    };
+
+    it("shows the author's name when present", async () => {
+      renderWithAuthor({
+        id: "u1",
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+      });
+      await openPopover();
+
+      expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    });
+
+    it("falls back to the email when the author has no name", async () => {
+      renderWithAuthor({ id: "u1", name: null, email: "grace@example.com" });
+      await openPopover();
+
+      expect(screen.getByText("grace@example.com")).toBeInTheDocument();
+    });
+
+    it("labels the row 'Unknown author' when no author is recorded", async () => {
+      renderWithAuthor(null);
+      await openPopover();
+
+      expect(screen.getByText("Unknown author")).toBeInTheDocument();
+    });
+  });
 });

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -95,7 +95,9 @@ export type VersionedPrompt = {
   authorId: string | null;
   author?: {
     id: string;
-    name: string;
+    name: string | null;
+    email: string | null;
+    image: string | null;
   } | null;
   inputs: LatestConfigVersionSchema["configData"]["inputs"];
   outputs: LatestConfigVersionSchema["configData"]["outputs"];
@@ -1311,7 +1313,9 @@ export class PromptService {
       author: config.latestVersion.author
         ? {
             id: config.latestVersion.author.id,
-            name: config.latestVersion.author.name,
+            name: config.latestVersion.author.name ?? null,
+            email: config.latestVersion.author.email ?? null,
+            image: config.latestVersion.author.image ?? null,
           }
         : null,
       updatedAt: config.updatedAt,

--- a/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
@@ -26,7 +26,12 @@ const configSchemaV1_0 = z.object({
   author: z
     .object({
       id: z.string(),
-      name: z.string(),
+      // name is nullable: many SSO/OAuth providers return a profile with no
+      // display name, and the User.name column is nullable. Requiring a string
+      // here made the version-history read path throw for name-less authors.
+      name: z.string().nullable(),
+      email: z.string().nullable().optional(),
+      image: z.string().nullable().optional(),
     })
     .nullable()
     .optional(),

--- a/langwatch/src/server/prompt-config/repositories/llm-config.repository.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config.repository.ts
@@ -44,7 +44,12 @@ export type CreateLlmConfigParams = Omit<
  */
 export interface LlmConfigWithLatestVersion extends LlmPromptConfig {
   latestVersion: LatestConfigVersionSchema & {
-    author?: { name: string } | null;
+    author?: {
+      id: string;
+      name: string | null;
+      email?: string | null;
+      image?: string | null;
+    } | null;
     runtimeParameters: Record<string, unknown>;
   };
   _count?: {

--- a/specs/prompts/prompt-version-history-author.feature
+++ b/specs/prompts/prompt-version-history-author.feature
@@ -1,0 +1,37 @@
+Feature: Prompt version history author clarity
+  As a LangWatch user reviewing a prompt's version history
+  I want each version to clearly show who authored it
+  So that I can tell my teammates' changes apart from automated ones
+
+  # Bound to src/prompts/__tests__/VersionHistoryListPopover.test.tsx
+  # ("when displaying the author of a version"). Previously every version
+  # rendered only a bare avatar with no name and no hover, so versions created
+  # via the SDK/API (no author on record) and users with no display name both
+  # showed as an anonymous silhouette.
+
+  Background:
+    Given I am logged into project "my-project"
+    And I open the version history for a prompt
+
+  @integration
+  Scenario: Author with a display name is shown by name
+    Given a version was authored by a user named "Ada Lovelace"
+    Then that version's author row shows "Ada Lovelace"
+    And hovering the row reveals a tooltip with the author's name and email
+
+  @integration
+  Scenario: Author without a display name falls back to their email
+    Given a version was authored by a user who has no display name
+    Then that version's author row shows the author's email
+    And hovering the row reveals a tooltip with the author's email
+
+  @integration
+  Scenario: Version created outside the app shows Unknown author
+    Given a version has no author on record
+    Then that version's author row shows "Unknown author"
+    And hovering the row explains that no author was recorded
+
+  @integration
+  Scenario: A signed-in author's profile photo is used as the avatar
+    Given a version was authored by a user with a profile photo
+    Then that version's avatar shows the photo instead of initials


### PR DESCRIPTION
## Problem

In the **Prompt Version History** popover, each version showed only a bare avatar — a generic orange silhouette with **no name and no tooltip on hover**, so there was no way to tell who authored a version. It hit two common cases:

- **Versions created via the SDK / API** have no author on record → anonymous silhouette.
- **Users with no display name** (e.g. email-only signups) → also blank, because the UI only ever rendered `author.name`.

> _"was wondering if we can make this person thingy a bit more clear — I have no clue who authored the prompt, and hovering over it gave me nothing."_

| Before | After |
|:---:|:---:|
| <img src="https://github.com/langwatch/langwatch/blob/assets/prompt-version-author-screenshots/prompt-version-author/before.png?raw=true" width="440"> | <img src="https://github.com/langwatch/langwatch/blob/assets/prompt-version-author-screenshots/prompt-version-author/after.png?raw=true" width="440"> |

Versions **1** and **2** are nameless silhouettes in _Before_; in _After_ they read **"Unknown author"** and the author's **email**.

## What changed

- **Clear author label** — display name → email → `Unknown author`, so the row is never a bare, unlabelled icon.
- **Hover tooltip** revealing the author's name + email (or, for SDK/API versions, that no author was recorded):

  <img src="https://github.com/langwatch/langwatch/blob/assets/prompt-version-author-screenshots/prompt-version-author/tooltip.png?raw=true" width="720">

- **SSO / OAuth profile photo** is used as the avatar when available, falling back to initials, then a silhouette (mirrors `PresenceAvatar`). Version 4 (Rogério) shows a real photo above.
- **API enrichment** — the versions endpoint now includes the author's `email` and `image`, and `author.name` is nullable in the version schema (a `null` name previously risked throwing on the read path).

The author row is extracted into a small `VersionAuthor` component.

## Testing

- `pnpm typecheck` ✅
- `pnpm test:unit run src/prompts/__tests__/VersionHistoryListPopover.test.tsx` — **11/11** ✅ (added: name shown, email fallback, "Unknown author")
- Verified end-to-end in the running app — the screenshots above are of the real popover (before captured by stashing the fix).
- Spec: `specs/prompts/prompt-version-history-author.feature`

## Notes

- The sibling **Optimization Studio** version history (`src/optimization_studio/components/History.tsx`) has the same gap (identical avatar code, plus a half-finished commented-out tooltip). Left out to keep this PR focused on the reported prompts popover — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved prompt version history author display with clearer name/email tooltips.
  * Added “Unknown author” messaging when no author is recorded.
  * Profile photo avatars now render when available, with initials fallback if the image can’t be loaded.

* **Bug Fixes**
  * Version history author rendering now tolerates missing/null author fields (including name/email/image) without errors, ensuring consistent UI output and validation behavior.

* **Tests**
  * Expanded automated coverage for author display and tooltip scenarios in the version history popover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->