### PR TITLE
fix(metrics): correct oldest-pending-age gauge + reset stale ClickHouse table gauges

### DIFF
--- a/langwatch/src/server/clickhouse/metrics.ts
+++ b/langwatch/src/server/clickhouse/metrics.ts
@@ -342,6 +342,16 @@ export async function collectStorageStats(
 
     const rows = await result.json<TableStats>();
 
+    // Reset before repopulating (mirrors the per-disk gauges below). Without
+    // this, a table that TTL-drops to zero active parts — or is simply absent
+    // from one tick's `system.parts` result — keeps its last non-zero value
+    // forever, so `clickhouse_table_bytes`/`_rows`/`_parts` report phantom size
+    // long after the data is gone (these feed the DB-size and trace_summaries
+    // alerts). Placed after the query resolves so a query error keeps the last
+    // known values rather than zeroing them.
+    clickhouseTableRows.reset();
+    clickhouseTableBytes.reset();
+    clickhouseTableParts.reset();
     for (const row of rows.data) {
       setClickHouseTableRows(row.table, parseInt(row.total_rows, 10));
       setClickHouseTableBytes(row.table, parseInt(row.total_bytes, 10));

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/metricsCollector.unit.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { register } from "prom-client";
+import type IORedis from "ioredis";
+import type { Cluster } from "ioredis";
+import { GroupQueueMetricsCollector } from "../metricsCollector";
+import { gqOldestPendingAgeMilliseconds } from "../metrics";
+import type { GroupStagingScripts } from "../scripts";
+
+const QUEUE = "test-queue";
+const PREFIX = "gq:test:";
+
+type ZRangeByScore = (...args: unknown[]) => Promise<string[]>;
+
+/** Minimal Redis stub exposing only the reads collect() performs. */
+function makeRedis(zrangebyscore: ZRangeByScore) {
+  return {
+    zcard: vi.fn(async () => 0),
+    scard: vi.fn(async () => 0),
+    smembers: vi.fn(async () => [] as string[]),
+    zrangebyscore: vi.fn(zrangebyscore),
+  } as unknown as (IORedis | Cluster) & {
+    zrangebyscore: ReturnType<typeof vi.fn>;
+  };
+}
+
+function runCollect(redis: IORedis | Cluster) {
+  const collector = new GroupQueueMetricsCollector({
+    scripts: { getKeyPrefix: () => PREFIX } as unknown as GroupStagingScripts,
+    processingQueue: { length: () => 0 } as never,
+    redisConnection: redis,
+    queueName: QUEUE,
+    activeJobCountFn: () => 0,
+    metricsIntervalMs: 60_000,
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    } as never,
+  });
+  // collect() is private; drive one cycle directly.
+  return (collector as unknown as { collect: () => Promise<void> }).collect();
+}
+
+async function readGauge(): Promise<number | undefined> {
+  const m = await gqOldestPendingAgeMilliseconds.get();
+  return m.values.find((v) => v.labels.queue_name === QUEUE)?.value;
+}
+
+describe("GroupQueueMetricsCollector — oldest pending age", () => {
+  beforeEach(() => {
+    register.resetMetrics();
+  });
+
+  it("reports the age of the oldest eligible-waiting group", async () => {
+    // Stub returns a group whose ready score is (query max) - 5000, so the
+    // computed age is exactly 5000ms regardless of wall-clock timing.
+    const redis = makeRedis(async (...args) => {
+      const max = Number(args[2]);
+      return ["group-abc", String(max - 5000)];
+    });
+
+    await runCollect(redis);
+
+    expect(await readGauge()).toBe(5000);
+
+    // The query must exclude the unblock sentinel (score 1) via an exclusive
+    // lower bound, cap at "now", and read only the single oldest member.
+    const args = redis.zrangebyscore.mock.calls.at(-1)!;
+    expect(args[0]).toBe(`${PREFIX}ready`);
+    expect(args[1]).toBe("(1");
+    expect(typeof args[2]).toBe("number");
+    expect(Number(args[2])).toBeGreaterThan(Date.now() - 5_000);
+    expect(args).toContain("WITHSCORES");
+    expect(args.slice(-3)).toEqual(["LIMIT", 0, 1]);
+  });
+
+  it("reports 0 when no group is eligible (empty / all in-flight / just unblocked)", async () => {
+    const redis = makeRedis(async () => []);
+    await runCollect(redis);
+    expect(await readGauge()).toBe(0);
+  });
+
+  it("never emits a negative age (clock skew / future score)", async () => {
+    const redis = makeRedis(async (...args) => {
+      const max = Number(args[2]);
+      return ["group-future", String(max + 1000)];
+    });
+    await runCollect(redis);
+    const age = await readGauge();
+    expect(age).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
@@ -14,6 +14,14 @@ import {
 import type { DispatchResult, GroupStagingScripts } from "./scripts";
 
 /**
+ * Ready-score written by UNBLOCK_LUA (app-layer/ops/repositories/
+ * queue.redis.repository.ts) to force a just-unblocked group to dispatch
+ * promptly. It is a sentinel (epoch 1ms), not a real eligibility time, so the
+ * oldest-pending-age gauge excludes it — see the computation in collect().
+ */
+const READY_UNBLOCK_SENTINEL_SCORE = 1;
+
+/**
  * Periodically collects metrics from the group queue processing and staging layers.
  */
 export class GroupQueueMetricsCollector {
@@ -96,32 +104,52 @@ export class GroupQueueMetricsCollector {
         this.params.activeJobCountFn(),
       );
 
-      // Oldest pending age: readyKey scores are dispatch-eligibility times but
-      // are re-scored to a FUTURE activeUntil while a group processes, so the
-      // per-group jobs zsets carry the trustworthy dispatchAfterMs timestamps.
-      // Sample up to 10 groups to avoid scanning all groups every collection.
-      const sampleGroups = await this.params.redisConnection.zrange(
-        readyKey,
-        0,
-        9,
-      );
-      let minDispatchAfterMs = Infinity;
-      for (const groupId of sampleGroups) {
-        const groupJobsKey = `${keyPrefix}group:${groupId}:jobs`;
-        const oldest = await this.params.redisConnection.zrange(
-          groupJobsKey,
-          0,
-          0,
+      // Oldest eligible-waiting age. A group's readyKey score is its
+      // dispatch-eligibility time, and every not-yet-dispatchable state is
+      // future-scored:
+      //   - genuinely eligible & waiting     → score <= now   (counted)
+      //   - in-flight (re-scored to activeUntil), backoff-pending retry,
+      //     and not-yet-due delayed stage    → score > now    (excluded)
+      // So the oldest eligible-waiting group is simply the smallest score in
+      // (sentinel, now]. STAGE writes the score with ZADD LT (keep-if-smaller)
+      // and COMPLETE rewrites it to the next remaining job, so the readyKey
+      // score already tracks the group's oldest still-pending job.
+      //
+      // This replaces the previous "min dispatchAfterMs over the first 10 ready
+      // groups" scan, which had two independent defects:
+      //   1. Sampling bias — zrange(readyKey, 0, 9) returns the 10 MOST
+      //      dispatch-eligible groups, not the oldest, so a real backlog sitting
+      //      past index 10 was never inspected and the gauge under-reported.
+      //   2. Wrong clock origin — it read the per-group jobs zset, whose scores
+      //      are PRESERVED across a block/park, so a just-unblocked group
+      //      reported its entire blocked duration as backlog age (0 -> hours in
+      //      one tick).
+      //
+      // Exclude the unblock sentinel: UNBLOCK_LUA (app-layer/ops/repositories/
+      // queue.redis.repository.ts) re-adds a group to ready with the constant
+      // score 1 (epoch 1ms) to force prompt dispatch — not a real eligibility
+      // time, so a just-unblocked group must not read as ~56 years. The
+      // exclusive `(1` lower bound drops it; any real timestamp is far larger.
+      //
+      // Known residual: unpark restores a group's preserved (pre-park) ready
+      // score, so a long-parked group briefly over-reports on unpark until it is
+      // dispatched (one scan cycle). Closing that needs an unpark re-score
+      // decision (queue-fairness change), tracked separately.
+      const nowMs = Date.now();
+      const oldestEligible =
+        await this.params.redisConnection.zrangebyscore(
+          readyKey,
+          `(${READY_UNBLOCK_SENTINEL_SCORE}`,
+          nowMs,
           "WITHSCORES",
+          "LIMIT",
+          0,
+          1,
         );
-        if (oldest.length >= 2) {
-          const score = Number(oldest[1]);
-          if (score > 0 && score < minDispatchAfterMs) {
-            minDispatchAfterMs = score;
-          }
-        }
-      }
-      const age = minDispatchAfterMs === Infinity ? 0 : Math.max(0, Date.now() - minDispatchAfterMs);
+      const age =
+        oldestEligible.length >= 2
+          ? Math.max(0, nowMs - Number(oldestEligible[1]))
+          : 0;
       gqOldestPendingAgeMilliseconds.set(
         { queue_name: this.params.queueName },
         age,


### PR DESCRIPTION
## Why

Triaging a noisy alert episode, we found `gq_oldest_pending_age_milliseconds` (the metric behind the **Events Backed Up** alert) reporting a group's entire *held* duration as *backlog age* — a **4141s spike two minutes after the alert had resolved**, which is physically impossible for a genuine backlog. Investigation surfaced two independent defects in the gauge plus an unrelated stale-gauge bug in the ClickHouse table metrics.

## The oldest-pending-age gauge — two defects

`metricsCollector.ts` computed `age = now - min(dispatchAfterMs)` over `zrange(readyKey, 0, 9)`:

1. **Wrong clock origin.** It read the per-group `group:{id}:jobs` zset, whose `dispatchAfterMs` scores are **preserved across a block/park** (`restageAndBlock` re-stages with the original score). So the instant a blocked/parked group re-enters `ready`, the gauge reports the whole held duration as backlog age (0 → hours in one tick).
2. **Sampling bias.** `zrange(readyKey, 0, 9)` returns the 10 *most dispatch-eligible* groups (lowest ready score), **not** the oldest. A genuine backlog sitting past index 10 is never inspected, so the gauge can also **under-report and fail to page**.

### Fix (metric-layer only — no queue-behaviour change)

Read the `readyKey` score directly over `(1, now]`:
- Every not-yet-dispatchable state is future-scored — in-flight (`activeUntil`), backoff retry, delayed stage — so `score <= now` cleanly selects the eligible-waiting set.
- The unblock sentinel (`UNBLOCK_LUA` writes score `1`) is dropped by the exclusive lower bound, so a just-unblocked group correctly reads ~0.
- One `ZRANGEBYSCORE readyKey (1 <now> WITHSCORES LIMIT 0 1` replaces the first-10 scan + per-group fan-out (cheaper, too).

**Known residual (documented in-code):** unpark restores a group's *preserved* ready score, so a long-parked group briefly over-reports on unpark until it's dispatched (one scan cycle). Closing that needs an unpark re-score — a queue-fairness decision — so it's deliberately out of scope here.

Adds a unit test for the computation (it was previously **untested**): correct age, sentinel-excluding query shape, 0-on-empty, no negatives.

## ClickHouse table gauges never reset

`clickhouse_table_rows` / `_bytes` / `_parts` were written but never `.reset()` (the per-disk gauges are). A table that TTL-drops to zero active parts kept its last non-zero value **forever**, feeding phantom size into the DB-size and `trace_summaries` alerts. Now reset before each repopulation, after the query resolves (so a query error keeps last-known values).

## Validation
- `tsgo` typecheck: changed files clean (pre-existing unrelated errors only).
- Unit tests: 3 new (oldest-pending) + 53 existing metric tests pass.
- (Local biome is config-broken on `main` independent of this change.)

## Not included (bigger than a collector fix)
The `/ops` dashboard collector also has fake-zero per-phase throughput/latency and an ingest-rate that spikes on un-park. Fixing those *correctly* needs new write-path instrumentation (per-phase latency samples; a staged counter) — scoped as a follow-up rather than risk the hot path here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage metrics now reset correctly when tables have no active data, preventing stale row, byte, and part counts.
  * Queue monitoring now reports the oldest pending item age more accurately and never shows negative values.
  * Pending-age metrics return zero when no eligible items are waiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->