### PR TITLE
fix(traces): wire the canonical log repository into the app-layer log read

### DIFF
--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -417,14 +417,14 @@ export function initializeDefaultApp(options?: {
     "SpanStorageService",
   );
   const logRecordStorage = traced(
-    new LogRecordStorageService(
-      clickhouseEnabled
+    new LogRecordStorageService({
+      repository: clickhouseEnabled
         ? new LogRecordStorageClickHouseRepository(resolveClickHouseClient)
         : new NullLogRecordStorageRepository(),
-      clickhouseEnabled
+      canonical: clickhouseEnabled
         ? new CanonicalLogRecordClickHouseRepository(resolveClickHouseClient)
         : new NullCanonicalLogRecordRepository(),
-    ),
+    }),
     "LogRecordStorageService",
   );
   const experiments = traced(
@@ -1388,10 +1388,10 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
           "SpanStorageService",
         ),
         logRecords: traced(
-          new LogRecordStorageService(
-            new NullLogRecordStorageRepository(),
-            new NullCanonicalLogRecordRepository(),
-          ),
+          new LogRecordStorageService({
+            repository: new NullLogRecordStorageRepository(),
+            canonical: new NullCanonicalLogRecordRepository(),
+          }),
           "LogRecordStorageService",
         ),
         collection: traced(

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -1,29 +1,50 @@
 import type { ClickHouseClient } from "@clickhouse/client";
-import type { LangyConversationProcessingEvent } from "~/server/event-sourcing/pipelines/langy-conversation-processing/schemas/events";
+import { createNoopEnterprisePipelineCommands } from "@ee/event-sourcing/pipelineSet";
 import { GovernanceKpisClickHouseRepository } from "@ee/governance/services/governanceKpis.clickhouse.repository";
 import { GovernanceOcsfEventsClickHouseRepository } from "@ee/governance/services/governanceOcsfEvents.clickhouse.repository";
 import { createLogger } from "@langwatch/observability";
 import type { PrismaClient } from "@prisma/client";
 import { env } from "~/env.mjs";
+import { sendRenderedSlackMessage } from "~/server/app-layer/automations/delivery/sendSlackWebhook";
+import { postSlackChatMessage } from "~/server/app-layer/automations/delivery/slackWebApi";
+import { liveTriggerNotifier } from "~/server/app-layer/automations/delivery/triggerNotifier";
+import { LangyCredentialService } from "~/server/app-layer/langy/LangyCredentialService";
+import { LangyFeedbackPromptService } from "~/server/app-layer/langy/langy-feedback-prompt.service";
+import {
+  mintLangySessionApiKey,
+  revokeLangySessionApiKey,
+} from "~/server/app-layer/langy/langyApiKey";
+import { createLangyWorkerPort } from "~/server/app-layer/langy/langyWorker";
+import { createLangyTokenBuffer } from "~/server/app-layer/langy/streaming/langyTokenBuffer";
+import { createLangyTurnAccessStore } from "~/server/app-layer/langy/streaming/langyTurnAccess";
+import { createLangyTurnHandoffStore } from "~/server/app-layer/langy/streaming/langyTurnHandoff";
 import {
   type ClickHouseClientResolver,
   clearCustomClientCache,
-  getClickHouseClientForProject,
   getClickHouseClientForOrganization,
+  getClickHouseClientForProject,
   getSharedClickHouseClient,
   isClickHouseEnabled,
 } from "~/server/clickhouse/clickhouseClient";
 import { closeClickHouseClient } from "~/server/clickhouse/client";
 import { prisma as globalPrisma } from "~/server/db";
+import type { LangyConversationProcessingEvent } from "~/server/event-sourcing/pipelines/langy-conversation-processing/schemas/events";
 import { getFeatureFlagStore } from "~/server/featureFlag/featureFlagStore.postgres";
 import { GatewayBudgetClickHouseRepository } from "~/server/gateway/budget.clickhouse.repository";
 import { GatewayBudgetRepository } from "~/server/gateway/budget.repository";
+import { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
 import { getEdgeSpoolFailOpenCounter } from "~/server/metrics";
+import {
+  LANGY_GITHUB_PRS_PER_DAY,
+  releaseLangyGithubPrPermit,
+  reserveLangyGithubPrPermit,
+} from "~/server/middleware/rate-limit-langy-github-prs";
+import { LANGY_CHAT_FEATURE_KEY } from "~/server/modelProviders/codexRestrictions";
+import { getVercelAIModel } from "~/server/modelProviders/utils";
 import { getPostHogInstance } from "~/server/posthog";
 import { PromptTagRepository } from "~/server/prompt-config/repositories/prompt-tag.repository";
 import { createS3Client } from "~/server/storage";
 import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
-import { liveTriggerNotifier } from "~/server/app-layer/automations/delivery/triggerNotifier";
 import { getSaaSPlanProvider } from "../../../ee/billing";
 import { NotificationService } from "../../../ee/billing/notifications/notification.service";
 import { NotificationRepository } from "../../../ee/billing/notifications/repositories/notification.repository";
@@ -48,87 +69,19 @@ import { DataRetentionPolicyRepository } from "../data-retention/policy/dataRete
 import { DataRetentionPolicyService } from "../data-retention/policy/dataRetentionPolicy.service";
 import { RetentionPolicyCache } from "../data-retention/retentionPolicyCache";
 import { RetroactiveUpdateService } from "../data-retention/retroactive/retroactiveUpdate.service";
-import {
-  NullScheduledJobRepository,
-  PrismaScheduledJobRepository,
-} from "./scheduler/scheduled-job.repository";
-import { schedulerRegistry } from "./scheduler/scheduler.registry";
-import { SchedulerService } from "./scheduler/scheduler.service";
-import { getAnalyticsService } from "./analytics";
-import { loadReportCharts } from "./reports/report-chart.service";
-import { dispatchScheduledReport } from "./reports/report-dispatch";
-import { toReportTraceRow } from "./reports/trace-report-row";
-import { translateFilterToClickHouse } from "./traces/filter-to-clickhouse";
-import { REPORT_SCHEDULER_TARGET_TYPE } from "./automations/report.builder";
-import { sendRenderedTriggerEmail } from "~/server/mailer/triggerEmail";
-import { sendRenderedSlackMessage } from "~/server/app-layer/automations/delivery/sendSlackWebhook";
-import { postSlackChatMessage } from "~/server/app-layer/automations/delivery/slackWebApi";
 import { EventSourcing } from "../event-sourcing";
 import type { PipelineRepositories } from "../event-sourcing/pipelineRegistry";
 import {
   type AppCommands,
   PipelineRegistry,
 } from "../event-sourcing/pipelineRegistry";
+import { buildAutomationDispatchPorts } from "../event-sourcing/pipelines/automations/automationDispatch.wiring";
 import { createExperimentRunItemAppendStore } from "../event-sourcing/pipelines/experiment-run-processing/projections/experimentRunResultStorage.store";
 import {
   ExperimentRunStateRepositoryClickHouse,
   ExperimentRunStateRepositoryMemory,
 } from "../event-sourcing/pipelines/experiment-run-processing/repositories";
-import { LangyConversationService } from "./langy/langy-conversation.service";
-import { LangyTurnService } from "./langy/langy-turn.service";
-import { LangyCredentialService } from "~/server/app-layer/langy/LangyCredentialService";
-import { createLangyWorkerPort } from "~/server/app-layer/langy/langyWorker";
-import { LANGY_CHAT_FEATURE_KEY } from "~/server/modelProviders/codexRestrictions";
-import { getVercelAIModel } from "~/server/modelProviders/utils";
-import {
-  mintLangySessionApiKey,
-  revokeLangySessionApiKey,
-} from "~/server/app-layer/langy/langyApiKey";
-import {
-  LANGY_GITHUB_PRS_PER_DAY,
-  releaseLangyGithubPrPermit,
-  reserveLangyGithubPrPermit,
-} from "~/server/middleware/rate-limit-langy-github-prs";
-import { createLangyTurnAccessStore } from "~/server/app-layer/langy/streaming/langyTurnAccess";
-import { createLangyTurnHandoffStore } from "~/server/app-layer/langy/streaming/langyTurnHandoff";
-import { createLangyTokenBuffer } from "~/server/app-layer/langy/streaming/langyTokenBuffer";
-import { LangyFeedbackPromptService } from "~/server/app-layer/langy/langy-feedback-prompt.service";
-import { LangyGithubInstallationsService } from "./langy/langy-github-installations.service";
-import {
-  LangyGithubAppTokenService,
-  type RedisLike,
-} from "./langy/langyGithubAppToken";
-import {
-  createLangyTrustedMessageReader,
-  LangyMessageService,
-} from "./langy/langy-message.service";
-import { PrismaLangyMessageRepository } from "./langy/repositories/langy-message.prisma.repository";
-import { NullLangyMessageRepository } from "./langy/repositories/langy-message.repository";
-import { NullLangyGithubInstallationsRepository } from "./langy/repositories/langy-github-installations.repository";
-import { PrismaLangyGithubInstallationsRepository } from "./langy/repositories/langy-github-installations.prisma.repository";
-import { createLangyConversationTitleGenerator } from "./langy/langy-title-generation.service";
-import { PrismaLangyConversationProjectionRepository } from "./langy/repositories/langy-conversation-projection.prisma.repository";
-import { PrismaLangyConversationTurnProjectionRepository } from "./langy/repositories/langy-conversation-turn-projection.prisma.repository";
-import { PrismaLangyMessageProjectionRepository } from "./langy/repositories/langy-message-projection.prisma.repository";
-import { PrismaLangyConversationRepository } from "./langy/repositories/langy-conversation.prisma.repository";
-import { NullLangyConversationRepository } from "./langy/repositories/langy-conversation.repository";
-import { PrismaLangyTurnAdmissionRepository } from "./langy/repositories/langy-turn-admission.prisma.repository";
-import { NullLangyTurnAdmissionRepository } from "./langy/repositories/langy-turn-admission.repository";
-import { ClickHouseLangyAnalyticsEventRepository } from "./langy/repositories/langy-analytics-event.clickhouse.repository";
-import { NullLangyAnalyticsEventRepository } from "./langy/repositories/langy-analytics-event.repository";
 import { LangyAnalyticsEventAppendStore } from "../event-sourcing/pipelines/langy-conversation-processing/projections/langyAnalyticsEvent.store";
-import {
-  InMemoryProcessStore,
-  PrismaProcessStore,
-} from "../event-sourcing/process-manager";
-import { PrismaTopicClusteringRunHistoryProjectionRepository } from "./topic-clustering/repositories/topic-clustering-run-history-projection.prisma.repository";
-import { PrismaTopicClusteringRunProjectionRepository } from "./topic-clustering/repositories/topic-clustering-run-projection.prisma.repository";
-import { PrismaTopicModelProjectionRepository } from "./topic-clustering/repositories/topic-model-projection.prisma.repository";
-import { startTopicClusteringBootSeeds } from "./topic-clustering/bootSeeds";
-import { PrismaTopicClusteringStatusRepository } from "./topic-clustering/repositories/topic-clustering-status.repository";
-import { TopicClusteringStatusService } from "./topic-clustering/topic-clustering-status.service";
-import { clusterTopicsForProject } from "./topic-clustering/clustering";
-import { createNoopEnterprisePipelineCommands } from "@ee/event-sourcing/pipelineSet";
 import type { ScenarioExecutionReactorHandle } from "../event-sourcing/pipelines/simulation-processing/reactors/scenarioExecution.reactor";
 import {
   SimulationRunStateRepositoryClickHouse,
@@ -138,6 +91,10 @@ import {
   SuiteRunStateRepositoryClickHouse,
   SuiteRunStateRepositoryMemory,
 } from "../event-sourcing/pipelines/suite-run-processing/repositories";
+import {
+  InMemoryProcessStore,
+  PrismaProcessStore,
+} from "../event-sourcing/process-manager";
 import { ExperimentService } from "../experiments/experiment.service";
 import { InviteService } from "../invites/invite.service";
 import { OrganizationRepository } from "../repositories/organization.repository";
@@ -146,7 +103,22 @@ import { EventUsageService } from "../traces/event-usage.service";
 import { TraceService } from "../traces/trace.service";
 import { TraceUsageService } from "../traces/trace-usage.service";
 import { runEvaluationWorkflow } from "../workflows/runWorkflow";
+import { getAnalyticsService } from "./analytics";
 import { App, getApp, globalForApp, initializeApp } from "./app";
+import { EmailSuppressionService } from "./automations/emailSuppression.service";
+import { REPORT_SCHEDULER_TARGET_TYPE } from "./automations/report.builder";
+import {
+  PrismaEmailSuppressionNameLookupRepository,
+  PrismaEmailSuppressionRepository,
+} from "./automations/repositories/emailSuppression.prisma.repository";
+import {
+  NullEmailSuppressionNameLookupRepository,
+  NullEmailSuppressionRepository,
+} from "./automations/repositories/emailSuppression.repository";
+import { PrismaTriggerRepository } from "./automations/repositories/trigger.prisma.repository";
+import { NullTriggerRepository } from "./automations/repositories/trigger.repository";
+import { TriggerService } from "./automations/trigger.service";
+import { testFireTrigger } from "./automations/trigger-template.service";
 import { PrismaBillingCheckpointService } from "./billing/billingCheckpoint.service";
 import { BroadcastService } from "./broadcast/broadcast.service";
 import { createClickHouseClientFromConfig } from "./clients/clickhouse.factory";
@@ -155,6 +127,17 @@ import { LangEvalsHttpClient } from "./clients/langevals/langevals.http.client";
 import { createRedisConnectionFromConfig } from "./clients/redis.factory";
 import { TiktokenClient } from "./clients/tokenizer/tiktoken.client";
 import { NullTokenizerClient } from "./clients/tokenizer/tokenizer.client";
+import { CodingAgentSessionService } from "./coding-agent/coding-agent-session.service";
+import { CodingAgentSessionClickHouseRepository } from "./coding-agent/repositories/coding-agent-session.clickhouse.repository";
+import { NullCodingAgentSessionRepository } from "./coding-agent/repositories/coding-agent-session.repository";
+import {
+  CodingAgentTraceSessionClickHouseRepository,
+  NullCodingAgentTraceSessionRepository,
+} from "./coding-agent/repositories/coding-agent-trace-session.repository";
+import {
+  NullSessionMetricSeriesRepository,
+  SessionMetricSeriesClickHouseRepository,
+} from "./coding-agent/repositories/session-metric-series.repository";
 import {
   type AppConfig,
   createAppConfigFromEnv,
@@ -178,36 +161,52 @@ import { EvaluationAnalyticsRollupClickHouseRepository } from "./evaluations/rep
 import { NullEvaluationAnalyticsRollupRepository } from "./evaluations/repositories/evaluation-analytics-rollup.repository";
 import { EvaluationRunClickHouseRepository } from "./evaluations/repositories/evaluation-run.clickhouse.repository";
 import { NullEvaluationRunRepository } from "./evaluations/repositories/evaluation-run.repository";
-import { CodingAgentSessionService } from "./coding-agent/coding-agent-session.service";
-import { CodingAgentSessionClickHouseRepository } from "./coding-agent/repositories/coding-agent-session.clickhouse.repository";
-import { NullCodingAgentSessionRepository } from "./coding-agent/repositories/coding-agent-session.repository";
+import { LangyConversationService } from "./langy/langy-conversation.service";
+import { LangyGithubInstallationsService } from "./langy/langy-github-installations.service";
 import {
-  CodingAgentTraceSessionClickHouseRepository,
-  NullCodingAgentTraceSessionRepository,
-} from "./coding-agent/repositories/coding-agent-trace-session.repository";
+  createLangyTrustedMessageReader,
+  LangyMessageService,
+} from "./langy/langy-message.service";
+import { createLangyConversationTitleGenerator } from "./langy/langy-title-generation.service";
+import { LangyTurnService } from "./langy/langy-turn.service";
 import {
-  NullSessionMetricSeriesRepository,
-  SessionMetricSeriesClickHouseRepository,
-} from "./coding-agent/repositories/session-metric-series.repository";
+  LangyGithubAppTokenService,
+  type RedisLike,
+} from "./langy/langyGithubAppToken";
+import { ClickHouseLangyAnalyticsEventRepository } from "./langy/repositories/langy-analytics-event.clickhouse.repository";
+import { NullLangyAnalyticsEventRepository } from "./langy/repositories/langy-analytics-event.repository";
+import { PrismaLangyConversationRepository } from "./langy/repositories/langy-conversation.prisma.repository";
+import { NullLangyConversationRepository } from "./langy/repositories/langy-conversation.repository";
+import { PrismaLangyConversationProjectionRepository } from "./langy/repositories/langy-conversation-projection.prisma.repository";
+import { PrismaLangyConversationTurnProjectionRepository } from "./langy/repositories/langy-conversation-turn-projection.prisma.repository";
+import { PrismaLangyGithubInstallationsRepository } from "./langy/repositories/langy-github-installations.prisma.repository";
+import { NullLangyGithubInstallationsRepository } from "./langy/repositories/langy-github-installations.repository";
+import { PrismaLangyMessageRepository } from "./langy/repositories/langy-message.prisma.repository";
+import { NullLangyMessageRepository } from "./langy/repositories/langy-message.repository";
+import { PrismaLangyMessageProjectionRepository } from "./langy/repositories/langy-message-projection.prisma.repository";
+import { PrismaLangyTurnAdmissionRepository } from "./langy/repositories/langy-turn-admission.prisma.repository";
+import { NullLangyTurnAdmissionRepository } from "./langy/repositories/langy-turn-admission.repository";
 import { CanonicalLogRecordClickHouseRepository } from "./logs/repositories/canonical-log-record.clickhouse.repository";
 import { NullCanonicalLogRecordRepository } from "./logs/repositories/canonical-log-record.repository";
+import { MetricDataPointClickHouseRepository } from "./metrics/repositories/metric-data-point.clickhouse.repository";
+import { NullMetricDataPointRepository } from "./metrics/repositories/metric-data-point.repository";
 import { MonitorService } from "./monitors/monitor.service";
 import { PrismaMonitorRepository } from "./monitors/repositories/monitor.prisma.repository";
+import { BlobStoreService } from "./ops/blob-store.service";
 import { EventExplorerService } from "./ops/event-explorer.service";
 import { ManagerExplorerService } from "./ops/manager-explorer.service";
 import { getOpsMetricsCollector } from "./ops/metrics-collector";
 import { QueueService } from "./ops/queue.service";
-import { SchedulerOpsService } from "./ops/scheduler-ops.service";
-import { BlobStoreService } from "./ops/blob-store.service";
+import { ReplayService } from "./ops/replay.service";
 import { BlobStoreRedisRepository } from "./ops/repositories/blob-store.redis.repository";
 import { NullBlobStoreRepository } from "./ops/repositories/blob-store.repository";
-import { ReplayService } from "./ops/replay.service";
 import { EventExplorerClickHouseRepository } from "./ops/repositories/event-explorer.clickhouse.repository";
 import { NullEventExplorerRepository } from "./ops/repositories/event-explorer.repository";
 import { QueueRedisRepository } from "./ops/repositories/queue.redis.repository";
 import { NullQueueRepository } from "./ops/repositories/queue.repository";
 import { ReplayRedisRepository } from "./ops/repositories/replay.redis.repository";
 import { NullReplayRepository } from "./ops/repositories/replay.repository";
+import { SchedulerOpsService } from "./ops/scheduler-ops.service";
 import { OrganizationService } from "./organizations/organization.service";
 import { PrismaOrganizationRepository } from "./organizations/repositories/organization.prisma.repository";
 import { NullOrganizationRepository } from "./organizations/repositories/organization.repository";
@@ -217,27 +216,42 @@ import { RedisPresenceRepository } from "./presence/repositories/presence.redis.
 import { ProjectService } from "./projects/project.service";
 import { PrismaProjectRepository } from "./projects/repositories/project.prisma.repository";
 import { NullProjectRepository } from "./projects/repositories/project.repository";
+import { loadReportCharts } from "./reports/report-chart.service";
+import { dispatchScheduledReport } from "./reports/report-dispatch";
+import { toReportTraceRow } from "./reports/trace-report-row";
+import {
+  NullScheduledJobRepository,
+  PrismaScheduledJobRepository,
+} from "./scheduler/scheduled-job.repository";
+import { schedulerRegistry } from "./scheduler/scheduler.registry";
+import { SchedulerService } from "./scheduler/scheduler.service";
 import { PrismaShareRepository } from "./share/repositories/share.prisma.repository";
+import { ShareService } from "./share/share.service";
 import { createShareViewDedupeService } from "./share/share-view-dedupe.service";
 import { createSharedTracePayloadCache } from "./share/shared-trace-cache.service";
-import { ShareService } from "./share/share.service";
 import { SimulationRunService } from "./simulations/simulation-run.service";
 import { createCompositePlanProvider } from "./subscription/composite-plan-provider";
 import { PlanProviderService } from "./subscription/plan-provider";
 import type { SubscriptionService } from "./subscription/subscription.service";
 import { SuiteRunService } from "./suites/suite-run.service";
+import { startTopicClusteringBootSeeds } from "./topic-clustering/bootSeeds";
+import { clusterTopicsForProject } from "./topic-clustering/clustering";
 import { NullTopicRepository } from "./topic-clustering/repositories/null-topic.repository";
 import { PrismaTopicRepository } from "./topic-clustering/repositories/topic.prisma.repository";
+import { PrismaTopicClusteringRunHistoryProjectionRepository } from "./topic-clustering/repositories/topic-clustering-run-history-projection.prisma.repository";
+import { PrismaTopicClusteringRunProjectionRepository } from "./topic-clustering/repositories/topic-clustering-run-projection.prisma.repository";
+import { PrismaTopicClusteringStatusRepository } from "./topic-clustering/repositories/topic-clustering-status.repository";
+import { PrismaTopicModelProjectionRepository } from "./topic-clustering/repositories/topic-model-projection.prisma.repository";
 import { TopicService } from "./topic-clustering/topic.service";
+import { TopicClusteringStatusService } from "./topic-clustering/topic-clustering-status.service";
 import { maybeExtractSpanMedia } from "./traces/edge-media-extraction";
 import { maybeSpool } from "./traces/edge-spool";
+import { translateFilterToClickHouse } from "./traces/filter-to-clickhouse";
 import { LogRecordStorageService } from "./traces/log-record-storage.service";
 import { LogRequestCollectionService } from "./traces/log-request-collection.service";
 import { MetricRequestCollectionService } from "./traces/metric-request-collection.service";
 import { LogRecordStorageClickHouseRepository } from "./traces/repositories/log-record-storage.clickhouse.repository";
 import { NullLogRecordStorageRepository } from "./traces/repositories/log-record-storage.repository";
-import { MetricDataPointClickHouseRepository } from "./metrics/repositories/metric-data-point.clickhouse.repository";
-import { NullMetricDataPointRepository } from "./metrics/repositories/metric-data-point.repository";
 import { SpanStorageClickHouseRepository } from "./traces/repositories/span-storage.clickhouse.repository";
 import { NullSpanStorageRepository } from "./traces/repositories/span-storage.repository";
 import { TraceAnalyticsClickHouseRepository } from "./traces/repositories/trace-analytics.clickhouse.repository";
@@ -258,20 +272,6 @@ import {
 import { TraceRequestCollectionService } from "./traces/trace-request-collection.service";
 import { TraceSummaryService } from "./traces/trace-summary.service";
 import { traced } from "./tracing";
-import { EmailSuppressionService } from "./automations/emailSuppression.service";
-import { buildAutomationDispatchPorts } from "../event-sourcing/pipelines/automations/automationDispatch.wiring";
-import {
-  PrismaEmailSuppressionNameLookupRepository,
-  PrismaEmailSuppressionRepository,
-} from "./automations/repositories/emailSuppression.prisma.repository";
-import {
-  NullEmailSuppressionNameLookupRepository,
-  NullEmailSuppressionRepository,
-} from "./automations/repositories/emailSuppression.repository";
-import { PrismaTriggerRepository } from "./automations/repositories/trigger.prisma.repository";
-import { NullTriggerRepository } from "./automations/repositories/trigger.repository";
-import { TriggerService } from "./automations/trigger.service";
-import { testFireTrigger } from "./automations/trigger-template.service";
 import { UsageService } from "./usage/usage.service";
 
 /**
@@ -421,6 +421,9 @@ export function initializeDefaultApp(options?: {
       clickhouseEnabled
         ? new LogRecordStorageClickHouseRepository(resolveClickHouseClient)
         : new NullLogRecordStorageRepository(),
+      clickhouseEnabled
+        ? new CanonicalLogRecordClickHouseRepository(resolveClickHouseClient)
+        : new NullCanonicalLogRecordRepository(),
     ),
     "LogRecordStorageService",
   );
@@ -1385,7 +1388,10 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
           "SpanStorageService",
         ),
         logRecords: traced(
-          new LogRecordStorageService(new NullLogRecordStorageRepository()),
+          new LogRecordStorageService(
+            new NullLogRecordStorageRepository(),
+            new NullCanonicalLogRecordRepository(),
+          ),
           "LogRecordStorageService",
         ),
         collection: traced(

--- a/langwatch/src/server/app-layer/traces/__tests__/log-record-storage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/log-record-storage.service.unit.test.ts
@@ -43,7 +43,7 @@ function makeService({
     getLogsByTraceId: canonicalGetLogsByTraceId,
   } as unknown as CanonicalLogRecordRepository;
   return {
-    service: new LogRecordStorageService(repository, canonical),
+    service: new LogRecordStorageService({ repository, canonical }),
     getLogsByTraceId,
     canonicalGetLogsByTraceId,
   };

--- a/langwatch/src/server/app-layer/traces/__tests__/log-record-storage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/log-record-storage.service.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { CanonicalLogRecordRepository } from "~/server/app-layer/logs/repositories/canonical-log-record.repository";
 import { LogRecordStorageService } from "../log-record-storage.service";
 import type {
   LogRecordStorageRepository,
@@ -20,13 +21,32 @@ const row: StoredLogRecordRow = {
   scopeVersion: null,
 };
 
-function makeService(getLogsByTraceId = vi.fn().mockResolvedValue([row])) {
+const canonicalRow: StoredLogRecordRow = {
+  ...row,
+  timeUnixMs: 1_700_000_000_500,
+  body: "user_prompt",
+  attributes: { "event.name": "user_prompt", prompt: "hi" },
+};
+
+function makeService({
+  legacyRows = [row],
+  canonicalRows = [] as StoredLogRecordRow[],
+} = {}) {
+  const getLogsByTraceId = vi.fn().mockResolvedValue(legacyRows);
   const repository = {
     insertLogRecord: vi.fn(),
     insertLogRecords: vi.fn(),
     getLogsByTraceId,
   } as unknown as LogRecordStorageRepository;
-  return { service: new LogRecordStorageService(repository), getLogsByTraceId };
+  const canonicalGetLogsByTraceId = vi.fn().mockResolvedValue(canonicalRows);
+  const canonical = {
+    getLogsByTraceId: canonicalGetLogsByTraceId,
+  } as unknown as CanonicalLogRecordRepository;
+  return {
+    service: new LogRecordStorageService(repository, canonical),
+    getLogsByTraceId,
+    canonicalGetLogsByTraceId,
+  };
 }
 
 describe("LogRecordStorageService.getLogsByTraceId", () => {
@@ -61,6 +81,42 @@ describe("LogRecordStorageService.getLogsByTraceId", () => {
         undefined,
         undefined,
       );
+    });
+
+    it("queries the canonical store with the same read and returns rows only it holds", async () => {
+      // The prod regression this pins: post-cutover traces exist ONLY in
+      // canonical `log_records`, so a read that skips canonical returns []
+      // and the drawer/transcript render contentless.
+      const { service, canonicalGetLogsByTraceId } = makeService({
+        legacyRows: [],
+        canonicalRows: [canonicalRow],
+      });
+
+      const result = await service.getLogsByTraceId(
+        "project_test",
+        "trace-1",
+        1_700_000_000_000,
+        250,
+      );
+
+      expect(canonicalGetLogsByTraceId).toHaveBeenCalledWith({
+        tenantId: "project_test",
+        traceId: "trace-1",
+        occurredAtMs: 1_700_000_000_000,
+        limit: 250,
+      });
+      expect(result).toEqual([canonicalRow]);
+    });
+
+    it("merges legacy and canonical rows in time order", async () => {
+      const { service } = makeService({
+        legacyRows: [row],
+        canonicalRows: [canonicalRow],
+      });
+
+      const result = await service.getLogsByTraceId("project_test", "trace-1");
+
+      expect(result).toEqual([row, canonicalRow]);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/log-record-storage.service.ts
+++ b/langwatch/src/server/app-layer/traces/log-record-storage.service.ts
@@ -28,16 +28,25 @@ import {
  * in time order — the same pattern the claude-marked read established.
  */
 export class LogRecordStorageService {
+  readonly repository: LogRecordStorageRepository;
+  private readonly canonical: CanonicalLogRecordRepository;
+
   /**
    * `canonical` is REQUIRED: canonical `log_records` is the only table still
    * receiving writes, so a service built without it reads legacy-only and
    * silently returns nothing for every trace ingested after the cutover.
    * Deployments without ClickHouse pass NullCanonicalLogRecordRepository.
    */
-  constructor(
-    readonly repository: LogRecordStorageRepository,
-    private readonly canonical: CanonicalLogRecordRepository,
-  ) {}
+  constructor({
+    repository,
+    canonical,
+  }: {
+    repository: LogRecordStorageRepository;
+    canonical: CanonicalLogRecordRepository;
+  }) {
+    this.repository = repository;
+    this.canonical = canonical;
+  }
 
   async insertLogRecord(record: NormalizedLogRecord): Promise<void> {
     await this.repository.insertLogRecord(record);
@@ -89,12 +98,16 @@ export function createDefaultLogRecordStorageService(): LogRecordStorageService 
     return client;
   };
   return isClickHouseEnabled()
-    ? new LogRecordStorageService(
-        new LogRecordStorageClickHouseRepository(resolveClickHouseClient),
-        new CanonicalLogRecordClickHouseRepository(resolveClickHouseClient),
-      )
-    : new LogRecordStorageService(
-        new NullLogRecordStorageRepository(),
-        new NullCanonicalLogRecordRepository(),
-      );
+    ? new LogRecordStorageService({
+        repository: new LogRecordStorageClickHouseRepository(
+          resolveClickHouseClient,
+        ),
+        canonical: new CanonicalLogRecordClickHouseRepository(
+          resolveClickHouseClient,
+        ),
+      })
+    : new LogRecordStorageService({
+        repository: new NullLogRecordStorageRepository(),
+        canonical: new NullCanonicalLogRecordRepository(),
+      });
 }

--- a/langwatch/src/server/app-layer/traces/log-record-storage.service.ts
+++ b/langwatch/src/server/app-layer/traces/log-record-storage.service.ts
@@ -28,9 +28,15 @@ import {
  * in time order — the same pattern the claude-marked read established.
  */
 export class LogRecordStorageService {
+  /**
+   * `canonical` is REQUIRED: canonical `log_records` is the only table still
+   * receiving writes, so a service built without it reads legacy-only and
+   * silently returns nothing for every trace ingested after the cutover.
+   * Deployments without ClickHouse pass NullCanonicalLogRecordRepository.
+   */
   constructor(
     readonly repository: LogRecordStorageRepository,
-    private readonly canonical?: CanonicalLogRecordRepository,
+    private readonly canonical: CanonicalLogRecordRepository,
   ) {}
 
   async insertLogRecord(record: NormalizedLogRecord): Promise<void> {
@@ -53,12 +59,12 @@ export class LogRecordStorageService {
   ): Promise<StoredLogRecordRow[]> {
     const [legacy, canonical] = await Promise.all([
       this.repository.getLogsByTraceId(tenantId, traceId, occurredAtMs, limit),
-      this.canonical?.getLogsByTraceId({
+      this.canonical.getLogsByTraceId({
         tenantId,
         traceId,
         occurredAtMs,
         limit,
-      }) ?? Promise.resolve([]),
+      }),
     ]);
     // Keep-last dedup: canonical goes LAST so it wins a divergent duplicate,
     // matching "canonical is the authoritative store".


### PR DESCRIPTION
## What

`getApp().traces.logRecords` was built with only the legacy `stored_log_records` repository. `LogRecordStorageService`'s canonical parameter was optional and the presets never passed it, so `this.canonical?.getLogsByTraceId(...) ?? []` silently contributed nothing to every trace-correlated log read: the trace drawer's input/output enrichment, the coding-agent terminal transcript, and the log accordions.

Legacy `stored_log_records` stopped receiving writes at the canonical cutover (prod: July 20, 12:39 UTC). Since then every newly ingested trace reads **zero** log records in production, even though its content sits fully correlated in canonical `log_records` (verified directly against prod ClickHouse: the affected trace has 29 correlated rows with intact prompt content, and the canonical read query returns them all when run by hand).

Visible symptom: coding-agent traces show "INPUT AND OUTPUT empty" on llm_request spans and the Terminal tab falls back to the contentless note. Tool-heavy sessions still looked rich because tool steps render from spans, which is why local dogfooding did not catch the log-borne half going dark.

## Fix

- Inject `CanonicalLogRecordClickHouseRepository` (or the Null variant without ClickHouse) in both preset branches.
- Make the canonical constructor parameter **required** so the compiler pins the wiring; no construction site can drop it again.
- Unit cases pin the canonical delegation (exact read arguments) and the canonical-only merge, i.e. the exact prod regression.

Because this is a read-time join, the fix retroactively restores content for every affected trace already ingested; no backfill needed.

## Validation

- typecheck green, `src/server/app-layer/traces` unit suite 1441/1441.
- Prod ClickHouse spot-checks: spans present, canonical log rows present and correlated, legacy table dead since the cutover; the repository's exact query returns the rows the UI could not see.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Trace log retrieval now reads from both the legacy and canonical log storage sources and merges results to present a consistent, chronological timeline.
  - When legacy logs are missing, canonical logs are returned automatically to improve coverage across deployments.
  - Behavior remains reliable whether advanced log storage is enabled or not.

- **Tests**
  - Added unit test coverage for canonical-only reads and for merging legacy + canonical log records in time order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->