### PR TITLE
fix(security): harden MCP outbound requests and browser policy

### DIFF
--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -742,6 +742,9 @@ importers:
       '@langwatch/scenario':
         specifier: ^0.4.6
         version: 0.4.10(5537b93b6807657c4a23641e4b707fe7)
+      '@langwatch/ssrf':
+        specifier: workspace:*
+        version: link:../langwatch/packages/ssrf
       '@opentelemetry/context-async-hooks':
         specifier: ^2.1.0
         version: 2.5.1(@opentelemetry/api@1.9.1)

--- a/langwatch/src/server/securityHeaders.ts
+++ b/langwatch/src/server/securityHeaders.ts
@@ -1,0 +1,43 @@
+import { buildStorageConnectSrc } from "./buildStorageConnectSrc";
+
+type SecurityHeaderEnvironment = Partial<
+  Record<"AWS_REGION" | "AZURE_BLOB_ENDPOINT" | "S3_BUCKET_NAME" | "S3_ENDPOINT" | "S3_REGION", string>
+>;
+
+export function buildSecurityHeaders({
+  dev,
+  environment = process.env,
+}: {
+  dev: boolean;
+  environment?: SecurityHeaderEnvironment;
+}): Record<string, string> {
+  const cspHeader = [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.posthog.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.googletagmanager.com https://*.pendo.io https://client.crisp.chat https://static.hsappstatic.net https://*.google-analytics.com https://www.google.com https://*.reo.dev",
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.pendo.io https://client.crisp.chat https://*.google.com https://*.reo.dev https://fonts.googleapis.com https://unpkg.com",
+    "img-src 'self' blob: data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://image.crisp.chat https://*.googletagmanager.com https://*.pendo.io https://*.google-analytics.com https://www.google.com https://*.reo.dev",
+    "font-src 'self' data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://client.crisp.chat https://www.google.com https://*.reo.dev https://fonts.gstatic.com",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    ...(!dev ? ["upgrade-insecure-requests"] : []),
+    "worker-src 'self' blob:",
+    `connect-src 'self' ${buildStorageConnectSrc(environment).join(
+      " "
+    )} https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev`,
+    "frame-src 'self' https://*.posthog.com https://*.pendo.io https://www.youtube.com https://get.langwatch.ai https://*.googletagmanager.com https://www.google.com https://*.reo.dev",
+  ].join("; ");
+
+  return {
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+    "Permissions-Policy": "geolocation=(), microphone=(), camera=(), payment=(), usb=()",
+    ...(!dev ? { "Content-Security-Policy": cspHeader } : {}),
+    ...(!dev
+      ? {
+          "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        }
+      : {}),
+  };
+}

--- a/langwatch/src/server/securityHeaders.unit.test.ts
+++ b/langwatch/src/server/securityHeaders.unit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSecurityHeaders } from "./securityHeaders";
+
+describe("buildSecurityHeaders", () => {
+  it("disables unused browser capabilities in production", () => {
+    const headers = buildSecurityHeaders({
+      dev: false,
+      environment: {},
+    });
+
+    expect(headers["Permissions-Policy"]).toBe("geolocation=(), microphone=(), camera=(), payment=(), usb=()");
+    expect(headers["Content-Security-Policy"]).toBeDefined();
+    expect(headers["Strict-Transport-Security"]).toBe("max-age=31536000; includeSubDomains");
+  });
+
+  it("keeps the capability restrictions on development responses", () => {
+    const headers = buildSecurityHeaders({
+      dev: true,
+      environment: {},
+    });
+
+    expect(headers["Permissions-Policy"]).toBe("geolocation=(), microphone=(), camera=(), payment=(), usb=()");
+    expect(headers["Content-Security-Policy"]).toBeUndefined();
+    expect(headers["Strict-Transport-Security"]).toBeUndefined();
+  });
+});

--- a/langwatch/src/server/securityHeaders.unit.test.ts
+++ b/langwatch/src/server/securityHeaders.unit.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildSecurityHeaders } from "./securityHeaders";
 
 describe("buildSecurityHeaders", () => {
+  /** @scenario Production HTTP responses include the Permissions-Policy header */
   it("disables unused browser capabilities in production", () => {
     const headers = buildSecurityHeaders({
       dev: false,

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -78,7 +78,7 @@ import {
   initializeInProcessApp,
   initializeWebApp,
 } from "./server/app-layer/presets";
-import { buildStorageConnectSrc } from "./server/buildStorageConnectSrc";
+import { buildSecurityHeaders } from "./server/securityHeaders";
 import {
   getWorkerMetricsPort,
   isMetricsAuthorized,
@@ -194,41 +194,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
   // In production, resolve the built client assets directory
   const clientDistDir = dev ? null : path.join(dir, "dist/client");
 
-  // Security headers (migrated from next.config.mjs)
-  const cspHeader = [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.posthog.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.googletagmanager.com https://*.pendo.io https://client.crisp.chat https://static.hsappstatic.net https://*.google-analytics.com https://www.google.com https://*.reo.dev",
-    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.pendo.io https://client.crisp.chat https://*.google.com https://*.reo.dev https://fonts.googleapis.com https://unpkg.com",
-    "img-src 'self' blob: data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://image.crisp.chat https://*.googletagmanager.com https://*.pendo.io https://*.google-analytics.com https://www.google.com https://*.reo.dev",
-    "font-src 'self' data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://client.crisp.chat https://www.google.com https://*.reo.dev https://fonts.gstatic.com",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'none'",
-    ...(!dev ? ["upgrade-insecure-requests"] : []),
-    "worker-src 'self' blob:",
-    // ADR-032: allow the browser's presigned PUT to object storage (derived
-    // from the same env the S3 client uses) — without it the CSP blocks the
-    // upload before it leaves the page and the drawer silently falls back.
-    `connect-src 'self' ${buildStorageConnectSrc({
-      S3_ENDPOINT: process.env.S3_ENDPOINT,
-      S3_REGION: process.env.S3_REGION,
-      S3_BUCKET_NAME: process.env.S3_BUCKET_NAME,
-      AWS_REGION: process.env.AWS_REGION,
-      AZURE_BLOB_ENDPOINT: process.env.AZURE_BLOB_ENDPOINT,
-    }).join(
-      " ",
-    )} https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev`,
-    "frame-src 'self' https://*.posthog.com https://*.pendo.io https://www.youtube.com https://get.langwatch.ai https://*.googletagmanager.com https://www.google.com https://*.reo.dev",
-  ].join("; ");
-
-  const securityHeaders: Record<string, string> = {
-    "Referrer-Policy": "no-referrer",
-    "X-Content-Type-Options": "nosniff",
-    // CSP only in production — dev needs inline scripts for Vite HMR
-    ...(!dev ? { "Content-Security-Policy": cspHeader } : {}),
-    ...(!dev ? { "Strict-Transport-Security": "max-age=31536000; includeSubDomains" } : {}),
-  };
+  const securityHeaders = buildSecurityHeaders({ dev });
 
   // Optional HTTPS + HTTP/2 path for local dev. Set
   // `LANGWATCH_DEV_HTTP2=1` and a self-signed cert is auto-generated on

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -46,6 +46,7 @@
     "@eslint/js": "^10.0.1",
     "@langwatch/handled-error": "workspace:*",
     "@langwatch/scenario": "^0.4.6",
+    "@langwatch/ssrf": "workspace:*",
     "@opentelemetry/context-async-hooks": "^2.1.0",
     "@opentelemetry/sdk-node": "^0.219.0",
     "@types/debug": "^4.1.13",

--- a/mcp-server/pnpm-lock.yaml
+++ b/mcp-server/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@langwatch/scenario':
         specifier: ^0.4.6
         version: 0.4.15(668bbc6991063a13cac3c4f471982977)
+      '@langwatch/ssrf':
+        specifier: workspace:*
+        version: link:../langwatch/packages/ssrf
       '@opentelemetry/context-async-hooks':
         specifier: ^2.1.0
         version: 2.8.0(@opentelemetry/api@1.9.1)
@@ -107,6 +110,18 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(zod@4.4.3)
 
+  ../langwatch/packages/ssrf:
+    devDependencies:
+      '@types/node':
+        specifier: ^26.0.1
+        version: 26.1.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.5(@types/node@26.1.1)(tsx@4.22.4)(yaml@2.9.0))
+
   ../packages/handled-error:
     devDependencies:
       '@opentelemetry/api':
@@ -117,7 +132,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@7.3.5(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.5(@types/node@26.1.1)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -1302,6 +1317,9 @@ packages:
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
@@ -2773,11 +2791,19 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -4232,6 +4258,10 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/node@26.1.1':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/prompts@2.4.9':
     dependencies:
       '@types/node': 25.9.1
@@ -4402,6 +4432,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.5(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@26.1.1)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@26.1.1)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -5715,9 +5753,13 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typescript@6.0.3: {}
+
   ufo@1.6.4: {}
 
   undici-types@7.24.6: {}
+
+  undici-types@8.3.0: {}
 
   unpipe@1.0.0: {}
 
@@ -5741,6 +5783,20 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
+      fsevents: 2.3.3
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  vite@7.3.5(@types/node@26.1.1)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       tsx: 4.22.4
       yaml: 2.9.0
@@ -5770,6 +5826,34 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.5(@types/node@26.1.1)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@26.1.1)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.2.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.5(@types/node@26.1.1)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.1
     transitivePeerDependencies:
       - msw
 

--- a/mcp-server/pnpm-workspace.yaml
+++ b/mcp-server/pnpm-workspace.yaml
@@ -1,9 +1,10 @@
 # Standalone workspace: mcp-server is installed on its own in CI, the
-# release workflow, and its Dockerfile. The handled-error contract package is
-# consumed as a source-only workspace dep (bundled by tsup for publish).
+# release workflow, and its Dockerfile. Shared source-only contract packages
+# are bundled by tsup for publish.
 packages:
   - .
   - ../packages/handled-error
+  - ../langwatch/packages/ssrf
 
 minimumReleaseAge: 10080
 

--- a/mcp-server/src/__tests__/all-tools.integration.test.ts
+++ b/mcp-server/src/__tests__/all-tools.integration.test.ts
@@ -1,6 +1,10 @@
 import { createServer, type Server } from "http";
 import { afterAll, beforeAll, describe, expect, it, vi, beforeEach } from "vitest";
 import { initConfig } from "../config.js";
+import {
+  fetchDocumentation,
+  resolveDocumentationUrl,
+} from "../documentation-fetch.js";
 
 // --- Canned responses for every API endpoint ---
 
@@ -624,7 +628,6 @@ function createMockServer(): Server {
 describe("All MCP tools integration", () => {
   let server: Server;
   let port: number;
-  let originalFetch: typeof globalThis.fetch;
 
   beforeAll(async () => {
     server = createMockServer();
@@ -639,94 +642,38 @@ describe("All MCP tools integration", () => {
         resolve();
       });
     });
-    originalFetch = globalThis.fetch;
   });
 
   afterAll(async () => {
     await new Promise<void>((resolve) => server.close(() => resolve()));
-    globalThis.fetch = originalFetch;
   });
 
   // =====================
   // 1. fetch_langwatch_docs
   // =====================
   describe("fetch_langwatch_docs", () => {
-    describe("when fetching the docs index", () => {
-      it("returns content from the langwatch docs URL", async () => {
-        // Intercept fetch to avoid hitting the real network
-        const mockFetch = vi.fn().mockResolvedValue({
-          text: () =>
-            Promise.resolve(
-              "# LangWatch Docs\nWelcome to LangWatch documentation.",
-            ),
-        });
-        globalThis.fetch = mockFetch;
-
-        // The tool is inlined in index.ts; call the same logic directly
-        const url = "https://langwatch.ai/docs/llms.txt";
-        const response = await fetch(url);
-        const text = await response.text();
-
-        expect(text).toContain("LangWatch");
-        expect(mockFetch).toHaveBeenCalledWith(url);
-
-        globalThis.fetch = originalFetch;
-      });
+    it("resolves the trusted docs index", () => {
+      expect(resolveDocumentationUrl("langwatch").toString()).toBe(
+        "https://langwatch.ai/docs/llms.txt",
+      );
     });
 
-    describe("when fetching a specific doc page", () => {
-      it("appends .md extension when missing", async () => {
-        const mockFetch = vi.fn().mockResolvedValue({
-          text: () => Promise.resolve("# Integration Guide"),
-        });
-        globalThis.fetch = mockFetch;
+    it("fetches trusted docs without following redirects", async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response("# Integration Guide"),
+      );
 
-        let urlToFetch = "https://langwatch.ai/docs/integration";
-        if (
-          !urlToFetch.endsWith(".md") &&
-          !urlToFetch.endsWith(".txt")
-        ) {
-          urlToFetch += ".md";
-        }
+      const text = await fetchDocumentation(
+        "langwatch",
+        "integration",
+        mockFetch,
+      );
 
-        const response = await fetch(urlToFetch);
-        const text = await response.text();
-
-        expect(text).toContain("Integration Guide");
-        expect(mockFetch).toHaveBeenCalledWith(
-          "https://langwatch.ai/docs/integration.md",
-        );
-
-        globalThis.fetch = originalFetch;
-      });
-    });
-
-    describe("when a relative path is provided", () => {
-      it("prepends the docs base URL", async () => {
-        const mockFetch = vi.fn().mockResolvedValue({
-          text: () => Promise.resolve("# Getting Started"),
-        });
-        globalThis.fetch = mockFetch;
-
-        let urlToFetch: string | undefined = "/getting-started";
-        if (urlToFetch && !urlToFetch.endsWith(".md") && !urlToFetch.endsWith(".txt")) {
-          urlToFetch += ".md";
-        }
-        if (!urlToFetch!.startsWith("http")) {
-          if (!urlToFetch!.startsWith("/")) {
-            urlToFetch = "/" + urlToFetch;
-          }
-          urlToFetch = "https://langwatch.ai/docs" + urlToFetch;
-        }
-
-        await fetch(urlToFetch);
-
-        expect(mockFetch).toHaveBeenCalledWith(
-          "https://langwatch.ai/docs/getting-started.md",
-        );
-
-        globalThis.fetch = originalFetch;
-      });
+      expect(text).toContain("Integration Guide");
+      expect(mockFetch).toHaveBeenCalledWith(
+        new URL("https://langwatch.ai/docs/integration.md"),
+        { redirect: "error" },
+      );
     });
   });
 
@@ -734,53 +681,16 @@ describe("All MCP tools integration", () => {
   // 2. fetch_scenario_docs
   // =====================
   describe("fetch_scenario_docs", () => {
-    describe("when fetching the scenario docs index", () => {
-      it("returns content from the scenario docs URL", async () => {
-        const mockFetch = vi.fn().mockResolvedValue({
-          text: () =>
-            Promise.resolve(
-              "# Scenario Testing\nLearn how to test agents.",
-            ),
-        });
-        globalThis.fetch = mockFetch;
-
-        const url = "https://langwatch.ai/scenario/llms.txt";
-        const response = await fetch(url);
-        const text = await response.text();
-
-        expect(text).toContain("Scenario Testing");
-        expect(mockFetch).toHaveBeenCalledWith(url);
-
-        globalThis.fetch = originalFetch;
-      });
+    it("resolves the trusted Scenario docs index", () => {
+      expect(resolveDocumentationUrl("scenario").toString()).toBe(
+        "https://langwatch.ai/scenario/llms.txt",
+      );
     });
 
-    describe("when fetching a specific scenario doc page", () => {
-      it("appends .md extension and prepends base URL for relative paths", async () => {
-        const mockFetch = vi.fn().mockResolvedValue({
-          text: () => Promise.resolve("# Setup Guide"),
-        });
-        globalThis.fetch = mockFetch;
-
-        let urlToFetch: string | undefined = "setup";
-        if (urlToFetch && !urlToFetch.endsWith(".md") && !urlToFetch.endsWith(".txt")) {
-          urlToFetch += ".md";
-        }
-        if (!urlToFetch!.startsWith("http")) {
-          if (!urlToFetch!.startsWith("/")) {
-            urlToFetch = "/" + urlToFetch;
-          }
-          urlToFetch = "https://langwatch.ai/scenario" + urlToFetch;
-        }
-
-        await fetch(urlToFetch);
-
-        expect(mockFetch).toHaveBeenCalledWith(
-          "https://langwatch.ai/scenario/setup.md",
-        );
-
-        globalThis.fetch = originalFetch;
-      });
+    it("normalizes a relative Scenario docs path", () => {
+      expect(resolveDocumentationUrl("scenario", "setup").toString()).toBe(
+        "https://langwatch.ai/scenario/setup.md",
+      );
     });
   });
 

--- a/mcp-server/src/__tests__/all-tools.integration.test.ts
+++ b/mcp-server/src/__tests__/all-tools.integration.test.ts
@@ -672,7 +672,10 @@ describe("All MCP tools integration", () => {
       expect(text).toContain("Integration Guide");
       expect(mockFetch).toHaveBeenCalledWith(
         new URL("https://langwatch.ai/docs/integration.md"),
-        { redirect: "error" },
+        {
+          redirect: "error",
+          signal: expect.any(AbortSignal),
+        },
       );
     });
   });

--- a/mcp-server/src/__tests__/documentation-fetch-security.integration.test.ts
+++ b/mcp-server/src/__tests__/documentation-fetch-security.integration.test.ts
@@ -1,0 +1,169 @@
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { initConfig } from "../config.js";
+import { fetchDocumentation, resolveDocumentationUrl } from "../documentation-fetch.js";
+
+const MCP_HEADERS = {
+  Accept: "application/json, text/event-stream",
+  Authorization: "Bearer security-regression-test",
+  "Content-Type": "application/json",
+};
+
+describe("MCP documentation fetch security", () => {
+  describe("URL validation", () => {
+    it.each([
+      ["langwatch" as const, undefined, "https://langwatch.ai/docs/llms.txt"],
+      ["scenario" as const, undefined, "https://langwatch.ai/scenario/llms.txt"],
+      ["langwatch" as const, "observability/tracing", "https://langwatch.ai/docs/observability/tracing.md"],
+      ["scenario" as const, "/scenario/guides/quickstart", "https://langwatch.ai/scenario/guides/quickstart.md"],
+      [
+        "langwatch" as const,
+        "https://langwatch.ai/docs/llms.txt?format=raw",
+        "https://langwatch.ai/docs/llms.txt?format=raw",
+      ],
+    ])("resolves trusted %s documentation URL %s", (kind, input, expected) => {
+      expect(resolveDocumentationUrl(kind, input).toString()).toBe(expected);
+    });
+
+    it.each([
+      ["langwatch" as const, "http://169.254.169.254/latest/meta-data/"],
+      ["langwatch" as const, "https://langwatch.ai.attacker.example/docs/x"],
+      ["langwatch" as const, "https://langwatch.ai@127.0.0.1/docs/x"],
+      ["langwatch" as const, "https://langwatch.ai:444/docs/x"],
+      ["langwatch" as const, "file:///etc/passwd"],
+      ["langwatch" as const, "https://langwatch.ai/scenario/llms.txt"],
+      ["langwatch" as const, "https://langwatch.ai/docs-evil/page.md"],
+      ["scenario" as const, "https://langwatch.ai/docs/llms.txt"],
+      ["scenario" as const, "https://langwatch.ai/scenario-evil/page.md"],
+      ["langwatch" as const, "https://langwatch.ai/docs/../scenario/llms.txt"],
+    ])("rejects untrusted %s documentation URL %s", (kind, input) => {
+      expect(() => resolveDocumentationUrl(kind, input)).toThrow(/trusted LangWatch documentation URL/);
+    });
+  });
+
+  it("disables redirects on trusted documentation fetches", async () => {
+    let receivedRedirectMode: RequestRedirect | undefined;
+    const fetchForTest: typeof fetch = async (_input, init) => {
+      receivedRedirectMode = init?.redirect;
+      return new Response("# documentation");
+    };
+
+    const text = await fetchDocumentation("langwatch", "https://langwatch.ai/docs/llms.txt", fetchForTest);
+
+    expect(text).toBe("# documentation");
+    expect(receivedRedirectMode).toBe("error");
+  });
+
+  it("rejects non-document responses from the trusted origin", async () => {
+    const fetchForTest: typeof fetch = async () =>
+      new Response("<html>unexpected</html>", {
+        headers: { "Content-Type": "text/html" },
+      });
+
+    await expect(fetchDocumentation("langwatch", "https://langwatch.ai/docs/llms.txt", fetchForTest)).rejects.toThrow(
+      /unexpected content type/
+    );
+  });
+
+  describe("HTTP tool transport", () => {
+    let mcpServer: Server;
+    let targetServer: Server;
+    let mcpPort: number;
+    let targetPort: number;
+    let sessionId: string;
+    let targetHits = 0;
+    let rpcId = 10;
+
+    beforeAll(async () => {
+      targetServer = createServer((_request, response) => {
+        targetHits += 1;
+        response.end("internal-only response");
+      });
+      await new Promise<void>((resolve) => {
+        targetServer.listen(0, "127.0.0.1", resolve);
+      });
+      const targetAddress = targetServer.address();
+      targetPort = typeof targetAddress === "object" && targetAddress ? targetAddress.port : 0;
+
+      initConfig({ endpoint: "https://app.langwatch.ai" });
+      const { startHttpServer } = await import("../http-server.js");
+      const started = await startHttpServer({ port: 0 });
+      mcpServer = started.server;
+      mcpPort = started.port;
+
+      const initializeResponse = await fetch(`http://127.0.0.1:${mcpPort}/mcp`, {
+        method: "POST",
+        headers: MCP_HEADERS,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "security-test", version: "1.0.0" },
+          },
+        }),
+      });
+      sessionId = initializeResponse.headers.get("mcp-session-id") ?? "";
+      expect(sessionId).not.toBe("");
+
+      await fetch(`http://127.0.0.1:${mcpPort}/mcp`, {
+        method: "POST",
+        headers: { ...MCP_HEADERS, "mcp-session-id": sessionId },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        }),
+      });
+    });
+
+    afterAll(async () => {
+      await Promise.all([
+        new Promise<void>((resolve, reject) => {
+          mcpServer.close((error) => (error ? reject(error) : resolve()));
+        }),
+        new Promise<void>((resolve, reject) => {
+          targetServer.close((error) => (error ? reject(error) : resolve()));
+        }),
+      ]);
+    });
+
+    async function callDocumentationTool(
+      name: "fetch_langwatch_docs" | "fetch_scenario_docs",
+      url: string
+    ): Promise<string> {
+      const response = await fetch(`http://127.0.0.1:${mcpPort}/mcp`, {
+        method: "POST",
+        headers: { ...MCP_HEADERS, "mcp-session-id": sessionId },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: rpcId++,
+          method: "tools/call",
+          params: { name, arguments: { url } },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      return response.text();
+    }
+
+    it.each(["fetch_langwatch_docs" as const, "fetch_scenario_docs" as const])(
+      "blocks %s from reaching a loopback HTTP server",
+      async (tool) => {
+        const hitsBefore = targetHits;
+        const body = await callDocumentationTool(tool, `http://127.0.0.1:${targetPort}/secrets`);
+
+        expect(body).toContain("trusted LangWatch documentation URL");
+        expect(targetHits).toBe(hitsBefore);
+      }
+    );
+
+    it("blocks cross-namespace fetches through the real MCP handler", async () => {
+      const body = await callDocumentationTool("fetch_langwatch_docs", "https://langwatch.ai/scenario/llms.txt");
+
+      expect(body).toContain("trusted LangWatch documentation URL");
+    });
+  });
+});

--- a/mcp-server/src/__tests__/documentation-fetch-security.integration.test.ts
+++ b/mcp-server/src/__tests__/documentation-fetch-security.integration.test.ts
@@ -12,6 +12,7 @@ const MCP_HEADERS = {
 
 describe("MCP documentation fetch security", () => {
   describe("URL validation", () => {
+    /** @scenario A documentation tool accepts its own trusted HTTPS pages */
     it.each([
       ["langwatch" as const, undefined, "https://langwatch.ai/docs/llms.txt"],
       ["scenario" as const, undefined, "https://langwatch.ai/scenario/llms.txt"],
@@ -26,6 +27,8 @@ describe("MCP documentation fetch security", () => {
       expect(resolveDocumentationUrl(kind, input).toString()).toBe(expected);
     });
 
+    /** @scenario A documentation tool rejects non-HTTPS and untrusted hosts */
+    /** @scenario A documentation tool rejects a trusted host outside its namespace */
     it.each([
       ["langwatch" as const, "http://169.254.169.254/latest/meta-data/"],
       ["langwatch" as const, "https://langwatch.ai.attacker.example/docs/x"],
@@ -42,10 +45,13 @@ describe("MCP documentation fetch security", () => {
     });
   });
 
-  it("disables redirects on trusted documentation fetches", async () => {
+  /** @scenario Documentation fetches do not follow redirects */
+  it("disables redirects and bounds trusted documentation fetches", async () => {
     let receivedRedirectMode: RequestRedirect | undefined;
+    let receivedSignal: AbortSignal | null | undefined;
     const fetchForTest: typeof fetch = async (_input, init) => {
       receivedRedirectMode = init?.redirect;
+      receivedSignal = init?.signal;
       return new Response("# documentation");
     };
 
@@ -53,6 +59,7 @@ describe("MCP documentation fetch security", () => {
 
     expect(text).toBe("# documentation");
     expect(receivedRedirectMode).toBe("error");
+    expect(receivedSignal).toBeInstanceOf(AbortSignal);
   });
 
   it("rejects non-document responses from the trusted origin", async () => {

--- a/mcp-server/src/__tests__/public-http-request-security.integration.test.ts
+++ b/mcp-server/src/__tests__/public-http-request-security.integration.test.ts
@@ -1,0 +1,71 @@
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { requestPublicJson, resolvePublicDestination } from "../public-http-request.js";
+
+describe("public HTTP request security", () => {
+  it.each([
+    "http://127.0.0.1/secrets",
+    "http://2130706433/secrets",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://10.0.0.1/internal",
+    "http://[::1]/secrets",
+    "file:///etc/passwd",
+    "http://user:password@example.com/",
+  ])("rejects unsafe destination %s", async (url) => {
+    await expect(resolvePublicDestination(url)).rejects.toThrow(/globally routable public addresses/);
+  });
+
+  it("fails closed when any resolved address is not public", async () => {
+    await expect(
+      resolvePublicDestination("https://agent.example/run", async () => [
+        { address: "93.184.216.34", family: 4 },
+        { address: "10.0.0.4", family: 4 },
+      ])
+    ).rejects.toThrow(/globally routable public addresses/);
+  });
+
+  it("pins a validated public destination", async () => {
+    await expect(
+      resolvePublicDestination("https://agent.example/run", async () => [{ address: "93.184.216.34", family: 4 }])
+    ).resolves.toMatchObject({
+      address: "93.184.216.34",
+      family: 4,
+    });
+  });
+
+  describe("real HTTP request", () => {
+    let server: Server;
+    let port: number;
+    let hits = 0;
+
+    beforeAll(async () => {
+      server = createServer((_request, response) => {
+        hits += 1;
+        response.setHeader("Content-Type", "application/json");
+        response.end(JSON.stringify({ secret: true }));
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      port = typeof address === "object" && address ? address.port : 0;
+    });
+
+    afterAll(async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    });
+
+    it("blocks loopback before opening a connection", async () => {
+      await expect(
+        requestPublicJson(`http://127.0.0.1:${port}/secrets`, {
+          method: "POST",
+          body: "{}",
+        })
+      ).rejects.toThrow(/globally routable public addresses/);
+      expect(hits).toBe(0);
+    });
+  });
+});

--- a/mcp-server/src/__tests__/public-http-request-security.integration.test.ts
+++ b/mcp-server/src/__tests__/public-http-request-security.integration.test.ts
@@ -1,9 +1,18 @@
 import { createServer, type Server } from "node:http";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { requestPublicJson, resolvePublicDestination } from "../public-http-request.js";
+import {
+  headersForRedirect,
+  requestPublicJson,
+  resolvePublicDestination,
+} from "../public-http-request.js";
 
 describe("public HTTP request security", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** @scenario Running an HTTP agent rejects unsafe destinations */
   it.each([
     "http://127.0.0.1/secrets",
     "http://2130706433/secrets",
@@ -31,6 +40,44 @@ describe("public HTTP request security", () => {
     ).resolves.toMatchObject({
       address: "93.184.216.34",
       family: 4,
+    });
+  });
+
+  it("bounds DNS resolution time", async () => {
+    vi.useFakeTimers();
+    const resolution = resolvePublicDestination(
+      "https://agent.example/run",
+      () => new Promise(() => undefined)
+    );
+    const rejection = expect(resolution).rejects.toThrow(
+      /destination could not be resolved/
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await rejection;
+  });
+
+  /** @scenario HTTP agent redirects are revalidated */
+  it("rejects private redirect targets and strips cross-origin secrets", async () => {
+    await expect(
+      resolvePublicDestination("http://127.0.0.1/redirect-target")
+    ).rejects.toThrow(/globally routable public addresses/);
+
+    expect(
+      headersForRedirect(
+        {
+          Authorization: "Bearer secret",
+          Cookie: "session=secret",
+          "Content-Type": "application/json",
+          "X-Api-Key": "secret",
+          "X-Request-Id": "request-1",
+        },
+        true
+      )
+    ).toEqual({
+      "Content-Type": "application/json",
+      "X-Request-Id": "request-1",
     });
   });
 

--- a/mcp-server/src/create-mcp-server.ts
+++ b/mcp-server/src/create-mcp-server.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import packageJson from "../package.json" with { type: "json" };
 import { requireApiKey } from "./config.js";
+import { fetchDocumentation } from "./documentation-fetch.js";
 import {
   createDatasetSchema,
   datasetColumnDefinitionSchema,
@@ -70,21 +71,8 @@ function registerTools(server: McpServer): void {
         ),
     },
     withToolLogging("fetch_langwatch_docs", async ({ url }) => {
-      let urlToFetch = url || "https://langwatch.ai/docs/llms.txt";
-      if (url && !urlToFetch.endsWith(".md") && !urlToFetch.endsWith(".txt")) {
-        urlToFetch += ".md";
-      }
-      if (!urlToFetch.startsWith("http")) {
-        if (!urlToFetch.startsWith("/")) {
-          urlToFetch = "/" + urlToFetch;
-        }
-        urlToFetch = "https://langwatch.ai/docs" + urlToFetch;
-      }
-      const response = await fetch(urlToFetch);
-
-      return {
-        content: [{ type: "text", text: await response.text() }],
-      };
+      const text = await fetchDocumentation("langwatch", url);
+      return { content: [{ type: "text", text }] };
     })
   );
 
@@ -100,21 +88,8 @@ function registerTools(server: McpServer): void {
         ),
     },
     withToolLogging("fetch_scenario_docs", async ({ url }) => {
-      let urlToFetch = url || "https://langwatch.ai/scenario/llms.txt";
-      if (url && !urlToFetch.endsWith(".md") && !urlToFetch.endsWith(".txt")) {
-        urlToFetch += ".md";
-      }
-      if (!urlToFetch.startsWith("http")) {
-        if (!urlToFetch.startsWith("/")) {
-          urlToFetch = "/" + urlToFetch;
-        }
-        urlToFetch = "https://langwatch.ai" + urlToFetch;
-      }
-      const response = await fetch(urlToFetch);
-
-      return {
-        content: [{ type: "text", text: await response.text() }],
-      };
+      const text = await fetchDocumentation("scenario", url);
+      return { content: [{ type: "text", text }] };
     })
   );
 

--- a/mcp-server/src/documentation-fetch.ts
+++ b/mcp-server/src/documentation-fetch.ts
@@ -1,0 +1,107 @@
+export type DocumentationKind = "langwatch" | "scenario";
+
+const TRUSTED_DOCUMENTATION_ORIGIN = "https://langwatch.ai";
+const MAX_DOCUMENTATION_BYTES = 2 * 1024 * 1024;
+const DOCUMENTATION_CONTENT_TYPES = new Set(["text/markdown", "text/plain"]);
+
+const DOCUMENTATION_CONFIG: Record<DocumentationKind, { defaultPath: string; namespace: string }> = {
+  langwatch: {
+    defaultPath: "/docs/llms.txt",
+    namespace: "/docs",
+  },
+  scenario: {
+    defaultPath: "/scenario/llms.txt",
+    namespace: "/scenario",
+  },
+};
+
+function documentationUrlError(namespace: string): Error {
+  return new Error(
+    `Only a trusted LangWatch documentation URL under ${TRUSTED_DOCUMENTATION_ORIGIN}${namespace}/ may be fetched`
+  );
+}
+
+export function resolveDocumentationUrl(kind: DocumentationKind, input?: string): URL {
+  const { defaultPath, namespace } = DOCUMENTATION_CONFIG[kind];
+  const value = input?.trim();
+  let url: URL;
+
+  try {
+    if (!value) {
+      url = new URL(defaultPath, TRUSTED_DOCUMENTATION_ORIGIN);
+    } else if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value) || value.startsWith("//")) {
+      url = new URL(value, TRUSTED_DOCUMENTATION_ORIGIN);
+    } else {
+      const relativePath = value.replace(/^\/+/, "");
+      const namespacePath = namespace.slice(1);
+      const path =
+        relativePath === namespacePath || relativePath.startsWith(`${namespacePath}/`)
+          ? `/${relativePath}`
+          : `${namespace}/${relativePath}`;
+      url = new URL(path, TRUSTED_DOCUMENTATION_ORIGIN);
+    }
+  } catch {
+    throw documentationUrlError(namespace);
+  }
+
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "langwatch.ai" ||
+    url.port !== "" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    !url.pathname.startsWith(`${namespace}/`)
+  ) {
+    throw documentationUrlError(namespace);
+  }
+
+  const lowerPath = url.pathname.toLowerCase();
+  if (!lowerPath.endsWith(".md") && !lowerPath.endsWith(".txt")) {
+    url.pathname += ".md";
+  }
+
+  return url;
+}
+
+export async function fetchDocumentation(
+  kind: DocumentationKind,
+  input?: string,
+  fetchImplementation: typeof fetch = fetch
+): Promise<string> {
+  const url = resolveDocumentationUrl(kind, input);
+  const response = await fetchImplementation(url, { redirect: "error" });
+  if (!response.ok) {
+    throw new Error(`Documentation request failed with status ${response.status}`);
+  }
+
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim() ?? "";
+  if (!DOCUMENTATION_CONTENT_TYPES.has(contentType)) {
+    throw new Error("Documentation response has an unexpected content type");
+  }
+
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > MAX_DOCUMENTATION_BYTES) {
+    throw new Error("Documentation response is too large");
+  }
+
+  if (!response.body) {
+    return "";
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let receivedBytes = 0;
+  let text = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return text + decoder.decode();
+    }
+    receivedBytes += value.byteLength;
+    if (receivedBytes > MAX_DOCUMENTATION_BYTES) {
+      await reader.cancel();
+      throw new Error("Documentation response is too large");
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+}

--- a/mcp-server/src/documentation-fetch.ts
+++ b/mcp-server/src/documentation-fetch.ts
@@ -2,6 +2,7 @@ export type DocumentationKind = "langwatch" | "scenario";
 
 const TRUSTED_DOCUMENTATION_ORIGIN = "https://langwatch.ai";
 const MAX_DOCUMENTATION_BYTES = 2 * 1024 * 1024;
+const DOCUMENTATION_TIMEOUT_MS = 30_000;
 const DOCUMENTATION_CONTENT_TYPES = new Set(["text/markdown", "text/plain"]);
 
 const DOCUMENTATION_CONFIG: Record<DocumentationKind, { defaultPath: string; namespace: string }> = {
@@ -69,7 +70,10 @@ export async function fetchDocumentation(
   fetchImplementation: typeof fetch = fetch
 ): Promise<string> {
   const url = resolveDocumentationUrl(kind, input);
-  const response = await fetchImplementation(url, { redirect: "error" });
+  const response = await fetchImplementation(url, {
+    redirect: "error",
+    signal: AbortSignal.timeout(DOCUMENTATION_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`Documentation request failed with status ${response.status}`);
   }

--- a/mcp-server/src/langwatch-api-agents.ts
+++ b/mcp-server/src/langwatch-api-agents.ts
@@ -1,4 +1,5 @@
 import { makeRequest } from "./langwatch-api.js";
+import { requestPublicJson } from "./public-http-request.js";
 
 export interface AgentSummary {
   id: string;
@@ -76,13 +77,12 @@ export async function runAgent(
       throw new Error("HTTP agent has no URL configured");
     }
 
-    const response = await fetch(url, {
+    const result = await requestPublicJson(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input ?? {}),
     });
 
-    const result = (await response.json()) as Record<string, unknown>;
     return { agentType: "http", result };
   }
 

--- a/mcp-server/src/public-http-request.ts
+++ b/mcp-server/src/public-http-request.ts
@@ -1,0 +1,193 @@
+import { lookup as dnsLookup } from "node:dns/promises";
+import { request as httpRequest, type RequestOptions } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { isIP } from "node:net";
+
+import { classify } from "@langwatch/ssrf";
+
+const MAX_REDIRECTS = 5;
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 30_000;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+type DnsResolver = (hostname: string, options: { all: true; verbatim: true }) => Promise<ResolvedAddress[]>;
+
+interface ResolvedAddress {
+  address: string;
+  family: number;
+}
+
+export interface PublicDestination {
+  address: string;
+  family: number;
+  url: URL;
+}
+
+function unsafeDestinationError(): Error {
+  return new Error("HTTP agent destinations must resolve only to globally routable public addresses");
+}
+
+function hostnameWithoutBrackets(hostname: string): string {
+  return hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+}
+
+function assertPublicAddress(address: string): void {
+  if (classify(address) !== "global") {
+    throw unsafeDestinationError();
+  }
+}
+
+export async function resolvePublicDestination(
+  input: string,
+  resolver: DnsResolver = dnsLookup
+): Promise<PublicDestination> {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new Error("HTTP agent URL is invalid");
+  }
+
+  if ((url.protocol !== "http:" && url.protocol !== "https:") || url.username !== "" || url.password !== "") {
+    throw unsafeDestinationError();
+  }
+
+  const hostname = hostnameWithoutBrackets(url.hostname);
+  const literalFamily = isIP(hostname);
+  if (literalFamily !== 0) {
+    assertPublicAddress(hostname);
+    return { address: hostname, family: literalFamily, url };
+  }
+
+  let addresses: ResolvedAddress[];
+  try {
+    addresses = await resolver(hostname, { all: true, verbatim: true });
+  } catch {
+    throw new Error("HTTP agent destination could not be resolved");
+  }
+
+  if (addresses.length === 0) {
+    throw new Error("HTTP agent destination could not be resolved");
+  }
+
+  for (const { address } of addresses) {
+    assertPublicAddress(address);
+  }
+
+  const selected = addresses.find(({ family }) => family === 4) ?? addresses[0]!;
+  return {
+    address: selected.address,
+    family: selected.family,
+    url,
+  };
+}
+
+interface PublicJsonRequestOptions {
+  body?: string;
+  headers?: Record<string, string>;
+  method?: "GET" | "POST";
+  signal?: AbortSignal;
+}
+
+function requestBody(
+  destination: PublicDestination,
+  options: PublicJsonRequestOptions
+): Promise<{ body: string; location?: string; statusCode: number }> {
+  return new Promise((resolve, reject) => {
+    const hostname = hostnameWithoutBrackets(destination.url.hostname);
+    const requestOptions: RequestOptions = {
+      protocol: destination.url.protocol,
+      hostname,
+      port: destination.url.port || undefined,
+      path: `${destination.url.pathname}${destination.url.search}`,
+      method: options.method ?? "GET",
+      headers: options.headers,
+      family: destination.family,
+      signal: options.signal,
+      lookup: (_hostname, _options, callback) => {
+        callback(null, destination.address, destination.family);
+      },
+    };
+    const transport = destination.url.protocol === "https:" ? httpsRequest : httpRequest;
+    const request = transport(requestOptions, (response) => {
+      const chunks: Buffer[] = [];
+      let receivedBytes = 0;
+      response.once("aborted", () => {
+        reject(new Error("HTTP agent response was interrupted"));
+      });
+      response.once("error", reject);
+
+      const contentLength = Number(response.headers["content-length"]);
+      if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
+        response.destroy(new Error("HTTP agent response is too large"));
+        return;
+      }
+
+      response.on("data", (chunk: Buffer) => {
+        receivedBytes += chunk.length;
+        if (receivedBytes > MAX_RESPONSE_BYTES) {
+          response.destroy(new Error("HTTP agent response is too large"));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.once("end", () => {
+        resolve({
+          body: Buffer.concat(chunks).toString("utf8"),
+          location: response.headers.location,
+          statusCode: response.statusCode ?? 0,
+        });
+      });
+    });
+
+    request.once("error", reject);
+    request.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      request.destroy(new Error("HTTP agent request timed out"));
+    });
+    if (options.body !== undefined) {
+      request.write(options.body);
+    }
+    request.end();
+  });
+}
+
+export async function requestPublicJson(
+  input: string,
+  options: PublicJsonRequestOptions = {},
+  redirectCount = 0
+): Promise<Record<string, unknown>> {
+  const destination = await resolvePublicDestination(input);
+  const response = await requestBody(destination, options);
+
+  if (REDIRECT_STATUSES.has(response.statusCode) && response.location) {
+    if (redirectCount >= MAX_REDIRECTS) {
+      throw new Error(`HTTP agent returned too many redirects`);
+    }
+    const redirectUrl = new URL(response.location, destination.url);
+    const preserveBody = response.statusCode === 307 || response.statusCode === 308;
+    return requestPublicJson(
+      redirectUrl.toString(),
+      preserveBody
+        ? options
+        : {
+            ...options,
+            body: undefined,
+            method: "GET",
+          },
+      redirectCount + 1
+    );
+  }
+
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw new Error(`HTTP agent returned an unsuccessful status: ${response.statusCode}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(response.body);
+  } catch {
+    throw new Error("HTTP agent returned invalid JSON");
+  }
+
+  return parsed as Record<string, unknown>;
+}

--- a/mcp-server/src/public-http-request.ts
+++ b/mcp-server/src/public-http-request.ts
@@ -9,6 +9,16 @@ const MAX_REDIRECTS = 5;
 const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
 const REQUEST_TIMEOUT_MS = 30_000;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const SENSITIVE_REDIRECT_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "cookie2",
+  "proxy-authorization",
+  "x-api-key",
+  "api-key",
+  "x-auth-token",
+  "x-access-token",
+]);
 
 type DnsResolver = (hostname: string, options: { all: true; verbatim: true }) => Promise<ResolvedAddress[]>;
 
@@ -37,6 +47,37 @@ function assertPublicAddress(address: string): void {
   }
 }
 
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error("request timed out")), timeoutMs);
+        timeout.unref();
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function headersForRedirect(
+  headers: Record<string, string> | undefined,
+  crossOrigin: boolean
+): Record<string, string> | undefined {
+  if (!headers || !crossOrigin) {
+    return headers;
+  }
+
+  const safeHeaders = Object.fromEntries(
+    Object.entries(headers).filter(([name]) => !SENSITIVE_REDIRECT_HEADERS.has(name.toLowerCase()))
+  );
+  return Object.keys(safeHeaders).length > 0 ? safeHeaders : undefined;
+}
+
 export async function resolvePublicDestination(
   input: string,
   resolver: DnsResolver = dnsLookup
@@ -61,7 +102,10 @@ export async function resolvePublicDestination(
 
   let addresses: ResolvedAddress[];
   try {
-    addresses = await resolver(hostname, { all: true, verbatim: true });
+    addresses = await withTimeout(
+      resolver(hostname, { all: true, verbatim: true }),
+      REQUEST_TIMEOUT_MS
+    );
   } catch {
     throw new Error("HTTP agent destination could not be resolved");
   }
@@ -164,14 +208,19 @@ export async function requestPublicJson(
       throw new Error(`HTTP agent returned too many redirects`);
     }
     const redirectUrl = new URL(response.location, destination.url);
+    const redirectHeaders = headersForRedirect(
+      options.headers,
+      redirectUrl.origin !== destination.url.origin
+    );
     const preserveBody = response.statusCode === 307 || response.statusCode === 308;
     return requestPublicJson(
       redirectUrl.toString(),
       preserveBody
-        ? options
+        ? { ...options, headers: redirectHeaders }
         : {
             ...options,
             body: undefined,
+            headers: redirectHeaders,
             method: "GET",
           },
       redirectCount + 1

--- a/mcp-server/tsup.config.ts
+++ b/mcp-server/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig([
     dts: true,
     // Source-only workspace package — must be bundled, not externalized,
     // since the published npm package has no runtime dep on it.
-    noExternal: ["@langwatch/handled-error"],
+    noExternal: ["@langwatch/handled-error", "@langwatch/ssrf"],
     sourcemap: true,
   },
 ]);

--- a/specs/security/mcp-documentation-fetch-hardening.feature
+++ b/specs/security/mcp-documentation-fetch-hardening.feature
@@ -1,0 +1,89 @@
+Feature: MCP outbound request and browser capability hardening
+  As a LangWatch operator
+  I want documentation tools and browser responses to follow least privilege
+  So that authenticated callers cannot turn LangWatch into a network proxy
+  and browser features are disabled unless the application needs them
+
+  Rule: MCP documentation tools fetch only their trusted documentation namespace
+
+    @integration @regression
+    Scenario Outline: A documentation tool accepts its own trusted HTTPS pages
+      Given the MCP tool "<tool>" is available
+      When it receives the URL "<url>"
+      Then it fetches the documentation page with redirects disabled
+
+      Examples:
+        | tool                 | url                                             |
+        | fetch_langwatch_docs | https://langwatch.ai/docs/observability/tracing |
+        | fetch_scenario_docs  | https://langwatch.ai/scenario/guides/quickstart |
+
+    @integration @regression
+    Scenario Outline: A documentation tool rejects non-HTTPS and untrusted hosts
+      Given the MCP tool "<tool>" is available
+      When it receives the URL "<url>"
+      Then it returns a validation error
+      And LangWatch makes no outbound request to that URL
+
+      Examples:
+        | tool                 | url                                           |
+        | fetch_langwatch_docs | http://169.254.169.254/latest/meta-data/      |
+        | fetch_langwatch_docs | https://langwatch.ai.attacker.example/docs/x |
+        | fetch_langwatch_docs | https://user@attacker.example/docs/x         |
+        | fetch_scenario_docs  | http://127.0.0.1:8080/secrets                 |
+        | fetch_scenario_docs  | file:///etc/passwd                            |
+
+    @unit @regression
+    Scenario Outline: A documentation tool rejects a trusted host outside its namespace
+      Given the MCP tool "<tool>" is available
+      When it receives the URL "<url>"
+      Then it returns a validation error
+
+      Examples:
+        | tool                 | url                                      |
+        | fetch_langwatch_docs | https://langwatch.ai/scenario/llms.txt   |
+        | fetch_scenario_docs  | https://langwatch.ai/docs/llms.txt       |
+        | fetch_langwatch_docs | https://langwatch.ai/docs-evil/page.md   |
+        | fetch_scenario_docs  | https://langwatch.ai/scenario-evil/x.md  |
+
+    @integration @regression
+    Scenario: Documentation fetches do not follow redirects
+      Given a trusted documentation URL returns an HTTP redirect
+      When an MCP documentation tool fetches that URL
+      Then the redirect is not followed
+      And no response body from the redirect destination is returned
+
+  Rule: Application responses explicitly disable unused browser capabilities
+
+    @integration @regression
+    Scenario: Production HTTP responses include the Permissions-Policy header
+      Given LangWatch is running in production mode
+      When a client requests the application root
+      Then the response contains the Permissions-Policy header
+      And geolocation is disabled
+      And microphone is disabled
+      And camera is disabled
+      And payment is disabled
+      And USB is disabled
+
+  Rule: Other MCP HTTP tools cannot reach non-public destinations
+
+    @integration @regression
+    Scenario Outline: Running an HTTP agent rejects unsafe destinations
+      Given a saved HTTP agent targets "<url>"
+      When the MCP tool runs that agent
+      Then it returns a validation error
+      And LangWatch makes no outbound request to that URL
+
+      Examples:
+        | url                                      |
+        | http://127.0.0.1:8080/secrets           |
+        | http://169.254.169.254/latest/meta-data/ |
+        | http://10.0.0.1/internal                 |
+
+    @integration @regression
+    Scenario: HTTP agent redirects are revalidated
+      Given a saved HTTP agent targets a public URL
+      And that URL redirects to a private destination
+      When the MCP tool runs that agent
+      Then it returns a validation error
+      And LangWatch does not request the private destination


### PR DESCRIPTION
## Summary

- restrict both MCP documentation fetch tools to the exact trusted HTTPS origin and their own documentation namespaces
- disable redirects, reject failed or non-document responses, and cap documentation responses at 2 MiB
- harden the saved HTTP agent request path found during the outbound-request sweep by rejecting non-public destinations, pinning validated DNS results, and revalidating every redirect
- add a restrictive `Permissions-Policy` header to all application responses without changing the existing CSP or HSTS behavior

## Security behavior

- rejects loopback, private, link-local, metadata, multicast, reserved, and mixed public/private DNS results
- rejects credentials in URLs and non-HTTP(S) schemes
- preserves the original hostname for Host and TLS validation while dialing only the validated IP
- limits HTTP agent responses to 5 MiB with a 30 second timeout
- allows documentation content only from `https://langwatch.ai/docs/` and `https://langwatch.ai/scenario/`

## Verification

- MCP regression suite: 23 files and 431 tests passed
- MCP TypeScript check passed
- MCP production bundle passed and includes the canonical SSRF classifier
- application security-header tests passed
- application source and test typechecks passed
- direct network dogfood fetched both trusted documentation indexes, accepted a public JSON agent endpoint, rejected metadata access, and rejected a public redirect to loopback
- browser QA confirmed the sign-in page renders normally and the API returns:

```text
Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=()
```

![Browser QA sign-in smoke test](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6091/security-hardening-browser-qa.png)

## Sweep

The sweep covered every outbound request in the MCP server. One additional caller-controlled backend request existed in the saved HTTP agent runner and is fixed in this PR. Platform API requests use the operator-configured LangWatch endpoint and do not accept per-call destination URLs.

Related staging deployment PR: https://github.com/langwatch/langwatch-saas/pull/802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Enhancements**
  - Centralized production security header generation with CSP and HSTS, plus a consistent hardened Permissions Policy.
  - Added trusted, HTTPS-only documentation fetching with strict URL validation, redirect blocking, and content/size limits.
  - Introduced globally-routable public HTTP request handling with DNS validation, timeouts, size caps, fail-closed behavior, and safer redirect/header handling; reused it across agent HTTP execution.
- **Reliability**
  - Improved MCP documentation tool implementations to use the shared validated fetching helper.
- **Tests**
  - Expanded unit and integration coverage for documentation and public HTTP security, including new end-to-end security scenarios.
- **Build/Chores**
  - Updated workspace/deps and bundling configuration to include the shared SSRF package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->