### PR TITLE
perf(evaluations): bound online evaluation performance query

### DIFF
--- a/langwatch/src/components/evaluations/OnlineEvaluationsTable.tsx
+++ b/langwatch/src/components/evaluations/OnlineEvaluationsTable.tsx
@@ -150,7 +150,7 @@ export const OnlineEvaluationsTable = ({
                 </Link>
               ) : (
                 <Text textStyle="sm" color="fg.muted">
-                  Analytics unavailable
+                  Analytics access required
                 </Text>
               )}
             </Table.Cell>

--- a/langwatch/src/components/evaluations/__tests__/OnlineEvaluationsTable.integration.test.tsx
+++ b/langwatch/src/components/evaluations/__tests__/OnlineEvaluationsTable.integration.test.tsx
@@ -174,7 +174,7 @@ describe("<OnlineEvaluationsTable />", () => {
       { wrapper: Wrapper },
     );
 
-    expect(screen.getAllByText("Analytics unavailable")).toHaveLength(3);
+    expect(screen.getAllByText("Analytics access required")).toHaveLength(3);
     expect(
       screen.queryByRole("button", { name: "Actions for Answer quality" }),
     ).not.toBeInTheDocument();

--- a/langwatch/src/components/evaluations/__tests__/OnlineEvaluationsTable.integration.test.tsx
+++ b/langwatch/src/components/evaluations/__tests__/OnlineEvaluationsTable.integration.test.tsx
@@ -164,7 +164,8 @@ describe("<OnlineEvaluationsTable />", () => {
     expect(onEdit).toHaveBeenCalledWith("monitor-down");
   });
 
-  it("does not render an empty action menu when the viewer has no row actions", () => {
+  /** @scenario A viewer without analytics access does not wait forever */
+  it("shows a stable permission state without an empty action menu", () => {
     render(
       <OnlineEvaluationsTable
         {...defaultProps}

--- a/langwatch/src/server/api/routers/monitors.ts
+++ b/langwatch/src/server/api/routers/monitors.ts
@@ -5,8 +5,11 @@ import { customAlphabet } from "nanoid";
 import { ZodError, z } from "zod";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { slugify } from "~/utils/slugify";
-import { getAnalyticsService } from "../../app-layer/analytics";
-import { buildSeriesName } from "../../app-layer/analytics/repositories/_timeseries-row-parser";
+import { AnalyticsClientUnavailableError } from "../../app-layer/analytics";
+import { summarizeMonitorPerformance } from "../../app-layer/evaluations/monitor-performance.service";
+import { MonitorPerformanceClickHouseRepository } from "../../app-layer/evaluations/repositories/monitor-performance.clickhouse.repository";
+import type { ClickHouseClientResolver } from "../../clickhouse/clickhouseClient";
+import { getClickHouseClientForProject } from "../../clickhouse/clickhouseClient";
 import {
   AVAILABLE_EVALUATORS,
   type EvaluatorTypes,
@@ -19,6 +22,18 @@ import { coerceMonitorMappings } from "../../tracer/tracesMapping";
 import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { copyEvaluatorToProject } from "./copyEvaluatorToProject";
+
+const PERFORMANCE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
+
+const resolveClickHouseClient: ClickHouseClientResolver = async (tenantId) => {
+  const client = await getClickHouseClientForProject(tenantId);
+  if (!client) throw new AnalyticsClientUnavailableError(tenantId);
+  return client;
+};
+
+const monitorPerformanceRepository = new MonitorPerformanceClickHouseRepository(
+  resolveClickHouseClient,
+);
 
 /**
  * Generates a unique slug for a monitor.
@@ -123,59 +138,23 @@ export const monitorsRouter = createTRPCRouter({
 
       if (monitors.length === 0) return [];
 
-      const series = monitors.map((monitor) => ({
-        metric: getEvaluatorDefinitions(monitor.checkType)?.isGuardrail
-          ? ("evaluations.evaluation_pass_rate" as const)
-          : ("evaluations.evaluation_score" as const),
-        aggregation: "avg" as const,
-        key: monitor.id,
-        filters: {
-          "evaluations.state": {
-            [monitor.id]: ["processed"],
-          },
-        },
+      const performanceMonitors = monitors.map((monitor) => ({
+        id: monitor.id,
+        isGuardrail:
+          getEvaluatorDefinitions(monitor.checkType)?.isGuardrail ?? false,
       }));
-      const endDate = Date.now();
-      const startDate = endDate - 7 * 24 * 60 * 60 * 1000;
-      const analytics = getAnalyticsService();
-      const baseInput = {
-        projectId: input.projectId,
-        startDate,
-        endDate,
-        filters: {},
-        series,
+      const endMs = Date.now();
+      const currentStartMs = endMs - PERFORMANCE_PERIOD_MS;
+      const buckets = await monitorPerformanceRepository.findBuckets({
+        tenantId: input.projectId,
+        evaluatorIds: monitors.map((monitor) => monitor.id),
+        previousStartMs: currentStartMs - PERFORMANCE_PERIOD_MS,
+        currentStartMs,
+        endMs,
         timeZone: input.timeZone ?? "UTC",
-      };
-
-      const [daily, summary] = await Promise.all([
-        analytics.getTimeseries({ ...baseInput, timeScale: 24 * 60 }),
-        analytics.getTimeseries({ ...baseInput, timeScale: "full" }),
-      ]);
-
-      return monitors.map((monitor, index) => {
-        const metric = series[index]!.metric;
-        const resultKey = buildSeriesName(series[index]!, index);
-        const numberAtKey = (
-          bucket: (typeof daily.currentPeriod)[number] | undefined,
-        ) => {
-          const value = bucket?.[resultKey];
-          return typeof value === "number" && Number.isFinite(value)
-            ? value
-            : null;
-        };
-
-        return {
-          monitorId: monitor.id,
-          metric: metric.endsWith("pass_rate")
-            ? ("pass_rate" as const)
-            : ("score" as const),
-          points: daily.currentPeriod
-            .map((bucket) => numberAtKey(bucket))
-            .filter((value): value is number => value !== null),
-          current: numberAtKey(summary.currentPeriod[0]),
-          previous: numberAtKey(summary.previousPeriod[0]),
-        };
       });
+
+      return summarizeMonitorPerformance(performanceMonitors, buckets);
     }),
   toggle: protectedProcedure
     .input(

--- a/langwatch/src/server/api/routers/monitors.ts
+++ b/langwatch/src/server/api/routers/monitors.ts
@@ -17,6 +17,7 @@ import { enforceLicenseLimit } from "../../license-enforcement";
 import { coerceMonitorMappings } from "../../tracer/tracesMapping";
 import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { currentVsPreviousDates } from "./analytics/common";
 import { copyEvaluatorToProject } from "./copyEvaluatorToProject";
 
 const PERFORMANCE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
@@ -131,10 +132,19 @@ export const monitorsRouter = createTRPCRouter({
       }));
       const endMs = Date.now();
       const currentStartMs = endMs - PERFORMANCE_PERIOD_MS;
+      // The previous window comes from the same helper the analytics page
+      // uses, so the trend comparison covers the exact same runs a user sees
+      // when they open the analytics page for this evaluation.
+      const { previousPeriodStartDate } = currentVsPreviousDates({
+        projectId: input.projectId,
+        startDate: currentStartMs,
+        endDate: endMs,
+        filters: {},
+      });
       return getApp().evaluations.performance.getPerformance({
         tenantId: input.projectId,
         monitors: performanceMonitors,
-        previousStartMs: currentStartMs - PERFORMANCE_PERIOD_MS,
+        previousStartMs: previousPeriodStartDate.getTime(),
         currentStartMs,
         endMs,
         timeZone: input.timeZone ?? "UTC",

--- a/langwatch/src/server/api/routers/monitors.ts
+++ b/langwatch/src/server/api/routers/monitors.ts
@@ -3,13 +3,9 @@ import { EvaluationExecutionMode, Prisma } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { customAlphabet } from "nanoid";
 import { ZodError, z } from "zod";
+import { getApp } from "~/server/app-layer";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { slugify } from "~/utils/slugify";
-import { AnalyticsClientUnavailableError } from "../../app-layer/analytics";
-import { summarizeMonitorPerformance } from "../../app-layer/evaluations/monitor-performance.service";
-import { MonitorPerformanceClickHouseRepository } from "../../app-layer/evaluations/repositories/monitor-performance.clickhouse.repository";
-import type { ClickHouseClientResolver } from "../../clickhouse/clickhouseClient";
-import { getClickHouseClientForProject } from "../../clickhouse/clickhouseClient";
 import {
   AVAILABLE_EVALUATORS,
   type EvaluatorTypes,
@@ -24,16 +20,6 @@ import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { copyEvaluatorToProject } from "./copyEvaluatorToProject";
 
 const PERFORMANCE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
-
-const resolveClickHouseClient: ClickHouseClientResolver = async (tenantId) => {
-  const client = await getClickHouseClientForProject(tenantId);
-  if (!client) throw new AnalyticsClientUnavailableError(tenantId);
-  return client;
-};
-
-const monitorPerformanceRepository = new MonitorPerformanceClickHouseRepository(
-  resolveClickHouseClient,
-);
 
 /**
  * Generates a unique slug for a monitor.
@@ -145,16 +131,14 @@ export const monitorsRouter = createTRPCRouter({
       }));
       const endMs = Date.now();
       const currentStartMs = endMs - PERFORMANCE_PERIOD_MS;
-      const buckets = await monitorPerformanceRepository.findBuckets({
+      return getApp().evaluations.performance.getPerformance({
         tenantId: input.projectId,
-        evaluatorIds: monitors.map((monitor) => monitor.id),
+        monitors: performanceMonitors,
         previousStartMs: currentStartMs - PERFORMANCE_PERIOD_MS,
         currentStartMs,
         endMs,
         timeZone: input.timeZone ?? "UTC",
       });
-
-      return summarizeMonitorPerformance(performanceMonitors, buckets);
     }),
   toggle: protectedProcedure
     .input(

--- a/langwatch/src/server/app-layer/dependencies.ts
+++ b/langwatch/src/server/app-layer/dependencies.ts
@@ -11,34 +11,41 @@ import type { RetroactiveUpdateService } from "../data-retention/retroactive/ret
 import type { EventSourcing } from "../event-sourcing/eventSourcing";
 import type { AppCommands } from "../event-sourcing/pipelineRegistry";
 import type { ExperimentService } from "../experiments/experiment.service";
+import type { EmailSuppressionService } from "./automations/emailSuppression.service";
+import type { TriggerService } from "./automations/trigger.service";
+import type {
+  TestFireResult,
+  TestFireTriggerInput,
+} from "./automations/trigger-template.service";
 import type { BroadcastService } from "./broadcast/broadcast.service";
+import type { CodingAgentSessionService } from "./coding-agent/coding-agent-session.service";
 import type { AppConfig } from "./config";
 import type { DspyStepService } from "./dspy-steps/dspy-step.service";
 import type { EvaluationExecutionService } from "./evaluations/evaluation-execution.service";
 import type { EvaluationRunService } from "./evaluations/evaluation-run.service";
+import type { MonitorPerformanceService } from "./evaluations/monitor-performance.service";
+import type { LangyCredentialService } from "./langy/LangyCredentialService";
+import type { LangyConversationService } from "./langy/langy-conversation.service";
+import type { LangyFeedbackPromptService } from "./langy/langy-feedback-prompt.service";
+import type { LangyGithubInstallationsService } from "./langy/langy-github-installations.service";
+import type { LangyMessageService } from "./langy/langy-message.service";
+import type { LangyTurnService } from "./langy/langy-turn.service";
+import type { BlobStoreService } from "./ops/blob-store.service";
 import type { EventExplorerService } from "./ops/event-explorer.service";
 import type { ManagerExplorerService } from "./ops/manager-explorer.service";
 import type { OpsMetricsCollector } from "./ops/metrics-collector";
 import type { QueueService } from "./ops/queue.service";
-import type { SchedulerOpsService } from "./ops/scheduler-ops.service";
-import type { BlobStoreService } from "./ops/blob-store.service";
 import type { ReplayService } from "./ops/replay.service";
+import type { SchedulerOpsService } from "./ops/scheduler-ops.service";
 import type { OrganizationService } from "./organizations/organization.service";
 import type { PresenceService } from "./presence/presence.service";
 import type { ProjectService } from "./projects/project.service";
-import type { SharedTracePayloadCache } from "./share/shared-trace-cache.service";
 import type { ShareService } from "./share/share.service";
+import type { SharedTracePayloadCache } from "./share/shared-trace-cache.service";
 import type { SimulationRunService } from "./simulations/simulation-run.service";
-import type { LangyConversationService } from "./langy/langy-conversation.service";
-import type { LangyTurnService } from "./langy/langy-turn.service";
-import type { LangyGithubInstallationsService } from "./langy/langy-github-installations.service";
-import type { LangyCredentialService } from "./langy/LangyCredentialService";
-import type { LangyMessageService } from "./langy/langy-message.service";
-import type { LangyFeedbackPromptService } from "./langy/langy-feedback-prompt.service";
 import type { PlanProvider } from "./subscription/plan-provider";
 import type { SubscriptionService } from "./subscription/subscription.service";
 import type { SuiteRunService } from "./suites/suite-run.service";
-import type { CodingAgentSessionService } from "./coding-agent/coding-agent-session.service";
 import type { TopicService } from "./topic-clustering/topic.service";
 import type { TopicClusteringStatusService } from "./topic-clustering/topic-clustering-status.service";
 import type { LogRecordStorageService } from "./traces/log-record-storage.service";
@@ -49,12 +56,6 @@ import type { TokenizerService } from "./traces/tokenizer.service";
 import type { TraceListService } from "./traces/trace-list.service";
 import type { TraceRequestCollectionService } from "./traces/trace-request-collection.service";
 import type { TraceSummaryService } from "./traces/trace-summary.service";
-import type { EmailSuppressionService } from "./automations/emailSuppression.service";
-import type { TriggerService } from "./automations/trigger.service";
-import type {
-  TestFireResult,
-  TestFireTriggerInput,
-} from "./automations/trigger-template.service";
 import type { UsageService } from "./usage/usage.service";
 
 export interface DataRetentionDependencies {
@@ -92,6 +93,7 @@ export interface AppDependencies {
   evaluations: {
     runs: EvaluationRunService;
     execution: EvaluationExecutionService;
+    performance: MonitorPerformanceService;
   };
   dspySteps: {
     steps: DspyStepService;

--- a/langwatch/src/server/app-layer/evaluations/__tests__/monitor-performance.fixtures.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/monitor-performance.fixtures.ts
@@ -1,0 +1,365 @@
+/**
+ * Fixtures and read helpers for the monitor-performance consistency suite:
+ * seeded trace/evaluation rows plus the analytics-page read path
+ * (`ClickHouseLegacyAnalyticsShim`) the suite compares against.
+ *
+ * @see specs/analytics/evaluation-pass-rate-consistency.feature
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import type { SeriesInputType } from "~/server/analytics/registry";
+import { buildSeriesName } from "~/server/app-layer/analytics/repositories/_timeseries-row-parser";
+import { ClickHouseLegacyAnalyticsShim } from "~/server/app-layer/analytics/repositories/legacy.shim";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HALF_DAY_MS = 12 * 60 * 60 * 1000;
+
+export interface SeededEvaluation {
+  traceId: string;
+  /** When the trace occurred; omitted to leave the run without a trace. */
+  traceOccurredAtMs?: number;
+  scheduledAtMs: number;
+  evaluatorId: string;
+  score: number | null;
+  passed: number | null;
+  status?: string;
+  evaluationId?: string;
+  updatedAtMs?: number;
+}
+
+export const traceSummaryRow = ({
+  tenantId,
+  traceId,
+  occurredAtMs,
+}: {
+  tenantId: string;
+  traceId: string;
+  occurredAtMs: number;
+}) => {
+  const occurredAt = new Date(occurredAtMs);
+  return {
+    ProjectionId: `projection-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: occurredAt,
+    CreatedAt: occurredAt,
+    UpdatedAt: occurredAt,
+    ComputedIOSchemaVersion: "",
+    ComputedInput: "in",
+    ComputedOutput: "out",
+    TimeToFirstTokenMs: 50,
+    TimeToLastTokenMs: 200,
+    TotalDurationMs: 200,
+    TokensPerSecond: 100,
+    SpanCount: 1,
+    ContainsErrorStatus: 0,
+    ContainsOKStatus: 1,
+    ErrorMessage: null,
+    Models: ["gpt-5-mini"],
+    TotalCost: 0.01,
+    TokensEstimated: false,
+    TotalPromptTokenCount: 100,
+    TotalCompletionTokenCount: 50,
+    OutputFromRootSpan: 0,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: 0,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+  };
+};
+
+export const evaluationRunRow = ({
+  tenantId,
+  seed: {
+    traceId,
+    scheduledAtMs,
+    evaluatorId,
+    score,
+    passed,
+    status = "processed",
+    evaluationId = `eval-${nanoid()}`,
+    updatedAtMs = scheduledAtMs,
+  },
+}: {
+  tenantId: string;
+  seed: SeededEvaluation;
+}) => ({
+  ProjectionId: `projection-${nanoid()}`,
+  TenantId: tenantId,
+  EvaluationId: evaluationId,
+  Version: "1",
+  EvaluatorId: evaluatorId,
+  EvaluatorType: "langevals/test",
+  TraceId: traceId,
+  Status: status,
+  Score: score,
+  Passed: passed,
+  Label: null,
+  ScheduledAt: new Date(scheduledAtMs),
+  UpdatedAt: new Date(updatedAtMs),
+  LastProcessedEventId: `event-${nanoid()}`,
+});
+
+/**
+ * One dataset exercising every way the two surfaces could diverge: uneven
+ * daily volumes, a corrected revision, an evaluation scheduled in the current
+ * window for a previous-window trace, a non-processed run, a run without a
+ * trace, and a trace outside the whole window.
+ */
+export const buildSeedMatrix = ({
+  tenantId,
+  scoreEvaluatorId,
+  guardrailEvaluatorId,
+  currentStartMs,
+  previousStartMs,
+}: {
+  tenantId: string;
+  scoreEvaluatorId: string;
+  guardrailEvaluatorId: string;
+  currentStartMs: number;
+  previousStartMs: number;
+}): SeededEvaluation[] => {
+  const correctedEvaluationId = `corrected-${nanoid()}`;
+  const correctedTraceId = `${tenantId}-trace-corrected`;
+  const day1Ms = currentStartMs + DAY_MS + HALF_DAY_MS;
+  const day2Ms = currentStartMs + 2 * DAY_MS + HALF_DAY_MS;
+  const day3Ms = currentStartMs + 3 * DAY_MS + HALF_DAY_MS;
+
+  return [
+    // Day 1 carries uneven scores so the daily average differs from the
+    // run-weighted period average.
+    {
+      traceId: `${tenantId}-trace-1`,
+      traceOccurredAtMs: day1Ms,
+      scheduledAtMs: day1Ms + 60_000,
+      evaluatorId: scoreEvaluatorId,
+      score: 0.2,
+      passed: 0,
+    },
+    {
+      traceId: `${tenantId}-trace-2`,
+      traceOccurredAtMs: day1Ms,
+      scheduledAtMs: day1Ms + 120_000,
+      evaluatorId: scoreEvaluatorId,
+      score: 0.8,
+      passed: 1,
+    },
+    {
+      traceId: `${tenantId}-trace-3`,
+      traceOccurredAtMs: day2Ms,
+      scheduledAtMs: day2Ms + 60_000,
+      evaluatorId: scoreEvaluatorId,
+      score: 1,
+      passed: 1,
+    },
+    // A corrected evaluation: only the latest revision may count.
+    {
+      traceId: correctedTraceId,
+      traceOccurredAtMs: day3Ms,
+      scheduledAtMs: day3Ms + 60_000,
+      evaluatorId: scoreEvaluatorId,
+      score: 0.1,
+      passed: 0,
+      evaluationId: correctedEvaluationId,
+    },
+    {
+      traceId: correctedTraceId,
+      scheduledAtMs: day3Ms + 60_000,
+      evaluatorId: scoreEvaluatorId,
+      score: 0.9,
+      passed: 1,
+      evaluationId: correctedEvaluationId,
+      updatedAtMs: day3Ms + 61_000,
+    },
+    // Previous-period run.
+    {
+      traceId: `${tenantId}-trace-previous`,
+      traceOccurredAtMs: currentStartMs - 2 * DAY_MS,
+      scheduledAtMs: currentStartMs - 2 * DAY_MS + 60_000,
+      evaluatorId: scoreEvaluatorId,
+      score: 0.4,
+      passed: 0,
+    },
+    // The trace occurred in the previous period but the evaluation only ran
+    // during the current one: both surfaces count it in the previous period
+    // because a run belongs to the day its trace occurred.
+    {
+      traceId: `${tenantId}-trace-late-eval`,
+      traceOccurredAtMs: currentStartMs - DAY_MS,
+      scheduledAtMs: currentStartMs + 4 * DAY_MS,
+      evaluatorId: scoreEvaluatorId,
+      score: 0.6,
+      passed: 1,
+    },
+    // Non-processed run: excluded everywhere.
+    {
+      traceId: `${tenantId}-trace-error`,
+      traceOccurredAtMs: day2Ms,
+      scheduledAtMs: day2Ms + 90_000,
+      evaluatorId: scoreEvaluatorId,
+      score: null,
+      passed: null,
+      status: "error",
+    },
+    // Run without any trace summary: excluded everywhere.
+    {
+      traceId: `${tenantId}-trace-missing`,
+      scheduledAtMs: day2Ms + 100_000,
+      evaluatorId: scoreEvaluatorId,
+      score: 0,
+      passed: 0,
+    },
+    // Trace outside the whole comparison window: excluded everywhere even
+    // though the evaluation was scheduled inside the current period.
+    {
+      traceId: `${tenantId}-trace-out-of-window`,
+      traceOccurredAtMs: previousStartMs - DAY_MS,
+      scheduledAtMs: currentStartMs + DAY_MS,
+      evaluatorId: scoreEvaluatorId,
+      score: 0.05,
+      passed: 0,
+    },
+    // Guardrail runs.
+    {
+      traceId: `${tenantId}-trace-guard-1`,
+      traceOccurredAtMs: day1Ms,
+      scheduledAtMs: day1Ms + 60_000,
+      evaluatorId: guardrailEvaluatorId,
+      score: null,
+      passed: 1,
+    },
+    {
+      traceId: `${tenantId}-trace-guard-2`,
+      traceOccurredAtMs: day1Ms,
+      scheduledAtMs: day1Ms + 120_000,
+      evaluatorId: guardrailEvaluatorId,
+      score: null,
+      passed: 0,
+    },
+    {
+      traceId: `${tenantId}-trace-guard-previous`,
+      traceOccurredAtMs: currentStartMs - 3 * DAY_MS,
+      scheduledAtMs: currentStartMs - 3 * DAY_MS + 60_000,
+      evaluatorId: guardrailEvaluatorId,
+      score: null,
+      passed: 1,
+    },
+    {
+      traceId: `${tenantId}-trace-guard-error`,
+      traceOccurredAtMs: day2Ms,
+      scheduledAtMs: day2Ms + 60_000,
+      evaluatorId: guardrailEvaluatorId,
+      score: null,
+      passed: null,
+      status: "error",
+    },
+  ];
+};
+
+export const seedMonitorPerformance = async ({
+  client,
+  tenantId,
+  seeded,
+}: {
+  client: ClickHouseClient;
+  tenantId: string;
+  seeded: SeededEvaluation[];
+}) => {
+  const traceRows = seeded
+    .filter((evaluation) => evaluation.traceOccurredAtMs !== undefined)
+    .map((evaluation) =>
+      traceSummaryRow({
+        tenantId,
+        traceId: evaluation.traceId,
+        occurredAtMs: evaluation.traceOccurredAtMs!,
+      }),
+    );
+  const evaluationRows = seeded.map((seed) =>
+    evaluationRunRow({ tenantId, seed }),
+  );
+
+  await client.insert({
+    table: "trace_summaries",
+    values: traceRows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+  await client.insert({
+    table: "evaluation_runs",
+    values: evaluationRows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+};
+
+export type AnalyticsPageMetric =
+  | "evaluations.evaluation_score"
+  | "evaluations.evaluation_pass_rate";
+
+const finiteOrNull = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+const analyticsPageSeries = ({
+  evaluatorId,
+  metric,
+}: {
+  evaluatorId: string;
+  metric: AnalyticsPageMetric;
+}): SeriesInputType => ({
+  metric,
+  aggregation: "avg",
+  key: evaluatorId,
+  filters: {
+    "evaluations.state": {
+      [evaluatorId]: ["processed"],
+    },
+  },
+});
+
+/**
+ * Reads the evaluator exactly the way the analytics page does: the legacy
+ * shim with per-series processed filters, one daily read for the chart and
+ * one full-period read for the headline.
+ */
+export const readAnalyticsPageNumbers = async ({
+  client,
+  tenantId,
+  evaluatorId,
+  metric,
+  currentStartMs,
+  endMs,
+}: {
+  client: ClickHouseClient;
+  tenantId: string;
+  evaluatorId: string;
+  metric: AnalyticsPageMetric;
+  currentStartMs: number;
+  endMs: number;
+}) => {
+  const shim = new ClickHouseLegacyAnalyticsShim(async () => client);
+  const series = analyticsPageSeries({ evaluatorId, metric });
+  const baseInput = {
+    projectId: tenantId,
+    startDate: currentStartMs,
+    endDate: endMs,
+    filters: {},
+    series: [series],
+    timeZone: "UTC",
+  };
+  const [daily, full] = await Promise.all([
+    shim.run({ ...baseInput, timeScale: 24 * 60 }),
+    shim.run({ ...baseInput, timeScale: "full" }),
+  ]);
+  const key = buildSeriesName(series, 0);
+
+  return {
+    current: finiteOrNull(full.currentPeriod[0]?.[key]),
+    previous: finiteOrNull(full.previousPeriod[0]?.[key]),
+    dailyValues: daily.currentPeriod
+      .map((bucket) => finiteOrNull(bucket[key]))
+      .filter((value): value is number => value !== null),
+  };
+};

--- a/langwatch/src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts
@@ -1,0 +1,235 @@
+/**
+ * @see specs/analytics/evaluation-pass-rate-consistency.feature
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { deleteEvaluationRunsByTenant } from "~/server/analytics/clickhouse/__tests__/test-utils/clickhouse-cleanup";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { summarizeMonitorPerformance } from "../monitor-performance.service";
+import { MonitorPerformanceClickHouseRepository } from "../repositories/monitor-performance.clickhouse.repository";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const tenantId = `test-monitor-performance-${nanoid()}`;
+const scoreEvaluatorId = `${tenantId}-score`;
+const guardrailEvaluatorId = `${tenantId}-guardrail`;
+const currentStartMs = Date.now() - 7 * DAY_MS;
+const previousStartMs = currentStartMs - 7 * DAY_MS;
+const endMs = currentStartMs + 7 * DAY_MS;
+
+let clickHouse: ClickHouseClient;
+let queryCount = 0;
+
+const evaluationRun = ({
+  evaluationId = `eval-${nanoid()}`,
+  evaluatorId,
+  scheduledAtMs,
+  score,
+  passed,
+  status = "processed",
+  updatedAtMs = scheduledAtMs,
+}: {
+  evaluationId?: string;
+  evaluatorId: string;
+  scheduledAtMs: number;
+  score: number | null;
+  passed: number | null;
+  status?: string;
+  updatedAtMs?: number;
+}) => ({
+  ProjectionId: `projection-${nanoid()}`,
+  TenantId: tenantId,
+  EvaluationId: evaluationId,
+  Version: "1",
+  EvaluatorId: evaluatorId,
+  EvaluatorType: "langevals/test",
+  TraceId: `trace-${nanoid()}`,
+  Status: status,
+  Score: score,
+  Passed: passed,
+  Label: null,
+  ScheduledAt: new Date(scheduledAtMs),
+  UpdatedAt: new Date(updatedAtMs),
+  LastProcessedEventId: `event-${nanoid()}`,
+});
+
+const countingClient = () =>
+  new Proxy(clickHouse, {
+    get(target, property, receiver) {
+      if (property === "query") {
+        return (params: Parameters<ClickHouseClient["query"]>[0]) => {
+          queryCount++;
+          return target.query(params);
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  clickHouse = containers.clickHouseClient;
+
+  const correctedEvaluationId = `corrected-${nanoid()}`;
+  const rows = [
+    evaluationRun({
+      evaluatorId: scoreEvaluatorId,
+      scheduledAtMs: currentStartMs + DAY_MS,
+      score: 0.2,
+      passed: 0,
+    }),
+    evaluationRun({
+      evaluatorId: scoreEvaluatorId,
+      scheduledAtMs: currentStartMs + DAY_MS,
+      score: 0.8,
+      passed: 1,
+    }),
+    evaluationRun({
+      evaluatorId: scoreEvaluatorId,
+      scheduledAtMs: currentStartMs + 2 * DAY_MS,
+      score: 1,
+      passed: 1,
+    }),
+    evaluationRun({
+      evaluatorId: scoreEvaluatorId,
+      scheduledAtMs: currentStartMs - DAY_MS,
+      score: 0.4,
+      passed: 0,
+    }),
+    evaluationRun({
+      evaluationId: correctedEvaluationId,
+      evaluatorId: scoreEvaluatorId,
+      scheduledAtMs: currentStartMs + 3 * DAY_MS,
+      score: 0.1,
+      passed: 0,
+    }),
+    evaluationRun({
+      evaluationId: correctedEvaluationId,
+      evaluatorId: scoreEvaluatorId,
+      scheduledAtMs: currentStartMs + 3 * DAY_MS,
+      score: 0.9,
+      passed: 1,
+      updatedAtMs: currentStartMs + 3 * DAY_MS + 1_000,
+    }),
+    evaluationRun({
+      evaluatorId: guardrailEvaluatorId,
+      scheduledAtMs: currentStartMs + DAY_MS,
+      score: null,
+      passed: 1,
+    }),
+    evaluationRun({
+      evaluatorId: guardrailEvaluatorId,
+      scheduledAtMs: currentStartMs + DAY_MS,
+      score: null,
+      passed: 0,
+    }),
+    evaluationRun({
+      evaluatorId: guardrailEvaluatorId,
+      scheduledAtMs: currentStartMs - DAY_MS,
+      score: null,
+      passed: 1,
+    }),
+    evaluationRun({
+      evaluatorId: guardrailEvaluatorId,
+      scheduledAtMs: currentStartMs + 2 * DAY_MS,
+      score: null,
+      passed: null,
+      status: "error",
+    }),
+    evaluationRun({
+      evaluatorId: scoreEvaluatorId,
+      scheduledAtMs: previousStartMs - DAY_MS,
+      score: 0,
+      passed: 0,
+    }),
+  ];
+
+  await clickHouse.insert({
+    table: "evaluation_runs",
+    values: rows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}, 180_000);
+
+afterAll(async () => {
+  await deleteEvaluationRunsByTenant({ client: clickHouse, tenantId });
+  await stopTestContainers();
+});
+
+describe("online evaluation monitor performance", () => {
+  /** @scenario Performance for every monitor is read in one bounded query */
+  it("loads current and previous performance with one real ClickHouse query", async () => {
+    queryCount = 0;
+    const repository = new MonitorPerformanceClickHouseRepository(async () =>
+      countingClient(),
+    );
+
+    const buckets = await repository.findBuckets({
+      tenantId,
+      evaluatorIds: [scoreEvaluatorId, guardrailEvaluatorId],
+      previousStartMs,
+      currentStartMs,
+      endMs,
+      timeZone: "UTC",
+    });
+    const performance = summarizeMonitorPerformance(
+      [
+        { id: scoreEvaluatorId, isGuardrail: false },
+        { id: guardrailEvaluatorId, isGuardrail: true },
+      ],
+      buckets,
+    );
+
+    expect(queryCount).toBe(1);
+    expect(performance).toEqual([
+      {
+        monitorId: scoreEvaluatorId,
+        metric: "score",
+        points: [0.5, 1, 0.9],
+        current: 0.725,
+        previous: 0.4,
+      },
+      {
+        monitorId: guardrailEvaluatorId,
+        metric: "pass_rate",
+        points: [0.5],
+        current: 0.5,
+        previous: 1,
+      },
+    ]);
+  });
+
+  it("returns an explicit no-data result for a monitor without runs", async () => {
+    const repository = new MonitorPerformanceClickHouseRepository(
+      async () => clickHouse,
+    );
+    const buckets = await repository.findBuckets({
+      tenantId,
+      evaluatorIds: [`${tenantId}-empty`],
+      previousStartMs,
+      currentStartMs,
+      endMs,
+      timeZone: "UTC",
+    });
+
+    expect(
+      summarizeMonitorPerformance(
+        [{ id: `${tenantId}-empty`, isGuardrail: false }],
+        buckets,
+      ),
+    ).toEqual([
+      {
+        monitorId: `${tenantId}-empty`,
+        metric: "score",
+        points: [],
+        current: null,
+        previous: null,
+      },
+    ]);
+  });
+});

--- a/langwatch/src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts
@@ -3,19 +3,15 @@
  *
  * The Online Evaluations table and the analytics page must publish the same
  * numbers. The analytics page reads evaluations through the trace-anchored
- * legacy path (`ClickHouseLegacyAnalyticsShim`), so besides pinning the
- * table's own expected values, this suite runs the shim with the exact
- * series the analytics page issues and asserts both read paths agree on the
- * headline, the previous period, and every daily bucket.
+ * legacy path, so besides pinning the table's own expected values, this
+ * suite reads the seeded dataset through both paths and asserts they agree
+ * on the headline, the previous period, and every daily bucket.
  */
 import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { deleteEvaluationRunsByTenant } from "~/server/analytics/clickhouse/__tests__/test-utils/clickhouse-cleanup";
-import type { SeriesInputType } from "~/server/analytics/registry";
 import { currentVsPreviousDates } from "~/server/api/routers/analytics/common";
-import { buildSeriesName } from "~/server/app-layer/analytics/repositories/_timeseries-row-parser";
-import { ClickHouseLegacyAnalyticsShim } from "~/server/app-layer/analytics/repositories/legacy.shim";
 import {
   cleanupTestData,
   startTestContainers,
@@ -26,9 +22,13 @@ import {
   summarizeMonitorPerformance,
 } from "../monitor-performance.service";
 import { MonitorPerformanceClickHouseRepository } from "../repositories/monitor-performance.clickhouse.repository";
+import {
+  buildSeedMatrix,
+  readAnalyticsPageNumbers,
+  seedMonitorPerformance,
+} from "./monitor-performance.fixtures";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const HALF_DAY_MS = 12 * 60 * 60 * 1000;
 const tenantId = `test-monitor-performance-${nanoid()}`;
 const scoreEvaluatorId = `${tenantId}-score`;
 const guardrailEvaluatorId = `${tenantId}-guardrail`;
@@ -46,87 +46,6 @@ const previousStartMs = currentVsPreviousDates({
 let clickHouse: ClickHouseClient;
 let queryCount = 0;
 
-interface SeededEvaluation {
-  traceId: string;
-  /** When the trace occurred; omitted to leave the run without a trace. */
-  traceOccurredAtMs?: number;
-  scheduledAtMs: number;
-  evaluatorId: string;
-  score: number | null;
-  passed: number | null;
-  status?: string;
-  evaluationId?: string;
-  updatedAtMs?: number;
-}
-
-const traceSummaryRow = ({
-  traceId,
-  occurredAtMs,
-}: {
-  traceId: string;
-  occurredAtMs: number;
-}) => {
-  const occurredAt = new Date(occurredAtMs);
-  return {
-    ProjectionId: `projection-${nanoid()}`,
-    TenantId: tenantId,
-    TraceId: traceId,
-    Version: "v1",
-    Attributes: {},
-    OccurredAt: occurredAt,
-    CreatedAt: occurredAt,
-    UpdatedAt: occurredAt,
-    ComputedIOSchemaVersion: "",
-    ComputedInput: "in",
-    ComputedOutput: "out",
-    TimeToFirstTokenMs: 50,
-    TimeToLastTokenMs: 200,
-    TotalDurationMs: 200,
-    TokensPerSecond: 100,
-    SpanCount: 1,
-    ContainsErrorStatus: 0,
-    ContainsOKStatus: 1,
-    ErrorMessage: null,
-    Models: ["gpt-5-mini"],
-    TotalCost: 0.01,
-    TokensEstimated: false,
-    TotalPromptTokenCount: 100,
-    TotalCompletionTokenCount: 50,
-    OutputFromRootSpan: 0,
-    OutputSpanEndTimeMs: 0,
-    BlockedByGuardrail: 0,
-    TopicId: null,
-    SubTopicId: null,
-    HasAnnotation: null,
-  };
-};
-
-const evaluationRunRow = ({
-  traceId,
-  scheduledAtMs,
-  evaluatorId,
-  score,
-  passed,
-  status = "processed",
-  evaluationId = `eval-${nanoid()}`,
-  updatedAtMs = scheduledAtMs,
-}: SeededEvaluation) => ({
-  ProjectionId: `projection-${nanoid()}`,
-  TenantId: tenantId,
-  EvaluationId: evaluationId,
-  Version: "1",
-  EvaluatorId: evaluatorId,
-  EvaluatorType: "langevals/test",
-  TraceId: traceId,
-  Status: status,
-  Score: score,
-  Passed: passed,
-  Label: null,
-  ScheduledAt: new Date(scheduledAtMs),
-  UpdatedAt: new Date(updatedAtMs),
-  LastProcessedEventId: `event-${nanoid()}`,
-});
-
 const countingClient = () =>
   new Proxy(clickHouse, {
     get(target, property, receiver) {
@@ -140,62 +59,6 @@ const countingClient = () =>
       return typeof value === "function" ? value.bind(target) : value;
     },
   });
-
-const finiteOrNull = (value: unknown): number | null =>
-  typeof value === "number" && Number.isFinite(value) ? value : null;
-
-type AnalyticsPageMetric =
-  | "evaluations.evaluation_score"
-  | "evaluations.evaluation_pass_rate";
-
-const analyticsPageSeries = ({
-  evaluatorId,
-  metric,
-}: {
-  evaluatorId: string;
-  metric: AnalyticsPageMetric;
-}): SeriesInputType => ({
-  metric,
-  aggregation: "avg",
-  key: evaluatorId,
-  filters: {
-    "evaluations.state": {
-      [evaluatorId]: ["processed"],
-    },
-  },
-});
-
-const readAnalyticsPageNumbers = async ({
-  evaluatorId,
-  metric,
-}: {
-  evaluatorId: string;
-  metric: AnalyticsPageMetric;
-}) => {
-  const shim = new ClickHouseLegacyAnalyticsShim(async () => clickHouse);
-  const series = analyticsPageSeries({ evaluatorId, metric });
-  const baseInput = {
-    projectId: tenantId,
-    startDate: currentStartMs,
-    endDate: endMs,
-    filters: {},
-    series: [series],
-    timeZone: "UTC",
-  };
-  const [daily, full] = await Promise.all([
-    shim.run({ ...baseInput, timeScale: 24 * 60 }),
-    shim.run({ ...baseInput, timeScale: "full" }),
-  ]);
-  const key = buildSeriesName(series, 0);
-
-  return {
-    current: finiteOrNull(full.currentPeriod[0]?.[key]),
-    previous: finiteOrNull(full.previousPeriod[0]?.[key]),
-    dailyValues: daily.currentPeriod
-      .map((bucket) => finiteOrNull(bucket[key]))
-      .filter((value): value is number => value !== null),
-  };
-};
 
 const readTablePerformance = async () => {
   const service = new MonitorPerformanceService(
@@ -239,163 +102,16 @@ beforeAll(async () => {
   const containers = await startTestContainers();
   clickHouse = containers.clickHouseClient;
 
-  const correctedEvaluationId = `corrected-${nanoid()}`;
-  const correctedTraceId = `${tenantId}-trace-corrected`;
-  const day1Ms = currentStartMs + DAY_MS + HALF_DAY_MS;
-  const day2Ms = currentStartMs + 2 * DAY_MS + HALF_DAY_MS;
-  const day3Ms = currentStartMs + 3 * DAY_MS + HALF_DAY_MS;
-
-  const seeded: SeededEvaluation[] = [
-    // Day 1 carries uneven scores so the daily average differs from the
-    // run-weighted period average.
-    {
-      traceId: `${tenantId}-trace-1`,
-      traceOccurredAtMs: day1Ms,
-      scheduledAtMs: day1Ms + 60_000,
-      evaluatorId: scoreEvaluatorId,
-      score: 0.2,
-      passed: 0,
-    },
-    {
-      traceId: `${tenantId}-trace-2`,
-      traceOccurredAtMs: day1Ms,
-      scheduledAtMs: day1Ms + 120_000,
-      evaluatorId: scoreEvaluatorId,
-      score: 0.8,
-      passed: 1,
-    },
-    {
-      traceId: `${tenantId}-trace-3`,
-      traceOccurredAtMs: day2Ms,
-      scheduledAtMs: day2Ms + 60_000,
-      evaluatorId: scoreEvaluatorId,
-      score: 1,
-      passed: 1,
-    },
-    // A corrected evaluation: only the latest revision may count.
-    {
-      traceId: correctedTraceId,
-      traceOccurredAtMs: day3Ms,
-      scheduledAtMs: day3Ms + 60_000,
-      evaluatorId: scoreEvaluatorId,
-      score: 0.1,
-      passed: 0,
-      evaluationId: correctedEvaluationId,
-    },
-    {
-      traceId: correctedTraceId,
-      scheduledAtMs: day3Ms + 60_000,
-      evaluatorId: scoreEvaluatorId,
-      score: 0.9,
-      passed: 1,
-      evaluationId: correctedEvaluationId,
-      updatedAtMs: day3Ms + 61_000,
-    },
-    // Previous-period run.
-    {
-      traceId: `${tenantId}-trace-previous`,
-      traceOccurredAtMs: currentStartMs - 2 * DAY_MS,
-      scheduledAtMs: currentStartMs - 2 * DAY_MS + 60_000,
-      evaluatorId: scoreEvaluatorId,
-      score: 0.4,
-      passed: 0,
-    },
-    // The trace occurred in the previous period but the evaluation only ran
-    // during the current one: both surfaces count it in the previous period
-    // because a run belongs to the day its trace occurred.
-    {
-      traceId: `${tenantId}-trace-late-eval`,
-      traceOccurredAtMs: currentStartMs - DAY_MS,
-      scheduledAtMs: currentStartMs + 4 * DAY_MS,
-      evaluatorId: scoreEvaluatorId,
-      score: 0.6,
-      passed: 1,
-    },
-    // Non-processed run: excluded everywhere.
-    {
-      traceId: `${tenantId}-trace-error`,
-      traceOccurredAtMs: day2Ms,
-      scheduledAtMs: day2Ms + 90_000,
-      evaluatorId: scoreEvaluatorId,
-      score: null,
-      passed: null,
-      status: "error",
-    },
-    // Run without any trace summary: excluded everywhere.
-    {
-      traceId: `${tenantId}-trace-missing`,
-      scheduledAtMs: day2Ms + 100_000,
-      evaluatorId: scoreEvaluatorId,
-      score: 0,
-      passed: 0,
-    },
-    // Trace outside the whole comparison window: excluded everywhere even
-    // though the evaluation was scheduled inside the current period.
-    {
-      traceId: `${tenantId}-trace-out-of-window`,
-      traceOccurredAtMs: previousStartMs - DAY_MS,
-      scheduledAtMs: currentStartMs + DAY_MS,
-      evaluatorId: scoreEvaluatorId,
-      score: 0.05,
-      passed: 0,
-    },
-    // Guardrail runs.
-    {
-      traceId: `${tenantId}-trace-guard-1`,
-      traceOccurredAtMs: day1Ms,
-      scheduledAtMs: day1Ms + 60_000,
-      evaluatorId: guardrailEvaluatorId,
-      score: null,
-      passed: 1,
-    },
-    {
-      traceId: `${tenantId}-trace-guard-2`,
-      traceOccurredAtMs: day1Ms,
-      scheduledAtMs: day1Ms + 120_000,
-      evaluatorId: guardrailEvaluatorId,
-      score: null,
-      passed: 0,
-    },
-    {
-      traceId: `${tenantId}-trace-guard-previous`,
-      traceOccurredAtMs: currentStartMs - 3 * DAY_MS,
-      scheduledAtMs: currentStartMs - 3 * DAY_MS + 60_000,
-      evaluatorId: guardrailEvaluatorId,
-      score: null,
-      passed: 1,
-    },
-    {
-      traceId: `${tenantId}-trace-guard-error`,
-      traceOccurredAtMs: day2Ms,
-      scheduledAtMs: day2Ms + 60_000,
-      evaluatorId: guardrailEvaluatorId,
-      score: null,
-      passed: null,
-      status: "error",
-    },
-  ];
-
-  const traceRows = seeded
-    .filter((evaluation) => evaluation.traceOccurredAtMs !== undefined)
-    .map((evaluation) =>
-      traceSummaryRow({
-        traceId: evaluation.traceId,
-        occurredAtMs: evaluation.traceOccurredAtMs!,
-      }),
-    );
-  const evaluationRows = seeded.map(evaluationRunRow);
-
-  await clickHouse.insert({
-    table: "trace_summaries",
-    values: traceRows,
-    format: "JSONEachRow",
-    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
-  });
-  await clickHouse.insert({
-    table: "evaluation_runs",
-    values: evaluationRows,
-    format: "JSONEachRow",
-    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  await seedMonitorPerformance({
+    client: clickHouse,
+    tenantId,
+    seeded: buildSeedMatrix({
+      tenantId,
+      scoreEvaluatorId,
+      guardrailEvaluatorId,
+      currentStartMs,
+      previousStartMs,
+    }),
   });
 }, 180_000);
 
@@ -478,8 +194,12 @@ describe("online evaluation monitor performance", () => {
     it("reports the same score values as the analytics page", async () => {
       const [scorePerformance] = await readTablePerformance();
       const analyticsPage = await readAnalyticsPageNumbers({
+        client: clickHouse,
+        tenantId,
         evaluatorId: scoreEvaluatorId,
         metric: "evaluations.evaluation_score",
+        currentStartMs,
+        endMs,
       });
 
       expectSameNumbers({ table: scorePerformance!, analyticsPage });
@@ -489,8 +209,12 @@ describe("online evaluation monitor performance", () => {
     it("reports the same pass rate as the analytics page", async () => {
       const [, guardrailPerformance] = await readTablePerformance();
       const analyticsPage = await readAnalyticsPageNumbers({
+        client: clickHouse,
+        tenantId,
         evaluatorId: guardrailEvaluatorId,
         metric: "evaluations.evaluation_pass_rate",
+        currentStartMs,
+        endMs,
       });
 
       expectSameNumbers({ table: guardrailPerformance!, analyticsPage });

--- a/langwatch/src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts
@@ -9,7 +9,10 @@ import {
   startTestContainers,
   stopTestContainers,
 } from "~/server/event-sourcing/__tests__/integration/testContainers";
-import { summarizeMonitorPerformance } from "../monitor-performance.service";
+import {
+  MonitorPerformanceService,
+  summarizeMonitorPerformance,
+} from "../monitor-performance.service";
 import { MonitorPerformanceClickHouseRepository } from "../repositories/monitor-performance.clickhouse.repository";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -168,22 +171,18 @@ describe("online evaluation monitor performance", () => {
     const repository = new MonitorPerformanceClickHouseRepository(async () =>
       countingClient(),
     );
-
-    const buckets = await repository.findBuckets({
+    const service = new MonitorPerformanceService(repository);
+    const performance = await service.getPerformance({
       tenantId,
-      evaluatorIds: [scoreEvaluatorId, guardrailEvaluatorId],
+      monitors: [
+        { id: scoreEvaluatorId, isGuardrail: false },
+        { id: guardrailEvaluatorId, isGuardrail: true },
+      ],
       previousStartMs,
       currentStartMs,
       endMs,
       timeZone: "UTC",
     });
-    const performance = summarizeMonitorPerformance(
-      [
-        { id: scoreEvaluatorId, isGuardrail: false },
-        { id: guardrailEvaluatorId, isGuardrail: true },
-      ],
-      buckets,
-    );
 
     expect(queryCount).toBe(1);
     expect(performance).toEqual([
@@ -218,10 +217,10 @@ describe("online evaluation monitor performance", () => {
     });
 
     expect(
-      summarizeMonitorPerformance(
-        [{ id: `${tenantId}-empty`, isGuardrail: false }],
+      summarizeMonitorPerformance({
+        monitors: [{ id: `${tenantId}-empty`, isGuardrail: false }],
         buckets,
-      ),
+      }),
     ).toEqual([
       {
         monitorId: `${tenantId}-empty`,

--- a/langwatch/src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts
@@ -1,11 +1,23 @@
 /**
  * @see specs/analytics/evaluation-pass-rate-consistency.feature
+ *
+ * The Online Evaluations table and the analytics page must publish the same
+ * numbers. The analytics page reads evaluations through the trace-anchored
+ * legacy path (`ClickHouseLegacyAnalyticsShim`), so besides pinning the
+ * table's own expected values, this suite runs the shim with the exact
+ * series the analytics page issues and asserts both read paths agree on the
+ * headline, the previous period, and every daily bucket.
  */
 import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { deleteEvaluationRunsByTenant } from "~/server/analytics/clickhouse/__tests__/test-utils/clickhouse-cleanup";
+import type { SeriesInputType } from "~/server/analytics/registry";
+import { currentVsPreviousDates } from "~/server/api/routers/analytics/common";
+import { buildSeriesName } from "~/server/app-layer/analytics/repositories/_timeseries-row-parser";
+import { ClickHouseLegacyAnalyticsShim } from "~/server/app-layer/analytics/repositories/legacy.shim";
 import {
+  cleanupTestData,
   startTestContainers,
   stopTestContainers,
 } from "~/server/event-sourcing/__tests__/integration/testContainers";
@@ -16,40 +28,96 @@ import {
 import { MonitorPerformanceClickHouseRepository } from "../repositories/monitor-performance.clickhouse.repository";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const HALF_DAY_MS = 12 * 60 * 60 * 1000;
 const tenantId = `test-monitor-performance-${nanoid()}`;
 const scoreEvaluatorId = `${tenantId}-score`;
 const guardrailEvaluatorId = `${tenantId}-guardrail`;
-const currentStartMs = Date.now() - 7 * DAY_MS;
-const previousStartMs = currentStartMs - 7 * DAY_MS;
-const endMs = currentStartMs + 7 * DAY_MS;
+const endMs = Date.now();
+const currentStartMs = endMs - 7 * DAY_MS;
+// Derived through the same helper the router and the analytics page use, so
+// the comparison below covers the identical previous window on both paths.
+const previousStartMs = currentVsPreviousDates({
+  projectId: "envelope",
+  startDate: currentStartMs,
+  endDate: endMs,
+  filters: {},
+}).previousPeriodStartDate.getTime();
 
 let clickHouse: ClickHouseClient;
 let queryCount = 0;
 
-const evaluationRun = ({
-  evaluationId = `eval-${nanoid()}`,
-  evaluatorId,
-  scheduledAtMs,
-  score,
-  passed,
-  status = "processed",
-  updatedAtMs = scheduledAtMs,
-}: {
-  evaluationId?: string;
-  evaluatorId: string;
+interface SeededEvaluation {
+  traceId: string;
+  /** When the trace occurred; omitted to leave the run without a trace. */
+  traceOccurredAtMs?: number;
   scheduledAtMs: number;
+  evaluatorId: string;
   score: number | null;
   passed: number | null;
   status?: string;
+  evaluationId?: string;
   updatedAtMs?: number;
-}) => ({
+}
+
+const traceSummaryRow = ({
+  traceId,
+  occurredAtMs,
+}: {
+  traceId: string;
+  occurredAtMs: number;
+}) => {
+  const occurredAt = new Date(occurredAtMs);
+  return {
+    ProjectionId: `projection-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: occurredAt,
+    CreatedAt: occurredAt,
+    UpdatedAt: occurredAt,
+    ComputedIOSchemaVersion: "",
+    ComputedInput: "in",
+    ComputedOutput: "out",
+    TimeToFirstTokenMs: 50,
+    TimeToLastTokenMs: 200,
+    TotalDurationMs: 200,
+    TokensPerSecond: 100,
+    SpanCount: 1,
+    ContainsErrorStatus: 0,
+    ContainsOKStatus: 1,
+    ErrorMessage: null,
+    Models: ["gpt-5-mini"],
+    TotalCost: 0.01,
+    TokensEstimated: false,
+    TotalPromptTokenCount: 100,
+    TotalCompletionTokenCount: 50,
+    OutputFromRootSpan: 0,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: 0,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+  };
+};
+
+const evaluationRunRow = ({
+  traceId,
+  scheduledAtMs,
+  evaluatorId,
+  score,
+  passed,
+  status = "processed",
+  evaluationId = `eval-${nanoid()}`,
+  updatedAtMs = scheduledAtMs,
+}: SeededEvaluation) => ({
   ProjectionId: `projection-${nanoid()}`,
   TenantId: tenantId,
   EvaluationId: evaluationId,
   Version: "1",
   EvaluatorId: evaluatorId,
   EvaluatorType: "langevals/test",
-  TraceId: `trace-${nanoid()}`,
+  TraceId: traceId,
   Status: status,
   Score: score,
   Passed: passed,
@@ -73,93 +141,266 @@ const countingClient = () =>
     },
   });
 
+const finiteOrNull = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+type AnalyticsPageMetric =
+  | "evaluations.evaluation_score"
+  | "evaluations.evaluation_pass_rate";
+
+const analyticsPageSeries = ({
+  evaluatorId,
+  metric,
+}: {
+  evaluatorId: string;
+  metric: AnalyticsPageMetric;
+}): SeriesInputType => ({
+  metric,
+  aggregation: "avg",
+  key: evaluatorId,
+  filters: {
+    "evaluations.state": {
+      [evaluatorId]: ["processed"],
+    },
+  },
+});
+
+const readAnalyticsPageNumbers = async ({
+  evaluatorId,
+  metric,
+}: {
+  evaluatorId: string;
+  metric: AnalyticsPageMetric;
+}) => {
+  const shim = new ClickHouseLegacyAnalyticsShim(async () => clickHouse);
+  const series = analyticsPageSeries({ evaluatorId, metric });
+  const baseInput = {
+    projectId: tenantId,
+    startDate: currentStartMs,
+    endDate: endMs,
+    filters: {},
+    series: [series],
+    timeZone: "UTC",
+  };
+  const [daily, full] = await Promise.all([
+    shim.run({ ...baseInput, timeScale: 24 * 60 }),
+    shim.run({ ...baseInput, timeScale: "full" }),
+  ]);
+  const key = buildSeriesName(series, 0);
+
+  return {
+    current: finiteOrNull(full.currentPeriod[0]?.[key]),
+    previous: finiteOrNull(full.previousPeriod[0]?.[key]),
+    dailyValues: daily.currentPeriod
+      .map((bucket) => finiteOrNull(bucket[key]))
+      .filter((value): value is number => value !== null),
+  };
+};
+
+const readTablePerformance = async () => {
+  const service = new MonitorPerformanceService(
+    new MonitorPerformanceClickHouseRepository(async () => clickHouse),
+  );
+  return service.getPerformance({
+    tenantId,
+    monitors: [
+      { id: scoreEvaluatorId, isGuardrail: false },
+      { id: guardrailEvaluatorId, isGuardrail: true },
+    ],
+    previousStartMs,
+    currentStartMs,
+    endMs,
+    timeZone: "UTC",
+  });
+};
+
+const expectSameNumbers = ({
+  table,
+  analyticsPage,
+}: {
+  table: { current: number | null; previous: number | null; points: number[] };
+  analyticsPage: {
+    current: number | null;
+    previous: number | null;
+    dailyValues: number[];
+  };
+}) => {
+  expect(analyticsPage.current).not.toBeNull();
+  expect(analyticsPage.previous).not.toBeNull();
+  expect(table.current).toBeCloseTo(analyticsPage.current!, 10);
+  expect(table.previous).toBeCloseTo(analyticsPage.previous!, 10);
+  expect(table.points).toHaveLength(analyticsPage.dailyValues.length);
+  table.points.forEach((point, index) => {
+    expect(point).toBeCloseTo(analyticsPage.dailyValues[index]!, 10);
+  });
+};
+
 beforeAll(async () => {
   const containers = await startTestContainers();
   clickHouse = containers.clickHouseClient;
 
   const correctedEvaluationId = `corrected-${nanoid()}`;
-  const rows = [
-    evaluationRun({
+  const correctedTraceId = `${tenantId}-trace-corrected`;
+  const day1Ms = currentStartMs + DAY_MS + HALF_DAY_MS;
+  const day2Ms = currentStartMs + 2 * DAY_MS + HALF_DAY_MS;
+  const day3Ms = currentStartMs + 3 * DAY_MS + HALF_DAY_MS;
+
+  const seeded: SeededEvaluation[] = [
+    // Day 1 carries uneven scores so the daily average differs from the
+    // run-weighted period average.
+    {
+      traceId: `${tenantId}-trace-1`,
+      traceOccurredAtMs: day1Ms,
+      scheduledAtMs: day1Ms + 60_000,
       evaluatorId: scoreEvaluatorId,
-      scheduledAtMs: currentStartMs + DAY_MS,
       score: 0.2,
       passed: 0,
-    }),
-    evaluationRun({
+    },
+    {
+      traceId: `${tenantId}-trace-2`,
+      traceOccurredAtMs: day1Ms,
+      scheduledAtMs: day1Ms + 120_000,
       evaluatorId: scoreEvaluatorId,
-      scheduledAtMs: currentStartMs + DAY_MS,
       score: 0.8,
       passed: 1,
-    }),
-    evaluationRun({
+    },
+    {
+      traceId: `${tenantId}-trace-3`,
+      traceOccurredAtMs: day2Ms,
+      scheduledAtMs: day2Ms + 60_000,
       evaluatorId: scoreEvaluatorId,
-      scheduledAtMs: currentStartMs + 2 * DAY_MS,
       score: 1,
       passed: 1,
-    }),
-    evaluationRun({
+    },
+    // A corrected evaluation: only the latest revision may count.
+    {
+      traceId: correctedTraceId,
+      traceOccurredAtMs: day3Ms,
+      scheduledAtMs: day3Ms + 60_000,
       evaluatorId: scoreEvaluatorId,
-      scheduledAtMs: currentStartMs - DAY_MS,
-      score: 0.4,
-      passed: 0,
-    }),
-    evaluationRun({
-      evaluationId: correctedEvaluationId,
-      evaluatorId: scoreEvaluatorId,
-      scheduledAtMs: currentStartMs + 3 * DAY_MS,
       score: 0.1,
       passed: 0,
-    }),
-    evaluationRun({
       evaluationId: correctedEvaluationId,
+    },
+    {
+      traceId: correctedTraceId,
+      scheduledAtMs: day3Ms + 60_000,
       evaluatorId: scoreEvaluatorId,
-      scheduledAtMs: currentStartMs + 3 * DAY_MS,
       score: 0.9,
       passed: 1,
-      updatedAtMs: currentStartMs + 3 * DAY_MS + 1_000,
-    }),
-    evaluationRun({
-      evaluatorId: guardrailEvaluatorId,
-      scheduledAtMs: currentStartMs + DAY_MS,
-      score: null,
-      passed: 1,
-    }),
-    evaluationRun({
-      evaluatorId: guardrailEvaluatorId,
-      scheduledAtMs: currentStartMs + DAY_MS,
-      score: null,
+      evaluationId: correctedEvaluationId,
+      updatedAtMs: day3Ms + 61_000,
+    },
+    // Previous-period run.
+    {
+      traceId: `${tenantId}-trace-previous`,
+      traceOccurredAtMs: currentStartMs - 2 * DAY_MS,
+      scheduledAtMs: currentStartMs - 2 * DAY_MS + 60_000,
+      evaluatorId: scoreEvaluatorId,
+      score: 0.4,
       passed: 0,
-    }),
-    evaluationRun({
-      evaluatorId: guardrailEvaluatorId,
-      scheduledAtMs: currentStartMs - DAY_MS,
-      score: null,
+    },
+    // The trace occurred in the previous period but the evaluation only ran
+    // during the current one: both surfaces count it in the previous period
+    // because a run belongs to the day its trace occurred.
+    {
+      traceId: `${tenantId}-trace-late-eval`,
+      traceOccurredAtMs: currentStartMs - DAY_MS,
+      scheduledAtMs: currentStartMs + 4 * DAY_MS,
+      evaluatorId: scoreEvaluatorId,
+      score: 0.6,
       passed: 1,
-    }),
-    evaluationRun({
-      evaluatorId: guardrailEvaluatorId,
-      scheduledAtMs: currentStartMs + 2 * DAY_MS,
+    },
+    // Non-processed run: excluded everywhere.
+    {
+      traceId: `${tenantId}-trace-error`,
+      traceOccurredAtMs: day2Ms,
+      scheduledAtMs: day2Ms + 90_000,
+      evaluatorId: scoreEvaluatorId,
       score: null,
       passed: null,
       status: "error",
-    }),
-    evaluationRun({
+    },
+    // Run without any trace summary: excluded everywhere.
+    {
+      traceId: `${tenantId}-trace-missing`,
+      scheduledAtMs: day2Ms + 100_000,
       evaluatorId: scoreEvaluatorId,
-      scheduledAtMs: previousStartMs - DAY_MS,
       score: 0,
       passed: 0,
-    }),
+    },
+    // Trace outside the whole comparison window: excluded everywhere even
+    // though the evaluation was scheduled inside the current period.
+    {
+      traceId: `${tenantId}-trace-out-of-window`,
+      traceOccurredAtMs: previousStartMs - DAY_MS,
+      scheduledAtMs: currentStartMs + DAY_MS,
+      evaluatorId: scoreEvaluatorId,
+      score: 0.05,
+      passed: 0,
+    },
+    // Guardrail runs.
+    {
+      traceId: `${tenantId}-trace-guard-1`,
+      traceOccurredAtMs: day1Ms,
+      scheduledAtMs: day1Ms + 60_000,
+      evaluatorId: guardrailEvaluatorId,
+      score: null,
+      passed: 1,
+    },
+    {
+      traceId: `${tenantId}-trace-guard-2`,
+      traceOccurredAtMs: day1Ms,
+      scheduledAtMs: day1Ms + 120_000,
+      evaluatorId: guardrailEvaluatorId,
+      score: null,
+      passed: 0,
+    },
+    {
+      traceId: `${tenantId}-trace-guard-previous`,
+      traceOccurredAtMs: currentStartMs - 3 * DAY_MS,
+      scheduledAtMs: currentStartMs - 3 * DAY_MS + 60_000,
+      evaluatorId: guardrailEvaluatorId,
+      score: null,
+      passed: 1,
+    },
+    {
+      traceId: `${tenantId}-trace-guard-error`,
+      traceOccurredAtMs: day2Ms,
+      scheduledAtMs: day2Ms + 60_000,
+      evaluatorId: guardrailEvaluatorId,
+      score: null,
+      passed: null,
+      status: "error",
+    },
   ];
 
+  const traceRows = seeded
+    .filter((evaluation) => evaluation.traceOccurredAtMs !== undefined)
+    .map((evaluation) =>
+      traceSummaryRow({
+        traceId: evaluation.traceId,
+        occurredAtMs: evaluation.traceOccurredAtMs!,
+      }),
+    );
+  const evaluationRows = seeded.map(evaluationRunRow);
+
+  await clickHouse.insert({
+    table: "trace_summaries",
+    values: traceRows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
   await clickHouse.insert({
     table: "evaluation_runs",
-    values: rows,
+    values: evaluationRows,
     format: "JSONEachRow",
     clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
   });
 }, 180_000);
 
 afterAll(async () => {
+  await cleanupTestData(tenantId);
   await deleteEvaluationRunsByTenant({ client: clickHouse, tenantId });
   await stopTestContainers();
 });
@@ -191,7 +432,7 @@ describe("online evaluation monitor performance", () => {
         metric: "score",
         points: [0.5, 1, 0.9],
         current: 0.725,
-        previous: 0.4,
+        previous: 0.5,
       },
       {
         monitorId: guardrailEvaluatorId,
@@ -230,5 +471,29 @@ describe("online evaluation monitor performance", () => {
         previous: null,
       },
     ]);
+  });
+
+  describe("when the analytics page reads the same period", () => {
+    /** @scenario The configuration table matches the analytics page numbers */
+    it("reports the same score values as the analytics page", async () => {
+      const [scorePerformance] = await readTablePerformance();
+      const analyticsPage = await readAnalyticsPageNumbers({
+        evaluatorId: scoreEvaluatorId,
+        metric: "evaluations.evaluation_score",
+      });
+
+      expectSameNumbers({ table: scorePerformance!, analyticsPage });
+    });
+
+    /** @scenario The configuration table matches the analytics page numbers */
+    it("reports the same pass rate as the analytics page", async () => {
+      const [, guardrailPerformance] = await readTablePerformance();
+      const analyticsPage = await readAnalyticsPageNumbers({
+        evaluatorId: guardrailEvaluatorId,
+        metric: "evaluations.evaluation_pass_rate",
+      });
+
+      expectSameNumbers({ table: guardrailPerformance!, analyticsPage });
+    });
   });
 });

--- a/langwatch/src/server/app-layer/evaluations/monitor-performance.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/monitor-performance.service.ts
@@ -1,0 +1,81 @@
+import type {
+  MonitorPerformanceBucket,
+  MonitorPerformancePeriod,
+} from "./repositories/monitor-performance.repository";
+
+export interface PerformanceMonitor {
+  id: string;
+  isGuardrail: boolean;
+}
+
+export interface OnlineEvaluationPerformance {
+  monitorId: string;
+  metric: "score" | "pass_rate";
+  points: number[];
+  current: number | null;
+  previous: number | null;
+}
+
+interface MetricTotal {
+  sum: number;
+  count: number;
+}
+
+const totalFor = (
+  bucket: MonitorPerformanceBucket,
+  isGuardrail: boolean,
+): MetricTotal =>
+  isGuardrail
+    ? { sum: bucket.passSum, count: bucket.passCount }
+    : { sum: bucket.scoreSum, count: bucket.scoreCount };
+
+const average = (totals: MetricTotal[]): number | null => {
+  const sum = totals.reduce((value, total) => value + total.sum, 0);
+  const count = totals.reduce((value, total) => value + total.count, 0);
+  return count > 0 ? sum / count : null;
+};
+
+const periodTotals = (
+  buckets: MonitorPerformanceBucket[],
+  period: MonitorPerformancePeriod,
+  isGuardrail: boolean,
+): MetricTotal[] =>
+  buckets
+    .filter((bucket) => bucket.period === period)
+    .map((bucket) => totalFor(bucket, isGuardrail));
+
+export const summarizeMonitorPerformance = (
+  monitors: PerformanceMonitor[],
+  buckets: MonitorPerformanceBucket[],
+): OnlineEvaluationPerformance[] => {
+  const bucketsByEvaluator = new Map<string, MonitorPerformanceBucket[]>();
+  for (const bucket of buckets) {
+    const evaluatorBuckets = bucketsByEvaluator.get(bucket.evaluatorId) ?? [];
+    evaluatorBuckets.push(bucket);
+    bucketsByEvaluator.set(bucket.evaluatorId, evaluatorBuckets);
+  }
+
+  return monitors.map((monitor) => {
+    const monitorBuckets = bucketsByEvaluator.get(monitor.id) ?? [];
+    const currentTotals = periodTotals(
+      monitorBuckets,
+      "current",
+      monitor.isGuardrail,
+    );
+    const previousTotals = periodTotals(
+      monitorBuckets,
+      "previous",
+      monitor.isGuardrail,
+    );
+
+    return {
+      monitorId: monitor.id,
+      metric: monitor.isGuardrail ? "pass_rate" : "score",
+      points: currentTotals
+        .filter((total) => total.count > 0)
+        .map((total) => total.sum / total.count),
+      current: average(currentTotals),
+      previous: average(previousTotals),
+    };
+  });
+};

--- a/langwatch/src/server/app-layer/evaluations/monitor-performance.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/monitor-performance.service.ts
@@ -1,6 +1,8 @@
 import type {
+  FindMonitorPerformanceParams,
   MonitorPerformanceBucket,
   MonitorPerformancePeriod,
+  MonitorPerformanceRepository,
 } from "./repositories/monitor-performance.repository";
 
 export interface PerformanceMonitor {
@@ -21,10 +23,13 @@ interface MetricTotal {
   count: number;
 }
 
-const totalFor = (
-  bucket: MonitorPerformanceBucket,
-  isGuardrail: boolean,
-): MetricTotal =>
+const totalFor = ({
+  bucket,
+  isGuardrail,
+}: {
+  bucket: MonitorPerformanceBucket;
+  isGuardrail: boolean;
+}): MetricTotal =>
   isGuardrail
     ? { sum: bucket.passSum, count: bucket.passCount }
     : { sum: bucket.scoreSum, count: bucket.scoreCount };
@@ -35,19 +40,26 @@ const average = (totals: MetricTotal[]): number | null => {
   return count > 0 ? sum / count : null;
 };
 
-const periodTotals = (
-  buckets: MonitorPerformanceBucket[],
-  period: MonitorPerformancePeriod,
-  isGuardrail: boolean,
-): MetricTotal[] =>
+const periodTotals = ({
+  buckets,
+  period,
+  isGuardrail,
+}: {
+  buckets: MonitorPerformanceBucket[];
+  period: MonitorPerformancePeriod;
+  isGuardrail: boolean;
+}): MetricTotal[] =>
   buckets
     .filter((bucket) => bucket.period === period)
-    .map((bucket) => totalFor(bucket, isGuardrail));
+    .map((bucket) => totalFor({ bucket, isGuardrail }));
 
-export const summarizeMonitorPerformance = (
-  monitors: PerformanceMonitor[],
-  buckets: MonitorPerformanceBucket[],
-): OnlineEvaluationPerformance[] => {
+export const summarizeMonitorPerformance = ({
+  monitors,
+  buckets,
+}: {
+  monitors: PerformanceMonitor[];
+  buckets: MonitorPerformanceBucket[];
+}): OnlineEvaluationPerformance[] => {
   const bucketsByEvaluator = new Map<string, MonitorPerformanceBucket[]>();
   for (const bucket of buckets) {
     const evaluatorBuckets = bucketsByEvaluator.get(bucket.evaluatorId) ?? [];
@@ -57,16 +69,16 @@ export const summarizeMonitorPerformance = (
 
   return monitors.map((monitor) => {
     const monitorBuckets = bucketsByEvaluator.get(monitor.id) ?? [];
-    const currentTotals = periodTotals(
-      monitorBuckets,
-      "current",
-      monitor.isGuardrail,
-    );
-    const previousTotals = periodTotals(
-      monitorBuckets,
-      "previous",
-      monitor.isGuardrail,
-    );
+    const currentTotals = periodTotals({
+      buckets: monitorBuckets,
+      period: "current",
+      isGuardrail: monitor.isGuardrail,
+    });
+    const previousTotals = periodTotals({
+      buckets: monitorBuckets,
+      period: "previous",
+      isGuardrail: monitor.isGuardrail,
+    });
 
     return {
       monitorId: monitor.id,
@@ -79,3 +91,20 @@ export const summarizeMonitorPerformance = (
     };
   });
 };
+
+export class MonitorPerformanceService {
+  constructor(private readonly repository: MonitorPerformanceRepository) {}
+
+  async getPerformance({
+    monitors,
+    ...query
+  }: Omit<FindMonitorPerformanceParams, "evaluatorIds"> & {
+    monitors: PerformanceMonitor[];
+  }): Promise<OnlineEvaluationPerformance[]> {
+    const buckets = await this.repository.findBuckets({
+      ...query,
+      evaluatorIds: monitors.map((monitor) => monitor.id),
+    });
+    return summarizeMonitorPerformance({ monitors, buckets });
+  }
+}

--- a/langwatch/src/server/app-layer/evaluations/repositories/monitor-performance.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/monitor-performance.clickhouse.repository.ts
@@ -25,41 +25,73 @@ interface ClickHouseMonitorPerformanceRow {
   PassCount: string;
 }
 
+/**
+ * The analytics page reads evaluations through the trace-anchored legacy
+ * path: latest-revision evaluation runs joined onto their trace summaries,
+ * date-filtered and day-bucketed on the trace's OccurredAt. This query keeps
+ * the exact same envelope so the number on the Online Evaluations table
+ * always equals the number on the analytics page for the same period:
+ * runs without a matching trace in the window (including thread-level runs
+ * with no TraceId) do not count, and a run belongs to the day its trace
+ * occurred, not the day the evaluation was scheduled.
+ *
+ * The evaluation subquery carries a two-day cushion instead of an exact
+ * range because runs are scheduled after their trace occurs; the cushion
+ * keeps partition pruning while still admitting late evaluations of
+ * in-window traces.
+ */
 const queryForTimeZone = (timeZone: string) => `
   SELECT
     EvaluatorId,
-    if(ScheduledAt >= {currentStart:DateTime64(3)}, 'current', 'previous') AS Period,
-    toString(toStartOfDay(ScheduledAt, '${validateTimeZone(timeZone)}')) AS Day,
+    if(TraceOccurredAt >= {currentStart:DateTime64(3)}, 'current', 'previous') AS Period,
+    toString(toStartOfDay(TraceOccurredAt, '${validateTimeZone(timeZone)}')) AS Day,
     sum(ifNull(Score, 0)) AS ScoreSum,
     count(Score) AS ScoreCount,
     sum(ifNull(Passed, 0)) AS PassSum,
     count(Passed) AS PassCount
   FROM (
     SELECT
-      tupleElement(Latest, 1) AS EvaluatorId,
-      tupleElement(Latest, 2) AS Status,
-      tupleElement(Latest, 3) AS Score,
-      tupleElement(Latest, 4) AS Passed,
-      tupleElement(Latest, 5) AS ScheduledAt
+      evaluations.EvaluatorId AS EvaluatorId,
+      evaluations.Status AS Status,
+      evaluations.Score AS Score,
+      evaluations.Passed AS Passed,
+      traces.TraceOccurredAt AS TraceOccurredAt
     FROM (
       SELECT
-        EvaluationId,
-        argMax(
-          tuple(EvaluatorId, Status, Score, Passed, ScheduledAt),
-          UpdatedAt
-        ) AS Latest
-      FROM evaluation_runs
-      PREWHERE TenantId = {tenantId:String}
-        AND ScheduledAt >= {previousStart:DateTime64(3)}
-        AND ScheduledAt < {end:DateTime64(3)}
-      WHERE EvaluatorId IN {evaluatorIds:Array(String)}
-      GROUP BY EvaluationId
-    )
+        TenantId,
+        TraceId,
+        argMax(OccurredAt, UpdatedAt) AS TraceOccurredAt
+      FROM trace_summaries
+      WHERE TenantId = {tenantId:String}
+        AND OccurredAt >= {previousStart:DateTime64(3)}
+        AND OccurredAt < {end:DateTime64(3)}
+      GROUP BY TenantId, TraceId
+    ) AS traces
+    INNER JOIN (
+      SELECT
+        TenantId,
+        tupleElement(Latest, 1) AS TraceId,
+        tupleElement(Latest, 2) AS EvaluatorId,
+        tupleElement(Latest, 3) AS Status,
+        tupleElement(Latest, 4) AS Score,
+        tupleElement(Latest, 5) AS Passed
+      FROM (
+        SELECT
+          TenantId,
+          EvaluationId,
+          argMax(tuple(TraceId, EvaluatorId, Status, Score, Passed), UpdatedAt) AS Latest
+        FROM evaluation_runs
+        WHERE TenantId = {tenantId:String}
+          AND EvaluatorId IN {evaluatorIds:Array(String)}
+          AND ScheduledAt >= {previousStart:DateTime64(3)} - INTERVAL 2 DAY
+          AND ScheduledAt < {end:DateTime64(3)} + INTERVAL 2 DAY
+        GROUP BY TenantId, EvaluationId
+      )
+    ) AS evaluations
+      ON traces.TenantId = evaluations.TenantId
+      AND traces.TraceId = evaluations.TraceId
   )
   WHERE Status = 'processed'
-    AND EvaluatorId IN {evaluatorIds:Array(String)}
-    AND ScheduledAt >= {previousStart:DateTime64(3)}
-    AND ScheduledAt < {end:DateTime64(3)}
   GROUP BY EvaluatorId, Period, Day
   ORDER BY EvaluatorId, Period, Day
 `;

--- a/langwatch/src/server/app-layer/evaluations/repositories/monitor-performance.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/monitor-performance.clickhouse.repository.ts
@@ -1,0 +1,128 @@
+import { createLogger } from "@langwatch/observability";
+import { ANALYTICS_CLICKHOUSE_SETTINGS } from "~/server/analytics/clickhouse/clickhouse-analytics.service";
+import { AnalyticsClientUnavailableError } from "~/server/app-layer/analytics/errors";
+import { validateTimeZone } from "~/server/app-layer/analytics/query-builders/_shared";
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
+import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
+import type {
+  FindMonitorPerformanceParams,
+  MonitorPerformanceBucket,
+  MonitorPerformancePeriod,
+  MonitorPerformanceRepository,
+} from "./monitor-performance.repository";
+
+const logger = createLogger(
+  "langwatch:app-layer:evaluations:monitor-performance-repository",
+);
+
+interface ClickHouseMonitorPerformanceRow {
+  EvaluatorId: string;
+  Period: MonitorPerformancePeriod;
+  Day: string;
+  ScoreSum: number;
+  ScoreCount: string;
+  PassSum: string;
+  PassCount: string;
+}
+
+const queryForTimeZone = (timeZone: string) => `
+  SELECT
+    EvaluatorId,
+    if(ScheduledAt >= {currentStart:DateTime64(3)}, 'current', 'previous') AS Period,
+    toString(toStartOfDay(ScheduledAt, '${validateTimeZone(timeZone)}')) AS Day,
+    sum(ifNull(Score, 0)) AS ScoreSum,
+    count(Score) AS ScoreCount,
+    sum(ifNull(Passed, 0)) AS PassSum,
+    count(Passed) AS PassCount
+  FROM (
+    SELECT
+      tupleElement(Latest, 1) AS EvaluatorId,
+      tupleElement(Latest, 2) AS Status,
+      tupleElement(Latest, 3) AS Score,
+      tupleElement(Latest, 4) AS Passed,
+      tupleElement(Latest, 5) AS ScheduledAt
+    FROM (
+      SELECT
+        EvaluationId,
+        argMax(
+          tuple(EvaluatorId, Status, Score, Passed, ScheduledAt),
+          UpdatedAt
+        ) AS Latest
+      FROM evaluation_runs
+      PREWHERE TenantId = {tenantId:String}
+        AND ScheduledAt >= {previousStart:DateTime64(3)}
+        AND ScheduledAt < {end:DateTime64(3)}
+      WHERE EvaluatorId IN {evaluatorIds:Array(String)}
+      GROUP BY EvaluationId
+    )
+  )
+  WHERE Status = 'processed'
+    AND EvaluatorId IN {evaluatorIds:Array(String)}
+    AND ScheduledAt >= {previousStart:DateTime64(3)}
+    AND ScheduledAt < {end:DateTime64(3)}
+  GROUP BY EvaluatorId, Period, Day
+  ORDER BY EvaluatorId, Period, Day
+`;
+
+export class MonitorPerformanceClickHouseRepository
+  implements MonitorPerformanceRepository
+{
+  constructor(private readonly resolveClient: ClickHouseClientResolver) {}
+
+  async findBuckets(
+    params: FindMonitorPerformanceParams,
+  ): Promise<MonitorPerformanceBucket[]> {
+    if (params.evaluatorIds.length === 0) return [];
+    EventUtils.validateTenantId(
+      { tenantId: params.tenantId },
+      "MonitorPerformanceClickHouseRepository.findBuckets",
+    );
+
+    const client = await this.resolveClient(params.tenantId);
+    if (!client) {
+      throw new AnalyticsClientUnavailableError(params.tenantId);
+    }
+
+    try {
+      const result = await client.query({
+        query: queryForTimeZone(params.timeZone),
+        query_params: {
+          tenantId: params.tenantId,
+          evaluatorIds: params.evaluatorIds,
+          previousStart: new Date(params.previousStartMs),
+          currentStart: new Date(params.currentStartMs),
+          end: new Date(params.endMs),
+        },
+        format: "JSONEachRow",
+        clickhouse_settings: {
+          ...ANALYTICS_CLICKHOUSE_SETTINGS,
+          max_execution_time: 15,
+        },
+      });
+      const rows = await result.json<ClickHouseMonitorPerformanceRow>();
+      return rows.map(toPerformanceBucket);
+    } catch (error) {
+      logger.error(
+        {
+          tenantId: params.tenantId,
+          evaluatorCount: params.evaluatorIds.length,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Failed to load online evaluation performance",
+      );
+      throw error;
+    }
+  }
+}
+
+const toPerformanceBucket = (
+  row: ClickHouseMonitorPerformanceRow,
+): MonitorPerformanceBucket => ({
+  evaluatorId: row.EvaluatorId,
+  period: row.Period,
+  day: row.Day,
+  scoreSum: Number(row.ScoreSum),
+  scoreCount: Number(row.ScoreCount),
+  passSum: Number(row.PassSum),
+  passCount: Number(row.PassCount),
+});

--- a/langwatch/src/server/app-layer/evaluations/repositories/monitor-performance.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/monitor-performance.repository.ts
@@ -24,3 +24,13 @@ export interface MonitorPerformanceRepository {
     params: FindMonitorPerformanceParams,
   ): Promise<MonitorPerformanceBucket[]>;
 }
+
+export class NullMonitorPerformanceRepository
+  implements MonitorPerformanceRepository
+{
+  async findBuckets(
+    _params: FindMonitorPerformanceParams,
+  ): Promise<MonitorPerformanceBucket[]> {
+    return [];
+  }
+}

--- a/langwatch/src/server/app-layer/evaluations/repositories/monitor-performance.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/monitor-performance.repository.ts
@@ -1,0 +1,26 @@
+export type MonitorPerformancePeriod = "current" | "previous";
+
+export interface MonitorPerformanceBucket {
+  evaluatorId: string;
+  period: MonitorPerformancePeriod;
+  day: string;
+  scoreSum: number;
+  scoreCount: number;
+  passSum: number;
+  passCount: number;
+}
+
+export interface FindMonitorPerformanceParams {
+  tenantId: string;
+  evaluatorIds: string[];
+  previousStartMs: number;
+  currentStartMs: number;
+  endMs: number;
+  timeZone: string;
+}
+
+export interface MonitorPerformanceRepository {
+  findBuckets(
+    params: FindMonitorPerformanceParams,
+  ): Promise<MonitorPerformanceBucket[]>;
+}

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -155,12 +155,15 @@ import { PrismaEvaluationCostRecorder } from "./evaluations/evaluation-cost.reco
 import { createDefaultModelEnvResolver } from "./evaluations/evaluation-execution.factories";
 import { EvaluationExecutionService } from "./evaluations/evaluation-execution.service";
 import { EvaluationRunService } from "./evaluations/evaluation-run.service";
+import { MonitorPerformanceService } from "./evaluations/monitor-performance.service";
 import { EvaluationAnalyticsClickHouseRepository } from "./evaluations/repositories/evaluation-analytics.clickhouse.repository";
 import { NullEvaluationAnalyticsRepository } from "./evaluations/repositories/evaluation-analytics.repository";
 import { EvaluationAnalyticsRollupClickHouseRepository } from "./evaluations/repositories/evaluation-analytics-rollup.clickhouse.repository";
 import { NullEvaluationAnalyticsRollupRepository } from "./evaluations/repositories/evaluation-analytics-rollup.repository";
 import { EvaluationRunClickHouseRepository } from "./evaluations/repositories/evaluation-run.clickhouse.repository";
 import { NullEvaluationRunRepository } from "./evaluations/repositories/evaluation-run.repository";
+import { MonitorPerformanceClickHouseRepository } from "./evaluations/repositories/monitor-performance.clickhouse.repository";
+import { NullMonitorPerformanceRepository } from "./evaluations/repositories/monitor-performance.repository";
 import { LangyConversationService } from "./langy/langy-conversation.service";
 import { LangyGithubInstallationsService } from "./langy/langy-github-installations.service";
 import {
@@ -482,6 +485,14 @@ export function initializeDefaultApp(options?: {
   const evaluations = {
     runs: evaluationRuns,
     execution: evaluationExecution,
+    performance: traced(
+      new MonitorPerformanceService(
+        clickhouseEnabled
+          ? new MonitorPerformanceClickHouseRepository(resolveClickHouseClient)
+          : new NullMonitorPerformanceRepository(),
+      ),
+      "MonitorPerformanceService",
+    ),
   };
 
   const planResolver = (organizationId: string) =>
@@ -1426,6 +1437,9 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
       ),
       execution:
         void 0 as unknown as AppDependencies["evaluations"]["execution"],
+      performance: new MonitorPerformanceService(
+        new NullMonitorPerformanceRepository(),
+      ),
     },
     dspySteps: { steps: new DspyStepService(new NullDspyStepRepository()) },
     experiments: ExperimentService.create(testPrisma),

--- a/specs/analytics/evaluation-pass-rate-consistency.feature
+++ b/specs/analytics/evaluation-pass-rate-consistency.feature
@@ -76,3 +76,25 @@ Feature: Evaluation pass-rate consistency across surfaces
     Given an online evaluation with no runs in the selected period
     When the user opens the Evaluations page
     Then the evaluation card shows a no-data placeholder instead of a percentage
+
+  # ---------------------------------------------------------------------------
+  # Online-evaluation list: bounded loading and permission behavior
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Performance for every monitor is read in one bounded query
+    Given a project with multiple online evaluations and guardrails
+    And processed evaluation runs exist inside and outside the comparison period
+    When the Online Evaluations page requests performance
+    Then one evaluation-runs query loads the daily and period summaries
+    And the query is restricted to the project's evaluator identifiers
+    And the query is restricted to the current and previous seven-day periods
+    And only the latest version of each evaluation run contributes to the result
+
+  @integration
+  Scenario: A viewer without analytics access does not wait forever
+    Given a user can view online evaluations but cannot view analytics
+    When the user opens the Online Evaluations page
+    Then the performance request is not sent
+    And each performance cell explains that analytics access is required
+    And no performance loading skeleton remains visible

--- a/specs/analytics/evaluation-pass-rate-consistency.feature
+++ b/specs/analytics/evaluation-pass-rate-consistency.feature
@@ -92,6 +92,14 @@ Feature: Evaluation pass-rate consistency across surfaces
     And only the latest version of each evaluation run contributes to the result
 
   @integration
+  Scenario: The configuration table matches the analytics page numbers
+    Given online evaluation runs with uneven daily volumes and a corrected revision
+    And an evaluation run whose trace occurred in the previous period
+    When the Online Evaluations table and the analytics page read the same period
+    Then both report the same current and previous values
+    And both report the same daily values
+
+  @integration
   Scenario: A viewer without analytics access does not wait forever
     Given a user can view online evaluations but cannot view analytics
     When the user opens the Online Evaluations page


### PR DESCRIPTION
## Summary

- replace two general-purpose analytics reads with one direct ClickHouse query
- keep the query trace-anchored exactly like the analytics page: latest-revision evaluation runs joined onto their in-window trace summaries, day-bucketed on the trace's occurred time
- derive the previous comparison window through `currentVsPreviousDates`, the same helper the analytics page uses
- deduplicate evaluation-run revisions before calculating daily points and weighted period summaries
- cap ClickHouse execution at 15 seconds so the table reaches an explicit error state instead of waiting indefinitely
- clarify the no-permission state as `Analytics access required`
- add real ClickHouse integration tests, including a cross-surface consistency suite, and update the BDD contract

No new cache was added.

## Why

The online-evaluations list only needs evaluator score or pass-rate summaries. It previously sent two calls through the generic analytics builder, one daily and one full-period. On the legacy route, each call could build a wide trace and evaluation join, including an expensive latest-version evaluation subquery.

The new path reads only the columns this screen needs, executes once, and derives the sparkline, current value, and previous value from that result.

## Consistency with the analytics page

The number on the table must always equal the number on the analytics page for the same period, matching the contract from #5858. The analytics page reads evaluations through the trace-anchored legacy path for every per-evaluator query, because series-level filters always route to the legacy fallback. The dedicated query reproduces that envelope:

- runs count on the day their trace occurred, not the day the evaluation was scheduled
- runs without a matching trace summary in the window, including thread-level runs with no trace, do not count on either surface
- the previous window is derived by the shared `currentVsPreviousDates` helper, so both surfaces compare against the identical set of runs
- only the latest revision of each evaluation contributes, and average metrics never fabricate a zero for empty days

The integration suite seeds one dataset and asserts the new read path and the analytics shim agree on the headline, the previous period, and every daily bucket, for both score and pass-rate metrics. The seed includes uneven daily volumes, a corrected revision, an evaluation scheduled in the current window for a previous-window trace, an error-status run, a run without a trace, and a trace outside the window.

## Verification

- `pnpm run typecheck:all`
- `pnpm exec vitest run -c vitest.integration.config.ts src/server/app-layer/evaluations/__tests__/monitor-performance.integration.test.ts --reporter=verbose` (4 tests, includes the cross-surface consistency suite)
- `pnpm exec vitest run -c vitest.integration.config.ts src/server/app-layer/analytics/__tests__/monitor-pass-rate.integration.test.ts --reporter=verbose` (7 tests)
- `pnpm exec vitest run -c vitest.integration.config.ts src/components/evaluations/__tests__/OnlineEvaluationsTable.integration.test.tsx --reporter=verbose`
- `pnpm run check:feature-parity` (2,843 enforced scenarios bound)
- real Chromium QA against `pnpm dev`
  - the table and the analytics page pinned to the same seven-day window render the same values: current 0.58 and previous 0.73 on both surfaces
  - forced request failure renders `Performance unavailable`

## Screenshots

The table and the analytics page report the same numbers for the same period:

![Online evaluations table with performance](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6093/online-evaluations/consistency-table.png)

![Analytics page for the same evaluation and period](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6093/online-evaluations/consistency-analytics.png)

Explicit request failure state:

![Online evaluations with unavailable performance](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-6093/online-evaluations/performance-error.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Online evaluation performance now shows consistent current and previous seven-day metrics across the evaluations table and the analytics view, including matching daily trends and latest evaluation revisions.
- **Bug Fixes**
  - Improved the empty/permission state messaging: users without analytics access now see “Analytics access required” (instead of “Analytics unavailable”) and never see a lingering loading/skeleton state.
- **Tests**
  - Added/updated integration coverage for bounded loading, latest-revision correctness, data-shape for missing runs, consistency between views, and the permission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->