### PR TITLE
fix(billing): enterprise plans are never ingestion-capped

### DIFF
--- a/langwatch/ee/billing/__tests__/notification.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/notification.service.unit.test.ts
@@ -279,7 +279,7 @@ describe("NotificationService", () => {
         const blocks = vi.mocked(mockSlackSend).mock.calls[0]?.[0]?.blocks;
         const allText = JSON.stringify(blocks);
         expect(allText).toContain("*Traces/month:* Unlimited");
-        expect(allText).not.toContain("999,999,999");
+        expect(allText).not.toContain(UNLIMITED_MESSAGES.toLocaleString());
       });
     });
 

--- a/langwatch/ee/billing/__tests__/notification.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/notification.service.unit.test.ts
@@ -38,6 +38,7 @@ vi.mock("../../../src/utils/posthogErrorCapture", () => ({
 
 import { sendUsageLimitEmail } from "../../../src/server/mailer/usageLimitEmail";
 import { captureException } from "../../../src/utils/posthogErrorCapture";
+import { UNLIMITED_MESSAGES } from "../planLimits";
 import { NotificationService } from "../notifications/notification.service";
 
 const mockSendUsageLimitEmail = sendUsageLimitEmail as ReturnType<
@@ -257,6 +258,28 @@ describe("NotificationService", () => {
             }),
           ]),
         });
+      });
+    });
+
+    describe("when the confirmed plan has no message cap", () => {
+      it("renders Traces/month as Unlimited instead of the sentinel number", async () => {
+        config.slackSubscriptionsChannel = "https://hooks.slack.com/subs";
+
+        await service.sendSlackSubscriptionEvent({
+          type: "confirmed",
+          organizationId: "org_1",
+          organizationName: "Acme",
+          plan: "ENTERPRISE",
+          subscriptionId: "sub_1",
+          startDate: new Date("2025-01-01"),
+          maxMembers: 1000,
+          maxMessagesPerMonth: UNLIMITED_MESSAGES,
+        });
+
+        const blocks = vi.mocked(mockSlackSend).mock.calls[0]?.[0]?.blocks;
+        const allText = JSON.stringify(blocks);
+        expect(allText).toContain("*Traces/month:* Unlimited");
+        expect(allText).not.toContain("999,999,999");
       });
     });
 

--- a/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { PLAN_LIMITS } from "../planLimits";
+import { PLAN_LIMITS, UNLIMITED_MESSAGES } from "../planLimits";
 import { PlanTypes } from "../planTypes";
 
 describe("PLAN_LIMITS", () => {
@@ -10,6 +10,15 @@ describe("PLAN_LIMITS", () => {
 
     it("sets ENTERPRISE maxProjects to 9999", () => {
       expect(PLAN_LIMITS[PlanTypes.ENTERPRISE].maxProjects).toBe(9999);
+    });
+
+    // Guards ingestion (checkLimit short-circuits) and the sidebar usage bar
+    // (hidden when the plan has no cap). A per-subscription DB override is the
+    // only way to re-cap an Enterprise org.
+    it("sets ENTERPRISE maxMessagesPerMonth to the unlimited sentinel", () => {
+      expect(PLAN_LIMITS[PlanTypes.ENTERPRISE].maxMessagesPerMonth).toBe(
+        UNLIMITED_MESSAGES,
+      );
     });
 
     it("sets FREE maxProjects to 2", () => {

--- a/langwatch/ee/billing/notifications/notification.service.ts
+++ b/langwatch/ee/billing/notifications/notification.service.ts
@@ -6,6 +6,7 @@ import {
 import type { AppConfig } from "../../../src/server/app-layer/config";
 import { sendUsageLimitEmail } from "../../../src/server/mailer/usageLimitEmail";
 import { captureException, toError } from "../../../src/utils/posthogErrorCapture";
+import { UNLIMITED_MESSAGES } from "../planLimits";
 import type {
   LicensePurchaseNotificationPayload,
   PlanLimitNotificationContext,
@@ -72,6 +73,11 @@ type NotificationServiceOptions = {
 
 const formatNumber = (value?: number | null) =>
   typeof value === "number" ? value.toLocaleString() : "-";
+
+const formatMessagesLimit = (value?: number | null) =>
+  typeof value === "number" && value >= UNLIMITED_MESSAGES
+    ? "Unlimited"
+    : formatNumber(value);
 
 const formatDate = (value?: Date | null) =>
   value
@@ -176,7 +182,7 @@ const buildConfirmedBlocks = (
         },
         {
           type: "mrkdwn",
-          text: `*Traces/month:* ${formatNumber(payload.maxMessagesPerMonth)}`,
+          text: `*Traces/month:* ${formatMessagesLimit(payload.maxMessagesPerMonth)}`,
         },
       ],
     },

--- a/langwatch/ee/billing/planLimits.ts
+++ b/langwatch/ee/billing/planLimits.ts
@@ -176,7 +176,9 @@ export const PLAN_LIMITS: Record<PlanType, PlanInfo> = {
     name: "Enterprise",
     maxMembers: 1000,
     maxProjects: 9999,
-    maxMessagesPerMonth: 1_000_000,
+    // Enterprise is never ingestion-capped; a per-subscription DB override
+    // (Subscription.maxMessagesPerMonth) re-instates a cap when set.
+    maxMessagesPerMonth: UNLIMITED_MESSAGES,
     prices: {
       USD: 999,
       EUR: 999,

--- a/langwatch/ee/licensing/__tests__/planTemplates.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/planTemplates.unit.test.ts
@@ -69,8 +69,8 @@ describe("ENTERPRISE_TEMPLATE", () => {
     expect(ENTERPRISE_TEMPLATE.maxProjects).toBe(500);
   });
 
-  it("has maxMessagesPerMonth of 10000000", () => {
-    expect(ENTERPRISE_TEMPLATE.maxMessagesPerMonth).toBe(10000000);
+  it("has unlimited maxMessagesPerMonth so licensed orgs are never ingestion-capped", () => {
+    expect(ENTERPRISE_TEMPLATE.maxMessagesPerMonth).toBe(DEFAULT_LIMIT);
   });
 
   it("has maxWorkflows of 1000", () => {

--- a/langwatch/ee/licensing/planTemplates.ts
+++ b/langwatch/ee/licensing/planTemplates.ts
@@ -68,7 +68,11 @@ export const ENTERPRISE_TEMPLATE: LicensePlanLimits = {
   maxMembersLite: 50,
   maxTeams: 100,
   maxProjects: 500,
-  maxMessagesPerMonth: 10000000,
+  // Enterprise licenses are never ingestion-capped by default; a CUSTOM
+  // license with an explicit cap is the way to enforce one. Only affects
+  // newly generated licenses — already-issued licenses keep their signed
+  // limits until reissued.
+  maxMessagesPerMonth: DEFAULT_LIMIT,
   evaluationsCredit: 0,
   maxWorkflows: 1000,
   maxPrompts: 1000,

--- a/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -317,8 +317,8 @@ describe("UsageService", () => {
       });
     });
 
-    describe("when org is on the ENTERPRISE subscription plan", () => {
-      it("never blocks ingestion and skips the usage count entirely", async () => {
+    describe("when org is on the ENTERPRISE plan with no message-cap override", () => {
+      it("does not block ingestion and skips the usage count entirely", async () => {
         vi.mocked(mockOrgService.getOrganizationIdByTeamId).mockResolvedValue(
           "org-123",
         );
@@ -331,6 +331,30 @@ describe("UsageService", () => {
         expect(result.exceeded).toBe(false);
         expect(mockTraceUsageService.getCountByProjects).not.toHaveBeenCalled();
         expect(mockEventUsageService.getCountByProjects).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when an ENTERPRISE org has a message-cap override at the cap", () => {
+      it("enforces the overridden limit", async () => {
+        vi.mocked(mockOrgService.getOrganizationIdByTeamId).mockResolvedValue(
+          "org-123",
+        );
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
+        // The plan provider merges Subscription.maxMessagesPerMonth over the
+        // plan defaults; checkLimit only sees the resolved plan.
+        (mockPlanResolver as ReturnType<typeof vi.fn>).mockResolvedValue({
+          ...PLAN_LIMITS[PlanTypes.ENTERPRISE],
+          maxMessagesPerMonth: 500_000,
+        });
+        mockTraceUsageService.getCountByProjects.mockResolvedValue([
+          { projectId: "proj-1", count: 500_000 },
+        ]);
+
+        const result = await service.checkLimit({ teamId: "team-123" });
+
+        expect(result.exceeded).toBe(true);
+        expect(result.maxMessagesPerMonth).toBe(500_000);
+        expect(result.planName).toBe("Enterprise");
       });
     });
 

--- a/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -1,7 +1,11 @@
 import { PricingModel } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TtlCache } from "~/server/utils/ttlCache";
-import { UNLIMITED_MESSAGES } from "../../../../../ee/billing/planLimits";
+import {
+  PLAN_LIMITS,
+  UNLIMITED_MESSAGES,
+} from "../../../../../ee/billing/planLimits";
+import { PlanTypes } from "../../../../../ee/billing/planTypes";
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import type { PlanInfo } from "../../../../../ee/licensing/planInfo";
 import type { OrganizationService } from "../../organizations/organization.service";
@@ -310,6 +314,23 @@ describe("UsageService", () => {
           "Monthly limit of 1000 events reached",
         );
         expect(mockPlanResolver).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when org is on the ENTERPRISE subscription plan", () => {
+      it("never blocks ingestion and skips the usage count entirely", async () => {
+        vi.mocked(mockOrgService.getOrganizationIdByTeamId).mockResolvedValue(
+          "org-123",
+        );
+        (mockPlanResolver as ReturnType<typeof vi.fn>).mockResolvedValue(
+          PLAN_LIMITS[PlanTypes.ENTERPRISE],
+        );
+
+        const result = await service.checkLimit({ teamId: "team-123" });
+
+        expect(result.exceeded).toBe(false);
+        expect(mockTraceUsageService.getCountByProjects).not.toHaveBeenCalled();
+        expect(mockEventUsageService.getCountByProjects).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
## Why

A customer report surfaced that Enterprise organizations resolve to a 1,000,000 messages/month cap. That cap is real, not cosmetic: the collector, OTLP, and scenario-events ingest paths all 429 with `ERR_PLAN_LIMIT` once the org crosses it. It also leaks into the UI inconsistently — `/settings/usage` deliberately hides limits for Enterprise, but the sidebar still shows a usage bar with a "You have used X traces out of 1,000,000 this month" tooltip. Enterprise should never be ingestion-blocked by a plan default; only an explicit per-org override should cap it.

## What changed

- **SaaS `ENTERPRISE` plan** now uses the existing `UNLIMITED_MESSAGES` sentinel instead of 1M (`ee/billing/planLimits.ts`).
- **`ENTERPRISE` license template** now uses `DEFAULT_LIMIT` instead of 10M (`ee/licensing/planTemplates.ts`), so newly generated enterprise licenses are uncapped.
- **Internal Slack subscription notification** renders "Unlimited" instead of the raw `999,999,999` sentinel (`ee/billing/notifications/notification.service.ts`).

## How it works

Everything else falls out of existing sentinel handling, no new conditionals:

- `UsageService.checkLimit` short-circuits to `exceeded: false` for unlimited plans and skips the monthly ClickHouse count entirely — all three ingest paths stop blocking (and stop paying for the count query).
- The sidebar `UsageIndicator` already hides itself when `maxMessagesPerMonth >= UNLIMITED_MESSAGES` — Enterprise now gets the same UX as growth-seat-event plans.
- `/settings/usage` keeps showing the real trace volume via the display-count path (`getCurrentMonthCountForDisplay`), unchanged.
- **The DB escape hatch still works**: a non-null `Subscription.maxMessagesPerMonth` override replaces the plan default in the plan provider, which re-instates enforcement and re-shows the sidebar bar. For self-hosted, a CUSTOM license with an explicit cap does the same.

## Test plan

- New regressions in `usage.service.unit.test.ts`: `checkLimit` does not block an ENTERPRISE org with no message-cap override and performs no usage count (fails without the fix — previously exceeded at 1M), and a sibling case proving an overridden Enterprise cap is still enforced at `checkLimit` level.
- New pin: `PLAN_LIMITS[ENTERPRISE].maxMessagesPerMonth === UNLIMITED_MESSAGES` (`planLimits.unit.test.ts`), documenting both the ingestion and sidebar behavior.
- Updated pin: enterprise license template is `DEFAULT_LIMIT` (`planTemplates.unit.test.ts`).
- New: Slack "Subscription activated" block renders `Traces/month: Unlimited` for uncapped plans (`notification.service.unit.test.ts`).
- Existing DB-override enforcement coverage untouched and green (`planProvider.unit.test.ts` — "returns the override value for maxMessagesPerMonth").
- Sweeps: unit (`ee`, subscription/license/sidebar components, usage + subscription app-layer) 1373 passed; integration for the same dirs 523 passed, 1 pre-existing unrelated failure (`pullerWorker.dispatch` SSRF guard blocking its own localhost fixture server). `pnpm typecheck` and `pnpm typecheck:tests` clean.

## Anything surprising?

- **Already-issued enterprise licenses keep their signed 10M limit** — license limits are embedded in the signed payload and can't be rewritten. Those orgs stay capped until their license is reissued from the (now uncapped) template.
- Worth a read-only prod check that no live Enterprise `Subscription` rows carry a stale `maxMessagesPerMonth` DB override, since an override would (by design) re-cap that org.

---
Tracked by langwatch/langwatch-saas#897
