### PR TITLE
feat(event-sourcing): coalesce recordTriggerMatch appends + durable dedup watermark (ADR-066 pillar 2)

### DIFF
--- a/dev/docs/adr/066-projection-clickhouse-cached-store.md
+++ b/dev/docs/adr/066-projection-clickhouse-cached-store.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-23
 
-**Status:** Accepted (Pillar 1 first adopter — `codingAgentSession` read-back store, migration 00053 — shipped in this PR; Pillar 2 append coalescing and the durable dedup watermark remain follow-ups)
+**Status:** Accepted (shipped with this ADR's PR train: Pillar 1 adopter #1 — `codingAgentSession` read-back store, migration 00053; Pillar 2 adopter #1 — `recordTriggerMatch` append coalescing on the count+byte-bounded drain; the durable dedup watermark — migration 00054. Remaining follow-ups are tracked in *Adopters & sequencing*.)
 
 **Re-affirms & hardens:** [ADR-007](./007-event-sourcing-architecture.md) §"Fold Projections", §"No Checkpoints" ("fold state = stored data"; "`store.get()` loads last state").
 
@@ -32,7 +32,7 @@ Underneath the incident is a design smell: the cache and the ClickHouse store we
 
 ### The same table was overwhelmed from the *other* side too
 
-`event_log` did not part-buildup from the fold refolds alone. The other heavy contributor was **producer-side**: a hot automation trigger firing tens of thousands of times minted **one tiny `async_insert` into `event_log` per match** (`recordTriggerMatch` has no coalescing — it appends one `TRIGGER_MATCH_RECORDED` event per match). Tens of thousands of individual inserts feed exactly the small-parts explosion that starves merges.
+`event_log` did not part-buildup from the fold refolds alone. The other heavy contributor was **producer-side**: a hot automation trigger firing tens of thousands of times minted **one tiny `async_insert` into `event_log` per match** (`recordTriggerMatch` had no coalescing at the time — one `TRIGGER_MATCH_RECORDED` append per match). Tens of thousands of individual inserts feed exactly the small-parts explosion that starves merges.
 
 So the outage had one shape from two directions:
 
@@ -85,7 +85,7 @@ Pillar 1 stops the *reads*. It does nothing for the *writes*, and the writes wer
 
 **A command that appends one `event_log` event per item, at high fan-in, MUST coalesce its appends into batched inserts** — N items become one `INSERT` of N rows, not N inserts of one row. `event_log` inserts already use `async_insert: 1, wait_for_async_insert: 1`; batching at the producer is what keeps each flush from becoming its own part.
 
-- The trigger of this ADR's incident, `recordTriggerMatch`, appends one `TRIGGER_MATCH_RECORDED` per match with no coalescing (`serializeByAggregate: true` only, no `coalesceMaxBatch`). A hot trigger firing 27k times is 27k inserts. It is both a *victim* of the `event_log` stall (its jobs can't commit) and a *contributor* to it.
+- The trigger of this ADR's incident, `recordTriggerMatch`, appended one `TRIGGER_MATCH_RECORDED` per match with no coalescing (`serializeByAggregate: true` only, no `coalesceMaxBatch`). A hot trigger firing 27k times was 27k inserts — both a *victim* of the `event_log` stall (its jobs couldn't commit) and a *contributor* to it. It is now Pillar 2's first adopter: `coalesceMaxBatch: TRIGGER_MATCH_COALESCE_MAX_BATCH` on the count+byte-bounded drain.
 - The queue substrate already supports coalescing (`coalesceMaxBatch` / `processBatch` on the GroupQueue — the same mechanism the fold side uses). Producers this hot opt into it; the batched handler stores one multi-row insert per drained batch.
 - **Coalescing bounds by event count AND byte size, whichever is reached first.** A fixed event count alone is the wrong bound: small events under-fill a batch (still one insert per few items), and large events over-fill it (a single insert that blows past `async_insert_max_data_size` and becomes an oversized part). The group drain therefore takes *up to N events* **and** *up to M bytes* — it sums each drained job's staged size and stops at either limit, so the coalesced insert size is predictable and stays inside the async-insert flush budget. A single job larger than M bytes is still taken alone (never deadlocked). This bound lives in the drain itself, so every coalescing consumer — folds and producers — gets it for free. (For blob-offloaded payloads the staged size is the descriptor, not the full body; high-fan-in producers emit small inline events, so the proxy is accurate where it matters, and the envelope's recorded size is the refinement if a large-event fold ever needs exactness.)
 - This is **not** the fold store — a producer has no read-modify-write state to read back. It is the write-side sibling of the same principle: keep `event_log` off the per-item hot path.
@@ -137,15 +137,15 @@ Independently of the store: fix the **session = traceId fallback** so one large 
 
 | Component | Kind | Lever |
 |---|---|---|
-| `recordTriggerMatch` command | producer — one `TRIGGER_MATCH_RECORDED` per match, no coalescing | **Pillar 2 adopter #1** — append coalescing |
+| `recordTriggerMatch` command | producer — one `TRIGGER_MATCH_RECORDED` per match (un-coalesced at incident time) | **Pillar 2 adopter #1 — shipped** (append coalescing on the count+byte-bounded drain) |
 | `triggerSettlement` | ADR-052 process manager, Postgres outbox state | None — evolves state incrementally from a PM store, never refolds `event_log`; its backlog is pure `event_log`-stall *symptom*, not a cause |
 
 ## Adopters & sequencing
 
 1. **Now (relief):** `refoldOnOutOfOrder: false` on `codingAgentSession` — safe today (order-insensitive derivation), stops the replay storm. Small standalone PR.
 2. **Pillar 1, first adopter:** `codingAgentSession` → lossless read-back store (kills `refoldOnStoreMiss` on the hot path). The concrete shape is in *"codingAgentSession decomposition"* below. Then roll the same pattern to any other lossy-row fold. Migration is per-fold: until the last lossy-row fold adopts read-back (ADR-034's slim analytics folds are the remaining users), `refoldOnStoreMiss` / `refoldOnOutOfOrder` stay in the executor for those folds — the Rules below bind a fold from the moment it adopts, and the flags (with their executor support) are deleted with the final adopter.
-3. **Pillar 2, first adopter:** append coalescing for `recordTriggerMatch`; audit other high-fan-in `event_log` producers and coalesce them.
-4. **Durable dedup watermark** in fold state — closes the cold idempotency hole so "throw-and-retry" is truly idempotent even across cache loss (the applied-event-id set is cache-only today).
+3. **Pillar 2, first adopter — shipped:** append coalescing for `recordTriggerMatch` (`processCommandBatch` → one multi-row insert; the drain bounds by count AND bytes for every coalescing consumer). **Remaining:** audit other high-fan-in `event_log` producers and coalesce them — serialized command producers registering without coalescing are logged at registration, so the gaps are enumerable.
+4. **Durable dedup watermark — shipped:** the applied-event-id set persists next to the state row (`AppliedEventIds`, migration 00054) and the executor commits the union of the loaded set and the fresh ids on retries, so "throw-and-retry" stays idempotent across cache loss for read-back folds. Folds without a durable set keep the cache-only behaviour.
 
 ## codingAgentSession decomposition (Pillar 1 adopter #1)
 
@@ -187,7 +187,7 @@ Recorded here so the application-side and server-side levers are visible togethe
 - Projection state tables are ReplacingMergeTree keyed by `(TenantId, aggregate)` + a monotonic version; reads select the latest version (`FINAL`/`argMax`) with LazilyRead `LIMIT 1` discipline.
 - `store()` writes ClickHouse first (throws on failure), then Redis. A cache-write failure is logged, never thrown — ClickHouse already holds the durable state.
 - Folds declare their ordering contract. `event_log` is never read on the delivery path — only by the replay tool, for version migration or recovery.
-- Redelivery dedup travels with the state (applied-event-id set, reset on each fresh delivery, bounded to the in-flight batch).
+- Redelivery dedup travels with the state (applied-event-id set, reset on each fresh delivery, bounded to the in-flight batch) — and, for read-back folds, persists durably next to the state row (migration 00054), so it survives cache loss.
 - **High-fan-in `event_log` producers coalesce their appends** — a batched multi-row insert per drained batch, not one insert per item. A producer where a single aggregate can mint events faster than they drain, and does not coalesce, is a part-buildup regression. Any cap on coalescing coverage is logged, not silent.
 
 ## References

--- a/dev/docs/adr/066-projection-clickhouse-cached-store.md
+++ b/dev/docs/adr/066-projection-clickhouse-cached-store.md
@@ -68,7 +68,7 @@ Every ClickHouse-backed fold projection gets the same store with the same contra
 - **`apply(state, batch)`** → in-process derivation. Pure; order-tolerant per the fold's *declared* ordering contract.
 - **`store(state)`** → **ClickHouse first (throws on failure), then Redis.** A full-state **replace**, keyed by `(TenantId, aggregate)` + a monotonic version (ReplacingMergeTree), latest version wins. **No read-time aggregation.**
 
-Idempotency is a **platform property**, not a per-fold concern: writes are full-state idempotent replaces; the GroupQueue serialises per aggregate (FIFO); redelivery is deduped by the applied-event-id set carried alongside the state (reset on each fresh delivery, so it stays bounded to the in-flight batch). Today that set travels with the *cached* state only, so redelivery dedup is exact while the cache holds the entry and degrades to at-least-once re-apply across cache loss; closing that cold hole durably is sequencing step 4 (the durable dedup watermark).
+Idempotency is a **platform property**, not a per-fold concern: writes are full-state idempotent replaces; the GroupQueue serialises per aggregate (FIFO); redelivery is deduped by the applied-event-id set carried alongside the state (reset on each fresh delivery, so it stays bounded to the in-flight batch). For read-back folds that set also persists durably next to the state row (sequencing step 4, the durable dedup watermark — migration 00054), so dedup survives cache loss; folds without a durable set keep the cache-only behaviour, exact while the cache holds the entry and degrading to at-least-once re-apply across cache loss.
 
 What the contract removes:
 
@@ -142,8 +142,8 @@ Independently of the store: fix the **session = traceId fallback** so one large 
 
 ## Adopters & sequencing
 
-1. **Now (relief):** `refoldOnOutOfOrder: false` on `codingAgentSession` — safe today (order-insensitive derivation), stops the replay storm. Small standalone PR.
-2. **Pillar 1, first adopter:** `codingAgentSession` → lossless read-back store (kills `refoldOnStoreMiss` on the hot path). The concrete shape is in *"codingAgentSession decomposition"* below. Then roll the same pattern to any other lossy-row fold. Migration is per-fold: until the last lossy-row fold adopts read-back (ADR-034's slim analytics folds are the remaining users), `refoldOnStoreMiss` / `refoldOnOutOfOrder` stay in the executor for those folds — the Rules below bind a fold from the moment it adopts, and the flags (with their executor support) are deleted with the final adopter.
+1. **Now (relief) — shipped:** `refoldOnOutOfOrder: false` on `codingAgentSession` — safe today (order-insensitive derivation), stops the replay storm. Small standalone PR.
+2. **Pillar 1, first adopter — shipped:** `codingAgentSession` → lossless read-back store (kills `refoldOnStoreMiss` on the hot path). The concrete shape is in *"codingAgentSession decomposition"* below. Then roll the same pattern to any other lossy-row fold. Migration is per-fold: until the last lossy-row fold adopts read-back (ADR-034's slim analytics folds are the remaining users), `refoldOnStoreMiss` / `refoldOnOutOfOrder` stay in the executor for those folds — the Rules below bind a fold from the moment it adopts, and the flags (with their executor support) are deleted with the final adopter.
 3. **Pillar 2, first adopter — shipped:** append coalescing for `recordTriggerMatch` (`processCommandBatch` → one multi-row insert; the drain bounds by count AND bytes for every coalescing consumer). **Remaining:** audit other high-fan-in `event_log` producers and coalesce them — serialized command producers registering without coalescing are logged at registration, so the gaps are enumerable.
 4. **Durable dedup watermark — shipped:** the applied-event-id set persists next to the state row (`AppliedEventIds`, migration 00054) and the executor commits the union of the loaded set and the fresh ids on retries, so "throw-and-retry" stays idempotent across cache loss for read-back folds. Folds without a durable set keep the cache-only behaviour.
 
@@ -192,12 +192,13 @@ Recorded here so the application-side and server-side levers are visible togethe
 
 ## References
 
-- **Behavioural contract:** [specs/event-sourcing/fold-read-back-store.feature](../../../specs/event-sourcing/fold-read-back-store.feature) (pillar 1), [specs/event-sourcing/producer-append-coalescing.feature](../../../specs/event-sourcing/producer-append-coalescing.feature) (pillar 2)
+- **Behavioural contract:** [specs/event-sourcing/fold-read-back-store.feature](../../../specs/event-sourcing/fold-read-back-store.feature) (pillar 1), [specs/event-sourcing/producer-append-coalescing.feature](../../../specs/event-sourcing/producer-append-coalescing.feature) (pillar 2), [specs/event-sourcing/fold-coalescing.feature](../../../specs/event-sourcing/fold-coalescing.feature) (the shared count+byte-bounded drain both sides ride)
 - [ADR-007](./007-event-sourcing-architecture.md) — event-sourcing architecture (this ADR hardens its storage model)
 - [ADR-015](./015-projection-replay-coordination.md) — replay coordination (narrowed to off-hot-path)
 - [ADR-021](./021-lean-fold-cache.md) — lean fold cache (fold-cache mechanics superseded here)
 - [ADR-022](./022-event-log-source-of-truth.md) — event_log as source of truth (heavy-content axis)
 - [ADR-034](./034-event-sourced-analytics-materialization.md) — analytics materialisation (its `refoldOnStoreMiss` continuity mechanism amended here)
 - [ADR-049](./049-langy-projection-independent-reactions.md) — Postgres operational-projection store (sibling implementation of the read-back principle)
+- [ADR-052](./052-automations-on-process-manager-substrate.md) — automations pipeline (pillar 2's first adopter, `recordTriggerMatch`, is an ADR-052 command; coalescing preserves its per-trigger FIFO ordering)
 - [ADR-055](./055-canonical-otlp-metric-and-log-pipelines.md) — map-vs-fold projection choice
 - [ADR-056](./056-coding-agent-pipeline-session-aggregate.md) — coding-agent session aggregate (store corrected here)

--- a/dev/docs/adr/066-projection-clickhouse-cached-store.md
+++ b/dev/docs/adr/066-projection-clickhouse-cached-store.md
@@ -2,7 +2,9 @@
 
 **Date:** 2026-07-23
 
-**Status:** Accepted (shipped with this ADR's PR train: Pillar 1 adopter #1 — `codingAgentSession` read-back store, migration 00053; Pillar 2 adopter #1 — `recordTriggerMatch` append coalescing on the count+byte-bounded drain; the durable dedup watermark — migration 00054. Remaining follow-ups are tracked in *Adopters & sequencing*.)
+**Status:** Accepted
+
+**Shipped** with this ADR's PR train: Pillar 1 adopter #1 — `codingAgentSession` read-back store, migration 00053; Pillar 2 adopter #1 — `recordTriggerMatch` append coalescing on the count+byte-bounded drain; the durable dedup watermark — migration 00054. Remaining follow-ups are tracked in *Adopters & sequencing*.
 
 **Re-affirms & hardens:** [ADR-007](./007-event-sourcing-architecture.md) §"Fold Projections", §"No Checkpoints" ("fold state = stored data"; "`store.get()` loads last state").
 

--- a/langwatch/src/server/app-layer/coding-agent/__tests__/coding-agent-session.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/coding-agent/__tests__/coding-agent-session.service.unit.test.ts
@@ -134,6 +134,8 @@ function makeService({
   const sessions: CodingAgentSessionRepository = {
     upsert: async () => {},
     findBySessionId: async () => row,
+    findBySessionIdWithApplied: async () =>
+      row ? { row, appliedEventIds: [] } : null,
     findManyRecent: async () => listed,
   };
   const traceSessions: CodingAgentTraceSessionRepository = {

--- a/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
@@ -238,6 +238,43 @@ describe("coding_agent_sessions round-trip (migration 00051)", () => {
     // The later write wins.
     expect(forSession[0]!.costUsd).toBeCloseTo(2);
   });
+
+  it("reads back the applied-event-id watermark next to the row (ADR-066)", async () => {
+    const row = sessionRow({ sessionId: `${tag}-applied` });
+    await sessions.upsert(row, 30, ["ev-1", "ev-2"]);
+
+    const withApplied = await sessions.findBySessionIdWithApplied({
+      tenantId,
+      sessionId: `${tag}-applied`,
+      startedAtMs: baseMs,
+    });
+    const direct = await sessions.findBySessionId({
+      tenantId,
+      sessionId: `${tag}-applied`,
+      startedAtMs: baseMs,
+    });
+
+    expect(withApplied).not.toBeNull();
+    // The watermark rides beside the row, not inside it.
+    expect(withApplied!.appliedEventIds).toEqual(["ev-1", "ev-2"]);
+    // The mapped row is exactly what findBySessionId returns — one read, same
+    // query, same decode.
+    expect(withApplied!.row).toEqual(direct);
+  });
+
+  it("reads back an empty watermark when a row is written without one", async () => {
+    const row = sessionRow({ sessionId: `${tag}-noapplied` });
+    await sessions.upsert(row, 30);
+
+    const withApplied = await sessions.findBySessionIdWithApplied({
+      tenantId,
+      sessionId: `${tag}-noapplied`,
+      startedAtMs: baseMs,
+    });
+
+    expect(withApplied).not.toBeNull();
+    expect(withApplied!.appliedEventIds).toEqual([]);
+  });
 });
 
 describe("coding_agent_trace_sessions map (migration 00051)", () => {

--- a/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/__tests__/coding-agent-session.clickhouse.repository.integration.test.ts
@@ -2,12 +2,17 @@
  * @vitest-environment node
  * @integration
  *
- * Round-trips the three coding-agent tables (migrations 00051 / 00052) through
+ * Round-trips the three coding-agent tables (migrations 00051-00054) through
  * their real INSERT/SELECT SQL against ClickHouse. The unit tests cover the
  * query shape and record mapping with a mocked client; this proves the
  * DDL↔repository column contract — a mismatched column name or type fails a
  * real insert loudly, which no mock can catch — plus the ReplacingMergeTree
- * dedup / last-write-wins semantics ADR-056 relies on.
+ * dedup / last-write-wins semantics ADR-056 relies on. It also covers the
+ * ADR-066 additions: the 00053 read-back state columns (sub-agent ids, ordered
+ * step start times, previous-call context, converged metric units) that let
+ * store.get() reconstruct working state without touching event_log, and the
+ * 00054 AppliedEventIds watermark that survives cache loss — including the
+ * mixed-deploy read of a pre-00054 row whose body omits the column entirely.
  */
 import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
@@ -166,7 +171,7 @@ afterAll(async () => {
   await stopTestContainers();
 });
 
-describe("coding_agent_sessions round-trip (migration 00051)", () => {
+describe("coding_agent_sessions round-trip (migrations 00051-00054)", () => {
   it("writes every column and reads the session back by its key", async () => {
     const row = sessionRow({
       sessionId: `${tag}-rt`,
@@ -269,6 +274,38 @@ describe("coding_agent_sessions round-trip (migration 00051)", () => {
     const withApplied = await sessions.findBySessionIdWithApplied({
       tenantId,
       sessionId: `${tag}-noapplied`,
+      startedAtMs: baseMs,
+    });
+
+    expect(withApplied).not.toBeNull();
+    expect(withApplied!.appliedEventIds).toEqual([]);
+  });
+
+  it("reads back an empty watermark for a pre-migration row that omits the column", async () => {
+    const sessionId = `${tag}-legacy`;
+    // The genuine mixed-deploy read: an old writer (or any row written before
+    // migration 00054) emits a JSONEachRow body with NO AppliedEventIds field
+    // at all, so ClickHouse supplies the column default — an empty
+    // Array(String). This is distinct from the case above, where `toRecord`
+    // still writes AppliedEventIds: []; here the field never leaves the writer,
+    // exercising the column default and the mapper's asStringArray fallback
+    // directly. Inserted through the same client the repository resolves.
+    await ch.insert({
+      table: "coding_agent_sessions",
+      values: [
+        {
+          TenantId: tenantId,
+          SessionId: sessionId,
+          StartedAt: new Date(baseMs),
+          Version: "2026-07-21",
+        },
+      ],
+      format: "JSONEachRow",
+    });
+
+    const withApplied = await sessions.findBySessionIdWithApplied({
+      tenantId,
+      sessionId,
       startedAtMs: baseMs,
     });
 

--- a/langwatch/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/coding-agent-session.clickhouse.repository.ts
@@ -122,6 +122,12 @@ interface ClickHouseWriteRecord {
   MetricSeries: [string, string, string, string, string, number][];
   LastEventOccurredAt: Date;
 
+  // ── Durable dedup watermark (ADR-066, migration 00054) ─────────────────
+  // The applied-event-id set the executor checks a redelivery against. Not fold
+  // state and not analytics — it rides next to the row so dedup survives cache
+  // loss.
+  AppliedEventIds: string[];
+
   _retention_days: number;
 }
 
@@ -131,6 +137,7 @@ const big = (n: number): string => String(Math.max(0, Math.round(n)));
 function toRecord(
   row: CodingAgentSessionRow,
   retentionDays?: number,
+  appliedEventIds: readonly string[] = [],
 ): ClickHouseWriteRecord {
   const now = new Date();
   return {
@@ -239,6 +246,8 @@ function toRecord(
     ]),
     LastEventOccurredAt: new Date(row.lastEventOccurredAt),
 
+    AppliedEventIds: [...appliedEventIds],
+
     _retention_days: retentionDays ?? PLATFORM_DEFAULT_RETENTION_DAYS,
   };
 }
@@ -251,6 +260,7 @@ export class CodingAgentSessionClickHouseRepository
   async upsert(
     row: CodingAgentSessionRow,
     retentionDays?: number,
+    appliedEventIds?: readonly string[],
   ): Promise<void> {
     EventUtils.validateTenantId(
       { tenantId: row.tenantId },
@@ -260,7 +270,7 @@ export class CodingAgentSessionClickHouseRepository
     try {
       await client.insert({
         table: TABLE_NAME,
-        values: [toRecord(row, retentionDays)],
+        values: [toRecord(row, retentionDays, appliedEventIds)],
         format: "JSONEachRow",
         clickhouse_settings: { async_insert: 1, wait_for_async_insert: 1 },
       });
@@ -274,7 +284,8 @@ export class CodingAgentSessionClickHouseRepository
   }
 
   /**
-   * One session by its key.
+   * The latest raw record for a session key, or null — the shared read behind
+   * both `findBySessionId` and `findBySessionIdWithApplied`.
    *
    * Dedups with the IN-tuple pattern (max(UpdatedAt) per key) rather than
    * FINAL: the ReplacingMergeTree only physically collapses rows sharing the
@@ -286,7 +297,7 @@ export class CodingAgentSessionClickHouseRepository
    * widened ±7 days rather than pinned to the exact ms — the window keeps
    * this a partition-pruned point read instead of a full-table scan.
    */
-  async findBySessionId({
+  private async findLatestRecord({
     tenantId,
     sessionId,
     startedAtMs,
@@ -294,7 +305,7 @@ export class CodingAgentSessionClickHouseRepository
     tenantId: string;
     sessionId: string;
     startedAtMs?: number;
-  }): Promise<CodingAgentSessionRow | null> {
+  }): Promise<Record<string, unknown> | null> {
     EventUtils.validateTenantId(
       { tenantId },
       "CodingAgentSessionClickHouseRepository.findBySessionId",
@@ -337,8 +348,35 @@ export class CodingAgentSessionClickHouseRepository
     });
 
     const rows = await result.json<Record<string, unknown>>();
-    const first = rows[0];
-    return first ? fromRecord(first) : null;
+    return rows[0] ?? null;
+  }
+
+  /** One session by its key, or null. */
+  async findBySessionId(params: {
+    tenantId: string;
+    sessionId: string;
+    startedAtMs?: number;
+  }): Promise<CodingAgentSessionRow | null> {
+    const record = await this.findLatestRecord(params);
+    return record ? fromRecord(record) : null;
+  }
+
+  /**
+   * The session plus its applied-event-id watermark (ADR-066, migration 00054).
+   * One ClickHouse read — the same query as `findBySessionId` — with the
+   * watermark carried alongside the mapped row rather than inside it.
+   */
+  async findBySessionIdWithApplied(params: {
+    tenantId: string;
+    sessionId: string;
+    startedAtMs?: number;
+  }): Promise<{ row: CodingAgentSessionRow; appliedEventIds: string[] } | null> {
+    const record = await this.findLatestRecord(params);
+    if (!record) return null;
+    return {
+      row: fromRecord(record),
+      appliedEventIds: asStringArray(record.AppliedEventIds),
+    };
   }
 
   /**
@@ -406,7 +444,11 @@ export class CodingAgentSessionClickHouseRepository
   }
 
   async upsertBatch(
-    entries: Array<{ row: CodingAgentSessionRow; retentionDays?: number }>,
+    entries: Array<{
+      row: CodingAgentSessionRow;
+      retentionDays?: number;
+      appliedEventIds?: readonly string[];
+    }>,
   ): Promise<void> {
     if (entries.length === 0) return;
 
@@ -431,8 +473,8 @@ export class CodingAgentSessionClickHouseRepository
     try {
       await client.insert({
         table: TABLE_NAME,
-        values: entries.map(({ row, retentionDays }) =>
-          toRecord(row, retentionDays),
+        values: entries.map(({ row, retentionDays, appliedEventIds }) =>
+          toRecord(row, retentionDays, appliedEventIds),
         ),
         format: "JSONEachRow",
         clickhouse_settings: { async_insert: 1, wait_for_async_insert: 1 },

--- a/langwatch/src/server/app-layer/coding-agent/repositories/coding-agent-session.repository.ts
+++ b/langwatch/src/server/app-layer/coding-agent/repositories/coding-agent-session.repository.ts
@@ -8,11 +8,25 @@ import type { CodingAgentSessionRow } from "~/server/event-sourcing/pipelines/co
  * per (TenantId, SessionId), so a re-fold simply writes a newer version.
  */
 export interface CodingAgentSessionRepository {
-  upsert(row: CodingAgentSessionRow, retentionDays?: number): Promise<void>;
+  /**
+   * `appliedEventIds` is the executor's redelivery-dedup watermark (ADR-066,
+   * migration 00054): the ids folded into this write, persisted next to the row
+   * so a retry with a cold cache still recognises a batch it already committed.
+   * Not part of the row — it is fold bookkeeping, not session state.
+   */
+  upsert(
+    row: CodingAgentSessionRow,
+    retentionDays?: number,
+    appliedEventIds?: readonly string[],
+  ): Promise<void>;
 
   /** Batch path. The store falls back to per-row upsert when absent. */
   upsertBatch?(
-    rows: Array<{ row: CodingAgentSessionRow; retentionDays?: number }>,
+    rows: Array<{
+      row: CodingAgentSessionRow;
+      retentionDays?: number;
+      appliedEventIds?: readonly string[];
+    }>,
   ): Promise<void>;
 
   /**
@@ -24,6 +38,18 @@ export interface CodingAgentSessionRepository {
     sessionId: string;
     startedAtMs?: number;
   }): Promise<CodingAgentSessionRow | null>;
+
+  /**
+   * The same session as `findBySessionId`, plus the applied-event-id watermark
+   * persisted next to it (ADR-066, migration 00054). Same query — the read-back
+   * store uses this on a cache miss so a retry can dedup a redelivered batch
+   * without the cache. Null when no row exists.
+   */
+  findBySessionIdWithApplied(params: {
+    tenantId: string;
+    sessionId: string;
+    startedAtMs?: number;
+  }): Promise<{ row: CodingAgentSessionRow; appliedEventIds: string[] } | null>;
 
   /**
    * A project's coding-agent sessions in a period, newest first. The time
@@ -53,6 +79,13 @@ export class NullCodingAgentSessionRepository
   }
 
   async findBySessionId(): Promise<CodingAgentSessionRow | null> {
+    return null;
+  }
+
+  async findBySessionIdWithApplied(): Promise<{
+    row: CodingAgentSessionRow;
+    appliedEventIds: string[];
+  } | null> {
     return null;
   }
 

--- a/langwatch/src/server/clickhouse/migrations/00054_coding_agent_sessions_applied_event_ids.sql
+++ b/langwatch/src/server/clickhouse/migrations/00054_coding_agent_sessions_applied_event_ids.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- ============================================================================
+-- coding_agent_sessions — durable dedup watermark (ADR-066, sequencing step 4).
+--
+-- Queue delivery is at-least-once. The applied-event-id set that lets a fold
+-- recognise a redelivered batch lived only in the Redis cache entry, so a
+-- committed write followed by a lost cache (TTL, eviction, restart) let a retry
+-- re-fold the same batch onto state that already contained it — a silent
+-- double-count. This column rides that set next to the state row so redelivery
+-- dedup survives cache loss. Bounded to the in-flight batch.
+-- ============================================================================
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions
+  ADD COLUMN IF NOT EXISTS AppliedEventIds Array(String) CODEC(ZSTD(1));
+-- +goose StatementEnd
+
+-- +goose Down
+-- Down migrations are commented out to prevent accidental data loss.
+-- To roll back, uncomment and run manually.
+--
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.coding_agent_sessions DROP COLUMN IF EXISTS AppliedEventIds;

--- a/langwatch/src/server/event-sourcing/eventSourcing.ts
+++ b/langwatch/src/server/event-sourcing/eventSourcing.ts
@@ -509,6 +509,12 @@ export class EventSourcing {
         const result = this.lookupEntry(payload);
         return result?.entry.coalesceMaxBatch ?? 1;
       },
+      coalesceMaxBytes: (payload: Record<string, unknown>) => {
+        // Resolve the same way as coalesceMaxBatch: per-job via routing meta.
+        // undefined falls back to the GroupQueue's DEFAULT_COALESCE_MAX_BYTES.
+        const result = this.lookupEntry(payload);
+        return result?.entry.coalesceMaxBytes;
+      },
       processBatch: async (payloads: Record<string, unknown>[]) => {
         if (payloads.length === 0) return;
         // A coalesced batch is always one group → one registry entry. Resolve

--- a/langwatch/src/server/event-sourcing/pipeline/staticBuilder.types.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/staticBuilder.types.ts
@@ -41,6 +41,20 @@ export interface CommandHandlerOptions<Payload = any> {
   getGroupKey?: (payload: Payload) => string;
   /** Share one command queue group per tenant and aggregate across command types. */
   serializeByAggregate?: boolean;
+  /**
+   * Coalesce this producer's appends into one multi-row insert (ADR-066 pillar
+   * 2). Set the max same-command jobs (including the dispatched one) to fold per
+   * batch when one aggregate can mint events faster than they drain (a hot
+   * trigger recording every match). Leave unset for a low-fan-in producer that
+   * appends at most one event per human action — it appends immediately.
+   */
+  coalesceMaxBatch?: number;
+  /**
+   * Optional byte cap for a coalesced batch (ADR-066 pillar 2); the drain stops
+   * before a job that would overflow it. Unset uses the GroupQueue default. Only
+   * consulted when `coalesceMaxBatch` enables coalescing.
+   */
+  coalesceMaxBytes?: number;
   makeJobId?: (payload: Payload) => string;
   delay?: number;
   concurrency?: number;

--- a/langwatch/src/server/event-sourcing/pipeline/staticBuilder.types.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/staticBuilder.types.ts
@@ -34,27 +34,46 @@ export interface KillSwitchOptions {
 }
 
 /**
- * Options for configuring a command handler in a static pipeline definition.
+ * Queue serialization and append-coalescing options (ADR-066 pillar 2), shared
+ * by both {@link CommandHandlerOptions} declarations — the static-pipeline
+ * builder's here and the dispatcher's runtime shape. Declared once so the JSDoc
+ * for these fields lives in a single place; both interfaces extend it rather
+ * than hand-syncing two copies.
  */
-export interface CommandHandlerOptions<Payload = any> {
-  getAggregateId?: (payload: Payload) => string;
-  getGroupKey?: (payload: Payload) => string;
-  /** Share one command queue group per tenant and aggregate across command types. */
+export interface CommandSerializationOptions {
+  /**
+   * Serialize this command with every other command that enables the option
+   * for the same tenant and aggregate. This keeps command handling, event
+   * append, and projection staging atomic with respect to the next command
+   * for that aggregate while allowing other aggregates to run concurrently.
+   */
   serializeByAggregate?: boolean;
   /**
-   * Coalesce this producer's appends into one multi-row insert (ADR-066 pillar
-   * 2). Set the max same-command jobs (including the dispatched one) to fold per
-   * batch when one aggregate can mint events faster than they drain (a hot
-   * trigger recording every match). Leave unset for a low-fan-in producer that
-   * appends at most one event per human action — it appends immediately.
+   * Coalesce this producer's appends (ADR-066 pillar 2). When one aggregate can
+   * mint events faster than they drain — a hot trigger recording every match —
+   * set the max number of same-command jobs (including the dispatched one) to
+   * fold into a single multi-row insert. Leave unset (or ≤ 1) for a low-fan-in
+   * producer where one aggregate appends at most one event per human action:
+   * those append immediately, with the per-job path unchanged.
    */
   coalesceMaxBatch?: number;
   /**
-   * Optional byte cap for a coalesced batch (ADR-066 pillar 2); the drain stops
-   * before a job that would overflow it. Unset uses the GroupQueue default. Only
-   * consulted when `coalesceMaxBatch` enables coalescing.
+   * Optional byte cap for a coalesced batch (ADR-066 pillar 2). The drain stops
+   * before a job that would push the batch past this size, keeping one insert
+   * inside the downstream flush budget; a job too large to fit becomes its own
+   * dispatch. Unset falls back to the GroupQueue default. Only consulted when
+   * `coalesceMaxBatch` enables coalescing.
    */
   coalesceMaxBytes?: number;
+}
+
+/**
+ * Options for configuring a command handler in a static pipeline definition.
+ */
+export interface CommandHandlerOptions<Payload = any>
+  extends CommandSerializationOptions {
+  getAggregateId?: (payload: Payload) => string;
+  getGroupKey?: (payload: Payload) => string;
   makeJobId?: (payload: Payload) => string;
   delay?: number;
   concurrency?: number;

--- a/langwatch/src/server/event-sourcing/pipelines/automations/__tests__/automationsPipeline.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/automations/__tests__/automationsPipeline.integration.test.ts
@@ -1,6 +1,12 @@
 import { TriggerAction } from "@prisma/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Redis } from "ioredis";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
+import {
+  getTestRedisConnection,
+  startTestContainers,
+  stopTestContainers,
+} from "../../../__tests__/integration/testContainers";
 import { createTenantId } from "../../../domain/tenantId";
 import { EventSourcing } from "../../../eventSourcing";
 import { mapCommands } from "../../../mapCommands";
@@ -232,3 +238,97 @@ describe("automations pipeline", () => {
     });
   });
 });
+
+// ADR-066 pillar 2 — the redis:null suites above never coalesce (the in-memory
+// queue processes one job at a time), so the coalesced processCommandBatch path
+// through the REAL recordTriggerMatch handler stays unexercised there. This suite
+// runs a redis-backed GroupQueue with the coalescing consumer live and proves the
+// end-to-end observable: several matches for one trigger collapse into one
+// multi-row event-store write, every match's distinct idempotency key preserved.
+const hasRedis = !!(process.env.REDIS_URL || process.env.CI_REDIS_URL);
+
+describe.skipIf(!hasRedis)(
+  "automations pipeline — coalesced redis-backed dispatch",
+  () => {
+    let redis: Redis;
+
+    beforeAll(async () => {
+      await startTestContainers();
+      redis = getTestRedisConnection()!;
+    });
+
+    afterAll(async () => {
+      await stopTestContainers();
+    });
+
+    afterEach(async () => {
+      await redis.flushall();
+    });
+
+    describe("given several matches for one trigger staged as a batch", () => {
+      describe("when the coalescing consumer drains them", () => {
+        it("stores every match in one multi-row call with distinct idempotency keys", async () => {
+          const processStore = new InMemoryProcessStore();
+          // processRole "all" runs the worker so the GroupQueue consumer actually
+          // drains and coalesces; no clickhouse → the in-memory event store backs
+          // reads, and we spy on its multi-row write.
+          const eventSourcing = new EventSourcing({
+            processStore,
+            redis,
+            processRole: "all",
+          });
+
+          try {
+            const pipeline = eventSourcing.register(
+              createAutomationsPipeline(pipelineDeps()),
+            );
+            const commands = mapCommands(pipeline.commands);
+
+            const eventStore = eventSourcing.getEventStore<AutomationEvent>()!;
+            const storeSpy = vi.spyOn(eventStore, "storeEvents");
+
+            // sendBatch stages all three atomically in one group, so the drain
+            // folds them into a single processCommandBatch call. Per-command
+            // sends would race the consumer and might never coalesce.
+            await commands.recordTriggerMatch.sendBatch!([
+              command("trace-1", 1_000),
+              command("trace-2", 2_000),
+              command("trace-3", 3_000),
+            ]);
+
+            await vi.waitFor(
+              async () => {
+                const events = await eventStore.getEvents(
+                  "trigger-1",
+                  { tenantId },
+                  "trigger",
+                );
+                expect(events).toHaveLength(3);
+              },
+              { timeout: 15_000, interval: 50 },
+            );
+
+            // One multi-row store call carried all three matches — the coalesced
+            // path collapsed three single-row appends into one insert.
+            const multiRowCalls = storeSpy.mock.calls.filter(
+              ([events]) => (events as readonly AutomationEvent[]).length > 1,
+            );
+            expect(multiRowCalls).toHaveLength(1);
+            const [batchedEvents] = multiRowCalls[0]!;
+            expect(
+              (batchedEvents as readonly AutomationEvent[]).map(
+                (event) => event.idempotencyKey,
+              ),
+            ).toEqual([
+              "trigger-1:trace-1:30000-0",
+              "trigger-1:trace-2:30000-0",
+              "trigger-1:trace-3:30000-0",
+            ]);
+          } finally {
+            await eventSourcing.close();
+          }
+        });
+      });
+    });
+  },
+);

--- a/langwatch/src/server/event-sourcing/pipelines/automations/__tests__/automationsPipeline.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/automations/__tests__/automationsPipeline.integration.test.ts
@@ -7,6 +7,10 @@ import {
   startTestContainers,
   stopTestContainers,
 } from "../../../__tests__/integration/testContainers";
+import {
+  cleanupTestDataForTenant,
+  getTenantIdString,
+} from "../../../__tests__/integration/testHelpers";
 import { createTenantId } from "../../../domain/tenantId";
 import { EventSourcing } from "../../../eventSourcing";
 import { mapCommands } from "../../../mapCommands";
@@ -262,7 +266,11 @@ describe.skipIf(!hasRedis)(
     });
 
     afterEach(async () => {
-      await redis.flushall();
+      // Tenant-scoped cleanup, not redis.flushall(): flushall bypasses tenant
+      // isolation and races other parallel suites on the shared test redis. The
+      // GroupQueue's own keys are torn down by eventSourcing.close() in the test
+      // body's finally; this drops any per-tenant rows left behind.
+      await cleanupTestDataForTenant(getTenantIdString(tenantId));
     });
 
     describe("given several matches for one trigger staged as a batch", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/automations/__tests__/automationsPipeline.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/automations/__tests__/automationsPipeline.integration.test.ts
@@ -12,6 +12,7 @@ import {
   createAutomationsPipeline,
   type AutomationsPipelineDeps,
 } from "../pipeline";
+import { TRIGGER_MATCH_COALESCE_MAX_BATCH } from "../schemas/constants";
 
 const tenantId = createTenantId("project-1");
 
@@ -123,7 +124,50 @@ describe("automations pipeline", () => {
     });
   });
 
+  // ADR-066 pillar 2: recordTriggerMatch opts into append coalescing. This suite
+  // runs on the in-memory queue (redis: null), which processes one job at a time
+  // and does NOT coalesce — so the "N matches → fewer inserts" observable is
+  // proven end-to-end at the GroupQueue layer (groupQueue.integration.test.ts,
+  // scripts.integration.test.ts). Here we pin the adopter's opt-in and confirm
+  // the config leaves every match durably recorded and in FIFO order.
   describe("given several matches for one trigger", () => {
+    describe("when coalescing is configured on the producer", () => {
+      it("registers recordTriggerMatch with append coalescing enabled", () => {
+        const builtPipeline = createAutomationsPipeline(pipelineDeps());
+        const recordMatch = builtPipeline.commands.find(
+          (c) => c.name === "recordTriggerMatch",
+        );
+
+        expect(recordMatch?.options?.coalesceMaxBatch).toBe(
+          TRIGGER_MATCH_COALESCE_MAX_BATCH,
+        );
+        expect(recordMatch?.options?.serializeByAggregate).toBe(true);
+      });
+
+      it("records every match durably in FIFO order", async () => {
+        const processStore = new InMemoryProcessStore();
+        eventSourcing = new EventSourcing({ processStore, redis: null });
+        const pipeline = eventSourcing.register(
+          createAutomationsPipeline(pipelineDeps()),
+        );
+        const commands = mapCommands(pipeline.commands);
+
+        await commands.recordTriggerMatch(command("trace-1", 1_000));
+        await commands.recordTriggerMatch(command("trace-2", 2_000));
+        await commands.recordTriggerMatch(command("trace-3", 3_000));
+
+        const events = await eventSourcing
+          .getEventStore<AutomationEvent>()!
+          .getEvents("trigger-1", { tenantId }, "trigger");
+
+        expect(events.map((event) => event.idempotencyKey)).toEqual([
+          "trigger-1:trace-1:30000-0",
+          "trigger-1:trace-2:30000-0",
+          "trigger-1:trace-3:30000-0",
+        ]);
+      });
+    });
+
     describe("when commands and committed events are delivered", () => {
       it("keeps FIFO ordering through the trigger process", async () => {
         const processStore = new InMemoryProcessStore();

--- a/langwatch/src/server/event-sourcing/pipelines/automations/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/automations/pipeline.ts
@@ -40,7 +40,10 @@ import {
   pruneSchema,
   webhookDeliveryPruneWake,
 } from "./process-manager/webhookDeliveryPrune.process";
-import { TRIGGER_MATCH_RECORDED_EVENT_TYPE } from "./schemas/constants";
+import {
+  TRIGGER_MATCH_COALESCE_MAX_BATCH,
+  TRIGGER_MATCH_RECORDED_EVENT_TYPE,
+} from "./schemas/constants";
 import type { AutomationEvent } from "./schemas/events";
 
 const logger = createLogger("langwatch:triggers:automations-pipeline");
@@ -92,6 +95,10 @@ export function createAutomationsPipeline(deps: AutomationsPipelineDeps) {
     .withAggregateType("trigger")
     .withCommand("recordTriggerMatch", RecordTriggerMatchCommand, {
       serializeByAggregate: true,
+      // ADR-066 pillar 2: a hot trigger appends one match per trace. Coalesce a
+      // backed-up trigger's matches into one multi-row insert instead of one
+      // tiny insert per match.
+      coalesceMaxBatch: TRIGGER_MATCH_COALESCE_MAX_BATCH,
     })
     .withProcessManager("triggerSettlement", (pm) =>
       pm

--- a/langwatch/src/server/event-sourcing/pipelines/automations/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/automations/schemas/constants.ts
@@ -3,6 +3,16 @@ export const RECORD_TRIGGER_MATCH_COMMAND_TYPE =
 export const TRIGGER_MATCH_RECORDED_EVENT_TYPE =
   "lw.automation.trigger.match_recorded" as const;
 
+/**
+ * Append-coalescing bound for recordTriggerMatch (ADR-066 pillar 2). A hot
+ * trigger records one match per trace; at high fan-in that is one tiny
+ * event_log insert per match, which floods the log with small parts. Folding up
+ * to this many same-trigger matches into a single multi-row insert keeps the
+ * producer off the per-item write path. Mirrors LOG/METRIC_MAP_COALESCE_MAX_BATCH
+ * (256) at a slightly lower count — a byte bound backs it up in the drain.
+ */
+export const TRIGGER_MATCH_COALESCE_MAX_BATCH = 200;
+
 export const AUTOMATIONS_COMMAND_TYPES = [
   RECORD_TRIGGER_MATCH_COMMAND_TYPE,
 ] as const;

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.store.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.store.unit.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import type { CodingAgentSessionRepository } from "~/server/app-layer/coding-agent/repositories/coding-agent-session.repository";
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import type { ProjectionStoreContext } from "~/server/event-sourcing/projections/projectionStoreContext";
+import {
+  type CodingAgentSessionRow,
+  type CodingAgentSessionState,
+  CODING_AGENT_SESSION_PROJECTION_VERSION_LATEST,
+  projectCodingAgentSessionToRow,
+} from "../codingAgentSession.foldProjection";
+import { CodingAgentSessionStore } from "../codingAgentSession.store";
+import { createInitCodingAgentSession } from "../../services/coding-agent-session.derivation";
+
+/**
+ * The store adapter's half of the durable dedup watermark (ADR-066): it threads
+ * `context.appliedEventIds` into the repository write, and reads the set back
+ * through `getWithApplied` so a retry with a cold cache can recognise a batch it
+ * already committed. `get()` delegates to `getWithApplied` so the two read paths
+ * cannot diverge.
+ */
+const tenantId = createTenantId("tenant-1");
+
+function makeState(
+  over: Partial<CodingAgentSessionState> = {},
+): CodingAgentSessionState {
+  return {
+    ...createInitCodingAgentSession(),
+    sessionKeySource: "provider",
+    traceIds: [],
+    startedAtMs: 1_000,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    LastEventOccurredAt: 1_000,
+    ...over,
+  };
+}
+
+function makeRow(state: CodingAgentSessionState): CodingAgentSessionRow {
+  return projectCodingAgentSessionToRow({
+    state,
+    tenantId: String(tenantId),
+    sessionId: "session-1",
+    version: CODING_AGENT_SESSION_PROJECTION_VERSION_LATEST,
+  });
+}
+
+/** Fake repository capturing writes and answering the read-back query. */
+class FakeRepo implements CodingAgentSessionRepository {
+  upsertCalls: Array<{
+    row: CodingAgentSessionRow;
+    retentionDays?: number;
+    appliedEventIds?: readonly string[];
+  }> = [];
+  batchEntries: Array<{
+    row: CodingAgentSessionRow;
+    retentionDays?: number;
+    appliedEventIds?: readonly string[];
+  }> = [];
+  withApplied: { row: CodingAgentSessionRow; appliedEventIds: string[] } | null =
+    null;
+  lastFindParams:
+    | { tenantId: string; sessionId: string; startedAtMs?: number }
+    | undefined;
+
+  async upsert(
+    row: CodingAgentSessionRow,
+    retentionDays?: number,
+    appliedEventIds?: readonly string[],
+  ): Promise<void> {
+    this.upsertCalls.push({ row, retentionDays, appliedEventIds });
+  }
+
+  async upsertBatch(
+    entries: Array<{
+      row: CodingAgentSessionRow;
+      retentionDays?: number;
+      appliedEventIds?: readonly string[];
+    }>,
+  ): Promise<void> {
+    this.batchEntries.push(...entries);
+  }
+
+  async findBySessionId(): Promise<CodingAgentSessionRow | null> {
+    return this.withApplied?.row ?? null;
+  }
+
+  async findBySessionIdWithApplied(params: {
+    tenantId: string;
+    sessionId: string;
+    startedAtMs?: number;
+  }): Promise<{ row: CodingAgentSessionRow; appliedEventIds: string[] } | null> {
+    this.lastFindParams = params;
+    return this.withApplied;
+  }
+
+  async findManyRecent(): Promise<CodingAgentSessionRow[]> {
+    return [];
+  }
+}
+
+const context = (over: Partial<ProjectionStoreContext> = {}): ProjectionStoreContext => ({
+  aggregateId: "session-1",
+  tenantId,
+  ...over,
+});
+
+describe("CodingAgentSessionStore durable dedup", () => {
+  describe("given a fold step commits state", () => {
+    describe("when the context carries applied event ids", () => {
+      it("forwards them to the repository upsert as the durable watermark", async () => {
+        const repo = new FakeRepo();
+        const store = new CodingAgentSessionStore(repo);
+
+        await store.store(
+          makeState(),
+          context({ appliedEventIds: ["e1", "e2"] }),
+        );
+
+        expect(repo.upsertCalls).toHaveLength(1);
+        expect(repo.upsertCalls[0]!.appliedEventIds).toEqual(["e1", "e2"]);
+      });
+    });
+
+    describe("when the context carries no applied event ids", () => {
+      it("forwards an empty watermark rather than omitting it", async () => {
+        const repo = new FakeRepo();
+        const store = new CodingAgentSessionStore(repo);
+
+        await store.store(makeState(), context());
+
+        expect(repo.upsertCalls[0]!.appliedEventIds).toEqual([]);
+      });
+    });
+  });
+
+  describe("given a batch commits several states", () => {
+    describe("when each entry carries its own applied event ids", () => {
+      it("forwards each entry's watermark to the batch write", async () => {
+        const repo = new FakeRepo();
+        const store = new CodingAgentSessionStore(repo);
+
+        await store.storeBatch([
+          {
+            state: makeState(),
+            context: context({ appliedEventIds: ["e1"] }),
+          },
+          {
+            state: makeState(),
+            context: context({
+              aggregateId: "session-2",
+              appliedEventIds: ["e2", "e3"],
+            }),
+          },
+        ]);
+
+        expect(repo.batchEntries.map((e) => e.appliedEventIds)).toEqual([
+          ["e1"],
+          ["e2", "e3"],
+        ]);
+      });
+    });
+  });
+
+  describe("given the read-back store holds a committed session", () => {
+    describe("when the fold reads the state with its watermark", () => {
+      /** @scenario a redelivered batch after a committed write does not double-count */
+      it("maps the row to state and returns the persisted watermark", async () => {
+        const repo = new FakeRepo();
+        const state = makeState({ modelCalls: 3 });
+        repo.withApplied = { row: makeRow(state), appliedEventIds: ["e1", "e2"] };
+        const store = new CodingAgentSessionStore(repo);
+
+        const result = await store.getWithApplied(
+          "session-1",
+          context({ occurredAtMs: 4_242 }),
+        );
+
+        expect(result.state?.modelCalls).toBe(3);
+        expect(result.appliedEventIds).toEqual(["e1", "e2"]);
+        // The occurredAt hint is threaded through as the partition-pruning key.
+        expect(repo.lastFindParams?.startedAtMs).toBe(4_242);
+      });
+    });
+
+    describe("when the session has never been folded", () => {
+      it("returns null state and an empty watermark", async () => {
+        const repo = new FakeRepo();
+        repo.withApplied = null;
+        const store = new CodingAgentSessionStore(repo);
+
+        const result = await store.getWithApplied("session-1", context());
+
+        expect(result.state).toBeNull();
+        expect(result.appliedEventIds).toEqual([]);
+      });
+    });
+  });
+
+  describe("given get() is called", () => {
+    describe("when a committed session exists", () => {
+      it("delegates to getWithApplied and returns state only", async () => {
+        const repo = new FakeRepo();
+        const state = makeState({ modelCalls: 7 });
+        repo.withApplied = { row: makeRow(state), appliedEventIds: ["e1"] };
+        const store = new CodingAgentSessionStore(repo);
+
+        const result = await store.get("session-1", context());
+
+        expect(result?.modelCalls).toBe(7);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.store.ts
@@ -28,8 +28,12 @@ export class CodingAgentSessionStore
     state: CodingAgentSessionState,
     context: ProjectionStoreContext,
   ): Promise<void> {
-    const result = this.toRow(state, context);
-    await this.repo.upsert(result.row, result.retentionDays);
+    const entry = this.toRow(state, context);
+    await this.repo.upsert(
+      entry.row,
+      entry.retentionDays,
+      entry.appliedEventIds,
+    );
   }
 
   async storeBatch(
@@ -48,8 +52,8 @@ export class CodingAgentSessionStore
       return;
     }
     await Promise.all(
-      rows.map(({ row, retentionDays }) =>
-        this.repo.upsert(row, retentionDays),
+      rows.map(({ row, retentionDays, appliedEventIds }) =>
+        this.repo.upsert(row, retentionDays, appliedEventIds),
       ),
     );
   }
@@ -60,6 +64,7 @@ export class CodingAgentSessionStore
   ): {
     row: ReturnType<typeof projectCodingAgentSessionToRow>;
     retentionDays: number;
+    appliedEventIds: string[];
   } {
     return {
       row: projectCodingAgentSessionToRow({
@@ -70,31 +75,53 @@ export class CodingAgentSessionStore
       }),
       retentionDays:
         context.retentionPolicy?.traces ?? PLATFORM_DEFAULT_RETENTION_DAYS,
+      // The executor's redelivery-dedup watermark, persisted next to the row so
+      // a retry with a cold cache still recognises a batch it committed.
+      appliedEventIds: context.appliedEventIds
+        ? [...context.appliedEventIds]
+        : [],
     };
   }
 
   /**
-   * Read the session's last committed state back (ADR-066) — the CH-fallthrough
-   * side of the read path: `RedisCachedFoldStore` serves the warm cache and only
-   * calls this on a miss. The row round-trips the full working state — counters,
-   * ordered steps (with their start times), the sub-agent dedup set, the
-   * previous-call context size, and the converged metric units — so a miss reads
-   * ONE point row and decodes it. It never replays `event_log`; that is the
+   * Read the session's last committed state back together with the
+   * applied-event-id watermark persisted next to it (ADR-066) — the
+   * CH-fallthrough side of the read path: `RedisCachedFoldStore` serves the warm
+   * cache and only calls this on a miss. The row round-trips the full working
+   * state — counters, ordered steps (with their start times), the sub-agent
+   * dedup set, the previous-call context size, and the converged metric units —
+   * plus the watermark, so a retry that reaches a cold cache can still recognise
+   * a batch it already committed. It never replays `event_log`; that is the
    * offline rebuild path, not this one.
    *
    * `context.occurredAtMs` prunes the read to a window of partitions around the
    * event being folded; absent, the repository scans (still keyed, still
    * correct — just not partition-pruned).
    */
-  async get(
+  async getWithApplied(
     aggregateId: string,
     context: ProjectionStoreContext,
-  ): Promise<CodingAgentSessionState | null> {
-    const row = await this.repo.findBySessionId({
+  ): Promise<{
+    state: CodingAgentSessionState | null;
+    appliedEventIds: string[];
+  }> {
+    const found = await this.repo.findBySessionIdWithApplied({
       tenantId: String(context.tenantId),
       sessionId: aggregateId,
       startedAtMs: context.occurredAtMs,
     });
-    return row ? codingAgentSessionStateFromRow(row) : null;
+    if (!found) return { state: null, appliedEventIds: [] };
+    return {
+      state: codingAgentSessionStateFromRow(found.row),
+      appliedEventIds: found.appliedEventIds,
+    };
+  }
+
+  /** State only; delegates to `getWithApplied` so the two paths cannot diverge. */
+  async get(
+    aggregateId: string,
+    context: ProjectionStoreContext,
+  ): Promise<CodingAgentSessionState | null> {
+    return (await this.getWithApplied(aggregateId, context)).state;
   }
 }

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.durableDedup.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.durableDedup.unit.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "../../domain/types";
+import {
+  createMockFoldProjectionDefinition,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../services/__tests__/testHelpers";
+import type { FoldProjectionStore } from "../foldProjection.types";
+import { FoldProjectionExecutor } from "../foldProjectionExecutor";
+import type { ProjectionStoreContext } from "../projectionStoreContext";
+
+/**
+ * Durable dedup watermark (ADR-066, sequencing step 4).
+ *
+ * A store that exposes `getWithApplied` persists the applied-event-id set next
+ * to its state row, so a retry that reaches a cold cache still learns which
+ * events an earlier attempt committed. The executor prefers that set over a
+ * blind re-apply, and — critically — records the UNION of the loaded set and
+ * the fresh ids at commit, so a retry chain that keeps losing its cache cannot
+ * lose track of a batch it already folded in.
+ */
+describe("FoldProjectionExecutor durable dedup", () => {
+  const tenantId = createTestTenantId();
+
+  interface FoldState {
+    ids: string[];
+    LastEventOccurredAt: number;
+  }
+
+  const init = (): FoldState => ({ ids: [], LastEventOccurredAt: 0 });
+
+  function makeEvent(id: string, createdAt: number): Event {
+    return createTestEvent(
+      TEST_CONSTANTS.AGGREGATE_ID,
+      TEST_CONSTANTS.AGGREGATE_TYPE,
+      tenantId,
+      undefined,
+      createdAt,
+      undefined,
+      {},
+      id,
+    );
+  }
+
+  /**
+   * A store whose durable read (`getWithApplied`) answers with a preset state
+   * and applied-event-id set — the shape a read-back store returns from
+   * ClickHouse when the Redis cache is cold.
+   */
+  function durableStore({
+    state,
+    appliedEventIds,
+  }: {
+    state: FoldState | null;
+    appliedEventIds: string[];
+  }): {
+    store: FoldProjectionStore<FoldState>;
+    storeFn: ReturnType<typeof vi.fn>;
+  } {
+    const storeFn = vi.fn().mockResolvedValue(undefined);
+    const store: FoldProjectionStore<FoldState> = {
+      get: vi.fn().mockResolvedValue(state),
+      getWithApplied: vi.fn().mockResolvedValue({ state, appliedEventIds }),
+      store: storeFn,
+    };
+    return { store, storeFn };
+  }
+
+  function appendingApply() {
+    return vi.fn((state: FoldState, event: Event): FoldState => ({
+      ids: [...state.ids, event.id],
+      LastEventOccurredAt: Math.max(
+        state.LastEventOccurredAt,
+        event.occurredAt ?? 0,
+      ),
+    }));
+  }
+
+  const contextWith = (
+    over: Partial<ProjectionStoreContext>,
+  ): ProjectionStoreContext => ({
+    aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+    tenantId,
+    ...over,
+  });
+
+  let executor: FoldProjectionExecutor;
+
+  beforeEach(() => {
+    executor = new FoldProjectionExecutor();
+  });
+
+  describe("given the durable applied-set already contains the redelivered batch", () => {
+    describe("when the same batch is redelivered on a retry with a cold cache", () => {
+      /** @scenario a redelivered batch after a committed write does not double-count */
+      it("does not re-apply, does not re-store, and returns the loaded state", async () => {
+        const a = makeEvent("a", 1000);
+        const b = makeEvent("b", 2000);
+        const loadedState: FoldState = {
+          ids: ["a", "b"],
+          LastEventOccurredAt: 2000,
+        };
+        const { store, storeFn } = durableStore({
+          state: loadedState,
+          appliedEventIds: ["a", "b"],
+        });
+        const apply = appendingApply();
+        const fold = createMockFoldProjectionDefinition("dedup", {
+          store,
+          init,
+          apply,
+        });
+
+        const result = (await executor.executeBatch(fold, [a, b], {
+          aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+          tenantId,
+          deliveryAttempt: 2,
+        })) as FoldState;
+
+        expect(apply).not.toHaveBeenCalled();
+        expect(storeFn).not.toHaveBeenCalled();
+        expect(result).toBe(loadedState);
+      });
+    });
+  });
+
+  describe("given a retry chain that keeps losing its cache", () => {
+    describe("when attempt 2 delivers the whole batch against the acked prefix", () => {
+      it("folds only the fresh remainder and records the union of loaded and fresh ids", async () => {
+        const [a, b, c, d] = [
+          makeEvent("a", 1000),
+          makeEvent("b", 2000),
+          makeEvent("c", 3000),
+          makeEvent("d", 4000),
+        ];
+        // Attempt 1 committed {a,b} then crashed pre-ack; its cache entry was
+        // lost, so only the durable row's {a,b} remains.
+        const { store, storeFn } = durableStore({
+          state: { ids: ["a", "b"], LastEventOccurredAt: 2000 },
+          appliedEventIds: ["a", "b"],
+        });
+        const fold = createMockFoldProjectionDefinition("dedup", {
+          store,
+          init,
+          apply: appendingApply(),
+        });
+
+        const result = (await executor.executeBatch(
+          fold,
+          [a!, b!, c!, d!],
+          contextWith({ deliveryAttempt: 2 }),
+        )) as FoldState;
+
+        // Only c and d were fresh; a and b were recognised and dropped.
+        expect(result.ids).toEqual(["a", "b", "c", "d"]);
+        expect(storeFn).toHaveBeenCalledTimes(1);
+        // The commit records the UNION, so a later redelivery of the whole
+        // batch against this row recognises every event.
+        expect(storeFn.mock.calls[0]![1].appliedEventIds).toEqual([
+          "a",
+          "b",
+          "c",
+          "d",
+        ]);
+      });
+    });
+
+    describe("when a subsequent attempt 3 redelivers the whole batch against the union", () => {
+      it("drops every event and never stores", async () => {
+        const [a, b, c, d] = [
+          makeEvent("a", 1000),
+          makeEvent("b", 2000),
+          makeEvent("c", 3000),
+          makeEvent("d", 4000),
+        ];
+        const loadedState: FoldState = {
+          ids: ["a", "b", "c", "d"],
+          LastEventOccurredAt: 4000,
+        };
+        const { store, storeFn } = durableStore({
+          state: loadedState,
+          appliedEventIds: ["a", "b", "c", "d"],
+        });
+        const apply = appendingApply();
+        const fold = createMockFoldProjectionDefinition("dedup", {
+          store,
+          init,
+          apply,
+        });
+
+        const result = (await executor.executeBatch(
+          fold,
+          [a!, b!, c!, d!],
+          contextWith({ deliveryAttempt: 3 }),
+        )) as FoldState;
+
+        expect(apply).not.toHaveBeenCalled();
+        expect(storeFn).not.toHaveBeenCalled();
+        expect(result).toBe(loadedState);
+      });
+    });
+  });
+
+  describe("given a fresh delivery", () => {
+    describe("when the batch commits", () => {
+      it("records only this batch's ids, resetting the durable set", async () => {
+        const a = makeEvent("a", 3000);
+        const b = makeEvent("b", 4000);
+        // A previous, acked batch left {x,y} on the durable row. A fresh
+        // delivery means that batch completed, so its ids can never be
+        // redelivered and must not be carried forward.
+        const { store, storeFn } = durableStore({
+          state: { ids: ["x", "y"], LastEventOccurredAt: 500 },
+          appliedEventIds: ["x", "y"],
+        });
+        const fold = createMockFoldProjectionDefinition("dedup", {
+          store,
+          init,
+          apply: appendingApply(),
+        });
+
+        await executor.executeBatch(
+          fold,
+          [a, b],
+          contextWith({ deliveryAttempt: 1 }),
+        );
+
+        expect(storeFn).toHaveBeenCalledTimes(1);
+        expect(storeFn.mock.calls[0]![1].appliedEventIds).toEqual(["a", "b"]);
+      });
+    });
+  });
+
+  describe("given a single redelivered event on the execute path", () => {
+    describe("when the durable set already contains it", () => {
+      /** @scenario a redelivered batch after a committed write does not double-count */
+      it("does not apply or store and returns the loaded state", async () => {
+        const a = makeEvent("a", 1000);
+        const loadedState: FoldState = { ids: ["a"], LastEventOccurredAt: 1000 };
+        const { store, storeFn } = durableStore({
+          state: loadedState,
+          appliedEventIds: ["a"],
+        });
+        const apply = appendingApply();
+        const fold = createMockFoldProjectionDefinition("dedup", {
+          store,
+          init,
+          apply,
+        });
+
+        const result = (await executor.execute(
+          fold,
+          a,
+          contextWith({ deliveryAttempt: 2 }),
+        )) as FoldState;
+
+        expect(apply).not.toHaveBeenCalled();
+        expect(storeFn).not.toHaveBeenCalled();
+        expect(result).toBe(loadedState);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
@@ -1,3 +1,4 @@
+import { register } from "prom-client";
 import { describe, expect, it, vi } from "vitest";
 import { createTenantId } from "../../domain/tenantId";
 import type { FoldProjectionStore } from "../foldProjection.types";
@@ -28,6 +29,51 @@ function createInnerStore(
   };
 
   return { store, calls };
+}
+
+/**
+ * An inner store that persists the applied-event-id set next to its state —
+ * the durable read-back shape (`getWithApplied`) a store gains under ADR-066.
+ * Its `get()` still answers state-only, so the wrapper's cache-miss path is
+ * exercised for both entry points.
+ */
+function createDurableInnerStore({
+  state = { count: 1, UpdatedAt: 100 },
+  appliedEventIds,
+}: {
+  state?: TestState | null;
+  appliedEventIds: string[];
+}) {
+  const calls = { get: [] as string[], getWithApplied: [] as string[] };
+  const store: FoldProjectionStore<TestState> = {
+    async get(aggregateId: string) {
+      calls.get.push(aggregateId);
+      return state;
+    },
+    async getWithApplied(aggregateId: string) {
+      calls.getWithApplied.push(aggregateId);
+      return { state, appliedEventIds };
+    },
+    async store() {},
+  };
+  return { store, calls };
+}
+
+/**
+ * Reads the dedup-unavailable counter straight off the registry for the
+ * `test_table` projection — a spy on a destructured copy would intercept
+ * nothing and pass regardless.
+ */
+async function dedupUnavailableCount(reason: string): Promise<number> {
+  const metric = await register
+    .getSingleMetric("es_fold_dedup_unavailable_total")
+    ?.get();
+  return (
+    metric?.values.find(
+      (v) =>
+        v.labels.projection_name === "test_table" && v.labels.reason === reason,
+    )?.value ?? 0
+  );
 }
 
 function createRedis() {
@@ -251,22 +297,6 @@ describe("RedisCachedFoldStore", () => {
   });
 
   describe("given a retry whose applied-set is gone", () => {
-    /** Reads the counter straight off the registry — a spy on a destructured
-     *  copy would intercept nothing and pass regardless. */
-    async function dedupUnavailableCount(reason: string): Promise<number> {
-      const { register } = await import("prom-client");
-      const metric = await register
-        .getSingleMetric("es_fold_dedup_unavailable_total")
-        ?.get();
-      return (
-        metric?.values.find(
-          (v) =>
-            v.labels.projection_name === "test_table" &&
-            v.labels.reason === reason,
-        )?.value ?? 0
-      );
-    }
-
     it("counts it, because the batch is about to be re-applied on top of itself", async () => {
       // The dangerous case is invisible in the existing signals: a miss on a
       // retry and a miss on a fresh delivery are the same observation, and the
@@ -293,6 +323,48 @@ describe("RedisCachedFoldStore", () => {
       await store.getWithApplied("agg-1", { ...CONTEXT, deliveryAttempt: 1 });
 
       expect(await dedupUnavailableCount("cache_miss")).toBe(before);
+    });
+  });
+
+  describe("given an inner store that persists the applied-set durably", () => {
+    describe("when a retry misses the cache and the durable set has ids", () => {
+      /** @scenario a redelivered batch after a committed write does not double-count */
+      it("returns the durable set and does not count dedup unavailable", async () => {
+        const before = await dedupUnavailableCount("cache_miss");
+
+        const redis = createRedis();
+        const inner = createDurableInnerStore({ appliedEventIds: ["e1", "e2"] });
+        const { store } = createStore(redis, inner);
+
+        const result = await store.getWithApplied("agg-1", {
+          ...CONTEXT,
+          deliveryAttempt: 2,
+        });
+
+        // The durable row answered the redelivery, so dedup was available.
+        expect(result.state).toEqual({ count: 1, UpdatedAt: 100 });
+        expect(result.appliedEventIds).toEqual(["e1", "e2"]);
+        expect(inner.calls.getWithApplied).toEqual(["agg-1"]);
+        expect(await dedupUnavailableCount("cache_miss")).toBe(before);
+      });
+    });
+
+    describe("when a retry misses the cache and the durable set is empty", () => {
+      it("still counts dedup unavailable, preserving the blind-reapply signal", async () => {
+        const before = await dedupUnavailableCount("cache_miss");
+
+        const redis = createRedis();
+        const inner = createDurableInnerStore({ appliedEventIds: [] });
+        const { store } = createStore(redis, inner);
+
+        const result = await store.getWithApplied("agg-1", {
+          ...CONTEXT,
+          deliveryAttempt: 2,
+        });
+
+        expect(result.appliedEventIds).toEqual([]);
+        expect(await dedupUnavailableCount("cache_miss")).toBe(before + 1);
+      });
     });
   });
 

--- a/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
@@ -98,9 +98,13 @@ const CONTEXT: ProjectionStoreContext = {
 };
 const CACHE_KEY = `fold:test_table:${String(TENANT)}:agg-1`;
 
-function createStore(
+function createStore<
+  Inner extends { store: FoldProjectionStore<TestState> } = ReturnType<
+    typeof createInnerStore
+  >,
+>(
   redis: ReturnType<typeof createRedis>,
-  inner = createInnerStore(),
+  inner: Inner = createInnerStore() as Inner,
 ) {
   return {
     inner,

--- a/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
@@ -104,7 +104,7 @@ function createStore<
   >,
 >(
   redis: ReturnType<typeof createRedis>,
-  inner: Inner = createInnerStore() as Inner,
+  inner: Inner = createInnerStore() as unknown as Inner,
 ) {
   return {
     inner,

--- a/langwatch/src/server/event-sourcing/projections/foldCache/__tests__/foldRedeliveryIdempotency.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldCache/__tests__/foldRedeliveryIdempotency.integration.test.ts
@@ -636,7 +636,10 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
         const evict = setInterval(() => {
           void redis
             .keys("fold:it_cache_lost_watermark:*")
-            .then((keys) => (keys.length > 0 ? redis.del(...keys) : 0));
+            .then((keys) => (keys.length > 0 ? redis.del(...keys) : 0))
+            // A transient redis hiccup mid-eviction must not surface as an
+            // unhandled rejection and flake the run; the next tick retries.
+            .catch(() => {});
         }, 20);
 
         try {

--- a/langwatch/src/server/event-sourcing/projections/foldCache/__tests__/foldRedeliveryIdempotency.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldCache/__tests__/foldRedeliveryIdempotency.integration.test.ts
@@ -90,6 +90,38 @@ function createDurableStore() {
   return { store, committed: () => committed };
 }
 
+/**
+ * A durable store that persists the applied-event-id watermark next to the
+ * committed state, exactly as `codingAgentSession.store.ts` wires it: `store`
+ * writes both the state and `context.appliedEventIds`, and `getWithApplied`
+ * hands the executor the state plus that watermark. This is the tier the cache
+ * falls through to on a miss, so a retry that reaches a cold cache can still
+ * recognise a batch it already committed — the difference that keeps the count
+ * at 1 across cache loss where a watermark-less durable store double-counts.
+ */
+function createDurableStoreWithWatermark() {
+  let committed: CounterState | null = null;
+  let appliedEventIds: string[] = [];
+  const store: FoldProjectionStore<CounterState> = {
+    async store(state, context) {
+      committed = state;
+      appliedEventIds = [...(context.appliedEventIds ?? [])];
+    },
+    async get() {
+      return committed;
+    },
+    async getWithApplied() {
+      return { state: committed, appliedEventIds: [...appliedEventIds] };
+    },
+  };
+  return { store, committed: () => committed };
+}
+
+type DurableStoreFactory = () => {
+  store: FoldProjectionStore<CounterState>;
+  committed: () => CounterState | null;
+};
+
 function toEvent(
   job: FoldJob,
   aggregateId: string = AGGREGATE,
@@ -151,6 +183,7 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
     coalesce,
     aggregateId = AGGREGATE,
     tenantId = TENANT,
+    durableFactory = createDurableStore,
   }: {
     keyPrefix: string;
     failFirstBatch?: boolean;
@@ -159,8 +192,9 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
     coalesce?: number;
     aggregateId?: string;
     tenantId?: ReturnType<typeof createTenantId>;
+    durableFactory?: DurableStoreFactory;
   }) {
-    const durable = createDurableStore();
+    const durable = durableFactory();
     const cached = new RedisCachedFoldStore<CounterState>(durable.store, redis, {
       keyPrefix,
     });
@@ -524,13 +558,15 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
   });
 
   describe("given the cache entry is lost before a redelivery", () => {
-    describe("when the job is retried", () => {
+    describe("when the durable store keeps no applied-event watermark", () => {
       it("double-counts — the known limit of a cache-held applied-set", async () => {
-        // Not a bug report, a boundary. The applied-set lives in the cache
-        // entry, so eviction or Redis loss takes the dedup with it. This
-        // degrades to the pre-existing behaviour rather than to something
-        // worse, and it is the reason the plan does not claim this closes the
-        // cold path. Pinned so the limit is visible rather than folklore.
+        // Not a bug report, a boundary scoped to a durable store WITHOUT an
+        // applied-event watermark (the default `createDurableStore` here). For
+        // such a store the applied-set lives only in the cache entry, so
+        // eviction or Redis loss takes the dedup with it. This degrades to the
+        // pre-existing behaviour rather than to something worse. The sibling
+        // scenario below shows a watermark-backed store closing this gap; this
+        // one pins the limit so it stays visible rather than folklore.
         const { queue, durable, applied } = createFoldQueue({
           keyPrefix: "it_cache_lost",
           failFirstBatch: true,
@@ -562,6 +598,56 @@ describe.skipIf(!hasTestcontainers)("fold redelivery idempotency", () => {
             timeout: 20_000,
             interval: 100,
           });
+        } finally {
+          clearInterval(evict);
+        }
+      }, 40_000);
+    });
+
+    describe("when the durable store persists an applied-event watermark", () => {
+      it("counts the event once even though the cache is lost", async () => {
+        // Same cache-eviction-across-the-retry-window flow as the sibling
+        // above, but the durable store persists the applied-event-id watermark
+        // next to its state (as codingAgentSession.store.ts does). On the retry
+        // the cache is cold, so the executor falls through to the durable store,
+        // reads the watermark back via getWithApplied, recognises the
+        // redelivered event, and skips it — closing the cold-cache double-count.
+        const { queue, durable, applied } = createFoldQueue({
+          keyPrefix: "it_cache_lost_watermark",
+          failFirstBatch: true,
+          durableFactory: createDurableStoreWithWatermark,
+        });
+        await queue.waitUntilReady();
+
+        await queue.send({
+          eventId: "event-1",
+          groupId: AGGREGATE,
+          occurredAt: Date.now(),
+        });
+
+        await vi.waitFor(() => expect(applied.length).toBeGreaterThanOrEqual(1), {
+          timeout: 15_000,
+          interval: 50,
+        });
+
+        // Keep the entry evicted for the whole retry window, exactly as the
+        // watermark-less scenario does, so the retry is forced through the
+        // durable read rather than served a warm cache.
+        const evict = setInterval(() => {
+          void redis
+            .keys("fold:it_cache_lost_watermark:*")
+            .then((keys) => (keys.length > 0 ? redis.del(...keys) : 0));
+        }, 20);
+
+        try {
+          // Wait for the redelivery to actually run (a second batch dispatch),
+          // then assert the durable count never moved past 1 — the watermark
+          // recognised the redelivered event across the cache loss.
+          await vi.waitFor(
+            () => expect(applied.length).toBeGreaterThanOrEqual(2),
+            { timeout: 20_000, interval: 100 },
+          );
+          expect(durable.committed()?.count).toBe(1);
         } finally {
           clearInterval(evict);
         }

--- a/langwatch/src/server/event-sourcing/projections/foldProjection.types.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjection.types.ts
@@ -203,4 +203,21 @@ export interface FoldProjectionStore<State> {
     aggregateId: string,
     context: ProjectionStoreContext,
   ): Promise<State | null>;
+
+  /**
+   * Retrieves the stored state together with the ids of the events already
+   * folded into it.
+   *
+   * Implemented by stores that persist the applied-event-id set durably next to
+   * the state row (first adopter: the codingAgentSession ClickHouse store) — and
+   * by the Redis cache wrapper, which serves the set from its entry. The
+   * executor prefers it over `get()` so redelivery dedup survives cache loss: a
+   * retry that reaches a cold cache can still read the durable set and recognise
+   * a batch it already committed. Stores that keep no such set omit it; the
+   * executor then reads `get()` and treats the applied set as empty.
+   */
+  getWithApplied?(
+    aggregateId: string,
+    context: ProjectionStoreContext,
+  ): Promise<{ state: State | null; appliedEventIds: string[] }>;
 }

--- a/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -5,6 +5,7 @@ import {
   observeEsFoldBlindReapplyEvents,
 } from "~/server/metrics";
 import type { Event } from "../domain/types";
+import { mergeAppliedEventIds } from "./foldCache/foldCacheEntry";
 import type {
   FoldProjectionDefinition,
   FoldProjectionStore,
@@ -126,28 +127,47 @@ export class FoldProjectionExecutor {
   /**
    * Loads state along with the ids of the events already folded into it.
    *
-   * Caching stores answer with the applied-set they recorded; the rest answer
-   * with an empty one, correctly — a store with no cache always reads the
-   * durable row, so it has no redelivery window to close.
+   * A store that keeps an applied-event-id set — the Redis cache wrapper, or a
+   * store that persists the set durably next to its row — answers with it via
+   * `getWithApplied`. A store that keeps none has no `getWithApplied`; its read
+   * carries an empty set and the executor treats every delivery as fresh.
    */
   private async loadWithApplied<State>(
     store: FoldProjectionStore<State>,
     key: string,
     context: ProjectionStoreContext,
   ): Promise<{ state: State | null; appliedEventIds: string[] }> {
-    const withApplied = (
-      store as FoldProjectionStore<State> & {
-        getWithApplied?: (
-          aggregateId: string,
-          context: ProjectionStoreContext,
-        ) => Promise<{ state: State | null; appliedEventIds: string[] }>;
-      }
-    ).getWithApplied;
-
-    if (typeof withApplied === "function") {
-      return await withApplied.call(store, key, context);
+    if (store.getWithApplied) {
+      return await store.getWithApplied(key, context);
     }
     return { state: await store.get(key, context), appliedEventIds: [] };
+  }
+
+  /**
+   * The applied-event-id set to record at commit.
+   *
+   * On a fresh delivery the previous batch for this group already acked (the
+   * queue holds one active batch per group), so its ids can never be
+   * redelivered — the set resets to this batch's fresh ids, staying bounded to
+   * one batch. On a RETRY it must instead be the UNION of the set loaded at read
+   * time and the fresh ids: a retry chain that keeps losing its cache would
+   * otherwise record only each attempt's fresh ids, and a later attempt
+   * redelivering the whole batch would re-apply the events an earlier attempt
+   * already folded into the durable row (silent double-count). Merging keeps
+   * every id the durable row still needs to recognise, capped and deduped.
+   */
+  private appliedIdsForCommit({
+    context,
+    loadedAppliedIds,
+    freshIds,
+  }: {
+    context: ProjectionStoreContext;
+    loadedAppliedIds: readonly string[];
+    freshIds: readonly string[];
+  }): string[] {
+    return (context.deliveryAttempt ?? 1) > 1
+      ? mergeAppliedEventIds({ previous: loadedAppliedIds, applied: freshIds })
+      : [...freshIds];
   }
 
   /**
@@ -237,7 +257,14 @@ export class FoldProjectionExecutor {
       if (refolded !== null) {
         await projection.store.store(
           refolded,
-          withAppliedEventIds(context, [event.id]),
+          withAppliedEventIds(
+            context,
+            this.appliedIdsForCommit({
+              context,
+              loadedAppliedIds: appliedEventIds,
+              freshIds: [event.id],
+            }),
+          ),
         );
         return refolded;
       }
@@ -308,7 +335,14 @@ export class FoldProjectionExecutor {
 
     await projection.store.store(
       state,
-      withAppliedEventIds(context, [event.id]),
+      withAppliedEventIds(
+        context,
+        this.appliedIdsForCommit({
+          context,
+          loadedAppliedIds: appliedEventIds,
+          freshIds: [event.id],
+        }),
+      ),
     );
     return state;
   }
@@ -373,7 +407,11 @@ export class FoldProjectionExecutor {
           refolded,
           withAppliedEventIds(
             context,
-            ordered.map((event) => event.id),
+            this.appliedIdsForCommit({
+              context,
+              loadedAppliedIds: appliedEventIds,
+              freshIds: ordered.map((event) => event.id),
+            }),
           ),
         );
         return refolded;
@@ -447,7 +485,11 @@ export class FoldProjectionExecutor {
       state,
       withAppliedEventIds(
         context,
-        fresh.map((event) => event.id),
+        this.appliedIdsForCommit({
+          context,
+          loadedAppliedIds: appliedEventIds,
+          freshIds: fresh.map((event) => event.id),
+        }),
       ),
     );
     return state;

--- a/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
+++ b/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
@@ -64,11 +64,14 @@ function readUpdatedAt<State>(state: State): number {
  * sums, appends) rather than being idempotent, and would double-count. The
  * executor uses that set to recognise and skip a redelivery.
  *
- * The set is deliberately NOT a durability mechanism. It lives in the cache
- * entry, so eviction or Redis loss takes it with them — which degrades to the
- * behaviour that existed before it, not to something worse. Closing the cold
- * path properly means making the folds themselves idempotent; see
- * dev/docs/plans/fold-idempotency-plan.md.
+ * The cache is the FAST tier for that set, not the only one. When the inner
+ * store implements `getWithApplied` (first adopter: the codingAgentSession
+ * ClickHouse store) it also persists the set durably alongside the state row,
+ * and this wrapper reads it back on a cache miss — so a retry that reaches a
+ * cold cache still recognises a batch it already committed, closing the
+ * cold-cache redelivery double-count. An inner store without `getWithApplied`
+ * keeps the pre-durable behaviour: eviction or Redis loss drops the set,
+ * degrading to a blind re-apply, not to something worse.
  */
 export class RedisCachedFoldStore<State>
   implements FoldProjectionStore<State>
@@ -95,8 +98,10 @@ export class RedisCachedFoldStore<State>
   }
 
   /**
-   * The state together with the ids already folded into it. On a miss the set
-   * is empty — there is no cached state to have applied anything to.
+   * The state together with the ids already folded into it. A cache hit serves
+   * both from the entry. On a miss the read falls through to the durable store,
+   * which carries the applied-set too when it implements `getWithApplied` (so a
+   * cold-cache retry can still dedup) and an empty set otherwise.
    */
   async getWithApplied(
     aggregateId: string,
@@ -116,16 +121,16 @@ export class RedisCachedFoldStore<State>
     }
 
     // A retry with no applied-set is the moment a batch gets re-applied on top
-    // of state that already holds it. Named by reason so an incident can tell a
-    // cold cache from a Redis fault from a corrupt entry.
-    if (isRetry) {
+    // of state that already holds it. A durable store that persists the set
+    // next to its row can still answer, though — so only count dedup as
+    // unavailable when even that came back empty. Named by reason so an incident
+    // can tell a cold cache from a Redis fault from a corrupt entry.
+    const durable = await this.readDurable(aggregateId, context);
+    if (isRetry && durable.appliedEventIds.length === 0) {
       incrementEsFoldDedupUnavailable(this.keyPrefix, cached.reason);
     }
 
-    return {
-      state: await this.readDurable(aggregateId, context),
-      appliedEventIds: [],
-    };
+    return durable;
   }
 
   private async readCached(
@@ -190,12 +195,23 @@ export class RedisCachedFoldStore<State>
     };
   }
 
+  /**
+   * The durable read behind a cache miss. When the inner store persists the
+   * applied-event-id set next to its row (`getWithApplied`), that set comes back
+   * too, so a retry with a cold cache can still recognise a batch it committed;
+   * otherwise the set is empty and dedup falls back to blind re-apply.
+   */
   private async readDurable(
     aggregateId: string,
     context: ProjectionStoreContext,
-  ): Promise<State | null> {
+  ): Promise<{ state: State | null; appliedEventIds: string[] }> {
     const startedAt = performance.now();
-    const result = await this.inner.get(aggregateId, context);
+    const result = this.inner.getWithApplied
+      ? await this.inner.getWithApplied(aggregateId, context)
+      : {
+          state: await this.inner.get(aggregateId, context),
+          appliedEventIds: [] as string[],
+        };
     observeEsFoldCacheGetDuration(
       this.keyPrefix,
       "clickhouse",

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -818,6 +818,11 @@ describe.skipIf(!hasTestcontainers)(
               ? Math.max(...batches.map((b) => b.length))
               : 0;
           expect(maxBatch).toBeLessThan(6);
+          // ...but a coalesced batch DID form — without this floor the assertion
+          // above passes vacuously when nothing coalesces (maxBatch 0), leaving
+          // the byte-split path untested. A batch of ≥2 proves siblings folded
+          // up to the byte budget rather than each dispatching alone.
+          expect(maxBatch).toBeGreaterThanOrEqual(2);
           // Every event processed exactly once — the remainder became later batches.
           const allIds = [...batches.flat(), ...singles].map((p) => p.id);
           expect(new Set(allIds).size).toBe(6);
@@ -901,6 +906,12 @@ describe.skipIf(!hasTestcontainers)(
             { timeout: 30000, interval: 50 },
           );
 
+          // A coalesced cmdA batch actually formed (j0 + j2 folded). Without this
+          // the no-mix loop below is vacuously true on an empty `batches`, so the
+          // "never mixes __jobName" invariant would never be exercised.
+          const coalesced = batches.filter((b) => b.length >= 2);
+          expect(coalesced.length).toBeGreaterThan(0);
+
           // The invariant: no coalesced batch ever contains two distinct job names.
           for (const batch of batches) {
             const names = new Set(
@@ -908,6 +919,15 @@ describe.skipIf(!hasTestcontainers)(
             );
             expect(names.size).toBe(1);
           }
+
+          // The foreign sibling (cmdB) was drained out of the cmdA group and
+          // processed via its own dispatch — proving restageDrainedSiblings ran
+          // rather than the cmdB job being folded or dropped.
+          const cmdBProcessed = [...batches.flat(), ...singles].some(
+            (p) => (p as Record<string, unknown>).__jobName === "cmdB",
+          );
+          expect(cmdBProcessed).toBe(true);
+
           // Every job processed exactly once — the foreign sibling was restaged,
           // not lost.
           const allIds = [...batches.flat(), ...singles].map((p) => p.id);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -9,6 +9,7 @@ import {
   vi,
 } from "vitest";
 import type { Redis } from "ioredis";
+import { register } from "prom-client";
 import {
   startTestContainers,
   stopTestContainers,
@@ -16,6 +17,15 @@ import {
 } from "../../../__tests__/integration/testContainers";
 import { GroupQueueProcessor } from "../groupQueue";
 import type { EventSourcedQueueDefinition } from "../../queue.types";
+
+async function foreignSiblingsRestagedCount(queueName: string): Promise<number> {
+  const metric = await register
+    .getSingleMetric("gq_foreign_siblings_restaged_total")
+    ?.get();
+  return (
+    metric?.values.find((v) => v.labels.queue_name === queueName)?.value ?? 0
+  );
+}
 
 // Skip when running without testcontainers (unit-only test runs)
 const hasTestcontainers = !!(
@@ -877,11 +887,13 @@ describe.skipIf(!hasTestcontainers)(
         it("never mixes __jobName within a batch and restages foreign siblings", async () => {
           const batches: TestPayload[][] = [];
           const singles: TestPayload[] = [];
+          const queueName = `{test/gq/mixed-${crypto.randomUUID().slice(0, 8)}}`;
           const queue = createQueue(
             async (p) => {
               singles.push(p);
             },
             {
+              name: queueName,
               processBatch: async (ps) => {
                 batches.push(ps as TestPayload[]);
               },
@@ -890,6 +902,9 @@ describe.skipIf(!hasTestcontainers)(
             },
           );
           await queue.waitUntilReady();
+
+          const foreignRestagedBefore =
+            await foreignSiblingsRestagedCount(queueName);
 
           await queue.sendBatch([
             { id: "j0", groupId: "group-a", value: "a", __jobName: "cmdA" },
@@ -932,6 +947,13 @@ describe.skipIf(!hasTestcontainers)(
           // not lost.
           const allIds = [...batches.flat(), ...singles].map((p) => p.id);
           expect(new Set(allIds).size).toBe(3);
+
+          // The mixed-command restage is counted distinctly from the
+          // batch-failure restage paths (ADR-066 pillar 2): exactly the one
+          // foreign cmdB sibling was recorded against this queue.
+          expect(await foreignSiblingsRestagedCount(queueName)).toBe(
+            foreignRestagedBefore + 1,
+          );
         });
       });
     });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -767,6 +767,153 @@ describe.skipIf(!hasTestcontainers)(
           );
         });
       });
+
+      // ADR-066 pillar 2: the drain is bounded by bytes as well as count. These
+      // exercise the byte budget end-to-end through the GroupQueueProcessor. Byte
+      // math is asserted at the Lua level in scripts.integration.test.ts; here we
+      // only need the observable: a burst that the count bound alone would fold
+      // whole is split by the byte bound, and nothing is lost.
+      describe("when a byte budget bounds the batch", () => {
+        /** @scenario 'a batch is bounded by size as well as count' */
+        it("splits a burst at the byte budget and loses nothing", async () => {
+          const batches: TestPayload[][] = [];
+          const singles: TestPayload[] = [];
+          const bulk = "x".repeat(500);
+          const queue = createQueue(
+            async (p) => {
+              singles.push(p);
+            },
+            {
+              processBatch: async (ps) => {
+                batches.push(ps as TestPayload[]);
+              },
+              coalesceMaxBatch: () => 50,
+              coalesceMaxBytes: () => 1500,
+              score: (p) => Number((p.id as string).slice(1)),
+            },
+          );
+          await queue.waitUntilReady();
+
+          await queue.sendBatch(
+            Array.from({ length: 6 }, (_, i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: bulk,
+            })),
+          );
+
+          await vi.waitFor(
+            () => {
+              const total =
+                batches.reduce((n, b) => n + b.length, 0) + singles.length;
+              expect(total).toBe(6);
+            },
+            { timeout: 30000, interval: 50 },
+          );
+
+          // The byte bound bit: the whole burst never collapsed into one batch,
+          // even though the count bound alone (50) would have folded all six.
+          const maxBatch =
+            batches.length > 0
+              ? Math.max(...batches.map((b) => b.length))
+              : 0;
+          expect(maxBatch).toBeLessThan(6);
+          // Every event processed exactly once — the remainder became later batches.
+          const allIds = [...batches.flat(), ...singles].map((p) => p.id);
+          expect(new Set(allIds).size).toBe(6);
+        });
+
+        /** @scenario 'a single oversized item is appended on its own' */
+        it("processes an oversized job on its own, coalescing nothing", async () => {
+          const batches: TestPayload[][] = [];
+          const singles: TestPayload[] = [];
+          const bulk = "x".repeat(500);
+          const queue = createQueue(
+            async (p) => {
+              singles.push(p);
+            },
+            {
+              processBatch: async (ps) => {
+                batches.push(ps as TestPayload[]);
+              },
+              coalesceMaxBatch: () => 50,
+              // Smaller than any single job's stored size, so every dispatch's
+              // own initialBytes already exceeds the budget.
+              coalesceMaxBytes: () => 50,
+              score: (p) => Number((p.id as string).slice(1)),
+            },
+          );
+          await queue.waitUntilReady();
+
+          await queue.sendBatch(
+            Array.from({ length: 4 }, (_, i) => ({
+              id: `j${i}`,
+              groupId: "group-a",
+              value: bulk,
+            })),
+          );
+
+          await vi.waitFor(
+            () => {
+              expect(singles.length).toBe(4);
+            },
+            { timeout: 30000, interval: 50 },
+          );
+          // No siblings are ever folded, so the batch handler is never called.
+          expect(batches.length).toBe(0);
+        });
+      });
+
+      // ADR-066 pillar 2: serialized commands share a group across command types,
+      // so a drained sibling can belong to a DIFFERENT __jobName. A coalesced
+      // batch must never mix job names; foreign siblings are restaged, not folded.
+      describe("when a group mixes __jobName (serialized commands)", () => {
+        /** @scenario 'coalescing preserves every item' */
+        it("never mixes __jobName within a batch and restages foreign siblings", async () => {
+          const batches: TestPayload[][] = [];
+          const singles: TestPayload[] = [];
+          const queue = createQueue(
+            async (p) => {
+              singles.push(p);
+            },
+            {
+              processBatch: async (ps) => {
+                batches.push(ps as TestPayload[]);
+              },
+              coalesceMaxBatch: () => 50,
+              score: (p) => Number((p.id as string).slice(1)),
+            },
+          );
+          await queue.waitUntilReady();
+
+          await queue.sendBatch([
+            { id: "j0", groupId: "group-a", value: "a", __jobName: "cmdA" },
+            { id: "j1", groupId: "group-a", value: "b", __jobName: "cmdB" },
+            { id: "j2", groupId: "group-a", value: "a", __jobName: "cmdA" },
+          ] as unknown as TestPayload[]);
+
+          await vi.waitFor(
+            () => {
+              const total =
+                batches.reduce((n, b) => n + b.length, 0) + singles.length;
+              expect(total).toBe(3);
+            },
+            { timeout: 30000, interval: 50 },
+          );
+
+          // The invariant: no coalesced batch ever contains two distinct job names.
+          for (const batch of batches) {
+            const names = new Set(
+              batch.map((p) => (p as Record<string, unknown>).__jobName),
+            );
+            expect(names.size).toBe(1);
+          }
+          // Every job processed exactly once — the foreign sibling was restaged,
+          // not lost.
+          const allIds = [...batches.flat(), ...singles].map((p) => p.id);
+          expect(new Set(allIds).size).toBe(3);
+        });
+      });
     });
   },
 );

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.poisonGuard.integration.test.ts
@@ -443,8 +443,10 @@ describe.skipIf(!hasTestcontainers)(
 
           // Stage BOTH jobs atomically as legacy bare-JSON so the small one is
           // the dispatched job (earliest score) and decodes fine, while the
-          // oversized one is drained as a coalesce sibling and blows the decode
-          // cap. Both due now; the small one sorts first.
+          // oversized one stays a staged sibling. Anything over the decode cap
+          // is necessarily over the drain's byte budget too, so it is never
+          // folded into a batch — it becomes its own dispatch and blows the
+          // decode cap there. Both due now; the small one sorts first.
           const scripts = new GroupStagingScripts(redis, name);
           const now = Date.now();
           const small = JSON.stringify({
@@ -483,16 +485,20 @@ describe.skipIf(!hasTestcontainers)(
             { timeout: 10000, interval: 100 },
           );
 
-          // The batch was parked before any handler ran (the oversized sibling
-          // is never JSON-parsed, so neither process nor processBatch fires).
-          expect(processed).not.toHaveBeenCalled();
-          expect(processBatch).not.toHaveBeenCalled();
+          // The byte budget kept the poison out of the batch: the small job's
+          // work completed exactly once, and the oversized value was parked on
+          // its own dispatch without ever being JSON-parsed — so no handler
+          // saw anything but the small payload.
+          const handledIds = [
+            ...processed.mock.calls.map(([p]) => p.id),
+            ...processBatch.mock.calls.flatMap(([ps]) => ps.map((p) => p.id)),
+          ];
+          expect(handledIds).toEqual(["job-small"]);
           const error = await storedError(name, "fat");
           expect(error).toContain("Poison guard");
           expect(error).toContain("parked unparsed");
-          // The batch's other work is not lost: the group still holds staged
-          // jobs (the re-staged siblings + the parked dispatched value), ready
-          // for operator inspection or replay on unblock, not dropped.
+          // The parked value is not lost: the group still holds it staged,
+          // ready for operator inspection or replay on unblock, not dropped.
           expect(
             await redis.zcard(`${name}:gq:group:fat:jobs`),
           ).toBeGreaterThan(0);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -5009,6 +5009,100 @@ describe("GroupStagingScripts.drainGroupReady", () => {
       ).toEqual([]);
     });
   });
+
+  // ADR-066 pillar 2: the drain is bounded by bytes as well as count. Each
+  // stored value here is exactly 100 bytes so the budget arithmetic is exact.
+  describe("when a byte budget is set", () => {
+    const sizedJson = (n: number) => `{"p":"${"x".repeat(n - 8)}"}`;
+
+    async function stageThreeSizedJobs() {
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          dispatchAfterMs: 100,
+          jobDataJson: sizedJson(100),
+        }),
+      );
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j2",
+          dispatchAfterMs: 200,
+          jobDataJson: sizedJson(100),
+        }),
+      );
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j3",
+          dispatchAfterMs: 300,
+          jobDataJson: sizedJson(100),
+        }),
+      );
+    }
+
+    /** @scenario 'a batch is bounded by size as well as count' */
+    it("stops before a job that would overflow the budget, leaving it staged", async () => {
+      await stageThreeSizedJobs();
+
+      // 0 + 100 + 100 = 200 ≤ 250 ✓, next 100 → 300 > 250 ✗: j3 stays.
+      const drained = await scripts.drainGroupReady({
+        groupId: "group-a",
+        nowMs: 10_000,
+        maxJobs: 10,
+        maxBytes: 250,
+        initialBytes: 0,
+      });
+
+      expect(drained.map((d) => d.stagedJobId)).toEqual(["j1", "j2"]);
+      expect(await inspectGroupJobs("group-a")).toEqual(["j3", "300"]);
+      expect(await inspectTotalPending()).toBe("1");
+    });
+
+    it("counts initialBytes (the dispatched job's own size) toward the budget", async () => {
+      await stageThreeSizedJobs();
+
+      // initialBytes already fills the budget, so the first candidate overflows.
+      const drained = await scripts.drainGroupReady({
+        groupId: "group-a",
+        nowMs: 10_000,
+        maxJobs: 10,
+        maxBytes: 250,
+        initialBytes: 250,
+      });
+
+      expect(drained).toEqual([]);
+      expect(await inspectTotalPending()).toBe("3");
+    });
+
+    /** @scenario 'a single oversized item is appended on its own' */
+    it("drains no siblings when the dispatched job alone exceeds the budget", async () => {
+      await stageThreeSizedJobs();
+
+      const drained = await scripts.drainGroupReady({
+        groupId: "group-a",
+        nowMs: 10_000,
+        maxJobs: 10,
+        maxBytes: 50,
+        initialBytes: 100,
+      });
+
+      expect(drained).toEqual([]);
+      expect(await inspectTotalPending()).toBe("3");
+    });
+
+    it("applies only the count bound when maxBytes is zero", async () => {
+      await stageThreeSizedJobs();
+
+      const drained = await scripts.drainGroupReady({
+        groupId: "group-a",
+        nowMs: 10_000,
+        maxJobs: 10,
+        maxBytes: 0,
+        initialBytes: 999_999,
+      });
+
+      expect(drained.map((d) => d.stagedJobId)).toEqual(["j1", "j2", "j3"]);
+    });
+  });
 });
 
 describe("group-key TTL safety net", () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -119,6 +119,19 @@ const GROUP_QUEUE_CONFIG = {
 const DEFAULT_DEDUPLICATION_TTL_MS = 200;
 
 /**
+ * Default byte budget for a coalesced batch when a queue enables coalescing but
+ * supplies no `coalesceMaxBytes` resolver (ADR-066 pillar 2).
+ *
+ * 4 MiB keeps a coalesced multi-row append inside the ClickHouse async-insert
+ * flush budget, so producer-side coalescing collapses many tiny appends into one
+ * insert without ever assembling an insert large enough to stall the flush. It
+ * is generous enough that the fold/map batches that predate ADR-066 stay bounded
+ * by their count limit (`coalesceMaxBatch`) in practice, so their behaviour is
+ * unchanged — the byte bound only ever binds first for a genuinely large burst.
+ */
+export const DEFAULT_COALESCE_MAX_BYTES = 4 * 1024 * 1024;
+
+/**
  * Decides whether a failed job attempt should be retried.
  *
  * Two non-retryable classes:
@@ -241,6 +254,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     delivery?: JobDelivery,
   ) => Promise<void>;
   private readonly coalesceMaxBatch?: (payload: Payload) => number | undefined;
+  private readonly coalesceMaxBytes?: (payload: Payload) => number | undefined;
   private readonly spanAttributes?: (payload: Payload) => SemConvAttributes;
   private readonly processingQueue: fastq.queueAsPromised<DispatchResult, void>;
   private readonly delay?: number;
@@ -283,6 +297,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       process,
       processBatch,
       coalesceMaxBatch,
+      coalesceMaxBytes,
       options: defOptions,
       delay,
       spanAttributes,
@@ -330,6 +345,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     this.process = process;
     this.processBatch = processBatch;
     this.coalesceMaxBatch = coalesceMaxBatch;
+    this.coalesceMaxBytes = coalesceMaxBytes;
     this.auditAdapter = auditAdapter;
     this.globalConcurrency =
       defOptions?.globalConcurrency ??
@@ -848,11 +864,21 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     let batchPayloads: Payload[] | null = null;
     let drainedSiblings: DrainedJob[] = [];
     if (maxBatch > 1 && this.processBatch) {
+      // Byte bound (ADR-066 pillar 2): the drain also stops before a job that
+      // would push the batch past maxBytes, counting the dispatched job's own
+      // stored size as the starting point. Whichever of the count/byte bound
+      // binds first wins; an oversized dispatched job (initialBytes already at
+      // or over the budget) drains no siblings and processes on its own.
+      const maxBytes =
+        this.coalesceMaxBytes?.(payload) ?? DEFAULT_COALESCE_MAX_BYTES;
+      const initialBytes = Buffer.byteLength(jobDataJson);
       try {
         drainedSiblings = await this.scripts.drainGroupReady({
           groupId,
           nowMs: Date.now(),
           maxJobs: maxBatch - 1,
+          maxBytes,
+          initialBytes,
         });
       } catch (err) {
         this.logger.warn(
@@ -864,6 +890,38 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           "Failed to drain group siblings for coalescing — processing single job",
         );
         drainedSiblings = [];
+      }
+      // Mixed-command groups (ADR-066 pillar 2): with `serializeByAggregate` the
+      // group key namespace is shared across command types, so a drained sibling
+      // can belong to a DIFFERENT job than the dispatched one. Fold/map groups
+      // are single-`__jobName` by construction, so for them this is a no-op. Only
+      // coalesce siblings whose `__jobName` matches the dispatched job's; restage
+      // the rest untouched (via the same path a failed batch uses) so they run as
+      // their own dispatches — a payload is never handed to another job's handler.
+      //
+      // Read the dispatched job's name the SAME way as each sibling
+      // (`readJobRoutingMeta`, null when absent), so a queue that sets no
+      // `__jobName` at all (every job null) still matches and coalesces — rather
+      // than the `jobName` local, which defaults absent to "unknown" and would
+      // mismatch a sibling's null.
+      if (drainedSiblings.length > 0) {
+        const dispatchedJobName = readJobRoutingMeta(jobDataJson).jobName;
+        const matchingSiblings: DrainedJob[] = [];
+        const foreignSiblings: DrainedJob[] = [];
+        for (const sibling of drainedSiblings) {
+          const siblingJobName = readJobRoutingMeta(
+            sibling.jobDataJson,
+          ).jobName;
+          if (siblingJobName === dispatchedJobName) {
+            matchingSiblings.push(sibling);
+          } else {
+            foreignSiblings.push(sibling);
+          }
+        }
+        if (foreignSiblings.length > 0) {
+          await this.restageDrainedSiblings(groupId, foreignSiblings);
+        }
+        drainedSiblings = matchingSiblings;
       }
       if (drainedSiblings.length > 0) {
         try {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -56,6 +56,7 @@ import {
 import {
   gqGroupAttemptReadFailuresTotal,
   gqGroupsBlockedTotal,
+  gqForeignSiblingsRestagedTotal,
   gqGroupsPoisonParkedTotal,
   gqJobDelayMilliseconds,
   gqJobDurationMilliseconds,
@@ -919,6 +920,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           }
         }
         if (foreignSiblings.length > 0) {
+          gqForeignSiblingsRestagedTotal.inc(
+            { queue_name: this.queueName },
+            foreignSiblings.length,
+          );
           await this.restageDrainedSiblings(groupId, foreignSiblings);
         }
         drainedSiblings = matchingSiblings;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -35,6 +35,8 @@ const metricNames = [
   // 2026-07-22 blob-retention fix
   "gq_blob_release_grace_total",
   "gq_blob_sweep_total",
+  // ADR-066 pillar 2 mixed-command isolation
+  "gq_foreign_siblings_restaged_total",
 ] as const;
 
 for (const name of metricNames) {
@@ -330,4 +332,22 @@ export const gqBlobSweepTotal = new Counter({
   name: "gq_blob_sweep_total",
   help: "Blobs examined by the reclaim runner, by outcome (leased, repaired, reclaimed, bookkeeping, pending) — outcomes partition the keyspace, so this is a total, not a floor",
   labelNames: ["queue_name", "outcome"] as const,
+});
+
+/**
+ * Drained siblings restaged because their `__jobName` differed from the
+ * dispatched job's (ADR-066 pillar 2 mixed-command isolation).
+ *
+ * Distinct from the batch-failure restage paths (transient decode, oversized
+ * poison) that share `restageDrainedSiblings`: those restage the WHOLE batch
+ * because dispatch aborted, whereas this restages only foreign-command siblings
+ * that were coalesced into a group whose key namespace is shared across command
+ * types under `serializeByAggregate`. A steady rate means genuinely mixed
+ * command traffic hitting one aggregate; a spike can flag a group-key collision
+ * or a misrouted producer. Counts siblings restaged, not restage calls.
+ */
+export const gqForeignSiblingsRestagedTotal = new Counter({
+  name: "gq_foreign_siblings_restaged_total",
+  help: "Drained siblings restaged untouched because their __jobName differed from the dispatched job (ADR-066 mixed-command isolation) — excludes the batch-failure restage paths",
+  labelNames: ["queue_name"] as const,
 });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -1078,6 +1078,17 @@ return results
  * so no other worker can concurrently dequeue from this group. Used to coalesce
  * a backed-up group's queued events into a single fold load/apply/store cycle.
  *
+ * Two bounds, whichever binds first (ADR-066 pillar 2):
+ *   - count: at most maxJobs candidates are considered.
+ *   - bytes: the drain stops BEFORE taking a job that would push
+ *     initialBytes + (sum of taken jobs' stored sizes) past maxBytes, so a
+ *     coalesced batch stays inside the downstream append/flush budget. A job
+ *     too large to fit is LEFT in staging (it becomes its own later dispatch),
+ *     never dropped. maxBytes <= 0 disables the byte bound (count bound only,
+ *     the pre-ADR-066 behaviour). Sizes are the stored envelope's `#value`,
+ *     which is the append-shaped quantity — for the small inline appends this
+ *     targets it equals the payload size.
+ *
  * Mirrors the per-job bookkeeping DISPATCH does for the jobs it removes:
  * ZREM from the jobs zset, HDEL the job data, and DECR total-pending. It does
  * NOT mark anything active and does NOT re-score ready — the caller's active
@@ -1088,23 +1099,42 @@ local jobsKey         = KEYS[1]
 local dataKey         = KEYS[2]
 local totalPendingKey = KEYS[3]
 
-local nowMs   = tonumber(ARGV[1])
-local maxJobs = tonumber(ARGV[2])
+local nowMs        = tonumber(ARGV[1])
+local maxJobs      = tonumber(ARGV[2])
+local maxBytes     = tonumber(ARGV[3]) or 0
+local initialBytes = tonumber(ARGV[4]) or 0
 
 local results = {}
 if maxJobs <= 0 then
   return results
 end
 
+-- Peek candidates in score order. HGET happens before the byte check so a job
+-- that would overflow the budget can be measured and then left in staging
+-- (we break rather than remove it), preserving score-ordered FIFO for the
+-- next dispatch.
 local entries = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, maxJobs)
+local accumulated = initialBytes
 local i = 1
 while i < #entries do
   local stagedJobId   = entries[i]
   local originalScore = entries[i + 1]
   i = i + 2
 
-  redis.call("ZREM", jobsKey, stagedJobId)
   local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+  local size = 0
+  if jobDataJson then
+    size = #jobDataJson
+  end
+
+  -- Byte bound: stop before the first job that would overflow the budget.
+  -- Ordering keeps the batch FIFO, so everything from here on stays staged.
+  if maxBytes > 0 and (accumulated + size) > maxBytes then
+    break
+  end
+  accumulated = accumulated + size
+
+  redis.call("ZREM", jobsKey, stagedJobId)
   redis.call("HDEL", dataKey, stagedJobId)
   redis.call("DECR", totalPendingKey)
 
@@ -1942,15 +1972,26 @@ export class GroupStagingScripts {
    * Drain up to maxJobs additional DUE jobs from a group's pending queue without
    * altering the group's active/ready state. Only safe while the caller holds
    * the group's active slot. Returns the drained jobs (may be empty).
+   *
+   * `maxBytes` caps the coalesced batch by the summed stored size of the jobs
+   * taken, counting `initialBytes` (the dispatched job's own stored size) toward
+   * the budget; the drain stops before a job that would overflow it, leaving that
+   * job in staging for its own later dispatch (ADR-066 pillar 2). `maxBytes <= 0`
+   * (the default) disables the byte bound, so callers that only want the count
+   * bound are unchanged.
    */
   async drainGroupReady({
     groupId,
     nowMs,
     maxJobs,
+    maxBytes = 0,
+    initialBytes = 0,
   }: {
     groupId: string;
     nowMs: number;
     maxJobs: number;
+    maxBytes?: number;
+    initialBytes?: number;
   }): Promise<DrainedJob[]> {
     if (maxJobs <= 0) return [];
 
@@ -1966,6 +2007,8 @@ export class GroupStagingScripts {
       totalPendingKey,
       String(nowMs),
       String(maxJobs),
+      String(maxBytes),
+      String(initialBytes),
     );
 
     if (!result || !Array.isArray(result) || result.length < 3) {

--- a/langwatch/src/server/event-sourcing/queues/queue.types.ts
+++ b/langwatch/src/server/event-sourcing/queues/queue.types.ts
@@ -152,6 +152,17 @@ export interface EventSourcedQueueDefinition<
   coalesceMaxBatch?: (payload: Payload) => number | undefined;
 
   /**
+   * Optional per-payload resolver for the maximum total byte size of a coalesced
+   * batch (ADR-066 pillar 2). The drain stops before taking a same-group job
+   * that would push the batch past this budget, so a coalesced append stays
+   * inside the downstream flush budget; a job too large to fit is left for its
+   * own later dispatch. Returns undefined to fall back to the GroupQueue default
+   * ({@link DEFAULT_COALESCE_MAX_BYTES}). Only consulted when `coalesceMaxBatch`
+   * enables coalescing.
+   */
+  coalesceMaxBytes?: (payload: Payload) => number | undefined;
+
+  /**
    * Optional options for the queue processor.
    */
   options?: EventSourcedQueueProcessorOptions;

--- a/langwatch/src/server/event-sourcing/services/commands/__tests__/commandDispatcher.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/services/commands/__tests__/commandDispatcher.unit.test.ts
@@ -12,8 +12,11 @@ import {
   TEST_CONSTANTS,
 } from "../../__tests__/testHelpers";
 import { ValidationError } from "../../errorHandling";
-import { processCommand } from "../commandDispatcher";
-import type { ProcessCommandParams } from "../commandDispatcher";
+import { processCommand, processCommandBatch } from "../commandDispatcher";
+import type {
+  ProcessCommandBatchParams,
+  ProcessCommandParams,
+} from "../commandDispatcher";
 
 // Mock the kill switch module
 vi.mock("../../../utils/killSwitch", () => ({
@@ -333,6 +336,277 @@ describe("processCommand", () => {
           customKey: "my-custom-key",
         }),
       );
+    });
+  });
+});
+
+// ADR-066 pillar 2 — coalesced same-command batch collapses N appends into one
+// storeEvents call. See specs/event-sourcing/producer-append-coalescing.feature.
+describe("processCommandBatch", () => {
+  const aggregateType: AggregateType = createTestAggregateType();
+  const commandType: CommandType = "lw.obs.trace.record_span";
+  const commandName = "recordSpan";
+
+  const payloadFor = (n: number): Record<string, unknown> => ({
+    tenantId: TEST_CONSTANTS.TENANT_ID_VALUE,
+    occurredAt: TEST_CONSTANTS.BASE_TIMESTAMP + n,
+    id: `agg-${n}`,
+  });
+
+  function makeValidEvent(): Event {
+    return createTestEvent(
+      TEST_CONSTANTS.AGGREGATE_ID,
+      aggregateType,
+      createTestTenantId(),
+      TEST_CONSTANTS.EVENT_TYPE_1,
+      TEST_CONSTANTS.BASE_TIMESTAMP,
+    );
+  }
+
+  // A valid event carrying an idempotency key derived from its command, so the
+  // store call can be asserted to preserve every payload's event and its key.
+  function eventWithKey(key: string): Event {
+    return { ...makeValidEvent(), idempotencyKey: key };
+  }
+
+  // Schema mock that echoes the payload as validated data, so each payload keeps
+  // its own tenantId / id through validation (unlike the single-path fixture,
+  // which returns one shared payload).
+  function createEchoCommandSchema(
+    overrides?: Partial<CommandSchema<any, CommandType>>,
+  ): CommandSchema<any, CommandType> {
+    return {
+      type: commandType,
+      validate: vi.fn((p: any) => ({ success: true, data: p })),
+      ...overrides,
+    };
+  }
+
+  function createDefaultBatchParams(
+    overrides?: Partial<ProcessCommandBatchParams<Event>>,
+  ): ProcessCommandBatchParams<Event> {
+    return {
+      payloads: [payloadFor(0)],
+      commandType,
+      commandSchema: createEchoCommandSchema(),
+      handler: {
+        handle: vi.fn(async (command: any) => [
+          eventWithKey(`k-${command.aggregateId}`),
+        ]),
+      },
+      getAggregateId: vi.fn((p: any) => p.id ?? TEST_CONSTANTS.AGGREGATE_ID),
+      storeEventsFn: vi.fn().mockResolvedValue(undefined),
+      aggregateType,
+      commandName,
+      pipelineName: "test-pipeline",
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
+    mockedIsComponentDisabled.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("given several same-command payloads for one aggregate", () => {
+    describe("when the batch is processed", () => {
+      /** @scenario 'many items for one aggregate become one insert' */
+      /** @scenario 'coalescing preserves every item' */
+      it("stores every payload's events in one call with idempotency keys preserved", async () => {
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const params = createDefaultBatchParams({
+          payloads: [payloadFor(0), payloadFor(1), payloadFor(2)],
+          storeEventsFn,
+        });
+
+        await processCommandBatch(params);
+
+        expect(storeEventsFn).toHaveBeenCalledTimes(1);
+        const [events, context] = storeEventsFn.mock.calls[0]!;
+        expect((events as Event[]).map((e) => e.idempotencyKey)).toEqual([
+          "k-agg-0",
+          "k-agg-1",
+          "k-agg-2",
+        ]);
+        expect(context).toEqual({
+          tenantId: createTenantId(TEST_CONSTANTS.TENANT_ID_VALUE),
+        });
+      });
+    });
+  });
+
+  describe("given a payload that fails schema validation", () => {
+    describe("when the batch is processed", () => {
+      it("throws ValidationError and stores nothing", async () => {
+        const storeEventsFn = vi.fn();
+        const commandSchema = createEchoCommandSchema({
+          validate: vi.fn((p: any) =>
+            p.id === "agg-1"
+              ? {
+                  success: false,
+                  error: {
+                    issues: [
+                      { path: ["id"], message: "bad", code: "custom" },
+                    ],
+                  },
+                }
+              : { success: true, data: p },
+          ),
+        });
+        const params = createDefaultBatchParams({
+          payloads: [payloadFor(0), payloadFor(1)],
+          commandSchema,
+          storeEventsFn,
+        });
+
+        await expect(processCommandBatch(params)).rejects.toThrow(
+          ValidationError,
+        );
+        expect(storeEventsFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given the kill switch disables one payload mid-batch", () => {
+    describe("when the batch is processed", () => {
+      it("skips the disabled payload and stores the rest", async () => {
+        mockedIsComponentDisabled
+          .mockResolvedValueOnce(false)
+          .mockResolvedValueOnce(true)
+          .mockResolvedValueOnce(false);
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const handler = {
+          handle: vi.fn(async (command: any) => [
+            eventWithKey(`k-${command.aggregateId}`),
+          ]),
+        };
+        const params = createDefaultBatchParams({
+          payloads: [payloadFor(0), payloadFor(1), payloadFor(2)],
+          handler,
+          storeEventsFn,
+        });
+
+        await processCommandBatch(params);
+
+        // The disabled payload never reached the handler; the batch continued.
+        expect(handler.handle).toHaveBeenCalledTimes(2);
+        const [events] = storeEventsFn.mock.calls[0]!;
+        expect((events as Event[]).map((e) => e.idempotencyKey)).toEqual([
+          "k-agg-0",
+          "k-agg-2",
+        ]);
+      });
+    });
+  });
+
+  describe("given payloads from two different tenants", () => {
+    describe("when the batch is processed", () => {
+      it("throws ValidationError before storing", async () => {
+        const storeEventsFn = vi.fn();
+        const params = createDefaultBatchParams({
+          payloads: [
+            payloadFor(0),
+            { ...payloadFor(1), tenantId: "other-tenant" },
+          ],
+          storeEventsFn,
+        });
+
+        await expect(processCommandBatch(params)).rejects.toThrow(
+          /mixes tenants/,
+        );
+        expect(storeEventsFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given a handler with post-store cleanup", () => {
+    describe("when the batch is stored", () => {
+      it("runs cleanup once per handled command", async () => {
+        const cleanupAfterStore = vi.fn().mockResolvedValue(undefined);
+        const handler = {
+          handle: vi.fn(async (command: any) => [
+            eventWithKey(`k-${command.aggregateId}`),
+          ]),
+          cleanupAfterStore,
+        };
+        const params = createDefaultBatchParams({
+          payloads: [payloadFor(0), payloadFor(1)],
+          handler,
+          storeEventsFn: vi.fn().mockResolvedValue(undefined),
+        });
+
+        await processCommandBatch(params);
+
+        expect(cleanupAfterStore).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe("given every handler returns no events", () => {
+    describe("when the batch is processed", () => {
+      it("skips the store call", async () => {
+        const storeEventsFn = vi.fn();
+        const params = createDefaultBatchParams({
+          payloads: [payloadFor(0), payloadFor(1)],
+          handler: { handle: vi.fn().mockResolvedValue([]) },
+          storeEventsFn,
+        });
+
+        await processCommandBatch(params);
+
+        expect(storeEventsFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given a handler that throws on one payload", () => {
+    describe("when the batch is processed", () => {
+      it("fails the whole batch without storing", async () => {
+        const storeEventsFn = vi.fn();
+        const handler = {
+          handle: vi.fn(async (command: any) => {
+            if (command.aggregateId === "agg-1") {
+              throw new Error("handler boom");
+            }
+            return [eventWithKey(`k-${command.aggregateId}`)];
+          }),
+        };
+        const params = createDefaultBatchParams({
+          payloads: [payloadFor(0), payloadFor(1), payloadFor(2)],
+          handler,
+          storeEventsFn,
+        });
+
+        await expect(processCommandBatch(params)).rejects.toThrow(
+          "handler boom",
+        );
+        expect(storeEventsFn).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given an empty payload list", () => {
+    describe("when the batch is processed", () => {
+      it("does nothing", async () => {
+        const storeEventsFn = vi.fn();
+        const handler = { handle: vi.fn() };
+        const params = createDefaultBatchParams({
+          payloads: [],
+          handler,
+          storeEventsFn,
+        });
+
+        await processCommandBatch(params);
+
+        expect(handler.handle).not.toHaveBeenCalled();
+        expect(storeEventsFn).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/services/commands/__tests__/commandDispatcher.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/services/commands/__tests__/commandDispatcher.unit.test.ts
@@ -414,7 +414,7 @@ describe("processCommandBatch", () => {
     vi.restoreAllMocks();
   });
 
-  describe("given several same-command payloads for one aggregate", () => {
+  describe("given several same-command payloads across aggregates", () => {
     describe("when the batch is processed", () => {
       /** @scenario 'many items for one aggregate become one insert' */
       /** @scenario 'coalescing preserves every item' */
@@ -544,6 +544,39 @@ describe("processCommandBatch", () => {
         await processCommandBatch(params);
 
         expect(cleanupAfterStore).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("when one command's cleanup rejects", () => {
+      /** @contract 'a cleanup failure must never roll back durable events' */
+      it("still resolves, stores once, and runs the remaining cleanups", async () => {
+        const cleanupAfterStore = vi.fn(async (command: any) => {
+          if (command.aggregateId === "agg-1") {
+            throw new Error("cleanup boom");
+          }
+        });
+        const handler = {
+          handle: vi.fn(async (command: any) => [
+            eventWithKey(`k-${command.aggregateId}`),
+          ]),
+          cleanupAfterStore,
+        };
+        const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+        const params = createDefaultBatchParams({
+          payloads: [payloadFor(0), payloadFor(1), payloadFor(2)],
+          handler,
+          storeEventsFn,
+        });
+
+        await expect(processCommandBatch(params)).resolves.toBeUndefined();
+
+        // The durable append happened exactly once, and the failing cleanup
+        // neither rolled it back nor stopped the other commands' cleanups.
+        expect(storeEventsFn).toHaveBeenCalledTimes(1);
+        expect(cleanupAfterStore).toHaveBeenCalledTimes(3);
+        expect(
+          cleanupAfterStore.mock.calls.map(([command]) => command.aggregateId),
+        ).toEqual(["agg-0", "agg-1", "agg-2"]);
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/services/commands/__tests__/commandDispatcher.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/services/commands/__tests__/commandDispatcher.unit.test.ts
@@ -377,7 +377,10 @@ describe("processCommandBatch", () => {
   ): CommandSchema<any, CommandType> {
     return {
       type: commandType,
-      validate: vi.fn((p: any) => ({ success: true, data: p })),
+      validate: vi.fn().mockImplementation((p: any) => ({
+        success: true,
+        data: p,
+      })),
       ...overrides,
     };
   }
@@ -446,7 +449,7 @@ describe("processCommandBatch", () => {
       it("throws ValidationError and stores nothing", async () => {
         const storeEventsFn = vi.fn();
         const commandSchema = createEchoCommandSchema({
-          validate: vi.fn((p: any) =>
+          validate: vi.fn().mockImplementation((p: any) =>
             p.id === "agg-1"
               ? {
                   success: false,

--- a/langwatch/src/server/event-sourcing/services/commands/commandDispatcher.ts
+++ b/langwatch/src/server/event-sourcing/services/commands/commandDispatcher.ts
@@ -15,7 +15,10 @@ import type { TenantId } from "../../domain/tenantId";
 import { createTenantId } from "../../domain/tenantId";
 import type { Event } from "../../domain/types";
 import { EventSchema } from "../../domain/types";
-import type { KillSwitchOptions } from "../../pipeline/staticBuilder.types";
+import type {
+  CommandSerializationOptions,
+  KillSwitchOptions,
+} from "../../pipeline/staticBuilder.types";
 import type { DeduplicationStrategy } from "../../queues";
 import type { EventStoreReadContext } from "../../stores/eventStore.types";
 import { EventUtils } from "../../utils/event.utils";
@@ -226,6 +229,185 @@ export interface ProcessCommandBatchParams<EventType extends Event>
 }
 
 /**
+ * Attempted-command counter shared with {@link processCommandBatch}'s catch
+ * block. Held in a mutable ref so a mid-loop throw still exposes the partial
+ * count for the failure metrics.
+ */
+interface BatchProgress {
+  attempted: number;
+}
+
+/**
+ * Schema-validate every payload up front (Phase 1). A failure throws (like the
+ * single path), failing the whole batch; downstream idempotency keys make the
+ * batch's retry safe.
+ */
+function validateBatchPayloads<EventType extends Event>(
+  params: ProcessCommandBatchParams<EventType>,
+): any[] {
+  const { payloads, commandSchema, commandType } = params;
+  return payloads.map((payload) => {
+    const validation = commandSchema.validate(payload);
+    if (!validation.success) {
+      throw new ValidationError(
+        `Invalid payload for command type "${commandType}". Validation failed.`,
+        "payload",
+        undefined,
+        {
+          commandType,
+          zodIssues: mapZodIssuesToLogContext(validation.error.issues),
+        },
+      );
+    }
+    return validation.data;
+  });
+}
+
+/**
+ * Resolve the single tenant for the batch, enforcing the defensive invariant
+ * that a coalesced batch comes from ONE tenant-scoped group. A mismatch is an
+ * upstream routing bug — fail loudly rather than write cross-tenant events
+ * under one tenant's insert.
+ */
+function resolveBatchTenantId(args: {
+  validatedPayloads: any[];
+  commandType: CommandType;
+}): TenantId {
+  const { validatedPayloads, commandType } = args;
+  const tenantId = createTenantId(String(validatedPayloads[0]!.tenantId));
+  for (const validated of validatedPayloads) {
+    if (createTenantId(String(validated.tenantId)) !== tenantId) {
+      throw new ValidationError(
+        `Coalesced batch for command type "${commandType}" mixes tenants. All payloads in one group share a tenant.`,
+        "tenantId",
+        undefined,
+        { commandType },
+      );
+    }
+  }
+  return tenantId;
+}
+
+/**
+ * Kill-switch-check, handle, and collect events for every validated payload in
+ * dispatch order. `progress.attempted` counts non-kill-switched payloads so the
+ * caller's metrics (and its catch block) see the count even on a mid-loop throw.
+ */
+async function handleBatchCommands<EventType extends Event>(args: {
+  params: ProcessCommandBatchParams<EventType>;
+  validatedPayloads: any[];
+  progress: BatchProgress;
+}): Promise<{ handledCommands: Command<any>[]; allEvents: EventType[] }> {
+  const { params, validatedPayloads, progress } = args;
+  const {
+    getAggregateId,
+    handler,
+    commandType,
+    aggregateType,
+    commandName,
+    featureFlagService,
+    killSwitchOptions,
+    logger: log,
+  } = params;
+
+  const handledCommands: Command<any>[] = [];
+  const allEvents: EventType[] = [];
+  for (const validated of validatedPayloads) {
+    const payloadTenantId = createTenantId(String(validated.tenantId));
+    const aggregateId = getAggregateId(validated);
+
+    const disabled = await isComponentDisabled({
+      featureFlagService,
+      aggregateType,
+      componentType: "command",
+      componentName: commandName,
+      tenantId: payloadTenantId,
+      customKey: killSwitchOptions?.customKey,
+      logger: log,
+    });
+    if (disabled) {
+      // Mirror the single path's silent return: no events, no metrics — but
+      // the rest of the batch still runs.
+      continue;
+    }
+
+    progress.attempted++;
+    const command = createCommand(
+      payloadTenantId,
+      aggregateId,
+      commandType,
+      validated,
+    );
+    const events = await handler.handle(command);
+    validateHandlerEvents(events, commandType);
+    handledCommands.push(command);
+    for (const event of events) {
+      allEvents.push(event);
+    }
+  }
+
+  return { handledCommands, allEvents };
+}
+
+/**
+ * Persist the batch in ONE multi-row append, then run each handled command's
+ * best-effort post-store cleanup (ADR-022). An empty event set skips the store.
+ * A cleanup failure is logged and swallowed — it must never roll back durable
+ * events.
+ */
+async function persistBatch<EventType extends Event>(args: {
+  params: ProcessCommandBatchParams<EventType>;
+  tenantId: TenantId;
+  allEvents: EventType[];
+  handledCommands: Command<any>[];
+}): Promise<void> {
+  const { params, tenantId, allEvents, handledCommands } = args;
+  const { handler, storeEventsFn, commandType, logger: log } = params;
+
+  if (allEvents.length === 0) {
+    return;
+  }
+
+  await storeEventsFn(allEvents, { tenantId });
+  if (handler.cleanupAfterStore) {
+    for (const command of handledCommands) {
+      try {
+        await handler.cleanupAfterStore(command);
+      } catch (err) {
+        log?.warn(
+          {
+            error: err instanceof Error ? err.message : String(err),
+            commandType,
+          },
+          "Post-store cleanup failed (best-effort) — event is durable, cleanup skipped",
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Emit one counter increment and one duration sample per attempted command,
+ * keeping counter and histogram 1:1 with the single path. The whole-batch time
+ * is amortised across attempts so each sample carries a per-command time rather
+ * than N-commands of it.
+ */
+function emitBatchMetrics<EventType extends Event>(args: {
+  params: ProcessCommandBatchParams<EventType>;
+  outcome: "completed" | "failed";
+  attempted: number;
+  durationMs: number;
+}): void {
+  const { params, outcome, attempted, durationMs } = args;
+  const { pipelineName, commandType } = params;
+  const perCommandMs = attempted > 0 ? durationMs / attempted : 0;
+  for (let i = 0; i < attempted; i++) {
+    incrementEsCommandTotal(pipelineName, commandType, outcome);
+    observeEsCommandDuration(pipelineName, commandType, perCommandMs);
+  }
+}
+
+/**
  * Batched sibling of {@link processCommand} (ADR-066 pillar 2).
  *
  * The GroupQueue drains a hot aggregate's queued same-command jobs and hands
@@ -255,141 +437,38 @@ export interface ProcessCommandBatchParams<EventType extends Event>
 export async function processCommandBatch<EventType extends Event>(
   params: ProcessCommandBatchParams<EventType>,
 ): Promise<void> {
-  const {
-    payloads,
-    commandType,
-    commandSchema,
-    handler,
-    getAggregateId,
-    storeEventsFn,
-    aggregateType,
-    commandName,
-    pipelineName,
-    featureFlagService,
-    killSwitchOptions,
-    logger: log,
-  } = params;
-
-  if (payloads.length === 0) {
+  if (params.payloads.length === 0) {
     return;
   }
 
-  // Phase 1 — schema-validate every payload up front. A failure throws (like the
-  // single path), failing the whole batch; downstream idempotency keys make the
-  // batch's retry safe.
-  const validatedPayloads = payloads.map((payload) => {
-    const validation = commandSchema.validate(payload);
-    if (!validation.success) {
-      throw new ValidationError(
-        `Invalid payload for command type "${commandType}". Validation failed.`,
-        "payload",
-        undefined,
-        {
-          commandType,
-          zodIssues: mapZodIssuesToLogContext(validation.error.issues),
-        },
-      );
-    }
-    return validation.data;
+  const validatedPayloads = validateBatchPayloads(params);
+  const tenantId = resolveBatchTenantId({
+    validatedPayloads,
+    commandType: params.commandType,
   });
 
-  // Defensive invariant: a coalesced batch comes from ONE group, which is
-  // tenant-scoped, so every payload must share a tenant. A mismatch is a routing
-  // bug upstream — fail loudly rather than write cross-tenant events under one
-  // tenant's insert.
-  const tenantId = createTenantId(String(validatedPayloads[0]!.tenantId));
-  for (const validated of validatedPayloads) {
-    if (createTenantId(String(validated.tenantId)) !== tenantId) {
-      throw new ValidationError(
-        `Coalesced batch for command type "${commandType}" mixes tenants. All payloads in one group share a tenant.`,
-        "tenantId",
-        undefined,
-        { commandType },
-      );
-    }
-  }
-
   const batchStartTime = performance.now();
-  // Commands whose handler ran and validated — cleanup runs per one of these.
-  const handledCommands: Command<any>[] = [];
-  const allEvents: EventType[] = [];
-  // Non-kill-switched payloads attempted this batch. Both metrics count this,
-  // mirroring the single path where a kill-switched return emits nothing.
-  let attempted = 0;
+  const progress: BatchProgress = { attempted: 0 };
   try {
-    for (const validated of validatedPayloads) {
-      const payloadTenantId = createTenantId(String(validated.tenantId));
-      const aggregateId = getAggregateId(validated);
-
-      const disabled = await isComponentDisabled({
-        featureFlagService,
-        aggregateType,
-        componentType: "command",
-        componentName: commandName,
-        tenantId: payloadTenantId,
-        customKey: killSwitchOptions?.customKey,
-        logger: log,
-      });
-      if (disabled) {
-        // Mirror the single path's silent return: no events, no metrics — but
-        // the rest of the batch still runs.
-        continue;
-      }
-
-      attempted++;
-      const command = createCommand(
-        payloadTenantId,
-        aggregateId,
-        commandType,
-        validated,
-      );
-      const events = await handler.handle(command);
-      validateHandlerEvents(events, commandType);
-      handledCommands.push(command);
-      for (const event of events) {
-        allEvents.push(event);
-      }
-    }
-
-    if (allEvents.length > 0) {
-      // ONE multi-row append for the whole batch (ADR-066 pillar 2).
-      await storeEventsFn(allEvents, { tenantId });
-      // ADR-022 post-store cleanup, per handled command, best-effort — a cleanup
-      // failure must never roll back durable events.
-      if (handler.cleanupAfterStore) {
-        for (const command of handledCommands) {
-          try {
-            await handler.cleanupAfterStore(command);
-          } catch (err) {
-            log?.warn(
-              {
-                error: err instanceof Error ? err.message : String(err),
-                commandType,
-              },
-              "Post-store cleanup failed (best-effort) — event is durable, cleanup skipped",
-            );
-          }
-        }
-      }
-    }
-
-    const durationMs = performance.now() - batchStartTime;
-    // Keep counter and histogram 1:1 like the single path: one duration sample
-    // per attempted command. The whole-batch time is amortised across them so
-    // the histogram's sample count matches the counter and each sample carries a
-    // per-command time rather than N-commands of it.
-    const perCommandMs = attempted > 0 ? durationMs / attempted : 0;
-    for (let i = 0; i < attempted; i++) {
-      incrementEsCommandTotal(pipelineName, commandType, "completed");
-      observeEsCommandDuration(pipelineName, commandType, perCommandMs);
-    }
+    const { handledCommands, allEvents } = await handleBatchCommands({
+      params,
+      validatedPayloads,
+      progress,
+    });
+    await persistBatch({ params, tenantId, allEvents, handledCommands });
+    emitBatchMetrics({
+      params,
+      outcome: "completed",
+      attempted: progress.attempted,
+      durationMs: performance.now() - batchStartTime,
+    });
   } catch (error) {
-    const durationMs = performance.now() - batchStartTime;
-    const perCommandMs = attempted > 0 ? durationMs / attempted : 0;
-    for (let i = 0; i < attempted; i++) {
-      incrementEsCommandTotal(pipelineName, commandType, "failed");
-      observeEsCommandDuration(pipelineName, commandType, perCommandMs);
-    }
+    emitBatchMetrics({
+      params,
+      outcome: "failed",
+      attempted: progress.attempted,
+      durationMs: performance.now() - batchStartTime,
+    });
     throw error;
   }
 }
@@ -397,33 +476,10 @@ export async function processCommandBatch<EventType extends Event>(
 /**
  * Options for configuring a command handler.
  */
-export interface CommandHandlerOptions<Payload> {
+export interface CommandHandlerOptions<Payload>
+  extends CommandSerializationOptions {
   getAggregateId?: (payload: Payload) => string;
   getGroupKey?: (payload: Payload) => string;
-  /**
-   * Serialize this command with every other command that enables the option
-   * for the same tenant and aggregate. This keeps command handling, event
-   * append, and projection staging atomic with respect to the next command
-   * for that aggregate while allowing other aggregates to run concurrently.
-   */
-  serializeByAggregate?: boolean;
-  /**
-   * Coalesce this producer's appends (ADR-066 pillar 2). When one aggregate can
-   * mint events faster than they drain — a hot trigger recording every match —
-   * set the max number of same-command jobs (including the dispatched one) to
-   * fold into a single multi-row insert. Leave unset (or ≤ 1) for a low-fan-in
-   * producer where one aggregate appends at most one event per human action:
-   * those append immediately, with the per-job path unchanged.
-   */
-  coalesceMaxBatch?: number;
-  /**
-   * Optional byte cap for a coalesced batch (ADR-066 pillar 2). The drain stops
-   * before a job that would push the batch past this size, keeping one insert
-   * inside the downstream flush budget; a job too large to fit becomes its own
-   * dispatch. Unset falls back to the GroupQueue default. Only consulted when
-   * `coalesceMaxBatch` enables coalescing.
-   */
-  coalesceMaxBytes?: number;
   delay?: number;
   deduplication?: DeduplicationStrategy<Payload>;
   concurrency?: number;

--- a/langwatch/src/server/event-sourcing/services/commands/commandDispatcher.ts
+++ b/langwatch/src/server/event-sourcing/services/commands/commandDispatcher.ts
@@ -230,10 +230,17 @@ export interface ProcessCommandBatchParams<EventType extends Event>
  *
  * The GroupQueue drains a hot aggregate's queued same-command jobs and hands
  * them here as one ordered batch. Each payload is validated, kill-switch-checked,
- * and handled IN ORDER exactly as the single path does, but every resulting
- * event is persisted in ONE `storeEventsFn` call — collapsing N tiny single-row
- * appends into one multi-row insert so a high-fan-in producer stays off the
- * per-item event-log write path.
+ * and handled in dispatch order, then every resulting event is persisted in ONE
+ * `storeEventsFn` call — collapsing N tiny single-row appends into one multi-row
+ * insert so a high-fan-in producer stays off the per-item event-log write path.
+ *
+ * Contract — this is NOT the single path applied N times. All handlers run
+ * BEFORE the single end-of-batch store, so a handler CANNOT read back its own (or
+ * an earlier same-batch payload's) just-appended events — unlike the single path,
+ * which stores between dispatches. Handlers coalesced here must therefore be
+ * stateless per item: each derives its events from its own command alone, not
+ * from same-batch appends. A command opting into `coalesceMaxBatch` must satisfy
+ * this; one that needs read-your-writes within the batch must not coalesce.
  *
  * Because the drain only coalesces siblings sharing a `__jobName`, every payload
  * is the SAME command type: one schema and one handler serve the whole batch.
@@ -367,16 +374,22 @@ export async function processCommandBatch<EventType extends Event>(
     }
 
     const durationMs = performance.now() - batchStartTime;
+    // Keep counter and histogram 1:1 like the single path: one duration sample
+    // per attempted command. The whole-batch time is amortised across them so
+    // the histogram's sample count matches the counter and each sample carries a
+    // per-command time rather than N-commands of it.
+    const perCommandMs = attempted > 0 ? durationMs / attempted : 0;
     for (let i = 0; i < attempted; i++) {
       incrementEsCommandTotal(pipelineName, commandType, "completed");
+      observeEsCommandDuration(pipelineName, commandType, perCommandMs);
     }
-    observeEsCommandDuration(pipelineName, commandType, durationMs);
   } catch (error) {
     const durationMs = performance.now() - batchStartTime;
+    const perCommandMs = attempted > 0 ? durationMs / attempted : 0;
     for (let i = 0; i < attempted; i++) {
       incrementEsCommandTotal(pipelineName, commandType, "failed");
+      observeEsCommandDuration(pipelineName, commandType, perCommandMs);
     }
-    observeEsCommandDuration(pipelineName, commandType, durationMs);
     throw error;
   }
 }

--- a/langwatch/src/server/event-sourcing/services/commands/commandDispatcher.ts
+++ b/langwatch/src/server/event-sourcing/services/commands/commandDispatcher.ts
@@ -101,7 +101,7 @@ function validateHandlerEvents(
       const validationError =
         parseResult.success === false
           ? `Validation errors: ${parseResult.error.issues
-              .map((issue: any) => `${issue.path.join(".")}: ${issue.message}`)
+              .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
               .join(", ")}`
           : "Unknown validation error";
 

--- a/langwatch/src/server/event-sourcing/services/commands/commandDispatcher.ts
+++ b/langwatch/src/server/event-sourcing/services/commands/commandDispatcher.ts
@@ -54,6 +54,72 @@ export interface ProcessCommandParams<EventType extends Event> {
 }
 
 /**
+ * Validates that a command handler returned a defined array of well-formed
+ * events, throwing a {@link ValidationError} otherwise.
+ *
+ * Extracted so {@link processCommand} and {@link processCommandBatch} reject
+ * identical malformed handler output rather than each carrying its own copy.
+ */
+function validateHandlerEvents(
+  events: unknown,
+  commandType: CommandType,
+): void {
+  if (!events) {
+    throw new ValidationError(
+      `Command handler for "${commandType}" returned undefined. Handler must return an array of events.`,
+      "events",
+      void 0,
+      { commandType },
+    );
+  }
+
+  if (!Array.isArray(events)) {
+    throw new ValidationError(
+      `Command handler for "${commandType}" returned a non-array value. Handler must return an array of events, but got: ${typeof events}`,
+      "events",
+      undefined,
+      { commandType },
+    );
+  }
+
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (!event) {
+      throw new ValidationError(
+        `Command handler for "${commandType}" returned an array with undefined at index ${i}. All events must be defined.`,
+        "events",
+        undefined,
+        { commandType, index: i },
+      );
+    }
+
+    if (!EventUtils.isValidEvent(event)) {
+      const parseResult = EventSchema.safeParse(event);
+      const validationError =
+        parseResult.success === false
+          ? `Validation errors: ${parseResult.error.issues
+              .map((issue: any) => `${issue.path.join(".")}: ${issue.message}`)
+              .join(", ")}`
+          : "Unknown validation error";
+
+      throw new ValidationError(
+        `Command handler for "${commandType}" returned an invalid event at index ${i}. Event must have id, aggregateId, timestamp, type, and data. ${validationError}.`,
+        "events",
+        undefined,
+        {
+          commandType,
+          index: i,
+          zodIssues:
+            parseResult.success === false
+              ? mapZodIssuesToLogContext(parseResult.error.issues)
+              : void 0,
+        },
+      );
+    }
+  }
+}
+
+/**
  * Processes a command: validates the payload, checks kill switch, invokes the handler,
  * validates resulting events, and stores them.
  *
@@ -113,61 +179,7 @@ export async function processCommand<EventType extends Event>(
   try {
     const events = await handler.handle(command);
 
-    if (!events) {
-      throw new ValidationError(
-        `Command handler for "${commandType}" returned undefined. Handler must return an array of events.`,
-        "events",
-        void 0,
-        { commandType },
-      );
-    }
-
-    if (!Array.isArray(events)) {
-      throw new ValidationError(
-        `Command handler for "${commandType}" returned a non-array value. Handler must return an array of events, but got: ${typeof events}`,
-        "events",
-        undefined,
-        { commandType },
-      );
-    }
-
-    for (let i = 0; i < events.length; i++) {
-      const event = events[i];
-      if (!event) {
-        throw new ValidationError(
-          `Command handler for "${commandType}" returned an array with undefined at index ${i}. All events must be defined.`,
-          "events",
-          undefined,
-          { commandType, index: i },
-        );
-      }
-
-      if (!EventUtils.isValidEvent(event)) {
-        const parseResult = EventSchema.safeParse(event);
-        const validationError =
-          parseResult.success === false
-            ? `Validation errors: ${parseResult.error.issues
-                .map(
-                  (issue: any) => `${issue.path.join(".")}: ${issue.message}`,
-                )
-                .join(", ")}`
-            : "Unknown validation error";
-
-        throw new ValidationError(
-          `Command handler for "${commandType}" returned an invalid event at index ${i}. Event must have id, aggregateId, timestamp, type, and data. ${validationError}.`,
-          "events",
-          undefined,
-          {
-            commandType,
-            index: i,
-            zodIssues:
-              parseResult.success === false
-                ? mapZodIssuesToLogContext(parseResult.error.issues)
-                : void 0,
-          },
-        );
-      }
-    }
+    validateHandlerEvents(events, commandType);
 
     if (events.length > 0) {
       await storeEventsFn(events, { tenantId });
@@ -203,6 +215,173 @@ export async function processCommand<EventType extends Event>(
 }
 
 /**
+ * Parameters for {@link processCommandBatch}: the same shape as
+ * {@link ProcessCommandParams} but with an ordered list of payloads instead of
+ * one.
+ */
+export interface ProcessCommandBatchParams<EventType extends Event>
+  extends Omit<ProcessCommandParams<EventType>, "payload"> {
+  /** Same-command payloads to coalesce, in dispatch (occurredAt) order. */
+  payloads: Record<string, unknown>[];
+}
+
+/**
+ * Batched sibling of {@link processCommand} (ADR-066 pillar 2).
+ *
+ * The GroupQueue drains a hot aggregate's queued same-command jobs and hands
+ * them here as one ordered batch. Each payload is validated, kill-switch-checked,
+ * and handled IN ORDER exactly as the single path does, but every resulting
+ * event is persisted in ONE `storeEventsFn` call — collapsing N tiny single-row
+ * appends into one multi-row insert so a high-fan-in producer stays off the
+ * per-item event-log write path.
+ *
+ * Because the drain only coalesces siblings sharing a `__jobName`, every payload
+ * is the SAME command type: one schema and one handler serve the whole batch.
+ *
+ * Failure semantics mirror the single path:
+ *  - a schema validation failure throws, failing the whole batch — the events
+ *    carry idempotency keys, so the retry is de-duplicated downstream;
+ *  - a kill-switched payload contributes no events and the batch continues;
+ *  - a handler error or malformed event fails the batch;
+ *  - an empty event set skips the store call.
+ */
+export async function processCommandBatch<EventType extends Event>(
+  params: ProcessCommandBatchParams<EventType>,
+): Promise<void> {
+  const {
+    payloads,
+    commandType,
+    commandSchema,
+    handler,
+    getAggregateId,
+    storeEventsFn,
+    aggregateType,
+    commandName,
+    pipelineName,
+    featureFlagService,
+    killSwitchOptions,
+    logger: log,
+  } = params;
+
+  if (payloads.length === 0) {
+    return;
+  }
+
+  // Phase 1 — schema-validate every payload up front. A failure throws (like the
+  // single path), failing the whole batch; downstream idempotency keys make the
+  // batch's retry safe.
+  const validatedPayloads = payloads.map((payload) => {
+    const validation = commandSchema.validate(payload);
+    if (!validation.success) {
+      throw new ValidationError(
+        `Invalid payload for command type "${commandType}". Validation failed.`,
+        "payload",
+        undefined,
+        {
+          commandType,
+          zodIssues: mapZodIssuesToLogContext(validation.error.issues),
+        },
+      );
+    }
+    return validation.data;
+  });
+
+  // Defensive invariant: a coalesced batch comes from ONE group, which is
+  // tenant-scoped, so every payload must share a tenant. A mismatch is a routing
+  // bug upstream — fail loudly rather than write cross-tenant events under one
+  // tenant's insert.
+  const tenantId = createTenantId(String(validatedPayloads[0]!.tenantId));
+  for (const validated of validatedPayloads) {
+    if (createTenantId(String(validated.tenantId)) !== tenantId) {
+      throw new ValidationError(
+        `Coalesced batch for command type "${commandType}" mixes tenants. All payloads in one group share a tenant.`,
+        "tenantId",
+        undefined,
+        { commandType },
+      );
+    }
+  }
+
+  const batchStartTime = performance.now();
+  // Commands whose handler ran and validated — cleanup runs per one of these.
+  const handledCommands: Command<any>[] = [];
+  const allEvents: EventType[] = [];
+  // Non-kill-switched payloads attempted this batch. Both metrics count this,
+  // mirroring the single path where a kill-switched return emits nothing.
+  let attempted = 0;
+  try {
+    for (const validated of validatedPayloads) {
+      const payloadTenantId = createTenantId(String(validated.tenantId));
+      const aggregateId = getAggregateId(validated);
+
+      const disabled = await isComponentDisabled({
+        featureFlagService,
+        aggregateType,
+        componentType: "command",
+        componentName: commandName,
+        tenantId: payloadTenantId,
+        customKey: killSwitchOptions?.customKey,
+        logger: log,
+      });
+      if (disabled) {
+        // Mirror the single path's silent return: no events, no metrics — but
+        // the rest of the batch still runs.
+        continue;
+      }
+
+      attempted++;
+      const command = createCommand(
+        payloadTenantId,
+        aggregateId,
+        commandType,
+        validated,
+      );
+      const events = await handler.handle(command);
+      validateHandlerEvents(events, commandType);
+      handledCommands.push(command);
+      for (const event of events) {
+        allEvents.push(event);
+      }
+    }
+
+    if (allEvents.length > 0) {
+      // ONE multi-row append for the whole batch (ADR-066 pillar 2).
+      await storeEventsFn(allEvents, { tenantId });
+      // ADR-022 post-store cleanup, per handled command, best-effort — a cleanup
+      // failure must never roll back durable events.
+      if (handler.cleanupAfterStore) {
+        for (const command of handledCommands) {
+          try {
+            await handler.cleanupAfterStore(command);
+          } catch (err) {
+            log?.warn(
+              {
+                error: err instanceof Error ? err.message : String(err),
+                commandType,
+              },
+              "Post-store cleanup failed (best-effort) — event is durable, cleanup skipped",
+            );
+          }
+        }
+      }
+    }
+
+    const durationMs = performance.now() - batchStartTime;
+    for (let i = 0; i < attempted; i++) {
+      incrementEsCommandTotal(pipelineName, commandType, "completed");
+    }
+    observeEsCommandDuration(pipelineName, commandType, durationMs);
+  } catch (error) {
+    const durationMs = performance.now() - batchStartTime;
+    for (let i = 0; i < attempted; i++) {
+      incrementEsCommandTotal(pipelineName, commandType, "failed");
+    }
+    observeEsCommandDuration(pipelineName, commandType, durationMs);
+    throw error;
+  }
+}
+
+/**
  * Options for configuring a command handler.
  */
 export interface CommandHandlerOptions<Payload> {
@@ -215,6 +394,23 @@ export interface CommandHandlerOptions<Payload> {
    * for that aggregate while allowing other aggregates to run concurrently.
    */
   serializeByAggregate?: boolean;
+  /**
+   * Coalesce this producer's appends (ADR-066 pillar 2). When one aggregate can
+   * mint events faster than they drain — a hot trigger recording every match —
+   * set the max number of same-command jobs (including the dispatched one) to
+   * fold into a single multi-row insert. Leave unset (or ≤ 1) for a low-fan-in
+   * producer where one aggregate appends at most one event per human action:
+   * those append immediately, with the per-job path unchanged.
+   */
+  coalesceMaxBatch?: number;
+  /**
+   * Optional byte cap for a coalesced batch (ADR-066 pillar 2). The drain stops
+   * before a job that would push the batch past this size, keeping one insert
+   * inside the downstream flush budget; a job too large to fit becomes its own
+   * dispatch. Unset falls back to the GroupQueue default. Only consulted when
+   * `coalesceMaxBatch` enables coalescing.
+   */
+  coalesceMaxBytes?: number;
   delay?: number;
   deduplication?: DeduplicationStrategy<Payload>;
   concurrency?: number;

--- a/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.commandGroupKey.test.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.commandGroupKey.test.ts
@@ -225,6 +225,147 @@ describe("QueueManager.initializeCommandQueues with getGroupKey", () => {
   });
 });
 
+// ADR-066 pillar 2 — append coalescing wiring + the un-coalesced-producer
+// visibility record. See specs/event-sourcing/producer-append-coalescing.feature.
+describe("QueueManager.initializeCommandQueues append coalescing", () => {
+  const aggregateType = createTestAggregateType();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function buildManager() {
+    const globalJobRegistry = new Map<string, JobRegistryEntry>();
+    const manager = new QueueManager({
+      aggregateType,
+      pipelineName: "test-pipeline",
+      globalQueue: createMockSharedQueue(),
+      globalJobRegistry,
+    });
+    return { manager, globalJobRegistry };
+  }
+
+  function loggerInfoSpyOf(manager: QueueManager) {
+    return vi.spyOn(
+      (manager as unknown as { logger: { info: (...a: any[]) => void } })
+        .logger,
+      "info",
+    );
+  }
+
+  describe("given a command that opts into coalescing", () => {
+    describe("when the command queue is initialized", () => {
+      it("wires coalesceMaxBatch, coalesceMaxBytes, and processBatch onto the registry entry", () => {
+        const { manager, globalJobRegistry } = buildManager();
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "hot",
+              handlerClass: createMockCommandHandlerClass("hot"),
+              options: {
+                serializeByAggregate: true,
+                coalesceMaxBatch: 200,
+                coalesceMaxBytes: 1024,
+              },
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        const entry = globalJobRegistry.get("test-pipeline:command:hot");
+        expect(entry?.coalesceMaxBatch).toBe(200);
+        expect(entry?.coalesceMaxBytes).toBe(1024);
+        expect(entry?.processBatch).toBeDefined();
+      });
+    });
+  });
+
+  describe("given a command that does not coalesce", () => {
+    describe("when the command queue is initialized", () => {
+      it("leaves processBatch and the coalesce bounds unset", () => {
+        const { manager, globalJobRegistry } = buildManager();
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "cold",
+              handlerClass: createMockCommandHandlerClass("cold"),
+              options: { serializeByAggregate: true },
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        const entry = globalJobRegistry.get("test-pipeline:command:cold");
+        expect(entry?.processBatch).toBeUndefined();
+        expect(entry?.coalesceMaxBatch).toBeUndefined();
+      });
+    });
+  });
+
+  describe("given a serialized producer registered without coalescing", () => {
+    describe("when the command queue is initialized", () => {
+      /** @scenario 'an un-coalesced high-fan-in producer is visible, not silent' */
+      it("emits a record naming the producer and its pipeline", () => {
+        const { manager } = buildManager();
+        const infoSpy = loggerInfoSpyOf(manager);
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "cold",
+              handlerClass: createMockCommandHandlerClass("cold"),
+              options: { serializeByAggregate: true },
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        expect(infoSpy).toHaveBeenCalledWith(
+          { pipeline: "test-pipeline", command: "cold" },
+          "serialized command producer registered without append coalescing",
+        );
+      });
+    });
+  });
+
+  describe("given a serialized producer that DOES coalesce", () => {
+    describe("when the command queue is initialized", () => {
+      it("does not emit the un-coalesced visibility record", () => {
+        const { manager } = buildManager();
+        const infoSpy = loggerInfoSpyOf(manager);
+
+        manager.initializeCommandQueues(
+          [
+            {
+              name: "hot",
+              handlerClass: createMockCommandHandlerClass("hot"),
+              options: { serializeByAggregate: true, coalesceMaxBatch: 200 },
+            },
+          ],
+          vi.fn(),
+          "test-pipeline",
+        );
+
+        expect(infoSpy).not.toHaveBeenCalledWith(
+          expect.anything(),
+          "serialized command producer registered without append coalescing",
+        );
+      });
+    });
+  });
+});
+
 describe("QueueManager.initializeHandlerQueues with groupKeyFn", () => {
   const aggregateType = createTestAggregateType();
   const tenantId = createTestTenantId();

--- a/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
@@ -20,6 +20,7 @@ import type { EventStoreReadContext } from "../../stores/eventStore.types";
 import {
   type CommandHandlerOptions,
   processCommand,
+  processCommandBatch,
 } from "../commands/commandDispatcher";
 import { ConfigurationError, ValidationError } from "../errorHandling";
 
@@ -48,6 +49,11 @@ export interface JobRegistryEntry {
    * (including the dispatched job). Defaults to 1 (no coalescing).
    */
   coalesceMaxBatch?: number;
+  /**
+   * Optional byte cap for a coalesced batch (ADR-066 pillar 2). Resolved by the
+   * global queue per job; undefined falls back to the GroupQueue default.
+   */
+  coalesceMaxBytes?: number;
 }
 
 interface QueuedEventConsumerDefinition<E extends Event> {
@@ -581,27 +587,58 @@ export class QueueManager<EventType extends Event = Event> {
           return `${this.aggregateType}:${String(key)}`;
         },
       });
+      const coalesceMaxBatch = cmdEntry.options.coalesceMaxBatch;
+
+      // ADR-066 pillar 2 visibility: a serialized producer that does NOT
+      // coalesce can still flood the event log one tiny insert per item under
+      // high fan-in. Record the gap at registration so it can be found and
+      // closed, instead of surfacing only as ClickHouse small-parts pressure.
+      if (
+        cmdEntry.options.serializeByAggregate &&
+        !(coalesceMaxBatch && coalesceMaxBatch > 1)
+      ) {
+        this.logger.info(
+          { pipeline: this.pipelineName, command: cmdName },
+          "serialized command producer registered without append coalescing",
+        );
+      }
+
+      // Shared across the single and batched processors — same command, same
+      // store, same kill switch; only the payload arity differs.
+      const commandProcessParams = {
+        commandType: cmdEntry.commandType,
+        commandSchema: cmdEntry.schema,
+        handler: cmdEntry.handler,
+        getAggregateId: cmdEntry.getAggregateId,
+        storeEventsFn: storeEvents,
+        aggregateType: this.aggregateType,
+        commandName: cmdEntry.commandName,
+        pipelineName: this.pipelineName,
+        featureFlagService: this.featureFlagService,
+        killSwitchOptions: cmdEntry.killSwitchOptions,
+        logger,
+      };
+
       const jobEntry: JobRegistryEntry = {
         groupKeyFn: commandGroupKeyFn,
         scoreFn: cmdEntry.options.serializeByAggregate
           ? () => Date.now()
           : (payload: any) => payload.occurredAt as number,
         process: async (payload: any) => {
-          await processCommand({
-            payload,
-            commandType: cmdEntry.commandType,
-            commandSchema: cmdEntry.schema,
-            handler: cmdEntry.handler,
-            getAggregateId: cmdEntry.getAggregateId,
-            storeEventsFn: storeEvents,
-            aggregateType: this.aggregateType,
-            commandName: cmdEntry.commandName,
-            pipelineName: this.pipelineName,
-            featureFlagService: this.featureFlagService,
-            killSwitchOptions: cmdEntry.killSwitchOptions,
-            logger,
-          });
+          await processCommand({ ...commandProcessParams, payload });
         },
+        // ADR-066 pillar 2: when the command opts into coalescing, fold a hot
+        // aggregate's queued same-command jobs into one multi-row insert. The
+        // GroupQueue only drains same-`__jobName` siblings, so every payload
+        // here is this command type. Left undefined otherwise (per-job path).
+        processBatch:
+          coalesceMaxBatch && coalesceMaxBatch > 1
+            ? async (payloads: any[]) => {
+                await processCommandBatch({ ...commandProcessParams, payloads });
+              }
+            : undefined,
+        coalesceMaxBatch,
+        coalesceMaxBytes: cmdEntry.options.coalesceMaxBytes,
         delay: cmdEntry.options.delay,
         deduplication: rawDedup,
         spanAttributes: cmdEntry.spanAttributes,

--- a/specs/event-sourcing/fold-coalescing.feature
+++ b/specs/event-sourcing/fold-coalescing.feature
@@ -104,10 +104,10 @@ Feature: Group-coalesced fold projections
     Then the stored spans are read again rather than serving the earlier result
 
   # The drain that coalesces a backed-up group is bounded by BOTH a count and a
-  # byte budget — one shared mechanism in the GroupQueue. Folds here are bounded
-  # by count (their events are small and uniform); the byte bound matters for
-  # producer-side command coalescing, whose behaviour (stop at the byte budget,
-  # a single oversized item on its own) is specced in
+  # byte budget — one shared mechanism in the GroupQueue (ADR-066, pillar 2).
+  # Folds here are bounded by count (their events are small and uniform); the
+  # byte bound matters for producer-side command coalescing, whose behaviour
+  # (stop at the byte budget, a single oversized item on its own) is specced in
   # producer-append-coalescing.feature rather than duplicated here.
   @integration @coalescing @queue
   Scenario: A backed-up group is folded in a single batch call

--- a/specs/event-sourcing/fold-coalescing.feature
+++ b/specs/event-sourcing/fold-coalescing.feature
@@ -103,6 +103,12 @@ Feature: Group-coalesced fold projections
     When trace data is derived again after the fold advances with newer spans
     Then the stored spans are read again rather than serving the earlier result
 
+  # The drain that coalesces a backed-up group is bounded by BOTH a count and a
+  # byte budget — one shared mechanism in the GroupQueue. Folds here are bounded
+  # by count (their events are small and uniform); the byte bound matters for
+  # producer-side command coalescing, whose behaviour (stop at the byte budget,
+  # a single oversized item on its own) is specced in
+  # producer-append-coalescing.feature rather than duplicated here.
   @integration @coalescing @queue
   Scenario: A backed-up group is folded in a single batch call
     Given a group with ten queued events

--- a/specs/event-sourcing/fold-read-back-store.feature
+++ b/specs/event-sourcing/fold-read-back-store.feature
@@ -35,6 +35,13 @@ Feature: Fold projections read back their own state
     Then a subsequent contribution does not double-count
     And derived measures that depend on prior context stay correct
 
+  Scenario: a redelivered batch after a committed write does not double-count
+    Given an aggregate whose committed state already contains a delivered batch
+    And the cache entry recording that batch was lost
+    When the same batch is delivered again
+    Then the fold recognises every event as already applied
+    And the stored state is unchanged
+
   Scenario: the event log is read only for a deliberate rebuild
     Given a projection whose logic version has changed
     When an operator replays the projection

--- a/specs/event-sourcing/fold-read-back-store.feature
+++ b/specs/event-sourcing/fold-read-back-store.feature
@@ -36,7 +36,8 @@ Feature: Fold projections read back their own state
     And derived measures that depend on prior context stay correct
 
   Scenario: a redelivered batch after a committed write does not double-count
-    Given an aggregate whose committed state already contains a delivered batch
+    Given a fold that persists its applied-event set durably next to its state
+    And an aggregate whose committed state already contains a delivered batch
     And the cache entry recording that batch was lost
     When the same batch is delivered again
     Then the fold recognises every event as already applied

--- a/specs/event-sourcing/poison-group-park-guard.feature
+++ b/specs/event-sourcing/poison-group-park-guard.feature
@@ -114,10 +114,10 @@ Feature: GroupQueue poison-group park guard
   Scenario: an oversized coalesced sibling parks the group without losing the batch
     Given a group whose dispatched job is small but a staged sibling exceeds the decode-side cap
     When a worker claims the group and coalesces a batch
-    Then the oversized sibling stays out of the batch, because it exceeds the batch's byte budget
+    Then the oversized sibling is never folded into the batch
     And the batch's other work completes normally instead of being held behind the poison
-    And when the oversized job's own turn comes, the group is moved to the blocked set without JSON-parsing it
-    And the stored group error explains it was parked unparsed
+    And when the oversized sibling's own turn comes, the group is moved to the blocked set without JSON-parsing it
+    And the stored group error explains why it was parked
 
   Scenario: the poison guard is disabled by setting the strike threshold to 0
     Given the strike-threshold kill switch is set to 0

--- a/specs/event-sourcing/poison-group-park-guard.feature
+++ b/specs/event-sourcing/poison-group-park-guard.feature
@@ -112,11 +112,12 @@ Feature: GroupQueue poison-group park guard
     And the worker's event loop remains responsive throughout
 
   Scenario: an oversized coalesced sibling parks the group without losing the batch
-    Given a group whose dispatched job is small but a coalesced sibling exceeds the decode-side cap
-    When a worker claims the group and drains the sibling to fold it into the batch
-    Then the group is moved to the blocked set without JSON-parsing the oversized sibling
-    And the stored group error explains the batch was parked unparsed
-    And the batch's other work is re-staged for operator inspection or replay instead of being dropped
+    Given a group whose dispatched job is small but a staged sibling exceeds the decode-side cap
+    When a worker claims the group and coalesces a batch
+    Then the oversized sibling stays out of the batch, because it exceeds the batch's byte budget
+    And the batch's other work completes normally instead of being held behind the poison
+    And when the oversized job's own turn comes, the group is moved to the blocked set without JSON-parsing it
+    And the stored group error explains it was parked unparsed
 
   Scenario: the poison guard is disabled by setting the strike threshold to 0
     Given the strike-threshold kill switch is set to 0

--- a/specs/event-sourcing/producer-append-coalescing.feature
+++ b/specs/event-sourcing/producer-append-coalescing.feature
@@ -42,4 +42,4 @@ Feature: High-fan-in producers coalesce their event-log appends
   Scenario: an un-coalesced high-fan-in producer is visible, not silent
     Given a high-fan-in producer that does not coalesce its appends
     When its pipeline starts
-    Then the gap is recorded with enough detail to find and close it
+    Then an operator-visible record names the producer and the coalescing coverage it lacks

--- a/specs/event-sourcing/producer-append-coalescing.feature
+++ b/specs/event-sourcing/producer-append-coalescing.feature
@@ -40,5 +40,6 @@ Feature: High-fan-in producers coalesce their event-log appends
     Then it appends immediately without waiting to batch
 
   Scenario: an un-coalesced high-fan-in producer is visible, not silent
-    Given a high-fan-in producer that does not coalesce its appends
-    Then the gap is recorded so it can be found and closed
+    Given a serialized producer registered without append coalescing
+    When the pipeline registers its producers
+    Then a record naming that producer and its pipeline is emitted, so the gap can be found and closed

--- a/specs/event-sourcing/producer-append-coalescing.feature
+++ b/specs/event-sourcing/producer-append-coalescing.feature
@@ -42,4 +42,4 @@ Feature: High-fan-in producers coalesce their event-log appends
   Scenario: an un-coalesced high-fan-in producer is visible, not silent
     Given a high-fan-in producer that does not coalesce its appends
     When its pipeline starts
-    Then an operator-visible record names the producer and the coalescing coverage it lacks
+    Then an operator-visible record names the producer, so the gap can be found and closed

--- a/specs/event-sourcing/producer-append-coalescing.feature
+++ b/specs/event-sourcing/producer-append-coalescing.feature
@@ -40,6 +40,6 @@ Feature: High-fan-in producers coalesce their event-log appends
     Then it appends immediately without waiting to batch
 
   Scenario: an un-coalesced high-fan-in producer is visible, not silent
-    Given a serialized producer registered without append coalescing
-    When the pipeline registers its producers
-    Then a record naming that producer and its pipeline is emitted, so the gap can be found and closed
+    Given a high-fan-in producer that does not coalesce its appends
+    When its pipeline starts
+    Then the gap is recorded with enough detail to find and close it

--- a/specs/event-sourcing/redis-fold-cache.feature
+++ b/specs/event-sourcing/redis-fold-cache.feature
@@ -75,6 +75,10 @@ Feature: Redis write-through cache for fold state
     And the fold is not failed, because the state is durable
     And the read is counted, because the record of applied events went with it
 
+  # The scenario below documents the measured limit of cache-only folds — it is
+  # not accepted retry behaviour. A fold that persists its applied-event set
+  # durably next to its state keeps exact dedup across cache loss instead
+  # (fold-read-back-store.feature).
   Scenario: Losing the cached entry loses the protection
     Given a fold that keeps its applied-event set in the cache entry only
     And a fold job failed after its state was stored
@@ -82,3 +86,4 @@ Feature: Redis write-through cache for fold state
     When the job is retried with the same events
     Then the events are applied again
     And the aggregate over-counts, as it did before the record existed
+    And the re-application is measured, not silent

--- a/specs/event-sourcing/redis-fold-cache.feature
+++ b/specs/event-sourcing/redis-fold-cache.feature
@@ -17,12 +17,16 @@ Feature: Redis write-through cache for fold state
   have been acked and its ids can never come back; a retry merges into it,
   because they still can.
 
-  Because the set lives in the cache entry, losing the entry loses the
-  protection. That leaves the cold path open, and closing it means making
-  the folds themselves idempotent, which this feature does not attempt. The
-  gap is measured rather than assumed: es_fold_dedup_unavailable_total counts
-  the reads that lost the record, es_fold_blind_reapply_events counts the
-  events re-applied without it.
+  For a fold that carries this set in the cache entry alone, losing the
+  entry loses the protection. That leaves the cold path open, and closing it
+  for those folds would mean making the folds themselves idempotent, which
+  this feature does not attempt. A read-back fold closes it a different way:
+  it persists the applied-event set durably next to its state (ADR-066), so
+  the set survives cache loss — that path is specced in
+  fold-read-back-store.feature. Where the set is cache-only the gap is
+  measured rather than assumed: es_fold_dedup_unavailable_total counts the
+  reads that lost the record, es_fold_blind_reapply_events counts the events
+  re-applied without it.
 
   Background:
     Given a fold projection with a cached store
@@ -72,7 +76,8 @@ Feature: Redis write-through cache for fold state
     And the read is counted, because the record of applied events went with it
 
   Scenario: Losing the cached entry loses the protection
-    Given a fold job failed after its state was stored
+    Given a fold that keeps its applied-event set in the cache entry only
+    And a fold job failed after its state was stored
     And its cached entry is evicted before the retry
     When the job is retried with the same events
     Then the events are applied again


### PR DESCRIPTION
## What

The two remaining ADR-066 hot-path levers. Follow-up to #6079 (merged — this PR now targets `main` directly):

1. **Durable dedup watermark** (`7051b1382`) — ADR-066 sequencing step 4. The applied-event-id set that lets a fold recognise a redelivered batch lived only in the Redis cache entry, so a committed `store()` + lost cache entry let a retry re-fold the same batch onto state that already contained it (silent double-count; the `es_fold_blind_reapply` window). Now:
   - `FoldProjectionStore.getWithApplied()` (optional): stores that persist the set durably answer redelivery dedup even with a cold cache; the executor prefers it and — critically — commits the **union** of the loaded set and the fresh ids on retries, so a retry chain that keeps losing its cache cannot lose track of a batch it already folded (three-attempt chain covered by tests).
   - `RedisCachedFoldStore` reads the durable set through on a miss; `es_fold_dedup_unavailable_total` now only counts when even the durable set is empty.
   - First adopter: `codingAgentSession` — **migration 00054** adds `AppliedEventIds Array(String)` (additive, `IF NOT EXISTS`); the row type and API read payloads are unchanged (the watermark rides beside the row, not in it).

2. **Pillar 2 — producer append coalescing** (`828d57cfb`), first adopter `recordTriggerMatch`. A hot trigger minted one tiny `event_log` `async_insert` per match. Now:
   - `processCommandBatch`: the GroupQueue's drained same-command batch validates/kill-switch-checks/handles per payload in order, then persists through **one** multi-row `storeEvents` insert. Batch failure retries whole; event idempotency keys dedup the replay downstream. Defensive tenant-homogeneity guard.
   - **Count+byte-bounded drain** (the ADR puts the bound in the drain so folds and producers share it): `drainGroupReady` stops before the job that would push the batch past `maxBytes` (dispatched job's size counts via `initialBytes`); an oversized item stays staged and appends alone. `DEFAULT_COALESCE_MAX_BYTES = 4 MiB`; `maxBytes <= 0` preserves the old count-only behaviour bit-for-bit.
   - **Mixed-command groups**: `serializeByAggregate` shares the group namespace across command types, so the drain now filters siblings by `__jobName` and restages foreign ones untouched — a payload is never handed to another command's handler.
   - `recordTriggerMatch` opts in with `TRIGGER_MATCH_COALESCE_MAX_BATCH = 200`; serialized command producers registering **without** coalescing get a structured registration-time log line (the spec's 'visible, not silent' scenario, rewritten to this observable).

## Specs

- `fold-read-back-store.feature`: new scenario *a redelivered batch after a committed write does not double-count* (bound via `@scenario`).
- `producer-append-coalescing.feature`: final scenario rewritten with a proper When/Then; scenarios bound to tests via `@scenario`.
- `fold-coalescing.feature`: cross-reference comment for the shared drain bound (no duplicated scenarios).
- `poison-group-park-guard.feature`: the oversized-coalesced-sibling scenario re-pinned to the byte-budget semantics (the poison never joins a batch; it parks the group on its own dispatch).
- `redis-fold-cache.feature` / `fold-read-back-store.feature`: the cache-loss over-count scenario is scoped to cache-only folds and the read-back redelivery scenario names its durable-watermark precondition, so the corpus answers "cache lost, batch redelivered" one way per fold class.

## Tests

- **Unit (all green locally):** `foldProjectionExecutor.durableDedup` (5), `redisCachedFoldStore` (16), `codingAgentSession.store` (6), `commandDispatcher` (20), `queueManager.commandGroupKey` (+ wiring/visibility), `cachedLuaScript` (4), plus adjacent regression suites (`foldProjectionExecutor`, `refoldOnMiss`, `foldRedeliveryTelemetry`, `queueManager`, `groupQueue.retries`) — all passing.
- **Integration (all green locally):** ClickHouse round-trip of `AppliedEventIds` incl. a genuine pre-migration row (7); Lua byte-bound + oversized-alone + mixed-`__jobName` restage (Redis, 20); automations pipeline coalescing opt-in + the real `recordTriggerMatch` handler through a coalescing redis-backed queue (7); fold redelivery idempotency incl. the end-to-end durable-watermark no-double-count scenario (18); poison guard (13 — its oversized-sibling scenario re-pinned to the byte-budget semantics: the poison never joins a batch, the healthy work completes, the group parks on the poison's own dispatch).

## Deployment Impact

- **Env vars:** none added, removed, or changed.
- **Helm values / chart:** no changes; nothing new to configure.
- **Default helm install:** unaffected — **migration 00054** is an additive `ADD COLUMN IF NOT EXISTS` on `coding_agent_sessions`, applied by the standard migration path (forward-migrate-then-deploy like 00053, no backfill). Old writers omitting the column read back as an empty watermark (covered by an integration test).
- **BYOC dataplane:** same additive migration through the same mechanism; no dataplane config or gateway impact.
- Behavioural: coalescing changes only *batching* of `recordTriggerMatch` appends (idempotency keys unchanged); the watermark only *adds* dedup coverage on the retry path.

## Follow-ups (unchanged from ADR sequencing)

- Audit the remaining serialized command producers (the four in evaluation-processing now log at registration) and coalesce the high-fan-in ones.
- Analytics folds' read-back adoption + platform-store extraction (pillar 1 completion) — tracked in ADR-066, not this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable per-session applied-event id tracking to preserve idempotency after cache loss.
  * Enabled byte-capped coalescing for command and group processing (defaulting when unset), including trigger-match batching.
  * Added batch command processing with shared validation and single-call multi-event persistence.
* **Bug Fixes**
  * Improved redelivery dedup by persisting and merging applied-id sets across retry attempts.
  * Prevented incorrect cross-command coalescing in mixed-command groups; foreign siblings are isolated and restaged.
* **Documentation**
  * Updated ADR/specs and migration notes for end-to-end coalescing and durable dedup.
* **Tests**
  * Expanded unit/integration coverage for watermark reads/writes, coalescing byte budgets, and mixed-command isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
