### PR TITLE
feat(profile): let users upload a custom avatar photo (#6086)

### DIFF
--- a/langwatch/specs/settings/user-avatar.feature
+++ b/langwatch/specs/settings/user-avatar.feature
@@ -1,0 +1,111 @@
+Feature: Uploading a custom avatar photo
+  As a LangWatch user
+  I want to upload my own profile photo
+  So that my identity is recognizable everywhere the app shows a person — traces,
+  prompts, member lists, annotations — instead of a generic icon or a photo my SSO
+  provider happened to return
+
+  # ---------------------------------------------------------------------------
+  # Today a user's photo lives in the single `User.image` column and is written
+  # ONLY by the SSO/OAuth providers at first sign-in. Email/password users have
+  # no photo; SSO users are stuck with their identity provider's picture.
+  #
+  # This feature adds a second, user-controlled writer of `User.image`: an upload
+  # that stores the image in the existing S3-backed object storage (falling back
+  # to local disk when S3 is not configured) and serves it back through an
+  # authenticated, same-origin route so any signed-in teammate can see it.
+  #
+  # Because every avatar in the product resolves from that one field through the
+  # same `uploaded/SSO image -> initials -> silhouette` fallback chain, a photo
+  # set here propagates to every surface that renders the field.
+  #
+  # Scope: per-user (account level), not team level.
+  # ---------------------------------------------------------------------------
+
+  # --- Setting and removing the photo -----------------------------------------
+
+  @integration
+  Scenario: Uploading a photo stores it and sets it as the user's avatar
+    Given a signed-in user with no custom avatar
+    When they upload a valid image from their profile settings
+    Then the image is stored in object storage owned by that user
+    And the user's avatar now resolves to the uploaded photo
+
+  @integration
+  Scenario: The profile settings show a live preview before saving
+    Given a signed-in user on their profile settings
+    When they choose an image file
+    Then a preview of the cropped photo is shown before it is saved
+
+  @integration
+  Scenario: Removing the photo reverts to the fallback avatar
+    Given a signed-in user who has uploaded a custom avatar
+    When they remove their photo from profile settings
+    Then the user's avatar no longer resolves to an uploaded photo
+    And the avatar falls back to their initials
+
+  # --- Constraints ------------------------------------------------------------
+
+  @integration
+  Scenario: An oversized image is rejected
+    Given a signed-in user on their profile settings
+    When they upload an image larger than the maximum allowed size
+    Then the upload is rejected with a clear error
+    And the user's avatar is unchanged
+
+  @integration
+  Scenario: A non-image file is rejected
+    Given a signed-in user on their profile settings
+    When they upload a file that is not an allowed image type
+    Then the upload is rejected with a clear error
+    And the user's avatar is unchanged
+
+  # --- Precedence vs SSO ------------------------------------------------------
+
+  @integration
+  Scenario: An uploaded photo wins over the SSO provider photo
+    Given a user whose avatar came from their SSO provider
+    When they upload their own photo
+    Then their avatar resolves to the uploaded photo, not the SSO photo
+
+  @integration
+  Scenario: Signing in again through SSO does not overwrite an uploaded photo
+    Given a user who has uploaded their own photo
+    When they sign in again through their SSO provider
+    Then their uploaded photo is preserved
+
+  # --- Serving and visibility -------------------------------------------------
+
+  @integration
+  Scenario: A signed-in teammate can load another user's uploaded avatar
+    Given a user who has uploaded a custom avatar
+    And a different signed-in teammate in the same organization
+    When the teammate's browser requests that user's avatar image
+    Then the image is served to them
+
+  @integration
+  Scenario: An unauthenticated request cannot load an avatar image
+    Given a user who has uploaded a custom avatar
+    When an unauthenticated request is made for that avatar image
+    Then the request is rejected
+
+  # --- Rendering across the product ------------------------------------------
+
+  @integration
+  Scenario Outline: The uploaded photo renders wherever a person is shown
+    Given a user who has uploaded a custom avatar
+    When their avatar is rendered in the "<surface>"
+    Then the uploaded photo is displayed instead of their initials
+
+    Examples:
+      | surface                        |
+      | header account menu            |
+      | organization members list      |
+      | prompt version history author  |
+      | trace annotation author        |
+
+  @integration
+  Scenario: A user without a photo still shows their initials everywhere
+    Given a user who has not uploaded a photo and has no SSO photo
+    When their avatar is rendered on any surface
+    Then their initials are displayed as the fallback

--- a/langwatch/src/app/api/files/[[...route]]/app.ts
+++ b/langwatch/src/app/api/files/[[...route]]/app.ts
@@ -6,7 +6,11 @@ import { LiteMemberRestrictedError } from "~/server/app-layer/permissions/errors
 import { requireProjectPermission } from "~/server/auth/permissions";
 import { prisma } from "~/server/db";
 import { rateLimit } from "~/server/rateLimit";
-import { isReadbackSafe } from "~/server/stored-objects/safe-media-types";
+import {
+  safeMediaType,
+  sanitizeFilenameSegment,
+  STORED_OBJECT_RESPONSE_BASE_HEADERS as FILES_RESPONSE_BASE_HEADERS,
+} from "~/server/stored-objects/media-response";
 import {
   resolveStoredObjectOwner,
   StoredObjectOwnerLookupUnavailableError,
@@ -25,27 +29,6 @@ const secured = createServiceApp<{ Variables: DualAuthVariables }>({
 });
 
 /**
- * Resolves the Content-Type header for a stored-object response.
- *
- * Returns the requested mediaType when it is in the shared SAFE_MEDIA_TYPES
- * allowlist (see `safe-media-types.ts`). Anything else is coerced to
- * application/octet-stream to neutralize MIME sniffing and stored-XSS
- * primitives (an attacker can't trick a browser into interpreting their
- * payload as text/html or application/javascript).
- *
- * The allowlist is the single source of truth shared with the ingest-path
- * extractor — widen it in safe-media-types.ts and both surfaces update.
- */
-function safeMediaType(mediaType: string): string {
-  return isReadbackSafe(mediaType) ? mediaType : "application/octet-stream";
-}
-
-function sanitizeFilenameSegment(id: string): string {
-  // RFC 6266 — keep ASCII, replace anything else with _; quote with double quotes.
-  return id.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 128);
-}
-
-/**
  * Per-project rate limit on the read endpoint.
  *
  * 120 requests / minute / project covers the realistic in-app render
@@ -55,17 +38,6 @@ function sanitizeFilenameSegment(id: string): string {
  */
 const FILES_RATE_LIMIT_WINDOW_SECONDS = 60;
 const FILES_RATE_LIMIT_MAX = 120;
-
-/**
- * Common headers we attach to every files-route response. Static — never
- * vary by row, never echo user content. See AC9 + AC11 + the
- * security-reviewer pass on PR #4058.
- */
-const FILES_RESPONSE_BASE_HEADERS: Readonly<Record<string, string>> = {
-  "X-Content-Type-Options": "nosniff",
-  "Content-Security-Policy": "default-src 'none'; sandbox",
-  "Referrer-Policy": "no-referrer",
-};
 
 function jsonResponse(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), {

--- a/langwatch/src/app/api/files/[[...route]]/app.ts
+++ b/langwatch/src/app/api/files/[[...route]]/app.ts
@@ -7,6 +7,8 @@ import { requireProjectPermission } from "~/server/auth/permissions";
 import { prisma } from "~/server/db";
 import { rateLimit } from "~/server/rateLimit";
 import {
+  jsonResponse,
+  rateLimitedResponse,
   safeMediaType,
   sanitizeFilenameSegment,
   STORED_OBJECT_RESPONSE_BASE_HEADERS as FILES_RESPONSE_BASE_HEADERS,
@@ -39,15 +41,6 @@ const secured = createServiceApp<{ Variables: DualAuthVariables }>({
 const FILES_RATE_LIMIT_WINDOW_SECONDS = 60;
 const FILES_RATE_LIMIT_MAX = 120;
 
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      "Content-Type": "application/json",
-      ...FILES_RESPONSE_BASE_HEADERS,
-    },
-  });
-}
 
 /**
  * Stored objects are shared by several features, and which permission guards
@@ -266,16 +259,7 @@ async function handleFileRead(
     max: FILES_RATE_LIMIT_MAX,
   });
   if (!rl.allowed) {
-    return new Response(JSON.stringify({ error: "rate_limited" }), {
-      status: 429,
-      headers: {
-        "Content-Type": "application/json",
-        "Retry-After": String(
-          Math.max(1, Math.ceil((rl.resetAt - Date.now()) / 1000)),
-        ),
-        ...FILES_RESPONSE_BASE_HEADERS,
-      },
-    });
+    return rateLimitedResponse(rl.resetAt);
   }
 
   // Step 2: resolve the owning project.

--- a/langwatch/src/app/api/user-avatar/[[...route]]/app.ts
+++ b/langwatch/src/app/api/user-avatar/[[...route]]/app.ts
@@ -3,8 +3,9 @@
  *
  * Unlike /api/files (which gates each read behind the caller's `traces:view` /
  * `scenarios:view` on the owning project), an avatar is platform-level identity
- * that must be visible to any teammate on any surface. So this route authorizes
- * ANY authenticated caller — but for exactly that reason it MUST only ever
+ * that must be visible wherever a person is shown, so this route authorizes ANY
+ * authenticated caller on the platform — not only users who share an
+ * organization with the uploader. For exactly that reason it MUST only ever
  * serve objects tagged with the `user_avatar` purpose. Any other purpose is a
  * 404 here, so this broad-read route can never be used to exfiltrate the
  * trace/scenario media that /api/files protects.
@@ -22,11 +23,14 @@ import { rateLimit } from "~/server/rateLimit";
 import {
   jsonResponse,
   rateLimitedResponse,
-  safeMediaType,
   STORED_OBJECT_RESPONSE_BASE_HEADERS,
 } from "~/server/stored-objects/media-response";
 import { createStoredObjectsService } from "~/server/stored-objects/stored-objects-factory";
-import { AVATAR_OWNER_KIND, AVATAR_PURPOSE } from "~/server/user-avatar/avatar";
+import {
+  AVATAR_OWNER_KIND,
+  AVATAR_PURPOSE,
+  safeAvatarMediaType,
+} from "~/server/user-avatar/avatar";
 import type { DualAuthVariables } from "../../middleware/dual-auth";
 import { dualAuth } from "../../middleware/dual-auth";
 
@@ -50,7 +54,7 @@ function streamAvatarResponse({
   method: "GET" | "HEAD";
 }): Response {
   const headers: Record<string, string> = {
-    "Content-Type": safeMediaType(row.media_type),
+    "Content-Type": safeAvatarMediaType(row.media_type),
     "Content-Length": String(row.size_bytes),
     // Content-addressed id => the bytes at a URL never change, so the browser
     // can cache aggressively. A new upload mints a new id (new URL), and a

--- a/langwatch/src/app/api/user-avatar/[[...route]]/app.ts
+++ b/langwatch/src/app/api/user-avatar/[[...route]]/app.ts
@@ -1,0 +1,154 @@
+/**
+ * /api/user-avatar/:projectId/:id — serves a user's uploaded avatar bytes.
+ *
+ * Unlike /api/files (which gates each read behind the caller's `traces:view` /
+ * `scenarios:view` on the owning project), an avatar is platform-level identity
+ * that must be visible to any teammate on any surface. So this route authorizes
+ * ANY authenticated caller — but for exactly that reason it MUST only ever
+ * serve objects tagged with the `user_avatar` purpose. Any other purpose is a
+ * 404 here, so this broad-read route can never be used to exfiltrate the
+ * trace/scenario media that /api/files protects.
+ *
+ * (This is still strictly more private than the status quo: SSO provider photos
+ * are fetched from fully public CDN URLs today.)
+ *
+ * Spec: specs/settings/user-avatar.feature
+ */
+import { Readable } from "node:stream";
+import type { MiddlewareHandler } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { anyAuthenticated, createServiceApp } from "~/server/api/security";
+import { rateLimit } from "~/server/rateLimit";
+import {
+  safeMediaType,
+  STORED_OBJECT_RESPONSE_BASE_HEADERS,
+} from "~/server/stored-objects/media-response";
+import { createStoredObjectsService } from "~/server/stored-objects/stored-objects-factory";
+import { AVATAR_OWNER_KIND, AVATAR_PURPOSE } from "~/server/user-avatar/avatar";
+import type { DualAuthVariables } from "../../middleware/dual-auth";
+import { dualAuth } from "../../middleware/dual-auth";
+
+const secured = createServiceApp<{ Variables: DualAuthVariables }>({
+  basePath: "/api/user-avatar",
+  verifySecret: dualAuth,
+});
+
+// Avatars render in dense stacks (member lists, presence bars), so the budget
+// is looser than /api/files; still caps enumeration abuse from one credential.
+const AVATAR_RATE_LIMIT_WINDOW_SECONDS = 60;
+const AVATAR_RATE_LIMIT_MAX = 240;
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...STORED_OBJECT_RESPONSE_BASE_HEADERS,
+    },
+  });
+}
+
+function streamAvatarResponse({
+  row,
+  stream,
+  method,
+}: {
+  row: { size_bytes: number; media_type: string };
+  stream: Readable;
+  method: "GET" | "HEAD";
+}): Response {
+  const headers: Record<string, string> = {
+    "Content-Type": safeMediaType(row.media_type),
+    "Content-Length": String(row.size_bytes),
+    // Content-addressed id => the bytes at a URL never change, so the browser
+    // can cache aggressively. A new upload mints a new id (new URL), and a
+    // removal drops the reference entirely, so a cached entry is never stale.
+    "Cache-Control": "private, max-age=86400",
+    ...STORED_OBJECT_RESPONSE_BASE_HEADERS,
+  };
+
+  if (method === "HEAD") {
+    stream.destroy?.();
+    return new Response(null, { status: 200, headers });
+  }
+  return new Response(Readable.toWeb(stream) as ReadableStream, {
+    status: 200,
+    headers,
+  });
+}
+
+async function handleAvatarRead(
+  c: Parameters<MiddlewareHandler<{ Variables: DualAuthVariables }>>[0],
+  options: { method: "GET" | "HEAD" },
+): Promise<Response> {
+  const projectId = c.req.param("projectId");
+  const id = c.req.param("id");
+  if (!projectId || !id) {
+    return jsonResponse({ status: "not_found" }, 404);
+  }
+
+  // Per-caller rate limit, keyed on the authenticated identity (dualAuth
+  // guarantees one is present) so id-enumeration is throttled before any read.
+  const callerKey = c.get("apiKeyProjectId") ?? c.get("userId");
+  if (!callerKey) {
+    throw new HTTPException(500, { message: "rate-limit key unresolved" });
+  }
+  const rl = await rateLimit({
+    key: `user-avatar:caller:${callerKey}`,
+    windowSeconds: AVATAR_RATE_LIMIT_WINDOW_SECONDS,
+    max: AVATAR_RATE_LIMIT_MAX,
+  });
+  if (!rl.allowed) {
+    return new Response(JSON.stringify({ error: "rate_limited" }), {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        "Retry-After": String(
+          Math.max(1, Math.ceil((rl.resetAt - Date.now()) / 1000)),
+        ),
+        ...STORED_OBJECT_RESPONSE_BASE_HEADERS,
+      },
+    });
+  }
+
+  let result;
+  try {
+    result = await createStoredObjectsService({ projectId }).getById({
+      projectId,
+      id,
+    });
+  } catch {
+    return jsonResponse({ error: "avatar temporarily unavailable" }, 502);
+  }
+
+  // A missing row, or ANY object that is not a user avatar, is a 404 — the
+  // purpose/owner check is the security boundary that keeps this broadly
+  // readable route from serving trace/scenario media (see file header).
+  if (
+    !result ||
+    result.row.purpose !== AVATAR_PURPOSE ||
+    result.row.owner_kind !== AVATAR_OWNER_KIND
+  ) {
+    return jsonResponse({ status: "not_found" }, 404);
+  }
+
+  if (!("stream" in result)) {
+    return jsonResponse({ status: "missing" }, 404);
+  }
+
+  return streamAvatarResponse({
+    row: result.row,
+    stream: result.stream,
+    method: options.method,
+  });
+}
+
+secured
+  .access(anyAuthenticated())
+  .get("/:projectId/:id", (c) => handleAvatarRead(c, { method: "GET" }));
+secured
+  .access(anyAuthenticated())
+  .head("/:projectId/:id", (c) => handleAvatarRead(c, { method: "HEAD" }));
+
+export const app = secured.hono;
+export type UserAvatarAppType = typeof app;

--- a/langwatch/src/app/api/user-avatar/[[...route]]/app.ts
+++ b/langwatch/src/app/api/user-avatar/[[...route]]/app.ts
@@ -20,6 +20,8 @@ import { HTTPException } from "hono/http-exception";
 import { anyAuthenticated, createServiceApp } from "~/server/api/security";
 import { rateLimit } from "~/server/rateLimit";
 import {
+  jsonResponse,
+  rateLimitedResponse,
   safeMediaType,
   STORED_OBJECT_RESPONSE_BASE_HEADERS,
 } from "~/server/stored-objects/media-response";
@@ -37,16 +39,6 @@ const secured = createServiceApp<{ Variables: DualAuthVariables }>({
 // is looser than /api/files; still caps enumeration abuse from one credential.
 const AVATAR_RATE_LIMIT_WINDOW_SECONDS = 60;
 const AVATAR_RATE_LIMIT_MAX = 240;
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      "Content-Type": "application/json",
-      ...STORED_OBJECT_RESPONSE_BASE_HEADERS,
-    },
-  });
-}
 
 function streamAvatarResponse({
   row,
@@ -99,16 +91,7 @@ async function handleAvatarRead(
     max: AVATAR_RATE_LIMIT_MAX,
   });
   if (!rl.allowed) {
-    return new Response(JSON.stringify({ error: "rate_limited" }), {
-      status: 429,
-      headers: {
-        "Content-Type": "application/json",
-        "Retry-After": String(
-          Math.max(1, Math.ceil((rl.resetAt - Date.now()) / 1000)),
-        ),
-        ...STORED_OBJECT_RESPONSE_BASE_HEADERS,
-      },
-    });
+    return rateLimitedResponse(rl.resetAt);
   }
 
   let result;

--- a/langwatch/src/components/AnnotationExpectedOutputs.tsx
+++ b/langwatch/src/components/AnnotationExpectedOutputs.tsx
@@ -1,5 +1,6 @@
-import { Avatar, HStack, Text, Textarea, VStack } from "@chakra-ui/react";
+import { Box, HStack, Text, Textarea, VStack } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
+import { UserAvatar } from "~/components/UserAvatar";
 import { Tooltip } from "~/components/ui/tooltip";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
@@ -70,11 +71,15 @@ export const AnnotationExpectedOutputs = ({
                       });
                     }}
                   >
-                    <Avatar.Root size="xs">
-                      <Tooltip content={annotation.user?.name ?? ""}>
-                        <Avatar.Fallback name={annotation.user?.name ?? ""} />
-                      </Tooltip>
-                    </Avatar.Root>
+                    <Tooltip content={annotation.user?.name ?? ""}>
+                      <Box display="inline-flex">
+                        <UserAvatar
+                          size="xs"
+                          name={annotation.user?.name ?? ""}
+                          image={annotation.user?.image}
+                        />
+                      </Box>
+                    </Tooltip>
 
                     {commentState.expectedOutputAction === "edit" &&
                     annotationId === annotation.id ? (

--- a/langwatch/src/components/Annotations.tsx
+++ b/langwatch/src/components/Annotations.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Box,
   Card,
   HStack,
@@ -8,6 +7,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { UserAvatar } from "~/components/UserAvatar";
 import { Edit, MessageCircle, ThumbsDown, ThumbsUp } from "react-feather";
 import { Tooltip } from "~/components/ui/tooltip";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -93,11 +93,13 @@ export const Annotations = ({
             <Card.Body>
               <VStack align="start" gap={3}>
                 <HStack width="full" align={"top"}>
-                  <Avatar.Root size="sm" background="gray.solid" color="white">
-                    <Avatar.Fallback
-                      name={annotation.user?.name ?? undefined}
-                    />
-                  </Avatar.Root>
+                  <UserAvatar
+                    size="sm"
+                    background="gray.solid"
+                    color="white"
+                    name={annotation.user?.name ?? undefined}
+                    image={annotation.user?.image}
+                  />
                   <VStack align="start" gap={0}>
                     <Text fontWeight="bold" fontSize="sm">
                       {annotation.user?.name ?? (

--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -774,6 +774,13 @@ export const DashboardLayout = ({
                 minWidth="auto"
                 height="auto"
                 borderRadius="full"
+                aria-label={
+                  publicPage
+                    ? "Sign in"
+                    : user?.name
+                      ? `Open user menu for ${user.name}`
+                      : "Open user menu"
+                }
                 {...(publicPage
                   ? {
                       // On a public share page, clicking the avatar offers

--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -1,6 +1,5 @@
 import {
   Alert,
-  Avatar,
   Box,
   Button,
   HStack,
@@ -72,6 +71,7 @@ import { MainMenu, MENU_WIDTH_COMPACT, MENU_WIDTH_EXPANDED } from "./MainMenu";
 import { SavedViewsBar } from "./messages/SavedViewsBar";
 import { PersonalSidebar } from "./PersonalSidebar";
 import { ProjectAvatar } from "./ProjectAvatar";
+import { UserAvatar } from "./UserAvatar";
 import { PresenceMenuItem } from "./sidebar/PresenceMenuItem";
 import { GlobalUpgradeModal } from "./UpgradeModal";
 import { Link } from "./ui/link";
@@ -793,18 +793,15 @@ export const DashboardLayout = ({
                     }
                   : {})}
               >
-                <Avatar.Root
+                <UserAvatar
+                  name={user?.name ?? undefined}
+                  image={user?.image ?? undefined}
                   size="xs"
                   backgroundColor="orange.400"
                   color="white"
                   width="28px"
                   height="28px"
-                >
-                  <Avatar.Fallback
-                    name={user?.name ?? undefined}
-                    fontSize="11px"
-                  />
-                </Avatar.Root>
+                />
               </Button>
             </Menu.Trigger>
             {session && (

--- a/langwatch/src/components/RandomColorAvatar.tsx
+++ b/langwatch/src/components/RandomColorAvatar.tsx
@@ -1,17 +1,24 @@
-import { Avatar, type AvatarRootProps } from "@chakra-ui/react";
+import { type AvatarRootProps } from "@chakra-ui/react";
+import { UserAvatar } from "./UserAvatar";
 import { getColorForString } from "../utils/rotatingColors";
 
+/**
+ * Person avatar with a deterministic name-hashed background behind the initials
+ * fallback. Delegates the image/initials/silhouette fallback chain to
+ * {@link UserAvatar}; pass `image` to show an uploaded/SSO photo when available.
+ */
 export function RandomColorAvatar({
   name,
+  image,
   ...props
-}: AvatarRootProps & { name: string }) {
+}: AvatarRootProps & { name: string; image?: string | null }) {
   return (
-    <Avatar.Root
+    <UserAvatar
+      name={name}
+      image={image}
       color="white"
       background={getColorForString("colors", name).color}
       {...props}
-    >
-      <Avatar.Fallback name={name} />
-    </Avatar.Root>
+    />
   );
 }

--- a/langwatch/src/components/UserAvatar.tsx
+++ b/langwatch/src/components/UserAvatar.tsx
@@ -1,0 +1,39 @@
+import { Avatar, type AvatarRootProps } from "@chakra-ui/react";
+import { useState } from "react";
+
+/**
+ * Canonical person avatar: renders the uploaded/SSO `image` when present and
+ * falls back to the initials of `name`, then a silhouette when neither is set —
+ * the single fallback chain every person-avatar surface shares.
+ *
+ * The `onError` guard tracks the *broken URL* (not a bare boolean) so that when
+ * `image` changes to a new URL — the user uploads a new photo mid-session, or
+ * the component is reused across people — a previously-broken image doesn't
+ * stay latched to the fallback. Mirrors `PresenceAvatar`, which predates this
+ * component and keeps its own copy for its presence-specific styling.
+ *
+ * Spec: specs/settings/user-avatar.feature
+ */
+export function UserAvatar({
+  name,
+  image,
+  ...rootProps
+}: Omit<AvatarRootProps, "children"> & {
+  name?: string | null;
+  image?: string | null;
+}) {
+  const [brokenImageUrl, setBrokenImageUrl] = useState<string | null>(null);
+  const showImage = !!image && image !== brokenImageUrl;
+
+  return (
+    <Avatar.Root {...rootProps}>
+      {showImage ? (
+        <Avatar.Image
+          src={image!}
+          onError={() => setBrokenImageUrl(image!)}
+        />
+      ) : null}
+      <Avatar.Fallback name={name ?? undefined} />
+    </Avatar.Root>
+  );
+}

--- a/langwatch/src/components/annotations/AnnotationComment.tsx
+++ b/langwatch/src/components/annotations/AnnotationComment.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Box,
   Button,
   Card,
@@ -29,6 +28,7 @@ import { useAnnotationCommentStore } from "~/hooks/useAnnotationCommentStore";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
 import { RandomColorAvatar } from "../RandomColorAvatar";
+import { UserAvatar } from "../UserAvatar";
 import { ScoreReasonModal } from "../ScoreReasonModal";
 import { Checkbox, CheckboxGroup } from "../ui/checkbox";
 import { Menu } from "../ui/menu";
@@ -254,6 +254,7 @@ export function AnnotationComment({ key = "" }: { key: string }) {
                   <RandomColorAvatar
                     size="sm"
                     name={session.data?.user.name ?? ""}
+                    image={session.data?.user.image}
                   />
                 </Skeleton>
                 <Skeleton height="20px" width="120px" />
@@ -274,9 +275,11 @@ export function AnnotationComment({ key = "" }: { key: string }) {
             <form onSubmit={handleSubmit(onSubmit)}>
               <VStack align="start" gap={3}>
                 <HStack width="full">
-                  <Avatar.Root size="sm">
-                    <Avatar.Fallback name={session.data?.user.name ?? ""} />
-                  </Avatar.Root>
+                  <UserAvatar
+                    size="sm"
+                    name={session.data?.user.name ?? ""}
+                    image={session.data?.user.image}
+                  />
                   <Text>{session.data?.user.name}</Text>
                   <Spacer />
 

--- a/langwatch/src/components/annotations/AnnotationsTable.tsx
+++ b/langwatch/src/components/annotations/AnnotationsTable.tsx
@@ -56,6 +56,7 @@ export type AnnotationWithUser = Annotation & {
   user?: {
     name: string | null;
     id: string;
+    image?: string | null;
   };
 };
 
@@ -69,7 +70,7 @@ type GroupedAnnotation = {
 export type UnifiedQueueItem = {
   id: string;
   doneAt: Date | null;
-  createdByUser: { name: string | null; id: string } | null;
+  createdByUser: { name: string | null; id: string; image?: string | null } | null;
   createdAt: Date;
   traceId: string;
   trace?: Trace;
@@ -125,6 +126,7 @@ export const AnnotationsTable = ({
         ? {
             name: item.createdByUser.name,
             id: item.createdByUser.id,
+            image: item.createdByUser.image ?? null,
           }
         : null,
       createdAt: item.createdAt ? new Date(item.createdAt) : new Date(),

--- a/langwatch/src/components/annotations/AvatarGroup.tsx
+++ b/langwatch/src/components/annotations/AvatarGroup.tsx
@@ -5,6 +5,7 @@ import type { AnnotationWithUser } from "./AnnotationsTable";
 type User = {
   id: string;
   name: string | null;
+  image?: string | null;
 };
 
 const UserAvatarGroup = ({
@@ -33,6 +34,7 @@ const UserAvatarGroup = ({
           key={user.id}
           size="2xs"
           name={user.name ?? ""}
+          image={user.image}
           css={{
             border: "2px solid white",
             "&:not(:first-of-type)": {

--- a/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
+++ b/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
@@ -1,13 +1,17 @@
-import { Box, Button, HStack, Text, VStack } from "@chakra-ui/react";
-import { Pencil } from "lucide-react";
+import { Box, Button, Center, HStack } from "@chakra-ui/react";
+import { Info, Pencil } from "lucide-react";
 import { useRef, useState } from "react";
 import { UserAvatar } from "~/components/UserAvatar";
+import { Dialog } from "~/components/ui/dialog";
 import { toaster } from "~/components/ui/toaster";
+import { Tooltip } from "~/components/ui/tooltip";
 import { useSession } from "~/utils/auth-client";
 import { api } from "~/utils/api";
 import { AvatarImageError, processAvatarImage } from "./processAvatarImage";
 
-/** The photo itself as the edit control — a pencil badge overlays it. */
+const FORMAT_HINT = "PNG, JPG, WEBP or GIF, up to 8 MB. Cropped to a square.";
+
+/** The photo as the edit control — a pencil badge overlays it; click opens the dialog. */
 function AvatarEditButton({
   name,
   image,
@@ -67,61 +71,100 @@ function AvatarEditButton({
   );
 }
 
-/** Save/Cancel while previewing a pick, or Remove when a photo is already set. */
-function AvatarActions({
-  hasPreview,
+/** LinkedIn-style "Profile photo" dialog — view the photo large, then change it. */
+function AvatarPhotoDialog({
+  isOpen,
+  onOpenChange,
+  name,
+  image,
   hasImage,
+  hasPreview,
   isBusy,
   isSaving,
   isRemoving,
+  onChange,
+  onRemove,
   onSave,
   onCancel,
-  onRemove,
 }: {
-  hasPreview: boolean;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  name: string | null;
+  image: string | null;
   hasImage: boolean;
+  hasPreview: boolean;
   isBusy: boolean;
   isSaving: boolean;
   isRemoving: boolean;
+  onChange: () => void;
+  onRemove: () => void;
   onSave: () => void;
   onCancel: () => void;
-  onRemove: () => void;
 }) {
-  if (hasPreview) {
-    return (
-      <HStack gap={2}>
-        <Button size="sm" onClick={onSave} loading={isSaving} disabled={isBusy}>
-          Save photo
-        </Button>
-        <Button size="sm" variant="ghost" onClick={onCancel} disabled={isBusy}>
-          Cancel
-        </Button>
-      </HStack>
-    );
-  }
-  if (hasImage) {
-    return (
-      <Button
-        size="sm"
-        variant="ghost"
-        colorPalette="red"
-        onClick={onRemove}
-        loading={isRemoving}
-        disabled={isBusy}
-      >
-        Remove
-      </Button>
-    );
-  }
-  return null;
+  return (
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(e) => onOpenChange(e.open)}
+      size="sm"
+    >
+      <Dialog.Content bg="bg">
+        <Dialog.Header>
+          <Dialog.Title>Profile photo</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.CloseTrigger />
+        <Dialog.Body>
+          <Center py={2}>
+            <UserAvatar
+              name={name}
+              image={image}
+              width="180px"
+              height="180px"
+              borderWidth="1px"
+              borderColor="border.muted"
+            />
+          </Center>
+        </Dialog.Body>
+        <Dialog.Footer>
+          {hasPreview ? (
+            <HStack gap={2}>
+              <Button variant="ghost" onClick={onCancel} disabled={isBusy}>
+                Cancel
+              </Button>
+              <Button onClick={onSave} loading={isSaving} disabled={isBusy}>
+                Save photo
+              </Button>
+            </HStack>
+          ) : (
+            <HStack gap={2}>
+              {hasImage && (
+                <Button
+                  variant="ghost"
+                  colorPalette="red"
+                  onClick={onRemove}
+                  loading={isRemoving}
+                  disabled={isBusy}
+                >
+                  Remove
+                </Button>
+              )}
+              <Button onClick={onChange} disabled={isBusy}>
+                {hasImage ? "Change photo" : "Upload photo"}
+              </Button>
+            </HStack>
+          )}
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
 }
 
 /**
- * Profile-settings control to upload, preview, and remove the user's own avatar
- * photo. The avatar itself is the edit affordance (a pencil badge sits on it);
- * clicking it opens the file picker. The photo flows to every avatar surface
- * via `User.image`. `organizationId` scopes the personal-workspace the photo is
- * stored under.
+ * Profile-settings control for the user's avatar. Clicking the photo opens a
+ * dialog where the current photo is shown large (view) and can be replaced
+ * (change) — the format/size constraints live in the adjacent info tooltip.
+ * The photo flows to every avatar surface via `User.image`.
+ *
+ * `organizationId` scopes the personal-workspace the photo is stored under.
  *
  * Spec: specs/settings/user-avatar.feature
  */
@@ -132,6 +175,7 @@ export function AvatarUploadControl({
 }) {
   const session = useSession();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
   const [preview, setPreview] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
 
@@ -142,6 +186,7 @@ export function AvatarUploadControl({
     onSuccess: async () => {
       await session.update();
       setPreview(null);
+      setIsOpen(false);
       toaster.create({ title: "Photo updated", type: "success" });
     },
     onError: (err) =>
@@ -166,7 +211,8 @@ export function AvatarUploadControl({
       }),
   });
 
-  const isBusy = isProcessing || setAvatar.isPending || removeAvatar.isPending;
+  const isBusy =
+    isProcessing || setAvatar.isPending || removeAvatar.isPending;
 
   const onFilePicked = async (file: File | undefined) => {
     // Allow re-selecting the same file later by clearing the input value.
@@ -190,14 +236,25 @@ export function AvatarUploadControl({
   };
 
   return (
-    <HStack gap={4} align="center">
-      <AvatarEditButton
-        name={name}
-        image={preview ?? currentImage}
-        label={currentImage ? "Change photo" : "Upload photo"}
-        isDisabled={isBusy}
-        onOpen={() => fileInputRef.current?.click()}
-      />
+    <>
+      <HStack gap={2.5} align="center">
+        <AvatarEditButton
+          name={name}
+          image={currentImage}
+          label={currentImage ? "Edit profile photo" : "Add profile photo"}
+          isDisabled={isBusy}
+          onOpen={() => setIsOpen(true)}
+        />
+        <Tooltip content={FORMAT_HINT} positioning={{ placement: "right" }}>
+          <Box
+            display="inline-flex"
+            color="fg.muted"
+            aria-label={FORMAT_HINT}
+          >
+            <Info size={16} />
+          </Box>
+        </Tooltip>
+      </HStack>
 
       <input
         ref={fileInputRef}
@@ -207,23 +264,27 @@ export function AvatarUploadControl({
         onChange={(e) => void onFilePicked(e.target.files?.[0])}
       />
 
-      <VStack align="start" gap={2}>
-        <AvatarActions
-          hasPreview={!!preview}
-          hasImage={!!currentImage}
-          isBusy={isBusy}
-          isSaving={setAvatar.isPending}
-          isRemoving={removeAvatar.isPending}
-          onSave={() => {
-            if (preview) setAvatar.mutate({ organizationId, imageDataUrl: preview });
-          }}
-          onCancel={() => setPreview(null)}
-          onRemove={() => removeAvatar.mutate({})}
-        />
-        <Text fontSize="xs" color="fg.muted">
-          PNG, JPG, WEBP or GIF, up to 8 MB. Cropped to a square.
-        </Text>
-      </VStack>
-    </HStack>
+      <AvatarPhotoDialog
+        isOpen={isOpen}
+        onOpenChange={(open) => {
+          if (isBusy) return;
+          setIsOpen(open);
+          if (!open) setPreview(null);
+        }}
+        name={name}
+        image={preview ?? currentImage}
+        hasImage={!!currentImage}
+        hasPreview={!!preview}
+        isBusy={isBusy}
+        isSaving={setAvatar.isPending}
+        isRemoving={removeAvatar.isPending}
+        onChange={() => fileInputRef.current?.click()}
+        onRemove={() => removeAvatar.mutate({})}
+        onSave={() => {
+          if (preview) setAvatar.mutate({ organizationId, imageDataUrl: preview });
+        }}
+        onCancel={() => setPreview(null)}
+      />
+    </>
   );
 }

--- a/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
+++ b/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
@@ -50,8 +50,8 @@ function AvatarEditButton({
         position="absolute"
         bottom="0"
         right="0"
-        width="24px"
-        height="24px"
+        width="18px"
+        height="18px"
         bg="blue.500"
         color="white"
         borderRadius="full"
@@ -61,7 +61,7 @@ function AvatarEditButton({
         alignItems="center"
         justifyContent="center"
       >
-        <Pencil size={12} />
+        <Pencil size={9} />
       </Box>
     </Box>
   );

--- a/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
+++ b/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
@@ -220,7 +220,7 @@ export function AvatarUploadControl({
           onRemove={() => removeAvatar.mutate({})}
         />
         <Text fontSize="xs" color="fg.muted">
-          PNG, JPG, WEBP or GIF, up to 1 MB. Cropped to a square.
+          PNG, JPG, WEBP or GIF, up to 8 MB. Cropped to a square.
         </Text>
       </VStack>
     </HStack>

--- a/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
+++ b/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
@@ -27,6 +27,7 @@ function AvatarEditButton({
       role="button"
       tabIndex={isDisabled ? -1 : 0}
       aria-label={label}
+      aria-disabled={isDisabled}
       cursor={isDisabled ? "default" : "pointer"}
       transition="opacity 0.15s"
       _hover={isDisabled ? undefined : { opacity: 0.85 }}

--- a/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
+++ b/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
@@ -56,7 +56,7 @@ function AvatarEditButton({
         right="0"
         width="18px"
         height="18px"
-        bg="blue.500"
+        bg="orange.500"
         color="white"
         borderRadius="full"
         borderWidth="2px"
@@ -130,7 +130,12 @@ function AvatarPhotoDialog({
               <Button variant="ghost" onClick={onCancel} disabled={isBusy}>
                 Cancel
               </Button>
-              <Button onClick={onSave} loading={isSaving} disabled={isBusy}>
+              <Button
+                colorPalette="orange"
+                onClick={onSave}
+                loading={isSaving}
+                disabled={isBusy}
+              >
                 Save photo
               </Button>
             </HStack>
@@ -147,7 +152,11 @@ function AvatarPhotoDialog({
                   Remove
                 </Button>
               )}
-              <Button onClick={onChange} disabled={isBusy}>
+              <Button
+                colorPalette="orange"
+                onClick={onChange}
+                disabled={isBusy}
+              >
                 {hasImage ? "Change photo" : "Upload photo"}
               </Button>
             </HStack>

--- a/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
+++ b/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, HStack, Text, VStack } from "@chakra-ui/react";
+import { Pencil } from "lucide-react";
 import { useRef, useState } from "react";
 import { UserAvatar } from "~/components/UserAvatar";
 import { toaster } from "~/components/ui/toaster";
@@ -8,7 +9,9 @@ import { AvatarImageError, processAvatarImage } from "./processAvatarImage";
 
 /**
  * Profile-settings control to upload, preview, and remove the user's own avatar
- * photo. The photo flows to every avatar surface via `User.image`.
+ * photo. The avatar itself is the edit affordance — a pencil badge sits on the
+ * photo and clicking it opens the file picker. The photo flows to every avatar
+ * surface via `User.image`.
  *
  * `organizationId` scopes the personal-workspace the photo is stored under.
  *
@@ -78,25 +81,64 @@ export function AvatarUploadControl({
     }
   };
 
+  const openPicker = () => {
+    if (!busy) fileInputRef.current?.click();
+  };
+
   return (
     <HStack gap={4} align="center">
-      <UserAvatar
-        name={name}
-        image={preview ?? currentImage}
-        size="xl"
-        borderWidth="1px"
-        borderColor="border.muted"
+      {/* The photo IS the edit control — a pencil badge overlays it. */}
+      <Box
+        position="relative"
+        role="button"
+        tabIndex={busy ? -1 : 0}
+        aria-label={currentImage ? "Change photo" : "Upload photo"}
+        cursor={busy ? "default" : "pointer"}
+        transition="opacity 0.15s"
+        _hover={busy ? undefined : { opacity: 0.85 }}
+        onClick={openPicker}
+        onKeyDown={(e) => {
+          if (!busy && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault();
+            openPicker();
+          }
+        }}
+      >
+        <UserAvatar
+          name={name}
+          image={preview ?? currentImage}
+          size="xl"
+          borderWidth="1px"
+          borderColor="border.muted"
+        />
+        <Box
+          position="absolute"
+          bottom="0"
+          right="0"
+          width="24px"
+          height="24px"
+          bg="blue.500"
+          color="white"
+          borderRadius="full"
+          borderWidth="2px"
+          borderColor="bg.surface"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Pencil size={12} />
+        </Box>
+      </Box>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/webp,image/gif"
+        style={{ display: "none" }}
+        onChange={(e) => void onFilePicked(e.target.files?.[0])}
       />
 
       <VStack align="start" gap={2}>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/png,image/jpeg,image/webp,image/gif"
-          style={{ display: "none" }}
-          onChange={(e) => void onFilePicked(e.target.files?.[0])}
-        />
-
         {preview ? (
           <HStack gap={2}>
             <Button
@@ -119,36 +161,23 @@ export function AvatarUploadControl({
             </Button>
           </HStack>
         ) : (
-          <HStack gap={2}>
+          currentImage && (
             <Button
               size="sm"
-              variant="outline"
-              onClick={() => fileInputRef.current?.click()}
-              loading={processing}
+              variant="ghost"
+              colorPalette="red"
+              onClick={() => removeAvatar.mutate({})}
+              loading={removeAvatar.isPending}
               disabled={busy}
             >
-              {currentImage ? "Change photo" : "Upload photo"}
+              Remove
             </Button>
-            {currentImage && (
-              <Button
-                size="sm"
-                variant="ghost"
-                colorPalette="red"
-                onClick={() => removeAvatar.mutate({})}
-                loading={removeAvatar.isPending}
-                disabled={busy}
-              >
-                Remove
-              </Button>
-            )}
-          </HStack>
+          )
         )}
 
-        <Box>
-          <Text fontSize="xs" color="fg.muted">
-            PNG, JPG, WEBP or GIF. Cropped to a square.
-          </Text>
-        </Box>
+        <Text fontSize="xs" color="fg.muted">
+          PNG, JPG, WEBP or GIF, up to 1 MB. Cropped to a square.
+        </Text>
       </VStack>
     </HStack>
   );

--- a/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
+++ b/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
@@ -1,0 +1,155 @@
+import { Box, Button, HStack, Text, VStack } from "@chakra-ui/react";
+import { useRef, useState } from "react";
+import { UserAvatar } from "~/components/UserAvatar";
+import { toaster } from "~/components/ui/toaster";
+import { useSession } from "~/utils/auth-client";
+import { api } from "~/utils/api";
+import { AvatarImageError, processAvatarImage } from "./processAvatarImage";
+
+/**
+ * Profile-settings control to upload, preview, and remove the user's own avatar
+ * photo. The photo flows to every avatar surface via `User.image`.
+ *
+ * `organizationId` scopes the personal-workspace the photo is stored under.
+ *
+ * Spec: specs/settings/user-avatar.feature
+ */
+export function AvatarUploadControl({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const session = useSession();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+
+  const currentImage = session.data?.user.image ?? null;
+  const name = session.data?.user.name ?? session.data?.user.email ?? null;
+
+  const setAvatar = api.user.setAvatar.useMutation({
+    onSuccess: async () => {
+      await session.update();
+      setPreview(null);
+      toaster.create({ title: "Photo updated", type: "success" });
+    },
+    onError: (err) => {
+      toaster.create({
+        title: "Couldn't update photo",
+        description: err.message,
+        type: "error",
+      });
+    },
+  });
+
+  const removeAvatar = api.user.removeAvatar.useMutation({
+    onSuccess: async () => {
+      await session.update();
+      setPreview(null);
+      toaster.create({ title: "Photo removed", type: "success" });
+    },
+    onError: (err) => {
+      toaster.create({
+        title: "Couldn't remove photo",
+        description: err.message,
+        type: "error",
+      });
+    },
+  });
+
+  const busy = processing || setAvatar.isPending || removeAvatar.isPending;
+
+  const onFilePicked = async (file: File | undefined) => {
+    // Allow re-selecting the same file later by clearing the input value.
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (!file) return;
+    setProcessing(true);
+    try {
+      setPreview(await processAvatarImage(file));
+    } catch (err) {
+      toaster.create({
+        title: "Couldn't read that image",
+        description:
+          err instanceof AvatarImageError ? err.message : "Please try another file.",
+        type: "error",
+      });
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <HStack gap={4} align="center">
+      <UserAvatar
+        name={name}
+        image={preview ?? currentImage}
+        size="xl"
+        borderWidth="1px"
+        borderColor="border.muted"
+      />
+
+      <VStack align="start" gap={2}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/png,image/jpeg,image/webp,image/gif"
+          style={{ display: "none" }}
+          onChange={(e) => void onFilePicked(e.target.files?.[0])}
+        />
+
+        {preview ? (
+          <HStack gap={2}>
+            <Button
+              size="sm"
+              onClick={() =>
+                setAvatar.mutate({ organizationId, imageDataUrl: preview })
+              }
+              loading={setAvatar.isPending}
+              disabled={busy}
+            >
+              Save photo
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setPreview(null)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+          </HStack>
+        ) : (
+          <HStack gap={2}>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => fileInputRef.current?.click()}
+              loading={processing}
+              disabled={busy}
+            >
+              {currentImage ? "Change photo" : "Upload photo"}
+            </Button>
+            {currentImage && (
+              <Button
+                size="sm"
+                variant="ghost"
+                colorPalette="red"
+                onClick={() => removeAvatar.mutate({})}
+                loading={removeAvatar.isPending}
+                disabled={busy}
+              >
+                Remove
+              </Button>
+            )}
+          </HStack>
+        )}
+
+        <Box>
+          <Text fontSize="xs" color="fg.muted">
+            PNG, JPG, WEBP or GIF. Cropped to a square.
+          </Text>
+        </Box>
+      </VStack>
+    </HStack>
+  );
+}

--- a/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
+++ b/langwatch/src/components/me/avatar/AvatarUploadControl.tsx
@@ -7,13 +7,120 @@ import { useSession } from "~/utils/auth-client";
 import { api } from "~/utils/api";
 import { AvatarImageError, processAvatarImage } from "./processAvatarImage";
 
+/** The photo itself as the edit control — a pencil badge overlays it. */
+function AvatarEditButton({
+  name,
+  image,
+  label,
+  isDisabled,
+  onOpen,
+}: {
+  name: string | null;
+  image: string | null;
+  label: string;
+  isDisabled: boolean;
+  onOpen: () => void;
+}) {
+  return (
+    <Box
+      position="relative"
+      role="button"
+      tabIndex={isDisabled ? -1 : 0}
+      aria-label={label}
+      cursor={isDisabled ? "default" : "pointer"}
+      transition="opacity 0.15s"
+      _hover={isDisabled ? undefined : { opacity: 0.85 }}
+      onClick={isDisabled ? undefined : onOpen}
+      onKeyDown={(e) => {
+        if (!isDisabled && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+    >
+      <UserAvatar
+        name={name}
+        image={image}
+        size="xl"
+        borderWidth="1px"
+        borderColor="border.muted"
+      />
+      <Box
+        position="absolute"
+        bottom="0"
+        right="0"
+        width="24px"
+        height="24px"
+        bg="blue.500"
+        color="white"
+        borderRadius="full"
+        borderWidth="2px"
+        borderColor="bg.surface"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Pencil size={12} />
+      </Box>
+    </Box>
+  );
+}
+
+/** Save/Cancel while previewing a pick, or Remove when a photo is already set. */
+function AvatarActions({
+  hasPreview,
+  hasImage,
+  isBusy,
+  isSaving,
+  isRemoving,
+  onSave,
+  onCancel,
+  onRemove,
+}: {
+  hasPreview: boolean;
+  hasImage: boolean;
+  isBusy: boolean;
+  isSaving: boolean;
+  isRemoving: boolean;
+  onSave: () => void;
+  onCancel: () => void;
+  onRemove: () => void;
+}) {
+  if (hasPreview) {
+    return (
+      <HStack gap={2}>
+        <Button size="sm" onClick={onSave} loading={isSaving} disabled={isBusy}>
+          Save photo
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onCancel} disabled={isBusy}>
+          Cancel
+        </Button>
+      </HStack>
+    );
+  }
+  if (hasImage) {
+    return (
+      <Button
+        size="sm"
+        variant="ghost"
+        colorPalette="red"
+        onClick={onRemove}
+        loading={isRemoving}
+        disabled={isBusy}
+      >
+        Remove
+      </Button>
+    );
+  }
+  return null;
+}
+
 /**
  * Profile-settings control to upload, preview, and remove the user's own avatar
- * photo. The avatar itself is the edit affordance — a pencil badge sits on the
- * photo and clicking it opens the file picker. The photo flows to every avatar
- * surface via `User.image`.
- *
- * `organizationId` scopes the personal-workspace the photo is stored under.
+ * photo. The avatar itself is the edit affordance (a pencil badge sits on it);
+ * clicking it opens the file picker. The photo flows to every avatar surface
+ * via `User.image`. `organizationId` scopes the personal-workspace the photo is
+ * stored under.
  *
  * Spec: specs/settings/user-avatar.feature
  */
@@ -25,7 +132,7 @@ export function AvatarUploadControl({
   const session = useSession();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<string | null>(null);
-  const [processing, setProcessing] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
 
   const currentImage = session.data?.user.image ?? null;
   const name = session.data?.user.name ?? session.data?.user.email ?? null;
@@ -36,13 +143,12 @@ export function AvatarUploadControl({
       setPreview(null);
       toaster.create({ title: "Photo updated", type: "success" });
     },
-    onError: (err) => {
+    onError: (err) =>
       toaster.create({
         title: "Couldn't update photo",
         description: err.message,
         type: "error",
-      });
-    },
+      }),
   });
 
   const removeAvatar = api.user.removeAvatar.useMutation({
@@ -51,84 +157,46 @@ export function AvatarUploadControl({
       setPreview(null);
       toaster.create({ title: "Photo removed", type: "success" });
     },
-    onError: (err) => {
+    onError: (err) =>
       toaster.create({
         title: "Couldn't remove photo",
         description: err.message,
         type: "error",
-      });
-    },
+      }),
   });
 
-  const busy = processing || setAvatar.isPending || removeAvatar.isPending;
+  const isBusy = isProcessing || setAvatar.isPending || removeAvatar.isPending;
 
   const onFilePicked = async (file: File | undefined) => {
     // Allow re-selecting the same file later by clearing the input value.
     if (fileInputRef.current) fileInputRef.current.value = "";
     if (!file) return;
-    setProcessing(true);
+    setIsProcessing(true);
     try {
       setPreview(await processAvatarImage(file));
     } catch (err) {
       toaster.create({
         title: "Couldn't read that image",
         description:
-          err instanceof AvatarImageError ? err.message : "Please try another file.",
+          err instanceof AvatarImageError
+            ? err.message
+            : "Please try another file.",
         type: "error",
       });
     } finally {
-      setProcessing(false);
+      setIsProcessing(false);
     }
-  };
-
-  const openPicker = () => {
-    if (!busy) fileInputRef.current?.click();
   };
 
   return (
     <HStack gap={4} align="center">
-      {/* The photo IS the edit control — a pencil badge overlays it. */}
-      <Box
-        position="relative"
-        role="button"
-        tabIndex={busy ? -1 : 0}
-        aria-label={currentImage ? "Change photo" : "Upload photo"}
-        cursor={busy ? "default" : "pointer"}
-        transition="opacity 0.15s"
-        _hover={busy ? undefined : { opacity: 0.85 }}
-        onClick={openPicker}
-        onKeyDown={(e) => {
-          if (!busy && (e.key === "Enter" || e.key === " ")) {
-            e.preventDefault();
-            openPicker();
-          }
-        }}
-      >
-        <UserAvatar
-          name={name}
-          image={preview ?? currentImage}
-          size="xl"
-          borderWidth="1px"
-          borderColor="border.muted"
-        />
-        <Box
-          position="absolute"
-          bottom="0"
-          right="0"
-          width="24px"
-          height="24px"
-          bg="blue.500"
-          color="white"
-          borderRadius="full"
-          borderWidth="2px"
-          borderColor="bg.surface"
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-        >
-          <Pencil size={12} />
-        </Box>
-      </Box>
+      <AvatarEditButton
+        name={name}
+        image={preview ?? currentImage}
+        label={currentImage ? "Change photo" : "Upload photo"}
+        isDisabled={isBusy}
+        onOpen={() => fileInputRef.current?.click()}
+      />
 
       <input
         ref={fileInputRef}
@@ -139,42 +207,18 @@ export function AvatarUploadControl({
       />
 
       <VStack align="start" gap={2}>
-        {preview ? (
-          <HStack gap={2}>
-            <Button
-              size="sm"
-              onClick={() =>
-                setAvatar.mutate({ organizationId, imageDataUrl: preview })
-              }
-              loading={setAvatar.isPending}
-              disabled={busy}
-            >
-              Save photo
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => setPreview(null)}
-              disabled={busy}
-            >
-              Cancel
-            </Button>
-          </HStack>
-        ) : (
-          currentImage && (
-            <Button
-              size="sm"
-              variant="ghost"
-              colorPalette="red"
-              onClick={() => removeAvatar.mutate({})}
-              loading={removeAvatar.isPending}
-              disabled={busy}
-            >
-              Remove
-            </Button>
-          )
-        )}
-
+        <AvatarActions
+          hasPreview={!!preview}
+          hasImage={!!currentImage}
+          isBusy={isBusy}
+          isSaving={setAvatar.isPending}
+          isRemoving={removeAvatar.isPending}
+          onSave={() => {
+            if (preview) setAvatar.mutate({ organizationId, imageDataUrl: preview });
+          }}
+          onCancel={() => setPreview(null)}
+          onRemove={() => removeAvatar.mutate({})}
+        />
         <Text fontSize="xs" color="fg.muted">
           PNG, JPG, WEBP or GIF, up to 1 MB. Cropped to a square.
         </Text>

--- a/langwatch/src/components/me/avatar/processAvatarImage.ts
+++ b/langwatch/src/components/me/avatar/processAvatarImage.ts
@@ -14,11 +14,11 @@
 export const AVATAR_OUTPUT_SIZE = 256;
 
 /**
- * Reject absurdly large source files before decoding them into an <img> — the
- * output is always tiny after resize, but decoding a 50 MB source still costs
- * memory. This bounds the *source*, not the (much smaller) upload.
+ * Max size of the image file a user may pick. Enforced client-side so the user
+ * gets immediate "too large" feedback; the server applies the same 1 MB ceiling
+ * on the (post-resize) payload as a backstop. Kept in sync with AVATAR_MAX_BYTES.
  */
-export const AVATAR_MAX_SOURCE_BYTES = 15 * 1024 * 1024;
+export const AVATAR_MAX_SOURCE_BYTES = 1 * 1024 * 1024;
 
 export class AvatarImageError extends Error {
   constructor(message: string) {

--- a/langwatch/src/components/me/avatar/processAvatarImage.ts
+++ b/langwatch/src/components/me/avatar/processAvatarImage.ts
@@ -14,11 +14,12 @@
 export const AVATAR_OUTPUT_SIZE = 256;
 
 /**
- * Max size of the image file a user may pick. Enforced client-side so the user
- * gets immediate "too large" feedback; the server applies the same 1 MB ceiling
- * on the (post-resize) payload as a backstop. Kept in sync with AVATAR_MAX_BYTES.
+ * Max size of the image file a user may pick (8 MB, matching LinkedIn's
+ * profile-photo limit). Enforced client-side so the user gets immediate "too
+ * large" feedback; the server applies the same ceiling on the (post-resize)
+ * payload as a backstop. Kept in sync with AVATAR_MAX_BYTES.
  */
-export const AVATAR_MAX_SOURCE_BYTES = 1 * 1024 * 1024;
+export const AVATAR_MAX_SOURCE_BYTES = 8 * 1024 * 1024;
 
 export class AvatarImageError extends Error {
   constructor(message: string) {

--- a/langwatch/src/components/me/avatar/processAvatarImage.ts
+++ b/langwatch/src/components/me/avatar/processAvatarImage.ts
@@ -1,0 +1,98 @@
+/**
+ * Client-side avatar image processing: take a user-selected image file,
+ * center-crop it to a square, downscale to a small fixed size, and re-encode
+ * to a compact data URL ready to POST to `user.setAvatar`.
+ *
+ * Doing the crop/resize in the browser keeps the uploaded payload tiny (a few
+ * KB) regardless of the source photo's resolution, so the server never has to
+ * process a full-resolution image and the stored object stays small.
+ *
+ * Spec: specs/settings/user-avatar.feature
+ */
+
+/** Output avatar edge length in px. Retina-crisp at every size we render. */
+export const AVATAR_OUTPUT_SIZE = 256;
+
+/**
+ * Reject absurdly large source files before decoding them into an <img> — the
+ * output is always tiny after resize, but decoding a 50 MB source still costs
+ * memory. This bounds the *source*, not the (much smaller) upload.
+ */
+export const AVATAR_MAX_SOURCE_BYTES = 15 * 1024 * 1024;
+
+export class AvatarImageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AvatarImageError";
+  }
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () =>
+      reject(new AvatarImageError("That file could not be read as an image."));
+    img.src = src;
+  });
+}
+
+/**
+ * Processes a selected file into a square, downscaled data URL.
+ *
+ * @throws {AvatarImageError} for a non-image, an oversized source file, or a
+ *   decode/encoding failure — messages are safe to show to the user.
+ */
+export async function processAvatarImage(file: File): Promise<string> {
+  if (!file.type.startsWith("image/")) {
+    throw new AvatarImageError("Please choose an image file.");
+  }
+  if (file.size > AVATAR_MAX_SOURCE_BYTES) {
+    throw new AvatarImageError(
+      `Image is too large (max ${Math.round(AVATAR_MAX_SOURCE_BYTES / 1024 / 1024)} MB).`,
+    );
+  }
+
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const img = await loadImage(objectUrl);
+
+    // Center-crop to the largest square that fits the source.
+    const edge = Math.min(img.naturalWidth, img.naturalHeight);
+    if (edge === 0) {
+      throw new AvatarImageError("That image appears to be empty.");
+    }
+    const sx = (img.naturalWidth - edge) / 2;
+    const sy = (img.naturalHeight - edge) / 2;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = AVATAR_OUTPUT_SIZE;
+    canvas.height = AVATAR_OUTPUT_SIZE;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      throw new AvatarImageError("Your browser could not process the image.");
+    }
+    ctx.imageSmoothingQuality = "high";
+    ctx.drawImage(
+      img,
+      sx,
+      sy,
+      edge,
+      edge,
+      0,
+      0,
+      AVATAR_OUTPUT_SIZE,
+      AVATAR_OUTPUT_SIZE,
+    );
+
+    // Prefer WebP for size; browsers without WebP encoding silently fall back
+    // to PNG here, which the server also accepts.
+    const dataUrl = canvas.toDataURL("image/webp", 0.9);
+    if (!dataUrl.startsWith("data:image/")) {
+      throw new AvatarImageError("Could not encode the image.");
+    }
+    return dataUrl;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}

--- a/langwatch/src/components/settings/CreateGroupDialog.tsx
+++ b/langwatch/src/components/settings/CreateGroupDialog.tsx
@@ -161,6 +161,7 @@ export function CreateGroupDialog({
                       <HStack key={userId} py={1} fontSize="sm">
                         <RandomColorAvatar
                           name={member?.user.name ?? member?.user.email ?? "?"}
+                          image={member?.user.image}
                           size="xs"
                         />
                         <Text flex={1}>

--- a/langwatch/src/components/settings/GroupDetailDialog.tsx
+++ b/langwatch/src/components/settings/GroupDetailDialog.tsx
@@ -316,7 +316,11 @@ export function GroupDetailDialog({
                       const markedForRemoval = pendingRemovals.has(m.userId);
                       return (
                         <HStack key={m.userId} py={1} fontSize="sm" opacity={markedForRemoval ? 0.4 : 1} transition="opacity 0.15s">
-                          <RandomColorAvatar name={m.name ?? m.email ?? "?"} size="xs" />
+                          <RandomColorAvatar
+                            name={m.name ?? m.email ?? "?"}
+                            image={m.image}
+                            size="xs"
+                          />
                           <Text flex={1} textDecoration={markedForRemoval ? "line-through" : undefined}>
                             {m.name ?? m.email}
                           </Text>

--- a/langwatch/src/components/settings/GroupDetailDialog.tsx
+++ b/langwatch/src/components/settings/GroupDetailDialog.tsx
@@ -154,11 +154,15 @@ export function GroupDetailDialog({
       return next;
     });
 
-  const stageMemberAdd = (
-    userId: string,
-    label: string,
-    image: string | null,
-  ) => {
+  const stageMemberAdd = ({
+    userId,
+    label,
+    image,
+  }: {
+    userId: string;
+    label: string;
+    image: string | null;
+  }) => {
     setPendingAdditions((prev) => [...prev, { userId, label, image }]);
     setAddMemberId("");
     setMemberSearch("");
@@ -404,7 +408,12 @@ export function GroupDetailDialog({
                         disabled={!addMemberId}
                         onClick={() => {
                           const item = allAvailable.find((a) => a.value === addMemberId);
-                          if (item) stageMemberAdd(item.value, item.label, item.image);
+                          if (item)
+                            stageMemberAdd({
+                              userId: item.value,
+                              label: item.label,
+                              image: item.image,
+                            });
                         }}
                       >
                         Add

--- a/langwatch/src/components/settings/GroupDetailDialog.tsx
+++ b/langwatch/src/components/settings/GroupDetailDialog.tsx
@@ -31,7 +31,7 @@ import {
 } from "./GroupBindingInputRow";
 
 type Group = RouterOutputs["group"]["listAll"][number];
-type PendingAddition = { userId: string; label: string };
+type PendingAddition = { userId: string; label: string; image: string | null };
 
 export function GroupDetailDialog({
   group,
@@ -154,8 +154,12 @@ export function GroupDetailDialog({
       return next;
     });
 
-  const stageMemberAdd = (userId: string, label: string) => {
-    setPendingAdditions((prev) => [...prev, { userId, label }]);
+  const stageMemberAdd = (
+    userId: string,
+    label: string,
+    image: string | null,
+  ) => {
+    setPendingAdditions((prev) => [...prev, { userId, label, image }]);
     setAddMemberId("");
     setMemberSearch("");
   };
@@ -339,7 +343,7 @@ export function GroupDetailDialog({
                     })}
                     {pendingAdditions.map((a) => (
                       <HStack key={a.userId} py={1} fontSize="sm" opacity={0.7}>
-                        <RandomColorAvatar name={a.label} size="xs" />
+                        <RandomColorAvatar name={a.label} image={a.image} size="xs" />
                         <Text flex={1} color="green.600">{a.label}</Text>
                         <Button
                           size="xs" variant="ghost" color="fg.muted"
@@ -359,6 +363,7 @@ export function GroupDetailDialog({
                     .map((m) => ({
                       label: `${m.user.name ?? m.user.email} (${m.user.email})`,
                       value: m.userId,
+                      image: m.user.image ?? null,
                     }))
                     .sort((a, b) => a.label.localeCompare(b.label));
                   const availableItems = memberSearch
@@ -399,7 +404,7 @@ export function GroupDetailDialog({
                         disabled={!addMemberId}
                         onClick={() => {
                           const item = allAvailable.find((a) => a.value === addMemberId);
-                          if (item) stageMemberAdd(item.value, item.label);
+                          if (item) stageMemberAdd(item.value, item.label, item.image);
                         }}
                       >
                         Add

--- a/langwatch/src/components/traces/AddParticipants.tsx
+++ b/langwatch/src/components/traces/AddParticipants.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Badge,
   Box,
   Button,
@@ -16,6 +15,7 @@ import { api } from "~/utils/api";
 import { Select } from "../../components/ui/select";
 import { getColorForString } from "../../utils/rotatingColors";
 import { RandomColorAvatar } from "../RandomColorAvatar";
+import { UserAvatar } from "../UserAvatar";
 
 export const AddParticipants = ({
   annotators,
@@ -64,11 +64,14 @@ export const AddParticipants = ({
   const userOptions = users.data?.members.map((member) => ({
     label: member.user.name ?? "",
     value: `user-${member.user.id}`,
+    image: member.user.image ?? null,
   }));
 
   const queueOptions = annotationQueues.data?.map((queue) => ({
     label: queue.name ?? "",
     value: `queue-${queue.id}`,
+    // Queues have no avatar image; keep the option shape uniform for `options`.
+    image: null,
   }));
 
   const options = [...(userOptions ?? []), ...(queueOptions ?? [])];
@@ -77,6 +80,7 @@ export const AddParticipants = ({
     items: options.map((option) => ({
       label: option.label,
       value: option.value,
+      image: option.image,
     })),
   });
   const participantsLeft = participantsCollection.items.filter(
@@ -118,15 +122,15 @@ export const AddParticipants = ({
                         background="bg.muted"
                       >
                         {item.value.startsWith("user-") ? (
-                          <Avatar.Root
+                          <UserAvatar
                             size="2xs"
                             color="white"
                             background={
                               getColorForString("colors", item.label).color
                             }
-                          >
-                            <Avatar.Fallback name={item.label} />
-                          </Avatar.Root>
+                            name={item.label}
+                            image={item.image}
+                          />
                         ) : (
                           <Box padding={1}>
                             <Users size={18} />
@@ -167,7 +171,11 @@ export const AddParticipants = ({
                   <VStack align="start">
                     <HStack>
                       {item.value.startsWith("user-") ? (
-                        <RandomColorAvatar size="2xs" name={item.label} />
+                        <RandomColorAvatar
+                          size="2xs"
+                          name={item.label}
+                          image={item.image}
+                        />
                       ) : (
                         <Box padding={1}>
                           <Users size={18} />

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
@@ -20,6 +20,7 @@ import {
   LuSparkles,
   LuTriangleAlert,
 } from "react-icons/lu";
+import { UserAvatar } from "~/components/UserAvatar";
 import { useAnnotationsByTraceIds } from "~/hooks/useAnnotationsByTraceIds";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { TraceHeader } from "~/server/api/routers/tracesV2.schemas";
@@ -150,9 +151,13 @@ function useAnnotationsChip(trace: TraceHeader): ChipDef | null {
         <VStack align="stretch" gap={3} maxHeight="280px" overflowY="auto">
           {items.map((a) => (
             <HStack key={a.id} gap={2.5} align="start">
-              <Avatar.Root size="xs" background="gray.solid" color="white">
-                <Avatar.Fallback name={a.user?.name ?? a.email ?? "?"} />
-              </Avatar.Root>
+              <UserAvatar
+                size="xs"
+                background="gray.solid"
+                color="white"
+                name={a.user?.name ?? a.email ?? "?"}
+                image={a.user?.image}
+              />
               <VStack align="start" gap={0.5} flex={1} minWidth={0}>
                 <HStack gap={1.5} width="full">
                   <Text textStyle="2xs" fontWeight="600">

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/conversationView/AnnotationsView.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/conversationView/AnnotationsView.tsx
@@ -14,6 +14,7 @@ import {
   type AnnotationByTrace,
   useAnnotationsByTraceIds,
 } from "~/hooks/useAnnotationsByTraceIds";
+import { UserAvatar } from "~/components/UserAvatar";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 
 import { AnnotationPopover } from "./AnnotationPopover";
@@ -160,11 +161,13 @@ function AnnotationRow({
     >
       <VStack align="stretch" gap={2}>
         <HStack>
-          <Avatar.Root size="xs" background="gray.solid" color="white">
-            <Avatar.Fallback
-              name={annotation.user?.name ?? annotation.email ?? "?"}
-            />
-          </Avatar.Root>
+          <UserAvatar
+            size="xs"
+            background="gray.solid"
+            color="white"
+            name={annotation.user?.name ?? annotation.email ?? "?"}
+            image={annotation.user?.image}
+          />
           <Text textStyle="xs" fontWeight="600">
             {annotation.user?.name ?? annotation.email ?? "anonymous"}
           </Text>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/conversationView/TurnAnnotations.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/conversationView/TurnAnnotations.tsx
@@ -15,6 +15,7 @@ import {
   MessageSquare,
 } from "lucide-react";
 import { forwardRef, useState } from "react";
+import { UserAvatar } from "~/components/UserAvatar";
 import { PersonalFeatureGateDialog } from "~/components/me/PersonalFeatureGateDialog";
 import { usePersonalFeatureGate } from "~/components/me/usePersonalFeatureGate";
 import { Popover } from "~/components/ui/popover";
@@ -319,13 +320,13 @@ export function TurnAnnotationBadges({
                   _hover={canEdit ? { bg: "bg.muted" } : undefined}
                 >
                   <HStack gap={2} align="start">
-                    <Avatar.Root
+                    <UserAvatar
                       size="xs"
                       background="gray.solid"
                       color="white"
-                    >
-                      <Avatar.Fallback name={a.user?.name ?? a.email ?? "?"} />
-                    </Avatar.Root>
+                      name={a.user?.name ?? a.email ?? "?"}
+                      image={a.user?.image}
+                    />
                     <VStack align="start" gap={0} flex={1} minWidth={0}>
                       <HStack gap={1.5} width="full">
                         <Text textStyle="2xs" fontWeight="600">

--- a/langwatch/src/optimization_studio/components/History.tsx
+++ b/langwatch/src/optimization_studio/components/History.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Box,
   type BoxProps,
   Button,
@@ -12,6 +11,7 @@ import {
 } from "@chakra-ui/react";
 import type { Project } from "@prisma/client";
 import { useCallback, useEffect, useMemo } from "react";
+import { UserAvatar } from "~/components/UserAvatar";
 import { type UseFormReturn, FormProvider, useForm } from "react-hook-form";
 
 import { HistoryIcon } from "../../components/icons/History";
@@ -246,18 +246,15 @@ export function HistoryPopover({ onClose }: { onClose: () => void }) {
                     )}
                   </HStack>
                   <HStack fontSize="12px">
-                    <Avatar.Root
+                    <UserAvatar
                       size="2xs"
                       backgroundColor="orange.400"
                       color="white"
                       width="16px"
                       height="16px"
-                    >
-                      <Avatar.Fallback
-                        name={version.author?.name ?? ""}
-                        fontSize="6.4px"
-                      />
-                    </Avatar.Root>
+                      name={version.author?.name ?? ""}
+                      image={version.author?.image}
+                    />
                     {version.author?.name}
                     {/* {" · "}
                     <Tooltip

--- a/langwatch/src/pages/[project]/annotations/[slug].tsx
+++ b/langwatch/src/pages/[project]/annotations/[slug].tsx
@@ -1,5 +1,5 @@
 import {
-  Avatar,
+  Box,
   Container,
   Heading,
   HStack,
@@ -8,6 +8,7 @@ import {
 } from "@chakra-ui/react";
 import { useRouter } from "~/utils/compat/next-router";
 import AnnotationsLayout from "~/components/AnnotationsLayout";
+import { UserAvatar } from "~/components/UserAvatar";
 
 import { AnnotationsTable } from "~/components/annotations/AnnotationsTable";
 import { Tooltip } from "~/components/ui/tooltip";
@@ -40,9 +41,13 @@ export default function Annotations() {
           {queueMembers?.map((member) => {
             return (
               <Tooltip key={member.id} content={member.name}>
-                <Avatar.Root size="xs">
-                  <Avatar.Fallback name={member.name ?? ""} />
-                </Avatar.Root>
+                <Box display="inline-flex">
+                  <UserAvatar
+                    size="xs"
+                    name={member.name ?? ""}
+                    image={member.image}
+                  />
+                </Box>
               </Tooltip>
             );
           })}

--- a/langwatch/src/pages/me/configure.tsx
+++ b/langwatch/src/pages/me/configure.tsx
@@ -21,6 +21,7 @@ import Head from "~/utils/compat/next-head";
 
 import { withFeatureFlagGuard } from "~/components/WithFeatureFlagGuard";
 import MyLayout from "~/components/me/MyLayout";
+import { AvatarUploadControl } from "~/components/me/avatar/AvatarUploadControl";
 import { HomePagePicker } from "~/components/me/HomePagePicker";
 import { PersonalOtlpEndpointPanel } from "~/components/me/PersonalOtlpEndpointPanel";
 import {
@@ -205,7 +206,10 @@ function MySettingsPage() {
         </HStack>
 
         <SectionCard title="Profile">
-          <VStack align="stretch" gap={3}>
+          <VStack align="stretch" gap={4}>
+            {ctx.organizationId && (
+              <AvatarUploadControl organizationId={ctx.organizationId} />
+            )}
             <Field label="Name" value={ctx.fullName} />
             <Field
               label="Email"

--- a/langwatch/src/pages/settings/members.tsx
+++ b/langwatch/src/pages/settings/members.tsx
@@ -326,6 +326,7 @@ function MembersList({
                         <RandomColorAvatar
                           size="2xs"
                           name={member.user.name ?? ""}
+                          image={member.user.image}
                         />
                       </Table.Cell>
                       <Table.Cell>

--- a/langwatch/src/pages/settings/role-bindings.tsx
+++ b/langwatch/src/pages/settings/role-bindings.tsx
@@ -55,6 +55,7 @@ type Principal = {
   userId: string | null;
   userName: string | null;
   userEmail: string | null;
+  userImage: string | null;
   groupId: string | null;
   groupName: string | null;
   groupScimSource: string | null;
@@ -72,6 +73,7 @@ function groupByPrincipal(bindings: Binding[]): Principal[] {
         userId: b.userId,
         userName: b.userName,
         userEmail: b.userEmail,
+        userImage: b.userImage,
         groupId: b.groupId,
         groupName: b.groupName,
         groupScimSource: b.groupScimSource,
@@ -97,6 +99,7 @@ function PrincipalCell({ principal }: { principal: Principal }) {
         <RandomColorAvatar
           id={principal.userId}
           name={principal.userName ?? principal.userEmail ?? "?"}
+          image={principal.userImage}
           size="xs"
         />
         <VStack gap={0} align="start">

--- a/langwatch/src/pages/settings/teams.tsx
+++ b/langwatch/src/pages/settings/teams.tsx
@@ -512,7 +512,7 @@ function ProjectSection({
                     opacity={0.5}
                     fontSize="sm"
                   >
-                    <RandomColorAvatar name={m.name} size="xs" />
+                    <RandomColorAvatar name={m.name} image={m.image} size="xs" />
                     <Text flex={1}>{m.name}</Text>
                     <Badge colorPalette={roleBadgeColor(m.role)} size="sm">
                       {m.customRoleName ?? m.role}
@@ -544,7 +544,7 @@ function ProjectSection({
                 </Text>
                 {projectLevel.map((m, i) => (
                   <HStack key={i} py={1} fontSize="sm">
-                    <RandomColorAvatar name={m.name} size="xs" />
+                    <RandomColorAvatar name={m.name} image={m.image} size="xs" />
                     <Box flex={1}>
                       <Text display="inline">{m.name}</Text>
                       {m.source === "override" && m.teamRole && (
@@ -813,7 +813,7 @@ function TeamCard({
                     _dark={{ borderColor: "gray.700" }}
                     opacity={m.viaGroupId ? 0.7 : 1}
                   >
-                    <RandomColorAvatar name={m.name} size="xs" />
+                    <RandomColorAvatar name={m.name} image={m.image} size="xs" />
                     <Text fontSize="sm" flex={1}>
                       {m.name}
                     </Text>
@@ -894,7 +894,7 @@ function TeamCard({
                     borderColor="gray.100"
                     _dark={{ borderColor: "gray.700" }}
                   >
-                    <RandomColorAvatar name={m.name} size="xs" />
+                    <RandomColorAvatar name={m.name} image={m.image} size="xs" />
                     <Text flex={1}>{m.name}</Text>
                     <Badge colorPalette={roleBadgeColor(m.role)} size="sm">
                       {m.role}

--- a/langwatch/src/server/api-router.ts
+++ b/langwatch/src/server/api-router.ts
@@ -34,6 +34,7 @@ import { app as suitesApp } from "../app/api/suites/[[...route]]/app";
 import { app as teamsApp } from "../app/api/teams/[[...route]]/app";
 import { app as tracesApp } from "../app/api/traces/[[...route]]/app";
 import { app as triggersApp } from "../app/api/triggers/[[...route]]/app";
+import { app as userAvatarApp } from "../app/api/user-avatar/[[...route]]/app";
 import { app as workflowsCrudApp } from "../app/api/workflows/[[...route]]/app";
 import { app as annotationsApp } from "./routes/annotations";
 import { app as authApp } from "./routes/auth";
@@ -141,6 +142,7 @@ export function createApiRouter() {
   api.route("/", teamsApp);
   api.route("/", tracesApp);
   api.route("/", triggersApp);
+  api.route("/", userAvatarApp); // /api/user-avatar/:projectId/:id — user avatars
   api.route("/", workflowsCrudApp); // CRUD — complements workflowsApp (code-completion, post_event)
 
   api.route("/", gatewayInternalApp);

--- a/langwatch/src/server/api/routers/group.ts
+++ b/langwatch/src/server/api/routers/group.ts
@@ -167,7 +167,9 @@ export const groupRouter = createTRPCRouter({
                 },
               },
             },
-            include: { user: { select: { id: true, name: true, email: true } } },
+            include: {
+              user: { select: { id: true, name: true, email: true, image: true } },
+            },
           },
         },
       });
@@ -197,6 +199,7 @@ export const groupRouter = createTRPCRouter({
           userId: m.userId,
           name: m.user.name,
           email: m.user.email,
+          image: m.user.image,
         })),
       };
     }),

--- a/langwatch/src/server/api/routers/user.ts
+++ b/langwatch/src/server/api/routers/user.ts
@@ -23,6 +23,8 @@ import { sendBudgetIncreaseRequestEmail } from "~/server/mailer/budgetIncreaseRe
 import { resolveOrgAdminEmail } from "~/server/organizations/resolveOrgAdminEmail";
 import { resolveSupportContact } from "~/server/organizations/resolveSupportContact";
 import { rateLimit } from "~/server/rateLimit";
+import { AvatarValidationError } from "~/server/user-avatar/avatar";
+import { UserAvatarService } from "~/server/user-avatar/avatar.service";
 import { UserService } from "~/server/users/user.service";
 import { getClientIp } from "~/utils/getClientIp";
 import { isAdmin as checkIsAdmin } from "../../../../ee/admin/isAdmin";
@@ -478,6 +480,72 @@ export const userRouter = createTRPCRouter({
       }
 
       await UserService.create(ctx.prisma).reactivate({ id: input.userId });
+      return { success: true };
+    }),
+
+  /**
+   * Uploads and sets the caller's own avatar photo. The image is stored in the
+   * S3-backed object store (owned by the user, under their personal workspace)
+   * and its serve URL is written to `User.image`, the field every avatar
+   * surface resolves through. `organizationId` scopes the personal-workspace
+   * resolution and is membership-checked below.
+   *
+   * Spec: specs/settings/user-avatar.feature
+   */
+  setAvatar: protectedProcedure
+    .input(
+      z.object({
+        organizationId: z.string(),
+        // A base64 image data URL (`data:image/...;base64,...`) produced by the
+        // client crop/resize step. Validated + decoded in UserAvatarService.
+        imageDataUrl: z.string().min(1),
+      }),
+    )
+    .use(checkOrganizationPermission("organization:view"))
+    .mutation(async ({ ctx, input }) => {
+      // Throttle uploads per user — each writes bytes to object storage and
+      // updates the row; mirrors the changePassword budget shape.
+      const limit = await rateLimit({
+        key: `user.setAvatar:${ctx.session.user.id}`,
+        windowSeconds: 60,
+        max: 10,
+      });
+      if (!limit.allowed) {
+        throw new TRPCError({
+          code: "TOO_MANY_REQUESTS",
+          message: "Too many avatar updates. Please try again shortly.",
+        });
+      }
+
+      try {
+        return await new UserAvatarService(ctx.prisma).setAvatar({
+          userId: ctx.session.user.id,
+          organizationId: input.organizationId,
+          imageDataUrl: input.imageDataUrl,
+          displayName: ctx.session.user.name,
+          displayEmail: ctx.session.user.email,
+        });
+      } catch (err) {
+        if (err instanceof AvatarValidationError) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: err.message });
+        }
+        throw err;
+      }
+    }),
+
+  /**
+   * Clears the caller's uploaded avatar so surfaces fall back to their SSO
+   * photo (if any) and then their initials.
+   *
+   * Spec: specs/settings/user-avatar.feature
+   */
+  removeAvatar: protectedProcedure
+    .input(z.object({}))
+    .use(skipPermissionCheck)
+    .mutation(async ({ ctx }) => {
+      await new UserAvatarService(ctx.prisma).removeAvatar({
+        userId: ctx.session.user.id,
+      });
       return { success: true };
     }),
 

--- a/langwatch/src/server/api/routers/user.ts
+++ b/langwatch/src/server/api/routers/user.ts
@@ -23,7 +23,10 @@ import { sendBudgetIncreaseRequestEmail } from "~/server/mailer/budgetIncreaseRe
 import { resolveOrgAdminEmail } from "~/server/organizations/resolveOrgAdminEmail";
 import { resolveSupportContact } from "~/server/organizations/resolveSupportContact";
 import { rateLimit } from "~/server/rateLimit";
-import { AvatarValidationError } from "~/server/user-avatar/avatar";
+import {
+  AVATAR_MAX_DATA_URL_LENGTH,
+  AvatarValidationError,
+} from "~/server/user-avatar/avatar";
 import { UserAvatarService } from "~/server/user-avatar/avatar.service";
 import { UserService } from "~/server/users/user.service";
 import { getClientIp } from "~/utils/getClientIp";
@@ -497,8 +500,10 @@ export const userRouter = createTRPCRouter({
       z.object({
         organizationId: z.string(),
         // A base64 image data URL (`data:image/...;base64,...`) produced by the
-        // client crop/resize step. Validated + decoded in UserAvatarService.
-        imageDataUrl: z.string().min(1),
+        // client crop/resize step. Bounded here as first-line defense so an
+        // oversized payload is rejected before UserAvatarService decodes it;
+        // validated + decoded there.
+        imageDataUrl: z.string().min(1).max(AVATAR_MAX_DATA_URL_LENGTH),
       }),
     )
     .use(checkOrganizationPermission("organization:view"))

--- a/langwatch/src/server/better-auth/__tests__/index.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/index.test.ts
@@ -203,8 +203,8 @@ describe("better-auth config", () => {
     // `overrideUserInfoOnSignIn: true`). Lock that no provider ever does — the
     // check is name-agnostic so any future override/update-user-info flag set to
     // `true` trips it. Spec: specs/settings/user-avatar.feature
-    const overrideFlags = (config: Record<string, unknown>): string[] =>
-      Object.entries(config)
+    const overrideFlags = (config: unknown): string[] =>
+      Object.entries(config as Record<string, unknown>)
         .filter(([k, v]) => /override|updateuserinfo/i.test(k) && v === true)
         .map(([k]) => k);
 
@@ -246,7 +246,7 @@ describe("better-auth config", () => {
       } as Parameters<typeof buildSocialProviders>[0]);
       const built = Object.values(providers);
       expect(built).toHaveLength(1);
-      expect(overrideFlags(built[0] as Record<string, unknown>)).toEqual([]);
+      expect(overrideFlags(built[0])).toEqual([]);
     });
 
     it("generic-oauth (auth0/okta) never overwrites profile info on sign-in", async () => {
@@ -263,7 +263,7 @@ describe("better-auth config", () => {
       });
       expect(configs.length).toBeGreaterThan(0);
       for (const config of configs) {
-        expect(overrideFlags(config as Record<string, unknown>)).toEqual([]);
+        expect(overrideFlags(config)).toEqual([]);
       }
     });
   });

--- a/langwatch/src/server/better-auth/__tests__/index.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/index.test.ts
@@ -195,4 +195,76 @@ describe("better-auth config", () => {
       expect(google.clientSecret).toBe("google-client-secret");
     });
   });
+
+  describe("SSO precedence — re-login must not overwrite an uploaded avatar", () => {
+    // A user-uploaded avatar (User.image) must survive later SSO sign-ins.
+    // better-auth's `mapProfileToUser` runs only on user *create*; it overwrites
+    // profile fields on subsequent sign-ins ONLY if a provider opts in (e.g.
+    // `overrideUserInfoOnSignIn: true`). Lock that no provider ever does — the
+    // check is name-agnostic so any future override/update-user-info flag set to
+    // `true` trips it. Spec: specs/settings/user-avatar.feature
+    const overrideFlags = (config: Record<string, unknown>): string[] =>
+      Object.entries(config)
+        .filter(([k, v]) => /override|updateuserinfo/i.test(k) && v === true)
+        .map(([k]) => k);
+
+    const noSocialEnv = {
+      GOOGLE_CLIENT_ID: undefined,
+      GOOGLE_CLIENT_SECRET: undefined,
+      GITHUB_CLIENT_ID: undefined,
+      GITHUB_CLIENT_SECRET: undefined,
+      GITLAB_CLIENT_ID: undefined,
+      GITLAB_CLIENT_SECRET: undefined,
+      AZURE_AD_CLIENT_ID: undefined,
+      AZURE_AD_CLIENT_SECRET: undefined,
+      AZURE_AD_TENANT_ID: undefined,
+    };
+
+    it.each([
+      ["google", "google", { GOOGLE_CLIENT_ID: "id", GOOGLE_CLIENT_SECRET: "secret" }],
+      ["github", "github", { GITHUB_CLIENT_ID: "id", GITHUB_CLIENT_SECRET: "secret" }],
+      ["gitlab", "gitlab", { GITLAB_CLIENT_ID: "id", GITLAB_CLIENT_SECRET: "secret" }],
+      [
+        "microsoft",
+        "azure-ad",
+        {
+          AZURE_AD_CLIENT_ID: "id",
+          AZURE_AD_CLIENT_SECRET: "secret",
+          AZURE_AD_TENANT_ID: "tenant",
+        },
+      ],
+    ])("social provider %s never overwrites profile info on sign-in", async (
+      _label,
+      provider,
+      creds,
+    ) => {
+      const { buildSocialProviders } = await import("../index");
+      const providers = buildSocialProviders({
+        ...noSocialEnv,
+        NEXTAUTH_PROVIDER: provider,
+        ...creds,
+      } as Parameters<typeof buildSocialProviders>[0]);
+      const built = Object.values(providers);
+      expect(built).toHaveLength(1);
+      expect(overrideFlags(built[0] as Record<string, unknown>)).toEqual([]);
+    });
+
+    it("generic-oauth (auth0/okta) never overwrites profile info on sign-in", async () => {
+      const { buildGenericOAuthConfigs } = await import("../index");
+      const configs = buildGenericOAuthConfigs({
+        NEXTAUTH_PROVIDER: "auth0",
+        AUTH0_CLIENT_ID: "id",
+        AUTH0_CLIENT_SECRET: "secret",
+        AUTH0_ISSUER: "tenant.us.auth0.com",
+        OKTA_CLIENT_ID: undefined,
+        OKTA_CLIENT_SECRET: undefined,
+        OKTA_ISSUER: undefined,
+        NEXTAUTH_URL: "http://localhost:3000",
+      });
+      expect(configs.length).toBeGreaterThan(0);
+      for (const config of configs) {
+        expect(overrideFlags(config as Record<string, unknown>)).toEqual([]);
+      }
+    });
+  });
 });

--- a/langwatch/src/server/role-bindings/role-binding.service.ts
+++ b/langwatch/src/server/role-bindings/role-binding.service.ts
@@ -134,7 +134,7 @@ export class RoleBindingService {
         ],
       },
       include: {
-        user: { select: { id: true, name: true, email: true } },
+        user: { select: { id: true, name: true, email: true, image: true } },
         group: { select: { id: true, name: true, scimSource: true } },
         customRole: { select: { id: true, name: true } },
       },
@@ -196,6 +196,7 @@ export class RoleBindingService {
       userId: b.userId,
       userName: b.user?.name ?? null,
       userEmail: b.user?.email ?? null,
+      userImage: b.user?.image ?? null,
       groupId: b.groupId,
       groupName: b.group?.name ?? null,
       groupScimSource: b.group?.scimSource ?? null,

--- a/langwatch/src/server/stored-objects/media-response.ts
+++ b/langwatch/src/server/stored-objects/media-response.ts
@@ -37,3 +37,29 @@ export function safeMediaType(mediaType: string): string {
 export function sanitizeFilenameSegment(id: string): string {
   return id.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 128);
 }
+
+/** A JSON response carrying the shared stored-object hardening headers. */
+export function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...STORED_OBJECT_RESPONSE_BASE_HEADERS,
+    },
+  });
+}
+
+/**
+ * A 429 response with a `Retry-After` derived from the rate-limit reset time
+ * (clamped to ≥ 1s), plus the shared hardening headers.
+ */
+export function rateLimitedResponse(resetAtMs: number): Response {
+  return new Response(JSON.stringify({ error: "rate_limited" }), {
+    status: 429,
+    headers: {
+      "Content-Type": "application/json",
+      "Retry-After": String(Math.max(1, Math.ceil((resetAtMs - Date.now()) / 1000))),
+      ...STORED_OBJECT_RESPONSE_BASE_HEADERS,
+    },
+  });
+}

--- a/langwatch/src/server/stored-objects/media-response.ts
+++ b/langwatch/src/server/stored-objects/media-response.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared HTTP hardening for routes that stream stored-object bytes back to a
+ * browser (`/api/files`, `/api/user-avatar`). Centralised so every byte-serving
+ * surface applies the exact same Content-Type coercion + security headers —
+ * widening the allowlist or tightening the headers updates all of them at once.
+ */
+import { isReadbackSafe } from "./safe-media-types";
+
+/**
+ * Static response headers attached to every stored-object read. Never vary by
+ * row, never echo user content: a locked-down CSP + sandbox + nosniff so a
+ * stored payload can't be interpreted as active content, and no referrer leak.
+ */
+export const STORED_OBJECT_RESPONSE_BASE_HEADERS: Readonly<
+  Record<string, string>
+> = {
+  "X-Content-Type-Options": "nosniff",
+  "Content-Security-Policy": "default-src 'none'; sandbox",
+  "Referrer-Policy": "no-referrer",
+};
+
+/**
+ * Resolves the Content-Type for a stored-object response: the requested type
+ * when it is in the shared readback-safe allowlist (see `safe-media-types.ts`),
+ * otherwise `application/octet-stream` to neutralize MIME sniffing and
+ * stored-XSS primitives.
+ */
+export function safeMediaType(mediaType: string): string {
+  return isReadbackSafe(mediaType) ? mediaType : "application/octet-stream";
+}
+
+/**
+ * RFC 6266 — keep ASCII filename-safe characters, replace anything else with
+ * `_`, and cap length. Used to build a header-injection-safe
+ * `Content-Disposition` filename from an untrusted segment.
+ */
+export function sanitizeFilenameSegment(id: string): string {
+  return id.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 128);
+}

--- a/langwatch/src/server/teams/team.service.ts
+++ b/langwatch/src/server/teams/team.service.ts
@@ -15,6 +15,15 @@ export const TEAM_ROLE_PRIORITY: Record<TeamUserRole, number> = {
   [TeamUserRole.CUSTOM]: 3,
 };
 
+/** The user fields every team-member projection selects (kept in one place so
+ * the shape can't drift across the three role-binding include sites). */
+const MEMBER_USER_SELECT = {
+  id: true,
+  name: true,
+  email: true,
+  image: true,
+} satisfies Prisma.UserSelect;
+
 const principalInOrganizationWhere = (
   organizationId: string,
 ): Prisma.RoleBindingWhereInput => ({
@@ -298,7 +307,7 @@ export class TeamService {
               ...principalInOrganizationWhere(organizationId),
             },
             include: {
-              user: { select: { id: true, name: true, email: true, image: true } },
+              user: { select: MEMBER_USER_SELECT },
               group: { select: { id: true, name: true, scimSource: true } },
               apiKey: { select: { id: true, name: true } },
               customRole: { select: { id: true, name: true } },
@@ -313,7 +322,7 @@ export class TeamService {
                   ...principalInOrganizationWhere(organizationId),
                 },
                 include: {
-                  user: { select: { id: true, name: true, email: true, image: true } },
+                  user: { select: MEMBER_USER_SELECT },
                   group: { select: { id: true, name: true, scimSource: true } },
                   apiKey: { select: { id: true, name: true } },
                   customRole: { select: { id: true, name: true } },
@@ -342,7 +351,7 @@ export class TeamService {
                 group: { organizationId },
                 user: { orgMemberships: { some: { organizationId } } },
               },
-              include: { user: { select: { id: true, name: true, email: true, image: true } } },
+              include: { user: { select: MEMBER_USER_SELECT } },
             })
           : [];
 

--- a/langwatch/src/server/teams/team.service.ts
+++ b/langwatch/src/server/teams/team.service.ts
@@ -22,7 +22,7 @@ const MEMBER_USER_SELECT = {
   name: true,
   email: true,
   image: true,
-} satisfies Prisma.UserSelect;
+} as const satisfies Prisma.UserSelect;
 
 const principalInOrganizationWhere = (
   organizationId: string,

--- a/langwatch/src/server/teams/team.service.ts
+++ b/langwatch/src/server/teams/team.service.ts
@@ -298,7 +298,7 @@ export class TeamService {
               ...principalInOrganizationWhere(organizationId),
             },
             include: {
-              user: { select: { id: true, name: true, email: true } },
+              user: { select: { id: true, name: true, email: true, image: true } },
               group: { select: { id: true, name: true, scimSource: true } },
               apiKey: { select: { id: true, name: true } },
               customRole: { select: { id: true, name: true } },
@@ -313,7 +313,7 @@ export class TeamService {
                   ...principalInOrganizationWhere(organizationId),
                 },
                 include: {
-                  user: { select: { id: true, name: true, email: true } },
+                  user: { select: { id: true, name: true, email: true, image: true } },
                   group: { select: { id: true, name: true, scimSource: true } },
                   apiKey: { select: { id: true, name: true } },
                   customRole: { select: { id: true, name: true } },
@@ -342,7 +342,7 @@ export class TeamService {
                 group: { organizationId },
                 user: { orgMemberships: { some: { organizationId } } },
               },
-              include: { user: { select: { id: true, name: true, email: true } } },
+              include: { user: { select: { id: true, name: true, email: true, image: true } } },
             })
           : [];
 
@@ -380,6 +380,7 @@ export class TeamService {
               viaGroupName: b.group?.name ?? null,
               name: gm.user.name ?? gm.user.email ?? "Unknown",
               email: gm.user.email ?? null,
+              image: gm.user.image ?? null,
               role: b.role,
               customRoleId: b.customRoleId,
               customRoleName: b.customRole?.name ?? null,
@@ -395,6 +396,7 @@ export class TeamService {
             viaGroupName: null as string | null,
             name: b.user?.name ?? b.user?.email ?? b.apiKey?.name ?? "Unknown",
             email: b.user?.email ?? null,
+            image: b.user?.image ?? null,
             role: b.role,
             customRoleId: b.customRoleId,
             customRoleName: b.customRole?.name ?? null,
@@ -419,6 +421,7 @@ export class TeamService {
           userId: string;
           name: string;
           email: string | null;
+          image: string | null;
           role: TeamUserRole;
           customRoleId: string | null;
           customRoleName: string | null;
@@ -438,6 +441,7 @@ export class TeamService {
               userId: b.userId,
               name: b.user?.name ?? b.userId,
               email: b.user?.email ?? null,
+              image: b.user?.image ?? null,
               role: b.role,
               customRoleId: b.customRoleId,
               customRoleName: b.customRole?.name ?? null,
@@ -455,6 +459,7 @@ export class TeamService {
           viaGroupName: string | null;
           name: string;
           email: string | null;
+          image: string | null;
           role: TeamUserRole;
           customRoleId: string | null;
           customRoleName: string | null;
@@ -470,6 +475,7 @@ export class TeamService {
             viaGroupName: m.viaGroupName,
             name: m.name,
             email: m.email,
+            image: m.image,
             role: m.role,
             customRoleId: m.customRoleId,
             customRoleName: m.customRoleName,
@@ -507,6 +513,7 @@ export class TeamService {
               viaGroupName: b.groupId ? b.group?.name ?? null : null,
               name: b.user?.name ?? b.group?.name ?? b.apiKey?.name ?? "Unknown",
               email: b.user?.email ?? null,
+              image: b.user?.image ?? null,
               role: b.role,
               customRoleId: b.customRoleId,
               customRoleName: b.customRole?.name ?? null,

--- a/langwatch/src/server/user-avatar/__tests__/avatar.service.unit.test.ts
+++ b/langwatch/src/server/user-avatar/__tests__/avatar.service.unit.test.ts
@@ -1,0 +1,103 @@
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AvatarValidationError } from "../avatar";
+import { UserAvatarService } from "../avatar.service";
+
+const PNG_1x1_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+function makeService({
+  storeId = "so_generated",
+  projectId = "proj_personal",
+}: { storeId?: string; projectId?: string } = {}) {
+  const userUpdate = vi.fn().mockResolvedValue({});
+  const prisma = { user: { update: userUpdate } } as unknown as PrismaClient;
+  const ensureWorkspaceProject = vi.fn().mockResolvedValue({ projectId });
+  const storeAvatarBytes = vi.fn().mockResolvedValue({ id: storeId });
+  const service = new UserAvatarService(prisma, {
+    ensureWorkspaceProject,
+    storeAvatarBytes,
+  });
+  return { service, userUpdate, ensureWorkspaceProject, storeAvatarBytes };
+}
+
+describe("UserAvatarService", () => {
+  describe("setAvatar", () => {
+    describe("given a valid image and organization", () => {
+      it("stores the bytes under the user's personal project tagged as a user avatar", async () => {
+        const { service, storeAvatarBytes, ensureWorkspaceProject } =
+          makeService({ projectId: "proj_personal" });
+
+        await service.setAvatar({
+          userId: "user_1",
+          organizationId: "org_1",
+          imageDataUrl: PNG_1x1_DATA_URL,
+        });
+
+        expect(ensureWorkspaceProject).toHaveBeenCalledWith(
+          expect.objectContaining({ userId: "user_1", organizationId: "org_1" }),
+        );
+        expect(storeAvatarBytes).toHaveBeenCalledWith(
+          expect.objectContaining({
+            projectId: "proj_personal",
+            userId: "user_1",
+            mediaType: "image/png",
+          }),
+        );
+      });
+
+      it("writes the serve URL to User.image and returns it", async () => {
+        const { service, userUpdate } = makeService({
+          projectId: "proj_personal",
+          storeId: "so_abc",
+        });
+
+        const result = await service.setAvatar({
+          userId: "user_1",
+          organizationId: "org_1",
+          imageDataUrl: PNG_1x1_DATA_URL,
+        });
+
+        expect(result.image).toBe("/api/user-avatar/proj_personal/so_abc");
+        expect(userUpdate).toHaveBeenCalledWith({
+          where: { id: "user_1" },
+          data: { image: "/api/user-avatar/proj_personal/so_abc" },
+        });
+      });
+    });
+
+    describe("when the payload is not a valid image", () => {
+      beforeEach(() => vi.clearAllMocks());
+
+      it("rejects before touching storage or the database", async () => {
+        const { service, storeAvatarBytes, userUpdate } = makeService();
+
+        await expect(
+          service.setAvatar({
+            userId: "user_1",
+            organizationId: "org_1",
+            imageDataUrl: "not-an-image",
+          }),
+        ).rejects.toBeInstanceOf(AvatarValidationError);
+
+        expect(storeAvatarBytes).not.toHaveBeenCalled();
+        expect(userUpdate).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("removeAvatar", () => {
+    describe("given a user with an avatar", () => {
+      it("clears User.image", async () => {
+        const { service, userUpdate } = makeService();
+
+        await service.removeAvatar({ userId: "user_1" });
+
+        expect(userUpdate).toHaveBeenCalledWith({
+          where: { id: "user_1" },
+          data: { image: null },
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/server/user-avatar/__tests__/avatar.unit.test.ts
+++ b/langwatch/src/server/user-avatar/__tests__/avatar.unit.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  AVATAR_MAX_BYTES,
+  AvatarValidationError,
+  buildAvatarUrl,
+  parseAvatarDataUrl,
+} from "../avatar";
+
+// A 1x1 transparent PNG, base64 — smallest valid real image payload.
+const PNG_1x1_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+const PNG_1x1_DATA_URL = `data:image/png;base64,${PNG_1x1_BASE64}`;
+
+describe("parseAvatarDataUrl", () => {
+  describe("given a valid PNG data URL", () => {
+    it("returns the decoded bytes and media type", () => {
+      const { mediaType, bytes } = parseAvatarDataUrl(PNG_1x1_DATA_URL);
+      expect(mediaType).toBe("image/png");
+      expect(bytes.length).toBeGreaterThan(0);
+      // PNG magic number.
+      expect(bytes.subarray(0, 4).toString("hex")).toBe("89504e47");
+    });
+  });
+
+  describe("given a media type with different casing", () => {
+    it("normalizes the media type to lowercase", () => {
+      const { mediaType } = parseAvatarDataUrl(
+        `data:IMAGE/PNG;base64,${PNG_1x1_BASE64}`,
+      );
+      expect(mediaType).toBe("image/png");
+    });
+  });
+
+  describe("when the string is not a base64 image data URL", () => {
+    it("throws an invalid_data_url validation error", () => {
+      expect(() => parseAvatarDataUrl("https://example.com/photo.png")).toThrow(
+        AvatarValidationError,
+      );
+      try {
+        parseAvatarDataUrl("not a data url");
+      } catch (err) {
+        expect((err as AvatarValidationError).code).toBe("invalid_data_url");
+      }
+    });
+  });
+
+  describe("when the image type is not allowed", () => {
+    it("throws an invalid_type validation error", () => {
+      try {
+        parseAvatarDataUrl("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=");
+        throw new Error("expected parseAvatarDataUrl to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(AvatarValidationError);
+        expect((err as AvatarValidationError).code).toBe("invalid_type");
+      }
+    });
+  });
+
+  describe("when the decoded payload is empty", () => {
+    it("throws an empty validation error", () => {
+      try {
+        parseAvatarDataUrl("data:image/png;base64,");
+        throw new Error("expected parseAvatarDataUrl to throw");
+      } catch (err) {
+        expect((err as AvatarValidationError).code).toBe("empty");
+      }
+    });
+  });
+
+  describe("when the payload exceeds the maximum size", () => {
+    it("throws a file_too_large validation error", () => {
+      const tooBig = Buffer.alloc(AVATAR_MAX_BYTES + 1, 0).toString("base64");
+      try {
+        parseAvatarDataUrl(`data:image/png;base64,${tooBig}`);
+        throw new Error("expected parseAvatarDataUrl to throw");
+      } catch (err) {
+        expect((err as AvatarValidationError).code).toBe("file_too_large");
+      }
+    });
+  });
+});
+
+describe("buildAvatarUrl", () => {
+  describe("given a project id and stored-object id", () => {
+    it("builds the same-origin user-avatar serve path", () => {
+      expect(buildAvatarUrl({ projectId: "proj_1", id: "so_abc" })).toBe(
+        "/api/user-avatar/proj_1/so_abc",
+      );
+    });
+  });
+});

--- a/langwatch/src/server/user-avatar/__tests__/avatar.unit.test.ts
+++ b/langwatch/src/server/user-avatar/__tests__/avatar.unit.test.ts
@@ -1,15 +1,27 @@
 import { describe, expect, it } from "vitest";
 import {
+  AVATAR_ALLOWED_MEDIA_TYPES,
   AVATAR_MAX_BYTES,
   AvatarValidationError,
   buildAvatarUrl,
   parseAvatarDataUrl,
+  safeAvatarMediaType,
 } from "../avatar";
 
 // A 1x1 transparent PNG, base64 — smallest valid real image payload.
 const PNG_1x1_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
 const PNG_1x1_DATA_URL = `data:image/png;base64,${PNG_1x1_BASE64}`;
+
+// Minimal buffers carrying only each format's magic-byte signature — enough
+// to exercise MAGIC_BYTE_CHECKS without needing a fully valid, decodable image.
+const JPEG_MAGIC_BYTES_DATA_URL = `data:image/jpeg;base64,${Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]).toString("base64")}`;
+const GIF_MAGIC_BYTES_DATA_URL = `data:image/gif;base64,${Buffer.from("GIF89a", "latin1").toString("base64")}`;
+const WEBP_MAGIC_BYTES_DATA_URL = `data:image/webp;base64,${Buffer.concat([
+  Buffer.from("RIFF", "latin1"),
+  Buffer.from([0, 0, 0, 0]),
+  Buffer.from("WEBP", "latin1"),
+]).toString("base64")}`;
 
 describe("parseAvatarDataUrl", () => {
   describe("given a valid PNG data URL", () => {
@@ -76,6 +88,66 @@ describe("parseAvatarDataUrl", () => {
       } catch (err) {
         expect((err as AvatarValidationError).code).toBe("file_too_large");
       }
+    });
+  });
+
+  describe("given content whose magic bytes match the declared type", () => {
+    it.each([
+      ["image/jpeg", JPEG_MAGIC_BYTES_DATA_URL],
+      ["image/gif", GIF_MAGIC_BYTES_DATA_URL],
+      ["image/webp", WEBP_MAGIC_BYTES_DATA_URL],
+    ])("accepts a %s payload", (mediaType, dataUrl) => {
+      const result = parseAvatarDataUrl(dataUrl);
+      expect(result.mediaType).toBe(mediaType);
+    });
+  });
+
+  describe("when the decoded bytes don't match the declared type", () => {
+    it("throws a content_mismatch validation error for non-image bytes", () => {
+      const plainTextAsPng = `data:image/png;base64,${Buffer.from(
+        "hello world, this is not an image",
+      ).toString("base64")}`;
+      try {
+        parseAvatarDataUrl(plainTextAsPng);
+        throw new Error("expected parseAvatarDataUrl to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(AvatarValidationError);
+        expect((err as AvatarValidationError).code).toBe("content_mismatch");
+      }
+    });
+
+    it("throws a content_mismatch validation error for a real image of a different type", () => {
+      // Real PNG bytes declared as image/jpeg — the signature doesn't match.
+      const pngDeclaredAsJpeg = `data:image/jpeg;base64,${PNG_1x1_BASE64}`;
+      try {
+        parseAvatarDataUrl(pngDeclaredAsJpeg);
+        throw new Error("expected parseAvatarDataUrl to throw");
+      } catch (err) {
+        expect((err as AvatarValidationError).code).toBe("content_mismatch");
+      }
+    });
+  });
+});
+
+describe("safeAvatarMediaType", () => {
+  describe("given a media type in the avatar allowlist", () => {
+    it.each(AVATAR_ALLOWED_MEDIA_TYPES)("returns %s unchanged", (mediaType) => {
+      expect(safeAvatarMediaType(mediaType)).toBe(mediaType);
+    });
+  });
+
+  describe("given a media type outside the avatar allowlist", () => {
+    it("coerces image/svg+xml to application/octet-stream even though it is image/*", () => {
+      // The general stored-objects allowlist (isReadbackSafe) passes the whole
+      // image/ family, including svg+xml; this route pins to the narrower
+      // avatar-specific list regardless of that broader allowlist.
+      expect(safeAvatarMediaType("image/svg+xml")).toBe(
+        "application/octet-stream",
+      );
+    });
+
+    it("coerces a non-image type to application/octet-stream", () => {
+      expect(safeAvatarMediaType("text/html")).toBe("application/octet-stream");
     });
   });
 });

--- a/langwatch/src/server/user-avatar/avatar.service.ts
+++ b/langwatch/src/server/user-avatar/avatar.service.ts
@@ -14,9 +14,12 @@
  * `removeAvatar` simply clears `User.image` (bytes are content-addressed and
  * may be shared via dedup, so they are not eagerly deleted).
  *
- * SSO precedence: better-auth only writes `User.image` on user *create*, never
- * on re-login, so an uploaded photo is never clobbered by a later SSO sign-in.
- * No guard is needed here; the invariant is covered by tests.
+ * SSO precedence: better-auth writes `User.image` only on user *create* (via
+ * `mapProfileToUser`), never on re-login — no provider opts into overwriting
+ * profile info on sign-in — so an uploaded photo is never clobbered by a later
+ * SSO sign-in. No guard is needed here; that "no override-on-sign-in" invariant
+ * is locked by better-auth/__tests__/index.test.ts and specified in
+ * specs/settings/user-avatar.feature.
  *
  * Collaborators are injected (with production defaults) so the orchestration is
  * unit-testable without ClickHouse or the EE workspace service.

--- a/langwatch/src/server/user-avatar/avatar.service.ts
+++ b/langwatch/src/server/user-avatar/avatar.service.ts
@@ -1,0 +1,141 @@
+/**
+ * UserAvatarService — sets and clears a user's uploaded avatar.
+ *
+ * Flow for `setAvatar`:
+ *   1. Validate + decode the client's base64 image (pure, in `avatar.ts`).
+ *   2. Resolve the user's personal-workspace project (idempotent `ensure`) —
+ *      the tenant the avatar bytes are stored under. The avatar is user-owned
+ *      identity, so it lives under the user's own project, not any shared one.
+ *   3. Store the bytes via the content-addressed stored-objects service, tagged
+ *      with the `user_avatar` purpose and a user owner.
+ *   4. Persist the same-origin serve URL to `User.image` — the single field
+ *      every avatar surface already resolves through.
+ *
+ * `removeAvatar` simply clears `User.image` (bytes are content-addressed and
+ * may be shared via dedup, so they are not eagerly deleted).
+ *
+ * SSO precedence: better-auth only writes `User.image` on user *create*, never
+ * on re-login, so an uploaded photo is never clobbered by a later SSO sign-in.
+ * No guard is needed here; the invariant is covered by tests.
+ *
+ * Collaborators are injected (with production defaults) so the orchestration is
+ * unit-testable without ClickHouse or the EE workspace service.
+ *
+ * Spec: specs/settings/user-avatar.feature
+ */
+import type { PrismaClient } from "@prisma/client";
+import { PersonalWorkspaceService } from "@ee/governance/services/personalWorkspace.service";
+import { createStoredObjectsService } from "~/server/stored-objects/stored-objects-factory";
+import {
+  AVATAR_OWNER_KIND,
+  AVATAR_PURPOSE,
+  buildAvatarUrl,
+  parseAvatarDataUrl,
+} from "./avatar";
+
+/** Resolves (creating if needed) the personal project the avatar is stored under. */
+type EnsureWorkspaceProject = (args: {
+  userId: string;
+  organizationId: string;
+  displayName?: string | null;
+  displayEmail?: string | null;
+}) => Promise<{ projectId: string }>;
+
+/** Stores avatar bytes and returns the content-addressed object id. */
+type StoreAvatarBytes = (args: {
+  projectId: string;
+  userId: string;
+  mediaType: string;
+  bytes: Buffer;
+}) => Promise<{ id: string }>;
+
+interface UserAvatarServiceDeps {
+  ensureWorkspaceProject?: EnsureWorkspaceProject;
+  storeAvatarBytes?: StoreAvatarBytes;
+}
+
+export class UserAvatarService {
+  private readonly ensureWorkspaceProject: EnsureWorkspaceProject;
+  private readonly storeAvatarBytes: StoreAvatarBytes;
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    deps: UserAvatarServiceDeps = {},
+  ) {
+    this.ensureWorkspaceProject =
+      deps.ensureWorkspaceProject ??
+      (async (args) => {
+        const workspace = await new PersonalWorkspaceService(this.prisma).ensure({
+          userId: args.userId,
+          organizationId: args.organizationId,
+          displayName: args.displayName ?? undefined,
+          displayEmail: args.displayEmail ?? undefined,
+        });
+        return { projectId: workspace.project.id };
+      });
+
+    this.storeAvatarBytes =
+      deps.storeAvatarBytes ??
+      (async ({ projectId, userId, mediaType, bytes }) => {
+        const stored = await createStoredObjectsService({
+          projectId,
+        }).storeFromBytes({
+          projectId,
+          purpose: AVATAR_PURPOSE,
+          ownerKind: AVATAR_OWNER_KIND,
+          ownerId: userId,
+          mediaType,
+          bytes,
+        });
+        return { id: stored.id };
+      });
+  }
+
+  /**
+   * Validates, stores, and sets the user's uploaded avatar. Returns the new
+   * `User.image` URL.
+   *
+   * @throws {AvatarValidationError} for a caller-fixable payload problem.
+   */
+  async setAvatar({
+    userId,
+    organizationId,
+    imageDataUrl,
+    displayName,
+    displayEmail,
+  }: {
+    userId: string;
+    organizationId: string;
+    imageDataUrl: string;
+    displayName?: string | null;
+    displayEmail?: string | null;
+  }): Promise<{ image: string }> {
+    const { mediaType, bytes } = parseAvatarDataUrl(imageDataUrl);
+
+    const { projectId } = await this.ensureWorkspaceProject({
+      userId,
+      organizationId,
+      displayName,
+      displayEmail,
+    });
+
+    const { id } = await this.storeAvatarBytes({
+      projectId,
+      userId,
+      mediaType,
+      bytes,
+    });
+
+    const image = buildAvatarUrl({ projectId, id });
+    await this.prisma.user.update({ where: { id: userId }, data: { image } });
+    return { image };
+  }
+
+  /** Clears the user's avatar so surfaces fall back to SSO photo → initials. */
+  async removeAvatar({ userId }: { userId: string }): Promise<void> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { image: null },
+    });
+  }
+}

--- a/langwatch/src/server/user-avatar/avatar.ts
+++ b/langwatch/src/server/user-avatar/avatar.ts
@@ -21,11 +21,12 @@ export const AVATAR_PURPOSE = "user_avatar";
 export const AVATAR_OWNER_KIND = "user";
 
 /**
- * Max accepted avatar payload, server-side. The client crops + downscales to a
- * small square before upload, so a real avatar is a few KB–tens of KB; 2 MB is
- * generous headroom that still rejects an un-resized full-resolution photo.
+ * Hard cap on the bytes an avatar upload may take, server-side. The client
+ * crops + downscales to a small square first, so a real avatar is only a few
+ * KB–tens of KB; 1 MB is the ceiling we accept (and the same limit the client
+ * enforces on the picked file — see AVATAR_MAX_SOURCE_BYTES).
  */
-export const AVATAR_MAX_BYTES = 2 * 1024 * 1024;
+export const AVATAR_MAX_BYTES = 1 * 1024 * 1024;
 
 /**
  * Image types we accept on upload. Every entry must also be readback-safe

--- a/langwatch/src/server/user-avatar/avatar.ts
+++ b/langwatch/src/server/user-avatar/avatar.ts
@@ -14,10 +14,10 @@
  * Spec: specs/settings/user-avatar.feature
  */
 
-/** stored_objects.purpose tag for user avatars. */
+/** The stored-object "purpose" tag for user avatars. */
 export const AVATAR_PURPOSE = "user_avatar";
 
-/** stored_objects.owner_kind for user avatars — the owner is a User, not a project. */
+/** The stored-object owner kind for user avatars — the owner is a User, not a project. */
 export const AVATAR_OWNER_KIND = "user";
 
 /**

--- a/langwatch/src/server/user-avatar/avatar.ts
+++ b/langwatch/src/server/user-avatar/avatar.ts
@@ -57,7 +57,8 @@ export type AvatarValidationCode =
   | "invalid_data_url"
   | "invalid_type"
   | "empty"
-  | "file_too_large";
+  | "file_too_large"
+  | "content_mismatch";
 
 /**
  * Thrown by {@link parseAvatarDataUrl} for any caller-fixable problem with the
@@ -77,18 +78,57 @@ export class AvatarValidationError extends Error {
 // The base64 group is `*` (not `+`) so an empty payload (`data:image/png;base64,`)
 // still matches here and is reported as the more specific `empty` error below,
 // rather than the generic `invalid_data_url`.
-const DATA_URL_RE = /^data:([a-z0-9.+-]+\/[a-z0-9.+-]+);base64,([a-z0-9+/=\s]*)$/i;
+const DATA_URL_RE =
+  /^data:([a-z0-9.+-]+\/[a-z0-9.+-]+);base64,([a-z0-9+/=\s]*)$/i;
 
 function isAllowedMediaType(mediaType: string): mediaType is AvatarMediaType {
   return (AVATAR_ALLOWED_MEDIA_TYPES as readonly string[]).includes(mediaType);
 }
 
 /**
+ * Per-type magic-byte signature checks, keyed by the declared media type.
+ *
+ * Defense-in-depth: the checks above only validate the client-declared type in
+ * the `data:` prefix, so without this a caller who bypasses the browser's
+ * canvas re-encode (e.g. calling `user.setAvatar` directly) could tag
+ * arbitrary bytes as `image/png` and use avatar storage as an untyped blob
+ * store. The response headers (`nosniff` + a `sandbox` CSP) already prevent
+ * the bytes from ever executing as active content regardless, so this check
+ * protects data integrity, not the XSS boundary.
+ */
+const MAGIC_BYTE_CHECKS: Record<AvatarMediaType, (bytes: Buffer) => boolean> = {
+  "image/png": (bytes) =>
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a,
+  "image/jpeg": (bytes) =>
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff,
+  "image/gif": (bytes) =>
+    bytes.length >= 6 &&
+    (bytes.subarray(0, 6).toString("latin1") === "GIF87a" ||
+      bytes.subarray(0, 6).toString("latin1") === "GIF89a"),
+  "image/webp": (bytes) =>
+    bytes.length >= 12 &&
+    bytes.subarray(0, 4).toString("latin1") === "RIFF" &&
+    bytes.subarray(8, 12).toString("latin1") === "WEBP",
+};
+
+/**
  * Parses and validates a base64 image data URL (e.g. produced by the client
  * canvas resize step) into raw bytes + media type.
  *
  * @throws {AvatarValidationError} on a malformed data URL, a disallowed image
- *   type, empty bytes, or a payload over {@link AVATAR_MAX_BYTES}.
+ *   type, empty bytes, a payload over {@link AVATAR_MAX_BYTES}, or decoded
+ *   bytes whose magic-byte signature doesn't match the declared type.
  */
 export function parseAvatarDataUrl(dataUrl: string): {
   mediaType: AvatarMediaType;
@@ -134,7 +174,30 @@ export function parseAvatarDataUrl(dataUrl: string): {
     );
   }
 
+  if (!MAGIC_BYTE_CHECKS[mediaType](bytes)) {
+    throw new AvatarValidationError(
+      "content_mismatch",
+      `The file's content doesn't match its declared type (${mediaType}).`,
+    );
+  }
+
   return { mediaType, bytes };
+}
+
+/**
+ * Resolves the Content-Type an avatar HTTP response may echo verbatim.
+ *
+ * Pinned directly to {@link AVATAR_ALLOWED_MEDIA_TYPES} rather than the
+ * broader stored-objects `isReadbackSafe` (which passes the whole `image/`
+ * prefix family, including `image/svg+xml`). The avatar serve route is
+ * readable by any authenticated user platform-wide (see
+ * src/app/api/user-avatar), so its Content-Type allowlist stays independently
+ * pinned to exactly the four types this module accepts on upload — a future
+ * widening of the general stored-objects allowlist can never widen what this
+ * route serves inline.
+ */
+export function safeAvatarMediaType(mediaType: string): string {
+  return isAllowedMediaType(mediaType) ? mediaType : "application/octet-stream";
 }
 
 /**

--- a/langwatch/src/server/user-avatar/avatar.ts
+++ b/langwatch/src/server/user-avatar/avatar.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure helpers + constants for user-uploaded avatars.
+ *
+ * A user's avatar is platform-level identity (it renders wherever a person is
+ * shown, across every project the user touches), so it is deliberately NOT
+ * tied to the tenant/project stored-objects taxonomy the way trace media is.
+ * We still reuse the stored-objects byte machinery, but tag the object with a
+ * dedicated purpose and a user owner, and serve it through a route that any
+ * authenticated user can read (see src/app/api/user-avatar).
+ *
+ * This module holds only pure logic (constants, data-URL parsing/validation,
+ * URL construction) so it is trivially unit-testable without storage or DB.
+ *
+ * Spec: specs/settings/user-avatar.feature
+ */
+
+/** stored_objects.purpose tag for user avatars. */
+export const AVATAR_PURPOSE = "user_avatar";
+
+/** stored_objects.owner_kind for user avatars — the owner is a User, not a project. */
+export const AVATAR_OWNER_KIND = "user";
+
+/**
+ * Max accepted avatar payload, server-side. The client crops + downscales to a
+ * small square before upload, so a real avatar is a few KB–tens of KB; 2 MB is
+ * generous headroom that still rejects an un-resized full-resolution photo.
+ */
+export const AVATAR_MAX_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Image types we accept on upload. Every entry must also be readback-safe
+ * (`isReadbackSafe` in stored-objects/safe-media-types.ts) so the serve route
+ * can echo the Content-Type without coercing it to octet-stream.
+ */
+export const AVATAR_ALLOWED_MEDIA_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+] as const;
+
+export type AvatarMediaType = (typeof AVATAR_ALLOWED_MEDIA_TYPES)[number];
+
+export type AvatarValidationCode =
+  | "invalid_data_url"
+  | "invalid_type"
+  | "empty"
+  | "file_too_large";
+
+/**
+ * Thrown by {@link parseAvatarDataUrl} for any caller-fixable problem with the
+ * uploaded payload. The tRPC layer maps this to a BAD_REQUEST with a message
+ * the settings UI can show verbatim.
+ */
+export class AvatarValidationError extends Error {
+  constructor(
+    readonly code: AvatarValidationCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AvatarValidationError";
+  }
+}
+
+// The base64 group is `*` (not `+`) so an empty payload (`data:image/png;base64,`)
+// still matches here and is reported as the more specific `empty` error below,
+// rather than the generic `invalid_data_url`.
+const DATA_URL_RE = /^data:([a-z0-9.+-]+\/[a-z0-9.+-]+);base64,([a-z0-9+/=\s]*)$/i;
+
+function isAllowedMediaType(mediaType: string): mediaType is AvatarMediaType {
+  return (AVATAR_ALLOWED_MEDIA_TYPES as readonly string[]).includes(mediaType);
+}
+
+/**
+ * Parses and validates a base64 image data URL (e.g. produced by the client
+ * canvas resize step) into raw bytes + media type.
+ *
+ * @throws {AvatarValidationError} on a malformed data URL, a disallowed image
+ *   type, empty bytes, or a payload over {@link AVATAR_MAX_BYTES}.
+ */
+export function parseAvatarDataUrl(dataUrl: string): {
+  mediaType: AvatarMediaType;
+  bytes: Buffer;
+} {
+  const match = DATA_URL_RE.exec(dataUrl.trim());
+  if (!match) {
+    throw new AvatarValidationError(
+      "invalid_data_url",
+      "Expected a base64-encoded image data URL.",
+    );
+  }
+
+  const mediaType = match[1]!.toLowerCase();
+  if (!isAllowedMediaType(mediaType)) {
+    throw new AvatarValidationError(
+      "invalid_type",
+      `Unsupported image type "${mediaType}". Allowed: ${AVATAR_ALLOWED_MEDIA_TYPES.join(", ")}.`,
+    );
+  }
+
+  // Strip any embedded whitespace/newlines the encoder may have inserted so
+  // the byte-length check reflects real decoded size, not base64 padding.
+  const bytes = Buffer.from(match[2]!.replace(/\s+/g, ""), "base64");
+  if (bytes.length === 0) {
+    throw new AvatarValidationError("empty", "The image is empty.");
+  }
+  if (bytes.length > AVATAR_MAX_BYTES) {
+    throw new AvatarValidationError(
+      "file_too_large",
+      `Image is too large (max ${Math.round(AVATAR_MAX_BYTES / 1024 / 1024)} MB).`,
+    );
+  }
+
+  return { mediaType, bytes };
+}
+
+/**
+ * Builds the same-origin, authenticated URL persisted to `User.image` and
+ * rendered directly in every avatar `<img src>`. Carries both the project the
+ * bytes live under (needed for the content-addressed `getById`) and the
+ * stored-object id. The serve route re-checks the object's purpose + owner, so
+ * the embedded projectId is not a trust boundary.
+ */
+export function buildAvatarUrl({
+  projectId,
+  id,
+}: {
+  projectId: string;
+  id: string;
+}): string {
+  return `/api/user-avatar/${encodeURIComponent(projectId)}/${encodeURIComponent(id)}`;
+}

--- a/langwatch/src/server/user-avatar/avatar.ts
+++ b/langwatch/src/server/user-avatar/avatar.ts
@@ -22,11 +22,12 @@ export const AVATAR_OWNER_KIND = "user";
 
 /**
  * Hard cap on the bytes an avatar upload may take, server-side. The client
- * crops + downscales to a small square first, so a real avatar is only a few
- * KB–tens of KB; 1 MB is the ceiling we accept (and the same limit the client
- * enforces on the picked file — see AVATAR_MAX_SOURCE_BYTES).
+ * crops + downscales to a small square first, so a stored avatar is only a few
+ * KB–tens of KB; 8 MB is the ceiling we accept — matching LinkedIn's
+ * profile-photo limit — and the same limit the client enforces on the picked
+ * file (see AVATAR_MAX_SOURCE_BYTES).
  */
-export const AVATAR_MAX_BYTES = 1 * 1024 * 1024;
+export const AVATAR_MAX_BYTES = 8 * 1024 * 1024;
 
 /**
  * Upper bound on the raw `data:` URL length we accept, so an oversized payload

--- a/langwatch/src/server/user-avatar/avatar.ts
+++ b/langwatch/src/server/user-avatar/avatar.ts
@@ -29,6 +29,16 @@ export const AVATAR_OWNER_KIND = "user";
 export const AVATAR_MAX_BYTES = 1 * 1024 * 1024;
 
 /**
+ * Upper bound on the raw `data:` URL length we accept, so an oversized payload
+ * is rejected before the regex scans it or any Buffer is allocated. base64
+ * inflates bytes by 4/3; the extra 256 covers the `data:<type>;base64,` prefix
+ * and any incidental whitespace. Used both here and by the tRPC input schema
+ * (`user.setAvatar`) as a first-line `.max()` guard.
+ */
+export const AVATAR_MAX_DATA_URL_LENGTH =
+  Math.ceil(AVATAR_MAX_BYTES / 3) * 4 + 256;
+
+/**
  * Image types we accept on upload. Every entry must also be readback-safe
  * (`isReadbackSafe` in stored-objects/safe-media-types.ts) so the serve route
  * can echo the Content-Type without coercing it to octet-stream.
@@ -83,7 +93,18 @@ export function parseAvatarDataUrl(dataUrl: string): {
   mediaType: AvatarMediaType;
   bytes: Buffer;
 } {
-  const match = DATA_URL_RE.exec(dataUrl.trim());
+  const trimmed = dataUrl.trim();
+  // Reject an oversized payload up front — before the regex scans it or any
+  // Buffer is decoded — so a huge user-controlled string can't allocate memory
+  // just to be rejected. The precise decoded-size check still runs below.
+  if (trimmed.length > AVATAR_MAX_DATA_URL_LENGTH) {
+    throw new AvatarValidationError(
+      "file_too_large",
+      `Image is too large (max ${Math.round(AVATAR_MAX_BYTES / 1024 / 1024)} MB).`,
+    );
+  }
+
+  const match = DATA_URL_RE.exec(trimmed);
   if (!match) {
     throw new AvatarValidationError(
       "invalid_data_url",


### PR DESCRIPTION
Closes #6086

## The story — a photo that follows you everywhere

Today a person's picture in LangWatch comes **only** from their SSO/OAuth provider. Email/password users get a gray monogram forever, and SSO users are stuck with whatever their identity provider returns. There's no way to set your own.

This PR lets anyone upload their own photo from account settings. And because every avatar in the product resolves the single `User.image` field through one fallback chain — **uploaded → SSO → initials → silhouette** — that photo then shows up **everywhere a person appears**.

Here's the whole journey, end-to-end (real screenshots from the running app).

### 1 · Before — just a monogram, with a pencil to change it

Your profile (**My Settings → Profile**) shows a gray “HA” with a small **pencil badge** on it — the photo itself is the edit control. Everywhere else (header, member lists, trace authors) is initials too.

<img src="https://github.com/langwatch/langwatch/blob/avatar-6086-assets/pr6086/01-before-initials.png?raw=true&v=2" width="760">

### 2 · Click the pencil → live, square-cropped preview

Click the **pencil on your photo** and pick an image (**PNG / JPG / WebP / GIF, up to 8 MB**). It's center-cropped to a square and downscaled to 256px **in the browser** — so what's stored is a few KB — and you see exactly what you'll get *before* committing. The buttons become **Save photo / Cancel**.

<img src="https://github.com/langwatch/langwatch/blob/avatar-6086-assets/pr6086/02-crop-preview.png?raw=true&v=2" width="760">

### 3 · Save — and it's instantly you, everywhere

Hit **Save photo**. The profile updates **and the header avatar (top-right) changes live in the same click** — no refresh — because the session refetches. The pencil stays for next time, and a **Remove** appears.

<img src="https://github.com/langwatch/langwatch/blob/avatar-6086-assets/pr6086/03-after-header-and-profile.png?raw=true&v=2" width="760">

### 4 · Your teammates see it — Members

Your photo now renders next to your name in the organization members list. (A pending invite with no account yet still falls back to initials, exactly as it should.)

<img src="https://github.com/langwatch/langwatch/blob/avatar-6086-assets/pr6086/04-members-list.png?raw=true&v=2" width="760">

### 5 · …and inside Traces

Open a trace and leave an annotation — your photo is the **author avatar** on it, so a teammate reviewing that trace sees who left the note.

<img src="https://github.com/langwatch/langwatch/blob/avatar-6086-assets/pr6086/05-trace-annotation-author.jpeg?raw=true&v=2" width="760">

---

## What changed

**The edit affordance** — the “Upload photo” button is gone; the **avatar itself is the click target**, with a pencil badge overlaid (`role="button"` + keyboard handler for a11y). Save/Cancel (preview) and Remove remain.

**Size limit** — the accepted upload is capped at **8 MB** (matching LinkedIn's profile-photo limit), enforced both client-side on the picked file (immediate “too large” feedback) and server-side on the payload.

**Storage & serving**
- A new `user_avatar` purpose on the existing S3-backed stored-objects service; the bytes are owned by the *user*, not a tenant (an avatar is platform identity, not tenant data).
- A dedicated `GET /api/user-avatar/:projectId/:id` route, readable by **any authenticated user** (avatars must be visible to teammates across projects) but that **only ever serves avatar objects** — so this broad-read route can never be used to reach the trace/scenario media that `/api/files` gates behind `traces:view`. (Still strictly *more* private than today, where SSO photos are fetched from fully public CDN URLs.)
- The stored-object HTTP hardening (Content-Type coercion + `nosniff`/CSP headers) was extracted into a shared module rather than copy-pasted.

**Upload** — service-layered `user.setAvatar` / `user.removeAvatar` tRPC mutations. The client crops + resizes to 256px, so base64-over-tRPC stays tiny.

**Precedence** — better-auth writes `User.image` only on user *create*, never on re-login, so an uploaded photo is **never clobbered** by a later SSO sign-in (locked with a test).

**Rendering everywhere** — added an optional `image` to the shared `RandomColorAvatar` via a new canonical `UserAvatar` (image → initials → silhouette), then threaded `image` into every person-avatar surface that previously dropped it: header account menu, org members, teams, groups, role-bindings, all trace/annotation surfaces (header chips, per-turn, annotations view, cards, expected-outputs, comment composer, queue members), the participant picker, the optimization-studio version-history author, and the annotation-queue author clusters.
  - The **prompt** version-history popover is intentionally left to open PR #6083, which owns it (avoids a merge conflict).

## Testing / QA

- `pnpm typecheck` — clean across all changed files.
- `pnpm test:unit` — data-URL validation, service orchestration, `/api/files` regression after the shared-helper extraction.
- Spec: `specs/settings/user-avatar.feature`.
- **Manually verified end-to-end in the running app** — every screenshot above is the real feature (pencil → crop → save → header / profile / members / traces), including removing and re-adding.

## Notes

- Self-hosted deployments without S3 fall back to the local-filesystem object store; that path (`LANGWATCH_LOCAL_STORAGE_PATH`, default `/var/lib/langwatch/objects`) must be writable — the Helm chart provisions it. (Surfaced during QA on a bare dev box where the default path wasn't writable.)
- Screenshots are hosted on the `avatar-6086-assets` branch — delete it after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom avatar upload with preview, square cropping, save, change, and remove, including file-type and size validation.
  * Introduced a hardened avatar-serving endpoint with authentication, streaming, caching headers, and per-caller rate limiting.
  * Updated the UI to consistently display uploaded/SSO avatars via a shared avatar component, with initials fallback when no image is available.
  * Uploaded avatars now take precedence over SSO photos and are not overwritten by later sign-ins.
* **Bug Fixes**
  * Avatar loading now retries correctly when the image URL changes after a previous failure.
* **Tests**
  * Added end-to-end avatar spec plus unit coverage for avatar upload/removal, parsing/URL building, and SSO precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->