### PR TITLE
fix(prompts): show full version commit messages, describe local-file updates

### DIFF
--- a/langwatch/src/prompts/VersionHistoryListPopover.tsx
+++ b/langwatch/src/prompts/VersionHistoryListPopover.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   HStack,
   Separator,
-  Spacer,
   Spinner,
   Tag,
   Text,
@@ -163,9 +162,15 @@ function VersionHistoryItem({
       <HStack width="full" gap={3} align="start">
         <VersionNumberBox version={data} minWidth="48px" />
         <VStack align="start" width="full" gap={1}>
-          <HStack width="full">
-            <HStack gap={2} flex={1} minWidth={0}>
-              <Text fontWeight={600} fontSize="13px" lineClamp={1}>
+          <HStack width="full" align="start">
+            <HStack gap={2} flex={1} minWidth={0} align="start">
+              <Text
+                fontWeight={600}
+                fontSize="13px"
+                wordBreak="break-word"
+                flex="1"
+                minWidth={0}
+              >
                 {data.commitMessage}
               </Text>
               {isCurrent && (
@@ -179,7 +184,6 @@ function VersionHistoryItem({
                 </Tag.Root>
               )}
             </HStack>
-            <Spacer />
             {/* Discard changes button - reloads current version (same as "Load this version") */}
             {isCurrent && hasUnsavedChanges && (
               <Button

--- a/langwatch/src/prompts/VersionHistoryListPopover.tsx
+++ b/langwatch/src/prompts/VersionHistoryListPopover.tsx
@@ -170,6 +170,10 @@ function VersionHistoryItem({
                 wordBreak="break-word"
                 flex="1"
                 minWidth={0}
+                // Generous enough that the 200-char message the Save Version
+                // dialog allows never clips; still bounds a pathological
+                // message set via the API/SDK, which has no length limit.
+                lineClamp={8}
               >
                 {data.commitMessage}
               </Text>

--- a/langwatch/src/prompts/__tests__/VersionHistoryListPopover.test.tsx
+++ b/langwatch/src/prompts/__tests__/VersionHistoryListPopover.test.tsx
@@ -338,7 +338,15 @@ describe("VersionHistoryListPopover", () => {
           renderWithChakra(<VersionHistoryListPopover configId="config-1" />);
           await openPopover();
 
-          expect(screen.getByText(longMessage)).toBeInTheDocument();
+          const messageEl = screen.getByText(longMessage);
+          // Full-text presence is supplementary: the DOM keeps the whole
+          // string even under a 1-line clamp, so it alone can't prove the
+          // text isn't visually cut off. Assert the clamp actually applied
+          // is the generous multi-line bound, not the single-line clamp
+          // that caused the "2-3 words" bug.
+          const style = getComputedStyle(messageEl);
+          expect(style.getPropertyValue("-webkit-line-clamp")).toBe("8");
+          expect(style.getPropertyValue("overflow")).toBe("hidden");
         });
       });
     });

--- a/langwatch/src/prompts/__tests__/VersionHistoryListPopover.test.tsx
+++ b/langwatch/src/prompts/__tests__/VersionHistoryListPopover.test.tsx
@@ -306,6 +306,44 @@ describe("VersionHistoryListPopover", () => {
     });
   });
 
+  describe("commit message of a version", () => {
+    const openPopover = async () => {
+      const historyButton = screen.getAllByTestId("version-history-button")[0]!;
+      fireEvent.click(historyButton);
+      await waitFor(() => {
+        expect(screen.getByText("Prompt Version History")).toBeInTheDocument();
+      });
+    };
+
+    describe("given the commit message is long", () => {
+      describe("when displaying the version history", () => {
+        /** @scenario "A long commit message is shown in full" */
+        it("renders the full message text", async () => {
+          const longMessage =
+            "Lowered temperature to reduce hallucination rate on the summarizer step, per eval run #82, and switched to the mini model to cut latency";
+
+          mockUseQuery.mockReturnValue({
+            data: [
+              {
+                id: "config-1",
+                versionId: "version-1",
+                version: 1,
+                commitMessage: longMessage,
+                author: { name: "User 1" },
+              },
+            ] as unknown as VersionedPrompt[],
+            isLoading: false,
+          });
+
+          renderWithChakra(<VersionHistoryListPopover configId="config-1" />);
+          await openPopover();
+
+          expect(screen.getByText(longMessage)).toBeInTheDocument();
+        });
+      });
+    });
+  });
+
   describe("author of a version", () => {
     const openPopover = async () => {
       const historyButton = screen.getAllByTestId("version-history-button")[0]!;

--- a/langwatch/src/server/prompt-config/__tests__/describe-local-file-update.unit.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/describe-local-file-update.unit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { describeLocalFileUpdate } from "../describe-local-file-update";
+
+describe("describeLocalFileUpdate()", () => {
+  describe("given no differences were computed", () => {
+    it("falls back to the generic message", () => {
+      expect(describeLocalFileUpdate(undefined)).toBe(
+        "Updated from local file",
+      );
+      expect(describeLocalFileUpdate([])).toBe("Updated from local file");
+    });
+  });
+
+  describe("given the sync changed a single field", () => {
+    it("names that field in the commit message", () => {
+      expect(
+        describeLocalFileUpdate(["model: gpt-4 → gpt-4o-mini"]),
+      ).toBe("Updated from local file (model: gpt-4 → gpt-4o-mini)");
+    });
+  });
+
+  describe("given the sync changed multiple fields", () => {
+    it("lists every changed field in the commit message", () => {
+      expect(
+        describeLocalFileUpdate([
+          "model: gpt-4 → gpt-4o-mini",
+          "temperature: 0.7 → 0.3",
+          "prompt content differs",
+        ]),
+      ).toBe(
+        "Updated from local file (model: gpt-4 → gpt-4o-mini; temperature: 0.7 → 0.3; prompt content differs)",
+      );
+    });
+  });
+});

--- a/langwatch/src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
@@ -204,6 +204,7 @@ describe("PromptService", () => {
     });
 
     describe("when local content differs from remote and no commit message is provided", () => {
+      /** @scenario "Syncing local changes without a commit message describes what changed" */
       it("describes the changed fields instead of a generic message", async () => {
         const existingPrompt = buildExistingPrompt();
 

--- a/langwatch/src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
@@ -203,6 +203,98 @@ describe("PromptService", () => {
       });
     });
 
+    describe("when local content differs from remote and no commit message is provided", () => {
+      it("describes the changed fields instead of a generic message", async () => {
+        const existingPrompt = buildExistingPrompt();
+
+        vi.spyOn(promptService, "getPromptByIdOrHandle").mockResolvedValue(
+          existingPrompt,
+        );
+
+        const updateSpy = vi
+          .spyOn(promptService, "updatePrompt")
+          .mockResolvedValue(existingPrompt);
+
+        mockRepository.compareConfigContent.mockReturnValue({
+          isEqual: false,
+          differences: [
+            "model: gpt-4 → gpt-4o-mini",
+            "temperature: 0.7 → 0.3",
+          ],
+        });
+
+        const localConfigData = {
+          model: "gpt-4o-mini",
+          prompt: "You are a helpful assistant",
+          messages: [{ role: "user" as const, content: "Hello {{input}}" }],
+          inputs: [{ identifier: "input", type: "str" }],
+          outputs: [{ identifier: "output", type: "str" }],
+          temperature: 0.3,
+        };
+
+        const result = await promptService.syncPrompt({
+          idOrHandle: "test-prompt",
+          localConfigData: localConfigData as any,
+          localVersion: 1,
+          projectId,
+          organizationId,
+        });
+
+        expect(result.action).toBe("updated");
+        expect(updateSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              commitMessage:
+                "Updated from local file (model: gpt-4 → gpt-4o-mini; temperature: 0.7 → 0.3)",
+            }),
+          }),
+        );
+      });
+
+      it("keeps the caller's commit message when one is provided", async () => {
+        const existingPrompt = buildExistingPrompt();
+
+        vi.spyOn(promptService, "getPromptByIdOrHandle").mockResolvedValue(
+          existingPrompt,
+        );
+
+        const updateSpy = vi
+          .spyOn(promptService, "updatePrompt")
+          .mockResolvedValue(existingPrompt);
+
+        mockRepository.compareConfigContent.mockReturnValue({
+          isEqual: false,
+          differences: ["model: gpt-4 → gpt-4o-mini"],
+        });
+
+        const localConfigData = {
+          model: "gpt-4o-mini",
+          prompt: "You are a helpful assistant",
+          messages: [{ role: "user" as const, content: "Hello {{input}}" }],
+          inputs: [{ identifier: "input", type: "str" }],
+          outputs: [{ identifier: "output", type: "str" }],
+          temperature: 0.7,
+        };
+
+        await promptService.syncPrompt({
+          idOrHandle: "test-prompt",
+          localConfigData: localConfigData as any,
+          localVersion: 1,
+          projectId,
+          organizationId,
+          commitMessage: "Switch to the cheaper model",
+        });
+
+        expect(updateSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              commitMessage: "Switch to the cheaper model",
+            }),
+          }),
+        );
+      });
+    });
+
     describe("when prompt does not exist and is created", () => {
       it("does not double-transform camelCase params through transformToDbFormat", async () => {
         vi.spyOn(promptService, "getPromptByIdOrHandle").mockResolvedValue(

--- a/langwatch/src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
@@ -293,6 +293,50 @@ describe("PromptService", () => {
           }),
         );
       });
+
+      it("describes runtime-parameter changes even when config content is unchanged", async () => {
+        const existingPrompt = buildExistingPrompt({
+          parameters: { max_tokens: 500 },
+        });
+
+        vi.spyOn(promptService, "getPromptByIdOrHandle").mockResolvedValue(
+          existingPrompt,
+        );
+
+        const updateSpy = vi
+          .spyOn(promptService, "updatePrompt")
+          .mockResolvedValue(existingPrompt);
+
+        // Config content itself is identical - only runtime parameters differ.
+        mockRepository.compareConfigContent.mockReturnValue({ isEqual: true });
+
+        const localConfigData = {
+          model: "gpt-4",
+          prompt: "You are a helpful assistant",
+          messages: [{ role: "user" as const, content: "Hello {{input}}" }],
+          inputs: [{ identifier: "input", type: "str" }],
+          outputs: [{ identifier: "output", type: "str" }],
+          temperature: 0.7,
+        };
+
+        const result = await promptService.syncPrompt({
+          idOrHandle: "test-prompt",
+          localConfigData: localConfigData as any,
+          localVersion: 1,
+          projectId,
+          organizationId,
+          parameters: { max_tokens: 1000 },
+        });
+
+        expect(result.action).toBe("updated");
+        expect(updateSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              commitMessage: "Updated from local file (max_tokens: 1000 → 500)",
+            }),
+          }),
+        );
+      });
     });
 
     describe("when prompt does not exist and is created", () => {

--- a/langwatch/src/server/prompt-config/describe-local-file-update.ts
+++ b/langwatch/src/server/prompt-config/describe-local-file-update.ts
@@ -1,0 +1,13 @@
+/**
+ * Auto-generated commit message for a version created by syncing local
+ * (CLI/SDK) config data over an existing remote version, used when the
+ * caller did not supply their own commit message. Reuses the differences
+ * already computed by `compareConfigContent` so the message says what
+ * actually changed instead of a generic "Updated from local file".
+ */
+export function describeLocalFileUpdate(differences: string[] | undefined): string {
+  if (!differences?.length) {
+    return "Updated from local file";
+  }
+  return `Updated from local file (${differences.join("; ")})`;
+}

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -1150,7 +1150,10 @@ export class PromptService {
         // Content differs - create new version
         const allDifferences = [
           ...(comparison.differences ?? []),
-          ...diffRuntimeParameters(params.parameters, existingPrompt.parameters),
+          ...diffRuntimeParameters({
+            localParameters: params.parameters,
+            remoteParameters: existingPrompt.parameters,
+          }),
         ];
         const updatedPrompt = await this.updatePrompt({
           idOrHandle: existingPrompt.id,

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -14,6 +14,7 @@ import {
   type outputsSchema,
   type promptingTechniqueSchema,
 } from "~/prompts/schemas/field-schemas";
+import { describeLocalFileUpdate } from "./describe-local-file-update";
 import { SchemaVersion } from "./enums";
 import {
   HandleGenerationError,
@@ -1151,7 +1152,8 @@ export class PromptService {
           projectId,
           data: {
             authorId,
-            commitMessage: commitMessage ?? "Updated from local file",
+            commitMessage:
+              commitMessage ?? describeLocalFileUpdate(comparison.differences),
             ...this.transformToDbFormat(resolvedConfigData),
             schemaVersion: SchemaVersion.V1_0,
             parameters: params.parameters,

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -34,6 +34,7 @@ import {
 } from "./repositories";
 import { PromptTagAssignmentRepository, TagValidationError } from "./repositories/llm-config-tag.repository";
 import {
+  diffRuntimeParameters,
   type getLatestConfigVersionSchema,
   LATEST_SCHEMA_VERSION,
   type LatestConfigVersionSchema,
@@ -1147,13 +1148,16 @@ export class PromptService {
         return { action: "up_to_date", prompt: existingPrompt };
       } else {
         // Content differs - create new version
+        const allDifferences = [
+          ...(comparison.differences ?? []),
+          ...diffRuntimeParameters(params.parameters, existingPrompt.parameters),
+        ];
         const updatedPrompt = await this.updatePrompt({
           idOrHandle: existingPrompt.id,
           projectId,
           data: {
             authorId,
-            commitMessage:
-              commitMessage ?? describeLocalFileUpdate(comparison.differences),
+            commitMessage: commitMessage ?? describeLocalFileUpdate(allDifferences),
             ...this.transformToDbFormat(resolvedConfigData),
             schemaVersion: SchemaVersion.V1_0,
             parameters: params.parameters,

--- a/langwatch/src/server/prompt-config/repositories/__tests__/diffRuntimeParameters.unit.test.ts
+++ b/langwatch/src/server/prompt-config/repositories/__tests__/diffRuntimeParameters.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { diffRuntimeParameters } from "../llm-config-version-schema";
+
+describe("diffRuntimeParameters()", () => {
+  describe("given both sides are equal", () => {
+    it("returns no differences", () => {
+      expect(
+        diffRuntimeParameters({ max_tokens: 500 }, { max_tokens: 500 }),
+      ).toEqual([]);
+    });
+
+    it("treats undefined/null/empty object as equivalent", () => {
+      expect(diffRuntimeParameters(undefined, null)).toEqual([]);
+      expect(diffRuntimeParameters(null, {})).toEqual([]);
+    });
+  });
+
+  describe("given a shared key changed value", () => {
+    it("describes the change in a → b order", () => {
+      expect(
+        diffRuntimeParameters({ max_tokens: 1000 }, { max_tokens: 500 }),
+      ).toEqual(["max_tokens: 1000 → 500"]);
+    });
+  });
+
+  describe("given a key only present on one side", () => {
+    it("describes a key added on the a side", () => {
+      expect(diffRuntimeParameters({ seed: 42 }, {})).toEqual([
+        "seed: 42 → undefined",
+      ]);
+    });
+
+    it("describes a key only present on the b side", () => {
+      expect(diffRuntimeParameters({}, { seed: 42 })).toEqual([
+        "seed: undefined → 42",
+      ]);
+    });
+  });
+
+  describe("given multiple keys changed", () => {
+    it("describes every changed key", () => {
+      const result = diffRuntimeParameters(
+        { max_tokens: 1000, top_p: 0.9 },
+        { max_tokens: 500, top_p: 0.9 },
+      );
+      expect(result).toEqual(["max_tokens: 1000 → 500"]);
+    });
+  });
+});

--- a/langwatch/src/server/prompt-config/repositories/__tests__/diffRuntimeParameters.unit.test.ts
+++ b/langwatch/src/server/prompt-config/repositories/__tests__/diffRuntimeParameters.unit.test.ts
@@ -44,7 +44,7 @@ describe("diffRuntimeParameters()", () => {
             localParameters: { seed: 42 },
             remoteParameters: {},
           }),
-        ).toEqual(["seed: 42 → undefined"]);
+        ).toEqual(["seed: 42 → unset"]);
       });
 
       it("describes a key only present on the remote side", () => {
@@ -53,7 +53,7 @@ describe("diffRuntimeParameters()", () => {
             localParameters: {},
             remoteParameters: { seed: 42 },
           }),
-        ).toEqual(["seed: undefined → 42"]);
+        ).toEqual(["seed: unset → 42"]);
       });
     });
 
@@ -67,6 +67,37 @@ describe("diffRuntimeParameters()", () => {
           "max_tokens: 1000 → 500",
           "top_p: 0.9 → 0.5",
         ]);
+      });
+    });
+
+    describe("given a nested value with the same data in a different key order", () => {
+      it("returns no differences", () => {
+        expect(
+          diffRuntimeParameters({
+            localParameters: { reasoning: { effort: "high", budget: 100 } },
+            remoteParameters: { reasoning: { budget: 100, effort: "high" } },
+          }),
+        ).toEqual([]);
+      });
+    });
+
+    describe("given a key explicitly set to undefined versus entirely missing", () => {
+      it("distinguishes local explicit-undefined from remote missing", () => {
+        expect(
+          diffRuntimeParameters({
+            localParameters: { seed: undefined },
+            remoteParameters: {},
+          }),
+        ).toEqual(["seed: undefined → unset"]);
+      });
+
+      it("distinguishes local missing from remote explicit-undefined", () => {
+        expect(
+          diffRuntimeParameters({
+            localParameters: {},
+            remoteParameters: { seed: undefined },
+          }),
+        ).toEqual(["seed: unset → undefined"]);
       });
     });
   });

--- a/langwatch/src/server/prompt-config/repositories/__tests__/diffRuntimeParameters.unit.test.ts
+++ b/langwatch/src/server/prompt-config/repositories/__tests__/diffRuntimeParameters.unit.test.ts
@@ -2,48 +2,72 @@ import { describe, expect, it } from "vitest";
 import { diffRuntimeParameters } from "../llm-config-version-schema";
 
 describe("diffRuntimeParameters()", () => {
-  describe("given both sides are equal", () => {
-    it("returns no differences", () => {
-      expect(
-        diffRuntimeParameters({ max_tokens: 500 }, { max_tokens: 500 }),
-      ).toEqual([]);
+  describe("when comparing local and remote runtime parameters", () => {
+    describe("given both sides are equal", () => {
+      it("returns no differences", () => {
+        expect(
+          diffRuntimeParameters({
+            localParameters: { max_tokens: 500 },
+            remoteParameters: { max_tokens: 500 },
+          }),
+        ).toEqual([]);
+      });
+
+      it("treats undefined/null/empty object as equivalent", () => {
+        expect(
+          diffRuntimeParameters({
+            localParameters: undefined,
+            remoteParameters: null,
+          }),
+        ).toEqual([]);
+        expect(
+          diffRuntimeParameters({ localParameters: null, remoteParameters: {} }),
+        ).toEqual([]);
+      });
     });
 
-    it("treats undefined/null/empty object as equivalent", () => {
-      expect(diffRuntimeParameters(undefined, null)).toEqual([]);
-      expect(diffRuntimeParameters(null, {})).toEqual([]);
-    });
-  });
-
-  describe("given a shared key changed value", () => {
-    it("describes the change in a → b order", () => {
-      expect(
-        diffRuntimeParameters({ max_tokens: 1000 }, { max_tokens: 500 }),
-      ).toEqual(["max_tokens: 1000 → 500"]);
-    });
-  });
-
-  describe("given a key only present on one side", () => {
-    it("describes a key added on the a side", () => {
-      expect(diffRuntimeParameters({ seed: 42 }, {})).toEqual([
-        "seed: 42 → undefined",
-      ]);
+    describe("given a shared key changed value", () => {
+      it("describes the change in local → remote order", () => {
+        expect(
+          diffRuntimeParameters({
+            localParameters: { max_tokens: 1000 },
+            remoteParameters: { max_tokens: 500 },
+          }),
+        ).toEqual(["max_tokens: 1000 → 500"]);
+      });
     });
 
-    it("describes a key only present on the b side", () => {
-      expect(diffRuntimeParameters({}, { seed: 42 })).toEqual([
-        "seed: undefined → 42",
-      ]);
-    });
-  });
+    describe("given a key only present on one side", () => {
+      it("describes a key added on the local side", () => {
+        expect(
+          diffRuntimeParameters({
+            localParameters: { seed: 42 },
+            remoteParameters: {},
+          }),
+        ).toEqual(["seed: 42 → undefined"]);
+      });
 
-  describe("given multiple keys changed", () => {
-    it("describes every changed key", () => {
-      const result = diffRuntimeParameters(
-        { max_tokens: 1000, top_p: 0.9 },
-        { max_tokens: 500, top_p: 0.9 },
-      );
-      expect(result).toEqual(["max_tokens: 1000 → 500"]);
+      it("describes a key only present on the remote side", () => {
+        expect(
+          diffRuntimeParameters({
+            localParameters: {},
+            remoteParameters: { seed: 42 },
+          }),
+        ).toEqual(["seed: undefined → 42"]);
+      });
+    });
+
+    describe("given multiple keys changed", () => {
+      it("describes every changed key", () => {
+        const result = diffRuntimeParameters({
+          localParameters: { max_tokens: 1000, top_p: 0.9 },
+          remoteParameters: { max_tokens: 500, top_p: 0.5 },
+        });
+        expect(result).toEqual([
+          "max_tokens: 1000 → 500",
+          "top_p: 0.9 → 0.5",
+        ]);
+      });
     });
   });
 });

--- a/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
@@ -150,6 +150,26 @@ export function runtimeParametersEqual(a: unknown, b: unknown): boolean {
   );
 }
 
+/**
+ * Per-key description of runtime parameters that differ between `a` and `b`,
+ * in the same `a → b` direction as `runtimeParametersEqual`'s arguments.
+ */
+export function diffRuntimeParameters(a: unknown, b: unknown): string[] {
+  const paramsA = (a ?? {}) as RuntimeParameters;
+  const paramsB = (b ?? {}) as RuntimeParameters;
+  const keys = new Set([...Object.keys(paramsA), ...Object.keys(paramsB)]);
+
+  const differences: string[] = [];
+  for (const key of keys) {
+    if (JSON.stringify(paramsA[key]) !== JSON.stringify(paramsB[key])) {
+      differences.push(
+        `${key}: ${JSON.stringify(paramsA[key])} → ${JSON.stringify(paramsB[key])}`,
+      );
+    }
+  }
+  return differences;
+}
+
 export function isValidHandle(handle: string): boolean {
   // npm package name pattern: allows lowercase letters, numbers, hyphens, and optionally one slash
   const npmPackagePattern = /^[a-z0-9_-]+(?:\/[a-z0-9_-]+)?$/;

--- a/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
@@ -151,6 +151,17 @@ export function runtimeParametersEqual(a: unknown, b: unknown): boolean {
 }
 
 /**
+ * Renders a single side of a runtime parameter diff. A key entirely absent
+ * from the object ("unset") must read differently from that key being
+ * present with an explicit `undefined` value, even though
+ * `JSON.stringify(undefined)` can't tell them apart on its own.
+ */
+function describeRuntimeParamValue(hasKey: boolean, value: unknown): string {
+  if (!hasKey) return "unset";
+  return value === undefined ? "undefined" : JSON.stringify(value);
+}
+
+/**
  * Per-key description of runtime parameters that differ between
  * `localParameters` and `remoteParameters`, in the same direction as
  * `runtimeParametersEqual`'s arguments. Canonicalizes nested values with
@@ -180,7 +191,7 @@ export function diffRuntimeParameters({
 
     if (!equal) {
       differences.push(
-        `${key}: ${hasA ? JSON.stringify(paramsA[key]) : "undefined"} → ${hasB ? JSON.stringify(paramsB[key]) : "undefined"}`,
+        `${key}: ${describeRuntimeParamValue(hasA, paramsA[key])} → ${describeRuntimeParamValue(hasB, paramsB[key])}`,
       );
     }
   }

--- a/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
@@ -151,19 +151,36 @@ export function runtimeParametersEqual(a: unknown, b: unknown): boolean {
 }
 
 /**
- * Per-key description of runtime parameters that differ between `a` and `b`,
- * in the same `a → b` direction as `runtimeParametersEqual`'s arguments.
+ * Per-key description of runtime parameters that differ between
+ * `localParameters` and `remoteParameters`, in the same direction as
+ * `runtimeParametersEqual`'s arguments. Canonicalizes nested values with
+ * `sortKeysDeep` (same as `runtimeParametersEqual`) so key reordering alone
+ * isn't reported as a change, and treats a key entirely missing from one
+ * side as distinct from that key being explicitly set to `undefined`.
  */
-export function diffRuntimeParameters(a: unknown, b: unknown): string[] {
-  const paramsA = (a ?? {}) as RuntimeParameters;
-  const paramsB = (b ?? {}) as RuntimeParameters;
+export function diffRuntimeParameters({
+  localParameters,
+  remoteParameters,
+}: {
+  localParameters: unknown;
+  remoteParameters: unknown;
+}): string[] {
+  const paramsA = (localParameters ?? {}) as RuntimeParameters;
+  const paramsB = (remoteParameters ?? {}) as RuntimeParameters;
   const keys = new Set([...Object.keys(paramsA), ...Object.keys(paramsB)]);
 
   const differences: string[] = [];
   for (const key of keys) {
-    if (JSON.stringify(paramsA[key]) !== JSON.stringify(paramsB[key])) {
+    const hasA = key in paramsA;
+    const hasB = key in paramsB;
+    const equal =
+      hasA === hasB &&
+      JSON.stringify(sortKeysDeep(paramsA[key])) ===
+        JSON.stringify(sortKeysDeep(paramsB[key]));
+
+    if (!equal) {
       differences.push(
-        `${key}: ${JSON.stringify(paramsA[key])} → ${JSON.stringify(paramsB[key])}`,
+        `${key}: ${hasA ? JSON.stringify(paramsA[key]) : "undefined"} → ${hasB ? JSON.stringify(paramsB[key]) : "undefined"}`,
       );
     }
   }

--- a/specs/prompts/prompt-version-detail-visibility.feature
+++ b/specs/prompts/prompt-version-detail-visibility.feature
@@ -1,0 +1,33 @@
+Feature: Prompt version history message detail
+  As a LangWatch user reviewing a prompt's version history
+  I want to see what actually happened in each version
+  So that I don't have to guess or open every version to find out
+
+  # Bound to:
+  # - src/prompts/__tests__/VersionHistoryListPopover.test.tsx
+  #   ("when a version's commit message is long")
+  # - src/server/prompt-config/__tests__/describe-local-file-update.unit.test.ts
+  # - src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
+  #   ("when syncing local changes without an explicit commit message")
+  #
+  # Previously the version list clamped every commit message to a single
+  # line, so anything past the first few words was hidden behind an
+  # ellipsis regardless of how descriptive the author had been. Separately,
+  # syncing a prompt from a local file without an explicit commit message
+  # always recorded the generic "Updated from local file", even though the
+  # actual changed fields were already known internally.
+
+  Background:
+    Given I am logged into project "my-project"
+    And I open the version history for a prompt
+
+  @integration
+  Scenario: A long commit message is shown in full
+    Given a version has a commit message longer than a single line
+    Then that version's commit message is shown in full, not cut off
+
+  @integration
+  Scenario: Syncing local changes without a commit message describes what changed
+    Given a prompt is synced from a local file with no commit message provided
+    And the local file changes the model and the temperature
+    Then the recorded commit message names the fields that changed


### PR DESCRIPTION
## Summary

Prompt Version History showed only 2-3 words of a version's commit message, no matter how descriptive it was.

- **The commit message was clamped to one line, and a competing flex `Spacer` left that line only a sliver wide** whenever the current-version tag or "Discard local changes" button was present (`VersionHistoryListPopover.tsx`). `Spacer` has `flex: 1`, same as the message row, so the two split the available width evenly instead of the message getting it. Combined with `lineClamp={1}`, this meant even a full 200-character description showed as `Upda…`.
- **Syncing a prompt from a local file without an explicit commit message always recorded the generic "Updated from local file"**, even though `compareConfigContent` already computes exactly what changed (model, temperature, prompt, messages, etc.) for CLI conflict reporting. That diff just wasn't reused for the commit message. Now: `Updated from local file (model: gpt-4o → gpt-4o-mini; temperature: 0.7 → 0.3)`.

Other auto-generated messages ("Initial version", `Duplicated from "x"`, `Restore from version N`) already carry meaningful context and were left as-is — this only enriches the one generic case where a real diff was sitting right there unused.

### Before

![before](https://github.com/langwatch/langwatch/blob/assets/prompt-version-detail-screenshots/prompt-version-detail/before.png?raw=true)

### After

![after](https://github.com/langwatch/langwatch/blob/assets/prompt-version-detail-screenshots/prompt-version-detail/after.png?raw=true)

### After, with the "Discard local changes" button present

The `Spacer` removal is the risky part of this change (it's what used to push that button to the row's right edge), so this confirms the layout still holds with the button in play:

![after with discard button](https://github.com/langwatch/langwatch/blob/assets/prompt-version-detail-screenshots/prompt-version-detail/after-with-discard-button.png?raw=true)

## Test plan

- [x] `describe-local-file-update.unit.test.ts` — new pure-function tests for the diff-to-message formatting
- [x] `syncPrompt.unit.test.ts` — enriched message wired through `syncPrompt`, explicit commit messages still take priority
- [x] `VersionHistoryListPopover.test.tsx` — long commit message renders in full
- [x] New feature file `specs/prompts/prompt-version-detail-visibility.feature`
- [x] `pnpm typecheck` clean
- [x] Manually verified in a running dev server via Playwright (screenshots above), including the layout with the "Discard local changes" button present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Prompt version history now shows long commit messages in full using wrapped, multi-line rendering (no truncation).
  - When syncing prompt updates from a local file without a custom commit message, the generated commit message now highlights which fields/runtime parameters changed.

- **Bug Fixes**
  - Improved the version-history popover header layout so the “discard local changes” action no longer has an unintended gap.

- **Tests**
  - Added/extended integration and unit tests to verify full long-message rendering and detailed, field-level commit message generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->