### PR TITLE
feat(coding-agent): fold Claude Cowork sessions via a registration-style agent registry

### DIFF
--- a/dev/docs/adr/056-coding-agent-pipeline-session-aggregate.md
+++ b/dev/docs/adr/056-coding-agent-pipeline-session-aggregate.md
@@ -6,10 +6,12 @@
 
 **Store corrected by:** [ADR-066](./066-projection-clickhouse-cached-store.md) — the session-aggregate store must read its full state back from ClickHouse. The no-read-back store (`get()` returns null, forcing an `event_log` refold on every cache miss and out-of-order delivery) caused a production outage and is forbidden. The pipeline shape and session-key decisions in this ADR stand.
 
+**Amended (2026-07-24):** the per-agent vocabulary moved from one grown-together normalization module into a **registration-style agent registry** (`coding-agent-processing/agents/` — one pure definition per agent: identity predicate, name prefixes, alias quirks; ordered, first match wins), mirroring the trace-canonicalisation extractor pattern. And the agent roster gained a sixth member: **`claude_cowork`** (Claude Cowork — the Claude desktop runtime in a VM; same event vocabulary as Claude Code, identified only by `service.name: cowork`, events-only export, model calls and tool runs folded from its `api_request`/`tool_result` events). Note the literal `claude_cowork` also names a governance IngestionSource type ([ADR-018](./018-governance-unified-observability-substrate.md)) — same product, different subsystem: governance ingests Cowork's span-shaped payloads org-wide; this pipeline folds its per-project session events.
+
 ## Context
 
-Coding agents (Claude Code, opencode, Codex, Gemini CLI, Copilot) emit three
-OTLP signals, and each correlates differently. These facts are verified
+Coding agents (Claude Code, Claude Cowork, opencode, Codex, Gemini CLI,
+Copilot) emit three OTLP signals, and each correlates differently. These facts are verified
 empirically (live telemetry + agent source), not assumed:
 
 - **Spans** carry real trace context. One session's spans share one wire
@@ -108,10 +110,13 @@ aggregate is the **session**, not the trace.
      session aggregate. It works for any trace, coding-agent or not.
    Neither surface can break the other.
 
-7. **Provider vocabulary lives here.** The per-agent adapters (token-bucket
-   spelling, non-additive buckets like Codex `total` / Gemini `tool`, MCP
-   name parsing from tool names) are single-sourced in this pipeline's
-   normalization services. Nothing agent-specific remains in
+7. **Provider vocabulary lives here.** The per-agent knowledge (identity
+   predicates, name prefixes, alias quirks) is single-sourced in this
+   pipeline's `agents/` registry — one pure definition per agent, folded
+   into shared tables by the normalization engine (see the 2026-07-24
+   amendment above). Cross-agent spelling folds (token buckets,
+   non-additive buckets like Codex `total` / Gemini `tool`, MCP name
+   parsing) stay in the engine. Nothing agent-specific remains in
    `trace-processing`.
 
 8. **Synthesis stays, generically.** Logs-only sources (a logs exporter with

--- a/langwatch/src/components/me/tiles/assistantIcons.ts
+++ b/langwatch/src/components/me/tiles/assistantIcons.ts
@@ -10,6 +10,7 @@
  */
 export const ASSISTANT_KINDS = [
   "claude_code",
+  "claude_cowork",
   "codex",
   "gemini",
   "opencode",
@@ -38,6 +39,13 @@ export const ASSISTANT_PRESETS: Record<
 > = {
   claude_code: {
     label: "Claude Code",
+    iconUrl: "/images/external-icons/claude-code.svg",
+    darkModeInvert: false,
+  },
+  // Same brand mark as Claude Code — Cowork is the desktop runtime of the
+  // same product family, and no separate icon asset exists for it.
+  claude_cowork: {
+    label: "Claude Cowork",
     iconUrl: "/images/external-icons/claude-code.svg",
     darkModeInvert: false,
   },

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/terminalView/TerminalView.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/terminalView/TerminalView.tsx
@@ -561,6 +561,7 @@ const AGENT_BANNERS: Record<
   { name: string; mark: MarkSpec }
 > = {
   claude_code: { name: "Claude Code", mark: claudeGradientMark(MARK_ROWS) },
+  claude_cowork: { name: "Claude Cowork", mark: claudeGradientMark(MARK_ROWS) },
   opencode: { name: "opencode", mark: OPENCODE_MARK },
   codex: { name: "Codex", mark: CODEX_MARK },
   gemini_cli: { name: "Gemini CLI", mark: GEMINI_MARK },

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/terminalView/sessionBanner.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/terminalView/sessionBanner.ts
@@ -16,6 +16,7 @@ import {
 /** Which agent's mark and name the banner draws. */
 export type BannerAgent =
   | "claude_code"
+  | "claude_cowork"
   | "opencode"
   | "codex"
   | "gemini_cli"
@@ -42,6 +43,9 @@ function detectBannerAgent({
   spans: SpanDetail[];
 }): BannerAgent {
   const service = serviceName.toLowerCase();
+  // Before the claude check: Cowork is the Claude runtime under another
+  // service name, so "claude" alone must not claim it.
+  if (service.includes("cowork")) return "claude_cowork";
   if (service.includes("claude")) return "claude_code";
   if (service.includes("opencode")) return "opencode";
   if (service.includes("codex")) return "codex";

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/logSummary.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/logSummary.ts
@@ -1,8 +1,6 @@
 import type { TraceLogRecordDto } from "~/server/api/routers/tracesV2";
-import {
-  type CodingAgentEvent,
-  normalizeEventName,
-} from "~/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-normalization";
+import type { CodingAgentEvent } from "~/server/event-sourcing/pipelines/coding-agent-processing/agents/_types";
+import { normalizeEventName } from "~/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-normalization";
 
 /**
  * A one-line, human summary for a log record whose `event.name` is one of the

--- a/langwatch/src/features/traces-v2/utils/terminalOrigin.ts
+++ b/langwatch/src/features/traces-v2/utils/terminalOrigin.ts
@@ -19,6 +19,7 @@ export interface TerminalOriginSignals {
 const CODING_AGENT_SERVICE_MARKERS = [
   "claude-code",
   "claude_code",
+  "cowork",
   "opencode",
   "codex",
   "gemini-cli",

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -1679,6 +1679,7 @@ export const tracesV2Router = createTRPCRouter({
         logs: logs.map((row) => ({
           timestampMs: row.timeUnixMs,
           attributes: (row.attributes ?? {}) as Record<string, unknown>,
+          serviceName: row.resourceAttributes?.["service.name"] ?? null,
         })),
       });
     }),

--- a/langwatch/src/server/app-layer/traces/coding-agent-transcript.derivation.ts
+++ b/langwatch/src/server/app-layer/traces/coding-agent-transcript.derivation.ts
@@ -121,6 +121,11 @@ export interface CodingAgentTranscript {
 export interface TranscriptLogRecord {
   timestampMs: number;
   attributes: Record<string, unknown>;
+  /**
+   * Resource-level service.name, when the caller has it. The only signal
+   * that separates Cowork from the Claude Code runtime it reuses.
+   */
+  serviceName?: string | null;
 }
 
 const MODEL_CALL_SPAN_NAMES = new Set([
@@ -578,7 +583,10 @@ function detectAgentFrom({
   logs: TranscriptLogRecord[];
 }): CodingAgent {
   for (const span of spans) {
-    const agent = detectCodingAgent({ recordName: span.name });
+    const agent = detectCodingAgent({
+      recordName: span.name,
+      serviceName: span.serviceName,
+    });
     if (agent !== "unknown") return agent;
     // opencode's spans are named by the Vercel AI SDK (`ai.streamText`), so
     // the name carries no agent; its request-header attributes do.
@@ -596,6 +604,7 @@ function detectAgentFrom({
   for (const log of logs) {
     const agent = detectCodingAgent({
       recordName: readString(log.attributes, "event.name"),
+      serviceName: log.serviceName,
     });
     if (agent !== "unknown") return agent;
   }

--- a/langwatch/src/server/app-layer/traces/coding-agent-transcript.derivation.ts
+++ b/langwatch/src/server/app-layer/traces/coding-agent-transcript.derivation.ts
@@ -583,10 +583,7 @@ function detectAgentFrom({
   logs: TranscriptLogRecord[];
 }): CodingAgent {
   for (const span of spans) {
-    const agent = detectCodingAgent({
-      recordName: span.name,
-      serviceName: span.serviceName,
-    });
+    const agent = detectCodingAgent({ recordName: span.name });
     if (agent !== "unknown") return agent;
     // opencode's spans are named by the Vercel AI SDK (`ai.streamText`), so
     // the name carries no agent; its request-header attributes do.

--- a/langwatch/src/server/app-layer/traces/coding-agent-transcript.derivation.ts
+++ b/langwatch/src/server/app-layer/traces/coding-agent-transcript.derivation.ts
@@ -1,6 +1,6 @@
 import type { SpanDetail } from "~/server/api/routers/tracesV2.schemas";
+import type { CodingAgent } from "~/server/event-sourcing/pipelines/coding-agent-processing/agents/_types";
 import {
-  type CodingAgent,
   detectCodingAgent,
   normalizeEventName,
   parseMcpToolName,

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/_types.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/_types.ts
@@ -1,0 +1,130 @@
+/**
+ * Agent Definition Types
+ *
+ * The coding-agent pipeline knows each agent through one pure, declarative
+ * definition (see the sibling files) registered in `./index.ts` — the same
+ * registration shape the trace canonicalisation extractors use. The engine in
+ * `../services/coding-agent-normalization.ts` folds the registry into the
+ * shared vocabulary; nothing outside `agents/` compares vendor literals.
+ */
+
+/** The agents we can name. `unknown` is not a failure — it is an honest answer. */
+export type CodingAgent =
+  | "claude_code"
+  | "claude_cowork"
+  | "opencode"
+  | "codex"
+  | "gemini_cli"
+  | "copilot"
+  | "unknown";
+
+/**
+ * The canonical event kinds. Every agent's event name maps onto one of these, or
+ * onto nothing (which is fine — an event we have no use for costs one lookup).
+ */
+export type CodingAgentEvent =
+  | "user_prompt"
+  | "assistant_response"
+  | "api_request"
+  | "api_response"
+  | "api_error"
+  | "api_refusal"
+  | "retries_exhausted"
+  | "tool_result"
+  | "tool_decision"
+  | "compaction"
+  | "permission_mode_changed"
+  | "skill_activated"
+  | "mcp_server_connection"
+  | "hook_execution_complete"
+  | "at_mention"
+  | "internal_error"
+  | "session_created"
+  | "session_idle"
+  | "session_error"
+  | "subtask_invoked"
+  | "commit";
+
+/** The canonical metric kinds, same idea as the event kinds. */
+export type CodingAgentMetric =
+  | "tool_call"
+  | "lines_of_code"
+  | "commit"
+  | "pull_request"
+  | "edit_decision"
+  | "active_time"
+  | "token_usage"
+  | "cost_usage";
+
+/**
+ * Token buckets. Every agent spells these differently, and the distinction
+ * that actually costs money (a cache READ is cheap, a cache WRITE costs more
+ * than fresh input) is spelled differently by every one of them.
+ */
+export type TokenType =
+  | "input"
+  | "output"
+  | "cache_read"
+  | "cache_creation"
+  | "reasoning";
+
+/**
+ * The identity signal for one record, pre-lowercased by the engine so every
+ * definition matches on the same normalized strings.
+ */
+export interface CodingAgentSignal {
+  /** A span name, metric name, or event name — whichever we have. */
+  name: string;
+  /** Instrumentation scope name. */
+  scope: string;
+  /** Resource-level service.name. */
+  service: string;
+}
+
+/**
+ * Does any of the three signals say this needle? The shared match primitive:
+ * a namespaced record name (`<needle>.`), or a scope / service that mentions
+ * the needle anywhere.
+ */
+export function signalSays(signal: CodingAgentSignal, needle: string): boolean {
+  return (
+    signal.name.startsWith(`${needle}.`) ||
+    signal.scope.includes(needle) ||
+    signal.service.includes(needle)
+  );
+}
+
+/**
+ * One agent, declaratively. Pure data and pure predicates — a definition
+ * never reads state, never writes, and is exercised only through the engine.
+ *
+ * Registration is ordered (see `CODING_AGENT_REGISTRY`): the first definition
+ * whose `matches` returns true names the record.
+ */
+export interface CodingAgentDefinition {
+  id: Exclude<CodingAgent, "unknown">;
+
+  /** Identity predicate over the pre-lowercased signal. */
+  matches(signal: CodingAgentSignal): boolean;
+
+  /**
+   * Name namespaces this agent prefixes onto its event/metric names, stripped
+   * before vocabulary matching. Longest-first where one contains another.
+   */
+  namePrefixes: readonly string[];
+
+  /**
+   * Vendor-specific event-name aliases (post-strip, dot-flattened) beyond the
+   * standard vocabulary the engine owns.
+   */
+  eventAliases?: Readonly<Record<string, CodingAgentEvent>>;
+
+  /** Vendor-specific metric aliases beyond the standard vocabulary. */
+  metricAliases?: Readonly<Record<string, CodingAgentMetric>>;
+
+  /**
+   * If the agent encodes the tool name in its SPAN NAME rather than an
+   * attribute, this resolves it; return null when the span is not a tool span.
+   */
+  toolNameFromSpanName?(spanName: string): string | null;
+}

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/_types.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/_types.ts
@@ -127,4 +127,12 @@ export interface CodingAgentDefinition {
    * attribute, this resolves it; return null when the span is not a tool span.
    */
   toolNameFromSpanName?(spanName: string): string | null;
+
+  /**
+   * True when the agent's telemetry is events-only (no spans): the session
+   * fold then folds model calls and tool runs from its LOG events. This is
+   * the double-count gate — an agent with this flag must never also emit
+   * the equivalent spans into the pipeline.
+   */
+  logsOnly?: boolean;
 }

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/claudeCode.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/claudeCode.ts
@@ -1,0 +1,16 @@
+import { type CodingAgentDefinition, signalSays } from "./_types";
+
+/**
+ * Claude Code (CLI). Namespaces its event and metric names under
+ * `claude_code.`, with scope `com.anthropic.claude_code.events` — the bare
+ * `anthropic` scope match catches records whose names arrive un-namespaced.
+ *
+ * Registered AFTER claude_cowork: Cowork runs this same runtime, so the
+ * anthropic scope alone must not claim a record whose service says cowork.
+ */
+export const claudeCodeAgent: CodingAgentDefinition = {
+  id: "claude_code",
+  matches: (signal) =>
+    signalSays(signal, "claude_code") || signal.scope.includes("anthropic"),
+  namePrefixes: ["claude_code."],
+};

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/claudeCowork.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/claudeCowork.ts
@@ -15,4 +15,7 @@ export const claudeCoworkAgent: CodingAgentDefinition = {
   id: "claude_cowork",
   matches: (signal) => signalSays(signal, "cowork"),
   namePrefixes: ["claude_cowork.", "cowork."],
+  // Cowork exports events over the logs protocol; spans only via a beta
+  // flag. The session fold folds its model calls and tool runs from events.
+  logsOnly: true,
 };

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/claudeCowork.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/claudeCowork.ts
@@ -1,0 +1,18 @@
+import { type CodingAgentDefinition, signalSays } from "./_types";
+
+/**
+ * Claude Cowork — the Claude desktop runtime working in a VM. Its telemetry
+ * is Claude Code's event vocabulary (same events, same content-capture
+ * knobs, `session.id` on every record), so nothing about the NAMES
+ * distinguishes it; the SERVICE identity does: it exports with
+ * `service.name: cowork` (and `terminal.type: non-interactive` on events).
+ *
+ * Registered FIRST — before claude_code — because its scope may say
+ * anthropic and its event names may carry the `claude_code.` namespace;
+ * the more specific service signal must win.
+ */
+export const claudeCoworkAgent: CodingAgentDefinition = {
+  id: "claude_cowork",
+  matches: (signal) => signalSays(signal, "cowork"),
+  namePrefixes: ["claude_cowork.", "cowork."],
+};

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/codex.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/codex.ts
@@ -1,0 +1,23 @@
+import { type CodingAgentDefinition, signalSays } from "./_types";
+
+/**
+ * Codex. Uses whatever `service_name` it was configured with — there is no
+ * stable scope string — so the record NAME (`codex.*`) is the signal.
+ * Has no lines-of-code and no cost metric at all; its cost must be priced
+ * from tokens, so there is nothing more to map here.
+ */
+export const codexAgent: CodingAgentDefinition = {
+  id: "codex",
+  matches: (signal) => signalSays(signal, "codex"),
+  namePrefixes: ["codex."],
+
+  eventAliases: {
+    // Codex names its shell outcome differently but means "the tool ran".
+    sandbox_outcome: "tool_result",
+  },
+
+  metricAliases: {
+    // Codex spells its token metric differently, and reports it per turn.
+    "turn.token_usage": "token_usage",
+  },
+};

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/copilot.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/copilot.ts
@@ -1,0 +1,19 @@
+import { type CodingAgentDefinition, signalSays } from "./_types";
+
+/**
+ * GitHub Copilot CLI. Namespaces under the ORG, not the product
+ * (`github.copilot.`). Emits its lifecycle events as SPAN EVENTS rather
+ * than log records; the aliases below map them so they fold the same way
+ * if they ever arrive as logs.
+ */
+export const copilotAgent: CodingAgentDefinition = {
+  id: "copilot",
+  matches: (signal) => signalSays(signal, "copilot"),
+  // Longest first: `github.copilot.` must strip before bare `copilot.`.
+  namePrefixes: ["github.copilot.", "copilot."],
+
+  eventAliases: {
+    session_compaction_complete: "compaction",
+    skill_invoked: "skill_activated",
+  },
+};

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/geminiCli.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/geminiCli.ts
@@ -1,0 +1,25 @@
+import { type CodingAgentDefinition, signalSays } from "./_types";
+
+/**
+ * Gemini CLI. Matches on `gemini_cli` and bare `gemini`. Its `tool` token
+ * type (tokens spent on tool DEFINITIONS, already inside the input count)
+ * and `total` bucket are excluded in the engine's shared token folding.
+ */
+export const geminiCliAgent: CodingAgentDefinition = {
+  id: "gemini_cli",
+  matches: (signal) =>
+    signalSays(signal, "gemini_cli") || signalSays(signal, "gemini"),
+  namePrefixes: ["gemini_cli."],
+
+  eventAliases: {
+    // Gemini logs a COMPLETED tool call (it carries success + duration_ms),
+    // which is our tool_result, not a separate "the tool was requested" fact.
+    tool_call: "tool_result",
+    chat_compression: "compaction",
+  },
+
+  metricAliases: {
+    // Gemini: `gemini_cli.lines.changed` with type=added|removed.
+    "lines.changed": "lines_of_code",
+  },
+};

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/index.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/index.ts
@@ -1,0 +1,29 @@
+import type { CodingAgentDefinition } from "./_types";
+import { claudeCodeAgent } from "./claudeCode";
+import { claudeCoworkAgent } from "./claudeCowork";
+import { codexAgent } from "./codex";
+import { copilotAgent } from "./copilot";
+import { geminiCliAgent } from "./geminiCli";
+import { opencodeAgent } from "./opencode";
+
+/**
+ * The agent registry — ordered, first match wins.
+ *
+ * Adding an agent is one definition file plus one entry here; the engine
+ * (`../services/coding-agent-normalization.ts`) folds the registry into the
+ * shared detection, prefix-stripping, and vocabulary tables. Nothing else
+ * changes.
+ *
+ * Order is load-bearing in exactly one place: claude_cowork sits before
+ * claude_code because Cowork reuses the Claude Code runtime (anthropic
+ * scope, claude_code-namespaced names) and only its service identity
+ * distinguishes it — the more specific signal must be asked first.
+ */
+export const CODING_AGENT_REGISTRY: readonly CodingAgentDefinition[] = [
+  claudeCoworkAgent,
+  claudeCodeAgent,
+  opencodeAgent,
+  codexAgent,
+  geminiCliAgent,
+  copilotAgent,
+];

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/index.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/index.ts
@@ -19,11 +19,22 @@ import { opencodeAgent } from "./opencode";
  * scope, claude_code-namespaced names) and only its service identity
  * distinguishes it — the more specific signal must be asked first.
  */
-export const CODING_AGENT_REGISTRY: readonly CodingAgentDefinition[] = [
+export const CODING_AGENT_REGISTRY = [
   claudeCoworkAgent,
   claudeCodeAgent,
   opencodeAgent,
   codexAgent,
   geminiCliAgent,
   copilotAgent,
-];
+] as const satisfies readonly CodingAgentDefinition[];
+
+/**
+ * The agents whose telemetry is events-only (`logsOnly` on the definition) —
+ * membership lives on the registry so adding an agent touches `agents/`
+ * only; the session derivation gates its event-folding on this set.
+ */
+export const LOGS_ONLY_AGENT_IDS: ReadonlySet<string> = new Set(
+  CODING_AGENT_REGISTRY.filter((agent) => agent.logsOnly === true).map(
+    (agent) => agent.id,
+  ),
+);

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/opencode.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/agents/opencode.ts
@@ -1,0 +1,27 @@
+import { type CodingAgentDefinition, signalSays } from "./_types";
+
+const OPENCODE_TOOL_SPAN = "opencode.tool.";
+
+/**
+ * opencode. Scope `com.opencode`; sends BARE event names (`tool_result`,
+ * not `opencode.tool_result`) and dots its session events
+ * (`session.created`) — both handled by the engine's strip/flatten, not
+ * aliases here. Its `lines_of_code.total` cumulative gauge is deliberately
+ * NOT mapped (it sits alongside the `.count` delta; adding both would
+ * double every line).
+ */
+export const opencodeAgent: CodingAgentDefinition = {
+  id: "opencode",
+  matches: (signal) => signalSays(signal, "opencode"),
+  namePrefixes: ["opencode."],
+
+  // opencode puts the tool name IN the span name (`opencode.tool.bash`)
+  // while Claude Code and Codex keep the span name constant and carry the
+  // tool in an attribute. Reading only the attribute loses every opencode
+  // tool; reading only the span name loses everyone else's.
+  toolNameFromSpanName: (spanName) => {
+    if (!spanName.startsWith(OPENCODE_TOOL_SPAN)) return null;
+    const tool = spanName.slice(OPENCODE_TOOL_SPAN.length);
+    return tool.length > 0 ? tool : null;
+  },
+};

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/__tests__/codingAgentSession.foldProjection.unit.test.ts
@@ -89,10 +89,12 @@ function logFactsEvent({
   facts,
   traceId = null,
   timeMs = 1_500,
+  agent = "claude_code",
 }: {
   facts: Record<string, string | number | boolean>;
   traceId?: string | null;
   timeMs?: number;
+  agent?: string;
 }): LogFactsContributedEvent {
   return {
     tenantId: createTenantId("tenant-1"),
@@ -101,7 +103,7 @@ function logFactsEvent({
       tenantId: "tenant-1",
       sessionId: SESSION_ID,
       sessionKeySource: "provider",
-      agent: "claude_code",
+      agent,
       occurredAt: timeMs,
       recordId: `rec-${timeMs}`,
       traceId,
@@ -543,6 +545,109 @@ describe("read-back losslessness (ADR-066)", () => {
       const decoded = codingAgentSessionStateFromRow(row);
 
       expect(decoded).toEqual(state);
+    });
+  });
+
+  describe("when a Cowork session folds from events only", () => {
+    /** @scenario a Cowork session is an agent session */
+    it("folds the model call — tokens, model, cost — from the api_request event", () => {
+      const projection = makeProjection();
+
+      const state = projection.handleCodingAgentSessionLogFactsContributed(
+        logFactsEvent({
+          agent: "claude_cowork",
+          facts: {
+            "event.name": "claude_code.api_request",
+            cost_usd: 0.42,
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_tokens: 1_000,
+            cache_creation_tokens: 200,
+            model: "claude-fable-5",
+            duration_ms: 800,
+          },
+        }),
+        initStateOf(projection),
+      );
+
+      expect(state.agent).toBe("claude_cowork");
+      expect(state.modelCalls).toBe(1);
+      expect(state.inputTokens).toBe(100);
+      expect(state.outputTokens).toBe(50);
+      expect(state.cacheReadTokens).toBe(1_000);
+      expect(state.cacheCreationTokens).toBe(200);
+      expect(state.costUsd).toBeCloseTo(0.42);
+      expect(state.models).toEqual(["claude-fable-5"]);
+    });
+
+    it("folds the tool run — name, count, step — from the tool_result event", () => {
+      const projection = makeProjection();
+
+      const state = projection.handleCodingAgentSessionLogFactsContributed(
+        logFactsEvent({
+          agent: "claude_cowork",
+          timeMs: 2_000,
+          facts: {
+            "event.name": "claude_code.tool_result",
+            tool_name: "Bash",
+            success: "true",
+            duration_ms: 120,
+            tool_result_size_bytes: 2_048,
+          },
+        }),
+        initStateOf(projection),
+      );
+
+      expect(state.toolCalls).toBe(1);
+      expect(state.toolCounts).toEqual({ Bash: 1 });
+      expect(state.steps).toEqual([
+        { name: "Bash", count: 1, startedAtMs: 2_000, failed: false },
+      ]);
+      expect(state.toolResultBytes).toBe(2_048);
+    });
+
+    it("identifies the user from Cowork's account uuid", () => {
+      const projection = makeProjection();
+
+      const state = projection.handleCodingAgentSessionLogFactsContributed(
+        logFactsEvent({
+          agent: "claude_cowork",
+          facts: {
+            "event.name": "claude_code.user_prompt",
+            prompt_length: 12,
+            "user.account_uuid": "0f6f44f5-2f4c-4a5e-9d3b-7f8f2f9a1b2c",
+          },
+        }),
+        initStateOf(projection),
+      );
+
+      expect(state.userId).toBe("0f6f44f5-2f4c-4a5e-9d3b-7f8f2f9a1b2c");
+    });
+  });
+
+  describe("when a span-bearing agent's api_request event contributes", () => {
+    /** @scenario re-delivered telemetry does not inflate a session */
+    it("folds cost only — its tokens arrive on the llm_request span", () => {
+      const projection = makeProjection();
+
+      const state = projection.handleCodingAgentSessionLogFactsContributed(
+        logFactsEvent({
+          agent: "claude_code",
+          facts: {
+            "event.name": "claude_code.api_request",
+            cost_usd: 0.42,
+            input_tokens: 100,
+            output_tokens: 50,
+          },
+        }),
+        initStateOf(projection),
+      );
+
+      expect(state.costUsd).toBeCloseTo(0.42);
+      // The double-count gate: these fold from the span for claude_code.
+      expect(state.modelCalls).toBe(0);
+      expect(state.inputTokens).toBe(0);
+      expect(state.outputTokens).toBe(0);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/projections/codingAgentSession.foldProjection.ts
@@ -202,6 +202,10 @@ export class CodingAgentSessionFoldProjection
     const next = applyLogToCodingAgentSession({
       state,
       attributes: data.facts,
+      // The contribution's own label, not the folded (first-writer-wins)
+      // state's — the logs-only gate must reflect what THIS record is.
+      agent: data.agent,
+      occurredAtMs: data.timeUnixMs,
     });
     return this.withContributionIdentity(
       { ...state, ...next },

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/schemas/contributions.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/schemas/contributions.ts
@@ -36,9 +36,9 @@ const contributionBaseSchema = z.object({
   sessionId: z.string().min(1),
   sessionKeySource: sessionKeySourceSchema,
   /**
-   * The detected agent (`claude_code`, `opencode`, `codex`, `gemini_cli`,
-   * `copilot`). Dispatchers gate on detection, so `unknown` never reaches a
-   * contribution.
+   * The detected agent (`claude_code`, `claude_cowork`, `opencode`, `codex`,
+   * `gemini_cli`, `copilot` — the ids in `../agents/`). Dispatchers gate on
+   * detection, so `unknown` never reaches a contribution.
    */
   agent: z.string().min(1),
   occurredAt: z.number().int().positive(),

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/__tests__/coding-agent-normalization.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/__tests__/coding-agent-normalization.unit.test.ts
@@ -58,6 +58,43 @@ describe("detectCodingAgent", () => {
     });
   });
 
+  describe("given a Cowork record", () => {
+    /**
+     * Cowork is the Claude desktop runtime working in a VM: its events reuse
+     * Claude Code's vocabulary and scope, and only the resource-level
+     * `service.name: cowork` (its docs' Service information table) names it.
+     * The service signal must beat the anthropic-scope fallback.
+     */
+    it("is named by its service, not its runtime's scope", () => {
+      expect(
+        detectCodingAgent({
+          scopeName: "com.anthropic.claude_code.events",
+          recordName: "claude_code.user_prompt",
+          serviceName: "cowork",
+        }),
+      ).toBe("claude_cowork");
+    });
+
+    it("is recognised from the service alone when events arrive bare", () => {
+      expect(
+        detectCodingAgent({
+          recordName: "user_prompt",
+          serviceName: "cowork",
+        }),
+      ).toBe("claude_cowork");
+    });
+
+    it("does not claim Claude Code sessions, which carry no cowork service", () => {
+      expect(
+        detectCodingAgent({
+          scopeName: "com.anthropic.claude_code.events",
+          recordName: "claude_code.user_prompt",
+          serviceName: "claude-code",
+        }),
+      ).toBe("claude_code");
+    });
+  });
+
   describe("given something that is not a coding agent", () => {
     it("says so, rather than guessing", () => {
       expect(detectCodingAgent({ recordName: "openai.chat" })).toBe("unknown");

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/__tests__/coding-agent-normalization.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/__tests__/coding-agent-normalization.unit.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import {
   detectCodingAgent,
   isCodingAgentMetricName,
+  mergeAliasTables,
   normalizeEventName,
   normalizeMetricName,
   normalizeTokenType,
@@ -141,6 +142,49 @@ describe("normalizeEventName", () => {
       expect(normalizeEventName("session.created")).toBe("session_created");
       expect(normalizeEventName("session.idle")).toBe("session_idle");
       expect(normalizeEventName("session.error")).toBe("session_error");
+    });
+  });
+
+  describe("given each agent's vendor-specific event spellings", () => {
+    /**
+     * These aliases live on the agent definitions (agents/*.ts) since the
+     * registry refactor; each is a REAL wire value, so a typo'd key or a
+     * broken registry merge would silently stop mapping a real event.
+     */
+    it("still lands them on the shared facts through the registry merge", () => {
+      expect(normalizeEventName("codex.sandbox_outcome")).toBe("tool_result");
+      expect(
+        normalizeEventName("github.copilot.session_compaction_complete"),
+      ).toBe("compaction");
+      expect(normalizeEventName("github.copilot.skill_invoked")).toBe(
+        "skill_activated",
+      );
+      expect(normalizeEventName("gemini_cli.tool_call")).toBe("tool_result");
+      expect(normalizeEventName("gemini_cli.chat_compression")).toBe(
+        "compaction",
+      );
+      expect(normalizeMetricName("codex.turn.token_usage")).toBe("token_usage");
+      expect(normalizeMetricName("gemini_cli.lines.changed")).toBe(
+        "lines_of_code",
+      );
+    });
+  });
+
+  describe("given two tables that disagree on one alias", () => {
+    it("refuses to merge them, so a wiring bug fails at module load", () => {
+      expect(() =>
+        mergeAliasTables({ tool_call: "tool_result" }, [
+          { tool_call: "compaction" },
+        ]),
+      ).toThrow(/Conflicting coding-agent alias "tool_call"/);
+    });
+
+    it("accepts a duplicate that agrees — same spelling, same fact", () => {
+      expect(
+        mergeAliasTables({ tool_call: "tool_result" }, [
+          { tool_call: "tool_result" },
+        ]),
+      ).toEqual({ tool_call: "tool_result" });
     });
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-normalization.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-normalization.ts
@@ -1,73 +1,42 @@
 /**
  * One vocabulary for every coding agent.
  *
- * Claude Code, opencode, Codex, Gemini CLI and Copilot all describe the same
- * handful of things — a model call, a tool run, a prompt, a denial, a token —
- * and every one of them spells those things differently. This module is where
- * that ends: raw wire strings in, one canonical fact out. Nothing downstream of
- * here should ever compare against a vendor's literal.
+ * Claude Code, Cowork, opencode, Codex, Gemini CLI and Copilot all describe
+ * the same handful of things — a model call, a tool run, a prompt, a denial,
+ * a token — and every one of them spells those things differently. This
+ * module is where that ends: raw wire strings in, one canonical fact out.
+ * Nothing downstream of here should ever compare against a vendor's literal.
  *
- * The rules below are not guesses. They come from reading each agent's source
+ * WHO each agent is lives in `../agents/` — one pure definition per agent,
+ * registered in an ordered registry (the trace-canonicalisation extractor
+ * shape). This engine folds the registry into the shared detection,
+ * prefix-stripping and alias tables; the per-vendor evidence lives with each
+ * definition. Adding an agent touches `agents/` only.
+ *
+ * The rules here are not guesses. They come from reading each agent's source
  * and from 30 days of live telemetry, and each surprising one carries the
  * evidence that forced it.
  */
 
-/** The agents we can name. `unknown` is not a failure — it is an honest answer. */
-export type CodingAgent =
-  | "claude_code"
-  | "opencode"
-  | "codex"
-  | "gemini_cli"
-  | "copilot"
-  | "unknown";
-
-/**
- * The canonical event kinds. Every agent's event name maps onto one of these, or
- * onto nothing (which is fine — an event we have no use for costs one lookup).
- */
-export type CodingAgentEvent =
-  | "user_prompt"
-  | "assistant_response"
-  | "api_request"
-  | "api_response"
-  | "api_error"
-  | "api_refusal"
-  | "retries_exhausted"
-  | "tool_result"
-  | "tool_decision"
-  | "compaction"
-  | "permission_mode_changed"
-  | "skill_activated"
-  | "mcp_server_connection"
-  | "hook_execution_complete"
-  | "at_mention"
-  | "internal_error"
-  | "session_created"
-  | "session_idle"
-  | "session_error"
-  | "subtask_invoked"
-  | "commit";
-
-/**
- * Token buckets. Three agents, three vocabularies for the same five things —
- * and the distinction that actually costs money (a cache READ is cheap, a cache
- * WRITE costs more than fresh input) is spelled differently by every one of them.
- */
-export type TokenType =
-  | "input"
-  | "output"
-  | "cache_read"
-  | "cache_creation"
-  | "reasoning";
+import { CODING_AGENT_REGISTRY } from "../agents";
+import type {
+  CodingAgent,
+  CodingAgentEvent,
+  CodingAgentMetric,
+  CodingAgentSignal,
+  TokenType,
+} from "../agents/_types";
 
 /**
  * Which agent produced this record.
  *
- * Deliberately NOT keyed on instrumentation scope. Claude Code uses
- * `com.anthropic.claude_code.events` and opencode uses `com.opencode`, but Codex
- * uses whatever `service_name` it was configured with — there is no stable scope
- * string to match on. The NAME of the span/metric/event is the reliable signal,
- * so that is what we key on, with the scope as a fallback hint.
+ * Deliberately NOT keyed on instrumentation scope alone. Claude Code uses
+ * `com.anthropic.claude_code.events` and opencode uses `com.opencode`, but
+ * Codex uses whatever `service_name` it was configured with — there is no
+ * stable scope string to match on. The NAME of the span/metric/event is the
+ * reliable signal, so that is what definitions key on, with the scope and
+ * service as supporting hints. Registry order resolves the one genuine
+ * overlap (Cowork before Claude Code — see `agents/index.ts`).
  */
 export function detectCodingAgent({
   scopeName,
@@ -79,20 +48,15 @@ export function detectCodingAgent({
   recordName?: string | null;
   serviceName?: string | null;
 }): CodingAgent {
-  const name = (recordName ?? "").toLowerCase();
-  const scope = (scopeName ?? "").toLowerCase();
-  const service = (serviceName ?? "").toLowerCase();
+  const signal: CodingAgentSignal = {
+    name: (recordName ?? "").toLowerCase(),
+    scope: (scopeName ?? "").toLowerCase(),
+    service: (serviceName ?? "").toLowerCase(),
+  };
 
-  const says = (needle: string) =>
-    name.startsWith(`${needle}.`) ||
-    scope.includes(needle) ||
-    service.includes(needle);
-
-  if (says("claude_code") || scope.includes("anthropic")) return "claude_code";
-  if (says("opencode")) return "opencode";
-  if (says("codex")) return "codex";
-  if (says("gemini_cli") || says("gemini")) return "gemini_cli";
-  if (says("copilot")) return "copilot";
+  for (const agent of CODING_AGENT_REGISTRY) {
+    if (agent.matches(signal)) return agent.id;
+  }
   return "unknown";
 }
 
@@ -102,9 +66,10 @@ export function detectCodingAgent({
  * The single most load-bearing function here, because it is the ONLY key every
  * agent agrees on — and they agree on it under four different names:
  *
- *   - Claude Code: `session.id` on logs and metrics, `gen_ai.conversation.id` on
- *     SPANS. Verified identical: the same UUID appears under both keys for the
- *     same trace, so a span and a log of one session do join.
+ *   - Claude Code / Cowork: `session.id` on logs and metrics,
+ *     `gen_ai.conversation.id` on SPANS. Verified identical: the same UUID
+ *     appears under both keys for the same trace, so a span and a log of one
+ *     session do join.
  *   - opencode:    `session.id` everywhere.
  *   - Codex:       `conversation.id` == `thread.id` == `session.id` (its MCP span
  *     sets two of them to the same thread id).
@@ -131,8 +96,8 @@ export function resolveConversationKey(
 /**
  * The canonical event, from whatever the agent called it.
  *
- * Two agents namespace their event names (`claude_code.tool_result`,
- * `codex.tool_result`) and one does not (opencode emits a bare `tool_result`),
+ * Some agents namespace their event names (`claude_code.tool_result`,
+ * `codex.tool_result`) and some do not (opencode emits a bare `tool_result`),
  * so the prefix is stripped before matching rather than enumerated per agent.
  */
 export function normalizeEventName(
@@ -150,7 +115,13 @@ export function normalizeEventName(
   return EVENT_ALIASES[canonical] ?? null;
 }
 
-const EVENT_ALIASES: Readonly<Record<string, CodingAgentEvent>> = {
+/**
+ * The canonical vocabulary every agent shares: identity mappings for the
+ * canonical names themselves, plus spellings not attributable to a single
+ * vendor. Vendor-specific aliases live on the agent definitions and are
+ * merged in below.
+ */
+const BASE_EVENT_ALIASES: Readonly<Record<string, CodingAgentEvent>> = {
   user_prompt: "user_prompt",
   assistant_response: "assistant_response",
   api_request: "api_request",
@@ -177,33 +148,16 @@ const EVENT_ALIASES: Readonly<Record<string, CodingAgentEvent>> = {
   session_error: "session_error",
   subtask_invoked: "subtask_invoked",
   commit: "commit",
-  // Codex names its shell outcome differently but means "the tool ran".
-  sandbox_outcome: "tool_result",
-  // Gemini logs a COMPLETED tool call (it carries success + duration_ms), which
-  // is our tool_result, not a separate "the tool was requested" fact.
-  tool_call: "tool_result",
-  chat_compression: "compaction",
   conversation_finished: "session_idle",
   slash_command: "user_prompt",
-  // Copilot emits these as SPAN EVENTS rather than log records — see the note on
-  // the Copilot shape below. Mapped so they fold the same way if they ever
-  // arrive as logs.
-  session_compaction_complete: "compaction",
-  skill_invoked: "skill_activated",
 };
 
 /**
  * The canonical metric, from whatever the agent called it.
  *
  * The agent prefix is the only difference for the metrics we care about
- * (`claude_code.lines_of_code.count` vs `opencode.lines_of_code.count`), so it is
- * stripped and the remainder matched — the same trick the event names use.
- *
- * Two deliberate omissions:
- *   - opencode's `lines_of_code.total` is a cumulative GAUGE that sits alongside
- *     the `.count` delta counter. Adding both would double every line.
- *   - Codex has no lines-of-code and no cost metric at all; its cost must be
- *     priced from tokens. There is nothing here to map.
+ * (`claude_code.lines_of_code.count` vs `opencode.lines_of_code.count`), so it
+ * is stripped and the remainder matched — the same trick the event names use.
  */
 export function normalizeMetricName(
   rawMetricName: string | null | undefined,
@@ -212,17 +166,7 @@ export function normalizeMetricName(
   return METRIC_ALIASES[stripAgentPrefix(rawMetricName)] ?? null;
 }
 
-export type CodingAgentMetric =
-  | "tool_call"
-  | "lines_of_code"
-  | "commit"
-  | "pull_request"
-  | "edit_decision"
-  | "active_time"
-  | "token_usage"
-  | "cost_usage";
-
-const METRIC_ALIASES: Readonly<Record<string, CodingAgentMetric>> = {
+const BASE_METRIC_ALIASES: Readonly<Record<string, CodingAgentMetric>> = {
   "lines_of_code.count": "lines_of_code",
   "commit.count": "commit",
   "pull_request.count": "pull_request",
@@ -230,12 +174,41 @@ const METRIC_ALIASES: Readonly<Record<string, CodingAgentMetric>> = {
   "active_time.total": "active_time",
   "token.usage": "token_usage",
   "cost.usage": "cost_usage",
-  // Codex spells its token metric differently, and reports it per turn.
-  "turn.token_usage": "token_usage",
-  // Gemini: `gemini_cli.lines.changed` with type=added|removed.
-  "lines.changed": "lines_of_code",
   "tool.call.count": "tool_call",
 };
+
+/** Base table + every registered agent's aliases, collisions rejected. */
+function mergeAliasTables<Value>(
+  base: Readonly<Record<string, Value>>,
+  perAgent: ReadonlyArray<Readonly<Record<string, Value>> | undefined>,
+): Readonly<Record<string, Value>> {
+  const merged: Record<string, Value> = { ...base };
+  for (const table of perAgent) {
+    if (!table) continue;
+    for (const [alias, canonical] of Object.entries(table)) {
+      if (alias in merged && merged[alias] !== canonical) {
+        // Module-load failure on a genuine conflict: two agents (or an agent
+        // and the base vocabulary) disagreeing on one spelling is a wiring
+        // bug, not a runtime condition.
+        throw new Error(
+          `Conflicting coding-agent alias "${alias}": ${String(merged[alias])} vs ${String(canonical)}`,
+        );
+      }
+      merged[alias] = canonical;
+    }
+  }
+  return Object.freeze(merged);
+}
+
+const EVENT_ALIASES = mergeAliasTables(
+  BASE_EVENT_ALIASES,
+  CODING_AGENT_REGISTRY.map((agent) => agent.eventAliases),
+);
+
+const METRIC_ALIASES = mergeAliasTables(
+  BASE_METRIC_ALIASES,
+  CODING_AGENT_REGISTRY.map((agent) => agent.metricAliases),
+);
 
 /**
  * Is this metric from a coding agent at all?
@@ -264,9 +237,21 @@ export const CODING_AGENT_CONTRIBUTION_KEYS: readonly string[] = [
   "session.id",
   "user.id",
   "user.email",
+  "user.account_uuid",
+  "user.account_id",
+  "organization.id",
   "app.version",
   "app.entrypoint",
   "terminal.type",
+  // Cowork correlation + decision vocabulary (its events are otherwise
+  // Claude Code's): the per-prompt id, in-session ordering, request speed
+  // tier, and the tool_result-embedded decision fields.
+  "prompt.id",
+  "event.sequence",
+  "speed",
+  "decision_type",
+  "decision_source",
+  "mcp_server_scope",
   "gen_ai.request.model",
   "mcp_server.name",
   "mcp_tool.name",
@@ -294,7 +279,6 @@ export const CODING_AGENT_CONTRIBUTION_KEYS: readonly string[] = [
   "post_tokens",
   "pre_tokens",
   "prompt_length",
-  "request_id",
   "response_length",
   "server_fallback_hop",
   "server_name",
@@ -312,6 +296,7 @@ export const CODING_AGENT_CONTRIBUTION_KEYS: readonly string[] = [
   "total_retry_duration_ms",
   "ttft_ms",
   "type",
+  "request_id",
 ];
 
 /**
@@ -323,15 +308,19 @@ export const CODING_AGENT_CONTRIBUTION_KEYS: readonly string[] = [
 export function liftCodingAgentLogFacts({
   scopeName,
   attributes,
+  serviceName,
 }: {
   scopeName: string | null | undefined;
   attributes: Record<string, unknown>;
+  /** Resource-level service.name — the only signal that names Cowork. */
+  serviceName?: string | null;
 }): Record<string, string | number | boolean> | null {
   const eventName = attributes["event.name"];
   if (
     detectCodingAgent({
       scopeName,
       recordName: typeof eventName === "string" ? eventName : null,
+      serviceName,
     }) === "unknown"
   ) {
     return null;
@@ -353,17 +342,10 @@ export function liftCodingAgentLogFacts({
 
 /** `claude_code.tool_result` → `tool_result`; `tool_result` → `tool_result`. */
 function stripAgentPrefix(name: string): string {
-  const AGENT_PREFIXES = [
-    "claude_code.",
-    "opencode.",
-    "codex.",
-    "gemini_cli.",
-    // Copilot namespaces under the ORG, not the product.
-    "github.copilot.",
-    "copilot.",
-  ];
-  for (const prefix of AGENT_PREFIXES) {
-    if (name.startsWith(prefix)) return name.slice(prefix.length);
+  for (const agent of CODING_AGENT_REGISTRY) {
+    for (const prefix of agent.namePrefixes) {
+      if (name.startsWith(prefix)) return name.slice(prefix.length);
+    }
   }
   return name;
 }
@@ -371,10 +353,10 @@ function stripAgentPrefix(name: string): string {
 /**
  * The token bucket, from any agent's spelling.
  *
- * The cache distinction is the one that matters and the one they all spell
- * differently: `cacheRead` (Claude Code, opencode) vs `cached_input` (Codex),
- * `cacheCreation` vs `cache_creation`. Getting this wrong does not throw — it
- * silently misprices the session, which is worse.
+ * Deliberately SHARED rather than per-agent: the spellings overlap and
+ * folding them in one place is what keeps a new agent's `cacheRead` /
+ * `cache_read` / `cached_input` from silently mispricing a session — which
+ * does not throw, and is worse than throwing.
  */
 export function normalizeTokenType(
   rawType: string | null | undefined,
@@ -422,12 +404,10 @@ export function normalizeTokenType(
 }
 
 /**
- * The tool that ran.
- *
- * opencode puts the tool name IN the span name (`opencode.tool.bash`) while
- * Claude Code and Codex keep the span name constant and carry the tool in an
- * attribute. Reading only the attribute loses every opencode tool; reading only
- * the span name loses everyone else's.
+ * The tool that ran: the attribute when the agent carries one, else whatever
+ * a registered definition can read off the span name (opencode encodes the
+ * tool there). Reading only the attribute loses every opencode tool; reading
+ * only the span name loses everyone else's.
  */
 export function resolveToolName({
   spanName,
@@ -439,12 +419,11 @@ export function resolveToolName({
   const fromAttr = firstString(attrs, ["tool_name", "tool.name"]);
   if (fromAttr !== null) return fromAttr;
 
-  // `opencode.tool.bash` → `bash`. Only the opencode shape encodes it this way.
   const name = spanName ?? "";
-  const OPENCODE_TOOL_SPAN = "opencode.tool.";
-  if (name.startsWith(OPENCODE_TOOL_SPAN)) {
-    const tool = name.slice(OPENCODE_TOOL_SPAN.length);
-    return tool.length > 0 ? tool : null;
+  if (name.length === 0) return null;
+  for (const agent of CODING_AGENT_REGISTRY) {
+    const tool = agent.toolNameFromSpanName?.(name) ?? null;
+    if (tool !== null) return tool;
   }
   return null;
 }

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-normalization.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-normalization.ts
@@ -177,8 +177,11 @@ const BASE_METRIC_ALIASES: Readonly<Record<string, CodingAgentMetric>> = {
   "tool.call.count": "tool_call",
 };
 
-/** Base table + every registered agent's aliases, collisions rejected. */
-function mergeAliasTables<Value>(
+/**
+ * Base table + every registered agent's aliases, collisions rejected.
+ * Exported for the unit suite, which proves the collision guard fires.
+ */
+export function mergeAliasTables<Value>(
   base: Readonly<Record<string, Value>>,
   perAgent: ReadonlyArray<Readonly<Record<string, Value>> | undefined>,
 ): Readonly<Record<string, Value>> {

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
@@ -369,10 +369,82 @@ function withIdentity(
     entrypoint: state.entrypoint ?? str(attrs["app.entrypoint"]),
     // Claude stamps user identity on log events, not spans; other agents send
     // none at all, so a session they produce honestly keeps null here.
-    // `user.id` only — it is the provider's opaque hash. `user.email` also
-    // rides those events but is raw human identity, and this value lands
-    // verbatim in a durable row.
-    userId: state.userId ?? str(attrs["user.id"]),
+    // Opaque provider ids only — Claude Code's `user.id` hash, or Cowork's
+    // account UUID / tagged account id. `user.email` also rides those events
+    // but is raw human identity, and this value lands verbatim in a durable
+    // row, so it is deliberately never read.
+    userId:
+      state.userId ??
+      str(attrs["user.id"]) ??
+      str(attrs["user.account_uuid"]) ??
+      str(attrs["user.account_id"]),
+  };
+}
+
+/**
+ * Fold one model call into the session, from whichever signal carries it.
+ *
+ * Claude Code reports the call on the `claude_code.llm_request` SPAN; a
+ * logs-only agent (Cowork) reports the same facts — model, tokens, cache
+ * buckets, attempt, duration — on its `api_request` EVENT. One fold, two
+ * carriers, so the vocabularies cannot drift. The caller gates which carrier
+ * counts for its agent (span-bearing agents fold spans, logs-only agents
+ * fold events) — folding both would double every call.
+ */
+function foldModelCall(
+  next: CodingAgentSessionData,
+  attrs: Record<string, unknown>,
+  fallbackDurationMs: number,
+): CodingAgentSessionData {
+  const agentId = str(attrs.agent_id);
+  if (agentId !== null) Object.assign(next, seenSubAgent(next, agentId));
+  const stopReason = str(attrs.stop_reason);
+  const ttft = num(attrs.ttft_ms);
+  const model = str(attrs.model) ?? str(attrs["gen_ai.request.model"]);
+  const requestId = str(attrs.request_id);
+
+  const cacheReadTokens = num(attrs.cache_read_tokens);
+  const cacheCreationTokens = num(attrs.cache_creation_tokens);
+  const contextTokens = cacheReadTokens + cacheCreationTokens;
+  // The first call is never a "rebuild" — there is nothing to reuse yet,
+  // so a cold cache isn't the session's fault. `previousCallContextTokens`
+  // starts at 0, which doubles as that gate.
+  const isRebuild =
+    next.previousCallContextTokens > 0 &&
+    cacheCreationTokens >= CACHE_REBUILD_MIN_TOKENS &&
+    cacheCreationTokens / next.previousCallContextTokens >=
+      CACHE_REBUILD_RATIO_THRESHOLD;
+
+  return {
+    ...next,
+    modelCalls: next.modelCalls + 1,
+    modelCallMs: next.modelCallMs + (num(attrs.duration_ms) || fallbackDurationMs),
+    ttftMsTotal: next.ttftMsTotal + ttft,
+    ttftSamples: next.ttftSamples + (ttft > 0 ? 1 : 0),
+    // Attempts includes the first try, so attempts > modelCalls means the
+    // session paid for retries somewhere.
+    attempts: next.attempts + Math.max(1, num(attrs.attempt)),
+    inputTokens: next.inputTokens + num(attrs.input_tokens),
+    outputTokens: next.outputTokens + num(attrs.output_tokens),
+    cacheReadTokens: next.cacheReadTokens + cacheReadTokens,
+    cacheCreationTokens: next.cacheCreationTokens + cacheCreationTokens,
+    peakContextTokens: Math.max(next.peakContextTokens, contextTokens),
+    cacheRebuildCount: next.cacheRebuildCount + (isRebuild ? 1 : 0),
+    largestCacheRebuildTokens: isRebuild
+      ? Math.max(next.largestCacheRebuildTokens, cacheCreationTokens)
+      : next.largestCacheRebuildTokens,
+    previousCallContextTokens: contextTokens,
+    models: model !== null ? addToBoundedSet(next.models, model) : next.models,
+    // The pointer back to the body that ended the session. Last call wins.
+    finalRequestId: requestId ?? next.finalRequestId,
+    // Only the LAST call's stop reason is the session's: the earlier ones all
+    // stop on `tool_use` by definition, since that is what drove the loop on.
+    ...(stopReason !== null
+      ? {
+          stopReason,
+          truncated: TRUNCATING_STOP_REASONS.has(stopReason),
+        }
+      : {}),
   };
 }
 
@@ -399,58 +471,7 @@ export function applySpanToCodingAgentSession({
   const durationMs = Math.max(0, span.endTimeUnixMs - span.startTimeUnixMs);
 
   if (span.name === CLAUDE.SPAN.LLM_REQUEST) {
-    const next = withIdentity(state, attrs);
-    const agentId = str(attrs.agent_id);
-    if (agentId !== null) Object.assign(next, seenSubAgent(next, agentId));
-    const stopReason = str(attrs.stop_reason);
-    const ttft = num(attrs.ttft_ms);
-    const model = str(attrs.model) ?? str(attrs["gen_ai.request.model"]);
-    const requestId = str(attrs.request_id);
-
-    const cacheReadTokens = num(attrs.cache_read_tokens);
-    const cacheCreationTokens = num(attrs.cache_creation_tokens);
-    const contextTokens = cacheReadTokens + cacheCreationTokens;
-    // The first call is never a "rebuild" — there is nothing to reuse yet,
-    // so a cold cache isn't the session's fault. `previousCallContextTokens`
-    // starts at 0, which doubles as that gate.
-    const isRebuild =
-      next.previousCallContextTokens > 0 &&
-      cacheCreationTokens >= CACHE_REBUILD_MIN_TOKENS &&
-      cacheCreationTokens / next.previousCallContextTokens >=
-        CACHE_REBUILD_RATIO_THRESHOLD;
-
-    return {
-      ...next,
-      modelCalls: next.modelCalls + 1,
-      modelCallMs: next.modelCallMs + (num(attrs.duration_ms) || durationMs),
-      ttftMsTotal: next.ttftMsTotal + ttft,
-      ttftSamples: next.ttftSamples + (ttft > 0 ? 1 : 0),
-      // Attempts includes the first try, so attempts > modelCalls means the
-      // session paid for retries somewhere.
-      attempts: next.attempts + Math.max(1, num(attrs.attempt)),
-      inputTokens: next.inputTokens + num(attrs.input_tokens),
-      outputTokens: next.outputTokens + num(attrs.output_tokens),
-      cacheReadTokens: next.cacheReadTokens + cacheReadTokens,
-      cacheCreationTokens: next.cacheCreationTokens + cacheCreationTokens,
-      peakContextTokens: Math.max(next.peakContextTokens, contextTokens),
-      cacheRebuildCount: next.cacheRebuildCount + (isRebuild ? 1 : 0),
-      largestCacheRebuildTokens: isRebuild
-        ? Math.max(next.largestCacheRebuildTokens, cacheCreationTokens)
-        : next.largestCacheRebuildTokens,
-      previousCallContextTokens: contextTokens,
-      models:
-        model !== null ? addToBoundedSet(next.models, model) : next.models,
-      // The pointer back to the body that ended the session. Last call wins.
-      finalRequestId: requestId ?? next.finalRequestId,
-      // Only the LAST call's stop reason is the session's: the earlier ones all
-      // stop on `tool_use` by definition, since that is what drove the loop on.
-      ...(stopReason !== null
-        ? {
-            stopReason,
-            truncated: TRUNCATING_STOP_REASONS.has(stopReason),
-          }
-        : {}),
-    };
+    return foldModelCall(withIdentity(state, attrs), attrs, durationMs);
   }
 
   if (span.name === CLAUDE.SPAN.SUBAGENT_SPAWN) {
@@ -479,10 +500,36 @@ export function applySpanToCodingAgentSession({
 
   if (span.name !== CLAUDE.SPAN.TOOL) return state;
 
-  const next = withIdentity(state, attrs);
+  return foldToolInvocation(withIdentity(state, attrs), {
+    attrs,
+    failed: span.statusCode === SPAN_STATUS_ERROR,
+    toolMs: num(attrs.duration_ms) || durationMs,
+    startedAtMs: span.startTimeUnixMs,
+  });
+}
+
+/**
+ * Fold one tool invocation into the session, from whichever signal carries
+ * it. Span-bearing agents report it on the `claude_code.tool` SPAN; a
+ * logs-only agent (Cowork) reports the same facts — tool name, success,
+ * duration, sizes — on its `tool_result` EVENT. The caller gates which
+ * carrier counts for its agent, so an agent with both never double-counts.
+ */
+function foldToolInvocation(
+  next: CodingAgentSessionData,
+  {
+    attrs,
+    failed,
+    toolMs,
+    startedAtMs,
+  }: {
+    attrs: Record<string, unknown>;
+    failed: boolean;
+    toolMs: number;
+    startedAtMs: number;
+  },
+): CodingAgentSessionData {
   const toolName = str(attrs.tool_name);
-  const failed = span.statusCode === SPAN_STATUS_ERROR;
-  const toolMs = num(attrs.duration_ms) || durationMs;
 
   const withTool: CodingAgentSessionData = {
     ...next,
@@ -511,7 +558,7 @@ export function applySpanToCodingAgentSession({
   if (toolAgentId === null) {
     withTool.steps = appendStep(next.steps, {
       name: toolName,
-      startedAtMs: span.startTimeUnixMs,
+      startedAtMs,
       failed,
     });
   }
@@ -549,21 +596,44 @@ export function applySpanToCodingAgentSession({
 }
 
 /**
+ * Agents whose telemetry is events-only: no spans arrive, so the facts that
+ * span-bearing agents fold from spans (model calls, tokens, tool runs) fold
+ * from their LOG events instead. Membership is the double-count gate — an
+ * agent listed here must never also emit the equivalent spans into this
+ * pipeline, or every call would fold twice.
+ */
+const LOGS_ONLY_AGENTS: ReadonlySet<string> = new Set(["claude_cowork"]);
+
+/**
  * Fold one LOG record's facts into the session.
  *
  * These are the facts with NO span: the tool the user denied (it never ran), the
  * model call that failed and was retried (a failed call has no successful span),
  * the authoritative cost, the compaction, the hook that blocked an action.
+ * For a logs-only agent (`LOGS_ONLY_AGENTS`) the log is ALSO the carrier of
+ * everything spans normally carry, so its `api_request` folds the model call
+ * and its `tool_result` folds the tool invocation.
  */
 export function applyLogToCodingAgentSession({
   state,
   attributes,
+  agent,
+  occurredAtMs,
 }: {
   state: CodingAgentSessionData;
   /** The contribution's lifted scalar facts — raw wire keys. */
   attributes: Record<string, unknown>;
+  /**
+   * The CONTRIBUTION's detected agent — deliberately not the folded state's,
+   * which is first-writer-wins and could have been established by a
+   * differently-labeled signal. Gates the logs-only folding below.
+   */
+  agent?: string;
+  /** The record's own time, for step placement on logs-only folds. */
+  occurredAtMs?: number;
 }): CodingAgentSessionData {
   const attrs = attributes;
+  const logsOnly = agent !== undefined && LOGS_ONLY_AGENTS.has(agent);
   // Normalize the agent's spelling into one vocabulary before matching. Claude
   // Code and Codex namespace their event names (`claude_code.tool_result`,
   // `codex.tool_result`); opencode sends a bare `tool_result` and dots its
@@ -595,14 +665,18 @@ export function applyLogToCodingAgentSession({
         responseChars: base.responseChars + num(attrs.response_length),
       };
 
-    case CLAUDE.EVENT.API_REQUEST:
+    case CLAUDE.EVENT.API_REQUEST: {
       // The authoritative cost: the agent reports what it was actually billed,
       // which no span carries.
-      return { ...base, costUsd: base.costUsd + num(attrs.cost_usd) };
+      const withCost = { ...base, costUsd: base.costUsd + num(attrs.cost_usd) };
+      // For a logs-only agent this event IS the model call — the same facts
+      // the llm_request span carries for Claude Code fold from here instead.
+      return logsOnly ? foldModelCall(withCost, attrs, 0) : withCost;
+    }
 
     case CLAUDE.EVENT.TOOL_RESULT: {
       const errorType = str(attrs.error_type);
-      return {
+      const withBytes = {
         ...base,
         // Bytes of tool OUTPUT fed back into the context — the usual cause of a
         // session bloating its way into a compaction.
@@ -614,6 +688,16 @@ export function applyLogToCodingAgentSession({
             ? bump(base.errorTypes, errorType)
             : base.errorTypes,
       };
+      // For a logs-only agent this event IS the tool run — name, duration,
+      // outcome — which span-bearing agents fold from the tool span.
+      return logsOnly
+        ? foldToolInvocation(withBytes, {
+            attrs,
+            failed: scalarStr(attrs.success) === "false",
+            toolMs: num(attrs.duration_ms),
+            startedAtMs: occurredAtMs ?? 0,
+          })
+        : withBytes;
     }
 
     case CLAUDE.EVENT.TOOL_DECISION: {

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/services/coding-agent-session.derivation.ts
@@ -1,3 +1,4 @@
+import { LOGS_ONLY_AGENT_IDS } from "../agents";
 import {
   normalizeEventName,
   normalizeMetricName,
@@ -595,14 +596,6 @@ function foldToolInvocation(
   return withTool;
 }
 
-/**
- * Agents whose telemetry is events-only: no spans arrive, so the facts that
- * span-bearing agents fold from spans (model calls, tokens, tool runs) fold
- * from their LOG events instead. Membership is the double-count gate — an
- * agent listed here must never also emit the equivalent spans into this
- * pipeline, or every call would fold twice.
- */
-const LOGS_ONLY_AGENTS: ReadonlySet<string> = new Set(["claude_cowork"]);
 
 /**
  * Fold one LOG record's facts into the session.
@@ -633,7 +626,10 @@ export function applyLogToCodingAgentSession({
   occurredAtMs?: number;
 }): CodingAgentSessionData {
   const attrs = attributes;
-  const logsOnly = agent !== undefined && LOGS_ONLY_AGENTS.has(agent);
+  // Membership rides the registry (`logsOnly` on the definition), so adding
+  // an events-only agent touches agents/ only. String-typed at this seam
+  // because the contribution schema is a wire string, not the union.
+  const isLogsOnly = agent !== undefined && LOGS_ONLY_AGENT_IDS.has(agent);
   // Normalize the agent's spelling into one vocabulary before matching. Claude
   // Code and Codex namespace their event names (`claude_code.tool_result`,
   // `codex.tool_result`); opencode sends a bare `tool_result` and dots its
@@ -671,7 +667,7 @@ export function applyLogToCodingAgentSession({
       const withCost = { ...base, costUsd: base.costUsd + num(attrs.cost_usd) };
       // For a logs-only agent this event IS the model call — the same facts
       // the llm_request span carries for Claude Code fold from here instead.
-      return logsOnly ? foldModelCall(withCost, attrs, 0) : withCost;
+      return isLogsOnly ? foldModelCall(withCost, attrs, 0) : withCost;
     }
 
     case CLAUDE.EVENT.TOOL_RESULT: {
@@ -690,7 +686,7 @@ export function applyLogToCodingAgentSession({
       };
       // For a logs-only agent this event IS the tool run — name, duration,
       // outcome — which span-bearing agents fold from the tool span.
-      return logsOnly
+      return isLogsOnly
         ? foldToolInvocation(withBytes, {
             attrs,
             failed: scalarStr(attrs.success) === "false",

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentLogFactsDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentLogFactsDispatch.unit.test.ts
@@ -21,6 +21,7 @@ function canonicalLogEvent({
   correlationSource = "none",
   providerSessionId = "",
   recordId = "rec-1",
+  resourceAttributes = { "service.version": "2.0.1" },
 }: {
   attributes: Record<string, unknown>;
   scopeName?: string;
@@ -29,6 +30,7 @@ function canonicalLogEvent({
   correlationSource?: string;
   providerSessionId?: string;
   recordId?: string;
+  resourceAttributes?: Record<string, unknown>;
 }): LogProcessingEvent {
   return {
     tenantId: createTenantId("tenant-1"),
@@ -40,9 +42,7 @@ function canonicalLogEvent({
       scopeName,
       eventName,
       attributesFlatJson: JSON.stringify(attributes),
-      resourceAttributesFlatJson: JSON.stringify({
-        "service.version": "2.0.1",
-      }),
+      resourceAttributesFlatJson: JSON.stringify(resourceAttributes),
       correlationTraceId,
       correlationSpanId: "",
       correlationSource,
@@ -96,6 +96,49 @@ describe("codingAgentLogFactsDispatch", () => {
       expect(contribution!.facts["service.version"]).toBe("2.0.1");
       // No correlation on the record: the contribution carries no trace.
       expect(contribution!.traceId).toBeNull();
+    });
+  });
+
+  describe("when a Cowork session's events arrive", () => {
+    /** @scenario a Cowork session is an agent session */
+    /** @scenario Cowork telemetry that shares Claude Code's event vocabulary is still Cowork */
+    it("labels the contribution claude_cowork and lifts its correlation facts", async () => {
+      const { subscriber, dispatched } = makeSubscriber();
+
+      // Real Cowork wire shape: Claude Code's runtime scope and event
+      // vocabulary, service.name `cowork`, logs-only (no spans, no wire
+      // correlation), per-prompt correlation via prompt.id + event.sequence.
+      await subscriber.handle(
+        canonicalLogEvent({
+          attributes: {
+            "event.name": "claude_code.user_prompt",
+            "session.id": "cw-sess-1",
+            "prompt.id": "0f6f44f5-2f4c-4a5e-9d3b-7f8f2f9a1b2c",
+            "event.sequence": 7,
+            "organization.id": "b3d7a45e-1189-4e0f-8b7a-2c3d4e5f6a7b",
+            "terminal.type": "non-interactive",
+            prompt_length: 42,
+          },
+          resourceAttributes: {
+            "service.name": "cowork",
+            "service.version": "1.1.4173",
+          },
+        }),
+        context,
+      );
+
+      expect(dispatched).toHaveLength(1);
+      const [contribution] = dispatched;
+      expect(contribution!.agent).toBe("claude_cowork");
+      expect(contribution!.sessionId).toBe("cw-sess-1");
+      expect(contribution!.sessionKeySource).toBe("provider");
+      expect(contribution!.traceId).toBeNull();
+      expect(contribution!.facts["prompt.id"]).toBe(
+        "0f6f44f5-2f4c-4a5e-9d3b-7f8f2f9a1b2c",
+      );
+      expect(contribution!.facts["event.sequence"]).toBe(7);
+      expect(contribution!.facts["terminal.type"]).toBe("non-interactive");
+      expect(contribution!.facts["service.version"]).toBe("1.1.4173");
     });
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentLogFactsDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentLogFactsDispatch.unit.test.ts
@@ -137,6 +137,9 @@ describe("codingAgentLogFactsDispatch", () => {
         "0f6f44f5-2f4c-4a5e-9d3b-7f8f2f9a1b2c",
       );
       expect(contribution!.facts["event.sequence"]).toBe(7);
+      expect(contribution!.facts["organization.id"]).toBe(
+        "b3d7a45e-1189-4e0f-8b7a-2c3d4e5f6a7b",
+      );
       expect(contribution!.facts["terminal.type"]).toBe("non-interactive");
       expect(contribution!.facts["service.version"]).toBe("1.1.4173");
     });

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentMetricFactsDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentMetricFactsDispatch.unit.test.ts
@@ -48,6 +48,7 @@ function dataPointEvent({
   valueInt = null,
   pointId = POINT_ID,
   seriesId = SERIES_ID,
+  resourceAttributes = {},
 }: {
   metricName: string;
   attributes?: Record<string, unknown>;
@@ -56,6 +57,7 @@ function dataPointEvent({
   valueInt?: string | null;
   pointId?: string;
   seriesId?: string;
+  resourceAttributes?: Record<string, unknown>;
 }): MetricProcessingEvent {
   return {
     tenantId: createTenantId("tenant-1"),
@@ -71,6 +73,7 @@ function dataPointEvent({
       aggregationTemporality: temporality,
       scopeName: "com.anthropic.claude_code",
       pointAttributesJson: encodeAttributes(attributes),
+      resourceAttributesJson: encodeAttributes(resourceAttributes),
       timeUnixMs: 1_500,
       valueType:
         valueDouble !== null ? "double" : valueInt !== null ? "int" : "none",
@@ -93,6 +96,31 @@ function makeSubscriber() {
 const context = { tenantId: "tenant-1", aggregateId: POINT_ID };
 
 describe("codingAgentMetricFactsDispatch", () => {
+  describe("when a Cowork session's metric arrives", () => {
+    /** @scenario Cowork telemetry that shares Claude Code's event vocabulary is still Cowork */
+    it("labels the contribution claude_cowork from the resource service", async () => {
+      const { subscriber, dispatched } = makeSubscriber();
+
+      // Claude Code's metric vocabulary and scope; only the resource-level
+      // service.name says cowork. Without the service signal this would
+      // first-writer-win the session's agent to claude_code.
+      await subscriber.handle(
+        dataPointEvent({
+          metricName: "claude_code.cost.usage",
+          attributes: { "session.id": "cw-sess-1" },
+          temporality: "cumulative",
+          valueDouble: 0.5,
+          resourceAttributes: { "service.name": "cowork" },
+        }),
+        context,
+      );
+
+      expect(dispatched).toHaveLength(1);
+      expect(dispatched[0]!.agent).toBe("claude_cowork");
+      expect(dispatched[0]!.sessionId).toBe("cw-sess-1");
+    });
+  });
+
   describe("when a cumulative coding-agent metric carries the session key", () => {
     /** @scenario a session that sent only metrics still appears */
     it("contributes the series' converged total, keyed by the series", async () => {

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/__tests__/codingAgentSpanFactsDispatch.unit.test.ts
@@ -24,6 +24,7 @@ function rawSpanEvent({
   startMs = 1_000,
   endMs = 2_000,
   statusCode = 0,
+  resourceAttributes = {},
 }: {
   name: string;
   spanId: string;
@@ -32,6 +33,7 @@ function rawSpanEvent({
   endMs?: number;
   /** OTLP status: 0 UNSET, 1 OK, 2 ERROR. */
   statusCode?: number;
+  resourceAttributes?: Record<string, string>;
 }): TraceProcessingEvent {
   return {
     tenantId: createTenantId("tenant-1"),
@@ -56,7 +58,12 @@ function rawSpanEvent({
         events: [],
         links: [],
       },
-      resource: { attributes: [] },
+      resource: {
+        attributes: Object.entries(resourceAttributes).map(([key, value]) => ({
+          key,
+          value: { stringValue: value },
+        })),
+      },
       instrumentationScope: { name: "com.anthropic.claude_code.tracing" },
     },
   } as unknown as TraceProcessingEvent;
@@ -155,6 +162,29 @@ describe("codingAgentSpanFactsDispatch", () => {
       );
 
       expect(dispatched).toHaveLength(0);
+    });
+  });
+
+  describe("when a Cowork session's span arrives (beta trace export)", () => {
+    /** @scenario Cowork telemetry that shares Claude Code's event vocabulary is still Cowork */
+    it("labels the contribution claude_cowork from the resource service", async () => {
+      const { subscriber, dispatched } = makeSubscriber();
+
+      // Claude Code's span name and scope; only resource service.name says
+      // cowork. The label must follow the service, not the runtime.
+      await subscriber.handle(
+        rawSpanEvent({
+          name: "claude_code.llm_request",
+          spanId: "s-cw",
+          attributes: { "gen_ai.conversation.id": "cw-sess-1" },
+          resourceAttributes: { "service.name": "cowork" },
+        }),
+        context,
+      );
+
+      expect(dispatched).toHaveLength(1);
+      expect(dispatched[0]!.agent).toBe("claude_cowork");
+      expect(dispatched[0]!.sessionId).toBe("cw-sess-1");
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentLogFactsDispatch.subscriber.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentLogFactsDispatch.subscriber.ts
@@ -44,15 +44,24 @@ export function createCodingAgentLogFactsDispatchSubscriber(deps: {
         attributes["event.name"] = record.eventName;
       }
 
-      const facts = liftCodingAgentLogFacts({
-        scopeName: record.scopeName,
-        attributes,
-      });
-      if (facts === null) return;
-
+      // Parsed before the gate: Cowork's events reuse Claude Code's scope and
+      // names, so resource-level service.name is what identifies them.
       const resourceAttributes = parseFlatAttributes(
         record.resourceAttributesFlatJson,
       );
+      const rawServiceName = resourceAttributes?.["service.name"];
+      const serviceName =
+        typeof rawServiceName === "string" && rawServiceName.length > 0
+          ? rawServiceName
+          : null;
+
+      const facts = liftCodingAgentLogFacts({
+        scopeName: record.scopeName,
+        attributes,
+        serviceName,
+      });
+      if (facts === null) return;
+
       const serviceVersion = resourceAttributes?.["service.version"];
       if (typeof serviceVersion === "string" && serviceVersion.length > 0) {
         facts["service.version"] = serviceVersion;
@@ -81,6 +90,7 @@ export function createCodingAgentLogFactsDispatchSubscriber(deps: {
             typeof attributes["event.name"] === "string"
               ? (attributes["event.name"] as string)
               : null,
+          serviceName,
         }),
         occurredAt: record.occurredAt,
         recordId: record.recordId,

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentLogFactsDispatch.subscriber.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentLogFactsDispatch.subscriber.ts
@@ -44,8 +44,18 @@ export function createCodingAgentLogFactsDispatchSubscriber(deps: {
         attributes["event.name"] = record.eventName;
       }
 
-      // Parsed before the gate: Cowork's events reuse Claude Code's scope and
-      // names, so resource-level service.name is what identifies them.
+      // Two-phase detection, so an ordinary application log costs one cheap
+      // name/scope check and never a resource-attributes parse. Cowork's
+      // events reuse Claude Code's runtime (anthropic scope, claude_code
+      // event names), so they PASS this gate as claude_code; the resource
+      // parse below then supplies the service.name that relabels them
+      // claude_cowork at the contribution.
+      const facts = liftCodingAgentLogFacts({
+        scopeName: record.scopeName,
+        attributes,
+      });
+      if (facts === null) return;
+
       const resourceAttributes = parseFlatAttributes(
         record.resourceAttributesFlatJson,
       );
@@ -54,13 +64,6 @@ export function createCodingAgentLogFactsDispatchSubscriber(deps: {
         typeof rawServiceName === "string" && rawServiceName.length > 0
           ? rawServiceName
           : null;
-
-      const facts = liftCodingAgentLogFacts({
-        scopeName: record.scopeName,
-        attributes,
-        serviceName,
-      });
-      if (facts === null) return;
 
       const serviceVersion = resourceAttributes?.["service.version"];
       if (typeof serviceVersion === "string" && serviceVersion.length > 0) {

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentMetricFactsDispatch.subscriber.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentMetricFactsDispatch.subscriber.ts
@@ -73,6 +73,11 @@ export function createCodingAgentMetricFactsDispatchSubscriber(deps: {
         agent: detectCodingAgent({
           recordName: point.metricName,
           scopeName: point.scopeName,
+          // Resource service.name is the only signal that separates Cowork
+          // from the Claude Code runtime it reuses; without it a session's
+          // metric contribution could first-writer-win the fold's agent to
+          // claude_code while its log contributions say claude_cowork.
+          serviceName: serviceNameFromResource(point.resourceAttributesJson),
         }),
         occurredAt: point.timeUnixMs,
         seriesId: isDelta ? point.pointId : point.seriesId,
@@ -117,4 +122,13 @@ function parsePointAttributes(
     logger.warn({ error }, "unparseable metric point attributes; skipping");
     return null;
   }
+}
+
+/** Resource-level service.name off the point's canonical KeyValue JSON. */
+function serviceNameFromResource(json: string): string | null {
+  const resource = parsePointAttributes(json);
+  const serviceName = resource?.["service.name"];
+  return typeof serviceName === "string" && serviceName.length > 0
+    ? serviceName
+    : null;
 }

--- a/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/coding-agent-processing/subscribers/codingAgentSpanFactsDispatch.subscriber.ts
@@ -82,6 +82,10 @@ export function createCodingAgentSpanFactsDispatchSubscriber(deps: {
         agent: detectCodingAgent({
           recordName: span.name,
           scopeName: span.instrumentationScope.name,
+          serviceName:
+            typeof span.resourceAttributes["service.name"] === "string"
+              ? (span.resourceAttributes["service.name"] as string)
+              : null,
         }),
         occurredAt: event.occurredAt,
         traceId: span.traceId,

--- a/specs/coding-agent/session-aggregate.feature
+++ b/specs/coding-agent/session-aggregate.feature
@@ -53,7 +53,7 @@ Feature: Coding-agent sessions
     Then it appears as a single-trace session of its own
 
   Scenario: a Cowork session is an agent session
-    When Claude Cowork sends its session telemetry as events with a session id and no spans
+    When Claude Cowork exports its session telemetry as events only, under one session id
     Then the session appears with its turns, tool activity, costs and token totals
     And the session is identified as Cowork
 

--- a/specs/coding-agent/session-aggregate.feature
+++ b/specs/coding-agent/session-aggregate.feature
@@ -51,3 +51,12 @@ Feature: Coding-agent sessions
   Scenario: a session without a session id is not lost
     When a coding-agent trace arrives whose telemetry carries no session id
     Then it appears as a single-trace session of its own
+
+  Scenario: a Cowork session is an agent session
+    When Claude Cowork sends its session telemetry as events with a session id and no spans
+    Then the session appears with its turns, tool activity, costs and token totals
+    And the session is identified as Cowork
+
+  Scenario: Cowork telemetry that shares Claude Code's event vocabulary is still Cowork
+    When a session's events carry Claude Code's event names but declare the Cowork service
+    Then the session is identified as Cowork, not Claude Code

--- a/specs/coding-agent/trace-fidelity.feature
+++ b/specs/coding-agent/trace-fidelity.feature
@@ -1,7 +1,7 @@
 Feature: Coding Agent Trace Fidelity (Path B direct OTLP)
 
-  Coding assistants (claude, codex, gemini, opencode) export OpenTelemetry
-  straight to LangWatch on the direct-OTLP "Path B". This feature captures the
+  Coding assistants (claude, cowork, codex, gemini, opencode, copilot) export
+  OpenTelemetry straight to LangWatch on the direct-OTLP "Path B". This feature captures the
   fidelity guarantees for what lands on the trace: token accuracy, reasoning
   signals, tool calls, and how the bundled cost classification is surfaced.
 


### PR DESCRIPTION
## What

Three things, one seam:

1. **Claude Cowork sessions fold into `coding_agent_sessions`** — labeled `claude_cowork`, keyed by their own `session.id`. Domain call: Cowork is not a new aggregate — it is a new *emitter* of the agent-session conversation this table already models. Same event vocabulary as Claude Code (`user_prompt`, `assistant_response`, `tool_result`, `tool_decision`, `api_request`, `api_error`), same session identity; only the resource-level `service.name: cowork` distinguishes it (same runtime, same scope, same event namespace) — so the service signal is threaded through **all three dispatchers** (log, span, metric) and the trace-view transcript, and precedence is encoded once in the registry (cowork before claude_code).

2. **Logs-only sessions fold real content.** Cowork exports events, not spans — so the facts span-bearing agents fold from spans fold from its events instead: `api_request` folds the model call (tokens, cache buckets, model, rebuild detection) via the same `foldModelCall` the `llm_request` span path uses, and `tool_result` folds the tool run (name, count, step) via the shared `foldToolInvocation`. The gate is the **contribution's** agent (never the first-writer-wins state), so an agent with both signals can never double-count. `withIdentity` accepts Cowork's opaque account ids for the session's user.

3. **The per-agent knowledge is a registration-style layer** (`coding-agent-processing/agents/`), mirroring the trace-canonicalisation extractor pattern: one pure definition per agent (identity predicate, name prefixes, vendor alias quirks, span-name tool resolution) in an ordered registry, folded into shared tables by the normalization engine. Adding an agent is one definition file plus one registry entry; alias collisions fail at module load (guard proven by test). ADR-056 carries the amendment (registry pattern, sixth agent, the governance `claude_cowork` naming cross-ref).

Frontend follows: terminal-origin markers, session banner (type + service detection + banner entry), and the assistant icon preset all know Cowork, so its sessions render as Cowork instead of falling through to defaults.

## Mappings

| Cowork emits | Lands as |
|---|---|
| `session.id` | the aggregate key (`SessionId`) |
| `service.name: cowork` / `service.version` | `Agent='claude_cowork'` / `AgentVersion` (existing columns — zero schema change) |
| `api_request` events | model calls: `cost`, `input/output/cache_read/cache_creation` tokens, models, cache-rebuild detection |
| `tool_result` events | tool runs: counts, names, steps, result/input bytes, error types |
| `tool_decision` events | denials vs aborts (existing path) |
| `user.account_uuid` / `user.account_id` | session `userId` (opaque ids only; `user.email` is deliberately never read) |
| `prompt.id`, `event.sequence`, `organization.id`, `speed`, `decision_type/source`, `mcp_server_scope` | lifted contribution scalars (correlation/attribution vocabulary) |
| `tool_input`, `tool_parameters`, prompt/response content | **not lifted** — content stays in `log_records`, joined at read (house rule) |

Perf note: the log dispatcher's gate stays two-phase — cheap name/scope check first, resource-attributes parse only for agent-positive records, so ordinary application logs pay nothing new.

## Behaviour proof

- `specs/coding-agent/session-aggregate.feature`: two new scenarios (events-only Cowork session with turns/tools/costs/tokens; shared vocabulary still labeled Cowork).
- Pre-existing suites pass unchanged (the registry refactor's purity proof). New tests pin: cowork detection precedence (service beats anthropic scope), the moved vendor aliases (real wire values), the alias-collision guard, cowork labeling in all three dispatchers, logs-only model-call + tool folding, the claude_code double-count gate, account-uuid identity, `organization.id` lift.
- 103 pipeline/app-layer + 199 frontend + 46 router tests green locally.

## Notes

- This PR went through an internal opus review panel (hygiene, code, test, feature, security, spec — security and hygiene clean); the review round is commit 15634aa0b.
- The governance ingest lane (`/api/ingest/otel/:sourceId`) already accepts `claude_cowork` for span-shaped payloads; that org-level lane is untouched. This PR is the product lane (`/api/otel/v1/logs` → canonical logs → session fold). ADR-056's amendment cross-references the shared naming.
- `user.email` arrives on every Cowork event; it stays in `log_records` attributes and is deliberately not projected into the session row.
- Follow-up PR (separate branch): retiring the legacy `stored_log_records` write chain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude Cowork assistant kind with matching icon preset.
  * Updated session/banner labeling so Cowork sessions display “Claude Cowork”.
  * Extended coding-agent transcript/session aggregation and trace-fidelity capture to recognize Cowork telemetry.
* **Bug Fixes**
  * Prevented Cowork runs from being misclassified as Claude Code by prioritizing `service.name: "cowork"`.
  * Improved event-only Cowork folding so sessions aggregate turns, tools, tokens, costs, and user attribution correctly.
* **Refactor**
  * Centralized coding-agent detection and normalization via a shared registry with alias-merging conflict checks.
* **Tests**
  * Added/expanded coverage for Cowork identification and aggregation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deployment Impact

- **No migration, no schema change**: `Agent`/`AgentVersion` are existing LowCardinality columns; `claude_cowork` is just a new value. No chart, env, or self-hosting change.
- Standard app rollout; behaviour changes only for telemetry whose resource says `service.name: cowork` (previously mislabeled `claude_code` or dropped) and for events-only sessions, whose model-call/tool folding starts on new contributions — no backfill, historical rows unchanged.
- The log dispatcher's resource-attribute parse stays gated behind the cheap name/scope check, so non-agent log volume costs nothing new.

