### PR TITLE
fix(langy): cut hopeless LLM 429 retry loops at the relay, chart netpol collector egress + IPv6 opt-in

### DIFF
--- a/charts/langyagent/templates/networkpolicy.yaml
+++ b/charts/langyagent/templates/networkpolicy.yaml
@@ -77,6 +77,26 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.networkPolicy.gatewayPort }}
+    {{- with .Values.networkPolicy.egressToOtelCollector }}
+    # Manager OTLP export (OTEL_OTLP_ENDPOINT). Without this rule a manager
+    # pointed at an in-cluster collector is silently blackholed by the
+    # default-deny; OTel exporters fail quietly by design, so the only symptom
+    # is telemetry that never arrives.
+    #
+    # AWS EKS eBPF dataplane gotcha, learned in production: egress to a
+    # ClusterIP Service is enforced PRE-DNAT against the Service's ClusterIP,
+    # and the network-policy controller only resolves that ClusterIP into the
+    # allow-list when this rule's podSelector matches the SERVICE's
+    # spec.selector labels (the selector map matched as a label set): matching
+    # only the POD labels resolves the pod IPs but not the ClusterIP, so the
+    # service-DNS path times out while direct pod-IP connects work. Select on
+    # the labels the collector's Service selects on.
+    - to:
+        {{- toYaml . | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ $.Values.networkPolicy.otelCollectorPort }}
+    {{- end }}
     {{- if .Values.networkPolicy.allowExternalHttps }}
     # External HTTPS (OpenCode update/telemetry, git/gh/npm over :443). This is
     # the pod's ONLY route to the public internet, and the most dangerous rule
@@ -108,12 +128,24 @@ spec:
               {{- range .Values.networkPolicy.privateExcept }}
               - {{ . }}
               {{- end }}
+        {{- if .Values.networkPolicy.allowExternalHttpsIpv6 }}
+        # OPT-IN, and only for genuinely dual-stack clusters. On an IPv4-only
+        # cluster this block is dead weight that BREAKS the AWS EKS eBPF
+        # dataplane: the aws-network-policy-agent's per-pod allow-list is an
+        # IPv4 LPM trie, a v6 `except` key (prefix length > 32) fails the map
+        # write with EINVAL, and the agent aborts the ENTIRE egress refresh on
+        # that first bad key. The policy then silently freezes at its pod-birth
+        # snapshot: every later endpoint change (a control-plane or gateway
+        # deploy, a collector move) leaves the pod pointed at stale IPs.
+        # IPv4-only pods cannot emit IPv6 anyway; omitting the rule DENIES v6
+        # (fail closed), it does not allow it.
         - ipBlock:
             cidr: ::/0
             except:
               {{- range .Values.networkPolicy.privateExceptV6 }}
               - {{ . }}
               {{- end }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: 443

--- a/charts/langyagent/values.yaml
+++ b/charts/langyagent/values.yaml
@@ -210,6 +210,26 @@ networkPolicy:
   egressToControlPlane: []
   gatewayPort: 5563
   egressToGateway: []
+  # Manager OTLP telemetry egress (OTEL_OTLP_ENDPOINT). Empty by default: no
+  # rule is rendered, and a manager pointed at an in-cluster collector is
+  # silently blackholed by the default-deny; OTel exporters fail quietly by
+  # design, so set this whenever telemetry targets a cluster-internal
+  # collector. On the AWS EKS eBPF dataplane the podSelector here must match
+  # the collector SERVICE's spec.selector labels, not merely the pods' — see
+  # the rule comment in networkpolicy.yaml (pre-DNAT ClusterIP enforcement).
+  #
+  # Example:
+  #   egressToOtelCollector:
+  #     - namespaceSelector:
+  #         matchLabels:
+  #           kubernetes.io/metadata.name: observability
+  #       podSelector:
+  #         matchLabels:
+  #           app.kubernetes.io/name: otel-collector
+  egressToOtelCollector: []
+  # The collector's POD port for the rule above (NetworkPolicy egress ports
+  # match the destination pod port). 4318 is OTLP/HTTP's default.
+  otelCollectorPort: 4318
   # External HTTPS egress for OpenCode workers — needed for `git clone`,
   # `gh` API calls, npm/pip installs the LLM-driven tools shell out to, and
   # opencode's own update/telemetry. Default false: this pod runs LLM-
@@ -257,6 +277,17 @@ networkPolicy:
                           # CIDR places PODS (and sometimes NODES + the apiserver
                           # ENI) here; NOT covered by RFC1918, so it MUST be
                           # excluded or a worker reaches neighbours on :443.
+  # IPv6 side of the external-HTTPS rule (`::/0` with the excepts below):
+  # OPT-IN, and only for genuinely dual-stack clusters. On an IPv4-only EKS
+  # cluster the v6 block is not just dead weight, it BREAKS enforcement: the
+  # aws-network-policy-agent's per-pod allow-list is an IPv4 LPM trie, a v6
+  # `except` key fails the eBPF map write with EINVAL, and the agent aborts
+  # the ENTIRE egress refresh on that first bad key, so the policy silently
+  # freezes at its pod-birth snapshot and every later endpoint change (a
+  # control-plane or gateway deploy, a collector move) leaves the pod pointed
+  # at stale IPs. IPv4-only pods cannot emit IPv6 anyway; omitting the rule
+  # DENIES v6 (fail closed), it does not allow it.
+  allowExternalHttpsIpv6: false
   privateExceptV6:
     - fd00::/8            # unique-local (incl. IPv6 metadata fd00:ec2::254)
     - fe80::/10           # link-local

--- a/services/langyagent/adapters/otelrelay/llmproxy.go
+++ b/services/langyagent/adapters/otelrelay/llmproxy.go
@@ -179,6 +179,22 @@ func (r *Relay) handleLLM(w http.ResponseWriter, req *http.Request) {
 			// The envelope deliberately carries no HTTP status; keep it in meta.
 			e.Meta["http_status"] = resp.StatusCode
 			entry.setLLMError(e)
+			// A 429 is retryable by the worker SDK's book, which is right for a
+			// burst and an endless silent spinner for a hard plan limit. Cut the
+			// loop here (see cutRateLimitRetry): the SDK sees a final failure,
+			// the turn fails, and the captured error above still carries the
+			// provider's own cause for the panel's plan-limit card.
+			if resp.StatusCode == http.StatusTooManyRequests {
+				hard := hasHardLimitReason(e)
+				strikes := entry.strikeRateLimit()
+				if hard || strikes >= rateLimitCutAfter {
+					cutRateLimitRetry(resp)
+					clog.Get(r.baseCtx).Info("otelrelay llm rate-limit retry loop cut",
+						zap.String("conversation", entry.info.ConversationID),
+						zap.Bool("hard_limit", hard),
+						zap.Int("consecutive", strikes))
+				}
+			}
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
@@ -218,6 +234,50 @@ func llmTargetURL(gatewayBaseURL, token string, reqURL *url.URL) (*url.URL, erro
 // backend's `{"detail": ...}`). The provider's message rides Meta["message"]
 // so the turn's terminal error frame still names the real failure.
 const llmUpstreamErrorCode = herr.Code("llm_upstream_error")
+
+// rateLimitCutAfter is how many CONSECUTIVE 429s a conversation's mediated LLM
+// calls may accumulate before the proxy converts the next one into a
+// non-retryable failure. A genuine burst (tokens-per-minute) clears within a
+// retry or two; only a limit that answers every backoff identically reaches
+// three in a row.
+const rateLimitCutAfter = 3
+
+// hardLimitReasonCodes are the provider discriminants that mark a 429 as a
+// PLAN limit — deterministic until the provider's window resets — rather than
+// a burst. These cut the retry loop on the FIRST strike: every retry would be
+// answered identically, and the panel already has bespoke copy for them
+// (langyErrorExplainer promotes `usage_limit_reached` to the plan-limit card).
+var hardLimitReasonCodes = map[herr.Code]bool{
+	"usage_limit_reached": true,
+	"codex_plan_limit":    true,
+}
+
+// hasHardLimitReason walks a captured LLM error's code and reason chain for a
+// hard plan-limit discriminant.
+func hasHardLimitReason(e herr.E) bool {
+	if hardLimitReasonCodes[e.Code] {
+		return true
+	}
+	for _, reason := range e.Reasons {
+		if nested, ok := reason.(herr.E); ok && hasHardLimitReason(nested) {
+			return true
+		}
+	}
+	return false
+}
+
+// cutRateLimitRetry rewrites an upstream 429 into a response the worker SDK
+// treats as FINAL. The body — the provider's own error JSON — passes through
+// untouched, so the agent's error event and the captured herr both still name
+// the real cause; only the status stops being an invitation to retry. The
+// retry-steering headers go with it so no SDK second-guesses the status.
+func cutRateLimitRetry(resp *http.Response) {
+	resp.StatusCode = http.StatusBadRequest
+	resp.Status = "400 Bad Request"
+	resp.Header.Del("Retry-After")
+	resp.Header.Del("x-should-retry")
+	resp.Header.Del("retry-after-ms")
+}
 
 // maxUpstreamMessageBytes bounds the provider message carried on a best-effort
 // capture, so a pathological body never bloats the error frame.

--- a/services/langyagent/adapters/otelrelay/llmproxy.go
+++ b/services/langyagent/adapters/otelrelay/llmproxy.go
@@ -184,16 +184,23 @@ func (r *Relay) handleLLM(w http.ResponseWriter, req *http.Request) {
 			// loop here (see cutRateLimitRetry): the SDK sees a final failure,
 			// the turn fails, and the captured error above still carries the
 			// provider's own cause for the panel's plan-limit card.
-			if resp.StatusCode == http.StatusTooManyRequests {
-				hard := hasHardLimitReason(e)
-				strikes := entry.strikeRateLimit()
-				if hard || strikes >= rateLimitCutAfter {
-					cutRateLimitRetry(resp)
-					clog.Get(r.baseCtx).Info("otelrelay llm rate-limit retry loop cut",
-						zap.String("conversation", entry.info.ConversationID),
-						zap.Bool("hard_limit", hard),
-						zap.Int("consecutive", strikes))
-				}
+			//
+			// The count is of UNINTERRUPTED 429s: any other answer, a 500
+			// included, resets it (without touching the capture above). A mixed
+			// flap is not a deterministic limit, and only a limit that answers
+			// every backoff identically should be cut.
+			if resp.StatusCode != http.StatusTooManyRequests {
+				entry.resetRateLimitStrikes()
+				return nil
+			}
+			hard := hasHardLimitReason(e)
+			strikes := entry.strikeRateLimit()
+			if hard || strikes >= rateLimitCutAfter {
+				cutRateLimitRetry(resp)
+				clog.Get(r.baseCtx).Info("otelrelay llm rate-limit retry loop cut",
+					zap.String("conversation", entry.info.ConversationID),
+					zap.Bool("hard_limit", hard),
+					zap.Int("consecutive", strikes))
 			}
 			return nil
 		},

--- a/services/langyagent/adapters/otelrelay/llmproxy_test.go
+++ b/services/langyagent/adapters/otelrelay/llmproxy_test.go
@@ -494,3 +494,128 @@ func TestLLMProxy_ErrorCapture(t *testing.T) {
 		}
 	})
 }
+
+// The proxy ends a hopeless retry loop: a hard plan limit answers every retry
+// identically, and the worker SDK's ever-growing backoff otherwise leaves the
+// turn spinning silently for hours while the panel's plan-limit card never
+// gets its chance.
+func TestLLMProxyRateLimitCut(t *testing.T) {
+	// One relay-mediated call; the fake gateway answers whatever the test
+	// scripted next.
+	callThrough := func(t *testing.T, relay *Relay, token string) *http.Response {
+		t.Helper()
+		resp, err := http.Post(relay.LLMBaseURLFor(token)+"/chat/completions", "application/json", strings.NewReader(`{}`))
+		if err != nil {
+			t.Fatalf("proxied LLM call: %v", err)
+		}
+		t.Cleanup(func() { resp.Body.Close() })
+		return resp
+	}
+
+	const usageLimitBody = `{"error":{"type":"usage_limit_reached","message":"You've hit your usage limit.","resets_in_seconds":10000}}`
+	const burstBody = `{"error":{"type":"rate_limit_exceeded","message":"Rate limit reached, retry shortly."}}`
+
+	// @scenario "A provider that says its usage limit is reached fails the turn at once"
+	t.Run("when the provider names its usage limit as reached", func(t *testing.T) {
+		gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Retry-After", "600")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(usageLimitBody))
+		}))
+		defer gateway.Close()
+
+		relay := startRelay(t)
+		token, _ := relay.Register(WorkerInfo{ConversationID: "conv-hard-limit", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
+
+		resp := callThrough(t, relay, token)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("first hard-limit call answered %d, want 400: the SDK must not retry into the same wall", resp.StatusCode)
+		}
+		if got := resp.Header.Get("Retry-After"); got != "" {
+			t.Errorf("Retry-After %q survived the cut; no header may invite a retry", got)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != usageLimitBody {
+			t.Errorf("body was altered by the cut:\n got %s\nwant %s", body, usageLimitBody)
+		}
+
+		// The captured cause still tells the truth: upstream said 429, and the
+		// discriminant the panel promotes to the plan-limit card is intact.
+		e, ok := relay.LastLLMError(token)
+		if !ok {
+			t.Fatal("the cut call must still leave a captured cause")
+		}
+		if e.Meta["http_status"] != http.StatusTooManyRequests {
+			t.Errorf("captured http_status = %v, want the REAL upstream 429", e.Meta["http_status"])
+		}
+		var cause herr.E
+		if len(e.Reasons) != 1 || !errors.As(e.Reasons[0], &cause) || cause.Code != "usage_limit_reached" {
+			t.Errorf("captured reasons = %v, want the usage_limit_reached discriminant", e.Reasons)
+		}
+	})
+
+	// @scenario "A rate-limit burst keeps its normal retries, then is cut"
+	t.Run("when the provider rate-limits without naming a deterministic limit", func(t *testing.T) {
+		var status int
+		gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Retry-After", "2")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			if status == http.StatusTooManyRequests {
+				_, _ = w.Write([]byte(burstBody))
+			} else {
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}
+		}))
+		defer gateway.Close()
+
+		relay := startRelay(t)
+		token, _ := relay.Register(WorkerInfo{ConversationID: "conv-burst", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
+
+		status = http.StatusTooManyRequests
+		for i := 1; i <= 2; i++ {
+			resp := callThrough(t, relay, token)
+			if resp.StatusCode != http.StatusTooManyRequests {
+				t.Fatalf("burst strike %d answered %d, want the 429 passed through for the SDK's own backoff", i, resp.StatusCode)
+			}
+			if resp.Header.Get("Retry-After") == "" {
+				t.Errorf("burst strike %d lost its Retry-After; a passed-through 429 keeps its headers", i)
+			}
+		}
+		if resp := callThrough(t, relay, token); resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("third consecutive 429 answered %d, want 400: the loop must be cut", resp.StatusCode)
+		}
+
+		// A success starts the count over: the next 429 is a fresh strike one.
+		status = http.StatusOK
+		if resp := callThrough(t, relay, token); resp.StatusCode != http.StatusOK {
+			t.Fatal("the scripted success must pass through")
+		}
+		status = http.StatusTooManyRequests
+		if resp := callThrough(t, relay, token); resp.StatusCode != http.StatusTooManyRequests {
+			t.Fatal("after a success the first 429 must pass through again: the count restarted")
+		}
+	})
+
+	// @scenario "A rate-limited conversation never blocks a healthy one"
+	t.Run("when a different conversation calls after another was cut", func(t *testing.T) {
+		gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(burstBody))
+		}))
+		defer gateway.Close()
+
+		relay := startRelay(t)
+		cutToken, _ := relay.Register(WorkerInfo{ConversationID: "conv-cut", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
+		freshToken, _ := relay.Register(WorkerInfo{ConversationID: "conv-fresh", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
+
+		for i := 0; i < rateLimitCutAfter; i++ {
+			callThrough(t, relay, cutToken)
+		}
+		if resp := callThrough(t, relay, freshToken); resp.StatusCode != http.StatusTooManyRequests {
+			t.Fatalf("the fresh conversation's first 429 answered %d, want the passthrough of its own strike one", resp.StatusCode)
+		}
+	})
+}

--- a/services/langyagent/adapters/otelrelay/llmproxy_test.go
+++ b/services/langyagent/adapters/otelrelay/llmproxy_test.go
@@ -499,123 +499,161 @@ func TestLLMProxy_ErrorCapture(t *testing.T) {
 // identically, and the worker SDK's ever-growing backoff otherwise leaves the
 // turn spinning silently for hours while the panel's plan-limit card never
 // gets its chance.
-func TestLLMProxyRateLimitCut(t *testing.T) {
-	// One relay-mediated call; the fake gateway answers whatever the test
-	// scripted next.
-	callThrough := func(t *testing.T, relay *Relay, token string) *http.Response {
-		t.Helper()
-		resp, err := http.Post(relay.LLMBaseURLFor(token)+"/chat/completions", "application/json", strings.NewReader(`{}`))
-		if err != nil {
-			t.Fatalf("proxied LLM call: %v", err)
+
+const rateLimitUsageLimitBody = `{"error":{"type":"usage_limit_reached","message":"You've hit your usage limit.","resets_in_seconds":10000}}`
+const rateLimitBurstBody = `{"error":{"type":"rate_limit_exceeded","message":"Rate limit reached, retry shortly."}}`
+
+// rateLimitGateway answers every call with whatever status the test scripted
+// next, with a Retry-After header and the matching body.
+func rateLimitGateway(t *testing.T, status *int) *httptest.Server {
+	t.Helper()
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(*status)
+		switch *status {
+		case http.StatusTooManyRequests:
+			_, _ = w.Write([]byte(rateLimitBurstBody))
+		case http.StatusOK:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			_, _ = w.Write([]byte(`{"error":{"message":"upstream sad"}}`))
 		}
-		t.Cleanup(func() { resp.Body.Close() })
-		return resp
+	}))
+	t.Cleanup(gateway.Close)
+	return gateway
+}
+
+// rateLimitCall makes one relay-mediated LLM call and returns the response.
+func rateLimitCall(t *testing.T, relay *Relay, token string) *http.Response {
+	t.Helper()
+	resp, err := http.Post(relay.LLMBaseURLFor(token)+"/chat/completions", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("proxied LLM call: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+// @scenario "A provider that says its usage limit is reached fails the turn at once"
+func TestLLMProxyRateLimitCut_HardLimit(t *testing.T) {
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "600")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(rateLimitUsageLimitBody))
+	}))
+	defer gateway.Close()
+
+	relay := startRelay(t)
+	token, _ := relay.Register(WorkerInfo{ConversationID: "conv-hard-limit", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
+
+	resp := rateLimitCall(t, relay, token)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("first hard-limit call answered %d, want 400: the SDK must not retry into the same wall", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Retry-After"); got != "" {
+		t.Errorf("Retry-After %q survived the cut; no header may invite a retry", got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != rateLimitUsageLimitBody {
+		t.Errorf("body was altered by the cut:\n got %s\nwant %s", body, rateLimitUsageLimitBody)
 	}
 
-	const usageLimitBody = `{"error":{"type":"usage_limit_reached","message":"You've hit your usage limit.","resets_in_seconds":10000}}`
-	const burstBody = `{"error":{"type":"rate_limit_exceeded","message":"Rate limit reached, retry shortly."}}`
+	// The captured cause still tells the truth: upstream said 429, and the
+	// discriminant the panel promotes to the plan-limit card is intact.
+	e, ok := relay.LastLLMError(token)
+	if !ok {
+		t.Fatal("the cut call must still leave a captured cause")
+	}
+	if e.Meta["http_status"] != http.StatusTooManyRequests {
+		t.Errorf("captured http_status = %v, want the REAL upstream 429", e.Meta["http_status"])
+	}
+	var cause herr.E
+	if len(e.Reasons) != 1 || !errors.As(e.Reasons[0], &cause) || cause.Code != "usage_limit_reached" {
+		t.Errorf("captured reasons = %v, want the usage_limit_reached discriminant", e.Reasons)
+	}
+}
 
-	// @scenario "A provider that says its usage limit is reached fails the turn at once"
-	t.Run("when the provider names its usage limit as reached", func(t *testing.T) {
-		gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Retry-After", "600")
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte(usageLimitBody))
-		}))
-		defer gateway.Close()
+// @scenario "A rate-limit burst keeps its normal retries, then is cut"
+func TestLLMProxyRateLimitCut_BurstThenCut(t *testing.T) {
+	status := http.StatusTooManyRequests
+	gateway := rateLimitGateway(t, &status)
 
-		relay := startRelay(t)
-		token, _ := relay.Register(WorkerInfo{ConversationID: "conv-hard-limit", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
+	relay := startRelay(t)
+	token, _ := relay.Register(WorkerInfo{ConversationID: "conv-burst", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
 
-		resp := callThrough(t, relay, token)
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("first hard-limit call answered %d, want 400: the SDK must not retry into the same wall", resp.StatusCode)
+	for i := 1; i <= 2; i++ {
+		resp := rateLimitCall(t, relay, token)
+		if resp.StatusCode != http.StatusTooManyRequests {
+			t.Fatalf("burst strike %d answered %d, want the 429 passed through for the SDK's own backoff", i, resp.StatusCode)
 		}
-		if got := resp.Header.Get("Retry-After"); got != "" {
-			t.Errorf("Retry-After %q survived the cut; no header may invite a retry", got)
+		if resp.Header.Get("Retry-After") == "" {
+			t.Errorf("burst strike %d lost its Retry-After; a passed-through 429 keeps its headers", i)
 		}
-		body, _ := io.ReadAll(resp.Body)
-		if string(body) != usageLimitBody {
-			t.Errorf("body was altered by the cut:\n got %s\nwant %s", body, usageLimitBody)
-		}
+	}
+	if resp := rateLimitCall(t, relay, token); resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("third consecutive 429 answered %d, want 400: the loop must be cut", resp.StatusCode)
+	}
 
-		// The captured cause still tells the truth: upstream said 429, and the
-		// discriminant the panel promotes to the plan-limit card is intact.
-		e, ok := relay.LastLLMError(token)
-		if !ok {
-			t.Fatal("the cut call must still leave a captured cause")
-		}
-		if e.Meta["http_status"] != http.StatusTooManyRequests {
-			t.Errorf("captured http_status = %v, want the REAL upstream 429", e.Meta["http_status"])
-		}
-		var cause herr.E
-		if len(e.Reasons) != 1 || !errors.As(e.Reasons[0], &cause) || cause.Code != "usage_limit_reached" {
-			t.Errorf("captured reasons = %v, want the usage_limit_reached discriminant", e.Reasons)
-		}
-	})
+	// A success starts the count over: the next 429 is a fresh strike one.
+	status = http.StatusOK
+	if resp := rateLimitCall(t, relay, token); resp.StatusCode != http.StatusOK {
+		t.Fatal("the scripted success must pass through")
+	}
+	status = http.StatusTooManyRequests
+	if resp := rateLimitCall(t, relay, token); resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatal("after a success the first 429 must pass through again: the count restarted")
+	}
+}
 
-	// @scenario "A rate-limit burst keeps its normal retries, then is cut"
-	t.Run("when the provider rate-limits without naming a deterministic limit", func(t *testing.T) {
-		var status int
-		gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Retry-After", "2")
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(status)
-			if status == http.StatusTooManyRequests {
-				_, _ = w.Write([]byte(burstBody))
-			} else {
-				_, _ = w.Write([]byte(`{"ok":true}`))
-			}
-		}))
-		defer gateway.Close()
+// A mixed flap is not a deterministic limit: any non-429 answer, a 500
+// included, breaks the run and the count starts over, while the captured
+// cause keeps naming the most recent real failure.
+//
+// @scenario "A rate-limit burst keeps its normal retries, then is cut"
+func TestLLMProxyRateLimitCut_InterruptedRunResets(t *testing.T) {
+	status := http.StatusTooManyRequests
+	gateway := rateLimitGateway(t, &status)
 
-		relay := startRelay(t)
-		token, _ := relay.Register(WorkerInfo{ConversationID: "conv-burst", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
+	relay := startRelay(t)
+	token, _ := relay.Register(WorkerInfo{ConversationID: "conv-flap", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
 
-		status = http.StatusTooManyRequests
-		for i := 1; i <= 2; i++ {
-			resp := callThrough(t, relay, token)
-			if resp.StatusCode != http.StatusTooManyRequests {
-				t.Fatalf("burst strike %d answered %d, want the 429 passed through for the SDK's own backoff", i, resp.StatusCode)
-			}
-			if resp.Header.Get("Retry-After") == "" {
-				t.Errorf("burst strike %d lost its Retry-After; a passed-through 429 keeps its headers", i)
-			}
-		}
-		if resp := callThrough(t, relay, token); resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("third consecutive 429 answered %d, want 400: the loop must be cut", resp.StatusCode)
-		}
+	rateLimitCall(t, relay, token) // 429, strike one
 
-		// A success starts the count over: the next 429 is a fresh strike one.
-		status = http.StatusOK
-		if resp := callThrough(t, relay, token); resp.StatusCode != http.StatusOK {
-			t.Fatal("the scripted success must pass through")
-		}
-		status = http.StatusTooManyRequests
-		if resp := callThrough(t, relay, token); resp.StatusCode != http.StatusTooManyRequests {
-			t.Fatal("after a success the first 429 must pass through again: the count restarted")
-		}
-	})
+	status = http.StatusInternalServerError
+	if resp := rateLimitCall(t, relay, token); resp.StatusCode != http.StatusInternalServerError {
+		t.Fatal("the scripted 500 must pass through")
+	}
+	// The 500 resets the run but its capture survives as the latest cause.
+	if e, ok := relay.LastLLMError(token); !ok || e.Meta["http_status"] != http.StatusInternalServerError {
+		t.Errorf("after the 500 the captured cause = %v, want the 500 kept", e.Meta)
+	}
 
-	// @scenario "A rate-limited conversation never blocks a healthy one"
-	t.Run("when a different conversation calls after another was cut", func(t *testing.T) {
-		gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte(burstBody))
-		}))
-		defer gateway.Close()
-
-		relay := startRelay(t)
-		cutToken, _ := relay.Register(WorkerInfo{ConversationID: "conv-cut", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
-		freshToken, _ := relay.Register(WorkerInfo{ConversationID: "conv-fresh", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
-
-		for i := 0; i < rateLimitCutAfter; i++ {
-			callThrough(t, relay, cutToken)
+	status = http.StatusTooManyRequests
+	for i := 1; i <= 2; i++ {
+		if resp := rateLimitCall(t, relay, token); resp.StatusCode != http.StatusTooManyRequests {
+			t.Fatalf("429 number %d after the 500 answered %d, want passthrough: the 500 restarted the count", i, resp.StatusCode)
 		}
-		if resp := callThrough(t, relay, freshToken); resp.StatusCode != http.StatusTooManyRequests {
-			t.Fatalf("the fresh conversation's first 429 answered %d, want the passthrough of its own strike one", resp.StatusCode)
-		}
-	})
+	}
+	if resp := rateLimitCall(t, relay, token); resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("third uninterrupted 429 answered %d, want 400: the fresh run reached the cut", resp.StatusCode)
+	}
+}
+
+// @scenario "A rate-limited conversation never blocks a healthy one"
+func TestLLMProxyRateLimitCut_ConversationIsolation(t *testing.T) {
+	status := http.StatusTooManyRequests
+	gateway := rateLimitGateway(t, &status)
+
+	relay := startRelay(t)
+	cutToken, _ := relay.Register(WorkerInfo{ConversationID: "conv-cut", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
+	freshToken, _ := relay.Register(WorkerInfo{ConversationID: "conv-fresh", GatewayBaseURL: gateway.URL, LLMVirtualKey: "vk"})
+
+	for i := 0; i < rateLimitCutAfter; i++ {
+		rateLimitCall(t, relay, cutToken)
+	}
+	if resp := rateLimitCall(t, relay, freshToken); resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("the fresh conversation's first 429 answered %d, want the passthrough of its own strike one", resp.StatusCode)
+	}
 }

--- a/services/langyagent/adapters/otelrelay/llmproxy_test.go
+++ b/services/langyagent/adapters/otelrelay/llmproxy_test.go
@@ -503,8 +503,6 @@ func TestLLMProxy_ErrorCapture(t *testing.T) {
 const rateLimitUsageLimitBody = `{"error":{"type":"usage_limit_reached","message":"You've hit your usage limit.","resets_in_seconds":10000}}`
 const rateLimitBurstBody = `{"error":{"type":"rate_limit_exceeded","message":"Rate limit reached, retry shortly."}}`
 
-// rateLimitGateway answers every call with whatever status the test scripted
-// next, with a Retry-After header and the matching body.
 func rateLimitGateway(t *testing.T, status *int) *httptest.Server {
 	t.Helper()
 	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -524,7 +522,6 @@ func rateLimitGateway(t *testing.T, status *int) *httptest.Server {
 	return gateway
 }
 
-// rateLimitCall makes one relay-mediated LLM call and returns the response.
 func rateLimitCall(t *testing.T, relay *Relay, token string) *http.Response {
 	t.Helper()
 	resp, err := http.Post(relay.LLMBaseURLFor(token)+"/chat/completions", "application/json", strings.NewReader(`{}`))

--- a/services/langyagent/adapters/otelrelay/otelrelay.go
+++ b/services/langyagent/adapters/otelrelay/otelrelay.go
@@ -173,8 +173,6 @@ func (e *workerEntry) clearLLMError() {
 	e.mu.Unlock()
 }
 
-// strikeRateLimit records one more consecutive rate-limited call and returns
-// the running count.
 func (e *workerEntry) strikeRateLimit() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/services/langyagent/adapters/otelrelay/otelrelay.go
+++ b/services/langyagent/adapters/otelrelay/otelrelay.go
@@ -182,6 +182,15 @@ func (e *workerEntry) strikeRateLimit() int {
 	return e.rateLimitStrikes
 }
 
+// resetRateLimitStrikes zeroes the consecutive-429 count without touching the
+// captured llmErr: any non-429 answer breaks the run, but a captured 5xx
+// cause must survive as the turn's most recent real failure.
+func (e *workerEntry) resetRateLimitStrikes() {
+	e.mu.Lock()
+	e.rateLimitStrikes = 0
+	e.mu.Unlock()
+}
+
 func (e *workerEntry) lastLLMError() (herr.E, bool) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()

--- a/services/langyagent/adapters/otelrelay/otelrelay.go
+++ b/services/langyagent/adapters/otelrelay/otelrelay.go
@@ -135,13 +135,22 @@ type workerEntry struct {
 	// cause behind the agent's laundered error event, captured so the turn's
 	// terminal error frame can carry the full typed chain through.
 	llmErr *herr.E
+	// rateLimitStrikes counts CONSECUTIVE rate-limited (429) mediated LLM
+	// calls for this conversation. A successful call resets it, as does a new
+	// turn. At the cut threshold handleLLM stops the worker SDK's retry loop:
+	// a hard plan limit answers every retry identically, and the SDK's
+	// ever-growing backoff otherwise leaves the turn spinning silently.
+	rateLimitStrikes int
 }
 
 func (e *workerEntry) setTurn(sc trace.SpanContext) {
 	e.mu.Lock()
 	e.turn = sc
-	// A new turn must never inherit the previous turn's failure as its cause.
+	// A new turn must never inherit the previous turn's failure as its cause,
+	// nor its rate-limit strikes: the user asked something new, so let the SDK
+	// retry from a clean slate (a hard limit will re-strike immediately).
 	e.llmErr = nil
+	e.rateLimitStrikes = 0
 	e.mu.Unlock()
 }
 
@@ -160,7 +169,17 @@ func (e *workerEntry) setLLMError(err herr.E) {
 func (e *workerEntry) clearLLMError() {
 	e.mu.Lock()
 	e.llmErr = nil
+	e.rateLimitStrikes = 0
 	e.mu.Unlock()
+}
+
+// strikeRateLimit records one more consecutive rate-limited call and returns
+// the running count.
+func (e *workerEntry) strikeRateLimit() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.rateLimitStrikes++
+	return e.rateLimitStrikes
 }
 
 func (e *workerEntry) lastLLMError() (herr.E, bool) {

--- a/specs/langy/langy-turn-recovery.feature
+++ b/specs/langy/langy-turn-recovery.feature
@@ -184,3 +184,36 @@ Feature: Langy recovers from a failed turn without making the user re-ask
     When both try to terminate the same turn
     Then only the first terminal is recorded
     And the second is collapsed as a duplicate, like a tool call's terminals
+
+  # A provider rate limit is retryable by every SDK's book, and for a burst
+  # (tokens-per-minute) that is right: back off a little and the call lands.
+  # But a PLAN limit ("usage limit reached until next week") answers every
+  # retry identically, and the coding agent's ever-growing backoff turns that
+  # into an hours-long silent spinner: the turn never fails, so the plan-limit
+  # card the panel already knows how to draw never gets its chance. The relay
+  # sits between the agent and the gateway and is the one place that sees every
+  # rejected call, so it is the one that ends the loop: it converts the hard
+  # rate limit into a failure the agent's SDK treats as final, keeping the
+  # provider's own body so the turn's error frame still names the real cause.
+
+  @unit
+  Scenario: A provider that says its usage limit is reached fails the turn at once
+    Given the model provider rejects a relayed call with a rate limit that names its usage limit as reached
+    When the relay answers the coding agent
+    Then the answer is a failure the agent's SDK does not retry
+    And it carries the provider's own error body unchanged
+    And the turn fails with the plan-limit explanation instead of spinning
+
+  @unit
+  Scenario: A rate-limit burst keeps its normal retries, then is cut
+    Given the model provider rate-limits relayed calls without naming a deterministic limit
+    When the same conversation's calls keep being rate-limited with no success in between
+    Then the first two rejections pass through for the SDK's own backoff
+    And the third consecutive rejection becomes a failure the SDK does not retry
+    But a successful call in between starts the count over
+
+  @unit
+  Scenario: A rate-limited conversation never blocks a healthy one
+    Given one conversation has been cut off at a hard rate limit
+    When a different conversation's calls are relayed
+    Then they pass through untouched with their own fresh count

--- a/specs/langy/langy-turn-recovery.feature
+++ b/specs/langy/langy-turn-recovery.feature
@@ -207,10 +207,10 @@ Feature: Langy recovers from a failed turn without making the user re-ask
   @unit
   Scenario: A rate-limit burst keeps its normal retries, then is cut
     Given the model provider rate-limits relayed calls without naming a deterministic limit
-    When the same conversation's calls keep being rate-limited with no success in between
+    When the same conversation's calls keep being rate-limited without interruption
     Then the first two rejections pass through for the SDK's own backoff
-    And the third consecutive rejection becomes a failure the SDK does not retry
-    But a successful call in between starts the count over
+    And the third uninterrupted rejection becomes a failure the SDK does not retry
+    But any other answer in between, a success or a different error, starts the count over
 
   @unit
   Scenario: A rate-limited conversation never blocks a healthy one


### PR DESCRIPTION
## What

Two hardening changes coming out of today's prod incident where Langy chats hung on "Starting up..." and "Poking Langy..." forever, plus the langyagent chart learnings from the same investigation.

### 1. The relay cuts hopeless LLM 429 retry loops

A conversation on the codex provider hit OpenAI's plan usage limit. The upstream answers every call with HTTP 429, the worker SDK treats 429 as retryable, and its exponential backoff grew to 8 to 17 minutes between attempts. The turn therefore never failed: no terminal error frame, no plan-limit card (which the panel already knows how to draw), just an eternal spinner.

The relay's LLM proxy is the one place that sees every rejected call, so it now ends the loop:

- A 429 whose body carries a hard plan-limit discriminant (`usage_limit_reached`, `codex_plan_limit`) is converted to a non-retryable 400 on the first strike.
- An undiscriminated 429 (a genuine tokens-per-minute burst) passes through twice for the SDK's own backoff and is cut on the third consecutive strike. Any success resets the count, as does a new turn.
- The provider's body passes through byte-for-byte and the captured cause keeps the real upstream status (429) plus the discriminant, so the turn's terminal frame still names the true failure and the panel renders its existing plan-limit card.
- Strike counts are per conversation; one rate-limited conversation never affects another.

Spec: `specs/langy/langy-turn-recovery.feature` (three new scenarios), bound by `llmproxy_test.go`.

### 2. Chart: collector egress rule + IPv6 external block made opt-in

Both encode what the prod incident taught us about the AWS EKS eBPF NetworkPolicy dataplane (aws-network-policy-agent):

- **`networkPolicy.egressToOtelCollector` (new, default empty):** a manager pointed at an in-cluster OTLP collector was silently blackholed by the default-deny; OTel exporters fail quietly by design, so the only symptom is telemetry that never arrives. The rule comment documents the sharp edge we hit in prod: egress to a ClusterIP Service is enforced pre-DNAT against the ClusterIP, and the EKS policy controller only resolves that ClusterIP into the allow-list when the rule's podSelector matches the collector Service's own `spec.selector` labels (matched as a label set). Selecting on a pod-only label resolves pod IPs but not the ClusterIP, so the service-DNS path times out while direct pod-IP connects work.
- **`networkPolicy.allowExternalHttpsIpv6` (new, default false):** the `::/0` external block is now opt-in. On an IPv4-only cluster it is not just dead weight, it breaks enforcement: the agent's per-pod allow-list is an IPv4 LPM trie, a v6 `except` key fails the eBPF map write with EINVAL, and the agent aborts the entire egress refresh on the first bad key. The policy silently freezes at its pod-birth snapshot and every later endpoint change (an app or gateway deploy) leaves the pod pointed at stale IPs. In prod this had blocked every egress map update for langy pods for 7 days (3042 failed refreshes). Omitting the rule on v4-only clusters denies v6 (fail closed), it does not allow anything.

## Why now

Full incident write-up is in the PR conversation (prod was mitigated live by patching the SaaS NetworkPolicies; the matching terraform change lands in the infra repo). The user-facing half, the eternal spinner on a hard provider limit, is fixed here.

## Test plan

- `go test ./...` in `services/langyagent` (all green; new tests cover first-strike hard-limit cut, burst passthrough then third-strike cut, reset on success, per-conversation isolation)
- `helm template` renders verified for default, v6 opt-in, and collector-rule configurations

## Deployment Impact

- **SaaS:** none at deploy time. The relay change ships with the next langyagent image roll; behavior change is only visible when a provider hard-rate-limits a conversation (turn fails fast with the plan-limit card instead of spinning). The SaaS NetworkPolicies are terraform-managed (langwatch-saas#803, already live via hotfix), not from this chart.
- **Self-hosted chart:** two new values, both default-safe. `networkPolicy.egressToOtelCollector` defaults to empty (no rendered rule, no change). `networkPolicy.allowExternalHttpsIpv6` defaults to false, which REMOVES the `::/0` block from rendered policies: on IPv4-only clusters this is the fix (v6 was never routable and the block froze AWS eBPF enforcement); genuinely dual-stack installs that relied on v6 external egress must set it to true.
- No migrations, no env changes, no restarts required beyond the normal image roll.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional network-policy egress to allow pods to send telemetry to an in-cluster OTEL collector.
  - Added opt-in support for IPv6 external HTTPS egress.

- **Bug Fixes**
  - Provider “usage limit reached” (429) errors now stop retries immediately while preserving the original error response details.
  - Repeated rate-limit (429) responses now stop retrying after the configured threshold, with retry state correctly reset across interruptions, successful calls, and separate conversations.

- **Tests**
  - Added coverage for hard usage limits, burst handling, counter resets, and conversation isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->