### PR TITLE
fix(automations): add features.bot_user to the Slack app manifest

### DIFF
--- a/langwatch/src/features/automations/providers/slack/__tests__/manifest.unit.test.ts
+++ b/langwatch/src/features/automations/providers/slack/__tests__/manifest.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { SLACK_APP_MANIFEST } from "../client";
 
 describe("Slack app manifest", () => {
-  describe("given the copy-paste manifest for \"Create app → From a manifest\"", () => {
+  describe('given the copy-paste manifest for "Create app → From a manifest"', () => {
     describe("when validating the manifest", () => {
       it("declares a bot_user alongside the bot oauth scopes", () => {
         expect(SLACK_APP_MANIFEST).toMatch(/scopes:\s*\n\s*bot:/);

--- a/langwatch/src/features/automations/providers/slack/__tests__/manifest.unit.test.ts
+++ b/langwatch/src/features/automations/providers/slack/__tests__/manifest.unit.test.ts
@@ -3,16 +3,20 @@ import { SLACK_APP_MANIFEST } from "../client";
 
 describe("Slack app manifest", () => {
   describe("given the copy-paste manifest for \"Create app → From a manifest\"", () => {
-    it("declares a bot_user alongside the bot oauth scopes", () => {
-      expect(SLACK_APP_MANIFEST).toMatch(/scopes:\s*\n\s*bot:/);
-      expect(SLACK_APP_MANIFEST).toMatch(/features:\s*\n\s*bot_user:/);
-    });
+    describe("when validating the manifest", () => {
+      it("declares a bot_user alongside the bot oauth scopes", () => {
+        expect(SLACK_APP_MANIFEST).toMatch(/scopes:\s*\n\s*bot:/);
+        expect(SLACK_APP_MANIFEST).toMatch(
+          /features:\s*\n\s*bot_user:\s*\n\s*display_name:\s*LangWatch\s*\n\s*always_online:\s*false/,
+        );
+      });
 
-    it("orders bot_user before oauth_config so Slack sees the feature first", () => {
-      const featuresIndex = SLACK_APP_MANIFEST.indexOf("features:");
-      const oauthIndex = SLACK_APP_MANIFEST.indexOf("oauth_config:");
-      expect(featuresIndex).toBeGreaterThan(-1);
-      expect(featuresIndex).toBeLessThan(oauthIndex);
+      it("orders bot_user before oauth_config so Slack sees the feature first", () => {
+        const featuresIndex = SLACK_APP_MANIFEST.indexOf("features:");
+        const oauthIndex = SLACK_APP_MANIFEST.indexOf("oauth_config:");
+        expect(featuresIndex).toBeGreaterThan(-1);
+        expect(featuresIndex).toBeLessThan(oauthIndex);
+      });
     });
   });
 });

--- a/langwatch/src/features/automations/providers/slack/__tests__/manifest.unit.test.ts
+++ b/langwatch/src/features/automations/providers/slack/__tests__/manifest.unit.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { SLACK_APP_MANIFEST } from "../client";
+
+describe("Slack app manifest", () => {
+  describe("given the copy-paste manifest for \"Create app → From a manifest\"", () => {
+    it("declares a bot_user alongside the bot oauth scopes", () => {
+      expect(SLACK_APP_MANIFEST).toMatch(/scopes:\s*\n\s*bot:/);
+      expect(SLACK_APP_MANIFEST).toMatch(/features:\s*\n\s*bot_user:/);
+    });
+
+    it("orders bot_user before oauth_config so Slack sees the feature first", () => {
+      const featuresIndex = SLACK_APP_MANIFEST.indexOf("features:");
+      const oauthIndex = SLACK_APP_MANIFEST.indexOf("oauth_config:");
+      expect(featuresIndex).toBeGreaterThan(-1);
+      expect(featuresIndex).toBeLessThan(oauthIndex);
+    });
+  });
+});

--- a/langwatch/src/features/automations/providers/slack/client.tsx
+++ b/langwatch/src/features/automations/providers/slack/client.tsx
@@ -209,9 +209,15 @@ const DELIVERY_ITEMS: { value: SlackDeliveryMethod; label: string }[] = [
  *     first; without it Slack rejects the post with `not_in_channel` until the
  *     bot is manually `/invite`d, which is the #1 setup snag
  *   - `channels:read` / `groups:read` — populate the channel picker
+ * `features.bot_user` is required alongside `oauth_config.scopes.bot` —
+ * Slack rejects the manifest with "OAuth requires bot_user" without it.
  */
-const SLACK_APP_MANIFEST = `display_information:
+export const SLACK_APP_MANIFEST = `display_information:
   name: LangWatch
+features:
+  bot_user:
+    display_name: LangWatch
+    always_online: false
 oauth_config:
   scopes:
     bot:


### PR DESCRIPTION
## Summary
- The Slack bot setup step's "Copy app manifest" button generated YAML with `oauth_config.scopes.bot` but no `features.bot_user` block. Slack requires both together, so pasting the copied manifest into "Create app → From a manifest" hit `OAuth requires bot_user` — a hard stop before the app could even be created.
- Adds the missing `features.bot_user` block (matches the app's display name, `always_online: false`) and exports the manifest constant so it's covered by a test.

## Test plan
- [x] `pnpm test:unit run src/features/automations/providers/slack/__tests__/manifest.unit.test.ts` — new test passes on the fix, and fails with the old (pre-fix) manifest, confirming it catches the regression
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Slack app manifest to include the required `features.bot_user` configuration.
  * Prevented Slack manifest validation failures by ensuring required bot/user settings are present alongside bot OAuth scopes.
* **Tests**
  * Added a unit test suite to verify the Slack manifest includes expected bot scopes, `bot_user` features, and correct manifest section ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->