### PR TITLE
fix(langy): live-watched turn failures render their typed card, not the unknown apology

### DIFF
--- a/langwatch/src/features/langy/__tests__/langyErrorExplainer.unit.test.ts
+++ b/langwatch/src/features/langy/__tests__/langyErrorExplainer.unit.test.ts
@@ -4,6 +4,7 @@ import {
   KNOWN_LANGY_ERROR_KINDS,
   type LangyDomainError,
   readLangyStreamError,
+  resolveLiveTurnError,
 } from "../logic/langyErrorExplainer";
 
 /**
@@ -399,6 +400,55 @@ describe("readLangyStreamError", () => {
   describe("given a legacy plain-string error", () => {
     it("returns null so the caller can fall back", () => {
       expect(readLangyStreamError("manager responded 503")).toBeNull();
+    });
+  });
+});
+
+describe("resolveLiveTurnError", () => {
+  const typedStreamError = JSON.stringify({
+    code: "langy_agent_errored",
+    httpStatus: 502,
+    meta: {},
+    reasons: [
+      {
+        kind: "llm_upstream_error",
+        meta: { http_status: 429, message: "The usage limit has been reached" },
+        reasons: [{ kind: "usage_limit_reached" }],
+      },
+    ],
+  });
+
+  describe("given the failure rode the stream's terminal entry", () => {
+    it("resolves the typed domain error off the live message", () => {
+      const domain = resolveLiveTurnError({
+        error: new Error(typedStreamError),
+        durableLastError: null,
+      });
+
+      expect(domain.code).toBe("langy_agent_errored");
+    });
+  });
+
+  // @scenario "A genuinely dead stream still names the durable failure"
+  describe("given the live stream died with no typed payload", () => {
+    it("reads the durable record instead of settling for unknown", () => {
+      const domain = resolveLiveTurnError({
+        error: new Error("SSE Error"),
+        durableLastError: typedStreamError,
+      });
+
+      expect(domain.code).toBe("langy_agent_errored");
+      expect(explainLangyError(domain).kind).toBe("langy_codex_plan_limit");
+    });
+
+    it("falls back to unknown only when the durable record is empty too", () => {
+      const domain = resolveLiveTurnError({
+        error: new Error("SSE Error"),
+        durableLastError: null,
+      });
+
+      expect(domain.code).toBe("unknown");
+      expect(domain.meta).toEqual({ error: "SSE Error" });
     });
   });
 });

--- a/langwatch/src/features/langy/__tests__/langyErrorExplainer.unit.test.ts
+++ b/langwatch/src/features/langy/__tests__/langyErrorExplainer.unit.test.ts
@@ -419,36 +419,42 @@ describe("resolveLiveTurnError", () => {
   });
 
   describe("given the failure rode the stream's terminal entry", () => {
-    it("resolves the typed domain error off the live message", () => {
-      const domain = resolveLiveTurnError({
-        error: new Error(typedStreamError),
-        durableLastError: null,
-      });
+    describe("when the live message carries the typed payload", () => {
+      it("resolves the typed domain error from it", () => {
+        const domain = resolveLiveTurnError({
+          error: new Error(typedStreamError),
+          durableLastError: null,
+        });
 
-      expect(domain.code).toBe("langy_agent_errored");
+        expect(domain.code).toBe("langy_agent_errored");
+      });
     });
   });
 
-  // @scenario "A genuinely dead stream still names the durable failure"
   describe("given the live stream died with no typed payload", () => {
-    it("reads the durable record instead of settling for unknown", () => {
-      const domain = resolveLiveTurnError({
-        error: new Error("SSE Error"),
-        durableLastError: typedStreamError,
-      });
+    describe("when the turn's failure is already on the durable record", () => {
+      /** @scenario "A genuinely dead stream still names the durable failure" */
+      it("reads the durable record instead of settling for unknown", () => {
+        const domain = resolveLiveTurnError({
+          error: new Error("SSE Error"),
+          durableLastError: typedStreamError,
+        });
 
-      expect(domain.code).toBe("langy_agent_errored");
-      expect(explainLangyError(domain).kind).toBe("langy_codex_plan_limit");
+        expect(domain.code).toBe("langy_agent_errored");
+        expect(explainLangyError(domain).kind).toBe("langy_codex_plan_limit");
+      });
     });
 
-    it("falls back to unknown only when the durable record is empty too", () => {
-      const domain = resolveLiveTurnError({
-        error: new Error("SSE Error"),
-        durableLastError: null,
-      });
+    describe("when the durable record is empty too", () => {
+      it("falls back to unknown", () => {
+        const domain = resolveLiveTurnError({
+          error: new Error("SSE Error"),
+          durableLastError: null,
+        });
 
-      expect(domain.code).toBe("unknown");
-      expect(domain.meta).toEqual({ error: "SSE Error" });
+        expect(domain.code).toBe("unknown");
+        expect(domain.meta).toEqual({ error: "SSE Error" });
+      });
     });
   });
 });

--- a/langwatch/src/features/langy/components/LangyPanel.tsx
+++ b/langwatch/src/features/langy/components/LangyPanel.tsx
@@ -99,6 +99,7 @@ import {
   explainLangyError,
   readLangyStreamError,
   readLangyTrpcError,
+  resolveLiveTurnError,
 } from "../logic/langyErrorExplainer";
 import {
   PANEL_SUGGESTION_COUNT,
@@ -1577,13 +1578,9 @@ function LangyPanel({
     // fallback now also carries the raw message so a genuinely-unhandled error
     // stays legible in the dev-mode debug drawer instead of being a black box.
     if (error) {
-      const domain = readLangyTrpcError(error) ??
-        readLangyStreamError(error.message) ?? {
-          code: "unknown",
-          meta: error.message ? { error: error.message } : {},
-          httpStatus: 500,
-        };
-      return explainLangyError(domain);
+      return explainLangyError(
+        resolveLiveTurnError({ error, durableLastError: historyLastError }),
+      );
     }
     // The DURABLE failure, off the conversation fold. A turn error lived only in
     // `useChat` state, so a refresh after a failed turn left the user's question

--- a/langwatch/src/features/langy/logic/langyErrorExplainer.ts
+++ b/langwatch/src/features/langy/logic/langyErrorExplainer.ts
@@ -244,6 +244,34 @@ export function readLangyStreamError(
   };
 }
 
+/**
+ * Resolve the domain error behind a LIVE turn failure. Three roads, in order:
+ * a turn-START rejection carries it on the tRPC error (`error.data.error`); a
+ * mid-turn failure rides the stream's terminal entry as a JSON message; and
+ * when the stream itself died with no typed payload (a genuinely broken
+ * connection), the turn's real, classified failure is usually already on the
+ * DURABLE record: naming it beats a generic apology whose cause the server
+ * knew all along. Only when all three come up empty does the caller fall back
+ * to the unknown card.
+ */
+export function resolveLiveTurnError({
+  error,
+  durableLastError,
+}: {
+  error: { message: string } & object;
+  durableLastError: string | null | undefined;
+}): LangyDomainError {
+  return (
+    readLangyTrpcError(error) ??
+    readLangyStreamError(error.message) ??
+    (durableLastError ? readLangyStreamError(durableLastError) : null) ?? {
+      code: "unknown",
+      meta: error.message ? { error: error.message } : {},
+      httpStatus: 500,
+    }
+  );
+}
+
 /** Read a Langy domain error off a tRPC client error (`error.data.error`). */
 export function readLangyTrpcError(err: unknown): LangyDomainError | null {
   const domain = readHandledError(err);

--- a/langwatch/src/utils/__tests__/sseLink.unit.test.ts
+++ b/langwatch/src/utils/__tests__/sseLink.unit.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The SSE link's frame classifier sits between the wire and every tRPC
+ * subscription. Its one dangerous ambiguity: `type: "error"` names BOTH the
+ * route wrapper's protocol failure and a legitimate domain data entry (the
+ * langy turn stream's terminal). Misfiling the domain entry kills the
+ * subscription and collapses every live-watched turn failure into the generic
+ * unknown card — with the typed cause sitting right there on the wire.
+ */
+import { describe, expect, it } from "vitest";
+import { classifySseFrame } from "../sseLink";
+
+describe("classifySseFrame", () => {
+  describe("given the route wrapper's protocol frames", () => {
+    it("recognises the connection acknowledgement", () => {
+      expect(classifySseFrame({ type: "connected" })).toBe("connected");
+    });
+
+    it("recognises the clean completion", () => {
+      expect(classifySseFrame({ type: "complete" })).toBe("complete");
+    });
+
+    it("treats an error frame carrying a string message as a protocol error", () => {
+      expect(classifySseFrame({ type: "error", message: "langy_not_enabled" })).toBe(
+        "protocol-error",
+      );
+    });
+
+    it("treats a bare error frame with no payload as a protocol error", () => {
+      expect(classifySseFrame({ type: "error" })).toBe("protocol-error");
+    });
+  });
+
+  // @scenario "A live-watched failure shows the same card a reload shows"
+  describe("given a subscription data entry whose own union contains an error variant", () => {
+    it("passes the langy turn terminal through as data, never a dead subscription", () => {
+      const turnTerminal = {
+        type: "error",
+        error: JSON.stringify({
+          code: "langy_agent_errored",
+          httpStatus: 502,
+          reasons: [{ code: "llm_upstream_error" }],
+        }),
+      };
+      expect(classifySseFrame(turnTerminal)).toBe("data");
+    });
+  });
+
+  describe("given payloads with no protocol discriminant", () => {
+    it("passes ordinary data entries through", () => {
+      expect(classifySseFrame({ type: "status", status: "Poking Langy…" })).toBe(
+        "data",
+      );
+      expect(classifySseFrame({ anything: 1 })).toBe("data");
+      expect(classifySseFrame("plain string")).toBe("data");
+      expect(classifySseFrame(null)).toBe("data");
+    });
+  });
+});

--- a/langwatch/src/utils/__tests__/sseLink.unit.test.ts
+++ b/langwatch/src/utils/__tests__/sseLink.unit.test.ts
@@ -4,55 +4,67 @@
  * route wrapper's protocol failure and a legitimate domain data entry (the
  * langy turn stream's terminal). Misfiling the domain entry kills the
  * subscription and collapses every live-watched turn failure into the generic
- * unknown card — with the typed cause sitting right there on the wire.
+ * unknown card, with the typed cause sitting right there on the wire.
  */
 import { describe, expect, it } from "vitest";
 import { classifySseFrame } from "../sseLink";
 
 describe("classifySseFrame", () => {
   describe("given the route wrapper's protocol frames", () => {
-    it("recognises the connection acknowledgement", () => {
-      expect(classifySseFrame({ type: "connected" })).toBe("connected");
+    describe("when the connection acknowledgement arrives", () => {
+      it("classifies it as connected", () => {
+        expect(classifySseFrame({ type: "connected" })).toBe("connected");
+      });
     });
 
-    it("recognises the clean completion", () => {
-      expect(classifySseFrame({ type: "complete" })).toBe("complete");
+    describe("when the clean completion arrives", () => {
+      it("classifies it as complete", () => {
+        expect(classifySseFrame({ type: "complete" })).toBe("complete");
+      });
     });
 
-    it("treats an error frame carrying a string message as a protocol error", () => {
-      expect(classifySseFrame({ type: "error", message: "langy_not_enabled" })).toBe(
-        "protocol-error",
-      );
+    describe("when an error frame carries a string message", () => {
+      it("classifies it as a protocol error", () => {
+        expect(
+          classifySseFrame({ type: "error", message: "langy_not_enabled" }),
+        ).toBe("protocol-error");
+      });
     });
 
-    it("treats a bare error frame with no payload as a protocol error", () => {
-      expect(classifySseFrame({ type: "error" })).toBe("protocol-error");
+    describe("when a bare error frame carries no payload at all", () => {
+      it("classifies it as a protocol error", () => {
+        expect(classifySseFrame({ type: "error" })).toBe("protocol-error");
+      });
     });
   });
 
-  // @scenario "A live-watched failure shows the same card a reload shows"
   describe("given a subscription data entry whose own union contains an error variant", () => {
-    it("passes the langy turn terminal through as data, never a dead subscription", () => {
-      const turnTerminal = {
-        type: "error",
-        error: JSON.stringify({
-          code: "langy_agent_errored",
-          httpStatus: 502,
-          reasons: [{ code: "llm_upstream_error" }],
-        }),
-      };
-      expect(classifySseFrame(turnTerminal)).toBe("data");
+    describe("when the langy turn terminal rides the stream", () => {
+      /** @scenario "A live-watched failure shows the same card a reload shows" */
+      it("passes it through as data, never a dead subscription", () => {
+        const turnTerminal = {
+          type: "error",
+          error: JSON.stringify({
+            code: "langy_agent_errored",
+            httpStatus: 502,
+            reasons: [{ code: "llm_upstream_error" }],
+          }),
+        };
+        expect(classifySseFrame(turnTerminal)).toBe("data");
+      });
     });
   });
 
   describe("given payloads with no protocol discriminant", () => {
-    it("passes ordinary data entries through", () => {
-      expect(classifySseFrame({ type: "status", status: "Poking Langy…" })).toBe(
-        "data",
-      );
-      expect(classifySseFrame({ anything: 1 })).toBe("data");
-      expect(classifySseFrame("plain string")).toBe("data");
-      expect(classifySseFrame(null)).toBe("data");
+    describe("when ordinary data entries arrive", () => {
+      it("passes them through untouched", () => {
+        expect(
+          classifySseFrame({ type: "status", status: "Poking Langy…" }),
+        ).toBe("data");
+        expect(classifySseFrame({ anything: 1 })).toBe("data");
+        expect(classifySseFrame("plain string")).toBe("data");
+        expect(classifySseFrame(null)).toBe("data");
+      });
     });
   });
 });

--- a/langwatch/src/utils/sseLink.ts
+++ b/langwatch/src/utils/sseLink.ts
@@ -25,6 +25,37 @@ export interface SSELinkOptions {
 const isObject = (v: unknown): v is Record<string, unknown> =>
   typeof v === "object" && v !== null;
 
+/**
+ * Classify one parsed SSE frame. A `type: "error"` frame is AMBIGUOUS: the
+ * route wrapper's PROTOCOL error (`{type:"error", message}`, the subscription
+ * generator threw, see routes/sse.ts) shares its discriminant with legitimate
+ * subscription DATA whose own union contains an error variant: the langy turn
+ * stream's terminal is `{type:"error", error:"<serialized domain error>"}`.
+ * The two shapes are disjoint (protocol always carries a string `message`,
+ * a domain entry carries `error` and no `message`), so split on that: a domain
+ * entry must flow to the subscriber as data, or every live-watched turn
+ * failure collapses into a dead subscription and the generic unknown card
+ * while the typed cause sits right there on the wire.
+ */
+export function classifySseFrame(
+  parsed: unknown,
+): "connected" | "complete" | "protocol-error" | "data" {
+  if (!isObject(parsed) || typeof parsed.type !== "string") return "data";
+  switch (parsed.type) {
+    case "connected":
+      return "connected";
+    case "complete":
+      return "complete";
+    case "error":
+      if (typeof parsed.message !== "string" && "error" in parsed) {
+        return "data";
+      }
+      return "protocol-error";
+    default:
+      return "data";
+  }
+}
+
 const toTrpcError = <TRouter extends AnyRouter>(
   err: unknown,
   prefix: string,
@@ -123,15 +154,14 @@ export function sseLink<TRouter extends AnyRouter = AnyRouter>(
             try {
               const parsed = superjson.parse(event.data) as SSEMessage;
 
-              if (isObject(parsed) && typeof parsed.type === "string") {
-                if (parsed.type === "connected") {
+              switch (classifySseFrame(parsed)) {
+                case "connected":
                   logger.debug(
                     { path: endpointUrl.pathname },
                     "SSE connection acknowledged",
                   );
                   return;
-                }
-                if (parsed.type === "complete") {
+                case "complete":
                   logger.info(
                     { path: endpointUrl.pathname },
                     "SSE stream completed",
@@ -139,10 +169,9 @@ export function sseLink<TRouter extends AnyRouter = AnyRouter>(
                   observer.complete();
                   close();
                   return;
-                }
-                if (parsed.type === "error") {
+                case "protocol-error": {
                   const msg =
-                    typeof parsed.message === "string"
+                    isObject(parsed) && typeof parsed.message === "string"
                       ? parsed.message
                       : "SSE Error";
                   logger.error(
@@ -153,6 +182,8 @@ export function sseLink<TRouter extends AnyRouter = AnyRouter>(
                   close();
                   return;
                 }
+                case "data":
+                  break;
               }
 
               logger.debug(

--- a/specs/langy/langy-turn-recovery.feature
+++ b/specs/langy/langy-turn-recovery.feature
@@ -217,3 +217,23 @@ Feature: Langy recovers from a failed turn without making the user re-ask
     Given one conversation has been cut off at a hard rate limit
     When a different conversation's calls are relayed
     Then they pass through untouched with their own fresh count
+
+  # The turn stream's terminal error entry shares its `type: "error"`
+  # discriminant with the SSE transport's own protocol failure frame. The
+  # transport once claimed every such frame for itself, so the one entry that
+  # names the real failure killed the subscription instead: watching a turn
+  # fail LIVE showed the generic unknown card, while reloading the same
+  # conversation showed the correct one from the durable record. The live road
+  # and the reload road must end at the same card.
+  @unit
+  Scenario: A live-watched failure shows the same card a reload shows
+    Given a turn fails while its conversation is open and streaming
+    When the typed failure rides the stream's terminal error entry
+    Then the entry reaches the panel as data, not as a dead connection
+    And the panel renders the same specific card a reload would render
+
+  @unit
+  Scenario: A genuinely dead stream still names the durable failure
+    Given the live stream itself breaks with no typed payload
+    When the turn's real failure is already on the durable record
+    Then the panel reads the durable error instead of settling for unknown

--- a/specs/langy/langy-turn-recovery.feature
+++ b/specs/langy/langy-turn-recovery.feature
@@ -227,13 +227,14 @@ Feature: Langy recovers from a failed turn without making the user re-ask
   # and the reload road must end at the same card.
   @unit
   Scenario: A live-watched failure shows the same card a reload shows
-    Given a turn fails while its conversation is open and streaming
-    When the typed failure rides the stream's terminal error entry
-    Then the entry reaches the panel as data, not as a dead connection
-    And the panel renders the same specific card a reload would render
+    Given the user is watching Langy answer when the turn fails
+    When the failure reaches the open conversation
+    Then the user sees the card that names what actually went wrong
+    And it is the same card a reload of the conversation would show
+    And the generic something-went-wrong card never appears in its place
 
   @unit
   Scenario: A genuinely dead stream still names the durable failure
-    Given the live stream itself breaks with no typed payload
-    When the turn's real failure is already on the durable record
-    Then the panel reads the durable error instead of settling for unknown
+    Given the live connection drops before Langy can say what went wrong
+    When the turn's failure is already on the conversation's record
+    Then the user sees the card naming that recorded failure, not a generic apology


### PR DESCRIPTION
## What

Fixes the "Something went wrong / unknown" card that rendered whenever a Langy turn failed while the user was watching live, reported today against a codex quota exhaustion in production. The typed, actionable error (the plan-limit card in this case) only ever appeared after a reload.

## Root cause

The custom tRPC SSE link (`src/utils/sseLink.ts`) special-cases data frames whose `type` is `"error"` as transport-level protocol failures. But the langy turn stream's terminal is a legitimate subscription data entry of exactly that shape: `{type: "error", error: "<serialized domain error>"}`. The link stole the one frame that names the real failure, looked for a `message` field it does not have, and errored the entire subscription with the literal string `SSE Error`. Downstream, the chat transport surfaced that as the turn's error, both domain readers returned null, and the panel fell back to the generic unknown card.

The result was fully deterministic and not codex-specific: every live-watched turn failure of any kind collapsed to unknown, while the durable path (reload) always showed the correct card because it re-reads the classified error from the projection.

Verified byte-level during local dogfooding: an EventSource tap showed the fully-typed error entry (`langy_agent_errored` with the `usage_limit_reached` discriminant) arriving on the wire in the same second the panel rendered "unknown", and a debug probe showed the panel's error object carrying `message: "SSE Error"`.

## Fix

- `classifySseFrame` (new, unit-tested): protocol frames and domain entries have disjoint shapes. A protocol error always carries a string `message` (see `routes/sse.ts`, which sends the handled code); a domain error entry carries `error` and no `message`. Error frames with a string `message` (or no payload at all) stay protocol errors; error-shaped domain entries flow to the subscriber as data.
- `resolveLiveTurnError` (new, unit-tested): when the live stream genuinely dies with no typed payload (a real transport break), the panel now reads the turn's classified failure off the durable record before settling for unknown, so even a broken connection names the real cause once the projection has it.
- Specs: two new scenarios in `specs/langy/langy-turn-recovery.feature` ("A live-watched failure shows the same card a reload shows", "A genuinely dead stream still names the durable failure"), bound by the new unit tests.

## Dogfooding proof (local stack, real codex account at its real quota limit)

Before: watching a turn fail live always ended at the generic card, with the typed error visible on the wire the whole time.

![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/langy-live-error-unknown-before.png)

After: fresh conversation, cold worker spawn, liveness re-drive at +32s, and the live panel resolves to the bespoke plan-limit card with the model-switch guidance:

![after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/langy-live-error-plan-limit-after.png)

The full live sequence observed: "Starting up…" at +2s, "Still starting up…" at +14s, "Reconnecting to the agent…" at +32s, plan-limit card at +60s (local cold spawns are slow; prod spawns land this in seconds). A warm-worker run shows the card in about 2 seconds.

## Test plan

- `vitest run` on `sseLink.unit.test.ts`, `langyErrorExplainer.unit.test.ts`, `langyChatTransport.unit.test.ts`: 44 tests green
- `pnpm typecheck` clean
- Live browser verification as above, including the cold-spawn plus liveness-intervention path that used to be the reliable reproducer

## Deployment Impact

None beyond the normal app roll. Client-only changes (SSE link classification, panel fallback); no server, schema, or chart changes. The relay-side 429 cut from #6104 is unchanged; this PR makes its result visible live instead of only after a reload.

## Observed but out of scope

A pre-existing "Maximum update depth exceeded" React warning fires on dashboard load in local dev, before the Langy panel is opened; unrelated to this path and left for a separate look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live turn error handling so typed live-stream terminal errors render the same specific UI details as reload.
  - Added fallback behavior to derive errors from the last saved (durable) turn error when live streams end without a typed payload.
  - Prevented domain error frames from being misclassified as connection/protocol failures.
  - Added a clear unknown-error fallback when no usable typed or durable details are available.

- **Tests**
  - Added unit coverage for live turn recovery scenarios, SSE frame classification, and error explainer fallback logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->