### PR TITLE
feat(sdks): 1.0 release prep, stable release channel and classifier

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -62,7 +62,7 @@
     "typescript-sdk": {
       "release-type": "node",
       "package-name": "langwatch",
-      "prerelease": true,
+      "prerelease": false,
       "component": "typescript-sdk",
       "include-component-in-tag": true,
       "tag-separator": "@",
@@ -102,7 +102,7 @@
     "python-sdk": {
       "release-type": "python",
       "package-name": "langwatch",
-      "prerelease": true,
+      "prerelease": false,
       "component": "python-sdk",
       "include-component-in-tag": true,
       "tag-separator": "@",
@@ -138,7 +138,7 @@
     "mcp-server": {
       "release-type": "node",
       "package-name": "@langwatch/mcp-server",
-      "prerelease": true,
+      "prerelease": false,
       "component": "mcp-server",
       "include-component-in-tag": true,
       "tag-separator": "@",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<3.14"
 license = { text = "MIT" }
 readme = "README.md"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
     "attrs>=24",
     "pksuid>=1.1.2",
     "pyyaml>=6.0.2",
+    # Progress bars for experiment loop()/aloop(); pure-python and tiny, so a
+    # declared dependency rather than an optional (it always runs there).
+    "tqdm>=4.62.0",
 ]
 
 [project.optional-dependencies]

--- a/python-sdk/src/langwatch/experiment/experiment.py
+++ b/python-sdk/src/langwatch/experiment/experiment.py
@@ -60,7 +60,7 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 _tracer = trace.get_tracer(__name__)
 
 
-def _is_dataframe(obj: Any) -> bool:
+def _is_dataframe(obj: object) -> bool:
     """True when obj is a pandas DataFrame, without importing pandas.
 
     Checked via sys.modules so plain iterables never pull pandas in: if
@@ -397,10 +397,10 @@ class Experiment:
             sys.exit(1)
 
     def _build_run_result(self) -> ExperimentRunResult:
+        """Build an ExperimentRunResult from the current results DataFrame."""
         # Imported lazily so importing langwatch.experiment does not require
         # pandas; this path only runs on DataFrames built from fetched results.
         import pandas as pd
-        """Build an ExperimentRunResult from the current results DataFrame."""
         run_url = self._run_url or ""
         df = self.results
 

--- a/python-sdk/src/langwatch/experiment/experiment.py
+++ b/python-sdk/src/langwatch/experiment/experiment.py
@@ -9,11 +9,11 @@ import threading
 import time
 import traceback
 import httpx
-import pandas as pd
 from opentelemetry import trace, context as otel_context
 from opentelemetry.trace import Span
 from pydantic import BaseModel, Field
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -29,6 +29,9 @@ from typing import (
     Union,
     cast,
 )
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 from tenacity import retry, stop_after_attempt, wait_exponential
 from tqdm.auto import tqdm
@@ -55,6 +58,17 @@ import urllib.parse
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 
 _tracer = trace.get_tracer(__name__)
+
+
+def _is_dataframe(obj: Any) -> bool:
+    """True when obj is a pandas DataFrame, without importing pandas.
+
+    Checked via sys.modules so plain iterables never pull pandas in: if
+    pandas was never imported, obj cannot be a DataFrame (pandas is an
+    optional dependency of the SDK).
+    """
+    pd = sys.modules.get("pandas")
+    return pd is not None and isinstance(obj, pd.DataFrame)
 
 
 @dataclass
@@ -276,6 +290,10 @@ class Experiment:
 
     def _fetch_results_as_df(self, retries: int = 5, delay: float = 3.0) -> pd.DataFrame:
         """Fetch per-row results from the platform and build a DataFrame."""
+        # Imported lazily so importing langwatch.experiment does not require
+        # pandas; it is only needed when reading per-row results back.
+        import pandas as pd
+
         endpoint = langwatch.get_endpoint()
         api_key = langwatch.get_api_key() or ""
 
@@ -379,6 +397,9 @@ class Experiment:
             sys.exit(1)
 
     def _build_run_result(self) -> ExperimentRunResult:
+        # Imported lazily so importing langwatch.experiment does not require
+        # pandas; this path only runs on DataFrames built from fetched results.
+        import pandas as pd
         """Build an ExperimentRunResult from the current results DataFrame."""
         run_url = self._run_url or ""
         df = self.results
@@ -556,7 +577,7 @@ class Experiment:
             progress_bar = tqdm(total=total_, desc="Evaluating")
 
             # Supports direct pandas df being passed in
-            if isinstance(iterable, pd.DataFrame):
+            if _is_dataframe(iterable):
                 iterable = cast(Iterable[ItemT], iterable.iterrows())  # type: ignore
 
             with ThreadPoolExecutor(max_workers=threads) as executor:
@@ -662,7 +683,7 @@ class Experiment:
                 total_ = len(cast(Sized, iterable))
             progress_bar = tqdm(total=total_, desc="Evaluating")
 
-            if isinstance(iterable, pd.DataFrame):
+            if _is_dataframe(iterable):
                 iterable = cast(Iterable[ItemT], iterable.iterrows())  # type: ignore
 
             self._async_semaphore = asyncio.Semaphore(concurrency)

--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -20,7 +20,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-07-17T17:19:05.065156Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -3345,6 +3345,8 @@ dependencies = [
     { name = "retry" },
     { name = "tenacity" },
     { name = "termcolor" },
+    { name = "tqdm", version = "4.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "tqdm", version = "4.67.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -3443,6 +3445,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.1" },
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "termcolor", specifier = ">=3.0.1" },
+    { name = "tqdm", specifier = ">=4.62.0" },
 ]
 provides-extras = ["langchain", "dspy", "litellm", "dev", "tests"]
 


### PR DESCRIPTION
## What

1.0 release prep for the four components graduating to stable: typescript-sdk, python-sdk, mcp-server and skills.

- Flip `prerelease: true` to `false` in release-please config for typescript-sdk, python-sdk and mcp-server, so their GitHub releases stop being marked as pre-releases (skills already had it off).
- Stamp python-sdk with the `Development Status :: 5 - Production/Stable` trove classifier (was `4 - Beta`).

## Why

Users read 0.x as "not reliable enough". There are no breaking changes pending; the SDKs have been stable for a long time, so we are promoting them to 1.0.0.

## How the version bump lands

Release-please cannot jump to 1.0.0 from conventional commits alone. After this merges, one single-footer shadow commit per component (the established `.release-please-shim` pattern, one path-routed file change with exactly one `Release-As: 1.0.0` footer each) forces the next release PR of each component to 1.0.0:

- typescript-sdk 0.37.0 -> 1.0.0
- python-sdk 0.26.0 -> 1.0.0
- mcp-server 0.10.1 -> 1.0.0
- skills 0.7.0 -> 1.0.0

sdk-go stays 0.x on purpose (younger surface, not part of this graduation). langevals, the app and the charts are untouched.

Verified: all CD workflows key on `startsWith(tag, '<component>@')` and are version-agnostic, and the GitHub prerelease marking at major >= 1 goes away with the flag flip. The `@langwatch/scenario` pins in mcp-server and skills are devDependencies only (not shipped), left for dependabot.

A companion PR in langwatch/scenario graduates `@langwatch/scenario` and `langwatch-scenario` to 1.0.0 the same way.

## Also in this PR: python-sdk pandas-free import chain

Graduating to 1.0 surfaced a real defect: `experiment.py` imported pandas at module load, so the eager chain `langwatch.evaluations -> langwatch.evaluation -> experiment` crashed on any install without pandas, and pandas was never a declared dependency in the first place. This is what forced langwatch-scenario to cap its langwatch pin at `<0.3` (users were silently resolving langwatch 0.2.19 from June 2025).

- pandas now loads lazily inside the results paths that actually need it, with a `sys.modules` guard for the DataFrame isinstance checks, matching the pattern `_results_df.py` already documents.
- tqdm, which `loop()`/`aloop()` always use for progress bars, becomes a declared dependency instead of an undeclared import.

Verified in a clean pandas-free venv: `import langwatch`, `langwatch.evaluations`, `langwatch.evaluation`, `langwatch.experiment`, `langwatch.workflow` and `langwatch.dataset` all import cleanly. Full python-sdk unit suite green. The scenario repo's full unit suite (1157 tests) also validated against this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress bar support for experiment loops.
  * Python SDK is now classified as production/stable.

* **Bug Fixes**
  * The Python SDK can now be imported without requiring pandas to be loaded immediately.
  * Preserved DataFrame handling for synchronous and asynchronous experiment evaluations.

* **Release Management**
  * TypeScript SDK, Python SDK, and MCP Server releases are now configured as stable rather than prerelease.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->